### PR TITLE
Fix SkillsBench app-server first-action watchdog

### DIFF
--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import tempfile
 import time
+from argparse import Namespace
 from pathlib import Path
 from typing import Any
 
@@ -1406,12 +1407,60 @@ time.sleep(30)
         assert trace["worker_process"]["stage"] == "first_action_timeout", trace
         assert trace["worker_contract"]["first_blocker"] == "first_action_timeout", trace
         assert trace["worker_process"]["stderr_bytes"] > 0, trace
-        assert timeout_arg.read_text(encoding="utf-8") == "0.0"
+        assert timeout_arg.read_text(encoding="utf-8") == "1.0"
         trace_text = json.dumps(trace, sort_keys=True)
         assert "private task placeholder" not in trace_text, trace
         assert str(work) not in trace_text, trace
         proc.terminate()
         proc.wait(timeout=2)
+
+
+def test_app_server_goal_launcher_defaults_first_action_watchdog() -> None:
+    from scripts.skillsbench_automation_loop import _host_local_acp_launch_command
+
+    command = _host_local_acp_launch_command(
+        _app_server_goal_command_args(first_action_timeout=None),
+        {"app_server_goal_worker_trace_dir": "/tmp/worker-traces"},
+    )
+    index = command.index("--first-action-timeout-sec")
+    assert command[index + 1] == "3600", command
+
+
+def test_app_server_goal_launcher_allows_explicit_first_action_disable() -> None:
+    from scripts.skillsbench_automation_loop import _host_local_acp_launch_command
+
+    command = _host_local_acp_launch_command(
+        _app_server_goal_command_args(first_action_timeout=0),
+        {"app_server_goal_worker_trace_dir": "/tmp/worker-traces"},
+    )
+    index = command.index("--first-action-timeout-sec")
+    assert command[index + 1] == "0", command
+
+
+def _app_server_goal_command_args(first_action_timeout: int | None) -> Namespace:
+    return Namespace(
+        local_acp_relay_command="",
+        route=ROUTE,
+        app_server_reasoning_effort="high",
+        app_server_acp_heartbeat_interval_sec=120.0,
+        dataset="skillsbench@1.1",
+        task_id="llm-prefix-cache-replay",
+        local_codex_bin="codex",
+        local_codex_sandbox="workspace-write",
+        local_codex_exec_timeout_sec=None,
+        local_codex_first_action_timeout_sec=first_action_timeout,
+        local_codex_bridge_idle_timeout_sec=None,
+        local_codex_task_output_quiet_timeout_sec=None,
+        outer_timeout_sec=7200,
+        agent_idle_timeout=900,
+        model="gpt-5.5",
+        host_local_acp_launch=True,
+        remote_command_file_bridge_solver_command="python bridge.py",
+        remote_command_file_bridge_ready=True,
+        remote_command_file_bridge_probe=False,
+        remote_command_file_bridge_probe_timeout_sec=10,
+        remote_command_file_bridge_agent_command="",
+    )
 
 
 def test_acp_relay_fails_fast_when_app_server_worker_only_uses_status_bridge() -> None:
@@ -1908,6 +1957,8 @@ if __name__ == "__main__":
     test_acp_relay_materializes_public_failure_trace_without_worker_output()
     test_acp_relay_fails_closed_when_zero_exit_worker_writes_no_public_output()
     test_acp_relay_fails_fast_when_app_server_worker_never_uses_bridge()
+    test_app_server_goal_launcher_defaults_first_action_watchdog()
+    test_app_server_goal_launcher_allows_explicit_first_action_disable()
     test_acp_relay_fails_fast_when_app_server_worker_only_uses_status_bridge()
     test_acp_relay_yields_after_task_output_quiet_timeout()
     test_full_run_fails_closed_until_bridge_is_materialized()

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -2030,8 +2030,6 @@ raise SystemExit(proc.returncode)
                 / "skillsbench_host_codex_goal_worker.py"
             )
             worker_first_action_timeout_sec = self._config.first_action_timeout_sec
