### PR TITLE
Package license in local release snapshots

### DIFF
--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -196,6 +196,7 @@ def main() -> int:
         release_root = wrapper.resolve().parents[1]
         assert (release_root / "loopx" / "cli.py").is_file(), release_root
         assert (release_root / ".github" / "workflows" / "update-notes.yml").is_file(), release_root
+        assert (release_root / "LICENSE").is_file(), release_root
         release_manifest_path = release_root / "release.json"
         assert release_manifest_path.is_file(), release_manifest_path
         release_manifest = json.loads(release_manifest_path.read_text(encoding="utf-8"))

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -110,6 +110,7 @@ copy_path "$repo_root/docs" "$release_tmp/docs"
 copy_path "$repo_root/examples" "$release_tmp/examples"
 copy_path "$repo_root/.github" "$release_tmp/.github"
 copy_path "$repo_root/README.md" "$release_tmp/README.md"
+copy_path "$repo_root/LICENSE" "$release_tmp/LICENSE"
 copy_path "$repo_root/pyproject.toml" "$release_tmp/pyproject.toml"
 find "$release_tmp" -name __pycache__ -type d -prune -exec rm -rf {} +
 find "$release_tmp" -name '*.pyc' -type f -delete


### PR DESCRIPTION
## Summary
- copy LICENSE into local release snapshots created by scripts/install-local.sh
- assert install-local-smoke verifies the release snapshot carries LICENSE

## Why
The new runtime-connector-catalog canary profile caught a default-release failure: codex-cli-tui-bootstrap-smoke-bundle-smoke builds a public archive from the installed release snapshot and expected LICENSE to be present. Source checkout passed, default installed loopx failed until the release snapshot included LICENSE.

## Validation
- python3 examples/install-local-smoke.py
- python3 examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py
- git diff --check
- python3 -m loopx.cli check --scan-path scripts/install-local.sh --scan-path examples/install-local-smoke.py
- scripts/install-local.sh
- test -f /Users/bytedance/.local/share/loopx/releases/20260701T022711Z/LICENSE
- loopx doctor
- loopx --format json canary run --profile runtime-connector-catalog --max-checks-per-profile 4 --check-limit 4 --timeout-seconds 120

## Boundary
- no benchmark job launch or runner behavior change
- no raw logs, credentials, local state, or private evidence committed
- release packaging adds only the public LICENSE file