### PR TITLE
Default SkillsBench ledger writes to private state

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -67,6 +67,7 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
     CODEX_ACP_RUNTIME_DEPS_SETUP_CMD,
     CODEX_ACP_RUNTIME_LAUNCH_PREFLIGHT_CMD,
     DEFAULT_HOST_LOCAL_CODEX_BRIDGE_IDLE_TIMEOUT_SEC,
+    DEFAULT_LEDGER,
     DEFAULT_MAX_ROUNDS,
     DEFAULT_PRODUCT_MODE_SOFT_VERIFY_POLICY,
     DEFAULT_SOFT_VERIFIER_TIMEOUT_SEC,
@@ -94,6 +95,7 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
     PRODUCT_MODE_MIN_FORMAL_MAX_ROUNDS,
     PRODUCT_MODE_CASE_STATE_PATH,
     PRODUCT_MODE_CASE_STATE_SCHEMA_VERSION,
+    PUBLIC_BENCHMARK_RUN_LEDGER,
     RUNNER_CONFIG_PUBLIC_FILENAME,
     RUNNER_PREREQUISITES_PUBLIC_FILENAME,
     SkillsBenchProductModeNoLifecycleRequests,
@@ -163,6 +165,36 @@ def test_skillsbench_default_blind_loop_budget_is_sixteen() -> None:
     assert args.max_rounds == DEFAULT_MAX_ROUNDS == 16, args
     assert "blind-loop" in args.route, args
     assert args.route != "codex-goal-mode-baseline", args
+
+
+def test_skillsbench_default_ledger_is_private_unless_published() -> None:
+    args = parse_args([])
+    assert Path(args.ledger_path) == DEFAULT_LEDGER, args
+    assert Path(args.global_ledger_path) == DEFAULT_LEDGER, args
+    assert ".local" in Path(args.ledger_path).parts, args
+    assert "docs" not in Path(args.ledger_path).parts, args
+
+    publish_args = parse_args(["--publish-public-ledger"])
+    assert (
+        Path(publish_args.ledger_path) == PUBLIC_BENCHMARK_RUN_LEDGER
+    ), publish_args
+    assert (
+        Path(publish_args.global_ledger_path) == PUBLIC_BENCHMARK_RUN_LEDGER
+    ), publish_args
+
+    explicit_args = parse_args(
+        [
+            "--publish-public-ledger",
+            "--ledger-path",
+            "explicit-run-group-ledger.json",
+        ]
+    )
+    assert Path(explicit_args.ledger_path) == Path(
+        "explicit-run-group-ledger.json"
+    ), explicit_args
+    assert (
+        Path(explicit_args.global_ledger_path) == PUBLIC_BENCHMARK_RUN_LEDGER
+    ), explicit_args
 
 
 def test_codex_app_server_goal_requires_public_safe_codex_api_tunnel_contract() -> None:

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -149,10 +149,16 @@ class SkillsBenchProductModeNoLifecycleRequests(RuntimeError):
 
 
 DEFAULT_SKILLSBENCH_ROOT = REPO_ROOT / ".local/benchmark/externals/skillsbench"
-DEFAULT_LEDGER = (
+PUBLIC_BENCHMARK_RUN_LEDGER = (
     REPO_ROOT
     / "docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json"
 )
+DEFAULT_PRIVATE_LEDGER = (
+    REPO_ROOT
+    / ".local/private-benchmark-jobs"
+    / "skillsbench-current-global-ledger/benchmark-run-ledger.json"
+)
+DEFAULT_LEDGER = DEFAULT_PRIVATE_LEDGER
 TERMINAL_OFFICIAL_NONPASSING_ATTRIBUTIONS = {
     "official_score_zero_case_failure",
     "official_verifier_solution_failure",
@@ -14735,14 +14741,25 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "--run-group-id",
         default=None,
     )
-    parser.add_argument("--ledger-path", default=str(DEFAULT_LEDGER))
+    parser.add_argument("--ledger-path", default=None)
     parser.add_argument(
         "--global-ledger-path",
-        default=str(DEFAULT_LEDGER),
+        default=None,
         help=(
-            "Canonical benchmark_run_ledger_v0 JSON. When --ledger-path points "
-            "to a run-group/local ledger, the runner inherits this ledger first "
-            "and syncs the new row back here unless --skip-global-ledger-sync is set."
+            "Canonical benchmark_run_ledger_v0 JSON. Defaults to a private "
+            ".local ledger unless --publish-public-ledger is set. When "
+            "--ledger-path points to a run-group/local ledger, the runner "
+            "inherits this ledger first and syncs the new row back here unless "
+            "--skip-global-ledger-sync is set."
+        ),
+    )
+    parser.add_argument(
+        "--publish-public-ledger",
+        action="store_true",
+        help=(
+            "Use the repository research ledger as the default --ledger-path "
+            "and --global-ledger-path. Without this explicit publish intent, "
+            "benchmark update-ledger writes default to a private .local ledger."
         ),
     )
     parser.add_argument(
@@ -15132,6 +15149,13 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     apt_fail_fast_explicit = "--fail-fast-on-apt-risk" in raw_argv
     verifier_fail_fast_explicit = "--fail-fast-on-verifier-bootstrap-risk" in raw_argv
     args = parser.parse_args(raw_argv)
+    default_ledger = (
+        PUBLIC_BENCHMARK_RUN_LEDGER if args.publish_public_ledger else DEFAULT_LEDGER
+    )
+    if args.ledger_path is None:
+        args.ledger_path = str(default_ledger)
+    if args.global_ledger_path is None:
+        args.global_ledger_path = str(default_ledger)
     args.apt_risk_fail_fast_defaulted = False
     args.verifier_bootstrap_fail_fast_defaulted = False
     args.bootstrap_light_fail_fast_defaulted = False


### PR DESCRIPTION
## Summary
- default SkillsBench benchmark ledger writes to a private local ledger instead of the repository research ledger
- add --publish-public-ledger for explicit public ledger updates
- add a focused smoke covering private default, explicit publish, and explicit path override

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py
- focused parse_args ledger-default assertions
- focused smoke invocation via runpy
- diff boundary scan for local absolute paths, raw artifacts, credentials, and proxy endpoints