### PR TITLE
Trim auto-research supervisor launch checks

### DIFF
--- a/examples/auto-research-demo-supervisor-smoke.py
+++ b/examples/auto-research-demo-supervisor-smoke.py
@@ -190,7 +190,9 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
     assert boundary["public_safe_redaction"] is True, payload
 
     for removed_key in [
+        "acceptance",
         "demo_acceptance",
+        "launch_checks",
         "board",
         "showcase_projection",
         "artifact_packet",

--- a/loopx/capabilities/auto_research/demo_supervisor.py
+++ b/loopx/capabilities/auto_research/demo_supervisor.py
@@ -225,7 +225,7 @@ def build_auto_research_demo_supervisor_plan(
         cli_bin=cli_bin,
         codex_bin=codex_bin,
     )
-    launch_checks = payload.pop("acceptance", None)
+    payload.pop("acceptance", None)
     payload.update(
         {
             "schema_version": AUTO_RESEARCH_DEMO_SUPERVISOR_SCHEMA_VERSION,
@@ -248,7 +248,6 @@ def build_auto_research_demo_supervisor_plan(
                 ],
                 "pattern": "decentralized_state_a2a",
             },
-            "launch_checks": launch_checks,
             "one_click_demo": {
                 "schema_version": "auto_research_one_click_demo_v1",
                 "mode": "visible_codex_tui_lanes",


### PR DESCRIPTION
## Summary
- stop exposing the generic runner acceptance packet as auto-research `launch_checks`
- strengthen the auto-research demo supervisor smoke so `acceptance` / `launch_checks` do not reappear in the product payload

## Validation
- python3 examples/auto-research-demo-supervisor-smoke.py
- python3 examples/auto-research-minimal-kernel-smoke.py
- python3 examples/generic-multi-agent-spec-contract-smoke.py
- python3 -m py_compile loopx/capabilities/auto_research/demo_supervisor.py
- git diff --check
- loopx check --scan-path loopx/capabilities/auto_research/demo_supervisor.py --scan-path examples/auto-research-demo-supervisor-smoke.py

## Boundary
Generic multi-agent launch acceptance remains in the reusable launcher; auto-research no longer surfaces it as a domain-level product packet.