### PR TITLE
Make auto-research playbook worker-local

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -339,11 +339,14 @@ The reusable skills have intentionally narrow jobs:
 
 | Skill | Use it for | Do not use it for |
 | --- | --- | --- |
-| `loopx-auto-research` | Running role-scoped auto-research lanes after LoopX has projected a role profile, frontier item, demo pane, or evidence/promotion task. | Assigning identity, bypassing quota/gates, acting as a leader agent, or selecting/promoting the whole research graph. |
 | `loopx-project` | Connecting projects, reading status/quota/history, diagnosing LoopX, generating heartbeat/review packets, and refreshing state. | Reading private project documents by default or replacing the CLI as source of truth. |
 | `loopx-pr-review` | Running `/loopx-pr-review`, preserving the `loopx pr-review` packet, and guiding per-PR five-block reviews. | Approving, commenting on, merging, self-merging, or admin-bypassing a PR. |
 | `loopx-doc-registry` | Registering durable project material and redacted authority-source metadata. | Copying raw doc bodies, internal URLs, or private comments into public repo docs. |
 | `loopx-self-repair` | Repairing surprising control-plane behavior, stale projection, tiny turns, or contradictory guard payloads. | Lowering gates, guessing around missing authority, or committing private runtime state. |
+
+Auto-research role guidance is worker-local: the visible worker launcher owns
+the `loopx-auto-research` playbook after it has projected a role profile,
+quota packet, and frontier item. It is not installed as a global LoopX skill.
 
 Keep three layers separate:
 
