### PR TITLE
Define multi-agent three-layer minimality contract

### DIFF
--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -35,4 +35,5 @@ Current contracts:
 - [value_connector_plan_v0](value-connector-plan-v0.md)
 - [openviking_session_memory_adapter_v0](openviking-session-memory-adapter-v0.md)
 - [local_agent_launch_plan_v0](local-agent-launch-plan-v0.md)
+- [multi_agent_three_layer_minimality_contract_v0](multi-agent-three-layer-minimality-v0.md)
 - [multi_agent_visible_launcher_v0](multi-agent-visible-launcher-v0.md)

--- a/docs/reference/protocols/multi-agent-three-layer-minimality-v0.md
+++ b/docs/reference/protocols/multi-agent-three-layer-minimality-v0.md
@@ -1,0 +1,72 @@
+# multi_agent_three_layer_minimality_contract_v0
+
+`multi_agent_three_layer_minimality_contract_v0` defines the reusable layering
+rule for LoopX multi-agent products:
+
+1. **User layer:** declares intent and a few product-level options.
+2. **Preset layer:** supplies domain defaults, role semantics, handoff hints,
+   and product evidence or metric adapters.
+3. **Kernel layer:** owns the reusable multi-agent mechanics.
+
+The goal is not only to minimize the user's snippet. The preset must also stay
+thin so auto-research can be a reusable example for future multi-agent products
+rather than a second product-specific runner.
+
+## Ownership
+
+| Layer | Owns | Must Not Own |
+| --- | --- | --- |
+| User | Objective, rounds, optional role overrides, and optional data/eval entrypoint. | Tmux/Codex TUI launch, pane-local tick commands, quota/frontier protocol details, worker plumbing, or machine JSON routing. |
+| Preset | Domain roles, handoff hints, metric/evidence loop, and domain defaults. | Generic runner lifecycle, real Codex TUI panes, workspace/trust-safe launch, pane-local A2A tick, todo/evidence/status protocol, or compact human status. |
+| Kernel | Multi-agent runner, real Codex TUI panes, workspace/trust-safe launch, pane-local A2A tick, todo/evidence/status protocol, compact human status, and default role prompt scaffolding. | Domain-specific research, benchmark, support, or sales semantics. |
+
+## Contract Shape
+
+The reusable helper lives in `loopx/capabilities/multi_agent/contract.py`:
+
+```python
+build_three_layer_minimality_contract(
+    product_id="customer-support",
+    preset_id="support_triage_preset",
+    user_intent_fields=["inbox", "rounds"],
+    preset_responsibilities=["triage_roles", "handoff_hints"],
+)
+```
+
+It returns:
+
+```json
+{
+  "schema_version": "multi_agent_three_layer_minimality_contract_v0",
+  "principle": "user_and_preset_stay_thin_kernel_owns_reusable_mechanics",
+  "user_layer": {
+    "owns": "intent"
+  },
+  "preset_layer": {
+    "must_remain_reusable": true
+  },
+  "kernel_layer": {
+    "cross_product_reuse_required": true
+  }
+}
+```
+
+## Auto-Research Preset
+
+Auto-research is one preset on top of the generic kernel. Its preset layer owns
+research roles, handoff hints, the metric/evidence loop, and domain defaults.
+It does not own the runner, TUI panes, workspace/trust-safe launch,
+pane-local A2A tick, or todo/evidence/status protocol.
+
+This keeps the public promise honest: a small auto-research recipe should prove
+that other products can also reuse the same kernel with their own thin preset.
+
+## Acceptance
+
+A change satisfies this contract only when:
+
+- the user recipe remains a few intent fields, not runner configuration;
+- the preset has no host process lifecycle or pane-local tick implementation;
+- the generic kernel contract stays domain-agnostic;
+- another multi-agent product can reuse the same kernel without importing
+  auto-research code.

--- a/docs/reference/protocols/multi-agent-visible-launcher-v0.md
+++ b/docs/reference/protocols/multi-agent-visible-launcher-v0.md
@@ -17,6 +17,11 @@ This contract intentionally sits between two existing surfaces:
 The visible launcher may plan or start panes, but it must not become a leader
 agent, hidden scheduler, promotion authority, or second source of truth.
 
+The launcher also follows
+[`multi_agent_three_layer_minimality_contract_v0`](multi-agent-three-layer-minimality-v0.md):
+both the user-facing recipe and the domain preset stay thin, while the generic
+kernel owns runner/TUI/tick/todo/evidence/status mechanics.
+
 ## Kernel Module
 
 The reusable product kernel lives in
