### PR TITLE
Fix visible Codex TUI trust launch

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -299,13 +299,15 @@ def main() -> int:
                 assert launch["attach_requested"] is False, visible_payload
                 assert launch["workspace_mode"] == "explicit_workspace", visible_payload
                 assert launch["codex_trust_workspace"] is True, visible_payload
-                assert launch["codex_trust_scope"] == "per_invocation_selected_workspace", visible_payload
+                assert (
+                    launch["codex_trust_scope"] == "persisted_selected_workspace_and_git_root"
+                ), visible_payload
                 workspace_route = visible_payload["visible_control_plane"]["workspace_route"]
                 assert workspace_route["side_lane_worktree_count"] == 0, workspace_route
                 assert workspace_route["primary_workspace"] == "visible_codex_tui_workspace", workspace_route
                 assert (
                     workspace_route["trust_prompt_avoidance"]
-                    == "demo_owned_clean_workspace_with_per_invocation_codex_trust_config"
+                    == "demo_owned_clean_workspace_with_persisted_codex_trust_config"
                 ), workspace_route
                 assert workspace_route["default_visible_workspace"] == "demo_owned_clean_workspace", workspace_route
                 acceptance = launch["visible_acceptance"]

--- a/examples/auto-research-demo-supervisor-smoke.py
+++ b/examples/auto-research-demo-supervisor-smoke.py
@@ -146,8 +146,9 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
         assert "LOOPX_VISIBLE_TUI_SILENT_BOOTSTRAP=1" in command, lane
         assert "LOOPX_CODEX_TUI_MODE=interactive" in command, lane
         assert "LOOPX_CODEX_TUI_PROMPT_ARTIFACT" in command, lane
-        assert "exec codex -c model_reasoning_effort=high" in command, lane
-        assert '-C "$LOOPX_PROJECT" "$BOOTSTRAP_PROMPT"' in command, lane
+        assert "LOOPX_CODEX_BIN=codex" in command, lane
+        assert "LOOPX_CODEX_REASONING_EFFORT=high" in command, lane
+        assert "exec python3 -c" in command, lane
         assert "codex exec" not in command, lane
         assert "codex_stream_filter" not in command, lane
         assert "[LoopX auto-research frontier]" not in command, lane
@@ -159,7 +160,9 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
     assert "tmux new-window" in start_script, start_script
     assert "LOOPX_PROJECT" in start_script, start_script
     assert "LOOPX_CODEX_TUI_MODE=interactive" in start_script, start_script
-    assert "exec codex -c model_reasoning_effort=high" in start_script, start_script
+    assert "LOOPX_CODEX_BIN=codex" in start_script, start_script
+    assert "LOOPX_CODEX_REASONING_EFFORT=high" in start_script, start_script
+    assert "exec python3 -c" in start_script, start_script
     assert "[Codex bootstrap]" not in start_script, start_script
     assert "[Codex bootstrap prompt]" not in start_script, start_script
     assert payload["commands"]["attach"] == "tmux attach -t loopx-auto-research", payload

--- a/examples/generic-multi-agent-one-command-smoke.py
+++ b/examples/generic-multi-agent-one-command-smoke.py
@@ -270,7 +270,9 @@ def main() -> int:
             start_payloads.append(
                 command_path.read_text(encoding="utf-8") if command_path.is_file() else command
             )
