### PR TITLE
Persist auto-research lane role profiles

### DIFF
--- a/examples/auto-research-demo-supervisor-smoke.py
+++ b/examples/auto-research-demo-supervisor-smoke.py
@@ -114,6 +114,8 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
         assert "LOOPX_GOAL_ID" in lane["visible_launch_command"], lane
         assert "LOOPX_VISIBLE_BOOTSTRAP_PAUSE_SECONDS" in lane["visible_launch_command"], lane
         assert "LOOPX_ROLE_PROFILE_JSON" in lane["visible_launch_command"], lane
+        assert "LOOPX_ROLE_PROFILE_PATH" in lane["visible_launch_command"], lane
+        assert "role_profile_path=%s" in lane["visible_launch_command"], lane
         assert "LOOPX_REQUIRED_SKILL" in lane["visible_launch_command"], lane
         assert "bootstrap-or-stop" in lane["visible_launch_command"], lane
         assert lane["visible_codex_tui"] == "codex", lane

--- a/examples/auto-research-one-click-ux-smoke.py
+++ b/examples/auto-research-one-click-ux-smoke.py
@@ -288,6 +288,8 @@ def main() -> int:
         assert f"--goal-id {TRACKING_GOAL_ID}" not in script_text, script_text
         assert "LOOPX_VISIBLE_LANE_COUNT=3" in script_text, script_text
         assert "LOOPX_REQUIRED_SKILL=loopx-auto-research" in script_text, script_text
+        assert "LOOPX_ROLE_PROFILE_PATH" in script_text, script_text
+        assert "role_profile_path=%s" in script_text, script_text
         assert "LOOPX_WORKER_SKILL_PATH" in script_text, script_text
         assert "worker_skill_path=%s" in script_text, script_text
         assert "model_reasoning_effort=high" in script_text, script_text

--- a/examples/auto-research-visible-launcher-smoke.py
+++ b/examples/auto-research-visible-launcher-smoke.py
@@ -189,7 +189,12 @@ def main() -> int:
             assert profile["stop_conditions"], profile
             assert "[LoopX role profile]" in command, command
             assert "LOOPX_ROLE_PROFILE_JSON" in command, command
+            assert "LOOPX_ROLE_PROFILE_PATH" in command, command
+            assert "role_profile_path=%s" in command, command
+            assert ".local/loopx-role-profiles" in command, command
+            assert "read that local JSON profile" in command, command
             assert "LOOPX_ROLE_ID" in command, command
+            assert "LOOPX_LANE_ID" in command, command
             assert "LOOPX_ROLE_PROFILE_REF" in command, command
             assert "LOOPX_REQUIRED_SKILL" in command, command
             assert "LOOPX_VISIBLE_LANE_COUNT=3" in command, command