@@ -25,6 +30,7 @@ on that module for:
 
 - `tui_multi_agent_runner_contract_v0`;
 - `generic_multi_agent_role_profile_v0`;
+- `multi_agent_three_layer_minimality_contract_v0`;
 - pane-local A2A prompt rules;
 - artifact-only machine JSON policy;
 - compact human status for launch previews.

--- a/examples/auto-research-demo-supervisor-smoke.py
+++ b/examples/auto-research-demo-supervisor-smoke.py
@@ -53,6 +53,28 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
     assert payload["mode"] == "dry_run", payload
     assert payload["goal_id"] == GOAL_ID, payload
 
+    layering = payload["layer_minimality_contract"]
+    assert (
+        layering["schema_version"] == "multi_agent_three_layer_minimality_contract_v0"
+    ), layering
+    assert layering["product_id"] == "auto-research", layering
+    assert layering["preset_id"] == "auto_research_thin_preset", layering
+    assert layering["principle"] == (
+        "user_and_preset_stay_thin_kernel_owns_reusable_mechanics"
+    ), layering
+    assert layering["user_layer"]["fields"] == [
+        "topic_or_objective",
+        "rounds",
+        "role_overrides",
+        "data_or_eval_entrypoint",
+    ], layering
+    assert "research_roles" in layering["preset_layer"]["owns"], layering
+    assert "metric_evidence_loop" in layering["preset_layer"]["owns"], layering
+    assert "multi_agent_runner" in layering["preset_layer"]["forbidden"], layering
+    assert "pane_local_a2a_tick" in layering["preset_layer"]["forbidden"], layering
+    assert "compact_human_status" in layering["kernel_layer"]["owns"], layering
+    assert layering["acceptance"]["preset_has_no_runner_process_logic"] is True, layering
+
     kernel = payload["auto_research"]
     assert kernel["schema_version"] == "auto_research_visible_demo_kernel_v0", payload
     assert kernel["uses_generic_runner"] is True, payload

