### PR TITLE
Prioritize explicit next action over monitor repair

### DIFF
--- a/examples/control_plane/quota-work-lane-policy-smoke.py
+++ b/examples/control_plane/quota-work-lane-policy-smoke.py
@@ -94,6 +94,34 @@ def main() -> int:
         must_attempt_work=False,
     )
 
+    explicit_next_action = build_work_lane_contract(
+        progress_scope="agent_lane",
+        external_poll_signal=False,
+        todo_counts={"open": 1, "advancement": 0, "monitor": 1},
+        monitor_due_count=0,
+        due_monitor_items=[],
+        first_advancement=None,
+        due_monitor_preempts_advancement=False,
+        outcome_followthrough=None,
+        next_action_requires_advancement=True,
+        monitor_due_item_limit=1,
+        monitor_schedule_gap_count=1,
+        monitor_schedule_gap_items=[{"todo_id": "todo_monitor_without_schedule"}],
+    )
+    assert_contract(
+        "explicit-next-action-over-monitor-schedule-gap",
+        explicit_next_action,
+        lane="advancement_task",
+        next_lane="advancement_task",
+        obligation="materialize_advancement_todo_or_blocker",
+        must_attempt_work=True,
+        monitor_policy="material_transition_only",
+    )
+    assert explicit_next_action["reason_codes"] == [
+        "monitor_todo_only",
+        "next_action_requires_advancement",
+    ], explicit_next_action
+
     resume_blocked_by_monitor = build_work_lane_contract(
         progress_scope="agent_lane",
         external_poll_signal=False,

--- a/examples/control_plane/work-lane-contract-smoke.py
+++ b/examples/control_plane/work-lane-contract-smoke.py
@@ -498,19 +498,18 @@ def assert_monitor_only_with_planning_next_action_materializes_advancement() -> 
     lane = guard["work_lane_contract"]
     assert lane["schema_version"] == "work_lane_contract_v1", lane
     assert lane["lane"] == "advancement_task", lane
-    assert lane["next_lane"] == "continuous_monitor", lane
-    assert lane["obligation"] == "repair_monitor_schedule_metadata", lane
+    assert lane["next_lane"] == "advancement_task", lane
+    assert lane["obligation"] == "materialize_advancement_todo_or_blocker", lane
     assert lane["must_attempt_work"] is True, lane
-    assert lane["reason_codes"] == ["monitor_todo_only", "monitor_schedule_metadata_gap"], lane
-    assert lane["monitor_policy"] == "repair_schedule_metadata_before_quiet_wait", lane
-    assert lane["monitor_schedule_gap_count"] == 2, lane
-    assert "continuous_monitor todo" in lane["action"], lane
+    assert lane["reason_codes"] == ["monitor_todo_only", "next_action_requires_advancement"], lane
+    assert lane["monitor_policy"] == "material_transition_only", lane
+    assert "materialize the planning/self-repair advancement todo" in lane["action"], lane
     assert guard["execution_obligation"]["contract_obligation"] == lane["obligation"], guard
     assert guard["execution_obligation"]["must_attempt_work"] is True, guard
     markdown = render_quota_should_run_markdown(guard)
-    assert "work_lane_contract: lane=advancement_task next=continuous_monitor" in markdown, markdown
-    assert "obligation=repair_monitor_schedule_metadata" in markdown, markdown
-    assert "work_lane_reason_codes: monitor_todo_only,monitor_schedule_metadata_gap" in markdown, markdown
+    assert "work_lane_contract: lane=advancement_task next=advancement_task" in markdown, markdown
+    assert "obligation=materialize_advancement_todo_or_blocker" in markdown, markdown
+    assert "work_lane_reason_codes: monitor_todo_only,next_action_requires_advancement" in markdown, markdown
 
 
 def assert_monitor_only_with_adapter_next_action_materializes_advancement() -> None:
@@ -543,12 +542,11 @@ def assert_monitor_only_with_adapter_next_action_materializes_advancement() -> N
     )
     lane = guard["work_lane_contract"]
     assert lane["lane"] == "advancement_task", lane
