### PR TITLE
Add generic multi-agent launch spec

### DIFF
--- a/docs/reference/protocols/multi-agent-visible-launcher-v0.md
+++ b/docs/reference/protocols/multi-agent-visible-launcher-v0.md
@@ -17,6 +17,59 @@ This contract intentionally sits between two existing surfaces:
 The visible launcher may plan or start panes, but it must not become a leader
 agent, hidden scheduler, promotion authority, or second source of truth.
 
+## User-Facing Spec
+
+Most callers should not author `multi_agent_visible_launcher_v0` packets by
+hand. They should provide a small `generic_multi_agent_launch_spec_v0` role
+spec and let `loopx multi-agent launch --spec <file>` expand it into the
+visible launcher packet.
+
+```json
+{
+  "schema_version": "generic_multi_agent_launch_spec_v0",
+  "goal_id": "loopx-meta",
+  "session_name": "loopx-custom-team",
+  "default_reasoning_effort": "high",
+  "roles": [
+    {
+      "lane_id": "planner",
+      "agent_id": "codex-main-control",
+      "role_id": "planner",
+      "scope": "Plan the next bounded step from the shared goal surface.",
+      "skill": {
+        "name": "loopx-planner-worker",
+        "source": "worker/SKILL.md"
+      },
+      "handoff_hints": [
+        "Create or update a LoopX todo for critic when a plan needs review."
+      ]
+    },
+    {
+      "lane_id": "critic",
+      "agent_id": "codex-side-bypass",
+      "role_id": "critic",
+      "scope": "Review the bounded step against the same todo and quota projection."
+    }
+  ]
+}
+```
+
+The spec is intentionally small:
+
+- `goal_id` selects the shared LoopX state surface;
+- each role names an `agent_id`, human role, and scope;
+- `skill.source` is resolved relative to the spec file and materialized as a
+  worker-local skill for that role;
+- `handoff_hints` describe how roles should use LoopX todos/evidence to pass
+  work, without creating a central workflow engine;
+- `--execute` starts visible Codex TUI panes, while the default mode only
+  previews the packet.
+
+This keeps product integration focused on role design and state-mediated
+handoff. The generated launcher packet still enforces artifact-only machine
+JSON, interactive Codex TUI windows, attach/stop controls, and public boundary
+fields.
+
 ## Ownership Split
 
 | Surface | Owns | Does not own |

