### PR TITLE
Extract visible multi-agent launcher seam

### DIFF
--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Smoke-test the reusable visible multi-agent launcher seam."""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from loopx.visible_multi_agent_launcher import execute_visible_multi_agent_launcher  # noqa: E402
+
+
+def write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def main() -> int:
+    auto_research_cli = (ROOT / "loopx/capabilities/auto_research/cli.py").read_text(
+        encoding="utf-8"
+    )
+    assert "from ...visible_multi_agent_launcher import execute_visible_multi_agent_launcher" in auto_research_cli
+    forbidden_defs = [
+        "def _launch_auto_research_with_tmux",
+        "def _tmux_visible_launch_acceptance",
+        "def _resolve_demo_workspace",
+        "def _resolve_auto_research_launcher",
+    ]
+    leaked_defs = [name for name in forbidden_defs if name in auto_research_cli]
+    assert not leaked_defs, leaked_defs
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        fake_bin = temp / "bin"
+        fake_bin.mkdir()
+        registry = temp / "registry.json"
+        runtime_root = temp / "runtime"
+        workspace = temp / "workspace"
+        tmux_log = temp / "tmux.jsonl"
+        registry.write_text(json.dumps({"common_runtime_root": str(runtime_root)}), encoding="utf-8")
+        write_executable(fake_bin / "loopx", "#!/usr/bin/env sh\nexit 0\n")
+        write_executable(fake_bin / "codex", "#!/usr/bin/env sh\nexit 0\n")
+        write_executable(
+            fake_bin / "tmux",
+            "\n".join(
+                [
+                    "#!/usr/bin/env python3",
+                    "import json, os, sys",
+                    "with open(os.environ['FAKE_TMUX_LOG'], 'a', encoding='utf-8') as f:",
+                    "    f.write(json.dumps(sys.argv[1:]) + '\\n')",
+                    "if len(sys.argv) > 1 and sys.argv[1] == 'has-session':",
+                    "    raise SystemExit(1)",
+                    "if len(sys.argv) > 1 and sys.argv[1] == 'list-windows':",
+                    "    print('planner\\nreviewer')",
+                    "    raise SystemExit(0)",
+                    "if len(sys.argv) > 1 and sys.argv[1] == 'capture-pane':",
+                    "    print('[LoopX visible acceptance]')",
+                    "    print('[LoopX role profile]')",
+                    "    print('[LoopX quota guard]')",
+                    "    print('[LoopX frontier]')",
+                    "    print('[bootstrap-or-stop]')",
+                    "    raise SystemExit(0)",
+                    "raise SystemExit(0)",
+                    "",
+                ]
+            ),
+        )
+
+        original_path = os.environ.get("PATH", "")
+        os.environ["PATH"] = f"{fake_bin}{os.pathsep}{original_path}"
+        os.environ["FAKE_TMUX_LOG"] = str(tmux_log)
+        try:
+            launch, chosen, workspace_mode = execute_visible_multi_agent_launcher(
+                payload={
+                    "session_name": "loopx-visible-launcher-smoke",
+                    "lanes": [
+                        {"lane_id": "planner", "frontier": "true", "visible_launch_command": "true"},
+                        {"lane_id": "reviewer", "visible_launch_command": "true"},
+                    ],
+                },
+                registry=registry,
+                runtime_root=runtime_root,
+                requested_launcher="tmux",
+                tmux_bin="tmux",
+                cli_bin="loopx",
+                codex_bin="codex",
+                attach=False,
+                replace_existing=False,
+                workspace=str(workspace),
+                create_workspace=True,
+                cwd=temp,
+            )
+        finally:
+            os.environ["PATH"] = original_path
+            os.environ.pop("FAKE_TMUX_LOG", None)
+
+        assert chosen == "tmux", launch
+        assert workspace_mode == "explicit_workspace", launch
+        assert workspace.is_dir(), workspace
+        assert launch["schema_version"] == "multi_agent_visible_launch_result_v0", launch
+        assert launch["started_lanes"] == ["planner", "reviewer"], launch
+        assert launch["surviving_lanes"] == ["planner", "reviewer"], launch
+        acceptance = launch["visible_acceptance"]
+        assert acceptance["schema_version"] == "multi_agent_visible_launch_acceptance_v0", acceptance
+        assert acceptance["accepted"] is True, acceptance
+        assert acceptance["missing_lanes"] == [], acceptance
+        assert all(item["frontier_or_blocked_reason_visible"] for item in acceptance["pane_checks"]), acceptance
+        log_entries = [json.loads(line) for line in tmux_log.read_text(encoding="utf-8").splitlines()]
+        assert any(entry[:1] == ["new-session"] for entry in log_entries), log_entries
+        assert sum(1 for entry in log_entries if entry[:1] == ["new-window"]) == 2, log_entries
+
+    print("visible-multi-agent-launcher-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -1,12 +1,6 @@
 from __future__ import annotations
 
 import argparse
-import os
-import platform
-import shlex
-import shutil
-import subprocess
-import time
 from collections import Counter
 from collections.abc import Callable
 from pathlib import Path
@@ -38,6 +32,7 @@ from ...rollout_event_log import (
     rollout_event_log_path,
 )
 from ...status import collect_status
+from ...visible_multi_agent_launcher import execute_visible_multi_agent_launcher
 
 
 PrintPayload = Callable[
@@ -411,374 +406,6 @@ def _append_auto_research_rollout_events(
     }
 
 
-def _require_executable(command: str, *, field: str) -> str:
-    path = shutil.which(command)
-    if not path:
-        raise ValueError(f"{field} executable not found on PATH: {command}")
-    return path
-
-
-def _apple_script_string(value: str) -> str:
-    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
-
-
-def _runtime_shell_command(
-    command: str,
-    *,
-    project: Path,
-    registry: Path,
-    runtime_root: Path,
-    errexit: bool = True,
-) -> str:
-    exports = [
-        "set -euo pipefail" if errexit else "set -uo pipefail",
-        f"export LOOPX_PROJECT={shlex.quote(str(project))}",
-        f"export LOOPX_REGISTRY={shlex.quote(str(registry))}",
-        f"export LOOPX_RUNTIME_ROOT={shlex.quote(str(runtime_root))}",
-    ]
-    return "; ".join([*exports, command])
-
-
-def _resolve_demo_workspace(
-    workspace: str | None,
-    *,
-    create: bool,
-    cwd: Path,
-) -> tuple[Path, str]:
-    if not workspace:
-        return cwd.resolve(), "current_directory"
-    path = Path(workspace).expanduser()
-    if not path.is_absolute():
-        path = cwd / path
-    if not path.exists():
-        if not create:
-            raise ValueError("workspace does not exist; pass --create-workspace to create it")
-        path.mkdir(parents=True, exist_ok=True)
-    if not path.is_dir():
-        raise ValueError("workspace must be a directory")
-    return path.resolve(), "explicit_workspace"
-
-
-def _mac_terminal_available() -> bool:
-    if platform.system() != "Darwin" or not shutil.which("osascript"):
-        return False
-    result = subprocess.run(
-        ["osascript", "-e", 'id of application "Terminal"'],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        check=False,
-        text=True,
-    )
-    return result.returncode == 0
-
-
-def _resolve_auto_research_launcher(*, requested: str, tmux_bin: str) -> str:
-    if requested != "auto":
-        return requested
-    if shutil.which(tmux_bin):
-        return "tmux"
-    if _mac_terminal_available():
-        return "terminal"
-    raise ValueError("no visible launcher found: install tmux or run on macOS with Terminal available")
-
-
-def _launch_auto_research_with_tmux(
-    *,
-    payload: dict[str, object],
-    project: Path,
-    workspace_mode: str,
-    registry: Path,
-    runtime_root: Path,
-    tmux_bin: str,
-    attach: bool,
-    replace_existing: bool,
-) -> dict[str, object]:
-    _require_executable(tmux_bin, field="tmux_bin")
-    session = str(payload.get("session_name") or "loopx-auto-research")
-    lanes = [item for item in payload.get("lanes", []) if isinstance(item, dict)]
-    if not lanes:
-        raise ValueError("demo supervisor has no lanes to launch")
-
-    env = os.environ.copy()
-    env.update(
-        {
-            "LOOPX_PROJECT": str(project),
-            "LOOPX_REGISTRY": str(registry),
-            "LOOPX_RUNTIME_ROOT": str(runtime_root),
-        }
-    )
-    exists = subprocess.run(
-        [tmux_bin, "has-session", "-t", session],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        check=False,
-        env=env,
-    )
-    if exists.returncode == 0:
-        if not replace_existing:
-            raise ValueError(
-                f"tmux session already exists: {session}; use --replace-existing or attach manually"
-            )
-        subprocess.run([tmux_bin, "kill-session", "-t", session], check=True, env=env)
-
-    first_frontier = str(lanes[0].get("frontier") or "")
-    if not first_frontier:
-        raise ValueError("first lane is missing a frontier command")
-    frontier_command = _runtime_shell_command(
-        f'cd "$LOOPX_PROJECT"; {first_frontier}; '
-        'FRONTIER_STATUS=$?; '
-        'printf "\\n[frontier window ready]\\nexit=%s\\n" "$FRONTIER_STATUS"; '
-        'exec /bin/sh -i',
-        project=project,
-        registry=registry,
-        runtime_root=runtime_root,
-        errexit=False,
-    )
-    subprocess.run(
-        [tmux_bin, "new-session", "-d", "-s", session, "-n", "frontier", "bash", "-lc", frontier_command],
-        check=True,
-        env=env,
-    )
-    started_lanes: list[str] = []
-    for lane in lanes:
-        lane_id = str(lane.get("lane_id") or "research-lane")
-        launch_command = str(lane.get("visible_launch_command") or "")
-        if not launch_command:
-            raise ValueError(f"lane {lane_id} is missing visible_launch_command")
-        subprocess.run(
-            [
-                tmux_bin,
-                "new-window",
-                "-d",
-                "-t",
-                session,
-                "-n",
-                lane_id,
-                "bash",
-                "-lc",
-                _runtime_shell_command(
-                    launch_command,
-                    project=project,
-                    registry=registry,
-                    runtime_root=runtime_root,
-                    errexit=False,
-                ),
-            ],
-            check=True,
-            env=env,
-        )
-        started_lanes.append(lane_id)
-    if attach:
-        subprocess.run([tmux_bin, "attach", "-t", session], check=True, env=env)
-    acceptance = _tmux_visible_launch_acceptance(
-        tmux_bin=tmux_bin,
-        session=session,
-        expected_lanes=started_lanes,
-        env=env,
-    )
-    return {
-        "schema_version": "auto_research_demo_launch_result_v0",
-        "executed": True,
-        "launcher": "tmux",
-        "session_name": session,
-        "started_lane_count": len(started_lanes),
-        "started_lanes": started_lanes,
-        "surviving_lane_count": len(acceptance["surviving_lanes"]),
-        "surviving_lanes": acceptance["surviving_lanes"],
-        "attach_command": f"{tmux_bin} attach -t {session}",
-        "stop_command": f"{tmux_bin} kill-session -t {session}",
-        "workspace_mode": workspace_mode,
-        "attach_requested": attach,
-        "operator_takeover": "attach to the tmux session, interrupt any lane, or kill the session",
-        "visible_acceptance": acceptance,
-    }
-
-
-def _tmux_visible_launch_acceptance(
-    *,
-    tmux_bin: str,
-    session: str,
-    expected_lanes: list[str],
-    env: dict[str, str],
-) -> dict[str, object]:
-    """Read back tmux pane evidence so launch success is not only process creation."""
-
-    required_markers = [
-        "[LoopX quota guard]",
-        "[bootstrap-or-stop]",
-    ]
-    last_payload: dict[str, object] | None = None
-    for attempt in range(20):
-        time.sleep(0.25)
-        list_result = subprocess.run(
-            [tmux_bin, "list-windows", "-t", session, "-F", "#{window_name}"],
-            check=False,
-            capture_output=True,
-            text=True,
-            env=env,
-        )
-        observed_windows = [
-            line.strip()
-            for line in list_result.stdout.splitlines()
-            if line.strip()
-        ]
-        surviving_lanes = [lane for lane in expected_lanes if lane in observed_windows]
-        lane_checks: list[dict[str, object]] = []
-        for lane in expected_lanes:
-            capture_result = subprocess.run(
-                [tmux_bin, "capture-pane", "-pt", f"{session}:{lane}", "-S", "-200"],
-                check=False,
-                capture_output=True,
-                text=True,
-                env=env,
-            )
-            capture = capture_result.stdout
-            visible_summary = "[LoopX visible acceptance]" in capture
-            role_profile_visible = (
-                "[LoopX role profile]" in capture
-                or "[LoopX role_profile]" in capture
-                or "role_profile=printed" in capture
-            )
-            quota_packet_visible = (
-                "[LoopX quota guard]" in capture
-                or "quota_guard=printed" in capture
-            )
-            bootstrap_or_stop_visible = (
-                "[bootstrap-or-stop]" in capture
-                or "bootstrap_or_stop=printed" in capture
-            )
-            markers_present = [marker for marker in required_markers if marker in capture]
-            if visible_summary:
-                markers_present.insert(0, "[LoopX visible acceptance]")
-            if role_profile_visible:
-                markers_present.insert(0, "[LoopX role profile]")
-            frontier_or_blocker_visible = (
-                "[LoopX auto-research frontier]" in capture
-                or "[LoopX blocked reason]" in capture
-                or "frontier_or_blocked_reason=printed" in capture
-            )
-            lane_checks.append(
-                {
-                    "lane_id": lane,
-                    "window_survived": lane in surviving_lanes,
-                    "capture_available": capture_result.returncode == 0,
-                    "role_profile_visible": role_profile_visible,
-                    "quota_packet_visible": quota_packet_visible,
-                    "frontier_or_blocked_reason_visible": frontier_or_blocker_visible,
-                    "bootstrap_or_stop_visible": bootstrap_or_stop_visible,
-                    "visible_acceptance_summary": visible_summary,
-                    "markers_present": markers_present,
-                }
-            )
-        accepted = (
-            list_result.returncode == 0
-            and len(surviving_lanes) == len(expected_lanes)
-            and all(
-                item["role_profile_visible"]
-                and item["quota_packet_visible"]
-                and item["frontier_or_blocked_reason_visible"]
-                and item["bootstrap_or_stop_visible"]
-                for item in lane_checks
-            )
-        )
-        last_payload = {
-            "schema_version": "auto_research_visible_launch_acceptance_v0",
-            "accepted": accepted,
-            "attempt_count": attempt + 1,
-            "observed_windows": observed_windows,
-            "expected_lanes": expected_lanes,
-            "surviving_lanes": surviving_lanes,
-            "missing_lanes": [lane for lane in expected_lanes if lane not in surviving_lanes],
-            "pane_checks": lane_checks,
-            "takeover_controls_visible": {
-                "attach_command": f"{tmux_bin} attach -t {session}",
-                "stop_command": f"{tmux_bin} kill-session -t {session}",
-            },
-        }
-        if accepted:
-            return last_payload
-    return last_payload or {
-        "schema_version": "auto_research_visible_launch_acceptance_v0",
-        "accepted": False,
-        "attempt_count": 0,
-        "observed_windows": [],
-        "expected_lanes": expected_lanes,
-        "surviving_lanes": [],
-        "missing_lanes": expected_lanes,
-        "pane_checks": [],
-        "takeover_controls_visible": {
-            "attach_command": f"{tmux_bin} attach -t {session}",
-            "stop_command": f"{tmux_bin} kill-session -t {session}",
-        },
-    }
-
-
-def _launch_auto_research_with_terminal(
-    *,
-    payload: dict[str, object],
-    project: Path,
-    workspace_mode: str,
-    registry: Path,
-    runtime_root: Path,
-) -> dict[str, object]:
-    _require_executable("osascript", field="osascript")
-    if not _mac_terminal_available():
-        raise ValueError("macOS Terminal is not available for --launcher terminal")
-    lanes = [item for item in payload.get("lanes", []) if isinstance(item, dict)]
-    if not lanes:
-        raise ValueError("demo supervisor has no lanes to launch")
-
-    first_frontier = str(lanes[0].get("frontier") or "")
-    frontier_command = _runtime_shell_command(
-        f'cd "$LOOPX_PROJECT"; {first_frontier}; printf "\\n[Terminal window ready]\\n"; exec $SHELL -l',
-        project=project,
-        registry=registry,
-        runtime_root=runtime_root,
-    )
-    subprocess.run(
-        [
-            "osascript",
-            "-e",
-            f'tell application "Terminal" to do script {_apple_script_string(frontier_command)}',
-        ],
-        check=True,
-    )
-    started_lanes: list[str] = []
-    for lane in lanes:
-        lane_id = str(lane.get("lane_id") or "research-lane")
-        launch_command = str(lane.get("visible_launch_command") or "")
-        if not launch_command:
-            raise ValueError(f"lane {lane_id} is missing visible_launch_command")
-        command = _runtime_shell_command(
-            f"printf '\\n[LoopX auto-research lane: {lane_id}]\\n'; {launch_command}",
-            project=project,
-            registry=registry,
-            runtime_root=runtime_root,
-        )
-        subprocess.run(
-            [
-                "osascript",
-                "-e",
-                f'tell application "Terminal" to do script {_apple_script_string(command)}',
-            ],
-            check=True,
-        )
-        started_lanes.append(lane_id)
-    return {
-        "schema_version": "auto_research_demo_launch_result_v0",
-        "executed": True,
-        "launcher": "terminal",
-        "session_name": str(payload.get("session_name") or "loopx-auto-research"),
-        "started_lane_count": len(started_lanes),
-        "started_lanes": started_lanes,
-        "attach_command": "already visible in Terminal windows",
-        "stop_command": "interrupt or close the opened Terminal windows",
-        "workspace_mode": workspace_mode,
-        "attach_requested": False,
-        "operator_takeover": "use the visible Terminal windows; interrupt any lane before writeback",
-    }
-
-
 def _execute_auto_research_demo_supervisor(
     payload: dict[str, object],
     *,
@@ -793,35 +420,31 @@ def _execute_auto_research_demo_supervisor(
     workspace: str | None,
     create_workspace: bool,
 ) -> dict[str, object]:
-    _require_executable(cli_bin, field="cli_bin")
-    _require_executable(codex_bin, field="codex_bin")
     registry = load_registry(registry_path)
     runtime_root = resolve_runtime_root(registry, runtime_root_arg)
-    chosen = _resolve_auto_research_launcher(requested=launcher, tmux_bin=tmux_bin)
-    project, workspace_mode = _resolve_demo_workspace(
-        workspace,
-        create=create_workspace,
+    result, chosen, workspace_mode = execute_visible_multi_agent_launcher(
+        payload=payload,
+        registry=registry_path,
+        runtime_root=runtime_root,
+        requested_launcher=launcher,
+        tmux_bin=tmux_bin,
+        cli_bin=cli_bin,
+        codex_bin=codex_bin,
+        attach=attach,
+        replace_existing=replace_existing,
+        workspace=workspace,
+        create_workspace=create_workspace,
         cwd=Path.cwd(),
+        launch_result_schema="auto_research_demo_launch_result_v0",
+        acceptance_schema="auto_research_visible_launch_acceptance_v0",
+        lane_default="research-lane",
+        terminal_lane_label_template="[LoopX auto-research lane: {lane_id}]",
+        frontier_or_blocker_markers=(
+            "[LoopX auto-research frontier]",
+            "[LoopX blocked reason]",
+        ),
+        frontier_or_blocker_status_markers=("frontier_or_blocked_reason=printed",),
     )
-    if chosen == "tmux":
-        result = _launch_auto_research_with_tmux(
-            payload=payload,
-            project=project,
-            workspace_mode=workspace_mode,
-            registry=registry_path,
-            runtime_root=runtime_root,
-            tmux_bin=tmux_bin,
-            attach=attach,
-            replace_existing=replace_existing,
-        )
-    else:
-        result = _launch_auto_research_with_terminal(
-            payload=payload,
-            project=project,
-            workspace_mode=workspace_mode,
-            registry=registry_path,
-            runtime_root=runtime_root,
-        )
     payload["mode"] = "executed_visible_launch"
     payload["launch_result"] = result
     boundary = payload.get("boundary")

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -1,0 +1,454 @@
+from __future__ import annotations
+
+import os
+import platform
+import shlex
+import shutil
+import subprocess
+import time
+from collections.abc import Iterable
+from pathlib import Path
+
+
+def require_executable(command: str, *, field: str) -> str:
+    path = shutil.which(command)
+    if not path:
+        raise ValueError(f"{field} executable not found on PATH: {command}")
+    return path
+
+
+def runtime_shell_command(
+    command: str,
+    *,
+    project: Path,
+    registry: Path,
+    runtime_root: Path,
+    errexit: bool = True,
+) -> str:
+    exports = [
+        "set -euo pipefail" if errexit else "set -uo pipefail",
+        f"export LOOPX_PROJECT={shlex.quote(str(project))}",
+        f"export LOOPX_REGISTRY={shlex.quote(str(registry))}",
+        f"export LOOPX_RUNTIME_ROOT={shlex.quote(str(runtime_root))}",
+    ]
+    return "; ".join([*exports, command])
+
+
+def resolve_visible_workspace(
+    workspace: str | None,
+    *,
+    create: bool,
+    cwd: Path,
+) -> tuple[Path, str]:
+    if not workspace:
+        return cwd.resolve(), "current_directory"
+    path = Path(workspace).expanduser()
+    if not path.is_absolute():
+        path = cwd / path
+    if not path.exists():
+        if not create:
+            raise ValueError("workspace does not exist; pass --create-workspace to create it")
+        path.mkdir(parents=True, exist_ok=True)
+    if not path.is_dir():
+        raise ValueError("workspace must be a directory")
+    return path.resolve(), "explicit_workspace"
+
+
+def mac_terminal_available() -> bool:
+    if platform.system() != "Darwin" or not shutil.which("osascript"):
+        return False
+    result = subprocess.run(
+        ["osascript", "-e", 'id of application "Terminal"'],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def resolve_visible_launcher(*, requested: str, tmux_bin: str) -> str:
+    if requested != "auto":
+        return requested
+    if shutil.which(tmux_bin):
+        return "tmux"
+    if mac_terminal_available():
+        return "terminal"
+    raise ValueError("no visible launcher found: install tmux or run on macOS with Terminal available")
+
+
+def execute_visible_multi_agent_launcher(
+    *,
+    payload: dict[str, object],
+    registry: Path,
+    runtime_root: Path,
+    requested_launcher: str,
+    tmux_bin: str,
+    cli_bin: str,
+    codex_bin: str,
+    attach: bool,
+    replace_existing: bool,
+    workspace: str | None,
+    create_workspace: bool,
+    cwd: Path,
+    launch_result_schema: str = "multi_agent_visible_launch_result_v0",
+    acceptance_schema: str = "multi_agent_visible_launch_acceptance_v0",
+    lane_default: str = "agent-lane",
+    terminal_lane_label_template: str = "[LoopX visible lane: {lane_id}]",
+    frontier_or_blocker_markers: Iterable[str] = ("[LoopX frontier]", "[LoopX blocked reason]"),
+    frontier_or_blocker_status_markers: Iterable[str] = ("frontier_or_blocked_reason=printed",),
+) -> tuple[dict[str, object], str, str]:
+    require_executable(cli_bin, field="cli_bin")
+    require_executable(codex_bin, field="codex_bin")
+    chosen = resolve_visible_launcher(requested=requested_launcher, tmux_bin=tmux_bin)
+    project, workspace_mode = resolve_visible_workspace(
+        workspace,
+        create=create_workspace,
+        cwd=cwd,
+    )
+    if chosen == "tmux":
+        result = launch_visible_multi_agent_with_tmux(
+            payload=payload,
+            project=project,
+            workspace_mode=workspace_mode,
+            registry=registry,
+            runtime_root=runtime_root,
+            tmux_bin=tmux_bin,
+            attach=attach,
+            replace_existing=replace_existing,
+            launch_result_schema=launch_result_schema,
+            acceptance_schema=acceptance_schema,
+            lane_default=lane_default,
+            frontier_or_blocker_markers=frontier_or_blocker_markers,
+            frontier_or_blocker_status_markers=frontier_or_blocker_status_markers,
+        )
+    elif chosen == "terminal":
+        result = launch_visible_multi_agent_with_terminal(
+            payload=payload,
+            project=project,
+            workspace_mode=workspace_mode,
+            registry=registry,
+            runtime_root=runtime_root,
+            launch_result_schema=launch_result_schema,
+            lane_default=lane_default,
+            terminal_lane_label_template=terminal_lane_label_template,
+        )
+    else:
+        raise ValueError(f"unsupported visible launcher: {chosen}")
+    return result, chosen, workspace_mode
+
+
+def launch_visible_multi_agent_with_tmux(
+    *,
+    payload: dict[str, object],
+    project: Path,
+    workspace_mode: str,
+    registry: Path,
+    runtime_root: Path,
+    tmux_bin: str,
+    attach: bool,
+    replace_existing: bool,
+    launch_result_schema: str,
+    acceptance_schema: str,
+    lane_default: str,
+    frontier_or_blocker_markers: Iterable[str],
+    frontier_or_blocker_status_markers: Iterable[str],
+) -> dict[str, object]:
+    require_executable(tmux_bin, field="tmux_bin")
+    session = str(payload.get("session_name") or "loopx-visible-agents")
+    lanes = [item for item in payload.get("lanes", []) if isinstance(item, dict)]
+    if not lanes:
+        raise ValueError("visible multi-agent launcher has no lanes to launch")
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "LOOPX_PROJECT": str(project),
+            "LOOPX_REGISTRY": str(registry),
+            "LOOPX_RUNTIME_ROOT": str(runtime_root),
+        }
+    )
+    exists = subprocess.run(
+        [tmux_bin, "has-session", "-t", session],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        check=False,
+        env=env,
+    )
+    if exists.returncode == 0:
+        if not replace_existing:
+            raise ValueError(
+                f"tmux session already exists: {session}; use --replace-existing or attach manually"
+            )
+        subprocess.run([tmux_bin, "kill-session", "-t", session], check=True, env=env)
+
+    first_frontier = str(lanes[0].get("frontier") or "")
+    if not first_frontier:
+        raise ValueError("first lane is missing a frontier command")
+    frontier_command = runtime_shell_command(
+        f'cd "$LOOPX_PROJECT"; {first_frontier}; '
+        'FRONTIER_STATUS=$?; '
+        'printf "\\n[frontier window ready]\\nexit=%s\\n" "$FRONTIER_STATUS"; '
+        'exec /bin/sh -i',
+        project=project,
+        registry=registry,
+        runtime_root=runtime_root,
+        errexit=False,
+    )
+    subprocess.run(
+        [tmux_bin, "new-session", "-d", "-s", session, "-n", "frontier", "bash", "-lc", frontier_command],
+        check=True,
+        env=env,
+    )
+    started_lanes: list[str] = []
+    for lane in lanes:
+        lane_id = str(lane.get("lane_id") or lane_default)
+        launch_command = str(lane.get("visible_launch_command") or "")
+        if not launch_command:
+            raise ValueError(f"lane {lane_id} is missing visible_launch_command")
+        subprocess.run(
+            [
+                tmux_bin,
+                "new-window",
+                "-d",
+                "-t",
+                session,
+                "-n",
+                lane_id,
+                "bash",
+                "-lc",
+                runtime_shell_command(
+                    launch_command,
+                    project=project,
+                    registry=registry,
+                    runtime_root=runtime_root,
+                    errexit=False,
+                ),
+            ],
+            check=True,
+            env=env,
+        )
+        started_lanes.append(lane_id)
+    if attach:
+        subprocess.run([tmux_bin, "attach", "-t", session], check=True, env=env)
+    acceptance = tmux_visible_launch_acceptance(
+        tmux_bin=tmux_bin,
+        session=session,
+        expected_lanes=started_lanes,
+        env=env,
+        schema_version=acceptance_schema,
+        frontier_or_blocker_markers=frontier_or_blocker_markers,
+        frontier_or_blocker_status_markers=frontier_or_blocker_status_markers,
+    )
+    return {
+        "schema_version": launch_result_schema,
+        "executed": True,
+        "launcher": "tmux",
+        "session_name": session,
+        "started_lane_count": len(started_lanes),
+        "started_lanes": started_lanes,
+        "surviving_lane_count": len(acceptance["surviving_lanes"]),
+        "surviving_lanes": acceptance["surviving_lanes"],
+        "attach_command": f"{tmux_bin} attach -t {session}",
+        "stop_command": f"{tmux_bin} kill-session -t {session}",
+        "workspace_mode": workspace_mode,
+        "attach_requested": attach,
+        "operator_takeover": "attach to the tmux session, interrupt any lane, or kill the session",
+        "visible_acceptance": acceptance,
+    }
+
+
+def tmux_visible_launch_acceptance(
+    *,
+    tmux_bin: str,
+    session: str,
+    expected_lanes: list[str],
+    env: dict[str, str],
+    schema_version: str,
+    frontier_or_blocker_markers: Iterable[str],
+    frontier_or_blocker_status_markers: Iterable[str],
+) -> dict[str, object]:
+    """Read back tmux pane evidence so launch success is not only process creation."""
+
+    required_markers = [
+        "[LoopX quota guard]",
+        "[bootstrap-or-stop]",
+    ]
+    frontier_markers = tuple(frontier_or_blocker_markers)
+    frontier_status_markers = tuple(frontier_or_blocker_status_markers)
+    last_payload: dict[str, object] | None = None
+    for attempt in range(20):
+        time.sleep(0.25)
+        list_result = subprocess.run(
+            [tmux_bin, "list-windows", "-t", session, "-F", "#{window_name}"],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        observed_windows = [
+            line.strip()
+            for line in list_result.stdout.splitlines()
+            if line.strip()
+        ]
+        surviving_lanes = [lane for lane in expected_lanes if lane in observed_windows]
+        lane_checks: list[dict[str, object]] = []
+        for lane in expected_lanes:
+            capture_result = subprocess.run(
+                [tmux_bin, "capture-pane", "-pt", f"{session}:{lane}", "-S", "-200"],
+                check=False,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+            capture = capture_result.stdout
+            visible_summary = "[LoopX visible acceptance]" in capture
+            role_profile_visible = (
+                "[LoopX role profile]" in capture
+                or "[LoopX role_profile]" in capture
+                or "role_profile=printed" in capture
+            )
+            quota_packet_visible = (
+                "[LoopX quota guard]" in capture
+                or "quota_guard=printed" in capture
+            )
+            bootstrap_or_stop_visible = (
+                "[bootstrap-or-stop]" in capture
+                or "bootstrap_or_stop=printed" in capture
+            )
+            markers_present = [marker for marker in required_markers if marker in capture]
+            if visible_summary:
+                markers_present.insert(0, "[LoopX visible acceptance]")
+            if role_profile_visible:
+                markers_present.insert(0, "[LoopX role profile]")
+            frontier_or_blocker_visible = (
+                any(marker in capture for marker in frontier_markers)
+                or any(marker in capture for marker in frontier_status_markers)
+            )
+            lane_checks.append(
+                {
+                    "lane_id": lane,
+                    "window_survived": lane in surviving_lanes,
+                    "capture_available": capture_result.returncode == 0,
+                    "role_profile_visible": role_profile_visible,
+                    "quota_packet_visible": quota_packet_visible,
+                    "frontier_or_blocked_reason_visible": frontier_or_blocker_visible,
+                    "bootstrap_or_stop_visible": bootstrap_or_stop_visible,
+                    "visible_acceptance_summary": visible_summary,
+                    "markers_present": markers_present,
+                }
+            )
+        accepted = (
+            list_result.returncode == 0
+            and len(surviving_lanes) == len(expected_lanes)
+            and all(
+                item["role_profile_visible"]
+                and item["quota_packet_visible"]
+                and item["frontier_or_blocked_reason_visible"]
+                and item["bootstrap_or_stop_visible"]
+                for item in lane_checks
+            )
+        )
+        last_payload = {
+            "schema_version": schema_version,
+            "accepted": accepted,
+            "attempt_count": attempt + 1,
+            "observed_windows": observed_windows,
+            "expected_lanes": expected_lanes,
+            "surviving_lanes": surviving_lanes,
+            "missing_lanes": [lane for lane in expected_lanes if lane not in surviving_lanes],
+            "pane_checks": lane_checks,
+            "takeover_controls_visible": {
+                "attach_command": f"{tmux_bin} attach -t {session}",
+                "stop_command": f"{tmux_bin} kill-session -t {session}",
+            },
+        }
+        if accepted:
+            return last_payload
+    return last_payload or {
+        "schema_version": schema_version,
+        "accepted": False,
+        "attempt_count": 0,
+        "observed_windows": [],
+        "expected_lanes": expected_lanes,
+        "surviving_lanes": [],
+        "missing_lanes": expected_lanes,
+        "pane_checks": [],
+        "takeover_controls_visible": {
+            "attach_command": f"{tmux_bin} attach -t {session}",
+            "stop_command": f"{tmux_bin} kill-session -t {session}",
+        },
+    }
+
+
+def launch_visible_multi_agent_with_terminal(
+    *,
+    payload: dict[str, object],
+    project: Path,
+    workspace_mode: str,
+    registry: Path,
+    runtime_root: Path,
+    launch_result_schema: str,
+    lane_default: str,
+    terminal_lane_label_template: str,
+) -> dict[str, object]:
+    require_executable("osascript", field="osascript")
+    if not mac_terminal_available():
+        raise ValueError("macOS Terminal is not available for --launcher terminal")
+    lanes = [item for item in payload.get("lanes", []) if isinstance(item, dict)]
+    if not lanes:
+        raise ValueError("visible multi-agent launcher has no lanes to launch")
+
+    first_frontier = str(lanes[0].get("frontier") or "")
+    frontier_command = runtime_shell_command(
+        f'cd "$LOOPX_PROJECT"; {first_frontier}; printf "\\n[Terminal window ready]\\n"; exec $SHELL -l',
+        project=project,
+        registry=registry,
+        runtime_root=runtime_root,
+    )
+    subprocess.run(
+        [
+            "osascript",
+            "-e",
+            f'tell application "Terminal" to do script {_apple_script_string(frontier_command)}',
+        ],
+        check=True,
+    )
+    started_lanes: list[str] = []
+    for lane in lanes:
+        lane_id = str(lane.get("lane_id") or lane_default)
+        launch_command = str(lane.get("visible_launch_command") or "")
+        if not launch_command:
+            raise ValueError(f"lane {lane_id} is missing visible_launch_command")
+        command = runtime_shell_command(
+            f"printf '\\n{terminal_lane_label_template.format(lane_id=lane_id)}\\n'; {launch_command}",
+            project=project,
+            registry=registry,
+            runtime_root=runtime_root,
+        )
+        subprocess.run(
+            [
+                "osascript",
+                "-e",
+                f'tell application "Terminal" to do script {_apple_script_string(command)}',
+            ],
+            check=True,
+        )
+        started_lanes.append(lane_id)
+    return {
+        "schema_version": launch_result_schema,
+        "executed": True,
+        "launcher": "terminal",
+        "session_name": str(payload.get("session_name") or "loopx-visible-agents"),
+        "started_lane_count": len(started_lanes),
+        "started_lanes": started_lanes,
+        "attach_command": "already visible in Terminal windows",
+        "stop_command": "interrupt or close the opened Terminal windows",
+        "workspace_mode": workspace_mode,
+        "attach_requested": False,
+        "operator_takeover": "use the visible Terminal windows; interrupt any lane before writeback",
+    }
+
+
+def _apple_script_string(value: str) -> str:
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'


### PR DESCRIPTION
## Summary
- Extract reusable tmux/Terminal visible multi-agent launch mechanics into `loopx/visible_multi_agent_launcher.py`.
- Keep auto-research as a thin domain adapter that supplies its schema, lane defaults, acceptance markers, and boundary updates.
- Add a durable smoke that calls the generic launcher directly and guards against generic pane logic growing back into auto-research CLI code.

## Validation
- `python3 examples/visible-multi-agent-launcher-smoke.py`
- `python3 examples/auto-research-visible-launcher-smoke.py`
- `python3 examples/auto-research-demo-e2e-smoke.py`
- `python3 examples/multi-agent-visible-launcher-protocol-smoke.py`
- `python3 -m py_compile loopx/visible_multi_agent_launcher.py loopx/capabilities/auto_research/cli.py examples/visible-multi-agent-launcher-smoke.py`
- `git diff --check origin/main...HEAD`
- `loopx check --scan-path loopx/visible_multi_agent_launcher.py --scan-path loopx/capabilities/auto_research/cli.py --scan-path examples/visible-multi-agent-launcher-smoke.py` (clean; pre-existing duplicate index rows warning only)

## Boundary
- No private state, raw logs, credentials, local paths, or absolute runtime artifacts are committed.
- This is a seam extraction plus smoke; auto-research visible demo behavior is covered by existing smokes.
