### PR TITLE
Require task progress for SkillsBench app goal turns

### DIFF
--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -1059,6 +1059,248 @@ sys.exit(0)
         proc.wait(timeout=2)
 
 
+def test_acp_relay_fails_fast_when_app_server_worker_never_uses_bridge() -> None:
+    fake_worker = """#!/usr/bin/env python3
+import time
+
+time.sleep(30)
+"""
+    with tempfile.TemporaryDirectory(prefix="skillsbench-app-goal-bridge-first-action-") as tmp:
+        root = Path(tmp)
+        worker = root / "fake_worker.py"
+        work = root / "work"
+        trace_dir = root / "worker-traces"
+        worker.write_text(fake_worker, encoding="utf-8")
+        worker.chmod(0o755)
+        work.mkdir()
+        bridge_command = (
+            f"{sys.executable} "
+            f"{REPO_ROOT / 'scripts' / 'skillsbench_remote_command_file_bridge.py'} "
+            "--serve-probe"
+        )
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "skillsbench_local_acp_relay.py"),
+                "--app-server-goal-worker",
+                "--task-id",
+                "llm-prefix-cache-replay",
+                "--worker-script",
+                str(worker),
+                "--timeout-sec",
+                "20",
+                "--first-action-timeout-sec",
+                "1",
+                "--remote-command-file-bridge-command",
+                bridge_command,
+                "--worker-public-trace-dir",
+                str(trace_dir),
+            ],
+            cwd=REPO_ROOT,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        assert proc.stdin is not None
+        assert proc.stdout is not None
+
+        def send(message: dict[str, Any]) -> None:
+            proc.stdin.write(json.dumps(message) + "\n")
+            proc.stdin.flush()
+
+        def read_response(request_id: int) -> dict[str, Any]:
+            while True:
+                line = proc.stdout.readline()
+                assert line, proc.stderr.read()
+                message = json.loads(line)
+                if message.get("id") == request_id and "method" not in message:
+                    return message
+
+        send({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
+        read_response(1)
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "session/new",
+                "params": {"cwd": str(work), "mcpServers": []},
+            }
+        )
+        session_id = read_response(2)["result"]["sessionId"]
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "session/prompt",
+                "params": {
+                    "sessionId": session_id,
+                    "prompt": [{"type": "text", "text": "private task placeholder"}],
+                },
+            }
+        )
+        final_response = read_response(3)
+        assert "result" in final_response, final_response
+        assert final_response["result"]["stopReason"] == "end_turn", final_response
+        traces = [
+            json.loads(path.read_text(encoding="utf-8"))
+            for path in sorted(trace_dir.glob("*.compact.json"))
+        ]
+        failure_traces = [
+            item
+            for item in traces
+            if item.get("trace_kind") == "host_worker_process_failure"
+        ]
+        assert len(failure_traces) == 1, traces
+        trace = failure_traces[0]
+        assert trace["ok"] is False, trace
+        assert trace["worker_process"]["stage"] == "first_action_timeout", trace
+        assert trace["worker_contract"]["first_blocker"] == "first_action_timeout", trace
+        assert trace["worker_process"]["stderr_bytes"] > 0, trace
+        trace_text = json.dumps(trace, sort_keys=True)
+        assert "private task placeholder" not in trace_text, trace
+        assert str(work) not in trace_text, trace
+        proc.terminate()
+        proc.wait(timeout=2)
+
+
+def test_acp_relay_fails_fast_when_app_server_worker_only_uses_status_bridge() -> None:
+    fake_worker = """#!/usr/bin/env python3
+import argparse
+import json
+import subprocess
+import time
+from pathlib import Path
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--prompt-file")
+args, _ = parser.parse_known_args()
+prompt = Path(args.prompt_file).read_text(encoding="utf-8")
+bridge = prompt.split("Private bridge command:\\n", 1)[1].splitlines()[0].strip()
+payload = {
+    "operation": "exec",
+    "cwd": "/app",
+    "command": "loopx status",
+    "timeout_sec": 1,
+}
+subprocess.run(
+    bridge,
+    input=json.dumps(payload),
+    shell=True,
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+)
+time.sleep(30)
+"""
+    with tempfile.TemporaryDirectory(prefix="skillsbench-app-goal-bridge-status-only-") as tmp:
+        root = Path(tmp)
+        worker = root / "fake_worker.py"
+        work = root / "work"
+        trace_dir = root / "worker-traces"
+        worker.write_text(fake_worker, encoding="utf-8")
+        worker.chmod(0o755)
+        work.mkdir()
+        bridge_command = (
+            f"{sys.executable} "
+            f"{REPO_ROOT / 'scripts' / 'skillsbench_remote_command_file_bridge.py'} "
+            "--serve-probe"
+        )
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "skillsbench_local_acp_relay.py"),
+                "--app-server-goal-worker",
+                "--task-id",
+                "llm-prefix-cache-replay",
+                "--worker-script",
+                str(worker),
+                "--timeout-sec",
+                "20",
+                "--first-action-timeout-sec",
+                "1",
+                "--remote-command-file-bridge-command",
+                bridge_command,
+                "--worker-public-trace-dir",
+                str(trace_dir),
+            ],
+            cwd=REPO_ROOT,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        assert proc.stdin is not None
+        assert proc.stdout is not None
+
+        def send(message: dict[str, Any]) -> None:
+            proc.stdin.write(json.dumps(message) + "\n")
+            proc.stdin.flush()
+
+        def read_response(request_id: int) -> dict[str, Any]:
+            while True:
+                line = proc.stdout.readline()
+                assert line, proc.stderr.read()
+                message = json.loads(line)
+                if message.get("id") == request_id and "method" not in message:
+                    return message
+
+        send({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
+        read_response(1)
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "session/new",
+                "params": {"cwd": str(work), "mcpServers": []},
+            }
+        )
+        session_id = read_response(2)["result"]["sessionId"]
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "session/prompt",
+                "params": {
+                    "sessionId": session_id,
+                    "prompt": [{"type": "text", "text": "private task placeholder"}],
+                },
+            }
+        )
+        final_response = read_response(3)
+        assert "result" in final_response, final_response
+        assert final_response["result"]["stopReason"] == "end_turn", final_response
+        traces = [
+            json.loads(path.read_text(encoding="utf-8"))
+            for path in sorted(trace_dir.glob("*.compact.json"))
+        ]
+        failure_traces = [
+            item
+            for item in traces
+            if item.get("trace_kind") == "host_worker_process_failure"
+        ]
+        assert len(failure_traces) == 1, traces
+        trace = failure_traces[0]
+        assert trace["worker_process"]["stage"] == (
+            "meaningful_bridge_progress_timeout"
+        ), trace
+        bridge_traces = [
+            item
+            for item in traces
+            if item.get("trace_kind") == "remote_command_file_bridge_agent_operations"
+        ]
+        assert len(bridge_traces) == 1, traces
+        agent_ops = bridge_traces[0]["remote_command_file_bridge_agent_operations"]
+        assert agent_ops["request_count"] == 1, bridge_traces
+        assert agent_ops["loopx_cli_call_count"] == 1, bridge_traces
+        assert agent_ops["task_facing_operation_count"] == 0, bridge_traces
+        trace_text = json.dumps(traces, sort_keys=True)
+        assert "private task placeholder" not in trace_text, traces
+        assert str(work) not in trace_text, traces
+        proc.terminate()
+        proc.wait(timeout=2)
+
+
 def test_full_run_fails_closed_until_bridge_is_materialized() -> None:
     result = subprocess.run(
         [
@@ -1135,6 +1377,8 @@ if __name__ == "__main__":
     test_acp_relay_preserves_public_worker_trace_on_worker_failure()
     test_acp_relay_materializes_public_failure_trace_without_worker_output()
     test_acp_relay_fails_closed_when_zero_exit_worker_writes_no_public_output()
+    test_acp_relay_fails_fast_when_app_server_worker_never_uses_bridge()
+    test_acp_relay_fails_fast_when_app_server_worker_only_uses_status_bridge()
     test_full_run_fails_closed_until_bridge_is_materialized()
     test_full_run_with_bridge_ready_requires_host_acp_launch()
     test_launcher_patches_rollout_planes_connect_acp()

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -6545,6 +6545,57 @@ def test_skillsbench_round_trace_records_best_round_score() -> None:
                 },
             },
         )
