### PR TITLE
Modularize version CLI command

### DIFF
--- a/examples/catalog-canary-planner-smoke.py
+++ b/examples/catalog-canary-planner-smoke.py
@@ -43,6 +43,7 @@ def assert_profiles_come_from_catalog_matrix() -> None:
         "pr-review-and-merge",
         "release-promotion",
         "control-plane-refactor",
+        "cli-command-contract",
         "monitor-scheduler",
         "state-write-correctness",
         "frontstage-rollout",
@@ -114,6 +115,16 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     )
     refactor_profile_ids = {profile["id"] for profile in refactor_payload["domain_profiles"]}
     assert "control-plane-refactor" in refactor_profile_ids, refactor_payload
+
+    cli_payload = build_catalog_canary_plan(
+        changed_files=["loopx/cli.py", "loopx/cli_commands/version.py"],
+        surfaces=["cli command modularization"],
+    )
+    cli_profile_ids = {profile["id"] for profile in cli_payload["domain_profiles"]}
+    assert "cli-command-contract" in cli_profile_ids, cli_payload
+    cli_profile = next(profile for profile in cli_payload["domain_profiles"] if profile["id"] == "cli-command-contract")
+    commands = [check["command"] for check in cli_profile["checks"]]
+    assert "python3 examples/cli-version-command-modularization-smoke.py" in commands, cli_profile
 
 
 def assert_explicit_profile_can_include_deep_checks() -> None:

