### PR TITLE
Fix LoopX worktree route aliasing

### DIFF
--- a/examples/auto-research-visible-launcher-smoke.py
+++ b/examples/auto-research-visible-launcher-smoke.py
@@ -78,6 +78,7 @@ def main() -> int:
         env = os.environ.copy()
         env["PATH"] = f"{fake_bin}{os.pathsep}{env.get('PATH', '')}"
         env["FAKE_TMUX_LOG"] = str(tmux_log)
+        workspace = temp / "visible-workspace"
 
         result = subprocess.run(
             [
@@ -105,6 +106,9 @@ def main() -> int:
                 "--execute",
                 "--launcher",
                 "tmux",
+                "--workspace",
+                str(workspace),
+                "--create-workspace",
             ],
             cwd=REPO_ROOT,
             env=env,
@@ -119,11 +123,16 @@ def main() -> int:
         assert payload["boundary"]["runs_codex"] is True, payload
         assert payload["boundary"]["writes_loopx_state"] is False, payload
         assert payload["boundary"]["spends_loopx_quota"] is False, payload
+        assert payload["boundary"]["workspace_mode"] == "explicit_workspace", payload
+        assert payload["boundary"]["workspace_write_scope"] == "user_selected_workspace_only", payload
+        assert payload["boundary"]["shared_state_route"] == "LOOPX_REGISTRY_and_LOOPX_RUNTIME_ROOT", payload
         launch = payload["launch_result"]
         assert launch["launcher"] == "tmux", launch
         assert launch["started_lane_count"] == 3, launch
         assert launch["attach_command"] == "tmux attach -t loopx-auto-research-smoke", launch
         assert launch["stop_command"] == "tmux kill-session -t loopx-auto-research-smoke", launch
+        assert launch["workspace_mode"] == "explicit_workspace", launch
+        assert workspace.is_dir(), workspace
 
         for lane in payload["lanes"]:
             command = lane["visible_launch_command"]

--- a/examples/bootstrap-command-pack-smoke.py
+++ b/examples/bootstrap-command-pack-smoke.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -11,10 +12,14 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
-def run_json(*args: str) -> dict[str, object]:
+def run_json(*args: str, env: dict[str, str] | None = None) -> dict[str, object]:
+    process_env = os.environ.copy()
+    if env:
+        process_env.update(env)
     result = subprocess.run(
         [sys.executable, "-m", "loopx.cli", "--format", "json", *args],
         cwd=REPO_ROOT,
+        env=process_env,
         text=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
@@ -196,6 +201,136 @@ def test_connected_project_reuses_existing_state() -> None:
         assert "loopx status" in str(payload["commands"])
 
 
+def test_linked_git_worktree_reuses_canonical_source_registry() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        primary = root / "primary"
+        primary.mkdir()
+        subprocess.run(["git", "init"], cwd=primary, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        subprocess.run(
+            ["git", "config", "user.email", "loopx@example.invalid"],
+            cwd=primary,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "LoopX Smoke"],
+            cwd=primary,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        (primary / "README.md").write_text("# primary\n", encoding="utf-8")
+        subprocess.run(["git", "add", "README.md"], cwd=primary, check=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        subprocess.run(
+            ["git", "commit", "-m", "init"],
+            cwd=primary,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        worktree = root / "linked-worktree"
+        subprocess.run(
+            ["git", "worktree", "add", "-b", "linked-smoke", str(worktree)],
+            cwd=primary,
+            check=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        canonical_goal = "canonical-goal"
+        state_file = primary / ".codex" / "goals" / canonical_goal / "ACTIVE_GOAL_STATE.md"
+        state_file.parent.mkdir(parents=True)
+        state_file.write_text("# Active Goal State\n", encoding="utf-8")
+        primary_registry = primary / ".loopx" / "registry.json"
+        primary_registry.parent.mkdir(parents=True)
+        primary_payload = {
+            "schema_version": "0.1",
+            "goals": [
+                {
+                    "id": canonical_goal,
+                    "status": "active",
+                    "repo": str(primary),
+                    "state_file": ".codex/goals/canonical-goal/ACTIVE_GOAL_STATE.md",
+                }
+            ],
+        }
+        primary_registry.write_text(json.dumps(primary_payload, indent=2) + "\n", encoding="utf-8")
+
+        shadow_goal = "linked-worktree-goal"
+        shadow_state = worktree / ".codex" / "goals" / shadow_goal / "ACTIVE_GOAL_STATE.md"
+        shadow_state.parent.mkdir(parents=True)
+        shadow_state.write_text("# Shadow State\n", encoding="utf-8")
+        shadow_registry = worktree / ".loopx" / "registry.json"
+        shadow_registry.parent.mkdir(parents=True)
+        shadow_registry.write_text(
+            json.dumps(
+                {
+                    "schema_version": "0.1",
+                    "goals": [
+                        {
+                            "id": shadow_goal,
+                            "status": "active",
+                            "repo": str(worktree),
+                            "state_file": ".codex/goals/linked-worktree-goal/ACTIVE_GOAL_STATE.md",
+                        }
+                    ],
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        runtime = root / "runtime"
+        global_registry = runtime / "registry.global.json"
+        global_registry.parent.mkdir(parents=True)
+        global_payload = {
+            "schema_version": "0.1",
+            "registry_role": "global-local",
+            "goals": [
+                {
+                    **primary_payload["goals"][0],
+                    "source_registry": str(primary_registry),
+                    "synced_at": "2026-06-28T00:00:00+00:00",
+                },
+                {
+                    "id": shadow_goal,
+                    "status": "active",
+                    "repo": str(worktree),
+                    "state_file": ".codex/goals/linked-worktree-goal/ACTIVE_GOAL_STATE.md",
+                    "source_registry": str(shadow_registry),
+                    "synced_at": "2026-06-28T00:00:00+00:00",
+                },
+            ],
+        }
+        global_registry.write_text(json.dumps(global_payload, indent=2) + "\n", encoding="utf-8")
+
+        payload = run_json(
+            "bootstrap-command-pack",
+            "--project",
+            str(worktree),
+            env={"LOOPX_RUNTIME_ROOT": str(runtime)},
+        )
+
+        connection = payload["project_connection"]
+        assert isinstance(connection, dict)
+        alias = connection["canonical_project_alias"]
+        assert isinstance(alias, dict)
+        assert alias["applied"] is True, alias
+        assert alias["kind"] == "git_worktree_canonical_source_registry", alias
+        assert Path(str(connection["input_project"])).resolve() == worktree.resolve(), connection
+        assert Path(str(payload["project"])).resolve() == primary.resolve(), payload
+        assert payload["goal_id"] == canonical_goal, payload
+        assert Path(str(connection["registry"])).resolve() == primary_registry.resolve(), connection
+        assert Path(str(connection["state_file"])).resolve() == state_file.resolve(), connection
+        assert connection["connection_state"] == "connected", connection
+        assert payload["recommended_next_step"]["requires_user_confirmation"] is False, payload
+        assert shadow_goal not in str(payload["message"])
+
+
 def test_skill_slash_fallback_contract() -> None:
     skill_text = (REPO_ROOT / "skills" / "loopx-project" / "SKILL.md").read_text(
         encoding="utf-8"
@@ -210,6 +345,8 @@ def test_skill_slash_fallback_contract() -> None:
     assert "`/loopx`" in skill_text
     assert "`/loopx <goal text>`" in skill_text
     assert "loopx bootstrap-command-pack --project ." in skill_text
+    assert "canonical_project_alias" in skill_text
+    assert "worktree-local shadow goal" in skill_text
     assert '--goal-text "<GOAL_TEXT>"' in skill_text
     assert "read/status-first" in skill_text
     assert "explicit goal-start intent" in normalized
@@ -239,6 +376,7 @@ def main() -> int:
     test_missing_project_stops_before_mutation()
     test_goal_text_invocation_plans_ranked_todos_before_activation()
     test_connected_project_reuses_existing_state()
+    test_linked_git_worktree_reuses_canonical_source_registry()
     test_skill_slash_fallback_contract()
     print("bootstrap command pack smoke passed")
     return 0

--- a/examples/codex-cli-bootstrap-message-smoke.py
+++ b/examples/codex-cli-bootstrap-message-smoke.py
@@ -33,6 +33,10 @@ MUST_HAVE = (
     "top user todo",
     "top agent todo",
     "next safe action",
+    "shared global registry",
+    "source_registry",
+    "route collision",
+    "goal is absent",
     "loopx bootstrap",
     "heartbeat-prompt --thin",
     "quota should-run",
@@ -55,6 +59,7 @@ def assert_message_contract(payload: dict[str, object]) -> None:
     assert payload["goal_id"] == GOAL_ID, payload
     assert payload["agent_id"] == AGENT_ID, payload
     assert "install-from-github.sh" in str(payload["install_repair_command"]), payload
+    assert payload["existing_goal_probe_command"] == payload["quota_guard_command"], payload
     assert "heartbeat-prompt --thin" in str(payload["heartbeat_prompt_command"]), payload
     assert "heartbeat-prompt --thin" in str(payload["heartbeat_prompt_json_command"]), payload
     assert "--format json heartbeat-prompt" in str(payload["heartbeat_prompt_json_command"]), payload
@@ -76,9 +81,13 @@ def assert_message_contract(payload: dict[str, object]) -> None:
     for phrase in MUST_HAVE:
         assert phrase in normalized, (phrase, message)
     assert normalized.index("install or repair LoopX") < normalized.index("bootstrap/connect this project"), message
+    assert normalized.index("probe whether this goal already exists") < normalized.index("bootstrap/connect this project"), message
+    assert normalized.index("shared global registry for this goal") < normalized.index("loopx bootstrap"), message
     assert normalized.index("bootstrap/connect this project") < normalized.index("heartbeat-prompt --thin"), message
     assert normalized.index("quota should-run") < normalized.index("interaction_contract"), message
     assert normalized.index("refresh-state") < normalized.index("quota spend-slot"), message
+    assert "do not run `loopx bootstrap` for the same `goal_id`" in normalized, message
+    assert "Only run bootstrap when the probe clearly says the goal is absent" in normalized, message
     assert "registry/quota identity alone" in normalized, message
     assert "Headless fallback should never be the only way" not in message, message
     assert "quota spend-slot --goal-id public-codex-cli-goal" in message, message

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from .bootstrap import default_goal_id
+from .project_alias import resolve_canonical_project_alias
 from .project_prompt import (
     DEFAULT_HANDOFF_ADAPTER_KIND,
     DEFAULT_HANDOFF_ADAPTER_STATUS,
@@ -55,17 +56,28 @@ def _select_goal(goals: list[dict[str, Any]], goal_id: str | None) -> tuple[str,
 
 
 def inspect_bootstrap_connection(project: Path, *, goal_id: str | None = None) -> dict[str, Any]:
-    resolved_project = _resolve_project(project)
+    input_project = _resolve_project(project)
+    alias = resolve_canonical_project_alias(input_project, goal_id=goal_id)
+    resolved_project = (
+        _resolve_project(Path(str(alias.get("canonical_project"))))
+        if alias.get("applied") and alias.get("canonical_project")
+        else input_project
+    )
     registry_path = resolved_project / ".loopx" / "registry.json"
     registry_exists = registry_path.exists()
     registry, registry_error = _read_registry(registry_path) if registry_exists else (None, None)
     inferred_goal_id = goal_id or default_goal_id(resolved_project)
     state_file = resolved_project / ".codex" / "goals" / inferred_goal_id / "ACTIVE_GOAL_STATE.md"
+    base_connection = {
+        "input_project": str(input_project),
+        "project": str(resolved_project),
+        "canonical_project_alias": alias,
+        "registry": str(registry_path),
+    }
 
     if registry_error:
         return {
-            "project": str(resolved_project),
-            "registry": str(registry_path),
+            **base_connection,
             "registry_exists": registry_exists,
             "goal_id": inferred_goal_id,
             "goal_found": False,
@@ -78,8 +90,7 @@ def inspect_bootstrap_connection(project: Path, *, goal_id: str | None = None) -
 
     if not registry:
         return {
-            "project": str(resolved_project),
-            "registry": str(registry_path),
+            **base_connection,
             "registry_exists": False,
             "goal_id": inferred_goal_id,
             "goal_found": False,
@@ -103,8 +114,7 @@ def inspect_bootstrap_connection(project: Path, *, goal_id: str | None = None) -
 
     if selected_goal is None:
         return {
-            "project": str(resolved_project),
-            "registry": str(registry_path),
+            **base_connection,
             "registry_exists": True,
             "goal_id": resolved_goal_id,
             "goal_found": False,
@@ -118,8 +128,7 @@ def inspect_bootstrap_connection(project: Path, *, goal_id: str | None = None) -
 
     if not selected_goal.get("state_file"):
         return {
-            "project": str(resolved_project),
-            "registry": str(registry_path),
+            **base_connection,
             "registry_exists": True,
             "goal_id": resolved_goal_id,
             "goal_found": True,
@@ -132,8 +141,7 @@ def inspect_bootstrap_connection(project: Path, *, goal_id: str | None = None) -
 
     if not state_file.exists():
         return {
-            "project": str(resolved_project),
-            "registry": str(registry_path),
+            **base_connection,
             "registry_exists": True,
             "goal_id": resolved_goal_id,
             "goal_found": True,
@@ -145,8 +153,7 @@ def inspect_bootstrap_connection(project: Path, *, goal_id: str | None = None) -
         }
 
     return {
-        "project": str(resolved_project),
-        "registry": str(registry_path),
+        **base_connection,
         "registry_exists": True,
         "goal_id": resolved_goal_id,
         "goal_found": True,
@@ -467,6 +474,14 @@ def render_loopx_bootstrap_command_pack_message(payload: dict[str, Any]) -> str:
     goal_text = payload.get("goal_text")
     state = connection.get("connection_state")
     reason = connection.get("reason")
+    alias = connection.get("canonical_project_alias")
+    alias = alias if isinstance(alias, dict) else {}
+    alias_note = (
+        f"\nInput project: `{connection.get('input_project')}`\n"
+        f"Canonical route: `{alias.get('canonical_project')}` via `{alias.get('source_registry')}`\n"
+        if alias.get("applied")
+        else ""
+    )
     goal_start_contract = payload.get("goal_start_contract")
     goal_start_contract = goal_start_contract if isinstance(goal_start_contract, dict) else {}
     onboarding = payload.get("onboarding_hint")
@@ -532,6 +547,7 @@ Project: `{project}`
 Goal id: `{goal_id}`
 Goal text: `{goal_text or ""}`
 Detected state: `{state}` ({reason})
+{alias_note}
 
 Rules:
 - This command pack preview is read-only. Do not run bootstrap/connect, create heartbeat automation, or spend quota while only previewing it.
@@ -583,12 +599,14 @@ Supported forms: `/loopx`, `/loopx <goal text>`
 ## Detected Project State
 
 - project: `{payload.get("project")}`
+- input_project: `{connection.get("input_project")}`
 - goal_id: `{payload.get("goal_id")}`
 - goal_text: `{payload.get("goal_text") or ""}`
 - connection_state: `{connection.get("connection_state")}`
 - reason: `{connection.get("reason")}`
 - registry: `{connection.get("registry")}`
 - state_file: `{connection.get("state_file")}`
+- canonical_project_alias: `{(connection.get("canonical_project_alias") or {}).get("kind") if isinstance(connection.get("canonical_project_alias"), dict) else None}`
 
 ## Recommended Next Step
 

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -256,6 +256,19 @@ def register_auto_research_commands(
         action="store_true",
         help="With tmux launcher, kill an existing session with the same name before launching.",
     )
+    demo_supervisor_parser.add_argument(
+        "--workspace",
+        help=(
+            "Directory where visible Codex lanes should start. Defaults to the current directory. "
+            "For demos, prefer an empty user-owned research workspace that shares LoopX state through "
+            "--registry/--runtime-root."
+        ),
+    )
+    demo_supervisor_parser.add_argument(
+        "--create-workspace",
+        action="store_true",
+        help="Create --workspace when it does not already exist.",
+    )
 
 
 def _append_auto_research_rollout_events(
@@ -338,6 +351,26 @@ def _runtime_shell_command(
     return "; ".join([*exports, command])
 
 
+def _resolve_demo_workspace(
+    workspace: str | None,
+    *,
+    create: bool,
+    cwd: Path,
+) -> tuple[Path, str]:
+    if not workspace:
+        return cwd.resolve(), "current_directory"
+    path = Path(workspace).expanduser()
+    if not path.is_absolute():
+        path = cwd / path
+    if not path.exists():
+        if not create:
+            raise ValueError("workspace does not exist; pass --create-workspace to create it")
+        path.mkdir(parents=True, exist_ok=True)
+    if not path.is_dir():
+        raise ValueError("workspace must be a directory")
+    return path.resolve(), "explicit_workspace"
+
+
 def _mac_terminal_available() -> bool:
     if platform.system() != "Darwin" or not shutil.which("osascript"):
         return False
@@ -365,6 +398,7 @@ def _launch_auto_research_with_tmux(
     *,
     payload: dict[str, object],
     project: Path,
+    workspace_mode: str,
     registry: Path,
     runtime_root: Path,
     tmux_bin: str,
@@ -452,6 +486,7 @@ def _launch_auto_research_with_tmux(
         "started_lanes": started_lanes,
         "attach_command": f"{tmux_bin} attach -t {session}",
         "stop_command": f"{tmux_bin} kill-session -t {session}",
+        "workspace_mode": workspace_mode,
         "attach_requested": attach,
         "operator_takeover": "attach to the tmux session, interrupt any lane, or kill the session",
     }
@@ -461,6 +496,7 @@ def _launch_auto_research_with_terminal(
     *,
     payload: dict[str, object],
     project: Path,
+    workspace_mode: str,
     registry: Path,
     runtime_root: Path,
 ) -> dict[str, object]:
@@ -516,6 +552,7 @@ def _launch_auto_research_with_terminal(
         "started_lanes": started_lanes,
         "attach_command": "already visible in Terminal windows",
         "stop_command": "interrupt or close the opened Terminal windows",
+        "workspace_mode": workspace_mode,
         "attach_requested": False,
         "operator_takeover": "use the visible Terminal windows; interrupt any lane before writeback",
     }
@@ -532,17 +569,24 @@ def _execute_auto_research_demo_supervisor(
     codex_bin: str,
     attach: bool,
     replace_existing: bool,
+    workspace: str | None,
+    create_workspace: bool,
 ) -> dict[str, object]:
     _require_executable(cli_bin, field="cli_bin")
     _require_executable(codex_bin, field="codex_bin")
     registry = load_registry(registry_path)
     runtime_root = resolve_runtime_root(registry, runtime_root_arg)
     chosen = _resolve_auto_research_launcher(requested=launcher, tmux_bin=tmux_bin)
-    project = Path.cwd()
+    project, workspace_mode = _resolve_demo_workspace(
+        workspace,
+        create=create_workspace,
+        cwd=Path.cwd(),
+    )
     if chosen == "tmux":
         result = _launch_auto_research_with_tmux(
             payload=payload,
             project=project,
+            workspace_mode=workspace_mode,
             registry=registry_path,
             runtime_root=runtime_root,
             tmux_bin=tmux_bin,
@@ -553,6 +597,7 @@ def _execute_auto_research_demo_supervisor(
         result = _launch_auto_research_with_terminal(
             payload=payload,
             project=project,
+            workspace_mode=workspace_mode,
             registry=registry_path,
             runtime_root=runtime_root,
         )
@@ -569,6 +614,9 @@ def _execute_auto_research_demo_supervisor(
                 "writes_loopx_state": False,
                 "spends_loopx_quota": False,
                 "external_service_call": False,
+                "workspace_mode": workspace_mode,
+                "workspace_write_scope": "user_selected_workspace_only",
+                "shared_state_route": "LOOPX_REGISTRY_and_LOOPX_RUNTIME_ROOT",
             }
         )
     return payload
@@ -680,6 +728,8 @@ def handle_auto_research_command(
                     codex_bin=args.codex_bin,
                     attach=args.attach,
                     replace_existing=args.replace_existing,
+                    workspace=args.workspace,
+                    create_workspace=args.create_workspace,
                 )
         else:
             raise ValueError(

--- a/loopx/project_alias.py
+++ b/loopx/project_alias.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Any
+
+from .paths import DEFAULT_RUNTIME_ROOT, global_registry_path
+from .registry import registry_goals
+
+
+def _resolve_path(path: Path) -> Path:
+    try:
+        return path.expanduser().resolve()
+    except OSError:
+        return path.expanduser().absolute()
+
+
+def _run_git(project: Path, *args: str) -> subprocess.CompletedProcess[str] | None:
+    try:
+        return subprocess.run(
+            ["git", "-C", str(project), *args],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=False,
+            timeout=2,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+
+
+def _git_root(project: Path) -> Path | None:
+    result = _run_git(project, "rev-parse", "--show-toplevel")
+    if result is None or result.returncode != 0:
+        return None
+    value = result.stdout.strip()
+    return _resolve_path(Path(value)) if value else None
+
+
+def _git_common_dir(project: Path) -> Path | None:
+    root = _git_root(project)
+    if root is None:
+        return None
+    result = _run_git(root, "rev-parse", "--git-common-dir")
+    if result is None or result.returncode != 0:
+        return None
+    value = result.stdout.strip()
+    if not value:
+        return None
+    common = Path(value).expanduser()
+    if not common.is_absolute():
+        common = root / common
+    return _resolve_path(common)
+
+
+def _primary_repo_from_common_dir(common_dir: Path | None) -> Path | None:
+    if common_dir is None:
+        return None
+    if common_dir.name == ".git":
+        return _resolve_path(common_dir.parent)
+    return None
+
+
+def _default_global_registry_path() -> Path:
+    runtime_env = os.environ.get("LOOPX_RUNTIME_ROOT")
+    runtime_root = Path(runtime_env).expanduser() if runtime_env else DEFAULT_RUNTIME_ROOT
+    return global_registry_path(runtime_root)
+
+
+def _read_global_registry(path: Path) -> dict[str, Any] | None:
+    try:
+        with path.expanduser().open(encoding="utf-8") as f:
+            payload = json.load(f)
+    except (FileNotFoundError, OSError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _source_repo_for_goal(goal: dict[str, Any]) -> Path | None:
+    repo = goal.get("repo")
+    if repo:
+        return _resolve_path(Path(str(repo)))
+    source_registry = goal.get("source_registry")
+    if not source_registry:
+        return None
+    path = _resolve_path(Path(str(source_registry)))
+    try:
+        return path.parents[1]
+    except IndexError:
+        return None
+
+
+def _same_path(left: Path | None, right: Path | None) -> bool:
+    if left is None or right is None:
+        return False
+    return _resolve_path(left) == _resolve_path(right)
+
+
+def resolve_canonical_project_alias(
+    project: Path,
+    *,
+    goal_id: str | None = None,
+    global_registry: Path | None = None,
+) -> dict[str, Any]:
+    """Map linked git worktrees back to the canonical LoopX source project."""
+
+    resolved_project = _resolve_path(project)
+    target_common_dir = _git_common_dir(resolved_project)
+    global_path = _resolve_path(global_registry or _default_global_registry_path())
+    payload = _read_global_registry(global_path)
+    if not payload or target_common_dir is None:
+        return {
+            "applied": False,
+            "kind": "none",
+            "input_project": str(resolved_project),
+            "global_registry": str(global_path),
+            "git_common_dir": str(target_common_dir) if target_common_dir else None,
+            "reason": "global registry or git common-dir unavailable",
+        }
+
+    primary_repo = _primary_repo_from_common_dir(target_common_dir)
+    current_registry = _resolve_path(resolved_project / ".loopx" / "registry.json")
+    candidates: list[dict[str, Any]] = []
+    for goal in registry_goals(payload):
+        candidate_goal_id = str(goal.get("id") or "")
+        if goal_id and candidate_goal_id != goal_id:
+            continue
+        source_repo = _source_repo_for_goal(goal)
+        if source_repo is None:
+            continue
+        source_common_dir = _git_common_dir(source_repo)
+        if not _same_path(source_common_dir, target_common_dir):
+            continue
+        source_registry_value = goal.get("source_registry")
+        source_registry = _resolve_path(Path(str(source_registry_value))) if source_registry_value else None
+        candidates.append(
+            {
+                "goal_id": candidate_goal_id,
+                "source_repo": str(source_repo),
+                "source_registry": str(source_registry) if source_registry else None,
+                "source_is_primary_repo": _same_path(source_repo, primary_repo),
+                "source_is_current_project": _same_path(source_repo, resolved_project),
+                "source_registry_is_current_project": _same_path(source_registry, current_registry),
+            }
+        )
+
+    if not candidates:
+        return {
+            "applied": False,
+            "kind": "none",
+            "input_project": str(resolved_project),
+            "global_registry": str(global_path),
+            "git_common_dir": str(target_common_dir),
+            "primary_repo": str(primary_repo) if primary_repo else None,
+            "reason": "no global source_registry shares this git common-dir",
+        }
+
+    if any(item["source_registry_is_current_project"] for item in candidates):
+        current_ids = [
+            str(item["goal_id"])
+            for item in candidates
+            if item["source_registry_is_current_project"] and item.get("goal_id")
+        ]
+        non_current_primary = [
+            item
+            for item in candidates
+            if item["source_is_primary_repo"] and not item["source_registry_is_current_project"]
+        ]
+        if not non_current_primary:
+            return {
+                "applied": False,
+                "kind": "current_project_is_registered_source",
+                "input_project": str(resolved_project),
+                "global_registry": str(global_path),
+                "git_common_dir": str(target_common_dir),
+                "primary_repo": str(primary_repo) if primary_repo else None,
+                "registered_goal_ids": current_ids,
+                "reason": "current project already owns a registered source_registry route",
+            }
+
+    def rank(item: dict[str, Any]) -> tuple[int, int, int, str]:
+        return (
+            0 if item["source_is_primary_repo"] else 1,
+            0 if not item["source_is_current_project"] else 1,
+            0 if item.get("source_registry") else 1,
+            str(item.get("source_registry") or item.get("source_repo") or ""),
+        )
+
+    selected = sorted(candidates, key=rank)[0]
+    selected_repo = Path(str(selected["source_repo"]))
+    if _same_path(selected_repo, resolved_project):
+        return {
+            "applied": False,
+            "kind": "selected_current_project",
+            "input_project": str(resolved_project),
+            "global_registry": str(global_path),
+            "git_common_dir": str(target_common_dir),
+            "primary_repo": str(primary_repo) if primary_repo else None,
+            "candidate_goal_ids": sorted({str(item["goal_id"]) for item in candidates if item.get("goal_id")}),
+            "reason": "best global route is the current project",
+        }
+
+    return {
+        "applied": True,
+        "kind": "git_worktree_canonical_source_registry",
+        "input_project": str(resolved_project),
+        "canonical_project": str(selected_repo),
+        "global_registry": str(global_path),
+        "git_common_dir": str(target_common_dir),
+        "primary_repo": str(primary_repo) if primary_repo else None,
+        "source_registry": selected.get("source_registry"),
+        "candidate_goal_ids": sorted({str(item["goal_id"]) for item in candidates if item.get("goal_id")}),
+        "selected_goal_id": selected.get("goal_id"),
+        "reason": "project is a git worktree; reusing canonical source_registry route",
+    }

--- a/loopx/project_prompt.py
+++ b/loopx/project_prompt.py
@@ -343,6 +343,7 @@ def build_codex_cli_bootstrap_message(
         goal_id=resolved_goal_id,
         agent_id=agent_id,
         cli_preflight=install_repair_command,
+        existing_goal_probe_command=quota_guard_command,
         connect_command=connect_command,
         heartbeat_prompt_json_command=heartbeat_prompt_json_command,
         heartbeat_prompt_command=heartbeat_prompt_command,
@@ -360,6 +361,7 @@ def build_codex_cli_bootstrap_message(
         "agent_id": agent_id,
         "cli_bin": cli_bin,
         "install_repair_command": install_repair_command,
+        "existing_goal_probe_command": quota_guard_command,
         "connect_command": connect_command,
         "heartbeat_prompt_command": heartbeat_prompt_command,
         "heartbeat_prompt_json_command": heartbeat_prompt_json_command,
@@ -497,6 +499,7 @@ def render_codex_cli_bootstrap_message_text(
     goal_id: str,
     agent_id: str | None,
     cli_preflight: str,
+    existing_goal_probe_command: str,
     connect_command: str,
     heartbeat_prompt_json_command: str,
     heartbeat_prompt_command: str,
@@ -517,14 +520,15 @@ headless `codex exec` for this bootstrap path.
 
 This first message is the setup/bootstrap instruction, not the reusable
 heartbeat prompt. Complete the setup in order: install or repair LoopX
-if needed; bootstrap/connect this project; then configure the current loop
-surface from the generated thin heartbeat prompt. For Codex CLI, set the
-current TUI goal to `/goal ` plus the thin `task_body`. For Codex App, set or
-refresh the heartbeat automation to start at 3 minutes with that same thin
-`task_body`, then follow quota `scheduler_hint` for backoff. If the current
-surface cannot be mutated from this session, show the exact pasteable `/goal`
-or automation body and report that as a concrete user gate; do not claim setup
-success.
+if needed; probe whether this goal already exists in the shared global
+registry; only bootstrap/connect this project when the goal is absent; then
+configure the current loop surface from the generated thin heartbeat prompt.
+For Codex CLI, set the current TUI goal to `/goal ` plus the thin `task_body`.
+For Codex App, set or refresh the heartbeat automation to start at 3 minutes
+with that same thin `task_body`, then follow quota `scheduler_hint` for
+backoff. If the current surface cannot be mutated from this session, show the
+exact pasteable `/goal` or automation body and report that as a concrete user
+gate; do not claim setup success.
 
 Project: `{project}`
 Goal id: `{goal_id}`
@@ -533,8 +537,9 @@ Goal id: `{goal_id}`
 Success criteria for this first setup turn:
 - I should not need to inspect registry paths, runtime roots, JSON payloads, or
   hidden session files.
-- If LoopX is already installed and this repo is already connected,
-  reuse the existing install/state and do not reinstall or duplicate bootstrap.
+- If LoopX is already installed and this goal is already present in the shared
+  global registry, reuse the existing `source_registry` route and do not
+  duplicate bootstrap from this worktree.
 - Configure the loop target after bootstrap: Codex CLI `/goal <thin task_body>`
   or Codex App heartbeat automation starting at 3 minutes with
   `<thin task_body>`, then follow quota `scheduler_hint`.
@@ -555,7 +560,21 @@ run:
 {cli_preflight}
 ```
 
-2. If this repo is not connected to LoopX yet, connect it conservatively:
+2. Before bootstrap/connect, probe the shared global registry for this goal:
+
+```bash
+{existing_goal_probe_command}
+```
+
+If this command returns a known goal, even with a normal delivery gate or
+workspace guard, treat the goal as already connected and reuse the existing
+global route/source_registry. In an independent side-agent worktree, do not
+run `loopx bootstrap` for the same `goal_id`; that can create a route collision
+between the primary checkout and the worktree. Only run bootstrap when the
+probe clearly says the goal is absent from the registered quota plan.
+
+3. If the goal is absent and this repo is not connected to LoopX yet, connect
+it conservatively:
 
 ```bash
 {connect_command}
@@ -564,7 +583,7 @@ run:
 If the connect output includes onboarding candidate todos, summarize them in
 this TUI and ask me which ones to accept before starting autonomous delivery.
 
-3. Generate the thin loop prompt after bootstrap/connect, not before. Do not
+4. Generate the thin loop prompt after route reuse or bootstrap/connect, not before. Do not
 hand-write or copy an old heartbeat body:
 
 ```bash
@@ -584,7 +603,7 @@ For review, the Markdown form is:
 {heartbeat_prompt_command}
 ```
 
-4. After install/connect and loop activation, run the quota/status guard for
+5. After install/connect and loop activation, run the quota/status guard for
 the first control-plane snapshot:
 
 ```bash
@@ -599,16 +618,16 @@ Follow `interaction_contract` exactly:
 - If delivery is allowed, choose one runnable agent todo after a short steering
   audit, preferably a current-agent claimed advancement todo.
 
-5. Report the current goal/gate/todo/next-action snapshot in this TUI. Stop
+6. Report the current goal/gate/todo/next-action snapshot in this TUI. Stop
 after setup unless I explicitly asked for delivery in this same turn. Do not
 store raw Codex transcripts, credentials, private paths, raw logs, or
 production artifacts in public docs or LoopX state.
 
-6. Before writeback, use this transcript-free validation checklist:
+7. Before writeback, use this transcript-free validation checklist:
 
 {checklist}
 
-7. After setup writeback, refresh state if needed. Do not spend quota for a
+8. After setup writeback, refresh state if needed. Do not spend quota for a
 setup-only turn. The configured thin loop spends only after a later validated
 delivery writeback. If I explicitly asked you to do delivery in this same turn
 and you completed a validated delivery segment, spend exactly once:

--- a/skills/loopx-project/SKILL.md
+++ b/skills/loopx-project/SKILL.md
@@ -45,6 +45,12 @@ writing project state:
 loopx bootstrap-command-pack --project .
 ```
 
+When the target is a linked git worktree, trust the command pack's
+`canonical_project_alias` / `source_registry` route. Do not manually run
+`loopx bootstrap` in the linked worktree merely because its local `.loopx`
+state is missing or stale; that can create a worktree-local shadow goal instead
+of updating the canonical project state.
+
 For `/loopx <goal text>`, pass the text after `/loopx` as the explicit
 goal-start objective:
 


### PR DESCRIPTION
## Motivation

Running `/loopx` or the command pack from a temporary linked git worktree could create or select a worktree-local shadow goal, even though the real project state already lived in the canonical source checkout. The root cause is that git worktrees share repository identity through the git common-dir, but LoopX project-local state is stored under each checkout's `.loopx` / `.codex`, and `bootstrap-command-pack` only inspected the current cwd.

## Changes

- Add a generic `project_alias` resolver that maps linked git worktrees back to the canonical project using git common-dir, primary worktree, and global-registry `source_registry` routes.
- Make `/loopx bootstrap-command-pack` expose `input_project` and `canonical_project_alias`, then inspect the canonical `.loopx/registry.json` instead of the linked worktree shadow state.
- Harden Codex CLI bootstrap instructions so lanes probe the shared global registry before bootstrap and avoid duplicate `loopx bootstrap` route collisions.
- Add `auto-research demo-supervisor --workspace/--create-workspace` so visible demos can start in an empty user-owned research folder while sharing LoopX state through registry/runtime env.
- Update the LoopX project skill and smokes for the linked-worktree shadow-goal regression.

## Validation

- `python3 examples/bootstrap-command-pack-smoke.py`
- `python3 examples/codex-cli-bootstrap-message-smoke.py`
- `python3 examples/auto-research-visible-launcher-smoke.py`
- `python3 -m loopx.cli check`
- Manual probe from `/private/tmp/loopx-auto-research-e2e-probe-20260628-2225` returned `project=/Users/bytedance/goal-harness`, `goal_id=loopx-auto-research-knn`, and `alias_kind=git_worktree_canonical_source_registry`.
