### PR TITLE
Keep pane JSON artifacts separate from wrapper

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -45,7 +45,10 @@ def main() -> int:
     )
     assert "raw JSON is not printed in visible panes" in launcher_source
     assert "Use $LOOPX_PANE_LOOPX for human-readable output" in launcher_source
-    assert "$LOOPX_PANE_LOOPX_JSON ... --format json > .local/<role>/<name>.public.json" in launcher_source
+    assert "$LOOPX_PANE_LOOPX_JSON <command>" in launcher_source
+    assert "$LOOPX_PANE_ARTIFACT_DIR/<name>.public.json" in launcher_source
+    assert "It injects --format json unless you pass an explicit --format." in launcher_source
+    assert "$LOOPX_PANE_LOOPX_JSON is a command path, not an output file." in launcher_source
     assert "LOOPX_PANE_WORKER_TURN" in launcher_source
     assert "loopx-pane-a2a-tick" in launcher_source
     assert "role_prompt_inside_codex_tui" in launcher_source

--- a/examples/generic-multi-agent-one-command-smoke.py
+++ b/examples/generic-multi-agent-one-command-smoke.py
@@ -200,6 +200,9 @@ def main() -> int:
         assert dry_packet["runner_contract"]["runner_surface"] == "tmux_codex_cli_tui", dry_packet
         assert dry_packet["runner_contract"]["coordination_model"]["leader_required"] is False, dry_packet
         assert dry_packet["runner_contract"]["pane_local_a2a"]["tick_command"] == "$LOOPX_PANE_A2A_TICK", dry_packet
+        assert dry_packet["runner_contract"]["pane_local_a2a"]["machine_json_destination"] == (
+            "$LOOPX_PANE_ARTIFACT_DIR/*.public.json"
+        ), dry_packet
         assert dry_packet["runner_contract"]["boundaries"]["domain_specific_research_logic"] is False, dry_packet
         assert dry_packet["interactive_tui_contract"]["schema_version"] == "multi_agent_visible_interactive_tui_contract_v0", dry_packet
         assert dry_packet["interactive_tui_contract"]["runner_contract"] == RUNNER_CONTRACT_SCHEMA_VERSION, dry_packet
@@ -273,6 +276,7 @@ def main() -> int:
         assert all("LOOPX_CODEX_BIN=codex" in command for command in start_payloads), start_payloads
         assert all("LOOPX_CODEX_REASONING_EFFORT=high" in command for command in start_payloads), start_payloads
         assert all("exec python3 -c" in command for command in start_payloads), start_payloads
+        assert all("LOOPX_PANE_ARTIFACT_DIR" in command for command in start_payloads), start_payloads
         assert all("codex exec" not in command for command in start_payloads), start_payloads
         launcher_source = (ROOT / "loopx/visible_multi_agent_launcher.py").read_text(
             encoding="utf-8"

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -89,13 +89,17 @@ def main() -> int:
     assert "demo_local_wrapper" not in launcher_source
     assert "scoped_loopx_wrapper" in launcher_source
     assert "LOOPX_PANE_LOOPX_JSON" in launcher_source
+    assert "LOOPX_PANE_ARTIFACT_DIR" in launcher_source
     assert "LOOPX_PANE_A2A_TICK" in launcher_source
     assert "loopx-pane-a2a-tick" in launcher_source
     assert "LOOPX_PANE_WORKER_TURN" in launcher_source
     assert "LOOPX_PANE_TICK_ROUNDS" in launcher_source
     assert "First action: immediately run `$LOOPX_PANE_A2A_TICK`" in launcher_source
     assert "LOOPX_VISIBLE_FORCE_MARKDOWN" in launcher_source
-    assert "format=markdown; machine_json_wrapper=$LOOPX_PANE_LOOPX_JSON" in launcher_source
+    assert "machine_json_command=$LOOPX_PANE_LOOPX_JSON artifact_dir=$LOOPX_PANE_ARTIFACT_DIR" in launcher_source
+    assert "$LOOPX_PANE_LOOPX_JSON is a command path, not an output file." in launcher_source
+    assert "It injects --format json unless you pass an explicit --format." in launcher_source
+    assert "Never write output to `$LOOPX_PANE_LOOPX_JSON`" in launcher_source
     assert "LoopX machine JSON hidden" in launcher_source
     assert "LOOPX_ALLOW_TTY_JSON" in launcher_source
     assert "stat.S_ISREG" in launcher_source
@@ -153,6 +157,10 @@ def main() -> int:
         "LOOPX_PANE_TICK_ROUNDS"
     )
     assert "LOOPX_PANE_WORKER_TURN" in runner_contract["lane_runtime_env"]["pane_tools"]
