### PR TITLE
Clarify auto research live claim boundary

### DIFF
--- a/docs/guides/auto-research-command-path.md
+++ b/docs/guides/auto-research-command-path.md
@@ -99,6 +99,8 @@ Expected minimal E2E result:
 
 - `execution_kind` is `minimal_research_kernel`;
 - `result_source` is `deterministic_protected_eval_kernel`;
+- `claim_summary.status` is `kernel_precheck_only`;
+- `claim_summary.live_worker_claim_allowed` is `false`;
 - `research_loop.dev_round_count` is `2`;
 - `research_loop.evidence_event_count` is `3`;
 - `research_loop.live_codex_lane_authored` is `false`;
@@ -127,6 +129,10 @@ Truth boundary:
 - `live_codex_e2e.executed` is `false`;
 - `live_codex_e2e.claim_allowed` is `false`;
 - `live_codex_e2e.evidence_source` is `not_collected_from_codex_lane_output`;
+- `claim_summary.can_claim` is limited to
+  `protected_eval_kernel_positive_precheck`;
+- `claim_summary.cannot_claim` includes
+  `visible_codex_workers_authored_result`;
 - `acceptance.ready_for_real_launch` does not mean live Codex lanes already
   produced the positive k-NN evidence;
 - `--launch-visible` proves visible panes can start, but pane startup alone is
@@ -171,7 +177,9 @@ With a valid compact live evidence packet, `live_codex_e2e.claim_allowed`
 means only that a live lane-authored dev claim may be projected. Holdout and
 promotion claims stay blocked by default: `holdout_claim_allowed=false`,
 `promotion_claim_allowed=false`, and the live `holdout_metric` is redacted from
-the claim projection. To project a live holdout or promotion claim, the compact
+the claim projection. The companion `claim_summary` switches to
+`live_worker_dev_evidence_ready`, with `claim_basis=live_codex_lane_output`.
+To project a live holdout or promotion claim, the compact
 evidence must carry explicit public-safe `claim_authority`, such as
 `separate_heldout_live_evidence` or `owner_approval`.
 

--- a/examples/auto-research-demo-e2e-smoke.py
+++ b/examples/auto-research-demo-e2e-smoke.py
@@ -91,6 +91,10 @@ def assert_e2e_payload(
         "deterministic_protected_eval_kernel",
         "deterministic_protected_eval_preview",
     }, payload
+    claim_summary = payload["claim_summary"]
+    assert claim_summary["schema_version"] == "auto_research_demo_claim_summary_v0", payload
+    assert claim_summary["live_worker_claim_allowed"] is False, payload
+    assert claim_summary["live_worker_authored"] is False, payload
     live = payload["live_codex_e2e"]
     assert live["executed"] is False, payload
     assert live["claim_allowed"] is False, payload
