### PR TITLE
Allow visible Codex exec in demo worktrees

### DIFF
--- a/examples/auto-research-visible-launcher-smoke.py
+++ b/examples/auto-research-visible-launcher-smoke.py
@@ -203,7 +203,7 @@ def main() -> int:
             assert "loopx_polling_prompt=visible_bootstrap_prompt" in command, command
             assert "reasoning_effort=high" in command, command
             assert "LOOPX_VISIBLE_BOOTSTRAP_PAUSE_SECONDS" in command, command
-            assert 'codex exec -c model_reasoning_effort=high --cd "$LOOPX_PROJECT" --sandbox danger-full-access "$BOOTSTRAP_PROMPT"' in command, command
+            assert 'codex exec -c model_reasoning_effort=high --cd "$LOOPX_PROJECT" --skip-git-repo-check --sandbox danger-full-access "$BOOTSTRAP_PROMPT"' in command, command
             assert "[Codex CLI exited]" in command, command
             assert "inspect this pane; interrupt, close, or retry manually" in command, command
             assert "exec /bin/sh -i" in command, command

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -165,7 +165,7 @@ def build_visible_lane_command(
         'sleep "${LOOPX_VISIBLE_BOOTSTRAP_PAUSE_SECONDS:-1}"; '
         "printf '\\n[Starting visible Codex exec]\\n'; "
         f"{_q(codex_bin)} exec -c model_reasoning_effort={_q(reasoning_effort)} "
-        '--cd "$LOOPX_PROJECT" --sandbox danger-full-access "$BOOTSTRAP_PROMPT"; '
+        '--cd "$LOOPX_PROJECT" --skip-git-repo-check --sandbox danger-full-access "$BOOTSTRAP_PROMPT"; '
         "CODEX_STATUS=$?; "
         "printf '\\n[Codex CLI exited]\\nexit=%s\\n' \"$CODEX_STATUS\"; "
         f"{keep_visible}"


### PR DESCRIPTION
## Summary
- Add `--skip-git-repo-check` to visible `codex exec` lanes so generated demo worktrees can run without stopping at Codex trust preflight.
- Update the focused auto-research launcher smoke to cover the exact command.

## Validation
- `python3 -m compileall -q loopx/visible_multi_agent_launcher.py`
- `python3 examples/auto-research-visible-launcher-smoke.py`
- `python3 examples/visible-multi-agent-launcher-smoke.py`
- `loopx check --scan-path loopx/visible_multi_agent_launcher.py --scan-path examples/auto-research-visible-launcher-smoke.py`
- `git diff --check`

## Boundary
- Public/private boundary scan clean.
- No raw pane transcript or local evidence committed.