### PR TITLE
quota: isolate autonomous replan decision plane

### DIFF
--- a/docs/product/core-control-plane/rule-seam-map.md
+++ b/docs/product/core-control-plane/rule-seam-map.md
@@ -34,6 +34,7 @@ private evidence migration, production actions, or public first-screen copy.
 | Work-lane policy | `_work_lane_contract` | Pure policy module that chooses lane, obligation, monitor policy, and reason codes from compact status inputs. | Parity snapshot for advancement, due monitor, external evidence, and quiet skip cases. |
 | Capability and boundary gates | `_capability_gate`, `_side_agent_workspace_guard`, `_automation_prompt_upgrade` | Gate evaluators that return typed decisions without mutating payloads. | Existing quota contract fields and workspace guard failure mode remain stable. |
 | Agent-lane selection | `_agent_lane_next_action`, `_agent_lane_frontier_hint` | Agent-scoped selector over normalized todo projections. | Current-agent claimed todos outrank unrelated agents; frontier hints stay diagnostic when no runnable candidate exists. |
+| Goal frontier and replan decision | `loopx.policies.goal_frontier`, `build_quota_should_run` adapter | Goal-frontier policy owns completion/replan projection; quota only selects the resulting interaction mode. | Required autonomous replan is decided before monitor quiet or agent-scope wait classification, without growing per-agent vision logic inside quota. |
 | Quota plan and should-run assembly | `build_quota_plan`, `build_quota_should_run` | Thin orchestration layer that merges status, quota accounting, gates, and policy outputs. | `quota should-run` JSON field names and interaction contract stay compatible. |
 | User/agent/CLI split | `_protocol_action_packet`, `_interaction_contract` | Protocol packet builder with no scheduler or writeback side effects. | Operator gate vs bounded delivery payloads keep the same action_required and must_attempt meanings. |
 | Scheduler policy | `_scheduler_hint` wrapper plus `loopx/policies/scheduler_hint.py` | Pure scheduler-hint builder fed by final decision state. | RRULE, reset token, and no-spend cadence fields stay stable for Codex App and local loops. |
@@ -82,6 +83,9 @@ private evidence migration, production actions, or public first-screen copy.
 - `goal_route_hint` may summarize current, other-agent, and unclaimed lane
   signals for hosts, but it is read-only advisory projection and must preserve
   shared `## Next Action`.
+- `goal_frontier_projection` is the small per-goal completion/replan view used
+  before lane-local quiet/wait decisions; keep its policy in
+  `loopx.policies.goal_frontier` rather than expanding `quota.py`.
 - Monitor routing is attribute based, not name based:
   `task_class=continuous_monitor` plus due metadata defines due monitor work,
   while `waiting_on=external_evidence` or

--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -645,6 +645,12 @@ synthesis that says whether the current lane should run, claim, wait, or
 reassign while preserving `## Next Action` as durable goal-level guidance. It
 is an advisory routing hint, not a writeback instruction and not a replacement
 for `agent_todo_summary`.
+When projected, `goal_frontier_projection.schema_version =
+goal_frontier_projection_v0` is the per-goal progress/frontier view used before
+lane-local quiet or wait decisions. Its `autonomous_replan_decision` says that a
+required replan must be selected independently of `monitor_quiet_skip` or
+`agent_scope_wait`; the policy lives in `loopx.policies.goal_frontier`, while
+quota only wires the selected mode into `interaction_contract`.
 If the active-state and latest-run actions differ,
 `next_action_projection_warning` asks the executor to explicitly write back the
 intended durable route with a primary goal-scope `refresh-state --next-action`

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1249,6 +1249,13 @@ todos remain visible, as long as the selected slice stays outside private,
 destructive, production, or owner-only authority and honors `stop_condition`.
 This is intended to keep monitor-only work from consuming the primary
 executable backlog, not to bypass real gates.
+`quota should-run` and `status --agent-id` may also expose
+`goal_frontier_projection.schema_version=goal_frontier_projection_v0`. This
+projection is owned by `loopx.policies.goal_frontier`: it is a compact per-goal
+progress/frontier view, not another quota sub-state. When it contains
+`autonomous_replan_decision`, that decision is made before lane-local
+`monitor_quiet_skip`, `agent_scope_wait`, or `agent_scope_exhausted` projection,
+so those local no-candidate states cannot mask a required bounded replan.
 The payload includes `interaction_contract.schema_version =
 loopx_interaction_contract_v0`, which is the primary user/agent/CLI
 protocol for a selected goal. It groups the current turn into a stable