--- a/examples/cli-multi-agent-command-modularization-smoke.py
+++ b/examples/cli-multi-agent-command-modularization-smoke.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CLI = ROOT / "loopx" / "cli.py"
+MODULE = ROOT / "loopx" / "cli_commands" / "multi_agent.py"
+INIT = ROOT / "loopx" / "cli_commands" / "__init__.py"
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *args],
+        cwd=ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def require_success(result: subprocess.CompletedProcess[str]) -> str:
+    if result.returncode != 0:
+        raise AssertionError(
+            f"expected success, got {result.returncode}\n"
+            f"stdout:\n{result.stdout}\n\nstderr:\n{result.stderr}"
+        )
+    return result.stdout
+
+
+def main() -> None:
+    cli_source = CLI.read_text(encoding="utf-8")
+    module_source = MODULE.read_text(encoding="utf-8")
+    init_source = INIT.read_text(encoding="utf-8")
+
+    require("multi_agent.py" not in cli_source, "cli.py should not embed multi-agent module details")
+    require(
+        "register_multi_agent_commands(sub, add_subcommand_format)" in cli_source,
+        "cli.py did not register multi-agent commands",
+    )
+    require("handle_multi_agent_command(" in cli_source, "cli.py did not dispatch multi-agent commands")
+    require("register_multi_agent_commands" in init_source, "__init__ omitted multi-agent registration")
+    require("handle_multi_agent_command" in init_source, "__init__ omitted multi-agent handler")
+
+    for marker in (
+        "register_multi_agent_commands",
+        "handle_multi_agent_command",
+        "build_visible_multi_agent_payload_from_spec",
+        "execute_visible_multi_agent_launcher",
+        "generic_multi_agent_launch_spec_v0",
+    ):
+        require(marker in module_source, f"multi-agent module missing {marker}")
+
+    help_text = require_success(run_cli("multi-agent", "launch", "--help"))
+    for option in (
+        "--spec",
+        "--execute",
+        "--workspace",
+        "--attach",
+        "--codex-trust-workspace",
+    ):
+        require(option in help_text, f"multi-agent launch help omitted {option}")
+
+    print("cli-multi-agent-command-modularization-smoke: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/generic-multi-agent-one-command-smoke.py
+++ b/examples/generic-multi-agent-one-command-smoke.py
@@ -25,125 +25,58 @@ PRIVATE_MARKERS = [
     "sec" + "ret",
 ]
 
-ONE_COMMAND = r'''
-import json
-import os
-from pathlib import Path
-
-from loopx.visible_multi_agent_launcher import (
-    build_visible_multi_agent_payload,
-    execute_visible_multi_agent_launcher,
-)
-
-
-goal_id = "loopx-meta"
-session_name = "loopx-generic-multi-agent-smoke"
-registry = Path(os.environ["SMOKE_REGISTRY"])
-runtime_root = Path(os.environ["SMOKE_RUNTIME_ROOT"])
-workspace = Path(os.environ["SMOKE_WORKSPACE"])
-cwd = Path(os.environ["SMOKE_CWD"])
-
-lanes = [
-    {
-        "lane_id": "planner",
-        "agent_id": "codex-main-control",
-        "role_id": "planner",
-        "responsibility": "Plan the next bounded step from the shared goal surface.",
-        "role_profile": {"schema_version": "generic_multi_agent_role_profile_v0", "role_id": "planner"},
-        "quota_guard": "loopx --format json --registry \"$LOOPX_REGISTRY\" --runtime-root \"$LOOPX_RUNTIME_ROOT\" quota should-run --goal-id loopx-meta --agent-id codex-main-control",
-        "frontier": "role-local state projection",
-        "bootstrap_message": "Planner role prompt",
-        "visible_launch_command": "exec codex -c model_reasoning_effort=high -C \"$LOOPX_PROJECT\" \"Planner role prompt\"",
-        "reasoning_effort": "high",
-        "lane_timeline": ["role_profile", "quota_guard", "frontier", "codex_tui"],
-    },
-    {
-        "lane_id": "critic",
-        "agent_id": "codex-side-bypass",
-        "role_id": "critic",
-        "responsibility": "Review the bounded step against the same todo and quota projection.",
-        "role_profile": {"schema_version": "generic_multi_agent_role_profile_v0", "role_id": "critic"},
-        "quota_guard": "loopx --format json --registry \"$LOOPX_REGISTRY\" --runtime-root \"$LOOPX_RUNTIME_ROOT\" quota should-run --goal-id loopx-meta --agent-id codex-side-bypass",
-        "frontier": "role-local state projection",
-        "bootstrap_message": "Critic role prompt",
-        "visible_launch_command": "exec codex -c model_reasoning_effort=high -C \"$LOOPX_PROJECT\" \"Critic role prompt\"",
-        "reasoning_effort": "high",
-        "lane_timeline": ["role_profile", "quota_guard", "frontier", "codex_tui"],
-    },
-]
-
-packet = build_visible_multi_agent_payload(
-    goal_id=goal_id,
-    session_name=session_name,
-    lanes=lanes,
-    tmux_bin="tmux",
-)
-packet.update({
-    "reasoning_contract": {
-        "default_reasoning_effort": "high",
-        "codex_cli_config_key": "model_reasoning_effort",
-    },
-    "shared_goal_surface": {
-        "shared_goal_id": goal_id,
-        "shared_state_route": "LOOPX_REGISTRY_and_LOOPX_RUNTIME_ROOT",
-        "shared_frontier": True,
-        "lane_identity_source": "role_profile_plus_agent_scoped_quota",
-        "all_lane_workspace_isolation": False,
-        "mutation_isolation_policy": "only mutating attempts require a claimed worktree or equivalent execution boundary",
-    },
-})
-
-launch_result = None
-if os.environ.get("SMOKE_EXECUTE") == "1":
-    launch_result, chosen, workspace_mode = execute_visible_multi_agent_launcher(
-        payload=packet,
-        registry=registry,
-        runtime_root=runtime_root,
-        requested_launcher="tmux",
-        tmux_bin="tmux",
-        cli_bin="loopx",
-        codex_bin="codex",
-        attach=False,
-        replace_existing=False,
-        workspace=str(workspace),
-        create_workspace=True,
-        cwd=cwd,
-    )
-    packet["mode"] = "execute"
-    packet["boundary"] = {
-        **packet["boundary"],
-        "starts_visible_processes": True,
-        "runs_agent_processes": True,
-    }
-else:
-    chosen = "dry_run_only"
-    workspace_mode = "not_created"
-
-print(json.dumps({
-    "schema_version": "generic_multi_agent_one_command_smoke_v0",
-    "chosen_launcher": chosen,
-    "workspace_mode": workspace_mode,
-    "packet": packet,
-    "launch_result": launch_result,
-}, sort_keys=True))
-'''
-
 
 def write_executable(path: Path, content: str) -> None:
     path.write_text(content, encoding="utf-8")
     path.chmod(0o755)
 
 
-def run_one_command(env: dict[str, str], *, execute: bool) -> dict[str, object]:
-    run_env = dict(env)
+def run_launch_command(
+    env: dict[str, str],
+    *,
+    spec_path: Path,
+    registry: Path,
+    runtime_root: Path,
+    workspace: Path,
+    execute: bool,
+) -> dict[str, object]:
+    command = [
+        sys.executable,
+        "-m",
+        "loopx.cli",
+        "--registry",
+        str(registry),
+        "--runtime-root",
+        str(runtime_root),
+        "--format",
+        "json",
+        "multi-agent",
+        "launch",
+        "--spec",
+        str(spec_path),
+        "--tmux-bin",
+        "tmux",
+        "--cli-bin",
+        "loopx",
+        "--codex-bin",
+        "codex",
+    ]
     if execute:
-        run_env["SMOKE_EXECUTE"] = "1"
+        command.extend(
+            [
+                "--execute",
+                "--workspace",
+                str(workspace),
+                "--create-workspace",
+                "--replace-existing",
+            ]
+        )
     completed = subprocess.run(
-        [sys.executable, "-c", ONE_COMMAND],
+        command,
         check=True,
         capture_output=True,
         text=True,
-        env=run_env,
+        env=env,
     )
     return json.loads(completed.stdout)
 
@@ -191,6 +124,49 @@ def main() -> int:
         tmux_log = temp / "tmux.jsonl"
         registry.write_text(json.dumps({"common_runtime_root": str(runtime_root)}), encoding="utf-8")
         runtime_root.mkdir()
+        worker_skill = temp / "worker" / "SKILL.md"
+        worker_skill.parent.mkdir()
+        worker_skill.write_text(
+            "# Planner Worker Skill\n\nUse LoopX todo/frontier state for handoff.\n",
+            encoding="utf-8",
+        )
+        spec_path = temp / "multi-agent-spec.json"
+        spec_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "generic_multi_agent_launch_spec_v0",
+                    "goal_id": "loopx-meta",
+                    "session_name": "loopx-generic-multi-agent-smoke",
+                    "default_reasoning_effort": "high",
+                    "roles": [
+                        {
+                            "lane_id": "planner",
+                            "agent_id": "codex-main-control",
+                            "role_id": "planner",
+                            "scope": "Plan the next bounded step from the shared goal surface.",
+                            "skill": {
+                                "name": "loopx-planner-worker",
+                                "source": "worker/SKILL.md",
+                            },
+                            "handoff_hints": [
+                                "Create or update a LoopX todo for critic when a plan needs review."
+                            ],
+                        },
+                        {
+                            "lane_id": "critic",
+                            "agent_id": "codex-side-bypass",
+                            "role_id": "critic",
+                            "scope": "Review the bounded step against the same todo and quota projection.",
+                            "handoff_hints": [
+                                "Complete the review todo or hand a focused fix todo back to planner."
+                            ],
+                        },
+                    ],
+                },
+                sort_keys=True,
+            ),
+            encoding="utf-8",
+        )
 
         write_executable(fake_bin / "loopx", "#!/usr/bin/env sh\nexit 0\n")
         write_executable(fake_bin / "codex", "#!/usr/bin/env sh\nexit 0\n")
