### PR TITLE
Define generic multi-agent visible launcher contract

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -96,6 +96,7 @@ incident report, or launch draft.
 - [Host integration plugin plan v0](reference/protocols/host-integration-plugin-plan-v0.md)
 - [Codex App host command registry v0](reference/protocols/codex-app-host-command-registry-v0.md)
 - [Local agent launch plan v0](reference/protocols/local-agent-launch-plan-v0.md)
+- [Multi-agent visible launcher v0](reference/protocols/multi-agent-visible-launcher-v0.md)
 - [Runtime connector catalog](runtime-connector-catalog.md)
 - [Reward gate direct-write contract](reward-gate-direct-write-contract.md)
 - [Worker bridge install contract](worker-bridge-install-contract.md)

--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -34,3 +34,4 @@ Current contracts:
 - [value_connector_plan_v0](value-connector-plan-v0.md)
 - [openviking_session_memory_adapter_v0](openviking-session-memory-adapter-v0.md)
 - [local_agent_launch_plan_v0](local-agent-launch-plan-v0.md)
+- [multi_agent_visible_launcher_v0](multi-agent-visible-launcher-v0.md)

--- a/docs/reference/protocols/multi-agent-visible-launcher-v0.md
+++ b/docs/reference/protocols/multi-agent-visible-launcher-v0.md
@@ -1,0 +1,224 @@
+# multi_agent_visible_launcher_v0
+
+`multi_agent_visible_launcher_v0` is the generic LoopX contract for starting
+several visible local agent panes for one shared goal. It is the reusable layer
+under domain demos such as auto-research: LoopX owns the goal surface, lane
+identity, quota/frontier/bootstrap guards, visible host controls, and public
+acceptance; the domain capability owns only role semantics and evidence
+writeback.
+
+This contract intentionally sits between two existing surfaces:
+
+- `local_agent_launch_plan_v0` previews what could be launched and remains
+  `mode=dry_run` only.
+- Domain capabilities, such as auto-research, provide role profiles, frontier
+  commands, and evidence packets.
+
+The visible launcher may plan or start panes, but it must not become a leader
+agent, hidden scheduler, promotion authority, or second source of truth.
+
+## Ownership Split
+
+| Surface | Owns | Does not own |
+| --- | --- | --- |
+| LoopX control plane | goal id, registered agents, todo claims, quota, gates, run history, and public/private boundary. | Domain-specific research, benchmark, or product semantics. |
+| Multi-agent visible launcher | pane layout, environment projection, visible start commands, attach/stop/retry controls, acceptance checks. | Todo truth, promotion decisions, hidden session injection, or write permission. |
+| Domain capability | lane roles, frontier command, role profile schema, domain artifact/evidence writeback. | Generic host process lifecycle, global quota, or cross-domain launcher policy. |
+| Host shell or app | Actual tmux/terminal/window process control after explicit local execution. | Authority to bypass LoopX guards or hide work from the user. |
+
+The launcher is a host convenience surface. Each pane remains a normal LoopX
+agent lane that must read the same goal state and pass its own guard.
+
+## Packet Shape
+
+```json
+{
+  "schema_version": "multi_agent_visible_launcher_v0",
+  "mode": "dry_run | execute",
+  "goal_id": "loopx-meta",
+  "session_name": "loopx-visible-goal",
+  "reasoning_contract": {
+    "default_reasoning_effort": "high",
+    "codex_cli_config_key": "model_reasoning_effort"
+  },
+  "shared_goal_surface": {
+    "shared_goal_id": "loopx-meta",
+    "shared_state_route": "LOOPX_REGISTRY_and_LOOPX_RUNTIME_ROOT",
+    "shared_frontier": true,
+    "lane_identity_source": "role_profile_plus_agent_scoped_quota",
+    "all_lane_workspace_isolation": false,
+    "mutation_isolation_policy": "only mutating attempts require a claimed worktree or equivalent execution boundary"
+  },
+  "lanes": [],
+  "commands": {
+    "start_script": [],
+    "attach": "tmux attach -t loopx-visible-goal",
+    "stop": "tmux kill-session -t loopx-visible-goal",
+    "retry": "rerun the same packet after quota/frontier refresh"
+  },
+  "acceptance": {},
+  "boundary": {}
+}
+```
+
+Required top-level fields:
+
+- `schema_version`: exactly `multi_agent_visible_launcher_v0`;
+- `mode`: `dry_run` for inspect-only packets, or `execute` only after a local
+  host explicitly starts panes;
+- `goal_id` and `session_name`;
+- `reasoning_contract`;
+- `shared_goal_surface`;
+- `lanes[]`;
+- `commands.attach`, `commands.stop`, and `commands.retry`;
+- `acceptance`;
+- `boundary`.
+
+## Shared Goal Surface
+
+Visible lanes share the target **goal surface**, not necessarily the same file
+mutation area. The shared surface is:
+
+- the registry selected by `LOOPX_REGISTRY`;
+- the runtime root selected by `LOOPX_RUNTIME_ROOT`;
+- the `goal_id`;
+- agent-scoped `quota should-run`;
+- todo projection, frontier projection, and run history for that goal;
+- public-safe evidence and rollout-event projections.
+
+`all_lane_workspace_isolation=false` is the normal LoopX multi-agent shape:
+agents cooperate on one goal surface. Isolation is applied only to the lane or
+attempt that mutates files, typically through an independent git worktree,
+scratch directory, or equivalent execution boundary. The launcher must make that
+policy explicit instead of silently moving every lane into unrelated state.
+
+## Lane Shape
+
+Each lane is small enough to print before the agent starts:
+
+```json
+{
+  "lane_id": "evidence-runner",
+  "agent_id": "codex-side-bypass",
+  "role_id": "evidence_runner",
+  "responsibility": "Run one bounded evidence attempt.",
+  "role_profile": {
+    "schema_version": "domain_role_profile_v0"
+  },
+  "quota_guard": "loopx ... quota should-run --goal-id ... --agent-id ...",
+  "frontier": "loopx ... <domain> frontier --goal-id ... --agent-id ...",
+  "bootstrap_message": "loopx codex-cli-bootstrap-message ...",
+  "visible_launch_command": "...",
+  "reasoning_effort": "high",
+  "lane_timeline": []
+}
+```
+
+Required lane fields:
+
+- `lane_id`, `agent_id`, `role_id`, and `responsibility`;
+- `role_profile` or `role_profile_ref`;
+- `quota_guard`;
+- `frontier`;
+- `bootstrap_message`;
+- `visible_launch_command` or host-equivalent command ref;
+- `reasoning_effort`;
+- `lane_timeline`.
+
+The pane title is cosmetic. The role profile plus agent-scoped quota/frontier
+packet is the lane identity authority.
+
+## Start Order
+
+Every visible lane follows the same generic start order:
+
+1. Print the role profile or role profile ref.
+2. Run `quota should-run --goal-id <goal-id> --agent-id <agent-id>`.
+3. Stop visibly if `interaction_contract.user_channel.action_required=true`,
+   delivery is disallowed, quota is false, or the packet is contradictory.
+4. Print the domain frontier or a blocked reason.
+5. Print the public-safe bootstrap message.
+6. Start the visible agent process only after the preceding packets are visible.
+7. Keep the pane open after exit so the user can inspect, interrupt, close, or
+   retry manually.
+
+The launcher must not inject prompts into a hidden session, hide guard output,
+or continue a lane after a user gate is projected.
+
+## Host Controls
+
+The packet must expose:
+
+- `attach`: how the user observes or takes over the whole session;
+- `stop`: how the user kills the whole session;
+- per-pane interrupt path using normal terminal controls;
+- `retry`: the safe retry shape, which must recompute quota/frontier/bootstrap
+  first instead of replaying stale hidden state;
+- visible acceptance markers that prove each pane printed profile, quota,
+  frontier-or-blocker, bootstrap-or-stop, and takeover controls.
+
+Host commands are public-safe command shapes. They must not include credentials,
+auth headers, raw transcript paths, private document ids, or local absolute
+paths in committed docs or fixtures.
+
+## Boundary
+
+Required boundary fields:
+
+```json
+{
+  "starts_visible_processes": false,
+  "runs_agent_processes": false,
+  "writes_loopx_state": false,
+  "spends_loopx_quota": false,
+  "reads_raw_transcripts": false,
+  "reads_session_files": false,
+  "reads_credentials": false,
+  "hidden_prompt_injection": false,
+  "shared_goal_surface": true,
+  "all_lane_workspace_isolation": false,
+  "public_safe_redaction": true
+}
+```
+
+For `mode=dry_run`, process and write fields must stay false. For
+`mode=execute`, `starts_visible_processes` and `runs_agent_processes` may become
+true only when the host actually starts visible panes; LoopX state write and
+quota spend still happen through the normal agent lane after validated
+writeback, not through the launcher packet itself.
+
+## Domain Adapter Responsibilities
+
+A domain capability that uses this contract supplies:
+
+- role profile schema and role-specific allowed actions;
+- frontier command and blocked-reason shape;
+- domain evidence or artifact writeback command;
+- domain-specific acceptance criteria;
+- public-safe demo fixture or deterministic positive seed when needed.
+
+The domain capability should not own generic attach/stop/retry, shared goal
+surface, high-reasoning launch flags, or pane survival checks.
+
+## Acceptance Checks
+
+A public fixture or implementation satisfies the contract when:
+
+1. the packet or protocol names `multi_agent_visible_launcher_v0`;
+2. it distinguishes `local_agent_launch_plan_v0` preview from visible launch;
+3. it says the launcher is not a leader agent, scheduler, promotion authority,
+   or second source of truth;
+4. it exposes shared goal surface through registry, runtime root, goal id,
+   agent-scoped quota, todo/frontier projection, run history, and evidence;
+5. it requires per-lane role identity, quota guard, frontier, bootstrap message,
+   high reasoning, lane timeline, and visible launch command;
+6. it requires attach, stop, retry, pane interrupt, and visible acceptance
+   markers;
+7. dry-run mode starts no process, runs no agent, writes no LoopX state, and
+   spends no quota;
+8. execute mode still writes state and spends quota only through normal LoopX
+   writeback after validation;
+9. it keeps workspace isolation scoped to mutating attempts rather than
+   splitting the shared goal surface; and
+10. public docs and fixtures contain no raw transcripts, credentials, private
+    links, internal project names, or local absolute paths.

