### PR TITLE
Keep blocked fallback quiet while preserving replan precedence

### DIFF
--- a/examples/todo-first-open-summary-smoke.py
+++ b/examples/todo-first-open-summary-smoke.py
@@ -193,16 +193,16 @@ def assert_blocked_priority_fallback_visible() -> None:
     )
     assert decision["should_run"] is True, decision
     fallback = decision["blocked_priority_fallback"]
-    assert fallback["notify_user"] is True, fallback
+    assert fallback["notify_user"] is False, fallback
     assert fallback["requires_user_action"] is False, fallback
     assert fallback["blocked_items"][0]["text"] == BLOCKED_CORE_TODO, fallback
     assert fallback["selected_executable"]["text"] == FALLBACK_TODO, fallback
-    assert decision["heartbeat_recommendation"]["notify"] == "NOTIFY", decision
+    assert decision["heartbeat_recommendation"]["notify"] == "DONT_NOTIFY", decision
     user_channel = decision["interaction_contract"]["user_channel"]
     assert user_channel["action_required"] is False, user_channel
-    assert user_channel["notify"] == "NOTIFY", user_channel
+    assert user_channel["notify"] == "DONT_NOTIFY", user_channel
     markdown = render_quota_should_run_markdown(decision)
-    assert "blocked_priority_fallback: notify_user=True" in markdown, markdown
+    assert "blocked_priority_fallback: notify_user=False" in markdown, markdown
     assert f"blocked_priority_item[1]: {BLOCKED_CORE_TODO}" in markdown, markdown
     assert f"blocked_priority_selected: {FALLBACK_TODO}" in markdown, markdown
 

--- a/examples/work-lane-contract-smoke.py
+++ b/examples/work-lane-contract-smoke.py
@@ -245,7 +245,7 @@ def assert_contract_word_alone_does_not_trigger_outcome_followthrough() -> None:
     assert "outcome_followthrough" not in lane, lane
 
 
-def assert_monitor_only_todo_waits_quietly() -> None:
+def assert_monitor_only_todo_requires_replan_before_quiet() -> None:
     guard = build_quota_should_run(
         status_payload(
             status="typed_task_lane_planning_writeback",
@@ -269,10 +269,10 @@ def assert_monitor_only_todo_waits_quietly() -> None:
         goal_id=GOAL_ID,
     )
     lane = guard["work_lane_contract"]
-    assert guard["decision"] == "skip", guard
-    assert guard["should_run"] is False, guard
+    assert guard["decision"] == "autonomous_replan_required", guard
+    assert guard["should_run"] is True, guard
     assert guard["normal_delivery_allowed"] is False, guard
-    assert guard["effective_action"] == "monitor_quiet_skip", guard
+    assert guard["effective_action"] == "autonomous_replan_required", guard
     assert lane["schema_version"] == "work_lane_contract_v1", lane
     assert lane["lane"] == "continuous_monitor", lane
     assert lane["monitor_kind"] == "todo_monitor", lane
@@ -280,14 +280,21 @@ def assert_monitor_only_todo_waits_quietly() -> None:
     assert lane["obligation"] == "quiet_until_material_monitor_transition", lane
     assert lane["must_attempt_work"] is False, lane
     assert lane["reason_codes"] == ["monitor_todo_only"], lane
-    assert guard["heartbeat_recommendation"]["recommended_mode"] == "monitor_quiet_until_material_transition", guard
-    assert guard["execution_obligation"]["kind"] == "monitor_quiet_skip", guard
-    assert guard["execution_obligation"]["must_attempt_work"] is False, guard
+    assert guard["heartbeat_recommendation"]["recommended_mode"] == "autonomous_replan_required", guard
+    assert guard["execution_obligation"]["kind"] == "autonomous_replan_required", guard
+    assert guard["execution_obligation"]["must_attempt_work"] is True, guard
+    assert guard["interaction_contract"]["mode"] == "autonomous_replan", guard
+    assert guard["autonomous_replan_decision"]["not_disturbed_by"] == [
+        "monitor_quiet_skip",
+        "agent_scope_wait",
+        "agent_scope_exhausted",
+    ], guard
     first_items = guard["agent_todo_summary"]["first_open_items"]
     assert [item["task_class"] for item in first_items] == ["continuous_monitor", "continuous_monitor"], guard
     markdown = render_quota_should_run_markdown(guard)
     assert "work_lane_contract: lane=continuous_monitor next=continuous_monitor" in markdown, markdown
     assert "obligation=quiet_until_material_monitor_transition" in markdown, markdown
+    assert "autonomous_replan_decision: decision=autonomous_replan_required" in markdown, markdown
 
 
 def assert_monitor_only_with_user_todo_surfaces_user_action_without_transition() -> None:
@@ -671,9 +678,13 @@ def assert_structured_monitor_registration_beats_action_text() -> None:
         goal_id=GOAL_ID,
     )
     lane = guard["work_lane_contract"]
