### PR TITLE
Preserve SkillsBench recovered reward ledger signals

### DIFF
--- a/examples/benchmark-run-ledger-smoke.py
+++ b/examples/benchmark-run-ledger-smoke.py
@@ -18,6 +18,7 @@ if str(REPO_ROOT) not in sys.path:
 from loopx.benchmark import build_terminal_bench_harbor_result_benchmark_run  # noqa: E402
 from loopx.benchmark_ledger import (  # noqa: E402
     BENCHMARK_RUN_LEDGER_SCHEMA_VERSION,
+    build_benchmark_run_ledger_current_aggregate,
     build_benchmark_run_ledger_entry,
     load_benchmark_run_ledger,
     merge_benchmark_run_ledgers,
@@ -839,6 +840,92 @@ def test_passed_pair_routes_to_baseline_solved_non_regression() -> None:
         assert case["latest_decision"]["decision"] == (
             "paired_baseline_solved_treatment_preserved"
         ), case
+
+
+def test_skillsbench_recovered_reward_closeout_fields_survive_current_aggregate() -> None:
+    run = {
+        "schema_version": "benchmark_run_v0",
+        "benchmark_id": "skillsbench@1.1",
+        "job_name": "skillsbench_recovered_reward_fixture",
+        "mode": "skillsbench_codex_app_server_goal_baseline",
+        "route": "codex-app-server-goal-baseline",
+        "official_score_status": "completed",
+        "official_task_score": {
+            "kind": "skillsbench_verifier_reward_recovered_from_verifier_artifact",
+            "passed": False,
+            "value": 0.0,
+        },
+        "score_failure_attribution": "official_score_zero_case_failure",
+        "runner_return_status": "interrupted_after_verifier_reward_artifact",
+        "failure_attribution_labels": [
+            "skillsbench_runner_error",
+            "official_score_zero_case_failure",
+            "skillsbench_runner_interrupted_after_verifier_reward_artifact",
+        ],
+        "runner_failure": {
+            "failure_class": "skillsbench_runner_interrupted_after_verifier_reward_artifact",
+            "score_recovered_from_verifier_artifact": True,
+        },
+        "verifier_reward_artifact_recovery": {
+            "schema_version": "skillsbench_verifier_reward_artifact_recovery_v0",
+            "status": "official_score_recovered_from_verifier_reward_artifact",
+            "official_result_json_materialized": False,
+            "reward_present": True,
+            "passed": False,
+        },
+        "validation": {
+            "verifier_reward_artifact_recovered": True,
+            "official_result_json_materialized": False,
+        },
+        "attempt_accounting": {
+            "lifecycle_phase": "worker_started",
+            "failure_label": "official_score_zero_case_failure",
+            "failure_class": "solver_failed",
+            "launcher_attempt_countable": True,
+            "case_attempt_countable": True,
+            "solver_attempt_countable": True,
+            "verifier_attempt_countable": True,
+            "official_score_attempt_countable": True,
+        },
+        "trials": [{"task_id": "recovered-reward-fixture", "exception_type": "none"}],
+    }
+    with tempfile.TemporaryDirectory(prefix="benchmark-ledger-recovered-reward-") as tmp:
+        root = Path(tmp)
+        ledger_path = root / "ledger.json"
+        update = update_benchmark_run_ledger(
+            ledger_path=ledger_path,
+            benchmark_run=run,
+            run_group_id="recovered-reward-closeout-fixture",
+            cwd=root,
+        )
+        entry = update["entry"]
+        assert entry["failure_class"] == "official_score_zero_case_failure", entry
+        assert entry["failure_scope"] == "case_or_solution", entry
+        assert entry["score_status"] == "failed", entry
+        assert entry["official_score_attempt_countable"] is True, entry
+        assert entry["runner_return_status"] == (
+            "interrupted_after_verifier_reward_artifact"
+        ), entry
+        assert entry["runner_score_recovered_from_verifier_artifact"] is True, entry
+        assert entry["verifier_reward_artifact_recovered"] is True, entry
+        assert entry["official_result_json_materialized"] is False, entry
+        assert entry["verifier_reward_artifact_recovery_status"] == (
+            "official_score_recovered_from_verifier_reward_artifact"
+        ), entry
+
+        aggregate = build_benchmark_run_ledger_current_aggregate(
+            load_benchmark_run_ledger(ledger_path),
+            canonical_case_ids=["recovered-reward-fixture"],
+        )
+        summary = aggregate["case_best"]["recovered-reward-fixture"]
+        assert summary["bucket"] == "official_zero", summary
+        assert summary["failure_class"] == "official_score_zero_case_failure", summary
+        assert summary["runner_return_status"] == (
+            "interrupted_after_verifier_reward_artifact"
+        ), summary
+        assert summary["runner_score_recovered_from_verifier_artifact"] is True, summary
+        assert summary["verifier_reward_artifact_recovered"] is True, summary
+        assert summary["official_result_json_materialized"] is False, summary
 
 
 def test_skillsbench_product_mode_pair_review_is_ledgered() -> None:
@@ -1888,6 +1975,7 @@ if __name__ == "__main__":
     test_verified_bridge_official_zero_routes_to_no_uplift_not_alignment()
     test_skillsbench_product_mode_pair_review_is_ledgered()
     test_skillsbench_product_mode_pair_blocks_shallow_lifecycle()
+    test_skillsbench_recovered_reward_closeout_fields_survive_current_aggregate()
     test_raw_max5_baseline_does_not_force_product_pair_without_product_treatment()
     test_ledger_ingests_post_launch_stale_active_marker()
     test_ledger_ingests_post_launch_ended_active_marker()

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -1504,6 +1504,21 @@ def build_benchmark_run_ledger_entry(
         if isinstance(benchmark_run.get("runner_prerequisites"), dict)
         else {}
     )
+    runner_failure = (
+        benchmark_run.get("runner_failure")
+        if isinstance(benchmark_run.get("runner_failure"), dict)
+        else {}
+    )
+    verifier_reward_artifact_recovery = (
+        benchmark_run.get("verifier_reward_artifact_recovery")
+        if isinstance(benchmark_run.get("verifier_reward_artifact_recovery"), dict)
+        else {}
+    )
+    validation = (
+        benchmark_run.get("validation")
+        if isinstance(benchmark_run.get("validation"), dict)
+        else {}
+    )
     runtime_preflight_passed = _codex_acp_runtime_preflight_passed(
         runner_prerequisites
     )
@@ -1576,7 +1591,50 @@ def build_benchmark_run_ledger_entry(
         else None,
         "failure_class": failure_class,
         "failure_scope": failure_scope,
-        "failure_labels": _compact_list(benchmark_run.get("failure_attribution_labels"), limit=8),
+        "failure_labels": _compact_list(
+            benchmark_run.get("failure_attribution_labels"),
+            limit=8,
+        ),
+        "runner_return_status": _compact_text(
+            benchmark_run.get("runner_return_status"),
+            limit=120,
+        ),
+        "runner_score_recovered_from_verifier_artifact": (
+            runner_failure.get("score_recovered_from_verifier_artifact")
+            if isinstance(
+                runner_failure.get("score_recovered_from_verifier_artifact"),
+                bool,
+            )
+            else None
+        ),
+        "verifier_reward_artifact_recovery_status": _compact_text(
+            verifier_reward_artifact_recovery.get("status"),
+            limit=120,
+        ),
+        "verifier_reward_artifact_recovered": (
+            validation.get("verifier_reward_artifact_recovered")
+            if isinstance(validation.get("verifier_reward_artifact_recovered"), bool)
+            else (
+                verifier_reward_artifact_recovery.get("reward_present")
+                if isinstance(
+                    verifier_reward_artifact_recovery.get("reward_present"),
+                    bool,
+                )
+                else None
+            )
+        ),
+        "official_result_json_materialized": (
+            verifier_reward_artifact_recovery.get("official_result_json_materialized")
+            if isinstance(
+                verifier_reward_artifact_recovery.get("official_result_json_materialized"),
+                bool,
+            )
+            else (
+                validation.get("official_result_json_materialized")
+                if isinstance(validation.get("official_result_json_materialized"), bool)
+                else None
+            )
+        ),
         "setup_blockers": _compact_list(
             benchmark_run.get("worker_setup_diagnostic_blockers"),
             limit=4,
@@ -2927,6 +2985,15 @@ def _current_aggregate_run_summary(run: dict[str, Any] | None) -> dict[str, Any]
         "official_passed",
         "failure_class",
         "failure_scope",
+        "failure_labels",
+        "attempt_lifecycle_phase",
+        "attempt_failure_label",
+        "attempt_failure_class",
+        "runner_return_status",
+        "runner_score_recovered_from_verifier_artifact",
+        "verifier_reward_artifact_recovery_status",
+        "verifier_reward_artifact_recovered",
+        "official_result_json_materialized",
         "repair_class",
         "repair_priority",
     )


### PR DESCRIPTION
## Summary
- carry recovered verifier reward artifact closeout fields into benchmark_run_ledger entries
- expose those fields in current aggregate case_best summaries
- add a focused ledger smoke for recovered reward artifact closeout attribution

## Validation
- python3 -m py_compile loopx/benchmark_ledger.py examples/benchmark-run-ledger-smoke.py
- python3 examples/benchmark-run-ledger-smoke.py

## Notes
- Does not launch benchmark jobs or change official scoring semantics.
- Keeps zero-score recovered reward cases countable while preserving runner/materialization noise separately.
