### PR TITLE
Refine visible pane pre-tick wake contract

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -251,7 +251,10 @@ def main() -> int:
                 "mode": "execute",
                 "session_name": session,
                 "target_lanes": target_lanes,
-                "prompt": "LoopX pane-local A2A wakeup: run $LOOPX_PANE_A2A_TICK now.",
+                "prompt": (
+                    "LoopX pane-local A2A wakeup: inspect $LOOPX_PANE_TICK_SUMMARY, "
+                    "then run $LOOPX_PANE_A2A_TICK only when another round is needed."
+                ),
                 "prompt_hash": "wakehash",
                 "coordination_model": "decentralized_state_a2a",
                 "wakeup_model": "fixed_prompt_broadcast",

--- a/examples/generic-multi-agent-one-command-smoke.py
+++ b/examples/generic-multi-agent-one-command-smoke.py
@@ -263,7 +263,18 @@ def main() -> int:
         ), driver
         assert driver["broadcaster"]["decides_work"] is False, driver
         assert driver["pane"]["tick_command"] == "$LOOPX_PANE_A2A_TICK", driver
+        assert driver["prompt"]["pre_tick_summary_ref"] == "$LOOPX_PANE_TICK_SUMMARY", driver
+        assert "launcher_pre_tick_summary" in driver["pane"]["reads"], driver
+        assert driver["pane"]["cadence_action"] == (
+            "fixed_prompt_wakeup_then_pre_tick_review_or_local_tick"
+        ), driver
         assert driver["acceptance"]["user_and_preset_do_not_own_tick_driver"] is True, driver
+        assert dry_packet["runner_contract"]["pane_local_a2a"]["pre_tick_summary"] == (
+            "$LOOPX_PANE_TICK_SUMMARY"
+        ), dry_packet
+        assert dry_packet["runner_contract"]["pane_local_a2a"]["pre_tick_output"] == (
+            "$LOOPX_PANE_TICK_OUTPUT_ARTIFACT"
+        ), dry_packet
         assert dry_packet["runner_contract"]["pane_local_a2a"]["machine_json_destination"] == (
             "$LOOPX_PANE_ARTIFACT_DIR/*.public.json"
         ), dry_packet
@@ -271,7 +282,9 @@ def main() -> int:
         compact = dry_packet["compact_human_status"]
         assert compact["schema_version"] == "generic_multi_agent_compact_status_v0", compact
         assert compact["role_count"] == 2, compact
-        assert compact["first_action"] == "$LOOPX_PANE_A2A_TICK", compact
+        assert compact["first_action"] == (
+            "pre_tick_summary_then_$LOOPX_PANE_A2A_TICK_when_needed"
+        ), compact
         assert compact["driver_model"] == (
             "fixed_prompt_broadcast_plus_pane_local_state_tick"
         ), compact
@@ -333,6 +346,8 @@ def main() -> int:
         assert dry_wake["broadcaster_reads_frontier"] is False, dry_wake
         assert dry_wake["broadcaster_selects_todo"] is False, dry_wake
         assert "$LOOPX_PANE_A2A_TICK" in dry_wake["prompt"], dry_wake
