### PR TITLE
Add git diff selector for catalog canaries

### DIFF
--- a/examples/catalog-canary-planner-smoke.py
+++ b/examples/catalog-canary-planner-smoke.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import json
+import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -19,6 +21,7 @@ from loopx.canary.planner import (  # noqa: E402
     build_catalog_canary_plan,
     build_catalog_canary_profiles,
 )
+from loopx.cli_commands.canary import collect_git_diff_changed_files  # noqa: E402
 
 
 def assert_profiles_come_from_catalog_matrix() -> None:
@@ -351,6 +354,104 @@ def assert_catalog_canary_selects_own_profile_not_benchmark() -> None:
     assert "python3 examples/catalog-canary-run-e2e-smoke.py" in commands, payload
 
 
+def _run_git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def _make_git_diff_selector_repo(tmp_dir: Path) -> tuple[Path, str]:
+    repo = tmp_dir / "selector-repo"
+    repo.mkdir()
+    _run_git(repo, "init")
+    _run_git(repo, "config", "user.email", "loopx-smoke@example.invalid")
+    _run_git(repo, "config", "user.name", "LoopX Smoke")
+
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    _run_git(repo, "add", "README.md")
+    _run_git(repo, "commit", "-m", "base")
+    base_ref = _run_git(repo, "rev-parse", "HEAD").stdout.strip()
+
+    committed_path = repo / "loopx" / "canary" / "planner.py"
+    committed_path.parent.mkdir(parents=True)
+    committed_path.write_text("# committed canary planner change\n", encoding="utf-8")
+    _run_git(repo, "add", "loopx/canary/planner.py")
+    _run_git(repo, "commit", "-m", "committed canary planner")
+
+    unstaged_path = repo / "examples" / "catalog-canary-planner-smoke.py"
+    unstaged_path.parent.mkdir(parents=True)
+    unstaged_path.write_text("# tracked catalog canary smoke change\n", encoding="utf-8")
+    _run_git(repo, "add", "examples/catalog-canary-planner-smoke.py")
+    _run_git(repo, "commit", "-m", "tracked catalog canary smoke")
+
+    staged_path = repo / "loopx" / "cli_commands" / "canary.py"
+    staged_path.parent.mkdir(parents=True)
+    staged_path.write_text("# staged cli canary change\n", encoding="utf-8")
+    _run_git(repo, "add", "loopx/cli_commands/canary.py")
+
+    unstaged_path.write_text("# unstaged catalog canary smoke change\n", encoding="utf-8")
+
+    untracked_path = repo / "docs" / "new-catalog-canary-note.md"
+    untracked_path.parent.mkdir(parents=True)
+    untracked_path.write_text("# untracked catalog canary note\n", encoding="utf-8")
+    return repo, base_ref
+
+
+def assert_git_diff_selector_covers_pr_and_worktree_changes(tmp_dir: Path) -> None:
+    repo, base_ref = _make_git_diff_selector_repo(tmp_dir)
+    assert _run_git(repo, "diff", "--name-only", "--cached").stdout.splitlines() == [
+        "loopx/cli_commands/canary.py",
+    ]
+    assert _run_git(repo, "diff", "--name-only").stdout.splitlines() == [
+        "examples/catalog-canary-planner-smoke.py",
+    ]
+    assert _run_git(repo, "ls-files", "--others", "--exclude-standard").stdout.splitlines() == [
+        "docs/new-catalog-canary-note.md",
+    ]
+    selector = collect_git_diff_changed_files(repo_root=repo, base_ref=base_ref)
+    assert selector["ok"] is True, selector
+    assert selector["successful_sources"] == ["base", "staged", "unstaged", "untracked"], selector
+    assert selector["changed_files"] == [
+        "examples/catalog-canary-planner-smoke.py",
+        "loopx/canary/planner.py",
+        "loopx/cli_commands/canary.py",
+        "docs/new-catalog-canary-note.md",
+    ], selector
+
+    env = dict(os.environ)
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "canary",
+            "plan",
+            "--from-git-diff",
+            "--git-diff-base",
+            base_ref,
+        ],
+        cwd=repo,
+        env=env,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(completed.stdout)
+    assert payload["selector_sources"]["git_diff"]["changed_file_count"] == 4, payload
+    assert payload["selection_inputs"]["changed_files"] == selector["changed_files"], payload
+    domain_profile_ids = {profile["id"] for profile in payload["domain_profiles"]}
+    assert "catalog-canary-contract" in domain_profile_ids, payload
+    assert "benchmark-adapter-readiness" not in domain_profile_ids, payload
+    assert "python3 examples/catalog-canary-planner-smoke.py" in payload["commands"], payload
+
+
 def assert_coverage_audit_tracks_p0_p1_patterns() -> None:
     payload = build_catalog_canary_coverage_audit()
     assert payload["ok"] is True, payload
