### PR TITLE
Document reusable multi-agent product recipe

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,9 @@ incident report, or launch draft.
 - [Auto-research command path](guides/auto-research-command-path.md): the
   shortest visible route from a clean workspace to an inspectable multi-agent
   auto-research rehearsal with stop and takeover controls.
+- [Multi-agent product recipe](guides/multi-agent-product-recipe.md): the
+  product-author path for keeping both user config and product presets thin
+  while the generic kernel owns runner, TUI, tick, status, and host controls.
 - [Product vision](product/vision.md): long-term product direction, Loop Agent
   definition, maintainer-first management surface, and open-source anchor
   strategy.
@@ -78,6 +81,7 @@ incident report, or launch draft.
 - [Getting started](guides/getting-started.md)
 - [Newcomer command path](guides/newcomer-command-path.md)
 - [Auto-research command path](guides/auto-research-command-path.md)
+- [Multi-agent product recipe](guides/multi-agent-product-recipe.md)
 - [Integration guide](integration.md)
 - [Benchmark developer workflow](benchmark-developer-workflow.md)
 - [Attention queue](attention-queue.md)

--- a/docs/guides/auto-research-command-path.md
+++ b/docs/guides/auto-research-command-path.md
@@ -6,6 +6,7 @@ employees appear, what artifacts to inspect, and how to stop or take over.
 
 Use the deeper showcase and protocol docs only after this path is clear:
 
+- [Multi-agent product recipe](multi-agent-product-recipe.md)
 - [Decentralized auto-research showcase](../product/decentralized-auto-research-showcase.md)
 - [auto_research_role_state_machine_v0](../reference/protocols/auto-research-role-state-machine-v0.md)
 - [auto_research_role_profile_v0](../reference/protocols/auto-research-role-profile-v0.md)
@@ -16,6 +17,8 @@ research roles, handoff hints, metric/evidence loop defaults, and seed todo
 phrasing. The generic kernel owns the real Codex TUI panes, pane-local A2A
 tick, workspace/trust-safe launch, todo/evidence/status protocol, and compact
 human status.
+Use the [multi-agent product recipe](multi-agent-product-recipe.md) when a new
+product wants to copy the pattern without copying auto-research code.
 
 ## Start From A Clean Workspace
 

