### PR TITLE
Add SkillsBench verifier bootstrap preflight

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -5029,6 +5029,87 @@ def test_skillsbench_apt_risk_preflight_blocks_full_run_without_benchflow() -> N
         )
 
 
+def test_skillsbench_verifier_bootstrap_preflight_blocks_full_run_without_benchflow() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-verifier-preflight-") as tmp:
+        root = Path(tmp)
+        task = root / "skillsbench" / "tasks" / "organize-messy-files"
+        dockerfile = task / "environment" / "Dockerfile"
+        verifier = task / "verifier" / "test.sh"
+        dockerfile.parent.mkdir(parents=True)
+        verifier.parent.mkdir(parents=True)
+        dockerfile.write_text("FROM python:3.12-slim\n", encoding="utf-8")
+        verifier.write_text(
+            "#!/bin/sh\n"
+            "curl -LsSf https://astral.sh/uv/0.9.7/install.sh | sh\n"
+            "uv add polars==1.37.1\n",
+            encoding="utf-8",
+        )
+        (task / "task.toml").write_text("version = \"1.1\"\n", encoding="utf-8")
+        jobs = root / "jobs"
+        ledger = root / "benchmark-run-ledger.json"
+        args = [
+            "--task-id",
+            "organize-messy-files",
+            "--route",
+            "codex-acp-blind-loop-baseline",
+            "--skillsbench-root",
+            str(root / "skillsbench"),
+            "--jobs-dir",
+            str(jobs),
+            "--job-name",
+            "organize-messy-files-verifier-bootstrap-preflight",
+            "--run-group-id",
+            "organize-messy-files-verifier-bootstrap-preflight",
+            "--ledger-path",
+            str(ledger),
+            "--fail-fast-on-verifier-bootstrap-risk",
+            "--update-ledger",
+        ]
+        plan = build_plan(parse_args(args))
+        preflight = plan["task_setup_preflight"]
+        assert preflight["status"] == "verifier_bootstrap_risk_detected", preflight
+        assert preflight["verifier_bootstrap_risk_detected"] is True, preflight
+        assert preflight["verifier_uv_bootstrap_risk_detected"] is True, preflight
+        assert preflight["verifier_external_download_risk_detected"] is True, preflight
+        assert preflight["verifier_package_install_risk_detected"] is True, preflight
+        assert preflight["raw_task_text_read"] is False, preflight
+
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            rc = skillsbench_automation_loop_main(args)
+
+        assert rc == 0, stderr.getvalue()
+        compact_path = (
+            jobs
+            / "organize-messy-files-verifier-bootstrap-preflight"
+            / "organize-messy-files__codex_acp_blind_loop"
+            / "benchmark_run.compact.json"
+        )
+        compact = json.loads(compact_path.read_text(encoding="utf-8"))
+        assert compact["score_failure_attribution"] == (
+            "skillsbench_verifier_bootstrap_risk_preflight_blocked"
+        ), compact
+        assert compact["task_setup_preflight"][
+            "verifier_bootstrap_risk_detected"
+        ] is True, compact
+        assert compact["task_staging"][
+            "verifier_bootstrap_risk_preflight_blocked"
+        ] is True, compact
+        assert compact["validation"]["no_raw_task_text_read"] is True, compact
+
+        update = load_benchmark_run_ledger(ledger)
+        case = update["benchmarks"]["skillsbench@1.1"]["cases"][
+            "organize-messy-files"
+        ]
+        assert case["latest_decision"]["decision"] == (
+            "baseline_verifier_bootstrap_preflight_selection_required"
+        ), case
+        entry = case["runs"][0]
+        assert entry["repair_class"] == (
+            "skillsbench_verifier_bootstrap_preflight_selection"
+        ), entry
+
+
 def test_skillsbench_docker_task_staging_caps_local_cpu_request() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-cpu-cap-stage-") as tmp:
         root = Path(tmp)

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -1420,6 +1420,16 @@ def skillsbench_runner_error_attribution(error_text: str) -> tuple[str, str, lis
             "skillsbench_docker_setup_preflight_blocked",
             "skillsbench_environment_setup_error",
         ]