--- a/examples/quota-replan-decision-plane-smoke.py
+++ b/examples/quota-replan-decision-plane-smoke.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Smoke-test autonomous replan isolation from local lane quiet/wait state."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.quota import build_quota_should_run, render_quota_should_run_markdown  # noqa: E402
+from loopx.status import compact_todo_group  # noqa: E402
+
+
+GOAL_ID = "replan-decision-plane-fixture"
+PRIMARY_AGENT = "codex-main-control"
+SIDE_AGENT = "codex-side-bypass"
+FUTURE_DUE_AT = "2999-01-01T00:00:00+00:00"
+
+
+REPLAN_OBLIGATION = {
+    "schema_version": "autonomous_replan_obligation_v0",
+    "required": True,
+    "stall_threshold": 2,
+    "trigger_count": 1,
+    "triggers": [{"kind": "periodic_review_due", "source": "fixture"}],
+    "next_validation_command": "python3 examples/quota-replan-decision-plane-smoke.py",
+    "stop_condition": "stop after one bounded replan slice writes back a concrete frontier delta",
+}
+
+
+def monitor_item() -> dict:
+    return {
+        "index": 1,
+        "todo_id": "todo_monitor_wait",
+        "text": "[P1-monitor] Monitor a fixture signal only when material transition appears.",
+        "role": "agent",
+        "status": "open",
+        "priority": "P1",
+        "task_class": "continuous_monitor",
+        "action_kind": "monitor",
+        "claimed_by": SIDE_AGENT,
+        "target_key": "fixture-signal",
+        "cadence": "15m",
+        "next_due_at": FUTURE_DUE_AT,
+    }
+
+
+def primary_claimed_advancement() -> dict:
+    return {
+        "index": 1,
+        "todo_id": "todo_primary_owned",
+        "text": "[P0] Primary agent owns the next visible advancement slice.",
+        "role": "agent",
+        "status": "open",
+        "priority": "P0",
+        "task_class": "advancement_task",
+        "claimed_by": PRIMARY_AGENT,
+    }
+
+
+def status_payload(agent_todo_items: list[dict]) -> dict:
+    agent_todos = compact_todo_group(
+        agent_todo_items,
+        source_section="Agent Todo",
+        role="agent",
+    )
+    assert agent_todos is not None
+    return {
+        "ok": True,
+        "attention_queue": {
+            "items": [
+                {
+                    "goal_id": GOAL_ID,
+                    "status": "active",
+                    "waiting_on": "",
+                    "severity": "active",
+                    "source": "active_state",
+                    "recommended_action": "Observe the fixture signal; no material transition is available.",
+                    "quota": {
+                        "compute": 1.0,
+                        "window_hours": 24,
+                        "slot_minutes": 1,
+                        "allowed_slots": 10,
+                        "spent_slots": 0,
+                        "state": "eligible",
+                        "reason": "eligible fixture",
+                    },
+                    "project_asset": {
+                        "next_action": "Observe the fixture signal; no material transition is available.",
+                        "agent_todos": agent_todos,
+                        "autonomous_replan_obligation": REPLAN_OBLIGATION,
+                    },
+                }
+            ]
+        },
+        "run_history": {
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "registry_member": True,
+                    "status": "active",
+                    "adapter_kind": "harness_self_improvement",
+                    "adapter_status": "connected-read-only",
+                    "quota": {
+                        "compute": 1.0,
+                        "window_hours": 24,
+                        "slot_minutes": 1,
+                        "allowed_slots": 10,
+                    },
+                    "coordination": {
+                        "registered_agents": [PRIMARY_AGENT, SIDE_AGENT],
+                        "primary_agent": PRIMARY_AGENT,
+                    },
+                }
+            ]
+        },
+    }
+
+
+def assert_replan_beats_monitor_quiet_skip() -> None:
+    guard = build_quota_should_run(
+        status_payload([monitor_item()]),
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+    )
+    assert guard["decision"] == "autonomous_replan_required", guard
+    assert guard["effective_action"] == "autonomous_replan_required", guard
+    assert guard["should_run"] is True, guard
+    assert guard["heartbeat_recommendation"]["recommended_mode"] == "autonomous_replan_required", guard
+    assert guard["execution_obligation"]["kind"] == "autonomous_replan_required", guard
+    assert guard["interaction_contract"]["mode"] == "autonomous_replan", guard
+    assert guard["interaction_contract"]["agent_channel"]["must_attempt"] is True, guard
+    assert guard["goal_frontier_projection"]["replan_required"] is True, guard
+    assert guard["goal_frontier_projection"]["monitor_only_lanes"]["present"] is True, guard
+    assert guard["autonomous_replan_decision"]["decision_plane"] == (
+        "goal_frontier_before_lane_quiet_or_agent_scope_wait"
+    ), guard
+    assert "monitor_quiet_skip" in guard["autonomous_replan_decision"]["not_disturbed_by"], guard
+    markdown = render_quota_should_run_markdown(guard)
+    assert "goal_frontier_projection: replan_required=True" in markdown, markdown
+    assert "autonomous_replan_decision: decision=autonomous_replan_required" in markdown, markdown
+
+
+def assert_replan_beats_agent_scope_wait() -> None:
+    guard = build_quota_should_run(
+        status_payload([primary_claimed_advancement()]),
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+    )
+    assert guard["decision"] == "autonomous_replan_required", guard
+    assert guard["effective_action"] == "autonomous_replan_required", guard
+    assert guard["should_run"] is True, guard
+    assert guard["heartbeat_recommendation"]["recommended_mode"] == "autonomous_replan_required", guard
+    assert guard["execution_obligation"]["kind"] == "autonomous_replan_required", guard
+    assert guard["interaction_contract"]["mode"] == "autonomous_replan", guard
+    assert "agent_scope_frontier" not in guard, guard
+    frontier = guard["goal_frontier_projection"]["remaining_advancement_frontier"]
+    assert frontier["current_agent_claimed_advancement_count"] == 0, guard
+    assert frontier["unclaimed_advancement_count"] == 0, guard
+    assert frontier["other_agent_claimed_advancement_count"] == 1, guard
+    assert "agent_scope_wait" in guard["autonomous_replan_decision"]["not_disturbed_by"], guard
+
+
+def main() -> None:
+    assert_replan_beats_monitor_quiet_skip()
+    assert_replan_beats_agent_scope_wait()
+    print("quota-replan-decision-plane-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/cli_commands/status.py
+++ b/loopx/cli_commands/status.py
@@ -426,6 +426,7 @@ def attach_agent_lane_next_actions(payload: dict[str, object], *, agent_id: str)
     attached = 0
     frontier_attached = 0
     hint_attached = 0
+    goal_frontier_attached = 0
     member_attached = 0
     for item in items:
         if not isinstance(item, dict):
@@ -460,6 +461,13 @@ def attach_agent_lane_next_actions(payload: dict[str, object], *, agent_id: str)
                 project_asset["agent_lane_frontier_hint"] = frontier_hint
             hint_attached += 1
             changed = True
+        goal_frontier = guard.get("goal_frontier_projection")
+        if isinstance(goal_frontier, dict):
+            item["goal_frontier_projection"] = goal_frontier
+            if isinstance(project_asset, dict):
+                project_asset["goal_frontier_projection"] = goal_frontier
+            goal_frontier_attached += 1
+            changed = True
         agent_member = _build_agent_member_projection(
             item,
             guard=guard,
@@ -473,13 +481,14 @@ def attach_agent_lane_next_actions(payload: dict[str, object], *, agent_id: str)
             changed = True
         if not changed:
             continue
-    if attached or frontier_attached or hint_attached or member_attached:
+    if attached or frontier_attached or hint_attached or goal_frontier_attached or member_attached:
         payload["agent_lane_next_action_projection"] = {
             "schema_version": "agent_lane_next_action_projection_v0",
             "agent_id": safe_agent_id,
             "attached_count": attached,
             "frontier_attached_count": frontier_attached,
             "frontier_hint_attached_count": hint_attached,
+            "goal_frontier_attached_count": goal_frontier_attached,
             "agent_member_attached_count": member_attached,
             "preserves_goal_next_action": True,
         }

--- a/loopx/diagnose.py
+++ b/loopx/diagnose.py
@@ -199,6 +199,8 @@ def _compact_quota_signals(quota: dict[str, Any]) -> dict[str, Any]:
         "agent_lane_next_action",
         "agent_scoped_user_gate_override",
         "agent_scope_frontier",
+        "goal_frontier_projection",
+        "autonomous_replan_decision",
     )
     return {key: quota.get(key) for key in keys if key in quota}
 

--- a/loopx/policies/goal_frontier.py
+++ b/loopx/policies/goal_frontier.py
@@ -1,0 +1,304 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+GOAL_FRONTIER_PROJECTION_SCHEMA_VERSION = "goal_frontier_projection_v0"
+AUTONOMOUS_REPLAN_DECISION_SCHEMA_VERSION = "autonomous_replan_decision_v0"
+AUTONOMOUS_REPLAN_REQUIRED_MODE = "autonomous_replan_required"
+TODO_TASK_CLASS_ADVANCEMENT = "advancement_task"
+TODO_TASK_CLASS_MONITOR = "continuous_monitor"
+
+
+def safe_non_negative_int(value: Any) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def select_autonomous_replan_obligation(
+    item: dict[str, Any],
+    project_asset: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    project_asset = project_asset if isinstance(project_asset, dict) else {}
+    value = item.get("autonomous_replan_obligation")
+    if isinstance(value, dict):
+        return value
+    value = project_asset.get("autonomous_replan_obligation")
+    if isinstance(value, dict):
+        return value
+    return None
+
+
+def autonomous_replan_is_required(replan_obligation: dict[str, Any] | None) -> bool:
+    return bool(replan_obligation and replan_obligation.get("required"))
+
+
+def autonomous_replan_decision_allowed(
+    *,
+    replan_obligation: dict[str, Any] | None,
+    plan_ok: bool,
+    workspace_blocked: bool,
+    automation_prompt_upgrade_required: bool,
+) -> bool:
+    return bool(
+        autonomous_replan_is_required(replan_obligation)
+        and plan_ok
+        and not workspace_blocked
+        and not automation_prompt_upgrade_required
+    )
+
+
+def _open_todo_count(summary: dict[str, Any] | None) -> int:
+    if not isinstance(summary, dict):
+        return 0
+    return safe_non_negative_int(summary.get("open_count"))
+
+
+def _todo_item_is_actionable_open(item: dict[str, Any]) -> bool:
+    if item.get("done") is True:
+        return False
+    status = str(item.get("status") or "open").strip().lower()
+    return status in {"", "open", "todo", "active", "pending"}
+
+
+def _todo_task_class(item: dict[str, Any]) -> str:
+    return str(item.get("task_class") or "").strip()
+
+
+def _count_advancement_items(items: Any, *, claimed_by: str | None = None) -> int:
+    if not isinstance(items, list):
+        return 0
+    count = 0
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if not _todo_item_is_actionable_open(item):
+            continue
+        if _todo_task_class(item) != TODO_TASK_CLASS_ADVANCEMENT:
+            continue
+        item_claimed_by = str(item.get("claimed_by") or "").strip()
+        if claimed_by == "__unclaimed__":
+            if item_claimed_by:
+                continue
+        elif claimed_by is not None and item_claimed_by != claimed_by:
+            continue
+        count += 1
+    return count
+
+
+def _summary_task_counts(summary: dict[str, Any] | None) -> dict[str, int]:
+    open_count = _open_todo_count(summary)
+    if not isinstance(summary, dict):
+        return {"open": open_count, "advancement": 0, "monitor": 0, "monitor_due": 0}
+    executable = summary.get("executable_backlog_items")
+    monitor_open = summary.get("monitor_open_items")
+    advancement_count = (
+        _count_advancement_items(executable)
+        if isinstance(executable, list)
+        else safe_non_negative_int(summary.get("claimed_advancement_open_count"))
+        + len(
+            [
+                item
+                for item in (summary.get("unclaimed_priority_open_items") or [])
+                if isinstance(item, dict)
+                and _todo_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
+            ]
+        )
+    )
+    monitor_count = (
+        len(
+            [
+                item
+                for item in monitor_open
+                if isinstance(item, dict)
+                and _todo_item_is_actionable_open(item)
+                and _todo_task_class(item) == TODO_TASK_CLASS_MONITOR
+            ]
+        )
+        if isinstance(monitor_open, list)
+        else safe_non_negative_int(summary.get("claimed_monitor_open_count"))
+    )
+    return {
+        "open": open_count,
+        "advancement": advancement_count,
+        "monitor": monitor_count,
+        "monitor_due": safe_non_negative_int(summary.get("monitor_due_count")),
+    }
+
+
+def build_goal_frontier_projection_from_summaries(
+    *,
+    goal_id: str,
+    agent_id: str | None,
+    user_todo_summary: dict[str, Any] | None,
+    agent_todo_summary: dict[str, Any] | None,
+    work_lane_contract: dict[str, Any] | None,
+    replan_obligation: dict[str, Any] | None,
+) -> dict[str, Any]:
+    user_counts = _summary_task_counts(user_todo_summary)
+    agent_counts = _summary_task_counts(agent_todo_summary)
+    current_agent_advancement_count = (
+        safe_non_negative_int(agent_todo_summary.get("current_agent_claimed_advancement_count"))
+        if isinstance(agent_todo_summary, dict)
+        else 0
+    )
+    unclaimed_advancement_count = (
+        _count_advancement_items(
+            agent_todo_summary.get("unclaimed_priority_open_items"),
+            claimed_by="__unclaimed__",
+        )
+        if isinstance(agent_todo_summary, dict)
+        else 0
+    )
+    other_agent_claimed_items: Any = None
+    if isinstance(agent_todo_summary, dict):
+        executable_items = agent_todo_summary.get("executable_backlog_items")
+        if isinstance(executable_items, list):
+            if agent_id:
+                current_agent_advancement_count = max(
+                    current_agent_advancement_count,
+                    _count_advancement_items(executable_items, claimed_by=agent_id),
+                )
+            unclaimed_advancement_count = max(
+                unclaimed_advancement_count,
+                _count_advancement_items(executable_items, claimed_by="__unclaimed__"),
+            )
+        claim_scope = (
+            agent_todo_summary.get("claim_scope")
+            if isinstance(agent_todo_summary.get("claim_scope"), dict)
+            else {}
+        )
+        other_agent_claimed_items = claim_scope.get("other_agent_claimed_items")
+    monitor_only_lane = bool(
+        work_lane_contract
+        and work_lane_contract.get("lane") == TODO_TASK_CLASS_MONITOR
+        and work_lane_contract.get("must_attempt_work") is False
+    )
+    return build_goal_frontier_projection(
+        goal_id=goal_id,
+        agent_id=agent_id,
+        user_counts=user_counts,
+        agent_counts=agent_counts,
+        current_agent_claimed_advancement_count=current_agent_advancement_count,
+        unclaimed_advancement_count=unclaimed_advancement_count,
+        other_agent_claimed_advancement_count=_count_advancement_items(
+            other_agent_claimed_items
+        ),
+        monitor_only_lane=monitor_only_lane,
+        replan_obligation=replan_obligation,
+    )
+
+
+def compact_replan_obligation(replan_obligation: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "schema_version": replan_obligation.get("schema_version"),
+        "stall_threshold": replan_obligation.get("stall_threshold"),
+        "trigger_count": replan_obligation.get("trigger_count"),
+        "triggers": replan_obligation.get("triggers") or [],
+        "next_validation_command": replan_obligation.get("next_validation_command"),
+        "stop_condition": replan_obligation.get("stop_condition"),
+    }
+
+
+def build_autonomous_replan_recommendation(
+    replan_obligation: dict[str, Any],
+    *,
+    reason: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "recommended_mode": AUTONOMOUS_REPLAN_REQUIRED_MODE,
+        "notify": "DONT_NOTIFY",
+        "replan_obligation": compact_replan_obligation(replan_obligation),
+        "spend_policy": (
+            "append exactly one heartbeat spend only after executing the selected "
+            "replan slice, validating it, and writing back todo split/add/retire state"
+        ),
+        "reason": reason
+        or (
+            "status exposes an autonomous replan obligation; advance the goal-level "
+            "planning-trigger slice before monitor-only or agent-scope wait classification"
+        ),
+    }
+
+
+def build_autonomous_replan_decision(replan_obligation: dict[str, Any]) -> dict[str, Any]:
+    triggers = (
+        replan_obligation.get("triggers")
+        if isinstance(replan_obligation.get("triggers"), list)
+        else []
+    )
+    return {
+        "schema_version": AUTONOMOUS_REPLAN_DECISION_SCHEMA_VERSION,
+        "required": True,
+        "decision": AUTONOMOUS_REPLAN_REQUIRED_MODE,
+        "decision_plane": "goal_frontier_before_lane_quiet_or_agent_scope_wait",
+        "not_disturbed_by": [
+            "monitor_quiet_skip",
+            "agent_scope_wait",
+            "agent_scope_exhausted",
+        ],
+        "trigger_count": safe_non_negative_int(replan_obligation.get("trigger_count")),
+        "triggers": [
+            trigger.get("kind")
+            for trigger in triggers
+            if isinstance(trigger, dict) and trigger.get("kind")
+        ],
+    }
+
+
+def build_goal_frontier_projection(
+    *,
+    goal_id: str,
+    agent_id: str | None,
+    user_counts: dict[str, int],
+    agent_counts: dict[str, int],
+    current_agent_claimed_advancement_count: int,
+    unclaimed_advancement_count: int,
+    other_agent_claimed_advancement_count: int,
+    monitor_only_lane: bool,
+    replan_obligation: dict[str, Any] | None,
+) -> dict[str, Any]:
+    replan_required = autonomous_replan_is_required(replan_obligation)
+    blockers: list[str] = []
+    if monitor_only_lane:
+        blockers.append("monitor_only_lane")
+    if (
+        current_agent_claimed_advancement_count == 0
+        and unclaimed_advancement_count == 0
+        and other_agent_claimed_advancement_count > 0
+    ):
+        blockers.append("other_agent_claimed_advancement")
+    if replan_required:
+        blockers.append("autonomous_replan_obligation")
+
+    projection: dict[str, Any] = {
+        "schema_version": GOAL_FRONTIER_PROJECTION_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "agent_id": agent_id,
+        "source": "quota_should_run",
+        "normalized_progress": {
+            "user_open_count": user_counts.get("open", 0),
+            "agent_open_count": agent_counts.get("open", 0),
+            "agent_advancement_open_count": agent_counts.get("advancement", 0),
+            "agent_monitor_open_count": agent_counts.get("monitor", 0),
+            "agent_monitor_due_count": agent_counts.get("monitor_due", 0),
+        },
+        "remaining_advancement_frontier": {
+            "current_agent_claimed_advancement_count": current_agent_claimed_advancement_count,
+            "unclaimed_advancement_count": unclaimed_advancement_count,
+            "other_agent_claimed_advancement_count": other_agent_claimed_advancement_count,
+        },
+        "monitor_only_lanes": {
+            "present": monitor_only_lane,
+            "quiet_until_material_transition": monitor_only_lane,
+        },
+        "autonomy_blockers": blockers,
+        "replan_required": replan_required,
+    }
+    if replan_required and isinstance(replan_obligation, dict):
+        projection["autonomous_replan_decision"] = build_autonomous_replan_decision(
+            replan_obligation
+        )
+    return projection

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -33,6 +33,13 @@ from .execution_profile import (
 from .long_task_cadence import long_task_cadence_hint_summary
 from .orchestration import compact_orchestration_policy, orchestration_policy_summary
 from .policies.execution_obligation import build_execution_obligation
+from .policies.goal_frontier import (
+    AUTONOMOUS_REPLAN_REQUIRED_MODE,
+    autonomous_replan_decision_allowed,
+    build_autonomous_replan_recommendation,
+    build_goal_frontier_projection_from_summaries,
+    select_autonomous_replan_obligation,
+)
 from .policies.goal_route_hint import build_goal_route_hint
 from .policies.monitor_todo import (
     monitor_todo_expires_at,
@@ -4336,7 +4343,7 @@ def _interaction_mode(payload: dict[str, Any]) -> str:
         return "user_action_required"
     if kind == "external_evidence_observation_required":
         return "external_evidence_observation"
-    if kind == "autonomous_replan_required":
+    if kind == AUTONOMOUS_REPLAN_REQUIRED_MODE:
         return "autonomous_replan"
     agent_scope_action = _agent_scope_frontier_action(effective_action)
     if agent_scope_action is not None:
@@ -4734,7 +4741,7 @@ def _automation_liveness(payload: dict[str, Any]) -> dict[str, Any]:
             ),
             "next_trigger": (
                 "material monitor transition, regression, concrete blocker, or "
-                "autonomous_replan_required"
+                f"{AUTONOMOUS_REPLAN_REQUIRED_MODE}"
             ),
             "spend_policy": "no quota spend for unchanged monitor-only polls",
         }
@@ -4773,7 +4780,7 @@ def _automation_liveness(payload: dict[str, Any]) -> dict[str, Any]:
             ),
             "spend_policy": "no quota spend for agent-scoped no-candidate checks",
         }
