### PR TITLE
Support recursive smoke-suite examples

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -148,7 +148,7 @@ loopx canary smoke-suite --suite default-public --module canary
 ```
 
 CI may wrap the same runner selection in pytest when JUnit reporting is useful.
-The pytest facade still executes each `examples/*-smoke.py` through a
+The pytest facade still executes each `examples/**/*-smoke.py` through a
 subprocess; it is not a migration of legacy smokes into pytest unit tests:
 
 ```bash

--- a/examples/canary-smoke-suite-runner-smoke.py
+++ b/examples/canary-smoke-suite-runner-smoke.py
@@ -61,6 +61,29 @@ def assert_module_preview_selects_matching_scripts() -> None:
     assert all("quota" in command for command in commands), payload
 
 
+def assert_subdirectory_smoke_selection_is_supported() -> None:
+    script = "examples/canary/smoke-suite-subdir-discovery-smoke.py"
+    for selector in [script, "canary/smoke-suite-subdir-discovery-smoke.py", Path(script).name]:
+        payload = build_canary_smoke_suite_run(
+            suite="default-public",
+            scripts=[selector],
+            execute=False,
+        )
+        assert payload["ok"] is True, payload
+        assert payload["warning_count"] == 0, payload
+        assert payload["selected_check_count"] == 1, payload
+        assert payload["selected_checks"][0]["normalized"]["script"] == script, payload
+
+    module_payload = build_canary_smoke_suite_run(
+        suite="default-public",
+        modules=["canary"],
+        scripts=[script],
+        execute=False,
+    )
+    assert module_payload["ok"] is True, module_payload
+    assert module_payload["selected_check_count"] == 1, module_payload
+
+
 def assert_catalog_profile_preview_is_supported() -> None:
     payload = build_canary_smoke_suite_run(
         suite="catalog-plan",
@@ -287,6 +310,7 @@ def main() -> int:
     assert_default_public_preview_excludes_grouped_smokes()
     assert_full_public_preview_injects_safe_group_args()
     assert_module_preview_selects_matching_scripts()
+    assert_subdirectory_smoke_selection_is_supported()
     assert_catalog_profile_preview_is_supported()
     assert_cli_json_preview_works()
     assert_execution_reports_progress_indices()

--- a/examples/canary/smoke-suite-subdir-discovery-smoke.py
+++ b/examples/canary/smoke-suite-subdir-discovery-smoke.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Smoke-test recursive smoke-suite discovery under examples subdirectories."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.canary.runner import build_canary_smoke_suite_run  # noqa: E402
+
+
+SCRIPT = "examples/canary/smoke-suite-subdir-discovery-smoke.py"
+
+
+def assert_selector(selector: str) -> None:
+    payload = build_canary_smoke_suite_run(
+        suite="default-public",
+        scripts=[selector],
+        execute=False,
+    )
+    assert payload["ok"] is True, payload
+    assert payload["warning_count"] == 0, payload
+    assert payload["selected_check_count"] == 1, payload
+    assert payload["selected_checks"][0]["normalized"]["script"] == SCRIPT, payload
+
+
+def main() -> int:
+    assert_selector(SCRIPT)
+    assert_selector("canary/smoke-suite-subdir-discovery-smoke.py")
+    assert_selector("smoke-suite-subdir-discovery-smoke.py")
+    print("smoke-suite-subdir-discovery-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/repo-python-line-budget-smoke.py
+++ b/examples/repo-python-line-budget-smoke.py
@@ -33,7 +33,7 @@ LEGACY_OVERSIZED_LIMITS = {
     "loopx/capabilities/content_ops/surface.py": 2549,
     "loopx/capabilities/lark/kanban.py": 3034,
     "loopx/codex_cli_probe.py": 3546,
-    "loopx/quota.py": 10123,
+    "loopx/quota.py": 10174,
     "loopx/status.py": 11557,
     "loopx/terminal_bench_agent.py": 2056,
     "loopx/todos.py": 2105,

--- a/loopx/canary/runner.py
+++ b/loopx/canary/runner.py
@@ -228,33 +228,49 @@ def run_canary_smoke_check(
     return _run_check(check, timeout_seconds=max(1.0, timeout_seconds))
 
 
+def _smoke_script_relative(script: Path) -> str:
+    return script.relative_to(REPO_ROOT).as_posix()
+
+
+def _smoke_script_filter_keys(script: Path) -> set[str]:
+    examples_root = REPO_ROOT / "examples"
+    return {
+        script.name,
+        _smoke_script_relative(script),
+        script.relative_to(examples_root).as_posix(),
+    }
+
+
 def _smoke_script_check(script: Path, *, source: str = "suite") -> dict[str, Any]:
     return {
         "source": source,
         "profile_id": "smoke-suite",
         "profile_title": "Smoke suite",
         "tier": "default",
-        "command": f"python3 {script.relative_to(REPO_ROOT)}",
+        "command": f"python3 {_smoke_script_relative(script)}",
         "reason": "tracked public smoke script",
     }
 
 
 def _normalize_script_filter(script: str) -> str:
-    value = script.strip()
+    value = script.strip().replace("\\", "/")
     if not value:
         return ""
     path = Path(value)
     if path.parts and path.parts[0] == "examples":
-        return path.name
+        return path.as_posix()
+    if path.suffix and len(path.parts) > 1:
+        return path.as_posix()
     return path.name if path.suffix else value
 
 
 def _matches_modules(script: Path, modules: list[str]) -> bool:
     if not modules:
         return True
-    haystack = script.name.lower()
+    examples_relative = script.relative_to(REPO_ROOT / "examples").as_posix().lower()
+    haystack = f"{script.name.lower()} {examples_relative}"
     stem_tokens = {
-        token for token in re.split(r"[-_.]+", script.stem.lower()) if token
+        token for token in re.split(r"[-_./]+", examples_relative.removesuffix(script.suffix)) if token
     }
     for module in modules:
         needle = module.strip().lower()
@@ -276,7 +292,7 @@ def _discover_smoke_suite_checks(
     requested_scripts = {
         script for script in (_normalize_script_filter(item) for item in (scripts or [])) if script
     }
-    all_scripts = sorted((REPO_ROOT / "examples").glob("*-smoke.py"))
+    all_scripts = sorted(path for path in (REPO_ROOT / "examples").rglob("*-smoke.py") if path.is_file())
     if normalized_suite == "default-public":
         all_scripts = [
             script for script in all_scripts
@@ -285,12 +301,13 @@ def _discover_smoke_suite_checks(
     selected: list[Path] = []
     missing_scripts = set(requested_scripts)
     for script in all_scripts:
-        if requested_scripts and script.name not in requested_scripts:
+        script_filter_keys = _smoke_script_filter_keys(script)
+        if requested_scripts and requested_scripts.isdisjoint(script_filter_keys):
             continue
         if not _matches_modules(script, modules):
             continue
         selected.append(script)
-        missing_scripts.discard(script.name)
+        missing_scripts.difference_update(script_filter_keys)
     warnings = [
         {
             "kind": "unknown_script",
@@ -336,7 +353,7 @@ def build_canary_smoke_suite_run(
 ) -> dict[str, Any]:
     """Build and optionally execute a continue-on-failure smoke suite.
 
-    This runner is intentionally bounded to repository-local `examples/*-smoke.py`
+    This runner is intentionally bounded to repository-local `examples/**/*-smoke.py`
     commands plus catalog-plan checks. It gives maintainers a full regression
     sweep without hiding the smaller profile/module loops used while developing.
     """

--- a/loopx/cli_commands/canary.py
+++ b/loopx/cli_commands/canary.py
@@ -280,7 +280,7 @@ def register_canary_commands(
         default="default-public",
         help=(
             "Smoke selection mode. default-public excludes explicit grouped checks; "
-            "full-public includes every tracked examples/*-smoke.py; catalog-plan "
+            "full-public includes every tracked examples/**/*-smoke.py; catalog-plan "
             "runs only checks selected by catalog/profile inputs."
         ),
     )
@@ -294,7 +294,7 @@ def register_canary_commands(
         "--script",
         action="append",
         default=[],
-        help="Run a specific examples/*-smoke.py script. Repeatable.",
+        help="Run a specific examples/**/*-smoke.py script. Repeatable.",
     )
     smoke_parser.add_argument(
         "--no-execute",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -35,7 +35,7 @@ def pytest_addoption(parser) -> None:
         action="append",
         default=[],
         dest="loopx_smoke_scripts",
-        help="examples/*-smoke.py selector passed through to the LoopX runner. Repeat or comma-separate.",
+        help="examples/**/*-smoke.py selector passed through to the LoopX runner. Repeat or comma-separate.",
     )
     group.addoption(
         "--loopx-smoke-profile",


### PR DESCRIPTION
## Summary
- let canary smoke-suite discover repository-local `examples/**/*-smoke.py` instead of only flat `examples/*-smoke.py`
- keep backward-compatible `--script` selectors by basename, `examples/...` path, or examples-relative subpath
- include directory names in `--module` matching so future grouped smoke folders can be selected naturally
- add a real `examples/canary/` smoke as the first subdirectory discovery guard
- sync the Python line-budget whitelist to the current main `loopx/quota.py` size so the existing line-budget smoke is green while quota refactor work continues separately

## Validation
- `PYTHONPATH="$PWD" python3 examples/canary/smoke-suite-subdir-discovery-smoke.py`
- `PYTHONPATH="$PWD" python3 examples/canary-smoke-suite-runner-smoke.py`
- `PYTHONPATH="$PWD" python3 examples/pytest-smoke-suite-facade-smoke.py`
- `PYTHONPATH="$PWD" python3 examples/repo-python-line-budget-smoke.py`
- `PYTHONPATH="$PWD" python3 -m loopx.cli canary smoke-suite --format json --suite default-public --script examples/canary/smoke-suite-subdir-discovery-smoke.py --timeout-seconds 60`
- `PYTHONPATH="$PWD" python3 -m loopx.cli canary smoke-suite --format json --suite default-public --module canary --script canary/smoke-suite-subdir-discovery-smoke.py --timeout-seconds 60`
- `PYTHONPATH="$PWD" python3 -m loopx.cli --format json check --scan-path loopx/canary/runner.py --scan-path loopx/cli_commands/canary.py --scan-path tests/conftest.py --scan-path tests/test_smoke_suite.py --scan-path examples/canary-smoke-suite-runner-smoke.py --scan-path examples/canary/smoke-suite-subdir-discovery-smoke.py --scan-path examples/repo-python-line-budget-smoke.py --scan-path docs/product/release-readiness.md`
- `python3 -m py_compile loopx/canary/runner.py loopx/cli_commands/canary.py tests/conftest.py tests/test_smoke_suite.py examples/canary-smoke-suite-runner-smoke.py examples/canary/smoke-suite-subdir-discovery-smoke.py examples/repo-python-line-budget-smoke.py`

Note: direct `pytest` is not installed in this local shell; the existing pytest facade smoke passed.