### PR TITLE
Render goal frontier in diagnose markdown

### DIFF
--- a/examples/agent-diagnose-packet-smoke.py
+++ b/examples/agent-diagnose-packet-smoke.py
@@ -174,12 +174,18 @@ def main() -> int:
         assert "can_self_drive" not in selected, selected
         assert selected["todo_evidence"]["agent_open_count"] == 1, selected
         assert selected["quota_signals"]["should_run"] is True, selected
+        assert selected["quota_signals"]["goal_frontier_projection"]["replan_required"] is False, (
+            selected
+        )
         assert selected["agent_reasoning_checklist"], selected
 
         markdown = run_markdown("--registry", str(registry), "diagnose", "--goal-id", GOAL_ID)
         assert "LoopX is not making the final diagnosis" in markdown, markdown
         assert "Agent Reasoning Checklist" in markdown, markdown
         assert "These are for the agent to run" in markdown, markdown
+        assert "goal_frontier_projection: replan_required=False" in markdown, markdown
+        assert "current_agent_advancement=0" in markdown, markdown
+        assert "unclaimed_advancement=1" in markdown, markdown
 
         gated_project = write_project(root, "gated-project")
         gated_goal_id = "diagnose-smoke-gated"

--- a/loopx/diagnose.py
+++ b/loopx/diagnose.py
@@ -205,6 +205,54 @@ def _compact_quota_signals(quota: dict[str, Any]) -> dict[str, Any]:
     return {key: quota.get(key) for key in keys if key in quota}
 
 
+def _goal_frontier_projection_line(goal_frontier: dict[str, Any]) -> str | None:
+    if not goal_frontier:
+        return None
+    normalized_progress = (
+        goal_frontier.get("normalized_progress")
+        if isinstance(goal_frontier.get("normalized_progress"), dict)
+        else {}
+    )
+    remaining = (
+        goal_frontier.get("remaining_advancement_frontier")
+        if isinstance(goal_frontier.get("remaining_advancement_frontier"), dict)
+        else {}
+    )
+    deferred_successors = (
+        goal_frontier.get("deferred_successors")
+        if isinstance(goal_frontier.get("deferred_successors"), dict)
+        else {}
+    )
+    monitor_only_lanes = (
+        goal_frontier.get("monitor_only_lanes")
+        if isinstance(goal_frontier.get("monitor_only_lanes"), dict)
+        else {}
+    )
+    acceptance_gaps = (
+        goal_frontier.get("acceptance_gaps")
+        if isinstance(goal_frontier.get("acceptance_gaps"), list)
+        else []
+    )
+    autonomy_blockers = (
+        goal_frontier.get("autonomy_blockers")
+        if isinstance(goal_frontier.get("autonomy_blockers"), list)
+        else []
+    )
+    return (
+        "- goal_frontier_projection: "
+        f"replan_required={goal_frontier.get('replan_required')} "
+        f"user_open={normalized_progress.get('user_open_count')} "
+        f"agent_open={normalized_progress.get('agent_open_count')} "
+        f"current_agent_advancement={remaining.get('current_agent_claimed_advancement_count')} "
+        f"unclaimed_advancement={remaining.get('unclaimed_advancement_count')} "
+        f"other_agent_advancement={remaining.get('other_agent_claimed_advancement_count')} "
+        f"deferred_ready={deferred_successors.get('ready_count')} "
+        f"monitor_only={monitor_only_lanes.get('present')} "
+        f"acceptance_gaps={len(acceptance_gaps)} "
+        f"autonomy_blockers={len(autonomy_blockers)}"
+    )
+
+
 def _build_goal_packet(
     *,
     status_payload: dict[str, Any],
@@ -379,6 +427,11 @@ def render_diagnosis_markdown(payload: dict[str, Any]) -> str:
                 f"- quota_reason: {quota.get('reason')}",
             ]
         )
+        goal_frontier_line = _goal_frontier_projection_line(
+            _as_dict(quota.get("goal_frontier_projection"))
+        )
+        if goal_frontier_line:
+            lines.append(goal_frontier_line)
 
     checklist = _as_list(selected.get("agent_reasoning_checklist"))
     if checklist:


### PR DESCRIPTION
## Summary
- Render `goal_frontier_projection` in `loopx diagnose --format markdown` so diagnose exposes whole-goal progress/frontier, deferred successor count, monitor-only status, acceptance gaps, and autonomy blockers.
- Extend the agent diagnose smoke to assert the JSON projection is present and the markdown sink renders advancement frontier counts.

## Product / architecture judgment
- Motivation: agents should not estimate whole-goal completion from chat memory when diagnosing why a lane appears idle.
- Solved: diagnose already carried the projection in compact quota signals; this PR makes the human-facing diagnosis sink show it directly.
- User/operator impact: status, quota, and diagnose now all expose the same compact frontier signal for replan and monitor-lane decisions.
- Risk: low, display-only markdown rendering plus focused smoke; no quota decision, permission, benchmark scoring, or public evidence-policy change.
- Design: keeps logic out of quota and avoids a new control plane; diagnose only renders an existing bounded projection.

## Validation
- `python3 -m py_compile loopx/diagnose.py`
- `PYTHONPATH=. python3 examples/agent-diagnose-packet-smoke.py`
- `git diff --check`
- public/private boundary scan over changed diff
