### PR TITLE
Harden canary smoke suite runner

### DIFF
--- a/examples/canary-smoke-suite-runner-smoke.py
+++ b/examples/canary-smoke-suite-runner-smoke.py
@@ -12,6 +12,7 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 
+from loopx.canary import runner as canary_runner  # noqa: E402
 from loopx.canary.runner import build_canary_smoke_suite_run  # noqa: E402
 
 
@@ -102,12 +103,141 @@ def assert_cli_json_preview_works() -> None:
     assert payload["executes_checks"] is False, payload
 
 
+def assert_execution_reports_progress_indices() -> None:
+    events: list[dict[str, object]] = []
+    payload = build_canary_smoke_suite_run(
+        suite="default-public",
+        scripts=["todo-contract-smoke.py"],
+        execute=True,
+        timeout_seconds=60,
+        progress_callback=events.append,
+    )
+    assert payload["ok"] is True, payload
+    assert payload["executed_check_count"] == 1, payload
+    check = payload["selected_checks"][0]
+    assert check["check_index"] == 1, payload
+    assert check["check_count"] == 1, payload
+    assert [event["event"] for event in events] == ["check_started", "check_finished"], events
+    assert events[0]["check_index"] == 1, events
+    assert events[0]["check_count"] == 1, events
+    assert events[1]["status"] == "passed", events
+
+
+def _fake_passed_check(
+    check: dict[str, object],
+    *,
+    timeout_seconds: float,
+    check_index: int | None = None,
+    check_count: int | None = None,
+) -> dict[str, object]:
+    normalized = canary_runner.normalize_canary_command(str(check.get("command") or ""))
+    result: dict[str, object] = {
+        **check,
+        "normalized": normalized,
+        "status": "passed",
+        "ok": True,
+        "returncode": 0,
+        "duration_seconds": 0.0,
+        "stdout_tail": "",
+        "stderr_tail": "",
+    }
+    if check_index is not None and check_count is not None:
+        result.update({"check_index": check_index, "check_count": check_count})
+    return result
+
+
+def assert_readonly_run_rejects_and_restores_tracked_side_effects() -> None:
+    original_run_check = canary_runner._run_check
+    original_tracked_change_paths = canary_runner._tracked_change_paths
+    original_restore_tracked_paths = canary_runner._restore_tracked_paths
+    restored: list[list[str]] = []
+    calls = {"tracked": 0}
+
+    def fake_tracked_change_paths() -> tuple[bool, list[str], str]:
+        calls["tracked"] += 1
+        if calls["tracked"] == 1 or restored:
+            return True, [], ""
+        return True, ["examples/generated-tracked-side-effect.txt"], ""
+
+    def fake_restore_tracked_paths(paths: list[str]) -> dict[str, object]:
+        restored.append(paths)
+        return {"ok": True, "restored_paths": paths}
+
+    try:
+        canary_runner._run_check = _fake_passed_check
+        canary_runner._tracked_change_paths = fake_tracked_change_paths
+        canary_runner._restore_tracked_paths = fake_restore_tracked_paths
+        payload = build_canary_smoke_suite_run(
+            suite="default-public",
+            scripts=["todo-contract-smoke.py"],
+            execute=True,
+            timeout_seconds=60,
+        )
+    finally:
+        canary_runner._run_check = original_run_check
+        canary_runner._tracked_change_paths = original_tracked_change_paths
+        canary_runner._restore_tracked_paths = original_restore_tracked_paths
+
+    assert payload["ok"] is False, payload
+    assert payload["writes_evidence"] is False, payload
+    assert payload["tracked_side_effect_failure_count"] == 1, payload
+    assert payload["side_effect_guard"]["enforced"] is True, payload
+    assert payload["side_effect_guard"]["auto_restored"] is True, payload
+    assert restored == [["examples/generated-tracked-side-effect.txt"]], payload
+    check = payload["selected_checks"][0]
+    assert check["status"] == "failed_tracked_side_effect", payload
+    assert check["tracked_side_effects"] == ["examples/generated-tracked-side-effect.txt"], payload
+    rendered = canary_runner.render_canary_smoke_suite_run_markdown(payload)
+    assert "- tracked_side_effect_failures: `1`" in rendered, rendered
+    assert "- tracked_side_effect_restore_ok: `true`" in rendered, rendered
+
+
+def assert_tracked_side_effects_require_explicit_allow() -> None:
+    original_run_check = canary_runner._run_check
+    original_tracked_change_paths = canary_runner._tracked_change_paths
+    original_restore_tracked_paths = canary_runner._restore_tracked_paths
+
+    def fake_tracked_change_paths() -> tuple[bool, list[str], str]:
+        return True, [], ""
+
+    def fail_restore_tracked_paths(paths: list[str]) -> dict[str, object]:
+        raise AssertionError(f"restore should not run when side effects are allowed: {paths}")
+
+    try:
+        canary_runner._run_check = _fake_passed_check
+        canary_runner._tracked_change_paths = fake_tracked_change_paths
+        canary_runner._restore_tracked_paths = fail_restore_tracked_paths
+        payload = build_canary_smoke_suite_run(
+            suite="default-public",
+            scripts=["todo-contract-smoke.py"],
+            execute=True,
+            timeout_seconds=60,
+            allow_tracked_side_effects=True,
+        )
+    finally:
+        canary_runner._run_check = original_run_check
+        canary_runner._tracked_change_paths = original_tracked_change_paths
+        canary_runner._restore_tracked_paths = original_restore_tracked_paths
+
+    assert payload["ok"] is True, payload
+    assert payload["writes_evidence"] is True, payload
+    assert payload["tracked_side_effect_failure_count"] == 0, payload
+    assert payload["side_effect_guard"]["tracked_side_effects_allowed"] is True, payload
+    assert payload["side_effect_guard"]["enforced"] is False, payload
+    rendered = canary_runner.render_canary_smoke_suite_run_markdown(payload)
+    assert "- writes_evidence: `true`" in rendered, rendered
+    assert "- read_only_guard_enforced: `false`" in rendered, rendered
+
+
 def main() -> int:
     assert_default_public_preview_excludes_grouped_smokes()
     assert_full_public_preview_injects_safe_group_args()
     assert_module_preview_selects_matching_scripts()
     assert_catalog_profile_preview_is_supported()
     assert_cli_json_preview_works()
