### PR TITLE
Clarify auto-research demo replay boundary

### DIFF
--- a/docs/guides/auto-research-command-path.md
+++ b/docs/guides/auto-research-command-path.md
@@ -32,11 +32,15 @@ export PATH="$HOME/.local/bin:$PATH"
 loopx doctor
 ```
 
-## 0. Prove The Positive E2E Path
+## 0. Prove The Deterministic Positive Replay
 
-The smallest visible demo is one command. It runs the deterministic positive
-replay, then opens the visible multi-agent panes through the normal
-auto-research surface:
+The fastest positive check is a deterministic replay. It proves that the
+starter pack, protected evaluator, public rollout evidence, board projection,
+and acceptance packet can all produce the expected k-NN result. It is intentionally
+fast and does not claim that live Codex lanes authored the research result.
+
+To run the replay and open visible panes through the normal auto-research
+surface:
 
 ```bash
 loopx --registry "$LOOPX_REGISTRY" \
@@ -53,12 +57,13 @@ loopx --registry "$LOOPX_REGISTRY" \
   --attach
 ```
 
-That command is the user-facing UX. Generic launcher internals stay inside
-LoopX; the operator does not need to know the module or implementation path.
+That command is the user-facing UX for a replay-backed visible demo. Generic
+launcher internals stay inside LoopX; the operator does not need to know the
+module or implementation path.
 
 If you want to inspect before opening visible Codex lanes, start with the
-read-only dry-run. It tells the operator which command will run the positive
-replay:
+read-only dry-run. It tells the operator which command will run the
+deterministic positive replay:
 
 ```bash
 loopx --registry "$LOOPX_REGISTRY" \
