### PR TITLE
Harden visible pane wake submission

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -61,7 +61,7 @@ def main() -> int:
     assert "$LOOPX_PANE_LOOPX_JSON is a command path, not an output file." in runtime_scripts_source
     assert "LOOPX_PANE_WORKER_TURN" in launcher_source
     assert "loopx-pane-a2a-tick" in runtime_scripts_source
-    assert "role_prompt_inside_codex_tui" in launcher_source
+    assert "role_prompt_public_artifact_for_fixed_wake" in launcher_source
     assert "model_reasoning_effort" in launcher_source
     assert "codex_stream_filter" not in launcher_source
     assert "build_auto_research_quickstart" not in demo_e2e_source
@@ -259,6 +259,28 @@ def main() -> int:
                 "broadcaster_reads_frontier": False,
                 "broadcaster_selects_todo": False,
                 "pane_decision_owner": "codex_tui_agent_via_loopx_state",
+                "pane_input_ready_verified": True,
+                "pane_input_ready_checks": [
+                    {
+                        "lane": lane,
+                        "ready": True,
+                        "attempt_count": 1,
+                        "capture_ok": True,
+                        "ready_marker": "codex_tui_first_turn_ready",
+                    }
+                    for lane in target_lanes
+                ],
+                "prompt_submit_checks": [
+                    {
+                        "target": f"{session}:{lane}",
+                        "initial_submit_key": "Enter",
+                        "retry_submit_key": None,
+                        "retry_count": 0,
+                        "capture_ok": True,
+                    }
+                    for lane in target_lanes
+                ],
+                "prompt_delivery": "tmux_paste_buffer_after_codex_tui_first_turn_ready",
                 "boundary": {
                     "writes_loopx_state": False,
                     "spends_loopx_quota": False,
@@ -313,6 +335,12 @@ def main() -> int:
         assert visible_loaded_rounds["multi_round_verified"] is True, visible_loaded_rounds
         assert visible_loaded_wake["wakeup_model"] == "fixed_prompt_broadcast", visible_loaded_wake
         assert visible_loaded_wake["coordination_model"] == "decentralized_state_a2a", visible_loaded_wake
+        assert visible_loaded_wake["pane_input_ready_verified"] is True, visible_loaded_wake
+        assert (
+            visible_loaded_wake["prompt_delivery"]
+            == "tmux_paste_buffer_after_codex_tui_first_turn_ready"
+        ), visible_loaded_wake
+        assert visible_loaded_wake["prompt_submit_checks"], visible_loaded_wake
         assert visible_loaded_wake["workflow_driver"] is False, visible_loaded_wake
         assert visible_loaded_wake["broadcaster_reads_frontier"] is False, visible_loaded_wake
         assert visible_loaded_wake["broadcaster_selects_todo"] is False, visible_loaded_wake
@@ -382,8 +410,12 @@ def main() -> int:
         fake_codex.write_text(
             "#!/usr/bin/env sh\n"
             f"{{ printf 'PWD=%s\\n' \"$PWD\"; printf 'ARGS=%s\\n' \"$*\"; }} >> {shlex.quote(str(codex_invocations))}\n"
-            "printf 'Fake Codex TUI ready\\n'\n"
-            "sleep 8\n",
+            "printf '╭────────────────────────╮\\n'\n"
+            "printf '│ >_ OpenAI Codex        │\\n'\n"
+            "printf '│ model: gpt-5.5 high    │\\n'\n"
+            "printf '╰────────────────────────╯\\n\\n'\n"
+            "printf '› Implement {feature}\\n'\n"
+            "sleep 30\n",
             encoding="utf-8",
         )
         fake_codex.chmod(0o755)
@@ -397,6 +429,13 @@ def main() -> int:
         env["PYTHONDONTWRITEBYTECODE"] = "1"
         env["PYTHONPATH"] = str(REPO_ROOT)
         env["PATH"] = f"{fake_bin}{os.pathsep}{env.get('PATH', '')}"
+        env["FAKE_TMUX_CAPTURE_TEXT"] = (
+            "╭────────────────────────╮\n"
+            "│ >_ OpenAI Codex        │\n"
+            "│ model: gpt-5.5 high    │\n"
+            "╰────────────────────────╯\n\n"
+            "› Implement {feature}\n"
+        )
         result = subprocess.run(
             [
                 sys.executable,
@@ -581,6 +620,12 @@ def main() -> int:
                 assert visible_wake["workflow_driver"] is False, visible_wake
                 assert visible_wake["broadcaster_reads_frontier"] is False, visible_wake
                 assert visible_wake["broadcaster_selects_todo"] is False, visible_wake
+                assert visible_wake["pane_input_ready_verified"] is True, visible_wake
+                assert (
+                    visible_wake["prompt_delivery"]
+                    == "tmux_paste_buffer_after_codex_tui_first_turn_ready"
+                ), visible_wake
+                assert visible_wake["prompt_submit_checks"], visible_wake
                 visible_readiness = visible_payload["visible_readiness"]
                 assert visible_readiness["schema_version"] == "auto_research_visible_readiness_v0", visible_readiness
                 assert visible_readiness["ready"] is True, visible_readiness

--- a/examples/auto-research-demo-supervisor-smoke.py
+++ b/examples/auto-research-demo-supervisor-smoke.py
@@ -170,7 +170,7 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
         assert "quota should-run" in lane["quota_guard"], lane
         assert f"--agent-id {lane['agent_id']}" in lane["quota_guard"], lane
         assert lane["frontier"] == "agent-scoped LoopX todo/quota/frontier projection", lane
-        assert lane["bootstrap_message"] == "role_prompt_inside_codex_tui", lane
+        assert lane["bootstrap_message"] == "role_prompt_public_artifact_for_fixed_wake", lane
         assert lane["pane_local_a2a"]["tick_command"] == "$LOOPX_PANE_A2A_TICK", lane
         assert lane["pane_local_a2a"]["worker_turn_configured"] is True, lane
         assert lane["pane_local_a2a"]["auto_start"] is True, lane

--- a/examples/auto-research-layered-e2e-acceptance-smoke.py
+++ b/examples/auto-research-layered-e2e-acceptance-smoke.py
@@ -172,7 +172,7 @@ def assert_three_layer_minimality() -> None:
     ], supervisor
     for lane in lanes:
         assert lane["pane_local_a2a"]["auto_start"] is True, lane
-        assert lane["bootstrap_message"] == "role_prompt_inside_codex_tui", lane
+        assert lane["bootstrap_message"] == "role_prompt_public_artifact_for_fixed_wake", lane
         assert "LOOPX_PANE_A2A_TICK" in lane["visible_launch_command"], lane
         assert "pane-a2a-tick.output.txt" in lane["visible_launch_command"], lane
         assert "--visible-lanes-accepted" in lane["visible_launch_command"], lane

--- a/examples/generic-multi-agent-one-command-smoke.py
+++ b/examples/generic-multi-agent-one-command-smoke.py
@@ -148,6 +148,14 @@ def fake_tmux_script() -> str:
             "if len(sys.argv) > 1 and sys.argv[1] == 'list-windows':",
             "    print('planner\\ncritic')",
             "    raise SystemExit(0)",
+            "if len(sys.argv) > 1 and sys.argv[1] == 'capture-pane':",
+            "    print('╭────────────────────────╮')",
+            "    print('│ >_ OpenAI Codex        │')",
+            "    print('│ model: gpt-5.5 high    │')",
+            "    print('╰────────────────────────╯')",
+            "    print()",
+            "    print('› Implement {feature}')",
+            "    raise SystemExit(0)",
             "raise SystemExit(0)",
             "",
         ]
@@ -335,6 +343,10 @@ def main() -> int:
         )
         assert exec_wake["mode"] == "execute", exec_wake
         assert exec_wake["target_lanes"] == ["planner", "critic"], exec_wake
