### PR TITLE
Fix archived resume targets for monitor quota

### DIFF
--- a/examples/quota-resume-gated-open-todo-smoke.py
+++ b/examples/quota-resume-gated-open-todo-smoke.py
@@ -10,7 +10,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.quota import build_quota_should_run  # noqa: E402
-from loopx.status import compact_todo_group  # noqa: E402
+from loopx.status import compact_todo_group, parse_active_state_todos  # noqa: E402
 
 
 GOAL_ID = "resume-gated-open-todo-fixture"
@@ -19,8 +19,11 @@ PRIMARY_AGENT = "codex-main-control"
 BLOCKING_TODO_ID = "todo_projection_refresh"
 GATED_TODO_ID = "todo_projection_wording"
 FALLBACK_TODO_ID = "todo_catalog_canary"
+ARCHIVED_DONE_TODO_ID = "todo_archived_pr_merge"
+ARCHIVE_GATED_MONITOR_ID = "todo_archive_gated_monitor"
 GATED_ACTION = "[P0] Review refreshed projection wording."
 FALLBACK_ACTION = "[P1] Continue catalog-driven product canary coverage."
+ARCHIVE_MONITOR_ACTION = "[P1] Monitor product refactor/catalog canary continuation."
 
 
 def build_agent_todos(*, prerequisite_status: str) -> dict:
@@ -176,9 +179,66 @@ def assert_ready_open_resume_todo_can_run() -> None:
     assert quota_payload["recommended_action"] == GATED_ACTION, quota_payload
 
 
