### PR TITLE
Clean remote SkillsBench workers after tunnel failures

### DIFF
--- a/examples/skillsbench-reverse-tunnel-supervisor-smoke.py
+++ b/examples/skillsbench-reverse-tunnel-supervisor-smoke.py
@@ -44,8 +44,16 @@ if "LOOPX_REVERSE_TUNNEL_PROBE" in remote_command:
     print("HTTP/1.1 200 Connection Established")
     sys.exit(0)
 
+if "LOOPX_REMOTE_FAILURE_CLEANUP" in remote_command:
+    print('{{"alive_after_count": 0, "docker_matched_count": 1, "docker_removed_count": 1, "docker_status": "ok", "kill_sent_count": 0, "matched_count": 2, "term_sent_count": 2}}')
+    sys.exit(0)
+
 if "cat >" in remote_command:
     sys.stdin.read()
+
+if "fail-skillsbench" in remote_command:
+    print("private failure detail")
+    sys.exit(42)
 
 print('{{"ok": true, "source": "fake_remote_command"}}')
 sys.exit(0)
@@ -113,6 +121,81 @@ def test_supervisor_holds_tunnel_and_redacts_private_command() -> None:
         assert opaque_destination not in public_text
         assert opaque_command not in public_text
         assert opaque_command in ssh_log.read_text(encoding="utf-8")
+        assert private_log.exists()
+
+
+def test_supervisor_cleans_remote_failure_without_public_pattern() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-tunnel-cleanup-") as tmp:
+        root = Path(tmp)
+        fake_ssh = root / "ssh"
+        ssh_log = root / "ssh.log"
+        public_output = root / "public.json"
+        private_log = root / "private.log"
+        _fake_ssh(fake_ssh, ssh_log)
+
+        opaque_destination = "opaque-benchmark-host.example"
+        opaque_cleanup_pattern = "redacted-cleanup-token-example"
+        opaque_command = (
+            "cd /opaque/workdir && fail-skillsbench --run-group "
+            + opaque_cleanup_pattern
+        )
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--ssh-bin",
+                str(fake_ssh),
+                "--ssh-destination",
+                opaque_destination,
+                "--remote-forward",
+                "127.0.0.1:18180:127.0.0.1:18180",
+                "--remote-command",
+                opaque_command,
+                "--remote-failure-cleanup-pattern",
+                opaque_cleanup_pattern,
+                "--remote-failure-cleanup-include-docker",
+                "--remote-failure-cleanup-timeout-sec",
+                "5",
+                "--public-output-path",
+                str(public_output),
+                "--private-log-path",
+                str(private_log),
+                "--tunnel-ready-timeout-sec",
+                "5",
+                "--probe-interval-sec",
+                "0.1",
+                "--run-timeout-sec",
+                "5",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 42, proc.stderr or proc.stdout
+        payload = json.loads(proc.stdout)
+        assert payload["ok"] is False, payload
+        assert payload["first_blocker"] == "remote_command_exit_nonzero", payload
+        assert payload["remote_command_exit_code"] == 42, payload
+        cleanup = payload["remote_failure_cleanup"]
+        assert cleanup["requested"] is True, cleanup
+        assert cleanup["attempted"] is True, cleanup
+        assert cleanup["trigger"] == "remote_command_exit_nonzero", cleanup
+        assert cleanup["exit_code"] == 0, cleanup
+        assert cleanup["matched_count"] == 2, cleanup
+        assert cleanup["term_sent_count"] == 2, cleanup
+        assert cleanup["alive_after_count"] == 0, cleanup
+        assert cleanup["docker_status"] == "ok", cleanup
+        assert cleanup["docker_matched_count"] == 1, cleanup
+        assert cleanup["docker_removed_count"] == 1, cleanup
+        assert cleanup["raw_pattern_recorded"] is False, cleanup
+        assert cleanup["raw_output_recorded"] is False, cleanup
+        public_text = json.dumps(payload, sort_keys=True)
+        assert opaque_destination not in public_text
+        assert opaque_command not in public_text
+        assert opaque_cleanup_pattern not in public_text
+        assert "LOOPX_REMOTE_FAILURE_CLEANUP" in ssh_log.read_text(encoding="utf-8")
         assert private_log.exists()
 
 
@@ -205,5 +288,6 @@ def test_supervisor_holds_json_bridge_and_materializes_remote_client() -> None:
 
 if __name__ == "__main__":
     test_supervisor_holds_tunnel_and_redacts_private_command()
+    test_supervisor_cleans_remote_failure_without_public_pattern()
     test_supervisor_holds_json_bridge_and_materializes_remote_client()
     print("skillsbench-reverse-tunnel-supervisor smoke ok")

