### PR TITLE
Improve auto-research one-click demo readiness

### DIFF
--- a/docs/guides/auto-research-command-path.md
+++ b/docs/guides/auto-research-command-path.md
@@ -75,13 +75,19 @@ The default visible digital employees are:
 
 | Pane | Role | What it owns |
 | --- | --- | --- |
-| `codex-product-capability:research-curator` | Research curator | Keeps the research contract, protected boundary, metric, stop policy, and operator gates explicit. |
+| `codex-product-capability:research-curator` | Research curator | Keeps the research contract, protected boundary, metric, stop policy, evidence review, and operator gates explicit. |
 | `codex-side-bypass:hypothesis-mapper` | Hypothesis mapper | Turns ideas into todo-backed hypotheses, successor links, and retirement rationale. |
-| `codex-main-control:evidence-runner` | Evidence runner | Executes one selected hypothesis in an isolated workspace and preserves scored or unscored evidence. |
-| `codex-value-explorer:evidence-verifier` | Evidence verifier | Classifies evidence into supported, contradicted, retry-needed, promotion-ready, or retired states. |
+| `codex-main-control:evidence-runner` | Evidence runner | Executes one selected hypothesis under an isolated attempt boundary when mutation is required and preserves scored or unscored evidence. |
 
 Each pane must route through its own quota/frontier/bootstrap path. The
-supervisor only makes those panes visible.
+supervisor only makes those panes visible. The panes share the same LoopX
+goal surface: registry, runtime root, frontier, todo projection, and evidence
+graph. Do not move every pane into an unrelated empty workspace; isolate only
+mutating evidence-runner attempts with a claimed git worktree or equivalent
+execution boundary.
+
+For compatibility or product experiments, `--agent` can still name explicit
+lanes, including a separate evidence-verifier lane.
 
 ## 3. Render The Acceptance Packet
 

