### PR TITLE
Add SkillsBench app-server Goal follow-up switch

### DIFF
--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -121,6 +121,79 @@ for line in sys.stdin:
     print(json.dumps({"id": mid, "result": result}), flush=True)
 """
 
+FAKE_CODEX_NORMAL_THEN_FOLLOWUP = """#!/usr/bin/env python3
+import json
+import sys
+
+turn_count = 0
+for line in sys.stdin:
+    msg = json.loads(line)
+    mid = msg.get("id")
+    method = msg.get("method")
+    if method == "initialized":
+        continue
+    if method == "initialize":
+        result = {"serverInfo": {"name": "fake-codex"}}
+    elif method == "thread/start":
+        result = {"thread": {"id": "thread-skillsbench"}}
+    elif method == "thread/goal/set":
+        result = {"goal": {"threadId": "thread-skillsbench", "status": "active"}}
+    elif method == "thread/goal/get":
+        result = {"goal": {"threadId": "thread-skillsbench", "status": "active"}}
+    elif method == "turn/start":
+        turn_count += 1
+        prompt_text = msg.get("params", {}).get("input", [{}])[0].get("text", "")
+        if turn_count == 1:
+            turn_id = "turn-normal-first"
+            item_id = "item-normal-first"
+            answer = "private worker draft"
+        else:
+            if "Continue the same SkillsBench task" not in prompt_text:
+                print(json.dumps({
+                    "id": mid,
+                    "error": {"code": -32602, "message": "missing continuation prompt"},
+                }), flush=True)
+                continue
+            if "Private task instruction placeholder" in prompt_text:
+                print(json.dumps({
+                    "id": mid,
+                    "error": {"code": -32602, "message": "raw task prompt repeated"},
+                }), flush=True)
+                continue
+            turn_id = "turn-normal-followup"
+            item_id = "item-normal-followup"
+            answer = "private worker answer after normal followup"
+        print(json.dumps({
+            "method": "turn/started",
+            "params": {
+                "threadId": "thread-skillsbench",
+                "turn": {"id": turn_id, "status": "inProgress"},
+            },
+        }), flush=True)
+        result = {"turn": {"id": turn_id, "status": "running"}}
+        print(json.dumps({"id": mid, "result": result}), flush=True)
+        print(json.dumps({
+            "method": "item/agentMessage/delta",
+            "params": {
+                "threadId": "thread-skillsbench",
+                "turnId": turn_id,
+                "itemId": item_id,
+                "delta": answer,
+            },
+        }), flush=True)
+        print(json.dumps({
+            "method": "turn/completed",
+            "params": {
+                "threadId": "thread-skillsbench",
+                "turn": {"id": turn_id, "status": "completed"},
+            },
+        }), flush=True)
+        continue
+    else:
+        result = {}
+    print(json.dumps({"id": mid, "result": result}), flush=True)
+"""
+
 FAKE_CODEX_NO_COMPLETION = """#!/usr/bin/env python3
 import json
 import sys
@@ -1005,6 +1078,8 @@ def test_app_server_retry_relay_command_carries_attempt_scope() -> None:
                 "retry-job-attempt-01",
                 "--rollout-name",
                 "bike-rebalance__codex_app_server_goal_independent_attempt_01",
+                "--app-server-goal-followup-max",
+                "2",
                 "--plan-only",
             ]
         )
@@ -1024,6 +1099,8 @@ def test_app_server_retry_relay_command_carries_attempt_scope() -> None:
         command[command.index("--rollout-name") + 1]
         == "bike-rebalance__codex_app_server_goal_independent_attempt_01"
     ), command
+    assert "--app-server-goal-followup-max" in command, command
+    assert command[command.index("--app-server-goal-followup-max") + 1] == "2", command
 
 
 def test_host_local_attempt_cleanup_matches_scoped_relay_subtree() -> None:
@@ -1277,6 +1354,70 @@ def test_host_worker_recovers_when_first_turn_only_echoes_context() -> None:
         public_json = json.dumps(payload)
         assert "context preamble" not in public_json, payload
         assert "private worker answer after context retry" not in public_json, payload
