### PR TITLE
Improve visible auto-research demo startup

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -299,14 +299,17 @@ def main() -> int:
                 assert launch["started_lane_count"] == 4, visible_payload
                 assert "frontier" not in launch["started_lanes"], visible_payload
                 assert launch["attach_requested"] is False, visible_payload
-                assert launch["workspace_mode"] == "current_directory", visible_payload
+                assert launch["workspace_mode"] == "explicit_workspace", visible_payload
+                assert launch["codex_trust_workspace"] is True, visible_payload
+                assert launch["codex_trust_scope"] == "per_invocation_selected_workspace", visible_payload
                 workspace_route = visible_payload["visible_control_plane"]["workspace_route"]
                 assert workspace_route["side_lane_worktree_count"] == 0, workspace_route
                 assert workspace_route["primary_workspace"] == "visible_codex_tui_workspace", workspace_route
                 assert (
                     workspace_route["trust_prompt_avoidance"]
-                    == "do_not_start_codex_tui_in_demo_local_git_worktrees"
+                    == "demo_owned_clean_workspace_with_per_invocation_codex_trust_config"
                 ), workspace_route
+                assert workspace_route["default_visible_workspace"] == "demo_owned_clean_workspace", workspace_route
                 acceptance = launch["visible_acceptance"]
                 assert acceptance["accepted"] is True, visible_payload
                 assert all(not item["blocked_before_bootstrap"] for item in acceptance["pane_checks"]), acceptance
@@ -324,8 +327,9 @@ def main() -> int:
                 invocation_text = codex_invocations.read_text(encoding="utf-8")
                 assert invocation_text.count("Fake Codex TUI") == 0, invocation_text
                 assert invocation_text.count("PWD=") == 4, invocation_text
-                assert invocation_text.count(f"PWD={workspace.resolve()}") == 4, invocation_text
-                assert invocation_text.count(f'-C {workspace.resolve()}') == 4, invocation_text
+                assert invocation_text.count("visible-user-workspace") >= 8, invocation_text
+                assert invocation_text.count("trust_level=trusted") == 0, invocation_text
+                assert invocation_text.count('trust_level="trusted"') == 4, invocation_text
                 assert "visible-lane-worktrees" not in invocation_text, invocation_text
                 assert "visible-control-plane" not in invocation_text, invocation_text
                 for lane in launch["started_lanes"]:

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -94,6 +94,8 @@ def main() -> int:
     assert "LOOPX_MACHINE_JSON=1 explicitly" in launcher_source
     assert "multi_agent_visible_interactive_tui_contract_v0" in launcher_source
     assert "LOOPX_CODEX_TUI_MODE=interactive" in launcher_source
+    assert "LOOPX_CODEX_TRUST_WORKSPACE" in launcher_source
+    assert "trust_level=" in launcher_source and "trusted" in launcher_source
     assert "pre_codex_character_stream" in launcher_source
     assert "build_visible_frontier_command" not in launcher_source
     assert 'FRONTIER_ARTIFACT_NAME="frontier.public.json"' not in launcher_source
@@ -311,6 +313,7 @@ def main() -> int:
                 workspace=str(workspace),
                 create_workspace=True,
                 cwd=temp,
+                codex_trust_workspace=True,
             )
         finally:
             os.environ["PATH"] = original_path
@@ -321,6 +324,8 @@ def main() -> int:
         assert workspace_mode == "explicit_workspace", launch
         assert workspace.is_dir(), workspace
         assert launch["schema_version"] == "multi_agent_visible_launch_result_v0", launch
