### PR TITLE
Preserve release snapshot source provenance

### DIFF
--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -19,15 +19,32 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.doctor import add_promotion_readiness_freshness, build_install_freshness  # noqa: E402
+from loopx.release_manifest import build_release_manifest, load_release_manifest  # noqa: E402
 
 
-def git_output(args: list[str]) -> str:
-    return subprocess.run(
+def git_output(args: list[str]) -> str | None:
+    result = subprocess.run(
         ["git", "-C", str(REPO_ROOT), *args],
-        check=True,
+        check=False,
         capture_output=True,
         text=True,
-    ).stdout.strip()
+    )
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip() or None
+
+
+def source_git_commit(root: Path = REPO_ROOT) -> str:
+    if root == REPO_ROOT:
+        commit = git_output(["rev-parse", "HEAD"])
+        if commit:
+            return commit
+    release_manifest = load_release_manifest(root)
+    manifest = release_manifest.get("manifest") if isinstance(release_manifest, dict) else None
+    source = manifest.get("source") if isinstance(manifest, dict) else None
+    commit = source.get("git_commit") if isinstance(source, dict) else None
+    assert isinstance(commit, str) and commit, release_manifest
+    return commit
 
 
 def run_install(env: dict[str, str], release_id: str) -> subprocess.CompletedProcess[str]:
