### PR TITLE
Add catalog canary coverage audit

### DIFF
--- a/examples/catalog-canary-planner-smoke.py
+++ b/examples/catalog-canary-planner-smoke.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -14,6 +15,7 @@ sys.path.insert(0, str(REPO_ROOT))
 CATALOG = REPO_ROOT / "docs" / "interaction-pattern-catalog.md"
 
 from loopx.canary.planner import (  # noqa: E402
+    build_catalog_canary_coverage_audit,
     build_catalog_canary_plan,
     build_catalog_canary_profiles,
 )
@@ -130,6 +132,50 @@ def assert_explicit_profile_can_include_deep_checks() -> None:
     assert "owner-review necessity/risk packet" in payload["note"], payload
 
 
+def assert_coverage_audit_tracks_p0_p1_patterns() -> None:
+    payload = build_catalog_canary_coverage_audit()
+    assert payload["ok"] is True, payload
+    assert payload["dry_run"] is True, payload
+    assert payload["executes_checks"] is False, payload
+    assert payload["priorities"] == ["P0", "P1"], payload
+    assert payload["required_pattern_count"] >= 20, payload
+    assert payload["missing_count"] == 0, payload
+    assert payload["invalid_exception_count"] == 0, payload
+    covered_ids = {row["pattern_id"] for row in payload["covered_patterns"]}
+    assert {"IP-001", "IP-004", "IP-024", "IP-029"} <= covered_ids, payload
+
+
+def assert_coverage_audit_reports_matrix_drift(tmp_dir: Path) -> None:
+    catalog_text = CATALOG.read_text(encoding="utf-8")
+    drift_text = catalog_text.replace(
+        "| Planning Governance | IP-010, IP-013, IP-018, IP-024 |",
+        "| Planning Governance | IP-010, IP-013, IP-018 |",
+        1,
+    )
+    drift_catalog = tmp_dir / "catalog-drift.md"
+    drift_catalog.write_text(drift_text, encoding="utf-8")
+    payload = build_catalog_canary_coverage_audit(catalog_path=drift_catalog)
+    assert payload["ok"] is False, payload
+    assert payload["missing_count"] == 1, payload
+    assert payload["missing_patterns"][0]["pattern_id"] == "IP-024", payload
+
+    excepted_catalog = tmp_dir / "catalog-deferred.md"
+    excepted_catalog.write_text(
+        drift_text
+        + "\n\n"
+        "## Canary Coverage Exceptions\n\n"
+        "| Pattern ID | Canary Coverage Status | Rationale | Owner |\n"
+        "| --- | --- | --- | --- |\n"
+        "| IP-024 | deferred | waits for a repair-delta profile owner before default canary coverage | codex-main-control |\n",
+        encoding="utf-8",
+    )
+    excepted_payload = build_catalog_canary_coverage_audit(catalog_path=excepted_catalog)
+    assert excepted_payload["ok"] is True, excepted_payload
+    assert excepted_payload["missing_count"] == 0, excepted_payload
+    assert excepted_payload["excepted_count"] == 1, excepted_payload
+    assert excepted_payload["excepted_patterns"][0]["pattern_id"] == "IP-024", excepted_payload
+
+
 def assert_cli_json_plan_is_dry_run() -> None:
     completed = subprocess.run(
         [
@@ -161,13 +207,40 @@ def assert_cli_json_plan_is_dry_run() -> None:
     assert any(profile["id"] == "monitor-scheduler" for profile in payload["domain_profiles"]), payload
 
 
+def assert_cli_json_coverage_audit_is_dry_run() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "canary",
+            "coverage-audit",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(completed.stdout)
+    assert payload["dry_run"] is True, payload
+    assert payload["executes_checks"] is False, payload
+    assert payload["drift_count"] == 0, payload
+
+
 def main() -> int:
     assert_profiles_come_from_catalog_matrix()
     assert_catalog_documents_selection_rules()
     assert_plan_selects_minimal_profiles_from_changed_surfaces()
     assert_pr_release_and_refactor_profiles_select()
     assert_explicit_profile_can_include_deep_checks()
+    assert_coverage_audit_tracks_p0_p1_patterns()
+    with tempfile.TemporaryDirectory(prefix="loopx-catalog-canary-smoke-") as tmp:
+        tmp_dir = Path(tmp)
+        assert_coverage_audit_reports_matrix_drift(tmp_dir)
     assert_cli_json_plan_is_dry_run()
+    assert_cli_json_coverage_audit_is_dry_run()
     print("catalog-canary-planner-smoke ok")
     return 0
 

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -9,6 +9,7 @@ CANARY_PROFILE_SCHEMA_VERSION = "catalog_canary_profile_v0"
 CANARY_DOMAIN_PROFILE_SCHEMA_VERSION = "catalog_canary_domain_profile_v0"
 CANARY_PROFILES_SCHEMA_VERSION = "catalog_canary_profiles_v0"
 CANARY_PLAN_SCHEMA_VERSION = "catalog_canary_plan_v0"
+CANARY_COVERAGE_AUDIT_SCHEMA_VERSION = "catalog_canary_coverage_audit_v0"
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_CATALOG_PATH = REPO_ROOT / "docs" / "interaction-pattern-catalog.md"
@@ -475,6 +476,125 @@ def build_catalog_canary_profiles(catalog_path: Path | None = None) -> dict[str,
     }
 
 
+def _catalog_pattern_rows(text: str) -> list[dict[str, str]]:
+    rows: list[dict[str, str]] = []
+    for line in text.splitlines():
+        if not line.strip().startswith("|"):
+            continue
+        cells = _split_table_row(line)
+        if len(cells) < 3:
+            continue
+        if cells[0] not in {"P0", "P1", "P2"} or not re.fullmatch(r"IP-\d{3}", cells[1]):
+            continue
+        rows.append(
+            {
+                "importance": cells[0],
+                "pattern_id": cells[1],
+                "name": cells[2],
+            }
+        )
+    return rows
+
+
+def _coverage_exception_rows(text: str) -> dict[str, dict[str, str]]:
+    table = _first_table_after(text, "| Pattern ID | Canary Coverage Status |")
+    exceptions: dict[str, dict[str, str]] = {}
+    for row in table:
+        pattern_id = next(iter(_pattern_ids(row.get("Pattern ID", ""))), "")
+        if not pattern_id:
+            continue
+        status = _slug(row.get("Canary Coverage Status", ""))
+        if status not in {"non-applicable", "not-applicable", "deferred"}:
+            continue
+        exceptions[pattern_id] = {
+            "pattern_id": pattern_id,
+            "status": "non-applicable" if status == "not-applicable" else status,
+            "rationale": row.get("Rationale", ""),
+            "owner": row.get("Owner", ""),
+        }
+    return exceptions
+
+
+def _coverage_exception_is_valid(exception: dict[str, str]) -> bool:
+    status = exception.get("status")
+    rationale = bool(str(exception.get("rationale") or "").strip())
+    owner = bool(str(exception.get("owner") or "").strip())
+    if status == "non-applicable":
+        return rationale
+    if status == "deferred":
+        return rationale and owner
+    return False
+
+
+def build_catalog_canary_coverage_audit(
+    *,
+    catalog_path: Path | None = None,
+    priorities: list[str] | None = None,
+) -> dict[str, Any]:
+    path, text = _read_catalog(catalog_path)
+    profile_packet = build_catalog_canary_profiles(catalog_path)
+    required_priorities = tuple(priorities or ["P0", "P1"])
+    pattern_rows = [
+        row
+        for row in _catalog_pattern_rows(text)
+        if row.get("importance") in required_priorities
+    ]
+    profile_coverage: dict[str, list[str]] = {}
+    for profile in profile_packet.get("profiles", []):
+        if not isinstance(profile, dict):
+            continue
+        profile_id = str(profile.get("id") or "")
+        for pattern_id in profile.get("pattern_ids", []):
+            if isinstance(pattern_id, str):
+                profile_coverage.setdefault(pattern_id, []).append(profile_id)
+    exceptions = _coverage_exception_rows(text)
+
+    covered: list[dict[str, Any]] = []
+    excepted: list[dict[str, Any]] = []
+    missing: list[dict[str, Any]] = []
+    invalid_exceptions: list[dict[str, Any]] = []
+    for row in pattern_rows:
+        pattern_id = row["pattern_id"]
+        profile_ids = profile_coverage.get(pattern_id, [])
+        if profile_ids:
+            covered.append({**row, "profile_ids": profile_ids})
+            continue
+        exception = exceptions.get(pattern_id)
+        if exception and _coverage_exception_is_valid(exception):
+            excepted.append({**row, **exception})
+            continue
+        if exception:
+            invalid_exceptions.append({**row, **exception})
+        else:
+            missing.append(row)
+
+    drift_count = len(missing) + len(invalid_exceptions)
+    return {
+        "ok": bool(profile_packet.get("ok")) and drift_count == 0,
+        "schema_version": CANARY_COVERAGE_AUDIT_SCHEMA_VERSION,
+        "source": _display_path(path),
+        "dry_run": True,
+        "executes_checks": False,
+        "priorities": list(required_priorities),
+        "required_pattern_count": len(pattern_rows),
+        "covered_count": len(covered),
+        "excepted_count": len(excepted),
+        "missing_count": len(missing),
+        "invalid_exception_count": len(invalid_exceptions),
+        "drift_count": drift_count,
+        "covered_patterns": covered,
+        "excepted_patterns": excepted,
+        "missing_patterns": missing,
+        "invalid_exceptions": invalid_exceptions,
+        "note": (
+            "Coverage means each selected catalog pattern is listed in a canary "
+            "family profile, or has an explicit non-applicable rationale or "
+            "deferred owner in a catalog coverage exception table. This audit "
+            "reports drift only; it does not force one giant canary or execute checks."
+        ),
+    }
+
+
 def _selector_blob(changed_files: list[str], surfaces: list[str]) -> str:
     return "\n".join([*changed_files, *surfaces]).lower()
 
@@ -737,6 +857,44 @@ def render_catalog_canary_plan_markdown(payload: dict[str, Any]) -> str:
             if isinstance(check, dict):
                 lines.append(
                     f"  - `{check.get('command')}` [{check.get('tier')}] - {check.get('reason')}"
+                )
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_catalog_canary_coverage_audit_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Catalog Canary Coverage Audit",
+        "",
+        f"- source: `{payload.get('source')}`",
+        "- dry_run: `true`",
+        "- executes_checks: `false`",
+        f"- priorities: `{', '.join(payload.get('priorities') or [])}`",
+        f"- required_patterns: `{payload.get('required_pattern_count')}`",
+        f"- covered: `{payload.get('covered_count')}`",
+        f"- excepted: `{payload.get('excepted_count')}`",
+        f"- missing: `{payload.get('missing_count')}`",
+        f"- invalid_exceptions: `{payload.get('invalid_exception_count')}`",
+        f"- drift: `{payload.get('drift_count')}`",
+        "",
+        str(payload.get("note") or ""),
+        "",
+    ]
+    if payload.get("missing_patterns"):
+        lines.extend(["## Missing Coverage", ""])
+        for row in payload.get("missing_patterns", []):
+            if isinstance(row, dict):
+                lines.append(
+                    f"- `{row.get('pattern_id')}` {row.get('name')} ({row.get('importance')})"
+                )
+        lines.append("")
+    if payload.get("invalid_exceptions"):
+        lines.extend(["## Invalid Exceptions", ""])
+        for row in payload.get("invalid_exceptions", []):
+            if isinstance(row, dict):
+                lines.append(
+                    f"- `{row.get('pattern_id')}` {row.get('status')}: "
+                    f"rationale={row.get('rationale')!r}; owner={row.get('owner')!r}"
                 )
         lines.append("")
     return "\n".join(lines).rstrip() + "\n"

--- a/loopx/cli_commands/canary.py
+++ b/loopx/cli_commands/canary.py
@@ -5,8 +5,10 @@ from collections.abc import Callable
 from pathlib import Path
 
 from ..canary.planner import (
+    build_catalog_canary_coverage_audit,
     build_catalog_canary_plan,
     build_catalog_canary_profiles,
+    render_catalog_canary_coverage_audit_markdown,
     render_catalog_canary_plan_markdown,
     render_catalog_canary_profiles_markdown,
 )
@@ -125,6 +127,24 @@ def register_canary_commands(
         help="Per-check timeout for executed canaries.",
     )
 
+    coverage_parser = canary_sub.add_parser(
+        "coverage-audit",
+        help="Report P0/P1 catalog patterns missing canary profile coverage or explicit exception rationale.",
+    )
+    add_subcommand_format(coverage_parser)
+    coverage_parser.add_argument(
+        "--catalog",
+        type=Path,
+        help="Override the interaction-pattern catalog path.",
+    )
+    coverage_parser.add_argument(
+        "--priority",
+        action="append",
+        choices=["P0", "P1", "P2"],
+        default=[],
+        help="Pattern priority to audit. Defaults to P0 and P1; repeat for multiple priorities.",
+    )
+
 
 def handle_canary_command(
     args: argparse.Namespace,
@@ -164,7 +184,13 @@ def handle_canary_command(
             timeout_seconds=float(args.timeout_seconds or 120.0),
         )
         renderer = render_catalog_canary_run_markdown
+    elif args.canary_command == "coverage-audit":
+        payload = build_catalog_canary_coverage_audit(
+            catalog_path=args.catalog,
+            priorities=list(args.priority or []) or None,
+        )
+        renderer = render_catalog_canary_coverage_audit_markdown
     else:
-        raise ValueError("canary requires `profiles`, `plan`, or `run`")
+        raise ValueError("canary requires `profiles`, `plan`, `run`, or `coverage-audit`")
     print_payload(payload, output_format(args), renderer)
     return 0 if payload.get("ok") else 1


### PR DESCRIPTION
## Summary
- add `loopx canary coverage-audit` to report P0/P1 catalog patterns missing family-profile coverage or explicit exception rationale
- keep the command read-only: it does not execute smoke checks or create new runtime contracts
- extend catalog canary planner smoke with real-catalog coverage, simulated matrix drift, deferred-owner exception, and CLI JSON checks

## Validation
- `python3 examples/catalog-canary-planner-smoke.py`
- `python3 -m compileall loopx/canary/planner.py loopx/cli_commands/canary.py`
- `python3 -m loopx.cli --format json canary coverage-audit`
- `python3 -m loopx.cli --format json check --scan-path loopx/canary/planner.py --scan-path loopx/cli_commands/canary.py --scan-path examples/catalog-canary-planner-smoke.py`
- `git diff --check`

## Risk
Low-to-medium CLI/read-path addition. Existing `canary profiles` and `canary plan` behavior is unchanged; new output is opt-in under `canary coverage-audit`. The audit reports drift only and avoids forcing every pattern into one giant canary.
