### PR TITLE
Fix SkillsBench independent retry worker cleanup

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -109,6 +109,7 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
     build_compose_setup_diagnostic,
     build_plan,
     cleanup_benchflow_setup_stall_children,
+    cleanup_host_local_acp_attempt_children,
     cleanup_benchflow_soft_verify_timeout_children,
     install_benchflow_user_loop_final_verify_recovery,
     install_benchflow_verifier_prep_timeout_override,
@@ -11222,6 +11223,177 @@ def test_skillsbench_setup_stall_cleanup_targets_current_job_only() -> None:
         assert job_name not in json.dumps(cleanup, sort_keys=True)
 
 
+def test_skillsbench_host_local_attempt_cleanup_targets_current_attempt_only() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-host-acp-cleanup-") as tmp:
+        args = parse_args(
+            [
+                "--task-id",
+                "bike-rebalance",
+                "--route",
+                "codex-app-server-goal-baseline",
+                "--jobs-dir",
+                str(Path(tmp) / "jobs"),
+                "--job-name",
+                "skillsbench-bike-rebalance-cleanup-fixture-attempt-01",
+                "--host-local-acp-launch",
+            ]
+        )
+        plan = build_plan(args)
+        job_name = plan["job_name"]
+        rollout_name = plan["rollout_name"]
+        ps_stdout = "\n".join(
+            [
+                (
+                    "201 1 python scripts/skillsbench_local_acp_relay.py "
+                    f"--worker-public-trace-dir /tmp/{job_name}/trace "
+                    f"--project-name {rollout_name}"
+                ),
+                (
+                    "202 201 python scripts/skillsbench_host_codex_goal_worker.py "
+                    "--turn-timeout-sec 3600"
+                ),
+                "203 202 codex app-server --listen 127.0.0.1:0",
+                (
+                    "204 1 python scripts/skillsbench_local_acp_relay.py "
+                    "--worker-public-trace-dir /tmp/unrelated/trace "
+                    "--project-name unrelated"
+                ),
+            ]
+        )
+        alive = {201, 202, 203, 204}
+        sent: list[tuple[int, int]] = []
+        original_run = skillsbench_loop.subprocess.run
+        original_kill = skillsbench_loop.os.kill
+        original_sleep = skillsbench_loop.time.sleep
+
+        def fake_run(*_args: Any, **_kwargs: Any) -> Any:
+            return types.SimpleNamespace(returncode=0, stdout=ps_stdout, stderr="")
+
+        def fake_kill(pid: int, sig: int) -> None:
+            if sig == 0:
+                if pid in alive:
+                    return
+                raise ProcessLookupError(pid)
+            sent.append((pid, sig))
+            if sig == skillsbench_loop.signal.SIGTERM:
+                alive.discard(pid)
+
+        try:
+            skillsbench_loop.subprocess.run = fake_run
+            skillsbench_loop.os.kill = fake_kill
+            skillsbench_loop.time.sleep = lambda _seconds: None
+            cleanup = cleanup_host_local_acp_attempt_children(
+                plan,
+                grace_seconds=0,
+            )
+        finally:
+            skillsbench_loop.subprocess.run = original_run
+            skillsbench_loop.os.kill = original_kill
+            skillsbench_loop.time.sleep = original_sleep
+
+        assert cleanup["status"] == "terminated", cleanup
+        assert cleanup["match_count"] == 3, cleanup
+        assert set(sent) == {
+            (201, skillsbench_loop.signal.SIGTERM),
+            (202, skillsbench_loop.signal.SIGTERM),
+            (203, skillsbench_loop.signal.SIGTERM),
+        }, sent
+        assert 204 in alive, alive
+        prereqs = plan["runner_prerequisites"]
+        assert_prerequisites_include(
+            prereqs,
+            {
+                "host_local_acp_attempt_cleanup_requested": True,
+                "host_local_acp_attempt_cleanup_raw_logs_read": False,
+                "host_local_acp_attempt_cleanup_raw_command_recorded": False,
+                "host_local_acp_attempt_cleanup_status": "terminated",
+                "host_local_acp_attempt_cleanup_match_count": 3,
+                "host_local_acp_attempt_cleanup_term_sent_count": 3,
+                "host_local_acp_attempt_cleanup_kill_sent_count": 0,
+                "host_local_acp_attempt_cleanup_alive_after_count": 0,
+            },
+        )
+        assert job_name not in json.dumps(cleanup, sort_keys=True)
+        assert rollout_name not in json.dumps(cleanup, sort_keys=True)
+
+
+def test_independent_goal_retry_records_attempt_cleanup_after_exception() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-retry-cleanup-summary-") as tmp:
+        args = parse_args(
+            [
+                "--task-id",
+                "bike-rebalance",
+                "--route",
+                "codex-app-server-goal-baseline",
+                "--jobs-dir",
+                str(Path(tmp) / "jobs"),
+                "--job-name",
+                "skillsbench-bike-rebalance-independent-cleanup",
+                "--independent-goal-retries",
+                "2",
+                "--host-local-acp-launch",
+            ]
+        )
+        cleanup_calls: list[str] = []
+        original_async_main = skillsbench_loop.async_main
+        original_cleanup = skillsbench_loop.cleanup_host_local_acp_attempt_children
+
+        async def fake_async_main(
+            _args: Any,
+            *,
+            plan: dict[str, Any] | None = None,
+        ) -> dict[str, Any]:
+            raise RuntimeError("fixture runner exception")
+
+        def fake_cleanup(plan_arg: dict[str, Any], **_kwargs: Any) -> dict[str, Any]:
+            cleanup_calls.append(str(plan_arg.get("job_name") or ""))
+            prereqs = plan_arg.setdefault("runner_prerequisites", {})
+            prereqs.update(
+                {
+                    "host_local_acp_attempt_cleanup_requested": True,
+                    "host_local_acp_attempt_cleanup_raw_logs_read": False,
+                    "host_local_acp_attempt_cleanup_raw_command_recorded": False,
+                    "host_local_acp_attempt_cleanup_status": "no_matching_processes",
+                    "host_local_acp_attempt_cleanup_match_count": 0,
+                    "host_local_acp_attempt_cleanup_term_sent_count": 0,
+                    "host_local_acp_attempt_cleanup_kill_sent_count": 0,
+                    "host_local_acp_attempt_cleanup_alive_after_count": 0,
+                }
+            )
+            return {
+                "schema_version": "skillsbench_host_local_acp_attempt_cleanup_v0",
+                "requested": True,
+                "raw_logs_read": False,
+                "raw_command_recorded": False,
+                "status": "no_matching_processes",
+                "match_count": 0,
+                "term_sent_count": 0,
+                "kill_sent_count": 0,
+                "alive_after_count": 0,
+            }
+
+        try:
+            skillsbench_loop.async_main = fake_async_main
+            skillsbench_loop.cleanup_host_local_acp_attempt_children = fake_cleanup
+            summary = asyncio.run(skillsbench_loop.async_independent_goal_retry_main(args))
+        finally:
+            skillsbench_loop.async_main = original_async_main
+            skillsbench_loop.cleanup_host_local_acp_attempt_children = original_cleanup
+
+        assert summary["success_observed"] is False, summary
+        assert summary["attempts_started"] == 2, summary
+        assert len(cleanup_calls) == 2, cleanup_calls
+        for attempt in summary["attempts"]:
+            cleanup = attempt["host_local_acp_attempt_cleanup"]
+            assert cleanup["requested"] is True, cleanup
+            assert cleanup["raw_logs_read"] is False, cleanup
+            assert cleanup["raw_command_recorded"] is False, cleanup
+            assert cleanup["status"] == "no_matching_processes", cleanup
+        summary_text = json.dumps(summary, sort_keys=True)
+        assert "fixture runner exception" not in summary_text
+        assert "/private/" not in summary_text
+
+
 def test_skillsbench_reduce_only_missing_result_records_closeout_exit_zero() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-missing-result-main-") as tmp:
         jobs_dir = Path(tmp) / "jobs"
