### PR TITLE
Define bounded goal vision replan contract

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -102,6 +102,7 @@ incident report, or launch draft.
 - [Codex App host command registry v0](reference/protocols/codex-app-host-command-registry-v0.md)
 - [Local agent launch plan v0](reference/protocols/local-agent-launch-plan-v0.md)
 - [Multi-agent visible launcher v0](reference/protocols/multi-agent-visible-launcher-v0.md)
+- [Goal vision replan contract v0](reference/protocols/goal-vision-replan-contract-v0.md)
 - [Runtime connector catalog](runtime-connector-catalog.md)
 - [Reward gate direct-write contract](reward-gate-direct-write-contract.md)
 - [Worker bridge install contract](worker-bridge-install-contract.md)

--- a/docs/product/core-control-plane/rule-seam-map.md
+++ b/docs/product/core-control-plane/rule-seam-map.md
@@ -35,6 +35,7 @@ private evidence migration, production actions, or public first-screen copy.
 | Capability and boundary gates | `_capability_gate`, `_side_agent_workspace_guard`, `_automation_prompt_upgrade` | Gate evaluators that return typed decisions without mutating payloads. | Existing quota contract fields and workspace guard failure mode remain stable. |
 | Agent-lane selection | `_agent_lane_next_action`, `_agent_lane_frontier_hint` | Agent-scoped selector over normalized todo projections. | Current-agent claimed todos outrank unrelated agents; frontier hints stay diagnostic when no runnable candidate exists. |
 | Goal frontier and replan decision | `loopx.policies.goal_frontier`, `build_quota_should_run` adapter | Goal-frontier policy owns completion/replan projection; quota only selects the resulting interaction mode. | Required autonomous replan is decided before monitor quiet or agent-scope wait classification, without growing per-agent vision logic inside quota. |
+| Agent vision and goal routing contract | Future goal-route policy/CLI adapter plus `goal_vision_replan_contract_v0` | CLI-enforced bounded vision fields and the vision/replan state machine. | Over-budget vision fails or compacts before status/quota; quota consumes projection only and does not own per-agent vision storage. |
 | Quota plan and should-run assembly | `build_quota_plan`, `build_quota_should_run` | Thin orchestration layer that merges status, quota accounting, gates, and policy outputs. | `quota should-run` JSON field names and interaction contract stay compatible. |
 | User/agent/CLI split | `_protocol_action_packet`, `_interaction_contract` | Protocol packet builder with no scheduler or writeback side effects. | Operator gate vs bounded delivery payloads keep the same action_required and must_attempt meanings. |
 | Scheduler policy | `_scheduler_hint` wrapper plus `loopx/policies/scheduler_hint.py` | Pure scheduler-hint builder fed by final decision state. | RRULE, reset token, and no-spend cadence fields stay stable for Codex App and local loops. |
@@ -86,6 +87,10 @@ private evidence migration, production actions, or public first-screen copy.
 - `goal_frontier_projection` is the small per-goal completion/replan view used
   before lane-local quiet/wait decisions; keep its policy in
   `loopx.policies.goal_frontier` rather than expanding `quota.py`.
+- Per-agent vision is a bounded goal-routing contract, not free-form planning
+  memory. Enforce its character budget at the CLI/write boundary; store verbose
+  rationale as evidence/docs; let replan patch vision only through the bounded
+  contract.
 - Monitor routing is attribute based, not name based:
   `task_class=continuous_monitor` plus due metadata defines due monitor work,
   while `waiting_on=external_evidence` or

--- a/docs/product/core-control-plane/state-machine.md
+++ b/docs/product/core-control-plane/state-machine.md
@@ -19,6 +19,8 @@ public-safe map over the current repository contracts, especially:
   contracts;
 - [`loopx/policies/scheduler_hint.py`](../../../loopx/policies/scheduler_hint.py)
   for cadence/backoff/reset-token behavior;
+- [`goal_vision_replan_contract_v0`](../../reference/protocols/goal-vision-replan-contract-v0.md)
+  for bounded per-agent vision, replan transitions, and goal-route projection;
 - [`loopx/todo_handoff_gate.py`](../../../loopx/todo_handoff_gate.py) for
   cross-agent handoff gate states;
 - [`loopx/project_map.py`](../../../loopx/project_map.py) and
