### PR TITLE
Route auto-research demo frontier separately

### DIFF
--- a/docs/guides/auto-research-command-path.md
+++ b/docs/guides/auto-research-command-path.md
@@ -61,6 +61,13 @@ That command is the user-facing UX for a replay-backed visible demo. Generic
 launcher internals stay inside LoopX; the operator does not need to know the
 module or implementation path.
 
+When this demo is being advanced from a broader productization goal such as
+`loopx-meta`, do not change `--goal-id` to that meta goal. Keep
+`--goal-id loopx-auto-research-knn` so the visible lanes read the positive
+auto-research frontier. Add `--tracking-goal-id loopx-meta` only when the
+caller needs metadata that says which parent goal is tracking the product work;
+tracking metadata never drives the visible lane frontier.
+
 If you want to inspect before opening visible Codex lanes, start with the
 read-only dry-run. It tells the operator which command will run the
 deterministic positive replay:

--- a/examples/auto-research-demo-e2e-smoke.py
+++ b/examples/auto-research-demo-e2e-smoke.py
@@ -14,6 +14,7 @@ from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 GOAL_ID = "loopx-auto-research-knn"
+TRACKING_GOAL_ID = "loopx-meta"
 AGENT_ID = "codex-side-bypass"
 GUIDE = REPO_ROOT / "docs" / "guides" / "auto-research-command-path.md"
 
@@ -58,10 +59,23 @@ def run_cli(args: list[str], *, registry: Path, runtime_root: Path) -> subproces
     )
 
 
-def assert_e2e_payload(payload: dict[str, Any], *, executed: bool) -> None:
+def assert_e2e_payload(
+    payload: dict[str, Any],
+    *,
+    executed: bool,
+    tracking_goal_id: str | None = None,
+) -> None:
     assert payload["ok"] is True, payload
     assert payload["schema_version"] == "auto_research_demo_e2e_result_v0", payload
     assert payload["goal_id"] == GOAL_ID, payload
+    assert payload["tracking_goal_id"] == tracking_goal_id, payload
+    route = payload["route_contract"]
+    assert route["schema_version"] == "auto_research_demo_frontier_route_v0", payload
+    assert route["frontier_goal_id"] == GOAL_ID, payload
+    assert route["visible_lanes_read_goal_id"] == GOAL_ID, payload
+    assert route["tracking_goal_id"] == tracking_goal_id, payload
+    assert route["tracking_goal_drives_frontier"] is False, payload
+    assert route["dedicated_positive_demo_frontier"] is True, payload
     assert payload["agent_id"] == AGENT_ID, payload
     assert payload["reasoning_effort"] == "high", payload
     assert payload["execution_kind"] in {
@@ -141,12 +155,21 @@ def main() -> int:
                 GOAL_ID,
                 "--agent-id",
                 AGENT_ID,
+                "--tracking-goal-id",
+                TRACKING_GOAL_ID,
                 "--execute",
             ],
             registry=registry,
             runtime_root=runtime_root,
         )