@@ -108,6 +112,14 @@ def assert_e2e_payload(
     assert protected_eval["executed"] is executed, payload
     assert loop["executed"] is executed, payload
     if executed:
+        assert claim_summary["status"] == "kernel_precheck_only", payload
+        assert claim_summary["claim_basis"] == "deterministic_protected_eval_kernel", payload
+        assert claim_summary["kernel_precheck_passed"] is True, payload
+        assert claim_summary["can_claim"] == ["protected_eval_kernel_positive_precheck"], payload
+        assert "visible_codex_workers_authored_result" in claim_summary["cannot_claim"], payload
+        assert claim_summary["dev_metric"] == 4.0, payload
+        assert claim_summary["holdout_metric"] is None, payload
+        assert claim_summary["holdout_metric_redacted"] is True, payload
         assert loop["result_source"] == "knn_pack_protected_eval", payload
         assert loop["candidate_count"] == 2, payload
         assert loop["dev_round_count"] == 2, payload
@@ -184,6 +196,10 @@ def assert_e2e_payload(
         assert payload["acceptance"]["claim_boundary"]["live_claim_scope"] == "dev_only", payload
         assert payload["acceptance"]["claim_boundary"]["promotion_claim_allowed"] is False, payload
     else:
+        assert claim_summary["status"] == "preview_only", payload
+        assert claim_summary["claim_basis"] == "dry_run_preview", payload
+        assert claim_summary["kernel_precheck_passed"] is False, payload
+        assert claim_summary["can_claim"] == ["one_command_preview_available"], payload
         assert loop["result_source"] == "deterministic_protected_eval_preview", payload
         assert "append public-safe evidence" in loop["expected_steps"], payload
         assert loop["live_codex_lane_authored"] is False, payload
@@ -411,6 +427,9 @@ def main() -> int:
         ).stdout
         assert "# LoopX Auto Research Minimal E2E Demo" in markdown, markdown
         assert "execution_kind: `minimal_research_preview`" in markdown, markdown
+        assert "claim_summary_status: `preview_only`" in markdown, markdown
+        assert "claim_summary_live_worker_claim_allowed: `False`" in markdown, markdown
+        assert "claim_summary_kernel_precheck_passed: `False`" in markdown, markdown
         assert "research_loop_executed: `False`" in markdown, markdown
         assert "research_loop_source: `deterministic_protected_eval_preview`" in markdown, markdown
         assert "research_loop_dev_rounds:" in markdown, markdown
@@ -470,12 +489,19 @@ def main() -> int:
         assert "`4.0`" in guide, guide
         assert "protected_eval_result.holdout_metric" in guide, guide
         assert "`4.5`" in guide, guide
+        assert "claim_summary.status" in guide, guide
+        assert "kernel_precheck_only" in guide, guide
+        assert "claim_summary.live_worker_claim_allowed" in guide, guide
+        assert "protected_eval_kernel_positive_precheck" in guide, guide
+        assert "visible_codex_workers_authored_result" in guide, guide
         assert "acceptance.ready_for_real_launch" in guide, guide
         assert "live_codex_e2e.executed" in guide, guide
         assert "live_codex_e2e.claim_allowed" in guide, guide
         assert "not_collected_from_codex_lane_output" in guide, guide
         assert "capture-live-evidence" in guide, guide
         assert "--live-evidence" in guide, guide
+        assert "live_worker_dev_evidence_ready" in guide, guide
+        assert "claim_basis=live_codex_lane_output" in guide, guide
         assert "raw logs" in guide, guide
         assert "private artifacts" in guide, guide
         assert "credentials" in guide, guide

--- a/examples/auto-research-live-codex-claim-boundary-smoke.py
+++ b/examples/auto-research-live-codex-claim-boundary-smoke.py
@@ -146,6 +146,11 @@ def main() -> int:
         assert no_live_payload["live_codex_e2e"]["evidence_source"] == (
             "not_collected_from_codex_lane_output"
         ), no_live_payload
+        assert no_live_payload["claim_summary"]["status"] == "kernel_precheck_only", no_live_payload
+        assert no_live_payload["claim_summary"]["live_worker_claim_allowed"] is False, no_live_payload
+        assert no_live_payload["claim_summary"]["claim_basis"] == (
+            "deterministic_protected_eval_kernel"
+        ), no_live_payload
         assert_public_board_claim_boundary(no_live_payload)
 
         evidence = temp / "live-evidence.public.json"
@@ -186,6 +191,7 @@ def main() -> int:
         )
         claimed_payload = json.loads(claimed.stdout)
         live = claimed_payload["live_codex_e2e"]
+        claim_summary = claimed_payload["claim_summary"]
         protected_eval = claimed_payload["protected_eval_result"]
         research_loop = claimed_payload["research_loop"]
         assert claimed_payload["ok"] is True, claimed_payload
@@ -219,6 +225,12 @@ def main() -> int:
         assert live["public_boundary"]["absolute_paths_recorded"] is False, claimed_payload
         assert live["public_boundary"]["credentials_recorded"] is False, claimed_payload
         assert live["public_boundary"]["local_workspace_path_redacted"] is True, claimed_payload
+        assert claim_summary["status"] == "live_worker_dev_evidence_ready", claimed_payload
+        assert claim_summary["claim_basis"] == "live_codex_lane_output", claimed_payload
+        assert claim_summary["live_worker_claim_allowed"] is True, claimed_payload
+        assert claim_summary["dev_metric"] == 4.0, claimed_payload
+        assert claim_summary["holdout_metric"] is None, claimed_payload
+        assert claim_summary["holdout_metric_redacted"] is True, claimed_payload
         assert_public_board_claim_boundary(claimed_payload)
         assert_public_safe(claimed_payload)
 
@@ -243,6 +255,7 @@ def main() -> int:
         )
         authorized_payload = json.loads(authorized.stdout)
         authorized_live = authorized_payload["live_codex_e2e"]
+        authorized_summary = authorized_payload["claim_summary"]
         assert authorized_live["claim_scope"] == "promotion_claim_authorized", authorized_payload
         assert authorized_live["holdout_claim_allowed"] is True, authorized_payload
         assert authorized_live["promotion_claim_allowed"] is True, authorized_payload
