### PR TITLE
Add auto-research demo acceptance packet

### DIFF
--- a/docs/product/decentralized-auto-research-showcase.md
+++ b/docs/product/decentralized-auto-research-showcase.md
@@ -287,6 +287,25 @@ loopx --format json auto-research demo-supervisor \
   --agent codex-main-control:control-plane-guard
 ```
 
+For a tighter user handoff, render the demo acceptance packet. It links the
+experimental board output, the dry-run supervisor plan, and the takeover
+checklist into one operator-facing packet:
+
+```bash
+loopx --format json auto-research acceptance \
+  --goal-id loopx-auto-research-knn \
+  --agent-id codex-side-bypass \
+  --agent codex-side-bypass:hypothesis-runner \
+  --agent codex-product-capability:evidence-promoter \
+  --agent codex-main-control:control-plane-guard
+```
+
+The user should accept the demo only when the packet says the board is
+read-only, the supervisor is still `dry_run`, every lane has quota/frontier/
+bootstrap checks before Codex, and attach/stop controls are visible. It is
+still not a public-first-screen approval; `ready_for_public_first_screen` stays
+false until the first-screen review gate is explicitly cleared.
+
 ### Visible Operator Rehearsal Path
 
 The first user-facing demo step is a single inspection command, not a hidden

--- a/examples/auto-research-demo-acceptance-smoke.py
+++ b/examples/auto-research-demo-acceptance-smoke.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Smoke-test the auto-research operator demo acceptance packet."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.capabilities.auto_research import (  # noqa: E402
+    AUTO_RESEARCH_DEMO_ACCEPTANCE_PACKET_SCHEMA_VERSION,
+    build_auto_research_board_projection,
+    build_auto_research_demo_acceptance_packet,
+    build_auto_research_demo_supervisor_plan,
+    build_auto_research_projection,
+    load_auto_research_fixture,
+)
+
+
+FIXTURE = REPO_ROOT / "examples/fixtures/decentralized-auto-research-knn.public.json"
+GOAL_ID = "loopx-auto-research-knn"
+AGENT_ID = "codex-side-bypass"
+LANES = [
+    "codex-side-bypass:hypothesis-runner",
+    "codex-product-capability:evidence-promoter",
+    "codex-main-control:control-plane-guard",
+]
+
+
+def assert_public_safe(payload: Any) -> None:
+    text = json.dumps(payload, sort_keys=True) if not isinstance(payload, str) else payload
+    forbidden = [
+        "/" + "Users/",
+        "/" + "private/",
+        "/" + "tmp/",
+        "lark" + "office",
+        "byte" + "dance",
+        "http" + "://",
+        "https" + "://",
+        "api" + "_key",
+        "pass" + "word",
+        "sec" + "ret",
+    ]
+    leaked = [needle for needle in forbidden if needle.lower() in text.lower()]
+    assert not leaked, leaked
+
+
+def assert_acceptance_packet(payload: dict[str, Any]) -> None:
+    assert payload["ok"] is True, payload
+    assert payload["schema_version"] == AUTO_RESEARCH_DEMO_ACCEPTANCE_PACKET_SCHEMA_VERSION, payload
+    assert payload["goal_id"] == GOAL_ID, payload
+    assert payload["surface"]["stage"] == "experimental", payload
+    assert payload["surface"]["first_screen_policy"] == (
+        "experimental_only_not_first_screen_without_owner_review"
+    ), payload
+    assert payload["readiness_summary"]["operator_can_review_now"] is True, payload
+    assert payload["readiness_summary"]["ready_for_real_launch"] is True, payload
+    assert payload["readiness_summary"]["ready_for_public_first_screen"] is False, payload
+    assert payload["board_output"]["read_only"] is True, payload
+    assert payload["board_output"]["source_kind"] == "public_fixture", payload
+    assert payload["board_output"]["promotion_candidate_count"] >= 1, payload
+    assert payload["board_output"]["user_gate_count"] >= 4, payload
+    assert payload["supervisor_rehearsal"]["mode"] == "dry_run", payload
+    assert payload["supervisor_rehearsal"]["lane_count"] == 3, payload
+    assert payload["supervisor_rehearsal"]["rehearsal_script_visible"] is True, payload
+    assert payload["supervisor_rehearsal"]["start_script_visible"] is True, payload
+    assert payload["supervisor_rehearsal"]["attach"] == "tmux attach -t loopx-auto-research", payload
+    assert payload["supervisor_rehearsal"]["stop"] == "tmux kill-session -t loopx-auto-research", payload
+    assert [lane["lane_id"] for lane in payload["lane_checks"]] == [
+        "hypothesis-runner",
+        "evidence-promoter",
+        "control-plane-guard",
+    ], payload
+    for lane in payload["lane_checks"]:
+        assert lane["quota_guard_visible"] is True, lane
+        assert lane["frontier_visible"] is True, lane
+        assert lane["bootstrap_visible"] is True, lane
+        assert lane["visible_codex_tui"] == "codex", lane
+    checklist = "\n".join(payload["operator_checklist"])
+    assert "dry-run rehearsal" in checklist, checklist
+    assert "quota should-run" in checklist, checklist
+    assert "attach and stop" in checklist, checklist
+    assert payload["accept_when"], payload
+    assert payload["reject_when"], payload
+    controls = "\n".join(payload["user_takeover"]["operator_controls"])
+    assert "rehearsal script first" in controls, controls
+    assert "attach to tmux" in controls, controls
+    boundary = payload["public_boundary"]
+    assert boundary["raw_logs_recorded"] is False, boundary
+    assert boundary["private_artifacts_recorded"] is False, boundary
+    assert boundary["local_paths_recorded"] is False, boundary
+    assert boundary["credentials_recorded"] is False, boundary
+    assert boundary["starts_tmux"] is False, boundary
+    assert boundary["runs_codex"] is False, boundary
+    assert boundary["writes_loopx_state"] is False, boundary
+    assert boundary["spends_loopx_quota"] is False, boundary
+    assert_public_safe(payload)
+
+
+def run_cli(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *args],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def main() -> int:
+    projection = build_auto_research_projection(
+        load_auto_research_fixture(FIXTURE),
+        agent_id=AGENT_ID,
+    )
+    board = build_auto_research_board_projection(projection)
+    supervisor = build_auto_research_demo_supervisor_plan(
+        goal_id=GOAL_ID,
+        agent_specs=LANES,
+    )
+    packet = build_auto_research_demo_acceptance_packet(board, supervisor)
+    assert_acceptance_packet(packet)
+
+    cli = run_cli(
+        [
+            "--format",
+            "json",
+            "auto-research",
+            "acceptance",
+            "--fixture",
+            str(FIXTURE),
+            "--agent-id",
+            AGENT_ID,
+            "--agent",
+            LANES[0],
+            "--agent",
+            LANES[1],
+            "--agent",
+            LANES[2],
+        ]
+    )
+    cli_payload = json.loads(cli.stdout)
+    assert_acceptance_packet(cli_payload)
+
+    markdown = run_cli(
+        [
+            "auto-research",
+            "acceptance",
+            "--fixture",
+            str(FIXTURE),
+            "--agent-id",
+            AGENT_ID,
+            "--agent",
+            LANES[0],
+        ]
+    ).stdout
+    assert "# LoopX Auto Research Demo Acceptance" in markdown, markdown
+    assert "ready_for_real_launch: `True`" in markdown, markdown
+    assert "ready_for_public_first_screen: `False`" in markdown, markdown
+    assert "## Operator Checklist" in markdown, markdown
+    assert "## User Takeover" in markdown, markdown
+    assert "tmux attach -t loopx-auto-research" in markdown, markdown
+    assert_public_safe(markdown)
+
+    print("auto-research-demo-acceptance-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/auto-research-rollout-readpath-smoke.py
+++ b/examples/auto-research-rollout-readpath-smoke.py
@@ -175,6 +175,31 @@ def board_projection(registry: Path) -> dict[str, Any]:
     )
 
 
+def acceptance_projection(registry: Path) -> dict[str, Any]:
+    return run_json(
+        [
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry),
+            "--format",
+            "json",
+            "auto-research",
+            "acceptance",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            "codex-side-bypass",
+            "--agent",
+            "codex-side-bypass:hypothesis-runner",
+            "--agent",
+            "codex-product-capability:evidence-promoter",
+            "--agent",
+            "codex-main-control:control-plane-guard",
+        ]
+    )
+
+
 def main() -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         temp = Path(temp_dir)
@@ -387,6 +412,21 @@ def main() -> None:
         assert board_payload["decision_candidates"]["promotion_candidates"], board_payload
         assert len(board_payload["user_gates"]) >= 4, board_payload
         assert_public_safe(board_payload)
+
+        acceptance_payload = acceptance_projection(registry)
+        assert acceptance_payload["ok"], acceptance_payload
+        assert acceptance_payload["schema_version"] == "auto_research_demo_acceptance_packet_v0", acceptance_payload
+        assert acceptance_payload["board_output"]["source_kind"] == "loopx_rollout_event_log", acceptance_payload
+        assert acceptance_payload["board_output"]["rollout_backed"] is True, acceptance_payload
+        assert acceptance_payload["supervisor_rehearsal"]["mode"] == "dry_run", acceptance_payload
+        assert acceptance_payload["readiness_summary"]["operator_can_review_now"] is True, acceptance_payload
+        assert acceptance_payload["readiness_summary"]["ready_for_real_launch"] is True, acceptance_payload
+        assert acceptance_payload["readiness_summary"]["ready_for_public_first_screen"] is False, acceptance_payload
+        assert acceptance_payload["public_boundary"]["starts_tmux"] is False, acceptance_payload
+        assert acceptance_payload["public_boundary"]["runs_codex"] is False, acceptance_payload
+        assert acceptance_payload["public_boundary"]["writes_loopx_state"] is False, acceptance_payload
+        assert acceptance_payload["public_boundary"]["spends_loopx_quota"] is False, acceptance_payload
+        assert_public_safe(acceptance_payload)
 
     print("auto-research-rollout-readpath-smoke ok")
 

--- a/loopx/capabilities/auto_research/__init__.py
+++ b/loopx/capabilities/auto_research/__init__.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from .core import (
     AUTO_RESEARCH_DEFAULT_GOAL_ID,
     AUTO_RESEARCH_DEFAULT_OBJECTIVE,
+    AUTO_RESEARCH_DEMO_ACCEPTANCE_PACKET_SCHEMA_VERSION,
     AUTO_RESEARCH_DEMO_SUPERVISOR_SCHEMA_VERSION,
     AUTO_RESEARCH_FIXTURE_SCHEMA_VERSION,
     AUTO_RESEARCH_PROJECTION_SCHEMA_VERSION,
@@ -21,6 +22,7 @@ from .core import (
     AUTO_RESEARCH_BOARD_SCHEMA_VERSION,
     AUTO_RESEARCH_EVIDENCE_PACKET_SCHEMA_VERSION,
     AUTO_RESEARCH_ROLLOUT_APPEND_SCHEMA_VERSION,
+    build_auto_research_demo_acceptance_packet,
     build_auto_research_demo_supervisor_plan,
     build_auto_research_board_projection,
     build_auto_research_quickstart,
@@ -49,6 +51,7 @@ from .core import (
 __all__ = [
     "AUTO_RESEARCH_DEFAULT_GOAL_ID",
     "AUTO_RESEARCH_DEFAULT_OBJECTIVE",
+    "AUTO_RESEARCH_DEMO_ACCEPTANCE_PACKET_SCHEMA_VERSION",
     "AUTO_RESEARCH_DEMO_SUPERVISOR_SCHEMA_VERSION",
     "AUTO_RESEARCH_FIXTURE_SCHEMA_VERSION",
     "AUTO_RESEARCH_PROJECTION_SCHEMA_VERSION",
@@ -67,6 +70,7 @@ __all__ = [
     "AUTO_RESEARCH_BOARD_SCHEMA_VERSION",
     "AUTO_RESEARCH_EVIDENCE_PACKET_SCHEMA_VERSION",
     "AUTO_RESEARCH_ROLLOUT_APPEND_SCHEMA_VERSION",
+    "build_auto_research_demo_acceptance_packet",
     "build_auto_research_demo_supervisor_plan",
     "build_auto_research_board_projection",
     "build_auto_research_quickstart",

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -11,6 +11,7 @@ from . import (
     AUTO_RESEARCH_QUICKSTART_TEMPLATE,
     AUTO_RESEARCH_ROLLOUT_APPEND_SCHEMA_VERSION,
     build_auto_research_board_projection,
+    build_auto_research_demo_acceptance_packet,
     build_auto_research_demo_supervisor_plan,
     build_auto_research_quickstart,
     build_auto_research_rollout_events,
@@ -126,6 +127,42 @@ def register_auto_research_commands(
         required=True,
         help="Agent id whose board/frontier should be projected.",
     )
+
+    acceptance_parser = auto_research_sub.add_parser(
+        "acceptance",
+        help="Render an operator acceptance packet that links board output, dry-run supervisor, and takeover checks.",
+    )
+    add_subcommand_format(acceptance_parser)
+    acceptance_parser.add_argument(
+        "--fixture",
+        help="Path to a decentralized_auto_research_fixture_v0 JSON file.",
+    )
+    acceptance_parser.add_argument(
+        "--goal-id",
+        help="Goal id for live LoopX quota/status input. Mutually exclusive with --fixture.",
+    )
+    acceptance_parser.add_argument(
+        "--agent-id",
+        required=True,
+        help="Agent id whose board/frontier should be projected.",
+    )
+    acceptance_parser.add_argument(
+        "--agent",
+        action="append",
+        default=[],
+        help=(
+            "Supervisor agent/lane pair as agent_id:lane_id. Repeat for each visible lane. "
+            "Omit to use the default LoopX auto-research demo lane set."
+        ),
+    )
+    acceptance_parser.add_argument(
+        "--session-name",
+        default="loopx-auto-research",
+        help="Public-safe tmux session name for the dry-run supervisor packet.",
+    )
+    acceptance_parser.add_argument("--cli-bin", default="loopx", help="LoopX CLI executable name.")
+    acceptance_parser.add_argument("--codex-bin", default="codex", help="Codex CLI executable name.")
+    acceptance_parser.add_argument("--tmux-bin", default="tmux", help="tmux executable name.")
 
     evidence_parser = auto_research_sub.add_parser(
         "evidence",
@@ -264,7 +301,7 @@ def handle_auto_research_command(
                 execute=args.execute,
                 cwd=Path.cwd(),
             )
-        elif args.auto_research_command in {"frontier", "board"}:
+        elif args.auto_research_command in {"frontier", "board", "acceptance"}:
             if bool(args.fixture) == bool(args.goal_id):
                 raise ValueError(f"auto-research {args.auto_research_command} requires exactly one of --fixture or --goal-id")
             if args.fixture:
@@ -296,8 +333,18 @@ def handle_auto_research_command(
                     quota_payload=quota_payload,
                     rollout_events=rollout_events,
                 )
-            if args.auto_research_command == "board":
+            if args.auto_research_command in {"board", "acceptance"}:
                 payload = build_auto_research_board_projection(payload)
+            if args.auto_research_command == "acceptance":
+                supervisor = build_auto_research_demo_supervisor_plan(
+                    goal_id=args.goal_id or payload["research_contract"]["goal_id"],
+                    agent_specs=args.agent,
+                    session_name=args.session_name,
+                    cli_bin=args.cli_bin,
+                    codex_bin=args.codex_bin,
+                    tmux_bin=args.tmux_bin,
+                )
+                payload = build_auto_research_demo_acceptance_packet(payload, supervisor)
         elif args.auto_research_command == "evidence":
             payload = load_auto_research_evidence_packet_inputs(
                 contract_path=args.contract,
@@ -333,7 +380,7 @@ def handle_auto_research_command(
         else:
             raise ValueError(
                 "auto-research requires the `quickstart`, `frontier`, `evidence`, "
-                "`board`, `append-evidence`, or `demo-supervisor` subcommand"
+                "`board`, `acceptance`, `append-evidence`, or `demo-supervisor` subcommand"
             )
     except Exception as exc:
         payload = {

--- a/loopx/capabilities/auto_research/core.py
+++ b/loopx/capabilities/auto_research/core.py
@@ -24,6 +24,7 @@ AUTO_RESEARCH_BOARD_SCHEMA_VERSION = "auto_research_frontstage_board_v0"
 AUTO_RESEARCH_ROLLOUT_APPEND_SCHEMA_VERSION = "auto_research_rollout_append_v0"
 AUTO_RESEARCH_QUICKSTART_SCHEMA_VERSION = "auto_research_quickstart_v0"
 AUTO_RESEARCH_DEMO_SUPERVISOR_SCHEMA_VERSION = "auto_research_demo_supervisor_plan_v0"
+AUTO_RESEARCH_DEMO_ACCEPTANCE_PACKET_SCHEMA_VERSION = "auto_research_demo_acceptance_packet_v0"
 AUTO_RESEARCH_DEFAULT_GOAL_ID = "loopx-auto-research-knn"
 AUTO_RESEARCH_DEFAULT_OBJECTIVE = "Improve exact k-nearest-neighbor inference under a protected evaluator."
 AUTO_RESEARCH_QUICKSTART_TEMPLATE = "knn-exact"
@@ -884,6 +885,226 @@ def build_auto_research_demo_supervisor_plan(
             "Attach to tmux before accepting any Codex prompt so every lane stays visible and interruptible.",
             "Use the printed quota/frontier packet in each pane to decide whether that lane should continue, ask, or stop.",
         ],
+    }
+
+
+def _command_available(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def build_auto_research_demo_acceptance_packet(
+    board: dict[str, Any],
+    supervisor: dict[str, Any],
+) -> dict[str, Any]:
+    """Bind board and dry-run supervisor output into a user acceptance packet.
+
+    The packet is a read-only operator aid. It does not re-run research,
+    launch tmux/Codex, write state, spend quota, or decide promotion. It only
+    names the visible checks a user should inspect before turning the
+    experimental auto-research demo into a real local launch.
+    """
+
+    board = _json_obj(board, field="board")
+    supervisor = _json_obj(supervisor, field="supervisor")
+    board_schema = _compact_public_token(
+        board.get("schema_version"),
+        field="board.schema_version",
+    )
+    supervisor_schema = _compact_public_token(
+        supervisor.get("schema_version"),
+        field="supervisor.schema_version",
+    )
+    if board_schema != AUTO_RESEARCH_BOARD_SCHEMA_VERSION:
+        raise ValueError(f"board.schema_version must be {AUTO_RESEARCH_BOARD_SCHEMA_VERSION}")
+    if supervisor_schema != AUTO_RESEARCH_DEMO_SUPERVISOR_SCHEMA_VERSION:
+        raise ValueError(f"supervisor.schema_version must be {AUTO_RESEARCH_DEMO_SUPERVISOR_SCHEMA_VERSION}")
+    if not board.get("ok"):
+        raise ValueError("board must be ok")
+    if not supervisor.get("ok"):
+        raise ValueError("supervisor must be ok")
+
+    binding = _json_obj(board.get("projection_binding"), field="board.projection_binding")
+    surface = _json_obj(board.get("surface"), field="board.surface")
+    research_contract = _json_obj(board.get("research_contract"), field="board.research_contract")
+    decisions = _json_obj(board.get("decision_candidates"), field="board.decision_candidates")
+    commands = _json_obj(supervisor.get("commands"), field="supervisor.commands")
+    one_click = _json_obj(supervisor.get("one_click_demo"), field="supervisor.one_click_demo")
+    acceptance = _json_obj(supervisor.get("demo_acceptance"), field="supervisor.demo_acceptance")
+    takeover = _json_obj(supervisor.get("user_takeover"), field="supervisor.user_takeover")
+    boundary = _json_obj(supervisor.get("boundary"), field="supervisor.boundary")
+    lanes = [item for item in supervisor.get("lanes") or [] if isinstance(item, dict)]
+    gates = [item for item in board.get("user_gates") or [] if isinstance(item, dict)]
+    metrics = [item for item in board.get("value_metrics") or [] if isinstance(item, dict)]
+    promotion_candidates = [
+        item for item in decisions.get("promotion_candidates") or [] if isinstance(item, dict)
+    ]
+    retirement_candidates = [
+        item for item in decisions.get("retirement_candidates") or [] if isinstance(item, dict)
+    ]
+
+    attach = _compact_optional_text(
+        commands.get("attach"),
+        field="acceptance.attach",
+        default="attach command missing",
+    )
+    stop = _compact_optional_text(
+        commands.get("stop"),
+        field="acceptance.stop",
+        default="stop command missing",
+    )
+    start_script = [str(item) for item in commands.get("start_script") or []]
+    rehearsal_script = [str(item) for item in one_click.get("script") or []]
+    attach_visible = _command_available(commands.get("attach"))
+    stop_visible = _command_available(commands.get("stop"))
+    dry_run_safe = all(
+        boundary.get(field) is expected
+        for field, expected in {
+            "dry_run_plan_only": True,
+            "starts_tmux": False,
+            "runs_codex": False,
+            "writes_loopx_state": False,
+            "spends_loopx_quota": False,
+            "reads_credentials": False,
+            "reads_session_files": False,
+        }.items()
+    )
+    lane_checks = [
+        {
+            "lane_id": _compact_public_token(lane.get("lane_id"), field="acceptance.lane_id"),
+            "agent_id": _compact_public_token(lane.get("agent_id"), field="acceptance.agent_id"),
+            "quota_guard_visible": _command_available(lane.get("quota_guard")),
+            "frontier_visible": _command_available(lane.get("frontier")),
+            "bootstrap_visible": _command_available(lane.get("bootstrap_message")),
+            "visible_codex_tui": _compact_optional_token(
+                lane.get("visible_codex_tui"),
+                field="acceptance.visible_codex_tui",
+                default="codex",
+            ),
+        }
+        for lane in lanes
+    ]
+    lanes_ready = bool(lane_checks) and all(
+        check["quota_guard_visible"] and check["frontier_visible"] and check["bootstrap_visible"]
+        for check in lane_checks
+    )
+
+    return {
+        "ok": True,
+        "schema_version": AUTO_RESEARCH_DEMO_ACCEPTANCE_PACKET_SCHEMA_VERSION,
+        "goal_id": _compact_public_token(
+            research_contract.get("goal_id"),
+            field="acceptance.goal_id",
+        ),
+        "surface": {
+            "title": _compact_optional_text(
+                surface.get("title"),
+                field="acceptance.title",
+                default="Auto Research Demo Acceptance",
+            ),
+            "stage": _compact_optional_token(surface.get("stage"), field="acceptance.stage", default="experimental"),
+            "first_screen_policy": _compact_optional_token(
+                binding.get("first_screen_policy"),
+                field="acceptance.first_screen_policy",
+                default="experimental_only_not_first_screen_without_owner_review",
+            ),
+        },
+        "readiness_summary": {
+            "operator_can_review_now": True,
+            "ready_for_real_launch": bool(
+                binding.get("read_only")
+                and dry_run_safe
+                and attach_visible
+                and stop_visible
+                and lanes_ready
+            ),
+            "ready_for_public_first_screen": False,
+            "reason": (
+                "Board and dry-run supervisor are inspectable; real launch still requires explicit local user action."
+                if dry_run_safe and lanes_ready
+                else "Missing a visible lane, attach/stop control, or dry-run boundary field."
+            ),
+        },
+        "board_output": {
+            "schema_version": board.get("schema_version"),
+            "read_only": bool(binding.get("read_only")),
+            "source_kind": _compact_optional_token(
+                binding.get("source_kind"),
+                field="acceptance.source_kind",
+                default="unknown_source",
+            ),
+            "rollout_backed": bool(binding.get("rollout_backed")),
+            "value_metric_count": len(metrics),
+            "promotion_candidate_count": len(promotion_candidates),
+            "retirement_candidate_count": len(retirement_candidates),
+            "user_gate_count": len(gates),
+        },
+        "supervisor_rehearsal": {
+            "schema_version": supervisor.get("schema_version"),
+            "mode": _compact_optional_token(supervisor.get("mode"), field="acceptance.mode", default="dry_run"),
+            "session_name": _compact_optional_token(
+                supervisor.get("session_name"),
+                field="acceptance.session_name",
+                default="loopx-auto-research",
+            ),
+            "lane_count": len(lanes),
+            "one_click_mode": _compact_optional_token(
+                one_click.get("mode"),
+                field="acceptance.one_click_mode",
+                default="copy_paste_dry_run_rehearsal",
+            ),
+            "default_safe": bool(one_click.get("default_safe")),
+            "rehearsal_script_visible": bool(rehearsal_script),
+            "start_script_visible": bool(start_script),
+            "attach": attach,
+            "stop": stop,
+        },
+        "lane_checks": lane_checks,
+        "operator_checklist": [
+            "Run the dry-run rehearsal first and inspect the printed start script.",
+            "Confirm every lane prints quota should-run before frontier, bootstrap, or Codex.",
+            "Confirm attach and stop commands are visible before accepting any Codex prompt.",
+            "Confirm the board is read-only and still experimental.",
+            "Confirm promotion candidates remain decision items, not automatic public claims.",
+        ],
+        "accept_when": _compact_public_text_list(
+            acceptance.get("operator_can_accept_when") or [],
+            field="acceptance.accept_when",
+        ),
+        "reject_when": _compact_public_text_list(
+            acceptance.get("operator_must_reject_when") or [],
+            field="acceptance.reject_when",
+        ),
+        "user_takeover": {
+            "operator_controls": _compact_public_text_list(
+                takeover.get("operator_controls") or [],
+                field="acceptance.operator_controls",
+            ),
+            "visible_status_cues": _compact_public_text_list(
+                takeover.get("visible_status_cues") or [],
+                field="acceptance.visible_status_cues",
+            ),
+            "handoff_boundary": _compact_optional_text(
+                takeover.get("handoff_boundary"),
+                field="acceptance.handoff_boundary",
+                default="supervisor owns layout only; LoopX remains source of truth",
+            ),
+        },
+        "upgrade_path": [
+            "Keep this packet as the required preflight before any real tmux/Codex launch.",
+            "Only after user approval, paste the printed start_script in a visible shell.",
+            "Attach to the tmux session before accepting any Codex prompt.",
+            "Use normal LoopX todo/evidence writeback; the supervisor never writes state directly.",
+        ],
+        "public_boundary": {
+            "raw_logs_recorded": False,
+            "private_artifacts_recorded": False,
+            "local_paths_recorded": False,
+            "credentials_recorded": False,
+            "starts_tmux": bool(boundary.get("starts_tmux")),
+            "runs_codex": bool(boundary.get("runs_codex")),
+            "writes_loopx_state": bool(boundary.get("writes_loopx_state")),
+            "spends_loopx_quota": bool(boundary.get("spends_loopx_quota")),
+        },
     }
 
 
@@ -2582,6 +2803,58 @@ def render_auto_research_projection_markdown(payload: dict[str, object]) -> str:
 def render_auto_research_markdown(payload: dict[str, object]) -> str:
     if not payload.get("ok"):
         return f"# LoopX Auto Research\n\n- ok: `False`\n- error: `{payload.get('error')}`\n"
+    if payload.get("schema_version") == AUTO_RESEARCH_DEMO_ACCEPTANCE_PACKET_SCHEMA_VERSION:
+        surface = payload.get("surface") if isinstance(payload.get("surface"), dict) else {}
+        summary = (
+            payload.get("readiness_summary")
+            if isinstance(payload.get("readiness_summary"), dict)
+            else {}
+        )
+        board = payload.get("board_output") if isinstance(payload.get("board_output"), dict) else {}
+        rehearsal = (
+            payload.get("supervisor_rehearsal")
+            if isinstance(payload.get("supervisor_rehearsal"), dict)
+            else {}
+        )
+        checks = payload.get("operator_checklist") if isinstance(payload.get("operator_checklist"), list) else []
+        controls = (
+            payload.get("user_takeover")
+            if isinstance(payload.get("user_takeover"), dict)
+            else {}
+        )
+        control_items = (
+            controls.get("operator_controls")
+            if isinstance(controls.get("operator_controls"), list)
+            else []
+        )
+        lines = [
+            "# LoopX Auto Research Demo Acceptance",
+            "",
+            f"- schema: `{payload.get('schema_version')}`",
+            f"- goal_id: `{payload.get('goal_id')}`",
+            f"- title: {surface.get('title')}",
+            f"- stage: `{surface.get('stage')}`",
+            f"- operator_can_review_now: `{summary.get('operator_can_review_now')}`",
+            f"- ready_for_real_launch: `{summary.get('ready_for_real_launch')}`",
+            f"- ready_for_public_first_screen: `{summary.get('ready_for_public_first_screen')}`",
+            f"- board_read_only: `{board.get('read_only')}`",
+            f"- board_source_kind: `{board.get('source_kind')}`",
+            f"- board_rollout_backed: `{board.get('rollout_backed')}`",
+            f"- supervisor_mode: `{rehearsal.get('mode')}`",
+            f"- lane_count: `{rehearsal.get('lane_count')}`",
+            f"- attach: `{rehearsal.get('attach')}`",
+            f"- stop: `{rehearsal.get('stop')}`",
+            "",
+            "## Operator Checklist",
+            "",
+        ]
+        for item in checks:
+            lines.append(f"- {item}")
+        if control_items:
+            lines.extend(["", "## User Takeover", ""])
+            for item in control_items:
+                lines.append(f"- {item}")
+        return "\n".join(lines) + "\n"
     if payload.get("schema_version") == AUTO_RESEARCH_BOARD_SCHEMA_VERSION:
         surface = payload.get("surface") if isinstance(payload.get("surface"), dict) else {}
         binding = (


### PR DESCRIPTION
## Motivation

The auto-research demo now has a read-only board packet and a dry-run supervisor packet, but an operator still had to mentally connect the two before deciding whether the local demo is safe to show or take over. This PR adds a focused acceptance packet that turns that handoff into one explicit CLI surface.

## Changes

- Add `auto_research_demo_acceptance_packet_v0` and `build_auto_research_demo_acceptance_packet()`.
- Add `loopx auto-research acceptance`, which accepts either fixture-backed or live goal-backed board input and binds it to the dry-run supervisor plan.
- Render Markdown for the acceptance packet with board readiness, supervisor mode, lane count, attach/stop controls, and user takeover checklist.
- Extend rollout read-path smoke so live rollout-backed board evidence also produces an acceptance packet.
- Document the operator acceptance command in the decentralized auto-research showcase blueprint.

## Safety / Boundary

This is read-only. It does not launch tmux, launch Codex, write LoopX state, spend quota, promote hypotheses, or change public first screens. The packet keeps `ready_for_public_first_screen=false` until the owner first-screen review gate is explicitly cleared.

## Validation

- `python3 -m py_compile loopx/capabilities/auto_research/core.py loopx/capabilities/auto_research/cli.py loopx/capabilities/auto_research/__init__.py examples/auto-research-demo-acceptance-smoke.py examples/auto-research-rollout-readpath-smoke.py`
- `python3 examples/auto-research-demo-acceptance-smoke.py`
- `python3 examples/auto-research-rollout-readpath-smoke.py`
- `python3 examples/auto-research-demo-supervisor-smoke.py`
- `python3 examples/decentralized-auto-research-frontier-smoke.py`
- `python3 -m loopx.cli auto-research --help | rg -n "acceptance|demo-supervisor|board"`
- `git diff --check HEAD~1 HEAD`
- public/private boundary scan over touched files
