### PR TITLE
Record SkillsBench citation-check rerun

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
@@ -2121,7 +2121,7 @@
             "repair_class": "verifier_or_infra_repair",
             "repair_priority": "P0",
             "treatment_failure_scope": "score_missing",
-            "treatment_run_id": "e907196f7c85"
+            "treatment_run_id": "c3b9fa70421c"
           },
           "runs": [
             {
@@ -3108,6 +3108,184 @@
                 "codex_acp_runtime_tools_patch_applied": true,
                 "include_task_skills": false,
                 "original_task_mutated": false,
+                "staged": true,
+                "task_skills_removed": true
+              },
+              "verifier_attempt_countable": true
+            },
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": true,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_loopx_treatment",
+              "artifact_refs": {
+                "compact_artifact_ref": ".local/private-benchmark-jobs/skillsbench-citation-check-goalstart-earlyexit-20260628T1235Z/citation-check__loopx_goal_start_product_mode/benchmark_run.compact.json"
+              },
+              "attempt_failure_class": "verifier_failed",
+              "attempt_failure_label": "verifier_infrastructure_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "citation-check",
+              "case_ids": [
+                "citation-check"
+              ],
+              "codex_acp_runtime_preflight_passed": true,
+              "declared_done_round": 15,
+              "failure_class": "verifier_infrastructure_failure",
+              "failure_labels": [
+                "verifier_infrastructure_failure",
+                "skillsbench_product_mode_declared_done_below_passing_reward",
+                "skillsbench_agent_premature_done_signal"
+              ],
+              "failure_scope": "score_missing",
+              "job_name": "skillsbench_1_1_citation_check_loopx_goal_start_product_mode",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loop_score_policy": "best_round_for_offline_controller_analysis",
+              "loopx_inside_case": true,
+              "max_rounds_budget": 16,
+              "mode": "skillsbench_loopx_goal_start_product_mode_treatment",
+              "model_control_status": "reported_model_from_result_metadata",
+              "next_action": "repair verifier or infra attribution before comparing arms",
+              "notes": "citation-check /loopx goal-start + reverse-channel rerun used formal 16-round budget; case-local LoopX public open todo count was 0 after declared done, but verifier never passed, so this is worker-verifier/goal-todo ...",
+              "official_feedback_blinded": true,
+              "official_score_attempt_countable": false,
+              "official_score_policy": "final_workspace_official_result",
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 16,
+                "checkpoint_required": true,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "execution_style": "orchestrated_agentloop_loopx_cli",
+                "orchestrated_driver_counts_as_product_mode": true,
+                "orchestrated_driver_lifecycle_satisfied": true,
+                "required": true,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 34,
+                "state_write_count": 92
+              },
+              "recorded_at": "2026-06-28T21:45:07+08:00",
+              "repair_class": "verifier_or_infra_repair",
+              "repair_priority": "P0",
+              "reward_feedback_forwarded": false,
+              "round_reward_count": 15,
+              "round_rewards": [
+                {
+                  "agent_round": 1,
+                  "passed": false,
+                  "reward_present": false,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 2,
+                  "passed": false,
+                  "reward_present": false,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 3,
+                  "passed": false,
+                  "reward_present": false,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 4,
+                  "passed": false,
+                  "reward_present": false,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 5,
+                  "passed": false,
+                  "reward_present": false,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 6,
+                  "passed": false,
+                  "reward_present": false,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 7,
+                  "passed": false,
+                  "reward_present": false,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 8,
+                  "passed": false,
+                  "reward_present": false,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 9,
+                  "passed": false,
+                  "reward_present": false,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 10,
+                  "passed": false,
+                  "reward_present": false,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 11,
+                  "passed": false,
+                  "reward_present": false,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 12,
+                  "passed": false,
+                  "reward_present": false,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 13,
+                  "passed": false,
+                  "reward_present": false,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 14,
+                  "passed": false,
+                  "reward_present": false,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 15,
+                  "passed": false,
+                  "reward_present": false,
+                  "tool_calls": 0
+                }
+              ],
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-citation-check-goalstart-earlyexit-20260628T1235Z",
+              "run_id": "c3b9fa70421c",
+              "score_status": "missing",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "recorded",
+              "submit_eligible": false,
+              "task_staging": {
+                "app_skills_mount_patch_applied": true,
+                "apt_retry_patch_applied": true,
+                "apt_retry_patch_required": true,
+                "apt_risk_preflight_blocked": false,
+                "apt_setup_risk_detected": true,
+                "codex_acp_runtime_tools_patch_applied": true,
+                "include_task_skills": false,
+                "original_task_mutated": false,
+                "resource_cap_patch": {
+                  "applied": false,
+                  "effective_cpus": 1.0,
+                  "host_cpus": 2.0,
+                  "requested_cpus": 1.0
+                },
                 "staged": true,
                 "task_skills_removed": true
               },