+    assert "LOOPX_PANE_ARTIFACT_DIR" in runner_contract["lane_runtime_env"]["pane_tools"]
+    assert runner_contract["pane_local_a2a"]["machine_json_destination"] == (
+        "$LOOPX_PANE_ARTIFACT_DIR/*.public.json"
+    )
     assert runner_contract["role_prompt_and_skill"]["worker_local_skill_only"] is True
     assert runner_contract["debug_artifacts"]["machine_json"] == (
         "redirected_public_artifacts_only"
@@ -205,6 +213,8 @@ def main() -> int:
     assert "auto_start_pane_local_a2a_tick" in generic_lane["lane_timeline"], generic_lane
     assert "LOOPX_PANE_A2A_TICK" in generic_lane["visible_launch_command"], generic_lane
     assert "LOOPX_PANE_WORKER_TURN" in generic_lane["visible_launch_command"], generic_lane
+    assert "LOOPX_PANE_ARTIFACT_DIR" in generic_lane["visible_launch_command"], generic_lane
+    assert "$LOOPX_PANE_ARTIFACT_DIR/quota.public.json" in generic_lane["quota_guard"], generic_lane
     assert "LOOPX_PANE_TICK_ROUNDS=2" in generic_lane["visible_launch_command"], generic_lane
     assert "LOOPX_PANE_TICK_SLEEP_SECONDS=1" in generic_lane["visible_launch_command"], generic_lane
 
@@ -293,6 +303,7 @@ def main() -> int:
                     "LOOPX_REAL_CLI": str(fake_bin / "loopx"),
                     "LOOPX_REGISTRY": str(registry),
                     "LOOPX_RUNTIME_ROOT": str(runtime_root),
+                    "LOOPX_PANE_ARTIFACT_DIR": str(workspace / ".local" / "pane-artifacts" / "reviewer"),
                 }
             )
             workspace.mkdir(parents=True, exist_ok=True)
@@ -316,7 +327,7 @@ def main() -> int:
                 capture_output=True,
                 text=True,
             )
-            machine_artifact = workspace / ".local" / "reviewer" / "status.public.json"
+            machine_artifact = workspace / ".local" / "pane-artifacts" / "reviewer" / "status.public.json"
             machine_artifact.parent.mkdir(parents=True, exist_ok=True)
             with machine_artifact.open("w", encoding="utf-8") as handle:
                 subprocess.run(
@@ -327,8 +338,20 @@ def main() -> int:
                     check=True,
                     text=True,
                 )
+            implicit_machine_artifact = (
+                workspace / ".local" / "pane-artifacts" / "reviewer" / "implicit-status.public.json"
+            )
+            with implicit_machine_artifact.open("w", encoding="utf-8") as handle:
+                subprocess.run(
+                    [str(workspace / ".local/bin/loopx-json"), "status"],
+                    env=scoped_env,
+                    stdout=handle,
+                    stderr=subprocess.STDOUT,
+                    check=True,
+                    text=True,
+                )
             explicit_machine = subprocess.run(
-                [str(workspace / ".local/bin/loopx-json"), "--format", "json", "status"],
+                [str(workspace / ".local/bin/loopx-json"), "status"],
                 env={**scoped_env, "LOOPX_MACHINE_JSON": "1"},
                 check=True,
                 capture_output=True,
@@ -354,12 +377,19 @@ def main() -> int:
                 capture_output=True,
                 text=True,
             )
-            assert "format=markdown; machine_json_wrapper=$LOOPX_PANE_LOOPX_JSON" in human.stdout, human.stdout
+            assert "machine_json_command=$LOOPX_PANE_LOOPX_JSON artifact_dir=$LOOPX_PANE_ARTIFACT_DIR" in human.stdout, human.stdout
             assert "--format markdown status" in human.stdout, human.stdout
             assert visible_pipe.returncode == 2, visible_pipe.stdout
             assert "LoopX machine JSON hidden" in visible_pipe.stdout, visible_pipe.stdout
