### PR TITLE
Repair auto-research pane handoff cleanup

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -220,24 +220,25 @@ def main() -> int:
         worker_loop = payload["worker_loop"]
         assert worker_loop["schema_version"] == "auto_research_worker_loop_v0", payload
         assert worker_loop["mode"] == "execute", payload
-        assert worker_loop["executed_turn_count"] == 4, payload
-        assert worker_loop["completed_turn_count"] == 4, payload
+        assert worker_loop["executed_turn_count"] == 5, payload
+        assert worker_loop["completed_turn_count"] == 5, payload
         assert worker_loop["selected_actions"] == [
             "write_research_contract",
             "propose_hypothesis",
             "run_dev_eval",
             "summarize_evidence",
+            "run_holdout_eval",
         ], payload
         assert worker_loop["stop_reason"] == "no_runnable_frontier", payload
         tonight = payload["tonight_experience"]
         assert tonight["ready"] is True, tonight
         assert tonight["positive_result"] is True, tonight
-        assert tonight["positive_result_basis"] == "public_safe_dev_evidence", tonight
+        assert tonight["positive_result_basis"] == "public_safe_dev_and_holdout_evidence", tonight
         assert tonight["coordination_pattern"] == "decentralized_state_a2a", tonight
         assert tonight["workflow_model"] == "state_projected_frontier_not_dynamic_workflow", tonight
         assert tonight["leader_agent_required"] is False, tonight
         assert tonight["dev_metric"] == 4.0, tonight
-        assert tonight["holdout_metric"] is None, tonight
+        assert tonight["holdout_metric"] == 4.5, tonight
         assert "--run-worker-loop" in tonight["one_command"], tonight
         assert "--headless" not in tonight["one_command"], tonight
         assert "--headless" in payload["commands"]["headless_worker_loop"], payload

--- a/examples/auto-research-worker-loop-smoke.py
+++ b/examples/auto-research-worker-loop-smoke.py
@@ -93,7 +93,7 @@ def main() -> int:
             "--lane-count",
             str(len(AGENT_IDS)),
             "--max-rounds",
-            "2",
+            "3",
             "--visible-lanes-accepted",
             "--complete-selected-todo",
             "--execute",
@@ -116,14 +116,15 @@ def main() -> int:
         assert payload["ok"] is True, payload
         assert payload["schema_version"] == "auto_research_worker_loop_v0", payload
         assert payload["mode"] == "execute", payload
