### PR TITLE
Recover SkillsBench task-output quiet workers

### DIFF
--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -8,6 +8,7 @@ import importlib.util
 import subprocess
 import sys
 import tempfile
+import time
 from pathlib import Path
 from typing import Any
 
@@ -1301,6 +1302,148 @@ time.sleep(30)
         proc.wait(timeout=2)
 
 
+def test_acp_relay_yields_after_task_output_quiet_timeout() -> None:
+    fake_worker = """#!/usr/bin/env python3
+import argparse
+import json
+import subprocess
+import time
+from pathlib import Path
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--prompt-file")
+args, _ = parser.parse_known_args()
+prompt = Path(args.prompt_file).read_text(encoding="utf-8")
+bridge = prompt.split("Private bridge command:\\n", 1)[1].splitlines()[0].strip()
+payload = {
+    "operation": "write_file",
+    "path": "/tmp/task-output.json",
+    "content": "{\\"ok\\": true}\\n",
+}
+subprocess.run(
+    bridge,
+    input=json.dumps(payload),
+    shell=True,
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+)
+time.sleep(30)
+"""
+    with tempfile.TemporaryDirectory(prefix="skillsbench-app-goal-output-quiet-") as tmp:
+        root = Path(tmp)
+        worker = root / "fake_worker.py"
+        work = root / "work"
+        trace_dir = root / "worker-traces"
+        worker.write_text(fake_worker, encoding="utf-8")
+        worker.chmod(0o755)
+        work.mkdir()
+        bridge_command = (
+            f"{sys.executable} "
+            f"{REPO_ROOT / 'scripts' / 'skillsbench_remote_command_file_bridge.py'} "
+            "--serve-probe"
+        )
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "skillsbench_local_acp_relay.py"),
+                "--app-server-goal-worker",
+                "--task-id",
+                "llm-prefix-cache-replay",
+                "--worker-script",
+                str(worker),
+                "--timeout-sec",
+                "20",
+                "--first-action-timeout-sec",
+                "5",
+                "--bridge-idle-timeout-sec",
+                "30",
+                "--task-output-quiet-timeout-sec",
+                "1",
+                "--remote-command-file-bridge-command",
+                bridge_command,
+                "--worker-public-trace-dir",
+                str(trace_dir),
+            ],
+            cwd=REPO_ROOT,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        assert proc.stdin is not None
+        assert proc.stdout is not None
+
+        def send(message: dict[str, Any]) -> None:
+            proc.stdin.write(json.dumps(message) + "\n")
+            proc.stdin.flush()
+
+        def read_response(request_id: int) -> dict[str, Any]:
+            deadline = time.monotonic() + 10
+            while time.monotonic() < deadline:
+                line = proc.stdout.readline()
+                assert line, proc.stderr.read()
+                message = json.loads(line)
+                if message.get("id") == request_id and "method" not in message:
+                    return message
+            raise AssertionError(proc.stderr.read())
+
+        send({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
+        read_response(1)
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "session/new",
+                "params": {"cwd": str(work), "mcpServers": []},
+            }
+        )
+        session_id = read_response(2)["result"]["sessionId"]
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "session/prompt",
+                "params": {
+                    "sessionId": session_id,
+                    "prompt": [{"type": "text", "text": "private task placeholder"}],
+                },
+            }
+        )
+        final_response = read_response(3)
+        assert "result" in final_response, final_response
+        assert final_response["result"]["stopReason"] == "end_turn", final_response
+        traces = [
+            json.loads(path.read_text(encoding="utf-8"))
+            for path in sorted(trace_dir.glob("*.compact.json"))
+        ]
+        failure_traces = [
+            item
+            for item in traces
+            if item.get("trace_kind") == "host_worker_process_failure"
+        ]
+        assert len(failure_traces) == 1, traces
+        trace = failure_traces[0]
+        assert trace["worker_process"]["stage"] == "task_output_quiet_timeout", trace
+        assert trace["worker_process"]["failure_category"] == (
+            "codex_exec_task_output_quiet_timeout"
+        ), trace
+        bridge_traces = [
+            item
+            for item in traces
+            if item.get("trace_kind") == "remote_command_file_bridge_agent_operations"
+        ]
+        assert len(bridge_traces) == 1, traces
+        agent_ops = bridge_traces[0]["remote_command_file_bridge_agent_operations"]
+        assert agent_ops["task_facing_operation_count"] == 1, bridge_traces
+        assert agent_ops["task_facing_success_count"] == 1, bridge_traces
+        trace_text = json.dumps(traces, sort_keys=True)
+        assert "private task placeholder" not in trace_text, traces
+        assert str(work) not in trace_text, traces
+        proc.terminate()
+        proc.wait(timeout=2)
+
+
 def test_full_run_fails_closed_until_bridge_is_materialized() -> None:
     result = subprocess.run(
         [
@@ -1379,6 +1522,7 @@ if __name__ == "__main__":
     test_acp_relay_fails_closed_when_zero_exit_worker_writes_no_public_output()
     test_acp_relay_fails_fast_when_app_server_worker_never_uses_bridge()
     test_acp_relay_fails_fast_when_app_server_worker_only_uses_status_bridge()
+    test_acp_relay_yields_after_task_output_quiet_timeout()
     test_full_run_fails_closed_until_bridge_is_materialized()
     test_full_run_with_bridge_ready_requires_host_acp_launch()
     test_launcher_patches_rollout_planes_connect_acp()

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -6145,7 +6145,8 @@ def test_host_local_acp_connect_contract_matches_benchflow_runtime() -> None:
         encoding="utf-8"
     )
     assert "def _benchflow_connect_acp_return_arity(target: Any) -> int:" in source
-    assert "return_arity = _benchflow_connect_acp_return_arity(" in source
+    assert "_benchflow_connect_acp_return_arity(" in source
+    assert "return_arity = connect_as_return_arity or _benchflow_connect_acp_return_arity(" in source
     assert "if return_arity >= 4:" in source
     assert "from benchflow.agents.protocol import ACPSessionAdapter" in source
     assert ") -> tuple[Any, ...]:" in source

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -1412,6 +1412,7 @@ def skillsbench_runner_error_attribution(error_text: str) -> tuple[str, str, lis
                 "bind source path" in text
                 or "mount" in text
                 or "volume" in text
+                or "task skills" in text
             )
         )
     ):
