### PR TITLE
Make app-server Goal baseline bridge-only by default

### DIFF
--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -1182,10 +1182,10 @@ def test_host_worker_contract_only_cli() -> None:
     assert contract["route"] == ROUTE, contract
     assert contract["worker_adapter"]["script"] == "scripts/skillsbench_host_codex_goal_worker.py", contract
     assert contract["worker_adapter"]["reasoning_effort"] == "high", contract
-    assert contract["worker_adapter"]["prompt_style"] == "native-goal", contract
+    assert contract["worker_adapter"]["prompt_style"] == "bridge-only", contract
     assert payload["loopx_mode"] == "codex_goal_mode_baseline", payload
     assert payload["loopx_access_packet_mode"] == "none", payload
-    assert payload["app_server_goal_prompt_style"] == "native-goal", payload
+    assert payload["app_server_goal_prompt_style"] == "bridge-only", payload
     assert payload["loopx_case_lifecycle_packet_injected"] is False, payload
     assert payload["benchmark_case_lifecycle_contract"] is None, payload
 
@@ -1236,33 +1236,33 @@ def test_host_worker_treatment_lifecycle_packet_is_public_safe() -> None:
     assert "/Users/" not in prompt
 
 
-def test_host_worker_cli_exec_like_prompt_style_suppresses_lifecycle_packet() -> None:
+def test_host_worker_bridge_prompt_styles_suppress_lifecycle_packet() -> None:
     worker = _load_worker_module()
-    args = worker.parse_args(
-        [
-            "--task-id",
-            "tictoc-unnecessary-abort-detection",
-            "--contract-only",
-            "--app-server-goal-prompt-style",
-            "cli-exec-like",
-            "--loopx-mode",
-            "codex_loopx",
-            "--loopx-access-packet-mode",
-            "compact",
-            "--loopx-case-id",
-            "tictoc-unnecessary-abort-detection",
-            "--loopx-arm-id",
-            "loopx_prompt_polling_test",
-            "--loopx-max-rounds",
-            "5",
-        ]
-    )
-    packet, contract = worker.build_loopx_case_lifecycle_packet(args)
-    assert packet == ""
-    assert contract is None
-    payload = worker.build_contract_payload(args)
-    assert payload["worker_adapter"]["prompt_style"] == "cli-exec-like", payload
-
+    for style in ("bridge-only", "cli-exec-like"):
+        args = worker.parse_args(
+            [
+                "--task-id",
+                "tictoc-unnecessary-abort-detection",
+                "--contract-only",
+                "--app-server-goal-prompt-style",
+                style,
+                "--loopx-mode",
+                "codex_loopx",
+                "--loopx-access-packet-mode",
+                "compact",
+                "--loopx-case-id",
+                "tictoc-unnecessary-abort-detection",
+                "--loopx-arm-id",
+                "loopx_prompt_polling_test",
+                "--loopx-max-rounds",
+                "5",
+            ]
+        )
+        packet, contract = worker.build_loopx_case_lifecycle_packet(args)
+        assert packet == ""
+        assert contract is None
+        payload = worker.build_contract_payload(args)
+        assert payload["worker_adapter"]["prompt_style"] == style, payload
 
 def test_host_worker_waits_for_completion_and_keeps_public_json_compact() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-app-goal-worker-") as tmp:
@@ -2505,7 +2505,7 @@ def _app_server_goal_command_args(first_action_timeout: int | None) -> Namespace
         local_acp_relay_command="",
         route=ROUTE,
         app_server_reasoning_effort="high",
-        app_server_goal_prompt_style="native-goal",
+        app_server_goal_prompt_style="bridge-only",
         app_server_acp_heartbeat_interval_sec=120.0,
         dataset="skillsbench@1.1",
         task_id="llm-prefix-cache-replay",
@@ -3025,7 +3025,7 @@ if __name__ == "__main__":
     test_launcher_plan_only_marks_bridge_ready_when_explicit()
     test_launcher_plan_only_marks_runner_ready_with_host_acp_launch()
     test_host_worker_contract_only_cli()
