### PR TITLE
Harden SkillsBench bootstrap-light preflight

### DIFF
--- a/examples/skillsbench-task-source-preflight-smoke.py
+++ b/examples/skillsbench-task-source-preflight-smoke.py
@@ -35,6 +35,35 @@ def _write_task(root: Path, relative: str, *, verifier_text: str = "") -> None:
         verifier.write_text(verifier_text, encoding="utf-8")
 
 
+def _app_goal_args(
+    *,
+    task_id: str,
+    skillsbench_root: Path,
+    jobs: Path,
+    ledger: Path,
+    job_name: str,
+) -> list[str]:
+    return [
+        "--task-id",
+        task_id,
+        "--route",
+        "codex-app-server-goal-baseline",
+        "--skillsbench-root",
+        str(skillsbench_root),
+        "--jobs-dir",
+        str(jobs),
+        "--job-name",
+        job_name,
+        "--run-group-id",
+        job_name,
+        "--ledger-path",
+        str(ledger),
+        "--update-ledger",
+        "--host-local-acp-launch",
+        "--remote-command-file-bridge-ready",
+    ]
+
+
 def test_sanity_task_source_fails_before_runner_spend() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-task-source-") as tmp:
         root = Path(tmp)
@@ -145,8 +174,11 @@ def test_reverse_tunnel_app_goal_defaults_verifier_bootstrap_fail_fast() -> None
             "--remote-command-file-bridge-ready",
         ]
         parsed = parse_args(args)
+        assert parsed.fail_fast_on_apt_risk is True
+        assert parsed.apt_risk_fail_fast_defaulted is True
         assert parsed.fail_fast_on_verifier_bootstrap_risk is True
         assert parsed.verifier_bootstrap_fail_fast_defaulted is True
+        assert parsed.bootstrap_light_fail_fast_defaulted is True
         plan = build_plan(parsed)
         preflight = plan["task_setup_preflight"]
         assert preflight["status"] == "verifier_bootstrap_risk_detected", preflight
@@ -155,8 +187,11 @@ def test_reverse_tunnel_app_goal_defaults_verifier_bootstrap_fail_fast() -> None
             "bootstrap_light_blocking_fields"
         ], preflight
         assert plan["bootstrap_light_candidate_required"] is True, plan
+        assert plan["fail_fast_on_apt_risk"] is True, plan
+        assert plan["apt_risk_fail_fast_defaulted"] is True, plan
         assert plan["fail_fast_on_verifier_bootstrap_risk"] is True, plan
         assert plan["verifier_bootstrap_fail_fast_defaulted"] is True, plan
+        assert plan["bootstrap_light_fail_fast_defaulted"] is True, plan
 
         stderr = io.StringIO()
         with contextlib.redirect_stderr(stderr):
@@ -183,11 +218,146 @@ def test_reverse_tunnel_app_goal_defaults_verifier_bootstrap_fail_fast() -> None
             "task_setup_preflight"
         ]["bootstrap_light_blocking_fields"]
         assert compact["task_staging"]["verifier_bootstrap_risk_preflight_blocked"] is True
+        assert compact["task_staging"]["bootstrap_light_preflight_blocked"] is True
+        assert compact["task_staging"]["bootstrap_light_blocker_kind"] == "verifier"
+        assert compact["runner_config"]["fail_fast_on_apt_risk"] is True
+        assert compact["runner_config"]["apt_risk_fail_fast_defaulted"] is True
         assert compact["runner_config"]["fail_fast_on_verifier_bootstrap_risk"] is True
         assert compact["runner_config"]["verifier_bootstrap_fail_fast_defaulted"] is True