-    assert guard["should_run"] is False, guard
+    assert guard["decision"] == "autonomous_replan_required", guard
+    assert guard["should_run"] is True, guard
+    assert guard["effective_action"] == "autonomous_replan_required", guard
     assert lane["lane"] == "continuous_monitor", lane
     assert lane["obligation"] == "quiet_until_material_monitor_transition", lane
+    assert guard["heartbeat_recommendation"]["recommended_mode"] == "autonomous_replan_required", guard
+    assert guard["interaction_contract"]["mode"] == "autonomous_replan", guard
     first_items = guard["agent_todo_summary"]["first_open_items"]
     assert first_items[0]["task_class"] == TODO_TASK_CLASS_MONITOR, guard
     assert first_items[0]["action_kind"] == "monitor", guard
@@ -715,7 +726,7 @@ def assert_mixed_monitor_and_advancement_routes_to_advancement() -> None:
     assert [item["task_class"] for item in first_items] == ["advancement_task", "continuous_monitor"], guard
 
 
-def assert_not_due_monitor_only_waits_quietly() -> None:
+def assert_not_due_monitor_only_requires_replan_before_quiet() -> None:
     guard = build_quota_should_run(
         status_payload(
             status="monitor_schedule_waiting",
@@ -735,11 +746,13 @@ def assert_not_due_monitor_only_waits_quietly() -> None:
         goal_id=GOAL_ID,
     )
     lane = guard["work_lane_contract"]
-    assert guard["decision"] == "skip", guard
-    assert guard["effective_action"] == "monitor_quiet_skip", guard
+    assert guard["decision"] == "autonomous_replan_required", guard
+    assert guard["effective_action"] == "autonomous_replan_required", guard
     assert lane["lane"] == "continuous_monitor", lane
     assert lane["monitor_kind"] == "todo_monitor", lane
     assert lane["must_attempt_work"] is False, lane
+    assert guard["heartbeat_recommendation"]["recommended_mode"] == "autonomous_replan_required", guard
+    assert guard["interaction_contract"]["mode"] == "autonomous_replan", guard
     assert guard["agent_todo_summary"]["monitor_due_count"] == 0, guard
 
 
@@ -1229,19 +1242,17 @@ def assert_side_agent_monitor_watch_without_handle_stays_quiet() -> None:
         agent_id="codex-side-bypass",
     )
     lane = guard["work_lane_contract"]
-    assert guard["decision"] == "skip", guard
-    assert guard["should_run"] is False, guard
-    assert guard["effective_action"] == "monitor_quiet_skip", guard
+    assert guard["decision"] == "autonomous_replan_required", guard
+    assert guard["should_run"] is True, guard
+    assert guard["effective_action"] == "autonomous_replan_required", guard
     assert lane["lane"] == "continuous_monitor", lane
     assert lane["monitor_kind"] == "todo_monitor", lane
     assert lane["must_attempt_work"] is False, lane
     assert "external_evidence_observation" not in guard, guard
-    assert guard["execution_obligation"]["must_attempt_work"] is False, guard
+    assert guard["execution_obligation"]["must_attempt_work"] is True, guard
     interaction = guard["interaction_contract"]
-    assert interaction["mode"] == "monitor_quiet_skip", interaction
-    assert interaction["agent_channel"]["quiet_noop_allowed"] is True, interaction
-    hint = guard["agent_lane_frontier_hint"]
-    assert hint["reason_code"] == "only_current_agent_monitor_work_remains", hint
+    assert interaction["mode"] == "autonomous_replan", interaction
+    assert interaction["agent_channel"]["quiet_noop_allowed"] is False, interaction
 
 
 def assert_side_agent_monitor_watch_with_handle_requires_observation() -> None:
@@ -2246,7 +2257,7 @@ def main() -> int:
     assert_structured_surface_only_run_requires_outcome_followthrough()
     assert_blocker_writeback_satisfies_contract_followthrough()
     assert_contract_word_alone_does_not_trigger_outcome_followthrough()
