### PR TITLE
Filter visible Codex stream noise

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -315,6 +315,7 @@ def main() -> int:
                     assert "role_profile_path=" not in capture, (lane, capture)
                     assert "[Codex bootstrap prompt]" not in capture, (lane, capture)
                     assert "codex_output=streaming_below" in capture, (lane, capture)
+                    assert "codex_stream_filter=public_safe" in capture, (lane, capture)
                     assert f"goal={visible_payload['goal_id']}" in capture, (lane, capture)
                 assert_public_safe(visible_payload)
             finally:

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -18,6 +18,7 @@ sys.path.insert(0, str(ROOT))
 
 from loopx.visible_multi_agent_launcher import (  # noqa: E402
     _SCOPED_LOOPX_WRAPPER_PY,
+    _VISIBLE_CODEX_STREAM_FILTER_PY,
     build_visible_multi_agent_payload,
     execute_visible_multi_agent_launcher,
 )
@@ -97,6 +98,37 @@ def main() -> int:
     assert 'FRONTIER_ARTIFACT_NAME="frontier.public.json"' in launcher_source
     assert 'artifact=%s\\\\n" "$FRONTIER_STATUS" "$FRONTIER_ARTIFACT_NAME"' in launcher_source
     assert 'artifact=%s\\\\n" "$FRONTIER_STATUS" "$FRONTIER_ARTIFACT"' not in launcher_source