--- a/docs/guides/multi-agent-product-recipe.md
+++ b/docs/guides/multi-agent-product-recipe.md
@@ -1,0 +1,224 @@
+# Multi-Agent Product Recipe
+
+This guide is the product-author path for building a LoopX multi-agent
+composition without copying auto-research internals. The target shape is:
+
+1. **User layer:** a few intent fields.
+2. **Product preset:** a small domain recipe.
+3. **Multi-agent kernel:** every reusable runner and state mechanic.
+
+The public promise of "launch multi-agent auto-research in the fewest lines" is
+a forcing function for this split. It is not enough to make the user command
+short if the auto-research preset becomes a second runner. Both the user layer
+and the product preset must stay thin, so another product can reuse the same
+kernel with a different role list, skill snippet, and evidence loop.
+
+Use this with:
+
+- [Multi-agent visible launcher v0](../reference/protocols/multi-agent-visible-launcher-v0.md)
+- [Three-layer minimality contract](../reference/protocols/multi-agent-three-layer-minimality-v0.md)
+- [Auto-research command path](auto-research-command-path.md)
+
+## Layer Rule
+
+| Layer | Keep It Small By Owning | Must Not Own |
+| --- | --- | --- |
+| User | Topic, objective, rounds, optional role overrides, and optional data or eval entrypoint. | Tmux, Codex TUI launch flags, pane-local tick commands, quota/frontier plumbing, machine JSON routing, or role bootstrap scripts. |
+| Product preset | Domain role list, agent scope, handoff/todo hints, worker skill snippet, default seed todos, and domain evidence or metric adapter. | Generic multi-agent runner, real Codex TUI panes, workspace/trust-safe launch, pane-local A2A tick, todo/evidence/status protocol, attach/stop/retry, or JSON visibility policy. |
+| Kernel | Multi-agent runner, true interactive Codex panes, pane-local A2A tick, workspace/trust-safe launch, todo/evidence/status protocol, compact human status, role prompt scaffolding, and host lifecycle controls. | Research, support, benchmark, sales, or other product-specific semantics. |
+
+If a second product would need the same code, move that code into the kernel.
+If the logic names a domain result, domain role, metric, artifact type, or
+handoff meaning, keep it in the preset.
+
+## Product Preset Shape
+
+A preset should be close to data plus one or two small adapters. It should not
+construct tmux commands, Codex invocation strings, or pane wrapper scripts.
+
+The minimum preset fields are:
+
+- `product_id`: stable product namespace, such as `auto-research`;
+- `objective_fields`: user-facing intent fields the product accepts;
+- `roles`: role list with `agent_id`, `role_id`, `lane_id`, and agent scope;
+- `skill`: worker-local skill snippet or source path for each role;
+- `handoff_hints`: how a role creates or completes LoopX todos for the next
+  role;
+- `seed_todos`: first todo titles or action kinds for a fresh run;
+- `evidence_adapter`: tiny domain writeback or metric loop, if the product
+  has scored evidence.
+
+Example product recipe:
+
+```json
+{
+  "schema_version": "generic_multi_agent_launch_spec_v0",
+  "goal_id": "loopx-demo-goal",
+  "session_name": "loopx-product-team",
+  "default_reasoning_effort": "high",
+  "roles": [
+    {
+      "lane_id": "planner",
+      "agent_id": "codex-main-control",
+      "role_id": "planner",
+      "scope": "Turn the objective into one bounded todo and a review handoff.",
+      "skill": {
+        "name": "product-planner",
+        "source": "skills/planner/SKILL.md"
+      },
+      "handoff_hints": [
+        "Create a LoopX todo for builder when the plan is ready."
+      ]
+    },
+    {
+      "lane_id": "builder",
+      "agent_id": "codex-side-bypass",
+      "role_id": "builder",
+      "scope": "Claim the selected todo, execute the bounded work, and write evidence.",
+      "skill": {
+        "name": "product-builder",
+        "source": "skills/builder/SKILL.md"
+      },
+      "handoff_hints": [
+        "Complete the todo or create a focused review todo with compact evidence."
+      ]
+    }
+  ]
+}
+```
+
+The kernel expands that spec into a visible launcher packet with role profiles,
+scoped LoopX wrappers, `$LOOPX_PANE_A2A_TICK`, artifact-only machine JSON, and
+tmux host controls.
+
+## Worker Skill Snippet
+
+Each role should receive a small worker-local skill. The skill explains domain
+behavior, not runner mechanics.
+
+Good skill snippet:
+
+```markdown
+# product-builder
+
+Use when this pane has a selected builder todo.
+
+1. Read your selected frontier through LoopX state.
+2. Work only inside the selected todo and role scope.
+3. Write public-safe evidence before completing the todo.
+4. If another role should continue, create a focused LoopX todo and name the
+   target role in the handoff hint.
+```
+
+Avoid putting these in a product skill:
+
+- how to start tmux;
+- how to run Codex;
+- how to write pane wrapper scripts;
+- how to hide or redirect machine JSON;
+- how quota/frontier/status files are routed;
+- how attach, stop, retry, or workspace trust is implemented.
+
+Those are kernel responsibilities.
+
+## Handoff And Todo Hints
+
+The product preset should describe handoff in LoopX terms, not as a hidden
+workflow engine. A role can:
+
+- complete the selected todo after writing compact evidence;
+- create a successor todo with `claimed_by` or target role metadata when the
+  next role is known;
+- leave blocker rationale when no safe action is available;
+- write a public-safe evidence pointer for the next role to read.
+
+The preset should not directly call another agent, inject text into another
+pane, or keep private side-channel state. Agents coordinate by reading and
+writing the shared LoopX state surface: registry, runtime root, todo projection,
+quota/frontier, run history, and public-safe evidence.
+
+## One-Command Launch
+
+For a custom composition, the generic path is:
+
+```bash
+loopx multi-agent launch \
+  --spec ./multi-agent-spec.public.json \
+  --workspace "$PWD" \
+  --execute \
+  --attach
+```
+
+For the auto-research preset, the product path remains:
+
+```bash
+loopx auto-research demo-e2e \
+  --agent-id codex-side-bypass \
+  --reasoning-effort high \
+  --execute \
+  --replace-existing
+```
+
+Both commands should open real interactive Codex CLI TUI panes. The first
+screen should be the role TUI, not raw JSON, shell streams, a hidden executor,
+or a generated worktree trust prompt.
+
+## Attach, Stop, Retry
+
+Every visible multi-agent product should expose the same host controls:
+
+```bash
+tmux attach -t <session-name>
+tmux kill-session -t <session-name>
+```
+
+Retry means rerun the product command after refreshing quota/frontier/bootstrap
+state. It must not replay stale hidden prompts or assume a previous pane still
+has authority. Use `--replace-existing` only when the operator intentionally
+wants to replace a session with the same name.
+
+Inside any pane, the user may interrupt the role and type normally. The pane is
+a real Codex CLI agent, not a passive log viewer.
+
+## Acceptance Checklist
+
+A new product preset is healthy when:
+
+- the user-facing entrypoint is intent plus a few options;
+- the preset defines role list, agent scope, skill snippet, handoff/todo hints,
+  seed todos, and optional evidence adapter;
+- the preset imports the generic multi-agent kernel instead of duplicating
+  runner, TUI, tick, workspace, status, or JSON policy code;
+- every visible pane starts as an interactive Codex CLI TUI;
+- each role's first action is the pane-local A2A tick;
+- machine JSON is written to public artifacts or an explicit machine channel,
+  not dumped into the first visible screen;
+- todos and evidence are the only handoff authority;
+- attach, stop, and retry are available without product-specific host logic;
+- no raw logs, credentials, private material, absolute local paths, or
+  generated transcripts enter committed docs or fixtures.
+
+## Auto-Research As The Reference Preset
+
+Auto-research should stay a reference preset, not the kernel. Its preset owns:
+
+- research roles such as curator, hypothesis mapper, evidence runner, and
+  verifier;
+- role-specific allowed actions;
+- research handoff hints;
+- metric/evidence loop defaults;
+- seed todo wording for the demo.
+
+It should not own:
+
+- multi-agent runner lifecycle;
+- real Codex TUI pane startup;
+- pane-local A2A tick implementation;
+- workspace trust handling;
+- generic todo/evidence/status protocol;
+- attach, stop, retry, or machine JSON visibility rules.
+
+When auto-research needs a new generic capability, implement it in the
+multi-agent kernel first, then let the auto-research preset consume it through a
+small role or evidence adapter. That is the path toward a reusable, lightweight
+kernel and a small promotional example.

