### PR TITLE
Project route continuation replans

### DIFF
--- a/examples/work-lane-contract-smoke.py
+++ b/examples/work-lane-contract-smoke.py
@@ -1393,6 +1393,88 @@ def assert_side_agent_scope_wait_mentions_blocking_owner() -> None:
     assert "blocking handoff" in guard["interaction_contract"]["agent_channel"]["primary_action"], guard
 
 
+def assert_side_agent_replans_route_continuation_before_blocking_wait() -> None:
+    route_review_gate = {
+        "index": 1,
+        "text": "[P0-review] Review the delivered visible launch slice before the route advances.",
+        "role": "agent",
+        "status": "open",
+        "priority": "P0-review",
+        "task_class": "advancement_task",
+        "action_kind": "route_review_gate",
+        "claimed_by": "codex-main-control",
+        "blocks_agent": "codex-side-bypass",
+        "todo_id": "todo_route_review_gate",
+        "unblocks_todo_id": "todo_delivered_visible_launch_slice",
+        "route_id": "auto_research_e2e",
+        "route_continuation_replan_required": True,
+        "route_continuation_reason": (
+            "the delivered slice is review-gated, but the same route has an "
+            "independent next e2e slice that must be projected as a todo"
+        ),
+    }
+    agent_todos = {
+        "schema_version": "todo_summary_v0",
+        "source_section": "Agent Todo",
+        "total_count": 1,
+        "open_count": 1,
+        "done_count": 0,
+        "first_open_items": [route_review_gate],
+        "items": [route_review_gate],
+    }
+    payload = status_payload(
+        status="route_continuation_review_gated",
+        has_agent_todo=False,
+        next_action="Continue the visible launch e2e route after the review gate.",
+        coordination={
+            "primary_agent": "codex-main-control",
+            "registered_agents": ["codex-main-control", "codex-side-bypass"],
+        },
+    )
+    item = payload["attention_queue"]["items"][0]
+    item["project_asset"]["agent_todos"] = agent_todos
+    item["agent_todos"] = agent_todos
+
+    guard = build_quota_should_run(
+        payload,
+        goal_id=GOAL_ID,
+        agent_id="codex-side-bypass",
+    )
+    assert guard["decision"] == "successor_replan_required", guard
+    assert guard["should_run"] is True, guard
+    assert guard["normal_delivery_allowed"] is False, guard
+    assert guard["actionable_by_codex"] is True, guard
+    assert "agent_lane_next_action" not in guard, guard
+    frontier = guard["agent_scope_frontier"]
+    assert frontier["action"] == "successor_replan_required", frontier
+    assert frontier["quiet_noop_allowed"] is False, frontier
+    assert frontier["requires_replan"] is True, frontier
+    assert frontier["candidate_counts"]["route_continuation_replan_candidate_count"] == 1, frontier
+    assert frontier["route_continuation_replan_candidates"][0]["route_id"] == "auto_research_e2e", frontier
+    assert (
+        guard["agent_todo_summary"]["current_agent_route_continuation_replan_count"] == 1
+    ), guard
+    assert guard["agent_todo_summary"]["unclaimed_route_continuation_replan_count"] == 0, guard
+    assert guard["agent_todo_summary"]["route_continuation_replan_count"] == 1, guard
+    assert guard["agent_todo_summary"]["current_agent_handoff_gate_count"] == 1, guard
+    hint = guard["agent_lane_frontier_hint"]
+    assert hint["schema_version"] == "agent_lane_frontier_hint_v0", hint
+    assert hint["decision"] == "add_next_advancement", hint
+    assert hint["reason_code"] == "route_continuation_replan_required", hint
+    assert hint["quiet_noop_allowed"] is False, hint
+    assert "loopx todo add" in hint["next_cli_action"], hint
+    contract = guard["interaction_contract"]
+    assert contract["mode"] == "successor_replan_required", contract
+    assert contract["agent_channel"]["must_attempt"] is True, contract
+    assert contract["agent_channel"]["delivery_allowed"] is False, contract
+    assert contract["agent_channel"]["quiet_noop_allowed"] is False, contract
+    assert "loopx todo add" in contract["cli_channel"]["next_cli_actions"][0], contract
+    markdown = render_quota_should_run_markdown(guard)
+    assert "agent_scope_frontier: action=successor_replan_required" in markdown, markdown
+    assert "route_continuation_replan_required" in markdown, markdown
+    assert "agent_scope_route_continuation_replan_candidates" in markdown, markdown
+
+
 def assert_scoped_user_gate_does_not_steal_other_agent_fallback() -> None:
     gated_action = (
         "[P0] Sync the local long-horizon protocol packet into the approved "
@@ -2043,6 +2125,7 @@ def main() -> int:
     assert_side_agent_next_action_projects_without_stealing_goal_next_action()
     assert_side_agent_waits_when_only_other_agent_has_claimed_work()
     assert_side_agent_scope_wait_mentions_blocking_owner()
+    assert_side_agent_replans_route_continuation_before_blocking_wait()
     assert_scoped_user_gate_does_not_steal_other_agent_fallback()
     assert_side_agent_replans_when_deferred_successor_is_ready()
     assert_side_agent_can_take_unclaimed_work()

--- a/examples/work-lane-contract-smoke.py
+++ b/examples/work-lane-contract-smoke.py
@@ -1468,7 +1468,14 @@ def assert_side_agent_replans_route_continuation_before_blocking_wait() -> None:
     assert contract["agent_channel"]["must_attempt"] is True, contract
     assert contract["agent_channel"]["delivery_allowed"] is False, contract
     assert contract["agent_channel"]["quiet_noop_allowed"] is False, contract
-    assert "loopx todo add" in contract["cli_channel"]["next_cli_actions"][0], contract
+    actions = contract["cli_channel"]["next_cli_actions"]
+    assert len(actions) == 3, actions
+    assert "loopx todo add" in actions[0], actions
+    assert "route_continuation_replan_recorded" in actions[1], actions
+    assert "loopx refresh-state" in actions[1], actions
+    assert "--agent-id codex-side-bypass" in actions[1], actions
+    assert "loopx quota spend-slot" in actions[2], actions
+    assert "--agent-id codex-side-bypass" in actions[2], actions
     markdown = render_quota_should_run_markdown(guard)
     assert "agent_scope_frontier: action=successor_replan_required" in markdown, markdown
     assert "route_continuation_replan_required" in markdown, markdown
@@ -1673,7 +1680,14 @@ def assert_side_agent_replans_when_deferred_successor_is_ready() -> None:
     assert contract["agent_channel"]["delivery_allowed"] is False, contract
     assert contract["agent_channel"]["quiet_noop_allowed"] is False, contract
     assert contract["cli_channel"]["spend_after_validation"] is True, contract
-    assert "todo_issue_surface_deferred" in contract["cli_channel"]["next_cli_actions"][0], contract
+    actions = contract["cli_channel"]["next_cli_actions"]
+    assert len(actions) == 3, actions
+    assert "todo_issue_surface_deferred" in actions[0], actions
+    assert "successor_replan_recorded" in actions[1], actions
+    assert "loopx refresh-state" in actions[1], actions
+    assert "--agent-id codex-side-bypass" in actions[1], actions
+    assert "loopx quota spend-slot" in actions[2], actions
+    assert "--agent-id codex-side-bypass" in actions[2], actions
     assert guard["automation_liveness"]["automation_action"] == "execute_bounded_work", guard
     markdown = render_quota_should_run_markdown(guard)
     assert "agent_scope_frontier: action=successor_replan_required" in markdown, markdown

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -934,6 +934,10 @@ def _compact_todo_summary_item(item: dict[str, Any], *, text: str | None = None)
         "consecutive_no_change",
         "material_change",
         "max_no_change_before_replan",
+        "route_continuation_replan_required",
+        "route_continuation_reason",
+        "route_id",
+        "route_key",
     ):
         if item.get(key) is not None:
             compact[key] = item.get(key)
