### PR TITLE
docs: define auto-research role profiles

### DIFF
--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -20,6 +20,7 @@ Current contracts:
 - [decentralized_auto_research_state_v0](decentralized-auto-research-state-v0.md)
 - [auto_research_lane_contract_v1](auto-research-lane-contract-v1.md)
 - [auto_research_role_state_machine_v0](auto-research-role-state-machine-v0.md)
+- [auto_research_role_profile_v0](auto-research-role-profile-v0.md)
 - [global_manager_command_v0](global-manager-command-v0.md)
 - [pr_review_command_v0](pr-review-command-v0.md)
 - [event_sourced_state_contract_v0](event-sourced-state-contract-v0.md)

--- a/docs/reference/protocols/auto-research-role-profile-v0.md
+++ b/docs/reference/protocols/auto-research-role-profile-v0.md
@@ -1,0 +1,177 @@
+# auto_research_role_profile_v0
+
+`auto_research_role_profile_v0` defines how a LoopX auto-research worker knows
+who it is before it loads any role-specific playbook. It bridges three existing
+surfaces:
+
+- the shared LoopX control plane, which grants identity and authority;
+- role-aware skills, which define how to act inside a phase;
+- repository or workspace `AGENTS.md`, which defines long-lived local rules.
+
+The contract exists because Arbor and LoopX use skills differently. Arbor can
+keep identity mostly inside a Coordinator / Executor topology, then load skills
+as phase playbooks. LoopX is decentralized: several workers may run in separate
+Codex sessions over one state graph, so identity must be explicit control-plane
+state rather than something inferred from a skill name or pane title.
+
+## Ownership Split
+
+| Surface | Owns | Does not own |
+| --- | --- | --- |
+| LoopX control plane | `agent_id`, `role_id`, claim, capability token, phase, write boundary, gate state, and stop condition. | The detailed reasoning checklist for an implementation phase. |
+| Role-aware skill | Commands, checklists, artifact schema reminders, review prompts, and phase-specific failure modes. | Authority to write, promote, merge, publish, or bypass gates. |
+| `AGENTS.md` | Repository-local and workspace-local rules such as private boundary, PR hygiene, first-screen review, protected paths, and local launch policy. | Dynamic role assignment or current frontier selection. |
+| Host launcher | Visible panes, environment variables, attach/stop controls, and takeover affordances. | Research truth, promotion decisions, or hidden scheduling authority. |
+
+This split keeps skills useful without letting them become a second source of
+identity. A worker can load the same `loopx-auto-research` skill in different
+roles, but the profile tells it which section applies and which writes are
+allowed.
+
+## Profile Shape
+
+The profile is public-safe and small enough to embed in a launcher packet,
+frontier item, bootstrap prompt, or future kernel API.
+
+```json
+{
+  "schema_version": "auto_research_role_profile_v0",
+  "goal_id": "loopx-auto-research-knn",
+  "agent_id": "codex-auto-research-runner-1",
+  "role_id": "evidence_runner",
+  "display_name": "Evidence runner",
+  "phase": "attempt_running",
+  "capability_token": "evidence_runner",
+  "todo_id": "todo_knn_attempt_001",
+  "hypothesis_id": "hyp_knn_vectorized_distance",
+  "allowed_actions": ["claim_attempt", "edit_allowed_scope", "run_dev_eval", "write_evidence"],
+  "write_scope": ["solution.py", "experiments/**"],
+  "protected_scope": ["task.py", "eval.py", "data/**"],
+  "required_skill": "loopx-auto-research",
+  "skill_section": "Evidence runner",
+  "agents_overlay": ["workspace/AGENTS.md"],
+  "stop_conditions": [
+    "quota should-run returns false",
+    "frontier is empty or claimed by another agent",
+    "protected scope would be edited",
+    "private material or credentials are required",
+    "operator gate is projected"
+  ],
+  "handoff_outputs": [
+    "research_evidence_event_v0",
+    "branch_or_artifact_ref",
+    "retry_or_retirement_rationale"
+  ]
+}
+```
+
+Required fields:
+
+- `goal_id`, `agent_id`, `role_id`, `phase`, and `todo_id` identify the current
+  worker and work item.
+- `capability_token` must match a capability in
+  `auto_research_role_state_machine_v0`.
+- `allowed_actions`, `write_scope`, `protected_scope`, and `stop_conditions`
+  bound what the worker may do.
+- `required_skill` and `skill_section` route the worker to the correct how-to
+  instructions after identity is resolved.
+
+Optional fields such as `hypothesis_id`, `agents_overlay`, and
+`handoff_outputs` make the profile more ergonomic but do not grant authority.
+
+## Resolution Order
+
+Every visible auto-research worker should resolve its instructions in this
+order:
+
+1. Read the role profile from the launcher packet, frontier item, or bootstrap
+   prompt.
+2. Run `quota should-run --goal-id ... --agent-id ...` and confirm the selected
+   todo still matches the profile.
+3. Read the current role/state-machine contract for allowed transitions.
+4. Load the required skill and only the section named by `skill_section`.
+5. Read applicable `AGENTS.md` overlays for repository and workspace rules.
+6. Act within `allowed_actions` and `write_scope`, then write only the listed
+   handoff outputs.
+
+If any source conflicts, the worker fails closed in this order:
+
+1. operator gate or private/security boundary;
+2. control-plane quota, claim, capability, or write-scope mismatch;
+3. repository `AGENTS.md` safety rule;
+4. skill checklist disagreement;
+5. launcher pane label or cosmetic prompt text.
+
+## Auto-Research Role Profiles
+
+The v0 demo should expose four logical always-on profiles. A host may render
+fewer panes only when the merged duties are explicit in the profile and the
+records still name the role that produced each transition.
+
+| Role id | Skill section | Primary phase | Writes | Must stop when |
+| --- | --- | --- | --- | --- |
+| `research_curator` | Research curator | `contract_ready`, `promotion_gate` | `research_contract_v0`, owner gate todos, protected-boundary notes. | The next step would select a winner, run an experiment, or publish unsupported evidence. |
+| `hypothesis_mapper` | Hypothesis mapper | `hypothesis_proposed`, `retired` | `research_hypothesis_v0`, successor todos, no-follow-up rationale. | Novelty requires the same source that inspired the idea, or negative evidence would be hidden. |
+| `evidence_runner` | Evidence runner | `frontier_selected`, `attempt_running` | Branch refs, dev eval evidence, retry packets. | Protected scope changes, promotion decisions, or private/raw artifacts are needed. |
+| `evidence_verifier` | Evidence verifier | `evidence_recorded`, `evaluated`, `promotion_gate` | Evaluation summary, promotion/retirement candidates, gate todos. | Evidence is dev-only but would be presented as promoted, or held-out data is missing when required. |
+
+Future roles such as gate steward, synthesis narrator, and frontier janitor are
+split candidates, not required v0 panes. They should be introduced only when
+evidence from the demo shows that a transition duty needs a separate owner.
+
+## Skill Strategy
+
+Start with one installed `loopx-auto-research` skill that contains role
+sections:
+
+- `Research curator`
+- `Hypothesis mapper`
+- `Evidence runner`
+- `Evidence verifier`
+- `Visible takeover and stop controls`
+
+This keeps trigger routing simple while the protocol settles. Split into
+role-specific skills only after a visible run shows repeated confusion that a
+single role-routed skill cannot prevent. The split decision should cite evidence
+such as wrong section loading, unauthorized writes, hidden negative evidence, or
+missed stop conditions.
+
+The skill body should not invent current work. Its first command should tell
+the agent to read the profile and run the quota/frontier command named by the
+profile. This mirrors Arbor's useful "load a checklist at the exact phase"
+behavior while preserving LoopX's decentralized identity model.
+
+## Demo Launcher Implications
+
+A visible tmux or terminal launcher should print the profile before starting
+Codex:
+
+```bash
+export LOOPX_GOAL_ID=loopx-auto-research-knn
+export LOOPX_AGENT_ID=codex-auto-research-runner-1
+export LOOPX_ROLE_ID=evidence_runner
+export LOOPX_ROLE_PROFILE_REF=auto_research_role_profile_v0
+loopx auto-research frontier --goal-id "$LOOPX_GOAL_ID" --agent-id "$LOOPX_AGENT_ID"
+```
+
+The pane title is cosmetic. The profile and quota/frontier projection are the
+authority. The launcher must keep attach, interrupt, and stop commands visible
+so the user can take over without reading hidden logs.
+
+## Acceptance Checks
+
+An implementation satisfies this contract when:
+
+- launcher and frontier packets expose `auto_research_role_profile_v0` for each
+  visible worker;
+- each profile names `agent_id`, `role_id`, `phase`, `capability_token`,
+  `allowed_actions`, `write_scope`, `protected_scope`, `required_skill`,
+  `skill_section`, and `stop_conditions`;
+- the default demo uses the four logical v0 role identities, with owner takeover
+  as a visible control surface rather than a research role;
+- the role-aware skill says identity comes from the profile and quota/frontier,
+  not from the skill itself;
+- `AGENTS.md` overlays can add stricter local rules but cannot expand a role's
+  authority beyond the control-plane profile;
+- validation proves no leader/coordinator pane is required for the demo to be
+  understandable or interruptible.

