### PR TITLE
Add decentralized A2A driver contract

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -320,8 +320,12 @@ def main() -> int:
         assert visible_loaded_readiness["manual_artifact_inspection_required"] is False, visible_loaded_readiness
         assert visible_loaded_readiness["wake_model"] == "fixed_prompt_broadcast", visible_loaded_readiness
         assert visible_loaded_readiness["workflow_model"] == (
-            "fixed_prompt_wakeup_plus_pane_local_state_tick"
+            "fixed_prompt_broadcast_plus_pane_local_state_tick"
         ), visible_loaded_readiness
+        assert visible_loaded_readiness["driver_owner_layer"] == (
+            "generic_multi_agent_kernel"
+        ), visible_loaded_readiness
+        assert visible_loaded_readiness["checks"]["kernel_driver_contract_loaded"] is True, visible_loaded_readiness
         assert visible_loaded_readiness["checks"]["workflow_driver_false"] is True, visible_loaded_readiness
         loaded_improvement = visible_loaded_readiness["improvement_summary"]
         assert loaded_improvement["baseline_metric"] == 1.0, loaded_improvement
@@ -535,6 +539,12 @@ def main() -> int:
                     visible_supervisor["pane_local_a2a"]["human_default"]
                     == "markdown_status_inside_codex_tui"
                 ), visible_supervisor
+                visible_driver = visible_supervisor["decentralized_a2a_driver"]
+                assert visible_driver["owner_layer"] == "generic_multi_agent_kernel", visible_driver
+                assert visible_driver["broadcaster_decides_work"] is False, visible_driver
+                assert (
+                    visible_driver["user_and_preset_do_not_own_tick_driver"] is True
+                ), visible_driver
                 visible_proof = visible_payload["visible_worker_proof"]
                 assert visible_proof["schema_version"] == "auto_research_visible_worker_proof_v0", visible_proof
                 assert visible_proof["lane_authored_evidence_loaded"] is True, visible_proof
@@ -566,6 +576,7 @@ def main() -> int:
                 ], visible_wake
                 assert visible_wake["wakeup_model"] == "fixed_prompt_broadcast", visible_wake
                 assert visible_wake["coordination_model"] == "decentralized_state_a2a", visible_wake
+                assert visible_wake["driver_owner_layer"] == "generic_multi_agent_kernel", visible_wake
                 assert visible_wake["workflow_driver"] is False, visible_wake
                 assert visible_wake["broadcaster_reads_frontier"] is False, visible_wake
                 assert visible_wake["broadcaster_selects_todo"] is False, visible_wake
@@ -575,6 +586,12 @@ def main() -> int:
                 assert visible_readiness["readiness_level"] == "ready", visible_readiness
                 assert visible_readiness["manual_artifact_inspection_required"] is False, visible_readiness
                 assert visible_readiness["wake_model"] == "fixed_prompt_broadcast", visible_readiness
+                assert visible_readiness["workflow_model"] == (
+                    "fixed_prompt_broadcast_plus_pane_local_state_tick"
+                ), visible_readiness
+                assert visible_readiness["driver_owner_layer"] == (
+                    "generic_multi_agent_kernel"
+                ), visible_readiness
                 assert visible_readiness["coordination_pattern"] == "decentralized_state_a2a", visible_readiness
                 assert visible_readiness["leader_agent_required"] is False, visible_readiness
                 assert visible_readiness["checks"] == {
@@ -585,6 +602,7 @@ def main() -> int:
                     "protected_scope_clean": True,
                     "positive_metric_over_baseline": True,
                     "workflow_driver_false": True,
+                    "kernel_driver_contract_loaded": True,
                 }, visible_readiness
                 assert visible_readiness["missing_requirements"] == [], visible_readiness
                 assert visible_readiness["rounds"]["max_completed"] >= 2, visible_readiness

--- a/examples/auto-research-demo-supervisor-smoke.py
+++ b/examples/auto-research-demo-supervisor-smoke.py
@@ -74,7 +74,9 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
     assert "research_roles" in layering["preset_layer"]["owns"], layering
     assert "metric_evidence_loop" in layering["preset_layer"]["owns"], layering
     assert "multi_agent_runner" in layering["preset_layer"]["forbidden"], layering
+    assert "decentralized_a2a_driver" in layering["preset_layer"]["forbidden"], layering
     assert "pane_local_a2a_tick" in layering["preset_layer"]["forbidden"], layering
+    assert "decentralized_a2a_driver" in layering["kernel_layer"]["owns"], layering
     assert "compact_human_status" in layering["kernel_layer"]["owns"], layering
     assert layering["acceptance"]["preset_has_no_runner_process_logic"] is True, layering
 
