### PR TITLE
Repair SkillsBench r12 nested result ingest

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
@@ -62,15 +62,15 @@
     },
     "skillsbench@1.1": {
       "benchmark_id": "skillsbench@1.1",
-      "case_count": 23,
+      "case_count": 43,
       "cases": {
         "3d-scan-calc": {
           "case_id": "3d-scan-calc",
           "latest_decision": {
-            "baseline_failure_scope": "passed",
-            "baseline_run_id": "fac3a39fdd9a",
-            "decision": "paired_baseline_solved_treatment_preserved",
-            "official_score_delta": 0.0,
+            "baseline_failure_scope": "case_or_solution",
+            "baseline_run_id": "295919e0907d",
+            "decision": "paired_treatment_improved",
+            "official_score_delta": 1.0,
             "treatment_failure_scope": "passed",
             "treatment_run_id": "7ea835b649e7"
           },
@@ -957,16 +957,75 @@
                 "task_skills_removed": true
               },
               "verifier_attempt_countable": true
+            },
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-01-3d-scan-calc",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-01-3d-scan-calc/result.json"
+              },
+              "attempt_failure_class": "solver_failed",
+              "attempt_failure_label": "official_verifier_solution_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "3d-scan-calc",
+              "case_ids": [
+                "3d-scan-calc"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "job_name": "skillsbench_1_1_3d_scan_calc_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": true,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:03+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "295919e0907d",
+              "score_status": "failed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "verifier_attempt_countable": true
             }
           ]
         },
         "ada-bathroom-plan-repair": {
           "case_id": "ada-bathroom-plan-repair",
           "latest_decision": {
-            "baseline_failure_scope": "passed",
-            "baseline_run_id": "7d919631a765",
-            "decision": "paired_baseline_solved_treatment_preserved",
-            "official_score_delta": 0.0,
+            "baseline_failure_scope": "case_or_solution",
+            "baseline_run_id": "a054b365d9fc",
+            "decision": "paired_treatment_improved",
+            "official_score_delta": 1.0,
             "treatment_failure_scope": "passed",
             "treatment_run_id": "52a934d39c59"
           },
@@ -1154,16 +1213,74 @@
               "source_event_schema": "benchmark_run_v0",
               "status": "completed",
               "submit_eligible": false
+            },
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-02-ada-bathroom-plan-repair",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-02-ada-bathroom-plan-repair/result.json"
+              },
+              "attempt_failure_class": "solver_failed",
+              "attempt_failure_label": "official_verifier_solution_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "ada-bathroom-plan-repair",
+              "case_ids": [
+                "ada-bathroom-plan-repair"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "job_name": "skillsbench_1_1_ada_bathroom_plan_repair_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": true,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:04+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "a054b365d9fc",
+              "score_status": "failed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "verifier_attempt_countable": true
             }
           ]
         },
         "adaptive-cruise-control": {
           "case_id": "adaptive-cruise-control",
           "latest_decision": {
-            "baseline_run_id": "235f52dc6a5b",
-            "decision": "baseline_runner_or_setup_repair_required",
-            "failure_class": "skillsbench_docker_compose_apt_repository_failure",
-            "failure_scope": "score_missing"
+            "baseline_run_id": "f7cfe8be0f89",
+            "decision": "baseline_failed_treatment_candidate",
+            "failure_scope": "case_or_solution"
           },
           "runs": [
             {
@@ -1217,19 +1334,78 @@
                 "staged": true,
                 "task_skills_removed": true
               }
+            },
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-03-adaptive-cruise-control",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-03-adaptive-cruise-control/result.json"
+              },
+              "attempt_failure_class": "solver_failed",
+              "attempt_failure_label": "official_verifier_solution_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "adaptive-cruise-control",
+              "case_ids": [
+                "adaptive-cruise-control"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "job_name": "skillsbench_1_1_adaptive_cruise_control_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": true,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:04+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "f7cfe8be0f89",
+              "score_status": "failed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "verifier_attempt_countable": true
             }
           ]
         },
         "azure-bgp-oscillation-route-leak": {
           "case_id": "azure-bgp-oscillation-route-leak",
           "latest_decision": {
-            "baseline_run_id": "788c64ee1ddd",
+            "baseline_run_id": "c1555cacf1d1",
             "decision": "product_mode_pair_incomplete",
             "product_mode_main_table_pair": {
-              "baseline_route_valid": true,
+              "baseline_route_valid": false,
               "benchmark_id": "skillsbench@1.1",
               "case_id": "azure-bgp-oscillation-route-leak",
-              "claim_blocker": "treatment_loopx_lifecycle_not_observed",
+              "claim_blocker": "baseline_not_raw_codex_autonomous_max5,baseline_official_feedback_not_blinded,baseline_reward_feedback_forwarding_not_disabled,baseline_compact_metrics_missing,treatment_loopx_lifecycle_not_observed",
               "comparison_id": "skillsbench_product_mode_main_table_v0",
               "headline_metrics": [
                 "best_score",
@@ -1239,7 +1415,7 @@
               ],
               "main_table_claim_allowed": false,
               "max_rounds_budget": 5,
-              "official_feedback_blinded": true,
+              "official_feedback_blinded": false,
               "product_mode_pair_complete": false,
               "schema_version": "benchmark_product_mode_comparison_v0",
               "treatment_loopx_lifecycle_observed": false,
@@ -1967,16 +2143,75 @@
                 "staged": true,
                 "task_skills_removed": true
               }
+            },
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-04-azure-bgp-oscillation-route-leak",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-04-azure-bgp-oscillation-route-leak/result.json"
+              },
+              "attempt_failure_class": "solver_failed",
+              "attempt_failure_label": "official_verifier_solution_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "azure-bgp-oscillation-route-leak",
+              "case_ids": [
+                "azure-bgp-oscillation-route-leak"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "job_name": "skillsbench_1_1_azure_bgp_oscillation_route_leak_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": true,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:05+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "c1555cacf1d1",
+              "score_status": "failed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "verifier_attempt_countable": true
             }
           ]
         },
         "bike-rebalance": {
           "case_id": "bike-rebalance",
           "latest_decision": {
-            "baseline_failure_scope": "passed",
-            "baseline_run_id": "7ab4d4e3f194",
-            "decision": "paired_baseline_solved_treatment_preserved",
-            "official_score_delta": 0.0,
+            "baseline_failure_scope": "case_or_solution",
+            "baseline_run_id": "be336852b280",
+            "decision": "paired_treatment_improved",
+            "official_score_delta": 1.0,
             "treatment_failure_scope": "passed",
             "treatment_run_id": "239aecc4f3a3"
           },
@@ -2106,16 +2341,75 @@
               "source_event_schema": "benchmark_run_v0",
               "status": "completed",
               "submit_eligible": false
+            },
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-05-bike-rebalance",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-05-bike-rebalance/result.json"
+              },
+              "attempt_failure_class": "solver_failed",
+              "attempt_failure_label": "official_verifier_solution_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "bike-rebalance",
+              "case_ids": [
+                "bike-rebalance"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "job_name": "skillsbench_1_1_bike_rebalance_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": true,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:05+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "be336852b280",
+              "score_status": "failed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "verifier_attempt_countable": true
             }
           ]
         },
         "citation-check": {
           "case_id": "citation-check",
           "latest_decision": {
-            "baseline_failure_scope": "passed",
-            "baseline_run_id": "2297b9236dc2",
-            "decision": "paired_baseline_solved_treatment_preserved",
-            "official_score_delta": 0.0,
+            "baseline_failure_scope": "case_or_solution",
+            "baseline_run_id": "1fac74f1baa0",
+            "decision": "paired_treatment_improved",
+            "official_score_delta": 1.0,
             "treatment_failure_scope": "passed",
             "treatment_run_id": "15ba747b3be5"
           },
@@ -3394,6 +3688,65 @@
                 "verifier_uv_bootstrap_version": "0.9.7"
               },
               "verifier_attempt_countable": true
+            },
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-06-citation-check",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-06-citation-check/result.json"
+              },
+              "attempt_failure_class": "solver_failed",
+              "attempt_failure_label": "official_verifier_solution_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "citation-check",
+              "case_ids": [
+                "citation-check"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "job_name": "skillsbench_1_1_citation_check_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": true,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:06+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "1fac74f1baa0",
+              "score_status": "failed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "verifier_attempt_countable": true
             }
           ]
         },