+        assert launch["codex_trust_workspace"] is True, launch
+        assert launch["codex_trust_scope"] == "per_invocation_selected_workspace", launch
         skills = launch["worker_skill_materialization"]
         assert skills == [
             {

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -476,6 +476,15 @@ def register_auto_research_commands(
         action="store_true",
         help="Create --workspace when it does not already exist.",
     )
+    demo_supervisor_parser.add_argument(
+        "--codex-trust-workspace",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help=(
+            "Pass a per-invocation Codex trust config for the selected visible workspace. "
+            "Default is off for generic supervisor launches."
+        ),
+    )
 
     demo_e2e_parser = auto_research_sub.add_parser(
         "demo-e2e",
@@ -610,12 +619,24 @@ def register_auto_research_commands(
     )
     demo_e2e_parser.add_argument(
         "--workspace",
-        help="Directory where visible Codex lanes should start when --launch-visible is set.",
+        help=(
+            "Directory where visible Codex lanes should start when --launch-visible is set. "
+            "Omit to use a demo-owned clean workspace."
+        ),
     )
     demo_e2e_parser.add_argument(
         "--create-workspace",
         action="store_true",
         help="Create --workspace when it does not already exist.",
+    )
+    demo_e2e_parser.add_argument(
+        "--codex-trust-workspace",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help=(
+            "Pass a per-invocation Codex trust config for the visible workspace. "
+            "Defaults on only for the demo-owned clean workspace."
+        ),
     )
 
 
@@ -632,6 +653,7 @@ def _execute_auto_research_demo_supervisor(
     replace_existing: bool,
     workspace: str | None,
     create_workspace: bool,
+    codex_trust_workspace: bool,
 ) -> dict[str, object]:
     registry = load_registry(registry_path)
     runtime_root = resolve_runtime_root(registry, runtime_root_arg)
@@ -648,6 +670,7 @@ def _execute_auto_research_demo_supervisor(
         workspace=workspace,
         create_workspace=create_workspace,
         cwd=Path.cwd(),
+        codex_trust_workspace=codex_trust_workspace,
         launch_result_schema="auto_research_demo_launch_result_v0",
         acceptance_schema="auto_research_visible_launch_acceptance_v0",
         lane_default="research-lane",
@@ -666,7 +689,13 @@ def _execute_auto_research_demo_supervisor(
                 "spends_loopx_quota": False,
                 "external_service_call": False,
                 "workspace_mode": workspace_mode,
-                "workspace_write_scope": "user_selected_workspace_only",
+                "workspace_write_scope": "selected_visible_workspace_only",
+                "codex_trust_workspace": codex_trust_workspace,
+                "codex_trust_scope": (
+                    "per_invocation_selected_workspace"
+                    if codex_trust_workspace
+                    else "native_codex_trust_prompt"
+                ),
                 "shared_state_route": "LOOPX_REGISTRY_and_LOOPX_RUNTIME_ROOT",
                 "shared_goal_surface": True,
                 "all_lane_workspace_isolation": False,
@@ -875,6 +904,7 @@ def handle_auto_research_command(
                     replace_existing=args.replace_existing,
                     workspace=args.workspace,
                     create_workspace=args.create_workspace,
+                    codex_trust_workspace=args.codex_trust_workspace,
                 )
         elif args.auto_research_command == "demo-e2e":
             if args.headless and args.launch_visible:
@@ -906,6 +936,18 @@ def handle_auto_research_command(
                     visible_runtime_root_arg: str | None,
                     _default_workspace: Path,
                 ) -> dict[str, object]:
+                    demo_owned_workspace = args.workspace is None
+                    visible_workspace = (
+                        str(_default_workspace / "visible-user-workspace")
+                        if demo_owned_workspace
+                        else args.workspace
+                    )
+                    create_visible_workspace = True if demo_owned_workspace else args.create_workspace
+                    codex_trust_workspace = (
+                        demo_owned_workspace
+                        if args.codex_trust_workspace is None
+                        else bool(args.codex_trust_workspace)
+                    )
                     return _execute_auto_research_demo_supervisor(
                         supervisor,
                         registry_path=visible_registry_path,
@@ -916,8 +958,9 @@ def handle_auto_research_command(
                         codex_bin=args.codex_bin,
                         attach=attach_visible,
                         replace_existing=args.replace_existing,
-                        workspace=args.workspace,
-                        create_workspace=args.create_workspace,
+                        workspace=visible_workspace,
+                        create_workspace=create_visible_workspace,
+                        codex_trust_workspace=codex_trust_workspace,
                     )
 
             run_hidden_worker_loop = bool(args.execute and (args.headless or args.run_worker_loop))

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -73,13 +73,17 @@ def _prepare_visible_demo_workspace_route(
         "schema_version": "auto_research_visible_demo_workspace_route_v0",
         "shared_goal_surface": "demo_local_loopx_registry_and_runtime",
         "primary_workspace": "visible_codex_tui_workspace",
+        "default_visible_workspace": "demo_owned_clean_workspace",
         "side_lane_workspace": "visible_codex_tui_workspace",
         "side_lane_worktree_count": 0,
         "side_lane_count": side_count,
-        "trust_prompt_avoidance": "do_not_start_codex_tui_in_demo_local_git_worktrees",
+        "trust_prompt_avoidance": (
+            "demo_owned_clean_workspace_with_per_invocation_codex_trust_config"
+        ),
         "mutation_isolation_policy": (
             "mutating attempts claim an execution boundary from inside the role; "
-            "the first visible TUI uses the operator-selected workspace"
+            "the first visible TUI uses the demo-owned clean workspace unless "
+            "the operator passes --workspace"
         ),
         "absolute_paths_recorded": False,
     }

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -154,6 +154,20 @@ def build_visible_lane_command(
     codex_bin: str,
     reasoning_effort: str,
 ) -> str:
+    trust_config_py = (
+        'import json, os; '
+        'print("projects." + json.dumps(os.environ["LOOPX_PROJECT"]) + '
+        '".trust_level=\\"trusted\\"")'
+    )
+    codex_trust_args = (
+        'if [ "${LOOPX_CODEX_TRUST_WORKSPACE:-0}" = "1" ]; then '
+        f'CODEX_TRUST_CONFIG="$(python3 -c {_q(trust_config_py)})"; '
+        f"exec {_q(codex_bin)} "
+        '-c "$CODEX_TRUST_CONFIG" '
+        f"-c model_reasoning_effort={_q(reasoning_effort)} "
+        '-C "$LOOPX_PROJECT" "$BOOTSTRAP_PROMPT"; '
+        "fi; "
+    )
     scoped_loopx_wrapper = (
         'LOOPX_REAL_CLI="$(command -v loopx)"; '
         "export LOOPX_REAL_CLI; "
@@ -186,6 +200,7 @@ def build_visible_lane_command(
         "fi; "
         "export LOOPX_CODEX_TUI_MODE=interactive; "
         "export LOOPX_CODEX_TUI_PROMPT_ARTIFACT=\"$BOOTSTRAP_ARTIFACT\"; "
+        f"{codex_trust_args}"
         f"exec {_q(codex_bin)} -c model_reasoning_effort={_q(reasoning_effort)} "
         '-C "$LOOPX_PROJECT" "$BOOTSTRAP_PROMPT"'
     )
@@ -421,6 +436,7 @@ def execute_visible_multi_agent_launcher(
     workspace: str | None,
     create_workspace: bool,
     cwd: Path,
+    codex_trust_workspace: bool = False,
     launch_result_schema: str = "multi_agent_visible_launch_result_v0",
     acceptance_schema: str = "multi_agent_visible_launch_acceptance_v0",
     lane_default: str = "agent-lane",
@@ -453,6 +469,7 @@ def execute_visible_multi_agent_launcher(
         launch_result_schema=launch_result_schema,
         acceptance_schema=acceptance_schema,
         lane_default=lane_default,
+        codex_trust_workspace=codex_trust_workspace,
     )
     result["worker_skill_materialization"] = worker_skills
     return result, chosen, workspace_mode
@@ -472,6 +489,7 @@ def _launch_with_tmux(
     launch_result_schema: str,
     acceptance_schema: str,
     lane_default: str,
+    codex_trust_workspace: bool,
 ) -> dict[str, object]:
     session = str(payload.get("session_name") or "loopx-visible-agents")
     lanes = [item for item in payload.get("lanes", []) if isinstance(item, dict)]
@@ -485,6 +503,7 @@ def _launch_with_tmux(
             "LOOPX_REGISTRY": str(registry),
             "LOOPX_RUNTIME_ROOT": str(runtime_root),
             "LOOPX_VISIBLE_SESSION": session,
+            "LOOPX_CODEX_TRUST_WORKSPACE": "1" if codex_trust_workspace else "0",
         }
     )
     exists = subprocess.run(
@@ -516,7 +535,8 @@ def _launch_with_tmux(
             script_dir=script_dir,
             name=lane_id,
             command=runtime_shell_command(
-                launch_command,
+                f"export LOOPX_CODEX_TRUST_WORKSPACE={_q('1' if codex_trust_workspace else '0')}; "
+                f"{launch_command}",
                 project=lane_project,
                 registry=registry,
                 runtime_root=runtime_root,
@@ -586,6 +606,12 @@ def _launch_with_tmux(
         "attach_command": f"{tmux_bin} attach -t {session}",
         "stop_command": f"{tmux_bin} kill-session -t {session}",
         "workspace_mode": workspace_mode,
+        "codex_trust_workspace": codex_trust_workspace,
+        "codex_trust_scope": (
+            "per_invocation_selected_workspace"
+            if codex_trust_workspace
+            else "native_codex_trust_prompt"
+        ),
         "script_mode": "runtime_local_files",
         "launcher_script_count": len(launcher_scripts),
         "attach_requested": attach,


### PR DESCRIPTION
## Summary
- make `auto-research demo-e2e --execute` default visible panes start in a demo-owned clean workspace instead of the caller cwd
- add a generic visible-launcher switch for per-invocation Codex workspace trust, default off outside demo-e2e
- update focused smokes to assert four interactive Codex TUI lanes survive, avoid visible-control-plane worktrees, hide first-screen JSON, and pass trust config only for the selected workspace

## Validation
- `PYTHONDONTWRITEBYTECODE=1 python3 examples/visible-multi-agent-launcher-smoke.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-demo-e2e-worker-loop-smoke.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 examples/generic-multi-agent-one-command-smoke.py`
- `git diff --check`
- `loopx check` (clean; existing loopx-meta duplicate-index warning only)

## Review note
This is intentionally not self-merged: it changes visible Codex TUI startup trust behavior, even though the default scope is limited to a demo-owned clean workspace.