@@ -81,14 +86,27 @@ loopx --registry "$LOOPX_REGISTRY" \
   --execute
 ```
 
-Expected positive result:
+Expected deterministic replay result:
 
+- `execution_kind` is `deterministic_replay`;
+- `result_source` is `generated_quickstart_pack_protected_eval_replay`;
 - `replay_result.dev_metric` is `4.0`;
 - `replay_result.holdout_metric` is `4.5`;
 - dev and holdout exactness are both `true`;
 - `protected_scope_clean` is `true`;
 - the board is rollout-backed and has at least one promotion candidate;
-- `acceptance.ready_for_real_launch` is `true`.
+- `acceptance.ready_for_real_launch` is `true`, meaning the visible launch
+  controls and public-safe board are ready for operator rehearsal.
+
+Truth boundary:
+
+- `live_codex_e2e.executed` is `false`;
+- `live_codex_e2e.claim_allowed` is `false`;
+- `live_codex_e2e.evidence_source` is `not_collected_from_codex_lane_output`;
+- `acceptance.ready_for_real_launch` does not mean live Codex lanes already
+  produced the positive k-NN evidence;
+- `--launch-visible` proves visible panes can start, but pane startup alone is
+  not a live Codex research result.
 
 For a full visible demo after an explicit replay step, add the visible lane
 launcher:

--- a/examples/auto-research-demo-e2e-smoke.py
+++ b/examples/auto-research-demo-e2e-smoke.py
@@ -64,6 +64,15 @@ def assert_e2e_payload(payload: dict[str, Any], *, executed: bool) -> None:
     assert payload["goal_id"] == GOAL_ID, payload
     assert payload["agent_id"] == AGENT_ID, payload
     assert payload["reasoning_effort"] == "high", payload
+    assert payload["execution_kind"] in {
+        "deterministic_replay",
+        "deterministic_replay_preview",
+    }, payload
+    assert payload["result_source"] == "generated_quickstart_pack_protected_eval_replay", payload
+    live = payload["live_codex_e2e"]
+    assert live["executed"] is False, payload
+    assert live["claim_allowed"] is False, payload
+    assert live["evidence_source"] == "not_collected_from_codex_lane_output", payload
     assert payload["supervisor"]["lane_count"] == 3, payload
     assert payload["supervisor"]["reasoning_contract"]["default_reasoning_effort"] == "high", payload
     assert payload["public_boundary"]["raw_logs_recorded"] is False, payload
@@ -71,9 +80,11 @@ def assert_e2e_payload(payload: dict[str, Any], *, executed: bool) -> None:
     assert payload["public_boundary"]["absolute_paths_recorded"] is False, payload
     assert payload["public_boundary"]["credentials_recorded"] is False, payload
     assert payload["public_boundary"]["local_workspace_path_redacted"] is True, payload
+    assert payload["public_boundary"]["live_codex_sessions_recorded"] is False, payload
     replay = payload["replay_result"]
     assert replay["executed"] is executed, payload
     if executed:
+        assert replay["result_source"] == "generated_quickstart_pack_protected_eval_replay", payload
         assert replay["status"] == "supported", payload
         assert replay["dev_metric"] == 4.0, payload
         assert replay["holdout_metric"] == 4.5, payload
@@ -89,6 +100,7 @@ def assert_e2e_payload(payload: dict[str, Any], *, executed: bool) -> None:
         assert payload["board"]["promotion_candidate_count"] >= 1, payload
         assert payload["acceptance"]["ready_for_real_launch"] is True, payload
     else:
+        assert replay["result_source"] == "deterministic_replay_preview", payload
         assert replay["expected_positive_result"] == "dev=4.0x holdout=4.5x after --execute", payload
     assert_public_safe(payload)
 
@@ -148,14 +160,18 @@ def main() -> int:
             registry=registry,
             runtime_root=runtime_root,
         ).stdout
-        assert "# LoopX Auto Research Demo E2E" in markdown, markdown
+        assert "# LoopX Auto Research Demo Replay" in markdown, markdown
+        assert "execution_kind: `deterministic_replay_preview`" in markdown, markdown
+        assert "live_codex_e2e_claim_allowed: `False`" in markdown, markdown
+        assert "live_codex_e2e_evidence_source: `not_collected_from_codex_lane_output`" in markdown, markdown
         assert "reasoning_effort: `high`" in markdown, markdown
-        assert "positive replay:" in markdown, markdown
+        assert "deterministic replay:" in markdown, markdown
         assert_public_safe(markdown)
 
         guide = GUIDE.read_text(encoding="utf-8")
-        assert "## 0. Prove The Positive E2E Path" in guide, guide
+        assert "## 0. Prove The Deterministic Positive Replay" in guide, guide
         assert "auto-research demo-e2e" in guide, guide
+        assert "does not claim that live Codex lanes authored the research result" in guide, guide
         assert "--reasoning-effort high" in guide, guide
         assert "--execute" in guide, guide
         assert "--launch-visible" in guide, guide
@@ -167,11 +183,14 @@ def main() -> int:
         assert "replay_result.holdout_metric" in guide, guide
         assert "`4.5`" in guide, guide
         assert "acceptance.ready_for_real_launch" in guide, guide
+        assert "live_codex_e2e.executed" in guide, guide
+        assert "live_codex_e2e.claim_allowed" in guide, guide
+        assert "not_collected_from_codex_lane_output" in guide, guide
         assert "raw logs" in guide, guide
         assert "private artifacts" in guide, guide
         assert "credentials" in guide, guide
         assert "local absolute workspace paths" in guide, guide
-        e2e_section = guide.split("## 0. Prove The Positive E2E Path", 1)[1].split(
+        e2e_section = guide.split("## 0. Prove The Deterministic Positive Replay", 1)[1].split(
             "## 1. Preview The Research Pack",
             1,
         )[0]

--- a/examples/auto-research-one-click-ux-smoke.py
+++ b/examples/auto-research-one-click-ux-smoke.py
@@ -131,13 +131,22 @@ def main() -> int:
         payload = json.loads(result.stdout)
         assert payload["ok"] is True, payload
         assert payload["mode"] == "execute", payload
+        assert payload["execution_kind"] == "deterministic_replay", payload
+        assert payload["result_source"] == "generated_quickstart_pack_protected_eval_replay", payload
         assert payload["reasoning_effort"] == "high", payload
         assert payload["replay_result"]["dev_metric"] == 4.0, payload
         assert payload["replay_result"]["holdout_metric"] == 4.5, payload
+        assert payload["replay_result"]["result_source"] == "generated_quickstart_pack_protected_eval_replay", payload
         assert payload["replay_result"]["protected_scope_clean"] is True, payload
         assert payload["acceptance"]["ready_for_real_launch"] is True, payload
         assert payload["public_boundary"]["launches_visible_lanes"] is True, payload
         assert payload["public_boundary"]["local_workspace_path_redacted"] is True, payload
+        assert payload["public_boundary"]["live_codex_sessions_recorded"] is False, payload
+        live = payload["live_codex_e2e"]
+        assert live["executed"] is False, payload
+        assert live["claim_allowed"] is False, payload
+        assert live["visible_lanes_launched"] is True, payload
+        assert live["evidence_source"] == "not_collected_from_codex_lane_output", payload
         visible = payload["visible_launch"]
         assert visible["mode"] == "executed_visible_launch", visible
         assert visible["boundary"]["shared_goal_surface"] is True, visible
@@ -148,10 +157,11 @@ def main() -> int:
         assert launch["workspace_mode"] == "explicit_workspace", launch
         assert launch["started_lane_count"] == 3, launch
         assert launch["visible_acceptance"]["accepted"] is True, launch
+        assert payload["live_codex_e2e"]["visible_lanes_accepted"] is True, payload
         assert workspace.is_dir(), workspace
 
         guide = GUIDE.read_text(encoding="utf-8")
-        one_command_section = guide.split("The smallest visible demo is one command.", 1)[1].split(
+        one_command_section = guide.split("To run the replay and open visible panes", 1)[1].split(
             "If you want to inspect before opening visible Codex lanes",
             1,
         )[0]
@@ -163,9 +173,12 @@ def main() -> int:
             "--workspace ./loopx-auto-research-demo",
             "--create-workspace",
             "--attach",
-            "Generic launcher internals stay inside\nLoopX",
+            "Generic\nlauncher internals stay inside LoopX",
+            "replay-backed visible demo",
         ]:
             assert snippet in one_command_section, snippet
+        assert "does not claim that live Codex lanes authored the research result" in guide, guide
+        assert "live_codex_e2e.claim_allowed" in guide, guide
         assert "visible_multi_agent_launcher" not in guide, guide
         assert "loopx/visible_multi_agent_launcher.py" not in guide, guide
         assert_public_safe(one_command_section)

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -279,7 +279,10 @@ def register_auto_research_commands(
 
     demo_e2e_parser = auto_research_sub.add_parser(
         "demo-e2e",
-        help="Run or preview the one-command k-NN positive demo path and report board/acceptance.",
+        help=(
+            "Run or preview the one-command deterministic k-NN replay path and "
+            "report board/acceptance truth boundaries."
+        ),
     )
     add_subcommand_format(demo_e2e_parser)
     demo_e2e_parser.add_argument("--agent-id", required=True)
@@ -301,12 +304,18 @@ def register_auto_research_commands(
     demo_e2e_parser.add_argument(
         "--execute",
         action="store_true",
-        help="Run protected evals and append public rollout evidence. Omit for a read-only one-command preview.",
+        help=(
+            "Run protected evals from the generated quickstart pack and append public rollout evidence. "
+            "This is a deterministic replay, not a live Codex lane result."
+        ),
     )
     demo_e2e_parser.add_argument(
         "--launch-visible",
         action="store_true",
-        help="With --execute, also launch the visible multi-lane supervisor.",
+        help=(
+            "With --execute, also launch the visible multi-lane supervisor. "
+            "Visible panes alone do not make the replay a live Codex E2E result."
+        ),
     )
     demo_e2e_parser.add_argument(
         "--keep-workspace",

--- a/loopx/capabilities/auto_research/core.py
+++ b/loopx/capabilities/auto_research/core.py
@@ -3391,19 +3391,31 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
         acceptance = payload.get("acceptance") if isinstance(payload.get("acceptance"), dict) else {}
         supervisor = payload.get("supervisor") if isinstance(payload.get("supervisor"), dict) else {}
         commands = payload.get("commands") if isinstance(payload.get("commands"), dict) else {}
+        live_codex = (
+            payload.get("live_codex_e2e")
+            if isinstance(payload.get("live_codex_e2e"), dict)
+            else {}
+        )
         lines = [
-            "# LoopX Auto Research Demo E2E",
+            "# LoopX Auto Research Demo Replay",
             "",
             f"- schema: `{payload.get('schema_version')}`",
             f"- mode: `{payload.get('mode')}`",
+            f"- execution_kind: `{payload.get('execution_kind')}`",
+            f"- result_source: `{payload.get('result_source')}`",
             f"- goal_id: `{payload.get('goal_id')}`",
             f"- agent_id: `{payload.get('agent_id')}`",
             f"- reasoning_effort: `{payload.get('reasoning_effort')}`",
             f"- replay_executed: `{replay.get('executed')}`",
+            f"- replay_result_source: `{replay.get('result_source')}`",
             f"- status: `{replay.get('status')}`",
             f"- dev_metric: `{replay.get('dev_metric')}`",
             f"- holdout_metric: `{replay.get('holdout_metric')}`",
             f"- protected_scope_clean: `{replay.get('protected_scope_clean')}`",
+            f"- live_codex_e2e_executed: `{live_codex.get('executed')}`",
+            f"- live_codex_e2e_claim_allowed: `{live_codex.get('claim_allowed')}`",
+            f"- live_codex_e2e_evidence_source: `{live_codex.get('evidence_source')}`",
+            f"- visible_lanes_launched: `{live_codex.get('visible_lanes_launched')}`",
             f"- appended_events: `{append.get('appended_count')}`",
             f"- skipped_existing_events: `{append.get('skipped_existing_count')}`",
             f"- board_rollout_backed: `{board.get('rollout_backed')}`",
@@ -3413,8 +3425,8 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
             "",
             "## Commands",
             "",
-            f"- positive replay: `{commands.get('positive_replay')}`",
-            f"- with visible lanes: `{commands.get('positive_replay_with_visible_lanes')}`",
+            f"- deterministic replay: `{commands.get('deterministic_replay')}`",
+            f"- replay plus visible lanes: `{commands.get('deterministic_replay_with_visible_lanes')}`",
         ]
         return "\n".join(lines) + "\n"
     if payload.get("schema_version") == AUTO_RESEARCH_BOARD_SCHEMA_VERSION:

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -196,6 +196,25 @@ def _command_text(
     return " ".join(parts)
 
 
+def _live_codex_truth_boundary(*, launch_visible: bool) -> dict[str, object]:
+    return {
+        "executed": False,
+        "claim_allowed": False,
+        "visible_lanes_launched": bool(launch_visible),
+        "visible_lanes_accepted": False,
+        "evidence_source": "not_collected_from_codex_lane_output",
+        "reason": (
+            "demo-e2e validates the deterministic positive replay and optional visible launcher; "
+            "it does not prove a live Codex multi-agent research result."
+        ),
+        "required_for_live_claim": [
+            "visible Codex lanes started from the launcher",
+            "lane-authored evidence appended to LoopX state",
+            "acceptance packet cites evidence_source=live_codex_lane_output",
+        ],
+    }
+
+
 def run_auto_research_demo_e2e(
     *,
     agent_id: str,
@@ -232,17 +251,19 @@ def run_auto_research_demo_e2e(
         "ok": True,
         "schema_version": AUTO_RESEARCH_DEMO_E2E_SCHEMA_VERSION,
         "mode": "execute" if execute else "dry_run",
+        "execution_kind": "deterministic_replay" if execute else "deterministic_replay_preview",
+        "result_source": "generated_quickstart_pack_protected_eval_replay",
         "goal_id": goal_id,
         "agent_id": agent_id,
         "reasoning_effort": reasoning_effort,
         "commands": {
-            "positive_replay": _command_text(
+            "deterministic_replay": _command_text(
                 cli_bin=cli_bin,
                 goal_id=goal_id,
                 agent_id=agent_id,
                 execute=True,
             ),
-            "positive_replay_with_visible_lanes": _command_text(
+            "deterministic_replay_with_visible_lanes": _command_text(
                 cli_bin=cli_bin,
                 goal_id=goal_id,
                 agent_id=agent_id,
@@ -264,7 +285,9 @@ def run_auto_research_demo_e2e(
             "local_workspace_path_redacted": True,
             "writes_loopx_state": bool(execute),
             "launches_visible_lanes": bool(launch_visible),
+            "live_codex_sessions_recorded": False,
         },
+        "live_codex_e2e": _live_codex_truth_boundary(launch_visible=launch_visible),
     }
     if not execute:
         quickstart = build_auto_research_quickstart(
@@ -283,6 +306,7 @@ def run_auto_research_demo_e2e(
         }
         payload["replay_result"] = {
             "executed": False,
+            "result_source": "deterministic_replay_preview",
             "expected_positive_result": "dev=4.0x holdout=4.5x after --execute",
         }
         return payload
@@ -343,6 +367,7 @@ def run_auto_research_demo_e2e(
                 },
                 "replay_result": {
                     "executed": True,
+                    "result_source": "generated_quickstart_pack_protected_eval_replay",
                     "status": evidence.get("summary", {}).get("status"),
                     "dev_metric": (dev.get("metric") or {}).get("value"),
                     "holdout_metric": (holdout.get("metric") or {}).get("value"),
@@ -362,11 +387,25 @@ def run_auto_research_demo_e2e(
         )
         if launch_visible and visible_launcher is not None:
             visible_payload = visible_launcher(dict(supervisor))
+            launch_result = (
+                visible_payload.get("launch_result")
+                if isinstance(visible_payload.get("launch_result"), dict)
+                else {}
+            )
+            visible_acceptance = (
+                launch_result.get("visible_acceptance")
+                if isinstance(launch_result.get("visible_acceptance"), dict)
+                else {}
+            )
             payload["visible_launch"] = {
                 "mode": visible_payload.get("mode"),
-                "launch_result": visible_payload.get("launch_result"),
+                "launch_result": launch_result,
                 "boundary": visible_payload.get("boundary"),
             }
+            live_boundary = payload["live_codex_e2e"]
+            if isinstance(live_boundary, dict):
+                live_boundary["visible_lanes_launched"] = True
+                live_boundary["visible_lanes_accepted"] = bool(visible_acceptance.get("accepted"))
         return payload
     finally:
         if tmp_obj is not None:


### PR DESCRIPTION
## Summary
- label demo-e2e output as deterministic replay instead of implying a live Codex research run
- add live_codex_e2e truth-boundary fields that keep claim_allowed=false until lane-authored evidence exists
- update the one-command guide and smokes so visible pane launch is not confused with live Codex E2E evidence

## Validation
- python3 examples/auto-research-demo-e2e-smoke.py
- python3 examples/auto-research-one-click-ux-smoke.py
- python3 examples/auto-research-visible-launcher-smoke.py
- python3 -m py_compile loopx/capabilities/auto_research/demo_e2e.py loopx/capabilities/auto_research/core.py loopx/capabilities/auto_research/cli.py
- git diff --check
- python3 -m loopx.cli check --scan-path loopx/capabilities/auto_research/demo_e2e.py --scan-path loopx/capabilities/auto_research/core.py --scan-path loopx/capabilities/auto_research/cli.py --scan-path examples/auto-research-demo-e2e-smoke.py --scan-path examples/auto-research-one-click-ux-smoke.py --scan-path docs/guides/auto-research-command-path.md