### PR TITLE
Fix SkillsBench ledger sync and retry stop policy

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger-v0.md
@@ -25,6 +25,16 @@ routing lesson.
 
 - Machine source: `benchmark-run-ledger.json`
 - Human view: `benchmark-run-ledger.md`
+- Canonical global source: `docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json`
+
+Benchmark launchers may also materialize a run-group/local
+`remote-ledger/benchmark-run-ledger.json` so interrupted or remote workspaces can
+resume with the current view. That local ledger is not canonical by itself. A
+run-group ledger should inherit the canonical global ledger before its first
+write, then upsert each terminal compact closeout back into the canonical global
+ledger. If a run-group ledger contains rows that the canonical global ledger
+does not, treat that as a sync gap rather than as two independent result
+sources.
 
 Both files are generated from compact `benchmark_run_v0` events. The Markdown
 view is for humans; the JSON is the source of truth.

--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -499,7 +499,10 @@ def test_launcher_plan_only_records_independent_retry_config() -> None:
     assert retry["enabled"] is True, retry
     assert retry["attempt_budget"] == 3, retry
     assert retry["fresh_goal_thread_per_attempt"] is True, retry
-    assert retry["stop_policy"] == "stop_after_first_official_reward_1_or_retry_budget", retry
+    assert retry["stop_policy"] == (
+        "stop_after_first_official_reward_1_or_first_terminal_"
+        "official_nonpassing_or_retry_budget"
+    ), retry
     assert retry["official_reward_feedback_forwarded_to_agent"] is False, retry
     assert retry["verifier_output_forwarded_to_agent"] is False, retry
     assert retry["raw_task_text_read_into_public_state"] is False, retry
@@ -534,17 +537,17 @@ def test_independent_goal_retry_stops_after_first_success() -> None:
         async def fake_async_main(args: Namespace, *, plan: dict[str, Any] | None = None) -> dict[str, Any]:
             assert args.independent_goal_retries == 1, args
             attempt_number = int(str(args.job_name).rsplit("-", 1)[-1])
-            reward = 1.0 if attempt_number == 2 else 0.0
+            reward = 1.0 if attempt_number == 2 else None
             return {
-                "ok": True,
+                "ok": reward is not None,
                 "launch_plan": plan or {},
                 "official_task_score": {
                     "kind": "fake_skillsbench_reward",
                     "value": reward,
-                    "passed": reward >= 1.0,
+                    "passed": reward == 1.0,
                 },
                 "score_failure_attribution": (
-                    "none" if reward >= 1.0 else "official_score_zero_case_failure"
+                    "none" if reward == 1.0 else "skillsbench_runner_error"
                 ),
             }
 
@@ -586,9 +589,87 @@ def test_independent_goal_retry_stops_after_first_success() -> None:
         assert payload["raw_trajectory_read_into_public_state"] is False, payload
         assert payload["raw_verifier_output_read_into_public_state"] is False, payload
         assert len(payload["attempts"]) == 2, payload
-        assert payload["attempts"][0]["official_reward"] == 0.0, payload
+        assert payload["attempts"][0]["official_reward"] is None, payload
+        assert payload["attempts"][0]["terminal_official_nonpassing"] is False, payload
         assert payload["attempts"][1]["official_reward"] == 1.0, payload