@@ -9920,7 +10098,7 @@
           ]
         }
       },
-      "run_count": 161
+      "run_count": 162
     },
     "swe-marathon": {
       "benchmark_id": "swe-marathon",
@@ -13972,5 +14150,5 @@
     "source_of_truth": "benchmark_run_v0 compact run events",
     "update_rule": "upsert one run entry when a benchmark case is ingested or closed"
   },
-  "updated_at": "2026-06-28T19:33:21+08:00"
+  "updated_at": "2026-06-28T21:45:07+08:00"
 }

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
@@ -5,7 +5,7 @@ benchmark case outcomes and artifact references; it must not contain raw
 logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 
 - schema_version: `benchmark_run_ledger_v0`
-- updated_at: `2026-06-28T19:33:21+08:00`
+- updated_at: `2026-06-28T21:45:07+08:00`
 
 ## Case Decisions
 
@@ -17,7 +17,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `adaptive-cruise-control` | `baseline_runner_or_setup_repair_required` | - | - | `1` |
 | `skillsbench@1.1` | `azure-bgp-oscillation-route-leak` | `product_mode_pair_incomplete` | `treatment_loopx_lifecycle_not_observed` | - | `10` |
 | `skillsbench@1.1` | `bike-rebalance` | `paired_baseline_solved_treatment_preserved` | - | - | `3` |
-| `skillsbench@1.1` | `citation-check` | `paired_treatment_verifier_or_infra_repair_required` | - | - | `12` |
+| `skillsbench@1.1` | `citation-check` | `paired_treatment_verifier_or_infra_repair_required` | - | - | `13` |
 | `skillsbench@1.1` | `civ6-adjacency-optimizer` | `paired_no_score_uplift` | - | - | `4` |
 | `skillsbench@1.1` | `dapt-intrusion-detection` | `paired_baseline_setup_preflight_selection_required` | - | - | `5` |
 | `skillsbench@1.1` | `debug-trl-grpo` | `paired_baseline_runner_or_setup_repair_required` | - | - | `9` |
@@ -124,6 +124,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `citation-check` | `skillsbench_raw_codex_autonomous_max5_baseline` | `case_attempt` | `1.0` | `1` | `1:1*` | `none` | `` |
 | `skillsbench@1.1` | `citation-check` | `codex_loopx_treatment` | `` | `0.0` | `` | `1:0,2:0,3:0,4:0,5:0,6:0,7:0,8:0,9:0,10:0,11:0,12:0` | `skillsbench_host_local_acp_codex_exec_failed_codex_exec_bridge_idle_timeout` | `.local/private-benchmark-jobs/skillsbench-citation-check-goal-start-local-20260627T0735Z/citation-check__loopx_goal_start_product_mode/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `citation-check` | `codex_loopx_treatment` | `case_attempt` | `missing` | `` | `` | `verifier_infrastructure_failure` | `.local/private-benchmark-jobs/skillsbench-citation-check-goal-start-post777-20260627T133638Z/remote-root/jobs/skillsbench-citation-check-goal-start-post777-20260627T133638Z-goalstart/citation-check__loopx_goal_start_product_mode/benchmark_run.compact.json` |
+| `skillsbench@1.1` | `citation-check` | `codex_loopx_treatment` | `case_attempt` | `missing` | `` | `1:missing,2:missing,3:missing,4:missing,5:missing,6:missing,7:missing,8:missing,9:missing,10:missing,11:missing,12:missing,13:missing,14:missing,15:missing` | `verifier_infrastructure_failure` | `.local/private-benchmark-jobs/skillsbench-citation-check-goalstart-earlyexit-20260628T1235Z/citation-check__loopx_goal_start_product_mode/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `civ6-adjacency-optimizer` | `codex_goal_mode_baseline` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `` |
 | `skillsbench@1.1` | `civ6-adjacency-optimizer` | `loopx_automation_loop_treatment` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `` |
 | `skillsbench@1.1` | `civ6-adjacency-optimizer` | `baseline` | `` | `0.0` | `` | `1:0,2:0` | `official_verifier_solution_failure` | `.local/private-benchmark-jobs/skillsbench-civ6-adjacency-optimizer-blind-baseline-v0/civ6-adjacency-optimizer__codex_acp_blind_loop_v0/benchmark_run.compact.json` |

