### PR TITLE
Clarify duplicate index status warnings

### DIFF
--- a/examples/contract-reward-overlay-smoke.py
+++ b/examples/contract-reward-overlay-smoke.py
@@ -114,8 +114,9 @@ def main() -> None:
         assert payload["ok"] is True, payload
         assert "reward-overlay-goal: reward overlay rows raw=2 unique=1 overlays=1" in checks, payload
         assert "reward-overlay-goal: duplicate index rows" not in warnings, payload
-        assert "plain-duplicate-goal: duplicate index rows raw=2 unique=1" in warnings, payload
-        assert "loopx history inspect-index-duplicates --goal-id plain-duplicate-goal" in warnings, payload
+        assert "plain-duplicate-goal: duplicate index rows raw=2 unique=1 unexpected=1" in warnings, payload
+        assert "loopx history --goal-id plain-duplicate-goal inspect-index-duplicates" in warnings, payload
+        assert "loopx history --goal-id plain-duplicate-goal repair-index-duplicates" in warnings, payload
         assert not any(".local/managed_doc" in item for item in payload["errors"]), payload
 
     print("contract-reward-overlay-smoke ok")

--- a/loopx/contract.py
+++ b/loopx/contract.py
@@ -203,11 +203,28 @@ def _index_duplicate_summary(index_path: Path) -> dict[str, Any]:
     }
 
 
-def _index_duplicate_warning(goal_id: object, raw: int, unique: int) -> str:
+def _index_duplicate_warning(
+    goal_id: object,
+    raw: int,
+    unique: int,
+    duplicate_summary: dict[str, Any] | None = None,
+) -> str:
     safe_goal_id = str(goal_id)
+    duplicate_summary = duplicate_summary or {}
+    detail_parts = []
+    unexpected_rows = int(duplicate_summary.get("unexpected_duplicate_rows") or 0)
+    reward_overlay_rows = int(duplicate_summary.get("reward_overlay_rows") or 0)
+    if unexpected_rows:
+        detail_parts.append(f"unexpected={unexpected_rows}")
+    if reward_overlay_rows:
+        detail_parts.append(f"reward_overlays={reward_overlay_rows}")
+    if not detail_parts and raw > unique:
+        detail_parts.append(f"duplicates={raw - unique}")
+    detail = f" {' '.join(detail_parts)}" if detail_parts else ""
     return (
-        f"{safe_goal_id}: duplicate index rows raw={raw} unique={unique}; "
-        f"inspect with `loopx history inspect-index-duplicates --goal-id {safe_goal_id}`"
+        f"{safe_goal_id}: duplicate index rows raw={raw} unique={unique}{detail}; "
+        f"inspect with `loopx history --goal-id {safe_goal_id} inspect-index-duplicates`; "
+        f"preview repair with `loopx history --goal-id {safe_goal_id} repair-index-duplicates`"
     )
 
 
@@ -486,14 +503,14 @@ def check_contract(
         if raw > unique:
             duplicate_summary = _index_duplicate_summary(Path(str(item.get("index_path") or "")))
             if duplicate_summary.get("unexpected_duplicate_rows"):
-                warnings.append(_index_duplicate_warning(item.get("id"), raw, unique))
+                warnings.append(_index_duplicate_warning(item.get("id"), raw, unique, duplicate_summary))
             elif duplicate_summary.get("reward_overlay_rows"):
                 checks.append(
                     f"{item.get('id')}: reward overlay rows raw={raw} unique={unique} "
                     f"overlays={duplicate_summary.get('reward_overlay_rows')}"
                 )
             else:
-                warnings.append(_index_duplicate_warning(item.get("id"), raw, unique))
+                warnings.append(_index_duplicate_warning(item.get("id"), raw, unique, duplicate_summary))
 
     boundary = scan_public_boundary(scan_roots, registry=registry)
     if boundary.get("ok"):


### PR DESCRIPTION
## Summary
- include unexpected duplicate and reward-overlay counts in duplicate-index contract warnings
- point operators at canonical inspect and repair-preview commands
- update the reward-overlay contract smoke for the clearer warning text

## Validation
- python3 -m py_compile loopx/contract.py examples/contract-reward-overlay-smoke.py examples/history-index-duplicate-inspection-smoke.py
- PYTHONPATH=. python3 examples/contract-reward-overlay-smoke.py
- PYTHONPATH=. python3 examples/history-index-duplicate-inspection-smoke.py
- PYTHONPATH=. python3 -m loopx.cli --format json --registry ~/.codex/loopx/registry.global.json --runtime-root ~/.codex/loopx status --goal-id loopx-meta | python3 -c "import json,sys; p=json.load(sys.stdin); print(\"\n\".join(p.get(\"contract\",{}).get(\"warnings\",[])))"
- git diff --check
- public/private boundary scan over changed paths