### PR TITLE
Persist auto-research append evidence output

### DIFF
--- a/examples/auto-research-live-evidence-capture-smoke.py
+++ b/examples/auto-research-live-evidence-capture-smoke.py
@@ -160,6 +160,8 @@ def main() -> int:
                 "append-evidence",
                 "--packet",
                 str(evidence_path),
+                "--output",
+                "append-result.public.json",
             ],
             registry=registry,
             runtime_root=runtime_root,
@@ -167,7 +169,8 @@ def main() -> int:
         )
         append_payload = json.loads(append.stdout)
         append_path = workspace / "append-result.public.json"
-        append_path.write_text(json.dumps(append_payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        assert append_path.is_file(), append_payload
+        assert json.loads(append_path.read_text(encoding="utf-8")) == append_payload, append_payload
         assert append_payload["appended_count"] == 3, append_payload
 
         live_path = workspace / "live-codex-e2e-evidence.public.json"

--- a/examples/auto-research-one-click-ux-smoke.py
+++ b/examples/auto-research-one-click-ux-smoke.py
@@ -129,6 +129,8 @@ def main() -> int:
             assert "codex-cli-bootstrap-message" not in bootstrap, lane
             assert "generic LoopX heartbeat worker" in bootstrap, lane
             assert "loopx-auto-research" in bootstrap, lane
+            assert "append-result.public.json" in bootstrap, lane
+            assert "capture-live-evidence" in bootstrap, lane
             assert "live-codex-e2e-evidence.public.json" in bootstrap, lane
             assert "lightweight multi-round kernel is not live Codex evidence" in bootstrap, lane
             assert "claim_allowed must remain false" in bootstrap, lane
@@ -251,9 +253,18 @@ def main() -> int:
         log_entries = [json.loads(line) for line in tmux_log.read_text(encoding="utf-8").splitlines()]
         assert any(entry[:1] == ["new-session"] for entry in log_entries), log_entries
         assert sum(1 for entry in log_entries if entry[:1] == ["new-window"]) == 3, log_entries
-        command_text = "\n".join(" ".join(entry) for entry in log_entries)
-        assert f"--goal-id {GOAL_ID}" in command_text, command_text
-        assert f"--goal-id {TRACKING_GOAL_ID}" not in command_text, command_text
+        script_paths = [
+            Path(entry[-1])
+            for entry in log_entries
+            if entry[:1] in (["new-session"], ["new-window"])
+        ]
+        assert len(script_paths) == 4, log_entries
+        script_text = "\n".join(path.read_text(encoding="utf-8") for path in script_paths)
+        assert f"--goal-id {GOAL_ID}" in script_text, script_text
+        assert f"--goal-id {TRACKING_GOAL_ID}" not in script_text, script_text
+        assert "LOOPX_VISIBLE_LANE_COUNT=3" in script_text, script_text
+        assert "append-result.public.json" in script_text, script_text
+        assert "capture-live-evidence" in script_text, script_text
         assert any(entry[:1] == ["list-windows"] for entry in log_entries), log_entries
         assert sum(1 for entry in log_entries if entry[:1] == ["capture-pane"]) == 3, log_entries
 

--- a/examples/auto-research-rollout-append-smoke.py
+++ b/examples/auto-research-rollout-append-smoke.py
@@ -113,7 +113,13 @@ def evidence_packet(dev: Path, holdout: Path) -> dict[str, Any]:
     )
 
 
-def append_packet(registry: Path, packet: Path, *, dry_run: bool = False) -> dict[str, Any]:
+def append_packet(
+    registry: Path,
+    packet: Path,
+    *,
+    dry_run: bool = False,
+    output: Path | None = None,
+) -> dict[str, Any]:
     args = [
         "-m",
         "loopx.cli",
@@ -128,6 +134,8 @@ def append_packet(registry: Path, packet: Path, *, dry_run: bool = False) -> dic
     ]
     if dry_run:
         args.append("--dry-run")
+    if output is not None:
+        args.extend(["--output", str(output)])
     return run_json(args)
 
 
@@ -176,11 +184,14 @@ def main() -> None:
         }, dry
         assert_public_safe(dry)
 
