### PR TITLE
Add one-click auto-research start entry

### DIFF
--- a/docs/guides/auto-research-command-path.md
+++ b/docs/guides/auto-research-command-path.md
@@ -61,8 +61,19 @@ It renders the fixed contract the visible multi-agent run must satisfy:
 This keeps the user layer and the auto-research preset thin. The user supplies
 one open question; auto-research supplies a fixed output contract; the generic
 kernel owns the runner, real Codex TUI panes, pane-local A2A tick, and
-todo/evidence/status protocol. Use `demo-e2e` when the next step is to launch
-the multi-round visible demo.
+todo/evidence/status protocol.
+
+The contract also includes the next one-command launch surface:
+
+```bash
+loopx auto-research start "<open question>" --execute
+```
+
+Without `--execute`, `start` returns the same contract-anchored runner packet as
+a dry-run preview. With `--execute`, it creates an isolated research frontier
+and starts the visible Codex TUI lanes through the generic multi-agent kernel.
+The user still only supplies one open question; agent ids, pane-local tick
+commands, evidence schemas, and runner wiring stay inside the kernel.
 
 ## Start From A Clean Workspace
 
@@ -90,32 +101,29 @@ loopx doctor
 
 ## 0. Prove The Worker-Loop Positive Path
 
-The fastest honest positive check is the worker-loop E2E path. It seeds a fresh
-demo-local LoopX goal, lets role-compatible workers read quota/frontier state,
-complete todo-backed turns, append public rollout evidence, and report the
-measured gain. It is intentionally small and still does not claim that visible
-Codex lanes authored the research result unless a compact live evidence packet
-is supplied.
+The fastest honest positive check is the one-question start path. It seeds a
+fresh demo-local LoopX goal, lets role-compatible workers read quota/frontier
+state, opens visible Codex TUI panes by default, and keeps the first output tied
+to the fixed user contract. It is intentionally small and still does not claim
+that visible Codex lanes authored the research result unless a compact live
+evidence packet is supplied.
 
-To run the multi-round path and open visible panes through the normal
-auto-research surface, use the human-facing command:
+To run the normal human-facing path and open visible panes:
 
 ```bash
 loopx --registry "$LOOPX_REGISTRY" \
   --runtime-root "$LOOPX_RUNTIME_ROOT" \
-  auto-research demo-e2e \
-  --agent-id codex-side-bypass \
-  --reasoning-effort high \
+  auto-research start "How should we evaluate autonomous research agents?" \
   --execute \
   --replace-existing
 ```
 
-That command is the user-facing UX for a multi-round visible demo. It creates a
-fresh isolated demo goal by default, runs the LoopX worker-loop, launches the
-visible tmux lanes, and attaches to the session. Each tmux window should open as
-a real interactive Codex CLI TUI role, not as a JSON/status stream. Generic
-launcher internals stay inside LoopX; the operator does not need to know the
-module or implementation path.
+That command is the user-facing UX for auto-research. It creates a fresh
+isolated demo goal by default, launches the visible tmux lanes, and attaches to
+the session. Each tmux window should open as a real interactive Codex CLI TUI
+role, not as a JSON/status stream. Generic launcher internals stay inside
+LoopX; the operator does not need to know `demo-e2e`, agent ids, or
+implementation paths.
 
 Visible Codex TUI panes default to the caller's current workspace, not to a
 demo-local git worktree. The demo registry, runtime root, queue, and evidence
@@ -138,9 +146,7 @@ multi-round positive path:
 ```bash
 loopx --registry "$LOOPX_REGISTRY" \
   --runtime-root "$LOOPX_RUNTIME_ROOT" \
-  auto-research demo-e2e \
-  --agent-id codex-side-bypass \
-  --reasoning-effort high
+  auto-research start "How should we evaluate autonomous research agents?"
 ```
 
 When the dry-run looks right, run the multi-round positive path:
@@ -148,9 +154,7 @@ When the dry-run looks right, run the multi-round positive path:
 ```bash
 loopx --registry "$LOOPX_REGISTRY" \
   --runtime-root "$LOOPX_RUNTIME_ROOT" \
-  auto-research demo-e2e \
-  --agent-id codex-side-bypass \
-  --reasoning-effort high \
+  auto-research start "How should we evaluate autonomous research agents?" \
   --execute
 ```
 