+    assert_execution_reports_progress_indices()
+    assert_readonly_run_rejects_and_restores_tracked_side_effects()
+    assert_tracked_side_effects_require_explicit_allow()
     print("canary-smoke-suite-runner-smoke ok")
     return 0
 

--- a/loopx/canary/runner.py
+++ b/loopx/canary/runner.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 import time
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from .planner import REPO_ROOT, build_catalog_canary_plan, flatten_catalog_canary_checks
 
@@ -25,6 +25,7 @@ PYTHON_BINARIES = {"python", "python3"}
 NODE_BINARIES = {"node"}
 SHELL_TOKENS = {"&&", "||", ";", "|", ">", "<", ">>", "2>", "2>>"}
 SMOKE_SUITE_CHOICES = {"default-public", "full-public", "catalog-plan"}
+ProgressCallback = Callable[[dict[str, Any]], None]
 
 
 def _is_relative_to(path: Path, parent: Path) -> bool:
@@ -112,9 +113,55 @@ def _display_argv(argv: list[str]) -> list[str]:
     return displayed
 
 
-def _run_check(check: dict[str, Any], *, timeout_seconds: float) -> dict[str, Any]:
+def _tracked_change_paths() -> tuple[bool, list[str], str]:
+    paths: set[str] = set()
+    stderr_parts: list[str] = []
+    ok = True
+    for args in (["diff", "--name-only"], ["diff", "--name-only", "--cached"]):
+        completed = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), *args],
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if completed.returncode != 0:
+            ok = False
+            stderr_parts.append(completed.stderr[-400:])
+            continue
+        paths.update(line.strip() for line in completed.stdout.splitlines() if line.strip())
+    return ok, sorted(paths), "\n".join(part for part in stderr_parts if part)
+
+
+def _restore_tracked_paths(paths: list[str]) -> dict[str, Any]:
+    if not paths:
+        return {"ok": True, "restored_paths": []}
+    completed = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "restore", "--staged", "--worktree", "--", *paths],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return {
+        "ok": completed.returncode == 0,
+        "returncode": completed.returncode,
+        "restored_paths": paths if completed.returncode == 0 else [],
+        "stderr_tail": completed.stderr[-800:],
+    }
+
+
+def _run_check(
+    check: dict[str, Any],
+    *,
+    timeout_seconds: float,
+    check_index: int | None = None,
+    check_count: int | None = None,
+) -> dict[str, Any]:
     normalized = normalize_canary_command(str(check.get("command") or ""))
     result = {**check, "normalized": normalized}
