### PR TITLE
Fix app-server goal user message echo handling

### DIFF
--- a/examples/codex-app-server-goal-driver-smoke.py
+++ b/examples/codex-app-server-goal-driver-smoke.py
@@ -39,11 +39,36 @@ for line in sys.stdin:
                 "error": {"code": -32602, "message": "missing high effort"},
             }), flush=True)
             continue
+        prompt_text = msg.get("params", {}).get("input", [{}])[0].get("text", "")
         print(json.dumps({
             "method": "turn/started",
             "params": {
                 "threadId": "thread-smoke",
                 "turn": {"id": "turn-event-smoke", "status": "inProgress"},
+            },
+        }), flush=True)
+        print(json.dumps({
+            "method": "item/started",
+            "params": {
+                "threadId": "thread-smoke",
+                "turnId": "turn-event-smoke",
+                "item": {
+                    "id": "user-item-smoke",
+                    "type": "userMessage",
+                    "content": [{"type": "text", "text": prompt_text}],
+                },
+            },
+        }), flush=True)
+        print(json.dumps({
+            "method": "item/completed",
+            "params": {
+                "threadId": "thread-smoke",
+                "turnId": "turn-event-smoke",
+                "item": {
+                    "id": "user-item-smoke",
+                    "type": "userMessage",
+                    "content": [{"type": "text", "text": prompt_text}],
+                },
             },
         }), flush=True)
         result = {"turn": {"id": "turn-response-smoke", "status": "running"}}
@@ -109,6 +134,8 @@ def main() -> int:
             assert compact["turn_start_response_turn_id_present"] is True, compact
             assert compact["turn_event_stream_turn_id_present"] is True, compact
             assert compact["turn_completed_observed"] is False
+            assert compact["user_message_item_count"] == 1, compact
+            assert compact["agent_message_item_count"] == 0, compact
             assert compact["raw_transcript_recorded"] is False
             assert "Synthetic prompt" not in json.dumps(compact)
             observed = module.observe_codex_app_server_goal_turn(
@@ -120,6 +147,8 @@ def main() -> int:
             compact = module.compact_turn_metadata(turn)
             assert compact["turn_completed_observed"] is True, compact
             assert compact["assistant_message_present"] is True, compact
+            assert compact["user_message_item_count"] == 1, compact
+            assert compact["agent_message_item_count"] == 0, compact
             assert "Synthetic final answer." not in json.dumps(compact), compact
         finally:
             turn.terminate()

--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -61,11 +61,36 @@ for line in sys.stdin:
                 "error": {"code": -32602, "message": "missing high effort"},
             }), flush=True)
             continue
+        prompt_text = msg.get("params", {}).get("input", [{}])[0].get("text", "")
         print(json.dumps({
             "method": "turn/started",
             "params": {
                 "threadId": "thread-skillsbench",
                 "turn": {"id": "turn-event-skillsbench", "status": "inProgress"},
+            },
+        }), flush=True)
+        print(json.dumps({
+            "method": "item/started",
+            "params": {
+                "threadId": "thread-skillsbench",
+                "turnId": "turn-event-skillsbench",
+                "item": {
+                    "id": "user-item-skillsbench",
+                    "type": "userMessage",
+                    "content": [{"type": "text", "text": prompt_text}],
+                },
+            },
+        }), flush=True)
+        print(json.dumps({
+            "method": "item/completed",
+            "params": {
+                "threadId": "thread-skillsbench",
+                "turnId": "turn-event-skillsbench",
+                "item": {
+                    "id": "user-item-skillsbench",
+                    "type": "userMessage",
+                    "content": [{"type": "text", "text": prompt_text}],
+                },
             },
         }), flush=True)
         result = {"turn": {"id": "turn-response-skillsbench", "status": "running"}}
@@ -113,6 +138,60 @@ for line in sys.stdin:
     elif method == "turn/start":
         result = {"turn": {"id": "turn-skillsbench", "status": "running"}}
         print(json.dumps({"id": mid, "result": result}), flush=True)
