### PR TITLE
Fix scoped diagnose quota projection

### DIFF
--- a/examples/agent-diagnose-packet-smoke.py
+++ b/examples/agent-diagnose-packet-smoke.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 GOAL_ID = "diagnose-smoke-goal"
+SCOPED_GOAL_ID = "diagnose-smoke-agent-scoped"
 
 
 def run_cli(*args: str, cwd: Path = REPO_ROOT) -> dict:
@@ -61,6 +62,79 @@ def bootstrap_project(project: Path, runtime: Path, goal_id: str, *, onboarding:
     if not onboarding:
         args.append("--no-onboarding-scan")
     return run_cli(*args)
+
+
+def write_agent_scoped_registry(root: Path, runtime: Path) -> Path:
+    project = write_project(root, "agent-scoped-project")
+    state_file = f".codex/goals/{SCOPED_GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    state_path = project / state_file
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        "---\n"
+        "status: active\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Agent-Scoped Diagnose Fixture\n\n"
+        "## User Todo\n\n"
+        "- [ ] [P0 user gate] Review the scoped projection repair PR before merge.\n"
+        "  <!-- loopx:todo todo_id=todo_user_gate_scoped status=open "
+        "task_class=user_gate action_kind=review_pr priority=P0 "
+        "blocks_agent=codex-main-control -->\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] [P1] Continue only safe fallback work after the scoped gate is projected.\n"
+        "  <!-- loopx:todo todo_id=todo_agent_fallback status=open "
+        "task_class=advancement_task action_kind=diagnose_projection "
+        "claimed_by=codex-main-control priority=P1 -->\n",
+        encoding="utf-8",
+    )
+    registry = project / ".loopx" / "registry.json"
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    registry.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": SCOPED_GOAL_ID,
+                        "domain": "agent-diagnose-fixture",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": state_file,
+                        "adapter": {
+                            "kind": "fixture_connected_delivery_v0",
+                            "status": "connected-delivery",
+                        },
+                        "quota": {
+                            "compute": 1.0,
+                            "window_hours": 24,
+                        },
+                        "coordination": {
+                            "primary_agent": "codex-main-control",
+                            "registered_agents": ["codex-main-control", "codex-side-observer"],
+                            "agent_profiles": {
+                                "codex-main-control": {
+                                    "role": "primary-agent",
+                                    "scope": "review, merge, final closeout",
+                                },
+                                "codex-side-observer": {
+                                    "role": "side-agent",
+                                    "scope": "read-only observation",
+                                },
+                            },
+                            "write_scope": ["docs/**"],
+                        },
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry
 
 
 def main() -> int:
@@ -117,6 +191,35 @@ def main() -> int:
         assert gated_selected["todo_evidence"]["user_open_count"] == 1, gated_selected
         assert "autonomous=yes/no" in str(gated_selected["user_question"]), gated_selected
         assert "can_self_drive" not in gated_selected, gated_selected
+
+        scoped_registry = write_agent_scoped_registry(root, runtime)
+        scoped_packet = run_cli(
+            "--registry",
+            str(scoped_registry),
+            "--runtime-root",
+            str(runtime),
+            "diagnose",
+            "--goal-id",
+            SCOPED_GOAL_ID,
+            "--agent-id",
+            "codex-main-control",
+        )
+        scoped_selected = scoped_packet["selected"]
+        assert scoped_packet["agent_id"] == "codex-main-control", scoped_packet
+        assert scoped_selected["agent_id"] == "codex-main-control", scoped_selected
+        assert scoped_selected["machine_signal"] == "user_or_controller_attention", scoped_selected
+        assert scoped_selected["todo_evidence"]["user_open_count"] == 1, scoped_selected
+        assert "Review the scoped projection repair PR" in str(scoped_selected), scoped_selected
+        assert "Regenerate the installed heartbeat automation prompt" not in str(scoped_selected), (
+            scoped_selected
+        )
+        assert (
+            scoped_selected["quota_signals"]["agent_identity"]["agent_id"]
+            == "codex-main-control"
+        ), scoped_selected
+        assert any("--agent-id codex-main-control" in command for command in scoped_selected["agent_commands"]), (
+            scoped_selected
+        )
 
     print("agent-diagnose-packet-smoke ok")
     return 0

