### PR TITLE
Document canary selection rules

### DIFF
--- a/docs/interaction-pattern-catalog.md
+++ b/docs/interaction-pattern-catalog.md
@@ -105,6 +105,30 @@ add evidence lifecycle checks for benchmark or external-handle changes, and add
 browser or deep integration only when a visual or end-to-end surface is being
 promoted.
 
+Use this selection order for ordinary PR, release, and refactor review:
+
+1. Start from changed files and touched surfaces, not from the PR title.
+2. Map those surfaces to catalog families and choose the cheapest archetype
+   that can catch the likely regression.
+3. Add one current-repo domain profile only when the surface has a known
+   product route, such as PR review, release promotion, monitor scheduling,
+   control-plane refactor, state-write correctness, frontstage rollout, or
+   benchmark adapter readiness.
+4. Keep default profiles on fixture-level or dry-run checks. Pull in deep,
+   browser, external, or writeback checks only when the PR promotes that exact
+   surface or the owner explicitly asks for promotion readiness.
+5. When hot-path and cold-path surfaces both changed, keep the hot-path canary
+   small enough to prove route/spend/notify behavior, then add a cold-path
+   detail check for the expanded inspector or review surface.
+
+Concrete examples:
+
+| Review Situation | Selector Shape | Default Profile Choice | Add Deep Checks Only When |
+| --- | --- | --- | --- |
+| PR review or self-merge workflow | changed files under `loopx/pr_review.py`, `skills/loopx-pr-review/`, GitHub public probe, or PR merge policy docs | PR review / merge domain profile plus Human Decision or Evidence Lifecycle when public-handle evidence changed | the PR changes posting, approval, merge, or external GitHub write behavior |
+| Release or install promotion | release-readiness docs, installer/update/wrapper code, `loopx doctor`, `loopx update`, or canary wrapper behavior | release-promotion domain profile plus Work Routing and State And Boundary checks | promoting a real release snapshot, app wrapper, dashboard, or writeback evidence |
+| Control-plane refactor | `loopx/quota.py`, `loopx/status.py`, scheduler policy, todo projection, or review-packet route changes | control-plane-refactor domain profile plus Work Routing and State And Boundary checks | moving a broad policy seam, changing public JSON fields, or touching monitor/scheduler writeback |
+
 ## Decision Scope Model
 
 User gates are not global booleans. The first-class model is a scoped decision:

