### PR TITLE
Clarify auto-research public claim boundary

### DIFF
--- a/examples/auto-research-demo-e2e-smoke.py
+++ b/examples/auto-research-demo-e2e-smoke.py
@@ -111,8 +111,21 @@ def assert_e2e_payload(
             "research_hypothesis": 1,
         }, payload
         assert payload["board"]["rollout_backed"] is True, payload
+        claim_boundary = payload["board"]["claim_boundary"]
+        assert claim_boundary["schema_version"] == "auto_research_public_claim_boundary_v0", payload
+        assert claim_boundary["live_claim_scope"] == "dev_only", payload
+        assert claim_boundary["holdout_result_scope"] == "rollout_context_only", payload
+        assert claim_boundary["holdout_claim_allowed"] is False, payload
+        assert claim_boundary["promotion_claim_allowed"] is False, payload
+        assert claim_boundary["first_screen_claim_allowed"] is False, payload
+        labels = [item["label"] for item in payload["board"]["value_metrics"]]
+        assert "Live claim scope" in labels, labels
+        assert "Rollout held-out context" in labels, labels
+        assert "Held-out result" not in labels, labels
         assert payload["board"]["promotion_candidate_count"] >= 1, payload
         assert payload["acceptance"]["ready_for_real_launch"] is True, payload
+        assert payload["acceptance"]["claim_boundary"]["live_claim_scope"] == "dev_only", payload
+        assert payload["acceptance"]["claim_boundary"]["promotion_claim_allowed"] is False, payload
     else:
         assert replay["result_source"] == "deterministic_replay_preview", payload
         assert replay["expected_positive_result"] == "dev=4.0x holdout=4.5x after --execute", payload
@@ -189,6 +202,7 @@ def main() -> int:
         assert "tracking_goal_drives_frontier: `False`" in markdown, markdown
         assert "live_codex_e2e_claim_allowed: `False`" in markdown, markdown
         assert "live_codex_e2e_evidence_source: `not_collected_from_codex_lane_output`" in markdown, markdown
+        assert "board_live_claim_scope" not in markdown, markdown
         assert "reasoning_effort: `high`" in markdown, markdown
         assert "deterministic replay:" in markdown, markdown
         assert_public_safe(markdown)

--- a/examples/auto-research-live-codex-claim-boundary-smoke.py
+++ b/examples/auto-research-live-codex-claim-boundary-smoke.py
@@ -110,6 +110,18 @@ def live_evidence_payload(*, claim_authority: dict[str, str] | None = None) -> d
     return payload
 
 
+def assert_public_board_claim_boundary(payload: dict[str, Any]) -> None:
+    boundary = payload["board"]["claim_boundary"]
+    assert boundary["schema_version"] == "auto_research_public_claim_boundary_v0", payload
+    assert boundary["live_claim_scope"] == "dev_only", payload
+    assert boundary["holdout_result_scope"] == "rollout_context_only", payload
+    assert boundary["holdout_claim_allowed"] is False, payload
+    assert boundary["promotion_result_scope"] == "candidate_only_not_auto_promoted", payload
+    assert boundary["promotion_claim_allowed"] is False, payload
+    assert boundary["first_screen_claim_allowed"] is False, payload
+    assert "automatic_promotion" in boundary["must_not_claim"], payload
+
+
 def main() -> int:
     with tempfile.TemporaryDirectory() as temp_dir:
         temp = Path(temp_dir)
@@ -132,6 +144,7 @@ def main() -> int:
         assert no_live_payload["live_codex_e2e"]["evidence_source"] == (
             "not_collected_from_codex_lane_output"
         ), no_live_payload
+        assert_public_board_claim_boundary(no_live_payload)
 
         evidence = temp / "live-evidence.public.json"
         evidence.write_text(json.dumps(live_evidence_payload(), sort_keys=True), encoding="utf-8")
@@ -200,6 +213,7 @@ def main() -> int:
         assert live["public_boundary"]["absolute_paths_recorded"] is False, claimed_payload
         assert live["public_boundary"]["credentials_recorded"] is False, claimed_payload
         assert live["public_boundary"]["local_workspace_path_redacted"] is True, claimed_payload
