### PR TITLE
Bump LoopX release version to 0.1.6

### DIFF
--- a/docs/product/codex-cli-no-clone-release-verification.md
+++ b/docs/product/codex-cli-no-clone-release-verification.md
@@ -14,7 +14,8 @@ The release verifier exercises the path as a fresh user would see it:
 2. run `scripts/install-from-github.sh` with the same archive-installer
    mechanism used by the public no-clone command;
 3. confirm the installed `loopx` wrapper can run `doctor`;
-4. confirm the installed help surface exposes the first-run commands:
+4. confirm the installed top-level help points at `loopx commands`, and the
+   installed command reference exposes the first-run commands:
    `codex-cli-bootstrap-message`, `codex-cli-tui-bootstrap-smoke-bundle`, and
    `codex-cli-visible-attach-acceptance`;
 5. generate the one-message TUI bootstrap text from the fresh project;

--- a/examples/release/codex-cli-no-clone-release-verification-smoke.py
+++ b/examples/release/codex-cli-no-clone-release-verification-smoke.py
@@ -99,8 +99,10 @@ def assert_installed_release(
     assert "ok: `True`" in doctor.stdout, doctor.stdout
 
     help_text = run([str(installed), "--help"], env=runtime_env, cwd=fresh_repo).stdout
+    assert "loopx commands" in help_text, help_text
+    commands_text = run([str(installed), "commands"], env=runtime_env, cwd=fresh_repo).stdout
     for command in FIRST_RUN_COMMANDS:
-        assert command in help_text, help_text
+        assert command in commands_text, commands_text
 
     assert (release_dir / "docs" / "product" / "codex-cli-first-run-rehearsal.md").exists()
     assert (release_dir / "docs" / "product" / "codex-cli-no-clone-release-verification.md").exists()

--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.5"
+__version__ = "0.1.6"

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -80,6 +80,14 @@ COMMAND_GROUPS: list[dict[str, object]] = [
                 "command": "loopx codex-cli-bootstrap-message",
                 "purpose": "Generate the visible Codex CLI TUI setup message.",
             },
+            {
+                "command": "loopx codex-cli-tui-bootstrap-smoke-bundle",
+                "purpose": "Generate a transcript-free Codex CLI first-run smoke bundle.",
+            },
+            {
+                "command": "loopx codex-cli-visible-attach-acceptance",
+                "purpose": "Check public-safe visible Codex CLI attach evidence.",
+            },
             {"command": "loopx heartbeat-prompt", "purpose": "Generate a guarded heartbeat automation body."},
             {"command": "loopx upgrade-plan", "purpose": "Plan default heartbeat upgrade propagation."},
             {"command": "loopx update", "purpose": "Check, dry-run, or execute the no-clone update path."},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.1.5"
+version = "0.1.6"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- bump LoopX package version from `0.1.5` to `0.1.6`
- expose the Codex CLI first-run verification commands in `loopx commands`
- update the no-clone release verification smoke to check top-level help for the command-reference route and `loopx commands` for the full first-run commands
- align the release verification doc with the current help/reference split

## Motivation / Problem
Today's fixes after `v0.1.5` materially improve the public release path: auto-research visible startup, decentralized/multi-agent driver hints, monitor scheduler backoff, command help, and release timeline/readiness surfaces. While preparing `v0.1.6`, the release no-clone smoke exposed a real contract drift: top-level help was intentionally compact, but the full first-run commands were not all listed in `loopx commands`.

## Product / Architecture Judgment
The fix keeps the compact top-level help design while making the full command reference carry the detailed first-run commands. That is the reusable surface new users and installed snapshots can rely on, and it avoids bloating `loopx --help` again.

## Installed-User Risk
Low. Existing installed users keep their current commands; after update they will see `loopx 0.1.6` and a more complete `loopx commands` reference. The no-clone smoke now validates the current intended help split instead of the older top-level-help assumption.

## Validation
- `python3 -m py_compile loopx/*.py loopx/cli_commands/*.py`
- `python3 examples/release/release-version-contract-smoke.py`
- `python3 examples/release/release-readiness-doc-smoke.py`
- `python3 examples/loopx-update-smoke.py`
- `python3 examples/fresh-clone-quickstart-smoke.py`
- `python3 examples/release/codex-cli-no-clone-release-verification-smoke.py`
- `python3 examples/canary/canary-promotion-readiness-smoke.py --no-write-evidence`
- `python3 examples/codex-cli-first-run-rehearsal-smoke.py`
- `python3 examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py`
- `python3 examples/codex-cli-proof-capture-demo-fixtures-smoke.py`
- `git diff --check`
- `PYTHONPATH=. python3 -m loopx.cli --version`
- `PYTHONPATH=. python3 -m loopx.cli --format json check --scan-path README.md --scan-path docs/ --scan-path examples/ --scan-path loopx/help_surface.py`

Note: `loopx check` reported the pre-existing `loopx-meta` duplicate-index warning; the public/private boundary scan was clean.
