### PR TITLE
Project monitor-gated resume repairs in quota

### DIFF
--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -574,21 +574,17 @@ JSON or Markdown decision:
         "local_scheduler",
         "codex_cli_tui",
         "claude_code_loop",
-        "final_quota_replan_check"
+        "final_quota_replan_check",
+        "reset_policy_detail",
+        "stateful_backoff_detail"
       ]
     },
     "reset_policy": {
-      "schema_version": "scheduler_reset_policy_v0",
-      "reset_to": "profile_initial_interval",
       "reset_token": "0123456789abcdef",
       "host_state_key": "scheduler_hint.reset_policy.reset_token",
       "codex_app_initial_interval_minutes": 30,
       "codex_app_initial_rrule": "FREQ=MINUTELY;INTERVAL=30",
-      "clear_unchanged_poll_state": true,
-      "identity_key_count": 6,
-      "identity_signature": "123456789abc",
-      "profile_signature": "abcdef123456",
-      "reset_condition_summary": "token_changed|user_feedback|new_or_reassigned_todo|gate_or_material_transition|active_work_projected"
+      "identity_signature": "123456789abc"
     }
   },
   "operator_question": "是否同意 project-main-control 先做 read-only map dry-run？",
@@ -736,17 +732,20 @@ been surfaced.
 Agent-scope waits use a more conservative adjustment curve such as
 `[10, 20, 30, 60]`, so a 600-second local tick stays close to the existing
 agent-to-agent interaction cadence before cooling further.
-Each hint also carries `reset_policy.schema_version=scheduler_reset_policy_v0`.
-Hosts should cache and compare `reset_policy.reset_token` across unchanged
-polls and reset the unchanged streak whenever the token changes. The token is
-derived from scheduler action plus the current identity/profile inputs, while
-the hot path only exposes short `identity_signature` and `profile_signature`
-debug aids instead of full snapshots. Hosts should also reset when an external
-event makes the goal actionable again, such as user feedback in the thread, a
-new or reassigned todo, a resolved gate, or material evidence transition. A
-reset applies
-`codex_app_initial_interval_minutes` (and the matching local scheduler initial
-interval) before starting unchanged backoff again; it never spends quota.
+The compact hot path carries only the reset fields hosts need to act:
+`reset_policy.reset_token`, `host_state_key`,
+`codex_app_initial_interval_minutes`, `codex_app_initial_rrule`, and the short
+`identity_signature`. Hosts should cache and compare `reset_token` across
+unchanged polls and reset the unchanged streak whenever the token changes. The
+token is derived from scheduler action plus the current identity/profile inputs;
+the explanatory reset profile, profile signature, reset condition summary, and
+stateful-backoff policy live in `scheduler_hint.cold_path_detail` when callers
+request `loopx quota should-run --include-scheduler-detail`. Hosts should also
+reset when an external event makes the goal actionable again, such as user
+feedback in the thread, a new or reassigned todo, a resolved gate, or material
+evidence transition. A reset applies `codex_app_initial_interval_minutes` (and
+the matching local scheduler initial interval) before starting unchanged
+backoff again; it never spends quota.
 For Codex App heartbeats, hosts and agents should use `automation_update` only
 when `codex_app.stateful_backoff.apply_needed=true` and
 `codex_app.recommended_rrule` is present. After `automation_update` succeeds,

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1280,14 +1280,16 @@ changes, final checks, and loop self-stop never spend quota. Host schedulers
 apply `recommended_interval_minutes` as the next target interval and multiply
 subsequent unchanged intervals by `unchanged_poll_backoff_multiplier` until
 `max_interval_minutes`; `example_progression_minutes` exposes the compact
-human-readable sequence. The hint also includes
-`reset_policy.schema_version=scheduler_reset_policy_v0`: hosts compare its
-`reset_token` between polls and clear the unchanged/backoff streak when that
-token changes, or when a user reply, new/reassigned todo, resolved gate, or
-material transition makes the goal actionable again. The token is derived from
-scheduler action plus identity/profile inputs, while the hot path carries only
-short identity/profile signatures instead of full snapshots. The reset moves
-Codex App/local cadence back to the current profile's initial interval before
+human-readable sequence. The hint also includes a compact `reset_policy`:
+hosts compare `reset_token` between polls and clear the unchanged/backoff
+streak when that token changes, or when a user reply, new/reassigned todo,
+resolved gate, or material transition makes the goal actionable again. The
+token is derived from scheduler action plus identity/profile inputs, while the
+hot path carries only action fields plus a short `identity_signature`; the
+profile signature, reset-condition summary, and full stateful-backoff policy are
+available from `scheduler_hint.cold_path_detail` when callers request
+`loopx quota should-run --include-scheduler-detail`. The reset moves Codex
+App/local cadence back to the current profile's initial interval before
 unchanged backoff resumes, and does not spend quota.
 Codex App heartbeats should use `automation_update` only when
 `codex_app.stateful_backoff.apply_needed=true` and

--- a/examples/control-plane-risk-characterization-smoke.py
+++ b/examples/control-plane-risk-characterization-smoke.py
@@ -384,8 +384,8 @@ def assert_monitor_quiet_skip_scheduler_and_packet_contract() -> None:
     assert scheduler["codex_app"]["recommended_rrule"] == (
         "FREQ=MINUTELY;INTERVAL=15"
     ), scheduler
-    assert scheduler["codex_app"]["stateful_backoff"]["current_interval_minutes"] == 15, scheduler
-    assert scheduler["codex_app"]["stateful_backoff"]["ack_required_after_apply"] is True, scheduler
+    assert scheduler["codex_app"]["recommended_interval_minutes"] == 15, scheduler
+    assert scheduler["codex_app"]["stateful_backoff"]["apply_needed"] is True, scheduler
     assert scheduler["codex_app"]["no_spend_for_cadence_change"] is True, scheduler
 
     packet = build_review_packet(payload, goal_id=GOAL_ID)
@@ -497,8 +497,8 @@ def assert_agent_scope_wait_scheduler_contract() -> None:
     assert scheduler["codex_app"]["recommended_rrule"] == (
         "FREQ=MINUTELY;INTERVAL=10"
     ), scheduler
-    assert scheduler["codex_app"]["stateful_backoff"]["current_interval_minutes"] == 10, scheduler
-    assert scheduler["codex_app"]["stateful_backoff"]["ack_required_after_apply"] is True, scheduler
+    assert scheduler["codex_app"]["recommended_interval_minutes"] == 10, scheduler
+    assert scheduler["codex_app"]["stateful_backoff"]["apply_needed"] is True, scheduler
     assert scheduler["codex_app"]["no_spend_for_cadence_change"] is True, scheduler
 
     packet = build_review_packet(payload, goal_id=GOAL_ID)

--- a/examples/control-plane-risk-characterization-smoke.py
+++ b/examples/control-plane-risk-characterization-smoke.py
@@ -19,6 +19,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from loopx.quota import build_quota_should_run  # noqa: E402
 from loopx.review_packet import build_review_packet  # noqa: E402
+from loopx.status import compact_todo_group  # noqa: E402
 
 
 GOAL_ID = "control-plane-risk-characterization"
