### PR TITLE
Add visible auto-research launcher

### DIFF
--- a/docs/product/decentralized-auto-research-showcase.md
+++ b/docs/product/decentralized-auto-research-showcase.md
@@ -287,6 +287,32 @@ loopx --format json auto-research demo-supervisor \
   --agent codex-main-control:control-plane-guard
 ```
 
+When the dry-run packet is acceptable, the same command can launch visible
+local Codex CLI TUIs. This is intentionally opt-in:
+
+```bash
+loopx auto-research demo-supervisor \
+  --goal-id loopx-auto-research-knn \
+  --agent codex-side-bypass:hypothesis-runner \
+  --agent codex-product-capability:evidence-promoter \
+  --agent codex-main-control:control-plane-guard \
+  --execute
+```
+
+`--execute` auto-selects `tmux` when available and otherwise falls back to
+macOS Terminal. Use `--launcher tmux` or `--launcher terminal` to make the
+choice explicit. With tmux, `--attach` immediately joins the session and
+`--replace-existing` replaces a stale session with the same name. Terminal mode
+opens visible windows directly, so takeover is the normal terminal interrupt
+or closing the launched windows.
+
+The executed launcher still is not a leader. Each lane window first runs its
+own `quota should-run`, then renders its own `auto-research frontier`, then
+prints the `codex-cli-bootstrap-message`, and only then starts `codex` with
+that visible bootstrap prompt. The launcher itself does not write LoopX state
+or spend LoopX quota; any writeback must happen through the visible Codex lane's
+normal LoopX todo/evidence commands.
+
 For a tighter user handoff, render the demo acceptance packet. It links the
 experimental board output, the dry-run supervisor plan, and the takeover
 checklist into one operator-facing packet:
@@ -335,6 +361,11 @@ The user should see four concrete things in the packet:
   every lane before accepting Codex prompts, and
   `tmux kill-session -t loopx-auto-research` to stop the rehearsal.
 
+After `--execute`, the packet includes `launch_result` with the selected
+launcher, started lanes, attach/stop command, and takeover instructions. For a
+first live demo, prefer `--execute --attach` when tmux is installed, or
+`--execute --launcher terminal` on a Mac without tmux.
+
 The safe demo acceptance bar is that the user can inspect the plan, attach to
 the visible tmux session before any Codex prompt is accepted, interrupt any
 lane manually, and confirm that each lane still routes through LoopX quota,
@@ -349,11 +380,12 @@ print without executing, each lane must show quota before frontier/bootstrap,
 attach and stop controls must be visible, and dry-run boundary fields must show
 no tmux, Codex, state, quota, credential, or session side effects.
 
-The generated shell plan uses environment placeholders such as `LOOPX_PROJECT`,
-`LOOPX_REGISTRY`, and `LOOPX_RUNTIME_ROOT` instead of embedding local absolute
-paths. A future `--execute` path must remain user-visible: attach to tmux
-before accepting any Codex prompt, preserve manual interrupt, and keep same-
-session prompt injection blocked until visible-attach and idle evidence pass.
+The generated dry-run shell plan uses environment placeholders such as
+`LOOPX_PROJECT`, `LOOPX_REGISTRY`, and `LOOPX_RUNTIME_ROOT` instead of embedding
+local absolute paths. The executed path resolves those values locally and
+injects them into the launched visible terminals without recording the local
+paths in the public packet. Same-session prompt injection remains blocked until
+visible-attach and idle evidence pass.
 
 Next reproduction steps:
 

--- a/examples/auto-research-visible-launcher-smoke.py
+++ b/examples/auto-research-visible-launcher-smoke.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Smoke-test the visible auto-research demo launcher without starting real TUI processes."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+GOAL_ID = "loopx-auto-research-knn"
+LANES = [
+    "codex-side-bypass:hypothesis-runner",
+    "codex-product-capability:evidence-promoter",
+    "codex-main-control:control-plane-guard",
+]
+
+
+def write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def assert_public_safe(payload: Any) -> None:
+    text = json.dumps(payload, sort_keys=True) if not isinstance(payload, str) else payload
+    forbidden = [
+        "/" + "Users/",
+        "/" + "private/",
+        "/" + "tmp/",
+        "lark" + "office",
+        "byte" + "dance",
+        "http://",
+        "https://",
+        "api" + "_key",
+        "pass" + "word",
+        "sec" + "ret",
+    ]
+    leaked = [needle for needle in forbidden if needle.lower() in text.lower()]
+    assert not leaked, leaked
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        fake_bin = temp / "bin"
+        fake_bin.mkdir()
+        registry = temp / "registry.json"
+        runtime_root = temp / "runtime"
+        tmux_log = temp / "tmux.jsonl"
+        registry.write_text(
+            json.dumps({"common_runtime_root": str(runtime_root), "goals": []}),
+            encoding="utf-8",
+        )
+        write_executable(
+            fake_bin / "tmux",
+            "\n".join(
+                [
+                    "#!/usr/bin/env python3",
+                    "import json, os, sys",
+                    "with open(os.environ['FAKE_TMUX_LOG'], 'a', encoding='utf-8') as f:",
+                    "    f.write(json.dumps(sys.argv[1:]) + '\\n')",
+                    "if len(sys.argv) > 1 and sys.argv[1] == 'has-session':",
+                    "    raise SystemExit(1)",
+                    "raise SystemExit(0)",
+                    "",
+                ]
+            ),
+        )
+        write_executable(fake_bin / "loopx", "#!/usr/bin/env sh\nexit 0\n")
+        write_executable(fake_bin / "codex", "#!/usr/bin/env sh\nexit 0\n")
+
+        env = os.environ.copy()
+        env["PATH"] = f"{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+        env["FAKE_TMUX_LOG"] = str(tmux_log)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "loopx.cli",
+                "--registry",
+                str(registry),
+                "--runtime-root",
+                str(runtime_root),
+                "--format",
+                "json",
+                "auto-research",
+                "demo-supervisor",
+                "--goal-id",
+                GOAL_ID,
+                "--session-name",
+                "loopx-auto-research-smoke",
+                "--agent",
+                LANES[0],
+                "--agent",
+                LANES[1],
+                "--agent",
+                LANES[2],
+                "--execute",
+                "--launcher",
+                "tmux",
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        payload = json.loads(result.stdout)
+        assert payload["ok"] is True, payload
+        assert payload["mode"] == "executed_visible_launch", payload
+        assert payload["boundary"]["starts_tmux"] is True, payload
+        assert payload["boundary"]["runs_codex"] is True, payload
+        assert payload["boundary"]["writes_loopx_state"] is False, payload
+        assert payload["boundary"]["spends_loopx_quota"] is False, payload
+        launch = payload["launch_result"]
+        assert launch["launcher"] == "tmux", launch
+        assert launch["started_lane_count"] == 3, launch
+        assert launch["attach_command"] == "tmux attach -t loopx-auto-research-smoke", launch
+        assert launch["stop_command"] == "tmux kill-session -t loopx-auto-research-smoke", launch
+
+        for lane in payload["lanes"]:
+            command = lane["visible_launch_command"]
+            assert "quota should-run" in command, command
+            assert "auto-research frontier" in command, command
+            assert "codex-cli-bootstrap-message" in command, command
+            assert 'exec codex "$BOOTSTRAP_PROMPT"' in command, command
+
+        log_entries = [json.loads(line) for line in tmux_log.read_text(encoding="utf-8").splitlines()]
+        assert log_entries[0][:1] == ["has-session"], log_entries
+        assert any(entry[:1] == ["new-session"] for entry in log_entries), log_entries
+        assert sum(1 for entry in log_entries if entry[:1] == ["new-window"]) == 3, log_entries
+        assert_public_safe(payload)
+
+    print("auto-research-visible-launcher-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
 import argparse
+import os
+import platform
+import shlex
+import shutil
+import subprocess
 from collections import Counter
 from collections.abc import Callable
 from pathlib import Path
@@ -227,6 +232,30 @@ def register_auto_research_commands(
     demo_supervisor_parser.add_argument("--cli-bin", default="loopx", help="LoopX CLI executable name.")
     demo_supervisor_parser.add_argument("--codex-bin", default="codex", help="Codex CLI executable name.")
     demo_supervisor_parser.add_argument("--tmux-bin", default="tmux", help="tmux executable name.")
+    demo_supervisor_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help=(
+            "Actually launch visible Codex CLI lanes. Omit for the default dry-run packet. "
+            "This only starts local visible terminals; LoopX writeback still happens through normal lane commands."
+        ),
+    )
+    demo_supervisor_parser.add_argument(
+        "--launcher",
+        choices=["auto", "tmux", "terminal"],
+        default="auto",
+        help="Visible process launcher for --execute. auto prefers tmux, then macOS Terminal.",
+    )
+    demo_supervisor_parser.add_argument(
+        "--attach",
+        action="store_true",
+        help="After --execute with tmux, attach to the session. Terminal launcher opens visible windows directly.",
+    )
+    demo_supervisor_parser.add_argument(
+        "--replace-existing",
+        action="store_true",
+        help="With tmux launcher, kill an existing session with the same name before launching.",
+    )
 
 
 def _append_auto_research_rollout_events(
@@ -280,6 +309,269 @@ def _append_auto_research_rollout_events(
             "source": "loopx_rollout_event_log",
         },
     }
+
+
+def _require_executable(command: str, *, field: str) -> str:
+    path = shutil.which(command)
+    if not path:
+        raise ValueError(f"{field} executable not found on PATH: {command}")
+    return path
+
+
+def _apple_script_string(value: str) -> str:
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def _runtime_shell_command(
+    command: str,
+    *,
+    project: Path,
+    registry: Path,
+    runtime_root: Path,
+) -> str:
+    exports = [
+        "set -euo pipefail",
+        f"export LOOPX_PROJECT={shlex.quote(str(project))}",
+        f"export LOOPX_REGISTRY={shlex.quote(str(registry))}",
+        f"export LOOPX_RUNTIME_ROOT={shlex.quote(str(runtime_root))}",
+    ]
+    return "; ".join([*exports, command])
+
+
+def _mac_terminal_available() -> bool:
+    if platform.system() != "Darwin" or not shutil.which("osascript"):
+        return False
+    result = subprocess.run(
+        ["osascript", "-e", 'id of application "Terminal"'],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def _resolve_auto_research_launcher(*, requested: str, tmux_bin: str) -> str:
+    if requested != "auto":
+        return requested
+    if shutil.which(tmux_bin):
+        return "tmux"
+    if _mac_terminal_available():
+        return "terminal"
+    raise ValueError("no visible launcher found: install tmux or run on macOS with Terminal available")
+
+
+def _launch_auto_research_with_tmux(
+    *,
+    payload: dict[str, object],
+    project: Path,
+    registry: Path,
+    runtime_root: Path,
+    tmux_bin: str,
+    attach: bool,
+    replace_existing: bool,
+) -> dict[str, object]:
+    _require_executable(tmux_bin, field="tmux_bin")
+    session = str(payload.get("session_name") or "loopx-auto-research")
+    lanes = [item for item in payload.get("lanes", []) if isinstance(item, dict)]
+    if not lanes:
+        raise ValueError("demo supervisor has no lanes to launch")
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "LOOPX_PROJECT": str(project),
+            "LOOPX_REGISTRY": str(registry),
+            "LOOPX_RUNTIME_ROOT": str(runtime_root),
+        }
+    )
+    exists = subprocess.run(
+        [tmux_bin, "has-session", "-t", session],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+        env=env,
+    )
+    if exists.returncode == 0:
+        if not replace_existing:
+            raise ValueError(
+                f"tmux session already exists: {session}; use --replace-existing or attach manually"
+            )
+        subprocess.run([tmux_bin, "kill-session", "-t", session], check=True, env=env)
+
+    first_frontier = str(lanes[0].get("frontier") or "")
+    if not first_frontier:
+        raise ValueError("first lane is missing a frontier command")
+    frontier_command = _runtime_shell_command(
+        f'cd "$LOOPX_PROJECT"; {first_frontier}',
+        project=project,
+        registry=registry,
+        runtime_root=runtime_root,
+    )
+    subprocess.run(
+        [tmux_bin, "new-session", "-d", "-s", session, "-n", "frontier", "bash", "-lc", frontier_command],
+        check=True,
+        env=env,
+    )
+    started_lanes: list[str] = []
+    for lane in lanes:
+        lane_id = str(lane.get("lane_id") or "research-lane")
+        launch_command = str(lane.get("visible_launch_command") or "")
+        if not launch_command:
+            raise ValueError(f"lane {lane_id} is missing visible_launch_command")
+        subprocess.run(
+            [
+                tmux_bin,
+                "new-window",
+                "-d",
+                "-t",
+                session,
+                "-n",
+                lane_id,
+                "bash",
+                "-lc",
+                _runtime_shell_command(
+                    launch_command,
+                    project=project,
+                    registry=registry,
+                    runtime_root=runtime_root,
+                ),
+            ],
+            check=True,
+            env=env,
+        )
+        started_lanes.append(lane_id)
+    if attach:
+        subprocess.run([tmux_bin, "attach", "-t", session], check=True, env=env)
+    return {
+        "schema_version": "auto_research_demo_launch_result_v0",
+        "executed": True,
+        "launcher": "tmux",
+        "session_name": session,
+        "started_lane_count": len(started_lanes),
+        "started_lanes": started_lanes,
+        "attach_command": f"{tmux_bin} attach -t {session}",
+        "stop_command": f"{tmux_bin} kill-session -t {session}",
+        "attach_requested": attach,
+        "operator_takeover": "attach to the tmux session, interrupt any lane, or kill the session",
+    }
+
+
+def _launch_auto_research_with_terminal(
+    *,
+    payload: dict[str, object],
+    project: Path,
+    registry: Path,
+    runtime_root: Path,
+) -> dict[str, object]:
+    _require_executable("osascript", field="osascript")
+    if not _mac_terminal_available():
+        raise ValueError("macOS Terminal is not available for --launcher terminal")
+    lanes = [item for item in payload.get("lanes", []) if isinstance(item, dict)]
+    if not lanes:
+        raise ValueError("demo supervisor has no lanes to launch")
+
+    first_frontier = str(lanes[0].get("frontier") or "")
+    frontier_command = _runtime_shell_command(
+        f'cd "$LOOPX_PROJECT"; {first_frontier}; printf "\\n[Terminal window ready]\\n"; exec $SHELL -l',
+        project=project,
+        registry=registry,
+        runtime_root=runtime_root,
+    )
+    subprocess.run(
+        [
+            "osascript",
+            "-e",
+            f'tell application "Terminal" to do script {_apple_script_string(frontier_command)}',
+        ],
+        check=True,
+    )
+    started_lanes: list[str] = []
+    for lane in lanes:
+        lane_id = str(lane.get("lane_id") or "research-lane")
+        launch_command = str(lane.get("visible_launch_command") or "")
+        if not launch_command:
+            raise ValueError(f"lane {lane_id} is missing visible_launch_command")
+        command = _runtime_shell_command(
+            f"printf '\\n[LoopX auto-research lane: {lane_id}]\\n'; {launch_command}",
+            project=project,
+            registry=registry,
+            runtime_root=runtime_root,
+        )
+        subprocess.run(
+            [
+                "osascript",
+                "-e",
+                f'tell application "Terminal" to do script {_apple_script_string(command)}',
+            ],
+            check=True,
+        )
+        started_lanes.append(lane_id)
+    return {
+        "schema_version": "auto_research_demo_launch_result_v0",
+        "executed": True,
+        "launcher": "terminal",
+        "session_name": str(payload.get("session_name") or "loopx-auto-research"),
+        "started_lane_count": len(started_lanes),
+        "started_lanes": started_lanes,
+        "attach_command": "already visible in Terminal windows",
+        "stop_command": "interrupt or close the opened Terminal windows",
+        "attach_requested": False,
+        "operator_takeover": "use the visible Terminal windows; interrupt any lane before writeback",
+    }
+
+
+def _execute_auto_research_demo_supervisor(
+    payload: dict[str, object],
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    launcher: str,
+    tmux_bin: str,
+    cli_bin: str,
+    codex_bin: str,
+    attach: bool,
+    replace_existing: bool,
+) -> dict[str, object]:
+    _require_executable(cli_bin, field="cli_bin")
+    _require_executable(codex_bin, field="codex_bin")
+    registry = load_registry(registry_path)
+    runtime_root = resolve_runtime_root(registry, runtime_root_arg)
+    chosen = _resolve_auto_research_launcher(requested=launcher, tmux_bin=tmux_bin)
+    project = Path.cwd()
+    if chosen == "tmux":
+        result = _launch_auto_research_with_tmux(
+            payload=payload,
+            project=project,
+            registry=registry_path,
+            runtime_root=runtime_root,
+            tmux_bin=tmux_bin,
+            attach=attach,
+            replace_existing=replace_existing,
+        )
+    else:
+        result = _launch_auto_research_with_terminal(
+            payload=payload,
+            project=project,
+            registry=registry_path,
+            runtime_root=runtime_root,
+        )
+    payload["mode"] = "executed_visible_launch"
+    payload["launch_result"] = result
+    boundary = payload.get("boundary")
+    if isinstance(boundary, dict):
+        boundary.update(
+            {
+                "dry_run_plan_only": False,
+                "starts_tmux": chosen == "tmux",
+                "opens_terminal": chosen == "terminal",
+                "runs_codex": True,
+                "writes_loopx_state": False,
+                "spends_loopx_quota": False,
+                "external_service_call": False,
+            }
+        )
+    return payload
 
 
 def handle_auto_research_command(
@@ -377,6 +669,18 @@ def handle_auto_research_command(
                 codex_bin=args.codex_bin,
                 tmux_bin=args.tmux_bin,
             )
+            if args.execute:
+                payload = _execute_auto_research_demo_supervisor(
+                    payload,
+                    registry_path=registry_path,
+                    runtime_root_arg=runtime_root_arg,
+                    launcher=args.launcher,
+                    tmux_bin=args.tmux_bin,
+                    cli_bin=args.cli_bin,
+                    codex_bin=args.codex_bin,
+                    attach=args.attach,
+                    replace_existing=args.replace_existing,
+                )
         else:
             raise ValueError(
                 "auto-research requires the `quickstart`, `frontier`, `evidence`, "

--- a/loopx/capabilities/auto_research/core.py
+++ b/loopx/capabilities/auto_research/core.py
@@ -623,6 +623,41 @@ def _env_bootstrap_command(*, cli_bin: str, goal_id: str, agent_id: str) -> str:
     )
 
 
+_QUOTA_GATE_PY = (
+    "import json,sys; "
+    "p=json.load(sys.stdin); "
+    "u=p.get('interaction_contract',{}).get('user_channel',{}); "
+    "a=p.get('interaction_contract',{}).get('agent_channel',{}); "
+    "delivery=a.get('delivery_allowed', p.get('should_run', True)); "
+    "ok=(not bool(u.get('action_required'))) and delivery is not False; "
+    "sys.exit(0 if ok else 42)"
+)
+
+
+def _env_lane_launch_command(
+    *,
+    quota_command: str,
+    frontier_command: str,
+    bootstrap_command: str,
+    codex_bin: str,
+) -> str:
+    return (
+        "set -euo pipefail; "
+        'cd "$LOOPX_PROJECT"; '
+        "printf '\\n[LoopX quota guard]\\n'; "
+        f"QUOTA_PACKET=\"$({quota_command})\"; "
+        "printf '%s\\n' \"$QUOTA_PACKET\"; "
+        f"printf '%s\\n' \"$QUOTA_PACKET\" | python3 -c {_shell_arg(_QUOTA_GATE_PY)}; "
+        "printf '\\n[LoopX auto-research frontier]\\n'; "
+        f"{frontier_command}; "
+        "printf '\\n[Codex bootstrap prompt]\\n'; "
+        f"BOOTSTRAP_PROMPT=\"$({bootstrap_command})\"; "
+        "printf '%s\\n' \"$BOOTSTRAP_PROMPT\"; "
+        "printf '\\n[Starting visible Codex CLI]\\n'; "
+        f"exec {_shell_arg(codex_bin)} \"$BOOTSTRAP_PROMPT\""
+    )
+
+
 def _demo_rehearsal_script(*, session: str, start_script: list[str], attach_command: str, stop_command: str) -> list[str]:
     """Return a copy-paste dry-run script that prints the real launch plan only."""
 
@@ -686,6 +721,12 @@ def build_auto_research_demo_supervisor_plan(
                 "frontier": frontier_command,
                 "bootstrap_message": bootstrap_command,
                 "visible_codex_tui": codex,
+                "visible_launch_command": _env_lane_launch_command(
+                    quota_command=quota_command,
+                    frontier_command=frontier_command,
+                    bootstrap_command=bootstrap_command,
+                    codex_bin=codex,
+                ),
                 "start_sequence": [
                     "run quota_guard and stop when user_channel.action_required=true",
                     "render the lane frontier from LoopX state",
@@ -731,24 +772,29 @@ def build_auto_research_demo_supervisor_plan(
         ": ${LOOPX_REGISTRY:?set LOOPX_REGISTRY to the LoopX registry path before running}",
         ": ${LOOPX_RUNTIME_ROOT:?set LOOPX_RUNTIME_ROOT to the LoopX runtime root before running}",
     ]
+    frontier_launch_command = (
+        'cd "$LOOPX_PROJECT"; '
+        + _env_frontier_command(cli_bin=cli, goal_id=goal, agent_id=lanes[0]["agent_id"])
+    )
     start_script = [
         *env_lines,
-        f"{_shell_arg(tmux)} new-session -d -s {_shell_arg(session)} -n frontier",
         (
-            f"{_shell_arg(tmux)} send-keys -t {_shell_arg(session)}:frontier "
-            f"{_shell_arg(_env_frontier_command(cli_bin=cli, goal_id=goal, agent_id=lanes[0]['agent_id']))} C-m"
+            f"{_shell_arg(tmux)} new-session -d -s {_shell_arg(session)} -n frontier "
+            f"bash -lc {_shell_arg(frontier_launch_command)}"
+        ),
+        (
+            f"{_shell_arg(tmux)} display-message -t {_shell_arg(session)} "
+            f"{_shell_arg('LoopX auto-research supervisor started; attach before accepting prompts')}"
         ),
     ]
     for pane in pane_plans:
         lane_id = str(pane["lane_id"])
-        lane_command = (
-            f"cd \"$LOOPX_PROJECT\"; {pane['quota_guard']}; {pane['frontier']}; "
-            f"{pane['bootstrap_message']}; {pane['visible_codex_tui']}"
-        )
         start_script.extend(
             [
-                f"{_shell_arg(tmux)} new-window -d -t {_shell_arg(session)} -n {_shell_arg(lane_id)}",
-                f"{_shell_arg(tmux)} send-keys -t {_shell_arg(session)}:{_shell_arg(lane_id)} {_shell_arg(lane_command)} C-m",
+                (
+                    f"{_shell_arg(tmux)} new-window -d -t {_shell_arg(session)} "
+                    f"-n {_shell_arg(lane_id)} bash -lc {_shell_arg(str(pane['visible_launch_command']))}"
+                ),
             ]
         )
     attach_command = f"{_shell_arg(tmux)} attach -t {_shell_arg(session)}"
@@ -2922,6 +2968,11 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
             if isinstance(payload.get("coordination_model"), dict)
             else {}
         )
+        launch_result = (
+            payload.get("launch_result")
+            if isinstance(payload.get("launch_result"), dict)
+            else {}
+        )
         lines = [
             "# LoopX Auto Research Demo Supervisor",
             "",
@@ -2983,6 +3034,14 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
                 lines.append(f"- accept when: {item}")
             for item in reject_when:
                 lines.append(f"- reject when: {item}")
+        if launch_result:
+            lines.extend(["", "## Visible Launch Result", ""])
+            lines.append(f"- launcher: `{launch_result.get('launcher')}`")
+            lines.append(f"- executed: `{launch_result.get('executed')}`")
+            lines.append(f"- started_lanes: `{launch_result.get('started_lane_count')}`")
+            lines.append(f"- attach: `{launch_result.get('attach_command')}`")
+            lines.append(f"- stop: `{launch_result.get('stop_command')}`")
+            lines.append(f"- takeover: {launch_result.get('operator_takeover')}")
         lines.extend(["", "## Shell Plan", ""])
         for line in commands.get("start_script") or []:
             lines.append(f"- `{line}`")


### PR DESCRIPTION
## Summary
- add explicit --execute launcher support for auto-research demo-supervisor
- prefer tmux and fall back to macOS Terminal so users can watch multiple Codex CLI lanes work visibly
- wire each lane through quota guard, frontier projection, bootstrap prompt, then visible Codex TUI
- add a fake-tmux smoke and document the live demo path

## Validation
- python3 -m py_compile loopx/capabilities/auto_research/core.py loopx/capabilities/auto_research/cli.py examples/auto-research-visible-launcher-smoke.py
- python3 examples/auto-research-demo-supervisor-smoke.py
- python3 examples/auto-research-demo-acceptance-smoke.py
- python3 examples/auto-research-rollout-readpath-smoke.py
- python3 examples/auto-research-visible-launcher-smoke.py
- python3 -m loopx.cli auto-research demo-supervisor --help | rg -n -- '--execute|--launcher|--attach|replace-existing'
- git diff --check