@@ -3401,7 +3754,7 @@
           "case_id": "civ6-adjacency-optimizer",
           "latest_decision": {
             "baseline_failure_scope": "case_or_solution",
-            "baseline_run_id": "973d9618d7f6",
+            "baseline_run_id": "c2fdec5fa337",
             "decision": "paired_no_score_uplift",
             "official_score_delta": 0.0,
             "treatment_failure_scope": "case_or_solution",
@@ -3573,20 +3926,213 @@
               "source_event_schema": "benchmark_run_v0",
               "status": "completed",
               "submit_eligible": false
+            },
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-07-civ6-adjacency-optimizer",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-07-civ6-adjacency-optimizer/result.json"
+              },
+              "attempt_failure_class": "solver_failed",
+              "attempt_failure_label": "official_verifier_solution_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "civ6-adjacency-optimizer",
+              "case_ids": [
+                "civ6-adjacency-optimizer"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "job_name": "skillsbench_1_1_civ6_adjacency_optimizer_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": true,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:07+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "c2fdec5fa337",
+              "score_status": "failed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "verifier_attempt_countable": true
+            }
+          ]
+        },
+        "court-form-filling": {
+          "case_id": "court-form-filling",
+          "latest_decision": {
+            "baseline_run_id": "0da6cc981a51",
+            "decision": "baseline_failed_treatment_candidate",
+            "failure_scope": "case_or_solution"
+          },
+          "runs": [
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-08-court-form-filling",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-08-court-form-filling/result.json"
+              },
+              "attempt_failure_class": "solver_failed",
+              "attempt_failure_label": "official_verifier_solution_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "court-form-filling",
+              "case_ids": [
+                "court-form-filling"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "job_name": "skillsbench_1_1_court_form_filling_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": true,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:08+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "0da6cc981a51",
+              "score_status": "failed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "verifier_attempt_countable": true
+            }
+          ]
+        },
+        "crystallographic-wyckoff-position-analysis": {
+          "case_id": "crystallographic-wyckoff-position-analysis",
+          "latest_decision": {
+            "baseline_run_id": "59a046e9b96c",
+            "decision": "baseline_failed_treatment_candidate",
+            "failure_scope": "case_or_solution"
+          },
+          "runs": [
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-09-crystallographic-wyckoff-position-analysis",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-09-crystallographic-wyckoff-position-analysis/result.json"
+              },
+              "attempt_failure_class": "solver_failed",
+              "attempt_failure_label": "official_verifier_solution_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "crystallographic-wyckoff-position-analysis",
+              "case_ids": [
+                "crystallographic-wyckoff-position-analysis"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "job_name": "skillsbench_1_1_crystallographic_wyckoff_position_analysis_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": true,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:09+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "59a046e9b96c",
+              "score_status": "failed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "verifier_attempt_countable": true
             }
           ]
         },
         "dapt-intrusion-detection": {
           "case_id": "dapt-intrusion-detection",
           "latest_decision": {
-            "baseline_failure_scope": "score_missing",
-            "baseline_run_id": "d1aee11b0f7a",
-            "decision": "paired_baseline_setup_preflight_selection_required",
-            "failure_class": "skillsbench_docker_apt_setup_risk_preflight_blocked",
-            "next_action": "select a non-apt-risk SkillsBench task for the next full baseline/treatment pair or repair the Docker apt setup route before rerunning this task",
-            "official_score_delta": null,
-            "repair_class": "skillsbench_setup_preflight_selection",
-            "repair_priority": "P1",
+            "baseline_failure_scope": "case_or_solution",
+            "baseline_run_id": "a7ebcaf53915",
+            "decision": "paired_no_score_uplift",
+            "official_score_delta": 0.0,
             "treatment_failure_scope": "case_or_solution",
             "treatment_run_id": "0f8854fed0c1"
           },
@@ -3842,6 +4388,134 @@
               "source_event_schema": "benchmark_run_v0",
               "status": "completed",
               "submit_eligible": false
+            },
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-10-dapt-intrusion-detection",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-10-dapt-intrusion-detection/result.json"
+              },
+              "attempt_failure_class": "solver_failed",
+              "attempt_failure_label": "official_verifier_solution_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "dapt-intrusion-detection",
+              "case_ids": [
+                "dapt-intrusion-detection"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "job_name": "skillsbench_1_1_dapt_intrusion_detection_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": true,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:10+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "a7ebcaf53915",
+              "score_status": "failed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "verifier_attempt_countable": true
+            }
+          ]
+        },
+        "data-to-d3": {
+          "case_id": "data-to-d3",
+          "latest_decision": {
+            "baseline_run_id": "0329fd23dbdd",
+            "decision": "baseline_failed_treatment_candidate",
+            "failure_scope": "case_or_solution"
+          },
+          "runs": [
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-11-data-to-d3",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-11-data-to-d3/result.json"
+              },
+              "attempt_failure_class": "solver_failed",
+              "attempt_failure_label": "official_verifier_solution_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "data-to-d3",
+              "case_ids": [
+                "data-to-d3"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "job_name": "skillsbench_1_1_data_to_d3_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": true,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:10+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "0329fd23dbdd",
+              "score_status": "failed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "verifier_attempt_countable": true
             }
           ]
         },
@@ -3849,9 +4523,9 @@
           "case_id": "debug-trl-grpo",
           "latest_decision": {
             "baseline_failure_scope": "score_missing",
-            "baseline_run_id": "a684e81ddb98",
+            "baseline_run_id": "4c5f1d946f2f",
             "decision": "paired_baseline_runner_or_setup_repair_required",
-            "failure_class": "skillsbench_docker_compose_apt_repository_failure",
+            "failure_class": "skillsbench_docker_compose_pip_bootstrap_failure",
             "official_score_delta": null,
             "treatment_failure_scope": "case_or_solution",
             "treatment_run_id": "eeabc7f865a1"
@@ -4359,15 +5033,1110 @@
                 "staged": true,
                 "task_skills_removed": true
               }
