### PR TITLE
Package GitHub workflows in local releases

### DIFF
--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -195,6 +195,7 @@ def main() -> int:
         assert wrapper.resolve().name == "loopx", wrapper.resolve()
         release_root = wrapper.resolve().parents[1]
         assert (release_root / "loopx" / "cli.py").is_file(), release_root
+        assert (release_root / ".github" / "workflows" / "update-notes.yml").is_file(), release_root
         release_manifest_path = release_root / "release.json"
         assert release_manifest_path.is_file(), release_manifest_path
         release_manifest = json.loads(release_manifest_path.read_text(encoding="utf-8"))

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -108,6 +108,7 @@ copy_path "$repo_root/scripts" "$release_tmp/scripts"
 copy_path "$repo_root/skills" "$release_tmp/skills"
 copy_path "$repo_root/docs" "$release_tmp/docs"
 copy_path "$repo_root/examples" "$release_tmp/examples"
+copy_path "$repo_root/.github" "$release_tmp/.github"
 copy_path "$repo_root/README.md" "$release_tmp/README.md"
 copy_path "$repo_root/pyproject.toml" "$release_tmp/pyproject.toml"
 find "$release_tmp" -name __pycache__ -type d -prune -exec rm -rf {} +


### PR DESCRIPTION
## Summary
- include the public `.github` directory in local release snapshots produced by `scripts/install-local.sh`
- extend `install-local-smoke` to assert the packaged release contains `.github/workflows/update-notes.yml`

## Why
`product-entry-workflows` canary caught a real installed-release mismatch: the source tree has `.github/workflows/update-notes.yml`, but the local release snapshot omitted `.github`, so the installed `examples/update-notes-archive-smoke.py` failed from the packaged release. The fix keeps release packaging aligned with the public canary surface.

## Validation
- `bash -n scripts/install-local.sh`
- `python3 examples/install-local-smoke.py`
- `python3 examples/update-notes-archive-smoke.py`
- `python3 -m compileall -q examples/install-local-smoke.py`
- temporary HOME install + installed `loopx --format json canary run --profile product-entry-workflows --max-checks-per-profile 4 --check-limit 4 --timeout-seconds 120` -> 4/4 passed
- `python3 -m loopx.cli --format json canary run --profile install-update --max-checks-per-profile 3 --check-limit 3 --timeout-seconds 120` -> 3/3 passed
- `git diff --check`
- `python3 -m loopx.cli check --scan-path scripts/install-local.sh --scan-path examples/install-local-smoke.py` -> public boundary clean; existing run-history duplicate-index warning only

## Boundary
Public installer/smoke fix only. No benchmark execution, credentials, raw logs, private state, or local artifacts.
