### PR TITLE
Improve auto-research start workspace UX

### DIFF
--- a/docs/guides/auto-research-command-path.md
+++ b/docs/guides/auto-research-command-path.md
@@ -74,6 +74,10 @@ a dry-run preview. With `--execute`, it creates an isolated research frontier
 and starts the visible Codex TUI lanes through the generic multi-agent kernel.
 The user still only supplies one open question; agent ids, pane-local tick
 commands, evidence schemas, and runner wiring stay inside the kernel.
+By default, visible panes open in a stable user-owned workspace under
+`~/loopx-auto-research/<run>/visible-workspace` so the first screen does not
+land in a generated temp directory. Pass `--workspace` to choose a different
+scratch directory.
 
 ## Start From A Clean Workspace
 
@@ -125,10 +129,11 @@ role, not as a JSON/status stream. Generic launcher internals stay inside
 LoopX; the operator does not need to know `demo-e2e`, agent ids, or
 implementation paths.
 
-Visible Codex TUI panes default to the caller's current workspace, not to a
-demo-local git worktree. The demo registry, runtime root, queue, and evidence
-state stay isolated, but the first screen should not be a generated worktree
-trust prompt. If you want an explicit scratch location, pass
+Visible Codex TUI panes default to a stable
+`~/loopx-auto-research/<run>/visible-workspace`, not to a demo-local git
+worktree or generated temp directory. The demo registry, runtime root, queue,
+and evidence state stay isolated, but the first screen should not be a
+generated worktree trust prompt. If you want an explicit scratch location, pass
 `--workspace "$HOME/loopx-auto-research-demo" --create-workspace`; avoid
 pointing `--workspace` at the demo-local control-plane directory.
 

--- a/examples/auto-research-user-contract-entry-smoke.py
+++ b/examples/auto-research-user-contract-entry-smoke.py
@@ -19,6 +19,9 @@ from loopx.capabilities.auto_research.user_contract import (  # noqa: E402
     AUTO_RESEARCH_USER_CONTRACT_SCHEMA_VERSION,
     build_auto_research_user_contract,
 )
+from loopx.capabilities.auto_research.cli import (  # noqa: E402
+    _default_auto_research_start_workspace,
+)
 
 
 QUESTION = "How should LoopX make visible multi-agent auto research useful?"
@@ -139,6 +142,17 @@ def run_cli(temp_dir: Path, *args: str) -> str:
 def main() -> None:
     payload = build_auto_research_user_contract(QUESTION)
     assert_contract(payload)
+    default_workspace = Path(
+        _default_auto_research_start_workspace("loopx-auto-research-demo-smoke")
+    )
+    assert default_workspace.parts[-3:] == (
+        "loopx-auto-research",
+        "loopx-auto-research-demo-smoke",
+        "visible-workspace",
+    ), default_workspace
+    assert default_workspace.is_absolute(), default_workspace
+    assert "/private/" not in str(default_workspace), default_workspace
+    assert "/tmp/" not in str(default_workspace), default_workspace
 
     with tempfile.TemporaryDirectory() as raw_temp_dir:
         temp_dir = Path(raw_temp_dir)

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -99,6 +99,15 @@ def _demo_goal_suffix(value: object, *, fallback: str = "run") -> str:
     return text[:40] or fallback
 
 
+def _default_auto_research_start_workspace(goal_id: str) -> str:
+    return str(
+        Path.home()
+        / "loopx-auto-research"
+        / _demo_goal_suffix(goal_id, fallback="run")
+        / "visible-workspace"
+    )
+
+
 def _resolve_demo_goal_surface(
     *,
     goal_id: str | None,
@@ -211,7 +220,7 @@ def register_auto_research_commands(
         "--workspace",
         help=(
             "Directory where visible Codex lanes should start. "
-            "Omit to use a demo-owned clean workspace."
+            "Omit to use ~/loopx-auto-research/<run>/visible-workspace."
         ),
     )
     start_parser.add_argument(
@@ -844,15 +853,15 @@ def handle_auto_research_command(
                     visible_runtime_root_arg: str | None,
                     _default_workspace: Path,
                 ) -> dict[str, object]:
-                    demo_owned_workspace = args.workspace is None
+                    default_start_workspace = args.workspace is None
                     visible_workspace = (
-                        str(_default_workspace / "visible-user-workspace")
-                        if demo_owned_workspace
+                        _default_auto_research_start_workspace(goal_id)
+                        if default_start_workspace
                         else args.workspace
                     )
-                    create_visible_workspace = True if demo_owned_workspace else args.create_workspace
+                    create_visible_workspace = True if default_start_workspace else args.create_workspace
                     codex_trust_workspace = (
-                        demo_owned_workspace
+                        default_start_workspace
                         if args.codex_trust_workspace is None
                         else bool(args.codex_trust_workspace)
                     )


### PR DESCRIPTION
## Summary
- default `loopx auto-research start --execute` visible panes to a stable user-owned workspace under `~/loopx-auto-research/<run>/visible-workspace`
- document the default workspace and `--workspace` override
- add a smoke assertion that the default start workspace avoids generated temp paths

## Product / Architecture Judgment
- Motivation: make the one-click auto-research path feel productized after the fixed user contract hands off to `auto-research start --execute`.
- Solved: real source-CLI visible launch now opens all Codex TUI lanes in the stable workspace while preserving two-round pane-local A2A evidence.
- User impact: first screen no longer exposes generated `/private/var` temp workspaces, reducing trust-prompt/path noise without moving auto-research details into the user or preset layer.
- Risk: narrow default workspace behavior change for `auto-research start`; explicit `--workspace` still overrides it.

## Validation
- `python3 -m py_compile loopx/capabilities/auto_research/cli.py examples/auto-research-user-contract-entry-smoke.py`
- `python3 examples/auto-research-user-contract-entry-smoke.py`
- `python3 examples/auto-research-layered-e2e-acceptance-smoke.py`
- `python3 examples/auto-research-demo-e2e-worker-loop-smoke.py`
- `python3 examples/auto-research-demo-supervisor-smoke.py`
- `git diff --check`
- source CLI: `auto-research start ... --execute --no-attach --wake-visible-after-launch --replace-existing --keep-workspace` verified visible launch ready, 4 panes accepted, 8 completed lane-rounds, max 2 rounds, protected scope clean
- source CLI: `auto-research "<open question>"` verified `one_click_start.command` is present

## Boundary
Public/private scan only matched the regression assertions that forbid `/private/` and `/tmp/` in the generated default workspace.