+            },
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-12-debug-trl-grpo",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-12-debug-trl-grpo/result.json"
+              },
+              "attempt_failure_class": "job_materialization_failed",
+              "attempt_failure_label": "skillsbench_docker_compose_pip_bootstrap_failure",
+              "attempt_lifecycle_phase": "runner_accepted_args",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": false,
+              "case_id": "debug-trl-grpo",
+              "case_ids": [
+                "debug-trl-grpo"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "skillsbench_docker_compose_pip_bootstrap_failure",
+              "failure_labels": [
+                "skillsbench_docker_compose_pip_bootstrap_failure",
+                "skillsbench_docker_compose_setup_failure",
+                "skillsbench_python_package_bootstrap_failure",
+                "skillsbench_environment_setup_error"
+              ],
+              "failure_scope": "score_missing",
+              "job_name": "skillsbench_1_1_debug_trl_grpo_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_score_attempt_countable": false,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:11+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "4c5f1d946f2f",
+              "score_status": "missing",
+              "solver_attempt_countable": false,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "recorded",
+              "submit_eligible": false,
+              "verifier_attempt_countable": false
+            }
+          ]
+        },
+        "dialogue-parser": {
+          "case_id": "dialogue-parser",
+          "latest_decision": {
+            "baseline_run_id": "5643fe357128",
+            "decision": "baseline_failed_treatment_candidate",
+            "failure_scope": "case_or_solution"
+          },
+          "runs": [
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-13-dialogue-parser",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-13-dialogue-parser/result.json"
+              },
+              "attempt_failure_class": "solver_failed",
+              "attempt_failure_label": "official_verifier_solution_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "dialogue-parser",
+              "case_ids": [
+                "dialogue-parser"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "job_name": "skillsbench_1_1_dialogue_parser_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": true,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:11+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "5643fe357128",
+              "score_status": "failed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "verifier_attempt_countable": true
+            }
+          ]
+        },
+        "drone-planning-control": {
+          "case_id": "drone-planning-control",
+          "latest_decision": {
+            "baseline_run_id": "7f318e363c23",
+            "decision": "baseline_failed_treatment_candidate",
+            "failure_scope": "case_or_solution"
+          },
+          "runs": [
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-14-drone-planning-control",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-14-drone-planning-control/result.json"
+              },
+              "attempt_failure_class": "solver_failed",
+              "attempt_failure_label": "official_verifier_solution_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "drone-planning-control",
+              "case_ids": [
+                "drone-planning-control"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "job_name": "skillsbench_1_1_drone_planning_control_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": true,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:12+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "7f318e363c23",
+              "score_status": "failed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "verifier_attempt_countable": true
+            }
+          ]
+        },
+        "dynamic-object-aware-egomotion": {
+          "case_id": "dynamic-object-aware-egomotion",
+          "latest_decision": {
+            "baseline_run_id": "0de991278094",
+            "decision": "baseline_failed_treatment_candidate",
+            "failure_scope": "case_or_solution"
+          },
+          "runs": [
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-15-dynamic-object-aware-egomotion",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-15-dynamic-object-aware-egomotion/result.json"
+              },
+              "attempt_failure_class": "solver_failed",
+              "attempt_failure_label": "official_verifier_solution_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "dynamic-object-aware-egomotion",
+              "case_ids": [
+                "dynamic-object-aware-egomotion"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "job_name": "skillsbench_1_1_dynamic_object_aware_egomotion_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": true,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:12+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "0de991278094",
+              "score_status": "failed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "verifier_attempt_countable": true
+            }
+          ]
+        },
+        "earthquake-phase-association": {
+          "case_id": "earthquake-phase-association",
+          "latest_decision": {
+            "baseline_run_id": "53d45697e575",
+            "decision": "baseline_failed_treatment_candidate",
+            "failure_scope": "case_or_solution"
+          },
+          "runs": [
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-16-earthquake-phase-association",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-16-earthquake-phase-association/result.json"
+              },
+              "attempt_failure_class": "solver_failed",
+              "attempt_failure_label": "official_verifier_solution_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "earthquake-phase-association",
+              "case_ids": [
+                "earthquake-phase-association"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "job_name": "skillsbench_1_1_earthquake_phase_association_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": true,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:13+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "53d45697e575",
+              "score_status": "failed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "verifier_attempt_countable": true
+            }
+          ]
+        },
+        "earthquake-plate-calculation": {
+          "case_id": "earthquake-plate-calculation",
+          "latest_decision": {
+            "baseline_run_id": "f1205441799b",
+            "decision": "baseline_failed_treatment_candidate",
+            "failure_scope": "case_or_solution"
+          },
+          "runs": [
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-17-earthquake-plate-calculation",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-17-earthquake-plate-calculation/result.json"
+              },
+              "attempt_failure_class": "solver_failed",
+              "attempt_failure_label": "official_verifier_solution_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "earthquake-plate-calculation",
+              "case_ids": [
+                "earthquake-plate-calculation"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "job_name": "skillsbench_1_1_earthquake_plate_calculation_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": true,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:13+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "f1205441799b",
+              "score_status": "failed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "verifier_attempt_countable": true
+            }
+          ]
+        },
+        "econ-detrending-correlation": {
+          "case_id": "econ-detrending-correlation",
+          "latest_decision": {
+            "baseline_run_id": "e0c3c78a0b1d",
+            "decision": "baseline_failed_treatment_candidate",
+            "failure_scope": "case_or_solution"
+          },
+          "runs": [
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-18-econ-detrending-correlation",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-18-econ-detrending-correlation/result.json"
+              },
+              "attempt_failure_class": "solver_failed",
+              "attempt_failure_label": "official_verifier_solution_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "econ-detrending-correlation",
+              "case_ids": [
+                "econ-detrending-correlation"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "job_name": "skillsbench_1_1_econ_detrending_correlation_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": true,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:14+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "e0c3c78a0b1d",
+              "score_status": "failed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "verifier_attempt_countable": true
+            }
+          ]
+        },
+        "edit-pdf": {
+          "case_id": "edit-pdf",
+          "latest_decision": {
+            "baseline_run_id": "6a2963456c70",
+            "decision": "baseline_failed_treatment_candidate",
+            "failure_scope": "case_or_solution"
+          },
+          "runs": [
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-19-edit-pdf",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-19-edit-pdf/result.json"
+              },
+              "attempt_failure_class": "solver_failed",
+              "attempt_failure_label": "official_verifier_solution_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "edit-pdf",
+              "case_ids": [
+                "edit-pdf"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "job_name": "skillsbench_1_1_edit_pdf_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": true,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:15+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "6a2963456c70",
+              "score_status": "failed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "verifier_attempt_countable": true
+            }
+          ]
+        },
+        "energy-ac-optimal-power-flow": {
+          "case_id": "energy-ac-optimal-power-flow",
+          "latest_decision": {
+            "baseline_run_id": "c3b36b96183b",
+            "decision": "baseline_failed_treatment_candidate",
+            "failure_scope": "case_or_solution"
+          },
+          "runs": [
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-20-energy-ac-optimal-power-flow",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-20-energy-ac-optimal-power-flow/result.json"
+              },
+              "attempt_failure_class": "solver_failed",
+              "attempt_failure_label": "official_verifier_solution_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "energy-ac-optimal-power-flow",
+              "case_ids": [
+                "energy-ac-optimal-power-flow"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "job_name": "skillsbench_1_1_energy_ac_optimal_power_flow_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": true,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:15+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "c3b36b96183b",
+              "score_status": "failed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "verifier_attempt_countable": true
+            }
+          ]
+        },
+        "energy-market-pricing": {
+          "case_id": "energy-market-pricing",
+          "latest_decision": {
+            "baseline_run_id": "5cf3c3bd1902",
+            "decision": "baseline_failed_treatment_candidate",
+            "failure_scope": "case_or_solution"
+          },
+          "runs": [
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-21-energy-market-pricing",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-21-energy-market-pricing/result.json"
+              },
+              "attempt_failure_class": "solver_failed",
+              "attempt_failure_label": "official_verifier_solution_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "energy-market-pricing",
+              "case_ids": [
+                "energy-market-pricing"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "job_name": "skillsbench_1_1_energy_market_pricing_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": true,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:16+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "5cf3c3bd1902",
+              "score_status": "failed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "verifier_attempt_countable": true
+            }
+          ]
+        },
+        "energy-unit-commitment": {
+          "case_id": "energy-unit-commitment",
+          "latest_decision": {
+            "baseline_run_id": "f77d67af1286",
+            "decision": "baseline_failed_treatment_candidate",
+            "failure_scope": "case_or_solution"
+          },
+          "runs": [
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-22-energy-unit-commitment",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-22-energy-unit-commitment/result.json"
+              },
+              "attempt_failure_class": "solver_failed",
+              "attempt_failure_label": "official_verifier_solution_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "energy-unit-commitment",
+              "case_ids": [
+                "energy-unit-commitment"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "job_name": "skillsbench_1_1_energy_unit_commitment_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": true,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:17+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "f77d67af1286",
+              "score_status": "failed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "verifier_attempt_countable": true
+            }
+          ]
+        },
+        "enterprise-information-search": {
+          "case_id": "enterprise-information-search",
+          "latest_decision": {
+            "baseline_run_id": "b06fec85e54b",
+            "decision": "baseline_failed_treatment_candidate",
+            "failure_scope": "case_or_solution"
+          },
+          "runs": [
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-23-enterprise-information-search",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-23-enterprise-information-search/result.json"
+              },
+              "attempt_failure_class": "solver_failed",
+              "attempt_failure_label": "official_verifier_solution_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "enterprise-information-search",
+              "case_ids": [
+                "enterprise-information-search"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "job_name": "skillsbench_1_1_enterprise_information_search_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": true,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:17+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "b06fec85e54b",
+              "score_status": "failed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "verifier_attempt_countable": true
+            }
+          ]
+        },
+        "exam-block-sequencing": {
+          "case_id": "exam-block-sequencing",
+          "latest_decision": {
+            "baseline_run_id": "1a453af65859",
+            "decision": "baseline_failed_treatment_candidate",
+            "failure_scope": "case_or_solution"
+          },
+          "runs": [
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-24-exam-block-sequencing",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-24-exam-block-sequencing/result.json"
+              },
+              "attempt_failure_class": "solver_failed",
+              "attempt_failure_label": "official_verifier_solution_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "exam-block-sequencing",
+              "case_ids": [
+                "exam-block-sequencing"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "job_name": "skillsbench_1_1_exam_block_sequencing_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": true,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:18+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "1a453af65859",
+              "score_status": "failed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "verifier_attempt_countable": true
+            }
+          ]
+        },
+        "exceltable-in-ppt": {
+          "case_id": "exceltable-in-ppt",
+          "latest_decision": {
+            "baseline_run_id": "c1b1022377d5",
+            "decision": "baseline_failed_treatment_candidate",
+            "failure_scope": "case_or_solution"
+          },
+          "runs": [
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-25-exceltable-in-ppt",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-25-exceltable-in-ppt/result.json"
+              },
+              "attempt_failure_class": "solver_failed",
+              "attempt_failure_label": "official_verifier_solution_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "exceltable-in-ppt",
+              "case_ids": [
+                "exceltable-in-ppt"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "job_name": "skillsbench_1_1_exceltable_in_ppt_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": true,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:18+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "c1b1022377d5",
+              "score_status": "failed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "verifier_attempt_countable": true
+            }
+          ]
+        },
+        "exoplanet-detection-period": {
+          "case_id": "exoplanet-detection-period",
+          "latest_decision": {
+            "baseline_run_id": "bc1ab5e36ad8",
+            "decision": "baseline_failed_treatment_candidate",
+            "failure_scope": "case_or_solution"
+          },
+          "runs": [
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-26-exoplanet-detection-period",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-26-exoplanet-detection-period/result.json"
+              },
+              "attempt_failure_class": "solver_failed",
+              "attempt_failure_label": "official_verifier_solution_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "exoplanet-detection-period",
+              "case_ids": [
+                "exoplanet-detection-period"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "job_name": "skillsbench_1_1_exoplanet_detection_period_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": true,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:19+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "bc1ab5e36ad8",
+              "score_status": "failed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "verifier_attempt_countable": true
+            }
+          ]
+        },
+        "financial-modeling-qa": {
+          "case_id": "financial-modeling-qa",
+          "latest_decision": {
+            "baseline_run_id": "d0eec78e5720",
+            "decision": "baseline_failed_treatment_candidate",
+            "failure_scope": "case_or_solution"
+          },
+          "runs": [
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-27-financial-modeling-qa",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-27-financial-modeling-qa/result.json"
+              },
+              "attempt_failure_class": "solver_failed",
+              "attempt_failure_label": "official_verifier_solution_failure",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "financial-modeling-qa",
+              "case_ids": [
+                "financial-modeling-qa"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "official_verifier_solution_failure",
+              "failure_labels": [
+                "official_verifier_solution_failure"
+              ],
+              "failure_scope": "case_or_solution",
+              "job_name": "skillsbench_1_1_financial_modeling_qa_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_passed": false,
+              "official_score": 0.0,
+              "official_score_attempt_countable": true,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:20+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "d0eec78e5720",
+              "score_status": "failed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "verifier_attempt_countable": true
             }
           ]
         },
         "fix-build-agentops": {
           "case_id": "fix-build-agentops",
           "latest_decision": {
-            "baseline_run_id": "09caa24411c3",
+            "baseline_run_id": "dad69fa8c811",
             "decision": "baseline_runner_or_setup_repair_required",
-            "failure_class": "skillsbench_docker_compose_apt_repository_failure",
+            "failure_class": "skillsbench_environment_app_mount_missing",
             "failure_scope": "score_missing"
           },
           "runs": [
@@ -4526,6 +6295,204 @@
                 "staged": true,
                 "task_skills_removed": true
               }
+            },
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-28-fix-build-agentops",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-28-fix-build-agentops/result.json"
+              },
+              "attempt_failure_class": "job_materialization_failed",
+              "attempt_failure_label": "skillsbench_environment_app_mount_missing",
+              "attempt_lifecycle_phase": "runner_accepted_args",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": false,
+              "case_id": "fix-build-agentops",
+              "case_ids": [
+                "fix-build-agentops"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "skillsbench_environment_app_mount_missing",
+              "failure_labels": [
+                "skillsbench_environment_app_mount_missing",
+                "skillsbench_environment_setup_error"
+              ],
+              "failure_scope": "score_missing",
+              "job_name": "skillsbench_1_1_fix_build_agentops_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_score_attempt_countable": false,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:20+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "dad69fa8c811",
+              "score_status": "missing",
+              "solver_attempt_countable": false,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "recorded",
+              "submit_eligible": false,
+              "verifier_attempt_countable": false
+            }
+          ]
+        },
+        "fix-build-google-auto": {
+          "case_id": "fix-build-google-auto",
+          "latest_decision": {
+            "baseline_run_id": "4f179ead5235",
+            "decision": "baseline_runner_or_setup_repair_required",
+            "failure_class": "skillsbench_docker_compose_apt_repository_failure",
+            "failure_scope": "score_missing"
+          },
+          "runs": [
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-29-fix-build-google-auto",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-29-fix-build-google-auto/result.json"
+              },
+              "attempt_failure_class": "job_materialization_failed",
+              "attempt_failure_label": "skillsbench_docker_compose_apt_repository_failure",
+              "attempt_lifecycle_phase": "runner_accepted_args",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": false,
+              "case_id": "fix-build-google-auto",
+              "case_ids": [
+                "fix-build-google-auto"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "skillsbench_docker_compose_apt_repository_failure",
+              "failure_labels": [
+                "skillsbench_docker_compose_apt_repository_failure",
+                "skillsbench_docker_compose_setup_failure",
+                "skillsbench_environment_setup_error"
+              ],
+              "failure_scope": "score_missing",
+              "job_name": "skillsbench_1_1_fix_build_google_auto_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_score_attempt_countable": false,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:21+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "4f179ead5235",
+              "score_status": "missing",
+              "solver_attempt_countable": false,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "recorded",
+              "submit_eligible": false,
+              "verifier_attempt_countable": false
+            }
+          ]
+        },
+        "fix-druid-loophole-cve": {
+          "case_id": "fix-druid-loophole-cve",
+          "latest_decision": {
+            "baseline_run_id": "f2bb5c9e3888",
+            "decision": "baseline_runner_or_setup_repair_required",
+            "failure_class": "skillsbench_docker_compose_apt_repository_failure",
+            "failure_scope": "score_missing"
+          },
+          "runs": [
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex_app_server_goal_baseline",
+              "artifact_refs": {
+                "artifact_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-30-fix-druid-loophole-cve",
+                "result_ref": "skillsbench-goal-baseline-30case-20260629T1921Z-r12-30-fix-druid-loophole-cve/result.json"
+              },
+              "attempt_failure_class": "job_materialization_failed",
+              "attempt_failure_label": "skillsbench_docker_compose_apt_repository_failure",
+              "attempt_lifecycle_phase": "runner_accepted_args",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": false,
+              "case_id": "fix-druid-loophole-cve",
+              "case_ids": [
+                "fix-druid-loophole-cve"
+              ],
+              "codex_acp_runtime_preflight_passed": false,
+              "failure_class": "skillsbench_docker_compose_apt_repository_failure",
+              "failure_labels": [
+                "skillsbench_docker_compose_apt_repository_failure",
+                "skillsbench_docker_compose_setup_failure",
+                "skillsbench_environment_setup_error"
+              ],
+              "failure_scope": "score_missing",
+              "job_name": "skillsbench_1_1_fix_druid_loophole_cve_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "r12 nested case-local official result ingested via result-root discovery",
+              "official_score_attempt_countable": false,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T06:18:22+08:00",
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-goal-baseline-30case-20260629T1921Z-r12",
+              "run_id": "f2bb5c9e3888",
+              "score_status": "missing",
+              "solver_attempt_countable": false,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "recorded",
+              "submit_eligible": false,
+              "verifier_attempt_countable": false
             }
           ]
         },