--- a/docs/product/decentralized-auto-research-showcase.md
+++ b/docs/product/decentralized-auto-research-showcase.md
@@ -292,9 +292,11 @@ loopx --format json auto-research demo-supervisor \
 ```
 
 The third segment is optional for compatibility; when omitted, LoopX infers the
-role from the lane name or from the default role order. The v0 default still
-uses the four logical roles from `auto_research_role_state_machine_v0`:
-research curator, hypothesis mapper, evidence runner, and evidence verifier.
+role from the lane name or from the default role order. The v0 default uses
+three registered lanes: research curator, hypothesis mapper, and evidence
+runner. Evidence review is folded into the curator lane until a separately
+registered verifier lane is needed. The explicit `--agent` form remains the
+escape hatch for rehearsing a four-role layout.
 
 When the dry-run packet is acceptable, the same command can launch visible
 local Codex CLI TUIs. This is intentionally opt-in:
@@ -322,6 +324,10 @@ own role profile, then runs `quota should-run`, then renders its own
 only then starts `codex` with that visible bootstrap prompt. The launcher
 itself does not write LoopX state or spend LoopX quota; any writeback must
 happen through the visible Codex lane's normal LoopX todo/evidence commands.
+All lanes share the same LoopX goal surface: registry, runtime root, frontier,
+todo projection, and evidence graph. Workspace isolation is not applied to
+every pane by default; only mutating evidence-runner attempts need a claimed
+git worktree or equivalent execution boundary.
 
 For a tighter user handoff, render the demo acceptance packet. It links the
 experimental board output, the dry-run supervisor plan, and the takeover
@@ -358,9 +364,12 @@ The user should see four concrete things in the packet:
 
 - `mode: dry_run`, plus a boundary block showing `starts_tmux`,
   `runs_codex`, `writes_loopx_state`, and `spends_loopx_quota` are all false;
-- one pane plan per digital worker lane, with that lane's own
+- one pane plan per default digital worker lane, with that lane's own
   `auto_research_role_profile_v0`, `quota should-run`, `auto-research
   frontier`, and `codex-cli-bootstrap-message` commands;
+- a shared goal-surface contract showing that all panes use the same LoopX
+  registry/runtime/frontier/evidence graph, while mutation isolation is reserved
+  for evidence-runner attempts;
 - a `start_script` array that can be copied into the user's shell only after
   the user sets `LOOPX_PROJECT`, `LOOPX_REGISTRY`, and
   `LOOPX_RUNTIME_ROOT`;

--- a/examples/auto-research-demo-supervisor-smoke.py
+++ b/examples/auto-research-demo-supervisor-smoke.py
@@ -54,6 +54,23 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
     assert payload["goal_id"] == GOAL_ID, payload
     assert payload["coordination_model"]["leader_agent_required"] is False, payload
     assert payload["coordination_model"]["supervisor_role"] == "host_shell_layout_only", payload
+    assert "quota_should_run" in payload["coordination_model"]["source_of_truth"], payload
+    surface = payload["goal_surface"]
+    assert surface["schema_version"] == "auto_research_shared_goal_surface_v0", surface
+    assert surface["shared_goal_id"] == GOAL_ID, surface
+    assert surface["lane_count"] == 4, surface
+    assert surface["lane_ids"] == [
+        "research-curator",
+        "hypothesis-mapper",
+        "evidence-runner",
+        "evidence-verifier",
+    ], surface
+    assert surface["uses_default_lanes"] is False, surface
+    assert surface["default_lane_count"] == 3, surface
+    assert surface["shared_frontier"] is True, surface
+    assert surface["all_lane_workspace_isolation"] is False, surface
+    assert "mutating evidence-runner attempts" in surface["mutation_isolation_policy"], surface
+    assert surface["explicit_agent_override"] is True, surface
 
     lanes = payload["lanes"]
     assert [lane["lane_id"] for lane in lanes] == [
@@ -89,6 +106,8 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
         assert "auto-research frontier" in lane["frontier"], lane
         assert "codex-cli-bootstrap-message" in lane["bootstrap_message"], lane
         assert "[LoopX role profile]" in lane["visible_launch_command"], lane
+        assert "[LoopX visible acceptance]" in lane["visible_launch_command"], lane
+        assert "LOOPX_VISIBLE_BOOTSTRAP_PAUSE_SECONDS" in lane["visible_launch_command"], lane
         assert "LOOPX_ROLE_PROFILE_JSON" in lane["visible_launch_command"], lane
         assert "LOOPX_REQUIRED_SKILL" in lane["visible_launch_command"], lane
         assert "bootstrap-or-stop" in lane["visible_launch_command"], lane
@@ -154,6 +173,9 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
     assert boundary["mutates_codex_session"] is False, payload
     assert boundary["writes_loopx_state"] is False, payload
     assert boundary["spends_loopx_quota"] is False, payload
+    assert boundary["shared_goal_surface"] is True, payload
+    assert boundary["all_lane_workspace_isolation"] is False, payload
+    assert "mutating evidence-runner attempts" in boundary["mutation_isolation_policy"], payload
     assert payload["future_gates"][0]["capability"] == "execute_start_script", payload
     assert_no_private_surface(payload)
 
@@ -188,6 +210,34 @@ def run_cli_json() -> dict[str, Any]:
 
 
 def main() -> int:
+    default_payload = build_auto_research_demo_supervisor_plan(
+        goal_id=GOAL_ID,
+    )
+    assert [lane["agent_id"] for lane in default_payload["lanes"]] == [
+        "codex-product-capability",
+        "codex-side-bypass",
+        "codex-main-control",
+    ], default_payload
+    assert [lane["lane_id"] for lane in default_payload["lanes"]] == [
+        "research-curator",
+        "hypothesis-mapper",
+        "evidence-runner",
+    ], default_payload
+    assert default_payload["goal_surface"]["lane_count"] == 3, default_payload
+    assert default_payload["goal_surface"]["lane_ids"] == [
+        "research-curator",
+        "hypothesis-mapper",
+        "evidence-runner",
+    ], default_payload
+    assert default_payload["goal_surface"]["uses_default_lanes"] is True, default_payload
+    assert default_payload["goal_surface"]["default_lane_count"] == 3, default_payload
+    assert default_payload["goal_surface"]["default_lane_ids"] == [
+        "research-curator",
+        "hypothesis-mapper",
+        "evidence-runner",
+    ], default_payload
+    assert "codex-value-explorer" not in json.dumps(default_payload), default_payload
+
     payload = build_auto_research_demo_supervisor_plan(
         goal_id=GOAL_ID,
         agent_specs=LANES,

--- a/examples/auto-research-visible-launcher-smoke.py
+++ b/examples/auto-research-visible-launcher-smoke.py
@@ -19,7 +19,6 @@ LANES = [
     "codex-product-capability:research-curator:research_curator",
     "codex-side-bypass:hypothesis-mapper:hypothesis_mapper",
     "codex-main-control:evidence-runner:evidence_runner",
-    "codex-value-explorer:evidence-verifier:evidence_verifier",
 ]
 
 
@@ -64,7 +63,7 @@ def main() -> int:
                 [
                     "#!/usr/bin/env python3",
                     "import json, os, sys",
-                    f"LANES = {json.dumps(['frontier', 'research-curator', 'hypothesis-mapper', 'evidence-runner', 'evidence-verifier'])}",
+                    f"LANES = {json.dumps(['frontier', 'research-curator', 'hypothesis-mapper', 'evidence-runner'])}",
                     "with open(os.environ['FAKE_TMUX_LOG'], 'a', encoding='utf-8') as f:",
                     "    f.write(json.dumps(sys.argv[1:]) + '\\n')",
                     "if len(sys.argv) > 1 and sys.argv[1] == 'has-session':",
@@ -73,13 +72,18 @@ def main() -> int:
                     "    print('\\n'.join(LANES))",
                     "    raise SystemExit(0)",
                     "if len(sys.argv) > 1 and sys.argv[1] == 'capture-pane':",
+                    "    print('[LoopX visible acceptance]')",
                     "    print('[LoopX role profile]')",
+                    "    print('role_profile=printed')",
                     "    print('lane_id=' + (sys.argv[sys.argv.index('-pt') + 1].split(':')[-1] if '-pt' in sys.argv else 'unknown'))",
                     "    print('[LoopX quota guard]')",
+                    "    print('quota_guard=printed')",
                     "    print('{\"interaction_contract\":{\"user_channel\":{\"action_required\":false},\"agent_channel\":{\"delivery_allowed\":true}}}')",
                     "    print('[LoopX auto-research frontier]')",
+                    "    print('frontier_or_blocked_reason=printed')",
                     "    print('{\"schema_version\":\"decentralized_research_frontier_v0\"}')",
                     "    print('[bootstrap-or-stop]')",
+                    "    print('bootstrap_or_stop=printed')",
                     "    print('continuing_to_visible_bootstrap')",
                     "    raise SystemExit(0)",
                     "raise SystemExit(0)",
@@ -112,14 +116,6 @@ def main() -> int:
                 GOAL_ID,
                 "--session-name",
                 "loopx-auto-research-smoke",
-                "--agent",
-                LANES[0],
-                "--agent",
-                LANES[1],
-                "--agent",
-                LANES[2],
-                "--agent",
-                LANES[3],
                 "--execute",
                 "--launcher",
                 "tmux",
@@ -143,15 +139,17 @@ def main() -> int:
         assert payload["boundary"]["workspace_mode"] == "explicit_workspace", payload
         assert payload["boundary"]["workspace_write_scope"] == "user_selected_workspace_only", payload
         assert payload["boundary"]["shared_state_route"] == "LOOPX_REGISTRY_and_LOOPX_RUNTIME_ROOT", payload
+        assert payload["boundary"]["shared_goal_surface"] is True, payload
+        assert payload["boundary"]["all_lane_workspace_isolation"] is False, payload
+        assert "mutating evidence-runner attempts" in payload["boundary"]["mutation_isolation_policy"], payload
         launch = payload["launch_result"]
         assert launch["launcher"] == "tmux", launch
-        assert launch["started_lane_count"] == 4, launch
-        assert launch["surviving_lane_count"] == 4, launch
+        assert launch["started_lane_count"] == 3, launch
+        assert launch["surviving_lane_count"] == 3, launch
         assert launch["surviving_lanes"] == [
             "research-curator",
             "hypothesis-mapper",
             "evidence-runner",
-            "evidence-verifier",
         ], launch
         assert launch["attach_command"] == "tmux attach -t loopx-auto-research-smoke", launch
         assert launch["stop_command"] == "tmux kill-session -t loopx-auto-research-smoke", launch
@@ -166,6 +164,8 @@ def main() -> int:
             assert pane["quota_packet_visible"] is True, pane
             assert pane["frontier_or_blocked_reason_visible"] is True, pane
             assert pane["bootstrap_or_stop_visible"] is True, pane
+            assert pane["visible_acceptance_summary"] is True, pane
+            assert "[LoopX visible acceptance]" in pane["markers_present"], pane
         assert workspace.is_dir(), workspace
 
         for lane in payload["lanes"]:
@@ -191,14 +191,19 @@ def main() -> int:
             assert "auto-research frontier" in command, command
             assert "codex-cli-bootstrap-message" in command, command
             assert "bootstrap-or-stop" in command, command
-            assert 'exec codex "$BOOTSTRAP_PROMPT"' in command, command
+            assert "[LoopX visible acceptance]" in command, command
+            assert "LOOPX_VISIBLE_BOOTSTRAP_PAUSE_SECONDS" in command, command
+            assert 'codex "$BOOTSTRAP_PROMPT"' in command, command
+            assert "[Codex CLI exited]" in command, command
+            assert "inspect this pane; interrupt, close, or retry manually" in command, command
+            assert "exec /bin/sh -i" in command, command
 
         log_entries = [json.loads(line) for line in tmux_log.read_text(encoding="utf-8").splitlines()]
         assert log_entries[0][:1] == ["has-session"], log_entries
         assert any(entry[:1] == ["new-session"] for entry in log_entries), log_entries
-        assert sum(1 for entry in log_entries if entry[:1] == ["new-window"]) == 4, log_entries
+        assert sum(1 for entry in log_entries if entry[:1] == ["new-window"]) == 3, log_entries
         assert any(entry[:1] == ["list-windows"] for entry in log_entries), log_entries
-        assert sum(1 for entry in log_entries if entry[:1] == ["capture-pane"]) == 4, log_entries
+        assert sum(1 for entry in log_entries if entry[:1] == ["capture-pane"]) == 3, log_entries
         assert_public_safe(payload)
 
     print("auto-research-visible-launcher-smoke ok")

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -342,9 +342,10 @@ def _runtime_shell_command(
     project: Path,
     registry: Path,
     runtime_root: Path,
+    errexit: bool = True,
 ) -> str:
     exports = [
-        "set -euo pipefail",
+        "set -euo pipefail" if errexit else "set -uo pipefail",
         f"export LOOPX_PROJECT={shlex.quote(str(project))}",
         f"export LOOPX_REGISTRY={shlex.quote(str(registry))}",
         f"export LOOPX_RUNTIME_ROOT={shlex.quote(str(runtime_root))}",
@@ -438,10 +439,14 @@ def _launch_auto_research_with_tmux(
     if not first_frontier:
         raise ValueError("first lane is missing a frontier command")
     frontier_command = _runtime_shell_command(
-        f'cd "$LOOPX_PROJECT"; {first_frontier}',
+        f'cd "$LOOPX_PROJECT"; {first_frontier}; '
+        'FRONTIER_STATUS=$?; '
+        'printf "\\n[frontier window ready]\\nexit=%s\\n" "$FRONTIER_STATUS"; '
+        'exec /bin/sh -i',
         project=project,
         registry=registry,
         runtime_root=runtime_root,
+        errexit=False,
     )
     subprocess.run(
         [tmux_bin, "new-session", "-d", "-s", session, "-n", "frontier", "bash", "-lc", frontier_command],
@@ -470,6 +475,7 @@ def _launch_auto_research_with_tmux(
                     project=project,
                     registry=registry,
                     runtime_root=runtime_root,
+                    errexit=False,
                 ),
             ],
             check=True,
@@ -511,77 +517,109 @@ def _tmux_visible_launch_acceptance(
 ) -> dict[str, object]:
     """Read back tmux pane evidence so launch success is not only process creation."""
 
-    # Give shells a short moment to render preflight markers before capture.
-    time.sleep(0.2)
-    list_result = subprocess.run(
-        [tmux_bin, "list-windows", "-t", session, "-F", "#{window_name}"],
-        check=False,
-        capture_output=True,
-        text=True,
-        env=env,
-    )
-    observed_windows = [
-        line.strip()
-        for line in list_result.stdout.splitlines()
-        if line.strip()
-    ]
-    surviving_lanes = [lane for lane in expected_lanes if lane in observed_windows]
     required_markers = [
         "[LoopX quota guard]",
         "[bootstrap-or-stop]",
     ]
-    lane_checks: list[dict[str, object]] = []
-    for lane in expected_lanes:
-        capture_result = subprocess.run(
-            [tmux_bin, "capture-pane", "-pt", f"{session}:{lane}", "-S", "-200"],
+    last_payload: dict[str, object] | None = None
+    for attempt in range(20):
+        time.sleep(0.25)
+        list_result = subprocess.run(
+            [tmux_bin, "list-windows", "-t", session, "-F", "#{window_name}"],
             check=False,
             capture_output=True,
             text=True,
             env=env,
         )
-        capture = capture_result.stdout
-        role_profile_visible = (
-            "[LoopX role profile]" in capture
-            or "[LoopX role_profile]" in capture
+        observed_windows = [
+            line.strip()
+            for line in list_result.stdout.splitlines()
+            if line.strip()
+        ]
+        surviving_lanes = [lane for lane in expected_lanes if lane in observed_windows]
+        lane_checks: list[dict[str, object]] = []
+        for lane in expected_lanes:
+            capture_result = subprocess.run(
+                [tmux_bin, "capture-pane", "-pt", f"{session}:{lane}", "-S", "-200"],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+            capture = capture_result.stdout
+            visible_summary = "[LoopX visible acceptance]" in capture
+            role_profile_visible = (
+                "[LoopX role profile]" in capture
+                or "[LoopX role_profile]" in capture
+                or "role_profile=printed" in capture
+            )
+            quota_packet_visible = (
+                "[LoopX quota guard]" in capture
+                or "quota_guard=printed" in capture
+            )
+            bootstrap_or_stop_visible = (
+                "[bootstrap-or-stop]" in capture
+                or "bootstrap_or_stop=printed" in capture
+            )
+            markers_present = [marker for marker in required_markers if marker in capture]
+            if visible_summary:
+                markers_present.insert(0, "[LoopX visible acceptance]")
+            if role_profile_visible:
+                markers_present.insert(0, "[LoopX role profile]")
+            frontier_or_blocker_visible = (
+                "[LoopX auto-research frontier]" in capture
+                or "[LoopX blocked reason]" in capture
+                or "frontier_or_blocked_reason=printed" in capture
+            )
+            lane_checks.append(
+                {
+                    "lane_id": lane,
+                    "window_survived": lane in surviving_lanes,
+                    "capture_available": capture_result.returncode == 0,
+                    "role_profile_visible": role_profile_visible,
+                    "quota_packet_visible": quota_packet_visible,
+                    "frontier_or_blocked_reason_visible": frontier_or_blocker_visible,
+                    "bootstrap_or_stop_visible": bootstrap_or_stop_visible,
+                    "visible_acceptance_summary": visible_summary,
+                    "markers_present": markers_present,
+                }
+            )
+        accepted = (
+            list_result.returncode == 0
+            and len(surviving_lanes) == len(expected_lanes)
+            and all(
+                item["role_profile_visible"]
+                and item["quota_packet_visible"]
+                and item["frontier_or_blocked_reason_visible"]
+                and item["bootstrap_or_stop_visible"]
+                for item in lane_checks
+            )
         )
-        markers_present = [marker for marker in required_markers if marker in capture]
-        if role_profile_visible:
-            markers_present.insert(0, "[LoopX role profile]")
-        frontier_or_blocker_visible = (
-            "[LoopX auto-research frontier]" in capture
-            or "[LoopX blocked reason]" in capture
-        )
-        lane_checks.append(
-            {
-                "lane_id": lane,
-                "window_survived": lane in surviving_lanes,
-                "capture_available": capture_result.returncode == 0,
-                "role_profile_visible": role_profile_visible,
-                "quota_packet_visible": "[LoopX quota guard]" in capture,
-                "frontier_or_blocked_reason_visible": frontier_or_blocker_visible,
-                "bootstrap_or_stop_visible": "[bootstrap-or-stop]" in capture,
-                "markers_present": markers_present,
-            }
-        )
-    accepted = (
-        list_result.returncode == 0
-        and len(surviving_lanes) == len(expected_lanes)
-        and all(
-            item["role_profile_visible"]
-            and item["quota_packet_visible"]
-            and item["frontier_or_blocked_reason_visible"]
-            and item["bootstrap_or_stop_visible"]
-            for item in lane_checks
-        )
-    )
-    return {
+        last_payload = {
+            "schema_version": "auto_research_visible_launch_acceptance_v0",
+            "accepted": accepted,
+            "attempt_count": attempt + 1,
+            "observed_windows": observed_windows,
+            "expected_lanes": expected_lanes,
+            "surviving_lanes": surviving_lanes,
+            "missing_lanes": [lane for lane in expected_lanes if lane not in surviving_lanes],
+            "pane_checks": lane_checks,
+            "takeover_controls_visible": {
+                "attach_command": f"{tmux_bin} attach -t {session}",
+                "stop_command": f"{tmux_bin} kill-session -t {session}",
+            },
+        }
+        if accepted:
+            return last_payload
+    return last_payload or {
         "schema_version": "auto_research_visible_launch_acceptance_v0",
-        "accepted": accepted,
-        "observed_windows": observed_windows,
+        "accepted": False,
+        "attempt_count": 0,
+        "observed_windows": [],
         "expected_lanes": expected_lanes,
-        "surviving_lanes": surviving_lanes,
-        "missing_lanes": [lane for lane in expected_lanes if lane not in surviving_lanes],
-        "pane_checks": lane_checks,
+        "surviving_lanes": [],
+        "missing_lanes": expected_lanes,
+        "pane_checks": [],
         "takeover_controls_visible": {
             "attach_command": f"{tmux_bin} attach -t {session}",
             "stop_command": f"{tmux_bin} kill-session -t {session}",
@@ -714,6 +752,12 @@ def _execute_auto_research_demo_supervisor(
                 "workspace_mode": workspace_mode,
                 "workspace_write_scope": "user_selected_workspace_only",
                 "shared_state_route": "LOOPX_REGISTRY_and_LOOPX_RUNTIME_ROOT",
+                "shared_goal_surface": True,
+                "all_lane_workspace_isolation": False,
+                "mutation_isolation_policy": (
+                    "only mutating evidence-runner attempts require a claimed git worktree "
+                    "or equivalent execution boundary"
+                ),
             }
         )
     return payload

--- a/loopx/capabilities/auto_research/core.py
+++ b/loopx/capabilities/auto_research/core.py
@@ -35,7 +35,7 @@ AUTO_RESEARCH_DEMO_DEFAULT_LANES = (
         "codex-product-capability",
         "research-curator",
         "research_curator",
-        "Keep the research contract, protected boundary, metric, stop policy, and operator gates explicit.",
+        "Keep the research contract, protected boundary, metric, stop policy, evidence review, and operator gates explicit.",
     ),
     (
         "codex-side-bypass",
@@ -47,13 +47,7 @@ AUTO_RESEARCH_DEMO_DEFAULT_LANES = (
         "codex-main-control",
         "evidence-runner",
         "evidence_runner",
-        "Execute one selected hypothesis in an isolated workspace and preserve scored or unscored evidence.",
-    ),
-    (
-        "codex-value-explorer",
-        "evidence-verifier",
-        "evidence_verifier",
-        "Classify evidence into supported, contradicted, retry-needed, promotion-ready, or retired states.",
+        "Execute one selected hypothesis under an isolated attempt boundary and preserve scored or unscored evidence.",
     ),
 )
 AUTO_RESEARCH_ROLE_PROFILE_REF = AUTO_RESEARCH_ROLE_PROFILE_SCHEMA_VERSION
@@ -992,7 +986,19 @@ def _env_lane_launch_command(
     role_profile: dict[str, Any],
 ) -> str:
     role_profile_prefix = _role_profile_shell_prefix(role_profile)
-    keep_visible = 'printf "\\n[user takeover]\\ninspect this pane; interrupt, close, or retry manually\\n"; exec "${SHELL:-/bin/sh}"'
+    visible_summary = (
+        'printf "\\n[LoopX visible acceptance]\\n"; '
+        'printf "role_profile=printed\\n"; '
+        'printf "quota_guard=printed\\n"; '
+        'printf "frontier_or_blocked_reason=printed\\n"; '
+        'printf "bootstrap_or_stop=printed\\n"; '
+        'printf "takeover_controls=visible\\n"'
+    )
+    keep_visible = (
+        f"{visible_summary}; "
+        'printf "\\n[user takeover]\\ninspect this pane; interrupt, close, or retry manually\\n"; '
+        "exec /bin/sh -i"
+    )
     return (
         "set -uo pipefail; "
         f"export LOOPX_ROLE_ID={_shell_arg(role_id)}; "
@@ -1037,8 +1043,13 @@ def _env_lane_launch_command(
         "printf '\\n[bootstrap-or-stop]\\nstopped_before_codex\\n'; "
         f"{keep_visible}; "
         "fi; "
+        f"{visible_summary}; "
+        'sleep "${LOOPX_VISIBLE_BOOTSTRAP_PAUSE_SECONDS:-1}"; '
         "printf '\\n[Starting visible Codex CLI]\\n'; "
-        f"exec {_shell_arg(codex_bin)} \"$BOOTSTRAP_PROMPT\""
+        f"{_shell_arg(codex_bin)} \"$BOOTSTRAP_PROMPT\"; "
+        "CODEX_STATUS=$?; "
+        "printf '\\n[Codex CLI exited]\\nexit=%s\\n' \"$CODEX_STATUS\"; "
+        f"{keep_visible}"
     )
 
 
@@ -1086,7 +1097,12 @@ def build_auto_research_demo_supervisor_plan(
     cli = _compact_public_token(cli_bin, field="cli_bin")
     codex = _compact_public_token(codex_bin, field="codex_bin")
     tmux = _compact_public_token(tmux_bin, field="tmux_bin")
+    uses_default_lanes = agent_specs is None
     lanes = _demo_lane_specs(agent_specs)
+    default_lane_ids = [
+        lane_id
+        for _agent_id, lane_id, _role_id, _responsibility in AUTO_RESEARCH_DEMO_DEFAULT_LANES
+    ]
 
     pane_plans: list[dict[str, Any]] = []
     for lane in lanes:
@@ -1165,7 +1181,7 @@ def build_auto_research_demo_supervisor_plan(
         )
 
     env_lines = [
-        "set -euo pipefail",
+        "set -uo pipefail",
         ": ${LOOPX_PROJECT:?set LOOPX_PROJECT to the repo root before running}",
         ": ${LOOPX_REGISTRY:?set LOOPX_REGISTRY to the LoopX registry path before running}",
         ": ${LOOPX_RUNTIME_ROOT:?set LOOPX_RUNTIME_ROOT to the LoopX runtime root before running}",
@@ -1173,6 +1189,9 @@ def build_auto_research_demo_supervisor_plan(
     frontier_launch_command = (
         'cd "$LOOPX_PROJECT"; '
         + _env_frontier_command(cli_bin=cli, goal_id=goal, agent_id=lanes[0]["agent_id"])
+        + '; FRONTIER_STATUS=$?; '
+        + 'printf "\\n[frontier window ready]\\nexit=%s\\n" "$FRONTIER_STATUS"; '
+        + 'exec /bin/sh -i'
     )
     start_script = [
         *env_lines,
@@ -1221,6 +1240,24 @@ def build_auto_research_demo_supervisor_plan(
                 "research_evidence_graph",
             ],
             "decentralized_rule": "each lane reads its own quota/frontier projection and writes back through normal LoopX todo/evidence APIs",
+        },
+        "goal_surface": {
+            "schema_version": "auto_research_shared_goal_surface_v0",
+            "shared_goal_id": goal,
+            "lane_count": len(pane_plans),
+            "lane_ids": [str(pane["lane_id"]) for pane in pane_plans],
+            "uses_default_lanes": uses_default_lanes,
+            "default_lane_count": len(default_lane_ids),
+            "default_lane_ids": default_lane_ids,
+            "shared_state_route": "LOOPX_REGISTRY_and_LOOPX_RUNTIME_ROOT",
+            "shared_frontier": True,
+            "lane_identity_source": "role_profile_v0_plus_agent_scoped_quota",
+            "all_lane_workspace_isolation": False,
+            "mutation_isolation_policy": (
+                "only mutating evidence-runner attempts require a claimed git worktree "
+                "or equivalent execution boundary"
+            ),
+            "explicit_agent_override": True,
         },
         "lanes": pane_plans,
         "commands": {
@@ -1330,6 +1367,12 @@ def build_auto_research_demo_supervisor_plan(
             "writes_loopx_state": False,
             "spends_loopx_quota": False,
             "external_service_call": False,
+            "shared_goal_surface": True,
+            "all_lane_workspace_isolation": False,
+            "mutation_isolation_policy": (
+                "only mutating evidence-runner attempts require a claimed git worktree "
+                "or equivalent execution boundary"
+            ),
         },
         "operator_notes": [
             "Set LOOPX_PROJECT, LOOPX_REGISTRY, and LOOPX_RUNTIME_ROOT in the user shell before running the script.",


### PR DESCRIPTION
## Summary

- Keep the auto-research visible demo panes alive long enough for user takeover and automated acceptance readback.
- Make the default demo three registered lanes sharing the same LoopX goal surface; explicit `--agent` remains the escape hatch for four-role rehearsals.
- Add shared goal-surface metadata plus focused smokes and docs so the launcher contract does not drift back to empty per-pane workspaces.

## Validation

- `python3 -m compileall loopx/capabilities/auto_research`
- `python3 examples/auto-research-demo-supervisor-smoke.py`
- `python3 examples/auto-research-visible-launcher-smoke.py`
- `python3 examples/auto-research-demo-acceptance-smoke.py`
- `git diff --check origin/main...HEAD`
- `loopx check --scan-path ...` on the six changed public files: errors=0, public boundary scan clean; existing duplicate-index warning only
- Real tmux launch rehearsal: 3 started lanes, 3 surviving lanes, visible acceptance accepted, shared goal surface true, all-lane workspace isolation false

## Boundary

No benchmark scoring, protected evaluator, credentials, raw logs, private state, production action, or public evidence-policy behavior changed.
