### PR TITLE
Add event-sourced read-path canary profile

### DIFF
--- a/examples/catalog-canary-planner-smoke.py
+++ b/examples/catalog-canary-planner-smoke.py
@@ -46,6 +46,7 @@ def assert_profiles_come_from_catalog_matrix() -> None:
         "control-plane-refactor",
         "status-read-path",
         "review-packet-read-path",
+        "event-sourced-read-path",
         "cli-command-contract",
         "todo-lifecycle",
         "monitor-scheduler",
@@ -160,6 +161,23 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     assert all(check["tier"] == "default" for check in review_packet_profile["checks"]), review_packet_profile
     assert review_packet_profile["deep_checks_available"] is True, review_packet_profile
     assert review_packet_profile["deep_checks_included"] is False, review_packet_profile
+
+    event_read_payload = build_catalog_canary_plan(
+        changed_files=["loopx/event_sourced_state.py", "loopx/rollout_event_log.py"],
+        surfaces=["event projection downstream read event-store read-path"],
+    )
+    event_read_profiles = {
+        profile["id"]: profile for profile in event_read_payload["domain_profiles"]
+    }
+    assert "event-sourced-read-path" in event_read_profiles, event_read_payload
+    event_read_profile = event_read_profiles["event-sourced-read-path"]
+    event_read_commands = [check["command"] for check in event_read_profile["checks"]]
+    assert "python3 examples/event-sourced-state-api-smoke.py" in event_read_commands, event_read_profile
+    assert "python3 examples/event-sourced-status-read-path-smoke.py" in event_read_commands, event_read_profile
+    assert "python3 examples/event-sourced-downstream-read-path-smoke.py" in event_read_commands, event_read_profile
+    assert all(check["tier"] == "default" for check in event_read_profile["checks"]), event_read_profile
+    assert event_read_profile["deep_checks_available"] is True, event_read_profile
+    assert event_read_profile["deep_checks_included"] is False, event_read_profile
 
     cli_payload = build_catalog_canary_plan(
         changed_files=["loopx/cli.py", "loopx/cli_commands/version.py"],

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -385,6 +385,51 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
         ],
     },
     {
+        "id": "event-sourced-read-path",
+        "title": "Event-sourced read-path contract",
+        "purpose": "Check event projection, status read path, downstream read surfaces, and migration gates before event-store/read-path changes ship.",
+        "catalog_families": ["Work Routing", "State And Boundary", "Planning Governance"],
+        "trigger_hints": (
+            "event-sourced",
+            "event sourced",
+            "event projection",
+            "event read-path",
+            "downstream read",
+            "event-store",
+            "event store",
+            "loopx/event_sourced_state.py",
+            "loopx/rollout_event_log.py",
+            "docs/reference/protocols/event-store-migration-bridge-v0.md",
+        ),
+        "checks": [
+            {
+                "command": "python3 examples/event-sourced-state-api-smoke.py",
+                "tier": "default",
+                "reason": "guards event append/replay API behavior used by read-path projections",
+            },
+            {
+                "command": "python3 examples/event-sourced-status-read-path-smoke.py",
+                "tier": "default",
+                "reason": "checks status consumption of event projection with Markdown fallback",
+            },
+            {
+                "command": "python3 examples/event-sourced-downstream-read-path-smoke.py",
+                "tier": "default",
+                "reason": "checks downstream read surfaces consume event projection without private state",
+            },
+            {
+                "command": "python3 examples/event-store-migration-bridge-smoke.py",
+                "tier": "deep",
+                "reason": "samples the migration bridge gates before bounded event read-path canaries",
+            },
+            {
+                "command": "python3 examples/event-sourced-replay-compaction-smoke.py",
+                "tier": "deep",
+                "reason": "checks replay compaction when broader event-store changes are promoted",
+            },
+        ],
+    },
+    {
         "id": "cli-command-contract",
         "title": "CLI command module contract",
         "purpose": "Check command-module boundaries, ownership budgets, and compatibility for LoopX CLI refactors.",


### PR DESCRIPTION
## Summary
- Adds an event-sourced-read-path catalog canary profile for event projection, status read path, downstream read surfaces, and event-store migration gates.
- Reuses existing public fixture smokes as default/deep checks instead of introducing new raw evidence or benchmark execution.
- Extends the planner smoke so changed event projection/downstream read surfaces select this profile.

## Motivation
The catalog-to-canary chain already covers status and review-packet read paths, but event-sourced downstream read-path work still required manual smoke selection. This makes the event projection/read-path bundle directly discoverable through loopx canary plan/run, matching the product-capability lane's responsibility for non-benchmark canary coverage.

## Validation
- python3 examples/catalog-canary-planner-smoke.py
- python3 examples/event-sourced-state-api-smoke.py && python3 examples/event-sourced-status-read-path-smoke.py && python3 examples/event-sourced-downstream-read-path-smoke.py
- python3 -m loopx.cli --format json canary run --profile event-sourced-read-path --check-limit 3
- python3 -m loopx.cli --format json canary plan --changed-file loopx/event_sourced_state.py --changed-file loopx/rollout_event_log.py --surface "event projection downstream read event-store read-path" --max-checks-per-profile 3
- python3 -m loopx.cli --format json canary run --profile event-sourced-read-path --include-deep-checks --max-checks-per-profile 5 --check-limit 5
- python3 -m py_compile loopx/canary/planner.py examples/catalog-canary-planner-smoke.py && git diff --check && python3 -m loopx.cli canary coverage-audit
- python3 -m loopx.cli check --scan-path loopx/canary/planner.py --scan-path examples/catalog-canary-planner-smoke.py

## Boundary
Small catalog/profile addition plus focused planner smoke. Public/private scan is clean for touched files; the only LoopX check warning is the existing duplicate run-index row warning. No benchmark jobs, no private material, no promotion evidence, and no production action.