### PR TITLE
Add SkillsBench current ledger aggregate

### DIFF
--- a/examples/skillsbench-current-ledger-aggregate-smoke.py
+++ b/examples/skillsbench-current-ledger-aggregate-smoke.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Smoke-test SkillsBench current ledger aggregation policy."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.benchmark_ledger import (  # noqa: E402
+    BENCHMARK_RUN_LEDGER_SCHEMA_VERSION,
+    build_benchmark_run_ledger_current_aggregate,
+    load_benchmark_run_ledger,
+    upsert_benchmark_run_ledger_entry,
+)
+
+
+BENCHMARK_ID = "skillsbench@1.1"
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def run_entry(
+    *,
+    run_id: str,
+    case_id: str,
+    recorded_at: str,
+    score: float | None,
+    score_status: str,
+    failure_class: str,
+    failure_scope: str,
+    labels: list[str] | None = None,
+) -> dict[str, Any]:
+    entry: dict[str, Any] = {
+        "run_id": run_id,
+        "recorded_at": recorded_at,
+        "benchmark_id": BENCHMARK_ID,
+        "case_id": case_id,
+        "case_ids": [case_id],
+        "run_group_id": run_id,
+        "arm_id": "codex_app_server_goal",
+        "status": "completed" if score is not None else "failed",
+        "score_status": score_status,
+        "failure_class": failure_class,
+        "failure_scope": failure_scope,
+        "failure_labels": labels or [],
+    }
+    if score is not None:
+        entry["official_score"] = score
+        entry["official_passed"] = score >= 1.0
+    return entry
+
+
+def make_ledger(path: Path) -> None:
+    ledger: dict[str, Any] = {
+        "schema_version": BENCHMARK_RUN_LEDGER_SCHEMA_VERSION,
+        "benchmarks": {},
+    }
+    # A later setup failure must not mask an earlier countable official zero.
+    for entry in (
+        run_entry(
+            run_id="latex-official-zero",
+            case_id="latex-formula-extraction",
+            recorded_at="2026-07-02T01:00:00+08:00",
+            score=0.0,
+            score_status="completed",
+            failure_class="task_solution_failure",
+            failure_scope="solution",
+            labels=["official_verifier_solution_failure"],
+        ),
+        run_entry(
+            run_id="latex-later-infra",
+            case_id="latex-formula-extraction",
+            recorded_at="2026-07-02T02:00:00+08:00",
+            score=None,
+            score_status="missing",
+            failure_class="skillsbench_docker_compose_build_stall_timeout",
+            failure_scope="runner_or_setup",
+            labels=["setup_runner_infra"],
+        ),
+        run_entry(
+            run_id="manufacturing-no-reward",
+            case_id="manufacturing-codebook-normalization",
+            recorded_at="2026-07-02T01:10:00+08:00",
+            score=None,
+            score_status="missing",
+            failure_class="verifier_no_reward",
+            failure_scope="runner_or_setup",
+            labels=["verifier_no_reward"],
+        ),
+        run_entry(
+            run_id="manufacturing-official-zero",
+            case_id="manufacturing-codebook-normalization",
+            recorded_at="2026-07-02T01:20:00+08:00",
+            score=0.0,
+            score_status="completed",
+            failure_class="task_solution_failure",
+            failure_scope="solution",
+            labels=["official_verifier_solution_failure"],
+        ),
+        run_entry(
+            run_id="partial-run",
+            case_id="lab-unit-harmonization",
+            recorded_at="2026-07-02T01:30:00+08:00",
+            score=0.5,
+            score_status="completed",
+            failure_class="task_solution_partial",
+            failure_scope="solution",
+        ),
+        run_entry(
+            run_id="setup-score-missing",
+            case_id="fix-druid-loophole-cve",
+            recorded_at="2026-07-02T01:40:00+08:00",
+            score=None,
+            score_status="missing",
+            failure_class="skillsbench_compose_setup_blocked_before_agent_rounds",
+            failure_scope="score_missing",
+        ),
+    ):
+        ledger = upsert_benchmark_run_ledger_entry(ledger, entry)
+    write_json(path, ledger)
+
+
+def test_current_aggregate_prefers_countable_results() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-current-aggregate-") as tmp:
+        root = Path(tmp)
+        ledger_path = root / "benchmark-run-ledger.json"
+        make_ledger(ledger_path)
+        ledger = load_benchmark_run_ledger(ledger_path)
+        aggregate = build_benchmark_run_ledger_current_aggregate(
+            ledger,
+            benchmark_id=BENCHMARK_ID,
+            canonical_case_ids=[
+                "latex-formula-extraction",
+                "manufacturing-codebook-normalization",
+                "lab-unit-harmonization",
+                "fix-druid-loophole-cve",
+                "never-run-case",
+            ],
+        )
+        assert aggregate["canonical_covered"] == 4, aggregate
+        assert aggregate["distribution"] == {
+            "missing": 1,
+            "official_zero": 2,
+            "partial": 1,
+            "pass": 0,
+            "setup_runner_infra": 1,
+            "verifier_no_reward": 0,
+        }, aggregate
+        assert (
+            aggregate["case_best"]["latex-formula-extraction"]["run_id"]
+            == "latex-official-zero"
+        ), aggregate["case_best"]["latex-formula-extraction"]
+        assert (
+            aggregate["case_best"]["manufacturing-codebook-normalization"]["run_id"]
+            == "manufacturing-official-zero"
+        ), aggregate["case_best"]["manufacturing-codebook-normalization"]
+
+
+def test_current_aggregate_cli_writes_public_safe_json() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-current-aggregate-cli-") as tmp:
+        root = Path(tmp)
+        ledger_path = root / "benchmark-run-ledger.json"
+        output_path = root / "current-aggregate-status.json"
+        canonical_path = root / "canonical-task-ids.txt"
+        make_ledger(ledger_path)
+        canonical_path.write_text(
+            "latex-formula-extraction\n"
+            "manufacturing-codebook-normalization\n"
+            "lab-unit-harmonization\n"
+            "fix-druid-loophole-cve\n"
+            "never-run-case\n",
+            encoding="utf-8",
+        )
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "loopx.cli",
+                "--format",
+                "json",
+                "benchmark",
+                "run-ledger-aggregate",
+                "--run-ledger-path",
+                str(ledger_path),
+                "--benchmark-id",
+                BENCHMARK_ID,
+                "--canonical-case-ids-file",
+                str(canonical_path),
+                "--output-json",
+                str(output_path),
+                "--execute",
+            ],
+            cwd=REPO_ROOT,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        payload = json.loads(result.stdout)
+        assert payload["ok"] is True, payload
+        assert output_path.exists(), payload
+        aggregate = json.loads(output_path.read_text(encoding="utf-8"))
+        assert aggregate["case_best"]["latex-formula-extraction"]["bucket"] == "official_zero"
+        assert aggregate["case_best"]["fix-druid-loophole-cve"]["bucket"] == "setup_runner_infra"
+        assert aggregate["selection_policy"]["source_paths_recorded"] is False
+        assert ".local" not in output_path.read_text(encoding="utf-8")
+
+
+if __name__ == "__main__":
+    test_current_aggregate_prefers_countable_results()
+    test_current_aggregate_cli_writes_public_safe_json()
+    print("skillsbench-current-ledger-aggregate-smoke: ok")

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -15,6 +15,9 @@ from .benchmark_core import (
 
 
 BENCHMARK_RUN_LEDGER_SCHEMA_VERSION = "benchmark_run_ledger_v0"
+BENCHMARK_RUN_LEDGER_CURRENT_AGGREGATE_SCHEMA_VERSION = (
+    "benchmark_run_ledger_current_aggregate_v0"
+)
 BENCHMARK_RUN_LEDGER_DEFAULT_PATH = Path(
     "docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json"
 )
@@ -2833,6 +2836,193 @@ def _iter_ledger_runs(ledger: dict[str, Any]) -> list[dict[str, Any]]:
                 if isinstance(run, dict):
                     runs.append(run)
     return runs
+
+
+def _ledger_score_value(run: dict[str, Any]) -> float | None:
+    value = run.get("official_score")
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _current_aggregate_bucket(run: dict[str, Any] | None) -> str:
+    if not isinstance(run, dict):
+        return "missing"
+    score = _ledger_score_value(run)
+    if score is not None:
+        if score >= 1.0:
+            return "pass"
+        if score > 0.0:
+            return "partial"
+        return "official_zero"
+    labels = set(_compact_list(run.get("failure_labels"), limit=16))
+    failure_class = _compact_text(run.get("failure_class"), limit=120)
+    failure_scope = _compact_text(run.get("failure_scope"), limit=120)
+    score_status = _compact_text(run.get("score_status"), limit=120)
+    if (
+        "verifier_no_reward" in labels
+        or "verifier_reward_missing" in labels
+        or "reward_missing" in failure_class
+        or "verifier_no_reward" in failure_class
+    ):
+        return "verifier_no_reward"
+    if (
+        failure_scope == "runner_or_setup"
+        or failure_scope == "score_missing"
+        or "infrastructure" in failure_class
+        or "setup" in failure_class
+        or "runner" in failure_class
+        or any("infra" in label or "setup" in label for label in labels)
+    ):
+        return "setup_runner_infra"
+    if score_status == "missing":
+        return "missing"
+    return "missing"
+
+
+_CURRENT_AGGREGATE_BUCKET_RANK = {
+    "missing": 0,
+    "setup_runner_infra": 1,
+    "verifier_no_reward": 2,
+    "official_zero": 3,
+    "partial": 4,
+    "pass": 5,
+}
+
+
+def _current_aggregate_run_sort_key(run: dict[str, Any]) -> tuple[Any, ...]:
+    bucket = _current_aggregate_bucket(run)
+    score = _ledger_score_value(run)
+    score_rank = score if score is not None else -1.0
+    return (
+        _CURRENT_AGGREGATE_BUCKET_RANK.get(bucket, 0),
+        score_rank,
+        _compact_text(run.get("recorded_at"), limit=80),
+        _compact_text(run.get("run_group_id"), limit=160),
+        _compact_text(run.get("run_id"), limit=80),
+    )
+
+
+def _current_aggregate_run_summary(run: dict[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(run, dict):
+        return {"bucket": "missing"}
+    keys = (
+        "run_id",
+        "recorded_at",
+        "benchmark_id",
+        "case_id",
+        "run_group_id",
+        "arm_id",
+        "route",
+        "status",
+        "score_status",
+        "official_score",
+        "official_passed",
+        "failure_class",
+        "failure_scope",
+        "repair_class",
+        "repair_priority",
+    )
+    summary = {key: run[key] for key in keys if key in run}
+    summary["bucket"] = _current_aggregate_bucket(run)
+    return summary
+
+
+def build_benchmark_run_ledger_current_aggregate(
+    ledger: dict[str, Any],
+    *,
+    benchmark_id: str = "skillsbench@1.1",
+    canonical_case_ids: list[str] | None = None,
+    source_ledger_count: int = 1,
+) -> dict[str, Any]:
+    """Build a current-case aggregate, preferring countable results over missing rows."""
+
+    normalized = _normalize_benchmark_run_ledger(dict(ledger))
+    benchmark = (
+        normalized.get("benchmarks", {}).get(benchmark_id)
+        if isinstance(normalized.get("benchmarks"), dict)
+        else None
+    )
+    cases = benchmark.get("cases") if isinstance(benchmark, dict) else {}
+    if not isinstance(cases, dict):
+        cases = {}
+    canonical_ids = [
+        _compact_text(case_id, limit=160)
+        for case_id in (canonical_case_ids or sorted(cases))
+        if _compact_text(case_id, limit=160)
+    ]
+    if not canonical_case_ids:
+        canonical_ids = sorted(cases)
+    distribution = {
+        "missing": 0,
+        "setup_runner_infra": 0,
+        "verifier_no_reward": 0,
+        "official_zero": 0,
+        "partial": 0,
+        "pass": 0,
+    }
+    cases_by_bucket = {bucket: [] for bucket in distribution}
+    case_best: dict[str, dict[str, Any]] = {}
+    deduped_run_ids: set[str] = set()
+    for case in cases.values():
+        if not isinstance(case, dict):
+            continue
+        for run in _active_ledger_runs(
+            [item for item in case.get("runs", []) if isinstance(item, dict)]
+        ):
+            run_id = _compact_text(run.get("run_id"), limit=80)
+            if run_id:
+                deduped_run_ids.add(run_id)
+    for case_id in canonical_ids:
+        case = cases.get(case_id)
+        runs = []
+        if isinstance(case, dict):
+            runs = _active_ledger_runs(
+                [item for item in case.get("runs", []) if isinstance(item, dict)]
+            )
+        best = max(runs, key=_current_aggregate_run_sort_key) if runs else None
+        summary = _current_aggregate_run_summary(best)
+        bucket = summary["bucket"]
+        distribution[bucket] = distribution.get(bucket, 0) + 1
+        cases_by_bucket.setdefault(bucket, []).append(case_id)
+        case_best[case_id] = summary
+    return {
+        "schema_version": BENCHMARK_RUN_LEDGER_CURRENT_AGGREGATE_SCHEMA_VERSION,
+        "benchmark_id": benchmark_id,
+        "canonical_total": len(canonical_ids),
+        "canonical_covered": sum(
+            count for bucket, count in distribution.items() if bucket != "missing"
+        ),
+        "distribution": distribution,
+        "cases_by_bucket": {
+            bucket: sorted(case_ids) for bucket, case_ids in cases_by_bucket.items()
+        },
+        "case_best": case_best,
+        "deduped_run_count": len(deduped_run_ids),
+        "source_ledger_files": source_ledger_count,
+        "selection_policy": {
+            "schema_version": "benchmark_run_ledger_current_selection_policy_v0",
+            "rule": "prefer_countable_official_result_over_missing_or_infra_rows",
+            "bucket_precedence": [
+                "pass",
+                "partial",
+                "official_zero",
+                "verifier_no_reward",
+                "setup_runner_infra",
+                "missing",
+            ],
+            "raw_logs_recorded": False,
+            "raw_task_text_recorded": False,
+            "source_paths_recorded": False,
+        },
+    }
 
 
 def merge_benchmark_run_ledgers(

--- a/loopx/cli_commands/benchmark_run_ledger_maintenance.py
+++ b/loopx/cli_commands/benchmark_run_ledger_maintenance.py
@@ -10,9 +10,11 @@ from pathlib import Path
 from ..benchmark_ledger import (
     BENCHMARK_RUN_LEDGER_DEFAULT_PATH,
     archive_benchmark_run_ledger_runs,
+    build_benchmark_run_ledger_current_aggregate,
     check_benchmark_run_ledger_drift,
     load_benchmark_run_ledger,
     merge_benchmark_run_ledgers,
+    upsert_benchmark_run_ledger_entry,
     update_benchmark_run_ledger,
 )
 from ..history import collect_history, load_registry
@@ -31,6 +33,7 @@ OutputFormat = Callable[[argparse.Namespace], str]
 
 BENCHMARK_RUN_LEDGER_MAINTENANCE_COMMANDS = {
     "run-ledger-archive",
+    "run-ledger-aggregate",
     "run-ledger-check",
     "run-ledger-merge",
     "run-ledger-upsert",
@@ -47,6 +50,22 @@ def _compact_benchmark_run_input(
         if isinstance(compact, dict):
             return compact_benchmark_run(compact), "harbor_job_result_reducer_v0"
     return compact_benchmark_run(payload), "benchmark_run_v0"
+
+
+def _iter_loaded_ledger_runs(ledger: dict[str, object]) -> list[dict[str, object]]:
+    runs: list[dict[str, object]] = []
+    benchmarks = ledger.get("benchmarks") if isinstance(ledger.get("benchmarks"), dict) else {}
+    for benchmark in benchmarks.values():
+        if not isinstance(benchmark, dict):
+            continue
+        cases = benchmark.get("cases") if isinstance(benchmark.get("cases"), dict) else {}
+        for case in cases.values():
+            if not isinstance(case, dict):
+                continue
+            for run in case.get("runs") or []:
+                if isinstance(run, dict):
+                    runs.append(run)
+    return runs
 
 
 def render_benchmark_run_ledger_upsert_markdown(payload: dict[str, object]) -> str:
@@ -216,6 +235,31 @@ def render_benchmark_run_ledger_merge_markdown(payload: dict[str, object]) -> st
     ]
     if merge.get("skipped_by_reason"):
         lines.append(f"- skipped_by_reason: `{merge.get('skipped_by_reason')}`")
+    if payload.get("error"):
+        lines.append(f"- error: {payload.get('error')}")
+    return "\n".join(lines) + "\n"
+
+
+def render_benchmark_run_ledger_aggregate_markdown(payload: dict[str, object]) -> str:
+    aggregate = payload.get("aggregate") if isinstance(payload.get("aggregate"), dict) else {}
+    distribution = (
+        aggregate.get("distribution")
+        if isinstance(aggregate.get("distribution"), dict)
+        else {}
+    )
+    lines = [
+        "# Benchmark Run Ledger Current Aggregate",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- dry_run: `{payload.get('dry_run')}`",
+        f"- updated: `{payload.get('updated')}`",
+        f"- benchmark: `{aggregate.get('benchmark_id')}`",
+        f"- canonical_covered: `{aggregate.get('canonical_covered')}` / `{aggregate.get('canonical_total')}`",
+        f"- distribution: `{distribution}`",
+        f"- deduped_run_count: `{aggregate.get('deduped_run_count')}`",
+        f"- source_ledger_files: `{aggregate.get('source_ledger_files')}`",
+        f"- output_json: `{payload.get('output_json')}`",
+    ]
     if payload.get("error"):
         lines.append(f"- error: {payload.get('error')}")
     return "\n".join(lines) + "\n"
@@ -401,6 +445,63 @@ def register_benchmark_run_ledger_maintenance_commands(
         "--execute",
         action="store_true",
         help="Write the merged benchmark run ledger.",
+    )
+
+    benchmark_run_ledger_aggregate_parser = benchmark_subparsers.add_parser(
+        "run-ledger-aggregate",
+        help=(
+            "Build a current-case aggregate from benchmark_run_ledger_v0 rows. "
+            "Countable official results outrank later missing or infra rows."
+        ),
+    )
+    benchmark_run_ledger_aggregate_parser.add_argument(
+        "--run-ledger-path",
+        default=str(BENCHMARK_RUN_LEDGER_DEFAULT_PATH),
+        help="Primary benchmark_run_ledger_v0 JSON.",
+    )
+    benchmark_run_ledger_aggregate_parser.add_argument(
+        "--source-run-ledger-path",
+        action="append",
+        default=[],
+        help="Additional source benchmark_run_ledger_v0 JSON. May be passed multiple times.",
+    )
+    benchmark_run_ledger_aggregate_parser.add_argument(
+        "--source-run-ledger-glob",
+        action="append",
+        default=[],
+        help=(
+            "Glob for additional source benchmark_run_ledger_v0 JSON files. "
+            "Matched paths are counted but not recorded in output."
+        ),
+    )
+    benchmark_run_ledger_aggregate_parser.add_argument(
+        "--benchmark-id",
+        default="skillsbench@1.1",
+        help="Benchmark id to aggregate.",
+    )
+    benchmark_run_ledger_aggregate_parser.add_argument(
+        "--canonical-case-id",
+        action="append",
+        default=[],
+        help="Canonical case id. May be passed multiple times.",
+    )
+    benchmark_run_ledger_aggregate_parser.add_argument(
+        "--canonical-case-ids-file",
+        help="Text file with one canonical case id per line.",
+    )
+    benchmark_run_ledger_aggregate_parser.add_argument(
+        "--output-json",
+        help="Optional output JSON path for the aggregate.",
+    )
+    benchmark_run_ledger_aggregate_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview aggregate without writing. This is the default.",
+    )
+    benchmark_run_ledger_aggregate_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Write --output-json.",
     )
 
     benchmark_run_ledger_check_parser = benchmark_subparsers.add_parser(
@@ -607,6 +708,110 @@ def handle_benchmark_run_ledger_maintenance_command(
             payload,
             output_format(args),
             render_benchmark_run_ledger_merge_markdown,
+        )
+        return 0 if payload.get("ok") else 1
+
+    if args.benchmark_command == "run-ledger-aggregate":
+        try:
+            if args.dry_run and args.execute:
+                raise ValueError(
+                    "benchmark run-ledger-aggregate accepts either --dry-run or --execute, not both"
+                )
+            source_paths = [Path(args.run_ledger_path).expanduser()]
+            source_paths.extend(Path(value).expanduser() for value in args.source_run_ledger_path)
+            for pattern in args.source_run_ledger_glob or []:
+                source_paths.extend(
+                    Path(value).expanduser()
+                    for value in glob.glob(str(Path(pattern).expanduser()), recursive=True)
+                )
+            canonical_case_ids = list(args.canonical_case_id or [])
+            if args.canonical_case_ids_file:
+                canonical_case_ids.extend(
+                    line.strip()
+                    for line in Path(args.canonical_case_ids_file)
+                    .expanduser()
+                    .read_text(encoding="utf-8")
+                    .splitlines()
+                    if line.strip()
+                )
+            merged_ledger = load_benchmark_run_ledger(args.run_ledger_path)
+            source_ledger_count = 0
+            source_run_count = 0
+            considered_run_count = 0
+            unique_source_paths = []
+            seen_sources = set()
+            for source_path in source_paths:
+                source_key = str(source_path.resolve(strict=False))
+                if source_key in seen_sources:
+                    continue
+                seen_sources.add(source_key)
+                unique_source_paths.append(source_path)
+                if not source_path.exists():
+                    continue
+                source_ledger_count += 1
+                source_ledger = load_benchmark_run_ledger(source_path)
+                for run in _iter_loaded_ledger_runs(source_ledger):
+                    source_run_count += 1
+                    if run.get("benchmark_id") != args.benchmark_id:
+                        continue
+                    considered_run_count += 1
+                    merged_ledger = upsert_benchmark_run_ledger_entry(
+                        merged_ledger,
+                        dict(run),
+                    )
+            aggregate = build_benchmark_run_ledger_current_aggregate(
+                merged_ledger,
+                benchmark_id=args.benchmark_id,
+                canonical_case_ids=canonical_case_ids or None,
+                source_ledger_count=source_ledger_count,
+            )
+            output_json = Path(args.output_json).expanduser() if args.output_json else None
+            if args.execute:
+                if output_json is None:
+                    raise ValueError("--execute requires --output-json")
+                output_json.parent.mkdir(parents=True, exist_ok=True)
+                output_json.write_text(
+                    json.dumps(aggregate, ensure_ascii=False, indent=2, sort_keys=True)
+                    + "\n",
+                    encoding="utf-8",
+                )
+            payload = {
+                "ok": True,
+                "dry_run": not bool(args.execute),
+                "updated": bool(args.execute),
+                "output_json": str(output_json) if output_json else None,
+                "aggregate": aggregate,
+                "merge_preview": {
+                    "schema_version": "benchmark_run_ledger_aggregate_source_merge_v0",
+                    "source_ledger_count": source_ledger_count,
+                    "source_run_count": source_run_count,
+                    "considered_run_count": considered_run_count,
+                    "source_paths_recorded": False,
+                    "unique_source_path_count": len(unique_source_paths),
+                },
+                "read_boundary": {
+                    "compact_only": True,
+                    "raw_logs_read": False,
+                    "task_text_read": False,
+                    "trajectory_read": False,
+                    "docker_invoked": False,
+                    "model_api_invoked": False,
+                    "upload_invoked": False,
+                },
+            }
+        except Exception as exc:
+            payload = {
+                "ok": False,
+                "dry_run": not bool(getattr(args, "execute", False)),
+                "updated": False,
+                "output_json": getattr(args, "output_json", None),
+                "aggregate": {"ok": False},
+                "error": str(exc),
+            }
+        print_payload(
+            payload,
+            output_format(args),
+            render_benchmark_run_ledger_aggregate_markdown,
         )
         return 0 if payload.get("ok") else 1
 


### PR DESCRIPTION
## Summary
- add a current aggregate builder for SkillsBench benchmark ledgers
- add a run-ledger-aggregate maintenance command that merges source ledgers without recording source paths
- add a focused smoke for bucket precedence so later missing/infra attempts cannot mask earlier countable official results

## Validation
- python3 -m py_compile loopx/benchmark_ledger.py loopx/cli_commands/benchmark_run_ledger_maintenance.py examples/skillsbench-current-ledger-aggregate-smoke.py
- python3 examples/skillsbench-current-ledger-aggregate-smoke.py
- python3 examples/benchmark-run-ledger-smoke.py
- python3 examples/cli-benchmark-run-ledger-command-modularization-smoke.py
- git diff --check
- boundary scan for proxy/local/private/raw-evidence strings on touched paths