### PR TITLE
Productize SkillsBench held-bridge launcher

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -10063,6 +10063,20 @@ def test_skillsbench_parallel_batch_isolates_case_process_argv() -> None:
     assert reparsed_child.bootstrap_light_fail_fast_defaulted is True, reparsed_child
 
 
+def test_skillsbench_single_task_ids_replaces_default_task_id() -> None:
+    args = parse_args(
+        [
+            "--task-ids",
+            "bike-rebalance",
+            "--route",
+            "codex-app-server-goal-baseline",
+            "--plan-only",
+        ]
+    )
+    assert args.task_id == "bike-rebalance", args
+    assert skillsbench_loop._batch_task_ids(args) == ["bike-rebalance"], args
+
+
 def test_skillsbench_parallel_batch_recovers_child_payload_from_mixed_stderr() -> None:
     args = parse_args(
         [
@@ -12994,6 +13008,7 @@ if __name__ == "__main__":
     test_cli_skillsbench_result_root_discovers_nested_case_result_for_ledger()
     test_skillsbench_runner_plan_supports_controller_trace_path()
     test_skillsbench_parallel_batch_isolates_case_process_argv()
+    test_skillsbench_single_task_ids_replaces_default_task_id()
     test_skillsbench_parallel_batch_recovers_child_payload_from_mixed_stderr()
     test_skillsbench_compact_runs_update_ledger_pair()
     test_skillsbench_repeat_same_mode_keeps_distinct_ledger_runs()

--- a/examples/skillsbench-reverse-tunnel-supervisor-smoke.py
+++ b/examples/skillsbench-reverse-tunnel-supervisor-smoke.py
@@ -44,6 +44,9 @@ if "LOOPX_REVERSE_TUNNEL_PROBE" in remote_command:
     print("HTTP/1.1 200 Connection Established")
     sys.exit(0)
 
+if "cat >" in remote_command:
+    sys.stdin.read()
+
 print('{{"ok": true, "source": "fake_remote_command"}}')
 sys.exit(0)
 """,
@@ -92,7 +95,7 @@ def test_supervisor_holds_tunnel_and_redacts_private_command() -> None:
             check=False,
             timeout=10,
         )
-        assert proc.returncode == 0, proc.stderr
+        assert proc.returncode == 0, proc.stderr or proc.stdout
         payload = json.loads(proc.stdout)
         persisted = json.loads(public_output.read_text(encoding="utf-8"))
         assert payload == persisted
@@ -113,6 +116,94 @@ def test_supervisor_holds_tunnel_and_redacts_private_command() -> None:
         assert private_log.exists()
 
 
+def test_supervisor_holds_json_bridge_and_materializes_remote_client() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-tunnel-json-") as tmp:
+        root = Path(tmp)
+        fake_ssh = root / "ssh"
+        ssh_log = root / "ssh.log"
+        public_output = root / "public.json"
+        private_log = root / "private.log"
+        local_socket = Path("/tmp") / f"{root.name}.sock"
+        _fake_ssh(fake_ssh, ssh_log)
+
+        opaque_destination = "opaque-benchmark-host.example"
+        opaque_bridge_command = "opaque-private-json-bridge-command"
+        opaque_remote_socket = "/tmp/opaque-private-json-bridge.sock"
+        opaque_remote_client = "/tmp/opaque-private-json-client"
+        opaque_command = (
+            "run-skillsbench --bridge {json_bridge_client} "
+            "--case bike-rebalance"
+        )
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--ssh-bin",
+                str(fake_ssh),
+                "--ssh-destination",
+                opaque_destination,
+                "--remote-forward",
+                "127.0.0.1:18180:127.0.0.1:18180",
+                "--remote-command",
+                opaque_command,
+                "--public-output-path",
+                str(public_output),
+                "--private-log-path",
+                str(private_log),
+                "--tunnel-ready-timeout-sec",
+                "5",
+                "--probe-interval-sec",
+                "0.1",
+                "--run-timeout-sec",
+                "5",
+                "--json-bridge",
+                "--json-bridge-command",
+                opaque_bridge_command,
+                "--json-local-socket",
+                str(local_socket),
+                "--json-remote-socket",
+                opaque_remote_socket,
+                "--json-remote-client-path",
+                opaque_remote_client,
+                "--json-socket-ready-timeout-sec",
+                "2",
+                "--remote-setup-timeout-sec",
+                "2",
+                "--json-server-timeout-sec",
+                "5",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 0, proc.stderr or proc.stdout
+        payload = json.loads(proc.stdout)
+        assert payload["ok"] is True, payload
+        assert payload["tunnel_ready"] is True, payload
+        bridge = payload["json_bridge"]
+        assert bridge["enabled"] is True, bridge
+        assert bridge["server_started"] is True, bridge
+        assert bridge["local_socket_ready"] is True, bridge
+        assert bridge["remote_socket_ready"] is True, bridge
+        assert bridge["remote_client_materialized"] is True, bridge
+        assert bridge["sandbox_env_probe_deferred"] is True, bridge
+        assert bridge["raw_bridge_command_recorded"] is False, bridge
+        assert bridge["raw_socket_paths_recorded"] is False, bridge
+        assert bridge["raw_client_path_recorded"] is False, bridge
+
+        public_text = json.dumps(payload, sort_keys=True)
+        assert opaque_destination not in public_text
+        assert opaque_bridge_command not in public_text
+        assert str(local_socket) not in public_text
+        assert opaque_remote_socket not in public_text
+        assert opaque_remote_client not in public_text
+        assert opaque_remote_client in ssh_log.read_text(encoding="utf-8")
+        assert private_log.exists()
+
+
 if __name__ == "__main__":
     test_supervisor_holds_tunnel_and_redacts_private_command()
+    test_supervisor_holds_json_bridge_and_materializes_remote_client()
     print("skillsbench-reverse-tunnel-supervisor smoke ok")

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -12878,6 +12878,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         parser.error("--task-ids must contain at least one task id")
     if len(set(batch_task_ids)) != len(batch_task_ids):
         parser.error("--task-ids must not contain duplicate task ids")
+    if args.task_ids is not None and len(batch_task_ids) == 1:
+        args.task_id = batch_task_ids[0]
     if (
         args.route in PRODUCT_MODE_CONTROLLER_ROUTES
         and not args.plan_only

--- a/scripts/skillsbench_reverse_tunnel_supervisor.py
+++ b/scripts/skillsbench_reverse_tunnel_supervisor.py
@@ -18,6 +18,7 @@ import shlex
 import signal
 import subprocess
 import sys
+import tempfile
 import time
 from pathlib import Path
 from typing import Any
@@ -27,6 +28,9 @@ SCHEMA_VERSION = "skillsbench_reverse_tunnel_supervisor_v0"
 DEFAULT_REMOTE_FORWARD = "127.0.0.1:18180:127.0.0.1:18180"
 DEFAULT_TEST_HOST = "chatgpt.com"
 DEFAULT_TEST_PORT = 443
+BRIDGE_HELPER = Path(__file__).resolve().with_name(
+    "skillsbench_reverse_channel_bridge.py"
+)
 
 
 def _host_kind(value: str) -> str:
@@ -95,21 +99,272 @@ def _ssh_base_command(args: argparse.Namespace) -> list[str]:
     return command
 
 
-def _tunnel_command(args: argparse.Namespace) -> list[str]:
+def _json_bridge_requested(args: argparse.Namespace) -> bool:
+    return bool(
+        args.json_bridge
+        or args.json_bridge_command
+        or args.json_remote_socket
+        or args.json_remote_client_path
+    )
+
+
+def _json_bridge_public_contract(args: argparse.Namespace) -> dict[str, Any]:
+    return {
+        "enabled": _json_bridge_requested(args),
+        "server_started": False,
+        "local_socket_ready": False,
+        "reverse_socket_forward_requested": bool(args.json_remote_socket),
+        "remote_socket_ready": False,
+        "remote_client_materialized": False,
+        "probe_policy": args.json_bridge_probe_policy,
+        "sandbox_env_probe_deferred": (
+            args.json_bridge_probe_policy == "sandbox-env-deferred"
+        ),
+        "sandbox_env_probe_defer_reason": (
+            "benchflow_ai_addr_ai_port_available_only_inside_task_sandbox"
+            if args.json_bridge_probe_policy == "sandbox-env-deferred"
+            else ""
+        ),
+        "raw_bridge_command_recorded": False,
+        "raw_socket_paths_recorded": False,
+        "raw_client_path_recorded": False,
+        "raw_probe_output_recorded": False,
+    }
+
+
+def _resolved_json_local_socket(
+    args: argparse.Namespace,
+    runtime_dir: Path,
+) -> Path:
+    if args.json_local_socket:
+        return Path(args.json_local_socket).expanduser()
+    return runtime_dir / "json-bridge.sock"
+
+
+def _cleanup_stale_local_forward(args: argparse.Namespace) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "requested": bool(args.cleanup_stale_local_forward),
+        "matched_count": 0,
+        "terminated_count": 0,
+        "raw_process_args_recorded": False,
+    }
+    if not args.cleanup_stale_local_forward:
+        return payload
+    try:
+        proc = subprocess.run(
+            ["ps", "-axo", "pid=,command="],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=5.0,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        payload["first_blocker"] = "stale_forward_scan_failed"
+        return payload
+
+    current_pid = os.getpid()
+    candidates: list[int] = []
+    for line in (proc.stdout or "").splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        pid_text, _, command = stripped.partition(" ")
+        try:
+            pid = int(pid_text)
+        except ValueError:
+            continue
+        if pid == current_pid:
+            continue
+        if (
+            args.ssh_destination in command
+            and args.remote_forward in command
+            and " -R " in f" {command} "
+        ):
+            candidates.append(pid)
+    payload["matched_count"] = len(candidates)
+    for pid in candidates:
+        try:
+            os.kill(pid, signal.SIGTERM)
+            payload["terminated_count"] = int(payload["terminated_count"]) + 1
+        except (OSError, ProcessLookupError):
+            continue
+    if candidates:
+        time.sleep(0.2)
+    return payload
+
+
+def _start_json_bridge_server(
+    args: argparse.Namespace,
+    *,
+    socket_path: Path,
+) -> subprocess.Popen[Any]:
+    return subprocess.Popen(
+        [
+            sys.executable,
+            str(BRIDGE_HELPER),
+            "serve-json",
+            "--socket",
+            str(socket_path),
+            "--bridge-command",
+            args.json_bridge_command,
+            "--timeout-sec",
+            str(max(1.0, float(args.json_server_timeout_sec))),
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        start_new_session=True,
+    )
+
+
+def _probe_local_json_socket(args: argparse.Namespace, socket_path: Path) -> bool:
+    deadline = time.monotonic() + max(1.0, float(args.json_socket_ready_timeout_sec))
+    while time.monotonic() < deadline:
+        if socket_path.exists():
+            return True
+        time.sleep(max(0.05, float(args.probe_interval_sec)))
+    return False
+
+
+def _run_remote_shell_command(
+    args: argparse.Namespace,
+    command: str,
+    *,
+    timeout_sec: float,
+) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [*_ssh_base_command(args), args.ssh_destination, command],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        timeout=max(1.0, float(timeout_sec)),
+        check=False,
+    )
+
+
+def _probe_remote_json_socket(args: argparse.Namespace) -> bool:
+    command = "test -S " + shlex.quote(args.json_remote_socket)
+    try:
+        proc = _run_remote_shell_command(
+            args,
+            command,
+            timeout_sec=args.json_socket_ready_timeout_sec,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return proc.returncode == 0
+
+
+def _materialize_remote_json_client(args: argparse.Namespace, runtime_dir: Path) -> bool:
+    local_client = runtime_dir / "json-bridge-client"
+    try:
+        subprocess.run(
+            [
+                sys.executable,
+                str(BRIDGE_HELPER),
+                "write-client",
+                "--kind",
+                "json",
+                "--socket",
+                args.json_remote_socket,
+                "--output",
+                str(local_client),
+            ],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=max(1.0, float(args.remote_setup_timeout_sec)),
+            check=True,
+        )
+        client_text = local_client.read_text(encoding="utf-8")
+        remote_path = args.json_remote_client_path
+        remote_parent = os.path.dirname(remote_path) or "."
+        remote_command = (
+            "umask 077; mkdir -p "
+            + shlex.quote(remote_parent)
+            + "; cat > "
+            + shlex.quote(remote_path)
+            + "; chmod 700 "
+            + shlex.quote(remote_path)
+        )
+        proc = subprocess.run(
+            [*_ssh_base_command(args), args.ssh_destination, remote_command],
+            input=client_text,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=max(1.0, float(args.remote_setup_timeout_sec)),
+            check=False,
+        )
+    except (OSError, subprocess.CalledProcessError, subprocess.TimeoutExpired):
+        return False
+    return proc.returncode == 0
+
+
+def _render_remote_command(args: argparse.Namespace) -> str:
+    command = args.remote_command
+    if _json_bridge_requested(args):
+        command = command.replace(
+            "{json_bridge_client}",
+            shlex.quote(args.json_remote_client_path),
+        )
+    return command
+
+
+def _remote_json_bridge_env_prefix(args: argparse.Namespace) -> str:
+    if not _json_bridge_requested(args):
+        return ""
+    assignments = {
+        "LOOPX_SKILLSBENCH_JSON_BRIDGE_CLIENT": args.json_remote_client_path,
+        "LOOPX_REVERSE_JSON_TIMEOUT_SEC": str(int(args.json_server_timeout_sec)),
+    }
+    return " ".join(
+        f"{name}={shlex.quote(value)}" for name, value in assignments.items()
+    )
+
+
+def _remote_command_with_bridge_env(args: argparse.Namespace) -> str:
+    rendered = _render_remote_command(args)
+    prefix = _remote_json_bridge_env_prefix(args)
+    if not prefix:
+        return rendered
+    return prefix + " " + rendered
+
+
+def _tunnel_command(
+    args: argparse.Namespace,
+    *,
+    json_local_socket: Path | None = None,
+) -> list[str]:
     keepalive = max(1, int(args.keepalive_interval_sec))
     remote_keepalive = (
         f"while true; do sleep {keepalive}; "
         "echo loopx_reverse_tunnel_keepalive >&2; done"
     )
-    return [
+    command = [
         *_ssh_base_command(args),
         "-o",
         "ExitOnForwardFailure=yes",
-        "-R",
-        args.remote_forward,
-        args.ssh_destination,
-        remote_keepalive,
     ]
+    if _json_bridge_requested(args) and json_local_socket is not None:
+        command.extend(
+            [
+                "-o",
+                "StreamLocalBindUnlink=yes",
+                "-R",
+                f"{args.json_remote_socket}:{json_local_socket}",
+            ]
+        )
+    command.extend(
+        [
+            "-R",
+            args.remote_forward,
+            args.ssh_destination,
+            remote_keepalive,
+        ]
+    )
+    return command
 
 
 def _probe_command(args: argparse.Namespace) -> str:
@@ -241,12 +496,68 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         "raw_remote_output_recorded": False,
         "private_log_written": False,
         "remote_forward": _forward_public_contract(args.remote_forward),
+        "json_bridge": _json_bridge_public_contract(args),
     }
 
     tunnel_proc: subprocess.Popen[Any] | None = None
+    json_bridge_proc: subprocess.Popen[Any] | None = None
+    runtime_dir_obj: tempfile.TemporaryDirectory[str] | None = None
+    json_local_socket: Path | None = None
+
+    def finish(returncode: int) -> tuple[int, dict[str, Any]]:
+        payload["duration_sec"] = round(max(0.0, time.time() - started_at), 3)
+        if tunnel_proc is not None:
+            payload["tunnel_cleanup_status"] = _stop_process_group(
+                tunnel_proc,
+                grace_sec=1.0,
+            )
+            if tunnel_proc.returncode is not None:
+                payload["tunnel_exit_code"] = tunnel_proc.returncode
+        if json_bridge_proc is not None:
+            payload["json_bridge"]["server_cleanup_status"] = _stop_process_group(
+                json_bridge_proc,
+                grace_sec=1.0,
+            )
+            if json_bridge_proc.returncode is not None:
+                payload["json_bridge"]["server_exit_code"] = (
+                    json_bridge_proc.returncode
+                )
+        if runtime_dir_obj is not None:
+            runtime_dir_obj.cleanup()
+        return returncode, payload
+
     try:
+        payload["stale_forward_cleanup"] = _cleanup_stale_local_forward(args)
+        runtime_dir_obj = tempfile.TemporaryDirectory(
+            prefix="loopx-rt-",
+            dir="/tmp",
+        )
+        runtime_dir = Path(runtime_dir_obj.name)
+        if _json_bridge_requested(args):
+            json_bridge_payload = payload["json_bridge"]
+            json_local_socket = _resolved_json_local_socket(args, runtime_dir)
+            try:
+                json_bridge_proc = _start_json_bridge_server(
+                    args,
+                    socket_path=json_local_socket,
+                )
+                json_bridge_payload["server_started"] = True
+            except OSError as exc:
+                payload["first_blocker"] = "json_bridge_server_launch_failed"
+                json_bridge_payload["server_error_type"] = type(exc).__name__[:80]
+                return finish(2)
+
+            if not _probe_local_json_socket(args, json_local_socket):
+                payload["first_blocker"] = "json_bridge_local_socket_not_ready"
+                return finish(2)
+            if json_bridge_proc.poll() is not None:
+                payload["first_blocker"] = "json_bridge_server_exited_before_ready"
+                json_bridge_payload["server_exit_code"] = json_bridge_proc.returncode
+                return finish(2)
+            json_bridge_payload["local_socket_ready"] = True
+
         tunnel_proc = subprocess.Popen(
-            _tunnel_command(args),
+            _tunnel_command(args, json_local_socket=json_local_socket),
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             text=True,
@@ -256,14 +567,14 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     except OSError as exc:
         payload["first_blocker"] = "reverse_tunnel_launch_failed"
         payload["tunnel_error_type"] = type(exc).__name__[:80]
-        return 2, payload
+        return finish(2)
 
     deadline = time.monotonic() + max(1.0, float(args.tunnel_ready_timeout_sec))
     while time.monotonic() < deadline:
         if tunnel_proc.poll() is not None:
             payload["first_blocker"] = "reverse_tunnel_process_exited_before_ready"
             payload["tunnel_exit_code"] = tunnel_proc.returncode
-            return 2, payload
+            return finish(2)
         ready, status = _run_remote_probe(args)
         payload["probe_attempt_count"] = int(payload["probe_attempt_count"]) + 1
         payload["probe_status"] = status
@@ -274,13 +585,32 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
 
     if payload["tunnel_ready"] is not True:
         payload["first_blocker"] = "reverse_tunnel_probe_not_ready"
-        return 2, payload
+        return finish(2)
+
+    if _json_bridge_requested(args):
+        json_bridge_payload = payload["json_bridge"]
+        if not _probe_remote_json_socket(args):
+            payload["first_blocker"] = "json_bridge_remote_socket_not_ready"
+            return finish(2)
+        json_bridge_payload["remote_socket_ready"] = True
+        assert runtime_dir_obj is not None
+        if not _materialize_remote_json_client(args, Path(runtime_dir_obj.name)):
+            payload["first_blocker"] = "json_bridge_remote_client_materialize_failed"
+            return finish(2)
+        json_bridge_payload["remote_client_materialized"] = True
+        json_bridge_payload["remote_command_placeholder_supported"] = (
+            "{json_bridge_client}" in args.remote_command
+        )
 
     if args.preflight_only or not args.remote_command:
         payload["ok"] = True
-        return 0, payload
+        return finish(0)
 
-    command = [*_ssh_base_command(args), args.ssh_destination, args.remote_command]
+    command = [
+        *_ssh_base_command(args),
+        args.ssh_destination,
+        _remote_command_with_bridge_env(args),
+    ]
     try:
         proc = subprocess.run(
             command,
@@ -303,7 +633,7 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         payload["ok"] = proc.returncode == 0
         if proc.returncode != 0:
             payload["first_blocker"] = "remote_command_exit_nonzero"
-        return (0 if proc.returncode == 0 else proc.returncode or 1), payload
+        return finish(0 if proc.returncode == 0 else proc.returncode or 1)
     except subprocess.TimeoutExpired as exc:
         stdout_text = exc.stdout if isinstance(exc.stdout, str) else ""
         stderr_text = exc.stderr if isinstance(exc.stderr, str) else ""
@@ -316,13 +646,7 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
             stderr_text=stderr_text,
         )
         payload["first_blocker"] = "remote_command_timeout"
-        return 124, payload
-    finally:
-        payload["duration_sec"] = round(max(0.0, time.time() - started_at), 3)
-        if tunnel_proc is not None:
-            payload["tunnel_cleanup_status"] = _stop_process_group(tunnel_proc)
-            if tunnel_proc.returncode is not None:
-                payload["tunnel_exit_code"] = tunnel_proc.returncode
+        return finish(124)
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -345,6 +669,68 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--tunnel-ready-timeout-sec", type=float, default=30.0)
     parser.add_argument("--keepalive-interval-sec", type=int, default=20)
     parser.add_argument("--run-timeout-sec", type=float, default=7200.0)
+    parser.add_argument(
+        "--cleanup-stale-local-forward",
+        action="store_true",
+        help=(
+            "Before launching, terminate matching local ssh -R processes for "
+            "the same destination and remote-forward. Public output records "
+            "counts only."
+        ),
+    )
+    parser.add_argument(
+        "--json-bridge",
+        action="store_true",
+        help=(
+            "Hold a per-run JSON reverse-channel bridge alongside the TCP "
+            "reverse tunnel."
+        ),
+    )
+    parser.add_argument(
+        "--json-bridge-command",
+        default="",
+        help=(
+            "Private local command executed by the JSON bridge server for "
+            "sandbox command/file requests. Not written to public output."
+        ),
+    )
+    parser.add_argument(
+        "--json-local-socket",
+        default="",
+        help=(
+            "Optional local Unix socket path for the JSON bridge server. "
+            "Omit to use a per-run temporary socket."
+        ),
+    )
+    parser.add_argument(
+        "--json-remote-socket",
+        default="",
+        help=(
+            "Remote Unix socket path exposed through ssh -R for the JSON "
+            "bridge. The raw path is not written to public output."
+        ),
+    )
+    parser.add_argument(
+        "--json-remote-client-path",
+        default="",
+        help=(
+            "Remote path where the JSON bridge client script is materialized. "
+            "Use {json_bridge_client} inside --remote-command to inject it."
+        ),
+    )
+    parser.add_argument("--json-server-timeout-sec", type=float, default=7200.0)
+    parser.add_argument("--json-socket-ready-timeout-sec", type=float, default=15.0)
+    parser.add_argument("--remote-setup-timeout-sec", type=float, default=30.0)
+    parser.add_argument(
+        "--json-bridge-probe-policy",
+        choices=("sandbox-env-deferred", "socket-only"),
+        default="sandbox-env-deferred",
+        help=(
+            "Pre-case readiness policy. sandbox-env-deferred avoids probing "
+            "AI_ADDR/AI_PORT before the BenchFlow task sandbox exists; socket-only "
+            "checks only the local/remote bridge socket and client lifecycle."
+        ),
+    )
     parser.add_argument("--remote-command", default="")
     parser.add_argument("--preflight-only", action="store_true")
     parser.add_argument(
@@ -357,7 +743,24 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=None,
         help="Optional path for compact public-safe supervisor JSON.",
     )
-    return parser.parse_args(argv)
+    args = parser.parse_args(argv)
+    if _json_bridge_requested(args):
+        args.json_bridge = True
+        missing = [
+            name
+            for name in (
+                "json_bridge_command",
+                "json_remote_socket",
+                "json_remote_client_path",
+            )
+            if not getattr(args, name)
+        ]
+        if missing:
+            parser.error(
+                "--json-bridge requires "
+                + ", ".join("--" + item.replace("_", "-") for item in missing)
+            )
+    return args
 
 
 def main(argv: list[str] | None = None) -> int:


### PR DESCRIPTION
## Summary
- bind single-element --task-ids to task_id so requested one-case runs cannot silently fall back to the default task
- extend the reverse-tunnel supervisor to own the per-run JSON held bridge lifecycle, including local server startup, Unix socket reverse-forwarding, remote client materialization, optional stale local forward cleanup, and sandbox-aware probe policy
- add public smokes for held-bridge redaction/lifecycle and the single --task-ids regression

## Validation
- python3 -m py_compile scripts/skillsbench_reverse_tunnel_supervisor.py scripts/skillsbench_automation_loop.py examples/skillsbench-reverse-tunnel-supervisor-smoke.py examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-reverse-tunnel-supervisor-smoke.py
- python3 -c "import importlib.util, pathlib; p=pathlib.Path('examples/skillsbench-benchmark-run-smoke.py'); spec=importlib.util.spec_from_file_location('skillsbench_benchmark_run_smoke', p); m=importlib.util.module_from_spec(spec); spec.loader.exec_module(m); m.test_skillsbench_single_task_ids_replaces_default_task_id(); print('single task-ids regression ok')"
- python3 -c "import importlib.util, pathlib; p=pathlib.Path('examples/skillsbench-benchmark-run-smoke.py'); spec=importlib.util.spec_from_file_location('skillsbench_benchmark_run_smoke', p); m=importlib.util.module_from_spec(spec); spec.loader.exec_module(m); m.test_skillsbench_parallel_batch_isolates_case_process_argv(); print('parallel batch argv regression ok')"
- loopx check --scan-path scripts/skillsbench_reverse_tunnel_supervisor.py --scan-path scripts/skillsbench_automation_loop.py --scan-path examples/skillsbench-reverse-tunnel-supervisor-smoke.py --scan-path examples/skillsbench-benchmark-run-smoke.py
- git diff --check

Note: full python3 examples/skillsbench-benchmark-run-smoke.py still fails before the new regression at existing test_cli_skillsbench_result_root_discovers_nested_case_result_for_ledger with KeyError: artifact_refs.