@@ -1650,6 +1654,155 @@ def _deferred_visibility_lanes(
     return lanes
 
 
+def _todo_summary_route_continuation_candidates(value: dict[str, Any]) -> list[dict[str, Any]]:
+    if not isinstance(value, dict):
+        return []
+    source_items: list[dict[str, Any]] = []
+    for key in (
+        "route_continuation_replan_candidates",
+        "route_continuation_candidates",
+    ):
+        raw_items = value.get(key) if isinstance(value.get(key), list) else []
+        source_items.extend(item for item in raw_items if isinstance(item, dict))
+
+    handoff_gates = _todo_summary_handoff_gates(value)
+    source_items.extend(
+        item
+        for item in handoff_gates
+        if isinstance(item, dict)
+        and item.get("route_continuation_replan_required") is True
+    )
+    if not source_items:
+        return []
+
+    candidates: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in source_items:
+        if item.get("route_continuation_replan_required") is False:
+            continue
+        task_class = item.get("task_class")
+        if task_class is not None and _todo_task_class(item) != TODO_TASK_CLASS_ADVANCEMENT:
+            continue
+        text = str(
+            item.get("text")
+            or item.get("title")
+            or item.get("recommended_action")
+            or item.get("route_continuation_reason")
+            or ""
+        ).strip()
+        identity = str(
+            item.get("todo_id")
+            or item.get("route_id")
+            or item.get("route_key")
+            or item.get("index")
+            or text
+        )
+        if not identity or identity in seen:
+            continue
+        seen.add(identity)
+        compact = _compact_todo_summary_item(item, text=text)
+        compact["route_continuation_replan_required"] = True
+        if item.get("route_continuation_reason") is not None:
+            compact["route_continuation_reason"] = item.get("route_continuation_reason")
+        if item.get("route_id") is not None:
+            compact["route_id"] = item.get("route_id")
+        if item.get("route_key") is not None:
+            compact["route_key"] = item.get("route_key")
+        candidates.append(compact)
+    return sorted(candidates, key=_todo_projection_sort_key)
+
+
+def _route_continuation_candidate_matches_agent(
+    item: dict[str, Any],
+    *,
+    agent_id: str,
+) -> bool:
+    blocks_agent = normalize_todo_blocks_agent(item.get("blocks_agent"))
+    if blocks_agent:
+        return blocks_agent == agent_id
+    claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
+    return not claimed_by or claimed_by == agent_id
+
+
+def _agent_filtered_route_continuation_items(
+    items: list[dict[str, Any]],
+    *,
+    agent_id: str | None,
+    claim: str,
+) -> list[dict[str, Any]]:
+    selected: list[dict[str, Any]] = []
+    for item in items:
+        blocks_agent = normalize_todo_blocks_agent(item.get("blocks_agent"))
+        claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
+        if claim == "current":
+            if not agent_id or not _route_continuation_candidate_matches_agent(
+                item,
+                agent_id=agent_id,
+            ):
+                continue
+        elif claim == "unclaimed":
+            if blocks_agent or claimed_by:
+                continue
+        elif claim == "other":
+            if not agent_id:
+                continue
+            if _route_continuation_candidate_matches_agent(item, agent_id=agent_id):
+                continue
+        selected.append(item)
+    return selected
+
+
+def _route_continuation_replan_lanes(
+    value: dict[str, Any],
+    *,
+    agent_identity: dict[str, Any] | None,
+) -> dict[str, Any]:
+    candidates = _todo_summary_route_continuation_candidates(value)
+    if not candidates:
+        return {}
+    lanes: dict[str, Any] = {
+        "route_continuation_replan_count": len(candidates),
+        "route_continuation_replan_candidates": candidates[:TODO_BACKLOG_ITEM_LIMIT],
+    }
+    agent_id = (
+        normalize_todo_claimed_by(agent_identity.get("agent_id"))
+        if isinstance(agent_identity, dict)
+        else None
+    )
+    if agent_id:
+        current_agent_candidates = _agent_filtered_route_continuation_items(
+            candidates,
+            agent_id=agent_id,
+            claim="current",
+        )
+        unclaimed_candidates = _agent_filtered_route_continuation_items(
+            candidates,
+            agent_id=agent_id,
+            claim="unclaimed",
+        )
+        other_agent_candidates = _agent_filtered_route_continuation_items(
+            candidates,
+            agent_id=agent_id,
+            claim="other",
+        )
+        lanes.update(
+            {
+                "current_agent_route_continuation_replan_candidates": current_agent_candidates[:TODO_BACKLOG_ITEM_LIMIT],
+                "unclaimed_route_continuation_replan_candidates": unclaimed_candidates[:TODO_BACKLOG_ITEM_LIMIT],
+                "other_agent_route_continuation_replan_candidates": other_agent_candidates[:TODO_BACKLOG_ITEM_LIMIT],
+                "current_agent_route_continuation_replan_count": len(current_agent_candidates),
+                "unclaimed_route_continuation_replan_count": len(unclaimed_candidates),
+                "other_agent_route_continuation_replan_count": len(other_agent_candidates),
+                "route_continuation_replan_selection_policy": (
+                    "quota may wake the current side-agent for route continuation "
+                    "replan candidates claimed by that agent or unclaimed; other-agent "
+                    "route candidates remain diagnostic visibility"
+                ),
+            }
+        )
+    return lanes
+
+
 def _todo_summary_source_items(value: dict[str, Any]) -> list[dict[str, Any]]:
     source_keys = (
         "active_next_action_items",
@@ -1852,6 +2005,12 @@ def _summarize_user_todos(
             agent_identity=agent_identity,
         )
     )
+    summary.update(
+        _route_continuation_replan_lanes(
+            value,
+            agent_identity=agent_identity,
+        )
+    )
     if claimed_open_items or value.get("claimed_open_count"):
         summary["claimed_open_count"] = value.get("claimed_open_count", len(claimed_open_items))
         summary["unclaimed_open_count"] = value.get(
@@ -1984,6 +2143,12 @@ def _summarize_project_asset_todos(
     )
     summary.update(
         _handoff_gate_lanes(
+            value,
+            agent_identity=agent_identity,
+        )
+    )
+    summary.update(
+        _route_continuation_replan_lanes(
             value,
             agent_identity=agent_identity,
         )
@@ -2629,6 +2794,36 @@ def _agent_lane_frontier_hint(
                 ),
             )
         deferred_todo_id = _first_compact_todo_id(frontier.get("deferred_resume_candidates"))
+        route_todo_id = _first_compact_todo_id(
+            frontier.get("route_continuation_replan_candidates")
+        )
+        route_candidates = (
+            frontier.get("route_continuation_replan_candidates")
+            if isinstance(frontier.get("route_continuation_replan_candidates"), list)
+            else []
+        )
+        route_candidate = (
+            route_candidates[0]
+            if route_candidates and isinstance(route_candidates[0], dict)
+            else {}
+        )
+        route_target = (
+            route_todo_id
+            or normalize_todo_id(route_candidate.get("route_id"))
+            or normalize_todo_id(route_candidate.get("route_key"))
+        )
+        if route_candidate:
+            return build_hint(
+                AgentLaneFrontierHintDecision.ADD_NEXT_ADVANCEMENT,
+                source="agent_scope_frontier",
+                reason_code="route_continuation_replan_required",
+                target_todo_id=route_target,
+                quiet_noop_allowed=False,
+                next_cli_action=(
+                    f"loopx todo add --goal-id {goal_id} --role agent "
+                    "--text '<public-safe route continuation advancement todo>'"
+                ),
+            )
         return build_hint(
             AgentLaneFrontierHintDecision.ADD_NEXT_ADVANCEMENT,
             source="agent_scope_frontier",
@@ -2797,6 +2992,57 @@ def _agent_scope_blocking_handoff_gates(
     return sorted(selected, key=_todo_projection_sort_key)
 
 
+def _agent_scope_route_continuation_replan_candidates(
+    agent_todo_summary: dict[str, Any],
+    *,
+    agent_id: str,
+) -> list[dict[str, Any]]:
+    candidates: list[dict[str, Any]] = []
+    for key in (
+        "current_agent_route_continuation_replan_candidates",
+        "unclaimed_route_continuation_replan_candidates",
+    ):
+        value = agent_todo_summary.get(key)
+        if isinstance(value, list):
+            candidates.extend(item for item in value if isinstance(item, dict))
+    if not candidates:
+        value = agent_todo_summary.get("route_continuation_replan_candidates")
+        if isinstance(value, list):
+            for item in value:
+                if not isinstance(item, dict):
+                    continue
+                if not _route_continuation_candidate_matches_agent(item, agent_id=agent_id):
+                    continue
+                candidates.append(item)
+
+    unique: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in candidates:
+        if item.get("route_continuation_replan_required") is False:
+            continue
+        identity = str(
+            item.get("todo_id")
+            or item.get("route_id")
+            or item.get("route_key")
+            or item.get("index")
+            or item.get("text")
+            or ""
+        )
+        if not identity or identity in seen:
+            continue
+        seen.add(identity)
+        compact = _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
+        compact["route_continuation_replan_required"] = True
+        if item.get("route_continuation_reason") is not None:
+            compact["route_continuation_reason"] = item.get("route_continuation_reason")
+        if item.get("route_id") is not None:
+            compact["route_id"] = item.get("route_id")
+        if item.get("route_key") is not None:
+            compact["route_key"] = item.get("route_key")
+        unique.append(compact)
+    return sorted(unique, key=_todo_projection_sort_key)
+
+
 def _agent_scope_no_candidate_frontier(
     *,
     agent_identity: dict[str, Any] | None,
@@ -2880,6 +3126,53 @@ def _agent_scope_no_candidate_frontier(
                 "deferred_resume_candidate_count": len(deferred_resume_candidates),
             },
             "deferred_resume_candidates": deferred_resume_candidates[:3],
+        }
+
+    route_continuation_replan_candidates = _agent_scope_route_continuation_replan_candidates(
+        agent_todo_summary,
+        agent_id=agent_id,
+    )
+    if route_continuation_replan_candidates:
+        first_candidate = route_continuation_replan_candidates[0]
+        route_label = (
+            str(
+                first_candidate.get("route_id")
+                or first_candidate.get("route_key")
+                or first_candidate.get("todo_id")
+                or ""
+            ).strip()
+            or "<route>"
+        )
+        reason = (
+            f"current side-agent {agent_id} has no open current/unclaimed "
+            "advancement candidate, but the route continuation projection "
+            f"requires a successor replan for {route_label}"
+        )
+        recommended_action = (
+            "Run a bounded route continuation replan before quiet wait: create or "
+            f"claim the next concrete {agent_id}/unclaimed advancement todo for "
+            f"{route_label}, or record an explicit no-follow-up rationale."
+        )
+        return {
+            "schema_version": AGENT_SCOPE_FRONTIER_SCHEMA_VERSION,
+            "agent_id": agent_id,
+            "primary_agent": normalize_todo_claimed_by(agent_identity.get("primary_agent")),
+            "action": AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value,
+            "effective_action": AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value,
+            "blocks_delivery": True,
+            "requires_replan": True,
+            "quiet_noop_allowed": False,
+            "spend_policy": "spend once after validated route continuation replan/todo writeback",
+            "reason": reason,
+            "recommended_action": recommended_action,
+            "candidate_counts": {
+                "current_agent_claimed_advancement_count": current_agent_count,
+                "unclaimed_advancement_count": unclaimed_count,
+                "route_continuation_replan_candidate_count": len(
+                    route_continuation_replan_candidates
+                ),
+            },
+            "route_continuation_replan_candidates": route_continuation_replan_candidates[:3],
         }
 
     blocking_handoff_gates = _agent_scope_blocking_handoff_gates(
@@ -3959,6 +4252,17 @@ def _interaction_next_cli_actions(payload: dict[str, Any], *, mode: str) -> list
             if isinstance(payload.get("agent_scope_frontier"), dict)
             else {}
         )
+        route_candidates = (
+            agent_scope_frontier.get("route_continuation_replan_candidates")
+            if isinstance(agent_scope_frontier.get("route_continuation_replan_candidates"), list)
+            else []
+        )
+        if route_candidates:
+            return [
+                f"loopx todo add --goal-id {goal_id} --role agent --text '<public-safe route continuation advancement todo>'",
+                f"loopx refresh-state --goal-id {goal_id} --classification route_continuation_replan_recorded --delivery-batch-scale single_surface --delivery-outcome outcome_progress",
+                f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute",
+            ]
         candidates = (
             agent_scope_frontier.get("deferred_resume_candidates")
             if isinstance(agent_scope_frontier.get("deferred_resume_candidates"), list)
@@ -8371,6 +8675,23 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
                 "- agent_scope_deferred_resume_candidates: "
                 f"`{len(deferred_resume_candidates)}` "
                 f"top_todo_id={first_candidate.get('todo_id')}"
+            )
+        route_continuation_candidates = (
+            agent_scope_frontier.get("route_continuation_replan_candidates")
+            if isinstance(agent_scope_frontier.get("route_continuation_replan_candidates"), list)
+            else []
+        )
+        if route_continuation_candidates:
+            first_candidate = (
+                route_continuation_candidates[0]
+                if isinstance(route_continuation_candidates[0], dict)
+                else {}
+            )
+            lines.append(
+                "- agent_scope_route_continuation_replan_candidates: "
+                f"`{len(route_continuation_candidates)}` "
+                f"top_todo_id={first_candidate.get('todo_id')} "
+                f"route={first_candidate.get('route_id') or first_candidate.get('route_key') or ''}"
             )
     automation_prompt_upgrade = (
         payload.get("automation_prompt_upgrade")

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -4228,6 +4228,16 @@ def _interaction_primary_agent_action(payload: dict[str, Any], *, mode: str) -> 
 
 def _interaction_next_cli_actions(payload: dict[str, Any], *, mode: str) -> list[str]:
     goal_id = str(payload.get("goal_id") or "<GOAL_ID>")
+    agent_identity = (
+        payload.get("agent_identity")
+        if isinstance(payload.get("agent_identity"), dict)
+        else {}
+    )
+    agent_arg = (
+        f" --agent-id {agent_identity.get('agent_id')}"
+        if agent_identity.get("agent_id")
+        else ""
+    )
     if mode == "automation_prompt_upgrade":
         automation_prompt_upgrade = (
             payload.get("automation_prompt_upgrade")
@@ -4260,8 +4270,8 @@ def _interaction_next_cli_actions(payload: dict[str, Any], *, mode: str) -> list
         if route_candidates:
             return [
                 f"loopx todo add --goal-id {goal_id} --role agent --text '<public-safe route continuation advancement todo>'",
-                f"loopx refresh-state --goal-id {goal_id} --classification route_continuation_replan_recorded --delivery-batch-scale single_surface --delivery-outcome outcome_progress",
-                f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute",
+                f"loopx refresh-state --goal-id {goal_id} --classification route_continuation_replan_recorded --delivery-batch-scale single_surface --delivery-outcome outcome_progress{agent_arg}",
+                f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute{agent_arg}",
             ]
         candidates = (
             agent_scope_frontier.get("deferred_resume_candidates")
@@ -4272,20 +4282,10 @@ def _interaction_next_cli_actions(payload: dict[str, Any], *, mode: str) -> list
         todo_id = str(first_candidate.get("todo_id") or "<todo_id>")
         return [
             f"loopx todo update --goal-id {goal_id} --todo-id {todo_id} --status open --note '<public-safe successor replan reason>'",
-            f"loopx refresh-state --goal-id {goal_id} --classification successor_replan_recorded --delivery-batch-scale single_surface --delivery-outcome outcome_progress",
-            f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute",
+            f"loopx refresh-state --goal-id {goal_id} --classification successor_replan_recorded --delivery-batch-scale single_surface --delivery-outcome outcome_progress{agent_arg}",
+            f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute{agent_arg}",
         ]
     if _agent_scope_frontier_action(mode) is not None:
-        agent_identity = (
-            payload.get("agent_identity")
-            if isinstance(payload.get("agent_identity"), dict)
-            else {}
-        )
-        agent_arg = (
-            f" --agent-id {agent_identity.get('agent_id')}"
-            if agent_identity.get("agent_id")
-            else ""
-        )
         return [
             "no quota spend while this agent has no in-scope runnable candidate",
             f"loopx --format json quota should-run --goal-id {goal_id}{agent_arg}",

--- a/loopx/todo_handoff_gate.py
+++ b/loopx/todo_handoff_gate.py
@@ -132,6 +132,10 @@ def _compact_handoff_gate(
         "resume_when",
         "no_followup",
         "superseded_by",
+        "route_continuation_replan_required",
+        "route_continuation_reason",
+        "route_id",
+        "route_key",
     ):
         value = gate.get(key)
         if value is not None:


### PR DESCRIPTION
## Summary
- Preserve route-continuation replan metadata through todo and handoff-gate compaction.
- Add quota lanes for route-continuation replan candidates and wake side-agents with successor_replan_required instead of quiet agent_scope_wait when the route still needs a concrete next advancement todo.
- Render route-continuation hints/CLI actions and cover the regression in work-lane contract smoke.

## Motivation
A side-agent can deliver an e2e slice and then become review-gated by a primary/reviewer handoff. If the same route still has independent next work, the previous no-candidate frontier collapsed to agent_scope_wait, so the automation stayed quiet instead of forcing a replan/todo projection. This PR gives that state a structured route-continuation signal.

## Validation
- python3 examples/work-lane-contract-smoke.py
- python3 examples/quota-cleared-blocker-successor-gate-smoke.py
- python3 examples/interaction-pattern-catalog-smoke.py
- python3 examples/monitor-scheduler-contract-smoke.py
- python3 examples/status-markdown-smoke.py
- python3 -m compileall loopx/quota.py loopx/todo_handoff_gate.py