### PR TITLE
Repair app-server goal event turn tracking

### DIFF
--- a/examples/codex-app-server-goal-driver-smoke.py
+++ b/examples/codex-app-server-goal-driver-smoke.py
@@ -39,13 +39,20 @@ for line in sys.stdin:
                 "error": {"code": -32602, "message": "missing high effort"},
             }), flush=True)
             continue
-        result = {"turn": {"id": "turn-smoke", "status": "running"}}
+        print(json.dumps({
+            "method": "turn/started",
+            "params": {
+                "threadId": "thread-smoke",
+                "turn": {"id": "turn-event-smoke", "status": "inProgress"},
+            },
+        }), flush=True)
+        result = {"turn": {"id": "turn-response-smoke", "status": "running"}}
         print(json.dumps({"id": mid, "result": result}), flush=True)
         print(json.dumps({
             "method": "item/agentMessage/delta",
             "params": {
                 "threadId": "thread-smoke",
-                "turnId": "turn-smoke",
+                "turnId": "turn-event-smoke",
                 "itemId": "item-smoke",
                 "delta": "Synthetic final answer.",
             },
@@ -54,7 +61,7 @@ for line in sys.stdin:
             "method": "turn/completed",
             "params": {
                 "threadId": "thread-smoke",
-                "turn": {"id": "turn-smoke", "status": "completed"},
+                "turn": {"id": "turn-event-smoke", "status": "completed"},
             },
         }), flush=True)
         continue
@@ -91,13 +98,16 @@ def main() -> int:
         )
         try:
             assert turn.thread_id == "thread-smoke"
-            assert turn.turn_id == "turn-smoke"
+            assert turn.turn_id == "turn-event-smoke"
             compact = module.compact_turn_metadata(turn)
             assert compact["schema_version"] == "codex_app_server_goal_turn_driver_v0"
             assert compact["thread_id_present"] is True
             assert compact["goal_get_present"] is True
             assert compact["goal_status"] == "active"
             assert compact["turn_id_present"] is True
+            assert compact["turn_id_source"] == "event_stream", compact
+            assert compact["turn_start_response_turn_id_present"] is True, compact
+            assert compact["turn_event_stream_turn_id_present"] is True, compact
             assert compact["turn_completed_observed"] is False
             assert compact["raw_transcript_recorded"] is False
             assert "Synthetic prompt" not in json.dumps(compact)

--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -61,13 +61,20 @@ for line in sys.stdin:
                 "error": {"code": -32602, "message": "missing high effort"},
             }), flush=True)
             continue
-        result = {"turn": {"id": "turn-skillsbench", "status": "running"}}
+        print(json.dumps({
+            "method": "turn/started",
+            "params": {
+                "threadId": "thread-skillsbench",
+                "turn": {"id": "turn-event-skillsbench", "status": "inProgress"},
+            },
+        }), flush=True)
+        result = {"turn": {"id": "turn-response-skillsbench", "status": "running"}}
         print(json.dumps({"id": mid, "result": result}), flush=True)
         print(json.dumps({
             "method": "item/agentMessage/delta",
             "params": {
                 "threadId": "thread-skillsbench",
-                "turnId": "turn-skillsbench",
+                "turnId": "turn-event-skillsbench",
                 "itemId": "item-skillsbench",
                 "delta": "private worker answer",
             },
@@ -76,7 +83,7 @@ for line in sys.stdin:
             "method": "turn/completed",
             "params": {
                 "threadId": "thread-skillsbench",
-                "turn": {"id": "turn-skillsbench", "status": "completed"},
+                "turn": {"id": "turn-event-skillsbench", "status": "completed"},
             },
         }), flush=True)
         continue
@@ -438,6 +445,9 @@ def test_host_worker_waits_for_completion_and_keeps_public_json_compact() -> Non
         assert payload["ok"] is True, payload
         assert payload["turn"]["turn_completed_observed"] is True, payload
         assert payload["turn"]["completion_source_of_truth"] == "codex_turn_completion", payload
