### PR TITLE
Share monitor summary item helper

### DIFF
--- a/examples/control_plane/todo-projection-shared-helper-smoke.py
+++ b/examples/control_plane/todo-projection-shared-helper-smoke.py
@@ -16,6 +16,7 @@ from loopx.quota import (  # noqa: E402
     _claimed_visibility_items as quota_claimed_visibility_items,
     _todo_item_claimed_by_agent_or_unclaimed as quota_todo_item_claimed_by_agent_or_unclaimed,
     _todo_item_is_deferred as quota_todo_item_is_deferred,
+    _todo_summary_monitor_items as quota_todo_summary_monitor_items,
     _todo_projection_sort_key as quota_todo_projection_sort_key,
     _todo_task_class as quota_todo_task_class,
     build_quota_should_run,
@@ -35,6 +36,7 @@ from loopx.todo_projection import (  # noqa: E402
     todo_item_claimed_by_agent_or_unclaimed as shared_todo_item_claimed_by_agent_or_unclaimed,
     todo_item_is_deferred as shared_todo_item_is_deferred,
     todo_projection_sort_key as shared_todo_projection_sort_key,
+    todo_summary_monitor_items as shared_todo_summary_monitor_items,
 )
 
 
@@ -278,6 +280,23 @@ def assert_deferred_helper_parity() -> None:
         assert predicate(open_item) is False, open_item
 
 
+def assert_monitor_item_collection_parity(summary: dict[str, Any]) -> None:
+    # Preserve legacy object-identity de-duplication: projected copies of the
+    # same todo_id can appear more than once across monitor summary lanes.
+    expected_ids = [
+        "todo_monitor_p0",
+        "todo_monitor_p0",
+        "todo_monitor_unscheduled",
+        "todo_monitor_p0",
+    ]
+    for selector in (
+        shared_todo_summary_monitor_items,
+        quota_todo_summary_monitor_items,
+    ):
+        selected_ids = [item["todo_id"] for item in selector(summary)]
+        assert selected_ids == expected_ids, selected_ids
+
+
 def assert_quota_uses_executable_advancement(summary: dict[str, Any]) -> None:
     payload = build_quota_should_run(
         status_payload(summary),
@@ -307,6 +326,7 @@ def main() -> int:
     assert_shared_ordering_parity(summary)
     assert_claimed_visibility_parity()
     assert_deferred_helper_parity()
+    assert_monitor_item_collection_parity(summary)
     assert_quota_uses_executable_advancement(summary)
     return 0
 

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -99,6 +99,7 @@ from .todo_projection import (
     todo_priority_rank as projection_todo_priority_rank,
     todo_projection_sort_key as projection_todo_projection_sort_key,
     todo_summary_claim_scope_agent_id as projection_todo_summary_claim_scope_agent_id,
+    todo_summary_monitor_items as projection_todo_summary_monitor_items,
     todo_summary_monitor_due_count as projection_todo_summary_monitor_due_count,
     todo_summary_monitor_due_items as projection_todo_summary_monitor_due_items,
     todo_summary_monitor_schedule_gap_count as projection_todo_summary_monitor_schedule_gap_count,
@@ -540,33 +541,7 @@ def _external_evidence_poll_signal(
 
 
 def _todo_summary_monitor_items(summary: dict[str, Any] | None) -> list[dict[str, Any]]:
-    if not isinstance(summary, dict):
-        return []
-    items: list[dict[str, Any]] = []
-    seen: set[tuple[str, int]] = set()
-    for key in (
-        "monitor_due_items",
-        "current_agent_claimed_monitor_items",
-        "monitor_open_items",
-        "claimed_monitor_open_items",
-        "first_open_items",
-    ):
-        values = summary.get(key)
-        if not isinstance(values, list):
-            continue
-        for value in values:
-            if not isinstance(value, dict):
-                continue
-            if not _todo_item_is_actionable_open(value):
-                continue
-            if _todo_task_class(value) != TODO_TASK_CLASS_MONITOR:
-                continue
-            identity = (normalize_todo_id(value.get("todo_id")) or "", id(value))
-            if identity in seen:
-                continue
-            seen.add(identity)
-            items.append(value)
-    return items
+    return projection_todo_summary_monitor_items(summary)
 
 
 def _projected_monitor_handle(summary: dict[str, Any] | None) -> dict[str, Any] | None:

--- a/loopx/todo_projection.py
+++ b/loopx/todo_projection.py
@@ -18,6 +18,7 @@ from .todo_contract import (
     TODO_STATUS_DEFERRED,
     TODO_TASK_CLASS_MONITOR,
     normalize_todo_claimed_by,
+    normalize_todo_id,
     normalize_todo_status,
 )
 
@@ -257,6 +258,36 @@ def todo_summary_monitor_writeback_supported(summary: dict[str, Any] | None) -> 
     if not contract:
         return True
     return contract.get("supported") is not False
+
+
+def todo_summary_monitor_items(summary: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not isinstance(summary, dict):
+        return []
+    items: list[dict[str, Any]] = []
+    seen: set[tuple[str, int]] = set()
+    for key in (
+        "monitor_due_items",
+        "current_agent_claimed_monitor_items",
+        "monitor_open_items",
+        "claimed_monitor_open_items",
+        "first_open_items",
+    ):
+        values = summary.get(key)
+        if not isinstance(values, list):
+            continue
+        for value in values:
+            if not isinstance(value, dict):
+                continue
+            if not todo_item_is_actionable_open(value):
+                continue
+            if todo_item_task_class(value) != TODO_TASK_CLASS_MONITOR:
+                continue
+            identity = (normalize_todo_id(value.get("todo_id")) or "", id(value))
+            if identity in seen:
+                continue
+            seen.add(identity)
+            items.append(value)
+    return items
 
 
 def _summary_monitor_items(


### PR DESCRIPTION
## Summary
- move quota's monitor summary item collection logic into `todo_projection.todo_summary_monitor_items`
- keep `quota._todo_summary_monitor_items` as a compatibility wrapper around the shared helper
- extend the shared-helper smoke to assert quota/shared monitor item collection parity, including the existing object-identity de-duplication behavior for repeated projected copies

## Validation
- `python3 -m py_compile loopx/todo_projection.py loopx/quota.py examples/control_plane/todo-projection-shared-helper-smoke.py`
- `python3 examples/control_plane/todo-projection-shared-helper-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- after rebasing onto `origin/main` (`9e1bb94c`): `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 0 --timeout-seconds 120 --no-progress`
- after rebasing onto `origin/main` (`9e1bb94c`): `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 20 --timeout-seconds 120 --no-progress`
- after rebasing onto `origin/main` (`9e1bb94c`): `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 40 --timeout-seconds 120 --no-progress`
- after rebasing onto `origin/main` (`9e1bb94c`): `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 60 --timeout-seconds 120 --no-progress`
- after rebasing onto `origin/main` (`9e1bb94c`): `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 80 --timeout-seconds 120 --no-progress`
- after rebasing onto `origin/main` (`9e1bb94c`): `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 100 --timeout-seconds 120 --no-progress`

All rebased core-control-plane windows were green: 120 selected / 120 executed / 0 failures / 0 timeouts.
