### PR TITLE
Document and smoke one-command auto-research demo

### DIFF
--- a/docs/guides/auto-research-command-path.md
+++ b/docs/guides/auto-research-command-path.md
@@ -34,8 +34,30 @@ loopx doctor
 
 ## 0. Prove The Positive E2E Path
 
-Start with the one-command replay before opening visible Codex lanes. The
-dry-run is read-only and tells the operator which command will run the positive
+The smallest visible demo is one command. It runs the deterministic positive
+replay, then opens the visible multi-agent panes through the normal
+auto-research surface:
+
+```bash
+loopx --registry "$LOOPX_REGISTRY" \
+  --runtime-root "$LOOPX_RUNTIME_ROOT" \
+  --format json auto-research demo-e2e \
+  --goal-id loopx-auto-research-knn \
+  --agent-id codex-side-bypass \
+  --reasoning-effort high \
+  --execute \
+  --launch-visible \
+  --launcher tmux \
+  --workspace ./loopx-auto-research-demo \
+  --create-workspace \
+  --attach
+```
+
+That command is the user-facing UX. Generic launcher internals stay inside
+LoopX; the operator does not need to know the module or implementation path.
+
+If you want to inspect before opening visible Codex lanes, start with the
+read-only dry-run. It tells the operator which command will run the positive
 replay:
 
 ```bash
@@ -68,7 +90,8 @@ Expected positive result:
 - the board is rollout-backed and has at least one promotion candidate;
 - `acceptance.ready_for_real_launch` is `true`.
 
-For a full visible demo, add the visible lane launcher:
+For a full visible demo after an explicit replay step, add the visible lane
+launcher:
 
 ```bash
 loopx --registry "$LOOPX_REGISTRY" \

