### PR TITLE
Thin auto-research preset boundary

### DIFF
--- a/docs/guides/auto-research-command-path.md
+++ b/docs/guides/auto-research-command-path.md
@@ -10,6 +10,13 @@ Use the deeper showcase and protocol docs only after this path is clear:
 - [auto_research_role_state_machine_v0](../reference/protocols/auto-research-role-state-machine-v0.md)
 - [auto_research_role_profile_v0](../reference/protocols/auto-research-role-profile-v0.md)
 
+Implementation boundary: auto-research is a thin preset over the generic
+multi-agent kernel. `loopx/capabilities/auto_research/preset.py` owns only the
+research roles, handoff hints, metric/evidence loop defaults, and seed todo
+phrasing. The generic kernel owns the real Codex TUI panes, pane-local A2A
+tick, workspace/trust-safe launch, todo/evidence/status protocol, and compact
+human status.
+
 ## Start From A Clean Workspace
 
 Use a user-owned directory for the visible demo, while keeping LoopX state in
@@ -124,9 +131,10 @@ Expected minimal E2E result:
 
 - `execution_kind` is `loopx_worker_loop`;
 - `result_source` is `loopx_worker_loop_public_evidence`;
-- `worker_loop.executed_turn_count` is `4`;
+- `worker_loop.executed_turn_count` is `5`;
 - `worker_loop.selected_actions` is
   `write_research_contract`, `propose_hypothesis`, `run_dev_eval`,
+  `summarize_evidence`,
   `run_holdout_eval`;
 - `tonight_experience.coordination_pattern` is `decentralized_state_a2a`;
 - `tonight_experience.dev_metric` is `4.0`;

--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -49,6 +49,9 @@ def main() -> int:
     demo_e2e_source = (
         REPO_ROOT / "loopx/capabilities/auto_research/demo_e2e.py"
     ).read_text(encoding="utf-8")
+    preset_source = (
+        REPO_ROOT / "loopx/capabilities/auto_research/preset.py"
+    ).read_text(encoding="utf-8")
     assert "raw JSON is not printed in visible panes" in runtime_scripts_source
     assert "Use $LOOPX_PANE_LOOPX for human-readable output" in runtime_scripts_source
     assert "$LOOPX_PANE_LOOPX_JSON <command>" in runtime_scripts_source
@@ -62,6 +65,10 @@ def main() -> int:
     assert "codex_stream_filter" not in launcher_source
     assert "build_auto_research_quickstart" not in demo_e2e_source
     assert "quickstart_preview" not in demo_e2e_source
