### PR TITLE
Add SkillsBench independent Goal retry arm

### DIFF
--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import importlib.util
 import subprocess
@@ -36,6 +37,7 @@ from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
 
 ROUTE = "codex-app-server-goal-baseline"
 WORKER_SCRIPT = REPO_ROOT / "scripts" / "skillsbench_host_codex_goal_worker.py"
+RUNNER_SCRIPT = REPO_ROOT / "scripts" / "skillsbench_automation_loop.py"
 
 FAKE_CODEX = """#!/usr/bin/env python3
 import json
@@ -311,6 +313,16 @@ def _load_worker_module() -> Any:
     return module
 
 
+def _load_runner_module() -> Any:
+    spec = importlib.util.spec_from_file_location(
+        "skillsbench_automation_loop", RUNNER_SCRIPT
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
 def test_route_contract_requires_native_goal_proof() -> None:
     contract = skillsbench_route_contract(ROUTE)
     assert contract["native_goal_mode_requested"] is True, contract
@@ -455,6 +467,136 @@ def test_launcher_plan_only_marks_runner_ready_with_host_acp_launch() -> None:
     assert (
         prereq["codex_app_server_goal_worker_runner_integration_ready"] is True
     ), prereq
+
+
+def test_launcher_plan_only_records_independent_retry_config() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-app-goal-retry-plan-") as tmp:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(RUNNER_SCRIPT),
+                "--task-id",
+                "bike-rebalance",
+                "--route",
+                ROUTE,
+                "--jobs-dir",
+                str(Path(tmp) / "jobs"),
+                "--remote-command-file-bridge-ready",
+                "--host-local-acp-launch",
+                "--independent-goal-retries",
+                "3",
+                "--plan-only",
+            ],
+            cwd=REPO_ROOT,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+    payload = json.loads(result.stdout)
+    plan = payload["launch_plan"]
+    retry = plan["independent_goal_retry"]
+    assert retry["schema_version"] == "skillsbench_independent_goal_retry_config_v0", retry
+    assert retry["enabled"] is True, retry
+    assert retry["attempt_budget"] == 3, retry
+    assert retry["fresh_goal_thread_per_attempt"] is True, retry
+    assert retry["stop_policy"] == "stop_after_first_official_reward_1_or_retry_budget", retry
+    assert retry["official_reward_feedback_forwarded_to_agent"] is False, retry
+    assert retry["verifier_output_forwarded_to_agent"] is False, retry
+    assert retry["raw_task_text_read_into_public_state"] is False, retry
+    assert retry["raw_trajectory_read_into_public_state"] is False, retry
+    assert retry["raw_verifier_output_read_into_public_state"] is False, retry
+
+
+def test_independent_goal_retry_stops_after_first_success() -> None:
+    runner = _load_runner_module()
+    original_async_main = runner.async_main
+    original_build_plan = runner.build_plan
+
+    with tempfile.TemporaryDirectory(prefix="skillsbench-app-goal-retry-") as tmp:
+        tmp_path = Path(tmp)
+
+        def fake_build_plan(args: Namespace) -> dict[str, Any]:
+            rollout_name = args.rollout_name or "rollout"
+            return {
+                "task_id": args.task_id,
+                "route": args.route,
+                "run_group_id": args.run_group_id,
+                "job_name": args.job_name,
+                "rollout_name": rollout_name,
+                "compact_benchmark_run_json": str(
+                    tmp_path / args.job_name / rollout_name / "benchmark_run.compact.json"
+                ),
+                "result_json": str(
+                    tmp_path / args.job_name / rollout_name / "result.json"
+                ),
+            }
+
+        async def fake_async_main(args: Namespace, *, plan: dict[str, Any] | None = None) -> dict[str, Any]:
+            assert args.independent_goal_retries == 1, args
+            attempt_number = int(str(args.job_name).rsplit("-", 1)[-1])
+            reward = 1.0 if attempt_number == 2 else 0.0
+            return {
+                "ok": True,
+                "launch_plan": plan or {},
+                "official_task_score": {
+                    "kind": "fake_skillsbench_reward",
+                    "value": reward,
+                    "passed": reward >= 1.0,
+                },
+                "score_failure_attribution": (
+                    "none" if reward >= 1.0 else "official_score_zero_case_failure"
+                ),
+            }
+
+        runner.build_plan = fake_build_plan
+        runner.async_main = fake_async_main
+        try:
+            payload = asyncio.run(
+                runner.async_independent_goal_retry_main(
+                    Namespace(
+                        task_id="bike-rebalance",
+                        task_ids=None,
+                        route=ROUTE,
+                        jobs_dir=str(tmp_path),
+                        run_group_id="retry-group",
+                        job_name="retry-job",
+                        rollout_name=None,
+                        independent_goal_retries=3,
+                        parallel_cases=1,
+                    )
+                )
+            )
+        finally:
+            runner.async_main = original_async_main
+            runner.build_plan = original_build_plan
+
+        assert payload["schema_version"] == "skillsbench_independent_goal_retry_summary_v0", payload
+        assert payload["ok"] is True, payload
+        assert payload["attempt_budget"] == 3, payload
+        assert payload["attempts_started"] == 2, payload
+        assert payload["first_success_attempt"] == 2, payload
+        assert payload["best_official_reward"] == 1.0, payload
+        assert payload["final_official_reward"] == 1.0, payload
+        assert payload["official_task_score"]["passed"] is True, payload
+        assert payload["stop_reason"] == "stop_after_first_official_reward_1_without_feedback", payload
+        assert payload["official_reward_feedback_forwarded_to_agent"] is False, payload
+        assert payload["verifier_output_forwarded_to_agent"] is False, payload
+        assert payload["reward_feedback_forwarded"] is False, payload
+        assert payload["raw_task_text_read_into_public_state"] is False, payload
+        assert payload["raw_trajectory_read_into_public_state"] is False, payload
+        assert payload["raw_verifier_output_read_into_public_state"] is False, payload
+        assert len(payload["attempts"]) == 2, payload
+        assert payload["attempts"][0]["official_reward"] == 0.0, payload
+        assert payload["attempts"][1]["official_reward"] == 1.0, payload
+        assert payload["attempts"][1]["official_success"] is True, payload
+        for attempt in payload["attempts"]:
+            assert attempt["raw_task_text_read"] is False, attempt
+            assert attempt["raw_trajectory_read"] is False, attempt
+            assert attempt["raw_verifier_output_read"] is False, attempt
+        summary_path = Path(payload["retry_summary_json"])
+        assert summary_path.exists(), payload
+        saved = json.loads(summary_path.read_text(encoding="utf-8"))
+        assert saved["first_success_attempt"] == 2, saved
 
 
 def test_host_worker_contract_only_cli() -> None:
@@ -1517,7 +1659,7 @@ time.sleep(30)
                 "--timeout-sec",
                 "20",
                 "--first-action-timeout-sec",
-                "1",
+                "5",
                 "--remote-command-file-bridge-command",
                 bridge_command,
                 "--worker-public-trace-dir",

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -6446,6 +6446,21 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         "run_group_id": str(args.run_group_id or ""),
         "sandbox": args.sandbox,
         "max_rounds": args.max_rounds,
+        "independent_goal_retry": {
+            "schema_version": "skillsbench_independent_goal_retry_config_v0",
+            "enabled": bool(int(getattr(args, "independent_goal_retries", 1) or 1) > 1),
+            "attempt_budget": max(
+                1, int(getattr(args, "independent_goal_retries", 1) or 1)
+            ),
+            "route_supported": route == "codex-app-server-goal-baseline",
+            "fresh_goal_thread_per_attempt": True,
+            "stop_policy": "stop_after_first_official_reward_1_or_retry_budget",
+            "official_reward_feedback_forwarded_to_agent": False,
+            "verifier_output_forwarded_to_agent": False,
+            "raw_task_text_read_into_public_state": False,
+            "raw_trajectory_read_into_public_state": False,
+            "raw_verifier_output_read_into_public_state": False,
+        },
         "treatment_prompt_style": args.treatment_prompt_style,
         "outer_timeout_sec": args.outer_timeout_sec,
         "sandbox_setup_timeout_sec": args.sandbox_setup_timeout,
@@ -12405,6 +12420,18 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--independent-goal-retries",
+        type=int,
+        default=1,
+        help=(
+            "Run the same codex-app-server-goal-baseline case as multiple "
+            "independent native Goal attempts. Each attempt gets a fresh "
+            "job/rollout/thread; official verifier reward is observed only by "
+            "the runner to decide whether to stop before the retry budget, and "
+            "is never forwarded to the worker."
+        ),
+    )
+    parser.add_argument(
         "--treatment-prompt-style",
         choices=("structured", "baseline-safe"),
         default="structured",
@@ -12880,6 +12907,21 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         parser.error("--task-ids must not contain duplicate task ids")
     if args.task_ids is not None and len(batch_task_ids) == 1:
         args.task_id = batch_task_ids[0]
+    if args.independent_goal_retries < 1:
+        parser.error("--independent-goal-retries must be >= 1")
+    if args.independent_goal_retries > 1:
+        if args.route != "codex-app-server-goal-baseline":
+            parser.error(
+                "--independent-goal-retries currently applies only to "
+                "codex-app-server-goal-baseline"
+            )
+        if args.reduce_only:
+            parser.error("--independent-goal-retries is not compatible with --reduce-only")
+        if len(batch_task_ids) > 1:
+            parser.error(
+                "--independent-goal-retries is not compatible with multi-case "
+                "--task-ids; retry one case at a time"
+            )
     if (
         args.route in PRODUCT_MODE_CONTROLLER_ROUTES
         and not args.plan_only
@@ -13299,6 +13341,208 @@ async def async_batch_main(
     }
 
 
+def _independent_goal_retry_enabled(args: argparse.Namespace) -> bool:
+    return int(getattr(args, "independent_goal_retries", 1) or 1) > 1
+
+
+def _safe_retry_slug(value: str) -> str:
+    slug = re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-")
+    return slug or "retry"
+
+
+def _clone_args_for_independent_goal_retry(
+    args: argparse.Namespace,
+    *,
+    attempt_index: int,
+    run_group_id: str,
+    base_job_name: str,
+) -> argparse.Namespace:
+    attempt_number = attempt_index + 1
+    attempt_args = argparse.Namespace(**vars(args))
+    attempt_args.independent_goal_retries = 1
+    attempt_args.task_ids = None
+    attempt_args.parallel_cases = 1
+    attempt_args.run_group_id = run_group_id
+    attempt_args.job_name = f"{base_job_name}-attempt-{attempt_number:02d}"
+    route_slug = _safe_retry_slug(str(args.route).replace("-", "_"))
+    attempt_args.rollout_name = (
+        f"{args.task_id}__{route_slug}_independent_attempt_{attempt_number:02d}"
+    )
+    return attempt_args
+
+
+def _official_reward_from_payload(payload: dict[str, Any]) -> float | None:
+    official_task_score = payload.get("official_task_score")
+    if isinstance(official_task_score, dict):
+        value = official_task_score.get("value")
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return float(value)
+    value = payload.get("official_score")
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value)
+    return None
+
+
+def _official_success_from_payload(payload: dict[str, Any]) -> bool:
+    official_task_score = payload.get("official_task_score")
+    if isinstance(official_task_score, dict):
+        if official_task_score.get("passed") is True:
+            return True
+    reward = _official_reward_from_payload(payload)
+    return bool(reward is not None and reward >= 1.0)
+
+
+def _independent_goal_retry_attempt_summary(
+    payload: dict[str, Any],
+    *,
+    attempt_index: int,
+) -> dict[str, Any]:
+    launch_plan = payload.get("launch_plan")
+    if not isinstance(launch_plan, dict):
+        launch_plan = {}
+    official_reward = _official_reward_from_payload(payload)
+    official_success = _official_success_from_payload(payload)
+    summary: dict[str, Any] = {
+        "schema_version": "skillsbench_independent_goal_retry_attempt_v0",
+        "attempt_index": attempt_index,
+        "attempt_number": attempt_index + 1,
+        "ok": payload.get("ok") is True,
+        "runner_returncode": int(payload.get("runner_returncode") or 0),
+        "official_success": official_success,
+        "official_reward": official_reward,
+        "score_failure_attribution": str(
+            payload.get("score_failure_attribution") or ""
+        ),
+        "raw_stdout_recorded": False,
+        "raw_stderr_recorded": False,
+        "raw_task_text_read": False,
+        "raw_trajectory_read": False,
+        "raw_verifier_output_read": False,
+    }
+    for key in (
+        "task_id",
+        "route",
+        "run_group_id",
+        "job_name",
+        "rollout_name",
+        "compact_benchmark_run_json",
+        "result_json",
+    ):
+        value = payload.get(key) or launch_plan.get(key)
+        if value:
+            summary[key] = str(value)
+    if not summary.get("compact_benchmark_run_json") and launch_plan.get(
+        "compact_benchmark_run_json"
+    ):
+        summary["compact_benchmark_run_json"] = str(
+            launch_plan.get("compact_benchmark_run_json")
+        )
+    if not summary.get("result_json") and launch_plan.get("result_json"):
+        summary["result_json"] = str(launch_plan.get("result_json"))
+    return summary
+
+
+async def async_independent_goal_retry_main(args: argparse.Namespace) -> dict[str, Any]:
+    attempt_budget = max(1, int(getattr(args, "independent_goal_retries", 1) or 1))
+    run_group_id = str(
+        args.run_group_id
+        or f"skillsbench-{args.task_id}-{args.route}-independent-retry-{_now_stamp()}"
+    )
+    base_job_name = _safe_retry_slug(
+        str(
+            args.job_name
+            or f"skillsbench-{args.task_id}-{args.route}-independent-retry-{_now_stamp()}"
+        )
+    )
+    jobs_dir = Path(args.jobs_dir).expanduser()
+    attempts: list[dict[str, Any]] = []
+    success_observed = False
+    first_success_attempt: int | None = None
+
+    for attempt_index in range(attempt_budget):
+        attempt_args = _clone_args_for_independent_goal_retry(
+            args,
+            attempt_index=attempt_index,
+            run_group_id=run_group_id,
+            base_job_name=base_job_name,
+        )
+        attempt_plan = build_plan(attempt_args)
+        try:
+            payload = await async_main(attempt_args, plan=attempt_plan)
+            payload["runner_returncode"] = 0
+        except Exception as exc:
+            payload, returncode = _build_runner_exception_closeout_payload(
+                attempt_args,
+                attempt_plan,
+                exc,
+            )
+            payload["runner_returncode"] = returncode
+        attempt_summary = _independent_goal_retry_attempt_summary(
+            payload,
+            attempt_index=attempt_index,
+        )
+        attempts.append(attempt_summary)
+        if attempt_summary.get("official_success") is True:
+            success_observed = True
+            first_success_attempt = attempt_index + 1
+            break
+
+    stop_reason = (
+        "stop_after_first_official_reward_1_without_feedback"
+        if success_observed
+        else "stop_after_independent_goal_retry_budget"
+    )
+    observed_rewards = [
+        float(attempt["official_reward"])
+        for attempt in attempts
+        if isinstance(attempt.get("official_reward"), (int, float))
+        and not isinstance(attempt.get("official_reward"), bool)
+    ]
+    best_official_reward = max(observed_rewards) if observed_rewards else None
+    final_official_reward = observed_rewards[-1] if observed_rewards else None
+    retry_summary = {
+        "schema_version": "skillsbench_independent_goal_retry_summary_v0",
+        "ok": success_observed,
+        "independent_goal_retry": True,
+        "task_id": str(args.task_id),
+        "route": str(args.route),
+        "run_group_id": run_group_id,
+        "attempt_budget": attempt_budget,
+        "attempts_started": len(attempts),
+        "attempts_completed": len(attempts),
+        "success_observed": success_observed,
+        "first_success_attempt": first_success_attempt,
+        "best_official_reward": best_official_reward,
+        "final_official_reward": final_official_reward,
+        "official_task_score": {
+            "kind": "skillsbench_independent_goal_retry_best_reward",
+            "value": best_official_reward,
+            "passed": success_observed,
+        },
+        "stop_reason": stop_reason,
+        "fresh_goal_thread_per_attempt": True,
+        "official_reward_feedback_forwarded_to_agent": False,
+        "verifier_output_forwarded_to_agent": False,
+        "reward_feedback_forwarded": False,
+        "raw_task_text_read_into_public_state": False,
+        "raw_trajectory_read_into_public_state": False,
+        "raw_verifier_output_read_into_public_state": False,
+        "attempts": attempts,
+        "runner_returncode": 0 if success_observed else max(
+            int(attempt.get("runner_returncode") or 0) for attempt in attempts
+        ),
+    }
+    summary_path = jobs_dir / base_job_name / "independent_goal_retry_summary.public.json"
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(
+        json.dumps(retry_summary, indent=2, sort_keys=True, default=_json_default)
+        + "\n",
+        encoding="utf-8",
+    )
+    retry_summary["retry_summary_json"] = str(summary_path)
+    return retry_summary
+
+
 def main(argv: list[str] | None = None) -> int:
     args = parse_args(argv or sys.argv[1:])
     logging.getLogger().setLevel(logging.WARNING)
@@ -13544,13 +13788,16 @@ def main(argv: list[str] | None = None) -> int:
         return 0
     task_ids = _batch_task_ids(args)
     batch_mode = len(task_ids) > 1
+    independent_retry_mode = _independent_goal_retry_enabled(args) and not args.plan_only
     if args.run_group_id is None:
         args.run_group_id = (
             f"skillsbench-batch-{args.route}-{_now_stamp()}"
             if batch_mode
+            else f"skillsbench-{args.task_id}-{args.route}-independent-retry-{_now_stamp()}"
+            if independent_retry_mode
             else f"skillsbench-{args.task_id}-{args.route}-{_now_stamp()}"
         )
-    plan = None if batch_mode else build_plan(args)
+    plan = None if batch_mode or independent_retry_mode else build_plan(args)
     previous_sigterm_handler = signal.getsignal(signal.SIGTERM)
 
     def _closeout_sigterm_handler(signum: int, frame: Any) -> None:
@@ -13562,10 +13809,26 @@ def main(argv: list[str] | None = None) -> int:
     try:
         if batch_mode:
             payload = asyncio.run(async_batch_main(args, task_ids=task_ids))
+        elif independent_retry_mode:
+            payload = asyncio.run(async_independent_goal_retry_main(args))
         else:
             payload = asyncio.run(async_main(args, plan=plan))
     except (KeyboardInterrupt, SkillsBenchRunnerInterrupted) as exc:
         if plan is None:
+            if independent_retry_mode:
+                payload = {
+                    "ok": False,
+                    "independent_goal_retry": True,
+                    "task_id": str(args.task_id),
+                    "route": str(args.route),
+                    "attempt_budget": int(args.independent_goal_retries),
+                    "run_group_id": args.run_group_id,
+                    "error_type": type(exc).__name__,
+                    "error": str(exc),
+                    "compact_closeout_recorded": False,
+                }
+                print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stderr)
+                return 1
             payload = {
                 "ok": False,
                 "batch": True,
@@ -13593,6 +13856,20 @@ def main(argv: list[str] | None = None) -> int:
         return returncode
     except Exception as exc:
         if plan is None:
+            if independent_retry_mode:
+                payload = {
+                    "ok": False,
+                    "independent_goal_retry": True,
+                    "task_id": str(args.task_id),
+                    "route": str(args.route),
+                    "attempt_budget": int(args.independent_goal_retries),
+                    "run_group_id": args.run_group_id,
+                    "error_type": type(exc).__name__,
+                    "error": str(exc),
+                    "compact_closeout_recorded": False,
+                }
+                print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stderr)
+                return 1
             payload = {
                 "ok": False,
                 "batch": True,


### PR DESCRIPTION
## Summary
- add --independent-goal-retries for codex-app-server-goal-baseline so the same SkillsBench case can run as fresh native Goal attempts
- stop the retry arm on first official reward=1 or retry budget, while keeping reward/verifier output withheld from the worker
- record public-safe retry accounting with attempt count, first success attempt, best/final reward, and no raw task/trajectory/verifier output flags

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-app-server-goal-worker-smoke.py
- python3 examples/skillsbench-app-server-goal-worker-smoke.py
- python3 examples/skillsbench-goal-start-product-mode-route-smoke.py
- git diff --check origin/main...HEAD
- loopx check --scan-path scripts/skillsbench_automation_loop.py --scan-path examples/skillsbench-app-server-goal-worker-smoke.py

## Boundary
No official reward/pass/fail/verifier output is forwarded to the worker. Retry summary is compact/public-safe accounting only.