-    assert lane["next_lane"] == "continuous_monitor", lane
-    assert lane["obligation"] == "repair_monitor_schedule_metadata", lane
+    assert lane["next_lane"] == "advancement_task", lane
+    assert lane["obligation"] == "materialize_advancement_todo_or_blocker", lane
     assert lane["must_attempt_work"] is True, lane
-    assert lane["reason_codes"] == ["monitor_todo_only", "monitor_schedule_metadata_gap"], lane
-    assert lane["monitor_policy"] == "repair_schedule_metadata_before_quiet_wait", lane
-    assert lane["monitor_schedule_gap_count"] == 2, lane
+    assert lane["reason_codes"] == ["monitor_todo_only", "next_action_requires_advancement"], lane
+    assert lane["monitor_policy"] == "material_transition_only", lane
     assert guard["heartbeat_recommendation"]["recommended_mode"] == "steering_audit_then_one_step", guard
     assert guard["execution_obligation"]["must_attempt_work"] is True, guard
     assert guard["execution_obligation"]["contract_obligation"] == lane["obligation"], guard
@@ -622,11 +620,10 @@ def assert_monitor_todo_with_executable_next_action_materializes_advancement() -
     assert guard["should_run"] is True, guard
     assert guard["effective_action"] == "normal_run", guard
     assert lane["lane"] == "advancement_task", lane
-    assert lane["next_lane"] == "continuous_monitor", lane
-    assert lane["obligation"] == "repair_monitor_schedule_metadata", lane
-    assert lane["reason_codes"] == ["monitor_todo_only", "monitor_schedule_metadata_gap"], lane
-    assert lane["monitor_policy"] == "repair_schedule_metadata_before_quiet_wait", lane
-    assert lane["monitor_schedule_gap_count"] == 1, lane
+    assert lane["next_lane"] == "advancement_task", lane
+    assert lane["obligation"] == "materialize_advancement_todo_or_blocker", lane
+    assert lane["reason_codes"] == ["monitor_todo_only", "next_action_requires_advancement"], lane
+    assert lane["monitor_policy"] == "material_transition_only", lane
     assert guard["execution_obligation"]["must_attempt_work"] is True, guard
     first_items = guard["agent_todo_summary"]["first_open_items"]
     assert first_items[0]["task_class"] == "continuous_monitor", guard

--- a/examples/protocol/protocol-action-packet-smoke.py
+++ b/examples/protocol/protocol-action-packet-smoke.py
@@ -437,16 +437,19 @@ def assert_executable_recommended_action_overrides_monitor_todo() -> None:
     assert guard["effective_action"] == "normal_run", guard
     lane = guard["work_lane_contract"]
     assert lane["lane"] == "advancement_task", lane
-    assert lane["next_lane"] == "continuous_monitor", lane
-    assert lane["obligation"] == "repair_monitor_schedule_metadata", lane
-    assert lane["reason_codes"] == ["monitor_todo_only", "monitor_schedule_metadata_gap"], lane
+    assert lane["next_lane"] == "advancement_task", lane
+    assert lane["obligation"] == "materialize_advancement_todo_or_blocker", lane
+    assert lane["reason_codes"] == ["monitor_todo_only", "next_action_requires_advancement"], lane
     assert guard["execution_obligation"]["must_attempt_work"] is True, guard
     packet = guard["protocol_action_packet"]
     assert "agent_action_required=true" in packet["summary"], packet
-    assert "agent_action=repair the selected continuous_monitor todo" in packet["summary"], packet
+    assert "Collect or aggregate additional same-protocol" in packet["summary"], packet
     contract = guard["interaction_contract"]
     assert contract["agent_channel"]["must_attempt"] is True, contract
