### PR TITLE
Wire visible auto-research lanes to worker turns

### DIFF
--- a/examples/auto-research-demo-supervisor-smoke.py
+++ b/examples/auto-research-demo-supervisor-smoke.py
@@ -109,6 +109,10 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
         assert "You are a visible LoopX auto-research lane" in lane["bootstrap_message"], lane
         assert "Do not run loopx bootstrap-command-pack" in lane["bootstrap_message"], lane
         assert "codex-cli-bootstrap-message" not in lane["bootstrap_message"], lane
+        assert "Minimal live worker-turn path" in lane["bootstrap_message"], lane
+        assert "auto-research worker-turn" in lane["bootstrap_message"], lane
+        assert "--complete-selected-todo" in lane["bootstrap_message"], lane
+        assert "$LOOPX_PANE_LOOPX" in lane["bootstrap_message"], lane
         assert "[LoopX role profile]" in lane["visible_launch_command"], lane
         assert "[LoopX visible acceptance]" in lane["visible_launch_command"], lane
         assert "LOOPX_GOAL_ID" in lane["visible_launch_command"], lane
@@ -130,6 +134,14 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
         assert lane["lane_timeline"][0]["command_ref"] == "role_profile", lane
         assert lane["lane_timeline"][1]["command_ref"] == "quota_guard", lane
         assert "operator is attached" in lane["lane_timeline"][-1]["continue_when"], lane
+    expected_action_hints = {
+        "research_curator": "`write_research_contract`",
+        "hypothesis_mapper": "`propose_hypothesis`",
+        "evidence_runner": "`run_dev_eval` or `write_evidence`",
+        "evidence_verifier": "`classify_evidence` or `write_evaluation_summary`",
+    }
+    for lane in lanes:
+        assert expected_action_hints[lane["role_id"]] in lane["bootstrap_message"], lane
 
     start_script = "\n".join(payload["commands"]["start_script"])
     assert "tmux new-session" in start_script, start_script

--- a/examples/auto-research-one-click-ux-smoke.py
+++ b/examples/auto-research-one-click-ux-smoke.py
@@ -129,6 +129,10 @@ def main() -> int:
             assert "codex-cli-bootstrap-message" not in bootstrap, lane
             assert "generic LoopX heartbeat worker" in bootstrap, lane
             assert "loopx-auto-research" in bootstrap, lane
+            assert "Minimal live worker-turn path" in bootstrap, lane
+            assert "auto-research worker-turn" in bootstrap, lane
+            assert "--complete-selected-todo" in bootstrap, lane
+            assert "$LOOPX_PANE_LOOPX" in bootstrap, lane
             assert "append-result.public.json" in bootstrap, lane
             assert "capture-live-evidence" in bootstrap, lane
             assert "live-codex-e2e-evidence.public.json" in bootstrap, lane

--- a/examples/auto-research-worker-turn-smoke.py
+++ b/examples/auto-research-worker-turn-smoke.py
@@ -17,12 +17,21 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.capabilities.auto_research.demo_e2e import run_auto_research_demo_e2e  # noqa: E402
+from loopx.capabilities.auto_research.demo_e2e import _seed_visible_demo_control_plane  # noqa: E402
+from loopx.capabilities.auto_research import build_auto_research_demo_supervisor_plan  # noqa: E402
 
 
 GOAL_ID = "loopx-auto-research-knn"
 CURATOR_AGENT_ID = "codex-product-capability"
 MAPPER_AGENT_ID = "codex-side-bypass"
 EVIDENCE_AGENT_ID = "codex-main-control"
+VERIFIER_AGENT_ID = "codex-value-explorer"
+FOUR_LANES = [
+    "codex-product-capability:research-curator:research_curator",
+    "codex-side-bypass:hypothesis-mapper:hypothesis_mapper",
+    "codex-main-control:evidence-runner:evidence_runner",
+    "codex-value-explorer:evidence-verifier:evidence_verifier",
+]
 
 
 def assert_public_safe(payload: Any) -> None:
@@ -254,6 +263,45 @@ def main() -> int:
         assert_public_safe(mapper_executed)
         assert_public_safe(executed)
         assert_public_safe(payload["visible_launch"])
