### PR TITLE
Clarify auto-research legacy import boundary

### DIFF
--- a/loopx/capabilities/auto_research/__init__.py
+++ b/loopx/capabilities/auto_research/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .core import (
+from .legacy_core import (
     AUTO_RESEARCH_DEFAULT_GOAL_ID,
     AUTO_RESEARCH_DEFAULT_OBJECTIVE,
     AUTO_RESEARCH_DEMO_ACCEPTANCE_PACKET_SCHEMA_VERSION,

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -6,7 +6,8 @@ from collections import Counter
 from collections.abc import Callable
 from pathlib import Path
 
-from . import (
+from .kernel import run_builtin_lightweight_demo
+from .legacy_core import (
     AUTO_RESEARCH_DEFAULT_GOAL_ID,
     AUTO_RESEARCH_DEFAULT_OBJECTIVE,
     AUTO_RESEARCH_QUICKSTART_TEMPLATE,
@@ -22,15 +23,14 @@ from . import (
     load_auto_research_evidence_packet_inputs,
     load_auto_research_fixture,
     render_auto_research_markdown,
-    run_builtin_lightweight_demo,
-    run_auto_research_worker_loop,
-    run_auto_research_worker_turn,
 )
 from .demo_e2e import run_auto_research_demo_e2e
 from .live_evidence import (
     LIVE_CODEX_E2E_DEFAULT_OUTPUT,
     capture_live_codex_e2e_evidence,
 )
+from .worker_loop import run_auto_research_worker_loop
+from .worker_runtime import run_auto_research_worker_turn
 from ...history import load_registry
 from ...paths import resolve_runtime_root
 from ...quota import build_quota_should_run

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -9,7 +9,8 @@ import tempfile
 from collections.abc import Callable
 from pathlib import Path
 
-from .core import (
+from .kernel import run_builtin_lightweight_demo
+from .legacy_core import (
     AUTO_RESEARCH_DEMO_E2E_SCHEMA_VERSION,
     AUTO_RESEARCH_DEFAULT_GOAL_ID,
     AUTO_RESEARCH_PROJECTION_SCHEMA_VERSION,
@@ -23,7 +24,6 @@ from .core import (
     build_research_evidence_graph_from_rollout_events,
     load_auto_research_evidence_packet_inputs,
 )
-from .kernel import run_builtin_lightweight_demo
 from .live_evidence import (
     build_live_codex_claim_from_evidence,
     load_live_codex_e2e_evidence,

--- a/loopx/capabilities/auto_research/live_evidence.py
+++ b/loopx/capabilities/auto_research/live_evidence.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from .core import (
+from .legacy_core import (
     AUTO_RESEARCH_ROLLOUT_APPEND_SCHEMA_VERSION,
     load_auto_research_evidence_packet,
     validate_auto_research_evidence_packet,

--- a/loopx/capabilities/auto_research/worker_runtime.py
+++ b/loopx/capabilities/auto_research/worker_runtime.py
@@ -8,7 +8,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-from .core import (
+from .legacy_core import (
     AUTO_RESEARCH_DEFAULT_GOAL_ID,
     AUTO_RESEARCH_DEFAULT_OBJECTIVE,
     AUTO_RESEARCH_QUICKSTART_TEMPLATE,


### PR DESCRIPTION
## Summary
- Route auto-research CLI, worker, demo E2E, live-evidence, and package exports to explicit kernel/legacy/worker modules instead of the compatibility core facade.
- Keep core.py as the legacy compatibility boundary while new paths avoid depending on it.

## Validation
- python3 -m py_compile loopx/capabilities/auto_research/core.py loopx/capabilities/auto_research/legacy_core.py loopx/capabilities/auto_research/kernel.py loopx/capabilities/auto_research/cli.py loopx/capabilities/auto_research/demo_e2e.py loopx/capabilities/auto_research/live_evidence.py loopx/capabilities/auto_research/worker_runtime.py loopx/capabilities/auto_research/worker_loop.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-lightweight-kernel-smoke.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-worker-loop-smoke.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-demo-supervisor-smoke.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-live-evidence-capture-smoke.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-one-click-ux-smoke.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-demo-e2e-smoke.py
- loopx check --scan-path loopx/capabilities/auto_research --scan-path examples (passes; existing duplicate index rows warning only)