### PR TITLE
Write installed release manifests

### DIFF
--- a/examples/codex-cli-packaged-install-smoke.py
+++ b/examples/codex-cli-packaged-install-smoke.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import tarfile
@@ -71,7 +72,27 @@ def main() -> None:
         )
         assert "ok: `True`" in doctor.stdout, doctor.stdout
         assert "## Install Freshness" in doctor.stdout, doctor.stdout
+        assert "release_manifest_available: `True`" in doctor.stdout, doctor.stdout
         assert "install-from-github.sh" in doctor.stdout, doctor.stdout
+        doctor_json = subprocess.run(
+            [str(installed), "--format", "json", "doctor"],
+            check=True,
+            env={**env, "PATH": f"{home / '.local' / 'bin'}:{env.get('PATH', '')}"},
+            text=True,
+            capture_output=True,
+        )
+        doctor_payload = json.loads(doctor_json.stdout)
+        release_root = Path(doctor_payload["package"]["release_root"])
+        manifest_path = release_root / "release.json"
+        assert manifest_path.is_file(), manifest_path
+        manifest = doctor_payload["release_manifest"]["manifest"]
+        assert manifest["schema_version"] == "loopx_release_manifest_v0", manifest
+        assert manifest["source"]["kind"] == "github_archive", manifest
+        assert manifest["source"]["repo"] == "huangruiteng/loopx", manifest
+        assert manifest["source"]["ref"] == "stable", manifest
+        assert manifest["source"]["archive_url"] == f"file://{archive}", manifest
+        assert manifest["source"]["archive_sha256"], manifest
+        assert manifest["skills"]["digest"], manifest
 
         for skill in (
             "loopx-project",

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -126,6 +126,16 @@ def main() -> int:
         assert wrapper.resolve().name == "loopx", wrapper.resolve()
         release_root = wrapper.resolve().parents[1]
         assert (release_root / "loopx" / "cli.py").is_file(), release_root
+        release_manifest_path = release_root / "release.json"
+        assert release_manifest_path.is_file(), release_manifest_path
+        release_manifest = json.loads(release_manifest_path.read_text(encoding="utf-8"))
+        assert release_manifest["schema_version"] == "loopx_release_manifest_v0", release_manifest
+        assert release_manifest["release_id"] == "install-smoke-initial", release_manifest
+        assert release_manifest["package"]["name"] == "loopx", release_manifest
+        assert release_manifest["package"]["version"], release_manifest
+        assert release_manifest["source"]["kind"] == "local_checkout", release_manifest
+        assert release_manifest["skills"]["digest"], release_manifest
+        assert release_manifest["skills"]["items"]["loopx-project"]["sha256"], release_manifest
         canary_wrapper = bin_dir / "loopx-canary"
         assert canary_wrapper.is_symlink(), canary_wrapper
         assert not (bin_dir / "goal-harness-canary").exists()
@@ -250,6 +260,10 @@ def main() -> int:
         assert freshness["status"] == "unknown", freshness
         assert freshness["requires_upgrade"] is False, freshness
         assert freshness["current_version"], freshness
+        assert freshness["release_manifest_available"] is True, freshness
+        assert freshness["release_manifest_path"] == str(release_manifest_path), freshness
+        assert freshness["manifest_source_kind"] == "local_checkout", freshness
+        assert freshness["manifest_skills_digest"] == release_manifest["skills"]["digest"], freshness
         assert "install-from-github.sh" in freshness["upgrade_command"], freshness
         assert "loopx doctor" in freshness["upgrade_command"], freshness
         assert doctor_payload["upgrade_hint"] == freshness, doctor_payload
@@ -258,6 +272,11 @@ def main() -> int:
         assert doctor_payload["path"]["loopx_canary"] == str(canary_wrapper), doctor_payload
         assert doctor_payload["path"]["loopx_canary_realpath"] == str(canary_wrapper.resolve()), doctor_payload
         assert doctor_payload["package"]["release_root"] == str(release_root), doctor_payload
+        assert doctor_payload["package"]["release_manifest_path"] == str(release_manifest_path), doctor_payload
+        assert doctor_payload["release_manifest"]["available"] is True, doctor_payload
+        assert doctor_payload["release_manifest"]["path"] == str(release_manifest_path), doctor_payload
+        assert doctor_payload["release_manifest"]["manifest"]["source"]["kind"] == "local_checkout", doctor_payload
+        assert doctor_payload["release_manifest"]["manifest"]["skills"]["digest"] == release_manifest["skills"]["digest"], doctor_payload
         assert doctor_payload["skill"]["path"] == str(skill), doctor_payload
         assert doctor_payload["skill"]["exists"] is True, doctor_payload
         assert doctor_payload["skill"]["delivery_hints"] is True, doctor_payload
@@ -275,6 +294,8 @@ def main() -> int:
         assert provenance["default_release"]["root"] == str(release_root), provenance
         assert provenance["default_release"]["release_id"] == release_root.name, provenance
         assert provenance["default_release"]["is_release_snapshot"] is True, provenance
+        assert provenance["default_release"]["release_manifest_available"] is True, provenance
+        assert provenance["default_release"]["release_manifest_path"] == str(release_manifest_path), provenance
         assert provenance["live_canary"]["root"] == str(REPO_ROOT), provenance
         assert provenance["live_canary"]["separate_from_default"] is True, provenance
         assert provenance["current_invocation"]["source"] == "release_snapshot", provenance
@@ -320,6 +341,8 @@ def main() -> int:
         assert "## Install Freshness" in doctor_markdown, doctor_markdown
         assert "schema_version: `loopx_install_freshness_v0`" in doctor_markdown, doctor_markdown
         assert "status: `unknown`" in doctor_markdown, doctor_markdown
+        assert "release_manifest_available: `True`" in doctor_markdown, doctor_markdown
+        assert "manifest_skills_digest:" in doctor_markdown, doctor_markdown
         assert "install-from-github.sh" in doctor_markdown, doctor_markdown
         assert "latest_promotion_readiness: available=`True`" in doctor_markdown, doctor_markdown
         assert "freshness=`fresh`" in doctor_markdown, doctor_markdown

--- a/examples/loopx-update-smoke.py
+++ b/examples/loopx-update-smoke.py
@@ -31,6 +31,28 @@ def fake_doctor_payload() -> dict[str, object]:
             "current_version": "0.1.2",
             "release_id": "20260621T170342Z",
         },
