### PR TITLE
Update derived state boundary smoke fixture

### DIFF
--- a/examples/derived-state-boundary-smoke.py
+++ b/examples/derived-state-boundary-smoke.py
@@ -12,6 +12,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.status import (  # noqa: E402
+    MAX_DEFERRED_TODO_VISIBILITY_ITEMS,
     MAX_PROJECT_ASSET_TODO_BACKLOG_ITEMS,
     MAX_PROJECT_ASSET_TODO_ITEMS,
     MAX_STATUS_TODOS_PER_ROLE,
@@ -87,6 +88,7 @@ def main() -> int:
         "truth": "derived",
         "canonical_source": "attention_queue.items[].agent_todos",
         "item_limit": MAX_PROJECT_ASSET_TODO_ITEMS,
+        "deferred_item_limit": MAX_DEFERRED_TODO_VISIBILITY_ITEMS,
     }, asset_summary
     assert asset_summary["detail_pointer"] == {
         "schema_version": TODO_PROJECTION_DETAIL_POINTER_SCHEMA_VERSION,
@@ -95,6 +97,16 @@ def main() -> int:
         "full_list_included": False,
     }, asset_summary
     assert len(asset_summary["items"]) == MAX_PROJECT_ASSET_TODO_ITEMS, asset_summary
+    assert asset_summary["claimed_open_count"] == 24, asset_summary
+    assert asset_summary["unclaimed_open_count"] == 6, asset_summary
+    assert len(asset_summary["first_executable_items"]) == MAX_PROJECT_ASSET_TODO_ITEMS, (
+        asset_summary
+    )
+    assert asset_summary["first_executable_items"][0]["todo_id"] == "todo_derived_01", (
+        asset_summary
+    )
+    assert asset_summary["claimed_advancement_open_count"] == 24, asset_summary
+    assert asset_summary["claimed_monitor_open_count"] == 0, asset_summary
     assert "backlog_items" not in asset_summary, asset_summary
     assert "claimed_open_items" not in asset_summary, asset_summary
 


### PR DESCRIPTION
## Summary
- Align the derived-state boundary smoke with the current project_asset todo projection contract.
- Pin the new bounded derived fields: deferred item limit, claimed/unclaimed counts, first executable items, and lane-specific claimed counts.
- Preserve the original boundary invariant that project_asset summaries stay bounded and do not expose backlog or claimed item lists as a second source of truth.

## Validation
- PYTHONPATH=. python3 examples/derived-state-boundary-smoke.py
- python3 -m py_compile examples/derived-state-boundary-smoke.py
- PYTHONPATH=. python3 -m loopx.cli --format json canary smoke-suite --suite full-public --script examples/derived-state-boundary-smoke.py --timeout-seconds 45 --no-progress
- loopx check --scan-path examples/derived-state-boundary-smoke.py

## Boundary
- Public synthetic smoke fixture only; no runtime behavior, credentials, private logs, benchmark raw logs, trajectories, or verifier output.