+        write_json(
+            worker_trace_dir / "bridge-agent-ops.compact.json",
+            {
+                "schema_version": "skillsbench_host_local_acp_relay_public_trace_v0",
+                "ok": True,
+                "route": "codex-app-server-goal-baseline",
+                "trace_kind": "remote_command_file_bridge_agent_operations",
+                "benchmark_id": "skillsbench@1.1",
+                "task_id": "llm-prefix-cache-replay",
+                "remote_command_file_bridge_agent_operations": {
+                    "schema_version": (
+                        "skillsbench_remote_command_file_bridge_agent_operations_v0"
+                    ),
+                    "request_count": 2,
+                    "success_count": 2,
+                    "failure_count": 0,
+                    "operation_counts": {"exec": 2},
+                    "returncode_counts": {"0": 2},
+                    "failure_category_counts": {},
+                    "loopx_cli_call_count": 0,
+                    "loopx_cli_subcommand_counts": {},
+                    "successful_loopx_cli_subcommand_counts": {},
+                    "successful_loopx_cli_command_records": [],
+                    "loopx_state_read_count": 0,
+                    "loopx_state_write_count": 0,
+                    "task_facing_operation_count": 2,
+                    "preflight_success_count": 0,
+                    "preflight_failure_count": 0,
+                    "task_facing_success_count": 2,
+                    "task_facing_failure_count": 0,
+                    "probe_operation_count": 0,
+                    "inflight_operation_count": 0,
+                    "interrupted_operation_count": 0,
+                    "task_facing_interrupted_count": 0,
+                    "raw_material_recorded": False,
+                },
+                "boundary": {
+                    "raw_command_recorded": False,
+                    "raw_stdout_recorded": False,
+                    "raw_stderr_recorded": False,
+                    "raw_task_text_recorded": False,
+                    "raw_logs_recorded": False,
+                    "raw_trajectory_recorded": False,
+                    "credential_values_recorded": False,
+                    "host_paths_recorded": False,
+                    "remote_paths_recorded": False,
+                    "upload_performed": False,
+                    "submit_performed": False,
+                },
+            },
+        )
         app_server_trace = {
             "schema_version": "skillsbench_loopx_controller_trace_v0",
             "route": "codex-app-server-goal-baseline",
@@ -6557,6 +6608,13 @@ def test_skillsbench_round_trace_records_best_round_score() -> None:
             "raw_agent_trajectory_recorded": False,
         }
         _merge_app_server_goal_worker_trace_summary(
+            {
+                "route": "codex-app-server-goal-baseline",
+                "app_server_goal_worker_trace_dir": str(worker_trace_dir),
+            },
+            app_server_trace,
+        )
+        _merge_host_local_acp_relay_trace_summary(
             {
                 "route": "codex-app-server-goal-baseline",
                 "app_server_goal_worker_trace_dir": str(worker_trace_dir),
@@ -6588,6 +6646,13 @@ def test_skillsbench_round_trace_records_best_round_score() -> None:
         assert native_counters["native_goal_worker_turn_start_count"] == 1, native_compact
         assert native_counters["native_goal_worker_turn_completed_observed_count"] == 1, native_compact
         assert native_counters["native_goal_worker_raw_material_recorded"] is False, native_compact
+        assert native_counters["remote_command_file_bridge_agent_request_count"] == 2, native_compact
+        assert native_counters[
+            "remote_command_file_bridge_agent_task_facing_operation_count"
+        ] == 2, native_compact
+        assert native_counters[
+            "remote_command_file_bridge_agent_task_facing_success_count"
+        ] == 2, native_compact
         native_validation = native_compact["validation"]
         assert native_validation["native_goal_worker_trace_observed"] is True, native_compact
         assert native_validation["native_goal_worker_trace_count"] == 1, native_compact

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -203,6 +203,46 @@ def _bridge_summary_has_inflight_operation(path: Path | None) -> bool:
     return starts > completions
 
 
+def _bridge_summary_has_meaningful_agent_progress(
+    path: Path | None,
+    *,
+    allow_loopx_closeout: bool,
+) -> bool:
+    """Return true once the worker has done task work or a real closeout action."""
+
+    if path is None or not path.exists():
+        return False
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return False
+    closeout_subcommands = {
+        ("todo", "complete"),
+        ("todo", "update"),
+        ("refresh-state",),
+        ("quota", "spend-slot"),
+    }
+    for line in lines:
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(record, dict):
+            continue
+        phase = str(record.get("record_phase") or "").strip().lower()
+        if phase == "complete" and _bridge_operation_record_interrupted(record):
+            continue
+        if record.get("task_facing_operation") is True:
+            return True
+        if allow_loopx_closeout and record.get("loopx_state_write") is True:
+            subcommands = record.get("loopx_subcommands")
+            if isinstance(subcommands, list):
+                key = tuple(str(item) for item in subcommands[:2])
+                if key in closeout_subcommands:
+                    return True
+    return False
+
+
 def _bridge_operation_record_interrupted(record: dict[str, Any]) -> bool:
     rc = record.get("returncode")
     if isinstance(rc, int) and not isinstance(rc, bool) and rc < 0:
@@ -212,6 +252,25 @@ def _bridge_operation_record_interrupted(record: dict[str, Any]) -> bool:
         "bridge_operation_interrupted",
         "bridge_controller_interrupted",
     }
+
+
+def _prompt_requires_meaningful_bridge_progress(prompt: str, *, route: str) -> bool:
+    text = prompt or ""
+    if "Private bridge command:" not in text:
+        return False
+    if route == "codex-app-server-goal-baseline":
+        return True
+    lowered = text.lower()
+    return any(
+        marker in lowered
+        for marker in (
+            "--- task instruction ---",
+            "mandatory product-mode solver checkpoint",
+            "mandatory host-local bridge recovery checkpoint",
+            "must start with either a task-facing sandbox bridge operation",
+            "task-facing validation or repair operation",
+        )
+    )
 
 
 def _codex_exec_failure_category(
@@ -646,6 +705,24 @@ class SkillsBenchLocalAcpRelay:
                             time.monotonic()
                             + max(1.0, self._config.first_action_timeout_sec)
                         )
+                    meaningful_progress_deadline = 0.0
+                    meaningful_progress_seen = False
+                    meaningful_progress_required = (
+                        bridge_summary_path is not None
+                        and self._config.first_action_timeout_sec > 0
+                        and _prompt_requires_meaningful_bridge_progress(
+                            prompt_for_codex,
+                            route=self._config.route,
+                        )
+                    )
+                    allow_loopx_closeout_progress = self._config.route.startswith(
+                        "loopx-"
+                    )
+                    if meaningful_progress_required:
+                        meaningful_progress_deadline = (
+                            time.monotonic()
+                            + max(1.0, self._config.first_action_timeout_sec)
+                        )
                     first_action_seen = not bool(first_action_deadline)
                     bridge_idle_timeout_sec = max(
                         0.0,
@@ -677,6 +754,15 @@ class SkillsBenchLocalAcpRelay:
                                 and current_bridge_summary_size > 0
                             ):
                                 first_action_seen = True
+                            if not meaningful_progress_seen:
+                                meaningful_progress_seen = (
+                                    _bridge_summary_has_meaningful_agent_progress(
+                                        bridge_summary_path,
+                                        allow_loopx_closeout=(
+                                            allow_loopx_closeout_progress
+                                        ),
+                                    )
+                                )
                         if (
                             not first_action_seen
                             and first_action_deadline
@@ -689,6 +775,33 @@ class SkillsBenchLocalAcpRelay:
                                 )
                             self._publish_codex_exec_failure_trace(
                                 stage="first_action_timeout",
+                                returncode=124,
+                                stdout_text="",
+                                stderr_text="codex_exec_first_action_timeout\n",
+                                final_message_present=output_path.exists(),
+                                final_message_bytes=(
+                                    output_path.stat().st_size
+                                    if output_path.exists()
+                                    else 0
+                                ),
+                                failure_category="codex_exec_first_action_timeout",
+                            )
+                            return _recoverable_codex_turn_failure_message(
+                                "codex_exec_first_action_timeout"
+                            )
+                        if (
+                            meaningful_progress_required
+                            and not meaningful_progress_seen
+                            and meaningful_progress_deadline
+                            and now >= meaningful_progress_deadline
+                        ):
+                            self._terminate_codex_process(proc)
+                            if bridge_summary_path is not None:
+                                self._publish_remote_bridge_agent_operations_trace(
+                                    bridge_summary_path=bridge_summary_path,
+                                )
+                            self._publish_codex_exec_failure_trace(
+                                stage="meaningful_bridge_progress_timeout",
                                 returncode=124,
                                 stdout_text="",
                                 stderr_text="codex_exec_first_action_timeout\n",
@@ -1914,6 +2027,34 @@ raise SystemExit(proc.returncode)
                     0.0,
                     float(self._config.bridge_idle_timeout_sec or 0.0),
                 )
+                bridge_first_action_deadline = 0.0
+                if (
+                    bridge_summary_path is not None
+                    and self._config.first_action_timeout_sec > 0
+                ):
+                    bridge_first_action_deadline = (
+                        time.monotonic()
+                        + max(1.0, self._config.first_action_timeout_sec)
+                    )
+                meaningful_progress_deadline = 0.0
+                meaningful_progress_seen = False
+                progress_route = self._config.route
+                if self._config.app_server_goal_worker and progress_route == "unknown":
+                    progress_route = "codex-app-server-goal-baseline"
+                meaningful_progress_required = (
+                    bridge_summary_path is not None
+                    and self._config.first_action_timeout_sec > 0
+                    and _prompt_requires_meaningful_bridge_progress(
+                        prompt_for_worker,
+                        route=progress_route,
+                    )
+                )
+                allow_loopx_closeout_progress = progress_route.startswith("loopx-")
+                if meaningful_progress_required:
+                    meaningful_progress_deadline = (
+                        time.monotonic()
+                        + max(1.0, self._config.first_action_timeout_sec)
+                    )
                 while proc.poll() is None:
                     now = time.monotonic()
                     if bridge_summary_path is not None:
@@ -1927,6 +2068,58 @@ raise SystemExit(proc.returncode)
                             last_bridge_summary_size = current_bridge_summary_size
                             last_bridge_activity_at = now
                             bridge_activity_seen = True
+                        if not meaningful_progress_seen:
+                            meaningful_progress_seen = (
+                                _bridge_summary_has_meaningful_agent_progress(
+                                    bridge_summary_path,
+                                    allow_loopx_closeout=allow_loopx_closeout_progress,
+                                )
+                            )
+                    if (
+                        not bridge_activity_seen
+                        and bridge_summary_path is not None
+                        and bridge_first_action_deadline
+                        and now >= bridge_first_action_deadline
+                    ):
+                        proc.terminate()
+                        stdout_text, stderr_text = proc.communicate(timeout=2)
+                        self._publish_remote_bridge_agent_operations_trace(
+                            bridge_summary_path=bridge_summary_path,
+                        )
+                        if not self._publish_worker_trace(output_json):
+                            self._publish_worker_failure_trace(
+                                stage="first_action_timeout",
+                                returncode=proc.returncode,
+                                stdout_text=stdout_text,
+                                stderr_text="codex_exec_first_action_timeout\n",
+                            )
+                        self._terminate_bridge_server_process(bridge_server_proc)
+                        return _recoverable_codex_turn_failure_message(
+                            "codex_exec_first_action_timeout"
+                        )
+                    if (
+                        meaningful_progress_required
+                        and not meaningful_progress_seen
+                        and bridge_summary_path is not None
+                        and meaningful_progress_deadline
+                        and now >= meaningful_progress_deadline
+                    ):
+                        proc.terminate()
+                        stdout_text, stderr_text = proc.communicate(timeout=2)
+                        self._publish_remote_bridge_agent_operations_trace(
+                            bridge_summary_path=bridge_summary_path,
+                        )
+                        if not self._publish_worker_trace(output_json):
+                            self._publish_worker_failure_trace(
+                                stage="meaningful_bridge_progress_timeout",
+                                returncode=proc.returncode,
+                                stdout_text=stdout_text,
+                                stderr_text="codex_exec_first_action_timeout\n",
+                            )
+                        self._terminate_bridge_server_process(bridge_server_proc)
+                        return _recoverable_codex_turn_failure_message(
+                            "codex_exec_first_action_timeout"
+                        )
                     if (
                         bridge_activity_seen
                         and bridge_summary_path is not None

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -6833,7 +6833,11 @@ def _merge_host_local_acp_relay_trace_summary(
         return
     raw_trace_dir = plan.get("host_local_acp_relay_trace_dir")
     if not isinstance(raw_trace_dir, str) or not raw_trace_dir.strip():
-        return
+        if plan.get("route") != "codex-app-server-goal-baseline":
+            return
+        raw_trace_dir = plan.get("app_server_goal_worker_trace_dir")
+        if not isinstance(raw_trace_dir, str) or not raw_trace_dir.strip():
+            return
     trace_dir = Path(raw_trace_dir)
     files = sorted(trace_dir.glob("*.compact.json")) if trace_dir.exists() else []
     solver_trace_count = 0


### PR DESCRIPTION
## Summary
- Require SkillsBench task-stage app-server/ACP turns to produce meaningful task-facing bridge progress within the first-action window.
- Treat no-bridge and status-only bridge turns as recoverable first-action failures instead of allowing long idle runs.
- Merge app-server bridge operation compact traces into the common controller/reducer counters so compact results and the ledger can observe task-facing bridge activity.

## Root Cause
The previous app-server route only knew that the native worker was alive or that some bridge file activity happened. That let internal app-server/TUI activity, or lifecycle-only commands such as status probes, masquerade as benchmark progress. The runner could then wait for a long timeout even when the worker had not actually operated on the task sandbox.

## Validation
- python3 -m py_compile loopx/benchmark_adapters/skillsbench_acp_relay.py scripts/skillsbench_automation_loop.py examples/skillsbench-app-server-goal-worker-smoke.py examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-app-server-goal-worker-smoke.py
- python3 examples/skillsbench-goal-start-product-mode-route-smoke.py
- focused: test_skillsbench_controller_trace_counts_are_compacted

No raw task text, trajectories, verifier output, credentials, or local private paths are added.