### PR TITLE
Add auto research demo canary profile

### DIFF
--- a/examples/auto-research-demo-supervisor-smoke.py
+++ b/examples/auto-research-demo-supervisor-smoke.py
@@ -104,7 +104,9 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
         assert "quota should-run" in lane["quota_guard"], lane
         assert f"--agent-id {lane['agent_id']}" in lane["quota_guard"], lane
         assert "auto-research frontier" in lane["frontier"], lane
-        assert "codex-cli-bootstrap-message" in lane["bootstrap_message"], lane
+        assert "You are a visible LoopX auto-research lane" in lane["bootstrap_message"], lane
+        assert "Do not run loopx bootstrap-command-pack" in lane["bootstrap_message"], lane
+        assert "codex-cli-bootstrap-message" not in lane["bootstrap_message"], lane
         assert "[LoopX role profile]" in lane["visible_launch_command"], lane
         assert "[LoopX visible acceptance]" in lane["visible_launch_command"], lane
         assert "LOOPX_VISIBLE_BOOTSTRAP_PAUSE_SECONDS" in lane["visible_launch_command"], lane
@@ -128,7 +130,9 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
     assert "tmux new-session" in start_script, start_script
     assert "tmux new-window" in start_script, start_script
     assert "LOOPX_PROJECT" in start_script, start_script
-    assert "codex-cli-bootstrap-message" in start_script, start_script
+    assert "[Codex bootstrap prompt]" in start_script, start_script
+    assert "You are a visible LoopX auto-research lane" in start_script, start_script
+    assert "codex-cli-bootstrap-message" not in start_script, start_script
     assert "auto-research frontier" in start_script, start_script
     assert payload["commands"]["attach"] == "tmux attach -t loopx-auto-research", payload
 

--- a/examples/auto-research-visible-launcher-smoke.py
+++ b/examples/auto-research-visible-launcher-smoke.py
@@ -190,7 +190,9 @@ def main() -> int:
             assert "LOOPX_REQUIRED_SKILL" in command, command
             assert "quota should-run" in command, command
             assert "auto-research frontier" in command, command
-            assert "codex-cli-bootstrap-message" in command, command
+            assert "[Codex bootstrap prompt]" in command, command
+            assert "You are a visible LoopX auto-research lane" in command, command
+            assert "codex-cli-bootstrap-message" not in command, command
             assert "bootstrap-or-stop" in command, command
             assert "[LoopX visible acceptance]" in command, command
             assert "reasoning_effort=high" in command, command

--- a/examples/catalog-canary-planner-smoke.py
+++ b/examples/catalog-canary-planner-smoke.py
@@ -50,6 +50,7 @@ def assert_profiles_come_from_catalog_matrix() -> None:
         "monitor-scheduler",
         "state-write-correctness",
         "frontstage-rollout",
+        "auto-research-demo",
         "benchmark-adapter-readiness",
     } <= domain_profile_ids, payload
 
@@ -164,6 +165,23 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     assert "python3 examples/todo-lifecycle-cli-smoke.py" in todo_commands, todo_profile
     assert all(check["tier"] == "default" for check in todo_profile["checks"]), todo_profile
     assert todo_profile["deep_checks_available"] is True, todo_profile
