### PR TITLE
Fix resume-gated todo quota routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,6 +524,27 @@ loopx heartbeat-prompt --thin --goal-id your-project-goal
 loopx quota spend-slot --goal-id your-project-goal --slots 1 --source heartbeat --execute
 ```
 
+The `next_automatic_turn` reported by `quota plan` is only an advisory
+scheduling hint: it chooses the highest-compute eligible goal, while
+operator-gated, focus-waiting, waiting, throttled, paused, and health-blocked
+goals stay out of the eligible lane.
+
+For stalled control-plane repair, `control_plane.self_repair.enabled=true` lets
+`quota should-run` return a bounded `decision=self_repair` contract; missing
+policy defaults off. When the payload includes a `gate_prompt` or
+`operator_question`, the target heartbeat should proactively ask that concrete
+user/controller gate and do not call the turn "no new user action" while they
+remain open. Even after a bounded safe-bypass step, its report still has to
+list existing open user todos. When `notify_user_on_open_todo=true`, skip
+delivery work and quota spend for that blocker-push turn.
+
+When `should_run=false` but `safe_bypass_allowed=true`, the heartbeat may still
+do one bounded read-only steering or analysis step. See
+`docs/quota-allocation.md` for the full allocation contract. After an automatic
+turn actually spends delivery compute, append one spend event. Do not append
+spend for quiet `should_run=false` skips, preflight failures, or pure dry-run
+previews.
+
 Three rules matter in daily use:
 
 - surface concrete user gates instead of summarizing them as "waiting for

--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -202,6 +202,13 @@ Deferred todos may carry a machine-readable resume condition with
   `resume_when=pr_merged:owner/repo#532`: the deferred todo becomes a successor
   candidate after a structured rollout event records that PR merge.
 
+Open todos may also carry `resume_when` when they are visible but not yet
+executable. Until the parsed `resume_condition.satisfied` value is true, status
+and quota keep the todo out of `first_executable_items`,
+`executable_backlog_items`, `capability_gate.runnable_candidates`, and
+`agent_lane_next_action`. When `resume_ready=true`, the open todo may enter the
+normal executable lane for its claimed agent.
+
 Status and quota expose deferred todos as a visibility lane after sorted open
 todo lanes. This is a deferred gate-resume lane: it is not runnable work, and
 it is not evidence that the current agent has no todo, until an agent reopens,

--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -354,6 +354,12 @@ ordinary delivery work. Only when no ready current-agent/unclaimed deferred
 resume exists should agent-scoped quota fall through to `agent_scope_wait`,
 `reassignment_required`, or `scope_exhausted`.
 
+Open todos with `resume_when` use the same readiness signal before they enter
+ordinary execution lanes. Until `resume_ready=true`, quota must not include the
+todo in `capability_gate.runnable_candidates` or `agent_lane_next_action`; it
+may continue with a lower-priority executable fallback when the interaction
+contract allows safe scoped fallback work.
+
 For completed handoff gates, record that rationale structurally as
 `no_followup=true`; status projects the gate as `cleared_no_followup` instead
 of waking the blocked agent with `successor_replan_required`.

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -941,6 +941,10 @@ Item fields:
   `unclaimed_deferred_resume_candidates`, and
   `other_agent_deferred_resume_candidates`, where only the first two can wake
   the current side agent before an agent-scoped no-candidate wait is allowed.
+  Open todos may also carry `resume_when`; status should attach
+  `resume_condition` / `resume_ready` but keep the item out of executable
+  backlog until `resume_ready=true`. This lets agents see not-yet-unlocked
+  successors without accidentally selecting them as current work.
   Optional future fields such as `created_at`, lease TTLs, dependencies, or
   evidence links should extend this item shape rather than inventing another
   todo surface.

--- a/examples/catalog-canary-planner-smoke.py
+++ b/examples/catalog-canary-planner-smoke.py
@@ -139,6 +139,26 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     refactor_profile_ids = {profile["id"] for profile in refactor_payload["domain_profiles"]}
     assert "control-plane-refactor" in refactor_profile_ids, refactor_payload
 