--- a/examples/multi-agent-visible-launcher-protocol-smoke.py
+++ b/examples/multi-agent-visible-launcher-protocol-smoke.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Smoke-check the generic multi-agent visible launcher protocol contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROTOCOL = ROOT / "docs/reference/protocols/multi-agent-visible-launcher-v0.md"
+LOCAL_PLAN = ROOT / "docs/reference/protocols/local-agent-launch-plan-v0.md"
+AUTO_RESEARCH_PROFILE = ROOT / "docs/reference/protocols/auto-research-role-profile-v0.md"
+AUTO_RESEARCH_GUIDE = ROOT / "docs/guides/auto-research-command-path.md"
+PROTOCOL_INDEX = ROOT / "docs/reference/protocols/README.md"
+DOCS_INDEX = ROOT / "docs/README.md"
+
+
+PRIVATE_MARKERS = [
+    "byte" + "dance",
+    "lark" + "office",
+    "fei" + "shu.cn",
+    "/" + "Users" + "/",
+    "/" + "private" + "/",
+    "/" + "tmp" + "/",
+    "api" + "_key",
+    "pass" + "word",
+    "sec" + "ret",
+]
+
+
+def read(path: Path) -> str:
+    assert path.exists(), f"missing {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def require(text: str, snippets: list[str], *, source: Path) -> None:
+    compact = " ".join(text.split())
+    missing = [
+        snippet for snippet in snippets if snippet not in text and " ".join(snippet.split()) not in compact
+    ]
+    assert not missing, f"{source}: missing {missing}"
+
+
+def assert_public_safe(text: str, label: str) -> None:
+    lower = text.lower()
+    leaked = [marker for marker in PRIVATE_MARKERS if marker.lower() in lower]
+    assert not leaked, f"{label} leaks private markers: {leaked}"
+
+
+def main() -> int:
+    protocol = read(PROTOCOL)
+    local_plan = read(LOCAL_PLAN)
+    auto_research_profile = read(AUTO_RESEARCH_PROFILE)
+    auto_research_guide = read(AUTO_RESEARCH_GUIDE)
+    protocol_index = read(PROTOCOL_INDEX)
+    docs_index = read(DOCS_INDEX)
+    changed_public_docs = "\n".join(
+        [
+            protocol,
+            protocol_index,
+            docs_index,
+        ]
+    )
+
+    assert_public_safe(changed_public_docs, "multi-agent visible launcher docs")
+
+    require(
+        protocol,
+        [
+            "multi_agent_visible_launcher_v0",
+            "local_agent_launch_plan_v0",
+            "Domain capabilities",
+            "not become a leader agent",
+            "Ownership Split",
+            "LoopX control plane",
+            "Multi-agent visible launcher",
+            "Host shell or app",
+            "schema_version",
+            "reasoning_contract",
+            "default_reasoning_effort",
+            "model_reasoning_effort",
+            "shared_goal_surface",
+            "LOOPX_REGISTRY_and_LOOPX_RUNTIME_ROOT",
+            "agent-scoped `quota should-run`",
+            "todo projection, frontier projection, and run history",
+            "public-safe evidence",
+            "all_lane_workspace_isolation=false",
+            "only mutating attempts require a claimed worktree",
+            "role_profile",
+            "quota_guard",
+            "frontier",
+            "bootstrap_message",
+            "visible_launch_command",
+            "reasoning_effort",
+            "lane_timeline",
+            "The pane title is cosmetic",
+            "Start Order",
+            "Run `quota should-run --goal-id <goal-id> --agent-id <agent-id>`",
+            "Print the domain frontier or a blocked reason",
+            "Start the visible agent process only after the preceding packets are visible",
+            "Host Controls",
+            "attach",
+            "stop",
+            "retry",
+            "visible acceptance markers",
+            "Boundary",
+            "hidden_prompt_injection",
+            "public_safe_redaction",
+            "Domain Adapter Responsibilities",
+            "Acceptance Checks",
+        ],
+        source=PROTOCOL,
+    )
+    require(
+        protocol,
+        [
+            "dry-run mode starts no process, runs no agent, writes no LoopX state, and\n   spends no quota",
+            "execute mode still writes state and spends quota only through normal LoopX\n   writeback after validation",
+            "workspace isolation scoped to mutating attempts rather than\n   splitting the shared goal surface",
+        ],
+        source=PROTOCOL,
+    )
+    forbidden = [
+        "launcher owns promotion decisions",
+        "all lanes must use separate goal state",
+        "may hide guard output",
+        "is a hidden scheduler",
+    ]
+    for phrase in forbidden:
+        assert phrase not in protocol, f"forbidden phrase present: {phrase}"
+
+    require(
+        local_plan,
+        [
+            "local_agent_launch_plan_v0",
+            "mode=dry_run",
+            "It must not start a process",
+        ],
+        source=LOCAL_PLAN,
+    )
+    require(
+        auto_research_profile,
+        [
+            "Host launcher",
+            "Visible panes",
+            "attach/stop controls",
+            "The pane title is cosmetic",
+        ],
+        source=AUTO_RESEARCH_PROFILE,
+    )
+    require(
+        auto_research_guide,
+        [
+            "The panes share the same LoopX\ngoal surface",
+            "isolate only\nmutating evidence-runner attempts",
+            "Each pane must route through its own quota/frontier/bootstrap path",
+        ],
+        source=AUTO_RESEARCH_GUIDE,
+    )
+    require(
+        protocol_index,
+        ["multi_agent_visible_launcher_v0", "multi-agent-visible-launcher-v0.md"],
+        source=PROTOCOL_INDEX,
+    )
+    require(
+        docs_index,
+        ["Multi-agent visible launcher v0", "reference/protocols/multi-agent-visible-launcher-v0.md"],
+        source=DOCS_INDEX,
+    )
+
+    print("multi-agent-visible-launcher-protocol-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Add multi_agent_visible_launcher_v0 as the generic contract below auto-research demos for visible multi-agent panes.
- Clarify shared goal surface, per-lane quota/frontier/bootstrap order, high reasoning, attach/stop/retry, and public-safe acceptance.
- Link the protocol from docs indexes and add a focused smoke for the contract.

## Validation
- python3 examples/multi-agent-visible-launcher-protocol-smoke.py
- python3 -m py_compile examples/multi-agent-visible-launcher-protocol-smoke.py
- python3 examples/auto-research-visible-launcher-smoke.py
- python3 examples/auto-research-demo-e2e-smoke.py
- python3 examples/decentralized-auto-research-protocol-smoke.py
- python3 examples/local-agent-launch-plan-smoke.py
- git diff --check
- loopx check --scan-path docs/reference/protocols/multi-agent-visible-launcher-v0.md --scan-path examples/multi-agent-visible-launcher-protocol-smoke.py --scan-path docs/reference/protocols/README.md --scan-path docs/README.md

## Boundary
- Public docs and durable smoke only.
- No runtime launcher behavior, no credentials, no private state, no raw logs.
- loopx check warning is the pre-existing loopx-meta duplicate index rows warning.