### PR TITLE
Expose SkillsBench app-server observability

### DIFF
--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -41,7 +41,9 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
     _host_local_acp_launch_command,
     _host_local_proxy_endpoint_probe,
     _host_local_acp_target_env,
+    _merge_app_server_goal_worker_trace_summary,
     _merge_host_local_acp_relay_trace_summary,
+    _public_runner_config,
     _public_runner_prerequisites,
     _replace_option_value,
     _run_host_local_acp_codex_exec_preflight,
@@ -444,6 +446,110 @@ if out:
         assert prerequisites["container_codex_acp_install_skipped"] is False
         assert plan["public_boundary"]["leaderboard_upload"] is False
         assert plan["public_boundary"]["public_submission"] is False
+        app_trace_dir = Path(tmp) / "app-server-goal-trace"
+        app_trace_dir.mkdir()
+        (app_trace_dir / "turn.compact.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": (
+                        "skillsbench_host_codex_goal_worker_public_trace_v0"
+                    ),
+                    "trace_kind": "turn",
+                    "ok": True,
+                    "turn": {
+                        "reasoning_effort": "xhigh",
+                        "goal_get_present": True,
+                        "turn_id_present": True,
+                        "turn_completed_observed": True,
+                        "assistant_message_present": True,
+                        "first_action_observed": True,
+                        "effective_action_observed": True,
+                    },
+                    "worker_adapter": {"reasoning_effort": "xhigh"},
+                    "boundary": {
+                        "raw_task_text_recorded": False,
+                        "raw_logs_recorded": False,
+                        "raw_trajectory_recorded": False,
+                        "credential_values_recorded": False,
+                        "host_paths_recorded": False,
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+        app_server_plan = {
+            "route": "codex-app-server-goal-baseline",
+            "app_server_reasoning_effort": "xhigh",
+            "app_server_goal_worker_trace_dir": str(app_trace_dir),
+            "runner_prerequisites": {
+                "schema_version": "skillsbench_runner_prerequisites_v0",
+                "codex_api_egress_preflight_required": True,
+                "codex_api_egress_preflight_ready": True,
+                "codex_api_egress_preflight_status": "ready",
+                "codex_api_egress_mode_resolved": "reverse-tunnel",
+                "codex_api_reverse_tunnel_required": True,
+                "codex_api_reverse_tunnel_proxy_configured": True,
+                "codex_api_reverse_tunnel_proxy_source": "env",
+                "codex_api_reverse_tunnel_proxy_scheme": "http",
+                "codex_api_reverse_tunnel_proxy_endpoint_kind": "ipv4",
+                "codex_api_reverse_tunnel_proxy_endpoint_port": 3128,
+                "codex_api_reverse_tunnel_proxy_url_recorded": False,
+            },
+        }
+        app_controller_trace: dict[str, object] = {}
+        _merge_app_server_goal_worker_trace_summary(
+            app_server_plan,
+            app_controller_trace,
+        )
+        app_server_config = _public_runner_config(app_server_plan)
+        app_server_observability = app_server_config[
+            "app_server_goal_worker_observability"
+        ]
+        assert app_server_observability["requested_reasoning_effort"] == "xhigh"
+        assert app_server_observability["observed_reasoning_effort"] == "xhigh"
+        assert app_server_observability["reasoning_effort_matches_request"] is True
+        assert app_server_observability["public_trace_read"] is True
+        assert app_server_observability["raw_material_recorded"] is False
+        assert (
+            app_server_observability[
+                "codex_api_egress_preflight_observation_status"
+            ]
+            == "executed_ready"
+        )
+        assert app_server_observability[
+            "codex_api_reverse_tunnel_proxy_url_recorded"
+        ] is False
+        app_failure_trace = Path(tmp) / "app-server-controller-trace.json"
+        app_failure_trace.write_text("{}", encoding="utf-8")
+        app_failure_compact = build_runner_failure_compact(
+            SimpleNamespace(
+                build_stall_timeout_sec=0,
+                dataset="skillsbench-v1.1",
+                model=None,
+                run_group_id=None,
+                route="codex-app-server-goal-baseline",
+                task_id="demo-task",
+            ),
+            {
+                "app_server_goal_worker_trace_dir": str(app_trace_dir),
+                "app_server_reasoning_effort": "xhigh",
+                "compact_benchmark_run_json": str(
+                    Path(tmp) / "app-server-failure-compact.json"
+                ),
+                "controller_trace_json": str(app_failure_trace),
+                "route": "codex-app-server-goal-baseline",
+                "runner_prerequisites": dict(
+                    app_server_plan["runner_prerequisites"]
+                ),
+            },
+            RuntimeError("app-server worker failed before result"),
+        )
+        assert app_failure_compact["runner_config"][
+            "app_server_goal_worker_observability"
+        ]["observed_reasoning_effort"] == "xhigh"
+        assert app_failure_compact["app_server_goal_worker_observability"][
+            "reasoning_effort_matches_request"
+        ] is True
         launch_args = SimpleNamespace(
             agent_idle_timeout=7200,
             app_server_acp_heartbeat_interval_sec=120.0,

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -8603,7 +8603,174 @@ def _public_runner_config(plan: dict[str, Any]) -> dict[str, Any]:
         value = prerequisites.get("benchmark_egress_no_proxy_entry_count")
         if isinstance(value, int) and not isinstance(value, bool):
             config["benchmark_egress_no_proxy_entry_count"] = value
+    app_server_observability = _app_server_goal_worker_observability(plan)
+    if app_server_observability:
+        config["app_server_goal_worker_observability"] = app_server_observability
     return config
+
+
+def _app_server_goal_worker_observability(
+    plan: dict[str, Any],
+    controller_trace: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a public-safe attribution packet for app-server Goal launches."""
+
+    if str(plan.get("route") or "") != "codex-app-server-goal-baseline":
+        return {}
+
+    trace_summary = plan.get("app_server_goal_worker_trace_summary")
+    if not isinstance(trace_summary, dict):
+        trace_summary = {}
+    if isinstance(controller_trace, dict):
+        trace_summary = {**trace_summary, **controller_trace}
+
+    prereqs = plan.get("runner_prerequisites")
+    if not isinstance(prereqs, dict):
+        prereqs = {}
+    egress = plan.get("codex_api_egress_preflight")
+    if not isinstance(egress, dict):
+        egress = {}
+
+    requested_effort = str(plan.get("app_server_reasoning_effort") or "")[:40]
+    observed_effort = str(
+        trace_summary.get("native_goal_worker_reasoning_effort") or ""
+    )[:40]
+    if requested_effort and observed_effort:
+        if requested_effort == observed_effort:
+            effort_status = "matched"
+        else:
+            effort_status = "mismatch"
+    elif requested_effort:
+        effort_status = "requested_not_yet_observed"
+    else:
+        effort_status = "not_recorded"
+
+    preflight_status = str(
+        egress.get("status")
+        or prereqs.get("codex_api_egress_preflight_status")
+        or ""
+    )[:80]
+    preflight_required = bool(
+        egress.get("required") or prereqs.get("codex_api_egress_preflight_required")
+    )
+    preflight_ready = bool(
+        egress.get("ready") or prereqs.get("codex_api_egress_preflight_ready")
+    )
+    if not preflight_required:
+        preflight_observation_status = "not_required"
+    elif preflight_ready:
+        preflight_observation_status = "executed_ready"
+    elif preflight_status and preflight_status != "pending":
+        preflight_observation_status = "executed_blocked"
+    else:
+        preflight_observation_status = "required_pending"
+
+    def _int_field(name: str) -> int:
+        value = trace_summary.get(name)
+        if isinstance(value, int) and not isinstance(value, bool):
+            return value
+        return 0
+
+    summary: dict[str, Any] = {
+        "schema_version": "skillsbench_app_server_goal_worker_observability_v0",
+        "route": "codex-app-server-goal-baseline",
+        "requested_reasoning_effort": requested_effort,
+        "observed_reasoning_effort": observed_effort,
+        "reasoning_effort_observation_status": effort_status,
+        "reasoning_effort_matches_request": bool(
+            requested_effort and observed_effort and requested_effort == observed_effort
+        ),
+        "trace_dir_configured": bool(plan.get("app_server_goal_worker_trace_dir")),
+        "trace_dir_present": bool(
+            trace_summary.get("native_goal_worker_trace_dir_present")
+        ),
+        "public_trace_read": bool(
+            trace_summary.get("native_goal_worker_public_trace_read")
+        ),
+        "trace_count": _int_field("native_goal_worker_trace_count"),
+        "lifecycle_trace_count": _int_field(
+            "native_goal_worker_lifecycle_trace_count"
+        ),
+        "prompt_received_count": _int_field(
+            "native_goal_worker_prompt_received_count"
+        ),
+        "goal_get_count": _int_field("native_goal_worker_goal_get_count"),
+        "turn_start_count": _int_field("native_goal_worker_turn_start_count"),
+        "turn_completed_observed_count": _int_field(
+            "native_goal_worker_turn_completed_observed_count"
+        ),
+        "assistant_message_present_count": _int_field(
+            "native_goal_worker_assistant_message_present_count"
+        ),
+        "effective_action_observed_count": _int_field(
+            "native_goal_worker_effective_action_observed_count"
+        ),
+        "first_action_observed_count": _int_field(
+            "native_goal_worker_first_action_observed_count"
+        ),
+        "raw_material_recorded": bool(
+            trace_summary.get("native_goal_worker_raw_material_recorded")
+        ),
+        "codex_api_egress_preflight_required": preflight_required,
+        "codex_api_egress_preflight_ready": preflight_ready,
+        "codex_api_egress_preflight_status": preflight_status,
+        "codex_api_egress_preflight_observation_status": (
+            preflight_observation_status
+        ),
+        "codex_api_egress_mode_resolved": str(
+            egress.get("resolved_mode")
+            or prereqs.get("codex_api_egress_mode_resolved")
+            or ""
+        )[:80],
+        "codex_api_reverse_tunnel_required": bool(
+            egress.get("reverse_tunnel_required")
+            or prereqs.get("codex_api_reverse_tunnel_required")
+        ),
+        "codex_api_reverse_tunnel_proxy_configured": bool(
+            egress.get("proxy_configured")
+            or prereqs.get("codex_api_reverse_tunnel_proxy_configured")
+        ),
+        "codex_api_reverse_tunnel_proxy_source": str(
+            egress.get("proxy_source")
+            or prereqs.get("codex_api_reverse_tunnel_proxy_source")
+            or ""
+        )[:40],
+        "codex_api_reverse_tunnel_proxy_scheme": str(
+            egress.get("proxy_scheme")
+            or prereqs.get("codex_api_reverse_tunnel_proxy_scheme")
+            or ""
+        )[:20],
+        "codex_api_reverse_tunnel_proxy_endpoint_kind": str(
+            egress.get("proxy_endpoint_kind")
+            or prereqs.get("codex_api_reverse_tunnel_proxy_endpoint_kind")
+            or ""
+        )[:40],
+        "codex_api_reverse_tunnel_proxy_endpoint_port": int(
+            egress.get("proxy_endpoint_port")
+            or prereqs.get("codex_api_reverse_tunnel_proxy_endpoint_port")
+            or 0
+        ),
+        "codex_api_reverse_tunnel_proxy_url_recorded": False,
+        "codex_api_egress_raw_probe_output_recorded": False,
+    }
+
+    for key in (
+        "native_goal_worker_failure_category",
+        "native_goal_worker_first_blocker",
+    ):
+        value = trace_summary.get(key)
+        if isinstance(value, str) and value:
+            summary[key] = value[:120]
+    efforts = trace_summary.get("native_goal_worker_reasoning_efforts")
+    if isinstance(efforts, list):
+        compact_efforts = [
+            item[:40]
+            for item in efforts
+            if isinstance(item, str) and item
+        ][:8]
+        if compact_efforts:
+            summary["observed_reasoning_efforts"] = compact_efforts
+    return summary
 
 
 def _runner_config_public_path(plan: dict[str, Any]) -> Path | None:
@@ -9363,6 +9530,44 @@ def _merge_app_server_goal_worker_trace_summary(
     )
     trace["native_goal_worker_public_trace_read"] = worker_trace_count > 0
     trace["native_goal_worker_raw_material_recorded"] = raw_material_recorded
+    public_summary_keys = (
+        "native_goal_worker_route",
+        "native_goal_worker_trace_dir_present",
+        "native_goal_worker_trace_count",
+        "native_goal_worker_lifecycle_trace_count",
+        "native_goal_worker_prompt_received_count",
+        "native_goal_worker_ok_count",
+        "native_goal_worker_failure_trace_count",
+        "native_goal_worker_failure_categories",
+        "native_goal_worker_failure_category",
+        "native_goal_worker_first_blockers",
+        "native_goal_worker_first_blocker",
+        "native_goal_worker_goal_get_count",
+        "native_goal_worker_turn_start_count",
+        "native_goal_worker_turn_completed_observed_count",
+        "native_goal_worker_assistant_message_present_count",
+        "native_goal_worker_assistant_context_only_count",
+        "native_goal_worker_context_only_recovery_attempted_count",
+        "native_goal_worker_context_only_recovery_succeeded_count",
+        "native_goal_worker_context_only_followup_start_attempted_count",
+        "native_goal_worker_context_only_followup_start_succeeded_count",
+        "native_goal_worker_transport_reconnect_attempted_count",
+        "native_goal_worker_transport_reconnect_succeeded_count",
+        "native_goal_worker_goal_reactivation_attempted_count",
+        "native_goal_worker_goal_reactivation_succeeded_count",
+        "native_goal_worker_post_context_assistant_chars_total",
+        "native_goal_worker_reasoning_efforts",
+        "native_goal_worker_reasoning_effort",
+        "native_goal_worker_first_action_observed_count",
+        "native_goal_worker_effective_action_observed_count",
+        "native_goal_worker_public_trace_read",
+        "native_goal_worker_raw_material_recorded",
+    )
+    plan["app_server_goal_worker_trace_summary"] = {
+        key: trace[key]
+        for key in public_summary_keys
+        if key in trace
+    }
     if worker_trace_count:
         trace["last_decision"] = "host_app_server_goal_worker_trace_recorded"
 
@@ -13110,6 +13315,12 @@ def reduce_result(
     runner_config = _public_runner_config(plan)
     if runner_config:
         compact["runner_config"] = runner_config
+    app_server_observability = _app_server_goal_worker_observability(
+        plan,
+        controller_trace,
+    )
+    if app_server_observability:
+        compact["app_server_goal_worker_observability"] = app_server_observability
     goal_start_control_score = _build_goal_start_product_mode_control_score(
         compact,
         plan,
@@ -13815,6 +14026,10 @@ def build_runner_failure_compact(
         exc,
         cleanup_if_missing=True,
     )
+    controller_trace = _read_controller_trace(plan)
+    _merge_app_server_goal_worker_trace_summary(plan, controller_trace)
+    _merge_host_local_acp_relay_trace_summary(plan, controller_trace)
+    _write_controller_trace(plan, controller_trace)
     _write_public_runner_config(plan)
     _write_public_runner_prerequisites(plan)
 
@@ -13944,6 +14159,12 @@ def build_runner_failure_compact(
     runner_config = _public_runner_config(plan)
     if runner_config:
         reduced["runner_config"] = runner_config
+    app_server_observability = _app_server_goal_worker_observability(
+        plan,
+        controller_trace,
+    )
+    if app_server_observability:
+        reduced["app_server_goal_worker_observability"] = app_server_observability
     recovered = _recover_runner_failure_score_from_controller_trace(reduced, plan)
     if not recovered:
         _recover_runner_failure_score_from_verifier_artifact(reduced, plan)


### PR DESCRIPTION
## Summary
- add public-safe app-server Goal worker observability to runner_config and compact outputs
- project requested/observed reasoning effort, worker trace counters, first-action/effective-action counts, and reverse-tunnel preflight status
- cover success/failure compact projection with the existing SkillsBench host-local launch smoke

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-host-local-launch-plan-smoke.py
- python3 examples/skillsbench-host-local-launch-plan-smoke.py
- git diff --check origin/main..HEAD
- public/private diff scan for proxy IPs, local paths, credentials, and raw benchmark evidence

## Boundary
- no scoring semantics changed
- no benchmark task semantics changed
- no raw task text, raw trajectories, verifier logs, credentials, or real proxy endpoint values committed