### PR TITLE
Extract claimed todo visibility helper

### DIFF
--- a/examples/control_plane/todo-projection-shared-helper-smoke.py
+++ b/examples/control_plane/todo-projection-shared-helper-smoke.py
@@ -13,16 +13,22 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.quota import (  # noqa: E402
+    _claimed_visibility_items as quota_claimed_visibility_items,
     _todo_projection_sort_key as quota_todo_projection_sort_key,
     _todo_task_class as quota_todo_task_class,
     build_quota_should_run,
 )
-from loopx.status import compact_todo_group, todo_projection_sort_key  # noqa: E402
+from loopx.status import (  # noqa: E402
+    claimed_visibility_items as status_claimed_visibility_items,
+    compact_todo_group,
+    todo_projection_sort_key,
+)
 from loopx.todo_contract import (  # noqa: E402
     TODO_TASK_CLASS_ADVANCEMENT,
     TODO_TASK_CLASS_MONITOR,
 )
 from loopx.todo_projection import (  # noqa: E402
+    todo_claimed_visibility_items as shared_claimed_visibility_items,
     todo_projection_sort_key as shared_todo_projection_sort_key,
 )
 
@@ -189,6 +195,51 @@ def assert_shared_ordering_parity(summary: dict[str, Any]) -> None:
     assert quota_todo_projection_sort_key(embedded_priority) == (0, 9), embedded_priority
 
 
