### PR TITLE
Expose scheduler hint in diagnose packets

### DIFF
--- a/examples/agent-diagnose-packet-smoke.py
+++ b/examples/agent-diagnose-packet-smoke.py
@@ -76,13 +76,34 @@ def assert_diagnose_markdown_separates_status_and_packet_goal_counts() -> None:
             "goal_count": 24,
             "goal_packet_count": 1,
             "run_count": 42,
-            "selected": {"todo_evidence": {}, "quota_signals": {}},
+            "selected": {
+                "todo_evidence": {},
+                "quota_signals": {
+                    "scheduler_hint": {
+                        "action": "run_now",
+                        "cadence_class": "active_work",
+                        "codex_app": {
+                            "apply": "update_rrule",
+                            "apply_needed": True,
+                            "recommended_rrule": "FREQ=MINUTELY;INTERVAL=3",
+                            "current_rrule": "FREQ=MINUTELY;INTERVAL=10",
+                            "no_spend_for_cadence_change": True,
+                        },
+                        "unchanged_poll": {
+                            "final_quota_replan_check_enabled": True,
+                        },
+                    }
+                },
+            },
             "goals": [{"goal_id": "selected-goal", "todo_evidence": {}}],
         }
     )
     assert "- status_goals: `24`" in markdown, markdown
     assert "- goal_packets: `1`" in markdown, markdown
     assert "- goals: `24`" not in markdown, markdown
+    assert "- scheduler_hint: action=run_now cadence=active_work" in markdown, markdown
+    assert "apply_needed=True" in markdown, markdown
+    assert "final_replan_check=True" in markdown, markdown
 
 
 def bootstrap_project(project: Path, runtime: Path, goal_id: str, *, onboarding: bool) -> dict:
@@ -220,6 +241,10 @@ def main() -> int:
         assert selected["quota_signals"]["goal_frontier_projection"]["replan_required"] is False, (
             selected
         )
+        scheduler_hint = selected["quota_signals"]["scheduler_hint"]
+        assert scheduler_hint["schema_version"] == "diagnose_scheduler_hint_summary_v0", selected
+        assert "local_scheduler" not in str(scheduler_hint), scheduler_hint
+        assert scheduler_hint["codex_app"]["no_spend_for_cadence_change"] is True, scheduler_hint
         assert selected["agent_reasoning_checklist"], selected
 
         markdown = run_markdown("--registry", str(registry), "diagnose", "--goal-id", GOAL_ID)
@@ -229,6 +254,8 @@ def main() -> int:
         assert "goal_frontier_projection: replan_required=False" in markdown, markdown
         assert "current_agent_advancement=0" in markdown, markdown
         assert "unclaimed_advancement=1" in markdown, markdown
+        assert "scheduler_hint: action=" in markdown, markdown
+        assert "no_spend_for_cadence_change=True" in markdown, markdown
 
         gated_project = write_project(root, "gated-project")
         gated_goal_id = "diagnose-smoke-gated"

--- a/loopx/diagnose.py
+++ b/loopx/diagnose.py
@@ -214,7 +214,47 @@ def _compact_quota_signals(quota: dict[str, Any]) -> dict[str, Any]:
         "goal_frontier_projection",
         "autonomous_replan_decision",
     )
