### PR TITLE
Expose generic runner contract in auto-research demo

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -216,7 +216,23 @@ def main() -> int:
         assert "research_loop" not in payload, payload
         assert "multiround_gain_acceptance" not in payload, payload
         assert payload["route_contract"]["goal_surface_mode"] == "fresh_demo_goal", payload
-        assert payload["supervisor"]["lane_count"] == 4, payload
+        supervisor = payload["supervisor"]
+        assert supervisor["lane_count"] == 4, payload
+        assert supervisor["uses_generic_runner"] is True, supervisor
+        assert supervisor["generic_spec_schema"] == "generic_multi_agent_launch_spec_v0", supervisor
+        assert supervisor["runner_contract_schema"] == "tui_multi_agent_runner_contract_v0", supervisor
+        assert supervisor["machine_json_policy"] == "artifact_only_in_visible_panes", supervisor
+        assert supervisor["domain_specific_runner_logic"] is False, supervisor
+        assert supervisor["pane_local_a2a"]["tick_command"] == "$LOOPX_PANE_A2A_TICK", supervisor
+        assert (
+            supervisor["pane_local_a2a"]["machine_json_destination"]
+            == "$LOOPX_PANE_ARTIFACT_DIR/*.public.json"
+        ), supervisor
+        assert (
+            supervisor["kernel_boundary"]["coordination_pattern"]
+            == "decentralized_state_a2a"
+        ), supervisor
+        assert supervisor["kernel_boundary"]["presentation_layers_in_kernel"] is False, supervisor
         worker_loop = payload["worker_loop"]
         assert worker_loop["schema_version"] == "auto_research_worker_loop_v0", payload
         assert worker_loop["mode"] == "execute", payload
@@ -293,6 +309,13 @@ def main() -> int:
                 assert visible_payload["result_source"] == "visible_worker_launcher", visible_payload
                 assert "worker_loop" not in visible_payload, visible_payload
                 assert "tonight_experience" not in visible_payload, visible_payload
+                visible_supervisor = visible_payload["supervisor"]
+                assert visible_supervisor["uses_generic_runner"] is True, visible_supervisor
+                assert visible_supervisor["machine_json_policy"] == "artifact_only_in_visible_panes", visible_supervisor
+                assert (
+                    visible_supervisor["pane_local_a2a"]["human_default"]
+                    == "markdown_status_inside_codex_tui"
+                ), visible_supervisor
                 visible_proof = visible_payload["visible_worker_proof"]
                 assert visible_proof["schema_version"] == "auto_research_visible_worker_proof_v0", visible_proof
                 assert visible_proof["lane_authored_evidence_loaded"] is False, visible_proof

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -284,6 +284,66 @@ def _visible_worker_proof(*, launch_visible: bool) -> dict[str, object]:
     }
 
 
+def _supervisor_summary(supervisor: dict[str, object]) -> dict[str, object]:
+    product_spec = (
+        supervisor.get("product_spec")
+        if isinstance(supervisor.get("product_spec"), dict)
+        else {}
+    )
+    runner_contract = (
+        supervisor.get("runner_contract")
+        if isinstance(supervisor.get("runner_contract"), dict)
+        else {}
+    )
+    pane_local_a2a = (
+        runner_contract.get("pane_local_a2a")
+        if isinstance(runner_contract.get("pane_local_a2a"), dict)
+        else {}
+    )
+    cli_contract = (
+        supervisor.get("cli_contract")
+        if isinstance(supervisor.get("cli_contract"), dict)
+        else {}
+    )
+    auto_research = (
+        supervisor.get("auto_research")
+        if isinstance(supervisor.get("auto_research"), dict)
+        else {}
+    )
+    coordination_model = (
+        supervisor.get("coordination_model")
+        if isinstance(supervisor.get("coordination_model"), dict)
+        else {}
+    )
+    return {
+        "schema_version": supervisor.get("schema_version"),
+        "mode": supervisor.get("mode"),
+        "lane_count": len(supervisor.get("lanes") or []),
+        "reasoning_contract": supervisor.get("reasoning_contract"),
+        "uses_generic_runner": bool(
+            product_spec.get("uses_generic_runner")
+            or auto_research.get("uses_generic_runner")
+        ),
+        "generic_spec_schema": product_spec.get("schema_version"),
+        "runner_contract_schema": runner_contract.get("schema_version"),
+        "pane_local_a2a": {
+            "tick_command": pane_local_a2a.get("tick_command"),
+            "machine_json_policy": pane_local_a2a.get("machine_json_policy"),
+            "machine_json_destination": pane_local_a2a.get("machine_json_destination"),
+            "human_default": pane_local_a2a.get("human_default"),
+        },
+        "machine_json_policy": cli_contract.get("machine_json_policy"),
+        "domain_specific_runner_logic": bool(product_spec.get("domain_specific")),
+        "kernel_boundary": {
+            "state_bus": auto_research.get("state_bus"),
+            "presentation_layers_in_kernel": bool(
+                auto_research.get("presentation_layers_in_kernel")
+            ),
+            "coordination_pattern": coordination_model.get("pattern"),
+        },
+    }
+
+
 def _compact_live_worker_evidence(evidence: dict[str, object]) -> dict[str, object]:
     return {
         "schema_version": "auto_research_live_worker_evidence_summary_v0",
@@ -442,12 +502,7 @@ def run_auto_research_demo_e2e(
                 tracking_goal_id=tracking_goal or None,
             ),
         },
-        "supervisor": {
-            "schema_version": supervisor.get("schema_version"),
-            "mode": supervisor.get("mode"),
-            "lane_count": len(supervisor.get("lanes") or []),
-            "reasoning_contract": supervisor.get("reasoning_contract"),
-        },
+        "supervisor": _supervisor_summary(supervisor),
         "public_boundary": {
             "raw_logs_recorded": False,
             "private_artifacts_recorded": False,


### PR DESCRIPTION
## Summary
- expose the generic multi-agent runner/spec contract in demo-e2e supervisor summaries
- assert pane-local A2A, artifact-only machine JSON, and no domain-specific runner logic in the existing auto-research e2e smoke

## Validation
- python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- python3 examples/auto-research-minimal-kernel-smoke.py
- python3 examples/generic-multi-agent-spec-contract-smoke.py
- python3 examples/auto-research-demo-supervisor-smoke.py
- python3 examples/visible-multi-agent-launcher-smoke.py
- python3 -m py_compile loopx/capabilities/auto_research/demo_e2e.py examples/auto-research-demo-e2e-worker-loop-smoke.py
- git diff --check
- loopx check --scan-path loopx/capabilities/auto_research/demo_e2e.py --scan-path examples/auto-research-demo-e2e-worker-loop-smoke.py