### PR TITLE
Relax refresh-state recommended action safety

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -470,9 +470,11 @@ The command accepts goals whose adapter kind is `read_only_project_map_v0` or a
 compatible `*_read_only_map_v0` variant, and whose adapter status is connected
 for read-only work. It inspects only registry metadata, the active state
 sections, and a bounded file-existence inventory. The compact run index records
-`classification=read_only_project_map`, public-safe `recommended_action`,
-artifact availability, map counts, and compact `residual_risks`; raw project
-evidence stays in the local private runtime payload.
+`classification=read_only_project_map`, local-control-plane
+`recommended_action`, artifact availability, map counts, and compact
+`residual_risks`; raw project evidence stays in the local private runtime
+payload, while public/export sinks redact local-private references before
+rendering shareable views.
 
 For planned high-complexity adapters, `read-only-map --dry-run` is allowed as
 the opt-in preview path. It returns `opt_in_required=true` and appends nothing,

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -976,10 +976,15 @@ run came from `loopx refresh-state`. Dashboard consumers should show it
 as Codex-ready work: the controller state changed, and the next agent turn
 should inspect the refreshed active state before continuing.
 If the refresh command was run without `--recommended-action`, the compact
-`recommended_action` should be the first public-safe item from the refreshed
-active state's `## Next Action`, including wrapped continuation lines; only when
-that durable section is absent should it fall back to the first open Agent Todo,
-and finally to a generic refresh notice. The record includes
+`recommended_action` should be the first local control-plane item from the
+refreshed active state's `## Next Action`, including wrapped continuation
+lines; only when that durable section is absent should it fall back to the first
+open Agent Todo, and finally to a generic refresh notice. This field may carry
+stable local routing references such as todo ids, branch names, agent ids, PR
+refs, or private-material pointers because it serves the individual operator's
+local loop. It must not carry credentials, auth headers, or inline secrets.
+Public/export sinks are responsible for redacting or omitting local/private
+references before rendering shareable surfaces. The record includes
 `recommended_action_source` (`explicit_arg`, `active_state_next_action`,
 `agent_todo_fallback`, or `default_refresh_action`) so consumers can distinguish
 run guidance from durable-state projection and last-resort compatibility