-        assert payload["attempts"][1]["official_success"] is True, payload
+
+
+def test_independent_goal_retry_stops_after_first_terminal_nonpassing_score() -> None:
+    runner = _load_runner_module()
+    original_async_main = runner.async_main
+    original_build_plan = runner.build_plan
+
+    with tempfile.TemporaryDirectory(prefix="skillsbench-independent-nonpass-") as tmp:
+        tmp_path = Path(tmp)
+
+        def fake_build_plan(args: Namespace) -> dict[str, Any]:
+            rollout_name = args.rollout_name or "bike-rebalance__codex_app_server_goal"
+            return {
+                "task_id": args.task_id,
+                "route": args.route,
+                "run_group_id": args.run_group_id,
+                "job_name": args.job_name,
+                "rollout_name": rollout_name,
+                "compact_benchmark_run_json": str(
+                    tmp_path / args.job_name / rollout_name / "benchmark_run.compact.json"
+                ),
+                "result_json": str(
+                    tmp_path / args.job_name / rollout_name / "result.json"
+                ),
+            }
+
+        async def fake_async_main(
+            args: Namespace,
+            *,
+            plan: dict[str, Any] | None = None,
+        ) -> dict[str, Any]:
+            assert args.independent_goal_retries == 1, args
+            return {
+                "ok": True,
+                "launch_plan": plan or {},
+                "official_task_score": {
+                    "kind": "fake_skillsbench_reward",
+                    "value": 0.0,
+                    "passed": False,
+                },
+                "score_failure_attribution": "official_verifier_solution_failure",
+            }
+
+        runner.build_plan = fake_build_plan
+        runner.async_main = fake_async_main
+        try:
+            payload = asyncio.run(
+                runner.async_independent_goal_retry_main(
+                    Namespace(
+                        task_id="bike-rebalance",
+                        task_ids=None,
+                        route=ROUTE,
+                        jobs_dir=str(tmp_path),
+                        run_group_id="retry-nonpass",
+                        job_name="retry-job",
+                        rollout_name=None,
+                        independent_goal_retries=3,
+                        parallel_cases=1,
+                    )
+                )
+            )
+        finally:
+            runner.async_main = original_async_main
+            runner.build_plan = original_build_plan
+
+        assert payload["ok"] is False, payload
+        assert payload["attempt_budget"] == 3, payload
+        assert payload["attempts_started"] == 1, payload
+        assert payload["terminal_official_nonpassing_observed"] is True, payload
+        assert payload["first_terminal_official_nonpassing_attempt"] == 1, payload
+        assert payload["best_official_reward"] == 0.0, payload
+        assert payload["final_official_reward"] == 0.0, payload
+        assert payload["stop_reason"] == (
+            "stop_after_first_terminal_official_nonpassing_verifier_result"
+        ), payload
+        assert len(payload["attempts"]) == 1, payload
+        assert payload["attempts"][0]["terminal_official_nonpassing"] is True, payload
+        assert payload["official_reward_feedback_forwarded_to_agent"] is False, payload
         for attempt in payload["attempts"]:
             assert attempt["raw_task_text_read"] is False, attempt
             assert attempt["raw_trajectory_read"] is False, attempt
@@ -596,7 +677,8 @@ def test_independent_goal_retry_stops_after_first_success() -> None:
         summary_path = Path(payload["retry_summary_json"])
         assert summary_path.exists(), payload
         saved = json.loads(summary_path.read_text(encoding="utf-8"))
-        assert saved["first_success_attempt"] == 2, saved
+        assert saved["first_success_attempt"] is None, saved
+        assert saved["terminal_official_nonpassing_observed"] is True, saved
 
 
 def test_host_worker_contract_only_cli() -> None:
@@ -2103,6 +2185,9 @@ if __name__ == "__main__":
     test_app_server_goal_launcher_allows_explicit_first_action_disable()
     test_acp_relay_fails_fast_when_app_server_worker_only_uses_status_bridge()
     test_acp_relay_yields_after_task_output_quiet_timeout()
+    test_launcher_plan_only_records_independent_retry_config()
+    test_independent_goal_retry_stops_after_first_success()
+    test_independent_goal_retry_stops_after_first_terminal_nonpassing_score()
     test_full_run_fails_closed_until_bridge_is_materialized()
     test_full_run_with_bridge_ready_requires_host_acp_launch()
     test_launcher_patches_rollout_planes_connect_acp()

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -122,6 +122,7 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
     product_mode_case_state_seed_text,
     product_mode_soft_verify_policy_for_route,
     reduce_result,
+    update_ledger as update_skillsbench_ledger,
     _runner_prerequisite_failure_attribution,
     _subcommand_family_count,
     _sync_relay_closeout_counts_into_compact,
@@ -10293,6 +10294,67 @@ def test_skillsbench_repeat_same_mode_keeps_distinct_ledger_runs() -> None:
         assert len(case["runs"]) == 4, case
 
 
