### PR TITLE
Fix SkillsBench verifier bootstrap proxy attribution

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -86,6 +86,7 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
     RUNNER_CONFIG_PUBLIC_FILENAME,
     RUNNER_PREREQUISITES_PUBLIC_FILENAME,
     SkillsBenchProductModeNoLifecycleRequests,
+    VERIFIER_BENCHMARK_EGRESS_PROXY_BEGIN,
     VERIFIER_UV_BOOTSTRAP_MIRROR_BEGIN,
     _tail,
     _apply_agent_message_only_no_tool_calls_attribution,
@@ -220,7 +221,7 @@ def test_benchmark_egress_proxy_env_is_public_safe_and_forwarded() -> None:
         task_dir.mkdir(parents=True)
         (task_dir / "task.toml").write_text("version = \"1.1\"\n", encoding="utf-8")
 
-        proxy_url = "http://benchmark-proxy.internal:18080"
+        proxy_url = "http://benchmark-proxy.example.invalid:18080"
         previous = os.environ.get("LOOPX_SKILLSBENCH_EGRESS_PROXY")
         os.environ["LOOPX_SKILLSBENCH_EGRESS_PROXY"] = proxy_url
         try:
@@ -4620,6 +4621,66 @@ def test_skillsbench_official_result_builder() -> None:
         assert compact["read_boundary"]["trajectory_read"] is False
 
 
