### PR TITLE
Add one-command auto-research worker-loop demo

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Smoke-test the one-command demo-e2e path with a real LoopX worker loop."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+AGENT_ID = "codex-side-bypass"
+GOAL_ID = "loopx-auto-research-demo-worker-loop-smoke"
+
+
+def assert_public_safe(payload: Any) -> None:
+    text = json.dumps(payload, sort_keys=True) if not isinstance(payload, str) else payload
+    forbidden = [
+        "/" + "Users/",
+        "/" + "private/",
+        "/" + "tmp/",
+        "http://",
+        "https://",
+        "api" + "_key",
+        "pass" + "word",
+        "sec" + "ret",
+    ]
+    leaked = [needle for needle in forbidden if needle.lower() in text.lower()]
+    assert not leaked, leaked
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        workspace = temp / "workspace"
+        workspace.mkdir()
+        registry = temp / "registry.json"
+        runtime_root = temp / "runtime"
+        registry.write_text(
+            json.dumps({"common_runtime_root": str(runtime_root), "goals": []}),
+            encoding="utf-8",
+        )
+        env = os.environ.copy()
+        env["PYTHONDONTWRITEBYTECODE"] = "1"
+        env["PYTHONPATH"] = str(REPO_ROOT)
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "loopx.cli",
+                "--registry",
+                str(registry),
+                "--runtime-root",
+                str(runtime_root),
+                "--format",
+                "json",
+                "auto-research",
+                "demo-e2e",
+                "--agent-id",
+                AGENT_ID,
+                "--demo-run-id",
+                "worker-loop-smoke",
+                "--execute",
+                "--run-worker-loop",
+            ],
+            cwd=workspace,
+            env=env,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise AssertionError(
+                f"demo-e2e worker-loop failed rc={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+            )
+        payload = json.loads(result.stdout)
+        assert payload["ok"] is True, payload
+        assert payload["goal_id"] == GOAL_ID, payload
+        assert payload["execution_kind"] == "loopx_worker_loop_plus_minimal_kernel", payload
+        assert payload["result_source"] == "loopx_worker_loop_with_protected_eval", payload
+        assert payload["route_contract"]["goal_surface_mode"] == "fresh_demo_goal", payload
+        assert payload["supervisor"]["lane_count"] == 4, payload
+        worker_loop = payload["worker_loop"]
+        assert worker_loop["schema_version"] == "auto_research_worker_loop_v0", payload
+        assert worker_loop["mode"] == "execute", payload
+        assert worker_loop["executed_turn_count"] == 4, payload
+        assert worker_loop["completed_turn_count"] == 4, payload
+        assert worker_loop["selected_actions"] == [
+            "write_research_contract",
+            "propose_hypothesis",
+            "run_dev_eval",
+            "run_holdout_eval",
+        ], payload
+        assert worker_loop["stop_reason"] == "no_runnable_frontier", payload
+        tonight = payload["tonight_experience"]
+        assert tonight["ready"] is True, tonight
+        assert tonight["positive_result"] is True, tonight
+        assert tonight["coordination_pattern"] == "decentralized_state_a2a", tonight
+        assert tonight["workflow_model"] == "state_projected_frontier_not_dynamic_workflow", tonight
+        assert tonight["leader_agent_required"] is False, tonight
+        assert tonight["dev_metric"] == 4.0, tonight
+        assert tonight["holdout_metric"] == 4.5, tonight
+        assert "--run-worker-loop" in tonight["one_command"], tonight
+        claim = payload["claim_summary"]
+        assert claim["status"] == "loopx_worker_loop_positive", claim
+        assert claim["can_claim"] == ["one_command_loopx_worker_loop_positive_result"], claim
+        assert "visible_codex_tui_authored_result" in claim["cannot_claim"], claim
+        assert_public_safe(payload)
+    print("auto-research-demo-e2e-worker-loop-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 import json
 import re
-from collections import Counter
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
@@ -13,15 +12,12 @@ from .legacy_core import (
     AUTO_RESEARCH_DEFAULT_GOAL_ID,
     AUTO_RESEARCH_DEFAULT_OBJECTIVE,
     AUTO_RESEARCH_QUICKSTART_TEMPLATE,
-    AUTO_RESEARCH_ROLLOUT_APPEND_SCHEMA_VERSION,
     build_auto_research_board_projection,
     build_auto_research_demo_acceptance_packet,
     build_auto_research_demo_supervisor_plan,
     build_auto_research_quickstart,
-    build_auto_research_rollout_events,
     build_live_auto_research_projection,
     build_auto_research_projection,
-    load_auto_research_evidence_packet,
     load_auto_research_evidence_packet_inputs,
     load_auto_research_fixture,
     render_auto_research_markdown,
@@ -33,14 +29,13 @@ from .live_evidence import (
 )
 from .worker_loop import run_auto_research_worker_loop
 from .worker_runtime import run_auto_research_worker_turn
+from .rollout_append import (
+    append_auto_research_rollout_events as _append_auto_research_rollout_events,
+)
 from ...history import load_registry
 from ...paths import resolve_runtime_root
 from ...quota import build_quota_should_run
-from ...rollout_event_log import (
-    append_rollout_event,
-    load_rollout_events,
-    rollout_event_log_path,
-)
+from ...rollout_event_log import load_rollout_events, rollout_event_log_path
 from ...status import collect_status
 from ...visible_multi_agent_launcher import execute_visible_multi_agent_launcher
 
@@ -493,6 +488,15 @@ def register_auto_research_commands(
     add_subcommand_format(demo_e2e_parser)
     demo_e2e_parser.add_argument("--agent-id", required=True)
     demo_e2e_parser.add_argument(
+        "--agent",
+        action="append",
+        default=[],
+        help=(
+            "Optional visible worker lane as agent_id:lane_id:role_id. "
+            "When --run-worker-loop is set and omitted, demo-e2e uses the default four-role worker loop."
+        ),
+    )
+    demo_e2e_parser.add_argument(
         "--goal-id",
         help=(
             "Research goal id for the demo evidence. "
@@ -533,6 +537,20 @@ def register_auto_research_commands(
             "and report measured dev/holdout gains. This still requires live evidence before "
             "claiming that visible Codex panes authored the result."
         ),
+    )
+    demo_e2e_parser.add_argument(
+        "--run-worker-loop",
+        action="store_true",
+        help=(
+            "With --execute, seed a demo-local LoopX goal queue and run the role-compatible "
+            "auto-research worker-loop against quota/frontier before optional visible launch."
+        ),
+    )
+    demo_e2e_parser.add_argument(
+        "--worker-loop-rounds",
+        type=int,
+        default=2,
+        help="Maximum worker-loop rounds for --run-worker-loop.",
     )
     demo_e2e_parser.add_argument(
         "--launch-visible",
@@ -603,59 +621,6 @@ def register_auto_research_commands(
         default="loopx-auto-research-lite",
         help="Public-safe goal id for the lightweight demo result.",
     )
-
-
-def _append_auto_research_rollout_events(
-    *,
-    packet_path: str,
-    registry_path: Path,
-    runtime_root_arg: str | None,
-    dry_run: bool,
-) -> dict[str, object]:
-    packet = load_auto_research_evidence_packet(packet_path)
-    goal_id = packet["research_contract"]["goal_id"]
-    events = build_auto_research_rollout_events(packet)
-    registry = load_registry(registry_path)
-    runtime_root = resolve_runtime_root(registry, runtime_root_arg)
-    log_path = rollout_event_log_path(runtime_root, goal_id)
-    existing_ids = {
-        str(event.get("event_id"))
-        for event in load_rollout_events(log_path)
-        if event.get("event_id")
-    }
-    appended_ids: list[str] = []
-    skipped_ids: list[str] = []
-    for event in events:
-        event_id = str(event["event_id"])
-        if event_id in existing_ids:
-            skipped_ids.append(event_id)
-            continue
-        if not dry_run:
-            append_rollout_event(log_path, event)
-            existing_ids.add(event_id)
-        appended_ids.append(event_id)
-    counts_by_kind = Counter(str(event.get("event_kind") or "") for event in events)
-    return {
-        "ok": True,
-        "schema_version": AUTO_RESEARCH_ROLLOUT_APPEND_SCHEMA_VERSION,
-        "goal_id": goal_id,
-        "dry_run": dry_run,
-        "event_count": len(events),
-        "appended_count": 0 if dry_run else len(appended_ids),
-        "would_append_count": len(appended_ids),
-        "skipped_existing_count": len(skipped_ids),
-        "event_ids": [str(event["event_id"]) for event in events],
-        "appended_event_ids": [] if dry_run else appended_ids,
-        "skipped_existing_event_ids": skipped_ids,
-        "counts_by_kind": dict(sorted(counts_by_kind.items())),
-        "packet_summary": packet["summary"],
-        "public_boundary": {
-            "raw_logs_recorded": False,
-            "private_artifacts_recorded": False,
-            "absolute_paths_recorded": False,
-            "source": "loopx_rollout_event_log",
-        },
-    }
 
 
 def _execute_auto_research_demo_supervisor(
@@ -962,10 +927,13 @@ def handle_auto_research_command(
                 agent_id=args.agent_id,
                 goal_id=goal_id,
                 goal_surface_mode=goal_surface_mode,
+                agent_specs=args.agent,
                 tracking_goal_id=args.tracking_goal_id,
                 objective=args.objective,
                 output_dir=args.output_dir,
                 execute=args.execute,
+                run_worker_loop=args.run_worker_loop,
+                worker_loop_rounds=args.worker_loop_rounds,
                 launch_visible=args.launch_visible,
                 keep_workspace=args.keep_workspace,
                 registry_path=registry_path,

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -6,7 +6,7 @@ import shlex
 import subprocess
 import sys
 import tempfile
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from pathlib import Path
 
 from .kernel import run_builtin_lightweight_demo
@@ -28,6 +28,8 @@ from .live_evidence import (
     build_live_codex_claim_from_evidence,
     load_live_codex_e2e_evidence,
 )
+from .rollout_append import append_auto_research_rollout_events
+from .worker_loop import run_auto_research_worker_loop
 from ...history import load_registry
 from ...paths import resolve_runtime_root
 from ...quota import build_quota_should_run
@@ -37,6 +39,13 @@ from ...status import collect_status
 
 AppendEvidence = Callable[[str], dict[str, object]]
 VisibleLauncher = Callable[..., dict[str, object]]
+
+DEFAULT_WORKER_LOOP_AGENT_SPECS = [
+    "codex-product-capability:research-curator:research_curator",
+    "codex-side-bypass:hypothesis-mapper:hypothesis_mapper",
+    "codex-main-control:evidence-runner:evidence_runner",
+    "codex-value-explorer:evidence-verifier:evidence_verifier",
+]
 
 
 def _safe_ref_fragment(value: object, *, fallback: str) -> str:
@@ -385,6 +394,7 @@ def _command_text(
     goal_id: str,
     agent_id: str,
     execute: bool,
+    run_worker_loop: bool = False,
     launch_visible: bool = False,
     live_evidence: bool = False,
     tracking_goal_id: str | None = None,
@@ -404,6 +414,8 @@ def _command_text(
         parts.extend(["--tracking-goal-id", shlex.quote(tracking_goal_id)])
     if execute:
         parts.append("--execute")
+    if run_worker_loop:
+        parts.append("--run-worker-loop")
     if launch_visible:
         parts.append("--launch-visible")
     if live_evidence:
@@ -439,6 +451,11 @@ def _demo_claim_summary(payload: dict[str, object]) -> dict[str, object]:
         if isinstance(payload.get("protected_eval_result"), dict)
         else {}
     )
+    tonight = (
+        payload.get("tonight_experience")
+        if isinstance(payload.get("tonight_experience"), dict)
+        else {}
+    )
     research_loop = (
         payload.get("research_loop")
         if isinstance(payload.get("research_loop"), dict)
@@ -466,6 +483,28 @@ def _demo_claim_summary(payload: dict[str, object]) -> dict[str, object]:
             "next_required": (
                 "separate held-out live evidence or owner-approved claim authority "
                 "is required before holdout or promotion claims"
+            ),
+        }
+
+    if tonight.get("ready") and tonight.get("positive_result"):
+        return {
+            "schema_version": "auto_research_demo_claim_summary_v0",
+            "status": "loopx_worker_loop_positive",
+            "claim_basis": "loopx_worker_loop_public_evidence",
+            "live_worker_claim_allowed": False,
+            "live_worker_authored": False,
+            "kernel_precheck_passed": bool(protected_eval.get("executed")),
+            "can_claim": ["one_command_loopx_worker_loop_positive_result"],
+            "cannot_claim": [
+                "visible_codex_tui_authored_result",
+                "automatic_promotion_success",
+            ],
+            "dev_metric": tonight.get("dev_metric"),
+            "holdout_metric": tonight.get("holdout_metric"),
+            "holdout_metric_redacted": False,
+            "next_required": (
+                "launch visible Codex panes or pass compact live evidence before claiming "
+                "Codex TUI workers authored the same result"
             ),
         }
 
@@ -627,9 +666,16 @@ def run_auto_research_demo_e2e(
     append_evidence: AppendEvidence,
     visible_launcher: VisibleLauncher | None = None,
     goal_surface_mode: str = "explicit_goal",
+    agent_specs: Sequence[str] | None = None,
+    run_worker_loop: bool = False,
+    worker_loop_rounds: int = 2,
 ) -> dict[str, object]:
     if launch_visible and not execute:
         raise ValueError("--launch-visible requires --execute")
+    if run_worker_loop and not execute:
+        raise ValueError("--run-worker-loop requires --execute")
+    if worker_loop_rounds < 1:
+        raise ValueError("--worker-loop-rounds must be >= 1")
     if launch_visible and visible_launcher is None:
         raise ValueError("--launch-visible requires a visible launcher callback")
     if live_evidence_path and not execute:
@@ -639,22 +685,38 @@ def run_auto_research_demo_e2e(
     if tracking_goal == goal_id:
         tracking_goal = ""
     reuses_default_internal_goal = goal_id == AUTO_RESEARCH_DEFAULT_GOAL_ID
+    effective_agent_specs = list(agent_specs or [])
+    if run_worker_loop and not effective_agent_specs:
+        effective_agent_specs = list(DEFAULT_WORKER_LOOP_AGENT_SPECS)
     supervisor = build_auto_research_demo_supervisor_plan(
         goal_id=goal_id,
+        agent_specs=effective_agent_specs,
         session_name=session_name,
         cli_bin=cli_bin,
         codex_bin=codex_bin,
         tmux_bin=tmux_bin,
         reasoning_effort=reasoning_effort,
     )
+    execution_kind = (
+        "loopx_worker_loop_plus_minimal_kernel"
+        if execute and run_worker_loop
+        else "minimal_research_kernel"
+        if execute
+        else "minimal_research_preview"
+    )
+    result_source = (
+        "loopx_worker_loop_with_protected_eval"
+        if execute and run_worker_loop
+        else "deterministic_protected_eval_kernel"
+        if execute
+        else "deterministic_protected_eval_preview"
+    )
     payload: dict[str, object] = {
         "ok": True,
         "schema_version": AUTO_RESEARCH_DEMO_E2E_SCHEMA_VERSION,
         "mode": "execute" if execute else "dry_run",
-        "execution_kind": "minimal_research_kernel" if execute else "minimal_research_preview",
-        "result_source": "deterministic_protected_eval_kernel"
-        if execute
-        else "deterministic_protected_eval_preview",
+        "execution_kind": execution_kind,
+        "result_source": result_source,
         "goal_id": goal_id,
         "tracking_goal_id": tracking_goal or None,
         "route_contract": {
@@ -692,6 +754,14 @@ def run_auto_research_demo_e2e(
                 agent_id=agent_id,
                 execute=True,
                 launch_visible=True,
+                tracking_goal_id=tracking_goal or None,
+            ),
+            "real_worker_loop": _command_text(
+                cli_bin=cli_bin,
+                goal_id=goal_id,
+                agent_id=agent_id,
+                execute=True,
+                run_worker_loop=True,
                 tracking_goal_id=tracking_goal or None,
             ),
             "live_codex_claim_from_evidence": _command_text(
@@ -757,6 +827,26 @@ def run_auto_research_demo_e2e(
         tmp_obj = tempfile.TemporaryDirectory(prefix="loopx-auto-research-demo-e2e.")
         demo_root = Path(tmp_obj.name)
     try:
+        visible_control: dict[str, object] | None = None
+        visible_registry_path: Path | None = None
+        visible_runtime_root_arg: str | None = None
+
+        def ensure_visible_control_plane() -> tuple[dict[str, object], Path, str | None]:
+            nonlocal visible_control, visible_registry_path, visible_runtime_root_arg
+            if visible_control is None or visible_registry_path is None:
+                (
+                    visible_control,
+                    visible_registry_path,
+                    visible_runtime_root_arg,
+                ) = _seed_visible_demo_control_plane(
+                    demo_root=demo_root,
+                    goal_id=goal_id,
+                    objective=objective,
+                    supervisor=supervisor,
+                )
+                payload["visible_control_plane"] = visible_control
+            return visible_control, visible_registry_path, visible_runtime_root_arg
+
         quickstart = build_auto_research_quickstart(
             agent_id=agent_id,
             goal_id=goal_id,
@@ -862,18 +952,91 @@ def run_auto_research_demo_e2e(
                 "workspace_retained": keep_workspace or launch_visible,
             }
         )
+        if run_worker_loop:
+            visible_control, visible_registry_path, visible_runtime_root_arg = ensure_visible_control_plane()
+            worker_agent_ids = [
+                str(lane.get("agent_id") or "").strip()
+                for lane in supervisor.get("lanes") or []
+                if isinstance(lane, dict) and str(lane.get("agent_id") or "").strip()
+            ]
+
+            def append_worker_evidence(packet_path: str) -> dict[str, object]:
+                return append_auto_research_rollout_events(
+                    packet_path=packet_path,
+                    registry_path=visible_registry_path,
+                    runtime_root_arg=visible_runtime_root_arg,
+                    dry_run=False,
+                )
+
+            worker_loop = run_auto_research_worker_loop(
+                registry_path=visible_registry_path,
+                runtime_root_arg=visible_runtime_root_arg,
+                goal_id=goal_id,
+                agent_ids=worker_agent_ids,
+                objective=objective,
+                workspace=demo_root / "visible-control-plane",
+                output_dir=output_dir,
+                execute=True,
+                append_evidence=append_worker_evidence,
+                lane_count=len(worker_agent_ids),
+                visible_lanes_accepted=True,
+                complete_selected_todo=True,
+                max_rounds=worker_loop_rounds,
+            )
+            payload["worker_loop"] = worker_loop
+            turns = worker_loop.get("turns") if isinstance(worker_loop.get("turns"), list) else []
+            dev_metric = next(
+                (turn.get("dev_metric") for turn in turns if isinstance(turn, dict) and turn.get("dev_metric") is not None),
+                None,
+            )
+            holdout_metric = next(
+                (
+                    turn.get("holdout_metric")
+                    for turn in turns
+                    if isinstance(turn, dict) and turn.get("holdout_metric") is not None
+                ),
+                None,
+            )
+            payload["tonight_experience"] = {
+                "schema_version": "auto_research_tonight_experience_v0",
+                "ready": bool(worker_loop.get("executed_turn_count")),
+                "one_command": payload["commands"]["real_worker_loop"],
+                "goal_id": goal_id,
+                "goal_surface_mode": goal_surface_mode,
+                "coordination_pattern": "decentralized_state_a2a",
+                "workflow_model": "state_projected_frontier_not_dynamic_workflow",
+                "driver_role": "polling_driver_only",
+                "leader_agent_required": False,
+                "worker_loop_round_count": worker_loop.get("round_count"),
+                "executed_turn_count": worker_loop.get("executed_turn_count"),
+                "completed_turn_count": worker_loop.get("completed_turn_count"),
+                "selected_actions": worker_loop.get("selected_actions"),
+                "dev_metric": dev_metric,
+                "holdout_metric": holdout_metric,
+                "positive_result": dev_metric is not None and holdout_metric is not None,
+                "state_surfaces": [
+                    "demo-local LoopX registry",
+                    "quota/frontier selection",
+                    "todo completion",
+                    "rollout event log",
+                ],
+                "worker_contract": (
+                    "Each role reads the shared LoopX state surface, accepts only its projected "
+                    "frontier item, writes public-safe evidence, and completes the selected todo."
+                ),
+                "public_boundary": {
+                    "raw_logs_recorded": False,
+                    "private_artifacts_recorded": False,
+                    "absolute_paths_recorded": False,
+                    "visible_codex_lane_authored": False,
+                },
+            }
         if launch_visible and visible_launcher is not None:
             (
                 visible_control,
                 visible_registry_path,
                 visible_runtime_root_arg,
-            ) = _seed_visible_demo_control_plane(
-                demo_root=demo_root,
-                goal_id=goal_id,
-                objective=objective,
-                supervisor=supervisor,
-            )
-            payload["visible_control_plane"] = visible_control
+            ) = ensure_visible_control_plane()
             visible_payload = visible_launcher(
                 dict(supervisor),
                 visible_registry_path,

--- a/loopx/capabilities/auto_research/rollout_append.py
+++ b/loopx/capabilities/auto_research/rollout_append.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+
+from .legacy_core import (
+    AUTO_RESEARCH_ROLLOUT_APPEND_SCHEMA_VERSION,
+    build_auto_research_rollout_events,
+    load_auto_research_evidence_packet,
+)
+from ...history import load_registry
+from ...paths import resolve_runtime_root
+from ...rollout_event_log import (
+    append_rollout_event,
+    load_rollout_events,
+    rollout_event_log_path,
+)
+
+
+def append_auto_research_rollout_events(
+    *,
+    packet_path: str,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    dry_run: bool,
+) -> dict[str, object]:
+    packet = load_auto_research_evidence_packet(packet_path)
+    goal_id = packet["research_contract"]["goal_id"]
+    events = build_auto_research_rollout_events(packet)
+    registry = load_registry(registry_path)
+    runtime_root = resolve_runtime_root(registry, runtime_root_arg)
+    log_path = rollout_event_log_path(runtime_root, goal_id)
+    existing_ids = {
+        str(event.get("event_id"))
+        for event in load_rollout_events(log_path)
+        if event.get("event_id")
+    }
+    appended_ids: list[str] = []
+    skipped_ids: list[str] = []
+    for event in events:
+        event_id = str(event["event_id"])
+        if event_id in existing_ids:
+            skipped_ids.append(event_id)
+            continue
+        if not dry_run:
+            append_rollout_event(log_path, event)
+            existing_ids.add(event_id)
+        appended_ids.append(event_id)
+    counts_by_kind = Counter(str(event.get("event_kind") or "") for event in events)
+    return {
+        "ok": True,
+        "schema_version": AUTO_RESEARCH_ROLLOUT_APPEND_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "dry_run": dry_run,
+        "event_count": len(events),
+        "appended_count": 0 if dry_run else len(appended_ids),
+        "would_append_count": len(appended_ids),
+        "skipped_existing_count": len(skipped_ids),
+        "event_ids": [str(event["event_id"]) for event in events],
+        "appended_event_ids": [] if dry_run else appended_ids,
+        "skipped_existing_event_ids": skipped_ids,
+        "counts_by_kind": dict(sorted(counts_by_kind.items())),
+        "packet_summary": packet["summary"],
+        "public_boundary": {
+            "raw_logs_recorded": False,
+            "private_artifacts_recorded": False,
+            "absolute_paths_recorded": False,
+            "source": "loopx_rollout_event_log",
+        },
+    }


### PR DESCRIPTION
## Summary
- add `auto-research demo-e2e --run-worker-loop` for a one-command role-compatible multi-round demo
- route the demo through a demo-local LoopX goal surface using decentralized state/A2A semantics: quota/frontier, todo completion, rollout event log
- extract rollout append into a small auto-research module so CLI no longer owns that core logic
- add a focused smoke proving the one-command path reaches contract -> hypothesis -> dev eval -> holdout eval with dev=4.0 and holdout=4.5

## Validation
- python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- python3 examples/auto-research-demo-goal-isolation-smoke.py
- python3 examples/auto-research-worker-turn-smoke.py
- python3 examples/auto-research-worker-loop-smoke.py
- python3 examples/auto-research-live-evidence-capture-smoke.py
- loopx check --scan-path loopx/capabilities/auto_research/cli.py --scan-path loopx/capabilities/auto_research/demo_e2e.py --scan-path loopx/capabilities/auto_research/rollout_append.py --scan-path examples/auto-research-demo-e2e-worker-loop-smoke.py

## User command

    loopx --format json auto-research demo-e2e --agent-id codex-side-bypass --execute --run-worker-loop
