### PR TITLE
Summarize auto-research visible readiness

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -295,6 +295,7 @@ def main() -> int:
         visible_loaded_evidence = visible_loaded_payload["live_worker_evidence"]
         visible_loaded_rounds = visible_loaded_payload["visible_pane_a2a_rounds"]
         visible_loaded_wake = visible_loaded_payload["visible_wake"]
+        visible_loaded_readiness = visible_loaded_payload["visible_readiness"]
         assert visible_loaded_proof["lane_authored_evidence_loaded"] is True, visible_loaded_payload
         assert visible_loaded_proof["pane_local_a2a_rounds_loaded"] is True, visible_loaded_payload
         assert visible_loaded_proof["pane_local_a2a_round_count"] == 2, visible_loaded_payload
@@ -315,6 +316,23 @@ def main() -> int:
         assert visible_loaded_wake["workflow_driver"] is False, visible_loaded_wake
         assert visible_loaded_wake["broadcaster_reads_frontier"] is False, visible_loaded_wake
         assert visible_loaded_wake["broadcaster_selects_todo"] is False, visible_loaded_wake
+        assert visible_loaded_readiness["ready"] is True, visible_loaded_readiness
+        assert visible_loaded_readiness["manual_artifact_inspection_required"] is False, visible_loaded_readiness
+        assert visible_loaded_readiness["wake_model"] == "fixed_prompt_broadcast", visible_loaded_readiness
+        assert visible_loaded_readiness["workflow_model"] == (
+            "fixed_prompt_wakeup_plus_pane_local_state_tick"
+        ), visible_loaded_readiness
+        assert visible_loaded_readiness["checks"]["workflow_driver_false"] is True, visible_loaded_readiness
+        loaded_improvement = visible_loaded_readiness["improvement_summary"]
+        assert loaded_improvement["baseline_metric"] == 1.0, loaded_improvement
+        assert loaded_improvement["round_1_dev_metric"] == 4.0, loaded_improvement
+        assert loaded_improvement["round_2_holdout_metric"] == 4.5, loaded_improvement
+        assert loaded_improvement["best_metric_source"] == "round_2_holdout", loaded_improvement
+        assert loaded_improvement["holdout_delta_over_dev"] == 0.5, loaded_improvement
+        assert "--wake-visible-after-launch" in visible_loaded_readiness["one_command"], visible_loaded_readiness
+        visible_loaded_markdown = render_auto_research_markdown(visible_loaded_payload)
+        assert "- visible_readiness_ready: `True`" in visible_loaded_markdown, visible_loaded_markdown
+        assert "- visible_best_metric: `4.5`" in visible_loaded_markdown, visible_loaded_markdown
         assert_public_safe(visible_loaded_payload)
 
     loop_markdown = render_auto_research_markdown(
@@ -509,6 +527,7 @@ def main() -> int:
                 assert visible_payload["result_source"] == "visible_worker_launcher", visible_payload
                 assert "worker_loop" not in visible_payload, visible_payload
                 assert "tonight_experience" not in visible_payload, visible_payload
+                assert "visible_readiness" in visible_payload, visible_payload
                 visible_supervisor = visible_payload["supervisor"]
                 assert visible_supervisor["uses_generic_runner"] is True, visible_supervisor
                 assert visible_supervisor["machine_json_policy"] == "artifact_only_in_visible_panes", visible_supervisor
@@ -550,6 +569,34 @@ def main() -> int:
                 assert visible_wake["workflow_driver"] is False, visible_wake
                 assert visible_wake["broadcaster_reads_frontier"] is False, visible_wake
                 assert visible_wake["broadcaster_selects_todo"] is False, visible_wake
+                visible_readiness = visible_payload["visible_readiness"]
+                assert visible_readiness["schema_version"] == "auto_research_visible_readiness_v0", visible_readiness
+                assert visible_readiness["ready"] is True, visible_readiness
+                assert visible_readiness["readiness_level"] == "ready", visible_readiness
+                assert visible_readiness["manual_artifact_inspection_required"] is False, visible_readiness
+                assert visible_readiness["wake_model"] == "fixed_prompt_broadcast", visible_readiness
+                assert visible_readiness["coordination_pattern"] == "decentralized_state_a2a", visible_readiness
+                assert visible_readiness["leader_agent_required"] is False, visible_readiness
+                assert visible_readiness["checks"] == {
+                    "visible_lanes_accepted": True,
+                    "cadence_wake_verified": True,
+                    "pane_local_multi_round_verified": True,
+                    "lane_authored_evidence_loaded": True,
+                    "protected_scope_clean": True,
+                    "positive_metric_over_baseline": True,
+                    "workflow_driver_false": True,
+                }, visible_readiness
+                assert visible_readiness["missing_requirements"] == [], visible_readiness
+                assert visible_readiness["rounds"]["max_completed"] >= 2, visible_readiness
+                improvement = visible_readiness["improvement_summary"]
+                assert improvement["baseline_metric"] == 1.0, improvement
+                assert improvement["round_1_dev_metric"] == 4.0, improvement
+                assert improvement["round_2_holdout_metric"] is None, improvement
+                assert improvement["best_metric"] == 4.0, improvement
+                assert improvement["best_metric_source"] == "round_1_dev", improvement
+                assert improvement["improved_over_baseline"] is True, improvement
+                assert improvement["holdout_delta_over_dev"] is None, improvement
+                assert "--wake-visible-after-launch" in visible_readiness["one_command"], visible_readiness
                 launch = visible_payload["visible_launch"]["launch_result"]
                 assert launch["started_lane_count"] == 4, visible_payload
                 assert "frontier" not in launch["started_lanes"], visible_payload

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -227,6 +227,7 @@ def _command_text(
     attach: bool = False,
     no_attach: bool = False,
     live_evidence: bool = False,
+    wake_visible_after_launch: bool = False,
     tracking_goal_id: str | None = None,
 ) -> str:
     parts = [
@@ -256,6 +257,8 @@ def _command_text(
         parts.append("--no-attach")
     if live_evidence:
         parts.extend(["--live-evidence", "<public-safe-live-evidence.json>"])
+    if wake_visible_after_launch:
+        parts.append("--wake-visible-after-launch")
     return " ".join(parts)
 
 
@@ -566,6 +569,102 @@ def _load_visible_wake_into_payload(
         )
 
 
+def _numeric_metric(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _build_visible_readiness(payload: dict[str, object]) -> dict[str, object]:
+    proof = (
+        payload.get("visible_worker_proof")
+        if isinstance(payload.get("visible_worker_proof"), dict)
+        else {}
+    )
+    rounds = (
+        payload.get("visible_pane_a2a_rounds")
+        if isinstance(payload.get("visible_pane_a2a_rounds"), dict)
+        else {}
+    )
+    evidence = (
+        payload.get("live_worker_evidence")
+        if isinstance(payload.get("live_worker_evidence"), dict)
+        else {}
+    )
+    wake = payload.get("visible_wake") if isinstance(payload.get("visible_wake"), dict) else {}
+    baseline = 1.0
+    dev_metric = _numeric_metric(evidence.get("dev_metric"))
+    holdout_metric = _numeric_metric(evidence.get("holdout_metric"))
+    best_metric = holdout_metric if holdout_metric is not None else dev_metric
+    best_source = (
+        "round_2_holdout"
+        if holdout_metric is not None
+        else "round_1_dev"
+        if dev_metric is not None
+        else None
+    )
+    protected_scope_clean = evidence.get("protected_scope_clean") is True
+    checks = {
+        "visible_lanes_accepted": proof.get("visible_lanes_accepted") is True,
+        "cadence_wake_verified": proof.get("cadence_wake_verified") is True,
+        "pane_local_multi_round_verified": rounds.get("multi_round_verified") is True,
+        "lane_authored_evidence_loaded": proof.get("lane_authored_evidence_loaded") is True,
+        "protected_scope_clean": protected_scope_clean,
+        "positive_metric_over_baseline": (
+            best_metric is not None and best_metric > baseline
+        ),
+        "workflow_driver_false": (
+            rounds.get("workflow_driver") is False and wake.get("workflow_driver") is False
+        ),
+    }
+    ready = all(checks.values())
+    return {
+        "schema_version": "auto_research_visible_readiness_v0",
+        "ready": ready,
+        "readiness_level": "ready" if ready else "collecting_evidence",
+        "one_command": payload.get("commands", {}).get("one_command_visible_wake_demo")
+        if isinstance(payload.get("commands"), dict)
+        else None,
+        "coordination_pattern": "decentralized_state_a2a",
+        "wake_model": wake.get("wakeup_model"),
+        "workflow_model": "fixed_prompt_wakeup_plus_pane_local_state_tick",
+        "leader_agent_required": False,
+        "manual_artifact_inspection_required": not ready,
+        "checks": checks,
+        "missing_requirements": [key for key, passed in checks.items() if not passed],
+        "rounds": {
+            "max_completed": rounds.get("max_rounds_completed"),
+            "total_completed": rounds.get("rounds_completed_total"),
+            "lane_count": rounds.get("lane_count"),
+        },
+        "improvement_summary": {
+            "baseline_metric": baseline,
+            "round_1_dev_metric": dev_metric,
+            "round_2_holdout_metric": holdout_metric,
+            "best_metric": best_metric,
+            "best_metric_source": best_source,
+            "improved_over_baseline": best_metric is not None and best_metric > baseline,
+            "holdout_delta_over_dev": (
+                holdout_metric - dev_metric
+                if holdout_metric is not None and dev_metric is not None
+                else None
+            ),
+        },
+        "public_boundary": {
+            "raw_logs_recorded": False,
+            "private_artifacts_recorded": False,
+            "absolute_paths_recorded": False,
+            "credentials_recorded": False,
+        },
+    }
+
+
+def _load_visible_readiness_into_payload(payload: dict[str, object]) -> None:
+    payload["visible_readiness"] = _build_visible_readiness(payload)
+
+
 def run_auto_research_demo_e2e(
     *,
     agent_id: str,
@@ -691,8 +790,18 @@ def run_auto_research_demo_e2e(
                 goal_id=goal_id,
                 agent_id=agent_id,
                 execute=True,
-                run_worker_loop=True,
+                launch_visible=True,
                 no_attach=True,
+                tracking_goal_id=tracking_goal or None,
+            ),
+            "one_command_visible_wake_demo": _command_text(
+                cli_bin=cli_bin,
+                goal_id=goal_id,
+                agent_id=agent_id,
+                execute=True,
+                launch_visible=True,
+                no_attach=True,
+                wake_visible_after_launch=True,
                 tracking_goal_id=tracking_goal or None,
             ),
             "one_command_worker_loop_with_visible_lanes": _command_text(
@@ -924,6 +1033,7 @@ def run_auto_research_demo_e2e(
                     evidence=live_evidence,
                     evidence_source="visible_launcher_artifact",
                 )
+            _load_visible_readiness_into_payload(payload)
         payload["workspace_retained"] = keep_workspace or launch_visible
         if live_evidence_path:
             live_evidence = load_live_codex_e2e_evidence(

--- a/loopx/capabilities/auto_research/human_view.py
+++ b/loopx/capabilities/auto_research/human_view.py
@@ -133,6 +133,16 @@ def _render_demo_e2e(payload: dict[str, object]) -> str:
         if isinstance(payload.get("visible_pane_a2a_rounds"), dict)
         else {}
     )
+    readiness = (
+        payload.get("visible_readiness")
+        if isinstance(payload.get("visible_readiness"), dict)
+        else {}
+    )
+    improvement = (
+        readiness.get("improvement_summary")
+        if isinstance(readiness.get("improvement_summary"), dict)
+        else {}
+    )
     lines = [
         "# LoopX Auto Research Minimal E2E Demo",
         "",
@@ -158,6 +168,10 @@ def _render_demo_e2e(payload: dict[str, object]) -> str:
         f"- visible_lanes_accepted: `{live.get('visible_lanes_accepted')}`",
         f"- visible_pane_a2a_rounds: `{pane_rounds.get('max_rounds_completed')}`",
         f"- decentralized_a2a_rounds_verified: `{pane_rounds.get('multi_round_verified')}`",
+        f"- visible_readiness_ready: `{readiness.get('ready')}`",
+        f"- visible_readiness_level: `{readiness.get('readiness_level')}`",
+        f"- visible_best_metric: `{improvement.get('best_metric')}`",
+        f"- visible_holdout_delta_over_dev: `{improvement.get('holdout_delta_over_dev')}`",
         f"- supervisor_lanes: `{supervisor.get('lane_count')}`",
     ]
     return "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary
- Add `visible_readiness` to auto-research demo-e2e payloads so the visible path has one compact readiness surface instead of scattered wake/round/evidence fields.
- Summarize fixed-prompt wake, pane-local multi-round A2A, live evidence, metric-over-baseline improvement, missing requirements, and public boundary in one object.
- Render readiness and best metric in the human demo-e2e view.
- Correct the `start_visible_lanes_without_attach` command example to be visible-only and add a one-command visible wake demo command.

## Product Boundary
- This does not make auto-research own runner mechanics; it only aggregates generic runner/kernel evidence.
- The readiness proof still requires `workflow_driver=false`, fixed-prompt wake, visible pane acceptance, pane-local rounds, public live evidence, and metric improvement over baseline.
- No raw pane transcripts, local paths, private artifacts, or credentials are recorded.

## Validation
- `python3 -m py_compile loopx/capabilities/auto_research/demo_e2e.py loopx/capabilities/auto_research/human_view.py examples/auto-research-demo-e2e-worker-loop-smoke.py`
- `python3 examples/auto-research-demo-e2e-worker-loop-smoke.py`
- `python3 examples/auto-research-layered-e2e-acceptance-smoke.py`
- `python3 examples/auto-research-demo-supervisor-smoke.py`
- `python3 examples/generic-multi-agent-one-command-smoke.py`
- `python3 examples/generic-multi-agent-spec-contract-smoke.py`
- `python3 examples/auto-research-worker-turn-smoke.py`
- `python3 examples/auto-research-live-evidence-capture-smoke.py`
- `python3 examples/auto-research-demo-goal-isolation-smoke.py`
- `git diff --check`
