### PR TITLE
Clarify visible multi-agent human stream contract

### DIFF
--- a/docs/reference/protocols/multi-agent-visible-launcher-v0.md
+++ b/docs/reference/protocols/multi-agent-visible-launcher-v0.md
@@ -49,6 +49,27 @@ agent lane that must read the same goal state and pass its own guard.
     "all_lane_workspace_isolation": false,
     "mutation_isolation_policy": "only mutating attempts require a claimed worktree or equivalent execution boundary"
   },
+  "human_stream_contract": {
+    "schema_version": "multi_agent_visible_human_stream_contract_v0",
+    "human_pane": [
+      "role_profile_summary",
+      "quota_summary",
+      "frontier_or_blocked_summary",
+      "bootstrap_artifact_ref",
+      "codex_stream",
+      "compact_exit_summary",
+      "takeover_controls"
+    ],
+    "machine_artifacts": [
+      "quota.public.json",
+      "frontier.public.json",
+      "bootstrap-prompt.public.txt",
+      "role_local_public_artifacts"
+    ],
+    "machine_json_policy": "file_or_explicit_machine_channel_only",
+    "visible_json_policy": "markdown_or_compact_summary_only",
+    "codex_stream": "stdout_stderr_visible_below_bootstrap"
+  },
   "lanes": [],
   "commands": {
     "start_script": [],
@@ -69,6 +90,7 @@ Required top-level fields:
 - `goal_id` and `session_name`;
 - `reasoning_contract`;
 - `shared_goal_surface`;
+- `human_stream_contract`;
 - `lanes[]`;
 - `commands.attach`, `commands.stop`, and `commands.retry`;
 - `acceptance`;
@@ -145,6 +167,29 @@ Every visible lane follows the same generic start order:
 The launcher must not inject prompts into a hidden session, hide guard output,
 or continue a lane after a user gate is projected.
 
+## Human Stream Contract
+
+The first screen of each visible pane is for humans. It should show role,
+todo/progress, guard status, frontier or blocked reason, bootstrap status, and
+the live Codex CLI stream. Raw quota, frontier, role profile, and machine JSON
+belong in public-safe artifacts or an explicit machine channel.
+
+Required visible markers:
+
+- `role_profile=printed`;
+- `quota_guard=printed`;
+- `frontier_or_blocked_reason=printed`;
+- `bootstrap_or_stop=printed`;
+- `loopx_agent_handshake=role_profile_quota_frontier_bootstrap`;
+- `human_stream_contract=role_todo_progress_codex_stream`;
+- `machine_json_policy=file_or_explicit_machine_channel_only`.
+
+The human pane may print compact summaries and artifact basenames, but it should
+not dump raw JSON, credentials, private logs, raw transcripts, or absolute local
+artifact paths. The Codex CLI stdout/stderr stream remains visible below the
+bootstrap marker so the user can watch the real worker response instead of a
+parallel presentation layer.
+
 ## Host Controls
 
 The packet must expose:
@@ -214,11 +259,13 @@ A public fixture or implementation satisfies the contract when:
    high reasoning, lane timeline, and visible launch command;
 6. it requires attach, stop, retry, pane interrupt, and visible acceptance
    markers;
-7. dry-run mode starts no process, runs no agent, writes no LoopX state, and
+7. it has a human stream contract that keeps raw machine JSON in artifacts or
+   explicit machine channels while streaming Codex CLI output visibly;
+8. dry-run mode starts no process, runs no agent, writes no LoopX state, and
    spends no quota;
-8. execute mode still writes state and spends quota only through normal LoopX
+9. execute mode still writes state and spends quota only through normal LoopX
    writeback after validation;
-9. it keeps workspace isolation scoped to mutating attempts rather than
+10. it keeps workspace isolation scoped to mutating attempts rather than
    splitting the shared goal surface; and
-10. public docs and fixtures contain no raw transcripts, credentials, private
+11. public docs and fixtures contain no raw transcripts, credentials, private
     links, internal project names, or local absolute paths.

--- a/examples/generic-multi-agent-one-command-smoke.py
+++ b/examples/generic-multi-agent-one-command-smoke.py
@@ -50,7 +50,7 @@ lanes = [
         "quota_guard": "loopx --format json --registry \"$LOOPX_REGISTRY\" --runtime-root \"$LOOPX_RUNTIME_ROOT\" quota should-run --goal-id loopx-meta --agent-id codex-main-control",
         "frontier": "printf '[LoopX frontier]\\nfrontier_or_blocked_reason=printed\\n'",
         "bootstrap_message": "printf '[bootstrap-or-stop]\\nmodel_reasoning_effort=high\\n'",
-        "visible_launch_command": "printf '[LoopX visible acceptance]\\n[LoopX role profile]\\n[LoopX quota guard]\\n[LoopX frontier]\\n[bootstrap-or-stop]\\nloopx_agent_handshake=role_profile_quota_frontier_bootstrap\\nloopx_polling_prompt=visible_bootstrap_prompt\\nreasoning_effort=high\\nmodel_reasoning_effort=high\\n'; exec /bin/sh -i",
+        "visible_launch_command": "printf '[LoopX visible acceptance]\\n[LoopX role profile]\\n[LoopX quota guard]\\n[LoopX frontier]\\n[bootstrap-or-stop]\\nloopx_agent_handshake=role_profile_quota_frontier_bootstrap\\nloopx_polling_prompt=visible_bootstrap_prompt\\nhuman_stream_contract=role_todo_progress_codex_stream\\nmachine_json_policy=file_or_explicit_machine_channel_only\\nreasoning_effort=high\\nmodel_reasoning_effort=high\\n'; exec /bin/sh -i",
         "reasoning_effort": "high",
         "lane_timeline": ["role_profile", "quota_guard", "frontier", "bootstrap"],
     },
@@ -63,7 +63,7 @@ lanes = [
         "quota_guard": "loopx --format json --registry \"$LOOPX_REGISTRY\" --runtime-root \"$LOOPX_RUNTIME_ROOT\" quota should-run --goal-id loopx-meta --agent-id codex-side-bypass",
         "frontier": "printf '[LoopX frontier]\\nfrontier_or_blocked_reason=printed\\n'",
         "bootstrap_message": "printf '[bootstrap-or-stop]\\nmodel_reasoning_effort=high\\n'",
-        "visible_launch_command": "printf '[LoopX visible acceptance]\\n[LoopX role profile]\\n[LoopX quota guard]\\n[LoopX frontier]\\n[bootstrap-or-stop]\\nloopx_agent_handshake=role_profile_quota_frontier_bootstrap\\nloopx_polling_prompt=visible_bootstrap_prompt\\nreasoning_effort=high\\nmodel_reasoning_effort=high\\n'; exec /bin/sh -i",
+        "visible_launch_command": "printf '[LoopX visible acceptance]\\n[LoopX role profile]\\n[LoopX quota guard]\\n[LoopX frontier]\\n[bootstrap-or-stop]\\nloopx_agent_handshake=role_profile_quota_frontier_bootstrap\\nloopx_polling_prompt=visible_bootstrap_prompt\\nhuman_stream_contract=role_todo_progress_codex_stream\\nmachine_json_policy=file_or_explicit_machine_channel_only\\nreasoning_effort=high\\nmodel_reasoning_effort=high\\n'; exec /bin/sh -i",
         "reasoning_effort": "high",
         "lane_timeline": ["role_profile", "quota_guard", "frontier", "bootstrap"],
     },
@@ -87,6 +87,27 @@ packet = {
         "mutation_isolation_policy": "only mutating attempts require a claimed worktree or equivalent execution boundary",
     },
     "lanes": lanes,
+    "human_stream_contract": {
+        "schema_version": "multi_agent_visible_human_stream_contract_v0",
+        "human_pane": [
+            "role_profile_summary",
+            "quota_summary",
+            "frontier_or_blocked_summary",
+            "bootstrap_artifact_ref",
+            "codex_stream",
+            "compact_exit_summary",
+            "takeover_controls",
+        ],
+        "machine_artifacts": [
+            "quota.public.json",
+            "frontier.public.json",
+            "bootstrap-prompt.public.txt",
+            "role_local_public_artifacts",
+        ],
+        "machine_json_policy": "file_or_explicit_machine_channel_only",
+        "visible_json_policy": "markdown_or_compact_summary_only",
+        "codex_stream": "stdout_stderr_visible_below_bootstrap",
+    },
     "commands": {
         "start_script": ["python -c <generic visible multi-agent launcher command>"],
         "attach": f"tmux attach -t {session_name}",
@@ -101,7 +122,11 @@ packet = {
             "[bootstrap-or-stop]",
             "loopx_agent_handshake=role_profile_quota_frontier_bootstrap",
             "loopx_polling_prompt=visible_bootstrap_prompt",
+            "human_stream_contract=role_todo_progress_codex_stream",
+            "machine_json_policy=file_or_explicit_machine_channel_only",
         ],
+        "machine_json_file_bound": True,
+        "codex_stream_visible": True,
     },
     "boundary": {
         "starts_visible_processes": False,
@@ -208,6 +233,8 @@ def fake_tmux_script() -> str:
             "    print('frontier_or_blocked_reason=printed')",
             "    print('loopx_agent_handshake=role_profile_quota_frontier_bootstrap')",
             "    print('loopx_polling_prompt=visible_bootstrap_prompt')",
+            "    print('human_stream_contract=role_todo_progress_codex_stream')",
+            "    print('machine_json_policy=file_or_explicit_machine_channel_only')",
             "    print('reasoning_effort=high')",
             "    print('model_reasoning_effort=high')",
             "    raise SystemExit(0)",
@@ -254,6 +281,11 @@ def main() -> int:
         assert dry_packet["reasoning_contract"]["default_reasoning_effort"] == "high", dry_packet
         assert dry_packet["shared_goal_surface"]["shared_state_route"] == "LOOPX_REGISTRY_and_LOOPX_RUNTIME_ROOT", dry_packet
         assert dry_packet["shared_goal_surface"]["all_lane_workspace_isolation"] is False, dry_packet
+        assert dry_packet["human_stream_contract"]["schema_version"] == "multi_agent_visible_human_stream_contract_v0", dry_packet
+        assert dry_packet["human_stream_contract"]["machine_json_policy"] == "file_or_explicit_machine_channel_only", dry_packet
+        assert dry_packet["human_stream_contract"]["codex_stream"] == "stdout_stderr_visible_below_bootstrap", dry_packet
+        assert dry_packet["acceptance"]["machine_json_file_bound"] is True, dry_packet
+        assert dry_packet["acceptance"]["codex_stream_visible"] is True, dry_packet
         assert dry_packet["boundary"]["starts_visible_processes"] is False, dry_packet
         assert dry_packet["boundary"]["spends_loopx_quota"] is False, dry_packet
         assert all(lane["reasoning_effort"] == "high" for lane in dry_packet["lanes"]), dry_packet

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -18,6 +18,7 @@ sys.path.insert(0, str(ROOT))
 
 from loopx.visible_multi_agent_launcher import (  # noqa: E402
     _SCOPED_LOOPX_WRAPPER_PY,
+    build_visible_multi_agent_payload,
     execute_visible_multi_agent_launcher,
 )
 
@@ -91,6 +92,37 @@ def main() -> int:
     assert "LOOPX_ALLOW_TTY_JSON" in launcher_source
     assert "stat.S_ISREG" in launcher_source
     assert "LOOPX_MACHINE_JSON=1 explicitly" in launcher_source
+    assert "human_stream_contract=role_todo_progress_codex_stream" in launcher_source
+    assert "machine_json_policy=file_or_explicit_machine_channel_only" in launcher_source
+
+    dry_packet = build_visible_multi_agent_payload(
+        goal_id="loopx-meta",
+        session_name="loopx-visible-launcher-contract-smoke",
+        lanes=[
+            {
+                "lane_id": "planner",
+                "frontier": "true",
+                "visible_launch_command": "true",
+            }
+        ],
+    )
+    assert dry_packet["commands"]["attach"] == "tmux attach -t loopx-visible-launcher-contract-smoke"
+    assert dry_packet["commands"]["stop"] == "tmux kill-session -t loopx-visible-launcher-contract-smoke"
+    assert "retry" in dry_packet["commands"], dry_packet
+    assert (
+        dry_packet["human_stream_contract"]["schema_version"]
+        == "multi_agent_visible_human_stream_contract_v0"
+    ), dry_packet
+    assert dry_packet["human_stream_contract"]["machine_json_policy"] == (
+        "file_or_explicit_machine_channel_only"
+    ), dry_packet
+    assert dry_packet["human_stream_contract"]["codex_stream"] == (
+        "stdout_stderr_visible_below_bootstrap"
+    ), dry_packet
+    assert dry_packet["acceptance"]["machine_json_file_bound"] is True, dry_packet
+    assert dry_packet["acceptance"]["codex_stream_visible"] is True, dry_packet
+    assert dry_packet["boundary"]["hidden_prompt_injection"] is False, dry_packet
+    assert dry_packet["boundary"]["spends_loopx_quota"] is False, dry_packet
 
     with tempfile.TemporaryDirectory() as temp_dir:
         temp = Path(temp_dir)
@@ -142,6 +174,8 @@ def main() -> int:
                     "    print('[bootstrap-or-stop]')",
                     "    print('loopx_agent_handshake=role_profile_quota_frontier_bootstrap')",
                     "    print('loopx_cli_scope=scoped_loopx_wrapper')",
+                    "    print('human_stream_contract=role_todo_progress_codex_stream')",
+                    "    print('machine_json_policy=file_or_explicit_machine_channel_only')",
                     "    raise SystemExit(0)",
                     "raise SystemExit(0)",
                     "",

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -292,6 +292,9 @@ def build_visible_lane_command(
         'printf "loopx_agent_handshake=role_profile_quota_frontier_bootstrap\\n"; '
         'printf "loopx_polling_prompt=visible_bootstrap_prompt\\n"; '
         'printf "loopx_cli_scope=scoped_loopx_wrapper\\n"; '
+        'printf "human_stream_contract=role_todo_progress_codex_stream\\n"; '
+        'printf "machine_json_policy=file_or_explicit_machine_channel_only\\n"; '
+        'printf "machine_artifacts=quota_frontier_bootstrap_public_files\\n"; '
         'printf "takeover_controls=visible\\n"; '
         f"printf 'reasoning_effort=%s\\n' {_q(reasoning_effort)}"
     )
@@ -421,6 +424,10 @@ def build_visible_multi_agent_payload(
     session = str(session_name or "loopx-visible-agents")
     attach_command = f"{_q(tmux_bin)} attach -t {_q(session)}"
     stop_command = f"{_q(tmux_bin)} kill-session -t {_q(session)}"
+    retry_command = (
+        "rerun the same visible launcher packet after refreshing quota, "
+        "frontier, and bootstrap"
+    )
     first_frontier = str(frontier_command or lane_list[0].get("frontier") or "")
     frontier_launcher = build_visible_frontier_command(first_frontier)
     start_script = [
@@ -456,10 +463,68 @@ def build_visible_multi_agent_payload(
         "goal_id": str(goal_id),
         "session_name": session,
         "lanes": lane_list,
+        "human_stream_contract": {
+            "schema_version": "multi_agent_visible_human_stream_contract_v0",
+            "human_pane": [
+                "role_profile_summary",
+                "quota_summary",
+                "frontier_or_blocked_summary",
+                "bootstrap_artifact_ref",
+                "codex_stream",
+                "compact_exit_summary",
+                "takeover_controls",
+            ],
+            "machine_artifacts": [
+                "quota.public.json",
+                "frontier.public.json",
+                "bootstrap-prompt.public.txt",
+                "role_local_public_artifacts",
+            ],
+            "machine_json_policy": "file_or_explicit_machine_channel_only",
+            "visible_json_policy": "markdown_or_compact_summary_only",
+            "codex_stream": "stdout_stderr_visible_below_bootstrap",
+            "forbidden_visible_content": [
+                "raw_quota_json",
+                "raw_frontier_json",
+                "raw_role_profile_json",
+                "credentials",
+                "raw_private_logs",
+                "absolute_local_artifact_paths",
+            ],
+        },
         "commands": {
             "start_script": start_script,
             "attach": attach_command,
             "stop": stop_command,
+            "retry": retry_command,
+        },
+        "acceptance": {
+            "schema_version": "multi_agent_visible_launcher_acceptance_contract_v0",
+            "required_markers": [
+                "role_profile=printed",
+                "quota_guard=printed",
+                "frontier_or_blocked_reason=printed",
+                "bootstrap_or_stop=printed",
+                "loopx_agent_handshake=role_profile_quota_frontier_bootstrap",
+                "human_stream_contract=role_todo_progress_codex_stream",
+                "machine_json_policy=file_or_explicit_machine_channel_only",
+            ],
+            "human_stream_contract": "multi_agent_visible_human_stream_contract_v0",
+            "machine_json_file_bound": True,
+            "codex_stream_visible": True,
+        },
+        "boundary": {
+            "starts_visible_processes": False,
+            "runs_agent_processes": False,
+            "writes_loopx_state": False,
+            "spends_loopx_quota": False,
+            "reads_raw_transcripts": False,
+            "reads_session_files": False,
+            "reads_credentials": False,
+            "hidden_prompt_injection": False,
+            "shared_goal_surface": True,
+            "all_lane_workspace_isolation": False,
+            "public_safe_redaction": True,
         },
     }
 
@@ -800,6 +865,8 @@ def _tmux_acceptance(
                 and any(marker in capture for marker in frontier_markers)
                 and ("[bootstrap-or-stop]" in capture or "bootstrap_or_stop=printed" in capture)
                 and "loopx_agent_handshake=role_profile_quota_frontier_bootstrap" in capture
+                and "human_stream_contract=role_todo_progress_codex_stream" in capture
+                and "machine_json_policy=file_or_explicit_machine_channel_only" in capture
                 and not blocked_before_bootstrap
             )
             pane_checks.append(


### PR DESCRIPTION
## Summary
- add a generic human/machine stream contract to the visible multi-agent launcher packet
- require visible panes to show concise human markers while keeping raw machine JSON in artifacts or explicit machine channels
- document the contract and extend generic/visible launcher smokes

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 examples/visible-multi-agent-launcher-smoke.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/generic-multi-agent-one-command-smoke.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- loopx check --scan-path loopx/visible_multi_agent_launcher.py --scan-path examples/visible-multi-agent-launcher-smoke.py --scan-path examples/generic-multi-agent-one-command-smoke.py --scan-path docs/reference/protocols/multi-agent-visible-launcher-v0.md

LoopX check passed with the existing duplicate-index warning only; public boundary scan was clean for the four candidate files.