### PR TITLE
Add multi-role auto-research worker turns

### DIFF
--- a/examples/auto-research-worker-turn-smoke.py
+++ b/examples/auto-research-worker-turn-smoke.py
@@ -20,6 +20,8 @@ from loopx.capabilities.auto_research.demo_e2e import run_auto_research_demo_e2e
 
 
 GOAL_ID = "loopx-auto-research-knn"
+CURATOR_AGENT_ID = "codex-product-capability"
+MAPPER_AGENT_ID = "codex-side-bypass"
 EVIDENCE_AGENT_ID = "codex-main-control"
 
 
@@ -44,7 +46,9 @@ def run_worker_turn(
     registry: Path,
     runtime_root: str | None,
     workspace: Path,
+    agent_id: str,
     execute: bool,
+    complete: bool = False,
 ) -> dict[str, Any]:
     env = os.environ.copy()
     env["PYTHONDONTWRITEBYTECODE"] = "1"
@@ -64,13 +68,15 @@ def run_worker_turn(
         "--goal-id",
         GOAL_ID,
         "--agent-id",
-        EVIDENCE_AGENT_ID,
+        agent_id,
         "--lane-count",
         "3",
         "--visible-lanes-accepted",
     ]
     if execute:
         args.append("--execute")
+    if complete:
+        args.append("--complete-selected-todo")
     result = subprocess.run(
         args,
         cwd=workspace,
@@ -126,30 +132,52 @@ def main() -> int:
             visible_runtime_root: str | None,
             default_workspace: Path,
         ) -> dict[str, object]:
-            preview = run_worker_turn(
+            curator_preview = run_worker_turn(
                 registry=visible_registry,
                 runtime_root=visible_runtime_root,
                 workspace=default_workspace,
+                agent_id=CURATOR_AGENT_ID,
                 execute=False,
             )
-            executed = run_worker_turn(
+            curator_executed = run_worker_turn(
                 registry=visible_registry,
                 runtime_root=visible_runtime_root,
                 workspace=default_workspace,
+                agent_id=CURATOR_AGENT_ID,
                 execute=True,
+                complete=True,
             )
-            captured["preview"] = preview
-            captured["executed"] = executed
+            mapper_executed = run_worker_turn(
+                registry=visible_registry,
+                runtime_root=visible_runtime_root,
+                workspace=default_workspace,
+                agent_id=MAPPER_AGENT_ID,
+                execute=True,
+                complete=True,
+            )
+            evidence_executed = run_worker_turn(
+                registry=visible_registry,
+                runtime_root=visible_runtime_root,
+                workspace=default_workspace,
+                agent_id=EVIDENCE_AGENT_ID,
+                execute=True,
+                complete=True,
+            )
+            captured["curator_preview"] = curator_preview
+            captured["curator_executed"] = curator_executed
+            captured["mapper_executed"] = mapper_executed
+            captured["evidence_executed"] = evidence_executed
             return {
                 "ok": True,
                 "schema_version": "auto_research_worker_turn_fake_launch_v0",
                 "mode": "executed_visible_launch",
                 "launch_result": {
                     "schema_version": "auto_research_worker_turn_fake_launch_result_v0",
-                    "worker_turn_executed": bool(executed.get("executed")),
+                    "worker_turn_executed": bool(evidence_executed.get("executed")),
+                    "worker_turn_count": 3,
                     "visible_acceptance": {
-                        "accepted": bool(executed.get("executed")),
-                        "worker_turn_schema": executed.get("schema_version"),
+                        "accepted": bool(evidence_executed.get("executed")),
+                        "worker_turn_schema": evidence_executed.get("schema_version"),
                     },
                 },
                 "public_boundary": {
@@ -181,19 +209,34 @@ def main() -> int:
         )
 
         assert payload["ok"] is True, payload
-        preview = captured["preview"]
-        executed = captured["executed"]
+        preview = captured["curator_preview"]
+        curator_executed = captured["curator_executed"]
+        mapper_executed = captured["mapper_executed"]
+        executed = captured["evidence_executed"]
         assert preview["schema_version"] == "auto_research_worker_turn_v0", preview
         assert preview["mode"] == "dry_run", preview
-        assert preview["selected_action"] == "run_dev_eval", preview
+        assert preview["selected_action"] == "write_research_contract", preview
         assert preview["selected_todo_id"], preview
+        assert curator_executed["schema_version"] == "auto_research_worker_turn_v0", curator_executed
+        assert curator_executed["mode"] == "execute", curator_executed
+        assert curator_executed["selected_action"] == "write_research_contract", curator_executed
+        assert curator_executed["artifact"]["kind"] == "research_contract", curator_executed
+        assert curator_executed["artifact_status"] == "contract_written", curator_executed
+        assert curator_executed["completion"]["status"] == "done", curator_executed
+        assert mapper_executed["schema_version"] == "auto_research_worker_turn_v0", mapper_executed
+        assert mapper_executed["mode"] == "execute", mapper_executed
+        assert mapper_executed["selected_action"] == "propose_hypothesis", mapper_executed
+        assert mapper_executed["artifact"]["kind"] == "research_hypothesis", mapper_executed
+        assert mapper_executed["artifact_status"] == "hypothesis_mapped", mapper_executed
+        assert mapper_executed["hypothesis_id"].startswith("hyp_"), mapper_executed
+        assert mapper_executed["completion"]["status"] == "done", mapper_executed
         assert executed["schema_version"] == "auto_research_worker_turn_v0", executed
         assert executed["mode"] == "execute", executed
         assert executed["selected_action"] == "run_dev_eval", executed
-        assert executed["selected_todo_id"] == preview["selected_todo_id"], executed
         assert executed["executed"] is True, executed
         assert executed["dev_metric"] == 4.0, executed
         assert executed["packet_status"] == "supported", executed
+        assert executed["completion"]["status"] == "done", executed
         assert executed["append"]["appended_count"] == 2, executed
         assert executed["append"]["counts_by_kind"] == {
             "research_evidence": 1,
@@ -204,8 +247,11 @@ def main() -> int:
         assert executed["live_evidence"]["dev_metric"] == 4.0, executed
         assert executed["frontier"]["frontier"]["selected"]["claimed_by"] == EVIDENCE_AGENT_ID, executed
         assert payload["visible_launch"]["launch_result"]["worker_turn_executed"] is True, payload
+        assert payload["visible_launch"]["launch_result"]["worker_turn_count"] == 3, payload
         assert payload["live_codex_e2e"]["visible_lanes_accepted"] is True, payload
         assert_public_safe(preview)
+        assert_public_safe(curator_executed)
+        assert_public_safe(mapper_executed)
         assert_public_safe(executed)
         assert_public_safe(payload["visible_launch"])
 

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -299,6 +299,11 @@ def register_auto_research_commands(
         help="Local filename for compact public-safe live evidence.",
     )
     worker_turn_parser.add_argument(
+        "--complete-selected-todo",
+        action="store_true",
+        help="After a successful --execute turn, mark the selected LoopX todo done.",
+    )
+    worker_turn_parser.add_argument(
         "--execute",
         action="store_true",
         help="Run the selected worker action. Omit to show the plan from quota/frontier.",
@@ -736,6 +741,7 @@ def handle_auto_research_command(
                 lane_count=args.lane_count,
                 visible_lanes_accepted=args.visible_lanes_accepted,
                 live_evidence_output=args.live_evidence_output,
+                complete_selected_todo=args.complete_selected_todo,
             )
         elif args.auto_research_command == "demo-supervisor":
             payload = build_auto_research_demo_supervisor_plan(

--- a/loopx/capabilities/auto_research/worker_runtime.py
+++ b/loopx/capabilities/auto_research/worker_runtime.py
@@ -12,9 +12,11 @@ from .core import (
     AUTO_RESEARCH_DEFAULT_GOAL_ID,
     AUTO_RESEARCH_DEFAULT_OBJECTIVE,
     AUTO_RESEARCH_QUICKSTART_TEMPLATE,
+    RESEARCH_HYPOTHESIS_SCHEMA_VERSION,
     build_auto_research_quickstart,
     build_live_auto_research_projection,
     load_auto_research_evidence_packet_inputs,
+    validate_research_hypothesis,
 )
 from .live_evidence import (
     LIVE_CODEX_E2E_DEFAULT_OUTPUT,
@@ -25,11 +27,17 @@ from ...paths import resolve_runtime_root
 from ...quota import build_quota_should_run
 from ...rollout_event_log import load_rollout_events, rollout_event_log_path
 from ...status import collect_status
+from ...todos import complete_goal_todo
 
 
 AUTO_RESEARCH_WORKER_TURN_SCHEMA_VERSION = "auto_research_worker_turn_v0"
 AUTO_RESEARCH_WORKER_FRONTIER_SCHEMA_VERSION = "auto_research_worker_frontier_v0"
-SUPPORTED_WORKER_ACTIONS = {"run_dev_eval", "write_evidence"}
+SUPPORTED_WORKER_ACTIONS = {
+    "write_research_contract",
+    "propose_hypothesis",
+    "run_dev_eval",
+    "write_evidence",
+}
 
 AppendEvidence = Callable[[str], dict[str, object]]
 
@@ -42,6 +50,14 @@ def _slug(value: object, *, default: str = "item") -> str:
 def _write_json(path: Path, payload: dict[str, object]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _artifact_summary(kind: str, *, filename: str) -> dict[str, object]:
+    return {
+        "kind": kind,
+        "filename": filename,
+        "paths_are_local_only": True,
+    }
 
 
 def _run_protected_eval(*, pack_dir: Path, split: str, output_path: Path) -> dict[str, object]:
@@ -84,6 +100,117 @@ def _ensure_quickstart_pack(
         cwd=workspace,
     )
     return pack_dir, "created"
+
+
+def _write_contract_artifact(
+    *,
+    pack_dir: Path,
+    output_path: Path,
+    goal_id: str,
+    todo_id: str,
+    agent_id: str,
+) -> dict[str, object]:
+    contract = json.loads((pack_dir / "research_contract.json").read_text(encoding="utf-8"))
+    artifact = {
+        "ok": True,
+        "schema_version": "auto_research_worker_contract_artifact_v0",
+        "goal_id": goal_id,
+        "todo_id": todo_id,
+        "agent_id": agent_id,
+        "research_contract": contract,
+        "summary": {
+            "status": "contract_written",
+            "metric": contract.get("metric"),
+            "promotion_policy": contract.get("promotion_policy"),
+        },
+        "public_boundary": {
+            "raw_logs_recorded": False,
+            "private_artifacts_recorded": False,
+            "absolute_paths_recorded": False,
+        },
+    }
+    _write_json(output_path, artifact)
+    return artifact
+
+
+def _write_hypothesis_artifact(
+    *,
+    output_path: Path,
+    goal_id: str,
+    todo_id: str,
+    agent_id: str,
+) -> dict[str, object]:
+    hypothesis = validate_research_hypothesis(
+        {
+            "schema_version": RESEARCH_HYPOTHESIS_SCHEMA_VERSION,
+            "hypothesis_id": f"hyp_{_slug(todo_id, default='todo')}_partial_selection",
+            "parent_hypothesis_id": "hyp_quickstart_partial_selection",
+            "todo_id": todo_id,
+            "claimed_by": agent_id,
+            "mechanism_family": "partial_selection",
+            "hypothesis": "Use exact partial selection to avoid full distance sorting.",
+            "status": "active",
+            "grounding_refs": ["quickstart:knn_exact_pack"],
+            "blocked_by": [],
+        }
+    )
+    artifact = {
+        "ok": True,
+        "schema_version": "auto_research_worker_hypothesis_artifact_v0",
+        "goal_id": goal_id,
+        "todo_id": todo_id,
+        "agent_id": agent_id,
+        "hypothesis": hypothesis,
+        "summary": {
+            "status": "hypothesis_mapped",
+            "hypothesis_id": hypothesis["hypothesis_id"],
+            "mechanism_family": hypothesis["mechanism_family"],
+        },
+        "public_boundary": {
+            "raw_logs_recorded": False,
+            "private_artifacts_recorded": False,
+            "absolute_paths_recorded": False,
+        },
+    }
+    _write_json(output_path, artifact)
+    return artifact
+
+
+def _complete_selected_todo(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    todo_id: str,
+    agent_id: str,
+    action: str,
+    execute: bool,
+) -> dict[str, object]:
+    if not execute:
+        return {"requested": True, "executed": False}
+    result = complete_goal_todo(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        todo_id=todo_id,
+        role="agent",
+        claimed_by=agent_id,
+        note=f"auto-research worker-turn completed {action}",
+        evidence=(
+            f"worker-turn agent={agent_id} action={action} wrote public-safe local artifact "
+            "and obeyed quota/frontier before completion"
+        ),
+        no_followup=True,
+        side_agent_self_merged=True,
+        dry_run=False,
+    )
+    return {
+        "requested": True,
+        "executed": True,
+        "ok": bool(result.get("ok")),
+        "changed": bool(result.get("changed")),
+        "todo_id": result.get("todo_id"),
+        "status": "done" if result.get("completed") else None,
+        "side_agent_self_merged": bool(result.get("side_agent_self_merged")),
+    }
 
 
 def load_auto_research_worker_frontier(
@@ -163,12 +290,12 @@ def run_auto_research_worker_turn(
     lane_count: int = 1,
     visible_lanes_accepted: bool = False,
     live_evidence_output: str = LIVE_CODEX_E2E_DEFAULT_OUTPUT,
+    complete_selected_todo: bool = False,
 ) -> dict[str, object]:
     """Run one LoopX-selected visible worker action.
 
     The worker does not choose its own work. It reads quota/frontier, checks the
-    selected action, then performs only the small public k-NN dev-eval evidence
-    turn that the visible auto-research demo currently needs.
+    selected action, then performs one small public-safe research turn.
     """
 
     workspace = workspace.resolve()
@@ -214,10 +341,11 @@ def run_auto_research_worker_turn(
             "agent_id": agent_id,
             "selected_todo_id": todo_id,
             "selected_action": action,
-            "would_execute": "quickstart_dev_eval_then_append_public_evidence",
+            "would_execute": action,
+            "completion": {"requested": complete_selected_todo, "executed": False},
             "frontier": frontier_packet,
         }
-    if append_evidence is None:
+    if action in {"run_dev_eval", "write_evidence"} and append_evidence is None:
         raise ValueError("execute requires an append_evidence callback")
 
     pack_dir, pack_mode = _ensure_quickstart_pack(
@@ -228,10 +356,96 @@ def run_auto_research_worker_turn(
         objective=objective,
     )
     run_dir = workspace / evidence_dir / _slug(agent_id, default="agent") / _slug(todo_id, default="todo")
+    contract_artifact_path = run_dir / "research-contract.public.json"
+    hypothesis_artifact_path = run_dir / "hypothesis.public.json"
     dev_result_path = run_dir / "dev-result.public.json"
     evidence_packet_path = run_dir / "evidence.public.json"
     append_result_path = run_dir / "append-result.public.json"
     live_evidence_path = run_dir / live_evidence_output
+
+    if action == "write_research_contract":
+        artifact = _write_contract_artifact(
+            pack_dir=pack_dir,
+            output_path=contract_artifact_path,
+            goal_id=goal_id,
+            todo_id=todo_id,
+            agent_id=agent_id,
+        )
+        completion = (
+            _complete_selected_todo(
+                registry_path=registry_path,
+                goal_id=goal_id,
+                todo_id=todo_id,
+                agent_id=agent_id,
+                action=action,
+                execute=True,
+            )
+            if complete_selected_todo
+            else {"requested": False}
+        )
+        return {
+            "ok": True,
+            "schema_version": AUTO_RESEARCH_WORKER_TURN_SCHEMA_VERSION,
+            "mode": "execute",
+            "goal_id": goal_id,
+            "agent_id": agent_id,
+            "selected_todo_id": todo_id,
+            "selected_action": action,
+            "executed": True,
+            "pack_mode": pack_mode,
+            "artifact": _artifact_summary("research_contract", filename="research-contract.public.json"),
+            "artifact_status": artifact["summary"]["status"],
+            "completion": completion,
+            "frontier": frontier_packet,
+            "public_boundary": {
+                "raw_logs_recorded": False,
+                "private_artifacts_recorded": False,
+                "absolute_paths_recorded": False,
+                "credentials_recorded": False,
+            },
+        }
+
+    if action == "propose_hypothesis":
+        artifact = _write_hypothesis_artifact(
+            output_path=hypothesis_artifact_path,
+            goal_id=goal_id,
+            todo_id=todo_id,
+            agent_id=agent_id,
+        )
+        completion = (
+            _complete_selected_todo(
+                registry_path=registry_path,
+                goal_id=goal_id,
+                todo_id=todo_id,
+                agent_id=agent_id,
+                action=action,
+                execute=True,
+            )
+            if complete_selected_todo
+            else {"requested": False}
+        )
+        return {
+            "ok": True,
+            "schema_version": AUTO_RESEARCH_WORKER_TURN_SCHEMA_VERSION,
+            "mode": "execute",
+            "goal_id": goal_id,
+            "agent_id": agent_id,
+            "selected_todo_id": todo_id,
+            "selected_action": action,
+            "executed": True,
+            "pack_mode": pack_mode,
+            "artifact": _artifact_summary("research_hypothesis", filename="hypothesis.public.json"),
+            "artifact_status": artifact["summary"]["status"],
+            "hypothesis_id": artifact["summary"]["hypothesis_id"],
+            "completion": completion,
+            "frontier": frontier_packet,
+            "public_boundary": {
+                "raw_logs_recorded": False,
+                "private_artifacts_recorded": False,
+                "absolute_paths_recorded": False,
+                "credentials_recorded": False,
+            },
+        }
 
     dev_result = _run_protected_eval(pack_dir=pack_dir, split="dev", output_path=dev_result_path)
     packet = load_auto_research_evidence_packet_inputs(
@@ -266,6 +480,18 @@ def run_auto_research_worker_turn(
         if isinstance(live_evidence, dict) and isinstance(live_evidence.get("lane_evidence"), dict)
         else {}
     )
+    completion = (
+        _complete_selected_todo(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            todo_id=todo_id,
+            agent_id=agent_id,
+            action=action,
+            execute=True,
+        )
+        if complete_selected_todo
+        else {"requested": False}
+    )
     return {
         "ok": True,
         "schema_version": AUTO_RESEARCH_WORKER_TURN_SCHEMA_VERSION,
@@ -297,6 +523,7 @@ def run_auto_research_worker_turn(
             "append_result": "append-result.public.json",
             "live_evidence": live_evidence_output if live_evidence else None,
         },
+        "completion": completion,
         "frontier": frontier_packet,
         "public_boundary": {
             "raw_logs_recorded": False,


### PR DESCRIPTION
## Summary
- extend `auto-research worker-turn` beyond evidence-only execution to support curator contract and mapper hypothesis turns
- add `--complete-selected-todo` so a successful worker turn can write back the selected LoopX todo completion
- update the worker-turn smoke to run curator, mapper, and evidence-runner turns through the CLI against a demo-local LoopX queue

## Validation
- `python3 -m py_compile loopx/capabilities/auto_research/worker_runtime.py loopx/capabilities/auto_research/cli.py examples/auto-research-worker-turn-smoke.py`
- `python3 examples/auto-research-worker-turn-smoke.py`
- `python3 examples/auto-research-demo-e2e-smoke.py`
- `python3 examples/auto-research-one-click-ux-smoke.py`
- `python3 examples/auto-research-demo-supervisor-smoke.py`
- `python3 examples/auto-research-visible-launcher-smoke.py`
- `python3 examples/auto-research-live-evidence-capture-smoke.py`
- `python3 examples/auto-research-skill-contract-smoke.py`
- `loopx check` (existing duplicate-index warning only)

## Boundary
- no raw logs, private artifacts, absolute local paths, or credentials are recorded in public outputs
- this does not claim fully autonomous visible Codex multi-round research yet; it adds the minimal role-compatible worker-turn chain needed for that next step