### PR TITLE
Classify SkillsBench verifier bootstrap missing scores

### DIFF
--- a/examples/control_plane/repo-python-line-budget-smoke.py
+++ b/examples/control_plane/repo-python-line-budget-smoke.py
@@ -29,16 +29,16 @@ LEGACY_OVERSIZED_LIMITS = {
     "examples/control_plane/work-lane-contract-smoke.py": 2336,
     "loopx/benchmark_adapters/skillsbench_acp_relay.py": 3144,
     "loopx/benchmark_adapters/terminal_bench.py": 10045,
-    "loopx/benchmark_ledger.py": 3732,
+    "loopx/benchmark_ledger.py": 3745,
     "loopx/capabilities/content_ops/surface.py": 2549,
     "loopx/capabilities/lark/kanban.py": 3034,
     "loopx/codex_cli_probe.py": 3546,
     "loopx/quota.py": 10628,
-    "loopx/status.py": 11745,
+    "loopx/status.py": 11758,
     "loopx/terminal_bench_agent.py": 2056,
     "loopx/todos.py": 2105,
     "scripts/harbor_host_codex_goal_agent.py": 2140,
-    "scripts/skillsbench_automation_loop.py": 16774,
+    "scripts/skillsbench_automation_loop.py": 16791,
 }
 
 