+        continue
+    else:
+        result = {}
+    print(json.dumps({"id": mid, "result": result}), flush=True)
+"""
+
+FAKE_CODEX_USER_ONLY_COMPLETED = """#!/usr/bin/env python3
+import json
+import sys
+
+for line in sys.stdin:
+    msg = json.loads(line)
+    mid = msg.get("id")
+    method = msg.get("method")
+    if method == "initialized":
+        continue
+    if method == "initialize":
+        result = {"serverInfo": {"name": "fake-codex"}}
+    elif method == "thread/start":
+        result = {"thread": {"id": "thread-skillsbench"}}
+    elif method == "thread/goal/set":
+        result = {"goal": {"threadId": "thread-skillsbench", "status": "active"}}
+    elif method == "thread/goal/get":
+        result = {"goal": {"threadId": "thread-skillsbench", "status": "active"}}
+    elif method == "turn/start":
+        prompt_text = msg.get("params", {}).get("input", [{}])[0].get("text", "")
+        print(json.dumps({
+            "method": "turn/started",
+            "params": {
+                "threadId": "thread-skillsbench",
+                "turn": {"id": "turn-user-only", "status": "inProgress"},
+            },
+        }), flush=True)
+        result = {"turn": {"id": "turn-user-only", "status": "running"}}
+        print(json.dumps({"id": mid, "result": result}), flush=True)
+        print(json.dumps({
+            "method": "item/completed",
+            "params": {
+                "threadId": "thread-skillsbench",
+                "turnId": "turn-user-only",
+                "item": {
+                    "id": "user-item-only",
+                    "type": "userMessage",
+                    "content": [{"type": "text", "text": prompt_text}],
+                },
+            },
+        }), flush=True)
+        print(json.dumps({
+            "method": "turn/completed",
+            "params": {
+                "threadId": "thread-skillsbench",
+                "turn": {"id": "turn-user-only", "status": "completed"},
+            },
+        }), flush=True)
         continue
     else:
         result = {}
@@ -452,6 +531,8 @@ def test_host_worker_waits_for_completion_and_keeps_public_json_compact() -> Non
         assert "completion_marker_observed" not in payload["turn"], payload
         assert "completion_marker_deleted" not in payload["turn"], payload
         assert payload["turn"]["assistant_message_present"] is True, payload
+        assert payload["turn"]["user_message_item_count"] == 1, payload
+        assert payload["turn"]["agent_message_item_count"] == 0, payload
         assert payload["loopx_case_lifecycle_packet_injected"] is False, payload
         assert payload["turn"]["loopx_case_lifecycle_packet_injected"] is False, payload
         assert payload["private_response_text"]["written"] is True, payload
@@ -517,6 +598,57 @@ def test_host_worker_fails_closed_on_first_action_timeout() -> None:
         assert payload["turn"]["first_action_timeout_sec"] == 1.0, payload
         assert not private_response.exists(), result
         assert not list(work.glob(".loopx_app_server_goal_worker_response_*.txt"))
+
+
+def test_host_worker_fails_closed_when_only_user_message_echo_completes() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-app-goal-worker-user-only-") as tmp:
+        root = Path(tmp)
+        fake = root / "codex"
+        prompt = root / "prompt.txt"
+        output = root / "worker.compact.json"
+        private_response = root / "private-response.txt"
+        fake.write_text(FAKE_CODEX_USER_ONLY_COMPLETED, encoding="utf-8")
+        fake.chmod(0o755)
+        prompt.write_text("Private task instruction placeholder.", encoding="utf-8")
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(WORKER_SCRIPT),
+                "--task-id",
+                "llm-prefix-cache-replay",
+                "--codex-bin",
+                str(fake),
+                "--work-dir",
+                str(root / "work"),
+                "--prompt-file",
+                str(prompt),
+                "--output-json",
+                str(output),
+                "--response-text-file",
+                str(private_response),
+                "--response-timeout-sec",
+                "5",
+                "--turn-timeout-sec",
+                "5",
+            ],
+            cwd=REPO_ROOT,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        assert result.returncode == 1, result
+        payload = json.loads(output.read_text(encoding="utf-8"))
+        assert payload["ok"] is False, payload
+        assert payload["error_type"] == "codex_app_server_no_assistant_message", payload
+        assert (
+            payload["worker_contract"]["first_blocker"]
+            == "codex_app_server_no_assistant_message"
+        ), payload
+        assert payload["turn"]["turn_completed_observed"] is True, payload
+        assert payload["turn"]["assistant_message_present"] is False, payload
+        assert payload["turn"]["user_message_item_count"] == 1, payload
+        assert payload["turn"]["non_user_item_completed_count"] == 0, payload
+        assert not private_response.exists(), result
 
 
 def test_acp_relay_delegates_to_app_server_goal_worker() -> None:

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -3118,7 +3118,11 @@ def _skillsbench_native_goal_worker_failure_label(
 ) -> str:
     if counters.get("native_goal_worker_route") is not True:
         return ""
