### PR TITLE
Tighten auto-research CLI import boundaries

### DIFF
--- a/examples/auto-research-minimal-kernel-smoke.py
+++ b/examples/auto-research-minimal-kernel-smoke.py
@@ -141,6 +141,8 @@ def assert_evidence_packet_boundary() -> None:
     assert "RESEARCH_HYPOTHESIS_SCHEMA_VERSION" in worker_text
     assert "load_auto_research_evidence_packet_inputs" in worker_text
     assert "from .evidence_packet import load_auto_research_evidence_packet_inputs" in cli_text
+    assert "from .quickstart_seed import (" in cli_text
+    assert "from .research_state import build_live_auto_research_projection" in cli_text
 
 
 def main() -> None:

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -8,19 +8,21 @@ from datetime import datetime, timezone
 from pathlib import Path
 
 from .legacy_core import (
-    AUTO_RESEARCH_DEFAULT_GOAL_ID,
-    AUTO_RESEARCH_DEFAULT_OBJECTIVE,
-    AUTO_RESEARCH_QUICKSTART_TEMPLATE,
     build_auto_research_board_projection,
     build_auto_research_demo_acceptance_packet,
     build_auto_research_demo_supervisor_plan,
-    build_auto_research_quickstart,
-    build_live_auto_research_projection,
     build_auto_research_projection,
     load_auto_research_fixture,
     render_auto_research_markdown,
 )
 from .evidence_packet import load_auto_research_evidence_packet_inputs
+from .quickstart_seed import (
+    AUTO_RESEARCH_DEFAULT_GOAL_ID,
+    AUTO_RESEARCH_DEFAULT_OBJECTIVE,
+    AUTO_RESEARCH_QUICKSTART_TEMPLATE,
+    build_auto_research_quickstart,
+)
+from .research_state import build_live_auto_research_projection
 from .demo_e2e import run_auto_research_demo_e2e
 from .live_evidence import (
     LIVE_CODEX_E2E_DEFAULT_OUTPUT,

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -8,14 +8,18 @@ from pathlib import Path
 
 from .legacy_core import (
     AUTO_RESEARCH_DEMO_E2E_SCHEMA_VERSION,
-    AUTO_RESEARCH_DEFAULT_GOAL_ID,
     AUTO_RESEARCH_PROJECTION_SCHEMA_VERSION,
     build_auto_research_board_projection,
     build_auto_research_demo_acceptance_packet,
     build_auto_research_demo_supervisor_plan,
-    build_auto_research_quickstart,
-    build_live_auto_research_projection,
     build_research_artifact_packet,
+)
+from .quickstart_seed import (
+    AUTO_RESEARCH_DEFAULT_GOAL_ID,
+    build_auto_research_quickstart,
+)
+from .research_state import (
+    build_live_auto_research_projection,
     build_research_decision_candidates,
     build_research_evidence_graph_from_rollout_events,
 )


### PR DESCRIPTION
## Summary
- make auto-research CLI import quickstart_seed and research_state directly instead of taking migrated kernel functions through legacy_core
- make demo_e2e import the same migrated helpers directly
- extend the minimal-kernel smoke so this import boundary does not regress

## Validation
- python3 -m py_compile loopx/capabilities/auto_research/cli.py loopx/capabilities/auto_research/demo_e2e.py loopx/capabilities/auto_research/quickstart_seed.py loopx/capabilities/auto_research/research_state.py
- python3 examples/auto-research-minimal-kernel-smoke.py
- python3 examples/auto-research-quickstart-smoke.py
- python3 -m loopx.cli --format json auto-research quickstart --agent-id codex-side-bypass
- python3 examples/auto-research-worker-turn-smoke.py
- python3 examples/auto-research-worker-loop-smoke.py
- python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- python3 examples/auto-research-demo-supervisor-smoke.py
- git diff --check
- loopx check --scan-path loopx/capabilities/auto_research/cli.py --scan-path loopx/capabilities/auto_research/demo_e2e.py --scan-path examples/auto-research-minimal-kernel-smoke.py