### PR TITLE
Clarify pr-review section detail hints

### DIFF
--- a/docs/reference/protocols/pr-review-command-v0.md
+++ b/docs/reference/protocols/pr-review-command-v0.md
@@ -149,37 +149,37 @@ absolute paths, private source bodies, or hidden CI artifacts.
         "sections": [
           {
             "label": "动机",
-            "word_hint": "40-80字",
+            "word_hint": "100-200字",
             "content": "",
-            "agent_instruction": "读 PR title/body/diff 后填写：这个 PR 为什么存在，想解决哪个用户或维护者问题。"
+            "agent_instruction": "读 PR title/body/diff 后填写：这个 PR 为什么存在，想解决哪个用户或维护者问题；说明触发背景和价值，不要只复述标题。"
           },
           {
             "label": "改动思路",
-            "word_hint": "40-100字",
+            "word_hint": "100-200字",
             "content": "",
-            "agent_instruction": "读关键 diff 后填写：作者采用什么路线解决问题，不要只复述文件名。"
+            "agent_instruction": "读关键 diff 后填写：作者采用什么路线解决问题，关键设计取舍是什么，不要只复述文件名。"
           },
           {
             "label": "具体改动",
-            "word_hint": "60-140字",
+            "word_hint": "100-200字",
             "content": "",
-            "agent_instruction": "读 diff 后填写：具体改了哪些模块、协议、命令、文档或测试，只保留决策相关细节。"
+            "agent_instruction": "读 diff 后填写：具体改了哪些模块、协议、命令、文档或测试；保留能支撑 review 决策的细节。"
           },
           {
             "label": "对主干的风险",
-            "word_hint": "40-100字",
+            "word_hint": "100-200字",
             "content": "",
-            "agent_instruction": "读 diff 和 checks 后填写：合入 main 可能破坏什么，哪些验证能覆盖。"
+            "agent_instruction": "读 diff、checks 和 main_regression_analysis 后填写：合入 main 可能破坏什么，哪些验证已覆盖，哪些残余风险还需要关注。"
           },
           {
             "label": "我的整体评价",
-            "word_hint": "30-80字",
+            "word_hint": "100-200字",
             "content": "",
-            "agent_instruction": "读完整 PR 后填写：approve / request changes / defer / merge after checks，并给一句理由。"
+            "agent_instruction": "读完整 PR 后填写：approve / request changes / defer / merge after checks；给出结论、理由和必要的后续条件。"
           }
         ],
         "review_order": ["docs/guides/newcomer-command-path.md", "docs/README.md"],
-        "output_hint": "Keep each PR concise; the filled five-block review is usually 100-200 Chinese characters total for small PRs and longer only when risk demands it."
+        "output_hint": "Write each of the five sections with concrete evidence and judgment; each section is usually 100-200 Chinese characters, shorter only for genuinely tiny PRs and longer when risk demands it."
       },
       "motivation": "Adds a newcomer command path...",
       "scale": {"changed_files": 3, "additions": 90, "deletions": 4},
@@ -256,6 +256,8 @@ The packet should let a reviewer move through PRs in order:
    focused validation.
 5. Let agentloop fill the blank five-block template:
    `动机`, `改动思路`, `具体改动`, `对主干的风险`, `我的整体评价`.
+   Each section should usually be 100-200 Chinese characters and include
+   concrete evidence and judgment after reading the selected PR.
 6. Treat `metadata_risk_hint` only as queue-ordering metadata. It must not be
    copied as the final risk judgement.
 7. Decide `approve`, `request changes`, `defer`, or `merge after checks`.
@@ -296,6 +298,9 @@ A first implementation is acceptable when:
   per-PR deep-read commands after the CLI packet selects a PR;
 - each PR includes `review_template.sections` for `动机`, `改动思路`,
   `具体改动`, `对主干的风险`, and `我的整体评价`;
+- each review template section carries a `100-200字` hint so the final chat
+  review explains evidence and judgment instead of collapsing the whole PR into
+  a single short paragraph;
 - template sections must leave `content` empty so agentloop reads the real PR
   before writing the review;
 - `metadata_risk_hint` must be repository-generic and must not special-case

--- a/examples/pr-review-command-smoke.py
+++ b/examples/pr-review-command-smoke.py
@@ -166,7 +166,7 @@ def main() -> int:
     template = first["review_template"]
     assert template["schema_version"] == "pr_review_five_block_template_v0", template
     assert "Empty scaffold only" in template["purpose"], template
-    assert "100-200 Chinese characters" in template["output_hint"], template
+    assert "each section is usually 100-200 Chinese characters" in template["output_hint"], template
     labels = [section["label"] for section in template["sections"]]
     assert labels == ["动机", "改动思路", "具体改动", "对主干的风险", "我的整体评价"], template
     for section in template["sections"]:
@@ -294,11 +294,11 @@ def main() -> int:
     assert "template below is intentionally blank" in markdown, markdown
     assert "- 推荐阅读顺序:" in markdown, markdown
     assert "- 五块模板（留空给 agentloop 填写）:" in markdown, markdown
-    assert "动机（40-80字）" in markdown, markdown
-    assert "改动思路（40-100字）" in markdown, markdown
-    assert "具体改动（60-140字）" in markdown, markdown
-    assert "对主干的风险（40-100字）" in markdown, markdown
-    assert "我的整体评价（30-80字）" in markdown, markdown
+    assert "动机（100-200字）" in markdown, markdown
+    assert "改动思路（100-200字）" in markdown, markdown
+    assert "具体改动（100-200字）" in markdown, markdown
+    assert "对主干的风险（100-200字）" in markdown, markdown
+    assert "我的整体评价（100-200字）" in markdown, markdown
     assert "main regression risk:" not in markdown, markdown
     assert "## Combined Review Sequence" in markdown, markdown
     assert "PR #773" in markdown, markdown

