### PR TITLE
Wire auto-research visible wake acceptance

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -241,6 +241,33 @@ def main() -> int:
                 "boundary": {"reads_raw_transcripts": False},
             }
 
+        def visible_wake(session: str, lanes: list[str]) -> dict[str, object]:
+            assert session == session_name, session
+            assert lanes == [], lanes
+            target_lanes = lanes or ["<all-session-windows>"]
+            return {
+                "ok": True,
+                "schema_version": "multi_agent_pane_a2a_wakeup_v0",
+                "mode": "execute",
+                "session_name": session,
+                "target_lanes": target_lanes,
+                "prompt": "LoopX pane-local A2A wakeup: run $LOOPX_PANE_A2A_TICK now.",
+                "prompt_hash": "wakehash",
+                "coordination_model": "decentralized_state_a2a",
+                "wakeup_model": "fixed_prompt_broadcast",
+                "workflow_driver": False,
+                "broadcaster_reads_frontier": False,
+                "broadcaster_selects_todo": False,
+                "pane_decision_owner": "codex_tui_agent_via_loopx_state",
+                "boundary": {
+                    "writes_loopx_state": False,
+                    "spends_loopx_quota": False,
+                    "reads_raw_transcripts": False,
+                    "reads_credentials": False,
+                    "runs_worker_turn_directly": False,
+                },
+            }
+
         visible_loaded_payload = run_auto_research_demo_e2e(
             agent_id=AGENT_ID,
             goal_id=GOAL_ID,
@@ -260,15 +287,20 @@ def main() -> int:
             live_evidence_path=None,
             append_evidence=lambda _path: {"ok": True},
             visible_launcher=visible_launcher,
+            visible_wake=visible_wake,
+            wake_visible_after_launch=True,
             visible_live_evidence_wait_seconds=0,
         )
         visible_loaded_proof = visible_loaded_payload["visible_worker_proof"]
         visible_loaded_evidence = visible_loaded_payload["live_worker_evidence"]
         visible_loaded_rounds = visible_loaded_payload["visible_pane_a2a_rounds"]
+        visible_loaded_wake = visible_loaded_payload["visible_wake"]
         assert visible_loaded_proof["lane_authored_evidence_loaded"] is True, visible_loaded_payload
         assert visible_loaded_proof["pane_local_a2a_rounds_loaded"] is True, visible_loaded_payload
         assert visible_loaded_proof["pane_local_a2a_round_count"] == 2, visible_loaded_payload
         assert visible_loaded_proof["decentralized_a2a_rounds_verified"] is True, visible_loaded_payload
+        assert visible_loaded_proof["cadence_wake_loaded"] is True, visible_loaded_payload
+        assert visible_loaded_proof["cadence_wake_verified"] is True, visible_loaded_payload
         assert visible_loaded_proof["evidence_source"] == "visible_launcher_artifact", visible_loaded_payload
         assert visible_loaded_evidence["loaded"] is True, visible_loaded_payload
         assert visible_loaded_evidence["agent_id"] == "codex-live-lane", visible_loaded_payload
@@ -278,6 +310,11 @@ def main() -> int:
         assert visible_loaded_rounds["workflow_driver"] is False, visible_loaded_rounds
         assert visible_loaded_rounds["max_rounds_completed"] == 2, visible_loaded_rounds
         assert visible_loaded_rounds["multi_round_verified"] is True, visible_loaded_rounds
