### PR TITLE
Expose selected todo alias for agent-lane quota

### DIFF
--- a/examples/control-plane-risk-characterization-smoke.py
+++ b/examples/control-plane-risk-characterization-smoke.py
@@ -169,6 +169,13 @@ def assert_agent_lane_delivery() -> None:
     assert lane["todo_id"] == "todo_characterize", lane
     assert lane["selected_by"] == "current_agent_claimed_todo", lane
     assert lane["preserves_goal_next_action"] is True, lane
+    selected = quota["selected_todo"]
+    assert selected["schema_version"] == "selected_todo_v0", selected
+    assert selected["source"] == "agent_lane_next_action", selected
+    assert selected["todo_source"] == "agent_todo_summary.first_executable_items", selected
+    assert selected["todo_id"] == lane["todo_id"], selected
+    assert selected["selected_by"] == lane["selected_by"], selected
+    assert selected["agent_id"] == AGENT_ID, selected
 
     packet = build_review_packet(payload, goal_id=GOAL_ID)
     assert packet["ok"] is True, packet

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -2817,6 +2817,40 @@ def _agent_lane_next_action(
     return None
 
 
+def _selected_todo_alias_from_agent_lane(
+    agent_lane_next_action: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if not isinstance(agent_lane_next_action, dict):
+        return None
+    todo_id = normalize_todo_id(agent_lane_next_action.get("todo_id"))
+    if not todo_id:
+        return None
+    alias = {
+        key: agent_lane_next_action.get(key)
+        for key in (
+            "todo_id",
+            "index",
+            "role",
+            "status",
+            "priority",
+            "title",
+            "text",
+            "task_class",
+            "action_kind",
+            "claimed_by",
+            "agent_id",
+            "selected_by",
+            "confidence",
+        )
+        if agent_lane_next_action.get(key) is not None
+    }
+    alias["schema_version"] = "selected_todo_v0"
+    alias["source"] = "agent_lane_next_action"
+    if agent_lane_next_action.get("source") is not None:
+        alias["todo_source"] = agent_lane_next_action.get("source")
+    return alias
+
+
 def _count_advancement_items(items: Any, *, claimed_by: str | None = None) -> int:
     if not isinstance(items, list):
         return 0
@@ -7037,6 +7071,9 @@ def build_quota_should_run(
             payload["agent_identity"] = agent_identity
         if agent_lane_next_action:
             payload["agent_lane_next_action"] = agent_lane_next_action
+            selected_todo_alias = _selected_todo_alias_from_agent_lane(agent_lane_next_action)
+            if selected_todo_alias:
+                payload["selected_todo"] = selected_todo_alias
         if agent_lane_frontier_hint:
             payload["agent_lane_frontier_hint"] = agent_lane_frontier_hint
         if agent_scope_frontier:


### PR DESCRIPTION
## Summary
- expose a compact top-level `selected_todo` alias whenever `agent_lane_next_action` selects a concrete todo
- keep the authoritative per-agent routing object unchanged while making older heartbeat parsers less likely to interpret `selected_todo=null` as no work
- add control-plane characterization smoke coverage for the alias

## Motivation
During heartbeat closeout after PR #1021, `quota should-run --agent-id codex-product-capability` correctly selected `agent_lane_next_action.todo_id=todo_efbbda3708f3`, but the top-level `selected_todo` field was absent. That is a compatibility/projection footgun for workers or dashboards that still inspect `selected_todo` first.

## Validation
- `python3 examples/control-plane-risk-characterization-smoke.py`
- `python3 -m py_compile loopx/quota.py`
- `python3 examples/work-lane-contract-smoke.py`
- `python3 examples/quota-resume-gated-open-todo-smoke.py`
- `python3 examples/quota-cleared-blocker-successor-gate-smoke.py`
- `PYTHONPATH="$PWD${PYTHONPATH:+:$PYTHONPATH}" python3 -m loopx.cli --format json canary run --profile control-plane-refactor --include-deep-checks --max-checks-per-profile 8 --check-limit 12 --timeout-seconds 240` -> 5/5 passed
- source CLI cross-check: `selected_todo.todo_id == agent_lane_next_action.todo_id == todo_efbbda3708f3`
- changed-file catalog canary -> `control-plane-refactor`, 8/8 passed
- `python3 -m loopx.cli check --scan-path loopx/quota.py --scan-path examples/control-plane-risk-characterization-smoke.py` -> ok, only existing duplicate-index warning
- `git diff --check`

## Boundary
- public runtime/control-plane compatibility fix only
- no private state, credentials, raw benchmark evidence, scoring, or production actions

## Merge routing
This touches the quota hot path, so product-capability is not self-merging it; please review/merge or request revision.