### PR TITLE
Add pytest facade for canary smoke suite

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -138,6 +138,26 @@ promotion-readiness evidence:
 python3 examples/canary-promotion-readiness-smoke.py
 ```
 
+For broader source-checkout regressions, keep `loopx canary smoke-suite` as the
+source of truth. Local and LoopX automation should continue to use the runner
+payload directly:
+
+```bash
+python3 examples/run-smokes.py --suite default-public --module canary
+loopx canary smoke-suite --suite default-public --module canary
+```
+
+CI may wrap the same runner selection in pytest when JUnit reporting is useful.
+The pytest facade still executes each `examples/*-smoke.py` through a
+subprocess; it is not a migration of legacy smokes into pytest unit tests:
+
+```bash
+python3 -m pytest tests/test_smoke_suite.py \
+  --loopx-smoke-suite default-public \
+  --loopx-smoke-module canary \
+  --junitxml smoke-suite.xml
+```
+
 If the source checkout has optional frontend dependencies installed, dashboard
 readiness can be included in the same canary. If a release snapshot omits the
 dashboard app, the canary should degrade gracefully and record that boundary

--- a/examples/catalog-canary-planner-smoke.py
+++ b/examples/catalog-canary-planner-smoke.py
@@ -431,6 +431,21 @@ def assert_catalog_canary_selects_own_profile_not_benchmark() -> None:
     assert "python3 examples/catalog-canary-planner-smoke.py" in commands, payload
     assert "python3 examples/catalog-canary-run-e2e-smoke.py" in commands, payload
     assert "python3 examples/canary-smoke-suite-runner-smoke.py" in commands, payload
+    assert "python3 examples/pytest-smoke-suite-facade-smoke.py" not in commands, payload
+
+
+def assert_catalog_canary_deep_profile_includes_pytest_facade() -> None:
+    payload = build_catalog_canary_plan(
+        profiles=["catalog-canary-contract"],
+        include_deep_checks=True,
+        max_checks_per_profile=4,
+    )
+    assert payload["domain_profile_count"] == 1, payload
+    profile = payload["domain_profiles"][0]
+    assert profile["id"] == "catalog-canary-contract", profile
+    assert profile["deep_checks_included"] is True, profile
+    commands = payload["commands"]
+    assert "python3 examples/pytest-smoke-suite-facade-smoke.py" in commands, payload
 
 
 def assert_install_update_does_not_select_release_promotion() -> None:
@@ -680,6 +695,7 @@ def main() -> int:
     assert_explicit_profile_can_include_deep_checks()
     assert_explicit_catalog_profile_id_selects_family_profile()
     assert_catalog_canary_selects_own_profile_not_benchmark()
+    assert_catalog_canary_deep_profile_includes_pytest_facade()
     assert_install_update_does_not_select_release_promotion()
     assert_coverage_audit_tracks_p0_p1_patterns()
     tmp = tempfile.mkdtemp(prefix="loopx-catalog-canary-smoke-")

--- a/examples/pytest-smoke-suite-facade-smoke.py
+++ b/examples/pytest-smoke-suite-facade-smoke.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Smoke-test the optional pytest facade over the canary smoke-suite runner."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _pytest_command() -> list[str] | None:
+    uvx = shutil.which("uvx")
+    if uvx:
+        return [uvx, "--with", "pytest>=8,<9", "pytest"]
+    try:
+        import pytest  # noqa: F401
+    except Exception:
+        return None
+    return [sys.executable, "-m", "pytest"]
+
+
+def main() -> int:
+    command_prefix = _pytest_command()
+    if command_prefix is None:
+        print("pytest-smoke-suite-facade-smoke skipped: pytest or uvx is unavailable")
+        return 0
+
+    with tempfile.TemporaryDirectory(prefix="loopx-pytest-smoke-suite-") as tmp_dir:
+        junit_path = Path(tmp_dir) / "smoke-suite.xml"
+        completed = subprocess.run(
+            [
+                *command_prefix,
+                "-q",
+                "tests/test_smoke_suite.py",
+                "--loopx-smoke-suite",
+                "catalog-plan",
+                "--loopx-smoke-profile",
+                "catalog-canary-contract",
+                "--loopx-smoke-limit",
+                "1",
+                "--loopx-smoke-timeout",
+                "60",
+                "--junitxml",
+                str(junit_path),
+            ],
+            cwd=REPO_ROOT,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            timeout=120,
+        )
+        if completed.returncode != 0:
+            raise AssertionError(
+                "pytest smoke-suite facade failed\n"
+                f"stdout:\n{completed.stdout[-2000:]}\n"
+                f"stderr:\n{completed.stderr[-2000:]}"
+            )
+        xml = junit_path.read_text(encoding="utf-8")
+        assert "<testsuite" in xml or "<testsuites" in xml, xml[:500]
+        assert "test_smoke_suite_script" in xml, xml[:500]
+
+    print("pytest-smoke-suite-facade-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -937,6 +937,11 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
                 "tier": "default",
                 "reason": "guards full-public, module-filtered, and catalog-profile smoke-suite selection",
             },
+            {
+                "command": "python3 examples/pytest-smoke-suite-facade-smoke.py",
+                "tier": "deep",
+                "reason": "guards optional pytest/JUnit reporting while keeping canary smoke-suite as source of truth",
+            },
         ],
     },
     {

--- a/loopx/canary/runner.py
+++ b/loopx/canary/runner.py
@@ -156,6 +156,16 @@ def _run_check(check: dict[str, Any], *, timeout_seconds: float) -> dict[str, An
     return result
 
 
+def run_canary_smoke_check(
+    check: dict[str, Any],
+    *,
+    timeout_seconds: float = 120.0,
+) -> dict[str, Any]:
+    """Execute one normalized canary smoke-suite check through the runner contract."""
+
+    return _run_check(check, timeout_seconds=max(1.0, timeout_seconds))
+
+
 def _smoke_script_check(script: Path, *, source: str = "suite") -> dict[str, Any]:
     return {
         "source": source,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,9 @@ license = { file = "LICENSE" }
 authors = [{ name = "LoopX contributors" }]
 dependencies = []
 
+[project.optional-dependencies]
+test = ["pytest>=8,<9"]
+
 [project.scripts]
 loopx = "loopx.cli:main"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.canary.runner import SMOKE_SUITE_CHOICES
+
+
+def pytest_addoption(parser) -> None:
+    group = parser.getgroup("loopx-smoke-suite")
+    group.addoption(
+        "--loopx-smoke-suite",
+        "--smoke-suite",
+        dest="loopx_smoke_suite",
+        choices=sorted(SMOKE_SUITE_CHOICES),
+        default="default-public",
+        help="Canary smoke-suite selector passed through to the LoopX runner.",
+    )
+    group.addoption(
+        "--loopx-smoke-module",
+        "--smoke-module",
+        action="append",
+        default=[],
+        dest="loopx_smoke_modules",
+        help="Module token filter passed through to the LoopX runner. Repeat or comma-separate.",
+    )
+    group.addoption(
+        "--loopx-smoke-script",
+        "--smoke-script",
+        action="append",
+        default=[],
+        dest="loopx_smoke_scripts",
+        help="examples/*-smoke.py selector passed through to the LoopX runner. Repeat or comma-separate.",
+    )
+    group.addoption(
+        "--loopx-smoke-profile",
+        "--smoke-profile",
+        action="append",
+        default=[],
+        dest="loopx_smoke_profiles",
+        help="Catalog profile selector passed through to the LoopX runner. Repeat or comma-separate.",
+    )
+    group.addoption(
+        "--loopx-smoke-family",
+        "--smoke-family",
+        action="append",
+        default=[],
+        dest="loopx_smoke_families",
+        help="Catalog family selector passed through to the LoopX runner. Repeat or comma-separate.",
+    )
+    group.addoption(
+        "--loopx-smoke-include-deep-checks",
+        "--smoke-include-deep-checks",
+        action="store_true",
+        default=False,
+        dest="loopx_smoke_include_deep_checks",
+        help="Include deep catalog checks when profile or family selectors are used.",
+    )
+    group.addoption(
+        "--loopx-smoke-limit",
+        "--smoke-limit",
+        type=int,
+        default=0,
+        dest="loopx_smoke_limit",
+        help="Maximum selected checks to run. Defaults to all selected checks.",
+    )
+    group.addoption(
+        "--loopx-smoke-timeout",
+        "--smoke-timeout",
+        type=float,
+        default=120.0,
+        dest="loopx_smoke_timeout",
+        help="Per-check timeout in seconds for each subprocess smoke.",
+    )

--- a/tests/test_smoke_suite.py
+++ b/tests/test_smoke_suite.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from loopx.canary.runner import build_canary_smoke_suite_run, run_canary_smoke_check
+
+
+def _option_list(config: Any, name: str) -> list[str]:
+    values = config.getoption(name) or []
+    items: list[str] = []
+    for value in values:
+        for item in str(value).split(","):
+            item = item.strip()
+            if item:
+                items.append(item)
+    return items
+
+
+def _build_preview(config: Any) -> dict[str, Any]:
+    return build_canary_smoke_suite_run(
+        suite=str(config.getoption("loopx_smoke_suite") or "default-public"),
+        modules=_option_list(config, "loopx_smoke_modules"),
+        scripts=_option_list(config, "loopx_smoke_scripts"),
+        families=_option_list(config, "loopx_smoke_families"),
+        profiles=_option_list(config, "loopx_smoke_profiles"),
+        include_deep_checks=bool(config.getoption("loopx_smoke_include_deep_checks")),
+        limit=int(config.getoption("loopx_smoke_limit") or 0),
+        execute=False,
+        timeout_seconds=float(config.getoption("loopx_smoke_timeout") or 120.0),
+    )
+
+
+def _preview(config: Any) -> dict[str, Any]:
+    cached = getattr(config, "_loopx_smoke_suite_preview", None)
+    if isinstance(cached, dict):
+        return cached
+    payload = _build_preview(config)
+    setattr(config, "_loopx_smoke_suite_preview", payload)
+    return payload
+
+
+def _check_id(check: dict[str, Any]) -> str:
+    normalized = check.get("normalized") if isinstance(check.get("normalized"), dict) else {}
+    script = normalized.get("script") or check.get("command") or "smoke"
+    return str(script).removeprefix("examples/").replace("/", "__")
+
+
+def _format_payload(payload: dict[str, Any]) -> str:
+    return json.dumps(payload, ensure_ascii=False, indent=2, sort_keys=True)
+
+
+def _format_result(result: dict[str, Any]) -> str:
+    normalized = result.get("normalized") if isinstance(result.get("normalized"), dict) else {}
+    lines = [
+        f"command: {' '.join(str(part) for part in normalized.get('display_argv') or [])}",
+        f"status: {result.get('status')}",
+        f"returncode: {result.get('returncode')}",
+        f"duration_seconds: {result.get('duration_seconds')}",
+    ]
+    if result.get("reason"):
+        lines.append(f"reason: {result.get('reason')}")
+    if result.get("stdout_tail"):
+        lines.extend(["stdout_tail:", str(result.get("stdout_tail")).rstrip()])
+    if result.get("stderr_tail"):
+        lines.extend(["stderr_tail:", str(result.get("stderr_tail")).rstrip()])
+    return "\n".join(lines)
+
+
+def pytest_generate_tests(metafunc: Any) -> None:
+    if "smoke_check" not in metafunc.fixturenames:
+        return
+    payload = _preview(metafunc.config)
+    checks = [
+        check
+        for check in payload.get("selected_checks", [])
+        if isinstance(check, dict)
+    ]
+    metafunc.parametrize("smoke_check", checks, ids=[_check_id(check) for check in checks])
+
+
+def test_smoke_suite_selection_contract(pytestconfig: Any) -> None:
+    payload = _preview(pytestconfig)
+    assert payload["schema_version"] == "canary_smoke_suite_run_v0", _format_payload(payload)
+    assert payload["executes_checks"] is False, _format_payload(payload)
+    assert payload["writes_evidence"] is False, _format_payload(payload)
+    assert payload["warning_count"] == 0, _format_payload(payload)
+    assert payload["unsafe_command_count"] == 0, _format_payload(payload)
+    assert payload["selected_check_count"] > 0, _format_payload(payload)
+    assert payload["ok"] is True, _format_payload(payload)
+
+
+def test_smoke_suite_script(smoke_check: dict[str, Any], pytestconfig: Any) -> None:
+    result = run_canary_smoke_check(
+        smoke_check,
+        timeout_seconds=float(pytestconfig.getoption("loopx_smoke_timeout") or 120.0),
+    )
+    assert result.get("ok") is True, _format_result(result)


### PR DESCRIPTION
## Summary
- add an optional pytest wrapper for the existing LoopX canary smoke-suite runner
- keep examples/*-smoke.py as subprocess-executed source of truth while exposing suite/module/script/profile selectors to pytest and JUnit output
- document the CI facade and add a deep catalog check plus focused facade smoke

## Validation
- python3 -m py_compile loopx/canary/runner.py loopx/canary/planner.py examples/pytest-smoke-suite-facade-smoke.py examples/catalog-canary-planner-smoke.py tests/conftest.py tests/test_smoke_suite.py
- python3 examples/canary-smoke-suite-runner-smoke.py
- python3 examples/catalog-canary-planner-smoke.py
- python3 examples/catalog-canary-run-e2e-smoke.py
- uvx --with 'pytest>=8,<9' pytest -q tests/test_smoke_suite.py --loopx-smoke-suite catalog-plan --loopx-smoke-profile catalog-canary-contract --loopx-smoke-limit 1 --loopx-smoke-timeout 60 --junitxml /tmp/loopx-pytest-smoke-suite.xml
- uvx --with 'pytest>=8,<9' pytest -q tests/test_smoke_suite.py --loopx-smoke-suite default-public --loopx-smoke-script canary-smoke-suite-runner-smoke.py --loopx-smoke-timeout 60
- uvx --with 'pytest>=8,<9' pytest -q tests/test_smoke_suite.py --loopx-smoke-suite default-public --loopx-smoke-module canary --loopx-smoke-limit 1 --loopx-smoke-timeout 60
- python3 examples/pytest-smoke-suite-facade-smoke.py
- python3 examples/run-smokes.py --suite full-public --script pytest-smoke-suite-facade-smoke.py --timeout-seconds 120
- git diff --check
- python3 -m loopx.cli check --scan-path pyproject.toml --scan-path loopx/canary/runner.py --scan-path loopx/canary/planner.py --scan-path examples/pytest-smoke-suite-facade-smoke.py --scan-path examples/catalog-canary-planner-smoke.py --scan-path tests --scan-path docs/product/release-readiness.md