### PR TITLE
Add auto-research live evidence capture helper

### DIFF
--- a/docs/guides/auto-research-command-path.md
+++ b/docs/guides/auto-research-command-path.md
@@ -108,8 +108,23 @@ Truth boundary:
 - `--launch-visible` proves visible panes can start, but pane startup alone is
   not a live Codex research result.
 
-To claim a live Codex lane-authored E2E result, pass a compact public-safe
-evidence packet produced by the visible lanes:
+To claim a live Codex lane-authored E2E result, first let the visible lane that
+appended evidence capture the compact public-safe live proof:
+
+```bash
+loopx --registry "$LOOPX_REGISTRY" \
+  --runtime-root "$LOOPX_RUNTIME_ROOT" \
+  --format json auto-research capture-live-evidence \
+  --packet ./evidence.public.json \
+  --append-result ./append-result.public.json \
+  --agent-id codex-side-bypass \
+  --lane-count 3 \
+  --visible-lanes-accepted \
+  --output ./live-codex-e2e-evidence.public.json \
+  --execute
+```
+
+Then pass that compact evidence packet to the E2E acceptance command:
 
 ```bash
 loopx --registry "$LOOPX_REGISTRY" \
@@ -122,10 +137,10 @@ loopx --registry "$LOOPX_REGISTRY" \
   --live-evidence ./live-codex-e2e-evidence.public.json
 ```
 
-That packet must use `source: live_codex_lane_output`, match the goal and
-agent, show accepted visible lanes, cite lane-authored evidence appended to
-LoopX state, and keep raw logs, private artifacts, credentials, and local
-absolute paths out of the payload. Without this packet,
+The capture helper requires `source: live_codex_lane_output`, matching goal and
+agent, accepted visible lanes, lane-authored evidence appended to LoopX state,
+and zero raw logs, private artifacts, credentials, or local absolute paths in
+the payload. Without this packet,
 `live_codex_e2e.claim_allowed` stays `false`.
 
 For a full visible demo after an explicit replay step, add the visible lane

--- a/examples/auto-research-demo-e2e-smoke.py
+++ b/examples/auto-research-demo-e2e-smoke.py
@@ -186,6 +186,7 @@ def main() -> int:
         assert "live_codex_e2e.executed" in guide, guide
         assert "live_codex_e2e.claim_allowed" in guide, guide
         assert "not_collected_from_codex_lane_output" in guide, guide
+        assert "capture-live-evidence" in guide, guide
         assert "--live-evidence" in guide, guide
         assert "raw logs" in guide, guide
         assert "private artifacts" in guide, guide

