### PR TITLE
Project post-pre-tick auto-research continuation frontier

### DIFF
--- a/examples/auto-research-worker-turn-smoke.py
+++ b/examples/auto-research-worker-turn-smoke.py
@@ -257,6 +257,10 @@ def main() -> int:
         assert executed["live_evidence"]["written"] is True, executed
         assert executed["live_evidence"]["evidence_source"] == "live_codex_lane_output", executed
         assert executed["live_evidence"]["dev_metric"] == 4.0, executed
+        assert executed["continuation_projection"]["source"] == "loopx_state_todo_frontier", executed
+        assert executed["followup"]["needed"] is True, executed
+        assert executed["followup"]["action_kind"] == "run_holdout_eval", executed
+        assert executed["followup"]["claimed_by"] == EVIDENCE_AGENT_ID, executed
         assert executed["frontier"]["frontier"]["selected"]["claimed_by"] == EVIDENCE_AGENT_ID, executed
         assert payload["visible_launch"]["launch_result"]["worker_turn_executed"] is True, payload
         assert payload["visible_launch"]["launch_result"]["worker_turn_count"] == 3, payload
@@ -307,14 +311,33 @@ def main() -> int:
                 ), turn
                 assert turn["frontier"]["frontier"]["selected"]["allowed_action"] == "run_dev_eval", turn
                 assert turn["live_evidence"]["written"] is True, turn
