### PR TITLE
Add todo lifecycle catalog canary profile

### DIFF
--- a/examples/catalog-canary-planner-smoke.py
+++ b/examples/catalog-canary-planner-smoke.py
@@ -45,6 +45,7 @@ def assert_profiles_come_from_catalog_matrix() -> None:
         "control-plane-refactor",
         "status-read-path",
         "cli-command-contract",
+        "todo-lifecycle",
         "monitor-scheduler",
         "state-write-correctness",
         "frontstage-rollout",
@@ -136,6 +137,18 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     cli_profile = next(profile for profile in cli_payload["domain_profiles"] if profile["id"] == "cli-command-contract")
     commands = [check["command"] for check in cli_profile["checks"]]
     assert "python3 examples/cli-version-command-modularization-smoke.py" in commands, cli_profile
+
+    todo_payload = build_catalog_canary_plan(
+        changed_files=["loopx/todos.py", "loopx/todo_contract.py"],
+        surfaces=["todo lifecycle todo claim todo list"],
+    )
+    todo_profiles = {profile["id"]: profile for profile in todo_payload["domain_profiles"]}
+    assert "todo-lifecycle" in todo_profiles, todo_payload
+    todo_profile = todo_profiles["todo-lifecycle"]
+    todo_commands = [check["command"] for check in todo_profile["checks"]]
+    assert "python3 examples/todo-lifecycle-cli-smoke.py" in todo_commands, todo_profile
+    assert all(check["tier"] == "default" for check in todo_profile["checks"]), todo_profile
+    assert todo_profile["deep_checks_available"] is True, todo_profile
 
 
 def assert_explicit_profile_can_include_deep_checks() -> None:

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -314,6 +314,56 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
         ],
     },
     {
+        "id": "todo-lifecycle",
+        "title": "Todo lifecycle contract",
+        "purpose": "Check todo metadata, lifecycle transitions, and event/list projection before todo read/write CLI changes ship.",
+        "catalog_families": ["State And Boundary", "Human Decision", "Planning Governance"],
+        "trigger_hints": (
+            "todo lifecycle",
+            "todo claim",
+            "todo list",
+            "todo complete",
+            "todo supersede",
+            "todo metadata",
+            "todo detail",
+            "loopx/todos.py",
+            "loopx/todo_contract.py",
+            "loopx/cli_commands/todo",
+        ),
+        "checks": [
+            {
+                "command": "python3 examples/todo-contract-smoke.py",
+                "tier": "default",
+                "reason": "guards the public todo status and metadata helper contract",
+            },
+            {
+                "command": "python3 examples/todo-cli-smoke.py",
+                "tier": "default",
+                "reason": "checks agent-facing todo add/update/list behavior on fixture state",
+            },
+            {
+                "command": "python3 examples/todo-lifecycle-cli-smoke.py",
+                "tier": "default",
+                "reason": "exercises claim, completion, successor, and handoff lifecycle transitions by todo_id",
+            },
+            {
+                "command": "python3 examples/todo-list-event-projection-smoke.py",
+                "tier": "default",
+                "reason": "guards event-sourced todo list projection with Markdown fallback",
+            },
+            {
+                "command": "python3 examples/todo-concurrent-write-lock-smoke.py",
+                "tier": "deep",
+                "reason": "samples lock behavior for concurrent todo writes",
+            },
+            {
+                "command": "python3 examples/todo-detail-cold-path-contract-smoke.py",
+                "tier": "deep",
+                "reason": "checks the cold-path todo detail contract when detail surfaces are promoted",
+            },
+        ],
+    },
+    {
         "id": "monitor-scheduler",
         "title": "Monitor scheduler routing",
         "purpose": "Check monitor due/quiet/replan behavior without polling external targets by default.",


### PR DESCRIPTION
## Summary
- add a todo-lifecycle current-repo canary profile for todo metadata, CLI lifecycle, event/list projection, write-lock, and cold-path detail checks
- make the catalog canary planner smoke assert that todo lifecycle/todo claim surfaces select the new profile

## Motivation
LoopX already had durable todo smoke coverage, but catalog canary planning did not expose a focused profile for todo read/write CLI changes. This makes non-benchmark todo refactors easier to gate with the catalog-to-canary chain instead of relying on ad hoc smoke selection.

## Validation
- python3 examples/todo-contract-smoke.py && python3 examples/todo-cli-smoke.py && python3 examples/todo-lifecycle-cli-smoke.py && python3 examples/todo-list-event-projection-smoke.py
- python3 examples/todo-concurrent-write-lock-smoke.py && python3 examples/todo-detail-cold-path-contract-smoke.py
- python3 examples/catalog-canary-planner-smoke.py
- python3 -m loopx.cli --format json canary plan --changed-file loopx/todos.py --surface 'todo lifecycle todo claim'
- python3 -m loopx.cli --format json canary run --profile todo-lifecycle --check-limit 4
- python3 -m loopx.cli --format json canary run --profile todo-lifecycle --include-deep-checks --max-checks-per-profile 6 --check-limit 6
- python3 -m py_compile loopx/canary/planner.py examples/catalog-canary-planner-smoke.py
- git diff --check origin/main...HEAD
- python3 -m loopx.cli check --scan-path loopx/canary/planner.py --scan-path examples/catalog-canary-planner-smoke.py
- python3 -m loopx.cli --format json canary coverage-audit

## Risk
Low. This only wires existing public smokes into catalog canary planning and does not change runtime todo behavior, benchmark behavior, permissions, or write paths.