### PR TITLE
Require verifier preflight for SkillsBench app goal

### DIFF
--- a/examples/skillsbench-task-source-preflight-smoke.py
+++ b/examples/skillsbench-task-source-preflight-smoke.py
@@ -23,12 +23,16 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
 )
 
 
-def _write_task(root: Path, relative: str) -> None:
+def _write_task(root: Path, relative: str, *, verifier_text: str = "") -> None:
     task = root / relative
     dockerfile = task / "environment" / "Dockerfile"
     dockerfile.parent.mkdir(parents=True, exist_ok=True)
     dockerfile.write_text("FROM scratch\n", encoding="utf-8")
     (task / "task.toml").write_text('version = "1.1"\n', encoding="utf-8")
+    if verifier_text:
+        verifier = task / "verifier" / "test.sh"
+        verifier.parent.mkdir(parents=True, exist_ok=True)
+        verifier.write_text(verifier_text, encoding="utf-8")
 
 
 def test_sanity_task_source_fails_before_runner_spend() -> None:
@@ -106,6 +110,84 @@ def test_sanity_task_source_fails_before_runner_spend() -> None:
         )
 
 
+def test_reverse_tunnel_app_goal_defaults_verifier_bootstrap_fail_fast() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-verifier-preflight-") as tmp:
+        root = Path(tmp)
+        skillsbench_root = root / "skillsbench"
+        _write_task(
+            skillsbench_root,
+            "tasks/verifier-network-bootstrap",
+            verifier_text=(
+                "#!/usr/bin/env bash\n"
+                "curl -LsSf https://astral.sh/uv/install.sh | sh\n"
+            ),
+        )
+
+        jobs = root / "jobs"
+        ledger = root / "ledger.json"
+        args = [
+            "--task-id",
+            "verifier-network-bootstrap",
+            "--route",
+            "codex-app-server-goal-baseline",
+            "--skillsbench-root",
+            str(skillsbench_root),
+            "--jobs-dir",
+            str(jobs),
+            "--job-name",
+            "skillsbench-verifier-bootstrap-preflight",
+            "--run-group-id",
+            "skillsbench-verifier-bootstrap-preflight",
+            "--ledger-path",
+            str(ledger),
+            "--update-ledger",
+            "--host-local-acp-launch",
+            "--remote-command-file-bridge-ready",
+        ]
+        parsed = parse_args(args)
+        assert parsed.fail_fast_on_verifier_bootstrap_risk is True
+        assert parsed.verifier_bootstrap_fail_fast_defaulted is True
+        plan = build_plan(parsed)
+        preflight = plan["task_setup_preflight"]
+        assert preflight["status"] == "verifier_bootstrap_risk_detected", preflight
+        assert preflight["bootstrap_light_candidate_eligible"] is False, preflight
+        assert "verifier_bootstrap_risk_detected" in preflight[
+            "bootstrap_light_blocking_fields"
+        ], preflight
+        assert plan["bootstrap_light_candidate_required"] is True, plan
+        assert plan["fail_fast_on_verifier_bootstrap_risk"] is True, plan
+        assert plan["verifier_bootstrap_fail_fast_defaulted"] is True, plan
+
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            rc = skillsbench_automation_loop_main(args)
+
+        assert rc == 0, stderr.getvalue()
+        compact_path = (
+            jobs
+            / "skillsbench-verifier-bootstrap-preflight"
+            / "verifier-network-bootstrap__codex_app_server_goal"
+            / "benchmark_run.compact.json"
+        )
+        compact = json.loads(compact_path.read_text(encoding="utf-8"))
+        assert compact["first_blocker"] == (
+            "skillsbench_verifier_bootstrap_risk_preflight_blocked"
+        )
+        assert compact["score_failure_attribution"] == (
+            "skillsbench_verifier_bootstrap_risk_preflight_blocked"
+        )
+        assert compact["task_setup_preflight"][
+            "bootstrap_light_candidate_eligible"
+        ] is False
+        assert "verifier_bootstrap_risk_detected" in compact[
+            "task_setup_preflight"
+        ]["bootstrap_light_blocking_fields"]
+        assert compact["task_staging"]["verifier_bootstrap_risk_preflight_blocked"] is True
+        assert compact["runner_config"]["fail_fast_on_verifier_bootstrap_risk"] is True
+        assert compact["runner_config"]["verifier_bootstrap_fail_fast_defaulted"] is True
+
+
 if __name__ == "__main__":
     test_sanity_task_source_fails_before_runner_spend()
