### PR TITLE
Add first-class update rollback command

### DIFF
--- a/examples/loopx-update-smoke.py
+++ b/examples/loopx-update-smoke.py
@@ -4,15 +4,22 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
+from tempfile import TemporaryDirectory
 from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 
-from loopx.self_update import DEFAULT_UPDATE_REF, build_update_plan
+from loopx.self_update import (
+    DEFAULT_UPDATE_REF,
+    build_rollback_plan,
+    build_update_plan,
+    execute_rollback_plan,
+)
 
 
 def fake_doctor_payload() -> dict[str, object]:
@@ -68,6 +75,47 @@ def fake_fresh_doctor_payload() -> dict[str, object]:
     return payload
 
 
+def fake_doctor_payload_for_release(release_root: Path) -> dict[str, object]:
+    return {
+        "path": {
+            "loopx": str(release_root.parents[4] / ".local" / "bin" / "loopx"),
+            "loopx_realpath": str(release_root / "scripts" / "loopx"),
+        },
+        "package": {
+            "release_root": str(release_root),
+        },
+        "install_freshness": {
+            "status": "fresh",
+            "requires_upgrade": False,
+            "reason": "fixture release",
+            "current_version": "0.1.3",
+            "release_id": release_root.name,
+        },
+    }
+
+
+def write_fixture_release(home: Path, release_id: str, *, doctor_ok: bool = True) -> Path:
+    script = home / ".local" / "share" / "loopx" / "releases" / release_id / "scripts" / "loopx"
+    script.parent.mkdir(parents=True, exist_ok=True)
+    doctor_body = (
+        "  printf '{\"ok\": true, \"source\": \"rollback-smoke\"}\\n'\n"
+        "  exit 0\n"
+        if doctor_ok
+        else "  printf '{\"ok\": false, \"source\": \"rollback-smoke\"}\\n'\n"
+        "  exit 7\n"
+    )
+    script.write_text(
+        "#!/usr/bin/env bash\n"
+        "if [[ \"$*\" == \"--format json doctor\" ]]; then\n"
+        f"{doctor_body}"
+        "fi\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+    return script.parent.parent
+
+
 def test_module_plan() -> None:
     payload = build_update_plan(
         repo="example/loopx",
@@ -86,6 +134,9 @@ def test_module_plan() -> None:
     assert payload["plan"]["mutates_loopx_runtime_state"] is False, payload
     assert payload["plan"]["mutates_release_install"] is False, payload
     assert payload["plan"]["backup"]["available"] is True, payload
+    assert payload["plan"]["backup"]["rollback_release_id"] == "20260621T170342Z", payload
+    assert "loopx update --rollback 20260621T170342Z" in payload["plan"]["backup"]["rollback_command"], payload
+    assert "ln -sfn" not in payload["plan"]["backup"]["rollback_command"], payload
     assert "LOOPX_ARCHIVE_URL=https://example.invalid/loopx.tar.gz" in payload["plan"]["install_command"], payload
 
 
@@ -112,6 +163,48 @@ def test_fresh_check_is_noop_recommendation() -> None:
     assert "no update needed" in payload["recommended_action"], payload
     assert "force a refresh" in payload["recommended_action"], payload
     assert "--execute` if you accept" not in payload["recommended_action"], payload
+
+
+def test_rollback_previous_executes_with_temp_home() -> None:
+    with TemporaryDirectory() as tmpdir:
+        home = Path(tmpdir)
+        previous_release = write_fixture_release(home, "20260621T170342Z")
+        current_release = write_fixture_release(home, "20260622T170342Z")
+        payload = build_rollback_plan(
+            release_id="previous",
+            doctor_payload=fake_doctor_payload_for_release(current_release),
+            home=home,
+        )
+        assert payload["ok"] is True, payload
+        assert payload["mode"] == "rollback", payload
+        assert payload["plan"]["selected_release_id"] == previous_release.name, payload
+        result = execute_rollback_plan(payload, home=home)
+        assert result["ok"] is True, result
+        loopx_bin = home / ".local" / "bin" / "loopx"
+        assert loopx_bin.is_symlink(), loopx_bin
+        assert loopx_bin.resolve() == (previous_release / "scripts" / "loopx").resolve(), loopx_bin.resolve()
+        assert result["execution"]["doctor_returncode"] == 0, result
+
+
+def test_rollback_restores_previous_when_doctor_fails() -> None:
+    with TemporaryDirectory() as tmpdir:
+        home = Path(tmpdir)
+        bad_release = write_fixture_release(home, "20260621T170342Z", doctor_ok=False)
+        current_release = write_fixture_release(home, "20260622T170342Z")
+        loopx_bin = home / ".local" / "bin" / "loopx"
+        loopx_bin.parent.mkdir(parents=True, exist_ok=True)
+        loopx_bin.symlink_to(current_release / "scripts" / "loopx")
+        payload = build_rollback_plan(
+            release_id=bad_release.name,
+            doctor_payload=fake_doctor_payload_for_release(current_release),
+            home=home,
+        )
+        assert payload["ok"] is True, payload
+        result = execute_rollback_plan(payload, home=home)
+        assert result["ok"] is False, result
+        assert result["execution"]["doctor_returncode"] == 7, result
+        assert result["execution"]["restored_previous_on_failure"] is True, result
+        assert loopx_bin.resolve() == (current_release / "scripts" / "loopx").resolve(), loopx_bin.resolve()
 
 
 def test_cli_check() -> None:
@@ -146,11 +239,46 @@ def test_cli_check() -> None:
     assert payload["plan"]["mutates_loopx_runtime_state"] is False, payload
 
 
+def test_cli_rollback_previous_with_temp_home() -> None:
+    with TemporaryDirectory() as tmpdir:
+        home = Path(tmpdir)
+        previous_release = write_fixture_release(home, "20260621T170342Z")
+        current_release = write_fixture_release(home, "20260622T170342Z")
+        loopx_bin = home / ".local" / "bin" / "loopx"
+        loopx_bin.parent.mkdir(parents=True, exist_ok=True)
+        loopx_bin.symlink_to(current_release / "scripts" / "loopx")
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "loopx.cli",
+                "update",
+                "--format",
+                "json",
+                "--rollback",
+                "previous",
+            ],
+            cwd=REPO_ROOT,
+            env={"HOME": str(home), "PATH": f"{home / '.local' / 'bin'}:{os.environ.get('PATH', '')}"},
+            text=True,
+            capture_output=True,
+        )
+        assert result.returncode == 0, (result.returncode, result.stdout, result.stderr)
+        payload = json.loads(result.stdout)
+        assert payload["ok"] is True, payload
+        assert payload["mode"] == "rollback", payload
+        assert payload["plan"]["selected_release_id"] == previous_release.name, payload
+        assert loopx_bin.resolve() == (previous_release / "scripts" / "loopx").resolve(), loopx_bin.resolve()
+
+
 def main() -> int:
     test_module_plan()
     test_default_source_uses_stable_ref()
     test_fresh_check_is_noop_recommendation()
