### PR TITLE
Add host command entry canary profile

### DIFF
--- a/examples/catalog-canary-planner-smoke.py
+++ b/examples/catalog-canary-planner-smoke.py
@@ -53,6 +53,7 @@ def assert_profiles_come_from_catalog_matrix() -> None:
         "state-write-correctness",
         "product-entry-workflows",
         "cross-runtime-impl-review-demo",
+        "host-command-entry",
         "frontstage-rollout",
         "auto-research-demo",
         "benchmark-adapter-readiness",
@@ -254,6 +255,28 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     assert all(check["tier"] == "default" for check in cross_runtime_profile["checks"])
     assert cross_runtime_profile["deep_checks_available"] is False, cross_runtime_profile
     assert cross_runtime_profile["deep_checks_included"] is False, cross_runtime_profile
+
+    host_command_payload = build_catalog_canary_plan(
+        changed_files=[
+            "loopx/cli_commands/slash_commands.py",
+            "docs/reference/protocols/codex-app-host-command-registry-v0.md",
+            "docs/reference/protocols/global-manager-command-v0.md",
+        ],
+        surfaces=["slash-commands /loopx-global-summary host command registry"],
+        max_checks_per_profile=3,
+    )
+    host_command_profiles = {
+        profile["id"]: profile for profile in host_command_payload["domain_profiles"]
+    }
+    assert "host-command-entry" in host_command_profiles, host_command_payload
+    host_command_profile = host_command_profiles["host-command-entry"]
+    host_command_commands = [check["command"] for check in host_command_profile["checks"]]
+    assert "python3 examples/slash-command-catalog-smoke.py" in host_command_commands
+    assert "python3 examples/codex-app-host-command-registry-smoke.py" in host_command_commands
+    assert "python3 examples/global-manager-command-protocol-smoke.py" in host_command_commands
+    assert all(check["tier"] == "default" for check in host_command_profile["checks"])
+    assert host_command_profile["deep_checks_available"] is False, host_command_profile
+    assert host_command_profile["deep_checks_included"] is False, host_command_profile
 
     auto_research_payload = build_catalog_canary_plan(
         changed_files=["loopx/capabilities/auto_research/core.py"],

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -666,6 +666,50 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
         ],
     },
     {
+        "id": "host-command-entry",
+        "title": "Host command entry and slash-command discovery",
+        "purpose": (
+            "Check slash-command discovery, Codex App host command routing, "
+            "and global manager command entry surfaces without mutating project state."
+        ),
+        "catalog_families": ["Human Decision", "Work Routing", "State And Boundary"],
+        "trigger_hints": (
+            "slash-command",
+            "slash command",
+            "slash-commands",
+            "/loopx-global-summary",
+            "/loopx-global-gates",
+            "/loopx-global-todos",
+            "/loopx-global-risks",
+            "global-manager",
+            "global manager",
+            "host command",
+            "host command registry",
+            "codex app host command",
+            "docs/reference/protocols/codex-app-host-command-registry-v0.md",
+            "docs/reference/protocols/global-manager-command-v0.md",
+            "loopx/cli_commands/slash_commands.py",
+            "loopx/cli_commands/summary_all.py",
+        ),
+        "checks": [
+            {
+                "command": "python3 examples/slash-command-catalog-smoke.py",
+                "tier": "default",
+                "reason": "guards public slash-command discovery and legacy alias visibility",
+            },
+            {
+                "command": "python3 examples/codex-app-host-command-registry-smoke.py",
+                "tier": "default",
+                "reason": "guards Codex App host command routing and fail-closed slash-command help",
+            },
+            {
+                "command": "python3 examples/global-manager-command-protocol-smoke.py",
+                "tier": "default",
+                "reason": "checks read-only global manager command protocol and aliases",
+            },
+        ],
+    },
+    {
         "id": "frontstage-rollout",
         "title": "Frontstage rollout projection",
         "purpose": "Check public frontstage/showcase projection data before visual browser smokes.",


### PR DESCRIPTION
## Summary
- add a catalog canary domain profile for slash-command discovery, Codex App host command routing, and global manager command entry surfaces
- map that profile to the existing no-write slash-command, host-command registry, and global-manager protocol smokes
- cover automatic planner selection in the catalog canary planner smoke

## Validation
- python3 examples/catalog-canary-planner-smoke.py
- python3 -m py_compile loopx/canary/planner.py examples/catalog-canary-planner-smoke.py
- python3 examples/slash-command-catalog-smoke.py && python3 examples/codex-app-host-command-registry-smoke.py && python3 examples/global-manager-command-protocol-smoke.py
- python3 -m loopx.cli --format json canary plan --changed-file loopx/cli_commands/slash_commands.py --changed-file docs/reference/protocols/codex-app-host-command-registry-v0.md --surface "slash-commands /loopx-global-summary host command registry" --max-checks-per-profile 3
- python3 -m loopx.cli --format json canary run --profile host-command-entry --check-limit 3
- python3 -m loopx.cli --format json check --scan-path loopx/canary/planner.py --scan-path examples/catalog-canary-planner-smoke.py
- git diff --check

## Boundary
- only public product canary planner code and focused smoke coverage changed
- no private state, credentials, raw logs, or benchmark material included