### PR TITLE
Keep visible multi-agent launcher contract generic

### DIFF
--- a/examples/generic-multi-agent-one-command-smoke.py
+++ b/examples/generic-multi-agent-one-command-smoke.py
@@ -306,6 +306,11 @@ def main() -> int:
             )
         assert all("reasoning_effort=high" in command for command in new_window_payloads), new_window_payloads
         assert all("model_reasoning_effort=high" in command for command in new_window_payloads), new_window_payloads
+        launcher_source = (ROOT / "loopx/visible_multi_agent_launcher.py").read_text(
+            encoding="utf-8"
+        )
+        assert "loopx_cli_scope=scoped_loopx_wrapper" in launcher_source
+        assert "demo_local_wrapper" not in launcher_source
 
     smoke_source = Path(__file__).read_text(encoding="utf-8").lower()
     domain_marker = "auto" + "-research"

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -25,6 +25,9 @@ def main() -> int:
     auto_research_cli = (ROOT / "loopx/capabilities/auto_research/cli.py").read_text(
         encoding="utf-8"
     )
+    launcher_source = (ROOT / "loopx/visible_multi_agent_launcher.py").read_text(
+        encoding="utf-8"
+    )
     assert "from ...visible_multi_agent_launcher import execute_visible_multi_agent_launcher" in auto_research_cli
     forbidden_defs = [
         "def _launch_auto_research_with_tmux",
@@ -34,6 +37,8 @@ def main() -> int:
     ]
     leaked_defs = [name for name in forbidden_defs if name in auto_research_cli]
     assert not leaked_defs, leaked_defs
+    assert "demo_local_wrapper" not in launcher_source
+    assert "loopx_cli_scope=scoped_loopx_wrapper" in launcher_source
 
     with tempfile.TemporaryDirectory() as temp_dir:
         temp = Path(temp_dir)
@@ -69,6 +74,7 @@ def main() -> int:
                     "    print('[LoopX frontier]')",
                     "    print('[bootstrap-or-stop]')",
                     "    print('loopx_agent_handshake=role_profile_quota_frontier_bootstrap')",
+                    "    print('loopx_cli_scope=scoped_loopx_wrapper')",
                     "    raise SystemExit(0)",
                     "raise SystemExit(0)",
                     "",

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -141,7 +141,7 @@ def build_visible_lane_command(
         'printf "bootstrap_or_stop=printed\\n"; '
         'printf "loopx_agent_handshake=role_profile_quota_frontier_bootstrap\\n"; '
         'printf "loopx_polling_prompt=visible_bootstrap_prompt\\n"; '
-        'printf "loopx_cli_scope=demo_local_wrapper\\n"; '
+        'printf "loopx_cli_scope=scoped_loopx_wrapper\\n"; '
         'printf "takeover_controls=visible\\n"; '
         f"printf 'reasoning_effort=%s\\n' {_q(reasoning_effort)}"
     )


### PR DESCRIPTION
## Summary
- rename the visible launcher CLI-scope marker from `demo_local_wrapper` to `scoped_loopx_wrapper`
- add smoke coverage so the generic launcher does not regress to demo/auto-research-specific naming

## Validation
- `python3 examples/visible-multi-agent-launcher-smoke.py`
- `python3 examples/generic-multi-agent-one-command-smoke.py`
- `python3 -m py_compile loopx/visible_multi_agent_launcher.py examples/visible-multi-agent-launcher-smoke.py examples/generic-multi-agent-one-command-smoke.py`
- `git diff --check`
- `loopx --format json check --scan-path loopx/visible_multi_agent_launcher.py --scan-path examples/visible-multi-agent-launcher-smoke.py --scan-path examples/generic-multi-agent-one-command-smoke.py`
