### PR TITLE
Fix SkillsBench pre-agent setup attribution

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -49,6 +49,7 @@ from loopx.benchmark_adapters.skillsbench_remote_bridge import (  # noqa: E402
     skillsbench_remote_command_file_bridge_command_is_fixture_probe,
 )
 from loopx.benchmark_adapters.skillsbench import (  # noqa: E402
+    apply_skillsbench_pre_agent_setup_diagnostic_attribution,
     skillsbench_runner_error_attribution,
     skillsbench_runner_error_fingerprint,
 )
@@ -5092,6 +5093,106 @@ def test_skillsbench_unclassified_compose_failure_fingerprint() -> None:
         assert "/Users/example/private/job/root" not in text, compact
 
 
+def test_skillsbench_app_server_pre_agent_setup_overrides_route_selected_gap() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-appserver-preagent-") as tmp:
+        root = Path(tmp)
+        run_dir = (
+            root
+            / "official"
+            / "2026-07-01__09-50-00"
+            / "fix-build-agentops__preagent"
+        )
+        result_path = run_dir / "result.json"
+        write_json(
+            result_path,
+            {
+                "task_name": "fix-build-agentops",
+                "rollout_name": "fix-build-agentops__preagent",
+                "rewards": None,
+                "agent": "codex-acp",
+                "agent_name": "codex-acp",
+                "model": "gpt-5.5",
+                "n_tool_calls": 0,
+                "n_prompts": 1,
+                "error": "BenchFlow setup blocked before agent lifecycle",
+                "verifier_error": None,
+                "partial_trajectory": False,
+                "trajectory_source": None,
+            },
+        )
+        write_json(run_dir / "timing.json", {"environment_setup": 1.0, "total": 1.0})
+        controller_trace = {
+            "schema_version": "skillsbench_loopx_controller_trace_v0",
+            "route": "codex-app-server-goal-baseline",
+            "last_decision": "host_app_server_goal_worker_selected",
+            "native_goal_worker_route": True,
+            "native_goal_worker_connected": False,
+            "native_goal_worker_trace_dir_present": False,
+            "native_goal_worker_public_trace_read": False,
+            "native_goal_worker_trace_count": 0,
+            "native_goal_worker_connect_count": 0,
+        }
+        compact = build_skillsbench_benchflow_result_benchmark_run(
+            result_path,
+            route="codex-app-server-goal-baseline",
+            controller_trace=controller_trace,
+        )
+        assert compact["score_failure_attribution"] == (
+            "skillsbench_native_goal_worker_uncountable_worker_route_selected_not_connected"
+        ), compact
+        compact["compose_setup_diagnostic"] = {
+            "schema_version": "skillsbench_compose_setup_diagnostic_v0",
+            "status": "runner_setup_blocked_before_agent_rounds",
+            "route": "codex-app-server-goal-baseline",
+            "failure_class": compact["score_failure_attribution"],
+            "agent_rounds_started": False,
+            "official_score_missing": True,
+            "case_attempt_budget_should_count": False,
+            "raw_logs_read": False,
+            "raw_task_text_read": False,
+            "raw_trajectory_read": False,
+        }
+
+        legacy_reduced = compact_benchmark_run(compact)
+        assert legacy_reduced is not None
+        assert legacy_reduced["score_failure_attribution"] == (
+            "skillsbench_runner_setup_blocked_before_agent_rounds"
+        ), legacy_reduced
+        assert "native_goal_worker_public_trace_missing" not in legacy_reduced[
+            "validation"
+        ]["failed_checks"], legacy_reduced
+        assert "pre_agent_setup_materialization_blocked" in legacy_reduced[
+            "validation"
+        ]["failed_checks"], legacy_reduced
+
+        apply_skillsbench_pre_agent_setup_diagnostic_attribution(compact)
+        assert compact["score_failure_attribution"] == (
+            "skillsbench_runner_setup_blocked_before_agent_rounds"
+        ), compact
+        accounting = compact["attempt_accounting"]
+        assert accounting["failure_label"] == (
+            "skillsbench_runner_setup_blocked_before_agent_rounds"
+        ), accounting
+        assert accounting["failure_class"] == "job_materialization_failed", accounting
+
+        ledger_path = root / "ledger.json"
+        update = update_benchmark_run_ledger(
+            ledger_path=ledger_path,
+            benchmark_run=compact,
+            run_group_id="skillsbench-appserver-preagent-test",
+            arm_id="baseline",
+            dry_run=False,
+        )
+        entry = update["entry"]
+        assert entry["arm_id"] == "codex_app_server_goal_baseline", entry
+        assert entry["failure_class"] == (
+            "skillsbench_runner_setup_blocked_before_agent_rounds"
+        ), entry
+        assert entry["attempt_failure_label"] == (
+            "skillsbench_runner_setup_blocked_before_agent_rounds"
+        ), entry
+
+
 def test_skillsbench_volume_mount_failure_attribution() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-volume-mount-") as tmp:
         result_path = write_official_skillsbench_volume_mount_failure(Path(tmp))
