### PR TITLE
Fix due monitor side-agent routing

### DIFF
--- a/examples/monitor-scheduler-contract-smoke.py
+++ b/examples/monitor-scheduler-contract-smoke.py
@@ -225,6 +225,43 @@ def assert_due_monitor_priority_does_not_steal_advancement_lane() -> None:
     assert guard["agent_todo_summary"]["monitor_due_count"] == 1, guard
 
 
+def assert_due_monitor_is_not_overridden_by_side_agent_scope_wait() -> None:
+    other_agent = "codex-main-control"
+    guard = guard_for(
+        [
+            monitor_item(
+                index=1,
+                todo_id="todo_side_due_monitor",
+                priority="P1",
+                next_due_at=PAST_DUE_AT,
+                target_key="side-agent-due-watch",
+            ),
+            advancement_item(index=2, priority="P1", claimed_by=other_agent),
+        ],
+        coordination={
+            "registered_agents": [other_agent, AGENT_ID],
+            "primary_agent": other_agent,
+        },
+    )
+    lane = guard["work_lane_contract"]
+    assert guard["agent_identity"]["role"] == "side-agent", guard
+    assert guard["decision"] == "run", guard
+    assert guard["effective_action"] == "normal_run", guard
+    assert guard["should_run"] is True, guard
+    assert guard["normal_delivery_allowed"] is True, guard
+    assert lane["monitor_kind"] == "todo_monitor_due", lane
+    assert lane["must_attempt_work"] is True, lane
+    assert lane["selected_todo_id"] == "todo_side_due_monitor", lane
+    assert "agent_scope_frontier" not in guard, guard
+    assert "agent_lane_frontier_hint" not in guard, guard
+    claim_scope = guard["agent_todo_summary"]["claim_scope"]
+    assert claim_scope["other_agent_claimed_open_count"] == 1, claim_scope
+    assert claim_scope["other_agent_claimed_weight"] == "diagnostic_only", claim_scope
+    contract = guard["interaction_contract"]
+    assert contract["agent_channel"]["must_attempt"] is True, contract
+    assert contract["agent_channel"]["quiet_noop_allowed"] is False, contract
+
+
 def assert_multiple_due_monitor_cap_and_order() -> None:
     guard = guard_for(
         [
@@ -331,6 +368,7 @@ def main() -> int:
     assert_due_monitor_requires_explicit_attempt()
     assert_expired_monitor_does_not_catch_up()
     assert_due_monitor_priority_does_not_steal_advancement_lane()
+    assert_due_monitor_is_not_overridden_by_side_agent_scope_wait()
     assert_multiple_due_monitor_cap_and_order()
     assert_other_agent_due_monitor_does_not_preempt_current_agent_lane()
     assert_other_agent_claimed_work_stays_diagnostic_when_no_current_lane()

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -2607,6 +2607,9 @@ def _agent_lane_frontier_hint(
                 next_cli_action=action,
             )
 
+    if _work_lane_due_monitor_attempt(work_lane_contract):
+        return None
+
     frontier = agent_scope_frontier if isinstance(agent_scope_frontier, dict) else {}
     frontier_action = _agent_scope_frontier_action(frontier.get("action"))
     if frontier_action == AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED:
@@ -2810,6 +2813,8 @@ def _agent_scope_no_candidate_frontier(
     if not agent_id or not isinstance(agent_todo_summary, dict):
         return None
     if isinstance(agent_lane_next_action, dict):
+        return None
+    if _work_lane_due_monitor_attempt(work_lane_contract):
         return None
     has_advancement_contract = (
         isinstance(work_lane_contract, dict)


### PR DESCRIPTION
## Summary
- keep a selected due `continuous_monitor` work lane from being overridden by side-agent `agent_scope_wait`
- suppress quiet monitor frontier hints when the work lane already requires a due monitor attempt
- add a monitor scheduler regression for side-agent due monitor plus other-agent advancement

## Validation
- `python examples/monitor-scheduler-contract-smoke.py`
- `python examples/quota-agent-scoped-user-gate-smoke.py`
- `python examples/work-lane-contract-smoke.py`
- `python -m py_compile loopx/quota.py examples/monitor-scheduler-contract-smoke.py`
- `git diff --check`
- `loopx check --scan-path loopx/quota.py --scan-path examples/monitor-scheduler-contract-smoke.py` (passes; existing duplicate-index warning only)

## Review note
Runtime/quota hot-path behavior change. Please review before merge; this PR intentionally adds no new runtime contract or metadata.
