### PR TITLE
Extract visible TUI runner contract

### DIFF
--- a/examples/generic-multi-agent-one-command-smoke.py
+++ b/examples/generic-multi-agent-one-command-smoke.py
@@ -12,6 +12,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
+RUNNER_CONTRACT_SCHEMA_VERSION = "tui_multi_agent_runner_contract_v0"
 
 PRIVATE_MARKERS = [
     "byte" + "dance",
@@ -195,9 +196,16 @@ def main() -> int:
         assert dry_packet["reasoning_contract"]["default_reasoning_effort"] == "high", dry_packet
         assert dry_packet["shared_goal_surface"]["shared_state_route"] == "LOOPX_REGISTRY_and_LOOPX_RUNTIME_ROOT", dry_packet
         assert dry_packet["shared_goal_surface"]["all_lane_workspace_isolation"] is False, dry_packet
+        assert dry_packet["runner_contract"]["schema_version"] == RUNNER_CONTRACT_SCHEMA_VERSION, dry_packet
+        assert dry_packet["runner_contract"]["runner_surface"] == "tmux_codex_cli_tui", dry_packet
+        assert dry_packet["runner_contract"]["coordination_model"]["leader_required"] is False, dry_packet
+        assert dry_packet["runner_contract"]["pane_local_a2a"]["tick_command"] == "$LOOPX_PANE_A2A_TICK", dry_packet
+        assert dry_packet["runner_contract"]["boundaries"]["domain_specific_research_logic"] is False, dry_packet
         assert dry_packet["interactive_tui_contract"]["schema_version"] == "multi_agent_visible_interactive_tui_contract_v0", dry_packet
+        assert dry_packet["interactive_tui_contract"]["runner_contract"] == RUNNER_CONTRACT_SCHEMA_VERSION, dry_packet
         assert dry_packet["interactive_tui_contract"]["machine_json_policy"] == "file_or_explicit_machine_channel_only", dry_packet
         assert dry_packet["interactive_tui_contract"]["codex_surface"] == "interactive_cli_tui", dry_packet
+        assert dry_packet["acceptance"]["runner_contract"] == RUNNER_CONTRACT_SCHEMA_VERSION, dry_packet
         assert dry_packet["acceptance"]["machine_json_file_bound"] is True, dry_packet
         assert dry_packet["acceptance"]["codex_tui_interactive"] is True, dry_packet
         assert dry_packet["boundary"]["starts_visible_processes"] is False, dry_packet

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -18,6 +18,7 @@ sys.path.insert(0, str(ROOT))
 
 from loopx.visible_multi_agent_launcher import (  # noqa: E402
     _SCOPED_LOOPX_WRAPPER_PY,
+    TUI_MULTI_AGENT_RUNNER_CONTRACT_SCHEMA_VERSION,
     build_visible_multi_agent_payload,
     build_visible_multi_agent_payload_from_spec,
     execute_visible_multi_agent_launcher,
@@ -97,6 +98,8 @@ def main() -> int:
     assert "stat.S_ISREG" in launcher_source
     assert "LOOPX_MACHINE_JSON=1 explicitly" in launcher_source
     assert "multi_agent_visible_interactive_tui_contract_v0" in launcher_source
+    assert TUI_MULTI_AGENT_RUNNER_CONTRACT_SCHEMA_VERSION in launcher_source
+    assert "build_tui_multi_agent_runner_contract" in launcher_source
     assert "LOOPX_CODEX_TUI_MODE=interactive" in launcher_source
     assert "LOOPX_CODEX_TRUST_WORKSPACE" in launcher_source
     assert "trust_level=" in launcher_source and "trusted" in launcher_source
@@ -123,18 +126,41 @@ def main() -> int:
     assert dry_packet["commands"]["attach"] == "tmux attach -t loopx-visible-launcher-contract-smoke"
     assert dry_packet["commands"]["stop"] == "tmux kill-session -t loopx-visible-launcher-contract-smoke"
     assert "retry" in dry_packet["commands"], dry_packet
+    runner_contract = dry_packet["runner_contract"]
+    assert runner_contract["schema_version"] == TUI_MULTI_AGENT_RUNNER_CONTRACT_SCHEMA_VERSION
+    assert runner_contract["coordination_model"]["leader_required"] is False, runner_contract
+    assert runner_contract["coordination_model"]["state_bus"] == (
+        "loopx_registry_runtime_todo_quota_frontier"
+    ), runner_contract
+    assert runner_contract["tmux_lifecycle"]["one_window_per_role"] is True, runner_contract
+    assert runner_contract["tmux_lifecycle"]["attach_command"] == dry_packet["commands"]["attach"]
+    assert runner_contract["tmux_lifecycle"]["stop_command"] == dry_packet["commands"]["stop"]
+    assert runner_contract["pane_local_a2a"]["tick_command"] == "$LOOPX_PANE_A2A_TICK"
+    assert "LOOPX_PANE_WORKER_TURN" in runner_contract["lane_runtime_env"]["pane_tools"]
+    assert runner_contract["role_prompt_and_skill"]["worker_local_skill_only"] is True
+    assert runner_contract["debug_artifacts"]["machine_json"] == (
+        "redirected_public_artifacts_only"
+    )
+    assert runner_contract["boundaries"]["domain_specific_research_logic"] is False
     assert (
         dry_packet["interactive_tui_contract"]["schema_version"]
         == "multi_agent_visible_interactive_tui_contract_v0"
     ), dry_packet
+    assert dry_packet["interactive_tui_contract"]["runner_contract"] == (
+        TUI_MULTI_AGENT_RUNNER_CONTRACT_SCHEMA_VERSION
+    )
     assert dry_packet["interactive_tui_contract"]["machine_json_policy"] == (
         "file_or_explicit_machine_channel_only"
     ), dry_packet
     assert dry_packet["interactive_tui_contract"]["codex_surface"] == "interactive_cli_tui", dry_packet
+    assert dry_packet["acceptance"]["runner_contract"] == (
+        TUI_MULTI_AGENT_RUNNER_CONTRACT_SCHEMA_VERSION
+    )
     assert dry_packet["acceptance"]["machine_json_file_bound"] is True, dry_packet
     assert dry_packet["acceptance"]["codex_tui_interactive"] is True, dry_packet
     assert dry_packet["boundary"]["hidden_prompt_injection"] is False, dry_packet
     assert dry_packet["boundary"]["spends_loopx_quota"] is False, dry_packet
+    assert dry_packet["boundary"]["all_lane_workspace_isolation"] is False, dry_packet
 
     generic_packet = build_visible_multi_agent_payload_from_spec(
         {
@@ -149,6 +175,10 @@ def main() -> int:
             ],
         }
     )
+    assert generic_packet["runner_contract"]["schema_version"] == (
+        TUI_MULTI_AGENT_RUNNER_CONTRACT_SCHEMA_VERSION
+    )
+    assert generic_packet["runner_contract"]["tmux_lifecycle"]["lane_count"] == 1
     generic_lane = generic_packet["lanes"][0]
     assert generic_lane["pane_local_a2a"]["tick_command"] == "$LOOPX_PANE_A2A_TICK", generic_lane
     assert generic_lane["pane_local_a2a"]["worker_turn_configured"] is True, generic_lane

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -10,6 +10,13 @@ from collections.abc import Iterable
 from pathlib import Path
 
 
+TUI_MULTI_AGENT_RUNNER_CONTRACT_SCHEMA_VERSION = "tui_multi_agent_runner_contract_v0"
+INTERACTIVE_TUI_CONTRACT_SCHEMA_VERSION = "multi_agent_visible_interactive_tui_contract_v0"
+VISIBLE_LAUNCHER_ACCEPTANCE_CONTRACT_SCHEMA_VERSION = (
+    "multi_agent_visible_launcher_acceptance_contract_v0"
+)
+
+
 _SCOPED_LOOPX_WRAPPER_PY = r"""
 import os
 from pathlib import Path
@@ -178,6 +185,96 @@ def resolve_visible_launcher(*, requested: str, tmux_bin: str) -> str:
     return "tmux"
 
 
+def build_tui_multi_agent_runner_contract(
+    *,
+    session_name: str,
+    lane_count: int,
+    attach_command: str,
+    stop_command: str,
+    retry_command: str,
+    all_lane_workspace_isolation: bool,
+) -> dict[str, object]:
+    """Describe the reusable visible-TUI runner without domain-specific steps."""
+
+    return {
+        "schema_version": TUI_MULTI_AGENT_RUNNER_CONTRACT_SCHEMA_VERSION,
+        "runner_surface": "tmux_codex_cli_tui",
+        "coordination_model": {
+            "leader_required": False,
+            "state_bus": "loopx_registry_runtime_todo_quota_frontier",
+            "selection": "agent_scoped_quota_should_run_frontier",
+            "handoff": "todo_and_public_safe_evidence",
+        },
+        "tmux_lifecycle": {
+            "session_name": session_name,
+            "lane_count": lane_count,
+            "one_window_per_role": True,
+            "remain_on_exit": True,
+            "replace_existing": "execute_flag_only",
+            "attach_command": attach_command,
+            "stop_command": stop_command,
+            "retry_command": retry_command,
+        },
+        "lane_runtime_env": {
+            "shared": [
+                "LOOPX_PROJECT",
+                "LOOPX_REGISTRY",
+                "LOOPX_RUNTIME_ROOT",
+                "LOOPX_VISIBLE_SESSION",
+                "LOOPX_VISIBLE_ARTIFACT_DIR",
+            ],
+            "role_identity": [
+                "LOOPX_ROLE_ID",
+                "LOOPX_ROLE_PROFILE_REF",
+                "LOOPX_GOAL_ID",
+                "LOOPX_AGENT_ID",
+            ],
+            "pane_tools": [
+                "LOOPX_PANE_LOOPX",
+                "LOOPX_PANE_LOOPX_JSON",
+                "LOOPX_PANE_A2A_TICK",
+                "LOOPX_PANE_WORKER_TURN",
+                "LOOPX_PANE_WORKER_LOOP",
+            ],
+            "workspace_policy": (
+                "shared_goal_surface_by_default; mutating lanes may opt into lane workspaces"
+            ),
+            "all_lane_workspace_isolation": all_lane_workspace_isolation,
+        },
+        "role_prompt_and_skill": {
+            "bootstrap_prompt": "written_to_public_artifact_then_passed_to_codex_tui",
+            "role_profile": "role-local public json artifact",
+            "skill_materialization": ".codex/skills/<skill>/SKILL.md",
+            "worker_local_skill_only": True,
+        },
+        "pane_local_a2a": {
+            "tick_command": "$LOOPX_PANE_A2A_TICK",
+            "reads": ["quota should-run", "agent-scoped frontier"],
+            "runs": ["LOOPX_PANE_WORKER_TURN", "LOOPX_PANE_WORKER_LOOP"],
+            "machine_json_policy": "file_or_explicit_machine_channel_only",
+            "human_default": "markdown_status_inside_codex_tui",
+        },
+        "user_takeover": {
+            "interactive_codex_tui": True,
+            "may_type_into_each_role": True,
+            "attach": attach_command,
+            "stop": stop_command,
+        },
+        "debug_artifacts": {
+            "machine_json": "redirected_public_artifacts_only",
+            "launcher_scripts": "runtime_local_debug_files",
+            "raw_transcripts": False,
+            "credentials": False,
+        },
+        "boundaries": {
+            "domain_specific_research_logic": False,
+            "runs_agent_processes_in_dry_run": False,
+            "writes_loopx_state_in_dry_run": False,
+            "spends_quota_in_dry_run": False,
+        },
+    }
+
+
 def build_visible_lane_command(
     *,
     role_id: str,
@@ -273,6 +370,17 @@ def build_visible_multi_agent_payload(
         "rerun the same visible launcher packet after refreshing quota, "
         "frontier, and bootstrap"
     )
+    all_lane_workspace_isolation = all(
+        bool(lane.get("workspace") or lane.get("project")) for lane in lane_list
+    )
+    runner_contract = build_tui_multi_agent_runner_contract(
+        session_name=session,
+        lane_count=len(lane_list),
+        attach_command=attach_command,
+        stop_command=stop_command,
+        retry_command=retry_command,
+        all_lane_workspace_isolation=all_lane_workspace_isolation,
+    )
     start_script = [
         "set -uo pipefail",
         ": ${LOOPX_PROJECT:?set LOOPX_PROJECT to the repo root before running}",
@@ -309,8 +417,10 @@ def build_visible_multi_agent_payload(
         "goal_id": str(goal_id),
         "session_name": session,
         "lanes": lane_list,
+        "runner_contract": runner_contract,
         "interactive_tui_contract": {
-            "schema_version": "multi_agent_visible_interactive_tui_contract_v0",
+            "schema_version": INTERACTIVE_TUI_CONTRACT_SCHEMA_VERSION,
+            "runner_contract": TUI_MULTI_AGENT_RUNNER_CONTRACT_SCHEMA_VERSION,
             "human_pane": [
                 "codex_cli_tui",
                 "role_prompt_inside_codex",
@@ -344,14 +454,15 @@ def build_visible_multi_agent_payload(
             "retry": retry_command,
         },
         "acceptance": {
-            "schema_version": "multi_agent_visible_launcher_acceptance_contract_v0",
+            "schema_version": VISIBLE_LAUNCHER_ACCEPTANCE_CONTRACT_SCHEMA_VERSION,
             "required_runtime_shape": [
                 "one_tmux_window_per_role",
                 "each_role_window_execs_codex_cli_tui",
                 "no_frontier_or_json_status_window",
                 "no_pre_codex_character_stream",
             ],
-            "interactive_tui_contract": "multi_agent_visible_interactive_tui_contract_v0",
+            "interactive_tui_contract": INTERACTIVE_TUI_CONTRACT_SCHEMA_VERSION,
+            "runner_contract": TUI_MULTI_AGENT_RUNNER_CONTRACT_SCHEMA_VERSION,
             "machine_json_file_bound": True,
             "codex_tui_interactive": True,
         },
@@ -365,7 +476,7 @@ def build_visible_multi_agent_payload(
             "reads_credentials": False,
             "hidden_prompt_injection": False,
             "shared_goal_surface": True,
-            "all_lane_workspace_isolation": False,
+            "all_lane_workspace_isolation": all_lane_workspace_isolation,
             "public_safe_redaction": True,
         },
     }


### PR DESCRIPTION
## Summary
- add a reusable tui_multi_agent_runner_contract_v0 to the visible multi-agent launcher payload
- describe tmux lifecycle, lane env, pane-local A2A tick, worker-local skill materialization, user takeover, and debug-only artifact boundaries
- pin the generic and visible launcher smokes to the runner contract without adding domain-specific auto-research logic

## Validation
- python3 -m py_compile loopx/visible_multi_agent_launcher.py examples/visible-multi-agent-launcher-smoke.py examples/generic-multi-agent-one-command-smoke.py
- python3 examples/visible-multi-agent-launcher-smoke.py
- python3 examples/generic-multi-agent-one-command-smoke.py
- python3 examples/auto-research-demo-supervisor-smoke.py
- python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- git diff --check
- public/private marker scan on changed paths