### PR TITLE
Add SkillsBench compact solution-quality signals

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -9023,6 +9023,54 @@ def test_skillsbench_product_mode_recompact_normalizes_agent_bridge_closeout() -
     assert "official_verifier_solution_failure" in labels, compact
     assert "skillsbench_product_mode_lifecycle_missing" not in labels, compact
     assert "skillsbench_product_mode_uncountable_treatment" not in labels, compact
+    solution_quality = compact["solution_quality_signals"]
+    assert solution_quality["outcome_class"] == "official_zero", compact
+    assert "official_zero_after_public_worker_activity" in solution_quality[
+        "solution_action_labels"
+    ], compact
+    assert solution_quality["rubric_miss_label_status"] == (
+        "not_available_from_compact_public_signals"
+    ), compact
+    assert compact["post_run_debug_gate"]["solution_quality"]["outcome_class"] == (
+        "official_zero"
+    ), compact
+
+
+def test_skillsbench_solution_quality_labels_partial_nonpass() -> None:
+    compact = compact_benchmark_run(
+        {
+            "schema_version": "benchmark_run_v0",
+            "source_runner": "official_skillsbench_benchflow_result",
+            "benchmark_id": "skillsbench",
+            "case_id": "sample-partial-task",
+            "case_ids": ["sample-partial-task"],
+            "mode": "single",
+            "official_score": 0.5,
+            "official_task_score": {
+                "kind": "skillsbench_verifier_reward",
+                "value": 0.5,
+                "passed": False,
+            },
+            "score_failure_attribution": "official_score_partial_case_failure",
+            "failure_attribution_labels": ["partial_trajectory"],
+        }
+    )
+    assert compact is not None
+    solution_quality = compact["solution_quality_signals"]
+    assert solution_quality["outcome_class"] == "partial_nonpass", compact
+    assert "partial_nonpass_official_score" in solution_quality[
+        "solution_action_labels"
+    ], compact
+    assert "partial_trajectory_public_label_present" in solution_quality[
+        "solution_action_labels"
+    ], compact
+    assert solution_quality["rubric_miss_labels"] == [], compact
+    assert solution_quality["rubric_miss_label_status"] == (
+        "not_available_from_compact_public_signals"
+    ), compact
+    assert compact["post_run_debug_gate"]["solution_quality"]["outcome_class"] == (
+        "partial_nonpass"
+    ), compact
 
 
 def test_skillsbench_agent_bridge_closeout_requires_successful_commands() -> None:
@@ -11596,6 +11644,18 @@ def test_skillsbench_runner_failure_recovers_zero_score_from_controller_trace() 
             "completed_nonpassing"
         ), gate
         assert gate["scorer_verifier"]["official_score_value"] == 0.0, gate
+        solution_quality = compact["solution_quality_signals"]
+        assert solution_quality["outcome_class"] == "official_zero", compact
+        assert "official_zero_after_public_worker_activity" in solution_quality[
+            "solution_action_labels"
+        ], compact
+        assert "runner_recovery_noise_recorded" in solution_quality[
+            "solution_action_labels"
+        ], compact
+        assert gate["solution_quality"]["outcome_class"] == "official_zero", gate
+        assert "runner_recovery_noise_recorded" in gate["solution_quality"][
+            "solution_action_labels"
+        ], gate
         assert compact["runner_failure"]["failure_class"] == (
             "skillsbench_runner_interrupted_after_controller_reward_observation"
         ), compact
@@ -14173,6 +14233,7 @@ if __name__ == "__main__":
     test_skillsbench_product_mode_declared_done_is_compacted()
     test_skillsbench_product_mode_lifecycle_checkpoint_is_compacted()
     test_skillsbench_product_mode_recompact_normalizes_agent_bridge_closeout()
