### PR TITLE
Fix SkillsBench staged empty skills context

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -6017,6 +6017,42 @@ def test_skillsbench_docker_task_staging_forwards_proxy_to_verifier_bootstrap() 
         )
 
 
+def test_skillsbench_docker_task_staging_keeps_empty_skills_build_context() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-empty-skills-context-") as tmp:
+        root = Path(tmp)
+        task = root / "tasks" / "radar-vital-signs"
+        dockerfile = task / "environment" / "Dockerfile"
+        skills_dir = task / "environment" / "skills"
+        dockerfile.parent.mkdir(parents=True)
+        skills_dir.mkdir(parents=True)
+        dockerfile.write_text(
+            "FROM python:3.11-slim\nCOPY skills /root/.codex/skills\n",
+            encoding="utf-8",
+        )
+        (skills_dir / "private_task_skill.md").write_text(
+            "task-local skill content should not be copied when disabled\n",
+            encoding="utf-8",
+        )
+        (task / "task.toml").write_text("version = \"1.1\"\n", encoding="utf-8")
+
+        staged_path, metadata = stage_task_for_sandbox(
+            task_path=task,
+            jobs_dir=root / "jobs",
+            job_name="radar-vital-signs-goal",
+            sandbox="docker",
+            include_task_skills=False,
+        )
+
+        staged_skills_dir = staged_path / "environment" / "skills"
+        assert metadata["task_skills_removed"] is True, metadata
+        assert metadata["empty_skills_build_context_required"] is True, metadata
+        assert metadata["empty_skills_build_context_created"] is True, metadata
+        assert staged_skills_dir.is_dir(), metadata
+        assert (staged_skills_dir / ".loopx_keep").exists(), metadata
+        assert not (staged_skills_dir / "private_task_skill.md").exists(), metadata
+        assert not skills_dir.joinpath(".loopx_keep").exists()
+
+
 def test_skillsbench_apt_risk_preflight_blocks_full_run_without_benchflow() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-apt-preflight-") as tmp:
         root = Path(tmp)

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -6928,6 +6928,35 @@ def patch_dockerfile_codex_acp_runtime_tools(dockerfile: Path) -> bool:
     return True
 
 
+def dockerfile_references_skills_build_context(dockerfile: Path) -> bool:
+    """Return whether the Dockerfile copies the local ``skills`` build context."""
+
+    if not dockerfile.exists():
+        return False
+    try:
+        text = dockerfile.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return False
+    pattern = re.compile(r"^\s*(?:COPY|ADD)\b[^\n]*\bskills(?:\s|$)", re.MULTILINE)
+    return bool(pattern.search(text))
+
+
+def ensure_empty_skills_build_context(dockerfile: Path) -> bool:
+    """Create an empty ``skills`` context when staging removed task skills."""
+
+    if not dockerfile_references_skills_build_context(dockerfile):
+        return False
+    skills_dir = dockerfile.parent / "skills"
+    if skills_dir.exists():
+        return False
+    skills_dir.mkdir(parents=True, exist_ok=True)
+    (skills_dir / ".loopx_keep").write_text(
+        "empty SkillsBench build context created by LoopX staging\n",
+        encoding="utf-8",
+    )
+    return True
+
+
 def stage_task_for_sandbox(
     *,
     task_path: Path,
@@ -6952,6 +6981,8 @@ def stage_task_for_sandbox(
         "dockerfile_pip_bootstrap_patch_required": False,
         "dockerfile_pip_bootstrap_patch_applied": False,
         "codex_acp_runtime_tools_patch_applied": False,
+        "empty_skills_build_context_required": False,
+        "empty_skills_build_context_created": False,
         "verifier_uv_bootstrap_risk_detected": False,
         "verifier_uv_bootstrap_mirror_patch_required": False,
         "verifier_uv_bootstrap_mirror_patch_applied": False,
@@ -7055,6 +7086,12 @@ def stage_task_for_sandbox(
     if not include_task_skills and staged_skills_dir.exists():
         shutil.rmtree(staged_skills_dir)
         task_skills_removed = True
+    empty_skills_context_required = dockerfile_references_skills_build_context(
+        staged_path / "environment" / "Dockerfile"
+    )
+    empty_skills_context_created = ensure_empty_skills_build_context(
+        staged_path / "environment" / "Dockerfile"
+    )
     patched = patch_dockerfile_app_skills_mount(
         staged_path / "environment" / "Dockerfile"
     )
@@ -7089,6 +7126,8 @@ def stage_task_for_sandbox(
                 DEFAULT_DOCKER_PIP_INDEX_HOST if pip_bootstrap_patched else ""
             ),
             "codex_acp_runtime_tools_patch_applied": runtime_tools_patched,
+            "empty_skills_build_context_required": empty_skills_context_required,
+            "empty_skills_build_context_created": empty_skills_context_created,
             "app_skills_mount_target": "/app/skills",
             "original_task_mutated": False,
             "task_skills_removed": task_skills_removed,


### PR DESCRIPTION
## Summary
- keep an empty staged `environment/skills` build context when task skills are disabled but the Dockerfile still copies `skills`
- expose public-safe staging metadata for this repair
- add a focused SkillsBench smoke covering the missing build-context regression

## Validation
- `python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py`
- direct smoke calls: verifier uv bootstrap, verifier proxy env, empty skills build context

## Boundary
No raw benchmark logs, verifier output, credentials, private proxy values, or local run paths are committed.
