### PR TITLE
Clarify promotion canary release boundary

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -100,6 +100,14 @@ The default promotion canary is:
 python3 examples/canary-promotion-readiness-smoke.py --no-write-evidence
 ```
 
+The default dashboard policy is `--dashboard-mode=auto`: source checkouts run
+dashboard demo-readiness when `apps/dashboard` is present, while installed
+release snapshots that omit the dashboard app skip that optional surface and
+keep the omission visible in the canary output. Use `--dashboard-mode=require`
+when the dashboard/frontstage itself is being promoted, and
+`--dashboard-mode=skip` only when the release boundary intentionally excludes
+the dashboard app.
+
 Use the writeback form only when you intentionally want to append fresh
 promotion-readiness evidence:
 
@@ -109,8 +117,9 @@ python3 examples/canary-promotion-readiness-smoke.py
 
 If the source checkout has optional frontend dependencies installed, dashboard
 readiness can be included in the same canary. If a release snapshot omits the
-dashboard app, record that as a release-boundary decision or follow-up instead
-of silently treating the dashboard path as covered.
+dashboard app, the canary should degrade gracefully and record that boundary
+rather than failing unrelated CLI/install promotion or silently treating the
+dashboard path as covered.
 
 ## What Is Safe To Depend On
 

--- a/examples/canary-promotion-readiness-boundary-smoke.py
+++ b/examples/canary-promotion-readiness-boundary-smoke.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Smoke-test promotion canary dashboard-boundary planning."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CANARY_PATH = REPO_ROOT / "examples" / "canary-promotion-readiness-smoke.py"
+
+
+def load_canary_module():
+    spec = importlib.util.spec_from_file_location(
+        "canary_promotion_readiness_smoke",
+        CANARY_PATH,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def main() -> int:
+    canary = load_canary_module()
+    with tempfile.TemporaryDirectory() as tmp:
+        root = Path(tmp)
+        release_dashboard = root / "release" / "apps" / "dashboard"
+        source_dashboard = root / "source" / "apps" / "dashboard"
+        source_dashboard.mkdir(parents=True)
+        (source_dashboard / "package.json").write_text("{}\n", encoding="utf-8")
+
+        auto_release = canary.dashboard_readiness_plan(dashboard_dir=release_dashboard)
+        assert auto_release["status"] == "skip", auto_release
+        assert "apps/dashboard is not present" in auto_release["reason"], auto_release
+
+        required_release = canary.dashboard_readiness_plan(
+            dashboard_dir=release_dashboard,
+            dashboard_mode="require",
+        )
+        assert required_release["status"] == "fail", required_release
+
+        browser_release = canary.dashboard_readiness_plan(
+            dashboard_dir=release_dashboard,
+            include_browser=True,
+        )
+        assert browser_release["status"] == "fail", browser_release
+
+        skipped_release = canary.dashboard_readiness_plan(
+            dashboard_dir=release_dashboard,
+            dashboard_mode="skip",
+            include_browser=True,
+        )
+        assert skipped_release["status"] == "skip", skipped_release
+        assert skipped_release["reason"] == "dashboard readiness explicitly skipped", skipped_release
+
+        source_plan = canary.dashboard_readiness_plan(dashboard_dir=source_dashboard)
+        assert source_plan["status"] == "run", source_plan
+        assert source_plan["command"][-1] == "--skip-browser", source_plan
+
+        source_browser_plan = canary.dashboard_readiness_plan(
+            dashboard_dir=source_dashboard,
+            include_browser=True,
+        )
+        assert source_browser_plan["status"] == "run", source_browser_plan
+        assert "--skip-browser" not in source_browser_plan["command"], source_browser_plan
+
+    print("canary-promotion-readiness-boundary-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/canary-promotion-readiness-smoke.py
+++ b/examples/canary-promotion-readiness-smoke.py
@@ -20,6 +20,7 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+DASHBOARD_DIR = REPO_ROOT / "apps" / "dashboard"
 
 COMMON_NODE_PATHS = [
     "/opt/homebrew/bin",
@@ -31,6 +32,10 @@ DEFAULT_READINESS_AGENT_LANE = "product_capability_catalog_canary"
 READINESS_CLASSIFICATION = "canary_promotion_readiness_smoke_group"
 READINESS_RECOMMENDED_ACTION = (
     "Canary promotion-readiness smoke passed; promotion may proceed after doctor/status reports fresh evidence."
+)
+READINESS_RECOMMENDED_ACTION_DASHBOARD_SKIPPED = (
+    "Canary promotion-readiness smoke passed for the installed release boundary; "
+    "dashboard readiness was skipped because apps/dashboard is not shipped in the release snapshot."
 )
 
 BASE_COMMANDS = [
@@ -46,6 +51,15 @@ BASE_COMMANDS = [
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dashboard-mode",
+        choices=("auto", "require", "skip"),
+        default="auto",
+        help=(
+            "Dashboard readiness policy: auto runs it when apps/dashboard is present, "
+            "require fails if the dashboard app is absent, and skip records the release-boundary omission."
+        ),
+    )
     parser.add_argument(
         "--include-browser",
         action="store_true",
@@ -93,9 +107,15 @@ def run_command(label: str, command: list[str], env: dict[str, str]) -> None:
 def write_readiness_evidence(
     env: dict[str, str],
     *,
+    dashboard_skipped: bool,
     agent_id: str | None = None,
     agent_lane: str | None = None,
 ) -> None:
+    recommended_action = (
+        READINESS_RECOMMENDED_ACTION_DASHBOARD_SKIPPED
+        if dashboard_skipped
+        else READINESS_RECOMMENDED_ACTION
+    )
     resolved_agent_id = (
         agent_id or os.environ.get("LOOPX_AGENT_ID") or DEFAULT_READINESS_AGENT_ID
     ).strip()
@@ -112,7 +132,7 @@ def write_readiness_evidence(
         "--classification",
         READINESS_CLASSIFICATION,
         "--recommended-action",
-        READINESS_RECOMMENDED_ACTION,
+        recommended_action,
         "--delivery-batch-scale",
         "multi_surface",
         "--delivery-outcome",
@@ -129,14 +149,64 @@ def write_readiness_evidence(
     )
 
 
+def dashboard_readiness_plan(
+    *,
+    dashboard_dir: Path = DASHBOARD_DIR,
+    dashboard_mode: str = "auto",
+    include_browser: bool = False,
+) -> dict[str, object]:
+    has_dashboard = (dashboard_dir / "package.json").is_file()
+    if dashboard_mode == "skip":
+        return {
+            "status": "skip",
+            "reason": "dashboard readiness explicitly skipped",
+            "command": None,
+        }
+    if has_dashboard:
+        command = [sys.executable, "examples/dashboard-demo-readiness-smoke.py"]
+        if not include_browser:
+            command.append("--skip-browser")
+        return {
+            "status": "run",
+            "reason": None,
+            "command": command,
+        }
+    reason = (
+        "apps/dashboard is not present in this checkout or release snapshot; "
+        "run from a source checkout or pass --dashboard-mode=skip to omit it intentionally"
+    )
+    if dashboard_mode == "require" or include_browser:
+        return {
+            "status": "fail",
+            "reason": reason,
+            "command": None,
+        }
+    return {
+        "status": "skip",
+        "reason": reason,
+        "command": None,
+    }
+
+
 def main() -> int:
     args = parse_args()
     env = build_env()
     commands = list(BASE_COMMANDS)
-    dashboard_command = [sys.executable, "examples/dashboard-demo-readiness-smoke.py"]
-    if not args.include_browser:
-        dashboard_command.append("--skip-browser")
-    commands.append(("dashboard demo readiness", dashboard_command))
+    dashboard_plan = dashboard_readiness_plan(
+        dashboard_mode=args.dashboard_mode,
+        include_browser=args.include_browser,
+    )
+    if dashboard_plan["status"] == "fail":
+        raise SystemExit(str(dashboard_plan["reason"]))
+    if dashboard_plan["status"] == "run":
+        dashboard_command = dashboard_plan["command"]
+        assert isinstance(dashboard_command, list)
+        commands.append(("dashboard demo readiness", dashboard_command))
+    else:
+        print(
+            f"[canary-promotion] dashboard demo readiness: skipped ({dashboard_plan['reason']})",
+            flush=True,
+        )
 
     for label, command in commands:
         run_command(label, command, env)
@@ -145,12 +215,16 @@ def main() -> int:
     if not args.no_write_evidence:
         write_readiness_evidence(
             env,
+            dashboard_skipped=dashboard_plan["status"] == "skip",
             agent_id=args.agent_id,
             agent_lane=args.agent_lane,
         )
         evidence_suffix = " with evidence writeback"
 
-    suffix = " with browser smokes" if args.include_browser else " without browser smokes"
+    if dashboard_plan["status"] == "skip":
+        suffix = " with dashboard readiness skipped"
+    else:
+        suffix = " with browser smokes" if args.include_browser else " without browser smokes"
     print(f"canary-promotion-readiness-smoke ok{suffix}{evidence_suffix}")
     return 0
 

--- a/examples/catalog-canary-planner-smoke.py
+++ b/examples/catalog-canary-planner-smoke.py
@@ -124,9 +124,14 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
         changed_files=["docs/product/release-readiness.md"],
         surfaces=["release promotion install update"],
     )
-    release_profile_ids = {profile["id"] for profile in release_payload["domain_profiles"]}
+    release_profiles = {profile["id"]: profile for profile in release_payload["domain_profiles"]}
+    release_profile_ids = set(release_profiles)
     assert "release-promotion" in release_profile_ids, release_payload
     assert "install-update" in release_profile_ids, release_payload
+    release_commands = [
+        check["command"] for check in release_profiles["release-promotion"]["checks"]
+    ]
+    assert "python3 examples/canary-promotion-readiness-boundary-smoke.py" in release_commands
 
     install_payload = build_catalog_canary_plan(
         changed_files=["scripts/install-local.sh", "loopx/self_update.py"],

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -223,6 +223,11 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
                 "reason": "checks promotion readiness from compact run history",
             },
             {
+                "command": "python3 examples/canary-promotion-readiness-boundary-smoke.py",
+                "tier": "default",
+                "reason": "guards dashboard release-boundary planning for source checkouts and release snapshots",
+            },
+            {
                 "command": "python3 examples/canary-promotion-no-write-contract-smoke.py",
                 "tier": "default",
                 "reason": "guards no-write promotion readiness behavior",


### PR DESCRIPTION
## Summary
- add dashboard-mode planning to the promotion readiness canary
- let installed release snapshots that omit apps/dashboard skip dashboard readiness visibly instead of failing unrelated CLI/install promotion
- add a focused boundary smoke for source checkout vs release snapshot behavior
- document when to use auto/require/skip dashboard readiness modes

## Validation
- python3 examples/canary-promotion-readiness-boundary-smoke.py
- python3 -m py_compile examples/canary-promotion-readiness-smoke.py examples/canary-promotion-readiness-boundary-smoke.py
- python3 examples/release-readiness-doc-smoke.py
- python3 examples/canary-promotion-readiness-smoke.py --dashboard-mode=skip --no-write-evidence
- git diff --check

## Boundary
- loopx check via the skip-dashboard canary passed with only the existing loopx-meta duplicate-index warning
- public/private scan only matched existing release-readiness safety language and $HOME examples

Review note: this is intentionally a canary/release-boundary behavior change, not a new runtime contract.