### PR TITLE
Fix SkillsBench xhigh app-server turn id drift

### DIFF
--- a/examples/codex-app-server-goal-driver-smoke.py
+++ b/examples/codex-app-server-goal-driver-smoke.py
@@ -41,6 +41,79 @@ for line in sys.stdin:
             }), flush=True)
             continue
         prompt_text = msg.get("params", {}).get("input", [{}])[0].get("text", "")
+        if "response-turn-id drift" in prompt_text:
+            result = {"turn": {"id": "turn-response-placeholder", "status": "running"}}
+            print(json.dumps({"id": mid, "result": result}), flush=True)
+            print(json.dumps({
+                "method": "turn/started",
+                "params": {
+                    "threadId": "thread-smoke",
+                    "turn": {"id": "turn-event-canonical", "status": "inProgress"},
+                },
+            }), flush=True)
+            print(json.dumps({
+                "method": "item/started",
+                "params": {
+                    "threadId": "thread-smoke",
+                    "turnId": "turn-event-canonical",
+                    "item": {
+                        "id": "user-item-drift-smoke",
+                        "type": "userMessage",
+                        "content": [{"type": "text", "text": prompt_text}],
+                    },
+                },
+            }), flush=True)
+            print(json.dumps({
+                "method": "item/completed",
+                "params": {
+                    "threadId": "thread-smoke",
+                    "turnId": "turn-event-canonical",
+                    "item": {
+                        "id": "user-item-drift-smoke",
+                        "type": "userMessage",
+                        "content": [{"type": "text", "text": prompt_text}],
+                    },
+                },
+            }), flush=True)
+            print(json.dumps({
+                "method": "item/started",
+                "params": {
+                    "threadId": "thread-smoke",
+                    "turnId": "turn-event-canonical",
+                    "item": {
+                        "id": "command-item-drift-smoke",
+                        "type": "commandExecution",
+                    },
+                },
+            }), flush=True)
+            print(json.dumps({
+                "method": "item/completed",
+                "params": {
+                    "threadId": "thread-smoke",
+                    "turnId": "turn-event-canonical",
+                    "item": {
+                        "id": "command-item-drift-smoke",
+                        "type": "commandExecution",
+                    },
+                },
+            }), flush=True)
+            print(json.dumps({
+                "method": "item/agentMessage/delta",
+                "params": {
+                    "threadId": "thread-smoke",
+                    "turnId": "turn-event-canonical",
+                    "itemId": "item-drift-smoke",
+                    "delta": "Drift final answer.",
+                },
+            }), flush=True)
+            print(json.dumps({
+                "method": "turn/completed",
+                "params": {
+                    "threadId": "thread-smoke",
+                    "turn": {"id": "turn-event-canonical", "status": "completed"},
+                },
+            }), flush=True)
+            continue
         if "event-style completion" in prompt_text:
             result = {"turn": {"id": "turn-event-msg-smoke", "status": "running"}}
             print(json.dumps({"id": mid, "result": result}), flush=True)
@@ -250,6 +323,31 @@ def main() -> int:
             assert compact["assistant_message_present"] is True, compact
         finally:
             xhigh_turn.terminate()
+
+        drift_turn = module.start_codex_app_server_goal_turn(
+            codex_bin=str(fake),
+            work_dir=root / "work-turn-id-drift",
+            objective="Synthetic objective.",
+            prompt="Synthetic response-turn-id drift prompt.",
+            model_name="gpt-5.5",
+            reasoning_effort="xhigh",
+            response_timeout_sec=5,
+            wait_for_completion=True,
+            turn_timeout_sec=5,
+        )
+        try:
+            assert drift_turn.turn_id == "turn-event-canonical", drift_turn
+            assert drift_turn.assistant_message == "Drift final answer."
+            compact = module.compact_turn_metadata(drift_turn)
+            assert compact["turn_id_source"] == "event_stream", compact
+            assert compact["turn_start_response_turn_id_present"] is True, compact
+            assert compact["turn_event_stream_turn_id_present"] is True, compact
+            assert compact["turn_completed_observed"] is True, compact
+            assert compact["assistant_message_present"] is True, compact
+            assert compact["non_user_item_completed_count"] >= 1, compact
+            assert "Drift final answer." not in json.dumps(compact), compact
+        finally:
+            drift_turn.terminate()
 
         event_completed_turn = module.start_codex_app_server_goal_turn(
             codex_bin=str(fake),

--- a/scripts/codex_app_server_goal_driver.py
+++ b/scripts/codex_app_server_goal_driver.py
@@ -379,6 +379,21 @@ def _record_turn_event(
         return False
     msg_turn_id = _notification_turn_id(params)
     msg_thread_id = _notification_thread_id(params)
+    if (
+        method == "turn/started"
+        and msg_turn_id
+        and msg_turn_id != turn.turn_id
+        and turn.turn_id_source == "turn_start_response"
+        and turn.turn_start_response_turn_id_present
+        and not turn.turn_event_stream_turn_id_present
+    ):
+        # Some app-server/model paths return a placeholder turn id in the
+        # turn/start response, then stream the real turn id on turn/started.
+        # Treat the streamed id as canonical so subsequent item/turn events are
+        # not filtered out as belonging to an unrelated turn.
+        turn.turn_id = msg_turn_id
+        turn.turn_id_source = "event_stream"
+        turn.turn_event_stream_turn_id_present = True
     if msg_turn_id and msg_turn_id != turn.turn_id:
         return False
     if msg_thread_id and msg_thread_id != turn.thread_id:


### PR DESCRIPTION
## Summary
- handle app-server `turn/start` response ids that differ from the streamed `turn/started` id
- promote the streamed id to the canonical turn id so later item/completed, command execution, assistant, and turn/completed events are not filtered out
- add a driver smoke for response-id/event-id drift with xhigh effort

## Validation
- `python3 -m py_compile scripts/codex_app_server_goal_driver.py examples/codex-app-server-goal-driver-smoke.py`
- `python3 examples/codex-app-server-goal-driver-smoke.py`
- `python3 examples/skillsbench-app-server-goal-worker-smoke.py`
- targeted `examples/skillsbench-benchmark-run-smoke.py::test_skillsbench_round_trace_records_best_round_score`
- local app-server xhigh protocol probe observed command execution and completed assistant output after this fix
