### PR TITLE
Add state-mediated auto-research worker loop

### DIFF
--- a/examples/auto-research-worker-loop-smoke.py
+++ b/examples/auto-research-worker-loop-smoke.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Smoke-test a minimal role-compatible auto-research worker loop."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.capabilities.auto_research import build_auto_research_demo_supervisor_plan  # noqa: E402
+from loopx.capabilities.auto_research.demo_e2e import _seed_visible_demo_control_plane  # noqa: E402
+
+
+GOAL_ID = "loopx-auto-research-knn"
+AGENT_IDS = [
+    "codex-product-capability",
+    "codex-side-bypass",
+    "codex-main-control",
+    "codex-value-explorer",
+]
+LANES = [
+    "codex-product-capability:research-curator:research_curator",
+    "codex-side-bypass:hypothesis-mapper:hypothesis_mapper",
+    "codex-main-control:evidence-runner:evidence_runner",
+    "codex-value-explorer:evidence-verifier:evidence_verifier",
+]
+
+
+def assert_public_safe(payload: Any) -> None:
+    text = json.dumps(payload, sort_keys=True) if not isinstance(payload, str) else payload
+    forbidden = [
+        "/" + "Users/",
+        "/" + "private/",
+        "/" + "tmp/",
+        "http" + "://",
+        "https" + "://",
+        "api" + "_key",
+        "pass" + "word",
+        "sec" + "ret",
+    ]
+    leaked = [needle for needle in forbidden if needle.lower() in text.lower()]
+    assert not leaked, leaked
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        supervisor = build_auto_research_demo_supervisor_plan(
+            goal_id=GOAL_ID,
+            agent_specs=LANES,
+            session_name="loopx-auto-research-worker-loop-smoke",
+            cli_bin="loopx",
+            codex_bin="codex",
+            tmux_bin="tmux",
+            reasoning_effort="high",
+        )
+        _visible_control, registry, runtime_root = _seed_visible_demo_control_plane(
+            demo_root=temp,
+            goal_id=GOAL_ID,
+            objective="Run a role-compatible live worker loop from LoopX queue to public-safe evidence.",
+            supervisor=supervisor,
+        )
+        workspace = temp / "shared-research-workspace"
+        workspace.mkdir()
+        env = os.environ.copy()
+        env["PYTHONDONTWRITEBYTECODE"] = "1"
+        env["PYTHONPATH"] = f"{REPO_ROOT}{os.pathsep}{env.get('PYTHONPATH', '')}"
+        args = [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry),
+            "--runtime-root",
+            str(runtime_root),
+            "--format",
+            "json",
+            "auto-research",
+            "worker-loop",
+            "--goal-id",
+            GOAL_ID,
+            "--lane-count",
+            str(len(AGENT_IDS)),
+            "--max-rounds",
+            "2",
+            "--visible-lanes-accepted",
+            "--complete-selected-todo",
+            "--execute",
+        ]
+        for agent_id in AGENT_IDS:
+            args.extend(["--agent-id", agent_id])
+        result = subprocess.run(
+            args,
+            cwd=workspace,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise AssertionError(
+                f"worker-loop failed rc={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+            )
+        payload = json.loads(result.stdout)
+        assert payload["ok"] is True, payload
+        assert payload["schema_version"] == "auto_research_worker_loop_v0", payload
+        assert payload["mode"] == "execute", payload
+        assert payload["executed_turn_count"] == 4, payload
+        assert payload["completed_turn_count"] == 4, payload
+        assert payload["stop_reason"] == "no_runnable_frontier", payload
+        assert payload["selected_actions"] == [
+            "write_research_contract",
+            "propose_hypothesis",
+            "run_dev_eval",
+            "classify_evidence",
+        ], payload
+        evidence_turn = next(
+            turn for turn in payload["turns"] if turn.get("selected_action") == "run_dev_eval"
+        )
+        assert evidence_turn["dev_metric"] == 4.0, evidence_turn
+        assert evidence_turn["appended_count"] == 2, evidence_turn
+        assert evidence_turn["live_evidence_written"] is True, evidence_turn
+        assert_public_safe(payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/auto_research/__init__.py
+++ b/loopx/capabilities/auto_research/__init__.py
@@ -62,6 +62,10 @@ from .worker_runtime import (
     load_auto_research_worker_frontier,
     run_auto_research_worker_turn,
 )
+from .worker_loop import (
+    AUTO_RESEARCH_WORKER_LOOP_SCHEMA_VERSION,
+    run_auto_research_worker_loop,
+)
 
 __all__ = [
     "AUTO_RESEARCH_DEFAULT_GOAL_ID",
@@ -117,7 +121,9 @@ __all__ = [
     "run_builtin_lightweight_demo",
     "run_lightweight_auto_research",
     "AUTO_RESEARCH_WORKER_FRONTIER_SCHEMA_VERSION",
+    "AUTO_RESEARCH_WORKER_LOOP_SCHEMA_VERSION",
     "AUTO_RESEARCH_WORKER_TURN_SCHEMA_VERSION",
     "load_auto_research_worker_frontier",
+    "run_auto_research_worker_loop",
     "run_auto_research_worker_turn",
 ]

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -23,6 +23,7 @@ from . import (
     load_auto_research_fixture,
     render_auto_research_markdown,
     run_builtin_lightweight_demo,
+    run_auto_research_worker_loop,
     run_auto_research_worker_turn,
 )
 from .demo_e2e import run_auto_research_demo_e2e
@@ -307,6 +308,69 @@ def register_auto_research_commands(
         "--execute",
         action="store_true",
         help="Run the selected worker action. Omit to show the plan from quota/frontier.",
+    )
+
+    worker_loop_parser = auto_research_sub.add_parser(
+        "worker-loop",
+        help="Run repeated LoopX-selected auto-research worker turns for a visible lane set.",
+    )
+    add_subcommand_format(worker_loop_parser)
+    worker_loop_parser.add_argument(
+        "--agent-id",
+        action="append",
+        required=True,
+        help="Agent id to poll in loop order. Repeat for each visible worker lane.",
+    )
+    worker_loop_parser.add_argument(
+        "--goal-id",
+        default=AUTO_RESEARCH_DEFAULT_GOAL_ID,
+        help="Research goal id whose quota/frontier each worker should obey.",
+    )
+    worker_loop_parser.add_argument(
+        "--objective",
+        default=AUTO_RESEARCH_DEFAULT_OBJECTIVE,
+        help="Public-safe objective used only when the quickstart pack must be created.",
+    )
+    worker_loop_parser.add_argument(
+        "--output-dir",
+        default="auto_research_knn_pack",
+        help="Quickstart pack directory inside the worker workspace.",
+    )
+    worker_loop_parser.add_argument(
+        "--evidence-dir",
+        default=".local/auto-research-worker",
+        help="Local-only evidence output directory inside the worker workspace.",
+    )
+    worker_loop_parser.add_argument(
+        "--lane-count",
+        type=int,
+        help="Visible lane count recorded when live evidence is captured.",
+    )
+    worker_loop_parser.add_argument(
+        "--visible-lanes-accepted",
+        action="store_true",
+        help="Acknowledge that the visible lanes were launched and accepted.",
+    )
+    worker_loop_parser.add_argument(
+        "--live-evidence-output",
+        default=LIVE_CODEX_E2E_DEFAULT_OUTPUT,
+        help="Local filename for compact public-safe live evidence.",
+    )
+    worker_loop_parser.add_argument(
+        "--complete-selected-todo",
+        action="store_true",
+        help="After successful --execute turns, mark selected LoopX todos done.",
+    )
+    worker_loop_parser.add_argument(
+        "--max-rounds",
+        type=int,
+        default=3,
+        help="Maximum polling rounds across the agent list.",
+    )
+    worker_loop_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Run each selected worker action. Omit to preview loop selection.",
     )
 
     demo_supervisor_parser = auto_research_sub.add_parser(
@@ -743,6 +807,32 @@ def handle_auto_research_command(
                 live_evidence_output=args.live_evidence_output,
                 complete_selected_todo=args.complete_selected_todo,
             )
+        elif args.auto_research_command == "worker-loop":
+            def append_loop_evidence(packet_path: str) -> dict[str, object]:
+                return _append_auto_research_rollout_events(
+                    packet_path=packet_path,
+                    registry_path=registry_path,
+                    runtime_root_arg=runtime_root_arg,
+                    dry_run=False,
+                )
+
+            payload = run_auto_research_worker_loop(
+                registry_path=registry_path,
+                runtime_root_arg=runtime_root_arg,
+                goal_id=args.goal_id,
+                agent_ids=args.agent_id,
+                objective=args.objective,
+                workspace=Path.cwd(),
+                output_dir=args.output_dir,
+                evidence_dir=args.evidence_dir,
+                execute=args.execute,
+                append_evidence=append_loop_evidence if args.execute else None,
+                lane_count=args.lane_count,
+                visible_lanes_accepted=args.visible_lanes_accepted,
+                live_evidence_output=args.live_evidence_output,
+                complete_selected_todo=args.complete_selected_todo,
+                max_rounds=args.max_rounds,
+            )
         elif args.auto_research_command == "demo-supervisor":
             payload = build_auto_research_demo_supervisor_plan(
                 goal_id=args.goal_id,
@@ -825,7 +915,7 @@ def handle_auto_research_command(
             raise ValueError(
                 "auto-research requires the `quickstart`, `frontier`, `evidence`, "
                 "`board`, `acceptance`, `append-evidence`, `capture-live-evidence`, "
-                "`worker-turn`, `demo-supervisor`, `demo-e2e`, or `lite-e2e` subcommand"
+                "`worker-turn`, `worker-loop`, `demo-supervisor`, `demo-e2e`, or `lite-e2e` subcommand"
             )
     except Exception as exc:
         payload = {

--- a/loopx/capabilities/auto_research/legacy_core.py
+++ b/loopx/capabilities/auto_research/legacy_core.py
@@ -947,12 +947,14 @@ def _auto_research_codex_bootstrap_prompt(
         "",
         "Minimal live worker-turn path:",
         f"1. Confirm the selected frontier action matches this role ({expected_actions}).",
-        "2. Preview the real LoopX-selected worker turn:",
+        "2. Single-pane preview:",
         "   `\"$LOOPX_PANE_LOOPX\" --format json auto-research worker-turn --goal-id \"$LOOPX_GOAL_ID\" --agent-id \"$LOOPX_AGENT_ID\"`",
-        "3. Execute the same worker turn only when the preview selected this lane:",
+        "3. Single-pane execute, only when the preview selected this lane:",
         "   `\"$LOOPX_PANE_LOOPX\" --format json auto-research worker-turn --goal-id \"$LOOPX_GOAL_ID\" --agent-id \"$LOOPX_AGENT_ID\" --lane-count \"${LOOPX_VISIBLE_LANE_COUNT:-1}\" --visible-lanes-accepted --complete-selected-todo --execute`",
-        "4. Stop after worker-turn reports executed=true and completion.status=done.",
-        "5. For evidence-runner, additionally require appended evidence and live_evidence.written=true.",
+        "4. Local multi-lane driver, when this pane is acting as the visible supervisor:",
+        "   `\"$LOOPX_PANE_LOOPX\" --format json auto-research worker-loop --goal-id \"$LOOPX_GOAL_ID\" $LOOPX_WORKER_LOOP_AGENT_ARGS --lane-count \"${LOOPX_VISIBLE_LANE_COUNT:-1}\" --visible-lanes-accepted --complete-selected-todo --execute`",
+        "5. Stop after the selected command reports executed/completed turns and no runnable frontier.",
+        "6. For evidence-runner, additionally require appended evidence and live_evidence.written=true.",
     ]
     return "\n".join(
         [
@@ -1056,6 +1058,7 @@ def _role_profile_for_lane(*, goal_id: str, lane: dict[str, str]) -> dict[str, A
 def _role_profile_shell_prefix(role_profile: dict[str, Any]) -> str:
     profile_json = json.dumps(role_profile, sort_keys=True, separators=(",", ":"))
     lane_count = str(role_profile.get("visible_lane_count") or "")
+    worker_loop_agent_args = str(role_profile.get("worker_loop_agent_args") or "")
     return (
         f"export LOOPX_GOAL_ID={_shell_arg(str(role_profile['goal_id']))}; "
         f"export LOOPX_AGENT_ID={_shell_arg(str(role_profile['agent_id']))}; "
@@ -1065,6 +1068,7 @@ def _role_profile_shell_prefix(role_profile: dict[str, Any]) -> str:
         f"export LOOPX_ROLE_PROFILE_REF={_shell_arg(str(role_profile['schema_version']))}; "
         f"export LOOPX_REQUIRED_SKILL={_shell_arg(str(role_profile['required_skill']))}; "
         f"export LOOPX_VISIBLE_LANE_COUNT={_shell_arg(lane_count)}; "
+        f"export LOOPX_WORKER_LOOP_AGENT_ARGS={_shell_arg(worker_loop_agent_args)}; "
         'export LOOPX_WORKER_SKILL_ROOT="$LOOPX_PROJECT/.codex/skills"; '
         'export LOOPX_WORKER_SKILL_PATH="$LOOPX_WORKER_SKILL_ROOT/$LOOPX_REQUIRED_SKILL/SKILL.md"; '
         f"LOOPX_ROLE_PROFILE_JSON={_shell_arg(profile_json)}; "
@@ -1151,6 +1155,9 @@ def build_auto_research_demo_supervisor_plan(
     effort = _compact_public_token(reasoning_effort, field="reasoning_effort")
     uses_default_lanes = agent_specs is None
     lanes = _demo_lane_specs(agent_specs)
+    worker_loop_agent_args = " ".join(
+        f"--agent-id {lane['agent_id']}" for lane in lanes
+    )
     default_lane_ids = [
         lane_id
         for _agent_id, lane_id, _role_id, _responsibility in AUTO_RESEARCH_DEMO_DEFAULT_LANES
@@ -1163,6 +1170,7 @@ def build_auto_research_demo_supervisor_plan(
         role_id = lane["role_id"]
         role_profile = _role_profile_for_lane(goal_id=goal, lane=lane)
         role_profile["visible_lane_count"] = len(lanes)
+        role_profile["worker_loop_agent_args"] = worker_loop_agent_args
         quota_command = _env_quota_command(cli_bin=cli, goal_id=goal, agent_id=agent_id)
         frontier_command = _env_frontier_command(cli_bin=cli, goal_id=goal, agent_id=agent_id)
         bootstrap_command = _env_auto_research_bootstrap_command(

--- a/loopx/capabilities/auto_research/worker_loop.py
+++ b/loopx/capabilities/auto_research/worker_loop.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from pathlib import Path
+
+from .worker_runtime import run_auto_research_worker_turn
+
+
+AUTO_RESEARCH_WORKER_LOOP_SCHEMA_VERSION = "auto_research_worker_loop_v0"
+
+AppendEvidence = Callable[[str], dict[str, object]]
+
+
+def _compact_turn(turn: dict[str, object], *, round_index: int) -> dict[str, object]:
+    completion = turn.get("completion") if isinstance(turn.get("completion"), dict) else {}
+    append = turn.get("append") if isinstance(turn.get("append"), dict) else {}
+    live_evidence = turn.get("live_evidence") if isinstance(turn.get("live_evidence"), dict) else {}
+    return {
+        "round": round_index,
+        "agent_id": turn.get("agent_id"),
+        "mode": turn.get("mode"),
+        "executed": bool(turn.get("executed")),
+        "selected_todo_id": turn.get("selected_todo_id"),
+        "selected_action": turn.get("selected_action"),
+        "completion_status": completion.get("status"),
+        "appended_count": append.get("appended_count"),
+        "dev_metric": turn.get("dev_metric"),
+        "live_evidence_written": bool(live_evidence.get("written")),
+    }
+
+
+def run_auto_research_worker_loop(
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    goal_id: str,
+    agent_ids: Sequence[str],
+    objective: str,
+    workspace: Path,
+    output_dir: str = "auto_research_knn_pack",
+    evidence_dir: str = ".local/auto-research-worker",
+    execute: bool = False,
+    append_evidence: AppendEvidence | None = None,
+    lane_count: int | None = None,
+    visible_lanes_accepted: bool = False,
+    live_evidence_output: str = "live-codex-e2e-evidence.public.json",
+    complete_selected_todo: bool = False,
+    max_rounds: int = 3,
+) -> dict[str, object]:
+    """Run repeated LoopX-selected worker turns for a fixed visible lane set.
+
+    The loop is intentionally thin: it does not pick research work itself. Each
+    pass delegates to worker-turn, so every lane re-reads quota/frontier before
+    writing any evidence.
+    """
+
+    clean_agents = [agent.strip() for agent in agent_ids if agent.strip()]
+    if not clean_agents:
+        raise ValueError("worker-loop requires at least one --agent-id")
+    if max_rounds < 1:
+        raise ValueError("worker-loop requires --max-rounds >= 1")
+    if execute and append_evidence is None:
+        raise ValueError("worker-loop --execute requires an append_evidence callback")
+
+    workspace = workspace.resolve()
+    effective_lane_count = lane_count or len(clean_agents)
+    turns: list[dict[str, object]] = []
+    stop_reason = "max_rounds"
+    for round_index in range(1, max_rounds + 1):
+        round_turns: list[dict[str, object]] = []
+        for agent_id in clean_agents:
+            turn = run_auto_research_worker_turn(
+                registry_path=registry_path,
+                runtime_root_arg=runtime_root_arg,
+                goal_id=goal_id,
+                agent_id=agent_id,
+                objective=objective,
+                workspace=workspace,
+                output_dir=output_dir,
+                evidence_dir=evidence_dir,
+                execute=execute,
+                append_evidence=append_evidence if execute else None,
+                lane_count=effective_lane_count,
+                visible_lanes_accepted=visible_lanes_accepted,
+                live_evidence_output=live_evidence_output,
+                complete_selected_todo=complete_selected_todo,
+            )
+            compact = _compact_turn(turn, round_index=round_index)
+            turns.append(compact)
+            round_turns.append(compact)
+        if not any(turn.get("mode") != "no_action" for turn in round_turns):
+            stop_reason = "no_runnable_frontier"
+            break
+        if execute and not any(turn.get("executed") for turn in round_turns):
+            stop_reason = "no_executed_turns"
+            break
+
+    executed_turns = [turn for turn in turns if turn.get("executed")]
+    completed_turns = [turn for turn in turns if turn.get("completion_status") == "done"]
+    selected_actions = [
+        str(turn.get("selected_action"))
+        for turn in turns
+        if turn.get("selected_action")
+    ]
+    return {
+        "ok": True,
+        "schema_version": AUTO_RESEARCH_WORKER_LOOP_SCHEMA_VERSION,
+        "mode": "execute" if execute else "dry_run",
+        "goal_id": goal_id,
+        "agent_ids": clean_agents,
+        "round_count": max((int(turn["round"]) for turn in turns), default=0),
+        "max_rounds": max_rounds,
+        "stop_reason": stop_reason,
+        "turn_count": len(turns),
+        "executed_turn_count": len(executed_turns),
+        "completed_turn_count": len(completed_turns),
+        "selected_actions": selected_actions,
+        "turns": turns,
+        "public_boundary": {
+            "source": "loopx_quota_frontier_worker_turns",
+            "raw_logs_recorded": False,
+            "private_artifacts_recorded": False,
+            "absolute_paths_recorded": False,
+            "credentials_recorded": False,
+        },
+    }


### PR DESCRIPTION
## Summary
- add a thin auto-research worker-loop command that repeatedly calls worker-turn across the current visible agent set
- keep the semantics state-mediated: every turn re-reads LoopX quota/frontier and writes back through normal todo/evidence paths
- update visible bootstrap hints to use the current lane-derived worker-loop agent list instead of a hard-coded dynamic workflow
- add a durable smoke proving curator -> mapper -> evidence-runner -> verifier over a demo-local LoopX queue

## Validation
- python3 -m py_compile loopx/capabilities/auto_research/legacy_core.py loopx/capabilities/auto_research/cli.py loopx/capabilities/auto_research/worker_loop.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-worker-loop-smoke.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-demo-supervisor-smoke.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-one-click-ux-smoke.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-worker-turn-smoke.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-live-evidence-capture-smoke.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-demo-e2e-smoke.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-skill-contract-smoke.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/visible-multi-agent-launcher-smoke.py
- loopx check --scan-path loopx/capabilities/auto_research --scan-path examples (passes; existing duplicate index warning only)