### PR TITLE
Share deferred todo projection helper

### DIFF
--- a/examples/control_plane/todo-projection-shared-helper-smoke.py
+++ b/examples/control_plane/todo-projection-shared-helper-smoke.py
@@ -14,6 +14,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from loopx.quota import (  # noqa: E402
     _claimed_visibility_items as quota_claimed_visibility_items,
+    _todo_item_is_deferred as quota_todo_item_is_deferred,
     _todo_projection_sort_key as quota_todo_projection_sort_key,
     _todo_task_class as quota_todo_task_class,
     build_quota_should_run,
@@ -21,6 +22,7 @@ from loopx.quota import (  # noqa: E402
 from loopx.status import (  # noqa: E402
     claimed_visibility_items as status_claimed_visibility_items,
     compact_todo_group,
+    todo_item_is_deferred as status_todo_item_is_deferred,
     todo_projection_sort_key,
 )
 from loopx.todo_contract import (  # noqa: E402
@@ -29,6 +31,7 @@ from loopx.todo_contract import (  # noqa: E402
 )
 from loopx.todo_projection import (  # noqa: E402
     todo_claimed_visibility_items as shared_claimed_visibility_items,
+    todo_item_is_deferred as shared_todo_item_is_deferred,
     todo_projection_sort_key as shared_todo_projection_sort_key,
 )
 
@@ -240,6 +243,29 @@ def assert_claimed_visibility_parity() -> None:
         ], selected_three
 
 
+def assert_deferred_helper_parity() -> None:
+    deferred = todo(
+        6,
+        "[P2] Resume after dependency lands.",
+        task_class=TODO_TASK_CLASS_ADVANCEMENT,
+        todo_id="todo_deferred",
+        status="deferred",
+    )
+    open_item = todo(
+        7,
+        "[P2] Still executable.",
+        task_class=TODO_TASK_CLASS_ADVANCEMENT,
+        todo_id="todo_open",
+    )
+    for predicate in (
+        shared_todo_item_is_deferred,
+        status_todo_item_is_deferred,
+        quota_todo_item_is_deferred,
+    ):
+        assert predicate(deferred) is True, deferred
+        assert predicate(open_item) is False, open_item
+
+
 def assert_quota_uses_executable_advancement(summary: dict[str, Any]) -> None:
     payload = build_quota_should_run(
         status_payload(summary),
@@ -268,6 +294,7 @@ def main() -> int:
     assert_status_summary_lanes(summary)
     assert_shared_ordering_parity(summary)
     assert_claimed_visibility_parity()
+    assert_deferred_helper_parity()
     assert_quota_uses_executable_advancement(summary)
     return 0
 

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -88,6 +88,7 @@ from .todo_projection import (
     todo_index_rank as projection_todo_index_rank,
     todo_item_expires_at as projection_todo_item_expires_at,
     todo_item_is_actionable_open as projection_todo_item_is_actionable_open,
+    todo_item_is_deferred as projection_todo_item_is_deferred,
     todo_item_is_due_monitor as projection_todo_item_is_due_monitor,
     todo_item_is_expired_monitor as projection_todo_item_is_expired_monitor,
     todo_item_missing_monitor_schedule as projection_todo_item_missing_monitor_schedule,
@@ -1619,7 +1620,7 @@ def _todo_summary_visibility_lanes(
 
 
 def _todo_item_is_deferred(item: dict[str, Any]) -> bool:
-    return (normalize_todo_status(item.get("status")) or "") == TODO_STATUS_DEFERRED
+    return projection_todo_item_is_deferred(item)
 
 
 def _todo_summary_deferred_items(value: dict[str, Any], key: str) -> list[dict[str, Any]]:

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -116,6 +116,7 @@ from .todo_projection import (
     todo_claimed_visibility_items as projection_todo_claimed_visibility_items,
     todo_item_expires_at as projection_todo_item_expires_at,
     todo_item_is_actionable_open as projection_todo_item_is_actionable_open,
+    todo_item_is_deferred as projection_todo_item_is_deferred,
     todo_item_is_due_monitor as projection_todo_item_is_due_monitor,
     todo_item_is_expired_monitor as projection_todo_item_is_expired_monitor,
     todo_item_missing_monitor_schedule as projection_todo_item_missing_monitor_schedule,
@@ -6029,7 +6030,7 @@ def claimed_visibility_items(items: list[dict[str, Any]], *, limit: int) -> list
 
 
 def todo_item_is_deferred(item: dict[str, Any]) -> bool:
-    return (normalize_todo_status(item.get("status")) or TODO_STATUS_OPEN) == "deferred"
+    return projection_todo_item_is_deferred(item)
 
 
 def normalized_pr_ref_parts(value: Any) -> dict[str, Any] | None:

--- a/loopx/todo_projection.py
+++ b/loopx/todo_projection.py
@@ -14,7 +14,12 @@ from .policies.monitor_todo import (
     monitor_todo_next_due_at,
     monitor_todo_task_class,
 )
-from .todo_contract import TODO_TASK_CLASS_MONITOR, normalize_todo_claimed_by
+from .todo_contract import (
+    TODO_STATUS_DEFERRED,
+    TODO_TASK_CLASS_MONITOR,
+    normalize_todo_claimed_by,
+    normalize_todo_status,
+)
 
 
 TODO_MISSING_PRIORITY_RANK = 50
@@ -161,6 +166,10 @@ def todo_item_task_class(
 
 def todo_item_is_actionable_open(item: dict[str, Any]) -> bool:
     return monitor_todo_is_actionable_open(item)
+
+
+def todo_item_is_deferred(item: dict[str, Any]) -> bool:
+    return (normalize_todo_status(item.get("status")) or "") == TODO_STATUS_DEFERRED
 
 
 def todo_item_next_due_at(item: dict[str, Any]) -> datetime | None:


### PR DESCRIPTION
## Summary
- Move deferred todo detection into the shared todo projection read model.
- Keep status/quota wrappers thin so existing call sites and behavior remain stable.
- Extend the shared helper smoke to assert parity across shared/status/quota deferred detection.

## Validation
- `python3 -m py_compile loopx/todo_projection.py loopx/status.py loopx/quota.py examples/control_plane/todo-projection-shared-helper-smoke.py`
- `python3 examples/control_plane/todo-projection-shared-helper-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 0 --timeout-seconds 120 --no-progress`
- `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 20 --timeout-seconds 120 --no-progress`
- `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 40 --timeout-seconds 120 --no-progress`
- `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 60 --timeout-seconds 120 --no-progress`
- `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 80 --timeout-seconds 120 --no-progress`
- `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 100 --timeout-seconds 120 --no-progress`
- `git diff --check`
