### PR TITLE
Fix unscheduled monitor todo projection

### DIFF
--- a/examples/control_plane/todo-projection-shared-helper-smoke.py
+++ b/examples/control_plane/todo-projection-shared-helper-smoke.py
@@ -64,6 +64,12 @@ def build_agent_todo_summary() -> dict[str, Any]:
                 todo_id="todo_advancement_p2",
             ),
             todo(
+                5,
+                "[P2] Monitor unscheduled public smoke signal after schedule metadata is added.",
+                task_class=TODO_TASK_CLASS_MONITOR,
+                todo_id="todo_monitor_unscheduled",
+            ),
+            todo(
                 2,
                 "[P0] Monitor public smoke signal and only write back if it changed.",
                 task_class=TODO_TASK_CLASS_MONITOR,
@@ -152,6 +158,10 @@ def assert_status_summary_lanes(summary: dict[str, Any]) -> None:
         "todo_monitor_p0",
     ], summary
     assert summary["monitor_due_count"] == 1, summary
+    assert [item["todo_id"] for item in summary["monitor_schedule_gap_items"]] == [
+        "todo_monitor_unscheduled",
+    ], summary
+    assert summary["monitor_schedule_gap_count"] == 1, summary
 
 
 def assert_shared_ordering_parity(summary: dict[str, Any]) -> None:
@@ -189,6 +199,10 @@ def assert_quota_uses_executable_advancement(summary: dict[str, Any]) -> None:
     assert quota_summary["first_open_items"][0]["todo_id"] == "todo_advancement_p0", payload
     assert quota_summary["first_executable_items"][0]["todo_id"] == "todo_advancement_p0", payload
     assert quota_summary["monitor_open_items"][0]["todo_id"] == "todo_monitor_p0", payload
+    assert quota_summary["monitor_schedule_gap_items"][0]["todo_id"] == (
+        "todo_monitor_unscheduled"
+    ), payload
+    assert quota_summary["monitor_schedule_gap_count"] == 1, payload
     assert quota_todo_task_class(quota_summary["monitor_open_items"][0]) == TODO_TASK_CLASS_MONITOR
     assert quota_todo_task_class(
         quota_summary["first_executable_items"][0]

--- a/examples/monitor-scheduler-contract-smoke.py
+++ b/examples/monitor-scheduler-contract-smoke.py
@@ -18,6 +18,23 @@ AGENT_ID = "codex-product-capability"
 PAST_DUE_AT = "2000-01-01T00:00:00+00:00"
 FUTURE_DUE_AT = "2999-01-01T00:00:00+00:00"
 EXPIRED_AT = "2000-01-01T00:05:00+00:00"
+FRONTIER_REPLAN_ACK_RUNS = [
+    {
+        "classification": "monitor_scheduler_replan_ack",
+        "agent_id": AGENT_ID,
+        "progress_scope": "agent_lane",
+        "autonomous_replan_ack": {
+            "schema_version": "autonomous_replan_ack_v0",
+            "recorded": True,
+            "source": "fixture",
+            "delta_contract": {
+                "schema_version": "repair_delta_contract_v0",
+                "delta_present": True,
+                "delta_kinds": ["watch_lane_continuation"],
+            },
+        },
+    }
+]
 
 
 def status_payload(
@@ -25,6 +42,7 @@ def status_payload(
     agent_todo_items: list[dict],
     status: str = "monitor_scheduler_fixture",
     coordination: dict | None = None,
+    latest_runs: list[dict] | None = None,
 ) -> dict:
     agent_todos = compact_todo_group(
         agent_todo_items,
@@ -78,6 +96,9 @@ def status_payload(
                         "registered_agents": [AGENT_ID],
                         "primary_agent": AGENT_ID,
                     },
+                    "latest_runs": latest_runs
+                    if latest_runs is not None
+                    else FRONTIER_REPLAN_ACK_RUNS,
                 }
             ]
         },
@@ -89,8 +110,9 @@ def monitor_item(
     index: int,
     todo_id: str,
     priority: str,
-    next_due_at: str,
     target_key: str,
+    next_due_at: str | None = None,
+    cadence: str | None = "15m",
     claimed_by: str = AGENT_ID,
     expires_at: str | None = None,
 ) -> dict:
@@ -105,9 +127,11 @@ def monitor_item(
         "action_kind": "monitor",
         "claimed_by": claimed_by,
         "target_key": target_key,
-        "cadence": "15m",
-        "next_due_at": next_due_at,
     }