-    test_host_worker_cli_exec_like_prompt_style_suppresses_lifecycle_packet()
+    test_host_worker_bridge_prompt_styles_suppress_lifecycle_packet()
     test_host_worker_waits_for_completion_and_keeps_public_json_compact()
     test_host_worker_recovers_when_first_turn_only_echoes_context()
     test_host_worker_can_run_normal_no_reward_followup()

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -799,7 +799,7 @@ def build_skillsbench_app_server_goal_worker_contract(
     cwd: str = "<skillsbench-task-workspace>",
     model: str = SKILLSBENCH_DEFAULT_MODEL,
     reasoning_effort: str = "high",
-    prompt_style: str = "native-goal",
+    prompt_style: str = "bridge-only",
     codex_bin: str = "codex",
     sandbox: str = "workspace-write",
     approval_policy: str = "never",
@@ -826,9 +826,9 @@ def build_skillsbench_app_server_goal_worker_contract(
     safe_task_id = _skillsbench_public_safe_label(task_id, limit=120)
     blockers = [str(item) for item in known_blockers if str(item)]
     safe_prompt_style = _skillsbench_public_safe_label(prompt_style, limit=40)
-    if safe_prompt_style not in {"native-goal", "cli-exec-like"}:
+    if safe_prompt_style not in {"bridge-only", "native-goal", "cli-exec-like"}:
         blockers.append("skillsbench_app_server_goal_prompt_style_invalid")
-        safe_prompt_style = "native-goal"
+        safe_prompt_style = "bridge-only"
     if not safe_dataset:
         safe_dataset = SKILLSBENCH_DEFAULT_DATASET
         blockers.append("skillsbench_dataset_not_public_safe")

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -468,9 +468,9 @@ def _prompt_with_app_server_closeout_instruction(prompt_text: str) -> str:
 
 def _normalized_app_server_goal_prompt_style(style: str | None) -> str:
     text = str(style or "").strip().lower()
-    if text in {"native-goal", "cli-exec-like"}:
+    if text in {"bridge-only", "native-goal", "cli-exec-like"}:
         return text
-    return "native-goal"
+    return "bridge-only"
 
 
 def _recoverable_codex_turn_failure_message(category: str) -> str:
@@ -526,7 +526,7 @@ class CodexExecConfig:
     stream_heartbeat_interval_sec: float = 120.0
     first_action_timeout_sec: float = 0.0
     app_server_goal_followup_max: int = 0
-    app_server_goal_prompt_style: str = "native-goal"
+    app_server_goal_prompt_style: str = "bridge-only"
     bridge_idle_timeout_sec: float = 0.0
     task_output_quiet_timeout_sec: float = 0.0
     reasoning_effort: str | None = None

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -1109,7 +1109,7 @@ def _host_local_acp_launch_command(
                     )
                 ),
                 "--app-server-goal-prompt-style",
-                str(getattr(args, "app_server_goal_prompt_style", "native-goal")),
+                str(getattr(args, "app_server_goal_prompt_style", "bridge-only")),
             ]
         )
         if worker_trace_dir:
@@ -7933,8 +7933,8 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
     app_server_reasoning_effort = _effective_app_server_reasoning_effort(args)
     codex_cli_reasoning_effort = _effective_codex_cli_reasoning_effort(args)
     app_server_goal_prompt_style = str(
-        getattr(args, "app_server_goal_prompt_style", "native-goal")
-        or "native-goal"
+        getattr(args, "app_server_goal_prompt_style", "bridge-only")
+        or "bridge-only"
     )
     codex_api_egress_preflight = _public_codex_api_egress_contract(
         args,
@@ -14725,13 +14725,13 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     )
     parser.add_argument(
         "--app-server-goal-prompt-style",
-        choices=("native-goal", "cli-exec-like"),
-        default="native-goal",
+        choices=("bridge-only", "native-goal", "cli-exec-like"),
+        default="bridge-only",
         help=(
-            "Prompt framing for codex-app-server-goal-baseline. native-goal "
-            "preserves the existing app-server Goal closeout/lifecycle "
-            "framing; cli-exec-like keeps the worker prompt closer to the "
-            "Codex exec bridge prompt for diagnostic canaries."
+            "Prompt framing for codex-app-server-goal-baseline. bridge-only "
+            "keeps the bare app-server baseline to task prompt plus sandbox "
+            "bridge; native-goal adds app closeout framing; cli-exec-like keeps "
+            "the worker prompt closer to Codex exec for diagnostic compatibility."
         ),
     )
     parser.add_argument("--max-verifier-output-chars", type=int, default=0)

--- a/scripts/skillsbench_host_codex_goal_worker.py
+++ b/scripts/skillsbench_host_codex_goal_worker.py
@@ -42,7 +42,7 @@ SKILLS_INSTRUCTIONS_END_MARKER = "</skills_instructions>"
 NORMAL_FOLLOWUP_PROMPT = """Continue the same SkillsBench task in this existing Goal thread.
 Do not use or infer verifier, reward, pass/fail, hidden-test, or gold-answer feedback; none is being provided.
 Review your prior work, improve the scored output if needed using only the visible task, workspace, and bridge context already available in this thread, and end the turn once the best task-required output exists."""
