### PR TITLE
Bump LoopX release version to 0.1.5

### DIFF
--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.4"
+__version__ = "0.1.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.1.4"
+version = "0.1.5"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- bump `loopx.__version__` and `pyproject.toml` to `0.1.5` for the next stable release

## Validation
- `python3 -m py_compile loopx/*.py`
- `python3 examples/release/release-version-contract-smoke.py`
- `python3 examples/release/codex-cli-no-clone-release-verification-smoke.py`
- `python3 examples/fresh-clone-quickstart-smoke.py`
- `python3 examples/loopx-update-smoke.py`
- `python3 examples/release/release-readiness-doc-smoke.py`
- `python3 examples/canary-promotion-readiness-smoke.py --no-write-evidence`
- `PYTHONPATH=. python3 -m loopx.cli check --scan-path README.md --scan-path docs/ --scan-path examples/`
- `git diff --check`
- `PYTHONPATH=. python3 -m loopx.cli version`

Note: `loopx check` reported an existing local runtime index duplicate warning under `loopx-meta`; public boundary scan was clean and `ok=True`.
