### PR TITLE
Classify thought-only app-server Goal stalls

### DIFF
--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -144,6 +144,51 @@ for line in sys.stdin:
     print(json.dumps({"id": mid, "result": result}), flush=True)
 """
 
+FAKE_CODEX_THOUGHT_ONLY_NO_COMPLETION = """#!/usr/bin/env python3
+import json
+import sys
+import time
+
+for line in sys.stdin:
+    msg = json.loads(line)
+    mid = msg.get("id")
+    method = msg.get("method")
+    if method == "initialized":
+        continue
+    if method == "initialize":
+        result = {"serverInfo": {"name": "fake-codex"}}
+    elif method == "thread/start":
+        result = {"thread": {"id": "thread-skillsbench"}}
+    elif method == "thread/goal/set":
+        result = {"goal": {"threadId": "thread-skillsbench", "status": "active"}}
+    elif method == "thread/goal/get":
+        result = {"goal": {"threadId": "thread-skillsbench", "status": "active"}}
+    elif method == "turn/start":
+        print(json.dumps({
+            "method": "turn/started",
+            "params": {
+                "threadId": "thread-skillsbench",
+                "turn": {"id": "turn-thought-only", "status": "inProgress"},
+            },
+        }), flush=True)
+        result = {"turn": {"id": "turn-thought-only", "status": "running"}}
+        print(json.dumps({"id": mid, "result": result}), flush=True)
+        print(json.dumps({
+            "method": "item/agentMessage/delta",
+            "params": {
+                "threadId": "thread-skillsbench",
+                "turnId": "turn-thought-only",
+                "itemId": "item-thought-only",
+                "delta": "thinking heartbeat without task action",
+            },
+        }), flush=True)
+        time.sleep(10)
+        continue
+    else:
+        result = {}
+    print(json.dumps({"id": mid, "result": result}), flush=True)
+"""
+
 FAKE_CODEX_USER_ONLY_COMPLETED = """#!/usr/bin/env python3
 import json
 import sys
@@ -598,6 +643,56 @@ def test_host_worker_fails_closed_on_first_action_timeout() -> None:
         assert payload["turn"]["first_action_timeout_sec"] == 1.0, payload
         assert not private_response.exists(), result
         assert not list(work.glob(".loopx_app_server_goal_worker_response_*.txt"))
