### PR TITLE
Avoid Maven package conffile prompt in SkillsBench staging

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -73,6 +73,7 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
     DEFAULT_DOCKER_APACHE_ARCHIVE_MIRROR_HOST,
     DEFAULT_DOCKER_MAVEN_MIRROR_HOST,
     DEFAULT_DOCKER_MAVEN_MIRROR_URL,
+    DEFAULT_DOCKER_MAVEN_SETTINGS_PATH,
     DEFAULT_DOCKER_PIP_INDEX_HOST,
     DEFAULT_VERIFIER_UV_RELEASE_MIRROR_HOST,
     DECLARED_DONE_MARKER,
@@ -6016,9 +6017,11 @@ def test_skillsbench_docker_task_staging_hardens_build_downloads() -> None:
         ) in staged_text, staged_text
         assert "# BEGIN LOOPX_SKILLSBENCH_MAVEN_MIRROR" in staged_text, staged_text
         assert DEFAULT_DOCKER_MAVEN_MIRROR_URL in staged_text, staged_text
-        assert "mvn --settings /etc/maven/settings.xml dependency:resolve" in (
-            staged_text
-        ), staged_text
+        assert (
+            f"mvn --settings {DEFAULT_DOCKER_MAVEN_SETTINGS_PATH} "
+            "dependency:resolve"
+        ) in staged_text, staged_text
+        assert "/etc/maven/settings.xml" not in staged_text, staged_text
         assert (
             "wget --tries=5 --timeout=120 --read-timeout=120 "
             "--retry-connrefused "
@@ -7363,7 +7366,7 @@ def test_skillsbench_reduce_only_recovers_prepared_task_staging_metadata() -> No
             "RUN true\n"
             "# END LOOPX_SKILLSBENCH_APT_RETRY\n"
             f"{DOCKER_MAVEN_MIRROR_BEGIN}\n"
-            "RUN mkdir -p /etc/maven\n"
+            "RUN mkdir -p /opt/loopx-maven\n"
             f"{DOCKER_MAVEN_MIRROR_END}\n"
             "RUN wget https://mirrors.huaweicloud.com/apache/druid/0.20.0/"
             "apache-druid-0.20.0-bin.tar.gz\n",

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -496,6 +496,7 @@ DEFAULT_DOCKER_APACHE_ARCHIVE_MIRROR_BASE = "https://mirrors.huaweicloud.com/apa
 DEFAULT_DOCKER_APACHE_ARCHIVE_MIRROR_HOST = "mirrors.huaweicloud.com"
 DEFAULT_DOCKER_MAVEN_MIRROR_URL = "https://repo.huaweicloud.com/repository/maven"
 DEFAULT_DOCKER_MAVEN_MIRROR_HOST = "repo.huaweicloud.com"
+DEFAULT_DOCKER_MAVEN_SETTINGS_PATH = "/opt/loopx-maven/settings.xml"
 VERIFIER_UV_BOOTSTRAP_MIRROR_BEGIN = (
     "# BEGIN LOOPX_SKILLSBENCH_VERIFIER_UV_BOOTSTRAP_MIRROR"
 )
@@ -6581,7 +6582,8 @@ def patch_dockerfile_maven_mirror(dockerfile: Path) -> bool:
     )
     settings_block = (
         f"{DOCKER_MAVEN_MIRROR_BEGIN}\n"
-        "RUN mkdir -p /etc/maven && cat > /etc/maven/settings.xml "
+        "RUN mkdir -p /opt/loopx-maven && cat > "
+        f"{DEFAULT_DOCKER_MAVEN_SETTINGS_PATH} "
         "<<'LOOPX_MAVEN_SETTINGS_EOF'\n"
         "<settings xmlns=\"http://maven.apache.org/SETTINGS/1.0.0\" "
         "xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" "
@@ -6610,7 +6612,7 @@ def patch_dockerfile_maven_mirror(dockerfile: Path) -> bool:
         text = _insert_dockerfile_block_after_first_from(text, settings_block)
     text = re.sub(
         r"\bmvn(?!\s+(?:--settings|-s)\b)",
-        "mvn --settings /etc/maven/settings.xml",
+        f"mvn --settings {DEFAULT_DOCKER_MAVEN_SETTINGS_PATH}",
         text,
     )
     if text == original:


### PR DESCRIPTION
## Summary
- move staged Maven mirror settings to a non-package-managed path
- keep staged mvn invocations pointed at that settings file
- add smoke coverage that the Dockerfile no longer writes /etc/maven/settings.xml

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py
- focused SkillsBench task-staging smoke calls
- python3 examples/skillsbench-benchmark-run-smoke.py
- git diff --check
- private-boundary scan over changed files