+        assert "Private task instruction placeholder" not in public_json, payload
+
+
+def test_host_worker_can_run_normal_no_reward_followup() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-app-goal-normal-followup-") as tmp:
+        root = Path(tmp)
+        fake = root / "codex"
+        prompt = root / "prompt.txt"
+        output = root / "worker.compact.json"
+        private_response = root / "private-response.txt"
+        fake.write_text(FAKE_CODEX_NORMAL_THEN_FOLLOWUP, encoding="utf-8")
+        fake.chmod(0o755)
+        prompt.write_text("Private task instruction placeholder.", encoding="utf-8")
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(WORKER_SCRIPT),
+                "--task-id",
+                "llm-prefix-cache-replay",
+                "--codex-bin",
+                str(fake),
+                "--work-dir",
+                str(root / "work"),
+                "--prompt-file",
+                str(prompt),
+                "--output-json",
+                str(output),
+                "--response-text-file",
+                str(private_response),
+                "--response-timeout-sec",
+                "5",
+                "--turn-timeout-sec",
+                "5",
+                "--normal-followup-max",
+                "1",
+            ],
+            cwd=REPO_ROOT,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        assert result.stdout == "", result
+        payload = json.loads(output.read_text(encoding="utf-8"))
+        assert payload["ok"] is True, payload
+        assert payload["error_type"] == "", payload
+        assert payload["turn"]["turn_attempt_count"] == 2, payload
+        assert payload["turn"]["context_only_turn_count"] == 0, payload
+        assert payload["turn"]["normal_followup_max"] == 1, payload
+        assert payload["turn"]["normal_followup_attempted"] is True, payload
+        assert payload["turn"]["normal_followup_succeeded"] is True, payload
+        assert payload["turn"]["normal_followup_start_attempted_count"] == 1, payload
+        assert payload["turn"]["normal_followup_start_succeeded_count"] == 1, payload
+        assert payload["normal_followup"]["enabled"] is True, payload
+        assert payload["normal_followup"]["verifier_feedback_provided"] is False, payload
+        assert payload["normal_followup"]["reward_feedback_provided"] is False, payload
+        assert len(payload["turn_attempts"]) == 2, payload
+        assert payload["turn_attempts"][0]["assistant_message_context_only"] is False, payload
+        assert payload["turn_attempts"][1]["selected_final_turn"] is True, payload
+        assert private_response.read_text(encoding="utf-8") == (
+            "private worker answer after normal followup"
+        )
+        public_json = json.dumps(payload)
+        assert "private worker draft" not in public_json, payload
+        assert "private worker answer after normal followup" not in public_json, payload
         assert "Private task instruction placeholder" not in public_json, payload
 
 
@@ -2838,6 +2979,7 @@ if __name__ == "__main__":
     test_host_worker_contract_only_cli()
     test_host_worker_waits_for_completion_and_keeps_public_json_compact()
     test_host_worker_recovers_when_first_turn_only_echoes_context()
+    test_host_worker_can_run_normal_no_reward_followup()
     test_host_worker_reactivates_goal_for_context_only_followup()
     test_host_worker_reconnects_context_only_followup_transport()
     test_host_worker_fails_closed_on_first_action_timeout()

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -518,6 +518,7 @@ class CodexExecConfig:
     worker_script: str | None = None
     stream_heartbeat_interval_sec: float = 120.0
     first_action_timeout_sec: float = 0.0
+    app_server_goal_followup_max: int = 0
     bridge_idle_timeout_sec: float = 0.0
     task_output_quiet_timeout_sec: float = 0.0
     reasoning_effort: str | None = None
@@ -2087,6 +2088,8 @@ raise SystemExit(proc.returncode)
                 str(self._config.timeout_sec),
                 "--first-action-timeout-sec",
                 str(worker_first_action_timeout_sec),
+                "--normal-followup-max",
+                str(max(0, int(self._config.app_server_goal_followup_max or 0))),
                 "--reasoning-effort",
                 str(self._config.reasoning_effort or "high"),
                 "--runner-integration-ready",
@@ -2464,6 +2467,12 @@ raise SystemExit(proc.returncode)
                     "context_only_followup_start_attempted",
                     "context_only_followup_start_succeeded",
                     "context_only_followup_start_error_type",
+                    "normal_followup_max",
+                    "normal_followup_attempted",
+                    "normal_followup_succeeded",
+                    "normal_followup_start_attempted_count",
+                    "normal_followup_start_succeeded_count",
+                    "normal_followup_start_error_type",
                     "transport_reconnect_attempted",
                     "transport_reconnect_succeeded",
                     "transport_reconnect_reason",