@@ -202,18 +178,20 @@ def main() -> int:
                 "PATH": f"{fake_bin}{os.pathsep}{env.get('PATH', '')}",
                 "PYTHONPATH": f"{ROOT}{os.pathsep}{env.get('PYTHONPATH', '')}",
                 "FAKE_TMUX_LOG": str(tmux_log),
-                "SMOKE_CWD": str(temp),
-                "SMOKE_REGISTRY": str(registry),
-                "SMOKE_RUNTIME_ROOT": str(runtime_root),
-                "SMOKE_WORKSPACE": str(workspace),
             }
         )
 
-        dry_run = run_one_command(env, execute=False)
-        assert dry_run["schema_version"] == "generic_multi_agent_one_command_smoke_v0", dry_run
-        assert dry_run["chosen_launcher"] == "dry_run_only", dry_run
-        dry_packet = dry_run["packet"]
+        dry_packet = run_launch_command(
+            env,
+            spec_path=spec_path,
+            registry=registry,
+            runtime_root=runtime_root,
+            workspace=workspace,
+            execute=False,
+        )
         assert dry_packet["mode"] == "dry_run", dry_packet
+        assert dry_packet["product_spec"]["schema_version"] == "generic_multi_agent_launch_spec_v0", dry_packet
+        assert dry_packet["product_spec"]["domain_specific"] is False, dry_packet
         assert dry_packet["reasoning_contract"]["default_reasoning_effort"] == "high", dry_packet
         assert dry_packet["shared_goal_surface"]["shared_state_route"] == "LOOPX_REGISTRY_and_LOOPX_RUNTIME_ROOT", dry_packet
         assert dry_packet["shared_goal_surface"]["all_lane_workspace_isolation"] is False, dry_packet