+    test_rollback_previous_executes_with_temp_home()
+    test_rollback_restores_previous_when_doctor_fails()
     test_cli_check()
+    test_cli_rollback_previous_with_temp_home()
     print("loopx-update-smoke ok")
     return 0
 

--- a/loopx/cli_commands/support_control.py
+++ b/loopx/cli_commands/support_control.py
@@ -27,7 +27,13 @@ from ..registry import (
     render_registry_markdown,
     resolve_state_file,
 )
-from ..self_update import build_update_plan, execute_update_plan, render_update_plan_markdown
+from ..self_update import (
+    build_rollback_plan,
+    build_update_plan,
+    execute_rollback_plan,
+    execute_update_plan,
+    render_update_plan_markdown,
+)
 from ..state_backup import (
     build_state_backup_plan,
     execute_state_backup_plan,
@@ -246,6 +252,11 @@ def register_support_control_commands(
     update_mode.add_argument("--check", action="store_true", help="Only report install freshness and update source.")
     update_mode.add_argument("--dry-run", action="store_true", help="Preview the update plan without installing.")
     update_mode.add_argument("--execute", action="store_true", help="Run the installer and validate with loopx doctor.")
+    update_mode.add_argument(
+        "--rollback",
+        metavar="RELEASE_ID",
+        help="Repoint the user-local loopx command to a release id, or use `previous` for the prior snapshot.",
+    )
     update_parser.add_argument(
         "--repo",
         help="GitHub repo owner/name used by the installer archive. Defaults to LOOPX_REPO or huangruiteng/loopx.",
@@ -502,15 +513,19 @@ def handle_support_control_command(
 
     if args.command == "update":
         try:
-            payload = build_update_plan(
-                repo=args.repo,
-                ref=args.ref,
-                archive_url=args.archive_url,
-                check_only=args.check,
-                execute=args.execute,
-            )
-            if args.execute:
-                payload = execute_update_plan(payload, timeout_seconds=args.timeout_seconds)
+            if args.rollback:
+                payload = build_rollback_plan(release_id=args.rollback)
+                payload = execute_rollback_plan(payload, timeout_seconds=args.timeout_seconds)
+            else:
+                payload = build_update_plan(
+                    repo=args.repo,
+                    ref=args.ref,
+                    archive_url=args.archive_url,
+                    check_only=args.check,
+                    execute=args.execute,
+                )
+                if args.execute:
+                    payload = execute_update_plan(payload, timeout_seconds=args.timeout_seconds)
         except Exception as exc:
             payload = {
                 "ok": False,

--- a/loopx/self_update.py
+++ b/loopx/self_update.py
@@ -12,6 +12,7 @@ from .doctor import NO_CLONE_INSTALL_URL, collect_doctor
 UPDATE_PLAN_SCHEMA_VERSION = "loopx_update_plan_v0"
 DEFAULT_UPDATE_REPO = "huangruiteng/loopx"
 DEFAULT_UPDATE_REF = "stable"
+ROLLBACK_PREVIOUS_ALIAS = "previous"
 
 
 def _source_config(
@@ -73,6 +74,36 @@ def _release_root_from_doctor(doctor_payload: dict[str, Any]) -> str | None:
     return None
 
 
+def _user_loopx_bin(home: Path | None = None) -> Path:
+    return (home or Path.home()) / ".local" / "bin" / "loopx"
+
+
+def _user_releases_dir(home: Path | None = None) -> Path:
+    return (home or Path.home()) / ".local" / "share" / "loopx" / "releases"
+
+
+def _release_script(release_root: Path) -> Path:
+    return release_root / "scripts" / "loopx"
+
+
+def _list_release_roots(releases_dir: Path) -> list[Path]:
+    if not releases_dir.exists():
+        return []
+    return sorted(
+        (
+            item
+            for item in releases_dir.iterdir()
+            if item.is_dir() and _release_script(item).exists()
+        ),
+        key=lambda item: item.name,
+        reverse=True,
+    )
+
+
+def _rollback_release_command(release_id: str) -> str:
+    return f"loopx update --rollback {shlex.quote(release_id)}\nloopx doctor"
+
+
 def _rollback_plan(doctor_payload: dict[str, Any]) -> dict[str, Any]:
     release_root = _release_root_from_doctor(doctor_payload)
     if not release_root:
@@ -82,13 +113,81 @@ def _rollback_plan(doctor_payload: dict[str, Any]) -> dict[str, Any]:
             "current_release_root": None,
             "rollback_command": None,
         }
+    release_id = Path(release_root).name
     return {
         "available": True,
-        "reason": "current release snapshot can be restored by repointing the user-local command",
+        "reason": "current release snapshot can be restored with the first-class rollback CLI",
+        "rollback_release_id": release_id,
         "current_release_root": release_root,
-        "rollback_command": (
-            f'ln -sfn "{release_root}/scripts/loopx" "$HOME/.local/bin/loopx"\n'
-            "loopx doctor"
+        "rollback_command": _rollback_release_command(release_id),
+    }
+
+
+def build_rollback_plan(
+    *,
+    release_id: str,
+    doctor_payload: dict[str, Any] | None = None,
+    home: Path | None = None,
+) -> dict[str, Any]:
+    doctor = doctor_payload or collect_doctor()
+    current_release_root = _release_root_from_doctor(doctor)
+    releases_dir = _user_releases_dir(home)
+    releases = _list_release_roots(releases_dir)
+    current_root_path = Path(current_release_root).resolve() if current_release_root else None
+    requested_release_id = release_id.strip()
+    selected: Path | None = None
+    reason = None
+
+    if not requested_release_id:
+        reason = "rollback release id is required"
+    elif requested_release_id == ROLLBACK_PREVIOUS_ALIAS:
+        for candidate in releases:
+            if current_root_path and candidate.resolve() == current_root_path:
+                continue
+            selected = candidate
+            break
+        if selected is None:
+            reason = "no previous release snapshot found"
+    elif "/" in requested_release_id or requested_release_id in {".", ".."}:
+        reason = "rollback release id must be a release directory name"
+    else:
+        candidate = releases_dir / requested_release_id
+        if not _release_script(candidate).exists():
+            reason = f"release snapshot not found: {requested_release_id}"
+        else:
+            selected = candidate
+
+    available = selected is not None
+    selected_release_id = selected.name if selected else None
+    selected_release_root = str(selected) if selected else None
+    return {
+        "ok": available,
+        "schema_version": UPDATE_PLAN_SCHEMA_VERSION,
+        "mode": "rollback",
+        "dry_run": False,
+        "execute_requested": True,
+        "requested_release_id": requested_release_id,
+        "current": {
+            "current_release_root": current_release_root,
+        },
+        "plan": {
+            "action": "rollback",
+            "available": available,
+            "reason": reason,
+            "releases_dir": str(releases_dir),
+            "release_count": len(releases),
+            "selected_release_id": selected_release_id,
+            "selected_release_root": selected_release_root,
+            "rollback_command": _rollback_release_command(requested_release_id),
+            "mutates_loopx_runtime_state": False,
+            "mutates_release_install": True,
+            "post_rollback_validation": "loopx doctor",
+        },
+        "execution": None,
+        "recommended_action": (
+            "rollback target selected; execute rollback and validate with doctor"
+            if available
+            else "choose an existing release id or use `loopx update --rollback previous` when available"
         ),
     }
 
@@ -206,7 +305,112 @@ def execute_update_plan(payload: dict[str, Any], *, timeout_seconds: int = 600) 
     return updated
 
 
+def execute_rollback_plan(
+    payload: dict[str, Any],
+    *,
+    timeout_seconds: int = 600,
+    home: Path | None = None,
+) -> dict[str, Any]:
+    plan = payload.get("plan") if isinstance(payload.get("plan"), dict) else {}
+    selected_release_root = plan.get("selected_release_root")
+    if not payload.get("ok") or not selected_release_root:
+        return payload
+    release_root = Path(str(selected_release_root))
+    target_script = _release_script(release_root)
+    loopx_bin = _user_loopx_bin(home)
+    previous_link_target = os.readlink(loopx_bin) if loopx_bin.is_symlink() else None
+    execution: dict[str, Any] = {
+        "target_script": str(target_script),
+        "loopx_command": str(loopx_bin),
+        "previous_link_target": previous_link_target,
+        "restored_previous_on_failure": False,
+    }
+    updated = dict(payload)
+    try:
+        loopx_bin.parent.mkdir(parents=True, exist_ok=True)
+        temp_link = loopx_bin.with_name(f".{loopx_bin.name}.rollback.{os.getpid()}")
+        if temp_link.exists() or temp_link.is_symlink():
+            temp_link.unlink()
+        temp_link.symlink_to(target_script)
+        os.replace(temp_link, loopx_bin)
+        doctor_result = subprocess.run(
+            [str(loopx_bin), "--format", "json", "doctor"],
+            text=True,
+            capture_output=True,
+            timeout=timeout_seconds,
+        )
+        execution.update(
+            {
+                "doctor_returncode": doctor_result.returncode,
+                "doctor_stdout_tail": doctor_result.stdout[-2000:],
+                "doctor_stderr_tail": doctor_result.stderr[-2000:],
+            }
+        )
+        updated["ok"] = doctor_result.returncode == 0
+        if not updated["ok"] and previous_link_target:
+            restore_link = loopx_bin.with_name(f".{loopx_bin.name}.rollback.restore.{os.getpid()}")
+            if restore_link.exists() or restore_link.is_symlink():
+                restore_link.unlink()
+            restore_link.symlink_to(previous_link_target)
+            os.replace(restore_link, loopx_bin)
+            execution["restored_previous_on_failure"] = True
+    except Exception as exc:
+        execution["error"] = str(exc)
+        updated["ok"] = False
+        if previous_link_target:
+            restore_link = loopx_bin.with_name(f".{loopx_bin.name}.rollback.restore.{os.getpid()}")
+            try:
+                if restore_link.exists() or restore_link.is_symlink():
+                    restore_link.unlink()
+                restore_link.symlink_to(previous_link_target)
+                os.replace(restore_link, loopx_bin)
+                execution["restored_previous_on_failure"] = True
+            except Exception as restore_exc:
+                execution["restore_error"] = str(restore_exc)
+    finally:
+        if "temp_link" in locals() and (temp_link.exists() or temp_link.is_symlink()):
+            temp_link.unlink()
+        if "restore_link" in locals() and (restore_link.exists() or restore_link.is_symlink()):
+            restore_link.unlink()
+    updated["execution"] = execution
+    updated["recommended_action"] = (
+        "rollback complete; review doctor output"
+        if updated["ok"]
+        else "rollback failed; inspect execution error before retrying"
+    )
+    return updated
+
+
 def render_update_plan_markdown(payload: dict[str, Any]) -> str:
+    if payload.get("mode") == "rollback":
+        plan = payload.get("plan") if isinstance(payload.get("plan"), dict) else {}
+        execution = payload.get("execution") if isinstance(payload.get("execution"), dict) else None
+        lines = [
+            "# LoopX Update Rollback",
+            "",
+            f"- OK: `{payload.get('ok')}`",
+            f"- Requested release: `{payload.get('requested_release_id')}`",
+            f"- Selected release: `{plan.get('selected_release_id')}`",
+            f"- Selected root: `{plan.get('selected_release_root')}`",
+            f"- Reason: `{plan.get('reason')}`",
+            f"- Runtime state mutation: `{plan.get('mutates_loopx_runtime_state')}`",
+            f"- Release install mutation: `{plan.get('mutates_release_install')}`",
+            f"- Recommended action: {payload.get('recommended_action')}",
+        ]
+        rollback_command = plan.get("rollback_command")
+        if rollback_command:
+            lines.extend(["", "## Rollback Command", "", "```bash", str(rollback_command), "```"])
+        if execution:
+            lines.extend(
+                [
+                    "",
+                    "## Execution",
+                    "",
+                    f"- Doctor return code: `{execution.get('doctor_returncode')}`",
+                ]
+            )
+        return "\n".join(lines) + "\n"
+
     source = payload.get("source") if isinstance(payload.get("source"), dict) else {}
     current = payload.get("current") if isinstance(payload.get("current"), dict) else {}
     plan = payload.get("plan") if isinstance(payload.get("plan"), dict) else {}


### PR DESCRIPTION
## Summary
- add `loopx update --rollback <release-id|previous>` as a first-class rollback path
- replace rollback guidance in update plans with the new CLI instead of raw `ln -sfn` shell snippets
- validate rollback by repointing the user-local `loopx` command and running `loopx doctor`
- restore the previous command symlink when rollback doctor validation fails
- extend update smoke coverage for module, CLI, missing target, previous target, and failure restore behavior

## Validation
- `python3 -m py_compile loopx/self_update.py loopx/cli_commands/support_control.py examples/loopx-update-smoke.py`
- `python3 examples/loopx-update-smoke.py`
- `python3 examples/install-local-smoke.py`
- `python3 examples/codex-cli-no-clone-release-verification-smoke.py`
- `python3 examples/fresh-clone-quickstart-smoke.py`
- `python3 -m loopx.cli update --format json --rollback missing-release` returns nonzero with expected JSON payload
- `git diff --check`
- `loopx check --scan-path loopx/self_update.py --scan-path loopx/cli_commands/support_control.py --scan-path examples/loopx-update-smoke.py` (ok; existing duplicate-index warning only)

## Self-merge note
Owner explicitly authorized self-merge for the v0.1 install/upgrade usability todo group.