### PR TITLE
Add status read-path canary profile

### DIFF
--- a/examples/catalog-canary-planner-smoke.py
+++ b/examples/catalog-canary-planner-smoke.py
@@ -43,6 +43,7 @@ def assert_profiles_come_from_catalog_matrix() -> None:
         "pr-review-and-merge",
         "release-promotion",
         "control-plane-refactor",
+        "status-read-path",
         "cli-command-contract",
         "monitor-scheduler",
         "state-write-correctness",
@@ -115,6 +116,16 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     )
     refactor_profile_ids = {profile["id"] for profile in refactor_payload["domain_profiles"]}
     assert "control-plane-refactor" in refactor_profile_ids, refactor_payload
+
+    status_payload = build_catalog_canary_plan(
+        changed_files=["loopx/status.py"],
+        surfaces=["status --goal-id read-path"],
+    )
+    status_profiles = {profile["id"]: profile for profile in status_payload["domain_profiles"]}
+    assert "status-read-path" in status_profiles, status_payload
+    status_commands = [check["command"] for check in status_profiles["status-read-path"]["checks"]]
+    assert "python3 examples/status-goal-filter-smoke.py" in status_commands, status_payload
+    assert all(check["tier"] == "default" for check in status_profiles["status-read-path"]["checks"]), status_payload
 
     cli_payload = build_catalog_canary_plan(
         changed_files=["loopx/cli.py", "loopx/cli_commands/version.py"],

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -253,6 +253,42 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
         ],
     },
     {
+        "id": "status-read-path",
+        "title": "Status read-path contract",
+        "purpose": "Check scoped status reads, markdown rendering, and goal-channel status export before status/read-path changes ship.",
+        "catalog_families": ["Work Routing", "State And Boundary"],
+        "trigger_hints": (
+            "read-path",
+            "status --goal-id",
+            "status data",
+            "goal status",
+            "loopx/status.py",
+            "loopx/cli_commands/status",
+        ),
+        "checks": [
+            {
+                "command": "python3 examples/status-goal-filter-smoke.py",
+                "tier": "default",
+                "reason": "guards scoped status projection and global default status behavior",
+            },
+            {
+                "command": "python3 examples/status-markdown-smoke.py",
+                "tier": "default",
+                "reason": "checks operator-facing markdown status rendering",
+            },
+            {
+                "command": "python3 examples/goal-channel-status-export-smoke.py",
+                "tier": "default",
+                "reason": "guards goal-channel status export consumed by non-hot-path readers",
+            },
+            {
+                "command": "python3 examples/status-quota-perf-budget-smoke.py",
+                "tier": "deep",
+                "reason": "runs the broader status/quota performance budget sample when explicitly requested",
+            },
+        ],
+    },
+    {
         "id": "cli-command-contract",
         "title": "CLI command module contract",
         "purpose": "Check command-module boundaries, ownership budgets, and compatibility for LoopX CLI refactors.",


### PR DESCRIPTION
## Summary
- Add a `status-read-path` catalog canary domain profile for scoped status/read-path changes.
- Wire the profile to existing default smokes for goal filtering, markdown status rendering, and goal-channel export.
- Extend the catalog canary planner smoke so status/read-path selectors prove the new profile is chosen without selecting it from generic README status text.

## Validation
- `python3 examples/catalog-canary-planner-smoke.py`
- `python3 -m loopx.cli --format json canary run --profile status-read-path --check-limit 4`
- `python3 -m py_compile loopx/canary/planner.py examples/catalog-canary-planner-smoke.py`
- `git diff --check origin/main...HEAD`
- `python3 -m loopx.cli check --scan-path loopx/canary/planner.py --scan-path examples/catalog-canary-planner-smoke.py`

`loopx check` reports only the pre-existing loopx-meta duplicate-index warning; the touched-file public boundary scan is clean.