--- a/examples/docs-governance-smoke.py
+++ b/examples/docs-governance-smoke.py
@@ -77,6 +77,7 @@ def main() -> int:
         "docs/showcases/",
         "product/codex-cli-tui-loop.md",
         "guides/auto-research-command-path.md",
+        "guides/multi-agent-product-recipe.md",
     ]:
         assert required in docs_index, required
 
@@ -87,6 +88,7 @@ def main() -> int:
         "docs/outreach/README.md",
         "docs/product/README.md",
         "docs/guides/auto-research-command-path.md",
+        "docs/guides/multi-agent-product-recipe.md",
         "docs/reference/README.md",
         "docs/reference/protocols/README.md",
         "docs/research/long-horizon-agent-benchmarks/README.md",
@@ -159,6 +161,22 @@ def main() -> int:
         "not a leader agent",
     ]:
         assert required in compact_auto_research_command_path, required
+
+    multi_agent_product_recipe = read("docs/guides/multi-agent-product-recipe.md")
+    compact_multi_agent_product_recipe = compact(multi_agent_product_recipe)
+    for required in [
+        "Multi-Agent Product Recipe",
+        "Product preset",
+        "Multi-agent kernel",
+        "role list",
+        "agent scope",
+        "worker-local skill snippet",
+        "handoff/todo hints",
+        "One-Command Launch",
+        "Attach, Stop, Retry",
+        "Auto-research should stay a reference preset, not the kernel",
+    ]:
+        assert required in compact_multi_agent_product_recipe, required
 
     print("docs-governance-smoke ok")
     return 0