--- a/examples/skillsbench-verifier-bootstrap-missing-score-smoke.py
+++ b/examples/skillsbench-verifier-bootstrap-missing-score-smoke.py
@@ -1,0 +1,153 @@
+#!/usr/bin/env python3
+"""Smoke-test SkillsBench verifier bootstrap missing-score attribution."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.status import compact_benchmark_run  # noqa: E402
+from loopx.benchmark_adapters.skillsbench_verifier_bootstrap import (  # noqa: E402
+    apply_skillsbench_verifier_bootstrap_missing_score_attribution,
+)
+
+
+def _missing_score_compact() -> dict:
+    return {
+        "schema_version": "benchmark_run_v0",
+        "source_runner": "official_skillsbench_benchflow_launch_failure",
+        "mode": "skillsbench_codex_app_server_goal_baseline",
+        "route": "codex-app-server-goal-baseline",
+        "dataset": "skillsbench@1.1",
+        "task_id": "powerlifting-coef-calc",
+        "agent": "codex",
+        "model": "gpt-5.5-codex",
+        "official_score_status": "missing",
+        "official_score": None,
+        "official_task_score": {
+            "kind": "skillsbench_verifier_reward_missing",
+            "value": None,
+            "passed": False,
+        },
+        "score_failure_attribution": "skillsbench_runner_error",
+        "failure_attribution_labels": [
+            "official_score_missing",
+            "skillsbench_runner_setup_error",
+        ],
+        "runner_failure": {
+            "schema_version": "skillsbench_runner_failure_v0",
+            "failure_class": "skillsbench_runner_error",
+            "raw_logs_read": False,
+            "raw_task_text_read": False,
+            "raw_trajectory_read": False,
+        },
+        "validation": {
+            "raw_verifier_output_read": False,
+            "raw_logs_read": False,
+            "raw_task_text_read": False,
+            "raw_trajectory_read": False,
+        },
+    }
+
+
+def _uv_bootstrap_plan() -> dict:
+    return {
+        "task_staging": {
+            "schema_version": "skillsbench_task_staging_v0",
+            "staged": True,
+            "verifier_uv_bootstrap_risk_detected": True,
+            "verifier_uv_bootstrap_mirror_patch_required": True,
+            "verifier_uv_bootstrap_mirror_patch_applied": True,
+            "verifier_uv_bootstrap_pip_fallback_patch_applied": True,
+            "verifier_uv_bootstrap_version": "0.7.13",
+            "verifier_uv_bootstrap_mirror_host": "releases.astral.sh",
+            "original_task_mutated": False,
+        },
+        "task_setup_preflight": {
+            "schema_version": "skillsbench_task_setup_preflight_v0",
+            "status": "verifier_bootstrap_risk_detected",
+            "verifier_uv_bootstrap_risk_detected": True,
+            "raw_task_text_read": False,
+            "raw_logs_read": False,
+            "raw_trajectory_read": False,
+        },
+    }
+
+
+def test_missing_score_uv_bootstrap_risk_gets_verifier_dependency_attribution() -> None:
+    compact = _missing_score_compact()
+    plan = _uv_bootstrap_plan()
+    changed = apply_skillsbench_verifier_bootstrap_missing_score_attribution(
+        compact,
+        task_staging=plan["task_staging"],
+        setup_preflight=plan["task_setup_preflight"],
+    )
+
+    assert changed is True, compact
+    assert compact["official_score_status"] == "missing", compact
+    assert compact["official_score"] is None, compact
+    assert compact["score_failure_attribution"] == (
+        "verifier_dependency_install_failure"
+    ), compact
+    assert compact["verifier_dependency_failure_count"] == 1, compact
+    assert "verifier_dependency_install_failure" in compact[
+        "failure_attribution_labels"
+    ], compact
+    assert "verifier_uv_install_or_download_failure" in compact[
+        "failure_attribution_labels"
+    ], compact
+    diagnostic = compact["verifier_bootstrap_diagnostic"]
+    assert diagnostic["raw_verifier_output_read"] is False, diagnostic
+    assert diagnostic["verifier_uv_bootstrap_version"] == "0.7.13", diagnostic
+    assert (
+        compact["official_task_score"]["kind"]
+        == "skillsbench_verifier_bootstrap_reward_missing"
+    ), compact
+
+    reduced = compact_benchmark_run(compact)
+    assert reduced is not None, compact
+    assert reduced["score_failure_attribution"] == (
+        "verifier_dependency_install_failure"
+    ), reduced
+    assert reduced["verifier_dependency_failure_count"] == 1, reduced
+
+
+def test_completed_score_is_not_reclassified_by_bootstrap_risk() -> None:
+    compact = _missing_score_compact()
+    plan = _uv_bootstrap_plan()
+    compact.update(
+        {
+            "official_score_status": "completed",
+            "official_score": 0.5,
+            "official_task_score": {
+                "kind": "skillsbench_verifier_reward",
+                "value": 0.5,
+                "passed": False,
+            },
+            "score_failure_attribution": "official_verifier_solution_failure",
+            "failure_attribution_labels": ["official_verifier_solution_failure"],
+        }
+    )
+
+    changed = apply_skillsbench_verifier_bootstrap_missing_score_attribution(
+        compact,
+        task_staging=plan["task_staging"],
+        setup_preflight=plan["task_setup_preflight"],
+    )
+
+    assert changed is False, compact
+    assert compact["score_failure_attribution"] == (
+        "official_verifier_solution_failure"
+    ), compact
+    assert "verifier_bootstrap_diagnostic" not in compact, compact
+
+
+if __name__ == "__main__":
+    test_missing_score_uv_bootstrap_risk_gets_verifier_dependency_attribution()
+    test_completed_score_is_not_reclassified_by_bootstrap_risk()
+    print("skillsbench-verifier-bootstrap-missing-score-smoke: ok")

--- a/loopx/benchmark_adapters/skillsbench_verifier_bootstrap.py
+++ b/loopx/benchmark_adapters/skillsbench_verifier_bootstrap.py
@@ -1,0 +1,164 @@
+"""Public-safe SkillsBench verifier bootstrap attribution helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+GENERIC_MISSING_ATTRIBUTIONS = {
+    "",
+    "none",
+    "official_score_missing",
+    "skillsbench_result_json_missing_after_runner_exit",
+    "skillsbench_runner_error",
+    "skillsbench_runner_failed_before_agent_install",
+    "skillsbench_runner_interrupted_before_official_result",
+    "skillsbench_runner_setup_error",
+    "skillsbench_verifier_reward_missing",
+}
+
+GENERIC_MISSING_LABELS = {
+    "official_score_missing",
+    "skillsbench_result_json_missing_after_runner_exit",
+    "skillsbench_runner_error",
+    "skillsbench_runner_failed_before_agent_install",
+    "skillsbench_runner_interrupted_before_official_result",
+    "skillsbench_runner_setup_error",
+    "skillsbench_verifier_reward_missing",
+}
+
+
+def _public_int(value: Any) -> int:
+    return value if isinstance(value, int) and not isinstance(value, bool) else 0
+
+
+def apply_skillsbench_verifier_bootstrap_missing_score_attribution(
+    compact: dict[str, Any],
+    *,
+    task_staging: dict[str, Any] | None = None,
+    setup_preflight: dict[str, Any] | None = None,
+) -> bool:
+    """Classify missing official score when public preflight saw uv bootstrap risk."""
+
+    if compact.get("official_score_status") != "missing":
+        return False
+    if compact.get("official_score") is not None:
+        return False
+
+    task_staging = task_staging if isinstance(task_staging, dict) else {}
+    setup_preflight = setup_preflight if isinstance(setup_preflight, dict) else {}
+    task_score = (
+        compact.get("official_task_score")
+        if isinstance(compact.get("official_task_score"), dict)
+        else {}
+    )
+    score_kind = str(task_score.get("kind") or "")
+    if score_kind and "missing" not in score_kind:
+        return False
+
+    uv_bootstrap_risk = (
+        task_staging.get("verifier_uv_bootstrap_risk_detected") is True
+        or setup_preflight.get("verifier_uv_bootstrap_risk_detected") is True
+    )
+    verifier_bootstrap_blocked = (
+        task_staging.get("verifier_bootstrap_risk_preflight_blocked") is True
+        or setup_preflight.get("first_blocker") == "verifier_bootstrap_risk"
+    )
+    if not (uv_bootstrap_risk or verifier_bootstrap_blocked):
+        return False
+
+    current_attribution = str(compact.get("score_failure_attribution") or "")
+    if current_attribution not in GENERIC_MISSING_ATTRIBUTIONS:
+        return False
+
+    existing_labels = [
+        label
+        for label in compact.get("failure_attribution_labels", [])
+        if isinstance(label, str) and label
+    ]
+    if any(label not in GENERIC_MISSING_LABELS for label in existing_labels):
+        return False
+
+    attribution = "verifier_dependency_install_failure"
+    compact["score_failure_attribution"] = attribution
+    compact["first_blocker"] = attribution
+    compact["repeat_blocked_by"] = attribution
+    compact["official_score_comparable_to_native_codex"] = False
+    compact["official_score_comparable_to_loopx_treatment"] = False
+    compact["verifier_failure_attribution_count"] = max(
+        1,
+        _public_int(compact.get("verifier_failure_attribution_count")),
+    )
+    compact["verifier_dependency_failure_count"] = max(
+        1,
+        _public_int(compact.get("verifier_dependency_failure_count")),
+    )
+
+    labels = list(existing_labels)
+    for label in (
+        attribution,
+        "verifier_uv_install_or_download_failure",
+        "skillsbench_verifier_bootstrap_missing_official_score",
+    ):
+        if label not in labels:
+            labels.append(label)
+    if verifier_bootstrap_blocked:
+        label = "skillsbench_verifier_bootstrap_preflight_blocked"
+        if label not in labels:
+            labels.append(label)
+    compact["failure_attribution_labels"] = labels
+
+    if isinstance(task_score, dict):
+        task_score = dict(task_score)
+        task_score["kind"] = "skillsbench_verifier_bootstrap_reward_missing"
+        task_score["value"] = None
+        task_score["passed"] = False
+        compact["official_task_score"] = task_score
+
+    runner_failure = compact.get("runner_failure")
+    if isinstance(runner_failure, dict):
+        runner_failure["failure_class"] = attribution
+        runner_failure["verifier_bootstrap_missing_score_attributed"] = True
+
+    diagnostic: dict[str, Any] = {
+        "schema_version": "skillsbench_verifier_bootstrap_missing_score_diagnostic_v0",
+        "status": "missing_official_score_with_verifier_bootstrap_risk",
+        "score_failure_attribution": attribution,
+        "verifier_uv_bootstrap_risk_detected": uv_bootstrap_risk,
+        "verifier_bootstrap_risk_preflight_blocked": verifier_bootstrap_blocked,
+        "verifier_uv_bootstrap_mirror_patch_required": task_staging.get(
+            "verifier_uv_bootstrap_mirror_patch_required"
+        )
+        is True,
+        "verifier_uv_bootstrap_mirror_patch_applied": task_staging.get(
+            "verifier_uv_bootstrap_mirror_patch_applied"
+        )
+        is True,
+        "verifier_uv_bootstrap_pip_fallback_patch_applied": task_staging.get(
+            "verifier_uv_bootstrap_pip_fallback_patch_applied"
+        )
+        is True,
+        "raw_verifier_output_read": False,
+        "raw_logs_read": False,
+        "raw_task_text_read": False,
+        "raw_trajectory_read": False,
+        "next_diagnostic_action": "prewarm_or_fail_fast_verifier_bootstrap_before_rerun",
+    }
+    for field in (
+        "verifier_uv_bootstrap_version",
+        "verifier_uv_bootstrap_mirror_host",
+    ):
+        value = task_staging.get(field) or setup_preflight.get(field)
+        if isinstance(value, str) and value:
+            diagnostic[field] = value[:180]
+    compact["verifier_bootstrap_diagnostic"] = diagnostic
+
+    validation = (
+        compact.get("validation")
+        if isinstance(compact.get("validation"), dict)
+        else {}
+    )
+    validation["raw_verifier_output_read"] = False
+    validation["verifier_bootstrap_missing_score_classified"] = True
+    compact["validation"] = validation
+    return True

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -108,6 +108,9 @@ from loopx.benchmark_adapters.skillsbench import (  # noqa: E402
     build_skillsbench_run_permission_policy,
     build_skillsbench_worker_handshake_preflight,
 )