@@ -10202,7 +12169,7 @@
           ]
         }
       },
-      "run_count": 163
+      "run_count": 193
     },
     "swe-marathon": {
       "benchmark_id": "swe-marathon",
@@ -14254,5 +16221,5 @@
     "source_of_truth": "benchmark_run_v0 compact run events",
     "update_rule": "upsert one run entry when a benchmark case is ingested or closed"
   },
-  "updated_at": "2026-06-29T17:31:26+08:00"
+  "updated_at": "2026-06-30T06:18:22+08:00"
 }

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
@@ -5,23 +5,43 @@ benchmark case outcomes and artifact references; it must not contain raw
 logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 
 - schema_version: `benchmark_run_ledger_v0`
-- updated_at: `2026-06-29T17:31:26+08:00`
+- updated_at: `2026-06-30T06:18:22+08:00`
 
 ## Case Decisions
 
 | Benchmark | Case | Decision | Product Pair | Case Routing | Runs |
 | --- | --- | --- | --- | --- | --- |
 | `skillsbench-cloud-oracle-sanity@v0` | `hello-world` | `single_arm_recorded` | - | - | `1` |
-| `skillsbench@1.1` | `3d-scan-calc` | `paired_baseline_solved_treatment_preserved` | - | - | `11` |
-| `skillsbench@1.1` | `ada-bathroom-plan-repair` | `paired_baseline_solved_treatment_preserved` | - | - | `4` |
-| `skillsbench@1.1` | `adaptive-cruise-control` | `baseline_runner_or_setup_repair_required` | - | - | `1` |
-| `skillsbench@1.1` | `azure-bgp-oscillation-route-leak` | `product_mode_pair_incomplete` | `treatment_loopx_lifecycle_not_observed` | - | `10` |
-| `skillsbench@1.1` | `bike-rebalance` | `paired_baseline_solved_treatment_preserved` | - | - | `3` |
-| `skillsbench@1.1` | `citation-check` | `paired_baseline_solved_treatment_preserved` | - | - | `14` |
-| `skillsbench@1.1` | `civ6-adjacency-optimizer` | `paired_no_score_uplift` | - | - | `4` |
-| `skillsbench@1.1` | `dapt-intrusion-detection` | `paired_baseline_setup_preflight_selection_required` | - | - | `5` |
-| `skillsbench@1.1` | `debug-trl-grpo` | `paired_baseline_runner_or_setup_repair_required` | - | - | `9` |
-| `skillsbench@1.1` | `fix-build-agentops` | `baseline_runner_or_setup_repair_required` | - | - | `2` |
+| `skillsbench@1.1` | `3d-scan-calc` | `paired_treatment_improved` | - | - | `12` |
+| `skillsbench@1.1` | `ada-bathroom-plan-repair` | `paired_treatment_improved` | - | - | `5` |
+| `skillsbench@1.1` | `adaptive-cruise-control` | `baseline_failed_treatment_candidate` | - | - | `2` |
+| `skillsbench@1.1` | `azure-bgp-oscillation-route-leak` | `product_mode_pair_incomplete` | `baseline_not_raw_codex_autonomous_max5,baseline_official_feedback_not_blinded,baseline_reward_feedback_forwarding_not...` | - | `11` |
+| `skillsbench@1.1` | `bike-rebalance` | `paired_treatment_improved` | - | - | `4` |
+| `skillsbench@1.1` | `citation-check` | `paired_treatment_improved` | - | - | `15` |
+| `skillsbench@1.1` | `civ6-adjacency-optimizer` | `paired_no_score_uplift` | - | - | `5` |
+| `skillsbench@1.1` | `court-form-filling` | `baseline_failed_treatment_candidate` | - | - | `1` |
+| `skillsbench@1.1` | `crystallographic-wyckoff-position-analysis` | `baseline_failed_treatment_candidate` | - | - | `1` |
+| `skillsbench@1.1` | `dapt-intrusion-detection` | `paired_no_score_uplift` | - | - | `6` |
+| `skillsbench@1.1` | `data-to-d3` | `baseline_failed_treatment_candidate` | - | - | `1` |
+| `skillsbench@1.1` | `debug-trl-grpo` | `paired_baseline_runner_or_setup_repair_required` | - | - | `10` |
+| `skillsbench@1.1` | `dialogue-parser` | `baseline_failed_treatment_candidate` | - | - | `1` |
+| `skillsbench@1.1` | `drone-planning-control` | `baseline_failed_treatment_candidate` | - | - | `1` |
+| `skillsbench@1.1` | `dynamic-object-aware-egomotion` | `baseline_failed_treatment_candidate` | - | - | `1` |
+| `skillsbench@1.1` | `earthquake-phase-association` | `baseline_failed_treatment_candidate` | - | - | `1` |
+| `skillsbench@1.1` | `earthquake-plate-calculation` | `baseline_failed_treatment_candidate` | - | - | `1` |
+| `skillsbench@1.1` | `econ-detrending-correlation` | `baseline_failed_treatment_candidate` | - | - | `1` |
+| `skillsbench@1.1` | `edit-pdf` | `baseline_failed_treatment_candidate` | - | - | `1` |
+| `skillsbench@1.1` | `energy-ac-optimal-power-flow` | `baseline_failed_treatment_candidate` | - | - | `1` |
+| `skillsbench@1.1` | `energy-market-pricing` | `baseline_failed_treatment_candidate` | - | - | `1` |
+| `skillsbench@1.1` | `energy-unit-commitment` | `baseline_failed_treatment_candidate` | - | - | `1` |
+| `skillsbench@1.1` | `enterprise-information-search` | `baseline_failed_treatment_candidate` | - | - | `1` |
+| `skillsbench@1.1` | `exam-block-sequencing` | `baseline_failed_treatment_candidate` | - | - | `1` |
+| `skillsbench@1.1` | `exceltable-in-ppt` | `baseline_failed_treatment_candidate` | - | - | `1` |
+| `skillsbench@1.1` | `exoplanet-detection-period` | `baseline_failed_treatment_candidate` | - | - | `1` |
+| `skillsbench@1.1` | `financial-modeling-qa` | `baseline_failed_treatment_candidate` | - | - | `1` |
+| `skillsbench@1.1` | `fix-build-agentops` | `baseline_runner_or_setup_repair_required` | - | - | `3` |
+| `skillsbench@1.1` | `fix-build-google-auto` | `baseline_runner_or_setup_repair_required` | - | - | `1` |
+| `skillsbench@1.1` | `fix-druid-loophole-cve` | `baseline_runner_or_setup_repair_required` | - | - | `1` |
 | `skillsbench@1.1` | `hello-world` | `baseline_runner_or_setup_repair_required` | - | - | `2` |
 | `skillsbench@1.1` | `llm-prefix-cache-replay` | `paired_no_score_uplift` | - | - | `25` |
 | `skillsbench@1.1` | `manufacturing-codebook-normalization` | `paired_no_score_uplift` | - | - | `4` |
@@ -93,11 +113,14 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `3d-scan-calc` | `codex_loopx_treatment` | `` | `0.0` | `` | `1:0,2:0,3:0,4:0,5:0,6:0,7:0,8:0,9:0,10:0,11:0,12:0` | `skillsbench_host_local_acp_codex_exec_failed_codex_exec_bridge_idle_timeout` | `` |
 | `skillsbench@1.1` | `3d-scan-calc` | `codex_loopx_treatment` | `` | `missing` | `` | `` | `skillsbench_host_local_acp_codex_exec_preflight_failed_bridge_command_failed` | `.local/private-benchmark-jobs/skillsbench-3d-scan-calc-goalstart-revchan-shim-20260628T111718Z/3d-scan-calc__loopx_goal_start_product_mode/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `3d-scan-calc` | `codex_loopx_treatment` | `case_attempt` | `1.0` | `2` | `1:0,2:1*,3:1*,4:1*` | `none` | `.local/private-benchmark-jobs/skillsbench-3d-scan-calc-goalstart-revchan-shim-20260628T111849Z/3d-scan-calc__loopx_goal_start_product_mode/benchmark_run.compact.json` |
+| `skillsbench@1.1` | `3d-scan-calc` | `codex_app_server_goal_baseline` | `case_attempt` | `0.0` | `` | `` | `official_verifier_solution_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-01-3d-scan-calc/result.json` |
 | `skillsbench@1.1` | `ada-bathroom-plan-repair` | `codex_goal_mode_baseline` | `` | `missing` | `` | `` | `skillsbench_codex_acp_launch_failed` | `.local/private-benchmark-jobs/skillsbench-ada-bathroom-plan-repair-pair-20260615T2346CST/ada-bathroom-plan-repair__codex_goal_mode_baseline_20260615T2346CST/ada-bathroom-plan-repair__codex_goal_mode_baseline/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `ada-bathroom-plan-repair` | `codex_goal_mode_baseline` | `` | `missing` | `` | `` | `skillsbench_codex_acp_binary_missing` | `.local/private-benchmark-jobs/skillsbench-ada-bathroom-plan-repair-preflight-rerun-20260616T0124CST/ada-bathroom-plan-repair__codex_goal_mode_baseline_preflight_rerun_20260616T0124CST/ada-bathroom-plan-repair__codex_goal_mode_baseline/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `ada-bathroom-plan-repair` | `baseline` | `` | `1.0` | `1` | `1:1*` | `none` | `.local/private-benchmark-jobs/skillsbench-ada-bathroom-plan-repair-blind-baseline-v0/ada-bathroom-plan-repair__codex_acp_blind_loop_v0/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `ada-bathroom-plan-repair` | `codex_loopx_treatment` | `` | `1.0` | `1` | `1:1*` | `none` | `.local/private-benchmark-jobs/skillsbench-ada-bathroom-plan-repair-blind-treatment-v0/ada-bathroom-plan-repair__loopx_blind_loop_v0/benchmark_run.compact.json` |