@@ -12905,6 +13077,8 @@ if __name__ == "__main__":
     test_skillsbench_intermediate_soft_verifier_phase_timeout_bounds_hung_exec()
     test_skillsbench_final_verifier_phase_timeout_bounds_hung_exec()
     test_skillsbench_intermediate_soft_verifier_return_cleans_orphan_processes()
+    test_skillsbench_host_local_attempt_cleanup_targets_current_attempt_only()
+    test_independent_goal_retry_records_attempt_cleanup_after_exception()
     test_skillsbench_local_driver_a2a_contract_keeps_codex_local()
     test_skillsbench_local_driver_a2a_contract_ready_only_after_both_sides()
     test_skillsbench_local_driver_a2a_contract_distinguishes_cli_from_handshake()

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -2084,6 +2084,7 @@ raise SystemExit(proc.returncode)
                     stdout=subprocess.PIPE,
                     stderr=subprocess.PIPE,
                     text=True,
+                    start_new_session=True,
                 )
                 self._write_worker_heartbeat(
                     stdout,
@@ -2170,7 +2171,7 @@ raise SystemExit(proc.returncode)
                         and bridge_first_action_deadline
                         and now >= bridge_first_action_deadline
                     ):
-                        proc.terminate()
+                        self._terminate_codex_process(proc, grace_sec=2)
                         stdout_text, stderr_text = proc.communicate(timeout=2)
                         self._publish_remote_bridge_agent_operations_trace(
                             bridge_summary_path=bridge_summary_path,
@@ -2193,7 +2194,7 @@ raise SystemExit(proc.returncode)
                         and meaningful_progress_deadline
                         and now >= meaningful_progress_deadline
                     ):
