### PR TITLE
Polish auto-research visible first screen

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -281,6 +281,17 @@ def main() -> int:
                 acceptance = launch["visible_acceptance"]
                 assert acceptance["accepted"] is True, visible_payload
                 assert all(not item["blocked_before_bootstrap"] for item in acceptance["pane_checks"]), acceptance
+                frontier_capture = subprocess.run(
+                    ["tmux", "capture-pane", "-pt", f"{session_name}:frontier", "-S", "-300"],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                ).stdout
+                assert "[LoopX frontier]" in frontier_capture, frontier_capture
+                assert "artifact=frontier.public.json" in frontier_capture, frontier_capture
+                assert '"schema_version"' not in frontier_capture, frontier_capture
+                assert "/" + "private/" not in frontier_capture, frontier_capture
+                assert "/" + "tmp/" not in frontier_capture, frontier_capture
                 skill_items = launch["worker_skill_materialization"]
                 assert skill_items, visible_payload
                 assert {item["source_resolution"] for item in skill_items} == {"package_root"}, skill_items
@@ -298,6 +309,9 @@ def main() -> int:
                     assert "quota_wait_timeout" not in capture, (lane, capture)
                     assert "frontier_wait_timeout" not in capture, (lane, capture)
                     assert '"schema_version"' not in capture, (lane, capture)
+                    assert "LOOPX_ROLE_PROFILE_JSON" not in capture, (lane, capture)
+                    assert "/" + "private/" not in capture, (lane, capture)
+                    assert "/" + "tmp/" not in capture, (lane, capture)
                     assert "role_profile_path=" not in capture, (lane, capture)
                     assert "[Codex bootstrap prompt]" not in capture, (lane, capture)
                     assert "codex_output=streaming_below" in capture, (lane, capture)

--- a/examples/auto-research-demo-supervisor-smoke.py
+++ b/examples/auto-research-demo-supervisor-smoke.py
@@ -119,7 +119,8 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
         assert "LOOPX_VISIBLE_BOOTSTRAP_PAUSE_SECONDS" in lane["visible_launch_command"], lane
         assert "LOOPX_ROLE_PROFILE_JSON" in lane["visible_launch_command"], lane
         assert "LOOPX_ROLE_PROFILE_PATH" in lane["visible_launch_command"], lane
-        assert "role_profile_path=%s" in lane["visible_launch_command"], lane
+        assert "role_profile_artifact=%s.public.json" in lane["visible_launch_command"], lane
+        assert "role_profile_path=%s" not in lane["visible_launch_command"], lane
         assert "LOOPX_REQUIRED_SKILL" in lane["visible_launch_command"], lane
         assert "bootstrap-or-stop" in lane["visible_launch_command"], lane
         assert lane["visible_codex_tui"] == "codex", lane
@@ -147,7 +148,9 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
     assert "tmux new-session" in start_script, start_script
     assert "tmux new-window" in start_script, start_script
     assert "LOOPX_PROJECT" in start_script, start_script
-    assert "[Codex bootstrap prompt]" in start_script, start_script
+    assert "[Codex bootstrap]" in start_script, start_script
+    assert "bootstrap_prompt_artifact" in start_script, start_script
+    assert "[Codex bootstrap prompt]" not in start_script, start_script
     assert "You are a visible LoopX auto-research lane" in start_script, start_script
     assert "codex-cli-bootstrap-message" not in start_script, start_script
     assert "auto-research frontier" in start_script, start_script
@@ -161,25 +164,34 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
     assert "dry-run rehearsal only" in rehearsal, rehearsal
     assert "does not start tmux" in rehearsal, rehearsal
     assert "LOOPX_PROJECT" in rehearsal, rehearsal
