### PR TITLE
Fix SkillsBench batch child payload parsing

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -10038,6 +10038,11 @@ def test_skillsbench_parallel_batch_isolates_case_process_argv() -> None:
     )
     child_argv = skillsbench_loop._batch_case_args_to_cli(case_args)
     assert "--task-ids" not in child_argv, child_argv
+    assert "--apt-risk-fail-fast-defaulted" not in child_argv, child_argv
+    assert "--bootstrap-light-fail-fast-defaulted" not in child_argv, child_argv
+    assert "--verifier-bootstrap-fail-fast-defaulted" not in child_argv, child_argv
+    assert "--fail-fast-on-apt-risk" not in child_argv, child_argv
+    assert "--fail-fast-on-verifier-bootstrap-risk" not in child_argv, child_argv
     assert child_argv[child_argv.index("--task-id") + 1] == (
         "adaptive-cruise-control"
     ), child_argv
@@ -10051,6 +10056,51 @@ def test_skillsbench_parallel_batch_isolates_case_process_argv() -> None:
     assert "--host-local-acp-launch" in child_argv, child_argv
     assert "--remote-command-file-bridge-ready" in child_argv, child_argv
     assert "--append-history" in child_argv, child_argv
+    reparsed_child = parse_args(child_argv)
+    assert reparsed_child.task_id == "adaptive-cruise-control", reparsed_child
+    assert reparsed_child.task_ids is None, reparsed_child
+    assert reparsed_child.parallel_cases == 1, reparsed_child
+    assert reparsed_child.bootstrap_light_fail_fast_defaulted is True, reparsed_child
+
+
+def test_skillsbench_parallel_batch_recovers_child_payload_from_mixed_stderr() -> None:
+    args = parse_args(
+        [
+            "--task-id",
+            "suricata-custom-exfil",
+            "--route",
+            "codex-app-server-goal-baseline",
+            "--host-local-acp-launch",
+            "--remote-command-file-bridge-ready",
+        ]
+    )
+    payload = {
+        "ok": False,
+        "task_id": "suricata-custom-exfil",
+        "route": "codex-app-server-goal-baseline",
+        "score_failure_attribution": "skillsbench_verifier_bootstrap_risk_preflight_blocked",
+        "compact_closeout_recorded": True,
+    }
+    recovered = skillsbench_loop._extract_batch_case_subprocess_payload(
+        case_args=args,
+        returncode=2,
+        stdout=b"",
+        stderr=(
+            "usage warning that must not become the payload\n"
+            + json.dumps(payload, sort_keys=True)
+            + "\n"
+        ).encode("utf-8"),
+    )
+    assert recovered["task_id"] == "suricata-custom-exfil", recovered
+    assert recovered["score_failure_attribution"] == (
+        "skillsbench_verifier_bootstrap_risk_preflight_blocked"
+    ), recovered
+    assert recovered["compact_closeout_recorded"] is True, recovered
+    assert recovered["batch_case_subprocess_payload_source"] == "stderr", recovered
+    assert recovered["batch_case_subprocess_payload_mixed_output"] is True, recovered
+    assert recovered["runner_returncode"] == 2, recovered
+    assert recovered.get("raw_stdout_recorded") is not True, recovered
+    assert recovered.get("raw_stderr_recorded") is not True, recovered
 
 
 def test_skillsbench_compact_runs_update_ledger_pair() -> None:
@@ -12943,6 +12993,8 @@ if __name__ == "__main__":
     test_cli_dry_run_skillsbench_official_result()
     test_cli_skillsbench_result_root_discovers_nested_case_result_for_ledger()
     test_skillsbench_runner_plan_supports_controller_trace_path()
+    test_skillsbench_parallel_batch_isolates_case_process_argv()
+    test_skillsbench_parallel_batch_recovers_child_payload_from_mixed_stderr()
     test_skillsbench_compact_runs_update_ledger_pair()
     test_skillsbench_repeat_same_mode_keeps_distinct_ledger_runs()
     test_skillsbench_runner_failure_compact_closeout()

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -13050,6 +13050,18 @@ def _batch_case_args_to_cli(case_args: argparse.Namespace) -> list[str]:
     for key, value in sorted(vars(case_args).items()):
         if key == "task_ids":
             continue
