### PR TITLE
Align external observation target with monitor handle

### DIFF
--- a/examples/work-lane-contract-smoke.py
+++ b/examples/work-lane-contract-smoke.py
@@ -1293,6 +1293,8 @@ def assert_side_agent_monitor_watch_with_handle_requires_observation() -> None:
     assert observation["monitor_handle"]["target_key"] == target_key, observation
     assert observation["monitor_handle"]["todo_id"] == "todo_side_external_observe", observation
     assert observation["monitor_handle"]["claimed_by"] == "codex-side-bypass", observation
+    assert observation["monitor_handle"]["target_text"] == monitor_todo, observation
+    assert observation["observation_target"] == monitor_todo, observation
     assert guard["execution_obligation"]["must_attempt_work"] is True, guard
     interaction = guard["interaction_contract"]
     assert interaction["mode"] == "external_evidence_observation", interaction

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -484,10 +484,15 @@ def _external_evidence_poll_signal(
     if scoped_monitor_watch and not scoped_monitor_handle:
         return None
 
-    observation_target = next((text for text in action_texts if text), None) or next(
-        (text for text in todo_texts if text),
-        "",
+    scoped_monitor_target = (
+        str(scoped_monitor_handle.get("target_text") or "").strip()
+        if isinstance(scoped_monitor_handle, dict)
+        else ""
     )
+    observation_target = scoped_monitor_target or next(
+        (text for text in action_texts if text),
+        None,
+    ) or next((text for text in todo_texts if text), "")
     signal = {
         "source": "active_state_or_latest_run",
         "trigger": "implicit_launched_external_poll",
@@ -554,6 +559,9 @@ def _projected_monitor_handle(summary: dict[str, Any] | None) -> dict[str, Any] 
         next_due_at = str(item.get("next_due_at") or "").strip()
         if next_due_at:
             handle["next_due_at"] = next_due_at
+        target_text = str(item.get("title") or item.get("text") or "").strip()
+        if target_text:
+            handle["target_text"] = target_text[:320]
         return handle
     return None
 


### PR DESCRIPTION
## Summary
- Include monitor todo text in projected monitor handles
- Prefer scoped monitor target text when building external-evidence observation targets
- Extend work-lane smoke coverage so side-agent observation target cannot be stolen by global/latest-run action text

## Validation
- python3 examples/work-lane-contract-smoke.py
- python3 examples/heartbeat-quota-flow-smoke.py
- python3 -m py_compile loopx/quota.py
- PYTHONPATH=/private/tmp/loopx-product-next-20260702 python3 -m loopx.cli --format json --registry "$HOME/.codex/loopx/registry.global.json" --runtime-root "$HOME/.codex/loopx" quota should-run --goal-id loopx-meta --agent-id codex-product-capability
- python3 -m loopx.cli check --scan-path loopx/quota.py --scan-path examples/work-lane-contract-smoke.py
- git diff --check

## Notes
The real quota payload now keeps observation_target aligned with todo_efbf10288fe7 instead of the benchmark latest-run text.
