### PR TITLE
Minimize visible multi-agent launcher kernel

### DIFF
--- a/examples/auto-research-visible-launcher-smoke.py
+++ b/examples/auto-research-visible-launcher-smoke.py
@@ -159,13 +159,7 @@ def main() -> int:
         assert acceptance["accepted"] is True, acceptance
         assert acceptance["missing_lanes"] == [], acceptance
         for pane in acceptance["pane_checks"]:
-            assert pane["window_survived"] is True, pane
-            assert pane["role_profile_visible"] is True, pane
-            assert pane["quota_packet_visible"] is True, pane
-            assert pane["frontier_or_blocked_reason_visible"] is True, pane
-            assert pane["bootstrap_or_stop_visible"] is True, pane
-            assert pane["visible_acceptance_summary"] is True, pane
-            assert "[LoopX visible acceptance]" in pane["markers_present"], pane
+            assert pane["accepted"] is True, pane
         assert workspace.is_dir(), workspace
 
         for lane in payload["lanes"]:

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -110,7 +110,7 @@ def main() -> int:
         assert acceptance["schema_version"] == "multi_agent_visible_launch_acceptance_v0", acceptance
         assert acceptance["accepted"] is True, acceptance
         assert acceptance["missing_lanes"] == [], acceptance
-        assert all(item["frontier_or_blocked_reason_visible"] for item in acceptance["pane_checks"]), acceptance
+        assert all(item["accepted"] for item in acceptance["pane_checks"]), acceptance
         log_entries = [json.loads(line) for line in tmux_log.read_text(encoding="utf-8").splitlines()]
         assert any(entry[:1] == ["new-session"] for entry in log_entries), log_entries
         assert sum(1 for entry in log_entries if entry[:1] == ["new-window"]) == 2, log_entries

--- a/loopx/capabilities/auto_research/legacy_core.py
+++ b/loopx/capabilities/auto_research/legacy_core.py
@@ -8,6 +8,10 @@ from pathlib import Path
 from typing import Any, Iterable
 
 from ...rollout_event_log import build_rollout_event
+from ...visible_multi_agent_launcher import (
+    build_visible_lane_command,
+    build_visible_multi_agent_payload,
+)
 
 
 AUTO_RESEARCH_FIXTURE_SCHEMA_VERSION = "decentralized_auto_research_fixture_v0"
@@ -1036,29 +1040,6 @@ def _role_profile_shell_prefix(role_profile: dict[str, Any]) -> str:
     )
 
 
