### PR TITLE
Backfill SkillsBench ledger attribution logically

### DIFF
--- a/examples/benchmark-run-ledger-smoke.py
+++ b/examples/benchmark-run-ledger-smoke.py
@@ -24,6 +24,7 @@ from loopx.benchmark_ledger import (  # noqa: E402
     merge_benchmark_run_ledgers,
     render_benchmark_run_ledger_markdown,
     update_benchmark_run_ledger,
+    upsert_benchmark_run_ledger_entry,
 )
 from loopx.status import compact_benchmark_run  # noqa: E402
 
@@ -982,6 +983,64 @@ def test_skillsbench_solution_quality_signals_are_derived_for_old_compact_runs()
     assert solution_quality["worker_activity"][
         "bridge_task_facing_operation_count"
     ] == 3, solution_quality
+
+
+def test_run_ledger_logical_backfill_preserves_existing_run_id() -> None:
+    benchmark_run = {
+        "schema_version": "benchmark_run_v0",
+        "benchmark_id": "skillsbench@1.1",
+        "case_id": "latex-formula-extraction",
+        "job_name": "skillsbench_1_1_latex_formula_extraction_codex_app_server_goal_baseline",
+        "mode": "skillsbench_codex_app_server_goal_baseline",
+        "official_task_score": {"passed": False, "value": 0.0},
+        "interaction_counters": {
+            "remote_command_file_bridge_agent_task_facing_operation_count": 13,
+            "remote_command_file_bridge_agent_task_facing_success_count": 13,
+        },
+    }
+    old_entry = build_benchmark_run_ledger_entry(
+        benchmark_run,
+        run_group_id="skillsbench-revtunnel-appgoal-infra-rerun14",
+        arm_id="codex_app_server_goal_baseline",
+    )
+    old_entry.pop("artifact_refs", None)
+    old_entry.pop("solution_quality_signals", None)
+    new_entry = build_benchmark_run_ledger_entry(
+        benchmark_run,
+        compact_artifact_ref="benchmark_run.compact.json",
+        run_group_id="skillsbench-revtunnel-appgoal-infra-rerun14",
+        arm_id="codex_app_server_goal_baseline",
+    )
+    assert old_entry["run_id"] != new_entry["run_id"]
+
+    updated = upsert_benchmark_run_ledger_entry(
+        {
+            "schema_version": BENCHMARK_RUN_LEDGER_SCHEMA_VERSION,
+            "benchmarks": {
+                "skillsbench@1.1": {
+                    "benchmark_id": "skillsbench@1.1",
+                    "cases": {
+                        "latex-formula-extraction": {
+                            "case_id": "latex-formula-extraction",
+                            "runs": [old_entry],
+                        }
+                    },
+                }
+            },
+        },
+        new_entry,
+    )
+    runs = updated["benchmarks"]["skillsbench@1.1"]["cases"][
+        "latex-formula-extraction"
+    ]["runs"]
+    assert len(runs) == 1, runs
+    assert runs[0]["run_id"] == old_entry["run_id"], runs
+    assert runs[0]["artifact_refs"] == {
+        "compact_artifact_ref": "benchmark_run.compact.json"
+    }, runs
+    assert runs[0]["solution_quality_signals"]["worker_activity"][
+        "bridge_task_facing_success_count"
+    ] == 13, runs
 
 
 def test_skillsbench_product_mode_pair_review_is_ledgered() -> None:

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -29,6 +29,17 @@ DEFAULT_AGENT_TIMEOUT_REPAIR_MULTIPLIER = 8
 DEFAULT_AGENT_SETUP_TIMEOUT_REPAIR_MULTIPLIER = 8
 DEFAULT_CODEX_SETUP_TIMEOUT_REPAIR_INSTALL_STRATEGY = "require_existing_codex"
 RUNTIME_CODEX_INSTALL_STRATEGY = "runtime_install_if_missing"
+LEDGER_LOGICAL_BACKFILL_FIELDS = (
+    "artifact_refs",
+    "solution_quality_signals",
+    "round_reward_count",
+    "round_success_observed",
+    "max_rounds_budget",
+    "official_feedback_blinded",
+    "reward_feedback_forwarded",
+    "task_setup_preflight",
+    "task_staging",
+)
 TERMINAL_BENCH_JOB_CASE_ARM_MARKERS = (
     "_codex_goal_mode_baseline",
     "_codex_loopx_treatment",
@@ -474,6 +485,45 @@ def _run_matches_token(run: dict[str, Any], *needles: str) -> bool:
         if any(lower_needle in token for token in tokens):
             return True
     return False
+
+
+def _ledger_missing_value(value: Any) -> bool:
+    return value is None or value in ("", [], {})
+
+
+def _ledger_logical_backfill_key(run: dict[str, Any]) -> tuple[str, ...]:
+    values: list[str] = []
+    for field in ("run_group_id", "arm_id", "job_name", "mode"):
+        text = _compact_text(run.get(field), limit=220)
+        if not text:
+            return ()
+        values.append(text)
+    return tuple(values)
+
+
+def _ledger_result_equivalent_for_backfill(
+    run: dict[str, Any],
+    entry: dict[str, Any],
+) -> bool:
+    for field in ("status", "score_status", "official_passed", "failure_class"):
+        if run.get(field) != entry.get(field):
+            return False
+    return run.get("official_score") == entry.get("official_score")
+
+
+def _merge_ledger_logical_backfill_fields(
+    run: dict[str, Any],
+    entry: dict[str, Any],
+) -> tuple[dict[str, Any], bool]:
+    merged = dict(run)
+    changed = False
+    for field in LEDGER_LOGICAL_BACKFILL_FIELDS:
+        if _ledger_missing_value(merged.get(field)) and not _ledger_missing_value(
+            entry.get(field)
+        ):
+            merged[field] = entry[field]
+            changed = True
+    return merged, changed
 
 
 def _product_mode_baseline_run(run: dict[str, Any]) -> bool:
@@ -2375,6 +2425,21 @@ def upsert_benchmark_run_ledger_entry(
             runs[index] = entry
             replaced = True
             break
+    if not replaced:
+        entry_backfill_key = _ledger_logical_backfill_key(entry)
+        if entry_backfill_key:
+            for index, run in enumerate(runs):
+                if (
+                    run.get("run_id") == entry.get("run_id")
+                    or _ledger_logical_backfill_key(run) != entry_backfill_key
+                    or not _ledger_result_equivalent_for_backfill(run, entry)
+                ):
+                    continue
+                merged, changed = _merge_ledger_logical_backfill_fields(run, entry)
+                if changed:
+                    runs[index] = merged
+                replaced = True
+                break
     if not replaced:
         runs.append(entry)
     runs.sort(key=lambda run: (str(run.get("recorded_at", "")), str(run.get("run_id", ""))))


### PR DESCRIPTION
Summary:
- add logical-match attribution backfill for existing benchmark ledger rows when adding refs/signals would otherwise change run_id
- preserve existing run_id and result fields while filling missing public attribution fields
- add smoke coverage that backfill does not duplicate a run

Validation:
- python3 -m py_compile loopx/benchmark_ledger.py examples/benchmark-run-ledger-smoke.py
- python3 examples/benchmark-run-ledger-smoke.py

Boundary:
- no benchmark jobs launched
- no raw task text, raw trajectories, verifier output, credentials, or local private paths committed
- no scoring, task semantics, leaderboard, or submission behavior changed