@@ -35,6 +37,8 @@ flowchart LR
   Owner["Owner route / handoff"] --> Quota
   Evidence["Evidence / rollout"] --> Todo
   Quota --> Scheduler["Scheduler / heartbeat"]
+  Quota --> Vision["Agent vision / replan"]
+  Vision --> Todo
   Quota --> Projection["Projection sinks"]
   Projection --> WriteAPI["LoopX write APIs"]
   WriteAPI --> Registry
@@ -384,6 +388,47 @@ preview until the `read_only_map_opt_in` operator gate approves it. Connected
 read-only states such as `connected`, `connected-read-only`, and
 `read-only-map-ready` can append a real read-only map.
 
+## 9. Agent Vision / Replan Machine
+
+Agent vision is compact executable routing state, not a scratchpad. Each agent
+may have a bounded vision packet that describes its current role direction,
+scope, acceptance summary, replan trigger, dreaming policy, and latest patch.
+The CLI/write API must enforce those budgets before quota or status consumes
+the projection.
+
+```mermaid
+stateDiagram-v2
+  [*] --> Unset
+  Unset --> DraftVision: goal configured or preset seeded
+  DraftVision --> ActiveVision: budget + acceptance validated
+  ActiveVision --> VisionDriftDetected: frontier exhausted or objective shifted
+  ActiveVision --> DreamProposal: advisory patch proposed
+  VisionDriftDetected --> ReplanRequired: goal-level trigger accepted
+  DreamProposal --> ReplanRequired: delivery route needed
+  ReplanRequired --> ReplanDrafted: bounded plan + todo delta
+  ReplanDrafted --> VisionPatchProposed: bounded vision patch
+  VisionPatchProposed --> ActiveVision: write correctness validated
+  ActiveVision --> Superseded: successor route replaces it
+  ActiveVision --> Retired: acceptance or no-follow-up recorded
+```
+
+| State | Product Meaning | Legal Exit |
+| --- | --- | --- |
+| `DraftVision` | A compact packet is being seeded or rewritten. | Validate budget and acceptance. |
+| `ActiveVision` | The role may use the packet for lane-local work. | Evidence, drift, dreaming proposal, supersession, or retirement. |
+| `ReplanRequired` | Goal-level progress requires replan before quiet/wait. | Write a bounded vision/todo/acceptance delta. |
+| `VisionPatchProposed` | Replan produced a bounded patch. | Apply through LoopX write APIs or reject as over budget. |
+
+The important ordering is goal-level first: required replan is evaluated before
+monitor quiet skip, scoped gate wait, or an individual agent's no-candidate
+state. Those local states may remain visible, but they cannot clear a required
+replan. An acknowledgement without a vision, todo, acceptance, or no-follow-up
+delta is `replan_noop`.
+
+See
+[`goal_vision_replan_contract_v0`](../../reference/protocols/goal-vision-replan-contract-v0.md)
+for the field budgets and projection contract.
+
 ## Catalog Linkage
 
 | Machine | Representative Patterns |
@@ -396,6 +441,7 @@ read-only states such as `connected`, `connected-read-only`, and
 | Scheduler / heartbeat | IP-008 Monitor Quiet Skip, IP-026 Agent-Scoped No-Candidate Gap |
 | Projection sink | IP-005 State Projection Gap |
 | Agent onboarding | Project bootstrap/connect and read-only-map opt-in flows |
+| Agent vision / replan | Autonomous replan, dreaming proposal promotion, successor replan |
 
 If a new interaction pattern cannot be placed in one of these machines, first
 check whether it is a UI variant, wording variant, or private incident label.

--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -37,3 +37,4 @@ Current contracts:
 - [local_agent_launch_plan_v0](local-agent-launch-plan-v0.md)
 - [multi_agent_three_layer_minimality_contract_v0](multi-agent-three-layer-minimality-v0.md)
 - [multi_agent_visible_launcher_v0](multi-agent-visible-launcher-v0.md)
+- [goal_vision_replan_contract_v0](goal-vision-replan-contract-v0.md)

