### PR TITLE
Update quota scheduler smoke expectations

### DIFF
--- a/examples/control_plane/quota-agent-scoped-user-gate-smoke.py
+++ b/examples/control_plane/quota-agent-scoped-user-gate-smoke.py
@@ -892,7 +892,9 @@ def assert_agent_without_advancement_candidate_and_only_monitor_work_stays_quiet
     assert scheduler["action"] == "backoff_until_material_transition", scheduler
     assert scheduler["codex_app"]["recommended_interval_minutes"] == 15, scheduler
     assert scheduler["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=15", scheduler
-    assert scheduler["codex_app"]["example_progression_minutes"] == [15, 30, 60], scheduler
+    # Monitor-only backoff is capped by the monitor cadence, so a 15m monitor
+    # should not be backed off beyond its next useful poll interval.
+    assert scheduler["codex_app"]["example_progression_minutes"] == [15, 15, 15], scheduler
     assert scheduler["unchanged_poll"]["limits"]["codex_cli_tui"] == 3, scheduler
     assert scheduler["unchanged_poll"]["final_quota_replan_check_enabled"] is True, scheduler
     assert scheduler["unchanged_poll"]["after_limits"]["claude_code_loop"] == "stop_loop", scheduler

--- a/examples/control_plane/quota-plan-smoke.py
+++ b/examples/control_plane/quota-plan-smoke.py
@@ -57,6 +57,7 @@ def scheduler_reset_profile_snapshot(scheduler: dict) -> dict:
         "codex_app_initial_interval_minutes": codex_app["recommended_interval_minutes"],
         "codex_app_initial_rrule": codex_app["recommended_rrule"],
         "codex_app_max_interval_minutes": codex_app["max_interval_minutes"],
+        "codex_app_progression_minutes": codex_app["example_progression_minutes"],
         "unchanged_poll_backoff_multiplier": codex_app["unchanged_poll_backoff_multiplier"],
         "local_scheduler_unchanged_poll_limit": limits["local_scheduler"],
         "claude_code_loop_unchanged_poll_limit": limits["claude_code_loop"],


### PR DESCRIPTION
## Summary
- align the agent-scoped monitor quiet-skip smoke with monitor cadence-capped scheduler backoff
- include `codex_app_progression_minutes` in the quota-plan smoke reset-token helper so it matches the runtime scheduler profile hash

## Audit result
- Ran a bounded full-public non-benchmark smoke batch for canary/quota/todo/project/session_runtime surfaces.
- Initial run: 77 executed, 2 stale characterization failures, 0 timeouts, 0 tracked side effects.
- After this fix: 77 executed, 0 failures, 0 timeouts, 0 tracked side effects.
- Module dry-run showed broad tokens can select benchmark-like scripts, so the executed batch used an explicit filtered script list to preserve the non-benchmark boundary.

## Validation
- PYTHONPATH=. python3 examples/control_plane/quota-agent-scoped-user-gate-smoke.py
- PYTHONPATH=. python3 examples/control_plane/quota-plan-smoke.py
- PYTHONPATH=. python3 examples/control_plane/monitor-scheduler-contract-smoke.py
- PYTHONPATH=. python3 -m loopx.cli --format json canary smoke-suite --suite full-public --script <77 non-benchmark scripts> --timeout-seconds 120 --no-progress
- git diff --check
- loopx check --scan-path examples/control_plane/quota-agent-scoped-user-gate-smoke.py --scan-path examples/control_plane/quota-plan-smoke.py
