### PR TITLE
Make auto-research claim boundary a default canary

### DIFF
--- a/examples/auto-research-live-codex-claim-boundary-smoke.py
+++ b/examples/auto-research-live-codex-claim-boundary-smoke.py
@@ -186,9 +186,13 @@ def main() -> int:
         )
         claimed_payload = json.loads(claimed.stdout)
         live = claimed_payload["live_codex_e2e"]
+        protected_eval = claimed_payload["protected_eval_result"]
+        research_loop = claimed_payload["research_loop"]
         assert claimed_payload["ok"] is True, claimed_payload
-        assert claimed_payload["replay_result"]["dev_metric"] == 4.0, claimed_payload
-        assert claimed_payload["replay_result"]["holdout_metric"] == 4.5, claimed_payload
+        assert protected_eval["dev_metric"] == 4.0, claimed_payload
+        assert protected_eval["holdout_metric"] == 4.5, claimed_payload
+        assert research_loop["dev_metric"] == 4.0, claimed_payload
+        assert research_loop["holdout_metric"] == 4.5, claimed_payload
         assert live["executed"] is True, claimed_payload
         assert live["claim_allowed"] is True, claimed_payload
         assert live["claim_scope"] == "dev_only", claimed_payload

--- a/examples/catalog-canary-planner-smoke.py
+++ b/examples/catalog-canary-planner-smoke.py
@@ -331,6 +331,10 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     assert (
         "python3 examples/decentralized-auto-research-frontier-smoke.py" in auto_research_commands
     ), auto_research_profile
+    assert (
+        "python3 examples/auto-research-live-codex-claim-boundary-smoke.py"
+        in auto_research_commands
+    ), auto_research_profile
     assert all(check["tier"] == "default" for check in auto_research_profile["checks"]), auto_research_profile
     assert auto_research_profile["deep_checks_available"] is True, auto_research_profile
 

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -790,14 +790,19 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
                 "reason": "checks the deterministic positive demo route, route contract, and no-live-claim boundary",
             },
             {
-                "command": "python3 examples/auto-research-one-click-ux-smoke.py",
-                "tier": "default",
-                "reason": "checks the one-command visible UX packet with fake tmux/Codex binaries",
-            },
-            {
                 "command": "python3 examples/decentralized-auto-research-frontier-smoke.py",
                 "tier": "default",
                 "reason": "checks shared frontier, evidence graph, board projection, and public boundary fixtures",
+            },
+            {
+                "command": "python3 examples/auto-research-live-codex-claim-boundary-smoke.py",
+                "tier": "default",
+                "reason": "guards that live E2E claims stay dev-only unless held-out or promotion authority is explicit",
+            },
+            {
+                "command": "python3 examples/auto-research-one-click-ux-smoke.py",
+                "tier": "default",
+                "reason": "checks the one-command visible UX packet with fake tmux/Codex binaries",
             },
             {
                 "command": "python3 examples/auto-research-demo-supervisor-smoke.py",
@@ -813,11 +818,6 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
                 "command": "python3 examples/auto-research-rollout-readpath-smoke.py",
                 "tier": "deep",
                 "reason": "checks rollout event read-path projection into live evidence graphs",
-            },
-            {
-                "command": "python3 examples/auto-research-live-codex-claim-boundary-smoke.py",
-                "tier": "deep",
-                "reason": "guards that live E2E claims require lane-authored public evidence",
             },
             {
                 "command": "python3 examples/auto-research-live-evidence-capture-smoke.py",


### PR DESCRIPTION
## Summary

- promote `auto-research-live-codex-claim-boundary-smoke.py` into the default `auto-research-demo` canary slice
- keep the default `auto-research-demo` run bounded by selecting the E2E route, frontier projection, and live claim-boundary checks first
- update the live claim-boundary smoke from the removed top-level `replay_result` field to the current `protected_eval_result` / `research_loop` output contract
- add planner smoke coverage so the claim-boundary check cannot silently fall out of the default auto-research profile again

## Motivation

The `auto-research-demo` profile previously passed without exercising the live Codex claim boundary. That meant the default canary could miss a regression where dev metrics are public but held-out or promotion claims become visible without explicit authority. This makes that boundary part of the default profile so canary runs can catch product-surface claim mistakes earlier.

## Validation

- `python3 examples/auto-research-live-codex-claim-boundary-smoke.py`
- `python3 examples/catalog-canary-planner-smoke.py`
- `python3 -m loopx.cli --format json canary run --profile auto-research-demo --max-checks-per-profile 3 --check-limit 3 --timeout-seconds 120`
- `python3 -m compileall -q loopx/canary/planner.py examples/catalog-canary-planner-smoke.py examples/auto-research-live-codex-claim-boundary-smoke.py`
- `git diff --check`
- `python3 -m loopx.cli check --scan-path loopx/canary/planner.py --scan-path examples/catalog-canary-planner-smoke.py --scan-path examples/auto-research-live-codex-claim-boundary-smoke.py`

## Boundary

Public canary/profile/smoke change only. No raw logs, private paths, credentials, benchmark runner changes, or promotion evidence writes.
