### PR TITLE
Document auto-research one-command demo path

### DIFF
--- a/docs/guides/auto-research-command-path.md
+++ b/docs/guides/auto-research-command-path.md
@@ -32,6 +32,68 @@ export PATH="$HOME/.local/bin:$PATH"
 loopx doctor
 ```
 
+## 0. Prove The Positive E2E Path
+
+Start with the one-command replay before opening visible Codex lanes. The
+dry-run is read-only and tells the operator which command will run the positive
+replay:
+
+```bash
+loopx --registry "$LOOPX_REGISTRY" \
+  --runtime-root "$LOOPX_RUNTIME_ROOT" \
+  --format json auto-research demo-e2e \
+  --goal-id loopx-auto-research-knn \
+  --agent-id codex-side-bypass \
+  --reasoning-effort high
+```
+
+When the dry-run looks right, run the deterministic positive replay:
+
+```bash
+loopx --registry "$LOOPX_REGISTRY" \
+  --runtime-root "$LOOPX_RUNTIME_ROOT" \
+  --format json auto-research demo-e2e \
+  --goal-id loopx-auto-research-knn \
+  --agent-id codex-side-bypass \
+  --reasoning-effort high \
+  --execute
+```
+
+Expected positive result:
+
+- `replay_result.dev_metric` is `4.0`;
+- `replay_result.holdout_metric` is `4.5`;
+- dev and holdout exactness are both `true`;
+- `protected_scope_clean` is `true`;
+- the board is rollout-backed and has at least one promotion candidate;
+- `acceptance.ready_for_real_launch` is `true`.
+
+For a full visible demo, add the visible lane launcher:
+
+```bash
+loopx --registry "$LOOPX_REGISTRY" \
+  --runtime-root "$LOOPX_RUNTIME_ROOT" \
+  --format json auto-research demo-e2e \
+  --goal-id loopx-auto-research-knn \
+  --agent-id codex-side-bypass \
+  --reasoning-effort high \
+  --execute \
+  --launch-visible \
+  --launcher tmux \
+  --attach
+```
+
+If a previous visible rehearsal is still alive, retry with
+`--replace-existing` or stop it first:
+
+```bash
+tmux kill-session -t loopx-auto-research
+```
+
+The one-command E2E path must not record raw logs, private artifacts,
+credentials, or local absolute workspace paths. It writes only public rollout
+evidence through the normal LoopX runtime root when `--execute` is present.
+
 ## 1. Preview The Research Pack
 
 The quickstart starts read-only. It returns the research contract, protected

--- a/examples/auto-research-demo-e2e-smoke.py
+++ b/examples/auto-research-demo-e2e-smoke.py
@@ -15,6 +15,7 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parents[1]
 GOAL_ID = "loopx-auto-research-knn"
 AGENT_ID = "codex-side-bypass"
+GUIDE = REPO_ROOT / "docs" / "guides" / "auto-research-command-path.md"
 
 
 def assert_public_safe(payload: Any) -> None:
@@ -151,6 +152,30 @@ def main() -> int:
         assert "reasoning_effort: `high`" in markdown, markdown
         assert "positive replay:" in markdown, markdown
         assert_public_safe(markdown)
+
+        guide = GUIDE.read_text(encoding="utf-8")
+        assert "## 0. Prove The Positive E2E Path" in guide, guide
+        assert "auto-research demo-e2e" in guide, guide
+        assert "--reasoning-effort high" in guide, guide
+        assert "--execute" in guide, guide
+        assert "--launch-visible" in guide, guide
+        assert "--attach" in guide, guide
+        assert "--replace-existing" in guide, guide
+        assert "tmux kill-session -t loopx-auto-research" in guide, guide
+        assert "replay_result.dev_metric" in guide, guide
+        assert "`4.0`" in guide, guide
+        assert "replay_result.holdout_metric" in guide, guide
+        assert "`4.5`" in guide, guide
+        assert "acceptance.ready_for_real_launch" in guide, guide
+        assert "raw logs" in guide, guide
+        assert "private artifacts" in guide, guide
+        assert "credentials" in guide, guide
+        assert "local absolute workspace paths" in guide, guide
+        e2e_section = guide.split("## 0. Prove The Positive E2E Path", 1)[1].split(
+            "## 1. Preview The Research Pack",
+            1,
+        )[0]
+        assert_public_safe(e2e_section)
 
     print("auto-research-demo-e2e-smoke ok")
     return 0


### PR DESCRIPTION
## Summary
- Add a top-level one-command positive E2E path to the auto-research command guide.
- Document expected dev/holdout positive metrics, high reasoning mode, visible launch, attach/stop/retry, and public safety boundaries.
- Extend the auto-research E2E smoke so the guide keeps the one-command path discoverable.

## Validation
- python3 examples/auto-research-demo-e2e-smoke.py
- python3 examples/auto-research-visible-launcher-smoke.py
- python3 examples/docs-governance-smoke.py
- python3 -m py_compile examples/auto-research-demo-e2e-smoke.py
- git diff --check
- loopx check --scan-path docs/guides/auto-research-command-path.md --scan-path examples/auto-research-demo-e2e-smoke.py