+    assert "_VISIBLE_CODEX_STREAM_FILTER_PY" in launcher_source
+    assert "worker-local skill block hidden" in launcher_source
+    assert " WARN codex_core_" in launcher_source
+
+    slash = "/"
+    private_tmp = slash + "private" + slash + "tmp"
+    var_folders = slash + "var" + slash + "folders"
+    filtered = subprocess.run(
+        [sys.executable, "-u", "-c", _VISIBLE_CODEX_STREAM_FILTER_PY],
+        input=(
+            "OpenAI Codex v0\n"
+            "user\n"
+            "hidden bootstrap prompt\n"
+            "codex\n"
+            "codex says hello\n"
+            "2026-01-01T00:00:00Z  WARN codex_core_plugins::manifest: noisy\n"
+            f"exec in {private_tmp}/loopx-demo/path\n"
+            "BEGIN_SKILL\nhidden skill body\nEND_SKILL\n"
+            f"result saved under {var_folders}/demo/file\n"
+        ),
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout
+    assert "codex says hello" in filtered, filtered
+    assert "hidden bootstrap prompt" not in filtered, filtered
+    assert "WARN codex_core" not in filtered, filtered
+    assert "hidden skill body" not in filtered, filtered
+    assert private_tmp not in filtered, filtered
+    assert var_folders not in filtered, filtered
+    assert "<local-path>" in filtered, filtered
 
     dry_packet = build_visible_multi_agent_payload(
         goal_id="loopx-meta",
@@ -120,10 +152,11 @@ def main() -> int:
         "file_or_explicit_machine_channel_only"
     ), dry_packet
     assert dry_packet["human_stream_contract"]["codex_stream"] == (
-        "stdout_stderr_visible_below_bootstrap"
+        "public_filtered_stdout_stderr_visible_below_bootstrap"
     ), dry_packet
     assert dry_packet["acceptance"]["machine_json_file_bound"] is True, dry_packet
     assert dry_packet["acceptance"]["codex_stream_visible"] is True, dry_packet
+    assert dry_packet["acceptance"]["codex_stream_public_filter"] is True, dry_packet
     assert dry_packet["boundary"]["hidden_prompt_injection"] is False, dry_packet
     assert dry_packet["boundary"]["spends_loopx_quota"] is False, dry_packet
 

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -176,6 +176,49 @@ human_target.write_text(
 human_target.chmod(0o700)
 """
 
+_VISIBLE_CODEX_STREAM_FILTER_PY = r"""
+import re
+import sys
+
+
+def redact_local_paths(text):
+    slash = chr(47)
+    prefixes = [
+        slash + "private" + slash + "var" + slash + "folders",
+        slash + "var" + slash + "folders",
+        slash + "private" + slash + "tmp",
+        slash + "tmp",
+    ]
+    for prefix in prefixes:
+        text = re.sub(re.escape(prefix) + r"[^ \n\r\t'\"`]+", "<local-path>", text)
+    return text
+
+
+skip_skill_block = False
+waiting_for_first_codex = True
+for raw in sys.stdin:
+    line = raw.rstrip("\n")
+    if waiting_for_first_codex:
+        if line == "codex":
+            waiting_for_first_codex = False
+            print("[Codex]", flush=True)
+        continue
+    if "BEGIN_SKILL" in line:
+        skip_skill_block = True
+        print("[Codex stream note] worker-local skill block hidden; Codex output continues below.", flush=True)
+        continue
+    if "END_SKILL" in line:
+        skip_skill_block = False
+        continue
+    if skip_skill_block:
+        continue
+    if " WARN codex_core_" in line:
+        continue
+    if line.startswith("warning: Skill descriptions were shortened"):
+        continue
+    print(redact_local_paths(line), flush=True)
+"""
+
 
 def _q(value: object) -> str:
     return shlex.quote(str(value))
@@ -393,6 +436,7 @@ def build_visible_lane_command(
         'if [ -n "${LOOPX_AGENT_ID:-}" ]; then printf "agent=%s\\n" "$LOOPX_AGENT_ID"; fi; '
         'if [ -n "${LOOPX_LANE_ID:-}" ]; then printf "lane=%s\\n" "$LOOPX_LANE_ID"; fi; '
         "printf 'codex_output=streaming_below\\n'; "
+        "printf 'codex_stream_filter=public_safe\\n'; "
         "if [ \"$BOOTSTRAP_STATUS\" -ne 0 ]; then "
         "printf '\\n[LoopX blocked reason]\\n'; "
         "printf 'bootstrap_command_failed exit=%s\\n' \"$BOOTSTRAP_STATUS\"; "
@@ -403,7 +447,8 @@ def build_visible_lane_command(
         'sleep "${LOOPX_VISIBLE_BOOTSTRAP_PAUSE_SECONDS:-1}"; '
         "printf '\\n[Starting visible Codex exec]\\n'; "
         f"{_q(codex_bin)} exec -c model_reasoning_effort={_q(reasoning_effort)} "
-        '--cd "$LOOPX_PROJECT" --skip-git-repo-check --sandbox danger-full-access "$BOOTSTRAP_PROMPT"; '
+        '--cd "$LOOPX_PROJECT" --skip-git-repo-check --sandbox danger-full-access "$BOOTSTRAP_PROMPT" '
+        f"2>&1 | python3 -u -c {_q(_VISIBLE_CODEX_STREAM_FILTER_PY)}; "
         "CODEX_STATUS=$?; "
         "printf '\\n[Codex CLI exited]\\nexit=%s\\n' \"$CODEX_STATUS\"; "
         f"{keep_visible}"
@@ -483,7 +528,7 @@ def build_visible_multi_agent_payload(
             ],
             "machine_json_policy": "file_or_explicit_machine_channel_only",
             "visible_json_policy": "markdown_or_compact_summary_only",
-            "codex_stream": "stdout_stderr_visible_below_bootstrap",
+            "codex_stream": "public_filtered_stdout_stderr_visible_below_bootstrap",
             "forbidden_visible_content": [
                 "raw_quota_json",
                 "raw_frontier_json",
@@ -513,6 +558,7 @@ def build_visible_multi_agent_payload(
             "human_stream_contract": "multi_agent_visible_human_stream_contract_v0",
             "machine_json_file_bound": True,
             "codex_stream_visible": True,
+            "codex_stream_public_filter": True,
         },
         "boundary": {
             "starts_visible_processes": False,


### PR DESCRIPTION
## Summary
- add a public-safe stream filter for visible Codex lanes so panes start at the Codex reply instead of raw runtime preamble/user prompt
- redact local paths and hide Codex runtime WARN/worker skill blocks while keeping human-readable Codex replies and execution summaries visible
- mark the multi-agent launcher contract as public-filtered stream output

## Validation
- PYTHONDONTWRITEBYTECODE=1 python3 examples/visible-multi-agent-launcher-smoke.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-demo-supervisor-smoke.py
- git diff --check
- loopx check --scan-path loopx/visible_multi_agent_launcher.py --scan-path examples/visible-multi-agent-launcher-smoke.py --scan-path examples/auto-research-demo-e2e-worker-loop-smoke.py