### PR TITLE
Allow agent-scoped todo list reads

### DIFF
--- a/examples/todo-cli-smoke.py
+++ b/examples/todo-cli-smoke.py
@@ -536,6 +536,40 @@ def main() -> int:
         assert claimed_fields["agent_todos"]["claimed_monitor_open_count"] == 1, claimed_fields
         assert claimed_fields["agent_todos"]["unclaimed_open_count"] == 0, claimed_fields
 
+        side_agent_list = run_cli(
+            registry_path,
+            "todo",
+            "list",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--agent-id",
+            "codex-side-bypass",
+        )
+        assert side_agent_list["ok"] is True, side_agent_list
+        assert side_agent_list["agent_id_filter"] == "codex-side-bypass", side_agent_list
+        assert side_agent_list["unfiltered_todo_count"] == 2, side_agent_list
+        assert side_agent_list["todo_count"] == 1, side_agent_list
+        assert side_agent_list["todos"][0]["todo_id"] == monitor_payload["todo_id"], side_agent_list
+        assert side_agent_list["todos"][0]["claimed_by"] == "codex-side-bypass", side_agent_list
+
+        main_agent_list = run_cli(
+            registry_path,
+            "todo",
+            "list",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--agent-id",
+            "codex-main-control",
+        )
+        assert main_agent_list["ok"] is True, main_agent_list
+        assert main_agent_list["todo_count"] == 1, main_agent_list
+        assert main_agent_list["todos"][0]["todo_id"] == metadata_payload["todo_id"], main_agent_list
+        assert main_agent_list["todos"][0]["claimed_by"] == "codex-main-control", main_agent_list
+
         preserve_claim_payload = run_cli(
             registry_path,
             "todo",

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -300,17 +300,22 @@ def handle_todo_command(
             and args.role == "user"
             and args.task_class == "user_gate"
         )
+        agent_id_allowed_for_read = args.todo_command == "list"
         global_gate_allowed = args.todo_command in {"add", "update"}
         if args.todo_command not in {"suggest", "capture-followups"} and (
-            (args.agent_id and not agent_id_allowed_for_gate_authoring)
+            (
+                args.agent_id
+                and not agent_id_allowed_for_gate_authoring
+                and not agent_id_allowed_for_read
+            )
             or (args.global_gate and not global_gate_allowed)
             or args.suggestion_sources
             or args.suggestion_limit is not None
             or args.suggestion_trigger
         ):
             raise ValueError(
-                "todo --agent-id is supported by `todo suggest` and by "
-                "`todo add/update --role user --task-class user_gate` for "
+                "todo --agent-id is supported by `todo list`, `todo suggest`, and "
+                "by `todo add/update --role user --task-class user_gate` for "
                 "agent-scoped user gates; --global-gate is supported by "
                 "`todo add/update` for user gates; --from, --limit, and "
                 "--trigger are only supported by `todo suggest`"
@@ -348,7 +353,6 @@ def handle_todo_command(
                     ("--next-task-class", args.next_task_class),
                     ("--next-action-kind", args.next_action_kind),
                     ("--side-agent-self-merged", args.side_agent_self_merged),
-                    ("--agent-id", args.agent_id),
                     ("--from", args.suggestion_sources),
                     ("--limit", args.suggestion_limit),
                     ("--trigger", args.suggestion_trigger),
@@ -359,7 +363,7 @@ def handle_todo_command(
             if unsupported:
                 raise ValueError(
                     "todo list only accepts --goal-id, optional --role, --status, --todo-id, "
-                    "--project, --state-file, --dry-run, and --format; unsupported: "
+                    "--agent-id, --project, --state-file, --dry-run, and --format; unsupported: "
                     + ", ".join(unsupported)
                 )
             payload = list_goal_todos(
@@ -368,6 +372,7 @@ def handle_todo_command(
                 role=args.role,
                 status=args.status,
                 todo_id=args.todo_id,
+                agent_id=args.agent_id,
                 project=Path(args.project).expanduser() if args.project else None,
                 state_file=Path(args.state_file).expanduser() if args.state_file else None,
             )

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -382,6 +382,7 @@ def filtered_todo_summary(
     role: str,
     status: str | None = None,
     todo_id: str | None = None,
+    agent_id: str | None = None,
 ) -> dict[str, Any]:
     items = list((summary or {}).get("items") or [])
     normalized_status = normalize_todo_status(status)
@@ -394,6 +395,23 @@ def filtered_todo_summary(
             for item in items
             if normalize_todo_id(item.get("todo_id")) == normalized_todo_id
         ]
+    normalized_agent_id = normalize_todo_claimed_by(agent_id) if agent_id else None
+    if normalized_agent_id:
+        if role == "agent":
+            items = [
+                item
+                for item in items
+                if not normalize_todo_claimed_by(item.get("claimed_by"))
+                or normalize_todo_claimed_by(item.get("claimed_by")) == normalized_agent_id
+            ]
+        elif role == "user":
+            items = [
+                item
+                for item in items
+                if bool(item.get("global_gate"))
+                or not normalize_todo_blocks_agent(item.get("blocks_agent"))
+                or normalize_todo_blocks_agent(item.get("blocks_agent")) == normalized_agent_id
+            ]
     source_section = str((summary or {}).get("source_section") or TODO_SECTION_HEADINGS[role])
     return (
         compact_todo_group(
@@ -513,12 +531,16 @@ def list_goal_todos(
     role: str | None = None,
     status: str | None = None,
     todo_id: str | None = None,
+    agent_id: str | None = None,
     project: Path | None = None,
     state_file: Path | None = None,
 ) -> dict[str, Any]:
     normalized_todo_id = normalize_todo_id(todo_id) if todo_id else None
     if todo_id and not normalized_todo_id:
         raise ValueError("todo_id must use the public token shape todo_<letters-digits-underscore-hyphen>")
+    normalized_agent_id = normalize_todo_claimed_by(agent_id) if agent_id else None
+    if agent_id and not normalized_agent_id:
+        raise ValueError("agent_id must be a public-safe agent token such as codex-main-control")
     registry = load_registry(registry_path)
     goal, resolved_project, resolved_state_file = resolve_goal_state(
         registry=registry,
@@ -565,13 +587,17 @@ def list_goal_todos(
     roles = [role] if role else ["user", "agent"]
     summaries: dict[str, dict[str, Any]] = {}
     todos: list[dict[str, Any]] = []
+    unfiltered_count = 0
     for item_role in roles:
         key = f"{item_role}_todos"
+        raw_summary = fields.get(key) if isinstance(fields, dict) else None
+        unfiltered_count += len((raw_summary or {}).get("items") or [])
         summary = filtered_todo_summary(
-            fields.get(key) if isinstance(fields, dict) else None,
+            raw_summary,
             role=item_role,
             status=status,
             todo_id=normalized_todo_id,
+            agent_id=normalized_agent_id,
         )
         summaries[key] = summary
         todos.extend(summary.get("items") or [])
@@ -591,6 +617,13 @@ def list_goal_todos(
         "state_file": str(resolved_state_file),
         "project": str(resolved_project) if resolved_project else None,
     }
+    if normalized_agent_id:
+        payload["agent_id_filter"] = normalized_agent_id
+        payload["unfiltered_todo_count"] = unfiltered_count
+        payload["filter_semantics"] = (
+            "agent todos include unclaimed items plus claimed_by=<agent>; "
+            "user todos include global, unscoped legacy, and blocks_agent=<agent> gates"
+        )
     if normalized_todo_id:
         payload["todo_id_filter"] = normalized_todo_id
         payload["matched"] = bool(todos)
@@ -1949,6 +1982,14 @@ def render_todo_markdown(payload: dict[str, Any]) -> str:
             f"- todo_count: `{payload.get('todo_count')}`",
             f"- state_file: `{payload.get('state_file')}`",
         ]
+        if payload.get("agent_id_filter"):
+            lines.extend(
+                [
+                    f"- agent_id_filter: `{payload.get('agent_id_filter')}`",
+                    f"- unfiltered_todo_count: `{payload.get('unfiltered_todo_count')}`",
+                    f"- filter_semantics: `{payload.get('filter_semantics')}`",
+                ]
+            )
         projection = payload.get("state_event_projection")
         if isinstance(projection, dict):
             lines.extend(


### PR DESCRIPTION
## Summary
- allow `loopx todo list --agent-id <agent>` as a read-only cold path
- filter agent todos to unclaimed plus `claimed_by=<agent>`, and user todos to global/unscoped plus `blocks_agent=<agent>` gates
- show the agent filter, unfiltered count, and canonical state file in the list payload/markdown

## Validation
- `python3 examples/todo-cli-smoke.py`
- `python3 examples/todo-list-event-projection-smoke.py`
- `python3 -m compileall -q loopx/cli_commands/todo.py loopx/todos.py`
- source-run `todo list --goal-id loopx-meta --role agent --agent-id codex-side-bypass` against the global registry
