### PR TITLE
Add smoke-suite profile manifest

### DIFF
--- a/examples/canary/smoke-suite-runner-smoke.py
+++ b/examples/canary/smoke-suite-runner-smoke.py
@@ -136,6 +136,42 @@ def assert_catalog_profile_preview_is_supported() -> None:
     assert payload["catalog_plan"]["planned_check_count"] == 1, payload
 
 
+def assert_named_smoke_profile_expands_to_suite_selection() -> None:
+    payload = build_canary_smoke_suite_run(
+        suite="default-public",
+        profiles=["core-control-plane"],
+        execute=False,
+    )
+    assert payload["ok"] is True, payload
+    assert payload["suite"] == "full-public", payload
+    assert payload["catalog_plan"] is None, payload
+    assert payload["selection_inputs"]["profiles"] == ["core-control-plane"], payload
+    assert payload["selection_inputs"]["smoke_profiles"] == ["core-control-plane"], payload
+    assert payload["selection_inputs"]["catalog_profiles"] == [], payload
+    assert "quota" in payload["selection_inputs"]["modules"], payload
+    assert "benchmark" in payload["selection_inputs"]["exclude_modules"], payload
+    scripts = [check["normalized"]["script"] for check in payload["selected_checks"]]
+    assert scripts, payload
+    assert any(script.startswith("examples/control_plane/") for script in scripts), payload
+    assert all("benchmark" not in script for script in scripts), payload
+    assert all("skillsbench" not in script for script in scripts), payload
+
+
+def assert_named_smoke_profile_can_mix_with_catalog_profile() -> None:
+    payload = build_canary_smoke_suite_run(
+        suite="default-public",
+        profiles=["canary-runner", "repo-architecture-budget"],
+        execute=False,
+    )
+    assert payload["ok"] is True, payload
+    assert payload["selection_inputs"]["smoke_profiles"] == ["canary-runner"], payload
+    assert payload["selection_inputs"]["catalog_profiles"] == ["repo-architecture-budget"], payload
+    assert payload["catalog_plan"]["planned_check_count"] == 1, payload
+    commands = [check["command"] for check in payload["selected_checks"]]
+    assert any("examples/canary/" in command for command in commands), payload
+    assert any("examples/control_plane/repo-python-line-budget-smoke.py" in command for command in commands), payload
+
+
 def assert_cli_json_preview_works() -> None:
     completed = subprocess.run(
         [
@@ -166,6 +202,39 @@ def assert_cli_json_preview_works() -> None:
     assert payload["schema_version"] == "canary_smoke_suite_run_v0", payload
     assert payload["selected_check_count"] == 2, payload
     assert payload["selection_inputs"]["exclude_modules"] == ["benchmark"], payload
+    assert payload["executes_checks"] is False, payload
+
+
+def assert_cli_named_smoke_profile_preview_works() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "canary",
+            "smoke-suite",
+            "--profile",
+            "canary-runner",
+            "--limit",
+            "3",
+            "--no-execute",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(completed.stdout)
+    assert payload["ok"] is True, payload
+    assert payload["suite"] == "full-public", payload
+    assert payload["selected_check_count"] == 3, payload
+    assert payload["selection_inputs"]["smoke_profiles"] == ["canary-runner"], payload
+    assert payload["selection_inputs"]["catalog_profiles"] == [], payload
+    scripts = [check["normalized"]["script"] for check in payload["selected_checks"]]
+    assert any(script.startswith("examples/canary/") for script in scripts), payload
+    assert all("benchmark" not in script for script in scripts), payload
     assert payload["executes_checks"] is False, payload
 
 
@@ -357,7 +426,10 @@ def main() -> int:
     assert_subdirectory_smoke_selection_is_supported()
     assert_legacy_root_script_selector_matches_moved_smokes()
     assert_catalog_profile_preview_is_supported()
+    assert_named_smoke_profile_expands_to_suite_selection()
+    assert_named_smoke_profile_can_mix_with_catalog_profile()
     assert_cli_json_preview_works()
+    assert_cli_named_smoke_profile_preview_works()
     assert_execution_reports_progress_indices()
     assert_git_probe_contract_is_explicit()
     assert_readonly_run_rejects_and_restores_tracked_side_effects()

--- a/examples/run-smokes.py
+++ b/examples/run-smokes.py
@@ -45,7 +45,7 @@ def parse_args() -> argparse.Namespace:
         "--profile",
         action="append",
         default=[],
-        help="Run catalog profile checks instead of the default full script set.",
+        help="Run a named smoke-suite profile or catalog profile.",
     )
     parser.add_argument(
         "--family",

--- a/loopx/canary/runner.py
+++ b/loopx/canary/runner.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any, Callable
 
 from .planner import REPO_ROOT, build_catalog_canary_plan, flatten_catalog_canary_checks
+from .smoke_profiles import resolve_smoke_suite_profiles
 
 
 CANARY_RUN_SCHEMA_VERSION = "catalog_canary_run_v0"
@@ -377,7 +378,6 @@ def build_canary_smoke_suite_run(
     sweep without hiding the smaller profile/module loops used while developing.
     """
 
-    normalized_suite = suite if suite in SMOKE_SUITE_CHOICES else "default-public"
     modules = list(modules or [])
     exclude_modules = list(exclude_modules or [])
     scripts = list(scripts or [])
@@ -385,9 +385,28 @@ def build_canary_smoke_suite_run(
     profiles = list(profiles or [])
     changed_files = list(changed_files or [])
     surfaces = list(surfaces or [])
-    catalog_selector_requested = bool(families or profiles or changed_files or surfaces)
+    profile_resolution = resolve_smoke_suite_profiles(
+        suite=suite,
+        suite_choices=SMOKE_SUITE_CHOICES,
+        modules=modules,
+        exclude_modules=exclude_modules,
+        profiles=profiles,
+    )
+    normalized_suite = str(profile_resolution["suite"])
+    modules = list(profile_resolution["modules"])
+    exclude_modules = list(profile_resolution["exclude_modules"])
+    smoke_profiles = list(profile_resolution["smoke_profiles"])
+    catalog_profiles = list(profile_resolution["catalog_profiles"])
+    profile_expansions = list(profile_resolution["profile_expansions"])
+    catalog_selector_requested = bool(families or catalog_profiles or changed_files or surfaces)
     suite_requested = normalized_suite != "catalog-plan"
-    if catalog_selector_requested and not modules and not scripts and normalized_suite == "default-public":
+    if (
+        catalog_selector_requested
+        and not modules
+        and not scripts
+        and not smoke_profiles
+        and normalized_suite == "default-public"
+    ):
         suite_requested = False
 
     selected: list[dict[str, Any]] = []
@@ -408,7 +427,7 @@ def build_canary_smoke_suite_run(
             changed_files=changed_files,
             surfaces=surfaces,
             families=families,
-            profiles=profiles,
+            profiles=catalog_profiles,
             include_deep_checks=include_deep_checks,
             max_checks_per_family=max_checks_per_family,
             max_checks_per_profile=max_checks_per_profile,
@@ -564,6 +583,9 @@ def build_canary_smoke_suite_run(
             "surfaces": surfaces,
             "families": families,
             "profiles": profiles,
+            "smoke_profiles": smoke_profiles,
+            "catalog_profiles": catalog_profiles,
+            "profile_expansions": profile_expansions,
             "include_deep_checks": include_deep_checks,
             "max_checks_per_family": max_checks_per_family,
             "max_checks_per_profile": max_checks_per_profile,
@@ -580,7 +602,8 @@ def build_canary_smoke_suite_run(
             "Smoke-suite run executes repository-local public smoke scripts with "
             "shell-free argv, per-check timeouts, and continue-on-failure reporting. "
             "Use --suite full-public for a full sweep, --module/--script for local "
-            "development, or catalog selectors such as --profile for canary-plan modules."
+            "development, recognized --profile values for named smoke-suite profiles, "
+            "or catalog selectors such as --profile for canary-plan modules."
         ),
     }
 

--- a/loopx/canary/smoke_profiles.py
+++ b/loopx/canary/smoke_profiles.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+NON_BENCHMARK_SMOKE_EXCLUDE_MODULES = [
+    "agentissue-bench",
+    "agents-last-exam",
+    "benchmark",
+    "skillsbench",
+    "swe-marathon",
+    "terminal-bench",
+]
+SMOKE_SUITE_PROFILE_MANIFEST: dict[str, dict[str, Any]] = {
+    "core-control-plane": {
+        "suite": "full-public",
+        "modules": [
+            "control-plane",
+            "control_plane",
+            "project",
+            "protocol",
+            "quota",
+            "review-packet",
+            "review_packet",
+            "scheduler",
+            "session-runtime",
+            "session_runtime",
+            "state",
+            "status",
+            "todo",
+        ],
+        "exclude_modules": NON_BENCHMARK_SMOKE_EXCLUDE_MODULES,
+        "description": "LoopX runtime/control-plane contracts without benchmark adapters.",
+    },
+    "canary-runner": {
+        "suite": "full-public",
+        "modules": ["canary", "smoke-suite", "smoke_suite"],
+        "exclude_modules": NON_BENCHMARK_SMOKE_EXCLUDE_MODULES,
+        "description": "Canary planner, runner, smoke-suite, and pytest facade contracts.",
+    },
+    "public-entry-install-release": {
+        "suite": "full-public",
+        "modules": [
+            "codex-cli-packaged-install",
+            "install",
+            "public-entry",
+            "public_entry",
+            "readme",
+            "release",
+        ],
+        "exclude_modules": NON_BENCHMARK_SMOKE_EXCLUDE_MODULES,
+        "description": "Public entry, packaged install, README, and release-readiness checks.",
+    },
+    "docs-project-content-ops": {
+        "suite": "full-public",
+        "modules": [
+            "content",
+            "content-ops",
+            "content_ops",
+            "docs",
+            "project",
+            "update-note",
+            "update_notes",
+        ],
+        "exclude_modules": NON_BENCHMARK_SMOKE_EXCLUDE_MODULES,
+        "description": "Docs, project lifecycle, and content/update-note operations checks.",
+    },
+}
+
+
+def _append_unique(values: list[str], additions: list[str]) -> list[str]:
+    seen = {value for value in values if value}
+    expanded = list(values)
+    for value in additions:
+        if not value or value in seen:
+            continue
+        seen.add(value)
+        expanded.append(value)
+    return expanded
+
+
+def resolve_smoke_suite_profiles(
+    *,
+    suite: str,
+    suite_choices: set[str],
+    modules: list[str],
+    exclude_modules: list[str],
+    profiles: list[str],
+) -> dict[str, Any]:
+    normalized_suite = suite if suite in suite_choices else "default-public"
+    expanded_modules = list(modules)
+    expanded_exclude_modules = list(exclude_modules)
+    smoke_profiles: list[str] = []
+    catalog_profiles: list[str] = []
+    profile_expansions: list[dict[str, Any]] = []
+    for profile in profiles:
+        profile_id = profile.strip()
+        if not profile_id:
+            continue
+        profile_spec = SMOKE_SUITE_PROFILE_MANIFEST.get(profile_id)
+        if profile_spec is None:
+            catalog_profiles.append(profile_id)
+            continue
+        smoke_profiles.append(profile_id)
+        normalized_suite = str(profile_spec.get("suite") or normalized_suite)
+        profile_modules = [
+            str(item)
+            for item in profile_spec.get("modules", [])
+            if str(item).strip()
+        ]
+        profile_excludes = [
+            str(item)
+            for item in profile_spec.get("exclude_modules", [])
+            if str(item).strip()
+        ]
+        expanded_modules = _append_unique(expanded_modules, profile_modules)
+        expanded_exclude_modules = _append_unique(
+            expanded_exclude_modules,
+            profile_excludes,
+        )
+        profile_expansions.append(
+            {
+                "profile": profile_id,
+                "suite": normalized_suite,
+                "modules": profile_modules,
+                "exclude_modules": profile_excludes,
+                "description": profile_spec.get("description"),
+            }
+        )
+    return {
+        "suite": normalized_suite,
+        "modules": expanded_modules,
+        "exclude_modules": expanded_exclude_modules,
+        "smoke_profiles": smoke_profiles,
+        "catalog_profiles": catalog_profiles,
+        "profile_expansions": profile_expansions,
+    }

--- a/loopx/cli_commands/canary.py
+++ b/loopx/cli_commands/canary.py
@@ -195,7 +195,11 @@ def _add_canary_selector_args(parser: argparse.ArgumentParser) -> None:
         "--profile",
         action="append",
         default=[],
-        help="Force-select a current-repo profile such as 'monitor-scheduler'. Repeat for multiple profiles.",
+        help=(
+            "Force-select a current-repo catalog profile, or a smoke-suite profile "
+            "when used with `canary smoke-suite`, such as core-control-plane. "
+            "Repeat for multiple profiles."
+        ),
     )
     parser.add_argument(
         "--include-deep-checks",
@@ -270,7 +274,7 @@ def register_canary_commands(
 
     smoke_parser = canary_sub.add_parser(
         "smoke-suite",
-        help="Run or preview public smoke scripts as a full suite, module subset, or catalog profile.",
+        help="Run or preview public smoke scripts as a full suite, module subset, smoke profile, or catalog profile.",
     )
     add_subcommand_format(smoke_parser)
     _add_canary_selector_args(smoke_parser)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,10 @@ def pytest_addoption(parser) -> None:
         action="append",
         default=[],
         dest="loopx_smoke_profiles",
-        help="Catalog profile selector passed through to the LoopX runner. Repeat or comma-separate.",
+        help=(
+            "Smoke-suite or catalog profile selector passed through to the LoopX "
+            "runner. Repeat or comma-separate."
+        ),
     )
     group.addoption(
         "--loopx-smoke-family",


### PR DESCRIPTION
## Summary
- add named smoke-suite profiles for core-control-plane, canary-runner, public-entry/install/release, and docs/project/content-ops
- split smoke-suite profile resolution from catalog profile selection so CLI and pytest facade share the same runner payload
- extend smoke-suite runner contract coverage for named and mixed profile selection

## Validation
- PYTHONPATH=. python examples/canary/smoke-suite-runner-smoke.py
- PYTHONPATH=. uv run --extra test python -m pytest -q tests/test_smoke_suite.py --loopx-smoke-profile canary-runner --loopx-smoke-limit 1 --loopx-smoke-timeout 90
- PYTHONPATH=. python -m loopx.cli --format json canary smoke-suite --profile canary-runner --limit 3 --timeout-seconds 120 --no-progress
- git diff --check
- PYTHONPATH=. python -m loopx.cli check --scan-path loopx/canary/runner.py --scan-path loopx/canary/smoke_profiles.py --scan-path loopx/cli_commands/canary.py --scan-path examples/canary/smoke-suite-runner-smoke.py --scan-path examples/run-smokes.py --scan-path tests/conftest.py