### PR TITLE
Align quota recovery contract with smoke fixtures

### DIFF
--- a/examples/heartbeat-quota-flow-smoke.py
+++ b/examples/heartbeat-quota-flow-smoke.py
@@ -195,7 +195,8 @@ def write_monitor_fixture(root: Path) -> tuple[Path, Path, Path]:
         "## User Todo / Owner Review Reading Queue\n\n"
         "- [x] [P1] Approve the private one-instance execution boundary before any real run.\n\n"
         "## Agent Todo\n\n"
-        "- [ ] [P2] Meta canary/readiness observation lane: keep status observable and repair only material transitions.\n",
+        "- [ ] [P2] Meta canary/readiness observation lane: keep status observable and repair only material transitions.\n"
+        "  <!-- loopx:todo todo_id=todo_77fad979d712 task_class=continuous_monitor cadence=15m next_due_at=2099-01-01T00:00:00Z -->\n",
         encoding="utf-8",
     )
     registry_path.parent.mkdir(parents=True, exist_ok=True)

--- a/examples/quota-agent-scoped-user-gate-smoke.py
+++ b/examples/quota-agent-scoped-user-gate-smoke.py
@@ -27,6 +27,8 @@ def todo_item(
     claimed_by: str | None = None,
     action_kind: str | None = None,
     blocks_agent: str | None = None,
+    cadence: str | None = None,
+    next_due_at: str | None = None,
 ) -> dict:
     item = {
         "todo_id": todo_id,
@@ -43,6 +45,10 @@ def todo_item(
         item["action_kind"] = action_kind
     if blocks_agent:
         item["blocks_agent"] = blocks_agent
+    if cadence:
+        item["cadence"] = cadence
+    if next_due_at:
+        item["next_due_at"] = next_due_at
     return item
 
 
@@ -146,6 +152,8 @@ def scoped_no_candidate_status_payload() -> dict:
         text="[P2] Monitor product-capability rollout evidence.",
         task_class="continuous_monitor",
         claimed_by="codex-product-capability",
+        cadence="15m",
+        next_due_at="2099-01-01T00:00:00Z",
     )
     agent_todos = {
         "schema_version": "todo_summary_v0",
@@ -236,6 +244,8 @@ def other_agent_gate_with_non_due_monitor_payload() -> dict:
         text="[P1-monitor] Monitor value-lane external signal when it becomes due.",
         task_class="continuous_monitor",
         claimed_by="codex-value-explorer",
+        cadence="1h",
+        next_due_at="2099-01-01T00:00:00Z",
     )
     return {
         "ok": True,
@@ -490,6 +500,8 @@ def exact_todo_gate_status_payload(*, include_fallback: bool = True) -> dict:
         task_class="continuous_monitor",
         claimed_by="codex-main-control",
         action_kind="corrected_x_launch_timing_monitor",
+        cadence="1h",
+        next_due_at="2099-01-01T00:00:00Z",
     )
     agent_items = [unavailable_auto_research, blocked_benchmark]
     if include_fallback:

--- a/examples/quota-plan-smoke.py
+++ b/examples/quota-plan-smoke.py
@@ -1113,21 +1113,24 @@ def assert_outcome_floor_projected_blocker_quiet_noop() -> None:
     monitor_item["project_asset"]["agent_todos"]["items"][0]["action_kind"] = "monitor"
     monitor_decision = build_quota_should_run(monitor_payload, goal_id=goal_id)
     assert "outcome_floor_blocker_projected" not in monitor_decision["quota"], monitor_decision
-    assert monitor_decision["effective_action"] == "autonomous_replan_required", monitor_decision
+    assert monitor_decision["effective_action"] == "outcome_floor_recovery", monitor_decision
     assert monitor_decision["should_run"] is True, monitor_decision
     assert monitor_decision["safe_bypass_kind"] == "outcome_floor_recovery", monitor_decision
     assert (
         monitor_decision["heartbeat_recommendation"]["recommended_mode"]
-        == "autonomous_replan_required"
+        == "outcome_floor_recovery"
     ), monitor_decision
-    assert (
-        monitor_decision["autonomous_replan_decision"]["decision_plane"]
-        == "goal_frontier_before_lane_quiet_or_agent_scope_wait"
-    ), monitor_decision
+    assert "work_lane_contract" not in monitor_decision, monitor_decision
+    execution = monitor_decision["execution_obligation"]
+    assert execution["kind"] == "outcome_floor_recovery", execution
+    assert execution["contract"] == "delivery_outcome_floor", execution
+    assert "outcome-floor evidence" in execution["contract_obligation"], execution
     monitor_contract = monitor_decision["interaction_contract"]
-    assert monitor_contract["mode"] == "autonomous_replan", monitor_contract
+    assert monitor_contract["mode"] == "outcome_floor_recovery", monitor_contract
     assert monitor_contract["agent_channel"]["must_attempt"] is True, monitor_contract
     assert monitor_contract["agent_channel"]["quiet_noop_allowed"] is False, monitor_contract
+    assert "outcome-floor evidence" in monitor_contract["agent_channel"]["primary_action"], monitor_contract
+    assert "outcome-floor evidence" in monitor_decision["protocol_action_packet"]["summary"], monitor_decision
 
 
 def assert_control_plane_health_self_repair_should_run() -> None:

--- a/loopx/policies/execution_obligation.py
+++ b/loopx/policies/execution_obligation.py
@@ -145,6 +145,24 @@ def build_execution_obligation(
                 "goal_boundary does not project"
             ),
         }