@@ -5968,7 +6069,12 @@ def test_skillsbench_apt_risk_preflight_blocks_full_run_without_benchflow() -> N
         assert case["latest_decision"]["decision"] == (
             "baseline_setup_preflight_selection_required"
         ), case
-        entry = case["runs"][0]
+        entry = next(
+            run
+            for run in case["runs"]
+            if run.get("run_group_id") == "setup-fuzzing-py-apt-risk-preflight"
+            and run.get("job_name") == "setup-fuzzing-py-apt-risk-preflight"
+        )
         assert entry["repair_class"] == "skillsbench_setup_preflight_selection", (
             entry
         )
@@ -6059,7 +6165,14 @@ def test_skillsbench_verifier_bootstrap_preflight_blocks_full_run_without_benchf
         assert case["latest_decision"]["decision"] == (
             "baseline_verifier_bootstrap_preflight_selection_required"
         ), case
-        entry = case["runs"][0]
+        entry = next(
+            run
+            for run in case["runs"]
+            if run.get("run_group_id")
+            == "organize-messy-files-verifier-bootstrap-preflight"
+            and run.get("job_name")
+            == "organize-messy-files-verifier-bootstrap-preflight"
+        )
         assert entry["repair_class"] == (
             "skillsbench_verifier_bootstrap_preflight_selection"
         ), entry

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -551,7 +551,147 @@ _SKILLSBENCH_SETUP_FAILURE_LABELS = {
     "skillsbench_docker_setup_preflight_blocked",
     "skillsbench_docker_compose_setup_failure",
     "skillsbench_docker_compose_unclassified_setup_failure",
+    "skillsbench_compose_setup_blocked_before_agent_rounds",
+    "skillsbench_runner_setup_blocked_before_agent_rounds",
+    "skillsbench_app_server_goal_pre_agent_materialization_blocked",
 }