--- a/examples/multi-agent-product-recipe-smoke.py
+++ b/examples/multi-agent-product-recipe-smoke.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Smoke-check the reusable multi-agent product recipe documentation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+RECIPE = ROOT / "docs" / "guides" / "multi-agent-product-recipe.md"
+DOCS_INDEX = ROOT / "docs" / "README.md"
+AUTO_RESEARCH_GUIDE = ROOT / "docs" / "guides" / "auto-research-command-path.md"
+
+
+PRIVATE_MARKERS = [
+    "byte" + "dance",
+    "lark" + "office",
+    "fei" + "shu.cn",
+    "/" + "Users" + "/",
+    "/" + "private" + "/",
+    "/" + "tmp" + "/",
+    "api" + "_key",
+    "pass" + "word",
+    "sec" + "ret",
+]
+
+
+def read(path: Path) -> str:
+    assert path.is_file(), f"missing {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def require(text: str, snippets: list[str], *, source: Path) -> None:
+    compact = " ".join(text.split())
+    missing = [
+        snippet for snippet in snippets if snippet not in text and " ".join(snippet.split()) not in compact
+    ]
+    assert not missing, f"{source}: missing {missing}"
+
+
+def assert_public_safe(text: str, label: str) -> None:
+    lower = text.lower()
+    leaked = [marker for marker in PRIVATE_MARKERS if marker.lower() in lower]
+    assert not leaked, f"{label} leaks private markers: {leaked}"
+
+
+def main() -> int:
+    recipe = read(RECIPE)
+    docs_index = read(DOCS_INDEX)
+    auto_research_guide = read(AUTO_RESEARCH_GUIDE)
+
+    assert_public_safe(recipe, "multi-agent product recipe")
+    require(
+        recipe,
+        [
+            "# Multi-Agent Product Recipe",
+            "User layer",
+            "Product preset",
+            "Multi-agent kernel",
+            "It is not enough to make the user command\nshort if the auto-research preset becomes a second runner",
+            "Both the user layer\nand the product preset must stay thin",
+            "role list",
+            "agent scope",
+            "worker-local skill snippet",
+            "handoff/todo hints",
+            "One-Command Launch",
+            "Attach, Stop, Retry",
+            "loopx multi-agent launch",
+            "loopx auto-research demo-e2e",
+            "real interactive Codex CLI TUI panes",
+            "first action is the pane-local A2A tick",
+            "machine JSON is written to public artifacts",
+            "todos and evidence are the only handoff authority",
+            "Auto-research should stay a reference preset, not the kernel",
+            "implement it in the\nmulti-agent kernel first",
+        ],
+        source=RECIPE,
+    )
+    require(
+        docs_index,
+        [
+            "Multi-agent product recipe",
+            "guides/multi-agent-product-recipe.md",
+        ],
+        source=DOCS_INDEX,
+    )
+    require(
+        auto_research_guide,
+        [
+            "Multi-agent product recipe",
+            "multi-agent-product-recipe.md",
+            "copy the pattern without copying auto-research code",
+        ],
+        source=AUTO_RESEARCH_GUIDE,
+    )
+
+    forbidden = [
+        "auto-research owns the runner",
+        "preset owns tmux",
+        "hidden workflow engine",
+        "raw JSON should be visible first",
+    ]
+    for phrase in forbidden:
+        assert phrase not in recipe, f"forbidden phrase present: {phrase}"
+
+    print("multi-agent-product-recipe-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a product-author recipe for reusable multi-agent products
- clarify the user / product preset / kernel split so user and preset both stay thin
- link auto-research to the generic recipe and add focused docs smoke coverage

## Validation
- python3 examples/multi-agent-product-recipe-smoke.py
- python3 examples/docs-governance-smoke.py
- python3 examples/multi-agent-visible-launcher-protocol-smoke.py
- git diff --check
- loopx check --scan-path docs/README.md --scan-path docs/guides/auto-research-command-path.md --scan-path docs/guides/multi-agent-product-recipe.md --scan-path examples/docs-governance-smoke.py --scan-path examples/multi-agent-product-recipe-smoke.py

## Merge posture
Small public docs plus focused smoke only. No runtime behavior, benchmark scoring, permission boundary, or first-screen product surface change.