### PR TITLE
Fix boundary scope repair candidate selection

### DIFF
--- a/examples/quota-action-scope-guard-smoke.py
+++ b/examples/quota-action-scope-guard-smoke.py
@@ -25,25 +25,28 @@ def status_payload(
     *,
     allowed_scopes: list[str],
     checkpointed_boundary_authority: list[dict] | None = None,
+    todos: list[dict] | None = None,
 ) -> dict:
-    todo = {
-        "index": 1,
-        "done": False,
-        "status": "open",
-        "text": TODO_TEXT,
-        "task_class": "advancement_task",
-        "action_kind": "implement",
-        "required_write_scopes": ["runners/openviking/**"],
-    }
+    todo_items = todos or [
+        {
+            "index": 1,
+            "done": False,
+            "status": "open",
+            "text": TODO_TEXT,
+            "task_class": "advancement_task",
+            "action_kind": "implement",
+            "required_write_scopes": ["runners/openviking/**"],
+        }
+    ]
     agent_todos = {
         "schema_version": "todo_summary_v0",
         "source_section": "Agent Todo",
-        "open_count": 1,
+        "open_count": len(todo_items),
         "done_count": 0,
-        "total_count": 1,
-        "first_open_items": [todo],
-        "first_executable_items": [todo],
-        "items": [todo],
+        "total_count": len(todo_items),
+        "first_open_items": todo_items,
+        "first_executable_items": todo_items,
+        "items": todo_items,
     }
     return {
         "ok": True,
@@ -164,6 +167,48 @@ def assert_allowed_scope_remains_runnable() -> None:
     assert payload["goal_boundary"]["write_scope"] == ["runners/**", "docs/**"], payload
 
 
+def assert_blocked_candidate_does_not_trigger_boundary_repair() -> None:
+    blocked_auto_research = {
+        "index": 1,
+        "done": False,
+        "status": "open",
+        "text": "Validate auto-research live evidence after the capability exists.",
+        "task_class": "advancement_task",
+        "action_kind": "validate_auto_research_live_bootstrap_hypothesis",
+        "required_capabilities": ["auto_research_frontier"],
+        "required_write_scopes": ["successor_todos", "grounding_refs"],
+    }
+    runnable_skillsbench = {
+        "index": 2,
+        "done": False,
+        "status": "open",
+        "text": "Rerun the SkillsBench reverse-tunnel app-server Goal batch.",
+        "task_class": "advancement_task",
+        "action_kind": "skillsbench_reverse_tunnel_batch_continuation",
+        "required_write_scopes": ["scripts/**", "docs/**", "examples/**"],
+        "target_capabilities": ["skillsbench_reverse_tunnel_batch"],
+    }
+    payload = build_quota_should_run(
+        status_payload(
+            allowed_scopes=["scripts/**", "docs/**", "examples/**"],
+            todos=[blocked_auto_research, runnable_skillsbench],
+        ),
+        goal_id=GOAL_ID,
+    )
+    assert payload["should_run"] is True, payload
+    assert payload["normal_delivery_allowed"] is True, payload
+    assert payload["effective_action"] == "normal_run", payload
+    assert "boundary_projection_gap" not in payload, payload
+    gate = payload["capability_gate"]
+    assert gate["action"] == "run", gate
+    assert gate["blocked_candidates"][0]["action_kind"] == (
+        "validate_auto_research_live_bootstrap_hypothesis"
+    ), gate
+    assert gate["runnable_candidates"][0]["action_kind"] == (
+        "skillsbench_reverse_tunnel_batch_continuation"
+    ), gate
+
+
 def assert_checkpointed_authority_compiles_into_goal_boundary() -> None:
     authority = build_checkpointed_boundary_authority_entry(
         write_scopes=["runners/**"],
@@ -217,6 +262,7 @@ def main() -> int:
     assert_required_write_scope_metadata_roundtrip()
     assert_missing_scope_repairs_boundary()
     assert_allowed_scope_remains_runnable()
+    assert_blocked_candidate_does_not_trigger_boundary_repair()
     assert_checkpointed_authority_compiles_into_goal_boundary()
     assert_expired_checkpointed_authority_does_not_authorize_write()
     print("quota-action-scope-guard-smoke ok")

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -5555,14 +5555,24 @@ def _boundary_projection_repair_hint(
     agent_todo_summary: dict[str, Any] | None,
     *,
     candidate_should_run: bool,
+    capability_gate: dict[str, Any] | None = None,
 ) -> dict[str, Any] | None:
     if not candidate_should_run or not isinstance(agent_todo_summary, dict):
         return None
     candidate_items: list[dict[str, Any]] = []
-    for key in ("first_executable_items", "first_open_items"):
-        value = agent_todo_summary.get(key)
-        if isinstance(value, list):
-            candidate_items.extend(item for item in value if isinstance(item, dict))
+    if isinstance(capability_gate, dict):
+        if capability_gate.get("action") != "run":
+            return None
+        runnable_candidates = capability_gate.get("runnable_candidates")
+        if isinstance(runnable_candidates, list) and runnable_candidates:
+            candidate_items.extend(
+                item for item in runnable_candidates if isinstance(item, dict)
+            )
+    if not candidate_items:
+        for key in ("first_executable_items", "first_open_items"):
+            value = agent_todo_summary.get(key)
+            if isinstance(value, list):
+                candidate_items.extend(item for item in value if isinstance(item, dict))
     selected: dict[str, Any] | None = None
     for item in candidate_items:
         if not _todo_item_is_actionable_open(item):
@@ -6579,6 +6589,7 @@ def build_quota_should_run(
             candidate_should_run=bool(
                 normal_delivery_allowed or recovery_allowed or self_repair_allowed
             ),
+            capability_gate=capability_gate,
         )
         if boundary_projection_repair:
             stall_self_repair = boundary_projection_repair


### PR DESCRIPTION
## Summary
- Make boundary projection repair check capability-gate runnable candidates when capability routing is available.
- Avoid letting blocked/out-of-capability todos trigger `boundary_projection_repair` ahead of a runnable selected todo.
- Add a quota action-scope smoke covering a blocked auto-research todo before a runnable SkillsBench todo.

## Root Cause
`quota should-run` computed a capability gate that correctly selected the runnable SkillsBench todo, but `_boundary_projection_repair_hint` independently scanned `agent_todo_summary.first_executable_items`. That list still included an earlier blocked auto-research todo with required write scopes like `successor_todos` / `grounding_refs`. The boundary repair hint therefore overrode the runnable candidate and projected a false `boundary_projection_repair`.

## Validation
- `python3 examples/quota-action-scope-guard-smoke.py`
- `python3 -m py_compile loopx/quota.py examples/quota-action-scope-guard-smoke.py`
- `git diff --check`
- `python3 -m loopx.cli --format json --registry "$HOME/.codex/loopx/registry.global.json" quota should-run --goal-id loopx-meta --agent-id codex-main-control | jq '{decision,effective_action,normal_delivery_allowed,boundary_projection_gap,agent_lane_next_action:{todo_id:.agent_lane_next_action.todo_id,action_kind:.agent_lane_next_action.action_kind}}'`
- `loopx check --scan-path loopx/quota.py --scan-path examples/quota-action-scope-guard-smoke.py`