+    if (
+        "verifier bootstrap risk preflight blocked" in text
+        or "verifier dependency bootstrap risk detected before full case run" in text
+    ):
+        label = "skillsbench_verifier_bootstrap_risk_preflight_blocked"
+        return label, label, [
+            label,
+            "skillsbench_verifier_setup_preflight_blocked",
+            "skillsbench_environment_setup_error",
+        ]
     if "docker compose command failed" in text:
         if (
             "cannot connect to the docker daemon" in text

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -949,6 +949,28 @@ def _repair_route(
                 "raw_task_text_required": False,
             },
         }
+    if failure_class == "skillsbench_verifier_bootstrap_risk_preflight_blocked":
+        return {
+            "repair_priority": "P1",
+            "repair_class": "skillsbench_verifier_bootstrap_preflight_selection",
+            "next_action": (
+                "select a SkillsBench task whose verifier does not require "
+                "network/package bootstrap, or repair/cache the verifier "
+                "bootstrap route before spending another full arm"
+            ),
+            "repair_profile": {
+                "schema_version": "benchmark_repair_profile_v0",
+                "repair_class": "skillsbench_verifier_bootstrap_preflight_selection",
+                "rerun_allowed_after_profile_applied": True,
+                "required_preflight": [
+                    "skillsbench_task_setup_preflight",
+                    "verifier_bootstrap_risk_detected",
+                    "task_staging.verifier_bootstrap_risk_preflight_blocked",
+                ],
+                "raw_logs_required": False,
+                "raw_task_text_required": False,
+            },
+        }
     if failure_class == "skillsbench_task_source_preflight_blocked":
         return {
             "repair_priority": "P1",
@@ -1785,6 +1807,8 @@ def _case_decision(case: dict[str, Any]) -> dict[str, Any]:
             decision = f"{prefix}_codex_acp_post_success_finalization_required"
         elif repair_class == "skillsbench_setup_preflight_selection":
             decision = f"{prefix}_setup_preflight_selection_required"
+        elif repair_class == "skillsbench_verifier_bootstrap_preflight_selection":
+            decision = f"{prefix}_verifier_bootstrap_preflight_selection_required"
         elif repair_class == "skillsbench_task_source_preflight_selection":
             decision = f"{prefix}_task_source_preflight_selection_required"
         elif repair_class == "worker_verifier_alignment":

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -2083,6 +2083,8 @@ def _compact_benchmark_task_staging(value: Any) -> dict[str, Any]:
         "apt_retry_patch_required",
         "apt_retry_patch_applied",
         "apt_risk_preflight_blocked",
+        "verifier_bootstrap_risk_detected",
+        "verifier_bootstrap_risk_preflight_blocked",
         "app_skills_mount_patch_applied",
         "codex_acp_runtime_tools_patch_applied",
         "task_skills_removed",
@@ -2133,6 +2135,11 @@ def _compact_benchmark_task_setup_preflight(value: Any) -> dict[str, Any]:
         "raw_trajectory_read",
         "apt_setup_risk_detected",
         "apt_retry_patch_required",
+        "verifier_present",
+        "verifier_bootstrap_risk_detected",
+        "verifier_uv_bootstrap_risk_detected",
+        "verifier_external_download_risk_detected",
+        "verifier_package_install_risk_detected",
         "dockerfile_present",
         "canonical_task_present",
         "alternate_source_supported_by_runner",
@@ -2147,6 +2154,12 @@ def _compact_benchmark_task_setup_preflight(value: Any) -> dict[str, Any]:
     )
     if nearest_task_ids:
         compact["nearest_canonical_task_ids"] = nearest_task_ids
+    verifier_risk_categories = public_safe_compact_list(
+        value.get("verifier_bootstrap_risk_categories"),
+        limit=MAX_BENCHMARK_RUN_LIST_ITEMS,
+    )
+    if verifier_risk_categories:
+        compact["verifier_bootstrap_risk_categories"] = verifier_risk_categories
     return compact
 
 

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -4046,6 +4046,8 @@ def _public_task_staging(value: Any) -> dict[str, Any]:
         "app_skills_mount_patch_applied",
         "apt_retry_patch_applied",
         "apt_risk_preflight_blocked",
+        "verifier_bootstrap_risk_detected",
+        "verifier_bootstrap_risk_preflight_blocked",
         "codex_acp_runtime_tools_patch_applied",
         "task_skills_removed",
         "original_task_mutated",
