### PR TITLE
Smooth visible auto-research worker flow

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -48,6 +48,8 @@ def main() -> int:
     assert "Use loopx-project" not in bootstrap_source
     assert "read that local JSON profile" not in bootstrap_source
     assert "Do not print, cat, or sed `$LOOPX_ROLE_PROFILE_PATH`" in bootstrap_source
+    assert "Do not run `--help`" in bootstrap_source
+    assert "worker-turn preview/execute as the human-facing polling command" in bootstrap_source
 
     worker_markdown = render_auto_research_markdown(
         {
@@ -80,6 +82,39 @@ def main() -> int:
     assert "# LoopX Auto Research Worker Turn" in worker_markdown
     assert "- selected_action: `run_dev_eval`" in worker_markdown
     assert '"schema_version"' not in worker_markdown
+
+    blocked_markdown = render_auto_research_markdown(
+        {
+            "ok": True,
+            "schema_version": "auto_research_worker_turn_v0",
+            "mode": "blocked",
+            "goal_id": GOAL_ID,
+            "agent_id": "codex-value-explorer",
+            "selected_todo_id": "todo_holdout_smoke",
+            "selected_action": "run_holdout_eval",
+            "executed": False,
+            "blocker": "waiting_for_dev_evidence",
+            "blocker_detail": "no dev-supported auto-research hypothesis is ready for holdout validation",
+            "completion": {"requested": True, "executed": False},
+            "frontier": {
+                "quota": {
+                    "should_run": True,
+                    "state": "eligible",
+                    "user_action_required": False,
+                },
+                "frontier": {
+                    "selected": {
+                        "todo_id": "todo_holdout_smoke",
+                        "allowed_action": "run_holdout_eval",
+                        "title": "Run held-out validation.",
+                    }
+                },
+            },
+        }
+    )
+    assert "- mode: `blocked`" in blocked_markdown
+    assert "- blocker: `waiting_for_dev_evidence`" in blocked_markdown
+    assert "Traceback" not in blocked_markdown
 
     loop_markdown = render_auto_research_markdown(
         {

--- a/loopx/capabilities/auto_research/legacy_core.py
+++ b/loopx/capabilities/auto_research/legacy_core.py
@@ -949,7 +949,7 @@ def _auto_research_codex_bootstrap_prompt(
         "Minimal live worker-turn path:",
         f"1. Confirm the selected frontier action matches this role ({expected_actions}).",
         "2. Confirm the pane-local wrapper exists: `test -x \"$LOOPX_PANE_LOOPX\"`.",
-        "3. Single-pane preview, using human-readable output:",
+        "3. Single-pane preview, using human-readable output. This command re-reads quota and frontier internally:",
         "   `\"$LOOPX_PANE_LOOPX\" auto-research worker-turn --format markdown --goal-id \"$LOOPX_GOAL_ID\" --agent-id \"$LOOPX_AGENT_ID\"`",
         "4. Single-pane execute, only when the preview selected this lane:",
         "   `\"$LOOPX_PANE_LOOPX\" auto-research worker-turn --format markdown --goal-id \"$LOOPX_GOAL_ID\" --agent-id \"$LOOPX_AGENT_ID\" --lane-count \"${LOOPX_VISIBLE_LANE_COUNT:-1}\" --visible-lanes-accepted --complete-selected-todo --execute`",
@@ -957,6 +957,7 @@ def _auto_research_codex_bootstrap_prompt(
         "   `\"$LOOPX_PANE_LOOPX\" auto-research worker-loop --format markdown --goal-id \"$LOOPX_GOAL_ID\" $LOOPX_WORKER_LOOP_AGENT_ARGS --lane-count \"${LOOPX_VISIBLE_LANE_COUNT:-1}\" --visible-lanes-accepted --complete-selected-todo --execute`",
         "6. Stop after the selected command reports executed/completed turns and no runnable frontier.",
         "7. For evidence-runner, additionally require appended evidence and live_evidence.written=true.",
+        "8. Do not run `--help` or full quota/status dumps on the first screen; if deep debugging is needed, redirect machine details to a local artifact and print a short summary.",
     ]
     return "\n".join(
         [
@@ -967,7 +968,8 @@ def _auto_research_codex_bootstrap_prompt(
             "Use only the pane-local LoopX wrapper: `$LOOPX_PANE_LOOPX`. Do not call bare `loopx` or an absolute LoopX binary; those can hit the wrong registry and make this demo goal look missing.",
             "The wrapper has this demo's registry/runtime baked in. If `$LOOPX_PANE_LOOPX` is unset or not executable, stop and report that blocker instead of falling back.",
             "Visible panes are for human observation: run worker-turn and worker-loop with `--format markdown`. Use `--format json` only when redirecting to an artifact file and printing a compact summary.",
-            "This pane is a visible LoopX polling turn: before each new action, rerun the printed quota should-run and auto-research frontier commands, then follow their interaction_contract.",
+            "This pane is a visible LoopX polling turn: use worker-turn preview/execute as the human-facing polling command; it re-reads quota and frontier internally.",
+            "Avoid `--help` probes and full quota/status dumps in the visible pane unless you are explaining a blocker.",
             "Do not run loopx bootstrap-command-pack, loopx heartbeat-prompt, or generic onboarding unless the printed frontier explicitly asks for it.",
             "If a future scheduled automation owns this lane, it must use a generated LoopX heartbeat/polling prompt; this visible bootstrap is the local manual polling prompt.",
             "",
@@ -3469,6 +3471,8 @@ def _render_auto_research_worker_turn_markdown(payload: dict[str, object]) -> st
         f"- selected_todo: `{payload.get('selected_todo_id') or selected.get('todo_id')}`",
         f"- selected_action: `{payload.get('selected_action') or selected.get('allowed_action')}`",
         f"- selected_title: {selected.get('title')}",
+        f"- blocker: `{payload.get('blocker')}`",
+        f"- blocker_detail: {payload.get('blocker_detail')}",
         f"- executed: `{payload.get('executed')}`",
         f"- would_execute: `{payload.get('would_execute')}`",
         f"- completion_status: `{completion.get('status')}`",

--- a/loopx/capabilities/auto_research/worker_runtime.py
+++ b/loopx/capabilities/auto_research/worker_runtime.py
@@ -586,7 +586,29 @@ def run_auto_research_worker_turn(
             goal_id=goal_id,
             rollout_events=rollout_events,
         )
-        candidate = _select_holdout_candidate(graph)
+        try:
+            candidate = _select_holdout_candidate(graph)
+        except ValueError as exc:
+            return {
+                "ok": True,
+                "schema_version": AUTO_RESEARCH_WORKER_TURN_SCHEMA_VERSION,
+                "mode": "blocked",
+                "goal_id": goal_id,
+                "agent_id": agent_id,
+                "selected_todo_id": todo_id,
+                "selected_action": action,
+                "executed": False,
+                "blocker": "waiting_for_dev_evidence",
+                "blocker_detail": str(exc),
+                "completion": {"requested": complete_selected_todo, "executed": False},
+                "frontier": frontier_packet,
+                "public_boundary": {
+                    "raw_logs_recorded": False,
+                    "private_artifacts_recorded": False,
+                    "absolute_paths_recorded": False,
+                    "credentials_recorded": False,
+                },
+            }
         holdout_result = _run_protected_eval(
             pack_dir=pack_dir,
             split="holdout",


### PR DESCRIPTION
## Summary
- make the visible worker prompt use worker-turn preview/execute as the first-screen polling path instead of long quota/help probes
- render holdout-before-dev as a normal worker-turn blocker rather than a failing command
- extend the demo worker-loop smoke for first-screen prompt hygiene and blocker markdown rendering

## Validation
- python3 -m py_compile loopx/capabilities/auto_research/legacy_core.py loopx/capabilities/auto_research/worker_runtime.py loopx/capabilities/auto_research/cli.py loopx/capabilities/auto_research/demo_e2e.py loopx/visible_multi_agent_launcher.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/visible-multi-agent-launcher-smoke.py
- loopx check --scan-path loopx/capabilities/auto_research/legacy_core.py --scan-path loopx/capabilities/auto_research/worker_runtime.py --scan-path examples/auto-research-demo-e2e-worker-loop-smoke.py

## Boundary
Public-safe auto-research UX and smoke changes only. No raw transcripts, credentials, private artifacts, or local paths are committed.
