### PR TITLE
Fix SkillsBench host-local Codex CLI preflight env

### DIFF
--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -613,6 +613,7 @@ if out:
                 local_codex_bin="/unused/when-explicit-client-is-configured",
                 local_codex_sandbox="workspace-write",
                 model="gpt-5.5",
+                reasoning_effort="xhigh",
                 route="loopx-product-mode",
                 task_id="demo-task",
             ),
@@ -628,6 +629,13 @@ if out:
                 explicit_preflight_command.index("--codex-bin") + 1
             ]
             == "/unused/when-explicit-client-is-configured"
+        )
+        assert "--reasoning-effort" in explicit_preflight_command
+        assert (
+            explicit_preflight_command[
+                explicit_preflight_command.index("--reasoning-effort") + 1
+            ]
+            == "xhigh"
         )
         bridge_preflight_command = _host_local_acp_codex_exec_preflight_command(
             SimpleNamespace(
@@ -646,6 +654,7 @@ if out:
                 remote_command_file_bridge_probe_timeout_sec=5.0,
                 remote_command_file_bridge_ready=True,
                 remote_command_file_bridge_solver_command="/tmp/remote-solver-bridge",
+                reasoning_effort="xhigh",
                 route="loopx-product-mode",
                 task_id="demo-task",
             ),
@@ -2170,6 +2179,95 @@ output.write_text({SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER!r}, encod
             "remote_command_file_bridge_agent_task_facing_operation_count"
             not in bridge_preflight_prereqs
         ), bridge_preflight_prereqs
+        captured_preflight: dict[str, object] = {}
+        original_relay_probe = _run_host_local_acp_codex_exec_preflight.__globals__[
+            "run_skillsbench_local_acp_relay_probe"
+        ]
+
+        def fake_relay_probe(command, **kwargs):
+            captured_preflight["command"] = list(command)
+            captured_preflight["env"] = dict(kwargs.get("env") or {})
+            return {
+                "ready": True,
+                "stage": "complete",
+                "first_blocker": "skillsbench_local_acp_relay_ready",
+                "response_marker_observed": True,
+            }
+
+        _run_host_local_acp_codex_exec_preflight.__globals__[
+            "run_skillsbench_local_acp_relay_probe"
+        ] = fake_relay_probe
+        try:
+            env_preflight_plan = {
+                "host_local_acp_relay_trace_dir": str(
+                    Path(tmp) / "env-preflight-traces"
+                ),
+                "runner_prerequisites": {},
+            }
+            env_preflight_args = SimpleNamespace(
+                codex_api_egress_mode="reverse-tunnel",
+                codex_api_reverse_tunnel_proxy=(
+                    "http://reverse-proxy.example.invalid:18080"
+                ),
+                dataset="skillsbench-v1.1",
+                host_local_acp_codex_exec_preflight_attempts=1,
+                host_local_acp_codex_exec_preflight_timeout_sec=20,
+                host_local_acp_launch=True,
+                local_acp_relay_command=None,
+                local_codex_bin=str(bridge_preflight_codex),
+                local_codex_first_action_timeout_sec=0,
+                local_codex_sandbox="workspace-write",
+                model="gpt-5.5",
+                remote_command_file_bridge_agent_command="",
+                remote_command_file_bridge_probe=False,
+                remote_command_file_bridge_probe_timeout_sec=5.0,
+                remote_command_file_bridge_ready=False,
+                remote_command_file_bridge_solver_command="",
+                reasoning_effort="xhigh",
+                route="codex-acp-blind-loop-baseline",
+                task_id="demo-task",
+            )
+            _run_host_local_acp_codex_exec_preflight(
+                env_preflight_args,
+                env_preflight_plan,
+            )
+        finally:
+            _run_host_local_acp_codex_exec_preflight.__globals__[
+                "run_skillsbench_local_acp_relay_probe"
+            ] = original_relay_probe
+        env_preflight_prereqs = env_preflight_plan["runner_prerequisites"]
+        assert (
+            env_preflight_prereqs["host_local_acp_codex_exec_preflight_status"]
+            == "passed"
+        ), env_preflight_prereqs
+        assert (
+            env_preflight_prereqs["host_local_acp_target_env_forwarded"] is True
+        ), env_preflight_prereqs
+        assert "HTTPS_PROXY" in env_preflight_prereqs["host_local_acp_target_env_keys"]
+        assert (
+            "LOOPX_CODEX_API_REVERSE_TUNNEL_PROXY"
+            in env_preflight_prereqs["host_local_acp_target_env_keys"]
+        )
+        assert (
+            env_preflight_prereqs["host_local_acp_proxy_endpoint_status"]
+            == "non_loopback_proxy"
+        ), env_preflight_prereqs
+        assert (
+            env_preflight_prereqs["host_local_acp_proxy_endpoint_raw_url_recorded"]
+            is False
+        ), env_preflight_prereqs
+        captured_env = captured_preflight["env"]
+        assert isinstance(captured_env, dict)
+        assert (
+            captured_env["HTTPS_PROXY"]
+            == "http://reverse-proxy.example.invalid:18080"
+        )
+        captured_command = captured_preflight["command"]
+        assert isinstance(captured_command, list)
+        assert "--reasoning-effort" in captured_command
+        assert captured_command[captured_command.index("--reasoning-effort") + 1] == (
+            "xhigh"
+        )
         preflight_plan = {
             "host_local_acp_relay_trace_dir": str(Path(tmp) / "preflight-traces"),
             "runner_prerequisites": {},
@@ -2187,6 +2285,7 @@ output.write_text({SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER!r}, encod
             remote_command_file_bridge_probe=False,
             remote_command_file_bridge_ready=False,
             remote_command_file_bridge_solver_command=None,
+            reasoning_effort="xhigh",
             route="loopx-product-mode",
             task_id="demo-task",
         )

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -2720,6 +2720,7 @@ def run_skillsbench_local_acp_relay_probe(
     prompt_text: str | None = None,
     required_response_marker: str | None = None,
     model_id: str | None = "probe-model",
+    env: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     argv = (
         _command_to_argv(command)
@@ -2736,6 +2737,7 @@ def run_skillsbench_local_acp_relay_probe(
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
+            env=({**os.environ, **env} if env else None),
         )
         stage = "initialize"
         initialize = _probe_request(

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -2073,6 +2073,9 @@ def _host_local_acp_codex_exec_preflight_command(
     )
     if args.model:
         command.extend(["--model", args.model])
+    cli_reasoning_effort = _effective_codex_cli_reasoning_effort(args)
+    if cli_reasoning_effort and args.route != "codex-app-server-goal-baseline":
+        command.extend(["--reasoning-effort", cli_reasoning_effort])
     relay_trace_dir = str(plan.get("host_local_acp_relay_trace_dir") or "")
     if relay_trace_dir:
         command.extend(
@@ -2297,7 +2300,15 @@ def _run_host_local_acp_codex_exec_preflight(
         int(getattr(args, "host_local_acp_codex_exec_preflight_attempts", 1) or 1),
     )
     command = _host_local_acp_codex_exec_preflight_command(args, plan)
-    proxy_probe = _host_local_proxy_endpoint_probe()
+    target_env = _host_local_acp_target_env({}, args=args)
+    prerequisites["host_local_acp_target_env_forwarded"] = bool(target_env)
+    prerequisites["host_local_acp_target_env_key_count"] = len(target_env)
+    prerequisites["host_local_acp_target_env_keys"] = sorted(target_env)
+    if target_env:
+        prerequisites["benchmark_egress_proxy_agent_env_injected"] = bool(
+            any(key.startswith("LOOPX_SKILLSBENCH") for key in target_env)
+        )
+    proxy_probe = _host_local_proxy_endpoint_probe(env=target_env or None)
     prerequisites["host_local_acp_proxy_endpoint_status"] = proxy_probe["status"]
     prerequisites["host_local_acp_proxy_endpoint_checked"] = (
         proxy_probe.get("checked") is True
@@ -2359,6 +2370,7 @@ def _run_host_local_acp_codex_exec_preflight(
                 else SKILLSBENCH_LOCAL_ACP_RELAY_READY_MARKER
             ),
             model_id=str(getattr(args, "model", "") or "") or None,
+            env=target_env or None,
         )
         ready = probe.get("ready") is True
         prerequisites["host_local_acp_codex_exec_preflight_ready"] = ready


### PR DESCRIPTION
## Summary
- forward the same host-local target environment into the Codex exec preflight relay probe that the formal ACP launch path uses
- pass generic `--reasoning-effort` through the Codex CLI preflight command so xhigh preflight matches the requested run path
- cover reverse-tunnel proxy env forwarding and reasoning-effort parity in the host-local ACP launch smoke

## Validation
- `python3 examples/skillsbench-host-local-launch-plan-smoke.py`
- `python3 -m py_compile scripts/skillsbench_automation_loop.py loopx/benchmark_adapters/skillsbench_acp_relay.py examples/skillsbench-host-local-launch-plan-smoke.py`
- selected proxy contract smoke: `test_benchmark_egress_proxy_env_is_public_safe_and_forwarded`, `test_codex_app_server_goal_rejects_non_http_codex_api_proxy_scheme`
- `git diff --check`
- `loopx check`

## Boundary
- No raw proxy URL, private benchmark logs, trajectories, verifier output, or local run artifact paths are committed.
