### PR TITLE
Expose deferred successors in goal frontier

### DIFF
--- a/examples/quota-replan-decision-plane-smoke.py
+++ b/examples/quota-replan-decision-plane-smoke.py
@@ -141,12 +141,20 @@ def assert_replan_beats_monitor_quiet_skip() -> None:
     assert guard["interaction_contract"]["agent_channel"]["must_attempt"] is True, guard
     assert guard["goal_frontier_projection"]["replan_required"] is True, guard
     assert guard["goal_frontier_projection"]["monitor_only_lanes"]["present"] is True, guard
+    assert guard["goal_frontier_projection"]["deferred_successors"] == {
+        "ready_count": 0,
+        "blocked_count": 0,
+        "current_agent_ready_count": 0,
+        "ready_todo_ids": [],
+    }, guard
+    assert guard["goal_frontier_projection"]["acceptance_gaps"] == [], guard
     assert guard["autonomous_replan_decision"]["decision_plane"] == (
         "goal_frontier_before_lane_quiet_or_agent_scope_wait"
     ), guard
     assert "monitor_quiet_skip" in guard["autonomous_replan_decision"]["not_disturbed_by"], guard
     markdown = render_quota_should_run_markdown(guard)
     assert "goal_frontier_projection: replan_required=True" in markdown, markdown
+    assert "deferred_ready=0 acceptance_gaps=0" in markdown, markdown
     assert "autonomous_replan_decision: decision=autonomous_replan_required" in markdown, markdown
 
 
@@ -167,6 +175,8 @@ def assert_replan_beats_agent_scope_wait() -> None:
     assert frontier["current_agent_claimed_advancement_count"] == 0, guard
     assert frontier["unclaimed_advancement_count"] == 0, guard
     assert frontier["other_agent_claimed_advancement_count"] == 1, guard
+    assert guard["goal_frontier_projection"]["deferred_successors"]["ready_count"] == 0, guard
+    assert guard["goal_frontier_projection"]["acceptance_gaps"] == [], guard
     assert "agent_scope_wait" in guard["autonomous_replan_decision"]["not_disturbed_by"], guard
 
 

--- a/examples/work-lane-contract-smoke.py
+++ b/examples/work-lane-contract-smoke.py
@@ -1803,6 +1803,14 @@ def assert_side_agent_replans_when_deferred_successor_is_ready() -> None:
     assert frontier["quiet_noop_allowed"] is False, frontier
     assert frontier["requires_replan"] is True, frontier
     assert frontier["deferred_resume_candidates"][0]["todo_id"] == "todo_issue_surface_deferred", frontier
+    goal_frontier = guard["goal_frontier_projection"]
+    deferred_successors = goal_frontier["deferred_successors"]
+    assert deferred_successors["ready_count"] == 1, goal_frontier
+    assert deferred_successors["blocked_count"] == 0, goal_frontier
+    assert deferred_successors["current_agent_ready_count"] == 1, goal_frontier
+    assert deferred_successors["top_ready_todo_id"] == "todo_issue_surface_deferred", goal_frontier
+    assert deferred_successors["ready_todo_ids"] == ["todo_issue_surface_deferred"], goal_frontier
+    assert goal_frontier["acceptance_gaps"] == [], goal_frontier
     hint = guard["agent_lane_frontier_hint"]
     assert hint["schema_version"] == "agent_lane_frontier_hint_v0", hint
     assert hint["decision"] == "add_next_advancement", hint

--- a/loopx/policies/goal_frontier.py
+++ b/loopx/policies/goal_frontier.py
@@ -199,6 +199,58 @@ def _frontier_advancement_counts(
     }
 
 
+def _compact_todo_id(item: Any) -> str | None:
+    if not isinstance(item, dict):
+        return None
+    todo_id = str(item.get("todo_id") or "").strip()
+    return todo_id or None
+
+
+def _deferred_successors(
+    summary: dict[str, Any] | None,
+    *,
+    agent_id: str | None,
+) -> dict[str, Any]:
+    if not isinstance(summary, dict):
+        return {
+            "ready_count": 0,
+            "blocked_count": 0,
+            "current_agent_ready_count": 0,
+            "ready_todo_ids": [],
+        }
+
+    ready_items = [
+        item
+        for item in (summary.get("deferred_resume_candidates") or [])
+        if isinstance(item, dict)
+    ]
+    deferred_items = [
+        item for item in (summary.get("deferred_items") or []) if isinstance(item, dict)
+    ]
+    deferred_count = max(
+        safe_non_negative_int(summary.get("deferred_count")),
+        len(deferred_items),
+        len(ready_items),
+    )
+    current_agent_ready_items = [
+        item
+        for item in ready_items
+        if agent_id and str(item.get("claimed_by") or "").strip() == agent_id
+    ]
+    ready_todo_ids = [
+        todo_id for todo_id in (_compact_todo_id(item) for item in ready_items[:5]) if todo_id
+    ]
+    projection = {
+        "ready_count": len(ready_items),
+        "blocked_count": max(0, deferred_count - len(ready_items)),
+        "current_agent_ready_count": len(current_agent_ready_items),
+        "ready_todo_ids": ready_todo_ids,
+    }
+    if ready_todo_ids:
+        projection["top_ready_todo_id"] = ready_todo_ids[0]
+    return projection
+
+
 def _is_monitor_only_lane(
     work_lane_contract: dict[str, Any] | None,
 ) -> bool:
@@ -325,6 +377,10 @@ def build_goal_frontier_projection_from_summaries(
         ],
         monitor_only_lane=monitor_only_lane,
         replan_obligation=replan_obligation,
+        deferred_successors=_deferred_successors(
+            agent_todo_summary,
+            agent_id=agent_id,
+        ),
     )
 
 
@@ -396,6 +452,7 @@ def build_goal_frontier_projection(
     other_agent_claimed_advancement_count: int,
     monitor_only_lane: bool,
     replan_obligation: dict[str, Any] | None,
+    deferred_successors: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     replan_required = autonomous_replan_is_required(replan_obligation)
     blockers: list[str] = []
@@ -431,6 +488,15 @@ def build_goal_frontier_projection(
             "present": monitor_only_lane,
             "quiet_until_material_transition": monitor_only_lane,
         },
+        "deferred_successors": deferred_successors
+        if isinstance(deferred_successors, dict)
+        else {
+            "ready_count": 0,
+            "blocked_count": 0,
+            "current_agent_ready_count": 0,
+            "ready_todo_ids": [],
+        },
+        "acceptance_gaps": [],
         "autonomy_blockers": blockers,
         "replan_required": replan_required,
     }

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -9639,12 +9639,24 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             if isinstance(goal_frontier.get("remaining_advancement_frontier"), dict)
             else {}
         )
+        deferred_successors = (
+            goal_frontier.get("deferred_successors")
+            if isinstance(goal_frontier.get("deferred_successors"), dict)
+            else {}
+        )
+        acceptance_gaps = (
+            goal_frontier.get("acceptance_gaps")
+            if isinstance(goal_frontier.get("acceptance_gaps"), list)
+            else []
+        )
         lines.append(
             "- goal_frontier_projection: "
             f"replan_required={goal_frontier.get('replan_required')} "
             f"current_agent_advancement={remaining.get('current_agent_claimed_advancement_count')} "
             f"unclaimed_advancement={remaining.get('unclaimed_advancement_count')} "
-            f"other_agent_advancement={remaining.get('other_agent_claimed_advancement_count')}"
+            f"other_agent_advancement={remaining.get('other_agent_claimed_advancement_count')} "
+            f"deferred_ready={deferred_successors.get('ready_count')} "
+            f"acceptance_gaps={len(acceptance_gaps)}"
         )
     replan_decision = (
         payload.get("autonomous_replan_decision")


### PR DESCRIPTION
## Summary
- Add a compact `deferred_successors` projection to `goal_frontier_projection`, including ready/blocked counts and top ready todo ids.
- Add an explicit `acceptance_gaps` projection field so status/quota/diagnose consumers can rely on a stable shape even when no gap is present.
- Render deferred-ready and acceptance-gap counts in quota markdown and cover both monitor-only and ready-deferred-successor cases with focused smokes.

## Validation
- python3 -m py_compile loopx/policies/goal_frontier.py loopx/quota.py
- python3 examples/quota-replan-decision-plane-smoke.py
- python3 examples/work-lane-contract-smoke.py
- python3 examples/status-markdown-smoke.py
- python3 examples/next-action-projection-contract-smoke.py
- live quota shape check for loopx-meta/codex-side-bypass with PYTHONPATH=. confirmed no decision change and new projection fields present
- git diff --check
- public/private boundary scan over diff

## Product / Architecture Judgment
This keeps the status sufficiency work in the goal-frontier projection seam. Quota only renders the compact facts; it does not absorb more per-agent vision or replan state-machine logic. The user/operator win is that agents can see ready deferred successors and explicit no-gap state from the same status/quota/diagnose payload instead of estimating from chat history.
