### PR TITLE
Fix visible auto-research demo startup

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -237,7 +237,7 @@ def main() -> int:
         assert tonight["leader_agent_required"] is False, tonight
         assert tonight["dev_metric"] == 4.0, tonight
         assert tonight["holdout_metric"] == 4.5, tonight
-        assert "--run-worker-loop" not in tonight["one_command"], tonight
+        assert "--run-worker-loop" in tonight["one_command"], tonight
         assert "--headless" not in tonight["one_command"], tonight
         assert "--headless" in payload["commands"]["headless_worker_loop"], payload
         assert "--no-attach" in payload["commands"]["start_visible_lanes_without_attach"], payload
@@ -287,6 +287,14 @@ def main() -> int:
                         f"visible demo-e2e failed rc={visible.returncode}\nstdout={visible.stdout}\nstderr={visible.stderr}"
                     )
                 visible_payload = json.loads(visible.stdout)
+                assert visible_payload["execution_kind"] == "visible_worker_launch", visible_payload
+                assert visible_payload["result_source"] == "visible_worker_launcher", visible_payload
+                assert "worker_loop" not in visible_payload, visible_payload
+                assert "tonight_experience" not in visible_payload, visible_payload
+                visible_claim = visible_payload["claim_summary"]
+                assert visible_claim["status"] == "visible_worker_queue_started", visible_claim
+                assert visible_claim["dev_metric"] is None, visible_claim
+                assert visible_claim["holdout_metric"] is None, visible_claim
                 launch = visible_payload["visible_launch"]["launch_result"]
                 assert launch["started_lane_count"] == 4, visible_payload
                 assert "frontier" not in launch["started_lanes"], visible_payload
@@ -308,7 +316,9 @@ def main() -> int:
                 assert {item["source_resolution"] for item in skill_items} == {"package_root"}, skill_items
                 assert all(item["materialized"] is True for item in skill_items), skill_items
                 for _attempt in range(40):
-                    if codex_invocations.exists():
+                    if codex_invocations.exists() and codex_invocations.read_text(
+                        encoding="utf-8"
+                    ).count("PWD=") >= 4:
                         break
                     time.sleep(0.25)
                 invocation_text = codex_invocations.read_text(encoding="utf-8")

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -532,9 +532,9 @@ def register_auto_research_commands(
         "--execute",
         action="store_true",
         help=(
-            "Seed a demo-local LoopX goal queue, run role-compatible worker-loop turns through "
-            "quota/frontier/todo writeback, and report measured dev/holdout gains. This still "
-            "requires live evidence before claiming that visible Codex panes authored the result."
+            "Seed a demo-local LoopX goal queue and, by default, launch visible Codex TUI lanes "
+            "that work the frontier from zero. Use --headless or --run-worker-loop for the "
+            "non-interactive worker-loop proof path."
         ),
     )
     demo_e2e_parser.add_argument(
@@ -920,9 +920,7 @@ def handle_auto_research_command(
                         create_workspace=args.create_workspace,
                     )
 
-            run_hidden_worker_loop = bool(
-                args.execute and (args.headless or args.run_worker_loop or launch_visible)
-            )
+            run_hidden_worker_loop = bool(args.execute and (args.headless or args.run_worker_loop))
             payload = run_auto_research_demo_e2e(
                 agent_id=args.agent_id,
                 goal_id=goal_id,

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -378,6 +378,8 @@ def _command_text(
         parts.extend(["--tracking-goal-id", shlex.quote(tracking_goal_id)])
     if execute:
         parts.append("--execute")
+    if run_worker_loop:
+        parts.append("--run-worker-loop")
     if headless:
         parts.append("--headless")
     if launch_visible:
@@ -507,7 +509,7 @@ def _demo_claim_summary(payload: dict[str, object]) -> dict[str, object]:
         "holdout_metric": None,
         "holdout_metric_redacted": False,
         "next_required": (
-            "run --execute to seed a demo-local LoopX queue and execute the worker-loop"
+            "run --execute to seed a demo-local LoopX queue and launch visible Codex lanes"
         ),
     }
 


### PR DESCRIPTION
## Summary
- make default `auto-research demo-e2e --execute` seed the demo queue and launch visible Codex TUI lanes without first running the hidden worker loop
- require explicit `--run-worker-loop` or `--headless` for the non-interactive positive proof path
- strengthen the demo smoke so visible launch payloads cannot include hidden `worker_loop` / `tonight_experience` results

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-demo-e2e-worker-loop-smoke.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-worker-turn-smoke.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-worker-loop-smoke.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 examples/visible-multi-agent-launcher-smoke.py`
- `git diff --check`
- private-boundary scan over changed files

## Boundary
No private paths, raw logs, credentials, or local runtime artifacts are committed. This is a narrow auto-research demo startup fix.