@@ -2488,6 +2497,21 @@ raise SystemExit(proc.returncode)
                     "followup_start_error_type",
                     "context_only_turn_count",
                     "turn_attempt_count",
+                ),
+            ),
+            "normal_followup": compact_dict(
+                payload.get("normal_followup"),
+                (
+                    "enabled",
+                    "max_followups",
+                    "attempted",
+                    "succeeded",
+                    "followup_start_attempted_count",
+                    "followup_start_succeeded_count",
+                    "followup_start_error_type",
+                    "turn_attempt_count",
+                    "reward_feedback_provided",
+                    "verifier_feedback_provided",
                 ),
             ),
             "worker_result": compact_dict(

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -1095,6 +1095,13 @@ def _host_local_acp_launch_command(
                 "30",
                 "--stream-heartbeat-interval-sec",
                 str(args.app_server_acp_heartbeat_interval_sec),
+                "--app-server-goal-followup-max",
+                str(
+                    max(
+                        0,
+                        int(getattr(args, "app_server_goal_followup_max", 0) or 0),
+                    )
+                ),
             ]
         )
         if worker_trace_dir:
@@ -8036,6 +8043,11 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         "app_server_reasoning_effort": (
             app_server_reasoning_effort if is_app_server_goal_route else ""
         ),
+        "app_server_goal_followup_max": (
+            max(0, int(args.app_server_goal_followup_max or 0))
+            if is_app_server_goal_route
+            else 0
+        ),
         "run_group_id": str(args.run_group_id or ""),
         "sandbox": args.sandbox,
         "max_rounds": args.max_rounds,
