### PR TITLE
Accept visible live evidence artifact names

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -154,7 +154,7 @@ def main() -> int:
                 / "evidence_runner"
             )
             artifact_dir.mkdir(parents=True, exist_ok=True)
-            (artifact_dir / "live_codex_e2e_evidence.public.json").write_text(
+            (artifact_dir / "live-codex-e2e-evidence.public.json").write_text(
                 json.dumps(
                     {
                         "schema_version": "auto_research_live_codex_lane_e2e_evidence_v0",

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -369,11 +369,14 @@ def _discover_visible_live_evidence(
 
     deadline = time.monotonic() + max(0.0, wait_seconds)
     while True:
-        candidates = (
-            sorted(artifact_root.glob("*/live_codex_e2e_evidence.public.json"))
-            if artifact_root.is_dir()
-            else []
-        )
+        candidates = []
+        if artifact_root.is_dir():
+            for artifact_name in (
+                "live-codex-e2e-evidence.public.json",
+                "live_codex_e2e_evidence.public.json",
+            ):
+                candidates.extend(artifact_root.glob(f"*/{artifact_name}"))
+            candidates = sorted(set(candidates))
         for candidate in candidates:
             try:
                 raw = json.loads(candidate.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- auto-discover both hyphenated and underscore live-evidence public artifact names from visible panes
- update the visible demo smoke to cover the hyphenated filename produced by real pane helpers

## Validation
- python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- python3 examples/auto-research-live-evidence-capture-smoke.py
- python3 -m py_compile loopx/capabilities/auto_research/demo_e2e.py examples/auto-research-demo-e2e-worker-loop-smoke.py
- git diff --check
- public/private scan of changed paths

## Boundary
Discovery remains limited to compact *.public.json artifacts under visible launcher artifact roots; no raw transcripts or private artifacts are read.