### PR TITLE
Update SkillsBench citation goal-start ledger

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
@@ -2114,14 +2114,10 @@
           "latest_decision": {
             "baseline_failure_scope": "passed",
             "baseline_run_id": "2297b9236dc2",
-            "decision": "paired_treatment_verifier_or_infra_repair_required",
-            "failure_class": "verifier_infrastructure_failure",
-            "next_action": "repair verifier or infra attribution before comparing arms",
-            "official_score_delta": null,
-            "repair_class": "verifier_or_infra_repair",
-            "repair_priority": "P0",
-            "treatment_failure_scope": "score_missing",
-            "treatment_run_id": "c3b9fa70421c"
+            "decision": "paired_baseline_solved_treatment_preserved",
+            "official_score_delta": 0.0,
+            "treatment_failure_scope": "passed",
+            "treatment_run_id": "15ba747b3be5"
           },
           "runs": [
             {
@@ -3288,6 +3284,114 @@
                 },
                 "staged": true,
                 "task_skills_removed": true
+              },
+              "verifier_attempt_countable": true
+            },
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_loopx_treatment",
+              "artifact_refs": {
+                "compact_artifact_ref": "cloud-ecs/skillsbench-citation-check-goalstart-taskrecenter-20260629T091301Z/jobs/skillsbench-citation-check-goalstart-taskrecenter-20260629T091301Z-goalstart/citation-check__loopx_goal_start_product_mode/benchmark_run.compact.json"
+              },
+              "attempt_failure_class": "none",
+              "attempt_failure_label": "none",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "best_reward_round": 2,
+              "best_round_is_final": true,
+              "best_round_passed": true,
+              "best_round_reward": 1.0,
+              "case_attempt_countable": true,
+              "case_id": "citation-check",
+              "case_ids": [
+                "citation-check"
+              ],
+              "codex_acp_runtime_preflight_passed": true,
+              "failure_class": "none",
+              "failure_scope": "passed",
+              "final_round": 2,
+              "final_round_passed": true,
+              "final_round_reward": 1.0,
+              "first_success_round": 2,
+              "job_name": "skillsbench_1_1_citation_check_loopx_goal_start_product_mode",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loop_score_policy": "best_round_for_offline_controller_analysis",
+              "loopx_inside_case": true,
+              "max_rounds_budget": 16,
+              "mode": "skillsbench_loopx_goal_start_product_mode_treatment",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "Goal-start reverse-channel task-recenter rerun on main 762c1c5f reached official score 1.0 in round 2; controller stopped after official success while keeping reward/verifier feedback blinded from the agent. Residual ...",
+              "official_feedback_blinded": true,
+              "official_passed": true,
+              "official_score": 1.0,
+              "official_score_attempt_countable": true,
+              "official_score_policy": "final_workspace_official_result",
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 2,
+                "checkpoint_required": true,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "execution_style": "orchestrated_agentloop_loopx_cli",
+                "orchestrated_driver_counts_as_product_mode": true,
+                "orchestrated_driver_lifecycle_satisfied": true,
+                "required": true,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 2,
+                "state_write_count": 6
+              },
+              "recorded_at": "2026-06-29T17:31:26+08:00",
+              "reward_feedback_forwarded": false,
+              "round_reward_count": 2,
+              "round_rewards": [
+                {
+                  "agent_round": 1,
+                  "passed": false,
+                  "reward": 0.0,
+                  "reward_present": true,
+                  "tool_calls": 0
+                },
+                {
+                  "agent_round": 2,
+                  "passed": true,
+                  "reward": 1.0,
+                  "reward_present": true,
+                  "tool_calls": 0
+                }
+              ],
+              "round_success_observed": true,
+              "run_group_id": "skillsbench-citation-check-goalstart-taskrecenter-20260629T091301Z",
+              "run_id": "15ba747b3be5",
+              "score_status": "passed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "task_staging": {
+                "app_skills_mount_patch_applied": true,
+                "apt_retry_patch_applied": true,
+                "apt_retry_patch_required": true,
+                "apt_risk_preflight_blocked": false,
+                "apt_setup_risk_detected": true,
+                "codex_acp_runtime_tools_patch_applied": true,
+                "include_task_skills": false,
+                "original_task_mutated": false,
+                "resource_cap_patch": {
+                  "applied": false,
+                  "host_cpus": 32.0
+                },
+                "staged": true,
+                "task_skills_removed": true,
+                "verifier_bootstrap_risk_detected": true,
+                "verifier_bootstrap_risk_preflight_blocked": false,
+                "verifier_uv_bootstrap_mirror_host": "releases.astral.sh",
+                "verifier_uv_bootstrap_mirror_patch_applied": true,
+                "verifier_uv_bootstrap_mirror_patch_required": true,
+                "verifier_uv_bootstrap_risk_detected": true,
+                "verifier_uv_bootstrap_version": "0.9.7"
               },
               "verifier_attempt_countable": true
             }
