### PR TITLE
Mirror SkillsBench Druid archive downloads

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -70,6 +70,7 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
     DEFAULT_MAX_ROUNDS,
     DEFAULT_PRODUCT_MODE_SOFT_VERIFY_POLICY,
     DEFAULT_SOFT_VERIFIER_TIMEOUT_SEC,
+    DEFAULT_DOCKER_APACHE_ARCHIVE_MIRROR_HOST,
     DEFAULT_DOCKER_PIP_INDEX_HOST,
     DEFAULT_VERIFIER_UV_RELEASE_MIRROR_HOST,
     DECLARED_DONE_MARKER,
@@ -5952,7 +5953,9 @@ def test_skillsbench_docker_task_staging_hardens_build_downloads() -> None:
         dockerfile.parent.mkdir(parents=True)
         original_text = (
             "FROM ubuntu:24.04\n"
-            "RUN wget https://archive.example.invalid/project.tar.gz && \\\n"
+            "RUN wget "
+            "https://archive.apache.org/dist/druid/0.20.0/"
+            "apache-druid-0.20.0-bin.tar.gz && \\\n"
             "    git clone https://github.com/example/project.git && \\\n"
             "    mvn dependency:resolve -DskipTests\n"
         )
@@ -5973,6 +5976,19 @@ def test_skillsbench_docker_task_staging_hardens_build_downloads() -> None:
         assert metadata["dockerfile_network_download_retry_patch_applied"] is True, (
             metadata
         )
