### PR TITLE
Fail fast on idle SkillsBench app-server goal turns

### DIFF
--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -451,7 +451,7 @@ def test_host_worker_waits_for_completion_and_keeps_public_json_compact() -> Non
         assert "Private task instruction placeholder" not in public_json, payload
 
 
-def test_host_worker_fails_closed_when_turn_completed_is_missing() -> None:
+def test_host_worker_fails_closed_on_first_action_timeout() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-app-goal-worker-no-complete-") as tmp:
         root = Path(tmp)
         fake = root / "codex"
@@ -481,7 +481,9 @@ def test_host_worker_fails_closed_when_turn_completed_is_missing() -> None:
                 "--response-timeout-sec",
                 "5",
                 "--turn-timeout-sec",
-                "0",
+                "5",
+                "--first-action-timeout-sec",
+                "1",
             ],
             cwd=REPO_ROOT,
             check=False,
@@ -489,8 +491,19 @@ def test_host_worker_fails_closed_when_turn_completed_is_missing() -> None:
             capture_output=True,
         )
         assert result.returncode == 1, result
-        assert "timed out waiting for app-server worker turn completion" in result.stderr
-        assert not output.exists(), result
+        assert result.stderr == "", result
+        payload = json.loads(output.read_text(encoding="utf-8"))
+        assert payload["ok"] is False, payload
+        assert payload["error_type"] == "codex_exec_first_action_timeout", payload
+        assert payload["worker_contract"]["ready"] is False, payload
+        assert (
+            payload["worker_contract"]["first_blocker"]
+            == "codex_exec_first_action_timeout"
+        ), payload
+        assert payload["turn"]["turn_id_present"] is True, payload
+        assert payload["turn"]["turn_completed_observed"] is False, payload
+        assert payload["turn"]["first_action_observed"] is False, payload
+        assert payload["turn"]["first_action_timeout_sec"] == 1.0, payload
         assert not private_response.exists(), result
         assert not list(work.glob(".loopx_app_server_goal_worker_response_*.txt"))
 
@@ -1115,7 +1128,7 @@ if __name__ == "__main__":
     test_launcher_plan_only_marks_runner_ready_with_host_acp_launch()
     test_host_worker_contract_only_cli()
     test_host_worker_waits_for_completion_and_keeps_public_json_compact()
-    test_host_worker_fails_closed_when_turn_completed_is_missing()
+    test_host_worker_fails_closed_on_first_action_timeout()
     test_acp_relay_delegates_to_app_server_goal_worker()
     test_acp_relay_materializes_lifecycle_trace_before_prompt()
     test_acp_relay_streams_public_keepalive_while_worker_runs()

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -1880,6 +1880,8 @@ raise SystemExit(proc.returncode)
                 str(self._config.response_timeout_sec),
                 "--turn-timeout-sec",
                 str(self._config.timeout_sec),
+                "--first-action-timeout-sec",
+                str(self._config.first_action_timeout_sec),
                 "--reasoning-effort",
                 str(self._config.reasoning_effort or "high"),
                 "--runner-integration-ready",
@@ -2097,8 +2099,17 @@ raise SystemExit(proc.returncode)
                     "assistant_message_chars",
                     "completion_hard_gate",
                     "completion_source_of_truth",
+                    "first_action_timeout_sec",
+                    "first_action_observed",
                     "raw_transcript_recorded",
                     "raw_assistant_message_recorded",
+                ),
+            ),
+            "worker_result": compact_dict(
+                payload,
+                (
+                    "ok",
+                    "error_type",
                 ),
             ),
             "private_response_text": compact_dict(

--- a/scripts/skillsbench_host_codex_goal_worker.py
+++ b/scripts/skillsbench_host_codex_goal_worker.py
@@ -100,17 +100,43 @@ def _prompt_with_loopx_case_lifecycle_packet(
     )
 
 
+def _first_action_observed(turn: Any) -> bool:
+    if int(getattr(turn, "agent_message_delta_count", 0) or 0) > 0:
+        return True
+    if int(getattr(turn, "agent_message_item_count", 0) or 0) > 0:
+        return True
+    if int(getattr(turn, "item_completed_count", 0) or 0) > 0:
+        return True
+    notifications = getattr(turn, "notifications", []) or []
+    for method in notifications:
+        text = str(method or "")
+        if text.startswith("item/"):
+            return True
+    return False
+
+
 def _wait_for_worker_turn_completion(
     turn: Any,
     *,
     timeout_sec: float,
+    first_action_timeout_sec: float = 0.0,
     poll_interval_sec: float = 1.0,
 ) -> bool:
-    deadline = time.monotonic() + max(0.0, timeout_sec)
+    started_at = time.monotonic()
+    deadline = started_at + max(0.0, timeout_sec)
+    first_action_deadline = 0.0
+    if first_action_timeout_sec > 0:
+        first_action_deadline = started_at + max(0.1, first_action_timeout_sec)
     while time.monotonic() < deadline:
         observe_codex_app_server_goal_turn(turn, timeout_sec=0.0, raise_on_error=False)
         if turn.turn_completed_observed:
             return True
+        if (
+            first_action_deadline
+            and not _first_action_observed(turn)
+            and time.monotonic() >= first_action_deadline
+        ):
+            raise TimeoutError("codex_exec_first_action_timeout")
         time.sleep(max(0.1, poll_interval_sec))
     observe_codex_app_server_goal_turn(turn, timeout_sec=0.0, raise_on_error=False)
     return bool(turn.turn_completed_observed)
@@ -142,21 +168,33 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
         response_timeout_sec=args.response_timeout_sec,
         wait_for_completion=False,
     )