@@ -88,6 +90,7 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
         "domain_defaults",
     ], preset
     assert "multi_agent_runner" in preset["forbidden"], preset
+    assert "decentralized_a2a_driver" in preset["forbidden"], preset
     assert "pane_local_a2a_tick" in preset["forbidden"], preset
 
     kernel = payload["auto_research"]
@@ -95,7 +98,10 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
     assert kernel["uses_generic_runner"] is True, payload
     assert kernel["surface_count"] == 4, payload
     assert kernel["state_bus"] == "loopx_registry_runtime_todo_quota_frontier", payload
-    assert kernel["worker_turn"] == "pane_local_a2a_tick", payload
+    assert kernel["kernel_driver"] == "decentralized_a2a_driver", payload
+    assert kernel["kernel_driver_schema"] == "multi_agent_decentralized_a2a_driver_contract_v0", payload
+    assert kernel["worker_turn_owner"] == "generic_multi_agent_kernel", payload
+    assert "pane_local_a2a_tick" in kernel["delegated_kernel_mechanics"], payload
     assert kernel["presentation_layers_in_kernel"] is False, payload
 
     coordination = payload["coordination_model"]
@@ -117,6 +123,10 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
     assert runner["coordination_model"]["state_bus"] == "loopx_registry_runtime_todo_quota_frontier", runner
     assert runner["pane_local_a2a"]["tick_command"] == "$LOOPX_PANE_A2A_TICK", runner
     assert runner["pane_local_a2a"]["human_default"] == "markdown_status_inside_codex_tui", runner
+    driver = runner["decentralized_a2a_driver"]
+    assert driver["owner_layer"] == "generic_multi_agent_kernel", driver
+    assert driver["broadcaster"]["decides_work"] is False, driver
+    assert driver["acceptance"]["user_and_preset_do_not_own_tick_driver"] is True, driver
     assert runner["role_prompt_and_skill"]["worker_local_skill_only"] is True, runner
 
     tui = payload["interactive_tui_contract"]

--- a/examples/auto-research-layered-e2e-acceptance-smoke.py
+++ b/examples/auto-research-layered-e2e-acceptance-smoke.py
@@ -127,6 +127,7 @@ def assert_three_layer_minimality() -> None:
         "multi_agent_runner",
         "real_codex_tui_panes",
         "workspace_and_trust_safe_launch",
+        "decentralized_a2a_driver",
         "pane_local_a2a_tick",
         "todo_evidence_status_protocol",
         "compact_human_status",
@@ -140,17 +141,22 @@ def assert_three_layer_minimality() -> None:
     assert preset["owns"] == layering["preset_layer"]["owns"], preset
     assert "multi_agent_runner" in preset["forbidden"], preset
     assert "real_codex_tui_panes" in preset["forbidden"], preset
+    assert "decentralized_a2a_driver" in preset["forbidden"], preset
     assert "pane_local_a2a_tick" in preset["forbidden"], preset
 
     auto_research = supervisor["auto_research"]
     assert auto_research["schema_version"] == AUTO_RESEARCH_PRESET_SCHEMA_VERSION, auto_research
     assert auto_research["uses_generic_runner"] is True, auto_research
     assert auto_research["presentation_layers_in_kernel"] is False, auto_research
-    assert auto_research["worker_turn"] == "pane_local_a2a_tick", auto_research
+    assert auto_research["kernel_driver"] == "decentralized_a2a_driver", auto_research
+    assert auto_research["worker_turn_owner"] == "generic_multi_agent_kernel", auto_research
+    assert "pane_local_a2a_tick" in auto_research["delegated_kernel_mechanics"], auto_research
 
     runner = supervisor["runner_contract"]
     assert runner["runner_surface"] == "tmux_codex_cli_tui", runner
     assert runner["coordination_model"]["leader_required"] is False, runner
+    assert runner["decentralized_a2a_driver"]["owner_layer"] == "generic_multi_agent_kernel", runner
+    assert runner["decentralized_a2a_driver"]["broadcaster"]["decides_work"] is False, runner
     assert runner["pane_local_a2a"]["tick_command"] == "$LOOPX_PANE_A2A_TICK", runner
     assert runner["pane_local_a2a"]["human_default"] == "markdown_status_inside_codex_tui", runner
     assert runner["pane_local_a2a"]["machine_json_destination"] == "$LOOPX_PANE_ARTIFACT_DIR/*.public.json", runner

--- a/examples/generic-multi-agent-one-command-smoke.py
+++ b/examples/generic-multi-agent-one-command-smoke.py
@@ -247,6 +247,15 @@ def main() -> int:
             "fixed_prompt_broadcast"
         ), dry_packet
         assert dry_packet["runner_contract"]["pane_local_a2a"]["cadence_broadcaster_decides_work"] is False, dry_packet