+def test_skillsbench_verifier_uv_bootstrap_error_is_not_solution_failure() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-uv-bootstrap-result-") as tmp:
+        root = Path(tmp)
+        run_dir = root / "official" / "2026-07-01__12-00-00" / "citation-check__abc123"
+        result_path = run_dir / "result.json"
+        write_json(
+            result_path,
+            {
+                "task_name": "citation-check",
+                "rollout_name": "citation-check__abc123",
+                "rewards": {"reward": 0.0},
+                "agent": "codex-acp",
+                "agent_name": "codex-acp",
+                "model": "gpt-5.5",
+                "n_tool_calls": 5,
+                "n_prompts": 1,
+                "error": None,
+                "verifier_error": (
+                    "downloading uv 0.9.7 x86_64-unknown-linux-gnu\n"
+                    "failed to download https://releases.astral.sh/github/uv/"
+                    "releases/download/0.9.7/uv-x86_64-unknown-linux-gnu.tar.gz\n"
+                    "/verifier/test.sh: line 27: uvx: command not found"
+                ),
+                "partial_trajectory": False,
+                "trajectory_source": "acp",
+            },
+        )
+        write_json(run_dir / "timing.json", {"agent_execution": 5.0, "total": 65.0})
+
+        compact = compact_benchmark_run(
+            build_skillsbench_benchflow_result_benchmark_run(
+                result_path,
+                route="codex-app-server-goal-baseline",
+            )
+        )
+
+        assert compact is not None
+        assert compact["official_score_status"] == "missing", compact
+        assert "official_score" not in compact, compact
+        assert "value" not in compact["official_task_score"], compact
+        assert compact["score_failure_attribution"] == (
+            "skillsbench_verifier_uv_bootstrap_failure"
+        ), compact
+        labels = compact["failure_attribution_labels"]
+        assert "skillsbench_verifier_uv_bootstrap_failure" in labels, compact
+        assert "skillsbench_verifier_bootstrap_failure" in labels, compact
+        assert "verifier_infrastructure_failure" in labels, compact
+        assert "official_verifier_solution_failure" not in labels, compact
+        assert "official_score_zero_case_failure" not in labels, compact
+        assert "skillsbench_verifier_uv_bootstrap_zero_reward_ignored" in compact[
+            "runner_warning_labels"
+        ], compact
+        accounting = compact["attempt_accounting"]
+        assert accounting["failure_class"] == "verifier_failed", compact
+        assert accounting["case_attempt_countable"] is True, compact
+        assert accounting["solver_attempt_countable"] is True, compact
+        assert accounting["verifier_attempt_countable"] is True, compact
+        assert accounting["official_score_attempt_countable"] is False, compact
+
+
 def test_skillsbench_result_reward_artifact_recovery() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-reward-recovery-") as tmp:
         result_path = write_official_skillsbench_reward_artifact_recovery_result(
@@ -5751,6 +5812,74 @@ def test_skillsbench_docker_task_staging_patches_verifier_uv_bootstrap_mirror() 
         assert staged_verifier.index("INSTALLER_DOWNLOAD_URL") < staged_verifier.index(
             "astral.sh/uv/0.9.7/install.sh"
         ), staged_verifier
+
+
+def test_skillsbench_docker_task_staging_forwards_proxy_to_verifier_bootstrap() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-verifier-proxy-stage-") as tmp:
+        root = Path(tmp)
+        task = root / "tasks" / "citation-check"
+        dockerfile = task / "environment" / "Dockerfile"
+        verifier = task / "verifier" / "test.sh"
+        dockerfile.parent.mkdir(parents=True)
+        verifier.parent.mkdir(parents=True)
+        dockerfile.write_text("FROM python:3.12-slim\n", encoding="utf-8")
+        original_verifier = (
+            "#!/bin/sh\n"
+            "set -x\n"
+            "curl -LsSf https://astral.sh/uv/0.9.7/install.sh | sh\n"
+            "uvx --with pytest==8.4.1 pytest /tests/test_outputs.py\n"
+        )
+        verifier.write_text(original_verifier, encoding="utf-8")
+        (task / "task.toml").write_text("version = \"1.1\"\n", encoding="utf-8")
+        proxy_url = "http://benchmark-proxy.example.invalid:18080"
+
+        staged_path, metadata = stage_task_for_sandbox(
+            task_path=task,
+            jobs_dir=root / "jobs",
+            job_name="citation-check-goalstart",
+            sandbox="docker",
+            include_task_skills=False,
+            benchmark_egress_proxy_env={
+                "LOOPX_SKILLSBENCH_EGRESS_PROXY": proxy_url,
+                "HTTPS_PROXY": proxy_url,
+                "HTTP_PROXY": proxy_url,
+                "ALL_PROXY": proxy_url,
+                "https_proxy": proxy_url,
+                "http_proxy": proxy_url,
+                "all_proxy": proxy_url,
+                "NO_PROXY": "localhost,127.0.0.1,::1",
+                "no_proxy": "localhost,127.0.0.1,::1",
+            },
+        )
+
+        assert metadata["staged"] is True, metadata
+        assert metadata["benchmark_egress_proxy_verifier_env_patch_required"] is True, (
+            metadata
+        )
+        assert metadata["benchmark_egress_proxy_verifier_env_patch_applied"] is True, (
+            metadata
+        )
+        assert metadata["benchmark_egress_proxy_verifier_env_key_count"] >= 8, metadata
+        assert metadata[
+            "benchmark_egress_proxy_verifier_env_raw_proxy_recorded"
+        ] is False, metadata
+        assert proxy_url not in json.dumps(metadata, sort_keys=True), metadata
+        assert verifier.read_text(encoding="utf-8") == original_verifier
+
+        staged_verifier = (staged_path / "verifier" / "test.sh").read_text(
+            encoding="utf-8"
+        )
+        assert VERIFIER_BENCHMARK_EGRESS_PROXY_BEGIN in staged_verifier, (
+            staged_verifier
+        )
+        assert staged_verifier.index(
+            VERIFIER_BENCHMARK_EGRESS_PROXY_BEGIN
+        ) < staged_verifier.index("set -x"), staged_verifier
+        assert f"export HTTPS_PROXY={proxy_url}" in staged_verifier, staged_verifier
+        assert f"export HTTP_PROXY={proxy_url}" in staged_verifier, staged_verifier
+        assert "case \"$-\" in *x*) loopx_restore_xtrace=1; set +x;; esac" in (
+            staged_verifier
+        )
 
 
 def test_skillsbench_apt_risk_preflight_blocks_full_run_without_benchflow() -> None:

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -554,6 +554,31 @@ _SKILLSBENCH_SETUP_FAILURE_LABELS = {
 }
 
 
+def _skillsbench_verifier_uv_bootstrap_failure(verifier_error_text: str) -> bool:
+    text = str(verifier_error_text or "").lower()
+    if not text:
+        return False
+    indicators = (
+        "uvx: command not found",
+        "uv: command not found",
+        "failed to download",
+        "releases.astral.sh",
+        "astral.sh/uv",
+        "uv-x86_64-unknown-linux-gnu",
+        "uv-aarch64-unknown-linux-gnu",
+        "installer_download_url",
+    )
+    if any(indicator in text for indicator in indicators) and re.search(
+        r"\buvx?\b|astral|releases\.astral|installer_download_url",
+        text,
+    ):
+        return True
+    return bool(
+        re.search(r"\buvx?\b.*(?:download|bootstrap|not found|installer)", text)
+        or re.search(r"(?:download|bootstrap|installer).*\buvx?\b", text)
+    )
+
+
 def _skillsbench_attempt_setup_blocked(failure_labels: Iterable[str]) -> bool:
     return any(
         str(label) in _SKILLSBENCH_SETUP_FAILURE_LABELS for label in failure_labels
@@ -582,6 +607,8 @@ def _skillsbench_attempt_failure_class(
         return BenchmarkFailureClass.SOLVER_FAILED
     if score_failure_attribution.startswith("skillsbench_native_goal_worker_"):
         return BenchmarkFailureClass.JOB_MATERIALIZATION_FAILED
+    if "skillsbench_verifier_uv_bootstrap_failure" in set(failure_labels):
+        return BenchmarkFailureClass.VERIFIER_FAILED
     if verifier_error_text and reward_value is None:
         return BenchmarkFailureClass.VERIFIER_FAILED
     if reward_value is None and score_failure_attribution != "none":
@@ -3325,7 +3352,6 @@ def build_skillsbench_benchflow_result_benchmark_run(
         reward_value, reward_artifact_source = _skillsbench_rollout_reward_artifact(
             result_path
         )
-    official_passed = bool(reward_value is not None and reward_value >= 1)
 
     timing_path = result_path.with_name("timing.json")
     timing: dict[str, Any] = {}
@@ -3352,6 +3378,17 @@ def build_skillsbench_benchflow_result_benchmark_run(
     verifier_error = result.get("verifier_error")
     error_text = str(error).strip() if error else ""
     verifier_error_text = str(verifier_error).strip() if verifier_error else ""
+    verifier_uv_bootstrap_failure = _skillsbench_verifier_uv_bootstrap_failure(
+        verifier_error_text
+    )
+    if (
+        verifier_uv_bootstrap_failure
+        and reward_value == 0
+        and reward_artifact_source is None
+    ):
+        reward_value = None
+        warning_labels.append("skillsbench_verifier_uv_bootstrap_zero_reward_ignored")
+    official_passed = bool(reward_value is not None and reward_value >= 1)
     failure_labels: list[str] = []
     exception_type = "none"
     score_failure_attribution = "none"
@@ -3367,11 +3404,31 @@ def build_skillsbench_benchflow_result_benchmark_run(
         )
     elif verifier_error_text:
         if score_failure_attribution in {"none", "skillsbench_runner_error"}:
-            exception_type = "skillsbench_verifier_error"
-            failure_labels.append("verifier_infrastructure_failure")
-            score_failure_attribution = "verifier_infrastructure_failure"
+            if verifier_uv_bootstrap_failure:
+                exception_type = "skillsbench_verifier_uv_bootstrap_failure"
+                failure_labels.extend(
+                    [
+                        "skillsbench_verifier_uv_bootstrap_failure",
+                        "skillsbench_verifier_bootstrap_failure",
+                        "verifier_infrastructure_failure",
+                    ]
+                )
+                score_failure_attribution = (
+                    "skillsbench_verifier_uv_bootstrap_failure"
+                )
+            else:
+                exception_type = "skillsbench_verifier_error"
+                failure_labels.append("verifier_infrastructure_failure")
+                score_failure_attribution = "verifier_infrastructure_failure"
         elif "verifier_infrastructure_failure" not in failure_labels:
             failure_labels.append("verifier_infrastructure_failure")
+        if (
+            verifier_uv_bootstrap_failure
+            and "skillsbench_verifier_uv_bootstrap_failure" not in failure_labels
+        ):
+            failure_labels.append("skillsbench_verifier_uv_bootstrap_failure")
+            if "skillsbench_verifier_bootstrap_failure" not in failure_labels:
+                failure_labels.append("skillsbench_verifier_bootstrap_failure")
 
     n_tool_calls = result.get("n_tool_calls")
     tool_calls = n_tool_calls if isinstance(n_tool_calls, int) else 0

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -78,7 +78,7 @@ import urllib.parse
 from contextlib import redirect_stderr, redirect_stdout
 from datetime import datetime
 from pathlib import Path
-from typing import Any, get_args, get_origin
+from typing import Any, Mapping, get_args, get_origin
 from urllib.parse import urlsplit
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -467,6 +467,12 @@ VERIFIER_UV_BOOTSTRAP_MIRROR_BEGIN = (
 )
 VERIFIER_UV_BOOTSTRAP_MIRROR_END = (
     "# END LOOPX_SKILLSBENCH_VERIFIER_UV_BOOTSTRAP_MIRROR"
+)
+VERIFIER_BENCHMARK_EGRESS_PROXY_BEGIN = (
+    "# BEGIN LOOPX_SKILLSBENCH_VERIFIER_BENCHMARK_EGRESS_PROXY"
+)
+VERIFIER_BENCHMARK_EGRESS_PROXY_END = (
+    "# END LOOPX_SKILLSBENCH_VERIFIER_BENCHMARK_EGRESS_PROXY"
 )
 DEFAULT_VERIFIER_UV_RELEASE_MIRROR_BASE = (
     "https://releases.astral.sh/github/uv/releases/download"
@@ -5576,6 +5582,9 @@ def _public_task_staging(value: Any) -> dict[str, Any]:
         "verifier_uv_bootstrap_risk_detected",
         "verifier_uv_bootstrap_mirror_patch_required",
         "verifier_uv_bootstrap_mirror_patch_applied",
+        "benchmark_egress_proxy_verifier_env_patch_required",
+        "benchmark_egress_proxy_verifier_env_patch_applied",
+        "benchmark_egress_proxy_verifier_env_raw_proxy_recorded",
         "verifier_bootstrap_risk_preflight_blocked",
         "verifier_bootstrap_fail_fast_defaulted",
         "codex_acp_runtime_tools_patch_applied",
@@ -5596,6 +5605,9 @@ def _public_task_staging(value: Any) -> dict[str, Any]:
     count = value.get("bootstrap_light_blocking_field_count")
     if isinstance(count, int) and not isinstance(count, bool) and count >= 0:
         compact["bootstrap_light_blocking_field_count"] = count
+    key_count = value.get("benchmark_egress_proxy_verifier_env_key_count")
+    if isinstance(key_count, int) and not isinstance(key_count, bool) and key_count >= 0:
+        compact["benchmark_egress_proxy_verifier_env_key_count"] = key_count
     resource_cap = value.get("resource_cap_patch")
     if isinstance(resource_cap, dict):
         safe_cap: dict[str, Any] = {}
@@ -5677,6 +5689,14 @@ def _discover_prepared_task_staging(plan: dict[str, Any]) -> dict[str, Any]:
         )
         if uv_versions:
             discovered["verifier_uv_bootstrap_version"] = uv_versions[0]
+    if VERIFIER_BENCHMARK_EGRESS_PROXY_BEGIN in verifier_text:
+        discovered.update(
+            {
+                "benchmark_egress_proxy_verifier_env_patch_required": True,
+                "benchmark_egress_proxy_verifier_env_patch_applied": True,
+                "benchmark_egress_proxy_verifier_env_raw_proxy_recorded": False,
+            }
+        )
     if DOCKER_PIP_BOOTSTRAP_BEGIN in dockerfile_text:
         discovered.update(
             {
@@ -6575,6 +6595,84 @@ def patch_verifier_uv_bootstrap_mirror(verifier: Path) -> dict[str, Any]:
     return metadata
 
 
+def _verifier_benchmark_egress_proxy_exports(
+    proxy_env: Mapping[str, str] | None,
+) -> dict[str, str]:
+    if not isinstance(proxy_env, Mapping):
+        return {}
+    proxy_url = str(proxy_env.get("LOOPX_SKILLSBENCH_EGRESS_PROXY") or "").strip()
+    if not proxy_url:
+        for key in BENCHMARK_EGRESS_PROXY_FORWARD_ENV_KEYS:
+            proxy_url = str(proxy_env.get(key) or "").strip()
+            if proxy_url:
+                break
+    if not proxy_url:
+        return {}
+    exports = {
+        key: proxy_url
+        for key in BENCHMARK_EGRESS_PROXY_FORWARD_ENV_KEYS
+    }
+    no_proxy = str(proxy_env.get("NO_PROXY") or proxy_env.get("no_proxy") or "").strip()
+    if no_proxy:
+        exports["NO_PROXY"] = no_proxy
+        exports["no_proxy"] = no_proxy
+    return exports
+
+
+def patch_verifier_benchmark_egress_proxy_env(
+    verifier: Path,
+    *,
+    proxy_env: Mapping[str, str] | None,
+) -> dict[str, Any]:
+    """Forward the private benchmark egress proxy into staged verifier scripts."""
+
+    exports = _verifier_benchmark_egress_proxy_exports(proxy_env)
+    metadata: dict[str, Any] = {
+        "benchmark_egress_proxy_verifier_env_patch_required": bool(exports),
+        "benchmark_egress_proxy_verifier_env_patch_applied": False,
+        "benchmark_egress_proxy_verifier_env_key_count": len(exports),
+        "benchmark_egress_proxy_verifier_env_raw_proxy_recorded": False,
+    }
+    if not verifier.exists() or not exports:
+        return metadata
+    try:
+        original = verifier.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return metadata
+    text = _strip_marker_block(
+        original,
+        VERIFIER_BENCHMARK_EGRESS_PROXY_BEGIN,
+        VERIFIER_BENCHMARK_EGRESS_PROXY_END,
+    )
+    block_lines = [
+        VERIFIER_BENCHMARK_EGRESS_PROXY_BEGIN,
+        "# Forward the runtime benchmark egress proxy into verifier bootstrap commands.",
+        "# The concrete proxy is staged only in the private prepared task copy.",
+        "loopx_restore_xtrace=''",
+        "case \"$-\" in *x*) loopx_restore_xtrace=1; set +x;; esac",
+    ]
+    for key in sorted(exports):
+        block_lines.append(f"export {key}={shlex.quote(exports[key])}")
+    block_lines.extend(
+        [
+            "[ -z \"${loopx_restore_xtrace}\" ] || set -x",
+            "unset loopx_restore_xtrace",
+            VERIFIER_BENCHMARK_EGRESS_PROXY_END,
+        ]
+    )
+    block = "\n".join(block_lines)
+    lines = text.splitlines()
+    insert_at = 0
+    if lines and lines[0].startswith("#!"):
+        insert_at = 1
+    patched_lines = [*lines[:insert_at], block, *lines[insert_at:]]
+    patched = "\n".join(patched_lines).rstrip() + "\n"
+    if patched != original:
+        _write_text_atomic(verifier, patched)
+    metadata["benchmark_egress_proxy_verifier_env_patch_applied"] = True
+    return metadata
+
+
 def patch_dockerfile_apt_retry(dockerfile: Path) -> bool:
     """Add public-safe apt retry/no-cache defaults to staged Dockerfiles."""
 
@@ -6730,6 +6828,7 @@ def stage_task_for_sandbox(
     job_name: str,
     sandbox: str,
     include_task_skills: bool = True,
+    benchmark_egress_proxy_env: Mapping[str, str] | None = None,
 ) -> tuple[Path, dict[str, Any]]:
     """Return the task path to run, staging Docker tasks when setup needs it."""
 
@@ -6749,6 +6848,10 @@ def stage_task_for_sandbox(
         "verifier_uv_bootstrap_risk_detected": False,
         "verifier_uv_bootstrap_mirror_patch_required": False,
         "verifier_uv_bootstrap_mirror_patch_applied": False,
+        "benchmark_egress_proxy_verifier_env_patch_required": False,
+        "benchmark_egress_proxy_verifier_env_patch_applied": False,
+        "benchmark_egress_proxy_verifier_env_key_count": 0,
+        "benchmark_egress_proxy_verifier_env_raw_proxy_recorded": False,
         "task_skills_removed": False,
         "resource_cap_patch": {
             "schema_version": "skillsbench_local_docker_resource_cap_v0",
@@ -6777,6 +6880,12 @@ def stage_task_for_sandbox(
         verifier_risk.get("verifier_uv_bootstrap_risk_detected")
         and verifier_risk.get("verifier_uv_bootstrap_version")
     )
+    verifier_proxy_exports = _verifier_benchmark_egress_proxy_exports(
+        benchmark_egress_proxy_env
+    )
+    needs_verifier_proxy_env_patch = bool(
+        verifier_proxy_exports and (task_path / "verifier" / "test.sh").exists()
+    )
     needs_runtime_tools_patch = (task_path / "environment" / "Dockerfile").exists()
     metadata["apt_setup_risk_detected"] = needs_apt_retry_patch
     metadata["apt_retry_patch_required"] = needs_apt_retry_patch
@@ -6794,6 +6903,12 @@ def stage_task_for_sandbox(
     metadata["verifier_uv_bootstrap_mirror_patch_required"] = (
         needs_verifier_uv_mirror_patch
     )
+    metadata["benchmark_egress_proxy_verifier_env_patch_required"] = (
+        needs_verifier_proxy_env_patch
+    )
+    metadata["benchmark_egress_proxy_verifier_env_key_count"] = len(
+        verifier_proxy_exports
+    )
     if isinstance(verifier_risk.get("verifier_uv_bootstrap_version"), str):
         metadata["verifier_uv_bootstrap_version"] = verifier_risk[
             "verifier_uv_bootstrap_version"
@@ -6806,6 +6921,7 @@ def stage_task_for_sandbox(
         and not needs_pip_bootstrap_patch
         and not needs_runtime_tools_patch
         and not needs_verifier_uv_mirror_patch
+        and not needs_verifier_proxy_env_patch
     ):
         metadata["resource_cap_patch"] = {
             "schema_version": "skillsbench_local_docker_resource_cap_v0",
@@ -6846,6 +6962,10 @@ def stage_task_for_sandbox(
     uv_mirror_metadata = patch_verifier_uv_bootstrap_mirror(
         staged_path / "verifier" / "test.sh"
     )
+    verifier_proxy_metadata = patch_verifier_benchmark_egress_proxy_env(
+        staged_path / "verifier" / "test.sh",
+        proxy_env=benchmark_egress_proxy_env,
+    )
     resource_cap_patch = patch_task_cpu_cap_for_local_docker(
         staged_path / "task.toml",
         host_cpus=host_cpus,
@@ -6875,6 +6995,7 @@ def stage_task_for_sandbox(
         ):
             continue
         metadata[key] = value
+    metadata.update(verifier_proxy_metadata)
     return staged_path, metadata
 
 
@@ -7163,6 +7284,10 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
                 and setup_preflight.get("verifier_uv_bootstrap_version")
             ),
             "verifier_uv_bootstrap_mirror_patch_applied": False,
+            "benchmark_egress_proxy_verifier_env_patch_required": False,
+            "benchmark_egress_proxy_verifier_env_patch_applied": False,
+            "benchmark_egress_proxy_verifier_env_key_count": 0,
+            "benchmark_egress_proxy_verifier_env_raw_proxy_recorded": False,
             "verifier_uv_bootstrap_version": (
                 str(setup_preflight.get("verifier_uv_bootstrap_version"))
                 if setup_preflight.get("verifier_uv_bootstrap_version")
@@ -10952,6 +11077,7 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
         job_name=str(plan["job_name"]),
         sandbox=args.sandbox,
         include_task_skills=bool(args.include_task_skills),
+        benchmark_egress_proxy_env=_benchmark_egress_proxy_env(args),
     )
     plan["task_staging"] = staging_metadata
     plan["effective_task_path"] = str(effective_task_path)


### PR DESCRIPTION
## Summary
- forward the runtime benchmark egress proxy into staged SkillsBench verifier scripts without recording raw proxy values in public metadata
- classify uv/uvx verifier bootstrap failures as verifier infrastructure failures instead of solution failures
- add focused regression smokes for proxy staging and uv bootstrap attribution

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py loopx/benchmark_adapters/skillsbench.py examples/skillsbench-benchmark-run-smoke.py
- focused SkillsBench smoke functions: benchmark proxy env forwarding, official result builder, uv bootstrap attribution, reward artifact recovery, uv mirror staging, verifier proxy staging
- git diff --check
- loopx check --scan-path scripts/skillsbench_automation_loop.py --scan-path loopx/benchmark_adapters/skillsbench.py --scan-path examples/skillsbench-benchmark-run-smoke.py