### PR TITLE
Fix monitor projection writeback scheduling

### DIFF
--- a/examples/monitor-scheduler-contract-smoke.py
+++ b/examples/monitor-scheduler-contract-smoke.py
@@ -225,6 +225,42 @@ def assert_due_monitor_priority_does_not_steal_advancement_lane() -> None:
     assert guard["agent_todo_summary"]["monitor_due_count"] == 1, guard
 
 
+def assert_read_only_projected_due_monitor_does_not_force_writeback() -> None:
+    status = status_payload(
+        agent_todo_items=[
+            monitor_item(
+                index=1,
+                todo_id="todo_projected_due_monitor",
+                priority="P0",
+                next_due_at=PAST_DUE_AT,
+                target_key="event-projected-watch",
+            ),
+            advancement_item(index=2, priority="P1"),
+        ]
+    )
+    agent_todos = status["attention_queue"]["items"][0]["project_asset"]["agent_todos"]
+    agent_todos["monitor_writeback"] = {
+        "schema_version": "monitor_writeback_contract_v0",
+        "supported": False,
+        "source": "event_projection_read_model",
+    }
+
+    guard = build_quota_should_run(
+        status,
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+    lane = guard["work_lane_contract"]
+    assert guard["decision"] == "run", guard
+    assert lane["lane"] == "advancement_task", lane
+    assert lane["reason_codes"] == ["open_agent_todo"], lane
+    assert lane.get("obligation") != "attempt_due_monitor", lane
+    summary = guard["agent_todo_summary"]
+    assert summary["monitor_due_count"] == 0, summary
+    assert summary["monitor_open_items"][0]["todo_id"] == "todo_projected_due_monitor", summary
+    assert summary["monitor_writeback"]["supported"] is False, summary
+
+
 def assert_due_monitor_is_not_overridden_by_side_agent_scope_wait() -> None:
     other_agent = "codex-main-control"
     guard = guard_for(
@@ -368,6 +404,7 @@ def main() -> int:
     assert_due_monitor_requires_explicit_attempt()
     assert_expired_monitor_does_not_catch_up()
     assert_due_monitor_priority_does_not_steal_advancement_lane()
+    assert_read_only_projected_due_monitor_does_not_force_writeback()
     assert_due_monitor_is_not_overridden_by_side_agent_scope_wait()
     assert_multiple_due_monitor_cap_and_order()
     assert_other_agent_due_monitor_does_not_preempt_current_agent_lane()

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -1943,6 +1943,22 @@ def _todo_summary_source_items(value: dict[str, Any]) -> list[dict[str, Any]]:
     return open_items
 
 
+def _todo_summary_monitor_writeback_contract(value: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    contract = value.get("monitor_writeback")
+    if not isinstance(contract, dict):
+        return None
+    return dict(contract)
+
+
+def _todo_summary_monitor_writeback_supported(value: dict[str, Any] | None) -> bool:
+    contract = _todo_summary_monitor_writeback_contract(value)
+    if not contract:
+        return True
+    return contract.get("supported") is not False
+
+
 def _handoff_ready_successor_todo_ids(value: dict[str, Any]) -> set[str]:
     ready: set[str] = set()
     for gate in _todo_summary_handoff_gates(value):
@@ -2061,12 +2077,17 @@ def _summarize_user_todos(
         if _todo_item_is_actionable_open(item)
         if _todo_task_class(item) == TODO_TASK_CLASS_MONITOR
     ]
-    monitor_due_items = [
-        item
-        for item in monitor_items
-        if _todo_item_is_due_monitor(item)
-        if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
-    ]
+    monitor_writeback_supported = _todo_summary_monitor_writeback_supported(value)
+    monitor_due_items = (
+        [
+            item
+            for item in monitor_items
+            if _todo_item_is_due_monitor(item)
+            if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
+        ]
+        if monitor_writeback_supported
+        else []
+    )
     claimed_open_items = [item for item in blocking_open_items if item.get("claimed_by")]
     gate_items = [
         item
@@ -2107,6 +2128,9 @@ def _summarize_user_todos(
         "backlog_items": open_items[:TODO_BACKLOG_ITEM_LIMIT],
         "executable_backlog_items": executable_items[:TODO_BACKLOG_ITEM_LIMIT],
     }
+    monitor_writeback = _todo_summary_monitor_writeback_contract(value)
+    if monitor_writeback:
+        summary["monitor_writeback"] = monitor_writeback
     summary.update(
         _todo_summary_visibility_lanes(
             blocking_open_items,
@@ -2209,12 +2233,17 @@ def _summarize_project_asset_todos(
         if _todo_item_is_actionable_open(item)
         if _todo_task_class(item) == TODO_TASK_CLASS_MONITOR
     ]
-    monitor_due_items = [
-        item
-        for item in monitor_items
-        if _todo_item_is_due_monitor(item)
-        if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
-    ]
+    monitor_writeback_supported = _todo_summary_monitor_writeback_supported(value)
+    monitor_due_items = (
+        [
+            item
+            for item in monitor_items
+            if _todo_item_is_due_monitor(item)
+            if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
+        ]
+        if monitor_writeback_supported
+        else []
+    )
     active_next_action_items = [
         _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
         for item in (value.get("active_next_action_items") or [])
@@ -2249,6 +2278,9 @@ def _summarize_project_asset_todos(
         "backlog_items": open_items[:TODO_BACKLOG_ITEM_LIMIT],
         "executable_backlog_items": executable_items[:TODO_BACKLOG_ITEM_LIMIT],
     }
+    monitor_writeback = _todo_summary_monitor_writeback_contract(value)
+    if monitor_writeback:
+        summary["monitor_writeback"] = monitor_writeback
     summary.update(
         _todo_summary_visibility_lanes(
             blocking_open_items,
@@ -5259,6 +5291,8 @@ def _todo_summary_claim_scope_agent_id(summary: dict[str, Any]) -> str | None:
 def _todo_summary_monitor_due_items(summary: dict[str, Any] | None) -> list[dict[str, Any]]:
     if not isinstance(summary, dict):
         return []
+    if not _todo_summary_monitor_writeback_supported(summary):
+        return []
     projected_items = summary.get("monitor_due_items")
     if isinstance(projected_items, list):
         due_items = [
@@ -5292,6 +5326,8 @@ def _todo_summary_monitor_due_count(
     due_items: list[dict[str, Any]] | None = None,
 ) -> int:
     if not isinstance(summary, dict):
+        return 0
+    if not _todo_summary_monitor_writeback_supported(summary):
         return 0
     agent_id = _todo_summary_claim_scope_agent_id(summary)
     if agent_id:

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -236,6 +236,7 @@ STATUS_CONTRACT_SCHEMA_VERSION = 2
 MINIMUM_DASHBOARD_STATUS_CONTRACT_SCHEMA_VERSION = 2
 STATUS_CONTRACT_RELOAD_HINT = "scripts/macos-dashboard-launchagent.sh restart"
 PROJECT_ASSET_TODO_PROJECTION_GAP_SCHEMA_VERSION = "project_asset_todo_projection_gap_v0"
+MONITOR_WRITEBACK_CONTRACT_SCHEMA_VERSION = "monitor_writeback_contract_v0"
 TODO_INDEX_SCHEMA_VERSION = "todo_index_v0"
 TODO_INDEX_ITEM_SCHEMA_VERSION = "todo_index_item_v0"
 DECISION_FRESHNESS_WINDOW_DAYS = 7
@@ -6360,6 +6361,27 @@ def compact_todo_group(
     return summary
 
 
+def attach_monitor_writeback_contract(
+    fields: dict[str, Any],
+    *,
+    supported: bool,
+    source: str,
+) -> None:
+    contract = {
+        "schema_version": MONITOR_WRITEBACK_CONTRACT_SCHEMA_VERSION,
+        "supported": supported,
+        "source": source,
+        "policy": (
+            "quota may route due monitor todos as runnable only when the selected "
+            "read model can be updated by todo_id or target_key"
+        ),
+    }
+    for key in ("user_todos", "agent_todos"):
+        summary = fields.get(key)
+        if isinstance(summary, dict):
+            summary["monitor_writeback"] = dict(contract)
+
+
 def redacted_status_todo_fields(fields: dict[str, Any]) -> dict[str, Any]:
     redacted = dict(fields)
     for key in ("user_todos", "agent_todos"):
@@ -7335,6 +7357,9 @@ def project_asset_todo_summary(
             summary["next_index"] = open_items[0].get("index")
         if open_items[0].get("claimed_by"):
             summary["next_claimed_by"] = open_items[0].get("claimed_by")
+    monitor_writeback = todos.get("monitor_writeback")
+    if isinstance(monitor_writeback, dict):
+        summary["monitor_writeback"] = dict(monitor_writeback)
     deferred_items = [
         compact_todo_item(item)
         for item in todos.get("deferred_items", [])
@@ -8300,6 +8325,11 @@ def active_state_todo_fields(
     )
     if event_fields.get("user_todos") or event_fields.get("agent_todos"):
         fields = event_fields
+        attach_monitor_writeback_contract(
+            fields,
+            supported=False,
+            source="event_projection_read_model",
+        )
     else:
         fields = parse_active_state_todos(
             state_text,
@@ -8307,6 +8337,11 @@ def active_state_todo_fields(
             state_path=state_path,
             preferred_todo_ids=preferred_todo_ids,
             rollout_events=rollout_events,
+        )
+        attach_monitor_writeback_contract(
+            fields,
+            supported=True,
+            source="markdown_active_state",
         )
         if event_fields:
             fields.update(event_fields)


### PR DESCRIPTION
## Summary
- add a monitor writeback contract to todo status projections
- keep due monitor todos visible from read-only event/project-asset projections without routing them into monitor-poll writeback
- preserve markdown active-state monitor scheduling as writable

## Validation
- python3 examples/monitor-scheduler-contract-smoke.py
- python3 examples/monitor-poll-writeback-smoke.py
- python3 examples/monitor-todo-policy-seam-smoke.py
- python3 examples/event-sourced-status-read-path-smoke.py
- python3 examples/event-sourced-downstream-read-path-smoke.py
- python3 examples/state-projection-gap-smoke.py
- python3 examples/quota-contract-smoke.py
- python3 examples/quota-work-lane-policy-smoke.py
- python3 examples/project-asset-todo-projection-gap-smoke.py
- python3 examples/active-state-structured-projection-smoke.py
- python3 examples/todo-list-event-projection-smoke.py
- python3 -m py_compile loopx/status.py loopx/quota.py
- git diff --check

## Notes
- no raw benchmark evidence, local paths, credentials, or private artifacts are included