+    if should_run and recommended_mode == "outcome_floor_recovery":
+        return {
+            "must_attempt_work": True,
+            "kind": "outcome_floor_recovery",
+            "minimum": "one_outcome_floor_evidence_or_blocker_segment",
+            "delivery_allowed": True,
+            "notify_is_execution_gate": False,
+            "contract": "delivery_outcome_floor",
+            "contract_obligation": (
+                "produce the required outcome-floor evidence artifact or write "
+                "the concrete blocker; do not spend for another surface-only report"
+            ),
+            "spend_policy": heartbeat_recommendation.get("spend_policy"),
+            "reason": (
+                "outcome-floor recovery is the selected safe-bypass execution "
+                "contract and must stay aligned with interaction_contract.mode"
+            ),
+        }
     if should_run and recommended_mode == "repair_capability_bridge":
         return {
             "must_attempt_work": True,

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -4554,7 +4554,13 @@ def _protocol_action_packet(payload: dict[str, Any]) -> dict[str, Any]:
     elif must_attempt_work:
         primary_actor = "agent"
         agent_action_required = True
-        agent_action = _protocol_first_candidate_action(payload) or "advance one bounded segment"
+        if str(execution_obligation.get("kind") or "") == "outcome_floor_recovery":
+            agent_action = (
+                "produce the required outcome-floor evidence artifact or write "
+                "the concrete blocker"
+            )
+        else:
+            agent_action = _protocol_first_candidate_action(payload) or "advance one bounded segment"
     else:
         primary_actor = "agent"
         agent_action_required = False
@@ -7506,6 +7512,11 @@ def build_quota_should_run(
             selected_recommended_action=selected_recommended_action,
         )
         agent_scope_action = _agent_scope_frontier_action(effective_action)
+        payload_work_lane_contract = (
+            None
+            if recovery_allowed and effective_action == "outcome_floor_recovery"
+            else work_lane_contract
+        )
         payload = {
             "ok": bool(plan.get("ok")) or self_repair_allowed or capability_repair_allowed or workspace_repair_allowed,
             "status_health_ok": bool(plan.get("ok")),
@@ -7590,7 +7601,7 @@ def build_quota_should_run(
                 should_run=should_run,
                 effective_action=effective_action,
                 heartbeat_recommendation=heartbeat_recommendation,
-                work_lane_contract=work_lane_contract,
+                work_lane_contract=payload_work_lane_contract,
                 external_evidence_observation=external_evidence_observation,
             ),
             "goal_boundary": goal_boundary,
@@ -7617,8 +7628,8 @@ def build_quota_should_run(
             payload["automation_prompt_upgrade"] = automation_prompt_upgrade
         if agent_scoped_user_gate_override:
             payload["agent_scoped_user_gate_override"] = agent_scoped_user_gate_override
-        if work_lane_contract:
-            payload["work_lane_contract"] = work_lane_contract
+        if payload_work_lane_contract:
+            payload["work_lane_contract"] = payload_work_lane_contract
         if capability_gate:
             payload["capability_gate"] = capability_gate
             if capability_gate.get("action") == "ask_owner":


### PR DESCRIPTION
## Summary
- give outcome-floor recovery an explicit execution_obligation contract so it stays aligned with interaction_contract.mode
- keep protocol_action_packet focused on outcome-floor evidence/blocker work instead of stale monitor metadata repair text
- update quota smoke fixtures for scheduled non-due monitor todos and current recovery semantics

## Validation
- python3 examples/heartbeat-quota-flow-smoke.py
- python3 examples/quota-agent-scoped-user-gate-smoke.py
- python3 examples/quota-plan-smoke.py
- PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --suite full-public --module quota --limit 20 --timeout-seconds 120 --format json --no-progress
- git diff --check
- PYTHONPATH=. python3 -m loopx.cli check --scan-path loopx/policies/execution_obligation.py --scan-path loopx/quota.py --scan-path examples/heartbeat-quota-flow-smoke.py --scan-path examples/quota-agent-scoped-user-gate-smoke.py --scan-path examples/quota-plan-smoke.py
- python3 -m compileall -q loopx/policies/execution_obligation.py loopx/quota.py

Note: installed loopx-canary resolves to the installed release source root; source-branch validation used PYTHONPATH=. python3 -m loopx.cli to exercise this worktree.