@@ -459,9 +560,13 @@ def main() -> int:
     assert_explicit_profile_can_include_deep_checks()
     assert_catalog_canary_selects_own_profile_not_benchmark()
     assert_coverage_audit_tracks_p0_p1_patterns()
-    with tempfile.TemporaryDirectory(prefix="loopx-catalog-canary-smoke-") as tmp:
+    tmp = tempfile.mkdtemp(prefix="loopx-catalog-canary-smoke-")
+    try:
         tmp_dir = Path(tmp)
         assert_coverage_audit_reports_matrix_drift(tmp_dir)
+        assert_git_diff_selector_covers_pr_and_worktree_changes(tmp_dir)
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
     assert_cli_json_plan_is_dry_run()
     assert_cli_json_coverage_audit_is_dry_run()
     print("catalog-canary-planner-smoke ok")

--- a/loopx/cli_commands/canary.py
+++ b/loopx/cli_commands/canary.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import subprocess
 from collections.abc import Callable
 from pathlib import Path
 
@@ -26,6 +27,113 @@ FormatSelector = Callable[..., str]
 AddFormat = Callable[[argparse.ArgumentParser], None]
 
 
+def _dedupe_preserving_order(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    deduped: list[str] = []
+    for value in values:
+        normalized = value.strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        deduped.append(normalized)
+    return deduped
+
+
+def _run_git_name_only(repo_root: Path, args: list[str]) -> dict[str, object]:
+    command = ["git", "-C", str(repo_root), *args]
+    completed = subprocess.run(
+        command,
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    files = [
+        line.strip()
+        for line in completed.stdout.splitlines()
+        if line.strip()
+    ]
+    return {
+        "ok": completed.returncode == 0,
+        "returncode": completed.returncode,
+        "command": command,
+        "changed_files": files,
+        "stderr_tail": completed.stderr[-800:],
+    }
+
+
+def collect_git_diff_changed_files(
+    *,
+    repo_root: Path,
+    base_ref: str = "origin/main",
+) -> dict[str, object]:
+    """Collect committed, staged, unstaged, and untracked paths for canary selection."""
+
+    base_ref = (base_ref or "origin/main").strip() or "origin/main"
+    sources = {
+        "base": _run_git_name_only(repo_root, ["diff", "--name-only", f"{base_ref}...HEAD"]),
+        "staged": _run_git_name_only(repo_root, ["diff", "--name-only", "--cached"]),
+        "unstaged": _run_git_name_only(repo_root, ["diff", "--name-only"]),
+        "untracked": _run_git_name_only(repo_root, ["ls-files", "--others", "--exclude-standard"]),
+    }
+    changed_files = _dedupe_preserving_order(
+        [
+            file
+            for source in sources.values()
+            for file in (source.get("changed_files") or [])
+            if isinstance(file, str)
+        ]
+    )
+    successful_sources = [
+        name for name, source in sources.items()
+        if source.get("ok")
+    ]
+    warnings = [
+        {
+            "source": name,
+            "returncode": source.get("returncode"),
+            "stderr_tail": source.get("stderr_tail"),
+        }
+        for name, source in sources.items()
+        if not source.get("ok")
+    ]
+    return {
+        "ok": bool(successful_sources),
+        "base_ref": base_ref,
+        "repo_root": str(repo_root),
+        "changed_files": changed_files,
+        "changed_file_count": len(changed_files),
+        "successful_sources": successful_sources,
+        "warnings": warnings,
+    }
+
+
+def _resolve_canary_changed_files(args: argparse.Namespace) -> tuple[list[str], dict[str, object] | None]:
+    changed_files = list(args.changed_file or [])
+    git_diff_selector = None
+    if bool(getattr(args, "from_git_diff", False)):
+        git_diff_selector = collect_git_diff_changed_files(
+            repo_root=Path.cwd(),
+            base_ref=str(getattr(args, "git_diff_base", "origin/main") or "origin/main"),
+        )
+        changed_files.extend(
+            file
+            for file in (git_diff_selector.get("changed_files") or [])
+            if isinstance(file, str)
+        )
+    return _dedupe_preserving_order(changed_files), git_diff_selector
+
+
+def _attach_selector_sources(
+    payload: dict[str, object],
+    *,
+    git_diff_selector: dict[str, object] | None,
+) -> None:
+    if git_diff_selector is None:
+        return
+    payload["selector_sources"] = {"git_diff": git_diff_selector}
+
+
 def _add_canary_selector_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--catalog",
@@ -37,6 +145,19 @@ def _add_canary_selector_args(parser: argparse.ArgumentParser) -> None:
         action="append",
         default=[],
         help="Changed path or glob-like surface. Repeat for multiple paths.",
+    )
+    parser.add_argument(
+        "--from-git-diff",
+        action="store_true",
+        help=(
+            "Append changed paths from git diff against --git-diff-base plus "
+            "staged, unstaged, and untracked working-tree changes."
+        ),
+    )
+    parser.add_argument(
+        "--git-diff-base",
+        default="origin/main",
+        help="Base ref for --from-git-diff committed changes. Defaults to origin/main.",
     )
     parser.add_argument(
         "--surface",
@@ -158,9 +279,10 @@ def handle_canary_command(
         payload = build_catalog_canary_profiles(catalog_path=args.catalog)
         renderer = render_catalog_canary_profiles_markdown
     elif args.canary_command == "plan":
+        changed_files, git_diff_selector = _resolve_canary_changed_files(args)
         payload = build_catalog_canary_plan(
             catalog_path=args.catalog,
-            changed_files=list(args.changed_file or []),
+            changed_files=changed_files,
             surfaces=list(args.surface or []),
             families=list(args.family or []),
             profiles=list(args.profile or []),
@@ -168,11 +290,13 @@ def handle_canary_command(
             max_checks_per_family=int(args.max_checks_per_family or 3),
             max_checks_per_profile=int(args.max_checks_per_profile or 3),
         )
+        _attach_selector_sources(payload, git_diff_selector=git_diff_selector)
         renderer = render_catalog_canary_plan_markdown
     elif args.canary_command == "run":
+        changed_files, git_diff_selector = _resolve_canary_changed_files(args)
         payload = build_catalog_canary_run(
             catalog_path=args.catalog,
-            changed_files=list(args.changed_file or []),
+            changed_files=changed_files,
             surfaces=list(args.surface or []),
             families=list(args.family or []),
             profiles=list(args.profile or []),
@@ -183,6 +307,7 @@ def handle_canary_command(
             execute=not bool(args.no_execute),
             timeout_seconds=float(args.timeout_seconds or 120.0),
         )
+        _attach_selector_sources(payload, git_diff_selector=git_diff_selector)
         renderer = render_catalog_canary_run_markdown
     elif args.canary_command == "coverage-audit":
         payload = build_catalog_canary_coverage_audit(


### PR DESCRIPTION
## Summary
- add `loopx canary plan/run --from-git-diff` with `--git-diff-base` so canary selection can consume branch, staged, unstaged, and untracked paths
- project selector provenance into JSON under `selector_sources.git_diff`
- extend the catalog canary planner smoke with a temp git repo that covers committed, staged, unstaged, and untracked changes

## Canary findings during development
- initial smoke exposed that `git diff --name-only` missed untracked files; fixed by adding `git ls-files --others --exclude-standard`
- executing `canary run --from-git-diff` exposed a flaky temp git repo cleanup path in the planner smoke; fixed with explicit best-effort cleanup

## Validation
- `python3 -m py_compile loopx/cli_commands/canary.py examples/catalog-canary-planner-smoke.py`
- `python3 examples/catalog-canary-planner-smoke.py`
- `python3 examples/catalog-canary-run-e2e-smoke.py`
- `python3 -m loopx.cli --format json canary run --from-git-diff --git-diff-base origin/main --check-limit 4 --timeout-seconds 180`
- `python3 -m loopx.cli check --scan-path loopx/cli_commands/canary.py --scan-path examples/catalog-canary-planner-smoke.py --limit 200` (passes; pre-existing duplicate index warning only)
- `git diff --check origin/main..HEAD`