### PR TITLE
Reuse shared todo claim visibility helper

### DIFF
--- a/examples/control_plane/todo-projection-shared-helper-smoke.py
+++ b/examples/control_plane/todo-projection-shared-helper-smoke.py
@@ -14,6 +14,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from loopx.quota import (  # noqa: E402
     _claimed_visibility_items as quota_claimed_visibility_items,
+    _todo_item_claimed_by_agent_or_unclaimed as quota_todo_item_claimed_by_agent_or_unclaimed,
     _todo_item_is_deferred as quota_todo_item_is_deferred,
     _todo_projection_sort_key as quota_todo_projection_sort_key,
     _todo_task_class as quota_todo_task_class,
@@ -31,6 +32,7 @@ from loopx.todo_contract import (  # noqa: E402
 )
 from loopx.todo_projection import (  # noqa: E402
     todo_claimed_visibility_items as shared_claimed_visibility_items,
+    todo_item_claimed_by_agent_or_unclaimed as shared_todo_item_claimed_by_agent_or_unclaimed,
     todo_item_is_deferred as shared_todo_item_is_deferred,
     todo_projection_sort_key as shared_todo_projection_sort_key,
 )
@@ -241,6 +243,16 @@ def assert_claimed_visibility_parity() -> None:
             "todo_a2",
             "todo_b1",
         ], selected_three
+    claimed_by_current = items[0]
+    claimed_by_other = items[2]
+    unclaimed = items[3]
+    for predicate in (
+        shared_todo_item_claimed_by_agent_or_unclaimed,
+        quota_todo_item_claimed_by_agent_or_unclaimed,
+    ):
+        assert predicate(claimed_by_current, agent_id="agent-a") is True, claimed_by_current
+        assert predicate(claimed_by_other, agent_id="agent-a") is False, claimed_by_other
+        assert predicate(unclaimed, agent_id="agent-a") is True, unclaimed
 
 
 def assert_deferred_helper_parity() -> None:

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -86,6 +86,7 @@ from .todo_handoff_gate import HandoffGateState, build_todo_handoff_gate_states
 from .todo_projection import (
     todo_claimed_visibility_items as projection_todo_claimed_visibility_items,
     todo_index_rank as projection_todo_index_rank,
+    todo_item_claimed_by_agent_or_unclaimed as projection_todo_item_claimed_by_agent_or_unclaimed,
     todo_item_expires_at as projection_todo_item_expires_at,
     todo_item_is_actionable_open as projection_todo_item_is_actionable_open,
     todo_item_is_deferred as projection_todo_item_is_deferred,
@@ -1451,8 +1452,7 @@ def _agent_claim_scoped_open_items(
 
 
 def _todo_item_claimed_by_agent_or_unclaimed(item: dict[str, Any], *, agent_id: str) -> bool:
-    claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
-    return not claimed_by or claimed_by == agent_id
+    return projection_todo_item_claimed_by_agent_or_unclaimed(item, agent_id=agent_id)
 
 
 def _agent_scope_selectable_todo_item(


### PR DESCRIPTION
## Summary
- reuse `todo_projection.todo_item_claimed_by_agent_or_unclaimed` from quota instead of keeping another inline claimed-by/unclaimed predicate
- extend the shared-helper smoke to assert parity between the shared helper and quota wrapper

## Validation
- `python3 -m py_compile loopx/quota.py examples/control_plane/todo-projection-shared-helper-smoke.py`
- `python3 examples/control_plane/todo-projection-shared-helper-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 0 --timeout-seconds 120 --no-progress`
- `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 20 --timeout-seconds 120 --no-progress`
- `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 40 --timeout-seconds 120 --no-progress`
- `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 60 --timeout-seconds 120 --no-progress`
- `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 80 --timeout-seconds 120 --no-progress`
- `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 100 --timeout-seconds 120 --no-progress`

All core-control-plane windows were green: 120 selected / 120 executed / 0 failures / 0 timeouts.