--- a/scripts/skillsbench_reverse_tunnel_supervisor.py
+++ b/scripts/skillsbench_reverse_tunnel_supervisor.py
@@ -480,6 +480,202 @@ def _size_bucket(value: str) -> str:
     return "5000_plus"
 
 
+def _remote_failure_cleanup_public_contract(args: argparse.Namespace) -> dict[str, Any]:
+    return {
+        "requested": bool(args.remote_failure_cleanup_pattern),
+        "attempted": False,
+        "trigger": "not_run",
+        "include_docker": bool(args.remote_failure_cleanup_include_docker),
+        "raw_pattern_recorded": False,
+        "raw_output_recorded": False,
+    }
+
+
+def _remote_failure_cleanup_command(args: argparse.Namespace) -> str:
+    code = r'''
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+
+pattern = sys.argv[1]
+include_docker = sys.argv[2] == "1"
+self_pid = os.getpid()
+self_pgid = os.getpgrp()
+parent_pid = os.getppid()
+ancestors = {parent_pid}
+cursor = parent_pid
+while cursor > 1:
+    try:
+        with open(f"/proc/{cursor}/stat", "r", encoding="utf-8", errors="replace") as handle:
+            parts = handle.read().split()
+        cursor = int(parts[3])
+    except Exception:
+        break
+    ancestors.add(cursor)
+
+
+def matching_pids():
+    matches = []
+    for name in os.listdir("/proc"):
+        if not name.isdigit():
+            continue
+        pid = int(name)
+        if pid == self_pid or pid in ancestors:
+            continue
+        try:
+            with open(f"/proc/{pid}/cmdline", "rb") as handle:
+                raw = handle.read()
+        except OSError:
+            continue
+        command = raw.replace(b"\x00", b" ").decode("utf-8", errors="replace")
+        if pattern not in command:
+            continue
+        try:
+            if os.getpgid(pid) == self_pgid:
+                continue
+        except OSError:
+            pass
+        matches.append(pid)
+    return sorted(set(matches))
+
+
+term_targets = matching_pids()
+term_sent = 0
+for pid in term_targets:
+    try:
+        os.kill(pid, signal.SIGTERM)
+        term_sent += 1
+    except OSError:
+        pass
+
+time.sleep(1.0)
+kill_targets = matching_pids()
+kill_sent = 0
+for pid in kill_targets:
+    try:
+        os.kill(pid, signal.SIGKILL)
+        kill_sent += 1
+    except OSError:
+        pass
+
+alive_after = matching_pids()
+docker_status = "not_requested"
+docker_matched = 0
+docker_removed = 0
+if include_docker:
+    docker_status = "ok"
+    try:
+        ps = subprocess.run(
+            ["docker", "ps", "--format", "{{.Names}}"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        names = [
+            line.strip()
+            for line in (ps.stdout or "").splitlines()
+            if line.strip() and pattern in line.strip()
+        ]
+        docker_matched = len(names)
+        for name in names:
+            rm = subprocess.run(
+                ["docker", "rm", "-f", name],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                text=True,
+                timeout=10,
+                check=False,
+            )
+            if rm.returncode == 0:
+                docker_removed += 1
+    except FileNotFoundError:
+        docker_status = "docker_unavailable"
+    except Exception:
+        docker_status = "docker_cleanup_failed"
+
+print(json.dumps({
+    "matched_count": len(term_targets),
+    "term_sent_count": term_sent,
+    "kill_sent_count": kill_sent,
+    "alive_after_count": len(alive_after),
+    "docker_status": docker_status,
+    "docker_matched_count": docker_matched,
+    "docker_removed_count": docker_removed,
+}, sort_keys=True))
+'''
+    include_docker = "1" if args.remote_failure_cleanup_include_docker else "0"
+    return (
+        "# LOOPX_REMOTE_FAILURE_CLEANUP\n"
+        + "python3 - "
+        + shlex.quote(args.remote_failure_cleanup_pattern)
+        + " "
+        + include_docker
+        + " <<'PY'\n"
+        + code.strip()
+        + "\nPY"
+    )
+
+
+def _run_remote_failure_cleanup(
+    args: argparse.Namespace,
+    *,
+    trigger: str,
+) -> dict[str, Any]:
+    payload = _remote_failure_cleanup_public_contract(args)
+    payload["trigger"] = trigger
+    if not args.remote_failure_cleanup_pattern:
+        return payload
+    payload["attempted"] = True
+    try:
+        proc = _run_remote_shell_command(
+            args,
+            _remote_failure_cleanup_command(args),
+            timeout_sec=args.remote_failure_cleanup_timeout_sec,
+        )
+    except subprocess.TimeoutExpired:
+        payload["first_blocker"] = "remote_failure_cleanup_timeout"
+        return payload
+    except OSError:
+        payload["first_blocker"] = "remote_failure_cleanup_launch_failed"
+        return payload
+
+    stdout_text = proc.stdout or ""
+    stderr_text = proc.stderr or ""
+    payload["exit_code"] = proc.returncode
+    payload["stdout_size_bucket"] = _size_bucket(stdout_text)
+    payload["stderr_size_bucket"] = _size_bucket(stderr_text)
+    if proc.returncode != 0:
+        payload["first_blocker"] = "remote_failure_cleanup_exit_nonzero"
+        return payload
+    try:
+        parsed = json.loads(stdout_text.strip().splitlines()[-1])
+    except (IndexError, json.JSONDecodeError):
+        payload["first_blocker"] = "remote_failure_cleanup_result_missing"
+        return payload
+    if not isinstance(parsed, dict):
+        payload["first_blocker"] = "remote_failure_cleanup_result_invalid"
+        return payload
+    for key in (
+        "matched_count",
+        "term_sent_count",
+        "kill_sent_count",
+        "alive_after_count",
+        "docker_matched_count",
+        "docker_removed_count",
+    ):
+        try:
+            payload[key] = int(parsed.get(key, 0))
+        except (TypeError, ValueError):
+            payload[key] = 0
+    payload["docker_status"] = str(parsed.get("docker_status", "unknown"))[:80]
+    return payload
+
+
 def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
     started_at = time.time()
     payload: dict[str, Any] = {
@@ -497,6 +693,7 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         "private_log_written": False,
         "remote_forward": _forward_public_contract(args.remote_forward),
         "json_bridge": _json_bridge_public_contract(args),
+        "remote_failure_cleanup": _remote_failure_cleanup_public_contract(args),
     }
 
     tunnel_proc: subprocess.Popen[Any] | None = None
