### PR TITLE
Add pane-local A2A tick for visible agents

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -51,7 +51,9 @@ def main() -> int:
     assert "read that local JSON profile" not in bootstrap_source
     assert "Do not print, cat, or sed `$LOOPX_ROLE_PROFILE_PATH`" in bootstrap_source
     assert "Do not run `--help`" in bootstrap_source
-    assert "worker-turn preview/execute as the human-facing polling command" in bootstrap_source
+    assert "prefer `$LOOPX_PANE_A2A_TICK` as the human-facing polling command" in bootstrap_source
+    assert '"$LOOPX_PANE_A2A_TICK"' in bootstrap_source
+    assert "LOOPX_PANE_WORKER_TURN" in bootstrap_source
     assert "rewrites accidental visible `--format json` to markdown" in bootstrap_source
     assert "$LOOPX_PANE_LOOPX_JSON ... --format json > .local/<role>/<name>.public.json" in bootstrap_source
 

--- a/examples/auto-research-demo-supervisor-smoke.py
+++ b/examples/auto-research-demo-supervisor-smoke.py
@@ -110,6 +110,12 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
         assert "Do not run loopx bootstrap-command-pack" in lane["bootstrap_message"], lane
         assert "codex-cli-bootstrap-message" not in lane["bootstrap_message"], lane
         assert "Minimal live worker-turn path" in lane["bootstrap_message"], lane
+        assert "$LOOPX_PANE_A2A_TICK" in lane["bootstrap_message"], lane
+        assert "LOOPX_PANE_A2A_TICK" in lane["visible_launch_command"], lane
+        assert "LOOPX_PANE_WORKER_TURN" in lane["visible_launch_command"], lane
+        assert lane["pane_local_a2a"]["tick_command"] == "$LOOPX_PANE_A2A_TICK", lane
+        assert lane["pane_local_a2a"]["worker_turn_configured"] is True, lane
+        assert lane["pane_local_a2a"]["stream_surface"] == "codex_cli_tui", lane
         assert "auto-research worker-turn" in lane["bootstrap_message"], lane
         assert "--complete-selected-todo" in lane["bootstrap_message"], lane
         assert "$LOOPX_PANE_LOOPX" in lane["bootstrap_message"], lane
@@ -138,10 +144,12 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
             "quota_guard",
             "frontier_projection",
             "bootstrap_prompt",
+            "pane_local_a2a_tick",
             "visible_codex",
         ], lane
         assert lane["lane_timeline"][0]["command_ref"] == "role_profile", lane
         assert lane["lane_timeline"][1]["command_ref"] == "quota_guard", lane