+    test_skillsbench_solution_quality_labels_partial_nonpass()
     test_skillsbench_agent_bridge_closeout_requires_successful_commands()
     test_skillsbench_product_mode_recompact_prefers_corroborated_solver_gap()
     test_skillsbench_product_mode_solver_activity_gap_is_compacted()

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -19,6 +19,7 @@ from ..benchmark_core import (
     canonical_lifecycle,
 )
 from ..codex_goal_baseline import build_codex_app_server_goal_worker_plan
+from .skillsbench_signals import build_skillsbench_solution_quality_signals
 
 
 SKILLSBENCH_DEFAULT_DATASET = "skillsbench@1.1"
@@ -5677,6 +5678,9 @@ def build_skillsbench_benchflow_result_benchmark_run(
             benchmark_run["runner_failure_fingerprint"] = runner_failure_fingerprint
     if partial_trajectory and not host_local_acp_codex_exec_failure_present:
         benchmark_run["failure_attribution_labels"].append("partial_trajectory")
+    benchmark_run["solution_quality_signals"] = (
+        build_skillsbench_solution_quality_signals(benchmark_run)
+    )
     return benchmark_run
 
 

--- a/loopx/benchmark_adapters/skillsbench_signals.py
+++ b/loopx/benchmark_adapters/skillsbench_signals.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def _number(value: Any) -> float | int | None:
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return value
+    return None
+
+
+def _positive_int(value: Any) -> int:
+    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+        return value
+    return 0
+
+
+def _compact_text(value: Any, *, limit: int = 160) -> str | None:
+    if value is None or isinstance(value, bool):
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    return text[:limit]
+
+
+def _compact_list(value: Any, *, limit: int = 16) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    labels: list[str] = []
+    for item in value:
+        text = _compact_text(item, limit=160)
+        if not text:
+            continue
+        labels.append(text)
+        if len(labels) >= limit:
+            break
+    return labels
+
+
+def _timeline_events_by_name(timeline: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    events = timeline.get("events") if isinstance(timeline.get("events"), list) else []
+    result: dict[str, dict[str, Any]] = {}
+    for event in events:
+        if not isinstance(event, dict):
+            continue
+        name = _compact_text(event.get("event"), limit=120)
+        if name and name not in result:
+            result[name] = event
+    return result
+
+
+def build_skillsbench_solution_quality_signals(
+    benchmark_run: dict[str, Any],
+) -> dict[str, Any]:
+    """Summarize solution-level public signals without raw benchmark material."""
+
+    if not isinstance(benchmark_run, dict):
+        return {}
+    official = (
+        benchmark_run.get("official_task_score")
+        if isinstance(benchmark_run.get("official_task_score"), dict)
+        else {}
+    )
+    score_value = _number(official.get("value"))
+    if score_value is None:
+        score_value = _number(benchmark_run.get("official_score"))
+    official_passed = official.get("passed")
+    if not isinstance(official_passed, bool):
+        official_passed = bool(score_value is not None and score_value >= 1)
+
+    labels = _compact_list(benchmark_run.get("failure_attribution_labels"))
+    counters = (
+        benchmark_run.get("interaction_counters")
+        if isinstance(benchmark_run.get("interaction_counters"), dict)
+        else {}
+    )
+    timeline = (
+        benchmark_run.get("case_event_timeline")
+        if isinstance(benchmark_run.get("case_event_timeline"), dict)
+        else {}
+    )
+    activity_event = _timeline_events_by_name(timeline).get("task_facing_activity", {})
+
+    bridge_operation_count = _positive_int(
+        activity_event.get("agent_bridge_task_facing_operation_count")
+    ) or _positive_int(
+        counters.get("remote_command_file_bridge_agent_task_facing_operation_count")
+    )
+    bridge_success_count = _positive_int(
+        activity_event.get("agent_bridge_task_facing_success_count")
+    ) or _positive_int(
+        counters.get("remote_command_file_bridge_agent_task_facing_success_count")
+    )
+    tool_call_count = _positive_int(
+        activity_event.get("acp_protocol_tool_call_count")
+    ) or _positive_int(counters.get("private_trajectory_tool_call_count"))
+    activity_status = (
+        _compact_text(activity_event.get("status"), limit=120)
+        or _compact_text(counters.get("host_local_acp_bridge_progress_status"), limit=120)
+        or ""
+    )
+    task_activity_observed = bool(
+        bridge_operation_count > 0
+        or bridge_success_count > 0
+        or tool_call_count > 0
+        or benchmark_run.get("native_goal_worker_connected") is True
+        or activity_status
+        in {
+            "task_activity_observed",
+            "bridge_task_facing_success_observed",
+            "agent_operation_trace_observed",
+        }
+    )
+
+    if score_value is None:
+        outcome_class = "missing_score"
+    elif official_passed:
+        outcome_class = "pass"
+    elif score_value == 0:
+        outcome_class = "official_zero"
+    elif score_value < 1:
+        outcome_class = "partial_nonpass"
+    else:
+        outcome_class = "nonpassing_unknown"
+
+    solution_action_labels: list[str] = []
+    if outcome_class == "official_zero":
+        solution_action_labels.append(
+            "official_zero_after_public_worker_activity"
+            if task_activity_observed
+            else "official_zero_without_public_worker_activity"
+        )
+    elif outcome_class == "partial_nonpass":
+        solution_action_labels.append("partial_nonpass_official_score")
+    elif outcome_class == "pass":
+        solution_action_labels.append("official_pass")
+    elif outcome_class == "missing_score":
+        solution_action_labels.append("official_score_missing")
+
+    runner_failure = (
+        benchmark_run.get("runner_failure")
+        if isinstance(benchmark_run.get("runner_failure"), dict)
+        else {}
+    )
+    runner_failure_class = _compact_text(runner_failure.get("failure_class"), limit=140)
+    if (
+        "skillsbench_runner_interrupted_after_controller_reward_observation" in labels
+        or runner_failure_class
+        == "skillsbench_runner_interrupted_after_controller_reward_observation"
+    ):
+        solution_action_labels.append("runner_recovery_noise_recorded")
+    if "partial_trajectory" in labels:
+        solution_action_labels.append("partial_trajectory_public_label_present")
+
+    rubric_miss_status = (
+        "not_applicable_pass"
+        if outcome_class == "pass"
+        else (
+            "score_missing"
+            if outcome_class == "missing_score"
+            else "not_available_from_compact_public_signals"
+        )
+    )
+    if rubric_miss_status == "not_available_from_compact_public_signals":
+        solution_action_labels.append("rubric_miss_labels_unavailable_compact_only")
+
+    deduped_labels: list[str] = []
+    for label in solution_action_labels:
+        if label not in deduped_labels:
+            deduped_labels.append(label)
+
+    return {
+        "schema_version": "skillsbench_solution_quality_signals_v0",
+        "source": "compact_public_signals",
+        "outcome_class": outcome_class,
+        "solution_action_labels": deduped_labels,
+        "rubric_miss_labels": [],
+        "rubric_miss_label_status": rubric_miss_status,
+        "worker_activity": {
+            "task_facing_activity_observed": task_activity_observed,
+            "worker_turn_or_bridge_observed": task_activity_observed,
+            "tool_call_count": tool_call_count,
+            "bridge_task_facing_operation_count": bridge_operation_count,
+            "bridge_task_facing_success_count": bridge_success_count,
+        },
+        "public_limits": [
+            "task_text_not_recorded",
+            "trajectory_not_recorded",
+            "verifier_output_not_recorded",
+        ],
+    }

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -7,6 +7,9 @@ from pathlib import Path
 import re
 from typing import Any
 
+from .benchmark_adapters.skillsbench_signals import (
+    build_skillsbench_solution_quality_signals,
+)
 from .control_plane import compact_control_plane_policy, control_plane_policy_summary
 from .contract import check_contract
 from .delivery_batch_scale import (
@@ -1205,6 +1208,7 @@ def build_skillsbench_post_run_debug_gate(
         run.get("failure_attribution_labels"),
         limit=MAX_BENCHMARK_RUN_LIST_ITEMS,
     )
+    solution_quality = build_skillsbench_solution_quality_signals(run)
     gate: dict[str, Any] = {
         "schema_version": "skillsbench_post_run_debug_gate_v0",
         "source": "compact_public_signals",
@@ -1373,6 +1377,8 @@ def build_skillsbench_post_run_debug_gate(
             "verifier_output_tail_public": False,
         },
     }
+    if solution_quality:
+        gate["solution_quality"] = solution_quality
     if labels:
         gate["failure_attribution_labels"] = labels
     if runner_failure:
@@ -4456,6 +4462,10 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
                 compact_validation[field] = validation[field]
         compact["validation"] = compact_validation
         _apply_skillsbench_pre_agent_setup_compact_projection(compact)
+
+    solution_quality = build_skillsbench_solution_quality_signals(compact)
+    if solution_quality:
+        compact["solution_quality_signals"] = solution_quality
 
     post_run_debug_gate = build_skillsbench_post_run_debug_gate(compact)
     if post_run_debug_gate:

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -8478,6 +8478,8 @@ def _public_runner_config(plan: dict[str, Any]) -> dict[str, Any]:
         "schema_version": "skillsbench_runner_config_v0",
         "raw_command_recorded": False,
         "raw_env_recorded": False,
+        "ledger_path_recorded": False,
+        "global_ledger_path_recorded": False,
     }
     string_fields = (
         "benchmark_id",
@@ -8490,8 +8492,6 @@ def _public_runner_config(plan: dict[str, Any]) -> dict[str, Any]:
         "job_name",
         "rollout_name",
         "treatment_prompt_style",
-        "ledger_path",
-        "global_ledger_path",
         "ledger_scope",
     )
     for field in string_fields:
@@ -12994,7 +12994,11 @@ def reduce_result(
     if goal_start_control_score:
         compact["goal_start_product_mode_control_score"] = goal_start_control_score
     compact["case_event_timeline"] = _build_case_event_timeline(compact, plan)
-    compact["post_run_debug_gate"] = build_skillsbench_post_run_debug_gate(compact)
+    post_run_debug_gate = build_skillsbench_post_run_debug_gate(compact)
+    compact["post_run_debug_gate"] = post_run_debug_gate
+    solution_quality = post_run_debug_gate.get("solution_quality")
+    if isinstance(solution_quality, dict):
+        compact["solution_quality_signals"] = solution_quality
     return compact
 
 
@@ -13821,7 +13825,11 @@ def build_runner_failure_compact(
     if not recovered:
         _recover_runner_failure_score_from_verifier_artifact(reduced, plan)
     reduced["case_event_timeline"] = _build_case_event_timeline(reduced, plan)
-    reduced["post_run_debug_gate"] = build_skillsbench_post_run_debug_gate(reduced)
+    post_run_debug_gate = build_skillsbench_post_run_debug_gate(reduced)
+    reduced["post_run_debug_gate"] = post_run_debug_gate
+    solution_quality = post_run_debug_gate.get("solution_quality")
+    if isinstance(solution_quality, dict):
+        reduced["solution_quality_signals"] = solution_quality
     return reduced
 
 


### PR DESCRIPTION
## Summary
- add a shared public-safe SkillsBench solution-quality signal helper for compact runs
- project solution-quality signals into generated compact runs, recompact/status gates, and final runner closeout paths
- avoid publishing runner ledger absolute paths in public runner config

## Validation
- python3 -m py_compile loopx/benchmark_adapters/skillsbench_signals.py loopx/benchmark_adapters/skillsbench.py loopx/status.py scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- targeted runpy smoke for solution-quality/recovered-zero/build-stall cases
- git diff --check
- staged public/private boundary scan for local paths, credentials, private endpoints