@@ -10098,7 +10202,7 @@
           ]
         }
       },
-      "run_count": 162
+      "run_count": 163
     },
     "swe-marathon": {
       "benchmark_id": "swe-marathon",
@@ -14150,5 +14254,5 @@
     "source_of_truth": "benchmark_run_v0 compact run events",
     "update_rule": "upsert one run entry when a benchmark case is ingested or closed"
   },
-  "updated_at": "2026-06-28T21:45:07+08:00"
+  "updated_at": "2026-06-29T17:31:26+08:00"
 }

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
@@ -5,7 +5,7 @@ benchmark case outcomes and artifact references; it must not contain raw
 logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 
 - schema_version: `benchmark_run_ledger_v0`
-- updated_at: `2026-06-28T21:45:07+08:00`
+- updated_at: `2026-06-29T17:31:26+08:00`
 
 ## Case Decisions
 
@@ -17,7 +17,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `adaptive-cruise-control` | `baseline_runner_or_setup_repair_required` | - | - | `1` |
 | `skillsbench@1.1` | `azure-bgp-oscillation-route-leak` | `product_mode_pair_incomplete` | `treatment_loopx_lifecycle_not_observed` | - | `10` |
 | `skillsbench@1.1` | `bike-rebalance` | `paired_baseline_solved_treatment_preserved` | - | - | `3` |
-| `skillsbench@1.1` | `citation-check` | `paired_treatment_verifier_or_infra_repair_required` | - | - | `13` |
+| `skillsbench@1.1` | `citation-check` | `paired_baseline_solved_treatment_preserved` | - | - | `14` |
 | `skillsbench@1.1` | `civ6-adjacency-optimizer` | `paired_no_score_uplift` | - | - | `4` |
 | `skillsbench@1.1` | `dapt-intrusion-detection` | `paired_baseline_setup_preflight_selection_required` | - | - | `5` |
 | `skillsbench@1.1` | `debug-trl-grpo` | `paired_baseline_runner_or_setup_repair_required` | - | - | `9` |
@@ -70,7 +70,6 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `P0` | `skillsbench@1.1` | `setup-fuzzing-py` | `codex_goal_mode_baseline` | `skillsbench_codex_acp_runtime_preflight` | `skillsbench_codex_acp_runtime_libssl_missing` | required_preflight=codex_acp_runtime_dependency_preflight,codex_acp_runtime_launch_preflight,skillsbench_compact_failure_class | prove the Codex ACP runtime can start inside the SkillsBench sandbox before rerunning or launching treatment; require compact dependency and launch preflight evidence instead of... |
 | `P0` | `skillsbench@1.1` | `suricata-custom-exfil` | `codex_loopx_treatment` | `skillsbench_codex_acp_runtime_preflight` | `skillsbench_codex_acp_jsonrpc_internal_error` | required_preflight=codex_acp_runtime_dependency_preflight,codex_acp_runtime_launch_preflight,skillsbench_compact_failure_class | prove the Codex ACP runtime can start inside the SkillsBench sandbox before rerunning or launching treatment; require compact dependency and launch preflight evidence instead of... |
 | `P0` | `terminal-bench@2.0` | `make-doom-for-mips` | `codex_loopx_treatment` | `verifier_attribution_required` | `score_failure_unattributed` |  | collect finer compact failure attribution before launching treatment |