+
+_SKILLSBENCH_PRE_AGENT_SETUP_STATUS_LABELS = {
+    "compose_setup_blocked_before_agent_rounds": (
+        "skillsbench_compose_setup_blocked_before_agent_rounds"
+    ),
+    "runner_setup_blocked_before_agent_rounds": (
+        "skillsbench_runner_setup_blocked_before_agent_rounds"
+    ),
+}
+
+_SKILLSBENCH_PRE_AGENT_SETUP_REPLACEABLE_ATTRIBUTIONS = {
+    "",
+    "none",
+    "score_missing",
+    "skillsbench_runner_error",
+    "skillsbench_result_json_missing_after_runner_exit",
+    "official_score_zero_case_failure",
+    "official_verifier_solution_failure",
+    "verifier_infrastructure_failure",
+}
+
+
+def _skillsbench_number(value: Any) -> float | int | None:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return value
+    return None
+
+
+def _skillsbench_official_score_missing(benchmark_run: dict[str, Any]) -> bool:
+    official = (
+        benchmark_run.get("official_task_score")
+        if isinstance(benchmark_run.get("official_task_score"), dict)
+        else {}
+    )
+    if _skillsbench_number(official.get("value")) is not None:
+        return False
+    return _skillsbench_number(benchmark_run.get("official_score")) is None
+
+
+def _skillsbench_pre_agent_setup_diagnostic_label(
+    benchmark_run: dict[str, Any],
+) -> str:
+    diagnostic = benchmark_run.get("compose_setup_diagnostic")
+    if not isinstance(diagnostic, dict):
+        return ""
+    label = _SKILLSBENCH_PRE_AGENT_SETUP_STATUS_LABELS.get(
+        str(diagnostic.get("status") or "")
+    )
+    if not label:
+        return ""
+    route = str(benchmark_run.get("route") or "")
+    mode = str(benchmark_run.get("mode") or "")
+    if route != "codex-app-server-goal-baseline" and mode != (
+        "skillsbench_codex_app_server_goal_baseline"
+    ):
+        return ""
+    if benchmark_run.get("native_goal_worker_route") is not True:
+        validation = benchmark_run.get("validation")
+        if not isinstance(validation, dict) or validation.get(
+            "native_goal_worker_route"
+        ) is not True:
+            return ""
+    if benchmark_run.get("native_goal_worker_connected") is True:
+        return ""
+    trace_count = benchmark_run.get("native_goal_worker_trace_count")
+    if (
+        isinstance(trace_count, int)
+        and not isinstance(trace_count, bool)
+        and trace_count > 0
+    ):
+        return ""
+    if diagnostic.get("agent_rounds_started") is True:
+        return ""
+    if not _skillsbench_official_score_missing(benchmark_run):
+        return ""
+    return label
+
+
+def apply_skillsbench_pre_agent_setup_diagnostic_attribution(
+    benchmark_run: dict[str, Any],
+) -> dict[str, Any]:
+    """Project app-server pre-agent setup blockers into terminal attribution.
+
+    The app-server Goal route can be selected before BenchFlow/compose has
+    materialized the native worker. Without this projection, downstream
+    reducers only see `native_goal_worker_route=true` plus no worker trace and
+    report a misleading worker connection failure.
+    """
+
+    label = _skillsbench_pre_agent_setup_diagnostic_label(benchmark_run)
+    if not label:
+        return benchmark_run
+    current = str(benchmark_run.get("score_failure_attribution") or "")
+    if (
+        current in _SKILLSBENCH_PRE_AGENT_SETUP_REPLACEABLE_ATTRIBUTIONS
+        or current.startswith("skillsbench_native_goal_worker_")
+    ):
+        benchmark_run["score_failure_attribution"] = label
+        benchmark_run["first_blocker"] = label
+    benchmark_run["pre_agent_setup_materialization_blocked"] = True
+    benchmark_run["native_goal_worker_pre_agent_setup_blocked"] = True
+
+    labels = [
+        item
+        for item in benchmark_run.get("failure_attribution_labels", [])
+        if isinstance(item, str) and item
+    ]
+    for item in (
+        label,
+        "skillsbench_app_server_goal_pre_agent_materialization_blocked",
+        "skillsbench_runner_setup_error",
+    ):
+        if item not in labels:
+            labels.append(item)
+    benchmark_run["failure_attribution_labels"] = labels
+
+    runner_failure = benchmark_run.get("runner_failure")
+    if not isinstance(runner_failure, dict):
+        runner_failure = {
+            "schema_version": "skillsbench_runner_failure_v0",
+            "raw_error_recorded": False,
+            "raw_logs_read": False,
+            "raw_task_text_read": False,
+            "raw_trajectory_read": False,
+        }
+        benchmark_run["runner_failure"] = runner_failure
+    runner_failure["exception_type"] = label
+    runner_failure["failure_class"] = label
+    runner_failure["pre_agent_setup_materialization_blocked"] = True
+
+    attempt_accounting = benchmark_run.get("attempt_accounting")
+    if isinstance(attempt_accounting, dict):
+        attempt_accounting["failure_label"] = label
+        attempt_accounting["failure_class"] = (
+            BenchmarkFailureClass.JOB_MATERIALIZATION_FAILED.value
+        )
+    return benchmark_run
 
 
 def _skillsbench_verifier_uv_bootstrap_failure(verifier_error_text: str) -> bool:

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -40,6 +40,18 @@ PRIVATE_ARTIFACT_REF_PATH_MARKERS = (
     "/var/folders/",
     "/tmp/",
 )
+PUBLIC_LEDGER_LINEAGE_RESULT_FILENAMES = {
+    "result.json",
+}
+PRIVATE_ARTIFACT_REF_PATH_PARTS = {
+    ".local",
+    "private",
+    "private-benchmark-jobs",
+    "users",
+    "volumes",
+    "var",
+    "tmp",
+}
 
 
 def _now_local_iso() -> str:
@@ -579,6 +591,24 @@ def _public_ledger_artifact_ref(
         return None
     classification = classify_benchmark_artifact_path(ref)
     if classification.get("allowed_to_read") is not True:
+        normalized = ref.replace("\\", "/").strip("/")
+        parts = [part for part in normalized.split("/") if part]
+        if (
+            not normalized
+            or ref.startswith("/")
+            or ref.startswith("~")
+            or ":" in normalized
+            or len(parts) != len(normalized.split("/"))
+            or any(part in {".", ".."} or part.startswith(".") for part in parts)
+            or any(part.lower() in PRIVATE_ARTIFACT_REF_PATH_PARTS for part in parts)
+            or classification.get("private_raw_surface") is True
+        ):
+            return None
+        basename = _compact_text(classification.get("basename"), limit=160)
+        if basename in PUBLIC_LEDGER_LINEAGE_RESULT_FILENAMES:
+            return normalized
+        if "." not in basename:
+            return normalized
         return None
     normalized = ref.replace("\\", "/")
     if any(marker in normalized for marker in PRIVATE_ARTIFACT_REF_PATH_MARKERS):
@@ -639,6 +669,8 @@ def _official_score(benchmark_run: dict[str, Any]) -> tuple[float | int | None, 
 def _infer_arm_id_from_job_name(job_name: str) -> str:
     if not job_name:
         return ""
+    if "codex_app_server_goal_baseline" in job_name:
+        return "codex_app_server_goal_baseline"
     if "codex_goal_mode_baseline" in job_name:
         return "codex_goal_mode_baseline"
     if "hardened_codex_baseline" in job_name:
@@ -656,6 +688,8 @@ def _infer_arm_id_from_job_name(job_name: str) -> str:
 
 def _infer_arm_id(benchmark_run: dict[str, Any]) -> str:
     mode = _compact_text(benchmark_run.get("mode"), limit=120)
+    if mode == "skillsbench_codex_app_server_goal_baseline":
+        return "codex_app_server_goal_baseline"
     if mode == "codex_goal_mode_baseline":
         return "codex_goal_mode_baseline"
     if mode in {"hardened_codex_baseline", "hardened-codex"}:
@@ -695,6 +729,40 @@ def _score_status(benchmark_run: dict[str, Any], score: float | int | None, pass
     return "passed" if passed else "failed"
 
 
+_SKILLSBENCH_PRE_AGENT_SETUP_STATUS_LABELS = {
+    "compose_setup_blocked_before_agent_rounds": (
+        "skillsbench_compose_setup_blocked_before_agent_rounds"
+    ),
+    "runner_setup_blocked_before_agent_rounds": (
+        "skillsbench_runner_setup_blocked_before_agent_rounds"
+    ),
+}
+
+
+def _skillsbench_pre_agent_setup_failure_class(
+    benchmark_run: dict[str, Any],
+) -> str:
+    diagnostic = (
+        benchmark_run.get("compose_setup_diagnostic")
+        if isinstance(benchmark_run.get("compose_setup_diagnostic"), dict)
+        else {}
+    )
+    label = _SKILLSBENCH_PRE_AGENT_SETUP_STATUS_LABELS.get(
+        _compact_text(diagnostic.get("status"), limit=120)
+    )
+    if not label:
+        return ""
+    mode = _compact_text(benchmark_run.get("mode"), limit=120)
+    route = _compact_text(benchmark_run.get("route"), limit=120)
+    if mode != "skillsbench_codex_app_server_goal_baseline" and route != (
+        "codex-app-server-goal-baseline"
+    ):
+        return ""
+    if diagnostic.get("agent_rounds_started") is True:
+        return ""
+    return label
+
+
 def _failure_class(benchmark_run: dict[str, Any], score: float | int | None) -> str:
     if _source_schema(benchmark_run) == "terminal_bench_post_launch_materialization_v0":
         compact_failure = _compact_text(
@@ -715,6 +783,10 @@ def _failure_class(benchmark_run: dict[str, Any], score: float | int | None) -> 
         return first_blocker or "post_launch_compact_result_missing"
     if score is not None and score != 0:
         return "none"
+    if score is None:
+        pre_agent_setup = _skillsbench_pre_agent_setup_failure_class(benchmark_run)
+        if pre_agent_setup:
+            return pre_agent_setup
     setup_blocker = _compact_first_from_lists(
         benchmark_run,
         "worker_setup_diagnostic_blockers",

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -2631,6 +2631,128 @@ def _compact_benchmark_compose_setup_diagnostic(value: Any) -> dict[str, Any]:
     return compact
 
 
+_SKILLSBENCH_PRE_AGENT_SETUP_STATUS_LABELS = {
+    "compose_setup_blocked_before_agent_rounds": (
+        "skillsbench_compose_setup_blocked_before_agent_rounds"
+    ),
+    "runner_setup_blocked_before_agent_rounds": (
+        "skillsbench_runner_setup_blocked_before_agent_rounds"
+    ),
+}
+
+
+def _skillsbench_compact_official_score_missing(compact: dict[str, Any]) -> bool:
+    official = (
+        compact.get("official_task_score")
+        if isinstance(compact.get("official_task_score"), dict)
+        else {}
+    )
+    value = official.get("value")
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return False
+    value = compact.get("official_score")
+    return not (isinstance(value, (int, float)) and not isinstance(value, bool))
+
+
+def _skillsbench_compact_pre_agent_setup_label(compact: dict[str, Any]) -> str:
+    diagnostic = compact.get("compose_setup_diagnostic")
+    if not isinstance(diagnostic, dict):
+        return ""
+    label = _SKILLSBENCH_PRE_AGENT_SETUP_STATUS_LABELS.get(
+        str(diagnostic.get("status") or "")
+    )
+    if not label:
+        return ""
+    if compact.get("mode") != "skillsbench_codex_app_server_goal_baseline":
+        return ""
+    validation = (
+        compact.get("validation") if isinstance(compact.get("validation"), dict) else {}
+    )
+    native_route = (
+        compact.get("native_goal_worker_route")
+        if "native_goal_worker_route" in compact
+        else validation.get("native_goal_worker_route")
+    )
+    if native_route is not True:
+        return ""
+    native_connected = (
+        compact.get("native_goal_worker_connected")
+        if "native_goal_worker_connected" in compact
+        else validation.get("native_goal_worker_connected")
+    )
+    if native_connected is True:
+        return ""
+    trace_count = (
+        compact.get("native_goal_worker_trace_count")
+        if "native_goal_worker_trace_count" in compact
+        else validation.get("native_goal_worker_trace_count")
+    )
+    if (
+        isinstance(trace_count, int)
+        and not isinstance(trace_count, bool)
+        and trace_count > 0
+    ):
+        return ""
+    if diagnostic.get("agent_rounds_started") is True:
+        return ""
+    if not _skillsbench_compact_official_score_missing(compact):
+        return ""
+    return label
+
+
+def _apply_skillsbench_pre_agent_setup_compact_projection(
+    compact: dict[str, Any],
+) -> None:
+    label = _skillsbench_compact_pre_agent_setup_label(compact)
+    if not label:
+        return
+    current = str(compact.get("score_failure_attribution") or "")
+    if (
+        current in {"", "none", "score_missing", "skillsbench_runner_error"}
+        or current.startswith("skillsbench_native_goal_worker_")
+    ):
+        compact["score_failure_attribution"] = label
+        compact["first_blocker"] = label
+    labels = [
+        item
+        for item in compact.get("failure_attribution_labels", [])
+        if isinstance(item, str) and item
+    ]
+    for item in (
+        label,
+        "skillsbench_app_server_goal_pre_agent_materialization_blocked",
+        "skillsbench_runner_setup_error",
+    ):
+        if item not in labels:
+            labels.append(item)
+    compact["failure_attribution_labels"] = labels[:MAX_BENCHMARK_RUN_LIST_ITEMS]
+    attempt_accounting = compact.get("attempt_accounting")
+    if isinstance(attempt_accounting, dict):
+        attempt_accounting["failure_label"] = label
+        attempt_accounting["failure_class"] = "job_materialization_failed"
+    runner_failure = compact.get("runner_failure")
+    if isinstance(runner_failure, dict):
+        runner_failure["exception_type"] = label
+        runner_failure["failure_class"] = label
+        runner_failure["pre_agent_setup_materialization_blocked"] = True
+    validation = compact.get("validation")
+    if isinstance(validation, dict):
+        failed = [
+            item
+            for item in validation.get("failed_checks", [])
+            if isinstance(item, str) and item
+        ]
+        failed = [
+            item for item in failed if item != "native_goal_worker_public_trace_missing"
+        ]
+        if "pre_agent_setup_materialization_blocked" not in failed:
+            failed.append("pre_agent_setup_materialization_blocked")
+        validation["failed_checks"] = failed[:MAX_BENCHMARK_RUN_LIST_ITEMS]
+        validation["all_passed"] = False
+    compact["pre_agent_setup_materialization_blocked"] = True
+    compact["native_goal_worker_pre_agent_setup_blocked"] = True
+
+
 def _compact_benchmark_result_discovery(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict):
         return {}
@@ -4044,6 +4166,7 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
     )
     if compose_setup_diagnostic:
         compact["compose_setup_diagnostic"] = compose_setup_diagnostic
+        _apply_skillsbench_pre_agent_setup_compact_projection(compact)
 
     progress = _compact_numeric_map(
         source.get("progress"),
@@ -4115,9 +4238,6 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
     )
     if case_event_timeline:
         compact["case_event_timeline"] = case_event_timeline
-    post_run_debug_gate = build_skillsbench_post_run_debug_gate(compact)
-    if post_run_debug_gate:
-        compact["post_run_debug_gate"] = post_run_debug_gate
 
     preflight_guard = _compact_benchmark_preflight_guard(source.get("preflight_guard"))
     if preflight_guard:
@@ -4196,10 +4316,17 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         )
         if (
             native_goal_worker_trace_missing
+            and compact.get("pre_agent_setup_materialization_blocked") is not True
             and "native_goal_worker_public_trace_missing" not in failed
             and len(failed) < MAX_BENCHMARK_RUN_LIST_ITEMS
         ):
             failed.append("native_goal_worker_public_trace_missing")
+        if (
+            compact.get("pre_agent_setup_materialization_blocked") is True
+            and "pre_agent_setup_materialization_blocked" not in failed
+            and len(failed) < MAX_BENCHMARK_RUN_LIST_ITEMS
+        ):
+            failed.append("pre_agent_setup_materialization_blocked")
         compact_validation: dict[str, Any] = {
             "all_passed": not failed
             and all(
@@ -4320,6 +4447,11 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
             if isinstance(validation.get(field), bool):
                 compact_validation[field] = validation[field]
         compact["validation"] = compact_validation
+        _apply_skillsbench_pre_agent_setup_compact_projection(compact)
+
+    post_run_debug_gate = build_skillsbench_post_run_debug_gate(compact)
+    if post_run_debug_gate:
+        compact["post_run_debug_gate"] = post_run_debug_gate
 
     trials: list[dict[str, Any]] = []
     for trial in trials_source or []:

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -103,6 +103,7 @@ from loopx.benchmark_case_state import (  # noqa: E402
     benchmark_case_active_state_write_command,
 )
 from loopx.benchmark_adapters.skillsbench import (  # noqa: E402
+    apply_skillsbench_pre_agent_setup_diagnostic_attribution,
     build_skillsbench_app_server_goal_worker_contract,
     build_skillsbench_run_permission_policy,
     build_skillsbench_worker_handshake_preflight,
@@ -12186,6 +12187,7 @@ def reduce_result(
     diagnostic = build_compose_setup_diagnostic(compact, plan)
     if diagnostic.get("status") != "not_applicable":
         compact["compose_setup_diagnostic"] = diagnostic
+        apply_skillsbench_pre_agent_setup_diagnostic_attribution(compact)
     runner_output_capture = _public_runner_output_capture(plan)
     if runner_output_capture:
         compact["runner_output_capture"] = runner_output_capture
@@ -12983,6 +12985,7 @@ def build_runner_failure_compact(
     diagnostic = build_compose_setup_diagnostic(compact, plan)
     if diagnostic.get("status") != "not_applicable":
         compact["compose_setup_diagnostic"] = diagnostic
+        apply_skillsbench_pre_agent_setup_diagnostic_attribution(compact)
     trials = compact.get("trials")
     if isinstance(trials, list) and trials:
         trial = trials[0]


### PR DESCRIPTION
## Summary
- classify app-server Goal pre-agent setup/materialization blockers before they are mistaken for native worker route connection failures
- propagate the setup attribution through automation-loop reduction, compact status projection, post-run debug gate inputs, and benchmark run ledger failure classes
- preserve public ledger lineage refs for safe relative result-root entries, and make related smokes robust to archived historical runs

## Validation
- python3 -m py_compile loopx/benchmark_adapters/skillsbench.py loopx/status.py loopx/benchmark_ledger.py scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- python3 examples/benchmark-run-ledger-smoke.py
- loopx check --scan-path examples/skillsbench-benchmark-run-smoke.py --scan-path loopx/benchmark_adapters/skillsbench.py --scan-path loopx/benchmark_ledger.py --scan-path loopx/status.py --scan-path scripts/skillsbench_automation_loop.py

Note: local ledger result files under docs/research/long-horizon-agent-benchmarks are intentionally left unstaged; they are run-result updates, not part of this repair PR.