### PR TITLE
[codex] Improve LoopX help and manpage

### DIFF
--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -253,7 +253,8 @@ loopx doctor
 
 The installer downloads a GitHub archive, writes a stable local release snapshot
 under `~/.local/share/loopx/releases/`, installs the CLI wrapper under
-`~/.local/bin`, and installs the reusable LoopX skills under
+`~/.local/bin`, installs the `man loopx` page under
+`~/.local/share/man`, and installs the reusable LoopX skills under
 `~/.codex/skills`.
 
 `loopx doctor` reports `install_freshness`. For a productized upgrade path, use
@@ -288,6 +289,8 @@ The checkout installer creates:
 
 - `~/.local/bin/loopx`, pointing at a stable local release snapshot;
 - `~/.local/bin/loopx-canary`, pointing at the live checkout;
+- `~/.local/share/man/man1/loopx.1.gz`, so `man loopx` opens the short
+  operator manual after the shell profile reloads;
 - the LoopX Codex skills under `~/.codex/skills`.
 
 Those global skills are the intended product surface for reusable LoopX
@@ -299,9 +302,10 @@ checkout to the default local release.
 
 ## Global Skill Install, Update, Repair, And Cleanup
 
-`scripts/install-local.sh` manages two reusable local surfaces:
+`scripts/install-local.sh` manages three reusable local surfaces:
 
 - the CLI wrappers under `~/.local/bin`;
+- the local manual page under `~/.local/share/man`;
 - the LoopX Codex skills under `~/.codex/skills`.
 
 For a no-clone install, use `loopx update` to refresh the release snapshot and