+        driver = dry_packet["runner_contract"]["decentralized_a2a_driver"]
+        assert driver["schema_version"] == "multi_agent_decentralized_a2a_driver_contract_v0", driver
+        assert driver["owner_layer"] == "generic_multi_agent_kernel", driver
+        assert driver["driver_model"] == (
+            "fixed_prompt_broadcast_plus_pane_local_state_tick"
+        ), driver
+        assert driver["broadcaster"]["decides_work"] is False, driver
+        assert driver["pane"]["tick_command"] == "$LOOPX_PANE_A2A_TICK", driver
+        assert driver["acceptance"]["user_and_preset_do_not_own_tick_driver"] is True, driver
         assert dry_packet["runner_contract"]["pane_local_a2a"]["machine_json_destination"] == (
             "$LOOPX_PANE_ARTIFACT_DIR/*.public.json"
         ), dry_packet
@@ -255,6 +264,9 @@ def main() -> int:
         assert compact["schema_version"] == "generic_multi_agent_compact_status_v0", compact
         assert compact["role_count"] == 2, compact
         assert compact["first_action"] == "$LOOPX_PANE_A2A_TICK", compact
+        assert compact["driver_model"] == (
+            "fixed_prompt_broadcast_plus_pane_local_state_tick"
+        ), compact
         assert compact["user_takeover"] == "attach to the session and type into any role pane", compact
         assert dry_packet["interactive_tui_contract"]["schema_version"] == "multi_agent_visible_interactive_tui_contract_v0", dry_packet
         assert dry_packet["interactive_tui_contract"]["runner_contract"] == RUNNER_CONTRACT_SCHEMA_VERSION, dry_packet
@@ -307,6 +319,8 @@ def main() -> int:
         assert dry_wake["target_lanes"] == ["planner"], dry_wake
         assert dry_wake["coordination_model"] == "decentralized_state_a2a", dry_wake
         assert dry_wake["wakeup_model"] == "fixed_prompt_broadcast", dry_wake
+        assert dry_wake["driver_contract"]["owner_layer"] == "generic_multi_agent_kernel", dry_wake
+        assert dry_wake["driver_contract"]["broadcaster"]["selects_todo"] is False, dry_wake
         assert dry_wake["workflow_driver"] is False, dry_wake
         assert dry_wake["broadcaster_reads_frontier"] is False, dry_wake
         assert dry_wake["broadcaster_selects_todo"] is False, dry_wake

