### PR TITLE
Expose actionable catalog canary plan commands

### DIFF
--- a/examples/catalog-canary-planner-smoke.py
+++ b/examples/catalog-canary-planner-smoke.py
@@ -56,6 +56,7 @@ def assert_profiles_come_from_catalog_matrix() -> None:
         "host-command-entry",
         "frontstage-rollout",
         "auto-research-demo",
+        "catalog-canary-contract",
         "benchmark-adapter-readiness",
     } <= domain_profile_ids, payload
 
@@ -80,6 +81,11 @@ def assert_plan_selects_minimal_profiles_from_changed_surfaces() -> None:
         assert all(check["tier"] == "default" for check in profile["checks"]), profile
         assert profile["deep_checks_available"] is True, profile
         assert profile["deep_checks_included"] is False, profile
+    assert payload["suggested_check_count"] == len(payload["suggested_checks"]), payload
+    assert payload["commands"] == [
+        check["command"] for check in payload["suggested_checks"]
+    ], payload
+    assert payload["suggested_checks"][0]["source"] == "domain_profile", payload
     assert payload["executes_checks"] is False, payload
 
 
@@ -332,6 +338,19 @@ def assert_explicit_profile_can_include_deep_checks() -> None:
     assert "owner-review necessity/risk packet" in payload["note"], payload
 
 
+def assert_catalog_canary_selects_own_profile_not_benchmark() -> None:
+    payload = build_catalog_canary_plan(
+        changed_files=["loopx/canary/planner.py", "loopx/canary/runner.py"],
+        surfaces=["catalog canary runner"],
+    )
+    domain_profiles = {profile["id"]: profile for profile in payload["domain_profiles"]}
+    assert "catalog-canary-contract" in domain_profiles, payload
+    assert "benchmark-adapter-readiness" not in domain_profiles, payload
+    commands = payload["commands"]
+    assert "python3 examples/catalog-canary-planner-smoke.py" in commands, payload
+    assert "python3 examples/catalog-canary-run-e2e-smoke.py" in commands, payload
+
+
 def assert_coverage_audit_tracks_p0_p1_patterns() -> None:
     payload = build_catalog_canary_coverage_audit()
     assert payload["ok"] is True, payload
@@ -402,6 +421,9 @@ def assert_cli_json_plan_is_dry_run() -> None:
     assert payload["dry_run"] is True, payload
     assert payload["executes_checks"] is False, payload
     assert payload["profile_count"] >= 1, payload
+    assert payload["suggested_check_count"] == len(payload["commands"]), payload
+    assert payload["commands"], payload
+    assert all(check["command"] in payload["commands"] for check in payload["suggested_checks"]), payload
     work_routing = next(profile for profile in payload["profiles"] if profile["family"] == "Work Routing")
     assert len(work_routing["candidate_checks"]) == 1, work_routing
     assert any(profile["id"] == "monitor-scheduler" for profile in payload["domain_profiles"]), payload
@@ -435,6 +457,7 @@ def main() -> int:
     assert_plan_selects_minimal_profiles_from_changed_surfaces()
     assert_pr_release_and_refactor_profiles_select()
     assert_explicit_profile_can_include_deep_checks()