--- a/examples/cli-version-command-modularization-smoke.py
+++ b/examples/cli-version-command-modularization-smoke.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Smoke-test the low-risk version command module boundary."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CLI = REPO_ROOT / "loopx" / "cli.py"
+INIT = REPO_ROOT / "loopx" / "cli_commands" / "__init__.py"
+MODULE = REPO_ROOT / "loopx" / "cli_commands" / "version.py"
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    env = {**os.environ, "PYTHONPATH": str(REPO_ROOT)}
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *args],
+        cwd=REPO_ROOT,
+        env=env,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def require_success(result: subprocess.CompletedProcess[str]) -> str:
+    if result.returncode != 0:
+        raise AssertionError(
+            f"expected success, got {result.returncode}\n"
+            f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+        )
+    return result.stdout
+
+
+def assert_source_shape() -> None:
+    cli_source = CLI.read_text(encoding="utf-8")
+    init_source = INIT.read_text(encoding="utf-8")
+    module_source = MODULE.read_text(encoding="utf-8")
+
+    for marker in [
+        'sub.add_parser("version"',
+        "def build_version_payload(",
+        "def render_version_markdown(",
+    ]:
+        require(marker not in cli_source, f"version implementation leaked into loopx/cli.py: {marker}")
+    for marker in [
+        "register_version_command(sub, add_subcommand_format)",
+        "handle_version_command(",
+    ]:
+        require(marker in cli_source, f"loopx/cli.py missing {marker}")
+    for marker in [
+        "handle_version_command",
+        "register_version_command",
+    ]:
+        require(marker in init_source, f"cli_commands/__init__.py missing {marker}")
+    for marker in [
+        "def build_version_payload(",
+        "def register_version_command(",
+        "def handle_version_command(",
+        "output_format(args)",
+    ]:
+        require(marker in module_source, f"version module missing {marker}")
+
+
+def assert_version_outputs() -> None:
+    legacy_flag = require_success(run_cli("--version")).strip()
+    markdown = require_success(run_cli("version")).strip()
+    require(legacy_flag == markdown, f"--version and version disagree: {legacy_flag!r} != {markdown!r}")
+    require(markdown.startswith("loopx "), markdown)
+
+    for args in [("--format", "json", "version"), ("version", "--format", "json")]:
+        payload = json.loads(require_success(run_cli(*args)))
+        require(payload["ok"] is True, str(payload))
+        require(payload["schema_version"] == "loopx_version_v0", str(payload))
+        require(payload["name"] == "loopx", str(payload))
+        require(payload["version"] == markdown.removeprefix("loopx "), str(payload))
+
+    help_text = require_success(run_cli("version", "--help"))
+    require("--format {markdown,json}" in help_text, help_text)
+
+
+def main() -> int:
+    assert_source_shape()
+    assert_version_outputs()
+    print("cli-version-command-modularization-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -253,6 +253,31 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
         ],
     },
     {
+        "id": "cli-command-contract",
+        "title": "CLI command module contract",
+        "purpose": "Check command-module boundaries, ownership budgets, and compatibility for LoopX CLI refactors.",
+        "catalog_families": ["State And Boundary", "Planning Governance"],
+        "trigger_hints": (
+            "loopx/cli.py",
+            "loopx/cli_commands",
+            "cli command",
+            "command modularization",
+            "command-module",
+        ),
+        "checks": [
+            {
+                "command": "python3 examples/cli-version-command-modularization-smoke.py",
+                "tier": "default",
+                "reason": "guards a low-risk command migration plus old version invocations",
+            },
+            {
+                "command": "python3 examples/cli-control-plane-command-modularization-smoke.py",
+                "tier": "default",
+                "reason": "samples todo/quota command compatibility after CLI command refactors",
+            },
+        ],
+    },
+    {
         "id": "monitor-scheduler",
         "title": "Monitor scheduler routing",
         "purpose": "Check monitor due/quiet/replan behavior without polling external targets by default.",

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -45,6 +45,7 @@ from .cli_commands import (
     handle_summary_all_command,
     handle_support_control_command,
     handle_todo_command,
+    handle_version_command,
     handle_worker_bridge_command,
     register_benchmark_command_group,
     register_bootstrap_connect_command,
@@ -65,6 +66,7 @@ from .cli_commands import (
     register_summary_all_command,
     register_support_control_commands,
     register_todo_command,
+    register_version_command,
     register_worker_bridge_commands,
 )
 from .cli_rollout import (
@@ -80,19 +82,6 @@ def print_payload(payload: dict[str, object], fmt: str, markdown_renderer) -> No
         print(json.dumps(payload, ensure_ascii=False, indent=2))
     else:
         print(markdown_renderer(payload))
-
-
-def build_version_payload() -> dict[str, object]:
-    return {
-        "ok": True,
-        "schema_version": "loopx_version_v0",
-        "name": "loopx",
-        "version": __version__,
-    }
-
-
-def render_version_markdown(payload: dict[str, object]) -> str:
-    return f"{payload.get('name')} {payload.get('version')}\n"
 
 
 def add_subcommand_format(arg_parser: argparse.ArgumentParser) -> None:
@@ -125,7 +114,7 @@ def main(argv: list[str] | None = None) -> int:
     parser.add_argument("--format", choices=["markdown", "json"], default="markdown")
     sub = parser.add_subparsers(dest="command", required=True)
 
-    sub.add_parser("version", help="Print the installed LoopX version.")
+    register_version_command(sub, add_subcommand_format)
 
     register_bootstrap_connect_command(sub)
 
@@ -209,9 +198,9 @@ def main(argv: list[str] | None = None) -> int:
         if fallback_registry.exists():
             registry_path = fallback_registry
 
-    if args.command == "version":
-        print_payload(build_version_payload(), args.format, render_version_markdown)
-        return 0
+    version_result = handle_version_command(args, output_format=output_format, print_payload=print_payload)
+    if version_result is not None:
+        return version_result
 
     bootstrap_connect_result = handle_bootstrap_connect_command(
         args,

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -158,6 +158,7 @@ from .terminal_bench_environment_result import (
     register_terminal_bench_environment_result_commands,
 )
 from .todo import handle_todo_command, register_todo_command
+from .version import handle_version_command, register_version_command
 from .worker_bridge import handle_worker_bridge_command, register_worker_bridge_commands
 
 __all__ = [
@@ -224,6 +225,7 @@ __all__ = [
     "handle_terminal_bench_adapter_command",
     "handle_terminal_bench_environment_result_command",
     "handle_todo_command",
+    "handle_version_command",
     "handle_worker_bridge_command",
     "register_agents_last_exam_commands",
     "register_agents_last_exam_baked_input_commands",
@@ -266,5 +268,6 @@ __all__ = [
     "register_terminal_bench_adapter_commands",
     "register_terminal_bench_environment_result_commands",
     "register_todo_command",
+    "register_version_command",
     "register_worker_bridge_commands",
 ]

--- a/loopx/cli_commands/version.py
+++ b/loopx/cli_commands/version.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+
+from .. import __version__
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+FormatSelector = Callable[..., str]
+
+
+def build_version_payload() -> dict[str, object]:
+    return {
+        "ok": True,
+        "schema_version": "loopx_version_v0",
+        "name": "loopx",
+        "version": __version__,
+    }
+
+
+def render_version_markdown(payload: dict[str, object]) -> str:
+    return f"{payload.get('name')} {payload.get('version')}\n"
+
+
+def register_version_command(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+) -> None:
+    parser = subparsers.add_parser("version", help="Print the installed LoopX version.")
+    add_subcommand_format(parser)
+
+
+def handle_version_command(
+    args: argparse.Namespace,
+    *,
+    output_format: FormatSelector,
+    print_payload: PrintPayload,
+) -> int | None:
+    if args.command != "version":
+        return None
+    print_payload(build_version_payload(), output_format(args), render_version_markdown)
+    return 0


### PR DESCRIPTION
## Summary
- Move the `version` subcommand implementation into `loopx/cli_commands/version.py`.
- Preserve existing `loopx --version`, `loopx version`, and `loopx --format json version` behavior while adding `loopx version --format json`.
- Add a `cli-command-contract` catalog canary profile so `loopx/cli.py` and `loopx/cli_commands/...` changes automatically select the version/control-plane command smokes.

## Validation
- `python3 examples/cli-version-command-modularization-smoke.py`
- `python3 examples/catalog-canary-planner-smoke.py`
- `python3 examples/cli-control-plane-command-modularization-smoke.py`
- `python3 -m py_compile loopx/cli.py loopx/cli_commands/__init__.py loopx/cli_commands/version.py loopx/canary/planner.py examples/cli-version-command-modularization-smoke.py examples/catalog-canary-planner-smoke.py`
- `python3 -m loopx.cli --format json canary coverage-audit`
- `python3 -m loopx.cli --format json canary run --changed-file loopx/cli.py --changed-file loopx/cli_commands/__init__.py --changed-file loopx/cli_commands/version.py --changed-file loopx/canary/planner.py --changed-file examples/cli-version-command-modularization-smoke.py --changed-file examples/catalog-canary-planner-smoke.py --check-limit 4`
- `python3 -m loopx.cli check --scan-path loopx/cli.py --scan-path loopx/cli_commands/__init__.py --scan-path loopx/cli_commands/version.py --scan-path loopx/canary/planner.py --scan-path examples/cli-version-command-modularization-smoke.py --scan-path examples/catalog-canary-planner-smoke.py`
- `python3 -m loopx.cli --version && python3 -m loopx.cli --format json version && python3 -m loopx.cli version --format json`

`loopx check` reported the existing loopx-meta duplicate-index warning; the public boundary scan is clean for this change set.
