### PR TITLE
Add generic SkillsBench reasoning effort

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -284,6 +284,92 @@ def test_codex_app_server_goal_requires_public_safe_codex_api_tunnel_contract() 
         ), codex_acp_config
 
 
+def test_generic_reasoning_effort_reaches_codex_exec_route() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-codex-reasoning-") as tmp:
+        root = Path(tmp)
+        skillsbench_root = root / "skillsbench"
+        task_dir = skillsbench_root / "tasks" / "citation-check"
+        task_dir.mkdir(parents=True)
+        (task_dir / "task.toml").write_text("version = \"1.1\"\n", encoding="utf-8")
+
+        args = parse_args(
+            [
+                "--task-id",
+                "citation-check",
+                "--route",
+                "codex-acp-blind-loop-baseline",
+                "--host-local-acp-launch",
+                "--reasoning-effort",
+                "xhigh",
+                "--skillsbench-root",
+                str(skillsbench_root),
+                "--jobs-dir",
+                str(root / "jobs"),
+            ]
+        )
+        plan = build_plan(args)
+        command = _host_local_acp_launch_command(args, plan)
+        assert plan["reasoning_effort"] == "xhigh", plan
+        assert plan["codex_cli_reasoning_effort"] == "xhigh", plan
+        assert plan["app_server_reasoning_effort"] == "", plan
+        assert command[command.index("--reasoning-effort") + 1] == "xhigh", command
+        config = plan["runner_config"]
+        assert config["reasoning_effort"] == "xhigh", config
+        assert config["codex_cli_reasoning_effort"] == "xhigh", config
+        assert "app_server_reasoning_effort" not in config, config
+
+
+def test_codex_exec_relay_maps_reasoning_effort_to_cli_config() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-codex-cli-effort-") as tmp:
+        root = Path(tmp)
+        fake_codex = root / "fake-codex"
+        argv_path = root / "argv.json"
+        fake_codex.write_text(
+            """#!/usr/bin/env python3
+import json
+import os
+import sys
+from pathlib import Path
+
+Path(os.environ["LOOPX_FAKE_CODEX_ARGV_PATH"]).write_text(json.dumps(sys.argv), encoding="utf-8")
+output_path = Path(sys.argv[sys.argv.index("--output-last-message") + 1])
+output_path.write_text("relay ok", encoding="utf-8")
+raise SystemExit(0)
+""",
+            encoding="utf-8",
+        )
+        fake_codex.chmod(0o700)
+
+        old_env = os.environ.get("LOOPX_FAKE_CODEX_ARGV_PATH")
+        os.environ["LOOPX_FAKE_CODEX_ARGV_PATH"] = str(argv_path)
+        try:
+            relay = SkillsBenchLocalAcpRelay(
+                CodexExecConfig(
+                    codex_bin=str(fake_codex),
+                    route="codex-acp-blind-loop-baseline",
+                    timeout_sec=5,
+                    reasoning_effort="xhigh",
+                )
+            )
+            response = relay._run_codex(
+                "public-safe prompt placeholder",
+                session={"cwd": str(root)},
+                session_id="session-cli-effort",
+                stdout=io.StringIO(),
+            )
+        finally:
+            if old_env is None:
+                os.environ.pop("LOOPX_FAKE_CODEX_ARGV_PATH", None)
+            else:
+                os.environ["LOOPX_FAKE_CODEX_ARGV_PATH"] = old_env
+
+        assert response == "relay ok", response
+        argv = json.loads(argv_path.read_text(encoding="utf-8"))
+        assert "-c" in argv, argv
+        config_value = argv[argv.index("-c") + 1]
+        assert config_value == 'model_reasoning_effort="xhigh"', argv
+
+
 def test_benchmark_egress_proxy_env_is_public_safe_and_forwarded() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-benchmark-egress-proxy-") as tmp:
         root = Path(tmp)
