### PR TITLE
Fail fast when Codex app-server stream closes

### DIFF
--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -148,6 +148,33 @@ for line in sys.stdin:
     print(json.dumps({"id": mid, "result": result}), flush=True)
 """
 
+FAKE_CODEX_EXIT_AFTER_TURN_START = """#!/usr/bin/env python3
+import json
+import sys
+
+for line in sys.stdin:
+    msg = json.loads(line)
+    mid = msg.get("id")
+    method = msg.get("method")
+    if method == "initialized":
+        continue
+    if method == "initialize":
+        result = {"serverInfo": {"name": "fake-codex"}}
+    elif method == "thread/start":
+        result = {"thread": {"id": "thread-skillsbench"}}
+    elif method == "thread/goal/set":
+        result = {"goal": {"threadId": "thread-skillsbench", "status": "active"}}
+    elif method == "thread/goal/get":
+        result = {"goal": {"threadId": "thread-skillsbench", "status": "active"}}
+    elif method == "turn/start":
+        result = {"turn": {"id": "turn-skillsbench", "status": "running"}}
+        print(json.dumps({"id": mid, "result": result}), flush=True)
+        raise SystemExit(0)
+    else:
+        result = {}
+    print(json.dumps({"id": mid, "result": result}), flush=True)
+"""
+
 FAKE_CODEX_THOUGHT_ONLY_NO_COMPLETION = """#!/usr/bin/env python3
 import json
 import sys
@@ -967,6 +994,65 @@ def test_host_worker_fails_closed_on_first_action_timeout() -> None:
         assert not list(work.glob(".loopx_app_server_goal_worker_response_*.txt"))
 
 
+def test_host_worker_fails_fast_when_app_server_stream_closes() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-app-goal-worker-eof-") as tmp:
+        root = Path(tmp)
+        fake = root / "codex"
+        prompt = root / "prompt.txt"
+        output = root / "worker.compact.json"
+        private_response = root / "private-response.txt"
+        fake.write_text(FAKE_CODEX_EXIT_AFTER_TURN_START, encoding="utf-8")
+        fake.chmod(0o755)
+        prompt.write_text("Private task instruction placeholder.", encoding="utf-8")
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(WORKER_SCRIPT),
+                "--task-id",
+                "llm-prefix-cache-replay",
+                "--codex-bin",
+                str(fake),
+                "--work-dir",
+                str(root / "work"),
+                "--prompt-file",
+                str(prompt),
+                "--output-json",
+                str(output),
+                "--response-text-file",
+                str(private_response),
+                "--response-timeout-sec",
+                "5",
+                "--turn-timeout-sec",
+                "60",
+                "--first-action-timeout-sec",
+                "60",
+            ],
+            cwd=REPO_ROOT,
+            check=False,
+            text=True,
+            capture_output=True,
+            timeout=5,
+        )
+        assert result.returncode == 1, result
+        payload = json.loads(output.read_text(encoding="utf-8"))
+        assert payload["ok"] is False, payload
+        assert (
+            payload["error_type"]
+            == "codex_app_server_stream_eof_before_completion"
+        ), payload
+        assert (
+            payload["worker_contract"]["first_blocker"]
+            == "codex_app_server_stream_eof_before_completion"
+        ), payload
+        assert payload["turn"]["turn_id_present"] is True, payload
+        assert payload["turn"]["turn_completed_observed"] is False, payload
+        assert payload["turn"]["stream_eof_observed"] is True, payload
+        assert payload["turn"]["process_exit_observed"] is True, payload
+        assert payload["turn"]["process_returncode"] == 0, payload
+        assert "process/exited" in payload["turn"]["notifications"], payload
+        assert not private_response.exists(), payload
+
+
 def test_host_worker_treats_thought_delta_as_no_effective_first_action() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-app-goal-worker-thought-only-") as tmp:
         root = Path(tmp)