-        assert all("exec codex -c model_reasoning_effort=high" in command for command in start_payloads), start_payloads
+        assert all("LOOPX_CODEX_BIN=codex" in command for command in start_payloads), start_payloads
+        assert all("LOOPX_CODEX_REASONING_EFFORT=high" in command for command in start_payloads), start_payloads
+        assert all("exec python3 -c" in command for command in start_payloads), start_payloads
         assert all("codex exec" not in command for command in start_payloads), start_payloads
         launcher_source = (ROOT / "loopx/visible_multi_agent_launcher.py").read_text(
             encoding="utf-8"

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -17,6 +17,7 @@ ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(ROOT))
 
 from loopx.visible_multi_agent_launcher import (  # noqa: E402
+    _CODEX_TUI_EXEC_PY,
     _SCOPED_LOOPX_WRAPPER_PY,
     TUI_MULTI_AGENT_RUNNER_CONTRACT_SCHEMA_VERSION,
     build_visible_multi_agent_payload,
@@ -104,7 +105,14 @@ def main() -> int:
     assert "build_tui_multi_agent_runner_contract" in launcher_source
     assert "LOOPX_CODEX_TUI_MODE=interactive" in launcher_source
     assert "LOOPX_CODEX_TRUST_WORKSPACE" in launcher_source
+    assert "LOOPX_CODEX_BIN" in launcher_source
+    assert "LOOPX_CODEX_REASONING_EFFORT" in launcher_source
+    assert "export BOOTSTRAP_PROMPT" in launcher_source
+    assert "_persist_codex_workspace_trust" in launcher_source
+    assert "rev-parse\", \"--show-toplevel" in launcher_source
     assert "trust_level=" in launcher_source and "trusted" in launcher_source
+    assert "trust_prompt_blocked" in launcher_source
+    assert "Do you trust the contents of this directory?" in launcher_source
     assert "pre_codex_character_stream" in launcher_source
     assert "build_visible_frontier_command" not in launcher_source
     assert 'FRONTIER_ARTIFACT_NAME="frontier.public.json"' not in launcher_source
@@ -208,6 +216,8 @@ def main() -> int:
         runtime_root = temp / "runtime"
         workspace = temp / "workspace"
         tmux_log = temp / "tmux.jsonl"
+        codex_home = temp / "codex-home"
+        codex_argv_log = temp / "codex-argv.json"
         worker_skill = temp / "worker" / "SKILL.md"
         wrapper_arg_log = temp / "wrapper-args.jsonl"
         worker_skill.parent.mkdir(parents=True)
@@ -228,7 +238,22 @@ def main() -> int:
                 ]
             ),
         )
-        write_executable(fake_bin / "codex", "#!/usr/bin/env sh\nprintf 'fake codex tui\\n'\nexit 0\n")
+        write_executable(
+            fake_bin / "codex",
+            "\n".join(
+                [
+                    "#!/usr/bin/env python3",
+                    "import json, os, sys",
+                    "path = os.environ.get('FAKE_CODEX_ARGV_LOG')",
+                    "if path:",
+                    "    with open(path, 'w', encoding='utf-8') as f:",
+                    "        json.dump(sys.argv, f)",
+                    "print('fake codex tui')",
+                    "raise SystemExit(0)",
+                    "",
+                ]
+            ),
+        )
         write_executable(
             fake_bin / "tmux",
             "\n".join(
@@ -243,6 +268,9 @@ def main() -> int:
                     "    print('planner\\nreviewer')",
                     "    raise SystemExit(0)",
                     "if len(sys.argv) > 1 and sys.argv[1] == 'capture-pane':",
+                    "    text = os.environ.get('FAKE_TMUX_CAPTURE_TEXT', '')",
+                    "    if text:",
+                    "        print(text)",
                     "    raise SystemExit(0)",
                     "raise SystemExit(0)",
                     "",
@@ -251,8 +279,11 @@ def main() -> int:
         )
 
         original_path = os.environ.get("PATH", "")
+        original_codex_home = os.environ.get("CODEX_HOME")
         os.environ["PATH"] = f"{fake_bin}{os.pathsep}{original_path}"
+        os.environ["CODEX_HOME"] = str(codex_home)
         os.environ["FAKE_TMUX_LOG"] = str(tmux_log)
+        os.environ["FAKE_CODEX_ARGV_LOG"] = str(codex_argv_log)
         os.environ["WRAPPER_ARG_LOG"] = str(wrapper_arg_log)
         try:
             scoped_env = dict(os.environ)
@@ -404,17 +435,84 @@ def main() -> int:
                 cwd=temp,
                 codex_trust_workspace=True,
             )