-APP_SERVER_GOAL_PROMPT_STYLES = ("native-goal", "cli-exec-like")
+APP_SERVER_GOAL_PROMPT_STYLES = ("bridge-only", "native-goal", "cli-exec-like")
 
 
 def _json_default(value: Any) -> str:
@@ -68,12 +68,12 @@ def _public_safe_label(value: Any, *, limit: int = 80) -> str:
 
 def _app_server_goal_prompt_style(args: argparse.Namespace) -> str:
     style = str(
-        getattr(args, "app_server_goal_prompt_style", "native-goal")
-        or "native-goal"
+        getattr(args, "app_server_goal_prompt_style", "bridge-only")
+        or "bridge-only"
     )
     if style in APP_SERVER_GOAL_PROMPT_STYLES:
         return style
-    return "native-goal"
+    return "bridge-only"
 
 
 def build_contract_payload(args: argparse.Namespace) -> dict[str, Any]:
@@ -97,7 +97,7 @@ def build_contract_payload(args: argparse.Namespace) -> dict[str, Any]:
 def build_loopx_case_lifecycle_packet(
     args: argparse.Namespace,
 ) -> tuple[str, dict[str, object] | None]:
-    if _app_server_goal_prompt_style(args) == "cli-exec-like":
+    if _app_server_goal_prompt_style(args) in {"bridge-only", "cli-exec-like"}:
         return "", None
     if args.loopx_mode != "codex_loopx":
         return "", None
@@ -633,10 +633,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument(
         "--app-server-goal-prompt-style",
         choices=APP_SERVER_GOAL_PROMPT_STYLES,
-        default="native-goal",
+        default="bridge-only",
         help=(
             "Prompt framing for native app-server Goal worker turns. "
-            "native-goal preserves the current app-server Goal contract; "
+            "bridge-only keeps the bare app-server baseline to task prompt "
+            "plus sandbox bridge only; native-goal adds app closeout framing; "
             "cli-exec-like suppresses app-only lifecycle prompt injection so "
             "canaries can isolate task framing versus Codex exec."
         ),

--- a/scripts/skillsbench_local_acp_relay.py
+++ b/scripts/skillsbench_local_acp_relay.py
@@ -115,13 +115,14 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     )
     parser.add_argument(
         "--app-server-goal-prompt-style",
-        choices=("native-goal", "cli-exec-like"),
-        default="native-goal",
+        choices=("bridge-only", "native-goal", "cli-exec-like"),
+        default="bridge-only",
         help=(
-            "Prompt framing for --app-server-goal-worker. native-goal keeps "
-            "the app-server closeout/lifecycle framing; cli-exec-like keeps "
-            "the worker prompt closer to the Codex exec bridge prompt for "
-            "diagnostic canaries."
+            "Prompt framing for --app-server-goal-worker. bridge-only keeps "
+            "the bare app-server baseline to task prompt plus sandbox bridge; "
+            "native-goal adds app closeout framing; cli-exec-like keeps the "
+            "worker prompt closer to the Codex exec bridge prompt for "
+            "diagnostic compatibility."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- make the bare SkillsBench app-server Goal baseline use `bridge-only` prompt framing by default
- keep `native-goal` as the explicit closeout-framed mode and `cli-exec-like` as a diagnostic compatibility mode
- suppress LoopX case lifecycle packet injection for `bridge-only` and `cli-exec-like` styles
- update the app-server worker smoke to cover bridge-only defaults and lifecycle-packet suppression

## Validation
- `python3 -m py_compile scripts/skillsbench_automation_loop.py scripts/skillsbench_local_acp_relay.py scripts/skillsbench_host_codex_goal_worker.py loopx/benchmark_adapters/skillsbench.py loopx/benchmark_adapters/skillsbench_acp_relay.py examples/skillsbench-app-server-goal-worker-smoke.py`
- `python3 examples/skillsbench-app-server-goal-worker-smoke.py`
- `git diff --check`
- plan-only sanity: app-server baseline reports `prompt_style=bridge-only`, worker contract `prompt_style=bridge-only`, lifecycle packet `null`

## SkillsBench ablation
Ran app-server Goal xhigh bridge-only on three previously informative cases; all three completed with official score 1.0 and public-safe worker traces showing one completed native Goal turn with effective bridge activity:

| case | score | prompt | effort |
| --- | ---: | --- | --- |
| jax-computing-basics | 1.0 | bridge-only | xhigh |
| threejs-to-obj | 1.0 | bridge-only | xhigh |
| react-performance-debugging | 1.0 | bridge-only | xhigh |

No private proxy endpoint, raw task text, raw trajectory, verifier output, or local/remote artifact path is included in this PR.