+        assert [item["retry_count"] for item in exec_wake["prompt_submit_checks"]] == [
+            0,
+            0,
+        ], exec_wake
         assert exec_wake["boundary"]["writes_loopx_state"] is False, exec_wake
         assert exec_wake["boundary"]["runs_worker_turn_directly"] is False, exec_wake
         assert_public_safe(

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -25,6 +25,7 @@ from loopx.visible_multi_agent_launcher import (  # noqa: E402
     build_visible_multi_agent_payload,
     build_visible_multi_agent_payload_from_spec,
     execute_visible_multi_agent_launcher,
+    wake_visible_multi_agent_panes,
 )
 
 
@@ -125,6 +126,9 @@ def main() -> int:
     assert "LOOPX_CODEX_BIN" in launcher_source
     assert "LOOPX_CODEX_REASONING_EFFORT" in launcher_source
     assert "export BOOTSTRAP_PROMPT" in launcher_source
+    assert "pane_input_ready_verified" in launcher_source
+    assert "tmux_paste_buffer_after_codex_tui_first_turn_ready" in launcher_source
+    assert "prompt_submit_checks" in launcher_source
     assert "_persist_codex_workspace_trust" in launcher_source
     assert "rev-parse\", \"--show-toplevel" in runtime_source
     assert "trust_level=" in runtime_source and "trusted" in runtime_source
@@ -513,6 +517,38 @@ def main() -> int:
                 cwd=temp,
                 codex_trust_workspace=True,
             )
