### PR TITLE
Document auto-research recipe promotion boundary

### DIFF
--- a/docs/guides/auto-research-command-path.md
+++ b/docs/guides/auto-research-command-path.md
@@ -20,6 +20,26 @@ human status.
 Use the [multi-agent product recipe](multi-agent-product-recipe.md) when a new
 product wants to copy the pattern without copying auto-research code.
 
+## Promotion Decision
+
+The validated visible proof is promoted into this existing command path, not
+into a second auto-research runner. The public recipe remains:
+
+- the operator runs one command;
+- the user layer supplies only topic, objective, rounds, reasoning effort, and
+  optional role overrides;
+- the auto-research preset supplies research roles, handoff hints, seed todos,
+  and evidence defaults;
+- the generic multi-agent kernel supplies runner, wake, pane-local tick, status,
+  attach, retry, and stop mechanics.
+
+A visible proof is ready for this path only when the configured roles open as
+real interactive Codex CLI panes, the fixed-prompt wake causes each pane to run
+its local A2A tick, role output is summarized through LoopX todo/evidence/status
+artifacts, and any live evidence packet is compact and public-safe. The proof
+must not depend on raw logs, private artifacts, credentials, local absolute
+paths, or a product-specific launcher hidden inside the auto-research preset.
+
 ## Start From A Clean Workspace
 
 Use a user-owned directory for the visible demo, while keeping LoopX state in

--- a/docs/guides/multi-agent-product-recipe.md
+++ b/docs/guides/multi-agent-product-recipe.md
@@ -163,6 +163,14 @@ Both commands should open real interactive Codex CLI TUI panes. The first
 screen should be the role TUI, not raw JSON, shell streams, a hidden executor,
 or a generated worktree trust prompt.
 
+For auto-research, a validated visible proof promotes the existing preset as
+the reference recipe only when the proof keeps that layer split intact. The
+operator still gets one command, but fixed-prompt wake, pane-local A2A tick,
+runner lifecycle, compact status, and public artifact routing stay in the
+generic multi-agent kernel. The auto-research preset may provide roles,
+handoff hints, seed todos, and evidence defaults; it must not grow a private
+launcher or hidden workflow driver to make the demo look shorter.
+
 ## Attach, Stop, Retry
 
 Every visible multi-agent product should expose the same host controls:
@@ -195,6 +203,9 @@ A new product preset is healthy when:
   not dumped into the first visible screen;
 - todos and evidence are the only handoff authority;
 - attach, stop, and retry are available without product-specific host logic;
+- a promoted auto-research proof demonstrates the same one-command visible
+  path with real Codex TUI panes, fixed-prompt wake, pane-local A2A ticks, and
+  compact public-safe live evidence when lane-authored evidence is claimed;
 - no raw logs, credentials, private material, absolute local paths, or
   generated transcripts enter committed docs or fixtures.
 

--- a/examples/multi-agent-product-recipe-smoke.py
+++ b/examples/multi-agent-product-recipe-smoke.py
@@ -71,6 +71,10 @@ def main() -> int:
             "first action is the pane-local A2A tick",
             "machine JSON is written to public artifacts",
             "todos and evidence are the only handoff authority",
+            "validated visible proof promotes the existing preset as\nthe reference recipe",
+            "fixed-prompt wake, pane-local A2A tick,\nrunner lifecycle, compact status, and public artifact routing stay in the\ngeneric multi-agent kernel",
+            "must not grow a private\nlauncher or hidden workflow driver",
+            "a promoted auto-research proof demonstrates the same one-command visible\n  path",
             "Auto-research should stay a reference preset, not the kernel",
             "implement it in the\nmulti-agent kernel first",
         ],
@@ -90,6 +94,10 @@ def main() -> int:
             "Multi-agent product recipe",
             "multi-agent-product-recipe.md",
             "copy the pattern without copying auto-research code",
+            "The validated visible proof is promoted into this existing command path",
+            "the operator runs one command",
+            "the generic multi-agent kernel supplies runner, wake, pane-local tick, status",
+            "fixed-prompt wake causes each pane to run\nits local A2A tick",
         ],
         source=AUTO_RESEARCH_GUIDE,
     )
@@ -98,6 +106,7 @@ def main() -> int:
         "auto-research owns the runner",
         "preset owns tmux",
         "hidden workflow engine",
+        "auto-research private launcher",
         "raw JSON should be visible first",
     ]
     for phrase in forbidden:


### PR DESCRIPTION
## Summary
- promote the validated visible auto-research proof into the existing command path instead of a second runner
- clarify that fixed-prompt wake, pane-local tick, runner lifecycle, compact status, and artifact routing stay in the generic multi-agent kernel
- extend the product-recipe smoke to guard the promotion boundary

## Validation
- PYTHONPATH=. python3 examples/multi-agent-product-recipe-smoke.py
- PYTHONPATH=. python3 examples/auto-research-layered-e2e-acceptance-smoke.py
- PYTHONPATH=. python3 examples/generic-multi-agent-one-command-smoke.py
- git diff --check
- loopx check --scan-path docs/guides/auto-research-command-path.md --scan-path docs/guides/multi-agent-product-recipe.md --scan-path examples/multi-agent-product-recipe-smoke.py