+        assert "$LOOPX_PANE_TICK_SUMMARY" in dry_wake["prompt"], dry_wake
+        assert "only run $LOOPX_PANE_A2A_TICK" in dry_wake["prompt"], dry_wake
         assert "\n" not in dry_wake["prompt"], dry_wake
         exec_wake = run_wake_command(
             env,
@@ -388,6 +403,11 @@ def main() -> int:
         assert all("LOOPX_CODEX_REASONING_EFFORT=high" in command for command in start_payloads), start_payloads
         assert all("exec python3 -c" in command for command in start_payloads), start_payloads
         assert all("LOOPX_PANE_ARTIFACT_DIR" in command for command in start_payloads), start_payloads
+        assert all("LOOPX_PANE_TICK_SUMMARY" in command for command in start_payloads), start_payloads
+        assert all(
+            "LOOPX_PANE_TICK_OUTPUT_ARTIFACT" in command
+            for command in start_payloads
+        ), start_payloads
         assert all("codex exec" not in command for command in start_payloads), start_payloads
         wake_entries = [entry["argv"] for entry in log_entries if entry["argv"][:1] in (["set-buffer"], ["paste-buffer"], ["send-keys"])]
         assert any(entry[:1] == ["set-buffer"] for entry in wake_entries), wake_entries

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -108,7 +108,11 @@ def main() -> int:
     assert "loopx-pane-a2a-tick" in launcher_source
     assert "LOOPX_PANE_WORKER_TURN" in launcher_source
     assert "LOOPX_PANE_TICK_ROUNDS" in launcher_source
+    assert "LOOPX_PANE_TICK_SUMMARY" in launcher_source
+    assert "LOOPX_PANE_TICK_OUTPUT_ARTIFACT" in launcher_source
     assert "The launcher runs `$LOOPX_PANE_A2A_TICK` before this Codex TUI opens." in contract_source
+    assert "First inspect `$LOOPX_PANE_TICK_SUMMARY`" in contract_source
+    assert "instead of immediately rerunning the tick" in contract_source
     assert "LOOPX_VISIBLE_FORCE_MARKDOWN" in launcher_source
     assert "machine_json_command=$LOOPX_PANE_LOOPX_JSON artifact_dir=$LOOPX_PANE_ARTIFACT_DIR" in runtime_source
     assert "$LOOPX_PANE_LOOPX_JSON is a command path, not an output file." in runtime_source
@@ -180,20 +184,37 @@ def main() -> int:
     assert driver["broadcaster"]["selects_todo"] is False, driver
     assert driver["broadcaster"]["runs_worker_turn"] is False, driver
     assert driver["pane"]["decision_owner"] == "codex_tui_agent_via_loopx_state", driver
+    assert driver["prompt"]["pre_tick_summary_ref"] == "$LOOPX_PANE_TICK_SUMMARY", driver
+    assert "launcher_pre_tick_summary" in driver["pane"]["reads"], driver
+    assert driver["pane"]["cadence_action"] == (
+        "fixed_prompt_wakeup_then_pre_tick_review_or_local_tick"
+    ), driver
     assert driver["acceptance"]["each_pane_decides_from_state"] is True, driver
     assert runner_contract["pane_local_a2a"]["first_action"] == (
-        "launcher runs $LOOPX_PANE_A2A_TICK before Codex TUI opens"
+        "launcher runs $LOOPX_PANE_A2A_TICK before Codex TUI opens; "
+        "live wake reviews $LOOPX_PANE_TICK_SUMMARY before rerun"
     )
     assert runner_contract["pane_local_a2a"]["bounded_rounds_env"] == (
         "LOOPX_PANE_TICK_ROUNDS"
     )
     assert "LOOPX_PANE_WORKER_TURN" in runner_contract["lane_runtime_env"]["pane_tools"]
     assert "LOOPX_PANE_ARTIFACT_DIR" in runner_contract["lane_runtime_env"]["pane_tools"]
+    assert "LOOPX_PANE_TICK_SUMMARY" in runner_contract["lane_runtime_env"]["pane_tools"]
+    assert (
+        "LOOPX_PANE_TICK_OUTPUT_ARTIFACT"
+        in runner_contract["lane_runtime_env"]["pane_tools"]
+    )
     assert runner_contract["pane_local_a2a"]["machine_json_destination"] == (
         "$LOOPX_PANE_ARTIFACT_DIR/*.public.json"
     )
     assert runner_contract["pane_local_a2a"]["rounds_artifact"] == (
         "$LOOPX_PANE_ARTIFACT_DIR/pane-a2a-rounds.public.json"
+    )
+    assert runner_contract["pane_local_a2a"]["pre_tick_summary"] == (
+        "$LOOPX_PANE_TICK_SUMMARY"
+    )
+    assert runner_contract["pane_local_a2a"]["pre_tick_output"] == (
+        "$LOOPX_PANE_TICK_OUTPUT_ARTIFACT"
     )
     assert runner_contract["role_prompt_and_skill"]["worker_local_skill_only"] is True
     assert runner_contract["debug_artifacts"]["machine_json"] == (
@@ -248,6 +269,8 @@ def main() -> int:
     assert "LOOPX_PANE_A2A_TICK" in generic_lane["visible_launch_command"], generic_lane
     assert "LOOPX_PANE_WORKER_TURN" in generic_lane["visible_launch_command"], generic_lane
     assert "LOOPX_PANE_ARTIFACT_DIR" in generic_lane["visible_launch_command"], generic_lane
+    assert "LOOPX_PANE_TICK_SUMMARY" in generic_lane["visible_launch_command"], generic_lane
+    assert "LOOPX_PANE_TICK_OUTPUT_ARTIFACT" in generic_lane["visible_launch_command"], generic_lane
     assert "$LOOPX_PANE_ARTIFACT_DIR/quota.public.json" in generic_lane["quota_guard"], generic_lane
     assert "LOOPX_PANE_TICK_ROUNDS=2" in generic_lane["visible_launch_command"], generic_lane
     assert "LOOPX_PANE_TICK_SLEEP_SECONDS=1" in generic_lane["visible_launch_command"], generic_lane
@@ -533,6 +556,8 @@ def main() -> int:
             assert wake["schema_version"] == "multi_agent_pane_a2a_wakeup_v0", wake
             assert wake["mode"] == "execute", wake
             assert wake["wakeup_model"] == "fixed_prompt_broadcast", wake
+            assert "$LOOPX_PANE_TICK_SUMMARY" in wake["prompt"], wake
+            assert "only run $LOOPX_PANE_A2A_TICK" in wake["prompt"], wake
             assert wake["pane_input_ready_verified"] is True, wake
             assert wake["prompt_delivery"] == (
                 "tmux_paste_buffer_after_codex_tui_first_turn_ready"

--- a/loopx/capabilities/multi_agent/contract.py
+++ b/loopx/capabilities/multi_agent/contract.py
@@ -19,9 +19,11 @@ THREE_LAYER_MINIMALITY_CONTRACT_SCHEMA_VERSION = (
 )
 
 PANE_LOCAL_A2A_WAKEUP_PROMPT = (
-    "LoopX pane-local A2A wakeup: read $LOOPX_CODEX_TUI_PROMPT_ARTIFACT for role/scope if needed, then run $LOOPX_PANE_A2A_TICK now. "
+    "LoopX pane-local A2A wakeup: read $LOOPX_CODEX_TUI_PROMPT_ARTIFACT for role/scope if needed. "
+    "First inspect $LOOPX_PANE_TICK_SUMMARY and summarize completed launcher pre-tick evidence when present; "
+    "only run $LOOPX_PANE_A2A_TICK if that summary is missing, the user asked for another round, or a fresh own-frontier check shows runnable work. "
     "Use only your own LOOPX_GOAL_ID/LOOPX_AGENT_ID quota/frontier; "
-    "if no runnable frontier, stay quiet with a brief no-action note; "
+    "if no runnable frontier remains, stay quiet with a brief no-action note; "
     "if advanced, summarize public evidence and next handoff. "
     "Do not ask the broadcaster for direction; LoopX state is the source of truth."
 )
@@ -125,7 +127,8 @@ def generic_role_prompt(
             "How to work:",
             "- Treat LoopX state as the shared A2A surface.",
             "- The launcher runs `$LOOPX_PANE_A2A_TICK` before this Codex TUI opens.",
-            "- If the tick artifact is missing or the user asks, rerun `$LOOPX_PANE_A2A_TICK` in this TUI.",
+            "- First inspect `$LOOPX_PANE_TICK_SUMMARY`; if it shows completed launcher rounds, summarize that evidence instead of immediately rerunning the tick.",
+            "- Rerun `$LOOPX_PANE_A2A_TICK` only when the summary is missing, the user asks for another round, or a fresh own-frontier check shows runnable work.",
             "- The tick reads your quota/frontier and then runs this role's worker-turn when configured.",
             "- When the tick completes, summarize what changed, what remains blocked, and stay interactive for user takeover.",
             "- For machine reads, run `$LOOPX_PANE_LOOPX_JSON` as the command and redirect output into `$LOOPX_PANE_ARTIFACT_DIR/<name>.public.json`; it defaults to `--format json`.",
@@ -159,6 +162,7 @@ def build_decentralized_a2a_driver_contract(
             "todo_embedded": False,
             "target_role_embedded": False,
             "target_role_artifact_ref": "$LOOPX_CODEX_TUI_PROMPT_ARTIFACT",
+            "pre_tick_summary_ref": "$LOOPX_PANE_TICK_SUMMARY",
         },
         "broadcaster": {
             "command": wake_command,
@@ -174,12 +178,13 @@ def build_decentralized_a2a_driver_contract(
             "decision_owner": "codex_tui_agent_via_loopx_state",
             "tick_command": "$LOOPX_PANE_A2A_TICK",
             "first_action": "launcher_pre_tui_tick",
-            "cadence_action": "fixed_prompt_wakeup_then_local_tick",
+            "cadence_action": "fixed_prompt_wakeup_then_pre_tick_review_or_local_tick",
             "reads": [
                 "own_LOOPX_GOAL_ID",
                 "own_LOOPX_AGENT_ID",
                 "quota_should_run",
                 "agent_scoped_frontier",
+                "launcher_pre_tick_summary",
             ],
             "may_run": ["LOOPX_PANE_WORKER_TURN", "LOOPX_PANE_WORKER_LOOP"],
             "writes": ["public_safe_evidence", "todo_completion_when_worker_turn_configured"],
@@ -255,6 +260,8 @@ def build_tui_multi_agent_runner_contract(
                 "LOOPX_PANE_LOOPX_JSON",
                 "LOOPX_PANE_ARTIFACT_DIR",
                 "LOOPX_PANE_A2A_TICK",
+                "LOOPX_PANE_TICK_SUMMARY",
+                "LOOPX_PANE_TICK_OUTPUT_ARTIFACT",
                 "LOOPX_PANE_WORKER_TURN",
                 "LOOPX_PANE_WORKER_LOOP",
             ],
@@ -272,14 +279,19 @@ def build_tui_multi_agent_runner_contract(
         "decentralized_a2a_driver": driver_contract,
         "pane_local_a2a": {
             "tick_command": driver_contract["pane"]["tick_command"],
-            "first_action": "launcher runs $LOOPX_PANE_A2A_TICK before Codex TUI opens",
+            "first_action": (
+                "launcher runs $LOOPX_PANE_A2A_TICK before Codex TUI opens; "
+                "live wake reviews $LOOPX_PANE_TICK_SUMMARY before rerun"
+            ),
             "cadence_wakeup_command": driver_contract["broadcaster"]["command"],
             "cadence_wakeup_model": driver_contract["broadcaster"]["model"],
             "cadence_broadcaster_decides_work": driver_contract["broadcaster"]["decides_work"],
-            "reads": ["quota should-run", "agent-scoped frontier"],
+            "reads": ["pre-tick summary", "quota should-run", "agent-scoped frontier"],
             "runs": driver_contract["pane"]["may_run"],
             "bounded_rounds_env": driver_contract["pane"]["rounds_env"],
             "rounds_artifact": driver_contract["pane"]["rounds_artifact"],
+            "pre_tick_summary": "$LOOPX_PANE_TICK_SUMMARY",
+            "pre_tick_output": "$LOOPX_PANE_TICK_OUTPUT_ARTIFACT",
             "machine_json_policy": "file_or_explicit_machine_channel_only",
             "machine_json_destination": "$LOOPX_PANE_ARTIFACT_DIR/*.public.json",
             "human_default": "markdown_status_inside_codex_tui",
@@ -405,7 +417,7 @@ def build_compact_human_status(payload: dict[str, object]) -> dict[str, object]:
         "roles": role_summaries,
         "attach": commands.get("attach"),
         "stop": commands.get("stop"),
-        "first_action": "$LOOPX_PANE_A2A_TICK",
+        "first_action": "pre_tick_summary_then_$LOOPX_PANE_A2A_TICK_when_needed",
         "driver_model": driver.get("driver_model")
         or "fixed_prompt_broadcast_plus_pane_local_state_tick",
         "coordination_pattern": driver.get("coordination_pattern")

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -473,12 +473,13 @@ def build_visible_lane_command(
         "printf 'bootstrap_command_failed exit=%s\\n' \"$BOOTSTRAP_STATUS\"; "
         "exec /bin/sh -i; "
         "fi; "
-        'PANE_A2A_TICK_ARTIFACT="$LOOPX_PANE_ARTIFACT_DIR/pane-a2a-tick.output.txt"; '
-        '"$LOOPX_PANE_A2A_TICK" > "$PANE_A2A_TICK_ARTIFACT" 2>&1; '
+        'export LOOPX_PANE_TICK_SUMMARY="$LOOPX_PANE_ARTIFACT_DIR/pane-a2a-rounds.public.json"; '
+        'export LOOPX_PANE_TICK_OUTPUT_ARTIFACT="$LOOPX_PANE_ARTIFACT_DIR/pane-a2a-tick.output.txt"; '
+        '"$LOOPX_PANE_A2A_TICK" > "$LOOPX_PANE_TICK_OUTPUT_ARTIFACT" 2>&1; '
         "PANE_A2A_TICK_STATUS=$?; "
         "if [ \"$PANE_A2A_TICK_STATUS\" -ne 0 ]; then "
         "printf '\\n[LoopX pane A2A blocked]\\n'; "
-        "printf 'tick_exit=%s artifact=%s\\n' \"$PANE_A2A_TICK_STATUS\" \"$PANE_A2A_TICK_ARTIFACT\"; "
+        "printf 'tick_exit=%s artifact=%s\\n' \"$PANE_A2A_TICK_STATUS\" \"$LOOPX_PANE_TICK_OUTPUT_ARTIFACT\"; "
         "fi; "
         "export LOOPX_CODEX_TUI_MODE=interactive; "
         "export LOOPX_CODEX_TUI_PROMPT_ARTIFACT=\"$BOOTSTRAP_ARTIFACT\"; "


### PR DESCRIPTION
## Summary
- make the generic fixed A2A wake prompt inspect `$LOOPX_PANE_TICK_SUMMARY` before asking a live Codex pane to rerun `$LOOPX_PANE_A2A_TICK`
- export stable pane-local pre-tick summary/output artifact env vars from the visible launcher
- keep auto-research thin by covering the behavior in generic multi-agent launcher smokes plus auto-research acceptance smokes

## Validation
- `python3 -m py_compile loopx/capabilities/multi_agent/contract.py loopx/visible_multi_agent_launcher.py loopx/capabilities/multi_agent/runtime_scripts.py`
- `python3 examples/visible-multi-agent-launcher-smoke.py`
- `python3 examples/generic-multi-agent-one-command-smoke.py`
- `python3 examples/auto-research-demo-e2e-worker-loop-smoke.py`
- `python3 examples/auto-research-demo-supervisor-smoke.py`
- `python3 examples/auto-research-layered-e2e-acceptance-smoke.py`
- `python3 examples/auto-research-user-contract-entry-smoke.py`
- `git diff --check`

## Boundary
- generic multi-agent kernel behavior only; no auto-research-specific runner logic
- no raw logs, credentials, private paths, or local runtime artifacts committed
