### PR TITLE
Keep active-work scheduler cadence at initial interval

### DIFF
--- a/examples/quota-scheduler-hint-compaction-smoke.py
+++ b/examples/quota-scheduler-hint-compaction-smoke.py
@@ -92,7 +92,12 @@ def assert_compact_runtime_policy_complete(name: str, compact: dict) -> None:
     assert stateful_backoff["current_rrule"] == codex_app["recommended_rrule"], (name, compact)
     assert stateful_backoff["state_status"] == "missing", (name, compact)
     assert "progression_index" in stateful_backoff["persist"], (name, compact)
-    assert stateful_backoff["same_identity_action"] == "advance_index_after_scheduler_ack", (
+    expected_same_identity_action = (
+        "keep_initial_interval_while_active_work"
+        if compact["cadence_class"] == "active_work"
+        else "advance_index_after_scheduler_ack"
+    )
+    assert stateful_backoff["same_identity_action"] == expected_same_identity_action, (
         name,
         compact,
     )

--- a/examples/quota-scheduler-policy-smoke.py
+++ b/examples/quota-scheduler-policy-smoke.py
@@ -63,6 +63,7 @@ def assert_policy_case(
     expected_action: str,
     expected_rrule: str,
     expected_progression: list[int] | None = None,
+    expected_same_identity_action: str = "advance_index_after_scheduler_ack",
 ) -> None:
     quota_wrapper = _scheduler_hint(deepcopy(base_payload))
     extracted = build_scheduler_hint(
@@ -108,7 +109,7 @@ def assert_policy_case(
     assert stateful_backoff["ack_required_after_apply"] is True, (name, extracted)
     assert stateful_backoff["current_rrule"] == expected_rrule, (name, extracted)
     assert stateful_backoff["state_status"] == "missing", (name, extracted)
-    assert stateful_backoff["same_identity_action"] == "advance_index_after_scheduler_ack", (
+    assert stateful_backoff["same_identity_action"] == expected_same_identity_action, (
         name,
         extracted,
     )
@@ -147,6 +148,7 @@ def main() -> int:
         payload(should_run=True, effective_action="normal_run"),
         expected_action="run_now",
         expected_rrule="FREQ=MINUTELY;INTERVAL=3",
+        expected_same_identity_action="keep_initial_interval_while_active_work",
     )
     assert_policy_case(
         "mapped-noop",

--- a/examples/quota-scheduler-state-ack-smoke.py
+++ b/examples/quota-scheduler-state-ack-smoke.py
@@ -61,6 +61,33 @@ def payload(*, recommended_action: str = "Wait for reassignment.") -> dict:
     }
 
 
+def active_payload() -> dict:
+    return {
+        "goal_id": "scheduler-state-ack-smoke",
+        "agent_identity": {"agent_id": "codex-side-agent"},
+        "should_run": True,
+        "effective_action": "normal_run",
+        "recommended_action": "Run the active work cadence smoke.",
+        "heartbeat_recommendation": {
+            "recommended_mode": "run_first_read_only_map",
+            "notify": "DONT_NOTIFY",
+            "spend_policy": "spend once after validated writeback",
+        },
+        "execution_obligation": {
+            "must_attempt_work": True,
+            "spend_policy": "spend after validation",
+        },
+        "automation_liveness": {
+            "automation_action": "execute_bounded_work",
+            "spend_policy": "spend after validation",
+        },
+        "interaction_contract": {
+            "mode": "bounded_delivery",
+            "user_channel": {"action_required": False},
+        },
+    }
+
+
 def state_from(hint: dict) -> dict:
     stateful = hint["codex_app"]["stateful_backoff"]
     return {
@@ -76,6 +103,13 @@ def state_from(hint: dict) -> dict:
         "last_applied_rrule": hint["codex_app"]["recommended_rrule"],
         "updated_at": "2026-01-01T00:00:00+00:00",
     }
+
+
+def state_from_hint_with_applied_rrule(hint: dict, *, index: int, rrule: str) -> dict:
+    state = state_from(hint)
+    state["progression_index"] = index
+    state["last_applied_rrule"] = rrule
+    return state
 
 
 def assert_policy_state_progression() -> None:
@@ -130,6 +164,45 @@ def assert_policy_state_progression() -> None:
     )
     assert reset["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=10", reset
     assert reset["codex_app"]["stateful_backoff"]["state_status"] == "reset_required", reset
+
+
+def assert_active_work_keeps_initial_cadence() -> None:
+    base = active_payload()
+    first = build_scheduler_hint(
+        deepcopy(base),
+        agent_scope_frontier_actions=AGENT_SCOPE_ACTIONS,
+    )
+    assert first["action"] == "run_now", first
+    assert first["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=3", first
+    assert (
+        first["codex_app"]["stateful_backoff"]["same_identity_action"]
+        == "keep_initial_interval_while_active_work"
+    ), first
+
+    stale_backoff_state = state_from_hint_with_applied_rrule(
+        first,
+        index=1,
+        rrule="FREQ=MINUTELY;INTERVAL=6",
+    )
+    repaired = build_scheduler_hint(
+        deepcopy(base),
+        agent_scope_frontier_actions=AGENT_SCOPE_ACTIONS,
+        codex_app_scheduler_state=stale_backoff_state,
+    )
+    assert repaired["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=3", repaired
+    assert repaired["codex_app"]["stateful_backoff"]["progression_index"] == 0, repaired
+    assert repaired["codex_app"]["stateful_backoff"]["state_status"] == "same_identity", repaired
+    assert repaired["codex_app"]["stateful_backoff"]["apply_needed"] is True, repaired
+
+    steady = build_scheduler_hint(
+        deepcopy(base),
+        agent_scope_frontier_actions=AGENT_SCOPE_ACTIONS,
+        codex_app_scheduler_state=state_from(repaired),
+    )
+    assert steady["codex_app"]["stateful_backoff"]["current_rrule"] == "FREQ=MINUTELY;INTERVAL=3", steady
+    assert steady["codex_app"]["stateful_backoff"]["progression_index"] == 0, steady
+    assert steady["codex_app"]["stateful_backoff"]["apply_needed"] is False, steady
+    assert "recommended_rrule" not in steady["codex_app"], steady
 
 
 def run_cli(root: Path, *args: str, registry_path: Path, runtime: Path, project: Path) -> dict:
@@ -330,6 +403,7 @@ def assert_cli_scheduler_ack_uses_should_run_lookback() -> None:
 
 def main() -> int:
     assert_policy_state_progression()
+    assert_active_work_keeps_initial_cadence()
     assert_cli_scheduler_ack_progression()
     assert_cli_scheduler_ack_uses_should_run_lookback()
     print("quota-scheduler-state-ack-smoke ok")

--- a/loopx/policies/scheduler_hint.py
+++ b/loopx/policies/scheduler_hint.py
@@ -96,6 +96,7 @@ def build_scheduler_hint(
         claude_limit: int | None,
         multiplier: int = 2,
         cadence_progression_override: list[int] | None = None,
+        advance_same_identity: bool = True,
     ) -> dict[str, Any]:
         cadence_progression = cadence_progression_override or [
             min(codex_interval * (multiplier**step), codex_max)
@@ -210,7 +211,8 @@ def build_scheduler_hint(
                     applied_index = int(scheduler_state.get("progression_index"))
                 except (TypeError, ValueError):
                     applied_index = -1
-                current_index = min(max(applied_index + 1, 0), len(cadence_progression) - 1)
+                next_index = applied_index + 1 if advance_same_identity else 0
+                current_index = min(max(next_index, 0), len(cadence_progression) - 1)
             else:
                 state_status = "reset_required"
         current_interval = cadence_progression[current_index]
@@ -255,7 +257,11 @@ def build_scheduler_hint(
                 "apply_needed": apply_needed,
                 "ack_required_after_apply": apply_needed,
                 "persist": "reset_token|identity_signature|progression_index|last_applied_rrule",
-                "same_identity_action": "advance_index_after_scheduler_ack",
+                "same_identity_action": (
+                    "advance_index_after_scheduler_ack"
+                    if advance_same_identity
+                    else "keep_initial_interval_while_active_work"
+                ),
                 "reset_action": "clear_progression_index_apply_initial_rrule",
                 "automation_update_scope": "rrule_only_preserve_body_name_status",
                 "state_status": state_status,
@@ -358,6 +364,7 @@ def build_scheduler_hint(
             codex_max=10,
             cli_limit=None,
             claude_limit=None,
+            advance_same_identity=False,
         )
 
     if user_required or recommended_mode in {"ask_operator_gate", "blocker_push_notify"}:


### PR DESCRIPTION
## Root Cause
Active work used the same Codex App stateful backoff progression as wait/monitor states. When the same runnable todo stayed selected across turns, a scheduler ack made the next active-work payload advance 3 -> 6 -> 10 minutes. That contradicted the reset policy text saying active_work_projected should restore the initial cadence.

## Fix
- keep same-identity progression enabled for wait/monitor states
- disable same-identity progression for cadence_class=active_work so active tasks stay at the initial 3-minute interval
- if an older active-work scheduler state already acked 6/10 minutes, the next active-work payload recommends 3 minutes and resets progression_index to 0
- add focused smoke coverage for the active-work regression and update compact policy assertions

## Validation
- python3 -m py_compile loopx/policies/scheduler_hint.py examples/quota-scheduler-policy-smoke.py examples/quota-scheduler-state-ack-smoke.py examples/quota-scheduler-hint-compaction-smoke.py
- python3 examples/quota-scheduler-policy-smoke.py
- python3 examples/quota-scheduler-state-ack-smoke.py
- python3 examples/quota-scheduler-hint-compaction-smoke.py
- python3 examples/heartbeat-prompt-smoke.py
- python3 -m loopx.cli canary smoke-suite --profile control-plane-refactor --profile status-read-path --max-checks-per-profile 4 --timeout-seconds 180
- git diff --check
- python3 -m loopx.cli check --scan-path loopx/policies/scheduler_hint.py --scan-path examples/quota-scheduler-policy-smoke.py --scan-path examples/quota-scheduler-state-ack-smoke.py --scan-path examples/quota-scheduler-hint-compaction-smoke.py

## Review Note
Not self-merged: this is a small validated fix, but it changes scheduler hot-path behavior.