### PR TITLE
Surface visible auto-research live evidence

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -38,6 +38,7 @@ def assert_public_safe(payload: Any) -> None:
 
 def main() -> int:
     sys.path.insert(0, str(REPO_ROOT))
+    from loopx.capabilities.auto_research.demo_e2e import run_auto_research_demo_e2e
     from loopx.capabilities.auto_research.human_view import render_auto_research_markdown
 
     launcher_source = (REPO_ROOT / "loopx/visible_multi_agent_launcher.py").read_text(
@@ -134,6 +135,98 @@ def main() -> int:
     assert "- mode: `blocked`" in blocked_markdown
     assert "- blocker: `waiting_for_dev_evidence`" in blocked_markdown
     assert "Traceback" not in blocked_markdown
+
+    with tempfile.TemporaryDirectory(prefix="loopx-visible-live-evidence-smoke.") as tmp:
+        tmp_root = Path(tmp)
+        session_name = "loopx-visible-live-evidence-smoke"
+
+        def visible_launcher(
+            _supervisor: dict[str, object],
+            _visible_registry_path: Path,
+            visible_runtime_root_arg: str | None,
+            _default_workspace: Path,
+        ) -> dict[str, object]:
+            assert visible_runtime_root_arg
+            artifact_dir = (
+                Path(visible_runtime_root_arg)
+                / "visible-launcher-artifacts"
+                / session_name
+                / "evidence_runner"
+            )
+            artifact_dir.mkdir(parents=True, exist_ok=True)
+            (artifact_dir / "live_codex_e2e_evidence.public.json").write_text(
+                json.dumps(
+                    {
+                        "schema_version": "auto_research_live_codex_lane_e2e_evidence_v0",
+                        "source": "live_codex_lane_output",
+                        "goal_id": GOAL_ID,
+                        "agent_id": "codex-live-lane",
+                        "visible_lanes": {
+                            "launched": True,
+                            "accepted": True,
+                            "lane_count": 1,
+                        },
+                        "lane_evidence": {
+                            "append_status": "appended_to_loopx_state",
+                            "dev_metric": 4.0,
+                            "holdout_metric": 4.5,
+                            "evidence_event_count": 2,
+                            "evidence_source": "live_codex_lane_output",
+                            "lane_authored": True,
+                            "protected_scope_clean": True,
+                            "result_status": "supported",
+                        },
+                        "public_boundary": {
+                            "raw_logs_recorded": False,
+                            "private_artifacts_recorded": False,
+                            "absolute_paths_recorded": False,
+                            "credentials_recorded": False,
+                            "local_workspace_path_redacted": True,
+                        },
+                    },
+                    sort_keys=True,
+                ),
+                encoding="utf-8",
+            )
+            return {
+                "mode": "executed_visible_launch",
+                "launch_result": {
+                    "session_name": session_name,
+                    "visible_acceptance": {"accepted": True},
+                },
+                "boundary": {"reads_raw_transcripts": False},
+            }
+
+        visible_loaded_payload = run_auto_research_demo_e2e(
+            agent_id=AGENT_ID,
+            goal_id=GOAL_ID,
+            tracking_goal_id=None,
+            objective="Smoke visible live evidence auto-load.",
+            output_dir=str(tmp_root / "out"),
+            execute=True,
+            launch_visible=True,
+            keep_workspace=False,
+            registry_path=tmp_root / "registry.json",
+            runtime_root_arg=str(tmp_root / "runtime"),
+            session_name=session_name,
+            cli_bin="loopx",
+            codex_bin="codex",
+            tmux_bin="tmux",
+            reasoning_effort="medium",
+            live_evidence_path=None,
+            append_evidence=lambda _path: {"ok": True},
+            visible_launcher=visible_launcher,
+            visible_live_evidence_wait_seconds=0,
+        )
+        visible_loaded_proof = visible_loaded_payload["visible_worker_proof"]
+        visible_loaded_evidence = visible_loaded_payload["live_worker_evidence"]
+        assert visible_loaded_proof["lane_authored_evidence_loaded"] is True, visible_loaded_payload
+        assert visible_loaded_proof["evidence_source"] == "visible_launcher_artifact", visible_loaded_payload
+        assert visible_loaded_evidence["loaded"] is True, visible_loaded_payload
+        assert visible_loaded_evidence["agent_id"] == "codex-live-lane", visible_loaded_payload
+        assert visible_loaded_evidence["dev_metric"] == 4.0, visible_loaded_payload
+        assert visible_loaded_evidence["holdout_metric"] == 4.5, visible_loaded_payload
+        assert_public_safe(visible_loaded_payload)
 
     loop_markdown = render_auto_research_markdown(
         {
@@ -308,6 +401,8 @@ def main() -> int:
                         session_name,
                         "--codex-bin",
                         "fake-codex-tui",
+                        "--visible-live-evidence-wait-seconds",
+                        "0",
                     ],
                     cwd=workspace,
                     env=env,

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -480,6 +480,12 @@ def register_auto_research_commands(
         ),
     )
     demo_e2e_parser.add_argument(
+        "--visible-live-evidence-wait-seconds",
+        type=float,
+        default=30.0,
+        help=argparse.SUPPRESS,
+    )
+    demo_e2e_parser.add_argument(
         "--keep-workspace",
         action="store_true",
         help="Keep the temporary demo workspace after execution. The output payload still redacts its absolute path.",
@@ -864,6 +870,7 @@ def handle_auto_research_command(
                 live_evidence_path=args.live_evidence,
                 append_evidence=append_demo_e2e_evidence,
                 visible_launcher=visible_launcher,
+                visible_live_evidence_wait_seconds=args.visible_live_evidence_wait_seconds,
             )
         else:
             raise ValueError(

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import shlex
 import tempfile
+import time
 from collections.abc import Callable, Sequence
 from pathlib import Path
 
@@ -354,6 +355,63 @@ def _compact_live_worker_evidence(evidence: dict[str, object]) -> dict[str, obje
     }
 
 
+def _discover_visible_live_evidence(
+    *,
+    runtime_root_arg: str | None,
+    session_name: str,
+    goal_id: str,
+    wait_seconds: float,
+) -> dict[str, object] | None:
+    if not runtime_root_arg:
+        return None
+    runtime_root = Path(runtime_root_arg)
+    artifact_root = runtime_root / "visible-launcher-artifacts" / session_name
+
+    deadline = time.monotonic() + max(0.0, wait_seconds)
+    while True:
+        candidates = (
+            sorted(artifact_root.glob("*/live_codex_e2e_evidence.public.json"))
+            if artifact_root.is_dir()
+            else []
+        )
+        for candidate in candidates:
+            try:
+                raw = json.loads(candidate.read_text(encoding="utf-8"))
+            except Exception:
+                continue
+            if not isinstance(raw, dict) or raw.get("goal_id") != goal_id:
+                continue
+            lane_agent_id = str(raw.get("agent_id") or "").strip()
+            if not lane_agent_id:
+                continue
+            try:
+                return load_live_codex_e2e_evidence(
+                    evidence_path=str(candidate),
+                    goal_id=goal_id,
+                    agent_id=lane_agent_id,
+                )
+            except ValueError:
+                continue
+        if time.monotonic() >= deadline:
+            return None
+        time.sleep(0.5)
+
+
+def _load_live_worker_evidence_into_payload(
+    *,
+    payload: dict[str, object],
+    evidence: dict[str, object],
+    evidence_source: str,
+) -> None:
+    payload["live_worker_evidence"] = _compact_live_worker_evidence(evidence)
+    visible_proof = payload["visible_worker_proof"]
+    if isinstance(visible_proof, dict):
+        visible_proof["lane_authored_evidence_loaded"] = True
+        visible_proof["visible_lanes_launched"] = True
+        visible_proof["visible_lanes_accepted"] = True
+        visible_proof["evidence_source"] = evidence_source
+
+
 def run_auto_research_demo_e2e(
     *,
     agent_id: str,
@@ -378,6 +436,7 @@ def run_auto_research_demo_e2e(
     agent_specs: Sequence[str] | None = None,
     run_worker_loop: bool = False,
     worker_loop_rounds: int = 3,
+    visible_live_evidence_wait_seconds: float = 30.0,
 ) -> dict[str, object]:
     if launch_visible and not execute:
         raise ValueError("--launch-visible requires --execute")
@@ -664,6 +723,18 @@ def run_auto_research_demo_e2e(
                 visible_proof["visible_lanes_launched"] = True
                 visible_proof["visible_lanes_accepted"] = bool(visible_acceptance.get("accepted"))
                 visible_proof["evidence_source"] = "visible_launcher"
+            live_evidence = _discover_visible_live_evidence(
+                runtime_root_arg=visible_runtime_root_arg,
+                session_name=str(launch_result.get("session_name") or session_name),
+                goal_id=goal_id,
+                wait_seconds=visible_live_evidence_wait_seconds,
+            )
+            if live_evidence is not None:
+                _load_live_worker_evidence_into_payload(
+                    payload=payload,
+                    evidence=live_evidence,
+                    evidence_source="visible_launcher_artifact",
+                )
         payload["workspace_retained"] = keep_workspace or launch_visible
         if live_evidence_path:
             live_evidence = load_live_codex_e2e_evidence(
@@ -671,13 +742,11 @@ def run_auto_research_demo_e2e(
                 goal_id=goal_id,
                 agent_id=agent_id,
             )
-            payload["live_worker_evidence"] = _compact_live_worker_evidence(live_evidence)
-            visible_proof = payload["visible_worker_proof"]
-            if isinstance(visible_proof, dict):
-                visible_proof["lane_authored_evidence_loaded"] = True
-                visible_proof["visible_lanes_launched"] = True
-                visible_proof["visible_lanes_accepted"] = True
-                visible_proof["evidence_source"] = "live_worker_evidence"
+            _load_live_worker_evidence_into_payload(
+                payload=payload,
+                evidence=live_evidence,
+                evidence_source="live_worker_evidence",
+            )
         return payload
     finally:
         if tmp_obj is not None:


### PR DESCRIPTION
## Summary
- auto-load compact lane-authored public live evidence from visible launcher artifacts after real Codex panes tick
- keep explicit --live-evidence behavior intact via shared payload projection helper
- add smoke coverage for automatic artifact loading and keep fake visible demo fast with zero wait

## Validation
- python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- python3 examples/auto-research-live-evidence-capture-smoke.py
- python3 -m py_compile loopx/capabilities/auto_research/demo_e2e.py loopx/capabilities/auto_research/cli.py examples/auto-research-demo-e2e-worker-loop-smoke.py
- git diff --check

## Boundary
No raw transcripts, private artifacts, credentials, or absolute paths are loaded into the payload; discovery is limited to *.public.json artifacts under the visible launcher artifact root.