### PR TITLE
Preserve agent id for delivery-completion quota spend

### DIFF
--- a/examples/quota-plan-smoke.py
+++ b/examples/quota-plan-smoke.py
@@ -2044,6 +2044,49 @@ def assert_monitor_poll_event_carries_agent_id() -> None:
     assert target["effective_action"] == "monitor_quiet_skip", target
 
 
+def assert_delivery_completion_spend_preserves_requested_agent_id() -> None:
+    before = {
+        "goal_id": "delivery-completion-goal",
+        "should_run": False,
+        "normal_delivery_allowed": False,
+        "recovery_delivery_allowed": False,
+        "effective_action": "monitor_quiet_skip",
+        "self_repair_allowed": False,
+        "capability_repair_allowed": False,
+        "workspace_repair_allowed": False,
+        "state": "eligible",
+        "safe_bypass_allowed": False,
+        "quota": {
+            "compute": 1.0,
+            "window_hours": 24,
+            "slot_minutes": 1,
+            "spent_slots": 0,
+            "allowed_slots": 1440,
+        },
+    }
+    after = deepcopy(before)
+    after["quota"] = {**before["quota"], "spent_slots": 1}
+    preview = {
+        "ok": True,
+        "mode": "spend-slot",
+        "dry_run": True,
+        "goal_id": "delivery-completion-goal",
+        "slots": 1,
+        "agent_id": SCOPED_AGENT_ID,
+        "before": before,
+        "after": after,
+        "delivery_completion_spend": True,
+        "delivery_run_generated_at": "2026-01-01T00:00:00+00:00",
+        "delivery_run_classification": "validated_delivery_fixture",
+    }
+    event = build_quota_slot_spend_event(preview, source="heartbeat")
+
+    assert event["agent_id"] == SCOPED_AGENT_ID, event
+    assert event["quota_event"]["agent_id"] == SCOPED_AGENT_ID, event
+    assert event["quota_event"]["delivery_run_classification"] == "validated_delivery_fixture", event
+    assert "validated delivery" in event["health_check"], event
+
+
 def main() -> int:
     assert_default_quota_is_duty_cycle()
     assert_rolling_window_ledger_expires_old_spends()
@@ -2071,6 +2114,7 @@ def main() -> int:
     assert_safe_bypass_slot_preview(status_payload)
     assert_quota_void_event_net_ledger()
     assert_monitor_poll_event_carries_agent_id()
+    assert_delivery_completion_spend_preserves_requested_agent_id()
     assert_slot_preview(build_quota_slot_preview(status_payload, goal_id="near-limit-half", slots=1))
     with tempfile.TemporaryDirectory(prefix="loopx-quota-plan-smoke-") as tmp:
         cli_plan, cli_markdown = run_cli_quota_plan(Path(tmp))

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -7237,6 +7237,7 @@ def build_quota_slot_preview(
 ) -> dict[str, Any]:
     safe_goal_id = str(goal_id or "").strip()
     safe_slots = max(1, _int_number(slots, default=1))
+    safe_requested_agent_id = normalize_todo_claimed_by(agent_id)
     before = build_quota_should_run(
         status_payload,
         goal_id=safe_goal_id,
@@ -7267,6 +7268,7 @@ def build_quota_slot_preview(
             "dry_run": True,
             "goal_id": safe_goal_id,
             "slots": safe_slots,
+            "agent_id": safe_requested_agent_id,
             "appended": False,
             "registry_mutated": False,
             "reason": (
@@ -7304,6 +7306,7 @@ def build_quota_slot_preview(
             "dry_run": True,
             "goal_id": safe_goal_id,
             "slots": safe_slots,
+            "agent_id": safe_requested_agent_id,
             "appended": False,
             "registry_mutated": False,
             "reason": before.get("reason") or "goal is not eligible for quota accounting preview",
@@ -7319,6 +7322,7 @@ def build_quota_slot_preview(
             "dry_run": True,
             "goal_id": safe_goal_id,
             "slots": safe_slots,
+            "agent_id": safe_requested_agent_id,
             "appended": False,
             "registry_mutated": False,
             "reason": "goal has no quota payload to preview",
@@ -7356,6 +7360,7 @@ def build_quota_slot_preview(
         "dry_run": True,
         "goal_id": safe_goal_id,
         "slots": safe_slots,
+        "agent_id": safe_requested_agent_id,
         "appended": False,
         "registry_mutated": False,
         "before": before,
@@ -7863,7 +7868,7 @@ def build_quota_slot_spend_event(
         raise ValueError(f"quota slot spend source must be one of: {', '.join(sorted(VALID_SLOT_SPEND_SOURCES))}")
     before = preview.get("before") if isinstance(preview.get("before"), dict) else {}
     after = preview.get("after") if isinstance(preview.get("after"), dict) else {}
-    safe_agent_id = _quota_decision_agent_id(before)
+    safe_agent_id = normalize_todo_claimed_by(preview.get("agent_id")) or _quota_decision_agent_id(before)
     slots = max(1, _int_number(preview.get("slots"), default=1))
     before_compact = _compact_quota_decision(before)
     after_compact = _compact_quota_decision(after)


### PR DESCRIPTION
## Summary
- preserve explicit --agent-id on delivery-completion quota spend events
- keep the existing delivery-completion eligibility gate unchanged
- add a focused quota-plan regression for requested-agent attribution

## Validation
- python3 examples/quota-plan-smoke.py
- python3 examples/heartbeat-quota-flow-smoke.py
- python3 -m py_compile loopx/quota.py examples/quota-plan-smoke.py examples/heartbeat-quota-flow-smoke.py
- git diff --check
- loopx check --scan-path loopx/quota.py --scan-path examples/quota-plan-smoke.py (existing duplicate-index warning only)

## Boundary
- narrow quota accounting attribution fix
- no quota eligibility broadening
- no credentials, private state, raw logs, or local artifacts committed