### PR TITLE
Align SkillsBench goal-start prompt lifecycle

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -839,6 +839,16 @@ def test_goal_start_workflow_driver_bootstraps_bridge_before_task_packet() -> No
     assert "--- TASK INSTRUCTION ---" not in bootstrap_prompt
     assert "Compute the requested coefficient." not in bootstrap_prompt
     assert "FIRST ACTION REQUIRED" in bootstrap_prompt
+    assert "/loopx goal-start" in bootstrap_prompt
+    assert "heartbeat-prompt" in bootstrap_prompt
+    assert "Codex CLI TUI `/goal`" in bootstrap_prompt
+    assert "interaction_contract" in bootstrap_prompt
+    assert "workspace_guard" in bootstrap_prompt
+    assert "goal_boundary" in bootstrap_prompt
+    assert "execution_obligation" in bootstrap_prompt
+    assert "scheduler_hint" in bootstrap_prompt
+    assert "never authorizes quota spend" in bootstrap_prompt
+    assert "selected P0 todo" in bootstrap_prompt
     assert "benchmark task instruction will be sent after" in bootstrap_prompt
     assert trace["product_mode_task_instruction_deferred_until_agent_lifecycle"] is True
     assert trace["product_mode_task_instruction_sent_initially"] is False
@@ -867,6 +877,12 @@ def test_goal_start_workflow_driver_bootstraps_bridge_before_task_packet() -> No
     assert "--- TASK INSTRUCTION ---" in task_prompt
     assert "Compute the requested coefficient." in task_prompt
     assert "The task packet is now available" in task_prompt
+    assert "/loopx goal-start" in task_prompt
+    assert "interaction_contract" in task_prompt
+    assert "workspace_guard" in task_prompt
+    assert "goal_boundary" in task_prompt
+    assert "execution_obligation" in task_prompt
+    assert "scheduler_hint" in task_prompt
     assert trace["product_mode_task_instruction_sent_after_agent_lifecycle"] is True
     assert trace["last_decision"] == "send_product_mode_task_instruction_after_agent_lifecycle"
 

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -840,6 +840,8 @@ def test_goal_start_workflow_driver_bootstraps_bridge_before_task_packet() -> No
     assert "Compute the requested coefficient." not in bootstrap_prompt
     assert "FIRST ACTION REQUIRED" in bootstrap_prompt
     assert "/loopx goal-start" in bootstrap_prompt
+    assert "headless `/loopx goal-start`" in bootstrap_prompt
+    assert "not a live-user chat" in bootstrap_prompt
     assert "heartbeat-prompt" in bootstrap_prompt
     assert "Codex CLI TUI `/goal`" in bootstrap_prompt
     assert "interaction_contract" in bootstrap_prompt
@@ -847,6 +849,11 @@ def test_goal_start_workflow_driver_bootstraps_bridge_before_task_packet() -> No
     assert "goal_boundary" in bootstrap_prompt
     assert "execution_obligation" in bootstrap_prompt
     assert "scheduler_hint" in bootstrap_prompt
+    assert "there is no human available" in bootstrap_prompt
+    assert "do not ask or wait for the user" in bootstrap_prompt
+    assert "proceed with the task-facing work" in bootstrap_prompt
+    assert "Only record a blocker when the sandbox bridge" in bootstrap_prompt
+    assert "ordinary benchmark routing" in bootstrap_prompt
     assert "never authorizes quota spend" in bootstrap_prompt
     assert "selected P0 todo" in bootstrap_prompt
     assert "benchmark task instruction will be sent after" in bootstrap_prompt
@@ -878,11 +885,16 @@ def test_goal_start_workflow_driver_bootstraps_bridge_before_task_packet() -> No
     assert "Compute the requested coefficient." in task_prompt
     assert "The task packet is now available" in task_prompt
     assert "/loopx goal-start" in task_prompt
+    assert "headless `/loopx goal-start`" in task_prompt
     assert "interaction_contract" in task_prompt
     assert "workspace_guard" in task_prompt
     assert "goal_boundary" in task_prompt
     assert "execution_obligation" in task_prompt
     assert "scheduler_hint" in task_prompt