-        assert_e2e_payload(json.loads(executed.stdout), executed=True)
+        executed_payload = json.loads(executed.stdout)
+        assert_e2e_payload(executed_payload, executed=True, tracking_goal_id=TRACKING_GOAL_ID)
+        replay_command = executed_payload["commands"]["deterministic_replay"]
+        visible_command = executed_payload["commands"]["deterministic_replay_with_visible_lanes"]
+        assert f"--goal-id {GOAL_ID}" in replay_command, replay_command
+        assert f"--goal-id {GOAL_ID}" in visible_command, visible_command
+        assert f"--tracking-goal-id {TRACKING_GOAL_ID}" in replay_command, replay_command
+        assert f"--tracking-goal-id {TRACKING_GOAL_ID}" in visible_command, visible_command
 
         markdown = run_cli(
             [
@@ -162,6 +185,8 @@ def main() -> int:
         ).stdout
         assert "# LoopX Auto Research Demo Replay" in markdown, markdown
         assert "execution_kind: `deterministic_replay_preview`" in markdown, markdown
+        assert "frontier_goal_id: `loopx-auto-research-knn`" in markdown, markdown
+        assert "tracking_goal_drives_frontier: `False`" in markdown, markdown
         assert "live_codex_e2e_claim_allowed: `False`" in markdown, markdown
         assert "live_codex_e2e_evidence_source: `not_collected_from_codex_lane_output`" in markdown, markdown
         assert "reasoning_effort: `high`" in markdown, markdown
@@ -175,6 +200,8 @@ def main() -> int:
         assert "--reasoning-effort high" in guide, guide
         assert "--execute" in guide, guide
         assert "--launch-visible" in guide, guide
+        assert "--tracking-goal-id loopx-meta" in guide, guide
+        assert "tracking metadata never drives the visible lane frontier" in guide, guide
         assert "--attach" in guide, guide
         assert "--replace-existing" in guide, guide
         assert "tmux kill-session -t loopx-auto-research" in guide, guide

--- a/examples/auto-research-one-click-ux-smoke.py
+++ b/examples/auto-research-one-click-ux-smoke.py
@@ -15,6 +15,7 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parents[1]
 GUIDE = REPO_ROOT / "docs" / "guides" / "auto-research-command-path.md"
 GOAL_ID = "loopx-auto-research-knn"
+TRACKING_GOAL_ID = "loopx-meta"
 AGENT_ID = "codex-side-bypass"
 SESSION = "loopx-auto-research-one-click-smoke"
 
@@ -151,6 +152,8 @@ def main() -> int:
                 GOAL_ID,
                 "--agent-id",
                 AGENT_ID,
+                "--tracking-goal-id",
+                TRACKING_GOAL_ID,
                 "--reasoning-effort",
                 "high",
                 "--execute",
@@ -172,6 +175,14 @@ def main() -> int:
         payload = json.loads(result.stdout)
         assert payload["ok"] is True, payload
         assert payload["mode"] == "execute", payload
+        assert payload["goal_id"] == GOAL_ID, payload
+        assert payload["tracking_goal_id"] == TRACKING_GOAL_ID, payload
+        route = payload["route_contract"]
+        assert route["frontier_goal_id"] == GOAL_ID, payload
+        assert route["visible_lanes_read_goal_id"] == GOAL_ID, payload
+        assert route["tracking_goal_id"] == TRACKING_GOAL_ID, payload
+        assert route["tracking_goal_drives_frontier"] is False, payload
+        assert route["dedicated_positive_demo_frontier"] is True, payload
         assert payload["execution_kind"] == "deterministic_replay", payload
         assert payload["result_source"] == "generated_quickstart_pack_protected_eval_replay", payload
         assert payload["reasoning_effort"] == "high", payload
@@ -228,6 +239,9 @@ def main() -> int:
         log_entries = [json.loads(line) for line in tmux_log.read_text(encoding="utf-8").splitlines()]
         assert any(entry[:1] == ["new-session"] for entry in log_entries), log_entries
         assert sum(1 for entry in log_entries if entry[:1] == ["new-window"]) == 3, log_entries
+        command_text = "\n".join(" ".join(entry) for entry in log_entries)
+        assert f"--goal-id {GOAL_ID}" in command_text, command_text
+        assert f"--goal-id {TRACKING_GOAL_ID}" not in command_text, command_text
         assert any(entry[:1] == ["list-windows"] for entry in log_entries), log_entries
         assert sum(1 for entry in log_entries if entry[:1] == ["capture-pane"]) == 3, log_entries
 

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -335,6 +335,13 @@ def register_auto_research_commands(
         help="Research goal id for the positive demo evidence.",
     )
     demo_e2e_parser.add_argument(
+        "--tracking-goal-id",
+        help=(
+            "Optional parent/productization goal id for status writeback context. "
+            "Visible lanes still inspect --goal-id as the research frontier."
+        ),
+    )
+    demo_e2e_parser.add_argument(
         "--objective",
         default=AUTO_RESEARCH_DEFAULT_OBJECTIVE,
         help="Compact public-safe research objective for the generated contract.",
@@ -684,6 +691,7 @@ def handle_auto_research_command(
             payload = run_auto_research_demo_e2e(
                 agent_id=args.agent_id,
                 goal_id=args.goal_id,
+                tracking_goal_id=args.tracking_goal_id,
                 objective=args.objective,
                 output_dir=args.output_dir,
                 execute=args.execute,

--- a/loopx/capabilities/auto_research/core.py
+++ b/loopx/capabilities/auto_research/core.py
@@ -3477,6 +3477,7 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
         acceptance = payload.get("acceptance") if isinstance(payload.get("acceptance"), dict) else {}
         supervisor = payload.get("supervisor") if isinstance(payload.get("supervisor"), dict) else {}
         commands = payload.get("commands") if isinstance(payload.get("commands"), dict) else {}
+        route = payload.get("route_contract") if isinstance(payload.get("route_contract"), dict) else {}
         live_codex = (
             payload.get("live_codex_e2e")
             if isinstance(payload.get("live_codex_e2e"), dict)
@@ -3490,6 +3491,9 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
             f"- execution_kind: `{payload.get('execution_kind')}`",
             f"- result_source: `{payload.get('result_source')}`",
             f"- goal_id: `{payload.get('goal_id')}`",
+            f"- tracking_goal_id: `{payload.get('tracking_goal_id')}`",
+            f"- frontier_goal_id: `{route.get('frontier_goal_id')}`",
+            f"- tracking_goal_drives_frontier: `{route.get('tracking_goal_drives_frontier')}`",
             f"- agent_id: `{payload.get('agent_id')}`",
             f"- reasoning_effort: `{payload.get('reasoning_effort')}`",
             f"- replay_executed: `{replay.get('executed')}`",

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -10,6 +10,7 @@ from pathlib import Path
 
 from .core import (
     AUTO_RESEARCH_DEMO_E2E_SCHEMA_VERSION,
+    AUTO_RESEARCH_DEFAULT_GOAL_ID,
     AUTO_RESEARCH_PROJECTION_SCHEMA_VERSION,
     build_auto_research_board_projection,
     build_auto_research_demo_acceptance_packet,
@@ -182,6 +183,7 @@ def _command_text(
     execute: bool,
     launch_visible: bool = False,
     live_evidence: bool = False,
+    tracking_goal_id: str | None = None,
 ) -> str:
     parts = [
         shlex.quote(cli_bin),
@@ -194,6 +196,8 @@ def _command_text(
         "--agent-id",
         shlex.quote(agent_id),
     ]
+    if tracking_goal_id:
+        parts.extend(["--tracking-goal-id", shlex.quote(tracking_goal_id)])
     if execute:
         parts.append("--execute")
     if launch_visible:
@@ -226,6 +230,7 @@ def run_auto_research_demo_e2e(
     *,
     agent_id: str,
     goal_id: str,
+    tracking_goal_id: str | None,
     objective: str,
     output_dir: str,
     execute: bool,
@@ -249,6 +254,9 @@ def run_auto_research_demo_e2e(
     if live_evidence_path and not execute:
         raise ValueError("--live-evidence requires --execute")
 
+    tracking_goal = tracking_goal_id.strip() if isinstance(tracking_goal_id, str) else ""
+    if tracking_goal == goal_id:
+        tracking_goal = ""
     supervisor = build_auto_research_demo_supervisor_plan(
         goal_id=goal_id,
         session_name=session_name,
@@ -264,6 +272,19 @@ def run_auto_research_demo_e2e(
         "execution_kind": "deterministic_replay" if execute else "deterministic_replay_preview",
         "result_source": "generated_quickstart_pack_protected_eval_replay",
         "goal_id": goal_id,
+        "tracking_goal_id": tracking_goal or None,
+        "route_contract": {
+            "schema_version": "auto_research_demo_frontier_route_v0",
+            "frontier_goal_id": goal_id,
+            "tracking_goal_id": tracking_goal or None,
+            "tracking_goal_drives_frontier": False,
+            "visible_lanes_read_goal_id": goal_id,
+            "dedicated_positive_demo_frontier": goal_id == AUTO_RESEARCH_DEFAULT_GOAL_ID,
+            "reason": (
+                "Use --goal-id for the research frontier that visible lanes inspect. "
+                "--tracking-goal-id is metadata for the parent productization goal and must not reroute panes."
+            ),
+        },
         "agent_id": agent_id,
         "reasoning_effort": reasoning_effort,
         "commands": {
@@ -272,6 +293,7 @@ def run_auto_research_demo_e2e(
                 goal_id=goal_id,
                 agent_id=agent_id,
                 execute=True,
+                tracking_goal_id=tracking_goal or None,
             ),
             "deterministic_replay_with_visible_lanes": _command_text(
                 cli_bin=cli_bin,
@@ -279,6 +301,7 @@ def run_auto_research_demo_e2e(
                 agent_id=agent_id,
                 execute=True,
                 launch_visible=True,
+                tracking_goal_id=tracking_goal or None,
             ),
             "live_codex_claim_from_evidence": _command_text(
                 cli_bin=cli_bin,
@@ -286,6 +309,7 @@ def run_auto_research_demo_e2e(
                 agent_id=agent_id,
                 execute=True,
                 live_evidence=True,
+                tracking_goal_id=tracking_goal or None,
             ),
         },
         "supervisor": {


### PR DESCRIPTION
## Summary
- add demo-e2e --tracking-goal-id metadata so productization goals can track the demo without driving the visible lane frontier
- expose an auto_research_demo_frontier_route_v0 contract showing that visible lanes read --goal-id, not the tracking goal
- document the loopx-meta/productization pattern and cover it in durable E2E smokes

## Validation
- python3 examples/auto-research-demo-e2e-smoke.py
- python3 examples/auto-research-one-click-ux-smoke.py
- python3 examples/auto-research-live-codex-claim-boundary-smoke.py
- python3 examples/generic-multi-agent-one-command-smoke.py
- python3 -m py_compile loopx/capabilities/auto_research/cli.py loopx/capabilities/auto_research/core.py loopx/capabilities/auto_research/demo_e2e.py
- git diff --check origin/main...HEAD
- python3 -m loopx.cli check --scan-path loopx/capabilities/auto_research/cli.py --scan-path loopx/capabilities/auto_research/core.py --scan-path loopx/capabilities/auto_research/demo_e2e.py --scan-path examples/auto-research-demo-e2e-smoke.py --scan-path examples/auto-research-one-click-ux-smoke.py --scan-path docs/guides/auto-research-command-path.md

LoopX check reports the existing duplicate-index warning only; public boundary scan is clean.