+        assert compact["runner_config"]["bootstrap_light_fail_fast_defaulted"] is True
+
+
+def test_reverse_tunnel_app_goal_defaults_apt_bootstrap_fail_fast() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-apt-bootstrap-") as tmp:
+        root = Path(tmp)
+        skillsbench_root = root / "skillsbench"
+        _write_task(skillsbench_root, "tasks/apt-bootstrap")
+        dockerfile = (
+            skillsbench_root
+            / "tasks"
+            / "apt-bootstrap"
+            / "environment"
+            / "Dockerfile"
+        )
+        dockerfile.write_text(
+            "FROM ubuntu:22.04\nRUN apt-get update && apt-get install -y curl\n",
+            encoding="utf-8",
+        )
+
+        jobs = root / "jobs"
+        ledger = root / "ledger.json"
+        args = _app_goal_args(
+            task_id="apt-bootstrap",
+            skillsbench_root=skillsbench_root,
+            jobs=jobs,
+            ledger=ledger,
+            job_name="skillsbench-apt-bootstrap-preflight",
+        )
+        parsed = parse_args(args)
+        assert parsed.fail_fast_on_apt_risk is True
+        assert parsed.apt_risk_fail_fast_defaulted is True
+        assert parsed.fail_fast_on_verifier_bootstrap_risk is True
+        assert parsed.bootstrap_light_fail_fast_defaulted is True
+        plan = build_plan(parsed)
+        preflight = plan["task_setup_preflight"]
+        assert preflight["status"] == "dockerfile_package_bootstrap_risk_detected", (
+            preflight
+        )
+        assert preflight["bootstrap_light_candidate_eligible"] is False, preflight
+        assert "apt_setup_risk_detected" in preflight[
+            "bootstrap_light_blocking_fields"
+        ], preflight
+        assert plan["bootstrap_light_candidate_required"] is True, plan
+
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            rc = skillsbench_automation_loop_main(args)
+
+        assert rc == 0, stderr.getvalue()
+        compact_path = (
+            jobs
+            / "skillsbench-apt-bootstrap-preflight"
+            / "apt-bootstrap__codex_app_server_goal"
+            / "benchmark_run.compact.json"
+        )
+        compact = json.loads(compact_path.read_text(encoding="utf-8"))
+        assert compact["first_blocker"] == (
+            "skillsbench_docker_apt_setup_risk_preflight_blocked"
+        )
+        assert compact["task_staging"]["bootstrap_light_preflight_blocked"] is True
+        assert compact["task_staging"]["bootstrap_light_blocker_kind"] == "apt"
+        assert compact["task_staging"]["apt_risk_preflight_blocked"] is True
+        assert compact["runner_config"]["fail_fast_on_apt_risk"] is True
+        assert compact["runner_config"]["apt_risk_fail_fast_defaulted"] is True
+        assert compact["runner_config"]["bootstrap_light_fail_fast_defaulted"] is True
+
+        update = load_benchmark_run_ledger(ledger)
+        case = update["benchmarks"]["skillsbench@1.1"]["cases"]["apt-bootstrap"]
+        assert case["latest_decision"]["decision"] == (
+            "baseline_setup_preflight_selection_required"
+        ), case
+        assert case["runs"][0]["repair_class"] == (
+            "skillsbench_setup_preflight_selection"
+        )
+
+
+def test_reverse_tunnel_app_goal_blocks_pip_bootstrap_light_risk() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-pip-bootstrap-") as tmp:
+        root = Path(tmp)
+        skillsbench_root = root / "skillsbench"
+        _write_task(skillsbench_root, "tasks/pip-bootstrap")
+        dockerfile = (
+            skillsbench_root
+            / "tasks"
+            / "pip-bootstrap"
+            / "environment"
+            / "Dockerfile"
+        )
+        dockerfile.write_text(
+            "FROM python:3.12-slim\nRUN python -m pip install pandas\n",
+            encoding="utf-8",
+        )
+
+        jobs = root / "jobs"
+        ledger = root / "ledger.json"
+        args = _app_goal_args(
+            task_id="pip-bootstrap",
+            skillsbench_root=skillsbench_root,
+            jobs=jobs,
+            ledger=ledger,
+            job_name="skillsbench-pip-bootstrap-preflight",
+        )
+
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            rc = skillsbench_automation_loop_main(args)
+
+        assert rc == 0, stderr.getvalue()
+        compact_path = (
+            jobs
+            / "skillsbench-pip-bootstrap-preflight"
+            / "pip-bootstrap__codex_app_server_goal"
+            / "benchmark_run.compact.json"
+        )
+        compact = json.loads(compact_path.read_text(encoding="utf-8"))
+        assert compact["first_blocker"] == (
+            "skillsbench_dockerfile_package_bootstrap_risk_preflight_blocked"
+        )
+        assert compact["task_staging"]["bootstrap_light_preflight_blocked"] is True
+        assert compact["task_staging"]["bootstrap_light_blocker_kind"] == (
+            "dockerfile_package"
+        )
+        assert compact["task_staging"][
+            "dockerfile_package_bootstrap_risk_preflight_blocked"
+        ] is True
+        assert compact["task_setup_preflight"][
+            "dockerfile_pip_bootstrap_patch_required"
+        ] is True
 
 
 if __name__ == "__main__":
     test_sanity_task_source_fails_before_runner_spend()
     test_reverse_tunnel_app_goal_defaults_verifier_bootstrap_fail_fast()
