### PR TITLE
Classify SkillsBench native worker startup failures

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -6764,6 +6764,7 @@ def test_skillsbench_round_trace_records_best_round_score() -> None:
         assert connected_no_trace_compact is not None
         no_trace_validation = connected_no_trace_compact["validation"]
         assert no_trace_validation["failed_checks"] == [
+            "native_goal_worker_countable_baseline",
             "native_goal_worker_public_trace_missing"
         ], connected_no_trace_compact
         assert no_trace_validation["native_goal_worker_connected"] is True, connected_no_trace_compact
@@ -6845,6 +6846,7 @@ def test_skillsbench_round_trace_records_best_round_score() -> None:
         assert lifecycle_trace_compact is not None
         lifecycle_validation = lifecycle_trace_compact["validation"]
         assert lifecycle_validation["failed_checks"] == [
+            "native_goal_worker_countable_baseline",
             "native_goal_worker_public_trace_missing"
         ], lifecycle_trace_compact
         assert lifecycle_validation["native_goal_worker_trace_observed"] is True, lifecycle_trace_compact
@@ -6857,6 +6859,112 @@ def test_skillsbench_round_trace_records_best_round_score() -> None:
         lifecycle_counters = lifecycle_trace_compact["interaction_counters"]
         assert lifecycle_counters["native_goal_worker_lifecycle_trace_count"] == 1, lifecycle_trace_compact
         assert lifecycle_counters["native_goal_worker_turn_start_count"] == 0, lifecycle_trace_compact
+
+        worker_failure_trace_dir = root / "native-worker-first-action-timeout"
+        worker_failure_trace_dir.mkdir()
+        write_json(
+            worker_failure_trace_dir / "worker-failure.compact.json",
+            {
+                "schema_version": "skillsbench_host_codex_goal_worker_public_trace_v0",
+                "ok": False,
+                "route": "codex-app-server-goal-baseline",
+                "trace_kind": "host_worker_process_failure",
+                "benchmark_id": "skillsbench@1.1",
+                "task_id": "llm-prefix-cache-replay",
+                "worker_process": {
+                    "schema_version": "skillsbench_host_worker_process_failure_v0",
+                    "stage": "first_action_timeout",
+                    "failure_category": "codex_exec_first_action_timeout",
+                    "returncode": -15,
+                    "stdout_bytes": 0,
+                    "stderr_bytes": 32,
+                    "raw_stdout_recorded": False,
+                    "raw_stderr_recorded": False,
+                    "host_paths_recorded": False,
+                },
+                "worker_contract": {
+                    "schema_version": "skillsbench_app_server_goal_worker_contract_v0",
+                    "route": "codex-app-server-goal-baseline",
+                    "ready": False,
+                    "runner_integration_ready": True,
+                    "first_blocker": "first_action_timeout",
+                },
+                "turn": {
+                    "thread_id_present": False,
+                    "goal_get_present": False,
+                    "turn_id_present": False,
+                    "turn_completed_observed": False,
+                    "assistant_message_present": False,
+                    "raw_transcript_recorded": False,
+                    "raw_assistant_message_recorded": False,
+                },
+                "boundary": {
+                    "raw_task_text_recorded": False,
+                    "raw_logs_recorded": False,
+                    "raw_trajectory_recorded": False,
+                    "credential_values_recorded": False,
+                    "host_paths_recorded": False,
+                },
+            },
+        )
+        first_action_timeout_trace = {
+            "schema_version": "skillsbench_loopx_controller_trace_v0",
+            "route": "codex-app-server-goal-baseline",
+            "trace_publicness": "public_counts_only_no_task_text_no_verifier_output",
+            "native_goal_worker_route": True,
+            "native_goal_worker_connected": True,
+            "native_goal_worker_connect_count": 1,
+            "raw_task_text_recorded": False,
+            "raw_verifier_output_recorded": False,
+            "raw_agent_trajectory_recorded": False,
+        }
+        _merge_app_server_goal_worker_trace_summary(
+            {
+                "route": "codex-app-server-goal-baseline",
+                "app_server_goal_worker_trace_dir": str(worker_failure_trace_dir),
+            },
+            first_action_timeout_trace,
+        )
+        first_action_timeout_compact = compact_benchmark_run(
+            build_skillsbench_benchflow_result_benchmark_run(
+                write_official_skillsbench_result(
+                    root / "native-worker-first-action-timeout-result",
+                    reward=0.0,
+                    task_id="llm-prefix-cache-replay",
+                ),
+                route="codex-app-server-goal-baseline",
+                controller_trace=first_action_timeout_trace,
+            )
+        )
+        assert first_action_timeout_compact is not None
+        expected_native_worker_failure = (
+            "skillsbench_native_goal_worker_failed_codex_exec_first_action_timeout"
+        )
+        assert (
+            first_action_timeout_compact["score_failure_attribution"]
+            == expected_native_worker_failure
+        ), first_action_timeout_compact
+        assert first_action_timeout_compact[
+            "official_score_comparable_to_native_codex"
+        ] is False, first_action_timeout_compact
+        assert first_action_timeout_compact[
+            "official_score_comparable_to_loopx_treatment"
+        ] is False, first_action_timeout_compact
+        assert "official_verifier_solution_failure" not in first_action_timeout_compact[
+            "failure_attribution_labels"
+        ], first_action_timeout_compact
+        assert first_action_timeout_compact["runner_failure"][
+            "native_goal_worker"
+        ]["failure_category"] == "codex_exec_first_action_timeout"
+        assert first_action_timeout_compact["validation"][
+            "native_goal_worker_failure_category"
+        ] == "codex_exec_first_action_timeout"
+        assert first_action_timeout_compact["native_goal_worker_contract"][
+            "countable_baseline"
+        ] is False
+        assert first_action_timeout_compact["attempt_accounting"][
+            "failure_class"
+        ] == "job_materialization_failed", first_action_timeout_compact
 
         empty_worker_trace_dir = root / "native-worker-empty-traces"
         empty_worker_trace_dir.mkdir()