+
+        supervisor = build_auto_research_demo_supervisor_plan(
+            goal_id=GOAL_ID,
+            agent_specs=FOUR_LANES,
+            reasoning_effort="high",
+        )
+        four_lane_root = temp / "four-lane-queue"
+        _summary, four_registry, four_runtime_root = _seed_visible_demo_control_plane(
+            demo_root=four_lane_root,
+            goal_id=GOAL_ID,
+            objective="Prove every visible auto-research role can run one LoopX-selected worker turn.",
+            supervisor=supervisor,
+        )
+        four_workspace = four_lane_root / "visible-control-plane"
+        for agent in [CURATOR_AGENT_ID, MAPPER_AGENT_ID, EVIDENCE_AGENT_ID]:
+            run_worker_turn(
+                registry=four_registry,
+                runtime_root=four_runtime_root,
+                workspace=four_workspace,
+                agent_id=agent,
+                execute=True,
+                complete=True,
+            )
+        verifier = run_worker_turn(
+            registry=four_registry,
+            runtime_root=four_runtime_root,
+            workspace=four_workspace,
+            agent_id=VERIFIER_AGENT_ID,
+            execute=True,
+            complete=True,
+        )
+        assert verifier["schema_version"] == "auto_research_worker_turn_v0", verifier
+        assert verifier["mode"] == "execute", verifier
+        assert verifier["selected_action"] == "classify_evidence", verifier
+        assert verifier["artifact"]["kind"] == "evaluation_summary", verifier
+        assert verifier["artifact_status"] == "evaluation_summary_written", verifier
+        assert verifier["completion"]["status"] == "done", verifier
+        assert verifier["promotion_decision_made"] is False, verifier
+        assert_public_safe(verifier)
 
     print("auto-research-worker-turn-smoke ok")
     return 0