+        "release_manifest": {
+            "available": True,
+            "path": "/home/user/.local/share/loopx/releases/20260621T170342Z/release.json",
+            "manifest": {
+                "schema_version": "loopx_release_manifest_v0",
+                "source": {
+                    "kind": "github_archive",
+                    "repo": "example/loopx",
+                    "ref": "stable",
+                    "archive_url": "https://codeload.github.com/example/loopx/tar.gz/stable",
+                    "archive_sha256": "abc123",
+                },
+                "package": {
+                    "name": "loopx",
+                    "version": "0.1.2",
+                },
+                "skills": {
+                    "digest": "skills123",
+                    "items": {},
+                },
+            },
+        },
     }
 
 
@@ -58,6 +80,9 @@ def test_module_plan() -> None:
     assert payload["dry_run"] is True, payload
     assert payload["execute_requested"] is False, payload
     assert payload["current"]["requires_upgrade"] is True, payload
+    assert payload["current"]["release_manifest_available"] is True, payload
+    assert payload["current"]["release_manifest"]["source"]["ref"] == "stable", payload
+    assert payload["current"]["release_manifest"]["source"]["archive_sha256"] == "abc123", payload
     assert payload["plan"]["mutates_loopx_runtime_state"] is False, payload
     assert payload["plan"]["mutates_release_install"] is False, payload
     assert payload["plan"]["backup"]["available"] is True, payload

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -12,6 +12,7 @@ from typing import Any
 from . import __version__
 from .paths import DEFAULT_RUNTIME_ROOT, global_registry_path
 from .registry_writability import probe_registry_write_path
