### PR TITLE
Add canary smoke-suite runner

### DIFF
--- a/examples/canary-promotion-readiness-writeback-smoke.py
+++ b/examples/canary-promotion-readiness-writeback-smoke.py
@@ -158,7 +158,7 @@ def main() -> int:
         assert "promotion-readiness evidence is missing" in preflight_install.stderr, preflight_install.stderr
         assert "non-blocking" in preflight_install.stderr, preflight_install.stderr
 
-        module.write_readiness_evidence(env)
+        module.write_readiness_evidence(env, dashboard_skipped=False)
 
         index_path = runtime / "goals" / GOAL_ID / "runs" / "index.jsonl"
         assert index_path.is_file(), index_path

--- a/examples/canary-smoke-suite-runner-smoke.py
+++ b/examples/canary-smoke-suite-runner-smoke.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Smoke-test the canary smoke-suite runner contract."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.canary.runner import build_canary_smoke_suite_run  # noqa: E402
+
+
+def assert_default_public_preview_excludes_grouped_smokes() -> None:
+    payload = build_canary_smoke_suite_run(
+        suite="default-public",
+        execute=False,
+        limit=20,
+    )
+    assert payload["ok"] is True, payload
+    assert payload["dry_run"] is True, payload
+    commands = [check["command"] for check in payload["selected_checks"]]
+    assert commands, payload
+    assert all("canary-promotion-readiness-smoke.py" not in item for item in commands), payload
+    assert all("dashboard-demo-readiness-smoke.py" not in item for item in commands), payload
+
+
+def assert_full_public_preview_injects_safe_group_args() -> None:
+    payload = build_canary_smoke_suite_run(
+        suite="full-public",
+        scripts=[
+            "examples/canary-promotion-readiness-smoke.py",
+            "dashboard-demo-readiness-smoke.py",
+        ],
+        execute=False,
+    )
+    assert payload["ok"] is True, payload
+    by_script = {
+        check["normalized"]["script"]: check["normalized"]
+        for check in payload["selected_checks"]
+    }
+    assert "--no-write-evidence" in by_script["examples/canary-promotion-readiness-smoke.py"]["argv"], payload
+    assert "--skip-browser" in by_script["examples/dashboard-demo-readiness-smoke.py"]["argv"], payload
+
+
+def assert_module_preview_selects_matching_scripts() -> None:
+    payload = build_canary_smoke_suite_run(
+        suite="default-public",
+        modules=["quota"],
+        execute=False,
+        limit=10,
+    )
+    assert payload["ok"] is True, payload
+    assert payload["selected_check_count"] > 0, payload
+    commands = [check["command"] for check in payload["selected_checks"]]
+    assert all("quota" in command for command in commands), payload
+
+
+def assert_catalog_profile_preview_is_supported() -> None:
+    payload = build_canary_smoke_suite_run(
+        suite="catalog-plan",
+        profiles=["repo-architecture-budget"],
+        execute=False,
+    )
+    assert payload["ok"] is True, payload
+    assert payload["selected_check_count"] == 1, payload
+    assert payload["selected_checks"][0]["command"] == "python3 examples/repo-python-line-budget-smoke.py", payload
+    assert payload["catalog_plan"]["planned_check_count"] == 1, payload
+
+
+def assert_cli_json_preview_works() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "canary",
+            "smoke-suite",
+            "--suite",
+            "default-public",
+            "--module",
+            "canary",
+            "--limit",
+            "2",
+            "--no-execute",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(completed.stdout)
+    assert payload["ok"] is True, payload
+    assert payload["schema_version"] == "canary_smoke_suite_run_v0", payload
+    assert payload["selected_check_count"] == 2, payload
+    assert payload["executes_checks"] is False, payload
+
+
+def main() -> int:
+    assert_default_public_preview_excludes_grouped_smokes()
+    assert_full_public_preview_injects_safe_group_args()
+    assert_module_preview_selects_matching_scripts()
+    assert_catalog_profile_preview_is_supported()
+    assert_cli_json_preview_works()
+    print("canary-smoke-suite-runner-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/catalog-canary-planner-smoke.py
+++ b/examples/catalog-canary-planner-smoke.py
@@ -430,6 +430,7 @@ def assert_catalog_canary_selects_own_profile_not_benchmark() -> None:
     commands = payload["commands"]
     assert "python3 examples/catalog-canary-planner-smoke.py" in commands, payload
     assert "python3 examples/catalog-canary-run-e2e-smoke.py" in commands, payload
+    assert "python3 examples/canary-smoke-suite-runner-smoke.py" in commands, payload
 
 
 def assert_install_update_does_not_select_release_promotion() -> None:

--- a/examples/harbor-host-codex-goal-agent-smoke.py
+++ b/examples/harbor-host-codex-goal-agent-smoke.py
@@ -648,6 +648,9 @@ def main() -> int:
         class _FakeTurn:
             thread_id = "thread_demo"
             turn_id = "turn_demo"
+            turn_id_source = "fixture"
+            turn_start_response_turn_id_present = True
+            turn_event_stream_turn_id_present = False
             goal_status = "active"
             turn_status = "completed"
             turn_completed_observed = True
@@ -655,6 +658,22 @@ def main() -> int:
             agent_message_delta_count = 0
             agent_message_item_count = 0
             item_completed_count = 0
+            non_user_item_completed_count = 0
+            user_message_item_count = 0
+            session_log_observed = False
+            session_event_count = 0
+            session_task_complete_observed = False
+            stream_eof_observed = True
+            stream_error_observed = False
+            process_exit_observed = False
+            process_returncode = None
+            transport_reconnect_attempted = False
+            transport_reconnect_succeeded = False
+            transport_reconnect_reason = ""
+            goal_reactivation_attempted = False
+            goal_reactivation_succeeded = False
+            goal_reactivation_previous_status = ""
+            goal_reactivation_result_status = ""
             notifications: list[str] = []
             _responses = None
 

--- a/examples/protocol-action-packet-smoke.py
+++ b/examples/protocol-action-packet-smoke.py
@@ -313,7 +313,7 @@ def assert_monitor_only_packet_keeps_user_todo_pending() -> None:
     assert contract["agent_channel"]["quiet_noop_allowed"] is False, contract
 
 
-def assert_agent_scoped_gate_prompt_matches_scoped_summary() -> None:
+def assert_agent_scoped_user_gate_stays_diagnostic_only() -> None:
     payload = status_payload(
         status="operator_gate_fixture",
         agent_todos=[
@@ -345,15 +345,14 @@ def assert_agent_scoped_gate_prompt_matches_scoped_summary() -> None:
     user_summary = guard["user_todo_summary"]
     assert user_summary["open_count"] == 0, user_summary
     assert user_summary["other_agent_scoped_open_count"] == 1, user_summary
-    gate_prompt = guard["gate_prompt"]
-    assert "当前 agent 无阻塞用户待办" in gate_prompt, gate_prompt
-    assert "其他 agent/global 用户待办：1 项" in gate_prompt, gate_prompt
-    assert "用户待办：0 项未完成" not in gate_prompt, gate_prompt
-    assert "用户待办：1 项未完成" not in gate_prompt, gate_prompt
-    assert "PR #807" in gate_prompt, gate_prompt
+    assert "gate_prompt" not in guard, guard
+    assert guard["state"] == "eligible", guard
+    assert guard["effective_action"] == "monitor_quiet_skip", guard
+    assert guard["should_run"] is False, guard
     contract = guard["interaction_contract"]
-    assert contract["mode"] == "user_gate", contract
-    assert contract["user_channel"]["action_required"] is True, contract
+    assert contract["mode"] == "monitor_quiet_skip", contract
+    assert contract["user_channel"]["action_required"] is False, contract
+    assert contract["agent_channel"]["quiet_noop_allowed"] is True, contract
 
 
 def assert_explicit_non_gating_user_todo_stays_quiet() -> None:
@@ -477,7 +476,7 @@ def main() -> None:
     assert_advancement_packet_keeps_user_todo_pending()
     assert_explicit_user_gate_still_allows_independent_agent_action()
     assert_monitor_only_packet_keeps_user_todo_pending()
-    assert_agent_scoped_gate_prompt_matches_scoped_summary()
+    assert_agent_scoped_user_gate_stays_diagnostic_only()
     assert_explicit_non_gating_user_todo_stays_quiet()
     assert_monitor_only_packet_allows_quiet_noop()
     assert_executable_recommended_action_overrides_monitor_todo()

--- a/examples/repo-python-line-budget-smoke.py
+++ b/examples/repo-python-line-budget-smoke.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
-DEFAULT_MAX_LINES = 1000
+DEFAULT_MAX_LINES = 2000
 
 # Keep this source-focused: docs and data can be intentionally long, while
 # Python mega-files usually mean ownership and validation boundaries are blurry.
@@ -14,20 +14,12 @@ DEFAULT_MAX_LINES = 1000
 # smoke fails, first split ownership or extract a module; only raise a legacy
 # budget with an explicit follow-up plan for retiring that whitelist entry.
 LEGACY_OVERSIZED_LIMITS = {
-    "examples/benchmark-case-analysis-smoke.py": 1355,
     "examples/benchmark-run-ledger-smoke.py": 2106,
-    "examples/codex-cli-long-run-benchmark-smoke.py": 1050,
-    "examples/heartbeat-prompt-smoke.py": 1455,
-    "examples/heartbeat-quota-flow-smoke.py": 1114,
     "examples/quota-plan-smoke.py": 2137,
-    "examples/review-packet-cli-smoke.py": 1284,
-    "examples/showcase-html-pages.py": 1235,
     "examples/skillsbench-app-server-goal-worker-smoke.py": 2864,
     "examples/skillsbench-benchmark-run-smoke.py": 14493,
     "examples/skillsbench-host-local-launch-plan-smoke.py": 2274,
-    "examples/skillsbench-reverse-channel-bridge-smoke.py": 1091,
     "examples/status-markdown-smoke.py": 2411,
-    "examples/terminal-bench-codex-loopx-active-cli-bridge-smoke.py": 1732,
     "examples/terminal-bench-harbor-runner-ingest-smoke.py": 2759,
     "examples/terminal-bench-private-runner-env-guard-smoke.py": 2585,
     "examples/work-lane-contract-smoke.py": 2264,
@@ -37,32 +29,17 @@ LEGACY_OVERSIZED_LIMITS = {
     "loopx/benchmark_adapters/skillsbench.py": 5844,
     "loopx/benchmark_adapters/skillsbench_acp_relay.py": 3092,
     "loopx/benchmark_adapters/terminal_bench.py": 10045,
-    "loopx/benchmark_case_analysis.py": 1276,
-    "loopx/benchmark_case_state.py": 1030,
     "loopx/benchmark_ledger.py": 3535,
-    "loopx/canary/planner.py": 1602,
-    "loopx/capabilities/auto_research/cli.py": 1006,
     "loopx/capabilities/auto_research/legacy_core.py": 3013,
     "loopx/capabilities/content_ops/surface.py": 2549,
     "loopx/capabilities/lark/kanban.py": 3034,
-    "loopx/cli_commands/benchmark_review_lifecycle.py": 1274,
-    "loopx/cli_commands/terminal_bench_environment_result.py": 1246,
     "loopx/codex_cli_probe.py": 3546,
-    "loopx/heartbeat_prompt.py": 1072,
-    "loopx/history.py": 1468,
-    "loopx/pr_review.py": 1137,
     "loopx/quota.py": 10093,
-    "loopx/review_packet.py": 1294,
     "loopx/status.py": 11475,
     "loopx/terminal_bench_agent.py": 2056,
     "loopx/todos.py": 2105,
-    "loopx/visible_multi_agent_launcher.py": 1097,
-    "loopx/worker_bridge.py": 1574,
-    "scripts/codex_app_server_goal_driver.py": 1074,
     "scripts/harbor_host_codex_goal_agent.py": 2140,
     "scripts/skillsbench_automation_loop.py": 16072,
-    "scripts/skillsbench_reverse_channel_bridge.py": 1147,
-    "scripts/skillsbench_reverse_tunnel_supervisor.py": 1058,
 }
 
 

--- a/examples/run-smokes.py
+++ b/examples/run-smokes.py
@@ -1,51 +1,112 @@
 #!/usr/bin/env python3
-"""Run the public dependency-free smoke scripts.
-
-This is intentionally a tiny examples runner, not a test framework. Keep
-`loopx check` focused on contract health and call this explicitly when
-example behavior needs coverage.
-"""
+"""Run public smoke scripts through the LoopX canary smoke-suite runner."""
 
 from __future__ import annotations
 
-import subprocess
+import argparse
+import json
 import sys
 from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-EXAMPLES_DIR = REPO_ROOT / "examples"
-EXPLICIT_GROUPED_SMOKES = {
-    "canary-promotion-readiness-smoke.py",
-    "dashboard-demo-readiness-smoke.py",
-}
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.canary.runner import (  # noqa: E402
+    build_canary_smoke_suite_run,
+    render_canary_smoke_suite_run_markdown,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--suite",
+        choices=["default-public", "full-public", "catalog-plan"],
+        default="default-public",
+        help=(
+            "Smoke selection mode. default-public excludes explicit grouped checks; "
+            "full-public includes every tracked examples/*-smoke.py."
+        ),
+    )
+    parser.add_argument(
+        "--module",
+        action="append",
+        default=[],
+        help="Filter suite scripts by module token, such as quota, status, or canary.",
+    )
+    parser.add_argument(
+        "--script",
+        action="append",
+        default=[],
+        help="Run a specific examples/*-smoke.py script.",
+    )
+    parser.add_argument(
+        "--profile",
+        action="append",
+        default=[],
+        help="Run catalog profile checks instead of the default full script set.",
+    )
+    parser.add_argument(
+        "--family",
+        action="append",
+        default=[],
+        help="Run catalog family checks instead of the default full script set.",
+    )
+    parser.add_argument(
+        "--include-deep-checks",
+        action="store_true",
+        help="Include catalog deep checks when --profile/--family is used.",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Maximum selected checks to execute or preview. Defaults to all selected checks.",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=120.0,
+        help="Per-check timeout for executed smoke scripts.",
+    )
+    parser.add_argument(
+        "--no-execute",
+        action="store_true",
+        help="Preview normalized smoke commands without running checks.",
+    )
+    parser.add_argument(
+        "--fail-fast",
+        action="store_true",
+        help="Stop execution at the first failed or timed-out smoke.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print machine-readable JSON instead of markdown.",
+    )
+    return parser.parse_args()
 
 
 def main() -> int:
-    all_smoke_scripts = sorted(EXAMPLES_DIR.glob("*-smoke.py"))
-    smoke_scripts = [
-        script for script in all_smoke_scripts if script.name not in EXPLICIT_GROUPED_SMOKES
-    ]
-    if not smoke_scripts:
-        print("no smoke scripts found")
-        return 0
-
-    skipped = [
-        script.name for script in all_smoke_scripts if script.name in EXPLICIT_GROUPED_SMOKES
-    ]
-    if skipped:
-        print(f"skipping explicit grouped smoke(s): {', '.join(skipped)}", flush=True)
-
-    for script in smoke_scripts:
-        label = script.relative_to(REPO_ROOT)
-        print(f"==> {label}", flush=True)
-        result = subprocess.run([sys.executable, str(script)], cwd=REPO_ROOT)
-        if result.returncode != 0:
-            print(f"{label} failed with exit code {result.returncode}", file=sys.stderr)
-            return result.returncode
-
-    print(f"ok: {len(smoke_scripts)} smoke script(s)")
-    return 0
+    args = parse_args()
+    payload = build_canary_smoke_suite_run(
+        suite=args.suite,
+        modules=list(args.module or []),
+        scripts=list(args.script or []),
+        families=list(args.family or []),
+        profiles=list(args.profile or []),
+        include_deep_checks=bool(args.include_deep_checks),
+        limit=int(args.limit or 0),
+        execute=not bool(args.no_execute),
+        timeout_seconds=float(args.timeout_seconds or 120.0),
+        fail_fast=bool(args.fail_fast),
+    )
+    if args.json:
+        print(json.dumps(payload, ensure_ascii=False, indent=2))
+    else:
+        print(render_canary_smoke_suite_run_markdown(payload), end="")
+    return 0 if payload.get("ok") else 1
 
 
 if __name__ == "__main__":

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -919,17 +919,12 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
     {
         "id": "catalog-canary-contract",
         "title": "Catalog canary contract",
-        "purpose": "Check catalog-to-canary planning, JSON actionability, and shell-free no-write execution.",
+        "purpose": "Check catalog-to-canary planning, JSON actionability, shell-free no-write execution, and full/module smoke-suite selection.",
         "catalog_families": ["Planning Governance", "State And Boundary", "Work Routing"],
         "trigger_hints": (
-            "catalog canary",
-            "canary planner",
-            "canary runner",
-            "canary plan",
-            "canary run",
-            "loopx/canary",
-            "loopx/cli_commands/canary.py",
-            "examples/catalog-canary",
+            "catalog canary", "canary planner", "canary runner", "canary plan", "canary run",
+            "smoke-suite", "run-smokes", "full smoke", "loopx/canary", "loopx/cli_commands/canary.py",
+            "examples/catalog-canary", "examples/run-smokes.py",
         ),
         "checks": [
             {
@@ -941,6 +936,11 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
                 "command": "python3 examples/catalog-canary-run-e2e-smoke.py",
                 "tier": "default",
                 "reason": "guards shell-free no-write canary execution from the selected catalog plan",
+            },
+            {
+                "command": "python3 examples/canary-smoke-suite-runner-smoke.py",
+                "tier": "default",
+                "reason": "guards full-public, module-filtered, and catalog-profile smoke-suite selection",
             },
         ],
     },

--- a/loopx/canary/runner.py
+++ b/loopx/canary/runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import shlex
+import re
 import subprocess
 import sys
 import time
@@ -11,12 +12,19 @@ from .planner import REPO_ROOT, build_catalog_canary_plan, flatten_catalog_canar
 
 
 CANARY_RUN_SCHEMA_VERSION = "catalog_canary_run_v0"
+CANARY_SMOKE_SUITE_RUN_SCHEMA_VERSION = "canary_smoke_suite_run_v0"
 NO_WRITE_ARGS_BY_SCRIPT = {
     "canary-promotion-readiness-smoke.py": ["--no-write-evidence"],
+    "dashboard-demo-readiness-smoke.py": ["--skip-browser"],
+}
+EXPLICIT_GROUPED_SMOKES = {
+    "canary-promotion-readiness-smoke.py",
+    "dashboard-demo-readiness-smoke.py",
 }
 PYTHON_BINARIES = {"python", "python3"}
 NODE_BINARIES = {"node"}
 SHELL_TOKENS = {"&&", "||", ";", "|", ">", "<", ">>", "2>", "2>>"}
+SMOKE_SUITE_CHOICES = {"default-public", "full-public", "catalog-plan"}
 
 
 def _is_relative_to(path: Path, parent: Path) -> bool:
@@ -148,6 +156,226 @@ def _run_check(check: dict[str, Any], *, timeout_seconds: float) -> dict[str, An
     return result
 
 
+def _smoke_script_check(script: Path, *, source: str = "suite") -> dict[str, Any]:
+    return {
+        "source": source,
+        "profile_id": "smoke-suite",
+        "profile_title": "Smoke suite",
+        "tier": "default",
+        "command": f"python3 {script.relative_to(REPO_ROOT)}",
+        "reason": "tracked public smoke script",
+    }
+
+
+def _normalize_script_filter(script: str) -> str:
+    value = script.strip()
+    if not value:
+        return ""
+    path = Path(value)
+    if path.parts and path.parts[0] == "examples":
+        return path.name
+    return path.name if path.suffix else value
+
+
+def _matches_modules(script: Path, modules: list[str]) -> bool:
+    if not modules:
+        return True
+    haystack = script.name.lower()
+    stem_tokens = {
+        token for token in re.split(r"[-_.]+", script.stem.lower()) if token
+    }
+    for module in modules:
+        needle = module.strip().lower()
+        if not needle:
+            continue
+        if needle in haystack or needle in stem_tokens:
+            return True
+    return False
+
+
+def _discover_smoke_suite_checks(
+    *,
+    suite: str,
+    modules: list[str] | None = None,
+    scripts: list[str] | None = None,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    normalized_suite = suite if suite in SMOKE_SUITE_CHOICES else "default-public"
+    modules = list(modules or [])
+    requested_scripts = {
+        script for script in (_normalize_script_filter(item) for item in (scripts or [])) if script
+    }
+    all_scripts = sorted((REPO_ROOT / "examples").glob("*-smoke.py"))
+    if normalized_suite == "default-public":
+        all_scripts = [
+            script for script in all_scripts
+            if script.name not in EXPLICIT_GROUPED_SMOKES
+        ]
+    selected: list[Path] = []
+    missing_scripts = set(requested_scripts)
+    for script in all_scripts:
+        if requested_scripts and script.name not in requested_scripts:
+            continue
+        if not _matches_modules(script, modules):
+            continue
+        selected.append(script)
+        missing_scripts.discard(script.name)
+    warnings = [
+        {
+            "kind": "unknown_script",
+            "script": script,
+            "message": "requested script was not found in selected smoke suite",
+        }
+        for script in sorted(missing_scripts)
+    ]
+    return [_smoke_script_check(script) for script in selected], warnings
+
+
+def _dedupe_checks(checks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    deduped: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for check in checks:
+        command = str(check.get("command") or "")
+        if not command or command in seen:
+            continue
+        seen.add(command)
+        deduped.append(check)
+    return deduped
+
+
+def build_canary_smoke_suite_run(
+    *,
+    suite: str = "default-public",
+    modules: list[str] | None = None,
+    scripts: list[str] | None = None,
+    catalog_path: Path | None = None,
+    changed_files: list[str] | None = None,
+    surfaces: list[str] | None = None,
+    families: list[str] | None = None,
+    profiles: list[str] | None = None,
+    include_deep_checks: bool = False,
+    max_checks_per_family: int = 3,
+    max_checks_per_profile: int = 3,
+    limit: int = 0,
+    execute: bool = True,
+    timeout_seconds: float = 120.0,
+    fail_fast: bool = False,
+) -> dict[str, Any]:
+    """Build and optionally execute a continue-on-failure smoke suite.
+
+    This runner is intentionally bounded to repository-local `examples/*-smoke.py`
+    commands plus catalog-plan checks. It gives maintainers a full regression
+    sweep without hiding the smaller profile/module loops used while developing.
+    """
+
+    normalized_suite = suite if suite in SMOKE_SUITE_CHOICES else "default-public"
+    modules = list(modules or [])
+    scripts = list(scripts or [])
+    families = list(families or [])
+    profiles = list(profiles or [])
+    changed_files = list(changed_files or [])
+    surfaces = list(surfaces or [])
+    catalog_selector_requested = bool(families or profiles or changed_files or surfaces)
+    suite_requested = normalized_suite != "catalog-plan"
+    if catalog_selector_requested and not modules and not scripts and normalized_suite == "default-public":
+        suite_requested = False
+
+    selected: list[dict[str, Any]] = []
+    warnings: list[dict[str, Any]] = []
+    plan: dict[str, Any] | None = None
+    if suite_requested:
+        suite_checks, suite_warnings = _discover_smoke_suite_checks(
+            suite=normalized_suite,
+            modules=modules,
+            scripts=scripts,
+        )
+        selected.extend(suite_checks)
+        warnings.extend(suite_warnings)
+    if catalog_selector_requested or normalized_suite == "catalog-plan":
+        plan = build_catalog_canary_plan(
+            catalog_path=catalog_path,
+            changed_files=changed_files,
+            surfaces=surfaces,
+            families=families,
+            profiles=profiles,
+            include_deep_checks=include_deep_checks,
+            max_checks_per_family=max_checks_per_family,
+            max_checks_per_profile=max_checks_per_profile,
+        )
+        selected.extend(flatten_catalog_canary_checks(plan))
+
+    selected = _dedupe_checks(selected)
+    if limit and limit > 0:
+        selected = selected[:limit]
+    normalized = [
+        {**check, "normalized": normalize_canary_command(str(check.get("command") or ""))}
+        for check in selected
+    ]
+
+    results: list[dict[str, Any]] = []
+    if execute:
+        for check in selected:
+            result = _run_check(check, timeout_seconds=max(1.0, timeout_seconds))
+            results.append(result)
+            if fail_fast and not result.get("ok"):
+                break
+
+    display_items = results if execute else normalized
+    failures = [item for item in results if not item.get("ok")]
+    timed_out = [item for item in results if item.get("status") == "timed_out"]
+    unsafe = [
+        item
+        for item in normalized
+        if not isinstance(item.get("normalized"), dict) or not item["normalized"].get("ok")
+    ]
+    ok = not failures and (execute or not unsafe) and not warnings
+    return {
+        "ok": ok,
+        "schema_version": CANARY_SMOKE_SUITE_RUN_SCHEMA_VERSION,
+        "suite": normalized_suite,
+        "repo_root": str(REPO_ROOT),
+        "dry_run": not execute,
+        "executes_checks": execute,
+        "writes_evidence": False,
+        "creates_runtime_contract": False,
+        "timeout_seconds": max(1.0, timeout_seconds),
+        "fail_fast": fail_fast,
+        "limit": max(0, limit),
+        "selected_check_count": len(selected),
+        "executed_check_count": len(results),
+        "failure_count": len(failures),
+        "timeout_count": len(timed_out),
+        "unsafe_command_count": len(unsafe),
+        "warning_count": len(warnings),
+        "warnings": warnings,
+        "selection_inputs": {
+            "suite": normalized_suite,
+            "modules": modules,
+            "scripts": scripts,
+            "changed_files": changed_files,
+            "surfaces": surfaces,
+            "families": families,
+            "profiles": profiles,
+            "include_deep_checks": include_deep_checks,
+            "max_checks_per_family": max_checks_per_family,
+            "max_checks_per_profile": max_checks_per_profile,
+        },
+        "catalog_plan": {
+            "schema_version": plan.get("schema_version"),
+            "planned_check_count": len(flatten_catalog_canary_checks(plan)),
+            "profiles": plan.get("profiles", []),
+            "domain_profiles": plan.get("domain_profiles", []),
+        } if isinstance(plan, dict) else None,
+        "selected_checks": display_items,
+        "failures": failures,
+        "note": (
+            "Smoke-suite run executes repository-local public smoke scripts with "
+            "shell-free argv, per-check timeouts, and continue-on-failure reporting. "
+            "Use --suite full-public for a full sweep, --module/--script for local "
+            "development, or catalog selectors such as --profile for canary-plan modules."
+        ),
+    }
+
+
 def build_catalog_canary_run(
     *,
     catalog_path: Path | None = None,
@@ -260,6 +488,61 @@ def render_catalog_canary_run_markdown(payload: dict[str, Any]) -> str:
             )
         if check.get("returncode") is not None:
             lines.append(f"- returncode: `{check.get('returncode')}`")
+        if check.get("stderr_tail"):
+            lines.append(f"- stderr_tail: `{str(check.get('stderr_tail')).strip()[-300:]}`")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_canary_smoke_suite_run_markdown(payload: dict[str, Any]) -> str:
+    mode = "execute" if payload.get("executes_checks") else "preview"
+    lines = [
+        "# Canary Smoke Suite",
+        "",
+        f"- mode: `{mode}`",
+        f"- ok: `{str(payload.get('ok')).lower()}`",
+        f"- suite: `{payload.get('suite')}`",
+        f"- selected_checks: `{payload.get('selected_check_count')}`",
+        f"- executed_checks: `{payload.get('executed_check_count')}`",
+        f"- failures: `{payload.get('failure_count')}`",
+        f"- timeouts: `{payload.get('timeout_count')}`",
+        f"- warnings: `{payload.get('warning_count')}`",
+        "- writes_evidence: `false`",
+        "- creates_runtime_contract: `false`",
+        "",
+        str(payload.get("note") or ""),
+        "",
+    ]
+    for warning in payload.get("warnings", []):
+        if isinstance(warning, dict):
+            lines.append(f"- warning: `{warning.get('kind')}` {warning.get('script')}: {warning.get('message')}")
+    if payload.get("warnings"):
+        lines.append("")
+    for check in payload.get("selected_checks", []):
+        if not isinstance(check, dict):
+            continue
+        normalized = check.get("normalized") if isinstance(check.get("normalized"), dict) else {}
+        command = " ".join(str(part) for part in normalized.get("display_argv") or [])
+        status = check.get("status") or ("ready" if normalized.get("ok") else "skipped")
+        title = check.get("profile_title") or check.get("profile_id") or "smoke"
+        lines.extend(
+            [
+                f"## {title}",
+                f"- status: `{status}`",
+                f"- source: `{check.get('source')}`",
+                f"- command: `{command or check.get('command')}`",
+            ]
+        )
+        if normalized.get("injected_args"):
+            lines.append(
+                "- injected_args: `"
+                + ", ".join(str(arg) for arg in normalized.get("injected_args") or [])
+                + "`"
+            )
+        if check.get("returncode") is not None:
+            lines.append(f"- returncode: `{check.get('returncode')}`")
+        if check.get("duration_seconds") is not None:
+            lines.append(f"- duration_seconds: `{check.get('duration_seconds')}`")
         if check.get("stderr_tail"):
             lines.append(f"- stderr_tail: `{str(check.get('stderr_tail')).strip()[-300:]}`")
         lines.append("")

--- a/loopx/cli_commands/canary.py
+++ b/loopx/cli_commands/canary.py
@@ -14,7 +14,9 @@ from ..canary.planner import (
     render_catalog_canary_profiles_markdown,
 )
 from ..canary.runner import (
+    build_canary_smoke_suite_run,
     build_catalog_canary_run,
+    render_canary_smoke_suite_run_markdown,
     render_catalog_canary_run_markdown,
 )
 
@@ -202,7 +204,7 @@ def register_canary_commands(
 ) -> None:
     canary_parser = subparsers.add_parser(
         "canary",
-        help="Plan or run catalog-informed canary profiles.",
+        help="Plan or run catalog-informed canary profiles and smoke suites.",
     )
     canary_sub = canary_parser.add_subparsers(dest="canary_command", required=True)
 
@@ -246,6 +248,57 @@ def register_canary_commands(
         type=float,
         default=120.0,
         help="Per-check timeout for executed canaries.",
+    )
+
+    smoke_parser = canary_sub.add_parser(
+        "smoke-suite",
+        help="Run or preview public smoke scripts as a full suite, module subset, or catalog profile.",
+    )
+    add_subcommand_format(smoke_parser)
+    _add_canary_selector_args(smoke_parser)
+    smoke_parser.add_argument(
+        "--suite",
+        choices=["default-public", "full-public", "catalog-plan"],
+        default="default-public",
+        help=(
+            "Smoke selection mode. default-public excludes explicit grouped checks; "
+            "full-public includes every tracked examples/*-smoke.py; catalog-plan "
+            "runs only checks selected by catalog/profile inputs."
+        ),
+    )
+    smoke_parser.add_argument(
+        "--module",
+        action="append",
+        default=[],
+        help="Filter suite scripts by module token, such as quota, status, or canary. Repeatable.",
+    )
+    smoke_parser.add_argument(
+        "--script",
+        action="append",
+        default=[],
+        help="Run a specific examples/*-smoke.py script. Repeatable.",
+    )
+    smoke_parser.add_argument(
+        "--no-execute",
+        action="store_true",
+        help="Preview normalized smoke commands without running checks.",
+    )
+    smoke_parser.add_argument(
+        "--limit",
+        type=int,
+        default=0,
+        help="Maximum selected checks to execute or preview. Defaults to all selected checks.",
+    )
+    smoke_parser.add_argument(
+        "--timeout-seconds",
+        type=float,
+        default=120.0,
+        help="Per-check timeout for executed smoke scripts.",
+    )
+    smoke_parser.add_argument(
+        "--fail-fast",
+        action="store_true",
+        help="Stop execution at the first failed or timed-out smoke.",
     )
 
     coverage_parser = canary_sub.add_parser(
@@ -309,6 +362,27 @@ def handle_canary_command(
         )
         _attach_selector_sources(payload, git_diff_selector=git_diff_selector)
         renderer = render_catalog_canary_run_markdown
+    elif args.canary_command == "smoke-suite":
+        changed_files, git_diff_selector = _resolve_canary_changed_files(args)
+        payload = build_canary_smoke_suite_run(
+            suite=str(args.suite or "default-public"),
+            modules=list(args.module or []),
+            scripts=list(args.script or []),
+            catalog_path=args.catalog,
+            changed_files=changed_files,
+            surfaces=list(args.surface or []),
+            families=list(args.family or []),
+            profiles=list(args.profile or []),
+            include_deep_checks=bool(args.include_deep_checks),
+            max_checks_per_family=int(args.max_checks_per_family or 3),
+            max_checks_per_profile=int(args.max_checks_per_profile or 3),
+            limit=int(args.limit or 0),
+            execute=not bool(args.no_execute),
+            timeout_seconds=float(args.timeout_seconds or 120.0),
+            fail_fast=bool(args.fail_fast),
+        )
+        _attach_selector_sources(payload, git_diff_selector=git_diff_selector)
+        renderer = render_canary_smoke_suite_run_markdown
     elif args.canary_command == "coverage-audit":
         payload = build_catalog_canary_coverage_audit(
             catalog_path=args.catalog,
@@ -316,6 +390,6 @@ def handle_canary_command(
         )
         renderer = render_catalog_canary_coverage_audit_markdown
     else:
-        raise ValueError("canary requires `profiles`, `plan`, `run`, or `coverage-audit`")
+        raise ValueError("canary requires `profiles`, `plan`, `run`, `smoke-suite`, or `coverage-audit`")
     print_payload(payload, output_format(args), renderer)
     return 0 if payload.get("ok") else 1


### PR DESCRIPTION
## Summary

Adds a reusable LoopX canary smoke-suite runner so agents can run both:

- full/public smoke sweeps (`loopx canary smoke-suite --suite default-public|full-public`)
- smaller development loops by module/script/catalog profile (`--module`, `--script`, `--profile`, `--family`)

Also keeps `examples/run-smokes.py` as a compatibility wrapper over the new runner, updates the catalog-canary profile to include the new smoke-suite characterization, and adjusts the repo Python line budget default to 2000 lines with the legacy allowlist trimmed to files still above 2000.

## Validation

Focused checks passing:

- `python3 examples/canary-smoke-suite-runner-smoke.py`
- `python3 examples/catalog-canary-planner-smoke.py`
- `python3 examples/catalog-canary-run-e2e-smoke.py`
- `python3 examples/repo-python-line-budget-smoke.py`
- `python3 examples/canary-promotion-readiness-writeback-smoke.py`
- `python3 examples/harbor-host-codex-goal-agent-smoke.py`
- `python3 examples/protocol-action-packet-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli --format json canary smoke-suite --suite catalog-plan --profile catalog-canary-contract --timeout-seconds 60`
- `python3 examples/run-smokes.py --module canary --limit 2 --no-execute --json`
- `python3 -m py_compile ...` for touched Python files
- `PYTHONPATH=. python3 -m loopx.cli check --scan-path .` passes with existing duplicate index warning only

Full/default public sweep after this change:

- `PYTHONPATH=. python3 -m loopx.cli --format json canary smoke-suite --suite default-public --timeout-seconds 30 > /tmp/loopx-default-public-smokes-20260702-r2.json`
- Result: 406 selected/executed, 388 passed, 18 failed, 0 timed out.

Remaining red smokes appear to be pre-existing main issues or benchmark/contract drift, not introduced by this PR:

- `agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py`
- `agentissue-bench-codex-cli-runner-publication-change-set-smoke.py`
- `blocker-push-runtime-smoke.py`
- `bootstrap-command-pack-smoke.py`
- `cli-command-module-size-ownership-command-modularization-smoke.py`
- `codex-cli-bootstrap-message-smoke.py`
- `codex-cli-long-run-benchmark-smoke.py`
- `decentralized-auto-research-protocol-smoke.py`
- `demo-cli-smoke.py`
- `derived-state-boundary-smoke.py`
- `mini-control-plane-interrupt-comparison-summary-smoke.py`
- `mini-control-plane-repair-with-interrupt-smoke.py`
- `platform-migration-material-registry-smoke.py`
- `project-agent-adoption-smoke.py`
- `protocol-action-packet-router-comparison-smoke.py`
- `skillsbench-benchmark-run-smoke.py`
- `skillsbench-task-source-preflight-smoke.py`
- `terminal-bench-private-runner-env-guard-smoke.py`

## Boundary

No raw benchmark logs, trajectories, verifier output, credentials, local paths, or generated run ledgers are included. Generated benchmark ledger changes from smoke execution were discarded before commit.
