### PR TITLE
Promote named smoke-suite profiles

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -170,6 +170,17 @@ python3 examples/run-smokes.py --suite default-public --module canary
 loopx canary smoke-suite --suite default-public --module canary
 ```
 
+For repeatable canary/refactor batches, prefer named smoke-suite profiles over
+hand-curated script lists. Profiles expand to the same runner payload as
+`--module`, `--script`, catalog selectors, and the pytest facade:
+
+```bash
+loopx canary smoke-profiles
+loopx canary smoke-suite --profile core-control-plane --no-execute
+loopx canary smoke-suite --profile canary-runner --timeout-seconds 60
+python3 examples/run-smokes.py --profile public-entry-install-release --no-execute
+```
+
 CI may wrap the same runner selection in pytest when JUnit reporting is useful.
 The pytest facade still executes each `examples/**/*-smoke.py` through a
 subprocess; it is not a migration of legacy smokes into pytest unit tests:
@@ -177,7 +188,7 @@ subprocess; it is not a migration of legacy smokes into pytest unit tests:
 ```bash
 python3 -m pytest tests/test_smoke_suite.py \
   --loopx-smoke-suite default-public \
-  --loopx-smoke-module canary \
+  --loopx-smoke-profile canary-runner \
   --junitxml smoke-suite.xml
 ```
 

--- a/examples/canary/smoke-suite-runner-smoke.py
+++ b/examples/canary/smoke-suite-runner-smoke.py
@@ -13,7 +13,10 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.canary import runner as canary_runner  # noqa: E402
-from loopx.canary.runner import build_canary_smoke_suite_run  # noqa: E402
+from loopx.canary.runner import (  # noqa: E402
+    build_canary_smoke_suite_profiles,
+    build_canary_smoke_suite_run,
+)
 
 
 def assert_default_public_preview_excludes_grouped_smokes() -> None:
@@ -157,6 +160,24 @@ def assert_named_smoke_profile_expands_to_suite_selection() -> None:
     assert all("skillsbench" not in script for script in scripts), payload
 
 
+def assert_named_smoke_profiles_are_discoverable() -> None:
+    payload = build_canary_smoke_suite_profiles()
+    assert payload["ok"] is True, payload
+    assert payload["schema_version"] == "canary_smoke_suite_profiles_v0", payload
+    assert payload["executes_checks"] is False, payload
+    assert payload["writes_evidence"] is False, payload
+    profiles = {profile["id"]: profile for profile in payload["profiles"]}
+    for profile_id in [
+        "core-control-plane",
+        "canary-runner",
+        "public-entry-install-release",
+        "docs-project-content-ops",
+    ]:
+        assert profile_id in profiles, payload
+        assert profiles[profile_id]["modules"], payload
+        assert "benchmark" in profiles[profile_id]["exclude_modules"], payload
+
+
 def assert_named_smoke_profile_can_mix_with_catalog_profile() -> None:
     payload = build_canary_smoke_suite_run(
         suite="default-public",
@@ -236,6 +257,59 @@ def assert_cli_named_smoke_profile_preview_works() -> None:
     assert any(script.startswith("examples/canary/") for script in scripts), payload
     assert all("benchmark" not in script for script in scripts), payload
     assert payload["executes_checks"] is False, payload
+
+
+def assert_cli_named_smoke_profiles_list_works() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "canary",
+            "smoke-profiles",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(completed.stdout)
+    assert payload["ok"] is True, payload
+    assert payload["schema_version"] == "canary_smoke_suite_profiles_v0", payload
+    profile_ids = {profile["id"] for profile in payload["profiles"]}
+    assert "core-control-plane" in profile_ids, payload
+    assert "canary-runner" in profile_ids, payload
+
+
+def assert_run_smokes_profile_preview_matches_runner_selection() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "examples/run-smokes.py",
+            "--json",
+            "--profile",
+            "core-control-plane",
+            "--exclude-module",
+            "status",
+            "--limit",
+            "2",
+            "--no-execute",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    payload = json.loads(completed.stdout)
+    assert payload["ok"] is True, payload
+    assert payload["selection_inputs"]["smoke_profiles"] == ["core-control-plane"], payload
+    assert "status" in payload["selection_inputs"]["exclude_modules"], payload
+    scripts = [check["normalized"]["script"] for check in payload["selected_checks"]]
+    assert scripts, payload
+    assert all("benchmark" not in script for script in scripts), payload
+    assert all("status" not in script for script in scripts), payload
 
 
 def assert_execution_reports_progress_indices() -> None:
@@ -426,10 +500,13 @@ def main() -> int:
     assert_subdirectory_smoke_selection_is_supported()
     assert_legacy_root_script_selector_matches_moved_smokes()
     assert_catalog_profile_preview_is_supported()
+    assert_named_smoke_profiles_are_discoverable()
     assert_named_smoke_profile_expands_to_suite_selection()
     assert_named_smoke_profile_can_mix_with_catalog_profile()
     assert_cli_json_preview_works()
     assert_cli_named_smoke_profile_preview_works()
+    assert_cli_named_smoke_profiles_list_works()
+    assert_run_smokes_profile_preview_matches_runner_selection()
     assert_execution_reports_progress_indices()
     assert_git_probe_contract_is_explicit()
     assert_readonly_run_rejects_and_restores_tracked_side_effects()

--- a/examples/run-smokes.py
+++ b/examples/run-smokes.py
@@ -36,6 +36,12 @@ def parse_args() -> argparse.Namespace:
         help="Filter suite scripts by module token, such as quota, status, or canary.",
     )
     parser.add_argument(
+        "--exclude-module",
+        action="append",
+        default=[],
+        help="Exclude suite scripts by module token after positive selection.",
+    )
+    parser.add_argument(
         "--script",
         action="append",
         default=[],
@@ -93,6 +99,7 @@ def main() -> int:
     payload = build_canary_smoke_suite_run(
         suite=args.suite,
         modules=list(args.module or []),
+        exclude_modules=list(args.exclude_module or []),
         scripts=list(args.script or []),
         families=list(args.family or []),
         profiles=list(args.profile or []),

--- a/loopx/canary/runner.py
+++ b/loopx/canary/runner.py
@@ -9,11 +9,12 @@ from pathlib import Path
 from typing import Any, Callable
 
 from .planner import REPO_ROOT, build_catalog_canary_plan, flatten_catalog_canary_checks
-from .smoke_profiles import resolve_smoke_suite_profiles
+from .smoke_profiles import list_smoke_suite_profiles, resolve_smoke_suite_profiles
 
 
 CANARY_RUN_SCHEMA_VERSION = "catalog_canary_run_v0"
 CANARY_SMOKE_SUITE_RUN_SCHEMA_VERSION = "canary_smoke_suite_run_v0"
+CANARY_SMOKE_SUITE_PROFILE_SCHEMA_VERSION = "canary_smoke_suite_profiles_v0"
 NO_WRITE_ARGS_BY_SCRIPT = {
     "canary-promotion-readiness-smoke.py": ["--no-write-evidence"],
     "dashboard-demo-readiness-smoke.py": ["--skip-browser"],
@@ -27,6 +28,27 @@ NODE_BINARIES = {"node"}
 SHELL_TOKENS = {"&&", "||", ";", "|", ">", "<", ">>", "2>", "2>>"}
 SMOKE_SUITE_CHOICES = {"default-public", "full-public", "catalog-plan"}
 ProgressCallback = Callable[[dict[str, Any]], None]
+
+
+def build_canary_smoke_suite_profiles() -> dict[str, Any]:
+    """List named smoke-suite profiles without reading catalog plans or running checks."""
+
+    profiles = list_smoke_suite_profiles()
+    return {
+        "ok": True,
+        "schema_version": CANARY_SMOKE_SUITE_PROFILE_SCHEMA_VERSION,
+        "source": "loopx.canary.smoke_profiles.SMOKE_SUITE_PROFILE_MANIFEST",
+        "profile_count": len(profiles),
+        "profiles": profiles,
+        "executes_checks": False,
+        "writes_evidence": False,
+        "creates_runtime_contract": False,
+        "note": (
+            "Named smoke-suite profiles expand to the same canary smoke-suite "
+            "runner payload used by CLI, pytest facade, and automation. Unknown "
+            "profile ids continue to route to catalog-profile selection."
+        ),
+    }
 
 
 def _is_relative_to(path: Path, parent: Path) -> bool:
@@ -793,4 +815,34 @@ def render_canary_smoke_suite_run_markdown(payload: dict[str, Any]) -> str:
         if check.get("stderr_tail"):
             lines.append(f"- stderr_tail: `{str(check.get('stderr_tail')).strip()[-300:]}`")
         lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def render_canary_smoke_suite_profiles_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# Canary Smoke Suite Profiles",
+        "",
+        f"- source: `{payload.get('source')}`",
+        f"- profiles: `{payload.get('profile_count')}`",
+        "- dry_run: `true`",
+        "- executes_checks: `false`",
+        "- writes_evidence: `false`",
+        "- creates_runtime_contract: `false`",
+        "",
+        str(payload.get("note") or ""),
+        "",
+    ]
+    for profile in payload.get("profiles", []):
+        if not isinstance(profile, dict):
+            continue
+        lines.extend(
+            [
+                f"## {profile.get('id')}",
+                f"- suite: `{profile.get('suite')}`",
+                f"- modules: `{', '.join(profile.get('modules') or [])}`",
+                f"- exclude_modules: `{', '.join(profile.get('exclude_modules') or [])}`",
+                f"- description: {profile.get('description')}",
+                "",
+            ]
+        )
     return "\n".join(lines).rstrip() + "\n"

--- a/loopx/canary/smoke_profiles.py
+++ b/loopx/canary/smoke_profiles.py
@@ -68,6 +68,31 @@ SMOKE_SUITE_PROFILE_MANIFEST: dict[str, dict[str, Any]] = {
 }
 
 
+def list_smoke_suite_profiles() -> list[dict[str, Any]]:
+    """Return stable, machine-readable smoke-suite profile metadata."""
+
+    profiles: list[dict[str, Any]] = []
+    for profile_id, profile_spec in sorted(SMOKE_SUITE_PROFILE_MANIFEST.items()):
+        profiles.append(
+            {
+                "id": profile_id,
+                "suite": str(profile_spec.get("suite") or "default-public"),
+                "modules": [
+                    str(item)
+                    for item in profile_spec.get("modules", [])
+                    if str(item).strip()
+                ],
+                "exclude_modules": [
+                    str(item)
+                    for item in profile_spec.get("exclude_modules", [])
+                    if str(item).strip()
+                ],
+                "description": str(profile_spec.get("description") or ""),
+            }
+        )
+    return profiles
+
+
 def _append_unique(values: list[str], additions: list[str]) -> list[str]:
     seen = {value for value in values if value}
     expanded = list(values)

--- a/loopx/cli_commands/canary.py
+++ b/loopx/cli_commands/canary.py
@@ -15,8 +15,10 @@ from ..canary.planner import (
     render_catalog_canary_profiles_markdown,
 )
 from ..canary.runner import (
+    build_canary_smoke_suite_profiles,
     build_canary_smoke_suite_run,
     build_catalog_canary_run,
+    render_canary_smoke_suite_profiles_markdown,
     render_canary_smoke_suite_run_markdown,
     render_catalog_canary_run_markdown,
 )
@@ -241,6 +243,12 @@ def register_canary_commands(
         help="Override the interaction-pattern catalog path.",
     )
 
+    smoke_profiles_parser = canary_sub.add_parser(
+        "smoke-profiles",
+        help="List named smoke-suite profiles used by CLI, pytest facade, and automation.",
+    )
+    add_subcommand_format(smoke_profiles_parser)
+
     plan_parser = canary_sub.add_parser(
         "plan",
         help="Select the smallest useful canary profiles for changed surfaces.",
@@ -376,6 +384,9 @@ def handle_canary_command(
     if args.canary_command == "profiles":
         payload = build_catalog_canary_profiles(catalog_path=args.catalog)
         renderer = render_catalog_canary_profiles_markdown
+    elif args.canary_command == "smoke-profiles":
+        payload = build_canary_smoke_suite_profiles()
+        renderer = render_canary_smoke_suite_profiles_markdown
     elif args.canary_command == "plan":
         changed_files, git_diff_selector = _resolve_canary_changed_files(args)
         payload = build_catalog_canary_plan(


### PR DESCRIPTION
## Summary
- expose named smoke-suite profiles as a read-only canary runner/CLI contract
- let examples/run-smokes.py consume the same profile/exclude-module runner payload
- document profile-based canary/refactor batches and pytest facade usage

## Validation
- python3 -m py_compile loopx/canary/smoke_profiles.py loopx/canary/runner.py loopx/cli_commands/canary.py examples/run-smokes.py examples/canary/smoke-suite-runner-smoke.py
- python3 examples/canary/smoke-suite-runner-smoke.py
- python3 -m loopx.cli --format json canary smoke-profiles
- python3 -m loopx.cli --format json canary smoke-suite --profile canary-runner --limit 3 --no-execute
- python3 examples/run-smokes.py --json --profile public-entry-install-release --limit 2 --no-execute
- python3 examples/canary/pytest-smoke-suite-facade-smoke.py
- python3 -m loopx.cli canary smoke-suite --profile canary-runner --limit 1 --timeout-seconds 60 --no-progress