### PR TITLE
Render goal frontier in status markdown

### DIFF
--- a/examples/status-markdown-smoke.py
+++ b/examples/status-markdown-smoke.py
@@ -1450,6 +1450,9 @@ def assert_status_agent_lane_next_action_projection() -> None:
     assert next_action["todo_id"] == "todo_side_tui", next_action
     assert next_action["agent_id"] == "codex-side-bypass", next_action
     assert next_action["preserves_goal_next_action"] is True, next_action
+    goal_frontier = item["goal_frontier_projection"]
+    assert goal_frontier["deferred_successors"]["ready_count"] == 0, goal_frontier
+    assert goal_frontier["acceptance_gaps"] == [], goal_frontier
     assert item["recommended_action"] == primary_action, item
     assert item["project_asset"]["next_action"] == primary_action, item
     member = item["agent_member"]
@@ -1475,6 +1478,8 @@ def assert_status_agent_lane_next_action_projection() -> None:
     assert "claims=todo_side_tui" in markdown, markdown
     assert "current_agent_todo: agent=codex-side-bypass todo_id=todo_side_tui" in markdown, markdown
     assert "source=agent_lane_next_action" in markdown, markdown
+    assert "goal_frontier_projection: replan_required=False" in markdown, markdown
+    assert "deferred_ready=0 acceptance_gaps=0" in markdown, markdown
     assert side_action in markdown, markdown
     assert f"next_agent_todo: {primary_action} claimed_by=codex-main-control scope=goal_all_agents" in markdown, markdown
     assert f"asset_agent_todo: {primary_action} claimed_by=codex-main-control scope=goal_all_agents" in markdown, markdown
@@ -1570,6 +1575,14 @@ def assert_status_agent_lane_frontier_hint_projection() -> None:
     assert "agent_lane_next_action" not in item, item
     frontier = item["agent_scope_frontier"]
     assert frontier["action"] == "agent_scope_wait", frontier
+    goal_frontier = item["goal_frontier_projection"]
+    assert goal_frontier["remaining_advancement_frontier"] == {
+        "current_agent_claimed_advancement_count": 0,
+        "unclaimed_advancement_count": 0,
+        "other_agent_claimed_advancement_count": 1,
+    }, goal_frontier
+    assert goal_frontier["deferred_successors"]["ready_count"] == 0, goal_frontier
+    assert goal_frontier["acceptance_gaps"] == [], goal_frontier
     hint = item["agent_lane_frontier_hint"]
     assert hint["schema_version"] == "agent_lane_frontier_hint_v0", hint
     assert hint["decision"] == "quiet_noop_blocker", hint
@@ -1583,6 +1596,8 @@ def assert_status_agent_lane_frontier_hint_projection() -> None:
     assert "agent_lane_frontier_hint: agent=codex-side-bypass" in markdown, markdown
     assert "decision=quiet_noop_blocker" in markdown, markdown
     assert "target_todo_id=todo_primary_route" in markdown, markdown
+    assert "goal_frontier_projection: replan_required=False" in markdown, markdown
+    assert "other_agent_advancement=1 deferred_ready=0 acceptance_gaps=0" in markdown, markdown
 
 
 def assert_quota_should_run(

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -11000,6 +11000,38 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
                     f"reason_code={_markdown_scalar(agent_lane_frontier_hint.get('reason_code') or '')} "
                     f"target_todo_id={_markdown_scalar(agent_lane_frontier_hint.get('target_todo_id') or '')}"
                 )
+            goal_frontier = (
+                project_asset.get("goal_frontier_projection")
+                if isinstance(project_asset.get("goal_frontier_projection"), dict)
+                else item.get("goal_frontier_projection")
+                if isinstance(item.get("goal_frontier_projection"), dict)
+                else {}
+            )
+            if goal_frontier:
+                remaining = (
+                    goal_frontier.get("remaining_advancement_frontier")
+                    if isinstance(goal_frontier.get("remaining_advancement_frontier"), dict)
+                    else {}
+                )
+                deferred_successors = (
+                    goal_frontier.get("deferred_successors")
+                    if isinstance(goal_frontier.get("deferred_successors"), dict)
+                    else {}
+                )
+                acceptance_gaps = (
+                    goal_frontier.get("acceptance_gaps")
+                    if isinstance(goal_frontier.get("acceptance_gaps"), list)
+                    else []
+                )
+                lines.append(
+                    "    - goal_frontier_projection: "
+                    f"replan_required={goal_frontier.get('replan_required')} "
+                    f"current_agent_advancement={remaining.get('current_agent_claimed_advancement_count')} "
+                    f"unclaimed_advancement={remaining.get('unclaimed_advancement_count')} "
+                    f"other_agent_advancement={remaining.get('other_agent_claimed_advancement_count')} "
+                    f"deferred_ready={deferred_successors.get('ready_count')} "
+                    f"acceptance_gaps={len(acceptance_gaps)}"
+                )
             dreaming_lane_badge = (
                 project_asset.get("dreaming_lane_badge")
                 if isinstance(project_asset.get("dreaming_lane_badge"), dict)


### PR DESCRIPTION
## Summary
- Render `goal_frontier_projection` in status markdown for agent-scoped views.
- Include current/unclaimed/other-agent advancement counts plus deferred-ready and acceptance-gap counts.
- Extend status markdown smoke coverage for both selected agent-lane work and agent-scope wait cases.

## Validation
- python3 -m py_compile loopx/status.py
- python3 examples/status-markdown-smoke.py
- python3 examples/quota-replan-decision-plane-smoke.py
- python3 examples/work-lane-contract-smoke.py
- live status markdown check with PYTHONPATH=. confirmed `goal_frontier_projection` appears with deferred/gap counts
- git diff --check
- public/private boundary scan over diff

## Product / Architecture Judgment
This is the display companion to the goal-frontier projection contract: quota/status/diagnose now expose the same compact frontier facts, and status markdown no longer hides deferred successor or acceptance-gap state from human-readable packets. It does not change scheduler, quota decisions, replan policy, or runner behavior.
