### PR TITLE
Clean stale SkillsBench reverse JSON sockets

### DIFF
--- a/examples/skillsbench-reverse-tunnel-supervisor-smoke.py
+++ b/examples/skillsbench-reverse-tunnel-supervisor-smoke.py
@@ -272,6 +272,11 @@ def test_supervisor_holds_json_bridge_and_materializes_remote_client() -> None:
         assert bridge["remote_socket_ready"] is True, bridge
         assert bridge["remote_client_materialized"] is True, bridge
         assert bridge["sandbox_env_probe_deferred"] is True, bridge
+        cleanup = bridge["remote_socket_cleanup"]
+        assert cleanup["requested"] is True, cleanup
+        assert cleanup["attempted"] is True, cleanup
+        assert cleanup["ok"] is True, cleanup
+        assert cleanup["exit_code"] == 0, cleanup
         assert bridge["raw_bridge_command_recorded"] is False, bridge
         assert bridge["raw_socket_paths_recorded"] is False, bridge
         assert bridge["raw_client_path_recorded"] is False, bridge
@@ -282,7 +287,10 @@ def test_supervisor_holds_json_bridge_and_materializes_remote_client() -> None:
         assert str(local_socket) not in public_text
         assert opaque_remote_socket not in public_text
         assert opaque_remote_client not in public_text
-        assert opaque_remote_client in ssh_log.read_text(encoding="utf-8")
+        ssh_log_text = ssh_log.read_text(encoding="utf-8")
+        assert "rm -f --" in ssh_log_text
+        assert opaque_remote_socket in ssh_log_text
+        assert opaque_remote_client in ssh_log_text
         assert private_log.exists()
 
 

--- a/scripts/skillsbench_reverse_tunnel_supervisor.py
+++ b/scripts/skillsbench_reverse_tunnel_supervisor.py
@@ -129,6 +129,7 @@ def _json_bridge_public_contract(args: argparse.Namespace) -> dict[str, Any]:
         "raw_socket_paths_recorded": False,
         "raw_client_path_recorded": False,
         "raw_probe_output_recorded": False,
+        "remote_socket_cleanup": _remote_json_socket_cleanup_public_contract(args),
     }
 
 
@@ -254,6 +255,45 @@ def _probe_remote_json_socket(args: argparse.Namespace) -> bool:
     except (OSError, subprocess.TimeoutExpired):
         return False
     return proc.returncode == 0
+
+
+def _remote_json_socket_cleanup_public_contract(
+    args: argparse.Namespace,
+) -> dict[str, Any]:
+    return {
+        "requested": bool(_json_bridge_requested(args) and args.json_remote_socket),
+        "attempted": False,
+        "ok": False,
+        "raw_socket_paths_recorded": False,
+        "raw_output_recorded": False,
+    }
+
+
+def _cleanup_remote_json_socket(args: argparse.Namespace) -> dict[str, Any]:
+    payload = _remote_json_socket_cleanup_public_contract(args)
+    if not payload["requested"]:
+        return payload
+    payload["attempted"] = True
+    command = "rm -f -- " + shlex.quote(args.json_remote_socket)
+    try:
+        proc = _run_remote_shell_command(
+            args,
+            command,
+            timeout_sec=args.remote_setup_timeout_sec,
+        )
+    except subprocess.TimeoutExpired:
+        payload["first_blocker"] = "json_bridge_remote_socket_cleanup_timeout"
+        return payload
+    except OSError:
+        payload["first_blocker"] = "json_bridge_remote_socket_cleanup_launch_failed"
+        return payload
+    payload["exit_code"] = proc.returncode
+    payload["stdout_size_bucket"] = _size_bucket(proc.stdout or "")
+    payload["stderr_size_bucket"] = _size_bucket(proc.stderr or "")
+    payload["ok"] = proc.returncode == 0
+    if proc.returncode != 0:
+        payload["first_blocker"] = "json_bridge_remote_socket_cleanup_exit_nonzero"
+    return payload
 
 
 def _materialize_remote_json_client(args: argparse.Namespace, runtime_dir: Path) -> bool:
@@ -752,6 +792,17 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
                 json_bridge_payload["server_exit_code"] = json_bridge_proc.returncode
                 return finish(2)
             json_bridge_payload["local_socket_ready"] = True
+            json_bridge_payload["remote_socket_cleanup"] = (
+                _cleanup_remote_json_socket(args)
+            )
+            if not json_bridge_payload["remote_socket_cleanup"].get("ok"):
+                payload["first_blocker"] = (
+                    json_bridge_payload["remote_socket_cleanup"].get(
+                        "first_blocker",
+                        "json_bridge_remote_socket_cleanup_failed",
+                    )
+                )
+                return finish(2)
 
         tunnel_proc = subprocess.Popen(
             _tunnel_command(args, json_local_socket=json_local_socket),


### PR DESCRIPTION
Summary
- Clean stale remote JSON bridge sockets before starting the reverse tunnel.
- Record only public-safe cleanup status in supervisor output.
- Extend the supervisor smoke to prove cleanup runs and remains redacted.

Validation
- python3 -m py_compile scripts/skillsbench_reverse_tunnel_supervisor.py examples/skillsbench-reverse-tunnel-supervisor-smoke.py
- python3 examples/skillsbench-reverse-tunnel-supervisor-smoke.py