### PR TITLE
Fix SkillsBench host-local ACP idle progress attribution

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -48,7 +48,10 @@ from loopx.benchmark_adapters.skillsbench_remote_bridge import (  # noqa: E402
     run_skillsbench_remote_command_file_bridge_probe,
     skillsbench_remote_command_file_bridge_command_is_fixture_probe,
 )
-from loopx.status import compact_benchmark_run  # noqa: E402
+from loopx.status import (  # noqa: E402
+    build_skillsbench_post_run_debug_gate,
+    compact_benchmark_run,
+)
 from scripts.skillsbench_automation_loop import (  # noqa: E402
     CODEX_ACP_RUNTIME_CONTAINER_BOOTSTRAP_CMD,
     CODEX_ACP_RUNTIME_DEPS_SETUP_CMD,
@@ -7823,6 +7826,222 @@ def test_skillsbench_host_local_idle_timeout_after_closeout_is_countable() -> No
         assert accounting["failure_class"] == "solver_failed", accounting
 
 
+def test_skillsbench_host_local_idle_no_output_progress_is_distinct() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-host-acp-idle-progress-") as tmp:
+        root = Path(tmp)
+        run_dir = root / "official" / "2026-06-15__00-00-00" / "sample-task__abc123"
+        result_path = run_dir / "result.json"
+        write_json(
+            result_path,
+            {
+                "task_name": "sample-task",
+                "rollout_name": "sample-task__abc123",
+                "rewards": None,
+                "agent": "codex-acp",
+                "agent_name": "codex-acp",
+                "model": "gpt-5.5",
+                "n_tool_calls": 0,
+                "n_prompts": 2,
+                "error": "ACP error -32002: local codex execution timeout",
+                "verifier_error": None,
+                "partial_trajectory": True,
+                "trajectory_source": "partial_acp",
+                "trajectory_summary": {
+                    "steps": 2,
+                    "round_count": 2,
+                    "tool_call_count": 0,
+                    "partial_trajectory": True,
+                },
+            },
+        )
+        write_json(
+            run_dir / "timing.json",
+            {
+                "environment_setup": 2.0,
+                "agent_setup": 1.0,
+                "agent_execution": 30.0,
+                "total": 33.0,
+            },
+        )
+        controller_trace = {
+            "schema_version": "skillsbench_loopx_controller_trace_v0",
+            "route": "loopx-goal-start-product-mode",
+            "trace_publicness": "public_counts_only_no_task_text_no_verifier_output",
+            "product_mode": True,
+            "max_rounds_budget": 16,
+            "initial_prompt_count": 1,
+            "followup_prompt_count": 2,
+            "stop_decision_count": 1,
+            "controller_action_decisions": 3,
+            "reward_observation_count": 2,
+            "remote_command_file_bridge_driver_lifecycle_execution_style": (
+                "orchestrated_agentloop_loopx_cli"
+            ),
+            "remote_command_file_bridge_driver_lifecycle_trace_count": 2,
+            "remote_command_file_bridge_driver_lifecycle_checkpoint_count": 2,
+            "remote_command_file_bridge_driver_lifecycle_request_count": 8,
+            "remote_command_file_bridge_driver_lifecycle_success_count": 8,
+            "remote_command_file_bridge_driver_lifecycle_failure_count": 0,
+            "remote_command_file_bridge_driver_lifecycle_loopx_cli_call_count": 8,
+            "remote_command_file_bridge_driver_lifecycle_loopx_state_read_count": 2,
+            "remote_command_file_bridge_driver_lifecycle_loopx_state_write_count": 2,
+            "remote_command_file_bridge_agent_operation_trace_status": (
+                "agent_operation_trace_recorded"
+            ),
+            "remote_command_file_bridge_agent_operation_trace_count": 2,
+            "remote_command_file_bridge_agent_operation_trace_satisfied": True,
+            "remote_command_file_bridge_agent_request_count": 5,
+            "remote_command_file_bridge_agent_task_facing_operation_count": 5,
+            "remote_command_file_bridge_agent_task_facing_success_count": 5,
+            "host_local_acp_bridge_progress_status": (
+                "bridge_task_facing_success_observed"
+            ),
+            "host_local_acp_bridge_progress_signal_source": (
+                "remote_command_file_bridge_agent_operations"
+            ),
+            "host_local_acp_codex_exec_failure_trace_present": True,
+            "host_local_acp_codex_exec_failure_trace_count": 2,
+            "host_local_acp_codex_exec_failure_category": (
+                "codex_exec_bridge_idle_timeout"
+            ),
+            "host_local_acp_codex_exec_failure_categories": [
+                "codex_exec_bridge_idle_timeout"
+            ],
+            "host_local_acp_codex_exec_failure_raw_material_recorded": False,
+            "product_mode_host_local_idle_no_task_output_progress": True,
+            "product_mode_host_local_idle_no_task_output_progress_stop": True,
+            "product_mode_host_local_idle_no_task_output_progress_streak": 2,
+            "product_mode_host_local_idle_no_task_output_progress_streak_threshold": 2,
+            "product_mode_host_local_idle_no_task_output_progress_round": 4,
+            "product_mode_host_local_idle_no_task_output_progress_stop_round": 4,
+            "product_mode_host_local_idle_no_task_output_progress_stop_count": 1,
+            "product_mode_host_local_idle_no_task_output_progress_acp_tool_calls": 0,
+            "product_mode_host_local_idle_no_task_output_progress_bridge_task_ops": 5,
+            "product_mode_host_local_idle_no_task_output_progress_bridge_task_successes": 5,
+            "product_mode_host_local_idle_no_task_output_progress_score_status": (
+                "missing"
+            ),
+            "product_mode_host_local_idle_no_task_output_progress_category": (
+                "codex_exec_bridge_idle_timeout"
+            ),
+            "product_mode_host_local_idle_no_task_output_progress_policy": (
+                "stop_after_two_host_local_idle_rounds_without_task_output_or_closeout"
+            ),
+            "last_decision": (
+                "stop_after_product_mode_host_local_idle_no_task_output_progress"
+            ),
+            "raw_task_text_recorded": False,
+            "raw_verifier_output_recorded": False,
+            "raw_agent_trajectory_recorded": False,
+        }
+        compact = compact_benchmark_run(
+            build_skillsbench_benchflow_result_benchmark_run(
+                result_path,
+                route="loopx-goal-start-product-mode",
+                controller_trace=controller_trace,
+            )
+        )
+        assert compact is not None
+        expected = "skillsbench_host_local_acp_idle_no_task_output_progress"
+        assert compact["score_failure_attribution"] == expected, compact
+        labels = compact["failure_attribution_labels"]
+        assert expected in labels, compact
+        assert "skillsbench_product_mode_transport_failure" in labels, compact
+        assert "skillsbench_runner_setup_error" not in labels, compact
+        assert "skillsbench_acp_agent_message_only_no_tool_calls" not in labels, compact
+        assert "official_score_zero_case_failure" not in labels, compact
+        accounting = compact["attempt_accounting"]
+        assert accounting["failure_class"] == "official_score_failed", accounting
+
+        counters = compact["interaction_counters"]
+        assert counters["private_trajectory_tool_call_count"] == 0, counters
+        assert counters["remote_command_file_bridge_agent_request_count"] == 5, counters
+        assert (
+            counters["remote_command_file_bridge_agent_task_facing_operation_count"]
+            == 5
+        ), counters
+        assert counters["host_local_acp_bridge_progress_status"] == (
+            "bridge_task_facing_success_observed"
+        ), counters
+        assert (
+            counters["product_mode_host_local_idle_no_task_output_progress_stop"]
+            is True
+        ), counters
+
+        timeline = skillsbench_loop._build_case_event_timeline(
+            compact,
+            {"runner_prerequisites": {}},
+        )
+        compact["case_event_timeline"] = timeline
+        gate = build_skillsbench_post_run_debug_gate(compact)
+        assert gate["todo_flow"]["task_facing_activity_status"] == (
+            "task_activity_observed"
+        ), gate
+        assert gate["todo_flow"]["host_local_acp_bridge_progress_status"] == (
+            "bridge_task_facing_success_observed"
+        ), gate
+        assert gate["todo_flow"]["acp_protocol_tool_call_count"] == 0, gate
+        assert gate["todo_flow"]["agent_bridge_task_facing_operation_count"] == 5, gate
+        assert gate["controller"]["status"] == (
+            "host_local_idle_no_task_output_progress_stop"
+        ), gate
+
+
+def test_product_mode_host_local_idle_no_output_progress_requires_new_trace() -> None:
+    trace: dict[str, Any] = {
+        "host_local_acp_codex_exec_failure_category": (
+            "codex_exec_bridge_idle_timeout"
+        ),
+        "host_local_acp_codex_exec_failure_trace_count": 1,
+        "remote_command_file_bridge_agent_request_count": 2,
+        "remote_command_file_bridge_agent_task_facing_operation_count": 2,
+        "remote_command_file_bridge_agent_task_facing_success_count": 2,
+    }
+    round_result = types.SimpleNamespace(n_tool_calls=0)
+
+    assert skillsbench_loop._product_mode_host_local_idle_no_task_output_progress_applicable(
+        trace,
+        round_result,
+        reward=None,
+    )
+    stopped = skillsbench_loop._record_product_mode_host_local_idle_no_task_output_progress(
+        trace,
+        agent_round=2,
+        reward=None,
+        round_result=round_result,
+    )
+    assert stopped is False, trace
+    assert (
+        trace["product_mode_host_local_idle_no_task_output_progress_streak"] == 1
+    ), trace
+    assert not skillsbench_loop._product_mode_host_local_idle_no_task_output_progress_applicable(
+        trace,
+        round_result,
+        reward=None,
+    )
+
+    trace["host_local_acp_codex_exec_failure_trace_count"] = 2
+    assert skillsbench_loop._product_mode_host_local_idle_no_task_output_progress_applicable(
+        trace,
+        round_result,
+        reward=0.0,
+    )
+    stopped = skillsbench_loop._record_product_mode_host_local_idle_no_task_output_progress(
+        trace,
+        agent_round=3,
+        reward=0.0,
+        round_result=round_result,
+    )
+    assert stopped is True, trace
+    assert trace["product_mode_host_local_idle_no_task_output_progress_stop"] is True
+    assert (
+        trace["product_mode_host_local_idle_no_task_output_progress_streak"] == 2
+    ), trace
+    assert trace["product_mode_host_local_idle_no_task_output_progress_policy"] == (
+        "stop_after_two_host_local_idle_rounds_without_task_output_or_closeout"
+    )
+
+
 def test_goal_start_host_local_defers_codex_exec_preflight_until_bridge_command() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-goal-start-preflight-") as tmp:
         args = parse_args(
@@ -11473,6 +11692,8 @@ if __name__ == "__main__":
     test_skillsbench_product_mode_solver_activity_gap_overrides_zero_score()
     test_skillsbench_product_mode_first_action_timeout_is_uncountable()
     test_skillsbench_host_local_idle_timeout_after_closeout_is_countable()
+    test_skillsbench_host_local_idle_no_output_progress_is_distinct()
+    test_product_mode_host_local_idle_no_output_progress_requires_new_trace()
     test_goal_start_host_local_defers_codex_exec_preflight_until_bridge_command()
     test_goal_start_host_exec_failure_overrides_zero_score_recovery()
     test_skillsbench_product_mode_declared_done_below_passing_reward_is_compacted()

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -463,9 +463,15 @@ def _skillsbench_attempt_failure_class(
     if _skillsbench_attempt_setup_blocked(failure_labels):
         return BenchmarkFailureClass.JOB_MATERIALIZATION_FAILED
     if score_failure_attribution in {
+        "skillsbench_host_local_acp_idle_no_task_output_progress",
         "skillsbench_product_mode_solver_activity_gap",
         "skillsbench_acp_agent_message_only_no_tool_calls",
     }:
+        if (
+            score_failure_attribution
+            == "skillsbench_host_local_acp_idle_no_task_output_progress"
+        ):
+            return BenchmarkFailureClass.OFFICIAL_SCORE_FAILED
         return BenchmarkFailureClass.SOLVER_FAILED
     if verifier_error_text and reward_value is None:
         return BenchmarkFailureClass.VERIFIER_FAILED
@@ -2154,6 +2160,14 @@ def _skillsbench_controller_trace_counters(
             "product_mode_no_open_todo_below_passing_reward_stop"
         )
         is True,
+        "product_mode_host_local_idle_no_task_output_progress": controller_trace.get(
+            "product_mode_host_local_idle_no_task_output_progress"
+        )
+        is True,
+        "product_mode_host_local_idle_no_task_output_progress_stop": controller_trace.get(
+            "product_mode_host_local_idle_no_task_output_progress_stop"
+        )
+        is True,
         "agent_declared_done": controller_trace.get("agent_declared_done") is True,
         "agent_declared_no_remaining_goals": controller_trace.get(
             "agent_declared_no_remaining_goals"
@@ -2458,6 +2472,33 @@ def _skillsbench_controller_trace_counters(
         "product_mode_no_open_todo_below_passing_reward_open_todo_count_public": count(
             "product_mode_no_open_todo_below_passing_reward_open_todo_count_public"
         ),
+        "product_mode_host_local_idle_no_task_output_progress_streak": count(
+            "product_mode_host_local_idle_no_task_output_progress_streak"
+        ),
+        "product_mode_host_local_idle_no_task_output_progress_streak_threshold": count(
+            "product_mode_host_local_idle_no_task_output_progress_streak_threshold"
+        ),
+        "product_mode_host_local_idle_no_task_output_progress_round": count(
+            "product_mode_host_local_idle_no_task_output_progress_round"
+        ),
+        "product_mode_host_local_idle_no_task_output_progress_stop_count": count(
+            "product_mode_host_local_idle_no_task_output_progress_stop_count"
+        ),
+        "product_mode_host_local_idle_no_task_output_progress_stop_round": count(
+            "product_mode_host_local_idle_no_task_output_progress_stop_round"
+        ),
+        "product_mode_host_local_idle_no_task_output_progress_last_failure_trace_count": count(
+            "product_mode_host_local_idle_no_task_output_progress_last_failure_trace_count"
+        ),
+        "product_mode_host_local_idle_no_task_output_progress_acp_tool_calls": count(
+            "product_mode_host_local_idle_no_task_output_progress_acp_tool_calls"
+        ),
+        "product_mode_host_local_idle_no_task_output_progress_bridge_task_ops": count(
+            "product_mode_host_local_idle_no_task_output_progress_bridge_task_ops"
+        ),
+        "product_mode_host_local_idle_no_task_output_progress_bridge_task_successes": count(
+            "product_mode_host_local_idle_no_task_output_progress_bridge_task_successes"
+        ),
         "product_mode_final_closeout_superseded_by_official_success": (
             controller_trace.get(
                 "product_mode_final_closeout_superseded_by_official_success"
@@ -2585,6 +2626,20 @@ def _skillsbench_controller_trace_counters(
         counters["host_local_acp_codex_exec_failure_category"] = (
             host_codex_failure_category
         )
+    bridge_progress_status = _skillsbench_public_safe_label(
+        controller_trace.get("host_local_acp_bridge_progress_status") or ""
+    )
+    if bridge_progress_status:
+        counters["host_local_acp_bridge_progress_status"] = (
+            bridge_progress_status
+        )
+    bridge_progress_source = _skillsbench_public_safe_label(
+        controller_trace.get("host_local_acp_bridge_progress_signal_source") or ""
+    )
+    if bridge_progress_source:
+        counters["host_local_acp_bridge_progress_signal_source"] = (
+            bridge_progress_source
+        )
     host_codex_failure_categories: list[str] = []
     raw_host_codex_failure_categories = controller_trace.get(
         "host_local_acp_codex_exec_failure_categories"
@@ -2655,6 +2710,46 @@ def _skillsbench_controller_trace_counters(
     if no_open_todo_score_status:
         counters["product_mode_no_open_todo_below_passing_reward_score_status"] = (
             no_open_todo_score_status
+        )
+    host_idle_score = controller_trace.get(
+        "product_mode_host_local_idle_no_task_output_progress_score"
+    )
+    if (
+        isinstance(host_idle_score, (int, float))
+        and not isinstance(host_idle_score, bool)
+    ):
+        counters["product_mode_host_local_idle_no_task_output_progress_score"] = float(
+            host_idle_score
+        )
+    host_idle_score_status = _skillsbench_public_safe_label(
+        controller_trace.get(
+            "product_mode_host_local_idle_no_task_output_progress_score_status"
+        )
+        or ""
+    )
+    if host_idle_score_status:
+        counters["product_mode_host_local_idle_no_task_output_progress_score_status"] = (
+            host_idle_score_status
+        )
+    host_idle_category = _skillsbench_public_safe_label(
+        controller_trace.get(
+            "product_mode_host_local_idle_no_task_output_progress_category"
+        )
+        or ""
+    )
+    if host_idle_category:
+        counters["product_mode_host_local_idle_no_task_output_progress_category"] = (
+            host_idle_category
+        )
+    host_idle_policy = _skillsbench_public_safe_label(
+        controller_trace.get(
+            "product_mode_host_local_idle_no_task_output_progress_policy"
+        )
+        or ""
+    )
+    if host_idle_policy:
+        counters["product_mode_host_local_idle_no_task_output_progress_policy"] = (
+            host_idle_policy
         )
     declared_done_policy = _skillsbench_public_safe_label(
         controller_trace.get("product_mode_declared_done_policy") or ""
@@ -3639,13 +3734,27 @@ def build_skillsbench_benchflow_result_benchmark_run(
         and agent_bridge_task_facing_operation_count > 0
         and agent_bridge_final_closeout_satisfied
     )
+    host_local_acp_idle_no_task_output_progress_stop = bool(
+        controller_counters.get(
+            "product_mode_host_local_idle_no_task_output_progress_stop"
+        )
+        is True
+    )
     if (
         host_local_acp_codex_exec_failure_present
         and not official_passed
         and not host_local_acp_idle_timeout_after_countable_closeout
     ):
-        host_failure_label = "skillsbench_host_local_acp_codex_exec_failed"
-        if host_local_acp_codex_exec_failure_category:
+        if host_local_acp_idle_no_task_output_progress_stop:
+            host_failure_label = (
+                "skillsbench_host_local_acp_idle_no_task_output_progress"
+            )
+        else:
+            host_failure_label = "skillsbench_host_local_acp_codex_exec_failed"
+        if (
+            host_local_acp_codex_exec_failure_category
+            and not host_local_acp_idle_no_task_output_progress_stop
+        ):
             host_failure_label = (
                 f"{host_failure_label}_{host_local_acp_codex_exec_failure_category}"
             )
@@ -3674,14 +3783,20 @@ def build_skillsbench_benchflow_result_benchmark_run(
         ]
         controller_budget_cutoff_before_followup = False
         controller_budget_cutoff_reason = "none"
-        for item in (
+        host_failure_extra_labels = [
             host_failure_label,
-            "skillsbench_host_local_acp_codex_exec_failed",
-            "skillsbench_runner_setup_error",
             "skillsbench_product_mode_transport_failure"
             if _is_skillsbench_loopx_product_mode_treatment_route(route)
             else "",
-        ):
+        ]
+        if not host_local_acp_idle_no_task_output_progress_stop:
+            host_failure_extra_labels.extend(
+                [
+                    "skillsbench_host_local_acp_codex_exec_failed",
+                    "skillsbench_runner_setup_error",
+                ]
+            )
+        for item in host_failure_extra_labels:
             if item and item not in failure_labels:
                 failure_labels.append(item)
     elif host_local_acp_idle_timeout_after_countable_closeout:
@@ -4270,6 +4385,13 @@ def build_skillsbench_benchflow_result_benchmark_run(
             "product_mode_no_open_todo_below_passing_reward_stop": controller_counters.get(
                 "product_mode_no_open_todo_below_passing_reward_stop", False
             ),
+            "product_mode_host_local_idle_no_task_output_progress": controller_counters.get(
+                "product_mode_host_local_idle_no_task_output_progress", False
+            ),
+            "product_mode_host_local_idle_no_task_output_progress_stop": controller_counters.get(
+                "product_mode_host_local_idle_no_task_output_progress_stop",
+                False,
+            ),
             "product_mode_lifecycle_checkpoint_count": controller_counters.get(
                 "product_mode_lifecycle_checkpoint_count", 0
             ),
@@ -4329,6 +4451,53 @@ def build_skillsbench_benchflow_result_benchmark_run(
             ),
             "product_mode_no_open_todo_below_passing_reward_score_status": controller_counters.get(
                 "product_mode_no_open_todo_below_passing_reward_score_status", ""
+            ),
+            "product_mode_host_local_idle_no_task_output_progress_streak": controller_counters.get(
+                "product_mode_host_local_idle_no_task_output_progress_streak",
+                0,
+            ),
+            "product_mode_host_local_idle_no_task_output_progress_streak_threshold": controller_counters.get(
+                "product_mode_host_local_idle_no_task_output_progress_streak_threshold",
+                0,
+            ),
+            "product_mode_host_local_idle_no_task_output_progress_round": controller_counters.get(
+                "product_mode_host_local_idle_no_task_output_progress_round",
+                0,
+            ),
+            "product_mode_host_local_idle_no_task_output_progress_stop_count": controller_counters.get(
+                "product_mode_host_local_idle_no_task_output_progress_stop_count",
+                0,
+            ),
+            "product_mode_host_local_idle_no_task_output_progress_stop_round": controller_counters.get(
+                "product_mode_host_local_idle_no_task_output_progress_stop_round",
+                0,
+            ),
+            "product_mode_host_local_idle_no_task_output_progress_acp_tool_calls": controller_counters.get(
+                "product_mode_host_local_idle_no_task_output_progress_acp_tool_calls",
+                0,
+            ),
+            "product_mode_host_local_idle_no_task_output_progress_bridge_task_ops": controller_counters.get(
+                "product_mode_host_local_idle_no_task_output_progress_bridge_task_ops",
+                0,
+            ),
+            "product_mode_host_local_idle_no_task_output_progress_bridge_task_successes": controller_counters.get(
+                "product_mode_host_local_idle_no_task_output_progress_bridge_task_successes",
+                0,
+            ),
+            "product_mode_host_local_idle_no_task_output_progress_score": controller_counters.get(
+                "product_mode_host_local_idle_no_task_output_progress_score"
+            ),
+            "product_mode_host_local_idle_no_task_output_progress_score_status": controller_counters.get(
+                "product_mode_host_local_idle_no_task_output_progress_score_status",
+                "",
+            ),
+            "product_mode_host_local_idle_no_task_output_progress_category": controller_counters.get(
+                "product_mode_host_local_idle_no_task_output_progress_category",
+                "",
+            ),
+            "product_mode_host_local_idle_no_task_output_progress_policy": controller_counters.get(
+                "product_mode_host_local_idle_no_task_output_progress_policy",
+                "",
             ),
             "product_mode_final_closeout_superseded_by_official_success": (
                 controller_counters.get(
@@ -4621,6 +4790,12 @@ def build_skillsbench_benchflow_result_benchmark_run(
                 controller_counters.get(
                     "host_local_acp_codex_exec_failure_trace_present", False
                 )
+            ),
+            "host_local_acp_bridge_progress_status": controller_counters.get(
+                "host_local_acp_bridge_progress_status", ""
+            ),
+            "host_local_acp_bridge_progress_signal_source": controller_counters.get(
+                "host_local_acp_bridge_progress_signal_source", ""
             ),
             "host_local_acp_codex_exec_failure_trace_count": (
                 controller_counters.get(

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -714,6 +714,8 @@ def _compact_benchmark_case_event_timeline(value: Any) -> dict[str, Any]:
         for field in (
             "execution_style",
             "agent_operation_trace_status",
+            "host_local_acp_bridge_progress_status",
+            "host_local_acp_bridge_progress_signal_source",
             "last_decision",
             "recovery_stage",
             "recovery_exception_type",
@@ -742,6 +744,7 @@ def _compact_benchmark_case_event_timeline(value: Any) -> dict[str, Any]:
             "trajectory_event_count",
             "trajectory_round_count",
             "trajectory_tool_call_count",
+            "acp_protocol_tool_call_count",
             "agent_bridge_request_count",
             "agent_bridge_task_facing_operation_count",
             "action_decision_count",
@@ -749,6 +752,8 @@ def _compact_benchmark_case_event_timeline(value: Any) -> dict[str, Any]:
             "followup_prompt_count",
             "stop_decision_count",
             "max_rounds_budget",
+            "host_local_idle_no_task_output_progress_streak",
+            "host_local_idle_no_task_output_progress_streak_threshold",
             "final_round",
             "recovery_delta_events",
             "recovery_delta_tool_calls",
@@ -1068,9 +1073,53 @@ def build_skillsbench_post_run_debug_gate(
                 in {"passed", "satisfied", "not_required"}
             ),
             "task_facing_activity_status": activity_status,
+            "host_local_acp_bridge_progress_status": (
+                public_safe_compact_text(
+                    activity_event.get("host_local_acp_bridge_progress_status"),
+                    limit=140,
+                )
+                or public_safe_compact_text(
+                    counters.get("host_local_acp_bridge_progress_status"),
+                    limit=140,
+                )
+                or "unknown"
+            ),
+            "host_local_acp_bridge_progress_signal_source": (
+                public_safe_compact_text(
+                    activity_event.get("host_local_acp_bridge_progress_signal_source"),
+                    limit=140,
+                )
+                or public_safe_compact_text(
+                    counters.get("host_local_acp_bridge_progress_signal_source"),
+                    limit=140,
+                )
+                or "unknown"
+            ),
+            "acp_protocol_tool_call_count": _benchmark_positive_int(
+                activity_event.get("acp_protocol_tool_call_count")
+            )
+            or _benchmark_positive_int(counters.get("private_trajectory_tool_call_count")),
+            "agent_bridge_task_facing_operation_count": _benchmark_positive_int(
+                activity_event.get("agent_bridge_task_facing_operation_count")
+            )
+            or _benchmark_positive_int(
+                counters.get("remote_command_file_bridge_agent_task_facing_operation_count")
+            ),
             "open_todo_count_public": _benchmark_positive_int(
                 counters.get("open_todo_count")
             ),
+            "host_local_idle_no_task_output_progress_streak": _benchmark_positive_int(
+                counters.get("product_mode_host_local_idle_no_task_output_progress_streak")
+            ),
+            "host_local_idle_no_task_output_progress_streak_threshold": _benchmark_positive_int(
+                counters.get(
+                    "product_mode_host_local_idle_no_task_output_progress_streak_threshold"
+                )
+            ),
+            "host_local_idle_no_task_output_progress_stop": counters.get(
+                "product_mode_host_local_idle_no_task_output_progress_stop"
+            )
+            is True,
             "no_open_todo_below_passing_reward_streak": _benchmark_positive_int(
                 counters.get(
                     "product_mode_no_open_todo_below_passing_reward_streak"
@@ -1180,6 +1229,8 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "product_mode_solver_activity_gap",
         "product_mode_declared_done_below_passing_reward",
         "product_mode_no_open_todo_below_passing_reward_stop",
+        "product_mode_host_local_idle_no_task_output_progress",
+        "product_mode_host_local_idle_no_task_output_progress_stop",
         "product_mode_final_closeout_superseded_by_official_success",
         "product_mode_no_tool_call_lifecycle_abort",
         "agent_declared_done",
@@ -1253,6 +1304,15 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "product_mode_no_open_todo_below_passing_reward_stop_count",
         "product_mode_no_open_todo_below_passing_reward_stop_round",
         "product_mode_no_open_todo_below_passing_reward_open_todo_count_public",
+        "product_mode_host_local_idle_no_task_output_progress_streak",
+        "product_mode_host_local_idle_no_task_output_progress_streak_threshold",
+        "product_mode_host_local_idle_no_task_output_progress_round",
+        "product_mode_host_local_idle_no_task_output_progress_stop_count",
+        "product_mode_host_local_idle_no_task_output_progress_stop_round",
+        "product_mode_host_local_idle_no_task_output_progress_last_failure_trace_count",
+        "product_mode_host_local_idle_no_task_output_progress_acp_tool_calls",
+        "product_mode_host_local_idle_no_task_output_progress_bridge_task_ops",
+        "product_mode_host_local_idle_no_task_output_progress_bridge_task_successes",
         "product_mode_final_closeout_superseded_round",
         "product_mode_no_tool_call_lifecycle_abort_count",
         "product_mode_no_tool_call_lifecycle_abort_round",
@@ -1342,6 +1402,7 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
     for field in (
         "product_mode_declared_done_below_passing_reward_score",
         "product_mode_no_open_todo_below_passing_reward_score",
+        "product_mode_host_local_idle_no_task_output_progress_score",
     ):
         raw = value.get(field)
         if isinstance(raw, (int, float)) and not isinstance(raw, bool):
@@ -1358,6 +1419,9 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "product_mode_solver_activity_missing_reason",
         "product_mode_declared_done_below_passing_reward_score_status",
         "product_mode_no_open_todo_below_passing_reward_score_status",
+        "product_mode_host_local_idle_no_task_output_progress_score_status",
+        "product_mode_host_local_idle_no_task_output_progress_category",
+        "product_mode_host_local_idle_no_task_output_progress_policy",
         "product_mode_declared_done_policy",
         "product_mode_final_closeout_superseded_reason",
         "controller_budget_cutoff_reason",
@@ -1371,6 +1435,8 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "remote_command_file_bridge_consumption_decision",
         "remote_command_file_bridge_driver_lifecycle_execution_style",
         "host_local_acp_codex_exec_failure_category",
+        "host_local_acp_bridge_progress_status",
+        "host_local_acp_bridge_progress_signal_source",
         "last_decision",
         "worker_submit_eligible_mismatch_reason",
         "worker_bridge_writeback_loss_reason",

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -317,6 +317,7 @@ PROTECTED_DIRECTIVE_RE = re.compile(
 DECLARED_DONE_MARKER = "AGENT_DECLARED_DONE_NO_REMAINING_GOALS"
 PRODUCT_MODE_FINAL_CLOSEOUT_MAX_CHECKPOINTS = 3
 PRODUCT_MODE_NO_OPEN_TODO_STOP_STREAK_THRESHOLD = 2
+PRODUCT_MODE_HOST_LOCAL_IDLE_NO_PROGRESS_STREAK_THRESHOLD = 2
 CODEX_ACP_RUNTIME_CONTAINER_BOOTSTRAP_CMD = (
     "set -e; "
     "export DEBIAN_FRONTEND=noninteractive; "
@@ -1606,6 +1607,8 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "host_local_acp_codex_exec_preflight_stage",
         "host_local_acp_codex_exec_preflight_first_blocker",
         "host_local_acp_codex_exec_failure_category",
+        "host_local_acp_bridge_progress_status",
+        "host_local_acp_bridge_progress_signal_source",
         "runner_interruption_kind",
         "runner_interruption_status",
         "reduce_only_prerequisites_source",
@@ -3213,10 +3216,24 @@ def _apply_agent_message_only_no_tool_calls_attribution(
     bridge_request_count = counters.get(
         "remote_command_file_bridge_agent_request_count"
     )
+    bridge_task_facing_count = counters.get(
+        "remote_command_file_bridge_agent_task_facing_operation_count"
+    )
+    bridge_progress_status = str(
+        counters.get("host_local_acp_bridge_progress_status") or ""
+    )
     if (
-        isinstance(bridge_request_count, int)
-        and not isinstance(bridge_request_count, bool)
-        and bridge_request_count > 0
+        (
+            isinstance(bridge_request_count, int)
+            and not isinstance(bridge_request_count, bool)
+            and bridge_request_count > 0
+        )
+        or (
+            isinstance(bridge_task_facing_count, int)
+            and not isinstance(bridge_task_facing_count, bool)
+            and bridge_task_facing_count > 0
+        )
+        or bridge_progress_status.startswith("bridge_")
     ):
         return False
 
@@ -3880,8 +3897,17 @@ def _build_case_event_timeline(
         trajectory_event_count=trajectory_event_count,
         trajectory_round_count=trajectory_round_count,
         trajectory_tool_call_count=trajectory_tool_call_count,
+        acp_protocol_tool_call_count=trajectory_tool_call_count,
         agent_bridge_request_count=agent_request_count,
         agent_bridge_task_facing_operation_count=task_facing_count,
+        host_local_acp_bridge_progress_status=(
+            counters.get("host_local_acp_bridge_progress_status")
+            or runner_prerequisites.get("host_local_acp_bridge_progress_status")
+        ),
+        host_local_acp_bridge_progress_signal_source=(
+            counters.get("host_local_acp_bridge_progress_signal_source")
+            or runner_prerequisites.get("host_local_acp_bridge_progress_signal_source")
+        ),
         agent_operation_trace_status=(
             counters.get("remote_command_file_bridge_agent_operation_trace_status")
             or runner_prerequisites.get(
@@ -3898,6 +3924,11 @@ def _build_case_event_timeline(
     controller_status = "not_observed"
     if counters.get("controller_official_success_observed") is True:
         controller_status = "official_success_observed"
+    elif (
+        counters.get("product_mode_host_local_idle_no_task_output_progress_stop")
+        is True
+    ):
+        controller_status = "host_local_idle_no_task_output_progress_stop"
     elif (
         counters.get("product_mode_no_open_todo_below_passing_reward_stop")
         is True
@@ -3929,6 +3960,14 @@ def _build_case_event_timeline(
         max_rounds_budget=_case_timeline_max_int(
             counters.get("controller_max_rounds_budget"),
             compact.get("controller_max_rounds_budget"),
+        ),
+        host_local_idle_no_task_output_progress_streak=_case_timeline_max_int(
+            counters.get("product_mode_host_local_idle_no_task_output_progress_streak")
+        ),
+        host_local_idle_no_task_output_progress_streak_threshold=_case_timeline_max_int(
+            counters.get(
+                "product_mode_host_local_idle_no_task_output_progress_streak_threshold"
+            )
         ),
         final_round=round_reward_trace.get("final_round"),
         best_round_reward=round_reward_trace.get("best_round_reward"),
@@ -6423,6 +6462,26 @@ def _merge_host_local_acp_relay_trace_summary(
             prerequisites.get("remote_command_file_bridge_agent_operation_trace_status")
             or "not_required"
         )
+    if agent_bridge_task_facing_success_count > 0:
+        host_local_acp_bridge_progress_status = (
+            "bridge_task_facing_success_observed"
+        )
+    elif agent_bridge_task_facing_operation_count > 0:
+        host_local_acp_bridge_progress_status = (
+            "bridge_task_facing_operation_observed_without_success"
+        )
+    elif agent_bridge_request_count > 0:
+        host_local_acp_bridge_progress_status = (
+            "bridge_agent_request_observed_no_task_facing"
+        )
+    elif host_local_acp_codex_exec_failure_category == "codex_exec_bridge_idle_timeout":
+        host_local_acp_bridge_progress_status = (
+            "codex_exec_bridge_idle_timeout_no_bridge_progress"
+        )
+    elif agent_trace_required:
+        host_local_acp_bridge_progress_status = "agent_operation_trace_missing"
+    else:
+        host_local_acp_bridge_progress_status = "not_required"
     trace["remote_command_file_bridge_agent_command_configured"] = (
         prerequisites.get("remote_command_file_bridge_agent_command_configured") is True
     )
@@ -6438,6 +6497,12 @@ def _merge_host_local_acp_relay_trace_summary(
     )
     trace["remote_command_file_bridge_agent_operation_trace_status"] = (
         agent_trace_status
+    )
+    trace["host_local_acp_bridge_progress_status"] = (
+        host_local_acp_bridge_progress_status
+    )
+    trace["host_local_acp_bridge_progress_signal_source"] = (
+        "remote_command_file_bridge_agent_operations"
     )
     trace["remote_command_file_bridge_agent_request_count"] = (
         agent_bridge_request_count
@@ -6592,6 +6657,12 @@ def _merge_host_local_acp_relay_trace_summary(
     )
     prerequisites["remote_command_file_bridge_agent_operation_trace_status"] = (
         agent_trace_status
+    )
+    prerequisites["host_local_acp_bridge_progress_status"] = (
+        host_local_acp_bridge_progress_status
+    )
+    prerequisites["host_local_acp_bridge_progress_signal_source"] = (
+        "remote_command_file_bridge_agent_operations"
     )
     prerequisites["remote_command_file_bridge_agent_request_count"] = (
         agent_bridge_request_count
@@ -7222,6 +7293,121 @@ def _product_mode_agent_bridge_closeout_observed(trace: dict[str, Any]) -> bool:
         )
         > 0
     )
+
+
+def _product_mode_host_local_idle_no_task_output_progress_applicable(
+    trace: dict[str, Any],
+    round_result: Any | None,
+    *,
+    reward: float | None,
+) -> bool:
+    if isinstance(reward, (int, float)) and not isinstance(reward, bool) and reward >= 1.0:
+        return False
+    if _product_mode_agent_bridge_closeout_observed(trace):
+        return False
+    if trace.get("host_local_acp_codex_exec_failure_category") != (
+        "codex_exec_bridge_idle_timeout"
+    ):
+        return False
+    failure_trace_count = _trace_max_int(
+        trace,
+        "host_local_acp_codex_exec_failure_trace_count",
+    )
+    if failure_trace_count <= 0:
+        return False
+    last_counted = _trace_max_int(
+        trace,
+        "product_mode_host_local_idle_no_task_output_progress_last_failure_trace_count",
+    )
+    if failure_trace_count <= last_counted:
+        return False
+    tool_call_count = (
+        _round_result_tool_call_count(round_result)
+        if round_result is not None
+        else None
+    )
+    return bool(
+        (isinstance(tool_call_count, int) and tool_call_count == 0)
+        or _trace_max_int(
+            trace,
+            "remote_command_file_bridge_agent_task_facing_operation_count",
+            "remote_command_file_bridge_agent_request_count",
+        )
+        > 0
+    )
+
+
+def _record_product_mode_host_local_idle_no_task_output_progress(
+    trace: dict[str, Any],
+    *,
+    agent_round: int,
+    reward: float | None,
+    round_result: Any | None,
+) -> bool:
+    current = trace.get("product_mode_host_local_idle_no_task_output_progress_streak")
+    if not isinstance(current, int) or isinstance(current, bool):
+        current = 0
+    streak = current + 1
+    threshold = PRODUCT_MODE_HOST_LOCAL_IDLE_NO_PROGRESS_STREAK_THRESHOLD
+    trace["product_mode_host_local_idle_no_task_output_progress"] = True
+    trace["product_mode_host_local_idle_no_task_output_progress_round"] = agent_round
+    trace["product_mode_host_local_idle_no_task_output_progress_streak"] = streak
+    trace["product_mode_host_local_idle_no_task_output_progress_streak_threshold"] = (
+        threshold
+    )
+    trace["product_mode_host_local_idle_no_task_output_progress_category"] = (
+        "codex_exec_bridge_idle_timeout"
+    )
+    trace[
+        "product_mode_host_local_idle_no_task_output_progress_last_failure_trace_count"
+    ] = _trace_max_int(trace, "host_local_acp_codex_exec_failure_trace_count")
+    tool_call_count = (
+        _round_result_tool_call_count(round_result)
+        if round_result is not None
+        else None
+    )
+    trace["product_mode_host_local_idle_no_task_output_progress_acp_tool_calls"] = (
+        tool_call_count if isinstance(tool_call_count, int) else 0
+    )
+    trace[
+        "product_mode_host_local_idle_no_task_output_progress_bridge_task_ops"
+    ] = _trace_max_int(
+        trace,
+        "remote_command_file_bridge_agent_task_facing_operation_count",
+    )
+    trace[
+        "product_mode_host_local_idle_no_task_output_progress_bridge_task_successes"
+    ] = _trace_max_int(
+        trace,
+        "remote_command_file_bridge_agent_task_facing_success_count",
+    )
+    if reward is None:
+        trace["product_mode_host_local_idle_no_task_output_progress_score_status"] = (
+            "missing"
+        )
+    else:
+        trace["product_mode_host_local_idle_no_task_output_progress_score"] = reward
+        trace["product_mode_host_local_idle_no_task_output_progress_score_status"] = (
+            "observed_below_passing"
+        )
+    if streak < threshold:
+        return False
+    trace["product_mode_host_local_idle_no_task_output_progress_stop"] = True
+    trace["product_mode_host_local_idle_no_task_output_progress_stop_round"] = (
+        agent_round
+    )
+    trace["product_mode_host_local_idle_no_task_output_progress_policy"] = (
+        "stop_after_two_host_local_idle_rounds_without_task_output_or_closeout"
+    )
+    stop_count = trace.get(
+        "product_mode_host_local_idle_no_task_output_progress_stop_count"
+    )
+    if not isinstance(stop_count, int) or isinstance(stop_count, bool):
+        stop_count = 0
+    trace["product_mode_host_local_idle_no_task_output_progress_stop_count"] = (
+        stop_count + 1
+    )
+    return True
 
 
 def _product_mode_solver_activity_observed(
@@ -7922,6 +8108,35 @@ def _build_product_mode_user(
             "has been recorded."
         )
 
+    def host_local_idle_no_progress_prompt(
+        round_number: int,
+        *,
+        task_instruction: str | None = None,
+    ) -> str:
+        task_clause = ""
+        if task_instruction:
+            task_clause = (
+                "\n\n--- TASK INSTRUCTION ---\n"
+                f"{task_instruction}\n\n"
+            )
+        return (
+            f"Mandatory host-local bridge recovery checkpoint before round "
+            f"{round_number}. The previous host-local Codex exec turn idled "
+            "after bridge activity and did not produce scored task output or "
+            "case closeout. This is not official reward or verifier feedback. "
+            "Do not wait for another local Codex process and do not answer with "
+            "status-only prose. Use the existing sandbox command/file bridge "
+            "now for one concrete task-facing action from `/app`: inspect the "
+            "task workspace, write or validate the scored output path if the "
+            "task names one, or record a compact blocker in the selected P0 "
+            "todo. If local task evidence proves completion, run the exact "
+            "case-local closeout sequence (`todo complete`, `refresh-state`, "
+            "`quota spend-slot --source adapter --execute`) before declaring "
+            "done.\n\n"
+            f"{closeout_commands(round_number)}"
+            f"{task_clause}"
+        )
+
     def final_closeout_prompt(round_number: int) -> str:
         return (
             f"Mandatory product-mode closeout checkpoint before finalization "
@@ -8169,6 +8384,50 @@ def _build_product_mode_user(
                         )
                         return self._scheduled_continuation_prompt(
                             scheduled_round=round + 1,
+                            task_instruction=instruction,
+                        )
+                    if (
+                        self._task_instruction_sent
+                        and product_mode_entry_lifecycle_gate_satisfied()
+                        and _product_mode_host_local_idle_no_task_output_progress_applicable(
+                            trace,
+                            round_result,
+                            reward=(
+                                float(reward)
+                                if isinstance(reward, (int, float))
+                                and not isinstance(reward, bool)
+                                else None
+                            ),
+                        )
+                    ):
+                        host_idle_stop = (
+                            _record_product_mode_host_local_idle_no_task_output_progress(
+                                trace,
+                                agent_round=round,
+                                reward=(
+                                    float(reward)
+                                    if isinstance(reward, (int, float))
+                                    and not isinstance(reward, bool)
+                                    else None
+                                ),
+                                round_result=round_result,
+                            )
+                        )
+                        _inc_counter(trace, "controller_action_decisions")
+                        if host_idle_stop or round >= max_rounds:
+                            _inc_counter(trace, "stop_decision_count")
+                            trace["last_decision"] = (
+                                "stop_after_product_mode_host_local_idle_no_"
+                                "task_output_progress"
+                            )
+                            return None
+                        _inc_counter(trace, "followup_prompt_count")
+                        trace["last_decision"] = (
+                            "send_product_mode_host_local_idle_no_task_output_"
+                            "progress_recovery"
+                        )
+                        return host_local_idle_no_progress_prompt(
+                            round + 1,
                             task_instruction=instruction,
                         )
                 if _round_result_declared_done(round_result):


### PR DESCRIPTION
## Summary
- distinguish ACP protocol tool-call counts from host-local reverse-channel task-facing bridge activity
- add a host-local idle/no-output recovery and two-strike stop policy after bridge idle timeout without scored output or closeout
- expose bridge progress and host-local idle signals in compact counters, case timelines, and post-run debug gates
- add regression smoke coverage for host-local idle/no-output attribution and repeated idle trace counting

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py loopx/benchmark_adapters/skillsbench.py loopx/status.py examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-host-local-launch-plan-smoke.py

## Boundary
Public-safe synthetic counters only; no raw task text, trajectories, verifier output, credentials, or local benchmark artifacts are committed.