### PR TITLE
Record SkillsBench 3d-scan-calc reverse tunnel pass

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json
@@ -67,10 +67,10 @@
         "3d-scan-calc": {
           "case_id": "3d-scan-calc",
           "latest_decision": {
-            "baseline_failure_scope": "case_or_solution",
-            "baseline_run_id": "295919e0907d",
-            "decision": "paired_treatment_improved",
-            "official_score_delta": 1.0,
+            "baseline_failure_scope": "passed",
+            "baseline_run_id": "379b296b4f16",
+            "decision": "paired_baseline_solved_treatment_preserved",
+            "official_score_delta": 0.0,
             "treatment_failure_scope": "passed",
             "treatment_run_id": "7ea835b649e7"
           },
@@ -1015,6 +1015,85 @@
               "source_event_schema": "benchmark_run_v0",
               "status": "completed",
               "submit_eligible": false,
+              "verifier_attempt_countable": true
+            },
+            {
+              "actual_model_verified": false,
+              "agent_declared_done": false,
+              "agent_model": "gpt-5.5",
+              "arm_id": "codex-app-server-goal-baseline",
+              "artifact_refs": {
+                "compact_artifact_ref": "runs/skillsbench-3d-scan-calc-native-goal-revtunnel-pr941-real-20260630T093746Z/benchmark_run.compact.json"
+              },
+              "attempt_failure_class": "none",
+              "attempt_failure_label": "none",
+              "attempt_lifecycle_phase": "verifier_scored",
+              "benchmark_id": "skillsbench@1.1",
+              "case_attempt_countable": true,
+              "case_id": "3d-scan-calc",
+              "case_ids": [
+                "3d-scan-calc"
+              ],
+              "codex_acp_runtime_preflight_passed": true,
+              "failure_class": "none",
+              "failure_scope": "passed",
+              "job_name": "skillsbench_1_1_3d_scan_calc_codex_app_server_goal_baseline",
+              "launcher_attempt_countable": true,
+              "leaderboard_evidence": false,
+              "loopx_inside_case": false,
+              "max_rounds_budget": 16,
+              "mode": "skillsbench_codex_app_server_goal_baseline",
+              "model_control_status": "reported_model_from_result_metadata",
+              "notes": "3d-scan-calc reverse-tunnel app-server Goal canary on main after PR #941; official reward=1.0; bridge task-facing ops 6/6; no upload.",
+              "official_feedback_blinded": true,
+              "official_passed": true,
+              "official_score": 1.0,
+              "official_score_attempt_countable": true,
+              "product_mode_lifecycle_contract": {
+                "checkpoint_count": 0,
+                "checkpoint_required": false,
+                "checkpoint_round": 0,
+                "countable_treatment": true,
+                "orchestrated_driver_counts_as_product_mode": false,
+                "orchestrated_driver_lifecycle_satisfied": false,
+                "required": false,
+                "satisfied": true,
+                "schema_version": "skillsbench_product_mode_lifecycle_contract_v0",
+                "state_read_count": 0,
+                "state_write_count": 0
+              },
+              "recorded_at": "2026-06-30T17:53:32+08:00",
+              "reward_feedback_forwarded": false,
+              "round_reward_count": 0,
+              "round_success_observed": false,
+              "run_group_id": "skillsbench-3d-scan-calc-native-goal-revtunnel-pr941-real-20260630T093746Z",
+              "run_id": "379b296b4f16",
+              "score_status": "passed",
+              "solver_attempt_countable": true,
+              "source_event_schema": "benchmark_run_v0",
+              "status": "completed",
+              "submit_eligible": false,
+              "task_staging": {
+                "app_skills_mount_patch_applied": true,
+                "apt_retry_patch_applied": true,
+                "apt_retry_patch_required": true,
+                "apt_risk_preflight_blocked": false,
+                "apt_setup_risk_detected": true,
+                "codex_acp_runtime_tools_patch_applied": true,
+                "include_task_skills": false,
+                "original_task_mutated": false,
+                "resource_cap_patch": {
+                  "applied": false,
+                  "host_cpus": 32.0
+                },
+                "staged": true,
+                "task_skills_removed": true,
+                "verifier_bootstrap_risk_detected": true,
+                "verifier_bootstrap_risk_preflight_blocked": false,
+                "verifier_uv_bootstrap_mirror_patch_applied": false,
+                "verifier_uv_bootstrap_mirror_patch_required": false,
+                "verifier_uv_bootstrap_risk_detected": false
+              },
               "verifier_attempt_countable": true
             }
           ]
@@ -12169,7 +12248,7 @@
           ]
         }
       },
-      "run_count": 193
+      "run_count": 194
     },
     "swe-marathon": {
       "benchmark_id": "swe-marathon",
@@ -16221,5 +16300,5 @@
     "source_of_truth": "benchmark_run_v0 compact run events",
     "update_rule": "upsert one run entry when a benchmark case is ingested or closed"
   },