+    assert "there is no human available" in task_prompt
+    assert "do not ask or wait for the user" in task_prompt
+    assert "proceed with the task-facing work" in task_prompt
+    assert "Only record a blocker when the sandbox bridge" in task_prompt
     assert trace["product_mode_task_instruction_sent_after_agent_lifecycle"] is True
     assert trace["last_decision"] == "send_product_mode_task_instruction_after_agent_lifecycle"
 

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -8392,8 +8392,9 @@ def _build_controller_user(max_output_chars: int, trace: dict[str, Any]):
                 "The previous attempt did not pass the verifier. Continue in the "
                 "same workspace, read /app/instruction.md if needed, inspect the "
                 "failure, make the smallest correct fix, and rerun validation. "
-                "Do not ask the human unless protected material or credentials are "
-                "required.\n\n"
+                "Do not ask or wait for a human during benchmark execution; if "
+                "the sandbox, task workspace, or required tooling is technically "
+                "unavailable, record that blocker and otherwise keep solving.\n\n"
                 + "\n".join(feedback)
             )
 
@@ -9070,6 +9071,7 @@ def _build_product_mode_user(
                     "verifier error, or verifier output. "
                 )
                 +
+                f"{goal_start_loop_alignment_contract()}"
                 f"{done_clause}"
                 f"{self._persistent_constraint_clause} {mode_clause} Keep scope "
                 "narrow, validate locally, and if there are no remaining goals, "
