### PR TITLE
Fix SkillsBench verifier staging guards

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -6036,6 +6036,47 @@ def test_skillsbench_docker_task_staging_adds_pip_bootstrap_patch() -> None:
         ), staged_text
 
 
+def test_skillsbench_docker_pip_bootstrap_skips_python_heredoc_imports() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-pip-heredoc-stage-") as tmp:
+        root = Path(tmp)
+        task = root / "tasks" / "latex-formula-extraction"
+        dockerfile = task / "environment" / "Dockerfile"
+        dockerfile.parent.mkdir(parents=True)
+        dockerfile.write_text(
+            "FROM ubuntu:24.04\n"
+            "RUN python3 - <<'PY'\n"
+            "from huggingface_hub import snapshot_download\n"
+            "snapshot_download(repo_id='example/model')\n"
+            "PY\n"
+            "RUN pip3 install marker-pdf==1.3.3\n",
+            encoding="utf-8",
+        )
+        (task / "task.toml").write_text("version = \"1.1\"\n", encoding="utf-8")
+
+        staged_path, metadata = stage_task_for_sandbox(
+            task_path=task,
+            jobs_dir=root / "jobs",
+            job_name="latex-formula-extraction-goalstart",
+            sandbox="docker",
+            include_task_skills=False,
+        )
+
+        assert metadata["dockerfile_pip_bootstrap_patch_applied"] is True, metadata
+        staged_text = (staged_path / "environment" / "Dockerfile").read_text(
+            encoding="utf-8"
+        )
+        assert staged_text.count(DOCKER_PIP_BOOTSTRAP_BEGIN) == 1, staged_text
+        heredoc_body = staged_text[
+            staged_text.index("RUN python3 - <<'PY'") : staged_text.index(
+                "PY\nRUN pip3 install"
+            )
+        ]
+        assert DOCKER_PIP_BOOTSTRAP_BEGIN not in heredoc_body, staged_text
+        assert staged_text.index(DOCKER_PIP_BOOTSTRAP_BEGIN) < staged_text.index(
+            "RUN python3 - <<'PY'"
+        ), staged_text
+
+
 def test_skillsbench_runtime_tools_patch_has_own_apt_retry_defaults() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-runtime-tools-apt-") as tmp:
         root = Path(tmp)
@@ -6086,6 +6127,7 @@ def test_skillsbench_docker_task_staging_patches_verifier_uv_bootstrap_mirror() 
             "#!/bin/sh\n"
             "apt-get update\n"
             "curl -LsSf https://astral.sh/uv/0.9.7/install.sh | sh\n"
+            "source \"$HOME/.local/bin/env\"\n"
             "uvx --with pytest==8.4.1 pytest /tests/test_outputs.py\n"
         )
         verifier.write_text(original_verifier, encoding="utf-8")
@@ -6111,6 +6153,9 @@ def test_skillsbench_docker_task_staging_patches_verifier_uv_bootstrap_mirror() 
         assert metadata[
             "verifier_uv_bootstrap_pip_fallback_patch_applied"
         ] is True, metadata
+        assert metadata["verifier_uv_env_source_guard_patch_applied"] is True, (
+            metadata
+        )
         assert metadata["verifier_uv_bootstrap_version"] == "0.9.7", metadata
         assert metadata["verifier_uv_bootstrap_mirror_host"] == (
             DEFAULT_VERIFIER_UV_RELEASE_MIRROR_HOST
@@ -6126,6 +6171,12 @@ def test_skillsbench_docker_task_staging_patches_verifier_uv_bootstrap_mirror() 
         assert "uv==${loopx_uv_version}" in staged_verifier, staged_verifier
         assert "loopx_uv_installer_timeout_sec" in staged_verifier, staged_verifier
         assert "timeout \"${loopx_uv_installer_timeout_sec}\" sh -c" in (
+            staged_verifier
+        )
+        assert 'if [ -f "$HOME/.local/bin/env" ]; then' in staged_verifier, (
+            staged_verifier
+        )
+        assert "source \"$HOME/.local/bin/env\"" not in staged_verifier, (
             staged_verifier
         )
         assert "releases.astral.sh/github/uv/releases/download" in staged_verifier, (

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -5795,6 +5795,10 @@ def _discover_prepared_task_staging(plan: dict[str, Any]) -> dict[str, Any]:
                     "python3 -m pip install" in verifier_text
                     and "uv==${loopx_uv_version}" in verifier_text
                 ),
+                "verifier_uv_env_source_guard_patch_applied": (
+                    'if [ -f "$HOME/.local/bin/env" ]; then' in verifier_text
+                    and '. "$HOME/.local/bin/env"' in verifier_text
+                ),
                 "verifier_uv_bootstrap_mirror_host": (
                     DEFAULT_VERIFIER_UV_RELEASE_MIRROR_HOST
                 ),
@@ -6883,6 +6887,7 @@ def patch_verifier_uv_bootstrap_mirror(verifier: Path) -> dict[str, Any]:
         "verifier_uv_bootstrap_mirror_patch_required": False,
         "verifier_uv_bootstrap_mirror_patch_applied": False,
         "verifier_uv_bootstrap_pip_fallback_patch_applied": False,
+        "verifier_uv_env_source_guard_patch_applied": False,
     }
     if not verifier.exists():
         return metadata