--- a/docs/reference/protocols/goal-vision-replan-contract-v0.md
+++ b/docs/reference/protocols/goal-vision-replan-contract-v0.md
@@ -1,0 +1,152 @@
+# goal_vision_replan_contract_v0
+
+`goal_vision_replan_contract_v0` defines the small per-goal contract that
+connects bounded agent vision, autonomous replan, dreaming proposals, and
+goal-routing projection. It is a kernel contract, not an auto-research preset.
+
+The purpose is to keep both the user layer and the product preset thin:
+
+- the user supplies intent and small overrides;
+- the preset supplies domain defaults and handoff hints;
+- the kernel owns bounded per-agent vision, replan state transitions, and the
+  read/write protocol used by quota and status.
+
+## Ownership Boundary
+
+| Layer | Owns | Must Not Own |
+| --- | --- | --- |
+| User | Objective, optional role overrides, and optional data/eval entrypoint. | Vision state-machine transitions, replan recovery policy, quota routing, or raw agent scratchpads. |
+| Preset | Domain roles, handoff hints, metric/evidence adapters, and compact default acceptance text. | Long-lived replan mechanics, pane-local tick policy, generic successor routing, or product-specific forks of the kernel state machine. |
+| Kernel | CLI-enforced vision budgets, vision/replan state transitions, goal-route projection, todo/evidence/status protocol, and compact default prompts. | Domain-specific research logic, benchmark scoring, support triage semantics, or sales workflow semantics. |
+
+`loopx/quota.py` should consume the final `goal_route_projection` or
+`goal_frontier_projection`. It should not grow per-agent vision storage,
+budgeting, dreaming, or product-specific replan logic.
+
+## CLI Budget
+
+Per-agent vision is an executable control-plane field, so the CLI/write API must
+enforce a hard size budget before the state reaches quota, status, or a visible
+agent pane. Long reasoning belongs in evidence artifacts or design docs.
+
+| Field | Max chars | Purpose |
+| --- | ---: | --- |
+| `vision_summary` | 420 | Current role-specific direction and success shape. |
+| `role_scope` | 280 | What this agent owns and must not own. |
+| `acceptance_summary` | 420 | Compact completion contract for this agent. |
+| `replan_trigger_summary` | 240 | Why the latest replan is required. |
+| `dreaming_policy` | 240 | Whether advisory dreaming can propose a patch. |
+| `last_patch_summary` | 240 | What changed in the latest bounded vision patch. |
+| `total_agent_vision` | 1200 | Aggregate budget for one agent's active vision packet. |
+
+Required write-path behavior:
+
+1. Reject over-budget writes with `vision_budget_exceeded`, or require an
+   explicit compacting command before writeback.
+2. Do not silently truncate fields; truncation hides control-plane intent.
+3. Store verbose rationale as evidence and reference it by id.
+4. Keep the latest bounded packet visible in status/quota so agents can reason
+   without reading private scratchpads or chat history.
+
+## State Machine
+
+```mermaid
+stateDiagram-v2
+  [*] --> Unset
+  Unset --> DraftVision: goal configured or preset seeded
+  DraftVision --> ActiveVision: CLI budget + acceptance validated
+  ActiveVision --> VisionDriftDetected: frontier exhausted or objective shifted
+  ActiveVision --> DreamProposal: advisory dreaming proposes a bounded patch
+  VisionDriftDetected --> ReplanRequired: trigger accepted
+  DreamProposal --> ReplanRequired: proposal needs delivery routing
+  ReplanRequired --> ReplanDrafted: bounded plan + todo delta prepared
+  ReplanDrafted --> VisionPatchProposed: patch updates vision and route
+  VisionPatchProposed --> ActiveVision: budget + write correctness validated
+  ActiveVision --> Superseded: goal route replaced
+  ActiveVision --> Retired: acceptance done or no-follow-up recorded
+```
+
+| State | Meaning | Required Exit Evidence |
+| --- | --- | --- |
+| `Unset` | No per-goal vision packet exists. | Goal configuration or preset seed. |
+| `DraftVision` | A bounded packet is being prepared. | CLI budget validation and acceptance text. |
+| `ActiveVision` | Agents may use the packet for lane-local work. | Progress, evidence, replan trigger, or retirement. |
+| `VisionDriftDetected` | Current vision no longer explains the frontier. | Concrete trigger, not vague "needs planning". |
+| `DreamProposal` | Advisory planning suggests a patch. | Explicit proposal id and public-safe summary. |
+| `ReplanRequired` | The next bounded work is replan, not quiet wait. | Replan obligation in goal-route/frontier projection. |
+| `ReplanDrafted` | A concrete route/todo/acceptance delta exists. | Bounded patch packet. |
+| `VisionPatchProposed` | The patch is ready to apply. | Budget check and local-state write correctness. |
+| `Superseded` | Another route replaces this packet. | `superseded_by` or successor id. |
+| `Retired` | The route is complete or intentionally closed. | Acceptance evidence or no-follow-up evidence. |
+
+## Replan Triggers
+
+A replan trigger is goal-level and should be evaluated before lane-local quiet
+or agent-scope wait decisions:
+
+- normalized progress shows no remaining advancement frontier;
+- monitor-only lanes have no material transition and acceptance remains open;
+- a cleared handoff has no successor or no-follow-up rationale;
+- a periodic autonomous replan obligation is due;
+- the user objective or acceptance contract changed;
+- an approved dreaming proposal requires a delivery route.
+
+The replan decision must not be disturbed by monitor quiet skip, scoped gate
+waiting, or a single agent having no runnable todo. Those may explain local
+lane state, but they cannot erase a required goal-level replan.
+
+## Replan Output
+
+A valid replan writes at least one bounded delta:
+
+```json
+{
+  "schema_version": "goal_vision_replan_contract_v0",
+  "goal_id": "example-goal",
+  "agent_id": "research-curator",
+  "state": "vision_patch_proposed",
+  "vision_patch": {
+    "vision_summary": "Map the next evidence frontier and hand off one runnable claim.",
+    "role_scope": "Owns research framing; does not run evaluation.",
+    "acceptance_summary": "One concrete successor todo plus evidence refs.",
+    "replan_trigger_summary": "Frontier exhausted while acceptance remains open."
+  },
+  "todo_delta": ["create_successor", "retire_stale_monitor"],
+  "validation": {
+    "budget_checked": true,
+    "write_correctness_checked": true
+  }
+}
+```
+
+An acknowledgement without a vision, todo, acceptance, or no-follow-up delta is
+a `replan_noop` and must not clear the obligation.
+
+## Projection Contract
+
+Status, quota, diagnose, and visible multi-agent panes should expose the same
+compact goal-route facts:
+
+- `normalized_progress`: how far the goal has moved relative to acceptance;
+- `remaining_frontier`: runnable or replanable next edges;
+- `monitor_only_lanes`: lanes that are waiting without advancement;
+- `deferred_successors`: successors blocked by handoff, resume, or gate;
+- `acceptance_gaps`: missing evidence or contract fields;
+- `autonomy_blockers`: concrete blockers to autonomous progress;
+- `vision_budget`: current character usage and any rejected overage reason.
+
+These fields are projections. Writeback still goes through LoopX write APIs,
+not through dashboards, Lark mirrors, or chat text.
+
+## Acceptance
+
+A change satisfies this contract only when:
+
+- per-agent vision fields are rejected or compacted at the CLI/write boundary;
+- replan state is decided from goal-level projection before local quiet/wait
+  classifications;
+- replan can clear an obligation only by writing a bounded delta;
+- `quota.py` consumes the resulting projection instead of storing vision logic;
+- auto-research remains a thin preset over the reusable kernel; and
+- public docs and smokes cover the budget, state machine, and `quota.py`
+  boundary without private material.

