### PR TITLE
Keep agent replan ACK visible after monitor polls

### DIFF
--- a/examples/quota-replan-decision-plane-smoke.py
+++ b/examples/quota-replan-decision-plane-smoke.py
@@ -61,10 +61,26 @@ def primary_claimed_advancement() -> dict:
     }
 
 
+def blocking_handoff_review() -> dict:
+    return {
+        "index": 2,
+        "todo_id": "todo_fixture_review_gate",
+        "text": "[P1] Primary agent reviews the side-agent delivery PR.",
+        "role": "agent",
+        "status": "open",
+        "priority": "P1",
+        "task_class": "advancement_task",
+        "action_kind": "review_merge",
+        "claimed_by": PRIMARY_AGENT,
+        "blocks_agent": SIDE_AGENT,
+    }
+
+
 def status_payload(
     agent_todo_items: list[dict],
     *,
     replan_obligation: dict | None = REPLAN_OBLIGATION,
+    latest_runs: list[dict] | None = None,
 ) -> dict:
     agent_todos = compact_todo_group(
         agent_todo_items,
@@ -120,6 +136,7 @@ def status_payload(
                         "registered_agents": [PRIMARY_AGENT, SIDE_AGENT],
                         "primary_agent": PRIMARY_AGENT,
                     },
+                    "latest_runs": latest_runs or [],
                 }
             ]
         },
@@ -195,10 +212,79 @@ def assert_empty_monitor_frontier_derives_replan() -> None:
     assert scheduler["cadence_class"] == "active_work", guard
 
 
+def assert_agent_ack_survives_other_agent_run_and_monitor_poll() -> None:
+    guard = build_quota_should_run(
+        status_payload(
+            [monitor_item()],
+            replan_obligation=None,
+            latest_runs=[
+                {
+                    "classification": "state_refreshed",
+                    "agent_id": PRIMARY_AGENT,
+                    "progress_scope": "agent_lane",
+                    "recommended_action": "Primary lane refreshed unrelated state.",
+                },
+                {
+                    "classification": "quota_monitor_poll",
+                    "agent_id": SIDE_AGENT,
+                    "recommended_action": "Fixture monitor stayed unchanged.",
+                    "monitor_target": {
+                        "schema_version": "quota_monitor_target_v0",
+                        "target_id": "fixture-monitor-target",
+                        "monitor_mode": "monitor_quiet_until_material_transition",
+                        "effective_action": "monitor_quiet_skip",
+                        "agent_id": SIDE_AGENT,
+                    },
+                },
+                {
+                    "classification": "monitor_poll_autonomous_replan_recorded_v0",
+                    "agent_id": SIDE_AGENT,
+                    "progress_scope": "agent_lane",
+                    "autonomous_replan_ack": {
+                        "schema_version": "autonomous_replan_ack_v0",
+                        "recorded": True,
+                        "source": "refresh_state",
+                        "delta_contract": {
+                            "schema_version": "repair_delta_contract_v0",
+                            "delta_present": True,
+                            "delta_kinds": ["watch_lane_continuation", "no_followup"],
+                        },
+                    },
+                },
+            ],
+        ),
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+    )
+    assert guard["effective_action"] == "monitor_quiet_skip", guard
+    assert guard["should_run"] is False, guard
+    assert guard["interaction_contract"]["mode"] == "monitor_quiet_skip", guard
+    assert guard["goal_frontier_projection"]["replan_required"] is False, guard
+    assert guard.get("autonomous_replan_obligation") is None, guard
+
+
+def assert_blocking_handoff_gate_beats_derived_monitor_replan() -> None:
+    guard = build_quota_should_run(
+        status_payload([monitor_item(), blocking_handoff_review()], replan_obligation=None),
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+    )
+    assert guard["effective_action"] == "monitor_quiet_skip", guard
+    assert guard["should_run"] is False, guard
+    assert guard["interaction_contract"]["mode"] == "monitor_quiet_skip", guard
+    assert guard["goal_route_hint"]["blocking_handoff_gates"][0]["todo_id"] == (
+        "todo_fixture_review_gate"
+    ), guard
+    assert guard["goal_frontier_projection"]["replan_required"] is False, guard
+    assert guard.get("autonomous_replan_obligation") is None, guard
+
+
 def main() -> None:
     assert_replan_beats_monitor_quiet_skip()
     assert_replan_beats_agent_scope_wait()
     assert_empty_monitor_frontier_derives_replan()