@@ -377,8 +380,7 @@ the pieces you intend to drop:
 
 ```bash
 rm -f ~/.local/bin/loopx ~/.local/bin/loopx-canary
-rm -rf ~/.codex/skills/loopx-auto-research \
-       ~/.codex/skills/loopx-project \
+rm -rf ~/.codex/skills/loopx-project \
        ~/.codex/skills/loopx-pr-review \
        ~/.codex/skills/loopx-doc-registry \
        ~/.codex/skills/loopx-self-repair

--- a/docs/reference/protocols/auto-research-role-profile-v0.md
+++ b/docs/reference/protocols/auto-research-role-profile-v0.md
@@ -5,7 +5,7 @@ who it is before it loads any role-specific playbook. It bridges three existing
 surfaces:
 
 - the shared LoopX control plane, which grants identity and authority;
-- role-aware skills, which define how to act inside a phase;
+- worker-local role playbooks, which define how to act inside a phase;
 - repository or workspace `AGENTS.md`, which defines long-lived local rules.
 
 The contract exists because Arbor and LoopX use skills differently. Arbor can
@@ -19,12 +19,12 @@ state rather than something inferred from a skill name or pane title.
 | Surface | Owns | Does not own |
 | --- | --- | --- |
 | LoopX control plane | `agent_id`, `role_id`, claim, capability token, phase, write boundary, gate state, and stop condition. | The detailed reasoning checklist for an implementation phase. |
-| Role-aware skill | Commands, checklists, artifact schema reminders, review prompts, and phase-specific failure modes. | Authority to write, promote, merge, publish, or bypass gates. |
+| Worker-local role playbook | Commands, checklists, artifact schema reminders, review prompts, and phase-specific failure modes. | Authority to write, promote, merge, publish, or bypass gates. |
 | `AGENTS.md` | Repository-local and workspace-local rules such as private boundary, PR hygiene, first-screen review, protected paths, and local launch policy. | Dynamic role assignment or current frontier selection. |
 | Host launcher | Visible panes, environment variables, attach/stop controls, and takeover affordances. | Research truth, promotion decisions, or hidden scheduling authority. |
 
-This split keeps skills useful without letting them become a second source of
-identity. A worker can load the same `loopx-auto-research` skill in different
+This split keeps playbooks useful without letting them become a second source of
+identity. A worker can load the same `loopx-auto-research` playbook in different
 roles, but the profile tells it which section applies and which writes are
 allowed.
 
@@ -119,10 +119,9 @@ Future roles such as gate steward, synthesis narrator, and frontier janitor are
 split candidates, not required v0 panes. They should be introduced only when
 evidence from the demo shows that a transition duty needs a separate owner.
 
-## Skill Strategy
+## Worker-Local Playbook Strategy
 
-Start with one installed `loopx-auto-research` skill that contains role
-sections:
+Use one worker-local `loopx-auto-research` playbook that contains role sections:
 
 - `Research curator`
 - `Hypothesis mapper`
@@ -130,14 +129,15 @@ sections:
 - `Evidence verifier`
 - `Visible takeover and stop controls`
 
-This keeps trigger routing simple while the protocol settles. Split into
-role-specific skills only after a visible run shows repeated confusion that a
-single role-routed skill cannot prevent. The split decision should cite evidence
+This keeps each visible worker aligned without exposing auto-research as a
+global LoopX skill for ordinary project agents. Split into role-specific
+worker playbooks only after a visible run shows repeated confusion that a single
+role-routed playbook cannot prevent. The split decision should cite evidence
 such as wrong section loading, unauthorized writes, hidden negative evidence, or
 missed stop conditions.
 
-The skill body should not invent current work. Its first command should tell
-the agent to read the profile and run the quota/frontier command named by the
+The playbook body should not invent current work. Its first command should tell
+the worker to read the profile and run the quota/frontier command named by the
 profile. This mirrors Arbor's useful "load a checklist at the exact phase"
 behavior while preserving LoopX's decentralized identity model.
 

--- a/examples/auto-research-demo-acceptance-smoke.py
+++ b/examples/auto-research-demo-acceptance-smoke.py
@@ -83,6 +83,7 @@ def assert_acceptance_packet(payload: dict[str, Any]) -> None:
         assert lane["role_id"] != "missing_role", lane
         assert lane["phase"] != "missing_phase", lane
         assert lane["required_skill"] == "loopx-auto-research", lane
+        assert lane["skill_distribution"] == "worker_local", lane
         assert lane["quota_guard_visible"] is True, lane
         assert lane["frontier_visible"] is True, lane
         assert lane["bootstrap_visible"] is True, lane

--- a/examples/auto-research-demo-supervisor-smoke.py
+++ b/examples/auto-research-demo-supervisor-smoke.py
@@ -93,6 +93,8 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
         assert profile["lane_id"] == lane["lane_id"], profile
         assert profile["role_id"] == lane["role_id"], profile
         assert profile["required_skill"] == "loopx-auto-research", profile
+        assert profile["skill_distribution"] == "worker_local", profile
+        assert profile["worker_skill_source"].endswith("auto_research/worker_skill/SKILL.md"), profile
         assert profile["phase"], profile
         assert profile["allowed_actions"], profile
         assert profile["skill_section"], profile
@@ -283,7 +285,9 @@ def main() -> int:
     assert "## Role Profiles" in markdown, markdown
     assert "loopx-auto-research" in markdown, markdown
     assert "## Lane Timeline" in markdown, markdown
-    assert "required_skill: `loopx-auto-research`" in markdown, markdown
+    assert "required_worker_playbook: `loopx-auto-research`" in markdown, markdown
+    assert "skill_distribution: `worker_local`" in markdown, markdown
+    assert "worker_skill_source: `loopx/capabilities/auto_research/worker_skill/SKILL.md`" in markdown, markdown
     assert "`role_profile` via `role_profile`" in markdown, markdown
     assert "`quota_guard` via `quota_guard`" in markdown, markdown
     assert "## One-Click Dry Run" in markdown, markdown

--- a/examples/auto-research-skill-contract-smoke.py
+++ b/examples/auto-research-skill-contract-smoke.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Smoke-test the installed loopx-auto-research skill contract."""
+"""Smoke-test the worker-local loopx-auto-research playbook contract."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ sys.path.insert(0, str(ROOT))
 from loopx.doctor import REQUIRED_INSTALLED_SKILL_PHRASES  # noqa: E402
 
 
-SKILL = ROOT / "skills" / "loopx-auto-research" / "SKILL.md"
+SKILL = ROOT / "loopx" / "capabilities" / "auto_research" / "worker_skill" / "SKILL.md"
 ROLE_PROFILE = ROOT / "docs" / "reference" / "protocols" / "auto-research-role-profile-v0.md"
 ROLE_STATE_MACHINE = ROOT / "docs" / "reference" / "protocols" / "auto-research-role-state-machine-v0.md"
 LANE_CONTRACT = ROOT / "docs" / "reference" / "protocols" / "auto-research-lane-contract-v1.md"
@@ -56,11 +56,12 @@ def main() -> int:
         "auto-research skill contract",
     )
 
-    for phrase in REQUIRED_INSTALLED_SKILL_PHRASES["loopx-auto-research"]:
-        assert phrase in compact_skill, f"doctor phrase missing from skill: {phrase!r}"
+    assert "loopx-auto-research" not in REQUIRED_INSTALLED_SKILL_PHRASES
 
     required_skill_terms = [
         "name: loopx-auto-research",
+        "worker-local role playbook",
+        "not a global LoopX skill",
         "Identity comes from LoopX control-plane metadata",
         "auto_research_role_profile_v0",
         'loopx --format json auto-research frontier --goal-id "$LOOPX_GOAL_ID" --agent-id "$LOOPX_AGENT_ID"',
@@ -96,11 +97,15 @@ def main() -> int:
         assert term.lower() not in lowered, f"skill drifted into forbidden term {term!r}"
 
     assert "required_skill\": \"loopx-auto-research\"" in role_profile, role_profile
-    assert "Start with one installed `loopx-auto-research` skill" in role_profile, role_profile
+    assert "worker-local" in role_profile, role_profile
     assert "auto_research_role_profile_v0" in role_state_machine, role_state_machine
     assert "product_narrator" in lane_contract, lane_contract
-    assert "`loopx-auto-research` | Running role-scoped auto-research lanes" in getting_started, getting_started
-    assert "~/.codex/skills/loopx-auto-research" in getting_started, getting_started
+    assert (
+        "`loopx-auto-research` | Running role-scoped auto-research lanes"
+        not in getting_started
+    ), getting_started
+    assert "worker-local" in getting_started, getting_started
+    assert "~/.codex/skills/loopx-auto-research" not in getting_started, getting_started
 
     print("auto-research-skill-contract-smoke ok")
     return 0

--- a/examples/auto-research-visible-launcher-smoke.py
+++ b/examples/auto-research-visible-launcher-smoke.py
@@ -170,12 +170,17 @@ def main() -> int:
             assert profile["schema_version"] == "auto_research_role_profile_v0", profile
             assert profile["role_id"] == lane["role_id"], profile
             assert profile["required_skill"] == "loopx-auto-research", profile
+            assert profile["skill_distribution"] == "worker_local", profile
+            assert profile["worker_skill_source"].endswith(
+                "auto_research/worker_skill/SKILL.md"
+            ), profile
             assert profile["write_scope"], profile
             assert profile["protected_scope"], profile
             assert profile["stop_conditions"], profile
             command = lane["visible_launch_command"]
             assert profile["schema_version"] == "auto_research_role_profile_v0", profile
             assert profile["required_skill"] == "loopx-auto-research", profile
+            assert profile["skill_distribution"] == "worker_local", profile
             assert profile["agent_id"] == lane["agent_id"], profile
             assert profile["lane_id"] == lane["lane_id"], profile
             assert profile["stop_conditions"], profile

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -122,7 +122,6 @@ def main() -> int:
             f"- legacy command disabled: {bin_dir / 'goal-harness-canary.legacy-disabled'}"
             in install.stdout
         ), install.stdout
-        assert f"- skill: {codex_home / 'skills' / 'loopx-auto-research'}" in install.stdout, install.stdout
         assert f"- skill: {codex_home / 'skills' / 'loopx-doc-registry'}" in install.stdout, install.stdout
         assert f"- skill: {codex_home / 'skills' / 'loopx-pr-review'}" in install.stdout, install.stdout
         assert f"- skill: {codex_home / 'skills' / 'loopx-project'}" in install.stdout, install.stdout
@@ -203,17 +202,7 @@ def main() -> int:
         ):
             assert phrase in pr_review_text, phrase
         auto_research_skill = codex_home / "skills" / "loopx-auto-research" / "SKILL.md"
-        auto_research_text = " ".join(auto_research_skill.read_text(encoding="utf-8").split())
-        for phrase in (
-            "Identity comes from LoopX control-plane metadata",
-            'loopx --format json auto-research frontier --goal-id "$LOOPX_GOAL_ID" --agent-id "$LOOPX_AGENT_ID"',
-            "No role owns the full graph",
-            "Do not infer role from pane title",
-            "auto_research_role_profile_v0",
-            "Projection Narrator",
-            "Control-Plane Guard",
-        ):
-            assert phrase in auto_research_text, phrase
+        assert not auto_research_skill.exists(), auto_research_skill
         doc_registry_skill = codex_home / "skills" / "loopx-doc-registry" / "SKILL.md"
         doc_registry_text = " ".join(doc_registry_skill.read_text(encoding="utf-8").split())
         for phrase in (
@@ -297,8 +286,7 @@ def main() -> int:
         assert doctor_payload["skill"]["path"] == str(skill), doctor_payload
         assert doctor_payload["skill"]["exists"] is True, doctor_payload
         assert doctor_payload["skill"]["delivery_hints"] is True, doctor_payload
-        assert doctor_payload["skills"]["loopx-auto-research"]["exists"] is True, doctor_payload
-        assert doctor_payload["skills"]["loopx-auto-research"]["required_phrases"] is True, doctor_payload
+        assert "loopx-auto-research" not in doctor_payload["skills"], doctor_payload
         assert doctor_payload["skills"]["loopx-project"]["exists"] is True, doctor_payload
         assert doctor_payload["skills"]["loopx-project"]["required_phrases"] is True, doctor_payload
         assert doctor_payload["skills"]["loopx-pr-review"]["exists"] is True, doctor_payload
@@ -349,7 +337,7 @@ def main() -> int:
         assert "installed_skill_delivery_hints: `True`" in doctor_markdown, doctor_markdown
         assert (
             "installed_required_skills: "
-            "`loopx-auto-research,loopx-doc-registry,loopx-pr-review,loopx-project,loopx-self-repair`"
+            "`loopx-doc-registry,loopx-pr-review,loopx-project,loopx-self-repair`"
             in doctor_markdown
         ), doctor_markdown
         assert "loopx_canary_realpath:" in doctor_markdown, doctor_markdown
@@ -385,7 +373,6 @@ def main() -> int:
             release_root=root / "releases" / "20260101T000000Z",
             repo_root=REPO_ROOT,
             skills={
-                "loopx-auto-research": {"exists": True, "required_phrases": True},
                 "loopx-project": {"exists": True, "required_phrases": True},
                 "loopx-pr-review": {"exists": True, "required_phrases": True},
                 "loopx-doc-registry": {"exists": True, "required_phrases": True},
@@ -403,7 +390,6 @@ def main() -> int:
             release_root=root / "releases" / "20260108T000000Z",
             repo_root=REPO_ROOT,
             skills={
-                "loopx-auto-research": {"exists": True, "required_phrases": True},
                 "loopx-project": {"exists": True, "required_phrases": True},
                 "loopx-pr-review": {"exists": True, "required_phrases": True},
                 "loopx-doc-registry": {"exists": True, "required_phrases": True},
@@ -419,7 +405,6 @@ def main() -> int:
             release_root=root / "releases" / "20260108T000000Z",
             repo_root=REPO_ROOT,
             skills={
-                "loopx-auto-research": {"exists": True, "required_phrases": True},
                 "loopx-project": {"exists": True, "required_phrases": True},
                 "loopx-pr-review": {"exists": True, "required_phrases": True},
                 "loopx-doc-registry": {"exists": True, "required_phrases": True},

--- a/loopx/capabilities/auto_research/legacy_core.py
+++ b/loopx/capabilities/auto_research/legacy_core.py
@@ -939,7 +939,7 @@ def _auto_research_codex_bootstrap_prompt(
     return "\n".join(
         [
             "You are a visible LoopX auto-research lane, not a generic LoopX heartbeat worker.",
-            "Use skills in this order: loopx-project for quota/status, then loopx-auto-research for this role.",
+            "Use loopx-project for quota/status, then follow the worker-local loopx-auto-research role playbook for this pane.",
             "This pane is a visible LoopX polling turn: before each new action, rerun the printed quota should-run and auto-research frontier commands, then follow their interaction_contract.",
             "Do not run loopx bootstrap-command-pack, loopx heartbeat-prompt, or generic onboarding unless the printed frontier explicitly asks for it.",
             "If a future scheduled automation owns this lane, it must use a generated LoopX heartbeat/polling prompt; this visible bootstrap is the local manual polling prompt.",
@@ -1007,7 +1007,9 @@ def _role_profile_for_lane(*, goal_id: str, lane: dict[str, str]) -> dict[str, A
         "write_scope": list(template["write_scope"]),
         "protected_scope": list(template["protected_scope"]),
         "required_skill": AUTO_RESEARCH_REQUIRED_SKILL,
+        "skill_distribution": "worker_local",
         "skill_section": template["skill_section"],
+        "worker_skill_source": "loopx/capabilities/auto_research/worker_skill/SKILL.md",
         "agents_overlay": ["workspace/AGENTS.md"],
         "stop_conditions": list(template["stop_conditions"]),
         "takeover_controls": [
@@ -1022,7 +1024,7 @@ def _role_profile_for_lane(*, goal_id: str, lane: dict[str, str]) -> dict[str, A
             "quota_should_run",
             "auto_research_frontier",
             "AGENTS.md",
-            "loopx-auto-research skill section",
+            "worker-local loopx-auto-research playbook section",
         ],
         "pane_title_is_authority": False,
     }
@@ -1486,6 +1488,11 @@ def build_auto_research_demo_acceptance_packet(
                 (lane.get("role_profile") or {}).get("required_skill") if isinstance(lane.get("role_profile"), dict) else None,
                 field="acceptance.required_skill",
                 default="missing_skill",
+            ),
+            "skill_distribution": _compact_optional_token(
+                (lane.get("role_profile") or {}).get("skill_distribution") if isinstance(lane.get("role_profile"), dict) else None,
+                field="acceptance.skill_distribution",
+                default="missing_distribution",
             ),
             "quota_guard_visible": _command_available(lane.get("quota_guard")),
             "frontier_visible": _command_available(lane.get("frontier")),
@@ -3601,7 +3608,7 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
                 continue
             profile = item.get("role_profile") if isinstance(item.get("role_profile"), dict) else {}
             lines.append(
-                f"- `{profile.get('role_id')}`: skill `{profile.get('required_skill')}` / "
+                f"- `{profile.get('role_id')}`: worker playbook `{profile.get('required_skill')}` / "
                 f"section `{profile.get('skill_section')}` / phase `{profile.get('phase')}`"
             )
         lines.extend(["", "## Role Profiles", ""])
@@ -3614,7 +3621,9 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
             lines.append(f"### {item.get('lane_id')}")
             lines.append(f"- role_id: `{profile.get('role_id')}`")
             lines.append(f"- phase: `{profile.get('phase')}`")
-            lines.append(f"- required_skill: `{profile.get('required_skill')}`")
+            lines.append(f"- required_worker_playbook: `{profile.get('required_skill')}`")
+            lines.append(f"- skill_distribution: `{profile.get('skill_distribution')}`")
+            lines.append(f"- worker_skill_source: `{profile.get('worker_skill_source')}`")
             lines.append(f"- skill_section: `{profile.get('skill_section')}`")
             lines.append(
                 "- allowed_actions: `"

