### PR TITLE
Stabilize visible auto-research pane ticks

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -428,8 +428,13 @@ def main() -> int:
                 ), visible_supervisor
                 visible_proof = visible_payload["visible_worker_proof"]
                 assert visible_proof["schema_version"] == "auto_research_visible_worker_proof_v0", visible_proof
-                assert visible_proof["lane_authored_evidence_loaded"] is False, visible_proof
+                assert visible_proof["lane_authored_evidence_loaded"] is True, visible_proof
+                assert visible_proof["evidence_source"] == "visible_launcher_artifact", visible_proof
                 assert visible_proof["visible_lanes_launched"] is True, visible_proof
+                live_evidence = visible_payload["live_worker_evidence"]
+                assert live_evidence["loaded"] is True, live_evidence
+                assert live_evidence["source"] == "live_codex_lane_output", live_evidence
+                assert live_evidence["dev_metric"] == 4.0, live_evidence
                 launch = visible_payload["visible_launch"]["launch_result"]
                 assert launch["started_lane_count"] == 4, visible_payload
                 assert "frontier" not in launch["started_lanes"], visible_payload

--- a/examples/auto-research-demo-supervisor-smoke.py
+++ b/examples/auto-research-demo-supervisor-smoke.py
@@ -168,8 +168,8 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
         assert lane["pane_local_a2a"]["tick_sleep_seconds"] == 3, lane
         assert lane["lane_timeline"] == [
             "role_profile",
-            "codex_tui",
             "auto_start_pane_local_a2a_tick",
+            "codex_tui",
             "frontier",
         ], lane
 
@@ -178,7 +178,11 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
         assert "LOOPX_PANE_WORKER_TURN" in command, lane
         assert "LOOPX_PANE_TICK_ROUNDS=3" in command, lane
         assert "LOOPX_PANE_TICK_SLEEP_SECONDS=3" in command, lane
+        assert "pane-a2a-tick.output.txt" in command, lane
         assert "auto-research worker-turn" in command, lane
+        assert "--visible-lanes-accepted" in command, lane
+        assert "LOOPX_VISIBLE_LANE_COUNT" in command, lane
+        assert "live-codex-e2e-evidence.public.json" in command, lane
         assert "--complete-selected-todo" in command, lane
         assert "LOOPX_VISIBLE_TUI_SILENT_BOOTSTRAP=1" in command, lane
         assert "LOOPX_CODEX_TUI_MODE=interactive" in command, lane

--- a/examples/auto-research-layered-e2e-acceptance-smoke.py
+++ b/examples/auto-research-layered-e2e-acceptance-smoke.py
@@ -168,6 +168,8 @@ def assert_three_layer_minimality() -> None:
         assert lane["pane_local_a2a"]["auto_start"] is True, lane
         assert lane["bootstrap_message"] == "role_prompt_inside_codex_tui", lane
         assert "LOOPX_PANE_A2A_TICK" in lane["visible_launch_command"], lane
+        assert "pane-a2a-tick.output.txt" in lane["visible_launch_command"], lane
+        assert "--visible-lanes-accepted" in lane["visible_launch_command"], lane
         assert "codex exec" not in lane["visible_launch_command"], lane
         assert "codex_stream_filter" not in lane["visible_launch_command"], lane
 

--- a/examples/auto-research-worker-turn-smoke.py
+++ b/examples/auto-research-worker-turn-smoke.py
@@ -21,7 +21,7 @@ from loopx.capabilities.auto_research.demo_e2e import run_auto_research_demo_e2e
 from loopx.capabilities.auto_research.demo_supervisor import (  # noqa: E402
     build_auto_research_demo_supervisor_plan,
 )
-from loopx.todos import add_goal_todo  # noqa: E402
+from loopx.todos import add_goal_todo, update_goal_todo  # noqa: E402
 
 
 GOAL_ID = "loopx-auto-research-demo"
@@ -273,15 +273,25 @@ def main() -> int:
             reasoning_effort="high",
         )
         four_lane_root = temp / "four-lane-queue"