+def assert_archived_done_resume_target_wakes_claimed_monitor() -> None:
+    fields = parse_active_state_todos(
+        "# Active Goal State\n\n"
+        "## Agent Todo\n\n"
+        f"- [ ] {ARCHIVE_MONITOR_ACTION}\n"
+        "  <!-- loopx:todo "
+        f"todo_id={ARCHIVE_GATED_MONITOR_ID} "
+        "status=open "
+        "task_class=continuous_monitor "
+        "claimed_by=codex-product-capability "
+        f"resume_when=todo_done:{ARCHIVED_DONE_TODO_ID} "
+        "cadence=6h "
+        "next_due_at=2026-01-01T00:00:00+00:00 "
+        "-->\n\n"
+        "## Completed Work Archive\n\n"
+        "- [x] [P0] Merge predecessor PR.\n"
+        "  <!-- loopx:todo "
+        f"todo_id={ARCHIVED_DONE_TODO_ID} "
+        "status=done "
+        "task_class=advancement_task "
+        "claimed_by=codex-main-control "
+        f"unblocks_todo_id={ARCHIVE_GATED_MONITOR_ID} "
+        "-->\n"
+    )
+    agent_todos = fields["agent_todos"]
+    active_ids = {item["todo_id"] for item in agent_todos["items"]}
+    assert ARCHIVE_GATED_MONITOR_ID in active_ids, agent_todos
+    assert ARCHIVED_DONE_TODO_ID not in active_ids, agent_todos
+
+    monitor = next(
+        item for item in agent_todos["items"] if item["todo_id"] == ARCHIVE_GATED_MONITOR_ID
+    )
+    assert monitor["resume_ready"] is True, monitor
+    assert monitor["resume_condition"]["target_status"] == "done", monitor
+    assert monitor["resume_condition"]["target_archive_state"] == "archive", monitor
+
+    monitor_open_ids = {
+        item["todo_id"] for item in agent_todos["monitor_open_items"]
+    }
+    assert ARCHIVE_GATED_MONITOR_ID in monitor_open_ids, agent_todos
+    assert agent_todos["monitor_due_count"] == 1, agent_todos
+
+    quota_payload = build_quota_should_run(
+        status_payload(agent_todos, next_action=ARCHIVE_MONITOR_ACTION),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+    summary = quota_payload["agent_todo_summary"]
+    current_agent_monitor_ids = {
+        item["todo_id"] for item in summary["current_agent_claimed_monitor_items"]
+    }
+    assert ARCHIVE_GATED_MONITOR_ID in current_agent_monitor_ids, quota_payload
+    assert summary["current_agent_claimed_monitor_count"] == 1, quota_payload
+    assert summary["monitor_due_count"] == 1, quota_payload
+
+
 def main() -> int:
     assert_not_ready_open_resume_todo_is_not_executable()
     assert_ready_open_resume_todo_can_run()
+    assert_archived_done_resume_target_wakes_claimed_monitor()
     print("quota-resume-gated-open-todo-smoke ok")
     return 0
 

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -6154,13 +6154,14 @@ def pr_merged_condition(target: str, rollout_events: list[dict[str, Any]]) -> di
 def apply_resume_conditions(
     items: list[dict[str, Any]],
     *,
+    resume_source_items: list[dict[str, Any]] | None = None,
     rollout_events: list[dict[str, Any]] | None = None,
 ) -> None:
-    by_id = {
-        str(item.get("todo_id") or ""): item
-        for item in items
-        if str(item.get("todo_id") or "")
-    }
+    by_id: dict[str, dict[str, Any]] = {}
+    for source_item in [*(resume_source_items or []), *items]:
+        todo_id = normalize_todo_id(source_item.get("todo_id"))
+        if todo_id:
+            by_id[todo_id] = source_item
     for item in items:
         resume_when = normalize_todo_resume_when(item.get("resume_when"))
         if not resume_when:
@@ -6182,6 +6183,9 @@ def apply_resume_conditions(
                 if isinstance(target_item, dict)
                 else None
             )
+            if isinstance(target_item, dict):
+                condition["target_archive_state"] = target_item.get("archive_state")
+                condition["target_source_section"] = target_item.get("source_section")
             condition["satisfied"] = condition["target_status"] == "done"
         elif kind == TODO_RESUME_KIND_PR_MERGED and target:
             condition.update(pr_merged_condition(target, rollout_events or []))
@@ -6206,6 +6210,7 @@ def compact_todo_group(
     source_section: str | None,
     role: str | None = None,
     preferred_todo_ids: set[str] | None = None,
+    resume_source_items: list[dict[str, Any]] | None = None,
     rollout_events: list[dict[str, Any]] | None = None,
     item_limit: int | None = MAX_STATUS_TODOS_PER_ROLE,
 ) -> dict[str, Any] | None:
@@ -6217,7 +6222,29 @@ def compact_todo_group(
         else item
         for item in items
     ]
-    apply_resume_conditions(items, rollout_events=rollout_events)
+    structured_resume_source_items = [
+        structured_todo_item(
+            item,
+            role=item.get("role") if isinstance(item.get("role"), str) else None,
+            source_section=(
+                item.get("source_section")
+                if isinstance(item.get("source_section"), str)
+                else source_section
+            ),
+            archive_state=(
+                str(item.get("archive_state"))
+                if item.get("archive_state") is not None
+                else "active"
+            ),
+        )
+        for item in (resume_source_items or [])
+        if isinstance(item, dict)
+    ]
+    apply_resume_conditions(
+        items,
+        resume_source_items=structured_resume_source_items,
+        rollout_events=rollout_events,
+    )
     open_items = [item for item in items if not item.get("done")]
     terminal_items = [item for item in items if item.get("done")]
     deferred_items = [item for item in terminal_items if todo_item_is_deferred(item)]
@@ -6422,33 +6449,49 @@ def parse_active_state_todos(
     role: str | None = None
     source_sections: dict[str, str | None] = {"user": None, "agent": None}
     items: dict[str, list[dict[str, Any]]] = {"user": [], "agent": []}
+    archive_items: list[dict[str, Any]] = []
+    archive_mode = False
+    archive_source_section: str | None = None
     current_todo: dict[str, Any] | None = None
 
     for line in state_text.splitlines():
         if line.startswith("## "):
             heading = line.lstrip("#").strip()
+            normalized_heading = heading.strip().lower()
+            archive_mode = any(
+                marker in normalized_heading for marker in TODO_ARCHIVE_HEADER_MARKERS
+            )
+            archive_source_section = heading if archive_mode else None
             role = todo_role_for_heading(heading)
             current_todo = None
             if role and source_sections[role] is None:
                 source_sections[role] = heading
             continue
-        if role is None:
+        if role is None and not archive_mode:
             continue
         match = TODO_TASK_PATTERN.match(line)
         if match:
             marker, text = match.groups()
             status = todo_status_from_marker(marker)
+            target_items = archive_items if archive_mode else items[str(role)]
             todo: dict[str, Any] = {
-                "index": len(items[role]) + 1,
+                "index": len(target_items) + 1,
                 "done": todo_done_for_status(status),
                 "status": status,
                 "text": normalize_todo_text(text),
             }
+            if archive_mode:
+                todo["archive_state"] = "archive"
+                todo["source_section"] = archive_source_section
+            else:
+                todo["archive_state"] = "active"
+                todo["source_section"] = source_sections[str(role)]
+                todo["role"] = role
             if goal is not None:
                 materials = extract_review_materials(text, goal=goal, state_path=state_path)
                 if materials:
                     todo["review_materials"] = materials
-            items[role].append(todo)
+            target_items.append(todo)
             current_todo = todo
             continue
         if current_todo is None or not line.startswith((" ", "\t")):
@@ -6462,11 +6505,16 @@ def parse_active_state_todos(
             current_todo["text"] = normalize_todo_text(f"{current_todo.get('text', '')} {continuation}")
 
     result: dict[str, Any] = {}
+    archived_resume_source_items = [
+        item for item in archive_items if normalize_todo_id(item.get("todo_id"))
+    ]
+    resume_source_items = [*items["user"], *items["agent"], *archived_resume_source_items]
     user = compact_todo_group(
         items["user"],
         source_section=source_sections["user"],
         role="user",
         preferred_todo_ids=preferred_todo_ids,
+        resume_source_items=resume_source_items,
         rollout_events=rollout_events,
         item_limit=item_limit,
     )
@@ -6475,6 +6523,7 @@ def parse_active_state_todos(
         source_section=source_sections["agent"],
         role="agent",
         preferred_todo_ids=preferred_todo_ids,
+        resume_source_items=resume_source_items,
         rollout_events=rollout_events,
         item_limit=item_limit,
     )


### PR DESCRIPTION
## Summary
- Resolve todo resume conditions against archived completed todos as read-only resume sources
- Keep archive todos out of active backlog while preserving target archive/source evidence in resume_condition
- Add regression coverage for a claimed continuous_monitor resumed by a Completed Work Archive todo_done target

## Validation
- python3 examples/quota-resume-gated-open-todo-smoke.py
- python3 examples/monitor-todo-policy-seam-smoke.py
- python3 examples/todo-capture-followups-smoke.py
- python3 -m py_compile loopx/status.py loopx/quota.py loopx/policies/monitor_todo.py
- python3 -m loopx.cli --format json --registry "/Users/bytedance/.codex/loopx/registry.global.json" --runtime-root "/Users/bytedance/.codex/loopx" quota should-run --goal-id loopx-meta --agent-id codex-product-capability
- python3 -m loopx.cli check --scan-path loopx/status.py --scan-path examples/quota-resume-gated-open-todo-smoke.py
- git diff --check

## Notes
- Verified todo_efbf10288fe7 now appears in current_agent_claimed_monitor_items and monitor_due_items for codex-product-capability.
- examples/project-agent-adoption-smoke.py is red on clean origin/main with waiting_on controller vs user_or_controller, so it is treated as pre-existing unrelated smoke drift.