@@ -252,6 +265,10 @@ def main() -> int:
         assert authorized_live["holdout_metric_redacted"] is False, authorized_payload
         assert authorized_live["holdout_claim_blocked_reason"] is None, authorized_payload
         assert authorized_live["promotion_claim_blocked_reason"] is None, authorized_payload
+        assert authorized_summary["live_worker_claim_allowed"] is True, authorized_payload
+        assert authorized_summary["holdout_metric"] == 4.5, authorized_payload
+        assert authorized_summary["holdout_metric_redacted"] is False, authorized_payload
+        assert authorized_summary["cannot_claim"] == [], authorized_payload
         assert_public_safe(authorized_payload)
 
     print("auto-research-live-codex-claim-boundary-smoke ok")

--- a/examples/auto-research-live-evidence-capture-smoke.py
+++ b/examples/auto-research-live-evidence-capture-smoke.py
@@ -251,6 +251,7 @@ def main() -> int:
         )
         claimed_payload = json.loads(claimed.stdout)
         live = claimed_payload["live_codex_e2e"]
+        claim_summary = claimed_payload["claim_summary"]
         assert live["executed"] is True, claimed_payload
         assert live["claim_allowed"] is True, claimed_payload
         assert live["evidence_source"] == "live_codex_lane_output", claimed_payload
@@ -263,6 +264,17 @@ def main() -> int:
         assert live["holdout_metric"] is None, claimed_payload
         assert live["holdout_metric_present"] is True, claimed_payload
         assert live["holdout_metric_redacted"] is True, claimed_payload
+        assert claim_summary["status"] == "live_worker_dev_evidence_ready", claimed_payload
+        assert claim_summary["claim_basis"] == "live_codex_lane_output", claimed_payload
+        assert claim_summary["live_worker_claim_allowed"] is True, claimed_payload
+        assert claim_summary["live_worker_authored"] is True, claimed_payload
+        assert claim_summary["kernel_precheck_passed"] is True, claimed_payload
+        assert claim_summary["can_claim"] == ["visible_worker_live_dev_evidence_supported"], claimed_payload
+        assert "live_holdout_metric_or_claim" in claim_summary["cannot_claim"], claimed_payload
+        assert "automatic_promotion_success" in claim_summary["cannot_claim"], claimed_payload
+        assert claim_summary["dev_metric"] == 4.0, claimed_payload
+        assert claim_summary["holdout_metric"] is None, claimed_payload
+        assert claim_summary["holdout_metric_redacted"] is True, claimed_payload
         assert_public_safe(claimed_payload)
 
     print("auto-research-live-evidence-capture-smoke ok")

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -427,6 +427,81 @@ def _live_codex_truth_boundary(*, launch_visible: bool) -> dict[str, object]:
     }
 
 
