### PR TITLE
Keep visible launcher JSON off TTY

### DIFF
--- a/docs/guides/auto-research-command-path.md
+++ b/docs/guides/auto-research-command-path.md
@@ -105,7 +105,11 @@ loopx --registry "$LOOPX_REGISTRY" \
   --headless
 ```
 
-To start tmux panes but stay in the current shell, use `--no-attach`.
+To start tmux panes but stay in the current shell, use `--no-attach`. Visible
+panes default to human-readable LoopX output. The pane-local `$LOOPX_PANE_LOOPX`
+wrapper rewrites accidental visible JSON requests to markdown, and
+`$LOOPX_PANE_LOOPX_JSON` is reserved for redirected or piped machine artifacts;
+it refuses to dump raw JSON directly into a visible terminal.
 
 Expected minimal E2E result:
 
@@ -270,6 +274,9 @@ lanes, including a separate evidence-verifier lane.
 The visible panes should do work through the same CLI path a heartbeat worker
 uses: each turn re-reads quota, frontier, todo projection, and rollout evidence
 before writing anything.
+The user-facing terminal should show the role, selected todo, action, blocker,
+and Codex CLI stream; raw JSON belongs in `.public.json` artifacts, not on the
+first visible screen.
 
 ```bash
 loopx --registry "$LOOPX_REGISTRY" \

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import json
 import os
+import pty
+import select
 import subprocess
 import sys
 import tempfile
@@ -23,6 +25,45 @@ from loopx.visible_multi_agent_launcher import (  # noqa: E402
 def write_executable(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
     path.chmod(0o755)
+
+
+def run_with_pty(command: list[str], *, env: dict[str, str]) -> tuple[int, str]:
+    master, slave = pty.openpty()
+    try:
+        proc = subprocess.Popen(
+            command,
+            env=env,
+            stdin=subprocess.DEVNULL,
+            stdout=slave,
+            stderr=slave,
+            close_fds=True,
+        )
+        os.close(slave)
+        chunks: list[bytes] = []
+        while True:
+            ready, _, _ = select.select([master], [], [], 0.2)
+            if master in ready:
+                try:
+                    data = os.read(master, 4096)
+                except OSError:
+                    data = b""
+                if data:
+                    chunks.append(data)
+            if proc.poll() is not None:
+                while True:
+                    try:
+                        data = os.read(master, 4096)
+                    except OSError:
+                        break
+                    if not data:
+                        break
+                    chunks.append(data)
+                return proc.returncode or 0, b"".join(chunks).decode(errors="replace")
+    finally:
+        try:
+            os.close(master)
+        except OSError:
+            pass
 
 
 def main() -> int:
@@ -46,6 +87,8 @@ def main() -> int:
     assert "LOOPX_PANE_LOOPX_JSON" in launcher_source
     assert "LOOPX_VISIBLE_FORCE_MARKDOWN" in launcher_source
     assert "format=markdown; machine_json_wrapper=$LOOPX_PANE_LOOPX_JSON" in launcher_source
+    assert "LoopX machine JSON hidden" in launcher_source
+    assert "LOOPX_ALLOW_TTY_JSON" in launcher_source
 
     with tempfile.TemporaryDirectory() as temp_dir:
         temp = Path(temp_dir)
@@ -140,9 +183,16 @@ def main() -> int:
                 capture_output=True,
                 text=True,
             )
+            tty_status, tty_output = run_with_pty(
+                [str(workspace / ".local/bin/loopx-json"), "--format", "json", "status"],
+                env=scoped_env,
+            )
             assert "format=markdown; machine_json_wrapper=$LOOPX_PANE_LOOPX_JSON" in human.stdout, human.stdout
             assert "--format markdown status" in human.stdout, human.stdout
             assert "--format json status" in machine.stdout, machine.stdout
+            assert tty_status == 2, tty_output
+            assert "LoopX machine JSON hidden" in tty_output, tty_output
+            assert "fake-loopx" not in tty_output, tty_output
 
             try:
                 execute_visible_multi_agent_launcher(

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -123,6 +123,11 @@ json_target.write_text(
     f"real = {real!r}\n"
     f"registry = {registry!r}\n"
     f"runtime = {runtime!r}\n"
+    "if sys.stdout.isatty() and os.environ.get('LOOPX_ALLOW_TTY_JSON') != '1' and os.environ.get('LOOPX_MACHINE_JSON') != '1':\n"
+    "    print('\\n[LoopX machine JSON hidden]\\nraw JSON is not printed in visible panes.\\n')\n"
+    "    print('Use $LOOPX_PANE_LOOPX for human-readable output, or redirect machine JSON:')\n"
+    "    print('  $LOOPX_PANE_LOOPX_JSON ... --format json > .local/<role>/<name>.public.json')\n"
+    "    raise SystemExit(2)\n"
     "os.execv(real, [real, '--registry', registry, '--runtime-root', runtime] + sys.argv[1:])\n",
     encoding="utf-8",
 )


### PR DESCRIPTION
## Summary
- prevent the pane-local machine JSON wrapper from dumping raw JSON directly into visible tmux/Codex panes
- keep redirected/piped JSON behavior available for control-plane artifacts
- document the visible-pane contract for auto-research demos

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 examples/visible-multi-agent-launcher-smoke.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/generic-multi-agent-one-command-smoke.py
- loopx check --scan-path loopx/visible_multi_agent_launcher.py --scan-path examples/visible-multi-agent-launcher-smoke.py --scan-path docs/guides/auto-research-command-path.md

## Boundary
- public boundary scan clean; existing loopx-meta duplicate-index warning remains unrelated