### PR TITLE
Accept catalog profile ids in canary profile selector

### DIFF
--- a/examples/catalog-canary-planner-smoke.py
+++ b/examples/catalog-canary-planner-smoke.py
@@ -351,6 +351,26 @@ def assert_explicit_profile_can_include_deep_checks() -> None:
     assert "owner-review necessity/risk packet" in payload["note"], payload
 
 
+def assert_explicit_catalog_profile_id_selects_family_profile() -> None:
+    payload = build_catalog_canary_plan(
+        profiles=["state-and-boundary"],
+        max_checks_per_family=4,
+    )
+    assert payload["profile_count"] == 1, payload
+    assert payload["domain_profile_count"] == 0, payload
+    profile = payload["profiles"][0]
+    assert profile["id"] == "state-and-boundary", profile
+    assert profile["family"] == "State And Boundary", profile
+    assert profile["selection_reasons"] == [
+        "selected because this catalog profile was explicitly requested",
+    ], profile
+    assert "python3 examples/todo-contract-smoke.py" in payload["commands"], payload
+    assert all(
+        check["source"] == "catalog_family"
+        for check in payload["suggested_checks"]
+    ), payload
+
+
 def assert_catalog_canary_selects_own_profile_not_benchmark() -> None:
     payload = build_catalog_canary_plan(
         changed_files=["loopx/canary/planner.py", "loopx/canary/runner.py"],
@@ -554,6 +574,33 @@ def assert_cli_json_plan_is_dry_run() -> None:
     assert any(profile["id"] == "monitor-scheduler" for profile in payload["domain_profiles"]), payload
 
 
+def assert_cli_profile_accepts_catalog_profile_id() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "canary",
+            "plan",
+            "--profile",
+            "state-and-boundary",
+            "--max-checks-per-family",
+            "1",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(completed.stdout)
+    assert payload["profile_count"] == 1, payload
+    assert payload["domain_profile_count"] == 0, payload
+    assert payload["profiles"][0]["id"] == "state-and-boundary", payload
+    assert payload["commands"] == ["python3 examples/todo-contract-smoke.py"], payload
+
+
 def assert_cli_json_coverage_audit_is_dry_run() -> None:
     completed = subprocess.run(
         [
@@ -582,6 +629,7 @@ def main() -> int:
     assert_plan_selects_minimal_profiles_from_changed_surfaces()
     assert_pr_release_and_refactor_profiles_select()
     assert_explicit_profile_can_include_deep_checks()
+    assert_explicit_catalog_profile_id_selects_family_profile()
     assert_catalog_canary_selects_own_profile_not_benchmark()
     assert_install_update_does_not_select_release_promotion()
     assert_coverage_audit_tracks_p0_p1_patterns()
@@ -593,6 +641,7 @@ def main() -> int:
     finally:
         shutil.rmtree(tmp, ignore_errors=True)
     assert_cli_json_plan_is_dry_run()
+    assert_cli_profile_accepts_catalog_profile_id()
     assert_cli_json_coverage_audit_is_dry_run()
     print("catalog-canary-planner-smoke ok")
     return 0

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -895,6 +895,10 @@ def _slug(value: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", value.lower()).strip("-")
 
 
+def _catalog_profile_id(profile: dict[str, Any]) -> str:
+    return _slug(str(profile.get("id") or profile.get("family") or ""))
+
+
 def _split_table_row(line: str) -> list[str]:
     return [cell.strip() for cell in line.strip().strip("|").split("|")]
 
@@ -1260,31 +1264,48 @@ def build_catalog_canary_plan(
     selector_blob = _selector_blob(changed_files, surfaces)
     max_checks = max(1, max_checks_per_family)
     max_profile_checks = max(1, max_checks_per_profile)
+    catalog_profile_ids = {
+        _catalog_profile_id(profile)
+        for profile in packet["profiles"]
+        if isinstance(profile, dict)
+    }
+    requested_catalog_profiles = requested_profiles & catalog_profile_ids
+    requested_domain_profiles = requested_profiles - requested_catalog_profiles
 
     selected_profiles: list[dict[str, Any]] = []
     for profile in packet["profiles"]:
-        if requested_profiles and not requested_families and not selector_blob:
+        profile_id = _catalog_profile_id(profile)
+        if requested_domain_profiles and not requested_catalog_profiles and not requested_families and not selector_blob:
             continue
         reasons = _selection_reasons(profile, selector_blob)
+        if requested_catalog_profiles and profile_id not in requested_catalog_profiles:
+            continue
         if requested_families and _slug(str(profile.get("family") or "")) not in requested_families:
             continue
-        if not requested_families and selector_blob and not reasons:
+        if not requested_catalog_profiles and not requested_families and selector_blob and not reasons:
             continue
         profile_copy = dict(profile)
         profile_copy["candidate_checks"] = list(profile_copy.get("candidate_checks", []))[:max_checks]
-        profile_copy["selection_reasons"] = reasons or [
-            "selected because no narrower selector was provided",
-        ]
+        if requested_catalog_profiles and profile_id in requested_catalog_profiles:
+            profile_copy["selection_reasons"] = reasons or [
+                "selected because this catalog profile was explicitly requested",
+            ]
+        else:
+            profile_copy["selection_reasons"] = reasons or [
+                "selected because no narrower selector was provided",
+            ]
         selected_profiles.append(profile_copy)
 
     selected_domain_profiles: list[dict[str, Any]] = []
     for profile in packet["domain_profiles"]:
         reasons = _domain_selection_reasons(profile, selector_blob)
-        if requested_profiles and _slug(str(profile.get("id") or "")) not in requested_profiles:
+        if requested_domain_profiles and _slug(str(profile.get("id") or "")) not in requested_domain_profiles:
             continue
-        if not requested_profiles and selector_blob and not reasons:
+        if requested_catalog_profiles and not requested_domain_profiles:
             continue
-        if not requested_profiles and not selector_blob:
+        if not requested_domain_profiles and selector_blob and not reasons:
+            continue
+        if not requested_domain_profiles and not selector_blob:
             continue
         profile_copy = _domain_profile_with_checks(
             profile,


### PR DESCRIPTION
## Summary
- make `loopx canary plan/run --profile <id>` accept catalog profile ids shown by `loopx canary profiles`, such as `state-and-boundary`
- keep existing domain-profile selector behavior intact and avoid selecting domain profiles when only a catalog profile id is requested
- add focused planner/CLI smoke coverage for the catalog-profile-id path

## Validation
- `python3 examples/catalog-canary-planner-smoke.py`
- `python3 examples/catalog-canary-run-e2e-smoke.py`
- `python3 -m loopx.cli --format json canary plan --profile state-and-boundary --max-checks-per-family 1`
- `python3 -m loopx.cli --format json canary run --profile state-and-boundary --max-checks-per-family 1 --check-limit 1 --timeout-seconds 60`
- `python3 -m compileall -q loopx/canary/planner.py examples/catalog-canary-planner-smoke.py`
- `git diff --check`
- `loopx check --scan-path loopx/canary/planner.py --scan-path examples/catalog-canary-planner-smoke.py`

## Boundary
This is a narrow canary-planner selector UX/runtime change. It does not touch benchmark execution, launch jobs, or include private/local evidence. Since it changes runtime selector semantics, I am leaving it for review instead of self-merging from the side-agent lane.