### PR TITLE
Record install source revision in doctor

### DIFF
--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -21,6 +21,15 @@ if str(REPO_ROOT) not in sys.path:
 from loopx.doctor import add_promotion_readiness_freshness, build_install_freshness  # noqa: E402
 
 
+def git_output(args: list[str]) -> str:
+    return subprocess.run(
+        ["git", "-C", str(REPO_ROOT), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
 def run_install(env: dict[str, str], release_id: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         [str(INSTALL_SCRIPT)],
@@ -94,6 +103,7 @@ def main() -> int:
             "PATH": os.environ.get("PATH", ""),
             "SHELL": "/bin/zsh",
         }
+        source_commit = git_output(["rev-parse", "HEAD"])
 
         install = run_install(env, "install-smoke-initial")
         assert "loopx installed locally" in install.stdout, install.stdout
@@ -134,6 +144,8 @@ def main() -> int:
         assert release_manifest["package"]["name"] == "loopx", release_manifest
         assert release_manifest["package"]["version"], release_manifest
         assert release_manifest["source"]["kind"] == "local_checkout", release_manifest
+        assert release_manifest["source"]["git_commit"] == source_commit, release_manifest
+        assert isinstance(release_manifest["source"]["git_dirty"], bool), release_manifest
         assert release_manifest["skills"]["digest"], release_manifest
         assert release_manifest["skills"]["items"]["loopx-project"]["sha256"], release_manifest
         canary_wrapper = bin_dir / "loopx-canary"
@@ -262,6 +274,9 @@ def main() -> int:
         assert freshness["release_manifest_available"] is True, freshness
         assert freshness["release_manifest_path"] == str(release_manifest_path), freshness
         assert freshness["manifest_source_kind"] == "local_checkout", freshness
+        assert freshness["manifest_source_git_commit"] == source_commit, freshness
+        assert freshness["manifest_source_git_commit_short"] == source_commit[:12], freshness
+        assert freshness["manifest_source_revision"] == source_commit, freshness
         assert freshness["manifest_skills_digest"] == release_manifest["skills"]["digest"], freshness
         assert "install-from-github.sh" in freshness["upgrade_command"], freshness
         assert "loopx doctor" in freshness["upgrade_command"], freshness
@@ -275,6 +290,9 @@ def main() -> int:
         assert doctor_payload["release_manifest"]["available"] is True, doctor_payload
         assert doctor_payload["release_manifest"]["path"] == str(release_manifest_path), doctor_payload
         assert doctor_payload["release_manifest"]["manifest"]["source"]["kind"] == "local_checkout", doctor_payload
+        assert (
+            doctor_payload["release_manifest"]["manifest"]["source"]["git_commit"] == source_commit
+        ), doctor_payload
         assert doctor_payload["release_manifest"]["manifest"]["skills"]["digest"] == release_manifest["skills"]["digest"], doctor_payload
         assert doctor_payload["skill"]["path"] == str(skill), doctor_payload
         assert doctor_payload["skill"]["exists"] is True, doctor_payload
@@ -341,6 +359,8 @@ def main() -> int:
         assert "schema_version: `loopx_install_freshness_v0`" in doctor_markdown, doctor_markdown
         assert "status: `unknown`" in doctor_markdown, doctor_markdown
         assert "release_manifest_available: `True`" in doctor_markdown, doctor_markdown
+        assert f"manifest_source_git_commit: `{source_commit[:12]}`" in doctor_markdown, doctor_markdown
+        assert "manifest_source: `local_checkout` @ `n/a`" not in doctor_markdown, doctor_markdown
         assert "manifest_skills_digest:" in doctor_markdown, doctor_markdown
         assert "install-from-github.sh" in doctor_markdown, doctor_markdown
         assert "latest_promotion_readiness: available=`True`" in doctor_markdown, doctor_markdown

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -109,6 +109,15 @@ def parse_release_id_time(release_id: str | None) -> datetime | None:
         return None
 
 
+def short_revision(value: Any, *, length: int = 12) -> str | None:
+    if not isinstance(value, str):
+        return None
+    text = value.strip()
+    if not text:
+        return None
+    return text[:length] if len(text) > length else text
+
+
 def build_install_freshness(
     *,
     command_path: Path | None,
@@ -163,6 +172,12 @@ def build_install_freshness(
     manifest_source = (
         manifest_body.get("source") if isinstance(manifest_body.get("source"), dict) else {}
     )
+    manifest_source_git_commit = manifest_source.get("git_commit")
+    manifest_source_revision = (
+        manifest_source_git_commit
+        or manifest_source.get("git_ref")
+        or manifest_source.get("ref")
+    )
     manifest_skills = (
         manifest_body.get("skills") if isinstance(manifest_body.get("skills"), dict) else {}
     )
@@ -186,6 +201,12 @@ def build_install_freshness(
         "manifest_source_kind": manifest_source.get("kind"),
         "manifest_source_repo": manifest_source.get("repo"),
         "manifest_source_ref": manifest_source.get("ref"),
+        "manifest_source_git_commit": manifest_source_git_commit,
+        "manifest_source_git_commit_short": short_revision(manifest_source_git_commit),
+        "manifest_source_git_ref": manifest_source.get("git_ref"),
+        "manifest_source_git_dirty": manifest_source.get("git_dirty"),
+        "manifest_source_revision": manifest_source_revision,
+        "manifest_source_revision_short": short_revision(manifest_source_revision),
         "manifest_archive_sha256": manifest_source.get("archive_sha256"),
         "manifest_skills_digest": manifest_skills.get("digest"),
     }
@@ -598,7 +619,12 @@ def render_doctor_markdown(payload: dict[str, Any]) -> str:
     freshness = payload.get("install_freshness") if isinstance(payload.get("install_freshness"), dict) else {}
     if freshness:
         manifest_source_repo = freshness.get("manifest_source_repo") or freshness.get("manifest_source_kind")
-        manifest_source_ref = freshness.get("manifest_source_ref") or "n/a"
+        manifest_source_ref = (
+            freshness.get("manifest_source_git_ref")
+            or freshness.get("manifest_source_ref")
+            or freshness.get("manifest_source_git_commit_short")
+            or "n/a"
+        )
         lines.extend(
             [
                 "",
@@ -612,6 +638,8 @@ def render_doctor_markdown(payload: dict[str, Any]) -> str:
                 f"- reason: `{freshness.get('reason')}`",
                 f"- release_manifest_available: `{freshness.get('release_manifest_available')}`",
                 f"- manifest_source: `{manifest_source_repo}` @ `{manifest_source_ref}`",
+                f"- manifest_source_git_commit: `{freshness.get('manifest_source_git_commit_short')}`",
+                f"- manifest_source_git_dirty: `{freshness.get('manifest_source_git_dirty')}`",
                 f"- manifest_archive_sha256: `{freshness.get('manifest_archive_sha256')}`",
                 f"- manifest_skills_digest: `{freshness.get('manifest_skills_digest')}`",
                 "- upgrade_command:",

--- a/loopx/release_manifest.py
+++ b/loopx/release_manifest.py
@@ -5,6 +5,7 @@ import hashlib
 import json
 import os
 from pathlib import Path
+import subprocess
 from typing import Any
 
 from . import __version__
@@ -48,10 +49,56 @@ def _hash_tree(root: Path) -> dict[str, Any]:
     }
 
 
+def _run_git(source_root: Path, args: list[str]) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(source_root), *args],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return None
+    if result.returncode != 0:
+        return None
+    value = result.stdout.strip()
+    return value or None
+
+
+def _git_metadata(source_root: Path | None) -> dict[str, Any]:
+    if source_root is None:
+        return {
+            "git_commit": None,
+            "git_ref": None,
+            "git_dirty": None,
+        }
+    root = source_root.expanduser().resolve()
+    if not root.exists():
+        return {
+            "git_commit": None,
+            "git_ref": None,
+            "git_dirty": None,
+        }
+    commit = _run_git(root, ["rev-parse", "HEAD"])
+    branch = _run_git(root, ["symbolic-ref", "--quiet", "--short", "HEAD"])
+    tag = _run_git(root, ["describe", "--tags", "--exact-match"])
+    status = _run_git(root, ["status", "--porcelain"])
+    if commit is None and branch is None and tag is None and status is None:
+        dirty: bool | None = None
+    else:
+        dirty = bool(status)
+    return {
+        "git_commit": commit,
+        "git_ref": branch or tag,
+        "git_dirty": dirty,
+    }
+
+
 def build_release_manifest(
     *,
     release_root: Path,
     release_id: str,
+    source_root: Path | None = None,
     installed_at: str | None = None,
     env: dict[str, str] | None = None,
 ) -> dict[str, Any]:
@@ -61,6 +108,7 @@ def build_release_manifest(
     repo = source_env.get("LOOPX_REPO")
     ref = source_env.get("LOOPX_REF")
     source_kind = "github_archive" if archive_url else "local_checkout"
+    git_metadata = _git_metadata(source_root)
     skills_root = release_root / "skills"
     skills: dict[str, Any] = {}
     if skills_root.exists():
@@ -81,6 +129,9 @@ def build_release_manifest(
             "kind": source_kind,
             "repo": repo,
             "ref": ref,
+            "git_commit": git_metadata["git_commit"],
+            "git_ref": git_metadata["git_ref"],
+            "git_dirty": git_metadata["git_dirty"],
             "archive_url": archive_url,
             "archive_sha256": archive_sha256,
         },
@@ -95,12 +146,14 @@ def write_release_manifest(
     *,
     release_root: Path,
     release_id: str,
+    source_root: Path | None = None,
     installed_at: str | None = None,
     env: dict[str, str] | None = None,
 ) -> Path:
     manifest = build_release_manifest(
         release_root=release_root,
         release_id=release_id,
+        source_root=source_root,
         installed_at=installed_at,
         env=env,
     )
@@ -158,11 +211,13 @@ def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description="Write a LoopX release manifest.")
     parser.add_argument("release_root")
     parser.add_argument("--release-id", required=True)
+    parser.add_argument("--source-root")
     parser.add_argument("--installed-at")
     args = parser.parse_args(argv)
     write_release_manifest(
         release_root=Path(args.release_root),
         release_id=args.release_id,
+        source_root=Path(args.source_root) if args.source_root else None,
         installed_at=args.installed_at,
     )
     return 0

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -115,6 +115,7 @@ find "$release_tmp" -name '*.pyc' -type f -delete
 PYTHONPATH="$release_tmp${PYTHONPATH:+:$PYTHONPATH}" "${LOOPX_PYTHON:-python3}" -m loopx.release_manifest \
   "$release_tmp" \
   --release-id "$release_id" \
+  --source-root "$repo_root" \
   --installed-at "$installed_at"
 chmod +x "$release_tmp/scripts/loopx"
 if [[ -e "$release_dir" ]]; then


### PR DESCRIPTION
## Summary

- record source checkout git metadata in release manifests when `install-local.sh` builds a local release snapshot
- surface the manifest source commit/ref/dirty state through `loopx doctor` JSON and markdown
- extend `examples/install-local-smoke.py` so the canary fails if local checkout provenance regresses back to `local_checkout @ n/a`

## Product / Architecture Judgment

Motivation: a just-merged source fix can be hidden by the default installed release snapshot. Before this change, doctor could only show `local_checkout @ n/a`, so operators had to manually cross-check source and wrapper behavior.

Solved or not: the change adds a reusable manifest provenance contract and validates the local-install read path end to end. Archive installs keep working without git metadata.

User/operator impact: `loopx doctor` can now explain which source revision produced the installed snapshot, and the install smoke catches the exact n/a regression that made the previous stale-wrapper issue hard to diagnose.

Main risk: installed-user compatibility. The manifest fields are additive, archive installs tolerate missing git metadata, and existing update reads continue to pass.

Design judgment: this is a general release provenance surface, not a one-off special case. A later refinement could compare the manifest commit against a live checkout commit when both are available, but the first step is making the installed snapshot self-describing.

## Validation

- `python3 -m py_compile loopx/release_manifest.py loopx/doctor.py`
- `python3 examples/install-local-smoke.py`
- `python3 examples/codex-cli-packaged-install-smoke.py`
- `python3 examples/loopx-update-smoke.py`
- `python3 -m loopx.cli check --scan-path loopx/release_manifest.py --scan-path loopx/doctor.py --scan-path scripts/install-local.sh --scan-path examples/install-local-smoke.py --limit 200`
- `git diff --check`

Boundary scan: `loopx check` public/private scan was clean for the changed files; it reported only the pre-existing duplicate index rows warning for `loopx-meta`.