@@ -6892,6 +7000,7 @@ def test_skillsbench_round_trace_records_best_round_score() -> None:
         assert empty_trace_compact is not None
         empty_trace_validation = empty_trace_compact["validation"]
         assert empty_trace_validation["failed_checks"] == [
+            "native_goal_worker_countable_baseline",
             "native_goal_worker_public_trace_missing"
         ], empty_trace_compact
         assert empty_trace_validation["native_goal_worker_connected"] is True, empty_trace_compact

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -640,6 +640,8 @@ def _skillsbench_attempt_failure_class(
         ):
             return BenchmarkFailureClass.OFFICIAL_SCORE_FAILED
         return BenchmarkFailureClass.SOLVER_FAILED
+    if score_failure_attribution.startswith("skillsbench_native_goal_worker_"):
+        return BenchmarkFailureClass.JOB_MATERIALIZATION_FAILED
     if verifier_error_text and reward_value is None:
         return BenchmarkFailureClass.VERIFIER_FAILED
     if reward_value is None and score_failure_attribution != "none":
@@ -2214,6 +2216,27 @@ def _skillsbench_controller_trace_counters(
                 counts[name[:80]] = value
         return dict(sorted(counts.items()))
 
+    def text_value(key: str, *, limit: int = 120) -> str:
+        value = controller_trace.get(key)
+        if not isinstance(value, str):
+            return ""
+        return value[:limit]
+
+    def text_list(key: str, *, limit: int = 120, max_items: int = 12) -> list[str]:
+        raw = controller_trace.get(key)
+        if not isinstance(raw, list):
+            return []
+        items: list[str] = []
+        for value in raw:
+            if not isinstance(value, str) or not value:
+                continue
+            safe = value[:limit]
+            if safe not in items:
+                items.append(safe)
+            if len(items) >= max_items:
+                break
+        return items
+
     def max_direct_or_subcommands(key: str, commands: tuple[str, ...]) -> int:
         direct = count(key)
         derived = sum(subcommand_count(command) for command in commands)
@@ -2429,6 +2452,21 @@ def _skillsbench_controller_trace_counters(
             "native_goal_worker_prompt_received_count"
         ),
         "native_goal_worker_ok_count": count("native_goal_worker_ok_count"),
+        "native_goal_worker_failure_trace_count": count(
+            "native_goal_worker_failure_trace_count"
+        ),
+        "native_goal_worker_failure_category": text_value(
+            "native_goal_worker_failure_category"
+        ),
+        "native_goal_worker_failure_categories": text_list(
+            "native_goal_worker_failure_categories"
+        ),
+        "native_goal_worker_first_blocker": text_value(
+            "native_goal_worker_first_blocker"
+        ),
+        "native_goal_worker_first_blockers": text_list(
+            "native_goal_worker_first_blockers"
+        ),
         "native_goal_worker_goal_get_count": count("native_goal_worker_goal_get_count"),
         "native_goal_worker_turn_start_count": count(
             "native_goal_worker_turn_start_count"
@@ -3073,6 +3111,41 @@ def _skillsbench_native_goal_worker_trace_status(
     return "worker_route_selected_not_connected"
 
 
+def _skillsbench_native_goal_worker_failure_label(
+    counters: dict[str, Any],
+    *,
+    trace_status: str,
+) -> str:
+    if counters.get("native_goal_worker_route") is not True:
+        return ""
+    if trace_status == "public_trace_observed":
+        return ""
+
+    reason = ""
+    for key in (
+        "native_goal_worker_failure_category",
+        "native_goal_worker_first_blocker",
+    ):
+        value = counters.get(key)
+        if isinstance(value, str) and value:
+            reason = value
+            break
+    if not reason:
+        reason = trace_status or "compact_proof_missing"
+    safe_reason = re.sub(r"[^a-zA-Z0-9]+", "_", reason).strip("_").lower()
+    if not safe_reason:
+        safe_reason = "compact_proof_missing"
+    prefix = (
+        "skillsbench_native_goal_worker_failed"
+        if (
+            counters.get("native_goal_worker_failure_trace_count", 0)
+            or counters.get("native_goal_worker_failure_category")
+        )
+        else "skillsbench_native_goal_worker_uncountable"
+    )
+    return f"{prefix}_{safe_reason}"[:160]
+
+
 def _round_reward_trace_stats(records: list[dict[str, Any]]) -> dict[str, Any]:
     numeric_records: list[dict[str, Any]] = []
     for item in records:
@@ -3428,6 +3501,50 @@ def build_skillsbench_benchflow_result_benchmark_run(
     def _trajectory_public_count(name: str) -> int:
         value = trajectory_summary.get(name, 0)
         return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
+    native_goal_worker_trace_count = controller_counters.get(
+        "native_goal_worker_trace_count", 0
+    )
+    if not isinstance(native_goal_worker_trace_count, int) or isinstance(
+        native_goal_worker_trace_count, bool
+    ):
+        native_goal_worker_trace_count = 0
+    native_goal_worker_trace_observed = native_goal_worker_trace_count > 0
+    native_goal_worker_trace_status = _skillsbench_native_goal_worker_trace_status(
+        controller_counters
+    )
+    native_goal_worker_failure_label = (
+        _skillsbench_native_goal_worker_failure_label(
+            controller_counters,
+            trace_status=native_goal_worker_trace_status,
+        )
+    )
+    native_goal_worker_countable = not bool(native_goal_worker_failure_label)
+    native_goal_worker_contract = {
+        "schema_version": "skillsbench_native_goal_worker_contract_v0",
+        "required": controller_counters.get("native_goal_worker_route") is True,
+        "countable_baseline": native_goal_worker_countable,
+        "trace_status": native_goal_worker_trace_status,
+        "trace_count": native_goal_worker_trace_count,
+        "ok_count": _controller_public_count("native_goal_worker_ok_count"),
+        "goal_get_count": _controller_public_count("native_goal_worker_goal_get_count"),
+        "turn_start_count": _controller_public_count(
+            "native_goal_worker_turn_start_count"
+        ),
+        "assistant_message_present_count": _controller_public_count(
+            "native_goal_worker_assistant_message_present_count"
+        ),
+        "failure_trace_count": _controller_public_count(
+            "native_goal_worker_failure_trace_count"
+        ),
+        "failure_category": str(
+            controller_counters.get("native_goal_worker_failure_category") or ""
+        )[:120],
+        "first_blocker": str(
+            controller_counters.get("native_goal_worker_first_blocker") or ""
+        )[:120],
+        "failure_label": native_goal_worker_failure_label,
+    }
 
     product_mode_lifecycle_required = _is_skillsbench_loopx_product_mode_treatment_route(
         route
@@ -4054,10 +4171,46 @@ def build_skillsbench_benchflow_result_benchmark_run(
         ):
             if item not in warning_labels:
                 warning_labels.append(item)
+    native_goal_worker_uncountable = bool(
+        native_goal_worker_failure_label and not official_passed
+    )
+    if native_goal_worker_uncountable:
+        exception_type = native_goal_worker_failure_label
+        score_failure_attribution = native_goal_worker_failure_label
+        runner_score_failure_attribution = native_goal_worker_failure_label
+        contract_official_score_comparable_to_native_codex = False
+        contract_official_score_comparable_to_loopx_treatment = False
+        failure_labels = [
+            item
+            for item in failure_labels
+            if item
+            not in {
+                "skillsbench_runner_error",
+                "skillsbench_codex_acp_jsonrpc_internal_error",
+                "skillsbench_codex_acp_transport_error",
+                "skillsbench_controller_budget_not_exercised",
+                "skillsbench_result_error_cut_off_followup_loop",
+                "skillsbench_result_timeout_after_agent_round_no_reward_artifact",
+                "skillsbench_result_error_after_agent_round",
+                "skillsbench_reward_artifact_missing",
+                "verifier_infrastructure_failure",
+                "official_score_zero_case_failure",
+                "official_verifier_solution_failure",
+            }
+        ]
+        for item in (
+            native_goal_worker_failure_label,
+            "skillsbench_native_goal_worker_uncountable_baseline",
+            "skillsbench_app_server_goal_worker_compact_proof_missing",
+            "skillsbench_runner_setup_error",
+        ):
+            if item and item not in failure_labels:
+                failure_labels.append(item)
     if trajectory_summary:
         evidence_files.append("loopx:acp_trajectory_summary")
     runner_failure: dict[str, Any] | None = None
-    if error_text:
+    runner_failure_fingerprint: dict[str, Any] | None = None
+    if error_text or native_goal_worker_uncountable:
         runner_failure = {
             "schema_version": "skillsbench_runner_failure_v0",
             "exception_type": exception_type,
@@ -4111,9 +4264,23 @@ def build_skillsbench_benchflow_result_benchmark_run(
                     )
                 ),
             }
-        runner_failure_fingerprint = skillsbench_runner_error_fingerprint(
-            error_text
-        )
+        if native_goal_worker_uncountable:
+            runner_failure["native_goal_worker"] = {
+                "schema_version": "skillsbench_native_goal_worker_failure_v0",
+                "trace_status": native_goal_worker_trace_status,
+                "failure_label": native_goal_worker_failure_label,
+                "failure_category": native_goal_worker_contract.get(
+                    "failure_category", ""
+                ),
+                "first_blocker": native_goal_worker_contract.get("first_blocker", ""),
+                "trace_count": native_goal_worker_trace_count,
+                "raw_transcript_recorded": False,
+                "raw_assistant_message_recorded": False,
+            }
+        if error_text:
+            runner_failure_fingerprint = skillsbench_runner_error_fingerprint(
+                error_text
+            )
     round_reward_records = controller_counters.get("round_rewards")
     if not isinstance(round_reward_records, list):
         round_reward_records = []
@@ -4309,17 +4476,6 @@ def build_skillsbench_benchflow_result_benchmark_run(
         failure_labels = []
         runner_failure = None
 
-    native_goal_worker_trace_count = controller_counters.get(
-        "native_goal_worker_trace_count", 0
-    )
-    if not isinstance(native_goal_worker_trace_count, int) or isinstance(
-        native_goal_worker_trace_count, bool
-    ):
-        native_goal_worker_trace_count = 0
-    native_goal_worker_trace_observed = native_goal_worker_trace_count > 0
-    native_goal_worker_trace_status = _skillsbench_native_goal_worker_trace_status(
-        controller_counters
-    )
     setup_blocked = _skillsbench_attempt_setup_blocked(failure_labels)
     attempt_accounting = build_benchmark_attempt_accounting(
         lifecycle=_skillsbench_attempt_lifecycle(
@@ -4842,6 +4998,15 @@ def build_skillsbench_benchflow_result_benchmark_run(
             "native_goal_worker_ok_count": controller_counters.get(
                 "native_goal_worker_ok_count", 0
             ),
+            "native_goal_worker_failure_trace_count": controller_counters.get(
+                "native_goal_worker_failure_trace_count", 0
+            ),
+            "native_goal_worker_failure_category": controller_counters.get(
+                "native_goal_worker_failure_category", ""
+            ),
+            "native_goal_worker_first_blocker": controller_counters.get(
+                "native_goal_worker_first_blocker", ""
+            ),
             "native_goal_worker_goal_get_count": controller_counters.get(
                 "native_goal_worker_goal_get_count", 0
             ),
@@ -5098,6 +5263,7 @@ def build_skillsbench_benchflow_result_benchmark_run(
             "does_not_upload_or_submit": True,
         },
         "product_mode_lifecycle_contract": product_mode_lifecycle_contract,
+        "native_goal_worker_contract": native_goal_worker_contract,
         "trials": [
             {
                 "task_id": task_id,
@@ -5149,6 +5315,13 @@ def build_skillsbench_benchflow_result_benchmark_run(
                 "native_goal_worker_prompt_received_count", 0
             ),
             "native_goal_worker_trace_status": native_goal_worker_trace_status,
+            "native_goal_worker_countable_baseline": native_goal_worker_countable,
+            "native_goal_worker_failure_category": native_goal_worker_contract.get(
+                "failure_category", ""
+            ),
+            "native_goal_worker_first_blocker": native_goal_worker_contract.get(
+                "first_blocker", ""
+            ),
             "remote_command_file_bridge_consumed_by_solver": (
                 controller_counters.get(
                     "remote_command_file_bridge_consumed_by_solver", False
@@ -5206,6 +5379,7 @@ def build_skillsbench_benchflow_result_benchmark_run(
             "official_score_comparable_to_native_codex": contract_official_score_comparable_to_native_codex,
             "official_score_comparable_to_loopx_treatment": contract_official_score_comparable_to_loopx_treatment,
             "product_mode_lifecycle": product_mode_lifecycle_contract,
+            "native_goal_worker": native_goal_worker_contract,
             "leaderboard_evidence": False,
         },
         "evidence_files": evidence_files,
@@ -5276,7 +5450,8 @@ def build_skillsbench_benchflow_result_benchmark_run(
         benchmark_run["result_discovery"] = dict(result_discovery)
     if runner_failure is not None:
         benchmark_run["runner_failure"] = runner_failure
-        benchmark_run["runner_failure_fingerprint"] = runner_failure_fingerprint
+        if runner_failure_fingerprint is not None:
+            benchmark_run["runner_failure_fingerprint"] = runner_failure_fingerprint
     if partial_trajectory and not host_local_acp_codex_exec_failure_present:
         benchmark_run["failure_attribution_labels"].append("partial_trajectory")
     return benchmark_run

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -1799,6 +1799,40 @@ def _compact_product_mode_lifecycle_contract(value: Any) -> dict[str, Any]:
     return compact
 
 
+def _compact_native_goal_worker_contract(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+
+    compact: dict[str, Any] = {}
+    schema = public_safe_compact_text(value.get("schema_version"), limit=100)
+    if schema:
+        compact["schema_version"] = schema
+    for field in ("required", "countable_baseline"):
+        if isinstance(value.get(field), bool):
+            compact[field] = value[field]
+    for field in (
+        "trace_count",
+        "ok_count",
+        "goal_get_count",
+        "turn_start_count",
+        "assistant_message_present_count",
+        "failure_trace_count",
+    ):
+        field_value = value.get(field)
+        if isinstance(field_value, int) and not isinstance(field_value, bool):
+            compact[field] = field_value
+    for field in (
+        "trace_status",
+        "failure_category",
+        "first_blocker",
+        "failure_label",
+    ):
+        text = public_safe_compact_text(value.get(field), limit=140)
+        if text:
+            compact[field] = text
+    return compact
+
+
 def _normalize_product_mode_lifecycle_contract(contract: dict[str, Any]) -> None:
     """Repair old compact records whose bridge closeout evidence was copied late."""
 
@@ -3892,6 +3926,36 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
                     compact_recovery[field] = user_loop_recovery[field]
             if compact_recovery:
                 compact_runner_failure["user_loop_recovery"] = compact_recovery
+        native_goal_worker = runner_failure.get("native_goal_worker")
+        if isinstance(native_goal_worker, dict):
+            compact_native_worker: dict[str, Any] = {}
+            for field in (
+                "schema_version",
+                "trace_status",
+                "failure_label",
+                "failure_category",
+                "first_blocker",
+            ):
+                value = public_safe_compact_text(
+                    native_goal_worker.get(field),
+                    limit=140,
+                )
+                if value:
+                    compact_native_worker[field] = value
+            for field in (
+                "trace_count",
+            ):
+                value = native_goal_worker.get(field)
+                if isinstance(value, int) and not isinstance(value, bool):
+                    compact_native_worker[field] = value
+            for field in (
+                "raw_transcript_recorded",
+                "raw_assistant_message_recorded",
+            ):
+                if isinstance(native_goal_worker.get(field), bool):
+                    compact_native_worker[field] = native_goal_worker[field]
+            if compact_native_worker:
+                compact_runner_failure["native_goal_worker"] = compact_native_worker
         if compact_runner_failure:
             compact["runner_failure"] = compact_runner_failure
 
@@ -3993,6 +4057,12 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
     if product_mode_lifecycle_contract:
         compact["product_mode_lifecycle_contract"] = product_mode_lifecycle_contract
         _repair_product_mode_lifecycle_missing_attribution(compact)
+
+    native_goal_worker_contract = _compact_native_goal_worker_contract(
+        source.get("native_goal_worker_contract")
+    )
+    if native_goal_worker_contract:
+        compact["native_goal_worker_contract"] = native_goal_worker_contract
 
     case_event_timeline = _compact_benchmark_case_event_timeline(
         source.get("case_event_timeline")
@@ -4100,6 +4170,8 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
             "case_success_claim_kind",
             "official_verifier_status",
             "native_goal_worker_trace_status",
+            "native_goal_worker_failure_category",
+            "native_goal_worker_first_blocker",
         ):
             text = public_safe_compact_text(validation.get(field), limit=140)
             if text:
@@ -4190,6 +4262,7 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
             "native_goal_worker_trace_dir_present",
             "native_goal_worker_public_trace_read",
             "native_goal_worker_trace_observed",
+            "native_goal_worker_countable_baseline",
             "runner_failure_compact_recorded",
             "no_raw_logs_read",
             "no_raw_task_text_read",

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -6907,6 +6907,9 @@ def _merge_app_server_goal_worker_trace_summary(
     lifecycle_trace_count = 0
     prompt_received_count = 0
     ok_count = 0
+    failure_trace_count = 0
+    failure_categories: list[str] = []
+    first_blockers: list[str] = []
     goal_get_count = 0
     turn_start_count = 0
     turn_completed_count = 0
@@ -6932,6 +6935,28 @@ def _merge_app_server_goal_worker_trace_summary(
                 prompt_received_count += 1
         if payload.get("ok") is True:
             ok_count += 1
+        worker_contract = (
+            payload.get("worker_contract")
+            if isinstance(payload.get("worker_contract"), dict)
+            else {}
+        )
+        first_blocker = worker_contract.get("first_blocker")
+        if isinstance(first_blocker, str) and first_blocker:
+            safe_blocker = first_blocker[:120]
+            if safe_blocker not in first_blockers:
+                first_blockers.append(safe_blocker)
+        worker_process = (
+            payload.get("worker_process")
+            if isinstance(payload.get("worker_process"), dict)
+            else {}
+        )
+        if payload.get("ok") is not True and worker_process:
+            failure_trace_count += 1
+            category = worker_process.get("failure_category")
+            if isinstance(category, str) and category:
+                safe_category = category[:120]
+                if safe_category not in failure_categories:
+                    failure_categories.append(safe_category)
         turn = payload.get("turn") if isinstance(payload.get("turn"), dict) else {}
         if turn.get("goal_get_present") is True:
             goal_get_count += 1
@@ -6966,6 +6991,15 @@ def _merge_app_server_goal_worker_trace_summary(
     trace["native_goal_worker_lifecycle_trace_count"] = lifecycle_trace_count
     trace["native_goal_worker_prompt_received_count"] = prompt_received_count
     trace["native_goal_worker_ok_count"] = ok_count
+    trace["native_goal_worker_failure_trace_count"] = failure_trace_count
+    trace["native_goal_worker_failure_categories"] = failure_categories
+    trace["native_goal_worker_failure_category"] = (
+        failure_categories[0] if failure_categories else ""
+    )
+    trace["native_goal_worker_first_blockers"] = first_blockers
+    trace["native_goal_worker_first_blocker"] = (
+        first_blockers[0] if first_blockers else ""
+    )
     trace["native_goal_worker_goal_get_count"] = goal_get_count
     trace["native_goal_worker_turn_start_count"] = turn_start_count
     trace["native_goal_worker_turn_completed_observed_count"] = turn_completed_count


### PR DESCRIPTION
## Summary
- surface native app-server goal worker failure categories from public worker compact traces
- treat unstarted native goal workers as uncountable baselines instead of verifier solution failures
- preserve native worker contract/failure fields in compact status and add an r12-shaped regression smoke

## Validation
- python3 -m py_compile loopx/benchmark_adapters/skillsbench.py scripts/skillsbench_automation_loop.py loopx/status.py examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- python3 examples/benchmark-run-ledger-smoke.py
- git diff --check
- loopx check

## Boundary
- diff scan found no /root, local absolute private path, .local/private, private benchmark job path, raw artifact path, or credential/raw-task marker in added lines