### PR TITLE
Let demo-local auto-research lanes bypass workspace guard

### DIFF
--- a/examples/auto-research-layered-e2e-acceptance-smoke.py
+++ b/examples/auto-research-layered-e2e-acceptance-smoke.py
@@ -266,6 +266,10 @@ def assert_two_round_outcome(payload: dict[str, Any]) -> None:
         "summarize_evidence",
     ], control
     assert control["workspace_route"]["primary_workspace"] == "visible_codex_tui_workspace", control
+    assert control["workspace_guard_policy"] == {
+        "side_agent_independent_worktree_required": False,
+        "repository_edits_still_require_lane_boundary": True,
+    }, control
     assert_public_safe(payload)
 
 

--- a/examples/side-agent-workspace-guard-smoke.py
+++ b/examples/side-agent-workspace-guard-smoke.py
@@ -189,6 +189,7 @@ def main() -> int:
         side = root / "side-worktree"
         foreign = root / "foreign"
         registry = root / "registry.global.json"
+        exempt_registry = root / "registry-exempt.global.json"
         init_repo(primary, side)
         registry.write_text(
             json.dumps(
@@ -203,10 +204,30 @@ def main() -> int:
             ),
             encoding="utf-8",
         )
+        exempt_policy = {
+            "schema_version": "loopx_workspace_guard_policy_v0",
+            "side_agent_independent_worktree_required": False,
+            "reason": "fixture-controlled local state boundary",
+        }
+        exempt_registry.write_text(
+            json.dumps(
+                {
+                    "goals": [
+                        {
+                            "id": GOAL_ID,
+                            "repo": str(primary),
+                            "workspace_guard_policy": exempt_policy,
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
         foreign.mkdir(parents=True)
         run_git(foreign, "init")
 
         payload = status_payload(primary, registry)
+        exempt_payload = status_payload(primary, exempt_registry)
 
         with pushd(primary):
             guarded = build_quota_should_run(
@@ -244,6 +265,18 @@ def main() -> int:
         assert primary_agent["normal_delivery_allowed"] is True, primary_agent
         assert "workspace_guard" not in primary_agent, primary_agent
         assert primary_agent["recommended_action"] == PRIMARY_TODO, primary_agent
+
+        exempt_payload["run_history"]["goals"][0]["workspace_guard_policy"] = exempt_policy
+        exempt_payload["attention_queue"]["items"][0]["workspace_guard_policy"] = exempt_policy
+        guard_exempt = build_quota_should_run(
+            exempt_payload,
+            goal_id=GOAL_ID,
+            agent_id="codex-side-bypass",
+        )
+        assert guard_exempt["normal_delivery_allowed"] is True, guard_exempt
+        assert guard_exempt["effective_action"] == "normal_run", guard_exempt
+        assert "workspace_guard" not in guard_exempt, guard_exempt
+        assert guard_exempt["recommended_action"] == SIDE_TODO, guard_exempt
 
         with pushd(side):
             side_ok = build_quota_should_run(

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -137,6 +137,23 @@ def _seed_visible_demo_control_plane(
         spawn_allowed=True,
         execute=True,
     )
+    registry_payload = json.loads(control_registry.read_text(encoding="utf-8"))
+    for goal in registry_payload.get("goals", []):
+        if isinstance(goal, dict) and str(goal.get("id")) == goal_id:
+            goal["workspace_guard_policy"] = {
+                "schema_version": "loopx_workspace_guard_policy_v0",
+                "side_agent_independent_worktree_required": False,
+                "reason": (
+                    "auto_research_demo_local_queue uses a demo-owned workspace and "
+                    "writes only demo-local LoopX state/evidence; repository edits still "
+                    "require an explicit lane-owned execution boundary"
+                ),
+            }
+            break
+    control_registry.write_text(
+        json.dumps(registry_payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
 
     seeded_todos: list[dict[str, object]] = []
     for lane in lanes:
@@ -186,6 +203,10 @@ def _seed_visible_demo_control_plane(
         "seeded_todos": seeded_todos,
         "state_route": "visible_lanes_use_LOOPX_REGISTRY_and_LOOPX_RUNTIME_ROOT",
         "workspace_route": workspace_route,
+        "workspace_guard_policy": {
+            "side_agent_independent_worktree_required": False,
+            "repository_edits_still_require_lane_boundary": True,
+        },
         "absolute_paths_recorded": False,
         "private_artifacts_recorded": False,
     }

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -5387,6 +5387,13 @@ def _side_agent_workspace_guard(
 ) -> dict[str, Any] | None:
     if not isinstance(agent_identity, dict) or agent_identity.get("role") != "side-agent":
         return None
+    workspace_guard_policy = (
+        goal.get("workspace_guard_policy")
+        if isinstance(goal.get("workspace_guard_policy"), dict)
+        else {}
+    )
+    if workspace_guard_policy.get("side_agent_independent_worktree_required") is False:
+        return None
     repo_value = goal.get("repo") or goal.get("project") or goal.get("root")
     if not repo_value:
         return None
@@ -6618,6 +6625,15 @@ def build_quota_plan(status_payload: dict[str, Any], *, mode: str = "status") ->
             "latest_run_generated_at": latest.get("generated_at"),
             "quota": quota,
         }
+        workspace_guard_policy = (
+            goal.get("workspace_guard_policy")
+            if isinstance(goal.get("workspace_guard_policy"), dict)
+            else status_goal.get("workspace_guard_policy")
+            if isinstance(status_goal.get("workspace_guard_policy"), dict)
+            else None
+        )
+        if workspace_guard_policy:
+            item["workspace_guard_policy"] = workspace_guard_policy
         if control_plane:
             item["control_plane"] = control_plane
         if project_asset:


### PR DESCRIPTION
## Summary
- add a durable `workspace_guard_policy` pass-through in quota planning
- mark demo-local auto-research queues as controlled local state/evidence boundaries so side-agent panes are not blocked by repository worktree guards
- extend workspace guard and layered auto-research smokes for the policy contract

## Validation
- `PYTHONPATH=. python3 examples/side-agent-workspace-guard-smoke.py`
- `PYTHONPATH=. python3 examples/auto-research-layered-e2e-acceptance-smoke.py`
- `PYTHONPATH=. python3 examples/visible-multi-agent-launcher-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli --registry ~/.codex/loopx/registry.global.json --runtime-root ~/.codex/loopx --format json check`
- real visible demo no-attach: accepted 4 Codex TUI panes and side-agent demo quota returned `normal_run` without `workspace_guard`

## Boundary
This does not weaken the default side-agent workspace guard. Only goals with an explicit `workspace_guard_policy.side_agent_independent_worktree_required=false` bypass the guard, and the auto-research demo policy still states that repository edits require a lane-owned execution boundary.