+
+
+def test_host_worker_treats_thought_delta_as_no_effective_first_action() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-app-goal-worker-thought-only-") as tmp:
+        root = Path(tmp)
+        fake = root / "codex"
+        prompt = root / "prompt.txt"
+        output = root / "worker.compact.json"
+        private_response = root / "private-response.txt"
+        fake.write_text(FAKE_CODEX_THOUGHT_ONLY_NO_COMPLETION, encoding="utf-8")
+        fake.chmod(0o755)
+        prompt.write_text("Private task instruction placeholder.", encoding="utf-8")
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(WORKER_SCRIPT),
+                "--task-id",
+                "llm-prefix-cache-replay",
+                "--codex-bin",
+                str(fake),
+                "--work-dir",
+                str(root / "work"),
+                "--prompt-file",
+                str(prompt),
+                "--output-json",
+                str(output),
+                "--response-text-file",
+                str(private_response),
+                "--response-timeout-sec",
+                "5",
+                "--turn-timeout-sec",
+                "5",
+                "--first-action-timeout-sec",
+                "1",
+            ],
+            cwd=REPO_ROOT,
+            check=False,
+            text=True,
+            capture_output=True,
+        )
+        assert result.returncode == 1, result
+        payload = json.loads(output.read_text(encoding="utf-8"))
+        assert payload["ok"] is False, payload
+        assert payload["error_type"] == "codex_exec_first_action_timeout", payload
+        assert payload["turn"]["first_action_observed"] is True, payload
+        assert payload["turn"]["effective_action_observed"] is False, payload
+        assert payload["turn"]["agent_message_delta_count"] == 1, payload
+        assert payload["turn"]["turn_completed_observed"] is False, payload
+        assert payload["turn"]["assistant_message_present"] is False, payload
+        assert not private_response.exists(), payload
 
 
 def test_host_worker_fails_closed_when_only_user_message_echo_completes() -> None:

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -2400,6 +2400,12 @@ def _skillsbench_controller_trace_counters(
         "native_goal_worker_assistant_message_present_count": count(
             "native_goal_worker_assistant_message_present_count"
         ),
+        "native_goal_worker_first_action_observed_count": count(
+            "native_goal_worker_first_action_observed_count"
+        ),
+        "native_goal_worker_effective_action_observed_count": count(
+            "native_goal_worker_effective_action_observed_count"
+        ),
         "remote_command_file_bridge_consumed_by_solver": controller_trace.get(
             "remote_command_file_bridge_consumed_by_solver"
         )
@@ -3479,6 +3485,12 @@ def build_skillsbench_benchflow_result_benchmark_run(
         ),
         "assistant_message_present_count": _controller_public_count(
             "native_goal_worker_assistant_message_present_count"
+        ),
+        "first_action_observed_count": _controller_public_count(
+            "native_goal_worker_first_action_observed_count"
+        ),
+        "effective_action_observed_count": _controller_public_count(
+            "native_goal_worker_effective_action_observed_count"
         ),
         "failure_trace_count": _controller_public_count(
             "native_goal_worker_failure_trace_count"
@@ -5302,6 +5314,14 @@ def build_skillsbench_benchflow_result_benchmark_run(
             ),
             "native_goal_worker_prompt_received_count": controller_counters.get(
                 "native_goal_worker_prompt_received_count", 0
+            ),
+            "native_goal_worker_first_action_observed_count": controller_counters.get(
+                "native_goal_worker_first_action_observed_count", 0
+            ),
+            "native_goal_worker_effective_action_observed_count": (
+                controller_counters.get(
+                    "native_goal_worker_effective_action_observed_count", 0
+                )
             ),
             "native_goal_worker_trace_status": native_goal_worker_trace_status,
             "native_goal_worker_countable_baseline": native_goal_worker_countable,

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -2397,6 +2397,7 @@ raise SystemExit(proc.returncode)
                     "completion_source_of_truth",
                     "first_action_timeout_sec",
                     "first_action_observed",
+                    "effective_action_observed",
                     "raw_transcript_recorded",
                     "raw_assistant_message_recorded",
                 ),

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -1576,6 +1576,8 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "native_goal_worker_turn_start_count",
         "native_goal_worker_turn_completed_observed_count",
         "native_goal_worker_assistant_message_present_count",
+        "native_goal_worker_first_action_observed_count",
+        "native_goal_worker_effective_action_observed_count",
         "remote_command_file_bridge_solver_trace_count",
         "remote_command_file_bridge_solver_probe_ready_count",
         "remote_command_file_bridge_solver_operation_count",
@@ -1816,6 +1818,8 @@ def _compact_native_goal_worker_contract(value: Any) -> dict[str, Any]:
         "goal_get_count",
         "turn_start_count",
         "assistant_message_present_count",
+        "first_action_observed_count",
+        "effective_action_observed_count",
         "failure_trace_count",
         "bridge_task_facing_operation_count",
         "bridge_task_facing_success_count",
@@ -3689,6 +3693,8 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         "native_goal_worker_turn_start_count",
         "native_goal_worker_turn_completed_observed_count",
         "native_goal_worker_assistant_message_present_count",
+        "native_goal_worker_first_action_observed_count",
+        "native_goal_worker_effective_action_observed_count",
         "remote_command_file_bridge_solver_trace_count",
         "remote_command_file_bridge_solver_probe_ready_count",
         "remote_command_file_bridge_solver_operation_count",
@@ -4196,6 +4202,8 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
             "native_goal_worker_trace_count",
             "native_goal_worker_lifecycle_trace_count",
             "native_goal_worker_prompt_received_count",
+            "native_goal_worker_first_action_observed_count",
+            "native_goal_worker_effective_action_observed_count",
         ):
             value = validation.get(field)
             if isinstance(value, int) and not isinstance(value, bool):

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -7258,6 +7258,8 @@ def _merge_app_server_goal_worker_trace_summary(
     turn_start_count = 0
     turn_completed_count = 0
     assistant_message_count = 0
+    first_action_count = 0
+    effective_action_count = 0
     raw_material_recorded = False
     for path in files:
         try:
@@ -7311,6 +7313,10 @@ def _merge_app_server_goal_worker_trace_summary(
             turn_completed_count += 1
         if turn.get("assistant_message_present") is True:
             assistant_message_count += 1
+        if turn.get("first_action_observed") is True:
+            first_action_count += 1
+        if turn.get("effective_action_observed") is True:
+            effective_action_count += 1
         boundary = (
             payload.get("boundary")
             if isinstance(payload.get("boundary"), dict)
@@ -7350,6 +7356,10 @@ def _merge_app_server_goal_worker_trace_summary(
     trace["native_goal_worker_turn_completed_observed_count"] = turn_completed_count
     trace["native_goal_worker_assistant_message_present_count"] = (
         assistant_message_count
+    )
+    trace["native_goal_worker_first_action_observed_count"] = first_action_count
+    trace["native_goal_worker_effective_action_observed_count"] = (
+        effective_action_count
     )
     trace["native_goal_worker_public_trace_read"] = worker_trace_count > 0
     trace["native_goal_worker_raw_material_recorded"] = raw_material_recorded

--- a/scripts/skillsbench_host_codex_goal_worker.py
+++ b/scripts/skillsbench_host_codex_goal_worker.py
@@ -115,6 +115,18 @@ def _first_action_observed(turn: Any) -> bool:
     return False
 
 
+def _effective_action_observed(turn: Any) -> bool:
+    if bool(getattr(turn, "turn_completed_observed", False)):
+        return True
+    if str(getattr(turn, "assistant_message", "") or ""):
+        return True
+    if int(getattr(turn, "agent_message_item_count", 0) or 0) > 0:
+        return True
+    if int(getattr(turn, "non_user_item_completed_count", 0) or 0) > 0:
+        return True
+    return False
+
+
 def _wait_for_worker_turn_completion(
     turn: Any,
     *,
@@ -133,7 +145,7 @@ def _wait_for_worker_turn_completion(
             return True
         if (
             first_action_deadline
-            and not _first_action_observed(turn)
+            and not _effective_action_observed(turn)
             and time.monotonic() >= first_action_deadline
         ):
             raise TimeoutError("codex_exec_first_action_timeout")
@@ -195,6 +207,7 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
                     0.0, float(args.first_action_timeout_sec or 0.0)
                 ),
                 "first_action_observed": _first_action_observed(turn),
+                "effective_action_observed": _effective_action_observed(turn),
                 "loopx_mode": args.loopx_mode,
                 "loopx_access_packet_mode": args.loopx_access_packet_mode,
                 "loopx_case_lifecycle_packet_injected": bool(lifecycle_packet),


### PR DESCRIPTION
## Summary
- distinguish weak first-action signals from effective worker actions in the SkillsBench app-server Goal worker
- keep thought-only agentMessage deltas from satisfying the first-action timeout gate
- propagate effective-action counters through public worker trace, controller trace, reducer, and compact status

## Validation
- python3 -m py_compile scripts/skillsbench_host_codex_goal_worker.py scripts/skillsbench_automation_loop.py loopx/benchmark_adapters/skillsbench_acp_relay.py loopx/benchmark_adapters/skillsbench.py loopx/status.py examples/skillsbench-app-server-goal-worker-smoke.py examples/skillsbench-benchmark-run-smoke.py
- uv run --with pytest python -m pytest examples/skillsbench-app-server-goal-worker-smoke.py -k 'first_action_timeout or thought_delta or only_user_message'
- uv run --with pytest python -m pytest examples/skillsbench-benchmark-run-smoke.py -k 'native_goal_worker or app_server_goal_worker'
- git diff --check

## Boundary
Public benchmark helper/runtime plumbing only. No raw benchmark logs, task text, credentials, private state, local artifact paths, scoring changes, leaderboard behavior, or task semantics.