### PR TITLE
Resolve auto-research worker skill from package root

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -118,6 +119,63 @@ def main() -> int:
         removed_replay_source = "deterministic_" + "protected_eval_kernel"
         assert removed_replay_source not in json.dumps(payload, sort_keys=True), payload
         assert_public_safe(payload)
+        if shutil.which("tmux") and shutil.which("true"):
+            session_name = "loopx-auto-research-worker-skill-smoke"
+            try:
+                visible = subprocess.run(
+                    [
+                        sys.executable,
+                        "-m",
+                        "loopx.cli",
+                        "--registry",
+                        str(registry),
+                        "--runtime-root",
+                        str(runtime_root),
+                        "--format",
+                        "json",
+                        "auto-research",
+                        "demo-e2e",
+                        "--agent-id",
+                        AGENT_ID,
+                        "--demo-run-id",
+                        "worker-skill-visible-smoke",
+                        "--execute",
+                        "--no-attach",
+                        "--replace-existing",
+                        "--session-name",
+                        session_name,
+                        "--workspace",
+                        str(workspace),
+                        "--create-workspace",
+                        "--codex-bin",
+                        "true",
+                    ],
+                    cwd=workspace,
+                    env=env,
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                if visible.returncode != 0:
+                    raise AssertionError(
+                        f"visible demo-e2e failed rc={visible.returncode}\nstdout={visible.stdout}\nstderr={visible.stderr}"
+                    )
+                visible_payload = json.loads(visible.stdout)
+                launch = visible_payload["visible_launch"]["launch_result"]
+                assert launch["started_lane_count"] == 4, visible_payload
+                assert launch["attach_requested"] is False, visible_payload
+                skill_items = launch["worker_skill_materialization"]
+                assert skill_items, visible_payload
+                assert {item["source_resolution"] for item in skill_items} == {"package_root"}, skill_items
+                assert all(item["materialized"] is True for item in skill_items), skill_items
+                assert_public_safe(visible_payload)
+            finally:
+                subprocess.run(
+                    ["tmux", "kill-session", "-t", session_name],
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    check=False,
+                )
     print("auto-research-demo-e2e-worker-loop-smoke ok")
     return 0
 

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -162,6 +162,7 @@ def main() -> int:
                 "destination": ".codex/skills/loopx-auto-research/SKILL.md",
                 "materialized": True,
                 "workspace_count": 1,
+                "source_resolution": "source_root",
             }
         ], skills
         assert (workspace / ".codex/skills/loopx-auto-research/SKILL.md").read_text(

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -324,9 +324,10 @@ def _materialize_worker_skills(
         source_name = str(profile.get("worker_skill_source") or "").strip()
         if not skill_name or not source_name:
             continue
-        source = Path(source_name)
-        if not source.is_absolute():
-            source = source_root / source
+        source, source_resolution = _resolve_worker_skill_source(
+            source_name,
+            source_root=source_root,
+        )
         workspace_values = [project]
         lane_workspace = _lane_workspace(lane, default_project=project)
         if lane_workspace != project:
@@ -337,6 +338,7 @@ def _materialize_worker_skills(
             "destination": f".codex/skills/{skill_name}/SKILL.md",
             "materialized": False,
             "workspace_count": len(workspace_values),
+            "source_resolution": source_resolution,
         }
         if source.is_file():
             for workspace in workspace_values:
@@ -348,6 +350,28 @@ def _materialize_worker_skills(
             item["missing_source"] = True
         results.append(item)
     return results
+
+
+def _resolve_worker_skill_source(source_name: str, *, source_root: Path) -> tuple[Path, str]:
+    source = Path(source_name)
+    if source.is_absolute():
+        return source, "absolute"
+
+    package_root = Path(__file__).resolve().parents[1]
+    candidates = [
+        ("source_root", source_root / source),
+        ("package_root", package_root / source),
+        ("module_root", Path(__file__).resolve().parent / source),
+    ]
+    seen: set[Path] = set()
+    for label, candidate in candidates:
+        resolved = candidate.resolve()
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        if resolved.is_file():
+            return resolved, label
+    return (source_root / source), "missing"
 
 
 def _worker_skill_materialization_errors(items: list[dict[str, object]]) -> list[str]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,6 @@ loopx = "loopx.cli:main"
 
 [tool.setuptools.packages.find]
 include = ["loopx*"]
+
+[tool.setuptools.package-data]
+"loopx.capabilities.auto_research" = ["worker_skill/SKILL.md"]


### PR DESCRIPTION
## Summary
- Resolve worker-local auto-research skill sources from the installed package/repo root when the user launches from an arbitrary workspace
- Include the worker skill markdown in package data so installed wheels can materialize it
- Extend visible launcher and demo E2E smokes to cover package-root skill materialization

## Validation
- python3 -m compileall loopx/visible_multi_agent_launcher.py loopx/capabilities/auto_research
- python3 examples/visible-multi-agent-launcher-smoke.py
- python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- python3 examples/auto-research-demo-supervisor-smoke.py
- python3 examples/auto-research-demo-goal-isolation-smoke.py
- loopx check --scan-path loopx/visible_multi_agent_launcher.py --scan-path examples/auto-research-demo-e2e-worker-loop-smoke.py --scan-path examples/visible-multi-agent-launcher-smoke.py --scan-path pyproject.toml
- uv build --wheel --out-dir /tmp/loopx-wheel-check-20260701, then verified loopx/capabilities/auto_research/worker_skill/SKILL.md is present in the wheel