### PR TITLE
Clarify auto-research minimal E2E kernel

### DIFF
--- a/docs/guides/auto-research-command-path.md
+++ b/docs/guides/auto-research-command-path.md
@@ -95,12 +95,15 @@ loopx --registry "$LOOPX_REGISTRY" \
   --execute
 ```
 
-Expected multi-round result:
+Expected minimal E2E result:
 
-- `execution_kind` is `multiround_research_kernel`;
-- `result_source` is `lightweight_multiround_kernel`;
+- `execution_kind` is `minimal_research_kernel`;
+- `result_source` is `deterministic_protected_eval_kernel`;
 - `research_loop.dev_round_count` is `2`;
 - `research_loop.evidence_event_count` is `3`;
+- `research_loop.live_codex_lane_authored` is `false`;
+- `research_loop.kernel_event_trace` contains the actual protected-eval
+  dev/dev/holdout events, not synthetic worker panels;
 - `research_loop.selected_hypothesis_id` is `hyp_partial_selection`;
 - `research_loop.dev_gain_over_baseline` is `3.0`;
 - `research_loop.holdout_gain_over_baseline` is `3.5`;

--- a/examples/auto-research-demo-e2e-smoke.py
+++ b/examples/auto-research-demo-e2e-smoke.py
@@ -84,12 +84,12 @@ def assert_e2e_payload(
     assert payload["agent_id"] == AGENT_ID, payload
     assert payload["reasoning_effort"] == "high", payload
     assert payload["execution_kind"] in {
-        "multiround_research_kernel",
-        "multiround_research_preview",
+        "minimal_research_kernel",
+        "minimal_research_preview",
     }, payload
     assert payload["result_source"] in {
-        "lightweight_multiround_kernel",
-        "lightweight_multiround_kernel_preview",
+        "deterministic_protected_eval_kernel",
+        "deterministic_protected_eval_preview",
     }, payload
     live = payload["live_codex_e2e"]
     assert live["executed"] is False, payload
@@ -119,14 +119,20 @@ def assert_e2e_payload(
         assert loop["holdout_metric"] == 4.5, payload
         assert loop["dev_gain_over_baseline"] == 3.0, payload
         assert loop["holdout_gain_over_baseline"] == 3.5, payload
-        assert [item["role"] for item in loop["worker_rounds"]] == [
-            "hypothesis_mapper",
-            "evidence_runner",
-            "evidence_verifier",
+        assert loop["live_codex_lane_authored"] is False, payload
+        trace = loop["kernel_event_trace"]
+        assert len(trace) == 3, payload
+        assert [item["split"] for item in trace] == ["dev", "dev", "holdout"], payload
+        assert trace[-1]["hypothesis_id"] == "hyp_partial_selection", payload
+        assert trace[-1]["gain_over_baseline"] == 3.5, payload
+        assert {item["result_source"] for item in trace} == {"knn_pack_protected_eval"}, payload
+        assert loop["state_transitions"] == [
+            "seed_quickstart_pack",
+            "run_protected_eval_dev_holdout",
+            "write_public_safe_evidence_packet",
+            "append_evidence_to_loopx_state",
+            "read_board_and_acceptance_projection",
         ], payload
-        assert {item["loopx_contract"] for item in loop["worker_rounds"]} == {
-            "role_profile_quota_frontier_cli_writeback"
-        }, payload
         assert protected_eval["result_source"] == "generated_quickstart_pack_protected_eval", payload
         assert protected_eval["status"] == "supported", payload
         assert protected_eval["dev_metric"] == 4.0, payload
@@ -157,10 +163,11 @@ def assert_e2e_payload(
         assert payload["acceptance"]["claim_boundary"]["live_claim_scope"] == "dev_only", payload
         assert payload["acceptance"]["claim_boundary"]["promotion_claim_allowed"] is False, payload
     else:
-        assert loop["result_source"] == "lightweight_multiround_kernel_preview", payload
-        assert "two dev rounds plus holdout" in loop["expected_rounds"], payload
-        assert protected_eval["result_source"] == "lightweight_multiround_kernel_preview", payload
-        assert protected_eval["expected_positive_result"] == "dev=4.0x holdout=4.5x after --execute", payload
+        assert loop["result_source"] == "deterministic_protected_eval_preview", payload
+        assert "append public-safe evidence" in loop["expected_steps"], payload
+        assert loop["live_codex_lane_authored"] is False, payload
+        assert protected_eval["result_source"] == "deterministic_protected_eval_preview", payload
+        assert protected_eval["expected_positive_result"] == "dev/holdout metrics are produced only after --execute", payload
     assert_public_safe(payload)
 
 
@@ -381,12 +388,13 @@ def main() -> int:
             registry=registry,
             runtime_root=runtime_root,
         ).stdout
-        assert "# LoopX Auto Research Multi-Round Demo" in markdown, markdown
-        assert "execution_kind: `multiround_research_preview`" in markdown, markdown
+        assert "# LoopX Auto Research Minimal E2E Demo" in markdown, markdown
+        assert "execution_kind: `minimal_research_preview`" in markdown, markdown
         assert "research_loop_executed: `False`" in markdown, markdown
-        assert "research_loop_source: `lightweight_multiround_kernel_preview`" in markdown, markdown
+        assert "research_loop_source: `deterministic_protected_eval_preview`" in markdown, markdown
         assert "research_loop_dev_rounds:" in markdown, markdown
         assert "research_loop_evidence_events:" in markdown, markdown
+        assert "research_loop_live_codex_lane_authored: `False`" in markdown, markdown
         assert "frontier_goal_id: `loopx-auto-research-knn`" in markdown, markdown
         assert "tracking_goal_drives_frontier: `False`" in markdown, markdown
         assert "live_codex_e2e_claim_allowed: `False`" in markdown, markdown

--- a/examples/auto-research-one-click-ux-smoke.py
+++ b/examples/auto-research-one-click-ux-smoke.py
@@ -187,11 +187,13 @@ def main() -> int:
         assert route["tracking_goal_id"] == TRACKING_GOAL_ID, payload
         assert route["tracking_goal_drives_frontier"] is False, payload
         assert route["dedicated_positive_demo_frontier"] is True, payload
-        assert payload["execution_kind"] == "multiround_research_kernel", payload
-        assert payload["result_source"] == "lightweight_multiround_kernel", payload
+        assert payload["execution_kind"] == "minimal_research_kernel", payload
+        assert payload["result_source"] == "deterministic_protected_eval_kernel", payload
         assert payload["reasoning_effort"] == "high", payload
         assert payload["research_loop"]["dev_round_count"] == 2, payload
         assert payload["research_loop"]["evidence_event_count"] == 3, payload
+        assert payload["research_loop"]["live_codex_lane_authored"] is False, payload
+        assert len(payload["research_loop"]["kernel_event_trace"]) == 3, payload
         assert payload["research_loop"]["dev_gain_over_baseline"] == 3.0, payload
         assert payload["research_loop"]["holdout_gain_over_baseline"] == 3.5, payload
         assert payload["protected_eval_result"]["dev_metric"] == 4.0, payload

--- a/examples/generic-multi-agent-one-command-smoke.py
+++ b/examples/generic-multi-agent-one-command-smoke.py
@@ -298,8 +298,14 @@ def main() -> int:
             if entry["argv"][:1] == ["new-window"]
         ]
         assert len(new_window_commands) == 2, log_entries
-        assert all("reasoning_effort=high" in command for command in new_window_commands), new_window_commands
-        assert all("model_reasoning_effort=high" in command for command in new_window_commands), new_window_commands
+        new_window_payloads = []
+        for command in new_window_commands:
+            command_path = Path(command)
+            new_window_payloads.append(
+                command_path.read_text(encoding="utf-8") if command_path.is_file() else command
+            )
+        assert all("reasoning_effort=high" in command for command in new_window_payloads), new_window_payloads
+        assert all("model_reasoning_effort=high" in command for command in new_window_payloads), new_window_payloads
 
     smoke_source = Path(__file__).read_text(encoding="utf-8").lower()
     domain_marker = "auto" + "-research"

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -427,6 +427,39 @@ def _live_codex_truth_boundary(*, launch_visible: bool) -> dict[str, object]:
     }
 
 
+def _metric_gain(metric: object, *, baseline: float = 1.0) -> float | None:
+    if metric is None:
+        return None
+    try:
+        return float(metric) - baseline
+    except (TypeError, ValueError):
+        return None
+
+
+def _compact_kernel_event_trace(research_loop: dict[str, object]) -> list[dict[str, object]]:
+    """Expose the deterministic kernel as evaluated events, not pretend workers."""
+
+    events = research_loop.get("evidence") if isinstance(research_loop.get("evidence"), list) else []
+    trace: list[dict[str, object]] = []
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        metric = event.get("metric")
+        trace.append(
+            {
+                "split": event.get("split"),
+                "hypothesis_id": event.get("hypothesis_id"),
+                "candidate_key": event.get("candidate_key"),
+                "status": event.get("status"),
+                "metric": metric,
+                "gain_over_baseline": _metric_gain(metric),
+                "result_source": event.get("result_source"),
+                "protected_scope_clean": event.get("protected_scope_clean"),
+            }
+        )
+    return trace
+
+
 def run_auto_research_demo_e2e(
     *,
     agent_id: str,
@@ -470,8 +503,10 @@ def run_auto_research_demo_e2e(
         "ok": True,
         "schema_version": AUTO_RESEARCH_DEMO_E2E_SCHEMA_VERSION,
         "mode": "execute" if execute else "dry_run",
-        "execution_kind": "multiround_research_kernel" if execute else "multiround_research_preview",
-        "result_source": "lightweight_multiround_kernel" if execute else "lightweight_multiround_kernel_preview",
+        "execution_kind": "minimal_research_kernel" if execute else "minimal_research_preview",
+        "result_source": "deterministic_protected_eval_kernel"
+        if execute
+        else "deterministic_protected_eval_preview",
         "goal_id": goal_id,
         "tracking_goal_id": tracking_goal or None,
         "route_contract": {
@@ -548,14 +583,14 @@ def run_auto_research_demo_e2e(
         }
         payload["protected_eval_result"] = {
             "executed": False,
-            "result_source": "lightweight_multiround_kernel_preview",
-            "expected_positive_result": "dev=4.0x holdout=4.5x after --execute",
+            "result_source": "deterministic_protected_eval_preview",
+            "expected_positive_result": "dev/holdout metrics are produced only after --execute",
         }
         payload["research_loop"] = {
             "executed": False,
-            "result_source": "lightweight_multiround_kernel_preview",
-            "expected_rounds": "two dev rounds plus holdout for the selected candidate after --execute",
-            "expected_gain": "selected candidate improves from baseline 1.0x to dev=4.0x and holdout=4.5x",
+            "result_source": "deterministic_protected_eval_preview",
+            "expected_steps": "seed quickstart pack, run protected eval, append public-safe evidence, read board",
+            "live_codex_lane_authored": False,
         }
         return payload
 
@@ -646,28 +681,14 @@ def run_auto_research_demo_e2e(
                         if research_loop.get("holdout_metric") is not None
                         else None
                     ),
-                    "worker_rounds": [
-                        {
-                            "round": 1,
-                            "role": "hypothesis_mapper",
-                            "transition": "seed_baseline_candidate",
-                            "hypothesis_id": "hyp_full_sort",
-                            "loopx_contract": "role_profile_quota_frontier_cli_writeback",
-                        },
-                        {
-                            "round": 2,
-                            "role": "evidence_runner",
-                            "transition": "try_positive_candidate",
-                            "hypothesis_id": "hyp_partial_selection",
-                            "loopx_contract": "role_profile_quota_frontier_cli_writeback",
-                        },
-                        {
-                            "round": 3,
-                            "role": "evidence_verifier",
-                            "transition": "holdout_validate_selected_candidate",
-                            "hypothesis_id": research_loop.get("selected_hypothesis_id"),
-                            "loopx_contract": "role_profile_quota_frontier_cli_writeback",
-                        },
+                    "live_codex_lane_authored": False,
+                    "kernel_event_trace": _compact_kernel_event_trace(research_loop),
+                    "state_transitions": [
+                        "seed_quickstart_pack",
+                        "run_protected_eval_dev_holdout",
+                        "write_public_safe_evidence_packet",
+                        "append_evidence_to_loopx_state",
+                        "read_board_and_acceptance_projection",
                     ],
                     "public_boundary": research_loop.get("public_boundary"),
                 },

--- a/loopx/capabilities/auto_research/legacy_core.py
+++ b/loopx/capabilities/auto_research/legacy_core.py
@@ -3487,7 +3487,7 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
             else {}
         )
         lines = [
-            "# LoopX Auto Research Multi-Round Demo",
+            "# LoopX Auto Research Minimal E2E Demo",
             "",
             f"- schema: `{payload.get('schema_version')}`",
             f"- mode: `{payload.get('mode')}`",
@@ -3507,6 +3507,8 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
             f"- research_loop_selected_hypothesis: `{research_loop.get('selected_hypothesis_id')}`",
             f"- research_loop_dev_gain: `{research_loop.get('dev_gain_over_baseline')}`",
             f"- research_loop_holdout_gain: `{research_loop.get('holdout_gain_over_baseline')}`",
+            f"- research_loop_live_codex_lane_authored: `{research_loop.get('live_codex_lane_authored')}`",
+            f"- research_loop_kernel_events: `{len(research_loop.get('kernel_event_trace') or [])}`",
             f"- protected_eval_executed: `{protected_eval.get('executed')}`",
             f"- protected_eval_source: `{protected_eval.get('result_source')}`",
             f"- protected_eval_status: `{protected_eval.get('status')}`",


### PR DESCRIPTION
## Summary
- rename the demo-e2e deterministic path to a minimal protected-eval kernel instead of a live multi-agent result
- replace synthetic worker_rounds with compact kernel_event_trace and real state transition labels
- keep live Codex claims gated on live evidence, while preserving the generic multi-agent launcher smoke against script-based lane launch commands

## Validation
- python3 examples/auto-research-demo-e2e-smoke.py
- python3 examples/auto-research-one-click-ux-smoke.py
- python3 examples/generic-multi-agent-one-command-smoke.py
- python3 examples/auto-research-live-codex-claim-boundary-smoke.py
- git diff --check
- public/private marker scan on changed diff