+| `skillsbench@1.1` | `ada-bathroom-plan-repair` | `codex_app_server_goal_baseline` | `case_attempt` | `0.0` | `` | `` | `official_verifier_solution_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-02-ada-bathroom-plan-repair/result.json` |
 | `skillsbench@1.1` | `adaptive-cruise-control` | `baseline` | `` | `missing` | `` | `` | `skillsbench_docker_compose_apt_repository_failure` | `.local/private-benchmark-jobs/skillsbench-adaptive-cruise-control-baseline-probe-20260616T0956CST/adaptive-cruise-control__codex_acp_blind_loop/benchmark_run.compact.json` |
+| `skillsbench@1.1` | `adaptive-cruise-control` | `codex_app_server_goal_baseline` | `case_attempt` | `0.0` | `` | `` | `official_verifier_solution_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-03-adaptive-cruise-control/result.json` |
 | `skillsbench@1.1` | `azure-bgp-oscillation-route-leak` | `baseline` | `` | `missing` | `` | `` | `skillsbench_runner_error` | `.local/private-benchmark-jobs/skillsbench-azure-bgp-route-leak-blind-baseline-20260616T101857CST/azure-bgp-oscillation-route-leak__codex_acp_blind_loop/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `azure-bgp-oscillation-route-leak` | `baseline` | `` | `missing` | `` | `` | `skillsbench_runner_error` | `.local/private-benchmark-jobs/skillsbench-azure-bgp-route-leak-blind-baseline-20260616T102256CST/azure-bgp-oscillation-route-leak__codex_acp_blind_loop/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `azure-bgp-oscillation-route-leak` | `baseline` | `` | `missing` | `` | `` | `skillsbench_runner_error` | `.local/private-benchmark-jobs/skillsbench-azure-bgp-route-leak-blind-baseline-20260616T102456CST/azure-bgp-oscillation-route-leak__codex_acp_blind_loop/benchmark_run.compact.json` |
@@ -108,9 +131,11 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `azure-bgp-oscillation-route-leak` | `codex_loopx_treatment` | `` | `0.0` | `` | `1:missing,2:0,3:0,4:0,5:0` | `official_verifier_solution_failure` | `.local/private-benchmark-jobs/skillsbench-azure-bgp-oscillation-route-leak-blind-treatment-max5-popen-20260616T1710CST/azure-bgp-oscillation-route-leak__loopx_blind_loop_max5/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `azure-bgp-oscillation-route-leak` | `skillsbench_raw_codex_autonomous_max5_baseline` | `` | `0.0` | `` | `1:0` | `official_verifier_solution_failure` | `.local/private-benchmark-jobs/skillsbench-azure-bgp-product-mode-20260617T195844CST/azure-bgp-oscillation-route-leak__raw_codex_autonomous_max5/azure-bgp-oscillation-route-leak__raw_codex_autonomous_max5/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `azure-bgp-oscillation-route-leak` | `codex_loopx_treatment` | `` | `0.0` | `` | `1:0,2:0,3:0,4:0,5:0` | `official_verifier_solution_failure` | `.local/private-benchmark-jobs/skillsbench-azure-bgp-product-mode-20260617T195844CST/azure-bgp-oscillation-route-leak__loopx_product_mode/azure-bgp-oscillation-route-leak__loopx_product_mode/benchmark_run.compact.json` |
+| `skillsbench@1.1` | `azure-bgp-oscillation-route-leak` | `codex_app_server_goal_baseline` | `case_attempt` | `0.0` | `` | `` | `official_verifier_solution_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-04-azure-bgp-oscillation-route-leak/result.json` |
 | `skillsbench@1.1` | `bike-rebalance` | `loopx-blind-loop-treatment-baseline-safe` | `` | `1.0` | `1` | `1:1*` | `none` | `private-benchmark-jobs/skillsbench-bike-rebalance-treatment-blind-20260616T082339CST-popen/bike-rebalance__loopx_blind_loop/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `bike-rebalance` | `codex-acp-blind-loop-baseline` | `` | `missing` | `` | `` | `skillsbench_runner_error` | `private-benchmark-jobs/skillsbench-bike-rebalance-baseline-blind-20260616T082339CST-popen/bike-rebalance__codex_acp_blind_loop/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `bike-rebalance` | `baseline` | `` | `1.0` | `1` | `1:1*` | `none` | `.local/private-benchmark-jobs/skillsbench-bike-rebalance-baseline-rerun-20260616T0852CST/bike-rebalance__codex_acp_blind_loop/benchmark_run.compact.json` |
+| `skillsbench@1.1` | `bike-rebalance` | `codex_app_server_goal_baseline` | `case_attempt` | `0.0` | `` | `` | `official_verifier_solution_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-05-bike-rebalance/result.json` |
 | `skillsbench@1.1` | `citation-check` | `codex_goal_mode_baseline` | `` | `missing` | `` | `` | `skillsbench_environment_app_mount_missing` | `result.json` |
 | `skillsbench@1.1` | `citation-check` | `codex_goal_mode_baseline` | `` | `1.0` | `` | `` | `none` | `result.json` |
 | `skillsbench@1.1` | `citation-check` | `baseline` | `` | `1.0` | `1` | `1:1*` | `none` | `.local/private-benchmark-jobs/skillsbench-citation-check-blind-baseline-v0/citation-check__codex_acp_blind_loop_v0/benchmark_run.compact.json` |