+from .release_manifest import load_release_manifest
 
 
 PROMOTION_READINESS_CLASSIFICATIONS = {
@@ -114,6 +115,7 @@ def build_install_freshness(
     release_root: Path | None,
     repo_root: Path,
     skills: dict[str, dict[str, Any]],
+    release_manifest: dict[str, Any] | None = None,
     now: datetime | None = None,
 ) -> dict[str, Any]:
     reference = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
@@ -153,6 +155,17 @@ def build_install_freshness(
         requires_upgrade = False
 
     contributor_upgrade_command = f"{repo_root / 'scripts' / 'install-local.sh'}\nloopx doctor"
+    manifest = release_manifest if isinstance(release_manifest, dict) else {}
+    manifest_body = manifest.get("manifest") if isinstance(manifest.get("manifest"), dict) else {}
+    manifest_package = (
+        manifest_body.get("package") if isinstance(manifest_body.get("package"), dict) else {}
+    )
+    manifest_source = (
+        manifest_body.get("source") if isinstance(manifest_body.get("source"), dict) else {}
+    )
+    manifest_skills = (
+        manifest_body.get("skills") if isinstance(manifest_body.get("skills"), dict) else {}
+    )
     return {
         "schema_version": "loopx_install_freshness_v0",
         "status": status,
@@ -166,6 +179,15 @@ def build_install_freshness(
         "no_clone_upgrade_command": NO_CLONE_UPGRADE_COMMAND,
         "contributor_upgrade_command": contributor_upgrade_command,
         "doctor_after_upgrade": "loopx doctor",
+        "release_manifest_available": manifest.get("available"),
+        "release_manifest_path": manifest.get("path"),
+        "release_manifest_reason": manifest.get("reason"),
+        "manifest_package_version": manifest_package.get("version"),
+        "manifest_source_kind": manifest_source.get("kind"),
+        "manifest_source_repo": manifest_source.get("repo"),
+        "manifest_source_ref": manifest_source.get("ref"),
+        "manifest_archive_sha256": manifest_source.get("archive_sha256"),
+        "manifest_skills_digest": manifest_skills.get("digest"),
     }
 
 
@@ -334,14 +356,18 @@ def collect_doctor() -> dict[str, Any]:
     wrapper_script = repo_root / "scripts" / "loopx"
     release_root = command_release_root(command_realpath)
     canary_root = command_release_root(canary_realpath)
+    release_manifest = load_release_manifest(release_root)
     path_entries = os.environ.get("PATH", "").split(os.pathsep)
     local_bin = user_local_bin()
     skills_root = codex_home() / "skills"
     skill_path = skills_root / "loopx-project" / "SKILL.md"
     skills = installed_skill_summary(skills_root)
+    default_release = command_root_summary(command_path, command_realpath)
+    default_release["release_manifest_available"] = release_manifest.get("available")
+    default_release["release_manifest_path"] = release_manifest.get("path")
     release_provenance = {
         "runtime_root": str(DEFAULT_RUNTIME_ROOT),
-        "default_release": command_root_summary(command_path, command_realpath),
+        "default_release": default_release,
         "live_canary": {
             **command_root_summary(canary_path, canary_realpath),
             "separate_from_default": bool(canary_realpath and command_realpath and canary_realpath != command_realpath),
@@ -360,6 +386,7 @@ def collect_doctor() -> dict[str, Any]:
         release_root=release_root,
         repo_root=repo_root,
         skills=skills,
+        release_manifest=release_manifest,
     )
     default_global_registry = global_registry_path(DEFAULT_RUNTIME_ROOT)
     global_registry_writability = probe_registry_write_path(default_global_registry, create_parent=True)
@@ -474,7 +501,9 @@ def collect_doctor() -> dict[str, Any]:
             "canary_root": str(canary_root) if canary_root else None,
             "install_script": str(install_script),
             "wrapper_script": str(wrapper_script),
+            "release_manifest_path": release_manifest.get("path"),
         },
+        "release_manifest": release_manifest,
         "release_provenance": release_provenance,
         "global_registry_writability": global_registry_writability,
         "install_freshness": install_freshness,
@@ -562,6 +591,8 @@ def render_doctor_markdown(payload: dict[str, Any]) -> str:
         )
     freshness = payload.get("install_freshness") if isinstance(payload.get("install_freshness"), dict) else {}
     if freshness:
+        manifest_source_repo = freshness.get("manifest_source_repo") or freshness.get("manifest_source_kind")
+        manifest_source_ref = freshness.get("manifest_source_ref") or "n/a"
         lines.extend(
             [
                 "",
@@ -573,6 +604,10 @@ def render_doctor_markdown(payload: dict[str, Any]) -> str:
                 f"- release_id: `{freshness.get('release_id')}`",
                 f"- release_age_hours: `{freshness.get('release_age_hours')}`",
                 f"- reason: `{freshness.get('reason')}`",
+                f"- release_manifest_available: `{freshness.get('release_manifest_available')}`",
+                f"- manifest_source: `{manifest_source_repo}` @ `{manifest_source_ref}`",
+                f"- manifest_archive_sha256: `{freshness.get('manifest_archive_sha256')}`",
+                f"- manifest_skills_digest: `{freshness.get('manifest_skills_digest')}`",
                 "- upgrade_command:",
                 "```bash",
                 str(freshness.get("upgrade_command") or ""),

--- a/loopx/release_manifest.py
+++ b/loopx/release_manifest.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from . import __version__
+
+
+RELEASE_MANIFEST_SCHEMA_VERSION = "loopx_release_manifest_v0"
+RELEASE_MANIFEST_FILENAME = "release.json"
+
+
+def _sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _hash_tree(root: Path) -> dict[str, Any]:
+    if not root.exists():
+        return {
+            "available": False,
+            "sha256": None,
+            "file_count": 0,
+            "reason": "path does not exist",
+        }
+
+    digest = hashlib.sha256()
+    file_count = 0
+    for path in sorted(item for item in root.rglob("*") if item.is_file()):
+        relative = path.relative_to(root).as_posix()
+        file_hash = _sha256_file(path)
+        digest.update(relative.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(file_hash.encode("ascii"))
+        digest.update(b"\n")
+        file_count += 1
+    return {
+        "available": True,
+        "sha256": digest.hexdigest(),
+        "file_count": file_count,
+    }
+
+
+def build_release_manifest(
+    *,
+    release_root: Path,
+    release_id: str,
+    installed_at: str | None = None,
+    env: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    source_env = env or os.environ
+    archive_url = source_env.get("LOOPX_ARCHIVE_URL")
+    archive_sha256 = source_env.get("LOOPX_ARCHIVE_SHA256")
+    repo = source_env.get("LOOPX_REPO")
+    ref = source_env.get("LOOPX_REF")
+    source_kind = "github_archive" if archive_url else "local_checkout"
+    skills_root = release_root / "skills"
+    skills: dict[str, Any] = {}
+    if skills_root.exists():
+        for skill_dir in sorted(item for item in skills_root.iterdir() if item.is_dir()):
+            skills[skill_dir.name] = _hash_tree(skill_dir)
+    skills_digest = hashlib.sha256(
+        json.dumps(skills, ensure_ascii=False, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+    return {
+        "schema_version": RELEASE_MANIFEST_SCHEMA_VERSION,
+        "release_id": release_id,
+        "installed_at": installed_at or datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+        "package": {
+            "name": "loopx",
+            "version": __version__,
+        },
+        "source": {
+            "kind": source_kind,
+            "repo": repo,
+            "ref": ref,
+            "archive_url": archive_url,
+            "archive_sha256": archive_sha256,
+        },
+        "skills": {
+            "digest": skills_digest,
+            "items": skills,
+        },
+    }
+
+
+def write_release_manifest(
+    *,
+    release_root: Path,
+    release_id: str,
+    installed_at: str | None = None,
+    env: dict[str, str] | None = None,
+) -> Path:
+    manifest = build_release_manifest(
+        release_root=release_root,
+        release_id=release_id,
+        installed_at=installed_at,
+        env=env,
+    )
+    manifest_path = release_root / RELEASE_MANIFEST_FILENAME
+    manifest_path.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
+def load_release_manifest(release_root: Path | None) -> dict[str, Any]:
+    if release_root is None:
+        return {
+            "available": False,
+            "path": None,
+            "reason": "release root is not available",
+            "manifest": None,
+        }
+    manifest_path = release_root / RELEASE_MANIFEST_FILENAME
+    if not manifest_path.exists():
+        return {
+            "available": False,
+            "path": str(manifest_path),
+            "reason": "release manifest does not exist",
+            "manifest": None,
+        }
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return {
+            "available": False,
+            "path": str(manifest_path),
+            "reason": f"release manifest is unreadable: {exc}",
+            "manifest": None,
+        }
+    if not isinstance(manifest, dict):
+        return {
+            "available": False,
+            "path": str(manifest_path),
+            "reason": "release manifest is not an object",
+            "manifest": None,
+        }
+    return {
+        "available": True,
+        "path": str(manifest_path),
+        "reason": None,
+        "manifest": manifest,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Write a LoopX release manifest.")
+    parser.add_argument("release_root")
+    parser.add_argument("--release-id", required=True)
+    parser.add_argument("--installed-at")
+    args = parser.parse_args(argv)
+    write_release_manifest(
+        release_root=Path(args.release_root),
+        release_id=args.release_id,
+        installed_at=args.installed_at,
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/self_update.py
+++ b/loopx/self_update.py
@@ -108,6 +108,16 @@ def build_update_plan(
         if isinstance(doctor.get("install_freshness"), dict)
         else {}
     )
+    release_manifest = (
+        doctor.get("release_manifest")
+        if isinstance(doctor.get("release_manifest"), dict)
+        else {}
+    )
+    release_manifest_body = (
+        release_manifest.get("manifest")
+        if isinstance(release_manifest.get("manifest"), dict)
+        else {}
+    )
     source = _source_config(repo=repo, ref=ref, archive_url=archive_url)
     install_command = _command_for_source(source)
     dry_run = not execute
@@ -140,6 +150,9 @@ def build_update_plan(
             "install_freshness_status": install_freshness.get("status"),
             "requires_upgrade": requires_upgrade,
             "reason": install_freshness.get("reason"),
+            "release_manifest_available": release_manifest.get("available"),
+            "release_manifest_path": release_manifest.get("path"),
+            "release_manifest": release_manifest_body,
         },
         "plan": {
             "action": "check_only" if check_only else "execute_installer" if execute else "dry_run",

--- a/scripts/install-from-github.sh
+++ b/scripts/install-from-github.sh
@@ -4,6 +4,9 @@ set -euo pipefail
 repo="${LOOPX_REPO:-huangruiteng/loopx}"
 ref="${LOOPX_REF:-stable}"
 archive_url="${LOOPX_ARCHIVE_URL:-https://codeload.github.com/$repo/tar.gz/$ref}"
+export LOOPX_REPO="$repo"
+export LOOPX_REF="$ref"
+export LOOPX_ARCHIVE_URL="$archive_url"
 
 need() {
   if ! command -v "$1" >/dev/null 2>&1; then
@@ -28,6 +31,19 @@ mkdir -p "$extract_dir"
 
 echo "loopx installer: downloading $archive_url" >&2
 curl -fsSL "$archive_url" -o "$archive_path"
+archive_sha256="$(python3 - "$archive_path" <<'PY'
+from pathlib import Path
+import hashlib
+import sys
+
+digest = hashlib.sha256()
+with Path(sys.argv[1]).open("rb") as handle:
+    for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+        digest.update(chunk)
+print(digest.hexdigest())
+PY
+)"
+export LOOPX_ARCHIVE_SHA256="$archive_sha256"
 tar -xzf "$archive_path" -C "$extract_dir"
 
 repo_root="$(find "$extract_dir" -mindepth 1 -maxdepth 1 -type d -print -quit)"

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -15,6 +15,7 @@ release_id="${LOOPX_RELEASE_ID:-$(date -u +%Y%m%dT%H%M%SZ)}"
 release_dir="$releases_dir/$release_id"
 release_tmp="$release_dir.tmp.$$"
 legacy_line=""
+installed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
 warn_stale_promotion_readiness() {
   local python_bin="${LOOPX_PYTHON:-python3}"
@@ -111,6 +112,10 @@ copy_path "$repo_root/README.md" "$release_tmp/README.md"
 copy_path "$repo_root/pyproject.toml" "$release_tmp/pyproject.toml"
 find "$release_tmp" -name __pycache__ -type d -prune -exec rm -rf {} +
 find "$release_tmp" -name '*.pyc' -type f -delete
+PYTHONPATH="$release_tmp${PYTHONPATH:+:$PYTHONPATH}" "${LOOPX_PYTHON:-python3}" -m loopx.release_manifest \
+  "$release_tmp" \
+  --release-id "$release_id" \
+  --installed-at "$installed_at"
 chmod +x "$release_tmp/scripts/loopx"
 if [[ -e "$release_dir" ]]; then
   rm -rf "$release_tmp"


### PR DESCRIPTION
## Summary
- write `release.json` into each installed LoopX release snapshot with release id, package version, source repo/ref/archive sha, and skills digest
- export archive source metadata from the GitHub installer so stable-channel installs are auditable
- surface release manifest details in `loopx doctor` and `loopx update --check` JSON/Markdown output
- extend install/update smokes to verify local and packaged installs publish/read the manifest

## Validation
- `python3 -m py_compile loopx/release_manifest.py loopx/doctor.py loopx/self_update.py`
- `bash -n scripts/install-local.sh`
- `bash -n scripts/install-from-github.sh`
- `python3 examples/loopx-update-smoke.py`
- `python3 examples/install-local-smoke.py`
- `python3 examples/codex-cli-packaged-install-smoke.py`
- `python3 examples/codex-cli-no-clone-release-verification-smoke.py`
- `python3 examples/fresh-clone-quickstart-smoke.py`
- `python3 examples/release-readiness-doc-smoke.py`
- `git diff --check`
- `loopx check --scan-path loopx/release_manifest.py --scan-path loopx/doctor.py --scan-path loopx/self_update.py --scan-path scripts/install-local.sh --scan-path scripts/install-from-github.sh --scan-path examples/install-local-smoke.py --scan-path examples/codex-cli-packaged-install-smoke.py --scan-path examples/loopx-update-smoke.py` (ok; existing duplicate-index warning only)

## Review note
This touches installer/doctor/update runtime behavior, so I am leaving it for product-capability review rather than self-merging.