### PR TITLE
Expose auto-research multiround gain acceptance

### DIFF
--- a/docs/guides/auto-research-command-path.md
+++ b/docs/guides/auto-research-command-path.md
@@ -107,6 +107,13 @@ Expected minimal E2E result:
 - `research_loop.selected_hypothesis_id` is `hyp_partial_selection`;
 - `research_loop.dev_gain_over_baseline` is `3.0`;
 - `research_loop.holdout_gain_over_baseline` is `3.5`;
+- `multiround_gain_acceptance.round_count` is `2`;
+- `multiround_gain_acceptance.hypotheses_attempted` lists the seed
+  full-sort hypothesis and the selected partial-selection hypothesis;
+- `multiround_gain_acceptance.evidence_events_appended` is `3`;
+- `multiround_gain_acceptance.final_gain_over_seed` is `3.5`;
+- `multiround_gain_acceptance.why_better` explains why the final result beats
+  the seed/baseline without reading raw logs;
 - `protected_eval_result.dev_metric` is `4.0`;
 - `protected_eval_result.holdout_metric` is `4.5`;
 - dev and holdout exactness are both `true`;

--- a/examples/auto-research-demo-e2e-smoke.py
+++ b/examples/auto-research-demo-e2e-smoke.py
@@ -133,6 +133,27 @@ def assert_e2e_payload(
             "append_evidence_to_loopx_state",
             "read_board_and_acceptance_projection",
         ], payload
+        gain_acceptance = payload["multiround_gain_acceptance"]
+        assert gain_acceptance["schema_version"] == "auto_research_multiround_gain_acceptance_v0", payload
+        assert gain_acceptance["round_count"] == 2, payload
+        assert gain_acceptance["hypotheses_attempted"] == [
+            "hyp_full_sort",
+            "hyp_partial_selection",
+        ], payload
+        assert gain_acceptance["evidence_event_count"] == 3, payload
+        assert gain_acceptance["evidence_events_appended"] == 3, payload
+        assert gain_acceptance["seed_hypothesis_id"] == "hyp_full_sort", payload
+        assert gain_acceptance["selected_hypothesis_id"] == "hyp_partial_selection", payload
+        assert gain_acceptance["seed_dev_metric"] == 1.0, payload
+        assert gain_acceptance["selected_dev_metric"] == 4.0, payload
+        assert gain_acceptance["selected_holdout_metric"] == 4.5, payload
+        assert gain_acceptance["dev_gain_over_baseline"] == 3.0, payload
+        assert gain_acceptance["holdout_gain_over_baseline"] == 3.5, payload
+        assert gain_acceptance["final_gain_over_seed"] == 3.5, payload
+        assert gain_acceptance["better_than_seed"] is True, payload
+        assert "partial-selection hypothesis beats the seed" in gain_acceptance["why_better"], payload
+        assert gain_acceptance["live_codex_lane_authored"] is False, payload
+        assert gain_acceptance["public_boundary"]["raw_logs_recorded"] is False, payload
         assert protected_eval["result_source"] == "generated_quickstart_pack_protected_eval", payload
         assert protected_eval["status"] == "supported", payload
         assert protected_eval["dev_metric"] == 4.0, payload
@@ -395,6 +416,12 @@ def main() -> int:
         assert "research_loop_dev_rounds:" in markdown, markdown
         assert "research_loop_evidence_events:" in markdown, markdown
         assert "research_loop_live_codex_lane_authored: `False`" in markdown, markdown
+        assert "multiround_gain_rounds:" in markdown, markdown
+        assert "multiround_gain_hypotheses:" in markdown, markdown
+        assert "multiround_gain_appended_events:" in markdown, markdown
+        assert "multiround_gain_final_delta:" in markdown, markdown
+        assert "multiround_gain_better_than_seed:" in markdown, markdown
+        assert "multiround_gain_why_better:" in markdown, markdown
         assert "frontier_goal_id: `loopx-auto-research-knn`" in markdown, markdown
         assert "tracking_goal_drives_frontier: `False`" in markdown, markdown
         assert "live_codex_e2e_claim_allowed: `False`" in markdown, markdown
@@ -434,6 +461,11 @@ def main() -> int:
         assert "research_loop.evidence_event_count" in guide, guide
         assert "research_loop.dev_gain_over_baseline" in guide, guide
         assert "research_loop.holdout_gain_over_baseline" in guide, guide