+        assert payload["turn"]["turn_id_source"] == "event_stream", payload
+        assert payload["turn"]["turn_start_response_turn_id_present"] is True, payload
+        assert payload["turn"]["turn_event_stream_turn_id_present"] is True, payload
         assert "completion_marker_requested" not in payload["turn"], payload
         assert "completion_marker_observed" not in payload["turn"], payload
         assert "completion_marker_deleted" not in payload["turn"], payload

--- a/scripts/codex_app_server_goal_driver.py
+++ b/scripts/codex_app_server_goal_driver.py
@@ -23,6 +23,9 @@ class CodexAppServerGoalTurn:
     process: subprocess.Popen[str]
     thread_id: str
     turn_id: str
+    turn_id_source: str = ""
+    turn_start_response_turn_id_present: bool = False
+    turn_event_stream_turn_id_present: bool = False
     next_request_id: int = 6
     goal_status: str = ""
     turn_status: str = ""
@@ -76,6 +79,7 @@ def _wait_for_response(
     *,
     notifications: list[str],
     timeout_sec: float,
+    side_events: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     deadline = time.monotonic() + timeout_sec
     while time.monotonic() < deadline:
@@ -90,6 +94,8 @@ def _wait_for_response(
         method = msg.get("method")
         if method:
             notifications.append(str(method))
+            if side_events is not None:
+                side_events.append(msg)
             continue
         if msg.get("id") == request_id:
             if msg.get("error"):
@@ -140,6 +146,23 @@ def _notification_turn_id(params: dict[str, Any]) -> str:
 
 def _notification_thread_id(params: dict[str, Any]) -> str:
     return str(params.get("threadId") or "")
+
+
+def _event_stream_turn_id(messages: list[dict[str, Any]]) -> str:
+    for preferred_method in ("turn/started", "item/started", "item/agentMessage/delta"):
+        for msg in messages:
+            if msg.get("method") != preferred_method:
+                continue
+            params = msg.get("params") if isinstance(msg.get("params"), dict) else {}
+            turn_id = _notification_turn_id(params)
+            if turn_id:
+                return turn_id
+    for msg in messages:
+        params = msg.get("params") if isinstance(msg.get("params"), dict) else {}
+        turn_id = _notification_turn_id(params)
+        if turn_id:
+            return turn_id
+    return ""
 
 
 def _item_text(item: Any) -> str:
@@ -200,6 +223,9 @@ def _record_turn_event(
         if isinstance(delta, str) and delta:
             turn._assistant_message_parts.append(delta)
             turn.agent_message_delta_count += 1
+        return False
+    if method == "turn/started":
+        turn.turn_status = _extract_turn_status(params) or turn.turn_status
         return False
     if method == "item/completed":
         turn.item_completed_count += 1
@@ -395,14 +421,18 @@ def start_codex_app_server_goal_turn(
             "params": turn_params,
         }
         _send_json(proc, turn_start)
+        turn_start_side_events: list[dict[str, Any]] = []
         turn_result = _wait_for_response(
             proc,
             responses,
             5,
             notifications=notifications,
             timeout_sec=response_timeout_sec,
+            side_events=turn_start_side_events,
         )
-        turn_id = _extract_turn_id(turn_result)
+        response_turn_id = _extract_turn_id(turn_result)
+        event_stream_turn_id = _event_stream_turn_id(turn_start_side_events)
+        turn_id = event_stream_turn_id or response_turn_id
         if not turn_id:
             raise CodexAppServerGoalDriverError("turn/start did not return turn id")
 
@@ -410,12 +440,17 @@ def start_codex_app_server_goal_turn(
             process=proc,
             thread_id=thread_id,
             turn_id=turn_id,
+            turn_id_source="event_stream" if event_stream_turn_id else "turn_start_response",
+            turn_start_response_turn_id_present=bool(response_turn_id),
+            turn_event_stream_turn_id_present=bool(event_stream_turn_id),
             next_request_id=6,
             goal_status=goal_status,
             turn_status=_extract_turn_status(turn_result),
             notifications=notifications,
             _responses=responses,
         )
+        for event in turn_start_side_events:
+            _record_turn_event(turn, event, raise_on_error=False)
         if wait_for_completion:
             _wait_for_turn_completion(
                 turn,
@@ -490,15 +525,19 @@ def start_codex_app_server_goal_followup_turn(
         "params": turn_params,
     }
     _send_json(turn.process, turn_start)
+    turn_start_side_events: list[dict[str, Any]] = []
     turn_result = _wait_for_response(
         turn.process,
         turn._responses,
         request_id,
         notifications=notifications,
         timeout_sec=response_timeout_sec,
+        side_events=turn_start_side_events,
     )
     request_id += 1
-    turn_id = _extract_turn_id(turn_result)
+    response_turn_id = _extract_turn_id(turn_result)
+    event_stream_turn_id = _event_stream_turn_id(turn_start_side_events)
+    turn_id = event_stream_turn_id or response_turn_id
     if not turn_id:
         raise CodexAppServerGoalDriverError("turn/start did not return turn id")
 
@@ -506,12 +545,17 @@ def start_codex_app_server_goal_followup_turn(
         process=turn.process,
         thread_id=turn.thread_id,
         turn_id=turn_id,
+        turn_id_source="event_stream" if event_stream_turn_id else "turn_start_response",
+        turn_start_response_turn_id_present=bool(response_turn_id),
+        turn_event_stream_turn_id_present=bool(event_stream_turn_id),
         next_request_id=request_id,
         goal_status=goal_status,
         turn_status=_extract_turn_status(turn_result),
         notifications=notifications,
         _responses=turn._responses,
     )
+    for event in turn_start_side_events:
+        _record_turn_event(followup, event, raise_on_error=False)
     if wait_for_completion:
         _wait_for_turn_completion(
             followup,
@@ -528,6 +572,13 @@ def compact_turn_metadata(turn: CodexAppServerGoalTurn) -> dict[str, Any]:
         "goal_get_present": bool(turn.goal_status),
         "goal_status": turn.goal_status,
         "turn_id_present": bool(turn.turn_id),
+        "turn_id_source": turn.turn_id_source,
+        "turn_start_response_turn_id_present": bool(
+            turn.turn_start_response_turn_id_present
+        ),
+        "turn_event_stream_turn_id_present": bool(
+            turn.turn_event_stream_turn_id_present
+        ),
         "turn_status": turn.turn_status,
         "turn_completed_observed": bool(turn.turn_completed_observed),
         "agent_message_delta_count": int(turn.agent_message_delta_count),


### PR DESCRIPTION
## Summary
- preserve app-server notifications observed while waiting for turn/start responses
- prefer the event-stream turn id when it differs from the turn/start response id
- expose public-safe compact id-source booleans and cover the protocol shape in driver and SkillsBench worker smokes

## Root Cause
Real Codex app-server runs can return a turn/start response whose turn.id differs from the subsequent event-stream turnId. The worker driver filtered item/agentMessage/delta and turn/completed against the response id, so real events were observed but not counted. That produced r12-shaped false worker timeouts and empty native-worker proof.

## Validation
- python3 -m py_compile scripts/codex_app_server_goal_driver.py scripts/skillsbench_host_codex_goal_worker.py examples/codex-app-server-goal-driver-smoke.py examples/skillsbench-app-server-goal-worker-smoke.py
- python3 examples/codex-app-server-goal-driver-smoke.py
- python3 examples/skillsbench-app-server-goal-worker-smoke.py
- real local codex app-server mini worker turn: ok=true, turn_completed_observed=true, turn_id_source=event_stream
- python3 examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-host-local-launch-plan-smoke.py
- git diff --check
- loopx check

## Boundary
Added diff lines contain no /root, /Users, .local/private, private benchmark job path, raw task marker, or credential marker.