+    work_lane_policy_payload = build_catalog_canary_plan(
+        changed_files=["loopx/policies/monitor_todo.py"],
+        surfaces=["resume_when resume_ready work-lane policy seam"],
+        max_checks_per_profile=3,
+    )
+    work_lane_profiles = {
+        profile["id"]: profile for profile in work_lane_policy_payload["domain_profiles"]
+    }
+    assert "control-plane-refactor" in work_lane_profiles, work_lane_policy_payload
+    work_lane_commands = [
+        check["command"] for check in work_lane_profiles["control-plane-refactor"]["checks"]
+    ]
+    assert "python3 examples/quota-resume-gated-open-todo-smoke.py" in work_lane_commands, (
+        work_lane_profiles["control-plane-refactor"]
+    )
+    assert all(
+        check["tier"] == "default"
+        for check in work_lane_profiles["control-plane-refactor"]["checks"]
+    ), work_lane_profiles["control-plane-refactor"]
+
     status_payload = build_catalog_canary_plan(
         changed_files=["loopx/status.py"],
         surfaces=["status --goal-id read-path"],

--- a/examples/catalog-canary-run-e2e-smoke.py
+++ b/examples/catalog-canary-run-e2e-smoke.py
@@ -61,6 +61,25 @@ def assert_profile_fixture_executes() -> None:
     assert result["profile_id"] == "control-plane-refactor", result
 
 
+def assert_domain_checks_precede_family_checks() -> None:
+    payload = build_catalog_canary_run(
+        changed_files=["loopx/policies/monitor_todo.py"],
+        surfaces=["resume_when work-lane policy seam"],
+        max_checks_per_family=1,
+        max_checks_per_profile=3,
+        check_limit=3,
+        execute=False,
+    )
+    assert payload["ok"] is True, payload
+    commands = [check["command"] for check in payload["selected_checks"]]
+    assert commands == [
+        "python3 examples/control-plane-risk-characterization-smoke.py",
+        "python3 examples/hot-path-interface-budget-smoke.py",
+        "python3 examples/quota-resume-gated-open-todo-smoke.py",
+    ], payload
+    assert all(check["source"] == "domain_profile" for check in payload["selected_checks"]), payload
+
+
 def assert_cli_run_executes_catalog_selected_check() -> None:
     completed = subprocess.run(
         [
@@ -101,6 +120,7 @@ def main() -> int:
     assert_release_readiness_gets_no_write_argument()
     assert_preview_does_not_execute_or_write()
     assert_profile_fixture_executes()
+    assert_domain_checks_precede_family_checks()
     assert_cli_run_executes_catalog_selected_check()
     print("catalog-canary-run-e2e-smoke ok")
     return 0

--- a/examples/quota-resume-gated-open-todo-smoke.py
+++ b/examples/quota-resume-gated-open-todo-smoke.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+"""Smoke-test quota routing for open todos gated by resume_when."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.quota import build_quota_should_run  # noqa: E402
+from loopx.status import compact_todo_group  # noqa: E402
+
+
+GOAL_ID = "resume-gated-open-todo-fixture"
+AGENT_ID = "codex-product-capability"
+PRIMARY_AGENT = "codex-main-control"
+BLOCKING_TODO_ID = "todo_projection_refresh"
+GATED_TODO_ID = "todo_projection_wording"
+FALLBACK_TODO_ID = "todo_catalog_canary"
+GATED_ACTION = "[P0] Review refreshed projection wording."
+FALLBACK_ACTION = "[P1] Continue catalog-driven product canary coverage."
+
+
+def build_agent_todos(*, prerequisite_status: str) -> dict:
+    agent_todos = compact_todo_group(
+        [
+            {
+                "index": 1,
+                "text": "[P0] Refresh the projection prerequisite.",
+                "role": "agent",
+                "status": prerequisite_status,
+                "priority": "P0",
+                "task_class": "continuous_monitor",
+                "claimed_by": "codex-side-bypass",
+                "todo_id": BLOCKING_TODO_ID,
+            },
+            {
+                "index": 2,
+                "text": GATED_ACTION,
+                "role": "agent",
+                "status": "open",
+                "priority": "P0",
+                "task_class": "advancement_task",
+                "claimed_by": AGENT_ID,
+                "todo_id": GATED_TODO_ID,
+                "required_capabilities": ["shell"],
+                "resume_when": f"todo_done:{BLOCKING_TODO_ID}",
+            },
+            {
+                "index": 3,
+                "text": FALLBACK_ACTION,
+                "role": "agent",
+                "status": "open",
+                "priority": "P1",
+                "task_class": "advancement_task",
+                "claimed_by": AGENT_ID,
+                "todo_id": FALLBACK_TODO_ID,
+                "required_capabilities": ["shell"],
+            },
+        ],
+        source_section="Agent Todo",
+        role="agent",
+    )
+    assert agent_todos is not None, agent_todos
+    return agent_todos
+
+
+def status_payload(agent_todos: dict, *, next_action: str) -> dict:
+    item = {
+        "goal_id": GOAL_ID,
+        "status": "resume_gated_open_todo_fixture",
+        "waiting_on": "codex",
+        "severity": "info",
+        "source": "project_asset",
+        "recommended_action": next_action,
+        "quota": {
+            "compute": 1.0,
+            "window_hours": 24,
+            "slot_minutes": 1,
+            "allowed_slots": 10,
+            "spent_slots": 0,
+            "state": "eligible",
+            "reason": "eligible fixture",
+        },
+        "coordination": {
+            "primary_agent": PRIMARY_AGENT,
+            "registered_agents": [PRIMARY_AGENT, "codex-side-bypass", AGENT_ID],
+        },
+        "project_asset": {
+            "next_action": next_action,
+            "stop_condition": "stop on private material",
+            "agent_todos": agent_todos,
+        },
+        "agent_todos": agent_todos,
+    }
+    return {
+        "ok": True,
+        "attention_queue": {"items": [item]},
+        "run_history": {
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "registry_member": True,
+                    "status": "resume_gated_open_todo_fixture",
+                    "adapter_kind": "harness_self_improvement",
+                    "adapter_status": "connected-read-only",
+                    "quota": {
+                        "compute": 1.0,
+                        "window_hours": 24,
+                        "slot_minutes": 1,
+                        "allowed_slots": 10,
+                    },
+                    "coordination": item["coordination"],
+                }
+            ]
+        },
+    }
+
+
+def selected_todo_id(payload: dict) -> str:
+    return payload["agent_lane_next_action"]["todo_id"]
+
+
+def runnable_todo_ids(payload: dict) -> list[str]:
+    return [
+        item["todo_id"]
+        for item in payload["capability_gate"]["runnable_candidates"]
+    ]
+
+
+def assert_not_ready_open_resume_todo_is_not_executable() -> None:
+    agent_todos = build_agent_todos(prerequisite_status="open")
+    gated = next(
+        item for item in agent_todos["backlog_items"] if item["todo_id"] == GATED_TODO_ID
+    )
+    assert gated["resume_ready"] is False, gated
+    executable_ids = {
+        item["todo_id"] for item in agent_todos["executable_backlog_items"]
+    }
+    assert GATED_TODO_ID not in executable_ids, agent_todos
+    assert FALLBACK_TODO_ID in executable_ids, agent_todos
+
+    quota_payload = build_quota_should_run(
+        status_payload(agent_todos, next_action=GATED_ACTION),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+    assert quota_payload["should_run"] is True, quota_payload
+    assert quota_payload["normal_delivery_allowed"] is True, quota_payload
+    assert selected_todo_id(quota_payload) == FALLBACK_TODO_ID, quota_payload
+    assert GATED_TODO_ID not in runnable_todo_ids(quota_payload), quota_payload
+    assert quota_payload["recommended_action"] == FALLBACK_ACTION, quota_payload
+
+
+def assert_ready_open_resume_todo_can_run() -> None:
+    agent_todos = build_agent_todos(prerequisite_status="done")
+    gated = next(
+        item for item in agent_todos["backlog_items"] if item["todo_id"] == GATED_TODO_ID
+    )
+    assert gated["resume_ready"] is True, gated
+    executable_ids = {
+        item["todo_id"] for item in agent_todos["executable_backlog_items"]
+    }
+    assert GATED_TODO_ID in executable_ids, agent_todos
+
+    quota_payload = build_quota_should_run(
+        status_payload(agent_todos, next_action=GATED_ACTION),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+    assert quota_payload["should_run"] is True, quota_payload
+    assert selected_todo_id(quota_payload) == GATED_TODO_ID, quota_payload
+    assert runnable_todo_ids(quota_payload)[0] == GATED_TODO_ID, quota_payload
+    assert quota_payload["recommended_action"] == GATED_ACTION, quota_payload
+
+
+def main() -> int:
+    assert_not_ready_open_resume_todo_is_not_executable()
+    assert_ready_open_resume_todo_can_run()
+    print("quota-resume-gated-open-todo-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -288,7 +288,17 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
         "title": "Control-plane refactor safety",
         "purpose": "Sample hot-path route, policy seam, and interface budget checks for quota/status refactors.",
         "catalog_families": ["Work Routing", "State And Boundary", "Planning Governance"],
-        "trigger_hints": ("refactor", "quota.py", "status.py", "control-plane", "policy seam"),
+        "trigger_hints": (
+            "refactor",
+            "quota.py",
+            "status.py",
+            "control-plane",
+            "policy seam",
+            "work-lane policy",
+            "resume_when",
+            "resume_ready",
+            "loopx/policies/monitor_todo.py",
+        ),
         "checks": [
             {
                 "command": "python3 examples/control-plane-risk-characterization-smoke.py",
@@ -299,6 +309,11 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
                 "command": "python3 examples/hot-path-interface-budget-smoke.py",
                 "tier": "default",
                 "reason": "keeps hot-path payload and module growth bounded",
+            },
+            {
+                "command": "python3 examples/quota-resume-gated-open-todo-smoke.py",
+                "tier": "default",
+                "reason": "guards resume_when-gated open todos from entering executable quota lanes early",
             },
             {
                 "command": "python3 examples/work-lane-contract-smoke.py",

--- a/loopx/canary/runner.py
+++ b/loopx/canary/runner.py
@@ -107,25 +107,6 @@ def _display_argv(argv: list[str]) -> list[str]:
 def _planned_checks(plan: dict[str, Any]) -> list[dict[str, Any]]:
     checks: list[dict[str, Any]] = []
     seen: set[str] = set()
-    for profile in plan.get("profiles", []):
-        if not isinstance(profile, dict):
-            continue
-        for check in profile.get("candidate_checks", []):
-            if not isinstance(check, dict):
-                continue
-            command = str(check.get("command") or "")
-            if not command or command in seen:
-                continue
-            seen.add(command)
-            checks.append(
-                {
-                    "source": "catalog_family",
-                    "profile_id": profile.get("id"),
-                    "profile_title": profile.get("family"),
-                    "tier": check.get("tier") or "default",
-                    **check,
-                }
-            )
     for profile in plan.get("domain_profiles", []):
         if not isinstance(profile, dict):
             continue
@@ -141,6 +122,25 @@ def _planned_checks(plan: dict[str, Any]) -> list[dict[str, Any]]:
                     "source": "domain_profile",
                     "profile_id": profile.get("id"),
                     "profile_title": profile.get("title"),
+                    "tier": check.get("tier") or "default",
+                    **check,
+                }
+            )
+    for profile in plan.get("profiles", []):
+        if not isinstance(profile, dict):
+            continue
+        for check in profile.get("candidate_checks", []):
+            if not isinstance(check, dict):
+                continue
+            command = str(check.get("command") or "")
+            if not command or command in seen:
+                continue
+            seen.add(command)
+            checks.append(
+                {
+                    "source": "catalog_family",
+                    "profile_id": profile.get("id"),
+                    "profile_title": profile.get("family"),
                     "tier": check.get("tier") or "default",
                     **check,
                 }

--- a/loopx/policies/monitor_todo.py
+++ b/loopx/policies/monitor_todo.py
@@ -6,6 +6,7 @@ from typing import Any
 from ..todo_contract import (
     TODO_STATUS_OPEN,
     TODO_TASK_CLASS_MONITOR,
+    normalize_todo_resume_when,
     normalize_todo_status,
     normalize_todo_task_class,
 )
@@ -36,7 +37,11 @@ def monitor_todo_is_actionable_open(item: dict[str, Any]) -> bool:
     if item.get("done") is True:
         return False
     status = normalize_todo_status(item.get("status")) or TODO_STATUS_OPEN
-    return status == TODO_STATUS_OPEN
+    if status != TODO_STATUS_OPEN:
+        return False
+    if normalize_todo_resume_when(item.get("resume_when")):
+        return item.get("resume_ready") is True
+    return True
 
 
 def monitor_todo_next_due_at(item: dict[str, Any]) -> datetime | None:


### PR DESCRIPTION
## Summary

- Treat open todos with `resume_when` as visible but not executable until `resume_ready=true`.
- Add a focused quota smoke for resume-gated open todos and wire it into the catalog canary control-plane-refactor profile.
- Prioritize domain-profile canary checks ahead of generic family checks so changed-file runs reach the specific regression checks before `check_limit` is exhausted.
- Update README and quota/status/todo contracts for the open `resume_when` semantics and restored quota contract wording.

## Motivation

A real `quota should-run --agent-id codex-product-capability` packet selected `todo_b4861f4d3b7a` even though it had `resume_when=todo_done:todo_244df4ff1836` and `resume_ready=false`. That made a deferred successor look executable and hid the safe catalog-canary fallback. This PR turns that current-state failure into a durable canary.

## Validation

- `python3 examples/quota-resume-gated-open-todo-smoke.py`
- `python3 examples/catalog-canary-planner-smoke.py`
- `python3 examples/catalog-canary-run-e2e-smoke.py`
- `python3 examples/quota-contract-smoke.py`
- `python3 examples/work-lane-contract-smoke.py`
- `python3 -m py_compile loopx/policies/monitor_todo.py loopx/canary/planner.py loopx/canary/runner.py loopx/status.py loopx/quota.py`
- `PYTHONPATH=/private/tmp/loopx-product-capability-next-20260630-1323 python3 -m loopx.cli --format json --registry "$HOME/.codex/loopx/registry.global.json" --runtime-root "$HOME/.codex/loopx" quota should-run --goal-id loopx-meta --agent-id codex-product-capability`
  - selected `todo_efbf10288fe7`; `todo_b4861f4d3b7a` remained visible with `resume_ready=false` but was not runnable.
- `python3 -m loopx.cli --format json canary run --changed-file loopx/policies/monitor_todo.py --surface "resume_when work-lane policy seam" --max-checks-per-family 1 --max-checks-per-profile 3 --check-limit 3 --timeout-seconds 60`
  - selected and passed the new `quota-resume-gated-open-todo-smoke.py` through the domain profile.
- `python3 -m loopx.cli --format json canary coverage-audit`
  - `missing_count=0`, `drift_count=0`.
- `python3 -m loopx.cli check --scan-path README.md --scan-path docs/project-agent-todo-contract.md --scan-path docs/status-data-contract.md --scan-path docs/quota-allocation.md --scan-path examples/quota-resume-gated-open-todo-smoke.py --scan-path examples/catalog-canary-planner-smoke.py --scan-path examples/catalog-canary-run-e2e-smoke.py --scan-path loopx/policies/monitor_todo.py --scan-path loopx/canary/planner.py --scan-path loopx/canary/runner.py`
  - public boundary clean; existing duplicate index warning only.
- `git diff --check`

## Review Note

This changes runtime quota routing semantics, so I am not self-merging it as a side-agent cleanup PR.