-                        proc.terminate()
+                        self._terminate_codex_process(proc, grace_sec=2)
                         stdout_text, stderr_text = proc.communicate(timeout=2)
                         self._publish_remote_bridge_agent_operations_trace(
                             bridge_summary_path=bridge_summary_path,
@@ -2219,7 +2220,7 @@ raise SystemExit(proc.returncode)
                         and now - last_bridge_activity_at
                         >= task_output_quiet_timeout_sec
                     ):
-                        proc.terminate()
+                        self._terminate_codex_process(proc, grace_sec=2)
                         stdout_text, stderr_text = proc.communicate(timeout=2)
                         self._publish_remote_bridge_agent_operations_trace(
                             bridge_summary_path=bridge_summary_path,
@@ -2246,7 +2247,7 @@ raise SystemExit(proc.returncode)
                         )
                         and now - last_bridge_activity_at >= bridge_idle_timeout_sec
                     ):
-                        proc.terminate()
+                        self._terminate_codex_process(proc, grace_sec=2)
                         stdout_text, stderr_text = proc.communicate(timeout=2)
                         self._publish_remote_bridge_agent_operations_trace(
                             bridge_summary_path=bridge_summary_path,
@@ -2263,7 +2264,7 @@ raise SystemExit(proc.returncode)
                             "codex_exec_bridge_idle_timeout"
                         )
                     if now >= deadline:
-                        proc.kill()
+                        self._terminate_codex_process(proc, grace_sec=2)
                         stdout_text, stderr_text = proc.communicate(timeout=2)
                         if bridge_summary_path is not None:
                             self._publish_remote_bridge_agent_operations_trace(
@@ -2290,6 +2291,7 @@ raise SystemExit(proc.returncode)
                     time.sleep(0.2)
                 stdout_text, stderr_text = proc.communicate(timeout=5)
             except subprocess.TimeoutExpired as exc:
+                self._terminate_codex_process(proc, grace_sec=2)
                 if bridge_summary_path is not None:
                     self._publish_remote_bridge_agent_operations_trace(
                         bridge_summary_path=bridge_summary_path,
@@ -2303,6 +2305,10 @@ raise SystemExit(proc.returncode)
                     )
                 self._terminate_bridge_server_process(bridge_server_proc)
                 raise TimeoutError from exc
+            except BaseException:
+                self._terminate_codex_process(proc, grace_sec=2)
+                self._terminate_bridge_server_process(bridge_server_proc)
+                raise
             if proc.returncode != 0:
                 if bridge_summary_path is not None:
                     self._publish_remote_bridge_agent_operations_trace(

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -2145,6 +2145,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_intermediate_soft_verify_timeout_stage",
         "benchflow_intermediate_soft_verify_timeout_cleanup_status",
         "benchflow_intermediate_soft_verify_orphan_cleanup_status",
+        "host_local_acp_attempt_cleanup_status",
         "benchflow_setup_stall_cleanup_status",
         "remote_command_file_bridge_consumption_status",
         "remote_command_file_bridge_agent_operation_trace_status",
@@ -2265,6 +2266,9 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_intermediate_soft_verify_timeout_cleanup_raw_logs_read",
         "benchflow_intermediate_soft_verify_orphan_cleanup_requested",
         "benchflow_intermediate_soft_verify_orphan_cleanup_raw_logs_read",
+        "host_local_acp_attempt_cleanup_requested",
+        "host_local_acp_attempt_cleanup_raw_logs_read",
+        "host_local_acp_attempt_cleanup_raw_command_recorded",
         "goal_start_product_mode",
         "goal_start_plan_required",
         "goal_start_selected_p0_lifecycle_required",
@@ -2325,6 +2329,10 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_intermediate_soft_verify_orphan_cleanup_term_sent_count",
         "benchflow_intermediate_soft_verify_orphan_cleanup_kill_sent_count",
         "benchflow_intermediate_soft_verify_orphan_cleanup_alive_after_count",
+        "host_local_acp_attempt_cleanup_match_count",
+        "host_local_acp_attempt_cleanup_term_sent_count",
+        "host_local_acp_attempt_cleanup_kill_sent_count",
+        "host_local_acp_attempt_cleanup_alive_after_count",
         "benchflow_verifier_prep_timeout_sec",
         "benchflow_final_verifier_timeout_sec",
         "benchflow_final_verifier_timeout_override_count",
@@ -2635,6 +2643,171 @@ def cleanup_benchflow_setup_stall_children(
             except ProcessLookupError:
                 continue
             except PermissionError:
+                continue
+        cleanup["kill_sent_count"] = kill_sent
+        time.sleep(0.1)
+        alive = {pid for pid in alive if is_alive(pid)}
+    cleanup["alive_after_count"] = len(alive)
+    if alive:
+        cleanup["status"] = "cleanup_incomplete"
+    elif kill_sent:
+        cleanup["status"] = "killed"
+    else:
+        cleanup["status"] = "terminated"
+    return publish()
+
+
+def cleanup_host_local_acp_attempt_children(
+    plan: dict[str, Any],
+    *,
+    grace_seconds: float = 3.0,
+) -> dict[str, Any]:
+    """Terminate host-local ACP/app-server worker processes scoped to one attempt."""
+
+    prerequisites = plan.setdefault("runner_prerequisites", {})
+    cleanup: dict[str, Any] = {
+        "schema_version": "skillsbench_host_local_acp_attempt_cleanup_v0",
+        "requested": True,
+        "raw_logs_read": False,
+        "raw_command_recorded": False,
+        "status": "not_attempted",
+        "match_count": 0,
+        "term_sent_count": 0,
+        "kill_sent_count": 0,
+        "alive_after_count": 0,
+    }
+
+    def publish() -> dict[str, Any]:
+        prerequisites["host_local_acp_attempt_cleanup_requested"] = True
+        prerequisites["host_local_acp_attempt_cleanup_raw_logs_read"] = False
+        prerequisites["host_local_acp_attempt_cleanup_raw_command_recorded"] = False
+        prerequisites["host_local_acp_attempt_cleanup_status"] = str(
+            cleanup.get("status") or "unknown"
+        )
+        for source, target in (
+            ("match_count", "host_local_acp_attempt_cleanup_match_count"),
+            ("term_sent_count", "host_local_acp_attempt_cleanup_term_sent_count"),
+            ("kill_sent_count", "host_local_acp_attempt_cleanup_kill_sent_count"),
+            ("alive_after_count", "host_local_acp_attempt_cleanup_alive_after_count"),
+        ):
+            value = cleanup.get(source)
+            if isinstance(value, int):
+                prerequisites[target] = value
+        return cleanup
+
+    if os.name != "posix":
+        cleanup["status"] = "unsupported_platform"
+        return publish()
+
+    if (
+        prerequisites.get("host_local_acp_launch") is not True
+        and prerequisites.get("agent_execution_mode") != "host_local_acp"
+    ):
+        cleanup["status"] = "not_applicable_no_host_local_acp"
+        return publish()
+
+    identifiers = [
+        str(value).strip()
+        for value in (plan.get("job_name"), plan.get("rollout_name"))
+        if str(value or "").strip()
+    ]
+    if not identifiers:
+        cleanup["status"] = "missing_run_identifiers"
+        return publish()
+
+    try:
+        proc = subprocess.run(
+            ["ps", "-eo", "pid=,ppid=,command="],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        cleanup["status"] = "process_table_unavailable"
+        return publish()
+    if proc.returncode != 0:
+        cleanup["status"] = "process_table_unavailable"
+        return publish()
+
+    entries: dict[int, tuple[int, str]] = {}
+    children: dict[int, set[int]] = {}
+    for line in proc.stdout.splitlines():
+        parts = line.strip().split(maxsplit=2)
+        if len(parts) < 3:
+            continue
+        try:
+            pid = int(parts[0])
+            ppid = int(parts[1])
+        except ValueError:
+            continue
+        command = parts[2]
+        entries[pid] = (ppid, command)
+        children.setdefault(ppid, set()).add(pid)
+
+    host_local_markers = (
+        "skillsbench_local_acp_relay.py",
+        "scripts/skillsbench_local_acp_relay.py",
+        "skillsbench_host_codex_goal_worker.py",
+        "scripts/skillsbench_host_codex_goal_worker.py",
+        "skillsbench_remote_command_file_bridge",
+        "remote_command_file_bridge",
+        "json_file_bridge",
+    )
+    protected_pids = {os.getpid(), os.getppid()}
+    root_matches = {
+        pid
+        for pid, (_ppid, command) in entries.items()
+        if pid not in protected_pids
+        and any(identifier in command for identifier in identifiers)
+        and any(marker in command for marker in host_local_markers)
+    }
+    to_terminate = set(root_matches)
+    stack = list(root_matches)
+    while stack:
+        parent = stack.pop()
+        for child in children.get(parent, set()):
+            if child not in to_terminate and child not in protected_pids:
+                to_terminate.add(child)
+                stack.append(child)
+
+    cleanup["match_count"] = len(to_terminate)
+    if not to_terminate:
+        cleanup["status"] = "no_matching_processes"
+        return publish()
+
+    def is_alive(pid: int) -> bool:
+        try:
+            os.kill(pid, 0)
+            return True
+        except ProcessLookupError:
+            return False
+        except PermissionError:
+            return True
+
+    term_sent = 0
+    for pid in sorted(to_terminate, reverse=True):
+        try:
+            os.kill(pid, signal.SIGTERM)
+            term_sent += 1
+        except (ProcessLookupError, PermissionError):
+            continue
+    cleanup["term_sent_count"] = term_sent
+
+    deadline = time.monotonic() + max(0.0, grace_seconds)
+    alive = {pid for pid in to_terminate if is_alive(pid)}
+    while alive and time.monotonic() < deadline:
+        time.sleep(0.1)
+        alive = {pid for pid in alive if is_alive(pid)}
+
+    kill_sent = 0
+    if alive:
+        for pid in sorted(alive, reverse=True):
+            try:
+                os.kill(pid, signal.SIGKILL)
+                kill_sent += 1
+            except (ProcessLookupError, PermissionError):
                 continue
         cleanup["kill_sent_count"] = kill_sent
         time.sleep(0.1)
@@ -13439,6 +13612,22 @@ def _independent_goal_retry_attempt_summary(
         )
     if not summary.get("result_json") and launch_plan.get("result_json"):
         summary["result_json"] = str(launch_plan.get("result_json"))
+    cleanup = payload.get("host_local_acp_attempt_cleanup")
+    if isinstance(cleanup, dict):
+        summary["host_local_acp_attempt_cleanup"] = {
+            "schema_version": str(
+                cleanup.get("schema_version")
+                or "skillsbench_host_local_acp_attempt_cleanup_v0"
+            )[:120],
+            "requested": cleanup.get("requested") is True,
+            "raw_logs_read": cleanup.get("raw_logs_read") is True,
+            "raw_command_recorded": cleanup.get("raw_command_recorded") is True,
+            "status": str(cleanup.get("status") or "unknown")[:120],
+            "match_count": int(cleanup.get("match_count") or 0),
+            "term_sent_count": int(cleanup.get("term_sent_count") or 0),
+            "kill_sent_count": int(cleanup.get("kill_sent_count") or 0),
+            "alive_after_count": int(cleanup.get("alive_after_count") or 0),
+        }
     return summary
 
 
@@ -13467,16 +13656,24 @@ async def async_independent_goal_retry_main(args: argparse.Namespace) -> dict[st
             base_job_name=base_job_name,
         )
         attempt_plan = build_plan(attempt_args)
+        attempt_cleanup: dict[str, Any] | None = None
         try:
             payload = await async_main(attempt_args, plan=attempt_plan)
             payload["runner_returncode"] = 0
         except Exception as exc:
+            attempt_cleanup = cleanup_host_local_acp_attempt_children(attempt_plan)
             payload, returncode = _build_runner_exception_closeout_payload(
                 attempt_args,
                 attempt_plan,
                 exc,
             )
             payload["runner_returncode"] = returncode
+        else:
+            attempt_cleanup = cleanup_host_local_acp_attempt_children(attempt_plan)
+            _write_public_runner_prerequisites(attempt_plan)
+        payload.setdefault("launch_plan", attempt_plan)
+        if attempt_cleanup is not None:
+            payload["host_local_acp_attempt_cleanup"] = attempt_cleanup
         attempt_summary = _independent_goal_retry_attempt_summary(
             payload,
             attempt_index=attempt_index,


### PR DESCRIPTION
## Summary
- add attempt-scoped cleanup for host-local ACP/app-server worker process trees between independent Goal retries
- publish public-safe cleanup status/counts into runner prerequisites and retry attempt summaries
- run app-server goal workers in their own process group and clean that group on relay timeouts/exceptions

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py loopx/benchmark_adapters/skillsbench_acp_relay.py examples/skillsbench-benchmark-run-smoke.py
- targeted SkillsBench smoke calls for host-local attempt cleanup, independent retry cleanup accounting, setup cleanup, app-server worker preflight, prereq compacting, and host exec failure attribution

No benchmark jobs launched in this PR; no raw task/log/trajectory/verifier output included.