### PR TITLE
Document existing-contract canary planning

### DIFF
--- a/docs/interaction-pattern-catalog.md
+++ b/docs/interaction-pattern-catalog.md
@@ -129,6 +129,16 @@ Concrete examples:
 | Release or install promotion | release-readiness docs, installer/update/wrapper code, `loopx doctor`, `loopx update`, or canary wrapper behavior | release-promotion domain profile plus Work Routing and State And Boundary checks | promoting a real release snapshot, app wrapper, dashboard, or writeback evidence |
 | Control-plane refactor | `loopx/quota.py`, `loopx/status.py`, scheduler policy, todo projection, or review-packet route changes | control-plane-refactor domain profile plus Work Routing and State And Boundary checks | moving a broad policy seam, changing public JSON fields, or touching monitor/scheduler writeback |
 
+Existing-contract-first rule: canary planning should consume current public
+runtime/status surfaces before proposing a new runtime contract. Prefer
+`quota should-run`, `status`, `review-packet`, `loopx check`, current smoke
+fixtures, and `loopx canary plan` output as the first evidence layer. A new
+runtime contract is justified only when these surfaces cannot represent a
+repeatable interaction that future controllers must route. In that case, stop
+at a review packet first: name the minimal missing behavior, list the existing
+contract alternatives rejected, state compatibility and migration risk, and
+propose focused smokes for owner review before implementation.
+
 ## Decision Scope Model
 
 User gates are not global booleans. The first-class model is a scoped decision:

--- a/examples/catalog-canary-planner-smoke.py
+++ b/examples/catalog-canary-planner-smoke.py
@@ -81,6 +81,10 @@ def assert_catalog_documents_selection_rules() -> None:
         "Control-plane refactor",
         "Keep default profiles on fixture-level or dry-run checks.",
         "When hot-path and cold-path surfaces both changed",
+        "Existing-contract-first rule: canary planning should consume current public\nruntime/status surfaces",
+        "`quota should-run`, `status`, `review-packet`, `loopx check`",
+        "stop\nat a review packet first",
+        "owner review before implementation",
     ]:
         assert snippet in catalog, snippet
 
@@ -120,6 +124,8 @@ def assert_explicit_profile_can_include_deep_checks() -> None:
     assert profile["id"] == "benchmark-adapter-readiness", profile
     assert profile["deep_checks_included"] is True, profile
     assert any(check["tier"] == "deep" for check in profile["checks"]), profile
+    assert "existing public runtime/status contracts first" in payload["note"], payload
+    assert "owner-review necessity/risk packet" in payload["note"], payload
 
 
 def assert_cli_json_plan_is_dry_run() -> None:

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -611,7 +611,10 @@ def build_catalog_canary_plan(
         "domain_profiles": selected_domain_profiles,
         "note": (
             "This planner only selects and explains candidate canary checks. "
-            "It does not execute smoke tests or create new runtime contracts."
+            "It does not execute smoke tests or create new runtime contracts. "
+            "Plan from existing public runtime/status contracts first; when a "
+            "new runtime contract seems necessary, stop at an owner-review "
+            "necessity/risk packet before implementation."
         ),
     }
 


### PR DESCRIPTION
## Summary
- Document that catalog-derived canary planning should use existing public runtime/status contracts first.
- Update the canary planner note to stop at an owner-review necessity/risk packet before any new runtime contract.
- Extend the catalog canary planner smoke to lock the documented rule and planner note.

## Boundary
- Public docs, read-only planner copy, and focused smoke only.
- No metadata schema change and no runtime contract change.

## Validation
- python3 examples/catalog-canary-planner-smoke.py
- python3 examples/interaction-pattern-catalog-smoke.py
- python3 -m py_compile loopx/canary/planner.py examples/catalog-canary-planner-smoke.py
- python3 -m loopx.cli --format json canary plan --changed-file loopx/quota.py --surface 'control-plane refactor scheduler hint' | python3 -m json.tool >/dev/null
- git diff --check
- loopx check --scan-path docs/interaction-pattern-catalog.md --scan-path loopx/canary/planner.py --scan-path examples/catalog-canary-planner-smoke.py
