### PR TITLE
Skip codex-exec preflight for SkillsBench app-server route

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -8533,6 +8533,36 @@ def test_goal_start_host_local_defers_codex_exec_preflight_until_bridge_command(
         )
 
 
+def test_app_server_goal_worker_skips_plain_codex_exec_preflight() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-app-server-preflight-") as tmp:
+        args = parse_args(
+            [
+                "--task-id",
+                "3d-scan-calc",
+                "--route",
+                "codex-app-server-goal-baseline",
+                "--host-local-acp-launch",
+                "--host-local-acp-codex-exec-preflight",
+                "--remote-command-file-bridge-ready",
+                "--jobs-dir",
+                str(Path(tmp) / "jobs"),
+                "--job-name",
+                "skillsbench-app-server-preflight-fixture",
+            ]
+        )
+        plan = build_plan(args)
+        prereqs = plan["runner_prerequisites"]
+        assert prereqs["host_local_acp_codex_exec_preflight_requested"] is False, (
+            prereqs
+        )
+        assert prereqs["host_local_acp_codex_exec_preflight_status"] == "not_requested", (
+            prereqs
+        )
+        assert prereqs["codex_acp_runtime_launch_preflight_stage"] == (
+            "not_applicable_app_server_goal_worker"
+        ), prereqs
+
+
 def test_goal_start_host_exec_failure_overrides_zero_score_recovery() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-goal-start-host-failure-") as tmp:
         args = parse_args(
@@ -12298,6 +12328,7 @@ if __name__ == "__main__":
     test_skillsbench_host_local_idle_no_output_progress_is_distinct()
     test_product_mode_host_local_idle_no_output_progress_requires_new_trace()
     test_goal_start_host_local_defers_codex_exec_preflight_until_bridge_command()
+    test_app_server_goal_worker_skips_plain_codex_exec_preflight()
     test_goal_start_host_exec_failure_overrides_zero_score_recovery()
     test_skillsbench_product_mode_declared_done_below_passing_reward_is_compacted()
     test_skillsbench_declared_done_missing_reward_status_is_compacted()

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -1306,6 +1306,12 @@ def _host_local_acp_codex_exec_preflight_should_run(
 ) -> bool:
     """Return whether the host-local Codex exec path must be probed first."""
 
+    if (
+        bool(getattr(args, "host_local_acp_launch", False))
+        and str(getattr(args, "route", "") or "")
+        == CODEX_APP_SERVER_GOAL_BASELINE_ROUTE
+    ):
+        return False
     if bool(getattr(args, "host_local_acp_codex_exec_preflight", False)):
         return True
     return bool(


### PR DESCRIPTION
## Summary

- skip the plain `codex exec` preflight for the native `codex-app-server-goal-baseline` route, even when the generic preflight flag is present
- add a regression smoke proving the app-server goal worker route stays on its own preflight/runtime surface

## Root Cause

The r11 30-case batch used the native app-server goal worker route, but the generic `--host-local-acp-codex-exec-preflight` flag still launched a plain `codex exec` ACP health prompt before each case. On the remote runner that plain exec path returned `codex_responses_stream_unavailable`, so all 30 cases were short-circuited before the app-server worker, reverse-channel bridge, verifier, or #914 task-output quiet recovery could run.

This preflight is a product-path mismatch: the native app-server goal worker does not execute through the plain codex-exec relay. The runner already records `codex_acp_runtime_launch_preflight_stage=not_applicable_app_server_goal_worker`; this change makes the host-local codex-exec preflight follow the same route boundary.

## Validation

- `python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py`
- targeted smokes: `test_goal_start_host_local_defers_codex_exec_preflight_until_bridge_command`, `test_app_server_goal_worker_skips_plain_codex_exec_preflight`
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `git diff --check`
- added-diff public/private boundary scan
