### PR TITLE
Repair full todo list projection

### DIFF
--- a/examples/todo-list-event-projection-smoke.py
+++ b/examples/todo-list-event-projection-smoke.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Smoke-test `loopx todo list` event projection preference and Markdown fallback."""
+"""Smoke-test `loopx todo list` event projection with Markdown late-todo overlay."""
 
 from __future__ import annotations
 
@@ -153,13 +153,20 @@ def main() -> int:
         projected = run_cli(registry_path, "todo", "list", "--goal-id", GOAL_ID, "--role", "agent")
         assert projected["ok"] is True, projected
         assert projected["read_only"] is True, projected
-        assert projected["source"] == "event_projection", projected
-        assert projected["todo_count"] == 2, projected
+        assert projected["source"] == "event_projection_with_markdown_overlay", projected
+        assert projected["todo_count"] == 3, projected
         assert [item["todo_id"] for item in projected["todos"]] == [
+            "todo_event_open",
+            "todo_markdown",
+            "todo_event_done",
+        ], projected
+        assert projected["projection_overlay"]["markdown_only_todo_ids"] == [
+            "todo_markdown"
+        ], projected
+        assert projected["projection_overlay"]["event_only_todo_ids"] == [
             "todo_event_open",
             "todo_event_done",
         ], projected
-        assert "todo_markdown" not in json.dumps(projected, sort_keys=True), projected
         assert projected["state_event_projection"]["source_event_count"] == 3, projected
 
         done_only = run_cli(
@@ -173,7 +180,7 @@ def main() -> int:
             "--status",
             "done",
         )
-        assert done_only["source"] == "event_projection", done_only
+        assert done_only["source"] == "event_projection_with_markdown_overlay", done_only
         assert done_only["todo_count"] == 1, done_only
         assert done_only["todos"][0]["todo_id"] == "todo_event_done", done_only
 

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -6024,6 +6024,7 @@ def compact_todo_group(
     role: str | None = None,
     preferred_todo_ids: set[str] | None = None,
     rollout_events: list[dict[str, Any]] | None = None,
+    item_limit: int | None = MAX_STATUS_TODOS_PER_ROLE,
 ) -> dict[str, Any] | None:
     if not items:
         return None
@@ -6154,7 +6155,7 @@ def compact_todo_group(
             for item in projected_deferred_items
             if item.get("resume_ready") is True
         ][:MAX_DEFERRED_TODO_VISIBILITY_ITEMS],
-        "items": budgeted_items[:MAX_STATUS_TODOS_PER_ROLE],
+        "items": budgeted_items if item_limit is None else budgeted_items[:item_limit],
     }
     handoff_gates = build_todo_handoff_gate_states(items)
     if handoff_gates:
@@ -6214,6 +6215,7 @@ def parse_active_state_todos(
     state_path: Path | None = None,
     preferred_todo_ids: set[str] | None = None,
     rollout_events: list[dict[str, Any]] | None = None,
+    item_limit: int | None = MAX_STATUS_TODOS_PER_ROLE,
 ) -> dict[str, Any]:
     role: str | None = None
     source_sections: dict[str, str | None] = {"user": None, "agent": None}
@@ -6264,6 +6266,7 @@ def parse_active_state_todos(
         role="user",
         preferred_todo_ids=preferred_todo_ids,
         rollout_events=rollout_events,
+        item_limit=item_limit,
     )
     agent = compact_todo_group(
         items["agent"],
@@ -6271,6 +6274,7 @@ def parse_active_state_todos(
         role="agent",
         preferred_todo_ids=preferred_todo_ids,
         rollout_events=rollout_events,
+        item_limit=item_limit,
     )
     if user:
         result["user_todos"] = user
@@ -6304,6 +6308,7 @@ def active_state_event_projection_fields(
     state_path: Path,
     preferred_todo_ids: set[str] | None = None,
     rollout_events: list[dict[str, Any]] | None = None,
+    item_limit: int | None = MAX_STATUS_TODOS_PER_ROLE,
 ) -> dict[str, Any]:
     goal_id = str(goal.get("id") or "").strip()
     for event_log_path in state_event_log_candidates(goal, state_path=state_path):
@@ -6321,6 +6326,7 @@ def active_state_event_projection_fields(
                 state_path=state_path,
                 preferred_todo_ids=preferred_todo_ids,
                 rollout_events=rollout_events,
+                item_limit=item_limit,
             )
         except (OSError, StateEventError) as exc:
             return {

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -395,7 +395,15 @@ def filtered_todo_summary(
             if normalize_todo_id(item.get("todo_id")) == normalized_todo_id
         ]
     source_section = str((summary or {}).get("source_section") or TODO_SECTION_HEADINGS[role])
-    return compact_todo_group(items, source_section=source_section, role=role) or empty_todo_summary(role=role)
+    return (
+        compact_todo_group(
+            items,
+            source_section=source_section,
+            role=role,
+            item_limit=None,
+        )
+        or empty_todo_summary(role=role)
+    )
 
 
 def todo_item_relations(item: dict[str, Any]) -> dict[str, Any]:
@@ -427,6 +435,77 @@ def todo_item_relations(item: dict[str, Any]) -> dict[str, Any]:
     return relations
 
 
+def _summary_items(fields: dict[str, Any], role: str) -> list[dict[str, Any]]:
+    summary = fields.get(f"{role}_todos") if isinstance(fields, dict) else None
+    if not isinstance(summary, dict):
+        return []
+    return [item for item in summary.get("items") or [] if isinstance(item, dict)]
+
+
+def _merge_todo_projection_fields(
+    *,
+    markdown_fields: dict[str, Any],
+    event_fields: dict[str, Any],
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    merged: dict[str, Any] = {}
+    overlay: dict[str, Any] = {
+        "schema_version": "todo_list_projection_overlay_v0",
+        "base": "markdown_active_state",
+        "overlay": "event_projection",
+        "markdown_only_todo_ids": [],
+        "event_only_todo_ids": [],
+        "overlaid_todo_ids": [],
+    }
+    for role in ("user", "agent"):
+        markdown_items = _summary_items(markdown_fields, role)
+        event_items = _summary_items(event_fields, role)
+        if not markdown_items and not event_items:
+            continue
+        by_id: dict[str, dict[str, Any]] = {}
+        order: list[str] = []
+        for item in markdown_items:
+            todo_id = normalize_todo_id(item.get("todo_id")) or build_todo_id(
+                role=role,
+                source_section=item.get("source_section"),
+                index=item.get("index"),
+                text=item.get("text"),
+            )
+            if todo_id not in by_id:
+                order.append(todo_id)
+            by_id[todo_id] = dict(item)
+        markdown_ids = set(order)
+        event_ids: set[str] = set()
+        for item in event_items:
+            todo_id = normalize_todo_id(item.get("todo_id")) or build_todo_id(
+                role=role,
+                source_section=item.get("source_section"),
+                index=item.get("index"),
+                text=item.get("text"),
+            )
+            event_ids.add(todo_id)
+            if todo_id not in by_id:
+                order.append(todo_id)
+                overlay["event_only_todo_ids"].append(todo_id)
+            else:
+                overlay["overlaid_todo_ids"].append(todo_id)
+            by_id[todo_id] = dict(item)
+        overlay["markdown_only_todo_ids"].extend(sorted(markdown_ids - event_ids))
+        source_section = str(
+            (markdown_fields.get(f"{role}_todos") or {}).get("source_section")
+            or (event_fields.get(f"{role}_todos") or {}).get("source_section")
+            or TODO_SECTION_HEADINGS[role]
+        )
+        summary = compact_todo_group(
+            [by_id[todo_id] for todo_id in order],
+            source_section=source_section,
+            role=role,
+            item_limit=None,
+        )
+        if summary:
+            merged[f"{role}_todos"] = summary
+    return merged, overlay
+
+
 def list_goal_todos(
     *,
     registry_path: Path,
@@ -455,19 +534,32 @@ def list_goal_todos(
     projection_fields = active_state_event_projection_fields(
         goal,
         state_path=resolved_state_file,
+        item_limit=None,
     )
     projection_has_todos = bool(
         projection_fields.get("user_todos") or projection_fields.get("agent_todos")
     )
-    if projection_has_todos:
+    markdown_fields = parse_active_state_todos(
+        resolved_state_file.read_text(encoding="utf-8"),
+        goal=goal,
+        state_path=resolved_state_file,
+        item_limit=None,
+    )
+    markdown_has_todos = bool(
+        markdown_fields.get("user_todos") or markdown_fields.get("agent_todos")
+    )
+    projection_overlay: dict[str, Any] | None = None
+    if projection_has_todos and markdown_has_todos:
+        fields, projection_overlay = _merge_todo_projection_fields(
+            markdown_fields=markdown_fields,
+            event_fields=projection_fields,
+        )
+        source = "event_projection_with_markdown_overlay"
+    elif projection_has_todos:
         fields = projection_fields
         source = "event_projection"
     else:
-        fields = parse_active_state_todos(
-            resolved_state_file.read_text(encoding="utf-8"),
-            goal=goal,
-            state_path=resolved_state_file,
-        )
+        fields = markdown_fields
         source = "markdown_active_state"
 
     roles = [role] if role else ["user", "agent"]
@@ -511,6 +603,10 @@ def list_goal_todos(
     payload.update(summaries)
     if source == "event_projection" and projection_fields.get("state_event_projection"):
         payload["state_event_projection"] = projection_fields["state_event_projection"]
+    if source == "event_projection_with_markdown_overlay":
+        if projection_fields.get("state_event_projection"):
+            payload["state_event_projection"] = projection_fields["state_event_projection"]
+        payload["projection_overlay"] = projection_overlay
     if projection_fields.get("state_event_projection_warning"):
         payload["state_event_projection_warning"] = projection_fields["state_event_projection_warning"]
     return payload


### PR DESCRIPTION
## Summary
- keep `loopx todo list` on the full active-state todo set instead of the display-budgeted status summary
- overlay event-projected todos onto Markdown active-state todos without dropping Markdown-only late todos
- extend the event projection smoke to cover the late-todo overlay contract

## Validation
- python3 -m py_compile loopx/status.py loopx/todos.py loopx/quota.py
- python3 examples/todo-list-event-projection-smoke.py
- python3 examples/todo-cli-smoke.py && python3 examples/todo-lifecycle-cli-smoke.py && python3 examples/todo-first-open-summary-smoke.py
- python3 examples/event-sourced-status-read-path-smoke.py && python3 examples/event-sourced-downstream-read-path-smoke.py && python3 examples/event-sourced-replay-compaction-smoke.py
- python3 examples/quota-resume-gated-open-todo-smoke.py && python3 examples/todo-detail-cold-path-contract-smoke.py
- git diff --check
- loopx check --scan-path loopx/todos.py --scan-path loopx/status.py --scan-path examples/todo-list-event-projection-smoke.py
- PYTHONPATH=. python3 -m loopx.cli --format json --registry ~/.codex/loopx/registry.global.json todo list --goal-id loopx-meta --role agent --todo-id todo_33ae3ea6391a
- PYTHONPATH=. python3 -m loopx.cli --format json --registry ~/.codex/loopx/registry.global.json --runtime-root ~/.codex/loopx quota should-run --goal-id loopx-meta --agent-id codex-side-bypass

## Boundary
- staged explicit public product/test paths only
- no local state, credentials, raw logs, or private artifacts included

## Note
`loopx check` reports the pre-existing loopx-meta duplicate-index warning; this PR does not touch run-history index maintenance.