-  "updated_at": "2026-06-30T06:18:22+08:00"
+  "updated_at": "2026-06-30T17:53:32+08:00"
 }

--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.md
@@ -5,14 +5,14 @@ benchmark case outcomes and artifact references; it must not contain raw
 logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 
 - schema_version: `benchmark_run_ledger_v0`
-- updated_at: `2026-06-30T06:18:22+08:00`
+- updated_at: `2026-06-30T17:53:32+08:00`
 
 ## Case Decisions
 
 | Benchmark | Case | Decision | Product Pair | Case Routing | Runs |
 | --- | --- | --- | --- | --- | --- |
 | `skillsbench-cloud-oracle-sanity@v0` | `hello-world` | `single_arm_recorded` | - | - | `1` |
-| `skillsbench@1.1` | `3d-scan-calc` | `paired_treatment_improved` | - | - | `12` |
+| `skillsbench@1.1` | `3d-scan-calc` | `paired_baseline_solved_treatment_preserved` | - | - | `13` |
 | `skillsbench@1.1` | `ada-bathroom-plan-repair` | `paired_treatment_improved` | - | - | `5` |
 | `skillsbench@1.1` | `adaptive-cruise-control` | `baseline_failed_treatment_candidate` | - | - | `2` |
 | `skillsbench@1.1` | `azure-bgp-oscillation-route-leak` | `product_mode_pair_incomplete` | `baseline_not_raw_codex_autonomous_max5,baseline_official_feedback_not_blinded,baseline_reward_feedback_forwarding_not...` | - | `11` |
@@ -114,6 +114,7 @@ logs, task prompts, trajectories, credentials, uploads, or absolute paths.
 | `skillsbench@1.1` | `3d-scan-calc` | `codex_loopx_treatment` | `` | `missing` | `` | `` | `skillsbench_host_local_acp_codex_exec_preflight_failed_bridge_command_failed` | `.local/private-benchmark-jobs/skillsbench-3d-scan-calc-goalstart-revchan-shim-20260628T111718Z/3d-scan-calc__loopx_goal_start_product_mode/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `3d-scan-calc` | `codex_loopx_treatment` | `case_attempt` | `1.0` | `2` | `1:0,2:1*,3:1*,4:1*` | `none` | `.local/private-benchmark-jobs/skillsbench-3d-scan-calc-goalstart-revchan-shim-20260628T111849Z/3d-scan-calc__loopx_goal_start_product_mode/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `3d-scan-calc` | `codex_app_server_goal_baseline` | `case_attempt` | `0.0` | `` | `` | `official_verifier_solution_failure` | `skillsbench-goal-baseline-30case-20260629T1921Z-r12-01-3d-scan-calc/result.json` |
+| `skillsbench@1.1` | `3d-scan-calc` | `codex-app-server-goal-baseline` | `case_attempt` | `1.0` | `` | `` | `none` | `runs/skillsbench-3d-scan-calc-native-goal-revtunnel-pr941-real-20260630T093746Z/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `ada-bathroom-plan-repair` | `codex_goal_mode_baseline` | `` | `missing` | `` | `` | `skillsbench_codex_acp_launch_failed` | `.local/private-benchmark-jobs/skillsbench-ada-bathroom-plan-repair-pair-20260615T2346CST/ada-bathroom-plan-repair__codex_goal_mode_baseline_20260615T2346CST/ada-bathroom-plan-repair__codex_goal_mode_baseline/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `ada-bathroom-plan-repair` | `codex_goal_mode_baseline` | `` | `missing` | `` | `` | `skillsbench_codex_acp_binary_missing` | `.local/private-benchmark-jobs/skillsbench-ada-bathroom-plan-repair-preflight-rerun-20260616T0124CST/ada-bathroom-plan-repair__codex_goal_mode_baseline_preflight_rerun_20260616T0124CST/ada-bathroom-plan-repair__codex_goal_mode_baseline/benchmark_run.compact.json` |
 | `skillsbench@1.1` | `ada-bathroom-plan-repair` | `baseline` | `` | `1.0` | `1` | `1:1*` | `none` | `.local/private-benchmark-jobs/skillsbench-ada-bathroom-plan-repair-blind-baseline-v0/ada-bathroom-plan-repair__codex_acp_blind_loop_v0/benchmark_run.compact.json` |


### PR DESCRIPTION
## Summary
- upsert the post-PR #941 reverse-tunnel app-server Goal canary for SkillsBench 3d-scan-calc into the public benchmark run ledger
- record official score 1.0 / failure none from compact benchmark_run_v0 only
- update the generated Markdown ledger row and case decision summary

## Validation
- python3 examples/benchmark-run-ledger-smoke.py
- git diff --check
- diff-only boundary scan for absolute/local/raw/secret markers
- loopx benchmark run-ledger-check --goal-id loopx-meta --run-ledger-path docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json (command ok; existing unrelated compact-history drift remains)

No raw task text, logs, trajectories, credentials, uploads, or absolute remote paths are added.