-    assert_monitor_only_todo_waits_quietly()
+    assert_monitor_only_todo_requires_replan_before_quiet()
     assert_monitor_only_with_user_todo_surfaces_user_action_without_transition()
     assert_blocked_agent_todo_with_user_gate_notifies_without_execution()
     assert_monitor_only_with_planning_next_action_materializes_advancement()
@@ -2256,7 +2267,7 @@ def main() -> int:
     assert_structured_todo_lane_registration_beats_text_fallback()
     assert_structured_monitor_registration_beats_action_text()
     assert_mixed_monitor_and_advancement_routes_to_advancement()
-    assert_not_due_monitor_only_waits_quietly()
+    assert_not_due_monitor_only_requires_replan_before_quiet()
     assert_due_monitor_only_requires_attempt()
     assert_due_monitor_lower_priority_does_not_preempt_advancement()
     assert_due_monitor_higher_priority_preempts_advancement()

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -2593,7 +2593,7 @@ def _blocked_priority_fallback(
         "schema_version": "blocked_priority_fallback_v0",
         "kind": "blocked_priority_fallback",
         "severity": "warning",
-        "notify_user": True,
+        "notify_user": False,
         "requires_user_action": False,
         "reason": (
             "a higher-priority agent todo is blocked or deferred before the "
@@ -2602,7 +2602,7 @@ def _blocked_priority_fallback(
         "blocked_items": blocked_items[:3],
         "selected_executable": selected_item,
         "recommended_action": (
-            "Surface the blocked core todo and why fallback is being selected; "
+            "Keep the blocked core todo visible in status while selecting fallback; "
             "continue the fallback only if it still matches the latest user priority."
         ),
     }
@@ -4874,6 +4874,23 @@ def _interaction_spend_policy(
     return "no spend without validated transition"
 
 
+def _blocked_priority_fallback_user_reason(payload: dict[str, Any]) -> str | None:
+    fallback = (
+        payload.get("blocked_priority_fallback")
+        if isinstance(payload.get("blocked_priority_fallback"), dict)
+        else {}
+    )
+    if not fallback:
+        return None
+    if (
+        fallback.get("requires_user_action") is not True
+        and fallback.get("notify_user") is not True
+    ):
+        return None
+    reason = str(fallback.get("reason") or "").strip()
+    return reason or None
+
+
 def _interaction_contract(payload: dict[str, Any]) -> dict[str, Any]:
     execution_obligation = (
         payload.get("execution_obligation")
@@ -4943,11 +4960,7 @@ def _interaction_contract(payload: dict[str, Any]) -> dict[str, Any]:
         payload.get("open_todo_notify_reason")
         or payload.get("gate_prompt")
         or payload.get("operator_question")
-        or (
-            payload.get("blocked_priority_fallback", {}).get("reason")
-            if isinstance(payload.get("blocked_priority_fallback"), dict)
-            else None
-        )
+        or _blocked_priority_fallback_user_reason(payload)
         or (
             payload.get("scoped_user_gate_fallback", {}).get("reason")
             if isinstance(payload.get("scoped_user_gate_fallback"), dict)
@@ -7212,11 +7225,15 @@ def build_quota_should_run(
         if blocked_priority_fallback and should_run:
             heartbeat_recommendation = {
                 **heartbeat_recommendation,
-                "notify": "NOTIFY",
-                "reason": blocked_priority_fallback.get("reason")
-                or heartbeat_recommendation.get("reason"),
                 "blocked_priority_fallback": blocked_priority_fallback,
             }
+            if blocked_priority_fallback.get("notify_user") is True:
+                heartbeat_recommendation = {
+                    **heartbeat_recommendation,
+                    "notify": "NOTIFY",
+                    "reason": blocked_priority_fallback.get("reason")
+                    or heartbeat_recommendation.get("reason"),
+                }
         external_evidence_observation = _external_evidence_observation_obligation(
             item,
             state=state,


### PR DESCRIPTION
## Summary
- keep blocked-priority fallback visible in quota/status without forcing user notifications when no user action is required
- preserve agent execution: agent_channel.must_attempt=true remains independent from quiet user channel
- update work-lane smoke expectations so monitor-only frontiers are overtaken by autonomous replan instead of quiet wait

## Validation
- python3 examples/todo-first-open-summary-smoke.py
- python3 examples/work-lane-contract-smoke.py
- python3 examples/heartbeat-quota-flow-smoke.py
- python3 examples/quota-replan-decision-plane-smoke.py
- python3 -m py_compile loopx/quota.py
- patched live guard dry check against loopx-meta
- git diff --check
- public/private boundary scan over diff
