### PR TITLE
Fix app-server Goal worker timeout default

### DIFF
--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -30,6 +30,7 @@ from loopx.benchmark_adapters.skillsbench_remote_bridge import (  # noqa: E402
     build_skillsbench_remote_command_file_bridge_probe_request,
 )
 from scripts.skillsbench_automation_loop import (  # noqa: E402
+    DEFAULT_TIMEOUT_SEC,
     DEFAULT_HOST_LOCAL_CODEX_BRIDGE_IDLE_TIMEOUT_SEC,
     HOST_LOCAL_ACP_AGENT_TIMEOUT_MARGIN_SEC,
     _apply_agent_message_only_no_tool_calls_attribution,
@@ -183,6 +184,7 @@ print(json.dumps({"ok": True, "stdout": "", "stderr": "", "exit_code": 0}))
         agent_idle_timeout=7200,
         host_local_acp_launch=True,
         local_codex_exec_timeout_sec=21600,
+        route="loopx-product-mode",
     )
     assert _effective_local_codex_exec_timeout_sec(timeout_args) == 21600
     assert _effective_benchflow_agent_timeout_sec(timeout_args) == (
@@ -193,6 +195,7 @@ print(json.dumps({"ok": True, "stdout": "", "stderr": "", "exit_code": 0}))
         host_local_acp_launch=True,
         local_codex_bridge_idle_timeout_sec=None,
         local_codex_exec_timeout_sec=None,
+        route="loopx-product-mode",
     )
     assert _effective_local_codex_exec_timeout_sec(
         default_host_local_timeout_args
@@ -204,8 +207,34 @@ print(json.dumps({"ok": True, "stdout": "", "stderr": "", "exit_code": 0}))
         agent_idle_timeout=7200,
         host_local_acp_launch=False,
         local_codex_exec_timeout_sec=21600,
+        route="loopx-product-mode",
     )
     assert _effective_benchflow_agent_timeout_sec(non_host_local_timeout_args) == 7200
+    app_server_goal_timeout_args = SimpleNamespace(
+        agent_idle_timeout=900,
+        host_local_acp_launch=True,
+        local_codex_bridge_idle_timeout_sec=None,
+        local_codex_exec_timeout_sec=None,
+        outer_timeout_sec=3600,
+        route="codex-app-server-goal-baseline",
+    )
+    assert _effective_local_codex_exec_timeout_sec(app_server_goal_timeout_args) == (
+        DEFAULT_TIMEOUT_SEC
+    )
+    assert _effective_benchflow_agent_timeout_sec(app_server_goal_timeout_args) == (
+        DEFAULT_TIMEOUT_SEC + HOST_LOCAL_ACP_AGENT_TIMEOUT_MARGIN_SEC
+    )
+    app_server_goal_outer_timeout_args = SimpleNamespace(
+        agent_idle_timeout=900,
+        host_local_acp_launch=True,
+        local_codex_bridge_idle_timeout_sec=None,
+        local_codex_exec_timeout_sec=None,
+        outer_timeout_sec=21600,
+        route="codex-app-server-goal-baseline",
+    )
+    assert _effective_local_codex_exec_timeout_sec(
+        app_server_goal_outer_timeout_args
+    ) == 21600
     replaced = _replace_option_value(
         ["relay", "--remote-command-file-bridge-command", "old", "--keep", "x"],
         "--remote-command-file-bridge-command",

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -1117,6 +1117,9 @@ def _effective_local_codex_exec_timeout_sec(args: argparse.Namespace) -> int:
         configured_raw is None
         and bool(getattr(args, "host_local_acp_launch", False))
     ):
+        if getattr(args, "route", "") == "codex-app-server-goal-baseline":
+            outer_timeout = max(0, int(getattr(args, "outer_timeout_sec", 0) or 0))
+            return max(configured, outer_timeout)
         bridge_idle_timeout = _effective_local_codex_bridge_idle_timeout_sec(args)
         if bridge_idle_timeout > 0:
             return max(
@@ -12339,7 +12342,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help=(
             "Per-prompt timeout for local Codex exec in host-local ACP launch "
             "mode. Omit to use the host-local bridge idle timeout plus a small "
-            "agent timeout margin."
+            "agent timeout margin, except codex-app-server-goal-baseline which "
+            "uses the longer of the default exec timeout and --outer-timeout-sec."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- keep host-local ACP relay fail-fast timeout behavior for non app-server Goal routes
- make codex-app-server-goal-baseline default local worker timeout use the longer of DEFAULT_TIMEOUT_SEC and --outer-timeout-sec instead of bridge idle + margin
- add launch-plan smoke coverage for ordinary relay vs app-server Goal timeout selection

## Why
Batch3 adaptive-cruise-control failed as skillsbench_native_goal_worker_failed_codex_app_server_turn_timeout after real reverse-bridge task-facing operations. The compact config showed local_codex_exec_timeout_sec=960, because the host-local default reused bridge idle timeout + margin as the total worker timeout. That is too short for native app-server Goal runs; bridge idle/quiet watchdogs should remain fail-fast gates, while the full worker turn gets the long run budget.

## Validation
- python3 examples/skillsbench-host-local-launch-plan-smoke.py
- python3 -m py_compile scripts/skillsbench_automation_loop.py
- git diff --check
- loopx check --scan-path scripts/skillsbench_automation_loop.py --scan-path examples/skillsbench-host-local-launch-plan-smoke.py