+    assert "DEFAULT_WORKER_LOOP_AGENT_SPECS" not in demo_e2e_source
+    assert "title_by_action" not in demo_e2e_source
+    assert "AUTO_RESEARCH_DEFAULT_LANES" in preset_source
+    assert "AUTO_RESEARCH_SEED_TITLES" in preset_source
 
     worker_markdown = render_auto_research_markdown(
         {

--- a/examples/auto-research-demo-supervisor-smoke.py
+++ b/examples/auto-research-demo-supervisor-smoke.py
@@ -18,6 +18,9 @@ from loopx.capabilities.auto_research.demo_supervisor import (  # noqa: E402
     AUTO_RESEARCH_DEMO_SUPERVISOR_SCHEMA_VERSION,
     build_auto_research_demo_supervisor_plan,
 )
+from loopx.capabilities.auto_research.preset import (  # noqa: E402
+    AUTO_RESEARCH_PRESET_SCHEMA_VERSION,
+)
 
 
 GOAL_ID = "loopx-auto-research-demo"
@@ -75,8 +78,20 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
     assert "compact_human_status" in layering["kernel_layer"]["owns"], layering
     assert layering["acceptance"]["preset_has_no_runner_process_logic"] is True, layering
 
+    preset = payload["preset"]
+    assert preset["schema_version"] == AUTO_RESEARCH_PRESET_SCHEMA_VERSION, preset
+    assert preset["role_count"] == 4, preset
+    assert preset["owns"] == [
+        "research_roles",
+        "handoff_hints",
+        "metric_evidence_loop",
+        "domain_defaults",
+    ], preset
+    assert "multi_agent_runner" in preset["forbidden"], preset
+    assert "pane_local_a2a_tick" in preset["forbidden"], preset
+
     kernel = payload["auto_research"]
-    assert kernel["schema_version"] == "auto_research_visible_demo_kernel_v0", payload
+    assert kernel["schema_version"] == AUTO_RESEARCH_PRESET_SCHEMA_VERSION, payload
     assert kernel["uses_generic_runner"] is True, payload
     assert kernel["surface_count"] == 4, payload
     assert kernel["state_bus"] == "loopx_registry_runtime_todo_quota_frontier", payload

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -9,6 +9,11 @@ from pathlib import Path
 from .demo_supervisor import build_auto_research_demo_supervisor_plan
 from .defaults import AUTO_RESEARCH_DEFAULT_GOAL_ID
 from .live_evidence import load_live_codex_e2e_evidence
+from .preset import (
+    auto_research_seed_action_for_role,
+    auto_research_seed_title,
+    default_auto_research_agent_specs,
+)
 from .rollout_append import append_auto_research_rollout_events
 from .worker_loop import run_auto_research_worker_loop
 
@@ -17,13 +22,6 @@ AppendEvidence = Callable[[str], dict[str, object]]
 VisibleLauncher = Callable[..., dict[str, object]]
 
 AUTO_RESEARCH_DEMO_E2E_SCHEMA_VERSION = "auto_research_demo_e2e_result_v0"
-
-DEFAULT_WORKER_LOOP_AGENT_SPECS = [
-    "codex-product-capability:research-curator:research_curator",
-    "codex-side-bypass:hypothesis-mapper:hypothesis_mapper",
-    "codex-main-control:evidence-runner:evidence_runner",
-    "codex-value-explorer:evidence-verifier:evidence_verifier",
-]
 
 
 def _prepare_visible_demo_workspace_route(
@@ -145,34 +143,11 @@ def _seed_visible_demo_control_plane(
         agent_id = str(lane.get("agent_id") or "").strip()
         role_id = str(lane.get("role_id") or "").strip()
         lane_id = str(lane.get("lane_id") or "").strip()
-        profile = lane.get("role_profile") if isinstance(lane.get("role_profile"), dict) else {}
-        allowed_actions = profile.get("allowed_actions") if isinstance(profile, dict) else []
-        action_kind = str((allowed_actions or ["advance_todo"])[0])
-        if role_id == "evidence_runner":
-            action_kind = "run_dev_eval"
-        title_by_action = {
-            "write_research_contract": (
-                "Write the public-safe research contract for the shared demo hypothesis."
-            ),
-            "propose_hypothesis": (
-                "Map the first shared idea into a todo-backed research hypothesis."
-            ),
-            "claim_attempt": (
-                "Claim one visible attempt boundary for the selected hypothesis."
-            ),
-            "run_dev_eval": (
-                "Run the selected hypothesis on the dev split, write public-safe evidence, append it, and capture live evidence."
-            ),
-            "run_holdout_eval": (
-                "Run held-out validation for the dev-supported hypothesis, append public-safe evidence, and summarize promotion readiness."
-            ),
-            "write_evaluation_summary": (
-                "Verify the evidence packet and open the next validation or promotion gate."
-            ),
-        }
-        title = title_by_action.get(
-            action_kind,
-            f"Run one role-compatible auto-research action for {role_id or lane_id}.",
+        action_kind = auto_research_seed_action_for_role(role_id)
+        title = auto_research_seed_title(
+            action_kind=action_kind,
+            role_id=role_id,
+            lane_id=lane_id,
         )
         result = add_goal_todo(
             registry_path=control_registry,
@@ -400,7 +375,7 @@ def run_auto_research_demo_e2e(
     reuses_default_internal_goal = goal_id == AUTO_RESEARCH_DEFAULT_GOAL_ID
     effective_agent_specs = list(agent_specs or [])
     if (run_worker_loop or launch_visible) and not effective_agent_specs:
-        effective_agent_specs = list(DEFAULT_WORKER_LOOP_AGENT_SPECS)
+        effective_agent_specs = default_auto_research_agent_specs()
     supervisor = build_auto_research_demo_supervisor_plan(
         goal_id=goal_id,
         agent_specs=effective_agent_specs,

--- a/loopx/capabilities/auto_research/demo_supervisor.py
+++ b/loopx/capabilities/auto_research/demo_supervisor.py
@@ -2,167 +2,20 @@
 
 from __future__ import annotations
 
-import shlex
 from collections.abc import Iterable
 from typing import Any
 
 from .defaults import AUTO_RESEARCH_DEFAULT_GOAL_ID, build_auto_research_layer_contract
+from .preset import (
+    AUTO_RESEARCH_PRESET_SCHEMA_VERSION,
+    build_auto_research_preset_role,
+    build_auto_research_preset_summary,
+    auto_research_lane_specs,
+)
 from ...visible_multi_agent_launcher import build_visible_multi_agent_payload_from_spec
 
 
 AUTO_RESEARCH_DEMO_SUPERVISOR_SCHEMA_VERSION = "auto_research_demo_supervisor_plan_v0"
-AUTO_RESEARCH_ROLE_PROFILE_SCHEMA_VERSION = "auto_research_role_profile_v0"
-AUTO_RESEARCH_REQUIRED_SKILL = "loopx-auto-research"
-AUTO_RESEARCH_WORKER_SKILL_SOURCE = (
-    "loopx/capabilities/auto_research/worker_skill/SKILL.md"
-)
-AUTO_RESEARCH_DEMO_TICK_ROUNDS = 3
-AUTO_RESEARCH_DEMO_TICK_SLEEP_SECONDS = 3
-
-AUTO_RESEARCH_DEMO_DEFAULT_LANES = (
-    (
-        "codex-product-capability",
-        "research-curator",
-        "research_curator",
-        "Define the research contract, protected boundary, metric, and first todo.",
-    ),
-    (
-        "codex-side-bypass",
-        "hypothesis-mapper",
-        "hypothesis_mapper",
-        "Turn the current idea into a todo-backed hypothesis and successor handoff.",
-    ),
-    (
-        "codex-main-control",
-        "evidence-runner",
-        "evidence_runner",
-        "Run one selected hypothesis and append public-safe evidence.",
-    ),
-    (
-        "codex-value-explorer",
-        "evidence-verifier",
-        "evidence_verifier",
-        "Read appended evidence and decide whether another round is needed.",
-    ),
-)
-
-AUTO_RESEARCH_ROLE_PROFILE_ORDER = (
-    "research_curator",
-    "hypothesis_mapper",
-    "evidence_runner",
-    "evidence_verifier",
-)
-
-AUTO_RESEARCH_ROLE_PROFILE_ALIASES = {
-    "research-curator": "research_curator",
-    "curator": "research_curator",
-    "hypothesis-mapper": "hypothesis_mapper",
-    "mapper": "hypothesis_mapper",
-    "hypothesis-runner": "hypothesis_mapper",
-    "evidence-runner": "evidence_runner",
-    "runner": "evidence_runner",
-    "evidence-verifier": "evidence_verifier",
-    "verifier": "evidence_verifier",
-    "evidence-promoter": "evidence_verifier",
-}
-
-_ROLE_PROFILES: dict[str, dict[str, object]] = {
-    "research_curator": {
-        "phase": "contract",
-        "allowed_actions": ["write_research_contract"],
-        "write_scope": ["research_contract_v0", "todo_item_v0"],
-        "handoff": ["Create the first hypothesis-mapper todo."],
-    },
-    "hypothesis_mapper": {
-        "phase": "hypothesis",
-        "allowed_actions": ["propose_hypothesis"],
-        "write_scope": ["research_hypothesis_v0", "todo_item_v0"],
-        "handoff": ["Create or unblock an evidence-runner todo."],
-    },
-    "evidence_runner": {
-        "phase": "evidence",
-        "allowed_actions": ["run_dev_eval"],
-        "write_scope": ["auto_research_evidence_packet_v0", "rollout_event_log"],
-        "handoff": ["Append scored evidence, complete the selected todo, and leave verifier context."],
-    },
-    "evidence_verifier": {
-        "phase": "verify",
-        "allowed_actions": ["summarize_evidence"],
-        "write_scope": ["research_evidence_graph_v0", "todo_item_v0"],
-        "handoff": ["Add a next-round hypothesis todo when evidence is incomplete."],
-    },
-}
-
-
-def _role_id_for_lane(raw_role: str, *, index: int) -> str:
-    raw = raw_role.strip()
-    role_id = AUTO_RESEARCH_ROLE_PROFILE_ALIASES.get(raw, raw)
-    if role_id in _ROLE_PROFILES:
-        return role_id
-    if raw:
-        allowed = ", ".join(AUTO_RESEARCH_ROLE_PROFILE_ORDER)
-        raise ValueError(f"unknown auto-research role_id {raw!r}; expected one of {allowed}")
-    return AUTO_RESEARCH_ROLE_PROFILE_ORDER[(index - 1) % len(AUTO_RESEARCH_ROLE_PROFILE_ORDER)]
-
-
-def _lane_specs(agent_specs: Iterable[str] | None) -> list[dict[str, str]]:
-    parsed_specs = list(agent_specs or [])
-    if not parsed_specs:
-        parsed_specs = [
-            f"{agent}:{lane}:{role}" for agent, lane, role, _scope in AUTO_RESEARCH_DEMO_DEFAULT_LANES
-        ]
-
-    lanes: list[dict[str, str]] = []
-    default_scope = {
-        lane: scope for _agent, lane, _role, scope in AUTO_RESEARCH_DEMO_DEFAULT_LANES
-    }
-    for index, raw in enumerate(parsed_specs, start=1):
-        parts = [part.strip() for part in str(raw).split(":")]
-        if len(parts) not in {1, 2, 3, 4} or not parts[0]:
-            raise ValueError("agent specs must be agent_id[:lane_id[:role_id[:scope]]]")
-        agent_id = parts[0]
-        lane_id = parts[1] if len(parts) >= 2 and parts[1] else f"lane-{index}"
-        role_id = _role_id_for_lane(parts[2] if len(parts) >= 3 else "", index=index)
-        scope = parts[3] if len(parts) >= 4 and parts[3] else default_scope.get(lane_id, role_id)
-        lanes.append(
-            {
-                "agent_id": agent_id,
-                "lane_id": lane_id,
-                "role_id": role_id,
-                "scope": scope,
-            }
-        )
-    return lanes
-
-
-def _profile(role_id: str, *, goal_id: str, agent_id: str) -> dict[str, object]:
-    base = dict(_ROLE_PROFILES[role_id])
-    return {
-        "schema_version": AUTO_RESEARCH_ROLE_PROFILE_SCHEMA_VERSION,
-        "goal_id": goal_id,
-        "agent_id": agent_id,
-        "role_id": role_id,
-        "required_skill": AUTO_RESEARCH_REQUIRED_SKILL,
-        "worker_skill_source": AUTO_RESEARCH_WORKER_SKILL_SOURCE,
-        "skill_distribution": "worker_local",
-        "stop_conditions": [
-            "quota says should_run=false or user_action_required=true",
-            "frontier has no selected todo for this agent",
-            "selected action is outside this role profile",
-            "work would require raw logs, credentials, protected scope, or private material",
-        ],
-        **base,
-    }
-
-
-def _worker_turn_command(*, goal_id: str, agent_id: str, objective: str) -> str:
-    return (
-        "$LOOPX_PANE_LOOPX auto-research worker-turn "
-        f"--goal-id {shlex.quote(goal_id)} "
-        f"--agent-id {shlex.quote(agent_id)} "
-        f"--objective {shlex.quote(objective)} "
-        "--execute --complete-selected-todo"
-    )
 
 
 def build_auto_research_demo_supervisor_plan(
@@ -183,36 +36,15 @@ def build_auto_research_demo_supervisor_plan(
     """
 
     goal = str(goal_id).strip() or AUTO_RESEARCH_DEFAULT_GOAL_ID
-    lanes = _lane_specs(agent_specs)
-    roles = []
-    for lane in lanes:
-        role_id = lane["role_id"]
-        agent_id = lane["agent_id"]
-        role_profile = _profile(role_id, goal_id=goal, agent_id=agent_id)
-        roles.append(
-            {
-                "agent_id": agent_id,
-                "lane_id": lane["lane_id"],
-                "role_id": role_id,
-                "scope": lane["scope"],
-                "responsibility": lane["scope"],
-                "role_profile_ref": f"{AUTO_RESEARCH_ROLE_PROFILE_SCHEMA_VERSION}:{role_id}",
-                "role_profile": role_profile,
-                "skill": {
-                    "name": AUTO_RESEARCH_REQUIRED_SKILL,
-                    "source": AUTO_RESEARCH_WORKER_SKILL_SOURCE,
-                },
-                "handoff_hints": role_profile.get("handoff") or [],
-                "worker_turn_command": _worker_turn_command(
-                    goal_id=goal,
-                    agent_id=agent_id,
-                    objective="Run the next bounded auto-research frontier item.",
-                ),
-                "tick_rounds": AUTO_RESEARCH_DEMO_TICK_ROUNDS,
-                "tick_sleep_seconds": AUTO_RESEARCH_DEMO_TICK_SLEEP_SECONDS,
-                "reasoning_effort": reasoning_effort,
-            }
+    lanes = auto_research_lane_specs(agent_specs)
+    roles = [
+        build_auto_research_preset_role(
+            lane=lane,
+            goal_id=goal,
+            reasoning_effort=reasoning_effort,
         )
+        for lane in lanes
+    ]
 
     payload = build_visible_multi_agent_payload_from_spec(
         {
@@ -231,8 +63,9 @@ def build_auto_research_demo_supervisor_plan(
             "schema_version": AUTO_RESEARCH_DEMO_SUPERVISOR_SCHEMA_VERSION,
             "mode": "dry_run",
             "layer_minimality_contract": build_auto_research_layer_contract(),
+            "preset": build_auto_research_preset_summary(role_count=len(roles)),
             "auto_research": {
-                "schema_version": "auto_research_visible_demo_kernel_v0",
+                "schema_version": AUTO_RESEARCH_PRESET_SCHEMA_VERSION,
                 "uses_generic_runner": True,
                 "surface_count": len(roles),
                 "state_bus": "loopx_registry_runtime_todo_quota_frontier",

--- a/loopx/capabilities/auto_research/preset.py
+++ b/loopx/capabilities/auto_research/preset.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import shlex
+from collections.abc import Iterable
+
+from .defaults import AUTO_RESEARCH_DEFAULT_GOAL_ID
+
+
+AUTO_RESEARCH_PRESET_SCHEMA_VERSION = "auto_research_thin_preset_v0"
+AUTO_RESEARCH_ROLE_PROFILE_SCHEMA_VERSION = "auto_research_role_profile_v0"
+AUTO_RESEARCH_REQUIRED_SKILL = "loopx-auto-research"
+AUTO_RESEARCH_WORKER_SKILL_SOURCE = (
+    "loopx/capabilities/auto_research/worker_skill/SKILL.md"
+)
+AUTO_RESEARCH_DEMO_TICK_ROUNDS = 3
+AUTO_RESEARCH_DEMO_TICK_SLEEP_SECONDS = 3
+
+AUTO_RESEARCH_DEFAULT_LANES = (
+    (
+        "codex-product-capability",
+        "research-curator",
+        "research_curator",
+        "Define the research contract, protected boundary, metric, and first todo.",
+    ),
+    (
+        "codex-side-bypass",
+        "hypothesis-mapper",
+        "hypothesis_mapper",
+        "Turn the current idea into a todo-backed hypothesis and successor handoff.",
+    ),
+    (
+        "codex-main-control",
+        "evidence-runner",
+        "evidence_runner",
+        "Run one selected hypothesis and append public-safe evidence.",
+    ),
+    (
+        "codex-value-explorer",
+        "evidence-verifier",
+        "evidence_verifier",
+        "Read appended evidence and decide whether another round is needed.",
+    ),
+)
+
+AUTO_RESEARCH_ROLE_PROFILE_ORDER = (
+    "research_curator",
+    "hypothesis_mapper",
+    "evidence_runner",
+    "evidence_verifier",
+)
+
+AUTO_RESEARCH_ROLE_PROFILE_ALIASES = {
+    "research-curator": "research_curator",
+    "curator": "research_curator",
+    "hypothesis-mapper": "hypothesis_mapper",
+    "mapper": "hypothesis_mapper",
+    "hypothesis-runner": "hypothesis_mapper",
+    "evidence-runner": "evidence_runner",
+    "runner": "evidence_runner",
+    "evidence-verifier": "evidence_verifier",
+    "verifier": "evidence_verifier",
+    "evidence-promoter": "evidence_verifier",
+}
+
+AUTO_RESEARCH_ROLE_PROFILES: dict[str, dict[str, object]] = {
+    "research_curator": {
+        "phase": "contract",
+        "allowed_actions": ["write_research_contract"],
+        "write_scope": ["research_contract_v0", "todo_item_v0"],
+        "handoff": ["Create the first hypothesis-mapper todo."],
+    },
+    "hypothesis_mapper": {
+        "phase": "hypothesis",
+        "allowed_actions": ["propose_hypothesis"],
+        "write_scope": ["research_hypothesis_v0", "todo_item_v0"],
+        "handoff": ["Create or unblock an evidence-runner todo."],
+    },
+    "evidence_runner": {
+        "phase": "evidence",
+        "allowed_actions": ["run_dev_eval"],
+        "write_scope": ["auto_research_evidence_packet_v0", "rollout_event_log"],
+        "handoff": ["Append scored evidence, complete the selected todo, and leave verifier context."],
+    },
+    "evidence_verifier": {
+        "phase": "verify",
+        "allowed_actions": ["summarize_evidence"],
+        "write_scope": ["research_evidence_graph_v0", "todo_item_v0"],
+        "handoff": ["Add a next-round hypothesis todo when evidence is incomplete."],
+    },
+}
+
+AUTO_RESEARCH_SEED_TITLES = {
+    "write_research_contract": (
+        "Write the public-safe research contract for the shared demo hypothesis."
+    ),
+    "propose_hypothesis": (
+        "Map the first shared idea into a todo-backed research hypothesis."
+    ),
+    "claim_attempt": "Claim one visible attempt boundary for the selected hypothesis.",
+    "run_dev_eval": (
+        "Run the selected hypothesis on the dev split, write public-safe evidence, append it, and capture live evidence."
+    ),
+    "run_holdout_eval": (
+        "Run held-out validation for the dev-supported hypothesis, append public-safe evidence, and summarize promotion readiness."
+    ),
+    "write_evaluation_summary": (
+        "Verify the evidence packet and open the next validation or promotion gate."
+    ),
+    "summarize_evidence": (
+        "Summarize dev evidence and hand off holdout validation when the hypothesis is supported."
+    ),
+}
+
+
+def default_auto_research_agent_specs() -> list[str]:
+    return [
+        f"{agent}:{lane}:{role}"
+        for agent, lane, role, _scope in AUTO_RESEARCH_DEFAULT_LANES
+    ]
+
+
+def auto_research_role_id(raw_role: str, *, index: int) -> str:
+    raw = raw_role.strip()
+    role_id = AUTO_RESEARCH_ROLE_PROFILE_ALIASES.get(raw, raw)
+    if role_id in AUTO_RESEARCH_ROLE_PROFILES:
+        return role_id
+    if raw:
+        allowed = ", ".join(AUTO_RESEARCH_ROLE_PROFILE_ORDER)
+        raise ValueError(f"unknown auto-research role_id {raw!r}; expected one of {allowed}")
+    return AUTO_RESEARCH_ROLE_PROFILE_ORDER[(index - 1) % len(AUTO_RESEARCH_ROLE_PROFILE_ORDER)]
+
+
+def auto_research_lane_specs(agent_specs: Iterable[str] | None) -> list[dict[str, str]]:
+    parsed_specs = list(agent_specs or [])
+    if not parsed_specs:
+        parsed_specs = default_auto_research_agent_specs()
+
+    lanes: list[dict[str, str]] = []
+    default_scope = {
+        lane: scope for _agent, lane, _role, scope in AUTO_RESEARCH_DEFAULT_LANES
+    }
+    for index, raw in enumerate(parsed_specs, start=1):
+        parts = [part.strip() for part in str(raw).split(":")]
+        if len(parts) not in {1, 2, 3, 4} or not parts[0]:
+            raise ValueError("agent specs must be agent_id[:lane_id[:role_id[:scope]]]")
+        agent_id = parts[0]
+        lane_id = parts[1] if len(parts) >= 2 and parts[1] else f"lane-{index}"
+        role_id = auto_research_role_id(parts[2] if len(parts) >= 3 else "", index=index)
+        scope = parts[3] if len(parts) >= 4 and parts[3] else default_scope.get(lane_id, role_id)
+        lanes.append(
+            {
+                "agent_id": agent_id,
+                "lane_id": lane_id,
+                "role_id": role_id,
+                "scope": scope,
+            }
+        )
+    return lanes
+
+
+def auto_research_role_profile(*, role_id: str, goal_id: str, agent_id: str) -> dict[str, object]:
+    base = dict(AUTO_RESEARCH_ROLE_PROFILES[role_id])
+    return {
+        "schema_version": AUTO_RESEARCH_ROLE_PROFILE_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "agent_id": agent_id,
+        "role_id": role_id,
+        "required_skill": AUTO_RESEARCH_REQUIRED_SKILL,
+        "worker_skill_source": AUTO_RESEARCH_WORKER_SKILL_SOURCE,
+        "skill_distribution": "worker_local",
+        "stop_conditions": [
+            "quota says should_run=false or user_action_required=true",
+            "frontier has no selected todo for this agent",
+            "selected action is outside this role profile",
+            "work would require raw logs, credentials, protected scope, or private material",
+        ],
+        **base,
+    }
+
+
+def auto_research_worker_turn_command(*, goal_id: str, agent_id: str, objective: str) -> str:
+    return (
+        "$LOOPX_PANE_LOOPX auto-research worker-turn "
+        f"--goal-id {shlex.quote(goal_id)} "
+        f"--agent-id {shlex.quote(agent_id)} "
+        f"--objective {shlex.quote(objective)} "
+        "--execute --complete-selected-todo"
+    )
+
+
+def auto_research_seed_action_for_role(role_id: str) -> str:
+    profile = AUTO_RESEARCH_ROLE_PROFILES.get(role_id) or {}
+    actions = profile.get("allowed_actions") if isinstance(profile, dict) else []
+    action = str((actions or ["advance_todo"])[0])
+    if role_id == "evidence_runner":
+        return "run_dev_eval"
+    return action
+
+
+def auto_research_seed_title(*, action_kind: str, role_id: str, lane_id: str) -> str:
+    return AUTO_RESEARCH_SEED_TITLES.get(
+        action_kind,
+        f"Run one role-compatible auto-research action for {role_id or lane_id}.",
+    )
+
+
+def build_auto_research_preset_role(
+    *,
+    lane: dict[str, str],
+    goal_id: str = AUTO_RESEARCH_DEFAULT_GOAL_ID,
+    reasoning_effort: str = "high",
+) -> dict[str, object]:
+    role_id = lane["role_id"]
+    agent_id = lane["agent_id"]
+    role_profile = auto_research_role_profile(
+        role_id=role_id,
+        goal_id=goal_id,
+        agent_id=agent_id,
+    )
+    return {
+        "agent_id": agent_id,
+        "lane_id": lane["lane_id"],
+        "role_id": role_id,
+        "scope": lane["scope"],
+        "responsibility": lane["scope"],
+        "role_profile_ref": f"{AUTO_RESEARCH_ROLE_PROFILE_SCHEMA_VERSION}:{role_id}",
+        "role_profile": role_profile,
+        "skill": {
+            "name": AUTO_RESEARCH_REQUIRED_SKILL,
+            "source": AUTO_RESEARCH_WORKER_SKILL_SOURCE,
+        },
+        "handoff_hints": role_profile.get("handoff") or [],
+        "worker_turn_command": auto_research_worker_turn_command(
+            goal_id=goal_id,
+            agent_id=agent_id,
+            objective="Run the next bounded auto-research frontier item.",
+        ),
+        "tick_rounds": AUTO_RESEARCH_DEMO_TICK_ROUNDS,
+        "tick_sleep_seconds": AUTO_RESEARCH_DEMO_TICK_SLEEP_SECONDS,
+        "reasoning_effort": reasoning_effort,
+    }
+
+
+def build_auto_research_preset_summary(*, role_count: int) -> dict[str, object]:
+    return {
+        "schema_version": AUTO_RESEARCH_PRESET_SCHEMA_VERSION,
+        "owns": [
+            "research_roles",
+            "handoff_hints",
+            "metric_evidence_loop",
+            "domain_defaults",
+        ],
+        "forbidden": [
+            "multi_agent_runner",
+            "real_codex_tui_panes",
+            "workspace_and_trust_safe_launch",
+            "pane_local_a2a_tick",
+            "todo_evidence_status_protocol",
+            "compact_human_status",
+        ],
+        "role_count": role_count,
+        "default_agent_specs": default_auto_research_agent_specs(),
+    }


### PR DESCRIPTION
## Summary
- move auto-research role/profile/seed defaults into a thin `preset.py` boundary
- make demo supervisor/e2e consume the preset instead of owning preset semantics inline
- add smokes/docs that keep auto-research minimal: preset owns research roles, handoff hints, metric/evidence loop, and domain defaults; generic kernel owns runner/TUI/tick/status mechanics

## Validation
- `python3 -m py_compile loopx/capabilities/auto_research/preset.py loopx/capabilities/auto_research/demo_supervisor.py loopx/capabilities/auto_research/demo_e2e.py`
- `python3 examples/auto-research-demo-supervisor-smoke.py`
- `python3 examples/auto-research-demo-e2e-worker-loop-smoke.py`
- `python3 examples/auto-research-worker-loop-smoke.py`
- `python3 examples/auto-research-worker-turn-smoke.py`
- `python3 examples/generic-multi-agent-runner-kernel-smoke.py`
- `python3 examples/generic-multi-agent-one-command-smoke.py`
- `python3 examples/decentralized-auto-research-protocol-smoke.py`
- `git diff --check`
- `loopx check --scan-path ...` (ok; existing duplicate-index warning only)
