### PR TITLE
Add benchmark run ledger merge command

### DIFF
--- a/examples/benchmark-run-ledger-smoke.py
+++ b/examples/benchmark-run-ledger-smoke.py
@@ -20,6 +20,7 @@ from loopx.benchmark_ledger import (  # noqa: E402
     BENCHMARK_RUN_LEDGER_SCHEMA_VERSION,
     build_benchmark_run_ledger_entry,
     load_benchmark_run_ledger,
+    merge_benchmark_run_ledgers,
     render_benchmark_run_ledger_markdown,
     update_benchmark_run_ledger,
 )
@@ -1800,6 +1801,80 @@ def test_ledger_artifact_refs_do_not_record_private_local_paths() -> None:
         assert "`benchmark_run.compact.json`" in rendered, rendered
 
 
+def test_ledger_merge_combines_run_group_ledgers_without_source_paths() -> None:
+    def skillsbench_compact(case_id: str, *, score: float, run_id: str) -> dict[str, Any]:
+        return {
+            "schema_version": "benchmark_run_v0",
+            "run_id": run_id,
+            "benchmark_id": "skillsbench@1.1",
+            "case_id": case_id,
+            "case_ids": [case_id],
+            "mode": "skillsbench_codex_app_server_goal_baseline",
+            "arm_id": "codex_app_server_goal_baseline",
+            "route": "codex-app-server-goal-baseline",
+            "official_task_score": {
+                "kind": "skillsbench_reward",
+                "value": score,
+                "passed": score >= 1.0,
+            },
+            "score_failure_attribution": (
+                "none" if score >= 1.0 else "official_verifier_solution_failure"
+            ),
+            "round_reward_trace": {
+                "records": [{"agent_round": 1, "reward": score, "passed": score >= 1.0}],
+                "first_success_round": 1 if score >= 1.0 else None,
+                "success_observed": score >= 1.0,
+                "max_rounds_budget": 10,
+                "official_feedback_blinded": True,
+                "reward_feedback_forwarded": False,
+            },
+        }
+
+    with tempfile.TemporaryDirectory(prefix="benchmark-run-ledger-merge-") as tmp:
+        root = Path(tmp)
+        source_a = root / "batch-a" / "benchmark-run-ledger.json"
+        source_b = root / "batch-b" / "benchmark-run-ledger.json"
+        target = root / "current" / "benchmark-run-ledger.json"
+        update_benchmark_run_ledger(
+            ledger_path=source_a,
+            benchmark_run=skillsbench_compact("alpha-case", score=1.0, run_id="run-alpha"),
+            run_group_id="skillsbench-revtunnel-appgoal-batch5-alpha",
+        )
+        update_benchmark_run_ledger(
+            ledger_path=source_b,
+            benchmark_run=skillsbench_compact("beta-case", score=0.0, run_id="run-beta"),
+            run_group_id="skillsbench-revtunnel-appgoal-batch5-beta",
+        )
+        dry_run = merge_benchmark_run_ledgers(
+            target_ledger_path=target,
+            source_ledger_paths=[source_a, source_b],
+            benchmark_ids=["skillsbench@1.1"],
+            run_group_contains=["batch5"],
+            dry_run=True,
+        )
+        assert dry_run["merge"]["updated"] is False, dry_run
+        assert target.exists() is False, "dry-run must not write the target ledger"
+
+        merged = merge_benchmark_run_ledgers(
+            target_ledger_path=target,
+            source_ledger_paths=[source_a, source_b, source_a],
+            benchmark_ids=["skillsbench@1.1"],
+            run_group_contains=["batch5"],
+            dry_run=False,
+        )
+        assert merged["merge"]["source_ledger_count"] == 2, merged
+        assert merged["merge"]["merged_run_count"] == 2, merged
+        assert merged["merge"]["new_run_id_count"] == 2, merged
+        assert merged["merge"]["source_paths_recorded"] is False, merged
+        serialized_merge = json.dumps(merged, sort_keys=True)
+        assert "source-run-ledger" not in serialized_merge, serialized_merge
+
+        ledger = load_benchmark_run_ledger(target)
+        cases = ledger["benchmarks"]["skillsbench@1.1"]["cases"]
+        assert set(cases) == {"alpha-case", "beta-case"}, cases
+        assert (root / "current" / "benchmark-run-ledger.md").exists()
+
+
 if __name__ == "__main__":
     test_ledger_entry_upsert_from_compact_run()
     test_ledger_classifies_compact_trial_exception_failure()
