### PR TITLE
Allow explicit SkillsBench staged bootstrap repair runs

### DIFF
--- a/examples/skillsbench-task-source-preflight-smoke.py
+++ b/examples/skillsbench-task-source-preflight-smoke.py
@@ -17,6 +17,8 @@ if str(REPO_ROOT) not in sys.path:
 
 from loopx.benchmark_ledger import load_benchmark_run_ledger  # noqa: E402
 from scripts.skillsbench_automation_loop import (  # noqa: E402
+    _bootstrap_light_blocker_kind,
+    _bootstrap_light_preflight_block_required,
     build_plan,
     main as skillsbench_automation_loop_main,
     parse_args,
@@ -355,9 +357,83 @@ def test_reverse_tunnel_app_goal_blocks_pip_bootstrap_light_risk() -> None:
         ] is True
 
 
+def test_reverse_tunnel_app_goal_allows_explicit_staged_bootstrap_repair() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-staged-bootstrap-") as tmp:
+        root = Path(tmp)
+        skillsbench_root = root / "skillsbench"
+        _write_task(skillsbench_root, "tasks/pip-bootstrap")
+        dockerfile = (
+            skillsbench_root
+            / "tasks"
+            / "pip-bootstrap"
+            / "environment"
+            / "Dockerfile"
+        )
+        dockerfile.write_text(
+            "FROM python:3.12-slim\nRUN python -m pip install pandas\n",
+            encoding="utf-8",
+        )
+
+        jobs = root / "jobs"
+        ledger = root / "ledger.json"
+        args = _app_goal_args(
+            task_id="pip-bootstrap",
+            skillsbench_root=skillsbench_root,
+            jobs=jobs,
+            ledger=ledger,
+            job_name="skillsbench-staged-bootstrap-allowed",
+        )
+        parsed = parse_args(args + ["--allow-staged-bootstrap-repair-run"])
+        assert parsed.allow_staged_bootstrap_repair_run is True
+        assert parsed.fail_fast_on_apt_risk is False
+        assert parsed.apt_risk_fail_fast_defaulted is False
+        assert parsed.fail_fast_on_verifier_bootstrap_risk is False
+        assert parsed.verifier_bootstrap_fail_fast_defaulted is False
+        assert parsed.bootstrap_light_fail_fast_defaulted is False
+
+        plan = build_plan(parsed)
+        preflight = plan["task_setup_preflight"]
+        assert plan["bootstrap_light_candidate_required"] is True, plan
+        assert plan["bootstrap_light_fail_fast_required"] is False, plan
+        assert plan["allow_staged_bootstrap_repair_run"] is True, plan
+        assert preflight["bootstrap_light_candidate_eligible"] is False, preflight
+        assert "dockerfile_pip_bootstrap_patch_required" in preflight[
+            "bootstrap_light_blocking_fields"
+        ], preflight
+        blocker_kind = _bootstrap_light_blocker_kind(
+            preflight["bootstrap_light_blocking_fields"]
+        )
+        assert blocker_kind == "dockerfile_package"
+        assert (
+            _bootstrap_light_preflight_block_required(
+                parsed,
+                blocker_kind=blocker_kind,
+            )
+            is False
+        )
+
+        explicitly_blocked = parse_args(
+            args
+            + [
+                "--allow-staged-bootstrap-repair-run",
+                "--fail-fast-on-apt-risk",
+            ]
+        )
+        assert explicitly_blocked.allow_staged_bootstrap_repair_run is True
+        assert explicitly_blocked.fail_fast_on_apt_risk is True
+        assert (
+            _bootstrap_light_preflight_block_required(
+                explicitly_blocked,
+                blocker_kind=blocker_kind,
+            )
+            is True
+        )
+
+
 if __name__ == "__main__":
     test_sanity_task_source_fails_before_runner_spend()
     test_reverse_tunnel_app_goal_defaults_verifier_bootstrap_fail_fast()
     test_reverse_tunnel_app_goal_defaults_apt_bootstrap_fail_fast()
     test_reverse_tunnel_app_goal_blocks_pip_bootstrap_light_risk()
+    test_reverse_tunnel_app_goal_allows_explicit_staged_bootstrap_repair()
     print("skillsbench-task-source-preflight-smoke ok")

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -1226,6 +1226,15 @@ def _formal_app_server_goal_bootstrap_light_guard_required(
     )
 
 
+def _formal_app_server_goal_bootstrap_light_fail_fast_required(
+    args: argparse.Namespace | None,
+) -> bool:
+    return bool(
+        _formal_app_server_goal_bootstrap_light_guard_required(args)
+        and not getattr(args, "allow_staged_bootstrap_repair_run", False)
+    )
+
+
 def _codex_api_reverse_tunnel_proxy(args: argparse.Namespace | None) -> tuple[str, str]:
     explicit = ""
     if args is not None:
@@ -5646,6 +5655,23 @@ def _bootstrap_light_blocker_kind(blocking_fields: list[str]) -> str:
     return "setup"
 
 