--- a/docs/reference/protocols/multi-agent-three-layer-minimality-v0.md
+++ b/docs/reference/protocols/multi-agent-three-layer-minimality-v0.md
@@ -16,9 +16,9 @@ rather than a second product-specific runner.
 
 | Layer | Owns | Must Not Own |
 | --- | --- | --- |
-| User | Objective, rounds, optional role overrides, and optional data/eval entrypoint. | Tmux/Codex TUI launch, pane-local tick commands, quota/frontier protocol details, worker plumbing, or machine JSON routing. |
-| Preset | Domain roles, handoff hints, metric/evidence loop, and domain defaults. | Generic runner lifecycle, real Codex TUI panes, workspace/trust-safe launch, pane-local A2A tick, todo/evidence/status protocol, or compact human status. |
-| Kernel | Multi-agent runner, real Codex TUI panes, workspace/trust-safe launch, pane-local A2A tick, todo/evidence/status protocol, compact human status, and default role prompt scaffolding. | Domain-specific research, benchmark, support, or sales semantics. |
+| User | Objective, rounds, optional role overrides, and optional data/eval entrypoint. | Tmux/Codex TUI launch, pane-local tick commands, quota/frontier protocol details, worker plumbing, per-agent vision/replan state, or machine JSON routing. |
+| Preset | Domain roles, handoff hints, metric/evidence loop, and domain defaults. | Generic runner lifecycle, real Codex TUI panes, workspace/trust-safe launch, pane-local A2A tick, todo/evidence/status protocol, per-agent vision budgets, replan state transitions, or compact human status. |
+| Kernel | Multi-agent runner, real Codex TUI panes, workspace/trust-safe launch, pane-local A2A tick, todo/evidence/status protocol, CLI-enforced per-agent vision budgets, vision/replan state transitions, compact human status, and default role prompt scaffolding. | Domain-specific research, benchmark, support, or sales semantics. |
 
 ## Contract Shape
 