+    assert_catalog_canary_selects_own_profile_not_benchmark()
     assert_coverage_audit_tracks_p0_p1_patterns()
     with tempfile.TemporaryDirectory(prefix="loopx-catalog-canary-smoke-") as tmp:
         tmp_dir = Path(tmp)

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -811,11 +811,49 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
         ],
     },
     {
+        "id": "catalog-canary-contract",
+        "title": "Catalog canary contract",
+        "purpose": "Check catalog-to-canary planning, JSON actionability, and shell-free no-write execution.",
+        "catalog_families": ["Planning Governance", "State And Boundary", "Work Routing"],
+        "trigger_hints": (
+            "catalog canary",
+            "canary planner",
+            "canary runner",
+            "canary plan",
+            "canary run",
+            "loopx/canary",
+            "loopx/cli_commands/canary.py",
+            "examples/catalog-canary",
+        ),
+        "checks": [
+            {
+                "command": "python3 examples/catalog-canary-planner-smoke.py",
+                "tier": "default",
+                "reason": "guards catalog coverage, selector routing, and actionable JSON plan commands",
+            },
+            {
+                "command": "python3 examples/catalog-canary-run-e2e-smoke.py",
+                "tier": "default",
+                "reason": "guards shell-free no-write canary execution from the selected catalog plan",
+            },
+        ],
+    },
+    {
         "id": "benchmark-adapter-readiness",
         "title": "Benchmark adapter readiness",
         "purpose": "Check public adapter contracts and evidence boundaries without launching benchmark jobs by default.",
         "catalog_families": ["Evidence Lifecycle", "State And Boundary", "Work Routing"],
-        "trigger_hints": ("benchmark", "adapter", "runner", "ledger", "skillsbench", "terminal-bench"),
+        "trigger_hints": (
+            "benchmark",
+            "benchmark adapter",
+            "benchmark runner",
+            "benchmark ledger",
+            "skillsbench",
+            "terminal-bench",
+            "loopx/benchmark",
+            "loopx/benchmark_case_state.py",
+            "examples/benchmark",
+        ),
         "checks": [
             {
                 "command": "python3 examples/benchmark-core-adapter-contract-smoke.py",
@@ -1141,6 +1179,52 @@ def _domain_profile_with_checks(
     return copied
 
 
+def flatten_catalog_canary_checks(plan: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return selected canary checks in execution order."""
+
+    checks: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for profile in plan.get("domain_profiles", []):
+        if not isinstance(profile, dict):
+            continue
+        for check in profile.get("checks", []):
+            if not isinstance(check, dict):
+                continue
+            command = str(check.get("command") or "")
+            if not command or command in seen:
+                continue
+            seen.add(command)
+            checks.append(
+                {
+                    "source": "domain_profile",
+                    "profile_id": profile.get("id"),
+                    "profile_title": profile.get("title"),
+                    "tier": check.get("tier") or "default",
+                    **check,
+                }
+            )
+    for profile in plan.get("profiles", []):
+        if not isinstance(profile, dict):
+            continue
+        for check in profile.get("candidate_checks", []):
+            if not isinstance(check, dict):
+                continue
+            command = str(check.get("command") or "")
+            if not command or command in seen:
+                continue
+            seen.add(command)
+            checks.append(
+                {
+                    "source": "catalog_family",
+                    "profile_id": profile.get("id"),
+                    "profile_title": profile.get("family"),
+                    "tier": check.get("tier") or "default",
+                    **check,
+                }
+            )
+    return checks
+
+
 def build_catalog_canary_plan(
     *,
     catalog_path: Path | None = None,
@@ -1196,7 +1280,7 @@ def build_catalog_canary_plan(
         ]
         selected_domain_profiles.append(profile_copy)
 
-    return {
+    payload = {
         "ok": True,
         "schema_version": CANARY_PLAN_SCHEMA_VERSION,
         "source": packet["source"],
@@ -1223,6 +1307,11 @@ def build_catalog_canary_plan(
             "necessity/risk packet before implementation."
         ),
     }
+    suggested_checks = flatten_catalog_canary_checks(payload)
+    payload["suggested_check_count"] = len(suggested_checks)
+    payload["suggested_checks"] = suggested_checks
+    payload["commands"] = [str(check.get("command") or "") for check in suggested_checks]
+    return payload
 
 
 def render_catalog_canary_profiles_markdown(payload: dict[str, Any]) -> str:

--- a/loopx/canary/runner.py
+++ b/loopx/canary/runner.py
@@ -7,7 +7,7 @@ import time
 from pathlib import Path
 from typing import Any
 
-from .planner import REPO_ROOT, build_catalog_canary_plan
+from .planner import REPO_ROOT, build_catalog_canary_plan, flatten_catalog_canary_checks
 
 
 CANARY_RUN_SCHEMA_VERSION = "catalog_canary_run_v0"
@@ -104,50 +104,6 @@ def _display_argv(argv: list[str]) -> list[str]:
     return displayed
 
 
-def _planned_checks(plan: dict[str, Any]) -> list[dict[str, Any]]:
-    checks: list[dict[str, Any]] = []
-    seen: set[str] = set()
-    for profile in plan.get("domain_profiles", []):
-        if not isinstance(profile, dict):
-            continue
-        for check in profile.get("checks", []):
-            if not isinstance(check, dict):
-                continue
-            command = str(check.get("command") or "")
-            if not command or command in seen:
-                continue
-            seen.add(command)
-            checks.append(
-                {
-                    "source": "domain_profile",
-                    "profile_id": profile.get("id"),
-                    "profile_title": profile.get("title"),
-                    "tier": check.get("tier") or "default",
-                    **check,
-                }
-            )
-    for profile in plan.get("profiles", []):
-        if not isinstance(profile, dict):
-            continue
-        for check in profile.get("candidate_checks", []):
-            if not isinstance(check, dict):
-                continue
-            command = str(check.get("command") or "")
-            if not command or command in seen:
-                continue
-            seen.add(command)
-            checks.append(
-                {
-                    "source": "catalog_family",
-                    "profile_id": profile.get("id"),
-                    "profile_title": profile.get("family"),
-                    "tier": check.get("tier") or "default",
-                    **check,
-                }
-            )
-    return checks
-
-
 def _run_check(check: dict[str, Any], *, timeout_seconds: float) -> dict[str, Any]:
     normalized = normalize_canary_command(str(check.get("command") or ""))
     result = {**check, "normalized": normalized}
@@ -216,7 +172,7 @@ def build_catalog_canary_run(
         max_checks_per_family=max_checks_per_family,
         max_checks_per_profile=max_checks_per_profile,
     )
-    planned = _planned_checks(plan)
+    planned = flatten_catalog_canary_checks(plan)
     selected = planned[: max(0, check_limit)]
     normalized = [
         {**check, "normalized": normalize_canary_command(str(check.get("command") or ""))}


### PR DESCRIPTION
## Summary

- add `suggested_checks` and `commands` to catalog canary plan JSON so machine consumers do not have to traverse profile internals
- reuse the same flattening helper from `canary run`, removing duplicate selected-check logic
- add a `catalog-canary-contract` profile for `loopx/canary/**` changes and narrow benchmark readiness triggers so generic canary runner changes do not select benchmark checks

## Product / Architecture Judgment

Motivation: while advancing the catalog-to-canary todo, the CLI plan was useful in markdown but less actionable in JSON, and a self-check of `loopx/canary/runner.py` incorrectly selected `benchmark-adapter-readiness` because that profile matched the generic word `runner`.

Solved or not: the diff makes the plan contract directly actionable via `commands`, keeps runner execution order derived from the same helper, and adds a regression smoke proving catalog-canary changes select their own profile instead of the benchmark lane.

User/operator impact: side agents can use `loopx canary plan --format json` as a real quality gate input, and non-benchmark canary work stays inside this agent lane instead of drifting into benchmark-owned checks.

Main risk: selection compatibility. The benchmark profile still matches benchmark-specific terms and paths, while catalog canary internals now have an explicit profile.

Design judgment: this is a reusable planner contract/refactor rather than a one-off exception; it removes duplicated flattening logic and makes future canary consumers simpler.

## Validation

- `python3 -m py_compile loopx/canary/planner.py loopx/canary/runner.py`
- `python3 examples/catalog-canary-planner-smoke.py`
- `python3 examples/catalog-canary-run-e2e-smoke.py`
- `python3 -m loopx.cli --format json canary plan --changed-file loopx/canary/planner.py --changed-file loopx/canary/runner.py --surface "catalog canary runner"`
- `python3 -m loopx.cli --format json canary run --changed-file loopx/canary/planner.py --changed-file loopx/canary/runner.py --surface "catalog canary runner" --check-limit 2 --timeout-seconds 60`
- `python3 -m loopx.cli check --scan-path loopx/canary/planner.py --scan-path loopx/canary/runner.py --scan-path examples/catalog-canary-planner-smoke.py --limit 200`
- `git diff --check`

Boundary scan: changed files were clean. `loopx check` reported only the existing duplicate index rows warning for `loopx-meta`.