+    if cadence:
+        item["cadence"] = cadence
+    if next_due_at:
+        item["next_due_at"] = next_due_at
     if expires_at:
         item["expires_at"] = expires_at
     return item
@@ -131,9 +155,14 @@ def guard_for(
     *,
     agent_id: str = AGENT_ID,
     coordination: dict | None = None,
+    latest_runs: list[dict] | None = None,
 ) -> dict:
     return build_quota_should_run(
-        status_payload(agent_todo_items=items, coordination=coordination),
+        status_payload(
+            agent_todo_items=items,
+            coordination=coordination,
+            latest_runs=latest_runs,
+        ),
         goal_id=GOAL_ID,
         agent_id=agent_id,
     )
@@ -157,6 +186,36 @@ def assert_not_due_monitor_waits_quietly() -> None:
     assert lane["obligation"] == "quiet_until_material_monitor_transition", lane
     assert lane["must_attempt_work"] is False, lane
     assert guard["agent_todo_summary"]["monitor_due_count"] == 0, guard
+
+
+def assert_unscheduled_monitor_requires_metadata_repair() -> None:
+    guard = guard_for(
+        [
+            monitor_item(
+                index=1,
+                todo_id="todo_monitor_unscheduled",
+                priority="P1",
+                target_key="update-note-draft-pr",
+                cadence=None,
+                next_due_at=None,
+            )
+        ]
+    )
+    lane = guard["work_lane_contract"]
+    summary = guard["agent_todo_summary"]
+    assert guard["decision"] == "run", guard
+    assert guard["effective_action"] == "normal_run", guard
+    assert lane["lane"] == "advancement_task", lane
+    assert lane["monitor_kind"] == "todo_monitor_schedule_gap", lane
+    assert lane["obligation"] == "repair_monitor_schedule_metadata", lane
+    assert lane["must_attempt_work"] is True, lane
+    assert lane["selected_todo_id"] == "todo_monitor_unscheduled", lane
+    assert summary["monitor_due_count"] == 0, summary
+    assert summary["monitor_schedule_gap_count"] == 1, summary
+    assert summary["monitor_schedule_gap_items"][0]["todo_id"] == "todo_monitor_unscheduled", summary
+    assert guard["interaction_contract"]["agent_channel"]["must_attempt"] is True, guard
+    assert guard["interaction_contract"]["agent_channel"]["quiet_noop_allowed"] is False, guard
+    assert guard["scheduler_hint"]["cadence_class"] == "active_work", guard
 
 
 def assert_due_monitor_requires_explicit_attempt() -> None:
@@ -401,6 +460,7 @@ def assert_other_agent_claimed_work_stays_diagnostic_when_no_current_lane() -> N
 
 def main() -> int:
     assert_not_due_monitor_waits_quietly()
+    assert_unscheduled_monitor_requires_metadata_repair()
     assert_due_monitor_requires_explicit_attempt()
     assert_expired_monitor_does_not_catch_up()
     assert_due_monitor_priority_does_not_steal_advancement_lane()

--- a/examples/monitor-todo-policy-seam-smoke.py
+++ b/examples/monitor-todo-policy-seam-smoke.py
@@ -16,12 +16,14 @@ from loopx.policies.monitor_todo import (  # noqa: E402
     monitor_todo_is_actionable_open,
     monitor_todo_is_due,
     monitor_todo_is_expired,
+    monitor_todo_missing_schedule,
     monitor_todo_next_due_at,
 )
 from loopx.status import (  # noqa: E402
     todo_item_is_actionable_open,
     todo_item_is_due_monitor,
     todo_item_is_expired_monitor,
+    todo_item_missing_monitor_schedule,
     todo_item_next_due_at,
 )
 
@@ -54,6 +56,14 @@ def assert_policy_matches_wrappers(item: dict[str, object], *, due: bool, expire
     assert monitor_todo_next_due_at(item) == quota_module._todo_item_next_due_at(item), item
     assert monitor_todo_is_actionable_open(item) == todo_item_is_actionable_open(item), item
     assert monitor_todo_is_actionable_open(item) == quota_module._todo_item_is_actionable_open(item), item
+    assert monitor_todo_missing_schedule(item, now=NOW) == todo_item_missing_monitor_schedule(
+        item,
+        now=NOW,
+    ), item
+    assert monitor_todo_missing_schedule(item, now=NOW) == quota_module._todo_item_missing_monitor_schedule(
+        item,
+        now=NOW,
+    ), item
 
 
 def main() -> int:
@@ -79,6 +89,10 @@ def main() -> int:
         due=False,
         expired=False,
     )