--- a/examples/generic-multi-agent-spec-contract-smoke.py
+++ b/examples/generic-multi-agent-spec-contract-smoke.py
@@ -23,6 +23,7 @@ from loopx.visible_multi_agent_launcher import (  # noqa: E402
     build_visible_multi_agent_payload_from_spec,
 )
 from loopx.capabilities.multi_agent.contract import (  # noqa: E402
+    DECENTRALIZED_A2A_DRIVER_CONTRACT_SCHEMA_VERSION,
     GENERIC_MULTI_AGENT_COMPACT_STATUS_SCHEMA_VERSION,
     GENERIC_MULTI_AGENT_ROLE_PROFILE_SCHEMA_VERSION,
     build_tui_multi_agent_runner_contract,
@@ -132,6 +133,14 @@ def main() -> int:
     assert runner["pane_local_a2a"]["tick_command"] == "$LOOPX_PANE_A2A_TICK", runner
     assert runner["pane_local_a2a"]["machine_json_policy"] == "file_or_explicit_machine_channel_only", runner
     assert runner["pane_local_a2a"]["machine_json_destination"] == "$LOOPX_PANE_ARTIFACT_DIR/*.public.json", runner
+    driver = runner["decentralized_a2a_driver"]
+    assert driver["schema_version"] == DECENTRALIZED_A2A_DRIVER_CONTRACT_SCHEMA_VERSION, driver
+    assert driver["owner_layer"] == "generic_multi_agent_kernel", driver
+    assert driver["coordination_pattern"] == "decentralized_state_a2a", driver
+    assert driver["broadcaster"]["model"] == "fixed_prompt_broadcast", driver
+    assert driver["broadcaster"]["decides_work"] is False, driver
+    assert driver["pane"]["decision_owner"] == "codex_tui_agent_via_loopx_state", driver
+    assert driver["acceptance"]["user_and_preset_do_not_own_tick_driver"] is True, driver
     assert runner["role_prompt_and_skill"]["worker_local_skill_only"] is True, runner
     assert runner["boundaries"]["domain_specific_research_logic"] is False, runner
     direct_runner = build_tui_multi_agent_runner_contract(
@@ -144,6 +153,9 @@ def main() -> int:
     )
     assert direct_runner["schema_version"] == TUI_MULTI_AGENT_RUNNER_CONTRACT_SCHEMA_VERSION
     assert direct_runner["pane_local_a2a"]["tick_command"] == "$LOOPX_PANE_A2A_TICK"
+    assert direct_runner["decentralized_a2a_driver"]["schema_version"] == (
+        DECENTRALIZED_A2A_DRIVER_CONTRACT_SCHEMA_VERSION
+    )
     assert direct_runner["boundaries"]["domain_specific_research_logic"] is False
 
     tui = payload["interactive_tui_contract"]
@@ -190,6 +202,8 @@ def main() -> int:
     assert compact["schema_version"] == GENERIC_MULTI_AGENT_COMPACT_STATUS_SCHEMA_VERSION, compact
     assert compact["role_count"] == 2, compact
     assert compact["first_action"] == "$LOOPX_PANE_A2A_TICK", compact
+    assert compact["driver_model"] == "fixed_prompt_broadcast_plus_pane_local_state_tick", compact
+    assert compact["coordination_pattern"] == "decentralized_state_a2a", compact
     assert compact["machine_json_policy"] == "artifact_only_in_visible_panes", compact
     assert [role["lane_id"] for role in compact["roles"]] == ["planner", "builder"], compact
     assert payload["boundary"]["starts_visible_processes"] is False, payload

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -85,7 +85,8 @@ def main() -> int:
     runtime_source = (ROOT / "loopx/capabilities/multi_agent/runtime_scripts.py").read_text(
         encoding="utf-8"
     )
-    assert "from ...visible_multi_agent_launcher import execute_visible_multi_agent_launcher" in auto_research_cli
+    assert "from ...visible_multi_agent_launcher import" in auto_research_cli
+    assert "execute_visible_multi_agent_launcher" in auto_research_cli
     forbidden_defs = [
         "def _launch_auto_research_with_tmux",
         "def _tmux_visible_launch_acceptance",
@@ -167,6 +168,15 @@ def main() -> int:
     )
     assert runner_contract["pane_local_a2a"]["cadence_wakeup_model"] == "fixed_prompt_broadcast"
     assert runner_contract["pane_local_a2a"]["cadence_broadcaster_decides_work"] is False
+    driver = runner_contract["decentralized_a2a_driver"]
+    assert driver["schema_version"] == "multi_agent_decentralized_a2a_driver_contract_v0", driver
+    assert driver["owner_layer"] == "generic_multi_agent_kernel", driver
+    assert driver["driver_model"] == "fixed_prompt_broadcast_plus_pane_local_state_tick", driver
+    assert driver["broadcaster"]["reads_frontier"] is False, driver
+    assert driver["broadcaster"]["selects_todo"] is False, driver
+    assert driver["broadcaster"]["runs_worker_turn"] is False, driver
+    assert driver["pane"]["decision_owner"] == "codex_tui_agent_via_loopx_state", driver
+    assert driver["acceptance"]["each_pane_decides_from_state"] is True, driver
     assert runner_contract["pane_local_a2a"]["first_action"] == (
         "launcher runs $LOOPX_PANE_A2A_TICK before Codex TUI opens"
     )

--- a/loopx/capabilities/auto_research/defaults.py
+++ b/loopx/capabilities/auto_research/defaults.py
@@ -32,6 +32,7 @@ def build_auto_research_layer_contract() -> dict[str, object]:
             "multi_agent_runner",
             "real_codex_tui_panes",
             "workspace_and_trust_safe_launch",
+            "decentralized_a2a_driver",
             "pane_local_a2a_tick",
             "todo_evidence_status_protocol",
             "compact_human_status",

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -303,6 +303,11 @@ def _supervisor_summary(supervisor: dict[str, object]) -> dict[str, object]:
         if isinstance(runner_contract.get("pane_local_a2a"), dict)
         else {}
     )
