### PR TITLE
Isolate parallel SkillsBench batch cases

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -9338,6 +9338,55 @@ def test_skillsbench_runner_plan_supports_controller_trace_path() -> None:
         assert plan["include_task_skills"] is False, plan
 
 
+def test_skillsbench_parallel_batch_isolates_case_process_argv() -> None:
+    args = parse_args(
+        [
+            "--task-ids",
+            "3d-scan-calc,adaptive-cruise-control",
+            "--parallel-cases",
+            "2",
+            "--route",
+            "codex-app-server-goal-baseline",
+            "--run-group-id",
+            "skillsbench-goal-baseline-30case-test",
+            "--job-name",
+            "skillsbench-goal-baseline-30case-test",
+            "--rollout-name",
+            "skillsbench-goal-baseline-30case-test",
+            "--max-rounds",
+            "16",
+            "--host-local-acp-launch",
+            "--remote-command-file-bridge-ready",
+            "--app-server-reasoning-effort",
+            "high",
+            "--append-history",
+        ]
+    )
+    assert skillsbench_loop._parallel_batch_requires_subprocess_isolation(2) is True
+    case_args = skillsbench_loop._clone_args_for_batch_case(
+        args,
+        task_id="adaptive-cruise-control",
+        index=1,
+        total=2,
+        run_group_id="skillsbench-goal-baseline-30case-test",
+    )
+    child_argv = skillsbench_loop._batch_case_args_to_cli(case_args)
+    assert "--task-ids" not in child_argv, child_argv
+    assert child_argv[child_argv.index("--task-id") + 1] == (
+        "adaptive-cruise-control"
+    ), child_argv
+    assert child_argv[child_argv.index("--parallel-cases") + 1] == "1", child_argv
+    assert child_argv[child_argv.index("--run-group-id") + 1] == (
+        "skillsbench-goal-baseline-30case-test"
+    ), child_argv
+    assert child_argv[child_argv.index("--job-name") + 1].endswith(
+        "-02-adaptive-cruise-control"
+    ), child_argv
+    assert "--host-local-acp-launch" in child_argv, child_argv
+    assert "--remote-command-file-bridge-ready" in child_argv, child_argv
+    assert "--append-history" in child_argv, child_argv
+
+
 def test_skillsbench_compact_runs_update_ledger_pair() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-ledger-smoke-") as tmp:
         root = Path(tmp)

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -12415,6 +12415,84 @@ def _clone_args_for_batch_case(
     return case_args
 
 
+def _batch_case_args_to_cli(case_args: argparse.Namespace) -> list[str]:
+    cli: list[str] = []
+    for key, value in sorted(vars(case_args).items()):
+        if key == "task_ids":
+            continue
+        option = "--" + key.replace("_", "-")
+        if key == "parallel_cases":
+            value = 1
+        if value is None:
+            continue
+        if isinstance(value, bool):
+            if value:
+                cli.append(option)
+            continue
+        cli.extend([option, str(value)])
+    return cli
+
+
+def _parallel_batch_requires_subprocess_isolation(parallel_cases: int) -> bool:
+    return parallel_cases > 1
+
+
+def _extract_batch_case_subprocess_payload(
+    *,
+    case_args: argparse.Namespace,
+    returncode: int,
+    stdout: bytes,
+    stderr: bytes,
+) -> dict[str, Any]:
+    text = stdout.decode("utf-8", errors="replace").strip()
+    if not text:
+        text = stderr.decode("utf-8", errors="replace").strip()
+    try:
+        payload = json.loads(text)
+        if not isinstance(payload, dict):
+            raise ValueError("child payload was not a JSON object")
+    except Exception as exc:
+        payload = {
+            "ok": False,
+            "task_id": str(case_args.task_id),
+            "run_group_id": str(case_args.run_group_id or ""),
+            "route": str(case_args.route),
+            "error_type": "SkillsBenchBatchCaseSubprocessPayloadError",
+            "error_class": type(exc).__name__,
+            "child_returncode": int(returncode),
+            "child_stdout_bytes": len(stdout),
+            "child_stderr_bytes": len(stderr),
+            "raw_stdout_recorded": False,
+            "raw_stderr_recorded": False,
+            "compact_closeout_recorded": False,
+        }
+    payload["batch_case_subprocess"] = True
+    payload["runner_returncode"] = int(returncode)
+    return payload
+
+
+async def _run_batch_case_subprocess(
+    case_args: argparse.Namespace,
+) -> dict[str, Any]:
+    command = [
+        sys.executable,
+        str(Path(__file__).resolve()),
+        *_batch_case_args_to_cli(case_args),
+    ]
+    proc = await asyncio.create_subprocess_exec(
+        *command,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    stdout, stderr = await proc.communicate()
+    return _extract_batch_case_subprocess_payload(
+        case_args=case_args,
+        returncode=int(proc.returncode or 0),
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
 async def async_batch_main(
     args: argparse.Namespace,
     *,
@@ -12427,6 +12505,9 @@ async def async_batch_main(
     )
     parallel_cases = min(max(1, int(args.parallel_cases or 1)), len(selected_task_ids))
     semaphore = asyncio.Semaphore(parallel_cases)
+    isolate_case_processes = _parallel_batch_requires_subprocess_isolation(
+        parallel_cases
+    )
 
     async def run_one(index: int, task_id: str) -> dict[str, Any]:
         case_args = _clone_args_for_batch_case(
@@ -12439,6 +12520,8 @@ async def async_batch_main(
         case_plan = build_plan(case_args)
         async with semaphore:
             try:
+                if isolate_case_processes:
+                    return await _run_batch_case_subprocess(case_args)
                 payload = await async_main(case_args, plan=case_plan)
                 payload["runner_returncode"] = 0
                 return payload
@@ -12460,6 +12543,7 @@ async def async_batch_main(
         "batch": True,
         "task_count": len(selected_task_ids),
         "parallel_cases": parallel_cases,
+        "case_process_isolation": isolate_case_processes,
         "run_group_id": run_group_id,
         "results": results,
         "runner_returncode": returncode,


### PR DESCRIPTION
## Summary
- Run parallel SkillsBench batch cases in per-case subprocesses instead of in the same Python process.
- Preserve the existing in-process path for serial batch/single-case execution.
- Add a focused smoke for child argv generation: no inherited task-ids, per-case task-id, parallel-cases=1, suffixed job/rollout names, and app-server/bridge flags preserved.

## Root Cause
A 30-case r8 run showed an adaptive-cruise-control worker launching with a reverse-channel bridge command for the 3d-scan-calc Docker project. The actual issue is not trace loss: parallel batch execution runs multiple BenchFlow cases in one Python process while run_benchflow_case patches module-global ACP hooks. Concurrent cases can therefore use another case's connect/bridge closure.

This PR fixes the isolation boundary so parallel cases cannot share those global BenchFlow hooks.

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py
- focused: test_skillsbench_parallel_batch_isolates_case_process_argv
- plan-only 2-case parallel batch exercised the subprocess path successfully
- python3 examples/skillsbench-app-server-goal-worker-smoke.py
- python3 examples/skillsbench-goal-start-product-mode-route-smoke.py

Boundary: no raw benchmark logs/tasks/trajectories, credentials, or local private paths added to tracked files.
