### PR TITLE
Skip pytest smoke facade when tests are unpackaged

### DIFF
--- a/examples/canary/pytest-smoke-suite-facade-smoke.py
+++ b/examples/canary/pytest-smoke-suite-facade-smoke.py
@@ -13,6 +13,13 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
+def _pytest_facade_available() -> bool:
+    return (
+        (REPO_ROOT / "tests" / "test_smoke_suite.py").is_file()
+        and (REPO_ROOT / "tests" / "conftest.py").is_file()
+    )
+
+
 def _pytest_command() -> list[str] | None:
     uvx = shutil.which("uvx")
     if uvx:
@@ -25,6 +32,13 @@ def _pytest_command() -> list[str] | None:
 
 
 def main() -> int:
+    if not _pytest_facade_available():
+        print(
+            "pytest-smoke-suite-facade-smoke skipped: pytest facade tests are "
+            "not packaged in this checkout"
+        )
+        return 0
+
     command_prefix = _pytest_command()
     if command_prefix is None:
         print("pytest-smoke-suite-facade-smoke skipped: pytest or uvx is unavailable")


### PR DESCRIPTION
## Summary
- classify the canary-runner red point from installed release snapshots as an optional pytest-facade packaging boundary
- skip the pytest facade smoke when tests/test_smoke_suite.py or tests/conftest.py is not present
- keep source checkouts running the real pytest/JUnit facade smoke

## Validation
- python3 -m py_compile examples/canary/pytest-smoke-suite-facade-smoke.py examples/canary/smoke-suite-runner-smoke.py
- python3 examples/canary/pytest-smoke-suite-facade-smoke.py
- release-like temp tree without tests skips the smoke
- python3 -m loopx.cli --format json canary smoke-suite --profile canary-runner --timeout-seconds 90 --no-progress
- python3 examples/canary/smoke-suite-runner-smoke.py

## Smoke classification
- canary-runner source checkout: green, 10/10
- core-control-plane first 20 source checkout: green, 20/20
- installed loopx release snapshot red: pytest facade tests are not packaged, so the optional facade smoke should skip there rather than fail unrelated canary profiles