+    decentralized_a2a_driver = (
+        runner_contract.get("decentralized_a2a_driver")
+        if isinstance(runner_contract.get("decentralized_a2a_driver"), dict)
+        else {}
+    )
     cli_contract = (
         supervisor.get("cli_contract")
         if isinstance(supervisor.get("cli_contract"), dict)
@@ -335,6 +340,29 @@ def _supervisor_summary(supervisor: dict[str, object]) -> dict[str, object]:
             "machine_json_destination": pane_local_a2a.get("machine_json_destination"),
             "rounds_artifact": pane_local_a2a.get("rounds_artifact"),
             "human_default": pane_local_a2a.get("human_default"),
+        },
+        "decentralized_a2a_driver": {
+            "schema_version": decentralized_a2a_driver.get("schema_version"),
+            "owner_layer": decentralized_a2a_driver.get("owner_layer"),
+            "driver_model": decentralized_a2a_driver.get("driver_model"),
+            "coordination_pattern": decentralized_a2a_driver.get("coordination_pattern"),
+            "broadcaster_decides_work": (
+                decentralized_a2a_driver.get("broadcaster", {}).get("decides_work")
+                if isinstance(decentralized_a2a_driver.get("broadcaster"), dict)
+                else None
+            ),
+            "pane_decision_owner": (
+                decentralized_a2a_driver.get("pane", {}).get("decision_owner")
+                if isinstance(decentralized_a2a_driver.get("pane"), dict)
+                else None
+            ),
+            "user_and_preset_do_not_own_tick_driver": (
+                decentralized_a2a_driver.get("acceptance", {}).get(
+                    "user_and_preset_do_not_own_tick_driver"
+                )
+                if isinstance(decentralized_a2a_driver.get("acceptance"), dict)
+                else None
+            ),
         },
         "machine_json_policy": cli_contract.get("machine_json_policy"),
         "domain_specific_runner_logic": bool(product_spec.get("domain_specific")),
@@ -542,6 +570,11 @@ def _load_visible_wake_into_payload(
     payload: dict[str, object],
     wake: dict[str, object],
 ) -> None:
+    driver = (
+        wake.get("driver_contract")
+        if isinstance(wake.get("driver_contract"), dict)
+        else {}
+    )
     payload["visible_wake"] = {
         "schema_version": wake.get("schema_version"),
         "mode": wake.get("mode"),
@@ -554,6 +587,8 @@ def _load_visible_wake_into_payload(
         "broadcaster_reads_frontier": bool(wake.get("broadcaster_reads_frontier")),
         "broadcaster_selects_todo": bool(wake.get("broadcaster_selects_todo")),
         "pane_decision_owner": wake.get("pane_decision_owner"),
+        "driver_contract_schema": driver.get("schema_version"),
+        "driver_owner_layer": driver.get("owner_layer"),
         "boundary": wake.get("boundary"),
     }
     visible_proof = payload["visible_worker_proof"]
@@ -594,6 +629,12 @@ def _build_visible_readiness(payload: dict[str, object]) -> dict[str, object]:
         else {}
     )
     wake = payload.get("visible_wake") if isinstance(payload.get("visible_wake"), dict) else {}
+    supervisor = payload.get("supervisor") if isinstance(payload.get("supervisor"), dict) else {}
+    driver = (
+        supervisor.get("decentralized_a2a_driver")
+        if isinstance(supervisor.get("decentralized_a2a_driver"), dict)
+        else {}
+    )
     baseline = 1.0
     dev_metric = _numeric_metric(evidence.get("dev_metric"))
     holdout_metric = _numeric_metric(evidence.get("holdout_metric"))
@@ -618,6 +659,10 @@ def _build_visible_readiness(payload: dict[str, object]) -> dict[str, object]:
         "workflow_driver_false": (
             rounds.get("workflow_driver") is False and wake.get("workflow_driver") is False
         ),