+            os.environ["FAKE_TMUX_CAPTURE_TEXT"] = (
+                "╭────────────────────────╮\n"
+                "│ >_ OpenAI Codex        │\n"
+                "│ model: gpt-5.5 high    │\n"
+                "╰────────────────────────╯\n\n"
+                "› Write tests for @filename\n"
+            )
+            wake = wake_visible_multi_agent_panes(
+                session_name="loopx-visible-launcher-smoke",
+                tmux_bin="tmux",
+                lanes=["planner", "reviewer"],
+                execute=True,
+            )
+            assert wake["schema_version"] == "multi_agent_pane_a2a_wakeup_v0", wake
+            assert wake["mode"] == "execute", wake
+            assert wake["wakeup_model"] == "fixed_prompt_broadcast", wake
+            assert wake["pane_input_ready_verified"] is True, wake
+            assert wake["prompt_delivery"] == (
+                "tmux_paste_buffer_after_codex_tui_first_turn_ready"
+            ), wake
+            assert [item["lane"] for item in wake["pane_input_ready_checks"]] == [
+                "planner",
+                "reviewer",
+            ], wake
+            assert all(
+                item["ready_marker"] == "codex_tui_first_turn_ready"
+                for item in wake["pane_input_ready_checks"]
+            ), wake
+            assert [item["retry_count"] for item in wake["prompt_submit_checks"]] == [
+                0,
+                0,
+            ], wake
 
             git_root_workspace = temp / "git-root" / "lanes" / "planner"
             git_root_workspace.mkdir(parents=True, exist_ok=True)
@@ -538,7 +574,8 @@ def main() -> int:
             )
             codex_args = json.loads(codex_argv_log.read_text(encoding="utf-8"))
             assert "-C" in codex_args and str(git_root_workspace) in codex_args, codex_args
