### PR TITLE
Define stable update channel default

### DIFF
--- a/docs/product/codex-cli-packaged-install.md
+++ b/docs/product/codex-cli-packaged-install.md
@@ -28,6 +28,10 @@ snapshot under `~/.local/share/loopx/releases/`, installs the
 `loopx` wrapper under `~/.local/bin`, and installs the reusable Codex
 skills under `~/.codex/skills`.
 
+By default, the archive source is the public `stable` ref. Maintainers can
+override it with `LOOPX_REF=main` when intentionally testing or repairing from
+the current repository head.
+
 It intentionally skips `loopx-canary` by default because there is no
 durable live checkout in this mode. Contributors who want a canary should clone
 the repository and run `scripts/install-local.sh`.
@@ -73,6 +77,10 @@ loopx doctor
 The update command plans the source archive, reports the installed release
 snapshot, preserves runtime state under `~/.codex/loopx`, and refreshes the
 executable and skills together when `--execute` is accepted.
+
+`loopx update` uses the same `stable` ref by default. Use `loopx update --ref
+main` only when you intentionally want a dev/head refresh instead of the stable
+channel.
 
 Re-running the curl installer is still the repair/fallback path when the local
 wrapper or release snapshot is broken enough that `loopx update` cannot run.

--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -17,6 +17,11 @@ export PATH="$HOME/.local/bin:$PATH"
 loopx doctor
 ```
 
+The installer and `loopx update` use the public `stable` ref by default. Use
+`LOOPX_REF=main` or `loopx update --ref main` only for maintainer/dev repair
+when you intentionally want the current repository head instead of the stable
+channel.
+
 For a user who already installed from the archive, update through the explicit
 CLI flow:
 
@@ -42,6 +47,10 @@ loopx-canary doctor
 
 The no-clone path is the user default. The clone-plus-canary path is the
 maintainer validation path.
+
+Before promoting a stable install/update recommendation, maintainers must move
+the public `stable` ref to the release commit that passed this gate. Do not
+claim stable-channel readiness while `stable` is missing or stale.
 
 ## Compatibility Gate
 

--- a/examples/loopx-update-smoke.py
+++ b/examples/loopx-update-smoke.py
@@ -12,7 +12,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 
-from loopx.self_update import build_update_plan
+from loopx.self_update import DEFAULT_UPDATE_REF, build_update_plan
 
 
 def fake_doctor_payload() -> dict[str, object]:
@@ -62,6 +62,15 @@ def test_module_plan() -> None:
     assert payload["plan"]["mutates_release_install"] is False, payload
     assert payload["plan"]["backup"]["available"] is True, payload
     assert "LOOPX_ARCHIVE_URL=https://example.invalid/loopx.tar.gz" in payload["plan"]["install_command"], payload
+
+
+def test_default_source_uses_stable_ref() -> None:
+    payload = build_update_plan(doctor_payload=fake_doctor_payload())
+    assert payload["source"]["ref"] == DEFAULT_UPDATE_REF == "stable", payload
+    assert payload["source"]["channel"] == "github_archive_stable", payload
+    assert payload["source"]["ref_source"] == "default_stable", payload
+    assert "/tar.gz/stable" in payload["source"]["archive_url"], payload
+    assert "LOOPX_REF=stable" in payload["plan"]["install_command"], payload
 
 
 def test_fresh_check_is_noop_recommendation() -> None:
@@ -114,6 +123,7 @@ def test_cli_check() -> None:
 
 def main() -> int:
     test_module_plan()
+    test_default_source_uses_stable_ref()
     test_fresh_check_is_noop_recommendation()
     test_cli_check()
     print("loopx-update-smoke ok")

--- a/loopx/cli_commands/support_control.py
+++ b/loopx/cli_commands/support_control.py
@@ -252,7 +252,7 @@ def register_support_control_commands(
     )
     update_parser.add_argument(
         "--ref",
-        help="Git ref used by the installer archive. Defaults to LOOPX_REF or main.",
+        help="Git ref used by the installer archive. Defaults to LOOPX_REF or stable.",
     )
     update_parser.add_argument(
         "--archive-url",

--- a/loopx/self_update.py
+++ b/loopx/self_update.py
@@ -11,7 +11,7 @@ from .doctor import NO_CLONE_INSTALL_URL, collect_doctor
 
 UPDATE_PLAN_SCHEMA_VERSION = "loopx_update_plan_v0"
 DEFAULT_UPDATE_REPO = "huangruiteng/loopx"
-DEFAULT_UPDATE_REF = "main"
+DEFAULT_UPDATE_REF = "stable"
 
 
 def _source_config(
@@ -21,14 +21,23 @@ def _source_config(
     archive_url: str | None,
 ) -> dict[str, Any]:
     selected_repo = repo or os.environ.get("LOOPX_REPO") or DEFAULT_UPDATE_REPO
-    selected_ref = ref or os.environ.get("LOOPX_REF") or DEFAULT_UPDATE_REF
-    selected_archive_url = archive_url or os.environ.get("LOOPX_ARCHIVE_URL")
+    ref_override = ref or os.environ.get("LOOPX_REF")
+    selected_ref = ref_override or DEFAULT_UPDATE_REF
+    archive_url_override = archive_url or os.environ.get("LOOPX_ARCHIVE_URL")
+    selected_archive_url = archive_url_override
     if not selected_archive_url:
         selected_archive_url = f"https://codeload.github.com/{selected_repo}/tar.gz/{selected_ref}"
+    if archive_url_override:
+        channel = "github_archive_url_override"
+    elif ref_override:
+        channel = "github_archive_override"
+    else:
+        channel = "github_archive_stable"
     return {
-        "channel": "github_archive",
+        "channel": channel,
         "repo": selected_repo,
         "ref": selected_ref,
+        "ref_source": "default_stable" if not ref_override else "override",
         "archive_url": selected_archive_url,
         "installer_url": NO_CLONE_INSTALL_URL,
     }

--- a/scripts/install-from-github.sh
+++ b/scripts/install-from-github.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 
 repo="${LOOPX_REPO:-huangruiteng/loopx}"
-ref="${LOOPX_REF:-main}"
+ref="${LOOPX_REF:-stable}"
 archive_url="${LOOPX_ARCHIVE_URL:-https://codeload.github.com/$repo/tar.gz/$ref}"
 
 need() {


### PR DESCRIPTION
## Summary
- switch the self-update and archive installer default ref from `main` to `stable`
- expose default-vs-override source metadata in update plans
- align install/update docs with the stable-channel gate and add smoke coverage

## Validation
- `python3 examples/loopx-update-smoke.py`
- `python3 examples/codex-cli-packaged-install-smoke.py`
- `python3 examples/codex-cli-no-clone-release-verification-smoke.py`
- `python3 examples/release-readiness-doc-smoke.py`
- `python3 -m py_compile loopx/self_update.py loopx/cli_commands/support_control.py`
- `git diff --check`
- `loopx check --scan-path loopx/self_update.py --scan-path scripts/install-from-github.sh --scan-path loopx/cli_commands/support_control.py --scan-path docs/product/release-readiness.md --scan-path docs/product/codex-cli-packaged-install.md --scan-path examples/loopx-update-smoke.py`

## Release gate
`git ls-remote` currently finds no `refs/heads/stable` or `v0.1` tag on origin. Do not merge/promote this default until maintainers create or move the public `stable` ref to the validated release commit.