### PR TITLE
Fix SkillsBench verifier uv bootstrap staging

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -56,6 +56,7 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
     DEFAULT_MAX_ROUNDS,
     DEFAULT_PRODUCT_MODE_SOFT_VERIFY_POLICY,
     DEFAULT_SOFT_VERIFIER_TIMEOUT_SEC,
+    DEFAULT_VERIFIER_UV_RELEASE_MIRROR_HOST,
     DECLARED_DONE_MARKER,
     DOCKER_CODEX_ACP_RUNTIME_TOOLS_BEGIN,
     DOCKER_APT_RETRY_BEGIN,
@@ -67,6 +68,7 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
     PRODUCT_MODE_CASE_STATE_SCHEMA_VERSION,
     RUNNER_PREREQUISITES_PUBLIC_FILENAME,
     SkillsBenchProductModeNoLifecycleRequests,
+    VERIFIER_UV_BOOTSTRAP_MIRROR_BEGIN,
     _tail,
     _apply_agent_message_only_no_tool_calls_attribution,
     _blind_loop_persistent_continuation_clause,
@@ -5103,6 +5105,59 @@ def test_skillsbench_runtime_tools_patch_has_own_apt_retry_defaults() -> None:
         )
 
 
+def test_skillsbench_docker_task_staging_patches_verifier_uv_bootstrap_mirror() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-uv-verifier-stage-") as tmp:
+        root = Path(tmp)
+        task = root / "tasks" / "citation-check"
+        dockerfile = task / "environment" / "Dockerfile"
+        verifier = task / "verifier" / "test.sh"
+        dockerfile.parent.mkdir(parents=True)
+        verifier.parent.mkdir(parents=True)
+        dockerfile.write_text("FROM python:3.12-slim\n", encoding="utf-8")
+        original_verifier = (
+            "#!/bin/sh\n"
+            "apt-get update\n"
+            "curl -LsSf https://astral.sh/uv/0.9.7/install.sh | sh\n"
+            "uvx --with pytest==8.4.1 pytest /tests/test_outputs.py\n"
+        )
+        verifier.write_text(original_verifier, encoding="utf-8")
+        (task / "task.toml").write_text("version = \"1.1\"\n", encoding="utf-8")
+
+        staged_path, metadata = stage_task_for_sandbox(
+            task_path=task,
+            jobs_dir=root / "jobs",
+            job_name="citation-check-goalstart",
+            sandbox="docker",
+            include_task_skills=False,
+        )
+
+        assert metadata["staged"] is True, metadata
+        assert metadata["verifier_bootstrap_risk_detected"] is True, metadata
+        assert metadata["verifier_uv_bootstrap_risk_detected"] is True, metadata
+        assert metadata["verifier_uv_bootstrap_mirror_patch_required"] is True, (
+            metadata
+        )
+        assert metadata["verifier_uv_bootstrap_mirror_patch_applied"] is True, (
+            metadata
+        )
+        assert metadata["verifier_uv_bootstrap_version"] == "0.9.7", metadata
+        assert metadata["verifier_uv_bootstrap_mirror_host"] == (
+            DEFAULT_VERIFIER_UV_RELEASE_MIRROR_HOST
+        ), metadata
+        assert verifier.read_text(encoding="utf-8") == original_verifier
+        staged_verifier = (staged_path / "verifier" / "test.sh").read_text(
+            encoding="utf-8"
+        )
+        assert VERIFIER_UV_BOOTSTRAP_MIRROR_BEGIN in staged_verifier, staged_verifier
+        assert "INSTALLER_DOWNLOAD_URL" in staged_verifier, staged_verifier
+        assert "releases.astral.sh/github/uv/releases/download" in staged_verifier, (
+            staged_verifier
+        )
+        assert staged_verifier.index("INSTALLER_DOWNLOAD_URL") < staged_verifier.index(
+            "astral.sh/uv/0.9.7/install.sh"
+        ), staged_verifier
+
+
 def test_skillsbench_apt_risk_preflight_blocks_full_run_without_benchflow() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-apt-preflight-") as tmp:
         root = Path(tmp)