+def test_skillsbench_run_group_ledger_inherits_and_syncs_global_ledger() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-ledger-global-sync-") as tmp:
+        root = Path(tmp)
+        global_ledger = root / "global" / "benchmark-run-ledger.json"
+        run_group_ledger = root / "run-group" / "benchmark-run-ledger.json"
+        inherited_compact = compact_skillsbench_run(
+            task_id="3d-scan-calc",
+            mode="skillsbench_codex_app_server_goal_baseline",
+            score=1.0,
+            passed=True,
+        )
+        update_benchmark_run_ledger(
+            ledger_path=global_ledger,
+            benchmark_run=inherited_compact,
+            run_group_id="skillsbench-global-existing",
+            dry_run=False,
+        )
+        new_compact = compact_skillsbench_run(
+            task_id="tictoc-unnecessary-abort-detection",
+            mode="skillsbench_codex_app_server_goal_baseline",
+            score=1.0,
+            passed=True,
+        )
+        args = parse_args(
+            [
+                "--task-id",
+                "tictoc-unnecessary-abort-detection",
+                "--route",
+                "codex-app-server-goal-baseline",
+                "--ledger-path",
+                str(run_group_ledger),
+                "--global-ledger-path",
+                str(global_ledger),
+                "--run-group-id",
+                "skillsbench-revtunnel-appgoal-batch5-fixture",
+                "--update-ledger",
+            ]
+        )
+        compact_path = (
+            root
+            / "remote-public"
+            / "tictoc-unnecessary-abort-detection"
+            / "benchmark_run.compact.json"
+        )
+        update = update_skillsbench_ledger(args, new_compact, compact_path=compact_path)
+        assert update["ledger_scope"] == "run_group_with_global_sync", update
+        assert update["global_ledger_inheritance"]["status"] == "inherited", update
+        assert update["global_ledger_inheritance"]["inherited"] is True, update
+        assert update["primary_ledger_update"]["updated"] is True, update
+        assert update["global_ledger_update"]["updated"] is True, update
+
+        local_ledger = load_benchmark_run_ledger(run_group_ledger)
+        global_payload = load_benchmark_run_ledger(global_ledger)
+        local_cases = local_ledger["benchmarks"]["skillsbench@1.1"]["cases"]
+        global_cases = global_payload["benchmarks"]["skillsbench@1.1"]["cases"]
+        assert "3d-scan-calc" in local_cases, local_cases
+        assert "tictoc-unnecessary-abort-detection" in local_cases, local_cases
+        assert "tictoc-unnecessary-abort-detection" in global_cases, global_cases
+        assert ".local" not in json.dumps(update, sort_keys=True), update
+
+
 def test_skillsbench_runner_failure_compact_closeout() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-runner-failure-") as tmp:
         args = parse_args(
@@ -13186,6 +13248,7 @@ if __name__ == "__main__":
     test_skillsbench_parallel_batch_recovers_child_payload_from_mixed_stderr()
     test_skillsbench_compact_runs_update_ledger_pair()
     test_skillsbench_repeat_same_mode_keeps_distinct_ledger_runs()
+    test_skillsbench_run_group_ledger_inherits_and_syncs_global_ledger()
     test_skillsbench_runner_failure_compact_closeout()
     test_skillsbench_runner_failure_case_event_timeline_is_compacted()
     test_skillsbench_runner_failure_recovers_zero_score_from_controller_trace()

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -152,6 +152,10 @@ DEFAULT_LEDGER = (
     REPO_ROOT
     / "docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json"
 )
+TERMINAL_OFFICIAL_NONPASSING_ATTRIBUTIONS = {
+    "official_score_zero_case_failure",
+    "official_verifier_solution_failure",
+}
 DEFAULT_GOAL_ID = "loopx-meta"
 DEFAULT_MODEL = "gpt-5.5"
 DEFAULT_TIMEOUT_SEC = 7200
@@ -179,6 +183,66 @@ HOST_LOCAL_ACP_TARGET_ENV_KEYS = (
     "no_proxy",
     "LOOPX_CODEX_API_REVERSE_TUNNEL_PROXY",
 )
+
+
+def _expanded_path(value: str | os.PathLike[str]) -> Path:
+    return Path(value).expanduser()
+
+
+def _same_ledger_path(left: Path, right: Path) -> bool:
+    return left.resolve(strict=False) == right.resolve(strict=False)
+
+
+def _ledger_scope_label(primary_path: Path, global_path: Path) -> str:
+    if _same_ledger_path(primary_path, global_path):
+        return "global"
+    return "run_group_with_global_sync"
+
+
+def _inherit_global_ledger_snapshot(
+    *,
+    primary_path: Path,
+    global_path: Path,
+    dry_run: bool,
+    enabled: bool,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "schema_version": "skillsbench_global_ledger_inheritance_v0",
+        "enabled": enabled,
+        "dry_run": dry_run,
+        "inherited": False,
+        "markdown_inherited": False,
+        "primary_ledger_path": str(primary_path),
+        "global_ledger_path": str(global_path),
+    }
+    if not enabled:
+        result["status"] = "disabled"
+        return result
+    if _same_ledger_path(primary_path, global_path):
+        result["status"] = "same_as_global"
+        return result
+    if primary_path.exists():
+        result["status"] = "primary_ledger_already_exists"
+        return result
+    if not global_path.exists():
+        result["status"] = "global_ledger_missing"
+        return result
+    if dry_run:
+        result["status"] = "would_inherit"
+        result["inherited"] = True
+        result["markdown_inherited"] = global_path.with_suffix(".md").exists()
+        return result
+
+    primary_path.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(global_path, primary_path)
+    result["inherited"] = True
+    global_markdown = global_path.with_suffix(".md")
+    primary_markdown = primary_path.with_suffix(".md")
+    if global_markdown.exists():
+        shutil.copy2(global_markdown, primary_markdown)
+        result["markdown_inherited"] = True
+    result["status"] = "inherited"
+    return result
 CODEX_API_REVERSE_TUNNEL_PROXY_ENV_KEYS = (
     "LOOPX_CODEX_API_REVERSE_TUNNEL_PROXY",
     "CODEX_API_REVERSE_TUNNEL_PROXY",
@@ -6627,7 +6691,10 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
             ),
             "route_supported": route == "codex-app-server-goal-baseline",
             "fresh_goal_thread_per_attempt": True,
-            "stop_policy": "stop_after_first_official_reward_1_or_retry_budget",
+            "stop_policy": (
+                "stop_after_first_official_reward_1_or_first_terminal_"
+                "official_nonpassing_or_retry_budget"
+            ),
             "official_reward_feedback_forwarded_to_agent": False,
             "verifier_output_forwarded_to_agent": False,
             "raw_task_text_read_into_public_state": False,
@@ -6689,6 +6756,13 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
             else ""
         ),
         "ledger_path": str(Path(args.ledger_path).expanduser()),