--- a/examples/generic-multi-agent-runner-kernel-smoke.py
+++ b/examples/generic-multi-agent-runner-kernel-smoke.py
@@ -14,9 +14,11 @@ sys.path.insert(0, str(ROOT))
 from loopx.capabilities.multi_agent.contract import (  # noqa: E402
     GENERIC_MULTI_AGENT_COMPACT_STATUS_SCHEMA_VERSION,
     GENERIC_MULTI_AGENT_ROLE_PROFILE_SCHEMA_VERSION,
+    THREE_LAYER_MINIMALITY_CONTRACT_SCHEMA_VERSION,
     TUI_MULTI_AGENT_RUNNER_CONTRACT_SCHEMA_VERSION,
     build_compact_human_status,
     build_generic_role_profile,
+    build_three_layer_minimality_contract,
     build_tui_multi_agent_runner_contract,
     generic_role_prompt,
     role_skill_profile,
@@ -92,6 +94,22 @@ def main() -> int:
     assert compact["role_count"] == 2, compact
     assert compact["roles"][0]["tick"] == "$LOOPX_PANE_A2A_TICK", compact
     assert compact["machine_json_policy"] == "artifact_only_in_visible_panes", compact
+
+    layering = build_three_layer_minimality_contract(
+        product_id="customer-support",
+        preset_id="support_triage_preset",
+        user_intent_fields=["inbox", "rounds"],
+        preset_responsibilities=["triage_roles", "handoff_hints", "resolution_policy"],
+        extension_points=["role_overrides", "ticket_adapter"],
+    )
+    assert layering["schema_version"] == THREE_LAYER_MINIMALITY_CONTRACT_SCHEMA_VERSION, layering
+    assert layering["principle"] == (
+        "user_and_preset_stay_thin_kernel_owns_reusable_mechanics"
+    ), layering
+    assert layering["user_layer"]["fields"] == ["inbox", "rounds"], layering
+    assert "multi_agent_runner" in layering["kernel_layer"]["owns"], layering
+    assert "pane_local_a2a_tick" in layering["preset_layer"]["forbidden"], layering
+    assert layering["acceptance"]["other_multi_agent_products_can_reuse_kernel"] is True, layering
 
     source = (ROOT / "loopx/capabilities/multi_agent/contract.py").read_text(encoding="utf-8")
     assert "auto" + "_research" not in source

--- a/examples/multi-agent-visible-launcher-protocol-smoke.py
+++ b/examples/multi-agent-visible-launcher-protocol-smoke.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 PROTOCOL = ROOT / "docs/reference/protocols/multi-agent-visible-launcher-v0.md"
+THREE_LAYER = ROOT / "docs/reference/protocols/multi-agent-three-layer-minimality-v0.md"
 LOCAL_PLAN = ROOT / "docs/reference/protocols/local-agent-launch-plan-v0.md"
 AUTO_RESEARCH_PROFILE = ROOT / "docs/reference/protocols/auto-research-role-profile-v0.md"
 AUTO_RESEARCH_GUIDE = ROOT / "docs/guides/auto-research-command-path.md"
@@ -49,6 +50,7 @@ def assert_public_safe(text: str, label: str) -> None:
 
 def main() -> int:
     protocol = read(PROTOCOL)
+    three_layer = read(THREE_LAYER)
     local_plan = read(LOCAL_PLAN)
     auto_research_profile = read(AUTO_RESEARCH_PROFILE)
     auto_research_guide = read(AUTO_RESEARCH_GUIDE)
@@ -57,6 +59,7 @@ def main() -> int:
     changed_public_docs = "\n".join(
         [
             protocol,
+            three_layer,
             protocol_index,
             docs_index,
         ]
@@ -71,9 +74,12 @@ def main() -> int:
             "local_agent_launch_plan_v0",
             "Domain capabilities",
             "not become a leader agent",
+            "multi_agent_three_layer_minimality_contract_v0",
+            "both the user-facing recipe and the domain preset stay thin",
             "Kernel Module",
             "loopx/capabilities/multi_agent/contract.py",
             "generic_multi_agent_role_profile_v0",
+            "multi_agent_three_layer_minimality_contract_v0",
             "compact human status",
             "visible_multi_agent_launcher.py",
             "Ownership Split",
@@ -141,6 +147,20 @@ def main() -> int:
         assert phrase not in protocol, f"forbidden phrase present: {phrase}"
 
     require(
+        three_layer,
+        [
+            "multi_agent_three_layer_minimality_contract_v0",
+            "User layer",
+            "Preset layer",
+            "Kernel layer",
+            "user_and_preset_stay_thin_kernel_owns_reusable_mechanics",
+            "The goal is not only to minimize the user's snippet",
+            "Auto-research is one preset on top of the generic kernel",
+            "another multi-agent product can reuse the same kernel",
+        ],
+        source=THREE_LAYER,
+    )
+    require(
         local_plan,
         [
             "local_agent_launch_plan_v0",
@@ -173,7 +193,12 @@ def main() -> int:
     )
     require(
         protocol_index,
-        ["multi_agent_visible_launcher_v0", "multi-agent-visible-launcher-v0.md"],
+        [
+            "multi_agent_three_layer_minimality_contract_v0",
+            "multi-agent-three-layer-minimality-v0.md",
+            "multi_agent_visible_launcher_v0",
+            "multi-agent-visible-launcher-v0.md",
+        ],
         source=PROTOCOL_INDEX,
     )
     require(

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -77,6 +77,9 @@ def main() -> int:
     launcher_source = (ROOT / "loopx/visible_multi_agent_launcher.py").read_text(
         encoding="utf-8"
     )
+    contract_source = (ROOT / "loopx/capabilities/multi_agent/contract.py").read_text(
+        encoding="utf-8"
+    )
     assert "from ...visible_multi_agent_launcher import execute_visible_multi_agent_launcher" in auto_research_cli
     forbidden_defs = [
         "def _launch_auto_research_with_tmux",
@@ -94,18 +97,18 @@ def main() -> int:
     assert "loopx-pane-a2a-tick" in launcher_source
     assert "LOOPX_PANE_WORKER_TURN" in launcher_source
     assert "LOOPX_PANE_TICK_ROUNDS" in launcher_source
-    assert "First action: immediately run `$LOOPX_PANE_A2A_TICK`" in launcher_source
+    assert "First action: immediately run `$LOOPX_PANE_A2A_TICK`" in contract_source
     assert "LOOPX_VISIBLE_FORCE_MARKDOWN" in launcher_source
     assert "machine_json_command=$LOOPX_PANE_LOOPX_JSON artifact_dir=$LOOPX_PANE_ARTIFACT_DIR" in launcher_source
     assert "$LOOPX_PANE_LOOPX_JSON is a command path, not an output file." in launcher_source
     assert "It injects --format json unless you pass an explicit --format." in launcher_source
-    assert "Never write output to `$LOOPX_PANE_LOOPX_JSON`" in launcher_source
+    assert "Never write output to `$LOOPX_PANE_LOOPX_JSON`" in contract_source
     assert "LoopX machine JSON hidden" in launcher_source
     assert "LOOPX_ALLOW_TTY_JSON" in launcher_source
     assert "stat.S_ISREG" in launcher_source
     assert "LOOPX_MACHINE_JSON=1 explicitly" in launcher_source
-    assert "multi_agent_visible_interactive_tui_contract_v0" in launcher_source
-    assert TUI_MULTI_AGENT_RUNNER_CONTRACT_SCHEMA_VERSION in launcher_source
+    assert "multi_agent_visible_interactive_tui_contract_v0" in contract_source
+    assert TUI_MULTI_AGENT_RUNNER_CONTRACT_SCHEMA_VERSION in contract_source
     assert "build_tui_multi_agent_runner_contract" in launcher_source
     assert "LOOPX_CODEX_TUI_MODE=interactive" in launcher_source
     assert "LOOPX_CODEX_TRUST_WORKSPACE" in launcher_source

--- a/loopx/capabilities/auto_research/defaults.py
+++ b/loopx/capabilities/auto_research/defaults.py
@@ -1,7 +1,45 @@
 from __future__ import annotations
 
+from ..multi_agent.contract import build_three_layer_minimality_contract
+
 
 AUTO_RESEARCH_DEFAULT_GOAL_ID = "loopx-auto-research-demo"
 AUTO_RESEARCH_DEFAULT_OBJECTIVE = (
     "Improve a bounded research candidate through public-safe multi-agent evidence."
 )
+AUTO_RESEARCH_PRESET_ID = "auto_research_thin_preset"
+
+
+def build_auto_research_layer_contract() -> dict[str, object]:
+    """Return the reusable layer split for auto-research as a thin preset."""
+
+    return build_three_layer_minimality_contract(
+        product_id="auto-research",
+        preset_id=AUTO_RESEARCH_PRESET_ID,
+        user_intent_fields=[
+            "topic_or_objective",
+            "rounds",
+            "role_overrides",
+            "data_or_eval_entrypoint",
+        ],
+        preset_responsibilities=[
+            "research_roles",
+            "handoff_hints",
+            "metric_evidence_loop",
+            "domain_defaults",
+        ],
+        preset_forbidden_mechanics=[
+            "multi_agent_runner",
+            "real_codex_tui_panes",
+            "workspace_and_trust_safe_launch",
+            "pane_local_a2a_tick",
+            "todo_evidence_status_protocol",
+            "compact_human_status",
+        ],
+        extension_points=[
+            "role_overrides",
+            "metric_adapter",
+            "evidence_packet_adapter",
+            "data_or_eval_entrypoint",
+        ],
+    )

--- a/loopx/capabilities/auto_research/demo_supervisor.py
+++ b/loopx/capabilities/auto_research/demo_supervisor.py
@@ -6,7 +6,7 @@ import shlex
 from collections.abc import Iterable
 from typing import Any
 
-from .defaults import AUTO_RESEARCH_DEFAULT_GOAL_ID
+from .defaults import AUTO_RESEARCH_DEFAULT_GOAL_ID, build_auto_research_layer_contract
 from ...visible_multi_agent_launcher import build_visible_multi_agent_payload_from_spec
 
 
@@ -230,6 +230,7 @@ def build_auto_research_demo_supervisor_plan(
         {
             "schema_version": AUTO_RESEARCH_DEMO_SUPERVISOR_SCHEMA_VERSION,
             "mode": "dry_run",
+            "layer_minimality_contract": build_auto_research_layer_contract(),
             "auto_research": {
                 "schema_version": "auto_research_visible_demo_kernel_v0",
                 "uses_generic_runner": True,

--- a/loopx/capabilities/multi_agent/contract.py
+++ b/loopx/capabilities/multi_agent/contract.py
@@ -11,6 +11,19 @@ VISIBLE_LAUNCHER_ACCEPTANCE_CONTRACT_SCHEMA_VERSION = (
 )
 GENERIC_MULTI_AGENT_ROLE_PROFILE_SCHEMA_VERSION = "generic_multi_agent_role_profile_v0"
 GENERIC_MULTI_AGENT_COMPACT_STATUS_SCHEMA_VERSION = "generic_multi_agent_compact_status_v0"
+THREE_LAYER_MINIMALITY_CONTRACT_SCHEMA_VERSION = (
+    "multi_agent_three_layer_minimality_contract_v0"
+)
+
+GENERIC_MULTI_AGENT_KERNEL_MECHANICS = (
+    "multi_agent_runner",
+    "real_codex_tui_panes",
+    "workspace_and_trust_safe_launch",
+    "pane_local_a2a_tick",
+    "todo_evidence_status_protocol",
+    "compact_human_status",
+    "default_role_prompt_scaffolding",
+)
 
 
 def positive_int_value(value: object, *, default: int) -> int:
@@ -205,6 +218,67 @@ def build_tui_multi_agent_runner_contract(
             "runs_agent_processes_in_dry_run": False,
             "writes_loopx_state_in_dry_run": False,
             "spends_quota_in_dry_run": False,
+        },
+    }
+
+
+def build_three_layer_minimality_contract(
+    *,
+    product_id: str,
+    preset_id: str,
+    user_intent_fields: Iterable[object] | None = None,
+    preset_responsibilities: Iterable[object] | None = None,
+    preset_forbidden_mechanics: Iterable[object] | None = None,
+    kernel_mechanics: Iterable[object] | None = None,
+    extension_points: Iterable[object] | None = None,
+) -> dict[str, object]:
+    """Describe how a product preset stays thin on the generic kernel.
+
+    The contract is intentionally product-agnostic: callers supply the preset's
+    domain responsibilities, while this module records the shared mechanics that
+    must remain in the reusable multi-agent kernel.
+    """
+
+    intent_fields = as_string_list(user_intent_fields) or ["objective"]
+    preset_owns = as_string_list(preset_responsibilities)
+    kernel_owns = as_string_list(kernel_mechanics) or list(GENERIC_MULTI_AGENT_KERNEL_MECHANICS)
+    forbidden = as_string_list(preset_forbidden_mechanics) or kernel_owns
+    extensions = as_string_list(extension_points)
+    return {
+        "schema_version": THREE_LAYER_MINIMALITY_CONTRACT_SCHEMA_VERSION,
+        "product_id": product_id,
+        "preset_id": preset_id,
+        "principle": "user_and_preset_stay_thin_kernel_owns_reusable_mechanics",
+        "line_budget_goal": {
+            "user_layer": "few_field_intent_or_config",
+            "preset_layer": "small_domain_defaults_and_handoff_contract",
+            "kernel_layer": "shared_multi_agent_runtime_and_state_protocol",
+        },
+        "user_layer": {
+            "owns": "intent",
+            "fields": intent_fields,
+            "forbidden": [
+                "tmux_or_process_lifecycle",
+                "quota_frontier_protocol_details",
+                "pane_local_tick_commands",
+                "raw_worker_or_status_plumbing",
+            ],
+        },
+        "preset_layer": {
+            "owns": preset_owns,
+            "forbidden": forbidden,
+            "must_remain_reusable": True,
+        },
+        "kernel_layer": {
+            "owns": kernel_owns,
+            "cross_product_reuse_required": True,
+        },
+        "extension_points": extensions,
+        "acceptance": {
+            "user_can_copy_small_recipe": True,
+            "preset_has_no_runner_process_logic": True,
+            "kernel_contract_is_domain_agnostic": True,
+            "other_multi_agent_products_can_reuse_kernel": True,
         },
     }
 


### PR DESCRIPTION
## Summary
- add a product-agnostic three-layer minimality contract to the generic multi-agent kernel
- expose auto-research as a thin preset layered on that kernel instead of a runner owner
- document the user / preset / kernel split and extend protocol smokes to keep the split durable

## Validation
- python3 -m py_compile loopx/capabilities/multi_agent/contract.py loopx/capabilities/auto_research/defaults.py loopx/capabilities/auto_research/demo_supervisor.py
- python3 examples/generic-multi-agent-runner-kernel-smoke.py
- python3 examples/generic-multi-agent-one-command-smoke.py
- python3 examples/generic-multi-agent-spec-contract-smoke.py
- python3 examples/visible-multi-agent-launcher-smoke.py
- python3 examples/auto-research-demo-supervisor-smoke.py
- python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- python3 examples/multi-agent-visible-launcher-protocol-smoke.py
- python3 examples/docs-governance-smoke.py
- git diff --check
- loopx check --scan-path docs/reference/protocols --scan-path examples/generic-multi-agent-runner-kernel-smoke.py --scan-path examples/auto-research-demo-supervisor-smoke.py --scan-path examples/multi-agent-visible-launcher-protocol-smoke.py --scan-path examples/visible-multi-agent-launcher-smoke.py --scan-path loopx/capabilities/multi_agent --scan-path loopx/capabilities/auto_research/defaults.py --scan-path loopx/capabilities/auto_research/demo_supervisor.py