### PR TITLE
Stop SkillsBench on repeated no-open-todo closeout

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -2286,7 +2286,7 @@ def test_product_mode_declared_done_requires_solver_activity_after_driver_lifecy
         assert trace.get("agent_declared_done") is not True, trace
 
 
-def test_product_mode_declared_done_below_passing_reward_continues() -> None:
+def test_product_mode_declared_done_stops_after_two_no_open_todo_rounds() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-declared-done-score-zero-") as tmp:
         root = Path(tmp)
         jobs_dir = root / "jobs"
@@ -2426,8 +2426,52 @@ def test_product_mode_declared_done_below_passing_reward_continues() -> None:
         assert trace["product_mode_declared_done_policy"] == (
             "continue_until_official_success_or_budget"
         )
+        assert trace[
+            "product_mode_no_open_todo_below_passing_reward_open_todo_count_public"
+        ] == 0
+        assert trace["product_mode_no_open_todo_below_passing_reward_streak"] == 1
+        assert (
+            trace[
+                "product_mode_no_open_todo_below_passing_reward_streak_threshold"
+            ]
+            == 2
+        )
+        assert (
+            trace["product_mode_no_open_todo_below_passing_reward_stop"]
+            is not True
+        )
         assert trace["followup_prompt_count"] == 1, trace
         assert trace["stop_decision_count"] == 0, trace
+
+        prompt = asyncio.run(
+            user.run(
+                3,
+                "Continue fixing the fixture.",
+                round_result=FakeRoundResult(),
+            )
+        )
+        assert prompt is None, trace
+        assert trace["last_decision"] == (
+            "stop_after_product_mode_two_no_open_todo_rounds_without_passing_reward"
+        )
+        assert trace["agent_declared_done"] is True, trace
+        assert trace["declared_done_round"] == 3, trace
+        assert trace["declared_done_score"] == 0.0, trace
+        assert trace["product_mode_declared_done_below_passing_reward_count"] == 2
+        assert trace["product_mode_declared_done_below_passing_reward_round"] == 3
+        assert trace["product_mode_no_open_todo_below_passing_reward_streak"] == 2
+        assert (
+            trace["product_mode_no_open_todo_below_passing_reward_stop"] is True
+        )
+        assert trace["product_mode_no_open_todo_below_passing_reward_stop_round"] == 3
+        assert (
+            trace["product_mode_no_open_todo_below_passing_reward_stop_count"] == 1
+        )
+        assert trace["product_mode_declared_done_policy"] == (
+            "stop_after_two_no_open_todo_rounds_without_passing_reward"
+        )
+        assert trace["followup_prompt_count"] == 1, trace
+        assert trace["stop_decision_count"] == 1, trace
 
 
 def test_product_mode_declared_done_missing_reward_continues() -> None:
@@ -2570,6 +2614,18 @@ def test_product_mode_declared_done_missing_reward_continues() -> None:
         )
         assert trace["product_mode_declared_done_policy"] == (
             "continue_until_official_success_or_budget"
+        )
+        assert trace[
+            "product_mode_no_open_todo_below_passing_reward_open_todo_count_public"
+        ] == 0
+        assert trace["product_mode_no_open_todo_below_passing_reward_streak"] == 1
+        assert (
+            trace["product_mode_no_open_todo_below_passing_reward_score_status"]
+            == "missing"
+        )
+        assert (
+            trace["product_mode_no_open_todo_below_passing_reward_stop"]
+            is not True
         )
         assert trace["followup_prompt_count"] == 1, trace
         assert trace["stop_decision_count"] == 0, trace
@@ -7552,8 +7608,8 @@ def test_skillsbench_product_mode_declared_done_below_passing_reward_is_compacte
             "heartbeat_count": 3,
             "controller_action_decisions": 3,
             "initial_prompt_count": 1,