@@ -988,7 +993,7 @@ fallback.
 the active state's durable `## Next Action`. To intentionally change that
 durable route in a multi-agent goal, the primary agent must run
 `refresh-state --agent-id <primary-agent> --progress-scope goal --next-action
-<public-safe action>`. Status projections may expose both
+<local control-plane action>`. Status projections may expose both
 `active_state_next_action` and
 `latest_run_recommended_action`; when they differ, `next_action_projection_warning`
 marks the drift instead of silently choosing one as the only truth.

--- a/examples/refresh-state-agent-lane-scope-smoke.py
+++ b/examples/refresh-state-agent-lane-scope-smoke.py
@@ -22,6 +22,9 @@ SIDE_ACTION = "Polish the hosted frontstage showcase for external developers."
 SIDE_HANDOFF_ACTION = (
     "Primary should inspect todo_primary while side lane switches to the next product todo."
 )
+LOCAL_CONTROL_ACTION = (
+    "Review standing authorization for todo_local_control before changing the runtime lane."
+)
 AUTO_RESEARCH_ACTION = (
     "[P0-auto-research] Use rollout-backed research_evidence_graph_v0 to generate "
     "live promotion and retirement candidates."
@@ -264,6 +267,49 @@ def main() -> None:
             assert lane["agent_lane"] == "codex-side-bypass", lane
             assert lane["recommended_action"] == SIDE_HANDOFF_ACTION, lane
             assert item["project_asset"]["agent_lane_recommendation"] == lane, item
+
+            state_refresh.now_local = lambda: "2026-06-20T00:03:30+00:00"
+            local_control_payload = state_refresh.refresh_state_run(
+                registry_path=registry_path,
+                runtime_root_override=str(runtime),
+                goal_id=GOAL_ID,
+                project=project,
+                state_file=None,
+                classification="side_lane_local_control_reference",
+                recommended_action=LOCAL_CONTROL_ACTION,
+                delivery_batch_scale="single_surface",
+                delivery_outcome="outcome_progress",
+                agent_id="codex-side-bypass",
+                dry_run=False,
+                sync_global=False,
+            )
+            assert (
+                local_control_payload["recommended_action"] == LOCAL_CONTROL_ACTION
+            ), local_control_payload
+
+            expect_value_error(
+                "recommended_action contains a secret-looking value",
+                lambda: state_refresh.refresh_state_run(
+                    registry_path=registry_path,
+                    runtime_root_override=str(runtime),
+                    goal_id=GOAL_ID,
+                    project=project,
+                    state_file=None,
+                    classification="side_lane_auth_header_blocked",
+                    recommended_action=(
+                        "Do not store "
+                        + "Author"
+                        + "ization: "
+                        + "Bear"
+                        + "er fake-token in control-plane action text."
+                    ),
+                    delivery_batch_scale="single_surface",
+                    delivery_outcome="outcome_progress",
+                    agent_id="codex-side-bypass",
+                    dry_run=True,
+                    sync_global=False,
+                ),
+            )
 
             expect_value_error(
                 "agent-lane refresh-state cannot update the durable active-state Next Action",

--- a/loopx/feedback.py
+++ b/loopx/feedback.py
@@ -31,6 +31,11 @@ PRIVATE_TEXT_PATTERNS = (
     re.compile(r"\b" + "pass" + r"word\b", re.I),
     re.compile(r"\b" + "sec" + r"ret\b", re.I),
 )
+LOCAL_CONTROL_TEXT_PATTERNS = (
+    re.compile(r"\b" + "Bear" + r"er\s+[A-Za-z0-9._~+/=-]+\b", re.I),
+    re.compile(r"\b" + "Author" + r"ization\s*:", re.I),
+    re.compile(r"\b(?:tok" + r"en|pass" + r"word|sec" + r"ret)\s*[:=]", re.I),
+)
 HUMAN_REWARD_FIELDS = (
     "recorded_at",
     "decision",
@@ -68,6 +73,23 @@ def validate_public_safe_text(label: str, value: str | None) -> None:
     for pattern in PRIVATE_TEXT_PATTERNS:
         if pattern.search(value):
             raise ValueError(f"{label} contains a private-looking value; keep raw evidence in private payloads")
+
+
+def validate_local_control_text(label: str, value: str | None) -> None:
+    """Validate text for local control-plane state, not public export.
+
+    Local routing fields such as recommended_action are allowed to mention
+    private/local material, stable control-plane refs, and ordinary governance
+    words. They still must not carry credentials or auth headers.
+    """
+
+    if not value:
+        return
+    for pattern in LOCAL_CONTROL_TEXT_PATTERNS:
+        if pattern.search(value):
+            raise ValueError(
+                f"{label} contains a secret-looking value; keep credentials out of control-plane text"
+            )
 
 
 def compact_reward(

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -9,7 +9,7 @@ from typing import Any
 
 from .delivery_batch_scale import DELIVERY_BATCH_SCALE_CHOICES, require_delivery_batch_scale
 from .delivery_outcome import DELIVERY_OUTCOME_CHOICES, require_delivery_outcome
-from .feedback import validate_public_safe_text
+from .feedback import validate_local_control_text, validate_public_safe_text
 from .file_lock import exclusive_file_lock
 from .global_registry import sync_project_registry_to_global
 from .history import load_registry, reserve_unique_run_paths, unique_run_paths
@@ -344,7 +344,7 @@ def first_open_agent_todo_action(state_text: str) -> str | None:
         if not action:
             continue
         try:
-            validate_public_safe_text("derived agent_todo recommended_action", action)
+            validate_local_control_text("derived agent_todo recommended_action", action)
         except ValueError:
             continue
         metadata = todo_metadata(lines, index)
@@ -392,7 +392,7 @@ def derive_recommended_action_with_source(state_text: str) -> tuple[str, str]:
         if not action:
             continue
         try:
-            validate_public_safe_text("derived recommended_action", action)
+            validate_local_control_text("derived recommended_action", action)
         except ValueError:
             continue
         return action, RECOMMENDED_ACTION_SOURCE_ACTIVE_NEXT_ACTION
@@ -742,7 +742,7 @@ def refresh_state_run(
         recommended_action_source = RECOMMENDED_ACTION_SOURCE_EXPLICIT
     else:
         action, recommended_action_source = derive_recommended_action_with_source(state_text)
-    validate_public_safe_text("recommended_action", action)
+    validate_local_control_text("recommended_action", action)
     repair_delta_contract: dict[str, Any] | None = None
     requested_classification = classification
     effective_autonomous_replan_recorded = bool(autonomous_replan_recorded)

--- a/skills/loopx-project/SKILL.md
+++ b/skills/loopx-project/SKILL.md
@@ -646,9 +646,11 @@ the control-plane signal consumed by quota, status, and review packets.
 This fixes stale dashboards where the latest run still shows an old
 `ready_for_controller_opt_in` or similar state. It also auto-syncs the project
 entry into the global registry. If you do not pass `--recommended-action`, the
-refresh run should publish the first public-safe item from `## Next Action` as
-the compact dashboard action, including wrapped continuation lines; keep raw
-evidence and private links in the state file, not in that action item.
+refresh run should publish the first local-control-plane item from
+`## Next Action` as the compact dashboard action, including wrapped continuation
+lines. `recommended_action` may include private/local routing references needed
+by the individual operator, but must not include credentials, auth headers, or
+inline secrets; shareable/public projections are responsible for redaction.
 
 For complex projects, do not pack a whole user reading queue into
 `## Next Action`. Keep the first Next Action item as one routing sentence, then


### PR DESCRIPTION
## Summary
- Treat refresh-state `recommended_action` as local control-plane text instead of public-safe export text.
- Allow stable routing/private refs such as todo ids, PR refs, agent ids, and private-material pointers in local action guidance.
- Keep credential/auth-header scanning for local action text, and document that public/export sinks own redaction.

## Boundary
- Runtime change is limited to refresh-state recommended-action validation and derived action filtering.
- Reward/operator-gate/public-safe fields remain on the stricter public-safe validator.
- No new runtime contract, metadata schema, or public projection field is added.

## Validation
- `python3 examples/refresh-state-agent-lane-scope-smoke.py`
- `python3 examples/refresh-state-write-correctness-smoke.py`
- `python3 -m py_compile loopx/feedback.py loopx/state_refresh.py examples/refresh-state-agent-lane-scope-smoke.py`
- `python3 examples/status-markdown-smoke.py`
- `python3 -m loopx.cli refresh-state ... --recommended-action "Owner review required: todo_95af363b560f standing authorization ... inspect private material if needed." --dry-run`
- `loopx check --scan-path ...`
- `git diff --check`