+        "global_ledger_path": str(Path(args.global_ledger_path).expanduser()),
+        "ledger_scope": _ledger_scope_label(
+            Path(args.ledger_path).expanduser(),
+            Path(args.global_ledger_path).expanduser(),
+        ),
+        "global_ledger_sync_enabled": not bool(args.skip_global_ledger_sync),
+        "ledger_inherit_enabled": not bool(args.skip_ledger_inherit),
         "run_permission_policy": run_permission_policy,
         "task_setup_preflight": setup_preflight,
         "codex_api_egress_preflight": codex_api_egress_preflight,
@@ -7058,6 +7132,9 @@ def _public_runner_config(plan: dict[str, Any]) -> dict[str, Any]:
         "job_name",
         "rollout_name",
         "treatment_prompt_style",
+        "ledger_path",
+        "global_ledger_path",
+        "ledger_scope",
     )
     for field in string_fields:
         value = plan.get(field)
@@ -7086,6 +7163,8 @@ def _public_runner_config(plan: dict[str, Any]) -> dict[str, Any]:
         "fail_fast_on_verifier_bootstrap_risk",
         "verifier_bootstrap_fail_fast_defaulted",
         "bootstrap_light_fail_fast_defaulted",
+        "global_ledger_sync_enabled",
+        "ledger_inherit_enabled",
     ):
         value = plan.get(field)
         if isinstance(value, bool):