@@ -225,14 +203,20 @@ def main() -> int:
         assert dry_packet["boundary"]["starts_visible_processes"] is False, dry_packet
         assert dry_packet["boundary"]["spends_loopx_quota"] is False, dry_packet
         assert all(lane["reasoning_effort"] == "high" for lane in dry_packet["lanes"]), dry_packet
-        assert dry_run["launch_result"] is None, dry_run
+        assert any(lane["role_profile"].get("required_skill") == "loopx-planner-worker" for lane in dry_packet["lanes"]), dry_packet
         assert_public_safe(dry_packet, "dry-run packet")
 
-        executed = run_one_command(env, execute=True)
-        assert executed["chosen_launcher"] == "tmux", executed
-        assert executed["workspace_mode"] == "explicit_workspace", executed
-        exec_packet = executed["packet"]
-        launch = executed["launch_result"]
+        exec_packet = run_launch_command(
+            env,
+            spec_path=spec_path,
+            registry=registry,
+            runtime_root=runtime_root,
+            workspace=workspace,
+            execute=True,
+        )
+        assert exec_packet["chosen_launcher"] == "tmux", exec_packet
+        assert exec_packet["workspace_mode"] == "explicit_workspace", exec_packet
+        launch = exec_packet["launch_result"]
         assert exec_packet["mode"] == "execute", exec_packet
         assert exec_packet["boundary"]["starts_visible_processes"] is True, exec_packet
         assert exec_packet["boundary"]["writes_loopx_state"] is False, exec_packet
@@ -244,9 +228,12 @@ def main() -> int:
         assert all(
             item["interactive_codex_tui_script"] for item in launch["visible_acceptance"]["pane_checks"]
         ), launch