-        first = append_packet(registry, packet_path)
+        append_output = temp / "append-result.public.json"
+        first = append_packet(registry, packet_path, output=append_output)
         assert first["dry_run"] is False, first
         assert first["event_count"] == 3, first
         assert first["appended_count"] == 3, first
         assert first["skipped_existing_count"] == 0, first
+        assert append_output.is_file(), first
+        assert json.loads(append_output.read_text(encoding="utf-8")) == first, first
         assert_public_safe(first)
 
         second = append_packet(registry, packet_path)

--- a/examples/auto-research-visible-launcher-smoke.py
+++ b/examples/auto-research-visible-launcher-smoke.py
@@ -185,12 +185,14 @@ def main() -> int:
             assert profile["skill_distribution"] == "worker_local", profile
             assert profile["agent_id"] == lane["agent_id"], profile
             assert profile["lane_id"] == lane["lane_id"], profile
+            assert profile["visible_lane_count"] == 3, profile
             assert profile["stop_conditions"], profile
             assert "[LoopX role profile]" in command, command
             assert "LOOPX_ROLE_PROFILE_JSON" in command, command
             assert "LOOPX_ROLE_ID" in command, command
             assert "LOOPX_ROLE_PROFILE_REF" in command, command
             assert "LOOPX_REQUIRED_SKILL" in command, command
+            assert "LOOPX_VISIBLE_LANE_COUNT=3" in command, command
             assert "quota should-run" in command, command
             assert "auto-research frontier" in command, command
             assert "LOOPX_VISIBLE_POLL_ATTEMPTS" in command, command

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -212,6 +212,10 @@ def register_auto_research_commands(
         action="store_true",
         help="Preview rollout events without appending them.",
     )
