### PR TITLE
Add auto-research question contract entrypoint

### DIFF
--- a/docs/guides/auto-research-command-path.md
+++ b/docs/guides/auto-research-command-path.md
@@ -40,6 +40,30 @@ artifacts, and any live evidence packet is compact and public-safe. The proof
 must not depend on raw logs, private artifacts, credentials, local absolute
 paths, or a product-specific launcher hidden inside the auto-research preset.
 
+## User Contract Entrypoint
+
+The smallest user-facing auto-research contract is one open question:
+
+```bash
+loopx auto-research "<open question>"
+```
+
+This command does not launch panes or claim that research has been completed.
+It renders the fixed contract the visible multi-agent run must satisfy:
+
+- `research_brief`: what has been read, what has not been read, and the claim
+  boundary;
+- `action_plan`: P0/P1/P2 work, capped at five todos;
+- `evidence_refs`: code, docs, benchmarks, issues, and pull requests;
+- `next_executable_step`: whether the next step can run automatically;
+- `gate`: the exact user judgment needed before crossing a boundary.
+
+This keeps the user layer and the auto-research preset thin. The user supplies
+one open question; auto-research supplies a fixed output contract; the generic
+kernel owns the runner, real Codex TUI panes, pane-local A2A tick, and
+todo/evidence/status protocol. Use `demo-e2e` when the next step is to launch
+the multi-round visible demo.
+
 ## Start From A Clean Workspace
 
 Use a user-owned directory for the visible demo, while keeping LoopX state in