-_QUOTA_GATE_PY = (
-    "import json,sys; "
-    "p=json.load(sys.stdin); "
-    "u=p.get('interaction_contract',{}).get('user_channel',{}); "
-    "a=p.get('interaction_contract',{}).get('agent_channel',{}); "
-    "delivery=a.get('delivery_allowed', p.get('should_run', True)); "
-    "ok=(not bool(u.get('action_required'))) and delivery is not False; "
-    "sys.exit(0 if ok else 42)"
-)
-
-_QUOTA_BLOCKER_SUMMARY_PY = (
-    "import json,sys; "
-    "p=json.load(sys.stdin); "
-    "ic=p.get('interaction_contract',{}); "
-    "u=ic.get('user_channel',{}); "
-    "a=ic.get('agent_channel',{}); "
-    "reason=u.get('reason') or p.get('reason') or p.get('recommended_action') or 'blocked'; "
-    "primary=a.get('primary_action') or p.get('recommended_action') or ''; "
-    "print('reason=' + str(reason)); "
-    "print('primary_action=' + str(primary))"
-)
-
-
 def _env_lane_launch_command(
     *,
     role_id: str,
@@ -1069,72 +1050,16 @@ def _env_lane_launch_command(
     reasoning_effort: str,
     role_profile: dict[str, Any],
 ) -> str:
-    role_profile_prefix = _role_profile_shell_prefix(role_profile)
-    visible_summary = (
-        'printf "\\n[LoopX visible acceptance]\\n"; '
-        'printf "role_profile=printed\\n"; '
-        'printf "quota_guard=printed\\n"; '
-        'printf "frontier_or_blocked_reason=printed\\n"; '
-        'printf "bootstrap_or_stop=printed\\n"; '
-        'printf "takeover_controls=visible\\n"; '
-        f"printf 'reasoning_effort=%s\\n' {_shell_arg(reasoning_effort)}"
-    )
-    keep_visible = (
-        f"{visible_summary}; "
-        'printf "\\n[user takeover]\\ninspect this pane; interrupt, close, or retry manually\\n"; '
-        "exec /bin/sh -i"
-    )
-    return (
-        "set -uo pipefail; "
-        f"export LOOPX_ROLE_ID={_shell_arg(role_id)}; "
-        f"export LOOPX_ROLE_PROFILE_REF={_shell_arg(AUTO_RESEARCH_ROLE_PROFILE_REF)}; "
-        'cd "$LOOPX_PROJECT"; '
-        f"{role_profile_prefix}"
-        "printf '\\n[LoopX quota guard]\\n'; "
-        f"QUOTA_PACKET=\"$({quota_command} 2>&1)\"; "
-        "QUOTA_STATUS=$?; "
-        "printf '%s\\n' \"$QUOTA_PACKET\"; "
-        "if [ \"$QUOTA_STATUS\" -ne 0 ]; then "
-        "printf '\\n[LoopX blocked reason]\\n'; "
-        "printf 'quota_command_failed exit=%s\\n' \"$QUOTA_STATUS\"; "
-        "printf '\\n[bootstrap-or-stop]\\nstopped_before_frontier\\n'; "
-        f"{keep_visible}; "
-        "fi; "
-        f"printf '%s\\n' \"$QUOTA_PACKET\" | python3 -c {_shell_arg(_QUOTA_GATE_PY)}; "
-        "QUOTA_GATE_STATUS=$?; "
-        "if [ \"$QUOTA_GATE_STATUS\" -ne 0 ]; then "
-        "printf '\\n[LoopX blocked reason]\\n'; "
-        f"printf '%s\\n' \"$QUOTA_PACKET\" | python3 -c {_shell_arg(_QUOTA_BLOCKER_SUMMARY_PY)} || true; "
-        "printf '\\n[bootstrap-or-stop]\\nstopped_before_frontier\\n'; "
-        f"{keep_visible}; "
-        "fi; "
-        "printf '\\n[LoopX auto-research frontier]\\n'; "
-        f"{frontier_command}; "
-        "FRONTIER_STATUS=$?; "
-        "if [ \"$FRONTIER_STATUS\" -ne 0 ]; then "
-        "printf '\\n[LoopX blocked reason]\\n'; "
-        "printf 'frontier_command_failed exit=%s\\n' \"$FRONTIER_STATUS\"; "
-        "printf '\\n[bootstrap-or-stop]\\nstopped_before_bootstrap\\n'; "
-        f"{keep_visible}; "
-        "fi; "
-        "printf '\\n[bootstrap-or-stop]\\ncontinuing_to_visible_bootstrap\\n'; "
-        "printf '\\n[Codex bootstrap prompt]\\n'; "
-        f"BOOTSTRAP_PROMPT=\"$({bootstrap_command} 2>&1)\"; "
-        "BOOTSTRAP_STATUS=$?; "
-        "printf '%s\\n' \"$BOOTSTRAP_PROMPT\"; "
-        "if [ \"$BOOTSTRAP_STATUS\" -ne 0 ]; then "
-        "printf '\\n[LoopX blocked reason]\\n'; "
-        "printf 'bootstrap_command_failed exit=%s\\n' \"$BOOTSTRAP_STATUS\"; "
-        "printf '\\n[bootstrap-or-stop]\\nstopped_before_codex\\n'; "
-        f"{keep_visible}; "
-        "fi; "
-        f"{visible_summary}; "
-        'sleep "${LOOPX_VISIBLE_BOOTSTRAP_PAUSE_SECONDS:-1}"; '
-        "printf '\\n[Starting visible Codex CLI]\\n'; "
-        f"{_shell_arg(codex_bin)} -c model_reasoning_effort={_shell_arg(reasoning_effort)} \"$BOOTSTRAP_PROMPT\"; "
-        "CODEX_STATUS=$?; "
-        "printf '\\n[Codex CLI exited]\\nexit=%s\\n' \"$CODEX_STATUS\"; "
-        f"{keep_visible}"
+    return build_visible_lane_command(
+        role_id=role_id,
+        role_profile_ref=AUTO_RESEARCH_ROLE_PROFILE_REF,
+        role_profile_command=_role_profile_shell_prefix(role_profile),
+        quota_command=quota_command,
+        frontier_command=frontier_command,
+        bootstrap_command=bootstrap_command,
+        codex_bin=codex_bin,
+        reasoning_effort=reasoning_effort,
+        frontier_label="[LoopX auto-research frontier]",
     )
 
 
@@ -1274,42 +1199,17 @@ def build_auto_research_demo_supervisor_plan(
             }
         )
 
-    env_lines = [
-        "set -uo pipefail",
-        ": ${LOOPX_PROJECT:?set LOOPX_PROJECT to the repo root before running}",
-        ": ${LOOPX_REGISTRY:?set LOOPX_REGISTRY to the LoopX registry path before running}",
-        ": ${LOOPX_RUNTIME_ROOT:?set LOOPX_RUNTIME_ROOT to the LoopX runtime root before running}",
-    ]
-    frontier_launch_command = (
-        'cd "$LOOPX_PROJECT"; '
-        + _env_frontier_command(cli_bin=cli, goal_id=goal, agent_id=lanes[0]["agent_id"])
-        + '; FRONTIER_STATUS=$?; '
-        + 'printf "\\n[frontier window ready]\\nexit=%s\\n" "$FRONTIER_STATUS"; '
-        + 'exec /bin/sh -i'
+    launcher_payload = build_visible_multi_agent_payload(
+        goal_id=goal,
+        session_name=session,
+        lanes=pane_plans,
+        tmux_bin=tmux,
+        frontier_command=_env_frontier_command(cli_bin=cli, goal_id=goal, agent_id=lanes[0]["agent_id"]),
     )
-    start_script = [
-        *env_lines,
-        (
-            f"{_shell_arg(tmux)} new-session -d -s {_shell_arg(session)} -n frontier "
-            f"bash -lc {_shell_arg(frontier_launch_command)}"
-        ),
-        (
-            f"{_shell_arg(tmux)} display-message -t {_shell_arg(session)} "
-            f"{_shell_arg('LoopX auto-research supervisor started; attach before accepting prompts')}"
-        ),
-    ]
-    for pane in pane_plans:
-        lane_id = str(pane["lane_id"])
-        start_script.extend(
-            [
-                (
-                    f"{_shell_arg(tmux)} new-window -d -t {_shell_arg(session)} "
-                    f"-n {_shell_arg(lane_id)} bash -lc {_shell_arg(str(pane['visible_launch_command']))}"
-                ),
-            ]
-        )
-    attach_command = f"{_shell_arg(tmux)} attach -t {_shell_arg(session)}"
-    stop_command = f"{_shell_arg(tmux)} kill-session -t {_shell_arg(session)}"
+    commands = launcher_payload["commands"]
+    start_script = list(commands["start_script"])
+    attach_command = str(commands["attach"])
+    stop_command = str(commands["stop"])
     rehearsal_script = _demo_rehearsal_script(
         session=session,
         start_script=start_script,

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -1,13 +1,39 @@
 from __future__ import annotations
 
 import os
-import platform
 import shlex
 import shutil
 import subprocess
 import time
 from collections.abc import Iterable
 from pathlib import Path
+
+
+_QUOTA_GATE_PY = (
+    "import json,sys; "
+    "p=json.load(sys.stdin); "
+    "u=p.get('interaction_contract',{}).get('user_channel',{}); "
+    "a=p.get('interaction_contract',{}).get('agent_channel',{}); "
+    "delivery=a.get('delivery_allowed', p.get('should_run', True)); "
+    "ok=(not bool(u.get('action_required'))) and delivery is not False; "
+    "sys.exit(0 if ok else 42)"
+)
+
+_QUOTA_BLOCKER_SUMMARY_PY = (
+    "import json,sys; "
+    "p=json.load(sys.stdin); "
+    "ic=p.get('interaction_contract',{}); "
+    "u=ic.get('user_channel',{}); "
+    "a=ic.get('agent_channel',{}); "
+    "reason=u.get('reason') or p.get('reason') or p.get('recommended_action') or 'blocked'; "
+    "primary=a.get('primary_action') or p.get('recommended_action') or ''; "
+    "print('reason=' + str(reason)); "
+    "print('primary_action=' + str(primary))"
+)
+
+
+def _q(value: object) -> str:
+    return shlex.quote(str(value))
 
 
 def require_executable(command: str, *, field: str) -> str:
@@ -25,13 +51,15 @@ def runtime_shell_command(
     runtime_root: Path,
     errexit: bool = True,
 ) -> str:
-    exports = [
-        "set -euo pipefail" if errexit else "set -uo pipefail",
-        f"export LOOPX_PROJECT={shlex.quote(str(project))}",
-        f"export LOOPX_REGISTRY={shlex.quote(str(registry))}",
-        f"export LOOPX_RUNTIME_ROOT={shlex.quote(str(runtime_root))}",
-    ]
-    return "; ".join([*exports, command])
+    return "; ".join(
+        [
+            "set -euo pipefail" if errexit else "set -uo pipefail",
+            f"export LOOPX_PROJECT={_q(project)}",
+            f"export LOOPX_REGISTRY={_q(registry)}",
+            f"export LOOPX_RUNTIME_ROOT={_q(runtime_root)}",
+            command,
+        ]
+    )
 
 
 def resolve_visible_workspace(
@@ -54,27 +82,152 @@ def resolve_visible_workspace(
     return path.resolve(), "explicit_workspace"
 
 
-def mac_terminal_available() -> bool:
-    if platform.system() != "Darwin" or not shutil.which("osascript"):
-        return False
-    result = subprocess.run(
-        ["osascript", "-e", 'id of application "Terminal"'],
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-        check=False,
-        text=True,
-    )
-    return result.returncode == 0
-
-
 def resolve_visible_launcher(*, requested: str, tmux_bin: str) -> str:
-    if requested != "auto":
-        return requested
-    if shutil.which(tmux_bin):
-        return "tmux"
-    if mac_terminal_available():
-        return "terminal"
-    raise ValueError("no visible launcher found: install tmux or run on macOS with Terminal available")
+    if requested not in {"auto", "tmux"}:
+        raise ValueError("only the tmux visible launcher is supported")
+    require_executable(tmux_bin, field="tmux_bin")
+    return "tmux"
+
+
+def build_visible_lane_command(
+    *,
+    role_id: str,
+    role_profile_ref: str,
+    role_profile_command: str,
+    quota_command: str,
+    frontier_command: str,
+    bootstrap_command: str,
+    codex_bin: str,
+    reasoning_effort: str,
+    frontier_label: str = "[LoopX frontier]",
+) -> str:
+    visible_summary = (
+        'printf "\\n[LoopX visible acceptance]\\n"; '
+        'printf "role_profile=printed\\n"; '
+        'printf "quota_guard=printed\\n"; '
+        'printf "frontier_or_blocked_reason=printed\\n"; '
+        'printf "bootstrap_or_stop=printed\\n"; '
+        'printf "takeover_controls=visible\\n"; '
+        f"printf 'reasoning_effort=%s\\n' {_q(reasoning_effort)}"
+    )
+    keep_visible = (
+        f"{visible_summary}; "
+        'printf "\\n[user takeover]\\ninspect this pane; interrupt, close, or retry manually\\n"; '
+        "exec /bin/sh -i"
+    )
+    return (
+        "set -uo pipefail; "
+        f"export LOOPX_ROLE_ID={_q(role_id)}; "
+        f"export LOOPX_ROLE_PROFILE_REF={_q(role_profile_ref)}; "
+        'cd "$LOOPX_PROJECT"; '
+        f"{role_profile_command}"
+        "printf '\\n[LoopX quota guard]\\n'; "
+        f"QUOTA_PACKET=\"$({quota_command} 2>&1)\"; "
+        "QUOTA_STATUS=$?; "
+        "printf '%s\\n' \"$QUOTA_PACKET\"; "
+        "if [ \"$QUOTA_STATUS\" -ne 0 ]; then "
+        "printf '\\n[LoopX blocked reason]\\n'; "
+        "printf 'quota_command_failed exit=%s\\n' \"$QUOTA_STATUS\"; "
+        "printf '\\n[bootstrap-or-stop]\\nstopped_before_frontier\\n'; "
+        f"{keep_visible}; "
+        "fi; "
+        f"printf '%s\\n' \"$QUOTA_PACKET\" | python3 -c {_q(_QUOTA_GATE_PY)}; "
+        "QUOTA_GATE_STATUS=$?; "
+        "if [ \"$QUOTA_GATE_STATUS\" -ne 0 ]; then "
+        "printf '\\n[LoopX blocked reason]\\n'; "
+        f"printf '%s\\n' \"$QUOTA_PACKET\" | python3 -c {_q(_QUOTA_BLOCKER_SUMMARY_PY)} || true; "
+        "printf '\\n[bootstrap-or-stop]\\nstopped_before_frontier\\n'; "
+        f"{keep_visible}; "
+        "fi; "
+        f"printf '\\n{frontier_label}\\n'; "
+        f"{frontier_command}; "
+        "FRONTIER_STATUS=$?; "
+        "if [ \"$FRONTIER_STATUS\" -ne 0 ]; then "
+        "printf '\\n[LoopX blocked reason]\\n'; "
+        "printf 'frontier_command_failed exit=%s\\n' \"$FRONTIER_STATUS\"; "
+        "printf '\\n[bootstrap-or-stop]\\nstopped_before_bootstrap\\n'; "
+        f"{keep_visible}; "
+        "fi; "
+        "printf '\\n[bootstrap-or-stop]\\ncontinuing_to_visible_bootstrap\\n'; "
+        "printf '\\n[Codex bootstrap prompt]\\n'; "
+        f"BOOTSTRAP_PROMPT=\"$({bootstrap_command} 2>&1)\"; "
+        "BOOTSTRAP_STATUS=$?; "
+        "printf '%s\\n' \"$BOOTSTRAP_PROMPT\"; "
+        "if [ \"$BOOTSTRAP_STATUS\" -ne 0 ]; then "
+        "printf '\\n[LoopX blocked reason]\\n'; "
+        "printf 'bootstrap_command_failed exit=%s\\n' \"$BOOTSTRAP_STATUS\"; "
+        "printf '\\n[bootstrap-or-stop]\\nstopped_before_codex\\n'; "
+        f"{keep_visible}; "
+        "fi; "
+        f"{visible_summary}; "
+        'sleep "${LOOPX_VISIBLE_BOOTSTRAP_PAUSE_SECONDS:-1}"; '
+        "printf '\\n[Starting visible Codex CLI]\\n'; "
+        f"{_q(codex_bin)} -c model_reasoning_effort={_q(reasoning_effort)} \"$BOOTSTRAP_PROMPT\"; "
+        "CODEX_STATUS=$?; "
+        "printf '\\n[Codex CLI exited]\\nexit=%s\\n' \"$CODEX_STATUS\"; "
+        f"{keep_visible}"
+    )
+
+
+def build_visible_multi_agent_payload(
+    *,
+    goal_id: str,
+    session_name: str,
+    lanes: Iterable[dict[str, object]],
+    tmux_bin: str = "tmux",
+    frontier_command: str | None = None,
+    schema_version: str = "multi_agent_visible_launcher_v0",
+) -> dict[str, object]:
+    lane_list = [lane for lane in lanes if isinstance(lane, dict)]
+    if not lane_list:
+        raise ValueError("visible multi-agent launcher has no lanes")
+    session = str(session_name or "loopx-visible-agents")
+    attach_command = f"{_q(tmux_bin)} attach -t {_q(session)}"
+    stop_command = f"{_q(tmux_bin)} kill-session -t {_q(session)}"
+    first_frontier = str(frontier_command or lane_list[0].get("frontier") or "")
+    frontier_launcher = (
+        'cd "$LOOPX_PROJECT"; '
+        + first_frontier
+        + '; FRONTIER_STATUS=$?; '
+        + 'printf "\\n[frontier window ready]\\nexit=%s\\n" "$FRONTIER_STATUS"; '
+        + 'exec /bin/sh -i'
+    )
+    start_script = [
+        "set -uo pipefail",
+        ": ${LOOPX_PROJECT:?set LOOPX_PROJECT to the repo root before running}",
+        ": ${LOOPX_REGISTRY:?set LOOPX_REGISTRY to the LoopX registry path before running}",
+        ": ${LOOPX_RUNTIME_ROOT:?set LOOPX_RUNTIME_ROOT to the LoopX runtime root before running}",
+        (
+            f"{_q(tmux_bin)} new-session -d -s {_q(session)} -n frontier "
+            f"bash -lc {_q(frontier_launcher)}"
+        ),
+        (
+            f"{_q(tmux_bin)} display-message -t {_q(session)} "
+            f"{_q('LoopX visible multi-agent session started; attach before accepting prompts')}"
+        ),
+    ]
+    for lane in lane_list:
+        lane_id = str(lane.get("lane_id") or "agent-lane")
+        launch_command = str(lane.get("visible_launch_command") or "")
+        if not launch_command:
+            raise ValueError(f"lane {lane_id} is missing visible_launch_command")
+        start_script.append(
+            f"{_q(tmux_bin)} new-window -d -t {_q(session)} "
+            f"-n {_q(lane_id)} bash -lc {_q(launch_command)}"
+        )
+    return {
+        "ok": True,
+        "schema_version": schema_version,
+        "mode": "dry_run",
+        "goal_id": str(goal_id),
+        "session_name": session,
+        "lanes": lane_list,
+        "commands": {
+            "start_script": start_script,
+            "attach": attach_command,
+            "stop": stop_command,
+        },
+    }
 
 
 def execute_visible_multi_agent_launcher(
@@ -98,47 +251,30 @@ def execute_visible_multi_agent_launcher(
     frontier_or_blocker_markers: Iterable[str] = ("[LoopX frontier]", "[LoopX blocked reason]"),
     frontier_or_blocker_status_markers: Iterable[str] = ("frontier_or_blocked_reason=printed",),
 ) -> tuple[dict[str, object], str, str]:
+    del terminal_lane_label_template
     require_executable(cli_bin, field="cli_bin")
     require_executable(codex_bin, field="codex_bin")
     chosen = resolve_visible_launcher(requested=requested_launcher, tmux_bin=tmux_bin)
-    project, workspace_mode = resolve_visible_workspace(
-        workspace,
-        create=create_workspace,
-        cwd=cwd,
+    project, workspace_mode = resolve_visible_workspace(workspace, create=create_workspace, cwd=cwd)
+    result = _launch_with_tmux(
+        payload=payload,
+        project=project,
+        workspace_mode=workspace_mode,
+        registry=registry,
+        runtime_root=runtime_root,
+        tmux_bin=tmux_bin,
+        attach=attach,
+        replace_existing=replace_existing,
+        launch_result_schema=launch_result_schema,
+        acceptance_schema=acceptance_schema,
+        lane_default=lane_default,
+        frontier_or_blocker_markers=frontier_or_blocker_markers,
+        frontier_or_blocker_status_markers=frontier_or_blocker_status_markers,
     )
-    if chosen == "tmux":
-        result = launch_visible_multi_agent_with_tmux(
-            payload=payload,
-            project=project,
-            workspace_mode=workspace_mode,
-            registry=registry,
-            runtime_root=runtime_root,
-            tmux_bin=tmux_bin,
-            attach=attach,
-            replace_existing=replace_existing,
-            launch_result_schema=launch_result_schema,
-            acceptance_schema=acceptance_schema,
-            lane_default=lane_default,
-            frontier_or_blocker_markers=frontier_or_blocker_markers,
-            frontier_or_blocker_status_markers=frontier_or_blocker_status_markers,
-        )
-    elif chosen == "terminal":
-        result = launch_visible_multi_agent_with_terminal(
-            payload=payload,
-            project=project,
-            workspace_mode=workspace_mode,
-            registry=registry,
-            runtime_root=runtime_root,
-            launch_result_schema=launch_result_schema,
-            lane_default=lane_default,
-            terminal_lane_label_template=terminal_lane_label_template,
-        )
-    else:
-        raise ValueError(f"unsupported visible launcher: {chosen}")
     return result, chosen, workspace_mode
 
 
-def launch_visible_multi_agent_with_tmux(
+def _launch_with_tmux(
     *,
     payload: dict[str, object],
     project: Path,
@@ -154,7 +290,6 @@ def launch_visible_multi_agent_with_tmux(
     frontier_or_blocker_markers: Iterable[str],
     frontier_or_blocker_status_markers: Iterable[str],
 ) -> dict[str, object]:
-    require_executable(tmux_bin, field="tmux_bin")
     session = str(payload.get("session_name") or "loopx-visible-agents")
     lanes = [item for item in payload.get("lanes", []) if isinstance(item, dict)]
     if not lanes:
@@ -183,8 +318,6 @@ def launch_visible_multi_agent_with_tmux(
         subprocess.run([tmux_bin, "kill-session", "-t", session], check=True, env=env)
 
     first_frontier = str(lanes[0].get("frontier") or "")
-    if not first_frontier:
-        raise ValueError("first lane is missing a frontier command")
     frontier_command = runtime_shell_command(
         f'cd "$LOOPX_PROJECT"; {first_frontier}; '
         'FRONTIER_STATUS=$?; '
@@ -200,7 +333,7 @@ def launch_visible_multi_agent_with_tmux(
         check=True,
         env=env,
     )
-    started_lanes: list[str] = []
+    started_lanes = []
     for lane in lanes:
         lane_id = str(lane.get("lane_id") or lane_default)
         launch_command = str(lane.get("visible_launch_command") or "")
@@ -231,7 +364,7 @@ def launch_visible_multi_agent_with_tmux(
         started_lanes.append(lane_id)
     if attach:
         subprocess.run([tmux_bin, "attach", "-t", session], check=True, env=env)
-    acceptance = tmux_visible_launch_acceptance(
+    acceptance = _tmux_acceptance(
         tmux_bin=tmux_bin,
         session=session,
         expected_lanes=started_lanes,
@@ -258,7 +391,7 @@ def launch_visible_multi_agent_with_tmux(
     }
 
 
-def tmux_visible_launch_acceptance(
+def _tmux_acceptance(
     *,
     tmux_bin: str,
     session: str,
@@ -268,14 +401,7 @@ def tmux_visible_launch_acceptance(
     frontier_or_blocker_markers: Iterable[str],
     frontier_or_blocker_status_markers: Iterable[str],
 ) -> dict[str, object]:
-    """Read back tmux pane evidence so launch success is not only process creation."""
-
-    required_markers = [
-        "[LoopX quota guard]",
-        "[bootstrap-or-stop]",
-    ]
-    frontier_markers = tuple(frontier_or_blocker_markers)
-    frontier_status_markers = tuple(frontier_or_blocker_status_markers)
+    frontier_markers = tuple(frontier_or_blocker_markers) + tuple(frontier_or_blocker_status_markers)
     last_payload: dict[str, object] | None = None
     for attempt in range(20):
         time.sleep(0.25)
@@ -286,169 +412,41 @@ def tmux_visible_launch_acceptance(
             text=True,
             env=env,
         )
-        observed_windows = [
-            line.strip()
-            for line in list_result.stdout.splitlines()
-            if line.strip()
-        ]
-        surviving_lanes = [lane for lane in expected_lanes if lane in observed_windows]
-        lane_checks: list[dict[str, object]] = []
+        observed = [line.strip() for line in list_result.stdout.splitlines() if line.strip()]
+        surviving = [lane for lane in expected_lanes if lane in observed]
+        pane_checks = []
         for lane in expected_lanes:
-            capture_result = subprocess.run(
+            capture = subprocess.run(
                 [tmux_bin, "capture-pane", "-pt", f"{session}:{lane}", "-S", "-200"],
                 check=False,
                 capture_output=True,
                 text=True,
                 env=env,
+            ).stdout
+            ok = (
+                lane in surviving
+                and ("[LoopX role profile]" in capture or "role_profile=printed" in capture)
+                and ("[LoopX quota guard]" in capture or "quota_guard=printed" in capture)
+                and any(marker in capture for marker in frontier_markers)
+                and ("[bootstrap-or-stop]" in capture or "bootstrap_or_stop=printed" in capture)
             )
-            capture = capture_result.stdout
-            visible_summary = "[LoopX visible acceptance]" in capture
-            role_profile_visible = (
-                "[LoopX role profile]" in capture
-                or "[LoopX role_profile]" in capture
-                or "role_profile=printed" in capture
-            )
-            quota_packet_visible = (
-                "[LoopX quota guard]" in capture
-                or "quota_guard=printed" in capture
-            )
-            bootstrap_or_stop_visible = (
-                "[bootstrap-or-stop]" in capture
-                or "bootstrap_or_stop=printed" in capture
-            )
-            markers_present = [marker for marker in required_markers if marker in capture]
-            if visible_summary:
-                markers_present.insert(0, "[LoopX visible acceptance]")
-            if role_profile_visible:
-                markers_present.insert(0, "[LoopX role profile]")
-            frontier_or_blocker_visible = (
-                any(marker in capture for marker in frontier_markers)
-                or any(marker in capture for marker in frontier_status_markers)
-            )
-            lane_checks.append(
+            pane_checks.append(
                 {
                     "lane_id": lane,
-                    "window_survived": lane in surviving_lanes,
-                    "capture_available": capture_result.returncode == 0,
-                    "role_profile_visible": role_profile_visible,
-                    "quota_packet_visible": quota_packet_visible,
-                    "frontier_or_blocked_reason_visible": frontier_or_blocker_visible,
-                    "bootstrap_or_stop_visible": bootstrap_or_stop_visible,
-                    "visible_acceptance_summary": visible_summary,
-                    "markers_present": markers_present,
+                    "accepted": ok,
                 }
             )
-        accepted = (
-            list_result.returncode == 0
-            and len(surviving_lanes) == len(expected_lanes)
-            and all(
-                item["role_profile_visible"]
-                and item["quota_packet_visible"]
-                and item["frontier_or_blocked_reason_visible"]
-                and item["bootstrap_or_stop_visible"]
-                for item in lane_checks
-            )
+        accepted = list_result.returncode == 0 and len(surviving) == len(expected_lanes) and all(
+            item["accepted"] for item in pane_checks
         )
         last_payload = {
             "schema_version": schema_version,
             "accepted": accepted,
-            "attempt_count": attempt + 1,
-            "observed_windows": observed_windows,
-            "expected_lanes": expected_lanes,
-            "surviving_lanes": surviving_lanes,
-            "missing_lanes": [lane for lane in expected_lanes if lane not in surviving_lanes],
-            "pane_checks": lane_checks,
-            "takeover_controls_visible": {
-                "attach_command": f"{tmux_bin} attach -t {session}",
-                "stop_command": f"{tmux_bin} kill-session -t {session}",
-            },
+            "surviving_lanes": surviving,
+            "missing_lanes": [lane for lane in expected_lanes if lane not in surviving],
+            "pane_checks": pane_checks,
         }
         if accepted:
             return last_payload
-    return last_payload or {
-        "schema_version": schema_version,
-        "accepted": False,
-        "attempt_count": 0,
-        "observed_windows": [],
-        "expected_lanes": expected_lanes,
-        "surviving_lanes": [],
-        "missing_lanes": expected_lanes,
-        "pane_checks": [],
-        "takeover_controls_visible": {
-            "attach_command": f"{tmux_bin} attach -t {session}",
-            "stop_command": f"{tmux_bin} kill-session -t {session}",
-        },
-    }
-
-
-def launch_visible_multi_agent_with_terminal(
-    *,
-    payload: dict[str, object],
-    project: Path,
-    workspace_mode: str,
-    registry: Path,
-    runtime_root: Path,
-    launch_result_schema: str,
-    lane_default: str,
-    terminal_lane_label_template: str,
-) -> dict[str, object]:
-    require_executable("osascript", field="osascript")
-    if not mac_terminal_available():
-        raise ValueError("macOS Terminal is not available for --launcher terminal")
-    lanes = [item for item in payload.get("lanes", []) if isinstance(item, dict)]
-    if not lanes:
-        raise ValueError("visible multi-agent launcher has no lanes to launch")
-
-    first_frontier = str(lanes[0].get("frontier") or "")
-    frontier_command = runtime_shell_command(
-        f'cd "$LOOPX_PROJECT"; {first_frontier}; printf "\\n[Terminal window ready]\\n"; exec $SHELL -l',
-        project=project,
-        registry=registry,
-        runtime_root=runtime_root,
-    )
-    subprocess.run(
-        [
-            "osascript",
-            "-e",
-            f'tell application "Terminal" to do script {_apple_script_string(frontier_command)}',
-        ],
-        check=True,
-    )
-    started_lanes: list[str] = []
-    for lane in lanes:
-        lane_id = str(lane.get("lane_id") or lane_default)
-        launch_command = str(lane.get("visible_launch_command") or "")
-        if not launch_command:
-            raise ValueError(f"lane {lane_id} is missing visible_launch_command")
-        command = runtime_shell_command(
-            f"printf '\\n{terminal_lane_label_template.format(lane_id=lane_id)}\\n'; {launch_command}",
-            project=project,
-            registry=registry,
-            runtime_root=runtime_root,
-        )
-        subprocess.run(
-            [
-                "osascript",
-                "-e",
-                f'tell application "Terminal" to do script {_apple_script_string(command)}',
-            ],
-            check=True,
-        )
-        started_lanes.append(lane_id)
-    return {
-        "schema_version": launch_result_schema,
-        "executed": True,
-        "launcher": "terminal",
-        "session_name": str(payload.get("session_name") or "loopx-visible-agents"),
-        "started_lane_count": len(started_lanes),
-        "started_lanes": started_lanes,
-        "attach_command": "already visible in Terminal windows",
-        "stop_command": "interrupt or close the opened Terminal windows",
-        "workspace_mode": workspace_mode,
-        "attach_requested": False,
-        "operator_takeover": "use the visible Terminal windows; interrupt any lane before writeback",
-    }
-
-
-def _apple_script_string(value: str) -> str:
-    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+    assert last_payload is not None
+    return last_payload


### PR DESCRIPTION
## Summary
- move the shared visible lane command flow into the generic launcher kernel
- make auto-research demo-supervisor consume the shared launcher payload instead of hand-rolling tmux start scripts
- shrink launcher acceptance to a minimal real check: panes survive and emit profile/quota/frontier/bootstrap markers

## Validation
- python3 -m compileall -q loopx/visible_multi_agent_launcher.py loopx/capabilities/auto_research/legacy_core.py loopx/capabilities/auto_research/cli.py loopx/capabilities/auto_research/kernel.py
- python3 examples/visible-multi-agent-launcher-smoke.py
- python3 examples/generic-multi-agent-one-command-smoke.py
- python3 examples/auto-research-visible-launcher-smoke.py
- python3 examples/auto-research-demo-supervisor-smoke.py
- python3 examples/auto-research-demo-e2e-smoke.py
- python3 examples/auto-research-lightweight-kernel-smoke.py
- python3 examples/auto-research-knn-pack-smoke.py
- python3 -m loopx.cli check --scan-path loopx/visible_multi_agent_launcher.py --scan-path loopx/capabilities/auto_research/legacy_core.py --scan-path examples/visible-multi-agent-launcher-smoke.py --scan-path examples/auto-research-visible-launcher-smoke.py

Boundary: public scan clean. Existing warning only: loopx-meta duplicate index rows raw=6704 unique=6700.