### PR TITLE
Expose contract warnings in diagnose packets

### DIFF
--- a/examples/agent-diagnose-packet-smoke.py
+++ b/examples/agent-diagnose-packet-smoke.py
@@ -95,6 +95,18 @@ def assert_diagnose_markdown_separates_status_and_packet_goal_counts() -> None:
                     }
                 },
             },
+            "status_summary": {
+                "contract_warnings": [
+                    "fixture-goal: duplicate index rows raw=2 unique=1 unexpected=1",
+                    "fixture-goal: stale projection warning A",
+                    "fixture-goal: stale projection warning B",
+                ],
+                "contract_warnings_total_count": 4,
+                "contract_warnings_truncated": True,
+                "contract_errors": [],
+                "contract_errors_total_count": 0,
+                "contract_errors_truncated": False,
+            },
             "goals": [{"goal_id": "selected-goal", "todo_evidence": {}}],
         }
     )
@@ -104,6 +116,9 @@ def assert_diagnose_markdown_separates_status_and_packet_goal_counts() -> None:
     assert "- scheduler_hint: action=run_now cadence=active_work" in markdown, markdown
     assert "apply_needed=True" in markdown, markdown
     assert "final_replan_check=True" in markdown, markdown
+    assert "Status Contract Signals" in markdown, markdown
+    assert "duplicate index rows raw=2 unique=1 unexpected=1" in markdown, markdown
+    assert "contract_warnings_truncated: total=4" in markdown, markdown
 
 
 def bootstrap_project(project: Path, runtime: Path, goal_id: str, *, onboarding: bool) -> dict:

--- a/loopx/diagnose.py
+++ b/loopx/diagnose.py
@@ -10,6 +10,7 @@ from .status import collect_status
 
 DIAGNOSIS_SCHEMA_VERSION = "loopx_agent_diagnosis_packet_v0"
 PACKET_KIND = "agent_reasoning_evidence_packet"
+STATUS_CONTRACT_SIGNAL_LIMIT = 3
 
 
 USER_DIAGNOSE_PROMPT = (
@@ -36,6 +37,16 @@ def _as_dict(value: Any) -> dict[str, Any]:
 
 def _as_list(value: Any) -> list[Any]:
     return value if isinstance(value, list) else []
+
+
+def _compact_text_signals(value: Any, *, limit: int = STATUS_CONTRACT_SIGNAL_LIMIT) -> dict[str, Any]:
+    items = [str(item).strip() for item in _as_list(value) if str(item).strip()]
+    bounded = items[: max(0, limit)]
+    return {
+        "items": bounded,
+        "truncated": len(items) > len(bounded),
+        "total_count": len(items),
+    }
 
 
 def _first_text(summary: dict[str, Any]) -> str | None:
@@ -427,6 +438,9 @@ def collect_diagnosis(
             limit=limit,
             agent_id=agent_id,
         )
+    contract = _as_dict(status_payload.get("contract"))
+    contract_errors = _compact_text_signals(contract.get("errors"))
+    contract_warnings = _compact_text_signals(contract.get("warnings"))
     return {
         "ok": bool(status_payload.get("ok")),
         "schema_version": DIAGNOSIS_SCHEMA_VERSION,
@@ -445,7 +459,13 @@ def collect_diagnosis(
         "selected": selected,
         "goals": goal_packets,
         "status_summary": {
-            "contract": _as_dict(status_payload.get("contract")).get("summary"),
+            "contract": contract.get("summary"),
+            "contract_errors": contract_errors["items"],
+            "contract_errors_total_count": contract_errors["total_count"],
+            "contract_errors_truncated": contract_errors["truncated"],
+            "contract_warnings": contract_warnings["items"],
+            "contract_warnings_total_count": contract_warnings["total_count"],
+            "contract_warnings_truncated": contract_warnings["truncated"],
             "global_registry": _as_dict(_as_dict(status_payload.get("global_registry")).get("summary")),
         },
         "user_prompt": USER_DIAGNOSE_PROMPT,
@@ -456,6 +476,7 @@ def render_diagnosis_markdown(payload: dict[str, Any]) -> str:
     selected = _as_dict(payload.get("selected"))
     todo_evidence = _as_dict(selected.get("todo_evidence"))
     quota = _as_dict(selected.get("quota_signals"))
+    status_summary = _as_dict(payload.get("status_summary"))
     lines = [
         "# LoopX Diagnosis Packet",
         "",
@@ -507,6 +528,23 @@ def render_diagnosis_markdown(payload: dict[str, Any]) -> str:
         scheduler_hint_line = _scheduler_hint_line(_as_dict(quota.get("scheduler_hint")))
         if scheduler_hint_line:
             lines.append(scheduler_hint_line)
+
+    contract_errors = _as_list(status_summary.get("contract_errors"))
+    contract_warnings = _as_list(status_summary.get("contract_warnings"))
+    if contract_errors or contract_warnings:
+        lines.extend(["", "## Status Contract Signals", ""])
+        for item in contract_errors:
+            lines.append(f"- contract_error: {item}")
+        if status_summary.get("contract_errors_truncated"):
+            lines.append(
+                f"- contract_errors_truncated: total={status_summary.get('contract_errors_total_count')}"
+            )
+        for item in contract_warnings:
+            lines.append(f"- contract_warning: {item}")
+        if status_summary.get("contract_warnings_truncated"):
+            lines.append(
+                f"- contract_warnings_truncated: total={status_summary.get('contract_warnings_total_count')}"
+            )
 
     checklist = _as_list(selected.get("agent_reasoning_checklist"))
     if checklist:


### PR DESCRIPTION
## Summary
- include bounded status contract warnings/errors in diagnose JSON packets
- render contract warning/error details in diagnose markdown so agents can reason without a separate status drill-down
- cover the markdown contract-warning path in the existing agent diagnose smoke

## Validation
- python3 -m py_compile loopx/diagnose.py examples/agent-diagnose-packet-smoke.py
- PYTHONPATH=. python3 examples/agent-diagnose-packet-smoke.py
- git diff --check
- PYTHONPATH=. python3 -m loopx.cli --format json --registry ~/.codex/loopx/registry.global.json --runtime-root ~/.codex/loopx diagnose --goal-id loopx-meta --agent-id codex-side-bypass
- PYTHONPATH=. python3 -m loopx.cli --format markdown --registry ~/.codex/loopx/registry.global.json --runtime-root ~/.codex/loopx diagnose --goal-id loopx-meta --agent-id codex-side-bypass | rg -n "Status Contract Signals|contract_warning|duplicate index"