+        assert "multiround_gain_acceptance.round_count" in guide, guide
+        assert "multiround_gain_acceptance.hypotheses_attempted" in guide, guide
+        assert "multiround_gain_acceptance.evidence_events_appended" in guide, guide
+        assert "multiround_gain_acceptance.final_gain_over_seed" in guide, guide
+        assert "multiround_gain_acceptance.why_better" in guide, guide
         assert "protected_eval_result.dev_metric" in guide, guide
         assert "`4.0`" in guide, guide
         assert "protected_eval_result.holdout_metric" in guide, guide

--- a/examples/auto-research-one-click-ux-smoke.py
+++ b/examples/auto-research-one-click-ux-smoke.py
@@ -196,6 +196,17 @@ def main() -> int:
         assert len(payload["research_loop"]["kernel_event_trace"]) == 3, payload
         assert payload["research_loop"]["dev_gain_over_baseline"] == 3.0, payload
         assert payload["research_loop"]["holdout_gain_over_baseline"] == 3.5, payload
+        gain_acceptance = payload["multiround_gain_acceptance"]
+        assert gain_acceptance["round_count"] == 2, payload
+        assert gain_acceptance["hypotheses_attempted"] == [
+            "hyp_full_sort",
+            "hyp_partial_selection",
+        ], payload
+        assert gain_acceptance["evidence_events_appended"] == 3, payload
+        assert gain_acceptance["final_gain_over_seed"] == 3.5, payload
+        assert gain_acceptance["better_than_seed"] is True, payload
+        assert "partial-selection hypothesis beats the seed" in gain_acceptance["why_better"], payload
+        assert gain_acceptance["live_codex_lane_authored"] is False, payload
         assert payload["protected_eval_result"]["dev_metric"] == 4.0, payload
         assert payload["protected_eval_result"]["holdout_metric"] == 4.5, payload
         assert (

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -460,6 +460,74 @@ def _compact_kernel_event_trace(research_loop: dict[str, object]) -> list[dict[s
     return trace
 
 
+def _compact_multiround_gain_acceptance(
+    research_loop: dict[str, object],
+    *,
+    append_payload: dict[str, object],
+) -> dict[str, object]:
+    trace = _compact_kernel_event_trace(research_loop)
+    dev_events = [event for event in trace if event.get("split") == "dev"]
+    attempted = []
+    for event in dev_events:
+        hypothesis_id = event.get("hypothesis_id")
+        if hypothesis_id and hypothesis_id not in attempted:
+            attempted.append(hypothesis_id)
+    seed_event = dev_events[0] if dev_events else {}
+    selected_id = research_loop.get("selected_hypothesis_id")
+    selected_dev = next(
+        (event for event in dev_events if event.get("hypothesis_id") == selected_id),
+        {},
+    )
+    holdout_event = next(
+        (
+            event
+            for event in trace
+            if event.get("split") == "holdout"
+            and event.get("hypothesis_id") == selected_id
+        ),
+        {},
+    )
+    seed_metric = seed_event.get("metric")
+    final_metric = holdout_event.get("metric") or selected_dev.get("metric")
+    better_than_seed = (
+        final_metric is not None
+        and seed_metric is not None
+        and float(final_metric) > float(seed_metric)
+    )
+    return {
+        "schema_version": "auto_research_multiround_gain_acceptance_v0",
+        "result_source": research_loop.get("result_source"),
+        "live_codex_lane_authored": False,
+        "round_count": research_loop.get("dev_round_count"),
+        "hypotheses_attempted": attempted,
+        "evidence_event_count": research_loop.get("evidence_event_count"),
+        "evidence_events_appended": append_payload.get("appended_count"),
+        "selected_hypothesis_id": selected_id,
+        "seed_hypothesis_id": seed_event.get("hypothesis_id"),
+        "seed_dev_metric": seed_metric,
+        "selected_dev_metric": selected_dev.get("metric"),
+        "selected_holdout_metric": holdout_event.get("metric"),
+        "dev_gain_over_baseline": _metric_gain(research_loop.get("dev_metric")),
+        "holdout_gain_over_baseline": _metric_gain(research_loop.get("holdout_metric")),
+        "final_gain_over_seed": (
+            float(final_metric) - float(seed_metric)
+            if final_metric is not None and seed_metric is not None
+            else None
+        ),
+        "better_than_seed": better_than_seed,
+        "why_better": (
+            "The selected partial-selection hypothesis beats the seed full-sort candidate "
+            "on dev and keeps the gain on holdout."
+        ),
+        "public_boundary": {
+            "raw_logs_recorded": False,
+            "private_artifacts_recorded": False,
+            "absolute_paths_recorded": False,
+            "live_codex_lane_authored": False,
+        },
+    }
+
+
 def run_auto_research_demo_e2e(
     *,
     agent_id: str,
@@ -692,6 +760,10 @@ def run_auto_research_demo_e2e(
                     ],
                     "public_boundary": research_loop.get("public_boundary"),
                 },
+                "multiround_gain_acceptance": _compact_multiround_gain_acceptance(
+                    research_loop,
+                    append_payload=append_payload,
+                ),
                 "append": {
                     "appended_count": append_payload.get("appended_count"),
                     "skipped_existing_count": append_payload.get("skipped_existing_count"),

--- a/loopx/capabilities/auto_research/legacy_core.py
+++ b/loopx/capabilities/auto_research/legacy_core.py
@@ -3473,6 +3473,11 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
         append = payload.get("append") if isinstance(payload.get("append"), dict) else {}
         board = payload.get("board") if isinstance(payload.get("board"), dict) else {}
         acceptance = payload.get("acceptance") if isinstance(payload.get("acceptance"), dict) else {}
+        gain_acceptance = (
+            payload.get("multiround_gain_acceptance")
+            if isinstance(payload.get("multiround_gain_acceptance"), dict)
+            else {}
+        )
         supervisor = payload.get("supervisor") if isinstance(payload.get("supervisor"), dict) else {}
         commands = payload.get("commands") if isinstance(payload.get("commands"), dict) else {}
         route = payload.get("route_contract") if isinstance(payload.get("route_contract"), dict) else {}
@@ -3509,6 +3514,12 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
             f"- research_loop_holdout_gain: `{research_loop.get('holdout_gain_over_baseline')}`",
             f"- research_loop_live_codex_lane_authored: `{research_loop.get('live_codex_lane_authored')}`",
             f"- research_loop_kernel_events: `{len(research_loop.get('kernel_event_trace') or [])}`",
+            f"- multiround_gain_rounds: `{gain_acceptance.get('round_count')}`",
+            f"- multiround_gain_hypotheses: `{gain_acceptance.get('hypotheses_attempted')}`",
+            f"- multiround_gain_appended_events: `{gain_acceptance.get('evidence_events_appended')}`",
+            f"- multiround_gain_final_delta: `{gain_acceptance.get('final_gain_over_seed')}`",
+            f"- multiround_gain_better_than_seed: `{gain_acceptance.get('better_than_seed')}`",
+            f"- multiround_gain_why_better: `{gain_acceptance.get('why_better')}`",
             f"- protected_eval_executed: `{protected_eval.get('executed')}`",
             f"- protected_eval_source: `{protected_eval.get('result_source')}`",
             f"- protected_eval_status: `{protected_eval.get('status')}`",


### PR DESCRIPTION
## Summary
- add a public-safe `multiround_gain_acceptance` projection to the auto-research E2E payload
- render the same gain acceptance fields in markdown output and the operator guide
- strengthen E2E and one-click smokes so round count, attempted hypotheses, appended evidence events, metric deltas, and why-better are all asserted

## Truth boundary
- this keeps `live_codex_lane_authored=false`; it does not claim visible Codex panes authored the result
- the projection summarizes the minimal research kernel evidence already appended through the E2E path

## Validation
- `python3 -m py_compile loopx/capabilities/auto_research/demo_e2e.py loopx/capabilities/auto_research/legacy_core.py examples/auto-research-demo-e2e-smoke.py examples/auto-research-one-click-ux-smoke.py`
- `python3 examples/auto-research-demo-e2e-smoke.py`
- `python3 examples/auto-research-one-click-ux-smoke.py`
- `python3 examples/visible-multi-agent-launcher-smoke.py`
- `python3 examples/auto-research-skill-contract-smoke.py`
- `python3 examples/generic-multi-agent-one-command-smoke.py`
- `git diff --check`
- `loopx check --scan-path loopx/capabilities/auto_research/demo_e2e.py --scan-path loopx/capabilities/auto_research/legacy_core.py --scan-path examples/auto-research-demo-e2e-smoke.py --scan-path examples/auto-research-one-click-ux-smoke.py --scan-path docs/guides/auto-research-command-path.md`
