### PR TITLE
Clarify smoke-suite guard availability

### DIFF
--- a/examples/canary-smoke-suite-runner-smoke.py
+++ b/examples/canary-smoke-suite-runner-smoke.py
@@ -123,6 +123,15 @@ def assert_execution_reports_progress_indices() -> None:
     assert events[1]["status"] == "passed", events
 
 
+def assert_git_probe_contract_is_explicit() -> None:
+    ok, paths, detail = canary_runner._tracked_change_paths()
+    assert isinstance(paths, list), paths
+    if ok:
+        assert detail == "", detail
+        return
+    assert detail.startswith(("not_a_git_worktree:", "git_diff_failed:")), detail
+
+
 def _fake_passed_check(
     check: dict[str, object],
     *,
@@ -182,6 +191,10 @@ def assert_readonly_run_rejects_and_restores_tracked_side_effects() -> None:
     assert payload["writes_evidence"] is False, payload
     assert payload["tracked_side_effect_failure_count"] == 1, payload
     assert payload["side_effect_guard"]["enforced"] is True, payload
+    assert (
+        payload["side_effect_guard"]["enforcement_reason"]
+        == "tracked_side_effect_guard_active"
+    ), payload
     assert payload["side_effect_guard"]["auto_restored"] is True, payload
     assert restored == [["examples/generated-tracked-side-effect.txt"]], payload
     check = payload["selected_checks"][0]
@@ -189,7 +202,43 @@ def assert_readonly_run_rejects_and_restores_tracked_side_effects() -> None:
     assert check["tracked_side_effects"] == ["examples/generated-tracked-side-effect.txt"], payload
     rendered = canary_runner.render_canary_smoke_suite_run_markdown(payload)
     assert "- tracked_side_effect_failures: `1`" in rendered, rendered
+    assert "- read_only_guard_reason: `tracked_side_effect_guard_active`" in rendered, rendered
     assert "- tracked_side_effect_restore_ok: `true`" in rendered, rendered
+
+
+def assert_unavailable_git_worktree_is_reported_explicitly() -> None:
+    original_run_check = canary_runner._run_check
+    original_tracked_change_paths = canary_runner._tracked_change_paths
+
+    def fake_tracked_change_paths() -> tuple[bool, list[str], str]:
+        return False, [], "not_a_git_worktree: fixture"
+
+    try:
+        canary_runner._run_check = _fake_passed_check
+        canary_runner._tracked_change_paths = fake_tracked_change_paths
+        payload = build_canary_smoke_suite_run(
+            suite="default-public",
+            scripts=["todo-contract-smoke.py"],
+            execute=True,
+            timeout_seconds=60,
+        )
+    finally:
+        canary_runner._run_check = original_run_check
+        canary_runner._tracked_change_paths = original_tracked_change_paths
+
+    assert payload["ok"] is True, payload
+    assert payload["writes_evidence"] is False, payload
+    assert payload["tracked_side_effect_failure_count"] == 0, payload
+    assert payload["side_effect_guard"]["git_status_ok"] is False, payload
+    assert payload["side_effect_guard"]["enforced"] is False, payload
+    assert payload["side_effect_guard"]["enforcement_reason"] == "git_worktree_unavailable", payload
+    assert (
+        payload["side_effect_guard"]["git_status_unavailable_reason"]
+        == "not_a_git_worktree: fixture"
+    ), payload
+    rendered = canary_runner.render_canary_smoke_suite_run_markdown(payload)
+    assert "- read_only_guard_enforced: `false`" in rendered, rendered
+    assert "- read_only_guard_reason: `git_worktree_unavailable`" in rendered, rendered
 
 
 def assert_tracked_side_effects_require_explicit_allow() -> None:
@@ -224,9 +273,14 @@ def assert_tracked_side_effects_require_explicit_allow() -> None:
     assert payload["tracked_side_effect_failure_count"] == 0, payload
     assert payload["side_effect_guard"]["tracked_side_effects_allowed"] is True, payload
     assert payload["side_effect_guard"]["enforced"] is False, payload
+    assert (
+        payload["side_effect_guard"]["enforcement_reason"]
+        == "tracked_side_effects_explicitly_allowed"
+    ), payload
     rendered = canary_runner.render_canary_smoke_suite_run_markdown(payload)
     assert "- writes_evidence: `true`" in rendered, rendered
     assert "- read_only_guard_enforced: `false`" in rendered, rendered
+    assert "- read_only_guard_reason: `tracked_side_effects_explicitly_allowed`" in rendered, rendered
 
 
 def main() -> int:
@@ -236,7 +290,9 @@ def main() -> int:
     assert_catalog_profile_preview_is_supported()
     assert_cli_json_preview_works()
     assert_execution_reports_progress_indices()
+    assert_git_probe_contract_is_explicit()
     assert_readonly_run_rejects_and_restores_tracked_side_effects()
+    assert_unavailable_git_worktree_is_reported_explicitly()
     assert_tracked_side_effects_require_explicit_allow()
     print("canary-smoke-suite-runner-smoke ok")
     return 0

--- a/loopx/canary/runner.py
+++ b/loopx/canary/runner.py
@@ -114,6 +114,21 @@ def _display_argv(argv: list[str]) -> list[str]:
 
 
 def _tracked_change_paths() -> tuple[bool, list[str], str]:
+    worktree_probe = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "--is-inside-work-tree"],
+        check=False,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    if worktree_probe.returncode != 0 or worktree_probe.stdout.strip() != "true":
+        detail = (
+            worktree_probe.stderr
+            or worktree_probe.stdout
+            or "repository root is not a git worktree"
+        ).strip()
+        return False, [], f"not_a_git_worktree: {detail[-400:]}"
+
     paths: set[str] = set()
     stderr_parts: list[str] = []
     ok = True
