### PR TITLE
Expose contract health signals in status

### DIFF
--- a/examples/status-markdown-smoke.py
+++ b/examples/status-markdown-smoke.py
@@ -21,6 +21,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from loopx.status import (  # noqa: E402
     build_promotion_readiness_summary,
+    build_contract_health_projection,
     collect_status,
     delivery_batch_scale_for_run,
     delivery_outcome_for_run,
@@ -1489,6 +1490,44 @@ def assert_status_agent_lane_next_action_projection() -> None:
     assert "authority=advisory_projection" in packet["project_agent_handoff"], packet
 
 
+def assert_status_contract_health_projection() -> None:
+    projection = build_contract_health_projection(
+        {
+            "summary": {"errors": 0, "warnings": 4, "checks": 8},
+            "errors": [],
+            "warnings": [
+                "fixture-goal: duplicate index rows raw=2 unique=1 unexpected=1",
+                "fixture-goal: stale projection warning A",
+                "fixture-goal: stale projection warning B",
+                "fixture-goal: stale projection warning C",
+            ],
+        }
+    )
+    assert projection["contract_summary"] == {"errors": 0, "warnings": 4, "checks": 8}, projection
+    assert projection["contract_warnings_total_count"] == 4, projection
+    assert projection["contract_warnings_truncated"] is True, projection
+    assert len(projection["contract_warnings"]) == 3, projection
+    payload = {
+        "ok": True,
+        "registry": "./fixtures/registry.json",
+        "runtime_root": "./fixtures/runtime",
+        "goal_count": 1,
+        "run_count": 1,
+        "status_contract": {
+            "schema_version": 2,
+            "minimum_dashboard_schema_version": 2,
+            "producer": "loopx status",
+        },
+        "contract": {"ok": True, "summary": {"errors": 0, "warnings": 4, "checks": 8}},
+        **projection,
+        "global_registry": {"available": False, "summary": {}},
+    }
+    markdown = render_status_markdown(payload)
+    assert "Status Contract Signals" in markdown, markdown
+    assert "duplicate index rows raw=2 unique=1 unexpected=1" in markdown, markdown
+    assert "contract_warnings_truncated: total=4" in markdown, markdown
+
+
 def assert_status_agent_lane_frontier_hint_projection() -> None:
     goal_id = "agent-lane-frontier-status-fixture"
     primary_action = "[P0] Continue the primary controller benchmark route."
@@ -2228,6 +2267,7 @@ def main() -> int:
     assert_promotion_readiness_summary_markdown()
     assert_promotion_gate_summary_markdown()
     assert_decision_freshness_summary_markdown()
+    assert_status_contract_health_projection()
     with tempfile.TemporaryDirectory(prefix="loopx-status-smoke-") as tmp:
         root = Path(tmp)
         registry_path = write_planned_registry(root)

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -238,6 +238,7 @@ MAX_BENCHMARK_RUN_LIST_ITEMS = 5
 STATUS_CONTRACT_SCHEMA_VERSION = 2
 MINIMUM_DASHBOARD_STATUS_CONTRACT_SCHEMA_VERSION = 2
 STATUS_CONTRACT_RELOAD_HINT = "scripts/macos-dashboard-launchagent.sh restart"
+STATUS_CONTRACT_SIGNAL_LIMIT = 3
 PROJECT_ASSET_TODO_PROJECTION_GAP_SCHEMA_VERSION = "project_asset_todo_projection_gap_v0"
 MONITOR_WRITEBACK_CONTRACT_SCHEMA_VERSION = "monitor_writeback_contract_v0"
 TODO_INDEX_SCHEMA_VERSION = "todo_index_v0"
@@ -10344,6 +10345,34 @@ def build_status_contract() -> dict[str, Any]:
     }
 
 
+def _compact_status_contract_signals(
+    value: Any,
+    *,
+    limit: int = STATUS_CONTRACT_SIGNAL_LIMIT,
+) -> dict[str, Any]:
+    items = [str(item).strip() for item in value or [] if str(item).strip()]
+    bounded = items[: max(0, limit)]
+    return {
+        "items": bounded,
+        "total_count": len(items),
+        "truncated": len(items) > len(bounded),
+    }
+
+
+def build_contract_health_projection(contract: dict[str, Any]) -> dict[str, Any]:
+    errors = _compact_status_contract_signals(contract.get("errors"))
+    warnings = _compact_status_contract_signals(contract.get("warnings"))
+    return {
+        "contract_summary": contract.get("summary"),
+        "contract_errors": errors["items"],
+        "contract_errors_total_count": errors["total_count"],
+        "contract_errors_truncated": errors["truncated"],
+        "contract_warnings": warnings["items"],
+        "contract_warnings_total_count": warnings["total_count"],
+        "contract_warnings_truncated": warnings["truncated"],
+    }
+
+
 def decision_event_kinds(run: dict[str, Any]) -> list[str]:
     kinds: list[str] = []
     if isinstance(run.get("human_reward"), dict):
@@ -10774,6 +10803,7 @@ def collect_status(
         "run_count": history.get("run_count"),
         "status_contract": build_status_contract(),
         "goal_filter": goal_filter,
+        **build_contract_health_projection(contract),
         "contract": {
             "ok": contract.get("ok"),
             "summary": contract.get("summary"),
@@ -10828,6 +10858,26 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
         f"warnings={summary.get('warnings')}, "
         f"checks={summary.get('checks')}"
     )
+    contract_errors = (
+        payload.get("contract_errors") if isinstance(payload.get("contract_errors"), list) else []
+    )
+    contract_warnings = (
+        payload.get("contract_warnings") if isinstance(payload.get("contract_warnings"), list) else []
+    )
+    if contract_errors or contract_warnings:
+        lines.extend(["", "## Status Contract Signals"])
+        for item in contract_errors:
+            lines.append(f"- error: {item}")
+        if payload.get("contract_errors_truncated"):
+            lines.append(
+                f"- contract_errors_truncated: total={payload.get('contract_errors_total_count')}"
+            )
+        for item in contract_warnings:
+            lines.append(f"- warning: {item}")
+        if payload.get("contract_warnings_truncated"):
+            lines.append(
+                f"- contract_warnings_truncated: total={payload.get('contract_warnings_total_count')}"
+            )
 
     global_registry = payload.get("global_registry") if isinstance(payload.get("global_registry"), dict) else {}
     global_summary = (


### PR DESCRIPTION
## Summary
- expose bounded contract health fields on status JSON: contract_summary, contract_errors, and contract_warnings
- render Status Contract Signals in status markdown when errors or warnings exist
- add status smoke coverage for warning truncation and markdown rendering

## Validation
- python3 -m py_compile loopx/status.py examples/status-markdown-smoke.py
- PYTHONPATH=. python3 examples/status-markdown-smoke.py
- PYTHONPATH=. python3 -m loopx.cli --format json --registry ~/.codex/loopx/registry.global.json --runtime-root ~/.codex/loopx status --goal-id loopx-meta
- git diff --check
- public/private boundary scan on changed files