-    return {key: quota.get(key) for key in keys if key in quota}
+    signals = {key: quota.get(key) for key in keys if key in quota}
+    scheduler_hint = _compact_scheduler_hint(_as_dict(quota.get("scheduler_hint")))
+    if scheduler_hint:
+        signals["scheduler_hint"] = scheduler_hint
+    return signals
+
+
+def _compact_scheduler_hint(scheduler_hint: dict[str, Any]) -> dict[str, Any]:
+    if not scheduler_hint:
+        return {}
+    codex_app = _as_dict(scheduler_hint.get("codex_app"))
+    stateful_backoff = _as_dict(codex_app.get("stateful_backoff"))
+    reset_policy = _as_dict(scheduler_hint.get("reset_policy"))
+    unchanged_poll = _as_dict(scheduler_hint.get("unchanged_poll"))
+    return {
+        "schema_version": "diagnose_scheduler_hint_summary_v0",
+        "action": scheduler_hint.get("action"),
+        "cadence_class": scheduler_hint.get("cadence_class"),
+        "reason": scheduler_hint.get("reason"),
+        "codex_app": {
+            "apply": codex_app.get("apply"),
+            "host_action": codex_app.get("host_action"),
+            "recommended_rrule": codex_app.get("recommended_rrule"),
+            "recommended_interval_minutes": codex_app.get("recommended_interval_minutes"),
+            "current_rrule": stateful_backoff.get("current_rrule"),
+            "apply_needed": stateful_backoff.get("apply_needed"),
+            "no_spend_for_cadence_change": codex_app.get("no_spend_for_cadence_change"),
+        },
+        "unchanged_poll": {
+            "final_quota_replan_check_enabled": unchanged_poll.get(
+                "final_quota_replan_check_enabled"
+            ),
+            "final_quota_replan_check_action": unchanged_poll.get(
+                "final_quota_replan_check_action"
+            ),
+        },
+        "reset_policy": {
+            "reset_token": reset_policy.get("reset_token"),
+            "codex_app_initial_rrule": reset_policy.get("codex_app_initial_rrule"),
+        },
+    }
 
 
 def _goal_frontier_projection_line(goal_frontier: dict[str, Any]) -> str | None:
@@ -262,6 +302,24 @@ def _goal_frontier_projection_line(goal_frontier: dict[str, Any]) -> str | None:
         f"monitor_only={monitor_only_lanes.get('present')} "
         f"acceptance_gaps={len(acceptance_gaps)} "
         f"autonomy_blockers={len(autonomy_blockers)}"
+    )
+
+
+def _scheduler_hint_line(scheduler_hint: dict[str, Any]) -> str | None:
+    if not scheduler_hint:
+        return None
+    codex_app = _as_dict(scheduler_hint.get("codex_app"))
+    unchanged_poll = _as_dict(scheduler_hint.get("unchanged_poll"))
+    return (
+        "- scheduler_hint: "
+        f"action={scheduler_hint.get('action')} "
+        f"cadence={scheduler_hint.get('cadence_class')} "
+        f"codex_app_apply={codex_app.get('apply')} "
+        f"apply_needed={codex_app.get('apply_needed')} "
+        f"recommended_rrule={codex_app.get('recommended_rrule')} "
+        f"current_rrule={codex_app.get('current_rrule')} "
+        f"final_replan_check={unchanged_poll.get('final_quota_replan_check_enabled')} "
+        f"no_spend_for_cadence_change={codex_app.get('no_spend_for_cadence_change')}"
     )
 
 
@@ -446,6 +504,9 @@ def render_diagnosis_markdown(payload: dict[str, Any]) -> str:
         )
         if goal_frontier_line:
             lines.append(goal_frontier_line)
+        scheduler_hint_line = _scheduler_hint_line(_as_dict(quota.get("scheduler_hint")))
+        if scheduler_hint_line:
+            lines.append(scheduler_hint_line)
 
     checklist = _as_list(selected.get("agent_reasoning_checklist"))
     if checklist:


### PR DESCRIPTION
## Summary
- add a compact scheduler hint summary to diagnose quota signals
- render a one-line scheduler hint in markdown diagnosis packets
- cover JSON and markdown behavior in the agent diagnose smoke

## Validation
- python3 -m py_compile loopx/diagnose.py examples/agent-diagnose-packet-smoke.py
- PYTHONPATH=. python3 examples/agent-diagnose-packet-smoke.py
- PYTHONPATH=. python3 -m loopx.cli --format markdown --registry ~/.codex/loopx/registry.global.json --runtime-root ~/.codex/loopx diagnose --goal-id loopx-meta --agent-id codex-side-bypass | rg "scheduler_hint|goal_frontier_projection|quota_should_run"
- PYTHONPATH=. python3 -m loopx.cli --format json --registry ~/.codex/loopx/registry.global.json --runtime-root ~/.codex/loopx diagnose --goal-id loopx-meta --agent-id codex-side-bypass | python3 -c "import json,sys; p=json.load(sys.stdin); q=p[\"selected\"][\"quota_signals\"]; s=q.get(\"scheduler_hint\",{}); print(s.get(\"schema_version\"), s.get(\"action\"), s.get(\"codex_app\",{}).get(\"apply_needed\"), s.get(\"codex_app\",{}).get(\"current_rrule\"))"
- git diff --check
- public/private boundary scan over changed paths