### PR TITLE
Export visible auto-research lane goal identity

### DIFF
--- a/examples/auto-research-demo-supervisor-smoke.py
+++ b/examples/auto-research-demo-supervisor-smoke.py
@@ -111,6 +111,7 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
         assert "codex-cli-bootstrap-message" not in lane["bootstrap_message"], lane
         assert "[LoopX role profile]" in lane["visible_launch_command"], lane
         assert "[LoopX visible acceptance]" in lane["visible_launch_command"], lane
+        assert "LOOPX_GOAL_ID" in lane["visible_launch_command"], lane
         assert "LOOPX_VISIBLE_BOOTSTRAP_PAUSE_SECONDS" in lane["visible_launch_command"], lane
         assert "LOOPX_ROLE_PROFILE_JSON" in lane["visible_launch_command"], lane
         assert "LOOPX_REQUIRED_SKILL" in lane["visible_launch_command"], lane

--- a/loopx/capabilities/auto_research/legacy_core.py
+++ b/loopx/capabilities/auto_research/legacy_core.py
@@ -1033,6 +1033,7 @@ def _role_profile_for_lane(*, goal_id: str, lane: dict[str, str]) -> dict[str, A
 def _role_profile_shell_prefix(role_profile: dict[str, Any]) -> str:
     profile_json = json.dumps(role_profile, sort_keys=True, separators=(",", ":"))
     return (
+        f"export LOOPX_GOAL_ID={_shell_arg(str(role_profile['goal_id']))}; "
         f"export LOOPX_AGENT_ID={_shell_arg(str(role_profile['agent_id']))}; "
         f"export LOOPX_ROLE_ID={_shell_arg(str(role_profile['role_id']))}; "
         f"export LOOPX_ROLE_PHASE={_shell_arg(str(role_profile['phase']))}; "


### PR DESCRIPTION
## Summary
- export `LOOPX_GOAL_ID` into visible auto-research lane environments
- cover the env contract in the demo supervisor smoke

## Validation
- `python3 -m compileall -q loopx/capabilities/auto_research loopx/visible_multi_agent_launcher.py`
- `python3 examples/auto-research-demo-supervisor-smoke.py`
- `loopx check --scan-path loopx/capabilities/auto_research/legacy_core.py --scan-path examples/auto-research-demo-supervisor-smoke.py`
- `git diff --check`

## Boundary
- Public boundary scan clean for changed files.
- No raw transcripts, private state, credentials, or local runtime artifacts committed.
