### PR TITLE
Derive SkillsBench ledger quality signals

### DIFF
--- a/examples/benchmark-run-ledger-smoke.py
+++ b/examples/benchmark-run-ledger-smoke.py
@@ -959,6 +959,31 @@ def test_skillsbench_recovered_reward_closeout_fields_survive_current_aggregate(
         ] == 4, summary
 
 
+def test_skillsbench_solution_quality_signals_are_derived_for_old_compact_runs() -> None:
+    entry = build_benchmark_run_ledger_entry(
+        {
+            "schema_version": "benchmark_run_v0",
+            "benchmark_id": "skillsbench@1.1",
+            "case_id": "old-compact-run-fixture",
+            "official_task_score": {"passed": False, "value": 0.0},
+            "interaction_counters": {
+                "remote_command_file_bridge_agent_task_facing_operation_count": 3,
+                "remote_command_file_bridge_agent_task_facing_success_count": 2,
+            },
+        }
+    )
+
+    solution_quality = entry["solution_quality_signals"]
+    assert solution_quality["outcome_class"] == "official_zero", solution_quality
+    assert solution_quality["solution_action_labels"] == [
+        "official_zero_after_public_worker_activity",
+        "rubric_miss_labels_unavailable_compact_only",
+    ], solution_quality
+    assert solution_quality["worker_activity"][
+        "bridge_task_facing_operation_count"
+    ] == 3, solution_quality
+
+
 def test_skillsbench_product_mode_pair_review_is_ledgered() -> None:
     baseline = {
         "schema_version": "benchmark_run_v0",

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -12,6 +12,9 @@ from .benchmark_core import (
     classify_benchmark_artifact_path,
     classify_product_mode_main_table_pair,
 )
+from .benchmark_adapters.skillsbench_signals import (
+    build_skillsbench_solution_quality_signals,
+)
 
 
 BENCHMARK_RUN_LEDGER_SCHEMA_VERSION = "benchmark_run_ledger_v0"
@@ -595,6 +598,21 @@ def _compact_skillsbench_solution_quality_signals(value: Any) -> dict[str, Any]:
     if compact_worker_activity:
         compact["worker_activity"] = compact_worker_activity
     return compact
+
+
+def _ledger_skillsbench_solution_quality_signals(
+    benchmark_run: dict[str, Any],
+    *,
+    benchmark_id: str,
+) -> dict[str, Any]:
+    signals = _compact_skillsbench_solution_quality_signals(
+        benchmark_run.get("solution_quality_signals")
+    )
+    if signals or not benchmark_id.lower().startswith("skillsbench"):
+        return signals
+    return _compact_skillsbench_solution_quality_signals(
+        build_skillsbench_solution_quality_signals(benchmark_run)
+    )
 
 
 def _terminal_bench_case_id_from_job_name(
@@ -1734,8 +1752,9 @@ def build_benchmark_run_ledger_entry(
     )
     if product_mode_lifecycle_contract:
         entry["product_mode_lifecycle_contract"] = product_mode_lifecycle_contract
-    solution_quality_signals = _compact_skillsbench_solution_quality_signals(
-        benchmark_run.get("solution_quality_signals")
+    solution_quality_signals = _ledger_skillsbench_solution_quality_signals(
+        benchmark_run,
+        benchmark_id=benchmark_id,
     )
     if solution_quality_signals:
         entry["solution_quality_signals"] = solution_quality_signals


### PR DESCRIPTION
Summary:
- derive SkillsBench solution-quality signals in benchmark ledger entry building when older compact benchmark_run rows do not already carry them
- keep the derivation scoped to skillsbench benchmark ids
- add smoke coverage for old compact rows with public worker counters

Validation:
- python3 -m py_compile loopx/benchmark_ledger.py examples/benchmark-run-ledger-smoke.py
- python3 examples/benchmark-run-ledger-smoke.py

Boundary:
- no benchmark jobs launched
- no raw task text, raw trajectories, verifier output, credentials, or local private paths committed
- no scoring, task semantics, leaderboard, or submission behavior changed