+    unscheduled = monitor_item()
+    unscheduled.pop("next_due_at")
+    assert_policy_matches_wrappers(unscheduled, due=False, expired=False)
+    assert monitor_todo_missing_schedule(unscheduled, now=NOW) is True, unscheduled
     assert monitor_todo_next_due_at({"next_due_at": "2026-01-01T00:00:00"}) == NOW
     print("monitor-todo-policy-seam-smoke ok")
     return 0

--- a/loopx/policies/monitor_todo.py
+++ b/loopx/policies/monitor_todo.py
@@ -48,6 +48,13 @@ def monitor_todo_next_due_at(item: dict[str, Any]) -> datetime | None:
     return parse_monitor_timestamp(item.get("next_due_at"))
 
 
+def monitor_todo_has_schedule(item: dict[str, Any]) -> bool:
+    return bool(
+        str(item.get("cadence") or "").strip()
+        or str(item.get("next_due_at") or "").strip()
+    )
+
+
 def monitor_todo_expires_at(item: dict[str, Any]) -> datetime | None:
     return parse_monitor_timestamp(item.get("expires_at"))
 
@@ -77,3 +84,18 @@ def monitor_todo_is_due(
         return False
     current_time = now or datetime.now(timezone.utc)
     return next_due_at <= current_time
+
+
+def monitor_todo_missing_schedule(
+    item: dict[str, Any],
+    *,
+    now: datetime | None = None,
+    task_text: str | None = None,
+) -> bool:
+    if not monitor_todo_is_actionable_open(item):
+        return False
+    if monitor_todo_task_class(item, task_text=task_text) != TODO_TASK_CLASS_MONITOR:
+        return False
+    if monitor_todo_is_expired(item, now=now):
+        return False
+    return not monitor_todo_has_schedule(item)

--- a/loopx/policies/work_lane.py
+++ b/loopx/policies/work_lane.py
@@ -18,6 +18,8 @@ def build_work_lane_contract(
     outcome_followthrough: dict[str, Any] | None,
     next_action_requires_advancement: bool,
     monitor_due_item_limit: int,
+    monitor_schedule_gap_count: int = 0,
+    monitor_schedule_gap_items: list[dict[str, Any]] | None = None,
     resume_blocked_by_monitor_count: int = 0,
     resume_blocked_by_monitor_items: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any] | None:
@@ -38,6 +40,8 @@ def build_work_lane_contract(
     monitor_only_todos = has_agent_todos and has_monitor_todos and not has_advancement_todos
     first_due_monitor = due_monitor_items[0] if due_monitor_items else None
     blocked_by_monitor_items = resume_blocked_by_monitor_items or []
+    schedule_gap_items = monitor_schedule_gap_items or []
+    first_schedule_gap = schedule_gap_items[0] if schedule_gap_items else None
 
     def due_monitor_contract(*, reason_codes: list[str]) -> dict[str, Any]:
         selected = first_due_monitor or {}
@@ -144,6 +148,28 @@ def build_work_lane_contract(
                 return due_monitor_contract(
                     reason_codes=["monitor_todo_only", "monitor_due"]
                 )
+            if first_schedule_gap:
+                return {
+                    "schema_version": WORK_LANE_CONTRACT_SCHEMA_VERSION,
+                    "lane": "advancement_task",
+                    "monitor_kind": "todo_monitor_schedule_gap",
+                    "next_lane": "continuous_monitor",
+                    "obligation": "repair_monitor_schedule_metadata",
+                    "must_attempt_work": True,
+                    "reason_codes": [
+                        "monitor_todo_only",
+                        "monitor_schedule_metadata_gap",
+                    ],
+                    "monitor_policy": "repair_schedule_metadata_before_quiet_wait",
+                    "monitor_schedule_gap_count": max(0, int(monitor_schedule_gap_count)),
+                    "monitor_schedule_gap_items": schedule_gap_items[:monitor_due_item_limit],
+                    "selected_todo_id": first_schedule_gap.get("todo_id"),
+                    "action": (
+                        "repair the selected continuous_monitor todo by adding cadence/"
+                        "next_due_at, superseding it, or recording an explicit no-schedule "
+                        "policy; do not silently collapse it into monitor_quiet_skip"
+                    ),
+                }
             if next_action_requires_advancement:
                 return {
                     "schema_version": WORK_LANE_CONTRACT_SCHEMA_VERSION,

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -88,11 +88,19 @@ from .todo_projection import (
     todo_item_is_actionable_open as projection_todo_item_is_actionable_open,
     todo_item_is_due_monitor as projection_todo_item_is_due_monitor,
     todo_item_is_expired_monitor as projection_todo_item_is_expired_monitor,
+    todo_item_missing_monitor_schedule as projection_todo_item_missing_monitor_schedule,
     todo_item_next_due_at as projection_todo_item_next_due_at,
     todo_item_task_class as projection_todo_item_task_class,
     todo_priority_label as projection_todo_priority_label,
     todo_priority_rank as projection_todo_priority_rank,
     todo_projection_sort_key as projection_todo_projection_sort_key,
+    todo_summary_claim_scope_agent_id as projection_todo_summary_claim_scope_agent_id,
+    todo_summary_monitor_due_count as projection_todo_summary_monitor_due_count,
+    todo_summary_monitor_due_items as projection_todo_summary_monitor_due_items,
+    todo_summary_monitor_schedule_gap_count as projection_todo_summary_monitor_schedule_gap_count,
+    todo_summary_monitor_schedule_gap_items as projection_todo_summary_monitor_schedule_gap_items,
+    todo_summary_monitor_writeback_contract as projection_todo_summary_monitor_writeback_contract,
+    todo_summary_monitor_writeback_supported as projection_todo_summary_monitor_writeback_supported,
 )
 
 
@@ -623,6 +631,11 @@ def _work_lane_contract(
         agent_todo_summary,
         due_items=due_monitor_items,
     )
+    monitor_schedule_gap_items = _todo_summary_monitor_schedule_gap_items(agent_todo_summary)
+    monitor_schedule_gap_count = _todo_summary_monitor_schedule_gap_count(
+        agent_todo_summary,
+        gap_items=monitor_schedule_gap_items,
+    )
     first_due_monitor = due_monitor_items[0] if due_monitor_items else None
     first_advancement = _first_executable_todo_item(agent_todo_summary)
     agent_id = _todo_summary_claim_scope_agent_id(agent_todo_summary or {})
@@ -643,6 +656,8 @@ def _work_lane_contract(
         todo_counts=todo_counts,
         monitor_due_count=due_monitor_count,
         due_monitor_items=due_monitor_items,
+        monitor_schedule_gap_count=monitor_schedule_gap_count,
+        monitor_schedule_gap_items=monitor_schedule_gap_items,
         first_advancement=first_advancement,
         due_monitor_preempts_advancement=due_monitor_preempts_advancement,
         outcome_followthrough=_outcome_followthrough_hint(item),
@@ -2118,25 +2133,11 @@ def _todo_summary_source_items(value: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 def _todo_summary_monitor_writeback_contract(value: dict[str, Any] | None) -> dict[str, Any] | None:
-    if not isinstance(value, dict):
-        return None
-    contract = value.get("monitor_writeback")
-    if not isinstance(contract, dict):
-        return None
-    if contract.get("supported") is not False:
-        return None
-    compact: dict[str, Any] = {"supported": False}
-    source = str(contract.get("source") or "").strip()
-    if source:
-        compact["source"] = source
-    return compact
+    return projection_todo_summary_monitor_writeback_contract(value)
 
 
 def _todo_summary_monitor_writeback_supported(value: dict[str, Any] | None) -> bool:
-    contract = _todo_summary_monitor_writeback_contract(value)
-    if not contract:
-        return True
-    return contract.get("supported") is not False
+    return projection_todo_summary_monitor_writeback_supported(value)
 
 
 def _handoff_ready_successor_todo_ids(value: dict[str, Any]) -> set[str]:
@@ -2268,6 +2269,12 @@ def _summarize_user_todos(
         if monitor_writeback_supported
         else []
     )
+    monitor_schedule_gap_items = projection_todo_summary_monitor_schedule_gap_items(
+        {
+            "monitor_open_items": monitor_items,
+            "monitor_writeback": value.get("monitor_writeback"),
+        }
+    )
     claimed_open_items = [item for item in blocking_open_items if item.get("claimed_by")]
     gate_items = [
         item
@@ -2303,6 +2310,8 @@ def _summarize_user_todos(
         "monitor_open_items": monitor_items,
         "monitor_due_count": len(monitor_due_items),
         "monitor_due_items": monitor_due_items[:MONITOR_DUE_ITEM_LIMIT],
+        "monitor_schedule_gap_count": len(monitor_schedule_gap_items),
+        "monitor_schedule_gap_items": monitor_schedule_gap_items[:MONITOR_DUE_ITEM_LIMIT],
         "active_next_action_items": active_next_action_items,
         "active_next_action_executable_items": active_next_action_executable_items,
         "backlog_items": open_items[:TODO_BACKLOG_ITEM_LIMIT],
@@ -5639,41 +5648,20 @@ def _todo_item_is_due_monitor(item: dict[str, Any], *, now: datetime | None = No
     return projection_todo_item_is_due_monitor(item, now=now)
 
 
+def _todo_item_missing_monitor_schedule(
+    item: dict[str, Any],
+    *,
+    now: datetime | None = None,
+) -> bool:
+    return projection_todo_item_missing_monitor_schedule(item, now=now)
+
+
 def _todo_summary_claim_scope_agent_id(summary: dict[str, Any]) -> str | None:
-    claim_scope = summary.get("claim_scope") if isinstance(summary.get("claim_scope"), dict) else {}
-    return normalize_todo_claimed_by(claim_scope.get("agent_id"))
+    return projection_todo_summary_claim_scope_agent_id(summary)
 
 
 def _todo_summary_monitor_due_items(summary: dict[str, Any] | None) -> list[dict[str, Any]]:
-    if not isinstance(summary, dict):
-        return []
-    if not _todo_summary_monitor_writeback_supported(summary):
-        return []
-    projected_items = summary.get("monitor_due_items")
-    if isinstance(projected_items, list):
-        due_items = [
-            item
-            for item in projected_items
-            if isinstance(item, dict)
-            if _todo_item_is_actionable_open(item)
-            if _todo_task_class(item) == TODO_TASK_CLASS_MONITOR
-        ]
-    else:
-        raw_items = summary.get("monitor_open_items")
-        due_items = [
-            item
-            for item in (raw_items if isinstance(raw_items, list) else [])
-            if isinstance(item, dict)
-            if _todo_item_is_due_monitor(item)
-        ]
-    agent_id = _todo_summary_claim_scope_agent_id(summary)
-    if agent_id:
-        due_items = [
-            item
-            for item in due_items
-            if _todo_item_claimed_by_agent_or_unclaimed(item, agent_id=agent_id)
-        ]
-    return sorted(due_items, key=_todo_projection_sort_key)
+    return projection_todo_summary_monitor_due_items(summary)
 
 
 def _todo_summary_monitor_due_count(
@@ -5681,28 +5669,24 @@ def _todo_summary_monitor_due_count(
     *,
     due_items: list[dict[str, Any]] | None = None,
 ) -> int:
-    if not isinstance(summary, dict):
-        return 0
-    if not _todo_summary_monitor_writeback_supported(summary):
-        return 0
-    agent_id = _todo_summary_claim_scope_agent_id(summary)
-    if agent_id:
-        raw_items = summary.get("monitor_open_items")
-        if isinstance(raw_items, list):
-            return len(
-                [
-                    item
-                    for item in raw_items
-                    if isinstance(item, dict)
-                    if _todo_item_is_due_monitor(item)
-                    if _todo_item_claimed_by_agent_or_unclaimed(item, agent_id=agent_id)
-                ]
-            )
-        return len(due_items if due_items is not None else _todo_summary_monitor_due_items(summary))
-    projected_count = summary.get("monitor_due_count")
-    if isinstance(projected_count, int):
-        return max(0, projected_count)
-    return len(due_items if due_items is not None else _todo_summary_monitor_due_items(summary))
+    return projection_todo_summary_monitor_due_count(summary, due_items=due_items)
+
+
+def _todo_summary_monitor_schedule_gap_items(
+    summary: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    return projection_todo_summary_monitor_schedule_gap_items(summary)
+
+
+def _todo_summary_monitor_schedule_gap_count(
+    summary: dict[str, Any] | None,
+    *,
+    gap_items: list[dict[str, Any]] | None = None,
+) -> int:
+    return projection_todo_summary_monitor_schedule_gap_count(
+        summary,
+        gap_items=gap_items,
+    )
 
 
 def _first_executable_todo_item(agent_todo_summary: dict[str, Any] | None) -> dict[str, Any] | None:
@@ -5791,12 +5775,14 @@ def _open_todo_task_counts(summary: dict[str, Any] | None) -> dict[str, int]:
             and _todo_task_class(item) == TODO_TASK_CLASS_MONITOR
         )
     monitor_due_count = _todo_summary_monitor_due_count(summary)
+    monitor_schedule_gap_count = _todo_summary_monitor_schedule_gap_count(summary)
     hidden_count = max(0, open_count - len(classified_items))
     return {
         "open": open_count,
         "advancement": advancement_count,
         "monitor": monitor_visible_count,
         "monitor_due": monitor_due_count,
+        "monitor_schedule_gap": monitor_schedule_gap_count,
         "hidden": hidden_count,
     }
 

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -117,6 +117,7 @@ from .todo_projection import (
     todo_item_is_actionable_open as projection_todo_item_is_actionable_open,
     todo_item_is_due_monitor as projection_todo_item_is_due_monitor,
     todo_item_is_expired_monitor as projection_todo_item_is_expired_monitor,
+    todo_item_missing_monitor_schedule as projection_todo_item_missing_monitor_schedule,
     todo_item_next_due_at as projection_todo_item_next_due_at,
     todo_item_task_class as projection_todo_item_task_class,
     todo_priority_parts as projection_todo_priority_parts,
@@ -6002,6 +6003,18 @@ def todo_item_is_due_monitor(item: dict[str, Any], *, now: datetime | None = Non
     return projection_todo_item_is_due_monitor(item, now=now, task_text_keys=("text",))
 
 
+def todo_item_missing_monitor_schedule(
+    item: dict[str, Any],
+    *,
+    now: datetime | None = None,
+) -> bool:
+    return projection_todo_item_missing_monitor_schedule(
+        item,
+        now=now,
+        task_text_keys=("text",),
+    )
+
+
 def todo_priority_rank(priority: Any) -> int:
     return projection_todo_priority_rank(priority)
 
@@ -6280,6 +6293,11 @@ def compact_todo_group(
         for item in monitor_items
         if todo_item_is_due_monitor(item)
     ]
+    monitor_schedule_gap_items = [
+        item
+        for item in monitor_items
+        if todo_item_missing_monitor_schedule(item)
+    ]
     claimed_advancement_items = [
         item
         for item in claimed_open_items
@@ -6327,6 +6345,11 @@ def compact_todo_group(
         "monitor_due_items": [
             compact_todo_item(item)
             for item in monitor_due_items[:MAX_MONITOR_DUE_ITEMS]
+        ],
+        "monitor_schedule_gap_count": len(monitor_schedule_gap_items),
+        "monitor_schedule_gap_items": [
+            compact_todo_item(item)
+            for item in monitor_schedule_gap_items[:MAX_MONITOR_DUE_ITEMS]
         ],
         "unclaimed_priority_open_items": [
             compact_todo_item(item)

--- a/loopx/todo_projection.py
+++ b/loopx/todo_projection.py
@@ -6,12 +6,15 @@ from typing import Any
 
 from .policies.monitor_todo import (
     monitor_todo_expires_at,
+    monitor_todo_has_schedule,
     monitor_todo_is_actionable_open,
     monitor_todo_is_due,
     monitor_todo_is_expired,
+    monitor_todo_missing_schedule,
     monitor_todo_next_due_at,
     monitor_todo_task_class,
 )
+from .todo_contract import TODO_TASK_CLASS_MONITOR, normalize_todo_claimed_by
 
 
 TODO_MISSING_PRIORITY_RANK = 50
@@ -113,6 +116,10 @@ def todo_item_next_due_at(item: dict[str, Any]) -> datetime | None:
     return monitor_todo_next_due_at(item)
 
 
+def todo_item_has_monitor_schedule(item: dict[str, Any]) -> bool:
+    return monitor_todo_has_schedule(item)
+
+
 def todo_item_expires_at(item: dict[str, Any]) -> datetime | None:
     return monitor_todo_expires_at(item)
 
@@ -131,4 +138,239 @@ def todo_item_is_due_monitor(
         item,
         now=now,
         task_text=todo_item_task_text(item, keys=task_text_keys),
+    )
+
+
+def todo_item_missing_monitor_schedule(
+    item: dict[str, Any],
+    *,
+    now: datetime | None = None,
+    task_text_keys: tuple[str, ...] = ("title", "text"),
+) -> bool:
+    return monitor_todo_missing_schedule(
+        item,
+        now=now,
+        task_text=todo_item_task_text(item, keys=task_text_keys),
+    )
+
+
+def todo_item_claimed_by_agent_or_unclaimed(
+    item: dict[str, Any],
+    *,
+    agent_id: str | None,
+) -> bool:
+    normalized_agent_id = normalize_todo_claimed_by(agent_id)
+    if not normalized_agent_id:
+        return True
+    claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
+    return not claimed_by or claimed_by == normalized_agent_id
+
+
+def todo_summary_claim_scope_agent_id(summary: dict[str, Any] | None) -> str | None:
+    if not isinstance(summary, dict):
+        return None
+    claim_scope = summary.get("claim_scope")
+    if not isinstance(claim_scope, dict):
+        return None
+    return normalize_todo_claimed_by(claim_scope.get("agent_id"))
+
+
+def todo_summary_monitor_writeback_contract(
+    summary: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if not isinstance(summary, dict):
+        return None
+    contract = summary.get("monitor_writeback")
+    if not isinstance(contract, dict):
+        return None
+    if contract.get("supported") is not False:
+        return None
+    compact: dict[str, Any] = {"supported": False}
+    source = str(contract.get("source") or "").strip()
+    if source:
+        compact["source"] = source
+    return compact
+
+
+def todo_summary_monitor_writeback_supported(summary: dict[str, Any] | None) -> bool:
+    contract = todo_summary_monitor_writeback_contract(summary)
+    if not contract:
+        return True
+    return contract.get("supported") is not False
+
+
+def _summary_monitor_items(
+    summary: dict[str, Any] | None,
+    *,
+    projected_key: str,
+    predicate: Any,
+    task_text_keys: tuple[str, ...],
+    text_mode: str,
+) -> list[dict[str, Any]]:
+    if not isinstance(summary, dict):
+        return []
+    if not todo_summary_monitor_writeback_supported(summary):
+        return []
+    projected_items = summary.get(projected_key)
+    if isinstance(projected_items, list):
+        items = [
+            item
+            for item in projected_items
+            if isinstance(item, dict)
+            if todo_item_is_actionable_open(item)
+            if todo_item_task_class(item, task_text_keys=task_text_keys)
+            == TODO_TASK_CLASS_MONITOR
+            if predicate(item)
+        ]
+    else:
+        raw_items = summary.get("monitor_open_items")
+        items = [
+            item
+            for item in (raw_items if isinstance(raw_items, list) else [])
+            if isinstance(item, dict)
+            if predicate(item)
+        ]
+    agent_id = todo_summary_claim_scope_agent_id(summary)
+    if agent_id:
+        items = [
+            item
+            for item in items
+            if todo_item_claimed_by_agent_or_unclaimed(item, agent_id=agent_id)
+        ]
+    return sorted(
+        items,
+        key=lambda item: todo_projection_sort_key(item, text_mode=text_mode),
+    )
+
+
+def todo_summary_monitor_due_items(
+    summary: dict[str, Any] | None,
+    *,
+    task_text_keys: tuple[str, ...] = ("title", "text"),
+    text_mode: str = "label",
+) -> list[dict[str, Any]]:
+    return _summary_monitor_items(
+        summary,
+        projected_key="monitor_due_items",
+        predicate=lambda item: todo_item_is_due_monitor(
+            item,
+            task_text_keys=task_text_keys,
+        ),
+        task_text_keys=task_text_keys,
+        text_mode=text_mode,
+    )
+
+
+def todo_summary_monitor_due_count(
+    summary: dict[str, Any] | None,
+    *,
+    due_items: list[dict[str, Any]] | None = None,
+    task_text_keys: tuple[str, ...] = ("title", "text"),
+    text_mode: str = "label",
+) -> int:
+    if not isinstance(summary, dict):
+        return 0
+    if not todo_summary_monitor_writeback_supported(summary):
+        return 0
+    agent_id = todo_summary_claim_scope_agent_id(summary)
+    if agent_id:
+        raw_items = summary.get("monitor_open_items")
+        if isinstance(raw_items, list):
+            return len(
+                [
+                    item
+                    for item in raw_items
+                    if isinstance(item, dict)
+                    if todo_item_is_due_monitor(item, task_text_keys=task_text_keys)
+                    if todo_item_claimed_by_agent_or_unclaimed(item, agent_id=agent_id)
+                ]
+            )
+        return len(
+            due_items
+            if due_items is not None
+            else todo_summary_monitor_due_items(
+                summary,
+                task_text_keys=task_text_keys,
+                text_mode=text_mode,
+            )
+        )
+    projected_count = summary.get("monitor_due_count")
+    if isinstance(projected_count, int):
+        return max(0, projected_count)
+    return len(
+        due_items
+        if due_items is not None
+        else todo_summary_monitor_due_items(
+            summary,
+            task_text_keys=task_text_keys,
+            text_mode=text_mode,
+        )
+    )
+
+
+def todo_summary_monitor_schedule_gap_items(
+    summary: dict[str, Any] | None,
+    *,
+    task_text_keys: tuple[str, ...] = ("title", "text"),
+    text_mode: str = "label",
+) -> list[dict[str, Any]]:
+    return _summary_monitor_items(
+        summary,
+        projected_key="monitor_schedule_gap_items",
+        predicate=lambda item: todo_item_missing_monitor_schedule(
+            item,
+            task_text_keys=task_text_keys,
+        ),
+        task_text_keys=task_text_keys,
+        text_mode=text_mode,
+    )
+
+
+def todo_summary_monitor_schedule_gap_count(
+    summary: dict[str, Any] | None,
+    *,
+    gap_items: list[dict[str, Any]] | None = None,
+    task_text_keys: tuple[str, ...] = ("title", "text"),
+    text_mode: str = "label",
+) -> int:
+    if not isinstance(summary, dict):
+        return 0
+    if not todo_summary_monitor_writeback_supported(summary):
+        return 0
+    agent_id = todo_summary_claim_scope_agent_id(summary)
+    if agent_id:
+        raw_items = summary.get("monitor_open_items")
+        if isinstance(raw_items, list):
+            return len(
+                [
+                    item
+                    for item in raw_items
+                    if isinstance(item, dict)
+                    if todo_item_missing_monitor_schedule(
+                        item,
+                        task_text_keys=task_text_keys,
+                    )
+                    if todo_item_claimed_by_agent_or_unclaimed(item, agent_id=agent_id)
+                ]
+            )
+        return len(
+            gap_items
+            if gap_items is not None
+            else todo_summary_monitor_schedule_gap_items(
+                summary,
+                task_text_keys=task_text_keys,
+                text_mode=text_mode,
+            )
+        )
+    projected_count = summary.get("monitor_schedule_gap_count")
+    if isinstance(projected_count, int):
+        return max(0, projected_count)
+    return len(
+        gap_items
+        if gap_items is not None
+        else todo_summary_monitor_schedule_gap_items(
+            summary,
+            task_text_keys=task_text_keys,
+            text_mode=text_mode,
+        )
     )


### PR DESCRIPTION
## Summary
- project continuous_monitor todos without cadence/next_due_at as monitor schedule metadata gaps instead of allowing silent monitor_quiet_skip
- keep the policy in shared todo projection/work-lane seams; quota.py only consumes the projected gap fields
- update monitor scheduler smoke to distinguish pre-ACK autonomous replan from post-ACK quiet monitor scheduling

## Validation
- python3 examples/quota-replan-decision-plane-smoke.py
- python3 examples/monitor-poll-writeback-smoke.py
- python3 examples/monitor-todo-policy-seam-smoke.py
- python3 examples/control_plane/todo-projection-shared-helper-smoke.py
- python3 examples/monitor-scheduler-contract-smoke.py
- python3 -m py_compile loopx/policies/monitor_todo.py loopx/todo_projection.py loopx/status.py loopx/quota.py loopx/policies/work_lane.py examples/monitor-scheduler-contract-smoke.py examples/monitor-todo-policy-seam-smoke.py examples/control_plane/todo-projection-shared-helper-smoke.py
- git diff --check
- loopx check --scan-path loopx/policies/monitor_todo.py --scan-path loopx/todo_projection.py --scan-path loopx/status.py --scan-path loopx/quota.py --scan-path loopx/policies/work_lane.py --scan-path examples/monitor-scheduler-contract-smoke.py --scan-path examples/monitor-todo-policy-seam-smoke.py --scan-path examples/control_plane/todo-projection-shared-helper-smoke.py

## Notes
- loopx check reports the existing loopx-meta duplicate index warning; public boundary scan was clean for the 8 changed files.