--- a/examples/slash-command-catalog-smoke.py
+++ b/examples/slash-command-catalog-smoke.py
@@ -66,6 +66,7 @@ def main() -> int:
         "对主干的风险",
         "我的整体评价",
     ], final_contract
+    assert "100-200 Chinese characters" in final_contract["section_length_hint"], final_contract
     assert "do not reconstruct" in pr_review["agent_contract"]["manual_gh_policy"], pr_review
     assert "summary-only projection" in pr_review["agent_contract"]["json_projection_policy"], pr_review
     onboarding = payload["onboarding"]

--- a/loopx/pr_review.py
+++ b/loopx/pr_review.py
@@ -573,28 +573,28 @@ def _review_template(item: dict[str, Any]) -> dict[str, Any]:
     sections = [
         _section(
             "动机",
-            "40-80字",
-            "读 PR title/body/diff 后填写：这个 PR 为什么存在，想解决哪个用户或维护者问题。",
+            "100-200字",
+            "读 PR title/body/diff 后填写：这个 PR 为什么存在，想解决哪个用户或维护者问题；说明触发背景和价值，不要只复述标题。",
         ),
         _section(
             "改动思路",
-            "40-100字",
-            "读关键 diff 后填写：作者采用什么路线解决问题，不要只复述文件名。",
+            "100-200字",
+            "读关键 diff 后填写：作者采用什么路线解决问题，关键设计取舍是什么，不要只复述文件名。",
         ),
         _section(
             "具体改动",
-            "60-140字",
-            "读 diff 后填写：具体改了哪些模块、协议、命令、文档或测试，只保留决策相关细节。",
+            "100-200字",
+            "读 diff 后填写：具体改了哪些模块、协议、命令、文档或测试；保留能支撑 review 决策的细节。",
         ),
         _section(
             "对主干的风险",
-            "40-100字",
-            "读 diff 和 checks 后填写：合入 main 可能破坏什么，哪些验证能覆盖。",
+            "100-200字",
+            "读 diff、checks 和 main_regression_analysis 后填写：合入 main 可能破坏什么，哪些验证已覆盖，哪些残余风险还需要关注。",
         ),
         _section(
             "我的整体评价",
-            "30-80字",
-            "读完整 PR 后填写：approve / request changes / defer / merge after checks，并给一句理由。",
+            "100-200字",
+            "读完整 PR 后填写：approve / request changes / defer / merge after checks；给出结论、理由和必要的后续条件。",
         ),
     ]
     return {
@@ -602,7 +602,7 @@ def _review_template(item: dict[str, Any]) -> dict[str, Any]:
         "purpose": "Empty scaffold only; agentloop fills it after reading PR body and diff.",
         "sections": sections,
         "review_order": _review_order(key_files),
-        "output_hint": "Keep each PR concise; the filled five-block review is usually 100-200 Chinese characters total for small PRs and longer only when risk demands it.",
+        "output_hint": "Write each of the five sections with concrete evidence and judgment; each section is usually 100-200 Chinese characters, shorter only for genuinely tiny PRs and longer when risk demands it.",
     }
 
 

--- a/loopx/slash_commands.py
+++ b/loopx/slash_commands.py
@@ -139,6 +139,7 @@ def build_slash_command_catalog(
                         "我的整体评价",
                     ],
                     "evidence_before_filling": "Read each selected PR body/files/diff/checks before filling the sections.",
+                    "section_length_hint": "Each section should usually be 100-200 Chinese characters with concrete evidence and judgment.",
                 },
                 "manual_gh_policy": (
                     "Use gh only after the CLI packet selects a PR; do not reconstruct "

--- a/skills/loopx-pr-review/SKILL.md
+++ b/skills/loopx-pr-review/SKILL.md
@@ -103,11 +103,14 @@ For each reviewed PR, use exactly these five headings:
 4. `对主干的风险`
 5. `我的整体评价`
 
-Use the packet's blank `review_template` only as structure and word-count hint.
-Do not copy fake/example content into the sections. Fill the content after
-reading PR body, files, checks, and diff. Small PRs usually fit in 100-200
-Chinese characters total; use more only when risk or diff complexity requires
-it.
+Use the packet's blank `review_template` as the required structure and minimum
+detail signal, not as fake/example content. Fill each section only after reading
+PR body, files, checks, and diff. Each of the five sections should usually be
+100-200 Chinese characters, with concrete evidence and judgment; go shorter
+only for genuinely tiny PRs and longer when risk or diff complexity requires it.
+Avoid title-only summaries such as "improves docs" or "low risk"; explain the
+background, implementation route, reviewer-relevant changes, main-branch risk,
+and final recommendation.
 
 ## Failure And Fallback
 


### PR DESCRIPTION
## Summary

- Make the `/loopx-pr-review` skill require more detailed five-block reviews, with each section usually 100-200 Chinese characters.
- Update `loopx pr-review` packet templates, slash-command agent contract metadata, and protocol docs to match the skill guidance.
- Extend smokes so the longer section hints stay covered.

## Validation

- `python3 examples/pr-review-command-smoke.py`
- `python3 examples/slash-command-catalog-smoke.py`
- `python3 examples/docs-governance-smoke.py`
- `python3 examples/check-public-boundary-smoke.py`
- `python3 -m py_compile loopx/pr_review.py loopx/slash_commands.py examples/pr-review-command-smoke.py examples/slash-command-catalog-smoke.py`
- `python3 /Users/bytedance/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/loopx-pr-review`
- `git diff --check`