+        assert_public_board_claim_boundary(claimed_payload)
         assert_public_safe(claimed_payload)
 
         authorized_evidence = temp / "authorized-live-evidence.public.json"

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -147,11 +147,17 @@ def _run_protected_eval(
 def _compact_board(board: dict[str, object]) -> dict[str, object]:
     decisions = board.get("decision_candidates") if isinstance(board.get("decision_candidates"), dict) else {}
     binding = board.get("projection_binding") if isinstance(board.get("projection_binding"), dict) else {}
+    claim_boundary = (
+        board.get("claim_boundary")
+        if isinstance(board.get("claim_boundary"), dict)
+        else {}
+    )
     return {
         "ok": bool(board.get("ok")),
         "rollout_backed": bool(binding.get("rollout_backed")),
         "promotion_candidate_count": len(decisions.get("promotion_candidates") or []),
         "retirement_candidate_count": len(decisions.get("retirement_candidates") or []),
+        "claim_boundary": claim_boundary,
         "value_metrics": board.get("value_metrics") or [],
     }
 
@@ -172,6 +178,7 @@ def _compact_acceptance(acceptance: dict[str, object]) -> dict[str, object]:
         "ready_for_real_launch": bool(summary.get("ready_for_real_launch")),
         "promotion_candidate_count": int(board.get("promotion_candidate_count") or 0),
         "rollout_backed": bool(board.get("rollout_backed")),
+        "claim_boundary": board.get("claim_boundary") if isinstance(board.get("claim_boundary"), dict) else {},
     }
 
 

--- a/loopx/capabilities/auto_research/legacy_core.py
+++ b/loopx/capabilities/auto_research/legacy_core.py
@@ -27,6 +27,7 @@ AUTO_RESEARCH_DEMO_SUPERVISOR_SCHEMA_VERSION = "auto_research_demo_supervisor_pl
 AUTO_RESEARCH_DEMO_ACCEPTANCE_PACKET_SCHEMA_VERSION = "auto_research_demo_acceptance_packet_v0"
 AUTO_RESEARCH_DEMO_E2E_SCHEMA_VERSION = "auto_research_demo_e2e_result_v0"
 AUTO_RESEARCH_ROLE_PROFILE_SCHEMA_VERSION = "auto_research_role_profile_v0"
+AUTO_RESEARCH_PUBLIC_CLAIM_BOUNDARY_SCHEMA_VERSION = "auto_research_public_claim_boundary_v0"
 AUTO_RESEARCH_DEFAULT_GOAL_ID = "loopx-auto-research-knn"
 AUTO_RESEARCH_DEFAULT_OBJECTIVE = "Improve exact k-nearest-neighbor inference under a protected evaluator."
 AUTO_RESEARCH_QUICKSTART_TEMPLATE = "knn-exact"
