### PR TITLE
Quiet side-lane next-action writeback warnings

### DIFF
--- a/examples/next-action-projection-contract-smoke.py
+++ b/examples/next-action-projection-contract-smoke.py
@@ -184,7 +184,10 @@ def main() -> None:
             assert first_item["next_action_projection_warning"]["requires_state_writeback"] is True, first_item
             assert first_decision["active_state_next_action"] == ACTIVE_NEXT_ACTION, first_decision
             assert first_decision["latest_run_recommended_action"] == RUN_RECOMMENDATION, first_decision
-            assert first_decision["next_action_projection_warning"]["requires_state_writeback"] is True, first_decision
+            first_warning = first_decision["next_action_projection_warning"]
+            assert first_warning["severity"] == "info", first_decision
+            assert first_warning["requires_state_writeback"] is False, first_decision
+            assert first_warning["agent_lane_next_action"] == "[P1] Polish the hosted frontstage public case card.", first_decision
 
             state_refresh.now_local = lambda: "2026-06-22T00:02:00+00:00"
             explicit_payload = state_refresh.refresh_state_run(
@@ -223,9 +226,19 @@ def main() -> None:
             assert lane["todo_id"] == "todo_side", second_decision
             assert lane["title"] == SIDE_AGENT_ACTION, second_decision
             assert SIDE_AGENT_ACTION in lane["text"], second_decision
+            warning = second_decision["next_action_projection_warning"]
+            assert warning["severity"] == "info", second_decision
+            assert warning["requires_state_writeback"] is False, second_decision
             assert (
-                second_decision["next_action_projection_warning"]["agent_lane_next_action"]
-                == lane["text"]
+                warning["reason"]
+                == "current agent lane action differs from the durable goal route while explicitly preserving the active-state Next Action"
+            ), second_decision
+            assert (
+                warning["recommended_action"]
+                == "run the agent-lane action without mutating active-state Next Action; only the primary/goal route should write a new durable Next Action"
+            ), second_decision
+            assert (
+                warning["agent_lane_next_action"] == lane["text"]
             ), second_decision
             assert "active_state_next_action" in status_markdown, status_markdown
             assert "latest_run_recommended_action" in status_markdown, status_markdown

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -7396,14 +7396,10 @@ def build_quota_should_run(
             or project_asset.get("latest_run_recommended_action"),
             limit=320,
         )
-        agent_lane_next_action_text = _protocol_action_text(
-            agent_lane_next_action.get("text") if isinstance(agent_lane_next_action, dict) else None,
-            limit=320,
-        )
         next_action_warning = next_action_projection_warning(
             active_state_next_action=active_state_next_action_text,
             latest_run_recommended_action=latest_run_recommended_action_text,
-            agent_lane_next_action=agent_lane_next_action_text,
+            agent_lane_next_action=agent_lane_next_action,
         )
         goal_route_hint = build_goal_route_hint(
             agent_identity=agent_identity,

--- a/loopx/state_projection.py
+++ b/loopx/state_projection.py
@@ -153,24 +153,43 @@ def next_action_projection_warning(
         return None
     if actions_are_projection_aligned(active_text, latest_text):
         return None
+    lane_preserves_goal_next_action = (
+        isinstance(agent_lane_next_action, dict)
+        and agent_lane_next_action.get("preserves_goal_next_action") is True
+    )
     warning: dict[str, Any] = {
         "schema_version": NEXT_ACTION_PROJECTION_WARNING_SCHEMA_VERSION,
         "kind": "next_action_projection_mismatch",
-        "severity": "warning",
-        "requires_state_writeback": True,
+        "severity": "info" if lane_preserves_goal_next_action else "warning",
+        "requires_state_writeback": not lane_preserves_goal_next_action,
         "active_state_next_action": active_text,
         "latest_run_recommended_action": latest_text,
-        "reason": (
+    }
+    if lane_preserves_goal_next_action:
+        warning["reason"] = (
+            "current agent lane action differs from the durable goal route while "
+            "explicitly preserving the active-state Next Action"
+        )
+        warning["recommended_action"] = (
+            "run the agent-lane action without mutating active-state Next Action; "
+            "only the primary/goal route should write a new durable Next Action"
+        )
+    else:
+        warning["reason"] = (
             "latest run recommended_action differs from the durable active-state "
             "Next Action"
-        ),
-        "recommended_action": (
+        )
+        warning["recommended_action"] = (
             "if the latest run action is the intended durable route, write it back "
             "explicitly with refresh-state --next-action; otherwise keep treating "
             "the run recommendation and active-state Next Action as separate signals"
-        ),
-    }
-    lane_text = _action_projection_text(agent_lane_next_action)
+        )
+    lane_value = (
+        agent_lane_next_action.get("text")
+        if isinstance(agent_lane_next_action, dict)
+        else agent_lane_next_action
+    )
+    lane_text = _action_projection_text(lane_value)
     if lane_text:
         warning["agent_lane_next_action"] = lane_text
     return warning


### PR DESCRIPTION
## Summary
- Treat next-action projection mismatches as informational when the selected agent lane explicitly preserves the durable goal Next Action.
- Pass the full agent-lane next-action object into quota warning projection so side-agent lane metadata is available.
- Extend the next-action projection contract smoke to cover the side-agent no-writeback case.

## Validation
- python3 -m py_compile loopx/state_projection.py loopx/quota.py
- python3 examples/next-action-projection-contract-smoke.py
- python3 examples/work-lane-contract-smoke.py
- python3 examples/status-markdown-smoke.py
- live quota shape check for loopx-meta/codex-side-bypass with PYTHONPATH=. confirmed severity=info and requires_state_writeback=false
- git diff --check
- public/private boundary scan over diff

## Product / Architecture Judgment
This is a narrow control-plane projection cleanup: side-agent lane work should not be told to mutate the durable goal route when the route hint says it is preserving that route. The reusable contract remains in state_projection/quota, while replan/vision policy stays outside quota.