### PR TITLE
Package dashboard sources in local LoopX releases

### DIFF
--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -195,6 +195,12 @@ def main() -> int:
         assert wrapper.resolve().name == "loopx", wrapper.resolve()
         release_root = wrapper.resolve().parents[1]
         assert (release_root / "loopx" / "cli.py").is_file(), release_root
+        dashboard_page = release_root / "apps" / "dashboard" / "src" / "views" / "dashboard-page.tsx"
+        action_packet = release_root / "apps" / "dashboard" / "src" / "data" / "action-packet.ts"
+        dashboard_node_modules = release_root / "apps" / "dashboard" / "node_modules"
+        assert dashboard_page.is_file(), dashboard_page
+        assert action_packet.is_file(), action_packet
+        assert not dashboard_node_modules.exists(), dashboard_node_modules
         assert (release_root / ".github" / "workflows" / "update-notes.yml").is_file(), release_root
         assert (release_root / "LICENSE").is_file(), release_root
         release_manifest_path = release_root / "release.json"

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -108,12 +108,18 @@ copy_path "$repo_root/scripts" "$release_tmp/scripts"
 copy_path "$repo_root/skills" "$release_tmp/skills"
 copy_path "$repo_root/docs" "$release_tmp/docs"
 copy_path "$repo_root/examples" "$release_tmp/examples"
+copy_path "$repo_root/apps" "$release_tmp/apps"
 copy_path "$repo_root/.github" "$release_tmp/.github"
 copy_path "$repo_root/README.md" "$release_tmp/README.md"
 copy_path "$repo_root/LICENSE" "$release_tmp/LICENSE"
 copy_path "$repo_root/pyproject.toml" "$release_tmp/pyproject.toml"
 find "$release_tmp" -name __pycache__ -type d -prune -exec rm -rf {} +
 find "$release_tmp" -name '*.pyc' -type f -delete
+if [[ -d "$release_tmp/apps" ]]; then
+  find "$release_tmp/apps" \
+    \( -name node_modules -o -name .next -o -name dist -o -name build -o -name coverage \) \
+    -type d -prune -exec rm -rf {} +
+fi
 PYTHONPATH="$release_tmp${PYTHONPATH:+:$PYTHONPATH}" "${LOOPX_PYTHON:-python3}" -m loopx.release_manifest \
   "$release_tmp" \
   --release-id "$release_id" \


### PR DESCRIPTION
## Summary
- include `apps/` in local release snapshots so release-based canaries can read dashboard/operator packet sources
- prune common frontend dependency/build artifacts from copied app sources
- extend install-local smoke to assert dashboard review-packet sources are present in the release snapshot

## Validation
- `python3 examples/install-local-smoke.py`
- `scripts/install-local.sh`
- `loopx --format json canary run --profile status-read-path --profile review-packet-read-path --include-deep-checks --max-checks-per-profile 8 --check-limit 12 --timeout-seconds 240`
- `python3 -m loopx.cli check --scan-path scripts/install-local.sh --scan-path examples/install-local-smoke.py`
- `git diff --check`
- `loopx doctor`

## Boundary
- public release packaging + durable validation only
- no private state, credentials, raw benchmark logs, or local evidence committed