### PR TITLE
Exclude sanity tasks from SkillsBench current aggregate

### DIFF
--- a/examples/skillsbench-current-ledger-aggregate-smoke.py
+++ b/examples/skillsbench-current-ledger-aggregate-smoke.py
@@ -41,6 +41,7 @@ def run_entry(
     failure_class: str,
     failure_scope: str,
     labels: list[str] | None = None,
+    task_setup_preflight: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     entry: dict[str, Any] = {
         "run_id": run_id,
@@ -56,6 +57,8 @@ def run_entry(
         "failure_scope": failure_scope,
         "failure_labels": labels or [],
     }
+    if task_setup_preflight is not None:
+        entry["task_setup_preflight"] = task_setup_preflight
     if score is not None:
         entry["official_score"] = score
         entry["official_passed"] = score >= 1.0
@@ -135,6 +138,14 @@ def make_ledger(path: Path) -> None:
             score_status="missing",
             failure_class="skillsbench_task_source_preflight_blocked",
             failure_scope="score_missing",
+            task_setup_preflight={
+                "schema_version": "skillsbench_task_setup_preflight_v0",
+                "status": "task_missing_from_canonical_tasks",
+                "task_id": "hello-world",
+                "canonical_task_present": False,
+                "alternate_source_kind": "experiments_sanity_tasks",
+                "alternate_source_supported_by_runner": False,
+            },
         ),
     ):
         ledger = upsert_benchmark_run_ledger_entry(ledger, entry)
@@ -176,6 +187,22 @@ def test_current_aggregate_prefers_countable_results() -> None:
             == "manufacturing-official-zero"
         ), aggregate["case_best"]["manufacturing-codebook-normalization"]
         assert "hello-world" not in aggregate["case_best"], aggregate["case_best"]
+
+
+def test_current_aggregate_default_inference_excludes_sanity_sources() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-current-aggregate-default-") as tmp:
+        ledger_path = Path(tmp) / "benchmark-run-ledger.json"
+        make_ledger(ledger_path)
+        ledger = load_benchmark_run_ledger(ledger_path)
+        aggregate = build_benchmark_run_ledger_current_aggregate(
+            ledger,
+            benchmark_id=BENCHMARK_ID,
+        )
+        assert aggregate["canonical_total"] == 4, aggregate
+        assert aggregate["canonical_covered"] == 4, aggregate
+        assert aggregate["distribution"]["setup_runner_infra"] == 1, aggregate
+        assert "hello-world" not in aggregate["case_best"], aggregate["case_best"]
+        assert "hello-world" not in aggregate["cases_by_bucket"]["setup_runner_infra"]
 
 
 def test_current_aggregate_cli_writes_public_safe_json() -> None:
@@ -235,5 +262,6 @@ def test_current_aggregate_cli_writes_public_safe_json() -> None:
 
 if __name__ == "__main__":
     test_current_aggregate_prefers_countable_results()
+    test_current_aggregate_default_inference_excludes_sanity_sources()
     test_current_aggregate_cli_writes_public_safe_json()
     print("skillsbench-current-ledger-aggregate-smoke: ok")

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -3147,6 +3147,39 @@ def _current_aggregate_run_summary(run: dict[str, Any] | None) -> dict[str, Any]
     return summary
 
 
+def _current_aggregate_case_is_noncanonical_sanity_source(case: dict[str, Any]) -> bool:
+    runs = _active_ledger_runs(
+        [item for item in case.get("runs", []) if isinstance(item, dict)]
+    )
+    if not runs:
+        return False
+    saw_sanity_source_preflight = False
+    for run in runs:
+        if _ledger_score_value(run) is not None:
+            return False
+        if _compact_text(run.get("failure_class"), limit=120) != (
+            "skillsbench_task_source_preflight_blocked"
+        ):
+            return False
+        preflight = run.get("task_setup_preflight")
+        if not isinstance(preflight, dict):
+            return False
+        if preflight.get("canonical_task_present") is not False:
+            return False
+        if _compact_text(preflight.get("status"), limit=120) != (
+            "task_missing_from_canonical_tasks"
+        ):
+            return False
+        if _compact_text(preflight.get("alternate_source_kind"), limit=120) != (
+            "experiments_sanity_tasks"
+        ):
+            return False
+        if preflight.get("alternate_source_supported_by_runner") is not False:
+            return False
+        saw_sanity_source_preflight = True
+    return saw_sanity_source_preflight
+
+
 def build_benchmark_run_ledger_current_aggregate(
     ledger: dict[str, Any],
     *,
@@ -3165,13 +3198,21 @@ def build_benchmark_run_ledger_current_aggregate(
     cases = benchmark.get("cases") if isinstance(benchmark, dict) else {}
     if not isinstance(cases, dict):
         cases = {}
-    canonical_ids = [
-        _compact_text(case_id, limit=160)
-        for case_id in (canonical_case_ids or sorted(cases))
-        if _compact_text(case_id, limit=160)
-    ]
-    if not canonical_case_ids:
-        canonical_ids = sorted(cases)
+    if canonical_case_ids:
+        canonical_ids = [
+            _compact_text(case_id, limit=160)
+            for case_id in canonical_case_ids
+            if _compact_text(case_id, limit=160)
+        ]
+    else:
+        canonical_ids = sorted(
+            case_id
+            for case_id, case in cases.items()
+            if not (
+                isinstance(case, dict)
+                and _current_aggregate_case_is_noncanonical_sanity_source(case)
+            )
+        )
     distribution = {
         "missing": 0,
         "setup_runner_infra": 0,


### PR DESCRIPTION
## Summary

- exclude explicit SkillsBench experiments/sanity task-source preflight rows from default current aggregate canonical inference
- keep explicit canonical-case inputs authoritative
- add a smoke covering default inference so `hello-world` cannot inflate canonical coverage or setup infra counts

## Validation

- `python3 examples/skillsbench-current-ledger-aggregate-smoke.py`
- `python3 examples/benchmark-run-ledger-smoke.py`
- `python3 -m compileall loopx/benchmark_ledger.py`
- `git diff --check`
- Applied to the current private global ledger with this branch on `PYTHONPATH`: aggregate becomes `87/87`, `setup_runner_infra=0`, `hello-world` excluded.

## Boundary

Public benchmark ledger logic and smoke only. No raw task text, raw trajectories, verifier output, credentials, local artifact paths, or proxy addresses are committed.
