### PR TITLE
Add smoke-suite module exclusions

### DIFF
--- a/examples/canary/smoke-suite-runner-smoke.py
+++ b/examples/canary/smoke-suite-runner-smoke.py
@@ -61,6 +61,29 @@ def assert_module_preview_selects_matching_scripts() -> None:
     assert all("quota" in command for command in commands), payload
 
 
+def assert_module_preview_supports_exclusions() -> None:
+    payload = build_canary_smoke_suite_run(
+        suite="full-public",
+        modules=["status"],
+        exclude_modules=["benchmark", "skillsbench", "terminal-bench", "swe-marathon"],
+        execute=False,
+    )
+    assert payload["ok"] is True, payload
+    assert payload["warning_count"] == 0, payload
+    assert payload["selected_check_count"] > 0, payload
+    scripts = [check["normalized"]["script"] for check in payload["selected_checks"]]
+    assert all("status" in script for script in scripts), payload
+    assert all("benchmark" not in script for script in scripts), payload
+    assert all("skillsbench" not in script for script in scripts), payload
+    assert all("terminal-bench" not in script for script in scripts), payload
+    assert payload["selection_inputs"]["exclude_modules"] == [
+        "benchmark",
+        "skillsbench",
+        "terminal-bench",
+        "swe-marathon",
+    ], payload
+
+
 def assert_subdirectory_smoke_selection_is_supported() -> None:
     script = "examples/canary/smoke-suite-subdir-discovery-smoke.py"
     for selector in [script, "canary/smoke-suite-subdir-discovery-smoke.py", Path(script).name]:
@@ -126,7 +149,9 @@ def assert_cli_json_preview_works() -> None:
             "--suite",
             "default-public",
             "--module",
-            "canary",
+            "status",
+            "--exclude-module",
+            "benchmark",
             "--limit",
             "2",
             "--no-execute",
@@ -140,6 +165,7 @@ def assert_cli_json_preview_works() -> None:
     assert payload["ok"] is True, payload
     assert payload["schema_version"] == "canary_smoke_suite_run_v0", payload
     assert payload["selected_check_count"] == 2, payload
+    assert payload["selection_inputs"]["exclude_modules"] == ["benchmark"], payload
     assert payload["executes_checks"] is False, payload
 
 
@@ -327,6 +353,7 @@ def main() -> int:
     assert_default_public_preview_excludes_grouped_smokes()
     assert_full_public_preview_injects_safe_group_args()
     assert_module_preview_selects_matching_scripts()
+    assert_module_preview_supports_exclusions()
     assert_subdirectory_smoke_selection_is_supported()
     assert_legacy_root_script_selector_matches_moved_smokes()
     assert_catalog_profile_preview_is_supported()