-    assert "start script - inspect before pasting" in rehearsal, rehearsal
-    assert "tmux new-session" in rehearsal, rehearsal
+    assert "launch posture" in rehearsal, rehearsal
+    assert "demo-e2e --execute" in rehearsal, rehearsal
+    assert "machine JSON/artifacts" in rehearsal, rehearsal
+    assert "start script - inspect before pasting" not in rehearsal, rehearsal
+    assert "tmux new-session" not in rehearsal, rehearsal
+    assert "LOOPX_ROLE_PROFILE_JSON" not in rehearsal, rehearsal
     assert "tmux attach -t loopx-auto-research" in rehearsal, rehearsal
     assert "tmux kill-session -t loopx-auto-research" in rehearsal, rehearsal
+    assert "prints the real one-command launch posture" in " ".join(
+        one_click["expected_visible_result"]
+    ), one_click
     assert "start tmux" in one_click["does_not"], one_click
     assert "launch Codex" in one_click["does_not"], one_click
 
     acceptance = payload["demo_acceptance"]
     assert acceptance["schema_version"] == "auto_research_demo_acceptance_v0", payload
+    assert "commands.start_script" not in acceptance["required_visible_fields"], acceptance
     assert "lanes[].role_profile" in acceptance["required_visible_fields"], acceptance
     assert "lanes[].lane_timeline" in acceptance["required_visible_fields"], acceptance
     assert any("role_profile_v0" in item for item in acceptance["operator_can_accept_when"]), acceptance
-    assert any("without executing it" in item for item in acceptance["operator_can_accept_when"]), acceptance
+    assert any("launch posture" in item for item in acceptance["operator_can_accept_when"]), acceptance
     assert any("role_profile_v0" in item for item in acceptance["operator_must_reject_when"]), acceptance
     assert any("hides attach/stop" in item for item in acceptance["operator_must_reject_when"]), acceptance
 
     takeover = payload["user_takeover"]
     assert takeover["schema_version"] == "auto_research_user_takeover_v0", payload
     assert any("rehearsal script first" in item for item in takeover["operator_controls"]), takeover
+    assert any("start_script is machine-bound" in item for item in takeover["operator_controls"]), takeover
     assert any("attach to tmux" in item for item in takeover["operator_controls"]), takeover
     assert any("role_profile_v0" in item for item in takeover["visible_status_cues"]), takeover
     assert any("quota guard" in item for item in takeover["visible_status_cues"]), takeover
@@ -312,6 +324,10 @@ def main() -> int:
     assert "## Demo Acceptance" in markdown, markdown
     assert "accept when:" in markdown, markdown
     assert "tmux attach -t loopx-auto-research" in markdown, markdown
+    assert "start_script: `machine_json_only`" in markdown, markdown
+    assert "loopx auto-research demo-e2e --execute" in markdown, markdown
+    assert "tmux new-session" not in markdown, markdown
+    assert "LOOPX_ROLE_PROFILE_JSON" not in markdown, markdown
 
     print("auto-research-demo-supervisor-smoke ok")
     return 0

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -94,6 +94,9 @@ def main() -> int:
     assert "LOOPX_MACHINE_JSON=1 explicitly" in launcher_source
     assert "human_stream_contract=role_todo_progress_codex_stream" in launcher_source
     assert "machine_json_policy=file_or_explicit_machine_channel_only" in launcher_source