+    test_reverse_tunnel_app_goal_defaults_apt_bootstrap_fail_fast()
+    test_reverse_tunnel_app_goal_blocks_pip_bootstrap_light_risk()
     print("skillsbench-task-source-preflight-smoke ok")

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -1544,6 +1544,16 @@ def skillsbench_runner_error_attribution(error_text: str) -> tuple[str, str, lis
             "skillsbench_environment_setup_error",
         ]
     if (
+        "dockerfile package bootstrap risk preflight blocked" in text
+        or "dockerfile package bootstrap risk detected before full case run" in text
+    ):
+        label = "skillsbench_dockerfile_package_bootstrap_risk_preflight_blocked"
+        return label, label, [
+            label,
+            "skillsbench_docker_setup_preflight_blocked",
+            "skillsbench_environment_setup_error",
+        ]
+    if (
         "verifier bootstrap risk preflight blocked" in text
         or "verifier dependency bootstrap risk detected before full case run" in text
     ):

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -125,9 +125,15 @@ def _compact_task_staging(value: Any) -> dict[str, Any]:
         "include_task_skills",
         "apt_setup_risk_detected",
         "apt_retry_patch_required",
+        "dockerfile_pip_install_risk_detected",
+        "dockerfile_pip_bootstrap_patch_required",
+        "dockerfile_pip_bootstrap_patch_applied",
+        "dockerfile_package_bootstrap_risk_preflight_blocked",
         "app_skills_mount_patch_applied",
         "apt_retry_patch_applied",
         "apt_risk_preflight_blocked",
+        "bootstrap_light_preflight_blocked",
+        "bootstrap_light_fail_fast_defaulted",
         "verifier_bootstrap_risk_detected",
         "verifier_uv_bootstrap_risk_detected",
         "verifier_uv_bootstrap_mirror_patch_required",
@@ -139,10 +145,18 @@ def _compact_task_staging(value: Any) -> dict[str, Any]:
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
-    for field in ("verifier_uv_bootstrap_version", "verifier_uv_bootstrap_mirror_host"):
+    for field in (
+        "dockerfile_pip_index_host",
+        "bootstrap_light_blocker_kind",
+        "verifier_uv_bootstrap_version",
+        "verifier_uv_bootstrap_mirror_host",
+    ):
         text = _compact_text(value.get(field), limit=140)
         if text:
             compact[field] = text
+    count = value.get("bootstrap_light_blocking_field_count")
+    if isinstance(count, int) and not isinstance(count, bool) and count >= 0:
+        compact["bootstrap_light_blocking_field_count"] = count
     cap = value.get("resource_cap_patch")
     if isinstance(cap, dict):
         safe_cap: dict[str, Any] = {}
@@ -183,6 +197,8 @@ def _compact_task_setup_preflight(value: Any) -> dict[str, Any]:
         "raw_trajectory_read",
         "apt_setup_risk_detected",
         "apt_retry_patch_required",
+        "dockerfile_pip_install_risk_detected",
+        "dockerfile_pip_bootstrap_patch_required",
         "verifier_present",
         "verifier_bootstrap_risk_detected",
         "verifier_uv_bootstrap_risk_detected",
@@ -193,6 +209,7 @@ def _compact_task_setup_preflight(value: Any) -> dict[str, Any]:
         "alternate_source_supported_by_runner",
         "task_source_path_recorded",
         "task_source_content_recorded",
+        "bootstrap_light_candidate_eligible",
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
@@ -986,14 +1003,17 @@ def _repair_route(
                 "raw_task_text_required": False,
             },
         }