+def _bootstrap_light_preflight_block_required(
+    args: argparse.Namespace,
+    *,
+    blocker_kind: str,
+) -> bool:
+    if getattr(args, "reduce_only", False):
+        return False
+    fail_fast_required = _formal_app_server_goal_bootstrap_light_fail_fast_required(
+        args
+    )
+    if blocker_kind in {"apt", "dockerfile_package"}:
+        return bool(args.fail_fast_on_apt_risk or fail_fast_required)
+    if blocker_kind == "verifier":
+        return bool(args.fail_fast_on_verifier_bootstrap_risk or fail_fast_required)
+    return False
+
+
 def _mark_bootstrap_light_preflight_blocked(
     *,
     staging: dict[str, Any],
@@ -6432,6 +6458,12 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         "bootstrap_light_candidate_required": bool(
             _formal_app_server_goal_bootstrap_light_guard_required(args)
         ),
+        "bootstrap_light_fail_fast_required": bool(
+            _formal_app_server_goal_bootstrap_light_fail_fast_required(args)
+        ),
+        "allow_staged_bootstrap_repair_run": bool(
+            getattr(args, "allow_staged_bootstrap_repair_run", False)
+        ),
         "fail_fast_on_apt_risk": bool(args.fail_fast_on_apt_risk),
         "apt_risk_fail_fast_defaulted": bool(
             getattr(args, "apt_risk_fail_fast_defaulted", False)
@@ -6859,6 +6891,8 @@ def _public_runner_config(plan: dict[str, Any]) -> dict[str, Any]:
         "include_task_skills",
         "host_local_acp_launch",
         "bootstrap_light_candidate_required",
+        "bootstrap_light_fail_fast_required",
+        "allow_staged_bootstrap_repair_run",
         "fail_fast_on_apt_risk",
         "apt_risk_fail_fast_defaulted",
         "fail_fast_on_verifier_bootstrap_risk",
@@ -12801,6 +12835,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "setup-preflight failure instead of spending a full case attempt."
         ),
     )
+    parser.add_argument(
+        "--allow-staged-bootstrap-repair-run",
+        action="store_true",
+        help=(
+            "For formal reverse-tunnel app-server Goal runs, allow the runner "
+            "to stage an isolated task copy and apply existing public-safe "
+            "Dockerfile/verifier bootstrap repairs instead of treating those "
+            "repairable setup risks as automatic preflight blockers. Explicit "
+            "--fail-fast-on-* flags still block."
+        ),
+    )
     apt_fail_fast_explicit = "--fail-fast-on-apt-risk" in raw_argv
     verifier_fail_fast_explicit = "--fail-fast-on-verifier-bootstrap-risk" in raw_argv
     args = parser.parse_args(raw_argv)
@@ -12808,19 +12853,19 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     args.verifier_bootstrap_fail_fast_defaulted = False
     args.bootstrap_light_fail_fast_defaulted = False
     if (
-        _formal_app_server_goal_bootstrap_light_guard_required(args)
+        _formal_app_server_goal_bootstrap_light_fail_fast_required(args)
         and not args.fail_fast_on_apt_risk
     ):
         args.fail_fast_on_apt_risk = True
         args.apt_risk_fail_fast_defaulted = not apt_fail_fast_explicit
     if (
-        _formal_app_server_goal_bootstrap_light_guard_required(args)
+        _formal_app_server_goal_bootstrap_light_fail_fast_required(args)
         and not args.fail_fast_on_verifier_bootstrap_risk
     ):
         args.fail_fast_on_verifier_bootstrap_risk = True
         args.verifier_bootstrap_fail_fast_defaulted = not verifier_fail_fast_explicit
     args.bootstrap_light_fail_fast_defaulted = bool(
-        _formal_app_server_goal_bootstrap_light_guard_required(args)
+        _formal_app_server_goal_bootstrap_light_fail_fast_required(args)
         and (
             args.apt_risk_fail_fast_defaulted
             or args.verifier_bootstrap_fail_fast_defaulted
@@ -12898,8 +12943,10 @@ async def async_main(
         bootstrap_light_blocking_fields
     )
     if (
-        (args.fail_fast_on_apt_risk or _formal_app_server_goal_bootstrap_light_guard_required(args))
-        and not args.reduce_only
+        _bootstrap_light_preflight_block_required(
+            args,
+            blocker_kind=bootstrap_light_blocker_kind,
+        )
         and bootstrap_light_blocker_kind in {"apt", "dockerfile_package"}
     ):
         staging = plan.setdefault("task_staging", {})
@@ -12920,11 +12967,10 @@ async def async_main(
             "Dockerfile package bootstrap risk detected before full case run"
         )
     if (
-        (
-            args.fail_fast_on_verifier_bootstrap_risk
-            or _formal_app_server_goal_bootstrap_light_guard_required(args)
+        _bootstrap_light_preflight_block_required(
+            args,
+            blocker_kind=bootstrap_light_blocker_kind,
         )
-        and not args.reduce_only
         and bootstrap_light_blocker_kind == "verifier"
     ):
         staging = plan.setdefault("task_staging", {})


### PR DESCRIPTION
## Summary
- Add an explicit --allow-staged-bootstrap-repair-run switch for formal reverse-tunnel app-server Goal runs.
- Keep the default bootstrap-light fail-fast behavior unchanged unless the new switch is passed.
- Expose the allow/fail-fast decision in public runner config and cover it with the SkillsBench task-source preflight smoke.

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-task-source-preflight-smoke.py
- python3 examples/skillsbench-task-source-preflight-smoke.py
