### PR TITLE
Remove stale replay wording from auto-research demo help

### DIFF
--- a/examples/auto-research-demo-e2e-smoke.py
+++ b/examples/auto-research-demo-e2e-smoke.py
@@ -240,6 +240,19 @@ def main() -> int:
 
         guide = GUIDE.read_text(encoding="utf-8")
         normalized_guide = " ".join(guide.split())
+        help_text = run_cli(
+            [
+                "auto-research",
+                "demo-e2e",
+                "--help",
+            ],
+            registry=registry,
+            runtime_root=runtime_root,
+        ).stdout
+        normalized_help = " ".join(help_text.split())
+        assert "Visible panes alone do not make the" in normalized_help, help_text
+        assert "round kernel a live Codex E2E result." in normalized_help, help_text
+        assert "Visible panes alone do not make the replay" not in help_text, help_text
         assert "## 0. Prove The Multi-Round Positive Path" in guide, guide
         assert "auto-research demo-e2e" in guide, guide
         assert "does not claim that visible Codex lanes authored the research result" in normalized_guide, guide

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -366,7 +366,7 @@ def register_auto_research_commands(
         action="store_true",
         help=(
             "With --execute, also launch the visible multi-lane supervisor. "
-            "Visible panes alone do not make the replay a live Codex E2E result."
+            "Visible panes alone do not make the multi-round kernel a live Codex E2E result."
         ),
     )
     demo_e2e_parser.add_argument(


### PR DESCRIPTION
## Summary
- replace the stale `replay` phrase in `auto-research demo-e2e --help`
- add smoke coverage so the help keeps saying the visible panes alone do not make the multi-round kernel a live Codex E2E result

## Validation
- `python3 -m compileall -q loopx/capabilities/auto_research`
- `python3 examples/auto-research-demo-e2e-smoke.py`
- `loopx check --scan-path loopx/capabilities/auto_research/cli.py --scan-path examples/auto-research-demo-e2e-smoke.py`
- `git diff --check`

## Boundary
- Tiny public CLI/help drift repair. No private state, credentials, raw logs, or local evidence committed.
