### PR TITLE
Preserve monitor repair lanes in side-agent frontier

### DIFF
--- a/examples/monitor-scheduler-contract-smoke.py
+++ b/examples/monitor-scheduler-contract-smoke.py
@@ -113,7 +113,7 @@ def monitor_item(
     target_key: str,
     next_due_at: str | None = None,
     cadence: str | None = "15m",
-    claimed_by: str = AGENT_ID,
+    claimed_by: str | None = AGENT_ID,
     expires_at: str | None = None,
 ) -> dict:
     item = {
@@ -125,9 +125,10 @@ def monitor_item(
         "priority": priority,
         "task_class": "continuous_monitor",
         "action_kind": "monitor",
-        "claimed_by": claimed_by,
         "target_key": target_key,
     }
+    if claimed_by:
+        item["claimed_by"] = claimed_by
     if cadence:
         item["cadence"] = cadence
     if next_due_at:
@@ -135,6 +136,22 @@ def monitor_item(
     if expires_at:
         item["expires_at"] = expires_at
     return item
+
+
+def blocking_handoff_item(*, index: int, todo_id: str = "todo_primary_handoff") -> dict:
+    return {
+        "index": index,
+        "text": "[P1] Primary review gate that blocks the product-capability lane.",
+        "todo_id": todo_id,
+        "role": "agent",
+        "status": "open",
+        "priority": "P1",
+        "task_class": "advancement_task",
+        "action_kind": "pr_review_merge",
+        "claimed_by": "codex-main-control",
+        "blocks_agent": AGENT_ID,
+        "unblocks_todo_id": "todo_after_handoff",
+    }
 
 
 def advancement_item(*, index: int, priority: str = "P1", claimed_by: str = AGENT_ID) -> dict:
@@ -216,6 +233,36 @@ def assert_unscheduled_monitor_requires_metadata_repair() -> None:
     assert guard["interaction_contract"]["agent_channel"]["must_attempt"] is True, guard
     assert guard["interaction_contract"]["agent_channel"]["quiet_noop_allowed"] is False, guard
     assert guard["scheduler_hint"]["cadence_class"] == "active_work", guard
+
+
+def assert_unscheduled_monitor_repair_survives_handoff_gates() -> None:
+    guard = guard_for(
+        [
+            monitor_item(
+                index=1,
+                todo_id="todo_monitor_unscheduled",
+                priority="P1",
+                target_key="update-note-draft-pr",
+                cadence=None,
+                next_due_at=None,
+                claimed_by=None,
+            ),
+            blocking_handoff_item(index=2),
+        ],
+        coordination={
+            "registered_agents": ["codex-main-control", AGENT_ID],
+            "primary_agent": "codex-main-control",
+        },
+    )
+    lane = guard["work_lane_contract"]
+    assert guard["decision"] == "run", guard
+    assert guard["effective_action"] == "normal_run", guard
+    assert "agent_scope_frontier" not in guard, guard
+    frontier_hint = guard.get("agent_lane_frontier_hint", {})
+    assert frontier_hint.get("decision") != "quiet_noop_blocker", guard
+    assert lane["monitor_kind"] == "todo_monitor_schedule_gap", lane
+    assert lane["obligation"] == "repair_monitor_schedule_metadata", lane
+    assert guard["interaction_contract"]["agent_channel"]["must_attempt"] is True, guard
 
 
 def assert_due_monitor_requires_explicit_attempt() -> None:
@@ -461,6 +508,7 @@ def assert_other_agent_claimed_work_stays_diagnostic_when_no_current_lane() -> N
 def main() -> int:
     assert_not_due_monitor_waits_quietly()
     assert_unscheduled_monitor_requires_metadata_repair()
+    assert_unscheduled_monitor_repair_survives_handoff_gates()
     assert_due_monitor_requires_explicit_attempt()
     assert_expired_monitor_does_not_catch_up()
     assert_due_monitor_priority_does_not_steal_advancement_lane()

--- a/loopx/policies/work_lane.py
+++ b/loopx/policies/work_lane.py
@@ -4,6 +4,32 @@ from typing import Any
 
 
 WORK_LANE_CONTRACT_SCHEMA_VERSION = "work_lane_contract_v1"
+WORK_LANE_CURRENT_AGENT_MONITOR_REPAIR_OBLIGATIONS = {
+    "attempt_due_monitor",
+    "repair_monitor_schedule_metadata",
+    "repair_resume_gate_or_close_standing_monitor",
+}
+
+
+def work_lane_contract_requires_current_agent_attempt(
+    contract: dict[str, Any] | None,
+) -> bool:
+    """Return true when the work-lane contract is itself an actionable lane.
+
+    This intentionally covers monitor-derived repair/attempt obligations, not
+    every `advancement_task` contract. A generic advancement contract may still
+    describe goal-level work claimed by another agent; monitor-derived contracts
+    are built from current-agent/unclaimed monitor projections and must not be
+    collapsed into agent-scope wait just because no ordinary advancement todo
+    exists.
+    """
+
+    if not isinstance(contract, dict):
+        return False
+    if contract.get("must_attempt_work") is not True:
+        return False
+    obligation = str(contract.get("obligation") or "")
+    return obligation in WORK_LANE_CURRENT_AGENT_MONITOR_REPAIR_OBLIGATIONS
 
 
 def build_work_lane_contract(

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -52,6 +52,7 @@ from .policies.scheduler_hint import (
 from .policies.work_lane import (
     WORK_LANE_CONTRACT_SCHEMA_VERSION,
     build_work_lane_contract as build_work_lane_contract_policy,
+    work_lane_contract_requires_current_agent_attempt,
 )
 from .scheduler_state import (
     CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
@@ -3160,6 +3161,8 @@ def _agent_lane_frontier_hint(
 
     if _work_lane_due_monitor_attempt(work_lane_contract):
         return None
+    if work_lane_contract_requires_current_agent_attempt(work_lane_contract):
+        return None
 
     frontier = agent_scope_frontier if isinstance(agent_scope_frontier, dict) else {}
     frontier_action = _agent_scope_frontier_action(frontier.get("action"))
@@ -3528,6 +3531,8 @@ def _agent_scope_no_candidate_frontier(
     if isinstance(agent_lane_next_action, dict):
         return None
     if _work_lane_due_monitor_attempt(work_lane_contract):
+        return None
+    if work_lane_contract_requires_current_agent_attempt(work_lane_contract):
         return None
     has_advancement_contract = (
         isinstance(work_lane_contract, dict)


### PR DESCRIPTION
Summary
- Treat monitor-derived work-lane obligations as current-agent actionable work, so side-agent frontier does not collapse schedule metadata repair into agent_scope_wait.
- Keep the classification in loopx.policies.work_lane; quota.py only consumes the policy helper.
- Add a regression where an unscheduled monitor repair survives a main-control blocking handoff gate.

Validation
- python3 examples/monitor-scheduler-contract-smoke.py
- python3 examples/monitor-todo-policy-seam-smoke.py
- python3 examples/control_plane/todo-projection-shared-helper-smoke.py
- python3 examples/quota-replan-decision-plane-smoke.py
- python3 -m py_compile loopx/policies/work_lane.py loopx/quota.py examples/monitor-scheduler-contract-smoke.py
- PYTHONPATH=$PWD python3 -m loopx.cli --format json --registry $HOME/.codex/loopx/registry.global.json --runtime-root $HOME/.codex/loopx quota should-run --goal-id loopx-meta --agent-id codex-product-capability
- loopx check --scan-path loopx/policies/work_lane.py --scan-path loopx/quota.py --scan-path examples/monitor-scheduler-contract-smoke.py

Notes
- This is the follow-up root-cause fix after PR #1183: schedule gaps were projected, but agent-scope frontier still overrode the actionable work-lane contract.
- Product-capability is not self-merging this runtime/quota path; main-control should review and merge or request revision.