### PR TITLE
Gate auto-research live E2E claims on lane evidence

### DIFF
--- a/docs/guides/auto-research-command-path.md
+++ b/docs/guides/auto-research-command-path.md
@@ -108,6 +108,26 @@ Truth boundary:
 - `--launch-visible` proves visible panes can start, but pane startup alone is
   not a live Codex research result.
 
+To claim a live Codex lane-authored E2E result, pass a compact public-safe
+evidence packet produced by the visible lanes:
+
+```bash
+loopx --registry "$LOOPX_REGISTRY" \
+  --runtime-root "$LOOPX_RUNTIME_ROOT" \
+  --format json auto-research demo-e2e \
+  --goal-id loopx-auto-research-knn \
+  --agent-id codex-side-bypass \
+  --reasoning-effort high \
+  --execute \
+  --live-evidence ./live-codex-e2e-evidence.public.json
+```
+
+That packet must use `source: live_codex_lane_output`, match the goal and
+agent, show accepted visible lanes, cite lane-authored evidence appended to
+LoopX state, and keep raw logs, private artifacts, credentials, and local
+absolute paths out of the payload. Without this packet,
+`live_codex_e2e.claim_allowed` stays `false`.
+
 For a full visible demo after an explicit replay step, add the visible lane
 launcher:
 

--- a/examples/auto-research-demo-e2e-smoke.py
+++ b/examples/auto-research-demo-e2e-smoke.py
@@ -186,6 +186,7 @@ def main() -> int:
         assert "live_codex_e2e.executed" in guide, guide
         assert "live_codex_e2e.claim_allowed" in guide, guide
         assert "not_collected_from_codex_lane_output" in guide, guide
+        assert "--live-evidence" in guide, guide
         assert "raw logs" in guide, guide
         assert "private artifacts" in guide, guide
         assert "credentials" in guide, guide