--- a/examples/status-neutral-run-window-smoke.py
+++ b/examples/status-neutral-run-window-smoke.py
@@ -13,7 +13,12 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.diagnose import collect_diagnosis  # noqa: E402
-from loopx.quota import QUOTA_MONITOR_POLL_CLASSIFICATION, build_quota_should_run  # noqa: E402
+from loopx.quota import (  # noqa: E402
+    QUOTA_MONITOR_POLL_CLASSIFICATION,
+    QUOTA_SLOT_SPENT_CLASSIFICATION,
+    QUOTA_SLOT_VOIDED_CLASSIFICATION,
+    build_quota_should_run,
+)
 from loopx.status import collect_status  # noqa: E402
 
 
@@ -129,6 +134,18 @@ def write_runs(root: Path) -> None:
             classification=QUOTA_MONITOR_POLL_CLASSIFICATION,
             action="monitor poll only; no status transition",
         )
+    append_run(
+        root,
+        generated_at="2026-01-01T00:07:00+00:00",
+        classification=QUOTA_SLOT_SPENT_CLASSIFICATION,
+        action="quota accounting only; no status transition",
+    )
+    append_run(
+        root,
+        generated_at="2026-01-01T00:08:00+00:00",
+        classification=QUOTA_SLOT_VOIDED_CLASSIFICATION,
+        action="quota void accounting only; no status transition",
+    )
 
 
 def main() -> int:
@@ -165,10 +182,10 @@ def main() -> int:
         run_goal = status["run_history"]["goals"][0]
         assert run_goal["latest_status_run"]["classification"] == REAL_CLASSIFICATION, run_goal
         assert len(run_goal["latest_runs"]) == 5, run_goal
-        assert {
-            run["classification"]
-            for run in run_goal["latest_runs"]
-        } == {QUOTA_MONITOR_POLL_CLASSIFICATION}, run_goal
+        latest_classifications = {run["classification"] for run in run_goal["latest_runs"]}
+        assert QUOTA_MONITOR_POLL_CLASSIFICATION in latest_classifications, run_goal
+        assert QUOTA_SLOT_SPENT_CLASSIFICATION in latest_classifications, run_goal
+        assert QUOTA_SLOT_VOIDED_CLASSIFICATION in latest_classifications, run_goal
 
         readiness = item["handoff_readiness"]
         assert readiness["post_handoff_latest_run"]["classification"] == REAL_CLASSIFICATION, readiness