@@ -12375,8 +12454,17 @@ def update_ledger(
         if args.route == "raw-codex-autonomous-max5"
         else "Codex ACP baseline"
     )
-    return update_benchmark_run_ledger(
-        ledger_path=Path(args.ledger_path).expanduser(),
+    primary_ledger_path = _expanded_path(args.ledger_path)
+    global_ledger_path = _expanded_path(args.global_ledger_path)
+    dry_run = not args.update_ledger
+    ledger_inheritance = _inherit_global_ledger_snapshot(
+        primary_path=primary_ledger_path,
+        global_path=global_ledger_path,
+        dry_run=dry_run,
+        enabled=not bool(args.skip_ledger_inherit),
+    )
+    primary_update = update_benchmark_run_ledger(
+        ledger_path=primary_ledger_path,
         benchmark_run=compact,
         compact_artifact_ref=compact_path,
         run_group_id=args.run_group_id,
@@ -12385,8 +12473,34 @@ def update_ledger(
             "no raw task/log/trajectory read into public state"
         ),
         cwd=REPO_ROOT,
-        dry_run=not args.update_ledger,
+        dry_run=dry_run,
     )
+    global_update: dict[str, Any] | None = None
+    if (
+        not args.skip_global_ledger_sync
+        and not _same_ledger_path(primary_ledger_path, global_ledger_path)
+    ):
+        global_update = update_benchmark_run_ledger(
+            ledger_path=global_ledger_path,
+            benchmark_run=compact,
+            compact_artifact_ref=compact_path,
+            run_group_id=args.run_group_id,
+            notes=(
+                f"official SkillsBench BenchFlow {note_route}; compact result only; "
+                "no raw task/log/trajectory read into public state"
+            ),
+            cwd=REPO_ROOT,
+            dry_run=dry_run,
+        )
+
+    result = dict(primary_update)
+    result["ledger_scope"] = _ledger_scope_label(primary_ledger_path, global_ledger_path)
+    result["primary_ledger_update"] = primary_update
+    result["global_ledger_path"] = str(global_ledger_path)
+    result["global_ledger_sync_enabled"] = not bool(args.skip_global_ledger_sync)
+    result["global_ledger_update"] = global_update
+    result["global_ledger_inheritance"] = ledger_inheritance
+    return result
 
 
 def append_history(args: argparse.Namespace, compact_path: Path) -> dict[str, Any]:
@@ -12723,6 +12837,25 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         default=None,
     )
     parser.add_argument("--ledger-path", default=str(DEFAULT_LEDGER))
+    parser.add_argument(
+        "--global-ledger-path",
+        default=str(DEFAULT_LEDGER),
+        help=(
+            "Canonical benchmark_run_ledger_v0 JSON. When --ledger-path points "
+            "to a run-group/local ledger, the runner inherits this ledger first "
+            "and syncs the new row back here unless --skip-global-ledger-sync is set."
+        ),
+    )
+    parser.add_argument(
+        "--skip-global-ledger-sync",
+        action="store_true",
+        help="Do not upsert run-group/local ledger rows back into --global-ledger-path.",
+    )
+    parser.add_argument(
+        "--skip-ledger-inherit",
+        action="store_true",
+        help="Do not initialize a missing run-group/local ledger from --global-ledger-path.",
+    )
     parser.add_argument("--goal-id", default=DEFAULT_GOAL_ID)
     parser.add_argument("--registry", default=str(REPO_ROOT / ".loopx/registry.json"))
     parser.add_argument("--runtime-root", default=str(REPO_ROOT / ".local"))
@@ -13565,6 +13698,16 @@ def _official_success_from_payload(payload: dict[str, Any]) -> bool:
     return bool(reward is not None and reward >= 1.0)
 
 