--- a/examples/auto-research-live-codex-claim-boundary-smoke.py
+++ b/examples/auto-research-live-codex-claim-boundary-smoke.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Smoke-test that live auto-research E2E claims require lane-authored evidence."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GOAL_ID = "loopx-auto-research-knn"
+AGENT_ID = "codex-side-bypass"
+
+
+def assert_public_safe(payload: Any) -> None:
+    text = json.dumps(payload, sort_keys=True) if not isinstance(payload, str) else payload
+    forbidden = [
+        "/" + "Users/",
+        "/" + "private/",
+        "/" + "tmp/",
+        "http://",
+        "https://",
+        "api" + "_key",
+        "pass" + "word",
+        "sec" + "ret",
+    ]
+    leaked = [needle for needle in forbidden if needle.lower() in text.lower()]
+    assert not leaked, leaked
+
+
+def run_cli(
+    args: list[str],
+    *,
+    registry: Path,
+    runtime_root: Path,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry),
+            "--runtime-root",
+            str(runtime_root),
+            "--format",
+            "json",
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def base_demo_args() -> list[str]:
+    return [
+        "auto-research",
+        "demo-e2e",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--reasoning-effort",
+        "high",
+    ]
+
+
+def live_evidence_payload() -> dict[str, Any]:
+    return {
+        "schema_version": "auto_research_live_codex_lane_e2e_evidence_v0",
+        "source": "live_codex_lane_output",
+        "goal_id": GOAL_ID,
+        "agent_id": AGENT_ID,
+        "visible_lanes": {
+            "launched": True,
+            "accepted": True,
+            "lane_count": 3,
+        },
+        "lane_evidence": {
+            "lane_authored": True,
+            "evidence_source": "live_codex_lane_output",
+            "append_status": "appended_to_loopx_state",
+            "evidence_event_count": 3,
+            "result_status": "supported",
+            "protected_scope_clean": True,
+            "dev_metric": 4.0,
+            "holdout_metric": 4.5,
+        },
+        "public_boundary": {
+            "raw_logs_recorded": False,
+            "private_artifacts_recorded": False,
+            "absolute_paths_recorded": False,
+            "credentials_recorded": False,
+            "local_workspace_path_redacted": True,
+        },
+    }
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        registry = temp / "registry.json"
+        runtime_root = temp / "runtime"
+        registry.write_text(
+            json.dumps({"common_runtime_root": str(runtime_root), "goals": []}),
+            encoding="utf-8",
+        )
+
+        no_live = run_cli(
+            [*base_demo_args(), "--execute"],
+            registry=registry,
+            runtime_root=runtime_root,
+        )
+        no_live_payload = json.loads(no_live.stdout)
+        assert no_live_payload["ok"] is True, no_live_payload
+        assert no_live_payload["live_codex_e2e"]["executed"] is False, no_live_payload
+        assert no_live_payload["live_codex_e2e"]["claim_allowed"] is False, no_live_payload
+        assert no_live_payload["live_codex_e2e"]["evidence_source"] == (
+            "not_collected_from_codex_lane_output"
+        ), no_live_payload
+
+        evidence = temp / "live-evidence.public.json"
+        evidence.write_text(json.dumps(live_evidence_payload(), sort_keys=True), encoding="utf-8")
+
+        dry_run_with_evidence = run_cli(
+            [*base_demo_args(), "--live-evidence", str(evidence)],
+            registry=registry,
+            runtime_root=runtime_root,
+            check=False,
+        )
+        assert dry_run_with_evidence.returncode == 1, dry_run_with_evidence.stdout
+        dry_error = json.loads(dry_run_with_evidence.stdout)
+        assert dry_error["ok"] is False, dry_error
+        assert "--live-evidence requires --execute" in dry_error["error"], dry_error
+        assert_public_safe(dry_error)
+
+        bad_evidence = temp / "bad-live-evidence.public.json"
+        bad_payload = live_evidence_payload()
+        bad_payload["source"] = "generated_quickstart_pack_protected_eval_replay"
+        bad_evidence.write_text(json.dumps(bad_payload, sort_keys=True), encoding="utf-8")
+        rejected = run_cli(
+            [*base_demo_args(), "--execute", "--live-evidence", str(bad_evidence)],
+            registry=registry,
+            runtime_root=runtime_root,
+            check=False,
+        )
+        assert rejected.returncode == 1, rejected.stdout
+        rejected_payload = json.loads(rejected.stdout)
+        assert rejected_payload["ok"] is False, rejected_payload
+        assert "source must be live_codex_lane_output" in rejected_payload["error"], rejected_payload
+        assert_public_safe(rejected_payload)
+
+        claimed = run_cli(
+            [*base_demo_args(), "--execute", "--live-evidence", str(evidence)],
+            registry=registry,
+            runtime_root=runtime_root,
+        )
+        claimed_payload = json.loads(claimed.stdout)
+        live = claimed_payload["live_codex_e2e"]
+        assert claimed_payload["ok"] is True, claimed_payload
+        assert claimed_payload["replay_result"]["dev_metric"] == 4.0, claimed_payload
+        assert claimed_payload["replay_result"]["holdout_metric"] == 4.5, claimed_payload
+        assert live["executed"] is True, claimed_payload
+        assert live["claim_allowed"] is True, claimed_payload
+        assert live["evidence_source"] == "live_codex_lane_output", claimed_payload
+        assert live["evidence_event_count"] == 3, claimed_payload
+        assert live["result_status"] == "supported", claimed_payload
+        assert live["dev_metric"] == 4.0, claimed_payload
+        assert live["holdout_metric"] == 4.5, claimed_payload
+        assert live["public_boundary"]["raw_logs_recorded"] is False, claimed_payload
+        assert live["public_boundary"]["private_artifacts_recorded"] is False, claimed_payload
+        assert live["public_boundary"]["absolute_paths_recorded"] is False, claimed_payload
+        assert live["public_boundary"]["credentials_recorded"] is False, claimed_payload
+        assert live["public_boundary"]["local_workspace_path_redacted"] is True, claimed_payload
+        assert_public_safe(claimed_payload)
+
+    print("auto-research-live-codex-claim-boundary-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -318,6 +318,13 @@ def register_auto_research_commands(
         ),
     )
     demo_e2e_parser.add_argument(
+        "--live-evidence",
+        help=(
+            "Path to compact public-safe live Codex lane evidence. "
+            "Only this can flip live_codex_e2e.claim_allowed; raw transcripts are not read."
+        ),
+    )
+    demo_e2e_parser.add_argument(
         "--keep-workspace",
         action="store_true",
         help="Keep the temporary demo workspace after execution. The output payload still redacts its absolute path.",
@@ -633,6 +640,7 @@ def handle_auto_research_command(
                 codex_bin=args.codex_bin,
                 tmux_bin=args.tmux_bin,
                 reasoning_effort=args.reasoning_effort,
+                live_evidence_path=args.live_evidence,
                 append_evidence=append_demo_e2e_evidence,
                 visible_launcher=visible_launcher,
             )

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -21,6 +21,10 @@ from .core import (
     build_research_evidence_graph_from_rollout_events,
     load_auto_research_evidence_packet_inputs,
 )
+from .live_evidence import (
+    build_live_codex_claim_from_evidence,
+    load_live_codex_e2e_evidence,
+)
 from ...history import load_registry
 from ...paths import resolve_runtime_root
 from ...quota import build_quota_should_run
@@ -177,6 +181,7 @@ def _command_text(
     agent_id: str,
     execute: bool,
     launch_visible: bool = False,
+    live_evidence: bool = False,
 ) -> str:
     parts = [
         shlex.quote(cli_bin),
@@ -193,6 +198,8 @@ def _command_text(
         parts.append("--execute")
     if launch_visible:
         parts.append("--launch-visible")
+    if live_evidence:
+        parts.extend(["--live-evidence", "<public-safe-live-evidence.json>"])
     return " ".join(parts)
 
 
@@ -231,6 +238,7 @@ def run_auto_research_demo_e2e(
     codex_bin: str,
     tmux_bin: str,
     reasoning_effort: str,
+    live_evidence_path: str | None,
     append_evidence: AppendEvidence,
     visible_launcher: VisibleLauncher | None = None,
 ) -> dict[str, object]:
@@ -238,6 +246,8 @@ def run_auto_research_demo_e2e(
         raise ValueError("--launch-visible requires --execute")
     if launch_visible and visible_launcher is None:
         raise ValueError("--launch-visible requires a visible launcher callback")
+    if live_evidence_path and not execute:
+        raise ValueError("--live-evidence requires --execute")
 
     supervisor = build_auto_research_demo_supervisor_plan(
         goal_id=goal_id,
@@ -269,6 +279,13 @@ def run_auto_research_demo_e2e(
                 agent_id=agent_id,
                 execute=True,
                 launch_visible=True,
+            ),
+            "live_codex_claim_from_evidence": _command_text(
+                cli_bin=cli_bin,
+                goal_id=goal_id,
+                agent_id=agent_id,
+                execute=True,
+                live_evidence=True,
             ),
         },
         "supervisor": {
@@ -406,6 +423,13 @@ def run_auto_research_demo_e2e(
             if isinstance(live_boundary, dict):
                 live_boundary["visible_lanes_launched"] = True
                 live_boundary["visible_lanes_accepted"] = bool(visible_acceptance.get("accepted"))
+        if live_evidence_path:
+            live_evidence = load_live_codex_e2e_evidence(
+                evidence_path=live_evidence_path,
+                goal_id=goal_id,
+                agent_id=agent_id,
+            )
+            payload["live_codex_e2e"] = build_live_codex_claim_from_evidence(live_evidence)
         return payload
     finally:
         if tmp_obj is not None:

--- a/loopx/capabilities/auto_research/live_evidence.py
+++ b/loopx/capabilities/auto_research/live_evidence.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+LIVE_CODEX_E2E_EVIDENCE_SCHEMA_VERSION = "auto_research_live_codex_lane_e2e_evidence_v0"
+
+
+def _require_dict(payload: dict[str, object], key: str) -> dict[str, object]:
+    value = payload.get(key)
+    if not isinstance(value, dict):
+        raise ValueError(f"live evidence field `{key}` must be an object")
+    return value
+
+
+def _require_bool(value: object, *, field: str, expected: bool = True) -> None:
+    if value is not expected:
+        raise ValueError(f"live evidence field `{field}` must be {expected}")
+
+
+def _require_positive_int(value: object, *, field: str) -> int:
+    if not isinstance(value, int) or value <= 0:
+        raise ValueError(f"live evidence field `{field}` must be a positive integer")
+    return value
+
+
+def _assert_live_evidence_public_safe(payload: dict[str, object]) -> None:
+    text = json.dumps(payload, sort_keys=True)
+    forbidden = [
+        "/" + "Users/",
+        "/" + "private/",
+        "/" + "tmp/",
+        "http://",
+        "https://",
+        "api" + "_key",
+        "pass" + "word",
+        "sec" + "ret",
+    ]
+    leaked = [needle for needle in forbidden if needle.lower() in text.lower()]
+    if leaked:
+        raise ValueError("live evidence must be compact and public-safe; forbidden material detected")
+
+
+def load_live_codex_e2e_evidence(
+    *,
+    evidence_path: str,
+    goal_id: str,
+    agent_id: str,
+) -> dict[str, object]:
+    try:
+        raw = Path(evidence_path).read_text(encoding="utf-8")
+        payload = json.loads(raw)
+    except Exception as exc:
+        raise ValueError("live evidence must be readable JSON") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("live evidence root must be an object")
+    if payload.get("schema_version") != LIVE_CODEX_E2E_EVIDENCE_SCHEMA_VERSION:
+        raise ValueError(
+            "live evidence schema_version must be "
+            f"{LIVE_CODEX_E2E_EVIDENCE_SCHEMA_VERSION}"
+        )
+    if payload.get("source") != "live_codex_lane_output":
+        raise ValueError("live evidence source must be live_codex_lane_output")
+    if payload.get("goal_id") != goal_id:
+        raise ValueError("live evidence goal_id does not match the demo goal")
+    if payload.get("agent_id") != agent_id:
+        raise ValueError("live evidence agent_id does not match the demo agent")
+
+    visible = _require_dict(payload, "visible_lanes")
+    lane_evidence = _require_dict(payload, "lane_evidence")
+    boundary = _require_dict(payload, "public_boundary")
+    _require_bool(visible.get("launched"), field="visible_lanes.launched")
+    _require_bool(visible.get("accepted"), field="visible_lanes.accepted")
+    lane_count = _require_positive_int(visible.get("lane_count"), field="visible_lanes.lane_count")
+    _require_bool(lane_evidence.get("lane_authored"), field="lane_evidence.lane_authored")
+    if lane_evidence.get("evidence_source") != "live_codex_lane_output":
+        raise ValueError("lane_evidence.evidence_source must be live_codex_lane_output")
+    if lane_evidence.get("append_status") != "appended_to_loopx_state":
+        raise ValueError("lane_evidence.append_status must be appended_to_loopx_state")
+    evidence_event_count = _require_positive_int(
+        lane_evidence.get("evidence_event_count"),
+        field="lane_evidence.evidence_event_count",
+    )
+    if lane_evidence.get("result_status") != "supported":
+        raise ValueError("lane_evidence.result_status must be supported")
+    _require_bool(
+        lane_evidence.get("protected_scope_clean"),
+        field="lane_evidence.protected_scope_clean",
+    )
+    for key in (
+        "raw_logs_recorded",
+        "private_artifacts_recorded",
+        "absolute_paths_recorded",
+        "credentials_recorded",
+    ):
+        _require_bool(boundary.get(key), field=f"public_boundary.{key}", expected=False)
+    _require_bool(
+        boundary.get("local_workspace_path_redacted"),
+        field="public_boundary.local_workspace_path_redacted",
+    )
+    _assert_live_evidence_public_safe(payload)
+    return {
+        "schema_version": payload["schema_version"],
+        "source": payload["source"],
+        "goal_id": goal_id,
+        "agent_id": agent_id,
+        "lane_count": lane_count,
+        "evidence_event_count": evidence_event_count,
+        "result_status": lane_evidence.get("result_status"),
+        "protected_scope_clean": True,
+        "dev_metric": lane_evidence.get("dev_metric"),
+        "holdout_metric": lane_evidence.get("holdout_metric"),
+        "public_boundary": {
+            "raw_logs_recorded": False,
+            "private_artifacts_recorded": False,
+            "absolute_paths_recorded": False,
+            "credentials_recorded": False,
+            "local_workspace_path_redacted": True,
+        },
+    }
+
+
+def build_live_codex_claim_from_evidence(evidence: dict[str, object]) -> dict[str, object]:
+    return {
+        "executed": True,
+        "claim_allowed": True,
+        "visible_lanes_launched": True,
+        "visible_lanes_accepted": True,
+        "evidence_source": "live_codex_lane_output",
+        "reason": (
+            "compact live Codex lane-authored evidence was validated; raw transcripts, "
+            "private artifacts, credentials, and local paths were not recorded."
+        ),
+        "evidence_schema_version": evidence.get("schema_version"),
+        "lane_count": evidence.get("lane_count"),
+        "evidence_event_count": evidence.get("evidence_event_count"),
+        "result_status": evidence.get("result_status"),
+        "protected_scope_clean": evidence.get("protected_scope_clean"),
+        "dev_metric": evidence.get("dev_metric"),
+        "holdout_metric": evidence.get("holdout_metric"),
+        "public_boundary": evidence.get("public_boundary"),
+    }


### PR DESCRIPTION
## Summary
- add a compact live Codex lane evidence contract for auto-research demo-e2e
- expose --live-evidence so live_codex_e2e.claim_allowed only flips after lane-authored evidence is validated
- document the replay/live boundary and add a focused claim-boundary smoke

## Validation
- python3 examples/auto-research-live-codex-claim-boundary-smoke.py
- python3 examples/auto-research-demo-e2e-smoke.py
- python3 examples/auto-research-one-click-ux-smoke.py
- python3 examples/generic-multi-agent-one-command-smoke.py
- python3 -m py_compile loopx/capabilities/auto_research/demo_e2e.py loopx/capabilities/auto_research/cli.py loopx/capabilities/auto_research/live_evidence.py
- git diff --check
- python3 -m loopx.cli --registry ~/.codex/loopx/registry.global.json --runtime-root ~/.codex/loopx check --scan-path loopx/capabilities/auto_research --scan-path examples/auto-research-live-codex-claim-boundary-smoke.py --scan-path docs/guides/auto-research-command-path.md

Note: this implements the acceptance gate for a future live Codex lane-authored proof; it does not claim the deterministic replay is a live Codex result.