@@ -4146,6 +4148,11 @@ def _public_task_setup_preflight(value: Any) -> dict[str, Any]:
         "raw_trajectory_read",
         "apt_setup_risk_detected",
         "apt_retry_patch_required",
+        "verifier_present",
+        "verifier_bootstrap_risk_detected",
+        "verifier_uv_bootstrap_risk_detected",
+        "verifier_external_download_risk_detected",
+        "verifier_package_install_risk_detected",
         "dockerfile_present",
         "canonical_task_present",
         "alternate_source_supported_by_runner",
@@ -4154,7 +4161,7 @@ def _public_task_setup_preflight(value: Any) -> dict[str, Any]:
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
-    for field in ("nearest_canonical_task_ids",):
+    for field in ("nearest_canonical_task_ids", "verifier_bootstrap_risk_categories"):
         raw_items = value.get(field)
         if isinstance(raw_items, list):
             compact[field] = [
@@ -4560,6 +4567,12 @@ def skillsbench_task_setup_preflight(
         "alternate_source_supported_by_runner": False,
         "apt_setup_risk_detected": False,
         "apt_retry_patch_required": False,
+        "verifier_present": False,
+        "verifier_bootstrap_risk_detected": False,
+        "verifier_uv_bootstrap_risk_detected": False,
+        "verifier_external_download_risk_detected": False,
+        "verifier_package_install_risk_detected": False,
+        "verifier_bootstrap_risk_categories": [],
     }
     skillsbench_root = expanded_task_path.parent.parent
     canonical_task_exists = expanded_task_path.is_dir()
@@ -4609,19 +4622,82 @@ def skillsbench_task_setup_preflight(
         return preflight
 
     apt_risk = dockerfile_needs_apt_retry_patch(dockerfile)
+    verifier_risk = skillsbench_verifier_bootstrap_risk(expanded_task_path)
+    preflight.update(verifier_risk)
+    verifier_bootstrap_risk = bool(
+        verifier_risk.get("verifier_bootstrap_risk_detected")
+    )
+    if apt_risk and verifier_bootstrap_risk:
+        setup_status = "setup_bootstrap_risk_detected"
+    elif apt_risk:
+        setup_status = "apt_risk_detected"
+    elif verifier_bootstrap_risk:
+        setup_status = "verifier_bootstrap_risk_detected"
+    else:
+        setup_status = "ok"
     preflight.update(
         {
-            "status": "apt_risk_detected" if apt_risk else "ok",
+            "status": setup_status,
             "apt_setup_risk_detected": apt_risk,
             "apt_retry_patch_required": apt_risk,
             "selection_recommendation": (
                 "route_to_setup_repair_or_use_fail_fast_guard"
-                if apt_risk
+                if apt_risk or verifier_bootstrap_risk
                 else "eligible_for_full_pair"
             ),
         }
     )
     return preflight
+
+
+def skillsbench_verifier_bootstrap_risk(task_path: Path) -> dict[str, Any]:
+    """Return public-safe verifier dependency bootstrap risk flags.
+
+    The check reads only the verifier wrapper shape and records booleans, not
+    raw task text, logs, trajectories, or verifier output. It catches cases
+    where the official verifier would spend the final closeout on network
+    bootstrap such as uv installation, curl/wget downloads, or package install
+    commands.
+    """
+
+    verifier = task_path / "verifier" / "test.sh"
+    result: dict[str, Any] = {
+        "verifier_present": verifier.exists(),
+        "verifier_bootstrap_risk_detected": False,
+        "verifier_uv_bootstrap_risk_detected": False,
+        "verifier_external_download_risk_detected": False,
+        "verifier_package_install_risk_detected": False,
+        "verifier_bootstrap_risk_categories": [],
+    }
+    if not verifier.exists():
+        return result
+    try:
+        text = verifier.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return result
+
+    categories: list[str] = []
+    uv_bootstrap_pattern = (
+        r"astral\.sh/uv|"
+        r"(?:^|[;&|(\s])uv(?:x|\s+add|\s+sync|\s+pip|\s+tool)"
+    )
+    if re.search(uv_bootstrap_pattern, text):
+        result["verifier_uv_bootstrap_risk_detected"] = True
+        categories.append("uv_bootstrap")
+    if re.search(r"(?:curl|wget)\s+[^;\n]*(?:https?://|astral\.sh)", text):
+        result["verifier_external_download_risk_detected"] = True
+        categories.append("external_download")
+    if re.search(
+        r"(?:python\s+-m\s+pip|pip3?|uv\s+pip|uv\s+add|"
+        r"poetry\s+install|npm\s+install|pnpm\s+install|"
+        r"yarn\s+install|apt-get\s+(?:update|install))",
+        text,
+    ):
+        result["verifier_package_install_risk_detected"] = True
+        categories.append("package_install")
+    result["verifier_bootstrap_risk_categories"] = sorted(set(categories))
+    result["verifier_bootstrap_risk_detected"] = bool(categories)
+    return result
 
 
 def patch_dockerfile_apt_retry(dockerfile: Path) -> bool:
@@ -4777,6 +4853,8 @@ def stage_task_for_sandbox(
     metadata["apt_setup_risk_detected"] = needs_apt_retry_patch
     metadata["apt_retry_patch_required"] = needs_apt_retry_patch
     metadata["apt_risk_preflight_blocked"] = False
+    metadata["verifier_bootstrap_risk_detected"] = False
+    metadata["verifier_bootstrap_risk_preflight_blocked"] = False
     if (
         not has_task_skills
         and not needs_resource_cap
@@ -5033,6 +5111,10 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
                 setup_preflight.get("apt_retry_patch_required")
             ),
             "apt_risk_preflight_blocked": False,
+            "verifier_bootstrap_risk_detected": bool(
+                setup_preflight.get("verifier_bootstrap_risk_detected")
+            ),
+            "verifier_bootstrap_risk_preflight_blocked": False,
         },
         "runner_prerequisites": {
             "schema_version": "skillsbench_runner_prerequisites_v0",
@@ -10050,6 +10132,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "failure instead of spending a full case attempt."
         ),
     )
+    parser.add_argument(
+        "--fail-fast-on-verifier-bootstrap-risk",
+        action="store_true",
+        help=(
+            "Before a full run, block Docker tasks whose public verifier "
+            "preflight detects network/package bootstrap risk such as uv, "
+            "curl/wget downloads, pip, npm, or apt commands; writes a compact "
+            "setup-preflight failure instead of spending a full case attempt."
+        ),
+    )
     args = parser.parse_args(argv)
     if (
         args.route in PRODUCT_MODE_CONTROLLER_ROUTES
@@ -10122,6 +10214,19 @@ async def async_main(
         raise SkillsBenchSetupPreflightBlocked(
             "skillsbench apt setup risk preflight blocked: "
             "apt-based Docker setup risk detected before full case run"
+        )
+    if (
+        args.fail_fast_on_verifier_bootstrap_risk
+        and not args.reduce_only
+        and setup_preflight.get("verifier_bootstrap_risk_detected") is True
+    ):
+        staging = plan.setdefault("task_staging", {})
+        if isinstance(staging, dict):
+            staging["verifier_bootstrap_risk_detected"] = True
+            staging["verifier_bootstrap_risk_preflight_blocked"] = True
+        raise SkillsBenchSetupPreflightBlocked(
+            "skillsbench verifier bootstrap risk preflight blocked: "
+            "verifier dependency bootstrap risk detected before full case run"
         )
     if (
         not args.reduce_only


### PR DESCRIPTION
## Summary
- add a public-safe SkillsBench verifier bootstrap preflight for uv/curl-wget/package-install risk
- add a fail-fast flag so risky verifier bootstrap cases close out before a full BenchFlow run
- preserve the new signals through compact reducer and ledger repair classification
- cover the path with a synthetic SkillsBench smoke

## Validation
- python -m py_compile scripts/skillsbench_automation_loop.py loopx/status.py loopx/benchmark_adapters/skillsbench.py loopx/benchmark_ledger.py examples/skillsbench-benchmark-run-smoke.py
- python examples/skillsbench-benchmark-run-smoke.py
- loopx check --scan-path scripts/skillsbench_automation_loop.py --scan-path loopx/status.py --scan-path loopx/benchmark_adapters/skillsbench.py --scan-path loopx/benchmark_ledger.py --scan-path examples/skillsbench-benchmark-run-smoke.py
- git diff --check

## Boundary
No local Docker benchmark run, no raw task text/log/trajectory/verifier output, no credentials, no leaderboard/submission behavior, and no scoring/task semantic changes.