+from loopx.benchmark_adapters.skillsbench_verifier_bootstrap import (  # noqa: E402
+    apply_skillsbench_verifier_bootstrap_missing_score_attribution,
+)
 from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
     SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER,
     SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_PROMPT,
@@ -13871,6 +13874,13 @@ def reduce_result(
                         if item not in existing_labels:
                             existing_labels.append(item)
                     compact["failure_attribution_labels"] = existing_labels
+    apply_skillsbench_verifier_bootstrap_missing_score_attribution(
+        compact,
+        task_staging=task_staging,
+        setup_preflight=_public_task_setup_preflight(
+            plan.get("task_setup_preflight")
+        ),
+    )
     if task_staging:
         compact["task_staging"] = task_staging
     discovery = plan.get("result_discovery")
@@ -14757,6 +14767,13 @@ def build_runner_failure_compact(
     recovered = _recover_runner_failure_score_from_controller_trace(reduced, plan)
     if not recovered:
         _recover_runner_failure_score_from_verifier_artifact(reduced, plan)
+    apply_skillsbench_verifier_bootstrap_missing_score_attribution(
+        reduced,
+        task_staging=_effective_public_task_staging(plan),
+        setup_preflight=_public_task_setup_preflight(
+            plan.get("task_setup_preflight")
+        ),
+    )
     reduced["case_event_timeline"] = _build_case_event_timeline(reduced, plan)
     post_run_debug_gate = build_skillsbench_post_run_debug_gate(reduced)
     reduced["post_run_debug_gate"] = post_run_debug_gate


### PR DESCRIPTION
## Summary
- add a public-safe SkillsBench verifier bootstrap attribution helper for missing official score closeouts with uv bootstrap risk
- wire the helper into both result reduction and runner-exception closeout after reward recovery has had a chance to preserve real official scores
- add a focused smoke covering missing-score attribution and the no-reclassify path for completed official scores

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py loopx/benchmark_adapters/skillsbench_verifier_bootstrap.py examples/skillsbench-verifier-bootstrap-missing-score-smoke.py examples/control_plane/repo-python-line-budget-smoke.py
- python3 examples/skillsbench-verifier-bootstrap-missing-score-smoke.py
- python3 examples/control_plane/repo-python-line-budget-smoke.py

## Known baseline caveat
- python3 examples/skillsbench-task-source-preflight-smoke.py still fails on the apt-bootstrap decision assertion on origin/main; this branch does not touch that routing path.

## Boundary
- no raw task text, raw verifier output, trajectories, credentials, proxy IPs, or local artifact paths are recorded by the new helper or smoke.