@@ -14323,6 +14409,8 @@ def test_skillsbench_reduce_only_preserves_persisted_public_prerequisites() -> N
 if __name__ == "__main__":
     test_skillsbench_default_blind_loop_budget_is_sixteen()
     test_codex_app_server_goal_requires_public_safe_codex_api_tunnel_contract()
+    test_generic_reasoning_effort_reaches_codex_exec_route()
+    test_codex_exec_relay_maps_reasoning_effort_to_cli_config()
     test_codex_app_server_goal_rejects_non_http_codex_api_proxy_scheme()
     test_codex_app_server_goal_blocks_without_codex_api_egress()
     test_benchmark_egress_proxy_env_is_public_safe_and_forwarded()

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -520,7 +520,7 @@ class CodexExecConfig:
     first_action_timeout_sec: float = 0.0
     bridge_idle_timeout_sec: float = 0.0
     task_output_quiet_timeout_sec: float = 0.0
-    reasoning_effort: str | None = "high"
+    reasoning_effort: str | None = None
     worker_public_trace_dir: str | None = None
     remote_command_file_bridge_command: str | None = None
     remote_command_file_bridge_agent_command: str | None = None
@@ -744,6 +744,14 @@ class SkillsBenchLocalAcpRelay:
                 str(output_path),
                 "--json",
             ]
+            if self._config.reasoning_effort:
+                cmd.extend(
+                    [
+                        "-c",
+                        "model_reasoning_effort="
+                        + json.dumps(str(self._config.reasoning_effort)),
+                    ]
+                )
             model = self._config.model or session.get("model")
             if model:
                 cmd.extend(["--model", str(model)])

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -1090,7 +1090,7 @@ def _host_local_acp_launch_command(
                 "--approval-policy",
                 "never",
                 "--reasoning-effort",
-                args.app_server_reasoning_effort,
+                _effective_app_server_reasoning_effort(args),
                 "--response-timeout-sec",
                 "30",
                 "--stream-heartbeat-interval-sec",
@@ -1129,6 +1129,9 @@ def _host_local_acp_launch_command(
             str(_effective_local_codex_task_output_quiet_timeout_sec(args)),
         ]
     )
+    cli_reasoning_effort = _effective_codex_cli_reasoning_effort(args)
+    if cli_reasoning_effort and args.route != "codex-app-server-goal-baseline":
+        command.extend(["--reasoning-effort", cli_reasoning_effort])
     if args.host_local_acp_launch and args.route != "codex-app-server-goal-baseline":
         heartbeat_interval = min(
             max(1.0, float(args.app_server_acp_heartbeat_interval_sec)),
@@ -1235,6 +1238,22 @@ def _host_local_acp_launch_command(
             ]
         )
     return command
+
+
+def _effective_reasoning_effort(args: argparse.Namespace) -> str:
+    return str(getattr(args, "reasoning_effort", None) or "").strip()
+
+
+def _effective_app_server_reasoning_effort(args: argparse.Namespace) -> str:
+    return str(
+        getattr(args, "reasoning_effort", None)
+        or getattr(args, "app_server_reasoning_effort", None)
+        or "high"
+    ).strip()
+
+
+def _effective_codex_cli_reasoning_effort(args: argparse.Namespace) -> str:
+    return _effective_reasoning_effort(args)
 
 
 def _effective_local_codex_exec_timeout_sec(args: argparse.Namespace) -> int:
@@ -7883,6 +7902,9 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
     loopx_source_mount = _loopx_source_mount_contract(args)
     requires_preinstalled_runtime = bool(agent_runtime_layer.get("required"))
     is_app_server_goal_route = route == "codex-app-server-goal-baseline"