-    if trace_status == "public_trace_observed":
+    has_worker_failure_trace = bool(
+        counters.get("native_goal_worker_failure_trace_count", 0)
+        or counters.get("native_goal_worker_failure_category")
+    )
+    if trace_status == "public_trace_observed" and not has_worker_failure_trace:
         return ""
 
     reason = ""

--- a/scripts/codex_app_server_goal_driver.py
+++ b/scripts/codex_app_server_goal_driver.py
@@ -34,6 +34,8 @@ class CodexAppServerGoalTurn:
     agent_message_delta_count: int = 0
     agent_message_item_count: int = 0
     item_completed_count: int = 0
+    non_user_item_completed_count: int = 0
+    user_message_item_count: int = 0
     notifications: list[str] = field(default_factory=list)
     _responses: "queue.Queue[dict[str, Any] | Exception] | None" = field(
         default=None,
@@ -230,8 +232,13 @@ def _record_turn_event(
     if method == "item/completed":
         turn.item_completed_count += 1
         item = params.get("item")
+        item_type = str(item.get("type") or "") if isinstance(item, dict) else ""
+        if item_type == "userMessage":
+            turn.user_message_item_count += 1
+            return False
+        turn.non_user_item_completed_count += 1
         item_text = _item_text(item)
-        if item_text:
+        if item_type == "agentMessage" and item_text:
             turn.agent_message_item_count += 1
             if not turn._assistant_message_parts:
                 turn._assistant_message_parts.append(item_text)
@@ -584,6 +591,8 @@ def compact_turn_metadata(turn: CodexAppServerGoalTurn) -> dict[str, Any]:
         "agent_message_delta_count": int(turn.agent_message_delta_count),
         "agent_message_item_count": int(turn.agent_message_item_count),
         "item_completed_count": int(turn.item_completed_count),
+        "non_user_item_completed_count": int(turn.non_user_item_completed_count),
+        "user_message_item_count": int(turn.user_message_item_count),
         "assistant_message_present": bool(assistant_message),
         "assistant_message_chars": len(assistant_message),
         "assistant_message_sha256": sha256(assistant_message.encode()).hexdigest()

--- a/scripts/skillsbench_host_codex_goal_worker.py
+++ b/scripts/skillsbench_host_codex_goal_worker.py
@@ -105,12 +105,12 @@ def _first_action_observed(turn: Any) -> bool:
         return True
     if int(getattr(turn, "agent_message_item_count", 0) or 0) > 0:
         return True
-    if int(getattr(turn, "item_completed_count", 0) or 0) > 0:
+    if int(getattr(turn, "non_user_item_completed_count", 0) or 0) > 0:
         return True
     notifications = getattr(turn, "notifications", []) or []
     for method in notifications:
         text = str(method or "")
-        if text.startswith("item/"):
+        if text.startswith("item/agentMessage"):
             return True
     return False
 
@@ -201,6 +201,12 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
                 "benchmark_case_lifecycle_contract": lifecycle_contract,
             }
         )
+        if (
+            not worker_error_type
+            and not args.no_wait_for_completion
+            and compact.get("assistant_message_present") is not True
+        ):
+            worker_error_type = "codex_app_server_no_assistant_message"
         private_response_written = False
         if args.response_text_file and turn.assistant_message:
             response_path = Path(args.response_text_file).expanduser()


### PR DESCRIPTION
## Summary\n- ignore app-server userMessage completion events when collecting assistant output\n- fail closed when a native SkillsBench goal worker completes without a real assistant message\n- keep worker failure traces authoritative for native baseline countability\n- add smokes for userMessage echo and user-only completion cases\n\n## Validation\n- python3 -m py_compile scripts/codex_app_server_goal_driver.py scripts/skillsbench_host_codex_goal_worker.py loopx/benchmark_adapters/skillsbench.py examples/codex-app-server-goal-driver-smoke.py examples/skillsbench-app-server-goal-worker-smoke.py\n- python3 examples/codex-app-server-goal-driver-smoke.py\n- python3 examples/skillsbench-app-server-goal-worker-smoke.py\n- python3 examples/skillsbench-benchmark-run-smoke.py\n- python3 examples/benchmark-run-ledger-smoke.py\n- git diff --check\n- loopx check\n