-    if failure_class == "skillsbench_docker_apt_setup_risk_preflight_blocked":
+    if failure_class in {
+        "skillsbench_docker_apt_setup_risk_preflight_blocked",
+        "skillsbench_dockerfile_package_bootstrap_risk_preflight_blocked",
+    }:
         return {
             "repair_priority": "P1",
             "repair_class": "skillsbench_setup_preflight_selection",
             "next_action": (
-                "select a non-apt-risk SkillsBench task for the next full "
-                "baseline/treatment pair or repair the Docker apt setup route "
-                "before rerunning this task"
+                "select a SkillsBench task without Docker package-bootstrap "
+                "setup risk for the next full baseline/treatment pair, or "
+                "repair the Docker setup route before rerunning this task"
             ),
             "repair_profile": {
                 "schema_version": "benchmark_repair_profile_v0",
@@ -1001,8 +1021,7 @@ def _repair_route(
                 "rerun_allowed_after_profile_applied": True,
                 "required_preflight": [
                     "skillsbench_task_setup_preflight",
-                    "task_staging.apt_setup_risk_detected",
-                    "task_staging.apt_risk_preflight_blocked",
+                    "task_staging.bootstrap_light_preflight_blocked",
                 ],
                 "raw_logs_required": False,
                 "raw_task_text_required": False,

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -2445,8 +2445,14 @@ def _compact_benchmark_task_staging(value: Any) -> dict[str, Any]:
         "include_task_skills",
         "apt_setup_risk_detected",
         "apt_retry_patch_required",
+        "dockerfile_pip_install_risk_detected",
+        "dockerfile_pip_bootstrap_patch_required",
+        "dockerfile_pip_bootstrap_patch_applied",
+        "dockerfile_package_bootstrap_risk_preflight_blocked",
         "apt_retry_patch_applied",
         "apt_risk_preflight_blocked",
+        "bootstrap_light_preflight_blocked",
+        "bootstrap_light_fail_fast_defaulted",
         "verifier_bootstrap_risk_detected",
         "verifier_uv_bootstrap_risk_detected",
         "verifier_uv_bootstrap_mirror_patch_required",
@@ -2460,10 +2466,18 @@ def _compact_benchmark_task_staging(value: Any) -> dict[str, Any]:
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
-    for field in ("verifier_uv_bootstrap_version", "verifier_uv_bootstrap_mirror_host"):
+    for field in (
+        "dockerfile_pip_index_host",
+        "bootstrap_light_blocker_kind",
+        "verifier_uv_bootstrap_version",
+        "verifier_uv_bootstrap_mirror_host",
+    ):
         text = public_safe_compact_text(value.get(field), limit=180)
         if text:
             compact[field] = text
+    count = value.get("bootstrap_light_blocking_field_count")
+    if isinstance(count, int) and not isinstance(count, bool) and count >= 0:
+        compact["bootstrap_light_blocking_field_count"] = count
 
     resource_cap = value.get("resource_cap_patch")
     if isinstance(resource_cap, dict):
@@ -2507,6 +2521,8 @@ def _compact_benchmark_task_setup_preflight(value: Any) -> dict[str, Any]:
         "raw_trajectory_read",
         "apt_setup_risk_detected",
         "apt_retry_patch_required",
+        "dockerfile_pip_install_risk_detected",
+        "dockerfile_pip_bootstrap_patch_required",
         "verifier_present",
         "verifier_bootstrap_risk_detected",
         "verifier_uv_bootstrap_risk_detected",

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -4985,9 +4985,12 @@ def _public_task_staging(value: Any) -> dict[str, Any]:
         "dockerfile_pip_install_risk_detected",
         "dockerfile_pip_bootstrap_patch_required",
         "dockerfile_pip_bootstrap_patch_applied",
+        "dockerfile_package_bootstrap_risk_preflight_blocked",
         "app_skills_mount_patch_applied",
         "apt_retry_patch_applied",
         "apt_risk_preflight_blocked",
+        "bootstrap_light_preflight_blocked",
+        "bootstrap_light_fail_fast_defaulted",
         "verifier_bootstrap_risk_detected",
         "verifier_uv_bootstrap_risk_detected",
         "verifier_uv_bootstrap_mirror_patch_required",
@@ -5002,12 +5005,16 @@ def _public_task_staging(value: Any) -> dict[str, Any]:
             compact[field] = value[field]
     for field in (
         "dockerfile_pip_index_host",
+        "bootstrap_light_blocker_kind",
         "verifier_uv_bootstrap_version",
         "verifier_uv_bootstrap_mirror_host",
     ):
         raw = value.get(field)
         if isinstance(raw, str) and raw:
             compact[field] = raw[:180]
+    count = value.get("bootstrap_light_blocking_field_count")
+    if isinstance(count, int) and not isinstance(count, bool) and count >= 0:
+        compact["bootstrap_light_blocking_field_count"] = count
     resource_cap = value.get("resource_cap_patch")
     if isinstance(resource_cap, dict):
         safe_cap: dict[str, Any] = {}
@@ -5138,6 +5145,8 @@ def _public_task_setup_preflight(value: Any) -> dict[str, Any]:
         "raw_trajectory_read",
         "apt_setup_risk_detected",
         "apt_retry_patch_required",
+        "dockerfile_pip_install_risk_detected",
+        "dockerfile_pip_bootstrap_patch_required",
         "verifier_present",
         "verifier_bootstrap_risk_detected",
         "verifier_uv_bootstrap_risk_detected",
@@ -5595,6 +5604,90 @@ def skillsbench_bootstrap_light_blocking_fields(
         for field in SKILLSBENCH_BOOTSTRAP_LIGHT_BLOCKING_PREFLIGHT_FIELDS
         if preflight.get(field) is True
     ]
+
+
+def _setup_preflight_public_blocking_fields(preflight: dict[str, Any]) -> list[str]:
+    raw_fields = preflight.get("bootstrap_light_blocking_fields")
+    if isinstance(raw_fields, list):
+        return [
+            field
+            for field in raw_fields
+            if isinstance(field, str)
+            and field
+            in (
+                *SKILLSBENCH_BOOTSTRAP_LIGHT_BLOCKING_PREFLIGHT_FIELDS,
+                "canonical_task_present",
+            )
+        ]
+    return skillsbench_bootstrap_light_blocking_fields(preflight)
+
+
+def _bootstrap_light_blocker_kind(blocking_fields: list[str]) -> str:
+    fields = set(blocking_fields)
+    if "canonical_task_present" in fields:
+        return "task_source"
+    if fields & {
+        "apt_setup_risk_detected",
+        "apt_retry_patch_required",
+    }:
+        return "apt"
+    if fields & {
+        "dockerfile_pip_install_risk_detected",
+        "dockerfile_pip_bootstrap_patch_required",
+    }:
+        return "dockerfile_package"
+    if fields & {
+        "verifier_bootstrap_risk_detected",
+        "verifier_uv_bootstrap_risk_detected",
+        "verifier_external_download_risk_detected",
+        "verifier_package_install_risk_detected",
+    }:
+        return "verifier"
+    return "setup"
+
+
+def _mark_bootstrap_light_preflight_blocked(
+    *,
+    staging: dict[str, Any],
+    setup_preflight: dict[str, Any],
+    blocking_fields: list[str],
+    args: argparse.Namespace,
+) -> str:
+    blocker_kind = _bootstrap_light_blocker_kind(blocking_fields)
+    staging["bootstrap_light_preflight_blocked"] = True
+    staging["bootstrap_light_blocker_kind"] = blocker_kind
+    staging["bootstrap_light_fail_fast_defaulted"] = bool(
+        getattr(args, "bootstrap_light_fail_fast_defaulted", False)
+    )
+    staging["bootstrap_light_blocking_field_count"] = len(blocking_fields)
+    if blocker_kind == "task_source":
+        staging["task_source_preflight_blocked"] = True
+    if blocker_kind in {"apt", "dockerfile_package"}:
+        staging["apt_setup_risk_detected"] = bool(
+            setup_preflight.get("apt_setup_risk_detected")
+        )
+        staging["apt_retry_patch_required"] = bool(
+            setup_preflight.get("apt_retry_patch_required")
+        )
+        staging["dockerfile_pip_install_risk_detected"] = bool(
+            setup_preflight.get("dockerfile_pip_install_risk_detected")
+        )
+        staging["dockerfile_pip_bootstrap_patch_required"] = bool(
+            setup_preflight.get("dockerfile_pip_bootstrap_patch_required")
+        )
+        if blocker_kind == "apt":
+            staging["apt_risk_preflight_blocked"] = True
+        else:
+            staging["dockerfile_package_bootstrap_risk_preflight_blocked"] = True
+    if blocker_kind == "verifier":
+        staging["verifier_bootstrap_risk_detected"] = bool(
+            setup_preflight.get("verifier_bootstrap_risk_detected")
+        )
+        staging["verifier_bootstrap_risk_preflight_blocked"] = True
+        staging["verifier_bootstrap_fail_fast_defaulted"] = bool(
+            getattr(args, "verifier_bootstrap_fail_fast_defaulted", False)
+        )
+    return blocker_kind
 
 
 def skillsbench_task_setup_preflight(
@@ -6339,11 +6432,18 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         "bootstrap_light_candidate_required": bool(
             _formal_app_server_goal_bootstrap_light_guard_required(args)
         ),
+        "fail_fast_on_apt_risk": bool(args.fail_fast_on_apt_risk),
+        "apt_risk_fail_fast_defaulted": bool(
+            getattr(args, "apt_risk_fail_fast_defaulted", False)
+        ),
         "fail_fast_on_verifier_bootstrap_risk": bool(
             args.fail_fast_on_verifier_bootstrap_risk
         ),
         "verifier_bootstrap_fail_fast_defaulted": bool(
             getattr(args, "verifier_bootstrap_fail_fast_defaulted", False)
+        ),
+        "bootstrap_light_fail_fast_defaulted": bool(
+            getattr(args, "bootstrap_light_fail_fast_defaulted", False)
         ),
         "remote_command_file_bridge_ready": bool(
             remote_command_file_bridge_materialized
@@ -6394,7 +6494,12 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
                 if setup_preflight.get("dockerfile_pip_bootstrap_patch_required")
                 else ""
             ),
+            "dockerfile_package_bootstrap_risk_preflight_blocked": False,
             "apt_risk_preflight_blocked": False,
+            "bootstrap_light_preflight_blocked": False,
+            "bootstrap_light_fail_fast_defaulted": bool(
+                getattr(args, "bootstrap_light_fail_fast_defaulted", False)
+            ),
             "verifier_bootstrap_risk_detected": bool(
                 setup_preflight.get("verifier_bootstrap_risk_detected")
             ),
@@ -6754,8 +6859,11 @@ def _public_runner_config(plan: dict[str, Any]) -> dict[str, Any]:
         "include_task_skills",
         "host_local_acp_launch",
         "bootstrap_light_candidate_required",
+        "fail_fast_on_apt_risk",
+        "apt_risk_fail_fast_defaulted",
         "fail_fast_on_verifier_bootstrap_risk",
         "verifier_bootstrap_fail_fast_defaulted",
+        "bootstrap_light_fail_fast_defaulted",
     ):
         value = plan.get(field)
         if isinstance(value, bool):
@@ -12693,15 +12801,31 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "setup-preflight failure instead of spending a full case attempt."
         ),
     )
+    apt_fail_fast_explicit = "--fail-fast-on-apt-risk" in raw_argv
     verifier_fail_fast_explicit = "--fail-fast-on-verifier-bootstrap-risk" in raw_argv
     args = parser.parse_args(raw_argv)
+    args.apt_risk_fail_fast_defaulted = False
     args.verifier_bootstrap_fail_fast_defaulted = False
+    args.bootstrap_light_fail_fast_defaulted = False
+    if (
+        _formal_app_server_goal_bootstrap_light_guard_required(args)
+        and not args.fail_fast_on_apt_risk
+    ):
+        args.fail_fast_on_apt_risk = True
+        args.apt_risk_fail_fast_defaulted = not apt_fail_fast_explicit
     if (
         _formal_app_server_goal_bootstrap_light_guard_required(args)
         and not args.fail_fast_on_verifier_bootstrap_risk
     ):
         args.fail_fast_on_verifier_bootstrap_risk = True
         args.verifier_bootstrap_fail_fast_defaulted = not verifier_fail_fast_explicit
+    args.bootstrap_light_fail_fast_defaulted = bool(
+        _formal_app_server_goal_bootstrap_light_guard_required(args)
+        and (
+            args.apt_risk_fail_fast_defaulted
+            or args.verifier_bootstrap_fail_fast_defaulted
+        )
+    )
     if args.parallel_cases < 1:
         parser.error("--parallel-cases must be >= 1")
     batch_task_ids = _split_task_ids_arg(args.task_ids)
@@ -12767,31 +12891,49 @@ async def async_main(
         if isinstance(plan.get("task_setup_preflight"), dict)
         else {}
     )
+    bootstrap_light_blocking_fields = _setup_preflight_public_blocking_fields(
+        setup_preflight
+    )
+    bootstrap_light_blocker_kind = _bootstrap_light_blocker_kind(
+        bootstrap_light_blocking_fields
+    )
     if (
-        args.fail_fast_on_apt_risk
+        (args.fail_fast_on_apt_risk or _formal_app_server_goal_bootstrap_light_guard_required(args))
         and not args.reduce_only
-        and setup_preflight.get("apt_setup_risk_detected") is True
+        and bootstrap_light_blocker_kind in {"apt", "dockerfile_package"}
     ):
         staging = plan.setdefault("task_staging", {})
         if isinstance(staging, dict):
-            staging["apt_setup_risk_detected"] = True
-            staging["apt_retry_patch_required"] = True
-            staging["apt_risk_preflight_blocked"] = True
+            bootstrap_light_blocker_kind = _mark_bootstrap_light_preflight_blocked(
+                staging=staging,
+                setup_preflight=setup_preflight,
+                blocking_fields=bootstrap_light_blocking_fields,
+                args=args,
+            )
+        if bootstrap_light_blocker_kind == "apt":
+            raise SkillsBenchSetupPreflightBlocked(
+                "skillsbench apt setup risk preflight blocked: "
+                "apt-based Docker setup risk detected before full case run"
+            )
         raise SkillsBenchSetupPreflightBlocked(
-            "skillsbench apt setup risk preflight blocked: "
-            "apt-based Docker setup risk detected before full case run"
+            "skillsbench dockerfile package bootstrap risk preflight blocked: "
+            "Dockerfile package bootstrap risk detected before full case run"
         )
     if (
-        args.fail_fast_on_verifier_bootstrap_risk
+        (
+            args.fail_fast_on_verifier_bootstrap_risk
+            or _formal_app_server_goal_bootstrap_light_guard_required(args)
+        )
         and not args.reduce_only
-        and setup_preflight.get("verifier_bootstrap_risk_detected") is True
+        and bootstrap_light_blocker_kind == "verifier"
     ):
         staging = plan.setdefault("task_staging", {})
         if isinstance(staging, dict):
-            staging["verifier_bootstrap_risk_detected"] = True
-            staging["verifier_bootstrap_risk_preflight_blocked"] = True
-            staging["verifier_bootstrap_fail_fast_defaulted"] = bool(
-                getattr(args, "verifier_bootstrap_fail_fast_defaulted", False)
+            _mark_bootstrap_light_preflight_blocked(
+                staging=staging,
+                setup_preflight=setup_preflight,
+                blocking_fields=bootstrap_light_blocking_fields,
+                args=args,
             )
         raise SkillsBenchSetupPreflightBlocked(
             "skillsbench verifier bootstrap risk preflight blocked: "
@@ -12803,6 +12945,13 @@ async def async_main(
     ):
         staging = plan.setdefault("task_staging", {})
         if isinstance(staging, dict):
+            if _formal_app_server_goal_bootstrap_light_guard_required(args):
+                _mark_bootstrap_light_preflight_blocked(
+                    staging=staging,
+                    setup_preflight=setup_preflight,
+                    blocking_fields=bootstrap_light_blocking_fields,
+                    args=args,
+                )
             staging["task_source_preflight_blocked"] = True
         raise SkillsBenchSetupPreflightBlocked(
             "skillsbench task source preflight blocked: "


### PR DESCRIPTION
## Summary
- default formal codex app-server Goal runs to fail fast on bootstrap-light apt/verifier risks before spending a full case attempt
- classify Dockerfile package bootstrap risk separately and keep bootstrap-light blocker fields in compact/status/ledger reducers
- extend the focused SkillsBench task-source preflight smoke to cover verifier, apt, and pip/package bootstrap blockers

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py loopx/benchmark_adapters/skillsbench.py loopx/benchmark_ledger.py loopx/status.py examples/skillsbench-task-source-preflight-smoke.py
- python3 examples/skillsbench-task-source-preflight-smoke.py
- git diff --check
- python3 -m loopx.cli check --scan-path scripts/skillsbench_automation_loop.py --scan-path loopx/benchmark_adapters/skillsbench.py --scan-path loopx/benchmark_ledger.py --scan-path loopx/status.py --scan-path examples/skillsbench-task-source-preflight-smoke.py --limit 200

## Notes
- No private/raw benchmark logs, credentials, local paths, or generated run artifacts are included.
- Broader examples/skillsbench-benchmark-run-smoke.py still fails on the existing artifact_refs drift; verified the same failure on current main, so it is not introduced by this branch.