-            if bridge_summary_path is not None:
-                worker_first_action_timeout_sec = 0.0
             cmd = [
                 sys.executable,
                 str(worker_script),

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -157,6 +157,7 @@ DEFAULT_MODEL = "gpt-5.5"
 DEFAULT_TIMEOUT_SEC = 7200
 DEFAULT_HOST_LOCAL_CODEX_BRIDGE_IDLE_TIMEOUT_SEC = 3600
 DEFAULT_HOST_LOCAL_CODEX_TASK_OUTPUT_QUIET_TIMEOUT_SEC = 600
+DEFAULT_APP_SERVER_GOAL_FIRST_ACTION_TIMEOUT_SEC = 3600
 DEFAULT_VERIFIER_PREP_TIMEOUT_SEC = 120
 DEFAULT_SOFT_VERIFIER_TIMEOUT_SEC = 600
 DEFAULT_PRODUCT_MODE_SOFT_VERIFY_POLICY = "every-round"
@@ -989,12 +990,7 @@ def _host_local_acp_launch_command(
             "--timeout-sec",
             str(_effective_local_codex_exec_timeout_sec(args)),
             "--first-action-timeout-sec",
-            str(
-                max(
-                    0,
-                    int(getattr(args, "local_codex_first_action_timeout_sec", 0) or 0),
-                )
-            ),
+            str(_effective_local_codex_first_action_timeout_sec(args)),
             "--bridge-idle-timeout-sec",
             str(_effective_local_codex_bridge_idle_timeout_sec(args)),
             "--task-output-quiet-timeout-sec",
@@ -1156,6 +1152,18 @@ def _effective_local_codex_bridge_idle_timeout_sec(args: argparse.Namespace) -> 
     if requested <= 0:
         return DEFAULT_HOST_LOCAL_CODEX_BRIDGE_IDLE_TIMEOUT_SEC
     return min(requested, DEFAULT_HOST_LOCAL_CODEX_BRIDGE_IDLE_TIMEOUT_SEC)
+
+
+def _effective_local_codex_first_action_timeout_sec(args: argparse.Namespace) -> int:
+    configured = getattr(args, "local_codex_first_action_timeout_sec", None)
+    if configured is not None:
+        return max(0, int(configured or 0))
+    if (
+        bool(getattr(args, "host_local_acp_launch", False))
+        and getattr(args, "route", "") == "codex-app-server-goal-baseline"
+    ):
+        return DEFAULT_APP_SERVER_GOAL_FIRST_ACTION_TIMEOUT_SEC
+    return 0
 
 
 def _effective_local_codex_task_output_quiet_timeout_sec(
@@ -12349,10 +12357,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "--local-codex-first-action-timeout-sec",
         type=int,
-        default=0,
+        default=None,
         help=(
             "Optional watchdog for the first sandbox bridge operation from a "
-            "host-local Codex turn. 0 disables the watchdog."
+            "host-local Codex turn. Omit to use the app-server Goal default "
+            f"({DEFAULT_APP_SERVER_GOAL_FIRST_ACTION_TIMEOUT_SEC}s) for "
+            "codex-app-server-goal-baseline; 0 disables the watchdog."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary

Fixes the SkillsBench `codex-app-server-goal-baseline` first-action watchdog so app-server Goal runs no longer sit at `prompt_received` without a terminal compact result when the worker never starts an effective task-facing action.

- adds a route-specific default first-action watchdog for app-server Goal launches when the option is omitted
- preserves explicit `--local-codex-first-action-timeout-sec 0` as a diagnostic disable switch
- stops the ACP relay from zeroing the worker watchdog merely because command/file bridge tracing is enabled
- extends the focused app-server Goal worker smoke coverage

## Validation

- `python3 examples/skillsbench-app-server-goal-worker-smoke.py`
- `python3 examples/skillsbench-goal-start-product-mode-route-smoke.py`
- `python3 -m compileall loopx scripts examples/skillsbench-app-server-goal-worker-smoke.py`
- `loopx check --scan-path scripts/skillsbench_automation_loop.py --scan-path loopx/benchmark_adapters/skillsbench_acp_relay.py --scan-path examples/skillsbench-app-server-goal-worker-smoke.py`
- `git diff --check`

`loopx check` reports only the existing duplicate index warning for `loopx-meta`; the public boundary scan is clean for the changed files.
