### PR TITLE
Make auto-research start wake visible panes by default

### DIFF
--- a/docs/guides/auto-research-command-path.md
+++ b/docs/guides/auto-research-command-path.md
@@ -72,8 +72,16 @@ loopx auto-research start "<open question>" --execute
 Without `--execute`, `start` returns the same contract-anchored runner packet as
 a dry-run preview. With `--execute`, it creates an isolated research frontier
 and starts the visible Codex TUI lanes through the generic multi-agent kernel.
+The launcher then broadcasts the fixed pane-local A2A wake prompt so each pane
+runs its own `$LOOPX_PANE_A2A_TICK` against LoopX quota/frontier state and writes
+compact public evidence before the operator takes over. This is still
+decentralized A2A, not a workflow driver: the broadcaster does not select todos,
+run worker turns, or write LoopX state.
+
 The user still only supplies one open question; agent ids, pane-local tick
-commands, evidence schemas, and runner wiring stay inside the kernel.
+commands, evidence schemas, and runner wiring stay inside the kernel. Pass
+`--no-wake-visible-after-launch --attach` only when you want to skip the default
+evidence-first wake and immediately enter the tmux session.
 By default, visible panes open in a stable user-owned workspace under
 `~/loopx-auto-research/<run>/visible-workspace` so the first screen does not
 land in a generated temp directory. Pass `--workspace` to choose a different
@@ -123,11 +131,12 @@ loopx --registry "$LOOPX_REGISTRY" \
 ```
 
 That command is the user-facing UX for auto-research. It creates a fresh
-isolated demo goal by default, launches the visible tmux lanes, and attaches to
-the session. Each tmux window should open as a real interactive Codex CLI TUI
-role, not as a JSON/status stream. Generic launcher internals stay inside
-LoopX; the operator does not need to know `demo-e2e`, agent ids, or
-implementation paths.
+isolated demo goal by default, launches the visible tmux lanes, broadcasts the
+fixed decentralized A2A wake prompt, and records compact wake/tick evidence
+before user takeover. Each tmux window should open as a real interactive Codex
+CLI TUI role, not as a JSON/status stream. Generic launcher internals stay
+inside LoopX; the operator does not need to know `demo-e2e`, agent ids, wake
+flags, or implementation paths.
 
 Visible Codex TUI panes default to a stable
 `~/loopx-auto-research/<run>/visible-workspace`, not to a demo-local git
@@ -163,8 +172,20 @@ loopx --registry "$LOOPX_REGISTRY" \
   --execute
 ```
 
-That command opens and attaches to tmux by default. For JSON-only automation,
-make the headless path explicit:
+That command starts visible panes, wakes each pane with the fixed
+decentralized A2A prompt, and keeps the current shell available for the compact
+JSON result. To attach immediately instead, opt out of the default wake first:
+
+```bash
+loopx --registry "$LOOPX_REGISTRY" \
+  --runtime-root "$LOOPX_RUNTIME_ROOT" \
+  auto-research start "How should we evaluate autonomous research agents?" \
+  --execute \
+  --no-wake-visible-after-launch \
+  --attach
+```
+
+For JSON-only automation, make the headless path explicit:
 
 ```bash
 loopx --registry "$LOOPX_REGISTRY" \
@@ -174,9 +195,9 @@ loopx --registry "$LOOPX_REGISTRY" \
   --headless
 ```
 
-To start tmux panes but stay in the current shell, use `--no-attach`. Visible
-panes default to the Codex CLI TUI. The pane-local `$LOOPX_PANE_LOOPX` wrapper
-is for human-readable LoopX commands inside that TUI, and
+Visible panes default to the Codex CLI TUI and the product start path stays in
+the current shell after recording wake evidence. The pane-local
+`$LOOPX_PANE_LOOPX` wrapper is for human-readable LoopX commands inside that TUI, and
 `$LOOPX_PANE_LOOPX_JSON` is reserved for redirected machine artifacts. Raw JSON
 should not be dumped into the first visible screen; future control surfaces can
 render those artifacts separately.
@@ -255,8 +276,10 @@ and zero raw logs, private artifacts, credentials, or local absolute paths in
 the payload. With this packet, the E2E result includes `live_worker_evidence`
 and flips `visible_worker_proof.lane_authored_evidence_loaded=true`.
 
