### PR TITLE
Guard lightweight auto-research kernel boundary

### DIFF
--- a/examples/auto-research-minimal-kernel-smoke.py
+++ b/examples/auto-research-minimal-kernel-smoke.py
@@ -28,6 +28,21 @@ from loopx.capabilities.auto_research import (  # noqa: E402
 
 KERNEL = REPO_ROOT / "loopx/capabilities/auto_research/kernel.py"
 CORE = REPO_ROOT / "loopx/capabilities/auto_research/core.py"
+INIT = REPO_ROOT / "loopx/capabilities/auto_research/__init__.py"
+LEGACY_CORE = REPO_ROOT / "loopx/capabilities/auto_research/legacy_core.py"
+
+KERNEL_FORBIDDEN_MARKERS = [
+    "legacy_core",
+    "demo_e2e",
+    "worker_runtime",
+    "visible_multi_agent_launcher",
+    "protected_eval",
+    "quickstart",
+    "knn",
+    "showcase",
+    "tmux",
+    "codex",
+]
 
 
 def assert_public_safe(payload: Any) -> None:
@@ -65,13 +80,28 @@ def assert_positive_result(payload: dict[str, Any]) -> None:
     assert_public_safe(payload)
 
 
-def main() -> None:
+def assert_kernel_boundary() -> None:
     kernel_text = KERNEL.read_text(encoding="utf-8")
     core_text = CORE.read_text(encoding="utf-8")
+    init_text = INIT.read_text(encoding="utf-8")
+    lightweight_surface = kernel_text + "\n" + core_text + "\n" + init_text
     assert len(kernel_text.splitlines()) <= 220
     assert len(core_text.splitlines()) <= 40
-    assert "run_builtin_lightweight_demo" not in kernel_text + core_text
-    assert "protected_eval.py" not in kernel_text
+    assert "run_builtin_lightweight_demo" not in lightweight_surface
+    leaked_markers = [
+        marker
+        for marker in KERNEL_FORBIDDEN_MARKERS
+        if marker.lower() in lightweight_surface.lower()
+    ]
+    assert not leaked_markers, leaked_markers
+
+    legacy_text = LEGACY_CORE.read_text(encoding="utf-8")
+    assert "Compatibility boundary" in legacy_text
+    assert "New product logic belongs in the lightweight kernel" in legacy_text
+
+
+def main() -> None:
+    assert_kernel_boundary()
 
     candidates = [
         lightweight_hypothesis(

--- a/loopx/capabilities/auto_research/core.py
+++ b/loopx/capabilities/auto_research/core.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 # New lightweight research kernel. Keep this file small: user-facing
-# auto-research additions should start here or in kernel.py, not in legacy_core.
+# auto-research additions should stay in core/kernel and wrap generic runners.
 from .kernel import (
     LIGHTWEIGHT_AUTO_RESEARCH_EVIDENCE_SCHEMA_VERSION,
     LIGHTWEIGHT_AUTO_RESEARCH_HYPOTHESIS_SCHEMA_VERSION,

--- a/loopx/capabilities/auto_research/legacy_core.py
+++ b/loopx/capabilities/auto_research/legacy_core.py
@@ -1,3 +1,10 @@
+"""Compatibility boundary for older auto-research demo/projection code.
+
+New product logic belongs in the lightweight kernel or generic multi-agent
+runner. Keep this module as a temporary adapter for legacy quickstart/demo
+callers while those paths are migrated or deleted.
+"""
+
 from __future__ import annotations
 
 import json


### PR DESCRIPTION
## Summary
- mark legacy auto-research code as a compatibility boundary
- strengthen the minimal-kernel smoke so core/kernel exports cannot depend on legacy/demo/quickstart/protected-eval markers
- keep the user-facing lightweight kernel small and evaluator-agnostic

## Validation
- python3 examples/auto-research-minimal-kernel-smoke.py
- python3 -m py_compile loopx/capabilities/auto_research/kernel.py loopx/capabilities/auto_research/core.py loopx/capabilities/auto_research/legacy_core.py examples/auto-research-minimal-kernel-smoke.py
- python3 examples/auto-research-demo-supervisor-smoke.py
- python3 examples/auto-research-worker-loop-smoke.py
- python3 examples/generic-multi-agent-one-command-smoke.py
- git diff --check