### PR TITLE
Prune auto-research default canary path

### DIFF
--- a/examples/catalog-canary-planner-smoke.py
+++ b/examples/catalog-canary-planner-smoke.py
@@ -358,13 +358,20 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     assert "auto-research-demo" in auto_research_profiles, auto_research_payload
     auto_research_profile = auto_research_profiles["auto-research-demo"]
     auto_research_commands = [check["command"] for check in auto_research_profile["checks"]]
-    assert "python3 examples/auto-research-demo-e2e-smoke.py" in auto_research_commands, auto_research_profile
+    assert (
+        "python3 examples/auto-research-lightweight-kernel-smoke.py"
+        in auto_research_commands
+    ), auto_research_profile
     assert (
         "python3 examples/decentralized-auto-research-frontier-smoke.py" in auto_research_commands
     ), auto_research_profile
     assert (
-        "python3 examples/auto-research-live-codex-claim-boundary-smoke.py"
-        in auto_research_commands
+        "python3 examples/auto-research-demo-e2e-smoke.py"
+        not in auto_research_commands
+    ), auto_research_profile
+    assert (
+        "python3 examples/auto-research-one-click-ux-smoke.py"
+        not in auto_research_commands
     ), auto_research_profile
     assert all(check["tier"] == "default" for check in auto_research_profile["checks"]), auto_research_profile
     assert auto_research_profile["deep_checks_available"] is True, auto_research_profile

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -834,13 +834,14 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
         "id": "auto-research-demo",
         "title": "Auto-research demo and frontier route",
         "purpose": (
-            "Check visible auto-research demo routing, deterministic E2E replay, "
-            "and shared frontier projection without launching real Codex lanes by default."
+            "Check the minimal auto-research kernel and shared frontier projection; "
+            "keep legacy visible/demo wrappers out of the default canary path."
         ),
         "catalog_families": ["Work Routing", "Evidence Lifecycle", "State And Boundary", "Human Decision"],
         "trigger_hints": (
             "auto-research",
             "auto research",
+            "lite-e2e",
             "demo-supervisor",
             "demo e2e",
             "frontier",
@@ -851,9 +852,9 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
         ),
         "checks": [
             {
-                "command": "python3 examples/auto-research-demo-e2e-smoke.py",
+                "command": "python3 examples/auto-research-lightweight-kernel-smoke.py",
                 "tier": "default",
-                "reason": "checks the deterministic positive demo route, route contract, and no-live-claim boundary",
+                "reason": "checks the minimal real kernel and one-command lite-e2e path",
             },
             {
                 "command": "python3 examples/decentralized-auto-research-frontier-smoke.py",
@@ -861,19 +862,24 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
                 "reason": "checks shared frontier, evidence graph, board projection, and public boundary fixtures",
             },
             {
-                "command": "python3 examples/auto-research-live-codex-claim-boundary-smoke.py",
-                "tier": "default",
-                "reason": "guards that live E2E claims stay dev-only unless held-out or promotion authority is explicit",
+                "command": "python3 examples/auto-research-demo-e2e-smoke.py",
+                "tier": "deep",
+                "reason": "samples the legacy demo route when compatibility coverage is explicitly requested",
             },
             {
-                "command": "python3 examples/auto-research-one-click-ux-smoke.py",
-                "tier": "default",
-                "reason": "checks the one-command visible UX packet with fake tmux/Codex binaries",
+                "command": "python3 examples/auto-research-live-codex-claim-boundary-smoke.py",
+                "tier": "deep",
+                "reason": "guards that live E2E claims stay dev-only unless held-out or promotion authority is explicit",
             },
             {
                 "command": "python3 examples/auto-research-demo-supervisor-smoke.py",
                 "tier": "deep",
                 "reason": "samples the full dry-run supervisor packet and lane bootstrap contract",
+            },
+            {
+                "command": "python3 examples/auto-research-one-click-ux-smoke.py",
+                "tier": "deep",
+                "reason": "checks the legacy one-command visible UX packet with fake tmux/Codex binaries",
             },
             {
                 "command": "python3 examples/auto-research-visible-launcher-smoke.py",


### PR DESCRIPTION
## Summary
- make the auto-research canary profile default to the lightweight kernel smoke plus shared frontier smoke
- move legacy demo/fake visible UX and live-claim-boundary checks to deep-only compatibility coverage
- update the catalog canary planner smoke to assert old demo/fake checks are no longer default

## Validation
- python3 -m py_compile loopx/canary/planner.py loopx/capabilities/auto_research/*.py
- python3 examples/catalog-canary-planner-smoke.py
- python3 examples/auto-research-lightweight-kernel-smoke.py
- python3 examples/decentralized-auto-research-frontier-smoke.py
- loopx check --scan-path loopx/canary/planner.py --scan-path examples/catalog-canary-planner-smoke.py