+    test_reverse_tunnel_app_goal_defaults_verifier_bootstrap_fail_fast()
     print("skillsbench-task-source-preflight-smoke ok")

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -2452,6 +2452,7 @@ def _compact_benchmark_task_staging(value: Any) -> dict[str, Any]:
         "verifier_uv_bootstrap_mirror_patch_required",
         "verifier_uv_bootstrap_mirror_patch_applied",
         "verifier_bootstrap_risk_preflight_blocked",
+        "verifier_bootstrap_fail_fast_defaulted",
         "app_skills_mount_patch_applied",
         "codex_acp_runtime_tools_patch_applied",
         "task_skills_removed",
@@ -2516,6 +2517,7 @@ def _compact_benchmark_task_setup_preflight(value: Any) -> dict[str, Any]:
         "alternate_source_supported_by_runner",
         "task_source_path_recorded",
         "task_source_content_recorded",
+        "bootstrap_light_candidate_eligible",
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
@@ -2537,6 +2539,12 @@ def _compact_benchmark_task_setup_preflight(value: Any) -> dict[str, Any]:
     )
     if verifier_risk_categories:
         compact["verifier_bootstrap_risk_categories"] = verifier_risk_categories
+    bootstrap_light_blocking_fields = public_safe_compact_list(
+        value.get("bootstrap_light_blocking_fields"),
+        limit=MAX_BENCHMARK_RUN_LIST_ITEMS,
+    )
+    if bootstrap_light_blocking_fields:
+        compact["bootstrap_light_blocking_fields"] = bootstrap_light_blocking_fields
     return compact
 
 

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -1214,6 +1214,18 @@ def _codex_api_egress_resolved_mode(args: argparse.Namespace | None) -> str:
     return requested
 
 
+def _formal_app_server_goal_bootstrap_light_guard_required(
+    args: argparse.Namespace | None,
+) -> bool:
+    return bool(
+        args is not None
+        and getattr(args, "route", "") == "codex-app-server-goal-baseline"
+        and getattr(args, "host_local_acp_launch", False)
+        and not getattr(args, "reduce_only", False)
+        and _codex_api_egress_resolved_mode(args) == "reverse-tunnel"
+    )
+
+
 def _codex_api_reverse_tunnel_proxy(args: argparse.Namespace | None) -> tuple[str, str]:
     explicit = ""
     if args is not None:
@@ -4981,6 +4993,7 @@ def _public_task_staging(value: Any) -> dict[str, Any]:
         "verifier_uv_bootstrap_mirror_patch_required",
         "verifier_uv_bootstrap_mirror_patch_applied",
         "verifier_bootstrap_risk_preflight_blocked",
+        "verifier_bootstrap_fail_fast_defaulted",
         "codex_acp_runtime_tools_patch_applied",
         "task_skills_removed",
         "original_task_mutated",
@@ -5135,6 +5148,7 @@ def _public_task_setup_preflight(value: Any) -> dict[str, Any]:
         "alternate_source_supported_by_runner",
         "task_source_path_recorded",
         "task_source_content_recorded",
+        "bootstrap_light_candidate_eligible",
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
@@ -5142,7 +5156,11 @@ def _public_task_setup_preflight(value: Any) -> dict[str, Any]:
         raw = value.get(field)
         if isinstance(raw, str) and raw:
             compact[field] = raw[:180]