@@ -9139,7 +9141,8 @@ def _build_product_mode_user(
                                 "status-only prose. Use the available sandbox "
                                 "command/file bridge now to inspect or modify the task "
                                 "workspace, then update the selected LoopX todo with "
-                                "public-safe evidence before any done/closeout claim."
+                                "public-safe evidence before any done/closeout claim. "
+                                f"{goal_start_loop_alignment_contract()}"
                             )
                         if no_tool_calls:
                             _record_product_mode_no_tool_call_lifecycle_abort(

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -8651,8 +8651,33 @@ def _build_product_mode_user(
         "or verifier tail will be shown during this run.\n\n"
     )
 
+    def goal_start_loop_alignment_contract() -> str:
+        if not goal_start_product_mode:
+            return ""
+        return (
+            "Goal-start loop alignment: this benchmark treatment models "
+            "headless `/loopx goal-start`, not a bare benchmark prompt and not "
+            "a live-user chat. The case-local `quota should-run` guard carries "
+            "the same machine loop fields as `heartbeat-prompt` and Codex CLI "
+            "TUI `/goal`: read `interaction_contract`, `workspace_guard`, "
+            "`goal_boundary`, `execution_obligation`, and `scheduler_hint` "
+            "before choosing work. In this benchmark route there is no human "
+            "available for routine next-step decisions, so do not ask or wait "
+            "for the user when the task can proceed. `scheduler_hint` is only "
+            "scheduling/final-check/self-stop policy and never authorizes quota "
+            "spend. Proceed with the task-facing work available to the official "
+            "runner instead of projecting permission boundaries. Only record a "
+            "blocker when the sandbox bridge, task workspace, or required "
+            "tooling is technically unavailable. Do not turn ordinary benchmark "
+            "routing, verifier failure, or uncertainty into a user gate. If "
+            "delivery is possible, continue with one bounded task-facing "
+            "segment, validate it, write back the selected P0 todo, and spend "
+            "exactly once only after the validated closeout sequence. "
+        )
+
     def treatment_state_contract() -> str:
         goal_start_clause = ""
+        goal_start_alignment = goal_start_loop_alignment_contract()
         if goal_start_product_mode:
             planned_count = (
                 planned_todo_count
@@ -8662,7 +8687,7 @@ def _build_product_mode_user(
                 else 3
             )
             goal_start_clause = (
-                "This route simulates `/loopx <task objective>` goal start: "
+                "This route models `/loopx goal-start <task objective>`: "
                 f"a compact ranked {planned_count}-todo plan must exist before "
                 "todo writes, "
                 f"with selected runnable P0 todo `{selected_p0_todo_id}` entering "
@@ -8680,6 +8705,7 @@ def _build_product_mode_user(
                 "and `refresh-state` checkpoint through the sandbox bridge "
                 "before this prompt. "
                 f"{goal_start_clause}"
+                f"{goal_start_alignment}"
                 "Do not repeat that setup checkpoint as "
                 "your first action. The benchmark task remains the primary "
                 "objective; LoopX commands track control-plane state and do "
@@ -8710,6 +8736,7 @@ def _build_product_mode_user(
             "the scored sandbox, then wait for the scheduler to send the task "
             "packet. "
             f"{goal_start_clause}"
+            f"{goal_start_alignment}"
             "Before reading, planning, solving, or answering the task, your first "
             "agent action must be a shell/tool call that sends the case-local "
             "LoopX CLI commands through the available sandbox bridge; a prose-only "
@@ -8807,9 +8834,10 @@ def _build_product_mode_user(
             "--- LOOPX PRODUCT-MODE CONTROL PLANE ---\n"
             "The canonical workflow lifecycle driver has already executed the "
             "case-local quota/todo/update/refresh checkpoint through the sandbox "
-            "bridge before this prompt. This route simulates `/loopx <task "
-            "objective>` goal start: a compact ranked todo plan and selected P0 "
+            "bridge before this prompt. This route models `/loopx goal-start "
+            "<task objective>`: a compact ranked todo plan and selected P0 "
             "todo have already been seeded in the case-local LoopX state. "
+            f"{goal_start_loop_alignment_contract()}"
             "Do not repeat setup lifecycle, do not solve from prose, and do not "
             "declare done in this bootstrap round. Your only job in this round "
             "is to prove task-facing sandbox access: copy and run the bridge "
@@ -8853,6 +8881,7 @@ def _build_product_mode_user(
             "changes, and continue solving. If local evidence shows the "
             "selected P0 is complete, run this exact case-local closeout "
             "sequence from `/app`:\n\n"
+            f"{goal_start_loop_alignment_contract()}"
             f"{closeout_commands(round_number)}"
             f"{task_clause}\n\n"
             "Do not answer with prose only, and only end with "
@@ -8886,6 +8915,7 @@ def _build_product_mode_user(
             "case-local closeout sequence (`todo complete`, `refresh-state`, "
             "`quota spend-slot --source adapter --execute`) before declaring "
             "done.\n\n"
+            f"{goal_start_loop_alignment_contract()}"
             f"{closeout_commands(round_number)}"
             f"{task_clause}"
         )
@@ -8902,6 +8932,7 @@ def _build_product_mode_user(
             "new broad exploration loop. If local task-facing validation "
             "indicates the selected P0 is complete, run this exact case-local "
             "closeout sequence from `/app` now:\n\n"
+            f"{goal_start_loop_alignment_contract()}"
             f"{closeout_commands(round_number)}"
             "If local validation does not support closeout, perform one "
             "focused task-facing validation or repair operation from `/app`, "


### PR DESCRIPTION
## Summary
- align the SkillsBench `/loopx goal-start` product-mode prompt with the heartbeat/Codex CLI TUI loop contract
- make the case-local quota guard fields explicit: `interaction_contract`, `workspace_guard`, `goal_boundary`, `execution_obligation`, and `scheduler_hint`
- clarify that `scheduler_hint` never authorizes quota spend, blockers should be recorded on the selected P0 todo, and spend happens exactly once after validated closeout
- add smoke coverage so bootstrap and task prompts keep the `/loopx goal-start` alignment contract visible

## Validation
- `python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py`
- `python3 examples/skillsbench-goal-start-product-mode-route-smoke.py`
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `python3 -m loopx.cli check --scan-path scripts/skillsbench_automation_loop.py --scan-path examples/skillsbench-benchmark-run-smoke.py`

LoopX check warning only: duplicate historical index rows for loopx-meta; public boundary scan clean for changed files.