+    if check_index is not None and check_count is not None:
+        result.update({"check_index": check_index, "check_count": check_count})
     if not normalized.get("ok"):
         result.update({"status": "skipped", "ok": False, "reason": normalized.get("reason")})
         return result
@@ -269,6 +316,8 @@ def build_canary_smoke_suite_run(
     execute: bool = True,
     timeout_seconds: float = 120.0,
     fail_fast: bool = False,
+    allow_tracked_side_effects: bool = False,
+    progress_callback: ProgressCallback | None = None,
 ) -> dict[str, Any]:
     """Build and optionally execute a continue-on-failure smoke suite.
 
@@ -322,16 +371,102 @@ def build_canary_smoke_suite_run(
     ]
 
     results: list[dict[str, Any]] = []
+    side_effect_guard: dict[str, Any] = {
+        "schema_version": "canary_smoke_suite_side_effect_guard_v0",
+        "tracked_side_effects_allowed": allow_tracked_side_effects,
+        "enforced": False,
+        "clean_start": None,
+        "tracked_before": [],
+        "tracked_side_effects": [],
+        "auto_restored": False,
+    }
     if execute:
-        for check in selected:
-            result = _run_check(check, timeout_seconds=max(1.0, timeout_seconds))
+        git_ok, tracked_before, git_stderr = _tracked_change_paths()
+        clean_start = git_ok and not tracked_before
+        side_effect_guard.update(
+            {
+                "git_status_ok": git_ok,
+                "clean_start": clean_start,
+                "tracked_before": tracked_before,
+                "enforced": bool(git_ok and not allow_tracked_side_effects),
+            }
+        )
+        if git_stderr:
+            side_effect_guard["git_status_stderr_tail"] = git_stderr[-800:]
+        for index, check in enumerate(selected, start=1):
+            normalized_check = normalize_canary_command(str(check.get("command") or ""))
+            if progress_callback:
+                progress_callback(
+                    {
+                        "schema_version": "canary_smoke_suite_progress_v0",
+                        "event": "check_started",
+                        "check_index": index,
+                        "check_count": len(selected),
+                        "command": " ".join(
+                            str(part) for part in normalized_check.get("display_argv") or []
+                        )
+                        or str(check.get("command") or ""),
+                    }
+                )
+            result = _run_check(
+                check,
+                timeout_seconds=max(1.0, timeout_seconds),
+                check_index=index,
+                check_count=len(selected),
+            )
+            if side_effect_guard["enforced"]:
+                after_ok, tracked_after, after_stderr = _tracked_change_paths()
+                side_effects = sorted(set(tracked_after) - set(tracked_before))
+                if side_effects:
+                    result.update(
+                        {
+                            "ok": False,
+                            "status": "failed_tracked_side_effect",
+                            "tracked_side_effects": side_effects,
+                        }
+                    )
+                    if clean_start:
+                        restore = _restore_tracked_paths(side_effects)
+                        result["tracked_side_effect_restore"] = restore
+                        side_effect_guard["auto_restored"] = (
+                            bool(side_effect_guard.get("auto_restored")) or bool(restore.get("ok"))
+                        )
+                if not after_ok and after_stderr:
+                    result["tracked_side_effect_stderr_tail"] = after_stderr[-800:]
+            if progress_callback:
+                progress_callback(
+                    {
+                        "schema_version": "canary_smoke_suite_progress_v0",
+                        "event": "check_finished",
+                        "check_index": index,
+                        "check_count": len(selected),
+                        "status": result.get("status"),
+                        "ok": bool(result.get("ok")),
+                        "duration_seconds": result.get("duration_seconds"),
+                    }
+                )
             results.append(result)
             if fail_fast and not result.get("ok"):
                 break
+        if side_effect_guard["enforced"]:
+            final_ok, tracked_after, final_stderr = _tracked_change_paths()
+            side_effects = sorted(set(tracked_after) - set(tracked_before))
+            side_effect_guard.update(
+                {
+                    "git_status_final_ok": final_ok,
+                    "tracked_after": tracked_after,
+                    "tracked_side_effects": side_effects,
+                }
+            )
+            if final_stderr:
+                side_effect_guard["git_status_final_stderr_tail"] = final_stderr[-800:]
 
     display_items = results if execute else normalized
     failures = [item for item in results if not item.get("ok")]
     timed_out = [item for item in results if item.get("status") == "timed_out"]
+    side_effect_failures = [
+        item for item in results if item.get("status") == "failed_tracked_side_effect"
+    ]
     unsafe = [
         item
         for item in normalized
@@ -345,15 +480,17 @@ def build_canary_smoke_suite_run(
         "repo_root": str(REPO_ROOT),
         "dry_run": not execute,
         "executes_checks": execute,
-        "writes_evidence": False,
+        "writes_evidence": bool(allow_tracked_side_effects),
         "creates_runtime_contract": False,
         "timeout_seconds": max(1.0, timeout_seconds),
         "fail_fast": fail_fast,
+        "side_effect_guard": side_effect_guard,
         "limit": max(0, limit),
         "selected_check_count": len(selected),
         "executed_check_count": len(results),
         "failure_count": len(failures),
         "timeout_count": len(timed_out),
+        "tracked_side_effect_failure_count": len(side_effect_failures),
         "unsafe_command_count": len(unsafe),
         "warning_count": len(warnings),
         "warnings": warnings,
@@ -506,6 +643,8 @@ def render_catalog_canary_run_markdown(payload: dict[str, Any]) -> str:
 
 def render_canary_smoke_suite_run_markdown(payload: dict[str, Any]) -> str:
     mode = "execute" if payload.get("executes_checks") else "preview"
+    guard = payload.get("side_effect_guard")
+    guard = guard if isinstance(guard, dict) else {}
     lines = [
         "# Canary Smoke Suite",
         "",
@@ -516,9 +655,12 @@ def render_canary_smoke_suite_run_markdown(payload: dict[str, Any]) -> str:
         f"- executed_checks: `{payload.get('executed_check_count')}`",
         f"- failures: `{payload.get('failure_count')}`",
         f"- timeouts: `{payload.get('timeout_count')}`",
+        f"- tracked_side_effect_failures: `{payload.get('tracked_side_effect_failure_count')}`",
         f"- warnings: `{payload.get('warning_count')}`",
-        "- writes_evidence: `false`",
+        f"- writes_evidence: `{str(payload.get('writes_evidence')).lower()}`",
         "- creates_runtime_contract: `false`",
+        f"- read_only_guard_enforced: `{str(guard.get('enforced')).lower()}`",
+        f"- read_only_guard_clean_start: `{str(guard.get('clean_start')).lower()}`",
         "",
         str(payload.get("note") or ""),
         "",
@@ -553,6 +695,15 @@ def render_canary_smoke_suite_run_markdown(payload: dict[str, Any]) -> str:
             lines.append(f"- returncode: `{check.get('returncode')}`")
         if check.get("duration_seconds") is not None:
             lines.append(f"- duration_seconds: `{check.get('duration_seconds')}`")
+        if check.get("tracked_side_effects"):
+            lines.append(
+                "- tracked_side_effects: `"
+                + ", ".join(str(path) for path in check.get("tracked_side_effects") or [])
+                + "`"
+            )
+        restore = check.get("tracked_side_effect_restore")
+        if isinstance(restore, dict):
+            lines.append(f"- tracked_side_effect_restore_ok: `{str(restore.get('ok')).lower()}`")
         if check.get("stderr_tail"):
             lines.append(f"- stderr_tail: `{str(check.get('stderr_tail')).strip()[-300:]}`")
         lines.append("")

--- a/loopx/cli_commands/canary.py
+++ b/loopx/cli_commands/canary.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import subprocess
+import sys
 from collections.abc import Callable
 from pathlib import Path
 
@@ -134,6 +135,23 @@ def _attach_selector_sources(
     if git_diff_selector is None:
         return
     payload["selector_sources"] = {"git_diff": git_diff_selector}
+
+
+def _print_smoke_suite_progress(event: dict[str, object]) -> None:
+    kind = str(event.get("event") or "")
+    index = event.get("check_index")
+    total = event.get("check_count")
+    if kind == "check_started":
+        command = str(event.get("command") or "")
+        print(f"[loopx canary] start {index}/{total}: {command}", file=sys.stderr, flush=True)
+    elif kind == "check_finished":
+        status = str(event.get("status") or "")
+        duration = event.get("duration_seconds")
+        print(
+            f"[loopx canary] done {index}/{total}: {status} ({duration}s)",
+            file=sys.stderr,
+            flush=True,
+        )
 
 
 def _add_canary_selector_args(parser: argparse.ArgumentParser) -> None:
@@ -300,6 +318,20 @@ def register_canary_commands(
         action="store_true",
         help="Stop execution at the first failed or timed-out smoke.",
     )
+    smoke_parser.add_argument(
+        "--allow-tracked-side-effects",
+        action="store_true",
+        help=(
+            "Allow selected smoke scripts to modify tracked files. Defaults to false; "
+            "read-only smoke-suite runs fail and restore generated tracked changes "
+            "when the suite starts from a clean tree."
+        ),
+    )
+    smoke_parser.add_argument(
+        "--no-progress",
+        action="store_true",
+        help="Do not print per-check smoke-suite progress to stderr during execution.",
+    )
 
     coverage_parser = canary_sub.add_parser(
         "coverage-audit",
@@ -380,6 +412,12 @@ def handle_canary_command(
             execute=not bool(args.no_execute),
             timeout_seconds=float(args.timeout_seconds or 120.0),
             fail_fast=bool(args.fail_fast),
+            allow_tracked_side_effects=bool(args.allow_tracked_side_effects),
+            progress_callback=(
+                None
+                if bool(args.no_execute) or bool(args.no_progress)
+                else _print_smoke_suite_progress
+            ),
         )
         _attach_selector_sources(payload, git_diff_selector=git_diff_selector)
         renderer = render_canary_smoke_suite_run_markdown


### PR DESCRIPTION
## Summary
- add per-check smoke-suite progress events and CLI stderr progress output
- add a read-only tracked side-effect guard with explicit --allow-tracked-side-effects escape hatch
- extend the runner smoke to cover progress, side-effect rejection/restoration, and markdown boundary output

## Validation
- python3 -m py_compile loopx/canary/runner.py loopx/cli_commands/canary.py examples/canary-smoke-suite-runner-smoke.py
- python3 examples/canary-smoke-suite-runner-smoke.py
- python3 -m loopx.cli canary smoke-suite --script todo-contract-smoke.py --timeout-seconds 60
- python3 -m loopx.cli canary smoke-suite --module canary --timeout-seconds 180
- python3 -m loopx.cli check --scan-path loopx/canary/runner.py --scan-path loopx/cli_commands/canary.py --scan-path examples/canary-smoke-suite-runner-smoke.py