### PR TITLE
Keep visible multi-agent panes human-readable

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -50,6 +50,8 @@ def main() -> int:
     assert "Do not print, cat, or sed `$LOOPX_ROLE_PROFILE_PATH`" in bootstrap_source
     assert "Do not run `--help`" in bootstrap_source
     assert "worker-turn preview/execute as the human-facing polling command" in bootstrap_source
+    assert "rewrites accidental visible `--format json` to markdown" in bootstrap_source
+    assert "$LOOPX_PANE_LOOPX_JSON ... --format json > .local/<role>/<name>.public.json" in bootstrap_source
 
     worker_markdown = render_auto_research_markdown(
         {

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -13,7 +14,10 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
-from loopx.visible_multi_agent_launcher import execute_visible_multi_agent_launcher  # noqa: E402
+from loopx.visible_multi_agent_launcher import (  # noqa: E402
+    _SCOPED_LOOPX_WRAPPER_PY,
+    execute_visible_multi_agent_launcher,
+)
 
 
 def write_executable(path: Path, content: str) -> None:
@@ -39,6 +43,9 @@ def main() -> int:
     assert not leaked_defs, leaked_defs
     assert "demo_local_wrapper" not in launcher_source
     assert "loopx_cli_scope=scoped_loopx_wrapper" in launcher_source
+    assert "LOOPX_PANE_LOOPX_JSON" in launcher_source
+    assert "LOOPX_VISIBLE_FORCE_MARKDOWN" in launcher_source
+    assert "format=markdown; machine_json_wrapper=$LOOPX_PANE_LOOPX_JSON" in launcher_source
 
     with tempfile.TemporaryDirectory() as temp_dir:
         temp = Path(temp_dir)
@@ -49,10 +56,25 @@ def main() -> int:
         workspace = temp / "workspace"
         tmux_log = temp / "tmux.jsonl"
         worker_skill = temp / "worker" / "SKILL.md"
+        wrapper_arg_log = temp / "wrapper-args.jsonl"
         worker_skill.parent.mkdir(parents=True)
         worker_skill.write_text("# Worker-local playbook\n", encoding="utf-8")
         registry.write_text(json.dumps({"common_runtime_root": str(runtime_root)}), encoding="utf-8")
-        write_executable(fake_bin / "loopx", "#!/usr/bin/env sh\nexit 0\n")
+        write_executable(
+            fake_bin / "loopx",
+            "\n".join(
+                [
+                    "#!/usr/bin/env python3",
+                    "import json, os, sys",
+                    "path = os.environ.get('WRAPPER_ARG_LOG')",
+                    "if path:",
+                    "    with open(path, 'a', encoding='utf-8') as f:",
+                    "        f.write(json.dumps(sys.argv[1:]) + '\\n')",
+                    "print('fake-loopx ' + ' '.join(sys.argv[1:]))",
+                    "",
+                ]
+            ),
+        )
         write_executable(fake_bin / "codex", "#!/usr/bin/env sh\nexit 0\n")
         write_executable(
             fake_bin / "tmux",
@@ -85,7 +107,43 @@ def main() -> int:
         original_path = os.environ.get("PATH", "")
         os.environ["PATH"] = f"{fake_bin}{os.pathsep}{original_path}"
         os.environ["FAKE_TMUX_LOG"] = str(tmux_log)
+        os.environ["WRAPPER_ARG_LOG"] = str(wrapper_arg_log)
         try:
+            scoped_env = dict(os.environ)
+            scoped_env.update(
+                {
+                    "LOOPX_PROJECT": str(workspace),
+                    "LOOPX_REAL_CLI": str(fake_bin / "loopx"),
+                    "LOOPX_REGISTRY": str(registry),
+                    "LOOPX_RUNTIME_ROOT": str(runtime_root),
+                }
+            )
+            workspace.mkdir(parents=True, exist_ok=True)
+            subprocess.run(
+                [sys.executable, "-c", _SCOPED_LOOPX_WRAPPER_PY],
+                env=scoped_env,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            human = subprocess.run(
+                [str(workspace / ".local/bin/loopx"), "--format", "json", "status"],
+                env=scoped_env,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            machine = subprocess.run(
+                [str(workspace / ".local/bin/loopx-json"), "--format", "json", "status"],
+                env=scoped_env,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            assert "format=markdown; machine_json_wrapper=$LOOPX_PANE_LOOPX_JSON" in human.stdout, human.stdout
+            assert "--format markdown status" in human.stdout, human.stdout
+            assert "--format json status" in machine.stdout, machine.stdout
+
             try:
                 execute_visible_multi_agent_launcher(
                     payload={
@@ -149,6 +207,7 @@ def main() -> int:
         finally:
             os.environ["PATH"] = original_path
             os.environ.pop("FAKE_TMUX_LOG", None)
+            os.environ.pop("WRAPPER_ARG_LOG", None)
 
         assert chosen == "tmux", launch
         assert workspace_mode == "explicit_workspace", launch

--- a/loopx/capabilities/auto_research/legacy_core.py
+++ b/loopx/capabilities/auto_research/legacy_core.py
@@ -957,7 +957,7 @@ def _auto_research_codex_bootstrap_prompt(
         "   `\"$LOOPX_PANE_LOOPX\" auto-research worker-loop --format markdown --goal-id \"$LOOPX_GOAL_ID\" $LOOPX_WORKER_LOOP_AGENT_ARGS --lane-count \"${LOOPX_VISIBLE_LANE_COUNT:-1}\" --visible-lanes-accepted --complete-selected-todo --execute`",
         "6. Stop after the selected command reports executed/completed turns and no runnable frontier.",
         "7. For evidence-runner, additionally require appended evidence and live_evidence.written=true.",
-        "8. Do not run `--help` or full quota/status dumps on the first screen; if deep debugging is needed, redirect machine details to a local artifact and print a short summary.",
+        "8. Do not run `--help` or full quota/status dumps on the first screen; if deep debugging is needed, use `$LOOPX_PANE_LOOPX_JSON ... --format json > .local/<role>/<name>.public.json` and print a short summary.",
     ]
     return "\n".join(
         [
@@ -965,9 +965,9 @@ def _auto_research_codex_bootstrap_prompt(
             "Use the pane-local LoopX wrapper for quota/status/frontier, then follow this compact role prompt.",
             "The worker-local loopx-auto-research playbook is available at `$LOOPX_WORKER_SKILL_PATH` for ambiguous cases, but do not print or cat it in the visible pane.",
             "Do not print, cat, or sed `$LOOPX_ROLE_PROFILE_PATH` or `$LOOPX_ROLE_PROFILE_JSON`; the visible role summary above is the human-facing profile.",
-            "Use only the pane-local LoopX wrapper: `$LOOPX_PANE_LOOPX`. Do not call bare `loopx` or an absolute LoopX binary; those can hit the wrong registry and make this demo goal look missing.",
-            "The wrapper has this demo's registry/runtime baked in. If `$LOOPX_PANE_LOOPX` is unset or not executable, stop and report that blocker instead of falling back.",
-            "Visible panes are for human observation: run worker-turn and worker-loop with `--format markdown`. Use `--format json` only when redirecting to an artifact file and printing a compact summary.",
+            "Use only the pane-local human LoopX wrapper: `$LOOPX_PANE_LOOPX`. Do not call bare `loopx` or an absolute LoopX binary; those can hit the wrong registry and make this demo goal look missing.",
+            "The human wrapper has this demo's registry/runtime baked in and rewrites accidental visible `--format json` to markdown. If `$LOOPX_PANE_LOOPX` is unset or not executable, stop and report that blocker instead of falling back.",
+            "Visible panes are for human observation: run worker-turn and worker-loop with `--format markdown`. If machine JSON is needed, use `$LOOPX_PANE_LOOPX_JSON ... --format json > .local/<role>/<name>.public.json` and print only a compact summary.",
             "This pane is a visible LoopX polling turn: use worker-turn preview/execute as the human-facing polling command; it re-reads quota and frontier internally.",
             "Avoid `--help` probes and full quota/status dumps in the visible pane unless you are explaining a blocker.",
             "Do not run loopx bootstrap-command-pack, loopx heartbeat-prompt, or generic onboarding unless the printed frontier explicitly asks for it.",

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -105,18 +105,67 @@ else:
                 emit(key, evidence_graph.get(key))
 """
 
-_SCOPED_LOOPX_WRAPPER_PY = (
-    "import os,shlex; "
-    "from pathlib import Path; "
-    "project=Path(os.environ['LOOPX_PROJECT']); "
-    "real=os.environ['LOOPX_REAL_CLI']; "
-    "registry=os.environ['LOOPX_REGISTRY']; "
-    "runtime=os.environ['LOOPX_RUNTIME_ROOT']; "
-    "target=project/'.local'/'bin'/'loopx'; "
-    "target.write_text('#!/usr/bin/env sh\\nexec ' + shlex.quote(real) + "
-    "' --registry ' + shlex.quote(registry) + "
-    "' --runtime-root ' + shlex.quote(runtime) + ' \"$@\"\\n', encoding='utf-8')"
+_SCOPED_LOOPX_WRAPPER_PY = r"""
+import os
+from pathlib import Path
+
+project = Path(os.environ["LOOPX_PROJECT"])
+real = os.environ["LOOPX_REAL_CLI"]
+registry = os.environ["LOOPX_REGISTRY"]
+runtime = os.environ["LOOPX_RUNTIME_ROOT"]
+bin_dir = project / ".local" / "bin"
+bin_dir.mkdir(parents=True, exist_ok=True)
+
+json_target = bin_dir / "loopx-json"
+json_target.write_text(
+    "#!/usr/bin/env python3\n"
+    "import os, sys\n"
+    f"real = {real!r}\n"
+    f"registry = {registry!r}\n"
+    f"runtime = {runtime!r}\n"
+    "os.execv(real, [real, '--registry', registry, '--runtime-root', runtime] + sys.argv[1:])\n",
+    encoding="utf-8",
 )
+json_target.chmod(0o700)
+
+human_target = bin_dir / "loopx"
+human_target.write_text(
+    "#!/usr/bin/env python3\n"
+    "import os, sys\n"
+    f"real = {real!r}\n"
+    f"registry = {registry!r}\n"
+    f"runtime = {runtime!r}\n"
+    "args = sys.argv[1:]\n"
+    "force = os.environ.get('LOOPX_VISIBLE_FORCE_MARKDOWN', '1') != '0'\n"
+    "machine_json = os.environ.get('LOOPX_MACHINE_JSON') == '1'\n"
+    "changed = False\n"
+    "if force and not machine_json:\n"
+    "    rewritten = []\n"
+    "    index = 0\n"
+    "    while index < len(args):\n"
+    "        arg = args[index]\n"
+    "        if arg == '--format' and index + 1 < len(args):\n"
+    "            rewritten.append(arg)\n"
+    "            value = args[index + 1]\n"
+    "            if value == 'json':\n"
+    "                value = 'markdown'\n"
+    "                changed = True\n"
+    "            rewritten.append(value)\n"
+    "            index += 2\n"
+    "            continue\n"
+    "        if arg == '--format=json':\n"
+    "            arg = '--format=markdown'\n"
+    "            changed = True\n"
+    "        rewritten.append(arg)\n"
+    "        index += 1\n"
+    "    args = rewritten\n"
+    "if changed:\n"
+    "    print('\\n[LoopX human view]\\nformat=markdown; machine_json_wrapper=$LOOPX_PANE_LOOPX_JSON\\n', flush=True)\n"
+    "os.execv(real, [real, '--registry', registry, '--runtime-root', runtime] + args)\n",
+    encoding="utf-8",
+)
+human_target.chmod(0o700)
+"""
 
 
 def _q(value: object) -> str:
@@ -165,7 +214,7 @@ def build_visible_frontier_command(
     return (
         'cd "$LOOPX_PROJECT"; '
         f"printf '\\n%s\\n' {_q(frontier_label)}; "
-        f"FRONTIER_PACKET=\"$({frontier_command} 2>&1)\"; "
+        f"FRONTIER_PACKET=\"$(LOOPX_MACHINE_JSON=1; export LOOPX_MACHINE_JSON; {frontier_command} 2>&1)\"; "
         "FRONTIER_STATUS=$?; "
         'FRONTIER_ARTIFACT="$LOOPX_VISIBLE_ARTIFACT_DIR/frontier.public.json"; '
         f"printf '%s\\n' \"$FRONTIER_PACKET\" | python3 -c {_q(_HUMAN_VIEW_PACKET_PY)} frontier \"$FRONTIER_ARTIFACT\" || true; "
@@ -219,7 +268,10 @@ def build_visible_lane_command(
         'mkdir -p "$LOOPX_PROJECT/.local/bin"; '
         f"python3 -c {_q(_SCOPED_LOOPX_WRAPPER_PY)}; "
         'chmod +x "$LOOPX_PROJECT/.local/bin/loopx"; '
+        'chmod +x "$LOOPX_PROJECT/.local/bin/loopx-json"; '
         'export LOOPX_PANE_LOOPX="$LOOPX_PROJECT/.local/bin/loopx"; '
+        'export LOOPX_PANE_LOOPX_JSON="$LOOPX_PROJECT/.local/bin/loopx-json"; '
+        'export LOOPX_VISIBLE_FORCE_MARKDOWN="${LOOPX_VISIBLE_FORCE_MARKDOWN:-1}"; '
         'export PATH="$LOOPX_PROJECT/.local/bin:$PATH"; '
     )
     visible_summary = (
@@ -262,7 +314,7 @@ def build_visible_lane_command(
         f"{role_profile_command}"
         f"{poll_header}"
         "printf '\\n[LoopX quota guard]\\nattempt=%s/%s\\n' \"$POLL_INDEX\" \"$POLL_ATTEMPTS\"; "
-        f"QUOTA_PACKET=\"$({quota_command} 2>&1)\"; "
+        f"QUOTA_PACKET=\"$(LOOPX_MACHINE_JSON=1; export LOOPX_MACHINE_JSON; {quota_command} 2>&1)\"; "
         "QUOTA_STATUS=$?; "
         'VISIBLE_ARTIFACT_PREFIX="${LOOPX_LANE_ID:-${LOOPX_ROLE_ID:-lane}}"; '
         'QUOTA_ARTIFACT="$LOOPX_VISIBLE_ARTIFACT_DIR/$VISIBLE_ARTIFACT_PREFIX.quota.public.json"; '
@@ -290,7 +342,7 @@ def build_visible_lane_command(
         f"{keep_visible}; "
         "fi; "
         f"printf '\\n{frontier_label}\\n'; "
-        f"FRONTIER_PACKET=\"$({frontier_command} 2>&1)\"; "
+        f"FRONTIER_PACKET=\"$(LOOPX_MACHINE_JSON=1; export LOOPX_MACHINE_JSON; {frontier_command} 2>&1)\"; "
         "FRONTIER_STATUS=$?; "
         'FRONTIER_ARTIFACT="$LOOPX_VISIBLE_ARTIFACT_DIR/$VISIBLE_ARTIFACT_PREFIX.frontier.public.json"; '
         f"printf '%s\\n' \"$FRONTIER_PACKET\" | python3 -c {_q(_HUMAN_VIEW_PACKET_PY)} frontier \"$FRONTIER_ARTIFACT\" || true; "


### PR DESCRIPTION
## Summary
- add pane-local human and machine LoopX wrappers for visible multi-agent sessions
- keep launcher quota/frontier reads on machine JSON while visible worker commands default to markdown
- update auto-research bootstrap guidance and focused smokes for the human/machine split

## Validation
- python3 -m py_compile loopx/visible_multi_agent_launcher.py loopx/capabilities/auto_research/legacy_core.py loopx/capabilities/auto_research/demo_e2e.py loopx/capabilities/auto_research/worker_runtime.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/visible-multi-agent-launcher-smoke.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- loopx check --scan-path loopx/visible_multi_agent_launcher.py --scan-path loopx/capabilities/auto_research/legacy_core.py --scan-path examples/visible-multi-agent-launcher-smoke.py --scan-path examples/auto-research-demo-e2e-worker-loop-smoke.py

Note: loopx check reports the existing loopx-meta duplicate index rows warning only.