-        _summary, four_registry, four_runtime_root = _seed_visible_demo_control_plane(
+        summary, four_registry, four_runtime_root = _seed_visible_demo_control_plane(
             demo_root=four_lane_root,
             goal_id=GOAL_ID,
             objective="Prove every visible auto-research role can run one LoopX-selected worker turn.",
             supervisor=supervisor,
         )
+        evidence_seed = next(
+            item for item in summary["seeded_todos"] if item["agent_id"] == EVIDENCE_AGENT_ID
+        )
+        alias_update = update_goal_todo(
+            registry_path=four_registry,
+            goal_id=GOAL_ID,
+            todo_id=str(evidence_seed["todo_id"]),
+            action_kind="run_read_only_adapter_tick",
+        )
+        assert alias_update["action_kind"] == "run_read_only_adapter_tick", alias_update
         four_workspace = four_lane_root / "visible-control-plane"
         for agent in [CURATOR_AGENT_ID, MAPPER_AGENT_ID, EVIDENCE_AGENT_ID]:
-            run_worker_turn(
+            turn = run_worker_turn(
                 registry=four_registry,
                 runtime_root=four_runtime_root,
                 workspace=four_workspace,
@@ -289,6 +299,22 @@ def main() -> int:
                 execute=True,
                 complete=True,
             )
+            if agent == EVIDENCE_AGENT_ID:
+                assert turn["mode"] == "execute", turn
+                assert turn["selected_action"] == "run_dev_eval", turn
+                assert turn["frontier"]["frontier"]["selected"]["mechanism_family"] == (
+                    "run_read_only_adapter_tick"
+                ), turn
+                assert turn["frontier"]["frontier"]["selected"]["allowed_action"] == "run_dev_eval", turn
+                assert turn["live_evidence"]["written"] is True, turn
+        alias_evidence = run_worker_turn(
+            registry=four_registry,
+            runtime_root=four_runtime_root,
+            workspace=four_workspace,
+            agent_id=EVIDENCE_AGENT_ID,
+            execute=False,
+        )
+        assert alias_evidence["mode"] == "no_action", alias_evidence
         verifier = run_worker_turn(
             registry=four_registry,
             runtime_root=four_runtime_root,

--- a/examples/generic-multi-agent-spec-contract-smoke.py
+++ b/examples/generic-multi-agent-spec-contract-smoke.py
@@ -176,6 +176,7 @@ def main() -> int:
         assert "LOOPX_PANE_WORKER_TURN" in command, lane
         assert "LOOPX_PANE_LOOPX_JSON" in command, lane
         assert "LOOPX_PANE_ARTIFACT_DIR" in command, lane
+        assert "pane-a2a-tick.output.txt" in command, lane
         assert "exec python3 -c" in command, lane
         assert "codex exec" not in command, lane
         assert "codex_stream_filter" not in command, lane

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -106,7 +106,7 @@ def main() -> int:
     assert "loopx-pane-a2a-tick" in launcher_source
     assert "LOOPX_PANE_WORKER_TURN" in launcher_source
     assert "LOOPX_PANE_TICK_ROUNDS" in launcher_source
-    assert "First action: immediately run `$LOOPX_PANE_A2A_TICK`" in contract_source
+    assert "The launcher runs `$LOOPX_PANE_A2A_TICK` before this Codex TUI opens." in contract_source
     assert "LOOPX_VISIBLE_FORCE_MARKDOWN" in launcher_source
     assert "machine_json_command=$LOOPX_PANE_LOOPX_JSON artifact_dir=$LOOPX_PANE_ARTIFACT_DIR" in runtime_source
     assert "$LOOPX_PANE_LOOPX_JSON is a command path, not an output file." in runtime_source
@@ -163,7 +163,7 @@ def main() -> int:
     assert runner_contract["tmux_lifecycle"]["stop_command"] == dry_packet["commands"]["stop"]
     assert runner_contract["pane_local_a2a"]["tick_command"] == "$LOOPX_PANE_A2A_TICK"
     assert runner_contract["pane_local_a2a"]["first_action"] == (
-        "run $LOOPX_PANE_A2A_TICK inside the Codex TUI"
+        "launcher runs $LOOPX_PANE_A2A_TICK before Codex TUI opens"
     )
     assert runner_contract["pane_local_a2a"]["bounded_rounds_env"] == (
         "LOOPX_PANE_TICK_ROUNDS"
@@ -229,6 +229,7 @@ def main() -> int:
     assert "$LOOPX_PANE_ARTIFACT_DIR/quota.public.json" in generic_lane["quota_guard"], generic_lane
     assert "LOOPX_PANE_TICK_ROUNDS=2" in generic_lane["visible_launch_command"], generic_lane
     assert "LOOPX_PANE_TICK_SLEEP_SECONDS=1" in generic_lane["visible_launch_command"], generic_lane
+    assert "pane-a2a-tick.output.txt" in generic_lane["visible_launch_command"], generic_lane
 
     with tempfile.TemporaryDirectory() as temp_dir:
         temp = Path(temp_dir)

--- a/loopx/capabilities/auto_research/preset.py
+++ b/loopx/capabilities/auto_research/preset.py
@@ -184,6 +184,9 @@ def auto_research_worker_turn_command(*, goal_id: str, agent_id: str, objective:
         f"--goal-id {shlex.quote(goal_id)} "
         f"--agent-id {shlex.quote(agent_id)} "
         f"--objective {shlex.quote(objective)} "
+        '--lane-count "${LOOPX_VISIBLE_LANE_COUNT:-1}" '
+        "--visible-lanes-accepted "
+        '--live-evidence-output "$LOOPX_PANE_ARTIFACT_DIR/live-codex-e2e-evidence.public.json" '
         "--execute --complete-selected-todo"
     )
 

--- a/loopx/capabilities/auto_research/research_state.py
+++ b/loopx/capabilities/auto_research/research_state.py
@@ -39,6 +39,9 @@ AUTO_RESEARCH_PROJECTION_SCHEMA_VERSION = "decentralized_auto_research_projectio
 RESEARCH_EVIDENCE_GRAPH_SCHEMA_VERSION = "research_evidence_graph_v0"
 RESEARCH_FRONTIER_SCHEMA_VERSION = "decentralized_research_frontier_v0"
 ROLLOUT_EVIDENCE_GRAPH_SOURCE_KIND = "loopx_rollout_event_log"
+AUTO_RESEARCH_ACTION_ALIASES = {
+    "run_read_only_adapter_tick": "run_dev_eval",
+}
 
 
 def load_auto_research_fixture(path: str | Path) -> dict[str, Any]:
@@ -113,6 +116,11 @@ def _claimed_by_current_or_unclaimed(item: dict[str, Any], *, agent_id: str) -> 
     return not claimed_by or claimed_by == agent_id
 
 
+def normalize_auto_research_action(action: object) -> str:
+    raw = str(action or "").strip()
+    return AUTO_RESEARCH_ACTION_ALIASES.get(raw, raw)
+
+
 def _todo_frontier_item(
     item: dict[str, Any],
     *,
@@ -149,7 +157,7 @@ def _todo_frontier_item(
         summary["blocked_by"] = _compact_public_text(blocked_by, field="live.blocked_by", max_len=160)
     else:
         summary["allowed_action"] = _compact_optional_text(
-            item.get("action_kind") or "advance_todo",
+            normalize_auto_research_action(item.get("action_kind") or "advance_todo"),
             field="live.allowed_action",
             default="advance_todo",
             max_len=96,

--- a/loopx/capabilities/auto_research/worker_runtime.py
+++ b/loopx/capabilities/auto_research/worker_runtime.py
@@ -29,6 +29,7 @@ from .research_state import (
     build_live_auto_research_projection,
     build_research_decision_candidates,
     build_research_evidence_graph_from_rollout_events,
+    normalize_auto_research_action,
 )
 from ...agent_registry import registered_agent_ids_from_registry
 from ...history import load_registry
@@ -628,7 +629,8 @@ def run_auto_research_worker_turn(
         workspace=workspace,
     )
     selected = frontier_packet["frontier"].get("selected") if isinstance(frontier_packet["frontier"], dict) else None
-    action = str((selected or {}).get("allowed_action") or "")
+    raw_action = str((selected or {}).get("allowed_action") or "")
+    action = normalize_auto_research_action(raw_action)
     todo_id = str((selected or {}).get("todo_id") or "")
     if not selected or not todo_id:
         return {

--- a/loopx/capabilities/multi_agent/contract.py
+++ b/loopx/capabilities/multi_agent/contract.py
@@ -112,7 +112,8 @@ def generic_role_prompt(
             "",
             "How to work:",
             "- Treat LoopX state as the shared A2A surface.",
-            "- First action: immediately run `$LOOPX_PANE_A2A_TICK` in this Codex TUI. Do not ask the user to start it.",
+            "- The launcher runs `$LOOPX_PANE_A2A_TICK` before this Codex TUI opens.",
+            "- If the tick artifact is missing or the user asks, rerun `$LOOPX_PANE_A2A_TICK` in this TUI.",
             "- The tick reads your quota/frontier and then runs this role's worker-turn when configured.",
             "- When the tick completes, summarize what changed, what remains blocked, and stay interactive for user takeover.",
             "- For machine reads, run `$LOOPX_PANE_LOOPX_JSON` as the command and redirect output into `$LOOPX_PANE_ARTIFACT_DIR/<name>.public.json`; it defaults to `--format json`.",
@@ -193,7 +194,7 @@ def build_tui_multi_agent_runner_contract(
         },
         "pane_local_a2a": {
             "tick_command": "$LOOPX_PANE_A2A_TICK",
-            "first_action": "run $LOOPX_PANE_A2A_TICK inside the Codex TUI",
+            "first_action": "launcher runs $LOOPX_PANE_A2A_TICK before Codex TUI opens",
             "reads": ["quota should-run", "agent-scoped frontier"],
             "runs": ["LOOPX_PANE_WORKER_TURN", "LOOPX_PANE_WORKER_LOOP"],
             "bounded_rounds_env": "LOOPX_PANE_TICK_ROUNDS",

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -171,6 +171,7 @@ def build_visible_lane_command(
     worker_loop_command: str | None = None,
     tick_rounds: int | None = None,
     tick_sleep_seconds: int | None = None,
+    visible_lane_count: int | None = None,
 ) -> str:
     codex_exec_env = (
         f"export LOOPX_CODEX_BIN={_q(codex_bin)}; "
@@ -203,6 +204,8 @@ def build_visible_lane_command(
         pane_a2a_env += f"export LOOPX_PANE_TICK_ROUNDS={_q(tick_rounds)}; "
     if tick_sleep_seconds and tick_sleep_seconds > 0:
         pane_a2a_env += f"export LOOPX_PANE_TICK_SLEEP_SECONDS={_q(tick_sleep_seconds)}; "
+    if visible_lane_count and visible_lane_count > 0:
+        pane_a2a_env += f"export LOOPX_VISIBLE_LANE_COUNT={_q(visible_lane_count)}; "
     return (
         "set -uo pipefail; "
         "export LOOPX_VISIBLE_TUI_SILENT_BOOTSTRAP=1; "
@@ -224,6 +227,13 @@ def build_visible_lane_command(
         "printf '\\n[LoopX blocked reason]\\n'; "
         "printf 'bootstrap_command_failed exit=%s\\n' \"$BOOTSTRAP_STATUS\"; "
         "exec /bin/sh -i; "
+        "fi; "
+        'PANE_A2A_TICK_ARTIFACT="$LOOPX_PANE_ARTIFACT_DIR/pane-a2a-tick.output.txt"; '
+        '"$LOOPX_PANE_A2A_TICK" > "$PANE_A2A_TICK_ARTIFACT" 2>&1; '
+        "PANE_A2A_TICK_STATUS=$?; "
+        "if [ \"$PANE_A2A_TICK_STATUS\" -ne 0 ]; then "
+        "printf '\\n[LoopX pane A2A blocked]\\n'; "
+        "printf 'tick_exit=%s artifact=%s\\n' \"$PANE_A2A_TICK_STATUS\" \"$PANE_A2A_TICK_ARTIFACT\"; "
         "fi; "
         "export LOOPX_CODEX_TUI_MODE=interactive; "
         "export LOOPX_CODEX_TUI_PROMPT_ARTIFACT=\"$BOOTSTRAP_ARTIFACT\"; "
@@ -480,12 +490,13 @@ def build_visible_multi_agent_payload_from_spec(
                 worker_loop_command=worker_loop_command,
                 tick_rounds=tick_rounds,
                 tick_sleep_seconds=tick_sleep_seconds,
+                visible_lane_count=len(roles),
             ),
             "reasoning_effort": reasoning_effort,
             "lane_timeline": [
                 "role_profile",
-                "codex_tui",
                 "auto_start_pane_local_a2a_tick",
+                "codex_tui",
                 "frontier",
             ],
         }
@@ -772,6 +783,7 @@ def _launch_with_tmux(
             name=lane_id,
             command=runtime_shell_command(
                 f"export LOOPX_CODEX_TRUST_WORKSPACE={_q('1' if codex_trust_workspace else '0')}; "
+                f"export LOOPX_VISIBLE_LANE_COUNT={_q(len(lanes))}; "
                 f"{launch_command}",
                 project=lane_project,
                 registry=registry,


### PR DESCRIPTION
## Summary
- run each visible pane's LoopX A2A tick before opening the Codex TUI, while keeping the tick pane-local rather than central worker-loop driven
- write pane live evidence into the launcher artifact directory so demo-e2e can load first-round evidence deterministically
- normalize the read-only adapter tick action onto the dev-eval worker action path and cover it with regression smokes

## Product/architecture judgment
This keeps the visible demo aligned with the LoopX product standard mode: the launcher prepares the pane-local runtime and guarantees one startup tick, then hands control to real interactive Codex TUI roles. It does not reintroduce hidden character-stream presentation or a central leader scanning the whole queue.

## Validation
- python3 examples/auto-research-worker-turn-smoke.py
- python3 examples/auto-research-demo-supervisor-smoke.py
- python3 examples/visible-multi-agent-launcher-smoke.py
- python3 examples/auto-research-layered-e2e-acceptance-smoke.py
- python3 examples/generic-multi-agent-spec-contract-smoke.py
- python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- python3 examples/auto-research-live-evidence-capture-smoke.py
- python3 -m py_compile loopx/capabilities/auto_research/preset.py loopx/capabilities/auto_research/research_state.py loopx/capabilities/auto_research/worker_runtime.py loopx/capabilities/multi_agent/contract.py loopx/visible_multi_agent_launcher.py
- git diff --check
- real visible demo-e2e with tmux/no-attach: visible_lanes_accepted=true, lane_authored_evidence_loaded=true, live_evidence_loaded=true, dev_metric=4.0