### PR TITLE
Align quota smoke with replan precedence

### DIFF
--- a/examples/quota-plan-smoke.py
+++ b/examples/quota-plan-smoke.py
@@ -1113,8 +1113,21 @@ def assert_outcome_floor_projected_blocker_quiet_noop() -> None:
     monitor_item["project_asset"]["agent_todos"]["items"][0]["action_kind"] = "monitor"
     monitor_decision = build_quota_should_run(monitor_payload, goal_id=goal_id)
     assert "outcome_floor_blocker_projected" not in monitor_decision["quota"], monitor_decision
-    assert monitor_decision["effective_action"] == "outcome_floor_recovery", monitor_decision
+    assert monitor_decision["effective_action"] == "autonomous_replan_required", monitor_decision
     assert monitor_decision["should_run"] is True, monitor_decision
+    assert monitor_decision["safe_bypass_kind"] == "outcome_floor_recovery", monitor_decision
+    assert (
+        monitor_decision["heartbeat_recommendation"]["recommended_mode"]
+        == "autonomous_replan_required"
+    ), monitor_decision
+    assert (
+        monitor_decision["autonomous_replan_decision"]["decision_plane"]
+        == "goal_frontier_before_lane_quiet_or_agent_scope_wait"
+    ), monitor_decision
+    monitor_contract = monitor_decision["interaction_contract"]
+    assert monitor_contract["mode"] == "autonomous_replan", monitor_contract
+    assert monitor_contract["agent_channel"]["must_attempt"] is True, monitor_contract
+    assert monitor_contract["agent_channel"]["quiet_noop_allowed"] is False, monitor_contract
 
 
 def assert_control_plane_health_self_repair_should_run() -> None:


### PR DESCRIPTION
## Summary
- update the quota plan smoke to expect `autonomous_replan_required` when an outcome-floor blocker becomes a monitor-only lane
- keep `outcome_floor_recovery` asserted as the lower-level safe-bypass signal while verifying replan precedence wins the interaction contract

## Why
PR #931 exposed that the full quota plan smoke still expected the old monitor recovery path. Current main intentionally routes monitor-only exhausted frontiers through autonomous replan before lane quiet/recovery decisions.

## Validation
- `python3 -m py_compile examples/quota-plan-smoke.py`
- `PYTHONPATH=. python3 examples/quota-plan-smoke.py`
- `PYTHONPATH=. python3 examples/quota-replan-decision-plane-smoke.py`
- `git diff --check`
- `loopx check --scan-path examples/quota-plan-smoke.py`
