### PR TITLE
Refine README loop agent demo surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,28 @@
-# LoopX
+<div align="center">
 
-<img align="right" src="docs/assets/loopx-logo.png" alt="LoopX loop engineering logo" width="148">
+<img src="docs/assets/loopx-logo.png" alt="LoopX loop engineering logo" width="180">
 
 **Loop engineering for long-running AI agents.**
 
-**Manage long-running agents like digital workers.**
+<sub>Manage Codex, Claude Code, Cursor, and other agent runtimes like
+reviewable digital workers: goals, gates, todos, quota, evidence, and handoff
+state in one local control plane.</sub>
+
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Python](https://img.shields.io/badge/python-3.11%2B-blue.svg)](pyproject.toml)
+[![Local first](https://img.shields.io/badge/control--plane-local--first-brightgreen.svg)](docs/public-private-boundary.md)
+[![Loop Agents](https://img.shields.io/badge/status-loop%20agents%20early-orange.svg)](docs/product/release-readiness.md)
 
 **把会干活的 Agent，接成可管理、可复盘、可持续改进的数字员工。**
 
-LoopX is a local control plane for loop engineering. It helps Codex,
-Claude Code, Cursor, and other agent runtimes keep working on goals that span
-hours, days, handoffs, and changing human feedback.
+</div>
+
+---
+
+LoopX is a local control plane for agent loops that last longer than one chat
+turn. It does not replace Codex, Claude Code, Cursor, or another runtime; it
+keeps the shared state those runtimes need to continue safely across hours,
+days, handoffs, blocked lanes, and changing human feedback.
 
 Use it when an agent is already useful for one session, but the work is too
 long, too gated, or too easy to lose across restarts. LoopX turns that agent
@@ -19,16 +31,7 @@ next actions, evidence, cost, and handoff state. The agent still needs a CLI,
 goal mode, automation hook, or loop scheduler; LoopX supplies the control
 plane, not hidden autonomy.
 
-Under the hood, LoopX keeps goals, gates, todos, claims, scopes, evidence, run
-history, quota, and human decisions in one compact layer. Product surfaces fold
-those mechanics into five questions a user can act on: what is the goal, what
-is next, what needs human judgment, what evidence changed, and whether the loop
-can be handed back to the agent.
-
-LoopX 把一次静态 goal 变成能持续流转的动态 loop：该等人的地方明确等人，
-不该空等的安全侧路继续推进，下一轮 agent 总能读到目标、边界、证据和交接。
-
-[What Is It](#what-is-it) · [Who Should Try It](#who-should-try-it) · [Quick Start](#quick-start) · [See It In Action](#see-it-in-action) ·
+[How It Works](#how-it-works) · [Quick Start](#quick-start) · [See It In Action](#see-it-in-action) ·
 [Capability Surface](#capability-surface) ·
 [Getting Started](docs/guides/getting-started.md) · [Showcases](docs/showcases/README.md) ·
 [Hosted Frontstage](https://huangruiteng.github.io/loopx/frontstage/) ·
@@ -39,17 +42,35 @@ LoopX 把一次静态 goal 变成能持续流转的动态 loop：该等人的地
 
 > Keep the loop moving. Keep the judgment human.
 
-## What Is It?
+## How It Works
 
-LoopX does not replace Codex, Claude Code, Cursor, or another agent
-runtime. It sits above them as a loop-engineering control plane: the runtime
-executes bounded agent loops, while LoopX preserves the dynamic goal state those
-loops need to keep working without losing the plot.
+Under the hood, LoopX keeps goals, gates, todos, claims, scopes, evidence, run
+history, quota, and human decisions in one compact layer. Product surfaces fold
+those mechanics into five questions a user can act on: what is the goal, what
+is next, what needs human judgment, what evidence changed, and whether the loop
+can be handed back to the agent.
 
 Short answer: LoopX is not another executor. Codex goal, Codex App
 automation, CLI scripts, cron jobs, or a human-visible TUI can trigger the next
 executor loop; LoopX keeps the goal, gate, evidence, quota, and handoff contract
 stable across those turns.
+
+```text
+goal / issue / project
+   │
+   ▼
+LoopX state: objective + gates + todos + scope + evidence + quota
+   │
+   ├─ human judgment needed? ── yes ─▶ ask / wait with a concrete user todo
+   │
+   ├─ safe fallback available? ──────▶ run a bounded agent slice
+   │
+   ▼
+Codex / Claude Code / Cursor / shell agent executes one loop
+   │
+   ▼
+write evidence + handoff + next todo ─▶ quota decides the next tick
+```
 
 | Layer | Role |
 | --- | --- |
@@ -67,6 +88,9 @@ turns, and off-hours without turning the project into a pile of hidden scripts
 and stale prompts. The technical contract underneath that promise is explicit:
 agent identity, todo ownership, scope, capability gates, quota, evidence
 writeback, and public/private boundaries stay visible to the next turn.
+
+LoopX 把一次静态 goal 变成能持续流转的动态 loop：该等人的地方明确等人，
+不该空等的安全侧路继续推进，下一轮 agent 总能读到目标、边界、证据和交接。
 
 ![LoopX control-plane board](docs/assets/control-plane-board.svg)
 
@@ -99,6 +123,15 @@ runtime dependencies outside the standard library.
 
 The easiest start is agent-first: ask the agent you already use to install,
 connect, diagnose, and show the next safe action before doing longer work.
+
+Pick the surface you already use:
+
+| Surface | Best when | Start with |
+| --- | --- | --- |
+| Codex App | You want recurring heartbeats and scheduler backoff inside Codex App. | Paste the setup message below, then use `loopx heartbeat-prompt --thin --goal-id <goal-id> --agent-id <agent-id> --agent-scope "<scope>"`. |
+| Codex CLI | You want the visible TUI to stay primary. | Run `codex`, paste the setup message, then set `/goal <thin task_body>`. |
+| Claude Code | You want Claude Code's native `/loop` to drive each tick. | Install the opt-in adapter, run `/loopx <task>`, then `/loop`. |
+| Manual shell / other agents | You want LoopX state without a supported runtime bridge. | `curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh \| bash`, then `loopx doctor` and `loopx bootstrap`. |
 
 ### Codex App
 
@@ -259,6 +292,7 @@ new control plane every time:
 | Multi-agent work routing | `/loopx <goal text>`<br>`loopx quota should-run`<br>`loopx todo claim` | Claimed agent lanes with scope, lease, next action, quota decision, and handoff state. | Multiple agents can work in parallel without hiding ownership or stepping on the same todo. |
 | Knowledge / workflow connector | `loopx connect`<br>`loopx lark-kanban`<br>`loopx value-connectors` | LoopX state projected into docs, boards, GitHub, or domain workflows while LoopX remains the source of truth. | Existing work surfaces become agent-aware without copying private state into public artifacts. |
 | P0 blocked -> safe fallback | `loopx quota should-run`<br>`loopx todo claim` | Kernel projection of the exact user gate, safe fallback todo, quota decision, and evidence boundary inside an active goal. | Less idle agent time while preserving human judgment on the blocked path. |
+| Candidate: Claude implements + Codex reviews | `/loopx <implementation goal>`<br>`loopx todo claim`<br>`loopx review-packet` | Role-scoped implementer todo, reviewer verdict, verifier command, evidence packet, and next handoff in one LoopX goal. | A [two-agent demo](docs/product/cross-runtime-impl-review-demo.md) can show collaboration without making either runtime the source of truth. |
 | Candidate: PR conflict resolution | `/loopx Resolve merge conflicts for <github-pr-url>` | Conflict patch, semantic risk note, focused validation, and review handoff before merge. | Less mechanical conflict work after high-throughput agent branches, with humans still judging risky merges. |
 
 Start the goal normally with `/loopx <goal text>`. The commands above are short

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -87,6 +87,10 @@ runtime contract, benchmark route, or launch draft.
 - [Codex CLI proof-capture demo](codex-cli-proof-capture-demo.md): public-safe
   sample fixtures and acceptance decisions for rehearsing the visible proof
   path without running Codex or reading session material.
+- [Cross-runtime implement/review demo](cross-runtime-impl-review-demo.md):
+  LoopX-native contract for a Claude Code implementation plus Codex review demo
+  that maps implementer, reviewer, verifier, gates, evidence, and handoff onto
+  normal LoopX todos and review packets.
 - [Codex CLI TUI continuation priority](codex-cli-tui-continuation-priority.md):
   the current scheduling guard that keeps same-open-TUI continuation ahead of
   frontstage/showcase polish when both are runnable.

--- a/docs/product/cross-runtime-impl-review-demo.md
+++ b/docs/product/cross-runtime-impl-review-demo.md
@@ -1,0 +1,177 @@
+# Cross-Runtime Implement/Review Demo
+
+This note defines a LoopX-native demo path for the pattern "Claude Code
+implements, Codex reviews" without making either runtime the source of truth.
+
+The comparable product shape is a two-agent coding loop, but LoopX should show
+a different strength: durable state, gates, evidence, quota, and handoff across
+agent surfaces. The demo should make the role split visible while preserving
+LoopX's control-plane boundary.
+
+## Demo Claim
+
+LoopX can coordinate an implementation/review loop across different agent
+runtimes:
+
+- Claude Code owns an implementation todo and writes a bounded patch.
+- Codex owns a review todo and produces a structured review verdict.
+- A verifier command or smoke result is recorded as compact evidence.
+- LoopX owns todo claims, gates, evidence, quota, and the next handoff.
+
+The demo must not claim that LoopX is itself a universal executor. Runtime
+launch still belongs to the host surface: Claude Code `/loop`, Codex App
+heartbeat, Codex CLI TUI goal mode, or an explicit shell bridge.
+
+## Current Public-Safe Flow
+
+```text
+user requirement
+   │
+   ▼
+/loopx <implementation goal>
+   │
+   ▼
+LoopX writes two role-scoped todos
+   │
+   ├─ claude-code-impl claims implementation
+   │     └─ patch summary + changed files + validation attempt
+   │
+   └─ codex-review claims review
+         └─ PASS/BLOCK verdict + findings + required verifier
+   │
+   ▼
+review-packet + quota should-run decide next handoff
+```
+
+Minimal command surface:
+
+```bash
+loopx todo add --goal-id <goal> --role agent \
+  --text "[P0] Implement <bounded requirement>." \
+  --claimed-by claude-code-impl
+
+loopx todo add --goal-id <goal> --role agent \
+  --text "[P0] Review the implementation patch and verifier result." \
+  --claimed-by codex-review
+
+loopx --format json quota should-run --goal-id <goal> --agent-id claude-code-impl
+loopx todo claim --goal-id <goal> --todo-id <todo_id> --claimed-by claude-code-impl
+loopx review-packet --goal-id <goal>
+loopx --format json quota should-run --goal-id <goal> --agent-id codex-review
+```
+
+For Claude Code, the visible runtime entry remains:
+
+```text
+/loopx <implementation goal>
+/loop
+```
+
+For Codex, the visible review entry remains one of the existing Codex surfaces:
+
+```text
+/loopx Review <implementation evidence>
+```
+
+or a Codex App heartbeat whose `quota should-run --agent-id codex-review`
+selects the review todo.
+
+## State Shape
+
+```yaml
+cross_runtime_impl_review_demo_v0:
+  goal_id: "public demo goal"
+  requirement: "bounded user-visible change"
+  roles:
+    implementer:
+      agent_id: "claude-code-impl"
+      runtime: "claude_code"
+      owns:
+        - patch proposal
+        - implementation evidence summary
+        - first verifier attempt
+      must_not:
+        - approve its own review gate
+        - publish or merge without owner approval
+    reviewer:
+      agent_id: "codex-review"
+      runtime: "codex"
+      owns:
+        - review verdict
+        - blocker list
+        - verifier recommendation
+      must_not:
+        - rewrite the implementation unless explicitly handed a fix todo
+        - treat style preferences as blocking defects
+  loopx_control_plane:
+    owns:
+      - todo claims
+      - quota decisions
+      - human gates
+      - compact evidence
+      - review packet
+      - next handoff
+  verifier:
+    command: "project-specific smoke or test command"
+    required_before_done: true
+  stop_conditions:
+    - user gate required
+    - source or write boundary unclear
+    - verifier missing or inconclusive
+    - reviewer BLOCK verdict with no bounded fix todo
+```
+
+## Review Verdict Contract
+
+The reviewer output should be compact enough for `review-packet` and dashboards:
+
+| Field | Meaning |
+| --- | --- |
+| `verdict` | `PASS`, `BLOCK`, or `INCONCLUSIVE`. |
+| `blockers` | Objective defects only: failing tests, broken behavior, unmet requirement, unsafe boundary. |
+| `suggestions` | Non-blocking style, naming, or follow-up notes. |
+| `verifier` | Command or smoke that was run, recommended, or missing. |
+| `handoff` | Next todo owner: implementer fix, reviewer accept, user gate, or archive. |
+
+This keeps the demo from becoming an argument between two models. A `BLOCK`
+verdict creates or preserves an implementation todo; a `PASS` verdict still
+requires verifier evidence before completion.
+
+## Productization Path
+
+1. **Docs/demo only.** README and this note describe the role contract, commands,
+   and boundary.
+2. **Fixture rehearsal.** Add a public fixture showing implementer evidence,
+   reviewer verdict, verifier result, and next handoff without running either
+   runtime.
+3. **Host adapter packet.** Add a dry-run CLI packet such as
+   `loopx demo impl-review --preset claude-codex --dry-run` that writes no
+   state and only renders the planned todos and gates.
+4. **Opt-in execution.** Only after the packet is stable, launch Claude Code or
+   Codex through their native visible surfaces and record compact evidence.
+
+The v0 demo should stop at docs plus fixture validation. That is enough to show
+the LoopX advantage over a single-runtime loop: the role split survives across
+tools, but human gates and evidence stay centralized.
+
+## Boundary
+
+Allowed public evidence:
+
+- public-safe requirement summary;
+- todo ids and agent ids;
+- changed-file summary;
+- verifier command and pass/fail/inconclusive label;
+- review verdict and blocker titles;
+- review-packet or dashboard links.
+
+Forbidden evidence:
+
+- raw Claude or Codex transcripts;
+- private prompts, credentials, local secrets, or private document links;
+- raw benchmark task text, trajectories, logs, or verifier tails;
+- unpublished maintainer messages;
+- permission changes, merge, publish, or external comments without owner gate.
+
+This makes the demo compatible with LoopX's public/private boundary and with
+the existing Claude Code opt-in adapter.

--- a/examples/readme-demo-surface-smoke.py
+++ b/examples/readme-demo-surface-smoke.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Validate the public README and cross-runtime demo surface."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def read(path: str) -> str:
+    return (REPO_ROOT / path).read_text(encoding="utf-8")
+
+
+def compact(text: str) -> str:
+    return " ".join(text.split())
+
+
+def main() -> int:
+    readme = read("README.md")
+    demo = read("docs/product/cross-runtime-impl-review-demo.md")
+    product_index = read("docs/product/README.md")
+    compact_readme = compact(readme)
+    compact_demo = compact(demo)
+
+    for required in [
+        '<div align="center">',
+        "Loop engineering for long-running AI agents.",
+        "Manage Codex, Claude Code, Cursor, and other agent runtimes",
+        "## How It Works",
+        "goal / issue / project",
+        "LoopX state: objective + gates + todos + scope + evidence + quota",
+        "Pick the surface you already use:",
+        "Codex App",
+        "Codex CLI",
+        "Claude Code",
+        "Manual shell / other agents",
+        "Candidate: Claude implements + Codex reviews",
+        "docs/product/cross-runtime-impl-review-demo.md",
+    ]:
+        assert required in readme, required
+
+    for required in [
+        "`/loopx <implementation goal>`",
+        "`loopx todo claim`",
+        "`loopx review-packet`",
+    ]:
+        assert required in compact_readme, required
+
+    for required in [
+        "# Cross-Runtime Implement/Review Demo",
+        "Claude Code owns an implementation todo",
+        "Codex owns a review todo",
+        "LoopX owns todo claims, gates, evidence, quota, and the next handoff",
+        "loopx todo add --goal-id <goal> --role agent",
+        "loopx --format json quota should-run --goal-id <goal> --agent-id claude-code-impl",
+        "loopx review-packet --goal-id <goal>",
+        "Review Verdict Contract",
+        "Forbidden evidence",
+        "raw Claude or Codex transcripts",
+    ]:
+        assert required in demo, required
+
+    for required in [
+        "verdict",
+        "blockers",
+        "suggestions",
+        "verifier",
+        "handoff",
+        "docs plus fixture validation",
+    ]:
+        assert required in compact_demo, required
+
+    assert "Cross-runtime implement/review demo" in product_index
+    assert "cross-runtime-impl-review-demo.md" in product_index
+
+    print("readme-demo-surface-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- reshape the README first screen toward a clearer product entry while preserving LoopX control-plane depth
- add a cross-runtime Claude Code implementation + Codex review demo contract
- add a focused README/demo surface smoke and link the product note from the product index

## Product judgment
Motivation: make the public README easier to parse at first glance and convert the Claude-implements/Codex-reviews idea into a bounded LoopX-native demo contract.

Solved: the README now has a clearer centered first screen, an explicit How It Works flow, short runtime entry table, and a demo path that links to a durable contract rather than overclaiming an executor.

Risk: public docs first-screen copy and public demo positioning. Owner reviewed and approved the first-screen direction before this PR. No runtime, benchmark, permission, or evidence-policy behavior changes.

## Validation
- python3 examples/readme-demo-surface-smoke.py
- python3 examples/docs-governance-smoke.py
- loopx check --scan-path README.md --scan-path docs/product/cross-runtime-impl-review-demo.md --scan-path docs/product/README.md --scan-path examples/readme-demo-surface-smoke.py
- git diff --check

## Boundary
Public docs and smoke only. Boundary scan passed; no private state, local paths, credentials, raw transcripts, benchmark logs, trajectories, or verifier output included.