### PR TITLE
Clarify duplicate index warning actions

### DIFF
--- a/examples/contract-reward-overlay-smoke.py
+++ b/examples/contract-reward-overlay-smoke.py
@@ -41,6 +41,11 @@ def write_run(run_dir: Path, goal_id: str, *, duplicate_kind: str) -> None:
         )
     elif duplicate_kind == "plain_duplicate":
         lines.append(dict(record))
+    elif duplicate_kind == "artifact_identity_collision":
+        lines = [
+            {**record, "classification": "benchmark_run_v0"},
+            {**record, "classification": "state_refreshed"},
+        ]
     else:
         raise ValueError(f"unknown duplicate_kind: {duplicate_kind}")
     (run_dir / "index.jsonl").write_text(
@@ -55,10 +60,15 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
     project.mkdir(parents=True)
     reward_state_file = project / ".codex" / "goals" / "reward-overlay-goal" / "ACTIVE_GOAL_STATE.md"
     duplicate_state_file = project / ".codex" / "goals" / "plain-duplicate-goal" / "ACTIVE_GOAL_STATE.md"
+    artifact_collision_state_file = (
+        project / ".codex" / "goals" / "artifact-collision-goal" / "ACTIVE_GOAL_STATE.md"
+    )
     reward_state_file.parent.mkdir(parents=True)
     duplicate_state_file.parent.mkdir(parents=True)
+    artifact_collision_state_file.parent.mkdir(parents=True)
     reward_state_file.write_text("---\nupdated_at: 2026-01-01T00:00:00+00:00\n---\n", encoding="utf-8")
     duplicate_state_file.write_text("---\nupdated_at: 2026-01-01T00:00:00+00:00\n---\n", encoding="utf-8")
+    artifact_collision_state_file.write_text("---\nupdated_at: 2026-01-01T00:00:00+00:00\n---\n", encoding="utf-8")
     local_private_doc = project / ".local" / "managed_doc" / "PRIVATE_DRAFT.md"
     local_private_doc.parent.mkdir(parents=True)
     private_host = "private-docs.example.invalid"
@@ -66,6 +76,11 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
 
     write_run(runtime_root / "goals" / "reward-overlay-goal" / "runs", "reward-overlay-goal", duplicate_kind="reward_overlay")
     write_run(runtime_root / "goals" / "plain-duplicate-goal" / "runs", "plain-duplicate-goal", duplicate_kind="plain_duplicate")
+    write_run(
+        runtime_root / "goals" / "artifact-collision-goal" / "runs",
+        "artifact-collision-goal",
+        duplicate_kind="artifact_identity_collision",
+    )
 
     registry = root / "registry.json"
     registry.write_text(
@@ -85,6 +100,14 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
                         "id": "plain-duplicate-goal",
                         "repo": str(project),
                         "state_file": ".codex/goals/plain-duplicate-goal/ACTIVE_GOAL_STATE.md",
+                        "domain": "smoke",
+                        "status": "connected-read-only",
+                        "adapter": {"kind": "smoke", "status": "connected-read-only"},
+                    },
+                    {
+                        "id": "artifact-collision-goal",
+                        "repo": str(project),
+                        "state_file": ".codex/goals/artifact-collision-goal/ACTIVE_GOAL_STATE.md",
                         "domain": "smoke",
                         "status": "connected-read-only",
                         "adapter": {"kind": "smoke", "status": "connected-read-only"},
@@ -114,9 +137,15 @@ def main() -> None:
         assert payload["ok"] is True, payload
         assert "reward-overlay-goal: reward overlay rows raw=2 unique=1 overlays=1" in checks, payload
         assert "reward-overlay-goal: duplicate index rows" not in warnings, payload
-        assert "plain-duplicate-goal: duplicate index rows raw=2 unique=1 unexpected=1" in warnings, payload
+        assert "plain-duplicate-goal: duplicate index rows raw=2 unique=1 unexpected=1 auto_repairable=1" in warnings, payload
         assert "loopx history --goal-id plain-duplicate-goal inspect-index-duplicates" in warnings, payload
         assert "loopx history --goal-id plain-duplicate-goal repair-index-duplicates" in warnings, payload
+        assert (
+            "artifact-collision-goal: duplicate index rows raw=2 unique=1 unexpected=1 "
+            "artifact_identity_collisions=1 artifact_collision_rows=1"
+        ) in warnings, payload
+        assert "artifact identity collisions need reviewed merge semantics" in warnings, payload
+        assert "loopx history --goal-id artifact-collision-goal repair-index-duplicates" not in warnings, payload
         assert not any(".local/managed_doc" in item for item in payload["errors"]), payload
 
     print("contract-reward-overlay-smoke ok")

--- a/loopx/contract.py
+++ b/loopx/contract.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any
 
 from .agent_registry import registered_agent_ids_for_goal
-from .history import collect_history, load_registry
+from .history import STRUCTURED_INDEX_KEYS, collect_history, load_registry
 from .paths import DEFAULT_RUNTIME_ROOT, rel_or_abs, resolve_runtime_root
 from .registry import inspect_registry, inspect_registry_boundary, registry_goals, resolve_state_file
 from .todo_contract import (
@@ -159,6 +159,9 @@ def _index_duplicate_summary(index_path: Path) -> dict[str, Any]:
             "duplicate_rows": 0,
             "reward_overlay_rows": 0,
             "unexpected_duplicate_rows": 0,
+            "repairable_duplicate_rows": 0,
+            "artifact_identity_collision_rows": 0,
+            "artifact_identity_collision_groups": 0,
         }
 
     with index_path.open(encoding="utf-8") as f:
@@ -180,6 +183,9 @@ def _index_duplicate_summary(index_path: Path) -> dict[str, Any]:
 
     reward_overlay_rows = 0
     unexpected_duplicate_rows = 0
+    repairable_duplicate_rows = 0
+    artifact_identity_collision_rows = 0
+    artifact_identity_collision_groups = 0
     for records in groups.values():
         if len(records) <= 1:
             continue
@@ -193,14 +199,42 @@ def _index_duplicate_summary(index_path: Path) -> dict[str, Any]:
         normalized_keys = {json.dumps(record, sort_keys=True, ensure_ascii=False) for record in normalized}
         if reward_records and len(normalized_keys) == 1:
             reward_overlay_rows += duplicate_rows
+        elif len(normalized_keys) == 1 or _is_repairable_structured_artifact_duplicate(records):
+            unexpected_duplicate_rows += duplicate_rows
+            repairable_duplicate_rows += duplicate_rows
         else:
             unexpected_duplicate_rows += duplicate_rows
+            artifact_identity_collision_rows += duplicate_rows
+            artifact_identity_collision_groups += 1
 
     return {
         "duplicate_rows": reward_overlay_rows + unexpected_duplicate_rows,
         "reward_overlay_rows": reward_overlay_rows,
         "unexpected_duplicate_rows": unexpected_duplicate_rows,
+        "repairable_duplicate_rows": repairable_duplicate_rows,
+        "artifact_identity_collision_rows": artifact_identity_collision_rows,
+        "artifact_identity_collision_groups": artifact_identity_collision_groups,
     }
+
+
+def _has_structured_index_payload(record: dict[str, Any]) -> bool:
+    return any(isinstance(record.get(key), dict) for key in STRUCTURED_INDEX_KEYS)
+
+
+def _is_repairable_structured_artifact_duplicate(records: list[dict[str, Any]]) -> bool:
+    classifications = {str(record.get("classification") or "") for record in records}
+    health_checks = {str(record.get("health_check") or "") for record in records if record.get("health_check")}
+    structured_rows = [record for record in records if _has_structured_index_payload(record)]
+    return (
+        len(structured_rows) == 1
+        and len(classifications) == 1
+        and len(health_checks) > 1
+        and all(
+            _has_structured_index_payload(record)
+            or all(key not in record for key in STRUCTURED_INDEX_KEYS)
+            for record in records
+        )
+    )
 
 
 def _index_duplicate_warning(
@@ -213,19 +247,34 @@ def _index_duplicate_warning(
     duplicate_summary = duplicate_summary or {}
     detail_parts = []
     unexpected_rows = int(duplicate_summary.get("unexpected_duplicate_rows") or 0)
+    repairable_rows = int(duplicate_summary.get("repairable_duplicate_rows") or 0)
+    artifact_collision_rows = int(duplicate_summary.get("artifact_identity_collision_rows") or 0)
+    artifact_collision_groups = int(duplicate_summary.get("artifact_identity_collision_groups") or 0)
     reward_overlay_rows = int(duplicate_summary.get("reward_overlay_rows") or 0)
     if unexpected_rows:
         detail_parts.append(f"unexpected={unexpected_rows}")
+    if repairable_rows:
+        detail_parts.append(f"auto_repairable={repairable_rows}")
+    if artifact_collision_groups:
+        detail_parts.append(f"artifact_identity_collisions={artifact_collision_groups}")
+    if artifact_collision_rows:
+        detail_parts.append(f"artifact_collision_rows={artifact_collision_rows}")
     if reward_overlay_rows:
         detail_parts.append(f"reward_overlays={reward_overlay_rows}")
     if not detail_parts and raw > unique:
         detail_parts.append(f"duplicates={raw - unique}")
     detail = f" {' '.join(detail_parts)}" if detail_parts else ""
-    return (
-        f"{safe_goal_id}: duplicate index rows raw={raw} unique={unique}{detail}; "
-        f"inspect with `loopx history --goal-id {safe_goal_id} inspect-index-duplicates`; "
-        f"preview repair with `loopx history --goal-id {safe_goal_id} repair-index-duplicates`"
-    )
+    inspect_command = f"`loopx history --goal-id {safe_goal_id} inspect-index-duplicates`"
+    repair_command = f"`loopx history --goal-id {safe_goal_id} repair-index-duplicates`"
+    if artifact_collision_rows:
+        action = (
+            f"inspect with {inspect_command}; artifact identity collisions need reviewed merge semantics"
+        )
+        if repairable_rows:
+            action += f"; preview safe repair for auto-repairable rows with {repair_command}"
+    else:
+        action = f"inspect with {inspect_command}; preview repair with {repair_command}"
+    return f"{safe_goal_id}: duplicate index rows raw={raw} unique={unique}{detail}; {action}"
 
 
 def _active_state_user_gate_scope_errors(registry: dict[str, Any]) -> tuple[list[str], int]:


### PR DESCRIPTION
## Summary
- classify duplicate run-index warnings into auto-repairable rows, artifact identity collisions, and reward overlays
- avoid suggesting repair preview as the action for blocked artifact identity collisions
- extend contract smoke coverage for artifact identity collision warning text

## Why
After PR #1176, diagnose exposed the duplicate-index warning directly. The warning still implied `repair-index-duplicates` was the next useful action, but the repair preview showed the live loopx-meta case is blocked by artifact identity collisions and needs reviewed merge semantics.

## Validation
- python3 -m py_compile loopx/contract.py examples/contract-reward-overlay-smoke.py
- PYTHONPATH=. python3 examples/contract-reward-overlay-smoke.py
- PYTHONPATH=. python3 examples/history-index-duplicate-inspection-smoke.py
- git diff --check
- PYTHONPATH=. python3 -m loopx.cli --format json --registry ~/.codex/loopx/registry.global.json --runtime-root ~/.codex/loopx status --goal-id loopx-meta
- PYTHONPATH=. python3 -m loopx.cli --format json --registry ~/.codex/loopx/registry.global.json --runtime-root ~/.codex/loopx diagnose --goal-id loopx-meta --agent-id codex-side-bypass