--- a/docs/reference/protocols/auto-research-role-state-machine-v0.md
+++ b/docs/reference/protocols/auto-research-role-state-machine-v0.md
@@ -18,6 +18,7 @@ The auto-research kernel is intentionally split into three protocol surfaces:
 | `decentralized_auto_research_state_v0` | Record and projection shapes: contract, todo-linked hypothesis, evidence event, frontier, evidence graph, showcase projection. | Which role may write each transition. |
 | `auto_research_lane_contract_v1` | Capability ownership for curator, proposer, executor, evaluator, and narrator lanes. | The ordered state machine and transition evidence. |
 | `auto_research_role_state_machine_v0` | Digital employee role map, state transition rules, takeover gates, and no-leader invariants. | Runtime scheduling, model prompts, or hidden orchestration. |
+| `auto_research_role_profile_v0` | Per-worker identity packet: `agent_id`, role, phase, capability, write scope, required skill section, AGENTS overlay, and stop conditions. | Research source records, phase checklist prose, or authority beyond quota/frontier. |
 
 All three contracts are peer artifacts under `docs/reference/protocols/`.
 Together they are the public-safe control-plane map for auto research.

--- a/examples/decentralized-auto-research-protocol-smoke.py
+++ b/examples/decentralized-auto-research-protocol-smoke.py
@@ -16,6 +16,7 @@ ROOT = Path(__file__).resolve().parents[1]
 PROTOCOL = ROOT / "docs/reference/protocols/decentralized-auto-research-state-v0.md"
 LANE_CONTRACT = ROOT / "docs/reference/protocols/auto-research-lane-contract-v1.md"
 ROLE_STATE_MACHINE = ROOT / "docs/reference/protocols/auto-research-role-state-machine-v0.md"