+def _demo_claim_summary(payload: dict[str, object]) -> dict[str, object]:
+    """Keep user-facing claims anchored to live evidence, not kernel replay."""
+
+    live = payload.get("live_codex_e2e") if isinstance(payload.get("live_codex_e2e"), dict) else {}
+    protected_eval = (
+        payload.get("protected_eval_result")
+        if isinstance(payload.get("protected_eval_result"), dict)
+        else {}
+    )
+    research_loop = (
+        payload.get("research_loop")
+        if isinstance(payload.get("research_loop"), dict)
+        else {}
+    )
+    live_claim_allowed = bool(live.get("claim_allowed"))
+    if live_claim_allowed:
+        cannot_claim: list[str] = []
+        if not live.get("holdout_claim_allowed"):
+            cannot_claim.append("live_holdout_metric_or_claim")
+        if not live.get("promotion_claim_allowed"):
+            cannot_claim.append("automatic_promotion_success")
+        return {
+            "schema_version": "auto_research_demo_claim_summary_v0",
+            "status": "live_worker_dev_evidence_ready",
+            "claim_basis": "live_codex_lane_output",
+            "live_worker_claim_allowed": True,
+            "live_worker_authored": True,
+            "kernel_precheck_passed": bool(protected_eval.get("executed")),
+            "can_claim": ["visible_worker_live_dev_evidence_supported"],
+            "cannot_claim": cannot_claim,
+            "dev_metric": live.get("dev_metric"),
+            "holdout_metric": live.get("holdout_metric"),
+            "holdout_metric_redacted": bool(live.get("holdout_metric_redacted")),
+            "next_required": (
+                "separate held-out live evidence or owner-approved claim authority "
+                "is required before holdout or promotion claims"
+            ),
+        }
+
+    kernel_precheck_passed = (
+        bool(protected_eval.get("executed"))
+        and protected_eval.get("status") == "supported"
+        and bool(research_loop.get("executed"))
+    )
+    return {
+        "schema_version": "auto_research_demo_claim_summary_v0",
+        "status": "kernel_precheck_only" if kernel_precheck_passed else "preview_only",
+        "claim_basis": (
+            "deterministic_protected_eval_kernel"
+            if kernel_precheck_passed
+            else "dry_run_preview"
+        ),
+        "live_worker_claim_allowed": False,
+        "live_worker_authored": False,
+        "kernel_precheck_passed": kernel_precheck_passed,
+        "can_claim": (
+            ["protected_eval_kernel_positive_precheck"]
+            if kernel_precheck_passed
+            else ["one_command_preview_available"]
+        ),
+        "cannot_claim": [
+            "visible_codex_workers_authored_result",
+            "live_holdout_metric_or_claim",
+            "automatic_promotion_success",
+        ],
+        "dev_metric": protected_eval.get("dev_metric") if kernel_precheck_passed else None,
+        "holdout_metric": None,
+        "holdout_metric_redacted": bool(kernel_precheck_passed),
+        "next_required": (
+            "capture compact public-safe live lane evidence and pass it with --live-evidence "
+            "before claiming visible-worker E2E success"
+        ),
+    }
+
+
 def _metric_gain(metric: object, *, baseline: float = 1.0) -> float | None:
     if metric is None:
         return None
@@ -660,6 +735,7 @@ def run_auto_research_demo_e2e(
             "expected_steps": "seed quickstart pack, run protected eval, append public-safe evidence, read board",
             "live_codex_lane_authored": False,
         }
+        payload["claim_summary"] = _demo_claim_summary(payload)
         return payload
 
     tmp_obj: tempfile.TemporaryDirectory[str] | None = None
@@ -818,6 +894,7 @@ def run_auto_research_demo_e2e(
                 agent_id=agent_id,
             )
             payload["live_codex_e2e"] = build_live_codex_claim_from_evidence(live_evidence)
+        payload["claim_summary"] = _demo_claim_summary(payload)
         return payload
     finally:
         if tmp_obj is not None:

--- a/loopx/capabilities/auto_research/legacy_core.py
+++ b/loopx/capabilities/auto_research/legacy_core.py
@@ -3494,6 +3494,11 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
             if isinstance(payload.get("live_codex_e2e"), dict)
             else {}
         )
+        claim_summary = (
+            payload.get("claim_summary")
+            if isinstance(payload.get("claim_summary"), dict)
+            else {}
+        )
         board_claim_boundary = (
             board.get("claim_boundary")
             if isinstance(board.get("claim_boundary"), dict)
@@ -3506,6 +3511,10 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
             f"- mode: `{payload.get('mode')}`",
             f"- execution_kind: `{payload.get('execution_kind')}`",
             f"- result_source: `{payload.get('result_source')}`",
+            f"- claim_summary_status: `{claim_summary.get('status')}`",
+            f"- claim_summary_basis: `{claim_summary.get('claim_basis')}`",
+            f"- claim_summary_live_worker_claim_allowed: `{claim_summary.get('live_worker_claim_allowed')}`",
+            f"- claim_summary_kernel_precheck_passed: `{claim_summary.get('kernel_precheck_passed')}`",
             f"- goal_id: `{payload.get('goal_id')}`",
             f"- tracking_goal_id: `{payload.get('tracking_goal_id')}`",
             f"- frontier_goal_id: `{route.get('frontier_goal_id')}`",


### PR DESCRIPTION
## Summary
- add a compact claim_summary to demo-e2e so kernel-only runs are explicitly labeled precheck-only
- switch claim_summary to live_worker_dev_evidence_ready only when compact live Codex lane evidence is supplied
- document and smoke-test the kernel/live claim boundary

## Validation
- python3 -m py_compile loopx/capabilities/auto_research/demo_e2e.py loopx/capabilities/auto_research/legacy_core.py loopx/capabilities/auto_research/live_evidence.py
- python3 examples/auto-research-demo-e2e-smoke.py
- python3 examples/auto-research-live-evidence-capture-smoke.py
- python3 examples/auto-research-live-codex-claim-boundary-smoke.py
- git diff --check
- loopx check