+
+    auto_research_payload = build_catalog_canary_plan(
+        changed_files=["loopx/capabilities/auto_research/core.py"],
+        surfaces=["auto-research demo frontier visible launcher"],
+    )
+    auto_research_profiles = {
+        profile["id"]: profile for profile in auto_research_payload["domain_profiles"]
+    }
+    assert "auto-research-demo" in auto_research_profiles, auto_research_payload
+    auto_research_profile = auto_research_profiles["auto-research-demo"]
+    auto_research_commands = [check["command"] for check in auto_research_profile["checks"]]
+    assert "python3 examples/auto-research-demo-e2e-smoke.py" in auto_research_commands, auto_research_profile
+    assert (
+        "python3 examples/decentralized-auto-research-frontier-smoke.py" in auto_research_commands
+    ), auto_research_profile
+    assert all(check["tier"] == "default" for check in auto_research_profile["checks"]), auto_research_profile
+    assert auto_research_profile["deep_checks_available"] is True, auto_research_profile
 
 
 def assert_explicit_profile_can_include_deep_checks() -> None:

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -489,6 +489,68 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
         ],
     },
     {
+        "id": "auto-research-demo",
+        "title": "Auto-research demo and frontier route",
+        "purpose": (
+            "Check visible auto-research demo routing, deterministic E2E replay, "
+            "and shared frontier projection without launching real Codex lanes by default."
+        ),
+        "catalog_families": ["Work Routing", "Evidence Lifecycle", "State And Boundary", "Human Decision"],
+        "trigger_hints": (
+            "auto-research",
+            "auto research",
+            "demo-supervisor",
+            "demo e2e",
+            "frontier",
+            "visible launcher",
+            "one-click",
+            "loopx/capabilities/auto_research",
+            "loopx/cli_commands/auto_research",
+        ),
+        "checks": [
+            {
+                "command": "python3 examples/auto-research-demo-e2e-smoke.py",
+                "tier": "default",
+                "reason": "checks the deterministic positive demo route, route contract, and no-live-claim boundary",
+            },
+            {
+                "command": "python3 examples/auto-research-one-click-ux-smoke.py",
+                "tier": "default",
+                "reason": "checks the one-command visible UX packet with fake tmux/Codex binaries",
+            },
+            {
+                "command": "python3 examples/decentralized-auto-research-frontier-smoke.py",
+                "tier": "default",
+                "reason": "checks shared frontier, evidence graph, board projection, and public boundary fixtures",
+            },
+            {
+                "command": "python3 examples/auto-research-demo-supervisor-smoke.py",
+                "tier": "deep",
+                "reason": "samples the full dry-run supervisor packet and lane bootstrap contract",
+            },
+            {
+                "command": "python3 examples/auto-research-visible-launcher-smoke.py",
+                "tier": "deep",
+                "reason": "runs the fake visible launcher acceptance path without starting real Codex work",
+            },
+            {
+                "command": "python3 examples/auto-research-rollout-readpath-smoke.py",
+                "tier": "deep",
+                "reason": "checks rollout event read-path projection into live evidence graphs",
+            },
+            {
+                "command": "python3 examples/auto-research-live-codex-claim-boundary-smoke.py",
+                "tier": "deep",
+                "reason": "guards that live E2E claims require lane-authored public evidence",
+            },
+            {
+                "command": "python3 examples/auto-research-live-evidence-capture-smoke.py",
+                "tier": "deep",
+                "reason": "checks compact live evidence capture fixtures for visible lanes",
+            },
+        ],
+    },
+    {
         "id": "benchmark-adapter-readiness",
         "title": "Benchmark adapter readiness",
         "purpose": "Check public adapter contracts and evidence boundaries without launching benchmark jobs by default.",


### PR DESCRIPTION
## Summary

- Add an `auto-research-demo` catalog canary profile for the visible auto-research demo, deterministic demo E2E replay, shared frontier projection, and deeper live-evidence boundary fixtures.
- Repair stale auto-research demo smoke assertions after the newer route stopped using the generic `codex-cli-bootstrap-message` helper and now prints a role-scoped bootstrap prompt directly.
- Extend the catalog canary planner smoke so changed auto-research surfaces select the new profile and default checks stay no-write/default-tier.

## Motivation / Product Judgment

PR #952 split the auto-research demo frontier into a more explicit route, but catalog canary planning still did not know that product entry. During validation, the visible-launcher and supervisor smokes exposed a stale fixture expectation for the old generic bootstrap command. The new contract is more product-correct: visible lanes get a role-scoped prompt that tells them to read the printed quota/frontier and avoid generic onboarding. This PR keeps that contract and updates the durable tests around it.

## Validation

- `python3 examples/auto-research-demo-supervisor-smoke.py`
- `python3 examples/auto-research-visible-launcher-smoke.py`
- `python3 examples/auto-research-demo-e2e-smoke.py`
- `python3 examples/auto-research-one-click-ux-smoke.py`
- `python3 examples/decentralized-auto-research-frontier-smoke.py`
- `python3 examples/catalog-canary-planner-smoke.py`
- `python3 -m loopx.cli --format json canary plan --changed-file loopx/capabilities/auto_research/core.py --surface 'auto-research demo frontier visible launcher'`
- `python3 -m loopx.cli --format json canary run --profile auto-research-demo --check-limit 3`
- `python3 -m loopx.cli --format json canary run --profile auto-research-demo --include-deep-checks --max-checks-per-profile 8 --check-limit 8`
- `python3 -m py_compile loopx/canary/planner.py examples/catalog-canary-planner-smoke.py examples/auto-research-demo-supervisor-smoke.py examples/auto-research-visible-launcher-smoke.py`
- `git diff --check`
- `python3 -m loopx.cli check --scan-path loopx/canary/planner.py --scan-path examples/catalog-canary-planner-smoke.py --scan-path examples/auto-research-demo-supervisor-smoke.py --scan-path examples/auto-research-visible-launcher-smoke.py`
- `python3 -m loopx.cli --format json canary coverage-audit`

`loopx check` reports the existing loopx-meta duplicate index row warning; public boundary scan for touched files is clean.

## Boundary

No real Codex lanes, external connectors, benchmark jobs, credentials, raw logs, private artifacts, or runtime evidence writes are introduced. The canary runner remains no-write and executes repository-local example smokes only.