--- a/examples/auto-research-one-click-ux-smoke.py
+++ b/examples/auto-research-one-click-ux-smoke.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Smoke-test the one-command visible auto-research UX."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GUIDE = REPO_ROOT / "docs" / "guides" / "auto-research-command-path.md"
+GOAL_ID = "loopx-auto-research-knn"
+AGENT_ID = "codex-side-bypass"
+SESSION = "loopx-auto-research-one-click-smoke"
+
+
+def write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def assert_public_safe(payload: Any) -> None:
+    text = json.dumps(payload, sort_keys=True) if not isinstance(payload, str) else payload
+    forbidden = [
+        "/" + "Users/",
+        "/" + "private/",
+        "/" + "tmp/",
+        "lark" + "office",
+        "byte" + "dance",
+        "http://",
+        "https://",
+        "api" + "_key",
+        "pass" + "word",
+        "sec" + "ret",
+    ]
+    leaked = [needle for needle in forbidden if needle.lower() in text.lower()]
+    assert not leaked, leaked
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        fake_bin = temp / "bin"
+        fake_bin.mkdir()
+        registry = temp / "registry.json"
+        runtime_root = temp / "runtime"
+        tmux_log = temp / "tmux.jsonl"
+        workspace = temp / "one-click-workspace"
+        registry.write_text(
+            json.dumps({"common_runtime_root": str(runtime_root), "goals": []}),
+            encoding="utf-8",
+        )
+        write_executable(fake_bin / "loopx", "#!/usr/bin/env sh\nexit 0\n")
+        write_executable(fake_bin / "codex", "#!/usr/bin/env sh\nexit 0\n")
+        write_executable(
+            fake_bin / "tmux",
+            "\n".join(
+                [
+                    "#!/usr/bin/env python3",
+                    "import json, os, sys",
+                    "lanes = ['frontier', 'research-curator', 'hypothesis-mapper', 'evidence-runner']",
+                    "with open(os.environ['FAKE_TMUX_LOG'], 'a', encoding='utf-8') as f:",
+                    "    f.write(json.dumps(sys.argv[1:]) + '\\n')",
+                    "if len(sys.argv) > 1 and sys.argv[1] == 'has-session':",
+                    "    raise SystemExit(1)",
+                    "if len(sys.argv) > 1 and sys.argv[1] == 'list-windows':",
+                    "    print('\\n'.join(lanes))",
+                    "    raise SystemExit(0)",
+                    "if len(sys.argv) > 1 and sys.argv[1] == 'capture-pane':",
+                    "    print('[LoopX visible acceptance]')",
+                    "    print('[LoopX role profile]')",
+                    "    print('role_profile=printed')",
+                    "    print('[LoopX quota guard]')",
+                    "    print('quota_guard=printed')",
+                    "    print('[LoopX auto-research frontier]')",
+                    "    print('frontier_or_blocked_reason=printed')",
+                    "    print('[bootstrap-or-stop]')",
+                    "    print('bootstrap_or_stop=printed')",
+                    "    raise SystemExit(0)",
+                    "raise SystemExit(0)",
+                    "",
+                ]
+            ),
+        )
+
+        env = os.environ.copy()
+        env["PATH"] = f"{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+        env["PYTHONDONTWRITEBYTECODE"] = "1"
+        env["FAKE_TMUX_LOG"] = str(tmux_log)
+
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "loopx.cli",
+                "--registry",
+                str(registry),
+                "--runtime-root",
+                str(runtime_root),
+                "--format",
+                "json",
+                "auto-research",
+                "demo-e2e",
+                "--goal-id",
+                GOAL_ID,
+                "--agent-id",
+                AGENT_ID,
+                "--reasoning-effort",
+                "high",
+                "--execute",
+                "--launch-visible",
+                "--launcher",
+                "tmux",
+                "--session-name",
+                SESSION,
+                "--workspace",
+                str(workspace),
+                "--create-workspace",
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        payload = json.loads(result.stdout)
+        assert payload["ok"] is True, payload
+        assert payload["mode"] == "execute", payload
+        assert payload["reasoning_effort"] == "high", payload
+        assert payload["replay_result"]["dev_metric"] == 4.0, payload
+        assert payload["replay_result"]["holdout_metric"] == 4.5, payload
+        assert payload["replay_result"]["protected_scope_clean"] is True, payload
+        assert payload["acceptance"]["ready_for_real_launch"] is True, payload
+        assert payload["public_boundary"]["launches_visible_lanes"] is True, payload
+        assert payload["public_boundary"]["local_workspace_path_redacted"] is True, payload
+        visible = payload["visible_launch"]
+        assert visible["mode"] == "executed_visible_launch", visible
+        assert visible["boundary"]["shared_goal_surface"] is True, visible
+        assert visible["boundary"]["all_lane_workspace_isolation"] is False, visible
+        launch = visible["launch_result"]
+        assert launch["launcher"] == "tmux", launch
+        assert launch["session_name"] == SESSION, launch
+        assert launch["workspace_mode"] == "explicit_workspace", launch
+        assert launch["started_lane_count"] == 3, launch
+        assert launch["visible_acceptance"]["accepted"] is True, launch
+        assert workspace.is_dir(), workspace
+
+        guide = GUIDE.read_text(encoding="utf-8")
+        one_command_section = guide.split("The smallest visible demo is one command.", 1)[1].split(
+            "If you want to inspect before opening visible Codex lanes",
+            1,
+        )[0]
+        for snippet in [
+            "auto-research demo-e2e",
+            "--execute",
+            "--launch-visible",
+            "--launcher tmux",
+            "--workspace ./loopx-auto-research-demo",
+            "--create-workspace",
+            "--attach",
+            "Generic launcher internals stay inside\nLoopX",
+        ]:
+            assert snippet in one_command_section, snippet
+        assert "visible_multi_agent_launcher" not in guide, guide
+        assert "loopx/visible_multi_agent_launcher.py" not in guide, guide
+        assert_public_safe(one_command_section)
+        assert_public_safe(payload)
+
+        log_entries = [json.loads(line) for line in tmux_log.read_text(encoding="utf-8").splitlines()]
+        assert any(entry[:1] == ["new-session"] for entry in log_entries), log_entries
+        assert sum(1 for entry in log_entries if entry[:1] == ["new-window"]) == 3, log_entries
+        assert any(entry[:1] == ["list-windows"] for entry in log_entries), log_entries
+        assert sum(1 for entry in log_entries if entry[:1] == ["capture-pane"]) == 3, log_entries
+
+    print("auto-research-one-click-ux-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- Put the shortest visible auto-research demo command at the front of the command-path guide.
- Add a durable one-click UX smoke that runs `auto-research demo-e2e --execute --launch-visible` with fake tmux/Codex binaries and verifies the positive replay plus visible pane acceptance.
- Guard that the user-facing guide does not expose the internal `visible_multi_agent_launcher` module path.

## Validation
- `python3 examples/auto-research-one-click-ux-smoke.py`
- `python3 examples/auto-research-demo-e2e-smoke.py`
- `python3 examples/auto-research-visible-launcher-smoke.py`
- `python3 examples/visible-multi-agent-launcher-smoke.py`
- `python3 examples/multi-agent-visible-launcher-protocol-smoke.py`
- `python3 -m py_compile examples/auto-research-one-click-ux-smoke.py`
- `git diff --check origin/main...HEAD`
- `loopx check --scan-path docs/guides/auto-research-command-path.md --scan-path examples/auto-research-one-click-ux-smoke.py` (clean; pre-existing duplicate index rows warning only)

## Boundary
- Public docs and a public smoke only.
- No private state, raw logs, credentials, local paths, or runtime artifacts committed.