--- a/loopx/cli_commands/status.py
+++ b/loopx/cli_commands/status.py
@@ -89,6 +89,13 @@ def register_status_commands(
     add_subcommand_format(diagnose_parser)
     diagnose_parser.add_argument("--goal-id", help="Goal id to diagnose. Defaults to the first attention item.")
     diagnose_parser.add_argument(
+        "--agent-id",
+        help=(
+            "Registered agent id for identity-scoped quota/todo projection. "
+            "Use this for multi-agent goals and heartbeat-driven diagnosis."
+        ),
+    )
+    diagnose_parser.add_argument(
         "--scan-root",
         default=default_public_scan_root(),
         help="Public files to scan for obvious private material. Defaults to the LoopX install root.",
@@ -502,6 +509,7 @@ def handle_diagnose_command(
             scan_roots=_scan_roots(args),
             limit=max(1, args.limit),
             goal_id=args.goal_id,
+            agent_id=args.agent_id,
         )
     except Exception as exc:
         payload = {

--- a/loopx/diagnose.py
+++ b/loopx/diagnose.py
@@ -88,13 +88,14 @@ def _goal_ids_for_packet(status_payload: dict[str, Any], *, goal_id: str | None,
     return ids
 
 
-def _quota_for_goal(status_payload: dict[str, Any], goal_id: str) -> dict[str, Any]:
+def _quota_for_goal(status_payload: dict[str, Any], goal_id: str, *, agent_id: str | None) -> dict[str, Any]:
     try:
-        return build_quota_should_run(status_payload, goal_id=goal_id)
+        return build_quota_should_run(status_payload, goal_id=goal_id, agent_id=agent_id)
     except Exception as exc:  # noqa: BLE001 - diagnosis packets should preserve compact failure context.
         return {
             "ok": False,
             "goal_id": goal_id,
+            "agent_id": agent_id,
             "error": str(exc),
             "should_run": False,
             "state": "diagnosis_quota_failed",
@@ -148,21 +149,32 @@ def _first_user_question(quota: dict[str, Any], item: dict[str, Any]) -> str | N
     return _first_text(_todo_summary(quota, item, role="user"))
 
 
-def _agent_commands(*, goal_id: str | None, registry_path: Path, scan_roots: list[Path], limit: int) -> list[str]:
+def _agent_commands(
+    *,
+    goal_id: str | None,
+    registry_path: Path,
+    scan_roots: list[Path],
+    limit: int,
+    agent_id: str | None,
+) -> list[str]:
     registry_arg = shlex.quote(str(registry_path))
     scan_args = " ".join(f"--scan-path {shlex.quote(str(path))}" for path in scan_roots)
     diagnose = f"loopx --registry {registry_arg} diagnose"
     status = f"loopx --registry {registry_arg} status"
+    agent_arg = f" --agent-id {shlex.quote(agent_id)}" if agent_id else ""
     if scan_args:
         diagnose = f"{diagnose} {scan_args}"
         status = f"{status} {scan_args}"
     commands = [
-        f"{diagnose} --limit {max(1, limit)}",
-        f"{status} --limit {max(1, limit)}",
+        f"{diagnose}{agent_arg} --limit {max(1, limit)}",
+        f"{status}{agent_arg} --limit {max(1, limit)}",
     ]
     if goal_id:
         quoted_goal = shlex.quote(goal_id)
-        commands.append(f"loopx --registry {registry_arg} --format json quota should-run --goal-id {quoted_goal}")
+        commands.append(
+            f"loopx --registry {registry_arg} --format json quota should-run "
+            f"--goal-id {quoted_goal}{agent_arg}"
+        )
         commands.append(f"loopx --registry {registry_arg} history --goal-id {quoted_goal} --limit {max(1, limit)}")
     return commands
 
@@ -183,6 +195,10 @@ def _compact_quota_signals(quota: dict[str, Any]) -> dict[str, Any]:
         "requires_user_action",
         "recommended_action",
         "reason",
+        "agent_identity",
+        "agent_lane_next_action",
+        "agent_scoped_user_gate_override",
+        "agent_scope_frontier",
     )
     return {key: quota.get(key) for key in keys if key in quota}
 
@@ -195,6 +211,7 @@ def _build_goal_packet(
     registry_path: Path,
     scan_roots: list[Path],
     limit: int,
+    agent_id: str | None,
 ) -> dict[str, Any]:
     goal_id = str((item or {}).get("goal_id") or quota.get("goal_id") or "")
     item = item or {}
@@ -218,6 +235,7 @@ def _build_goal_packet(
             "first_agent_todo": _first_text(agent_summary),
         },
         "quota_signals": _compact_quota_signals(quota),
+        "agent_id": agent_id,
         "interaction_contract": _as_dict(quota.get("interaction_contract")),
         "work_lane_contract": _as_dict(quota.get("work_lane_contract")),
         "goal_boundary": _as_dict(quota.get("goal_boundary")),
@@ -233,6 +251,7 @@ def _build_goal_packet(
             registry_path=registry_path,
             scan_roots=scan_roots,
             limit=limit,
+            agent_id=agent_id,
         ),
     }
 
@@ -244,6 +263,7 @@ def collect_diagnosis(
     scan_roots: list[Path],
     limit: int,
     goal_id: str | None = None,
+    agent_id: str | None = None,
 ) -> dict[str, Any]:
     limit = max(1, limit)
     registry_path = registry_path.expanduser()
@@ -262,7 +282,7 @@ def collect_diagnosis(
     goal_packets = []
     for current_goal_id in goal_ids:
         item = item_by_goal.get(current_goal_id)
-        quota = _quota_for_goal(status_payload, current_goal_id)
+        quota = _quota_for_goal(status_payload, current_goal_id, agent_id=agent_id)
         goal_packets.append(
             _build_goal_packet(
                 status_payload=status_payload,
@@ -271,6 +291,7 @@ def collect_diagnosis(
                 registry_path=registry_path,
                 scan_roots=scan_roots,
                 limit=limit,
+                agent_id=agent_id,
             )
         )
     selected_item = _select_attention_item(status_payload, goal_id=goal_id)
@@ -280,10 +301,11 @@ def collect_diagnosis(
         selected = _build_goal_packet(
             status_payload=status_payload,
             item=selected_item,
-            quota={"ok": True, "goal_id": selected_goal_id, "should_run": False},
+            quota={"ok": True, "goal_id": selected_goal_id, "agent_id": agent_id, "should_run": False},
             registry_path=registry_path,
             scan_roots=scan_roots,
             limit=limit,
+            agent_id=agent_id,
         )
     return {
         "ok": bool(status_payload.get("ok")),
@@ -293,6 +315,7 @@ def collect_diagnosis(
         "registry": str(registry_path),
         "runtime_root": status_payload.get("runtime_root"),
         "goal_id": goal_id,
+        "agent_id": agent_id,
         "selected_goal_id": selected.get("goal_id"),
         "status_ok": status_payload.get("ok"),
         "goal_count": status_payload.get("goal_count"),

--- a/loopx/history.py
+++ b/loopx/history.py
@@ -17,6 +17,7 @@ from .paths import resolve_runtime_root
 from .quota import (
     QUOTA_MONITOR_POLL_CLASSIFICATION,
     QUOTA_SLOT_SPENT_CLASSIFICATION,
+    QUOTA_SLOT_VOIDED_CLASSIFICATION,
     goal_quota_with_spend_ledger,
 )
 from .registry import read_json, registry_goals
@@ -24,6 +25,7 @@ from .registry import read_json, registry_goals
 
 STATUS_NEUTRAL_CLASSIFICATIONS = {
     QUOTA_SLOT_SPENT_CLASSIFICATION,
+    QUOTA_SLOT_VOIDED_CLASSIFICATION,
     QUOTA_MONITOR_POLL_CLASSIFICATION,
     *PROMOTION_READINESS_CLASSIFICATIONS,
 }


### PR DESCRIPTION
## Summary
- add an agent-scoped `loopx diagnose --agent-id` path so multi-agent diagnosis reuses the same scoped quota/todo projection as heartbeat `quota should-run`
- keep `quota_slot_voided` in the shared status-neutral classification set so quota accounting events do not replace the latest real status run
- add regression smokes for scoped user-gate projection and neutral quota spend/void windows

## Validation
- `python3 -m py_compile loopx/diagnose.py loopx/cli_commands/status.py loopx/history.py examples/status-neutral-run-window-smoke.py examples/agent-diagnose-packet-smoke.py`
- `python3 examples/status-neutral-run-window-smoke.py`
- `python3 examples/agent-diagnose-packet-smoke.py`
- `python3 -m loopx.cli --format json check --scan-path examples/agent-diagnose-packet-smoke.py --scan-path examples/status-neutral-run-window-smoke.py --scan-path loopx/cli_commands/status.py --scan-path loopx/diagnose.py --scan-path loopx/history.py`
- current scoped diagnose check: `loopx diagnose --goal-id loopx-meta --agent-id codex-main-control` projects `user_open_count=2` instead of the stale automation prompt upgrade