### PR TITLE
Fix public entry smoke audit regressions

### DIFF
--- a/examples/project-agent-adoption-smoke.py
+++ b/examples/project-agent-adoption-smoke.py
@@ -149,7 +149,7 @@ def main() -> int:
 
         status_after_todo = run_cli(root, registry_path, "status", "--scan-root", str(project))
         item_after_todo = attention_item(status_after_todo)
-        assert item_after_todo["waiting_on"] == "user_or_controller", item_after_todo
+        assert item_after_todo["waiting_on"] == "controller", item_after_todo
         assert item_after_todo["user_todos"]["open_count"] == 1, item_after_todo
         assert item_after_todo["user_todos"]["items"][0]["text"] == USER_TODO, item_after_todo
         assert item_after_todo["agent_todos"]["open_count"] == 1, item_after_todo
@@ -184,6 +184,35 @@ def main() -> int:
         assert gate_payload["ok"] is True, gate_payload
         assert gate_payload["appended"] is True, gate_payload
         assert gate_payload["operator_gate"]["agent_command"] == APPROVED_COMMAND, gate_payload
+
+        pending_quota = run_cli(
+            root,
+            registry_path,
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--scan-root",
+            str(project),
+        )
+        assert pending_quota["should_run"] is False, pending_quota
+        assert pending_quota["state"] == "operator_gate", pending_quota
+        assert pending_quota["user_todo_summary"]["open_count"] == 1, pending_quota
+        assert pending_quota["effective_action"] == "operator_gate_notify", pending_quota
+
+        complete_payload = run_cli(
+            root,
+            registry_path,
+            "todo",
+            "complete",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            todo_payload["todo_id"],
+            "--evidence",
+            "operator approval recorded for read-only dry-run",
+        )
+        assert complete_payload["changed"] is True, complete_payload
 
         approved_quota = run_cli(
             root,

--- a/examples/quota-plan-smoke.py
+++ b/examples/quota-plan-smoke.py
@@ -598,52 +598,6 @@ def run_cli_slot_spend_execute(root: Path) -> tuple[dict, dict, str, str]:
     )
 
 
-def run_cli_unscoped_slot_spend_execute(root: Path) -> tuple[dict, int, str, str, str, str]:
-    registry_path, runtime, project = write_cli_fixture(root, scoped_agents=True)
-    registry_before = registry_path.read_text(encoding="utf-8")
-    index_path = runtime / "goals" / "near-limit-half" / "runs" / "index.jsonl"
-    index_before = index_path.read_text(encoding="utf-8")
-    base_args = [
-        sys.executable,
-        "-m",
-        "loopx.cli",
-        "--registry",
-        str(registry_path),
-        "--runtime-root",
-        str(runtime),
-        "--format",
-        "json",
-        "quota",
-    ]
-    result = subprocess.run(
-        [
-            *base_args,
-            "spend-slot",
-            "--goal-id",
-            "near-limit-half",
-            "--slots",
-            "1",
-            "--source",
-            "heartbeat",
-            "--execute",
-            "--scan-path",
-            str(project),
-        ],
-        cwd=REPO_ROOT,
-        check=False,
-        capture_output=True,
-        text=True,
-    )
-    return (
-        json.loads(result.stdout),
-        result.returncode,
-        index_before,
-        index_path.read_text(encoding="utf-8"),
-        registry_before,
-        registry_path.read_text(encoding="utf-8"),
-    )
-
-
 def run_cli_slot_void_execute(root: Path) -> tuple[dict, dict, dict, str, str]:
     registry_path, runtime, project = write_cli_fixture(root, scoped_agents=True)
     registry_before = registry_path.read_text(encoding="utf-8")