-| `P0` | `skillsbench@1.1` | `citation-check` | `codex_loopx_treatment` | `verifier_or_infra_repair` | `verifier_infrastructure_failure` |  | repair verifier or infra attribution before comparing arms |
 | `P0` | `terminal-bench@2.0` | `install-windows-3.11` | `codex_loopx_treatment` | `worker_verifier_alignment` | `worker_validation_scope_ambiguous_official_score_failure` |  | align worker self-validation with verifier-facing compact evidence before repeating |
 | `P1` | `swe-marathon` | `zstd-decoder` | `swe_marathon_loopx_prompt_polling_treatment_10800` | `case_exception_research` | `agent_exception_before_solution_completion` |  | inspect compact exception attribution and form a case-level intervention hypothesis |
 | `P1` | `terminal-bench@2.0` | `pytorch-model-recovery` | `codex_goal_mode_baseline` | `case_exception_research` | `agent_exception_before_solution_completion` |  | inspect compact exception attribution and form a case-level intervention hypothesis |
@@ -125,6 +124,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `citation-check` | `codex_loopx_treatment` | `` | `0.0` | `` | `1:0,2:0,3:0,4:0,5:0,6:0,7:0,8:0,9:0,10:0,11:0,12:0` | `skillsbench_host_local_acp_codex_exec_failed_codex_exec_bridge_idle_timeout` | `.local/private-benchmark-jobs/skillsbench-citation-check-goal-start-local-20260627T0735Z/citation-check__loopx_goal_start_product_mode/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `citation-check` | `codex_loopx_treatment` | `case_attempt` | `missing` | `` | `` | `verifier_infrastructure_failure` | `.local/private-benchmark-jobs/skillsbench-citation-check-goal-start-post777-20260627T133638Z/remote-root/jobs/skillsbench-citation-check-goal-start-post777-20260627T133638Z-goalstart/citation-check__loopx_goal_start_product_mode/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `citation-check` | `codex_loopx_treatment` | `case_attempt` | `missing` | `` | `1:missing,2:missing,3:missing,4:missing,5:missing,6:missing,7:missing,8:missing,9:missing,10:missing,11:missing,12:missing,13:missing,14:missing,15:missing` | `verifier_infrastructure_failure` | `.local/private-benchmark-jobs/skillsbench-citation-check-goalstart-earlyexit-20260628T1235Z/citation-check__loopx_goal_start_product_mode/benchmark_run.compact.json` |
+| `skillsbench@1.1` | `citation-check` | `codex_loopx_treatment` | `case_attempt` | `1.0` | `2` | `1:0,2:1*` | `none` | `cloud-ecs/skillsbench-citation-check-goalstart-taskrecenter-20260629T091301Z/jobs/skillsbench-citation-check-goalstart-taskrecenter-20260629T091301Z-goalstart/citation-check__loopx_goal_start_product_mode/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `civ6-adjacency-optimizer` | `codex_goal_mode_baseline` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `` |
 | `skillsbench@1.1` | `civ6-adjacency-optimizer` | `loopx_automation_loop_treatment` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `` |
 | `skillsbench@1.1` | `civ6-adjacency-optimizer` | `baseline` | `` | `0.0` | `` | `1:0,2:0` | `official_verifier_solution_failure` | `.local/private-benchmark-jobs/skillsbench-civ6-adjacency-optimizer-blind-baseline-v0/civ6-adjacency-optimizer__codex_acp_blind_loop_v0/benchmark_run.compact.json` |


### PR DESCRIPTION
## Summary
- record the latest citation-check loopx goal-start reverse-channel rerun as official score 1.0
- update the citation-check latest decision from verifier/infra repair to baseline-solved treatment preserved
- refresh the generated benchmark run ledger markdown

## Validation
- python3 -m json.tool docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json >/dev/null
- python3 examples/benchmark-run-ledger-smoke.py
- git diff --check
- compact-only run-ledger-upsert dry run confirmed raw logs/task text were not read

## Boundary
Public ledger fields only; no raw benchmark logs, task text, raw trajectory, verifier tails, credentials, or absolute local paths are added.