### PR TITLE
Add private LoopX state backup command

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -64,6 +64,27 @@ Success looks like this:
 - `loopx status` shows the goal and who should act next;
 - local runtime state is ignored, not committed.
 
+## Local State Backup
+
+Before risky migrations, local scheduler changes, or release-install repair,
+preview the state archive:
+
+```bash
+loopx backup-state --project .
+```
+
+Write the archive only when the preview looks right:
+
+```bash
+loopx backup-state --project . --execute
+```
+
+The backup is written under `~/.codex/loopx/backups` by default and captures the
+shared LoopX runtime root, this project's `.loopx`, `.codex/goals`, and
+`.local/goals` state, Codex App automations, and installed `loopx-*` skills
+when present. Treat the archive and manifest as private local recovery
+material; do not commit them or publish their contents.
+
 ## Codex CLI TUI Setup
 
 For Codex CLI users, the product target is: start in the Codex TUI, send one

--- a/examples/cli-support-control-command-modularization-smoke.py
+++ b/examples/cli-support-control-command-modularization-smoke.py
@@ -42,6 +42,7 @@ def main() -> None:
     init_source = INIT.read_text(encoding="utf-8")
 
     forbidden_cli_markers = [
+        "backup_state_parser = sub.add_parser",
         "heartbeat_prompt_parser = sub.add_parser",
         "promotion_gate_parser = sub.add_parser",
         "upgrade_plan_parser = sub.add_parser",
@@ -53,9 +54,11 @@ def main() -> None:
         "build_promotion_gate(",
         "build_upgrade_plan(",
         "build_update_plan(",
+        "build_state_backup_plan(",
         "inspect_registry(",
         "inspect_registry_boundary(",
         "serve_status(",
+        'if args.command == "backup-state":',
         'if args.command == "heartbeat-prompt":',
         'if args.command == "promotion-gate":',
         'if args.command == "upgrade-plan":',
@@ -72,6 +75,7 @@ def main() -> None:
         "register_support_control_commands",
         "handle_support_control_command",
         "resolve_heartbeat_active_state",
+        "backup-state",
         "heartbeat-prompt",
         "promotion-gate",
         "upgrade-plan",
@@ -86,6 +90,7 @@ def main() -> None:
     require("handle_support_control_command" in init_source, "__init__ omitted support/control handler")
 
     for command, options in {
+        "backup-state": ("--project", "--output-dir", "--backup-id", "--execute"),
         "heartbeat-prompt": ("--goal-id", "--agent-id", "--thin"),
         "promotion-gate": ("--format",),
         "upgrade-plan": ("--installed-manifest", "--cli-bin", "--mode"),

--- a/examples/loopx-project-skill-goal-text-precedence-smoke.py
+++ b/examples/loopx-project-skill-goal-text-precedence-smoke.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Guard the loopx-project skill against downgrading goal text to bare /loopx."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL = ROOT / "skills" / "loopx-project" / "SKILL.md"
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def main() -> int:
+    text = SKILL.read_text(encoding="utf-8")
+    require("Recognized project-local goal-start command:" in text, "goal-start heading missing")
+    require("- `/loopx <goal text>`" in text, "goal-text command missing")
+    require("- `/loopx`\n" not in text, "bare /loopx should not be listed as project-local fallback")
+    require("If there is any non-whitespace text after `/loopx`, it is goal text." in text, "goal text precedence missing")
+    require("do not downgrade the\nrequest into a status or inspection turn" in text, "downgrade guard missing")
+    require("Bare `/loopx` is read/status-first" not in text, "bare /loopx status-first branch should not steer this skill")
+    print("loopx-project-skill-goal-text-precedence-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/state-backup-smoke.py
+++ b/examples/state-backup-smoke.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Smoke-test local LoopX state backup planning and execution."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tarfile
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.state_backup import build_state_backup_plan, execute_state_backup_plan
+
+
+def write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def write_json(path: Path, payload: dict[str, object]) -> None:
+    write_text(path, json.dumps(payload, ensure_ascii=False, indent=2) + "\n")
+
+
+def seed_fixture(root: Path) -> tuple[Path, Path, Path]:
+    home = root / "home"
+    codex_home = home / ".codex"
+    runtime = codex_home / "loopx"
+    project = root / "project"
+
+    write_json(runtime / "registry.global.json", {"schema_version": "0.1", "goals": [{"id": "fixture"}]})
+    write_json(project / ".loopx" / "registry.json", {"schema_version": "0.1", "goals": [{"id": "fixture"}]})
+    write_text(project / ".codex" / "goals" / "fixture" / "ACTIVE_GOAL_STATE.md", "# fixture\n")
+    write_text(project / ".local" / "goals" / "fixture" / "ACTIVE_GOAL_STATE.md", "# local fixture\n")
+    write_json(codex_home / "automations" / "fixture.json", {"automation_id": "fixture"})
+    write_text(codex_home / "skills" / "loopx-fixture" / "SKILL.md", "# fixture skill\n")
+
+    # This path lives under the default output dir and must not be captured.
+    write_text(runtime / "backups" / "old" / "stale.txt", "stale backup\n")
+    return project, runtime, codex_home
+
+
+def run_cli(project: Path, runtime: Path, backup_id: str, env: dict[str, str]) -> dict[str, object]:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "--runtime-root",
+            str(runtime),
+            "backup-state",
+            "--project",
+            str(project),
+            "--backup-id",
+            backup_id,
+            "--execute",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 0, (result.returncode, result.stdout, result.stderr)
+    return json.loads(result.stdout)
+
+
+def assert_archive(payload: dict[str, object]) -> None:
+    archive_path = Path(str(payload["archive_path"]))
+    manifest_path = Path(str(payload["manifest_path"]))
+    assert archive_path.exists(), payload
+    assert manifest_path.exists(), payload
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == "loopx_state_backup_v0", manifest
+    assert manifest["dry_run"] is False, manifest
+    execution = manifest["execution"]
+    assert execution["archive_sha256"], execution
+    assert execution["archive_size_bytes"] > 0, execution
+    with tarfile.open(archive_path, "r:gz") as archive:
+        names = set(archive.getnames())
+    assert "runtime-root/registry.global.json" in names, names
+    assert "project/.loopx/registry.json" in names, names
+    assert "project/.codex/goals/fixture/ACTIVE_GOAL_STATE.md" in names, names
+    assert "project/.local/goals/fixture/ACTIVE_GOAL_STATE.md" in names, names
+    assert "codex/automations/fixture.json" in names, names
+    assert "codex/skills/loopx-fixture/SKILL.md" in names, names
+    assert "manifest.json" in names, names
+    assert "runtime-root/backups/old/stale.txt" not in names, names
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-state-backup-smoke-") as tmp:
+        root = Path(tmp)
+        project, runtime, codex_home = seed_fixture(root)
+        env = {
+            **os.environ,
+            "HOME": str(codex_home.parent),
+            "CODEX_HOME": str(codex_home),
+            "PYTHONPATH": str(REPO_ROOT),
+        }
+        old_home = os.environ.get("HOME")
+        old_codex_home = os.environ.get("CODEX_HOME")
+        os.environ["HOME"] = str(codex_home.parent)
+        os.environ["CODEX_HOME"] = str(codex_home)
+        try:
+            plan = build_state_backup_plan(project=project, runtime_root=runtime, backup_id="module-fixture")
+            assert plan["ok"] is True, plan
+            assert plan["dry_run"] is True, plan
+            assert plan["summary"]["included_target_count"] >= 5, plan
+            applied = execute_state_backup_plan(plan)
+            assert applied["ok"] is True, applied
+            assert applied["dry_run"] is False, applied
+            assert_archive(applied)
+        finally:
+            if old_home is None:
+                os.environ.pop("HOME", None)
+            else:
+                os.environ["HOME"] = old_home
+            if old_codex_home is None:
+                os.environ.pop("CODEX_HOME", None)
+            else:
+                os.environ["CODEX_HOME"] = old_codex_home
+
+        cli_payload = run_cli(project, runtime, "cli-fixture", env)
+        assert cli_payload["ok"] is True, cli_payload
+        assert cli_payload["summary"]["included_target_count"] >= 5, cli_payload
+        assert_archive(cli_payload)
+
+    print("state-backup-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/cli_commands/support_control.py
+++ b/loopx/cli_commands/support_control.py
@@ -28,6 +28,11 @@ from ..registry import (
     resolve_state_file,
 )
 from ..self_update import build_update_plan, execute_update_plan, render_update_plan_markdown
+from ..state_backup import (
+    build_state_backup_plan,
+    execute_state_backup_plan,
+    render_state_backup_markdown,
+)
 from ..status import render_status_markdown
 from ..status_server import (
     DEFAULT_STATUS_HOST,
@@ -46,6 +51,7 @@ FormatSelector = Callable[..., str]
 AddFormat = Callable[[argparse.ArgumentParser], None]
 
 SUPPORT_CONTROL_COMMANDS = {
+    "backup-state",
     "heartbeat-prompt",
     "promotion-gate",
     "upgrade-plan",
@@ -114,6 +120,40 @@ def register_support_control_commands(
     subparsers: argparse._SubParsersAction,
     add_subcommand_format: AddFormat,
 ) -> None:
+    backup_state_parser = subparsers.add_parser(
+        "backup-state",
+        help="Preview or create a private local archive of LoopX state.",
+    )
+    add_subcommand_format(backup_state_parser)
+    backup_state_parser.add_argument(
+        "--project",
+        default=".",
+        help="Project root whose .loopx, .codex/goals, and .local/goals state should be included.",
+    )
+    backup_state_parser.add_argument(
+        "--output-dir",
+        help="Directory for the backup archive and manifest. Defaults to <runtime-root>/backups.",
+    )
+    backup_state_parser.add_argument(
+        "--backup-id",
+        help="Stable id for the archive name. Defaults to a UTC timestamp.",
+    )
+    backup_state_parser.add_argument(
+        "--no-automations",
+        action="store_true",
+        help="Exclude $CODEX_HOME/automations from the backup.",
+    )
+    backup_state_parser.add_argument(
+        "--no-skills",
+        action="store_true",
+        help="Exclude $CODEX_HOME/skills/loopx-* skill directories from the backup.",
+    )
+    backup_state_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Write the backup archive and manifest. Omit for a dry-run plan.",
+    )
+
     heartbeat_prompt_parser = subparsers.add_parser(
         "heartbeat-prompt",
         help="Generate a guarded Codex App heartbeat automation task body.",
@@ -289,6 +329,34 @@ def handle_support_control_command(
 ) -> int | None:
     if args.command not in SUPPORT_CONTROL_COMMANDS:
         return None
+
+    if args.command == "backup-state":
+        try:
+            backup_runtime_root = Path(args.runtime_root).expanduser() if args.runtime_root else None
+            if backup_runtime_root is None and registry_path.exists():
+                backup_runtime_root = resolve_runtime_root(load_registry(registry_path))
+            payload = build_state_backup_plan(
+                project=Path(args.project).expanduser(),
+                runtime_root=backup_runtime_root,
+                output_dir=Path(args.output_dir).expanduser() if args.output_dir else None,
+                backup_id=args.backup_id,
+                include_automations=not bool(args.no_automations),
+                include_skills=not bool(args.no_skills),
+            )
+            if args.execute:
+                payload = execute_state_backup_plan(payload)
+        except Exception as exc:
+            payload = {
+                "ok": False,
+                "schema_version": "loopx_state_backup_v0",
+                "mode": "state_backup",
+                "dry_run": not bool(getattr(args, "execute", False)),
+                "execute_requested": bool(getattr(args, "execute", False)),
+                "error": str(exc),
+                "recommended_action": "fix backup planning before retrying",
+            }
+        print_payload(payload, output_format(args), render_state_backup_markdown)
+        return 0 if payload.get("ok") else 1
 
     if args.command == "heartbeat-prompt":
         active_state = None

--- a/loopx/state_backup.py
+++ b/loopx/state_backup.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import io
+import json
+import os
+from pathlib import Path
+import tarfile
+from typing import Any
+
+from . import __version__
+from .paths import DEFAULT_RUNTIME_ROOT
+
+
+STATE_BACKUP_SCHEMA_VERSION = "loopx_state_backup_v0"
+
+
+def _utc_timestamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _codex_home() -> Path:
+    return Path(os.environ.get("CODEX_HOME", Path.home() / ".codex")).expanduser()
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _resolved(path: Path) -> Path:
+    return path.expanduser().resolve(strict=False)
+
+
+def _should_skip(path: Path, exclude_roots: list[Path]) -> bool:
+    resolved = _resolved(path)
+    return any(resolved == root or _is_relative_to(resolved, root) for root in exclude_roots)
+
+
+def _path_stats(path: Path, exclude_roots: list[Path]) -> tuple[dict[str, int], list[str]]:
+    stats = {"paths": 0, "files": 0, "directories": 0, "symlinks": 0, "bytes": 0}
+    warnings: list[str] = []
+
+    def visit(item: Path) -> None:
+        if _should_skip(item, exclude_roots):
+            return
+        try:
+            stat = item.lstat()
+        except OSError as exc:
+            warnings.append(f"could not stat {item}: {exc}")
+            return
+        stats["paths"] += 1
+        stats["bytes"] += int(stat.st_size)
+        if item.is_symlink():
+            stats["symlinks"] += 1
+            return
+        if item.is_dir():
+            stats["directories"] += 1
+            try:
+                children = sorted(item.iterdir(), key=lambda child: child.name)
+            except OSError as exc:
+                warnings.append(f"could not list {item}: {exc}")
+                return
+            for child in children:
+                visit(child)
+            return
+        stats["files"] += 1
+
+    visit(path)
+    return stats, warnings
+
+
+def _target(
+    *,
+    key: str,
+    source_path: Path,
+    archive_path: str,
+    exclude_roots: list[Path],
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None, list[str]]:
+    if not source_path.exists() and not source_path.is_symlink():
+        return None, {"key": key, "source_path": str(source_path), "reason": "path does not exist"}, []
+    stats, warnings = _path_stats(source_path, exclude_roots)
+    return (
+        {
+            "key": key,
+            "source_path": str(source_path),
+            "archive_path": archive_path,
+            "stats": stats,
+        },
+        None,
+        warnings,
+    )
+
+
+def _discover_targets(
+    *,
+    project: Path,
+    runtime_root: Path,
+    output_dir: Path,
+    include_automations: bool,
+    include_skills: bool,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]], list[str]]:
+    targets: list[dict[str, Any]] = []
+    missing: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    exclude_roots = [_resolved(output_dir)]
+
+    def add(key: str, source_path: Path, archive_path: str) -> None:
+        found, absent, target_warnings = _target(
+            key=key,
+            source_path=source_path.expanduser(),
+            archive_path=archive_path,
+            exclude_roots=exclude_roots,
+        )
+        if found is not None:
+            targets.append(found)
+        if absent is not None:
+            missing.append(absent)
+        warnings.extend(target_warnings)
+
+    add("runtime_root", runtime_root, "runtime-root")
+    add("project_loopx", project / ".loopx", "project/.loopx")
+    add("project_codex_goals", project / ".codex" / "goals", "project/.codex/goals")
+    add("project_local_goals", project / ".local" / "goals", "project/.local/goals")
+
+    codex_home = _codex_home()
+    if include_automations:
+        add("codex_automations", codex_home / "automations", "codex/automations")
+    if include_skills:
+        skills_root = codex_home / "skills"
+        skill_dirs = sorted(skills_root.glob("loopx-*")) if skills_root.exists() else []
+        if skill_dirs:
+            for skill_dir in skill_dirs:
+                add(f"codex_skill:{skill_dir.name}", skill_dir, f"codex/skills/{skill_dir.name}")
+        else:
+            missing.append(
+                {
+                    "key": "codex_loopx_skills",
+                    "source_path": str(skills_root / "loopx-*"),
+                    "reason": "no loopx-* skills found",
+                }
+            )
+    return targets, missing, warnings
+
+
+def build_state_backup_plan(
+    *,
+    project: Path | str = ".",
+    runtime_root: Path | str | None = None,
+    output_dir: Path | str | None = None,
+    backup_id: str | None = None,
+    include_automations: bool = True,
+    include_skills: bool = True,
+) -> dict[str, Any]:
+    resolved_project = _resolved(Path(project))
+    resolved_runtime_root = _resolved(Path(runtime_root).expanduser() if runtime_root else DEFAULT_RUNTIME_ROOT)
+    resolved_output_dir = _resolved(Path(output_dir).expanduser() if output_dir else resolved_runtime_root / "backups")
+    resolved_backup_id = backup_id or _utc_timestamp()
+    archive_path = resolved_output_dir / f"loopx-state-{resolved_backup_id}.tar.gz"
+    manifest_path = resolved_output_dir / f"loopx-state-{resolved_backup_id}.manifest.json"
+    targets, missing, warnings = _discover_targets(
+        project=resolved_project,
+        runtime_root=resolved_runtime_root,
+        output_dir=resolved_output_dir,
+        include_automations=include_automations,
+        include_skills=include_skills,
+    )
+    total_stats = {
+        "paths": sum(int(item.get("stats", {}).get("paths", 0)) for item in targets),
+        "files": sum(int(item.get("stats", {}).get("files", 0)) for item in targets),
+        "directories": sum(int(item.get("stats", {}).get("directories", 0)) for item in targets),
+        "symlinks": sum(int(item.get("stats", {}).get("symlinks", 0)) for item in targets),
+        "bytes": sum(int(item.get("stats", {}).get("bytes", 0)) for item in targets),
+    }
+    return {
+        "ok": True,
+        "schema_version": STATE_BACKUP_SCHEMA_VERSION,
+        "mode": "state_backup",
+        "dry_run": True,
+        "execute_requested": False,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "backup_id": resolved_backup_id,
+        "project": str(resolved_project),
+        "runtime_root": str(resolved_runtime_root),
+        "codex_home": str(_codex_home()),
+        "output_dir": str(resolved_output_dir),
+        "archive_path": str(archive_path),
+        "manifest_path": str(manifest_path),
+        "included": targets,
+        "missing": missing,
+        "warnings": warnings,
+        "summary": {
+            "included_target_count": len(targets),
+            "missing_target_count": len(missing),
+            "warning_count": len(warnings),
+            "total_stats": total_stats,
+        },
+        "execution": None,
+        "recommended_action": (
+            "run `loopx backup-state --execute` to write the private local backup"
+            if targets
+            else "no backup targets found; check --project, --runtime-root, and CODEX_HOME"
+        ),
+    }
+
+
+def _add_path_to_tar(tar: tarfile.TarFile, source: Path, archive_path: str, exclude_roots: list[Path]) -> None:
+    if _should_skip(source, exclude_roots):
+        return
+    if source.is_dir() and not source.is_symlink():
+        tar.add(source, arcname=archive_path, recursive=False)
+        for child in sorted(source.iterdir(), key=lambda item: item.name):
+            _add_path_to_tar(tar, child, f"{archive_path}/{child.name}", exclude_roots)
+        return
+    tar.add(source, arcname=archive_path, recursive=False)
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def execute_state_backup_plan(payload: dict[str, Any]) -> dict[str, Any]:
+    archive_path = Path(str(payload["archive_path"])).expanduser()
+    manifest_path = Path(str(payload["manifest_path"])).expanduser()
+    output_dir = Path(str(payload["output_dir"])).expanduser()
+    included = payload.get("included") if isinstance(payload.get("included"), list) else []
+    if not included:
+        updated = dict(payload)
+        updated["ok"] = False
+        updated["execute_requested"] = True
+        updated["recommended_action"] = "no backup targets found; nothing was written"
+        return updated
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    exclude_roots = [_resolved(output_dir)]
+    updated = dict(payload)
+    updated["dry_run"] = False
+    updated["execute_requested"] = True
+    updated["package_version"] = __version__
+    updated["execution"] = {
+        "archive_path": str(archive_path),
+        "manifest_path": str(manifest_path),
+        "archive_sha256": None,
+        "archive_size_bytes": None,
+    }
+    updated["recommended_action"] = "backup written; keep the archive local and private"
+
+    manifest_for_archive = dict(updated)
+    manifest_bytes = json.dumps(manifest_for_archive, ensure_ascii=False, indent=2).encode("utf-8")
+    with tarfile.open(archive_path, "w:gz", dereference=False) as tar:
+        for item in included:
+            if not isinstance(item, dict):
+                continue
+            source = Path(str(item.get("source_path") or "")).expanduser()
+            archive_name = str(item.get("archive_path") or source.name)
+            if source.exists() or source.is_symlink():
+                _add_path_to_tar(tar, source, archive_name, exclude_roots)
+        info = tarfile.TarInfo("manifest.json")
+        info.size = len(manifest_bytes)
+        info.mtime = int(datetime.now(timezone.utc).timestamp())
+        tar.addfile(info, io.BytesIO(manifest_bytes))
+
+    execution = dict(updated["execution"])
+    execution["archive_sha256"] = _sha256_file(archive_path)
+    execution["archive_size_bytes"] = archive_path.stat().st_size
+    updated["execution"] = execution
+    manifest_path.write_text(json.dumps(updated, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    return updated
+
+
+def render_state_backup_markdown(payload: dict[str, Any]) -> str:
+    summary = payload.get("summary") if isinstance(payload.get("summary"), dict) else {}
+    total = summary.get("total_stats") if isinstance(summary.get("total_stats"), dict) else {}
+    lines = [
+        "# LoopX State Backup",
+        "",
+        f"- OK: `{payload.get('ok')}`",
+        f"- Dry run: `{payload.get('dry_run')}`",
+        f"- Backup id: `{payload.get('backup_id')}`",
+        f"- Project: `{payload.get('project')}`",
+        f"- Runtime root: `{payload.get('runtime_root')}`",
+        f"- Output dir: `{payload.get('output_dir')}`",
+        f"- Included targets: `{summary.get('included_target_count')}`",
+        f"- Missing targets: `{summary.get('missing_target_count')}`",
+        f"- Total paths: `{total.get('paths')}`",
+        f"- Total bytes: `{total.get('bytes')}`",
+        f"- Recommended action: {payload.get('recommended_action')}",
+    ]
+    execution = payload.get("execution")
+    if isinstance(execution, dict):
+        lines.extend(
+            [
+                "",
+                "## Written Files",
+                "",
+                f"- Archive: `{execution.get('archive_path')}`",
+                f"- Manifest: `{execution.get('manifest_path')}`",
+                f"- Archive sha256: `{execution.get('archive_sha256')}`",
+                f"- Archive bytes: `{execution.get('archive_size_bytes')}`",
+            ]
+        )
+    included = payload.get("included") if isinstance(payload.get("included"), list) else []
+    if included:
+        lines.extend(["", "## Included", ""])
+        for item in included:
+            if isinstance(item, dict):
+                stats = item.get("stats") if isinstance(item.get("stats"), dict) else {}
+                lines.append(
+                    f"- `{item.get('key')}` -> `{item.get('archive_path')}` "
+                    f"({stats.get('paths')} paths)"
+                )
+    missing = payload.get("missing") if isinstance(payload.get("missing"), list) else []
+    if missing:
+        lines.extend(["", "## Missing", ""])
+        for item in missing:
+            if isinstance(item, dict):
+                lines.append(f"- `{item.get('key')}`: {item.get('reason')}")
+    warnings = payload.get("warnings") if isinstance(payload.get("warnings"), list) else []
+    if warnings:
+        lines.extend(["", "## Warnings", ""])
+        for warning in warnings:
+            lines.append(f"- {warning}")
+    return "\n".join(lines) + "\n"

--- a/skills/loopx-project/SKILL.md
+++ b/skills/loopx-project/SKILL.md
@@ -28,9 +28,8 @@ automatically.
 When the visible user message is exactly a LoopX slash command or starts with a
 LoopX slash command plus arguments, do not treat it as ordinary chat.
 
-Recognized project-local commands:
+Recognized project-local goal-start command:
 
-- `/loopx`
 - `/loopx <goal text>`
 
 Recognized repo-review commands:
@@ -38,12 +37,9 @@ Recognized repo-review commands:
 - `/loopx-pr-review`
 - `/loopx-pr-review <time window or filter text>`
 
-From the target project root, run the bootstrap command pack before planning or
-writing project state:
-
-```bash
-loopx bootstrap-command-pack --project .
-```
+If there is any non-whitespace text after `/loopx`, it is goal text. Preserve
+that exact trailing text, pass it to the command pack, and do not downgrade the
+request into a status or inspection turn.
 
 When the target is a linked git worktree, trust the command pack's
 `canonical_project_alias` / `source_registry` route. Do not manually run
@@ -51,8 +47,8 @@ When the target is a linked git worktree, trust the command pack's
 state is missing or stale; that can create a worktree-local shadow goal instead
 of updating the canonical project state.
 
-For `/loopx <goal text>`, pass the text after `/loopx` as the explicit
-goal-start objective:
+From the target project root, pass the text after `/loopx` as the explicit
+goal-start objective before planning or writing project state:
 
 ```bash
 loopx bootstrap-command-pack --project . --goal-text "<GOAL_TEXT>"
@@ -63,14 +59,12 @@ they are known. If `--goal-text` is not available, refresh the local LoopX CLI
 or use the checked-out LoopX repository CLI for validation; do not silently
 downgrade `/loopx <goal text>` into a bare `/loopx` read-only command.
 
-Bare `/loopx` is read/status-first: inspect the returned command pack, stop
-before registry/state writes that require confirmation, and keep quota unspent
-while only previewing the pack. `/loopx <goal text>` is an explicit goal-start
-intent: first produce a concise ordered plan, then write todos in priority
-order, using planner order plus `todo add` write order as the same-priority
-tie-breaker. For broad or fuzzy product directions, use a small
-public-safe planning set; for clear bounded problems, use the minimum
-sufficient ordered todo plan and avoid management-only filler.
+`/loopx <goal text>` is an explicit goal-start intent: first produce a concise
+ordered plan, then write todos in priority order, using planner order plus
+`todo add` write order as the same-priority tie-breaker. For broad or fuzzy
+product directions, use a small public-safe planning set; for clear bounded
+problems, use the minimum sufficient ordered todo plan and avoid
+management-only filler.
 
 Global manager slash commands such as `/loopx-global-summary`,
 `/loopx-global-gates`, `/loopx-global-todos`, and `/loopx-global-risks` are not
@@ -91,7 +85,6 @@ When a user has just connected a project or receives a bootstrap command pack
 for the first time, briefly tell them the usable commands instead of assuming
 they will inspect CLI help:
 
-- `/loopx`: inspect or preview this project's LoopX connection/status.
 - `/loopx <goal text>`: start a concrete goal with a plan-before-todo-write
   flow.
 - `/loopx-global-summary`: read the global progress digest.


### PR DESCRIPTION
## Summary

- Add `loopx backup-state` as a dry-run-first support/control command that can write a private local tar.gz archive plus sidecar manifest under `<runtime-root>/backups`.
- Capture shared LoopX runtime state, project `.loopx`, `.codex/goals`, `.local/goals`, Codex App automations, and installed `loopx-*` skills while excluding the backup output directory itself.
- Refine the `loopx-project` skill so `/loopx <goal text>` dominates the plan-before-todo flow and the skill no longer advertises bare `/loopx` as the project-local fallback.
- Document local state backup usage in the getting-started guide.

## Validation

- `python3 examples/loopx-project-skill-goal-text-precedence-smoke.py`
- `python3 examples/state-backup-smoke.py`
- `python3 examples/cli-support-control-command-modularization-smoke.py`
- `python3 examples/loopx-update-smoke.py`
- `python3 -m py_compile loopx/state_backup.py loopx/cli_commands/support_control.py`
- `loopx check --scan-path docs/guides/getting-started.md --scan-path examples/cli-support-control-command-modularization-smoke.py --scan-path examples/loopx-project-skill-goal-text-precedence-smoke.py --scan-path examples/state-backup-smoke.py --scan-path loopx/cli_commands/support_control.py --scan-path loopx/state_backup.py --scan-path skills/loopx-project/SKILL.md`

`loopx check` reported only the pre-existing duplicate index rows warning for `loopx-meta`; the candidate public boundary scan was clean.

## Local State Backup Run

After validating the command, I wrote the requested private local backup outside the repository:

- archive: `/Users/bytedance/.codex/loopx/backups/loopx-state-20260629T145227Z.tar.gz`
- manifest: `/Users/bytedance/.codex/loopx/backups/loopx-state-20260629T145227Z.manifest.json`
- archive sha256: `c22a4b4b0d3fcf5d2072110bac1732b26d421efa9bfdf722c5f069fb56cfc395`

Those files are local recovery material and are not committed.