@@ -829,7 +833,8 @@ sync-global             merge project registry into the global registry
 check                   run contract and public/private boundary checks
 ```
 
-Use `loopx <command> --help` for command-specific flags.
+Use `loopx commands` for the grouped CLI reference, `loopx <command> --help`
+for command-specific flags, or `man loopx` for the installed operator manual.
 
 ## Repository Quality Guard
 

--- a/docs/guides/newcomer-command-path.md
+++ b/docs/guides/newcomer-command-path.md
@@ -77,3 +77,5 @@ the product path:
   installation, debugging, or maintainer workflows.
 - Contributors may still use the full command reference in
   [Getting started](getting-started.md#command-reference).
+- Installed users can run `man loopx` or `loopx commands` when they need a
+  grouped operator reference instead of the first-run path.

--- a/examples/cli-help-manpage-smoke.py
+++ b/examples/cli-help-manpage-smoke.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import gzip
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LONG_TAIL_COMMAND = "codex-cli-visible-first-response-capture-plan"
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *args],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+    )
+
+
+def assert_concise_default_help(output: str) -> None:
+    assert "LoopX keeps long-running agent work moving" in output, output
+    assert "Start here:" in output, output
+    assert "/loopx <goal text>" in output, output
+    assert "loopx commands" in output, output
+    assert "man loopx" in output, output
+    assert LONG_TAIL_COMMAND not in output, output
+    assert len(output.splitlines()) <= 36, output
+
+
+def assert_default_help_surface() -> None:
+    bare = run_cli()
+    assert bare.returncode == 0, (bare.returncode, bare.stdout, bare.stderr)
+    assert_concise_default_help(bare.stdout)
+    assert bare.stderr == "", bare.stderr
+
+    top_help = run_cli("--help")
+    assert top_help.returncode == 0, (top_help.returncode, top_help.stdout, top_help.stderr)
+    assert_concise_default_help(top_help.stdout)
+    assert top_help.stderr == "", top_help.stderr
+
+
+def assert_command_reference_surface() -> None:
+    result = run_cli("commands")
+    assert result.returncode == 0, (result.returncode, result.stdout, result.stderr)
+    assert "LoopX command reference" in result.stdout, result.stdout
+    assert "Daily operator commands" in result.stdout, result.stdout
+    assert "Maintainer and adapter commands" in result.stdout, result.stdout
+    assert "loopx <command> --help" in result.stdout, result.stdout
+    assert "codex-cli-bootstrap-message" in result.stdout, result.stdout
+    assert result.stderr == "", result.stderr
+
+
+def assert_installer_manpage_surface() -> None:
+    script = REPO_ROOT / "scripts" / "install-local.sh"
+    subprocess.run(["bash", "-n", str(script)], check=True)
+
+    with tempfile.TemporaryDirectory(prefix="loopx-help-manpage-smoke-") as raw_tmp:
+        tmp = Path(raw_tmp)
+        home = tmp / "home"
+        bin_dir = home / ".local" / "bin"
+        man_root = home / ".local" / "share" / "man"
+        profile = home / ".zshrc"
+        home.mkdir()
+        env = {
+            **os.environ,
+            "HOME": str(home),
+            "CODEX_HOME": str(home / ".codex"),
+            "LOOPX_BIN_DIR": str(bin_dir),
+            "LOOPX_RELEASES_DIR": str(home / ".local" / "share" / "loopx" / "releases"),
+            "LOOPX_SHELL_PROFILE": str(profile),
+            "LOOPX_INSTALL_SKILL": "0",
+            "LOOPX_INSTALL_CANARY": "0",
+            "LOOPX_RELEASE_ID": "help-manpage-smoke-release",
+            "PATH": os.environ.get("PATH", ""),
+            "SHELL": "/bin/zsh",
+        }
+
+        install = subprocess.run(
+            [str(script)],
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        assert f"- manpage: {man_root / 'man1' / 'loopx.1.gz'}" in install.stdout, install.stdout
+
+        installed_help = subprocess.run(
+            [str(bin_dir / "loopx")],
+            cwd=tmp,
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+        assert installed_help.returncode == 0, (
+            installed_help.returncode,
+            installed_help.stdout,
+            installed_help.stderr,
+        )
+        assert_concise_default_help(installed_help.stdout)
+        assert installed_help.stderr == "", installed_help.stderr
+
+        manpage = man_root / "man1" / "loopx.1.gz"
+        assert manpage.is_file(), manpage
+        with gzip.open(manpage, "rt", encoding="utf-8") as handle:
+            man_text = handle.read()
+        assert ".TH LOOPX 1" in man_text, man_text
+        assert "loopx commands" in man_text, man_text
+        assert "loopx COMMAND --help" in man_text, man_text
+
+        profile_text = profile.read_text(encoding="utf-8")
+        assert 'export MANPATH="$HOME/.local/share/man:${MANPATH:-}"' in profile_text, profile_text
+
+        man = subprocess.run(
+            ["man", "-M", str(man_root), "loopx"],
+            cwd=tmp,
+            env={**env, "MANPAGER": "cat", "PAGER": "cat"},
+            text=True,
+            capture_output=True,
+        )
+        assert man.returncode == 0, (man.returncode, man.stdout, man.stderr)
+        assert "LOOPX(1)" in man.stdout, man.stdout
+        assert "LoopX keeps long-running agent work moving" in man.stdout, man.stdout
+
+
+def main() -> int:
+    assert_default_help_surface()
+    assert_command_reference_surface()
+    assert_installer_manpage_surface()
+    print("cli-help-manpage-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/codex-cli-packaged-install-smoke.py
+++ b/examples/codex-cli-packaged-install-smoke.py
@@ -39,6 +39,7 @@ def main() -> None:
                 "scripts",
                 "skills",
                 "docs",
+                "man",
                 "examples",
                 "README.md",
                 "pyproject.toml",
@@ -62,6 +63,7 @@ def main() -> None:
 
         installed = home / ".local" / "bin" / "loopx"
         assert installed.exists(), installed
+        assert (home / ".local" / "share" / "man" / "man1" / "loopx.1.gz").is_file()
         assert not (home / ".local" / "bin" / "goal-harness").exists()
         doctor = subprocess.run(
             [str(installed), "doctor"],

--- a/examples/fresh-clone-quickstart-smoke.py
+++ b/examples/fresh-clone-quickstart-smoke.py
@@ -56,6 +56,7 @@ def main() -> int:
 
         home = root / "home"
         bin_dir = home / ".local" / "bin"
+        man_root = home / ".local" / "share" / "man"
         codex_home = home / ".codex"
         profile = home / ".zshrc"
         home.mkdir()
@@ -75,6 +76,7 @@ def main() -> int:
         install = run([str(clone / "scripts" / "install-local.sh")], cwd=clone, env=env)
         assert "loopx installed locally" in install.stdout, install.stdout
         assert f"- executable: {bin_dir / 'loopx'}" in install.stdout, install.stdout
+        assert f"- manpage: {man_root / 'man1' / 'loopx.1.gz'}" in install.stdout, install.stdout
         assert f"- canary executable: {bin_dir / 'loopx-canary'}" in install.stdout, install.stdout
         assert f"- skill: {codex_home / 'skills' / 'loopx-project'}" in install.stdout, install.stdout
         assert f"- skill: {codex_home / 'skills' / 'loopx-pr-review'}" in install.stdout, install.stdout
@@ -91,6 +93,10 @@ def main() -> int:
         release_root = wrapper.resolve().parents[1]
         assert release_root != clone, release_root
         assert (release_root / "loopx" / "cli.py").is_file(), release_root
+        assert (man_root / "man1" / "loopx.1.gz").is_file()
+        assert 'export MANPATH="$HOME/.local/share/man:${MANPATH:-}"' in profile.read_text(
+            encoding="utf-8"
+        )
         assert (codex_home / "skills" / "loopx-project" / "SKILL.md").is_file()
         assert (codex_home / "skills" / "loopx-pr-review" / "SKILL.md").is_file()
         assert (codex_home / "skills" / "loopx-self-repair" / "SKILL.md").is_file()

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -76,6 +76,12 @@ from .cli_rollout import (
     append_benchmark_run_rollout_event,
     append_cli_rollout_event,
 )
+from .help_surface import (
+    build_command_reference_payload,
+    render_command_reference_markdown,
+    render_concise_help,
+    top_level_help_requested,
+)
 from .paths import DEFAULT_RUNTIME_ROOT, default_registry_path, global_registry_path
 
 
@@ -109,6 +115,11 @@ def user_supplied_registry(argv: list[str] | None) -> bool:
 
 
 def main(argv: list[str] | None = None) -> int:
+    raw_argv = sys.argv[1:] if argv is None else list(argv)
+    if top_level_help_requested(raw_argv):
+        print(render_concise_help(sys.argv[0] if argv is None else "loopx"), end="")
+        return 0
+
     parser = argparse.ArgumentParser(description="LoopX control-plane helper.")
     parser.add_argument("--version", action="version", version=f"loopx {__version__}")
     parser.add_argument("--registry", default=str(default_registry_path()), help="Path to a project-local registry.")
@@ -117,6 +128,12 @@ def main(argv: list[str] | None = None) -> int:
     sub = parser.add_subparsers(dest="command", required=True)
 
     register_version_command(sub, add_subcommand_format)
+
+    commands_parser = sub.add_parser(
+        "commands",
+        help="Show grouped LoopX command reference for operators and contributors.",
+    )
+    add_subcommand_format(commands_parser)
 
     register_bootstrap_connect_command(sub)
 
@@ -205,6 +222,14 @@ def main(argv: list[str] | None = None) -> int:
     version_result = handle_version_command(args, output_format=output_format, print_payload=print_payload)
     if version_result is not None:
         return version_result
+
+    if args.command == "commands":
+        print_payload(
+            build_command_reference_payload(),
+            output_format(args),
+            render_command_reference_markdown,
+        )
+        return 0
 
     bootstrap_connect_result = handle_bootstrap_connect_command(
         args,

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+GLOBAL_OPTIONS_WITH_VALUE = {"--registry", "--runtime-root", "--format"}
+GLOBAL_OPTIONS_WITH_EQUALS = tuple(f"{option}=" for option in sorted(GLOBAL_OPTIONS_WITH_VALUE))
+HELP_FLAGS = {"-h", "--help"}
+
+
+COMMAND_GROUPS: list[dict[str, object]] = [
+    {
+        "title": "Start here",
+        "commands": [
+            {
+                "command": "/loopx",
+                "purpose": "Ask the agent to inspect LoopX status, gates, todos, and next action.",
+            },
+            {
+                "command": "/loopx <goal text>",
+                "purpose": "Start or continue one concrete long-running goal through the agent.",
+            },
+            {
+                "command": "loopx doctor",
+                "purpose": "Check install, PATH, release snapshot, skills, and import health.",
+            },
+            {
+                "command": "loopx bootstrap-command-pack --project .",
+                "purpose": "Generate a setup packet for a manual shell or first agent handoff.",
+            },
+        ],
+    },
+    {
+        "title": "Daily operator commands",
+        "commands": [
+            {"command": "loopx status", "purpose": "Show goals, gates, attention queue, and next action."},
+            {
+                "command": "loopx diagnose --goal-id <goal-id>",
+                "purpose": "Build a compact evidence packet when behavior is surprising.",
+            },
+            {
+                "command": "loopx review-packet --goal-id <goal-id>",
+                "purpose": "Render a handoff or review packet for operator judgment.",
+            },
+            {"command": "loopx todo --help", "purpose": "Show todo lifecycle commands."},
+            {"command": "loopx quota should-run", "purpose": "Decide whether the next agent turn should run."},
+            {"command": "loopx history --goal-id <goal-id>", "purpose": "Read compact run history."},
+        ],
+    },
+    {
+        "title": "Setup and automation commands",
+        "commands": [
+            {"command": "loopx bootstrap / loopx connect", "purpose": "Create or connect project-local state."},
+            {
+                "command": "loopx new-project-prompt",
+                "purpose": "Generate a copy-paste project connection prompt for an agent.",
+            },
+            {
+                "command": "loopx codex-cli-bootstrap-message",
+                "purpose": "Generate the visible Codex CLI TUI setup message.",
+            },
+            {"command": "loopx heartbeat-prompt", "purpose": "Generate a guarded heartbeat automation body."},
+            {"command": "loopx upgrade-plan", "purpose": "Plan default heartbeat upgrade propagation."},
+            {"command": "loopx update", "purpose": "Check, dry-run, or execute the no-clone update path."},
+        ],
+    },
+    {
+        "title": "Maintainer and adapter commands",
+        "commands": [
+            {"command": "loopx check", "purpose": "Run contract and public/private boundary checks."},
+            {"command": "loopx registry", "purpose": "Inspect registered goals and adapters."},
+            {"command": "loopx sync-global", "purpose": "Merge project state into the shared registry."},
+            {"command": "loopx register-agent", "purpose": "Register an automation agent."},
+            {"command": "loopx lark-kanban", "purpose": "Project LoopX state into a Feishu/Lark Base board."},
+            {"command": "loopx issue-fix", "purpose": "Build public-safe issue or PR fix workflow packets."},
+            {"command": "loopx auto-research", "purpose": "Project public-safe research frontiers."},
+            {"command": "loopx multi-agent", "purpose": "Launch visible role-scoped Codex TUI agents."},
+            {"command": "loopx canary", "purpose": "Plan or run catalog-informed smoke profiles."},
+            {"command": "loopx benchmark", "purpose": "Use fixture-only benchmark runner skeletons by default."},
+        ],
+    },
+]
+
+
+def _program_name(program: str) -> str:
+    name = program.rsplit("/", 1)[-1]
+    if name in {"loopx", "cli.py", "__main__.py"}:
+        return "loopx"
+    if program.endswith("loopx.cli") or " -m loopx.cli" in program:
+        return "loopx"
+    return program or "loopx"
+
+
+def top_level_help_requested(argv: list[str]) -> bool:
+    if not argv:
+        return True
+    help_positions = [index for index, value in enumerate(argv) if value in HELP_FLAGS]
+    if not help_positions:
+        return False
+    help_index = help_positions[0]
+    index = 0
+    while index < help_index:
+        value = argv[index]
+        if value in GLOBAL_OPTIONS_WITH_VALUE:
+            index += 2
+            continue
+        if value.startswith(GLOBAL_OPTIONS_WITH_EQUALS):
+            index += 1
+            continue
+        return False
+    return True
+
+
+def render_concise_help(program: str = "loopx") -> str:
+    program = _program_name(program)
+    return "\n".join(
+        [
+            "LoopX keeps long-running agent work moving by preserving goals, todos, gates, quota,",
+            "and evidence between agent turns.",
+            "",
+            "Usage:",
+            f"  {program} [global options] <command> [command options]",
+            f"  {program} <command> --help",
+            "",
+            "Start here:",
+            "  /loopx                         Ask the agent to inspect LoopX state.",
+            "  /loopx <goal text>             Start or continue a concrete long-running goal.",
+            "  loopx doctor                   Check install, PATH, release snapshot, and skills.",
+            "  loopx bootstrap-command-pack --project .",
+            "                                  Generate a setup packet for a manual shell path.",
+            "",
+            "Daily operator commands:",
+            "  loopx status                   Show current goals, gates, and next action.",
+            "  loopx diagnose --goal-id ID    Build a compact evidence packet.",
+            "  loopx todo --help              Add, claim, complete, update, or archive todos.",
+            "  loopx quota should-run         Decide whether the next agent turn should run.",
+            "",
+            "Global options:",
+            "  --registry PATH   --runtime-root PATH   --format markdown|json",
+            "",
+            "More:",
+            "  loopx commands                 Show grouped command reference.",
+            "  loopx <command> --help         Show flags for one command.",
+            "  man loopx                      Open the installed manual page.",
+            "  docs/guides/newcomer-command-path.md",
+            "",
+        ]
+    )
+
+
+def build_command_reference_payload() -> dict[str, Any]:
+    return {
+        "ok": True,
+        "schema_version": "loopx_command_reference_v0",
+        "summary": "Grouped LoopX command reference for operators and contributors.",
+        "groups": COMMAND_GROUPS,
+        "more": [
+            "loopx <command> --help",
+            "man loopx",
+            "docs/guides/getting-started.md#command-reference",
+        ],
+    }
+
+
+def render_command_reference_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# LoopX command reference",
+        "",
+        str(payload.get("summary") or ""),
+        "",
+    ]
+    groups = payload.get("groups") if isinstance(payload.get("groups"), list) else []
+    for group in groups:
+        if not isinstance(group, dict):
+            continue
+        title = str(group.get("title") or "Commands")
+        lines.extend([f"## {title}", ""])
+        commands = group.get("commands") if isinstance(group.get("commands"), list) else []
+        for command in commands:
+            if not isinstance(command, dict):
+                continue
+            name = str(command.get("command") or "").strip()
+            purpose = str(command.get("purpose") or "").strip()
+            if name and purpose:
+                lines.append(f"- `{name}` - {purpose}")
+        lines.append("")
+    lines.extend(
+        [
+            "For command-specific flags, run `loopx <command> --help`.",
+            "For the manual page, run `man loopx` after installing LoopX.",
+            "",
+        ]
+    )
+    return "\n".join(lines)

--- a/man/loopx.1
+++ b/man/loopx.1
@@ -1,0 +1,74 @@
+.TH LOOPX 1 "2026-07-03" "LoopX 0.1.4" "User Commands"
+.SH NAME
+loopx \- control-plane helper for long-running agent work
+.SH SYNOPSIS
+.B loopx
+[\fB--registry\fR \fIPATH\fR]
+[\fB--runtime-root\fR \fIPATH\fR]
+[\fB--format\fR \fImarkdown|json\fR]
+\fICOMMAND\fR
+[\fIARGS\fR]
+.br
+.B loopx
+\fICOMMAND\fR
+\fB--help\fR
+.br
+.B loopx commands
+.SH DESCRIPTION
+LoopX keeps long-running agent work moving by preserving goals, todos, gates,
+quota, and evidence between agent turns.
+.PP
+The default command surface is intentionally short. New users should start with
+the agent slash command path, then use the CLI for install checks, status,
+diagnosis, and handoff packets.
+.SH START HERE
+.TP
+.B /loopx
+Ask the agent to inspect LoopX status, gates, todos, and next action.
+.TP
+.B /loopx <goal text>
+Start or continue one concrete long-running goal through the agent.
+.TP
+.B loopx doctor
+Check install, PATH, release snapshot, skills, and import health.
+.TP
+.B loopx bootstrap-command-pack --project .
+Generate a setup packet for a manual shell or first agent handoff.
+.SH DAILY COMMANDS
+.TP
+.B loopx status
+Show current goals, gates, attention queue, and next action.
+.TP
+.B loopx diagnose --goal-id <goal-id>
+Build a compact evidence packet when behavior is surprising.
+.TP
+.B loopx review-packet --goal-id <goal-id>
+Render a handoff or review packet for operator judgment.
+.TP
+.B loopx todo --help
+Show todo add, claim, complete, update, supersede, and archive forms.
+.TP
+.B loopx quota should-run
+Decide whether the next agent turn should run.
+.SH MORE COMMANDS
+.TP
+.B loopx commands
+Show the grouped command reference.
+.TP
+.B loopx COMMAND --help
+Show flags for one command.
+.TP
+.B docs/guides/newcomer-command-path.md
+Explains the minimal product path for new users.
+.TP
+.B docs/guides/getting-started.md#command-reference
+Keeps the longer operator and contributor command catalog.
+.SH INSTALL NOTES
+The LoopX local installer writes this manual to
+\fI$HOME/.local/share/man/man1/loopx.1.gz\fR by default and adds
+\fI$HOME/.local/share/man\fR to MANPATH in the selected shell profile.
+If the current shell has not reloaded that profile, run:
+.PP
+.B MANPATH="$HOME/.local/share/man:${MANPATH:-}" man loopx
+.SH SEE ALSO
+.BR man (1)

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -8,6 +8,8 @@ bin_dir="${LOOPX_BIN_DIR:-$HOME/.local/bin}"
 shell_profile="${LOOPX_SHELL_PROFILE:-}"
 codex_home="${CODEX_HOME:-$HOME/.codex}"
 skills_dir="${LOOPX_SKILLS_DIR:-$codex_home/skills}"
+man_root="${LOOPX_MAN_ROOT:-$HOME/.local/share/man}"
+man_dir="${LOOPX_MAN_DIR:-$man_root/man1}"
 install_skill="${LOOPX_INSTALL_SKILL:-1}"
 install_canary="${LOOPX_INSTALL_CANARY:-1}"
 releases_dir="${LOOPX_RELEASES_DIR:-$HOME/.local/share/loopx/releases}"
@@ -107,6 +109,7 @@ copy_path "$repo_root/loopx" "$release_tmp/loopx"
 copy_path "$repo_root/scripts" "$release_tmp/scripts"
 copy_path "$repo_root/skills" "$release_tmp/skills"
 copy_path "$repo_root/docs" "$release_tmp/docs"
+copy_path "$repo_root/man" "$release_tmp/man"
 copy_path "$repo_root/examples" "$release_tmp/examples"
 copy_path "$repo_root/apps" "$release_tmp/apps"
 copy_path "$repo_root/.github" "$release_tmp/.github"
@@ -154,6 +157,38 @@ if [[ -n "$shell_profile" ]]; then
       fi
     } >>"$shell_profile"
   fi
+  if ! grep -F "$man_root" "$shell_profile" >/dev/null 2>&1 \
+    && ! grep -F '$HOME/.local/share/man' "$shell_profile" >/dev/null 2>&1; then
+    {
+      printf '\n# LoopX local manual\n'
+      if [[ "$man_root" == "$HOME/.local/share/man" ]]; then
+        printf 'export MANPATH="$HOME/.local/share/man:${MANPATH:-}"\n'
+      else
+        printf 'export MANPATH="%s:${MANPATH:-}"\n' "$man_root"
+      fi
+    } >>"$shell_profile"
+  fi
+fi
+
+man_line="- manpage: skipped (source missing)"
+man_source="$release_dir/man/loopx.1"
+man_target="$man_dir/loopx.1.gz"
+if [[ -f "$man_source" ]]; then
+  mkdir -p "$man_dir"
+  MAN_SOURCE="$man_source" MAN_TARGET="$man_target" "${LOOPX_PYTHON:-python3}" - <<'PY'
+from pathlib import Path
+import gzip
+import os
+import shutil
+
+source = Path(os.environ["MAN_SOURCE"])
+target = Path(os.environ["MAN_TARGET"])
+target.parent.mkdir(parents=True, exist_ok=True)
+with source.open("rb") as raw, gzip.open(target, "wb", compresslevel=9) as zipped:
+    shutil.copyfileobj(raw, zipped)
+PY
+  chmod 0644 "$man_target"
+  man_line="- manpage: $man_target"
 fi
 
 export PATH="$bin_dir:$PATH"
@@ -206,6 +241,8 @@ cat <<EOF
 loopx installed locally
 - executable: $bin_dir/loopx
 - release: $release_dir
+- manual root: $man_root
+$man_line
 $canary_line
 - executable compatibility: none
 $legacy_line
@@ -215,5 +252,7 @@ $claude_line
 
 Current shell can use it with:
   export PATH="$bin_dir:\$PATH"
+  export MANPATH="$man_root:\${MANPATH:-}"
   loopx doctor
+  man loopx
 EOF


### PR DESCRIPTION
## Summary

- Replace the top-level `loopx` / `loopx --help` argparse command dump with a concise first-run operator guide.
- Add `loopx commands` for grouped command reference while preserving `loopx <command> --help` for detailed flags.
- Ship and install a `man loopx` page through the local/no-clone release snapshot path, including MANPATH profile setup.
- Add smoke coverage for the default help surface, installed wrapper behavior, manpage installability, and packaged/fresh-clone install paths.

## Root cause

The CLI parser treated the full subcommand catalog as the default help surface, so first-time users saw long-tail maintainer and adapter commands before the product path. The installer also copied release files and skills, but never installed a manpage or MANPATH entry, so `man loopx` could not resolve.

## Validation

- `python3 examples/cli-help-manpage-smoke.py`
- `python3 examples/codex-cli-packaged-install-smoke.py`
- `python3 examples/fresh-clone-quickstart-smoke.py`
- `python3 examples/subcommand-format-smoke.py`
- `python3 examples/docs-governance-smoke.py && python3 examples/check-public-boundary-smoke.py`
- `python3 -m loopx.cli --help && python3 -m loopx.cli commands --format json && python3 -m loopx.cli status --help`
- `git diff --cached --check` before commit

Known unrelated check result: `python3 examples/cli-command-module-size-ownership-command-modularization-smoke.py` currently fails on `benchmark_run_ledger.py has 851 lines, above budget 820`; this PR does not touch that file or command family.
