### PR TITLE
Make auto-research demo use the multiround kernel

### DIFF
--- a/docs/guides/auto-research-command-path.md
+++ b/docs/guides/auto-research-command-path.md
@@ -32,14 +32,16 @@ export PATH="$HOME/.local/bin:$PATH"
 loopx doctor
 ```
 
-## 0. Prove The Deterministic Positive Replay
+## 0. Prove The Multi-Round Positive Path
 
-The fastest positive check is a deterministic replay. It proves that the
-starter pack, protected evaluator, public rollout evidence, board projection,
-and acceptance packet can all produce the expected k-NN result. It is intentionally
-fast and does not claim that live Codex lanes authored the research result.
+The fastest positive check is a lightweight multi-round research kernel. It
+tries the baseline and candidate hypotheses on dev, selects the improved
+candidate, validates it on holdout, appends public rollout evidence, and reports
+the measured gain. It is intentionally small and still does not claim that
+visible Codex lanes authored the research result unless a compact live evidence
+packet is supplied.
 
-To run the replay and open visible panes through the normal auto-research
+To run the multi-round path and open visible panes through the normal auto-research
 surface:
 
 ```bash
@@ -57,7 +59,7 @@ loopx --registry "$LOOPX_REGISTRY" \
   --attach
 ```
 
-That command is the user-facing UX for a replay-backed visible demo. Generic
+That command is the user-facing UX for a multi-round visible demo. Generic
 launcher internals stay inside LoopX; the operator does not need to know the
 module or implementation path.
 
@@ -70,7 +72,7 @@ tracking metadata never drives the visible lane frontier.
 
 If you want to inspect before opening visible Codex lanes, start with the
 read-only dry-run. It tells the operator which command will run the
-deterministic positive replay:
+multi-round positive path:
 
 ```bash
 loopx --registry "$LOOPX_REGISTRY" \
@@ -81,7 +83,7 @@ loopx --registry "$LOOPX_REGISTRY" \
   --reasoning-effort high
 ```
 
-When the dry-run looks right, run the deterministic positive replay:
+When the dry-run looks right, run the multi-round positive path:
 
 ```bash
 loopx --registry "$LOOPX_REGISTRY" \
@@ -93,12 +95,17 @@ loopx --registry "$LOOPX_REGISTRY" \
   --execute
 ```
 
-Expected deterministic replay result:
+Expected multi-round result:
 
-- `execution_kind` is `deterministic_replay`;
-- `result_source` is `generated_quickstart_pack_protected_eval_replay`;
-- `replay_result.dev_metric` is `4.0`;
-- `replay_result.holdout_metric` is `4.5`;
+- `execution_kind` is `multiround_research_kernel`;
+- `result_source` is `lightweight_multiround_kernel`;
+- `research_loop.dev_round_count` is `2`;
+- `research_loop.evidence_event_count` is `3`;
+- `research_loop.selected_hypothesis_id` is `hyp_partial_selection`;
+- `research_loop.dev_gain_over_baseline` is `3.0`;
+- `research_loop.holdout_gain_over_baseline` is `3.5`;
+- `protected_eval_result.dev_metric` is `4.0`;
+- `protected_eval_result.holdout_metric` is `4.5`;
 - dev and holdout exactness are both `true`;
 - `protected_scope_clean` is `true`;
 - the board is rollout-backed and has at least one promotion candidate;
@@ -158,7 +165,7 @@ the claim projection. To project a live holdout or promotion claim, the compact
 evidence must carry explicit public-safe `claim_authority`, such as
 `separate_heldout_live_evidence` or `owner_approval`.
 
-For a full visible demo after an explicit replay step, add the visible lane
+For a full visible demo after an explicit multi-round run, add the visible lane
 launcher:
 
 ```bash