+
+            git_root_workspace = temp / "git-root" / "lanes" / "planner"
+            git_root_workspace.mkdir(parents=True, exist_ok=True)
+            subprocess.run(
+                ["git", "init", str(temp / "git-root")],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            subprocess.run(
+                [sys.executable, "-c", _CODEX_TUI_EXEC_PY],
+                env={
+                    **os.environ,
+                    "LOOPX_CODEX_BIN": str(fake_bin / "codex"),
+                    "LOOPX_PROJECT": str(git_root_workspace),
+                    "LOOPX_CODEX_REASONING_EFFORT": "high",
+                    "BOOTSTRAP_PROMPT": "planner prompt",
+                    "LOOPX_CODEX_TRUST_WORKSPACE": "1",
+                },
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            codex_args = json.loads(codex_argv_log.read_text(encoding="utf-8"))
+            assert "-C" in codex_args and str(git_root_workspace) in codex_args, codex_args
+            assert codex_args[-1] == "planner prompt", codex_args
+            trust_args = [
+                item
+                for index, item in enumerate(codex_args)
+                if index > 0 and codex_args[index - 1] == "-c" and ".trust_level=" in item
+            ]
+            assert any(str(git_root_workspace) in item for item in trust_args), codex_args
+            assert any(str(temp / "git-root") in item for item in trust_args), codex_args
+
+            os.environ["FAKE_TMUX_CAPTURE_TEXT"] = "Do you trust the contents of this directory?"
+            blocked_launch, _, _ = execute_visible_multi_agent_launcher(
+                payload={
+                    "session_name": "loopx-visible-launcher-trust-block-smoke",
+                    "lanes": [
+                        {
+                            "lane_id": "planner",
+                            "visible_launch_command": "exec codex -c model_reasoning_effort=high -C \"$LOOPX_PROJECT\" planner",
+                        }
+                    ],
+                },
+                registry=registry,
+                runtime_root=runtime_root,
+                requested_launcher="tmux",
+                tmux_bin="tmux",
+                cli_bin="loopx",
+                codex_bin="codex",
+                attach=False,
+                replace_existing=False,
+                workspace=str(workspace),
+                create_workspace=True,
+                cwd=temp,
+                codex_trust_workspace=True,
+            )
         finally:
             os.environ["PATH"] = original_path
+            if original_codex_home is None:
+                os.environ.pop("CODEX_HOME", None)
+            else:
+                os.environ["CODEX_HOME"] = original_codex_home
             os.environ.pop("FAKE_TMUX_LOG", None)
+            os.environ.pop("FAKE_CODEX_ARGV_LOG", None)
             os.environ.pop("WRAPPER_ARG_LOG", None)
+            os.environ.pop("FAKE_TMUX_CAPTURE_TEXT", None)
 
         assert chosen == "tmux", launch
         assert workspace_mode == "explicit_workspace", launch
         assert workspace.is_dir(), workspace
         assert launch["schema_version"] == "multi_agent_visible_launch_result_v0", launch
         assert launch["codex_trust_workspace"] is True, launch
-        assert launch["codex_trust_scope"] == "per_invocation_selected_workspace", launch
+        assert launch["codex_trust_scope"] == "persisted_selected_workspace_and_git_root", launch
+        assert launch["codex_trust_config"]["trusted_path_count"] >= 1, launch
+        config_text = (codex_home / "config.toml").read_text(encoding="utf-8")
+        assert str(workspace) in config_text, config_text
         skills = launch["worker_skill_materialization"]
         assert skills == [
             {
@@ -439,6 +537,12 @@ def main() -> int:
         assert acceptance["missing_lanes"] == [], acceptance
         assert all(item["accepted"] for item in acceptance["pane_checks"]), acceptance
         assert all(item["interactive_codex_tui_script"] for item in acceptance["pane_checks"]), acceptance
+        assert not any(item["trust_prompt_blocked"] for item in acceptance["pane_checks"]), acceptance
+
+        blocked_acceptance = blocked_launch["visible_acceptance"]
+        assert blocked_acceptance["accepted"] is False, blocked_acceptance
+        assert blocked_acceptance["pane_checks"][0]["trust_prompt_blocked"] is True, blocked_acceptance
+
         log_entries = [json.loads(line) for line in tmux_log.read_text(encoding="utf-8").splitlines()]
         assert any(entry[:1] == ["new-session"] for entry in log_entries), log_entries
         assert sum(1 for entry in log_entries if entry[:1] == ["new-window"]) == 1, log_entries

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -632,7 +632,7 @@ def _execute_auto_research_demo_supervisor(
                 "workspace_write_scope": "selected_visible_workspace_only",
                 "codex_trust_workspace": codex_trust_workspace,
                 "codex_trust_scope": (
-                    "per_invocation_selected_workspace"
+                    "persisted_selected_workspace_and_git_root"
                     if codex_trust_workspace
                     else "native_codex_trust_prompt"
                 ),

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -64,7 +64,7 @@ def _prepare_visible_demo_workspace_route(
         "side_lane_worktree_count": 0,
         "side_lane_count": side_count,
         "trust_prompt_avoidance": (
-            "demo_owned_clean_workspace_with_per_invocation_codex_trust_config"
+            "demo_owned_clean_workspace_with_persisted_codex_trust_config"
         ),
         "mutation_isolation_policy": (
             "mutating attempts claim an execution boundary from inside the role; "

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -139,6 +139,40 @@ tick_target.write_text(
 tick_target.chmod(0o700)
 """
 
+
+_CODEX_TUI_EXEC_PY = r"""
+import json
+import os
+import subprocess
+
+codex = os.environ["LOOPX_CODEX_BIN"]
+project = os.environ["LOOPX_PROJECT"]
+reasoning_effort = os.environ["LOOPX_CODEX_REASONING_EFFORT"]
+prompt = os.environ["BOOTSTRAP_PROMPT"]
+
+args = [codex]
+if os.environ.get("LOOPX_CODEX_TRUST_WORKSPACE") == "1":
+    candidates = [project, os.path.realpath(project)]
+    git_root = subprocess.run(
+        ["git", "-C", project, "rev-parse", "--show-toplevel"],
+        check=False,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if git_root:
+        candidates.extend([git_root, os.path.realpath(git_root)])
+    seen = set()
+    for path in candidates:
+        if not path or path in seen:
+            continue
+        seen.add(path)
+        args.extend(["-c", f"projects.{json.dumps(path)}.trust_level=\"trusted\""])
+
+args.extend(["-c", f"model_reasoning_effort={reasoning_effort}", "-C", project, prompt])
+os.execvp(codex, args)
+"""
+
+
 def _q(value: object) -> str:
     return shlex.quote(str(value))
 
@@ -148,6 +182,70 @@ def require_executable(command: str, *, field: str) -> str:
     if not path:
         raise ValueError(f"{field} executable not found on PATH: {command}")
     return path
+
+
+def _codex_config_path() -> Path:
+    return Path(os.environ.get("CODEX_HOME") or (Path.home() / ".codex")) / "config.toml"
+
+
+def _toml_project_header(path: str) -> str:
+    return f"[projects.{json.dumps(path)}]"
+
+
+def _trust_project_in_config_text(text: str, path: str) -> str:
+    header = _toml_project_header(path)
+    lines = text.splitlines()
+    for index, line in enumerate(lines):
+        if line.strip() != header:
+            continue
+        end = index + 1
+        while end < len(lines) and not lines[end].lstrip().startswith("["):
+            end += 1
+        for trust_index in range(index + 1, end):
+            if lines[trust_index].strip().startswith("trust_level"):
+                lines[trust_index] = 'trust_level = "trusted"'
+                break
+        else:
+            lines.insert(index + 1, 'trust_level = "trusted"')
+        return "\n".join(lines) + "\n"
+    suffix = "" if not text or text.endswith("\n") else "\n"
+    return text + suffix + f"\n{header}\ntrust_level = \"trusted\"\n"
+
+
+def _codex_trust_candidate_paths(project: Path) -> list[str]:
+    candidates = [str(project), os.path.realpath(project)]
+    git_root = subprocess.run(
+        ["git", "-C", str(project), "rev-parse", "--show-toplevel"],
+        check=False,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    if git_root:
+        candidates.extend([git_root, os.path.realpath(git_root)])
+    trusted: list[str] = []
+    seen = set()
+    for path in candidates:
+        if path and path not in seen:
+            seen.add(path)
+            trusted.append(path)
+    return trusted
+
+
+def _persist_codex_workspace_trust(paths: Iterable[str]) -> dict[str, object]:
+    config = _codex_config_path()
+    config.parent.mkdir(parents=True, exist_ok=True)
+    before = config.read_text(encoding="utf-8") if config.exists() else ""
+    after = before
+    trusted_paths = []
+    for path in paths:
+        trusted_paths.append(path)
+        after = _trust_project_in_config_text(after, path)
+    if after != before:
+        config.write_text(after, encoding="utf-8")
+    return {
+        "persisted": after != before,
+        "trusted_path_count": len(trusted_paths),
+    }
 
 
 def runtime_shell_command(
@@ -311,19 +409,9 @@ def build_visible_lane_command(
     tick_rounds: int | None = None,
     tick_sleep_seconds: int | None = None,
 ) -> str:
-    trust_config_py = (
-        'import json, os; '
-        'print("projects." + json.dumps(os.environ["LOOPX_PROJECT"]) + '
-        '".trust_level=\\"trusted\\"")'
-    )
-    codex_trust_args = (
-        'if [ "${LOOPX_CODEX_TRUST_WORKSPACE:-0}" = "1" ]; then '
-        f'CODEX_TRUST_CONFIG="$(python3 -c {_q(trust_config_py)})"; '
-        f"exec {_q(codex_bin)} "
-        '-c "$CODEX_TRUST_CONFIG" '
-        f"-c model_reasoning_effort={_q(reasoning_effort)} "
-        '-C "$LOOPX_PROJECT" "$BOOTSTRAP_PROMPT"; '
-        "fi; "
+    codex_exec_env = (
+        f"export LOOPX_CODEX_BIN={_q(codex_bin)}; "
+        f"export LOOPX_CODEX_REASONING_EFFORT={_q(reasoning_effort)}; "
     )
     scoped_loopx_wrapper = (
         'LOOPX_REAL_CLI="$(command -v loopx)"; '
@@ -364,6 +452,7 @@ def build_visible_lane_command(
         'VISIBLE_ARTIFACT_PREFIX="${LOOPX_LANE_ID:-${LOOPX_ROLE_ID:-lane}}"; '
         f"BOOTSTRAP_PROMPT=\"$({bootstrap_command} 2>&1)\"; "
         "BOOTSTRAP_STATUS=$?; "
+        "export BOOTSTRAP_PROMPT; "
         'BOOTSTRAP_ARTIFACT="$LOOPX_VISIBLE_ARTIFACT_DIR/$VISIBLE_ARTIFACT_PREFIX.bootstrap-prompt.public.txt"; '
         'printf "%s\\n" "$BOOTSTRAP_PROMPT" > "$BOOTSTRAP_ARTIFACT"; '
         "if [ \"$BOOTSTRAP_STATUS\" -ne 0 ]; then "
@@ -373,9 +462,8 @@ def build_visible_lane_command(
         "fi; "
         "export LOOPX_CODEX_TUI_MODE=interactive; "
         "export LOOPX_CODEX_TUI_PROMPT_ARTIFACT=\"$BOOTSTRAP_ARTIFACT\"; "
-        f"{codex_trust_args}"
-        f"exec {_q(codex_bin)} -c model_reasoning_effort={_q(reasoning_effort)} "
-        '-C "$LOOPX_PROJECT" "$BOOTSTRAP_PROMPT"'
+        f"{codex_exec_env}"
+        f"exec python3 -c {_q(_CODEX_TUI_EXEC_PY)}"
     )
 
 
@@ -944,6 +1032,17 @@ def _launch_with_tmux(
     lanes = [item for item in payload.get("lanes", []) if isinstance(item, dict)]
     if not lanes:
         raise ValueError("visible multi-agent launcher has no lanes to launch")
+    codex_trust_config: dict[str, object] = {
+        "persisted": False,
+        "trusted_path_count": 0,
+    }
+    if codex_trust_workspace:
+        trust_paths: list[str] = []
+        for lane in lanes:
+            trust_paths.extend(
+                _codex_trust_candidate_paths(_lane_workspace(lane, default_project=project))
+            )
+        codex_trust_config = _persist_codex_workspace_trust(trust_paths)
 
     env = os.environ.copy()
     env.update(
@@ -1056,8 +1155,9 @@ def _launch_with_tmux(
         "stop_command": f"{tmux_bin} kill-session -t {session}",
         "workspace_mode": workspace_mode,
         "codex_trust_workspace": codex_trust_workspace,
+        "codex_trust_config": codex_trust_config,
         "codex_trust_scope": (
-            "per_invocation_selected_workspace"
+            "persisted_selected_workspace_and_git_root"
             if codex_trust_workspace
             else "native_codex_trust_prompt"
         ),
@@ -1081,7 +1181,8 @@ def _tmux_acceptance(
 ) -> dict[str, object]:
     codex_name = Path(codex_bin).name or "codex"
     last_payload: dict[str, object] | None = None
-    for attempt in range(20):
+    min_stable_acceptance_attempts = 12
+    for attempt in range(32):
         time.sleep(0.25)
         list_result = subprocess.run(
             [tmux_bin, "list-windows", "-t", session, "-F", "#{window_name}"],
@@ -1116,7 +1217,14 @@ def _tmux_acceptance(
                 "quota_wait_timeout",
                 "bootstrap_command_failed",
             ]
+            trust_prompt_markers = [
+                "Do you trust the contents of this directory?",
+                "Working with untrusted contents",
+                "Trusting will apply to the repository root:",
+                "Press enter to continue",
+            ]
             blocked_before_bootstrap = any(marker in capture for marker in failure_markers)
+            trust_prompt_blocked = any(marker in capture for marker in trust_prompt_markers)
             script_words = script_text.replace("\n", " ").replace(";", " ").split()
             uses_headless_codex_subcommand = any(
                 Path(word).name == codex_name
@@ -1130,12 +1238,18 @@ def _tmux_acceptance(
                 and "| python3" not in script_text
                 and not uses_headless_codex_subcommand
             )
-            ok = lane in surviving and not blocked_before_bootstrap and script_execs_codex_tui
+            ok = (
+                lane in surviving
+                and not blocked_before_bootstrap
+                and not trust_prompt_blocked
+                and script_execs_codex_tui
+            )
             pane_checks.append(
                 {
                     "lane_id": lane,
                     "accepted": ok,
                     "blocked_before_bootstrap": blocked_before_bootstrap,
+                    "trust_prompt_blocked": trust_prompt_blocked,
                     "interactive_codex_tui_script": script_execs_codex_tui,
                     "pane_current_command": current_command,
                 }
@@ -1150,7 +1264,9 @@ def _tmux_acceptance(
             "missing_lanes": [lane for lane in expected_lanes if lane not in surviving],
             "pane_checks": pane_checks,
         }
-        if accepted:
+        if any(item["trust_prompt_blocked"] for item in pane_checks):
+            return last_payload
+        if accepted and attempt + 1 >= min_stable_acceptance_attempts:
             return last_payload
     assert last_payload is not None
     return last_payload


### PR DESCRIPTION
## Summary
- persist Codex trust for demo-selected visible workspaces before tmux launches real TUI panes
- pass Codex through a small argv-safe launcher that trusts both lane workspace and git root, then starts interactive TUI
- make visible acceptance fail on native trust prompts and wait for a stable no-prompt first screen

## Validation
- python3 examples/visible-multi-agent-launcher-smoke.py
- python3 examples/auto-research-demo-supervisor-smoke.py
- python3 examples/generic-multi-agent-one-command-smoke.py
- python3 examples/multi-agent-visible-launcher-protocol-smoke.py
- python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- python3 -m loopx.cli check --scan-path loopx/visible_multi_agent_launcher.py --scan-path loopx/capabilities/auto_research/cli.py --scan-path loopx/capabilities/auto_research/demo_e2e.py --scan-path examples/visible-multi-agent-launcher-smoke.py --scan-path examples/auto-research-demo-supervisor-smoke.py --scan-path examples/generic-multi-agent-one-command-smoke.py --scan-path examples/auto-research-demo-e2e-worker-loop-smoke.py
- live tmux demo with real Codex TUI panes accepted=true; no trust prompt in all four panes after 20s

## Boundary
- no raw transcripts or private artifacts committed
- visible output remains real Codex TUI panes; machine JSON stays out of default pane view