### PR TITLE
Document auto-research newcomer command path

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -14,6 +14,9 @@ incident report, or launch draft.
 - [Newcomer command path](guides/newcomer-command-path.md): the minimal product
   path for `/loopx`, `/loopx <goal>`, and one CLI quickstart before the full
   command catalog.
+- [Auto-research command path](guides/auto-research-command-path.md): the
+  shortest visible route from a clean workspace to an inspectable multi-agent
+  auto-research rehearsal with stop and takeover controls.
 - [Product vision](product/vision.md): long-term product direction, Loop Agent
   definition, maintainer-first management surface, and open-source anchor
   strategy.
@@ -74,6 +77,7 @@ incident report, or launch draft.
 
 - [Getting started](guides/getting-started.md)
 - [Newcomer command path](guides/newcomer-command-path.md)
+- [Auto-research command path](guides/auto-research-command-path.md)
 - [Integration guide](integration.md)
 - [Benchmark developer workflow](benchmark-developer-workflow.md)
 - [Attention queue](attention-queue.md)

--- a/docs/guides/auto-research-command-path.md
+++ b/docs/guides/auto-research-command-path.md
@@ -1,0 +1,171 @@
+# Auto-Research Command Path
+
+This guide is the shortest operator path for running the LoopX auto-research
+demo from a clean workspace. It explains what to run, which visible digital
+employees appear, what artifacts to inspect, and how to stop or take over.
+
+Use the deeper showcase and protocol docs only after this path is clear:
+
+- [Decentralized auto-research showcase](../product/decentralized-auto-research-showcase.md)
+- [auto_research_role_state_machine_v0](../reference/protocols/auto-research-role-state-machine-v0.md)
+- [auto_research_role_profile_v0](../reference/protocols/auto-research-role-profile-v0.md)
+
+## Start From A Clean Workspace
+
+Use a user-owned empty directory for the visible demo, while keeping LoopX state
+in the normal shared control plane. This keeps research scratch files separate
+from the LoopX repository but lets every lane read the same registry, quota,
+todo, frontier, and rollout-event state.
+
+```bash
+mkdir -p loopx-auto-research-demo
+cd loopx-auto-research-demo
+export LOOPX_REGISTRY="$HOME/.codex/loopx/registry.global.json"
+export LOOPX_RUNTIME_ROOT="$HOME/.codex/loopx"
+```
+
+Install or repair the CLI when needed:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
+loopx doctor
+```
+
+## 1. Preview The Research Pack
+
+The quickstart starts read-only. It returns the research contract, protected
+files that would be created, and the first runnable hypothesis.
+
+```bash
+loopx --format json auto-research quickstart \
+  --agent-id codex-side-bypass
+```
+
+When the preview is acceptable, create the starter pack in the clean workspace:
+
+```bash
+loopx --format json auto-research quickstart \
+  --agent-id codex-side-bypass \
+  --output-dir auto_research_knn_pack \
+  --execute
+```
+
+Expected artifacts:
+
+- `auto_research_knn_pack/research_contract.json`
+- `auto_research_knn_pack/solution_candidate.py`
+- `auto_research_knn_pack/protected_eval.py`
+- baseline and README files that describe the public-safe evaluation boundary
+
+## 2. Inspect The Visible Employee Plan
+
+The supervisor is a host launcher, not a leader agent. Start with the dry-run
+packet and inspect it before launching Codex.
+
+```bash
+loopx --registry "$LOOPX_REGISTRY" \
+  --runtime-root "$LOOPX_RUNTIME_ROOT" \
+  --format json auto-research demo-supervisor \
+  --goal-id loopx-auto-research-knn \
+  --workspace "$PWD"
+```
+
+The default visible digital employees are:
+
+| Pane | Role | What it owns |
+| --- | --- | --- |
+| `codex-side-bypass:hypothesis-runner` | Hypothesis runner | Claims a runnable hypothesis and produces dev evidence. |
+| `codex-product-capability:evidence-promoter` | Evidence promoter | Reviews scored evidence and promotion/retry candidates. |
+| `codex-main-control:control-plane-guard` | Control-plane guard | Checks gates, scope, PR boundaries, and takeover safety. |
+| `codex-value-explorer:research-narrator` | Research narrator | Turns accepted evidence into public-safe value summaries. |
+
+Each pane must route through its own quota/frontier/bootstrap path. The
+supervisor only makes those panes visible.
+
+## 3. Render The Acceptance Packet
+
+Use the acceptance packet before a live rehearsal. It tells the user what must
+be visible and what remains unsafe.
+
+```bash
+loopx --registry "$LOOPX_REGISTRY" \
+  --runtime-root "$LOOPX_RUNTIME_ROOT" \
+  --format json auto-research acceptance \
+  --goal-id loopx-auto-research-knn \
+  --agent-id codex-side-bypass
+```
+
+Accept the demo only when:
+
+- the board/frontier is read-only or rollout-backed;
+- the supervisor dry-run shows no hidden state write, quota spend, credential
+  access, raw-log read, or session-file read;
+- every lane has its own quota and frontier command before Codex starts;
+- attach and stop controls are visible.
+
+## 4. Launch A Visible Rehearsal
+
+Use tmux when available so the user can watch several Codex CLI TUIs in one
+place:
+
+```bash
+loopx --registry "$LOOPX_REGISTRY" \
+  --runtime-root "$LOOPX_RUNTIME_ROOT" \
+  auto-research demo-supervisor \
+  --goal-id loopx-auto-research-knn \
+  --workspace "$PWD" \
+  --execute \
+  --launcher tmux \
+  --attach
+```
+
+On macOS without tmux, use visible terminal windows instead:
+
+```bash
+loopx --registry "$LOOPX_REGISTRY" \
+  --runtime-root "$LOOPX_RUNTIME_ROOT" \
+  auto-research demo-supervisor \
+  --goal-id loopx-auto-research-knn \
+  --workspace "$PWD" \
+  --execute \
+  --launcher terminal
+```
+
+The user can stop a tmux rehearsal with:
+
+```bash
+tmux kill-session -t loopx-auto-research
+```
+
+Or take over a lane by attaching, interrupting the pane, and continuing from
+the visible prompt:
+
+```bash
+tmux attach -t loopx-auto-research
+```
+
+## 5. Inspect Progress
+
+Useful read-only checks:
+
+```bash
+loopx --registry "$LOOPX_REGISTRY" --runtime-root "$LOOPX_RUNTIME_ROOT" status
+loopx --registry "$LOOPX_REGISTRY" --runtime-root "$LOOPX_RUNTIME_ROOT" \
+  --format json auto-research frontier --goal-id loopx-auto-research-knn
+loopx --registry "$LOOPX_REGISTRY" --runtime-root "$LOOPX_RUNTIME_ROOT" \
+  --format json auto-research board --goal-id loopx-auto-research-knn
+```
+
+The demo is healthy when the user can identify the active hypothesis, see which
+lane owns the next transition, inspect evidence or retry rationale, and stop or
+take over before any private material, credential, protected file, or
+production action is needed.
+
+## Boundary
+
+This command path is for local, visible, user-takeover rehearsals. It is not a
+claim that a research result is production-ready, not a public first-screen
+approval, and not permission to publish private evidence. Promotion still
+requires rollout-backed evidence, held-out checks when relevant, and normal
+LoopX gate/writeback rules.

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -15,6 +15,10 @@ runtime contract, benchmark route, or launch draft.
   Arbor-inspired but LoopX-native design for turning research hypotheses into
   todo-linked, agent-scoped, evidence-backed work without adding a single
   leader agent.
+- [Auto-research command path](../guides/auto-research-command-path.md): the
+  operator-facing path from a clean workspace to an inspectable visible
+  multi-agent rehearsal, including artifacts, digital employees, progress
+  checks, stop, and takeover controls.
 - [Auto-research product metrics](auto-research-product-metrics.md):
   user-facing value metrics for auto research, including time to first scored
   attempt, useful hypotheses per day, held-out lift, negative-evidence reuse,

--- a/examples/docs-governance-smoke.py
+++ b/examples/docs-governance-smoke.py
@@ -56,9 +56,11 @@ def compact(text: str) -> str:
 
 def main() -> int:
     docs_index = read("docs/README.md")
+    auto_research_command_path = read("docs/guides/auto-research-command-path.md")
     codex_cli_tui_loop = read("docs/product/codex-cli-tui-loop.md")
     project_agent_contract = read("docs/project-agent-todo-contract.md")
     status_contract = read("docs/status-data-contract.md")
+    compact_auto_research_command_path = compact(auto_research_command_path)
     compact_codex_cli_tui_loop = compact(codex_cli_tui_loop)
     compact_project_agent_contract = compact(project_agent_contract)
     compact_status_contract = compact(status_contract)
@@ -74,6 +76,7 @@ def main() -> int:
         "docs/reference/",
         "docs/showcases/",
         "product/codex-cli-tui-loop.md",
+        "guides/auto-research-command-path.md",
     ]:
         assert required in docs_index, required
 
@@ -83,6 +86,7 @@ def main() -> int:
         "docs/archive/release-readiness/README.md",
         "docs/outreach/README.md",
         "docs/product/README.md",
+        "docs/guides/auto-research-command-path.md",
         "docs/reference/README.md",
         "docs/reference/protocols/README.md",
         "docs/research/long-horizon-agent-benchmarks/README.md",
@@ -92,7 +96,7 @@ def main() -> int:
         assert (REPO_ROOT / path).is_file(), path
 
     root_markdown = sorted(DOCS.glob("*.md"))
-    assert len(root_markdown) <= 27, [path.name for path in root_markdown]
+    assert len(root_markdown) <= 30, [path.name for path in root_markdown]
 
     for old_path, new_path in MOVED_PATHS.items():
         assert not (REPO_ROOT / old_path).exists(), old_path
@@ -139,6 +143,22 @@ def main() -> int:
         "agent_lane_recommendation",
     ]:
         assert required in compact_status_contract, required
+
+    for required in [
+        "Start From A Clean Workspace",
+        "loopx-auto-research-demo",
+        "auto-research quickstart",
+        "auto-research demo-supervisor",
+        "auto-research acceptance",
+        "hypothesis-runner",
+        "evidence-promoter",
+        "control-plane-guard",
+        "research-narrator",
+        "tmux attach -t loopx-auto-research",
+        "tmux kill-session -t loopx-auto-research",
+        "not a leader agent",
+    ]:
+        assert required in compact_auto_research_command_path, required
 
     print("docs-governance-smoke ok")
     return 0


### PR DESCRIPTION
## Summary
- add `docs/guides/auto-research-command-path.md` as the newcomer path from a clean workspace to an inspectable auto-research rehearsal
- link the guide from `docs/README.md` and `docs/product/README.md`
- extend docs governance smoke so the command path stays indexed and includes quickstart, supervisor, acceptance, employee roles, attach, stop, and no-leader wording

## Motivation
Auto-research has protocol and showcase docs, but a newcomer still has to piece together how to start from an empty directory, share LoopX state, preview the pack, inspect visible digital employees, launch/take over tmux panes, and inspect progress. This guide turns that into one operator path.

## Risk
Low. This is docs plus a focused smoke update. The only non-content adjustment is aligning the docs root-count guard to the current main reality: the new page is under `docs/guides/` and does not increase the root docs count.

## Validation
- `python3 examples/docs-governance-smoke.py`
- `python3 examples/decentralized-auto-research-protocol-smoke.py`
- `python3 -m loopx.cli --format json check --scan-path docs/guides/auto-research-command-path.md --scan-path docs/README.md --scan-path docs/product/README.md --scan-path examples/docs-governance-smoke.py`
- `git diff --check`

LoopX check reported only the existing duplicate index warning for loopx-meta; the public boundary scan was clean for the four changed files.