@@ -6952,6 +6957,7 @@ def patch_verifier_uv_bootstrap_mirror(verifier: Path) -> dict[str, Any]:
     if not inserted:
         patched_lines.extend(block.splitlines())
     patched = "\n".join(patched_lines).rstrip() + "\n"
+    patched, source_guard_applied = _patch_verifier_uv_env_source_guard(patched)
     if patched != original:
         _write_text_atomic(verifier, patched)
     metadata.update(
@@ -6960,6 +6966,7 @@ def patch_verifier_uv_bootstrap_mirror(verifier: Path) -> dict[str, Any]:
             "verifier_uv_bootstrap_mirror_patch_required": True,
             "verifier_uv_bootstrap_mirror_patch_applied": True,
             "verifier_uv_bootstrap_pip_fallback_patch_applied": True,
+            "verifier_uv_env_source_guard_patch_applied": source_guard_applied,
             "verifier_uv_bootstrap_version": version,
             "verifier_uv_bootstrap_mirror_host": (
                 DEFAULT_VERIFIER_UV_RELEASE_MIRROR_HOST
@@ -6967,6 +6974,34 @@ def patch_verifier_uv_bootstrap_mirror(verifier: Path) -> dict[str, Any]:
         }
     )
     return metadata
+
+
+def _patch_verifier_uv_env_source_guard(text: str) -> tuple[str, bool]:
+    """Guard uv installer env sourcing when the pip wheel already provided uvx."""
+
+    source_lines = {
+        'source "$HOME/.local/bin/env"',
+        "source $HOME/.local/bin/env",
+        '. "$HOME/.local/bin/env"',
+        ". $HOME/.local/bin/env",
+    }
+    replacement = [
+        'if [ -f "$HOME/.local/bin/env" ]; then',
+        '  . "$HOME/.local/bin/env"',
+        "fi",
+    ]
+    patched_lines: list[str] = []
+    applied = False
+    for line in text.splitlines():
+        if line.strip() in source_lines:
+            indent = line[: len(line) - len(line.lstrip())]
+            patched_lines.extend(f"{indent}{part}" for part in replacement)
+            applied = True
+        else:
+            patched_lines.append(line)
+    if not applied:
+        return text, False
+    return "\n".join(patched_lines).rstrip() + "\n", True
 
 
 def _verifier_benchmark_egress_proxy_exports(
@@ -7115,10 +7150,19 @@ def patch_dockerfile_pip_bootstrap(dockerfile: Path) -> bool:
     )
     patched_lines: list[str] = []
     inserted = False
+    heredoc_delimiter: str | None = None
     for line in text.splitlines():
         patched_lines.append(line)
+        if heredoc_delimiter is not None:
+            if line.strip() == heredoc_delimiter:
+                heredoc_delimiter = None
+            continue
+        heredoc_delimiter = _dockerfile_heredoc_delimiter(line)
         stripped = line.strip()
-        if stripped.upper().startswith("FROM ") and " scratch" not in stripped.lower():
+        if (
+            _is_dockerfile_from_instruction(stripped)
+            and " scratch" not in stripped.lower()
+        ):
             patched_lines.extend(["", *block.splitlines(), ""])
             inserted = True
     if not inserted:
@@ -7128,6 +7172,27 @@ def patch_dockerfile_pip_bootstrap(dockerfile: Path) -> bool:
         return False
     _write_text_atomic(dockerfile, patched)
     return True
+
+
+def _dockerfile_heredoc_delimiter(line: str) -> str | None:
+    """Return a Dockerfile shell heredoc delimiter opened on this line."""
+
+    match = re.search(r"<<-?\s*['\"]?([A-Za-z_][A-Za-z0-9_]*)['\"]?", line)
+    if not match:
+        return None
+    return match.group(1)
+
+
+def _is_dockerfile_from_instruction(stripped_line: str) -> bool:
+    """Match Dockerfile ``FROM`` instructions without matching heredoc Python."""
+
+    return bool(
+        re.match(
+            r"^FROM(?:\s+--platform=\S+)?\s+\S+(?:\s+AS\s+\S+)?\s*$",
+            stripped_line,
+            flags=re.IGNORECASE,
+        )
+    )
 
 
 def patch_dockerfile_codex_acp_runtime_tools(dockerfile: Path) -> bool:


### PR DESCRIPTION
## Summary
- keep Dockerfile pip bootstrap insertion out of shell/Python heredoc bodies and match only real Dockerfile FROM instructions
- guard verifier uv env sourcing when pip-wheel fallback already provided uvx
- add focused SkillsBench smoke coverage for the LaTeX heredoc and verifier uv guard regressions

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- git diff --check
- public/private scan on changed files: no private proxy, auth, or local benchmark artifact paths introduced