@@ -56,7 +56,8 @@ It returns:
 Auto-research is one preset on top of the generic kernel. Its preset layer owns
 research roles, handoff hints, the metric/evidence loop, and domain defaults.
 It does not own the runner, TUI panes, workspace/trust-safe launch,
-pane-local A2A tick, or todo/evidence/status protocol.
+pane-local A2A tick, todo/evidence/status protocol, per-agent vision budgets,
+or replan state transitions.
 
 This keeps the public promise honest: a small auto-research recipe should prove
 that other products can also reuse the same kernel with their own thin preset.
@@ -67,6 +68,7 @@ A change satisfies this contract only when:
 
 - the user recipe remains a few intent fields, not runner configuration;
 - the preset has no host process lifecycle or pane-local tick implementation;
+- the preset has no product-specific fork of per-agent vision/replan mechanics;
 - the generic kernel contract stays domain-agnostic;
 - another multi-agent product can reuse the same kernel without importing
   auto-research code.

--- a/examples/core-control-plane-diagrams-smoke.py
+++ b/examples/core-control-plane-diagrams-smoke.py
@@ -58,6 +58,7 @@ def main() -> None:
         "Scheduler / Heartbeat Machine",
         "Projection Sink Machine",
         "Agent Onboarding / Automation Enablement Machine",
+        "Agent Vision / Replan Machine",
     ):
         assert section in docs["state-machine.md"], f"missing state machine: {section}"
     assert "```mermaid" in combined

