### PR TITLE
Update README E2E exploration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,23 +170,32 @@ ask me to manually run `heartbeat-prompt`. Then stop and report the project
 connection status, current user gate, top agent todo, and next safe action.
 ```
 
-Then start a real long-running task in normal language:
+Then start a real E2E exploration in normal language:
 
 ```text
-/loopx Stabilize our flaky checkout tests, split the fix into safe PR-sized
-steps, keep private logs out of public artifacts, and hand off any production
-or release decision back to me.
+/loopx Explore an LLM semantic rerank slice for a recommendation or search
+system: build an offline eval set, implement a minimal candidate -> semantic
+feature -> rerank -> eval path, add trace/cache/fallback/cost guardrails,
+compare baseline vs treatment, and stop for production traffic, private data,
+credentials, or AB/canary gates.
 ```
 
-LoopX will plan before writing state, then create ordered P0/P1/P2 todos such
-as:
+LoopX will plan before writing state, then create ordered P0/P1/P2 todos that
+make the algorithm, infra, validation, and human gates visible.
+
+<details>
+<summary>Example visible todos</summary>
 
 ```text
-[P0] Reproduce the flaky checkout failure and capture public-safe evidence.
-[P0] Patch the narrowest failing path and run the focused smoke.
-[P1] Open or prepare the PR with validation notes and remaining risk.
-[P2] Add a follow-up monitor or cleanup task only if the evidence justifies it.
+[P0] Build the offline eval set: samples, labels, baseline, metrics, leakage check.
+[P0] Implement the vertical slice: candidate input -> semantic feature -> rerank -> eval.
+[P0] Add infra guardrails: trace schema, cache/fallback, rate limit, latency/cost budget.
+[P0] Ask before production traffic, private data, credentials, or AB/canary decisions.
+[P1] Compare baseline vs treatment with effect, cost, latency, and failure cases.
+[P2] Write the promotion handoff: canary evidence, rollback plan, and next experiment.
 ```
+
+</details>
 
 After that, each tick reads `quota should-run`: if a user gate blocks the chosen
 path, the agent asks a concrete question; if a safe fallback exists, it keeps


### PR DESCRIPTION
## Summary
- Replace the Quick Start flaky-test example with a compact E2E LLM semantic rerank exploration example.
- Keep the generated P0/P1/P2 todo sample available but collapsed under `<details>` so the first read stays concise.

## Product / Architecture Judgment
- Motivation: the README Quick Start should show LoopX on production-like engineering + algorithm exploration, not only open-source maintenance.
- Solved: yes; the new example covers offline eval, semantic feature/rerank implementation, trace/cache/fallback/cost guardrails, baseline-vs-treatment validation, and human gates.
- User/operator impact: technical and algorithm readers can see that LoopX turns a complex exploration into visible ordered todos across algorithm, infra, validation, and approval boundaries.
- Main risk: docs-only wording risk; no runtime, permission, benchmark, or installed-user behavior changes.
- Design judgment: keep the main path short and put detailed generated todos in a collapsed sample to avoid README bloat while preserving the capability signal.

## Validation
- `git diff --check`
- `loopx check --scan-path README.md` (errors=0; pre-existing loopx-meta duplicate-index warning only)
- Public/private boundary scan of `README.md`; matches are generic boundary guidance, not private state or credentials.

## Merge Decision
Self-merge after owner approval: small single-purpose public docs change, validated, no runtime or permission-sensitive behavior.