+    assert 'FRONTIER_ARTIFACT_NAME="frontier.public.json"' in launcher_source
+    assert 'artifact=%s\\\\n" "$FRONTIER_STATUS" "$FRONTIER_ARTIFACT_NAME"' in launcher_source
+    assert 'artifact=%s\\\\n" "$FRONTIER_STATUS" "$FRONTIER_ARTIFACT"' not in launcher_source
 
     dry_packet = build_visible_multi_agent_payload(
         goal_id="loopx-meta",

--- a/loopx/capabilities/auto_research/legacy_core.py
+++ b/loopx/capabilities/auto_research/legacy_core.py
@@ -1118,10 +1118,9 @@ def _env_lane_launch_command(
     )
 
 
-def _demo_rehearsal_script(*, session: str, start_script: list[str], attach_command: str, stop_command: str) -> list[str]:
-    """Return a copy-paste dry-run script that prints the real launch plan only."""
+def _demo_rehearsal_script(*, session: str, attach_command: str, stop_command: str) -> list[str]:
+    """Return a copy-paste dry-run script that keeps machine launch shell hidden."""
 
-    quoted_start_lines = " ".join(_shell_arg(line) for line in start_script)
     return [
         "set -euo pipefail",
         "echo 'LoopX auto-research demo supervisor: dry-run rehearsal only'",
@@ -1131,8 +1130,9 @@ def _demo_rehearsal_script(*, session: str, start_script: list[str], attach_comm
         ": ${LOOPX_RUNTIME_ROOT:?set LOOPX_RUNTIME_ROOT to the LoopX runtime root before rehearsal}",
         "printf '\\n[visible session]\\n'",
         f"printf '%s\\n' {_shell_arg(session)}",
-        "printf '\\n[start script - inspect before pasting]\\n'",
-        f"printf '%s\\n' {quoted_start_lines}",
+        "printf '\\n[launch posture]\\n'",
+        "printf '%s\\n' 'Real launch uses: loopx auto-research demo-e2e --execute'",
+        "printf '%s\\n' 'Internal tmux bootstrap shell stays in machine JSON/artifacts, not the first screen.'",
         "printf '\\n[attach after start]\\n'",
         f"printf '%s\\n' {_shell_arg(attach_command)}",
         "printf '\\n[stop / user takeover abort]\\n'",
@@ -1272,7 +1272,6 @@ def build_auto_research_demo_supervisor_plan(
     stop_command = str(commands["stop"])
     rehearsal_script = _demo_rehearsal_script(
         session=session,
-        start_script=start_script,
         attach_command=attach_command,
         stop_command=stop_command,
     )
@@ -1337,7 +1336,7 @@ def build_auto_research_demo_supervisor_plan(
             "script": rehearsal_script,
             "expected_visible_result": [
                 "prints the tmux session name",
-                "prints every command that would be pasted into a visible pane",
+                "prints the real one-command launch posture without dumping internal shell",
                 "prints attach and stop commands for user takeover",
             ],
             "does_not": [
@@ -1352,7 +1351,6 @@ def build_auto_research_demo_supervisor_plan(
             "schema_version": "auto_research_demo_acceptance_v0",
             "required_visible_fields": [
                 "commands.one_click_dry_run_rehearsal",
-                "commands.start_script",
                 "commands.attach",
                 "commands.stop",
                 "lanes[].role_id",
@@ -1366,7 +1364,7 @@ def build_auto_research_demo_supervisor_plan(
                 "boundary",
             ],
             "operator_can_accept_when": [
-                "the rehearsal script prints the real start script without executing it",
+                "the rehearsal script prints launch posture without exposing internal tmux bootstrap shell",
                 "every lane prints role_profile_v0 before quota, frontier, bootstrap, or Codex startup",
                 "every lane has a quota guard before frontier/bootstrap/Codex startup",
                 "the attach command is visible before any Codex prompt is accepted",
@@ -1385,8 +1383,8 @@ def build_auto_research_demo_supervisor_plan(
         "user_takeover": {
             "schema_version": "auto_research_user_takeover_v0",
             "operator_controls": [
-                "run the rehearsal script first and inspect the printed start script",
-                "paste start_script manually only after deciding to launch the visible demo",
+                "run the rehearsal script first to confirm attach/stop controls",
+                "use demo-e2e --execute for real launch; internal start_script is machine-bound",
                 "attach to tmux before accepting any Codex prompt",
                 "use the stop command to kill the whole demo session",
                 "interrupt an individual pane with the normal terminal interrupt before any write path",
@@ -1642,13 +1640,14 @@ def build_auto_research_demo_acceptance_packet(
             ),
             "default_safe": bool(one_click.get("default_safe")),
             "rehearsal_script_visible": bool(rehearsal_script),
-            "start_script_visible": bool(start_script),
+            "start_script_visible": False,
+            "start_script_machine_bound": bool(start_script),
             "attach": attach,
             "stop": stop,
         },
         "lane_checks": lane_checks,
         "operator_checklist": [
-            "Run the dry-run rehearsal first and inspect the printed start script.",
+            "Run the dry-run rehearsal first and inspect attach/stop controls.",
             "Confirm every lane prints role_profile_v0 with agent_id, role_id, phase, allowed writes, required skill, stop conditions, and takeover controls.",
             "Confirm every lane prints quota should-run before frontier, bootstrap, or Codex.",
             "Confirm attach and stop commands are visible before accepting any Codex prompt.",
@@ -1680,7 +1679,7 @@ def build_auto_research_demo_acceptance_packet(
         },
         "upgrade_path": [
             "Keep this packet as the required preflight before any real tmux/Codex launch.",
-            "Only after user approval, paste the printed start_script in a visible shell.",
+            "Use demo-e2e --execute for real tmux/Codex launch; keep internal start_script machine-bound.",
             "Attach to the tmux session before accepting any Codex prompt.",
             "Use normal LoopX todo/evidence writeback; the supervisor never writes state directly.",
         ],
@@ -3867,8 +3866,8 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
             if acceptance:
                 lines.append(f"- visible_acceptance: `{acceptance.get('accepted')}`")
         lines.extend(["", "## Shell Plan", ""])
-        for line in commands.get("start_script") or []:
-            lines.append(f"- `{line}`")
+        lines.append("- start_script: `machine_json_only`")
+        lines.append("- launch: `loopx auto-research demo-e2e --execute`")
         lines.extend(
             [
                 "",

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -225,9 +225,10 @@ def build_visible_frontier_command(
         f"printf '\\n%s\\n' {_q(frontier_label)}; "
         f"FRONTIER_PACKET=\"$(LOOPX_MACHINE_JSON=1; export LOOPX_MACHINE_JSON; {frontier_command} 2>&1)\"; "
         "FRONTIER_STATUS=$?; "
-        'FRONTIER_ARTIFACT="$LOOPX_VISIBLE_ARTIFACT_DIR/frontier.public.json"; '
+        'FRONTIER_ARTIFACT_NAME="frontier.public.json"; '
+        'FRONTIER_ARTIFACT="$LOOPX_VISIBLE_ARTIFACT_DIR/$FRONTIER_ARTIFACT_NAME"; '
         f"printf '%s\\n' \"$FRONTIER_PACKET\" | python3 -c {_q(_HUMAN_VIEW_PACKET_PY)} frontier \"$FRONTIER_ARTIFACT\" || true; "
-        'printf "\\n[frontier window ready]\\nexit=%s\\nartifact=%s\\n" "$FRONTIER_STATUS" "$FRONTIER_ARTIFACT"; '
+        'printf "\\n[frontier window ready]\\nexit=%s\\nartifact=%s\\n" "$FRONTIER_STATUS" "$FRONTIER_ARTIFACT_NAME"; '
         "exec /bin/sh -i"
     )
 


### PR DESCRIPTION
## Summary
- keep the visible frontier pane on compact artifact names instead of local absolute paths
- keep auto-research rehearsal/markdown first screens from dumping internal tmux shell
- add smoke coverage for frontier/lane panes staying JSON-free and path-free while Codex output remains visible

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 examples/visible-multi-agent-launcher-smoke.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-demo-supervisor-smoke.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- git diff --check
- loopx check --scan-path loopx/visible_multi_agent_launcher.py --scan-path loopx/capabilities/auto_research/legacy_core.py --scan-path examples/visible-multi-agent-launcher-smoke.py --scan-path examples/auto-research-demo-supervisor-smoke.py --scan-path examples/auto-research-demo-e2e-worker-loop-smoke.py