@@ -1744,7 +1830,7 @@ def test_app_server_goal_launcher_defaults_first_action_watchdog() -> None:
         {"app_server_goal_worker_trace_dir": "/tmp/worker-traces"},
     )
     index = command.index("--first-action-timeout-sec")
-    assert command[index + 1] == "3600", command
+    assert command[index + 1] == "900", command
 
 
 def test_app_server_goal_launcher_allows_explicit_first_action_disable() -> None:
@@ -2271,6 +2357,7 @@ if __name__ == "__main__":
     test_host_worker_contract_only_cli()
     test_host_worker_waits_for_completion_and_keeps_public_json_compact()
     test_host_worker_fails_closed_on_first_action_timeout()
+    test_host_worker_fails_fast_when_app_server_stream_closes()
     test_acp_relay_delegates_to_app_server_goal_worker()
     test_acp_relay_materializes_lifecycle_trace_before_prompt()
     test_acp_relay_streams_public_keepalive_while_worker_runs()

--- a/scripts/codex_app_server_goal_driver.py
+++ b/scripts/codex_app_server_goal_driver.py
@@ -41,6 +41,10 @@ class CodexAppServerGoalTurn:
     session_event_count: int = 0
     session_log_observed: bool = False
     session_task_complete_observed: bool = False
