### PR TITLE
Honor reverse tunnel egress for host-local Codex

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -228,6 +228,61 @@ def test_codex_app_server_goal_requires_public_safe_codex_api_tunnel_contract() 
         assert config["codex_api_reverse_tunnel_proxy_url_recorded"] is False, config
         assert proxy_url not in json.dumps(config, sort_keys=True), config
 
+        benchmark_proxy_url = "http://benchmark-proxy.example.invalid:3128"
+        codex_acp_args = parse_args(
+            [
+                "--task-id",
+                "citation-check",
+                "--route",
+                "codex-acp-blind-loop-baseline",
+                "--host-local-acp-launch",
+                "--codex-api-egress-mode",
+                "reverse-tunnel",
+                "--codex-api-reverse-tunnel-proxy",
+                proxy_url,
+                "--benchmark-egress-proxy",
+                benchmark_proxy_url,
+                "--benchmark-egress-proxy-mode",
+                "require",
+                "--skillsbench-root",
+                str(skillsbench_root),
+                "--jobs-dir",
+                str(root / "jobs-codex-acp"),
+            ]
+        )
+        codex_acp_plan = build_plan(codex_acp_args)
+        codex_acp_egress = codex_acp_plan["codex_api_egress_preflight"]
+        assert codex_acp_egress["required"] is True, codex_acp_egress
+        assert codex_acp_egress["resolved_mode"] == "reverse-tunnel", codex_acp_egress
+        assert codex_acp_egress["reverse_tunnel_required"] is True, codex_acp_egress
+        codex_acp_config = codex_acp_plan["runner_config"]
+        assert (
+            codex_acp_config["codex_api_egress_mode_resolved"] == "reverse-tunnel"
+        ), codex_acp_config
+        assert codex_acp_config["codex_api_reverse_tunnel_required"] is True, (
+            codex_acp_config
+        )
+        agent_env = {
+            "HTTPS_PROXY": benchmark_proxy_url,
+            "HTTP_PROXY": benchmark_proxy_url,
+            "ALL_PROXY": benchmark_proxy_url,
+            "LOOPX_SKILLSBENCH_EGRESS_PROXY": benchmark_proxy_url,
+        }
+        codex_acp_target_env = skillsbench_loop._host_local_acp_target_env(
+            agent_env,
+            args=codex_acp_args,
+        )
+        for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY"):
+            assert codex_acp_target_env[key] == proxy_url, codex_acp_target_env
+        assert (
+            codex_acp_target_env["LOOPX_SKILLSBENCH_EGRESS_PROXY"]
+            == benchmark_proxy_url
+        ), codex_acp_target_env
+        assert benchmark_proxy_url not in json.dumps(
+            codex_acp_config,
+            sort_keys=True,
+        ), codex_acp_config
+
 
 def test_benchmark_egress_proxy_env_is_public_safe_and_forwarded() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-benchmark-egress-proxy-") as tmp:

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -1323,10 +1323,12 @@ def _effective_local_codex_task_output_quiet_timeout_sec(
 
 
 def _codex_api_egress_preflight_required(args: argparse.Namespace) -> bool:
-    return (
-        getattr(args, "route", "") == "codex-app-server-goal-baseline"
-        and bool(getattr(args, "host_local_acp_launch", False))
-    )
+    if not bool(getattr(args, "host_local_acp_launch", False)):
+        return False
+    requested = _codex_api_egress_requested_mode(args)
+    if requested in {"reverse-tunnel", "direct"}:
+        return True
+    return getattr(args, "route", "") == "codex-app-server-goal-baseline"
 
 
 def _codex_api_egress_requested_mode(args: argparse.Namespace | None) -> str:
@@ -1339,13 +1341,15 @@ def _codex_api_egress_requested_mode(args: argparse.Namespace | None) -> str:
 
 
 def _codex_api_egress_resolved_mode(args: argparse.Namespace | None) -> str:
-    if args is None or not _codex_api_egress_preflight_required(args):
+    if args is None or not bool(getattr(args, "host_local_acp_launch", False)):
         return "not_required"
     requested = _codex_api_egress_requested_mode(args)
     if requested == "auto":
         # Formal remote app-server benchmark runs must use the reverse tunnel
         # path by default; direct egress is only for explicit local debugging.
-        return "reverse-tunnel"
+        if getattr(args, "route", "") == "codex-app-server-goal-baseline":
+            return "reverse-tunnel"
+        return "not_required"
     return requested
 
 
@@ -1952,7 +1956,11 @@ def _host_local_acp_target_env(
             continue
         target_env[key] = str(value)
     proxy_url, _proxy_source = _codex_api_reverse_tunnel_proxy(args)
-    if proxy_url and args is not None and _codex_api_egress_preflight_required(args):
+    if (
+        proxy_url
+        and args is not None
+        and _codex_api_egress_resolved_mode(args) == "reverse-tunnel"
+    ):
         for key in CODEX_API_PROXY_FORWARD_ENV_KEYS:
             target_env[key] = proxy_url
         target_env.setdefault("NO_PROXY", "localhost,127.0.0.1,::1")
@@ -14772,11 +14780,12 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         choices=CODEX_API_EGRESS_MODE_CHOICES,
         default=os.environ.get("LOOPX_CODEX_API_EGRESS_MODE", "auto"),
         help=(
-            "How native app-server goal workers reach the Codex backend. "
-            "For formal host-local app-server benchmark runs, auto resolves "
-            "to reverse-tunnel so the runner fails fast unless a checked HTTP "
-            "CONNECT reverse tunnel proxy is configured. direct is intended "
-            "only for explicit local debugging."
+            "How host-local Codex workers reach the Codex backend. For formal "
+            "host-local app-server benchmark runs, auto resolves to "
+            "reverse-tunnel so the runner fails fast unless a checked HTTP "
+            "CONNECT reverse tunnel proxy is configured. For other host-local "
+            "routes, explicit reverse-tunnel/direct requests are honored; "
+            "direct is intended only for explicit local debugging."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- honor explicit Codex API egress modes for all host-local Codex workers, not only app-server route
- let reverse-tunnel Codex API proxy override benchmark egress proxy in the host-local ACP target env
- add a regression smoke for codex-acp host-local runs where benchmark setup proxy and Codex API reverse tunnel are both configured

## Validation
- `python3 - <<'PY' ... test_codex_app_server_goal_requires_public_safe_codex_api_tunnel_contract() ... PY`
- `python3 examples/skillsbench-host-local-launch-plan-smoke.py`
- `python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py`
- `git diff --check`
- `loopx check --scan-path scripts/skillsbench_automation_loop.py --scan-path examples/skillsbench-benchmark-run-smoke.py`

## Note
- Full `python3 examples/skillsbench-benchmark-run-smoke.py` still fails on an existing ledger-repeat fixture assertion (`test_skillsbench_repeat_same_mode_keeps_distinct_ledger_runs`), unrelated to this egress patch.