+    worker_error_type = ""
     try:
         if not args.no_wait_for_completion:
-            turn_completed = _wait_for_worker_turn_completion(
-                turn,
-                timeout_sec=args.turn_timeout_sec,
-            )
-            if not turn_completed:
-                raise TimeoutError(
-                    "timed out waiting for app-server worker turn completion"
+            try:
+                turn_completed = _wait_for_worker_turn_completion(
+                    turn,
+                    timeout_sec=args.turn_timeout_sec,
+                    first_action_timeout_sec=args.first_action_timeout_sec,
                 )
+                if not turn_completed:
+                    raise TimeoutError(
+                        "timed out waiting for app-server worker turn completion"
+                    )
+            except TimeoutError as exc:
+                if str(exc) == "codex_exec_first_action_timeout":
+                    worker_error_type = "codex_exec_first_action_timeout"
+                else:
+                    worker_error_type = "codex_app_server_turn_timeout"
         compact = compact_turn_metadata(turn)
         compact.update(
             {
                 "completion_hard_gate": False,
                 "completion_source_of_truth": "codex_turn_completion",
+                "first_action_timeout_sec": max(
+                    0.0, float(args.first_action_timeout_sec or 0.0)
+                ),
+                "first_action_observed": _first_action_observed(turn),
                 "loopx_mode": args.loopx_mode,
                 "loopx_access_packet_mode": args.loopx_access_packet_mode,
                 "loopx_case_lifecycle_packet_injected": bool(lifecycle_packet),
@@ -171,13 +209,27 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
             private_response_written = True
     finally:
         turn.terminate()
-    ok = bool(compact.get("turn_id_present")) and (
+    worker_contract = build_contract_payload(args)
+    if worker_error_type:
+        worker_contract = dict(worker_contract)
+        blockers = list(worker_contract.get("blockers") or [])
+        if worker_error_type not in blockers:
+            blockers.insert(0, worker_error_type)
+        worker_contract.update(
+            {
+                "ready": False,
+                "first_blocker": worker_error_type,
+                "blockers": blockers,
+            }
+        )
+    ok = not worker_error_type and bool(compact.get("turn_id_present")) and (
         args.no_wait_for_completion
         or compact.get("turn_completed_observed") is True
     )
     return {
         "schema_version": "skillsbench_host_codex_goal_worker_result_v0",
         "ok": ok,
+        "error_type": worker_error_type,
         "route": "codex-app-server-goal-baseline",
         "benchmark_id": args.dataset,
         "task_id": args.task_id,
@@ -185,7 +237,7 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
         "loopx_access_packet_mode": args.loopx_access_packet_mode,
         "loopx_case_lifecycle_packet_injected": bool(lifecycle_packet),
         "benchmark_case_lifecycle_contract": lifecycle_contract,
-        "worker_contract": build_contract_payload(args),
+        "worker_contract": worker_contract,
         "prompt": {
             "sha256": stable_text_digest(prompt),
             "chars": len(prompt),
@@ -232,6 +284,7 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--response-text-file")
     parser.add_argument("--response-timeout-sec", type=float, default=30.0)
     parser.add_argument("--turn-timeout-sec", type=float, default=7200.0)
+    parser.add_argument("--first-action-timeout-sec", type=float, default=0.0)
     parser.add_argument(
         "--no-wait-for-completion",
         action="store_true",


### PR DESCRIPTION
## Summary\n- add a first-action watchdog to the host Codex app-server Goal worker\n- pass the watchdog timeout through the SkillsBench ACP relay\n- expose first-action timeout/observed fields in public worker trace and cover the no-action fake app-server case\n\n## Validation\n- python3 -m py_compile scripts/skillsbench_host_codex_goal_worker.py loopx/benchmark_adapters/skillsbench_acp_relay.py examples/skillsbench-app-server-goal-worker-smoke.py\n- python3 examples/skillsbench-app-server-goal-worker-smoke.py\n- python3 examples/skillsbench-goal-start-product-mode-route-smoke.py