+    stream_eof_observed: bool = False
+    stream_error_observed: bool = False
+    process_exit_observed: bool = False
+    process_returncode: int | None = None
     notifications: list[str] = field(default_factory=list)
     _responses: "queue.Queue[dict[str, Any] | Exception] | None" = field(
         default=None,
@@ -287,6 +291,11 @@ def _record_turn_event(
     raise_on_error: bool,
 ) -> bool:
     if isinstance(msg, EOFError):
+        turn.stream_eof_observed = True
+        returncode = turn.process.poll()
+        if returncode is not None:
+            turn.process_exit_observed = True
+            turn.process_returncode = int(returncode)
         if raise_on_error:
             raise CodexAppServerGoalDriverError(
                 "codex app-server exited before turn completion"
@@ -294,6 +303,7 @@ def _record_turn_event(
         turn.notifications.append("stream/eof")
         return False
     if isinstance(msg, Exception):
+        turn.stream_error_observed = True
         if raise_on_error:
             raise CodexAppServerGoalDriverError(str(msg))
         turn.notifications.append("stream/error")
@@ -429,6 +439,10 @@ def observe_codex_app_server_goal_turn(
     """Drain app-server turn events without making completion a success gate."""
     if turn._responses is None:
         return bool(turn.turn_completed_observed)
+    returncode = turn.process.poll()
+    if returncode is not None:
+        turn.process_exit_observed = True
+        turn.process_returncode = int(returncode)
     if _observe_codex_session_events(turn):
         return True
     deadline = time.monotonic() + max(0.0, timeout_sec)
@@ -441,6 +455,12 @@ def observe_codex_app_server_goal_turn(
         except queue.Empty:
             if _observe_codex_session_events(turn):
                 return True
+            returncode = turn.process.poll()
+            if returncode is not None:
+                turn.process_exit_observed = True
+                turn.process_returncode = int(returncode)
+                if not turn.turn_completed_observed:
+                    turn.notifications.append("process/exited")
             if not until_completed or time.monotonic() >= deadline:
                 return bool(turn.turn_completed_observed)
             continue
@@ -767,6 +787,10 @@ def compact_turn_metadata(turn: CodexAppServerGoalTurn) -> dict[str, Any]:
         "session_log_observed": bool(turn.session_log_observed),
         "session_event_count": int(turn.session_event_count),
         "session_task_complete_observed": bool(turn.session_task_complete_observed),
+        "stream_eof_observed": bool(turn.stream_eof_observed),
+        "stream_error_observed": bool(turn.stream_error_observed),
+        "process_exit_observed": bool(turn.process_exit_observed),
+        "process_returncode": turn.process_returncode,
         "assistant_message_present": bool(assistant_message),
         "assistant_message_chars": len(assistant_message),
         "assistant_message_sha256": sha256(assistant_message.encode()).hexdigest()

--- a/scripts/skillsbench_host_codex_goal_worker.py
+++ b/scripts/skillsbench_host_codex_goal_worker.py
@@ -31,6 +31,7 @@ from loopx.benchmark_case_state import (  # noqa: E402
 )
 from loopx.codex_goal_baseline import stable_text_digest  # noqa: E402
 from scripts.codex_app_server_goal_driver import (  # noqa: E402
+    CodexAppServerGoalDriverError,
     compact_turn_metadata,
     observe_codex_app_server_goal_turn,
     start_codex_app_server_goal_turn,
@@ -127,6 +128,25 @@ def _effective_action_observed(turn: Any) -> bool:
     return False
 
 
+def _terminal_app_server_failure(turn: Any) -> str:
+    if bool(getattr(turn, "turn_completed_observed", False)):
+        return ""
+    if bool(getattr(turn, "stream_eof_observed", False)):
+        return "codex_app_server_stream_eof_before_completion"
+    if bool(getattr(turn, "stream_error_observed", False)):
+        return "codex_app_server_stream_error_before_completion"
+    process = getattr(turn, "process", None)
+    returncode = None
+    if process is not None:
+        try:
+            returncode = process.poll()
+        except Exception:
+            returncode = None
+    if returncode is not None or bool(getattr(turn, "process_exit_observed", False)):
+        return "codex_app_server_process_exited_before_completion"
+    return ""
+
+
 def _wait_for_worker_turn_completion(
     turn: Any,
     *,
@@ -141,6 +161,9 @@ def _wait_for_worker_turn_completion(
         first_action_deadline = started_at + max(0.1, first_action_timeout_sec)
     while time.monotonic() < deadline:
         observe_codex_app_server_goal_turn(turn, timeout_sec=0.0, raise_on_error=False)
+        terminal_failure = _terminal_app_server_failure(turn)
+        if terminal_failure:
+            raise CodexAppServerGoalDriverError(terminal_failure)
         if turn.turn_completed_observed:
             return True
         if (
@@ -151,6 +174,9 @@ def _wait_for_worker_turn_completion(
             raise TimeoutError("codex_exec_first_action_timeout")
         time.sleep(max(0.1, poll_interval_sec))
     observe_codex_app_server_goal_turn(turn, timeout_sec=0.0, raise_on_error=False)
+    terminal_failure = _terminal_app_server_failure(turn)
+    if terminal_failure:
+        raise CodexAppServerGoalDriverError(terminal_failure)
     return bool(turn.turn_completed_observed)
 
 
@@ -193,9 +219,11 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
                     raise TimeoutError(
                         "timed out waiting for app-server worker turn completion"
                     )
-            except TimeoutError as exc:
+            except (TimeoutError, CodexAppServerGoalDriverError) as exc:
                 if str(exc) == "codex_exec_first_action_timeout":
                     worker_error_type = "codex_exec_first_action_timeout"
+                elif str(exc).startswith("codex_app_server_"):
+                    worker_error_type = str(exc)
                 else:
                     worker_error_type = "codex_app_server_turn_timeout"
         compact = compact_turn_metadata(turn)


### PR DESCRIPTION
## Summary
- record Codex app-server stream EOF / process exit in compact turn metadata
- make the SkillsBench app-server Goal worker fail fast when the app-server exits before turn completion
- add a fake-codex regression smoke so closed streams do not wait for the long first-action timeout

## Validation
- python3 -m py_compile scripts/codex_app_server_goal_driver.py scripts/skillsbench_host_codex_goal_worker.py
- python3 examples/codex-app-server-goal-driver-smoke.py
- python3 examples/skillsbench-app-server-goal-worker-smoke.py