+    reasoning_effort = _effective_reasoning_effort(args)
+    app_server_reasoning_effort = _effective_app_server_reasoning_effort(args)
+    codex_cli_reasoning_effort = _effective_codex_cli_reasoning_effort(args)
     codex_api_egress_preflight = _public_codex_api_egress_contract(
         args,
         status=(
@@ -7969,7 +7991,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
             task_id=task_id,
             cwd="<skillsbench-task-workspace>",
             model=args.model,
-            reasoning_effort=args.app_server_reasoning_effort,
+            reasoning_effort=app_server_reasoning_effort,
             sandbox="workspace-write",
             approval_policy="never",
             no_upload=True,
@@ -7995,8 +8017,12 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
             else "codex-acp"
         ),
         "model": args.model,
+        "reasoning_effort": reasoning_effort,
+        "codex_cli_reasoning_effort": (
+            codex_cli_reasoning_effort if not is_app_server_goal_route else ""
+        ),
         "app_server_reasoning_effort": (
-            args.app_server_reasoning_effort if is_app_server_goal_route else ""
+            app_server_reasoning_effort if is_app_server_goal_route else ""
         ),
         "run_group_id": str(args.run_group_id or ""),
         "sandbox": args.sandbox,
@@ -8498,6 +8524,8 @@ def _public_runner_config(plan: dict[str, Any]) -> dict[str, Any]:
         "route",
         "agent",
         "model",
+        "reasoning_effort",
+        "codex_cli_reasoning_effort",
         "app_server_reasoning_effort",
         "sandbox",
         "run_group_id",
@@ -14431,12 +14459,22 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     )
     parser.add_argument("--model", default=DEFAULT_MODEL)
     parser.add_argument(
+        "--reasoning-effort",
+        default=None,
+        help=(
+            "Generic Codex reasoning effort for routes backed by Codex. "
+            "For codex-acp routes this is forwarded to codex exec via "
+            "-c model_reasoning_effort=...; for native app-server Goal routes "
+            "it overrides --app-server-reasoning-effort."
+        ),
+    )
+    parser.add_argument(
         "--app-server-reasoning-effort",
         default="high",
         help=(
-            "Reasoning effort passed as turn/start effort for native "
-            "codex-app-server-goal-baseline runs. Formal benchmark runs "
-            "default to high."
+            "Legacy/native app-server-only reasoning effort passed as "
+            "turn/start effort for codex-app-server-goal-baseline runs. "
+            "Prefer --reasoning-effort for cross-route benchmark runs."
         ),
     )
     parser.add_argument("--sandbox", default="docker")

--- a/scripts/skillsbench_local_acp_relay.py
+++ b/scripts/skillsbench_local_acp_relay.py
@@ -72,10 +72,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("--approval-policy", default="never")
     parser.add_argument(
         "--reasoning-effort",
-        default="high",
+        default=None,
         help=(
-            "Codex app-server turn/start effort for --app-server-goal-worker. "
-            "Formal benchmark runs default to high."
+            "Reasoning effort passed to Codex. For codex exec this maps to "
+            "-c model_reasoning_effort=...; for --app-server-goal-worker this "
+            "maps to the native app-server turn/start effort."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- add a generic `--reasoning-effort` SkillsBench runner option
- forward generic effort through host-local ACP to Codex CLI via `codex exec -c model_reasoning_effort=...`
- keep `--app-server-reasoning-effort` as the app-server-only legacy option and expose CLI/app-server effort in public runner config

## Validation
- `python3 -m py_compile scripts/skillsbench_automation_loop.py scripts/skillsbench_local_acp_relay.py loopx/benchmark_adapters/skillsbench_acp_relay.py examples/skillsbench-benchmark-run-smoke.py`
- targeted reasoning-effort smoke via importlib: `test_generic_reasoning_effort_reaches_codex_exec_route`, `test_codex_exec_relay_maps_reasoning_effort_to_cli_config`
- plan-only smoke for `--route codex-acp-blind-loop-baseline --host-local-acp-launch --reasoning-effort xhigh`

## Note
- Full `examples/skillsbench-benchmark-run-smoke.py` currently fails at `test_skillsbench_repeat_same_mode_keeps_distinct_ledger_runs` with a ledger run-count assertion unrelated to this parameter path; generated ledger docs were restored and are not included.