+        assert lane["lane_timeline"][4]["command_ref"] == "$LOOPX_PANE_A2A_TICK", lane
         assert "operator is attached" in lane["lane_timeline"][-1]["continue_when"], lane
     expected_action_hints = {
         "research_curator": "`write_research_contract`",

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -19,6 +19,7 @@ sys.path.insert(0, str(ROOT))
 from loopx.visible_multi_agent_launcher import (  # noqa: E402
     _SCOPED_LOOPX_WRAPPER_PY,
     build_visible_multi_agent_payload,
+    build_visible_multi_agent_payload_from_spec,
     execute_visible_multi_agent_launcher,
 )
 
@@ -86,6 +87,9 @@ def main() -> int:
     assert "demo_local_wrapper" not in launcher_source
     assert "scoped_loopx_wrapper" in launcher_source
     assert "LOOPX_PANE_LOOPX_JSON" in launcher_source
+    assert "LOOPX_PANE_A2A_TICK" in launcher_source
+    assert "loopx-pane-a2a-tick" in launcher_source
+    assert "LOOPX_PANE_WORKER_TURN" in launcher_source
     assert "LOOPX_VISIBLE_FORCE_MARKDOWN" in launcher_source
     assert "format=markdown; machine_json_wrapper=$LOOPX_PANE_LOOPX_JSON" in launcher_source
     assert "LoopX machine JSON hidden" in launcher_source
@@ -131,6 +135,26 @@ def main() -> int:
     assert dry_packet["acceptance"]["codex_tui_interactive"] is True, dry_packet
     assert dry_packet["boundary"]["hidden_prompt_injection"] is False, dry_packet
     assert dry_packet["boundary"]["spends_loopx_quota"] is False, dry_packet
+
+    generic_packet = build_visible_multi_agent_payload_from_spec(
+        {
+            "goal_id": "loopx-meta",
+            "roles": [
+                {
+                    "agent_id": "codex-side-bypass",
+                    "role_id": "planner",
+                    "scope": "plan one state-backed handoff",
+                    "worker_turn_command": "printf 'turn streamed\\n'",
+                }
+            ],
+        }
+    )
+    generic_lane = generic_packet["lanes"][0]
+    assert generic_lane["pane_local_a2a"]["tick_command"] == "$LOOPX_PANE_A2A_TICK", generic_lane
+    assert generic_lane["pane_local_a2a"]["worker_turn_configured"] is True, generic_lane
+    assert "pane_local_a2a_tick" in generic_lane["lane_timeline"], generic_lane
+    assert "LOOPX_PANE_A2A_TICK" in generic_lane["visible_launch_command"], generic_lane
+    assert "LOOPX_PANE_WORKER_TURN" in generic_lane["visible_launch_command"], generic_lane
 
     with tempfile.TemporaryDirectory() as temp_dir:
         temp = Path(temp_dir)
@@ -239,6 +263,20 @@ def main() -> int:
                 [str(workspace / ".local/bin/loopx-json"), "--format", "json", "status"],
                 env=scoped_env,
             )
+            tick = subprocess.run(
+                [str(workspace / ".local/bin/loopx-pane-a2a-tick")],
+                env={
+                    **scoped_env,
+                    "LOOPX_PANE_LOOPX": str(workspace / ".local/bin/loopx"),
+                    "LOOPX_GOAL_ID": "loopx-meta",
+                    "LOOPX_AGENT_ID": "codex-side-bypass",
+                    "LOOPX_ROLE_ID": "planner",
+                    "LOOPX_PANE_WORKER_TURN": "printf 'worker turn streamed\\n'",
+                },
+                check=True,
+                capture_output=True,
+                text=True,
+            )
             assert "format=markdown; machine_json_wrapper=$LOOPX_PANE_LOOPX_JSON" in human.stdout, human.stdout
             assert "--format markdown status" in human.stdout, human.stdout
             assert visible_pipe.returncode == 2, visible_pipe.stdout
@@ -249,6 +287,10 @@ def main() -> int:
             assert tty_status == 2, tty_output
             assert "LoopX machine JSON hidden" in tty_output, tty_output
             assert "fake-loopx" not in tty_output, tty_output