--- a/loopx/capabilities/auto_research/worker_skill/SKILL.md
+++ b/loopx/capabilities/auto_research/worker_skill/SKILL.md
@@ -5,6 +5,10 @@ description: Use when a LoopX worker is operating an auto-research lane, demo pa
 
 # LoopX Auto Research
 
+This is a worker-local role playbook for auto-research panes. It is packaged
+with the auto-research capability and should be injected or referenced by the
+worker launcher; it is not a global LoopX skill for ordinary project agents.
+
 ## Routing Boundary
 
 Use this skill after a LoopX auto-research worker has a role profile,

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -29,13 +29,6 @@ NO_CLONE_UPGRADE_COMMAND = (
 )
 RELEASE_ID_TIMESTAMP_RE = re.compile(r"^\d{8}T\d{6}Z$")
 REQUIRED_INSTALLED_SKILL_PHRASES = {
-    "loopx-auto-research": (
-        "Identity comes from LoopX control-plane metadata",
-        'loopx --format json auto-research frontier --goal-id "$LOOPX_GOAL_ID" --agent-id "$LOOPX_AGENT_ID"',
-        "No role owns the full graph",
-        "Do not infer role from pane title",
-        "auto_research_role_profile_v0",
-    ),
     "loopx-project": (
         "--classification <PUBLIC_SAFE_PROGRESS_CLASSIFICATION>",
         "--delivery-batch-scale multi_surface",


### PR DESCRIPTION
## Summary
- Move the auto-research role playbook out of the globally installed `skills/` tree into the auto-research capability as worker-local material.
- Remove `loopx-auto-research` from doctor/install required global skill checks and install smoke expectations.
- Mark auto-research role profiles and acceptance packets with `skill_distribution=worker_local` and document the boundary.

## Validation
- python3 -m compileall -q loopx/doctor.py loopx/capabilities/auto_research/legacy_core.py loopx/capabilities/auto_research/cli.py
- python3 examples/auto-research-skill-contract-smoke.py
- python3 examples/install-local-smoke.py
- python3 examples/codex-cli-packaged-install-smoke.py
- python3 examples/fresh-clone-quickstart-smoke.py
- python3 examples/auto-research-visible-launcher-smoke.py
- python3 examples/auto-research-demo-supervisor-smoke.py
- python3 examples/auto-research-demo-acceptance-smoke.py
- python3 -m loopx.cli check --scan-path loopx/doctor.py --scan-path loopx/capabilities/auto_research/legacy_core.py --scan-path loopx/capabilities/auto_research/worker_skill/SKILL.md --scan-path examples/auto-research-skill-contract-smoke.py --scan-path examples/install-local-smoke.py --scan-path examples/auto-research-visible-launcher-smoke.py --scan-path examples/auto-research-demo-supervisor-smoke.py --scan-path examples/auto-research-demo-acceptance-smoke.py --scan-path docs/reference/protocols/auto-research-role-profile-v0.md --scan-path docs/guides/getting-started.md

LoopX check warning is the pre-existing duplicate loopx-meta history index rows; public boundary scan is clean.