--- a/examples/benchmark-run-ledger-smoke.py
+++ b/examples/benchmark-run-ledger-smoke.py
@@ -956,6 +956,34 @@ def test_skillsbench_product_mode_pair_review_is_ledgered() -> None:
         rendered = render_benchmark_run_ledger_markdown(ledger)
         assert "`main_table_ready`" in rendered, rendered
 
+    long_round_treatment = json.loads(json.dumps(treatment))
+    long_round_treatment["case_id"] = "product-mode-long-round-fixture"
+    long_round_treatment["round_reward_trace"]["max_rounds_budget"] = 16
+    long_round_treatment["round_reward_trace"]["records"] = [
+        {"agent_round": round_index, "passed": False, "reward_present": False}
+        for round_index in range(1, 16)
+    ]
+
+    with tempfile.TemporaryDirectory(
+        prefix="benchmark-run-ledger-product-pair-long-round-"
+    ) as tmp:
+        root = Path(tmp)
+        ledger_path = root / "ledger.json"
+        update_benchmark_run_ledger(
+            ledger_path=ledger_path,
+            benchmark_run=long_round_treatment,
+            run_group_id="product-pair-long-round-ledger-smoke",
+            cwd=root,
+        )
+        ledger = load_benchmark_run_ledger(ledger_path)
+        case = ledger["benchmarks"]["skillsbench@1.1"]["cases"][
+            "product-mode-long-round-fixture"
+        ]
+        run = case["runs"][0]
+        assert run["max_rounds_budget"] == 16, run
+        assert run["round_reward_count"] == 15, run
+        assert run["round_rewards"][-1]["agent_round"] == 15, run
+
 
 def test_skillsbench_product_mode_pair_blocks_shallow_lifecycle() -> None:
     baseline = {

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -56,7 +56,7 @@ def _compact_list(value: Any, *, limit: int = 8) -> list[str]:
     return result
 
 
-def _compact_round_reward_records(value: Any, *, limit: int = 12) -> list[dict[str, Any]]:
+def _compact_round_reward_records(value: Any, *, limit: int = 32) -> list[dict[str, Any]]:
     if not isinstance(value, list):
         return []
     records: list[dict[str, Any]] = []


### PR DESCRIPTION
## Summary
- Record the latest SkillsBench citation-check /loopx goal-start + reverse-channel rerun in the benchmark run ledger.
- Preserve all compact round-reward records for long product-mode runs instead of truncating at 12.
- Add a ledger smoke that locks 16-round/15-record retention.

## Validation
- python3 examples/benchmark-run-ledger-smoke.py
- python3 examples/benchmark-case-analysis-smoke.py
- python3 -m loopx.cli benchmark run-ledger-check --goal-id loopx-meta --run-ledger-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
- python3 -m loopx.cli check --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md --scan-path examples/benchmark-run-ledger-smoke.py --scan-path loopx/benchmark_ledger.py
- python3 -m py_compile loopx/benchmark_ledger.py examples/benchmark-run-ledger-smoke.py
- git diff --check origin/main...HEAD

Note: loopx check reports the existing loopx-meta duplicate history-index warning; public boundary scan is clean.