### PR TITLE
Drop auto-research demo quickstart preview

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -43,6 +43,9 @@ def main() -> int:
     launcher_source = (REPO_ROOT / "loopx/visible_multi_agent_launcher.py").read_text(
         encoding="utf-8"
     )
+    demo_e2e_source = (
+        REPO_ROOT / "loopx/capabilities/auto_research/demo_e2e.py"
+    ).read_text(encoding="utf-8")
     assert "raw JSON is not printed in visible panes" in launcher_source
     assert "Use $LOOPX_PANE_LOOPX for human-readable output" in launcher_source
     assert "$LOOPX_PANE_LOOPX_JSON <command>" in launcher_source
@@ -54,6 +57,8 @@ def main() -> int:
     assert "role_prompt_inside_codex_tui" in launcher_source
     assert "model_reasoning_effort" in launcher_source
     assert "codex_stream_filter" not in launcher_source
+    assert "build_auto_research_quickstart" not in demo_e2e_source
+    assert "quickstart_preview" not in demo_e2e_source
 
     worker_markdown = render_auto_research_markdown(
         {

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -7,10 +7,7 @@ from collections.abc import Callable, Sequence
 from pathlib import Path
 
 from .demo_supervisor import build_auto_research_demo_supervisor_plan
-from .quickstart_seed import (
-    AUTO_RESEARCH_DEFAULT_GOAL_ID,
-    build_auto_research_quickstart,
-)
+from .quickstart_seed import AUTO_RESEARCH_DEFAULT_GOAL_ID
 from .live_evidence import load_live_codex_e2e_evidence
 from .rollout_append import append_auto_research_rollout_events
 from .worker_loop import run_auto_research_worker_loop
@@ -516,20 +513,6 @@ def run_auto_research_demo_e2e(
         "visible_worker_proof": _visible_worker_proof(launch_visible=launch_visible),
     }
     if not execute:
-        quickstart = build_auto_research_quickstart(
-            agent_id=agent_id,
-            goal_id=goal_id,
-            objective=objective,
-            output_dir=output_dir,
-            execute=False,
-            cwd=Path.cwd(),
-        )
-        payload["quickstart_preview"] = {
-            "schema_version": quickstart.get("schema_version"),
-            "mode": quickstart.get("mode"),
-            "template": quickstart.get("template"),
-            "next_commands": quickstart.get("next_commands"),
-        }
         payload["worker_loop_preview"] = {
             "executed": False,
             "result_source": "dry_run_preview",


### PR DESCRIPTION
## Summary
- remove the dry-run `quickstart_preview` from `auto-research demo-e2e` so the default demo path stays focused on visible multi-agent lanes and worker-loop preview
- keep the explicit `auto-research quickstart` command intact for the k-NN starter pack
- strengthen the worker-loop e2e smoke to prevent `quickstart_preview` or `build_auto_research_quickstart` from re-entering demo-e2e

## Validation
- python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- python3 examples/auto-research-minimal-kernel-smoke.py
- python3 examples/auto-research-quickstart-smoke.py
- python3 -m py_compile loopx/capabilities/auto_research/demo_e2e.py examples/auto-research-demo-e2e-worker-loop-smoke.py
- git diff --check
- loopx check --scan-path loopx/capabilities/auto_research/demo_e2e.py --scan-path examples/auto-research-demo-e2e-worker-loop-smoke.py

## Boundary
This does not delete the quickstart capability; it keeps it behind the explicit quickstart command instead of the one-command demo-e2e default payload.