--- a/loopx/capabilities/auto_research/legacy_core.py
+++ b/loopx/capabilities/auto_research/legacy_core.py
@@ -936,18 +936,24 @@ def _auto_research_codex_bootstrap_prompt(
     stop_conditions = _compact_prompt_list(role_profile.get("stop_conditions"))
     effort = _compact_public_token(reasoning_effort, field="bootstrap.reasoning_effort")
     goal = _compact_public_token(goal_id, field="bootstrap.goal_id")
-    role_specific_steps: list[str] = []
-    if role_id == "evidence_runner":
-        role_specific_steps = [
-            "",
-            "Evidence runner minimal live demo path:",
-            "1. Confirm the selected frontier action is `run_dev_eval` or `write_evidence` for this agent.",
-            "2. Preview the real LoopX-selected worker turn:",
-            "   `loopx --format json auto-research worker-turn --goal-id \"$LOOPX_GOAL_ID\" --agent-id \"$LOOPX_AGENT_ID\"`",
-            "3. Execute the same worker turn only when the preview selected this lane:",
-            "   `loopx --format json auto-research worker-turn --goal-id \"$LOOPX_GOAL_ID\" --agent-id \"$LOOPX_AGENT_ID\" --lane-count \"${LOOPX_VISIBLE_LANE_COUNT:-1}\" --visible-lanes-accepted --execute`",
-            "4. Complete only the selected todo after worker-turn reports executed=true, appended evidence, and live_evidence.written=true.",
-        ]
+    expected_actions_by_role = {
+        "research_curator": "`write_research_contract`",
+        "hypothesis_mapper": "`propose_hypothesis`",
+        "evidence_runner": "`run_dev_eval` or `write_evidence`",
+        "evidence_verifier": "`classify_evidence` or `write_evaluation_summary`",
+    }
+    expected_actions = expected_actions_by_role.get(role_id, "one allowed action from this role profile")
+    role_specific_steps: list[str] = [
+        "",
+        "Minimal live worker-turn path:",
+        f"1. Confirm the selected frontier action matches this role ({expected_actions}).",
+        "2. Preview the real LoopX-selected worker turn:",
+        "   `\"$LOOPX_PANE_LOOPX\" --format json auto-research worker-turn --goal-id \"$LOOPX_GOAL_ID\" --agent-id \"$LOOPX_AGENT_ID\"`",
+        "3. Execute the same worker turn only when the preview selected this lane:",
+        "   `\"$LOOPX_PANE_LOOPX\" --format json auto-research worker-turn --goal-id \"$LOOPX_GOAL_ID\" --agent-id \"$LOOPX_AGENT_ID\" --lane-count \"${LOOPX_VISIBLE_LANE_COUNT:-1}\" --visible-lanes-accepted --complete-selected-todo --execute`",
+        "4. Stop after worker-turn reports executed=true and completion.status=done.",
+        "5. For evidence-runner, additionally require appended evidence and live_evidence.written=true.",
+    ]
     return "\n".join(
         [
             "You are a visible LoopX auto-research lane, not a generic LoopX heartbeat worker.",

--- a/loopx/capabilities/auto_research/worker_runtime.py
+++ b/loopx/capabilities/auto_research/worker_runtime.py
@@ -15,6 +15,8 @@ from .core import (
     RESEARCH_HYPOTHESIS_SCHEMA_VERSION,
     build_auto_research_quickstart,
     build_live_auto_research_projection,
+    build_research_decision_candidates,
+    build_research_evidence_graph_from_rollout_events,
     load_auto_research_evidence_packet_inputs,
     validate_research_hypothesis,
 )
@@ -37,6 +39,8 @@ SUPPORTED_WORKER_ACTIONS = {
     "propose_hypothesis",
     "run_dev_eval",
     "write_evidence",
+    "classify_evidence",
+    "write_evaluation_summary",
 }
 
 AppendEvidence = Callable[[str], dict[str, object]]
@@ -167,6 +171,59 @@ def _write_hypothesis_artifact(
             "mechanism_family": hypothesis["mechanism_family"],
         },
         "public_boundary": {
+            "raw_logs_recorded": False,
+            "private_artifacts_recorded": False,
+            "absolute_paths_recorded": False,
+        },
+    }
+    _write_json(output_path, artifact)
+    return artifact
+
+
+def _write_evaluation_summary_artifact(
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    output_path: Path,
+    goal_id: str,
+    todo_id: str,
+    agent_id: str,
+) -> dict[str, object]:
+    registry = load_registry(registry_path)
+    runtime_root = resolve_runtime_root(registry, runtime_root_arg)
+    rollout_events = load_rollout_events(rollout_event_log_path(runtime_root, goal_id))
+    graph = build_research_evidence_graph_from_rollout_events(
+        goal_id=goal_id,
+        rollout_events=rollout_events,
+    )
+    decisions = build_research_decision_candidates(graph)
+    artifact = {
+        "ok": True,
+        "schema_version": "auto_research_worker_evaluation_summary_v0",
+        "goal_id": goal_id,
+        "todo_id": todo_id,
+        "agent_id": agent_id,
+        "evidence_graph_summary": {
+            "event_count": graph.get("event_count"),
+            "hypothesis_count": graph.get("hypothesis_count"),
+            "best_dev_metric": graph.get("best_dev_metric"),
+            "best_holdout_metric": graph.get("best_holdout_metric"),
+            "holdout_improved": graph.get("holdout_improved"),
+            "negative_evidence_count": graph.get("negative_evidence_count"),
+        },
+        "decision_summary": {
+            "dev_promotion_candidate_count": len(decisions.get("dev_promotion_candidates") or []),
+            "validated_promotion_candidate_count": len(decisions.get("validated_promotion_candidates") or []),
+            "promotion_candidate_count": len(decisions.get("promotion_candidates") or []),
+            "retirement_candidate_count": len(decisions.get("retirement_candidates") or []),
+        },
+        "summary": {
+            "status": "evaluation_summary_written",
+            "claim_allowed": bool(decisions.get("validated_promotion_candidates")),
+            "promotion_decision_made": False,
+        },
+        "public_boundary": {
+            "source": "loopx_rollout_event_log",
             "raw_logs_recorded": False,
             "private_artifacts_recorded": False,
             "absolute_paths_recorded": False,
@@ -358,6 +415,7 @@ def run_auto_research_worker_turn(
     run_dir = workspace / evidence_dir / _slug(agent_id, default="agent") / _slug(todo_id, default="todo")
     contract_artifact_path = run_dir / "research-contract.public.json"
     hypothesis_artifact_path = run_dir / "hypothesis.public.json"
+    evaluation_summary_path = run_dir / "evaluation-summary.public.json"
     dev_result_path = run_dir / "dev-result.public.json"
     evidence_packet_path = run_dir / "evidence.public.json"
     append_result_path = run_dir / "append-result.public.json"
@@ -437,6 +495,51 @@ def run_auto_research_worker_turn(
             "artifact": _artifact_summary("research_hypothesis", filename="hypothesis.public.json"),
             "artifact_status": artifact["summary"]["status"],
             "hypothesis_id": artifact["summary"]["hypothesis_id"],
+            "completion": completion,
+            "frontier": frontier_packet,
+            "public_boundary": {
+                "raw_logs_recorded": False,
+                "private_artifacts_recorded": False,
+                "absolute_paths_recorded": False,
+                "credentials_recorded": False,
+            },
+        }
+
+    if action in {"classify_evidence", "write_evaluation_summary"}:
+        artifact = _write_evaluation_summary_artifact(
+            registry_path=registry_path,
+            runtime_root_arg=runtime_root_arg,
+            output_path=evaluation_summary_path,
+            goal_id=goal_id,
+            todo_id=todo_id,
+            agent_id=agent_id,
+        )
+        completion = (
+            _complete_selected_todo(
+                registry_path=registry_path,
+                goal_id=goal_id,
+                todo_id=todo_id,
+                agent_id=agent_id,
+                action=action,
+                execute=True,
+            )
+            if complete_selected_todo
+            else {"requested": False}
+        )
+        return {
+            "ok": True,
+            "schema_version": AUTO_RESEARCH_WORKER_TURN_SCHEMA_VERSION,
+            "mode": "execute",
+            "goal_id": goal_id,
+            "agent_id": agent_id,
+            "selected_todo_id": todo_id,
+            "selected_action": action,
+            "executed": True,
+            "pack_mode": pack_mode,
+            "artifact": _artifact_summary("evaluation_summary", filename="evaluation-summary.public.json"),
+            "artifact_status": artifact["summary"]["status"],
+            "claim_allowed": artifact["summary"]["claim_allowed"],
+            "promotion_decision_made": artifact["summary"]["promotion_decision_made"],
             "completion": completion,
             "frontier": frontier_packet,
             "public_boundary": {


### PR DESCRIPTION
## Summary
- route visible auto-research bootstrap prompts for curator, mapper, runner, and verifier through `auto-research worker-turn`
- add verifier worker-turn support for `classify_evidence` / `write_evaluation_summary` using the rollout evidence graph
- extend smokes so the 4-lane queue proves each role can run a LoopX-selected worker turn and write back its selected todo

## Validation
- `python3 -m py_compile loopx/capabilities/auto_research/worker_runtime.py loopx/capabilities/auto_research/legacy_core.py examples/auto-research-worker-turn-smoke.py examples/auto-research-demo-supervisor-smoke.py examples/auto-research-one-click-ux-smoke.py`
- `python3 examples/auto-research-demo-supervisor-smoke.py`
- `python3 examples/auto-research-one-click-ux-smoke.py`
- `python3 examples/auto-research-worker-turn-smoke.py`
- `python3 examples/auto-research-demo-e2e-smoke.py`
- `python3 examples/auto-research-visible-launcher-smoke.py`
- `python3 examples/auto-research-live-evidence-capture-smoke.py`
- `python3 examples/auto-research-skill-contract-smoke.py`
- `loopx check` (existing duplicate-index warning only)

## Boundary
- verifier summary is read-only over public-safe rollout evidence and does not make promotion decisions
- no raw logs, private artifacts, absolute local paths, or credentials are recorded
- this is a step toward truthful visible-worker multi-round proof, not the final live Codex autonomous multi-round claim