### PR TITLE
Refine v0.1 install and update path

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ Connect the current project to LoopX.
 Do not clone the LoopX repository for ordinary use. If `loopx` is not on PATH,
 install or repair it with the official no-clone installer:
 curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
 
 Then run `loopx doctor`. Work only from the current project root: if LoopX state
 already exists, reuse it and do not create or overwrite a goal; if the project
@@ -151,6 +152,7 @@ Connect this repo to LoopX from this visible Codex CLI TUI. Do not clone the
 LoopX repository for ordinary use. If `loopx` is not on PATH, install or repair
 it with the official no-clone installer:
 curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
+export PATH="$HOME/.local/bin:$PATH"
 
 Then run `loopx doctor`. Work only from this project root: if LoopX state
 already exists, reuse it and do not create or overwrite a goal; if the project

--- a/docs/product/codex-cli-packaged-install.md
+++ b/docs/product/codex-cli-packaged-install.md
@@ -60,16 +60,22 @@ This keeps the product hierarchy clear:
 
 ## Update Path
 
-For users installed through the archive script, update is the same command:
+For users installed through the archive script, update through the explicit
+LoopX CLI flow:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
+loopx update --check
+loopx update --dry-run
+loopx update --execute
 loopx doctor
 ```
 
-Each run creates a new timestamped release snapshot and repoints
-`~/.local/bin/loopx` to it. Runtime state stays under `~/.codex/loopx`,
-while the executable and skills are refreshed together.
+The update command plans the source archive, reports the installed release
+snapshot, preserves runtime state under `~/.codex/loopx`, and refreshes the
+executable and skills together when `--execute` is accepted.
+
+Re-running the curl installer is still the repair/fallback path when the local
+wrapper or release snapshot is broken enough that `loopx update` cannot run.
 
 ## Contributor Path
 
@@ -95,7 +101,7 @@ should later add:
 - `pipx install loopx` or `uv tool install loopx` after package
   publishing is ready;
 - a Homebrew formula for macOS users;
-- a small update command that reports current release id, latest available
+- signed release manifests that report current release id, latest available
   release, and installed skill freshness.
 
 Do not make these future channels block the current Codex CLI TUI path. The

--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -27,6 +27,10 @@ loopx update --execute
 loopx doctor
 ```
 
+Re-running the curl installer remains a repair/fallback path when the wrapper
+or local release snapshot is broken. It is not the primary update path for a
+healthy archive install.
+
 For contributors, keep the clone-plus-canary path:
 
 ```bash

--- a/examples/loopx-update-smoke.py
+++ b/examples/loopx-update-smoke.py
@@ -34,6 +34,18 @@ def fake_doctor_payload() -> dict[str, object]:
     }
 
 
+def fake_fresh_doctor_payload() -> dict[str, object]:
+    payload = fake_doctor_payload()
+    payload["install_freshness"] = {
+        "status": "fresh",
+        "requires_upgrade": False,
+        "reason": "fixture is intentionally fresh",
+        "current_version": "0.1.3",
+        "release_id": "20260622T170342Z",
+    }
+    return payload
+
+
 def test_module_plan() -> None:
     payload = build_update_plan(
         repo="example/loopx",
@@ -50,6 +62,22 @@ def test_module_plan() -> None:
     assert payload["plan"]["mutates_release_install"] is False, payload
     assert payload["plan"]["backup"]["available"] is True, payload
     assert "LOOPX_ARCHIVE_URL=https://example.invalid/loopx.tar.gz" in payload["plan"]["install_command"], payload
+
+
+def test_fresh_check_is_noop_recommendation() -> None:
+    payload = build_update_plan(
+        repo="example/loopx",
+        ref="fixture",
+        archive_url="https://example.invalid/loopx.tar.gz",
+        check_only=True,
+        doctor_payload=fake_fresh_doctor_payload(),
+    )
+    assert payload["ok"] is True, payload
+    assert payload["check_only"] is True, payload
+    assert payload["current"]["requires_upgrade"] is False, payload
+    assert "no update needed" in payload["recommended_action"], payload
+    assert "force a refresh" in payload["recommended_action"], payload
+    assert "--execute` if you accept" not in payload["recommended_action"], payload
 
 
 def test_cli_check() -> None:
@@ -86,6 +114,7 @@ def test_cli_check() -> None:
 
 def main() -> int:
     test_module_plan()
+    test_fresh_check_is_noop_recommendation()
     test_cli_check()
     print("loopx-update-smoke ok")
     return 0

--- a/loopx/self_update.py
+++ b/loopx/self_update.py
@@ -103,6 +103,18 @@ def build_update_plan(
     install_command = _command_for_source(source)
     dry_run = not execute
     path = doctor.get("path") if isinstance(doctor.get("path"), dict) else {}
+    requires_upgrade = install_freshness.get("requires_upgrade")
+    if execute:
+        recommended_action = "review execution result and post-update doctor output"
+    elif requires_upgrade is False:
+        recommended_action = (
+            "no update needed; use `loopx update --dry-run` or "
+            "`loopx update --execute` only to force a refresh"
+        )
+    elif check_only:
+        recommended_action = "run `loopx update --dry-run` to review the source and rollback plan"
+    else:
+        recommended_action = "run `loopx update --execute` if you accept the source and rollback plan"
     return {
         "ok": True,
         "schema_version": UPDATE_PLAN_SCHEMA_VERSION,
@@ -117,7 +129,7 @@ def build_update_plan(
             "current_version": install_freshness.get("current_version"),
             "release_id": install_freshness.get("release_id"),
             "install_freshness_status": install_freshness.get("status"),
-            "requires_upgrade": install_freshness.get("requires_upgrade"),
+            "requires_upgrade": requires_upgrade,
             "reason": install_freshness.get("reason"),
         },
         "plan": {
@@ -129,11 +141,7 @@ def build_update_plan(
             "backup": _rollback_plan(doctor),
         },
         "execution": None,
-        "recommended_action": (
-            "run `loopx update --execute` if you accept the source and rollback plan"
-            if not execute
-            else "review execution result and post-update doctor output"
-        ),
+        "recommended_action": recommended_action,
     }
 
 


### PR DESCRIPTION
## Summary

- add the missing `export PATH="$HOME/.local/bin:$PATH"` step to the README Codex App and Codex CLI paste blocks
- align the Codex CLI packaged install doc with `loopx update --check/--dry-run/--execute` as the healthy update path, leaving the curl installer as repair/fallback
- make fresh `loopx update --check` output recommend no action instead of suggesting execute, with smoke coverage

## Validation

- `python3 examples/loopx-update-smoke.py`
- `python3 examples/release-readiness-doc-smoke.py`
- `python3 examples/codex-cli-no-clone-release-verification-smoke.py`
- `python3 examples/fresh-clone-quickstart-smoke.py`
- `python3 -m py_compile loopx/self_update.py`
- `git diff --check`
- `loopx check --scan-path README.md --scan-path docs/product/release-readiness.md --scan-path docs/product/codex-cli-packaged-install.md --scan-path examples/loopx-update-smoke.py --scan-path loopx/self_update.py`
