### PR TITLE
Preserve SkillsBench ledger attribution refs

### DIFF
--- a/examples/benchmark-run-ledger-smoke.py
+++ b/examples/benchmark-run-ledger-smoke.py
@@ -877,6 +877,29 @@ def test_skillsbench_recovered_reward_closeout_fields_survive_current_aggregate(
             "verifier_reward_artifact_recovered": True,
             "official_result_json_materialized": False,
         },
+        "solution_quality_signals": {
+            "schema_version": "skillsbench_solution_quality_signals_v0",
+            "source": "compact_public_signals",
+            "outcome_class": "official_zero",
+            "solution_action_labels": [
+                "official_zero_after_public_worker_activity",
+                "runner_recovery_noise_recorded",
+            ],
+            "rubric_miss_labels": [],
+            "rubric_miss_label_status": "not_available_from_compact_public_signals",
+            "worker_activity": {
+                "task_facing_activity_observed": True,
+                "worker_turn_or_bridge_observed": True,
+                "tool_call_count": 3,
+                "bridge_task_facing_operation_count": 4,
+                "bridge_task_facing_success_count": 4,
+            },
+            "public_limits": [
+                "task_text_not_recorded",
+                "trajectory_not_recorded",
+                "verifier_output_not_recorded",
+            ],
+        },
         "attempt_accounting": {
             "lifecycle_phase": "worker_started",
             "failure_label": "official_score_zero_case_failure",
@@ -912,6 +935,11 @@ def test_skillsbench_recovered_reward_closeout_fields_survive_current_aggregate(
         assert entry["verifier_reward_artifact_recovery_status"] == (
             "official_score_recovered_from_verifier_reward_artifact"
         ), entry
+        solution_quality = entry["solution_quality_signals"]
+        assert solution_quality["outcome_class"] == "official_zero", solution_quality
+        assert solution_quality["worker_activity"][
+            "bridge_task_facing_operation_count"
+        ] == 4, solution_quality
 
         aggregate = build_benchmark_run_ledger_current_aggregate(
             load_benchmark_run_ledger(ledger_path),
@@ -926,6 +954,9 @@ def test_skillsbench_recovered_reward_closeout_fields_survive_current_aggregate(
         assert summary["runner_score_recovered_from_verifier_artifact"] is True, summary
         assert summary["verifier_reward_artifact_recovered"] is True, summary
         assert summary["official_result_json_materialized"] is False, summary
+        assert summary["solution_quality_signals"]["worker_activity"][
+            "bridge_task_facing_success_count"
+        ] == 4, summary
 
 
 def test_skillsbench_product_mode_pair_review_is_ledgered() -> None:
@@ -1554,6 +1585,8 @@ def test_cli_compact_run_json_updates_run_ledger() -> None:
         ledger = load_benchmark_run_ledger(ledger_path)
         case = ledger["benchmarks"]["terminal-bench@2.0"]["cases"]["timeout-fixture"]
         assert len(case["runs"]) == 1, case
+        refs = case["runs"][0]["artifact_refs"]
+        assert refs == {"compact_artifact_ref": "compact-run.json"}, refs
         assert case["latest_decision"]["decision"] == (
             "baseline_failed_treatment_candidate"
         ), case

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -44,7 +44,12 @@ PRIVATE_ARTIFACT_REF_PATH_MARKERS = (
     "/tmp/",
 )
 PUBLIC_LEDGER_LINEAGE_RESULT_FILENAMES = {
+    "benchmark-run.json",
+    "benchmark_run.json",
+    "compact-run.json",
+    "loopx-worker-benchmark-run.json",
     "result.json",
+    "skillsbench-compact-benchmark-run-v0.json",
 }
 PRIVATE_ARTIFACT_REF_PATH_PARTS = {
     ".local",
@@ -547,6 +552,48 @@ def _compact_product_mode_lifecycle_contract(value: Any) -> dict[str, Any]:
     execution_style = _compact_text(value.get("execution_style"), limit=120)
     if execution_style:
         compact["execution_style"] = execution_style
+    return compact
+
+
+def _compact_skillsbench_solution_quality_signals(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    compact: dict[str, Any] = {}
+    for field in (
+        "schema_version",
+        "source",
+        "outcome_class",
+        "rubric_miss_label_status",
+    ):
+        text = _compact_text(value.get(field), limit=120)
+        if text:
+            compact[field] = text
+    for field in ("solution_action_labels", "rubric_miss_labels", "public_limits"):
+        labels = _compact_list(value.get(field), limit=12)
+        if labels:
+            compact[field] = labels
+    worker_activity = (
+        value.get("worker_activity")
+        if isinstance(value.get("worker_activity"), dict)
+        else {}
+    )
+    compact_worker_activity: dict[str, Any] = {}
+    for field in (
+        "task_facing_activity_observed",
+        "worker_turn_or_bridge_observed",
+    ):
+        if isinstance(worker_activity.get(field), bool):
+            compact_worker_activity[field] = worker_activity[field]
+    for field in (
+        "tool_call_count",
+        "bridge_task_facing_operation_count",
+        "bridge_task_facing_success_count",
+    ):
+        raw = worker_activity.get(field)
+        if isinstance(raw, int) and not isinstance(raw, bool):
+            compact_worker_activity[field] = max(0, raw)
+    if compact_worker_activity:
+        compact["worker_activity"] = compact_worker_activity
     return compact
 
 
@@ -1687,6 +1734,11 @@ def build_benchmark_run_ledger_entry(
     )
     if product_mode_lifecycle_contract:
         entry["product_mode_lifecycle_contract"] = product_mode_lifecycle_contract
+    solution_quality_signals = _compact_skillsbench_solution_quality_signals(
+        benchmark_run.get("solution_quality_signals")
+    )
+    if solution_quality_signals:
+        entry["solution_quality_signals"] = solution_quality_signals
     attempt_accounting = (
         benchmark_run.get("attempt_accounting")
         if isinstance(benchmark_run.get("attempt_accounting"), dict)
@@ -2979,10 +3031,16 @@ def _current_aggregate_run_summary(run: dict[str, Any] | None) -> dict[str, Any]
         "run_group_id",
         "arm_id",
         "route",
+        "artifact_refs",
         "status",
         "score_status",
         "official_score",
         "official_passed",
+        "round_reward_count",
+        "round_success_observed",
+        "max_rounds_budget",
+        "official_feedback_blinded",
+        "reward_feedback_forwarded",
         "failure_class",
         "failure_scope",
         "failure_labels",
@@ -2994,6 +3052,9 @@ def _current_aggregate_run_summary(run: dict[str, Any] | None) -> dict[str, Any]
         "verifier_reward_artifact_recovery_status",
         "verifier_reward_artifact_recovered",
         "official_result_json_materialized",
+        "solution_quality_signals",
+        "task_setup_preflight",
+        "task_staging",
         "repair_class",
         "repair_priority",
     )

--- a/loopx/cli_commands/benchmark_run_ledger_maintenance.py
+++ b/loopx/cli_commands/benchmark_run_ledger_maintenance.py
@@ -846,13 +846,18 @@ def handle_benchmark_run_ledger_maintenance_command(
                 )
 
             input_path_text = args.benchmark_run_json or args.post_launch_json
+            compact_artifact_ref_cwd = None
             if input_path_text == "-":
                 run_input = json.loads(sys.stdin.read())
                 compact_artifact_ref = args.compact_artifact_ref
             else:
                 input_path = Path(input_path_text).expanduser()
                 run_input = json.loads(input_path.read_text(encoding="utf-8"))
-                compact_artifact_ref = args.compact_artifact_ref or str(input_path)
+                if args.compact_artifact_ref:
+                    compact_artifact_ref = args.compact_artifact_ref
+                else:
+                    compact_artifact_ref = str(input_path)
+                    compact_artifact_ref_cwd = input_path.parent
             if not isinstance(run_input, dict):
                 raise ValueError("ledger input JSON must contain an object")
 
@@ -882,6 +887,7 @@ def handle_benchmark_run_ledger_maintenance_command(
                 arm_id=args.arm_id,
                 notes=args.run_ledger_note,
                 dry_run=dry_run,
+                cwd=compact_artifact_ref_cwd,
             )
             payload = {
                 "ok": True,


### PR DESCRIPTION
Summary:
- keep public-safe compact benchmark_run JSON refs when run-ledger-upsert reads a file path
- preserve SkillsBench solution-quality counters and artifact refs in current aggregate summaries
- extend benchmark-run-ledger smoke coverage for compact refs and solution-quality signals

Validation:
- python3 -m py_compile loopx/benchmark_ledger.py loopx/cli_commands/benchmark_run_ledger_maintenance.py examples/benchmark-run-ledger-smoke.py
- python3 examples/benchmark-run-ledger-smoke.py

Boundary:
- no benchmark jobs launched
- no scoring, task semantics, leaderboard, credentials, raw logs, or local private artifact paths included