@@ -33,10 +34,12 @@ def todo_item(
     priority: str = "P0",
     task_class: str = "advancement_task",
     role: str = "agent",
+    status: str = "open",
     claimed_by: str | None = None,
     blocks_agent: str | None = None,
     index: int = 1,
     next_due_at: str | None = None,
+    resume_when: str | None = None,
 ) -> dict[str, Any]:
     item: dict[str, Any] = {
         "todo_id": todo_id,
@@ -45,8 +48,8 @@ def todo_item(
         "title": title,
         "priority": priority,
         "role": role,
-        "status": "open",
-        "done": False,
+        "status": status,
+        "done": status == "done",
         "task_class": task_class,
     }
     if claimed_by:
@@ -55,6 +58,8 @@ def todo_item(
         item["blocks_agent"] = blocks_agent
     if next_due_at:
         item["next_due_at"] = next_due_at
+    if resume_when:
+        item["resume_when"] = resume_when
     return item
 
 
@@ -86,11 +91,12 @@ def todo_summary(items: list[dict[str, Any]], *, role: str) -> dict[str, Any]:
 def status_payload(
     agent_items: list[dict[str, Any]],
     *,
+    agent_todos: dict[str, Any] | None = None,
     user_items: list[dict[str, Any]] | None = None,
     quota_state: str = "eligible",
     safe_bypass: bool = False,
 ) -> dict[str, Any]:
-    agent_todos = todo_summary(agent_items, role="agent")
+    agent_todos = agent_todos or todo_summary(agent_items, role="agent")
     user_todos = todo_summary(user_items or [], role="user")
     quota = {
         "state": quota_state,
@@ -391,6 +397,70 @@ def assert_monitor_quiet_skip_scheduler_and_packet_contract() -> None:
     ], packet
 
 
+def assert_standing_monitor_gate_does_not_quiet_skip_gated_advancement() -> None:
+    agent_todos = compact_todo_group(
+        [
+            todo_item(
+                todo_id="todo_standing_gate",
+                title="Monitor the product refactor/catalog canary gate.",
+                priority="P1",
+                task_class="continuous_monitor",
+                claimed_by=AGENT_ID,
+                index=1,
+            ),
+            todo_item(
+                todo_id="todo_gated_refactor",
+                title="Triage and fix product/core smoke regressions.",
+                priority="P2",
+                task_class="advancement_task",
+                claimed_by=AGENT_ID,
+                index=2,
+                resume_when="todo_done:todo_standing_gate",
+            ),
+        ],
+        source_section="Agent Todo",
+        role="agent",
+        item_limit=None,
+    )
+    assert agent_todos is not None, agent_todos
+    assert agent_todos["resume_blocked_count"] == 1, agent_todos
+    blocked = agent_todos["resume_blocked_items"][0]
+    assert blocked["todo_id"] == "todo_gated_refactor", blocked
+    assert blocked["resume_ready"] is False, blocked
+    assert blocked["resume_condition"]["target_task_class"] == "continuous_monitor", blocked
+
+    quota = build_quota_should_run(
+        status_payload([], agent_todos=agent_todos),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+    assert quota["decision"] == "successor_replan_required", quota
+    assert quota["should_run"] is True, quota
+    assert quota["effective_action"] == "successor_replan_required", quota
+
+    summary = quota["agent_todo_summary"]
+    assert summary["current_agent_monitor_blocked_resume_count"] == 1, summary
+    assert summary["current_agent_claimed_advancement_count"] == 0, summary
+    assert summary["current_agent_claimed_monitor_count"] == 1, summary
+
+    contract = quota["work_lane_contract"]
+    assert contract["lane"] == "advancement_task", contract
+    assert contract["obligation"] == "repair_resume_gate_or_close_standing_monitor", contract
+    assert "resume_blocked_by_open_monitor" in contract["reason_codes"], contract
+
+    frontier = quota["agent_scope_frontier"]
+    assert frontier["action"] == "successor_replan_required", frontier
+    assert frontier["quiet_noop_allowed"] is False, frontier
+    top = frontier["monitor_blocked_resume_candidates"][0]
+    assert top["todo_id"] == "todo_gated_refactor", top
+    assert top["blocking_monitor_todo_id"] == "todo_standing_gate", top
+
+    interaction = quota["interaction_contract"]
+    assert interaction["mode"] == "successor_replan_required", interaction
+    assert interaction["agent_channel"]["must_attempt"] is True, interaction
+    assert interaction["agent_channel"]["quiet_noop_allowed"] is False, interaction
+
+
 def assert_agent_scope_wait_scheduler_contract() -> None:
     payload = status_payload(
         [
@@ -446,6 +516,7 @@ def main() -> None:
     assert_current_agent_claimed_advancement_beats_other_agent_frontier()
     assert_higher_priority_due_monitor_preempts_advancement()
     assert_monitor_quiet_skip_scheduler_and_packet_contract()
+    assert_standing_monitor_gate_does_not_quiet_skip_gated_advancement()
     assert_agent_scope_wait_scheduler_contract()
     print("control-plane-risk-characterization-smoke ok")
 

--- a/examples/heartbeat-quota-flow-smoke.py
+++ b/examples/heartbeat-quota-flow-smoke.py
@@ -672,22 +672,17 @@ def main() -> int:
         assert "claude_code_loop" not in first_guard["scheduler_hint"], first_guard
         assert "cold_path_detail" not in first_guard["scheduler_hint"], first_guard
         reset = first_guard["scheduler_hint"]["reset_policy"]
-        assert reset["schema_version"] == "scheduler_reset_policy_v0", reset
-        assert reset["profile_action"] == "backoff_until_material_transition", reset
         assert isinstance(reset["reset_token"], str) and len(reset["reset_token"]) == 16, reset
         assert reset["host_state_key"] == "scheduler_hint.reset_policy.reset_token", reset
         assert reset["codex_app_initial_interval_minutes"] == 15, reset
         assert reset["codex_app_initial_rrule"] == "FREQ=MINUTELY;INTERVAL=15", reset
-        assert reset["identity_key_count"] == len(first_guard["scheduler_hint"]["unchanged_identity_keys"]), reset
         assert len(reset["identity_signature"]) == 12, reset
-        assert len(reset["profile_signature"]) == 12, reset
         assert "identity_snapshot" not in reset, reset
         assert "profile_snapshot" not in reset, reset
         assert "identity_keys" not in reset, reset
-        assert "token_changed" in reset["reset_condition_summary"], reset
-        assert "material_transition" in reset["reset_condition_summary"], reset
-        assert "active_work_projected" in reset["reset_condition_summary"], reset
-        assert reset["clear_unchanged_poll_state"] is True, reset
+        assert "profile_signature" not in reset, reset
+        assert "reset_condition_summary" not in reset, reset
+        assert "clear_unchanged_poll_state" not in reset, reset
         first_reset_token = reset["reset_token"]
         assert "automation=keep_active_quiet" in first_guard["protocol_action_packet"]["summary"], first_guard
         assert "scheduler=backoff_until_material_transition" in first_guard["protocol_action_packet"]["summary"], first_guard
@@ -807,7 +802,7 @@ def main() -> int:
         replan_reset = replan_guard["scheduler_hint"]["reset_policy"]
         assert replan_reset["codex_app_initial_rrule"] == "FREQ=MINUTELY;INTERVAL=3", replan_reset
         assert replan_reset["reset_token"] != first_reset_token, replan_reset
-        assert "active_work_projected" in replan_reset["reset_condition_summary"], replan_reset
+        assert "reset_condition_summary" not in replan_reset, replan_reset
         assert "automation=execute_bounded_work" in replan_guard["protocol_action_packet"]["summary"], replan_guard
         interaction = replan_guard["interaction_contract"]
         assert interaction["mode"] == "autonomous_replan", interaction

--- a/examples/hot-path-interface-budget-smoke.py
+++ b/examples/hot-path-interface-budget-smoke.py
@@ -297,7 +297,7 @@ def main() -> int:
         assert "identity_keys" not in reset_policy, reset_policy
         assert "profile" not in reset_policy, reset_policy
         assert len(reset_policy["identity_signature"]) == 12, reset_policy
-        assert len(reset_policy["profile_signature"]) == 12, reset_policy
+        assert "profile_signature" not in reset_policy, reset_policy
         assert handoff_payload["within_budget"] is True, handoff_payload
         summaries = [
             assert_surface("heartbeat_prompt_json", heartbeat_payload),

--- a/examples/quota-agent-scoped-user-gate-smoke.py
+++ b/examples/quota-agent-scoped-user-gate-smoke.py
@@ -890,23 +890,18 @@ def assert_agent_without_advancement_candidate_and_only_monitor_work_stays_quiet
     assert "claude_code_loop" not in scheduler, scheduler
     assert "cold_path_detail" not in scheduler, scheduler
     reset = scheduler["reset_policy"]
-    assert reset["schema_version"] == "scheduler_reset_policy_v0", reset
-    assert reset["profile_action"] == "backoff_until_material_transition", reset
     assert isinstance(reset["reset_token"], str) and len(reset["reset_token"]) == 16, reset
     assert reset["host_state_key"] == "scheduler_hint.reset_policy.reset_token", reset
     assert reset["codex_app_initial_interval_minutes"] == 15, reset
     assert reset["codex_app_initial_rrule"] == "FREQ=MINUTELY;INTERVAL=15", reset
     assert scheduler["codex_app"]["max_interval_minutes"] == 60, scheduler
-    assert reset["identity_key_count"] == len(scheduler["unchanged_identity_keys"]), reset
     assert len(reset["identity_signature"]) == 12, reset
-    assert len(reset["profile_signature"]) == 12, reset
     assert "identity_snapshot" not in reset, reset
     assert "profile_snapshot" not in reset, reset
     assert "identity_keys" not in reset, reset
-    assert "token_changed" in reset["reset_condition_summary"], reset
-    assert "new_or_reassigned_todo" in reset["reset_condition_summary"], reset
-    assert "active_work_projected" in reset["reset_condition_summary"], reset
-    assert reset["no_spend_for_reset"] is True, reset
+    assert "profile_signature" not in reset, reset
+    assert "reset_condition_summary" not in reset, reset
+    assert "no_spend_for_reset" not in reset, reset
     assert "scheduler=backoff_until_material_transition" in payload["protocol_action_packet"]["summary"], payload
 
 

--- a/examples/quota-cleared-blocker-successor-gate-smoke.py
+++ b/examples/quota-cleared-blocker-successor-gate-smoke.py
@@ -263,8 +263,8 @@ def assert_cleared_blocker_requires_successor_replan() -> None:
     assert scheduler["action"] == "run_now", scheduler
     assert scheduler["cadence_class"] == "active_work", scheduler
     assert scheduler["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=3", scheduler
-    assert scheduler["codex_app"]["stateful_backoff"]["current_interval_minutes"] == 3, scheduler
-    assert scheduler["codex_app"]["stateful_backoff"]["ack_required_after_apply"] is True, scheduler
+    assert scheduler["codex_app"]["recommended_interval_minutes"] == 3, scheduler
+    assert scheduler["codex_app"]["stateful_backoff"]["apply_needed"] is True, scheduler
     assert scheduler["codex_app"]["no_spend_for_cadence_change"] is True, scheduler
 
 

--- a/examples/quota-plan-smoke.py
+++ b/examples/quota-plan-smoke.py
@@ -1611,16 +1611,12 @@ def assert_heartbeat_recommendation_lifecycle() -> None:
     assert "claude_code_loop" not in scheduler, scheduler
     assert "cold_path_detail" not in scheduler, scheduler
     reset = scheduler["reset_policy"]
-    assert reset["schema_version"] == "scheduler_reset_policy_v0", reset
-    assert reset["reset_to"] == "profile_initial_interval", reset
     assert isinstance(reset["reset_token"], str) and len(reset["reset_token"]) == 16, reset
     assert reset["reset_token"] == expected_scheduler_reset_token(scheduler, mapped_decision), reset
     assert reset["host_state_key"] == "scheduler_hint.reset_policy.reset_token", reset
     assert reset["codex_app_initial_interval_minutes"] == 60, reset
     assert reset["codex_app_initial_rrule"] == "FREQ=MINUTELY;INTERVAL=60", reset
-    assert reset["identity_key_count"] == len(scheduler["unchanged_identity_keys"]), reset
     assert len(reset["identity_signature"]) == 12, reset
-    assert len(reset["profile_signature"]) == 12, reset
     assert "identity_snapshot" not in reset, reset
     assert "profile_snapshot" not in reset, reset
     assert "identity_keys" not in reset, reset
@@ -1630,24 +1626,21 @@ def assert_heartbeat_recommendation_lifecycle() -> None:
     assert profile_snapshot["codex_app_initial_rrule"] == "FREQ=MINUTELY;INTERVAL=60", profile_snapshot
     assert profile_snapshot["codex_app_max_interval_minutes"] == 240, profile_snapshot
     assert profile_snapshot["unchanged_poll_backoff_multiplier"] == 2, profile_snapshot
-    assert reset["profile_signature"] == _short_hash(profile_snapshot, 12), reset
     identity_snapshot = {
         key: _nested_value(mapped_decision, key)
         for key in scheduler["unchanged_identity_keys"]
     }
     assert identity_snapshot["recommended_action"] == mapped_decision["recommended_action"], identity_snapshot
     assert reset["identity_signature"] == _short_hash(identity_snapshot, 12), reset
-    assert "token_changed" in reset["reset_condition_summary"], reset
-    assert "user_feedback" in reset["reset_condition_summary"], reset
-    assert "new_or_reassigned_todo" in reset["reset_condition_summary"], reset
-    assert "active_work_projected" in reset["reset_condition_summary"], reset
+    assert "profile_signature" not in reset, reset
+    assert "reset_condition_summary" not in reset, reset
     assert "do not run another dry-run" in mapped_rec["spend_policy"], mapped_rec
     assert "heartbeat_recommendation: mode=mapped_noop_if_unchanged notify=DONT_NOTIFY" in mapped_markdown
     assert "heartbeat_stop_if_unchanged: `True`" in mapped_markdown, mapped_markdown
     assert "scheduler_hint: action=backoff_until_fresh_evidence" in mapped_markdown, mapped_markdown
     assert "codex_app_rrule=FREQ=MINUTELY;INTERVAL=60" in mapped_markdown, mapped_markdown
     assert "codex_app_progression=[60, 120, 240]" in mapped_markdown, mapped_markdown
-    assert "scheduler_reset: reset_to=profile_initial_interval initial_interval=60" in mapped_markdown, mapped_markdown
+    assert "scheduler_reset: initial_interval=60" in mapped_markdown, mapped_markdown
     assert "initial_rrule=FREQ=MINUTELY;INTERVAL=60" in mapped_markdown, mapped_markdown
     assert "reset_generation=" in mapped_markdown, mapped_markdown
     assert (

--- a/examples/quota-scheduler-hint-compaction-smoke.py
+++ b/examples/quota-scheduler-hint-compaction-smoke.py
@@ -83,32 +83,19 @@ def assert_compact_runtime_policy_complete(name: str, compact: dict) -> None:
         compact,
     )
     assert stateful_backoff["reset_token"] == compact["reset_policy"]["reset_token"], (name, compact)
-    assert stateful_backoff["progression_minutes"] == codex_app["example_progression_minutes"], (
-        name,
-        compact,
-    )
     assert stateful_backoff["apply_needed"] is True, (name, compact)
-    assert stateful_backoff["ack_required_after_apply"] is True, (name, compact)
     assert stateful_backoff["current_rrule"] == codex_app["recommended_rrule"], (name, compact)
     assert stateful_backoff["state_status"] == "missing", (name, compact)
-    assert "progression_index" in stateful_backoff["persist"], (name, compact)
-    expected_same_identity_action = (
-        "keep_initial_interval_while_active_work"
-        if compact["cadence_class"] == "active_work"
-        else "advance_index_after_scheduler_ack"
-    )
-    assert stateful_backoff["same_identity_action"] == expected_same_identity_action, (
-        name,
-        compact,
-    )
-    assert stateful_backoff["reset_action"] == "clear_progression_index_apply_initial_rrule", (
-        name,
-        compact,
-    )
-    assert stateful_backoff["automation_update_scope"] == "rrule_only_preserve_body_name_status", (
-        name,
-        compact,
-    )
+    for omitted in (
+        "progression_minutes",
+        "current_interval_minutes",
+        "ack_required_after_apply",
+        "persist",
+        "same_identity_action",
+        "reset_action",
+        "automation_update_scope",
+    ):
+        assert omitted not in stateful_backoff, (name, omitted, compact)
     assert set(unchanged_poll["limits"]) == set(RUNTIME_KEYS), (name, compact)
     assert set(unchanged_poll["after_limits"]) == set(RUNTIME_KEYS), (name, compact)
     assert "final_quota_replan_check_enabled" in unchanged_poll, (name, compact)
@@ -116,8 +103,15 @@ def assert_compact_runtime_policy_complete(name: str, compact: dict) -> None:
     assert unchanged_poll["spend_policy"], (name, compact)
     assert compact["reset_policy"]["reset_token"], (name, compact)
     assert compact["reset_policy"]["codex_app_initial_rrule"], (name, compact)
-    assert compact["reset_policy"]["codex_app_tool"] == "automation_update", (name, compact)
-    assert "automation_update" in compact["reset_policy"]["codex_app_apply"], (name, compact)
+    for omitted in (
+        "schema_version",
+        "codex_app_tool",
+        "codex_app_apply",
+        "profile_signature",
+        "identity_key_count",
+        "reset_condition_summary",
+    ):
+        assert omitted not in compact["reset_policy"], (name, omitted, compact)
     detail_ref = compact["detail_ref"]
     assert detail_ref["omitted_by_default"] is True, (name, compact)
     assert detail_ref["execution_required"] is False, (name, compact)
@@ -164,8 +158,28 @@ def assert_compact_scheduler(name: str, source_payload: dict) -> None:
     assert cold_path["local_scheduler"]["recommended_interval_minutes"], (name, detailed)
     assert cold_path["codex_cli_tui"]["final_quota_replan_check"], (name, detailed)
     assert cold_path["claude_code_loop"]["after_limit"], (name, detailed)
+    stateful_detail = cold_path["stateful_backoff_detail"]
+    assert stateful_detail["progression_minutes"] == compact["codex_app"]["example_progression_minutes"], (
+        name,
+        detailed,
+    )
+    assert stateful_detail["ack_required_after_apply"] is True, (name, detailed)
+    expected_same_identity_action = (
+        "keep_initial_interval_while_active_work"
+        if compact["cadence_class"] == "active_work"
+        else "advance_index_after_scheduler_ack"
+    )
+    assert stateful_detail["same_identity_action"] == expected_same_identity_action, (
+        name,
+        detailed,
+    )
+    reset_detail = cold_path["reset_policy_detail"]
+    assert reset_detail["schema_version"] == "scheduler_reset_policy_v0", (name, detailed)
+    assert reset_detail["codex_app_tool"] == "automation_update", (name, detailed)
+    assert "automation_update" in reset_detail["codex_app_apply"], (name, detailed)
+    assert len(reset_detail["profile_signature"]) == 12, (name, detailed)
     assert json_size(compact) < json_size(detailed), (name, json_size(compact), json_size(detailed))
-    assert json_size(compact) <= 3_300, (name, json_size(compact))
+    assert json_size(compact) <= 2_700, (name, json_size(compact))
 
 
 def run_should_run_cli(*, include_detail: bool, registry_path: Path, runtime: Path, project: Path) -> dict:
@@ -229,6 +243,10 @@ def assert_cli_compact_and_detail_contract() -> None:
     assert detailed["cold_path_detail"]["codex_cli_tui"]["final_quota_replan_check"], detailed
     assert detailed["cold_path_detail"]["claude_code_loop"]["after_limit"] == (
         compact["unchanged_poll"]["after_limits"]["claude_code_loop"]
+    ), detailed
+    assert detailed["cold_path_detail"]["reset_policy_detail"]["codex_app_tool"] == "automation_update", detailed
+    assert detailed["cold_path_detail"]["stateful_backoff_detail"]["progression_minutes"] == (
+        compact["codex_app"]["example_progression_minutes"]
     ), detailed
 
 

--- a/examples/quota-scheduler-policy-smoke.py
+++ b/examples/quota-scheduler-policy-smoke.py
@@ -102,25 +102,20 @@ def assert_policy_case(
             name,
             extracted,
         )
-        assert stateful_backoff["progression_minutes"] == expected_progression, (name, extracted)
     assert stateful_backoff["schema_version"] == "codex_app_stateful_backoff_v0", (name, extracted)
     assert stateful_backoff["state_key"] == "scheduler_hint.codex_app.stateful_backoff", (name, extracted)
     assert stateful_backoff["apply_needed"] is True, (name, extracted)
-    assert stateful_backoff["ack_required_after_apply"] is True, (name, extracted)
     assert stateful_backoff["current_rrule"] == expected_rrule, (name, extracted)
     assert stateful_backoff["state_status"] == "missing", (name, extracted)
-    assert stateful_backoff["same_identity_action"] == expected_same_identity_action, (
-        name,
-        extracted,
-    )
-    assert stateful_backoff["reset_action"] == "clear_progression_index_apply_initial_rrule", (
-        name,
-        extracted,
-    )
-    assert stateful_backoff["automation_update_scope"] == "rrule_only_preserve_body_name_status", (
-        name,
-        extracted,
-    )
+    for omitted in (
+        "progression_minutes",
+        "current_interval_minutes",
+        "ack_required_after_apply",
+        "same_identity_action",
+        "reset_action",
+        "automation_update_scope",
+    ):
+        assert omitted not in stateful_backoff, (name, omitted, extracted)
     assert "local_scheduler" not in extracted, (name, extracted)
     assert "codex_cli_tui" not in extracted, (name, extracted)
     assert "claude_code_loop" not in extracted, (name, extracted)
@@ -129,13 +124,30 @@ def assert_policy_case(
     assert detailed["cold_path_detail"]["local_scheduler"]["recommended_interval_minutes"], (name, detailed)
     assert detailed["cold_path_detail"]["codex_cli_tui"]["final_quota_replan_check"], (name, detailed)
     assert detailed["cold_path_detail"]["claude_code_loop"]["after_limit"], (name, detailed)
+    stateful_detail = detailed["cold_path_detail"]["stateful_backoff_detail"]
+    if expected_progression is not None:
+        assert stateful_detail["progression_minutes"] == expected_progression, (name, detailed)
+    assert stateful_detail["ack_required_after_apply"] is True, (name, detailed)
+    assert stateful_detail["same_identity_action"] == expected_same_identity_action, (
+        name,
+        detailed,
+    )
+    assert stateful_detail["reset_action"] == "clear_progression_index_apply_initial_rrule", (
+        name,
+        detailed,
+    )
+    assert stateful_detail["automation_update_scope"] == "rrule_only_preserve_body_name_status", (
+        name,
+        detailed,
+    )
     reset = extracted["reset_policy"]
-    assert reset["schema_version"] == "scheduler_reset_policy_v0", (name, reset)
-    assert reset["codex_app_tool"] == "automation_update", (name, reset)
-    assert "automation_update" in reset["codex_app_apply"], (name, reset)
     assert isinstance(reset["reset_token"], str) and len(reset["reset_token"]) == 16, (name, reset)
     assert len(reset["identity_signature"]) == 12, (name, reset)
-    assert len(reset["profile_signature"]) == 12, (name, reset)
+    reset_detail = detailed["cold_path_detail"]["reset_policy_detail"]
+    assert reset_detail["schema_version"] == "scheduler_reset_policy_v0", (name, reset_detail)
+    assert reset_detail["codex_app_tool"] == "automation_update", (name, reset_detail)
+    assert "automation_update" in reset_detail["codex_app_apply"], (name, reset_detail)
+    assert len(reset_detail["profile_signature"]) == 12, (name, reset_detail)
     assert stateful_backoff["reset_token"] == reset["reset_token"], (name, reset)
     assert stateful_backoff["identity_signature"] == reset["identity_signature"], (name, reset)
     assert "identity_snapshot" not in reset, (name, reset)

--- a/examples/quota-scheduler-state-ack-smoke.py
+++ b/examples/quota-scheduler-state-ack-smoke.py
@@ -99,7 +99,7 @@ def state_from(hint: dict) -> dict:
         "reset_token": stateful["reset_token"],
         "identity_signature": stateful["identity_signature"],
         "progression_index": stateful["progression_index"],
-        "progression_minutes": stateful["progression_minutes"],
+        "progression_minutes": hint["codex_app"]["example_progression_minutes"],
         "last_applied_rrule": hint["codex_app"]["recommended_rrule"],
         "updated_at": "2026-01-01T00:00:00+00:00",
     }
@@ -174,10 +174,16 @@ def assert_active_work_keeps_initial_cadence() -> None:
     )
     assert first["action"] == "run_now", first
     assert first["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=3", first
+    assert "same_identity_action" not in first["codex_app"]["stateful_backoff"], first
+    first_detailed = build_scheduler_hint(
+        deepcopy(base),
+        agent_scope_frontier_actions=AGENT_SCOPE_ACTIONS,
+        include_detail=True,
+    )
     assert (
-        first["codex_app"]["stateful_backoff"]["same_identity_action"]
+        first_detailed["cold_path_detail"]["stateful_backoff_detail"]["same_identity_action"]
         == "keep_initial_interval_while_active_work"
-    ), first
+    ), first_detailed
 
     stale_backoff_state = state_from_hint_with_applied_rrule(
         first,

--- a/examples/quota-work-lane-policy-smoke.py
+++ b/examples/quota-work-lane-policy-smoke.py
@@ -94,6 +94,39 @@ def main() -> int:
         must_attempt_work=False,
     )
 
+    resume_blocked_by_monitor = build_work_lane_contract(
+        progress_scope="agent_lane",
+        external_poll_signal=False,
+        todo_counts={"open": 2, "advancement": 0, "monitor": 1},
+        monitor_due_count=0,
+        due_monitor_items=[],
+        first_advancement=None,
+        due_monitor_preempts_advancement=False,
+        outcome_followthrough=None,
+        next_action_requires_advancement=False,
+        monitor_due_item_limit=1,
+        resume_blocked_by_monitor_count=1,
+        resume_blocked_by_monitor_items=[
+            {
+                "todo_id": "todo_gated_refactor",
+                "resume_when": "todo_done:todo_standing_gate",
+            }
+        ],
+    )
+    assert_contract(
+        "resume-blocked-by-monitor",
+        resume_blocked_by_monitor,
+        lane="advancement_task",
+        obligation="repair_resume_gate_or_close_standing_monitor",
+        must_attempt_work=True,
+        monitor_policy="material_transition_only",
+        selected_todo_id="todo_gated_refactor",
+    )
+    assert resume_blocked_by_monitor["reason_codes"] == [
+        "monitor_todo_only",
+        "resume_blocked_by_open_monitor",
+    ], resume_blocked_by_monitor
+
     dependency_advancement = build_work_lane_contract(
         progress_scope="dependency_observation",
         external_poll_signal=False,

--- a/examples/status-quota-review-packet-parity-smoke.py
+++ b/examples/status-quota-review-packet-parity-smoke.py
@@ -171,7 +171,7 @@ def assert_quota_parity(payload: dict) -> None:
     assert scheduler["cadence_class"] == "active_work", scheduler
     codex_app = scheduler["codex_app"]
     assert codex_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=3", scheduler
-    assert codex_app["stateful_backoff"]["current_interval_minutes"] == 3, scheduler
+    assert codex_app["recommended_interval_minutes"] == 3, scheduler
     assert codex_app["no_spend_for_cadence_change"] is True, scheduler
     assert scheduler["reset_policy"]["codex_app_initial_rrule"] == "FREQ=MINUTELY;INTERVAL=3", scheduler
 

--- a/loopx/policies/scheduler_hint.py
+++ b/loopx/policies/scheduler_hint.py
@@ -87,10 +87,15 @@ def build_codex_app_scheduler_ack_event(
         raise ValueError(
             f"quota scheduler-ack applied_rrule {safe_applied_rrule!r} does not match expected {expected_rrule!r}"
         )
+    codex_progression = (
+        codex_app.get("example_progression_minutes")
+        if isinstance(codex_app.get("example_progression_minutes"), list)
+        else []
+    )
     progression_minutes = (
         stateful_backoff.get("progression_minutes")
         if isinstance(stateful_backoff.get("progression_minutes"), list)
-        else []
+        else codex_progression
     )
     progression_index = max(0, _int_number(stateful_backoff.get("progression_index"), default=0))
     safe_generated_at = generated_at or ""
@@ -264,7 +269,7 @@ def build_scheduler_hint(
                 default=str,
             ).encode("utf-8")
         ).hexdigest()[:12]
-        reset_policy = {
+        reset_policy_detail = {
             "schema_version": SCHEDULER_RESET_POLICY_SCHEMA_VERSION,
             "source": "quota.should-run",
             "reset_to": "profile_initial_interval",
@@ -283,6 +288,13 @@ def build_scheduler_hint(
             "codex_app_tool": "automation_update",
             "codex_app_apply": "call_automation_update_to_restore_initial_rrule_on_token_change",
             "no_spend_for_reset": True,
+        }
+        reset_policy = {
+            "reset_token": reset_token,
+            "host_state_key": "scheduler_hint.reset_policy.reset_token",
+            "codex_app_initial_interval_minutes": codex_interval,
+            "codex_app_initial_rrule": codex_rrule,
+            "identity_signature": identity_signature,
         }
         local_scheduler = {
             "recommended_interval_minutes": codex_interval,
@@ -332,6 +344,19 @@ def build_scheduler_hint(
         current_rrule = rrule_for_minutes(current_interval)
         last_applied_rrule = str(scheduler_state.get("last_applied_rrule") or "").strip()
         apply_needed = state_status != "same_identity" or last_applied_rrule != current_rrule
+        stateful_backoff_detail = {
+            "progression_minutes": cadence_progression,
+            "current_interval_minutes": current_interval,
+            "ack_required_after_apply": apply_needed,
+            "persist": "reset_token|identity_signature|progression_index|last_applied_rrule",
+            "same_identity_action": (
+                "advance_index_after_scheduler_ack"
+                if advance_same_identity
+                else "keep_initial_interval_while_active_work"
+            ),
+            "reset_action": "clear_progression_index_apply_initial_rrule",
+            "automation_update_scope": "rrule_only_preserve_body_name_status",
+        }
         codex_app = {
             "recommended_interval_minutes": current_interval,
             "max_interval_minutes": codex_max,
@@ -363,20 +388,9 @@ def build_scheduler_hint(
                 "state_key": CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
                 "identity_signature": identity_signature,
                 "reset_token": reset_token,
-                "progression_minutes": cadence_progression,
                 "progression_index": current_index,
-                "current_interval_minutes": current_interval,
                 "current_rrule": current_rrule,
                 "apply_needed": apply_needed,
-                "ack_required_after_apply": apply_needed,
-                "persist": "reset_token|identity_signature|progression_index|last_applied_rrule",
-                "same_identity_action": (
-                    "advance_index_after_scheduler_ack"
-                    if advance_same_identity
-                    else "keep_initial_interval_while_active_work"
-                ),
-                "reset_action": "clear_progression_index_apply_initial_rrule",
-                "automation_update_scope": "rrule_only_preserve_body_name_status",
                 "state_status": state_status,
             },
             "no_spend_for_cadence_change": True,
@@ -425,6 +439,8 @@ def build_scheduler_hint(
                     "codex_cli_tui",
                     "claude_code_loop",
                     "final_quota_replan_check",
+                    "reset_policy_detail",
+                    "stateful_backoff_detail",
                 ],
             },
         }
@@ -436,6 +452,8 @@ def build_scheduler_hint(
                 "codex_cli_tui": codex_cli_tui,
                 "claude_code_loop": claude_code_loop,
                 "final_quota_replan_check": final_replan_check,
+                "reset_policy_detail": reset_policy_detail,
+                "stateful_backoff_detail": stateful_backoff_detail,
             }
         return scheduler_hint
 

--- a/loopx/policies/work_lane.py
+++ b/loopx/policies/work_lane.py
@@ -18,6 +18,8 @@ def build_work_lane_contract(
     outcome_followthrough: dict[str, Any] | None,
     next_action_requires_advancement: bool,
     monitor_due_item_limit: int,
+    resume_blocked_by_monitor_count: int = 0,
+    resume_blocked_by_monitor_items: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any] | None:
     """Return the work-lane execution contract from precomputed quota facts.
 
@@ -35,6 +37,7 @@ def build_work_lane_contract(
     has_monitor_todos = monitor_count > 0
     monitor_only_todos = has_agent_todos and has_monitor_todos and not has_advancement_todos
     first_due_monitor = due_monitor_items[0] if due_monitor_items else None
+    blocked_by_monitor_items = resume_blocked_by_monitor_items or []
 
     def due_monitor_contract(*, reason_codes: list[str]) -> dict[str, Any]:
         selected = first_due_monitor or {}
@@ -111,6 +114,29 @@ def build_work_lane_contract(
                 "action": (
                     "verify the observable external result handle; if it is absent, "
                     "write a compact blocker instead of rerunning launched work"
+                ),
+            }
+        if resume_blocked_by_monitor_count > 0 and not first_due_monitor:
+            selected = blocked_by_monitor_items[0] if blocked_by_monitor_items else {}
+            reason_codes = ["resume_blocked_by_open_monitor"]
+            if monitor_only_todos:
+                reason_codes.insert(0, "monitor_todo_only")
+            return {
+                "schema_version": WORK_LANE_CONTRACT_SCHEMA_VERSION,
+                "lane": "advancement_task",
+                "next_lane": "advancement_task",
+                "obligation": "repair_resume_gate_or_close_standing_monitor",
+                "must_attempt_work": True,
+                "reason_codes": reason_codes,
+                "monitor_policy": "material_transition_only",
+                "resume_blocked_by_monitor_count": max(0, int(resume_blocked_by_monitor_count)),
+                "resume_blocked_by_monitor_items": blocked_by_monitor_items[:monitor_due_item_limit],
+                "selected_todo_id": selected.get("todo_id"),
+                "selected_resume_when": selected.get("resume_when"),
+                "action": (
+                    "repair the standing monitor dependency: close/supersede the monitor "
+                    "after validated evidence, or replan the gated advancement todo with a "
+                    "non-blocking monitor contract"
                 ),
             }
         if monitor_only_todos:

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -616,6 +616,11 @@ def _work_lane_contract(
     )
     first_due_monitor = due_monitor_items[0] if due_monitor_items else None
     first_advancement = _first_executable_todo_item(agent_todo_summary)
+    agent_id = _todo_summary_claim_scope_agent_id(agent_todo_summary or {})
+    monitor_blocked_resume_candidates = _agent_scope_monitor_blocked_resume_candidates(
+        agent_todo_summary,
+        agent_id=agent_id,
+    )
     due_monitor_preempts_advancement = bool(
         first_due_monitor
         and (
@@ -634,6 +639,8 @@ def _work_lane_contract(
         outcome_followthrough=_outcome_followthrough_hint(item),
         next_action_requires_advancement=_next_action_requires_advancement(item),
         monitor_due_item_limit=MONITOR_DUE_ITEM_LIMIT,
+        resume_blocked_by_monitor_count=len(monitor_blocked_resume_candidates),
+        resume_blocked_by_monitor_items=monitor_blocked_resume_candidates,
     )
 
 
@@ -1680,6 +1687,97 @@ def _todo_summary_deferred_items(value: dict[str, Any], key: str) -> list[dict[s
     return sorted(items, key=_todo_projection_sort_key)
 
 
+def _dedupe_todo_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    unique: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, Any]] = set()
+    for item in items:
+        todo_id = normalize_todo_id(item.get("todo_id")) or ""
+        text = str(item.get("text") or "").strip()
+        identity = (todo_id, text, item.get("index"))
+        if identity in seen:
+            continue
+        seen.add(identity)
+        unique.append(item)
+    return unique
+
+
+def _todo_summary_resume_blocked_items(value: dict[str, Any]) -> list[dict[str, Any]]:
+    if not isinstance(value, dict):
+        return []
+    source_items = (
+        value.get("resume_blocked_items")
+        if isinstance(value.get("resume_blocked_items"), list)
+        else []
+    )
+    if not source_items:
+        for key in ("items", "backlog_items", "first_open_items"):
+            raw_items = value.get(key) if isinstance(value.get(key), list) else []
+            source_items.extend(item for item in raw_items if isinstance(item, dict))
+    items: list[dict[str, Any]] = []
+    for item in source_items:
+        if not isinstance(item, dict):
+            continue
+        text = str(item.get("text") or "").strip()
+        if not text:
+            continue
+        if item.get("done") is True:
+            continue
+        if not normalize_todo_resume_when(item.get("resume_when")):
+            continue
+        if item.get("resume_ready") is not False:
+            continue
+        items.append(_compact_todo_summary_item(item, text=text))
+    return sorted(_dedupe_todo_items(items), key=_todo_projection_sort_key)
+
+
+def _monitor_target_todo_ids(value: dict[str, Any]) -> set[str]:
+    ids: set[str] = set()
+    for key in (
+        "monitor_open_items",
+        "current_agent_claimed_monitor_items",
+        "claimed_monitor_open_items",
+        "items",
+        "backlog_items",
+        "first_open_items",
+    ):
+        source_items = value.get(key) if isinstance(value.get(key), list) else []
+        for item in source_items:
+            if not isinstance(item, dict):
+                continue
+            todo_id = normalize_todo_id(item.get("todo_id"))
+            if not todo_id:
+                continue
+            if _todo_task_class(item) == TODO_TASK_CLASS_MONITOR:
+                ids.add(todo_id)
+    return ids
+
+
+def _todo_summary_monitor_blocked_resume_items(value: dict[str, Any]) -> list[dict[str, Any]]:
+    monitor_ids = _monitor_target_todo_ids(value)
+    candidates: list[dict[str, Any]] = []
+    for item in _todo_summary_resume_blocked_items(value):
+        if _todo_task_class(item) != TODO_TASK_CLASS_ADVANCEMENT:
+            continue
+        condition = item.get("resume_condition") if isinstance(item.get("resume_condition"), dict) else {}
+        target_todo_id = normalize_todo_id(
+            condition.get("target_todo_id") or condition.get("target")
+        )
+        target_status = normalize_todo_status(condition.get("target_status"))
+        target_task_class = normalize_todo_task_class(
+            condition.get("target_task_class"),
+            text="",
+        )
+        if target_status != TODO_STATUS_OPEN:
+            continue
+        if target_task_class != TODO_TASK_CLASS_MONITOR and target_todo_id not in monitor_ids:
+            continue
+        candidate = dict(item)
+        if target_todo_id:
+            candidate["blocking_monitor_todo_id"] = target_todo_id
+        candidates.append(candidate)
+    return sorted(_dedupe_todo_items(candidates), key=_todo_projection_sort_key)
+
+
 def _agent_claim_filtered_deferred_items(
     items: list[dict[str, Any]],
     *,
@@ -1697,6 +1795,72 @@ def _agent_claim_filtered_deferred_items(
             continue
         selected.append(item)
     return selected
+
+
+def _resume_blocked_visibility_lanes(
+    value: dict[str, Any],
+    *,
+    agent_identity: dict[str, Any] | None,
+) -> dict[str, Any]:
+    resume_blocked_items = _todo_summary_resume_blocked_items(value)
+    monitor_blocked_items = _todo_summary_monitor_blocked_resume_items(value)
+    if not resume_blocked_items and not monitor_blocked_items:
+        return {}
+    lanes: dict[str, Any] = {
+        "resume_blocked_count": len(resume_blocked_items),
+        "resume_blocked_items": resume_blocked_items[:TODO_DEFERRED_VISIBILITY_LIMIT],
+    }
+    if monitor_blocked_items:
+        lanes.update(
+            {
+                "monitor_blocked_resume_count": len(monitor_blocked_items),
+                "monitor_blocked_resume_candidates": monitor_blocked_items[
+                    :TODO_DEFERRED_VISIBILITY_LIMIT
+                ],
+            }
+        )
+    agent_id = (
+        normalize_todo_claimed_by(agent_identity.get("agent_id"))
+        if isinstance(agent_identity, dict)
+        else None
+    )
+    if agent_id and monitor_blocked_items:
+        current_agent_candidates = _agent_claim_filtered_deferred_items(
+            monitor_blocked_items,
+            agent_id=agent_id,
+            claim="current",
+        )
+        unclaimed_candidates = _agent_claim_filtered_deferred_items(
+            monitor_blocked_items,
+            agent_id=agent_id,
+            claim="unclaimed",
+        )
+        other_agent_candidates = _agent_claim_filtered_deferred_items(
+            monitor_blocked_items,
+            agent_id=agent_id,
+            claim="other",
+        )
+        lanes.update(
+            {
+                "current_agent_monitor_blocked_resume_candidates": current_agent_candidates[
+                    :TODO_DEFERRED_VISIBILITY_LIMIT
+                ],
+                "unclaimed_monitor_blocked_resume_candidates": unclaimed_candidates[
+                    :TODO_DEFERRED_VISIBILITY_LIMIT
+                ],
+                "other_agent_monitor_blocked_resume_candidates": other_agent_candidates[
+                    :TODO_DEFERRED_VISIBILITY_LIMIT
+                ],
+                "current_agent_monitor_blocked_resume_count": len(current_agent_candidates),
+                "unclaimed_monitor_blocked_resume_count": len(unclaimed_candidates),
+                "other_agent_monitor_blocked_resume_count": len(other_agent_candidates),
+                "monitor_blocked_resume_selection_policy": (
+                    "open advancement todos gated by todo_done:<continuous_monitor> "
+                    "must project as successor replan/state repair instead of quiet monitor wait"
+                ),
+            }
+        )
+    return lanes
 
 
 def _deferred_visibility_lanes(
@@ -1920,6 +2084,10 @@ def _todo_summary_source_items(value: dict[str, Any]) -> list[dict[str, Any]]:
         "current_agent_claimed_open_items",
         "current_agent_claimed_advancement_items",
         "current_agent_claimed_monitor_items",
+        "resume_blocked_items",
+        "monitor_blocked_resume_candidates",
+        "current_agent_monitor_blocked_resume_candidates",
+        "unclaimed_monitor_blocked_resume_candidates",
         "items",
     )
     ready_successor_todo_ids = _handoff_ready_successor_todo_ids(value)
@@ -2162,6 +2330,12 @@ def _summarize_user_todos(
     )
     summary.update(
         _deferred_visibility_lanes(
+            value,
+            agent_identity=agent_identity,
+        )
+    )
+    summary.update(
+        _resume_blocked_visibility_lanes(
             value,
             agent_identity=agent_identity,
         )
@@ -3007,6 +3181,34 @@ def _agent_lane_frontier_hint(
                     "--no-follow-up --evidence '<public-safe rationale>'"
                 ),
             )
+        monitor_candidates = (
+            frontier.get("monitor_blocked_resume_candidates")
+            if isinstance(frontier.get("monitor_blocked_resume_candidates"), list)
+            else []
+        )
+        monitor_candidate = (
+            monitor_candidates[0]
+            if monitor_candidates and isinstance(monitor_candidates[0], dict)
+            else {}
+        )
+        monitor_blocker_id = normalize_todo_id(
+            monitor_candidate.get("blocking_monitor_todo_id")
+        )
+        if monitor_candidate:
+            target_todo_id = normalize_todo_id(monitor_candidate.get("todo_id"))
+            return build_hint(
+                AgentLaneFrontierHintDecision.ADD_NEXT_ADVANCEMENT,
+                source="agent_scope_frontier",
+                reason_code="resume_blocked_by_open_monitor",
+                target_todo_id=target_todo_id or monitor_blocker_id,
+                quiet_noop_allowed=False,
+                next_cli_action=(
+                    f"loopx todo complete --goal-id {goal_id} --todo-id {monitor_blocker_id} "
+                    "--evidence '<validated gate evidence>'"
+                    if monitor_blocker_id
+                    else None
+                ),
+            )
         deferred_todo_id = _first_compact_todo_id(frontier.get("deferred_resume_candidates"))
         route_todo_id = _first_compact_todo_id(
             frontier.get("route_continuation_replan_candidates")
@@ -3133,6 +3335,59 @@ def _agent_scope_deferred_resume_candidates(
             continue
         seen.add(identity)
         unique.append(_compact_todo_summary_item(item, text=str(item.get("text") or "").strip()))
+    return sorted(unique, key=_todo_projection_sort_key)
+
+
+def _agent_scope_monitor_blocked_resume_candidates(
+    agent_todo_summary: dict[str, Any] | None,
+    *,
+    agent_id: str | None,
+) -> list[dict[str, Any]]:
+    if not isinstance(agent_todo_summary, dict):
+        return []
+    candidates: list[dict[str, Any]] = []
+    if agent_id:
+        for key in (
+            "current_agent_monitor_blocked_resume_candidates",
+            "unclaimed_monitor_blocked_resume_candidates",
+        ):
+            value = agent_todo_summary.get(key)
+            if isinstance(value, list):
+                candidates.extend(item for item in value if isinstance(item, dict))
+    else:
+        value = agent_todo_summary.get("monitor_blocked_resume_candidates")
+        if isinstance(value, list):
+            candidates.extend(item for item in value if isinstance(item, dict))
+
+    unique: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in candidates:
+        if _todo_task_class(item) != TODO_TASK_CLASS_ADVANCEMENT:
+            continue
+        if item.get("resume_ready") is not False:
+            continue
+        condition = item.get("resume_condition") if isinstance(item.get("resume_condition"), dict) else {}
+        if normalize_todo_status(condition.get("target_status")) != TODO_STATUS_OPEN:
+            continue
+        target_todo_id = normalize_todo_id(
+            item.get("blocking_monitor_todo_id")
+            or condition.get("target_todo_id")
+            or condition.get("target")
+        )
+        target_task_class = normalize_todo_task_class(
+            condition.get("target_task_class"),
+            text="",
+        )
+        if target_task_class != TODO_TASK_CLASS_MONITOR and not target_todo_id:
+            continue
+        identity = str(item.get("todo_id") or item.get("index") or item.get("text") or "")
+        if identity in seen:
+            continue
+        seen.add(identity)
+        compact = _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
+        if target_todo_id:
+            compact["blocking_monitor_todo_id"] = target_todo_id
+        unique.append(compact)
     return sorted(unique, key=_todo_projection_sort_key)
 
 
@@ -3306,6 +3561,47 @@ def _agent_scope_no_candidate_frontier(
         )
     if current_agent_count > 0 or unclaimed_count > 0:
         return None
+
+    monitor_blocked_resume_candidates = _agent_scope_monitor_blocked_resume_candidates(
+        agent_todo_summary,
+        agent_id=agent_id,
+    )
+    if monitor_blocked_resume_candidates:
+        first_candidate = monitor_blocked_resume_candidates[0]
+        candidate_todo_id = str(first_candidate.get("todo_id") or "").strip() or "<todo_id>"
+        monitor_todo_id = (
+            str(first_candidate.get("blocking_monitor_todo_id") or "").strip()
+            or "<monitor_todo_id>"
+        )
+        reason = (
+            f"current side-agent {agent_id} has advancement todo {candidate_todo_id} "
+            f"gated by open continuous_monitor {monitor_todo_id}; a standing monitor "
+            "cannot be the todo_done prerequisite for autonomous continuation"
+        )
+        recommended_action = (
+            "Run a bounded gate-model repair before quiet wait: close/supersede "
+            f"{monitor_todo_id} after validated evidence, or rewrite {candidate_todo_id} "
+            "to use a non-blocking monitor contract before delivery."
+        )
+        return {
+            "schema_version": AGENT_SCOPE_FRONTIER_SCHEMA_VERSION,
+            "agent_id": agent_id,
+            "primary_agent": normalize_todo_claimed_by(agent_identity.get("primary_agent")),
+            "action": AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value,
+            "effective_action": AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value,
+            "blocks_delivery": True,
+            "requires_replan": True,
+            "quiet_noop_allowed": False,
+            "spend_policy": "spend once after validated standing-monitor gate repair/todo writeback",
+            "reason": reason,
+            "recommended_action": recommended_action,
+            "candidate_counts": {
+                "current_agent_claimed_advancement_count": current_agent_count,
+                "unclaimed_advancement_count": unclaimed_count,
+                "monitor_blocked_resume_candidate_count": len(monitor_blocked_resume_candidates),
+            },
+            "monitor_blocked_resume_candidates": monitor_blocked_resume_candidates[:3],
+        }
 
     deferred_resume_candidates = _agent_scope_deferred_resume_candidates(
         agent_todo_summary,
@@ -4472,6 +4768,27 @@ def _interaction_next_cli_actions(payload: dict[str, Any], *, mode: str) -> list
             if isinstance(payload.get("agent_scope_frontier"), dict)
             else {}
         )
+        monitor_candidates = (
+            agent_scope_frontier.get("monitor_blocked_resume_candidates")
+            if isinstance(agent_scope_frontier.get("monitor_blocked_resume_candidates"), list)
+            else []
+        )
+        if monitor_candidates:
+            first_candidate = (
+                monitor_candidates[0]
+                if isinstance(monitor_candidates[0], dict)
+                else {}
+            )
+            monitor_todo_id = str(
+                first_candidate.get("blocking_monitor_todo_id") or "<monitor_todo_id>"
+            )
+            gated_todo_id = str(first_candidate.get("todo_id") or "<gated_todo_id>")
+            return [
+                f"loopx todo complete --goal-id {goal_id} --todo-id {monitor_todo_id} --evidence '<validated gate evidence>'",
+                f"loopx todo update --goal-id {goal_id} --todo-id {gated_todo_id} --note '<public-safe gate repair reason>'",
+                f"loopx refresh-state --goal-id {goal_id} --classification standing_monitor_gate_repair_recorded --delivery-batch-scale single_surface --delivery-outcome outcome_progress{agent_arg}",
+                f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute{agent_arg}",
+            ]
         route_candidates = (
             agent_scope_frontier.get("route_continuation_replan_candidates")
             if isinstance(agent_scope_frontier.get("route_continuation_replan_candidates"), list)
@@ -4756,6 +5073,22 @@ def _automation_liveness(payload: dict[str, Any]) -> dict[str, Any]:
             "spend_policy": "no quota spend for identity prompt upgrade preflight",
         }
     if effective_action == AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value:
+        agent_scope_frontier = (
+            payload.get("agent_scope_frontier")
+            if isinstance(payload.get("agent_scope_frontier"), dict)
+            else {}
+        )
+        if agent_scope_frontier.get("monitor_blocked_resume_candidates"):
+            return {
+                **base,
+                "automation_action": "execute_bounded_work",
+                "reason": (
+                    "a current-agent advancement todo is gated by an open standing "
+                    "monitor; repair the gate model before another quiet no-op"
+                ),
+                "next_trigger": "standing monitor gate repair writeback or fresh quota guard",
+                "spend_policy": "spend once only after validated gate repair/todo writeback",
+            }
         return {
             **base,
             "automation_action": "execute_bounded_work",

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -10279,14 +10279,10 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
         if reset_policy:
             lines.append(
                 "- scheduler_reset: "
-                f"reset_to={reset_policy.get('reset_to')} "
                 f"initial_interval={reset_policy.get('codex_app_initial_interval_minutes')} "
                 f"initial_rrule={reset_policy.get('codex_app_initial_rrule')} "
                 f"reset_generation={reset_policy.get('reset_token')} "
-                f"identity_key_count={reset_policy.get('identity_key_count')} "
-                f"identity_signature={reset_policy.get('identity_signature')} "
-                f"profile_signature={reset_policy.get('profile_signature')} "
-                f"conditions={reset_policy.get('reset_condition_summary')}"
+                f"identity_signature={reset_policy.get('identity_signature')}"
             )
     protocol_action_packet = (
         payload.get("protocol_action_packet")

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -6186,6 +6186,10 @@ def apply_resume_conditions(
             if isinstance(target_item, dict):
                 condition["target_archive_state"] = target_item.get("archive_state")
                 condition["target_source_section"] = target_item.get("source_section")
+                condition["target_task_class"] = todo_item_task_class(target_item)
+                target_claimed_by = normalize_todo_claimed_by(target_item.get("claimed_by"))
+                if target_claimed_by:
+                    condition["target_claimed_by"] = target_claimed_by
             condition["satisfied"] = condition["target_status"] == "done"
         elif kind == TODO_RESUME_KIND_PR_MERGED and target:
             condition.update(pr_merged_condition(target, rollout_events or []))
@@ -6263,6 +6267,12 @@ def compact_todo_group(
         for item in projected_open_items
         if todo_item_is_actionable_open(item)
         if todo_item_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
+    ]
+    resume_blocked_items = [
+        item
+        for item in projected_open_items
+        if normalize_todo_resume_when(item.get("resume_when"))
+        if item.get("resume_ready") is False
     ]
     monitor_items = [
         item
@@ -6367,6 +6377,12 @@ def compact_todo_group(
         ][:MAX_DEFERRED_TODO_VISIBILITY_ITEMS],
         "items": budgeted_items if item_limit is None else budgeted_items[:item_limit],
     }
+    if resume_blocked_items:
+        summary["resume_blocked_count"] = len(resume_blocked_items)
+        summary["resume_blocked_items"] = [
+            compact_todo_item(item)
+            for item in resume_blocked_items[:MAX_DEFERRED_TODO_VISIBILITY_ITEMS]
+        ]
     handoff_gates = build_todo_handoff_gate_states(items)
     if handoff_gates:
         summary["handoff_gates"] = handoff_gates


### PR DESCRIPTION
## Summary

- Project resume-blocked open todos into status only when present, including resume target task class/owner metadata.
- Teach quota/work-lane selection that an advancement todo gated by `todo_done:<open continuous_monitor>` is not a quiet monitor wait; it must project `successor_replan_required` so the agent repairs the standing monitor gate or rewrites the successor contract.
- Add focused smoke coverage for standing monitor resume gates and work-lane policy.

## Root Cause

A long-lived `continuous_monitor` was used as a `todo_done` prerequisite for product-capability advancement todos. Because the monitor was open by design, those successors were hidden from the current-agent executable lane and quota fell through to monitor/agent-scope wait behavior. A standing monitor should observe or trigger material transitions; it should not block unrelated implementation candidates indefinitely.

## Validation

- `python3 -m py_compile loopx/status.py loopx/quota.py loopx/policies/work_lane.py`
- `python3 examples/control-plane-risk-characterization-smoke.py`
- `python3 examples/quota-work-lane-policy-smoke.py`
- `python3 examples/quota-resume-gated-open-todo-smoke.py`
- `python3 examples/hot-path-interface-budget-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli check --scan-path loopx/status.py --scan-path loopx/quota.py --scan-path loopx/policies/work_lane.py --scan-path examples/quota-work-lane-policy-smoke.py --scan-path examples/control-plane-risk-characterization-smoke.py --scan-path examples/quota-resume-gated-open-todo-smoke.py --scan-path examples/hot-path-interface-budget-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --suite catalog-plan --profile control-plane-refactor --profile catalog-canary-contract --max-checks-per-profile 2 --timeout-seconds 180 --no-progress`

## Notes

- The real `loopx-meta` state was repaired locally by marking the standing monitor `todo_efbf10288fe7` done after its evidence gate; both source and installed `loopx` now select `todo_6f2a742c8a57` as bounded delivery.
- `loopx check` still reports an existing warning: `loopx-meta` duplicate index rows raw=7175 unique=7171.
- Hot-path budget is tight (`quota_should_run_json` is close to its current cap), so this PR avoids adding empty resume-blocked fields to dashboard/status payloads.
