### PR TITLE
Seed role-compatible auto research demo queue

### DIFF
--- a/examples/auto-research-demo-e2e-smoke.py
+++ b/examples/auto-research-demo-e2e-smoke.py
@@ -13,6 +13,11 @@ from typing import Any
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.capabilities.auto_research.demo_e2e import run_auto_research_demo_e2e  # noqa: E402
+
 GOAL_ID = "loopx-auto-research-knn"
 TRACKING_GOAL_ID = "loopx-meta"
 AGENT_ID = "codex-side-bypass"
@@ -159,6 +164,136 @@ def assert_e2e_payload(
     assert_public_safe(payload)
 
 
+def assert_visible_demo_local_control_plane(*, registry: Path, runtime_root: Path) -> None:
+    captured: dict[str, Any] = {}
+
+    def fake_append_evidence(_packet_path: str) -> dict[str, object]:
+        return {
+            "appended_count": 3,
+            "skipped_existing_count": 0,
+            "counts_by_kind": {"research_evidence": 2, "research_hypothesis": 1},
+        }
+
+    def fake_visible_launcher(
+        supervisor: dict[str, object],
+        visible_registry: Path,
+        visible_runtime_root: str | None,
+    ) -> dict[str, object]:
+        captured["registry"] = visible_registry
+        captured["runtime_root"] = visible_runtime_root
+        expected_actions = {
+            "codex-product-capability": "write_research_contract",
+            "codex-side-bypass": "propose_hypothesis",
+            "codex-main-control": "claim_attempt",
+        }
+        for agent_id, action in expected_actions.items():
+            quota = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "loopx.cli",
+                    "--registry",
+                    str(visible_registry),
+                    "--runtime-root",
+                    str(visible_runtime_root),
+                    "--format",
+                    "json",
+                    "quota",
+                    "should-run",
+                    "--goal-id",
+                    GOAL_ID,
+                    "--agent-id",
+                    agent_id,
+                ],
+                cwd=REPO_ROOT,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            quota_payload = json.loads(quota.stdout)
+            next_action = quota_payload["agent_lane_next_action"]
+            assert next_action["action_kind"] == action, quota_payload
+            assert next_action["claimed_by"] == agent_id, quota_payload
+            frontier = subprocess.run(
+                [
+                    sys.executable,
+                    "-m",
+                    "loopx.cli",
+                    "--registry",
+                    str(visible_registry),
+                    "--runtime-root",
+                    str(visible_runtime_root),
+                    "--format",
+                    "json",
+                    "auto-research",
+                    "frontier",
+                    "--goal-id",
+                    GOAL_ID,
+                    "--agent-id",
+                    agent_id,
+                ],
+                cwd=REPO_ROOT,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            frontier_payload = json.loads(frontier.stdout)
+            selected = frontier_payload["frontier"]["selected"]
+            assert selected["allowed_action"] == action, frontier_payload
+            assert selected["claimed_by"] == agent_id, frontier_payload
+        return {
+            "mode": "executed_visible_launch",
+            "launch_result": {
+                "started_lane_count": len(supervisor.get("lanes") or []),
+                "surviving_lane_count": len(supervisor.get("lanes") or []),
+                "visible_acceptance": {"accepted": True, "missing_lanes": []},
+            },
+            "boundary": {
+                "shared_state_route": "LOOPX_REGISTRY_and_LOOPX_RUNTIME_ROOT",
+                "starts_tmux": False,
+                "runs_codex": False,
+            },
+        }
+
+    payload = run_auto_research_demo_e2e(
+        agent_id=AGENT_ID,
+        goal_id=GOAL_ID,
+        tracking_goal_id=TRACKING_GOAL_ID,
+        objective="Improve exact k-nearest-neighbor inference under a protected evaluator.",
+        output_dir=".local/auto-research-demo",
+        execute=True,
+        launch_visible=True,
+        keep_workspace=False,
+        registry_path=registry,
+        runtime_root_arg=str(runtime_root),
+        session_name="loopx-auto-research-smoke",
+        cli_bin="loopx",
+        codex_bin="codex",
+        tmux_bin="tmux",
+        reasoning_effort="high",
+        live_evidence_path=None,
+        append_evidence=fake_append_evidence,
+        visible_launcher=fake_visible_launcher,
+    )
+    assert captured["registry"] != registry, captured
+    assert captured["runtime_root"] != str(runtime_root), captured
+    control = payload["visible_control_plane"]
+    assert control["schema_version"] == "auto_research_visible_demo_control_plane_v0", payload
+    assert control["mode"] == "demo_local_loopx_queue", payload
+    assert control["goal_id"] == GOAL_ID, payload
+    assert control["registry_scope"] == "demo_local_runtime", payload
+    assert control["registered_agent_count"] == 3, payload
+    assert control["seeded_todo_count"] == 3, payload
+    assert {item["action_kind"] for item in control["seeded_todos"]} == {
+        "write_research_contract",
+        "propose_hypothesis",
+        "claim_attempt",
+    }, payload
+    assert control["absolute_paths_recorded"] is False, payload
+    assert payload["live_codex_e2e"]["visible_lanes_accepted"] is True, payload
+    assert_public_safe(payload)
+
+
 def main() -> int:
     with tempfile.TemporaryDirectory() as temp_dir:
         temp = Path(temp_dir)
@@ -210,6 +345,7 @@ def main() -> int:
         assert f"--goal-id {GOAL_ID}" in visible_command, visible_command
         assert f"--tracking-goal-id {TRACKING_GOAL_ID}" in kernel_command, kernel_command
         assert f"--tracking-goal-id {TRACKING_GOAL_ID}" in visible_command, visible_command
+        assert_visible_demo_local_control_plane(registry=registry, runtime_root=runtime_root)
 
         markdown = run_cli(
             [

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -684,13 +684,17 @@ def handle_auto_research_command(
                     dry_run=False,
                 )
 
-            visible_launcher: Callable[[dict[str, object]], dict[str, object]] | None = None
+            visible_launcher: Callable[[dict[str, object], Path, str | None], dict[str, object]] | None = None
             if args.launch_visible:
-                def visible_launcher(supervisor: dict[str, object]) -> dict[str, object]:
+                def visible_launcher(
+                    supervisor: dict[str, object],
+                    visible_registry_path: Path,
+                    visible_runtime_root_arg: str | None,
+                ) -> dict[str, object]:
                     return _execute_auto_research_demo_supervisor(
                         supervisor,
-                        registry_path=registry_path,
-                        runtime_root_arg=runtime_root_arg,
+                        registry_path=visible_registry_path,
+                        runtime_root_arg=visible_runtime_root_arg,
                         launcher=args.launcher,
                         tmux_bin=args.tmux_bin,
                         cli_bin=args.cli_bin,

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -35,7 +35,139 @@ from ...status import collect_status
 
 
 AppendEvidence = Callable[[str], dict[str, object]]
-VisibleLauncher = Callable[[dict[str, object]], dict[str, object]]
+VisibleLauncher = Callable[..., dict[str, object]]
+
+
+def _seed_visible_demo_control_plane(
+    *,
+    demo_root: Path,
+    goal_id: str,
+    objective: str,
+    supervisor: dict[str, object],
+) -> tuple[dict[str, object], Path, str]:
+    """Create a tiny demo-local LoopX queue for visible workers."""
+
+    from ...bootstrap import bootstrap_project
+    from ...configure_goal import configure_goal
+    from ...todos import add_goal_todo
+
+    control_project = demo_root / "visible-control-plane"
+    control_registry = demo_root / "visible-control-plane.registry.json"
+    control_runtime = demo_root / "visible-control-plane.runtime"
+    bootstrap_project(
+        project=control_project,
+        registry_path=control_registry,
+        runtime_root=control_runtime,
+        goal_id=goal_id,
+        objective=objective,
+        domain="auto-research-demo",
+        role="agent",
+        parent_goal_id=None,
+        state_file=None,
+        goal_doc=None,
+        adapter_kind="auto_research_demo_local_queue",
+        adapter_status="connected",
+        next_probe=None,
+        spawn_allowed=True,
+        max_children=3,
+        allowed_domains=["auto-research-demo"],
+        write_scope=["examples/**", "experiments/**", ".local/**"],
+        claim_ttl_minutes=60,
+        onboarding_scan_enabled=False,
+        accept_onboarding_agent_todos=False,
+        begin_autonomous_advance=True,
+        codex_app_heartbeat="no",
+        force=False,
+        dry_run=False,
+        sync_global=False,
+    )
+
+    lanes = [lane for lane in supervisor.get("lanes") or [] if isinstance(lane, dict)]
+    agents = sorted(
+        {
+            str(lane.get("agent_id") or "").strip()
+            for lane in lanes
+            if str(lane.get("agent_id") or "").strip()
+        }
+    )
+    primary_agent = (
+        "codex-main-control"
+        if "codex-main-control" in agents
+        else (agents[0] if agents else None)
+    )
+    configure_goal(
+        registry_path=control_registry,
+        goal_id=goal_id,
+        registered_agents=agents,
+        primary_agent=primary_agent,
+        waiting_on="codex",
+        orchestration_mode="multi_subagent",
+        spawn_allowed=True,
+        execute=True,
+    )
+
+    seeded_todos: list[dict[str, object]] = []
+    for lane in lanes:
+        agent_id = str(lane.get("agent_id") or "").strip()
+        role_id = str(lane.get("role_id") or "").strip()
+        lane_id = str(lane.get("lane_id") or "").strip()
+        profile = lane.get("role_profile") if isinstance(lane.get("role_profile"), dict) else {}
+        allowed_actions = profile.get("allowed_actions") if isinstance(profile, dict) else []
+        action_kind = str((allowed_actions or ["advance_todo"])[0])
+        title_by_action = {
+            "write_research_contract": (
+                "Write the public-safe research contract for the quickstart k-NN hypothesis."
+            ),
+            "propose_hypothesis": (
+                "Map the quickstart partial-selection idea into a todo-backed research hypothesis."
+            ),
+            "claim_attempt": (
+                "Claim one visible attempt boundary for the selected quickstart hypothesis."
+            ),
+            "run_dev_eval": (
+                "Run the selected quickstart hypothesis on the dev split and write public-safe evidence."
+            ),
+            "write_evaluation_summary": (
+                "Verify the evidence packet and open the next validation or promotion gate."
+            ),
+        }
+        title = title_by_action.get(
+            action_kind,
+            f"Run one role-compatible auto-research action for {role_id or lane_id}.",
+        )
+        result = add_goal_todo(
+            registry_path=control_registry,
+            goal_id=goal_id,
+            role="agent",
+            text=f"[P0-auto-research-live] {title}",
+            task_class="advancement_task",
+            action_kind=action_kind,
+            claimed_by=agent_id or None,
+            project=control_project,
+        )
+        seeded_todos.append(
+            {
+                "todo_id": result.get("todo_id"),
+                "agent_id": agent_id,
+                "lane_id": lane_id,
+                "role_id": role_id,
+                "action_kind": action_kind,
+            }
+        )
+
+    summary = {
+        "schema_version": "auto_research_visible_demo_control_plane_v0",
+        "mode": "demo_local_loopx_queue",
+        "goal_id": goal_id,
+        "registry_scope": "demo_local_runtime",
+        "registered_agent_count": len(agents),
+        "seeded_todo_count": len(seeded_todos),
+        "seeded_todos": seeded_todos,
+        "state_route": "visible_lanes_use_LOOPX_REGISTRY_and_LOOPX_RUNTIME_ROOT",
+        "absolute_paths_recorded": False,
+        "private_artifacts_recorded": False,
+    }
+    return summary, control_registry, str(control_runtime)
 
 
 def _live_board_and_acceptance(
@@ -489,7 +621,22 @@ def run_auto_research_demo_e2e(
             }
         )
         if launch_visible and visible_launcher is not None:
-            visible_payload = visible_launcher(dict(supervisor))
+            (
+                visible_control,
+                visible_registry_path,
+                visible_runtime_root_arg,
+            ) = _seed_visible_demo_control_plane(
+                demo_root=demo_root,
+                goal_id=goal_id,
+                objective=objective,
+                supervisor=supervisor,
+            )
+            payload["visible_control_plane"] = visible_control
+            visible_payload = visible_launcher(
+                dict(supervisor),
+                visible_registry_path,
+                visible_runtime_root_arg,
+            )
             launch_result = (
                 visible_payload.get("launch_result")
                 if isinstance(visible_payload.get("launch_result"), dict)


### PR DESCRIPTION
## Summary
- Seed a demo-local LoopX control plane for `auto-research demo-e2e --execute --launch-visible`, so visible workers read role-compatible quota/frontier todos instead of stale real-goal gates.
- Route the visible launcher through that demo-local registry/runtime while keeping worker panes on normal LoopX quota/frontier/CLI writeback flow.
- Add smoke coverage that verifies each demo role is selected by quota/frontier with its role-profile action.

## Validation
- `python3 -m compileall -q loopx/capabilities/auto_research loopx/visible_multi_agent_launcher.py`
- `python3 examples/auto-research-demo-e2e-smoke.py`
- `python3 examples/auto-research-visible-launcher-smoke.py`
- `python3 examples/auto-research-demo-supervisor-smoke.py`
- `python3 examples/auto-research-lightweight-kernel-smoke.py`
- `python3 examples/auto-research-one-click-ux-smoke.py`
- `loopx check --scan-path loopx/capabilities/auto_research/demo_e2e.py --scan-path loopx/capabilities/auto_research/cli.py --scan-path examples/auto-research-demo-e2e-smoke.py` (passes; existing loopx-meta duplicate-index warning only)