+def _terminal_official_nonpassing_from_payload(payload: dict[str, Any]) -> bool:
+    reward = _official_reward_from_payload(payload)
+    if reward is None or _official_success_from_payload(payload):
+        return False
+    return (
+        str(payload.get("score_failure_attribution") or "")
+        in TERMINAL_OFFICIAL_NONPASSING_ATTRIBUTIONS
+    )
+
+
 def _independent_goal_retry_attempt_summary(
     payload: dict[str, Any],
     *,
@@ -13575,6 +13718,7 @@ def _independent_goal_retry_attempt_summary(
         launch_plan = {}
     official_reward = _official_reward_from_payload(payload)
     official_success = _official_success_from_payload(payload)
+    terminal_official_nonpassing = _terminal_official_nonpassing_from_payload(payload)
     summary: dict[str, Any] = {
         "schema_version": "skillsbench_independent_goal_retry_attempt_v0",
         "attempt_index": attempt_index,
@@ -13583,6 +13727,7 @@ def _independent_goal_retry_attempt_summary(
         "runner_returncode": int(payload.get("runner_returncode") or 0),
         "official_success": official_success,
         "official_reward": official_reward,
+        "terminal_official_nonpassing": terminal_official_nonpassing,
         "score_failure_attribution": str(
             payload.get("score_failure_attribution") or ""
         ),
@@ -13647,6 +13792,8 @@ async def async_independent_goal_retry_main(args: argparse.Namespace) -> dict[st
     attempts: list[dict[str, Any]] = []
     success_observed = False
     first_success_attempt: int | None = None
+    terminal_official_nonpassing_observed = False
+    first_terminal_official_nonpassing_attempt: int | None = None
 
     for attempt_index in range(attempt_budget):
         attempt_args = _clone_args_for_independent_goal_retry(
@@ -13683,12 +13830,17 @@ async def async_independent_goal_retry_main(args: argparse.Namespace) -> dict[st
             success_observed = True
             first_success_attempt = attempt_index + 1
             break
+        if attempt_summary.get("terminal_official_nonpassing") is True:
+            terminal_official_nonpassing_observed = True
+            first_terminal_official_nonpassing_attempt = attempt_index + 1
+            break
 
-    stop_reason = (
-        "stop_after_first_official_reward_1_without_feedback"
-        if success_observed
-        else "stop_after_independent_goal_retry_budget"
-    )
+    if success_observed:
+        stop_reason = "stop_after_first_official_reward_1_without_feedback"
+    elif terminal_official_nonpassing_observed:
+        stop_reason = "stop_after_first_terminal_official_nonpassing_verifier_result"
+    else:
+        stop_reason = "stop_after_independent_goal_retry_budget"
     observed_rewards = [
         float(attempt["official_reward"])
         for attempt in attempts
@@ -13709,6 +13861,12 @@ async def async_independent_goal_retry_main(args: argparse.Namespace) -> dict[st
         "attempts_completed": len(attempts),
         "success_observed": success_observed,
         "first_success_attempt": first_success_attempt,
+        "terminal_official_nonpassing_observed": (
+            terminal_official_nonpassing_observed
+        ),
+        "first_terminal_official_nonpassing_attempt": (
+            first_terminal_official_nonpassing_attempt
+        ),
         "best_official_reward": best_official_reward,
         "final_official_reward": final_official_reward,
         "official_task_score": {


### PR DESCRIPTION
## Summary
- add canonical global ledger inheritance/sync for SkillsBench run-group ledgers
- stop independent Goal retries after the first terminal official nonpassing verifier result, while still retrying runner/transport missing-score gaps
- document canonical global vs run-group ledger semantics and add focused smokes

## Aggregated current evidence since 2026-06-30 Asia/Shanghai
- canonical global active rows: 4 attempts / 4 cases: 2 pass, 1 verifier solution failure, 1 app-server timeout
- batch5 run-group ledger inherited those 4 rows and added 3 local rows: 1 pass, 2 worker route selected/not connected
- revtunnel app-goal compact artifacts not yet canonical-global: bike-rebalance has 7 attempts, but under the repaired policy it should be one case-level terminal verifier failure after the first official score=0, not repeated retries

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-app-server-goal-worker-smoke.py examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-app-server-goal-worker-smoke.py
- targeted importlib smoke: run-group ledger inherits/syncs global; compact ledger pair; repeat same mode distinct runs; retry cleanup accounting
- loopx check public boundary scan clean for touched files