@@ -160,9 +164,7 @@ make the headless path explicit:
 ```bash
 loopx --registry "$LOOPX_REGISTRY" \
   --runtime-root "$LOOPX_RUNTIME_ROOT" \
-  --format json auto-research demo-e2e \
-  --agent-id codex-side-bypass \
-  --reasoning-effort high \
+  --format json auto-research start "How should we evaluate autonomous research agents?" \
   --execute \
   --headless
 ```

--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -595,6 +595,7 @@ def main() -> int:
                 assert visible_readiness["coordination_pattern"] == "decentralized_state_a2a", visible_readiness
                 assert visible_readiness["leader_agent_required"] is False, visible_readiness
                 assert visible_readiness["checks"] == {
+                    "user_contract_accepted": True,
                     "visible_lanes_accepted": True,
                     "cadence_wake_verified": True,
                     "pane_local_multi_round_verified": True,
@@ -614,6 +615,7 @@ def main() -> int:
                 assert improvement["best_metric_source"] == "round_1_dev", improvement
                 assert improvement["improved_over_baseline"] is True, improvement
                 assert improvement["holdout_delta_over_dev"] is None, improvement
+                assert "auto-research start" in visible_readiness["one_command"], visible_readiness
                 assert "--wake-visible-after-launch" in visible_readiness["one_command"], visible_readiness
                 launch = visible_payload["visible_launch"]["launch_result"]
                 assert launch["started_lane_count"] == 4, visible_payload

--- a/examples/auto-research-layered-e2e-acceptance-smoke.py
+++ b/examples/auto-research-layered-e2e-acceptance-smoke.py
@@ -202,6 +202,19 @@ def assert_two_round_outcome(payload: dict[str, Any]) -> None:
     assert payload["result_source"] == "loopx_worker_loop_public_evidence", payload
     assert payload["route_contract"]["goal_surface_mode"] == "fresh_demo_goal", payload
 
+    user_contract = payload["user_contract"]
+    assert user_contract["mode"] == "user_contract", user_contract
+    assert user_contract["open_question"], user_contract
+    assert user_contract["one_click_start"]["uses_generic_kernel"] is True, user_contract
+    assert (
+        user_contract["one_click_start"]["command_template"]
+        == 'loopx auto-research start "<open question>" --execute'
+    ), user_contract
+    assert payload["contract_acceptance"]["accepted"] is True, payload
+    assert payload["contract_acceptance"]["checks"]["one_click_start_present"] is True, payload
+    assert "auto-research start" in payload["commands"]["one_question_start"], payload
+    assert "--execute" in payload["commands"]["one_question_start"], payload
+
     supervisor = payload["supervisor"]
     assert supervisor["uses_generic_runner"] is True, supervisor
     assert supervisor["domain_specific_runner_logic"] is False, supervisor

--- a/examples/auto-research-user-contract-entry-smoke.py
+++ b/examples/auto-research-user-contract-entry-smoke.py
@@ -57,6 +57,10 @@ def assert_contract(payload: dict[str, Any]) -> None:
 
     command_contract = payload["command_contract"]
     assert command_contract["canonical_invocation"] == 'loopx auto-research "<open question>"'
+    assert (
+        command_contract["one_click_start_invocation"]
+        == 'loopx auto-research start "<open question>" --execute'
+    )
     assert command_contract["user_required_inputs"] == ["open_question"], command_contract
     assert command_contract["max_action_plan_todos"] == 5, command_contract
     assert command_contract["auto_research_required_outputs"] == [
@@ -66,6 +70,19 @@ def assert_contract(payload: dict[str, Any]) -> None:
         "next_executable_step",
         "gate",
     ], command_contract
+
+    one_click_start = payload["one_click_start"]
+    assert (
+        one_click_start["command_template"]
+        == 'loopx auto-research start "<open question>" --execute'
+    ), one_click_start
+    assert one_click_start["command"].startswith("loopx auto-research start "), one_click_start
+    assert one_click_start["command"].endswith(" --execute"), one_click_start
+    assert one_click_start["preview_command"].startswith("loopx auto-research start "), one_click_start
+    assert one_click_start["starts"] == "visible_codex_tui_lanes", one_click_start
+    assert one_click_start["uses_generic_kernel"] is True, one_click_start
+    assert one_click_start["coordination_model"] == "decentralized_state_a2a", one_click_start
+    assert "agent_ids" in one_click_start["user_does_not_choose"], one_click_start
 
     brief = payload["research_brief"]
     assert set(brief) == {"read", "not_read", "claim_boundary"}, brief
@@ -144,12 +161,55 @@ def main() -> None:
         explicit_payload = json.loads(explicit_json)
         assert len(explicit_payload["action_plan"]) == 3, explicit_payload
 
+        start_json = run_cli(
+            temp_dir,
+            "--format",
+            "json",
+            "auto-research",
+            "start",
+            QUESTION,
+        )
+        start_payload = json.loads(start_json)
+        assert start_payload["ok"] is True, start_payload
+        assert start_payload["mode"] == "dry_run", start_payload
+        assert start_payload["execution_kind"] == "worker_loop_preview", start_payload
+        assert start_payload["contract_acceptance"]["accepted"] is True, start_payload
+        assert_contract(start_payload["user_contract"])
+        assert (
+            start_payload["commands"]["one_question_contract"]
+            == f"loopx auto-research '{QUESTION}'"
+        ), start_payload
+        assert (
+            start_payload["commands"]["one_question_start"]
+            == f"loopx auto-research start '{QUESTION}' --execute"
+        ), start_payload
+        assert_public_boundary(start_payload)
+
+        start_headless_json = run_cli(
+            temp_dir,
+            "--format",
+            "json",
+            "auto-research",
+            "start",
+            QUESTION,
+            "--execute",
+            "--headless",
+        )
+        start_headless_payload = json.loads(start_headless_json)
+        assert start_headless_payload["ok"] is True, start_headless_payload
+        assert start_headless_payload["execution_kind"] == "loopx_worker_loop", start_headless_payload
+        assert start_headless_payload["contract_acceptance"]["accepted"] is True, start_headless_payload
+        assert start_headless_payload["worker_loop"]["executed_turn_count"] >= 5, start_headless_payload
+        assert "auto-research start" in start_headless_payload["commands"]["one_question_start"], start_headless_payload
+        assert_public_boundary(start_headless_payload)
+
         markdown = run_cli(temp_dir, "auto-research", QUESTION)
         assert "# LoopX Auto Research" in markdown, markdown
         for required in [
             "## Research Brief",
             "## Action Plan",
             "## Evidence Refs",
+            "## One-Click Start",
             "## Next Executable Step",
             "## Gate",
         ]:

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -49,6 +49,7 @@ FormatSelector = Callable[..., str]
 AddFormat = Callable[[argparse.ArgumentParser], None]
 
 AUTO_RESEARCH_DEMO_GOAL_PREFIX = "loopx-auto-research-demo"
+AUTO_RESEARCH_START_AGENT_ID = "auto-research-operator"
 AUTO_RESEARCH_SUBCOMMANDS = frozenset(
     {
         "append-evidence",
@@ -58,6 +59,7 @@ AUTO_RESEARCH_SUBCOMMANDS = frozenset(
         "demo-supervisor",
         "evidence",
         "frontier",
+        "start",
         "worker-loop",
         "worker-turn",
     }
@@ -146,6 +148,106 @@ def register_auto_research_commands(
         type=int,
         default=5,
         help="Maximum action-plan todos, capped at 5.",
+    )
+
+    start_parser = auto_research_sub.add_parser(
+        "start",
+        help="Start visible multi-agent auto-research from one open question.",
+    )
+    add_subcommand_format(start_parser)
+    start_parser.add_argument("open_question", help="Quoted open research question.")
+    start_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help=(
+            "Create an isolated research goal and launch visible Codex TUI lanes. "
+            "Omit to preview the exact contract, commands, and runner packet."
+        ),
+    )
+    start_parser.add_argument(
+        "--headless",
+        action="store_true",
+        help="With --execute, run the non-interactive worker-loop proof instead of visible panes.",
+    )
+    start_parser.add_argument(
+        "--wake-visible-after-launch",
+        action="store_true",
+        help="After launching visible panes, broadcast the fixed decentralized A2A wake prompt.",
+    )
+    start_parser.add_argument(
+        "--no-attach",
+        action="store_true",
+        help="With visible --execute, start tmux in the background instead of attaching.",
+    )
+    start_parser.add_argument(
+        "--attach",
+        action="store_true",
+        help="With visible --execute, attach to tmux after launch. This is the default unless --no-attach or --wake-visible-after-launch is set.",
+    )
+    start_parser.add_argument(
+        "--demo-run-id",
+        help="Optional public-safe suffix for the isolated goal id.",
+    )
+    start_parser.add_argument(
+        "--goal-id",
+        help=argparse.SUPPRESS,
+    )
+    start_parser.add_argument(
+        "--tracking-goal-id",
+        help=argparse.SUPPRESS,
+    )
+    start_parser.add_argument(
+        "--worker-loop-rounds",
+        type=int,
+        default=3,
+        help=argparse.SUPPRESS,
+    )
+    start_parser.add_argument(
+        "--session-name",
+        default="loopx-auto-research",
+        help="Public-safe tmux session name for visible lanes.",
+    )
+    start_parser.add_argument(
+        "--workspace",
+        help=(
+            "Directory where visible Codex lanes should start. "
+            "Omit to use a demo-owned clean workspace."
+        ),
+    )
+    start_parser.add_argument(
+        "--create-workspace",
+        action="store_true",
+        help="Create --workspace when it does not already exist.",
+    )
+    start_parser.add_argument(
+        "--keep-workspace",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    start_parser.add_argument("--cli-bin", default="loopx", help=argparse.SUPPRESS)
+    start_parser.add_argument("--codex-bin", default="codex", help=argparse.SUPPRESS)
+    start_parser.add_argument("--tmux-bin", default="tmux", help=argparse.SUPPRESS)
+    start_parser.add_argument(
+        "--reasoning-effort",
+        default="high",
+        help=argparse.SUPPRESS,
+    )
+    start_parser.add_argument(
+        "--launcher",
+        choices=["auto", "tmux"],
+        default="auto",
+        help=argparse.SUPPRESS,
+    )
+    start_parser.add_argument(
+        "--replace-existing",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    start_parser.add_argument(
+        "--codex-trust-workspace",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help=argparse.SUPPRESS,
     )
 
     frontier_parser = auto_research_sub.add_parser(
@@ -700,6 +802,111 @@ def handle_auto_research_command(
                 args.open_question,
                 max_todos=args.max_todos,
             )
+        elif args.auto_research_command == "start":
+            if args.headless and args.wake_visible_after_launch and args.execute:
+                raise ValueError("--headless cannot be combined with --wake-visible-after-launch")
+            if args.no_attach and args.attach:
+                raise ValueError("--attach cannot be combined with --no-attach")
+            if args.wake_visible_after_launch and args.attach:
+                raise ValueError(
+                    "--wake-visible-after-launch cannot be combined with --attach; "
+                    "wake evidence must be recorded before operator takeover"
+                )
+            goal_id, goal_surface_mode = _resolve_demo_goal_surface(
+                goal_id=args.goal_id,
+                demo_run_id=args.demo_run_id,
+                inherit_default_goal=False,
+            )
+
+            def append_start_evidence(packet_path: str) -> dict[str, object]:
+                return _append_auto_research_rollout_events(
+                    packet_path=packet_path,
+                    registry_path=registry_path,
+                    runtime_root_arg=runtime_root_arg,
+                    dry_run=False,
+                )
+
+            visible_launcher: Callable[[dict[str, object], Path, str | None, Path], dict[str, object]] | None = None
+            visible_wake: Callable[[str, list[str]], dict[str, object]] | None = None
+            launch_visible = bool(args.execute and not args.headless)
+            attach_visible = bool(
+                args.attach
+                or (
+                    launch_visible
+                    and not args.no_attach
+                    and not args.wake_visible_after_launch
+                )
+            )
+            if launch_visible:
+                def visible_launcher(
+                    supervisor: dict[str, object],
+                    visible_registry_path: Path,
+                    visible_runtime_root_arg: str | None,
+                    _default_workspace: Path,
+                ) -> dict[str, object]:
+                    demo_owned_workspace = args.workspace is None
+                    visible_workspace = (
+                        str(_default_workspace / "visible-user-workspace")
+                        if demo_owned_workspace
+                        else args.workspace
+                    )
+                    create_visible_workspace = True if demo_owned_workspace else args.create_workspace
+                    codex_trust_workspace = (
+                        demo_owned_workspace
+                        if args.codex_trust_workspace is None
+                        else bool(args.codex_trust_workspace)
+                    )
+                    return _execute_auto_research_demo_supervisor(
+                        supervisor,
+                        registry_path=visible_registry_path,
+                        runtime_root_arg=visible_runtime_root_arg,
+                        launcher=args.launcher,
+                        tmux_bin=args.tmux_bin,
+                        cli_bin=args.cli_bin,
+                        codex_bin=args.codex_bin,
+                        attach=attach_visible,
+                        replace_existing=args.replace_existing,
+                        workspace=visible_workspace,
+                        create_workspace=create_visible_workspace,
+                        codex_trust_workspace=codex_trust_workspace,
+                    )
+
+                def visible_wake(session: str, lanes: list[str]) -> dict[str, object]:
+                    return wake_visible_multi_agent_panes(
+                        session_name=session,
+                        tmux_bin=args.tmux_bin,
+                        lanes=lanes,
+                        execute=True,
+                    )
+
+            payload = run_auto_research_demo_e2e(
+                agent_id=AUTO_RESEARCH_START_AGENT_ID,
+                goal_id=goal_id,
+                goal_surface_mode=goal_surface_mode,
+                agent_specs=[],
+                tracking_goal_id=args.tracking_goal_id,
+                objective=args.open_question,
+                output_dir="auto_research_lightweight_kernel",
+                execute=args.execute,
+                run_worker_loop=bool(args.execute and args.headless),
+                worker_loop_rounds=args.worker_loop_rounds,
+                launch_visible=launch_visible,
+                keep_workspace=args.keep_workspace,
+                registry_path=registry_path,
+                runtime_root_arg=runtime_root_arg,
+                session_name=args.session_name,
+                cli_bin=args.cli_bin,
+                codex_bin=args.codex_bin,
+                tmux_bin=args.tmux_bin,
+                reasoning_effort=args.reasoning_effort,
+                live_evidence_path=None,
+                append_evidence=append_start_evidence,
+                visible_launcher=visible_launcher,
+                visible_wake=visible_wake,
+                wake_visible_after_launch=bool(
+                    args.execute and args.wake_visible_after_launch
+                ),
+            )
         elif args.auto_research_command == "frontier":
             if bool(args.fixture) == bool(args.goal_id):
                 raise ValueError(f"auto-research {args.auto_research_command} requires exactly one of --fixture or --goal-id")
@@ -975,7 +1182,8 @@ def handle_auto_research_command(
             raise ValueError(
                 "auto-research requires the `contract`, `frontier`, `evidence`, "
                 "`append-evidence`, `capture-live-evidence`, "
-                "`worker-turn`, `worker-loop`, `demo-supervisor`, or `demo-e2e` subcommand"
+                "`worker-turn`, `worker-loop`, `demo-supervisor`, `demo-e2e`, "
+                "or `start` subcommand"
             )
     except Exception as exc:
         payload = {

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -16,6 +16,7 @@ from .preset import (
     default_auto_research_agent_specs,
 )
 from .rollout_append import append_auto_research_rollout_events
+from .user_contract import build_auto_research_user_contract
 from .worker_loop import run_auto_research_worker_loop
 
 
@@ -260,6 +261,109 @@ def _command_text(
     if wake_visible_after_launch:
         parts.append("--wake-visible-after-launch")
     return " ".join(parts)
+
+
+def _contract_command_text(*, cli_bin: str, objective: str) -> str:
+    return f"{shlex.quote(cli_bin)} auto-research {shlex.quote(str(objective).strip())}"
+
+
+def _start_command_text(
+    *,
+    cli_bin: str,
+    objective: str,
+    execute: bool = False,
+    headless: bool = False,
+    no_attach: bool = False,
+    wake_visible_after_launch: bool = False,
+) -> str:
+    parts = [
+        shlex.quote(cli_bin),
+        "auto-research",
+        "start",
+        shlex.quote(str(objective).strip()),
+    ]
+    if execute:
+        parts.append("--execute")
+    if headless:
+        parts.append("--headless")
+    if no_attach:
+        parts.append("--no-attach")
+    if wake_visible_after_launch:
+        parts.append("--wake-visible-after-launch")
+    return " ".join(parts)
+
+
+def _contract_acceptance(user_contract: dict[str, object]) -> dict[str, object]:
+    command = (
+        user_contract.get("command_contract")
+        if isinstance(user_contract.get("command_contract"), dict)
+        else {}
+    )
+    required_outputs = (
+        command.get("auto_research_required_outputs")
+        if isinstance(command.get("auto_research_required_outputs"), list)
+        else []
+    )
+    output_field_map = {
+        "research_brief": "research_brief",
+        "action_plan": "action_plan",
+        "evidence_refs": "evidence_refs",
+        "next_executable_step": "next_executable_step",
+        "gate": "gate",
+    }
+    present_outputs = [
+        output
+        for output in required_outputs
+        if user_contract.get(output_field_map.get(str(output), "")) is not None
+    ]
+    action_plan = user_contract.get("action_plan")
+    gate = user_contract.get("gate") if isinstance(user_contract.get("gate"), dict) else {}
+    next_step = (
+        user_contract.get("next_executable_step")
+        if isinstance(user_contract.get("next_executable_step"), dict)
+        else {}
+    )
+    one_click_start = (
+        user_contract.get("one_click_start")
+        if isinstance(user_contract.get("one_click_start"), dict)
+        else {}
+    )
+    checks = {
+        "one_question_input": user_contract.get("open_question") not in (None, ""),
+        "required_outputs_present": len(present_outputs) == len(required_outputs),
+        "action_plan_bounded": isinstance(action_plan, list) and 0 < len(action_plan) <= 5,
+        "next_step_automatic_by_default": next_step.get("can_run_automatically") is True,
+        "gate_present": bool(gate.get("user_judgment_needed")),
+        "canonical_invocation_short": (
+            command.get("canonical_invocation") == 'loopx auto-research "<open question>"'
+        ),
+        "one_click_start_present": (
+            one_click_start.get("command_template")
+            == 'loopx auto-research start "<open question>" --execute'
+        ),
+        "one_click_start_uses_generic_kernel": (
+            one_click_start.get("uses_generic_kernel") is True
+            and one_click_start.get("coordination_model") == "decentralized_state_a2a"
+        ),
+    }
+    accepted = all(checks.values())
+    return {
+        "schema_version": "auto_research_user_contract_acceptance_v0",
+        "accepted": accepted,
+        "canonical_invocation": command.get("canonical_invocation"),
+        "required_outputs": required_outputs,
+        "present_outputs": present_outputs,
+        "checks": checks,
+        "missing_outputs": [
+            output for output in required_outputs if output not in present_outputs
+        ],
+        "public_boundary": {
+            "raw_logs_recorded": False,
+            "private_artifacts_recorded": False,
+            "absolute_paths_recorded": False,
+            "credentials_recorded": False,
+        },
+    }
 
 
 def _visible_worker_proof(*, launch_visible: bool) -> dict[str, object]:
@@ -630,6 +734,11 @@ def _build_visible_readiness(payload: dict[str, object]) -> dict[str, object]:
     )
     wake = payload.get("visible_wake") if isinstance(payload.get("visible_wake"), dict) else {}
     supervisor = payload.get("supervisor") if isinstance(payload.get("supervisor"), dict) else {}
+    contract_acceptance = (
+        payload.get("contract_acceptance")
+        if isinstance(payload.get("contract_acceptance"), dict)
+        else {}
+    )
     driver = (
         supervisor.get("decentralized_a2a_driver")
         if isinstance(supervisor.get("decentralized_a2a_driver"), dict)
@@ -648,6 +757,7 @@ def _build_visible_readiness(payload: dict[str, object]) -> dict[str, object]:
     )
     protected_scope_clean = evidence.get("protected_scope_clean") is True
     checks = {
+        "user_contract_accepted": contract_acceptance.get("accepted") is True,
         "visible_lanes_accepted": proof.get("visible_lanes_accepted") is True,
         "cadence_wake_verified": proof.get("cadence_wake_verified") is True,
         "pane_local_multi_round_verified": rounds.get("multi_round_verified") is True,
@@ -669,7 +779,8 @@ def _build_visible_readiness(payload: dict[str, object]) -> dict[str, object]:
         "schema_version": "auto_research_visible_readiness_v0",
         "ready": ready,
         "readiness_level": "ready" if ready else "collecting_evidence",
-        "one_command": payload.get("commands", {}).get("one_command_visible_wake_demo")
+        "one_command": payload.get("commands", {}).get("one_question_start_with_visible_wake")
+        or payload.get("commands", {}).get("one_command_visible_wake_demo")
         if isinstance(payload.get("commands"), dict)
         else None,
         "coordination_pattern": "decentralized_state_a2a",
@@ -678,10 +789,19 @@ def _build_visible_readiness(payload: dict[str, object]) -> dict[str, object]:
         or "fixed_prompt_broadcast_plus_pane_local_state_tick",
         "driver_owner_layer": driver.get("owner_layer"),
         "auto_research_preset_role": "thin_domain_defaults_only",
+        "user_contract_invocation": contract_acceptance.get("canonical_invocation"),
         "leader_agent_required": False,
         "manual_artifact_inspection_required": not ready,
         "checks": checks,
         "missing_requirements": [key for key, passed in checks.items() if not passed],
+        "contract_acceptance": {
+            "accepted": contract_acceptance.get("accepted") is True,
+            "required_outputs": contract_acceptance.get("required_outputs"),
+            "present_outputs": contract_acceptance.get("present_outputs"),
+            "one_click_start": contract_acceptance.get("checks", {}).get("one_click_start_present")
+            if isinstance(contract_acceptance.get("checks"), dict)
+            else False,
+        },
         "rounds": {
             "max_completed": rounds.get("max_rounds_completed"),
             "total_completed": rounds.get("rounds_completed_total"),
@@ -763,6 +883,8 @@ def run_auto_research_demo_e2e(
     effective_agent_specs = list(agent_specs or [])
     if (run_worker_loop or launch_visible) and not effective_agent_specs:
         effective_agent_specs = default_auto_research_agent_specs()
+    user_contract = build_auto_research_user_contract(objective)
+    contract_acceptance = _contract_acceptance(user_contract)
     supervisor = build_auto_research_demo_supervisor_plan(
         goal_id=goal_id,
         agent_specs=effective_agent_specs,
@@ -815,7 +937,29 @@ def run_auto_research_demo_e2e(
         },
         "agent_id": agent_id,
         "reasoning_effort": reasoning_effort,
+        "user_contract": user_contract,
+        "contract_acceptance": contract_acceptance,
         "commands": {
+            "one_question_contract": _contract_command_text(
+                cli_bin=cli_bin,
+                objective=objective,
+            ),
+            "one_question_start": _start_command_text(
+                cli_bin=cli_bin,
+                objective=objective,
+                execute=True,
+            ),
+            "one_question_start_preview": _start_command_text(
+                cli_bin=cli_bin,
+                objective=objective,
+            ),
+            "one_question_start_with_visible_wake": _start_command_text(
+                cli_bin=cli_bin,
+                objective=objective,
+                execute=True,
+                no_attach=True,
+                wake_visible_after_launch=True,
+            ),
             "one_command_worker_loop": _command_text(
                 cli_bin=cli_bin,
                 goal_id=goal_id,

--- a/loopx/capabilities/auto_research/human_view.py
+++ b/loopx/capabilities/auto_research/human_view.py
@@ -24,6 +24,11 @@ def _render_user_contract(payload: dict[str, object]) -> str:
     brief = payload.get("research_brief") if isinstance(payload.get("research_brief"), dict) else {}
     plan = payload.get("action_plan") if isinstance(payload.get("action_plan"), list) else []
     evidence = payload.get("evidence_refs") if isinstance(payload.get("evidence_refs"), dict) else {}
+    one_click_start = (
+        payload.get("one_click_start")
+        if isinstance(payload.get("one_click_start"), dict)
+        else {}
+    )
     next_step = (
         payload.get("next_executable_step")
         if isinstance(payload.get("next_executable_step"), dict)
@@ -65,6 +70,13 @@ def _render_user_contract(payload: dict[str, object]) -> str:
             f"- benchmarks: `{_join_or_none(evidence.get('benchmarks'))}`",
             f"- issues: `{_join_or_none(evidence.get('issues'))}`",
             f"- pull_requests: `{_join_or_none(evidence.get('pull_requests'))}`",
+            "",
+            "## One-Click Start",
+            "",
+            f"- command: `{one_click_start.get('command')}`",
+            f"- preview: `{one_click_start.get('preview_command')}`",
+            f"- starts: `{one_click_start.get('starts')}`",
+            f"- coordination_model: `{one_click_start.get('coordination_model')}`",
             "",
             "## Next Executable Step",
             "",
@@ -208,6 +220,12 @@ def _render_demo_e2e(payload: dict[str, object]) -> str:
         if isinstance(payload.get("visible_readiness"), dict)
         else {}
     )
+    contract_acceptance = (
+        payload.get("contract_acceptance")
+        if isinstance(payload.get("contract_acceptance"), dict)
+        else {}
+    )
+    commands = payload.get("commands") if isinstance(payload.get("commands"), dict) else {}
     improvement = (
         readiness.get("improvement_summary")
         if isinstance(readiness.get("improvement_summary"), dict)
@@ -224,6 +242,9 @@ def _render_demo_e2e(payload: dict[str, object]) -> str:
         f"- tracking_goal_id: `{payload.get('tracking_goal_id')}`",
         f"- frontier_goal_id: `{route.get('frontier_goal_id')}`",
         f"- agent_id: `{payload.get('agent_id')}`",
+        f"- user_contract_accepted: `{contract_acceptance.get('accepted')}`",
+        f"- one_question_contract: `{commands.get('one_question_contract')}`",
+        f"- one_question_start: `{commands.get('one_question_start')}`",
         f"- reasoning_effort: `{payload.get('reasoning_effort')}`",
         f"- worker_loop_executed_turns: `{worker_loop.get('executed_turn_count')}`",
         f"- worker_loop_completed_turns: `{worker_loop.get('completed_turn_count')}`",

--- a/loopx/capabilities/auto_research/user_contract.py
+++ b/loopx/capabilities/auto_research/user_contract.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shlex
 from typing import Any
 
 
@@ -42,6 +43,7 @@ def build_auto_research_user_contract(
             "owner_layer": "auto_research_preset",
         },
     ][:todo_limit]
+    start_command = f"loopx auto-research start {shlex.quote(question)} --execute"
     return {
         "ok": True,
         "schema_version": AUTO_RESEARCH_USER_CONTRACT_SCHEMA_VERSION,
@@ -56,6 +58,7 @@ def build_auto_research_user_contract(
         "command_contract": {
             "canonical_invocation": 'loopx auto-research "<open question>"',
             "explicit_invocation": 'loopx auto-research contract "<open question>"',
+            "one_click_start_invocation": 'loopx auto-research start "<open question>" --execute',
             "user_required_inputs": ["open_question"],
             "auto_research_required_outputs": [
                 "research_brief",
@@ -65,6 +68,23 @@ def build_auto_research_user_contract(
                 "gate",
             ],
             "max_action_plan_todos": 5,
+        },
+        "one_click_start": {
+            "schema_version": "auto_research_one_click_start_v0",
+            "command_template": 'loopx auto-research start "<open question>" --execute',
+            "command": start_command,
+            "preview_command_template": 'loopx auto-research start "<open question>"',
+            "preview_command": f"loopx auto-research start {shlex.quote(question)}",
+            "starts": "visible_codex_tui_lanes",
+            "uses_generic_kernel": True,
+            "coordination_model": "decentralized_state_a2a",
+            "user_does_not_choose": [
+                "agent_ids",
+                "tmux_layout",
+                "pane_tick_command",
+                "evidence_packet_schema",
+                "frontier_protocol",
+            ],
         },
         "research_brief": {
             "read": [],


### PR DESCRIPTION
## Summary
- add a one-click auto-research start contract surfaced from `loopx auto-research "<open question>"`
- add `loopx auto-research start "<open question>"` as the thin user-facing launch surface over the existing generic visible runner/A2A kernel
- anchor demo-e2e readiness and docs on the one-question contract/start path, with focused smoke coverage for dry-run, headless execute, layered E2E, and visible readiness

## Validation
- `python3 -m py_compile loopx/capabilities/auto_research/user_contract.py loopx/capabilities/auto_research/human_view.py loopx/capabilities/auto_research/demo_e2e.py loopx/capabilities/auto_research/cli.py examples/auto-research-user-contract-entry-smoke.py examples/auto-research-layered-e2e-acceptance-smoke.py examples/auto-research-demo-e2e-worker-loop-smoke.py`
- `python3 examples/auto-research-user-contract-entry-smoke.py`
- `python3 examples/auto-research-layered-e2e-acceptance-smoke.py`
- `python3 examples/auto-research-demo-e2e-worker-loop-smoke.py`
- `python3 examples/auto-research-demo-supervisor-smoke.py`
- `git diff --check origin/main...HEAD`

## Boundary
- no benchmark scoring changes
- no production actions
- no raw logs/private artifacts/local paths committed
