### PR TITLE
Fix release packaging smoke gaps

### DIFF
--- a/examples/active-state-interface-budget-smoke.py
+++ b/examples/active-state-interface-budget-smoke.py
@@ -73,6 +73,16 @@ def assert_next_action_budget(path: Path) -> None:
 
 
 def assert_no_tracked_live_active_state() -> None:
+    git_check = subprocess.run(
+        ["git", "rev-parse", "--is-inside-work-tree"],
+        cwd=REPO_ROOT,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=False,
+    )
+    if git_check.returncode != 0:
+        return
     output = subprocess.check_output(
         ["git", "ls-files"],
         cwd=REPO_ROOT,

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -209,6 +209,7 @@ def main() -> int:
         assert action_packet.is_file(), action_packet
         assert not dashboard_node_modules.exists(), dashboard_node_modules
         assert (release_root / ".github" / "workflows" / "update-notes.yml").is_file(), release_root
+        assert (release_root / "CONTRIBUTOR_TASKS.md").is_file(), release_root
         assert (release_root / "LICENSE").is_file(), release_root
         release_manifest_path = release_root / "release.json"
         assert release_manifest_path.is_file(), release_manifest_path

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -111,6 +111,7 @@ copy_path "$repo_root/examples" "$release_tmp/examples"
 copy_path "$repo_root/apps" "$release_tmp/apps"
 copy_path "$repo_root/.github" "$release_tmp/.github"
 copy_path "$repo_root/README.md" "$release_tmp/README.md"
+copy_path "$repo_root/CONTRIBUTOR_TASKS.md" "$release_tmp/CONTRIBUTOR_TASKS.md"
 copy_path "$repo_root/LICENSE" "$release_tmp/LICENSE"
 copy_path "$repo_root/pyproject.toml" "$release_tmp/pyproject.toml"
 find "$release_tmp" -name __pycache__ -type d -prune -exec rm -rf {} +


### PR DESCRIPTION
## Summary
- make active-state interface budget smoke run git-tracked live-state checks only inside a git checkout
- include CONTRIBUTOR_TASKS.md in local release snapshots so shipped public docs satisfy session-runtime adapter doc smoke
- add installer smoke coverage for the contributor task doc in release snapshots

## Validation
- PYTHONPATH=. python3 examples/active-state-interface-budget-smoke.py
- PYTHONPATH=. python3 examples/session-runtime-control-plane-adapter-doc-smoke.py
- python3 -m py_compile examples/active-state-interface-budget-smoke.py examples/session-runtime-control-plane-adapter-doc-smoke.py examples/install-local-smoke.py
- isolated release snapshot install, then python3 examples/active-state-interface-budget-smoke.py and python3 examples/session-runtime-control-plane-adapter-doc-smoke.py from the release root
- PYTHONPATH=. python3 examples/install-local-smoke.py
- PYTHONPATH=. python3 -m loopx.cli --format json canary smoke-suite --suite full-public --script examples/active-state-interface-budget-smoke.py --timeout-seconds 45 --no-progress
- PYTHONPATH=. python3 -m loopx.cli --format json canary smoke-suite --suite full-public --script examples/session-runtime-control-plane-adapter-doc-smoke.py --timeout-seconds 45 --no-progress
- loopx check --scan-path scripts/install-local.sh --scan-path examples/active-state-interface-budget-smoke.py --scan-path examples/session-runtime-control-plane-adapter-doc-smoke.py --scan-path examples/install-local-smoke.py
- git diff --check

## Boundary
- public installer/smoke fixture only
- no private state, credentials, raw benchmark evidence, or local paths committed