--- a/examples/catalog-canary-planner-smoke.py
+++ b/examples/catalog-canary-planner-smoke.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
+CATALOG = REPO_ROOT / "docs" / "interaction-pattern-catalog.md"
 
 from loopx.canary.planner import (  # noqa: E402
     build_catalog_canary_plan,
@@ -37,6 +38,7 @@ def assert_profiles_come_from_catalog_matrix() -> None:
     assert all("command" in check and "reason" in check for check in work_routing["candidate_checks"])
     domain_profile_ids = {profile["id"] for profile in payload["domain_profiles"]}
     assert {
+        "pr-review-and-merge",
         "release-promotion",
         "control-plane-refactor",
         "monitor-scheduler",
@@ -67,6 +69,43 @@ def assert_plan_selects_minimal_profiles_from_changed_surfaces() -> None:
         assert profile["deep_checks_available"] is True, profile
         assert profile["deep_checks_included"] is False, profile
     assert payload["executes_checks"] is False, payload
+
+
+def assert_catalog_documents_selection_rules() -> None:
+    catalog = CATALOG.read_text(encoding="utf-8")
+    for snippet in [
+        "Use this selection order for ordinary PR, release, and refactor review:",
+        "Start from changed files and touched surfaces, not from the PR title.",
+        "PR review or self-merge workflow",
+        "Release or install promotion",
+        "Control-plane refactor",
+        "Keep default profiles on fixture-level or dry-run checks.",
+        "When hot-path and cold-path surfaces both changed",
+    ]:
+        assert snippet in catalog, snippet
+
+
+def assert_pr_release_and_refactor_profiles_select() -> None:
+    pr_payload = build_catalog_canary_plan(
+        changed_files=["loopx/pr_review.py", "skills/loopx-pr-review/SKILL.md"],
+        surfaces=["pr-review public PR metadata"],
+    )
+    pr_profile_ids = {profile["id"] for profile in pr_payload["domain_profiles"]}
+    assert "pr-review-and-merge" in pr_profile_ids, pr_payload
+
+    release_payload = build_catalog_canary_plan(
+        changed_files=["docs/product/release-readiness.md"],
+        surfaces=["release promotion install update"],
+    )
+    release_profile_ids = {profile["id"] for profile in release_payload["domain_profiles"]}
+    assert "release-promotion" in release_profile_ids, release_payload
+
+    refactor_payload = build_catalog_canary_plan(
+        changed_files=["loopx/quota.py", "loopx/status.py"],
+        surfaces=["control-plane refactor scheduler hint"],
+    )
+    refactor_profile_ids = {profile["id"] for profile in refactor_payload["domain_profiles"]}
+    assert "control-plane-refactor" in refactor_profile_ids, refactor_payload
 
 
 def assert_explicit_profile_can_include_deep_checks() -> None:
@@ -116,7 +155,9 @@ def assert_cli_json_plan_is_dry_run() -> None:
 
 def main() -> int:
     assert_profiles_come_from_catalog_matrix()
+    assert_catalog_documents_selection_rules()
     assert_plan_selects_minimal_profiles_from_changed_surfaces()
+    assert_pr_release_and_refactor_profiles_select()
     assert_explicit_profile_can_include_deep_checks()
     assert_cli_json_plan_is_dry_run()
     print("catalog-canary-planner-smoke ok")

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -180,6 +180,30 @@ FAMILY_SELECTOR_HINTS: dict[str, tuple[str, ...]] = {
 
 CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
     {
+        "id": "pr-review-and-merge",
+        "title": "PR review and merge workflow",
+        "purpose": "Check public PR review packets, public-handle evidence, and merge-gate boundaries without approving or merging anything.",
+        "catalog_families": ["Human Decision", "Evidence Lifecycle", "State And Boundary"],
+        "trigger_hints": ("pr-review", "pull request", "github pr", "self-merge", "merge policy", "public pr metadata"),
+        "checks": [
+            {
+                "command": "python3 examples/pr-review-command-smoke.py",
+                "tier": "default",
+                "reason": "checks the public-safe /loopx-pr-review packet and review-card contract",
+            },
+            {
+                "command": "python3 examples/value-connectors-github-public-probe-smoke.py",
+                "tier": "default",
+                "reason": "guards public GitHub issue/PR metadata probes without raw body capture",
+            },
+            {
+                "command": "python3 examples/check-public-boundary-smoke.py",
+                "tier": "deep",
+                "reason": "runs broader public/private boundary checks when review artifacts are promoted",
+            },
+        ],
+    },
+    {
         "id": "release-promotion",
         "title": "Release promotion readiness",
         "purpose": "Check whether the release/canary promotion path is ready without mutating the install.",


### PR DESCRIPTION
## Summary
- document the catalog-based selection order for PR, release, and refactor canaries
- add a read-only PR review / merge domain profile to the canary planner
- extend the planner smoke so PR, release, and refactor selectors stay mapped to expected profiles

## Boundary
- no runtime contract changes
- no metadata schema changes for LoopX runtime state
- no canary execution; planner remains dry-run and explanatory

## Validation
- python3 examples/catalog-canary-planner-smoke.py
- python3 examples/interaction-pattern-catalog-smoke.py
- python3 -m py_compile loopx/canary/planner.py examples/catalog-canary-planner-smoke.py
- python3 examples/pr-review-command-smoke.py
- python3 examples/value-connectors-github-public-probe-smoke.py
- python3 -m loopx.cli --format json canary plan --changed-file loopx/pr_review.py --surface 'pr-review public PR metadata' | python3 -m json.tool >/dev/null
- python3 -m loopx.cli --format json canary profiles | python3 -m json.tool >/dev/null
- git diff --check
- loopx check --scan-path docs/interaction-pattern-catalog.md --scan-path loopx/canary/planner.py --scan-path examples/catalog-canary-planner-smoke.py

LoopX check warning only: existing duplicate run-history index rows for loopx-meta.