### PR TITLE
Add SkillsBench app-server Goal prompt style switch

### DIFF
--- a/examples/control_plane/repo-python-line-budget-smoke.py
+++ b/examples/control_plane/repo-python-line-budget-smoke.py
@@ -16,7 +16,7 @@ DEFAULT_MAX_LINES = 2000
 LEGACY_OVERSIZED_LIMITS = {
     "examples/benchmark-run-ledger-smoke.py": 2106,
     "examples/control_plane/quota-plan-smoke.py": 2176,
-    "examples/skillsbench-app-server-goal-worker-smoke.py": 3006,
+    "examples/skillsbench-app-server-goal-worker-smoke.py": 3056,
     "examples/skillsbench-benchmark-run-smoke.py": 14613,
     "examples/skillsbench-host-local-launch-plan-smoke.py": 2373,
     "examples/control_plane/status-markdown-smoke.py": 2607,
@@ -25,9 +25,9 @@ LEGACY_OVERSIZED_LIMITS = {
     "loopx/benchmark.py": 2875,
     "loopx/benchmark_adapters/agentissue.py": 2644,
     "loopx/benchmark_adapters/agents_last_exam.py": 3998,
-    "loopx/benchmark_adapters/skillsbench.py": 5844,
+    "loopx/benchmark_adapters/skillsbench.py": 5850,
     "examples/control_plane/work-lane-contract-smoke.py": 2336,
-    "loopx/benchmark_adapters/skillsbench_acp_relay.py": 3126,
+    "loopx/benchmark_adapters/skillsbench_acp_relay.py": 3144,
     "loopx/benchmark_adapters/terminal_bench.py": 10045,
     "loopx/benchmark_ledger.py": 3535,
     "loopx/capabilities/content_ops/surface.py": 2549,
@@ -38,7 +38,7 @@ LEGACY_OVERSIZED_LIMITS = {
     "loopx/terminal_bench_agent.py": 2056,
     "loopx/todos.py": 2105,
     "scripts/harbor_host_codex_goal_agent.py": 2140,
-    "scripts/skillsbench_automation_loop.py": 16241,
+    "scripts/skillsbench_automation_loop.py": 16265,
 }
 
 

--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -760,6 +760,8 @@ def test_launcher_plan_only_uses_native_worker_route() -> None:
                 ROUTE,
                 "--jobs-dir",
                 str(Path(tmp) / "jobs"),
+                "--app-server-goal-prompt-style",
+                "cli-exec-like",
                 "--plan-only",
             ],
             cwd=REPO_ROOT,
@@ -771,8 +773,10 @@ def test_launcher_plan_only_uses_native_worker_route() -> None:
     assert payload["ok"] is True, payload
     plan = payload["launch_plan"]
     assert_plan_prerequisites(plan)
+    assert plan["app_server_goal_prompt_style"] == "cli-exec-like", plan
     contract = plan["app_server_goal_worker_contract"]
     assert contract["route"] == ROUTE, contract
+    assert contract["worker_adapter"]["prompt_style"] == "cli-exec-like", contract
     assert contract["worker_plan"]["schema_version"] == "codex_app_server_goal_worker_v0", contract
     assert plan["app_server_goal_worker_trace_dir"].endswith(
         "app_server_goal_worker_traces"
@@ -1178,8 +1182,10 @@ def test_host_worker_contract_only_cli() -> None:
     assert contract["route"] == ROUTE, contract
     assert contract["worker_adapter"]["script"] == "scripts/skillsbench_host_codex_goal_worker.py", contract
     assert contract["worker_adapter"]["reasoning_effort"] == "high", contract
+    assert contract["worker_adapter"]["prompt_style"] == "native-goal", contract
     assert payload["loopx_mode"] == "codex_goal_mode_baseline", payload
     assert payload["loopx_access_packet_mode"] == "none", payload
+    assert payload["app_server_goal_prompt_style"] == "native-goal", payload
     assert payload["loopx_case_lifecycle_packet_injected"] is False, payload
     assert payload["benchmark_case_lifecycle_contract"] is None, payload
 
@@ -1228,6 +1234,34 @@ def test_host_worker_treatment_lifecycle_packet_is_public_safe() -> None:
     assert "official SkillsBench/BenchFlow verifier authoritative" in prompt
     assert "Private task instruction placeholder." in prompt
     assert "/Users/" not in prompt
+
+
+def test_host_worker_cli_exec_like_prompt_style_suppresses_lifecycle_packet() -> None:
+    worker = _load_worker_module()
+    args = worker.parse_args(
+        [
+            "--task-id",
+            "tictoc-unnecessary-abort-detection",
+            "--contract-only",
+            "--app-server-goal-prompt-style",
+            "cli-exec-like",
+            "--loopx-mode",
+            "codex_loopx",
+            "--loopx-access-packet-mode",
+            "compact",
+            "--loopx-case-id",
+            "tictoc-unnecessary-abort-detection",
+            "--loopx-arm-id",
+            "loopx_prompt_polling_test",
+            "--loopx-max-rounds",
+            "5",
+        ]
+    )
+    packet, contract = worker.build_loopx_case_lifecycle_packet(args)
+    assert packet == ""
+    assert contract is None
+    payload = worker.build_contract_payload(args)
+    assert payload["worker_adapter"]["prompt_style"] == "cli-exec-like", payload
 
 
 def test_host_worker_waits_for_completion_and_keeps_public_json_compact() -> None:
@@ -2471,6 +2505,7 @@ def _app_server_goal_command_args(first_action_timeout: int | None) -> Namespace
         local_acp_relay_command="",
         route=ROUTE,
         app_server_reasoning_effort="high",
+        app_server_goal_prompt_style="native-goal",
         app_server_acp_heartbeat_interval_sec=120.0,
         dataset="skillsbench@1.1",
         task_id="llm-prefix-cache-replay",
@@ -2490,6 +2525,19 @@ def _app_server_goal_command_args(first_action_timeout: int | None) -> Namespace
         remote_command_file_bridge_probe_timeout_sec=10,
         remote_command_file_bridge_agent_command="",
     )
+
+
+def test_app_server_goal_launcher_carries_prompt_style() -> None:
+    runner = _load_runner_module()
+    args = _app_server_goal_command_args(first_action_timeout=30)
+    args.app_server_goal_prompt_style = "cli-exec-like"
+    command = runner._host_local_acp_launch_command(
+        args,
+        {"app_server_goal_worker_trace_dir": "/tmp/worker-traces"},
+    )
+    assert "--app-server-goal-prompt-style" in command, command
+    index = command.index("--app-server-goal-prompt-style")
+    assert command[index + 1] == "cli-exec-like", command
 
 
 def test_acp_relay_fails_fast_when_app_server_worker_only_uses_status_bridge() -> None:
@@ -2977,6 +3025,7 @@ if __name__ == "__main__":
     test_launcher_plan_only_marks_bridge_ready_when_explicit()
     test_launcher_plan_only_marks_runner_ready_with_host_acp_launch()
     test_host_worker_contract_only_cli()
+    test_host_worker_cli_exec_like_prompt_style_suppresses_lifecycle_packet()
     test_host_worker_waits_for_completion_and_keeps_public_json_compact()
     test_host_worker_recovers_when_first_turn_only_echoes_context()
     test_host_worker_can_run_normal_no_reward_followup()
@@ -2993,6 +3042,7 @@ if __name__ == "__main__":
     test_acp_relay_fails_fast_when_app_server_worker_never_uses_bridge()
     test_app_server_goal_launcher_defaults_first_action_watchdog()
     test_app_server_goal_launcher_allows_explicit_first_action_disable()
+    test_app_server_goal_launcher_carries_prompt_style()
     test_acp_relay_fails_fast_when_app_server_worker_only_uses_status_bridge()
     test_acp_relay_yields_after_task_output_quiet_timeout()
     test_launcher_plan_only_records_independent_retry_config()

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -799,6 +799,7 @@ def build_skillsbench_app_server_goal_worker_contract(
     cwd: str = "<skillsbench-task-workspace>",
     model: str = SKILLSBENCH_DEFAULT_MODEL,
     reasoning_effort: str = "high",
+    prompt_style: str = "native-goal",
     codex_bin: str = "codex",
     sandbox: str = "workspace-write",
     approval_policy: str = "never",
@@ -824,6 +825,10 @@ def build_skillsbench_app_server_goal_worker_contract(
     safe_dataset = _skillsbench_public_safe_label(dataset, limit=80)
     safe_task_id = _skillsbench_public_safe_label(task_id, limit=120)
     blockers = [str(item) for item in known_blockers if str(item)]
+    safe_prompt_style = _skillsbench_public_safe_label(prompt_style, limit=40)
+    if safe_prompt_style not in {"native-goal", "cli-exec-like"}:
+        blockers.append("skillsbench_app_server_goal_prompt_style_invalid")
+        safe_prompt_style = "native-goal"
     if not safe_dataset:
         safe_dataset = SKILLSBENCH_DEFAULT_DATASET
         blockers.append("skillsbench_dataset_not_public_safe")
@@ -890,6 +895,7 @@ def build_skillsbench_app_server_goal_worker_contract(
                 reasoning_effort, limit=40
             )
             or "high",
+            "prompt_style": safe_prompt_style,
             "agent_execution_mode": "host_codex_app_server_goal_worker",
             "worker_surface": "codex_app_server",
             "native_goal_methods_required": list(worker_plan["methods"]),

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -466,6 +466,13 @@ def _prompt_with_app_server_closeout_instruction(prompt_text: str) -> str:
     )
 
 
+def _normalized_app_server_goal_prompt_style(style: str | None) -> str:
+    text = str(style or "").strip().lower()
+    if text in {"native-goal", "cli-exec-like"}:
+        return text
+    return "native-goal"
+
+
 def _recoverable_codex_turn_failure_message(category: str) -> str:
     return (
         "LoopX recoverable Codex turn failure: "
@@ -519,6 +526,7 @@ class CodexExecConfig:
     stream_heartbeat_interval_sec: float = 120.0
     first_action_timeout_sec: float = 0.0
     app_server_goal_followup_max: int = 0
+    app_server_goal_prompt_style: str = "native-goal"
     bridge_idle_timeout_sec: float = 0.0
     task_output_quiet_timeout_sec: float = 0.0
     reasoning_effort: str | None = None
@@ -2043,9 +2051,16 @@ raise SystemExit(proc.returncode)
                     bridge_probe=bridge_probe,
                     bridge_command_for_agent=str(instrumented_bridge),
                 )
-            prompt_for_worker = _prompt_with_app_server_closeout_instruction(
-                prompt_for_worker
+            app_server_goal_prompt_style = _normalized_app_server_goal_prompt_style(
+                self._config.app_server_goal_prompt_style
             )
+            app_server_goal_closeout_injected = (
+                app_server_goal_prompt_style == "native-goal"
+            )
+            if app_server_goal_closeout_injected:
+                prompt_for_worker = _prompt_with_app_server_closeout_instruction(
+                    prompt_for_worker
+                )
             prompt_path.write_text(prompt_for_worker, encoding="utf-8")
             worker_script = (
                 Path(self._config.worker_script).expanduser()
@@ -2090,6 +2105,8 @@ raise SystemExit(proc.returncode)
                 str(worker_first_action_timeout_sec),
                 "--normal-followup-max",
                 str(max(0, int(self._config.app_server_goal_followup_max or 0))),
+                "--app-server-goal-prompt-style",
+                app_server_goal_prompt_style,
                 "--reasoning-effort",
                 str(self._config.reasoning_effort or "high"),
                 "--runner-integration-ready",
@@ -2423,6 +2440,7 @@ raise SystemExit(proc.returncode)
                 worker_adapter,
                 (
                     "reasoning_effort",
+                    "prompt_style",
                     "agent_execution_mode",
                     "worker_surface",
                     "context_only_followup_supported",
@@ -2430,7 +2448,7 @@ raise SystemExit(proc.returncode)
             ),
             "prompt": compact_dict(
                 payload.get("prompt"),
-                ("sha256", "chars", "raw_recorded"),
+                ("sha256", "chars", "raw_recorded", "style"),
             ),
             "turn": compact_dict(
                 payload.get("turn"),

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -1108,6 +1108,8 @@ def _host_local_acp_launch_command(
                         int(getattr(args, "app_server_goal_followup_max", 0) or 0),
                     )
                 ),
+                "--app-server-goal-prompt-style",
+                str(getattr(args, "app_server_goal_prompt_style", "native-goal")),
             ]
         )
         if worker_trace_dir:
@@ -7930,6 +7932,10 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
     reasoning_effort = _effective_reasoning_effort(args)
     app_server_reasoning_effort = _effective_app_server_reasoning_effort(args)
     codex_cli_reasoning_effort = _effective_codex_cli_reasoning_effort(args)
+    app_server_goal_prompt_style = str(
+        getattr(args, "app_server_goal_prompt_style", "native-goal")
+        or "native-goal"
+    )
     codex_api_egress_preflight = _public_codex_api_egress_contract(
         args,
         status=(
@@ -8017,6 +8023,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
             cwd="<skillsbench-task-workspace>",
             model=args.model,
             reasoning_effort=app_server_reasoning_effort,
+            prompt_style=app_server_goal_prompt_style,
             sandbox="workspace-write",
             approval_policy="never",
             no_upload=True,
@@ -8053,6 +8060,11 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
             max(0, int(args.app_server_goal_followup_max or 0))
             if is_app_server_goal_route
             else 0
+        ),
+        "app_server_goal_prompt_style": (
+            app_server_goal_prompt_style
+            if is_app_server_goal_route
+            else ""
         ),
         "run_group_id": str(args.run_group_id or ""),
         "sandbox": args.sandbox,
@@ -8557,6 +8569,7 @@ def _public_runner_config(plan: dict[str, Any]) -> dict[str, Any]:
         "reasoning_effort",
         "codex_cli_reasoning_effort",
         "app_server_reasoning_effort",
+        "app_server_goal_prompt_style",
         "sandbox",
         "run_group_id",
         "job_name",
@@ -14708,6 +14721,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "completed codex-app-server-goal-baseline turns. The follow-up "
             "prompt provides no verifier/reward/pass-fail feedback to the "
             "worker. 0 preserves the native single-turn baseline."
+        ),
+    )
+    parser.add_argument(
+        "--app-server-goal-prompt-style",
+        choices=("native-goal", "cli-exec-like"),
+        default="native-goal",
+        help=(
+            "Prompt framing for codex-app-server-goal-baseline. native-goal "
+            "preserves the existing app-server Goal closeout/lifecycle "
+            "framing; cli-exec-like keeps the worker prompt closer to the "
+            "Codex exec bridge prompt for diagnostic canaries."
         ),
     )
     parser.add_argument("--max-verifier-output-chars", type=int, default=0)

--- a/scripts/skillsbench_host_codex_goal_worker.py
+++ b/scripts/skillsbench_host_codex_goal_worker.py
@@ -42,6 +42,7 @@ SKILLS_INSTRUCTIONS_END_MARKER = "</skills_instructions>"
 NORMAL_FOLLOWUP_PROMPT = """Continue the same SkillsBench task in this existing Goal thread.
 Do not use or infer verifier, reward, pass/fail, hidden-test, or gold-answer feedback; none is being provided.
 Review your prior work, improve the scored output if needed using only the visible task, workspace, and bridge context already available in this thread, and end the turn once the best task-required output exists."""
+APP_SERVER_GOAL_PROMPT_STYLES = ("native-goal", "cli-exec-like")
 
 
 def _json_default(value: Any) -> str:
@@ -65,6 +66,16 @@ def _public_safe_label(value: Any, *, limit: int = 80) -> str:
     return label[:limit]
 
 
+def _app_server_goal_prompt_style(args: argparse.Namespace) -> str:
+    style = str(
+        getattr(args, "app_server_goal_prompt_style", "native-goal")
+        or "native-goal"
+    )
+    if style in APP_SERVER_GOAL_PROMPT_STYLES:
+        return style
+    return "native-goal"
+
+
 def build_contract_payload(args: argparse.Namespace) -> dict[str, Any]:
     return build_skillsbench_app_server_goal_worker_contract(
         dataset=args.dataset,
@@ -72,6 +83,7 @@ def build_contract_payload(args: argparse.Namespace) -> dict[str, Any]:
         cwd="<skillsbench-task-workspace>",
         model=args.model,
         reasoning_effort=args.reasoning_effort,
+        prompt_style=_app_server_goal_prompt_style(args),
         codex_bin=args.codex_bin,
         sandbox=args.sandbox,
         approval_policy=args.approval_policy,
@@ -85,6 +97,8 @@ def build_contract_payload(args: argparse.Namespace) -> dict[str, Any]:
 def build_loopx_case_lifecycle_packet(
     args: argparse.Namespace,
 ) -> tuple[str, dict[str, object] | None]:
+    if _app_server_goal_prompt_style(args) == "cli-exec-like":
+        return "", None
     if args.loopx_mode != "codex_loopx":
         return "", None
     if args.loopx_access_packet_mode == "none":
@@ -216,6 +230,7 @@ def _compact_worker_turn(
             "assistant_message_context_only": _assistant_message_context_only(turn),
             "post_context_assistant_chars": _post_context_assistant_chars(turn),
             "reasoning_effort": _public_safe_label(args.reasoning_effort) or "high",
+            "app_server_goal_prompt_style": _app_server_goal_prompt_style(args),
             "loopx_mode": args.loopx_mode,
             "loopx_access_packet_mode": args.loopx_access_packet_mode,
             "loopx_case_lifecycle_packet_injected": bool(lifecycle_packet),
@@ -268,10 +283,7 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
     objective = args.objective or f"Complete SkillsBench task {args.task_id}"
     work_dir.mkdir(parents=True, exist_ok=True)
     lifecycle_packet, lifecycle_contract = build_loopx_case_lifecycle_packet(args)
-    effective_prompt = _prompt_with_loopx_case_lifecycle_packet(
-        prompt,
-        lifecycle_packet,
-    )
+    effective_prompt = _prompt_with_loopx_case_lifecycle_packet(prompt, lifecycle_packet)
     turn = start_codex_app_server_goal_turn(
         codex_bin=args.codex_bin,
         work_dir=work_dir,
@@ -504,6 +516,7 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
         "rollout_name": args.rollout_name,
         "loopx_mode": args.loopx_mode,
         "loopx_access_packet_mode": args.loopx_access_packet_mode,
+        "app_server_goal_prompt_style": _app_server_goal_prompt_style(args),
         "loopx_case_lifecycle_packet_injected": bool(lifecycle_packet),
         "benchmark_case_lifecycle_contract": lifecycle_contract,
         "worker_contract": worker_contract,
@@ -513,6 +526,7 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
             "effective_sha256": stable_text_digest(effective_prompt),
             "effective_chars": len(effective_prompt),
             "raw_recorded": False,
+            "style": _app_server_goal_prompt_style(args),
         },
         "turn": compact,
         "turn_attempts": attempt_compacts,
@@ -617,6 +631,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--app-server-goal-prompt-style",
+        choices=APP_SERVER_GOAL_PROMPT_STYLES,
+        default="native-goal",
+        help=(
+            "Prompt framing for native app-server Goal worker turns. "
+            "native-goal preserves the current app-server Goal contract; "
+            "cli-exec-like suppresses app-only lifecycle prompt injection so "
+            "canaries can isolate task framing versus Codex exec."
+        ),
+    )
+    parser.add_argument(
         "--no-wait-for-completion",
         action="store_true",
         help=(
@@ -682,6 +707,7 @@ def main(argv: list[str] | None = None) -> int:
             {
                 "loopx_mode": args.loopx_mode,
                 "loopx_access_packet_mode": args.loopx_access_packet_mode,
+                "app_server_goal_prompt_style": _app_server_goal_prompt_style(args),
                 "loopx_case_lifecycle_packet_injected": bool(lifecycle_packet),
                 "benchmark_case_lifecycle_contract": lifecycle_contract,
             }

--- a/scripts/skillsbench_local_acp_relay.py
+++ b/scripts/skillsbench_local_acp_relay.py
@@ -114,6 +114,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--app-server-goal-prompt-style",
+        choices=("native-goal", "cli-exec-like"),
+        default="native-goal",
+        help=(
+            "Prompt framing for --app-server-goal-worker. native-goal keeps "
+            "the app-server closeout/lifecycle framing; cli-exec-like keeps "
+            "the worker prompt closer to the Codex exec bridge prompt for "
+            "diagnostic canaries."
+        ),
+    )
+    parser.add_argument(
         "--bridge-idle-timeout-sec",
         type=float,
         default=0.0,
@@ -209,6 +220,7 @@ def main(argv: list[str] | None = None) -> int:
             stream_heartbeat_interval_sec=args.stream_heartbeat_interval_sec,
             first_action_timeout_sec=args.first_action_timeout_sec,
             app_server_goal_followup_max=args.app_server_goal_followup_max,
+            app_server_goal_prompt_style=args.app_server_goal_prompt_style,
             bridge_idle_timeout_sec=args.bridge_idle_timeout_sec,
             task_output_quiet_timeout_sec=args.task_output_quiet_timeout_sec,
             worker_public_trace_dir=args.worker_public_trace_dir,


### PR DESCRIPTION
## Summary
- add `--app-server-goal-prompt-style {native-goal,cli-exec-like}` for SkillsBench native app-server Goal runs
- pass the style through runner, local ACP relay, host Goal worker, public plan/config, and compact worker trace
- keep default `native-goal` behavior unchanged while enabling a CLI-exec-like diagnostic canary without raw prompt or verifier leakage

## Validation
- `python3 -m py_compile scripts/skillsbench_automation_loop.py scripts/skillsbench_local_acp_relay.py scripts/skillsbench_host_codex_goal_worker.py loopx/benchmark_adapters/skillsbench.py loopx/benchmark_adapters/skillsbench_acp_relay.py examples/skillsbench-app-server-goal-worker-smoke.py examples/repo-python-line-budget-smoke.py`
- `python3 examples/skillsbench-app-server-goal-worker-smoke.py`
- `python3 examples/repo-python-line-budget-smoke.py`
- plan-only probe for `--app-server-goal-prompt-style cli-exec-like` records style in public launch plan and worker adapter contract

## Boundary
- no benchmark run launched
- no raw task text, raw trajectory, verifier output, credentials, proxy address, or local private artifact committed

Follow-up after review/merge: run one jax app-server Goal canary arm with `cli-exec-like` against the existing app-server baseline framing.