@@ -127,7 +142,7 @@ def _tracked_change_paths() -> tuple[bool, list[str], str]:
         )
         if completed.returncode != 0:
             ok = False
-            stderr_parts.append(completed.stderr[-400:])
+            stderr_parts.append(f"git_diff_failed: {completed.stderr[-400:]}")
             continue
         paths.update(line.strip() for line in completed.stdout.splitlines() if line.strip())
     return ok, sorted(paths), "\n".join(part for part in stderr_parts if part)
@@ -375,6 +390,7 @@ def build_canary_smoke_suite_run(
         "schema_version": "canary_smoke_suite_side_effect_guard_v0",
         "tracked_side_effects_allowed": allow_tracked_side_effects,
         "enforced": False,
+        "enforcement_reason": "not_executed",
         "clean_start": None,
         "tracked_before": [],
         "tracked_side_effects": [],
@@ -383,16 +399,23 @@ def build_canary_smoke_suite_run(
     if execute:
         git_ok, tracked_before, git_stderr = _tracked_change_paths()
         clean_start = git_ok and not tracked_before
+        if allow_tracked_side_effects:
+            enforcement_reason = "tracked_side_effects_explicitly_allowed"
+        elif not git_ok:
+            enforcement_reason = "git_worktree_unavailable"
+        else:
+            enforcement_reason = "tracked_side_effect_guard_active"
         side_effect_guard.update(
             {
                 "git_status_ok": git_ok,
                 "clean_start": clean_start,
                 "tracked_before": tracked_before,
                 "enforced": bool(git_ok and not allow_tracked_side_effects),
+                "enforcement_reason": enforcement_reason,
             }
         )
         if git_stderr:
-            side_effect_guard["git_status_stderr_tail"] = git_stderr[-800:]
+            side_effect_guard["git_status_unavailable_reason"] = git_stderr[-800:]
         for index, check in enumerate(selected, start=1):
             normalized_check = normalize_canary_command(str(check.get("command") or ""))
             if progress_callback:
@@ -660,6 +683,7 @@ def render_canary_smoke_suite_run_markdown(payload: dict[str, Any]) -> str:
         f"- writes_evidence: `{str(payload.get('writes_evidence')).lower()}`",
         "- creates_runtime_contract: `false`",
         f"- read_only_guard_enforced: `{str(guard.get('enforced')).lower()}`",
+        f"- read_only_guard_reason: `{guard.get('enforcement_reason')}`",
         f"- read_only_guard_clean_start: `{str(guard.get('clean_start')).lower()}`",
         "",
         str(payload.get("note") or ""),


### PR DESCRIPTION
## Summary
- make canary smoke-suite side-effect guard report when the repo root is not a git worktree
- expose `side_effect_guard.enforcement_reason` in JSON and Markdown output
- cover active guard, unavailable git worktree, and explicit side-effect allow modes in the runner smoke

## Product / architecture judgment
Motivation: full-public smoke runs from installed release snapshots can lack `.git`, so the read-only side-effect guard was silently unavailable and produced an unstructured git stderr tail.

Solved: the runner now distinguishes active guard, explicit allow, and unavailable git worktree as stable payload states. The smoke keeps this as a characterization before broader quota/status refactors.

Impact: operators can tell whether a smoke-suite run is enforcing source-worktree side-effect safety or only executing scripts from a release snapshot.

Risk: narrow canary runner output/schema additive change; no benchmark scoring, permission, or public first-screen changes.

## Validation
- `python3 -m py_compile loopx/canary/runner.py examples/canary-smoke-suite-runner-smoke.py`
- `python3 examples/canary-smoke-suite-runner-smoke.py`
- `python3 -m loopx.cli --format json canary smoke-suite --script todo-contract-smoke.py --timeout-seconds 60 --no-progress`
- `python3 -m loopx.cli check --scan-path loopx/canary/runner.py --scan-path examples/canary-smoke-suite-runner-smoke.py`
- `git diff --check`

Boundary scan: candidate paths scanned for private paths, credentials, raw benchmark evidence, and verifier/trajectory terms; no public-boundary issue found.
