### PR TITLE
Scope visible worker LoopX commands to demo state

### DIFF
--- a/examples/auto-research-visible-launcher-smoke.py
+++ b/examples/auto-research-visible-launcher-smoke.py
@@ -193,6 +193,7 @@ def main() -> int:
             assert "auto-research frontier" in command, command
             assert "[Codex bootstrap prompt]" in command, command
             assert "You are a visible LoopX auto-research lane" in command, command
+            assert "pane-local `loopx` command on PATH" in command, command
             assert "visible LoopX polling turn" in command, command
             assert "follow their interaction_contract" in command, command
             assert "generated LoopX heartbeat/polling prompt" in command, command
@@ -201,6 +202,8 @@ def main() -> int:
             assert "[LoopX visible acceptance]" in command, command
             assert "loopx_agent_handshake=role_profile_quota_frontier_bootstrap" in command, command
             assert "loopx_polling_prompt=visible_bootstrap_prompt" in command, command
+            assert "loopx_cli_scope=demo_local_wrapper" in command, command
+            assert 'exec "$LOOPX_REAL_CLI" --registry "$LOOPX_REGISTRY" --runtime-root "$LOOPX_RUNTIME_ROOT" "$@"' in command, command
             assert "reasoning_effort=high" in command, command
             assert "LOOPX_VISIBLE_BOOTSTRAP_PAUSE_SECONDS" in command, command
             assert 'codex exec -c model_reasoning_effort=high --cd "$LOOPX_PROJECT" --skip-git-repo-check --sandbox danger-full-access "$BOOTSTRAP_PROMPT"' in command, command

--- a/loopx/capabilities/auto_research/legacy_core.py
+++ b/loopx/capabilities/auto_research/legacy_core.py
@@ -941,6 +941,8 @@ def _auto_research_codex_bootstrap_prompt(
             "You are a visible LoopX auto-research lane, not a generic LoopX heartbeat worker.",
             "Use loopx-project for quota/status, then follow the worker-local loopx-auto-research role playbook for this pane.",
             "If LOOPX_WORKER_SKILL_PATH is present, read that local playbook path instead of relying on global skill discovery.",
+            "Use the pane-local `loopx` command on PATH; the visible launcher scopes it to this demo's LOOPX_REGISTRY and LOOPX_RUNTIME_ROOT.",
+            "Do not bypass that wrapper with an absolute LoopX binary unless the printed quota/frontier commands explicitly require it.",
             "This pane is a visible LoopX polling turn: before each new action, rerun the printed quota should-run and auto-research frontier commands, then follow their interaction_contract.",
             "Do not run loopx bootstrap-command-pack, loopx heartbeat-prompt, or generic onboarding unless the printed frontier explicitly asks for it.",
             "If a future scheduled automation owns this lane, it must use a generated LoopX heartbeat/polling prompt; this visible bootstrap is the local manual polling prompt.",

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -101,6 +101,17 @@ def build_visible_lane_command(
     reasoning_effort: str,
     frontier_label: str = "[LoopX frontier]",
 ) -> str:
+    scoped_loopx_wrapper = (
+        'LOOPX_REAL_CLI="$(command -v loopx)"; '
+        "export LOOPX_REAL_CLI; "
+        'mkdir -p "$LOOPX_PROJECT/.local/bin"; '
+        "printf '%s\\n' "
+        "'#!/usr/bin/env sh' "
+        "'exec \"$LOOPX_REAL_CLI\" --registry \"$LOOPX_REGISTRY\" --runtime-root \"$LOOPX_RUNTIME_ROOT\" \"$@\"' "
+        '> "$LOOPX_PROJECT/.local/bin/loopx"; '
+        'chmod +x "$LOOPX_PROJECT/.local/bin/loopx"; '
+        'export PATH="$LOOPX_PROJECT/.local/bin:$PATH"; '
+    )
     visible_summary = (
         'printf "\\n[LoopX visible acceptance]\\n"; '
         'printf "role_profile=printed\\n"; '
@@ -109,6 +120,7 @@ def build_visible_lane_command(
         'printf "bootstrap_or_stop=printed\\n"; '
         'printf "loopx_agent_handshake=role_profile_quota_frontier_bootstrap\\n"; '
         'printf "loopx_polling_prompt=visible_bootstrap_prompt\\n"; '
+        'printf "loopx_cli_scope=demo_local_wrapper\\n"; '
         'printf "takeover_controls=visible\\n"; '
         f"printf 'reasoning_effort=%s\\n' {_q(reasoning_effort)}"
     )
@@ -122,6 +134,7 @@ def build_visible_lane_command(
         f"export LOOPX_ROLE_ID={_q(role_id)}; "
         f"export LOOPX_ROLE_PROFILE_REF={_q(role_profile_ref)}; "
         'cd "$LOOPX_PROJECT"; '
+        f"{scoped_loopx_wrapper}"
         f"{role_profile_command}"
         "printf '\\n[LoopX quota guard]\\n'; "
         f"QUOTA_PACKET=\"$({quota_command} 2>&1)\"; "


### PR DESCRIPTION
## Summary
- Put a pane-local `loopx` wrapper on PATH before visible Codex workers run, so bare worker `loopx ...` commands stay scoped to the demo-local registry/runtime.
- Tell workers to use that pane-local LoopX command instead of bypassing the scoped control plane.
- Extend the focused launcher smoke to assert the scoped wrapper contract.

## Validation
- `python3 -m compileall -q loopx/capabilities/auto_research loopx/visible_multi_agent_launcher.py`
- `python3 examples/auto-research-visible-launcher-smoke.py`
- `python3 examples/auto-research-demo-e2e-smoke.py`
- `python3 examples/visible-multi-agent-launcher-smoke.py`
- `loopx check --scan-path loopx/visible_multi_agent_launcher.py --scan-path loopx/capabilities/auto_research/legacy_core.py --scan-path examples/auto-research-visible-launcher-smoke.py`
- `git diff --check`

## Boundary
- Public/private boundary scan clean.
- No raw pane transcript, private state, or local evidence committed.