+        assert (
+            metadata["dockerfile_apache_archive_mirror_patch_required"] is True
+        ), metadata
+        assert metadata["dockerfile_apache_archive_mirror_patch_applied"] is True, (
+            metadata
+        )
+        assert (
+            metadata["dockerfile_apache_archive_mirror_host"]
+            == DEFAULT_DOCKER_APACHE_ARCHIVE_MIRROR_HOST
+        ), metadata
+        assert metadata["dockerfile_apache_archive_raw_url_recorded"] is False, (
+            metadata
+        )
         assert dockerfile.read_text(encoding="utf-8") == original_text
         staged_text = (staged_path / "environment" / "Dockerfile").read_text(
             encoding="utf-8"
@@ -5980,9 +5996,16 @@ def test_skillsbench_docker_task_staging_hardens_build_downloads() -> None:
         assert DOCKER_NETWORK_DOWNLOAD_RETRY_BEGIN in staged_text, staged_text
         assert "GIT_HTTP_LOW_SPEED_LIMIT=1000" in staged_text, staged_text
         assert "maven.wagon.http.retryHandler.count=5" in staged_text, staged_text
+        assert "https://archive.apache.org/dist/druid/" not in staged_text, staged_text
+        assert (
+            "https://mirrors.huaweicloud.com/apache/druid/0.20.0/"
+            "apache-druid-0.20.0-bin.tar.gz"
+        ) in staged_text, staged_text
         assert (
             "wget --tries=5 --timeout=120 --read-timeout=120 "
-            "--retry-connrefused https://archive.example.invalid/project.tar.gz"
+            "--retry-connrefused "
+            "https://mirrors.huaweicloud.com/apache/druid/0.20.0/"
+            "apache-druid-0.20.0-bin.tar.gz"
         ) in staged_text, staged_text
 
 
@@ -7203,6 +7226,12 @@ def test_skillsbench_task_staging_metadata_is_compacted() -> None:
             "verifier_uv_bootstrap_mirror_host": (
                 DEFAULT_VERIFIER_UV_RELEASE_MIRROR_HOST
             ),
+            "dockerfile_apache_archive_mirror_patch_required": True,
+            "dockerfile_apache_archive_mirror_patch_applied": True,
+            "dockerfile_apache_archive_mirror_host": (
+                DEFAULT_DOCKER_APACHE_ARCHIVE_MIRROR_HOST
+            ),
+            "dockerfile_apache_archive_raw_url_recorded": False,
             "task_skills_removed": False,
             "original_task_mutated": False,
             "resource_cap_patch": {
@@ -7234,6 +7263,12 @@ def test_skillsbench_task_staging_metadata_is_compacted() -> None:
             "verifier_uv_bootstrap_mirror_host": (
                 DEFAULT_VERIFIER_UV_RELEASE_MIRROR_HOST
             ),
+            "dockerfile_apache_archive_mirror_patch_required": True,
+            "dockerfile_apache_archive_mirror_patch_applied": True,
+            "dockerfile_apache_archive_mirror_host": (
+                DEFAULT_DOCKER_APACHE_ARCHIVE_MIRROR_HOST
+            ),
+            "dockerfile_apache_archive_raw_url_recorded": False,
             "task_skills_removed": False,
             "original_task_mutated": False,
             "resource_cap_patch": {
@@ -7261,6 +7296,9 @@ def test_skillsbench_task_staging_metadata_is_compacted() -> None:
         assert entry_staging["verifier_uv_bootstrap_mirror_patch_applied"] is True, (
             update
         )
+        assert (
+            entry_staging["dockerfile_apache_archive_mirror_patch_applied"] is True
+        ), update
         assert "staged_task_path" not in json.dumps(update, sort_keys=True), update
 
 
@@ -7296,7 +7334,9 @@ def test_skillsbench_reduce_only_recovers_prepared_task_staging_metadata() -> No
             "FROM ubuntu:20.04\n"
             f"{DOCKER_APT_RETRY_BEGIN}\n"
             "RUN true\n"
-            "# END LOOPX_SKILLSBENCH_APT_RETRY\n",
+            "# END LOOPX_SKILLSBENCH_APT_RETRY\n"
+            "RUN wget https://mirrors.huaweicloud.com/apache/druid/0.20.0/"
+            "apache-druid-0.20.0-bin.tar.gz\n",
             encoding="utf-8",
         )
         verifier.write_text(
@@ -7322,6 +7362,12 @@ def test_skillsbench_reduce_only_recovers_prepared_task_staging_metadata() -> No
         assert compact["task_staging"][
             "verifier_uv_bootstrap_version"
         ] == "0.9.7", compact
+        assert compact["task_staging"][
+            "dockerfile_apache_archive_mirror_patch_applied"
+        ] is True, compact
+        assert compact["task_staging"]["dockerfile_apache_archive_mirror_host"] == (
+            DEFAULT_DOCKER_APACHE_ARCHIVE_MIRROR_HOST
+        ), compact
         assert compact["task_staging"]["task_skills_removed"] is True, compact
         compact_text = json.dumps(compact, sort_keys=True)
         assert "prepared-tasks" not in compact_text, compact

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -151,6 +151,9 @@ def _compact_task_staging(value: Any) -> dict[str, Any]:
         "verifier_uv_bootstrap_mirror_patch_required",
         "verifier_uv_bootstrap_mirror_patch_applied",
         "verifier_bootstrap_risk_preflight_blocked",
+        "dockerfile_apache_archive_mirror_patch_required",
+        "dockerfile_apache_archive_mirror_patch_applied",
+        "dockerfile_apache_archive_raw_url_recorded",
         "codex_acp_runtime_tools_patch_applied",
         "task_skills_removed",
         "original_task_mutated",
@@ -162,6 +165,7 @@ def _compact_task_staging(value: Any) -> dict[str, Any]:
         "bootstrap_light_blocker_kind",
         "verifier_uv_bootstrap_version",
         "verifier_uv_bootstrap_mirror_host",
+        "dockerfile_apache_archive_mirror_host",
     ):
         text = _compact_text(value.get(field), limit=140)
         if text:

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -2457,6 +2457,9 @@ def _compact_benchmark_task_staging(value: Any) -> dict[str, Any]:
         "verifier_uv_bootstrap_risk_detected",
         "verifier_uv_bootstrap_mirror_patch_required",
         "verifier_uv_bootstrap_mirror_patch_applied",
+        "dockerfile_apache_archive_mirror_patch_required",
+        "dockerfile_apache_archive_mirror_patch_applied",
+        "dockerfile_apache_archive_raw_url_recorded",
         "verifier_bootstrap_risk_preflight_blocked",
         "verifier_bootstrap_fail_fast_defaulted",
         "app_skills_mount_patch_applied",
@@ -2471,6 +2474,7 @@ def _compact_benchmark_task_staging(value: Any) -> dict[str, Any]:
         "bootstrap_light_blocker_kind",
         "verifier_uv_bootstrap_version",
         "verifier_uv_bootstrap_mirror_host",
+        "dockerfile_apache_archive_mirror_host",
     ):
         text = public_safe_compact_text(value.get(field), limit=180)
         if text:

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -490,6 +490,8 @@ DOCKER_NETWORK_DOWNLOAD_RETRY_BEGIN = (
 DOCKER_NETWORK_DOWNLOAD_RETRY_END = (
     "# END LOOPX_SKILLSBENCH_NETWORK_DOWNLOAD_RETRY"
 )
+DEFAULT_DOCKER_APACHE_ARCHIVE_MIRROR_BASE = "https://mirrors.huaweicloud.com/apache"
+DEFAULT_DOCKER_APACHE_ARCHIVE_MIRROR_HOST = "mirrors.huaweicloud.com"
 VERIFIER_UV_BOOTSTRAP_MIRROR_BEGIN = (
     "# BEGIN LOOPX_SKILLSBENCH_VERIFIER_UV_BOOTSTRAP_MIRROR"
 )
@@ -5671,6 +5673,9 @@ def _public_task_staging(value: Any) -> dict[str, Any]:
         "dockerfile_wget_gpg_key_retry_patch_applied",
         "dockerfile_network_download_retry_patch_required",
         "dockerfile_network_download_retry_patch_applied",
+        "dockerfile_apache_archive_mirror_patch_required",
+        "dockerfile_apache_archive_mirror_patch_applied",
+        "dockerfile_apache_archive_raw_url_recorded",
         "dockerfile_package_bootstrap_risk_preflight_blocked",
         "app_skills_mount_patch_applied",
         "apt_retry_patch_applied",
@@ -5698,6 +5703,7 @@ def _public_task_staging(value: Any) -> dict[str, Any]:
         "bootstrap_light_blocker_kind",
         "verifier_uv_bootstrap_version",
         "verifier_uv_bootstrap_mirror_host",
+        "dockerfile_apache_archive_mirror_host",
     ):
         raw = value.get(field)
         if isinstance(raw, str) and raw:
@@ -5782,6 +5788,15 @@ def _discover_prepared_task_staging(plan: dict[str, Any]) -> dict[str, Any]:
         "dockerfile_network_download_retry_patch_applied": (
             DOCKER_NETWORK_DOWNLOAD_RETRY_BEGIN in dockerfile_text
         ),
+        "dockerfile_apache_archive_mirror_patch_applied": (
+            DEFAULT_DOCKER_APACHE_ARCHIVE_MIRROR_HOST in dockerfile_text
+        ),
+        "dockerfile_apache_archive_mirror_host": (
+            DEFAULT_DOCKER_APACHE_ARCHIVE_MIRROR_HOST
+            if DEFAULT_DOCKER_APACHE_ARCHIVE_MIRROR_HOST in dockerfile_text
+            else ""
+        ),
+        "dockerfile_apache_archive_raw_url_recorded": False,
         "codex_acp_runtime_tools_patch_applied": (
             DOCKER_CODEX_ACP_RUNTIME_TOOLS_BEGIN in dockerfile_text
         ),
@@ -6481,6 +6496,36 @@ def patch_dockerfile_wget_gpg_key_retry(dockerfile: Path) -> bool:
 
     patched, count = pattern.subn(replace, original)
     if count == 0 or patched == original:
+        return False
+    _write_text_atomic(dockerfile, patched)
+    return True
+
+
+def dockerfile_needs_apache_archive_mirror_rewrite(dockerfile: Path) -> bool:
+    if not dockerfile.exists():
+        return False
+    text = dockerfile.read_text(encoding="utf-8", errors="replace")
+    return (
+        "https://archive.apache.org/dist/druid/" in text
+        or "http://archive.apache.org/dist/druid/" in text
+    )
+
+
+def patch_dockerfile_apache_archive_mirror(dockerfile: Path) -> bool:
+    """Rewrite known slow Apache archive Druid downloads to a public mirror."""
+
+    if not dockerfile_needs_apache_archive_mirror_rewrite(dockerfile):
+        return False
+    original = dockerfile.read_text(encoding="utf-8", errors="replace")
+    mirror_base = DEFAULT_DOCKER_APACHE_ARCHIVE_MIRROR_BASE.rstrip("/")
+    patched = original.replace(
+        "https://archive.apache.org/dist/druid/",
+        f"{mirror_base}/druid/",
+    ).replace(
+        "http://archive.apache.org/dist/druid/",
+        f"{mirror_base}/druid/",
+    )
+    if patched == original:
         return False
     _write_text_atomic(dockerfile, patched)
     return True
@@ -7409,6 +7454,10 @@ def stage_task_for_sandbox(
         "dockerfile_wget_gpg_key_retry_patch_applied": False,
         "dockerfile_network_download_retry_patch_required": False,
         "dockerfile_network_download_retry_patch_applied": False,
+        "dockerfile_apache_archive_mirror_patch_required": False,
+        "dockerfile_apache_archive_mirror_patch_applied": False,
+        "dockerfile_apache_archive_mirror_host": "",
+        "dockerfile_apache_archive_raw_url_recorded": False,
         "codex_acp_runtime_tools_patch_applied": False,
         "empty_skills_build_context_required": False,
         "empty_skills_build_context_created": False,
@@ -7460,6 +7509,11 @@ def stage_task_for_sandbox(
     needs_network_download_retry_patch = dockerfile_needs_network_download_retry_patch(
         task_path / "environment" / "Dockerfile"
     )
+    needs_apache_archive_mirror_patch = (
+        dockerfile_needs_apache_archive_mirror_rewrite(
+            task_path / "environment" / "Dockerfile"
+        )
+    )
     verifier_risk = skillsbench_verifier_bootstrap_risk(task_path)
     needs_verifier_uv_mirror_patch = bool(
         verifier_risk.get("verifier_uv_bootstrap_risk_detected")
@@ -7492,6 +7546,13 @@ def stage_task_for_sandbox(
     metadata["dockerfile_network_download_retry_patch_required"] = (
         needs_network_download_retry_patch
     )
+    metadata["dockerfile_apache_archive_mirror_patch_required"] = (
+        needs_apache_archive_mirror_patch
+    )
+    if needs_apache_archive_mirror_patch:
+        metadata["dockerfile_apache_archive_mirror_host"] = (
+            DEFAULT_DOCKER_APACHE_ARCHIVE_MIRROR_HOST
+        )
     metadata["verifier_bootstrap_risk_detected"] = bool(
         verifier_risk.get("verifier_bootstrap_risk_detected")
     )
@@ -7527,6 +7588,7 @@ def stage_task_for_sandbox(
         and not needs_elan_toolchain_retry_patch
         and not needs_wget_gpg_key_retry_patch
         and not needs_network_download_retry_patch
+        and not needs_apache_archive_mirror_patch
         and not needs_runtime_tools_patch
         and not needs_verifier_uv_mirror_patch
         and not needs_verifier_proxy_env_patch
@@ -7585,6 +7647,9 @@ def stage_task_for_sandbox(
     wget_gpg_key_retry_patched = patch_dockerfile_wget_gpg_key_retry(
         staged_path / "environment" / "Dockerfile"
     )
+    apache_archive_mirror_patched = patch_dockerfile_apache_archive_mirror(
+        staged_path / "environment" / "Dockerfile"
+    )
     network_download_retry_patched = patch_dockerfile_network_download_retry(
         staged_path / "environment" / "Dockerfile"
     )
@@ -7623,6 +7688,15 @@ def stage_task_for_sandbox(
             "dockerfile_network_download_retry_patch_applied": (
                 network_download_retry_patched
             ),
+            "dockerfile_apache_archive_mirror_patch_applied": (
+                apache_archive_mirror_patched
+            ),
+            "dockerfile_apache_archive_mirror_host": (
+                DEFAULT_DOCKER_APACHE_ARCHIVE_MIRROR_HOST
+                if apache_archive_mirror_patched
+                else ""
+            ),
+            "dockerfile_apache_archive_raw_url_recorded": False,
             "codex_acp_runtime_tools_patch_applied": runtime_tools_patched,
             "empty_skills_build_context_required": empty_skills_context_required,
             "empty_skills_build_context_created": empty_skills_context_created,


### PR DESCRIPTION
## Summary
- rewrite staged SkillsBench Druid Apache archive downloads to a public Apache mirror before Docker build retry hardening
- keep public-safe task-staging metadata for the mirror rewrite across reducer, status, and run ledger surfaces
- extend SkillsBench smoke coverage for mirror rewrite, retry wrapping, and compact recovery

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py loopx/benchmark_ledger.py loopx/status.py examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- git diff --check
- private-boundary scan over changed files