--- a/examples/goal-vision-replan-contract-smoke.py
+++ b/examples/goal-vision-replan-contract-smoke.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Smoke-check the goal vision/replan contract stays compact and reusable."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PROTOCOL = ROOT / "docs" / "reference" / "protocols" / "goal-vision-replan-contract-v0.md"
+PROTOCOL_INDEX = ROOT / "docs" / "reference" / "protocols" / "README.md"
+DOCS_INDEX = ROOT / "docs" / "README.md"
+STATE_MACHINE = ROOT / "docs" / "product" / "core-control-plane" / "state-machine.md"
+RULE_SEAM = ROOT / "docs" / "product" / "core-control-plane" / "rule-seam-map.md"
+THREE_LAYER = ROOT / "docs" / "reference" / "protocols" / "multi-agent-three-layer-minimality-v0.md"
+
+
+PRIVATE_MARKERS = [
+    "byte" + "dance",
+    "lark" + "office",
+    "/" + "Users" + "/",
+    "/" + "private" + "/",
+    "/" + "tmp" + "/",
+    "api" + "_key",
+    "pass" + "word",
+    "sec" + "ret",
+]
+
+
+def read(path: Path) -> str:
+    assert path.exists(), f"missing {path}"
+    return path.read_text(encoding="utf-8")
+
+
+def require(text: str, snippets: list[str], *, source: Path) -> None:
+    compact = " ".join(text.split())
+    missing = [
+        snippet for snippet in snippets if snippet not in text and " ".join(snippet.split()) not in compact
+    ]
+    assert not missing, f"{source}: missing {missing}"
+
+
+def assert_public_safe(text: str, label: str) -> None:
+    lower = text.lower()
+    leaked = [marker for marker in PRIVATE_MARKERS if marker.lower() in lower]
+    assert not leaked, f"{label} leaks private markers: {leaked}"
+
+
+def main() -> int:
+    protocol = read(PROTOCOL)
+    protocol_index = read(PROTOCOL_INDEX)
+    docs_index = read(DOCS_INDEX)
+    state_machine = read(STATE_MACHINE)
+    rule_seam = read(RULE_SEAM)
+    three_layer = read(THREE_LAYER)
+
+    assert_public_safe(
+        "\n".join([protocol, protocol_index, docs_index, state_machine, rule_seam, three_layer]),
+        "goal vision/replan docs",
+    )
+
+    require(
+        protocol,
+        [
+            "goal_vision_replan_contract_v0",
+            "CLI Budget",
+            "`vision_summary` | 420",
+            "`total_agent_vision` | 1200",
+            "Reject over-budget writes with `vision_budget_exceeded`",
+            "Do not silently truncate fields",
+            "Long reasoning belongs in evidence artifacts or design docs",
+            "State Machine",
+            "ActiveVision --> VisionDriftDetected",
+            "ReplanRequired --> ReplanDrafted",
+            "VisionPatchProposed --> ActiveVision",
+            "The replan decision must not be disturbed by monitor quiet skip",
+            "An acknowledgement without a vision, todo, acceptance, or no-follow-up delta is",
+            "`replan_noop`",
+            "`quota.py` consumes the resulting projection instead of storing vision logic",
+        ],
+        source=PROTOCOL,
+    )
+    require(
+        state_machine,
+        [
+            "Agent Vision / Replan Machine",
+            "required replan is evaluated before",
+            "An acknowledgement without a vision, todo, acceptance, or no-follow-up",
+            "goal-vision-replan-contract-v0.md",
+        ],
+        source=STATE_MACHINE,
+    )
+    require(
+        rule_seam,
+        [
+            "Agent vision and goal routing contract",
+            "Over-budget vision fails or compacts before status/quota",
+            "rather than expanding `quota.py`",
+            "Per-agent vision is a bounded goal-routing contract",
+        ],
+        source=RULE_SEAM,
+    )
+    require(
+        three_layer,
+        [
+            "per-agent vision/replan state",
+            "per-agent vision budgets",
+            "vision/replan state transitions",
+            "product-specific fork of per-agent vision/replan mechanics",
+        ],
+        source=THREE_LAYER,
+    )
+    require(
+        protocol_index,
+        ["goal_vision_replan_contract_v0", "goal-vision-replan-contract-v0.md"],
+        source=PROTOCOL_INDEX,
+    )
+    require(
+        docs_index,
+        ["Goal vision replan contract v0", "reference/protocols/goal-vision-replan-contract-v0.md"],
+        source=DOCS_INDEX,
+    )
+
+    print("goal-vision-replan-contract-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a goal_vision_replan_contract_v0 protocol for CLI-enforced per-agent vision budgets and the vision-to-replan-to-vision state machine
- link the contract from core state machines, rule seam map, protocol indexes, and the multi-agent three-layer minimality contract
- add a focused smoke that guards the budget, state-machine, and quota.py boundary language

## Validation
- python3 examples/goal-vision-replan-contract-smoke.py
- python3 examples/core-control-plane-diagrams-smoke.py
- python3 examples/multi-agent-visible-launcher-protocol-smoke.py
- python3 examples/docs-governance-smoke.py
- git diff --check origin/main..HEAD
- loopx check --scan-path docs/reference/protocols/goal-vision-replan-contract-v0.md --scan-path docs/product/core-control-plane/state-machine.md --scan-path docs/product/core-control-plane/rule-seam-map.md --scan-path docs/reference/protocols/multi-agent-three-layer-minimality-v0.md --scan-path docs/reference/protocols/README.md --scan-path docs/README.md --scan-path examples/goal-vision-replan-contract-smoke.py --scan-path examples/core-control-plane-diagrams-smoke.py

LoopX check warning: existing loopx-meta duplicate index rows raw=7227 unique=7223.