--- a/examples/auto-research-user-contract-entry-smoke.py
+++ b/examples/auto-research-user-contract-entry-smoke.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Smoke-test the one-question auto-research user contract entrypoint."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.capabilities.auto_research.user_contract import (  # noqa: E402
+    AUTO_RESEARCH_USER_CONTRACT_SCHEMA_VERSION,
+    build_auto_research_user_contract,
+)
+
+
+QUESTION = "How should LoopX make visible multi-agent auto research useful?"
+
+
+def assert_public_boundary(payload: dict[str, Any]) -> None:
+    text = json.dumps(payload, sort_keys=True)
+    forbidden = [
+        "/" + "Users/",
+        "/" + "private/",
+        "/" + "tmp/",
+        "lark" + "office",
+        "byte" + "dance",
+        "http" + "://",
+        "https" + "://",
+        "api" + "_key",
+        "pass" + "word",
+        "sec" + "ret",
+    ]
+    leaked = [needle for needle in forbidden if needle.lower() in text.lower()]
+    assert not leaked, leaked
+
+
+def assert_contract(payload: dict[str, Any]) -> None:
+    assert payload["ok"] is True, payload
+    assert payload["schema_version"] == AUTO_RESEARCH_USER_CONTRACT_SCHEMA_VERSION, payload
+    assert payload["mode"] == "user_contract", payload
+    assert payload["product_id"] == "auto-research", payload
+    assert payload["open_question"] == QUESTION, payload
+
+    layering = payload["layering"]
+    assert layering["user_layer"] == "one open question", layering
+    assert layering["auto_research_layer"] == "fixed output contract only", layering
+    assert "multi-agent runner" in layering["kernel_layer"], layering
+    assert "pane-local tick" in layering["kernel_layer"], layering
+
+    command_contract = payload["command_contract"]
+    assert command_contract["canonical_invocation"] == 'loopx auto-research "<open question>"'
+    assert command_contract["user_required_inputs"] == ["open_question"], command_contract
+    assert command_contract["max_action_plan_todos"] == 5, command_contract
+    assert command_contract["auto_research_required_outputs"] == [
+        "research_brief",
+        "action_plan",
+        "evidence_refs",
+        "next_executable_step",
+        "gate",
+    ], command_contract
+
+    brief = payload["research_brief"]
+    assert set(brief) == {"read", "not_read", "claim_boundary"}, brief
+    assert brief["read"] == [], brief
+    assert "source code" in brief["not_read"], brief
+    assert "evidence ref" in brief["claim_boundary"], brief
+
+    action_plan = payload["action_plan"]
+    assert 1 <= len(action_plan) <= 5, action_plan
+    assert [item["priority"] for item in action_plan][:2] == ["P0", "P0"], action_plan
+    assert all(item["owner_layer"] != "user_layer" for item in action_plan), action_plan
+
+    evidence = payload["evidence_refs"]
+    assert set(evidence) == {"code", "docs", "benchmarks", "issues", "pull_requests"}, evidence
+    assert all(value == [] for value in evidence.values()), evidence
+
+    step = payload["next_executable_step"]
+    assert step["can_run_automatically"] is True, step
+    assert "read-only evidence discovery" in step["step"], step
+
+    gate = payload["gate"]
+    assert gate["user_judgment_needed"], gate
+    assert "public/read-only discovery" in gate["default_without_user_gate"], gate
+
+    boundary = payload["public_boundary"]
+    assert boundary == {
+        "raw_logs": False,
+        "private_material": False,
+        "credentials": False,
+        "destructive_git": False,
+        "production_actions": False,
+    }, boundary
+    assert_public_boundary(payload)
+
+
+def run_cli(temp_dir: Path, *args: str) -> str:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(temp_dir / "registry.json"),
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=True,
+    )
+    return result.stdout
+
+
+def main() -> None:
+    payload = build_auto_research_user_contract(QUESTION)
+    assert_contract(payload)
+
+    with tempfile.TemporaryDirectory() as raw_temp_dir:
+        temp_dir = Path(raw_temp_dir)
+        shorthand_json = run_cli(temp_dir, "--format", "json", "auto-research", QUESTION)
+        assert_contract(json.loads(shorthand_json))
+
+        group_format_json = run_cli(temp_dir, "auto-research", "--format", "json", QUESTION)
+        assert_contract(json.loads(group_format_json))
+
+        explicit_json = run_cli(
+            temp_dir,
+            "--format",
+            "json",
+            "auto-research",
+            "contract",
+            QUESTION,
+            "--max-todos",
+            "3",
+        )
+        explicit_payload = json.loads(explicit_json)
+        assert len(explicit_payload["action_plan"]) == 3, explicit_payload
+
+        markdown = run_cli(temp_dir, "auto-research", QUESTION)
+        assert "# LoopX Auto Research" in markdown, markdown
+        for required in [
+            "## Research Brief",
+            "## Action Plan",
+            "## Evidence Refs",
+            "## Next Executable Step",
+            "## Gate",
+        ]:
+            assert required in markdown, markdown
+
+        supervisor_json = run_cli(
+            temp_dir,
+            "--format",
+            "json",
+            "auto-research",
+            "demo-supervisor",
+            "--goal-id",
+            "loopx-auto-research-contract-entry-smoke",
+        )
+        supervisor_payload = json.loads(supervisor_json)
+        assert supervisor_payload["schema_version"] == "auto_research_demo_supervisor_plan_v0"
+
+    print("auto-research-user-contract-entry-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -29,6 +29,7 @@ from .worker_runtime import run_auto_research_worker_turn
 from .rollout_append import (
     append_auto_research_rollout_events as _append_auto_research_rollout_events,
 )
+from .user_contract import build_auto_research_user_contract
 from ...history import load_registry
 from ...paths import resolve_runtime_root
 from ...quota import build_quota_should_run
@@ -48,6 +49,47 @@ FormatSelector = Callable[..., str]
 AddFormat = Callable[[argparse.ArgumentParser], None]
 
 AUTO_RESEARCH_DEMO_GOAL_PREFIX = "loopx-auto-research-demo"
+AUTO_RESEARCH_SUBCOMMANDS = frozenset(
+    {
+        "append-evidence",
+        "capture-live-evidence",
+        "contract",
+        "demo-e2e",
+        "demo-supervisor",
+        "evidence",
+        "frontier",
+        "worker-loop",
+        "worker-turn",
+    }
+)
+
+
+def rewrite_auto_research_question_argv(argv: list[str]) -> list[str]:
+    """Map `loopx auto-research "<question>"` to the explicit contract command."""
+
+    values = list(argv)
+    try:
+        command_index = values.index("auto-research")
+    except ValueError:
+        return values
+
+    cursor = command_index + 1
+    while cursor < len(values):
+        token = values[cursor]
+        if token == "--format" and cursor + 1 < len(values):
+            cursor += 2
+            continue
+        if token.startswith("--format="):
+            cursor += 1
+            continue
+        break
+    if cursor >= len(values):
+        return values
+
+    token = values[cursor]
+    if token.startswith("-") or token in AUTO_RESEARCH_SUBCOMMANDS:
+        return values
+    return values[:cursor] + ["contract"] + values[cursor:]
 
 
 def _demo_goal_suffix(value: object, *, fallback: str = "run") -> str:
@@ -83,10 +125,29 @@ def register_auto_research_commands(
         "auto-research",
         help="Project public-safe decentralized auto-research frontiers.",
     )
+    auto_research_parser.add_argument(
+        "--format",
+        dest="auto_research_format",
+        choices=["markdown", "json"],
+        help="Output format for the auto-research command group.",
+    )
     auto_research_sub = auto_research_parser.add_subparsers(
         dest="auto_research_command",
         required=True,
     )
+    contract_parser = auto_research_sub.add_parser(
+        "contract",
+        help="Render the fixed user-facing auto-research contract for one open question.",
+    )
+    add_subcommand_format(contract_parser)
+    contract_parser.add_argument("open_question", help="Quoted open research question.")
+    contract_parser.add_argument(
+        "--max-todos",
+        type=int,
+        default=5,
+        help="Maximum action-plan todos, capped at 5.",
+    )
+
     frontier_parser = auto_research_sub.add_parser(
         "frontier",
         help="Render a per-agent decentralized research frontier from a public fixture or live LoopX state.",
@@ -634,7 +695,12 @@ def handle_auto_research_command(
     print_payload: PrintPayload,
 ) -> int:
     try:
-        if args.auto_research_command == "frontier":
+        if args.auto_research_command == "contract":
+            payload = build_auto_research_user_contract(
+                args.open_question,
+                max_todos=args.max_todos,
+            )
+        elif args.auto_research_command == "frontier":
             if bool(args.fixture) == bool(args.goal_id):
                 raise ValueError(f"auto-research {args.auto_research_command} requires exactly one of --fixture or --goal-id")
             if args.fixture:
@@ -907,7 +973,7 @@ def handle_auto_research_command(
             )
         else:
             raise ValueError(
-                "auto-research requires the `frontier`, `evidence`, "
+                "auto-research requires the `contract`, `frontier`, `evidence`, "
                 "`append-evidence`, `capture-live-evidence`, "
                 "`worker-turn`, `worker-loop`, `demo-supervisor`, or `demo-e2e` subcommand"
             )
@@ -917,5 +983,5 @@ def handle_auto_research_command(
             "mode": "auto-research",
             "error": str(exc),
         }
-    print_payload(payload, output_format(args), render_auto_research_markdown)
+    print_payload(payload, output_format(args, "auto_research_format"), render_auto_research_markdown)
     return 0 if payload.get("ok") else 1

--- a/loopx/capabilities/auto_research/human_view.py
+++ b/loopx/capabilities/auto_research/human_view.py
@@ -8,9 +8,79 @@ on legacy presentation helpers.
 from __future__ import annotations
 
 from .evidence_packet import AUTO_RESEARCH_ROLLOUT_APPEND_SCHEMA_VERSION
+from .user_contract import AUTO_RESEARCH_USER_CONTRACT_SCHEMA_VERSION
 
 
 AUTO_RESEARCH_DEMO_E2E_SCHEMA_VERSION = "auto_research_demo_e2e_result_v0"
+
+
+def _join_or_none(values: object) -> str:
+    if isinstance(values, list) and values:
+        return ", ".join(str(item) for item in values)
+    return "none"
+
+
+def _render_user_contract(payload: dict[str, object]) -> str:
+    brief = payload.get("research_brief") if isinstance(payload.get("research_brief"), dict) else {}
+    plan = payload.get("action_plan") if isinstance(payload.get("action_plan"), list) else []
+    evidence = payload.get("evidence_refs") if isinstance(payload.get("evidence_refs"), dict) else {}
+    next_step = (
+        payload.get("next_executable_step")
+        if isinstance(payload.get("next_executable_step"), dict)
+        else {}
+    )
+    gate = payload.get("gate") if isinstance(payload.get("gate"), dict) else {}
+    gates = gate.get("user_judgment_needed") if isinstance(gate.get("user_judgment_needed"), list) else []
+    lines = [
+        "# LoopX Auto Research",
+        "",
+        f"- schema: `{payload.get('schema_version')}`",
+        f"- question: {payload.get('open_question')}",
+        "",
+        "## Research Brief",
+        "",
+        f"- read: `{_join_or_none(brief.get('read'))}`",
+        f"- not_read: `{_join_or_none(brief.get('not_read'))}`",
+        f"- claim_boundary: {brief.get('claim_boundary')}",
+        "",
+        "## Action Plan",
+        "",
+    ]
+    if not plan:
+        lines.append("- none")
+    for item in plan:
+        if not isinstance(item, dict):
+            continue
+        lines.append(
+            f"- {item.get('priority')}: {item.get('todo')} "
+            f"(`{item.get('owner_layer')}`)"
+        )
+    lines.extend(
+        [
+            "",
+            "## Evidence Refs",
+            "",
+            f"- code: `{_join_or_none(evidence.get('code'))}`",
+            f"- docs: `{_join_or_none(evidence.get('docs'))}`",
+            f"- benchmarks: `{_join_or_none(evidence.get('benchmarks'))}`",
+            f"- issues: `{_join_or_none(evidence.get('issues'))}`",
+            f"- pull_requests: `{_join_or_none(evidence.get('pull_requests'))}`",
+            "",
+            "## Next Executable Step",
+            "",
+            f"- can_run_automatically: `{next_step.get('can_run_automatically')}`",
+            f"- step: {next_step.get('step')}",
+            "",
+            "## Gate",
+            "",
+        ]
+    )
+    if not gates:
+        lines.append("- none")
+    for item in gates:
+        lines.append(f"- {item}")
+    lines.append(f"- default_without_user_gate: {gate.get('default_without_user_gate')}")
+    return "\n".join(lines) + "\n"
 
 
 def render_auto_research_projection_markdown(payload: dict[str, object]) -> str:
@@ -339,6 +409,8 @@ def render_auto_research_markdown(payload: dict[str, object]) -> str:
     schema = payload.get("schema_version")
     if schema == "auto_research_worker_turn_v0":
         return _render_worker_turn(payload)
+    if schema == AUTO_RESEARCH_USER_CONTRACT_SCHEMA_VERSION:
+        return _render_user_contract(payload)
     if schema == "auto_research_worker_loop_v0":
         return _render_worker_loop(payload)
     if schema == AUTO_RESEARCH_DEMO_E2E_SCHEMA_VERSION:

--- a/loopx/capabilities/auto_research/user_contract.py
+++ b/loopx/capabilities/auto_research/user_contract.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+AUTO_RESEARCH_USER_CONTRACT_SCHEMA_VERSION = "auto_research_user_contract_v0"
+
+
+def build_auto_research_user_contract(
+    open_question: str,
+    *,
+    max_todos: int = 5,
+) -> dict[str, Any]:
+    question = " ".join(str(open_question or "").strip().split())
+    if not question:
+        raise ValueError('auto-research requires an open question, e.g. loopx auto-research "..."')
+    todo_limit = min(max(1, int(max_todos)), 5)
+    action_plan = [
+        {
+            "priority": "P0",
+            "todo": "Define the research brief and claim boundary before making factual claims.",
+            "owner_layer": "auto_research_preset",
+        },
+        {
+            "priority": "P0",
+            "todo": "Collect evidence refs from allowed code, docs, benchmarks, issues, and PRs.",
+            "owner_layer": "generic_kernel_agents",
+        },
+        {
+            "priority": "P1",
+            "todo": "Run a decentralized multi-agent pass: curator maps sources, mapper proposes claims, runner gathers evidence, verifier checks boundaries.",
+            "owner_layer": "generic_kernel_runner",
+        },
+        {
+            "priority": "P1",
+            "todo": "Produce the next executable step and say whether it can run automatically.",
+            "owner_layer": "auto_research_preset",
+        },
+        {
+            "priority": "P2",
+            "todo": "Summarize gates and unresolved evidence gaps without expanding the user contract.",
+            "owner_layer": "auto_research_preset",
+        },
+    ][:todo_limit]
+    return {
+        "ok": True,
+        "schema_version": AUTO_RESEARCH_USER_CONTRACT_SCHEMA_VERSION,
+        "mode": "user_contract",
+        "product_id": "auto-research",
+        "open_question": question,
+        "layering": {
+            "user_layer": "one open question",
+            "auto_research_layer": "fixed output contract only",
+            "kernel_layer": "multi-agent runner, Codex TUI panes, pane-local tick, todo/evidence/status protocol",
+        },
+        "command_contract": {
+            "canonical_invocation": 'loopx auto-research "<open question>"',
+            "explicit_invocation": 'loopx auto-research contract "<open question>"',
+            "user_required_inputs": ["open_question"],
+            "auto_research_required_outputs": [
+                "research_brief",
+                "action_plan",
+                "evidence_refs",
+                "next_executable_step",
+                "gate",
+            ],
+            "max_action_plan_todos": 5,
+        },
+        "research_brief": {
+            "read": [],
+            "not_read": [
+                "source code",
+                "docs",
+                "benchmarks",
+                "issues",
+                "pull requests",
+            ],
+            "claim_boundary": (
+                "Initial contract only: no factual claim is accepted until it is backed "
+                "by an evidence ref and checked by the verifier lane."
+            ),
+        },
+        "action_plan": action_plan,
+        "evidence_refs": {
+            "code": [],
+            "docs": [],
+            "benchmarks": [],
+            "issues": [],
+            "pull_requests": [],
+        },
+        "next_executable_step": {
+            "can_run_automatically": True,
+            "step": (
+                "Start with read-only evidence discovery and claim-boundary drafting. "
+                "Escalate to the user only when private material, credentials, production "
+                "actions, or destructive git operations are required."
+            ),
+        },
+        "gate": {
+            "user_judgment_needed": [
+                "Which private or restricted sources, if any, are allowed.",
+                "Whether production actions, credentialed connectors, or destructive git are allowed.",
+                "Whether unresolved evidence gaps are acceptable for the final claim.",
+            ],
+            "default_without_user_gate": "public/read-only discovery plus local evidence draft",
+        },
+        "public_boundary": {
+            "raw_logs": False,
+            "private_material": False,
+            "credentials": False,
+            "destructive_git": False,
+            "production_actions": False,
+        },
+    }

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -17,6 +17,7 @@ from .capabilities.issue_fix.cli import (
 from .capabilities.auto_research.cli import (
     handle_auto_research_command,
     register_auto_research_commands,
+    rewrite_auto_research_question_argv,
 )
 from .capabilities.value_connectors.cli import (
     handle_value_connector_command,
@@ -119,6 +120,7 @@ def main(argv: list[str] | None = None) -> int:
     if top_level_help_requested(raw_argv):
         print(render_concise_help(sys.argv[0] if argv is None else "loopx"), end="")
         return 0
+    raw_argv = rewrite_auto_research_question_argv(raw_argv)
 
     parser = argparse.ArgumentParser(description="LoopX control-plane helper.")
     parser.add_argument("--version", action="version", version=f"loopx {__version__}")
@@ -178,7 +180,7 @@ def main(argv: list[str] | None = None) -> int:
     register_todo_command(sub)
     register_quota_command(sub)
 
-    args = parser.parse_args(argv)
+    args = parser.parse_args(raw_argv)
     registry_path = Path(args.registry).expanduser()
     if (
         args.command
@@ -211,7 +213,7 @@ def main(argv: list[str] | None = None) -> int:
             "uninstall-project",
             "version",
         }
-        and not user_supplied_registry(argv)
+        and not user_supplied_registry(raw_argv)
         and not registry_path.exists()
     ):
         runtime_root = Path(args.runtime_root).expanduser() if args.runtime_root else DEFAULT_RUNTIME_ROOT
@@ -257,7 +259,7 @@ def main(argv: list[str] | None = None) -> int:
     support_control_result = handle_support_control_command(
         args,
         registry_path=registry_path,
-        registry_was_supplied=user_supplied_registry(argv),
+        registry_was_supplied=user_supplied_registry(raw_argv),
         print_payload=print_payload,
         output_format=output_format,
     )
@@ -362,7 +364,7 @@ def main(argv: list[str] | None = None) -> int:
             args,
             registry_path=registry_path,
             runtime_root_arg=args.runtime_root,
-            allow_missing_registry=not user_supplied_registry(argv),
+            allow_missing_registry=not user_supplied_registry(raw_argv),
             print_payload=print_payload,
         )
 


### PR DESCRIPTION
## Summary
- add `loopx auto-research "<open question>"` as the fixed user contract entrypoint
- render research brief, capped action plan, evidence refs, next executable step, and gate in JSON/Markdown
- document the thin user/preset/kernel split and cover the entrypoint with a smoke test

## Validation
- `python3 -m py_compile loopx/capabilities/auto_research/user_contract.py loopx/capabilities/auto_research/cli.py loopx/cli.py loopx/capabilities/auto_research/human_view.py examples/auto-research-user-contract-entry-smoke.py`
- `python3 examples/auto-research-user-contract-entry-smoke.py`
- `python3 examples/auto-research-demo-supervisor-smoke.py`
- `python3 examples/docs-governance-smoke.py`
- `python3 examples/auto-research-minimal-kernel-smoke.py`