### PR TITLE
Use generic visible launch acceptance schema

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -343,6 +343,7 @@ def main() -> int:
                 ), workspace_route
                 assert workspace_route["default_visible_workspace"] == "demo_owned_clean_workspace", workspace_route
                 acceptance = launch["visible_acceptance"]
+                assert acceptance["schema_version"] == "multi_agent_visible_launch_acceptance_v0", acceptance
                 assert acceptance["accepted"] is True, visible_payload
                 assert visible_proof["visible_lanes_accepted"] is True, visible_proof
                 assert all(not item["blocked_before_bootstrap"] for item in acceptance["pane_checks"]), acceptance

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -612,7 +612,6 @@ def _execute_auto_research_demo_supervisor(
         cwd=Path.cwd(),
         codex_trust_workspace=codex_trust_workspace,
         launch_result_schema="auto_research_demo_launch_result_v0",
-        acceptance_schema="auto_research_visible_launch_acceptance_v0",
         lane_default="research-lane",
     )
     payload["mode"] = "executed_visible_launch"


### PR DESCRIPTION
## Summary
- remove the auto-research-specific visible launch acceptance schema override
- keep the auto-research demo launch result schema while letting pane launch health use the generic multi-agent acceptance contract
- lock the worker-loop smoke to `multi_agent_visible_launch_acceptance_v0`

## Validation
- `python3 examples/auto-research-demo-e2e-worker-loop-smoke.py`
- `python3 examples/auto-research-minimal-kernel-smoke.py`
- `python3 -m py_compile loopx/capabilities/auto_research/cli.py examples/auto-research-demo-e2e-worker-loop-smoke.py`
- `rg -n "auto_research_visible_launch_acceptance_v0|acceptance_schema=|acceptance_schema" loopx/capabilities/auto_research examples/auto-research-demo-e2e-worker-loop-smoke.py` returned no matches
- `git diff --check`
- `loopx check --scan-path loopx/capabilities/auto_research/cli.py --scan-path examples/auto-research-demo-e2e-worker-loop-smoke.py`

## Boundary
Public/private scan clean for the changed files. The only keyword hits were pre-existing help text about the shared internal demo goal.