--- a/examples/auto-research-demo-e2e-smoke.py
+++ b/examples/auto-research-demo-e2e-smoke.py
@@ -79,10 +79,13 @@ def assert_e2e_payload(
     assert payload["agent_id"] == AGENT_ID, payload
     assert payload["reasoning_effort"] == "high", payload
     assert payload["execution_kind"] in {
-        "deterministic_replay",
-        "deterministic_replay_preview",
+        "multiround_research_kernel",
+        "multiround_research_preview",
     }, payload
-    assert payload["result_source"] == "generated_quickstart_pack_protected_eval_replay", payload
+    assert payload["result_source"] in {
+        "lightweight_multiround_kernel",
+        "lightweight_multiround_kernel_preview",
+    }, payload
     live = payload["live_codex_e2e"]
     assert live["executed"] is False, payload
     assert live["claim_allowed"] is False, payload
@@ -95,16 +98,37 @@ def assert_e2e_payload(
     assert payload["public_boundary"]["credentials_recorded"] is False, payload
     assert payload["public_boundary"]["local_workspace_path_redacted"] is True, payload
     assert payload["public_boundary"]["live_codex_sessions_recorded"] is False, payload
-    replay = payload["replay_result"]
-    assert replay["executed"] is executed, payload
+    protected_eval = payload["protected_eval_result"]
+    loop = payload["research_loop"]
+    assert protected_eval["executed"] is executed, payload
+    assert loop["executed"] is executed, payload
     if executed:
-        assert replay["result_source"] == "generated_quickstart_pack_protected_eval_replay", payload
-        assert replay["status"] == "supported", payload
-        assert replay["dev_metric"] == 4.0, payload
-        assert replay["holdout_metric"] == 4.5, payload
-        assert replay["dev_exact"] is True, payload
-        assert replay["holdout_exact"] is True, payload
-        assert replay["protected_scope_clean"] is True, payload
+        assert loop["result_source"] == "knn_pack_protected_eval", payload
+        assert loop["candidate_count"] == 2, payload
+        assert loop["dev_round_count"] == 2, payload
+        assert loop["evidence_event_count"] == 3, payload
+        assert loop["selected_hypothesis_id"] == "hyp_partial_selection", payload
+        assert loop["decision"] == "validated_positive", payload
+        assert loop["baseline_metric"] == 1.0, payload
+        assert loop["dev_metric"] == 4.0, payload
+        assert loop["holdout_metric"] == 4.5, payload
+        assert loop["dev_gain_over_baseline"] == 3.0, payload
+        assert loop["holdout_gain_over_baseline"] == 3.5, payload
+        assert [item["role"] for item in loop["worker_rounds"]] == [
+            "hypothesis_mapper",
+            "evidence_runner",
+            "evidence_verifier",
+        ], payload
+        assert {item["loopx_contract"] for item in loop["worker_rounds"]} == {
+            "role_profile_quota_frontier_cli_writeback"
+        }, payload
+        assert protected_eval["result_source"] == "generated_quickstart_pack_protected_eval", payload
+        assert protected_eval["status"] == "supported", payload
+        assert protected_eval["dev_metric"] == 4.0, payload
+        assert protected_eval["holdout_metric"] == 4.5, payload
+        assert protected_eval["dev_exact"] is True, payload
+        assert protected_eval["holdout_exact"] is True, payload
+        assert protected_eval["protected_scope_clean"] is True, payload
         assert payload["append"]["appended_count"] == 3, payload
         assert payload["append"]["counts_by_kind"] == {
             "research_evidence": 2,
@@ -128,8 +152,10 @@ def assert_e2e_payload(
         assert payload["acceptance"]["claim_boundary"]["live_claim_scope"] == "dev_only", payload
         assert payload["acceptance"]["claim_boundary"]["promotion_claim_allowed"] is False, payload
     else:
-        assert replay["result_source"] == "deterministic_replay_preview", payload
-        assert replay["expected_positive_result"] == "dev=4.0x holdout=4.5x after --execute", payload
+        assert loop["result_source"] == "lightweight_multiround_kernel_preview", payload
+        assert "two dev rounds plus holdout" in loop["expected_rounds"], payload
+        assert protected_eval["result_source"] == "lightweight_multiround_kernel_preview", payload
+        assert protected_eval["expected_positive_result"] == "dev=4.0x holdout=4.5x after --execute", payload
     assert_public_safe(payload)
 
 
@@ -178,11 +204,11 @@ def main() -> int:
         )
         executed_payload = json.loads(executed.stdout)
         assert_e2e_payload(executed_payload, executed=True, tracking_goal_id=TRACKING_GOAL_ID)
-        replay_command = executed_payload["commands"]["deterministic_replay"]
-        visible_command = executed_payload["commands"]["deterministic_replay_with_visible_lanes"]
-        assert f"--goal-id {GOAL_ID}" in replay_command, replay_command
+        kernel_command = executed_payload["commands"]["multiround_kernel"]
+        visible_command = executed_payload["commands"]["multiround_kernel_with_visible_lanes"]
+        assert f"--goal-id {GOAL_ID}" in kernel_command, kernel_command
         assert f"--goal-id {GOAL_ID}" in visible_command, visible_command
-        assert f"--tracking-goal-id {TRACKING_GOAL_ID}" in replay_command, replay_command
+        assert f"--tracking-goal-id {TRACKING_GOAL_ID}" in kernel_command, kernel_command
         assert f"--tracking-goal-id {TRACKING_GOAL_ID}" in visible_command, visible_command
 
         markdown = run_cli(
@@ -197,21 +223,26 @@ def main() -> int:
             registry=registry,
             runtime_root=runtime_root,
         ).stdout
-        assert "# LoopX Auto Research Demo Replay" in markdown, markdown
-        assert "execution_kind: `deterministic_replay_preview`" in markdown, markdown
+        assert "# LoopX Auto Research Multi-Round Demo" in markdown, markdown
+        assert "execution_kind: `multiround_research_preview`" in markdown, markdown
+        assert "research_loop_executed: `False`" in markdown, markdown
+        assert "research_loop_source: `lightweight_multiround_kernel_preview`" in markdown, markdown
+        assert "research_loop_dev_rounds:" in markdown, markdown
+        assert "research_loop_evidence_events:" in markdown, markdown
         assert "frontier_goal_id: `loopx-auto-research-knn`" in markdown, markdown
         assert "tracking_goal_drives_frontier: `False`" in markdown, markdown
         assert "live_codex_e2e_claim_allowed: `False`" in markdown, markdown
         assert "live_codex_e2e_evidence_source: `not_collected_from_codex_lane_output`" in markdown, markdown
         assert "board_live_claim_scope" not in markdown, markdown
         assert "reasoning_effort: `high`" in markdown, markdown
-        assert "deterministic replay:" in markdown, markdown
+        assert "multi-round research:" in markdown, markdown
         assert_public_safe(markdown)
 
         guide = GUIDE.read_text(encoding="utf-8")
-        assert "## 0. Prove The Deterministic Positive Replay" in guide, guide
+        normalized_guide = " ".join(guide.split())
+        assert "## 0. Prove The Multi-Round Positive Path" in guide, guide
         assert "auto-research demo-e2e" in guide, guide
-        assert "does not claim that live Codex lanes authored the research result" in guide, guide
+        assert "does not claim that visible Codex lanes authored the research result" in normalized_guide, guide
         assert "--reasoning-effort high" in guide, guide
         assert "--execute" in guide, guide
         assert "--launch-visible" in guide, guide
@@ -220,9 +251,13 @@ def main() -> int:
         assert "--attach" in guide, guide
         assert "--replace-existing" in guide, guide
         assert "tmux kill-session -t loopx-auto-research" in guide, guide
-        assert "replay_result.dev_metric" in guide, guide
+        assert "research_loop.dev_round_count" in guide, guide
+        assert "research_loop.evidence_event_count" in guide, guide
+        assert "research_loop.dev_gain_over_baseline" in guide, guide
+        assert "research_loop.holdout_gain_over_baseline" in guide, guide
+        assert "protected_eval_result.dev_metric" in guide, guide
         assert "`4.0`" in guide, guide
-        assert "replay_result.holdout_metric" in guide, guide
+        assert "protected_eval_result.holdout_metric" in guide, guide
         assert "`4.5`" in guide, guide
         assert "acceptance.ready_for_real_launch" in guide, guide
         assert "live_codex_e2e.executed" in guide, guide
@@ -234,7 +269,7 @@ def main() -> int:
         assert "private artifacts" in guide, guide
         assert "credentials" in guide, guide
         assert "local absolute workspace paths" in guide, guide
-        e2e_section = guide.split("## 0. Prove The Deterministic Positive Replay", 1)[1].split(
+        e2e_section = guide.split("## 0. Prove The Multi-Round Positive Path", 1)[1].split(
             "## 1. Preview The Research Pack",
             1,
         )[0]

--- a/examples/auto-research-one-click-ux-smoke.py
+++ b/examples/auto-research-one-click-ux-smoke.py
@@ -82,6 +82,8 @@ def main() -> int:
                     "    print('frontier_or_blocked_reason=printed')",
                     "    print('[bootstrap-or-stop]')",
                     "    print('bootstrap_or_stop=printed')",
+                    "    print('worker_skill_path=.codex/skills/loopx-auto-research/SKILL.md')",
+                    "    print('loopx_agent_handshake=role_profile_quota_frontier_bootstrap')",
                     "    raise SystemExit(0)",
                     "raise SystemExit(0)",
                     "",
@@ -128,7 +130,7 @@ def main() -> int:
             assert "generic LoopX heartbeat worker" in bootstrap, lane
             assert "loopx-auto-research" in bootstrap, lane
             assert "live-codex-e2e-evidence.public.json" in bootstrap, lane
-            assert "Deterministic replay is not live Codex evidence" in bootstrap, lane
+            assert "lightweight multi-round kernel is not live Codex evidence" in bootstrap, lane
             assert "claim_allowed must remain false" in bootstrap, lane
             assert "model_reasoning_effort=high" in bootstrap, lane
             assert "model_reasoning_effort=high" in launch_command, lane
@@ -183,13 +185,20 @@ def main() -> int:
         assert route["tracking_goal_id"] == TRACKING_GOAL_ID, payload
         assert route["tracking_goal_drives_frontier"] is False, payload
         assert route["dedicated_positive_demo_frontier"] is True, payload
-        assert payload["execution_kind"] == "deterministic_replay", payload
-        assert payload["result_source"] == "generated_quickstart_pack_protected_eval_replay", payload
+        assert payload["execution_kind"] == "multiround_research_kernel", payload
+        assert payload["result_source"] == "lightweight_multiround_kernel", payload
         assert payload["reasoning_effort"] == "high", payload
-        assert payload["replay_result"]["dev_metric"] == 4.0, payload
-        assert payload["replay_result"]["holdout_metric"] == 4.5, payload
-        assert payload["replay_result"]["result_source"] == "generated_quickstart_pack_protected_eval_replay", payload
-        assert payload["replay_result"]["protected_scope_clean"] is True, payload
+        assert payload["research_loop"]["dev_round_count"] == 2, payload
+        assert payload["research_loop"]["evidence_event_count"] == 3, payload
+        assert payload["research_loop"]["dev_gain_over_baseline"] == 3.0, payload
+        assert payload["research_loop"]["holdout_gain_over_baseline"] == 3.5, payload
+        assert payload["protected_eval_result"]["dev_metric"] == 4.0, payload
+        assert payload["protected_eval_result"]["holdout_metric"] == 4.5, payload
+        assert (
+            payload["protected_eval_result"]["result_source"]
+            == "generated_quickstart_pack_protected_eval"
+        ), payload
+        assert payload["protected_eval_result"]["protected_scope_clean"] is True, payload
         assert payload["acceptance"]["ready_for_real_launch"] is True, payload
         assert payload["public_boundary"]["launches_visible_lanes"] is True, payload
         assert payload["public_boundary"]["local_workspace_path_redacted"] is True, payload
@@ -208,12 +217,15 @@ def main() -> int:
         assert launch["session_name"] == SESSION, launch
         assert launch["workspace_mode"] == "explicit_workspace", launch
         assert launch["started_lane_count"] == 3, launch
+        assert len(launch["worker_skill_materialization"]) == 3, launch
+        assert all(item["materialized"] for item in launch["worker_skill_materialization"]), launch
         assert launch["visible_acceptance"]["accepted"] is True, launch
         assert payload["live_codex_e2e"]["visible_lanes_accepted"] is True, payload
         assert workspace.is_dir(), workspace
 
         guide = GUIDE.read_text(encoding="utf-8")
-        one_command_section = guide.split("To run the replay and open visible panes", 1)[1].split(
+        normalized_guide = " ".join(guide.split())
+        one_command_section = guide.split("To run the multi-round path and open visible panes", 1)[1].split(
             "If you want to inspect before opening visible Codex lanes",
             1,
         )[0]
@@ -226,10 +238,10 @@ def main() -> int:
             "--create-workspace",
             "--attach",
             "Generic\nlauncher internals stay inside LoopX",
-            "replay-backed visible demo",
+            "multi-round visible demo",
         ]:
             assert snippet in one_command_section, snippet
-        assert "does not claim that live Codex lanes authored the research result" in guide, guide
+        assert "does not claim that visible Codex lanes authored the research result" in normalized_guide, guide
         assert "live_codex_e2e.claim_allowed" in guide, guide
         assert "visible_multi_agent_launcher" not in guide, guide
         assert "loopx/visible_multi_agent_launcher.py" not in guide, guide

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -43,6 +43,9 @@ def main() -> int:
         runtime_root = temp / "runtime"
         workspace = temp / "workspace"
         tmux_log = temp / "tmux.jsonl"
+        worker_skill = temp / "worker" / "SKILL.md"
+        worker_skill.parent.mkdir(parents=True)
+        worker_skill.write_text("# Worker-local playbook\n", encoding="utf-8")
         registry.write_text(json.dumps({"common_runtime_root": str(runtime_root)}), encoding="utf-8")
         write_executable(fake_bin / "loopx", "#!/usr/bin/env sh\nexit 0\n")
         write_executable(fake_bin / "codex", "#!/usr/bin/env sh\nexit 0\n")
@@ -82,7 +85,14 @@ def main() -> int:
                     "session_name": "loopx-visible-launcher-smoke",
                     "lanes": [
                         {"lane_id": "planner", "frontier": "true", "visible_launch_command": "true"},
-                        {"lane_id": "reviewer", "visible_launch_command": "true"},
+                        {
+                            "lane_id": "reviewer",
+                            "visible_launch_command": "true",
+                            "role_profile": {
+                                "required_skill": "loopx-auto-research",
+                                "worker_skill_source": "worker/SKILL.md",
+                            },
+                        },
                     ],
                 },
                 registry=registry,
@@ -105,6 +115,18 @@ def main() -> int:
         assert workspace_mode == "explicit_workspace", launch
         assert workspace.is_dir(), workspace
         assert launch["schema_version"] == "multi_agent_visible_launch_result_v0", launch
+        skills = launch["worker_skill_materialization"]
+        assert skills == [
+            {
+                "skill": "loopx-auto-research",
+                "source": "worker/SKILL.md",
+                "destination": ".codex/skills/loopx-auto-research/SKILL.md",
+                "materialized": True,
+            }
+        ], skills
+        assert (workspace / ".codex/skills/loopx-auto-research/SKILL.md").read_text(
+            encoding="utf-8"
+        ) == "# Worker-local playbook\n"
         assert launch["started_lanes"] == ["planner", "reviewer"], launch
         assert launch["surviving_lanes"] == ["planner", "reviewer"], launch
         acceptance = launch["visible_acceptance"]

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -324,7 +324,7 @@ def register_auto_research_commands(
     demo_e2e_parser = auto_research_sub.add_parser(
         "demo-e2e",
         help=(
-            "Run or preview the one-command deterministic k-NN replay path and "
+            "Run or preview the one-command multi-round k-NN research path and "
             "report board/acceptance truth boundaries."
         ),
     )
@@ -356,8 +356,9 @@ def register_auto_research_commands(
         "--execute",
         action="store_true",
         help=(
-            "Run protected evals from the generated quickstart pack and append public rollout evidence. "
-            "This is a deterministic replay, not a live Codex lane result."
+            "Run the lightweight multi-round protected-eval kernel, append public rollout evidence, "
+            "and report measured dev/holdout gains. This still requires live evidence before "
+            "claiming that visible Codex panes authored the result."
         ),
     )
     demo_e2e_parser.add_argument(

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -22,6 +22,7 @@ from .core import (
     build_research_evidence_graph_from_rollout_events,
     load_auto_research_evidence_packet_inputs,
 )
+from .kernel import run_builtin_lightweight_demo
 from .live_evidence import (
     build_live_codex_claim_from_evidence,
     load_live_codex_e2e_evidence,
@@ -222,7 +223,7 @@ def _live_codex_truth_boundary(*, launch_visible: bool) -> dict[str, object]:
         "visible_lanes_accepted": False,
         "evidence_source": "not_collected_from_codex_lane_output",
         "reason": (
-            "demo-e2e validates the deterministic positive replay and optional visible launcher; "
+            "demo-e2e validates the lightweight multi-round research kernel and optional visible launcher; "
             "it does not prove a live Codex multi-agent research result."
         ),
         "required_for_live_claim": [
@@ -276,8 +277,8 @@ def run_auto_research_demo_e2e(
         "ok": True,
         "schema_version": AUTO_RESEARCH_DEMO_E2E_SCHEMA_VERSION,
         "mode": "execute" if execute else "dry_run",
-        "execution_kind": "deterministic_replay" if execute else "deterministic_replay_preview",
-        "result_source": "generated_quickstart_pack_protected_eval_replay",
+        "execution_kind": "multiround_research_kernel" if execute else "multiround_research_preview",
+        "result_source": "lightweight_multiround_kernel" if execute else "lightweight_multiround_kernel_preview",
         "goal_id": goal_id,
         "tracking_goal_id": tracking_goal or None,
         "route_contract": {
@@ -295,14 +296,14 @@ def run_auto_research_demo_e2e(
         "agent_id": agent_id,
         "reasoning_effort": reasoning_effort,
         "commands": {
-            "deterministic_replay": _command_text(
+            "multiround_kernel": _command_text(
                 cli_bin=cli_bin,
                 goal_id=goal_id,
                 agent_id=agent_id,
                 execute=True,
                 tracking_goal_id=tracking_goal or None,
             ),
-            "deterministic_replay_with_visible_lanes": _command_text(
+            "multiround_kernel_with_visible_lanes": _command_text(
                 cli_bin=cli_bin,
                 goal_id=goal_id,
                 agent_id=agent_id,
@@ -352,10 +353,16 @@ def run_auto_research_demo_e2e(
             "template": quickstart.get("template"),
             "next_commands": quickstart.get("next_commands"),
         }
-        payload["replay_result"] = {
+        payload["protected_eval_result"] = {
             "executed": False,
-            "result_source": "deterministic_replay_preview",
+            "result_source": "lightweight_multiround_kernel_preview",
             "expected_positive_result": "dev=4.0x holdout=4.5x after --execute",
+        }
+        payload["research_loop"] = {
+            "executed": False,
+            "result_source": "lightweight_multiround_kernel_preview",
+            "expected_rounds": "two dev rounds plus holdout for the selected candidate after --execute",
+            "expected_gain": "selected candidate improves from baseline 1.0x to dev=4.0x and holdout=4.5x",
         }
         return payload
 
@@ -398,6 +405,7 @@ def run_auto_research_demo_e2e(
         evidence_path = pack_dir / "evidence.public.json"
         evidence_path.write_text(json.dumps(evidence, indent=2, sort_keys=True) + "\n", encoding="utf-8")
         append_payload = append_evidence(str(evidence_path))
+        research_loop = run_builtin_lightweight_demo(goal_id=goal_id)
         board, acceptance = _live_board_and_acceptance(
             goal_id=goal_id,
             agent_id=agent_id,
@@ -413,15 +421,62 @@ def run_auto_research_demo_e2e(
                     "mode": quickstart.get("mode"),
                     "template": quickstart.get("template"),
                 },
-                "replay_result": {
+                "protected_eval_result": {
                     "executed": True,
-                    "result_source": "generated_quickstart_pack_protected_eval_replay",
+                    "result_source": "generated_quickstart_pack_protected_eval",
                     "status": evidence.get("summary", {}).get("status"),
                     "dev_metric": (dev.get("metric") or {}).get("value"),
                     "holdout_metric": (holdout.get("metric") or {}).get("value"),
                     "dev_exact": bool(dev.get("exact")),
                     "holdout_exact": bool(holdout.get("exact")),
                     "protected_scope_clean": bool(evidence.get("summary", {}).get("protected_scope_clean")),
+                },
+                "research_loop": {
+                    "executed": True,
+                    "result_source": research_loop.get("result_source"),
+                    "schema_version": research_loop.get("schema_version"),
+                    "decision": research_loop.get("decision"),
+                    "candidate_count": research_loop.get("candidate_count"),
+                    "dev_round_count": research_loop.get("dev_round_count"),
+                    "evidence_event_count": research_loop.get("evidence_event_count"),
+                    "selected_hypothesis_id": research_loop.get("selected_hypothesis_id"),
+                    "baseline_metric": 1.0,
+                    "dev_metric": research_loop.get("dev_metric"),
+                    "holdout_metric": research_loop.get("holdout_metric"),
+                    "dev_gain_over_baseline": (
+                        float(research_loop["dev_metric"]) - 1.0
+                        if research_loop.get("dev_metric") is not None
+                        else None
+                    ),
+                    "holdout_gain_over_baseline": (
+                        float(research_loop["holdout_metric"]) - 1.0
+                        if research_loop.get("holdout_metric") is not None
+                        else None
+                    ),
+                    "worker_rounds": [
+                        {
+                            "round": 1,
+                            "role": "hypothesis_mapper",
+                            "transition": "seed_baseline_candidate",
+                            "hypothesis_id": "hyp_full_sort",
+                            "loopx_contract": "role_profile_quota_frontier_cli_writeback",
+                        },
+                        {
+                            "round": 2,
+                            "role": "evidence_runner",
+                            "transition": "try_positive_candidate",
+                            "hypothesis_id": "hyp_partial_selection",
+                            "loopx_contract": "role_profile_quota_frontier_cli_writeback",
+                        },
+                        {
+                            "round": 3,
+                            "role": "evidence_verifier",
+                            "transition": "holdout_validate_selected_candidate",
+                            "hypothesis_id": research_loop.get("selected_hypothesis_id"),
+                            "loopx_contract": "role_profile_quota_frontier_cli_writeback",
+                        },
+                    ],
+                    "public_boundary": research_loop.get("public_boundary"),
                 },
                 "append": {
                     "appended_count": append_payload.get("appended_count"),

--- a/loopx/capabilities/auto_research/legacy_core.py
+++ b/loopx/capabilities/auto_research/legacy_core.py
@@ -940,6 +940,7 @@ def _auto_research_codex_bootstrap_prompt(
         [
             "You are a visible LoopX auto-research lane, not a generic LoopX heartbeat worker.",
             "Use loopx-project for quota/status, then follow the worker-local loopx-auto-research role playbook for this pane.",
+            "If LOOPX_WORKER_SKILL_PATH is present, read that local playbook path instead of relying on global skill discovery.",
             "This pane is a visible LoopX polling turn: before each new action, rerun the printed quota should-run and auto-research frontier commands, then follow their interaction_contract.",
             "Do not run loopx bootstrap-command-pack, loopx heartbeat-prompt, or generic onboarding unless the printed frontier explicitly asks for it.",
             "If a future scheduled automation owns this lane, it must use a generated LoopX heartbeat/polling prompt; this visible bootstrap is the local manual polling prompt.",
@@ -962,7 +963,7 @@ def _auto_research_codex_bootstrap_prompt(
             "",
             "Live E2E proof contract:",
             "- Work only from the printed auto-research frontier and this role profile.",
-            "- Deterministic replay is not live Codex evidence; do not claim replay metrics as lane-authored results.",
+            "- The lightweight multi-round kernel is not live Codex evidence; do not claim kernel metrics as lane-authored results.",
             "- If you author evidence, use public-safe loopx auto-research evidence and append-evidence commands.",
             "- A controller may later run capture-live-evidence to create live-codex-e2e-evidence.public.json.",
             "- claim_allowed must remain false until that public-safe live evidence file exists and validates.",
@@ -1037,10 +1038,13 @@ def _role_profile_shell_prefix(role_profile: dict[str, Any]) -> str:
         f"export LOOPX_ROLE_PHASE={_shell_arg(str(role_profile['phase']))}; "
         f"export LOOPX_ROLE_PROFILE_REF={_shell_arg(str(role_profile['schema_version']))}; "
         f"export LOOPX_REQUIRED_SKILL={_shell_arg(str(role_profile['required_skill']))}; "
+        'export LOOPX_WORKER_SKILL_ROOT="$LOOPX_PROJECT/.codex/skills"; '
+        'export LOOPX_WORKER_SKILL_PATH="$LOOPX_WORKER_SKILL_ROOT/$LOOPX_REQUIRED_SKILL/SKILL.md"; '
         f"LOOPX_ROLE_PROFILE_JSON={_shell_arg(profile_json)}; "
         "export LOOPX_ROLE_PROFILE_JSON; "
         "printf '\\n[LoopX role profile]\\n'; "
         "printf '%s\\n' \"$LOOPX_ROLE_PROFILE_JSON\"; "
+        "printf 'worker_skill_path=%s\\n' \"$LOOPX_WORKER_SKILL_PATH\"; "
     )
 
 
@@ -2853,7 +2857,7 @@ def build_auto_research_board_projection(
                 "label": "Rollout held-out context",
                 "value": _metric_display(best_holdout),
                 "baseline": _metric_display(baseline),
-                "interpretation": "Shown as rollout or replay context, not as a live Codex holdout claim.",
+                "interpretation": "Shown as rollout context, not as a live Codex holdout claim.",
                 "source": "evidence_graph.best_holdout_metric",
             },
             {
@@ -3435,7 +3439,16 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
                 lines.append(f"- {item}")
         return "\n".join(lines) + "\n"
     if payload.get("schema_version") == AUTO_RESEARCH_DEMO_E2E_SCHEMA_VERSION:
-        replay = payload.get("replay_result") if isinstance(payload.get("replay_result"), dict) else {}
+        protected_eval = (
+            payload.get("protected_eval_result")
+            if isinstance(payload.get("protected_eval_result"), dict)
+            else {}
+        )
+        research_loop = (
+            payload.get("research_loop")
+            if isinstance(payload.get("research_loop"), dict)
+            else {}
+        )
         append = payload.get("append") if isinstance(payload.get("append"), dict) else {}
         board = payload.get("board") if isinstance(payload.get("board"), dict) else {}
         acceptance = payload.get("acceptance") if isinstance(payload.get("acceptance"), dict) else {}
@@ -3453,7 +3466,7 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
             else {}
         )
         lines = [
-            "# LoopX Auto Research Demo Replay",
+            "# LoopX Auto Research Multi-Round Demo",
             "",
             f"- schema: `{payload.get('schema_version')}`",
             f"- mode: `{payload.get('mode')}`",
@@ -3465,12 +3478,20 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
             f"- tracking_goal_drives_frontier: `{route.get('tracking_goal_drives_frontier')}`",
             f"- agent_id: `{payload.get('agent_id')}`",
             f"- reasoning_effort: `{payload.get('reasoning_effort')}`",
-            f"- replay_executed: `{replay.get('executed')}`",
-            f"- replay_result_source: `{replay.get('result_source')}`",
-            f"- status: `{replay.get('status')}`",
-            f"- dev_metric: `{replay.get('dev_metric')}`",
-            f"- holdout_metric: `{replay.get('holdout_metric')}`",
-            f"- protected_scope_clean: `{replay.get('protected_scope_clean')}`",
+            f"- research_loop_executed: `{research_loop.get('executed')}`",
+            f"- research_loop_source: `{research_loop.get('result_source')}`",
+            f"- research_loop_decision: `{research_loop.get('decision')}`",
+            f"- research_loop_dev_rounds: `{research_loop.get('dev_round_count')}`",
+            f"- research_loop_evidence_events: `{research_loop.get('evidence_event_count')}`",
+            f"- research_loop_selected_hypothesis: `{research_loop.get('selected_hypothesis_id')}`",
+            f"- research_loop_dev_gain: `{research_loop.get('dev_gain_over_baseline')}`",
+            f"- research_loop_holdout_gain: `{research_loop.get('holdout_gain_over_baseline')}`",
+            f"- protected_eval_executed: `{protected_eval.get('executed')}`",
+            f"- protected_eval_source: `{protected_eval.get('result_source')}`",
+            f"- protected_eval_status: `{protected_eval.get('status')}`",
+            f"- protected_eval_dev_metric: `{protected_eval.get('dev_metric')}`",
+            f"- protected_eval_holdout_metric: `{protected_eval.get('holdout_metric')}`",
+            f"- protected_scope_clean: `{protected_eval.get('protected_scope_clean')}`",
             f"- live_codex_e2e_executed: `{live_codex.get('executed')}`",
             f"- live_codex_e2e_claim_allowed: `{live_codex.get('claim_allowed')}`",
             f"- live_codex_e2e_claim_scope: `{live_codex.get('claim_scope')}`",
@@ -3487,8 +3508,8 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
             "",
             "## Commands",
             "",
-            f"- deterministic replay: `{commands.get('deterministic_replay')}`",
-            f"- replay plus visible lanes: `{commands.get('deterministic_replay_with_visible_lanes')}`",
+            f"- multi-round research: `{commands.get('multiround_kernel')}`",
+            f"- multi-round research plus visible lanes: `{commands.get('multiround_kernel_with_visible_lanes')}`",
         ]
         if board_claim_boundary:
             lines.extend(

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -232,6 +232,42 @@ def build_visible_multi_agent_payload(
     }
 
 
+def _materialize_worker_skills(
+    *,
+    payload: dict[str, object],
+    project: Path,
+    source_root: Path,
+) -> list[dict[str, object]]:
+    results: list[dict[str, object]] = []
+    lanes = [item for item in payload.get("lanes", []) if isinstance(item, dict)]
+    for lane in lanes:
+        profile = lane.get("role_profile")
+        if not isinstance(profile, dict):
+            continue
+        skill_name = str(profile.get("required_skill") or "").strip()
+        source_name = str(profile.get("worker_skill_source") or "").strip()
+        if not skill_name or not source_name:
+            continue
+        source = Path(source_name)
+        if not source.is_absolute():
+            source = source_root / source
+        destination = project / ".codex" / "skills" / skill_name / "SKILL.md"
+        item = {
+            "skill": skill_name,
+            "source": source_name,
+            "destination": f".codex/skills/{skill_name}/SKILL.md",
+            "materialized": False,
+        }
+        if source.is_file():
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copyfile(source, destination)
+            item["materialized"] = True
+        else:
+            item["missing_source"] = True
+        results.append(item)
+    return results
+
+
 def execute_visible_multi_agent_launcher(
     *,
     payload: dict[str, object],
@@ -258,6 +294,11 @@ def execute_visible_multi_agent_launcher(
     require_executable(codex_bin, field="codex_bin")
     chosen = resolve_visible_launcher(requested=requested_launcher, tmux_bin=tmux_bin)
     project, workspace_mode = resolve_visible_workspace(workspace, create=create_workspace, cwd=cwd)
+    worker_skills = _materialize_worker_skills(
+        payload=payload,
+        project=project,
+        source_root=cwd,
+    )
     result = _launch_with_tmux(
         payload=payload,
         project=project,
@@ -273,6 +314,7 @@ def execute_visible_multi_agent_launcher(
         frontier_or_blocker_markers=frontier_or_blocker_markers,
         frontier_or_blocker_status_markers=frontier_or_blocker_status_markers,
     )
+    result["worker_skill_materialization"] = worker_skills
     return result, chosen, workspace_mode
 
 


### PR DESCRIPTION
## Summary
- switch `auto-research demo-e2e` from replay-facing output to the lightweight multi-round research kernel
- expose protected eval results separately from `research_loop` gains and worker rounds
- materialize worker-local `loopx-auto-research` playbooks into visible launcher workspaces so panes do not rely on a global skill
- refresh the one-click guide and durable smokes around the multi-round path

## Validation
- `python3 -m compileall -q loopx/capabilities/auto_research loopx/visible_multi_agent_launcher.py`
- `python3 examples/auto-research-lightweight-kernel-smoke.py`
- `python3 examples/auto-research-demo-e2e-smoke.py`
- `python3 examples/auto-research-demo-supervisor-smoke.py`
- `python3 examples/auto-research-one-click-ux-smoke.py`
- `python3 examples/visible-multi-agent-launcher-smoke.py`
- `python3 examples/generic-multi-agent-one-command-smoke.py`
- `loopx check --scan-path loopx/capabilities/auto_research --scan-path loopx/visible_multi_agent_launcher.py --scan-path examples/auto-research-demo-e2e-smoke.py --scan-path examples/auto-research-one-click-ux-smoke.py --scan-path examples/visible-multi-agent-launcher-smoke.py --scan-path docs/guides/auto-research-command-path.md`
- `python3 -m loopx.cli --format json auto-research demo-e2e --goal-id loopx-auto-research-knn --agent-id codex-side-bypass --tracking-goal-id loopx-meta --reasoning-effort high --execute | jq '{execution_kind,result_source,protected_eval_result,research_loop,live_codex_e2e}'`

## Boundary
- Public/private scan is clean; no raw logs, credentials, or local evidence are committed.
- This PR proves the one-command multi-round kernel path and launcher readiness. It still keeps `live_codex_e2e.claim_allowed=false` until a visible Codex lane-authored evidence packet is captured.