+    append_parser.add_argument(
+        "--output",
+        help="Write the append result JSON to this path without recording the path in LoopX state.",
+    )
 
     live_evidence_parser = auto_research_sub.add_parser(
         "capture-live-evidence",
@@ -638,6 +642,13 @@ def handle_auto_research_command(
                 runtime_root_arg=runtime_root_arg,
                 dry_run=args.dry_run,
             )
+            if args.output:
+                output_path = Path(args.output).expanduser()
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                output_path.write_text(
+                    json.dumps(payload, indent=2, sort_keys=True) + "\n",
+                    encoding="utf-8",
+                )
         elif args.auto_research_command == "capture-live-evidence":
             payload = capture_live_codex_e2e_evidence(
                 packet_path=args.packet,
@@ -647,7 +658,9 @@ def handle_auto_research_command(
                 visible_lanes_accepted=args.visible_lanes_accepted,
             )
             if args.execute:
-                Path(args.output).expanduser().write_text(
+                output_path = Path(args.output).expanduser()
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                output_path.write_text(
                     json.dumps(payload, indent=2, sort_keys=True) + "\n",
                     encoding="utf-8",
                 )

--- a/loopx/capabilities/auto_research/legacy_core.py
+++ b/loopx/capabilities/auto_research/legacy_core.py
@@ -966,8 +966,8 @@ def _auto_research_codex_bootstrap_prompt(
             "Live E2E proof contract:",
             "- Work only from the printed auto-research frontier and this role profile.",
             "- The lightweight multi-round kernel is not live Codex evidence; do not claim kernel metrics as lane-authored results.",
-            "- If you author evidence, use public-safe loopx auto-research evidence and append-evidence commands.",
-            "- A controller may later run capture-live-evidence to create live-codex-e2e-evidence.public.json.",
+            "- If you author evidence, write a public packet, run append-evidence with --output .local/evidence-runner/append-result.public.json, then run capture-live-evidence.",
+            "- capture-live-evidence should create .local/evidence-runner/live-codex-e2e-evidence.public.json only after the real append succeeds.",
             "- claim_allowed must remain false until that public-safe live evidence file exists and validates.",
             "",
             "Never include credentials, raw private logs, raw session transcripts, local absolute paths, or private artifacts.",
@@ -1034,6 +1034,7 @@ def _role_profile_for_lane(*, goal_id: str, lane: dict[str, str]) -> dict[str, A
 
 def _role_profile_shell_prefix(role_profile: dict[str, Any]) -> str:
     profile_json = json.dumps(role_profile, sort_keys=True, separators=(",", ":"))
+    lane_count = str(role_profile.get("visible_lane_count") or "")
     return (
         f"export LOOPX_GOAL_ID={_shell_arg(str(role_profile['goal_id']))}; "
         f"export LOOPX_AGENT_ID={_shell_arg(str(role_profile['agent_id']))}; "
@@ -1041,6 +1042,7 @@ def _role_profile_shell_prefix(role_profile: dict[str, Any]) -> str:
         f"export LOOPX_ROLE_PHASE={_shell_arg(str(role_profile['phase']))}; "
         f"export LOOPX_ROLE_PROFILE_REF={_shell_arg(str(role_profile['schema_version']))}; "
         f"export LOOPX_REQUIRED_SKILL={_shell_arg(str(role_profile['required_skill']))}; "
+        f"export LOOPX_VISIBLE_LANE_COUNT={_shell_arg(lane_count)}; "
         'export LOOPX_WORKER_SKILL_ROOT="$LOOPX_PROJECT/.codex/skills"; '
         'export LOOPX_WORKER_SKILL_PATH="$LOOPX_WORKER_SKILL_ROOT/$LOOPX_REQUIRED_SKILL/SKILL.md"; '
         f"LOOPX_ROLE_PROFILE_JSON={_shell_arg(profile_json)}; "
@@ -1133,6 +1135,7 @@ def build_auto_research_demo_supervisor_plan(
         lane_id = lane["lane_id"]
         role_id = lane["role_id"]
         role_profile = _role_profile_for_lane(goal_id=goal, lane=lane)
+        role_profile["visible_lane_count"] = len(lanes)
         quota_command = _env_quota_command(cli_bin=cli, goal_id=goal, agent_id=agent_id)
         frontier_command = _env_frontier_command(cli_bin=cli, goal_id=goal, agent_id=agent_id)
         bootstrap_command = _env_auto_research_bootstrap_command(

--- a/loopx/capabilities/auto_research/worker_skill/SKILL.md
+++ b/loopx/capabilities/auto_research/worker_skill/SKILL.md
@@ -179,6 +179,26 @@ Append only after review of the packet and boundary:
 loopx --format json auto-research append-evidence \
   --packet "$AUTO_RESEARCH_EVIDENCE_PACKET_JSON" \
   --dry-run
+
+append_result="${APPEND_RESULT_JSON:-.local/evidence-runner/append-result.public.json}"
+loopx --format json auto-research append-evidence \
+  --packet "$AUTO_RESEARCH_EVIDENCE_PACKET_JSON" \
+  --output "$append_result"
+```
+
+After a real append succeeds in a visible lane, capture compact live evidence
+from the lane-authored packet and append result:
+
+```bash
+live_evidence="${LIVE_CODEX_E2E_EVIDENCE_JSON:-.local/evidence-runner/live-codex-e2e-evidence.public.json}"
+loopx --format json auto-research capture-live-evidence \
+  --packet "$AUTO_RESEARCH_EVIDENCE_PACKET_JSON" \
+  --append-result "$append_result" \
+  --agent-id "$LOOPX_AGENT_ID" \
+  --lane-count "${LOOPX_VISIBLE_LANE_COUNT:-1}" \
+  --visible-lanes-accepted \
+  --output "$live_evidence" \
+  --execute
 ```
 
 Must not:


### PR DESCRIPTION
## Summary
- add `auto-research append-evidence --output` so visible workers can persist their real append result without controller reconstruction
- expose visible lane count to worker panes and update the worker-local auto-research playbook to capture live evidence after a real append
- update focused smokes for append output, live evidence capture, one-click visible launcher, and lane profile export

## Validation
- `python3 -m compileall -q loopx/capabilities/auto_research loopx/visible_multi_agent_launcher.py`
- `python3 examples/auto-research-rollout-append-smoke.py`
- `python3 examples/auto-research-live-evidence-capture-smoke.py`
- `python3 examples/auto-research-one-click-ux-smoke.py`
- `python3 examples/auto-research-visible-launcher-smoke.py`
- `python3 examples/auto-research-skill-contract-smoke.py`
- `python3 examples/auto-research-demo-supervisor-smoke.py`
- `python3 examples/auto-research-demo-e2e-smoke.py`
- `python3 examples/auto-research-live-codex-claim-boundary-smoke.py`
- `git diff --check`
- `loopx check --scan-path ...` (clean public boundary scan; existing duplicate index-row warning only)