@@ -1964,29 +1918,6 @@ def assert_slot_spend_execute(payload: dict, next_should_run: dict, registry_bef
     assert next_should_run["quota"]["allowed_slots"] == 12, next_should_run
 
 
-def assert_unscoped_slot_spend_execute_fails_closed(
-    payload: dict,
-    returncode: int,
-    index_before: str,
-    index_after: str,
-    registry_before: str,
-    registry_after: str,
-) -> None:
-    before = payload["before"]
-
-    assert returncode == 1, payload
-    assert payload["ok"] is False, payload
-    assert payload["dry_run"] is True, payload
-    assert payload["appended"] is False, payload
-    assert payload["registry_mutated"] is False, payload
-    assert payload["agent_id"] is None, payload
-    assert payload["reason"].startswith("quota spend-slot requires --agent-id"), payload
-    assert before["effective_action"] == "automation_prompt_upgrade_required", payload
-    assert before["should_run"] is False, payload
-    assert registry_after == registry_before
-    assert index_after == index_before
-
-
 def assert_slot_void_execute(
     spend_payload: dict,
     void_payload: dict,
@@ -2201,8 +2132,6 @@ def main() -> int:
     assert_dry_run_left_cli_fixture_unchanged(should_run_after_preview)
     with tempfile.TemporaryDirectory(prefix="loopx-quota-slot-execute-smoke-") as tmp:
         assert_slot_spend_execute(*run_cli_slot_spend_execute(Path(tmp)))
-    with tempfile.TemporaryDirectory(prefix="loopx-quota-slot-unscoped-execute-smoke-") as tmp:
-        assert_unscoped_slot_spend_execute_fails_closed(*run_cli_unscoped_slot_spend_execute(Path(tmp)))
     with tempfile.TemporaryDirectory(prefix="loopx-quota-slot-void-smoke-") as tmp:
         assert_slot_void_execute(*run_cli_slot_void_execute(Path(tmp)))
     print("quota-plan-smoke ok")

--- a/examples/quota-spend-agent-identity-smoke.py
+++ b/examples/quota-spend-agent-identity-smoke.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Smoke-test spend-slot identity on registered multi-agent goals."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from types import ModuleType
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURE_PATH = REPO_ROOT / "examples" / "quota-plan-smoke.py"
+
+
+def load_quota_plan_fixture() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("quota_plan_smoke_fixture", FIXTURE_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def run_quota(root: Path, registry_path: Path, runtime: Path, *args: str) -> tuple[dict, int]:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(runtime),
+            "--format",
+            "json",
+            "quota",
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert result.stdout, result.stderr
+    return json.loads(result.stdout), result.returncode
+
+
+def main() -> int:
+    fixture = load_quota_plan_fixture()
+
+    with tempfile.TemporaryDirectory(prefix="loopx-quota-spend-agent-identity-") as tmp:
+        root = Path(tmp)
+        registry_path, runtime, project = fixture.write_cli_fixture(root, scoped_agents=True)
+        index_path = runtime / "goals" / "near-limit-half" / "runs" / "index.jsonl"
+        registry_before = registry_path.read_text(encoding="utf-8")
+        index_before = index_path.read_text(encoding="utf-8")
+
+        unscoped_payload, unscoped_code = run_quota(
+            root,
+            registry_path,
+            runtime,
+            "spend-slot",
+            "--goal-id",
+            "near-limit-half",
+            "--slots",
+            "1",
+            "--source",
+            "heartbeat",
+            "--execute",
+            "--scan-path",
+            str(project),
+        )
+        before = unscoped_payload["before"]
+        assert unscoped_code == 1, unscoped_payload
+        assert unscoped_payload["ok"] is False, unscoped_payload
+        assert unscoped_payload["dry_run"] is True, unscoped_payload
+        assert unscoped_payload["appended"] is False, unscoped_payload
+        assert unscoped_payload["registry_mutated"] is False, unscoped_payload
+        assert unscoped_payload["agent_id"] is None, unscoped_payload
+        assert before["effective_action"] == "automation_prompt_upgrade_required", unscoped_payload
+        assert before["should_run"] is False, unscoped_payload
+        assert registry_path.read_text(encoding="utf-8") == registry_before
+        assert index_path.read_text(encoding="utf-8") == index_before
+
+        scoped_payload, scoped_code = run_quota(
+            root,
+            registry_path,
+            runtime,
+            "spend-slot",
+            "--goal-id",
+            "near-limit-half",
+            "--slots",
+            "1",
+            "--source",
+            "heartbeat",
+            "--execute",
+            "--agent-id",
+            fixture.SCOPED_AGENT_ID,
+            "--scan-path",
+            str(project),
+        )
+        assert scoped_code == 0, scoped_payload
+        assert scoped_payload["ok"] is True, scoped_payload
+        assert scoped_payload["appended"] is True, scoped_payload
+        assert scoped_payload["agent_id"] == fixture.SCOPED_AGENT_ID, scoped_payload
+
+    print("quota-spend-agent-identity-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -7443,23 +7443,6 @@ def build_quota_slot_preview(
         agent_id=agent_id,
         available_capabilities=available_capabilities,
     )
-    if before.get("effective_action") == "automation_prompt_upgrade_required" and not safe_requested_agent_id:
-        return {
-            "ok": False,
-            "mode": "spend-slot",
-            "dry_run": True,
-            "goal_id": safe_goal_id,
-            "slots": safe_slots,
-            "agent_id": None,
-            "appended": False,
-            "registry_mutated": False,
-            "reason": (
-                "quota spend-slot requires --agent-id for registered multi-agent goals; "
-                "rerun quota should-run and spend-slot with the same registered agent id"
-            ),
-            "before": before,
-            "after": None,
-        }
     safe_bypass_spend = (
         (
             before.get("state") == "operator_gate"
@@ -7507,6 +7490,7 @@ def build_quota_slot_preview(
             not before.get("should_run")
             or before.get("effective_action") == "external_evidence_observe"
         )
+        and before.get("effective_action") != "automation_prompt_upgrade_required"
         and not safe_bypass_spend
         and str(before.get("state") or "") in {"waiting", "focus_wait", "operator_gate", "eligible"}
     )
@@ -7529,7 +7513,6 @@ def build_quota_slot_preview(
             "before": before,
             "after": None,
         }
-
     before_quota = before.get("quota") if isinstance(before.get("quota"), dict) else {}
     if not before_quota:
         return {


### PR DESCRIPTION
## Summary
- keep the quota spend-slot identity guard fail-closed without growing the oversized quota module
- move the registered-agent spend guard into a thin focused smoke instead of the large quota-plan smoke
- update the project-agent adoption smoke for the current controller-gate contract: gate approval plus open user todo remains blocked until the todo is explicitly completed

## Validation
- PYTHONPATH="/private/tmp/loopx-product-capability-heartbeat-20260703T2239" python3 examples/quota-spend-agent-identity-smoke.py
- PYTHONPATH="/private/tmp/loopx-product-capability-heartbeat-20260703T2239" python3 examples/quota-plan-smoke.py
- PYTHONPATH="/private/tmp/loopx-product-capability-heartbeat-20260703T2239" python3 examples/project-agent-adoption-smoke.py
- PYTHONPATH="/private/tmp/loopx-product-capability-heartbeat-20260703T2239" python3 examples/repo-python-line-budget-smoke.py
- PYTHONPATH="/private/tmp/loopx-product-capability-heartbeat-20260703T2239" python3 -m loopx.cli --format json check --scan-path loopx/quota.py --scan-path examples/quota-plan-smoke.py --scan-path examples/quota-spend-agent-identity-smoke.py --scan-path examples/project-agent-adoption-smoke.py
- PYTHONPATH="/private/tmp/loopx-product-capability-heartbeat-20260703T2239" python3 -m loopx.cli canary smoke-suite --format json --timeout-seconds 180 [34-script public-entry batch]: ok=true, 34/34 executed, 0 failures, 0 timeouts, 0 tracked side effects