@@ -633,6 +830,10 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         payload["ok"] = proc.returncode == 0
         if proc.returncode != 0:
             payload["first_blocker"] = "remote_command_exit_nonzero"
+            payload["remote_failure_cleanup"] = _run_remote_failure_cleanup(
+                args,
+                trigger="remote_command_exit_nonzero",
+            )
         return finish(0 if proc.returncode == 0 else proc.returncode or 1)
     except subprocess.TimeoutExpired as exc:
         stdout_text = exc.stdout if isinstance(exc.stdout, str) else ""
@@ -646,6 +847,10 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
             stderr_text=stderr_text,
         )
         payload["first_blocker"] = "remote_command_timeout"
+        payload["remote_failure_cleanup"] = _run_remote_failure_cleanup(
+            args,
+            trigger="remote_command_timeout",
+        )
         return finish(124)
 
 
@@ -669,6 +874,29 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--tunnel-ready-timeout-sec", type=float, default=30.0)
     parser.add_argument("--keepalive-interval-sec", type=int, default=20)
     parser.add_argument("--run-timeout-sec", type=float, default=7200.0)
+    parser.add_argument(
+        "--remote-failure-cleanup-pattern",
+        default="",
+        help=(
+            "Private remote process/container name substring to clean up after "
+            "a nonzero or timed-out remote command. Public output records "
+            "counts only, never the pattern."
+        ),
+    )
+    parser.add_argument(
+        "--remote-failure-cleanup-include-docker",
+        action="store_true",
+        help=(
+            "Also remove running Docker containers whose names contain the "
+            "private cleanup pattern. Public output records counts only."
+        ),
+    )
+    parser.add_argument(
+        "--remote-failure-cleanup-timeout-sec",
+        type=float,
+        default=60.0,
+        help="Timeout for the private remote failure cleanup command.",
+    )
     parser.add_argument(
         "--cleanup-stale-local-forward",
         action="store_true",


### PR DESCRIPTION
## Summary
- add supervisor-side remote failure cleanup for nonzero/timed-out SkillsBench commands
- keep cleanup pattern, ssh destination, command, and raw output out of public JSON
- cover the behavior with the reverse-tunnel supervisor smoke

## Validation
- python3 -m py_compile scripts/skillsbench_reverse_tunnel_supervisor.py examples/skillsbench-reverse-tunnel-supervisor-smoke.py
- python3 examples/skillsbench-reverse-tunnel-supervisor-smoke.py
- python3 examples/benchmark-attempt-accounting-smoke.py