### PR TITLE
Hint LoopX runtime drivers in help

### DIFF
--- a/docs/guides/newcomer-command-path.md
+++ b/docs/guides/newcomer-command-path.md
@@ -24,6 +24,19 @@ Examples:
 /loopx split this refactor into PR-sized slices and stop at unsafe gates
 ```
 
+## Choose The Loop Driver
+
+LoopX preserves goal state, gates, todos, quota, and evidence. It does not
+replace the app or CLI that runs the next agent turn. Pick the driver that
+matches the surface you already use:
+
+| Surface | Start with | What keeps it moving |
+| --- | --- | --- |
+| Codex App | `/loopx <goal text>` in the project thread | The app heartbeat automation. Let the agent install or refresh the generated LoopX heartbeat body; start at the bootstrap cadence, then follow `quota should-run.scheduler_hint`. |
+| Codex CLI | `codex` from the project root, then `/loopx <goal text>` | The visible TUI goal. Use `loopx codex-cli-bootstrap-message --project .` when you need a generated setup prompt, and keep the executor visible to the user. |
+| Claude Code | Enable the opt-in LoopX adapter, then `/loopx <goal text>` | Claude Code's native `/loop`, gated by LoopX `should_run`, drives each tick. |
+| Other agent or shell | `loopx bootstrap-command-pack --project .` | A CLI, task, automation, heartbeat, or scheduler hook must run the next turn. If the surface has no such hook, LoopX can track state but the user drives it manually. |
+
 ## One CLI Quickstart
 
 Use this when an agent asks for the manual shell path, or when you are setting

--- a/examples/cli-help-manpage-smoke.py
+++ b/examples/cli-help-manpage-smoke.py
@@ -26,6 +26,9 @@ def assert_concise_default_help(output: str) -> None:
     assert "LoopX keeps long-running agent work moving" in output, output
     assert "Start here:" in output, output
     assert "/loopx <goal text>" in output, output
+    assert "Run the loop:" in output, output
+    assert "Codex App" in output, output
+    assert "Claude Code" in output, output
     assert "loopx commands" in output, output
     assert "man loopx" in output, output
     assert LONG_TAIL_COMMAND not in output, output
@@ -49,6 +52,8 @@ def assert_command_reference_surface() -> None:
     assert result.returncode == 0, (result.returncode, result.stdout, result.stderr)
     assert "LoopX command reference" in result.stdout, result.stdout
     assert "Daily operator commands" in result.stdout, result.stdout
+    assert "Loop driver hints" in result.stdout, result.stdout
+    assert "Claude Code /loop" in result.stdout, result.stdout
     assert "Maintainer and adapter commands" in result.stdout, result.stdout
     assert "loopx <command> --help" in result.stdout, result.stdout
     assert "codex-cli-bootstrap-message" in result.stdout, result.stdout
@@ -110,6 +115,8 @@ def assert_installer_manpage_surface() -> None:
         with gzip.open(manpage, "rt", encoding="utf-8") as handle:
             man_text = handle.read()
         assert ".TH LOOPX 1" in man_text, man_text
+        assert ".SH LOOP DRIVERS" in man_text, man_text
+        assert "Codex App automation" in man_text, man_text
         assert "loopx commands" in man_text, man_text
         assert "loopx COMMAND --help" in man_text, man_text
 
@@ -126,6 +133,7 @@ def assert_installer_manpage_surface() -> None:
         assert man.returncode == 0, (man.returncode, man.stdout, man.stderr)
         assert "LOOPX(1)" in man.stdout, man.stdout
         assert "LoopX keeps long-running agent work moving" in man.stdout, man.stdout
+        assert "heartbeat automation" in man.stdout, man.stdout
 
 
 def main() -> int:

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -48,6 +48,27 @@ COMMAND_GROUPS: list[dict[str, object]] = [
         ],
     },
     {
+        "title": "Loop driver hints",
+        "commands": [
+            {
+                "command": "Codex App automation",
+                "purpose": "Use `/loopx <goal>` and let the app create or refresh the heartbeat automation.",
+            },
+            {
+                "command": "Codex CLI visible goal",
+                "purpose": "Stay in the visible TUI; use `loopx codex-cli-bootstrap-message` for setup when needed.",
+            },
+            {
+                "command": "Claude Code /loop",
+                "purpose": "Enable the opt-in adapter, start `/loopx <goal>`, then let Claude Code `/loop` tick it.",
+            },
+            {
+                "command": "Other agent or shell",
+                "purpose": "Use a CLI, task, automation, heartbeat, or scheduler hook; otherwise drive LoopX manually.",
+            },
+        ],
+    },
+    {
         "title": "Setup and automation commands",
         "commands": [
             {"command": "loopx bootstrap / loopx connect", "purpose": "Create or connect project-local state."},
@@ -134,6 +155,12 @@ def render_concise_help(program: str = "loopx") -> str:
             "  loopx diagnose --goal-id ID    Build a compact evidence packet.",
             "  loopx todo --help              Add, claim, complete, update, or archive todos.",
             "  loopx quota should-run         Decide whether the next agent turn should run.",
+            "",
+            "Run the loop:",
+            "  Codex App      use /loopx <goal>; let the app set the heartbeat automation.",
+            "  Codex CLI      keep visible TUI; run loopx codex-cli-bootstrap-message.",
+            "  Claude Code    enable the adapter, start /loopx <goal>, then run /loop.",
+            "  Other agents   need a CLI/task/automation/loop hook, or run LoopX manually.",
             "",
             "Global options:",
             "  --registry PATH   --runtime-root PATH   --format markdown|json",

--- a/man/loopx.1
+++ b/man/loopx.1
@@ -50,6 +50,24 @@ Show todo add, claim, complete, update, supersede, and archive forms.
 .TP
 .B loopx quota should-run
 Decide whether the next agent turn should run.
+.SH LOOP DRIVERS
+.TP
+.B Codex App automation
+Use \fB/loopx <goal>\fR and let the app create or refresh the LoopX heartbeat
+automation. Start at the bootstrap cadence, then follow LoopX scheduler hints.
+.TP
+.B Codex CLI visible goal
+Keep the Codex CLI TUI as the visible executor. Use
+\fBloopx codex-cli-bootstrap-message\fR when a generated setup message is
+needed.
+.TP
+.B Claude Code /loop
+Enable the opt-in LoopX adapter, start \fB/loopx <goal>\fR, then use Claude
+Code's native \fB/loop\fR to drive each tick.
+.TP
+.B Other agents or shell
+Use LoopX only with a CLI, task, automation, heartbeat, or scheduler hook that
+can run the next turn. Without such a hook, run LoopX commands manually.
 .SH MORE COMMANDS
 .TP
 .B loopx commands


### PR DESCRIPTION
## Summary

- Add a compact `Run the loop` section to the top-level `loopx` / `loopx --help` surface so first-run users understand which app or CLI drives the next agent turn.
- Add grouped `Loop driver hints` to `loopx commands`, covering Codex App automation, Codex CLI visible goals, Claude Code `/loop`, and generic agent/shell hooks.
- Mirror the same loop-driver model in `man loopx` and the newcomer command path guide, with smoke coverage for the new help/manpage text.

## Validation

- `python3 examples/cli-help-manpage-smoke.py`
- `python3 examples/fresh-clone-quickstart-smoke.py`
- `python3 examples/docs-governance-smoke.py`
- `python3 examples/check-public-boundary-smoke.py`
- `python3 -m py_compile loopx/help_surface.py examples/cli-help-manpage-smoke.py`
- `git diff --check`
