### PR TITLE
Keep pane machine JSON file-bound

### DIFF
--- a/docs/guides/auto-research-command-path.md
+++ b/docs/guides/auto-research-command-path.md
@@ -108,8 +108,9 @@ loopx --registry "$LOOPX_REGISTRY" \
 To start tmux panes but stay in the current shell, use `--no-attach`. Visible
 panes default to human-readable LoopX output. The pane-local `$LOOPX_PANE_LOOPX`
 wrapper rewrites accidental visible JSON requests to markdown, and
-`$LOOPX_PANE_LOOPX_JSON` is reserved for redirected or piped machine artifacts;
-it refuses to dump raw JSON directly into a visible terminal.
+`$LOOPX_PANE_LOOPX_JSON` is reserved for redirected machine artifacts; it refuses
+to dump raw JSON directly into a visible terminal or a Codex-visible pipe unless
+the launcher explicitly sets `LOOPX_MACHINE_JSON=1`.
 
 Expected minimal E2E result:
 

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -89,6 +89,8 @@ def main() -> int:
     assert "format=markdown; machine_json_wrapper=$LOOPX_PANE_LOOPX_JSON" in launcher_source
     assert "LoopX machine JSON hidden" in launcher_source
     assert "LOOPX_ALLOW_TTY_JSON" in launcher_source
+    assert "stat.S_ISREG" in launcher_source
+    assert "LOOPX_MACHINE_JSON=1 explicitly" in launcher_source
 
     with tempfile.TemporaryDirectory() as temp_dir:
         temp = Path(temp_dir)
@@ -176,9 +178,26 @@ def main() -> int:
                 capture_output=True,
                 text=True,
             )
-            machine = subprocess.run(
+            visible_pipe = subprocess.run(
                 [str(workspace / ".local/bin/loopx-json"), "--format", "json", "status"],
                 env=scoped_env,
+                capture_output=True,
+                text=True,
+            )
+            machine_artifact = workspace / ".local" / "reviewer" / "status.public.json"
+            machine_artifact.parent.mkdir(parents=True, exist_ok=True)
+            with machine_artifact.open("w", encoding="utf-8") as handle:
+                subprocess.run(
+                    [str(workspace / ".local/bin/loopx-json"), "--format", "json", "status"],
+                    env=scoped_env,
+                    stdout=handle,
+                    stderr=subprocess.STDOUT,
+                    check=True,
+                    text=True,
+                )
+            explicit_machine = subprocess.run(
+                [str(workspace / ".local/bin/loopx-json"), "--format", "json", "status"],
+                env={**scoped_env, "LOOPX_MACHINE_JSON": "1"},
                 check=True,
                 capture_output=True,
                 text=True,
@@ -189,7 +208,11 @@ def main() -> int:
             )
             assert "format=markdown; machine_json_wrapper=$LOOPX_PANE_LOOPX_JSON" in human.stdout, human.stdout
             assert "--format markdown status" in human.stdout, human.stdout
-            assert "--format json status" in machine.stdout, machine.stdout
+            assert visible_pipe.returncode == 2, visible_pipe.stdout
+            assert "LoopX machine JSON hidden" in visible_pipe.stdout, visible_pipe.stdout
+            assert "fake-loopx" not in visible_pipe.stdout, visible_pipe.stdout
+            assert "--format json status" in machine_artifact.read_text(encoding="utf-8")
+            assert "--format json status" in explicit_machine.stdout, explicit_machine.stdout
             assert tty_status == 2, tty_output
             assert "LoopX machine JSON hidden" in tty_output, tty_output
             assert "fake-loopx" not in tty_output, tty_output

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -119,14 +119,18 @@ bin_dir.mkdir(parents=True, exist_ok=True)
 json_target = bin_dir / "loopx-json"
 json_target.write_text(
     "#!/usr/bin/env python3\n"
-    "import os, sys\n"
+    "import os, stat, sys\n"
     f"real = {real!r}\n"
     f"registry = {registry!r}\n"
     f"runtime = {runtime!r}\n"
-    "if sys.stdout.isatty() and os.environ.get('LOOPX_ALLOW_TTY_JSON') != '1' and os.environ.get('LOOPX_MACHINE_JSON') != '1':\n"
+    "explicit = os.environ.get('LOOPX_MACHINE_JSON') == '1' or os.environ.get('LOOPX_ALLOW_TTY_JSON') == '1' or os.environ.get('LOOPX_ALLOW_VISIBLE_JSON') == '1'\n"
+    "stdout_mode = os.fstat(sys.stdout.fileno()).st_mode\n"
+    "stdout_is_file = stat.S_ISREG(stdout_mode)\n"
+    "if not explicit and not stdout_is_file:\n"
     "    print('\\n[LoopX machine JSON hidden]\\nraw JSON is not printed in visible panes.\\n')\n"
     "    print('Use $LOOPX_PANE_LOOPX for human-readable output, or redirect machine JSON:')\n"
     "    print('  $LOOPX_PANE_LOOPX_JSON ... --format json > .local/<role>/<name>.public.json')\n"
+    "    print('Internal launcher pipes must set LOOPX_MACHINE_JSON=1 explicitly.')\n"
     "    raise SystemExit(2)\n"
     "os.execv(real, [real, '--registry', registry, '--runtime-root', runtime] + sys.argv[1:])\n",
     encoding="utf-8",


### PR DESCRIPTION
## Summary
- keep pane-local machine JSON wrapper off visible pipes unless explicitly authorized
- allow JSON artifacts through normal file redirection
- extend visible launcher smoke and command-path docs for the new boundary

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 examples/visible-multi-agent-launcher-smoke.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/generic-multi-agent-one-command-smoke.py
- loopx check --scan-path loopx/visible_multi_agent_launcher.py --scan-path examples/visible-multi-agent-launcher-smoke.py --scan-path docs/guides/auto-research-command-path.md
- git diff --check origin/main...HEAD