@@ -1519,6 +1520,7 @@ def build_auto_research_demo_acceptance_packet(
         raise ValueError("supervisor must be ok")
 
     binding = _json_obj(board.get("projection_binding"), field="board.projection_binding")
+    claim_boundary = _json_obj(board.get("claim_boundary"), field="board.claim_boundary")
     surface = _json_obj(board.get("surface"), field="board.surface")
     research_contract = _json_obj(board.get("research_contract"), field="board.research_contract")
     decisions = _json_obj(board.get("decision_candidates"), field="board.decision_candidates")
@@ -1651,6 +1653,13 @@ def build_auto_research_demo_acceptance_packet(
             "promotion_candidate_count": len(promotion_candidates),
             "retirement_candidate_count": len(retirement_candidates),
             "user_gate_count": len(gates),
+            "claim_boundary": {
+                "live_claim_scope": claim_boundary.get("live_claim_scope"),
+                "holdout_result_scope": claim_boundary.get("holdout_result_scope"),
+                "holdout_claim_allowed": bool(claim_boundary.get("holdout_claim_allowed")),
+                "promotion_claim_allowed": bool(claim_boundary.get("promotion_claim_allowed")),
+                "first_screen_claim_allowed": bool(claim_boundary.get("first_screen_claim_allowed")),
+            },
         },
         "supervisor_rehearsal": {
             "schema_version": supervisor.get("schema_version"),
@@ -2619,6 +2628,12 @@ def build_live_auto_research_projection(
         if isinstance(node, dict) and node.get("status") == "promoted" and node.get("hypothesis_id")
     ]
     retired = [item["hypothesis_id"] for item in decision_candidates["retirement_candidates"]]
+    claim_boundary = _board_public_claim_boundary(
+        source_kind=source_kind,
+        best_dev=evidence_graph.get("best_dev_metric"),
+        best_holdout=evidence_graph.get("best_holdout_metric"),
+        promotion_candidate_count=len(decision_candidates["promotion_candidates"]),
+    )
     showcase_projection = {
         "schema_version": RESEARCH_SHOWCASE_PROJECTION_SCHEMA_VERSION,
         "title": "LoopX Live Auto Research Frontier",
@@ -2638,6 +2653,7 @@ def build_live_auto_research_projection(
         "promoted_hypotheses": promoted,
         "retired_or_contradicted_hypotheses": retired,
         "negative_evidence_count": evidence_graph.get("negative_evidence_count"),
+        "claim_boundary": claim_boundary,
         "decentralized_pattern": (
             "todo_backed_live_frontier_rollout_evidence_graph"
             if source_kind == ROLLOUT_EVIDENCE_GRAPH_SOURCE_KIND
@@ -2657,6 +2673,7 @@ def build_live_auto_research_projection(
         "evidence_graph": evidence_graph,
         "showcase_projection": showcase_projection,
         "artifact_packet": artifact_packet,
+        "public_claim_boundary": claim_boundary,
         "public_boundary": {
             "raw_logs_recorded": False,
             "private_artifacts_recorded": False,
@@ -2676,6 +2693,40 @@ def _metric_display(value: Any, *, suffix: str = "x") -> str:
     if number == int(number):
         return f"{int(number)}{suffix}"
     return f"{number:.1f}{suffix}"
+
+
+def _board_public_claim_boundary(
+    *,
+    source_kind: str,
+    best_dev: Any,
+    best_holdout: Any,
+    promotion_candidate_count: int,
+) -> dict[str, Any]:
+    dev_present = _finite_float(best_dev, field="board.claim_boundary.best_dev") is not None
+    holdout_present = _finite_float(best_holdout, field="board.claim_boundary.best_holdout") is not None
+    rollout_backed = source_kind == ROLLOUT_EVIDENCE_GRAPH_SOURCE_KIND
+    return {
+        "schema_version": AUTO_RESEARCH_PUBLIC_CLAIM_BOUNDARY_SCHEMA_VERSION,
+        "live_claim_scope": "dev_only",
+        "dev_evidence_present": dev_present,
+        "dev_claim_rule": "claim only when live_codex_e2e.claim_allowed is true",
+        "holdout_metric_present": holdout_present,
+        "holdout_result_scope": "rollout_context_only" if rollout_backed else "projection_context_only",
+        "holdout_claim_allowed": False,
+        "promotion_candidate_count": int(promotion_candidate_count),
+        "promotion_result_scope": "candidate_only_not_auto_promoted",
+        "promotion_claim_allowed": False,
+        "first_screen_claim_allowed": False,
+        "public_claim": (
+            "Live lane-authored dev evidence may be shown only from live_codex_e2e; "
+            "held-out rollout context and promotion remain separate claims."
+        ),
+        "must_not_claim": [
+            "live_holdout_result_without_authority",
+            "automatic_promotion",
+            "first_screen_product_claim_without_owner_review",
+        ],
+    }
 
 
 def _board_user_gates() -> list[dict[str, str]]:
@@ -2834,6 +2885,12 @@ def build_auto_research_board_projection(
         for item in frontier.get("runnable") or []
         if isinstance(item, dict)
     ][:3]
+    claim_boundary = _board_public_claim_boundary(
+        source_kind=source_kind,
+        best_dev=best_dev,
+        best_holdout=best_holdout,
+        promotion_candidate_count=len(promotion_candidates),
+    )
     return {
         "ok": True,
         "schema_version": AUTO_RESEARCH_BOARD_SCHEMA_VERSION,
@@ -2852,6 +2909,7 @@ def build_auto_research_board_projection(
             "source_kind": source_kind,
             "rollout_backed": bool(artifact.get("rollout_backed")),
             "first_screen_policy": "experimental_only_not_first_screen_without_owner_review",
+            "public_claim_boundary_schema": claim_boundary["schema_version"],
             "frontier_agent_id": agent,
         },
         "research_contract": {
@@ -2872,7 +2930,10 @@ def build_auto_research_board_projection(
                 ),
                 "baseline": _metric_display(baseline),
             },
-            "promotion_policy": "Promote only after split-aware evidence, clean protected boundary, and explicit operator gate.",
+            "promotion_policy": (
+                "Default public projection may show dev-only live evidence; held-out rollout context "
+                "and promotion require separate authority."
+            ),
             "commands": [
                 {
                     "label": "frontier",
@@ -2884,26 +2945,34 @@ def build_auto_research_board_projection(
                 },
             ],
         },
+        "claim_boundary": claim_boundary,
         "value_metrics": [
             {
-                "label": "Held-out result",
+                "label": "Live claim scope",
+                "value": claim_boundary["live_claim_scope"],
+                "baseline": "unbounded_live_claim",
+                "interpretation": "Only lane-authorized dev evidence can be stated as live by default.",
+                "source": "public_claim_boundary.live_claim_scope",
+            },
+            {
+                "label": "Rollout held-out context",
                 "value": _metric_display(best_holdout),
                 "baseline": _metric_display(baseline),
-                "interpretation": "Promotion value is only legible when held-out evidence is present or explicitly missing.",
+                "interpretation": "Shown as rollout or replay context, not as a live Codex holdout claim.",
                 "source": "evidence_graph.best_holdout_metric",
             },
             {
                 "label": "Dev to holdout transfer",
                 "value": f"{_metric_display(best_dev)} -> {_metric_display(best_holdout)}",
                 "baseline": "dev evidence before promotion",
-                "interpretation": "The board keeps dev iteration separate from promotion evidence.",
+                "interpretation": "The board keeps dev iteration, held-out context, and public claim authority separate.",
                 "source": "research_evidence_graph_v0",
             },
             {
                 "label": "Promotion candidates",
                 "value": str(len(promotion_candidates)),
                 "baseline": "0 without evidence",
-                "interpretation": "Candidates remain review items; the board does not auto-promote them.",
+                "interpretation": "Candidates remain review items; the board does not auto-promote or make first-screen claims.",
                 "source": "artifact_packet.decision_packet",
             },
             {
@@ -3483,6 +3552,11 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
             if isinstance(payload.get("live_codex_e2e"), dict)
             else {}
         )
+        board_claim_boundary = (
+            board.get("claim_boundary")
+            if isinstance(board.get("claim_boundary"), dict)
+            else {}
+        )
         lines = [
             "# LoopX Auto Research Demo Replay",
             "",
@@ -3521,6 +3595,17 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
             f"- deterministic replay: `{commands.get('deterministic_replay')}`",
             f"- replay plus visible lanes: `{commands.get('deterministic_replay_with_visible_lanes')}`",
         ]
+        if board_claim_boundary:
+            lines.extend(
+                [
+                    "",
+                    "## Board Claim Boundary",
+                    "",
+                    f"- board_live_claim_scope: `{board_claim_boundary.get('live_claim_scope')}`",
+                    f"- board_holdout_result_scope: `{board_claim_boundary.get('holdout_result_scope')}`",
+                    f"- board_promotion_claim_allowed: `{board_claim_boundary.get('promotion_claim_allowed')}`",
+                ]
+            )
         return "\n".join(lines) + "\n"
     if payload.get("schema_version") == AUTO_RESEARCH_BOARD_SCHEMA_VERSION:
         surface = payload.get("surface") if isinstance(payload.get("surface"), dict) else {}
@@ -3532,6 +3617,11 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
         decisions = (
             payload.get("decision_candidates")
             if isinstance(payload.get("decision_candidates"), dict)
+            else {}
+        )
+        claim_boundary = (
+            payload.get("claim_boundary")
+            if isinstance(payload.get("claim_boundary"), dict)
             else {}
         )
         gates = payload.get("user_gates") if isinstance(payload.get("user_gates"), list) else []
@@ -3546,6 +3636,10 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
             f"- source_kind: `{binding.get('source_kind')}`",
             f"- rollout_backed: `{binding.get('rollout_backed')}`",
             f"- first_screen_policy: `{binding.get('first_screen_policy')}`",
+            f"- live_claim_scope: `{claim_boundary.get('live_claim_scope')}`",
+            f"- holdout_result_scope: `{claim_boundary.get('holdout_result_scope')}`",
+            f"- promotion_claim_allowed: `{claim_boundary.get('promotion_claim_allowed')}`",
+            f"- first_screen_claim_allowed: `{claim_boundary.get('first_screen_claim_allowed')}`",
             f"- value metrics: `{len(metrics)}`",
             f"- promotion candidates: `{len(decisions.get('promotion_candidates') or [])}`",
             f"- retirement candidates: `{len(decisions.get('retirement_candidates') or [])}`",


### PR DESCRIPTION
## Summary
- add an explicit public claim boundary to auto-research projections and board packets
- label held-out 4.5x as rollout/replay context, not a live Codex holdout claim
- expose the same boundary through demo E2E/acceptance compact outputs and smoke coverage

## Validation
- python3 -m compileall -q loopx/capabilities/auto_research examples/auto-research-demo-e2e-smoke.py examples/auto-research-live-codex-claim-boundary-smoke.py
- python3 examples/auto-research-demo-e2e-smoke.py
- python3 examples/auto-research-live-codex-claim-boundary-smoke.py
- python3 examples/auto-research-demo-acceptance-smoke.py
- python3 -m loopx.cli check --scan-path loopx/capabilities/auto_research --scan-path examples/auto-research-demo-e2e-smoke.py --scan-path examples/auto-research-live-codex-claim-boundary-smoke.py
