### PR TITLE
Add runtime connector catalog canary profile

### DIFF
--- a/examples/catalog-canary-planner-smoke.py
+++ b/examples/catalog-canary-planner-smoke.py
@@ -57,6 +57,7 @@ def assert_profiles_come_from_catalog_matrix() -> None:
         "product-entry-workflows",
         "cross-runtime-impl-review-demo",
         "host-command-entry",
+        "runtime-connector-catalog",
         "frontstage-rollout",
         "auto-research-demo",
         "catalog-canary-contract",
@@ -319,6 +320,33 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     assert all(check["tier"] == "default" for check in host_command_profile["checks"])
     assert host_command_profile["deep_checks_available"] is False, host_command_profile
     assert host_command_profile["deep_checks_included"] is False, host_command_profile
+
+    runtime_connector_payload = build_catalog_canary_plan(
+        changed_files=["docs/runtime-connector-catalog.md"],
+        surfaces=[
+            "runtime connector catalog codex app heartbeat codex cli tui "
+            "claude code loop worker bridge scheduler_hint scoped identity"
+        ],
+        max_checks_per_profile=4,
+    )
+    runtime_connector_profiles = {
+        profile["id"]: profile for profile in runtime_connector_payload["domain_profiles"]
+    }
+    assert "runtime-connector-catalog" in runtime_connector_profiles, runtime_connector_payload
+    runtime_connector_profile = runtime_connector_profiles["runtime-connector-catalog"]
+    runtime_connector_commands = [
+        check["command"] for check in runtime_connector_profile["checks"]
+    ]
+    assert "python3 examples/heartbeat-prompt-smoke.py" in runtime_connector_commands
+    assert (
+        "python3 examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py"
+        in runtime_connector_commands
+    )
+    assert "python3 examples/claude-goalmode-lifecycle-smoke.py" in runtime_connector_commands
+    assert "python3 examples/worker-bridge-install-contract-smoke.py" in runtime_connector_commands
+    assert all(check["tier"] == "default" for check in runtime_connector_profile["checks"])
+    assert runtime_connector_profile["deep_checks_available"] is True, runtime_connector_profile
+    assert runtime_connector_profile["deep_checks_included"] is False, runtime_connector_profile
 
     auto_research_payload = build_catalog_canary_plan(
         changed_files=["loopx/capabilities/auto_research/core.py"],

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -751,6 +751,62 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
         ],
     },
     {
+        "id": "runtime-connector-catalog",
+        "title": "Runtime connector catalog",
+        "purpose": (
+            "Check Codex App heartbeat, Codex CLI TUI, Claude Code loop, "
+            "and worker bridge connector contracts from the public runtime catalog."
+        ),
+        "catalog_families": ["Work Routing", "State And Boundary", "Planning Governance"],
+        "trigger_hints": (
+            "runtime connector",
+            "runtime connector catalog",
+            "runtime-connector-catalog",
+            "docs/runtime-connector-catalog.md",
+            "codex app heartbeat",
+            "codex_app_heartbeat",
+            "codex cli tui",
+            "codex_cli_tui",
+            "claude code loop",
+            "claude_code_loop",
+            "shell worker",
+            "http webhook",
+            "worker bridge",
+            "worker_bridge",
+            "scheduler_hint",
+            "scoped identity",
+            "runtime loop",
+            "host runtime",
+        ),
+        "checks": [
+            {
+                "command": "python3 examples/heartbeat-prompt-smoke.py",
+                "tier": "default",
+                "reason": "guards Codex App heartbeat identity, scheduler hints, and no-spend cadence behavior",
+            },
+            {
+                "command": "python3 examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py",
+                "tier": "default",
+                "reason": "checks Codex CLI TUI bootstrap bundle and scoped LoopX command contract",
+            },
+            {
+                "command": "python3 examples/claude-goalmode-lifecycle-smoke.py",
+                "tier": "default",
+                "reason": "checks the Claude Code goal-mode loop lifecycle without production actions",
+            },
+            {
+                "command": "python3 examples/worker-bridge-install-contract-smoke.py",
+                "tier": "default",
+                "reason": "checks generic worker bridge install/status contracts without private runtime material",
+            },
+            {
+                "command": "python3 examples/host-integration-surface-smoke.py",
+                "tier": "deep",
+                "reason": "samples the broader host integration surface when connector catalog changes are promoted",
+            },
+        ],
+    },
+    {
         "id": "frontstage-rollout",
         "title": "Frontstage rollout projection",
         "purpose": "Check public frontstage/showcase projection data before visual browser smokes.",


### PR DESCRIPTION
## Summary
- add a runtime-connector-catalog canary domain profile for Codex App heartbeat, Codex CLI TUI, Claude Code loop, and worker bridge connector contracts
- make catalog planner smoke assert docs/runtime-connector-catalog.md selects that profile and default checks

## Validation
- python3 examples/heartbeat-prompt-smoke.py
- python3 examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py
- python3 examples/claude-goalmode-lifecycle-smoke.py
- python3 examples/worker-bridge-install-contract-smoke.py
- python3 examples/catalog-canary-planner-smoke.py
- python3 examples/catalog-canary-run-e2e-smoke.py
- python3 -m py_compile loopx/canary/planner.py examples/catalog-canary-planner-smoke.py
- python3 -m loopx.cli --format json canary run --profile runtime-connector-catalog --max-checks-per-profile 4 --check-limit 4 --timeout-seconds 120
- python3 -m loopx.cli check --scan-path loopx/canary/planner.py --scan-path examples/catalog-canary-planner-smoke.py
- python3 examples/host-integration-surface-smoke.py
- git diff --check

## Boundary
- no runtime behavior change outside canary profile selection
- no benchmark job launch, raw logs, credentials, local paths, or private evidence