### PR TITLE
Add review-packet catalog canary profile

### DIFF
--- a/examples/catalog-canary-planner-smoke.py
+++ b/examples/catalog-canary-planner-smoke.py
@@ -45,6 +45,7 @@ def assert_profiles_come_from_catalog_matrix() -> None:
         "install-update",
         "control-plane-refactor",
         "status-read-path",
+        "review-packet-read-path",
         "cli-command-contract",
         "todo-lifecycle",
         "monitor-scheduler",
@@ -143,6 +144,22 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     status_commands = [check["command"] for check in status_profiles["status-read-path"]["checks"]]
     assert "python3 examples/status-goal-filter-smoke.py" in status_commands, status_payload
     assert all(check["tier"] == "default" for check in status_profiles["status-read-path"]["checks"]), status_payload
+
+    review_packet_payload = build_catalog_canary_plan(
+        changed_files=["loopx/review_packet.py", "loopx/cli_commands/status.py"],
+        surfaces=["review-packet handoff-only operator packet read-path"],
+    )
+    review_packet_profiles = {
+        profile["id"]: profile for profile in review_packet_payload["domain_profiles"]
+    }
+    assert "review-packet-read-path" in review_packet_profiles, review_packet_payload
+    review_packet_profile = review_packet_profiles["review-packet-read-path"]
+    review_packet_commands = [check["command"] for check in review_packet_profile["checks"]]
+    assert "python3 examples/review-packet-cli-smoke.py" in review_packet_commands, review_packet_profile
+    assert "python3 examples/review-packet-smoke.py" in review_packet_commands, review_packet_profile
+    assert all(check["tier"] == "default" for check in review_packet_profile["checks"]), review_packet_profile
+    assert review_packet_profile["deep_checks_available"] is True, review_packet_profile
+    assert review_packet_profile["deep_checks_included"] is False, review_packet_profile
 
     cli_payload = build_catalog_canary_plan(
         changed_files=["loopx/cli.py", "loopx/cli_commands/version.py"],

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -342,6 +342,49 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
         ],
     },
     {
+        "id": "review-packet-read-path",
+        "title": "Review-packet read-path contract",
+        "purpose": "Check operator review packets, handoff-only payloads, and task-graph lineage before review-packet/read-path changes ship.",
+        "catalog_families": ["Work Routing", "Human Decision", "State And Boundary"],
+        "trigger_hints": (
+            "review-packet",
+            "review packet",
+            "handoff-only",
+            "project-agent handoff",
+            "operator packet",
+            "loopx/review_packet.py",
+            "loopx/cli_commands/status",
+            "docs/status-data-contract.md",
+        ),
+        "checks": [
+            {
+                "command": "python3 examples/review-packet-cli-smoke.py",
+                "tier": "default",
+                "reason": "guards CLI-visible review-packet and handoff-only JSON contracts",
+            },
+            {
+                "command": "python3 examples/review-packet-smoke.py",
+                "tier": "default",
+                "reason": "checks dashboard/operator packet copy and public-safe handoff text",
+            },
+            {
+                "command": "python3 examples/task-graph-projection-fixture-smoke.py",
+                "tier": "default",
+                "reason": "guards task-graph lineage consumed by review packets without private sources",
+            },
+            {
+                "command": "python3 examples/control-plane-integrated-canary-smoke.py",
+                "tier": "deep",
+                "reason": "samples the bounded status -> quota -> review-packet event read path",
+            },
+            {
+                "command": "python3 examples/hot-path-interface-budget-smoke.py",
+                "tier": "deep",
+                "reason": "checks review-packet handoff interface budgets after hot-path changes",
+            },
+        ],
+    },
+    {
         "id": "cli-command-contract",
         "title": "CLI command module contract",
         "purpose": "Check command-module boundaries, ownership budgets, and compatibility for LoopX CLI refactors.",


### PR DESCRIPTION
## Summary
- add a `review-packet-read-path` domain profile to catalog canary planning
- map existing review-packet, handoff-only, task-graph, integrated read-path, and interface-budget smokes into default/deep tiers
- extend the planner smoke so review-packet surfaces select the new profile

## Motivation
Review-packet/read-path changes already had reusable public smokes, but catalog canary planning did not surface them as a named domain profile. This makes the next review-packet or handoff-only change discover the right default and deep checks directly from `loopx canary plan/run`.

## Validation
- `python3 examples/catalog-canary-planner-smoke.py`
- `python3 examples/review-packet-cli-smoke.py && python3 examples/review-packet-smoke.py && python3 examples/task-graph-projection-fixture-smoke.py`
- `python3 -m loopx.cli --format json canary plan --changed-file loopx/review_packet.py --changed-file loopx/cli_commands/status.py --surface "review-packet handoff-only operator packet read-path"`
- `python3 -m loopx.cli --format json canary run --profile review-packet-read-path --check-limit 3`
- `python3 -m loopx.cli --format json canary run --profile review-packet-read-path --include-deep-checks --max-checks-per-profile 5 --check-limit 5`
- `python3 -m py_compile loopx/canary/planner.py examples/catalog-canary-planner-smoke.py`
- `git diff --check`
- `python3 -m loopx.cli check --scan-path loopx/canary/planner.py --scan-path examples/catalog-canary-planner-smoke.py` (clean candidate scan; existing duplicate run-history index warning only)
- `python3 -m loopx.cli --format json canary coverage-audit`

## Boundary
- public planner/smoke files only
- no runtime behavior change
- no private state, generated logs, credentials, raw benchmark artifacts, or local evidence included

## Risk
Low. This only registers an existing-smoke profile and planner assertion; default runs stay fixture-level, deep checks remain opt-in.