+            assert "role=planner agent=codex-side-bypass" in tick.stdout, tick.stdout
+            assert "quota should-run" in tick.stdout, tick.stdout
+            assert "--format markdown" in tick.stdout, tick.stdout
+            assert "worker turn streamed" in tick.stdout, tick.stdout
 
             try:
                 execute_visible_multi_agent_launcher(

--- a/loopx/capabilities/auto_research/legacy_core.py
+++ b/loopx/capabilities/auto_research/legacy_core.py
@@ -948,16 +948,18 @@ def _auto_research_codex_bootstrap_prompt(
         "",
         "Minimal live worker-turn path:",
         f"1. Confirm the selected frontier action matches this role ({expected_actions}).",
-        "2. Confirm the pane-local wrapper exists: `test -x \"$LOOPX_PANE_LOOPX\"`.",
-        "3. Single-pane preview, using human-readable output. This command re-reads quota and frontier internally:",
+        "2. Confirm the pane-local A2A tick exists: `test -x \"$LOOPX_PANE_A2A_TICK\"`.",
+        "3. Preferred one-step visible turn, using human-readable output. This reads quota/frontier and then runs this role's worker-turn:",
+        "   `\"$LOOPX_PANE_A2A_TICK\"`",
+        "4. Manual single-pane preview, if the tick reports a blocker. This command re-reads quota and frontier internally:",
         "   `\"$LOOPX_PANE_LOOPX\" auto-research worker-turn --format markdown --goal-id \"$LOOPX_GOAL_ID\" --agent-id \"$LOOPX_AGENT_ID\"`",
-        "4. Single-pane execute, only when the preview selected this lane:",
+        "5. Manual single-pane execute, only when the preview selected this lane:",
         "   `\"$LOOPX_PANE_LOOPX\" auto-research worker-turn --format markdown --goal-id \"$LOOPX_GOAL_ID\" --agent-id \"$LOOPX_AGENT_ID\" --lane-count \"${LOOPX_VISIBLE_LANE_COUNT:-1}\" --visible-lanes-accepted --complete-selected-todo --execute`",
-        "5. Local multi-lane driver, when this pane is acting as the visible supervisor:",
+        "6. Local multi-lane driver, when this pane is acting as the visible supervisor:",
         "   `\"$LOOPX_PANE_LOOPX\" auto-research worker-loop --format markdown --goal-id \"$LOOPX_GOAL_ID\" $LOOPX_WORKER_LOOP_AGENT_ARGS --lane-count \"${LOOPX_VISIBLE_LANE_COUNT:-1}\" --visible-lanes-accepted --complete-selected-todo --execute`",
-        "6. Stop after the selected command reports executed/completed turns and no runnable frontier.",
-        "7. For evidence-runner, additionally require appended evidence and live_evidence.written=true.",
-        "8. Do not run `--help` or full quota/status dumps on the first screen; if deep debugging is needed, use `$LOOPX_PANE_LOOPX_JSON ... --format json > .local/<role>/<name>.public.json` and print a short summary.",
+        "7. Stop after the selected command reports executed/completed turns and no runnable frontier.",
+        "8. For evidence-runner, additionally require appended evidence and live_evidence.written=true.",
+        "9. Do not run `--help` or full quota/status dumps on the first screen; if deep debugging is needed, use `$LOOPX_PANE_LOOPX_JSON ... --format json > .local/<role>/<name>.public.json` and print a short summary.",
     ]
     return "\n".join(
         [
@@ -968,7 +970,7 @@ def _auto_research_codex_bootstrap_prompt(
             "Use only the pane-local human LoopX wrapper: `$LOOPX_PANE_LOOPX`. Do not call bare `loopx` or an absolute LoopX binary; those can hit the wrong registry and make this demo goal look missing.",
             "The human wrapper has this demo's registry/runtime baked in and rewrites accidental visible `--format json` to markdown. If `$LOOPX_PANE_LOOPX` is unset or not executable, stop and report that blocker instead of falling back.",
             "Visible panes are for human observation: run worker-turn and worker-loop with `--format markdown`. If machine JSON is needed, use `$LOOPX_PANE_LOOPX_JSON ... --format json > .local/<role>/<name>.public.json` and print only a compact summary.",
-            "This pane is a visible LoopX polling turn: use worker-turn preview/execute as the human-facing polling command; it re-reads quota and frontier internally.",
+            "This pane is a visible LoopX polling turn: prefer `$LOOPX_PANE_A2A_TICK` as the human-facing polling command; it re-reads quota/frontier and streams the worker-turn result in this Codex TUI.",
             "Avoid `--help` probes and full quota/status dumps in the visible pane unless you are explaining a blocker.",
             "Do not run loopx bootstrap-command-pack, loopx heartbeat-prompt, or generic onboarding unless the role-local worker-turn/frontier result explicitly asks for it.",
             "If a future scheduled automation owns this lane, it must use a generated LoopX heartbeat/polling prompt; this visible bootstrap is the local manual polling prompt.",
@@ -1097,6 +1099,15 @@ def _role_profile_shell_prefix(role_profile: dict[str, Any]) -> str:
     )
 
 
+def _auto_research_pane_worker_turn_command() -> str:
+    return (
+        '"$LOOPX_PANE_LOOPX" auto-research worker-turn --format markdown '
+        '--goal-id "$LOOPX_GOAL_ID" --agent-id "$LOOPX_AGENT_ID" '
+        '--lane-count "${LOOPX_VISIBLE_LANE_COUNT:-1}" '
+        "--visible-lanes-accepted --complete-selected-todo --execute"
+    )
+
+
 def _env_lane_launch_command(
     *,
     role_id: str,
@@ -1112,6 +1123,9 @@ def _env_lane_launch_command(
         bootstrap_command=bootstrap_command,
         codex_bin=codex_bin,
         reasoning_effort=reasoning_effort,
+        goal_id=str(role_profile.get("goal_id") or ""),
+        agent_id=str(role_profile.get("agent_id") or ""),
+        worker_turn_command=_auto_research_pane_worker_turn_command(),
     )
 
 
@@ -1197,6 +1211,12 @@ def build_auto_research_demo_supervisor_plan(
                 "window_name": lane_id,
                 "quota_guard": quota_command,
                 "frontier": frontier_command,
+                "pane_local_a2a": {
+                    "tick_command": "$LOOPX_PANE_A2A_TICK",
+                    "worker_turn_command_ref": "LOOPX_PANE_WORKER_TURN",
+                    "worker_turn_configured": True,
+                    "stream_surface": "codex_cli_tui",
+                },
                 "bootstrap_message": bootstrap_command,
                 "visible_codex_tui": codex,
                 "reasoning_effort": effort,
@@ -1241,6 +1261,13 @@ def build_auto_research_demo_supervisor_plan(
                         "operator_visible_signal": "prompt is passed to the Codex TUI, not printed as shell text",
                         "continue_when": "Codex TUI starts with the role-scoped prompt",
                         "stop_when": "bootstrap would bypass LoopX quota, todo claims, or evidence writeback",
+                    },
+                    {
+                        "phase": "pane_local_a2a_tick",
+                        "command_ref": "$LOOPX_PANE_A2A_TICK",
+                        "operator_visible_signal": "the Codex TUI role runs a human-readable state-backed worker turn",
+                        "continue_when": "the tick reads this agent's frontier and streams worker-turn output in the pane",
+                        "stop_when": "the tick reports user action, no action, or contradictory role identity",
                     },
                     {
                         "phase": "visible_codex",

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -79,6 +79,38 @@ human_target.write_text(
     encoding="utf-8",
 )
 human_target.chmod(0o700)
+
+tick_target = bin_dir / "loopx-pane-a2a-tick"
+tick_target.write_text(
+    "#!/usr/bin/env python3\n"
+    "import os, shlex, subprocess\n"
+    "from pathlib import Path\n"
+    "loopx = os.environ.get('LOOPX_PANE_LOOPX') or str(Path(os.environ.get('LOOPX_PROJECT', '.')) / '.local' / 'bin' / 'loopx')\n"
+    "goal = os.environ.get('LOOPX_GOAL_ID', '').strip()\n"
+    "agent = os.environ.get('LOOPX_AGENT_ID', '').strip()\n"
+    "role = os.environ.get('LOOPX_ROLE_ID', '').strip() or os.environ.get('LOOPX_LANE_ID', '').strip() or agent\n"
+    "if not goal or not agent:\n"
+    "    print('\\n[LoopX pane A2A]\\nmissing LOOPX_GOAL_ID or LOOPX_AGENT_ID; cannot read role-local frontier.\\n', flush=True)\n"
+    "    raise SystemExit(2)\n"
+    "def run(args):\n"
+    "    print('\\n[LoopX pane A2A] ' + ' '.join(shlex.quote(str(arg)) for arg in args), flush=True)\n"
+    "    return subprocess.call([str(arg) for arg in args])\n"
+    "print(f'\\n[LoopX pane A2A] role={role} agent={agent}\\n', flush=True)\n"
+    "status = run([loopx, '--format', 'markdown', 'quota', 'should-run', '--goal-id', goal, '--agent-id', agent])\n"
+    "if status != 0:\n"
+    "    raise SystemExit(status)\n"
+    "turn = os.environ.get('LOOPX_PANE_WORKER_TURN', '').strip()\n"
+    "loop = os.environ.get('LOOPX_PANE_WORKER_LOOP', '').strip()\n"
+    "command = turn or loop\n"
+    "if not command:\n"
+    "    print('\\n[LoopX pane A2A]\\nNo role worker-turn command is configured; continue manually with $LOOPX_PANE_LOOPX.\\n', flush=True)\n"
+    "    raise SystemExit(0)\n"
+    "label = 'worker-turn' if turn else 'worker-loop'\n"
+    "print(f'\\n[LoopX pane A2A {label}]\\n{command}\\n', flush=True)\n"
+    "raise SystemExit(subprocess.call(command, shell=True, executable=os.environ.get('SHELL') or '/bin/bash'))\n",
+    encoding="utf-8",
+)
+tick_target.chmod(0o700)
 """
 
 def _q(value: object) -> str:
@@ -154,6 +186,10 @@ def build_visible_lane_command(
     bootstrap_command: str,
     codex_bin: str,
     reasoning_effort: str,
+    goal_id: str | None = None,
+    agent_id: str | None = None,
+    worker_turn_command: str | None = None,
+    worker_loop_command: str | None = None,
 ) -> str:
     trust_config_py = (
         'import json, os; '
@@ -176,11 +212,22 @@ def build_visible_lane_command(
         f"python3 -c {_q(_SCOPED_LOOPX_WRAPPER_PY)}; "
         'chmod +x "$LOOPX_PROJECT/.local/bin/loopx"; '
         'chmod +x "$LOOPX_PROJECT/.local/bin/loopx-json"; '
+        'chmod +x "$LOOPX_PROJECT/.local/bin/loopx-pane-a2a-tick"; '
         'export LOOPX_PANE_LOOPX="$LOOPX_PROJECT/.local/bin/loopx"; '
         'export LOOPX_PANE_LOOPX_JSON="$LOOPX_PROJECT/.local/bin/loopx-json"; '
+        'export LOOPX_PANE_A2A_TICK="$LOOPX_PROJECT/.local/bin/loopx-pane-a2a-tick"; '
         'export LOOPX_VISIBLE_FORCE_MARKDOWN="${LOOPX_VISIBLE_FORCE_MARKDOWN:-1}"; '
         'export PATH="$LOOPX_PROJECT/.local/bin:$PATH"; '
     )
+    pane_a2a_env = ""
+    if goal_id:
+        pane_a2a_env += f"export LOOPX_GOAL_ID={_q(goal_id)}; "
+    if agent_id:
+        pane_a2a_env += f"export LOOPX_AGENT_ID={_q(agent_id)}; "
+    if worker_turn_command:
+        pane_a2a_env += f"export LOOPX_PANE_WORKER_TURN={_q(worker_turn_command)}; "
+    if worker_loop_command:
+        pane_a2a_env += f"export LOOPX_PANE_WORKER_LOOP={_q(worker_loop_command)}; "
     return (
         "set -uo pipefail; "
         "export LOOPX_VISIBLE_TUI_SILENT_BOOTSTRAP=1; "
@@ -188,6 +235,7 @@ def build_visible_lane_command(
         f"export LOOPX_ROLE_PROFILE_REF={_q(role_profile_ref)}; "
         'cd "$LOOPX_PROJECT"; '
         f"{scoped_loopx_wrapper}"
+        f"{pane_a2a_env}"
         f"{role_profile_command}"
         'VISIBLE_ARTIFACT_PREFIX="${LOOPX_LANE_ID:-${LOOPX_ROLE_ID:-lane}}"; '
         f"BOOTSTRAP_PROMPT=\"$({bootstrap_command} 2>&1)\"; "
@@ -377,7 +425,7 @@ def _generic_role_prompt(
             "",
             "How to work:",
             "- Treat LoopX state as the shared A2A surface.",
-            "- Start by reading your agent-scoped todo/quota/frontier with $LOOPX_PANE_LOOPX.",
+            "- Start one role-local A2A turn with `$LOOPX_PANE_A2A_TICK`; it reads your quota/frontier and then runs this role's worker-turn when configured.",
             "- Keep machine JSON redirected through $LOOPX_PANE_LOOPX_JSON into .local artifacts.",
             "- Write compact public-safe evidence before completing or handing off a todo.",
             "- The user may type into this pane; respond like a normal Codex CLI agent.",
@@ -434,6 +482,8 @@ def build_visible_multi_agent_payload_from_spec(
         )
         skill_profile = _role_skill_profile(raw_role.get("skill"))
         reasoning_effort = str(raw_role.get("reasoning_effort") or default_reasoning_effort)
+        worker_turn_command = str(raw_role.get("worker_turn_command") or "").strip()
+        worker_loop_command = str(raw_role.get("worker_loop_command") or "").strip()
         role_profile = {
             "schema_version": "generic_multi_agent_role_profile_v0",
             "role_id": role_id,
@@ -474,6 +524,11 @@ def build_visible_multi_agent_payload_from_spec(
                 f"> .local/{lane_slug}/quota.public.json"
             ),
             "frontier": "agent-scoped LoopX todo/quota/frontier projection",
+            "pane_local_a2a": {
+                "tick_command": "$LOOPX_PANE_A2A_TICK",
+                "worker_turn_configured": bool(worker_turn_command),
+                "worker_loop_configured": bool(worker_loop_command),
+            },
             "bootstrap_message": "role_prompt_inside_codex_tui",
             "visible_launch_command": build_visible_lane_command(
                 role_id=role_id,
@@ -482,9 +537,13 @@ def build_visible_multi_agent_payload_from_spec(
                 bootstrap_command=bootstrap_command,
                 codex_bin=codex_bin,
                 reasoning_effort=reasoning_effort,
+                goal_id=goal_id,
+                agent_id=agent_id,
+                worker_turn_command=worker_turn_command,
+                worker_loop_command=worker_loop_command,
             ),
             "reasoning_effort": reasoning_effort,
-            "lane_timeline": ["role_profile", "quota_guard", "frontier", "codex_tui"],
+            "lane_timeline": ["role_profile", "pane_local_a2a_tick", "frontier", "codex_tui"],
         }
         if raw_role.get("workspace") or raw_role.get("project"):
             lane["workspace"] = str(raw_role.get("workspace") or raw_role.get("project"))
@@ -508,6 +567,8 @@ def build_visible_multi_agent_payload_from_spec(
                     "skill",
                     "handoff_hints",
                     "reasoning_effort",
+                    "worker_turn_command",
+                    "worker_loop_command",
                 ],
                 "role_count": len(lanes),
                 "uses_generic_runner": True,


### PR DESCRIPTION
## Summary
- add a generic pane-local `$LOOPX_PANE_A2A_TICK` helper alongside the scoped human/json LoopX wrappers
- let generic multi-agent specs configure worker-turn/worker-loop commands without printing machine JSON in visible panes
- wire auto-research visible lanes to run their role-local worker-turn through the pane-local tick and expose the timeline in the supervisor packet

## Validation
- python3 -m py_compile loopx/visible_multi_agent_launcher.py loopx/capabilities/auto_research/legacy_core.py examples/visible-multi-agent-launcher-smoke.py examples/auto-research-demo-supervisor-smoke.py examples/auto-research-demo-e2e-worker-loop-smoke.py
- python3 examples/visible-multi-agent-launcher-smoke.py
- python3 examples/auto-research-demo-supervisor-smoke.py
- python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- python3 examples/generic-multi-agent-one-command-smoke.py
- git diff --check origin/main..HEAD

## Review Notes
This is a small runtime/UX seam, not a direct merge candidate from the side lane. Please review the product fit: the shell launcher should remain layout-only while each visible Codex TUI role performs the state-backed tick.