+            assert "LOOPX_PANE_ARTIFACT_DIR" in visible_pipe.stdout, visible_pipe.stdout
+            assert "command path, not an output file" in visible_pipe.stdout, visible_pipe.stdout
+            assert "injects --format json" in visible_pipe.stdout, visible_pipe.stdout
             assert "fake-loopx" not in visible_pipe.stdout, visible_pipe.stdout
             assert "--format json status" in machine_artifact.read_text(encoding="utf-8")
+            assert "--format json status" in implicit_machine_artifact.read_text(encoding="utf-8")
+            assert (workspace / ".local/bin/loopx-json").read_text(encoding="utf-8").startswith(
+                "#!/usr/bin/env python3"
+            )
             assert "--format json status" in explicit_machine.stdout, explicit_machine.stdout
             assert tty_status == 2, tty_output
             assert "LoopX machine JSON hidden" in tty_output, tty_output

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -41,10 +41,17 @@ json_target.write_text(
     "if not explicit and not stdout_is_file:\n"
     "    print('\\n[LoopX machine JSON hidden]\\nraw JSON is not printed in visible panes.\\n')\n"
     "    print('Use $LOOPX_PANE_LOOPX for human-readable output, or redirect machine JSON:')\n"
-    "    print('  $LOOPX_PANE_LOOPX_JSON ... --format json > .local/<role>/<name>.public.json')\n"
+    "    print('  mkdir -p \"$LOOPX_PANE_ARTIFACT_DIR\"')\n"
+    "    print('  $LOOPX_PANE_LOOPX_JSON <command> > \"$LOOPX_PANE_ARTIFACT_DIR/<name>.public.json\"')\n"
+    "    print('$LOOPX_PANE_LOOPX_JSON is a command path, not an output file.')\n"
+    "    print('It injects --format json unless you pass an explicit --format.')\n"
     "    print('Internal launcher pipes must set LOOPX_MACHINE_JSON=1 explicitly.')\n"
     "    raise SystemExit(2)\n"
-    "os.execv(real, [real, '--registry', registry, '--runtime-root', runtime] + sys.argv[1:])\n",
+    "args = sys.argv[1:]\n"
+    "has_format = any(arg == '--format' or arg.startswith('--format=') for arg in args)\n"
+    "if not has_format:\n"
+    "    args = ['--format', 'json'] + args\n"
+    "os.execv(real, [real, '--registry', registry, '--runtime-root', runtime] + args)\n",
     encoding="utf-8",
 )
 json_target.chmod(0o700)
@@ -81,7 +88,7 @@ human_target.write_text(
     "        index += 1\n"
     "    args = rewritten\n"
     "if changed:\n"
-    "    print('\\n[LoopX human view]\\nformat=markdown; machine_json_wrapper=$LOOPX_PANE_LOOPX_JSON\\n', flush=True)\n"
+    "    print('\\n[LoopX human view]\\nformat=markdown; machine_json_command=$LOOPX_PANE_LOOPX_JSON artifact_dir=$LOOPX_PANE_ARTIFACT_DIR\\n', flush=True)\n"
     "os.execv(real, [real, '--registry', registry, '--runtime-root', runtime] + args)\n",
     encoding="utf-8",
 )