@@ -5225,9 +5280,16 @@ def test_skillsbench_verifier_bootstrap_preflight_blocks_full_run_without_benchf
         assert preflight["status"] == "verifier_bootstrap_risk_detected", preflight
         assert preflight["verifier_bootstrap_risk_detected"] is True, preflight
         assert preflight["verifier_uv_bootstrap_risk_detected"] is True, preflight
+        assert preflight["verifier_uv_bootstrap_version"] == "0.9.7", preflight
         assert preflight["verifier_external_download_risk_detected"] is True, preflight
         assert preflight["verifier_package_install_risk_detected"] is True, preflight
         assert preflight["raw_task_text_read"] is False, preflight
+        assert plan["task_staging"][
+            "verifier_uv_bootstrap_mirror_patch_required"
+        ] is True, plan
+        assert plan["task_staging"][
+            "verifier_uv_bootstrap_mirror_patch_applied"
+        ] is False, plan
 
         stderr = io.StringIO()
         with contextlib.redirect_stderr(stderr):
@@ -5933,6 +5995,13 @@ def test_skillsbench_task_staging_metadata_is_compacted() -> None:
             "apt_retry_patch_applied": True,
             "apt_risk_preflight_blocked": False,
             "codex_acp_runtime_tools_patch_applied": True,