-            assert codex_args[-1] == "planner prompt", codex_args
+            assert "planner prompt" not in codex_args, codex_args
+            assert codex_args[-1] == str(git_root_workspace), codex_args
             trust_args = [
                 item
                 for index, item in enumerate(codex_args)

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -691,6 +691,10 @@ def _load_visible_wake_into_payload(
         "broadcaster_reads_frontier": bool(wake.get("broadcaster_reads_frontier")),
         "broadcaster_selects_todo": bool(wake.get("broadcaster_selects_todo")),
         "pane_decision_owner": wake.get("pane_decision_owner"),
+        "pane_input_ready_verified": wake.get("pane_input_ready_verified") is True,
+        "pane_input_ready_checks": wake.get("pane_input_ready_checks") or [],
+        "prompt_submit_checks": wake.get("prompt_submit_checks") or [],
+        "prompt_delivery": wake.get("prompt_delivery"),
         "driver_contract_schema": driver.get("schema_version"),
         "driver_owner_layer": driver.get("owner_layer"),
         "boundary": wake.get("boundary"),
@@ -705,6 +709,7 @@ def _load_visible_wake_into_payload(
             and wake.get("workflow_driver") is False
             and wake.get("broadcaster_reads_frontier") is False
             and wake.get("broadcaster_selects_todo") is False
+            and wake.get("pane_input_ready_verified") is True
         )
 
 

--- a/loopx/capabilities/multi_agent/contract.py
+++ b/loopx/capabilities/multi_agent/contract.py
@@ -19,7 +19,7 @@ THREE_LAYER_MINIMALITY_CONTRACT_SCHEMA_VERSION = (
 )
 
 PANE_LOCAL_A2A_WAKEUP_PROMPT = (
-    "LoopX pane-local A2A wakeup: run $LOOPX_PANE_A2A_TICK now. "
+    "LoopX pane-local A2A wakeup: read $LOOPX_CODEX_TUI_PROMPT_ARTIFACT for role/scope if needed, then run $LOOPX_PANE_A2A_TICK now. "
     "Use only your own LOOPX_GOAL_ID/LOOPX_AGENT_ID quota/frontier; "
     "if no runnable frontier, stay quiet with a brief no-action note; "
     "if advanced, summarize public evidence and next handoff. "
@@ -158,6 +158,7 @@ def build_decentralized_a2a_driver_contract(
             "frontier_embedded": False,
             "todo_embedded": False,
             "target_role_embedded": False,
+            "target_role_artifact_ref": "$LOOPX_CODEX_TUI_PROMPT_ARTIFACT",
         },
         "broadcaster": {
             "command": wake_command,
@@ -263,7 +264,7 @@ def build_tui_multi_agent_runner_contract(
             "all_lane_workspace_isolation": all_lane_workspace_isolation,
         },
         "role_prompt_and_skill": {
-            "bootstrap_prompt": "written_to_public_artifact_then_passed_to_codex_tui",
+            "bootstrap_prompt": "written_to_public_artifact_for_fixed_wake_context",
             "role_profile": "role-local public json artifact",
             "skill_materialization": ".codex/skills/<skill>/SKILL.md",
             "worker_local_skill_only": True,

--- a/loopx/capabilities/multi_agent/runtime_scripts.py
+++ b/loopx/capabilities/multi_agent/runtime_scripts.py
@@ -182,7 +182,6 @@ import subprocess
 codex = os.environ["LOOPX_CODEX_BIN"]
 project = os.environ["LOOPX_PROJECT"]
 reasoning_effort = os.environ["LOOPX_CODEX_REASONING_EFFORT"]
-prompt = os.environ["BOOTSTRAP_PROMPT"]
 
 args = [codex]
 if os.environ.get("LOOPX_CODEX_TRUST_WORKSPACE") == "1":
@@ -202,6 +201,6 @@ if os.environ.get("LOOPX_CODEX_TRUST_WORKSPACE") == "1":
         seen.add(path)
         args.extend(["-c", f"projects.{json.dumps(path)}.trust_level=\"trusted\""])
 
-args.extend(["-c", f"model_reasoning_effort={reasoning_effort}", "-C", project, prompt])
+args.extend(["-c", f"model_reasoning_effort={reasoning_effort}", "-C", project])
 os.execvp(codex, args)
 """

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -37,6 +37,7 @@ def _q(value: object) -> str:
 
 PANE_A2A_WAKEUP_SCHEMA_VERSION = "multi_agent_pane_a2a_wakeup_v0"
 PANE_A2A_WAKEUP_PROMPT = PANE_LOCAL_A2A_WAKEUP_PROMPT
+PANE_A2A_INPUT_READY_TIMEOUT_SECONDS = 90.0
 
 
 def require_executable(command: str, *, field: str) -> str:
@@ -50,6 +51,128 @@ def build_pane_a2a_wakeup_prompt() -> str:
     """Return the fixed prompt broadcast to live Codex TUI panes."""
 
     return PANE_A2A_WAKEUP_PROMPT
+
+
+def _codex_tui_input_ready(capture: str) -> bool:
+    if "OpenAI Codex" not in capture:
+        return False
+    model_lines = [line for line in capture.splitlines() if "model:" in line]
+    if not model_lines or "loading" in model_lines[-1]:
+        return False
+    marker_index = capture.rfind(model_lines[-1])
+    current_view = capture[marker_index:] if marker_index >= 0 else capture
+    if "Queued follow-up inputs" in current_view or "Working (" in current_view:
+        return False
+    if "Starting MCP servers" in current_view:
+        return False
+    return "\n› " in current_view or "\r\n› " in current_view
+
+
+def _wait_for_tmux_pane_input_ready(
+    *,
+    tmux_bin: str,
+    session: str,
+    lane: str,
+    env: dict[str, str],
+    timeout_seconds: float = PANE_A2A_INPUT_READY_TIMEOUT_SECONDS,
+) -> dict[str, object]:
+    deadline = time.monotonic() + max(0.25, timeout_seconds)
+    attempts = 0
+    target = f"{session}:{lane}"
+    while True:
+        attempts += 1
+        capture = subprocess.run(
+            [tmux_bin, "capture-pane", "-pt", target, "-S", "-80"],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        ready = capture.returncode == 0 and _codex_tui_input_ready(capture.stdout)
+        if ready:
+            return {
+                "lane": lane,
+                "ready": True,
+                "attempt_count": attempts,
+                "capture_ok": True,
+                "ready_marker": "codex_tui_first_turn_ready",
+            }
+        if time.monotonic() >= deadline:
+            return {
+                "lane": lane,
+                "ready": False,
+                "attempt_count": attempts,
+                "capture_ok": capture.returncode == 0,
+                "ready_marker": None,
+            }
+        time.sleep(0.25)
+
+
+def _prompt_still_waiting_for_submit(capture: str, prompt: str) -> bool:
+    if not capture or not prompt:
+        return False
+    model_lines = [line for line in capture.splitlines() if "model:" in line]
+    marker_index = capture.rfind(model_lines[-1]) if model_lines else -1
+    current_view = capture[marker_index:] if marker_index >= 0 else capture
+    if "Working (" in current_view or "Queued follow-up inputs" in current_view:
+        return False
+    words = [part for part in prompt.split()[:4] if part]
+    return bool(words) and all(word in current_view for word in words)
+
+
+def _paste_and_submit_tmux_prompt(
+    *,
+    tmux_bin: str,
+    target: str,
+    buffer_name: str,
+    prompt: str,
+    env: dict[str, str],
+) -> dict[str, object]:
+    subprocess.run(
+        [tmux_bin, "paste-buffer", "-b", buffer_name, "-t", target],
+        check=True,
+        env=env,
+    )
+    subprocess.run(
+        [tmux_bin, "send-keys", "-t", target, "Enter"],
+        check=True,
+        env=env,
+    )
+    retry = False
+    capture_ok = False
+    observation_count = 0
+    for _ in range(20):
+        time.sleep(0.25)
+        observation_count += 1
+        capture = subprocess.run(
+            [tmux_bin, "capture-pane", "-pt", target, "-S", "-80"],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        capture_ok = capture.returncode == 0
+        if not capture_ok:
+            continue
+        if _prompt_still_waiting_for_submit(capture.stdout, prompt):
+            retry = True
+            break
+        if "Working (" in capture.stdout or "Queued follow-up inputs" in capture.stdout:
+            break
+    if retry:
+        subprocess.run(
+            [tmux_bin, "send-keys", "-t", target, "Enter"],
+            check=True,
+            env=env,
+        )
+    return {
+        "target": target,
+        "initial_submit_key": "Enter",
+        "retry_submit_key": "Enter" if retry else None,
+        "retry_count": 1 if retry else 0,
+        "capture_ok": capture_ok,
+        "observation_count": observation_count,
+    }
 
 
 def wake_visible_multi_agent_panes(
@@ -71,6 +194,8 @@ def wake_visible_multi_agent_panes(
     prompt_hash = sha256(prompt_text.encode("utf-8")).hexdigest()[:16]
     target_lanes = [str(lane).strip() for lane in lanes or [] if str(lane).strip()]
     driver_contract = build_decentralized_a2a_driver_contract()
+    input_ready_checks: list[dict[str, object]] = []
+    prompt_submit_checks: list[dict[str, object]] = []
 
     if execute:
         require_executable(tmux_bin, field="tmux_bin")
@@ -86,6 +211,25 @@ def wake_visible_multi_agent_panes(
             target_lanes = [line.strip() for line in listed.stdout.splitlines() if line.strip()]
         if not target_lanes:
             raise ValueError("multi-agent wake found no target panes")
+        input_ready_checks = [
+            _wait_for_tmux_pane_input_ready(
+                tmux_bin=tmux_bin,
+                session=session,
+                lane=lane,
+                env=env,
+            )
+            for lane in target_lanes
+        ]
+        not_ready = [
+            str(check.get("lane"))
+            for check in input_ready_checks
+            if check.get("ready") is not True
+        ]
+        if not_ready:
+            raise ValueError(
+                "multi-agent wake target pane input was not ready: "
+                + ", ".join(not_ready)
+            )
         buffer_name = f"loopx-pane-a2a-wakeup-{prompt_hash}"
         subprocess.run(
             [tmux_bin, "set-buffer", "-b", buffer_name, "--", prompt_text],
@@ -94,15 +238,14 @@ def wake_visible_multi_agent_panes(
         )
         for lane in target_lanes:
             target = f"{session}:{lane}"
-            subprocess.run(
-                [tmux_bin, "paste-buffer", "-b", buffer_name, "-t", target],
-                check=True,
-                env=env,
-            )
-            subprocess.run(
-                [tmux_bin, "send-keys", "-t", target, "Enter"],
-                check=True,
-                env=env,
+            prompt_submit_checks.append(
+                _paste_and_submit_tmux_prompt(
+                    tmux_bin=tmux_bin,
+                    target=target,
+                    buffer_name=buffer_name,
+                    prompt=prompt_text,
+                    env=env,
+                )
             )
 
     return {
@@ -120,6 +263,17 @@ def wake_visible_multi_agent_panes(
         "broadcaster_reads_frontier": driver_contract["broadcaster"]["reads_frontier"],
         "broadcaster_selects_todo": driver_contract["broadcaster"]["selects_todo"],
         "pane_decision_owner": driver_contract["pane"]["decision_owner"],
+        "pane_input_ready_verified": (
+            bool(input_ready_checks)
+            and all(check.get("ready") is True for check in input_ready_checks)
+        )
+        if execute
+        else False,
+        "pane_input_ready_checks": input_ready_checks,
+        "prompt_submit_checks": prompt_submit_checks,
+        "prompt_delivery": (
+            "tmux_paste_buffer_after_codex_tui_first_turn_ready" if execute else "dry_run"
+        ),
         "boundary": {
             "writes_loopx_state": False,
             "spends_loopx_quota": False,
@@ -567,7 +721,7 @@ def build_visible_multi_agent_payload_from_spec(
                 "tick_rounds": tick_rounds,
                 "tick_sleep_seconds": tick_sleep_seconds,
             },
-            "bootstrap_message": "role_prompt_inside_codex_tui",
+            "bootstrap_message": "role_prompt_public_artifact_for_fixed_wake",
             "visible_launch_command": build_visible_lane_command(
                 role_id=role_id,
                 role_profile_ref=role_profile_ref,


### PR DESCRIPTION
Summary
- Wait for Codex TUI first-turn readiness before broadcasting pane-local A2A wake prompts.
- Keep role and scope as pane-local artifacts instead of argv bootstrap prompts so the fixed wake is the visible driver.
- Record pane input readiness and submit checks in visible wake payloads and auto-research readiness evidence.

Validation
- python3 examples/visible-multi-agent-launcher-smoke.py
- python3 examples/generic-multi-agent-one-command-smoke.py
- python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- python3 examples/auto-research-demo-supervisor-smoke.py
- python3 examples/auto-research-layered-e2e-acceptance-smoke.py
- python3 examples/auto-research-user-contract-entry-smoke.py
- git diff --check
- Source one-command visible proof passed with real tmux/Codex panes and decentralized wake evidence.