--- a/examples/auto-research-live-evidence-capture-smoke.py
+++ b/examples/auto-research-live-evidence-capture-smoke.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env python3
+"""Smoke-test compact live evidence capture for visible auto-research lanes."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GOAL_ID = "loopx-auto-research-knn"
+AGENT_ID = "codex-side-bypass"
+
+
+def assert_public_safe(payload: Any) -> None:
+    text = json.dumps(payload, sort_keys=True) if not isinstance(payload, str) else payload
+    forbidden = [
+        "/" + "Users/",
+        "/" + "private/",
+        "/" + "tmp/",
+        "http://",
+        "https://",
+        "api" + "_key",
+        "pass" + "word",
+        "sec" + "ret",
+    ]
+    leaked = [needle for needle in forbidden if needle.lower() in text.lower()]
+    assert not leaked, leaked
+
+
+def run_cli(
+    args: list[str],
+    *,
+    registry: Path,
+    runtime_root: Path,
+    cwd: Path,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry),
+            "--runtime-root",
+            str(runtime_root),
+            "--format",
+            "json",
+            *args,
+        ],
+        cwd=cwd,
+        env=env,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def run_eval(pack_dir: Path, split: str) -> dict[str, Any]:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(pack_dir / "protected_eval.py"),
+            "--solution",
+            str(pack_dir / "solution_candidate.py"),
+            "--split",
+            split,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+    (pack_dir / f"{split}-result.public.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return payload
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        workspace = temp / "workspace"
+        workspace.mkdir()
+        registry = temp / "registry.json"
+        runtime_root = temp / "runtime"
+        registry.write_text(
+            json.dumps({"common_runtime_root": str(runtime_root), "goals": []}),
+            encoding="utf-8",
+        )
+
+        quickstart = run_cli(
+            [
+                "auto-research",
+                "quickstart",
+                "--goal-id",
+                GOAL_ID,
+                "--agent-id",
+                AGENT_ID,
+                "--output-dir",
+                "auto_research_knn_pack",
+                "--execute",
+            ],
+            registry=registry,
+            runtime_root=runtime_root,
+            cwd=workspace,
+        )
+        pack_dir = workspace / json.loads(quickstart.stdout)["pack_dir"]
+        dev = run_eval(pack_dir, "dev")
+        holdout = run_eval(pack_dir, "holdout")
+        assert dev["metric"]["value"] == 4.0, dev
+        assert holdout["metric"]["value"] == 4.5, holdout
+
+        evidence = run_cli(
+            [
+                "auto-research",
+                "evidence",
+                "--contract",
+                str(pack_dir / "research_contract.json"),
+                "--eval-result",
+                str(pack_dir / "dev-result.public.json"),
+                "--eval-result",
+                str(pack_dir / "holdout-result.public.json"),
+                "--hypothesis-id",
+                "hyp_live_lane_partial_selection",
+                "--todo-id",
+                "todo_live_lane_partial_selection",
+                "--agent-id",
+                AGENT_ID,
+                "--claimed-by",
+                AGENT_ID,
+                "--mechanism-family",
+                "partial_selection",
+                "--hypothesis",
+                "Use exact partial selection to avoid full distance sorting.",
+                "--grounding-ref",
+                "visible-lane:public-demo",
+            ],
+            registry=registry,
+            runtime_root=runtime_root,
+            cwd=workspace,
+        )
+        evidence_payload = json.loads(evidence.stdout)
+        evidence_path = workspace / "evidence.public.json"
+        evidence_path.write_text(json.dumps(evidence_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+        append = run_cli(
+            [
+                "auto-research",
+                "append-evidence",
+                "--packet",
+                str(evidence_path),
+            ],
+            registry=registry,
+            runtime_root=runtime_root,
+            cwd=workspace,
+        )
+        append_payload = json.loads(append.stdout)
+        append_path = workspace / "append-result.public.json"
+        append_path.write_text(json.dumps(append_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        assert append_payload["appended_count"] == 3, append_payload
+
+        live_path = workspace / "live-codex-e2e-evidence.public.json"
+        rejected = run_cli(
+            [
+                "auto-research",
+                "capture-live-evidence",
+                "--packet",
+                str(evidence_path),
+                "--append-result",
+                str(append_path),
+                "--agent-id",
+                AGENT_ID,
+                "--lane-count",
+                "3",
+            ],
+            registry=registry,
+            runtime_root=runtime_root,
+            cwd=workspace,
+            check=False,
+        )
+        assert rejected.returncode == 1, rejected.stdout
+        rejected_payload = json.loads(rejected.stdout)
+        assert rejected_payload["ok"] is False, rejected_payload
+        assert "accepted visible lanes" in rejected_payload["error"], rejected_payload
+        assert_public_safe(rejected_payload)
+
+        capture = run_cli(
+            [
+                "auto-research",
+                "capture-live-evidence",
+                "--packet",
+                str(evidence_path),
+                "--append-result",
+                str(append_path),
+                "--agent-id",
+                AGENT_ID,
+                "--lane-count",
+                "3",
+                "--visible-lanes-accepted",
+                "--output",
+                str(live_path),
+                "--execute",
+            ],
+            registry=registry,
+            runtime_root=runtime_root,
+            cwd=workspace,
+        )
+        live_payload = json.loads(capture.stdout)
+        assert live_path.is_file(), live_payload
+        assert json.loads(live_path.read_text(encoding="utf-8")) == live_payload, live_payload
+        assert live_payload["schema_version"] == "auto_research_live_codex_lane_e2e_evidence_v0", live_payload
+        assert live_payload["source"] == "live_codex_lane_output", live_payload
+        assert live_payload["goal_id"] == GOAL_ID, live_payload
+        assert live_payload["agent_id"] == AGENT_ID, live_payload
+        assert live_payload["visible_lanes"]["accepted"] is True, live_payload
+        assert live_payload["lane_evidence"]["append_status"] == "appended_to_loopx_state", live_payload
+        assert live_payload["lane_evidence"]["evidence_event_count"] == 2, live_payload
+        assert live_payload["lane_evidence"]["dev_metric"] == 4.0, live_payload
+        assert live_payload["lane_evidence"]["holdout_metric"] == 4.5, live_payload
+        assert_public_safe(live_payload)
+
+        claimed = run_cli(
+            [
+                "auto-research",
+                "demo-e2e",
+                "--goal-id",
+                GOAL_ID,
+                "--agent-id",
+                AGENT_ID,
+                "--execute",
+                "--live-evidence",
+                str(live_path),
+            ],
+            registry=registry,
+            runtime_root=runtime_root,
+            cwd=workspace,
+        )
+        claimed_payload = json.loads(claimed.stdout)
+        live = claimed_payload["live_codex_e2e"]
+        assert live["executed"] is True, claimed_payload
+        assert live["claim_allowed"] is True, claimed_payload
+        assert live["evidence_source"] == "live_codex_lane_output", claimed_payload
+        assert live["evidence_event_count"] == 2, claimed_payload
+        assert live["dev_metric"] == 4.0, claimed_payload
+        assert live["holdout_metric"] == 4.5, claimed_payload
+        assert_public_safe(claimed_payload)
+
+    print("auto-research-live-evidence-capture-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 from collections import Counter
 from collections.abc import Callable
 from pathlib import Path
@@ -23,6 +24,10 @@ from . import (
     render_auto_research_markdown,
 )
 from .demo_e2e import run_auto_research_demo_e2e
+from .live_evidence import (
+    LIVE_CODEX_E2E_DEFAULT_OUTPUT,
+    capture_live_codex_e2e_evidence,
+)
 from ...history import load_registry
 from ...paths import resolve_runtime_root
 from ...quota import build_quota_should_run
@@ -205,6 +210,44 @@ def register_auto_research_commands(
         "--dry-run",
         action="store_true",
         help="Preview rollout events without appending them.",
+    )
+
+    live_evidence_parser = auto_research_sub.add_parser(
+        "capture-live-evidence",
+        help="Build compact public-safe live Codex E2E evidence after lane-authored evidence is appended.",
+    )
+    add_subcommand_format(live_evidence_parser)
+    live_evidence_parser.add_argument(
+        "--packet",
+        required=True,
+        help="Path to the public auto_research_evidence_packet_v0 JSON produced by a visible lane.",
+    )
+    live_evidence_parser.add_argument(
+        "--append-result",
+        required=True,
+        help="Path to the JSON output from a real auto-research append-evidence run.",
+    )
+    live_evidence_parser.add_argument("--agent-id", required=True)
+    live_evidence_parser.add_argument(
+        "--lane-count",
+        type=int,
+        default=3,
+        help="Accepted visible lane count to record in the compact live evidence.",
+    )
+    live_evidence_parser.add_argument(
+        "--visible-lanes-accepted",
+        action="store_true",
+        help="Required acknowledgement that the visible lanes were launched and accepted.",
+    )
+    live_evidence_parser.add_argument(
+        "--output",
+        default=LIVE_CODEX_E2E_DEFAULT_OUTPUT,
+        help="Output path for --execute. The path is not recorded in the evidence payload.",
+    )
+    live_evidence_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Write the compact evidence JSON to --output. Omit to preview the payload.",
     )
 
     demo_supervisor_parser = auto_research_sub.add_parser(
@@ -575,6 +618,19 @@ def handle_auto_research_command(
                 runtime_root_arg=runtime_root_arg,
                 dry_run=args.dry_run,
             )
+        elif args.auto_research_command == "capture-live-evidence":
+            payload = capture_live_codex_e2e_evidence(
+                packet_path=args.packet,
+                append_result_path=args.append_result,
+                agent_id=args.agent_id,
+                lane_count=args.lane_count,
+                visible_lanes_accepted=args.visible_lanes_accepted,
+            )
+            if args.execute:
+                Path(args.output).expanduser().write_text(
+                    json.dumps(payload, indent=2, sort_keys=True) + "\n",
+                    encoding="utf-8",
+                )
         elif args.auto_research_command == "demo-supervisor":
             payload = build_auto_research_demo_supervisor_plan(
                 goal_id=args.goal_id,
@@ -647,7 +703,8 @@ def handle_auto_research_command(
         else:
             raise ValueError(
                 "auto-research requires the `quickstart`, `frontier`, `evidence`, "
-                "`board`, `acceptance`, `append-evidence`, `demo-supervisor`, or `demo-e2e` subcommand"
+                "`board`, `acceptance`, `append-evidence`, `capture-live-evidence`, "
+                "`demo-supervisor`, or `demo-e2e` subcommand"
             )
     except Exception as exc:
         payload = {

--- a/loopx/capabilities/auto_research/core.py
+++ b/loopx/capabilities/auto_research/core.py
@@ -3657,4 +3657,21 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
             f"- skipped_existing: `{payload.get('skipped_existing_count')}`",
         ]
         return "\n".join(lines) + "\n"
+    if payload.get("schema_version") == "auto_research_live_codex_lane_e2e_evidence_v0":
+        visible = payload.get("visible_lanes") if isinstance(payload.get("visible_lanes"), dict) else {}
+        evidence = payload.get("lane_evidence") if isinstance(payload.get("lane_evidence"), dict) else {}
+        lines = [
+            "# LoopX Auto Research Live Evidence",
+            "",
+            f"- schema: `{payload.get('schema_version')}`",
+            f"- goal_id: `{payload.get('goal_id')}`",
+            f"- agent_id: `{payload.get('agent_id')}`",
+            f"- source: `{payload.get('source')}`",
+            f"- visible_lanes_accepted: `{visible.get('accepted')}`",
+            f"- lane_count: `{visible.get('lane_count')}`",
+            f"- evidence_events: `{evidence.get('evidence_event_count')}`",
+            f"- result_status: `{evidence.get('result_status')}`",
+            f"- protected_scope_clean: `{evidence.get('protected_scope_clean')}`",
+        ]
+        return "\n".join(lines) + "\n"
     return render_auto_research_projection_markdown(payload)

--- a/loopx/capabilities/auto_research/live_evidence.py
+++ b/loopx/capabilities/auto_research/live_evidence.py
@@ -3,8 +3,15 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from .core import (
+    AUTO_RESEARCH_ROLLOUT_APPEND_SCHEMA_VERSION,
+    load_auto_research_evidence_packet,
+    validate_auto_research_evidence_packet,
+)
+
 
 LIVE_CODEX_E2E_EVIDENCE_SCHEMA_VERSION = "auto_research_live_codex_lane_e2e_evidence_v0"
+LIVE_CODEX_E2E_DEFAULT_OUTPUT = "live-codex-e2e-evidence.public.json"
 
 
 def _require_dict(payload: dict[str, object], key: str) -> dict[str, object]:
@@ -40,6 +47,114 @@ def _assert_live_evidence_public_safe(payload: dict[str, object]) -> None:
     leaked = [needle for needle in forbidden if needle.lower() in text.lower()]
     if leaked:
         raise ValueError("live evidence must be compact and public-safe; forbidden material detected")
+
+
+def _load_json_object(path: str | Path, *, field: str) -> dict[str, object]:
+    try:
+        payload = json.loads(Path(path).expanduser().read_text(encoding="utf-8"))
+    except Exception as exc:
+        raise ValueError(f"{field} must be readable JSON") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"{field} root must be an object")
+    return payload
+
+
+def _metric_by_split(packet: dict[str, object], split: str) -> object:
+    for event in packet.get("evidence_events") or []:
+        if not isinstance(event, dict) or event.get("split") != split:
+            continue
+        metric = event.get("metric")
+        if isinstance(metric, dict):
+            return metric.get("value")
+    return None
+
+
+def build_live_codex_e2e_evidence_from_packet(
+    *,
+    packet: dict[str, object],
+    append_result: dict[str, object],
+    agent_id: str,
+    lane_count: int,
+    visible_lanes_accepted: bool,
+) -> dict[str, object]:
+    packet = validate_auto_research_evidence_packet(packet)
+    if append_result.get("schema_version") != AUTO_RESEARCH_ROLLOUT_APPEND_SCHEMA_VERSION:
+        raise ValueError(f"append result schema_version must be {AUTO_RESEARCH_ROLLOUT_APPEND_SCHEMA_VERSION}")
+    if append_result.get("dry_run") is not False:
+        raise ValueError("append result must come from a real append-evidence run")
+    summary = packet["summary"]
+    goal_id = summary["goal_id"]
+    if append_result.get("goal_id") != goal_id:
+        raise ValueError("append result goal_id must match the evidence packet")
+    if str(agent_id) != str(packet["hypothesis"]["claimed_by"]):
+        raise ValueError("agent_id must match the packet hypothesis claimed_by field")
+    if not isinstance(lane_count, int) or lane_count <= 0:
+        raise ValueError("lane_count must be a positive integer")
+    if not visible_lanes_accepted:
+        raise ValueError("live evidence capture requires accepted visible lanes")
+    if append_result.get("appended_count", 0) <= 0:
+        raise ValueError("append result must include at least one fresh appended event")
+    counts = append_result.get("counts_by_kind")
+    if not isinstance(counts, dict) or int(counts.get("research_evidence") or 0) <= 0:
+        raise ValueError("append result must include at least one research_evidence event")
+    if summary.get("status") != "supported":
+        raise ValueError("live evidence can only be captured from a supported packet")
+    if summary.get("protected_scope_clean") is not True:
+        raise ValueError("live evidence requires protected_scope_clean=true")
+    if int(summary.get("negative_evidence_count") or 0) != 0:
+        raise ValueError("live evidence requires zero negative evidence")
+    if int(summary.get("needs_retry_count") or 0) != 0:
+        raise ValueError("live evidence requires zero retry-needed evidence")
+    payload = {
+        "ok": True,
+        "schema_version": LIVE_CODEX_E2E_EVIDENCE_SCHEMA_VERSION,
+        "source": "live_codex_lane_output",
+        "goal_id": goal_id,
+        "agent_id": agent_id,
+        "visible_lanes": {
+            "launched": True,
+            "accepted": True,
+            "lane_count": lane_count,
+        },
+        "lane_evidence": {
+            "lane_authored": True,
+            "evidence_source": "live_codex_lane_output",
+            "append_status": "appended_to_loopx_state",
+            "evidence_event_count": int(summary["evidence_event_count"]),
+            "result_status": summary["status"],
+            "protected_scope_clean": True,
+            "dev_metric": _metric_by_split(packet, "dev"),
+            "holdout_metric": _metric_by_split(packet, "holdout"),
+        },
+        "public_boundary": {
+            "raw_logs_recorded": False,
+            "private_artifacts_recorded": False,
+            "absolute_paths_recorded": False,
+            "credentials_recorded": False,
+            "local_workspace_path_redacted": True,
+        },
+    }
+    _assert_live_evidence_public_safe(payload)
+    return payload
+
+
+def capture_live_codex_e2e_evidence(
+    *,
+    packet_path: str,
+    append_result_path: str,
+    agent_id: str,
+    lane_count: int,
+    visible_lanes_accepted: bool,
+) -> dict[str, object]:
+    packet = load_auto_research_evidence_packet(packet_path)
+    append_result = _load_json_object(append_result_path, field="append_result_file")
+    return build_live_codex_e2e_evidence_from_packet(
+        packet=packet,
+        append_result=append_result,
+        agent_id=agent_id,
+        lane_count=lane_count,
+        visible_lanes_accepted=visible_lanes_accepted,
+    )
 
 
 def load_live_codex_e2e_evidence(


### PR DESCRIPTION
## Summary
- add auto-research capture-live-evidence to build compact live Codex lane evidence from public packet + append-result artifacts
- require accepted visible lanes, fresh appended evidence, supported status, clean protected boundary, and no raw/private/local-path material
- document the helper in the one-command path and cover capture -> demo-e2e --live-evidence with a durable smoke

## Validation
- python3 examples/auto-research-live-evidence-capture-smoke.py
- python3 examples/auto-research-live-codex-claim-boundary-smoke.py
- python3 examples/auto-research-demo-e2e-smoke.py
- python3 examples/auto-research-one-click-ux-smoke.py
- python3 examples/generic-multi-agent-one-command-smoke.py
- python3 -m py_compile loopx/capabilities/auto_research/cli.py loopx/capabilities/auto_research/core.py loopx/capabilities/auto_research/live_evidence.py
- git diff --check
- python3 -m loopx.cli --registry ~/.codex/loopx/registry.global.json --runtime-root ~/.codex/loopx check --scan-path loopx/capabilities/auto_research --scan-path examples/auto-research-live-evidence-capture-smoke.py --scan-path docs/guides/auto-research-command-path.md

Note: this still does not launch live Codex panes by itself; it gives accepted visible lanes a compact public-safe way to emit the evidence file required by the live claim gate.