### PR TITLE
Make auto-research demo open tmux by default

### DIFF
--- a/docs/guides/auto-research-command-path.md
+++ b/docs/guides/auto-research-command-path.md
@@ -48,27 +48,26 @@ surface:
 loopx --registry "$LOOPX_REGISTRY" \
   --runtime-root "$LOOPX_RUNTIME_ROOT" \
   --format json auto-research demo-e2e \
-  --goal-id loopx-auto-research-knn \
   --agent-id codex-side-bypass \
   --reasoning-effort high \
   --execute \
-  --launch-visible \
   --launcher tmux \
-  --workspace ./loopx-auto-research-demo \
-  --create-workspace \
-  --attach
+  --workspace . \
+  --create-workspace
 ```
 
-That command is the user-facing UX for a multi-round visible demo. Generic
-launcher internals stay inside LoopX; the operator does not need to know the
-module or implementation path.
+That command is the user-facing UX for a multi-round visible demo. It creates a
+fresh isolated demo goal by default, runs the LoopX worker-loop, launches the
+visible tmux lanes, and attaches to the session. Generic launcher internals stay
+inside LoopX; the operator does not need to know the module or implementation
+path.
 
 When this demo is being advanced from a broader productization goal such as
-`loopx-meta`, do not change `--goal-id` to that meta goal. Keep
-`--goal-id loopx-auto-research-knn` so the visible lanes read the positive
-auto-research frontier. Add `--tracking-goal-id loopx-meta` only when the
-caller needs metadata that says which parent goal is tracking the product work;
-tracking metadata never drives the visible lane frontier.
+`loopx-meta`, do not change `--goal-id` to that meta goal. Omit `--goal-id` for
+an isolated demo goal, or pass a purpose-built research frontier goal when you
+want visible lanes to read an existing target. Add `--tracking-goal-id loopx-meta`
+only when the caller needs metadata that says which parent goal is tracking the
+product work; tracking metadata never drives the visible lane frontier.
 
 If you want to inspect before opening visible Codex lanes, start with the
 read-only dry-run. It tells the operator which command will run the
@@ -78,7 +77,6 @@ multi-round positive path:
 loopx --registry "$LOOPX_REGISTRY" \
   --runtime-root "$LOOPX_RUNTIME_ROOT" \
   --format json auto-research demo-e2e \
-  --goal-id loopx-auto-research-knn \
   --agent-id codex-side-bypass \
   --reasoning-effort high
 ```
@@ -89,11 +87,25 @@ When the dry-run looks right, run the multi-round positive path:
 loopx --registry "$LOOPX_REGISTRY" \
   --runtime-root "$LOOPX_RUNTIME_ROOT" \
   --format json auto-research demo-e2e \
-  --goal-id loopx-auto-research-knn \
   --agent-id codex-side-bypass \
   --reasoning-effort high \
   --execute
 ```
+
+That command opens and attaches to tmux by default. For JSON-only automation,
+make the headless path explicit:
+
+```bash
+loopx --registry "$LOOPX_REGISTRY" \
+  --runtime-root "$LOOPX_RUNTIME_ROOT" \
+  --format json auto-research demo-e2e \
+  --agent-id codex-side-bypass \
+  --reasoning-effort high \
+  --execute \
+  --headless
+```
+
+To start tmux panes but stay in the current shell, use `--no-attach`.
 
 Expected minimal E2E result:
 
@@ -122,7 +134,7 @@ Truth boundary:
   `one_command_loopx_worker_loop_positive_result`;
 - `claim_summary.cannot_claim` includes
   `visible_codex_tui_authored_result`;
-- `--launch-visible` proves visible panes can start, but pane startup alone is
+- the default visible launch proves panes can start, but pane startup alone is
   not a live Codex research result.
 
 To claim a live Codex lane-authored E2E result, first let the visible lane that
@@ -147,10 +159,10 @@ Then pass that compact evidence packet back to the E2E readback command:
 loopx --registry "$LOOPX_REGISTRY" \
   --runtime-root "$LOOPX_RUNTIME_ROOT" \
   --format json auto-research demo-e2e \
-  --goal-id loopx-auto-research-knn \
   --agent-id codex-side-bypass \
   --reasoning-effort high \
   --execute \
+  --headless \
   --live-evidence ./live-codex-e2e-evidence.public.json
 ```
 
@@ -170,14 +182,13 @@ To project a live holdout or promotion claim, the compact
 evidence must carry explicit public-safe `claim_authority`, such as
 `separate_heldout_live_evidence` or `owner_approval`.
 