@@ -8728,6 +8740,21 @@ def _app_server_goal_worker_observability(
         "reasoning_effort_matches_request": bool(
             requested_effort and observed_effort and requested_effort == observed_effort
         ),
+        "requested_normal_followup_max": max(
+            0, int(plan.get("app_server_goal_followup_max") or 0)
+        ),
+        "normal_followup_attempted_count": _int_field(
+            "native_goal_worker_normal_followup_attempted_count"
+        ),
+        "normal_followup_succeeded_count": _int_field(
+            "native_goal_worker_normal_followup_succeeded_count"
+        ),
+        "normal_followup_start_attempted_count": _int_field(
+            "native_goal_worker_normal_followup_start_attempted_count"
+        ),
+        "normal_followup_start_succeeded_count": _int_field(
+            "native_goal_worker_normal_followup_start_succeeded_count"
+        ),
         "trace_dir_configured": bool(plan.get("app_server_goal_worker_trace_dir")),
         "trace_dir_present": bool(
             trace_summary.get("native_goal_worker_trace_dir_present")
@@ -9359,6 +9386,10 @@ def _merge_app_server_goal_worker_trace_summary(
     context_only_recovery_succeeded_count = 0
     context_only_followup_start_attempted_count = 0
     context_only_followup_start_succeeded_count = 0
+    normal_followup_attempted_count = 0
+    normal_followup_succeeded_count = 0
+    normal_followup_start_attempted_count = 0
+    normal_followup_start_succeeded_count = 0
     transport_reconnect_attempted_count = 0
     transport_reconnect_succeeded_count = 0
     goal_reactivation_attempted_count = 0
@@ -9466,6 +9497,43 @@ def _merge_app_server_goal_worker_trace_summary(
             or recovery.get("followup_start_succeeded") is True
         ):
             context_only_followup_start_succeeded_count += 1
+        normal_followup = (
+            payload.get("normal_followup")
+            if isinstance(payload.get("normal_followup"), dict)
+            else {}
+        )
+        if (
+            turn.get("normal_followup_attempted") is True
+            or normal_followup.get("attempted") is True
+        ):
+            normal_followup_attempted_count += 1
+        if (
+            turn.get("normal_followup_succeeded") is True
+            or normal_followup.get("succeeded") is True
+        ):
+            normal_followup_succeeded_count += 1
+        normal_attempts = turn.get("normal_followup_start_attempted_count")
+        if isinstance(normal_attempts, int) and not isinstance(
+            normal_attempts, bool
+        ):
+            normal_followup_start_attempted_count += max(0, normal_attempts)
+        else:
+            normal_attempts = normal_followup.get("followup_start_attempted_count")
+            if isinstance(normal_attempts, int) and not isinstance(
+                normal_attempts, bool
+            ):
+                normal_followup_start_attempted_count += max(0, normal_attempts)
+        normal_successes = turn.get("normal_followup_start_succeeded_count")
+        if isinstance(normal_successes, int) and not isinstance(
+            normal_successes, bool
+        ):
+            normal_followup_start_succeeded_count += max(0, normal_successes)
+        else:
+            normal_successes = normal_followup.get("followup_start_succeeded_count")
+            if isinstance(normal_successes, int) and not isinstance(
+                normal_successes, bool
+            ):
+                normal_followup_start_succeeded_count += max(0, normal_successes)
         if turn.get("transport_reconnect_attempted") is True:
             transport_reconnect_attempted_count += 1
         if turn.get("transport_reconnect_succeeded") is True:
@@ -9553,6 +9621,18 @@ def _merge_app_server_goal_worker_trace_summary(
     trace["native_goal_worker_context_only_followup_start_succeeded_count"] = (
         context_only_followup_start_succeeded_count
     )
+    trace["native_goal_worker_normal_followup_attempted_count"] = (
+        normal_followup_attempted_count
+    )
+    trace["native_goal_worker_normal_followup_succeeded_count"] = (
+        normal_followup_succeeded_count
+    )
+    trace["native_goal_worker_normal_followup_start_attempted_count"] = (
+        normal_followup_start_attempted_count
+    )
+    trace["native_goal_worker_normal_followup_start_succeeded_count"] = (
+        normal_followup_start_succeeded_count
+    )
     trace["native_goal_worker_transport_reconnect_attempted_count"] = (
         transport_reconnect_attempted_count
     )
@@ -9599,6 +9679,10 @@ def _merge_app_server_goal_worker_trace_summary(
         "native_goal_worker_context_only_recovery_succeeded_count",
         "native_goal_worker_context_only_followup_start_attempted_count",
         "native_goal_worker_context_only_followup_start_succeeded_count",
+        "native_goal_worker_normal_followup_attempted_count",
+        "native_goal_worker_normal_followup_succeeded_count",
+        "native_goal_worker_normal_followup_start_attempted_count",
+        "native_goal_worker_normal_followup_start_succeeded_count",
         "native_goal_worker_transport_reconnect_attempted_count",
         "native_goal_worker_transport_reconnect_succeeded_count",
         "native_goal_worker_goal_reactivation_attempted_count",
@@ -14607,6 +14691,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "Public-safe ACP thought keepalive interval while a host "
             "app-server Goal worker is active. Must stay below "
             "--agent-idle-timeout for long-running native Goal cases."
+        ),
+    )
+    parser.add_argument(
+        "--app-server-goal-followup-max",
+        type=int,
+        default=0,
+        help=(
+            "Experimental same-thread continuation budget for ordinary "
+            "completed codex-app-server-goal-baseline turns. The follow-up "
+            "prompt provides no verifier/reward/pass-fail feedback to the "
+            "worker. 0 preserves the native single-turn baseline."
         ),
     )
     parser.add_argument("--max-verifier-output-chars", type=int, default=0)

--- a/scripts/skillsbench_host_codex_goal_worker.py
+++ b/scripts/skillsbench_host_codex_goal_worker.py
@@ -39,6 +39,9 @@ from scripts.codex_app_server_goal_driver import (  # noqa: E402
 )
 
 SKILLS_INSTRUCTIONS_END_MARKER = "</skills_instructions>"
+NORMAL_FOLLOWUP_PROMPT = """Continue the same SkillsBench task in this existing Goal thread.
+Do not use or infer verifier, reward, pass/fail, hidden-test, or gold-answer feedback; none is being provided.
+Review your prior work, improve the scored output if needed using only the visible task, workspace, and bridge context already available in this thread, and end the turn once the best task-required output exists."""
 
 
 def _json_default(value: Any) -> str:
@@ -286,9 +289,13 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
     attempt_compacts: list[dict[str, Any]] = []
     try:
         followup_budget = max(0, int(args.context_only_followup_max or 0))
+        normal_followup_budget = max(0, int(args.normal_followup_max or 0))
         context_only_followup_start_attempted = False
         context_only_followup_start_succeeded = False
         context_only_followup_start_error_type = ""
+        normal_followup_start_attempted_count = 0
+        normal_followup_start_succeeded_count = 0
+        normal_followup_start_error_type = ""
         attempt_number = 1
         while True:
             if not args.no_wait_for_completion:
@@ -324,20 +331,28 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
             attempt_compacts.append(compact)
             if worker_error_type or args.no_wait_for_completion:
                 break
-            if compact.get("assistant_message_context_only") is not True:
+            if compact.get("assistant_message_context_only") is True:
+                if followup_budget <= 0:
+                    worker_error_type = "codex_app_server_context_only_assistant_message"
+                    break
+                followup_budget -= 1
+                followup_prompt = effective_prompt
+                followup_error_kind = "context_only"
+                context_only_followup_start_attempted = True
+            elif normal_followup_budget > 0:
+                normal_followup_budget -= 1
+                followup_prompt = NORMAL_FOLLOWUP_PROMPT
+                followup_error_kind = "normal"
+                normal_followup_start_attempted_count += 1
+            else:
                 break
-            if followup_budget <= 0:
-                worker_error_type = "codex_app_server_context_only_assistant_message"
-                break
-            followup_budget -= 1
             attempt_number += 1
-            context_only_followup_start_attempted = True
             try:
                 active_turn = start_codex_app_server_goal_followup_turn(
                     active_turn,
                     codex_bin=args.codex_bin,
                     work_dir=work_dir,
-                    prompt=effective_prompt,
+                    prompt=followup_prompt,
                     model_name=args.model,
                     reasoning_effort=args.reasoning_effort,
                     objective=objective,
@@ -348,15 +363,22 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
                     response_timeout_sec=args.response_timeout_sec,
                     wait_for_completion=False,
                 )
-                context_only_followup_start_succeeded = True
+                if followup_error_kind == "context_only":
+                    context_only_followup_start_succeeded = True
+                else:
+                    normal_followup_start_succeeded_count += 1
             except CodexAppServerGoalDriverError as exc:
                 detail = str(exc)
-                worker_error_type = (
-                    detail
-                    if detail.startswith("codex_app_server_")
-                    else "codex_app_server_context_only_followup_start_failed"
-                )
-                context_only_followup_start_error_type = worker_error_type
+                if detail.startswith("codex_app_server_"):
+                    worker_error_type = detail
+                elif followup_error_kind == "context_only":
+                    worker_error_type = "codex_app_server_context_only_followup_start_failed"
+                else:
+                    worker_error_type = "codex_app_server_normal_followup_start_failed"
+                if followup_error_kind == "context_only":
+                    context_only_followup_start_error_type = worker_error_type
+                else:
+                    normal_followup_start_error_type = worker_error_type
                 break
         turn = active_turn
         compact = _compact_worker_turn(
@@ -410,6 +432,23 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
                 "context_only_followup_start_error_type": (
                     context_only_followup_start_error_type
                 ),
+                "normal_followup_max": max(0, int(args.normal_followup_max or 0)),
+                "normal_followup_attempted": bool(
+                    normal_followup_start_attempted_count
+                ),
+                "normal_followup_succeeded": bool(
+                    normal_followup_start_attempted_count
+                    and normal_followup_start_succeeded_count
+                    == normal_followup_start_attempted_count
+                    and not worker_error_type
+                ),
+                "normal_followup_start_attempted_count": (
+                    normal_followup_start_attempted_count
+                ),
+                "normal_followup_start_succeeded_count": (
+                    normal_followup_start_succeeded_count
+                ),
+                "normal_followup_start_error_type": normal_followup_start_error_type,
             }
         )
         if attempt_compacts:
@@ -426,6 +465,8 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
             and compact.get("assistant_message_context_only") is True
         ):
             worker_error_type = "codex_app_server_context_only_assistant_message"
+        if worker_error_type and compact.get("normal_followup_attempted") is True:
+            compact["normal_followup_succeeded"] = False
         private_response_written = False
         if args.response_text_file and turn.assistant_message:
             response_path = Path(args.response_text_file).expanduser()
@@ -494,6 +535,24 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
             ),
             "turn_attempt_count": int(compact.get("turn_attempt_count") or 1),
         },
