### PR TITLE
Make visible auto-research demo run live dev evidence

### DIFF
--- a/examples/auto-research-demo-e2e-smoke.py
+++ b/examples/auto-research-demo-e2e-smoke.py
@@ -188,7 +188,7 @@ def assert_visible_demo_local_control_plane(*, registry: Path, runtime_root: Pat
         expected_actions = {
             "codex-product-capability": "write_research_contract",
             "codex-side-bypass": "propose_hypothesis",
-            "codex-main-control": "claim_attempt",
+            "codex-main-control": "run_dev_eval",
         }
         lane_workspaces = {
             str(lane.get("agent_id")): Path(str(lane.get("workspace"))).resolve()
@@ -303,7 +303,7 @@ def assert_visible_demo_local_control_plane(*, registry: Path, runtime_root: Pat
     assert {item["action_kind"] for item in control["seeded_todos"]} == {
         "write_research_contract",
         "propose_hypothesis",
-        "claim_attempt",
+        "run_dev_eval",
     }, payload
     workspace_route = control["workspace_route"]
     assert workspace_route["shared_goal_surface"] == "demo_local_loopx_registry_and_runtime", payload

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -165,6 +165,8 @@ def _seed_visible_demo_control_plane(
         profile = lane.get("role_profile") if isinstance(lane.get("role_profile"), dict) else {}
         allowed_actions = profile.get("allowed_actions") if isinstance(profile, dict) else []
         action_kind = str((allowed_actions or ["advance_todo"])[0])
+        if role_id == "evidence_runner":
+            action_kind = "run_dev_eval"
         title_by_action = {
             "write_research_contract": (
                 "Write the public-safe research contract for the quickstart k-NN hypothesis."
@@ -176,7 +178,7 @@ def _seed_visible_demo_control_plane(
                 "Claim one visible attempt boundary for the selected quickstart hypothesis."
             ),
             "run_dev_eval": (
-                "Run the selected quickstart hypothesis on the dev split and write public-safe evidence."
+                "Run the selected quickstart hypothesis on the dev split, write public-safe evidence, append it, and capture live evidence."
             ),
             "write_evaluation_summary": (
                 "Verify the evidence packet and open the next validation or promotion gate."

--- a/loopx/capabilities/auto_research/legacy_core.py
+++ b/loopx/capabilities/auto_research/legacy_core.py
@@ -936,6 +936,20 @@ def _auto_research_codex_bootstrap_prompt(
     stop_conditions = _compact_prompt_list(role_profile.get("stop_conditions"))
     effort = _compact_public_token(reasoning_effort, field="bootstrap.reasoning_effort")
     goal = _compact_public_token(goal_id, field="bootstrap.goal_id")
+    role_specific_steps: list[str] = []
+    if role_id == "evidence_runner":
+        role_specific_steps = [
+            "",
+            "Evidence runner minimal live demo path:",
+            "1. Confirm the selected frontier action is `run_dev_eval` or `write_evidence` for this agent.",
+            "2. Run the quickstart dev evaluator from this pane workspace:",
+            "   `python3 auto_research_knn_pack/protected_eval.py --solution auto_research_knn_pack/solution_candidate.py --split dev > .local/evidence-runner/dev-result.public.json`",
+            "3. Build the public evidence packet:",
+            "   `loopx --format json auto-research evidence --contract auto_research_knn_pack/research_contract.json --eval-result .local/evidence-runner/dev-result.public.json --hypothesis-id hyp_quickstart_partial_selection --todo-id <selected todo_id> --agent-id \"$LOOPX_AGENT_ID\" --claimed-by \"$LOOPX_AGENT_ID\" --mechanism-family partial_selection --hypothesis \"Use exact partial selection to avoid full distance sorting.\" > .local/evidence-runner/evidence.public.json`",
+            "4. Run `append-evidence --dry-run`, then real `append-evidence --output .local/evidence-runner/append-result.public.json`.",
+            "5. Run `capture-live-evidence --packet .local/evidence-runner/evidence.public.json --append-result .local/evidence-runner/append-result.public.json --agent-id \"$LOOPX_AGENT_ID\" --lane-count \"${LOOPX_VISIBLE_LANE_COUNT:-1}\" --visible-lanes-accepted --output .local/evidence-runner/live-codex-e2e-evidence.public.json --execute`.",
+            "6. Complete only the selected todo after the evidence files exist and the append result reports appended evidence.",
+        ]
     return "\n".join(
         [
             "You are a visible LoopX auto-research lane, not a generic LoopX heartbeat worker.",
@@ -969,6 +983,7 @@ def _auto_research_codex_bootstrap_prompt(
             "- If you author evidence, write a public packet, run append-evidence with --output .local/evidence-runner/append-result.public.json, then run capture-live-evidence.",
             "- capture-live-evidence should create .local/evidence-runner/live-codex-e2e-evidence.public.json only after the real append succeeds.",
             "- claim_allowed must remain false until that public-safe live evidence file exists and validates.",
+            *role_specific_steps,
             "",
             "Never include credentials, raw private logs, raw session transcripts, local absolute paths, or private artifacts.",
             "End with a compact public-safe summary of commands run, evidence written, blocker, or next role-local todo.",


### PR DESCRIPTION
## Summary
- seed the visible auto-research demo evidence-runner with a direct run_dev_eval task instead of an intermediate claim-only task
- add a minimal evidence-runner bootstrap path for dev eval, evidence packet creation, append-evidence, and live evidence capture
- update the demo E2E smoke to assert the executable run_dev_eval frontier

## Validation
- python3 -m py_compile loopx/capabilities/auto_research/demo_e2e.py loopx/capabilities/auto_research/legacy_core.py
- python3 examples/auto-research-demo-e2e-smoke.py
- python3 examples/auto-research-one-click-ux-smoke.py
- python3 examples/visible-multi-agent-launcher-smoke.py
- live visible tmux/Codex run: produced lane-authored dev evidence with dev_metric=4.0, append_result appended_count=2, and live-codex-e2e-evidence.public.json validated with claim_allowed=true for dev_only

## Boundary
- no raw transcripts, private artifacts, credentials, or local paths are committed
- holdout=4.5 remains rollout-backed context, not a live Codex holdout claim