--- a/loopx/capabilities/auto_research/legacy_core.py
+++ b/loopx/capabilities/auto_research/legacy_core.py
@@ -955,6 +955,7 @@ def _auto_research_codex_bootstrap_prompt(
             "You are a visible LoopX auto-research lane, not a generic LoopX heartbeat worker.",
             "Use loopx-project for quota/status, then follow the worker-local loopx-auto-research role playbook for this pane.",
             "If LOOPX_WORKER_SKILL_PATH is present, read that local playbook path instead of relying on global skill discovery.",
+            "If LOOPX_ROLE_PROFILE_PATH is present, read that local JSON profile before relying on pane title or environment-only identity.",
             "Use the pane-local LoopX wrapper. Prefer `./.local/bin/loopx` or `$LOOPX_PANE_LOOPX`; bare `loopx` is allowed only after `command -v loopx` points inside this workspace.",
             "The wrapper has this demo's registry/runtime baked in, so do not bypass it with an absolute LoopX binary unless the printed quota/frontier commands explicitly require it.",
             "This pane is a visible LoopX polling turn: before each new action, rerun the printed quota should-run and auto-research frontier commands, then follow their interaction_contract.",
@@ -969,7 +970,8 @@ def _auto_research_codex_bootstrap_prompt(
             f"Responsibility: {responsibility}",
             f"Reasoning: model_reasoning_effort={effort}",
             "",
-            "Before any write, resolve identity from LOOPX_ROLE_PROFILE_JSON, the printed quota packet, and the printed auto-research frontier.",
+            "Before any write, resolve identity from LOOPX_ROLE_PROFILE_PATH or LOOPX_ROLE_PROFILE_JSON, the printed quota packet, and the printed auto-research frontier.",
+            "Prefer the durable local profile at LOOPX_ROLE_PROFILE_PATH when it exists; use LOOPX_ROLE_PROFILE_JSON only as a fallback.",
             "If any of those disagree, or quota/frontier no longer selects this role, stop and report the blocker in this pane.",
             f"Allowed actions: {allowed_actions}",
             f"Allowed write scope: {write_scope}",
@@ -1053,6 +1055,7 @@ def _role_profile_shell_prefix(role_profile: dict[str, Any]) -> str:
     return (
         f"export LOOPX_GOAL_ID={_shell_arg(str(role_profile['goal_id']))}; "
         f"export LOOPX_AGENT_ID={_shell_arg(str(role_profile['agent_id']))}; "
+        f"export LOOPX_LANE_ID={_shell_arg(str(role_profile['lane_id']))}; "
         f"export LOOPX_ROLE_ID={_shell_arg(str(role_profile['role_id']))}; "
         f"export LOOPX_ROLE_PHASE={_shell_arg(str(role_profile['phase']))}; "
         f"export LOOPX_ROLE_PROFILE_REF={_shell_arg(str(role_profile['schema_version']))}; "
@@ -1062,7 +1065,12 @@ def _role_profile_shell_prefix(role_profile: dict[str, Any]) -> str:
         'export LOOPX_WORKER_SKILL_PATH="$LOOPX_WORKER_SKILL_ROOT/$LOOPX_REQUIRED_SKILL/SKILL.md"; '
         f"LOOPX_ROLE_PROFILE_JSON={_shell_arg(profile_json)}; "
         "export LOOPX_ROLE_PROFILE_JSON; "
+        'export LOOPX_ROLE_PROFILE_DIR="$LOOPX_PROJECT/.local/loopx-role-profiles"; '
+        'mkdir -p "$LOOPX_ROLE_PROFILE_DIR"; '
+        'export LOOPX_ROLE_PROFILE_PATH="$LOOPX_ROLE_PROFILE_DIR/$LOOPX_LANE_ID.public.json"; '
+        'printf "%s\\n" "$LOOPX_ROLE_PROFILE_JSON" > "$LOOPX_ROLE_PROFILE_PATH"; '
         "printf '\\n[LoopX role profile]\\n'; "
+        "printf 'role_profile_path=%s\\n' \"$LOOPX_ROLE_PROFILE_PATH\"; "
         "printf '%s\\n' \"$LOOPX_ROLE_PROFILE_JSON\"; "
         "printf 'worker_skill_path=%s\\n' \"$LOOPX_WORKER_SKILL_PATH\"; "
     )


### PR DESCRIPTION
## Summary
- write each visible auto-research lane role profile to a durable pane-local JSON file
- teach the Codex bootstrap prompt to prefer that file over env-only identity
- extend visible/one-click/supervisor smokes to guard the profile-path contract

## Validation
- python3 examples/auto-research-demo-supervisor-smoke.py
- python3 examples/auto-research-visible-launcher-smoke.py
- python3 examples/auto-research-one-click-ux-smoke.py
- python3 examples/auto-research-demo-e2e-smoke.py
- python3 examples/auto-research-skill-contract-smoke.py
- python3 examples/generic-multi-agent-one-command-smoke.py
- python3 -m py_compile loopx/capabilities/auto_research/legacy_core.py loopx/capabilities/auto_research/demo_e2e.py loopx/capabilities/auto_research/cli.py loopx/visible_multi_agent_launcher.py
- git diff --check
- loopx check --scan-path loopx/capabilities/auto_research/legacy_core.py --scan-path examples/auto-research-demo-supervisor-smoke.py --scan-path examples/auto-research-visible-launcher-smoke.py --scan-path examples/auto-research-one-click-ux-smoke.py

## Live Proof
A visible auto-research run after this change produced lane-authored dev evidence from a real Codex evidence-runner pane: one supported dev evidence event was appended, live evidence was captured with source=live_codex_lane_output, dev_metric=4.0, and the public boundary reported no raw logs, private artifacts, credentials, or absolute paths.
