### PR TITLE
Extract shared todo projection helpers

### DIFF
--- a/examples/control_plane/todo-projection-shared-helper-smoke.py
+++ b/examples/control_plane/todo-projection-shared-helper-smoke.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Smoke-test shared todo projection ordering across status and quota."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.quota import (  # noqa: E402
+    _todo_projection_sort_key as quota_todo_projection_sort_key,
+    _todo_task_class as quota_todo_task_class,
+    build_quota_should_run,
+)
+from loopx.status import compact_todo_group, todo_projection_sort_key  # noqa: E402
+from loopx.todo_contract import (  # noqa: E402
+    TODO_TASK_CLASS_ADVANCEMENT,
+    TODO_TASK_CLASS_MONITOR,
+)
+from loopx.todo_projection import (  # noqa: E402
+    todo_projection_sort_key as shared_todo_projection_sort_key,
+)
+
+
+GOAL_ID = "todo-projection-shared-helper-goal"
+AGENT_ID = "codex-product-capability"
+
+
+def todo(
+    index: int,
+    text: str,
+    *,
+    task_class: str,
+    todo_id: str,
+    **metadata: Any,
+) -> dict[str, Any]:
+    item = {
+        "schema_version": "todo_item_v0",
+        "todo_id": todo_id,
+        "role": "agent",
+        "source_section": "Agent Todo",
+        "status": "open",
+        "done": False,
+        "index": index,
+        "text": text,
+        "task_class": task_class,
+    }
+    item.update(metadata)
+    return item
+
+
+def build_agent_todo_summary() -> dict[str, Any]:
+    summary = compact_todo_group(
+        [
+            todo(
+                4,
+                "[P2] Continue low-risk canary cleanup after the core projection parity lands.",
+                task_class=TODO_TASK_CLASS_ADVANCEMENT,
+                todo_id="todo_advancement_p2",
+            ),
+            todo(
+                2,
+                "[P0] Monitor public smoke signal and only write back if it changed.",
+                task_class=TODO_TASK_CLASS_MONITOR,
+                todo_id="todo_monitor_p0",
+                next_due_at="2026-01-01T00:00:00+00:00",
+            ),
+            todo(
+                3,
+                "[P0] Extract todo projection helper for status and quota parity.",
+                task_class=TODO_TASK_CLASS_ADVANCEMENT,
+                todo_id="todo_advancement_p0",
+                claimed_by=AGENT_ID,
+            ),
+            todo(
+                1,
+                "[P1] Add characterization before moving more control-plane code.",
+                task_class=TODO_TASK_CLASS_ADVANCEMENT,
+                todo_id="todo_advancement_p1",
+            ),
+        ],
+        source_section="Agent Todo",
+        role="agent",
+    )
+    assert summary is not None, summary
+    return summary
+
+
+def status_payload(agent_todos: dict[str, Any]) -> dict[str, Any]:
+    quota = {
+        "compute": 1.0,
+        "window_hours": 24,
+        "slot_minutes": 1,
+        "allowed_slots": 1440,
+        "spent_slots": 0,
+        "state": "eligible",
+        "reason": "fixture eligible quota",
+    }
+    return {
+        "ok": True,
+        "attention_queue": {
+            "items": [
+                {
+                    "goal_id": GOAL_ID,
+                    "status": "active",
+                    "waiting_on": "codex",
+                    "severity": "info",
+                    "source": "project_asset",
+                    "quota": quota,
+                    "agent_todos": agent_todos,
+                    "project_asset": {
+                        "agent_todos": agent_todos,
+                        "next_action": "Use the first executable advancement todo.",
+                    },
+                }
+            ]
+        },
+        "run_history": {
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "registry_member": True,
+                    "quota": quota,
+                    "latest_runs": [],
+                    "coordination": {
+                        "primary_agent": "codex-main-control",
+                        "registered_agents": ["codex-main-control", AGENT_ID],
+                    },
+                }
+            ]
+        },
+    }
+
+
+def assert_status_summary_lanes(summary: dict[str, Any]) -> None:
+    assert [item["todo_id"] for item in summary["first_open_items"]] == [
+        "todo_monitor_p0",
+        "todo_advancement_p0",
+        "todo_advancement_p1",
+    ], summary
+    assert [item["todo_id"] for item in summary["first_executable_items"]] == [
+        "todo_advancement_p0",
+        "todo_advancement_p1",
+        "todo_advancement_p2",
+    ], summary
+    assert [item["todo_id"] for item in summary["monitor_due_items"]] == [
+        "todo_monitor_p0",
+    ], summary
+    assert summary["monitor_due_count"] == 1, summary
+
+
+def assert_shared_ordering_parity(summary: dict[str, Any]) -> None:
+    first_open = [item for item in summary["first_open_items"] if isinstance(item, dict)]
+    assert [item["todo_id"] for item in sorted(first_open, key=todo_projection_sort_key)] == [
+        "todo_monitor_p0",
+        "todo_advancement_p0",
+        "todo_advancement_p1",
+    ], first_open
+    assert [item["todo_id"] for item in sorted(first_open, key=quota_todo_projection_sort_key)] == [
+        "todo_monitor_p0",
+        "todo_advancement_p0",
+        "todo_advancement_p1",
+    ], first_open
+    assert [item["todo_id"] for item in sorted(first_open, key=shared_todo_projection_sort_key)] == [
+        "todo_monitor_p0",
+        "todo_advancement_p0",
+        "todo_advancement_p1",
+    ], first_open
+    embedded_priority = {
+        "index": 9,
+        "text": "Keep this text with embedded P0 wording but no bracket prefix.",
+    }
+    assert todo_projection_sort_key(embedded_priority) == (50, 9), embedded_priority
+    assert quota_todo_projection_sort_key(embedded_priority) == (0, 9), embedded_priority
+
+
+def assert_quota_uses_executable_advancement(summary: dict[str, Any]) -> None:
+    payload = build_quota_should_run(
+        status_payload(summary),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+    quota_summary = payload["agent_todo_summary"]
+    assert quota_summary["first_open_items"][0]["todo_id"] == "todo_advancement_p0", payload
+    assert quota_summary["first_executable_items"][0]["todo_id"] == "todo_advancement_p0", payload
+    assert quota_summary["monitor_open_items"][0]["todo_id"] == "todo_monitor_p0", payload
+    assert quota_todo_task_class(quota_summary["monitor_open_items"][0]) == TODO_TASK_CLASS_MONITOR
+    assert quota_todo_task_class(
+        quota_summary["first_executable_items"][0]
+    ) == TODO_TASK_CLASS_ADVANCEMENT
+    lane = payload["work_lane_contract"]
+    assert lane["lane"] == "advancement_task", payload
+    assert payload["agent_lane_next_action"]["todo_id"] == "todo_advancement_p0", payload
+
+
+def main() -> int:
+    summary = build_agent_todo_summary()
+    assert_status_summary_lanes(summary)
+    assert_shared_ordering_parity(summary)
+    assert_quota_uses_executable_advancement(summary)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -41,14 +41,6 @@ from .policies.goal_frontier import (
     select_autonomous_replan_obligation,
 )
 from .policies.goal_route_hint import build_goal_route_hint
-from .policies.monitor_todo import (
-    monitor_todo_expires_at,
-    monitor_todo_is_actionable_open,
-    monitor_todo_is_due,
-    monitor_todo_is_expired,
-    monitor_todo_next_due_at,
-    monitor_todo_task_class,
-)
 from .policies.outcome_followthrough import build_outcome_followthrough_hint
 from .policies.scheduler_hint import (
     build_codex_app_scheduler_ack_event,
@@ -89,6 +81,18 @@ from .todo_contract import (
     normalize_todo_task_class,
 )
 from .todo_handoff_gate import HandoffGateState, build_todo_handoff_gate_states
+from .todo_projection import (
+    todo_index_rank as projection_todo_index_rank,
+    todo_item_expires_at as projection_todo_item_expires_at,
+    todo_item_is_actionable_open as projection_todo_item_is_actionable_open,
+    todo_item_is_due_monitor as projection_todo_item_is_due_monitor,
+    todo_item_is_expired_monitor as projection_todo_item_is_expired_monitor,
+    todo_item_next_due_at as projection_todo_item_next_due_at,
+    todo_item_task_class as projection_todo_item_task_class,
+    todo_priority_label as projection_todo_priority_label,
+    todo_priority_rank as projection_todo_priority_rank,
+    todo_projection_sort_key as projection_todo_projection_sort_key,
+)
 
 
 DEFAULT_COMPUTE_QUOTA = 1.0
@@ -229,8 +233,6 @@ TODO_BACKLOG_ITEM_LIMIT = 8
 TODO_DEFERRED_VISIBILITY_LIMIT = 8
 TODO_VISIBILITY_LANE_LIMIT = 16
 MONITOR_DUE_ITEM_LIMIT = 1
-TODO_MISSING_PRIORITY_RANK = 50
-TODO_MISSING_INDEX = 999999
 EXTERNAL_EVIDENCE_OBSERVE_PATTERNS = (
     re.compile(
         r"(?i)\b(?:poll(?:ing)?|observ(?:e|ing)|watch(?:ing)?|await(?:ing)?|wait\s+for|monitor(?:ing)?)\b.*\b"
@@ -1347,39 +1349,19 @@ def _capability_gate(
 
 
 def _todo_priority_label(item: dict[str, Any]) -> str | None:
-    priority = item.get("priority")
-    if isinstance(priority, str) and priority.strip():
-        return priority.strip().upper()
-    text = " ".join(
-        str(value or "")
-        for value in (item.get("title"), item.get("text"))
-        if str(value or "").strip()
-    )
-    match = re.search(r"\bP([0-4])\b", text.upper())
-    if not match:
-        return None
-    return f"P{match.group(1)}"
+    return projection_todo_priority_label(item)
 
 
 def _todo_priority_rank(item: dict[str, Any]) -> int:
-    priority = _todo_priority_label(item)
-    if not priority:
-        return TODO_MISSING_PRIORITY_RANK
-    match = re.match(r"P([0-4])", priority)
-    if not match:
-        return TODO_MISSING_PRIORITY_RANK
-    return int(match.group(1))
+    return projection_todo_priority_rank(item)
 
 
 def _todo_index_rank(item: dict[str, Any]) -> int:
-    try:
-        return int(item.get("index"))
-    except (TypeError, ValueError):
-        return TODO_MISSING_INDEX
+    return projection_todo_index_rank(item)
 
 
 def _todo_projection_sort_key(item: dict[str, Any]) -> tuple[int, int]:
-    return (_todo_priority_rank(item), _todo_index_rank(item))
+    return projection_todo_projection_sort_key(item)
 
 
 def _claimed_visibility_items(items: list[dict[str, Any]], *, limit: int) -> list[dict[str, Any]]:
@@ -5281,37 +5263,27 @@ def _user_gate_todo_notify_reason(summary: dict[str, Any] | None) -> str:
 
 
 def _todo_task_class(item: dict[str, Any]) -> str:
-    text = " ".join(
-        str(value or "")
-        for value in (item.get("title"), item.get("text"))
-        if str(value or "").strip()
-    )
-    return monitor_todo_task_class(item, task_text=text)
+    return projection_todo_item_task_class(item)
 
 
 def _todo_item_is_actionable_open(item: dict[str, Any]) -> bool:
-    return monitor_todo_is_actionable_open(item)
+    return projection_todo_item_is_actionable_open(item)
 
 
 def _todo_item_next_due_at(item: dict[str, Any]) -> datetime | None:
-    return monitor_todo_next_due_at(item)
+    return projection_todo_item_next_due_at(item)
 
 
 def _todo_item_expires_at(item: dict[str, Any]) -> datetime | None:
-    return monitor_todo_expires_at(item)
+    return projection_todo_item_expires_at(item)
 
 
 def _todo_item_is_expired_monitor(item: dict[str, Any], *, now: datetime | None = None) -> bool:
-    return monitor_todo_is_expired(item, now=now)
+    return projection_todo_item_is_expired_monitor(item, now=now)
 
 
 def _todo_item_is_due_monitor(item: dict[str, Any], *, now: datetime | None = None) -> bool:
-    text = " ".join(
-        str(value or "")
-        for value in (item.get("title"), item.get("text"))
-        if str(value or "").strip()
-    )
-    return monitor_todo_is_due(item, now=now, task_text=text)
+    return projection_todo_item_is_due_monitor(item, now=now)
 
 
 def _todo_summary_claim_scope_agent_id(summary: dict[str, Any]) -> str | None:

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -53,14 +53,6 @@ from .materials import extract_review_materials
 from .operator_gate import DEFAULT_OPERATOR_GATE, default_operator_question, normalize_operator_question
 from .orchestration import compact_orchestration_policy, orchestration_policy_summary
 from .paths import global_registry_path, resolve_runtime_root
-from .policies.monitor_todo import (
-    monitor_todo_expires_at,
-    monitor_todo_is_actionable_open,
-    monitor_todo_is_due,
-    monitor_todo_is_expired,
-    monitor_todo_next_due_at,
-    monitor_todo_task_class,
-)
 from .projections.task_graph import (
     TASK_GRAPH_MAX_USER_GATE_NODES,
     TASK_GRAPH_PROJECTION_SCHEMA_VERSION,
@@ -120,6 +112,17 @@ from .todo_contract import (
     todo_status_from_marker,
 )
 from .todo_handoff_gate import build_todo_handoff_gate_states
+from .todo_projection import (
+    todo_item_expires_at as projection_todo_item_expires_at,
+    todo_item_is_actionable_open as projection_todo_item_is_actionable_open,
+    todo_item_is_due_monitor as projection_todo_item_is_due_monitor,
+    todo_item_is_expired_monitor as projection_todo_item_is_expired_monitor,
+    todo_item_next_due_at as projection_todo_item_next_due_at,
+    todo_item_task_class as projection_todo_item_task_class,
+    todo_priority_parts as projection_todo_priority_parts,
+    todo_priority_rank as projection_todo_priority_rank,
+    todo_projection_sort_key as projection_todo_projection_sort_key,
+)
 
 
 CODEX_READY_CLASSIFICATIONS = {
@@ -5820,10 +5823,7 @@ def todo_role_for_heading(heading: str) -> str | None:
 
 
 def todo_priority_parts(text: str) -> tuple[str | None, str]:
-    match = AUTONOMOUS_PRIORITY_PATTERN.match(text)
-    if not match:
-        return None, text
-    return match.group(1).strip().upper(), match.group(2).strip()
+    return projection_todo_priority_parts(text)
 
 
 def structured_todo_item(
@@ -5973,46 +5973,35 @@ def compact_active_next_action_todo_item(item: dict[str, Any]) -> dict[str, Any]
 
 
 def todo_item_task_class(item: dict[str, Any]) -> str:
-    return monitor_todo_task_class(item, task_text=str(item.get("text") or ""))
+    return projection_todo_item_task_class(item, task_text_keys=("text",))
 
 
 def todo_item_is_actionable_open(item: dict[str, Any]) -> bool:
-    return monitor_todo_is_actionable_open(item)
+    return projection_todo_item_is_actionable_open(item)
 
 
 def todo_item_next_due_at(item: dict[str, Any]) -> datetime | None:
-    return monitor_todo_next_due_at(item)
+    return projection_todo_item_next_due_at(item)
 
 
 def todo_item_expires_at(item: dict[str, Any]) -> datetime | None:
-    return monitor_todo_expires_at(item)
+    return projection_todo_item_expires_at(item)
 
 
 def todo_item_is_expired_monitor(item: dict[str, Any], *, now: datetime | None = None) -> bool:
-    return monitor_todo_is_expired(item, now=now)
+    return projection_todo_item_is_expired_monitor(item, now=now)
 
 
 def todo_item_is_due_monitor(item: dict[str, Any], *, now: datetime | None = None) -> bool:
-    return monitor_todo_is_due(item, now=now, task_text=str(item.get("text") or ""))
+    return projection_todo_item_is_due_monitor(item, now=now, task_text_keys=("text",))
 
 
 def todo_priority_rank(priority: Any) -> int:
-    if not isinstance(priority, str):
-        return 50
-    match = re.match(r"P([0-4])", priority.strip().upper())
-    if not match:
-        return 50
-    return int(match.group(1))
+    return projection_todo_priority_rank(priority)
 
 
 def todo_projection_sort_key(item: dict[str, Any]) -> tuple[int, int]:
-    priority = item.get("priority")
-    if not isinstance(priority, str):
-        priority, _ = todo_priority_parts(str(item.get("text") or ""))
-    return (
-        todo_priority_rank(priority),
-        int(item.get("index") or 999999),
-    )
+    return projection_todo_projection_sort_key(item, text_mode="prefix")
 
 
 def claimed_visibility_items(items: list[dict[str, Any]], *, limit: int) -> list[dict[str, Any]]:

--- a/loopx/todo_projection.py
+++ b/loopx/todo_projection.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from datetime import datetime
+import re
+from typing import Any
+
+from .policies.monitor_todo import (
+    monitor_todo_expires_at,
+    monitor_todo_is_actionable_open,
+    monitor_todo_is_due,
+    monitor_todo_is_expired,
+    monitor_todo_next_due_at,
+    monitor_todo_task_class,
+)
+
+
+TODO_MISSING_PRIORITY_RANK = 50
+TODO_MISSING_INDEX = 999999
+TODO_PRIORITY_PREFIX_PATTERN = re.compile(
+    r"^\s*\[(P[0-4][^\]]*)\]\s*(.+)$",
+    re.IGNORECASE,
+)
+TODO_PRIORITY_LABEL_PATTERN = re.compile(r"\bP([0-4])\b", re.IGNORECASE)
+
+
+def todo_priority_parts(text: str) -> tuple[str | None, str]:
+    match = TODO_PRIORITY_PREFIX_PATTERN.match(text)
+    if not match:
+        return None, text
+    return match.group(1).strip().upper(), match.group(2).strip()
+
+
+def todo_priority_label(
+    item: dict[str, Any],
+    *,
+    text_mode: str = "label",
+) -> str | None:
+    priority = item.get("priority")
+    if isinstance(priority, str) and priority.strip():
+        return priority.strip().upper()
+    text = " ".join(
+        str(value or "")
+        for value in (item.get("title"), item.get("text"))
+        if str(value or "").strip()
+    )
+    if text_mode == "prefix":
+        priority, _ = todo_priority_parts(text)
+        return priority
+    match = TODO_PRIORITY_LABEL_PATTERN.search(text.upper())
+    if not match:
+        return None
+    return f"P{match.group(1)}"
+
+
+def todo_priority_rank(value: Any, *, text_mode: str = "label") -> int:
+    if isinstance(value, dict):
+        priority = todo_priority_label(value, text_mode=text_mode)
+    elif isinstance(value, str):
+        priority = value.strip().upper()
+    else:
+        priority = None
+    if not priority:
+        return TODO_MISSING_PRIORITY_RANK
+    match = re.match(r"P([0-4])", priority)
+    if not match:
+        return TODO_MISSING_PRIORITY_RANK
+    return int(match.group(1))
+
+
+def todo_index_rank(item: dict[str, Any]) -> int:
+    try:
+        return int(item.get("index"))
+    except (TypeError, ValueError):
+        return TODO_MISSING_INDEX
+
+
+def todo_projection_sort_key(
+    item: dict[str, Any],
+    *,
+    text_mode: str = "label",
+) -> tuple[int, int]:
+    return (todo_priority_rank(item, text_mode=text_mode), todo_index_rank(item))
+
+
+def todo_item_task_text(
+    item: dict[str, Any],
+    *,
+    keys: tuple[str, ...] = ("title", "text"),
+) -> str:
+    return " ".join(
+        str(item.get(key) or "")
+        for key in keys
+        if str(item.get(key) or "").strip()
+    )
+
+
+def todo_item_task_class(
+    item: dict[str, Any],
+    *,
+    task_text_keys: tuple[str, ...] = ("title", "text"),
+) -> str:
+    return monitor_todo_task_class(
+        item,
+        task_text=todo_item_task_text(item, keys=task_text_keys),
+    )
+
+
+def todo_item_is_actionable_open(item: dict[str, Any]) -> bool:
+    return monitor_todo_is_actionable_open(item)
+
+
+def todo_item_next_due_at(item: dict[str, Any]) -> datetime | None:
+    return monitor_todo_next_due_at(item)
+
+
+def todo_item_expires_at(item: dict[str, Any]) -> datetime | None:
+    return monitor_todo_expires_at(item)
+
+
+def todo_item_is_expired_monitor(item: dict[str, Any], *, now: datetime | None = None) -> bool:
+    return monitor_todo_is_expired(item, now=now)
+
+
+def todo_item_is_due_monitor(
+    item: dict[str, Any],
+    *,
+    now: datetime | None = None,
+    task_text_keys: tuple[str, ...] = ("title", "text"),
+) -> bool:
+    return monitor_todo_is_due(
+        item,
+        now=now,
+        task_text=todo_item_task_text(item, keys=task_text_keys),
+    )


### PR DESCRIPTION
## Summary
- Add loopx.todo_projection as the shared helper for todo priority sorting, task-class classification, and monitor due/actionability predicates.
- Rewire status and quota to use thin wrappers around the shared helper while preserving their existing projection semantics.
- Add a control-plane smoke covering P0/P1/P2 ordering, advancement vs monitor lane separation, agent-scoped quota selection, and canary smoke-suite execution.

## Validation
- python3 examples/control_plane/todo-projection-shared-helper-smoke.py
- python3 examples/todo-first-open-summary-smoke.py
- python3 examples/monitor-scheduler-contract-smoke.py
- python3 examples/side-agent-workspace-guard-smoke.py
- python3 examples/capability-gate-smoke.py
- PYTHONPATH="/private/tmp/loopx-todo-projection-shared-helper-20260703" python3 -m loopx.cli canary smoke-suite --format json --suite default-public --script examples/control_plane/todo-projection-shared-helper-smoke.py --timeout-seconds 60
- python3 -m py_compile loopx/todo_projection.py loopx/status.py loopx/quota.py examples/control_plane/todo-projection-shared-helper-smoke.py
- git diff --check
- PYTHONPATH="/private/tmp/loopx-todo-projection-shared-helper-20260703" python3 -m loopx.cli --format json check --scan-path loopx/todo_projection.py --scan-path loopx/status.py --scan-path loopx/quota.py --scan-path examples/control_plane/todo-projection-shared-helper-smoke.py

## Review note
This touches quota/status hot-path selection helpers, so it is intentionally not self-merged.