@@ -349,6 +356,7 @@ def build_tui_multi_agent_runner_contract(
             "pane_tools": [
                 "LOOPX_PANE_LOOPX",
                 "LOOPX_PANE_LOOPX_JSON",
+                "LOOPX_PANE_ARTIFACT_DIR",
                 "LOOPX_PANE_A2A_TICK",
                 "LOOPX_PANE_WORKER_TURN",
                 "LOOPX_PANE_WORKER_LOOP",
@@ -371,6 +379,7 @@ def build_tui_multi_agent_runner_contract(
             "runs": ["LOOPX_PANE_WORKER_TURN", "LOOPX_PANE_WORKER_LOOP"],
             "bounded_rounds_env": "LOOPX_PANE_TICK_ROUNDS",
             "machine_json_policy": "file_or_explicit_machine_channel_only",
+            "machine_json_destination": "$LOOPX_PANE_ARTIFACT_DIR/*.public.json",
             "human_default": "markdown_status_inside_codex_tui",
         },
         "user_takeover": {
@@ -445,6 +454,8 @@ def build_visible_lane_command(
         "export LOOPX_VISIBLE_TUI_SILENT_BOOTSTRAP=1; "
         f"export LOOPX_ROLE_ID={_q(role_id)}; "
         f"export LOOPX_ROLE_PROFILE_REF={_q(role_profile_ref)}; "
+        'export LOOPX_PANE_ARTIFACT_DIR="${LOOPX_PANE_ARTIFACT_DIR:-$LOOPX_VISIBLE_ARTIFACT_DIR/${LOOPX_ROLE_ID:-lane}}"; '
+        'mkdir -p "$LOOPX_PANE_ARTIFACT_DIR"; '
         'cd "$LOOPX_PROJECT"; '
         f"{scoped_loopx_wrapper}"
         f"{pane_a2a_env}"
@@ -662,7 +673,8 @@ def _generic_role_prompt(
             "- First action: immediately run `$LOOPX_PANE_A2A_TICK` in this Codex TUI. Do not ask the user to start it.",
             "- The tick reads your quota/frontier and then runs this role's worker-turn when configured.",
             "- When the tick completes, summarize what changed, what remains blocked, and stay interactive for user takeover.",
-            "- Keep machine JSON redirected through $LOOPX_PANE_LOOPX_JSON into .local artifacts.",
+            "- For machine reads, run `$LOOPX_PANE_LOOPX_JSON` as the command and redirect output into `$LOOPX_PANE_ARTIFACT_DIR/<name>.public.json`; it defaults to `--format json`.",
+            "- Never write output to `$LOOPX_PANE_LOOPX_JSON`; it is the executable wrapper, not an artifact path.",
             "- Write compact public-safe evidence before completing or handing off a todo.",
             "- The user may type into this pane; respond like a normal Codex CLI agent.",
         ]
@@ -767,9 +779,10 @@ def build_visible_multi_agent_payload_from_spec(
             "role_profile": role_profile,
             "role_profile_ref": role_profile_ref,
             "quota_guard": (
+                "mkdir -p \"$LOOPX_PANE_ARTIFACT_DIR\" && "
                 "$LOOPX_PANE_LOOPX_JSON quota should-run "
                 f"--goal-id {_q(goal_id)} --agent-id {_q(agent_id)} "
-                f"> .local/{lane_slug}/quota.public.json"
+                "> \"$LOOPX_PANE_ARTIFACT_DIR/quota.public.json\""
             ),
             "frontier": "agent-scoped LoopX todo/quota/frontier projection",
             "pane_local_a2a": {


### PR DESCRIPTION
## Summary

Fix the visible multi-agent pane JSON contract so user-facing Codex TUI workers keep raw machine JSON out of the pane while still writing valid JSON artifacts reliably.

- add `LOOPX_PANE_ARTIFACT_DIR` as the explicit per-pane JSON artifact destination
- keep `LOOPX_PANE_LOOPX_JSON` as an executable wrapper only, with help text warning that it is not an output file
- make the JSON wrapper inject `--format json` by default unless an explicit `--format` is provided
- tighten visible launcher/generic runner/auto-research smokes around this contract

## Product / Architecture Judgment

Motivation: the visible auto-research demo had real Codex TUI panes, but workers could confuse the JSON wrapper path with an output path or omit `--format json`, causing bad pane artifacts and poor first-run UX.

Solved: the runner now exposes a reusable command-vs-artifact contract that applies beyond auto-research: one env var for the LoopX JSON command, one env var for artifact destination.

Impact: users should see live Codex roles doing work instead of raw JSON streams or wrapper errors; worker panes can write machine-readable evidence with less prompt fragility.

Risk: low. This changes launcher wrapper behavior only for the visible multi-agent pane-local command path and preserves explicit `--format` overrides.

## Validation

- `python3 -m py_compile loopx/visible_multi_agent_launcher.py loopx/capabilities/auto_research/demo_e2e.py loopx/capabilities/auto_research/demo_supervisor.py`
- `python3 examples/visible-multi-agent-launcher-smoke.py`
- `python3 examples/generic-multi-agent-one-command-smoke.py`
- `python3 examples/auto-research-demo-e2e-worker-loop-smoke.py`
- `python3 examples/auto-research-demo-supervisor-smoke.py`
- `git diff --check origin/main...HEAD`
- `python3 -m loopx.cli --format json check --scan-path ...` (clean errors; existing loopx-meta duplicate-index warning only)
- real no-attach tmux/Codex TUI demo launched from this branch: 4 panes accepted, no trust prompt, `LOOPX_PANE_ARTIFACT_DIR` visible, JSON artifacts parsed with `jq`, and a second-round follow-up todo was written from the verifier lane.