+    assert_agent_ack_survives_other_agent_run_and_monitor_poll()
+    assert_blocking_handoff_gate_beats_derived_monitor_replan()
     print("quota-replan-decision-plane-smoke ok")
 
 

--- a/loopx/policies/goal_frontier.py
+++ b/loopx/policies/goal_frontier.py
@@ -209,6 +209,29 @@ def _is_monitor_only_lane(
     )
 
 
+def _blocking_handoff_gate_count(
+    agent_todo_summary: dict[str, Any] | None,
+    *,
+    agent_id: str | None,
+) -> int:
+    if not agent_id or not isinstance(agent_todo_summary, dict):
+        return 0
+    gates = agent_todo_summary.get("current_agent_handoff_gates")
+    if not isinstance(gates, list):
+        gates = agent_todo_summary.get("handoff_gates")
+    if not isinstance(gates, list):
+        return 0
+    return len(
+        [
+            item
+            for item in gates
+            if isinstance(item, dict)
+            and str(item.get("blocks_agent") or "").strip() == agent_id
+            and str(item.get("gate_state") or "").strip() == "blocking"
+        ]
+    )
+
+
 def derive_goal_frontier_replan_obligation_from_summaries(
     *,
     user_todo_summary: dict[str, Any] | None,
@@ -228,6 +251,8 @@ def derive_goal_frontier_replan_obligation_from_summaries(
     if autonomous_replan_is_required(existing_replan_obligation):
         return None
     if autonomous_replan_ack_has_frontier_delta(latest_replan_ack):
+        return None
+    if _blocking_handoff_gate_count(agent_todo_summary, agent_id=agent_id) > 0:
         return None
 
     user_counts = _summary_task_counts(user_todo_summary)

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -112,6 +112,12 @@ QUOTA_SLOT_SPENT_CLASSIFICATION = "quota_slot_spent"
 QUOTA_SLOT_VOIDED_CLASSIFICATION = "quota_slot_voided"
 QUOTA_MONITOR_POLL_CLASSIFICATION = "quota_monitor_poll"
 QUOTA_SCHEDULER_ACK_CLASSIFICATION = "quota_scheduler_ack"
+AUTONOMOUS_REPLAN_ACK_NEUTRAL_CLASSIFICATIONS = {
+    QUOTA_SLOT_SPENT_CLASSIFICATION,
+    QUOTA_SLOT_VOIDED_CLASSIFICATION,
+    QUOTA_SCHEDULER_ACK_CLASSIFICATION,
+    "delivery_completion_spend_accounted_v0",
+}
 DEFAULT_SLOT_SPEND_SOURCE = "heartbeat"
 VALID_SLOT_SPEND_SOURCES = {"heartbeat", "controller", "adapter"}
 USER_GATE_ACTION_KIND_HINTS = (
@@ -6883,6 +6889,81 @@ def _registry_goal_by_id(status_payload: dict[str, Any]) -> dict[str, dict[str, 
     }
 
 
+def _compact_autonomous_replan_ack(run: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(run, dict):
+        return None
+    ack = run.get("autonomous_replan_ack")
+    if not isinstance(ack, dict) or ack.get("recorded") is not True:
+        return None
+    delta_contract = ack.get("delta_contract")
+    if not isinstance(delta_contract, dict) or delta_contract.get("delta_present") is not True:
+        return None
+    compact_delta = {
+        "schema_version": delta_contract.get("schema_version"),
+        "delta_present": True,
+        "delta_kinds": [
+            str(item)
+            for item in (delta_contract.get("delta_kinds") or [])
+            if str(item or "").strip()
+        ],
+    }
+    result = {
+        "schema_version": ack.get("schema_version"),
+        "recorded": True,
+        "source": ack.get("source"),
+        "delta_contract": compact_delta,
+    }
+    agent_id = str(run.get("agent_id") or "").strip()
+    if agent_id:
+        result["agent_id"] = agent_id
+    return result
+
+
+def _latest_autonomous_replan_ack_for_agent(
+    status_payload: dict[str, Any],
+    *,
+    goal_id: str,
+    agent_id: str | None,
+) -> dict[str, Any] | None:
+    if not agent_id:
+        return None
+    run_history = (
+        status_payload.get("run_history")
+        if isinstance(status_payload.get("run_history"), dict)
+        else {}
+    )
+    goals = run_history.get("goals") if isinstance(run_history.get("goals"), list) else []
+    goal = next(
+        (
+            item
+            for item in goals
+            if isinstance(item, dict) and str(item.get("id") or "") == goal_id
+        ),
+        None,
+    )
+    latest_runs = goal.get("latest_runs") if isinstance(goal, dict) else None
+    if not isinstance(latest_runs, list):
+        return None
+    for run in latest_runs:
+        if not isinstance(run, dict):
+            continue
+        run_agent_id = str(run.get("agent_id") or "").strip()
+        if run_agent_id and run_agent_id != agent_id:
+            continue
+        replan_ack = _compact_autonomous_replan_ack(run)
+        if replan_ack:
+            return replan_ack
+        classification = str(run.get("classification") or "").strip()
+        if not classification:
+            continue
+        if classification in AUTONOMOUS_REPLAN_ACK_NEUTRAL_CLASSIFICATIONS:
+            continue
+        if classification == QUOTA_MONITOR_POLL_CLASSIFICATION:
+            continue
+        return None
+    return None
+
+
 def _recovery_delivery_allowed(quota: dict[str, Any], *, plan_ok: bool) -> bool:
     return (
         bool(plan_ok)
@@ -7039,13 +7120,19 @@ def build_quota_should_run(
             if isinstance(agent_identity, dict)
             else None
         )
+        latest_agent_replan_ack = _latest_autonomous_replan_ack_for_agent(
+            status_payload,
+            goal_id=safe_goal_id,
+            agent_id=agent_frontier_id,
+        )
         frontier_replan_obligation = derive_goal_frontier_replan_obligation_from_summaries(
             user_todo_summary=user_todo_summary,
             agent_todo_summary=agent_todo_summary,
             work_lane_contract=work_lane_contract,
             agent_id=agent_frontier_id,
             existing_replan_obligation=replan_obligation,
-            latest_replan_ack=(
+            latest_replan_ack=latest_agent_replan_ack
+            or (
                 item.get("autonomous_replan_ack")
                 if isinstance(item.get("autonomous_replan_ack"), dict)
                 else project_asset.get("autonomous_replan_ack")


### PR DESCRIPTION
## Summary

- keep an agent-scoped autonomous replan ACK visible to `quota should-run --agent-id ...` even when another agent records a later non-neutral run
- prevent monitor-only lanes from immediately re-entering `autonomous_replan_required` after a valid `watch_lane_continuation` / `no_followup` ACK plus monitor-poll
- keep derived frontier replan from overriding a current-agent blocking handoff gate; that state remains monitor quiet / wait with route-hint evidence instead of replan loop
- add focused regressions to `quota-replan-decision-plane-smoke.py`

## Validation

- `python3 examples/quota-replan-decision-plane-smoke.py`
- `python3 examples/heartbeat-quota-flow-smoke.py`
- `python3 examples/monitor-poll-writeback-smoke.py`
- `python3 -m py_compile loopx/quota.py loopx/policies/goal_frontier.py examples/quota-replan-decision-plane-smoke.py`
- `git diff --check`
- `loopx --format json check --scan-path loopx/quota.py --scan-path loopx/policies/goal_frontier.py --scan-path examples/quota-replan-decision-plane-smoke.py`
- live verification with patched source: `quota should-run --goal-id loopx-meta --agent-id codex-product-capability` projects `monitor_quiet_skip`, `replan_required=false`, and keeps blocking handoff gates in the route hint
