### PR TITLE
Use task root for SkillsBench current aggregates

### DIFF
--- a/examples/skillsbench-current-ledger-aggregate-smoke.py
+++ b/examples/skillsbench-current-ledger-aggregate-smoke.py
@@ -127,6 +127,15 @@ def make_ledger(path: Path) -> None:
             failure_class="skillsbench_compose_setup_blocked_before_agent_rounds",
             failure_scope="score_missing",
         ),
+        run_entry(
+            run_id="sanity-task-preflight",
+            case_id="hello-world",
+            recorded_at="2026-07-02T01:50:00+08:00",
+            score=None,
+            score_status="missing",
+            failure_class="skillsbench_task_source_preflight_blocked",
+            failure_scope="score_missing",
+        ),
     ):
         ledger = upsert_benchmark_run_ledger_entry(ledger, entry)
     write_json(path, ledger)
@@ -166,6 +175,7 @@ def test_current_aggregate_prefers_countable_results() -> None:
             aggregate["case_best"]["manufacturing-codebook-normalization"]["run_id"]
             == "manufacturing-official-zero"
         ), aggregate["case_best"]["manufacturing-codebook-normalization"]
+        assert "hello-world" not in aggregate["case_best"], aggregate["case_best"]
 
 
 def test_current_aggregate_cli_writes_public_safe_json() -> None:
@@ -173,15 +183,19 @@ def test_current_aggregate_cli_writes_public_safe_json() -> None:
         root = Path(tmp)
         ledger_path = root / "benchmark-run-ledger.json"
         output_path = root / "current-aggregate-status.json"
-        canonical_path = root / "canonical-task-ids.txt"
+        canonical_root = root / "skillsbench" / "tasks"
         make_ledger(ledger_path)
-        canonical_path.write_text(
-            "latex-formula-extraction\n"
-            "manufacturing-codebook-normalization\n"
-            "lab-unit-harmonization\n"
-            "fix-druid-loophole-cve\n"
-            "never-run-case\n",
-            encoding="utf-8",
+        for case_id in [
+            "latex-formula-extraction",
+            "manufacturing-codebook-normalization",
+            "lab-unit-harmonization",
+            "fix-druid-loophole-cve",
+            "never-run-case",
+        ]:
+            (canonical_root / case_id).mkdir(parents=True, exist_ok=True)
+        (root / "skillsbench" / "experiments" / "sanity-tasks" / "hello-world").mkdir(
+            parents=True,
+            exist_ok=True,
         )
         result = subprocess.run(
             [
@@ -196,8 +210,8 @@ def test_current_aggregate_cli_writes_public_safe_json() -> None:
                 str(ledger_path),
                 "--benchmark-id",
                 BENCHMARK_ID,
-                "--canonical-case-ids-file",
-                str(canonical_path),
+                "--canonical-case-root",
+                str(canonical_root),
                 "--output-json",
                 str(output_path),
                 "--execute",
@@ -211,8 +225,10 @@ def test_current_aggregate_cli_writes_public_safe_json() -> None:
         assert payload["ok"] is True, payload
         assert output_path.exists(), payload
         aggregate = json.loads(output_path.read_text(encoding="utf-8"))
+        assert aggregate["canonical_total"] == 5, aggregate
         assert aggregate["case_best"]["latex-formula-extraction"]["bucket"] == "official_zero"
         assert aggregate["case_best"]["fix-druid-loophole-cve"]["bucket"] == "setup_runner_infra"
+        assert "hello-world" not in aggregate["case_best"]
         assert aggregate["selection_policy"]["source_paths_recorded"] is False
         assert ".local" not in output_path.read_text(encoding="utf-8")
 

--- a/loopx/cli_commands/benchmark_run_ledger_maintenance.py
+++ b/loopx/cli_commands/benchmark_run_ledger_maintenance.py
@@ -490,6 +490,14 @@ def register_benchmark_run_ledger_maintenance_commands(
         help="Text file with one canonical case id per line.",
     )
     benchmark_run_ledger_aggregate_parser.add_argument(
+        "--canonical-case-root",
+        help=(
+            "Directory whose immediate child directories are canonical case ids. "
+            "Use this for benchmark task roots so sanity/preflight tasks outside "
+            "the canonical root do not enter the denominator."
+        ),
+    )
+    benchmark_run_ledger_aggregate_parser.add_argument(
         "--output-json",
         help="Optional output JSON path for the aggregate.",
     )
@@ -733,6 +741,17 @@ def handle_benchmark_run_ledger_maintenance_command(
                     .read_text(encoding="utf-8")
                     .splitlines()
                     if line.strip()
+                )
+            if args.canonical_case_root:
+                canonical_root = Path(args.canonical_case_root).expanduser()
+                if not canonical_root.is_dir():
+                    raise ValueError(
+                        f"--canonical-case-root is not a directory: {canonical_root}"
+                    )
+                canonical_case_ids.extend(
+                    child.name
+                    for child in sorted(canonical_root.iterdir(), key=lambda item: item.name)
+                    if child.is_dir() and child.name
                 )
             merged_ledger = load_benchmark_run_ledger(args.run_ledger_path)
             source_ledger_count = 0


### PR DESCRIPTION
## Summary
- add --canonical-case-root to benchmark run-ledger-aggregate
- derive canonical case ids from immediate child directories of the benchmark task root
- extend the SkillsBench aggregate smoke so sanity/preflight-only hello-world does not enter the formal denominator

## Validation
- python3 -m py_compile loopx/cli_commands/benchmark_run_ledger_maintenance.py examples/skillsbench-current-ledger-aggregate-smoke.py
- python3 examples/skillsbench-current-ledger-aggregate-smoke.py
- python3 examples/benchmark-run-ledger-smoke.py
- python3 examples/cli-benchmark-run-ledger-command-modularization-smoke.py
- python3 -m loopx.cli benchmark run-ledger-aggregate --help
- git diff --check
- boundary scan for proxy/local/private/raw-evidence strings on touched paths
- local private current aggregate check using the formal SkillsBench task root produced 87/87 covered with zero missing/setup/verifier-no-reward buckets