### PR TITLE
Require worker-local skills before visible launch

### DIFF
--- a/examples/auto-research-one-click-ux-smoke.py
+++ b/examples/auto-research-one-click-ux-smoke.py
@@ -221,8 +221,19 @@ def main() -> int:
         assert launch["session_name"] == SESSION, launch
         assert launch["workspace_mode"] == "explicit_workspace", launch
         assert launch["started_lane_count"] == 3, launch
-        assert len(launch["worker_skill_materialization"]) == 3, launch
-        assert all(item["materialized"] for item in launch["worker_skill_materialization"]), launch
+        worker_skills = launch["worker_skill_materialization"]
+        assert len(worker_skills) == 3, launch
+        assert all(item["skill"] == "loopx-auto-research" for item in worker_skills), launch
+        assert all(item["materialized"] for item in worker_skills), launch
+        assert all(not item.get("missing_source") for item in worker_skills), launch
+        assert all(
+            item["destination"] == ".codex/skills/loopx-auto-research/SKILL.md"
+            for item in worker_skills
+        ), launch
+        worker_skill_path = workspace / ".codex/skills/loopx-auto-research/SKILL.md"
+        worker_skill_text = worker_skill_path.read_text(encoding="utf-8")
+        assert "name: loopx-auto-research" in worker_skill_text, worker_skill_text
+        assert "worker-local role playbook" in worker_skill_text, worker_skill_text
         assert launch["visible_acceptance"]["accepted"] is True, launch
         assert payload["live_codex_e2e"]["visible_lanes_accepted"] is True, payload
         assert workspace.is_dir(), workspace
@@ -265,6 +276,10 @@ def main() -> int:
         assert f"--goal-id {GOAL_ID}" in script_text, script_text
         assert f"--goal-id {TRACKING_GOAL_ID}" not in script_text, script_text
         assert "LOOPX_VISIBLE_LANE_COUNT=3" in script_text, script_text
+        assert "LOOPX_REQUIRED_SKILL=loopx-auto-research" in script_text, script_text
+        assert "LOOPX_WORKER_SKILL_PATH" in script_text, script_text
+        assert "worker_skill_path=%s" in script_text, script_text
+        assert "model_reasoning_effort=high" in script_text, script_text
         assert "append-result.public.json" in script_text, script_text
         assert "capture-live-evidence" in script_text, script_text
         assert any(entry[:1] == ["list-windows"] for entry in log_entries), log_entries

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -80,6 +80,39 @@ def main() -> int:
         os.environ["PATH"] = f"{fake_bin}{os.pathsep}{original_path}"
         os.environ["FAKE_TMUX_LOG"] = str(tmux_log)
         try:
+            try:
+                execute_visible_multi_agent_launcher(
+                    payload={
+                        "session_name": "loopx-visible-launcher-missing-skill-smoke",
+                        "lanes": [
+                            {
+                                "lane_id": "reviewer",
+                                "visible_launch_command": "true",
+                                "role_profile": {
+                                    "required_skill": "loopx-auto-research",
+                                    "worker_skill_source": "worker/MISSING.md",
+                                },
+                            },
+                        ],
+                    },
+                    registry=registry,
+                    runtime_root=runtime_root,
+                    requested_launcher="tmux",
+                    tmux_bin="tmux",
+                    cli_bin="loopx",
+                    codex_bin="codex",
+                    attach=False,
+                    replace_existing=False,
+                    workspace=str(temp / "missing-skill-workspace"),
+                    create_workspace=True,
+                    cwd=temp,
+                )
+                raise AssertionError("missing worker-local skill source should fail closed")
+            except ValueError as exc:
+                assert "worker-local skill materialization failed" in str(exc), exc
+                assert "worker/MISSING.md" in str(exc), exc
+            assert not tmux_log.exists(), tmux_log
+
             launch, chosen, workspace_mode = execute_visible_multi_agent_launcher(
                 payload={
                     "session_name": "loopx-visible-launcher-smoke",

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -350,6 +350,16 @@ def _materialize_worker_skills(
     return results
 
 
+def _worker_skill_materialization_errors(items: list[dict[str, object]]) -> list[str]:
+    errors: list[str] = []
+    for item in items:
+        if item.get("missing_source"):
+            errors.append(f"{item.get('skill')}: missing {item.get('source')}")
+        elif item and not item.get("materialized"):
+            errors.append(f"{item.get('skill')}: not materialized")
+    return errors
+
+
 def _lane_workspace(lane: dict[str, object], *, default_project: Path) -> Path:
     raw = lane.get("workspace") or lane.get("project")
     if not raw:
@@ -405,6 +415,12 @@ def execute_visible_multi_agent_launcher(
         project=project,
         source_root=cwd,
     )
+    worker_skill_errors = _worker_skill_materialization_errors(worker_skills)
+    if worker_skill_errors:
+        raise ValueError(
+            "worker-local skill materialization failed: "
+            + "; ".join(worker_skill_errors)
+        )
     result = _launch_with_tmux(
         payload=payload,
         project=project,


### PR DESCRIPTION
## Summary
- fail closed when a visible multi-agent lane declares a worker-local skill whose source cannot be materialized
- strengthen the generic launcher smoke so missing worker-local playbooks do not start tmux
- strengthen the auto-research one-click smoke to verify local playbook materialization and high-reasoning launch contract

## Validation
- python3 examples/visible-multi-agent-launcher-smoke.py
- python3 examples/auto-research-one-click-ux-smoke.py
- python3 examples/auto-research-skill-contract-smoke.py
- python3 examples/generic-multi-agent-one-command-smoke.py
- python3 -m py_compile loopx/visible_multi_agent_launcher.py examples/visible-multi-agent-launcher-smoke.py examples/auto-research-one-click-ux-smoke.py
- git diff --check
- loopx check --scan-path loopx/visible_multi_agent_launcher.py --scan-path examples/visible-multi-agent-launcher-smoke.py --scan-path examples/auto-research-one-click-ux-smoke.py