### PR TITLE
Scope diagnose drilldown commands to goal

### DIFF
--- a/examples/agent-diagnose-packet-smoke.py
+++ b/examples/agent-diagnose-packet-smoke.py
@@ -261,6 +261,14 @@ def main() -> int:
         assert "local_scheduler" not in str(scheduler_hint), scheduler_hint
         assert scheduler_hint["codex_app"]["no_spend_for_cadence_change"] is True, scheduler_hint
         assert selected["agent_reasoning_checklist"], selected
+        assert any(
+            " diagnose " in command and f"--goal-id {GOAL_ID}" in command
+            for command in selected["agent_commands"]
+        ), selected
+        assert any(
+            " status " in command and f"--goal-id {GOAL_ID}" in command
+            for command in selected["agent_commands"]
+        ), selected
 
         markdown = run_markdown("--registry", str(registry), "diagnose", "--goal-id", GOAL_ID)
         assert "LoopX is not making the final diagnosis" in markdown, markdown
@@ -311,6 +319,9 @@ def main() -> int:
         assert any("--agent-id codex-main-control" in command for command in scoped_selected["agent_commands"]), (
             scoped_selected
         )
+        assert any(
+            f"--goal-id {SCOPED_GOAL_ID}" in command for command in scoped_selected["agent_commands"]
+        ), scoped_selected
 
     print("agent-diagnose-packet-smoke ok")
     return 0

--- a/loopx/diagnose.py
+++ b/loopx/diagnose.py
@@ -185,12 +185,13 @@ def _agent_commands(
     diagnose = f"loopx --registry {registry_arg} diagnose"
     status = f"loopx --registry {registry_arg} status"
     agent_arg = f" --agent-id {shlex.quote(agent_id)}" if agent_id else ""
+    goal_arg = f" --goal-id {shlex.quote(goal_id)}" if goal_id else ""
     if scan_args:
         diagnose = f"{diagnose} {scan_args}"
         status = f"{status} {scan_args}"
     commands = [
-        f"{diagnose}{agent_arg} --limit {max(1, limit)}",
-        f"{status}{agent_arg} --limit {max(1, limit)}",
+        f"{diagnose}{goal_arg}{agent_arg} --limit {max(1, limit)}",
+        f"{status}{goal_arg}{agent_arg} --limit {max(1, limit)}",
     ]
     if goal_id:
         quoted_goal = shlex.quote(goal_id)


### PR DESCRIPTION
## Summary
- include `--goal-id` on diagnose/status drill-down commands emitted by `loopx diagnose --goal-id ...`
- keep quota/history command behavior unchanged
- add smoke assertions for goal-scoped agent commands, including agent-scoped packets

## Validation
- python3 -m py_compile loopx/diagnose.py examples/agent-diagnose-packet-smoke.py
- PYTHONPATH=. python3 examples/agent-diagnose-packet-smoke.py
- PYTHONPATH=. python3 -m loopx.cli --format json --registry ~/.codex/loopx/registry.global.json --runtime-root ~/.codex/loopx diagnose --goal-id loopx-meta --agent-id codex-side-bypass
- git diff --check
- public/private boundary scan on changed files