-        assert_public_safe(exec_packet, "execute packet")
+        skill_items = launch["worker_skill_materialization"]
+        assert skill_items and skill_items[0]["materialized"] is True, launch
+        assert (workspace / ".codex" / "skills" / "loopx-planner-worker" / "SKILL.md").is_file()
         assert_public_safe(
             {
+                "product_spec": exec_packet["product_spec"],
                 "schema_version": launch["schema_version"],
                 "launcher": launch["launcher"],
                 "started_lanes": launch["started_lanes"],

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -34,6 +34,7 @@ from .cli_commands import (
     handle_history_command,
     handle_lark_kanban_command,
     handle_ml_experiment_command,
+    handle_multi_agent_command,
     handle_project_lifecycle_command,
     handle_pr_review_command,
     handle_quota_command,
@@ -56,6 +57,7 @@ from .cli_commands import (
     register_history_command,
     register_lark_kanban_commands,
     register_ml_experiment_commands,
+    register_multi_agent_commands,
     register_project_lifecycle_commands,
     register_pr_review_command,
     register_quota_command,
@@ -139,6 +141,8 @@ def main(argv: list[str] | None = None) -> int:
     register_ml_experiment_commands(sub, add_subcommand_format)
 
     register_auto_research_commands(sub, add_subcommand_format)
+
+    register_multi_agent_commands(sub, add_subcommand_format)
 
     register_registry_admin_commands(sub)
 
@@ -262,6 +266,16 @@ def main(argv: list[str] | None = None) -> int:
             output_format=output_format,
             print_payload=print_payload,
         )
+
+    multi_agent_result = handle_multi_agent_command(
+        args,
+        registry_path=registry_path,
+        runtime_root_arg=args.runtime_root,
+        output_format=output_format,
+        print_payload=print_payload,
+    )
+    if multi_agent_result is not None:
+        return multi_agent_result
 
     if args.command == "content-ops":
         return handle_content_ops_command(args, output_format=output_format, print_payload=print_payload)

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -83,6 +83,7 @@ from .dreaming import handle_dreaming_command, register_dreaming_commands
 from .history import handle_history_command, register_history_command
 from .lark_kanban import handle_lark_kanban_command, register_lark_kanban_commands
 from .ml_experiment import handle_ml_experiment_command, register_ml_experiment_commands
+from .multi_agent import handle_multi_agent_command, register_multi_agent_commands
 from .project_lifecycle import (
     handle_project_lifecycle_command,
     register_project_lifecycle_commands,
@@ -206,6 +207,7 @@ __all__ = [
     "handle_history_command",
     "handle_lark_kanban_command",
     "handle_ml_experiment_command",
+    "handle_multi_agent_command",
     "handle_new_project_prompt_command",
     "handle_project_lifecycle_command",
     "handle_pr_review_command",
@@ -251,6 +253,7 @@ __all__ = [
     "register_history_command",
     "register_lark_kanban_commands",
     "register_ml_experiment_commands",
+    "register_multi_agent_commands",
     "register_project_lifecycle_commands",
     "register_pr_review_command",
     "register_quota_command",

--- a/loopx/cli_commands/multi_agent.py
+++ b/loopx/cli_commands/multi_agent.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import argparse
+import json
+from collections.abc import Callable
+from pathlib import Path
+
+from ..history import load_registry
+from ..paths import resolve_runtime_root
+from ..visible_multi_agent_launcher import (
+    build_visible_multi_agent_payload_from_spec,
+    execute_visible_multi_agent_launcher,
+)
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+FormatSelector = Callable[..., str]
+AddFormat = Callable[[argparse.ArgumentParser], None]
+
+
+def register_multi_agent_commands(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: AddFormat,
+) -> None:
+    parser = subparsers.add_parser(
+        "multi-agent",
+        help="Launch visible Codex TUI agents from a small role spec.",
+    )
+    multi_agent_sub = parser.add_subparsers(dest="multi_agent_command", required=True)
+    launch = multi_agent_sub.add_parser(
+        "launch",
+        help="Preview or launch a tmux session with one interactive Codex TUI per role.",
+    )
+    add_subcommand_format(launch)
+    launch.add_argument("--spec", required=True, help="Path to a generic_multi_agent_launch_spec_v0 JSON file.")
+    launch.add_argument("--execute", action="store_true", help="Start the visible TUI session. Omit for preview.")
+    launch.add_argument("--workspace", help="Workspace root for all lanes. Defaults to the current directory.")
+    launch.add_argument("--create-workspace", action="store_true", help="Create --workspace if it is missing.")
+    launch.add_argument("--session-name", help="Override spec.session_name.")
+    launch.add_argument("--reasoning-effort", help="Override spec.default_reasoning_effort.")
+    launch.add_argument("--launcher", choices=["auto", "tmux"], default="tmux")
+    launch.add_argument("--tmux-bin", default="tmux")
+    launch.add_argument("--cli-bin", default="loopx")
+    launch.add_argument("--codex-bin", default="codex")
+    launch.add_argument("--attach", action="store_true", help="Attach to the session after launch.")
+    launch.add_argument("--replace-existing", action="store_true", help="Replace an existing session of the same name.")
+    launch.add_argument(
+        "--codex-trust-workspace",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Pass a trusted project config to each Codex TUI lane.",
+    )
+
+
+def _load_spec(path: Path) -> dict[str, object]:
+    with path.open(encoding="utf-8") as handle:
+        value = json.load(handle)
+    if not isinstance(value, dict):
+        raise ValueError("multi-agent spec must be a JSON object")
+    return value
+
+
+def _render_multi_agent_launch_markdown(payload: dict[str, object]) -> str:
+    if not payload.get("ok"):
+        return f"LoopX multi-agent launch failed: {payload.get('error')}"
+    lanes = [lane for lane in payload.get("lanes", []) if isinstance(lane, dict)]
+    lines = [
+        "# LoopX Multi-Agent Launch",
+        f"- mode: {payload.get('mode')}",
+        f"- goal: {payload.get('goal_id')}",
+        f"- session: {payload.get('session_name')}",
+        f"- roles: {len(lanes)}",
+    ]
+    for lane in lanes:
+        lines.append(
+            f"- {lane.get('lane_id')}: {lane.get('role_id')} "
+            f"({lane.get('agent_id')})"
+        )
+    commands = payload.get("commands") if isinstance(payload.get("commands"), dict) else {}
+    if commands.get("attach"):
+        lines.append("")
+        lines.append(f"attach: `{commands.get('attach')}`")
+    launch_result = payload.get("launch_result")
+    if isinstance(launch_result, dict):
+        accepted = (
+            launch_result.get("visible_acceptance", {})
+            if isinstance(launch_result.get("visible_acceptance"), dict)
+            else {}
+        )
+        lines.append("")
+        lines.append(f"visible accepted: {accepted.get('accepted')}")
+        lines.append(f"started lanes: {', '.join(str(item) for item in launch_result.get('started_lanes', []))}")
+    return "\n".join(lines)
+
+
+def handle_multi_agent_command(
+    args: argparse.Namespace,
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    output_format: FormatSelector,
+    print_payload: PrintPayload,
+) -> int | None:
+    if args.command != "multi-agent":
+        return None
+    try:
+        if args.multi_agent_command != "launch":
+            raise ValueError("multi-agent requires the `launch` subcommand")
+        spec_path = Path(args.spec).expanduser()
+        spec = _load_spec(spec_path)
+        if args.session_name:
+            spec = {**spec, "session_name": args.session_name}
+        if args.reasoning_effort:
+            spec = {**spec, "default_reasoning_effort": args.reasoning_effort}
+        payload = build_visible_multi_agent_payload_from_spec(
+            spec,
+            tmux_bin=args.tmux_bin,
+            cli_bin=args.cli_bin,
+            codex_bin=args.codex_bin,
+        )
+        if args.execute:
+            registry = load_registry(registry_path)
+            runtime_root = resolve_runtime_root(registry, runtime_root_arg)
+            launch_result, chosen, workspace_mode = execute_visible_multi_agent_launcher(
+                payload=payload,
+                registry=registry_path,
+                runtime_root=runtime_root,
+                requested_launcher=args.launcher,
+                tmux_bin=args.tmux_bin,
+                cli_bin=args.cli_bin,
+                codex_bin=args.codex_bin,
+                attach=bool(args.attach),
+                replace_existing=bool(args.replace_existing),
+                workspace=args.workspace,
+                create_workspace=bool(args.create_workspace),
+                cwd=Path.cwd(),
+                codex_trust_workspace=bool(args.codex_trust_workspace),
+                source_root=spec_path.parent,
+            )
+            payload["mode"] = "execute"
+            payload["chosen_launcher"] = chosen
+            payload["workspace_mode"] = workspace_mode
+            payload["launch_result"] = launch_result
+            payload["boundary"] = {
+                **payload["boundary"],
+                "starts_visible_processes": True,
+                "runs_agent_processes": True,
+            }
+    except Exception as exc:
+        payload = {"ok": False, "mode": "multi-agent", "error": str(exc)}
+    print_payload(payload, output_format(args), _render_multi_agent_launch_markdown)
+    return 0 if payload.get("ok") else 1

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import shlex
 import shutil
@@ -322,6 +323,222 @@ def build_visible_multi_agent_payload(
     }
 
 
+def _as_string_list(value: object) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value.strip()] if value.strip() else []
+    if isinstance(value, Iterable):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return [str(value).strip()] if str(value).strip() else []
+
+
+def _role_skill_profile(skill: object) -> dict[str, str]:
+    if not skill:
+        return {}
+    if isinstance(skill, str):
+        source = skill.strip()
+        if not source:
+            return {}
+        name = Path(source).parent.name or Path(source).stem or "worker-skill"
+        return {"required_skill": name, "worker_skill_source": source}
+    if not isinstance(skill, dict):
+        return {}
+    name = str(skill.get("name") or skill.get("skill_name") or "").strip()
+    source = str(skill.get("source") or skill.get("path") or "").strip()
+    if not name and source:
+        name = Path(source).parent.name or Path(source).stem
+    if not name or not source:
+        return {}
+    return {"required_skill": name, "worker_skill_source": source}
+
+
+def _generic_role_prompt(
+    *,
+    goal_id: str,
+    agent_id: str,
+    role_id: str,
+    scope: str,
+    handoff_hints: list[str],
+    skill_name: str | None,
+) -> str:
+    lines = [
+        "LoopX multi-agent role",
+        f"Goal: {goal_id}",
+        f"Agent: {agent_id}",
+        f"Role: {role_id}",
+    ]
+    if scope:
+        lines.extend(["", "Scope:", scope])
+    if skill_name:
+        lines.extend(["", "Local skill:", f"Use ${skill_name} when it applies to this role."])
+    lines.extend(
+        [
+            "",
+            "How to work:",
+            "- Treat LoopX state as the shared A2A surface.",
+            "- Start by reading your agent-scoped todo/quota/frontier with $LOOPX_PANE_LOOPX.",
+            "- Keep machine JSON redirected through $LOOPX_PANE_LOOPX_JSON into .local artifacts.",
+            "- Write compact public-safe evidence before completing or handing off a todo.",
+            "- The user may type into this pane; respond like a normal Codex CLI agent.",
+        ]
+    )
+    if handoff_hints:
+        lines.append("")
+        lines.append("Handoff hints:")
+        lines.extend(f"- {hint}" for hint in handoff_hints)
+    return "\n".join(lines)
+
+
+def build_visible_multi_agent_payload_from_spec(
+    spec: dict[str, object],
+    *,
+    tmux_bin: str = "tmux",
+    cli_bin: str = "loopx",
+    codex_bin: str = "codex",
+) -> dict[str, object]:
+    """Build a visible launcher packet from a small user-facing role spec."""
+
+    if not isinstance(spec, dict):
+        raise ValueError("multi-agent launch spec must be an object")
+    goal_id = str(spec.get("goal_id") or "").strip()
+    if not goal_id:
+        raise ValueError("multi-agent launch spec requires goal_id")
+    roles = spec.get("roles") or spec.get("agents") or spec.get("lanes")
+    if not isinstance(roles, list) or not roles:
+        raise ValueError("multi-agent launch spec requires a non-empty roles list")
+    session_name = str(spec.get("session_name") or f"loopx-{_script_slug(goal_id)}-agents")
+    default_reasoning_effort = str(
+        spec.get("default_reasoning_effort") or spec.get("reasoning_effort") or "high"
+    )
+    lanes: list[dict[str, object]] = []
+    for index, raw_role in enumerate(roles, start=1):
+        if not isinstance(raw_role, dict):
+            raise ValueError(f"role #{index} must be an object")
+        agent_id = str(raw_role.get("agent_id") or "").strip()
+        if not agent_id:
+            raise ValueError(f"role #{index} requires agent_id")
+        lane_id = str(raw_role.get("lane_id") or raw_role.get("role_id") or agent_id).strip()
+        role_id = str(raw_role.get("role_id") or lane_id).strip()
+        scope = str(
+            raw_role.get("scope")
+            or raw_role.get("agent_scope")
+            or raw_role.get("responsibility")
+            or ""
+        ).strip()
+        responsibility = str(raw_role.get("responsibility") or scope or role_id).strip()
+        handoff_hints = _as_string_list(
+            raw_role.get("handoff")
+            or raw_role.get("handoff_hints")
+            or raw_role.get("interaction_hints")
+        )
+        skill_profile = _role_skill_profile(raw_role.get("skill"))
+        reasoning_effort = str(raw_role.get("reasoning_effort") or default_reasoning_effort)
+        role_profile = {
+            "schema_version": "generic_multi_agent_role_profile_v0",
+            "role_id": role_id,
+            "agent_id": agent_id,
+            "agent_scope": scope,
+            "responsibility": responsibility,
+            "handoff_hints": handoff_hints,
+        }
+        role_profile.update(skill_profile)
+        lane_slug = _script_slug(lane_id)
+        role_profile_json = json.dumps(role_profile, ensure_ascii=False, sort_keys=True)
+        role_profile_command = (
+            "mkdir -p \"$LOOPX_VISIBLE_ARTIFACT_DIR\"; "
+            f"printf '%s\\n' {_q(role_profile_json)} "
+            f"> \"$LOOPX_VISIBLE_ARTIFACT_DIR/{lane_slug}.role-profile.public.json\"; "
+        )
+        prompt = _generic_role_prompt(
+            goal_id=goal_id,
+            agent_id=agent_id,
+            role_id=role_id,
+            scope=scope,
+            handoff_hints=handoff_hints,
+            skill_name=skill_profile.get("required_skill"),
+        )
+        bootstrap_command = f"printf '%s\\n' {_q(prompt)}"
+        lane = {
+            "lane_id": lane_id,
+            "agent_id": agent_id,
+            "role_id": role_id,
+            "responsibility": responsibility,
+            "agent_scope": scope,
+            "handoff_hints": handoff_hints,
+            "role_profile": role_profile,
+            "role_profile_ref": f"generic_multi_agent_launch_spec_v0:{role_id}",
+            "quota_guard": (
+                "$LOOPX_PANE_LOOPX_JSON quota should-run "
+                f"--goal-id {_q(goal_id)} --agent-id {_q(agent_id)} "
+                f"> .local/{lane_slug}/quota.public.json"
+            ),
+            "frontier": "agent-scoped LoopX todo/quota/frontier projection",
+            "bootstrap_message": "role_prompt_inside_codex_tui",
+            "visible_launch_command": build_visible_lane_command(
+                role_id=role_id,
+                role_profile_ref=f"generic_multi_agent_launch_spec_v0:{role_id}",
+                role_profile_command=role_profile_command,
+                bootstrap_command=bootstrap_command,
+                codex_bin=codex_bin,
+                reasoning_effort=reasoning_effort,
+            ),
+            "reasoning_effort": reasoning_effort,
+            "lane_timeline": ["role_profile", "quota_guard", "frontier", "codex_tui"],
+        }
+        if raw_role.get("workspace") or raw_role.get("project"):
+            lane["workspace"] = str(raw_role.get("workspace") or raw_role.get("project"))
+        lanes.append(lane)
+
+    packet = build_visible_multi_agent_payload(
+        goal_id=goal_id,
+        session_name=session_name,
+        lanes=lanes,
+        tmux_bin=tmux_bin,
+    )
+    packet.update(
+        {
+            "product_spec": {
+                "schema_version": "generic_multi_agent_launch_spec_v0",
+                "input_shape": ["goal_id", "session_name", "roles"],
+                "role_fields": [
+                    "agent_id",
+                    "role_id",
+                    "scope",
+                    "skill",
+                    "handoff_hints",
+                    "reasoning_effort",
+                ],
+                "role_count": len(lanes),
+                "uses_generic_runner": True,
+                "domain_specific": False,
+            },
+            "reasoning_contract": {
+                "default_reasoning_effort": default_reasoning_effort,
+                "codex_cli_config_key": "model_reasoning_effort",
+            },
+            "shared_goal_surface": {
+                "shared_goal_id": goal_id,
+                "shared_state_route": "LOOPX_REGISTRY_and_LOOPX_RUNTIME_ROOT",
+                "shared_frontier": True,
+                "lane_identity_source": "role_profile_plus_agent_scoped_quota",
+                "all_lane_workspace_isolation": any("workspace" in lane for lane in lanes),
+                "mutation_isolation_policy": (
+                    "mutating attempts require agent-scoped todo/frontier and a claimed "
+                    "worktree or equivalent execution boundary"
+                ),
+            },
+            "cli_contract": {
+                "cli_bin": cli_bin,
+                "codex_bin": codex_bin,
+                "tmux_bin": tmux_bin,
+                "machine_json_policy": "artifact_only_in_visible_panes",
+            },
+        }
+    )
+    return packet
+
+
 def _materialize_worker_skills(
     *,
     payload: dict[str, object],
@@ -437,6 +654,7 @@ def execute_visible_multi_agent_launcher(
     create_workspace: bool,
     cwd: Path,
     codex_trust_workspace: bool = False,
+    source_root: Path | None = None,
     launch_result_schema: str = "multi_agent_visible_launch_result_v0",
     acceptance_schema: str = "multi_agent_visible_launch_acceptance_v0",
     lane_default: str = "agent-lane",
@@ -448,7 +666,7 @@ def execute_visible_multi_agent_launcher(
     worker_skills = _materialize_worker_skills(
         payload=payload,
         project=project,
-        source_root=cwd,
+        source_root=source_root or cwd,
     )
     worker_skill_errors = _worker_skill_materialization_errors(worker_skills)
     if worker_skill_errors:


### PR DESCRIPTION
## Summary
- add `loopx multi-agent launch --spec` for previewing or launching visible Codex TUI roles from a small generic role spec
- add a spec-to-visible-launcher builder that maps roles, scope, worker-local skills, and handoff hints into the existing tmux/Codex TUI packet
- update the generic launcher smoke and protocol docs so auto research can be one product example instead of owning the multi-agent runner shape

## Validation
- `python3 -m py_compile loopx/visible_multi_agent_launcher.py loopx/cli_commands/multi_agent.py loopx/cli.py examples/generic-multi-agent-one-command-smoke.py examples/cli-multi-agent-command-modularization-smoke.py`
- `python3 examples/cli-multi-agent-command-modularization-smoke.py`
- `python3 examples/generic-multi-agent-one-command-smoke.py`
- `python3 examples/visible-multi-agent-launcher-smoke.py`
- `python3 examples/multi-agent-visible-launcher-protocol-smoke.py`
- `loopx --format json check` (passes; existing duplicate-index warning only)

## Boundary
- no raw machine JSON is printed before Codex TUI startup; visible panes remain interactive Codex CLI windows
- worker-local skill paths are resolved relative to the spec file and materialized into lane workspaces
- launcher packet remains read-only for LoopX state and quota; actual writeback still belongs to agent lanes
