### PR TITLE
Share first executable todo helper

### DIFF
--- a/examples/control_plane/todo-projection-shared-helper-smoke.py
+++ b/examples/control_plane/todo-projection-shared-helper-smoke.py
@@ -14,6 +14,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from loopx.quota import (  # noqa: E402
     _claimed_visibility_items as quota_claimed_visibility_items,
+    _first_executable_todo_item as quota_first_executable_todo_item,
     _todo_item_claimed_by_agent_or_unclaimed as quota_todo_item_claimed_by_agent_or_unclaimed,
     _todo_item_is_deferred as quota_todo_item_is_deferred,
     _todo_summary_monitor_items as quota_todo_summary_monitor_items,
@@ -36,6 +37,7 @@ from loopx.todo_projection import (  # noqa: E402
     todo_item_claimed_by_agent_or_unclaimed as shared_todo_item_claimed_by_agent_or_unclaimed,
     todo_item_is_deferred as shared_todo_item_is_deferred,
     todo_projection_sort_key as shared_todo_projection_sort_key,
+    todo_summary_first_executable_item as shared_first_executable_todo_item,
     todo_summary_monitor_items as shared_todo_summary_monitor_items,
 )
 
@@ -297,6 +299,16 @@ def assert_monitor_item_collection_parity(summary: dict[str, Any]) -> None:
         assert selected_ids == expected_ids, selected_ids
 
 
+def assert_first_executable_item_parity(summary: dict[str, Any]) -> None:
+    for selector in (
+        shared_first_executable_todo_item,
+        quota_first_executable_todo_item,
+    ):
+        selected = selector(summary)
+        assert isinstance(selected, dict), summary
+        assert selected["todo_id"] == "todo_advancement_p0", selected
+
+
 def assert_quota_uses_executable_advancement(summary: dict[str, Any]) -> None:
     payload = build_quota_should_run(
         status_payload(summary),
@@ -327,6 +339,7 @@ def main() -> int:
     assert_claimed_visibility_parity()
     assert_deferred_helper_parity()
     assert_monitor_item_collection_parity(summary)
+    assert_first_executable_item_parity(summary)
     assert_quota_uses_executable_advancement(summary)
     return 0
 

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -99,6 +99,7 @@ from .todo_projection import (
     todo_priority_rank as projection_todo_priority_rank,
     todo_projection_sort_key as projection_todo_projection_sort_key,
     todo_summary_claim_scope_agent_id as projection_todo_summary_claim_scope_agent_id,
+    todo_summary_first_executable_item as projection_todo_summary_first_executable_item,
     todo_summary_monitor_items as projection_todo_summary_monitor_items,
     todo_summary_monitor_due_count as projection_todo_summary_monitor_due_count,
     todo_summary_monitor_due_items as projection_todo_summary_monitor_due_items,
@@ -5644,22 +5645,7 @@ def _todo_summary_monitor_schedule_gap_count(
 
 
 def _first_executable_todo_item(agent_todo_summary: dict[str, Any] | None) -> dict[str, Any] | None:
-    if not isinstance(agent_todo_summary, dict):
-        return None
-    items = (
-        agent_todo_summary.get("first_executable_items")
-        if isinstance(agent_todo_summary.get("first_executable_items"), list)
-        else []
-    )
-    for item in items:
-        if not isinstance(item, dict):
-            continue
-        if not _todo_item_is_actionable_open(item):
-            continue
-        if _todo_task_class(item) != TODO_TASK_CLASS_ADVANCEMENT:
-            continue
-        return item
-    return None
+    return projection_todo_summary_first_executable_item(agent_todo_summary)
 
 
 def _open_todo_task_counts(summary: dict[str, Any] | None) -> dict[str, int]:

--- a/loopx/todo_projection.py
+++ b/loopx/todo_projection.py
@@ -16,6 +16,7 @@ from .policies.monitor_todo import (
 )
 from .todo_contract import (
     TODO_STATUS_DEFERRED,
+    TODO_TASK_CLASS_ADVANCEMENT,
     TODO_TASK_CLASS_MONITOR,
     normalize_todo_claimed_by,
     normalize_todo_id,
@@ -465,3 +466,24 @@ def todo_summary_monitor_schedule_gap_count(
             text_mode=text_mode,
         )
     )
+
+
+def todo_summary_first_executable_item(
+    summary: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if not isinstance(summary, dict):
+        return None
+    items = (
+        summary.get("first_executable_items")
+        if isinstance(summary.get("first_executable_items"), list)
+        else []
+    )
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if not todo_item_is_actionable_open(item):
+            continue
+        if todo_item_task_class(item) != TODO_TASK_CLASS_ADVANCEMENT:
+            continue
+        return item
+    return None


### PR DESCRIPTION
## Summary
- move quota's first executable advancement todo selection into `todo_projection.todo_summary_first_executable_item`
- keep `quota._first_executable_todo_item` as a compatibility wrapper around the shared helper
- extend the shared-helper smoke to assert quota/shared first-executable parity

## Validation
- `python3 -m py_compile loopx/todo_projection.py loopx/quota.py examples/control_plane/todo-projection-shared-helper-smoke.py`
- `python3 examples/control_plane/todo-projection-shared-helper-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 0 --timeout-seconds 120 --no-progress`
- `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 20 --timeout-seconds 120 --no-progress`
- `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 40 --timeout-seconds 120 --no-progress`
- `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 60 --timeout-seconds 120 --no-progress`
- `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 80 --timeout-seconds 120 --no-progress`
- `python3 -m loopx.cli --format json canary smoke-suite --profile core-control-plane --limit 20 --offset 100 --timeout-seconds 120 --no-progress`

All core-control-plane windows were green: 120 selected / 120 executed / 0 failures / 0 timeouts.