-    for field in ("nearest_canonical_task_ids", "verifier_bootstrap_risk_categories"):
+    for field in (
+        "nearest_canonical_task_ids",
+        "verifier_bootstrap_risk_categories",
+        "bootstrap_light_blocking_fields",
+    ):
         raw_items = value.get(field)
         if isinstance(raw_items, list):
             compact[field] = [
@@ -5555,6 +5573,30 @@ def _skillsbench_public_task_label(value: Any, *, limit: int = 120) -> str:
     return label[:limit]
 
 
+SKILLSBENCH_BOOTSTRAP_LIGHT_BLOCKING_PREFLIGHT_FIELDS = (
+    "apt_setup_risk_detected",
+    "apt_retry_patch_required",
+    "dockerfile_pip_install_risk_detected",
+    "dockerfile_pip_bootstrap_patch_required",
+    "verifier_bootstrap_risk_detected",
+    "verifier_uv_bootstrap_risk_detected",
+    "verifier_external_download_risk_detected",
+    "verifier_package_install_risk_detected",
+)
+
+
+def skillsbench_bootstrap_light_blocking_fields(
+    preflight: dict[str, Any],
+) -> list[str]:
+    if preflight.get("canonical_task_present") is False:
+        return ["canonical_task_present"]
+    return [
+        field
+        for field in SKILLSBENCH_BOOTSTRAP_LIGHT_BLOCKING_PREFLIGHT_FIELDS
+        if preflight.get(field) is True
+    ]
+
+
 def skillsbench_task_setup_preflight(
     *,
     task_path: Path,
@@ -5585,6 +5627,8 @@ def skillsbench_task_setup_preflight(
         "verifier_external_download_risk_detected": False,
         "verifier_package_install_risk_detected": False,
         "verifier_bootstrap_risk_categories": [],
+        "bootstrap_light_candidate_eligible": False,
+        "bootstrap_light_blocking_fields": [],
     }
     skillsbench_root = expanded_task_path.parent.parent
     canonical_task_exists = expanded_task_path.is_dir()
@@ -5621,9 +5665,13 @@ def skillsbench_task_setup_preflight(
                 ),
             }
         )
+        preflight["bootstrap_light_blocking_fields"] = (
+            skillsbench_bootstrap_light_blocking_fields(preflight)
+        )
         return preflight
     if sandbox != "docker":
         preflight["status"] = "not_applicable"
+        preflight["bootstrap_light_candidate_eligible"] = True
         return preflight
 
     dockerfile = expanded_task_path / "environment" / "Dockerfile"