@@ -125,15 +150,21 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `citation-check` | `codex_loopx_treatment` | `case_attempt` | `missing` | `` | `` | `verifier_infrastructure_failure` | `.local/private-benchmark-jobs/skillsbench-citation-check-goal-start-post777-20260627T133638Z/remote-root/jobs/skillsbench-citation-check-goal-start-post777-20260627T133638Z-goalstart/citation-check__loopx_goal_start_product_mode/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `citation-check` | `codex_loopx_treatment` | `case_attempt` | `missing` | `` | `1:missing,2:missing,3:missing,4:missing,5:missing,6:missing,7:missing,8:missing,9:missing,10:missing,11:missing,12:missing,13:missing,14:missing,15:missing` | `verifier_infrastructure_failure` | `.local/private-benchmark-jobs/skillsbench-citation-check-goalstart-earlyexit-20260628T1235Z/citation-check__loopx_goal_start_product_mode/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `citation-check` | `codex_loopx_treatment` | `case_attempt` | `1.0` | `2` | `1:0,2:1*` | `none` | `cloud-ecs/skillsbench-citation-check-goalstart-taskrecenter-20260629T091301Z/jobs/skillsbench-citation-check-goalstart-taskrecenter-20260629T091301Z-goalstart/citation-check__loopx_goal_start_product_mode/benchmark_run.compact.json` |
+| `skillsbench@1.1` | `citation-check` | `codex_app_server_goal_baseline` | `case_attempt` | `0.0` | `` | `` | `official_verifier_solution_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-06-citation-check/result.json` |
 | `skillsbench@1.1` | `civ6-adjacency-optimizer` | `codex_goal_mode_baseline` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `` |
 | `skillsbench@1.1` | `civ6-adjacency-optimizer` | `loopx_automation_loop_treatment` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `` |
 | `skillsbench@1.1` | `civ6-adjacency-optimizer` | `baseline` | `` | `0.0` | `` | `1:0,2:0` | `official_verifier_solution_failure` | `.local/private-benchmark-jobs/skillsbench-civ6-adjacency-optimizer-blind-baseline-v0/civ6-adjacency-optimizer__codex_acp_blind_loop_v0/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `civ6-adjacency-optimizer` | `codex_loopx_treatment` | `` | `0.0` | `` | `1:0,2:0` | `official_verifier_solution_failure` | `.local/private-benchmark-jobs/skillsbench-civ6-adjacency-optimizer-blind-treatment-v0/civ6-adjacency-optimizer__loopx_blind_loop_v0/benchmark_run.compact.json` |
+| `skillsbench@1.1` | `civ6-adjacency-optimizer` | `codex_app_server_goal_baseline` | `case_attempt` | `0.0` | `` | `` | `official_verifier_solution_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-07-civ6-adjacency-optimizer/result.json` |
+| `skillsbench@1.1` | `court-form-filling` | `codex_app_server_goal_baseline` | `case_attempt` | `0.0` | `` | `` | `official_verifier_solution_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-08-court-form-filling/result.json` |
+| `skillsbench@1.1` | `crystallographic-wyckoff-position-analysis` | `codex_app_server_goal_baseline` | `case_attempt` | `0.0` | `` | `` | `official_verifier_solution_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-09-crystallographic-wyckoff-position-analysis/result.json` |
 | `skillsbench@1.1` | `dapt-intrusion-detection` | `codex_goal_mode_baseline` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `` |
 | `skillsbench@1.1` | `dapt-intrusion-detection` | `loopx_automation_loop_treatment` | `` | `1.0` | `` | `` | `none` | `` |
 | `skillsbench@1.1` | `dapt-intrusion-detection` | `baseline` | `` | `0.0` | `` | `1:0,2:0` | `official_verifier_solution_failure` | `.local/private-benchmark-jobs/skillsbench-dapt-intrusion-detection-blind-baseline-v0/dapt-intrusion-detection__codex_acp_blind_loop_v0/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `dapt-intrusion-detection` | `codex_loopx_treatment` | `` | `0.0` | `` | `1:0,2:0` | `official_verifier_solution_failure` | `.local/private-benchmark-jobs/skillsbench-dapt-intrusion-detection-blind-treatment-v0/dapt-intrusion-detection__loopx_blind_loop_v0/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `dapt-intrusion-detection` | `skillsbench_codex_acp_blind_loop_baseline` | `` | `missing` | `` | `` | `skillsbench_docker_apt_setup_risk_preflight_blocked` | `.local/private-benchmark-jobs/skillsbench-dapt-intrusion-detection-codex-acp-blind-loop-baseline-20260616T230958CST/dapt-intrusion-detection__codex_acp_blind_loop/benchmark_run.compact.json` |
+| `skillsbench@1.1` | `dapt-intrusion-detection` | `codex_app_server_goal_baseline` | `case_attempt` | `0.0` | `` | `` | `official_verifier_solution_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-10-dapt-intrusion-detection/result.json` |
+| `skillsbench@1.1` | `data-to-d3` | `codex_app_server_goal_baseline` | `case_attempt` | `0.0` | `` | `` | `official_verifier_solution_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-11-data-to-d3/result.json` |
 | `skillsbench@1.1` | `debug-trl-grpo` | `codex_goal_mode_baseline` | `` | `0.25` | `` | `` | `none` | `` |
 | `skillsbench@1.1` | `debug-trl-grpo` | `loopx_automation_loop_treatment` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `` |
 | `skillsbench@1.1` | `debug-trl-grpo` | `baseline` | `` | `0.25` | `` | `1:0.25,2:0.25` | `none` | `.local/private-benchmark-jobs/skillsbench-debug-trl-grpo-blind-baseline-v0/debug-trl-grpo__codex_acp_blind_loop_v0/benchmark_run.compact.json` |
@@ -143,8 +174,27 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `debug-trl-grpo` | `codex_loopx_treatment` | `` | `0.0` | `` | `1:0.25,2:0.25,3:0,4:0,5:0` | `official_verifier_solution_failure` | `.local/private-benchmark-jobs/skillsbench-debug-trl-grpo-blind-treatment-max5-launchd-20260616T150011CST/debug-trl-grpo__loopx_blind_loop_max5/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `debug-trl-grpo` | `skillsbench_raw_codex_autonomous_max5_baseline` | `` | `missing` | `` | `` | `skillsbench_docker_compose_image_build_failure` | `.local/private-benchmark-jobs/skillsbench-product-mode-debug-trl-raw-baseline-20260616T1959CST/skillsbench_product_mode_debug_trl_raw_baseline_20260616T1959CST/debug-trl-grpo__raw_codex_autonomous_max5/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `debug-trl-grpo` | `skillsbench_raw_codex_autonomous_max5_baseline` | `` | `missing` | `` | `` | `skillsbench_docker_compose_apt_repository_failure` | `.local/private-benchmark-jobs/skillsbench-product-mode-debug-trl-raw-baseline-after-runtime-apt-20260616T2011CST/skillsbench_product_mode_debug_trl_raw_baseline_after_runtime_apt_20260616T2011CST/debug-trl-grpo__raw_codex_autonomous_max5_runtime_apt/benchmark_run.compact.json` |
+| `skillsbench@1.1` | `debug-trl-grpo` | `codex_app_server_goal_baseline` | `` | `missing` | `` | `` | `skillsbench_docker_compose_pip_bootstrap_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-12-debug-trl-grpo/result.json` |
+| `skillsbench@1.1` | `dialogue-parser` | `codex_app_server_goal_baseline` | `case_attempt` | `0.0` | `` | `` | `official_verifier_solution_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-13-dialogue-parser/result.json` |
+| `skillsbench@1.1` | `drone-planning-control` | `codex_app_server_goal_baseline` | `case_attempt` | `0.0` | `` | `` | `official_verifier_solution_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-14-drone-planning-control/result.json` |
+| `skillsbench@1.1` | `dynamic-object-aware-egomotion` | `codex_app_server_goal_baseline` | `case_attempt` | `0.0` | `` | `` | `official_verifier_solution_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-15-dynamic-object-aware-egomotion/result.json` |
+| `skillsbench@1.1` | `earthquake-phase-association` | `codex_app_server_goal_baseline` | `case_attempt` | `0.0` | `` | `` | `official_verifier_solution_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-16-earthquake-phase-association/result.json` |
+| `skillsbench@1.1` | `earthquake-plate-calculation` | `codex_app_server_goal_baseline` | `case_attempt` | `0.0` | `` | `` | `official_verifier_solution_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-17-earthquake-plate-calculation/result.json` |
+| `skillsbench@1.1` | `econ-detrending-correlation` | `codex_app_server_goal_baseline` | `case_attempt` | `0.0` | `` | `` | `official_verifier_solution_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-18-econ-detrending-correlation/result.json` |
+| `skillsbench@1.1` | `edit-pdf` | `codex_app_server_goal_baseline` | `case_attempt` | `0.0` | `` | `` | `official_verifier_solution_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-19-edit-pdf/result.json` |
+| `skillsbench@1.1` | `energy-ac-optimal-power-flow` | `codex_app_server_goal_baseline` | `case_attempt` | `0.0` | `` | `` | `official_verifier_solution_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-20-energy-ac-optimal-power-flow/result.json` |
+| `skillsbench@1.1` | `energy-market-pricing` | `codex_app_server_goal_baseline` | `case_attempt` | `0.0` | `` | `` | `official_verifier_solution_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-21-energy-market-pricing/result.json` |
+| `skillsbench@1.1` | `energy-unit-commitment` | `codex_app_server_goal_baseline` | `case_attempt` | `0.0` | `` | `` | `official_verifier_solution_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-22-energy-unit-commitment/result.json` |
+| `skillsbench@1.1` | `enterprise-information-search` | `codex_app_server_goal_baseline` | `case_attempt` | `0.0` | `` | `` | `official_verifier_solution_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-23-enterprise-information-search/result.json` |
+| `skillsbench@1.1` | `exam-block-sequencing` | `codex_app_server_goal_baseline` | `case_attempt` | `0.0` | `` | `` | `official_verifier_solution_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-24-exam-block-sequencing/result.json` |
+| `skillsbench@1.1` | `exceltable-in-ppt` | `codex_app_server_goal_baseline` | `case_attempt` | `0.0` | `` | `` | `official_verifier_solution_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-25-exceltable-in-ppt/result.json` |
+| `skillsbench@1.1` | `exoplanet-detection-period` | `codex_app_server_goal_baseline` | `case_attempt` | `0.0` | `` | `` | `official_verifier_solution_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-26-exoplanet-detection-period/result.json` |
+| `skillsbench@1.1` | `financial-modeling-qa` | `codex_app_server_goal_baseline` | `case_attempt` | `0.0` | `` | `` | `official_verifier_solution_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-27-financial-modeling-qa/result.json` |
 | `skillsbench@1.1` | `fix-build-agentops` | `baseline` | `` | `missing` | `` | `` | `skillsbench_docker_compose_setup_failure` | `.local/private-benchmark-jobs/skillsbench-fix-build-agentops-blind-baseline-20260616T102752CST/fix-build-agentops__codex_acp_blind_loop/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `fix-build-agentops` | `skillsbench_raw_codex_autonomous_max5_baseline` | `` | `missing` | `` | `` | `skillsbench_docker_compose_apt_repository_failure` | `.local/private-benchmark-jobs/skillsbench-fix-build-agentops-raw-codex-autonomous-max5-20260617T1412CST/fix-build-agentops__raw_codex_autonomous_max5/benchmark_run.compact.json` |
