### PR TITLE
Keep install canaries off release promotion checks

### DIFF
--- a/examples/catalog-canary-planner-smoke.py
+++ b/examples/catalog-canary-planner-smoke.py
@@ -354,6 +354,20 @@ def assert_catalog_canary_selects_own_profile_not_benchmark() -> None:
     assert "python3 examples/catalog-canary-run-e2e-smoke.py" in commands, payload
 
 
+def assert_install_update_does_not_select_release_promotion() -> None:
+    payload = build_catalog_canary_plan(
+        changed_files=["loopx/doctor.py", "examples/install-local-smoke.py"],
+        max_checks_per_profile=3,
+    )
+    domain_profiles = {profile["id"]: profile for profile in payload["domain_profiles"]}
+    assert "install-update" in domain_profiles, payload
+    assert "release-promotion" not in domain_profiles, payload
+    commands = payload["commands"]
+    assert "python3 examples/install-local-smoke.py" in commands, payload
+    assert "python3 examples/loopx-update-smoke.py" in commands, payload
+    assert all("canary-promotion-readiness-smoke.py" not in command for command in commands), payload
+
+
 def _run_git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         ["git", "-C", str(repo), *args],
@@ -559,6 +573,7 @@ def main() -> int:
     assert_pr_release_and_refactor_profiles_select()
     assert_explicit_profile_can_include_deep_checks()
     assert_catalog_canary_selects_own_profile_not_benchmark()
+    assert_install_update_does_not_select_release_promotion()
     assert_coverage_audit_tracks_p0_p1_patterns()
     tmp = tempfile.mkdtemp(prefix="loopx-catalog-canary-smoke-")
     try:

--- a/examples/catalog-canary-run-e2e-smoke.py
+++ b/examples/catalog-canary-run-e2e-smoke.py
@@ -61,6 +61,24 @@ def assert_profile_fixture_executes() -> None:
     assert result["profile_id"] == "control-plane-refactor", result
 
 
+def assert_install_update_preview_stays_dashboard_free() -> None:
+    payload = build_catalog_canary_run(
+        changed_files=["loopx/doctor.py", "examples/install-local-smoke.py"],
+        max_checks_per_profile=3,
+        check_limit=4,
+        execute=False,
+    )
+    assert payload["ok"] is True, payload
+    profile_ids = {profile["id"] for profile in payload["domain_profiles"]}
+    assert "install-update" in profile_ids, payload
+    assert "release-promotion" not in profile_ids, payload
+    commands = [check["command"] for check in payload["selected_checks"]]
+    assert "python3 examples/install-local-smoke.py" in commands, payload
+    assert "python3 examples/loopx-update-smoke.py" in commands, payload
+    assert all("canary-promotion-readiness-smoke.py" not in command for command in commands), payload
+    assert all("dashboard-demo-readiness-smoke.py" not in command for command in commands), payload
+
+
 def assert_domain_checks_precede_family_checks() -> None:
     payload = build_catalog_canary_run(
         changed_files=["loopx/policies/monitor_todo.py"],
@@ -120,6 +138,7 @@ def main() -> int:
     assert_release_readiness_gets_no_write_argument()
     assert_preview_does_not_execute_or_write()
     assert_profile_fixture_executes()
+    assert_install_update_preview_stays_dashboard_free()
     assert_domain_checks_precede_family_checks()
     assert_cli_run_executes_catalog_selected_check()
     print("catalog-canary-run-e2e-smoke ok")

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -209,7 +209,13 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
         "title": "Release promotion readiness",
         "purpose": "Check whether the release/canary promotion path is ready without mutating the install.",
         "catalog_families": ["Work Routing", "Planning Governance", "State And Boundary"],
-        "trigger_hints": ("release", "promotion", "canary-promotion", "install", "upgrade"),
+        "trigger_hints": (
+            "release",
+            "release promotion",
+            "promotion",
+            "canary-promotion",
+            "promotion-readiness",
+        ),
         "checks": [
             {
                 "command": "python3 examples/canary-promotion-readiness-smoke.py",


### PR DESCRIPTION
## Summary
- remove generic install/upgrade selectors from the release-promotion canary profile
- keep install/update file changes routed to the install-update profile
- add planner and runner smokes that assert install canaries stay dashboard/promotion-readiness free

## Motivation
Catalog canary `--from-git-diff` previously selected both `install-update` and `release-promotion` for install-local/doctor changes because `release-promotion` matched the generic `install` hint. That could make Python/install canaries fail on missing `apps/dashboard` npm dependencies even when dashboard checks were not requested.

## Validation
- `python3 examples/catalog-canary-planner-smoke.py`
- `python3 examples/catalog-canary-run-e2e-smoke.py`
- `python3 -m py_compile loopx/canary/planner.py examples/catalog-canary-planner-smoke.py examples/catalog-canary-run-e2e-smoke.py`
- `python3 -m loopx.cli --format json canary run --changed-file loopx/doctor.py --changed-file examples/install-local-smoke.py --max-checks-per-profile 3 --check-limit 4 --timeout-seconds 180` (install-update 3/3)
- `python3 -m loopx.cli --format json canary run --from-git-diff --git-diff-base origin/main --max-checks-per-profile 3 --check-limit 4 --timeout-seconds 180` (catalog-canary-contract 2/2)
- `python3 -m loopx.cli check --scan-path loopx/canary/planner.py --scan-path examples/catalog-canary-planner-smoke.py --scan-path examples/catalog-canary-run-e2e-smoke.py --limit 200` (passes; pre-existing duplicate-index warning only)
- `git diff --check origin/main...HEAD && git diff --check`

## Notes
This does not weaken explicit release promotion checks: `--profile release-promotion`, release/promotion selectors, and canary-promotion selectors still choose the release-promotion profile.