@@ -66,6 +83,48 @@ def write_promotion_readiness(
     return readiness_record
 
 
+def assert_release_snapshot_source_fallback(root: Path) -> None:
+    source_root = root / "source-snapshot"
+    release_root = root / "nested-release"
+    source_root.mkdir()
+    release_root.mkdir()
+    source_manifest = {
+        "schema_version": "loopx_release_manifest_v0",
+        "release_id": "fixture-source",
+        "source": {
+            "kind": "github_archive",
+            "repo": "huangruiteng/loopx",
+            "ref": "main",
+            "git_commit": "abc123def4567890abc123def4567890abc123de",
+            "git_ref": "main",
+            "git_dirty": False,
+            "archive_url": "https://example.com/loopx.tar.gz",
+            "archive_sha256": "f" * 64,
+        },
+        "package": {"name": "loopx", "version": "0.1.2"},
+        "skills": {"digest": "fixture", "items": {}},
+    }
+    (source_root / "release.json").write_text(
+        json.dumps(source_manifest, indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    nested_manifest = build_release_manifest(
+        release_root=release_root,
+        release_id="fixture-nested",
+        source_root=source_root,
+        installed_at="2026-01-01T00:00:00Z",
+    )
+    assert nested_manifest["source"]["git_commit"] == source_manifest["source"]["git_commit"], nested_manifest
+    assert nested_manifest["source"]["git_ref"] == source_manifest["source"]["git_ref"], nested_manifest
+    assert nested_manifest["source"]["git_dirty"] is False, nested_manifest
+    assert nested_manifest["source"]["kind"] == "github_archive", nested_manifest
+    assert nested_manifest["source"]["repo"] == source_manifest["source"]["repo"], nested_manifest
+    assert nested_manifest["source"]["ref"] == source_manifest["source"]["ref"], nested_manifest
+    assert nested_manifest["source"]["archive_url"] == source_manifest["source"]["archive_url"], nested_manifest
+    assert nested_manifest["source"]["archive_sha256"] == source_manifest["source"]["archive_sha256"], nested_manifest
+
+
 def main() -> int:
     with tempfile.TemporaryDirectory(prefix="loopx-install-smoke-") as tmp:
         root = Path(tmp)
@@ -93,6 +152,7 @@ def main() -> int:
         (bin_dir / "goal-harness-canary").symlink_to(legacy_canary)
         codex_home = home / ".codex"
         profile = home / ".zshrc"
+        assert_release_snapshot_source_fallback(root)
         env = {
             **os.environ,
             "HOME": str(home),
@@ -103,7 +163,7 @@ def main() -> int:
             "PATH": os.environ.get("PATH", ""),
             "SHELL": "/bin/zsh",
         }
-        source_commit = git_output(["rev-parse", "HEAD"])
+        source_commit = source_git_commit()
 
         install = run_install(env, "install-smoke-initial")
         assert "loopx installed locally" in install.stdout, install.stdout

--- a/loopx/release_manifest.py
+++ b/loopx/release_manifest.py
@@ -94,6 +94,70 @@ def _git_metadata(source_root: Path | None) -> dict[str, Any]:
     }
 
 
+def _manifest_source_metadata(source_root: Path | None) -> dict[str, Any]:
+    if source_root is None:
+        return {
+            "git_commit": None,
+            "git_ref": None,
+            "git_dirty": None,
+            "kind": None,
+            "repo": None,
+            "ref": None,
+            "archive_url": None,
+            "archive_sha256": None,
+        }
+    manifest_path = source_root.expanduser() / RELEASE_MANIFEST_FILENAME
+    try:
+        manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {
+            "git_commit": None,
+            "git_ref": None,
+            "git_dirty": None,
+            "kind": None,
+            "repo": None,
+            "ref": None,
+            "archive_url": None,
+            "archive_sha256": None,
+        }
+    source = manifest.get("source") if isinstance(manifest, dict) else None
+    if not isinstance(source, dict):
+        return {
+            "git_commit": None,
+            "git_ref": None,
+            "git_dirty": None,
+            "kind": None,
+            "repo": None,
+            "ref": None,
+            "archive_url": None,
+            "archive_sha256": None,
+        }
+    return {
+        "git_commit": source.get("git_commit"),
+        "git_ref": source.get("git_ref") or source.get("ref"),
+        "git_dirty": source.get("git_dirty"),
+        "kind": source.get("kind"),
+        "repo": source.get("repo"),
+        "ref": source.get("ref"),
+        "archive_url": source.get("archive_url"),
+        "archive_sha256": source.get("archive_sha256"),
+    }
+
+
+def _source_metadata(source_root: Path | None) -> dict[str, Any]:
+    git_metadata = _git_metadata(source_root)
+    if any(git_metadata.get(key) is not None for key in ("git_commit", "git_ref", "git_dirty")):
+        return {
+            **git_metadata,
+            "kind": None,
+            "repo": None,
+            "ref": None,
+            "archive_url": None,
+            "archive_sha256": None,
+        }
+    return _manifest_source_metadata(source_root)
+
+
 def build_release_manifest(
     *,
     release_root: Path,
@@ -103,12 +167,12 @@ def build_release_manifest(
     env: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     source_env = env or os.environ
-    archive_url = source_env.get("LOOPX_ARCHIVE_URL")
-    archive_sha256 = source_env.get("LOOPX_ARCHIVE_SHA256")
-    repo = source_env.get("LOOPX_REPO")
-    ref = source_env.get("LOOPX_REF")
-    source_kind = "github_archive" if archive_url else "local_checkout"
-    git_metadata = _git_metadata(source_root)
+    source_metadata = _source_metadata(source_root)
+    archive_url = source_env.get("LOOPX_ARCHIVE_URL") or source_metadata.get("archive_url")
+    archive_sha256 = source_env.get("LOOPX_ARCHIVE_SHA256") or source_metadata.get("archive_sha256")
+    repo = source_env.get("LOOPX_REPO") or source_metadata.get("repo")
+    ref = source_env.get("LOOPX_REF") or source_metadata.get("ref")
+    source_kind = "github_archive" if archive_url else (source_metadata.get("kind") or "local_checkout")
     skills_root = release_root / "skills"
     skills: dict[str, Any] = {}
     if skills_root.exists():
@@ -129,9 +193,9 @@ def build_release_manifest(
             "kind": source_kind,
             "repo": repo,
             "ref": ref,
-            "git_commit": git_metadata["git_commit"],
-            "git_ref": git_metadata["git_ref"],
-            "git_dirty": git_metadata["git_dirty"],
+            "git_commit": source_metadata["git_commit"],
+            "git_ref": source_metadata["git_ref"],
+            "git_dirty": source_metadata["git_dirty"],
             "archive_url": archive_url,
             "archive_sha256": archive_sha256,
         },


### PR DESCRIPTION
## Summary
- preserve source provenance when building a release manifest from an existing release snapshot that has release.json but no .git directory
- update install-local smoke to read the expected source commit from release.json when git metadata is unavailable
- add a release-snapshot fixture assertion so catalog release-promotion canaries catch this path

## Validation
- python3 -m py_compile loopx/release_manifest.py examples/install-local-smoke.py
- python3 examples/install-local-smoke.py
- release-snapshot fixture: copied the checkout without .git, wrote release.json, then ran python3 examples/install-local-smoke.py from the snapshot
- PYTHONPATH=. python3 -m loopx.cli canary run --format json --profile catalog-canary-contract --profile release-promotion --check-limit 4 --timeout-seconds 90
- python3 examples/canary-promotion-readiness-smoke.py --no-write-evidence
- loopx canary coverage-audit --format json
- loopx check --scan-path loopx/release_manifest.py --scan-path examples/install-local-smoke.py --limit 200
- git diff --check

## Notes
- Complements PR #983: selector isolation keeps install/update canaries from accidentally selecting release-promotion; this PR fixes the explicit release-promotion snapshot provenance path.