### PR TITLE
Add auto-research role profiles to demo launcher

### DIFF
--- a/docs/product/decentralized-auto-research-showcase.md
+++ b/docs/product/decentralized-auto-research-showcase.md
@@ -268,6 +268,9 @@ The packet has two important product properties:
 - every lane receives its own `quota should-run` and `auto-research frontier`
   command, so work routing still comes from LoopX state, todo claims, gates,
   and evidence graph projections.
+- every lane prints `auto_research_role_profile_v0` before quota/frontier/
+  bootstrap, so the visible worker knows its role, skill section, write scope,
+  protected scope, and stop conditions before it starts.
 - the default "one-click" path is a dry-run rehearsal script: it checks the
   required environment variables and prints the tmux start, attach, and stop
   commands without starting tmux, launching Codex, writing LoopX state, or
@@ -282,10 +285,16 @@ Operators can pass explicit lanes when rehearsing a real local demo:
 ```bash
 loopx --format json auto-research demo-supervisor \
   --goal-id loopx-auto-research-knn \
-  --agent codex-side-bypass:hypothesis-runner \
-  --agent codex-product-capability:evidence-promoter \
-  --agent codex-main-control:control-plane-guard
+  --agent codex-product-capability:research-curator:research_curator \
+  --agent codex-side-bypass:hypothesis-mapper:hypothesis_mapper \
+  --agent codex-main-control:evidence-runner:evidence_runner \
+  --agent codex-value-explorer:evidence-verifier:evidence_verifier
 ```
+
+The third segment is optional for compatibility; when omitted, LoopX infers the
+role from the lane name or from the default role order. The v0 default still
+uses the four logical roles from `auto_research_role_state_machine_v0`:
+research curator, hypothesis mapper, evidence runner, and evidence verifier.
 
 When the dry-run packet is acceptable, the same command can launch visible
 local Codex CLI TUIs. This is intentionally opt-in:
@@ -293,9 +302,10 @@ local Codex CLI TUIs. This is intentionally opt-in:
 ```bash
 loopx auto-research demo-supervisor \
   --goal-id loopx-auto-research-knn \
-  --agent codex-side-bypass:hypothesis-runner \
-  --agent codex-product-capability:evidence-promoter \
-  --agent codex-main-control:control-plane-guard \
+  --agent codex-product-capability:research-curator:research_curator \
+  --agent codex-side-bypass:hypothesis-mapper:hypothesis_mapper \
+  --agent codex-main-control:evidence-runner:evidence_runner \
+  --agent codex-value-explorer:evidence-verifier:evidence_verifier \
   --execute
 ```
 
@@ -307,11 +317,11 @@ opens visible windows directly, so takeover is the normal terminal interrupt
 or closing the launched windows.
 
 The executed launcher still is not a leader. Each lane window first runs its
-own `quota should-run`, then renders its own `auto-research frontier`, then
-prints the `codex-cli-bootstrap-message`, and only then starts `codex` with
-that visible bootstrap prompt. The launcher itself does not write LoopX state
-or spend LoopX quota; any writeback must happen through the visible Codex lane's
-normal LoopX todo/evidence commands.
+own role profile, then runs `quota should-run`, then renders its own
+`auto-research frontier`, then prints the `codex-cli-bootstrap-message`, and
+only then starts `codex` with that visible bootstrap prompt. The launcher
+itself does not write LoopX state or spend LoopX quota; any writeback must
+happen through the visible Codex lane's normal LoopX todo/evidence commands.
 
 For a tighter user handoff, render the demo acceptance packet. It links the
 experimental board output, the dry-run supervisor plan, and the takeover
@@ -321,16 +331,18 @@ checklist into one operator-facing packet:
 loopx --format json auto-research acceptance \
   --goal-id loopx-auto-research-knn \
   --agent-id codex-side-bypass \
-  --agent codex-side-bypass:hypothesis-runner \
-  --agent codex-product-capability:evidence-promoter \
-  --agent codex-main-control:control-plane-guard
+  --agent codex-product-capability:research-curator:research_curator \
+  --agent codex-side-bypass:hypothesis-mapper:hypothesis_mapper \
+  --agent codex-main-control:evidence-runner:evidence_runner \
+  --agent codex-value-explorer:evidence-verifier:evidence_verifier
 ```
 
 The user should accept the demo only when the packet says the board is
-read-only, the supervisor is still `dry_run`, every lane has quota/frontier/
-bootstrap checks before Codex, and attach/stop controls are visible. It is
-still not a public-first-screen approval; `ready_for_public_first_screen` stays
-false until the first-screen review gate is explicitly cleared.
+read-only, the supervisor is still `dry_run`, every lane has role profile plus
+quota/frontier/bootstrap checks before Codex, and attach/stop controls are
+visible. It is still not a public-first-screen approval;
+`ready_for_public_first_screen` stays false until the first-screen review gate
+is explicitly cleared.
 
 ### Visible Operator Rehearsal Path
 
@@ -339,10 +351,7 @@ launcher:
 
 ```bash
 loopx --format json auto-research demo-supervisor \