-        alias_evidence = run_worker_turn(
+        projected_holdout = run_worker_turn(
             registry=four_registry,
             runtime_root=four_runtime_root,
             workspace=four_workspace,
             agent_id=EVIDENCE_AGENT_ID,
             execute=False,
         )
-        assert alias_evidence["mode"] == "no_action", alias_evidence
+        assert projected_holdout["mode"] == "dry_run", projected_holdout
+        assert projected_holdout["selected_action"] == "run_holdout_eval", projected_holdout
+        assert projected_holdout["frontier"]["frontier"]["selected"]["claimed_by"] == (
+            EVIDENCE_AGENT_ID
+        ), projected_holdout
+        assert projected_holdout["frontier"]["frontier"]["selected"]["todo_id"] == (
+            turn["followup"]["todo_id"]
+        ), projected_holdout
+        holdout = run_worker_turn(
+            registry=four_registry,
+            runtime_root=four_runtime_root,
+            workspace=four_workspace,
+            agent_id=EVIDENCE_AGENT_ID,
+            execute=True,
+            complete=True,
+        )
+        assert holdout["mode"] == "execute", holdout
+        assert holdout["selected_action"] == "run_holdout_eval", holdout
+        assert holdout["holdout_metric"] == 4.5, holdout
+        assert holdout["completion"]["status"] == "done", holdout
         verifier = run_worker_turn(
             registry=four_registry,
             runtime_root=four_runtime_root,
@@ -328,25 +351,15 @@ def main() -> int:
         assert verifier["selected_action"] == "summarize_evidence", verifier
         assert verifier["artifact"]["kind"] == "evaluation_summary", verifier
         assert verifier["artifact_status"] == "evaluation_summary_written", verifier
-        assert verifier["claim_allowed"] is False, verifier
+        assert verifier["claim_allowed"] is True, verifier
         assert verifier["promotion_decision_made"] is False, verifier
-        assert verifier["followup"]["needed"] is True, verifier
-        assert verifier["followup"]["action_kind"] == "run_holdout_eval", verifier
-        assert verifier["followup"]["claimed_by"] == EVIDENCE_AGENT_ID, verifier
+        assert verifier["followup"]["needed"] is False, verifier
+        assert verifier["followup"]["reason"] in {
+            "holdout_already_validated",
+            "no_dev_promotion_candidate",
+        }, verifier
         assert verifier["completion"]["status"] == "done", verifier
         assert_public_safe(verifier)
-        holdout = run_worker_turn(
-            registry=four_registry,
-            runtime_root=four_runtime_root,
-            workspace=four_workspace,
-            agent_id=EVIDENCE_AGENT_ID,
-            execute=True,
-            complete=True,
-        )
-        assert holdout["mode"] == "execute", holdout
-        assert holdout["selected_action"] == "run_holdout_eval", holdout
-        assert holdout["holdout_metric"] == 4.5, holdout
-        assert holdout["completion"]["status"] == "done", holdout
         generic = add_goal_todo(
             registry_path=four_registry,
             goal_id=GOAL_ID,

--- a/loopx/capabilities/auto_research/worker_runtime.py
+++ b/loopx/capabilities/auto_research/worker_runtime.py
@@ -414,6 +414,47 @@ def _maybe_add_holdout_followup_todo(
     }
 
 
+def _project_holdout_followup_after_dev_evidence(
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    output_path: Path,
+    goal_id: str,
+    todo_id: str,
+    agent_id: str,
+    execute: bool,
+) -> dict[str, object]:
+    """Project a dev-supported candidate into ordinary LoopX todo/frontier state."""
+
+    artifact = _write_evaluation_summary_artifact(
+        registry_path=registry_path,
+        runtime_root_arg=runtime_root_arg,
+        output_path=output_path,
+        goal_id=goal_id,
+        todo_id=todo_id,
+        agent_id=agent_id,
+    )
+    followup = _maybe_add_holdout_followup_todo(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        source_todo_id=todo_id,
+        agent_id=agent_id,
+        decision_summary=artifact["decision_summary"],
+        execute=execute,
+    )
+    return {
+        "schema_version": "auto_research_continuation_projection_v0",
+        "source": "loopx_state_todo_frontier",
+        "candidate_kind": "holdout_validation",
+        "decision_summary": artifact["decision_summary"],
+        "followup": followup,
+        "artifact": _artifact_summary(
+            "evaluation_summary",
+            filename="evaluation-summary.public.json",
+        ),
+    }
+
+
 def _generic_handoff_is_satisfied(
     *,
     selected: dict[str, object],
@@ -993,6 +1034,15 @@ def run_auto_research_worker_turn(
     _write_json(evidence_packet_path, packet)
     append_result = append_evidence(str(evidence_packet_path))
     _write_json(append_result_path, append_result)
+    continuation = _project_holdout_followup_after_dev_evidence(
+        registry_path=registry_path,
+        runtime_root_arg=runtime_root_arg,
+        output_path=evaluation_summary_path,
+        goal_id=goal_id,
+        todo_id=todo_id,
+        agent_id=agent_id,
+        execute=True,
+    )
 
     live_evidence: dict[str, object] | None = None
     if visible_lanes_accepted:
@@ -1048,6 +1098,8 @@ def run_auto_research_worker_turn(
             "evidence_source": live_evidence.get("source") if live_evidence else None,
             "dev_metric": live_lane_evidence.get("dev_metric"),
         },
+        "continuation_projection": continuation,
+        "followup": continuation["followup"],
         "artifacts": {
             "paths_are_local_only": True,
             "evidence_packet": "evidence.public.json",


### PR DESCRIPTION
## Summary
- Project dev-supported auto-research evidence into a normal LoopX run_holdout_eval successor todo immediately after run_dev_eval.
- Keep launcher/wake prompt dumb: next rounds still re-read LoopX quota/frontier and the evidence-runner pane claims its own todo.
- Update worker-turn smoke to prove the projected holdout todo is selected by the evidence-runner frontier before execution.

## Validation
- python3 -m py_compile loopx/capabilities/auto_research/worker_runtime.py examples/auto-research-worker-turn-smoke.py
- python3 examples/auto-research-worker-turn-smoke.py
- python3 examples/auto-research-worker-loop-smoke.py
- python3 examples/auto-research-layered-e2e-acceptance-smoke.py
- python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- python3 examples/auto-research-demo-supervisor-smoke.py
- python3 examples/visible-multi-agent-launcher-smoke.py
- python3 examples/generic-multi-agent-one-command-smoke.py
- git diff --check
- public/private boundary scan on changed paths: clean