+            "verifier_uv_bootstrap_risk_detected": True,
+            "verifier_uv_bootstrap_mirror_patch_required": True,
+            "verifier_uv_bootstrap_mirror_patch_applied": True,
+            "verifier_uv_bootstrap_version": "0.9.7",
+            "verifier_uv_bootstrap_mirror_host": (
+                DEFAULT_VERIFIER_UV_RELEASE_MIRROR_HOST
+            ),
             "task_skills_removed": False,
             "original_task_mutated": False,
             "resource_cap_patch": {
@@ -5957,6 +6026,13 @@ def test_skillsbench_task_staging_metadata_is_compacted() -> None:
             "apt_retry_patch_applied": True,
             "apt_risk_preflight_blocked": False,
             "codex_acp_runtime_tools_patch_applied": True,
+            "verifier_uv_bootstrap_risk_detected": True,
+            "verifier_uv_bootstrap_mirror_patch_required": True,
+            "verifier_uv_bootstrap_mirror_patch_applied": True,
+            "verifier_uv_bootstrap_version": "0.9.7",
+            "verifier_uv_bootstrap_mirror_host": (
+                DEFAULT_VERIFIER_UV_RELEASE_MIRROR_HOST
+            ),
             "task_skills_removed": False,
             "original_task_mutated": False,
             "resource_cap_patch": {
@@ -5981,6 +6057,9 @@ def test_skillsbench_task_staging_metadata_is_compacted() -> None:
         assert entry_staging["apt_retry_patch_applied"] is True, update
         assert entry_staging["apt_setup_risk_detected"] is True, update
         assert entry_staging["codex_acp_runtime_tools_patch_applied"] is True, update
+        assert entry_staging["verifier_uv_bootstrap_mirror_patch_applied"] is True, (
+            update
+        )
         assert "staged_task_path" not in json.dumps(update, sort_keys=True), update
 
 
@@ -6009,7 +6088,9 @@ def test_skillsbench_reduce_only_recovers_prepared_task_staging_metadata() -> No
             / "setup-fuzzing-py"
         )
         dockerfile = prepared / "environment" / "Dockerfile"
+        verifier = prepared / "verifier" / "test.sh"
         dockerfile.parent.mkdir(parents=True)
+        verifier.parent.mkdir(parents=True)
         dockerfile.write_text(
             "FROM ubuntu:20.04\n"
             f"{DOCKER_APT_RETRY_BEGIN}\n"
@@ -6017,12 +6098,30 @@ def test_skillsbench_reduce_only_recovers_prepared_task_staging_metadata() -> No
             "# END LOOPX_SKILLSBENCH_APT_RETRY\n",
             encoding="utf-8",
         )
+        verifier.write_text(
+            "#!/bin/sh\n"
+            f"{VERIFIER_UV_BOOTSTRAP_MIRROR_BEGIN}\n"
+            "export INSTALLER_DOWNLOAD_URL="
+            "https://releases.astral.sh/github/uv/releases/download/0.9.7/"
+            "uv-x86_64-unknown-linux-gnu.tar.gz\n"
+            "# END LOOPX_SKILLSBENCH_VERIFIER_UV_BOOTSTRAP_MIRROR\n"
+            "curl -LsSf https://astral.sh/uv/0.9.7/install.sh | sh\n",
+            encoding="utf-8",
+        )
 
         compact = reduce_result(args, result_path, plan)
 
         assert compact["task_staging"]["staged"] is True, compact
         assert compact["task_staging"]["apt_retry_patch_applied"] is True, compact
-        assert compact["task_staging"]["codex_acp_runtime_tools_patch_applied"] is False, compact
+        assert compact["task_staging"][
+            "codex_acp_runtime_tools_patch_applied"
+        ] is False, compact
+        assert compact["task_staging"][
+            "verifier_uv_bootstrap_mirror_patch_applied"
+        ] is True, compact
+        assert compact["task_staging"][
+            "verifier_uv_bootstrap_version"
+        ] == "0.9.7", compact
         assert compact["task_staging"]["task_skills_removed"] is True, compact
         compact_text = json.dumps(compact, sort_keys=True)
         assert "prepared-tasks" not in compact_text, compact
@@ -11332,7 +11431,9 @@ if __name__ == "__main__":
     test_skillsbench_no_skill_route_removes_staged_task_skills()
     test_skillsbench_docker_task_staging_adds_apt_retry_patch()
     test_skillsbench_runtime_tools_patch_has_own_apt_retry_defaults()
+    test_skillsbench_docker_task_staging_patches_verifier_uv_bootstrap_mirror()
     test_skillsbench_apt_risk_preflight_blocks_full_run_without_benchflow()
+    test_skillsbench_verifier_bootstrap_preflight_blocks_full_run_without_benchflow()
     test_skillsbench_docker_task_staging_caps_local_cpu_request()
     test_skillsbench_volume_mount_failure_attribution()
     test_skillsbench_runner_plan_supports_baseline_route()

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -116,12 +116,21 @@ def _compact_task_staging(value: Any) -> dict[str, Any]:
         "app_skills_mount_patch_applied",
         "apt_retry_patch_applied",
         "apt_risk_preflight_blocked",
+        "verifier_bootstrap_risk_detected",
+        "verifier_uv_bootstrap_risk_detected",
+        "verifier_uv_bootstrap_mirror_patch_required",
+        "verifier_uv_bootstrap_mirror_patch_applied",
+        "verifier_bootstrap_risk_preflight_blocked",
         "codex_acp_runtime_tools_patch_applied",
         "task_skills_removed",
         "original_task_mutated",
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
+    for field in ("verifier_uv_bootstrap_version", "verifier_uv_bootstrap_mirror_host"):
+        text = _compact_text(value.get(field), limit=140)
+        if text:
+            compact[field] = text
     cap = value.get("resource_cap_patch")
     if isinstance(cap, dict):
         safe_cap: dict[str, Any] = {}
@@ -162,6 +171,11 @@ def _compact_task_setup_preflight(value: Any) -> dict[str, Any]:
         "raw_trajectory_read",
         "apt_setup_risk_detected",
         "apt_retry_patch_required",
+        "verifier_present",
+        "verifier_bootstrap_risk_detected",
+        "verifier_uv_bootstrap_risk_detected",
+        "verifier_external_download_risk_detected",
+        "verifier_package_install_risk_detected",
         "dockerfile_present",
         "canonical_task_present",
         "alternate_source_supported_by_runner",
@@ -170,6 +184,9 @@ def _compact_task_setup_preflight(value: Any) -> dict[str, Any]:
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
+    text = _compact_text(value.get("verifier_uv_bootstrap_version"), limit=140)
+    if text:
+        compact["verifier_uv_bootstrap_version"] = text
     nearest_ids = value.get("nearest_canonical_task_ids")
     if isinstance(nearest_ids, list):
         compact_nearest: list[str] = []
@@ -179,6 +196,15 @@ def _compact_task_setup_preflight(value: Any) -> dict[str, Any]:
                 compact_nearest.append(text)
         if compact_nearest:
             compact["nearest_canonical_task_ids"] = compact_nearest
+    verifier_categories = value.get("verifier_bootstrap_risk_categories")
+    if isinstance(verifier_categories, list):
+        compact_categories: list[str] = []
+        for item in verifier_categories[:5]:
+            text = _compact_text(item, limit=120)
+            if text:
+                compact_categories.append(text)
+        if compact_categories:
+            compact["verifier_bootstrap_risk_categories"] = compact_categories
     return compact
 
 
@@ -212,6 +238,9 @@ def _compact_compose_setup_diagnostic(value: Any) -> dict[str, Any]:
         "runner_launch_preflight_passed",
         "apt_setup_risk_detected",
         "apt_retry_patch_required",
+        "verifier_uv_bootstrap_risk_detected",
+        "verifier_uv_bootstrap_mirror_patch_required",
+        "verifier_uv_bootstrap_mirror_patch_applied",
         "staged_task_prepared",
         "task_skills_removed",
         "codex_acp_runtime_tools_patch_applied",

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -2084,6 +2084,9 @@ def _compact_benchmark_task_staging(value: Any) -> dict[str, Any]:
         "apt_retry_patch_applied",
         "apt_risk_preflight_blocked",
         "verifier_bootstrap_risk_detected",
+        "verifier_uv_bootstrap_risk_detected",
+        "verifier_uv_bootstrap_mirror_patch_required",
+        "verifier_uv_bootstrap_mirror_patch_applied",
         "verifier_bootstrap_risk_preflight_blocked",
         "app_skills_mount_patch_applied",
         "codex_acp_runtime_tools_patch_applied",
@@ -2092,6 +2095,10 @@ def _compact_benchmark_task_staging(value: Any) -> dict[str, Any]:
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
+    for field in ("verifier_uv_bootstrap_version", "verifier_uv_bootstrap_mirror_host"):
+        text = public_safe_compact_text(value.get(field), limit=180)
+        if text:
+            compact[field] = text
 
     resource_cap = value.get("resource_cap_patch")
     if isinstance(resource_cap, dict):
@@ -2148,6 +2155,12 @@ def _compact_benchmark_task_setup_preflight(value: Any) -> dict[str, Any]:
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
+    text = public_safe_compact_text(
+        value.get("verifier_uv_bootstrap_version"),
+        limit=180,
+    )
+    if text:
+        compact["verifier_uv_bootstrap_version"] = text
     nearest_task_ids = public_safe_compact_list(
         value.get("nearest_canonical_task_ids"),
         limit=MAX_BENCHMARK_RUN_LIST_ITEMS,
@@ -2195,6 +2208,9 @@ def _compact_benchmark_compose_setup_diagnostic(value: Any) -> dict[str, Any]:
         "runner_launch_preflight_passed",
         "apt_setup_risk_detected",
         "apt_retry_patch_required",
+        "verifier_uv_bootstrap_risk_detected",
+        "verifier_uv_bootstrap_mirror_patch_required",
+        "verifier_uv_bootstrap_mirror_patch_applied",
         "staged_task_prepared",
         "task_skills_removed",
         "codex_acp_runtime_tools_patch_applied",

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -286,6 +286,16 @@ DOCKER_CODEX_ACP_RUNTIME_TOOLS_BEGIN = (
 DOCKER_CODEX_ACP_RUNTIME_TOOLS_END = (
     "# END LOOPX_SKILLSBENCH_CODEX_ACP_RUNTIME_TOOLS"
 )
+VERIFIER_UV_BOOTSTRAP_MIRROR_BEGIN = (
+    "# BEGIN LOOPX_SKILLSBENCH_VERIFIER_UV_BOOTSTRAP_MIRROR"
+)
+VERIFIER_UV_BOOTSTRAP_MIRROR_END = (
+    "# END LOOPX_SKILLSBENCH_VERIFIER_UV_BOOTSTRAP_MIRROR"
+)
+DEFAULT_VERIFIER_UV_RELEASE_MIRROR_BASE = (
+    "https://releases.astral.sh/github/uv/releases/download"
+)
+DEFAULT_VERIFIER_UV_RELEASE_MIRROR_HOST = "releases.astral.sh"
 DOCKER_HOST_CPU_ENV = "LOOPX_SKILLSBENCH_DOCKER_CPUS"
 SANDBOX_PATH_RE = re.compile(r"/(?:app|root|workspace|tmp)/[A-Za-z0-9_./-]+")
 LOOPX_CLI_RE = re.compile(r"(?:^|\s|/)loopx(?:\s|$)")
@@ -4054,6 +4064,9 @@ def _public_task_staging(value: Any) -> dict[str, Any]:
         "apt_retry_patch_applied",
         "apt_risk_preflight_blocked",
         "verifier_bootstrap_risk_detected",
+        "verifier_uv_bootstrap_risk_detected",
+        "verifier_uv_bootstrap_mirror_patch_required",
+        "verifier_uv_bootstrap_mirror_patch_applied",
         "verifier_bootstrap_risk_preflight_blocked",
         "codex_acp_runtime_tools_patch_applied",
         "task_skills_removed",
@@ -4061,6 +4074,10 @@ def _public_task_staging(value: Any) -> dict[str, Any]:
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
+    for field in ("verifier_uv_bootstrap_version", "verifier_uv_bootstrap_mirror_host"):
+        raw = value.get(field)
+        if isinstance(raw, str) and raw:
+            compact[field] = raw[:180]
     resource_cap = value.get("resource_cap_patch")
     if isinstance(resource_cap, dict):
         safe_cap: dict[str, Any] = {}
@@ -4098,8 +4115,18 @@ def _discover_prepared_task_staging(plan: dict[str, Any]) -> dict[str, Any]:
         )
     except OSError:
         dockerfile_text = ""
+    verifier = prepared_task / "verifier" / "test.sh"
+    try:
+        verifier_text = (
+            verifier.read_text(encoding="utf-8", errors="replace")
+            if verifier.exists()
+            else ""
+        )
+    except OSError:
+        verifier_text = ""
+    uv_versions = _verifier_uv_bootstrap_versions(verifier_text)
     include_task_skills = bool(plan.get("include_task_skills"))
-    return {
+    discovered = {
         "schema_version": "skillsbench_task_staging_v0",
         "staged": True,
         "include_task_skills": include_task_skills,
@@ -4116,6 +4143,20 @@ def _discover_prepared_task_staging(plan: dict[str, Any]) -> dict[str, Any]:
         ),
         "original_task_mutated": False,
     }
+    if VERIFIER_UV_BOOTSTRAP_MIRROR_BEGIN in verifier_text:
+        discovered.update(
+            {
+                "verifier_uv_bootstrap_risk_detected": True,
+                "verifier_uv_bootstrap_mirror_patch_required": True,
+                "verifier_uv_bootstrap_mirror_patch_applied": True,
+                "verifier_uv_bootstrap_mirror_host": (
+                    DEFAULT_VERIFIER_UV_RELEASE_MIRROR_HOST
+                ),
+            }
+        )
+        if uv_versions:
+            discovered["verifier_uv_bootstrap_version"] = uv_versions[0]
+    return discovered
 
 
 def _effective_public_task_staging(plan: dict[str, Any]) -> dict[str, Any]:
@@ -4168,6 +4209,10 @@ def _public_task_setup_preflight(value: Any) -> dict[str, Any]:
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
+    for field in ("verifier_uv_bootstrap_version",):
+        raw = value.get(field)
+        if isinstance(raw, str) and raw:
+            compact[field] = raw[:180]
     for field in ("nearest_canonical_task_ids", "verifier_bootstrap_risk_categories"):
         raw_items = value.get(field)
         if isinstance(raw_items, list):
@@ -4340,6 +4385,19 @@ def build_compose_setup_diagnostic(
         )
         is True
         or task_staging.get("apt_retry_patch_required") is True,
+        "verifier_uv_bootstrap_risk_detected": setup_preflight.get(
+            "verifier_uv_bootstrap_risk_detected"
+        )
+        is True
+        or task_staging.get("verifier_uv_bootstrap_risk_detected") is True,
+        "verifier_uv_bootstrap_mirror_patch_required": task_staging.get(
+            "verifier_uv_bootstrap_mirror_patch_required"
+        )
+        is True,
+        "verifier_uv_bootstrap_mirror_patch_applied": task_staging.get(
+            "verifier_uv_bootstrap_mirror_patch_applied"
+        )
+        is True,
         "staged_task_prepared": task_staging.get("staged") is True,
         "task_skills_removed": task_staging.get("task_skills_removed") is True,
         "codex_acp_runtime_tools_patch_applied": task_staging.get(
@@ -4683,6 +4741,9 @@ def skillsbench_verifier_bootstrap_risk(task_path: Path) -> dict[str, Any]:
     except OSError:
         return result
 
+    uv_versions = _verifier_uv_bootstrap_versions(text)
+    if uv_versions:
+        result["verifier_uv_bootstrap_version"] = uv_versions[0]
     categories: list[str] = []
     uv_bootstrap_pattern = (
         r"astral\.sh/uv|"
@@ -4705,6 +4766,97 @@ def skillsbench_verifier_bootstrap_risk(task_path: Path) -> dict[str, Any]:
     result["verifier_bootstrap_risk_categories"] = sorted(set(categories))
     result["verifier_bootstrap_risk_detected"] = bool(categories)
     return result
+
+
+def _verifier_uv_bootstrap_versions(text: str) -> list[str]:
+    versions: list[str] = []
+    seen: set[str] = set()
+    for match in re.finditer(
+        r"https?://astral\.sh/uv/(?P<version>[0-9A-Za-z][0-9A-Za-z._+-]*)/install\.sh",
+        text,
+    ):
+        version = match.group("version")
+        if version and version not in seen:
+            versions.append(version)
+            seen.add(version)
+    return versions
+
+
+def patch_verifier_uv_bootstrap_mirror(verifier: Path) -> dict[str, Any]:
+    """Point staged uv installer bootstrap at a reachable public mirror.
+
+    The patch is applied only to the copied prepared task. It does not alter
+    scoring assertions, task instructions, or verifier command order; it only
+    supplies uv's installer with the tarball URL that the official installer
+    would otherwise derive from a GitHub release URL.
+    """
+
+    metadata: dict[str, Any] = {
+        "verifier_uv_bootstrap_risk_detected": False,
+        "verifier_uv_bootstrap_mirror_patch_required": False,
+        "verifier_uv_bootstrap_mirror_patch_applied": False,
+    }
+    if not verifier.exists():
+        return metadata
+    try:
+        original = verifier.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return metadata
+    text = _strip_marker_block(
+        original,
+        VERIFIER_UV_BOOTSTRAP_MIRROR_BEGIN,
+        VERIFIER_UV_BOOTSTRAP_MIRROR_END,
+    )
+    versions = _verifier_uv_bootstrap_versions(text)
+    if not versions:
+        return metadata
+
+    version = versions[0]
+    block = (
+        f"{VERIFIER_UV_BOOTSTRAP_MIRROR_BEGIN}\n"
+        "# Use a public mirror for uv release tarballs when GitHub release\n"
+        "# downloads stall behind the benchmark runner network path.\n"
+        f"loopx_uv_release_mirror={shlex.quote(DEFAULT_VERIFIER_UV_RELEASE_MIRROR_BASE)}\n"
+        f"loopx_uv_version={shlex.quote(version)}\n"
+        "loopx_uv_arch=$(uname -m 2>/dev/null || true)\n"
+        "case \"$loopx_uv_arch\" in\n"
+        "  x86_64|amd64) loopx_uv_target=x86_64-unknown-linux-gnu ;;\n"
+        "  aarch64|arm64) loopx_uv_target=aarch64-unknown-linux-gnu ;;\n"
+        "  *) loopx_uv_target=x86_64-unknown-linux-gnu ;;\n"
+        "esac\n"
+        "if [ -z \"${INSTALLER_DOWNLOAD_URL:-}\" ]; then\n"
+        "  export INSTALLER_DOWNLOAD_URL=\"${loopx_uv_release_mirror}/${loopx_uv_version}/uv-${loopx_uv_target}.tar.gz\"\n"
+        "fi\n"
+        f"{VERIFIER_UV_BOOTSTRAP_MIRROR_END}"
+    )
+    patched_lines: list[str] = []
+    inserted = False
+    for line in text.splitlines():
+        if (
+            not inserted
+            and "astral.sh/uv/" in line
+            and "install.sh" in line
+        ):
+            patched_lines.extend(block.splitlines())
+            inserted = True
+        patched_lines.append(line)
+    if not inserted:
+        patched_lines.extend(block.splitlines())
+    patched = "\n".join(patched_lines).rstrip() + "\n"
+    if patched != original:
+        _write_text_atomic(verifier, patched)
+    metadata.update(
+        {
+            "verifier_uv_bootstrap_risk_detected": True,
+            "verifier_uv_bootstrap_mirror_patch_required": True,
+            "verifier_uv_bootstrap_mirror_patch_applied": True,
+            "verifier_uv_bootstrap_version": version,
+            "verifier_uv_bootstrap_mirror_host": (
+                DEFAULT_VERIFIER_UV_RELEASE_MIRROR_HOST
+            ),
+        }
+    )
+    return metadata
 
 
 def patch_dockerfile_apt_retry(dockerfile: Path) -> bool:
@@ -4836,6 +4988,9 @@ def stage_task_for_sandbox(
         "app_skills_mount_patch_applied": False,
         "apt_retry_patch_applied": False,
         "codex_acp_runtime_tools_patch_applied": False,
+        "verifier_uv_bootstrap_risk_detected": False,
+        "verifier_uv_bootstrap_mirror_patch_required": False,
+        "verifier_uv_bootstrap_mirror_patch_applied": False,
         "task_skills_removed": False,
         "resource_cap_patch": {
             "schema_version": "skillsbench_local_docker_resource_cap_v0",
@@ -4856,17 +5011,35 @@ def stage_task_for_sandbox(
     needs_apt_retry_patch = dockerfile_needs_apt_retry_patch(
         task_path / "environment" / "Dockerfile"
     )
+    verifier_risk = skillsbench_verifier_bootstrap_risk(task_path)
+    needs_verifier_uv_mirror_patch = bool(
+        verifier_risk.get("verifier_uv_bootstrap_risk_detected")
+        and verifier_risk.get("verifier_uv_bootstrap_version")
+    )
     needs_runtime_tools_patch = (task_path / "environment" / "Dockerfile").exists()
     metadata["apt_setup_risk_detected"] = needs_apt_retry_patch
     metadata["apt_retry_patch_required"] = needs_apt_retry_patch
     metadata["apt_risk_preflight_blocked"] = False
-    metadata["verifier_bootstrap_risk_detected"] = False
+    metadata["verifier_bootstrap_risk_detected"] = bool(
+        verifier_risk.get("verifier_bootstrap_risk_detected")
+    )
+    metadata["verifier_uv_bootstrap_risk_detected"] = bool(
+        verifier_risk.get("verifier_uv_bootstrap_risk_detected")
+    )
+    metadata["verifier_uv_bootstrap_mirror_patch_required"] = (
+        needs_verifier_uv_mirror_patch
+    )
+    if isinstance(verifier_risk.get("verifier_uv_bootstrap_version"), str):
+        metadata["verifier_uv_bootstrap_version"] = verifier_risk[
+            "verifier_uv_bootstrap_version"
+        ]
     metadata["verifier_bootstrap_risk_preflight_blocked"] = False
     if (
         not has_task_skills
         and not needs_resource_cap
         and not needs_apt_retry_patch
         and not needs_runtime_tools_patch
+        and not needs_verifier_uv_mirror_patch
     ):
         metadata["resource_cap_patch"] = {
             "schema_version": "skillsbench_local_docker_resource_cap_v0",
@@ -4901,6 +5074,9 @@ def stage_task_for_sandbox(
     runtime_tools_patched = patch_dockerfile_codex_acp_runtime_tools(
         staged_path / "environment" / "Dockerfile"
     )
+    uv_mirror_metadata = patch_verifier_uv_bootstrap_mirror(
+        staged_path / "verifier" / "test.sh"
+    )
     resource_cap_patch = patch_task_cpu_cap_for_local_docker(
         staged_path / "task.toml",
         host_cpus=host_cpus,
@@ -4918,6 +5094,14 @@ def stage_task_for_sandbox(
             "resource_cap_patch": resource_cap_patch,
         }
     )
+    for key, value in uv_mirror_metadata.items():
+        if (
+            key == "verifier_uv_bootstrap_risk_detected"
+            and value is False
+            and metadata.get(key) is True
+        ):
+            continue
+        metadata[key] = value
     return staged_path, metadata
 
 
@@ -5120,6 +5304,19 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
             "apt_risk_preflight_blocked": False,
             "verifier_bootstrap_risk_detected": bool(
                 setup_preflight.get("verifier_bootstrap_risk_detected")
+            ),
+            "verifier_uv_bootstrap_risk_detected": bool(
+                setup_preflight.get("verifier_uv_bootstrap_risk_detected")
+            ),
+            "verifier_uv_bootstrap_mirror_patch_required": bool(
+                setup_preflight.get("verifier_uv_bootstrap_risk_detected")
+                and setup_preflight.get("verifier_uv_bootstrap_version")
+            ),
+            "verifier_uv_bootstrap_mirror_patch_applied": False,
+            "verifier_uv_bootstrap_version": (
+                str(setup_preflight.get("verifier_uv_bootstrap_version"))
+                if setup_preflight.get("verifier_uv_bootstrap_version")
+                else ""
             ),
             "verifier_bootstrap_risk_preflight_blocked": False,
         },


### PR DESCRIPTION
## Summary
- patch staged SkillsBench verifier wrappers to provide uv installer tarball downloads through the public releases.astral.sh mirror when tasks use astral.sh/uv install.sh
- propagate public-safe uv bootstrap patch metadata through compact status and benchmark ledger reducers
- add SkillsBench smoke coverage for staging, preflight, compact, and reduce-only recovery

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py loopx/status.py loopx/benchmark_ledger.py
- git diff --check
- python3 examples/skillsbench-benchmark-run-smoke.py

No scoring, task semantics, leaderboard behavior, private material, raw trajectories, verifier output, or local paths are included.