-            "followup_prompt_count": 2,
-            "stop_decision_count": 0,
+            "followup_prompt_count": 1,
+            "stop_decision_count": 1,
             "reward_observation_count": 2,
             "round_rewards": [
                 {"agent_round": 1, "reward_present": True, "reward": 0.0},
@@ -7564,17 +7620,29 @@ def test_skillsbench_product_mode_declared_done_below_passing_reward_is_compacte
             "declared_done_round": 2,
             "declared_done_score": 0.0,
             "product_mode_declared_done_below_passing_reward": True,
-            "product_mode_declared_done_below_passing_reward_count": 1,
+            "product_mode_declared_done_below_passing_reward_count": 2,
             "product_mode_declared_done_below_passing_reward_round": 2,
             "product_mode_declared_done_below_passing_reward_score": 0.0,
             "product_mode_declared_done_below_passing_reward_score_status": (
                 "observed_below_passing"
             ),
+            "open_todo_count": 0,
+            "product_mode_no_open_todo_below_passing_reward_stop": True,
+            "product_mode_no_open_todo_below_passing_reward_streak": 2,
+            "product_mode_no_open_todo_below_passing_reward_streak_threshold": 2,
+            "product_mode_no_open_todo_below_passing_reward_round": 2,
+            "product_mode_no_open_todo_below_passing_reward_stop_count": 1,
+            "product_mode_no_open_todo_below_passing_reward_stop_round": 2,
+            "product_mode_no_open_todo_below_passing_reward_open_todo_count_public": 0,
+            "product_mode_no_open_todo_below_passing_reward_score": 0.0,
+            "product_mode_no_open_todo_below_passing_reward_score_status": (
+                "observed_below_passing"
+            ),
             "product_mode_declared_done_policy": (
-                "continue_until_official_success_or_budget"
+                "stop_after_two_no_open_todo_rounds_without_passing_reward"
             ),
             "last_decision": (
-                "send_product_mode_success_or_budget_continuation_after_declared_done"
+                "stop_after_product_mode_two_no_open_todo_rounds_without_passing_reward"
             ),
             "raw_task_text_recorded": False,
             "raw_verifier_output_recorded": False,
@@ -7591,7 +7659,7 @@ def test_skillsbench_product_mode_declared_done_below_passing_reward_is_compacte
         counters = compact["interaction_counters"]
         assert counters["product_mode_declared_done_below_passing_reward"] is True
         assert (
-            counters["product_mode_declared_done_below_passing_reward_count"] == 1
+            counters["product_mode_declared_done_below_passing_reward_count"] == 2
         )
         assert (
             counters["product_mode_declared_done_below_passing_reward_round"] == 2
@@ -7606,13 +7674,54 @@ def test_skillsbench_product_mode_declared_done_below_passing_reward_is_compacte
             == "observed_below_passing"
         )
         assert counters["product_mode_declared_done_policy"] == (
-            "continue_until_official_success_or_budget"
+            "stop_after_two_no_open_todo_rounds_without_passing_reward"
         )
+        assert (
+            counters["product_mode_no_open_todo_below_passing_reward_stop"] is True
+        )
+        assert counters["product_mode_no_open_todo_below_passing_reward_streak"] == 2
+        assert (
+            counters[
+                "product_mode_no_open_todo_below_passing_reward_streak_threshold"
+            ]
+            == 2
+        )
+        assert (
+            counters[
+                "product_mode_no_open_todo_below_passing_reward_open_todo_count_public"
+            ]
+            == 0
+        )
+        assert (
+            counters["product_mode_no_open_todo_below_passing_reward_score"] == 0.0
+        )
+        round_trace = compact["round_reward_trace"]
+        assert (
+            round_trace["product_mode_no_open_todo_below_passing_reward_stop"]
+            is True
+        ), round_trace
+        assert (
+            round_trace["product_mode_no_open_todo_below_passing_reward_streak"] == 2
+        ), round_trace
+        post_run_gate = compact["post_run_debug_gate"]
+        assert (
+            post_run_gate["todo_flow"]["no_open_todo_below_passing_reward_stop"]
+            is True
+        ), post_run_gate
+        assert (
+            post_run_gate["todo_flow"]["no_open_todo_below_passing_reward_streak"]
+            == 2
+        ), post_run_gate
         labels = compact["failure_attribution_labels"]
         assert (
             "skillsbench_product_mode_declared_done_below_passing_reward" in labels
         )
         assert "skillsbench_agent_premature_done_signal" in labels
+        assert (
+            "skillsbench_product_mode_no_open_todo_below_passing_reward_stop"
+            in labels
+        )
+        assert "skillsbench_solver_exhausted_no_open_todos" in labels
 
 
 def test_skillsbench_declared_done_missing_reward_status_is_compacted() -> None:
@@ -10813,7 +10922,7 @@ if __name__ == "__main__":
     test_product_mode_case_state_seed_uses_active_goal_shape()
     test_product_mode_declared_done_requires_case_state_depth()
     test_product_mode_declared_done_requires_solver_activity_after_driver_lifecycle()
-    test_product_mode_declared_done_below_passing_reward_continues()
+    test_product_mode_declared_done_stops_after_two_no_open_todo_rounds()
     test_product_mode_declared_done_missing_reward_continues()
     test_product_mode_missing_lifecycle_prompts_exact_checkpoint()
     test_product_mode_no_tool_call_continues_before_checkpoint_loop()

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -2140,6 +2140,10 @@ def _skillsbench_controller_trace_counters(
             "product_mode_declared_done_below_passing_reward"
         )
         is True,
+        "product_mode_no_open_todo_below_passing_reward_stop": controller_trace.get(
+            "product_mode_no_open_todo_below_passing_reward_stop"
+        )
+        is True,
         "agent_declared_done": controller_trace.get("agent_declared_done") is True,
         "agent_declared_no_remaining_goals": controller_trace.get(
             "agent_declared_no_remaining_goals"
@@ -2425,6 +2429,25 @@ def _skillsbench_controller_trace_counters(
         "product_mode_declared_done_below_passing_reward_round": count(
             "product_mode_declared_done_below_passing_reward_round"
         ),
+        "open_todo_count": count("open_todo_count"),
+        "product_mode_no_open_todo_below_passing_reward_streak": count(
+            "product_mode_no_open_todo_below_passing_reward_streak"
+        ),
+        "product_mode_no_open_todo_below_passing_reward_streak_threshold": count(
+            "product_mode_no_open_todo_below_passing_reward_streak_threshold"
+        ),
+        "product_mode_no_open_todo_below_passing_reward_round": count(
+            "product_mode_no_open_todo_below_passing_reward_round"
+        ),
+        "product_mode_no_open_todo_below_passing_reward_stop_count": count(
+            "product_mode_no_open_todo_below_passing_reward_stop_count"
+        ),
+        "product_mode_no_open_todo_below_passing_reward_stop_round": count(
+            "product_mode_no_open_todo_below_passing_reward_stop_round"
+        ),
+        "product_mode_no_open_todo_below_passing_reward_open_todo_count_public": count(
+            "product_mode_no_open_todo_below_passing_reward_open_todo_count_public"
+        ),
         "product_mode_final_closeout_superseded_by_official_success": (
             controller_trace.get(
                 "product_mode_final_closeout_superseded_by_official_success"
@@ -2593,6 +2616,16 @@ def _skillsbench_controller_trace_counters(
         counters["product_mode_declared_done_below_passing_reward_score"] = float(
             below_passing_score
         )
+    no_open_todo_score = controller_trace.get(
+        "product_mode_no_open_todo_below_passing_reward_score"
+    )
+    if (
+        isinstance(no_open_todo_score, (int, float))
+        and not isinstance(no_open_todo_score, bool)
+    ):
+        counters["product_mode_no_open_todo_below_passing_reward_score"] = float(
+            no_open_todo_score
+        )
     below_passing_score_status = _skillsbench_public_safe_label(
         controller_trace.get(
             "product_mode_declared_done_below_passing_reward_score_status"
@@ -2602,6 +2635,16 @@ def _skillsbench_controller_trace_counters(
     if below_passing_score_status:
         counters["product_mode_declared_done_below_passing_reward_score_status"] = (
             below_passing_score_status
+        )
+    no_open_todo_score_status = _skillsbench_public_safe_label(
+        controller_trace.get(
+            "product_mode_no_open_todo_below_passing_reward_score_status"
+        )
+        or ""
+    )
+    if no_open_todo_score_status:
+        counters["product_mode_no_open_todo_below_passing_reward_score_status"] = (
+            no_open_todo_score_status
         )
     declared_done_policy = _skillsbench_public_safe_label(
         controller_trace.get("product_mode_declared_done_policy") or ""
@@ -3483,6 +3526,19 @@ def build_skillsbench_benchflow_result_benchmark_run(
         ):
             if item not in failure_labels:
                 failure_labels.append(item)
+    product_mode_no_open_todo_below_passing_reward_stop = bool(
+        controller_counters.get(
+            "product_mode_no_open_todo_below_passing_reward_stop"
+        )
+        is True
+    )
+    if product_mode_no_open_todo_below_passing_reward_stop and not official_passed:
+        for item in (
+            "skillsbench_product_mode_no_open_todo_below_passing_reward_stop",
+            "skillsbench_solver_exhausted_no_open_todos",
+        ):
+            if item not in failure_labels:
+                failure_labels.append(item)
     user_loop_final_verify_recovery_triggered = bool(
         controller_counters.get("benchflow_user_loop_final_verify_recovery_triggered")
     )
@@ -3740,7 +3796,30 @@ def build_skillsbench_benchflow_result_benchmark_run(
                 "agent_declared_no_remaining_goals"
             )
             is True,
+            "product_mode_no_open_todo_below_passing_reward_stop": (
+                controller_counters.get(
+                    "product_mode_no_open_todo_below_passing_reward_stop"
+                )
+                is True
+            ),
         }
+        for source_key in (
+            "product_mode_no_open_todo_below_passing_reward_streak",
+            "product_mode_no_open_todo_below_passing_reward_streak_threshold",
+            "product_mode_no_open_todo_below_passing_reward_round",
+            "product_mode_no_open_todo_below_passing_reward_stop_round",
+            "product_mode_no_open_todo_below_passing_reward_open_todo_count_public",
+        ):
+            value = controller_counters.get(source_key)
+            if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+                round_reward_trace[source_key] = value
+        score_status = controller_counters.get(
+            "product_mode_no_open_todo_below_passing_reward_score_status"
+        )
+        if isinstance(score_status, str) and score_status:
+            round_reward_trace[
+                "product_mode_no_open_todo_below_passing_reward_score_status"
+            ] = score_status
         declared_done_round = controller_counters.get("declared_done_round")
         if (
             isinstance(declared_done_round, int)
@@ -3754,6 +3833,16 @@ def build_skillsbench_benchflow_result_benchmark_run(
             and not isinstance(declared_done_score, bool)
         ):
             round_reward_trace["declared_done_score"] = float(declared_done_score)
+        no_open_todo_score = controller_counters.get(
+            "product_mode_no_open_todo_below_passing_reward_score"
+        )
+        if (
+            isinstance(no_open_todo_score, (int, float))
+            and not isinstance(no_open_todo_score, bool)
+        ):
+            round_reward_trace[
+                "product_mode_no_open_todo_below_passing_reward_score"
+            ] = float(no_open_todo_score)
         round_reward_trace.update(round_stats)
 
     post_success_score = {}
@@ -4168,6 +4257,9 @@ def build_skillsbench_benchflow_result_benchmark_run(
             "product_mode_declared_done_below_passing_reward": controller_counters.get(
                 "product_mode_declared_done_below_passing_reward", False
             ),
+            "product_mode_no_open_todo_below_passing_reward_stop": controller_counters.get(
+                "product_mode_no_open_todo_below_passing_reward_stop", False
+            ),
             "product_mode_lifecycle_checkpoint_count": controller_counters.get(
                 "product_mode_lifecycle_checkpoint_count", 0
             ),
@@ -4200,6 +4292,33 @@ def build_skillsbench_benchflow_result_benchmark_run(
             ),
             "product_mode_declared_done_policy": controller_counters.get(
                 "product_mode_declared_done_policy", ""
+            ),
+            "open_todo_count": controller_counters.get("open_todo_count", 0),
+            "product_mode_no_open_todo_below_passing_reward_streak": controller_counters.get(
+                "product_mode_no_open_todo_below_passing_reward_streak", 0
+            ),
+            "product_mode_no_open_todo_below_passing_reward_streak_threshold": controller_counters.get(
+                "product_mode_no_open_todo_below_passing_reward_streak_threshold",
+                0,
+            ),
+            "product_mode_no_open_todo_below_passing_reward_round": controller_counters.get(
+                "product_mode_no_open_todo_below_passing_reward_round", 0
+            ),
+            "product_mode_no_open_todo_below_passing_reward_stop_count": controller_counters.get(
+                "product_mode_no_open_todo_below_passing_reward_stop_count", 0
+            ),
+            "product_mode_no_open_todo_below_passing_reward_stop_round": controller_counters.get(
+                "product_mode_no_open_todo_below_passing_reward_stop_round", 0
+            ),
+            "product_mode_no_open_todo_below_passing_reward_open_todo_count_public": controller_counters.get(
+                "product_mode_no_open_todo_below_passing_reward_open_todo_count_public",
+                0,
+            ),
+            "product_mode_no_open_todo_below_passing_reward_score": controller_counters.get(
+                "product_mode_no_open_todo_below_passing_reward_score"
+            ),
+            "product_mode_no_open_todo_below_passing_reward_score_status": controller_counters.get(
+                "product_mode_no_open_todo_below_passing_reward_score_status", ""
             ),
             "product_mode_final_closeout_superseded_by_official_success": (
                 controller_counters.get(

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -1071,6 +1071,20 @@ def build_skillsbench_post_run_debug_gate(
             "open_todo_count_public": _benchmark_positive_int(
                 counters.get("open_todo_count")
             ),
+            "no_open_todo_below_passing_reward_streak": _benchmark_positive_int(
+                counters.get(
+                    "product_mode_no_open_todo_below_passing_reward_streak"
+                )
+            ),
+            "no_open_todo_below_passing_reward_streak_threshold": _benchmark_positive_int(
+                counters.get(
+                    "product_mode_no_open_todo_below_passing_reward_streak_threshold"
+                )
+            ),
+            "no_open_todo_below_passing_reward_stop": counters.get(
+                "product_mode_no_open_todo_below_passing_reward_stop"
+            )
+            is True,
         },
         "controller": {
             "status": (
@@ -1165,6 +1179,7 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "product_mode_solver_activity_required",
         "product_mode_solver_activity_gap",
         "product_mode_declared_done_below_passing_reward",
+        "product_mode_no_open_todo_below_passing_reward_stop",
         "product_mode_final_closeout_superseded_by_official_success",
         "product_mode_no_tool_call_lifecycle_abort",
         "agent_declared_done",
@@ -1231,6 +1246,13 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "product_mode_solver_activity_gap_round",
         "product_mode_declared_done_below_passing_reward_count",
         "product_mode_declared_done_below_passing_reward_round",
+        "open_todo_count",
+        "product_mode_no_open_todo_below_passing_reward_streak",
+        "product_mode_no_open_todo_below_passing_reward_streak_threshold",
+        "product_mode_no_open_todo_below_passing_reward_round",
+        "product_mode_no_open_todo_below_passing_reward_stop_count",
+        "product_mode_no_open_todo_below_passing_reward_stop_round",
+        "product_mode_no_open_todo_below_passing_reward_open_todo_count_public",
         "product_mode_final_closeout_superseded_round",
         "product_mode_no_tool_call_lifecycle_abort_count",
         "product_mode_no_tool_call_lifecycle_abort_round",
@@ -1317,7 +1339,10 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
     ):
         if isinstance(value.get(field), int) and not isinstance(value.get(field), bool):
             compact[field] = value[field]
-    for field in ("product_mode_declared_done_below_passing_reward_score",):
+    for field in (
+        "product_mode_declared_done_below_passing_reward_score",
+        "product_mode_no_open_todo_below_passing_reward_score",
+    ):
         raw = value.get(field)
         if isinstance(raw, (int, float)) and not isinstance(raw, bool):
             compact[field] = float(raw)
@@ -1332,6 +1357,7 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "product_mode_lifecycle_checkpoint_missing_reason",
         "product_mode_solver_activity_missing_reason",
         "product_mode_declared_done_below_passing_reward_score_status",
+        "product_mode_no_open_todo_below_passing_reward_score_status",
         "product_mode_declared_done_policy",
         "product_mode_final_closeout_superseded_reason",
         "controller_budget_cutoff_reason",
@@ -1637,6 +1663,8 @@ def _compact_benchmark_round_reward_trace(value: Any) -> dict[str, Any]:
         "official_feedback_blinded",
         "reward_feedback_forwarded",
         "agent_declared_done",
+        "agent_declared_no_remaining_goals",
+        "product_mode_no_open_todo_below_passing_reward_stop",
         "official_score_recovered_from_controller_trace",
     ):
         if isinstance(value.get(field), bool):
@@ -1648,14 +1676,28 @@ def _compact_benchmark_round_reward_trace(value: Any) -> dict[str, Any]:
         "final_round",
         "best_reward_round",
         "official_score_recovered_round",
+        "product_mode_no_open_todo_below_passing_reward_streak",
+        "product_mode_no_open_todo_below_passing_reward_streak_threshold",
+        "product_mode_no_open_todo_below_passing_reward_round",
+        "product_mode_no_open_todo_below_passing_reward_stop_round",
+        "product_mode_no_open_todo_below_passing_reward_open_todo_count_public",
     ):
         raw = value.get(field)
         if isinstance(raw, int) and not isinstance(raw, bool) and raw >= 0:
             compact[field] = raw
-    for field in ("final_round_reward", "best_round_reward", "declared_done_score"):
+    for field in (
+        "final_round_reward",
+        "best_round_reward",
+        "declared_done_score",
+        "product_mode_no_open_todo_below_passing_reward_score",
+    ):
         raw = value.get(field)
         if isinstance(raw, (int, float)) and not isinstance(raw, bool):
             compact[field] = float(raw)
+    for field in ("product_mode_no_open_todo_below_passing_reward_score_status",):
+        text = public_safe_compact_text(value.get(field), limit=100)
+        if text:
+            compact[field] = text
     for field in ("final_round_passed", "best_round_passed", "best_round_is_final"):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -305,6 +305,7 @@ PROTECTED_DIRECTIVE_RE = re.compile(
 )
 DECLARED_DONE_MARKER = "AGENT_DECLARED_DONE_NO_REMAINING_GOALS"
 PRODUCT_MODE_FINAL_CLOSEOUT_MAX_CHECKPOINTS = 3
+PRODUCT_MODE_NO_OPEN_TODO_STOP_STREAK_THRESHOLD = 2
 CODEX_ACP_RUNTIME_CONTAINER_BOOTSTRAP_CMD = (
     "set -e; "
     "export DEBIAN_FRONTEND=noninteractive; "
@@ -3539,7 +3540,11 @@ def _build_goal_start_product_mode_control_score(
         counters.get("product_mode_declared_done_below_passing_reward_count")
     )
     premature_done_stop_reason = ""
-    if (
+    if counters.get("product_mode_no_open_todo_below_passing_reward_stop") is True:
+        premature_done_stop_reason = (
+            last_decision or "no_open_todo_below_passing_reward_stop"
+        )
+    elif (
         counters.get("product_mode_declared_done_below_passing_reward") is True
         and last_decision.startswith("stop_after")
         and "below_passing_reward" in last_decision
@@ -3879,6 +3884,11 @@ def _build_case_event_timeline(
     controller_status = "not_observed"
     if counters.get("controller_official_success_observed") is True:
         controller_status = "official_success_observed"
+    elif (
+        counters.get("product_mode_no_open_todo_below_passing_reward_stop")
+        is True
+    ):
+        controller_status = "no_open_todo_below_passing_reward_stop"
     elif counters.get("product_mode_declared_done_below_passing_reward") is True:
         controller_status = "declared_done_below_passing_reward"
     elif counters.get("agent_declared_done") is True:
@@ -5675,6 +5685,13 @@ def _new_controller_trace(route: str, *, max_rounds: int | None = None) -> dict[
         "agent_declared_no_remaining_goals": False,
         "declared_done_round": None,
         "declared_done_score": None,
+        "product_mode_no_open_todo_below_passing_reward_stop": False,
+        "product_mode_no_open_todo_below_passing_reward_streak": 0,
+        "product_mode_no_open_todo_below_passing_reward_streak_threshold": (
+            PRODUCT_MODE_NO_OPEN_TODO_STOP_STREAK_THRESHOLD
+            if loopx_product_mode
+            else 0
+        ),
         "loopx_state_reads": 0,
         "loopx_state_writes": 0,
         "loopx_case_state_reads": 0,
@@ -6739,6 +6756,50 @@ def _record_product_mode_declared_done_below_passing_reward(
     if not isinstance(current, int) or isinstance(current, bool):
         current = 0
     trace["product_mode_declared_done_below_passing_reward_count"] = current + 1
+
+
+def _record_product_mode_no_open_todo_below_passing_reward(
+    trace: dict[str, Any],
+    *,
+    agent_round: int,
+    reward: float | None,
+) -> bool:
+    current = trace.get("product_mode_no_open_todo_below_passing_reward_streak")
+    if not isinstance(current, int) or isinstance(current, bool):
+        current = 0
+    streak = current + 1
+    threshold = PRODUCT_MODE_NO_OPEN_TODO_STOP_STREAK_THRESHOLD
+    trace["open_todo_count"] = 0
+    trace["product_mode_no_open_todo_below_passing_reward_open_todo_count_public"] = 0
+    trace["product_mode_no_open_todo_below_passing_reward_streak"] = streak
+    trace["product_mode_no_open_todo_below_passing_reward_streak_threshold"] = (
+        threshold
+    )
+    trace.setdefault("product_mode_no_open_todo_below_passing_reward_stop", False)
+    trace["product_mode_no_open_todo_below_passing_reward_round"] = agent_round
+    if reward is None:
+        trace["product_mode_no_open_todo_below_passing_reward_score_status"] = (
+            "missing"
+        )
+    else:
+        trace["product_mode_no_open_todo_below_passing_reward_score"] = reward
+        trace["product_mode_no_open_todo_below_passing_reward_score_status"] = (
+            "observed_below_passing"
+        )
+    if streak < threshold:
+        return False
+    trace["product_mode_no_open_todo_below_passing_reward_stop"] = True
+    trace["product_mode_no_open_todo_below_passing_reward_stop_round"] = agent_round
+    trace["product_mode_declared_done_policy"] = (
+        "stop_after_two_no_open_todo_rounds_without_passing_reward"
+    )
+    stop_count = trace.get("product_mode_no_open_todo_below_passing_reward_stop_count")
+    if not isinstance(stop_count, int) or isinstance(stop_count, bool):
+        stop_count = 0
+    trace["product_mode_no_open_todo_below_passing_reward_stop_count"] = (
+        stop_count + 1
+    )
+    return True
 
 
 def _product_mode_depth_gate_satisfied(trace: dict[str, Any]) -> bool:
@@ -7893,6 +7954,25 @@ def _build_product_mode_user(
                             ),
                         )
                         _inc_counter(trace, "controller_action_decisions")
+                        no_open_todo_stop = (
+                            _record_product_mode_no_open_todo_below_passing_reward(
+                                trace,
+                                agent_round=round,
+                                reward=(
+                                    float(reward)
+                                    if isinstance(reward, (int, float))
+                                    and not isinstance(reward, bool)
+                                    else None
+                                ),
+                            )
+                        )
+                        if no_open_todo_stop:
+                            _inc_counter(trace, "stop_decision_count")
+                            trace["last_decision"] = (
+                                "stop_after_product_mode_two_no_open_todo_rounds_"
+                                "without_passing_reward"
+                            )
+                            return None
                         if round >= max_rounds:
                             _inc_counter(trace, "stop_decision_count")
                             trace["last_decision"] = (


### PR DESCRIPTION
## Summary
- stop SkillsBench product-mode runs after two consecutive accepted no-open-todo declared-done observations when the official reward is still below passing or missing
- record the stop as a non-success solver-exhaustion condition with public-safe counters, round_reward_trace fields, post-run debug gate fields, and failure labels
- keep first declared-done/below-pass as a continuation so one self-repair round still happens before early exhaustion stop

## Validation
- python3 examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-goal-start-product-mode-route-smoke.py
- python3 examples/benchmark-run-ledger-smoke.py
- python3 examples/benchmark-case-analysis-smoke.py
- python3 -m py_compile scripts/skillsbench_automation_loop.py loopx/benchmark_adapters/skillsbench.py loopx/status.py examples/skillsbench-benchmark-run-smoke.py examples/skillsbench-goal-start-product-mode-route-smoke.py
- git diff --check
- python3 -m loopx.cli check --scan-path scripts/skillsbench_automation_loop.py --scan-path loopx/benchmark_adapters/skillsbench.py --scan-path loopx/status.py --scan-path examples/skillsbench-benchmark-run-smoke.py

## Boundary
- staged explicit public pathspecs only
- no raw benchmark logs, trajectories, verifier output, credentials, local private state, or new benchmark launches
- LoopX check warning was existing run-history duplicate index rows for loopx-meta; candidate public boundary scan was clean