### PR TITLE
Run visible auto-research lanes from real worktrees

### DIFF
--- a/examples/auto-research-demo-e2e-smoke.py
+++ b/examples/auto-research-demo-e2e-smoke.py
@@ -190,7 +190,16 @@ def assert_visible_demo_local_control_plane(*, registry: Path, runtime_root: Pat
             "codex-side-bypass": "propose_hypothesis",
             "codex-main-control": "claim_attempt",
         }
+        lane_workspaces = {
+            str(lane.get("agent_id")): Path(str(lane.get("workspace"))).resolve()
+            for lane in supervisor.get("lanes", [])
+            if isinstance(lane, dict) and lane.get("workspace")
+        }
         for agent_id, action in expected_actions.items():
+            lane_cwd = lane_workspaces.get(agent_id, default_workspace)
+            assert lane_cwd.is_dir(), lane_cwd
+            env = os.environ.copy()
+            env["PYTHONPATH"] = f"{REPO_ROOT}{os.pathsep}{env.get('PYTHONPATH', '')}"
             quota = subprocess.run(
                 [
                     sys.executable,
@@ -209,7 +218,8 @@ def assert_visible_demo_local_control_plane(*, registry: Path, runtime_root: Pat
                     "--agent-id",
                     agent_id,
                 ],
-                cwd=REPO_ROOT,
+                cwd=lane_cwd,
+                env=env,
                 check=True,
                 capture_output=True,
                 text=True,
@@ -236,7 +246,8 @@ def assert_visible_demo_local_control_plane(*, registry: Path, runtime_root: Pat
                     "--agent-id",
                     agent_id,
                 ],
-                cwd=REPO_ROOT,
+                cwd=lane_cwd,
+                env=env,
                 check=True,
                 capture_output=True,
                 text=True,
@@ -294,6 +305,11 @@ def assert_visible_demo_local_control_plane(*, registry: Path, runtime_root: Pat
         "propose_hypothesis",
         "claim_attempt",
     }, payload
+    workspace_route = control["workspace_route"]
+    assert workspace_route["shared_goal_surface"] == "demo_local_loopx_registry_and_runtime", payload
+    assert workspace_route["side_lane_workspace"] == "independent_git_worktree", payload
+    assert workspace_route["side_lane_worktree_count"] == 2, payload
+    assert workspace_route["absolute_paths_recorded"] is False, payload
     assert control["absolute_paths_recorded"] is False, payload
     assert payload["workspace_retained"] is True, payload
     assert payload["live_codex_e2e"]["visible_lanes_accepted"] is True, payload

--- a/examples/auto-research-visible-launcher-smoke.py
+++ b/examples/auto-research-visible-launcher-smoke.py
@@ -203,7 +203,7 @@ def main() -> int:
             assert "loopx_polling_prompt=visible_bootstrap_prompt" in command, command
             assert "reasoning_effort=high" in command, command
             assert "LOOPX_VISIBLE_BOOTSTRAP_PAUSE_SECONDS" in command, command
-            assert 'codex -c model_reasoning_effort=high "$BOOTSTRAP_PROMPT"' in command, command
+            assert 'codex exec -c model_reasoning_effort=high --cd "$LOOPX_PROJECT" --sandbox danger-full-access "$BOOTSTRAP_PROMPT"' in command, command
             assert "[Codex CLI exited]" in command, command
             assert "inspect this pane; interrupt, close, or retry manually" in command, command
             assert "exec /bin/sh -i" in command, command

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -122,6 +122,7 @@ def main() -> int:
                 "source": "worker/SKILL.md",
                 "destination": ".codex/skills/loopx-auto-research/SKILL.md",
                 "materialized": True,
+                "workspace_count": 1,
             }
         ], skills
         assert (workspace / ".codex/skills/loopx-auto-research/SKILL.md").read_text(

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import shlex
 import subprocess
 import sys
@@ -36,6 +37,56 @@ from ...status import collect_status
 
 AppendEvidence = Callable[[str], dict[str, object]]
 VisibleLauncher = Callable[..., dict[str, object]]
+
+
+def _safe_ref_fragment(value: object, *, fallback: str) -> str:
+    text = re.sub(r"[^A-Za-z0-9._-]+", "-", str(value or "").strip()).strip("-._")
+    return text[:48] or fallback
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+
+
+def _prepare_visible_demo_git_workspaces(
+    *,
+    control_project: Path,
+    demo_root: Path,
+    lanes: list[dict[str, object]],
+    primary_agent: str | None,
+) -> dict[str, object]:
+    """Give side-agent lanes real git worktrees while sharing one LoopX state."""
+
+    (control_project / ".gitignore").write_text(".local/\n", encoding="utf-8")
+    _git(control_project, "init")
+    _git(control_project, "config", "user.email", "loopx-demo@example.invalid")
+    _git(control_project, "config", "user.name", "LoopX Demo")
+    _git(control_project, "add", ".")
+    _git(control_project, "commit", "-m", "seed visible auto research demo control plane")
+
+    worktree_root = demo_root / "visible-lane-worktrees"
+    side_count = 0
+    for index, lane in enumerate(lanes, start=1):
+        agent_id = str(lane.get("agent_id") or "").strip()
+        if not agent_id or agent_id == primary_agent:
+            lane["workspace_role"] = "primary_control_project"
+            continue
+        lane_id = _safe_ref_fragment(lane.get("lane_id"), fallback=f"lane-{index}")
+        branch = f"demo/{_safe_ref_fragment(agent_id, fallback=f'agent-{index}')}-{index}"
+        workspace = worktree_root / lane_id
+        _git(control_project, "worktree", "add", "-b", branch, str(workspace))
+        lane["workspace"] = str(workspace)
+        lane["workspace_role"] = "independent_git_worktree"
+        side_count += 1
+
+    return {
+        "schema_version": "auto_research_visible_demo_workspace_route_v0",
+        "shared_goal_surface": "demo_local_loopx_registry_and_runtime",
+        "primary_workspace": "control_project_git_worktree",
+        "side_lane_workspace": "independent_git_worktree",
+        "side_lane_worktree_count": side_count,
+        "absolute_paths_recorded": False,
+    }
 
 
 def _seed_visible_demo_control_plane(
@@ -155,6 +206,13 @@ def _seed_visible_demo_control_plane(
             }
         )
 
+    workspace_route = _prepare_visible_demo_git_workspaces(
+        control_project=control_project,
+        demo_root=demo_root,
+        lanes=lanes,
+        primary_agent=primary_agent,
+    )
+
     summary = {
         "schema_version": "auto_research_visible_demo_control_plane_v0",
         "mode": "demo_local_loopx_queue",
@@ -164,6 +222,7 @@ def _seed_visible_demo_control_plane(
         "seeded_todo_count": len(seeded_todos),
         "seeded_todos": seeded_todos,
         "state_route": "visible_lanes_use_LOOPX_REGISTRY_and_LOOPX_RUNTIME_ROOT",
+        "workspace_route": workspace_route,
         "absolute_paths_recorded": False,
         "private_artifacts_recorded": False,
     }

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -163,8 +163,9 @@ def build_visible_lane_command(
         "fi; "
         f"{visible_summary}; "
         'sleep "${LOOPX_VISIBLE_BOOTSTRAP_PAUSE_SECONDS:-1}"; '
-        "printf '\\n[Starting visible Codex CLI]\\n'; "
-        f"{_q(codex_bin)} -c model_reasoning_effort={_q(reasoning_effort)} \"$BOOTSTRAP_PROMPT\"; "
+        "printf '\\n[Starting visible Codex exec]\\n'; "
+        f"{_q(codex_bin)} exec -c model_reasoning_effort={_q(reasoning_effort)} "
+        '--cd "$LOOPX_PROJECT" --sandbox danger-full-access "$BOOTSTRAP_PROMPT"; '
         "CODEX_STATUS=$?; "
         "printf '\\n[Codex CLI exited]\\nexit=%s\\n' \"$CODEX_STATUS\"; "
         f"{keep_visible}"
@@ -251,21 +252,37 @@ def _materialize_worker_skills(
         source = Path(source_name)
         if not source.is_absolute():
             source = source_root / source
-        destination = project / ".codex" / "skills" / skill_name / "SKILL.md"
+        workspace_values = [project]
+        lane_workspace = _lane_workspace(lane, default_project=project)
+        if lane_workspace != project:
+            workspace_values.append(lane_workspace)
         item = {
             "skill": skill_name,
             "source": source_name,
             "destination": f".codex/skills/{skill_name}/SKILL.md",
             "materialized": False,
+            "workspace_count": len(workspace_values),
         }
         if source.is_file():
-            destination.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copyfile(source, destination)
+            for workspace in workspace_values:
+                destination = workspace / ".codex" / "skills" / skill_name / "SKILL.md"
+                destination.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(source, destination)
             item["materialized"] = True
         else:
             item["missing_source"] = True
         results.append(item)
     return results
+
+
+def _lane_workspace(lane: dict[str, object], *, default_project: Path) -> Path:
+    raw = lane.get("workspace") or lane.get("project")
+    if not raw:
+        return default_project
+    path = Path(str(raw)).expanduser()
+    if not path.is_absolute():
+        path = default_project / path
+    return path.resolve()
 
 
 def execute_visible_multi_agent_launcher(
@@ -383,6 +400,9 @@ def _launch_with_tmux(
         launch_command = str(lane.get("visible_launch_command") or "")
         if not launch_command:
             raise ValueError(f"lane {lane_id} is missing visible_launch_command")
+        lane_project = _lane_workspace(lane, default_project=project)
+        if not lane_project.is_dir():
+            raise ValueError(f"lane {lane_id} workspace does not exist")
         subprocess.run(
             [
                 tmux_bin,
@@ -396,7 +416,7 @@ def _launch_with_tmux(
                 "-lc",
                 runtime_shell_command(
                     launch_command,
-                    project=project,
+                    project=lane_project,
                     registry=registry,
                     runtime_root=runtime_root,
                     errexit=False,


### PR DESCRIPTION
## Summary
- Run visible auto-research Codex lanes with `codex exec` so one-command demos do not pause on interactive trust prompts.
- Give side-agent demo lanes independent git worktrees while keeping one shared demo-local LoopX registry/runtime goal surface.
- Extend focused smokes to prove side-agent quota/frontier routing works from lane worktrees and worker-local skills still materialize.

## Validation
- `python3 -m compileall -q loopx/capabilities/auto_research loopx/visible_multi_agent_launcher.py`
- `python3 examples/visible-multi-agent-launcher-smoke.py`
- `python3 examples/auto-research-visible-launcher-smoke.py`
- `python3 examples/auto-research-demo-e2e-smoke.py`
- `python3 examples/generic-multi-agent-one-command-smoke.py`
- `loopx check --scan-path loopx/visible_multi_agent_launcher.py --scan-path loopx/capabilities/auto_research/demo_e2e.py --scan-path examples/auto-research-demo-e2e-smoke.py --scan-path examples/auto-research-visible-launcher-smoke.py --scan-path examples/visible-multi-agent-launcher-smoke.py`
- `git diff --check`

## Boundary
- Public/private boundary scan clean.
- No raw session transcripts, credentials, private artifacts, or local evidence are committed.