+ROLE_PROFILE = ROOT / "docs/reference/protocols/auto-research-role-profile-v0.md"
 PROTOCOL_README = ROOT / "docs/reference/protocols/README.md"
 BLUEPRINT = ROOT / "docs/product/decentralized-auto-research-showcase.md"
 
@@ -47,6 +48,7 @@ def main() -> None:
     protocol = _read(PROTOCOL)
     lane_contract = _read(LANE_CONTRACT)
     role_state_machine = _read(ROLE_STATE_MACHINE)
+    role_profile = _read(ROLE_PROFILE)
     protocol_readme = _read(PROTOCOL_README)
     blueprint = _read(BLUEPRINT)
     combined = (
@@ -56,6 +58,8 @@ def main() -> None:
         + "\n"
         + role_state_machine
         + "\n"
+        + role_profile
+        + "\n"
         + protocol_readme
         + "\n"
         + blueprint
@@ -63,6 +67,7 @@ def main() -> None:
     compact_protocol = re.sub(r"\s+", " ", protocol)
     compact_lane_contract = re.sub(r"\s+", " ", lane_contract)
     compact_role_state_machine = re.sub(r"\s+", " ", role_state_machine)
+    compact_role_profile = re.sub(r"\s+", " ", role_profile)
 
     _assert_public_safe(combined, "decentralized auto-research docs")
 
@@ -95,6 +100,7 @@ def main() -> None:
     assert "auto_research_role_state_machine_v0" in protocol
     assert "auto_research_lane_contract_v1" in protocol_readme
     assert "auto_research_role_state_machine_v0" in protocol_readme
+    assert "auto_research_role_profile_v0" in protocol_readme
 
     required_lane_terms = [
         "auto_research_lane_contract_v1",
@@ -157,6 +163,35 @@ def main() -> None:
     assert "Gate handling is a transition duty" in compact_role_state_machine
     for future_role in ("Frontier janitor", "Synthesis narrator", "Gate steward"):
         assert f"| {future_role} |" in role_state_machine, f"future split missing {future_role}"
+
+    required_role_profile_terms = [
+        "auto_research_role_profile_v0",
+        "LoopX control plane",
+        "Role-aware skill",
+        "AGENTS.md",
+        "Host launcher",
+        "agent_id",
+        "role_id",
+        "phase",
+        "capability_token",
+        "allowed_actions",
+        "write_scope",
+        "protected_scope",
+        "required_skill",
+        "skill_section",
+        "stop_conditions",
+        "research_curator",
+        "hypothesis_mapper",
+        "evidence_runner",
+        "evidence_verifier",
+        "loopx-auto-research",
+        "quota should-run --goal-id",
+        "The pane title is cosmetic",
+    ]
+    for term in required_role_profile_terms:
+        assert term in role_profile, f"role profile missing {term!r}"
+    assert "skills useful without letting them become a second source of identity" in compact_role_profile
+    assert "identity comes from the profile and quota/frontier" in compact_role_profile
 
     required_blueprint_terms = [
         "Decentralized Auto Research: k-NN Speedup",


### PR DESCRIPTION
## Motivation
LoopX auto-research needs to solve two separate problems: who a worker is, and how that worker should act in a phase. Arbor can keep identity mostly in Coordinator/Executor topology and load skills as phase playbooks; LoopX needs explicit per-worker identity because multiple decentralized Codex sessions share one control plane.

## Changes
- Add `auto_research_role_profile_v0` protocol.
- Define the ownership split between LoopX control plane, role-aware skill, `AGENTS.md`, and host launcher.
- Specify the profile shape, resolution order, fail-closed priority, four v0 role profiles, skill strategy, and visible launcher implications.
- Link the new profile contract from the protocols index and role state-machine companion table.
- Extend the decentralized auto-research protocol smoke to assert the new contract and no-leader identity boundaries.

## Validation
- `python3 -m py_compile examples/decentralized-auto-research-protocol-smoke.py`
- `python3 examples/decentralized-auto-research-protocol-smoke.py`
- `git diff --check`
- `loopx check --scan-path docs/reference/protocols/auto-research-role-profile-v0.md --scan-path docs/reference/protocols/README.md --scan-path docs/reference/protocols/auto-research-role-state-machine-v0.md --scan-path examples/decentralized-auto-research-protocol-smoke.py`

## Risk
Docs and smoke only. No runtime behavior, launch behavior, first-screen public surface, or repository write policy changes.