+        if key in BATCH_CASE_INTERNAL_ARG_KEYS:
+            continue
+        if (
+            key == "fail_fast_on_apt_risk"
+            and getattr(case_args, "apt_risk_fail_fast_defaulted", False)
+        ):
+            continue
+        if (
+            key == "fail_fast_on_verifier_bootstrap_risk"
+            and getattr(case_args, "verifier_bootstrap_fail_fast_defaulted", False)
+        ):
+            continue
         option = "--" + key.replace("_", "-")
         if key == "parallel_cases":
             value = 1
@@ -13067,6 +13079,39 @@ def _parallel_batch_requires_subprocess_isolation(parallel_cases: int) -> bool:
     return parallel_cases > 1
 
 
+BATCH_CASE_INTERNAL_ARG_KEYS = frozenset(
+    {
+        "apt_risk_fail_fast_defaulted",
+        "bootstrap_light_fail_fast_defaulted",
+        "verifier_bootstrap_fail_fast_defaulted",
+    }
+)
+
+
+def _load_json_object_from_mixed_text(text: str) -> tuple[dict[str, Any], bool]:
+    stripped = text.strip()
+    if not stripped:
+        raise ValueError("empty child payload")
+    try:
+        payload = json.loads(stripped)
+        if isinstance(payload, dict):
+            return payload, False
+    except json.JSONDecodeError:
+        pass
+
+    decoder = json.JSONDecoder()
+    for index, char in enumerate(stripped):
+        if char != "{":
+            continue
+        try:
+            payload, _ = decoder.raw_decode(stripped[index:])
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            return payload, True
+    raise ValueError("child payload did not contain a JSON object")
+
+
 def _extract_batch_case_subprocess_payload(
     *,
     case_args: argparse.Namespace,
@@ -13074,13 +13119,36 @@ def _extract_batch_case_subprocess_payload(
     stdout: bytes,
     stderr: bytes,
 ) -> dict[str, Any]:
-    text = stdout.decode("utf-8", errors="replace").strip()
-    if not text:
-        text = stderr.decode("utf-8", errors="replace").strip()
+    streams = [
+        ("stdout", stdout.decode("utf-8", errors="replace")),
+        ("stderr", stderr.decode("utf-8", errors="replace")),
+    ]
+    if stdout and stderr:
+        streams.append(
+            (
+                "combined",
+                (
+                    stdout.decode("utf-8", errors="replace")
+                    + "\n"
+                    + stderr.decode("utf-8", errors="replace")
+                ),
+            )
+        )
+    last_exc: Exception | None = None
     try:
-        payload = json.loads(text)
-        if not isinstance(payload, dict):
-            raise ValueError("child payload was not a JSON object")
+        payload: dict[str, Any] | None = None
+        mixed_output = False
+        payload_source = ""
+        for payload_source, text in streams:
+            try:
+                payload, mixed_output = _load_json_object_from_mixed_text(text)
+                break
+            except Exception as exc:
+                last_exc = exc
+        if payload is None:
+            raise last_exc or ValueError("child payload missing")
+        payload["batch_case_subprocess_payload_source"] = payload_source
+        payload["batch_case_subprocess_payload_mixed_output"] = mixed_output
     except Exception as exc:
         payload = {
             "ok": False,
@@ -13089,6 +13157,9 @@ def _extract_batch_case_subprocess_payload(
             "route": str(case_args.route),
             "error_type": "SkillsBenchBatchCaseSubprocessPayloadError",
             "error_class": type(exc).__name__,
+            "payload_error_class": (
+                type(last_exc).__name__ if last_exc is not None else type(exc).__name__
+            ),
             "child_returncode": int(returncode),
             "child_stdout_bytes": len(stdout),
             "child_stderr_bytes": len(stderr),


### PR DESCRIPTION
## Summary
- skip parse-derived internal fail-fast provenance fields when serializing SkillsBench batch child CLI args
- preserve defaulted fail-fast semantics by letting child parse_args rederive formal route defaults
- recover structured child JSON payloads from stdout/stderr with harmless mixed output without recording raw output
- cover the batch child argv and payload recovery contracts in the SkillsBench benchmark smoke

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py
- focused batch subprocess smoke for argv isolation and mixed stderr payload recovery
- plan-only --task-ids ... --parallel-cases 2 subprocess batch e2e
- git diff --check
- loopx check --scan-path scripts/skillsbench_automation_loop.py --scan-path examples/skillsbench-benchmark-run-smoke.py --limit 200