-  --goal-id loopx-auto-research-knn \
-  --agent codex-side-bypass:hypothesis-runner \
-  --agent codex-product-capability:evidence-promoter \
-  --agent codex-main-control:control-plane-guard
+  --goal-id loopx-auto-research-knn
 ```
 
 The user should see four concrete things in the packet:
@@ -350,13 +359,14 @@ The user should see four concrete things in the packet:
 - `mode: dry_run`, plus a boundary block showing `starts_tmux`,
   `runs_codex`, `writes_loopx_state`, and `spends_loopx_quota` are all false;
 - one pane plan per digital worker lane, with that lane's own
-  `quota should-run`, `auto-research frontier`, and
-  `codex-cli-bootstrap-message` commands;
+  `auto_research_role_profile_v0`, `quota should-run`, `auto-research
+  frontier`, and `codex-cli-bootstrap-message` commands;
 - a `start_script` array that can be copied into the user's shell only after
   the user sets `LOOPX_PROJECT`, `LOOPX_REGISTRY`, and
   `LOOPX_RUNTIME_ROOT`;
 - a `lane_timeline` for each lane, making the visible sequence explicit:
-  quota guard, frontier projection, bootstrap prompt, then visible Codex TUI;
+  role profile, quota guard, frontier projection, bootstrap prompt, then
+  visible Codex TUI;
 - explicit takeover controls: `tmux attach -t loopx-auto-research` to inspect
   every lane before accepting Codex prompts, and
   `tmux kill-session -t loopx-auto-research` to stop the rehearsal.

--- a/examples/auto-research-demo-supervisor-smoke.py
+++ b/examples/auto-research-demo-supervisor-smoke.py
@@ -189,6 +189,16 @@ def main() -> int:
     )
     assert_supervisor_contract(payload)
 
+    try:
+        build_auto_research_demo_supervisor_plan(
+            goal_id=GOAL_ID,
+            agent_specs=["codex-main-control:evidence-runner:not_a_role"],
+        )
+    except ValueError as exc:
+        assert "role_id must be one of" in str(exc), exc
+    else:
+        raise AssertionError("explicit invalid role_id must not silently fallback")
+
     cli_payload = run_cli_json()
     assert_supervisor_contract(cli_payload)
 

--- a/examples/auto-research-demo-supervisor-smoke.py
+++ b/examples/auto-research-demo-supervisor-smoke.py
@@ -22,9 +22,10 @@ from loopx.capabilities.auto_research import (  # noqa: E402
 
 GOAL_ID = "loopx-auto-research-knn"
 LANES = [
-    "codex-side-bypass:hypothesis-runner",
-    "codex-product-capability:evidence-promoter",
-    "codex-main-control:control-plane-guard",
+    "codex-product-capability:research-curator:research_curator",
+    "codex-side-bypass:hypothesis-mapper:hypothesis_mapper",
+    "codex-main-control:evidence-runner:evidence_runner",
+    "codex-value-explorer:evidence-verifier:evidence_verifier",
 ]
 
 
@@ -56,11 +57,32 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
 
     lanes = payload["lanes"]
     assert [lane["lane_id"] for lane in lanes] == [
-        "hypothesis-runner",
-        "evidence-promoter",
-        "control-plane-guard",
+        "research-curator",
+        "hypothesis-mapper",
+        "evidence-runner",
+        "evidence-verifier",
+    ], payload
+    assert [lane["role_id"] for lane in lanes] == [
+        "research_curator",
+        "hypothesis_mapper",
+        "evidence_runner",
+        "evidence_verifier",
     ], payload
     for lane in lanes:
+        profile = lane["role_profile"]
+        assert profile["schema_version"] == "auto_research_role_profile_v0", profile
+        assert profile["goal_id"] == GOAL_ID, profile
+        assert profile["agent_id"] == lane["agent_id"], profile
+        assert profile["role_id"] == lane["role_id"], profile
+        assert profile["required_skill"] == "loopx-auto-research", profile
+        assert profile["skill_section"], profile
+        assert profile["write_scope"], profile
+        assert profile["protected_scope"], profile
+        assert profile["stop_conditions"], profile
+        assert profile["pane_title_is_authority"] is False, profile
+        assert "role profile" in lane["visible_launch_command"], lane
+        assert "LOOPX_ROLE_ID" in lane["visible_launch_command"], lane
+        assert "LOOPX_ROLE_PROFILE_REF" in lane["visible_launch_command"], lane
         assert "quota should-run" in lane["quota_guard"], lane
         assert f"--agent-id {lane['agent_id']}" in lane["quota_guard"], lane
         assert "auto-research frontier" in lane["frontier"], lane
@@ -68,12 +90,14 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
         assert lane["visible_codex_tui"] == "codex", lane
         phases = [item["phase"] for item in lane["lane_timeline"]]
         assert phases == [
+            "role_profile",
             "quota_guard",
             "frontier_projection",
             "bootstrap_prompt",
             "visible_codex",
         ], lane
-        assert lane["lane_timeline"][0]["command_ref"] == "quota_guard", lane
+        assert lane["lane_timeline"][0]["command_ref"] == "role_profile", lane
+        assert lane["lane_timeline"][1]["command_ref"] == "quota_guard", lane
         assert "operator is attached" in lane["lane_timeline"][-1]["continue_when"], lane
 
     start_script = "\n".join(payload["commands"]["start_script"])
@@ -101,14 +125,18 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
 
     acceptance = payload["demo_acceptance"]
     assert acceptance["schema_version"] == "auto_research_demo_acceptance_v0", payload
+    assert "lanes[].role_profile" in acceptance["required_visible_fields"], acceptance
     assert "lanes[].lane_timeline" in acceptance["required_visible_fields"], acceptance
+    assert any("role_profile_v0" in item for item in acceptance["operator_can_accept_when"]), acceptance
     assert any("without executing it" in item for item in acceptance["operator_can_accept_when"]), acceptance
+    assert any("role_profile_v0" in item for item in acceptance["operator_must_reject_when"]), acceptance
     assert any("hides attach/stop" in item for item in acceptance["operator_must_reject_when"]), acceptance
 
     takeover = payload["user_takeover"]
     assert takeover["schema_version"] == "auto_research_user_takeover_v0", payload
     assert any("rehearsal script first" in item for item in takeover["operator_controls"]), takeover
     assert any("attach to tmux" in item for item in takeover["operator_controls"]), takeover
+    assert any("role_profile_v0" in item for item in takeover["visible_status_cues"]), takeover
     assert any("quota guard" in item for item in takeover["visible_status_cues"]), takeover
 
     boundary = payload["boundary"]
@@ -143,6 +171,8 @@ def run_cli_json() -> dict[str, Any]:
             LANES[1],
             "--agent",
             LANES[2],
+            "--agent",
+            LANES[3],
         ],
         cwd=REPO_ROOT,
         check=True,
@@ -181,7 +211,10 @@ def main() -> int:
     ).stdout
     assert "# LoopX Auto Research Demo Supervisor" in markdown, markdown
     assert "leader_agent_required: `False`" in markdown, markdown
+    assert "## Role Profiles" in markdown, markdown
+    assert "loopx-auto-research" in markdown, markdown
     assert "## Lane Timeline" in markdown, markdown
+    assert "`role_profile` via `role_profile`" in markdown, markdown
     assert "`quota_guard` via `quota_guard`" in markdown, markdown
     assert "## One-Click Dry Run" in markdown, markdown
     assert "copy_paste_dry_run_rehearsal" in markdown, markdown

--- a/examples/auto-research-visible-launcher-smoke.py
+++ b/examples/auto-research-visible-launcher-smoke.py
@@ -16,9 +16,10 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 
 GOAL_ID = "loopx-auto-research-knn"
 LANES = [
-    "codex-side-bypass:hypothesis-runner",
-    "codex-product-capability:evidence-promoter",
-    "codex-main-control:control-plane-guard",
+    "codex-product-capability:research-curator:research_curator",
+    "codex-side-bypass:hypothesis-mapper:hypothesis_mapper",
+    "codex-main-control:evidence-runner:evidence_runner",
+    "codex-value-explorer:evidence-verifier:evidence_verifier",
 ]
 
 
@@ -103,6 +104,8 @@ def main() -> int:
                 LANES[1],
                 "--agent",
                 LANES[2],
+                "--agent",
+                LANES[3],
                 "--execute",
                 "--launcher",
                 "tmux",
@@ -128,14 +131,24 @@ def main() -> int:
         assert payload["boundary"]["shared_state_route"] == "LOOPX_REGISTRY_and_LOOPX_RUNTIME_ROOT", payload
         launch = payload["launch_result"]
         assert launch["launcher"] == "tmux", launch
-        assert launch["started_lane_count"] == 3, launch
+        assert launch["started_lane_count"] == 4, launch
         assert launch["attach_command"] == "tmux attach -t loopx-auto-research-smoke", launch
         assert launch["stop_command"] == "tmux kill-session -t loopx-auto-research-smoke", launch
         assert launch["workspace_mode"] == "explicit_workspace", launch
         assert workspace.is_dir(), workspace
 
         for lane in payload["lanes"]:
+            profile = lane["role_profile"]
+            assert profile["schema_version"] == "auto_research_role_profile_v0", profile
+            assert profile["role_id"] == lane["role_id"], profile
+            assert profile["required_skill"] == "loopx-auto-research", profile
+            assert profile["write_scope"], profile
+            assert profile["protected_scope"], profile
+            assert profile["stop_conditions"], profile
             command = lane["visible_launch_command"]
+            assert "LoopX role profile" in command, command
+            assert "LOOPX_ROLE_ID" in command, command
+            assert "LOOPX_ROLE_PROFILE_REF" in command, command
             assert "quota should-run" in command, command
             assert "auto-research frontier" in command, command
             assert "codex-cli-bootstrap-message" in command, command
@@ -144,7 +157,7 @@ def main() -> int:
         log_entries = [json.loads(line) for line in tmux_log.read_text(encoding="utf-8").splitlines()]
         assert log_entries[0][:1] == ["has-session"], log_entries
         assert any(entry[:1] == ["new-session"] for entry in log_entries), log_entries
-        assert sum(1 for entry in log_entries if entry[:1] == ["new-window"]) == 3, log_entries
+        assert sum(1 for entry in log_entries if entry[:1] == ["new-window"]) == 4, log_entries
         assert_public_safe(payload)
 
     print("auto-research-visible-launcher-smoke ok")

--- a/loopx/capabilities/auto_research/core.py
+++ b/loopx/capabilities/auto_research/core.py
@@ -31,26 +31,195 @@ AUTO_RESEARCH_QUICKSTART_TEMPLATE = "knn-exact"
 ROLLOUT_EVIDENCE_GRAPH_SOURCE_KIND = "loopx_rollout_event_log"
 AUTO_RESEARCH_DEMO_DEFAULT_LANES = (
     (
-        "codex-side-bypass",
-        "hypothesis-runner",
-        "Claim the next runnable hypothesis and run dev evidence without owning promotion.",
+        "codex-product-capability",
+        "research-curator",
+        "research_curator",
+        "Keep the research contract, protected boundary, metric, stop policy, and operator gates explicit.",
     ),
     (
-        "codex-product-capability",
-        "evidence-promoter",
-        "Read scored evidence, promotion candidates, and product metric gaps.",
+        "codex-side-bypass",
+        "hypothesis-mapper",
+        "hypothesis_mapper",
+        "Turn research ideas into todo-backed hypotheses, successor links, and retirement rationale.",
     ),
     (
         "codex-main-control",
-        "control-plane-guard",
-        "Guard repo, review, merge, and user-gate boundaries without acting as a research leader.",
+        "evidence-runner",
+        "evidence_runner",
+        "Execute one selected hypothesis in an isolated workspace and preserve scored or unscored evidence.",
     ),
     (
         "codex-value-explorer",
-        "research-narrator",
-        "Turn accepted evidence into public-safe showcase and value-metric summaries.",
+        "evidence-verifier",
+        "evidence_verifier",
+        "Classify evidence into supported, contradicted, retry-needed, promotion-ready, or retired states.",
     ),
 )
+AUTO_RESEARCH_ROLE_PROFILE_SCHEMA_VERSION = "auto_research_role_profile_v0"
+AUTO_RESEARCH_ROLE_PROFILE_REF = AUTO_RESEARCH_ROLE_PROFILE_SCHEMA_VERSION
+AUTO_RESEARCH_REQUIRED_SKILL = "loopx-auto-research"
+AUTO_RESEARCH_ROLE_PROFILE_ORDER = (
+    "research_curator",
+    "hypothesis_mapper",
+    "evidence_runner",
+    "evidence_verifier",
+)
+AUTO_RESEARCH_ROLE_PROFILE_TEMPLATES: dict[str, dict[str, Any]] = {
+    "research_curator": {
+        "display_name": "Research curator",
+        "phase": "contract_ready",
+        "skill_section": "Research curator",
+        "allowed_actions": [
+            "write_research_contract",
+            "record_protected_boundary",
+            "open_operator_gate_todo",
+            "request_public_projection",
+        ],
+        "write_scope": [
+            "research_contract_v0",
+            "protected_boundary_notes",
+            "owner_gate_todos",
+            "public_projection_requests",
+        ],
+        "protected_scope": [
+            "experiment_execution",
+            "promotion_decision_without_evidence",
+            "public_first_screen_without_owner_review",
+        ],
+        "stop_conditions": [
+            "the next step would pick a winner",
+            "the next step would run an experiment",
+            "the next step would publish unsupported evidence",
+            "operator gate is projected",
+        ],
+        "handoff_outputs": [
+            "research_contract_v0",
+            "protected_boundary_note",
+            "operator_gate_todo",
+        ],
+    },
+    "hypothesis_mapper": {
+        "display_name": "Hypothesis mapper",
+        "phase": "hypothesis_proposed",
+        "skill_section": "Hypothesis mapper",
+        "allowed_actions": [
+            "propose_hypothesis",
+            "link_parent_hypothesis",
+            "open_successor_todo",
+            "record_no_followup_rationale",
+        ],
+        "write_scope": [
+            "research_hypothesis_v0",
+            "successor_todos",
+            "grounding_refs",
+            "no_followup_rationale",
+        ],
+        "protected_scope": [
+            "evidence_execution",
+            "evidence_deletion",
+            "novelty_claim_from_ideation_source",
+        ],
+        "stop_conditions": [
+            "novelty requires the same source that inspired the idea",
+            "negative evidence would be hidden",
+            "quota frontier is empty or claimed by another agent",
+            "operator gate is projected",
+        ],
+        "handoff_outputs": [
+            "research_hypothesis_v0",
+            "successor_todo",
+            "retirement_or_no_followup_rationale",
+        ],
+    },
+    "evidence_runner": {
+        "display_name": "Evidence runner",
+        "phase": "attempt_running",
+        "skill_section": "Evidence runner",
+        "allowed_actions": [
+            "claim_attempt",
+            "edit_allowed_scope",
+            "run_dev_eval",
+            "write_evidence",
+        ],
+        "write_scope": [
+            "claimed_hypothesis_worktree",
+            "branch_refs",
+            "research_evidence_event_v0",
+            "retry_packets",
+        ],
+        "protected_scope": [
+            "protected_evaluator",
+            "promotion_gate",
+            "raw_private_artifacts",
+            "credentials",
+        ],
+        "stop_conditions": [
+            "protected scope would be edited",
+            "promotion decision is needed",
+            "private material or credentials are required",
+            "quota should-run returns false",
+        ],
+        "handoff_outputs": [
+            "research_evidence_event_v0",
+            "branch_or_artifact_ref",
+            "retry_or_retirement_rationale",
+        ],
+    },
+    "evidence_verifier": {
+        "display_name": "Evidence verifier",
+        "phase": "evaluated",
+        "skill_section": "Evidence verifier",
+        "allowed_actions": [
+            "classify_evidence",
+            "write_evaluation_summary",
+            "open_promotion_gate",
+            "open_retirement_candidate",
+        ],
+        "write_scope": [
+            "evaluation_summary",
+            "promotion_candidate",
+            "retirement_candidate",
+            "gate_todos",
+            "projection_ready_evidence",
+        ],
+        "protected_scope": [
+            "experiment_execution",
+            "dev_only_promotion",
+            "gate_bypass",
+            "hidden_negative_evidence",
+        ],
+        "stop_conditions": [
+            "held-out evidence is missing when required",
+            "dev-only lift would be presented as promoted",
+            "operator gate is projected",
+            "public/private boundary is unclear",
+        ],
+        "handoff_outputs": [
+            "evaluation_summary",
+            "promotion_or_retirement_candidate",
+            "gate_todo",
+        ],
+    },
+}
+AUTO_RESEARCH_ROLE_PROFILE_ALIASES = {
+    "curator": "research_curator",
+    "research-curator": "research_curator",
+    "research_curator": "research_curator",
+    "hypothesis-runner": "hypothesis_mapper",
+    "hypothesis-mapper": "hypothesis_mapper",
+    "hypothesis_mapper": "hypothesis_mapper",
+    "mapper": "hypothesis_mapper",
+    "runner": "evidence_runner",
+    "evidence-runner": "evidence_runner",
+    "evidence_runner": "evidence_runner",
+    "executor": "evidence_runner",
+    "promoter": "evidence_verifier",
+    "evidence-promoter": "evidence_verifier",
+    "evidence-verifier": "evidence_verifier",
+    "evidence_verifier": "evidence_verifier",
+    "verifier": "evidence_verifier",
+    "control-plane-guard": "research_curator",
+}
 
 HYPOTHESIS_STATUSES = {
     "proposed",
@@ -554,21 +723,45 @@ def _shell_arg(value: str) -> str:
     return shlex.quote(value)
 
 
+def _role_id_for_lane(*, lane_id: str, index: int, explicit_role_id: str | None = None) -> str:
+    raw = explicit_role_id or lane_id
+    role_id = AUTO_RESEARCH_ROLE_PROFILE_ALIASES.get(raw, raw)
+    if role_id in AUTO_RESEARCH_ROLE_PROFILE_TEMPLATES:
+        return role_id
+    return AUTO_RESEARCH_ROLE_PROFILE_ORDER[(index - 1) % len(AUTO_RESEARCH_ROLE_PROFILE_ORDER)]
+
+
 def _demo_lane_specs(agent_specs: Iterable[str] | None) -> list[dict[str, str]]:
     raw_specs = list(agent_specs or [])
-    parsed_specs: list[tuple[str, str, str]] = []
+    parsed_specs: list[tuple[str, str, str, str]] = []
     if raw_specs:
         for index, raw in enumerate(raw_specs, start=1):
             text = _compact_public_text(raw, field="agent[]", max_len=180)
             if ":" in text:
-                agent_id, lane_id = text.split(":", 1)
+                parts = text.split(":")
+                if len(parts) == 2:
+                    agent_id, lane_id = parts
+                    explicit_role_id = None
+                elif len(parts) == 3:
+                    agent_id, lane_id, explicit_role_id = parts
+                else:
+                    raise ValueError("agent[] must be agent_id:lane_id or agent_id:lane_id:role_id")
             else:
                 agent_id = text
                 lane_id = f"research-lane-{index}"
+                explicit_role_id = None
             parsed_specs.append(
                 (
                     _compact_public_token(agent_id, field="agent_id"),
                     _compact_public_token(lane_id, field="lane_id"),
+                    _compact_public_token(
+                        _role_id_for_lane(
+                            lane_id=lane_id,
+                            index=index,
+                            explicit_role_id=explicit_role_id,
+                        ),
+                        field="role_id",
+                    ),
                     "Work from the shared LoopX frontier for this lane; do not assume a leader agent.",
                 )
             )
@@ -578,7 +771,7 @@ def _demo_lane_specs(agent_specs: Iterable[str] | None) -> list[dict[str, str]]:
     lanes: list[dict[str, str]] = []
     seen_agents: set[str] = set()
     seen_lanes: set[str] = set()
-    for agent_id, lane_id, responsibility in parsed_specs:
+    for agent_id, lane_id, role_id, responsibility in parsed_specs:
         if agent_id in seen_agents:
             raise ValueError(f"duplicate agent_id in demo supervisor lane plan: {agent_id}")
         if lane_id in seen_lanes:
@@ -589,6 +782,7 @@ def _demo_lane_specs(agent_specs: Iterable[str] | None) -> list[dict[str, str]]:
             {
                 "agent_id": agent_id,
                 "lane_id": lane_id,
+                "role_id": role_id,
                 "responsibility": _compact_public_text(
                     responsibility,
                     field="lane.responsibility",
@@ -623,6 +817,32 @@ def _env_bootstrap_command(*, cli_bin: str, goal_id: str, agent_id: str) -> str:
     )
 
 
+def _role_profile_for_lane(*, goal_id: str, lane: dict[str, str]) -> dict[str, Any]:
+    role_id = _compact_public_token(lane["role_id"], field="lane.role_id")
+    template = AUTO_RESEARCH_ROLE_PROFILE_TEMPLATES[role_id]
+    return {
+        "schema_version": AUTO_RESEARCH_ROLE_PROFILE_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "agent_id": lane["agent_id"],
+        "role_id": role_id,
+        "display_name": template["display_name"],
+        "phase": template["phase"],
+        "capability_token": role_id,
+        "todo_id": "pending_frontier_selection",
+        "hypothesis_id": "pending_frontier_selection",
+        "allowed_actions": list(template["allowed_actions"]),
+        "write_scope": list(template["write_scope"]),
+        "protected_scope": list(template["protected_scope"]),
+        "required_skill": AUTO_RESEARCH_REQUIRED_SKILL,
+        "skill_section": template["skill_section"],
+        "agents_overlay": ["workspace/AGENTS.md"],
+        "stop_conditions": list(template["stop_conditions"]),
+        "handoff_outputs": list(template["handoff_outputs"]),
+        "identity_source": "loopx_control_plane_profile_then_quota_frontier",
+        "pane_title_is_authority": False,
+    }
+
+
 _QUOTA_GATE_PY = (
     "import json,sys; "
     "p=json.load(sys.stdin); "
@@ -636,6 +856,8 @@ _QUOTA_GATE_PY = (
 
 def _env_lane_launch_command(
     *,
+    role_id: str,
+    role_profile_json: str,
     quota_command: str,
     frontier_command: str,
     bootstrap_command: str,
@@ -643,7 +865,11 @@ def _env_lane_launch_command(
 ) -> str:
     return (
         "set -euo pipefail; "
+        f"export LOOPX_ROLE_ID={_shell_arg(role_id)}; "
+        f"export LOOPX_ROLE_PROFILE_REF={_shell_arg(AUTO_RESEARCH_ROLE_PROFILE_REF)}; "
         'cd "$LOOPX_PROJECT"; '
+        "printf '\\n[LoopX role profile]\\n'; "
+        f"printf '%s\\n' {_shell_arg(role_profile_json)}; "
         "printf '\\n[LoopX quota guard]\\n'; "
         f"QUOTA_PACKET=\"$({quota_command})\"; "
         "printf '%s\\n' \"$QUOTA_PACKET\"; "
@@ -708,6 +934,13 @@ def build_auto_research_demo_supervisor_plan(
     for lane in lanes:
         agent_id = lane["agent_id"]
         lane_id = lane["lane_id"]
+        role_id = lane["role_id"]
+        role_profile = _role_profile_for_lane(goal_id=goal, lane=lane)
+        role_profile_json = json.dumps(
+            role_profile,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
         quota_command = _env_quota_command(cli_bin=cli, goal_id=goal, agent_id=agent_id)
         frontier_command = _env_frontier_command(cli_bin=cli, goal_id=goal, agent_id=agent_id)
         bootstrap_command = _env_bootstrap_command(cli_bin=cli, goal_id=goal, agent_id=agent_id)
@@ -715,25 +948,37 @@ def build_auto_research_demo_supervisor_plan(
             {
                 "lane_id": lane_id,
                 "agent_id": agent_id,
+                "role_id": role_id,
                 "responsibility": lane["responsibility"],
+                "role_profile": role_profile,
                 "window_name": lane_id,
                 "quota_guard": quota_command,
                 "frontier": frontier_command,
                 "bootstrap_message": bootstrap_command,
                 "visible_codex_tui": codex,
                 "visible_launch_command": _env_lane_launch_command(
+                    role_id=role_id,
+                    role_profile_json=role_profile_json,
                     quota_command=quota_command,
                     frontier_command=frontier_command,
                     bootstrap_command=bootstrap_command,
                     codex_bin=codex,
                 ),
                 "start_sequence": [
+                    "print role_profile_v0 so the lane knows its identity before any work",
                     "run quota_guard and stop when user_channel.action_required=true",
                     "render the lane frontier from LoopX state",
                     "print the public-safe bootstrap message for this visible TUI",
                     "start Codex CLI visibly; do not inject hidden prompts into an existing session",
                 ],
                 "lane_timeline": [
+                    {
+                        "phase": "role_profile",
+                        "command_ref": "role_profile",
+                        "operator_visible_signal": f"{role_profile['role_id']} profile, skill section, write scope, and stop conditions",
+                        "continue_when": "profile identity matches the intended visible worker lane",
+                        "stop_when": "profile is missing, conflicts with AGENTS.md, or grants broader authority than quota/frontier",
+                    },
                     {
                         "phase": "quota_guard",
                         "command_ref": "quota_guard",
@@ -859,6 +1104,8 @@ def build_auto_research_demo_supervisor_plan(
                 "commands.start_script",
                 "commands.attach",
                 "commands.stop",
+                "lanes[].role_id",
+                "lanes[].role_profile",
                 "lanes[].quota_guard",
                 "lanes[].frontier",
                 "lanes[].bootstrap_message",
@@ -868,12 +1115,14 @@ def build_auto_research_demo_supervisor_plan(
             ],
             "operator_can_accept_when": [
                 "the rehearsal script prints the real start script without executing it",
+                "every lane prints auto_research_role_profile_v0 before quota/frontier/bootstrap",
                 "every lane has a quota guard before frontier/bootstrap/Codex startup",
                 "the attach command is visible before any Codex prompt is accepted",
                 "the stop command and terminal interrupt path are visible",
                 "boundary fields prove no tmux/Codex/state/quota side effects in dry-run mode",
             ],
             "operator_must_reject_when": [
+                "a lane lacks role_profile_v0, skill section, write scope, or stop conditions",
                 "a lane can start without quota should-run",
                 "the packet hides attach/stop controls",
                 "the packet embeds local absolute paths, credentials, raw sessions, or private links",
@@ -891,6 +1140,7 @@ def build_auto_research_demo_supervisor_plan(
             ],
             "visible_status_cues": [
                 "frontier window shows the shared research frontier",
+                "each lane window prints its role_profile_v0 before quota/frontier/bootstrap",
                 "each lane window prints its own quota guard before Codex starts",
                 "each lane window prints its own auto-research frontier before Codex starts",
                 "bootstrap message is visible in the same pane that would run Codex",
@@ -2989,7 +3239,17 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
             if not isinstance(item, dict):
                 continue
             lines.append(
-                f"- `{item.get('lane_id')}` / `{item.get('agent_id')}`: {item.get('responsibility')}"
+                f"- `{item.get('lane_id')}` / `{item.get('agent_id')}` / `{item.get('role_id')}`: "
+                f"{item.get('responsibility')}"
+            )
+        lines.extend(["", "## Role Profiles", ""])
+        for item in lanes:
+            if not isinstance(item, dict):
+                continue
+            profile = item.get("role_profile") if isinstance(item.get("role_profile"), dict) else {}
+            lines.append(
+                f"- `{profile.get('role_id')}`: skill `{profile.get('required_skill')}` / "
+                f"section `{profile.get('skill_section')}` / phase `{profile.get('phase')}`"
             )
         lines.extend(["", "## Lane Timeline", ""])
         for item in lanes:

--- a/loopx/capabilities/auto_research/core.py
+++ b/loopx/capabilities/auto_research/core.py
@@ -728,6 +728,9 @@ def _role_id_for_lane(*, lane_id: str, index: int, explicit_role_id: str | None 
     role_id = AUTO_RESEARCH_ROLE_PROFILE_ALIASES.get(raw, raw)
     if role_id in AUTO_RESEARCH_ROLE_PROFILE_TEMPLATES:
         return role_id
+    if explicit_role_id is not None:
+        allowed = ", ".join(AUTO_RESEARCH_ROLE_PROFILE_ORDER)
+        raise ValueError(f"agent[] role_id must be one of: {allowed}")
     return AUTO_RESEARCH_ROLE_PROFILE_ORDER[(index - 1) % len(AUTO_RESEARCH_ROLE_PROFILE_ORDER)]
 
 


### PR DESCRIPTION
## Motivation

The auto-research demo launcher already had a visible dry-run and execute path, but its default lanes still reflected an older lane model and did not make each worker identity visible before launch. For the real demo, each decentralized worker should know its role, write scope, skill section, and stop conditions before Codex starts.

## Changes

- Align default demo-supervisor lanes with the four logical auto_research_role_state_machine_v0 roles: research curator, hypothesis mapper, evidence runner, and evidence verifier.
- Add auto_research_role_profile_v0 packets to every launcher lane: role id, phase, capability token, allowed actions, write/protected scope, required skill section, stop conditions, and handoff outputs.
- Print the role profile in each visible launch command before quota/frontier/bootstrap, while keeping the supervisor as a shell layout rather than a leader agent.
- Keep compatibility for explicit lane args and add optional agent_id:lane_id:role_id syntax.
- Update focused smokes and the auto-research showcase docs.

## Risk

Medium: this touches the auto-research demo launcher contract and default lane semantics. The default path remains dry-run only, with no tmux/Codex launch, no LoopX state write, and no quota spend. Real launch still requires explicit --execute.

## Validation

- python3 examples/auto-research-demo-supervisor-smoke.py
- python3 examples/auto-research-visible-launcher-smoke.py
- python3 examples/decentralized-auto-research-protocol-smoke.py
- python3 -m py_compile loopx/capabilities/auto_research/core.py loopx/capabilities/auto_research/cli.py
- python3 -m loopx.cli --format json auto-research demo-supervisor --goal-id loopx-auto-research-knn

## Boundary

Public-safe files only. Candidate private-boundary scan only matched smoke forbidden-string fixtures and the existing private-marker regex, not leaked material.

