### PR TITLE
Fix quota handoff successor canary routing

### DIFF
--- a/examples/catalog-canary-planner-smoke.py
+++ b/examples/catalog-canary-planner-smoke.py
@@ -161,7 +161,7 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     work_lane_policy_payload = build_catalog_canary_plan(
         changed_files=["loopx/policies/monitor_todo.py"],
         surfaces=["resume_when resume_ready work-lane policy seam"],
-        max_checks_per_profile=3,
+        max_checks_per_profile=4,
     )
     work_lane_profiles = {
         profile["id"]: profile for profile in work_lane_policy_payload["domain_profiles"]
@@ -171,6 +171,9 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
         check["command"] for check in work_lane_profiles["control-plane-refactor"]["checks"]
     ]
     assert "python3 examples/quota-resume-gated-open-todo-smoke.py" in work_lane_commands, (
+        work_lane_profiles["control-plane-refactor"]
+    )
+    assert "python3 examples/quota-cleared-blocker-successor-gate-smoke.py" in work_lane_commands, (
         work_lane_profiles["control-plane-refactor"]
     )
     assert all(

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -308,7 +308,12 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
             "work-lane policy",
             "resume_when",
             "resume_ready",
+            "handoff",
+            "blocks_agent",
+            "unblocks_todo_id",
+            "successor",
             "loopx/policies/monitor_todo.py",
+            "loopx/todo_handoff_gate.py",
         ),
         "checks": [
             {
@@ -325,6 +330,11 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
                 "command": "python3 examples/quota-resume-gated-open-todo-smoke.py",
                 "tier": "default",
                 "reason": "guards resume_when-gated open todos from entering executable quota lanes early",
+            },
+            {
+                "command": "python3 examples/quota-cleared-blocker-successor-gate-smoke.py",
+                "tier": "default",
+                "reason": "guards cleared handoff gates waking the blocked agent through a concrete successor todo",
             },
             {
                 "command": "python3 examples/work-lane-contract-smoke.py",

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -1892,6 +1892,7 @@ def _todo_summary_source_items(value: dict[str, Any]) -> list[dict[str, Any]]:
         "current_agent_claimed_monitor_items",
         "items",
     )
+    ready_successor_todo_ids = _handoff_ready_successor_todo_ids(value)
     open_items: list[dict[str, Any]] = []
     for key in source_keys:
         source_items = value.get(key) if isinstance(value.get(key), list) else []
@@ -1910,8 +1911,40 @@ def _todo_summary_source_items(value: dict[str, Any]) -> list[dict[str, Any]]:
             )
             if duplicate:
                 continue
-            open_items.append(_compact_todo_summary_item(item, text=text))
+            compact = _compact_todo_summary_item(item, text=text)
+            todo_id = normalize_todo_id(compact.get("todo_id"))
+            if (
+                todo_id
+                and todo_id in ready_successor_todo_ids
+                and normalize_todo_resume_when(compact.get("resume_when"))
+                and "resume_ready" not in compact
+            ):
+                compact["resume_ready"] = True
+                compact["resume_condition"] = {
+                    "schema_version": "todo_resume_condition_v0",
+                    "resume_when": compact.get("resume_when"),
+                    "satisfied": True,
+                    "source": "handoff_gate_cleared_with_successor",
+                }
+            open_items.append(compact)
     return open_items
+
+
+def _handoff_ready_successor_todo_ids(value: dict[str, Any]) -> set[str]:
+    ready: set[str] = set()
+    for gate in _todo_summary_handoff_gates(value):
+        if not isinstance(gate, dict):
+            continue
+        if str(gate.get("gate_state") or "") != HandoffGateState.CLEARED_WITH_SUCCESSOR.value:
+            continue
+        successor_ids = gate.get("successor_todo_ids")
+        if not isinstance(successor_ids, list):
+            continue
+        for todo_id in successor_ids:
+            normalized = normalize_todo_id(todo_id)
+            if normalized:
+                ready.add(normalized)
+    return ready
 
 
 def _todo_summary_handoff_gates(value: dict[str, Any]) -> list[dict[str, Any]]:


### PR DESCRIPTION
## Summary
- let quota infer `resume_ready=true` for open successor todos when a projected handoff gate is already `cleared_with_successor`
- add the cleared-handoff successor smoke to the control-plane refactor canary profile
- extend the catalog canary planner smoke so this regression remains selected for deeper control-plane canary runs

## Why
A canary/E2E check caught that `quota-cleared-blocker-successor-gate-smoke.py` failed on latest main: quota returned `run`, but no `agent_lane_next_action` was projected for the successor todo. That made a cleared handoff easy to appear as progress-ready while the concrete next todo stayed invisible to the agent lane.

## Validation
- `python3 examples/quota-cleared-blocker-successor-gate-smoke.py`
- `python3 examples/catalog-canary-planner-smoke.py`
- `python3 examples/catalog-canary-run-e2e-smoke.py`
- `python3 -m loopx.cli --format json canary run --profile control-plane-refactor --max-checks-per-profile 4 --check-limit 4 --timeout-seconds 60`
- `python3 examples/quota-contract-smoke.py`
- `python3 examples/control-plane-integrated-canary-smoke.py`
- `python3 examples/quota-resume-gated-open-todo-smoke.py`
- `python3 examples/quota-agent-scoped-user-gate-smoke.py`
- `python3 -m py_compile loopx/quota.py loopx/canary/planner.py examples/catalog-canary-planner-smoke.py`
- `git diff --check`
- `loopx check --scan-path loopx/quota.py --scan-path loopx/canary/planner.py --scan-path examples/catalog-canary-planner-smoke.py` (passes with existing duplicate-index warning only)
