### PR TITLE
Add minimal auto-research worker turn

### DIFF
--- a/examples/auto-research-worker-turn-smoke.py
+++ b/examples/auto-research-worker-turn-smoke.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Smoke-test the minimal LoopX-selected auto-research worker turn."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.capabilities.auto_research.demo_e2e import run_auto_research_demo_e2e  # noqa: E402
+
+
+GOAL_ID = "loopx-auto-research-knn"
+EVIDENCE_AGENT_ID = "codex-main-control"
+
+
+def assert_public_safe(payload: Any) -> None:
+    text = json.dumps(payload, sort_keys=True) if not isinstance(payload, str) else payload
+    forbidden = [
+        "/" + "Users/",
+        "/" + "private/",
+        "/" + "tmp/",
+        "http" + "://",
+        "https" + "://",
+        "api" + "_key",
+        "pass" + "word",
+        "sec" + "ret",
+    ]
+    leaked = [needle for needle in forbidden if needle.lower() in text.lower()]
+    assert not leaked, leaked
+
+
+def run_worker_turn(
+    *,
+    registry: Path,
+    runtime_root: str | None,
+    workspace: Path,
+    execute: bool,
+) -> dict[str, Any]:
+    env = os.environ.copy()
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    env["PYTHONPATH"] = f"{REPO_ROOT}{os.pathsep}{env.get('PYTHONPATH', '')}"
+    args = [
+        sys.executable,
+        "-m",
+        "loopx.cli",
+        "--registry",
+        str(registry),
+        "--runtime-root",
+        str(runtime_root),
+        "--format",
+        "json",
+        "auto-research",
+        "worker-turn",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        EVIDENCE_AGENT_ID,
+        "--lane-count",
+        "3",
+        "--visible-lanes-accepted",
+    ]
+    if execute:
+        args.append("--execute")
+    result = subprocess.run(
+        args,
+        cwd=workspace,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"worker-turn failed rc={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+    return json.loads(result.stdout)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        registry = temp / "registry.json"
+        runtime_root = temp / "runtime"
+        registry.write_text(
+            json.dumps({"common_runtime_root": str(runtime_root), "goals": []}),
+            encoding="utf-8",
+        )
+
+        captured: dict[str, Any] = {}
+
+        def fake_append_evidence(_packet_path: str) -> dict[str, object]:
+            return {
+                "ok": True,
+                "schema_version": "auto_research_rollout_append_v0",
+                "goal_id": GOAL_ID,
+                "dry_run": False,
+                "event_count": 3,
+                "appended_count": 3,
+                "would_append_count": 3,
+                "skipped_existing_count": 0,
+                "event_ids": ["kernel-hypothesis", "kernel-dev", "kernel-holdout"],
+                "appended_event_ids": ["kernel-hypothesis", "kernel-dev", "kernel-holdout"],
+                "skipped_existing_event_ids": [],
+                "counts_by_kind": {"research_evidence": 2, "research_hypothesis": 1},
+                "packet_summary": {"goal_id": GOAL_ID},
+                "public_boundary": {
+                    "raw_logs_recorded": False,
+                    "private_artifacts_recorded": False,
+                    "absolute_paths_recorded": False,
+                },
+            }
+
+        def fake_visible_launcher(
+            _supervisor: dict[str, object],
+            visible_registry: Path,
+            visible_runtime_root: str | None,
+            default_workspace: Path,
+        ) -> dict[str, object]:
+            preview = run_worker_turn(
+                registry=visible_registry,
+                runtime_root=visible_runtime_root,
+                workspace=default_workspace,
+                execute=False,
+            )
+            executed = run_worker_turn(
+                registry=visible_registry,
+                runtime_root=visible_runtime_root,
+                workspace=default_workspace,
+                execute=True,
+            )
+            captured["preview"] = preview
+            captured["executed"] = executed
+            return {
+                "ok": True,
+                "schema_version": "auto_research_worker_turn_fake_launch_v0",
+                "mode": "executed_visible_launch",
+                "launch_result": {
+                    "schema_version": "auto_research_worker_turn_fake_launch_result_v0",
+                    "worker_turn_executed": bool(executed.get("executed")),
+                    "visible_acceptance": {
+                        "accepted": bool(executed.get("executed")),
+                        "worker_turn_schema": executed.get("schema_version"),
+                    },
+                },
+                "public_boundary": {
+                    "raw_logs_recorded": False,
+                    "private_artifacts_recorded": False,
+                    "absolute_paths_recorded": False,
+                },
+            }
+
+        payload = run_auto_research_demo_e2e(
+            agent_id="codex-side-bypass",
+            goal_id=GOAL_ID,
+            tracking_goal_id="loopx-meta",
+            objective="Prove the visible worker can run a LoopX-selected auto-research evidence turn.",
+            output_dir="auto_research_knn_pack",
+            execute=True,
+            launch_visible=True,
+            keep_workspace=False,
+            registry_path=registry,
+            runtime_root_arg=str(runtime_root),
+            session_name="loopx-auto-research-worker-turn-smoke",
+            cli_bin="loopx",
+            codex_bin="codex",
+            tmux_bin="tmux",
+            reasoning_effort="high",
+            live_evidence_path=None,
+            append_evidence=fake_append_evidence,
+            visible_launcher=fake_visible_launcher,
+        )
+
+        assert payload["ok"] is True, payload
+        preview = captured["preview"]
+        executed = captured["executed"]
+        assert preview["schema_version"] == "auto_research_worker_turn_v0", preview
+        assert preview["mode"] == "dry_run", preview
+        assert preview["selected_action"] == "run_dev_eval", preview
+        assert preview["selected_todo_id"], preview
+        assert executed["schema_version"] == "auto_research_worker_turn_v0", executed
+        assert executed["mode"] == "execute", executed
+        assert executed["selected_action"] == "run_dev_eval", executed
+        assert executed["selected_todo_id"] == preview["selected_todo_id"], executed
+        assert executed["executed"] is True, executed
+        assert executed["dev_metric"] == 4.0, executed
+        assert executed["packet_status"] == "supported", executed
+        assert executed["append"]["appended_count"] == 2, executed
+        assert executed["append"]["counts_by_kind"] == {
+            "research_evidence": 1,
+            "research_hypothesis": 1,
+        }, executed
+        assert executed["live_evidence"]["written"] is True, executed
+        assert executed["live_evidence"]["claim_source"] == "live_codex_lane_output", executed
+        assert executed["live_evidence"]["dev_metric"] == 4.0, executed
+        assert executed["frontier"]["frontier"]["selected"]["claimed_by"] == EVIDENCE_AGENT_ID, executed
+        assert payload["visible_launch"]["launch_result"]["worker_turn_executed"] is True, payload
+        assert payload["live_codex_e2e"]["visible_lanes_accepted"] is True, payload
+        assert_public_safe(preview)
+        assert_public_safe(executed)
+        assert_public_safe(payload["visible_launch"])
+
+    print("auto-research-worker-turn-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/auto_research/__init__.py
+++ b/loopx/capabilities/auto_research/__init__.py
@@ -56,6 +56,12 @@ from .kernel import (
     run_builtin_lightweight_demo,
     run_lightweight_auto_research,
 )
+from .worker_runtime import (
+    AUTO_RESEARCH_WORKER_FRONTIER_SCHEMA_VERSION,
+    AUTO_RESEARCH_WORKER_TURN_SCHEMA_VERSION,
+    load_auto_research_worker_frontier,
+    run_auto_research_worker_turn,
+)
 
 __all__ = [
     "AUTO_RESEARCH_DEFAULT_GOAL_ID",
@@ -110,4 +116,8 @@ __all__ = [
     "lightweight_hypothesis",
     "run_builtin_lightweight_demo",
     "run_lightweight_auto_research",
+    "AUTO_RESEARCH_WORKER_FRONTIER_SCHEMA_VERSION",
+    "AUTO_RESEARCH_WORKER_TURN_SCHEMA_VERSION",
+    "load_auto_research_worker_frontier",
+    "run_auto_research_worker_turn",
 ]

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -23,6 +23,7 @@ from . import (
     load_auto_research_fixture,
     render_auto_research_markdown,
     run_builtin_lightweight_demo,
+    run_auto_research_worker_turn,
 )
 from .demo_e2e import run_auto_research_demo_e2e
 from .live_evidence import (
@@ -253,6 +254,54 @@ def register_auto_research_commands(
         "--execute",
         action="store_true",
         help="Write the compact evidence JSON to --output. Omit to preview the payload.",
+    )
+
+    worker_turn_parser = auto_research_sub.add_parser(
+        "worker-turn",
+        help="Run one LoopX-selected auto-research worker turn from quota/frontier.",
+    )
+    add_subcommand_format(worker_turn_parser)
+    worker_turn_parser.add_argument("--agent-id", required=True)
+    worker_turn_parser.add_argument(
+        "--goal-id",
+        default=AUTO_RESEARCH_DEFAULT_GOAL_ID,
+        help="Research goal id whose quota/frontier this worker should obey.",
+    )
+    worker_turn_parser.add_argument(
+        "--objective",
+        default=AUTO_RESEARCH_DEFAULT_OBJECTIVE,
+        help="Public-safe objective used only when the quickstart pack must be created.",
+    )
+    worker_turn_parser.add_argument(
+        "--output-dir",
+        default="auto_research_knn_pack",
+        help="Quickstart pack directory inside the worker workspace.",
+    )
+    worker_turn_parser.add_argument(
+        "--evidence-dir",
+        default=".local/auto-research-worker",
+        help="Local-only evidence output directory inside the worker workspace.",
+    )
+    worker_turn_parser.add_argument(
+        "--lane-count",
+        type=int,
+        default=1,
+        help="Visible lane count recorded when live evidence is captured.",
+    )
+    worker_turn_parser.add_argument(
+        "--visible-lanes-accepted",
+        action="store_true",
+        help="Acknowledge that the visible lanes were launched and accepted.",
+    )
+    worker_turn_parser.add_argument(
+        "--live-evidence-output",
+        default=LIVE_CODEX_E2E_DEFAULT_OUTPUT,
+        help="Local filename for compact public-safe live evidence.",
+    )
+    worker_turn_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Run the selected worker action. Omit to show the plan from quota/frontier.",
     )
 
     demo_supervisor_parser = auto_research_sub.add_parser(
@@ -664,6 +713,30 @@ def handle_auto_research_command(
                     json.dumps(payload, indent=2, sort_keys=True) + "\n",
                     encoding="utf-8",
                 )
+        elif args.auto_research_command == "worker-turn":
+            def append_worker_evidence(packet_path: str) -> dict[str, object]:
+                return _append_auto_research_rollout_events(
+                    packet_path=packet_path,
+                    registry_path=registry_path,
+                    runtime_root_arg=runtime_root_arg,
+                    dry_run=False,
+                )
+
+            payload = run_auto_research_worker_turn(
+                registry_path=registry_path,
+                runtime_root_arg=runtime_root_arg,
+                goal_id=args.goal_id,
+                agent_id=args.agent_id,
+                objective=args.objective,
+                workspace=Path.cwd(),
+                output_dir=args.output_dir,
+                evidence_dir=args.evidence_dir,
+                execute=args.execute,
+                append_evidence=append_worker_evidence if args.execute else None,
+                lane_count=args.lane_count,
+                visible_lanes_accepted=args.visible_lanes_accepted,
+                live_evidence_output=args.live_evidence_output,
+            )
         elif args.auto_research_command == "demo-supervisor":
             payload = build_auto_research_demo_supervisor_plan(
                 goal_id=args.goal_id,
@@ -746,7 +819,7 @@ def handle_auto_research_command(
             raise ValueError(
                 "auto-research requires the `quickstart`, `frontier`, `evidence`, "
                 "`board`, `acceptance`, `append-evidence`, `capture-live-evidence`, "
-                "`demo-supervisor`, `demo-e2e`, or `lite-e2e` subcommand"
+                "`worker-turn`, `demo-supervisor`, `demo-e2e`, or `lite-e2e` subcommand"
             )
     except Exception as exc:
         payload = {

--- a/loopx/capabilities/auto_research/legacy_core.py
+++ b/loopx/capabilities/auto_research/legacy_core.py
@@ -942,13 +942,11 @@ def _auto_research_codex_bootstrap_prompt(
             "",
             "Evidence runner minimal live demo path:",
             "1. Confirm the selected frontier action is `run_dev_eval` or `write_evidence` for this agent.",
-            "2. Run the quickstart dev evaluator from this pane workspace:",
-            "   `python3 auto_research_knn_pack/protected_eval.py --solution auto_research_knn_pack/solution_candidate.py --split dev > .local/evidence-runner/dev-result.public.json`",
-            "3. Build the public evidence packet:",
-            "   `loopx --format json auto-research evidence --contract auto_research_knn_pack/research_contract.json --eval-result .local/evidence-runner/dev-result.public.json --hypothesis-id hyp_quickstart_partial_selection --todo-id <selected todo_id> --agent-id \"$LOOPX_AGENT_ID\" --claimed-by \"$LOOPX_AGENT_ID\" --mechanism-family partial_selection --hypothesis \"Use exact partial selection to avoid full distance sorting.\" > .local/evidence-runner/evidence.public.json`",
-            "4. Run `append-evidence --dry-run`, then real `append-evidence --output .local/evidence-runner/append-result.public.json`.",
-            "5. Run `capture-live-evidence --packet .local/evidence-runner/evidence.public.json --append-result .local/evidence-runner/append-result.public.json --agent-id \"$LOOPX_AGENT_ID\" --lane-count \"${LOOPX_VISIBLE_LANE_COUNT:-1}\" --visible-lanes-accepted --output .local/evidence-runner/live-codex-e2e-evidence.public.json --execute`.",
-            "6. Complete only the selected todo after the evidence files exist and the append result reports appended evidence.",
+            "2. Preview the real LoopX-selected worker turn:",
+            "   `loopx --format json auto-research worker-turn --goal-id \"$LOOPX_GOAL_ID\" --agent-id \"$LOOPX_AGENT_ID\"`",
+            "3. Execute the same worker turn only when the preview selected this lane:",
+            "   `loopx --format json auto-research worker-turn --goal-id \"$LOOPX_GOAL_ID\" --agent-id \"$LOOPX_AGENT_ID\" --lane-count \"${LOOPX_VISIBLE_LANE_COUNT:-1}\" --visible-lanes-accepted --execute`",
+            "4. Complete only the selected todo after worker-turn reports executed=true, appended evidence, and live_evidence.written=true.",
         ]
     return "\n".join(
         [

--- a/loopx/capabilities/auto_research/worker_runtime.py
+++ b/loopx/capabilities/auto_research/worker_runtime.py
@@ -1,0 +1,307 @@
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from .core import (
+    AUTO_RESEARCH_DEFAULT_GOAL_ID,
+    AUTO_RESEARCH_DEFAULT_OBJECTIVE,
+    AUTO_RESEARCH_QUICKSTART_TEMPLATE,
+    build_auto_research_quickstart,
+    build_live_auto_research_projection,
+    load_auto_research_evidence_packet_inputs,
+)
+from .live_evidence import (
+    LIVE_CODEX_E2E_DEFAULT_OUTPUT,
+    build_live_codex_e2e_evidence_from_packet,
+)
+from ...history import load_registry
+from ...paths import resolve_runtime_root
+from ...quota import build_quota_should_run
+from ...rollout_event_log import load_rollout_events, rollout_event_log_path
+from ...status import collect_status
+
+
+AUTO_RESEARCH_WORKER_TURN_SCHEMA_VERSION = "auto_research_worker_turn_v0"
+AUTO_RESEARCH_WORKER_FRONTIER_SCHEMA_VERSION = "auto_research_worker_frontier_v0"
+SUPPORTED_WORKER_ACTIONS = {"run_dev_eval", "write_evidence"}
+
+AppendEvidence = Callable[[str], dict[str, object]]
+
+
+def _slug(value: object, *, default: str = "item") -> str:
+    text = re.sub(r"[^A-Za-z0-9._-]+", "-", str(value or "")).strip("-._")
+    return text[:80] or default
+
+
+def _write_json(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _run_protected_eval(*, pack_dir: Path, split: str, output_path: Path) -> dict[str, object]:
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(pack_dir / "protected_eval.py"),
+            "--solution",
+            str(pack_dir / "solution_candidate.py"),
+            "--split",
+            split,
+        ],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+    _write_json(output_path, payload)
+    return payload
+
+
+def _ensure_quickstart_pack(
+    *,
+    workspace: Path,
+    output_dir: str,
+    agent_id: str,
+    goal_id: str,
+    objective: str,
+) -> tuple[Path, str]:
+    pack_dir = (workspace / output_dir).resolve()
+    if pack_dir.exists():
+        return pack_dir, "existing"
+    build_auto_research_quickstart(
+        agent_id=agent_id,
+        goal_id=goal_id,
+        objective=objective,
+        output_dir=output_dir,
+        template=AUTO_RESEARCH_QUICKSTART_TEMPLATE,
+        execute=True,
+        cwd=workspace,
+    )
+    return pack_dir, "created"
+
+
+def load_auto_research_worker_frontier(
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    goal_id: str,
+    agent_id: str,
+    workspace: Path,
+) -> dict[str, object]:
+    """Read the same quota/frontier surfaces a visible worker must obey."""
+
+    status_payload = collect_status(
+        registry_path=registry_path,
+        runtime_root_override=runtime_root_arg,
+        scan_roots=[workspace],
+        limit=5,
+        goal_id=goal_id,
+    )
+    quota_payload = build_quota_should_run(
+        status_payload,
+        goal_id=goal_id,
+        agent_id=agent_id,
+    )
+    registry = load_registry(registry_path)
+    runtime_root = resolve_runtime_root(registry, runtime_root_arg)
+    projection = build_live_auto_research_projection(
+        goal_id=goal_id,
+        agent_id=agent_id,
+        quota_payload=quota_payload,
+        rollout_events=load_rollout_events(rollout_event_log_path(runtime_root, goal_id)),
+    )
+    frontier = projection["frontier"]
+    selected = frontier.get("selected") if isinstance(frontier, dict) else None
+    return {
+        "ok": True,
+        "schema_version": AUTO_RESEARCH_WORKER_FRONTIER_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "agent_id": agent_id,
+        "quota": {
+            "ok": bool(quota_payload.get("ok")),
+            "should_run": bool(quota_payload.get("should_run")),
+            "state": quota_payload.get("state"),
+            "user_action_required": bool(
+                ((quota_payload.get("interaction_contract") or {}).get("user_channel") or {}).get(
+                    "action_required"
+                )
+            ),
+        },
+        "frontier": {
+            "selected": selected,
+            "runnable_count": len(frontier.get("runnable") or []) if isinstance(frontier, dict) else 0,
+            "blocked_count": len(frontier.get("blocked") or []) if isinstance(frontier, dict) else 0,
+            "source_kind": frontier.get("source_kind") if isinstance(frontier, dict) else None,
+        },
+        "public_boundary": {
+            "source": "loopx_quota_and_auto_research_frontier",
+            "raw_logs_recorded": False,
+            "private_artifacts_recorded": False,
+            "absolute_paths_recorded": False,
+        },
+    }
+
+
+def run_auto_research_worker_turn(
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    goal_id: str = AUTO_RESEARCH_DEFAULT_GOAL_ID,
+    agent_id: str,
+    objective: str = AUTO_RESEARCH_DEFAULT_OBJECTIVE,
+    workspace: Path,
+    output_dir: str = "auto_research_knn_pack",
+    evidence_dir: str = ".local/auto-research-worker",
+    execute: bool = False,
+    append_evidence: AppendEvidence | None = None,
+    lane_count: int = 1,
+    visible_lanes_accepted: bool = False,
+    live_evidence_output: str = LIVE_CODEX_E2E_DEFAULT_OUTPUT,
+) -> dict[str, object]:
+    """Run one LoopX-selected visible worker action.
+
+    The worker does not choose its own work. It reads quota/frontier, checks the
+    selected action, then performs only the small public k-NN dev-eval evidence
+    turn that the visible auto-research demo currently needs.
+    """
+
+    workspace = workspace.resolve()
+    frontier_packet = load_auto_research_worker_frontier(
+        registry_path=registry_path,
+        runtime_root_arg=runtime_root_arg,
+        goal_id=goal_id,
+        agent_id=agent_id,
+        workspace=workspace,
+    )
+    selected = frontier_packet["frontier"].get("selected") if isinstance(frontier_packet["frontier"], dict) else None
+    action = str((selected or {}).get("allowed_action") or "")
+    todo_id = str((selected or {}).get("todo_id") or "")
+    if not selected or not todo_id:
+        return {
+            "ok": True,
+            "schema_version": AUTO_RESEARCH_WORKER_TURN_SCHEMA_VERSION,
+            "mode": "no_action",
+            "goal_id": goal_id,
+            "agent_id": agent_id,
+            "executed": False,
+            "frontier": frontier_packet,
+        }
+    if action not in SUPPORTED_WORKER_ACTIONS:
+        return {
+            "ok": True,
+            "schema_version": AUTO_RESEARCH_WORKER_TURN_SCHEMA_VERSION,
+            "mode": "unsupported_action",
+            "goal_id": goal_id,
+            "agent_id": agent_id,
+            "selected_todo_id": todo_id,
+            "selected_action": action,
+            "supported_actions": sorted(SUPPORTED_WORKER_ACTIONS),
+            "executed": False,
+            "frontier": frontier_packet,
+        }
+    if not execute:
+        return {
+            "ok": True,
+            "schema_version": AUTO_RESEARCH_WORKER_TURN_SCHEMA_VERSION,
+            "mode": "dry_run",
+            "goal_id": goal_id,
+            "agent_id": agent_id,
+            "selected_todo_id": todo_id,
+            "selected_action": action,
+            "would_execute": "quickstart_dev_eval_then_append_public_evidence",
+            "frontier": frontier_packet,
+        }
+    if append_evidence is None:
+        raise ValueError("execute requires an append_evidence callback")
+
+    pack_dir, pack_mode = _ensure_quickstart_pack(
+        workspace=workspace,
+        output_dir=output_dir,
+        agent_id=agent_id,
+        goal_id=goal_id,
+        objective=objective,
+    )
+    run_dir = workspace / evidence_dir / _slug(agent_id, default="agent") / _slug(todo_id, default="todo")
+    dev_result_path = run_dir / "dev-result.public.json"
+    evidence_packet_path = run_dir / "evidence.public.json"
+    append_result_path = run_dir / "append-result.public.json"
+    live_evidence_path = run_dir / live_evidence_output
+
+    dev_result = _run_protected_eval(pack_dir=pack_dir, split="dev", output_path=dev_result_path)
+    packet = load_auto_research_evidence_packet_inputs(
+        contract_path=pack_dir / "research_contract.json",
+        eval_result_paths=[dev_result_path],
+        hypothesis_id=f"hyp_{_slug(todo_id, default='todo')}_partial_selection",
+        todo_id=todo_id,
+        agent_id=agent_id,
+        claimed_by=agent_id,
+        mechanism_family="partial_selection",
+        hypothesis="Use exact partial selection to avoid full distance sorting.",
+        grounding_refs=["quickstart:knn_exact_pack"],
+        attempt_start=1,
+    )
+    _write_json(evidence_packet_path, packet)
+    append_result = append_evidence(str(evidence_packet_path))
+    _write_json(append_result_path, append_result)
+
+    live_evidence: dict[str, object] | None = None
+    if visible_lanes_accepted:
+        live_evidence = build_live_codex_e2e_evidence_from_packet(
+            packet=packet,
+            append_result=append_result,
+            agent_id=agent_id,
+            lane_count=lane_count,
+            visible_lanes_accepted=True,
+        )
+        _write_json(live_evidence_path, live_evidence)
+
+    live_lane_evidence = (
+        live_evidence.get("lane_evidence")
+        if isinstance(live_evidence, dict) and isinstance(live_evidence.get("lane_evidence"), dict)
+        else {}
+    )
+    return {
+        "ok": True,
+        "schema_version": AUTO_RESEARCH_WORKER_TURN_SCHEMA_VERSION,
+        "mode": "execute",
+        "goal_id": goal_id,
+        "agent_id": agent_id,
+        "selected_todo_id": todo_id,
+        "selected_action": action,
+        "executed": True,
+        "pack_mode": pack_mode,
+        "dev_metric": (dev_result.get("metric") or {}).get("value")
+        if isinstance(dev_result.get("metric"), dict)
+        else None,
+        "packet_status": packet["summary"]["status"],
+        "append": {
+            "schema_version": append_result.get("schema_version"),
+            "goal_id": append_result.get("goal_id"),
+            "appended_count": append_result.get("appended_count"),
+            "counts_by_kind": append_result.get("counts_by_kind"),
+        },
+        "live_evidence": {
+            "written": live_evidence is not None,
+            "claim_source": live_evidence.get("source") if live_evidence else None,
+            "dev_metric": live_lane_evidence.get("dev_metric"),
+        },
+        "artifacts": {
+            "paths_are_local_only": True,
+            "evidence_packet": "evidence.public.json",
+            "append_result": "append-result.public.json",
+            "live_evidence": live_evidence_output if live_evidence else None,
+        },
+        "frontier": frontier_packet,
+        "public_boundary": {
+            "raw_logs_recorded": False,
+            "private_artifacts_recorded": False,
+            "absolute_paths_recorded": False,
+            "credentials_recorded": False,
+        },
+    }


### PR DESCRIPTION
## Summary

- add a minimal `auto-research worker-turn` runtime that reads LoopX quota/frontier before doing work
- let an evidence-runner worker turn run the quickstart dev evaluator, build public evidence, append rollout events, and optionally capture compact live evidence
- update the visible evidence-runner bootstrap to call the worker-turn command instead of walking through several manual evidence commands
- add a focused smoke proving a demo-local visible worker queue can select `run_dev_eval` and append public-safe evidence

## Claim boundary

This is not a claim that the full visible Codex multi-round loop is finished. It is the next real step: a visible lane can now run one LoopX-selected worker turn through the CLI and write public-safe evidence instead of relying on deterministic kernel replay or manual instructions.

## Validation

- `python3 -m py_compile loopx/capabilities/auto_research/worker_runtime.py loopx/capabilities/auto_research/cli.py loopx/capabilities/auto_research/__init__.py examples/auto-research-worker-turn-smoke.py`
- `python3 examples/auto-research-worker-turn-smoke.py`
- `python3 examples/auto-research-demo-e2e-smoke.py`
- `python3 examples/auto-research-one-click-ux-smoke.py`
- `python3 examples/auto-research-demo-supervisor-smoke.py`
- `python3 examples/auto-research-live-evidence-capture-smoke.py`
- `python3 examples/auto-research-skill-contract-smoke.py`
- `loopx check` (passes; existing warning: loopx-meta duplicate index rows raw=6848 unique=6844)
- candidate public/private scan clean for edited files
