### PR TITLE
Add todo list point lookup

### DIFF
--- a/examples/todo-cli-smoke.py
+++ b/examples/todo-cli-smoke.py
@@ -291,6 +291,69 @@ def main() -> int:
         assert fields["user_todos"]["source_section"] == "User Todo / Owner Review Reading Queue", fields
         assert fields["agent_todos"]["source_section"] == "Agent Todo", fields
 
+        default_list = run_cli(registry_path, "todo", "list", "--goal-id", GOAL_ID)
+        assert default_list["todo_count"] == 3, default_list
+        assert "todo_id_filter" not in default_list, default_list
+        assert "matched" not in default_list, default_list
+        assert "relations" not in default_list, default_list
+
+        scoped_gate_lookup = run_cli(
+            registry_path,
+            "todo",
+            "list",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            scoped_gate["todo_id"],
+        )
+        assert scoped_gate_lookup["ok"] is True, scoped_gate_lookup
+        assert scoped_gate_lookup["todo_id_filter"] == scoped_gate["todo_id"], scoped_gate_lookup
+        assert scoped_gate_lookup["todo_count"] == 1, scoped_gate_lookup
+        assert scoped_gate_lookup["matched"] is True, scoped_gate_lookup
+        assert scoped_gate_lookup["todo"]["todo_id"] == scoped_gate["todo_id"], scoped_gate_lookup
+        assert scoped_gate_lookup["relations"]["blocks_agent"] == "codex-side-bypass", scoped_gate_lookup
+        assert scoped_gate_lookup["relations"]["decision_scope"]["scope_key"] == (
+            "external_publish_channel"
+        ), scoped_gate_lookup
+        assert scoped_gate_lookup["user_todos"]["open_count"] == 1, scoped_gate_lookup
+        assert scoped_gate_lookup["agent_todos"]["open_count"] == 0, scoped_gate_lookup
+
+        agent_lookup = run_cli(
+            registry_path,
+            "todo",
+            "list",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--todo-id",
+            metadata_payload["todo_id"],
+        )
+        assert agent_lookup["todo_count"] == 1, agent_lookup
+        assert agent_lookup["matched"] is True, agent_lookup
+        assert agent_lookup["todo"]["todo_id"] == metadata_payload["todo_id"], agent_lookup
+        assert agent_lookup["todo"]["action_kind"] == "run_eval", agent_lookup
+        assert agent_lookup["relations"]["required_capabilities"] == [
+            "shell",
+            "benchmark_runner",
+        ], agent_lookup
+
+        missing_lookup = run_cli(
+            registry_path,
+            "todo",
+            "list",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            "todo_missing_lookup_0001",
+        )
+        assert missing_lookup["ok"] is True, missing_lookup
+        assert missing_lookup["todo_count"] == 0, missing_lookup
+        assert missing_lookup["matched"] is False, missing_lookup
+        assert missing_lookup["todo"] is None, missing_lookup
+        assert missing_lookup["relations"] == {}, missing_lookup
+        assert missing_lookup["not_found"] is True, missing_lookup
+
         monitor_payload = run_cli(
             registry_path,
             "todo",

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -321,7 +321,6 @@ def handle_todo_command(
                 for flag, value in (
                     ("--text", args.text),
                     ("--follow-up", args.followups),
-                    ("--todo-id", args.todo_id),
                     ("--note", args.note),
                     ("--evidence", args.evidence),
                     ("--reason", args.reason),
@@ -359,7 +358,7 @@ def handle_todo_command(
             ]
             if unsupported:
                 raise ValueError(
-                    "todo list only accepts --goal-id, optional --role, --status, "
+                    "todo list only accepts --goal-id, optional --role, --status, --todo-id, "
                     "--project, --state-file, --dry-run, and --format; unsupported: "
                     + ", ".join(unsupported)
                 )
@@ -368,6 +367,7 @@ def handle_todo_command(
                 goal_id=args.goal_id,
                 role=args.role,
                 status=args.status,
+                todo_id=args.todo_id,
                 project=Path(args.project).expanduser() if args.project else None,
                 state_file=Path(args.state_file).expanduser() if args.state_file else None,
             )

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -381,13 +381,50 @@ def filtered_todo_summary(
     *,
     role: str,
     status: str | None = None,
+    todo_id: str | None = None,
 ) -> dict[str, Any]:
     items = list((summary or {}).get("items") or [])
     normalized_status = normalize_todo_status(status)
     if normalized_status:
         items = [item for item in items if todo_item_status(item) == normalized_status]
+    normalized_todo_id = normalize_todo_id(todo_id) if todo_id else None
+    if normalized_todo_id:
+        items = [
+            item
+            for item in items
+            if normalize_todo_id(item.get("todo_id")) == normalized_todo_id
+        ]
     source_section = str((summary or {}).get("source_section") or TODO_SECTION_HEADINGS[role])
     return compact_todo_group(items, source_section=source_section, role=role) or empty_todo_summary(role=role)
+
+
+def todo_item_relations(item: dict[str, Any]) -> dict[str, Any]:
+    relations: dict[str, Any] = {}
+    for key in (
+        "claimed_by",
+        "blocks_agent",
+        "global_gate",
+        "unblocks_todo_id",
+        "superseded_by",
+        "resume_when",
+        "resume_condition",
+        "resume_ready",
+        "decision_scope",
+        "required_decision_scopes",
+        "required_write_scopes",
+        "required_capabilities",
+        "target_capabilities",
+        "task_class",
+        "action_kind",
+        "target_key",
+        "cadence",
+        "next_due_at",
+        "expires_at",
+    ):
+        value = item.get(key)
+        if value is not None and value != []:
+            relations[key] = value
+    return relations
 
 
 def list_goal_todos(
@@ -396,9 +433,13 @@ def list_goal_todos(
     goal_id: str,
     role: str | None = None,
     status: str | None = None,
+    todo_id: str | None = None,
     project: Path | None = None,
     state_file: Path | None = None,
 ) -> dict[str, Any]:
+    normalized_todo_id = normalize_todo_id(todo_id) if todo_id else None
+    if todo_id and not normalized_todo_id:
+        raise ValueError("todo_id must use the public token shape todo_<letters-digits-underscore-hyphen>")
     registry = load_registry(registry_path)
     goal, resolved_project, resolved_state_file = resolve_goal_state(
         registry=registry,
@@ -438,10 +479,12 @@ def list_goal_todos(
             fields.get(key) if isinstance(fields, dict) else None,
             role=item_role,
             status=status,
+            todo_id=normalized_todo_id,
         )
         summaries[key] = summary
         todos.extend(summary.get("items") or [])
 
+    matched_todo = todos[0] if len(todos) == 1 else None
     payload: dict[str, Any] = {
         "ok": True,
         "dry_run": True,
@@ -456,6 +499,15 @@ def list_goal_todos(
         "state_file": str(resolved_state_file),
         "project": str(resolved_project) if resolved_project else None,
     }
+    if normalized_todo_id:
+        payload["todo_id_filter"] = normalized_todo_id
+        payload["matched"] = bool(todos)
+        payload["todo"] = matched_todo
+        payload["relations"] = todo_item_relations(matched_todo) if matched_todo else {}
+        if len(todos) > 1:
+            payload["ambiguous"] = True
+        if not todos:
+            payload["not_found"] = True
     payload.update(summaries)
     if source == "event_projection" and projection_fields.get("state_event_projection"):
         payload["state_event_projection"] = projection_fields["state_event_projection"]


### PR DESCRIPTION
## Summary
- allow `loopx todo list --todo-id <id>` as a read-only point lookup on the existing todo list surface
- return optional point-lookup fields only when `--todo-id` is provided, keeping default list output unchanged
- include compact relation fields from the matched todo without introducing a new runtime contract

## Validation
- `python3 examples/todo-cli-smoke.py`
- `python3 -m py_compile loopx/todos.py loopx/cli_commands/todo.py`
- `git diff --check`

## Notes
- The smoke covers default list output, user-gate lookup, agent-todo lookup, and missing-id lookup.
- This is a narrow CLI behavior slice, so it should be reviewed before merging.