### PR TITLE
Fix SkillsBench bridge attempt accounting

### DIFF
--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -1586,6 +1586,144 @@ time.sleep(30)
         proc.wait(timeout=2)
 
 
+def test_acp_relay_yields_after_task_facing_exec_quiet_timeout() -> None:
+    fake_worker = """#!/usr/bin/env python3
+import argparse
+import json
+import subprocess
+import time
+from pathlib import Path
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--prompt-file")
+args, _ = parser.parse_known_args()
+prompt = Path(args.prompt_file).read_text(encoding="utf-8")
+bridge = prompt.split("Private bridge command:\\n", 1)[1].splitlines()[0].strip()
+payload = {
+    "operation": "exec",
+    "command": "printf '{\\"ok\\": true}\\n' > /tmp/task-output.json",
+}
+subprocess.run(
+    bridge,
+    input=json.dumps(payload),
+    shell=True,
+    text=True,
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+)
+time.sleep(30)
+"""
+    with tempfile.TemporaryDirectory(prefix="skillsbench-app-goal-exec-quiet-") as tmp:
+        root = Path(tmp)
+        worker = root / "fake_worker.py"
+        work = root / "work"
+        trace_dir = root / "worker-traces"
+        worker.write_text(fake_worker, encoding="utf-8")
+        worker.chmod(0o755)
+        work.mkdir()
+        bridge_command = (
+            f"{sys.executable} "
+            f"{REPO_ROOT / 'scripts' / 'skillsbench_remote_command_file_bridge.py'} "
+            "--serve-probe"
+        )
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "skillsbench_local_acp_relay.py"),
+                "--app-server-goal-worker",
+                "--task-id",
+                "llm-prefix-cache-replay",
+                "--worker-script",
+                str(worker),
+                "--timeout-sec",
+                "20",
+                "--first-action-timeout-sec",
+                "5",
+                "--bridge-idle-timeout-sec",
+                "30",
+                "--task-output-quiet-timeout-sec",
+                "1",
+                "--remote-command-file-bridge-command",
+                bridge_command,
+                "--worker-public-trace-dir",
+                str(trace_dir),
+            ],
+            cwd=REPO_ROOT,
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        assert proc.stdin is not None
+        assert proc.stdout is not None
+
+        def send(message: dict[str, Any]) -> None:
+            proc.stdin.write(json.dumps(message) + "\n")
+            proc.stdin.flush()
+
+        def read_response(request_id: int) -> dict[str, Any]:
+            deadline = time.monotonic() + 10
+            while time.monotonic() < deadline:
+                line = proc.stdout.readline()
+                assert line, proc.stderr.read()
+                message = json.loads(line)
+                if message.get("id") == request_id and "method" not in message:
+                    return message
+            raise AssertionError(proc.stderr.read())
+
+        send({"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}})
+        read_response(1)
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "session/new",
+                "params": {"cwd": str(work), "mcpServers": []},
+            }
+        )
+        session_id = read_response(2)["result"]["sessionId"]
+        send(
+            {
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "session/prompt",
+                "params": {
+                    "sessionId": session_id,
+                    "prompt": [{"type": "text", "text": "private task placeholder"}],
+                },
+            }
+        )
+        final_response = read_response(3)
+        assert "result" in final_response, final_response
+        assert final_response["result"]["stopReason"] == "end_turn", final_response
+        traces = [
+            json.loads(path.read_text(encoding="utf-8"))
+            for path in sorted(trace_dir.glob("*.compact.json"))
+        ]
+        failure_traces = [
+            item
+            for item in traces
+            if item.get("trace_kind") == "host_worker_process_failure"
+        ]
+        assert len(failure_traces) == 1, traces
+        trace = failure_traces[0]
+        assert trace["worker_process"]["stage"] == "task_output_quiet_timeout", trace
+        bridge_traces = [
+            item
+            for item in traces
+            if item.get("trace_kind") == "remote_command_file_bridge_agent_operations"
+        ]
+        assert len(bridge_traces) == 1, traces
+        agent_ops = bridge_traces[0]["remote_command_file_bridge_agent_operations"]
+        assert agent_ops["operation_counts"]["exec"] == 1, bridge_traces
+        assert agent_ops["task_facing_success_count"] == 1, bridge_traces
+        trace_text = json.dumps(traces, sort_keys=True)
+        assert "private task placeholder" not in trace_text, traces
+        assert str(work) not in trace_text, traces
+        proc.terminate()
+        proc.wait(timeout=2)
+
+
 def test_full_run_fails_closed_until_bridge_is_materialized() -> None:
     result = subprocess.run(
         [

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -7223,6 +7223,102 @@ def test_skillsbench_round_trace_records_best_round_score() -> None:
             "failure_class"
         ] == "job_materialization_failed", no_assistant_compact
 
+        bridge_quiet_result_path = write_official_skillsbench_result(
+            root / "native-worker-bridge-quiet-result",
+            reward=0.0,
+            task_id="adaptive-cruise-control",
+        )
+        bridge_quiet_result = json.loads(
+            bridge_quiet_result_path.read_text(encoding="utf-8")
+        )
+        bridge_quiet_result["error"] = "codex_exec_task_output_quiet_timeout"
+        write_json(bridge_quiet_result_path, bridge_quiet_result)
+        bridge_quiet_trace = {
+            "schema_version": "skillsbench_loopx_controller_trace_v0",
+            "route": "codex-app-server-goal-baseline",
+            "trace_publicness": "public_counts_only_no_task_text_no_verifier_output",
+            "native_goal_worker_route": True,
+            "native_goal_worker_connected": True,
+            "native_goal_worker_connect_count": 1,
+            "native_goal_worker_trace_dir_present": True,
+            "native_goal_worker_public_trace_read": True,
+            "native_goal_worker_trace_count": 4,
+            "native_goal_worker_lifecycle_trace_count": 3,
+            "native_goal_worker_prompt_received_count": 1,
+            "native_goal_worker_failure_trace_count": 1,
+            "native_goal_worker_failure_category": "codex_exec_task_output_quiet_timeout",
+            "native_goal_worker_first_blocker": "task_output_quiet_timeout",
+            "remote_command_file_bridge_agent_operation_trace_status": (
+                "agent_operation_trace_recorded"
+            ),
+            "remote_command_file_bridge_agent_operation_trace_satisfied": True,
+            "remote_command_file_bridge_agent_request_count": 20,
+            "remote_command_file_bridge_agent_task_facing_operation_count": 20,
+            "remote_command_file_bridge_agent_task_facing_success_count": 20,
+            "remote_command_file_bridge_agent_failure_count": 0,
+            "host_local_acp_bridge_progress_status": (
+                "bridge_task_facing_success_observed"
+            ),
+            "host_local_acp_bridge_progress_signal_source": (
+                "remote_command_file_bridge_agent_operations"
+            ),
+            "host_local_acp_codex_exec_failure_trace_present": True,
+            "host_local_acp_codex_exec_failure_trace_count": 1,
+            "host_local_acp_codex_exec_failure_category": (
+                "codex_exec_task_output_quiet_timeout"
+            ),
+            "host_local_acp_codex_exec_failure_categories": [
+                "codex_exec_task_output_quiet_timeout"
+            ],
+            "host_local_acp_codex_exec_failure_raw_material_recorded": False,
+            "raw_task_text_recorded": False,
+            "raw_verifier_output_recorded": False,
+            "raw_agent_trajectory_recorded": False,
+        }
+        bridge_quiet_compact = compact_benchmark_run(
+            build_skillsbench_benchflow_result_benchmark_run(
+                bridge_quiet_result_path,
+                route="codex-app-server-goal-baseline",
+                controller_trace=bridge_quiet_trace,
+            )
+        )
+        assert bridge_quiet_compact is not None
+        assert bridge_quiet_compact["score_failure_attribution"] == (
+            "official_score_zero_case_failure"
+        ), bridge_quiet_compact
+        assert "runner_failure" not in bridge_quiet_compact, bridge_quiet_compact
+        assert "skillsbench_runner_setup_error" not in bridge_quiet_compact[
+            "failure_attribution_labels"
+        ], bridge_quiet_compact
+        assert (
+            "skillsbench_host_local_acp_task_output_quiet_after_bridge_attempt"
+            in bridge_quiet_compact["runner_warning_labels"]
+        ), bridge_quiet_compact
+        bridge_quiet_worker = bridge_quiet_compact["native_goal_worker_contract"]
+        assert bridge_quiet_worker["countable_baseline"] is True, bridge_quiet_compact
+        assert bridge_quiet_worker["countability_source"] == (
+            "remote_command_file_bridge_task_facing_success"
+        ), bridge_quiet_compact
+        assert bridge_quiet_worker["bridge_task_facing_success_count"] == 20, (
+            bridge_quiet_compact
+        )
+        bridge_quiet_accounting = bridge_quiet_compact["attempt_accounting"]
+        assert bridge_quiet_accounting["failure_class"] == "solver_failed", (
+            bridge_quiet_accounting
+        )
+        assert bridge_quiet_accounting["case_attempt_countable"] is True, (
+            bridge_quiet_accounting
+        )
+        assert bridge_quiet_accounting["solver_attempt_countable"] is True, (
+            bridge_quiet_accounting
+        )
+        assert bridge_quiet_accounting["verifier_attempt_countable"] is True, (
+            bridge_quiet_accounting
+        )
+        assert bridge_quiet_accounting["official_score_attempt_countable"] is True, (
+            bridge_quiet_accounting
+        )
+
         empty_worker_trace_dir = root / "native-worker-empty-traces"
         empty_worker_trace_dir.mkdir()
         connected_empty_trace_dir = {

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -3527,11 +3527,33 @@ def build_skillsbench_benchflow_result_benchmark_run(
             trace_status=native_goal_worker_trace_status,
         )
     )
-    native_goal_worker_countable = not bool(native_goal_worker_failure_label)
+    native_goal_worker_bridge_task_success_count = _controller_public_count(
+        "remote_command_file_bridge_agent_task_facing_success_count"
+    )
+    native_goal_worker_bridge_task_operation_count = _controller_public_count(
+        "remote_command_file_bridge_agent_task_facing_operation_count"
+    )
+    native_goal_worker_countable_via_bridge_activity = bool(
+        route == "codex-app-server-goal-baseline"
+        and native_goal_worker_failure_label
+        and reward_value is not None
+        and native_goal_worker_bridge_task_success_count > 0
+    )
+    native_goal_worker_countable = bool(
+        not native_goal_worker_failure_label
+        or native_goal_worker_countable_via_bridge_activity
+    )
     native_goal_worker_contract = {
         "schema_version": "skillsbench_native_goal_worker_contract_v0",
         "required": controller_counters.get("native_goal_worker_route") is True,
         "countable_baseline": native_goal_worker_countable,
+        "countability_source": (
+            "remote_command_file_bridge_task_facing_success"
+            if native_goal_worker_countable_via_bridge_activity
+            else "app_server_turn_trace"
+            if not native_goal_worker_failure_label
+            else "none"
+        ),
         "trace_status": native_goal_worker_trace_status,
         "trace_count": native_goal_worker_trace_count,
         "ok_count": _controller_public_count("native_goal_worker_ok_count"),
@@ -3548,6 +3570,8 @@ def build_skillsbench_benchflow_result_benchmark_run(
         "failure_category": str(
             controller_counters.get("native_goal_worker_failure_category") or ""
         )[:120],
+        "bridge_task_facing_operation_count": native_goal_worker_bridge_task_operation_count,
+        "bridge_task_facing_success_count": native_goal_worker_bridge_task_success_count,
         "first_blocker": str(
             controller_counters.get("native_goal_worker_first_blocker") or ""
         )[:120],
@@ -4096,10 +4120,18 @@ def build_skillsbench_benchflow_result_benchmark_run(
         )
         is True
     )
+    host_local_acp_task_output_quiet_after_bridge_attempt = bool(
+        host_local_acp_codex_exec_failure_present
+        and host_local_acp_codex_exec_failure_category
+        == "codex_exec_task_output_quiet_timeout"
+        and reward_value is not None
+        and agent_bridge_task_facing_success_count > 0
+    )
     if (
         host_local_acp_codex_exec_failure_present
         and not official_passed
         and not host_local_acp_idle_timeout_after_countable_closeout
+        and not host_local_acp_task_output_quiet_after_bridge_attempt
     ):
         if host_local_acp_idle_no_task_output_progress_stop:
             host_failure_label = (
@@ -4155,6 +4187,34 @@ def build_skillsbench_benchflow_result_benchmark_run(
         for item in host_failure_extra_labels:
             if item and item not in failure_labels:
                 failure_labels.append(item)
+    elif host_local_acp_task_output_quiet_after_bridge_attempt:
+        warning_label = (
+            "skillsbench_host_local_acp_task_output_quiet_after_bridge_attempt"
+        )
+        failure_labels = [
+            item
+            for item in failure_labels
+            if item
+            not in {
+                "skillsbench_runner_error",
+                "skillsbench_host_local_acp_task_output_quiet_timeout",
+                "verifier_infrastructure_failure",
+                "official_verifier_solution_failure",
+            }
+        ]
+        if reward_value == 0 and score_failure_attribution in {
+            "",
+            "none",
+            "skillsbench_runner_error",
+            "skillsbench_host_local_acp_task_output_quiet_timeout",
+        }:
+            exception_type = "none"
+            score_failure_attribution = "official_score_zero_case_failure"
+            runner_score_failure_attribution = "none"
+            if "official_score_zero_case_failure" not in failure_labels:
+                failure_labels.append("official_score_zero_case_failure")
+        if warning_label not in warning_labels:
+            warning_labels.append(warning_label)
     elif host_local_acp_idle_timeout_after_countable_closeout:
         warning_label = (
             "skillsbench_host_local_acp_idle_timeout_after_countable_closeout"
@@ -4180,7 +4240,9 @@ def build_skillsbench_benchflow_result_benchmark_run(
             if item not in warning_labels:
                 warning_labels.append(item)
     native_goal_worker_uncountable = bool(
-        native_goal_worker_failure_label and not official_passed
+        native_goal_worker_failure_label
+        and not official_passed
+        and not native_goal_worker_countable_via_bridge_activity
     )
     if native_goal_worker_uncountable:
         exception_type = native_goal_worker_failure_label
@@ -4218,7 +4280,10 @@ def build_skillsbench_benchflow_result_benchmark_run(
         evidence_files.append("loopx:acp_trajectory_summary")
     runner_failure: dict[str, Any] | None = None
     runner_failure_fingerprint: dict[str, Any] | None = None
-    if error_text or native_goal_worker_uncountable:
+    if (
+        error_text
+        and not host_local_acp_task_output_quiet_after_bridge_attempt
+    ) or native_goal_worker_uncountable:
         runner_failure = {
             "schema_version": "skillsbench_runner_failure_v0",
             "exception_type": exception_type,

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import os
 import re
 import selectors
 import shlex
+import shutil
 import signal
 import subprocess
 import sys
@@ -78,6 +80,15 @@ SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_PROMPT = (
     "After the bridge response returns, reply exactly "
     f"{SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER} and end the turn."
 )
+
+
+@contextlib.contextmanager
+def _temporary_directory_ignore_cleanup_errors(*, prefix: str):
+    path = tempfile.mkdtemp(prefix=prefix)
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
 
 
 def _prompt_requires_bridge_first_action(prompt: str) -> bool:
@@ -246,6 +257,22 @@ def _bridge_summary_has_meaningful_agent_progress(
 def _bridge_summary_has_successful_task_file_write(path: Path | None) -> bool:
     """Return true after the worker successfully writes task-facing files."""
 
+    return _bridge_summary_has_successful_task_operation(path, operation="write_file")
+
+
+def _bridge_summary_has_successful_task_operation(
+    path: Path | None,
+    *,
+    operation: str | None = None,
+) -> bool:
+    """Return true after a successful task-facing bridge operation.
+
+    Some agents create scored outputs via an ``exec`` command rather than the
+    bridge ``write_file`` operation. Treat that as sufficient task-output
+    progress for the quiet closeout watchdog; the verifier remains the source
+    of truth for whether the side effect is correct.
+    """
+
     if path is None or not path.exists():
         return False
     try:
@@ -262,7 +289,7 @@ def _bridge_summary_has_successful_task_file_write(path: Path | None) -> bool:
         phase = str(record.get("record_phase") or "").strip().lower()
         if phase != "complete" or _bridge_operation_record_interrupted(record):
             continue
-        if record.get("operation") != "write_file":
+        if operation is not None and record.get("operation") != operation:
             continue
         if record.get("task_facing_operation") is not True:
             continue
@@ -1947,7 +1974,9 @@ raise SystemExit(proc.returncode)
     ) -> str:
         cwd = _safe_cwd(session.get("cwd"), default=os.getcwd())
         self._publish_worker_lifecycle_trace("prompt_received")
-        with tempfile.TemporaryDirectory(prefix="gh-skillsbench-goal-worker-") as tmp:
+        with _temporary_directory_ignore_cleanup_errors(
+            prefix="gh-skillsbench-goal-worker-"
+        ) as tmp:
             tmp_path = Path(tmp)
             prompt_path = tmp_path / "prompt.txt"
             output_json = tmp_path / "worker.compact.json"
@@ -2091,7 +2120,7 @@ raise SystemExit(proc.returncode)
                         time.monotonic()
                         + max(1.0, self._config.first_action_timeout_sec)
                     )
-                task_output_write_seen = False
+                task_output_progress_seen = False
                 while proc.poll() is None:
                     now = time.monotonic()
                     if bridge_summary_path is not None:
@@ -2113,11 +2142,11 @@ raise SystemExit(proc.returncode)
                                 )
                             )
                         if (
-                            not task_output_write_seen
+                            not task_output_progress_seen
                             and task_output_quiet_timeout_sec > 0
                         ):
-                            task_output_write_seen = (
-                                _bridge_summary_has_successful_task_file_write(
+                            task_output_progress_seen = (
+                                _bridge_summary_has_successful_task_operation(
                                     bridge_summary_path
                                 )
                             )
@@ -2167,7 +2196,7 @@ raise SystemExit(proc.returncode)
                             "codex_exec_first_action_timeout"
                         )
                     if (
-                        task_output_write_seen
+                        task_output_progress_seen
                         and bridge_summary_path is not None
                         and task_output_quiet_timeout_sec > 0
                         and not _bridge_summary_has_inflight_operation(

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -1817,11 +1817,14 @@ def _compact_native_goal_worker_contract(value: Any) -> dict[str, Any]:
         "turn_start_count",
         "assistant_message_present_count",
         "failure_trace_count",
+        "bridge_task_facing_operation_count",
+        "bridge_task_facing_success_count",
     ):
         field_value = value.get(field)
         if isinstance(field_value, int) and not isinstance(field_value, bool):
             compact[field] = field_value
     for field in (
+        "countability_source",
         "trace_status",
         "failure_category",
         "first_blocker",


### PR DESCRIPTION
## Summary
- Count successful reverse-channel bridge task-facing operations as native app-server worker activity, so successful exec/file side effects are not misclassified as uncountable materialization failures.
- Let the app-server relay quiet-closeout trigger after any successful task-facing bridge operation, not only bridge write_file, while keeping the official verifier as the score source.
- Preserve bridge task-facing counters in compact/status surfaces and add regression coverage for the r18-style pass path plus exec side-effect closeout.

## Validation
- python3 -m py_compile loopx/benchmark_adapters/skillsbench_acp_relay.py loopx/benchmark_adapters/skillsbench.py loopx/status.py examples/skillsbench-app-server-goal-worker-smoke.py examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-app-server-goal-worker-smoke.py
- python3 examples/skillsbench-benchmark-run-smoke.py

## Boundary
- Public helper/runtime and smoke changes only.
- No raw task text, raw trajectories, private benchmark logs, credentials, local run paths, or verifier output tails are committed.