### PR TITLE
Isolate auto-research demo goal defaults

### DIFF
--- a/examples/auto-research-demo-goal-isolation-smoke.py
+++ b/examples/auto-research-demo-goal-isolation-smoke.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Smoke-test isolated goal defaults for the one-command auto-research demo."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_GOAL_ID = "loopx-auto-research-knn"
+FRESH_GOAL_ID = "loopx-auto-research-demo-smoke-001"
+EXPLICIT_GOAL_ID = "loopx-auto-research-demo-explicit"
+AGENT_ID = "codex-side-bypass"
+
+
+def assert_public_safe(payload: Any) -> None:
+    text = json.dumps(payload, sort_keys=True) if not isinstance(payload, str) else payload
+    forbidden = [
+        "/" + "Users/",
+        "/" + "private/",
+        "/" + "tmp/",
+        "http://",
+        "https://",
+        "api" + "_key",
+        "pass" + "word",
+        "sec" + "ret",
+    ]
+    leaked = [needle for needle in forbidden if needle.lower() in text.lower()]
+    assert not leaked, leaked
+
+
+def run_cli(
+    args: list[str],
+    *,
+    registry: Path,
+    runtime_root: Path,
+    cwd: Path,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry),
+            "--runtime-root",
+            str(runtime_root),
+            "--format",
+            "json",
+            *args,
+        ],
+        cwd=cwd,
+        env=env,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def read_json(result: subprocess.CompletedProcess[str]) -> dict[str, Any]:
+    payload = json.loads(result.stdout)
+    assert_public_safe(payload)
+    return payload
+
+
+def assert_route(
+    payload: dict[str, Any],
+    *,
+    goal_id: str,
+    mode: str,
+    reuses_default: bool,
+) -> None:
+    assert payload["ok"] is True, payload
+    assert payload["goal_id"] == goal_id, payload
+    route = payload["route_contract"]
+    assert route["frontier_goal_id"] == goal_id, route
+    assert route["visible_lanes_read_goal_id"] == goal_id, route
+    assert route["goal_surface_mode"] == mode, route
+    assert route["reuses_default_internal_goal"] is reuses_default, route
+    assert route["default_internal_goal_id"] == DEFAULT_GOAL_ID, route
+    assert route["dedicated_positive_demo_frontier"] is (not reuses_default), route
+    if mode == "fresh_demo_goal":
+        assert route["fresh_goal_default"] is True, route
+        assert route["inherits_default_goal"] is False, route
+        assert goal_id.startswith("loopx-auto-research-demo-"), route
+    if mode == "inherited_default_goal":
+        assert route["fresh_goal_default"] is False, route
+        assert route["inherits_default_goal"] is True, route
+    assert "--goal-id " + goal_id in payload["commands"]["multiround_kernel"], payload
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        workspace = temp / "workspace"
+        workspace.mkdir()
+        registry = temp / "registry.json"
+        runtime_root = temp / "runtime"
+        registry.write_text(
+            json.dumps({"common_runtime_root": str(runtime_root), "goals": []}),
+            encoding="utf-8",
+        )
+
+        fresh = read_json(
+            run_cli(
+                [
+                    "auto-research",
+                    "demo-e2e",
+                    "--agent-id",
+                    AGENT_ID,
+                    "--demo-run-id",
+                    "smoke-001",
+                ],
+                registry=registry,
+                runtime_root=runtime_root,
+                cwd=workspace,
+            )
+        )
+        assert_route(
+            fresh,
+            goal_id=FRESH_GOAL_ID,
+            mode="fresh_demo_goal",
+            reuses_default=False,
+        )
+
+        inherited = read_json(
+            run_cli(
+                [
+                    "auto-research",
+                    "demo-e2e",
+                    "--agent-id",
+                    AGENT_ID,
+                    "--inherit-default-goal",
+                ],
+                registry=registry,
+                runtime_root=runtime_root,
+                cwd=workspace,
+            )
+        )
+        assert_route(
+            inherited,
+            goal_id=DEFAULT_GOAL_ID,
+            mode="inherited_default_goal",
+            reuses_default=True,
+        )
+
+        explicit = read_json(
+            run_cli(
+                [
+                    "auto-research",
+                    "demo-e2e",
+                    "--agent-id",
+                    AGENT_ID,
+                    "--goal-id",
+                    EXPLICIT_GOAL_ID,
+                ],
+                registry=registry,
+                runtime_root=runtime_root,
+                cwd=workspace,
+            )
+        )
+        assert_route(
+            explicit,
+            goal_id=EXPLICIT_GOAL_ID,
+            mode="explicit_goal",
+            reuses_default=False,
+        )
+
+        supervisor = read_json(
+            run_cli(
+                [
+                    "auto-research",
+                    "demo-supervisor",
+                    "--demo-run-id",
+                    "smoke-001",
+                ],
+                registry=registry,
+                runtime_root=runtime_root,
+                cwd=workspace,
+            )
+        )
+        assert supervisor["goal_id"] == FRESH_GOAL_ID, supervisor
+        surface = supervisor["goal_surface_route"]
+        assert surface["mode"] == "fresh_demo_goal", surface
+        assert surface["fresh_by_default"] is True, surface
+        assert surface["reuses_default_internal_goal"] is False, surface
+
+        conflict = read_json(
+            run_cli(
+                [
+                    "auto-research",
+                    "demo-e2e",
+                    "--agent-id",
+                    AGENT_ID,
+                    "--goal-id",
+                    EXPLICIT_GOAL_ID,
+                    "--inherit-default-goal",
+                ],
+                registry=registry,
+                runtime_root=runtime_root,
+                cwd=workspace,
+                check=False,
+            )
+        )
+        assert conflict["ok"] is False, conflict
+        assert "--inherit-default-goal cannot be combined with --goal-id" in conflict["error"], conflict
+
+    print("auto-research demo goal isolation smoke passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -2,8 +2,10 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 from collections import Counter
 from collections.abc import Callable
+from datetime import datetime, timezone
 from pathlib import Path
 
 from .kernel import run_builtin_lightweight_demo
@@ -49,6 +51,33 @@ PrintPayload = Callable[
 ]
 FormatSelector = Callable[..., str]
 AddFormat = Callable[[argparse.ArgumentParser], None]
+
+AUTO_RESEARCH_DEMO_GOAL_PREFIX = "loopx-auto-research-demo"
+
+
+def _demo_goal_suffix(value: object, *, fallback: str = "run") -> str:
+    text = re.sub(r"[^A-Za-z0-9._-]+", "-", str(value or "").strip()).strip("-._")
+    return text[:40] or fallback
+
+
+def _resolve_demo_goal_surface(
+    *,
+    goal_id: str | None,
+    demo_run_id: str | None,
+    inherit_default_goal: bool,
+) -> tuple[str, str]:
+    if inherit_default_goal and goal_id:
+        raise ValueError("--inherit-default-goal cannot be combined with --goal-id")
+    if inherit_default_goal and demo_run_id:
+        raise ValueError("--inherit-default-goal cannot be combined with --demo-run-id")
+    if goal_id and demo_run_id:
+        raise ValueError("--demo-run-id is only used when --goal-id is omitted")
+    if inherit_default_goal:
+        return AUTO_RESEARCH_DEFAULT_GOAL_ID, "inherited_default_goal"
+    if goal_id:
+        return goal_id, "explicit_goal"
+    run_id = demo_run_id or datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return f"{AUTO_RESEARCH_DEMO_GOAL_PREFIX}-{_demo_goal_suffix(run_id)}", "fresh_demo_goal"
 
 
 def register_auto_research_commands(
@@ -380,8 +409,19 @@ def register_auto_research_commands(
     add_subcommand_format(demo_supervisor_parser)
     demo_supervisor_parser.add_argument(
         "--goal-id",
-        default=AUTO_RESEARCH_DEFAULT_GOAL_ID,
-        help="Research goal id whose frontier each lane should inspect.",
+        help=(
+            "Research goal id whose frontier each lane should inspect. "
+            "Omit to use a fresh demo-local goal surface."
+        ),
+    )
+    demo_supervisor_parser.add_argument(
+        "--demo-run-id",
+        help="Public-safe suffix for the generated demo goal id when --goal-id is omitted.",
+    )
+    demo_supervisor_parser.add_argument(
+        "--inherit-default-goal",
+        action="store_true",
+        help=f"Opt into the shared internal demo goal {AUTO_RESEARCH_DEFAULT_GOAL_ID}.",
     )
     demo_supervisor_parser.add_argument(
         "--agent",
@@ -454,8 +494,19 @@ def register_auto_research_commands(
     demo_e2e_parser.add_argument("--agent-id", required=True)
     demo_e2e_parser.add_argument(
         "--goal-id",
-        default=AUTO_RESEARCH_DEFAULT_GOAL_ID,
-        help="Research goal id for the positive demo evidence.",
+        help=(
+            "Research goal id for the demo evidence. "
+            "Omit to create a fresh isolated demo goal surface."
+        ),
+    )
+    demo_e2e_parser.add_argument(
+        "--demo-run-id",
+        help="Public-safe suffix for the generated demo goal id when --goal-id is omitted.",
+    )
+    demo_e2e_parser.add_argument(
+        "--inherit-default-goal",
+        action="store_true",
+        help=f"Opt into reusing the shared internal demo goal {AUTO_RESEARCH_DEFAULT_GOAL_ID}.",
     )
     demo_e2e_parser.add_argument(
         "--tracking-goal-id",
@@ -833,8 +884,13 @@ def handle_auto_research_command(
                 max_rounds=args.max_rounds,
             )
         elif args.auto_research_command == "demo-supervisor":
-            payload = build_auto_research_demo_supervisor_plan(
+            goal_id, goal_surface_mode = _resolve_demo_goal_surface(
                 goal_id=args.goal_id,
+                demo_run_id=args.demo_run_id,
+                inherit_default_goal=args.inherit_default_goal,
+            )
+            payload = build_auto_research_demo_supervisor_plan(
+                goal_id=goal_id,
                 agent_specs=args.agent,
                 session_name=args.session_name,
                 cli_bin=args.cli_bin,
@@ -842,6 +898,14 @@ def handle_auto_research_command(
                 tmux_bin=args.tmux_bin,
                 reasoning_effort=args.reasoning_effort,
             )
+            payload["goal_surface_route"] = {
+                "schema_version": "auto_research_demo_goal_surface_v0",
+                "mode": goal_surface_mode,
+                "goal_id": goal_id,
+                "fresh_by_default": goal_surface_mode == "fresh_demo_goal",
+                "reuses_default_internal_goal": goal_id == AUTO_RESEARCH_DEFAULT_GOAL_ID,
+                "default_internal_goal_id": AUTO_RESEARCH_DEFAULT_GOAL_ID,
+            }
             if args.execute:
                 payload = _execute_auto_research_demo_supervisor(
                     payload,
@@ -857,6 +921,12 @@ def handle_auto_research_command(
                     create_workspace=args.create_workspace,
                 )
         elif args.auto_research_command == "demo-e2e":
+            goal_id, goal_surface_mode = _resolve_demo_goal_surface(
+                goal_id=args.goal_id,
+                demo_run_id=args.demo_run_id,
+                inherit_default_goal=args.inherit_default_goal,
+            )
+
             def append_demo_e2e_evidence(packet_path: str) -> dict[str, object]:
                 return _append_auto_research_rollout_events(
                     packet_path=packet_path,
@@ -890,7 +960,8 @@ def handle_auto_research_command(
 
             payload = run_auto_research_demo_e2e(
                 agent_id=args.agent_id,
-                goal_id=args.goal_id,
+                goal_id=goal_id,
+                goal_surface_mode=goal_surface_mode,
                 tracking_goal_id=args.tracking_goal_id,
                 objective=args.objective,
                 output_dir=args.output_dir,

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -626,6 +626,7 @@ def run_auto_research_demo_e2e(
     live_evidence_path: str | None,
     append_evidence: AppendEvidence,
     visible_launcher: VisibleLauncher | None = None,
+    goal_surface_mode: str = "explicit_goal",
 ) -> dict[str, object]:
     if launch_visible and not execute:
         raise ValueError("--launch-visible requires --execute")
@@ -637,6 +638,7 @@ def run_auto_research_demo_e2e(
     tracking_goal = tracking_goal_id.strip() if isinstance(tracking_goal_id, str) else ""
     if tracking_goal == goal_id:
         tracking_goal = ""
+    reuses_default_internal_goal = goal_id == AUTO_RESEARCH_DEFAULT_GOAL_ID
     supervisor = build_auto_research_demo_supervisor_plan(
         goal_id=goal_id,
         session_name=session_name,
@@ -657,14 +659,21 @@ def run_auto_research_demo_e2e(
         "tracking_goal_id": tracking_goal or None,
         "route_contract": {
             "schema_version": "auto_research_demo_frontier_route_v0",
+            "goal_surface_mode": goal_surface_mode,
             "frontier_goal_id": goal_id,
             "tracking_goal_id": tracking_goal or None,
             "tracking_goal_drives_frontier": False,
             "visible_lanes_read_goal_id": goal_id,
-            "dedicated_positive_demo_frontier": goal_id == AUTO_RESEARCH_DEFAULT_GOAL_ID,
+            "fresh_goal_default": goal_surface_mode == "fresh_demo_goal",
+            "inherits_default_goal": goal_surface_mode == "inherited_default_goal",
+            "reuses_default_internal_goal": reuses_default_internal_goal,
+            "default_internal_goal_id": AUTO_RESEARCH_DEFAULT_GOAL_ID,
+            "dedicated_positive_demo_frontier": not reuses_default_internal_goal,
             "reason": (
-                "Use --goal-id for the research frontier that visible lanes inspect. "
-                "--tracking-goal-id is metadata for the parent productization goal and must not reroute panes."
+                "Omitting --goal-id creates an isolated demo goal surface. "
+                "Use --goal-id to target a specific research frontier, or --inherit-default-goal "
+                "to intentionally reuse the internal shared demo goal. --tracking-goal-id is metadata "
+                "for the parent productization goal and must not reroute panes."
             ),
         },
         "agent_id": agent_id,


### PR DESCRIPTION
## Summary
- make auto-research demo-e2e and demo-supervisor default to a fresh demo goal surface when --goal-id is omitted
- keep explicit --goal-id targeting and add --inherit-default-goal for intentional reuse of loopx-auto-research-knn
- expose goal-surface routing in the demo route contract and add a focused smoke

## Validation
- python3 -m compileall loopx/capabilities/auto_research examples/auto-research-demo-goal-isolation-smoke.py
- python3 examples/auto-research-demo-goal-isolation-smoke.py
- python3 examples/auto-research-demo-supervisor-smoke.py
- python3 examples/auto-research-live-evidence-capture-smoke.py
- python3 examples/auto-research-worker-turn-smoke.py
- loopx check --scan-path loopx/capabilities/auto_research/cli.py --scan-path loopx/capabilities/auto_research/demo_e2e.py --scan-path examples/auto-research-demo-goal-isolation-smoke.py