@@ -5631,6 +5679,7 @@ def skillsbench_task_setup_preflight(
     preflight["dockerfile_present"] = dockerfile_exists
     if not dockerfile_exists:
         preflight["status"] = "no_dockerfile"
+        preflight["bootstrap_light_candidate_eligible"] = True
         return preflight
 
     apt_risk = dockerfile_needs_apt_retry_patch(dockerfile)
@@ -5648,6 +5697,15 @@ def skillsbench_task_setup_preflight(
         setup_status = "verifier_bootstrap_risk_detected"
     else:
         setup_status = "ok"
+    risk_fields = skillsbench_bootstrap_light_blocking_fields(
+        {
+            **preflight,
+            "apt_setup_risk_detected": apt_risk,
+            "apt_retry_patch_required": apt_risk,
+            "dockerfile_pip_install_risk_detected": pip_risk,
+            "dockerfile_pip_bootstrap_patch_required": pip_risk,
+        }
+    )
     preflight.update(
         {
             "status": setup_status,
@@ -5655,10 +5713,12 @@ def skillsbench_task_setup_preflight(
             "apt_retry_patch_required": apt_risk,
             "dockerfile_pip_install_risk_detected": pip_risk,
             "dockerfile_pip_bootstrap_patch_required": pip_risk,
+            "bootstrap_light_candidate_eligible": not risk_fields,
+            "bootstrap_light_blocking_fields": risk_fields,
             "selection_recommendation": (
                 "route_to_setup_repair_or_use_fail_fast_guard"
-                if apt_risk or pip_risk or verifier_bootstrap_risk
-                else "eligible_for_full_pair"
+                if risk_fields
+                else "eligible_for_bootstrap_light_full_pair"
             ),
         }
     )
@@ -6276,6 +6336,15 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         ),
         "include_task_skills": bool(args.include_task_skills),
         "host_local_acp_launch": bool(args.host_local_acp_launch),
+        "bootstrap_light_candidate_required": bool(
+            _formal_app_server_goal_bootstrap_light_guard_required(args)
+        ),
+        "fail_fast_on_verifier_bootstrap_risk": bool(
+            args.fail_fast_on_verifier_bootstrap_risk
+        ),
+        "verifier_bootstrap_fail_fast_defaulted": bool(
+            getattr(args, "verifier_bootstrap_fail_fast_defaulted", False)
+        ),
         "remote_command_file_bridge_ready": bool(
             remote_command_file_bridge_materialized
         ),
@@ -6681,7 +6750,13 @@ def _public_runner_config(plan: dict[str, Any]) -> dict[str, Any]:
         value = plan.get(field)
         if isinstance(value, int) and not isinstance(value, bool):
             config[field] = value
-    for field in ("include_task_skills", "host_local_acp_launch"):
+    for field in (
+        "include_task_skills",
+        "host_local_acp_launch",
+        "bootstrap_light_candidate_required",
+        "fail_fast_on_verifier_bootstrap_risk",
+        "verifier_bootstrap_fail_fast_defaulted",
+    ):
         value = plan.get(field)
         if isinstance(value, bool):
             config[field] = value
@@ -12109,6 +12184,7 @@ def _build_runner_exception_closeout_payload(
 
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
+    raw_argv = list(argv)
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--task-id", default="react-performance-debugging")
     parser.add_argument(
@@ -12617,7 +12693,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "setup-preflight failure instead of spending a full case attempt."
         ),
     )
-    args = parser.parse_args(argv)
+    verifier_fail_fast_explicit = "--fail-fast-on-verifier-bootstrap-risk" in raw_argv
+    args = parser.parse_args(raw_argv)
+    args.verifier_bootstrap_fail_fast_defaulted = False
+    if (
+        _formal_app_server_goal_bootstrap_light_guard_required(args)
+        and not args.fail_fast_on_verifier_bootstrap_risk
+    ):
+        args.fail_fast_on_verifier_bootstrap_risk = True
+        args.verifier_bootstrap_fail_fast_defaulted = not verifier_fail_fast_explicit
     if args.parallel_cases < 1:
         parser.error("--parallel-cases must be >= 1")
     batch_task_ids = _split_task_ids_arg(args.task_ids)
@@ -12706,6 +12790,9 @@ async def async_main(
         if isinstance(staging, dict):
             staging["verifier_bootstrap_risk_detected"] = True
             staging["verifier_bootstrap_risk_preflight_blocked"] = True
+            staging["verifier_bootstrap_fail_fast_defaulted"] = bool(
+                getattr(args, "verifier_bootstrap_fail_fast_defaulted", False)
+            )
         raise SkillsBenchSetupPreflightBlocked(
             "skillsbench verifier bootstrap risk preflight blocked: "
             "verifier dependency bootstrap risk detected before full case run"


### PR DESCRIPTION
## Summary
- default formal codex-app-server-goal-baseline reverse-tunnel runs to fail fast on verifier bootstrap risk
- expose bootstrap-light candidate eligibility and blocking fields in runner/reducer compact output
- add a focused SkillsBench preflight smoke covering verifier bootstrap quarantine before a full case attempt

## Validation
- python3 examples/skillsbench-task-source-preflight-smoke.py
- python3 examples/skillsbench-goal-start-product-mode-route-smoke.py
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-task-source-preflight-smoke.py loopx/status.py
- git diff --check
- loopx check --scan-path scripts/skillsbench_automation_loop.py --scan-path loopx/status.py --scan-path examples/skillsbench-task-source-preflight-smoke.py