### PR TITLE
Fix promotion readiness canary writeback identity

### DIFF
--- a/examples/canary-promotion-no-write-contract-smoke.py
+++ b/examples/canary-promotion-no-write-contract-smoke.py
@@ -30,6 +30,9 @@ def main() -> int:
     dashboard_source = DASHBOARD_DEMO_SMOKE.read_text(encoding="utf-8")
 
     assert_contains(canary_source, "--no-write-evidence", "canary no-write flag")
+    assert_contains(canary_source, "--agent-id", "canary refresh-state agent id flag")
+    assert_contains(canary_source, "DEFAULT_READINESS_AGENT_ID", "canary default writeback agent")
+    assert_contains(canary_source, "DEFAULT_READINESS_AGENT_LANE", "canary default writeback lane")
     assert_contains(canary_source, "dashboard-demo-readiness-smoke.py", "canary dashboard demo-readiness command")
     assert_contains(canary_source, 'commands.append(("dashboard demo readiness", dashboard_command))', "canary grouped path append")
     assert_before(

--- a/examples/canary-promotion-readiness-smoke.py
+++ b/examples/canary-promotion-readiness-smoke.py
@@ -26,6 +26,8 @@ COMMON_NODE_PATHS = [
     "/usr/local/bin",
 ]
 READINESS_GOAL_ID = "loopx-meta"
+DEFAULT_READINESS_AGENT_ID = "codex-product-capability"
+DEFAULT_READINESS_AGENT_LANE = "product_capability_catalog_canary"
 READINESS_CLASSIFICATION = "canary_promotion_readiness_smoke_group"
 READINESS_RECOMMENDED_ACTION = (
     "Canary promotion-readiness smoke passed; promotion may proceed after doctor/status reports fresh evidence."
@@ -54,6 +56,22 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Run checks only; do not append the promotion-readiness evidence event.",
     )
+    parser.add_argument(
+        "--agent-id",
+        default=os.environ.get("LOOPX_AGENT_ID") or DEFAULT_READINESS_AGENT_ID,
+        help=(
+            "Registered agent id used for the readiness evidence writeback. "
+            "Defaults to LOOPX_AGENT_ID or codex-product-capability."
+        ),
+    )
+    parser.add_argument(
+        "--agent-lane",
+        default=os.environ.get("LOOPX_AGENT_LANE") or DEFAULT_READINESS_AGENT_LANE,
+        help=(
+            "Public-safe agent lane label used for the readiness evidence writeback. "
+            "Defaults to LOOPX_AGENT_LANE or product_capability_catalog_canary."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -72,25 +90,41 @@ def run_command(label: str, command: list[str], env: dict[str, str]) -> None:
     subprocess.run(command, cwd=REPO_ROOT, env=env, check=True)
 
 
-def write_readiness_evidence(env: dict[str, str]) -> None:
+def write_readiness_evidence(
+    env: dict[str, str],
+    *,
+    agent_id: str | None = None,
+    agent_lane: str | None = None,
+) -> None:
+    resolved_agent_id = (
+        agent_id or os.environ.get("LOOPX_AGENT_ID") or DEFAULT_READINESS_AGENT_ID
+    ).strip()
+    resolved_agent_lane = (
+        agent_lane or os.environ.get("LOOPX_AGENT_LANE") or DEFAULT_READINESS_AGENT_LANE
+    ).strip()
+    command = [
+        sys.executable,
+        "-m",
+        "loopx.cli",
+        "refresh-state",
+        "--goal-id",
+        READINESS_GOAL_ID,
+        "--classification",
+        READINESS_CLASSIFICATION,
+        "--recommended-action",
+        READINESS_RECOMMENDED_ACTION,
+        "--delivery-batch-scale",
+        "multi_surface",
+        "--delivery-outcome",
+        "primary_goal_outcome",
+    ]
+    if resolved_agent_id:
+        command.extend(["--agent-id", resolved_agent_id])
+    if resolved_agent_lane:
+        command.extend(["--agent-lane", resolved_agent_lane])
     run_command(
         "promotion readiness evidence writeback",
-        [
-            sys.executable,
-            "-m",
-            "loopx.cli",
-            "refresh-state",
-            "--goal-id",
-            READINESS_GOAL_ID,
-            "--classification",
-            READINESS_CLASSIFICATION,
-            "--recommended-action",
-            READINESS_RECOMMENDED_ACTION,
-            "--delivery-batch-scale",
-            "multi_surface",
-            "--delivery-outcome",
-            "primary_goal_outcome",
-        ],
+        command,
         env,
     )
 
@@ -109,7 +143,11 @@ def main() -> int:
 
     evidence_suffix = " without evidence writeback"
     if not args.no_write_evidence:
-        write_readiness_evidence(env)
+        write_readiness_evidence(
+            env,
+            agent_id=args.agent_id,
+            agent_lane=args.agent_lane,
+        )
         evidence_suffix = " with evidence writeback"
 
     suffix = " with browser smokes" if args.include_browser else " without browser smokes"

--- a/examples/canary-promotion-readiness-writeback-smoke.py
+++ b/examples/canary-promotion-readiness-writeback-smoke.py
@@ -101,6 +101,13 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path, Path]:
                         "status": "active-read-only",
                         "repo": str(project),
                         "state_file": state_file,
+                        "coordination": {
+                            "primary_agent": "codex-main-control",
+                            "registered_agents": [
+                                "codex-main-control",
+                                "codex-product-capability",
+                            ],
+                        },
                         "adapter": {
                             "kind": "harness_self_improvement",
                             "status": "connected-read-only",
@@ -167,6 +174,9 @@ def main() -> int:
         assert record["delivery_batch_scale"] == "multi_surface", record
         assert record["delivery_outcome"] == "primary_goal_outcome", record
         assert record["recommended_action"] == module.READINESS_RECOMMENDED_ACTION, record
+        assert record["progress_scope"] == "agent_lane", record
+        assert record["agent_id"] == module.DEFAULT_READINESS_AGENT_ID, record
+        assert record["agent_lane"] == module.DEFAULT_READINESS_AGENT_LANE, record
 
         json_path = Path(record["json_path"])
         markdown_path = Path(record["markdown_path"])
@@ -179,6 +189,9 @@ def main() -> int:
         assert payload["classification"] == module.READINESS_CLASSIFICATION, payload
         assert payload["delivery_batch_scale"] == "multi_surface", payload
         assert payload["delivery_outcome"] == "primary_goal_outcome", payload
+        assert payload["progress_scope"] == "agent_lane", payload
+        assert payload["agent_id"] == module.DEFAULT_READINESS_AGENT_ID, payload
+        assert payload["agent_lane"] == module.DEFAULT_READINESS_AGENT_LANE, payload
         assert payload["state"]["path"] == str(state_path), payload
 
         global_registry = runtime / "registry.global.json"


### PR DESCRIPTION
Summary
- Add an explicit agent identity and lane to canary promotion-readiness evidence writeback.
- Upgrade the isolated writeback smoke fixture to a multi-agent registry so it catches missing refresh-state agent envelopes.
- Extend the no-write contract smoke to guard the new writeback identity contract.

Validation
- python3 examples/canary-promotion-readiness-smoke.py --no-write-evidence
- python3 examples/canary-promotion-readiness-writeback-smoke.py
- python3 examples/canary-promotion-no-write-contract-smoke.py
- python3 examples/canary-promotion-readiness-smoke.py
- python3 -m loopx.cli check --scan-path examples/canary-promotion-readiness-smoke.py --scan-path examples/canary-promotion-readiness-writeback-smoke.py --scan-path examples/canary-promotion-no-write-contract-smoke.py
- python3 -m loopx.cli --format json promotion-gate