-    assert "repair the selected continuous_monitor todo" in contract["agent_channel"]["primary_action"], contract
+    assert (
+        "Collect or aggregate additional same-protocol"
+        in contract["agent_channel"]["primary_action"]
+    ), contract
 
 
 def assert_goal_scoped_primary_action_ignores_foreign_backlog() -> None:

--- a/loopx/policies/work_lane.py
+++ b/loopx/policies/work_lane.py
@@ -174,6 +174,19 @@ def build_work_lane_contract(
                 return due_monitor_contract(
                     reason_codes=["monitor_todo_only", "monitor_due"]
                 )
+            if next_action_requires_advancement:
+                return {
+                    "schema_version": WORK_LANE_CONTRACT_SCHEMA_VERSION,
+                    "lane": "advancement_task",
+                    "next_lane": "advancement_task",
+                    "obligation": "materialize_advancement_todo_or_blocker",
+                    "must_attempt_work": True,
+                    "reason_codes": ["monitor_todo_only", "next_action_requires_advancement"],
+                    "monitor_policy": "material_transition_only",
+                    "action": (
+                        "materialize the planning/self-repair advancement todo or write a concrete blocker"
+                    ),
+                }
             if first_schedule_gap:
                 return {
                     "schema_version": WORK_LANE_CONTRACT_SCHEMA_VERSION,
@@ -194,19 +207,6 @@ def build_work_lane_contract(
                         "repair the selected continuous_monitor todo by adding cadence/"
                         "next_due_at, superseding it, or recording an explicit no-schedule "
                         "policy; do not silently collapse it into monitor_quiet_skip"
-                    ),
-                }
-            if next_action_requires_advancement:
-                return {
-                    "schema_version": WORK_LANE_CONTRACT_SCHEMA_VERSION,
-                    "lane": "advancement_task",
-                    "next_lane": "advancement_task",
-                    "obligation": "materialize_advancement_todo_or_blocker",
-                    "must_attempt_work": True,
-                    "reason_codes": ["monitor_todo_only", "next_action_requires_advancement"],
-                    "monitor_policy": "material_transition_only",
-                    "action": (
-                        "materialize the planning/self-repair advancement todo or write a concrete blocker"
                     ),
                 }
             return {


### PR DESCRIPTION
## Summary

- Fix work-lane precedence so an explicit executable `next_action` / `recommended_action` wins over monitor schedule metadata repair.
- Keep monitor schedule metadata repair for pure monitor-only lanes that lack `cadence` / `next_due_at` / explicit no-schedule policy.
- Update low-level work-lane, quota projection, and protocol action packet smokes to lock both cases.

## Why this is runtime, not just smoke

PR #1204 exposed that the smoke had mixed two distinct cases:

1. Pure monitor-only todo with missing schedule metadata should be actionable as `repair_monitor_schedule_metadata`; otherwise a standing monitor can silently collapse into quiet wait with no cadence.
2. Monitor-only visible todos plus an explicit executable `next_action` should not be captured by monitor metadata repair. The existing docs describe this as `materialize_advancement_todo_or_blocker`: the worker should create/restore the concrete advancement todo or write the blocker, while the protocol packet can still show the concrete next action text.

This PR changes the runtime priority in `loopx/policies/work_lane.py` to match that product contract: due monitors still preempt, explicit executable next action comes next, schedule metadata repair is the fallback for monitor-only no-next-action cases.

## Validation

- `PYTHONPATH=. python3 examples/control_plane/quota-work-lane-policy-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/work-lane-contract-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/monitor-scheduler-contract-smoke.py`
- `PYTHONPATH=. python3 examples/protocol/protocol-action-packet-smoke.py`
- `PYTHONPATH=. python3 -m py_compile loopx/policies/work_lane.py examples/control_plane/quota-work-lane-policy-smoke.py examples/control_plane/work-lane-contract-smoke.py examples/protocol/protocol-action-packet-smoke.py`
- `git diff --check`
- Added-line public/private boundary scan: no hits.