-        assert payload["executed_turn_count"] == 4, payload
-        assert payload["completed_turn_count"] == 4, payload
+        assert payload["executed_turn_count"] == 5, payload
+        assert payload["completed_turn_count"] == 5, payload
         assert payload["stop_reason"] == "no_runnable_frontier", payload
         assert payload["selected_actions"] == [
             "write_research_contract",
             "propose_hypothesis",
             "run_dev_eval",
             "summarize_evidence",
+            "run_holdout_eval",
         ], payload
         evidence_turn = next(
             turn for turn in payload["turns"] if turn.get("selected_action") == "run_dev_eval"
@@ -137,6 +138,13 @@ def main() -> int:
         assert verifier_turn["completion_status"] == "done", verifier_turn
         assert verifier_turn["claim_allowed"] is None, verifier_turn
         assert verifier_turn["appended_count"] is None, verifier_turn
+        holdout_turn = next(
+            turn for turn in payload["turns"] if turn.get("selected_action") == "run_holdout_eval"
+        )
+        assert holdout_turn["holdout_metric"] == 4.5, holdout_turn
+        assert holdout_turn["completion_status"] == "done", holdout_turn
+        final_round = [turn for turn in payload["turns"] if turn.get("round") == 3]
+        assert final_round and all(turn["mode"] == "no_action" for turn in final_round), payload
         assert_public_safe(payload)
     return 0
 

--- a/examples/auto-research-worker-turn-smoke.py
+++ b/examples/auto-research-worker-turn-smoke.py
@@ -21,6 +21,7 @@ from loopx.capabilities.auto_research.demo_e2e import run_auto_research_demo_e2e
 from loopx.capabilities.auto_research.demo_supervisor import (  # noqa: E402
     build_auto_research_demo_supervisor_plan,
 )
+from loopx.todos import add_goal_todo  # noqa: E402
 
 
 GOAL_ID = "loopx-auto-research-knn"
@@ -303,8 +304,48 @@ def main() -> int:
         assert verifier["artifact_status"] == "evaluation_summary_written", verifier
         assert verifier["claim_allowed"] is False, verifier
         assert verifier["promotion_decision_made"] is False, verifier
+        assert verifier["followup"]["needed"] is True, verifier
+        assert verifier["followup"]["action_kind"] == "run_holdout_eval", verifier
+        assert verifier["followup"]["claimed_by"] == EVIDENCE_AGENT_ID, verifier
         assert verifier["completion"]["status"] == "done", verifier
         assert_public_safe(verifier)
+        holdout = run_worker_turn(
+            registry=four_registry,
+            runtime_root=four_runtime_root,
+            workspace=four_workspace,
+            agent_id=EVIDENCE_AGENT_ID,
+            execute=True,
+            complete=True,
+        )
+        assert holdout["mode"] == "execute", holdout
+        assert holdout["selected_action"] == "run_holdout_eval", holdout
+        assert holdout["holdout_metric"] == 4.5, holdout
+        assert holdout["completion"]["status"] == "done", holdout
+        generic = add_goal_todo(
+            registry_path=four_registry,
+            goal_id=GOAL_ID,
+            role="agent",
+            text="[P0-auto-research-verify] Verify supported dev evidence and close the promotion handoff.",
+            task_class="advancement_task",
+            claimed_by=VERIFIER_AGENT_ID,
+            project=four_workspace,
+        )
+        assert generic["added"] is True, generic
+        cleanup = run_worker_turn(
+            registry=four_registry,
+            runtime_root=four_runtime_root,
+            workspace=four_workspace,
+            agent_id=VERIFIER_AGENT_ID,
+            execute=True,
+            complete=True,
+        )
+        assert cleanup["mode"] == "execute", cleanup
+        assert cleanup["selected_action"] == "advance_todo", cleanup
+        assert cleanup["artifact_status"] == "satisfied_generic_handoff_closed", cleanup
+        assert cleanup["completion"]["status"] == "done", cleanup
+        assert cleanup["decision_summary"]["validated_promotion_candidate_count"] == 1, cleanup
+        assert_public_safe(holdout)
+        assert_public_safe(cleanup)
 
     print("auto-research-worker-turn-smoke ok")
     return 0

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -494,7 +494,7 @@ def register_auto_research_commands(
     demo_e2e_parser.add_argument(
         "--worker-loop-rounds",
         type=int,
-        default=2,
+        default=3,
         help="Maximum worker-loop rounds for --execute.",
     )
     demo_e2e_parser.add_argument(

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -324,7 +324,7 @@ def run_auto_research_demo_e2e(
     goal_surface_mode: str = "explicit_goal",
     agent_specs: Sequence[str] | None = None,
     run_worker_loop: bool = False,
-    worker_loop_rounds: int = 2,
+    worker_loop_rounds: int = 3,
 ) -> dict[str, object]:
     if launch_visible and not execute:
         raise ValueError("--launch-visible requires --execute")
@@ -575,8 +575,12 @@ def run_auto_research_demo_e2e(
                 "selected_actions": worker_loop.get("selected_actions"),
                 "dev_metric": dev_metric,
                 "holdout_metric": holdout_metric,
-                "positive_result": dev_metric is not None,
-                "positive_result_basis": "public_safe_dev_evidence",
+                "positive_result": holdout_metric is not None or dev_metric is not None,
+                "positive_result_basis": (
+                    "public_safe_dev_and_holdout_evidence"
+                    if holdout_metric is not None
+                    else "public_safe_dev_evidence"
+                ),
                 "state_surfaces": [
                     "demo-local LoopX registry",
                     "quota/frontier selection",

--- a/loopx/capabilities/auto_research/worker_runtime.py
+++ b/loopx/capabilities/auto_research/worker_runtime.py
@@ -28,12 +28,13 @@ from .research_state import (
     build_research_decision_candidates,
     build_research_evidence_graph_from_rollout_events,
 )
+from ...agent_registry import registered_agent_ids_from_registry
 from ...history import load_registry
 from ...paths import resolve_runtime_root
 from ...quota import build_quota_should_run
 from ...rollout_event_log import load_rollout_events, rollout_event_log_path
 from ...status import collect_status
-from ...todos import complete_goal_todo
+from ...todos import add_goal_todo, complete_goal_todo
 
 
 AUTO_RESEARCH_WORKER_TURN_SCHEMA_VERSION = "auto_research_worker_turn_v0"
@@ -48,6 +49,21 @@ SUPPORTED_WORKER_ACTIONS = {
     "summarize_evidence",
     "write_evaluation_summary",
 }
+DEFAULT_EVIDENCE_RUNNER_AGENT_ID = "codex-main-control"
+HOLDOUT_FOLLOWUP_TEXT = (
+    "[P0-auto-research-live] Run held-out validation for the dev-supported "
+    "hypothesis, append public-safe evidence, and summarize promotion readiness."
+)
+GENERIC_VERIFIER_HANDOFF_KEYWORDS = (
+    "verify",
+    "verifier",
+    "validate",
+    "validation",
+    "evidence",
+    "holdout",
+    "promotion",
+    "promote",
+)
 
 AppendEvidence = Callable[[str], dict[str, object]]
 
@@ -265,6 +281,154 @@ def _select_holdout_candidate(graph: dict[str, object]) -> dict[str, object]:
     )[0]
 
 
+def _evidence_runner_agent_id(*, registry_path: Path, goal_id: str, current_agent_id: str) -> str:
+    registered = registered_agent_ids_from_registry(registry_path, goal_id)
+    if DEFAULT_EVIDENCE_RUNNER_AGENT_ID in registered:
+        return DEFAULT_EVIDENCE_RUNNER_AGENT_ID
+    for agent_id in registered:
+        if agent_id != current_agent_id:
+            return agent_id
+    return current_agent_id
+
+
+def _maybe_add_holdout_followup_todo(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    source_todo_id: str,
+    agent_id: str,
+    decision_summary: dict[str, object],
+    execute: bool,
+) -> dict[str, object]:
+    dev_candidate_count = int(decision_summary.get("dev_promotion_candidate_count") or 0)
+    validated_candidate_count = int(decision_summary.get("validated_promotion_candidate_count") or 0)
+    if not dev_candidate_count:
+        return {"needed": False, "reason": "no_dev_promotion_candidate"}
+    if validated_candidate_count:
+        return {"needed": False, "reason": "holdout_already_validated"}
+
+    claimed_by = _evidence_runner_agent_id(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        current_agent_id=agent_id,
+    )
+    if not execute:
+        return {
+            "needed": True,
+            "executed": False,
+            "action_kind": "run_holdout_eval",
+            "claimed_by": claimed_by,
+            "unblocks_todo_id": source_todo_id,
+        }
+
+    result = add_goal_todo(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        role="agent",
+        text=HOLDOUT_FOLLOWUP_TEXT,
+        task_class="advancement_task",
+        action_kind="run_holdout_eval",
+        claimed_by=claimed_by,
+        unblocks_todo_id=source_todo_id,
+        dry_run=False,
+    )
+    return {
+        "needed": True,
+        "executed": True,
+        "added": bool(result.get("added")),
+        "already_exists": bool(result.get("already_exists")),
+        "metadata_updated": bool(result.get("metadata_updated")),
+        "todo_id": result.get("todo_id"),
+        "action_kind": result.get("action_kind") or "run_holdout_eval",
+        "claimed_by": result.get("claimed_by") or claimed_by,
+        "unblocks_todo_id": result.get("unblocks_todo_id") or source_todo_id,
+    }
+
+
+def _generic_handoff_is_satisfied(
+    *,
+    selected: dict[str, object],
+    evidence_graph: dict[str, object],
+    decisions: dict[str, list[dict[str, object]]],
+) -> bool:
+    if not decisions.get("validated_promotion_candidates"):
+        return False
+    if not evidence_graph.get("holdout_improved"):
+        return False
+    selected_text = " ".join(
+        str(selected.get(key) or "")
+        for key in ("title", "mechanism_family", "source_kind", "todo_id")
+    ).lower()
+    return any(keyword in selected_text for keyword in GENERIC_VERIFIER_HANDOFF_KEYWORDS)
+
+
+def _maybe_close_satisfied_generic_handoff(
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    goal_id: str,
+    todo_id: str,
+    agent_id: str,
+    selected: dict[str, object],
+    action: str,
+    execute: bool,
+    complete_selected_todo: bool,
+    frontier_packet: dict[str, object],
+) -> dict[str, object] | None:
+    if action != "advance_todo":
+        return None
+    registry = load_registry(registry_path)
+    runtime_root = resolve_runtime_root(registry, runtime_root_arg)
+    graph = build_research_evidence_graph_from_rollout_events(
+        goal_id=goal_id,
+        rollout_events=load_rollout_events(rollout_event_log_path(runtime_root, goal_id)),
+    )
+    decisions = build_research_decision_candidates(graph)
+    if not _generic_handoff_is_satisfied(
+        selected=selected,
+        evidence_graph=graph,
+        decisions=decisions,
+    ):
+        return None
+
+    completion = (
+        _complete_selected_todo(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            todo_id=todo_id,
+            agent_id=agent_id,
+            action="satisfied_generic_handoff",
+            execute=True,
+        )
+        if execute and complete_selected_todo
+        else {"requested": complete_selected_todo, "executed": False}
+    )
+    return {
+        "ok": True,
+        "schema_version": AUTO_RESEARCH_WORKER_TURN_SCHEMA_VERSION,
+        "mode": "execute" if execute else "dry_run",
+        "goal_id": goal_id,
+        "agent_id": agent_id,
+        "selected_todo_id": todo_id,
+        "selected_action": action,
+        "executed": bool(execute and complete_selected_todo),
+        "artifact_status": "satisfied_generic_handoff_closed",
+        "decision_summary": {
+            "validated_promotion_candidate_count": len(decisions.get("validated_promotion_candidates") or []),
+            "holdout_improved": bool(graph.get("holdout_improved")),
+        },
+        "completion": completion,
+        "frontier": frontier_packet,
+        "public_boundary": {
+            "source": "rollout_event_log_and_todo_projection",
+            "raw_logs_recorded": False,
+            "private_artifacts_recorded": False,
+            "absolute_paths_recorded": False,
+            "credentials_recorded": False,
+        },
+    }
+
+
 def _complete_selected_todo(
     *,
     registry_path: Path,
@@ -408,6 +572,20 @@ def run_auto_research_worker_turn(
             "executed": False,
             "frontier": frontier_packet,
         }
+    cleanup = _maybe_close_satisfied_generic_handoff(
+        registry_path=registry_path,
+        runtime_root_arg=runtime_root_arg,
+        goal_id=goal_id,
+        todo_id=todo_id,
+        agent_id=agent_id,
+        selected=selected,
+        action=action,
+        execute=execute,
+        complete_selected_todo=complete_selected_todo,
+        frontier_packet=frontier_packet,
+    )
+    if cleanup is not None:
+        return cleanup
     if action not in SUPPORTED_WORKER_ACTIONS:
         return {
             "ok": True,
@@ -547,6 +725,14 @@ def run_auto_research_worker_turn(
             todo_id=todo_id,
             agent_id=agent_id,
         )
+        followup = _maybe_add_holdout_followup_todo(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            source_todo_id=todo_id,
+            agent_id=agent_id,
+            decision_summary=artifact["decision_summary"],
+            execute=True,
+        )
         completion = (
             _complete_selected_todo(
                 registry_path=registry_path,
@@ -573,6 +759,7 @@ def run_auto_research_worker_turn(
             "artifact_status": artifact["summary"]["status"],
             "claim_allowed": artifact["summary"]["claim_allowed"],
             "promotion_decision_made": artifact["summary"]["promotion_decision_made"],
+            "followup": followup,
             "completion": completion,
             "frontier": frontier_packet,
             "public_boundary": {


### PR DESCRIPTION
## Summary
- make verifier turns create a role-compatible run_holdout_eval successor when dev evidence needs holdout validation
- close already-satisfied generic verifier handoff todos after holdout success instead of surfacing unsupported_action
- let demo-e2e worker-loop default to enough rounds to reach holdout and clean no-action

## Validation
- python3 -m py_compile loopx/capabilities/auto_research/worker_runtime.py loopx/capabilities/auto_research/demo_e2e.py loopx/capabilities/auto_research/cli.py examples/auto-research-worker-turn-smoke.py examples/auto-research-worker-loop-smoke.py examples/auto-research-demo-e2e-worker-loop-smoke.py
- python3 examples/auto-research-worker-turn-smoke.py
- python3 examples/auto-research-worker-loop-smoke.py
- python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- python3 examples/auto-research-demo-supervisor-smoke.py
- git diff --check
- loopx check --scan-path loopx/capabilities/auto_research/worker_runtime.py --scan-path loopx/capabilities/auto_research/demo_e2e.py --scan-path loopx/capabilities/auto_research/cli.py --scan-path examples/auto-research-worker-turn-smoke.py --scan-path examples/auto-research-worker-loop-smoke.py --scan-path examples/auto-research-demo-e2e-worker-loop-smoke.py