-For an explicit visible demo command, `--launch-visible --attach` is still
-accepted, but it is equivalent to the default `--execute` behavior:
+For maintainer-level rehearsal, `demo-e2e --launch-visible --attach` is still
+accepted as a lower-level command. It is not the user-facing product path; the
+short `auto-research start "<open question>" --execute` command owns the
+default evidence-first wake behavior.
 
 ```bash
 loopx --registry "$LOOPX_REGISTRY" \

--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -333,7 +333,8 @@ def main() -> int:
         assert loaded_improvement["round_2_holdout_metric"] == 4.5, loaded_improvement
         assert loaded_improvement["best_metric_source"] == "round_2_holdout", loaded_improvement
         assert loaded_improvement["holdout_delta_over_dev"] == 0.5, loaded_improvement
-        assert "--wake-visible-after-launch" in visible_loaded_readiness["one_command"], visible_loaded_readiness
+        assert visible_loaded_readiness["one_command"].endswith("--execute"), visible_loaded_readiness
+        assert "--wake-visible-after-launch" not in visible_loaded_readiness["one_command"], visible_loaded_readiness
         visible_loaded_markdown = render_auto_research_markdown(visible_loaded_payload)
         assert "- visible_readiness_ready: `True`" in visible_loaded_markdown, visible_loaded_markdown
         assert "- visible_best_metric: `4.5`" in visible_loaded_markdown, visible_loaded_markdown
@@ -616,7 +617,8 @@ def main() -> int:
                 assert improvement["improved_over_baseline"] is True, improvement
                 assert improvement["holdout_delta_over_dev"] is None, improvement
                 assert "auto-research start" in visible_readiness["one_command"], visible_readiness
-                assert "--wake-visible-after-launch" in visible_readiness["one_command"], visible_readiness
+                assert visible_readiness["one_command"].endswith("--execute"), visible_readiness
+                assert "--wake-visible-after-launch" not in visible_readiness["one_command"], visible_readiness
                 launch = visible_payload["visible_launch"]["launch_result"]
                 assert launch["started_lane_count"] == 4, visible_payload
                 assert "frontier" not in launch["started_lanes"], visible_payload

--- a/examples/auto-research-user-contract-entry-smoke.py
+++ b/examples/auto-research-user-contract-entry-smoke.py
@@ -7,6 +7,7 @@ import json
 import subprocess
 import sys
 import tempfile
+from argparse import Namespace
 from pathlib import Path
 from typing import Any
 
@@ -21,6 +22,8 @@ from loopx.capabilities.auto_research.user_contract import (  # noqa: E402
 )
 from loopx.capabilities.auto_research.cli import (  # noqa: E402
     _default_auto_research_start_workspace,
+    _start_attach_visible,
+    _start_wake_visible_after_launch,
 )
 
 
@@ -139,9 +142,76 @@ def run_cli(temp_dir: Path, *args: str) -> str:
     return result.stdout
 
 
+def assert_start_wake_contract() -> None:
+    default_visible = Namespace(
+        execute=True,
+        headless=False,
+        wake_visible_after_launch=True,
+        attach=False,
+        no_attach=False,
+    )
+    assert _start_wake_visible_after_launch(default_visible) is True
+    assert (
+        _start_attach_visible(
+            default_visible,
+            wake_visible_after_launch=_start_wake_visible_after_launch(default_visible),
+        )
+        is False
+    )
+
+    manual_takeover = Namespace(
+        execute=True,
+        headless=False,
+        wake_visible_after_launch=False,
+        attach=False,
+        no_attach=False,
+    )
+    assert _start_wake_visible_after_launch(manual_takeover) is False
+    assert (
+        _start_attach_visible(
+            manual_takeover,
+            wake_visible_after_launch=_start_wake_visible_after_launch(manual_takeover),
+        )
+        is True
+    )
+
+    background_manual = Namespace(
+        execute=True,
+        headless=False,
+        wake_visible_after_launch=False,
+        attach=False,
+        no_attach=True,
+    )
+    assert _start_wake_visible_after_launch(background_manual) is False
+    assert (
+        _start_attach_visible(
+            background_manual,
+            wake_visible_after_launch=_start_wake_visible_after_launch(background_manual),
+        )
+        is False
+    )
+
+    headless = Namespace(
+        execute=True,
+        headless=True,
+        wake_visible_after_launch=True,
+        attach=False,
+        no_attach=False,
+    )
+    assert _start_wake_visible_after_launch(headless) is False
+    assert (
+        _start_attach_visible(
+            headless,
+            wake_visible_after_launch=_start_wake_visible_after_launch(headless),
+        )
+        is False
+    )
+
+
 def main() -> None:
     payload = build_auto_research_user_contract(QUESTION)
     assert_contract(payload)
+    assert_start_wake_contract()
     default_workspace = Path(
         _default_auto_research_start_workspace("loopx-auto-research-demo-smoke")
     )

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -108,6 +108,30 @@ def _default_auto_research_start_workspace(goal_id: str) -> str:
     )
 
 
+def _start_wake_visible_after_launch(args: argparse.Namespace) -> bool:
+    """Return whether `auto-research start` should wake visible lanes after launch."""
+
+    return bool(
+        args.execute
+        and not args.headless
+        and getattr(args, "wake_visible_after_launch", True)
+    )
+
+
+def _start_attach_visible(args: argparse.Namespace, *, wake_visible_after_launch: bool) -> bool:
+    """Return whether `auto-research start` should attach to visible lanes."""
+
+    launch_visible = bool(args.execute and not args.headless)
+    return bool(
+        args.attach
+        or (
+            launch_visible
+            and not args.no_attach
+            and not wake_visible_after_launch
+        )
+    )
+
+
 def _resolve_demo_goal_surface(
     *,
     goal_id: str | None,
@@ -181,7 +205,20 @@ def register_auto_research_commands(
     start_parser.add_argument(
         "--wake-visible-after-launch",
         action="store_true",
-        help="After launching visible panes, broadcast the fixed decentralized A2A wake prompt.",
+        default=True,
+        help=(
+            "After launching visible panes, broadcast the fixed decentralized A2A wake prompt. "
+            "This is the default for visible --execute and is kept for explicitness."
+        ),
+    )
+    start_parser.add_argument(
+        "--no-wake-visible-after-launch",
+        dest="wake_visible_after_launch",
+        action="store_false",
+        help=(
+            "Disable the default fixed-prompt wake after visible launch. "
+            "Use this when you want to attach immediately and let lanes wait for manual input."
+        ),
     )
     start_parser.add_argument(
         "--no-attach",
@@ -191,7 +228,10 @@ def register_auto_research_commands(
     start_parser.add_argument(
         "--attach",
         action="store_true",
-        help="With visible --execute, attach to tmux after launch. This is the default unless --no-attach or --wake-visible-after-launch is set.",
+        help=(
+            "With visible --execute, attach to tmux after launch. "
+            "Default wake records evidence first; pass --no-wake-visible-after-launch to attach immediately."
+        ),
     )
     start_parser.add_argument(
         "--demo-run-id",
@@ -812,14 +852,13 @@ def handle_auto_research_command(
                 max_todos=args.max_todos,
             )
         elif args.auto_research_command == "start":
-            if args.headless and args.wake_visible_after_launch and args.execute:
-                raise ValueError("--headless cannot be combined with --wake-visible-after-launch")
             if args.no_attach and args.attach:
                 raise ValueError("--attach cannot be combined with --no-attach")
-            if args.wake_visible_after_launch and args.attach:
+            wake_visible_after_launch = _start_wake_visible_after_launch(args)
+            if wake_visible_after_launch and args.attach:
                 raise ValueError(
-                    "--wake-visible-after-launch cannot be combined with --attach; "
-                    "wake evidence must be recorded before operator takeover"
+                    "--attach cannot be combined with the default visible wake; "
+                    "pass --no-wake-visible-after-launch when operator takeover should happen first"
                 )
             goal_id, goal_surface_mode = _resolve_demo_goal_surface(
                 goal_id=args.goal_id,
@@ -838,13 +877,9 @@ def handle_auto_research_command(
             visible_launcher: Callable[[dict[str, object], Path, str | None, Path], dict[str, object]] | None = None
             visible_wake: Callable[[str, list[str]], dict[str, object]] | None = None
             launch_visible = bool(args.execute and not args.headless)
-            attach_visible = bool(
-                args.attach
-                or (
-                    launch_visible
-                    and not args.no_attach
-                    and not args.wake_visible_after_launch
-                )
+            attach_visible = _start_attach_visible(
+                args,
+                wake_visible_after_launch=wake_visible_after_launch,
             )
             if launch_visible:
                 def visible_launcher(
@@ -912,9 +947,7 @@ def handle_auto_research_command(
                 append_evidence=append_start_evidence,
                 visible_launcher=visible_launcher,
                 visible_wake=visible_wake,
-                wake_visible_after_launch=bool(
-                    args.execute and args.wake_visible_after_launch
-                ),
+                wake_visible_after_launch=wake_visible_after_launch,
             )
         elif args.auto_research_command == "frontier":
             if bool(args.fixture) == bool(args.goal_id):

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -957,8 +957,6 @@ def run_auto_research_demo_e2e(
                 cli_bin=cli_bin,
                 objective=objective,
                 execute=True,
-                no_attach=True,
-                wake_visible_after_launch=True,
             ),
             "one_command_worker_loop": _command_text(
                 cli_bin=cli_bin,


### PR DESCRIPTION
## Summary
- Make the one-question command loopx auto-research start "<open question>" --execute use the fixed decentralized pane wake by default for visible runs.
- Keep the wake/tick runtime in the generic kernel; the broadcaster still does not choose todos, run worker turns, or write LoopX state.
- Add --no-wake-visible-after-launch for immediate attach/manual takeover and update the command-path guide/smokes.

## Validation
- python3 -m py_compile loopx/capabilities/auto_research/cli.py loopx/capabilities/auto_research/demo_e2e.py examples/auto-research-user-contract-entry-smoke.py examples/auto-research-demo-e2e-worker-loop-smoke.py
- python3 examples/auto-research-user-contract-entry-smoke.py
- python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- python3 examples/auto-research-layered-e2e-acceptance-smoke.py
- python3 examples/generic-multi-agent-runner-kernel-smoke.py
- python3 examples/auto-research-demo-supervisor-smoke.py
- python3 examples/visible-multi-agent-launcher-smoke.py
- python3 examples/generic-multi-agent-one-command-smoke.py
- git diff --check
