### PR TITLE
Align status agent claims with selected lane

### DIFF
--- a/examples/status-markdown-smoke.py
+++ b/examples/status-markdown-smoke.py
@@ -1490,6 +1490,124 @@ def assert_status_agent_lane_next_action_projection() -> None:
     assert "authority=advisory_projection" in packet["project_agent_handoff"], packet
 
 
+def assert_status_agent_member_selected_lane_claim_survives_truncated_claim_list() -> None:
+    goal_id = "agent-lane-truncated-claims-fixture"
+    selected_todo = {
+        "schema_version": "todo_item_v0",
+        "todo_id": "todo_selected_lane",
+        "index": 116,
+        "role": "agent",
+        "status": "open",
+        "priority": "P0",
+        "task_class": "advancement_task",
+        "action_kind": "rapid_self_merge_kernel_iteration",
+        "claimed_by": "codex-side-bypass",
+        "text": "[P0] Continue the selected side-agent lane.",
+    }
+    visible_stale_claims = [
+        {
+            "schema_version": "todo_item_v0",
+            "todo_id": f"todo_visible_stale_claim_{offset}",
+            "index": 56 + offset,
+            "role": "agent",
+            "status": "blocked",
+            "priority": "P0",
+            "task_class": "advancement_task",
+            "action_kind": "old_side_lane",
+            "claimed_by": "codex-side-bypass",
+            "text": "[P0] Old side-agent claim kept in the visible status window.",
+        }
+        for offset in range(10)
+    ]
+    primary_todo = {
+        "schema_version": "todo_item_v0",
+        "todo_id": "todo_primary_visible",
+        "index": 22,
+        "role": "agent",
+        "status": "open",
+        "priority": "P0",
+        "task_class": "blocker",
+        "claimed_by": "codex-main-control",
+        "text": "[P0] Primary visible item.",
+    }
+    agent_todos = {
+        "schema_version": "todo_summary_v0",
+        "open_count": 105,
+        "done_count": 0,
+        "total_count": 105,
+        "items": [primary_todo, *visible_stale_claims, selected_todo],
+        "first_open_items": [primary_todo, *visible_stale_claims[:2]],
+        "first_executable_items": [selected_todo],
+    }
+    coordination = {
+        "primary_agent": "codex-main-control",
+        "registered_agents": ["codex-main-control", "codex-side-bypass"],
+    }
+    payload = {
+        "ok": True,
+        "registry": "./fixtures/registry.json",
+        "runtime_root": "./fixtures/runtime",
+        "goal_count": 1,
+        "run_count": 1,
+        "contract": {"ok": True, "summary": {"errors": 0, "warnings": 0, "checks": 0}},
+        "global_registry": {"available": False, "summary": {}},
+        "attention_queue": {
+            "available": True,
+            "item_count": 1,
+            "items": [
+                {
+                    "goal_id": goal_id,
+                    "status": "primary_route_active",
+                    "waiting_on": "codex",
+                    "severity": "action",
+                    "recommended_action": primary_todo["text"],
+                    "source": "registry",
+                    "coordination": coordination,
+                    "quota": {
+                        "state": "eligible",
+                        "compute": 1.0,
+                        "window_hours": 24,
+                        "slot_minutes": 1,
+                        "allowed_slots": 10,
+                    },
+                    "agent_todos": agent_todos,
+                    "project_asset": {
+                        "owner": "codex-main-control",
+                        "gate": "none",
+                        "stop_condition": "stop on unsafe workspace or user gate",
+                        "next_action": primary_todo["text"],
+                        "agent_todos": project_asset_todo_summary(agent_todos, role="agent"),
+                    },
+                }
+            ],
+        },
+        "run_history": {
+            "goals": [
+                {
+                    "id": goal_id,
+                    "registry_member": True,
+                    "status": "primary_route_active",
+                    "coordination": coordination,
+                    "quota": {
+                        "compute": 1.0,
+                        "window_hours": 24,
+                        "slot_minutes": 1,
+                        "allowed_slots": 10,
+                    },
+                }
+            ]
+        },
+    }
+    attach_agent_lane_next_actions(payload, agent_id="codex-side-bypass")
+    item = payload["attention_queue"]["items"][0]
+    assert item["agent_lane_next_action"]["todo_id"] == "todo_selected_lane", item
+    member = item["agent_member"]
+    assert member["current_claims"][0] == "todo_selected_lane", member
+    assert "todo_visible_stale_claim_0" in member["current_claims"], member
+    markdown = render_status_markdown(payload)
+    assert "claims=todo_selected_lane,todo_visible_stale_claim_0" in markdown, markdown
+
+
 def assert_status_contract_health_projection() -> None:
     projection = build_contract_health_projection(
         {
@@ -2457,6 +2575,7 @@ def main() -> int:
     assert_promotion_readiness_full_scan_fallback()
     assert_promotion_readiness_warning_in_quota_guard()
     assert_status_agent_lane_next_action_projection()
+    assert_status_agent_member_selected_lane_claim_survives_truncated_claim_list()
     assert_status_agent_lane_frontier_hint_projection()
     print("status-markdown-smoke ok")
     return 0

--- a/loopx/cli_commands/status.py
+++ b/loopx/cli_commands/status.py
@@ -356,6 +356,39 @@ def _current_claims_for_agent(item: dict[str, Any], *, agent_id: str) -> list[st
     return claims
 
 
+def _selected_claim_for_agent(guard: dict[str, Any], *, agent_id: str) -> str | None:
+    next_action = guard.get("agent_lane_next_action")
+    if not isinstance(next_action, dict):
+        return None
+    todo_id = str(next_action.get("todo_id") or "").strip()
+    if not todo_id:
+        return None
+    lane_agent = normalize_todo_claimed_by(next_action.get("agent_id"))
+    if lane_agent and lane_agent != agent_id:
+        return None
+    if next_action.get("claim_required_before_work") is True:
+        return None
+    claimed_by = normalize_todo_claimed_by(next_action.get("claimed_by"))
+    selected_by = str(next_action.get("selected_by") or "").strip()
+    if claimed_by == agent_id or selected_by == "current_agent_claimed_todo":
+        return todo_id
+    return None
+
+
+def _current_claims_with_selected_lane(
+    item: dict[str, Any],
+    *,
+    guard: dict[str, Any],
+    agent_id: str,
+) -> list[str]:
+    claims = _current_claims_for_agent(item, agent_id=agent_id)
+    selected_claim = _selected_claim_for_agent(guard, agent_id=agent_id)
+    if not selected_claim:
+        return claims
+    claims = [claim for claim in claims if claim != selected_claim]
+    return [selected_claim, *claims]
+
+
 def _build_agent_member_projection(
     item: dict[str, Any],
     *,
@@ -372,7 +405,7 @@ def _build_agent_member_projection(
         limit=80,
     )
     worktree_policy, requires_independent_worktree = _profile_worktree_policy(profile)
-    claims = _current_claims_for_agent(item, agent_id=agent_id)
+    claims = _current_claims_with_selected_lane(item, guard=guard, agent_id=agent_id)
     member: dict[str, Any] = {
         "schema_version": "agent_member_v0",
         "agent_id": agent_id,


### PR DESCRIPTION
## Summary
- make status agent_member.current_claims prioritize the selected claimed agent lane todo
- keep visible older claims after the selected lane instead of letting truncated status windows hide the active claim
- add a status markdown smoke for selected lane claims that sit beyond the visible claim window

## Validation
- python3 -m py_compile loopx/cli_commands/status.py examples/status-markdown-smoke.py
- PYTHONPATH=. python3 examples/status-markdown-smoke.py
- PYTHONPATH=. python3 -m loopx.cli --format json --registry ~/.codex/loopx/registry.global.json --runtime-root ~/.codex/loopx status --goal-id loopx-meta --agent-id codex-side-bypass
- PYTHONPATH=. python3 -m loopx.cli check
- git diff --check
- public/private scan on changed paths