### PR TITLE
Fix SkillsBench bridge scored output paths

### DIFF
--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -48,6 +48,9 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
 from scripts.skillsbench_reverse_channel_bridge import (  # noqa: E402
     _run_codex_payload,
 )
+from scripts.skillsbench_docker_command_file_bridge import (  # noqa: E402
+    _safe_path as _docker_bridge_safe_path,
+)
 
 SCRIPT = REPO_ROOT / "scripts" / "skillsbench_automation_loop.py"
 RELAY_SCRIPT = REPO_ROOT / "scripts" / "skillsbench_local_acp_relay.py"
@@ -83,6 +86,31 @@ def main() -> int:
     assert "pwd && ls -la" in first_action_block
     assert "/tmp/private-bridge" in first_action_block
     assert "<private bridge command>" not in first_action_block
+    assert '/root/answer.json' in packet, packet
+    assert '/root/task-input-or-data' in packet, packet
+    assert "`/app`, `/tmp`, and `/root`" in packet, packet
+    assert _docker_bridge_safe_path("/app/.codex/goals/state.json") == (
+        "/app/.codex/goals/state.json"
+    )
+    assert _docker_bridge_safe_path("/tmp/loopx/probe.txt") == (
+        "/tmp/loopx/probe.txt"
+    )
+    assert _docker_bridge_safe_path("/root/test.bib") == "/root/test.bib"
+    assert _docker_bridge_safe_path("/root/answer.json") == "/root/answer.json"
+    for blocked_path in ("/home/agent/answer.json", "relative/path", "/"):
+        try:
+            _docker_bridge_safe_path(blocked_path)
+        except ValueError as exc:
+            assert str(exc) in {"path_outside_allowed_roots", "path_invalid"}
+        else:
+            raise AssertionError(f"unexpected allowed path: {blocked_path}")
+    for protected_root in ("/app", "/tmp", "/root"):
+        try:
+            _docker_bridge_safe_path(protected_root, allow_file=False)
+        except ValueError as exc:
+            assert str(exc) == "path_refuses_sandbox_root"
+        else:
+            raise AssertionError(f"unexpected cleanup root: {protected_root}")
     with tempfile.TemporaryDirectory(prefix="skillsbench-agent-probe-count-") as tmp:
         tmp_path = Path(tmp)
         fake_bridge = tmp_path / "fake-bridge"

--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -1564,7 +1564,7 @@ subprocess.run(
                         "LoopX bridge test. Your first tool action should be "
                         "a shell pipeline that sends JSON to the private bridge.\n\n"
                         "Private bridge command:\n"
-                        "/tmp/not-recorded"
+                        "ssh loopx-unavailable.example"
                     ),
                 ],
                 "timeout_sec": 5,

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -1174,7 +1174,11 @@ LoopX SkillsBench remote workspace bridge:
   - {{"operation":"exec","cwd":"/app","command":"pwd","timeout_sec":10}}
   - {{"operation":"read_file","path":"/app/path/to/file","max_bytes":20000}}
   - {{"operation":"write_file","path":"/app/path/to/file","content":"..."}}
+  - {{"operation":"read_file","path":"/root/task-input-or-data","max_bytes":20000}}
+  - {{"operation":"write_file","path":"/root/answer.json","content":"..."}}
   - {{"operation":"cleanup","path":"/app/path/to/temp"}}
+- Allowed sandbox path roots are `/app`, `/tmp`, and `/root`; use `/root`
+  when the task instruction names a scored input or output path there.
 - Do not upload, submit, expose credentials, quote the bridge command in final output, or record raw stdout/stderr/task text in public artifacts.
 - The bridge readiness probe completed with ready=true and operation_count={operation_count}.
 - If a LoopX product-mode lifecycle contract is present later in this prompt,

--- a/scripts/skillsbench_docker_command_file_bridge.py
+++ b/scripts/skillsbench_docker_command_file_bridge.py
@@ -33,6 +33,7 @@ OPERATION_RESPONSE_SCHEMA_VERSION = (
     "skillsbench_remote_command_file_bridge_operation_response_v0"
 )
 MAX_CAPTURE_BYTES = 200_000
+ALLOWED_SANDBOX_PATH_ROOTS = ("/app", "/tmp", "/root")
 
 
 def _json_response(payload: dict[str, Any]) -> int:
@@ -46,11 +47,13 @@ def _safe_path(value: Any, *, allow_file: bool = True) -> str:
         raise ValueError("path_missing")
     if "\x00" in text or not text.startswith("/"):
         raise ValueError("path_invalid")
-    allowed_roots = ("/app", "/tmp")
-    if not any(text == root or text.startswith(root + "/") for root in allowed_roots):
+    if not any(
+        text == root or text.startswith(root + "/")
+        for root in ALLOWED_SANDBOX_PATH_ROOTS
+    ):
         raise ValueError("path_outside_allowed_roots")
-    if not allow_file and text == "/app":
-        raise ValueError("path_refuses_app_root")
+    if not allow_file and text in ALLOWED_SANDBOX_PATH_ROOTS:
+        raise ValueError("path_refuses_sandbox_root")
     return text
 
 


### PR DESCRIPTION
## Summary
- allow the docker-backed SkillsBench command/file bridge to access /root/** in addition to /app/** and /tmp/** so task-required scored artifacts such as /root/answer.json can be written and verified
- keep destructive cleanup from targeting any sandbox root directly
- update the host-local bridge prompt and smoke coverage for /root task input/output paths

## Validation
- python3 -m py_compile scripts/skillsbench_docker_command_file_bridge.py loopx/benchmark_adapters/skillsbench_acp_relay.py examples/skillsbench-host-local-launch-plan-smoke.py
- python3 examples/skillsbench-host-local-launch-plan-smoke.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- git diff --check

## Boundary
- no raw benchmark logs, trajectories, credentials, or local private artifacts committed
- not self-merged because this changes the bridge path allowlist / permission boundary