@@ -1822,4 +1897,5 @@ if __name__ == "__main__":
     test_cli_post_launch_json_updates_run_ledger()
     test_cli_run_ledger_archive_hides_old_skillsbench_rows_from_current_view()
     test_ledger_artifact_refs_do_not_record_private_local_paths()
+    test_ledger_merge_combines_run_group_ledgers_without_source_paths()
     print("benchmark-run-ledger-smoke: ok")

--- a/examples/cli-benchmark-run-ledger-command-modularization-smoke.py
+++ b/examples/cli-benchmark-run-ledger-command-modularization-smoke.py
@@ -45,6 +45,11 @@ def main() -> int:
         raise AssertionError(help_result.stderr or help_result.stdout)
     assert_contains(help_result.stdout, "--update-run-ledger")
     assert_contains(help_result.stdout, "--skillsbench-route")
+    merge_help_result = run_cli("benchmark", "run-ledger-merge", "--help")
+    if merge_help_result.returncode != 0:
+        raise AssertionError(merge_help_result.stderr or merge_help_result.stdout)
+    assert_contains(merge_help_result.stdout, "--source-run-ledger-path")
+    assert_contains(merge_help_result.stdout, "--source-run-ledger-glob")
 
     terminal_result = run_cli(
         "--format",
@@ -270,6 +275,80 @@ def main() -> int:
             raise AssertionError(check_payload)
         if check_payload["read_boundary"].get("upload_invoked") is not False:
             raise AssertionError(check_payload)
+
+        def compact_source_ledger(case_id: str, run_id: str) -> dict[str, object]:
+            return {
+                "schema_version": "benchmark_run_ledger_v0",
+                "benchmarks": {
+                    "skillsbench@1.1": {
+                        "cases": {
+                            case_id: {
+                                "case_id": case_id,
+                                "runs": [
+                                    {
+                                        "run_id": run_id,
+                                        "benchmark_id": "skillsbench@1.1",
+                                        "case_id": case_id,
+                                        "arm_id": "codex_app_server_goal_baseline",
+                                        "mode": "skillsbench_codex_app_server_goal_baseline",
+                                        "run_group_id": (
+                                            "skillsbench-revtunnel-appgoal-batch5-smoke"
+                                        ),
+                                        "official_score": 0.0,
+                                        "official_passed": False,
+                                        "failure_class": (
+                                            "official_verifier_solution_failure"
+                                        ),
+                                    }
+                                ],
+                            }
+                        }
+                    }
+                },
+            }
+
+        source_a = temp_root / "source-a" / "benchmark-run-ledger.json"
+        source_b = temp_root / "source-b" / "benchmark-run-ledger.json"
+        source_a.parent.mkdir(parents=True)
+        source_b.parent.mkdir(parents=True)
+        source_a.write_text(
+            json.dumps(compact_source_ledger("merge-alpha", "merge-run-alpha")),
+            encoding="utf-8",
+        )
+        source_b.write_text(
+            json.dumps(compact_source_ledger("merge-beta", "merge-run-beta")),
+            encoding="utf-8",
+        )
+        merged_ledger = temp_root / "merged" / "benchmark-run-ledger.json"
+        merge_result = run_cli(
+            "--format",
+            "json",
+            "benchmark",
+            "run-ledger-merge",
+            "--run-ledger-path",
+            str(merged_ledger),
+            "--source-run-ledger-path",
+            str(source_a),
+            "--source-run-ledger-path",
+            str(source_b),
+            "--benchmark-id",
+            "skillsbench@1.1",
+            "--run-group-contains",
+            "batch5",
+            "--execute",
+        )
+        if merge_result.returncode != 0:
+            raise AssertionError(merge_result.stderr or merge_result.stdout)
+        merge_payload = payload_from(merge_result)
+        if merge_payload.get("ok") is not True:
+            raise AssertionError(merge_payload)
+        merge_summary = merge_payload["merge"]
+        if merge_summary.get("source_paths_recorded") is not False:
+            raise AssertionError(merge_payload)
+        if merge_summary.get("merged_run_count") != 2:
+            raise AssertionError(merge_payload)
+        if str(source_a) in merge_result.stdout or str(source_b) in merge_result.stdout:
+            raise AssertionError(merge_result.stdout)
 
     print("cli-benchmark-run-ledger-command-modularization-smoke: ok")
     return 0

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -2755,6 +2755,147 @@ def _iter_ledger_runs(ledger: dict[str, Any]) -> list[dict[str, Any]]:
     return runs
 
 
+def merge_benchmark_run_ledgers(
+    *,
+    target_ledger_path: str | Path,
+    source_ledger_paths: list[str | Path],
+    benchmark_ids: list[str] | None = None,
+    run_group_contains: list[str] | None = None,
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Merge public benchmark_run_ledger_v0 files into one canonical ledger."""
+
+    if not source_ledger_paths:
+        raise ValueError("at least one source benchmark run ledger is required")
+    target_path = Path(target_ledger_path).expanduser()
+    markdown_path = target_path.with_suffix(".md")
+    benchmark_filter = {
+        _compact_text(value, limit=120)
+        for value in (benchmark_ids or [])
+        if _compact_text(value, limit=120)
+    }
+    run_group_filters = [
+        _compact_text(value, limit=160)
+        for value in (run_group_contains or [])
+        if _compact_text(value, limit=160)
+    ]
+    unique_sources: list[Path] = []
+    seen_sources: set[str] = set()
+    for source in source_ledger_paths:
+        source_path = Path(source).expanduser()
+        source_key = str(source_path.resolve(strict=False))
+        if source_key in seen_sources:
+            continue
+        seen_sources.add(source_key)
+        unique_sources.append(source_path)
+
+    def apply_merge(start_ledger: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+        updated = _normalize_benchmark_run_ledger(dict(start_ledger))
+        before_run_ids = {
+            _compact_text(run.get("run_id"), limit=80)
+            for run in _iter_ledger_runs(updated)
+            if _compact_text(run.get("run_id"), limit=80)
+        }
+        before_signatures = {_ledger_entry_signature(run) for run in _iter_ledger_runs(updated)}
+        source_ledger_count = 0
+        missing_source_count = 0
+        source_run_count = 0
+        considered_run_count = 0
+        merged_run_count = 0
+        skipped_run_count = 0
+        skipped_by_reason: dict[str, int] = {}
+
+        def skip(reason: str) -> None:
+            nonlocal skipped_run_count
+            skipped_run_count += 1
+            skipped_by_reason[reason] = skipped_by_reason.get(reason, 0) + 1
+
+        for source_path in unique_sources:
+            if not source_path.exists():
+                missing_source_count += 1
+                continue
+            source_ledger_count += 1
+            source_ledger = load_benchmark_run_ledger(source_path)
+            for run in _iter_ledger_runs(source_ledger):
+                if not isinstance(run, dict):
+                    continue
+                source_run_count += 1
+                benchmark_id = _compact_text(run.get("benchmark_id"), limit=120)
+                if benchmark_filter and benchmark_id not in benchmark_filter:
+                    skip("benchmark_filter")
+                    continue
+                run_group_id = _compact_text(run.get("run_group_id"), limit=160)
+                if run_group_filters and not any(
+                    token in run_group_id for token in run_group_filters
+                ):
+                    skip("run_group_filter")
+                    continue
+                if not _entry_is_public_ledger_closeout(run):
+                    skip("non_terminal")
+                    continue
+                considered_run_count += 1
+                updated = upsert_benchmark_run_ledger_entry(updated, dict(run))
+                merged_run_count += 1
+
+        updated = _normalize_benchmark_run_ledger(updated)
+        after_runs = _iter_ledger_runs(updated)
+        after_run_ids = {
+            _compact_text(run.get("run_id"), limit=80)
+            for run in after_runs
+            if _compact_text(run.get("run_id"), limit=80)
+        }
+        after_signatures = {_ledger_entry_signature(run) for run in after_runs}
+        summary = {
+            "schema_version": "benchmark_run_ledger_merge_v0",
+            "ok": True,
+            "dry_run": dry_run,
+            "updated": not dry_run,
+            "ledger_path": str(target_path),
+            "markdown_path": str(markdown_path),
+            "source_ledger_count": source_ledger_count,
+            "missing_source_count": missing_source_count,
+            "source_run_count": source_run_count,
+            "considered_run_count": considered_run_count,
+            "merged_run_count": merged_run_count,
+            "new_run_id_count": len(after_run_ids - before_run_ids),
+            "new_signature_count": len(after_signatures - before_signatures),
+            "target_run_count": len(after_runs),
+            "skipped_run_count": skipped_run_count,
+            "skipped_by_reason": skipped_by_reason,
+            "benchmark_ids": sorted(benchmark_filter),
+            "run_group_contains": run_group_filters,
+            "source_paths_recorded": False,
+        }
+        return updated, summary
+
+    if dry_run:
+        _, summary = apply_merge(load_benchmark_run_ledger(target_path))
+    else:
+        with _LedgerWriteLock(target_path):
+            updated, summary = apply_merge(load_benchmark_run_ledger(target_path))
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = target_path.with_suffix(target_path.suffix + ".tmp")
+            tmp_markdown_path = markdown_path.with_suffix(markdown_path.suffix + ".tmp")
+            tmp_path.write_text(
+                json.dumps(updated, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            tmp_markdown_path.write_text(
+                render_benchmark_run_ledger_markdown(updated),
+                encoding="utf-8",
+            )
+            tmp_path.replace(target_path)
+            tmp_markdown_path.replace(markdown_path)
+    return {
+        "ok": True,
+        "dry_run": dry_run,
+        "updated": not dry_run,
+        "ledger_path": str(target_path),
+        "markdown_path": str(markdown_path),
+        "merge": summary,
+    }
+
+
 def _history_benchmark_run(record: dict[str, Any]) -> dict[str, Any] | None:
     if record.get("schema_version") == "benchmark_run_v0":
         return record

--- a/loopx/cli_commands/benchmark_run_ledger_maintenance.py
+++ b/loopx/cli_commands/benchmark_run_ledger_maintenance.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import glob
 import json
 import sys
 from collections.abc import Callable
@@ -11,6 +12,7 @@ from ..benchmark_ledger import (
     archive_benchmark_run_ledger_runs,
     check_benchmark_run_ledger_drift,
     load_benchmark_run_ledger,
+    merge_benchmark_run_ledgers,
     update_benchmark_run_ledger,
 )
 from ..history import collect_history, load_registry
@@ -30,6 +32,7 @@ OutputFormat = Callable[[argparse.Namespace], str]
 BENCHMARK_RUN_LEDGER_MAINTENANCE_COMMANDS = {
     "run-ledger-archive",
     "run-ledger-check",
+    "run-ledger-merge",
     "run-ledger-upsert",
 }
 
@@ -186,6 +189,38 @@ def render_benchmark_run_ledger_archive_markdown(payload: dict[str, object]) -> 
     return "\n".join(lines) + "\n"
 
 
+def render_benchmark_run_ledger_merge_markdown(payload: dict[str, object]) -> str:
+    merge = payload.get("merge") if isinstance(payload.get("merge"), dict) else {}
+    read_boundary = (
+        payload.get("read_boundary")
+        if isinstance(payload.get("read_boundary"), dict)
+        else {}
+    )
+    lines = [
+        "# Benchmark Run Ledger Merge",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- dry_run: `{payload.get('dry_run')}`",
+        f"- updated: `{payload.get('updated')}`",
+        f"- source_ledger_count: `{merge.get('source_ledger_count')}`",
+        f"- source_run_count: `{merge.get('source_run_count')}`",
+        f"- considered_run_count: `{merge.get('considered_run_count')}`",
+        f"- merged_run_count: `{merge.get('merged_run_count')}`",
+        f"- new_run_id_count: `{merge.get('new_run_id_count')}`",
+        f"- target_run_count: `{merge.get('target_run_count')}`",
+        f"- source paths recorded: `{merge.get('source_paths_recorded')}`",
+        f"- ledger: `{payload.get('ledger_path')}`",
+        f"- compact only: `{read_boundary.get('compact_only')}`",
+        f"- raw logs read: `{read_boundary.get('raw_logs_read')}`",
+        f"- task text read: `{read_boundary.get('task_text_read')}`",
+    ]
+    if merge.get("skipped_by_reason"):
+        lines.append(f"- skipped_by_reason: `{merge.get('skipped_by_reason')}`")
+    if payload.get("error"):
+        lines.append(f"- error: {payload.get('error')}")
+    return "\n".join(lines) + "\n"
+
+
 def register_benchmark_run_ledger_maintenance_commands(
     benchmark_subparsers: argparse._SubParsersAction,
 ) -> None:
@@ -313,6 +348,59 @@ def register_benchmark_run_ledger_maintenance_commands(
         "--execute",
         action="store_true",
         help="Write the benchmark run ledger update.",
+    )
+
+    benchmark_run_ledger_merge_parser = benchmark_subparsers.add_parser(
+        "run-ledger-merge",
+        help=(
+            "Merge multiple public benchmark_run_ledger_v0 JSON files into one "
+            "canonical ledger. This reads compact ledger rows only."
+        ),
+    )
+    benchmark_run_ledger_merge_parser.add_argument(
+        "--run-ledger-path",
+        default=str(BENCHMARK_RUN_LEDGER_DEFAULT_PATH),
+        help="Target benchmark_run_ledger_v0 JSON. Markdown is rendered next to it.",
+    )
+    benchmark_run_ledger_merge_parser.add_argument(
+        "--source-run-ledger-path",
+        action="append",
+        default=[],
+        help="Source benchmark_run_ledger_v0 JSON. May be passed multiple times.",
+    )
+    benchmark_run_ledger_merge_parser.add_argument(
+        "--source-run-ledger-glob",
+        action="append",
+        default=[],
+        help=(
+            "Glob for source benchmark_run_ledger_v0 JSON files. May be passed "
+            "multiple times; matched source paths are not recorded in the output."
+        ),
+    )
+    benchmark_run_ledger_merge_parser.add_argument(
+        "--benchmark-id",
+        action="append",
+        default=[],
+        help="Only merge runs for this benchmark id. May be passed multiple times.",
+    )
+    benchmark_run_ledger_merge_parser.add_argument(
+        "--run-group-contains",
+        action="append",
+        default=[],
+        help=(
+            "Only merge runs whose run_group_id contains this public-safe token. "
+            "May be passed multiple times."
+        ),
+    )
+    benchmark_run_ledger_merge_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview merge update without writing. This is the default.",
+    )
+    benchmark_run_ledger_merge_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Write the merged benchmark run ledger.",
     )
 
     benchmark_run_ledger_check_parser = benchmark_subparsers.add_parser(
@@ -450,6 +538,75 @@ def handle_benchmark_run_ledger_maintenance_command(
             payload,
             output_format(args),
             render_benchmark_run_ledger_archive_markdown,
+        )
+        return 0 if payload.get("ok") else 1
+
+    if args.benchmark_command == "run-ledger-merge":
+        try:
+            if args.dry_run and args.execute:
+                raise ValueError(
+                    "benchmark run-ledger-merge accepts either --dry-run or --execute, not both"
+                )
+            source_paths = [Path(value).expanduser() for value in args.source_run_ledger_path]
+            for pattern in args.source_run_ledger_glob or []:
+                source_paths.extend(
+                    Path(value).expanduser()
+                    for value in glob.glob(str(Path(pattern).expanduser()), recursive=True)
+                )
+            if not source_paths:
+                raise ValueError(
+                    "provide at least one --source-run-ledger-path or --source-run-ledger-glob"
+                )
+            merge_update = merge_benchmark_run_ledgers(
+                target_ledger_path=args.run_ledger_path,
+                source_ledger_paths=source_paths,
+                benchmark_ids=list(args.benchmark_id or []),
+                run_group_contains=list(args.run_group_contains or []),
+                dry_run=not bool(args.execute),
+            )
+            payload = {
+                "ok": True,
+                "dry_run": not bool(args.execute),
+                "updated": bool(args.execute),
+                "ledger_path": args.run_ledger_path,
+                "markdown_path": merge_update.get("markdown_path"),
+                "merge": merge_update.get("merge"),
+                "read_boundary": {
+                    "compact_only": True,
+                    "raw_logs_read": False,
+                    "task_text_read": False,
+                    "trajectory_read": False,
+                    "docker_invoked": False,
+                    "model_api_invoked": False,
+                    "upload_invoked": False,
+                },
+            }
+        except Exception as exc:
+            payload = {
+                "ok": False,
+                "dry_run": not bool(getattr(args, "execute", False)),
+                "updated": False,
+                "ledger_path": args.run_ledger_path,
+                "merge": {
+                    "schema_version": "benchmark_run_ledger_merge_v0",
+                    "ok": False,
+                    "source_paths_recorded": False,
+                },
+                "read_boundary": {
+                    "compact_only": True,
+                    "raw_logs_read": False,
+                    "task_text_read": False,
+                    "trajectory_read": False,
+                    "docker_invoked": False,
+                    "model_api_invoked": False,
+                    "upload_invoked": False,
+                },
+                "error": str(exc),
+            }
+        print_payload(
+            payload,
+            output_format(args),
+            render_benchmark_run_ledger_merge_markdown,
         )
         return 0 if payload.get("ok") else 1
 


### PR DESCRIPTION
## Summary
- add a public-safe benchmark run ledger merge API
- expose `loopx benchmark run-ledger-merge` for canonical aggregate ledgers from multiple run-group ledgers
- cover merge behavior, CLI registration, and source-path redaction with focused smokes

## Validation
- `python3 -m py_compile loopx/benchmark_ledger.py loopx/cli_commands/benchmark_run_ledger_maintenance.py examples/benchmark-run-ledger-smoke.py examples/cli-benchmark-run-ledger-command-modularization-smoke.py`
- `python3 examples/benchmark-run-ledger-smoke.py`
- `python3 examples/cli-benchmark-run-ledger-command-modularization-smoke.py`
- `git diff --check`
- `loopx check --scan-path loopx/benchmark_ledger.py --scan-path loopx/cli_commands/benchmark_run_ledger_maintenance.py --scan-path examples/benchmark-run-ledger-smoke.py --scan-path examples/cli-benchmark-run-ledger-command-modularization-smoke.py`