+def assert_claimed_visibility_parity() -> None:
+    items = [
+        todo(
+            1,
+            "[P1] Claimed by A one.",
+            task_class=TODO_TASK_CLASS_ADVANCEMENT,
+            todo_id="todo_a1",
+            claimed_by="agent-a",
+        ),
+        todo(
+            2,
+            "[P1] Claimed by A two.",
+            task_class=TODO_TASK_CLASS_ADVANCEMENT,
+            todo_id="todo_a2",
+            claimed_by="agent-a",
+        ),
+        todo(
+            3,
+            "[P1] Claimed by B one.",
+            task_class=TODO_TASK_CLASS_ADVANCEMENT,
+            todo_id="todo_b1",
+            claimed_by="agent-b",
+        ),
+        todo(
+            4,
+            "[P1] Unclaimed filler.",
+            task_class=TODO_TASK_CLASS_ADVANCEMENT,
+            todo_id="todo_unclaimed",
+        ),
+    ]
+    for selector in (
+        shared_claimed_visibility_items,
+        status_claimed_visibility_items,
+        quota_claimed_visibility_items,
+    ):
+        selected_two = selector(items, limit=2)
+        assert [item["todo_id"] for item in selected_two] == ["todo_a1", "todo_b1"], selected_two
+        selected_three = selector(items, limit=3)
+        assert [item["todo_id"] for item in selected_three] == [
+            "todo_a1",
+            "todo_a2",
+            "todo_b1",
+        ], selected_three
+
+
 def assert_quota_uses_executable_advancement(summary: dict[str, Any]) -> None:
     payload = build_quota_should_run(
         status_payload(summary),
@@ -216,6 +267,7 @@ def main() -> int:
     summary = build_agent_todo_summary()
     assert_status_summary_lanes(summary)
     assert_shared_ordering_parity(summary)
+    assert_claimed_visibility_parity()
     assert_quota_uses_executable_advancement(summary)
     return 0
 

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -84,6 +84,7 @@ from .todo_contract import (
 )
 from .todo_handoff_gate import HandoffGateState, build_todo_handoff_gate_states
 from .todo_projection import (
+    todo_claimed_visibility_items as projection_todo_claimed_visibility_items,
     todo_index_rank as projection_todo_index_rank,
     todo_item_expires_at as projection_todo_item_expires_at,
     todo_item_is_actionable_open as projection_todo_item_is_actionable_open,
@@ -1395,48 +1396,7 @@ def _todo_projection_sort_key(item: dict[str, Any]) -> tuple[int, int]:
 
 
 def _claimed_visibility_items(items: list[dict[str, Any]], *, limit: int) -> list[dict[str, Any]]:
-    if limit <= 0 or len(items) <= limit:
-        return items[:limit]
-    claim_order: list[str] = []
-    buckets: dict[str, list[dict[str, Any]]] = {}
-    for item in items:
-        claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
-        if not claimed_by:
-            continue
-        if claimed_by not in buckets:
-            buckets[claimed_by] = []
-            claim_order.append(claimed_by)
-        buckets[claimed_by].append(item)
-    if not buckets:
-        return items[:limit]
-
-    original_index = {id(item): index for index, item in enumerate(items)}
-    per_claimant_cap = max(1, limit // len(buckets))
-    selected: list[dict[str, Any]] = []
-    selected_ids: set[int] = set()
-    for claimed_by in claim_order:
-        taken = 0
-        for item in buckets[claimed_by]:
-            if taken >= per_claimant_cap:
-                break
-            if len(selected) >= limit:
-                break
-            selected.append(item)
-            selected_ids.add(id(item))
-            taken += 1
-        if len(selected) >= limit:
-            break
-
-    if len(selected) < limit:
-        for item in items:
-            if id(item) in selected_ids:
-                continue
-            selected.append(item)
-            selected_ids.add(id(item))
-            if len(selected) >= limit:
-                break
-
-    return sorted(selected, key=lambda item: original_index.get(id(item), 999999))[:limit]
+    return projection_todo_claimed_visibility_items(items, limit=limit)
 
 
 def _agent_claim_scoped_open_items(

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -113,6 +113,7 @@ from .todo_contract import (
 )
 from .todo_handoff_gate import build_todo_handoff_gate_states
 from .todo_projection import (
+    todo_claimed_visibility_items as projection_todo_claimed_visibility_items,
     todo_item_expires_at as projection_todo_item_expires_at,
     todo_item_is_actionable_open as projection_todo_item_is_actionable_open,
     todo_item_is_due_monitor as projection_todo_item_is_due_monitor,
@@ -6024,48 +6025,7 @@ def todo_projection_sort_key(item: dict[str, Any]) -> tuple[int, int]:
 
 
 def claimed_visibility_items(items: list[dict[str, Any]], *, limit: int) -> list[dict[str, Any]]:
-    if limit <= 0 or len(items) <= limit:
-        return items[:limit]
-    claim_order: list[str] = []
-    buckets: dict[str, list[dict[str, Any]]] = {}
-    for item in items:
-        claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
-        if not claimed_by:
-            continue
-        if claimed_by not in buckets:
-            buckets[claimed_by] = []
-            claim_order.append(claimed_by)
-        buckets[claimed_by].append(item)
-    if not buckets:
-        return items[:limit]
-
-    original_index = {id(item): index for index, item in enumerate(items)}
-    per_claimant_cap = max(1, limit // len(buckets))
-    selected: list[dict[str, Any]] = []
-    selected_ids: set[int] = set()
-    for claimed_by in claim_order:
-        taken = 0
-        for item in buckets[claimed_by]:
-            if taken >= per_claimant_cap:
-                break
-            if len(selected) >= limit:
-                break
-            selected.append(item)
-            selected_ids.add(id(item))
-            taken += 1
-        if len(selected) >= limit:
-            break
-
-    if len(selected) < limit:
-        for item in items:
-            if id(item) in selected_ids:
-                continue
-            selected.append(item)
-            selected_ids.add(id(item))
-            if len(selected) >= limit:
-                break
-
-    return sorted(selected, key=lambda item: original_index.get(id(item), 999999))[:limit]
+    return projection_todo_claimed_visibility_items(items, limit=limit)
 
 
 def todo_item_is_deferred(item: dict[str, Any]) -> bool:

--- a/loopx/todo_projection.py
+++ b/loopx/todo_projection.py
@@ -85,6 +85,57 @@ def todo_projection_sort_key(
     return (todo_priority_rank(item, text_mode=text_mode), todo_index_rank(item))
 
 
+def todo_claimed_visibility_items(
+    items: list[dict[str, Any]],
+    *,
+    limit: int,
+) -> list[dict[str, Any]]:
+    if limit <= 0 or len(items) <= limit:
+        return items[:limit]
+    claim_order: list[str] = []
+    buckets: dict[str, list[dict[str, Any]]] = {}
+    for item in items:
+        claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
+        if not claimed_by:
+            continue
+        if claimed_by not in buckets:
+            buckets[claimed_by] = []
+            claim_order.append(claimed_by)
+        buckets[claimed_by].append(item)
+    if not buckets:
+        return items[:limit]
+
+    original_index = {id(item): index for index, item in enumerate(items)}
+    per_claimant_cap = max(1, limit // len(buckets))
+    selected: list[dict[str, Any]] = []
+    selected_ids: set[int] = set()
+    for claimed_by in claim_order:
+        taken = 0
+        for item in buckets[claimed_by]:
+            if taken >= per_claimant_cap:
+                break
+            if len(selected) >= limit:
+                break
+            selected.append(item)
+            selected_ids.add(id(item))
+            taken += 1
+        if len(selected) >= limit:
+            break
+
+    if len(selected) < limit:
+        for item in items:
+            if id(item) in selected_ids:
+                continue
+            selected.append(item)
+            selected_ids.add(id(item))
+            if len(selected) >= limit:
+                break
+
+    return sorted(selected, key=lambda item: original_index.get(id(item), TODO_MISSING_INDEX))[
+        :limit
+    ]
+
+
 def todo_item_task_text(
     item: dict[str, Any],
     *,


### PR DESCRIPTION
## Summary
- Move the duplicated claim-aware todo visibility selection helper from `status.py` and `quota.py` into `todo_projection.py`.
- Keep status/quota wrappers thin so existing call sites and public behavior stay unchanged.
- Extend the shared todo projection smoke to assert parity across the shared helper and both wrappers.

## Validation
- `python3 -m py_compile loopx/todo_projection.py loopx/status.py loopx/quota.py examples/control_plane/todo-projection-shared-helper-smoke.py`
- `python3 examples/control_plane/todo-projection-shared-helper-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 0 --timeout-seconds 120 --no-progress`
- `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 20 --timeout-seconds 120 --no-progress`
- `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 40 --timeout-seconds 120 --no-progress`
- `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 60 --timeout-seconds 120 --no-progress`
- `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 80 --timeout-seconds 120 --no-progress`
- `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 100 --timeout-seconds 120 --no-progress`
- `git diff --check`
