### PR TITLE
Add LoopX auto-research skill contract

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -318,6 +318,7 @@ The reusable skills have intentionally narrow jobs:
 
 | Skill | Use it for | Do not use it for |
 | --- | --- | --- |
+| `loopx-auto-research` | Running role-scoped auto-research lanes after LoopX has projected a role profile, frontier item, demo pane, or evidence/promotion task. | Assigning identity, bypassing quota/gates, acting as a leader agent, or selecting/promoting the whole research graph. |
 | `loopx-project` | Connecting projects, reading status/quota/history, diagnosing LoopX, generating heartbeat/review packets, and refreshing state. | Reading private project documents by default or replacing the CLI as source of truth. |
 | `loopx-pr-review` | Running `/loopx-pr-review`, preserving the `loopx pr-review` packet, and guiding per-PR five-block reviews. | Approving, commenting on, merging, self-merging, or admin-bypassing a PR. |
 | `loopx-doc-registry` | Registering durable project material and redacted authority-source metadata. | Copying raw doc bodies, internal URLs, or private comments into public repo docs. |
@@ -355,7 +356,8 @@ the pieces you intend to drop:
 
 ```bash
 rm -f ~/.local/bin/loopx ~/.local/bin/loopx-canary
-rm -rf ~/.codex/skills/loopx-project \
+rm -rf ~/.codex/skills/loopx-auto-research \
+       ~/.codex/skills/loopx-project \
        ~/.codex/skills/loopx-pr-review \
        ~/.codex/skills/loopx-doc-registry \
        ~/.codex/skills/loopx-self-repair

--- a/examples/auto-research-skill-contract-smoke.py
+++ b/examples/auto-research-skill-contract-smoke.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Smoke-test the installed loopx-auto-research skill contract."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from loopx.doctor import REQUIRED_INSTALLED_SKILL_PHRASES  # noqa: E402
+
+
+SKILL = ROOT / "skills" / "loopx-auto-research" / "SKILL.md"
+ROLE_PROFILE = ROOT / "docs" / "reference" / "protocols" / "auto-research-role-profile-v0.md"
+ROLE_STATE_MACHINE = ROOT / "docs" / "reference" / "protocols" / "auto-research-role-state-machine-v0.md"
+LANE_CONTRACT = ROOT / "docs" / "reference" / "protocols" / "auto-research-lane-contract-v1.md"
+GETTING_STARTED = ROOT / "docs" / "guides" / "getting-started.md"
+
+
+PRIVATE_MARKERS = [
+    "byte" + "dance",
+    "lark" + "office",
+    "fei" + "shu.cn",
+    "/" + "Users" + "/",
+    "/" + "private" + "/",
+    "api" + "_key",
+    "pass" + "word",
+    "sec" + "ret",
+]
+
+
+def _read(path: Path) -> str:
+    assert path.exists(), f"missing {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def _assert_public_safe(text: str, label: str) -> None:
+    lower = text.lower()
+    leaked = [marker for marker in PRIVATE_MARKERS if marker.lower() in lower]
+    assert not leaked, f"{label} leaks private marker(s): {leaked}"
+
+
+def main() -> int:
+    skill = _read(SKILL)
+    compact_skill = " ".join(skill.split())
+    role_profile = _read(ROLE_PROFILE)
+    role_state_machine = _read(ROLE_STATE_MACHINE)
+    lane_contract = _read(LANE_CONTRACT)
+    getting_started = _read(GETTING_STARTED)
+
+    _assert_public_safe(
+        "\n".join([skill, role_profile, role_state_machine, lane_contract, getting_started]),
+        "auto-research skill contract",
+    )
+
+    for phrase in REQUIRED_INSTALLED_SKILL_PHRASES["loopx-auto-research"]:
+        assert phrase in compact_skill, f"doctor phrase missing from skill: {phrase!r}"
+
+    required_skill_terms = [
+        "name: loopx-auto-research",
+        "Identity comes from LoopX control-plane metadata",
+        "auto_research_role_profile_v0",
+        'loopx --format json auto-research frontier --goal-id "$LOOPX_GOAL_ID" --agent-id "$LOOPX_AGENT_ID"',
+        "No role owns the full graph",
+        "Do not infer role from pane title",
+        "Research Curator",
+        "Hypothesis Mapper",
+        "Evidence Runner",
+        "Evidence Verifier",
+        "Projection Narrator",
+        "Control-Plane Guard",
+        "Shared Stop Conditions",
+        "research_contract_v0",
+        "research_hypothesis_v0",
+        "auto_research_evidence_packet_v0",
+        "research_showcase_projection_v0",
+        "quota should-run",
+        "demo-supervisor",
+        "--execute",
+    ]
+    for term in required_skill_terms:
+        assert term in compact_skill, f"skill missing {term!r}"
+
+    forbidden_skill_terms = [
+        "skill assigns identity",
+        "pane title is authoritative",
+        "leader agent required",
+        "coordinator owns the graph",
+        "promote without evidence",
+    ]
+    lowered = compact_skill.lower()
+    for term in forbidden_skill_terms:
+        assert term.lower() not in lowered, f"skill drifted into forbidden term {term!r}"
+
+    assert "required_skill\": \"loopx-auto-research\"" in role_profile, role_profile
+    assert "Start with one installed `loopx-auto-research` skill" in role_profile, role_profile
+    assert "auto_research_role_profile_v0" in role_state_machine, role_state_machine
+    assert "product_narrator" in lane_contract, lane_contract
+    assert "`loopx-auto-research` | Running role-scoped auto-research lanes" in getting_started, getting_started
+    assert "~/.codex/skills/loopx-auto-research" in getting_started, getting_started
+
+    print("auto-research-skill-contract-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -112,6 +112,7 @@ def main() -> int:
             f"- legacy command disabled: {bin_dir / 'goal-harness-canary.legacy-disabled'}"
             in install.stdout
         ), install.stdout
+        assert f"- skill: {codex_home / 'skills' / 'loopx-auto-research'}" in install.stdout, install.stdout
         assert f"- skill: {codex_home / 'skills' / 'loopx-doc-registry'}" in install.stdout, install.stdout
         assert f"- skill: {codex_home / 'skills' / 'loopx-pr-review'}" in install.stdout, install.stdout
         assert f"- skill: {codex_home / 'skills' / 'loopx-project'}" in install.stdout, install.stdout
@@ -179,6 +180,18 @@ def main() -> int:
             "Do not use this skill to approve",
         ):
             assert phrase in pr_review_text, phrase
+        auto_research_skill = codex_home / "skills" / "loopx-auto-research" / "SKILL.md"
+        auto_research_text = " ".join(auto_research_skill.read_text(encoding="utf-8").split())
+        for phrase in (
+            "Identity comes from LoopX control-plane metadata",
+            'loopx --format json auto-research frontier --goal-id "$LOOPX_GOAL_ID" --agent-id "$LOOPX_AGENT_ID"',
+            "No role owns the full graph",
+            "Do not infer role from pane title",
+            "auto_research_role_profile_v0",
+            "Projection Narrator",
+            "Control-Plane Guard",
+        ):
+            assert phrase in auto_research_text, phrase
         doc_registry_skill = codex_home / "skills" / "loopx-doc-registry" / "SKILL.md"
         doc_registry_text = " ".join(doc_registry_skill.read_text(encoding="utf-8").split())
         for phrase in (
@@ -248,6 +261,8 @@ def main() -> int:
         assert doctor_payload["skill"]["path"] == str(skill), doctor_payload
         assert doctor_payload["skill"]["exists"] is True, doctor_payload
         assert doctor_payload["skill"]["delivery_hints"] is True, doctor_payload
+        assert doctor_payload["skills"]["loopx-auto-research"]["exists"] is True, doctor_payload
+        assert doctor_payload["skills"]["loopx-auto-research"]["required_phrases"] is True, doctor_payload
         assert doctor_payload["skills"]["loopx-project"]["exists"] is True, doctor_payload
         assert doctor_payload["skills"]["loopx-project"]["required_phrases"] is True, doctor_payload
         assert doctor_payload["skills"]["loopx-pr-review"]["exists"] is True, doctor_payload
@@ -296,7 +311,7 @@ def main() -> int:
         assert "installed_skill_delivery_hints: `True`" in doctor_markdown, doctor_markdown
         assert (
             "installed_required_skills: "
-            "`loopx-doc-registry,loopx-pr-review,loopx-project,loopx-self-repair`"
+            "`loopx-auto-research,loopx-doc-registry,loopx-pr-review,loopx-project,loopx-self-repair`"
             in doctor_markdown
         ), doctor_markdown
         assert "loopx_canary_realpath:" in doctor_markdown, doctor_markdown
@@ -328,6 +343,7 @@ def main() -> int:
             release_root=root / "releases" / "20260101T000000Z",
             repo_root=REPO_ROOT,
             skills={
+                "loopx-auto-research": {"exists": True, "required_phrases": True},
                 "loopx-project": {"exists": True, "required_phrases": True},
                 "loopx-pr-review": {"exists": True, "required_phrases": True},
                 "loopx-doc-registry": {"exists": True, "required_phrases": True},
@@ -345,6 +361,7 @@ def main() -> int:
             release_root=root / "releases" / "20260108T000000Z",
             repo_root=REPO_ROOT,
             skills={
+                "loopx-auto-research": {"exists": True, "required_phrases": True},
                 "loopx-project": {"exists": True, "required_phrases": True},
                 "loopx-pr-review": {"exists": True, "required_phrases": True},
                 "loopx-doc-registry": {"exists": True, "required_phrases": True},

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -27,6 +27,13 @@ NO_CLONE_UPGRADE_COMMAND = (
 )
 RELEASE_ID_TIMESTAMP_RE = re.compile(r"^\d{8}T\d{6}Z$")
 REQUIRED_INSTALLED_SKILL_PHRASES = {
+    "loopx-auto-research": (
+        "Identity comes from LoopX control-plane metadata",
+        'loopx --format json auto-research frontier --goal-id "$LOOPX_GOAL_ID" --agent-id "$LOOPX_AGENT_ID"',
+        "No role owns the full graph",
+        "Do not infer role from pane title",
+        "auto_research_role_profile_v0",
+    ),
     "loopx-project": (
         "--classification <PUBLIC_SAFE_PROGRESS_CLASSIFICATION>",
         "--delivery-batch-scale multi_surface",

--- a/skills/loopx-auto-research/SKILL.md
+++ b/skills/loopx-auto-research/SKILL.md
@@ -1,0 +1,280 @@
+---
+name: loopx-auto-research
+description: Use when a LoopX worker is operating an auto-research lane, demo pane, frontier item, evidence packet, promotion/retirement decision, or visible tmux/Codex auto-research rehearsal. Identity must come from the LoopX role profile and quota/frontier packet; this skill only provides role-specific execution checklists, artifact contracts, and stop conditions.
+---
+
+# LoopX Auto Research
+
+## Routing Boundary
+
+Use this skill after a LoopX auto-research worker has a role profile,
+frontier item, launcher packet, or user-visible demo pane. The skill is the
+role playbook. It is not the source of truth for identity, authority, current
+frontier, or merge/publication permission.
+
+Identity comes from LoopX control-plane metadata:
+
+- `auto_research_role_profile_v0` in the launcher/frontier/bootstrap packet;
+- `quota should-run --goal-id ... --agent-id ...`;
+- todo claim, capability token, write scope, and protected scope;
+- repository or workspace `AGENTS.md` rules, which can only make the boundary
+  stricter.
+
+No role owns the full graph. Do not infer role from pane title, branch name,
+tmux window name, or the section of this skill that happens to be visible.
+
+## First Commands
+
+Before doing research work, resolve identity and frontier from LoopX:
+
+```bash
+loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" \
+  --runtime-root "$HOME/.codex/loopx" \
+  quota should-run --goal-id "$LOOPX_GOAL_ID" --agent-id "$LOOPX_AGENT_ID"
+
+loopx --format json auto-research frontier \
+  --goal-id "$LOOPX_GOAL_ID" \
+  --agent-id "$LOOPX_AGENT_ID"
+```
+
+Equivalent compact frontier command: `loopx --format json auto-research frontier --goal-id "$LOOPX_GOAL_ID" --agent-id "$LOOPX_AGENT_ID"`.
+
+If the launcher exported `LOOPX_ROLE_ID`, `LOOPX_ROLE_PROFILE_REF`,
+`LOOPX_ROLE_PHASE`, or a profile JSON path, compare those values with the quota
+and frontier packets. Stop when they disagree. Do not guess the intended role.
+
+For a visible demo rehearsal, inspect the dry-run supervisor before execution:
+
+```bash
+loopx --format json auto-research demo-supervisor \
+  --goal-id "$LOOPX_GOAL_ID"
+```
+
+Only run with `--execute` when the user explicitly opted into starting visible
+local panes. The default rehearsal must not start Codex, write LoopX state, or
+spend quota by itself.
+
+## Role Resolution
+
+Map the role profile to one of these sections:
+
+| Role id or lane | Skill section | Authority source |
+| --- | --- | --- |
+| `research_curator` | Research curator | role profile, quota packet, contract todo |
+| `hypothesis_mapper`, `hypothesis-runner` when proposing | Hypothesis mapper | role profile, frontier packet, hypothesis todo |
+| `evidence_runner`, `hypothesis-runner` when executing | Evidence runner | role profile, selected frontier item, write scope |
+| `evidence_verifier`, `evidence-promoter` | Evidence verifier | role profile, evidence packet, promotion policy |
+| `research-narrator`, `product_narrator` | Projection narrator | read-only projection packet and first-screen gate |
+| `control-plane-guard` | Control-plane guard | quota/status/check packet and repository rules |
+
+The current demo may render fewer or differently named panes than the four
+logical research roles. That is only a host layout choice. Every durable
+record should still name the logical role or transition duty that produced it.
+
+## Shared Stop Conditions
+
+Stop and report the exact blocker when any of these are true:
+
+- quota says `should_run=false`, `delivery_allowed=false`, or a user/operator
+  gate is open;
+- the selected todo is missing, claimed by another agent, or not compatible
+  with the profile's `capability_token`;
+- the next edit touches `protected_scope`, credentials, private material, raw
+  logs, raw evaluator data, or unapproved publication surfaces;
+- the profile, frontier, `AGENTS.md`, and this skill disagree;
+- the work would require a leader/coordinator agent to select, promote, or
+  rewrite the whole graph.
+
+## Research Curator
+
+Use when the role owns objective, metric, editable scope, protected scope,
+budget, and gates.
+
+Allowed actions:
+
+- create or refresh `research_contract_v0`;
+- make protected boundaries explicit;
+- write user/operator gate todos when promotion or publication needs judgment;
+- request read-only projections from existing evidence.
+
+Useful command:
+
+```bash
+loopx --format json auto-research quickstart \
+  --goal-id "$LOOPX_GOAL_ID" \
+  --agent-id "$LOOPX_AGENT_ID"
+```
+
+Artifact contract:
+
+- objective is public-safe and bounded;
+- metric direction and protected evaluator are explicit;
+- write scope and protected scope are named;
+- promotion policy says what evidence is sufficient.
+
+Must not:
+
+- pick winners;
+- run experiments;
+- present unsupported metrics as product value.
+
+## Hypothesis Mapper
+
+Use when the role turns ideas into todo-backed hypotheses, refinements,
+successors, or retirements.
+
+Allowed actions:
+
+- create `research_hypothesis_v0` records with `todo_id`, `claimed_by`,
+  mechanism family, parent link, and grounding refs or no-grounding rationale;
+- retire duplicates, exhausted retries, or contradicted directions while
+  keeping negative evidence visible;
+- add the next bounded agent todo.
+
+Before writing:
+
+- confirm the idea is not claiming novelty from the same source used to ideate;
+- confirm the hypothesis can be attempted inside allowed write scope;
+- keep todo order and rationale in LoopX state, not only in chat.
+
+Must not:
+
+- delete failures;
+- select a winner;
+- hide contradictory evidence by replacing a hypothesis with a cleaner story.
+
+## Evidence Runner
+
+Use when the role runs exactly one selected hypothesis in an isolated
+workspace/worktree and records attempt evidence.
+
+Allowed actions:
+
+- claim the current frontier item selected for this agent;
+- edit only allowed solution or experiment scope;
+- run dev or holdout evaluation only when the contract permits it;
+- build an `auto_research_evidence_packet_v0` or equivalent public-safe event.
+
+Useful command after a protected eval result exists:
+
+```bash
+loopx --format json auto-research evidence \
+  --contract "$RESEARCH_CONTRACT_JSON" \
+  --eval-result "$EVAL_RESULT_JSON" \
+  --hypothesis-id "$HYPOTHESIS_ID" \
+  --todo-id "$TODO_ID" \
+  --agent-id "$LOOPX_AGENT_ID" \
+  --claimed-by "$LOOPX_AGENT_ID" \
+  --mechanism-family "$MECHANISM_FAMILY" \
+  --hypothesis "$HYPOTHESIS_TEXT"
+```
+
+Append only after review of the packet and boundary:
+
+```bash
+loopx --format json auto-research append-evidence \
+  --packet "$AUTO_RESEARCH_EVIDENCE_PACKET_JSON" \
+  --dry-run
+```
+
+Must not:
+
+- edit protected evaluator/data scope;
+- promote results;
+- omit failed, inconclusive, or guardrail-failed attempts.
+
+## Evidence Verifier
+
+Use when the role reads evidence and classifies it as supported,
+contradicted, retry-needed, promotion-ready, or retirement-ready.
+
+Allowed actions:
+
+- apply the contract's metric and promotion policy to scored or unscored
+  evidence;
+- request retry with a bounded reason and resumable ref;
+- create promotion, retirement, or gate candidates;
+- write compact validation notes for the next worker.
+
+Verification checklist:
+
+- split label and metric direction are explicit;
+- dev evidence is not represented as held-out proof;
+- boundary says protected scope stayed clean;
+- negative evidence remains queryable.
+
+Must not:
+
+- bypass an owner/operator gate;
+- certify a showcase claim;
+- rewrite the hypothesis graph to make the result look cleaner.
+
+## Projection Narrator
+
+Use when the role is read-only product narration over accepted projections. This
+is a transition duty in v0 and may become a separate role later.
+
+Allowed actions:
+
+- render `research_showcase_projection_v0` from promoted, retired, and retry
+  evidence;
+- update public-safe docs or Frontstage surfaces only from projection refs;
+- preserve failed and retired directions as useful learning.
+
+Useful command:
+
+```bash
+loopx --format json auto-research board \
+  --goal-id "$LOOPX_GOAL_ID" \
+  --agent-id "$LOOPX_AGENT_ID"
+```
+
+Must stop before:
+
+- inventing metrics;
+- reading private source bodies;
+- changing first viewport, hero, primary CTA, or opening nav without the
+  first-screen review gate.
+
+## Control-Plane Guard
+
+Use when the role checks whether a visible demo, frontier, evidence append,
+merge, or publication action is safe and interruptible.
+
+Allowed actions:
+
+- run quota/status/check packets;
+- validate public/private boundary;
+- confirm attach/stop/takeover controls are visible;
+- write blockers or repair todos when projection is contradictory.
+
+Useful command:
+
+```bash
+loopx --format json auto-research acceptance \
+  --goal-id "$LOOPX_GOAL_ID" \
+  --agent-id "$LOOPX_AGENT_ID"
+```
+
+Must not:
+
+- act as a leader agent;
+- select experiments for other roles;
+- approve its own gate.
+
+## Writeback
+
+After a validated step, write back only the smallest durable artifact allowed
+by the role:
+
+- `research_contract_v0`;
+- `research_hypothesis_v0`;
+- `auto_research_evidence_packet_v0`;
+- promotion/retirement/gate candidate;
+- `research_showcase_projection_v0`;
+- LoopX todo completion plus next todo/rationale;
+- `loopx refresh-state` and one quota spend only after validation when the
+  quota contract permits it.
+
+If the step is blocked, write the blocker as a todo/rationale and do not spend
+quota merely for discovering an unchanged gate.


### PR DESCRIPTION
## Summary

Add a dedicated `loopx-auto-research` Codex skill that turns the existing auto-research role/profile protocols into an installed execution playbook.

The skill keeps the LoopX/Arbor design split explicit:

- identity, role, phase, claim, write scope, gates, and stop conditions come from LoopX control-plane metadata;
- the skill only provides role-specific commands, artifact contracts, and failure/stop checklists;
- visible demo panes are host layout, not authority, and no role owns the full research graph.

## Changes

- Add `skills/loopx-auto-research/SKILL.md` with sections for curator, hypothesis mapper, evidence runner, evidence verifier, projection narrator, and control-plane guard.
- Add `examples/auto-research-skill-contract-smoke.py` to lock the skill/protocol contract and public boundary.
- Add the skill to `loopx doctor` required installed-skill phrase checks.
- Extend `examples/install-local-smoke.py` so local install copies and validates the skill.
- Document the new reusable skill in `docs/guides/getting-started.md`.

## Validation

- `python3 examples/auto-research-skill-contract-smoke.py`
- `python3 -m compileall loopx/doctor.py`
- `python3 examples/decentralized-auto-research-protocol-smoke.py`
- `python3 examples/install-local-smoke.py`
- `python3 -m loopx.cli --format json check --scan-path skills/loopx-auto-research/SKILL.md --scan-path examples/auto-research-skill-contract-smoke.py --scan-path loopx/doctor.py --scan-path examples/install-local-smoke.py --scan-path docs/guides/getting-started.md`
- `git diff --cached --check`

`loopx check` reports the existing global duplicate run-history index warning for `loopx-meta`, with no errors and a clean public-boundary scan for the changed files.

## Risk

Low to medium. This changes install/doctor expectations for LoopX skills, so users with an older installed skill set will see `loopx-auto-research` as missing until they reinstall/update. Runtime behavior is otherwise unchanged; the new skill is a playbook and smoke contract, not an auto-research executor.
