### PR TITLE
Fix SkillsBench app worker bridge watchdog

### DIFF
--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -1298,16 +1298,27 @@ sys.exit(0)
 
 
 def test_acp_relay_fails_fast_when_app_server_worker_never_uses_bridge() -> None:
-    fake_worker = """#!/usr/bin/env python3
-import time
-
-time.sleep(30)
-"""
     with tempfile.TemporaryDirectory(prefix="skillsbench-app-goal-bridge-first-action-") as tmp:
         root = Path(tmp)
         worker = root / "fake_worker.py"
         work = root / "work"
         trace_dir = root / "worker-traces"
+        timeout_arg = trace_dir / "first_action_timeout_arg.txt"
+        fake_worker = f"""#!/usr/bin/env python3
+import argparse
+import time
+from pathlib import Path
+
+parser = argparse.ArgumentParser()
+parser.add_argument("--first-action-timeout-sec")
+args, _ = parser.parse_known_args()
+Path({str(timeout_arg)!r}).parent.mkdir(parents=True, exist_ok=True)
+Path({str(timeout_arg)!r}).write_text(
+    str(args.first_action_timeout_sec),
+    encoding="utf-8",
+)
+time.sleep(30)
+"""
         worker.write_text(fake_worker, encoding="utf-8")
         worker.chmod(0o755)
         work.mkdir()
@@ -1395,6 +1406,7 @@ time.sleep(30)
         assert trace["worker_process"]["stage"] == "first_action_timeout", trace
         assert trace["worker_contract"]["first_blocker"] == "first_action_timeout", trace
         assert trace["worker_process"]["stderr_bytes"] > 0, trace
+        assert timeout_arg.read_text(encoding="utf-8") == "0.0"
         trace_text = json.dumps(trace, sort_keys=True)
         assert "private task placeholder" not in trace_text, trace
         assert str(work) not in trace_text, trace

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -2029,6 +2029,9 @@ raise SystemExit(proc.returncode)
                 / "scripts"
                 / "skillsbench_host_codex_goal_worker.py"
             )
+            worker_first_action_timeout_sec = self._config.first_action_timeout_sec
+            if bridge_summary_path is not None:
+                worker_first_action_timeout_sec = 0.0
             cmd = [
                 sys.executable,
                 str(worker_script),
@@ -2055,7 +2058,7 @@ raise SystemExit(proc.returncode)
                 "--turn-timeout-sec",
                 str(self._config.timeout_sec),
                 "--first-action-timeout-sec",
-                str(self._config.first_action_timeout_sec),
+                str(worker_first_action_timeout_sec),
                 "--reasoning-effort",
                 str(self._config.reasoning_effort or "high"),
                 "--runner-integration-ready",


### PR DESCRIPTION
## Summary
- let the SkillsBench relay own first-action watchdogs when a remote bridge operation log exists
- keep the host app-server worker first-action watchdog for non-bridge runs
- add a smoke assertion that bridged app-server worker invocations receive first-action timeout 0.0 while relay-level first-action failure still works

## Validation
- python3 -m py_compile loopx/benchmark_adapters/skillsbench_acp_relay.py examples/skillsbench-app-server-goal-worker-smoke.py
- uv run --with pytest python -m pytest examples/skillsbench-app-server-goal-worker-smoke.py -k 'app_server or bridge or quiet or first_action'
- uv run --with pytest python -m pytest examples/skillsbench-benchmark-run-smoke.py -k 'native_goal_worker or app_server_goal_worker or bridge_attempt or timeout'
- git diff --check

## Evidence
Observed on remote 3d-scan-calc native Goal canary: reverse tunnel became http_connect_ready and the solver wrote the correct /root/mass_report.json, but the host worker still failed with codex_exec_first_action_timeout because it could not see bridge task-facing operations. This PR makes the relay's bridge-aware watchdog authoritative for bridged runs.