### PR TITLE
Keep auto-research launcher panes visible

### DIFF
--- a/examples/auto-research-demo-supervisor-smoke.py
+++ b/examples/auto-research-demo-supervisor-smoke.py
@@ -91,6 +91,7 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
         assert "[LoopX role profile]" in lane["visible_launch_command"], lane
         assert "LOOPX_ROLE_PROFILE_JSON" in lane["visible_launch_command"], lane
         assert "LOOPX_REQUIRED_SKILL" in lane["visible_launch_command"], lane
+        assert "bootstrap-or-stop" in lane["visible_launch_command"], lane
         assert lane["visible_codex_tui"] == "codex", lane
         phases = [item["phase"] for item in lane["lane_timeline"]]
         assert phases == [

--- a/examples/auto-research-visible-launcher-smoke.py
+++ b/examples/auto-research-visible-launcher-smoke.py
@@ -64,10 +64,24 @@ def main() -> int:
                 [
                     "#!/usr/bin/env python3",
                     "import json, os, sys",
+                    f"LANES = {json.dumps(['frontier', 'research-curator', 'hypothesis-mapper', 'evidence-runner', 'evidence-verifier'])}",
                     "with open(os.environ['FAKE_TMUX_LOG'], 'a', encoding='utf-8') as f:",
                     "    f.write(json.dumps(sys.argv[1:]) + '\\n')",
                     "if len(sys.argv) > 1 and sys.argv[1] == 'has-session':",
                     "    raise SystemExit(1)",
+                    "if len(sys.argv) > 1 and sys.argv[1] == 'list-windows':",
+                    "    print('\\n'.join(LANES))",
+                    "    raise SystemExit(0)",
+                    "if len(sys.argv) > 1 and sys.argv[1] == 'capture-pane':",
+                    "    print('[LoopX role profile]')",
+                    "    print('lane_id=' + (sys.argv[sys.argv.index('-pt') + 1].split(':')[-1] if '-pt' in sys.argv else 'unknown'))",
+                    "    print('[LoopX quota guard]')",
+                    "    print('{\"interaction_contract\":{\"user_channel\":{\"action_required\":false},\"agent_channel\":{\"delivery_allowed\":true}}}')",
+                    "    print('[LoopX auto-research frontier]')",
+                    "    print('{\"schema_version\":\"decentralized_research_frontier_v0\"}')",
+                    "    print('[bootstrap-or-stop]')",
+                    "    print('continuing_to_visible_bootstrap')",
+                    "    raise SystemExit(0)",
                     "raise SystemExit(0)",
                     "",
                 ]
@@ -132,9 +146,26 @@ def main() -> int:
         launch = payload["launch_result"]
         assert launch["launcher"] == "tmux", launch
         assert launch["started_lane_count"] == 4, launch
+        assert launch["surviving_lane_count"] == 4, launch
+        assert launch["surviving_lanes"] == [
+            "research-curator",
+            "hypothesis-mapper",
+            "evidence-runner",
+            "evidence-verifier",
+        ], launch
         assert launch["attach_command"] == "tmux attach -t loopx-auto-research-smoke", launch
         assert launch["stop_command"] == "tmux kill-session -t loopx-auto-research-smoke", launch
         assert launch["workspace_mode"] == "explicit_workspace", launch
+        acceptance = launch["visible_acceptance"]
+        assert acceptance["schema_version"] == "auto_research_visible_launch_acceptance_v0", acceptance
+        assert acceptance["accepted"] is True, acceptance
+        assert acceptance["missing_lanes"] == [], acceptance
+        for pane in acceptance["pane_checks"]:
+            assert pane["window_survived"] is True, pane
+            assert pane["role_profile_visible"] is True, pane
+            assert pane["quota_packet_visible"] is True, pane
+            assert pane["frontier_or_blocked_reason_visible"] is True, pane
+            assert pane["bootstrap_or_stop_visible"] is True, pane
         assert workspace.is_dir(), workspace
 
         for lane in payload["lanes"]:
@@ -159,12 +190,15 @@ def main() -> int:
             assert "quota should-run" in command, command
             assert "auto-research frontier" in command, command
             assert "codex-cli-bootstrap-message" in command, command
+            assert "bootstrap-or-stop" in command, command
             assert 'exec codex "$BOOTSTRAP_PROMPT"' in command, command
 
         log_entries = [json.loads(line) for line in tmux_log.read_text(encoding="utf-8").splitlines()]
         assert log_entries[0][:1] == ["has-session"], log_entries
         assert any(entry[:1] == ["new-session"] for entry in log_entries), log_entries
         assert sum(1 for entry in log_entries if entry[:1] == ["new-window"]) == 4, log_entries
+        assert any(entry[:1] == ["list-windows"] for entry in log_entries), log_entries
+        assert sum(1 for entry in log_entries if entry[:1] == ["capture-pane"]) == 4, log_entries
         assert_public_safe(payload)
 
     print("auto-research-visible-launcher-smoke ok")

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -6,6 +6,7 @@ import platform
 import shlex
 import shutil
 import subprocess
+import time
 from collections import Counter
 from collections.abc import Callable
 from pathlib import Path
@@ -477,6 +478,12 @@ def _launch_auto_research_with_tmux(
         started_lanes.append(lane_id)
     if attach:
         subprocess.run([tmux_bin, "attach", "-t", session], check=True, env=env)
+    acceptance = _tmux_visible_launch_acceptance(
+        tmux_bin=tmux_bin,
+        session=session,
+        expected_lanes=started_lanes,
+        env=env,
+    )
     return {
         "schema_version": "auto_research_demo_launch_result_v0",
         "executed": True,
@@ -484,11 +491,101 @@ def _launch_auto_research_with_tmux(
         "session_name": session,
         "started_lane_count": len(started_lanes),
         "started_lanes": started_lanes,
+        "surviving_lane_count": len(acceptance["surviving_lanes"]),
+        "surviving_lanes": acceptance["surviving_lanes"],
         "attach_command": f"{tmux_bin} attach -t {session}",
         "stop_command": f"{tmux_bin} kill-session -t {session}",
         "workspace_mode": workspace_mode,
         "attach_requested": attach,
         "operator_takeover": "attach to the tmux session, interrupt any lane, or kill the session",
+        "visible_acceptance": acceptance,
+    }
+
+
+def _tmux_visible_launch_acceptance(
+    *,
+    tmux_bin: str,
+    session: str,
+    expected_lanes: list[str],
+    env: dict[str, str],
+) -> dict[str, object]:
+    """Read back tmux pane evidence so launch success is not only process creation."""
+
+    # Give shells a short moment to render preflight markers before capture.
+    time.sleep(0.2)
+    list_result = subprocess.run(
+        [tmux_bin, "list-windows", "-t", session, "-F", "#{window_name}"],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    observed_windows = [
+        line.strip()
+        for line in list_result.stdout.splitlines()
+        if line.strip()
+    ]
+    surviving_lanes = [lane for lane in expected_lanes if lane in observed_windows]
+    required_markers = [
+        "[LoopX quota guard]",
+        "[bootstrap-or-stop]",
+    ]
+    lane_checks: list[dict[str, object]] = []
+    for lane in expected_lanes:
+        capture_result = subprocess.run(
+            [tmux_bin, "capture-pane", "-pt", f"{session}:{lane}", "-S", "-200"],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        capture = capture_result.stdout
+        role_profile_visible = (
+            "[LoopX role profile]" in capture
+            or "[LoopX role_profile]" in capture
+        )
+        markers_present = [marker for marker in required_markers if marker in capture]
+        if role_profile_visible:
+            markers_present.insert(0, "[LoopX role profile]")
+        frontier_or_blocker_visible = (
+            "[LoopX auto-research frontier]" in capture
+            or "[LoopX blocked reason]" in capture
+        )
+        lane_checks.append(
+            {
+                "lane_id": lane,
+                "window_survived": lane in surviving_lanes,
+                "capture_available": capture_result.returncode == 0,
+                "role_profile_visible": role_profile_visible,
+                "quota_packet_visible": "[LoopX quota guard]" in capture,
+                "frontier_or_blocked_reason_visible": frontier_or_blocker_visible,
+                "bootstrap_or_stop_visible": "[bootstrap-or-stop]" in capture,
+                "markers_present": markers_present,
+            }
+        )
+    accepted = (
+        list_result.returncode == 0
+        and len(surviving_lanes) == len(expected_lanes)
+        and all(
+            item["role_profile_visible"]
+            and item["quota_packet_visible"]
+            and item["frontier_or_blocked_reason_visible"]
+            and item["bootstrap_or_stop_visible"]
+            for item in lane_checks
+        )
+    )
+    return {
+        "schema_version": "auto_research_visible_launch_acceptance_v0",
+        "accepted": accepted,
+        "observed_windows": observed_windows,
+        "expected_lanes": expected_lanes,
+        "surviving_lanes": surviving_lanes,
+        "missing_lanes": [lane for lane in expected_lanes if lane not in surviving_lanes],
+        "pane_checks": lane_checks,
+        "takeover_controls_visible": {
+            "attach_command": f"{tmux_bin} attach -t {session}",
+            "stop_command": f"{tmux_bin} kill-session -t {session}",
+        },
     }
 
 

--- a/loopx/capabilities/auto_research/core.py
+++ b/loopx/capabilities/auto_research/core.py
@@ -969,6 +969,18 @@ _QUOTA_GATE_PY = (
     "sys.exit(0 if ok else 42)"
 )
 
+_QUOTA_BLOCKER_SUMMARY_PY = (
+    "import json,sys; "
+    "p=json.load(sys.stdin); "
+    "ic=p.get('interaction_contract',{}); "
+    "u=ic.get('user_channel',{}); "
+    "a=ic.get('agent_channel',{}); "
+    "reason=u.get('reason') or p.get('reason') or p.get('recommended_action') or 'blocked'; "
+    "primary=a.get('primary_action') or p.get('recommended_action') or ''; "
+    "print('reason=' + str(reason)); "
+    "print('primary_action=' + str(primary))"
+)
+
 
 def _env_lane_launch_command(
     *,
@@ -980,21 +992,51 @@ def _env_lane_launch_command(
     role_profile: dict[str, Any],
 ) -> str:
     role_profile_prefix = _role_profile_shell_prefix(role_profile)
+    keep_visible = 'printf "\\n[user takeover]\\ninspect this pane; interrupt, close, or retry manually\\n"; exec "${SHELL:-/bin/sh}"'
     return (
-        "set -euo pipefail; "
+        "set -uo pipefail; "
         f"export LOOPX_ROLE_ID={_shell_arg(role_id)}; "
         f"export LOOPX_ROLE_PROFILE_REF={_shell_arg(AUTO_RESEARCH_ROLE_PROFILE_REF)}; "
         'cd "$LOOPX_PROJECT"; '
         f"{role_profile_prefix}"
         "printf '\\n[LoopX quota guard]\\n'; "
-        f"QUOTA_PACKET=\"$({quota_command})\"; "
+        f"QUOTA_PACKET=\"$({quota_command} 2>&1)\"; "
+        "QUOTA_STATUS=$?; "
         "printf '%s\\n' \"$QUOTA_PACKET\"; "
+        "if [ \"$QUOTA_STATUS\" -ne 0 ]; then "
+        "printf '\\n[LoopX blocked reason]\\n'; "
+        "printf 'quota_command_failed exit=%s\\n' \"$QUOTA_STATUS\"; "
+        "printf '\\n[bootstrap-or-stop]\\nstopped_before_frontier\\n'; "
+        f"{keep_visible}; "
+        "fi; "
         f"printf '%s\\n' \"$QUOTA_PACKET\" | python3 -c {_shell_arg(_QUOTA_GATE_PY)}; "
+        "QUOTA_GATE_STATUS=$?; "
+        "if [ \"$QUOTA_GATE_STATUS\" -ne 0 ]; then "
+        "printf '\\n[LoopX blocked reason]\\n'; "
+        f"printf '%s\\n' \"$QUOTA_PACKET\" | python3 -c {_shell_arg(_QUOTA_BLOCKER_SUMMARY_PY)} || true; "
+        "printf '\\n[bootstrap-or-stop]\\nstopped_before_frontier\\n'; "
+        f"{keep_visible}; "
+        "fi; "
         "printf '\\n[LoopX auto-research frontier]\\n'; "
         f"{frontier_command}; "
+        "FRONTIER_STATUS=$?; "
+        "if [ \"$FRONTIER_STATUS\" -ne 0 ]; then "
+        "printf '\\n[LoopX blocked reason]\\n'; "
+        "printf 'frontier_command_failed exit=%s\\n' \"$FRONTIER_STATUS\"; "
+        "printf '\\n[bootstrap-or-stop]\\nstopped_before_bootstrap\\n'; "
+        f"{keep_visible}; "
+        "fi; "
+        "printf '\\n[bootstrap-or-stop]\\ncontinuing_to_visible_bootstrap\\n'; "
         "printf '\\n[Codex bootstrap prompt]\\n'; "
-        f"BOOTSTRAP_PROMPT=\"$({bootstrap_command})\"; "
+        f"BOOTSTRAP_PROMPT=\"$({bootstrap_command} 2>&1)\"; "
+        "BOOTSTRAP_STATUS=$?; "
         "printf '%s\\n' \"$BOOTSTRAP_PROMPT\"; "
+        "if [ \"$BOOTSTRAP_STATUS\" -ne 0 ]; then "
+        "printf '\\n[LoopX blocked reason]\\n'; "
+        "printf 'bootstrap_command_failed exit=%s\\n' \"$BOOTSTRAP_STATUS\"; "
+        "printf '\\n[bootstrap-or-stop]\\nstopped_before_codex\\n'; "
+        f"{keep_visible}; "
+        "fi; "
         "printf '\\n[Starting visible Codex CLI]\\n'; "
         f"exec {_shell_arg(codex_bin)} \"$BOOTSTRAP_PROMPT\""
     )
@@ -3460,9 +3502,17 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
             lines.append(f"- launcher: `{launch_result.get('launcher')}`")
             lines.append(f"- executed: `{launch_result.get('executed')}`")
             lines.append(f"- started_lanes: `{launch_result.get('started_lane_count')}`")
+            lines.append(f"- surviving_lanes: `{launch_result.get('surviving_lane_count')}`")
             lines.append(f"- attach: `{launch_result.get('attach_command')}`")
             lines.append(f"- stop: `{launch_result.get('stop_command')}`")
             lines.append(f"- takeover: {launch_result.get('operator_takeover')}")
+            acceptance = (
+                launch_result.get("visible_acceptance")
+                if isinstance(launch_result.get("visible_acceptance"), dict)
+                else {}
+            )
+            if acceptance:
+                lines.append(f"- visible_acceptance: `{acceptance.get('accepted')}`")
         lines.extend(["", "## Shell Plan", ""])
         for line in commands.get("start_script") or []:
             lines.append(f"- `{line}`")


### PR DESCRIPTION
## Motivation
Auto-research E2E launch should be visible and user-takeover friendly. A tmux launch that only reports new-window commands can look successful while individual lanes exit silently after quota/frontier/bootstrap blockers.

## Changes
- Add role_profile, quota guard, blocked reason, bootstrap-or-stop, and takeover markers to each lane launch command.
- Keep blocked/non-runnable panes open in the user shell instead of exiting silently.
- Read back tmux windows and captured pane markers into launch_result.visible_acceptance, including surviving lanes and pane checks.
- Extend visible launcher and supervisor smokes to cover pane persistence evidence.

## Risk
Medium-low. The change touches auto-research launcher plumbing and smoke fixtures, but does not change quota decisions, research scoring, or external execution permissions. Main risk is shell portability around the existing tmux launch command style.

## Validation
- python3 examples/auto-research-visible-launcher-smoke.py
- python3 examples/auto-research-demo-supervisor-smoke.py
- python3 examples/auto-research-demo-acceptance-smoke.py
- python3 -m compileall loopx/capabilities/auto_research
- git diff --check
- loopx check --scan-path loopx/capabilities/auto_research --scan-path examples/auto-research-visible-launcher-smoke.py --scan-path examples/auto-research-demo-supervisor-smoke.py

Note: loopx check reported only pre-existing duplicate index row warnings.