### PR TITLE
Add decentralized multi-agent wake prompt

### DIFF
--- a/examples/generic-multi-agent-one-command-smoke.py
+++ b/examples/generic-multi-agent-one-command-smoke.py
@@ -82,6 +82,46 @@ def run_launch_command(
     return json.loads(completed.stdout)
 
 
+def run_wake_command(
+    env: dict[str, str],
+    *,
+    registry: Path,
+    runtime_root: Path,
+    session_name: str,
+    execute: bool,
+    lanes: list[str] | None = None,
+) -> dict[str, object]:
+    command = [
+        sys.executable,
+        "-m",
+        "loopx.cli",
+        "--registry",
+        str(registry),
+        "--runtime-root",
+        str(runtime_root),
+        "--format",
+        "json",
+        "multi-agent",
+        "wake",
+        "--session-name",
+        session_name,
+        "--tmux-bin",
+        "tmux",
+    ]
+    for lane in lanes or []:
+        command.extend(["--lane", lane])
+    if execute:
+        command.append("--execute")
+    completed = subprocess.run(
+        command,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return json.loads(completed.stdout)
+
+
 def assert_public_safe(value: object, label: str) -> None:
     text = json.dumps(value, sort_keys=True).lower()
     leaked = [marker for marker in PRIVATE_MARKERS if marker.lower() in text]
@@ -200,6 +240,13 @@ def main() -> int:
         assert dry_packet["runner_contract"]["runner_surface"] == "tmux_codex_cli_tui", dry_packet
         assert dry_packet["runner_contract"]["coordination_model"]["leader_required"] is False, dry_packet
         assert dry_packet["runner_contract"]["pane_local_a2a"]["tick_command"] == "$LOOPX_PANE_A2A_TICK", dry_packet
+        assert dry_packet["runner_contract"]["pane_local_a2a"]["cadence_wakeup_command"] == (
+            "loopx multi-agent wake --session-name <session>"
+        ), dry_packet
+        assert dry_packet["runner_contract"]["pane_local_a2a"]["cadence_wakeup_model"] == (
+            "fixed_prompt_broadcast"
+        ), dry_packet
+        assert dry_packet["runner_contract"]["pane_local_a2a"]["cadence_broadcaster_decides_work"] is False, dry_packet
         assert dry_packet["runner_contract"]["pane_local_a2a"]["machine_json_destination"] == (
             "$LOOPX_PANE_ARTIFACT_DIR/*.public.json"
         ), dry_packet
@@ -247,6 +294,35 @@ def main() -> int:
         skill_items = launch["worker_skill_materialization"]
         assert skill_items and skill_items[0]["materialized"] is True, launch
         assert (workspace / ".codex" / "skills" / "loopx-planner-worker" / "SKILL.md").is_file()
+        dry_wake = run_wake_command(
+            env,
+            registry=registry,
+            runtime_root=runtime_root,
+            session_name="loopx-generic-multi-agent-smoke",
+            execute=False,
+            lanes=["planner"],
+        )
+        assert dry_wake["schema_version"] == "multi_agent_pane_a2a_wakeup_v0", dry_wake
+        assert dry_wake["mode"] == "dry_run", dry_wake
+        assert dry_wake["target_lanes"] == ["planner"], dry_wake
+        assert dry_wake["coordination_model"] == "decentralized_state_a2a", dry_wake
+        assert dry_wake["wakeup_model"] == "fixed_prompt_broadcast", dry_wake
+        assert dry_wake["workflow_driver"] is False, dry_wake
+        assert dry_wake["broadcaster_reads_frontier"] is False, dry_wake
+        assert dry_wake["broadcaster_selects_todo"] is False, dry_wake
+        assert "$LOOPX_PANE_A2A_TICK" in dry_wake["prompt"], dry_wake
+        assert "\n" not in dry_wake["prompt"], dry_wake
+        exec_wake = run_wake_command(
+            env,
+            registry=registry,
+            runtime_root=runtime_root,
+            session_name="loopx-generic-multi-agent-smoke",
+            execute=True,
+        )
+        assert exec_wake["mode"] == "execute", exec_wake
+        assert exec_wake["target_lanes"] == ["planner", "critic"], exec_wake
+        assert exec_wake["boundary"]["writes_loopx_state"] is False, exec_wake
+        assert exec_wake["boundary"]["runs_worker_turn_directly"] is False, exec_wake
         assert_public_safe(
             {
                 "product_spec": exec_packet["product_spec"],
@@ -260,7 +336,11 @@ def main() -> int:
         )
 
         log_entries = [json.loads(line) for line in tmux_log.read_text(encoding="utf-8").splitlines()]
-        env_snapshots = [entry["env"] for entry in log_entries]
+        env_snapshots = [
+            entry["env"]
+            for entry in log_entries
+            if entry["env"].get("LOOPX_REGISTRY")
+        ]
         assert env_snapshots, log_entries
         for snapshot in env_snapshots:
             assert snapshot["LOOPX_REGISTRY"] == str(registry), snapshot
@@ -283,6 +363,11 @@ def main() -> int:
         assert all("exec python3 -c" in command for command in start_payloads), start_payloads
         assert all("LOOPX_PANE_ARTIFACT_DIR" in command for command in start_payloads), start_payloads
         assert all("codex exec" not in command for command in start_payloads), start_payloads
+        wake_entries = [entry["argv"] for entry in log_entries if entry["argv"][:1] in (["set-buffer"], ["paste-buffer"], ["send-keys"])]
+        assert any(entry[:1] == ["set-buffer"] for entry in wake_entries), wake_entries
+        assert sum(1 for entry in wake_entries if entry[:1] == ["paste-buffer"]) == 2, wake_entries
+        assert sum(1 for entry in wake_entries if entry[:1] == ["send-keys"] and entry[-1] == "Enter") == 2, wake_entries
+        assert any("$LOOPX_PANE_A2A_TICK" in " ".join(entry) for entry in wake_entries), wake_entries
         launcher_source = (ROOT / "loopx/visible_multi_agent_launcher.py").read_text(
             encoding="utf-8"
         )

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -162,6 +162,11 @@ def main() -> int:
     assert runner_contract["tmux_lifecycle"]["attach_command"] == dry_packet["commands"]["attach"]
     assert runner_contract["tmux_lifecycle"]["stop_command"] == dry_packet["commands"]["stop"]
     assert runner_contract["pane_local_a2a"]["tick_command"] == "$LOOPX_PANE_A2A_TICK"
+    assert runner_contract["pane_local_a2a"]["cadence_wakeup_command"] == (
+        "loopx multi-agent wake --session-name <session>"
+    )
+    assert runner_contract["pane_local_a2a"]["cadence_wakeup_model"] == "fixed_prompt_broadcast"
+    assert runner_contract["pane_local_a2a"]["cadence_broadcaster_decides_work"] is False
     assert runner_contract["pane_local_a2a"]["first_action"] == (
         "launcher runs $LOOPX_PANE_A2A_TICK before Codex TUI opens"
     )

--- a/loopx/capabilities/multi_agent/contract.py
+++ b/loopx/capabilities/multi_agent/contract.py
@@ -195,6 +195,9 @@ def build_tui_multi_agent_runner_contract(
         "pane_local_a2a": {
             "tick_command": "$LOOPX_PANE_A2A_TICK",
             "first_action": "launcher runs $LOOPX_PANE_A2A_TICK before Codex TUI opens",
+            "cadence_wakeup_command": "loopx multi-agent wake --session-name <session>",
+            "cadence_wakeup_model": "fixed_prompt_broadcast",
+            "cadence_broadcaster_decides_work": False,
             "reads": ["quota should-run", "agent-scoped frontier"],
             "runs": ["LOOPX_PANE_WORKER_TURN", "LOOPX_PANE_WORKER_LOOP"],
             "bounded_rounds_env": "LOOPX_PANE_TICK_ROUNDS",

--- a/loopx/cli_commands/multi_agent.py
+++ b/loopx/cli_commands/multi_agent.py
@@ -10,6 +10,7 @@ from ..paths import resolve_runtime_root
 from ..visible_multi_agent_launcher import (
     build_visible_multi_agent_payload_from_spec,
     execute_visible_multi_agent_launcher,
+    wake_visible_multi_agent_panes,
 )
 
 
@@ -53,6 +54,20 @@ def register_multi_agent_commands(
         default=False,
         help="Pass a trusted project config to each Codex TUI lane.",
     )
+    wake = multi_agent_sub.add_parser(
+        "wake",
+        help="Broadcast the fixed pane-local A2A prompt to live visible Codex TUI panes.",
+    )
+    add_subcommand_format(wake)
+    wake.add_argument("--session-name", required=True, help="tmux session to wake.")
+    wake.add_argument(
+        "--lane",
+        action="append",
+        default=[],
+        help="Specific pane/window name to wake. Repeat to target multiple panes. Omit with --execute to list the session windows.",
+    )
+    wake.add_argument("--tmux-bin", default="tmux")
+    wake.add_argument("--execute", action="store_true", help="Send the fixed prompt to tmux panes.")
 
 
 def _load_spec(path: Path) -> dict[str, object]:
@@ -96,6 +111,21 @@ def _render_multi_agent_launch_markdown(payload: dict[str, object]) -> str:
     return "\n".join(lines)
 
 
+def _render_multi_agent_wake_markdown(payload: dict[str, object]) -> str:
+    if not payload.get("ok"):
+        return f"LoopX multi-agent wake failed: {payload.get('error')}"
+    lines = [
+        "# LoopX Multi-Agent Wake",
+        f"- mode: {payload.get('mode')}",
+        f"- session: {payload.get('session_name')}",
+        f"- wakeup_model: {payload.get('wakeup_model')}",
+        f"- coordination_model: {payload.get('coordination_model')}",
+        f"- workflow_driver: {payload.get('workflow_driver')}",
+        f"- target_lanes: {', '.join(str(item) for item in payload.get('target_lanes') or [])}",
+    ]
+    return "\n".join(lines)
+
+
 def handle_multi_agent_command(
     args: argparse.Namespace,
     *,
@@ -107,8 +137,17 @@ def handle_multi_agent_command(
     if args.command != "multi-agent":
         return None
     try:
+        if args.multi_agent_command == "wake":
+            payload = wake_visible_multi_agent_panes(
+                session_name=args.session_name,
+                tmux_bin=args.tmux_bin,
+                lanes=args.lane,
+                execute=bool(args.execute),
+            )
+            print_payload(payload, output_format(args), _render_multi_agent_wake_markdown)
+            return 0
         if args.multi_agent_command != "launch":
-            raise ValueError("multi-agent requires the `launch` subcommand")
+            raise ValueError("multi-agent requires the `launch` or `wake` subcommand")
         spec_path = Path(args.spec).expanduser()
         spec = _load_spec(spec_path)
         if args.session_name:

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -7,6 +7,7 @@ import shutil
 import subprocess
 import time
 from collections.abc import Iterable
+from hashlib import sha256
 from pathlib import Path
 
 from .capabilities.multi_agent.contract import (
@@ -32,11 +33,103 @@ def _q(value: object) -> str:
     return shlex.quote(str(value))
 
 
+PANE_A2A_WAKEUP_SCHEMA_VERSION = "multi_agent_pane_a2a_wakeup_v0"
+PANE_A2A_WAKEUP_PROMPT = (
+    "LoopX pane-local A2A wakeup: run $LOOPX_PANE_A2A_TICK now. "
+    "Use only your own LOOPX_GOAL_ID/LOOPX_AGENT_ID quota/frontier; "
+    "if no runnable frontier, stay quiet with a brief no-action note; "
+    "if advanced, summarize public evidence and next handoff. "
+    "Do not ask the broadcaster for direction; LoopX state is the source of truth."
+)
+
+
 def require_executable(command: str, *, field: str) -> str:
     path = shutil.which(command)
     if not path:
         raise ValueError(f"{field} executable not found on PATH: {command}")
     return path
+
+
+def build_pane_a2a_wakeup_prompt() -> str:
+    """Return the fixed prompt broadcast to live Codex TUI panes."""
+
+    return PANE_A2A_WAKEUP_PROMPT
+
+
+def wake_visible_multi_agent_panes(
+    *,
+    session_name: str,
+    tmux_bin: str = "tmux",
+    lanes: Iterable[str] | None = None,
+    execute: bool = False,
+    prompt: str | None = None,
+) -> dict[str, object]:
+    """Broadcast the fixed A2A prompt; each pane still decides via LoopX state."""
+
+    session = str(session_name or "").strip()
+    if not session:
+        raise ValueError("multi-agent wake requires --session-name")
+    prompt_text = str(prompt or build_pane_a2a_wakeup_prompt()).strip()
+    if not prompt_text:
+        raise ValueError("multi-agent wake prompt must not be empty")
+    prompt_hash = sha256(prompt_text.encode("utf-8")).hexdigest()[:16]
+    target_lanes = [str(lane).strip() for lane in lanes or [] if str(lane).strip()]
+
+    if execute:
+        require_executable(tmux_bin, field="tmux_bin")
+        env = os.environ.copy()
+        if not target_lanes:
+            listed = subprocess.run(
+                [tmux_bin, "list-windows", "-t", session, "-F", "#{window_name}"],
+                check=True,
+                capture_output=True,
+                text=True,
+                env=env,
+            )
+            target_lanes = [line.strip() for line in listed.stdout.splitlines() if line.strip()]
+        if not target_lanes:
+            raise ValueError("multi-agent wake found no target panes")
+        buffer_name = f"loopx-pane-a2a-wakeup-{prompt_hash}"
+        subprocess.run(
+            [tmux_bin, "set-buffer", "-b", buffer_name, "--", prompt_text],
+            check=True,
+            env=env,
+        )
+        for lane in target_lanes:
+            target = f"{session}:{lane}"
+            subprocess.run(
+                [tmux_bin, "paste-buffer", "-b", buffer_name, "-t", target],
+                check=True,
+                env=env,
+            )
+            subprocess.run(
+                [tmux_bin, "send-keys", "-t", target, "Enter"],
+                check=True,
+                env=env,
+            )
+
+    return {
+        "ok": True,
+        "schema_version": PANE_A2A_WAKEUP_SCHEMA_VERSION,
+        "mode": "execute" if execute else "dry_run",
+        "session_name": session,
+        "target_lanes": target_lanes if target_lanes else ["<all-session-windows>"],
+        "prompt": prompt_text,
+        "prompt_hash": prompt_hash,
+        "coordination_model": "decentralized_state_a2a",
+        "wakeup_model": "fixed_prompt_broadcast",
+        "workflow_driver": False,
+        "broadcaster_reads_frontier": False,
+        "broadcaster_selects_todo": False,
+        "pane_decision_owner": "codex_tui_agent_via_loopx_state",
+        "boundary": {
+            "writes_loopx_state": False,
+            "spends_loopx_quota": False,
+            "reads_raw_transcripts": False,
+            "reads_credentials": False,
+            "runs_worker_turn_directly": False,
+        },
+    }
 
 
 def _codex_config_path() -> Path:


### PR DESCRIPTION
## Summary
- add `loopx multi-agent wake` to broadcast a fixed pane-local A2A prompt into live Codex TUI panes
- declare the fixed-prompt cadence model in the generic multi-agent runner contract
- cover dry-run and tmux execution with generic/visible multi-agent smokes

## Product boundary
- broadcaster only wakes panes; it does not read frontier, select todos, run worker-turns, write LoopX state, or spend quota
- each Codex pane remains the decision owner through its own `$LOOPX_PANE_A2A_TICK`

## Validation
- `python3 -m py_compile loopx/visible_multi_agent_launcher.py loopx/cli_commands/multi_agent.py loopx/capabilities/multi_agent/contract.py`
- `python3 examples/generic-multi-agent-one-command-smoke.py`
- `python3 examples/visible-multi-agent-launcher-smoke.py`
- `python3 examples/generic-multi-agent-spec-contract-smoke.py`
- `python3 examples/auto-research-demo-supervisor-smoke.py`
- `python3 examples/auto-research-demo-e2e-worker-loop-smoke.py`
- `git diff --check`
