### PR TITLE
Keep visible auto research demo workspace

### DIFF
--- a/examples/auto-research-demo-e2e-smoke.py
+++ b/examples/auto-research-demo-e2e-smoke.py
@@ -178,9 +178,13 @@ def assert_visible_demo_local_control_plane(*, registry: Path, runtime_root: Pat
         supervisor: dict[str, object],
         visible_registry: Path,
         visible_runtime_root: str | None,
+        default_workspace: Path,
     ) -> dict[str, object]:
         captured["registry"] = visible_registry
         captured["runtime_root"] = visible_runtime_root
+        captured["workspace"] = default_workspace
+        assert default_workspace.is_dir(), default_workspace
+        assert list(default_workspace.glob(".local/auto-research-demo/**/protected_eval.py")), default_workspace
         expected_actions = {
             "codex-product-capability": "write_research_contract",
             "codex-side-bypass": "propose_hypothesis",
@@ -277,6 +281,7 @@ def assert_visible_demo_local_control_plane(*, registry: Path, runtime_root: Pat
     )
     assert captured["registry"] != registry, captured
     assert captured["runtime_root"] != str(runtime_root), captured
+    assert captured["workspace"] != REPO_ROOT, captured
     control = payload["visible_control_plane"]
     assert control["schema_version"] == "auto_research_visible_demo_control_plane_v0", payload
     assert control["mode"] == "demo_local_loopx_queue", payload
@@ -290,6 +295,7 @@ def assert_visible_demo_local_control_plane(*, registry: Path, runtime_root: Pat
         "claim_attempt",
     }, payload
     assert control["absolute_paths_recorded"] is False, payload
+    assert payload["workspace_retained"] is True, payload
     assert payload["live_codex_e2e"]["visible_lanes_accepted"] is True, payload
     assert_public_safe(payload)
 

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -690,7 +690,9 @@ def handle_auto_research_command(
                     supervisor: dict[str, object],
                     visible_registry_path: Path,
                     visible_runtime_root_arg: str | None,
+                    default_workspace: Path,
                 ) -> dict[str, object]:
+                    workspace = args.workspace or str(default_workspace)
                     return _execute_auto_research_demo_supervisor(
                         supervisor,
                         registry_path=visible_registry_path,
@@ -701,7 +703,7 @@ def handle_auto_research_command(
                         codex_bin=args.codex_bin,
                         attach=args.attach,
                         replace_existing=args.replace_existing,
-                        workspace=args.workspace,
+                        workspace=workspace,
                         create_workspace=args.create_workspace,
                     )
 

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -499,7 +499,7 @@ def run_auto_research_demo_e2e(
         return payload
 
     tmp_obj: tempfile.TemporaryDirectory[str] | None = None
-    if keep_workspace:
+    if keep_workspace or launch_visible:
         demo_root = Path(tempfile.mkdtemp(prefix="loopx-auto-research-demo-e2e."))
     else:
         tmp_obj = tempfile.TemporaryDirectory(prefix="loopx-auto-research-demo-e2e.")
@@ -617,7 +617,7 @@ def run_auto_research_demo_e2e(
                 },
                 "board": _compact_board(board),
                 "acceptance": _compact_acceptance(acceptance),
-                "workspace_retained": keep_workspace,
+                "workspace_retained": keep_workspace or launch_visible,
             }
         )
         if launch_visible and visible_launcher is not None:
@@ -636,6 +636,7 @@ def run_auto_research_demo_e2e(
                 dict(supervisor),
                 visible_registry_path,
                 visible_runtime_root_arg,
+                demo_root,
             )
             launch_result = (
                 visible_payload.get("launch_result")


### PR DESCRIPTION
## Summary
- Keep the generated demo workspace whenever `auto-research demo-e2e --execute --launch-visible` starts visible panes.
- Use that generated workspace as the default pane workspace when the user does not pass `--workspace`, so panes can see the quickstart pack and demo-local LoopX control plane.
- Extend the E2E smoke to verify the default workspace contains the generated protected-eval pack while public output remains path-redacted.

## Validation
- `python3 -m compileall -q loopx/capabilities/auto_research loopx/visible_multi_agent_launcher.py`
- `python3 examples/auto-research-demo-e2e-smoke.py`
- `python3 examples/auto-research-visible-launcher-smoke.py`
- `loopx check --scan-path loopx/capabilities/auto_research/demo_e2e.py --scan-path loopx/capabilities/auto_research/cli.py --scan-path examples/auto-research-demo-e2e-smoke.py` (passes; existing loopx-meta duplicate-index warning only)
