### PR TITLE
Move release and public-entry smokes into subdirs

### DIFF
--- a/docs/product/codex-cli-no-clone-release-verification.md
+++ b/docs/product/codex-cli-no-clone-release-verification.md
@@ -27,7 +27,7 @@ credentials, mutate a Codex session, or spend LoopX quota.
 Run it with:
 
 ```bash
-python3 examples/codex-cli-no-clone-release-verification-smoke.py
+python3 examples/release/codex-cli-no-clone-release-verification-smoke.py
 ```
 
 ## Current Result
@@ -61,7 +61,7 @@ while contributor clone-plus-canary remains the development path.
 Before promoting a new release snapshot, run:
 
 ```bash
-python3 examples/codex-cli-no-clone-release-verification-smoke.py
+python3 examples/release/codex-cli-no-clone-release-verification-smoke.py
 python3 examples/codex-cli-first-run-rehearsal-smoke.py
 python3 examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py
 python3 examples/codex-cli-proof-capture-demo-fixtures-smoke.py

--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -81,11 +81,11 @@ on a new surface, run the smallest gate that covers the touched surface:
 
 ```bash
 python3 -m py_compile loopx/*.py
-python3 examples/codex-cli-no-clone-release-verification-smoke.py
+python3 examples/release/codex-cli-no-clone-release-verification-smoke.py
 python3 examples/fresh-clone-quickstart-smoke.py
 python3 examples/loopx-update-smoke.py
-python3 examples/release-version-contract-smoke.py
-python3 examples/release-readiness-doc-smoke.py
+python3 examples/release/release-version-contract-smoke.py
+python3 examples/release/release-readiness-doc-smoke.py
 git diff --check
 loopx check --scan-path README.md --scan-path docs/ --scan-path examples/
 ```

--- a/examples/canary/catalog-planner-smoke.py
+++ b/examples/canary/catalog-planner-smoke.py
@@ -284,7 +284,7 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     product_entry_commands = [check["command"] for check in product_entry_profile["checks"]]
     assert "python3 examples/issue-fix-workflow-contract-smoke.py" in product_entry_commands, product_entry_profile
     assert "python3 examples/content-ops-issue-fix-intake-smoke.py" in product_entry_commands, product_entry_profile
-    assert "python3 examples/readme-demo-surface-smoke.py" in product_entry_commands, product_entry_profile
+    assert "python3 examples/public_entry/readme-demo-surface-smoke.py" in product_entry_commands, product_entry_profile
     assert "python3 examples/update-notes-archive-smoke.py" in product_entry_commands, product_entry_profile
     assert all(check["tier"] == "default" for check in product_entry_profile["checks"]), product_entry_profile
     assert product_entry_profile["deep_checks_available"] is True, product_entry_profile
@@ -311,7 +311,7 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     assert (
         "python3 examples/cross-runtime-impl-review-demo-smoke.py" in cross_runtime_commands
     ), cross_runtime_profile
-    assert "python3 examples/readme-demo-surface-smoke.py" in cross_runtime_commands
+    assert "python3 examples/public_entry/readme-demo-surface-smoke.py" in cross_runtime_commands
     assert all(check["tier"] == "default" for check in cross_runtime_profile["checks"])
     assert cross_runtime_profile["deep_checks_available"] is False, cross_runtime_profile
     assert cross_runtime_profile["deep_checks_included"] is False, cross_runtime_profile

--- a/examples/canary/smoke-suite-runner-smoke.py
+++ b/examples/canary/smoke-suite-runner-smoke.py
@@ -84,6 +84,23 @@ def assert_subdirectory_smoke_selection_is_supported() -> None:
     assert module_payload["selected_check_count"] == 1, module_payload
 
 
+def assert_legacy_root_script_selector_matches_moved_smokes() -> None:
+    moved_scripts = {
+        "examples/readme-demo-surface-smoke.py": "examples/public_entry/readme-demo-surface-smoke.py",
+        "examples/release-readiness-doc-smoke.py": "examples/release/release-readiness-doc-smoke.py",
+    }
+    for legacy_selector, expected_script in moved_scripts.items():
+        payload = build_canary_smoke_suite_run(
+            suite="default-public",
+            scripts=[legacy_selector],
+            execute=False,
+        )
+        assert payload["ok"] is True, payload
+        assert payload["warning_count"] == 0, payload
+        assert payload["selected_check_count"] == 1, payload
+        assert payload["selected_checks"][0]["normalized"]["script"] == expected_script, payload
+
+
 def assert_catalog_profile_preview_is_supported() -> None:
     payload = build_canary_smoke_suite_run(
         suite="catalog-plan",
@@ -311,6 +328,7 @@ def main() -> int:
     assert_full_public_preview_injects_safe_group_args()
     assert_module_preview_selects_matching_scripts()
     assert_subdirectory_smoke_selection_is_supported()
+    assert_legacy_root_script_selector_matches_moved_smokes()
     assert_catalog_profile_preview_is_supported()
     assert_cli_json_preview_works()
     assert_execution_reports_progress_indices()

--- a/examples/cross-runtime-impl-review-demo-smoke.py
+++ b/examples/cross-runtime-impl-review-demo-smoke.py
@@ -81,7 +81,7 @@ def assert_cli_json_packet() -> None:
         "--requirement",
         "Ship a small public-safe docs change",
         "--verifier",
-        "python3 examples/readme-demo-surface-smoke.py",
+        "python3 examples/public_entry/readme-demo-surface-smoke.py",
     )
     assert completed.returncode == 0, completed.stderr
     payload = json.loads(completed.stdout)

--- a/examples/public_entry/readme-demo-surface-smoke.py
+++ b/examples/public_entry/readme-demo-surface-smoke.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from pathlib import Path
 
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 def read(path: str) -> str:

--- a/examples/release/codex-cli-no-clone-release-verification-smoke.py
+++ b/examples/release/codex-cli-no-clone-release-verification-smoke.py
@@ -11,7 +11,7 @@ import tempfile
 from pathlib import Path
 
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[2]
 DOC = REPO_ROOT / "docs" / "product" / "codex-cli-no-clone-release-verification.md"
 FIRST_RUN_DOC = REPO_ROOT / "docs" / "product" / "codex-cli-first-run-rehearsal.md"
 PRODUCT_README = REPO_ROOT / "docs" / "product" / "README.md"
@@ -70,7 +70,7 @@ def assert_docs() -> None:
         "Current release route: **ready as the default candidate, with one boundary**.",
         "network access to GitHub archive endpoints",
         "same-TUI automation is not the default path",
-        "python3 examples/codex-cli-no-clone-release-verification-smoke.py",
+        "python3 examples/release/codex-cli-no-clone-release-verification-smoke.py",
         "no raw Codex transcript or session material",
         "no Codex execution as part of the verifier",
     )

--- a/examples/release/release-readiness-doc-smoke.py
+++ b/examples/release/release-readiness-doc-smoke.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from pathlib import Path
 
 
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = Path(__file__).resolve().parents[2]
 DOC = ROOT / "docs" / "product" / "release-readiness.md"
 README = ROOT / "README.md"
 DOCS_INDEX = ROOT / "docs" / "README.md"
@@ -60,10 +60,10 @@ def main() -> None:
         "loopx update --execute",
         "## Named Version Contract",
         "The version source is `loopx.__version__`, mirrored by `pyproject.toml`",
-        "examples/release-version-contract-smoke.py",
+        "examples/release/release-version-contract-smoke.py",
         "## Compatibility Gate",
-        "examples/codex-cli-no-clone-release-verification-smoke.py",
-        "examples/release-readiness-doc-smoke.py",
+        "examples/release/codex-cli-no-clone-release-verification-smoke.py",
+        "examples/release/release-readiness-doc-smoke.py",
         "## Canary Model",
         "catalog-informed readiness slice",
         "near-E2E",

--- a/examples/release/release-version-contract-smoke.py
+++ b/examples/release/release-version-contract-smoke.py
@@ -10,7 +10,7 @@ import tempfile
 from pathlib import Path
 
 
-REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 
 from loopx import __version__  # noqa: E402

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -681,7 +681,7 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
                 "reason": "checks content-ops issue-fix intake from public metadata without external reads or writes",
             },
             {
-                "command": "python3 examples/readme-demo-surface-smoke.py",
+                "command": "python3 examples/public_entry/readme-demo-surface-smoke.py",
                 "tier": "default",
                 "reason": "guards the README and cross-runtime implement/review demo entry surface",
             },
@@ -740,7 +740,7 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
                 "reason": "guards the dry-run packet, CLI route, role split, and no-write boundary",
             },
             {
-                "command": "python3 examples/readme-demo-surface-smoke.py",
+                "command": "python3 examples/public_entry/readme-demo-surface-smoke.py",
                 "tier": "default",
                 "reason": "guards the public README and product note entry points for the demo",
             },

--- a/loopx/canary/runner.py
+++ b/loopx/canary/runner.py
@@ -258,6 +258,8 @@ def _normalize_script_filter(script: str) -> str:
         return ""
     path = Path(value)
     if path.parts and path.parts[0] == "examples":
+        if path.suffix and len(path.parts) == 2:
+            return path.name
         return path.as_posix()
     if path.suffix and len(path.parts) > 1:
         return path.as_posix()


### PR DESCRIPTION
## Summary
- move release verification smokes into examples/release and README public-entry smoke into examples/public_entry
- update release/public-entry docs and canary planner commands to the new paths
- keep legacy root --script selectors working by matching moved scripts by basename

## Validation
- python3 examples/release/release-readiness-doc-smoke.py
- python3 examples/release/release-version-contract-smoke.py
- python3 examples/public_entry/readme-demo-surface-smoke.py
- python3 examples/release/codex-cli-no-clone-release-verification-smoke.py
- python3 examples/canary/smoke-suite-runner-smoke.py
- python3 examples/canary/catalog-planner-smoke.py
- python3 examples/canary/catalog-run-e2e-smoke.py
- python3 examples/cross-runtime-impl-review-demo-smoke.py
- python3 -m py_compile loopx/canary/runner.py loopx/canary/planner.py examples/release/release-readiness-doc-smoke.py examples/release/release-version-contract-smoke.py examples/release/codex-cli-no-clone-release-verification-smoke.py examples/public_entry/readme-demo-surface-smoke.py examples/canary/smoke-suite-runner-smoke.py
- python3 -m loopx.cli --format json canary smoke-suite --suite default-public --script examples/readme-demo-surface-smoke.py --no-execute
- python3 -m loopx.cli --format json canary smoke-suite --suite default-public --script examples/public_entry/readme-demo-surface-smoke.py --no-execute
- python3 -m loopx.cli --format json canary smoke-suite --suite default-public --script examples/release-readiness-doc-smoke.py --no-execute
- git diff --check
- python3 -m loopx.cli --format json check --scan-path loopx/canary --scan-path examples/canary --scan-path examples/release --scan-path examples/public_entry --scan-path docs/product/release-readiness.md --scan-path docs/product/codex-cli-no-clone-release-verification.md --scan-path examples/cross-runtime-impl-review-demo-smoke.py