@@ -1565,6 +1566,9 @@ def skillsbench_runner_error_attribution(error_text: str) -> tuple[str, str, lis
             "skillsbench_docker_compose_unclassified_setup_failure",
             "skillsbench_environment_setup_error",
         ]
+    if "codex_exec_task_output_quiet_timeout" in text:
+        label = "skillsbench_host_local_acp_task_output_quiet_timeout"
+        return label, label, [label, "skillsbench_host_local_acp_recoverable_timeout"]
     label = "skillsbench_runner_error"
     return label, label, [label]
 
@@ -1602,6 +1606,7 @@ def skillsbench_runner_error_fingerprint(error_text: str) -> dict[str, Any]:
         "volume_mount_failure": r"mount|volume|bind source path",
         "permission_denied": r"permission denied|operation not permitted",
         "missing_file": r"no such file|not found|does not exist",
+        "task_output_quiet_timeout": r"codex_exec_task_output_quiet_timeout",
         "image_build": r"failed to solve|failed to build|dockerfile|pull access denied|manifest unknown",
         "port_conflict": r"port is already allocated|address already in use|ports are not available|bind for",
         "apt_failure": r"apt-get|apt update|apt |gpg error|hash sum mismatch|failed to fetch",

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -243,6 +243,34 @@ def _bridge_summary_has_meaningful_agent_progress(
     return False
 
 
+def _bridge_summary_has_successful_task_file_write(path: Path | None) -> bool:
+    """Return true after the worker successfully writes task-facing files."""
+
+    if path is None or not path.exists():
+        return False
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return False
+    for line in lines:
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(record, dict):
+            continue
+        phase = str(record.get("record_phase") or "").strip().lower()
+        if phase != "complete" or _bridge_operation_record_interrupted(record):
+            continue
+        if record.get("operation") != "write_file":
+            continue
+        if record.get("task_facing_operation") is not True:
+            continue
+        if record.get("success") is True or record.get("returncode") == 0:
+            return True
+    return False
+
+
 def _bridge_operation_record_interrupted(record: dict[str, Any]) -> bool:
     rc = record.get("returncode")
     if isinstance(rc, int) and not isinstance(rc, bool) and rc < 0:
@@ -346,6 +374,8 @@ def _codex_exec_failure_category(
         return "codex_usage_limit"
     if "codex_exec_first_action_timeout" in text:
         return "codex_exec_first_action_timeout"
+    if "codex_exec_task_output_quiet_timeout" in text:
+        return "codex_exec_task_output_quiet_timeout"
     if "codex_exec_bridge_idle_timeout" in text:
         return "codex_exec_bridge_idle_timeout"
     if "unexpected argument" in text or "unrecognized option" in text:
@@ -375,6 +405,7 @@ def _codex_exec_failure_category(
 
 RECOVERABLE_CODEX_TURN_FAILURE_CATEGORIES = {
     "codex_exec_first_action_timeout",
+    "codex_exec_task_output_quiet_timeout",
     "codex_exec_bridge_idle_timeout",
 }
 
@@ -445,6 +476,7 @@ class CodexExecConfig:
     stream_heartbeat_interval_sec: float = 120.0
     first_action_timeout_sec: float = 0.0
     bridge_idle_timeout_sec: float = 0.0
+    task_output_quiet_timeout_sec: float = 0.0
     reasoning_effort: str | None = "high"
     worker_public_trace_dir: str | None = None
     remote_command_file_bridge_command: str | None = None
@@ -2027,6 +2059,10 @@ raise SystemExit(proc.returncode)
                     0.0,
                     float(self._config.bridge_idle_timeout_sec or 0.0),
                 )
+                task_output_quiet_timeout_sec = max(
+                    0.0,
+                    float(self._config.task_output_quiet_timeout_sec or 0.0),
+                )
                 bridge_first_action_deadline = 0.0
                 if (
                     bridge_summary_path is not None
@@ -2055,6 +2091,7 @@ raise SystemExit(proc.returncode)
                         time.monotonic()
                         + max(1.0, self._config.first_action_timeout_sec)
                     )
+                task_output_write_seen = False
                 while proc.poll() is None:
                     now = time.monotonic()
                     if bridge_summary_path is not None:
@@ -2073,6 +2110,15 @@ raise SystemExit(proc.returncode)
                                 _bridge_summary_has_meaningful_agent_progress(
                                     bridge_summary_path,
                                     allow_loopx_closeout=allow_loopx_closeout_progress,
+                                )
+                            )
+                        if (
+                            not task_output_write_seen
+                            and task_output_quiet_timeout_sec > 0
+                        ):
+                            task_output_write_seen = (
+                                _bridge_summary_has_successful_task_file_write(
+                                    bridge_summary_path
                                 )
                             )
                     if (
@@ -2119,6 +2165,34 @@ raise SystemExit(proc.returncode)
                         self._terminate_bridge_server_process(bridge_server_proc)
                         return _recoverable_codex_turn_failure_message(
                             "codex_exec_first_action_timeout"
+                        )
+                    if (
+                        task_output_write_seen
+                        and bridge_summary_path is not None
+                        and task_output_quiet_timeout_sec > 0
+                        and not _bridge_summary_has_inflight_operation(
+                            bridge_summary_path
+                        )
+                        and now - last_bridge_activity_at
+                        >= task_output_quiet_timeout_sec
+                    ):
+                        proc.terminate()
+                        stdout_text, stderr_text = proc.communicate(timeout=2)
+                        self._publish_remote_bridge_agent_operations_trace(
+                            bridge_summary_path=bridge_summary_path,
+                        )
+                        if not self._publish_worker_trace(output_json):
+                            self._publish_worker_failure_trace(
+                                stage="task_output_quiet_timeout",
+                                returncode=proc.returncode,
+                                stdout_text=stdout_text,
+                                stderr_text=(
+                                    "codex_exec_task_output_quiet_timeout\n"
+                                ),
+                            )
+                        self._terminate_bridge_server_process(bridge_server_proc)
+                        return _recoverable_codex_turn_failure_message(
+                            "codex_exec_task_output_quiet_timeout"
                         )
                     if (
                         bridge_activity_seen
@@ -2341,6 +2415,10 @@ raise SystemExit(proc.returncode)
         )
         if not safe_stage:
             safe_stage = "worker_failed_before_public_trace"
+        failure_category = _codex_exec_failure_category(
+            returncode=returncode,
+            stderr_text=stderr_text,
+        )
         trace = {
             "schema_version": "skillsbench_host_codex_goal_worker_public_trace_v0",
             "ok": False,
@@ -2351,6 +2429,7 @@ raise SystemExit(proc.returncode)
             "worker_process": {
                 "schema_version": "skillsbench_host_worker_process_failure_v0",
                 "stage": safe_stage,
+                "failure_category": failure_category,
                 "returncode": returncode
                 if isinstance(returncode, int) and not isinstance(returncode, bool)
                 else None,

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -1590,6 +1590,8 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "remote_command_file_bridge_agent_refresh_state_count",
         "remote_command_file_bridge_agent_quota_spend_slot_count",
         "remote_command_file_bridge_agent_task_facing_operation_count",
+        "remote_command_file_bridge_agent_task_facing_success_count",
+        "remote_command_file_bridge_agent_task_facing_failure_count",
         "remote_command_file_bridge_driver_lifecycle_trace_count",
         "remote_command_file_bridge_driver_lifecycle_checkpoint_count",
         "remote_command_file_bridge_driver_lifecycle_request_count",

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -160,6 +160,7 @@ DEFAULT_GOAL_ID = "loopx-meta"
 DEFAULT_MODEL = "gpt-5.5"
 DEFAULT_TIMEOUT_SEC = 7200
 DEFAULT_HOST_LOCAL_CODEX_BRIDGE_IDLE_TIMEOUT_SEC = 3600
+DEFAULT_HOST_LOCAL_CODEX_TASK_OUTPUT_QUIET_TIMEOUT_SEC = 600
 DEFAULT_VERIFIER_PREP_TIMEOUT_SEC = 120
 DEFAULT_SOFT_VERIFIER_TIMEOUT_SEC = 600
 DEFAULT_PRODUCT_MODE_SOFT_VERIFY_POLICY = "every-round"
@@ -986,6 +987,8 @@ def _host_local_acp_launch_command(
             ),
             "--bridge-idle-timeout-sec",
             str(_effective_local_codex_bridge_idle_timeout_sec(args)),
+            "--task-output-quiet-timeout-sec",
+            str(_effective_local_codex_task_output_quiet_timeout_sec(args)),
         ]
     )
     if args.host_local_acp_launch and args.route != "codex-app-server-goal-baseline":
@@ -1140,6 +1143,27 @@ def _effective_local_codex_bridge_idle_timeout_sec(args: argparse.Namespace) -> 
     if requested <= 0:
         return DEFAULT_HOST_LOCAL_CODEX_BRIDGE_IDLE_TIMEOUT_SEC
     return min(requested, DEFAULT_HOST_LOCAL_CODEX_BRIDGE_IDLE_TIMEOUT_SEC)
+
+
+def _effective_local_codex_task_output_quiet_timeout_sec(
+    args: argparse.Namespace,
+) -> int:
+    configured = getattr(args, "local_codex_task_output_quiet_timeout_sec", None)
+    if configured is not None:
+        requested = max(0, int(configured or 0))
+        if requested <= 0:
+            return 0
+        bridge_idle_timeout = _effective_local_codex_bridge_idle_timeout_sec(args)
+        if bridge_idle_timeout <= 0:
+            return requested
+        return min(requested, bridge_idle_timeout)
+    bridge_idle_timeout = _effective_local_codex_bridge_idle_timeout_sec(args)
+    if bridge_idle_timeout <= 0:
+        return 0
+    return min(
+        DEFAULT_HOST_LOCAL_CODEX_TASK_OUTPUT_QUIET_TIMEOUT_SEC,
+        bridge_idle_timeout,
+    )
 
 
 def _host_local_acp_target_env(agent_env: object) -> dict[str, str]:
@@ -1953,6 +1977,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_agent_timeout_original_sec",
         "benchflow_agent_timeout_effective_sec",
         "benchflow_agent_timeout_host_local_acp_exec_timeout_sec",
+        "benchflow_agent_timeout_host_local_acp_task_output_quiet_timeout_sec",
         "benchflow_agent_timeout_host_local_acp_margin_sec",
         "host_local_acp_connect_return_arity",
         "benchflow_user_loop_recovery_round",
@@ -5941,6 +5966,9 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         "outer_timeout_sec": args.outer_timeout_sec,
         "sandbox_setup_timeout_sec": args.sandbox_setup_timeout,
         "agent_idle_timeout_sec": args.agent_idle_timeout,
+        "local_codex_task_output_quiet_timeout_sec": (
+            _effective_local_codex_task_output_quiet_timeout_sec(args)
+        ),
         "include_task_skills": bool(args.include_task_skills),
         "host_local_acp_launch": bool(args.host_local_acp_launch),
         "remote_command_file_bridge_ready": bool(
@@ -6310,6 +6338,7 @@ def _public_runner_config(plan: dict[str, Any]) -> dict[str, Any]:
         "sandbox_setup_timeout_sec",
         "agent_idle_timeout_sec",
         "build_stall_timeout_sec",
+        "local_codex_task_output_quiet_timeout_sec",
     )
     for field in int_fields:
         value = plan.get(field)
@@ -6334,6 +6363,10 @@ def _public_runner_config(plan: dict[str, Any]) -> dict[str, Any]:
             (
                 "benchflow_agent_timeout_host_local_acp_exec_timeout_sec",
                 "local_codex_exec_timeout_sec",
+            ),
+            (
+                "benchflow_agent_timeout_host_local_acp_task_output_quiet_timeout_sec",
+                "local_codex_task_output_quiet_timeout_sec",
             ),
         ):
             value = prerequisites.get(source)
@@ -10463,6 +10496,9 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
             prerequisites["benchflow_agent_timeout_host_local_acp_exec_timeout_sec"] = (
                 _effective_local_codex_exec_timeout_sec(args)
             )
+            prerequisites[
+                "benchflow_agent_timeout_host_local_acp_task_output_quiet_timeout_sec"
+            ] = _effective_local_codex_task_output_quiet_timeout_sec(args)
             prerequisites["benchflow_agent_timeout_host_local_acp_margin_sec"] = (
                 HOST_LOCAL_ACP_AGENT_TIMEOUT_MARGIN_SEC
             )
@@ -12148,6 +12184,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "from a host-local Codex turn. Omit to use the host-local default "
             f"({DEFAULT_HOST_LOCAL_CODEX_BRIDGE_IDLE_TIMEOUT_SEC}s); 0 disables "
             "the watchdog."
+        ),
+    )
+    parser.add_argument(
+        "--local-codex-task-output-quiet-timeout-sec",
+        type=int,
+        default=None,
+        help=(
+            "Optional watchdog after a successful task-facing file write and no "
+            "inflight bridge operation. Omit to use the host-local default "
+            f"({DEFAULT_HOST_LOCAL_CODEX_TASK_OUTPUT_QUIET_TIMEOUT_SEC}s); "
+            "0 disables the watchdog."
         ),
     )
     parser.add_argument(

--- a/scripts/skillsbench_local_acp_relay.py
+++ b/scripts/skillsbench_local_acp_relay.py
@@ -109,6 +109,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--task-output-quiet-timeout-sec",
+        type=float,
+        default=0.0,
+        help=(
+            "Optional timeout after a successful task-facing file write and no "
+            "inflight sandbox bridge operation. 0 disables the watchdog."
+        ),
+    )
+    parser.add_argument(
         "--worker-script",
         default=None,
         help="Optional path to skillsbench_host_codex_goal_worker.py.",
@@ -183,6 +192,7 @@ def main(argv: list[str] | None = None) -> int:
             stream_heartbeat_interval_sec=args.stream_heartbeat_interval_sec,
             first_action_timeout_sec=args.first_action_timeout_sec,
             bridge_idle_timeout_sec=args.bridge_idle_timeout_sec,
+            task_output_quiet_timeout_sec=args.task_output_quiet_timeout_sec,
             worker_public_trace_dir=args.worker_public_trace_dir,
             remote_command_file_bridge_command=(
                 args.remote_command_file_bridge_command


### PR DESCRIPTION
## Summary

- add a host-local ACP task-output quiet watchdog so a worker that already wrote a task-facing scored output yields back to the runner/verifier instead of consuming the full long bridge idle timeout
- surface the new recoverable timeout through failure attribution and compact interaction counters
- cover the behavior with focused app-server worker and benchmark-run smokes

## Root Cause

A SkillsBench app-server worker can successfully write the required task-facing output file but then fail to produce a natural closeout. With the 60-minute bridge idle timeout, the runner keeps waiting for the worker instead of handing control back to the verifier. That makes successful cases look stuck and delays or loses official result recovery.

The fix makes successful task-facing file writes a bounded recovery signal: after the write succeeds and there is no inflight bridge operation for the quiet window, the relay terminates the worker turn with a recoverable failure category. The runner can then continue into verifier/reducer recovery instead of waiting for the long idle timeout.

## Validation

- `python3 -m py_compile loopx/benchmark_adapters/skillsbench_acp_relay.py loopx/benchmark_adapters/skillsbench.py loopx/status.py scripts/skillsbench_local_acp_relay.py scripts/skillsbench_automation_loop.py examples/skillsbench-app-server-goal-worker-smoke.py examples/skillsbench-benchmark-run-smoke.py`
- `python3 examples/skillsbench-app-server-goal-worker-smoke.py`
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `git diff --check`
- scanned added diff for local paths, credentials, private logs, and raw verifier leakage