-    if must_attempt_work or recommended_mode == "autonomous_replan_required":
+    if must_attempt_work or recommended_mode == AUTONOMOUS_REPLAN_REQUIRED_MODE:
         return {
             **base,
             "automation_action": "execute_bounded_work",
@@ -5905,13 +5912,7 @@ def _heartbeat_recommendation(
     lifecycle_flags = item.get("lifecycle_flags")
     quota = item.get("quota") if isinstance(item.get("quota"), dict) else {}
     project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
-    replan_obligation = (
-        item.get("autonomous_replan_obligation")
-        if isinstance(item.get("autonomous_replan_obligation"), dict)
-        else project_asset.get("autonomous_replan_obligation")
-        if isinstance(project_asset.get("autonomous_replan_obligation"), dict)
-        else None
-    )
+    replan_obligation = select_autonomous_replan_obligation(item, project_asset)
     has_user_todos = _open_todo_count(user_todo_summary) > 0
     has_agent_todos = _open_todo_count(agent_todo_summary) > 0
     work_lane_contract = work_lane_contract or _work_lane_contract(item, agent_todo_summary=agent_todo_summary)
@@ -5939,6 +5940,11 @@ def _heartbeat_recommendation(
             "spend_policy": stall_self_repair.get("spend_policy") or base["spend_policy"],
             "reason": stall_self_repair.get("reason") or "control-plane stall requires bounded repair",
             "repair_focus": stall_self_repair.get("repair_focus"),
+        }
+    if should_run and replan_obligation and replan_obligation.get("required"):
+        return {
+            **base,
+            **build_autonomous_replan_recommendation(replan_obligation),
         }
     if state in {"focus_wait", "waiting"} and has_user_todos:
         return {
@@ -5989,29 +5995,6 @@ def _heartbeat_recommendation(
             "recommended_mode": "quota_skip",
             "reason": f"quota state is {state}; skip delivery compute",
         }
-    if replan_obligation and replan_obligation.get("required"):
-        payload = {
-            **base,
-            "recommended_mode": "autonomous_replan_required",
-            "notify": "DONT_NOTIFY",
-            "replan_obligation": {
-                "schema_version": replan_obligation.get("schema_version"),
-                "stall_threshold": replan_obligation.get("stall_threshold"),
-                "trigger_count": replan_obligation.get("trigger_count"),
-                "triggers": replan_obligation.get("triggers") or [],
-                "next_validation_command": replan_obligation.get("next_validation_command"),
-                "stop_condition": replan_obligation.get("stop_condition"),
-            },
-            "spend_policy": (
-                "append exactly one heartbeat spend only after executing the selected "
-                "replan slice, validating it, and writing back todo split/add/retire state"
-            ),
-            "reason": (
-                "status exposes an autonomous replan obligation; advance the "
-                "planning-trigger slice before another monitor-only or repeated action"
-            ),
-        }
-        return payload
 
     if item.get("agent_command"):
         return {
@@ -6726,6 +6709,20 @@ def build_quota_should_run(
         )
         self_repair_allowed = bool(stall_self_repair and stall_self_repair.get("allowed"))
         work_lane_contract = _work_lane_contract(item, agent_todo_summary=agent_todo_summary)
+        replan_obligation = select_autonomous_replan_obligation(item, project_asset)
+        agent_frontier_id = (
+            normalize_todo_claimed_by(agent_identity.get("agent_id"))
+            if isinstance(agent_identity, dict)
+            else None
+        )
+        goal_frontier_projection = build_goal_frontier_projection_from_summaries(
+            goal_id=safe_goal_id,
+            agent_id=agent_frontier_id,
+            user_todo_summary=user_todo_summary,
+            agent_todo_summary=agent_todo_summary,
+            work_lane_contract=work_lane_contract,
+            replan_obligation=replan_obligation,
+        )
         capability_gate = _capability_gate(
             agent_todo_summary,
             available_capabilities=_available_capabilities(available_capabilities),
@@ -6805,6 +6802,21 @@ def build_quota_should_run(
             state=state,
             quota=quota,
         )
+        replan_decision_allowed = autonomous_replan_decision_allowed(
+            replan_obligation=replan_obligation,
+            plan_ok=bool(plan.get("ok")),
+            workspace_blocked=bool(workspace_guard),
+            automation_prompt_upgrade_required=automation_prompt_upgrade_required,
+        )
+        if replan_decision_allowed:
+            normal_delivery_allowed = False
+            recovery_allowed = False
+            should_run = True
+            effective_action = AUTONOMOUS_REPLAN_REQUIRED_MODE
+            reason = (
+                "autonomous replan obligation is selected before monitor quiet "
+                "or agent-scope wait classification"
+            )
         if automation_prompt_upgrade_required:
             should_run = False
             effective_action = "automation_prompt_upgrade_required"
@@ -6900,7 +6912,8 @@ def build_quota_should_run(
             effective_action = "external_evidence_observe"
             reason = "external evidence monitor requires read-only observation before quiet no-op"
         monitor_quiet_skip = (
-            normal_delivery_allowed
+            not replan_decision_allowed
+            and normal_delivery_allowed
             and not recovery_allowed
             and not self_repair_allowed
             and isinstance(work_lane_contract, dict)
@@ -6947,6 +6960,12 @@ def build_quota_should_run(
                 or automation_prompt_upgrade.get("reason")
                 or selected_recommended_action
             )
+        if replan_decision_allowed:
+            selected_recommended_action = (
+                str(replan_obligation.get("recommended_action") or "").strip()
+                or str(replan_obligation.get("stop_condition") or "").strip()
+                or "Run one bounded autonomous replan slice and write back the selected todo/frontier changes."
+            )
         scoped_user_gate_fallback = _scoped_user_gate_fallback(
             user_todo_summary,
             agent_todo_summary,
@@ -6954,7 +6973,7 @@ def build_quota_should_run(
             allow_unrelated_gate=bool(quota.get("safe_bypass_allowed")),
         )
         agent_lane_next_action = None
-        if not due_monitor_attempt:
+        if not due_monitor_attempt and not replan_decision_allowed:
             agent_lane_next_action = _agent_lane_next_action(
                 agent_identity=agent_identity,
                 agent_todo_summary=agent_todo_summary,
@@ -6973,24 +6992,28 @@ def build_quota_should_run(
                 selected_recommended_action,
                 agent_lane_next_action=agent_lane_next_action,
             )
-        agent_scope_frontier = _agent_scope_no_candidate_frontier(
-            agent_identity=agent_identity,
-            agent_todo_summary=agent_todo_summary,
-            agent_lane_next_action=agent_lane_next_action,
-            work_lane_contract=work_lane_contract,
-            candidate_should_run=bool(should_run and normal_delivery_allowed),
-        )
-        agent_lane_frontier_hint = _agent_lane_frontier_hint(
-            goal_id=safe_goal_id,
-            agent_identity=agent_identity,
-            agent_todo_summary=agent_todo_summary,
-            agent_lane_next_action=agent_lane_next_action,
-            agent_scope_frontier=agent_scope_frontier,
-            work_lane_contract=work_lane_contract,
-        )
+        agent_scope_frontier = None
+        if not replan_decision_allowed:
+            agent_scope_frontier = _agent_scope_no_candidate_frontier(
+                agent_identity=agent_identity,
+                agent_todo_summary=agent_todo_summary,
+                agent_lane_next_action=agent_lane_next_action,
+                work_lane_contract=work_lane_contract,
+                candidate_should_run=bool(should_run and normal_delivery_allowed),
+            )
+        agent_lane_frontier_hint = None
+        if not replan_decision_allowed:
+            agent_lane_frontier_hint = _agent_lane_frontier_hint(
+                goal_id=safe_goal_id,
+                agent_identity=agent_identity,
+                agent_todo_summary=agent_todo_summary,
+                agent_lane_next_action=agent_lane_next_action,
+                agent_scope_frontier=agent_scope_frontier,
+                work_lane_contract=work_lane_contract,
+            )
         if agent_scope_frontier and agent_lane_frontier_hint:
             agent_scope_frontier["frontier_hint"] = agent_lane_frontier_hint
-        if agent_scope_frontier:
+        if agent_scope_frontier and not replan_decision_allowed:
             frontier_action = str(agent_scope_frontier.get("effective_action") or "")
             successor_replan_required = (
                 frontier_action == AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value
@@ -7054,7 +7077,9 @@ def build_quota_should_run(
             "mode": "should-run",
             "goal_id": safe_goal_id,
             "decision": (
-                "run"
+                AUTONOMOUS_REPLAN_REQUIRED_MODE
+                if replan_decision_allowed
+                else "run"
                 if normal_delivery_allowed
                 else "observe"
                 if external_evidence_observation
@@ -7134,9 +7159,13 @@ def build_quota_should_run(
                 external_evidence_observation=external_evidence_observation,
             ),
             "goal_boundary": goal_boundary,
+            "goal_frontier_projection": goal_frontier_projection,
             "plan_summary": plan.get("summary"),
             "todo_write_hint": _todo_write_hint(safe_goal_id),
         }
+        autonomous_replan_decision = goal_frontier_projection.get("autonomous_replan_decision")
+        if isinstance(autonomous_replan_decision, dict):
+            payload["autonomous_replan_decision"] = autonomous_replan_decision
         if agent_identity:
             payload["agent_identity"] = agent_identity
         if agent_lane_next_action:
@@ -7202,7 +7231,7 @@ def build_quota_should_run(
                         or "no-work polling should ask the current open user todo"
                     )
                     payload["open_todo_notification_policy"] = "repeat_until_resolved"
-        if scoped_user_gate_fallback:
+        if scoped_user_gate_fallback and not replan_decision_allowed:
             payload["scoped_user_gate_fallback"] = scoped_user_gate_fallback
             payload["should_run"] = True
             if payload.get("decision") == "skip":
@@ -7291,13 +7320,6 @@ def build_quota_should_run(
         )
         if archive_warning:
             payload["completed_todo_archive_warning"] = archive_warning
-        replan_obligation = (
-            item.get("autonomous_replan_obligation")
-            if isinstance(item.get("autonomous_replan_obligation"), dict)
-            else project_asset.get("autonomous_replan_obligation")
-            if isinstance(project_asset.get("autonomous_replan_obligation"), dict)
-            else None
-        )
         if replan_obligation:
             payload["autonomous_replan_obligation"] = replan_obligation
         dreaming_proposal = (
@@ -9282,6 +9304,35 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
                 f"top_todo_id={first_candidate.get('todo_id')} "
                 f"route={first_candidate.get('route_id') or first_candidate.get('route_key') or ''}"
             )
+    goal_frontier = (
+        payload.get("goal_frontier_projection")
+        if isinstance(payload.get("goal_frontier_projection"), dict)
+        else {}
+    )
+    if goal_frontier:
+        remaining = (
+            goal_frontier.get("remaining_advancement_frontier")
+            if isinstance(goal_frontier.get("remaining_advancement_frontier"), dict)
+            else {}
+        )
+        lines.append(
+            "- goal_frontier_projection: "
+            f"replan_required={goal_frontier.get('replan_required')} "
+            f"current_agent_advancement={remaining.get('current_agent_claimed_advancement_count')} "
+            f"unclaimed_advancement={remaining.get('unclaimed_advancement_count')} "
+            f"other_agent_advancement={remaining.get('other_agent_claimed_advancement_count')}"
+        )
+    replan_decision = (
+        payload.get("autonomous_replan_decision")
+        if isinstance(payload.get("autonomous_replan_decision"), dict)
+        else {}
+    )
+    if replan_decision:
+        lines.append(
+            "- autonomous_replan_decision: "
+            f"decision={replan_decision.get('decision')} "
+            f"plane={replan_decision.get('decision_plane')}"
+        )
     automation_prompt_upgrade = (
         payload.get("automation_prompt_upgrade")
         if isinstance(payload.get("automation_prompt_upgrade"), dict)


### PR DESCRIPTION
## Summary
- Move goal-frontier and required autonomous-replan decision logic into `loopx.policies.goal_frontier` so `quota.py` remains a thin adapter/wiring layer.
- Select `autonomous_replan_required` before monitor quiet skip, agent-scope wait, or agent-scope exhausted projection can mask it.
- Expose `goal_frontier_projection` / `autonomous_replan_decision` through quota, status, diagnose, markdown, and public data-contract docs.

## Validation
- python3 -m py_compile loopx/quota.py loopx/policies/goal_frontier.py loopx/cli_commands/status.py loopx/diagnose.py examples/quota-replan-decision-plane-smoke.py
- python3 examples/quota-replan-decision-plane-smoke.py
- python3 examples/autonomous-replan-obligation-smoke.py
- python3 examples/monitor-scheduler-contract-smoke.py
- python3 examples/quota-agent-scoped-user-gate-smoke.py
- python3 examples/quota-cleared-blocker-successor-gate-smoke.py
- python3 examples/docs-governance-smoke.py
- python3 examples/interaction-pattern-catalog-smoke.py
- git diff --check origin/main...HEAD
- loopx check --scan-path docs/product/core-control-plane/rule-seam-map.md --scan-path docs/quota-allocation.md --scan-path docs/status-data-contract.md --scan-path loopx/policies/goal_frontier.py --scan-path loopx/quota.py --scan-path loopx/cli_commands/status.py --scan-path loopx/diagnose.py --scan-path examples/quota-replan-decision-plane-smoke.py

## Review note
This touches runtime quota behavior, so it should be reviewed rather than self-merged.