+        "kernel_driver_contract_loaded": (
+            driver.get("owner_layer") == "generic_multi_agent_kernel"
+            and driver.get("user_and_preset_do_not_own_tick_driver") is True
+        ),
     }
     ready = all(checks.values())
     return {
@@ -629,7 +674,10 @@ def _build_visible_readiness(payload: dict[str, object]) -> dict[str, object]:
         else None,
         "coordination_pattern": "decentralized_state_a2a",
         "wake_model": wake.get("wakeup_model"),
-        "workflow_model": "fixed_prompt_wakeup_plus_pane_local_state_tick",
+        "workflow_model": driver.get("driver_model")
+        or "fixed_prompt_broadcast_plus_pane_local_state_tick",
+        "driver_owner_layer": driver.get("owner_layer"),
+        "auto_research_preset_role": "thin_domain_defaults_only",
         "leader_agent_required": False,
         "manual_artifact_inspection_required": not ready,
         "checks": checks,

--- a/loopx/capabilities/auto_research/demo_supervisor.py
+++ b/loopx/capabilities/auto_research/demo_supervisor.py
@@ -58,6 +58,16 @@ def build_auto_research_demo_supervisor_plan(
         codex_bin=codex_bin,
     )
     payload.pop("acceptance", None)
+    runner_contract = (
+        payload.get("runner_contract")
+        if isinstance(payload.get("runner_contract"), dict)
+        else {}
+    )
+    driver_contract = (
+        runner_contract.get("decentralized_a2a_driver")
+        if isinstance(runner_contract.get("decentralized_a2a_driver"), dict)
+        else {}
+    )
     payload.update(
         {
             "schema_version": AUTO_RESEARCH_DEMO_SUPERVISOR_SCHEMA_VERSION,
@@ -69,7 +79,14 @@ def build_auto_research_demo_supervisor_plan(
                 "uses_generic_runner": True,
                 "surface_count": len(roles),
                 "state_bus": "loopx_registry_runtime_todo_quota_frontier",
-                "worker_turn": "pane_local_a2a_tick",
+                "kernel_driver": "decentralized_a2a_driver",
+                "kernel_driver_schema": driver_contract.get("schema_version"),
+                "delegated_kernel_mechanics": [
+                    "fixed_prompt_wakeup",
+                    "pane_local_a2a_tick",
+                    "todo_evidence_status_protocol",
+                ],
+                "worker_turn_owner": "generic_multi_agent_kernel",
                 "presentation_layers_in_kernel": False,
             },
             "coordination_model": {

--- a/loopx/capabilities/auto_research/preset.py
+++ b/loopx/capabilities/auto_research/preset.py
@@ -257,6 +257,7 @@ def build_auto_research_preset_summary(*, role_count: int) -> dict[str, object]:
             "multi_agent_runner",
             "real_codex_tui_panes",
             "workspace_and_trust_safe_launch",
+            "decentralized_a2a_driver",
             "pane_local_a2a_tick",
             "todo_evidence_status_protocol",
             "compact_human_status",

--- a/loopx/capabilities/multi_agent/contract.py
+++ b/loopx/capabilities/multi_agent/contract.py
@@ -9,16 +9,28 @@ INTERACTIVE_TUI_CONTRACT_SCHEMA_VERSION = "multi_agent_visible_interactive_tui_c
 VISIBLE_LAUNCHER_ACCEPTANCE_CONTRACT_SCHEMA_VERSION = (
     "multi_agent_visible_launcher_acceptance_contract_v0"
 )
+DECENTRALIZED_A2A_DRIVER_CONTRACT_SCHEMA_VERSION = (
+    "multi_agent_decentralized_a2a_driver_contract_v0"
+)
 GENERIC_MULTI_AGENT_ROLE_PROFILE_SCHEMA_VERSION = "generic_multi_agent_role_profile_v0"
 GENERIC_MULTI_AGENT_COMPACT_STATUS_SCHEMA_VERSION = "generic_multi_agent_compact_status_v0"
 THREE_LAYER_MINIMALITY_CONTRACT_SCHEMA_VERSION = (
     "multi_agent_three_layer_minimality_contract_v0"
 )
 
+PANE_LOCAL_A2A_WAKEUP_PROMPT = (
+    "LoopX pane-local A2A wakeup: run $LOOPX_PANE_A2A_TICK now. "
+    "Use only your own LOOPX_GOAL_ID/LOOPX_AGENT_ID quota/frontier; "
+    "if no runnable frontier, stay quiet with a brief no-action note; "
+    "if advanced, summarize public evidence and next handoff. "
+    "Do not ask the broadcaster for direction; LoopX state is the source of truth."
+)
+
 GENERIC_MULTI_AGENT_KERNEL_MECHANICS = (
     "multi_agent_runner",
     "real_codex_tui_panes",
     "workspace_and_trust_safe_launch",
+    "decentralized_a2a_driver",
     "pane_local_a2a_tick",
     "todo_evidence_status_protocol",
     "compact_human_status",
@@ -129,6 +141,69 @@ def generic_role_prompt(
     return "\n".join(lines)
 
 
+def build_decentralized_a2a_driver_contract(
+    *,
+    wake_command: str = "loopx multi-agent wake --session-name <session>",
+) -> dict[str, object]:
+    """Describe the reusable fixed-prompt driver for live Codex TUI agents."""
+
+    return {
+        "schema_version": DECENTRALIZED_A2A_DRIVER_CONTRACT_SCHEMA_VERSION,
+        "owner_layer": "generic_multi_agent_kernel",
+        "driver_model": "fixed_prompt_broadcast_plus_pane_local_state_tick",
+        "coordination_pattern": "decentralized_state_a2a",
+        "prompt": {
+            "trigger": PANE_LOCAL_A2A_WAKEUP_PROMPT,
+            "instruction_only": True,
+            "frontier_embedded": False,
+            "todo_embedded": False,
+            "target_role_embedded": False,
+        },
+        "broadcaster": {
+            "command": wake_command,
+            "model": "fixed_prompt_broadcast",
+            "reads_frontier": False,
+            "selects_todo": False,
+            "runs_worker_turn": False,
+            "writes_loopx_state": False,
+            "spends_quota": False,
+            "decides_work": False,
+        },
+        "pane": {
+            "decision_owner": "codex_tui_agent_via_loopx_state",
+            "tick_command": "$LOOPX_PANE_A2A_TICK",
+            "first_action": "launcher_pre_tui_tick",
+            "cadence_action": "fixed_prompt_wakeup_then_local_tick",
+            "reads": [
+                "own_LOOPX_GOAL_ID",
+                "own_LOOPX_AGENT_ID",
+                "quota_should_run",
+                "agent_scoped_frontier",
+            ],
+            "may_run": ["LOOPX_PANE_WORKER_TURN", "LOOPX_PANE_WORKER_LOOP"],
+            "writes": ["public_safe_evidence", "todo_completion_when_worker_turn_configured"],
+            "rounds_env": "LOOPX_PANE_TICK_ROUNDS",
+            "rounds_artifact": "$LOOPX_PANE_ARTIFACT_DIR/pane-a2a-rounds.public.json",
+        },
+        "layer_budget": {
+            "user_layer": ["goal_id", "roles", "optional_overrides"],
+            "preset_layer": ["domain_roles", "handoff_hints", "worker_turn_command"],
+            "kernel_layer": [
+                "tmux_codex_tui_lifecycle",
+                "fixed_prompt_wakeup",
+                "pane_local_tick_runtime",
+                "loopx_state_protocol",
+            ],
+        },
+        "acceptance": {
+            "broadcaster_is_not_workflow": True,
+            "no_leader_frontier_scan": True,
+            "each_pane_decides_from_state": True,
+            "user_and_preset_do_not_own_tick_driver": True,
+        },
+    }
+
+
 def build_tui_multi_agent_runner_contract(
     *,
     session_name: str,
@@ -140,6 +215,7 @@ def build_tui_multi_agent_runner_contract(
 ) -> dict[str, object]:
     """Describe the reusable visible-TUI runner without domain-specific steps."""
 
+    driver_contract = build_decentralized_a2a_driver_contract()
     return {
         "schema_version": TUI_MULTI_AGENT_RUNNER_CONTRACT_SCHEMA_VERSION,
         "runner_surface": "tmux_codex_cli_tui",
@@ -192,16 +268,17 @@ def build_tui_multi_agent_runner_contract(
             "skill_materialization": ".codex/skills/<skill>/SKILL.md",
             "worker_local_skill_only": True,
         },
+        "decentralized_a2a_driver": driver_contract,
         "pane_local_a2a": {
-            "tick_command": "$LOOPX_PANE_A2A_TICK",
+            "tick_command": driver_contract["pane"]["tick_command"],
             "first_action": "launcher runs $LOOPX_PANE_A2A_TICK before Codex TUI opens",
-            "cadence_wakeup_command": "loopx multi-agent wake --session-name <session>",
-            "cadence_wakeup_model": "fixed_prompt_broadcast",
-            "cadence_broadcaster_decides_work": False,
+            "cadence_wakeup_command": driver_contract["broadcaster"]["command"],
+            "cadence_wakeup_model": driver_contract["broadcaster"]["model"],
+            "cadence_broadcaster_decides_work": driver_contract["broadcaster"]["decides_work"],
             "reads": ["quota should-run", "agent-scoped frontier"],
-            "runs": ["LOOPX_PANE_WORKER_TURN", "LOOPX_PANE_WORKER_LOOP"],
-            "bounded_rounds_env": "LOOPX_PANE_TICK_ROUNDS",
-            "rounds_artifact": "$LOOPX_PANE_ARTIFACT_DIR/pane-a2a-rounds.public.json",
+            "runs": driver_contract["pane"]["may_run"],
+            "bounded_rounds_env": driver_contract["pane"]["rounds_env"],
+            "rounds_artifact": driver_contract["pane"]["rounds_artifact"],
             "machine_json_policy": "file_or_explicit_machine_channel_only",
             "machine_json_destination": "$LOOPX_PANE_ARTIFACT_DIR/*.public.json",
             "human_default": "markdown_status_inside_codex_tui",
@@ -293,6 +370,12 @@ def build_compact_human_status(payload: dict[str, object]) -> dict[str, object]:
 
     lanes = [lane for lane in payload.get("lanes", []) if isinstance(lane, dict)]
     commands = payload.get("commands") if isinstance(payload.get("commands"), dict) else {}
+    runner = payload.get("runner_contract") if isinstance(payload.get("runner_contract"), dict) else {}
+    driver = (
+        runner.get("decentralized_a2a_driver")
+        if isinstance(runner.get("decentralized_a2a_driver"), dict)
+        else {}
+    )
     session = str(payload.get("session_name") or "")
     role_summaries = []
     for lane in lanes:
@@ -322,6 +405,10 @@ def build_compact_human_status(payload: dict[str, object]) -> dict[str, object]:
         "attach": commands.get("attach"),
         "stop": commands.get("stop"),
         "first_action": "$LOOPX_PANE_A2A_TICK",
+        "driver_model": driver.get("driver_model")
+        or "fixed_prompt_broadcast_plus_pane_local_state_tick",
+        "coordination_pattern": driver.get("coordination_pattern")
+        or "decentralized_state_a2a",
         "machine_json_policy": "artifact_only_in_visible_panes",
         "user_takeover": "attach to the session and type into any role pane",
     }

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -13,9 +13,11 @@ from pathlib import Path
 from .capabilities.multi_agent.contract import (
     GENERIC_MULTI_AGENT_ROLE_PROFILE_SCHEMA_VERSION,
     INTERACTIVE_TUI_CONTRACT_SCHEMA_VERSION,
+    PANE_LOCAL_A2A_WAKEUP_PROMPT,
     TUI_MULTI_AGENT_RUNNER_CONTRACT_SCHEMA_VERSION,
     VISIBLE_LAUNCHER_ACCEPTANCE_CONTRACT_SCHEMA_VERSION,
     as_string_list as _as_string_list,
+    build_decentralized_a2a_driver_contract,
     build_compact_human_status,
     build_generic_role_profile,
     build_tui_multi_agent_runner_contract,
@@ -34,13 +36,7 @@ def _q(value: object) -> str:
 
 
 PANE_A2A_WAKEUP_SCHEMA_VERSION = "multi_agent_pane_a2a_wakeup_v0"
-PANE_A2A_WAKEUP_PROMPT = (
-    "LoopX pane-local A2A wakeup: run $LOOPX_PANE_A2A_TICK now. "
-    "Use only your own LOOPX_GOAL_ID/LOOPX_AGENT_ID quota/frontier; "
-    "if no runnable frontier, stay quiet with a brief no-action note; "
-    "if advanced, summarize public evidence and next handoff. "
-    "Do not ask the broadcaster for direction; LoopX state is the source of truth."
-)
+PANE_A2A_WAKEUP_PROMPT = PANE_LOCAL_A2A_WAKEUP_PROMPT
 
 
 def require_executable(command: str, *, field: str) -> str:
@@ -74,6 +70,7 @@ def wake_visible_multi_agent_panes(
         raise ValueError("multi-agent wake prompt must not be empty")
     prompt_hash = sha256(prompt_text.encode("utf-8")).hexdigest()[:16]
     target_lanes = [str(lane).strip() for lane in lanes or [] if str(lane).strip()]
+    driver_contract = build_decentralized_a2a_driver_contract()
 
     if execute:
         require_executable(tmux_bin, field="tmux_bin")
@@ -118,10 +115,11 @@ def wake_visible_multi_agent_panes(
         "prompt_hash": prompt_hash,
         "coordination_model": "decentralized_state_a2a",
         "wakeup_model": "fixed_prompt_broadcast",
+        "driver_contract": driver_contract,
         "workflow_driver": False,
-        "broadcaster_reads_frontier": False,
-        "broadcaster_selects_todo": False,
-        "pane_decision_owner": "codex_tui_agent_via_loopx_state",
+        "broadcaster_reads_frontier": driver_contract["broadcaster"]["reads_frontier"],
+        "broadcaster_selects_todo": driver_contract["broadcaster"]["selects_todo"],
+        "pane_decision_owner": driver_contract["pane"]["decision_owner"],
         "boundary": {
             "writes_loopx_state": False,
             "spends_loopx_quota": False,


### PR DESCRIPTION
## Summary\n- move the fixed-prompt pane wake model into a reusable generic multi-agent kernel driver contract\n- make auto-research supervisor/readiness reference that kernel contract instead of owning driver semantics\n- extend generic/visible/auto-research smokes so user and auto-research layers stay thin while the kernel owns pane-local A2A mechanics\n\n## Validation\n- python3 -m py_compile loopx/capabilities/multi_agent/contract.py loopx/visible_multi_agent_launcher.py loopx/capabilities/auto_research/defaults.py loopx/capabilities/auto_research/preset.py loopx/capabilities/auto_research/demo_supervisor.py loopx/capabilities/auto_research/demo_e2e.py\n- python3 examples/generic-multi-agent-spec-contract-smoke.py\n- python3 examples/generic-multi-agent-one-command-smoke.py\n- python3 examples/visible-multi-agent-launcher-smoke.py\n- python3 examples/auto-research-demo-supervisor-smoke.py\n- python3 examples/auto-research-demo-e2e-worker-loop-smoke.py\n- python3 examples/auto-research-layered-e2e-acceptance-smoke.py\n- python3 examples/auto-research-live-evidence-capture-smoke.py\n- git diff --check HEAD~1..HEAD\n- private marker scan on committed diff