### PR TITLE
Unpin lightweight kernel smoke from legacy core

### DIFF
--- a/examples/auto-research-minimal-kernel-smoke.py
+++ b/examples/auto-research-minimal-kernel-smoke.py
@@ -29,7 +29,6 @@ from loopx.capabilities.auto_research import (  # noqa: E402
 KERNEL = REPO_ROOT / "loopx/capabilities/auto_research/kernel.py"
 CORE = REPO_ROOT / "loopx/capabilities/auto_research/core.py"
 INIT = REPO_ROOT / "loopx/capabilities/auto_research/__init__.py"
-LEGACY_CORE = REPO_ROOT / "loopx/capabilities/auto_research/legacy_core.py"
 
 KERNEL_FORBIDDEN_MARKERS = [
     "legacy_core",
@@ -94,11 +93,6 @@ def assert_kernel_boundary() -> None:
         if marker.lower() in lightweight_surface.lower()
     ]
     assert not leaked_markers, leaked_markers
-
-    legacy_text = LEGACY_CORE.read_text(encoding="utf-8")
-    assert "Compatibility boundary" in legacy_text
-    assert "New product logic belongs in the lightweight kernel" in legacy_text
-
 
 def main() -> None:
     assert_kernel_boundary()


### PR DESCRIPTION
## Summary
- remove the minimal kernel smoke's requirement that legacy_core.py exists
- keep the actual lightweight surface guard: kernel/core/init cannot depend on legacy/demo/quickstart/protected-eval markers

## Why
This is the first deletion-oriented cleanup after PR #1100. It removes a test anchor that would keep legacy_core.py alive even after its remaining callers are migrated or deleted.

## Validation
- python3 examples/auto-research-minimal-kernel-smoke.py
- python3 -m py_compile examples/auto-research-minimal-kernel-smoke.py loopx/capabilities/auto_research/kernel.py loopx/capabilities/auto_research/core.py loopx/capabilities/auto_research/__init__.py
- git diff --check
- private-boundary scan on changed file