-For a full visible demo after an explicit multi-round run, add the visible lane
-launcher:
+For an explicit visible demo command, `--launch-visible --attach` is still
+accepted, but it is equivalent to the default `--execute` behavior:
 
 ```bash
 loopx --registry "$LOOPX_REGISTRY" \
   --runtime-root "$LOOPX_RUNTIME_ROOT" \
   --format json auto-research demo-e2e \
-  --goal-id loopx-auto-research-knn \
   --agent-id codex-side-bypass \
   --reasoning-effort high \
   --execute \

--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -65,6 +65,7 @@ def main() -> int:
                 "--demo-run-id",
                 "worker-loop-smoke",
                 "--execute",
+                "--headless",
             ],
             cwd=workspace,
             env=env,
@@ -107,6 +108,9 @@ def main() -> int:
         assert tonight["dev_metric"] == 4.0, tonight
         assert tonight["holdout_metric"] == 4.5, tonight
         assert "--run-worker-loop" not in tonight["one_command"], tonight
+        assert "--headless" not in tonight["one_command"], tonight
+        assert "--headless" in payload["commands"]["headless_worker_loop"], payload
+        assert "--no-attach" in payload["commands"]["start_visible_lanes_without_attach"], payload
         claim = payload["claim_summary"]
         assert claim["status"] == "loopx_worker_loop_positive", claim
         assert claim["can_claim"] == ["one_command_loopx_worker_loop_positive_result"], claim

--- a/examples/auto-research-live-codex-claim-boundary-smoke.py
+++ b/examples/auto-research-live-codex-claim-boundary-smoke.py
@@ -73,6 +73,7 @@ def base_demo_args() -> list[str]:
         AGENT_ID,
         "--reasoning-effort",
         "high",
+        "--headless",
     ]
 
 

--- a/examples/auto-research-live-evidence-capture-smoke.py
+++ b/examples/auto-research-live-evidence-capture-smoke.py
@@ -242,6 +242,7 @@ def main() -> int:
                 "--agent-id",
                 AGENT_ID,
                 "--execute",
+                "--headless",
                 "--live-evidence",
                 str(live_path),
             ],

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -553,9 +553,15 @@ def register_auto_research_commands(
         "--launch-visible",
         action="store_true",
         help=(
-            "With --execute, also launch the visible multi-lane supervisor. "
+            "With --execute, explicitly launch the visible multi-lane supervisor. "
+            "This is the default unless --headless is set. "
             "Visible panes alone do not make the multi-round kernel a live Codex E2E result."
         ),
+    )
+    demo_e2e_parser.add_argument(
+        "--headless",
+        action="store_true",
+        help="With --execute, skip visible tmux/Codex panes and return JSON only.",
     )
     demo_e2e_parser.add_argument(
         "--live-evidence",
@@ -591,7 +597,12 @@ def register_auto_research_commands(
     demo_e2e_parser.add_argument(
         "--attach",
         action="store_true",
-        help="After --launch-visible with tmux, attach to the session.",
+        help="After visible launch with tmux, attach to the session. This is the default for --execute unless --no-attach is set.",
+    )
+    demo_e2e_parser.add_argument(
+        "--no-attach",
+        action="store_true",
+        help="With the default visible --execute launch, start tmux in the background instead of attaching.",
     )
     demo_e2e_parser.add_argument(
         "--replace-existing",
@@ -883,6 +894,8 @@ def handle_auto_research_command(
                     create_workspace=args.create_workspace,
                 )
         elif args.auto_research_command == "demo-e2e":
+            if args.headless and args.launch_visible:
+                raise ValueError("--headless cannot be combined with --launch-visible")
             goal_id, goal_surface_mode = _resolve_demo_goal_surface(
                 goal_id=args.goal_id,
                 demo_run_id=args.demo_run_id,
@@ -897,8 +910,13 @@ def handle_auto_research_command(
                     dry_run=False,
                 )
 
-            visible_launcher: Callable[[dict[str, object], Path, str | None], dict[str, object]] | None = None
-            if args.launch_visible:
+            visible_launcher: Callable[[dict[str, object], Path, str | None, Path], dict[str, object]] | None = None
+            auto_visible_launch = bool(args.execute and not args.headless)
+            launch_visible = bool(args.launch_visible or auto_visible_launch)
+            attach_visible = bool(args.attach or (auto_visible_launch and not args.no_attach))
+            if args.no_attach and args.attach:
+                raise ValueError("--attach cannot be combined with --no-attach")
+            if launch_visible:
                 def visible_launcher(
                     supervisor: dict[str, object],
                     visible_registry_path: Path,
@@ -914,7 +932,7 @@ def handle_auto_research_command(
                         tmux_bin=args.tmux_bin,
                         cli_bin=args.cli_bin,
                         codex_bin=args.codex_bin,
-                        attach=args.attach,
+                        attach=attach_visible,
                         replace_existing=args.replace_existing,
                         workspace=workspace,
                         create_workspace=args.create_workspace,
@@ -931,7 +949,7 @@ def handle_auto_research_command(
                 execute=args.execute,
                 run_worker_loop=args.execute,
                 worker_loop_rounds=args.worker_loop_rounds,
-                launch_visible=args.launch_visible,
+                launch_visible=launch_visible,
                 keep_workspace=args.keep_workspace,
                 registry_path=registry_path,
                 runtime_root_arg=runtime_root_arg,

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -367,6 +367,9 @@ def _command_text(
     execute: bool,
     run_worker_loop: bool = False,
     launch_visible: bool = False,
+    headless: bool = False,
+    attach: bool = False,
+    no_attach: bool = False,
     live_evidence: bool = False,
     tracking_goal_id: str | None = None,
 ) -> str:
@@ -385,8 +388,14 @@ def _command_text(
         parts.extend(["--tracking-goal-id", shlex.quote(tracking_goal_id)])
     if execute:
         parts.append("--execute")
+    if headless:
+        parts.append("--headless")
     if launch_visible:
         parts.append("--launch-visible")
+    if attach:
+        parts.append("--attach")
+    if no_attach:
+        parts.append("--no-attach")
     if live_evidence:
         parts.extend(["--live-evidence", "<public-safe-live-evidence.json>"])
     return " ".join(parts)
@@ -590,6 +599,24 @@ def run_auto_research_demo_e2e(
                 run_worker_loop=True,
                 tracking_goal_id=tracking_goal or None,
             ),
+            "headless_worker_loop": _command_text(
+                cli_bin=cli_bin,
+                goal_id=goal_id,
+                agent_id=agent_id,
+                execute=True,
+                run_worker_loop=True,
+                headless=True,
+                tracking_goal_id=tracking_goal or None,
+            ),
+            "start_visible_lanes_without_attach": _command_text(
+                cli_bin=cli_bin,
+                goal_id=goal_id,
+                agent_id=agent_id,
+                execute=True,
+                run_worker_loop=True,
+                no_attach=True,
+                tracking_goal_id=tracking_goal or None,
+            ),
             "one_command_worker_loop_with_visible_lanes": _command_text(
                 cli_bin=cli_bin,
                 goal_id=goal_id,
@@ -597,6 +624,7 @@ def run_auto_research_demo_e2e(
                 execute=True,
                 run_worker_loop=True,
                 launch_visible=True,
+                attach=True,
                 tracking_goal_id=tracking_goal or None,
             ),
             "live_codex_claim_from_evidence": _command_text(


### PR DESCRIPTION
## Summary
- Make `auto-research demo-e2e --execute` launch and attach visible tmux lanes by default.
- Add explicit `--headless` for JSON-only automation and `--no-attach` for background tmux startup.
- Update the command-path guide and smokes so default demos use isolated goal surfaces and CI paths stay headless.

## Validation
- `python3 -m compileall loopx/capabilities/auto_research`
- `python3 examples/auto-research-demo-e2e-worker-loop-smoke.py`
- `python3 examples/auto-research-live-codex-claim-boundary-smoke.py`
- `python3 examples/auto-research-live-evidence-capture-smoke.py`
- `python3 examples/auto-research-demo-goal-isolation-smoke.py`
- `python3 examples/auto-research-demo-supervisor-smoke.py`
- `python3 examples/visible-multi-agent-launcher-smoke.py`
- `loopx check --scan-path loopx/capabilities/auto_research/cli.py --scan-path loopx/capabilities/auto_research/demo_e2e.py --scan-path examples/auto-research-demo-e2e-worker-loop-smoke.py --scan-path examples/auto-research-live-codex-claim-boundary-smoke.py --scan-path examples/auto-research-live-evidence-capture-smoke.py --scan-path docs/guides/auto-research-command-path.md`
- default visible launch smoke with `--execute --no-attach --codex-bin true` started 4 tmux lanes without requiring `--launch-visible`
