### PR TITLE
Recenter SkillsBench solver continuations on task

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -676,7 +676,10 @@ def test_product_mode_initial_prompt_keeps_task_visible_after_lifecycle_gate() -
         user.run(1, "Compute the requested coefficient.", FakeRoundResult())
     )
     assert task_prompt is not None
-    assert "--- TASK INSTRUCTION ---" not in task_prompt
+    assert "--- TASK INSTRUCTION ---" in task_prompt
+    assert "Compute the requested coefficient." in task_prompt
+    assert "The task above remains the primary objective" in task_prompt
+    assert "write or validate that path before closeout" in task_prompt
     assert "The task packet is now available" not in task_prompt
     assert "Mandatory product-mode solver checkpoint" in task_prompt
     assert "task-facing sandbox bridge operation" in task_prompt
@@ -2264,6 +2267,10 @@ def test_product_mode_declared_done_requires_solver_activity_after_driver_lifecy
         assert prompt is not None, trace
         assert "Mandatory product-mode solver checkpoint" in prompt
         assert "selected P0 solver/closeout evidence" in prompt
+        assert "--- TASK INSTRUCTION ---" in prompt
+        assert "Fix the fixture." in prompt
+        assert "The task above remains the primary objective" in prompt
+        assert "write or validate that path before closeout" in prompt
         assert "task-facing sandbox bridge operation" in prompt
         assert "todo complete" in prompt
         assert "benchmark_case_agent_closeout" in prompt
@@ -3140,6 +3147,10 @@ def test_product_mode_workflow_driver_task_bridge_activity_avoids_no_tool_abort(
     )
     assert prompt is not None, trace
     assert "Mandatory product-mode solver checkpoint" in prompt
+    assert "--- TASK INSTRUCTION ---" in prompt
+    assert "Fix the fixture." in prompt
+    assert "The task above remains the primary objective" in prompt
+    assert "write or validate that path before closeout" in prompt
     assert "task-facing sandbox bridge operation" in prompt
     assert "selected P0 closeout sequence" in prompt
     assert (

--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -427,7 +427,7 @@ if out:
         heartbeat_index = launch_command.index("--stream-heartbeat-interval-sec")
         assert launch_command[heartbeat_index + 1] == "15.0"
         bridge_idle_index = launch_command.index("--bridge-idle-timeout-sec")
-        assert launch_command[bridge_idle_index + 1] == "7200"
+        assert launch_command[bridge_idle_index + 1] == "600"
         launch_args.local_codex_bridge_idle_timeout_sec = 0
         bridge_idle_disabled_command = _host_local_acp_launch_command(
             launch_args,

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -145,6 +145,7 @@ DEFAULT_LEDGER = (
 DEFAULT_GOAL_ID = "loopx-meta"
 DEFAULT_MODEL = "gpt-5.5"
 DEFAULT_TIMEOUT_SEC = 7200
+DEFAULT_HOST_LOCAL_CODEX_BRIDGE_IDLE_TIMEOUT_SEC = 600
 DEFAULT_VERIFIER_PREP_TIMEOUT_SEC = 120
 DEFAULT_SOFT_VERIFIER_TIMEOUT_SEC = 600
 DEFAULT_PRODUCT_MODE_SOFT_VERIFY_POLICY = "every-round"
@@ -953,7 +954,10 @@ def _effective_local_codex_bridge_idle_timeout_sec(args: argparse.Namespace) -> 
     configured = getattr(args, "local_codex_bridge_idle_timeout_sec", None)
     if configured is not None:
         return max(0, int(configured or 0))
-    return max(0, int(getattr(args, "agent_idle_timeout", 0) or 0))
+    requested = max(0, int(getattr(args, "agent_idle_timeout", 0) or 0))
+    if requested <= 0:
+        return DEFAULT_HOST_LOCAL_CODEX_BRIDGE_IDLE_TIMEOUT_SEC
+    return min(requested, DEFAULT_HOST_LOCAL_CODEX_BRIDGE_IDLE_TIMEOUT_SEC)
 
 
 def _host_local_acp_target_env(agent_env: object) -> dict[str, str]:
@@ -7875,7 +7879,22 @@ def _build_product_mode_user(
             "instruction will be sent after that bridge action is observed."
         )
 
-    def solver_activity_prompt(round_number: int) -> str:
+    def solver_activity_prompt(
+        round_number: int,
+        *,
+        task_instruction: str | None = None,
+    ) -> str:
+        task_clause = ""
+        if task_instruction:
+            task_clause = (
+                "\n\n--- TASK INSTRUCTION ---\n"
+                f"{task_instruction}\n\n"
+                "The task above remains the primary objective for this turn. "
+                "Do not spend the turn only proving bridge access or repeating "
+                "status; use the bridge to finish the task-facing work, and if "
+                "the task names a scored output path, write or validate that "
+                "path before closeout."
+            )
         return (
             f"Mandatory product-mode solver checkpoint before round {round_number} "
             "continues. The previous round produced enough LoopX lifecycle "
@@ -7896,6 +7915,7 @@ def _build_product_mode_user(
             "selected P0 is complete, run this exact case-local closeout "
             "sequence from `/app`:\n\n"
             f"{closeout_commands(round_number)}"
+            f"{task_clause}\n\n"
             "Do not answer with prose only, and only end with "
             f"{DECLARED_DONE_MARKER} after meaningful local task work or "
             "validation and the corresponding LoopX closeout/spend evidence "
@@ -8217,7 +8237,10 @@ def _build_product_mode_user(
                             trace["last_decision"] = (
                                 "send_product_mode_solver_activity_continuation"
                             )
-                            return solver_activity_prompt(round + 1)
+                            return solver_activity_prompt(
+                                round + 1,
+                                task_instruction=instruction,
+                            )
                     if treatment:
                         _record_declared_done(
                             trace,
@@ -8375,7 +8398,10 @@ def _build_product_mode_user(
                 trace["last_decision"] = (
                     "send_product_mode_solver_activity_continuation"
                 )
-                return solver_activity_prompt(round + 1)
+                return solver_activity_prompt(
+                    round + 1,
+                    task_instruction=instruction,
+                )
             if round == 0:
                 _inc_counter(trace, "controller_action_decisions")
                 _inc_counter(trace, "initial_prompt_count")


### PR DESCRIPTION
## Summary
- include the task instruction in product-mode solver-activity continuation prompts so timeout/recovery turns stay focused on the scored output instead of only repeating bridge/checkpoint work
- cap the default host-local Codex bridge idle timeout at 600 seconds while preserving explicit 0 as opt-out
- update SkillsBench smokes for the new continuation and timeout contracts

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py examples/skillsbench-host-local-launch-plan-smoke.py
- python3 examples/skillsbench-host-local-launch-plan-smoke.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- git diff --check

## Boundary
- public benchmark runtime/helper and focused smoke updates only
- no raw benchmark logs, trajectories, credentials, local private paths, scoring changes, or task semantics changes