### PR TITLE
Fix auto-research visible demo startup

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -164,10 +164,26 @@ def main() -> int:
                 launch = visible_payload["visible_launch"]["launch_result"]
                 assert launch["started_lane_count"] == 4, visible_payload
                 assert launch["attach_requested"] is False, visible_payload
+                acceptance = launch["visible_acceptance"]
+                assert acceptance["accepted"] is True, visible_payload
+                assert all(not item["blocked_before_bootstrap"] for item in acceptance["pane_checks"]), acceptance
                 skill_items = launch["worker_skill_materialization"]
                 assert skill_items, visible_payload
                 assert {item["source_resolution"] for item in skill_items} == {"package_root"}, skill_items
                 assert all(item["materialized"] is True for item in skill_items), skill_items
+                for lane in launch["started_lanes"]:
+                    capture = subprocess.run(
+                        ["tmux", "capture-pane", "-pt", f"{session_name}:{lane}", "-S", "-300"],
+                        check=False,
+                        capture_output=True,
+                        text=True,
+                    ).stdout
+                    assert "continuing_to_visible_bootstrap" in capture, (lane, capture)
+                    assert "state_projection_gap" not in capture, (lane, capture)
+                    assert "stopped_before_frontier" not in capture, (lane, capture)
+                    assert "quota_wait_timeout" not in capture, (lane, capture)
+                    assert "frontier_wait_timeout" not in capture, (lane, capture)
+                    assert f"Goal: {visible_payload['goal_id']}" in capture, (lane, capture)
                 assert_public_safe(visible_payload)
             finally:
                 subprocess.run(

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -938,6 +938,10 @@ def handle_auto_research_command(
                         create_workspace=args.create_workspace,
                     )
 
+            run_hidden_worker_loop = bool(
+                args.execute
+                and (args.headless or (args.run_worker_loop and not launch_visible))
+            )
             payload = run_auto_research_demo_e2e(
                 agent_id=args.agent_id,
                 goal_id=goal_id,
@@ -947,7 +951,7 @@ def handle_auto_research_command(
                 objective=args.objective,
                 output_dir=args.output_dir,
                 execute=args.execute,
-                run_worker_loop=args.execute,
+                run_worker_loop=run_hidden_worker_loop,
                 worker_loop_rounds=args.worker_loop_rounds,
                 launch_visible=launch_visible,
                 keep_workspace=args.keep_workspace,

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -474,6 +474,33 @@ def _demo_claim_summary(payload: dict[str, object]) -> dict[str, object]:
             ),
         }
 
+    visible_launch = (
+        payload.get("visible_launch")
+        if isinstance(payload.get("visible_launch"), dict)
+        else {}
+    )
+    if payload.get("mode") == "execute" and visible_launch:
+        return {
+            "schema_version": "auto_research_demo_claim_summary_v0",
+            "status": "visible_worker_queue_started",
+            "claim_basis": "demo_local_loopx_queue_and_visible_codex_panes",
+            "live_worker_claim_allowed": False,
+            "live_worker_authored": False,
+            "can_claim": ["visible_role_todo_flow_started"],
+            "cannot_claim": [
+                "visible_codex_workers_completed_result",
+                "live_holdout_metric_or_claim",
+                "automatic_promotion_success",
+            ],
+            "dev_metric": None,
+            "holdout_metric": None,
+            "holdout_metric_redacted": False,
+            "next_required": (
+                "let the visible Codex panes run the printed worker-turn commands; "
+                "then pass compact live evidence before claiming a completed live result"
+            ),
+        }
+
     return {
         "schema_version": "auto_research_demo_claim_summary_v0",
         "status": "preview_only",
@@ -536,7 +563,7 @@ def run_auto_research_demo_e2e(
         tracking_goal = ""
     reuses_default_internal_goal = goal_id == AUTO_RESEARCH_DEFAULT_GOAL_ID
     effective_agent_specs = list(agent_specs or [])
-    if run_worker_loop and not effective_agent_specs:
+    if (run_worker_loop or launch_visible) and not effective_agent_specs:
         effective_agent_specs = list(DEFAULT_WORKER_LOOP_AGENT_SPECS)
     supervisor = build_auto_research_demo_supervisor_plan(
         goal_id=goal_id,

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -628,6 +628,15 @@ def _tmux_acceptance(
                 text=True,
                 env=env,
             ).stdout
+            failure_markers = [
+                "stopped_before_frontier",
+                "stopped_before_bootstrap",
+                "stopped_before_codex",
+                "quota_wait_timeout",
+                "frontier_wait_timeout",
+                "frontier_not_ready",
+            ]
+            blocked_before_bootstrap = any(marker in capture for marker in failure_markers)
             ok = (
                 lane in surviving
                 and ("[LoopX role profile]" in capture or "role_profile=printed" in capture)
@@ -635,11 +644,13 @@ def _tmux_acceptance(
                 and any(marker in capture for marker in frontier_markers)
                 and ("[bootstrap-or-stop]" in capture or "bootstrap_or_stop=printed" in capture)
                 and "loopx_agent_handshake=role_profile_quota_frontier_bootstrap" in capture
+                and not blocked_before_bootstrap
             )
             pane_checks.append(
                 {
                     "lane_id": lane,
                     "accepted": ok,
+                    "blocked_before_bootstrap": blocked_before_bootstrap,
                 }
             )
         accepted = list_result.returncode == 0 and len(surviving) == len(expected_lanes) and all(


### PR DESCRIPTION
## Summary
- make visible `auto-research demo-e2e --execute` start from the fresh demo goal queue instead of pre-consuming todos with the hidden worker-loop
- keep headless `--execute` on the worker-loop path for deterministic non-visible validation
- reject visible-launch acceptance when panes stop before frontier/bootstrap or hit wait timeouts
- extend the auto-research E2E smoke to capture tmux panes and guard against `state_projection_gap` / `stopped_before_frontier` regressions

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-demo-e2e-worker-loop-smoke.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-demo-goal-isolation-smoke.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 examples/visible-multi-agent-launcher-smoke.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 examples/generic-multi-agent-one-command-smoke.py`
- source-run visible repro: 4 role panes reached `continuing_to_visible_bootstrap` on a fresh demo goal, with no state-projection gap markers
