### PR TITLE
Use README social preview banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<img src="docs/assets/loopx-logo.png" alt="LoopX loop engineering logo" width="180">
+<img src="docs/assets/loopx-social-preview.png" alt="LoopX loop engineering social preview banner" width="720">
 
 **Loop engineering for long-running AI agents.**
 

--- a/examples/readme-demo-surface-smoke.py
+++ b/examples/readme-demo-surface-smoke.py
@@ -26,6 +26,8 @@ def main() -> int:
 
     for required in [
         '<div align="center">',
+        "docs/assets/loopx-social-preview.png",
+        "LoopX loop engineering social preview banner",
         "Loop engineering for long-running AI agents.",
         "Manage Codex, Claude Code, Cursor, and other agent runtimes",
         "## How It Works",
@@ -40,6 +42,9 @@ def main() -> int:
         "docs/product/cross-runtime-impl-review-demo.md",
     ]:
         assert required in readme, required
+
+    first_screen = readme.split("## How It Works", 1)[0]
+    assert "docs/assets/loopx-logo.png" not in first_screen
 
     for required in [
         "`/loopx <implementation goal>`",


### PR DESCRIPTION
## Summary
- replace the README first-screen standalone logo with the existing social preview banner asset
- extend the README surface smoke so the banner choice stays covered

## Validation
- python3 examples/readme-demo-surface-smoke.py
- python3 examples/docs-governance-smoke.py
- loopx check --scan-path README.md --scan-path examples/readme-demo-surface-smoke.py
- git diff --check

## Boundary
- owner-approved first-screen presentation change
- public docs + focused smoke only; no runtime, benchmark scoring, permission, private state, or generated log changes