--- a/loopx/canary/runner.py
+++ b/loopx/canary/runner.py
@@ -298,10 +298,12 @@ def _discover_smoke_suite_checks(
     *,
     suite: str,
     modules: list[str] | None = None,
+    exclude_modules: list[str] | None = None,
     scripts: list[str] | None = None,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     normalized_suite = suite if suite in SMOKE_SUITE_CHOICES else "default-public"
     modules = list(modules or [])
+    exclude_modules = list(exclude_modules or [])
     requested_scripts = {
         script for script in (_normalize_script_filter(item) for item in (scripts or [])) if script
     }
@@ -318,6 +320,9 @@ def _discover_smoke_suite_checks(
         if requested_scripts and requested_scripts.isdisjoint(script_filter_keys):
             continue
         if not _matches_modules(script, modules):
+            continue
+        if exclude_modules and _matches_modules(script, exclude_modules):
+            missing_scripts.difference_update(script_filter_keys)
             continue
         selected.append(script)
         missing_scripts.difference_update(script_filter_keys)
@@ -348,6 +353,7 @@ def build_canary_smoke_suite_run(
     *,
     suite: str = "default-public",
     modules: list[str] | None = None,
+    exclude_modules: list[str] | None = None,
     scripts: list[str] | None = None,
     catalog_path: Path | None = None,
     changed_files: list[str] | None = None,
@@ -373,6 +379,7 @@ def build_canary_smoke_suite_run(
 
     normalized_suite = suite if suite in SMOKE_SUITE_CHOICES else "default-public"
     modules = list(modules or [])
+    exclude_modules = list(exclude_modules or [])
     scripts = list(scripts or [])
     families = list(families or [])
     profiles = list(profiles or [])
@@ -390,6 +397,7 @@ def build_canary_smoke_suite_run(
         suite_checks, suite_warnings = _discover_smoke_suite_checks(
             suite=normalized_suite,
             modules=modules,
+            exclude_modules=exclude_modules,
             scripts=scripts,
         )
         selected.extend(suite_checks)
@@ -550,6 +558,7 @@ def build_canary_smoke_suite_run(
         "selection_inputs": {
             "suite": normalized_suite,
             "modules": modules,
+            "exclude_modules": exclude_modules,
             "scripts": scripts,
             "changed_files": changed_files,
             "surfaces": surfaces,

--- a/loopx/cli_commands/canary.py
+++ b/loopx/cli_commands/canary.py
@@ -291,6 +291,15 @@ def register_canary_commands(
         help="Filter suite scripts by module token, such as quota, status, or canary. Repeatable.",
     )
     smoke_parser.add_argument(
+        "--exclude-module",
+        action="append",
+        default=[],
+        help=(
+            "Exclude suite scripts by module token after positive --module/--script selection. "
+            "Useful for bounded non-benchmark sweeps."
+        ),
+    )
+    smoke_parser.add_argument(
         "--script",
         action="append",
         default=[],
@@ -399,6 +408,7 @@ def handle_canary_command(
         payload = build_canary_smoke_suite_run(
             suite=str(args.suite or "default-public"),
             modules=list(args.module or []),
+            exclude_modules=list(args.exclude_module or []),
             scripts=list(args.script or []),
             catalog_path=args.catalog,
             changed_files=changed_files,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,14 @@ def pytest_addoption(parser) -> None:
         help="Module token filter passed through to the LoopX runner. Repeat or comma-separate.",
     )
     group.addoption(
+        "--loopx-smoke-exclude-module",
+        "--smoke-exclude-module",
+        action="append",
+        default=[],
+        dest="loopx_smoke_exclude_modules",
+        help="Module token exclusion passed through to the LoopX runner. Repeat or comma-separate.",
+    )
+    group.addoption(
         "--loopx-smoke-script",
         "--smoke-script",
         action="append",

--- a/tests/test_smoke_suite.py
+++ b/tests/test_smoke_suite.py
@@ -21,6 +21,7 @@ def _build_preview(config: Any) -> dict[str, Any]:
     return build_canary_smoke_suite_run(
         suite=str(config.getoption("loopx_smoke_suite") or "default-public"),
         modules=_option_list(config, "loopx_smoke_modules"),
+        exclude_modules=_option_list(config, "loopx_smoke_exclude_modules"),
         scripts=_option_list(config, "loopx_smoke_scripts"),
         families=_option_list(config, "loopx_smoke_families"),
         profiles=_option_list(config, "loopx_smoke_profiles"),


### PR DESCRIPTION
## Summary
- add smoke-suite `exclude_modules` support in the canary runner
- expose `--exclude-module` through the LoopX CLI and pytest smoke-suite facade
- cover non-benchmark status smoke selection in the canary runner smoke

## Why
Broad module tokens such as `status` can match benchmark-adjacent smoke scripts by path/name. The full-public non-benchmark audit needs a reusable runner-level negative selector instead of hand-curated script lists.

## Validation
- `PYTHONPATH=. python3 examples/canary/smoke-suite-runner-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli --format json canary smoke-suite --suite full-public --module status --exclude-module benchmark --exclude-module skillsbench --exclude-module terminal-bench --exclude-module swe-marathon --timeout-seconds 120 --no-progress` (14/14 passed)
- `uv run --extra test python -m pytest -q tests/test_smoke_suite.py --loopx-smoke-suite full-public --loopx-smoke-module status --loopx-smoke-exclude-module benchmark --loopx-smoke-exclude-module skillsbench --loopx-smoke-exclude-module terminal-bench --loopx-smoke-exclude-module swe-marathon --loopx-smoke-limit 1 --loopx-smoke-timeout 90`
- `git diff --check`
- `loopx check --scan-path loopx/canary/runner.py --scan-path loopx/cli_commands/canary.py --scan-path tests/conftest.py --scan-path tests/test_smoke_suite.py --scan-path examples/canary/smoke-suite-runner-smoke.py`
