### PR TITLE
Prefer selected agent todo in diagnose

### DIFF
--- a/examples/agent-diagnose-packet-smoke.py
+++ b/examples/agent-diagnose-packet-smoke.py
@@ -11,6 +11,10 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.diagnose import _first_agent_todo_text  # noqa: E402
+
 GOAL_ID = "diagnose-smoke-goal"
 SCOPED_GOAL_ID = "diagnose-smoke-agent-scoped"
 
@@ -42,6 +46,22 @@ def write_project(root: Path, name: str) -> Path:
     project.mkdir()
     (project / "README.md").write_text("# Diagnose fixture\n", encoding="utf-8")
     return project
+
+
+def assert_selected_agent_todo_preferred() -> None:
+    selected = "[P0] Run the selected lane-local kernel slice."
+    blocked = "[P0] Old blocked item that should not headline diagnose."
+    executable = "[P1] Fallback executable item."
+    assert (
+        _first_agent_todo_text(
+            {"agent_lane_next_action": {"text": selected}},
+            {
+                "backlog_items": [{"status": "blocked", "text": blocked}],
+                "first_executable_items": [{"status": "open", "text": executable}],
+            },
+        )
+        == selected
+    )
 
 
 def bootstrap_project(project: Path, runtime: Path, goal_id: str, *, onboarding: bool) -> dict:
@@ -138,6 +158,7 @@ def write_agent_scoped_registry(root: Path, runtime: Path) -> Path:
 
 
 def main() -> int:
+    assert_selected_agent_todo_preferred()
     with tempfile.TemporaryDirectory(prefix="loopx-agent-diagnose-smoke-") as tmp:
         root = Path(tmp)
         runtime = root / "runtime"

--- a/loopx/diagnose.py
+++ b/loopx/diagnose.py
@@ -48,6 +48,18 @@ def _first_text(summary: dict[str, Any]) -> str | None:
     return None
 
 
+def _first_agent_todo_text(quota: dict[str, Any], summary: dict[str, Any]) -> str | None:
+    selected = _as_dict(quota.get("agent_lane_next_action"))
+    if selected.get("text"):
+        return str(selected.get("text"))
+    if selected.get("title"):
+        return str(selected.get("title"))
+    for item in _as_list(summary.get("first_executable_items")):
+        if isinstance(item, dict) and item.get("text"):
+            return str(item.get("text"))
+    return _first_text(summary)
+
+
 def _open_count(summary: dict[str, Any]) -> int:
     for key in ("open_count", "open"):
         value = summary.get(key)
@@ -282,7 +294,7 @@ def _build_goal_packet(
             "user_open_count": _open_count(user_summary),
             "agent_open_count": _open_count(agent_summary),
             "first_user_todo": _first_text(user_summary),
-            "first_agent_todo": _first_text(agent_summary),
+            "first_agent_todo": _first_agent_todo_text(quota, agent_summary),
         },
         "quota_signals": _compact_quota_signals(quota),
         "agent_id": agent_id,


### PR DESCRIPTION
## Summary
- Prefer `agent_lane_next_action` when building diagnose `first_agent_todo` evidence.
- Fall back to executable agent todos before generic backlog text, so blocked/stale backlog items do not headline an otherwise runnable lane.
- Add a focused diagnose smoke assertion for the selected-todo preference.

## Product / architecture judgment
- Motivation: after #1171 made diagnose more visible, the packet surfaced a misleading `first_agent_todo` from a blocked backlog item while quota had already selected the current runnable lane.
- Solved: diagnose now mirrors quota's selected agent lane action in its headline todo evidence without changing todo selection or quota behavior.
- User/operator impact: agent-facing diagnosis is less contradictory; operators see the actual current lane instead of an unrelated blocked P0.
- Risk: low, display-packet ordering only plus a focused smoke; no scheduler, quota decision, permission, benchmark scoring, or evidence-policy change.
- Design: keeps this as a diagnose sink correction and does not expand `quota.py`.

## Validation
- `python3 -m py_compile loopx/diagnose.py examples/agent-diagnose-packet-smoke.py`
- `python3 examples/agent-diagnose-packet-smoke.py`
- `git diff --check`
- public/private boundary scan over changed diff