+        "normal_followup": {
+            "enabled": max(0, int(args.normal_followup_max or 0)) > 0,
+            "max_followups": max(0, int(args.normal_followup_max or 0)),
+            "attempted": bool(compact.get("normal_followup_attempted")),
+            "succeeded": bool(compact.get("normal_followup_succeeded")),
+            "followup_start_attempted_count": int(
+                compact.get("normal_followup_start_attempted_count") or 0
+            ),
+            "followup_start_succeeded_count": int(
+                compact.get("normal_followup_start_succeeded_count") or 0
+            ),
+            "followup_start_error_type": str(
+                compact.get("normal_followup_start_error_type") or ""
+            ),
+            "turn_attempt_count": int(compact.get("turn_attempt_count") or 1),
+            "reward_feedback_provided": False,
+            "verifier_feedback_provided": False,
+        },
         "private_response_text": {
             "written": private_response_written,
             "path_recorded": False,
@@ -544,6 +603,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "Retry in the same app-server thread when a completed turn only "
             "echoes startup context. The retry keeps xhigh/Goal runs from "
             "writing the context preamble as the scored answer."
+        ),
+    )
+    parser.add_argument(
+        "--normal-followup-max",
+        type=int,
+        default=0,
+        help=(
+            "Experimental same-thread continuation budget for ordinary "
+            "completed app-server Goal turns. The continuation prompt provides "
+            "no verifier, reward, pass/fail, hidden-test, or gold-answer "
+            "feedback; default 0 preserves baseline single-turn behavior."
         ),
     )
     parser.add_argument(

--- a/scripts/skillsbench_local_acp_relay.py
+++ b/scripts/skillsbench_local_acp_relay.py
@@ -104,6 +104,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--app-server-goal-followup-max",
+        type=int,
+        default=0,
+        help=(
+            "Experimental same-thread continuation budget for ordinary "
+            "completed app-server Goal worker turns. No verifier/reward "
+            "feedback is forwarded. 0 preserves the single-turn baseline."
+        ),
+    )
+    parser.add_argument(
         "--bridge-idle-timeout-sec",
         type=float,
         default=0.0,
@@ -198,6 +208,7 @@ def main(argv: list[str] | None = None) -> int:
             worker_script=args.worker_script,
             stream_heartbeat_interval_sec=args.stream_heartbeat_interval_sec,
             first_action_timeout_sec=args.first_action_timeout_sec,
+            app_server_goal_followup_max=args.app_server_goal_followup_max,
             bridge_idle_timeout_sec=args.bridge_idle_timeout_sec,
             task_output_quiet_timeout_sec=args.task_output_quiet_timeout_sec,
             worker_public_trace_dir=args.worker_public_trace_dir,


### PR DESCRIPTION
## Summary
- add an opt-in same-thread normal follow-up budget for SkillsBench native app-server Goal workers
- thread the budget through runner -> local ACP relay -> host Goal worker
- expose public-safe compact counters and observability fields for follow-up attempts
- add a focused fake app-server smoke that proves the follow-up gets no verifier/reward feedback and does not repeat the raw task prompt

## Validation
- python3 -m py_compile scripts/skillsbench_host_codex_goal_worker.py scripts/skillsbench_local_acp_relay.py scripts/skillsbench_automation_loop.py loopx/benchmark_adapters/skillsbench_acp_relay.py examples/skillsbench-app-server-goal-worker-smoke.py
- python3 examples/skillsbench-app-server-goal-worker-smoke.py
- python3 scripts/skillsbench_automation_loop.py --task-id llm-prefix-cache-replay --route codex-app-server-goal-baseline --host-local-acp-launch --remote-command-file-bridge-ready --app-server-goal-followup-max 1 --plan-only
- git diff --check
- loopx check --scan-path scripts/skillsbench_host_codex_goal_worker.py --scan-path scripts/skillsbench_local_acp_relay.py --scan-path scripts/skillsbench_automation_loop.py --scan-path loopx/benchmark_adapters/skillsbench_acp_relay.py --scan-path examples/skillsbench-app-server-goal-worker-smoke.py

Default follow-up budget is 0, so the existing native app-server Goal baseline remains single-turn unless explicitly opted in.