### PR TITLE
Ignore app-server developer messages in Goal driver

### DIFF
--- a/examples/codex-app-server-goal-driver-smoke.py
+++ b/examples/codex-app-server-goal-driver-smoke.py
@@ -155,6 +155,19 @@ for line in sys.stdin:
                     "type": "response_item",
                     "payload": {
                         "type": "message",
+                        "role": "developer",
+                        "content": [
+                            {
+                                "type": "input_text",
+                                "text": "<permissions instructions>startup context</permissions instructions><skills_instructions>skill context</skills_instructions>",
+                            }
+                        ],
+                    },
+                }) + "\\n")
+                session.write(json.dumps({
+                    "type": "response_item",
+                    "payload": {
+                        "type": "message",
                         "role": "assistant",
                         "content": [
                             {"type": "text", "text": "Session file final answer."}
@@ -393,14 +406,18 @@ def main() -> int:
             assert compact["turn_completed_observed"] is True, compact
             assert compact["turn_status"] == "completed", compact
             assert compact["session_log_observed"] is True, compact
-            assert compact["session_event_count"] >= 2, compact
+            assert compact["session_event_count"] >= 3, compact
             assert compact["session_task_complete_observed"] is True, compact
             assert compact["assistant_message_present"] is True, compact
+            assert session_completed_turn.assistant_message == "Session file final answer."
             assert compact["assistant_message_chars"] == len(
                 "Session file final answer."
             )
+            assert compact["agent_message_item_count"] == 1, compact
+            assert compact["non_user_item_completed_count"] == 1, compact
             assert "event_msg:task_complete" in compact["notifications"], compact
             assert "Session file final answer." not in json.dumps(compact), compact
+            assert "startup context" not in json.dumps(compact), compact
         finally:
             session_completed_turn.terminate()
 

--- a/scripts/codex_app_server_goal_driver.py
+++ b/scripts/codex_app_server_goal_driver.py
@@ -417,6 +417,8 @@ def _record_turn_event(
         if role == "user":
             turn.user_message_item_count += 1
             return False
+        if role != "assistant":
+            return False
         if item_text:
             turn._assistant_message_parts.append(item_text)
         turn.agent_message_item_count += 1


### PR DESCRIPTION
## Summary
- ignore non-assistant response_item message records when compacting Codex app-server Goal turns
- cover the session-log fallback path where developer startup context appears before an assistant answer

## Why
- xhigh app-server sessions can write developer/startup context into the session jsonl before model output
- treating that context as an assistant message makes benchmark workers falsely classify the turn as context-only

## Validation
- python3 -m py_compile scripts/codex_app_server_goal_driver.py examples/codex-app-server-goal-driver-smoke.py scripts/skillsbench_host_codex_goal_worker.py loopx/benchmark_adapters/skillsbench_acp_relay.py loopx/benchmark_adapters/skillsbench.py scripts/skillsbench_automation_loop.py
- python3 examples/codex-app-server-goal-driver-smoke.py
- python3 examples/skillsbench-app-server-goal-worker-smoke.py
- targeted skillsbench round trace smoke

## Boundary
- no raw task text, raw trajectories, verifier output, credentials, proxy values, or local benchmark logs are committed