### PR TITLE
Project handoff agent in status member

### DIFF
--- a/examples/status-markdown-smoke.py
+++ b/examples/status-markdown-smoke.py
@@ -30,7 +30,7 @@ from loopx.status import (  # noqa: E402
     render_status_markdown,
 )
 from loopx.quota import build_quota_should_run, render_quota_should_run_markdown  # noqa: E402
-from loopx.cli_commands.status import attach_agent_lane_next_actions  # noqa: E402
+from loopx.cli_commands.status import attach_agent_lane_next_actions, _review_handoff_agent  # noqa: E402
 from loopx.review_packet import build_review_packet  # noqa: E402
 from loopx.handoff_budget import PROJECT_AGENT_HANDOFF_BUDGET  # noqa: E402
 
@@ -1608,6 +1608,27 @@ def assert_status_agent_member_selected_lane_claim_survives_truncated_claim_list
     assert "claims=todo_selected_lane,todo_visible_stale_claim_0" in markdown, markdown
 
 
+def assert_status_agent_member_handoff_uses_quota_identity() -> None:
+    assert (
+        _review_handoff_agent(
+            coordination={},
+            profile={},
+            identity={"handoff_agent": "codex-product-capability"},
+            role="side-agent",
+        )
+        == "codex-product-capability"
+    )
+    assert (
+        _review_handoff_agent(
+            coordination={"side_agent_handoff_agent": "codex-main-control"},
+            profile={},
+            identity={"handoff_agent": "codex-product-capability"},
+            role="side-agent",
+        )
+        == "codex-product-capability"
+    )
+
+
 def assert_status_contract_health_projection() -> None:
     projection = build_contract_health_projection(
         {
@@ -2576,6 +2597,7 @@ def main() -> int:
     assert_promotion_readiness_warning_in_quota_guard()
     assert_status_agent_lane_next_action_projection()
     assert_status_agent_member_selected_lane_claim_survives_truncated_claim_list()
+    assert_status_agent_member_handoff_uses_quota_identity()
     assert_status_agent_lane_frontier_hint_projection()
     print("status-markdown-smoke ok")
     return 0

--- a/loopx/cli_commands/status.py
+++ b/loopx/cli_commands/status.py
@@ -321,6 +321,7 @@ def _review_handoff_agent(
     *,
     coordination: dict[str, Any],
     profile: dict[str, Any],
+    identity: dict[str, Any],
     role: str | None,
 ) -> str | None:
     review_policy = profile.get("review_policy")
@@ -328,6 +329,9 @@ def _review_handoff_agent(
         handoff_agent = normalize_todo_claimed_by(review_policy.get("handoff_agent"))
         if handoff_agent:
             return handoff_agent
+    handoff_agent = normalize_todo_claimed_by(identity.get("handoff_agent"))
+    if handoff_agent:
+        return handoff_agent
     if role == "side-agent":
         return normalize_todo_claimed_by(coordination.get("side_agent_handoff_agent"))
     return None
@@ -431,6 +435,7 @@ def _build_agent_member_projection(
     handoff_agent = _review_handoff_agent(
         coordination=coordination,
         profile=profile,
+        identity=identity,
         role=role,
     )
     if handoff_agent:


### PR DESCRIPTION
## Summary
- make status agent_member handoff projection reuse the canonical quota agent_identity.handoff_agent
- keep profile review_policy as the highest-precedence local override
- add a focused status smoke for identity-based handoff projection

## Validation
- python3 -m py_compile loopx/cli_commands/status.py examples/status-markdown-smoke.py
- PYTHONPATH=. python3 examples/status-markdown-smoke.py
- PYTHONPATH=. python3 -m loopx.cli --format json --registry ~/.codex/loopx/registry.global.json --runtime-root ~/.codex/loopx status --goal-id loopx-meta --agent-id codex-side-bypass
- PYTHONPATH=. python3 -m loopx.cli check
- git diff --check
- public/private scan on changed paths