+| `skillsbench@1.1` | `fix-build-agentops` | `codex_app_server_goal_baseline` | `` | `missing` | `` | `` | `skillsbench_environment_app_mount_missing` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-28-fix-build-agentops/result.json` |
+| `skillsbench@1.1` | `fix-build-google-auto` | `codex_app_server_goal_baseline` | `` | `missing` | `` | `` | `skillsbench_docker_compose_apt_repository_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-29-fix-build-google-auto/result.json` |
+| `skillsbench@1.1` | `fix-druid-loophole-cve` | `codex_app_server_goal_baseline` | `` | `missing` | `` | `` | `skillsbench_docker_compose_apt_repository_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-30-fix-druid-loophole-cve/result.json` |
 | `skillsbench@1.1` | `hello-world` | `skillsbench_raw_codex_autonomous_max5_baseline` | `` | `missing` | `` | `` | `skillsbench_runner_failed_before_agent_install` | `.local/private-benchmark-jobs/skillsbench-canonical-hello-world-base-20260623T0211/skillsbench-canonical-hello-world-base-20260623T0211/hello-world__raw_codex_autonomous_max5/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `hello-world` | `skillsbench_raw_codex_autonomous_max5_baseline` | `` | `missing` | `` | `` | `skillsbench_runner_failed_before_agent_install` | `.local/private-benchmark-jobs/skillsbench-hello-world-canonical-lifecycle-20260622T225217Z-base/hello-world__raw_codex_autonomous_max5/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `llm-prefix-cache-replay` | `codex_goal_mode_baseline` | `` | `0.0` | `` | `` | `official_verifier_solution_failure` | `` |

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -9420,6 +9420,96 @@ def test_cli_dry_run_skillsbench_official_result() -> None:
         assert payload["benchmark_cli"]["skillsbench_result_ingested"] is True, payload
 
 
+def test_cli_skillsbench_result_root_discovers_nested_case_result_for_ledger() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-cli-result-root-smoke-") as tmp:
+        root = Path(tmp)
+        registry_path, runtime = write_registry(root)
+        run_group_id = "skillsbench-goal-baseline-30case-r12-fixture"
+        task_id = "citation-check"
+        case_root = root / run_group_id / task_id
+        nested_result = case_root / task_id / "result.json"
+        write_json(
+            nested_result,
+            {
+                "task_name": task_id,
+                "rollout_name": f"{task_id}__nested_fixture",
+                "rewards": {"reward": 0.0},
+                "agent": "codex-acp",
+                "agent_name": "codex-acp",
+                "model": "gpt-5.5",
+                "n_tool_calls": 9,
+                "n_prompts": 2,
+                "error": None,
+                "verifier_error": None,
+                "partial_trajectory": False,
+                "trajectory_source": "acp",
+            },
+        )
+        write_json(nested_result.with_name("timing.json"), {"total": 42.0})
+        write_json(
+            case_root / "other-task" / "result.json",
+            {
+                "task_name": "other-task",
+                "rollout_name": "other-task__nested_fixture",
+                "rewards": {"reward": 1.0},
+            },
+        )
+        ledger_path = root / "visible-ledger.json"
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "loopx.cli",
+                "--registry",
+                str(registry_path),
+                "--runtime-root",
+                str(runtime),
+                "--format",
+                "json",
+                "benchmark",
+                "run",
+                "skillsbench",
+                "--goal-id",
+                GOAL_ID,
+                "--skillsbench-route",
+                "codex-goal-mode-baseline",
+                "--include-task-name",
+                task_id,
+                "--skillsbench-result-root",
+                str(case_root),
+                "--update-run-ledger",
+                "--run-ledger-path",
+                str(ledger_path),
+                "--run-group-id",
+                run_group_id,
+                "--arm-id",
+                "codex_goal_mode_baseline",
+                "--execute",
+                "--no-global-sync",
+            ],
+            cwd=REPO_ROOT,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        payload = json.loads(result.stdout)
+        assert payload["ok"] is True, payload
+        assert payload["benchmark_cli"]["skillsbench_result_ingested"] is True, payload
+        assert payload["benchmark_cli"]["skillsbench_result_root_ingested"] is True, payload
+        discovery = payload["skillsbench_result_discovery"]
+        assert discovery["status"] == "found", discovery
+        assert discovery["selected_relative_to_root"] == f"{task_id}/result.json", discovery
+        assert payload["benchmark_run"]["result_discovery"]["status"] == "found", payload
+        ledger_payload = payload["benchmark_run_ledger"]
+        assert ledger_payload["updated"] is True, ledger_payload
+        entry = ledger_payload["entry"]
+        assert entry["case_id"] == task_id, entry
+        refs = entry["artifact_refs"]
+        assert refs["artifact_ref"] == task_id, refs
+        assert refs["result_ref"] == f"{task_id}/result.json", refs
+        assert (root / "visible-ledger.md").exists(), "CLI should render markdown"
+
+
 def test_skillsbench_runner_plan_supports_controller_trace_path() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-trace-plan-") as tmp:
         root = Path(tmp)
@@ -12341,6 +12431,7 @@ if __name__ == "__main__":
     test_skillsbench_acp_trajectory_summary_is_compacted()
     test_cli_dry_run_skillsbench_skeleton()
     test_cli_dry_run_skillsbench_official_result()
+    test_cli_skillsbench_result_root_discovers_nested_case_result_for_ledger()
     test_skillsbench_runner_plan_supports_controller_trace_path()
     test_skillsbench_compact_runs_update_ledger_pair()
     test_skillsbench_repeat_same_mode_keeps_distinct_ledger_runs()

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -74,6 +74,7 @@ SKILLSBENCH_APP_SERVER_GOAL_WORKER_CONTRACT_SCHEMA_VERSION = (
 SKILLSBENCH_VERIFIER_DEPENDENCY_PREWARM_BLOCKER = (
     "skillsbench_verifier_dependency_prewarm_required"
 )
+SKILLSBENCH_RESULT_DISCOVERY_SCHEMA_VERSION = "skillsbench_result_discovery_v0"
 SKILLSBENCH_VERIFIER_DEPENDENCY_PREWARM_APT_PACKAGES = (
     "python3",
     "python3-pip",
@@ -156,6 +157,137 @@ def _skillsbench_rollout_reward_artifact(
     if not math.isfinite(reward):
         return None, None
     return reward, "official_skillsbench_rollout_verifier_reward_txt"
+
+
+def _skillsbench_safe_relative(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.name
+
+
+def discover_skillsbench_benchflow_result_json(
+    search_root: str | Path,
+    *,
+    expected_result_json: str | Path | None = None,
+    task_id: str | None = None,
+    rollout_name: str | None = None,
+) -> tuple[Path | None, dict[str, Any]]:
+    """Find an official SkillsBench/BenchFlow result.json below a safe root.
+
+    The discovery reads only compact official result.json metadata. It does not
+    inspect prompts, trajectories, verifier logs, task text, screenshots, or
+    credentials. This shared helper keeps CLI ledger ingest aligned with the
+    automation-loop reducer when BenchFlow materializes nested result paths.
+    """
+
+    root = Path(search_root).expanduser()
+    requested_task = str(task_id or "").strip()
+    requested_rollout = str(rollout_name or "").strip()
+
+    def base_discovery(status: str, policy: str) -> dict[str, Any]:
+        return {
+            "schema_version": SKILLSBENCH_RESULT_DISCOVERY_SCHEMA_VERSION,
+            "status": status,
+            "selection_policy": policy,
+            "raw_logs_read": False,
+            "raw_task_text_read": False,
+            "raw_trajectory_read": False,
+        }
+
+    if root.name == "result.json":
+        discovery = base_discovery(
+            "found" if root.is_file() else "missing",
+            "explicit_result_json",
+        )
+        discovery["candidate_count"] = 1 if root.is_file() else 0
+        if root.is_file():
+            discovery["selected_relative_to_root"] = root.name
+            discovery["selected_relative_to_job"] = root.name
+            return root, discovery
+        return None, discovery
+
+    expected = Path(expected_result_json).expanduser() if expected_result_json else None
+    if expected is not None and expected.is_file():
+        discovery = base_discovery("found", "planned_result_path")
+        discovery["candidate_count"] = 1
+        discovery["selected_relative_to_root"] = _skillsbench_safe_relative(
+            expected,
+            root,
+        )
+        discovery["selected_relative_to_job"] = discovery["selected_relative_to_root"]
+        return expected, discovery
+
+    if not root.is_dir():
+        discovery = base_discovery("missing", "result_root_scan")
+        discovery["candidate_count"] = 0
+        return None, discovery
+
+    candidates = sorted(path for path in root.rglob("result.json") if path.is_file())
+    ranked: list[tuple[int, float, str, Path, list[str]]] = []
+    for candidate in candidates:
+        score = 0
+        reasons: list[str] = []
+        if requested_rollout and candidate.parent.name == requested_rollout:
+            score += 100
+            reasons.append("parent_matches_requested_rollout")
+        elif requested_task and candidate.parent.name.startswith(f"{requested_task}__"):
+            score += 30
+            reasons.append("parent_matches_task_rollout_prefix")
+        try:
+            result = json.loads(candidate.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            result = {}
+        if isinstance(result, dict):
+            result_task = str(result.get("task_name") or "")
+            if requested_task and result_task == requested_task:
+                score += 50
+                reasons.append("result_task_matches_request")
+            result_rollout = str(result.get("rollout_name") or "")
+            if requested_rollout and result_rollout == requested_rollout:
+                score += 100
+                reasons.append("result_rollout_matches_request")
+            elif requested_task and result_rollout.startswith(f"{requested_task}__"):
+                score += 20
+                reasons.append("result_rollout_matches_task_prefix")
+            if not requested_task and not requested_rollout and len(candidates) == 1:
+                score += 1
+                reasons.append("single_candidate")
+        if score <= 0:
+            continue
+        try:
+            mtime = candidate.stat().st_mtime
+        except OSError:
+            mtime = 0.0
+        ranked.append((score, mtime, candidate.as_posix(), candidate, reasons))
+
+    if not ranked:
+        discovery = base_discovery(
+            "ambiguous" if candidates else "missing",
+            "result_root_scan_best_match",
+        )
+        discovery["candidate_count"] = len(candidates)
+        discovery["matched_candidate_count"] = 0
+        return None, discovery
+
+    ranked.sort(key=lambda item: (item[0], item[1], item[2]), reverse=True)
+    top_score, _top_mtime, _path_key, selected, reasons = ranked[0]
+    tied_top_count = sum(
+        1 for score, _mtime, _path, _candidate, _reasons in ranked if score == top_score
+    )
+    discovery = base_discovery("found", "result_root_scan_best_match")
+    discovery.update(
+        {
+            "tie_breaker": "highest_match_score_then_newest_mtime",
+            "candidate_count": len(candidates),
+            "matched_candidate_count": len(ranked),
+            "top_score_candidate_count": tied_top_count,
+            "selected_relative_to_root": _skillsbench_safe_relative(selected, root),
+            "selection_reasons": reasons,
+        }
+    )
+    discovery["selected_relative_to_job"] = discovery["selected_relative_to_root"]
+    return selected, discovery
 
 
 def skillsbench_route_contract(route: str) -> dict[str, Any]:
@@ -3011,6 +3143,7 @@ def build_skillsbench_benchflow_result_benchmark_run(
     model: str | None = None,
     runner_warning_labels: Iterable[str] | None = None,
     controller_trace: dict[str, Any] | None = None,
+    result_discovery: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build a public-safe benchmark_run_v0 from an official SkillsBench result.
 
@@ -5139,6 +5272,8 @@ def build_skillsbench_benchflow_result_benchmark_run(
         benchmark_run["timing"] = timing_summary
     if round_reward_trace is not None:
         benchmark_run["round_reward_trace"] = round_reward_trace
+    if isinstance(result_discovery, dict) and result_discovery:
+        benchmark_run["result_discovery"] = dict(result_discovery)
     if runner_failure is not None:
         benchmark_run["runner_failure"] = runner_failure
         benchmark_run["runner_failure_fingerprint"] = runner_failure_fingerprint

--- a/loopx/cli_commands/benchmark_run_ledger.py
+++ b/loopx/cli_commands/benchmark_run_ledger.py
@@ -14,6 +14,7 @@ from ..benchmark_adapters.skillsbench import (
     SKILLSBENCH_ROUTES,
     build_skillsbench_benchmark_run,
     build_skillsbench_benchflow_result_benchmark_run,
+    discover_skillsbench_benchflow_result_json,
     skillsbench_recommended_action,
 )
 from ..benchmark_adapters.terminal_bench import (
@@ -69,6 +70,14 @@ PrintPayload = Callable[
 ]
 OutputFormat = Callable[[argparse.Namespace], str]
 AppendBenchmarkRunRolloutEvent = Callable[..., dict[str, object]]
+
+
+def _safe_relative_path(path: Path, root: Path) -> str:
+    try:
+        return path.relative_to(root).as_posix()
+    except ValueError:
+        return path.name
+
 
 BENCHMARK_RUN_LEDGER_COMMANDS = (
     {
@@ -132,6 +141,15 @@ def register_benchmark_run_ledger_commands(
             "benchmark_run_v0. This reducer reads only result.json and sibling "
             "timing.json; it does not read prompts, trajectories, verifier logs, "
             "task text, credentials, upload, or submit."
+        ),
+    )
+    benchmark_run_parser.add_argument(
+        "--skillsbench-result-root",
+        help=(
+            "Discover and ingest an official SkillsBench/BenchFlow result.json below "
+            "this job, case, or run-group directory. Discovery reads only compact "
+            "result.json metadata and supports nested paths such as "
+            "case_dir/case_dir/result.json."
         ),
     )
     benchmark_run_parser.add_argument(
@@ -369,10 +387,13 @@ def handle_benchmark_run_ledger_command(
         try:
             if args.dry_run and args.execute:
                 raise ValueError("benchmark run accepts either --dry-run or --execute, not both")
+            skillsbench_result_path: Path | None = None
+            skillsbench_result_root_path: Path | None = None
+            skillsbench_result_discovery: dict[str, object] | None = None
             if args.benchmark_name == "skillsbench":
                 classification = args.classification or (
                     "skillsbench_official_benchflow_result_ingest_v0"
-                    if args.skillsbench_result_json
+                    if args.skillsbench_result_json or args.skillsbench_result_root
                     else (
                         "skillsbench_"
                         + str(args.skillsbench_route).replace("-", "_")
@@ -454,6 +475,10 @@ def handle_benchmark_run_ledger_command(
                     "skillsbench skeleton does not accept Terminal-Bench runner, "
                     "Harbor ingest, preflight, timeout, fake-worker, or bridge flags"
                 )
+            if args.skillsbench_result_json and args.skillsbench_result_root:
+                raise ValueError(
+                    "--skillsbench-result-json and --skillsbench-result-root are mutually exclusive"
+                )
             if args.harbor_job_dir and (
                 args.fake_worker
                 or args.preflight_guard
@@ -522,12 +547,41 @@ def handle_benchmark_run_ledger_command(
                     else args.model
                 )
                 if args.skillsbench_result_json:
+                    skillsbench_result_path, skillsbench_result_discovery = (
+                        discover_skillsbench_benchflow_result_json(
+                            Path(args.skillsbench_result_json).expanduser(),
+                        )
+                    )
+                    if skillsbench_result_path is None:
+                        raise ValueError(
+                            "SkillsBench --skillsbench-result-json does not exist "
+                            "or is not a result.json file"
+                        )
+                elif args.skillsbench_result_root:
+                    skillsbench_result_root_path = Path(
+                        args.skillsbench_result_root
+                    ).expanduser()
+                    skillsbench_result_path, skillsbench_result_discovery = (
+                        discover_skillsbench_benchflow_result_json(
+                            skillsbench_result_root_path,
+                            task_id=skillsbench_task,
+                        )
+                    )
+                    if skillsbench_result_path is None:
+                        raise ValueError(
+                            "SkillsBench result discovery did not find a matching "
+                            f"result.json below --skillsbench-result-root; "
+                            f"status={skillsbench_result_discovery.get('status')} "
+                            f"candidate_count={skillsbench_result_discovery.get('candidate_count')}"
+                        )
+                if skillsbench_result_path is not None:
                     benchmark_run_input = build_skillsbench_benchflow_result_benchmark_run(
-                        args.skillsbench_result_json,
+                        skillsbench_result_path,
                         route=args.skillsbench_route,
                         dataset=skillsbench_dataset,
                         agent=args.agent,
                         model=skillsbench_model,
+                        result_discovery=skillsbench_result_discovery,
                     )
                 else:
                     benchmark_run_input = build_skillsbench_benchmark_run(
@@ -649,9 +703,8 @@ def handle_benchmark_run_ledger_command(
                     args.active_user_assisted_treatment
                 ),
                 "harbor_job_result_ingested": bool(args.harbor_job_dir),
-                "skillsbench_result_ingested": bool(
-                    getattr(args, "skillsbench_result_json", None)
-                ),
+                "skillsbench_result_ingested": skillsbench_result_path is not None,
+                "skillsbench_result_root_ingested": bool(args.skillsbench_result_root),
                 "timeout_multiplier_preview_requested": (
                     timeout_multiplier_preview_requested
                     or timeout_multiplier_preview_defaulted
@@ -666,15 +719,12 @@ def handle_benchmark_run_ledger_command(
                 "auth_values_read": False,
                 "submit_eligible": False,
             }
+            if skillsbench_result_discovery is not None:
+                payload["skillsbench_result_discovery"] = skillsbench_result_discovery
             if args.update_run_ledger:
                 harbor_job_path = (
                     Path(args.harbor_job_dir).expanduser()
                     if args.harbor_job_dir
-                    else None
-                )
-                skillsbench_result_path = (
-                    Path(args.skillsbench_result_json).expanduser()
-                    if getattr(args, "skillsbench_result_json", None)
                     else None
                 )
                 inferred_run_group_id = args.run_group_id
@@ -686,31 +736,43 @@ def handle_benchmark_run_ledger_command(
                     )
                 if (
                     not inferred_run_group_id
+                    and skillsbench_result_root_path is not None
+                ):
+                    inferred_run_group_id = skillsbench_result_root_path.name
+                if (
+                    not inferred_run_group_id
                     and skillsbench_result_path is not None
                 ):
                     inferred_run_group_id = (
                         skillsbench_result_path.parent.parent.name
                     )
+                skillsbench_artifact_ref = None
+                skillsbench_result_ref = None
+                if skillsbench_result_path is not None:
+                    if skillsbench_result_root_path is not None:
+                        skillsbench_artifact_ref = _safe_relative_path(
+                            skillsbench_result_path.parent,
+                            skillsbench_result_root_path,
+                        )
+                        skillsbench_result_ref = _safe_relative_path(
+                            skillsbench_result_path,
+                            skillsbench_result_root_path,
+                        )
+                    else:
+                        skillsbench_artifact_ref = skillsbench_result_path.parent.name
+                        skillsbench_result_ref = skillsbench_result_path.name
                 payload["benchmark_run_ledger"] = update_benchmark_run_ledger(
                     ledger_path=args.run_ledger_path,
                     benchmark_run=benchmark_run,
                     artifact_ref=(
                         str(harbor_job_path)
                         if harbor_job_path is not None
-                        else (
-                            skillsbench_result_path.parent.name
-                            if skillsbench_result_path is not None
-                            else None
-                        )
+                        else skillsbench_artifact_ref
                     ),
                     result_ref=(
                         str(harbor_job_path / "result.json")
                         if harbor_job_path is not None
-                        else (
-                            skillsbench_result_path.name
-                            if skillsbench_result_path is not None
-                            else None
-                        )
+                        else skillsbench_result_ref
                     ),
                     compact_artifact_ref=payload.get("json_path")
                     if isinstance(payload.get("json_path"), str)
@@ -754,6 +816,7 @@ def handle_benchmark_run_ledger_command(
                     (
                         "skillsbench_official_benchflow_result_ingest_v0"
                         if getattr(args, "skillsbench_result_json", None)
+                        or getattr(args, "skillsbench_result_root", None)
                         else (
                             "skillsbench_"
                             + str(getattr(args, "skillsbench_route", "")).replace("-", "_")

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -2553,6 +2553,41 @@ def _compact_benchmark_compose_setup_diagnostic(value: Any) -> dict[str, Any]:
     return compact
 
 
+def _compact_benchmark_result_discovery(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+
+    compact: dict[str, Any] = {}
+    for field in (
+        "schema_version",
+        "status",
+        "selection_policy",
+        "tie_breaker",
+        "selected_relative_to_root",
+        "selected_relative_to_job",
+    ):
+        text = public_safe_compact_text(value.get(field), limit=180)
+        if text:
+            compact[field] = text
+    for field in (
+        "candidate_count",
+        "matched_candidate_count",
+        "top_score_candidate_count",
+    ):
+        if isinstance(value.get(field), int) and not isinstance(value.get(field), bool):
+            compact[field] = value[field]
+    for field in ("raw_logs_read", "raw_task_text_read", "raw_trajectory_read"):
+        if isinstance(value.get(field), bool):
+            compact[field] = value[field]
+    reasons = public_safe_compact_list(
+        value.get("selection_reasons"),
+        limit=MAX_BENCHMARK_RUN_LIST_ITEMS,
+    )
+    if reasons:
+        compact["selection_reasons"] = reasons
+    return compact
+
+
 def _compact_active_user_assisted_treatment_preflight(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict):
         return {}
@@ -3698,6 +3733,11 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
     )
     if runner_prerequisites:
         compact["runner_prerequisites"] = runner_prerequisites
+    result_discovery = _compact_benchmark_result_discovery(
+        source.get("result_discovery")
+    )
+    if result_discovery:
+        compact["result_discovery"] = result_discovery
     task_setup_preflight = _compact_benchmark_task_setup_preflight(
         source.get("task_setup_preflight")
     )


### PR DESCRIPTION
## Summary
- add SkillsBench result-root discovery for nested BenchFlow outputs such as case_dir/case_dir/result.json
- carry public-safe result discovery through compact benchmark runs and ledger ingest
- ingest the 30-case r12 app-server goal baseline official results into the common benchmark case ledger

## R12 ledger outcome
- rows ingested: 30
- official pass/reward=1: 0
- official verifier solution failures: 26
- setup/bootstrap failures: 4
- new r12 artifact refs are run-group-relative result.json paths only

## Validation
- python3 -m py_compile loopx/benchmark_adapters/skillsbench.py loopx/cli_commands/benchmark_run_ledger.py loopx/status.py examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- python3 examples/benchmark-run-ledger-smoke.py
- python3 examples/autonomous-replan-obligation-smoke.py
- git diff --check
- loopx check --scan-path loopx/benchmark_adapters/skillsbench.py --scan-path loopx/cli_commands/benchmark_run_ledger.py --scan-path loopx/status.py --scan-path examples/skillsbench-benchmark-run-smoke.py --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md

LoopX check passed with only the pre-existing duplicate index-row warning for loopx-meta runtime history.