+        assert visible_loaded_wake["wakeup_model"] == "fixed_prompt_broadcast", visible_loaded_wake
+        assert visible_loaded_wake["coordination_model"] == "decentralized_state_a2a", visible_loaded_wake
+        assert visible_loaded_wake["workflow_driver"] is False, visible_loaded_wake
+        assert visible_loaded_wake["broadcaster_reads_frontier"] is False, visible_loaded_wake
+        assert visible_loaded_wake["broadcaster_selects_todo"] is False, visible_loaded_wake
         assert_public_safe(visible_loaded_payload)
 
     loop_markdown = render_auto_research_markdown(
@@ -448,6 +485,7 @@ def main() -> int:
                         "worker-skill-visible-smoke",
                         "--execute",
                         "--no-attach",
+                        "--wake-visible-after-launch",
                         "--replace-existing",
                         "--session-name",
                         session_name,
@@ -486,6 +524,8 @@ def main() -> int:
                 assert visible_proof["pane_local_a2a_rounds_loaded"] is True, visible_proof
                 assert visible_proof["pane_local_a2a_round_count"] >= 2, visible_proof
                 assert visible_proof["decentralized_a2a_rounds_verified"] is True, visible_proof
+                assert visible_proof["cadence_wake_loaded"] is True, visible_proof
+                assert visible_proof["cadence_wake_verified"] is True, visible_proof
                 live_evidence = visible_payload["live_worker_evidence"]
                 assert live_evidence["loaded"] is True, live_evidence
                 assert live_evidence["source"] == "live_codex_lane_output", live_evidence
@@ -496,6 +536,20 @@ def main() -> int:
                 assert visible_rounds["workflow_driver"] is False, visible_rounds
                 assert visible_rounds["max_rounds_completed"] >= 2, visible_rounds
                 assert visible_rounds["multi_round_verified"] is True, visible_rounds
+                visible_wake = visible_payload["visible_wake"]
+                assert visible_wake["schema_version"] == "multi_agent_pane_a2a_wakeup_v0", visible_wake
+                assert visible_wake["mode"] == "execute", visible_wake
+                assert visible_wake["target_lanes"] == [
+                    "research-curator",
+                    "hypothesis-mapper",
+                    "evidence-runner",
+                    "evidence-verifier",
+                ], visible_wake
+                assert visible_wake["wakeup_model"] == "fixed_prompt_broadcast", visible_wake
+                assert visible_wake["coordination_model"] == "decentralized_state_a2a", visible_wake
+                assert visible_wake["workflow_driver"] is False, visible_wake
+                assert visible_wake["broadcaster_reads_frontier"] is False, visible_wake
+                assert visible_wake["broadcaster_selects_todo"] is False, visible_wake
                 launch = visible_payload["visible_launch"]["launch_result"]
                 assert launch["started_lane_count"] == 4, visible_payload
                 assert "frontier" not in launch["started_lanes"], visible_payload

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -34,7 +34,10 @@ from ...paths import resolve_runtime_root
 from ...quota import build_quota_should_run
 from ...rollout_event_log import load_rollout_events, rollout_event_log_path
 from ...status import collect_status
-from ...visible_multi_agent_launcher import execute_visible_multi_agent_launcher
+from ...visible_multi_agent_launcher import (
+    execute_visible_multi_agent_launcher,
+    wake_visible_multi_agent_panes,
+)
 
 
 PrintPayload = Callable[
@@ -486,6 +489,14 @@ def register_auto_research_commands(
         help=argparse.SUPPRESS,
     )
     demo_e2e_parser.add_argument(
+        "--wake-visible-after-launch",
+        action="store_true",
+        help=(
+            "After starting visible tmux panes, broadcast the fixed pane-local A2A "
+            "wake prompt. Each pane still runs its own LoopX tick from state."
+        ),
+    )
+    demo_e2e_parser.add_argument(
         "--keep-workspace",
         action="store_true",
         help="Keep the temporary demo workspace after execution. The output payload still redacts its absolute path.",
@@ -807,11 +818,24 @@ def handle_auto_research_command(
                 )
 
             visible_launcher: Callable[[dict[str, object], Path, str | None, Path], dict[str, object]] | None = None
+            visible_wake: Callable[[str, list[str]], dict[str, object]] | None = None
             auto_visible_launch = bool(args.execute and not args.headless)
             launch_visible = bool(args.launch_visible or auto_visible_launch)
-            attach_visible = bool(args.attach or (auto_visible_launch and not args.no_attach))
             if args.no_attach and args.attach:
                 raise ValueError("--attach cannot be combined with --no-attach")
+            if args.wake_visible_after_launch and args.attach:
+                raise ValueError(
+                    "--wake-visible-after-launch cannot be combined with --attach; "
+                    "wake evidence must be recorded before operator takeover"
+                )
+            attach_visible = bool(
+                args.attach
+                or (
+                    auto_visible_launch
+                    and not args.no_attach
+                    and not args.wake_visible_after_launch
+                )
+            )
             if launch_visible:
                 def visible_launcher(
                     supervisor: dict[str, object],
@@ -845,6 +869,13 @@ def handle_auto_research_command(
                         create_workspace=create_visible_workspace,
                         codex_trust_workspace=codex_trust_workspace,
                     )
+                def visible_wake(session: str, lanes: list[str]) -> dict[str, object]:
+                    return wake_visible_multi_agent_panes(
+                        session_name=session,
+                        tmux_bin=args.tmux_bin,
+                        lanes=lanes,
+                        execute=True,
+                    )
 
             run_hidden_worker_loop = bool(args.execute and (args.headless or args.run_worker_loop))
             payload = run_auto_research_demo_e2e(
@@ -870,6 +901,8 @@ def handle_auto_research_command(
                 live_evidence_path=args.live_evidence,
                 append_evidence=append_demo_e2e_evidence,
                 visible_launcher=visible_launcher,
+                visible_wake=visible_wake,
+                wake_visible_after_launch=bool(args.wake_visible_after_launch),
                 visible_live_evidence_wait_seconds=args.visible_live_evidence_wait_seconds,
             )
         else:

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -21,6 +21,7 @@ from .worker_loop import run_auto_research_worker_loop
 
 AppendEvidence = Callable[[str], dict[str, object]]
 VisibleLauncher = Callable[..., dict[str, object]]
+VisibleWake = Callable[[str, Sequence[str]], dict[str, object]]
 
 AUTO_RESEARCH_DEMO_E2E_SCHEMA_VERSION = "auto_research_demo_e2e_result_v0"
 
@@ -265,6 +266,8 @@ def _visible_worker_proof(*, launch_visible: bool) -> dict[str, object]:
         "pane_local_a2a_rounds_loaded": False,
         "pane_local_a2a_round_count": 0,
         "decentralized_a2a_rounds_verified": False,
+        "cadence_wake_loaded": False,
+        "cadence_wake_verified": False,
         "visible_lanes_launched": bool(launch_visible),
         "visible_lanes_accepted": False,
         "evidence_source": "not_loaded",
@@ -531,6 +534,38 @@ def _load_visible_pane_a2a_rounds_into_payload(
         )
 
 
+def _load_visible_wake_into_payload(
+    *,
+    payload: dict[str, object],
+    wake: dict[str, object],
+) -> None:
+    payload["visible_wake"] = {
+        "schema_version": wake.get("schema_version"),
+        "mode": wake.get("mode"),
+        "session_name": wake.get("session_name"),
+        "target_lanes": wake.get("target_lanes"),
+        "prompt_hash": wake.get("prompt_hash"),
+        "coordination_model": wake.get("coordination_model"),
+        "wakeup_model": wake.get("wakeup_model"),
+        "workflow_driver": bool(wake.get("workflow_driver")),
+        "broadcaster_reads_frontier": bool(wake.get("broadcaster_reads_frontier")),
+        "broadcaster_selects_todo": bool(wake.get("broadcaster_selects_todo")),
+        "pane_decision_owner": wake.get("pane_decision_owner"),
+        "boundary": wake.get("boundary"),
+    }
+    visible_proof = payload["visible_worker_proof"]
+    if isinstance(visible_proof, dict):
+        visible_proof["cadence_wake_loaded"] = True
+        visible_proof["cadence_wake_verified"] = (
+            wake.get("mode") == "execute"
+            and wake.get("coordination_model") == "decentralized_state_a2a"
+            and wake.get("wakeup_model") == "fixed_prompt_broadcast"
+            and wake.get("workflow_driver") is False
+            and wake.get("broadcaster_reads_frontier") is False
+            and wake.get("broadcaster_selects_todo") is False
+        )
+
+
 def run_auto_research_demo_e2e(
     *,
     agent_id: str,
@@ -551,6 +586,8 @@ def run_auto_research_demo_e2e(
     live_evidence_path: str | None,
     append_evidence: AppendEvidence,
     visible_launcher: VisibleLauncher | None = None,
+    visible_wake: VisibleWake | None = None,
+    wake_visible_after_launch: bool = False,
     goal_surface_mode: str = "explicit_goal",
     agent_specs: Sequence[str] | None = None,
     run_worker_loop: bool = False,
@@ -565,6 +602,10 @@ def run_auto_research_demo_e2e(
         raise ValueError("--worker-loop-rounds must be >= 1")
     if launch_visible and visible_launcher is None:
         raise ValueError("--launch-visible requires a visible launcher callback")
+    if wake_visible_after_launch and not launch_visible:
+        raise ValueError("--wake-visible-after-launch requires --launch-visible")
+    if wake_visible_after_launch and visible_wake is None:
+        raise ValueError("--wake-visible-after-launch requires a visible wake callback")
     if live_evidence_path and not execute:
         raise ValueError("--live-evidence requires --execute")
 
@@ -671,6 +712,10 @@ def run_auto_research_demo_e2e(
                 execute=True,
                 live_evidence=True,
                 tracking_goal_id=tracking_goal or None,
+            ),
+            "wake_visible_lanes": (
+                f"{shlex.quote(cli_bin)} --format json multi-agent wake --session-name "
+                f"{shlex.quote(session_name)} --execute"
             ),
         },
         "supervisor": _supervisor_summary(supervisor),
@@ -842,6 +887,20 @@ def run_auto_research_demo_e2e(
                 visible_proof["visible_lanes_launched"] = True
                 visible_proof["visible_lanes_accepted"] = bool(visible_acceptance.get("accepted"))
                 visible_proof["evidence_source"] = "visible_launcher"
+            if wake_visible_after_launch and visible_wake is not None:
+                lane_ids = [
+                    str(lane).strip()
+                    for lane in launch_result.get("started_lanes") or []
+                    if str(lane).strip()
+                ]
+                wake_payload = visible_wake(
+                    str(launch_result.get("session_name") or session_name),
+                    lane_ids,
+                )
+                _load_visible_wake_into_payload(
+                    payload=payload,
+                    wake=wake_payload,
+                )
             pane_rounds = _discover_visible_pane_a2a_rounds(
                 runtime_root_arg=visible_runtime_root_arg,
                 session_name=str(launch_result.get("session_name") or session_name),


### PR DESCRIPTION
## Summary
- Add an optional `--wake-visible-after-launch` demo-e2e path that broadcasts the fixed pane-local A2A wake prompt after visible Codex panes start.
- Record compact `visible_wake` proof in auto-research demo payloads without exposing the raw prompt, raw pane transcripts, or local paths.
- Extend the demo-e2e smoke so visible multi-round evidence now proves both pane-local A2A rounds and the decentralized fixed-prompt cadence wake boundary.

## Boundary
- The broadcaster does not read frontier, select todos, run worker turns directly, write LoopX state, or spend quota.
- Each pane remains responsible for running `$LOOPX_PANE_A2A_TICK` from its own LoopX state.
- `--wake-visible-after-launch` avoids attach during evidence capture; users can attach with the returned tmux command after the payload is written.

## Validation
- `python3 -m py_compile loopx/capabilities/auto_research/demo_e2e.py loopx/capabilities/auto_research/cli.py examples/auto-research-demo-e2e-worker-loop-smoke.py`
- `python3 examples/auto-research-demo-e2e-worker-loop-smoke.py`
- `python3 examples/auto-research-layered-e2e-acceptance-smoke.py`
- `python3 examples/auto-research-demo-supervisor-smoke.py`
- `python3 examples/generic-multi-agent-one-command-smoke.py`
- `python3 examples/generic-multi-agent-spec-contract-smoke.py`
- `git diff --check`
