### PR TITLE
Make auto-research successor todos role-local

### DIFF
--- a/docs/reference/protocols/auto-research-lane-contract-v1.md
+++ b/docs/reference/protocols/auto-research-lane-contract-v1.md
@@ -80,6 +80,14 @@ The graph can be rendered as a tree, but it is not owned by a tree manager. A
 lane appends or updates the smallest source record it is authorized to touch;
 projection builders derive frontiers and product views afterward.
 
+Successor work should stay equally small. A role profile may declare a
+`successor_todos` rule such as "after `run_dev_eval`, if dev evidence is
+supported and no holdout exists, add `run_holdout_eval` for
+`codex-main-control`." The pane-local tick applies that declaration by writing a
+normal LoopX todo with `claimed_by`, `action_kind`, and `unblocks_todo_id`.
+The next agent still re-enters through its own `quota should-run` and frontier;
+there is no separate continuation projector or central research manager.
+
 ## Capability Rules
 
 1. A `research_curator` may create or amend `research_contract_v0` only inside
@@ -88,7 +96,7 @@ projection builders derive frontiers and product views afterward.
    agent todo and has `claimed_by`, `todo_id`, `mechanism_family`, and
    grounding refs or a clear no-grounding reason.
 3. A `research_executor` may run only the hypothesis selected by current
-   agent-scoped quota or an explicitly claimed successor todo.
+   agent-scoped quota or an explicitly claimed role-declared successor todo.
 4. An `evaluator_promoter` may promote only when dev evidence, held-out
    evidence, clean boundary, and required gates are present.
 5. A `product_narrator` may publish only from `research_evidence_graph_v0`

--- a/docs/reference/protocols/auto-research-role-profile-v0.md
+++ b/docs/reference/protocols/auto-research-role-profile-v0.md
@@ -61,6 +61,17 @@ frontier item, bootstrap prompt, or future kernel API.
     "research_evidence_event_v0",
     "branch_or_artifact_ref",
     "retry_or_retirement_rationale"
+  ],
+  "successor_todos": [
+    {
+      "after_action": "run_dev_eval",
+      "when": "dev_supported_without_holdout",
+      "target_agent_id": "codex-main-control",
+      "target_role_id": "evidence_runner",
+      "task_class": "advancement_task",
+      "action_kind": "run_holdout_eval",
+      "text": "Run held-out validation for the dev-supported hypothesis."
+    }
   ]
 }
 ```
@@ -76,8 +87,13 @@ Required fields:
 - `required_skill` and `skill_section` route the worker to the correct how-to
   instructions after identity is resolved.
 
-Optional fields such as `hypothesis_id`, `agents_overlay`, and
-`handoff_outputs` make the profile more ergonomic but do not grant authority.
+Optional fields such as `hypothesis_id`, `agents_overlay`, `handoff_outputs`,
+and `successor_todos` make the profile more ergonomic but do not grant
+authority. A successor todo declaration is a small role-local handoff rule: when
+the worker completes `after_action` and the `when` condition is satisfied, the
+pane-local tick may write the named LoopX todo for `target_agent_id`. It is not a
+graph-wide planner, and it must still pass quota, todo metadata, and
+public/private boundary checks before another agent can run it.
 
 ## Resolution Order
 
@@ -92,7 +108,7 @@ order:
 4. Load the required skill and only the section named by `skill_section`.
 5. Read applicable `AGENTS.md` overlays for repository and workspace rules.
 6. Act within `allowed_actions` and `write_scope`, then write only the listed
-   handoff outputs.
+   handoff outputs and role-declared successor todos.
 
 If any source conflicts, the worker fails closed in this order:
 
@@ -112,7 +128,7 @@ records still name the role that produced each transition.
 | --- | --- | --- | --- | --- |
 | `research_curator` | Research curator | `contract_ready`, `promotion_gate` | `research_contract_v0`, owner gate todos, protected-boundary notes. | The next step would select a winner, run an experiment, or publish unsupported evidence. |
 | `hypothesis_mapper` | Hypothesis mapper | `hypothesis_proposed`, `retired` | `research_hypothesis_v0`, successor todos, no-follow-up rationale. | Novelty requires the same source that inspired the idea, or negative evidence would be hidden. |
-| `evidence_runner` | Evidence runner | `frontier_selected`, `attempt_running` | Branch refs, dev eval evidence, retry packets. | Protected scope changes, promotion decisions, or private/raw artifacts are needed. |
+| `evidence_runner` | Evidence runner | `frontier_selected`, `attempt_running` | Branch refs, dev/holdout eval evidence, retry packets, role-declared successor todos. | Protected scope changes, promotion decisions, or private/raw artifacts are needed. |
 | `evidence_verifier` | Evidence verifier | `evidence_recorded`, `evaluated`, `promotion_gate` | Held-out validation evidence, evaluation summary, promotion/retirement candidates, gate todos. | Evidence is dev-only but would be presented as promoted, or held-out data is missing when required. |
 
 Future roles such as gate steward, synthesis narrator, and frontier janitor are

--- a/examples/auto-research-demo-supervisor-smoke.py
+++ b/examples/auto-research-demo-supervisor-smoke.py
@@ -166,6 +166,16 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
         assert expected_action_hints[lane["role_id"]] in profile["allowed_actions"], profile
         assert profile["write_scope"], profile
         assert profile["stop_conditions"], profile
+        if lane["role_id"] == "evidence_runner":
+            successors = profile["successor_todos"]
+            assert successors[0]["after_action"] == "run_dev_eval", profile
+            assert successors[0]["target_agent_id"] == "codex-main-control", profile
+            assert successors[0]["action_kind"] == "run_holdout_eval", profile
+            assert "run_holdout_eval" in profile["allowed_actions"], profile
+        if lane["role_id"] == "evidence_verifier":
+            successors = profile["successor_todos"]
+            assert successors[0]["after_action"] == "summarize_evidence", profile
+            assert successors[0]["target_role_id"] == "evidence_runner", profile
 
         assert "quota should-run" in lane["quota_guard"], lane
         assert f"--agent-id {lane['agent_id']}" in lane["quota_guard"], lane

--- a/examples/auto-research-worker-turn-smoke.py
+++ b/examples/auto-research-worker-turn-smoke.py
@@ -29,6 +29,7 @@ CURATOR_AGENT_ID = "codex-product-capability"
 MAPPER_AGENT_ID = "codex-side-bypass"
 EVIDENCE_AGENT_ID = "codex-main-control"
 VERIFIER_AGENT_ID = "codex-value-explorer"
+ALT_EVIDENCE_AGENT_ID = "codex-alt-evidence"
 FOUR_LANES = [
     "codex-product-capability:research-curator:research_curator",
     "codex-side-bypass:hypothesis-mapper:hypothesis_mapper",
@@ -62,6 +63,30 @@ def run_worker_turn(
     execute: bool,
     complete: bool = False,
 ) -> dict[str, Any]:
+    result = run_worker_turn_process(
+        registry=registry,
+        runtime_root=runtime_root,
+        workspace=workspace,
+        agent_id=agent_id,
+        execute=execute,
+        complete=complete,
+    )
+    if result.returncode != 0:
+        raise AssertionError(
+            f"worker-turn failed rc={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+        )
+    return json.loads(result.stdout)
+
+
+def run_worker_turn_process(
+    *,
+    registry: Path,
+    runtime_root: str | None,
+    workspace: Path,
+    agent_id: str,
+    execute: bool,
+    complete: bool = False,
+) -> subprocess.CompletedProcess[str]:
     env = os.environ.copy()
     env["PYTHONDONTWRITEBYTECODE"] = "1"
     env["PYTHONPATH"] = f"{REPO_ROOT}{os.pathsep}{env.get('PYTHONPATH', '')}"
@@ -89,7 +114,7 @@ def run_worker_turn(
         args.append("--execute")
     if complete:
         args.append("--complete-selected-todo")
-    result = subprocess.run(
+    return subprocess.run(
         args,
         cwd=workspace,
         env=env,
@@ -97,11 +122,6 @@ def run_worker_turn(
         capture_output=True,
         text=True,
     )
-    if result.returncode != 0:
-        raise AssertionError(
-            f"worker-turn failed rc={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
-        )
-    return json.loads(result.stdout)
 
 
 def main() -> int:
@@ -257,10 +277,14 @@ def main() -> int:
         assert executed["live_evidence"]["written"] is True, executed
         assert executed["live_evidence"]["evidence_source"] == "live_codex_lane_output", executed
         assert executed["live_evidence"]["dev_metric"] == 4.0, executed
-        assert executed["continuation_projection"]["source"] == "loopx_state_todo_frontier", executed
+        assert executed["successor_todos"]["source"] == "role_profile_successor_todos", executed
+        assert executed["successor_todos"]["role_id"] == "evidence_runner", executed
+        assert executed["successor_todos"]["action"] == "run_dev_eval", executed
+        assert executed["successor_todos"]["successors"][0]["target_role_id"] == "evidence_runner", executed
         assert executed["followup"]["needed"] is True, executed
         assert executed["followup"]["action_kind"] == "run_holdout_eval", executed
         assert executed["followup"]["claimed_by"] == EVIDENCE_AGENT_ID, executed
+        assert executed["followup"]["source"] == "role_profile_successor_todos", executed
         assert executed["frontier"]["frontier"]["selected"]["claimed_by"] == EVIDENCE_AGENT_ID, executed
         assert payload["visible_launch"]["launch_result"]["worker_turn_executed"] is True, payload
         assert payload["visible_launch"]["launch_result"]["worker_turn_count"] == 3, payload
@@ -385,6 +409,47 @@ def main() -> int:
         assert cleanup["decision_summary"]["validated_promotion_candidate_count"] == 1, cleanup
         assert_public_safe(holdout)
         assert_public_safe(cleanup)
+
+        alt_supervisor = build_auto_research_demo_supervisor_plan(
+            goal_id=GOAL_ID,
+            agent_specs=[
+                "codex-alt-curator:research-curator:research_curator",
+                "codex-alt-mapper:hypothesis-mapper:hypothesis_mapper",
+                f"{ALT_EVIDENCE_AGENT_ID}:evidence-runner:evidence_runner",
+                "codex-alt-verifier:evidence-verifier:evidence_verifier",
+            ],
+            reasoning_effort="high",
+        )
+        alt_root = temp / "missing-successor-target"
+        _alt_summary, alt_registry, alt_runtime_root = _seed_visible_demo_control_plane(
+            demo_root=alt_root,
+            goal_id=GOAL_ID,
+            objective="Prove role-declared successor targets fail closed when the target agent is not registered.",
+            supervisor=alt_supervisor,
+        )
+        alt_workspace = alt_root / "visible-control-plane"
+        for agent in ["codex-alt-curator", "codex-alt-mapper"]:
+            turn = run_worker_turn(
+                registry=alt_registry,
+                runtime_root=alt_runtime_root,
+                workspace=alt_workspace,
+                agent_id=agent,
+                execute=True,
+                complete=True,
+            )
+            assert turn["mode"] == "execute", turn
+        missing_target = run_worker_turn_process(
+            registry=alt_registry,
+            runtime_root=alt_runtime_root,
+            workspace=alt_workspace,
+            agent_id=ALT_EVIDENCE_AGENT_ID,
+            execute=True,
+            complete=True,
+        )
+        assert missing_target.returncode != 0, missing_target.stdout
+        assert "successor target_agent_id 'codex-main-control' is not registered" in (
+            missing_target.stdout + missing_target.stderr
+        ), missing_target
 
     print("auto-research-worker-turn-smoke ok")
     return 0

--- a/loopx/capabilities/auto_research/preset.py
+++ b/loopx/capabilities/auto_research/preset.py
@@ -14,6 +14,10 @@ AUTO_RESEARCH_WORKER_SKILL_SOURCE = (
 )
 AUTO_RESEARCH_DEMO_TICK_ROUNDS = 3
 AUTO_RESEARCH_DEMO_TICK_SLEEP_SECONDS = 3
+AUTO_RESEARCH_HOLDOUT_SUCCESSOR_TEXT = (
+    "[P0-auto-research-live] Run held-out validation for the dev-supported "
+    "hypothesis, append public-safe evidence, and summarize promotion readiness."
+)
 
 AUTO_RESEARCH_DEFAULT_LANES = (
     (
@@ -77,16 +81,51 @@ AUTO_RESEARCH_ROLE_PROFILES: dict[str, dict[str, object]] = {
     },
     "evidence_runner": {
         "phase": "evidence",
-        "allowed_actions": ["run_dev_eval"],
+        "allowed_actions": ["run_dev_eval", "run_holdout_eval"],
         "write_scope": ["auto_research_evidence_packet_v0", "rollout_event_log"],
-        "handoff": ["Append scored evidence, complete the selected todo, and leave verifier context."],
+        "handoff": [
+            "Append scored evidence, complete the selected todo, and create the declared successor todo when the role profile says another split is due."
+        ],
+        "successor_todos": [
+            {
+                "after_action": "run_dev_eval",
+                "when": "dev_supported_without_holdout",
+                "target_agent_id": "codex-main-control",
+                "target_role_id": "evidence_runner",
+                "task_class": "advancement_task",
+                "action_kind": "run_holdout_eval",
+                "text": AUTO_RESEARCH_HOLDOUT_SUCCESSOR_TEXT,
+            }
+        ],
     },
     "evidence_verifier": {
         "phase": "verify",
         "allowed_actions": ["summarize_evidence"],
         "write_scope": ["research_evidence_graph_v0", "todo_item_v0"],
-        "handoff": ["Add a next-round hypothesis todo when evidence is incomplete."],
+        "handoff": ["Add a role-declared successor todo when evidence needs another bounded split."],
+        "successor_todos": [
+            {
+                "after_action": "summarize_evidence",
+                "when": "dev_supported_without_holdout",
+                "target_agent_id": "codex-main-control",
+                "target_role_id": "evidence_runner",
+                "task_class": "advancement_task",
+                "action_kind": "run_holdout_eval",
+                "text": AUTO_RESEARCH_HOLDOUT_SUCCESSOR_TEXT,
+            }
+        ],
     },
+}
+
+AUTO_RESEARCH_ACTION_ROLE_IDS = {
+    "write_research_contract": "research_curator",
+    "propose_hypothesis": "hypothesis_mapper",
+    "run_dev_eval": "evidence_runner",
+    "run_holdout_eval": "evidence_runner",
+    "write_evidence": "evidence_runner",
+    "classify_evidence": "evidence_verifier",
+    "summarize_evidence": "evidence_verifier",
+    "write_evaluation_summary": "evidence_verifier",
 }
 
 AUTO_RESEARCH_SEED_TITLES = {
@@ -176,6 +215,22 @@ def auto_research_role_profile(*, role_id: str, goal_id: str, agent_id: str) -> 
         ],
         **base,
     }
+
+
+def auto_research_role_id_for_action(action: str) -> str:
+    return AUTO_RESEARCH_ACTION_ROLE_IDS.get(action, "")
+
+
+def auto_research_successor_specs_for_action(*, role_id: str, action: str) -> list[dict[str, object]]:
+    profile = AUTO_RESEARCH_ROLE_PROFILES.get(role_id) or {}
+    specs = profile.get("successor_todos") if isinstance(profile, dict) else []
+    if not isinstance(specs, list):
+        return []
+    return [
+        dict(spec)
+        for spec in specs
+        if isinstance(spec, dict) and str(spec.get("after_action") or "") == action
+    ]
 
 
 def auto_research_worker_turn_command(*, goal_id: str, agent_id: str, objective: str) -> str:

--- a/loopx/capabilities/auto_research/worker_runtime.py
+++ b/loopx/capabilities/auto_research/worker_runtime.py
@@ -25,6 +25,10 @@ from .live_evidence import (
     LIVE_CODEX_E2E_DEFAULT_OUTPUT,
     build_live_codex_e2e_evidence_from_packet,
 )
+from .preset import (
+    auto_research_role_id_for_action,
+    auto_research_successor_specs_for_action,
+)
 from .research_state import (
     build_live_auto_research_projection,
     build_research_decision_candidates,
@@ -53,10 +57,6 @@ SUPPORTED_WORKER_ACTIONS = {
     "write_evaluation_summary",
 }
 DEFAULT_EVIDENCE_RUNNER_AGENT_ID = "codex-main-control"
-HOLDOUT_FOLLOWUP_TEXT = (
-    "[P0-auto-research-live] Run held-out validation for the dev-supported "
-    "hypothesis, append public-safe evidence, and summarize promotion readiness."
-)
 GENERIC_VERIFIER_HANDOFF_KEYWORDS = (
     "verify",
     "verifier",
@@ -350,108 +350,151 @@ def _select_holdout_candidate(graph: dict[str, object]) -> dict[str, object]:
     )[0]
 
 
-def _evidence_runner_agent_id(*, registry_path: Path, goal_id: str, current_agent_id: str) -> str:
+def _successor_condition_met(condition: str, *, decision_summary: dict[str, object]) -> tuple[bool, str]:
+    if condition == "always":
+        return True, "always"
+    if condition == "dev_supported_without_holdout":
+        dev_candidate_count = int(decision_summary.get("dev_promotion_candidate_count") or 0)
+        validated_candidate_count = int(
+            decision_summary.get("validated_promotion_candidate_count") or 0
+        )
+        if not dev_candidate_count:
+            return False, "no_dev_promotion_candidate"
+        if validated_candidate_count:
+            return False, "holdout_already_validated"
+        return True, condition
+    return False, f"unsupported_successor_condition:{condition or 'missing'}"
+
+
+def _resolve_successor_target_agent(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    current_agent_id: str,
+    spec: dict[str, object],
+) -> str:
     registered = registered_agent_ids_from_registry(registry_path, goal_id)
-    if DEFAULT_EVIDENCE_RUNNER_AGENT_ID in registered:
-        return DEFAULT_EVIDENCE_RUNNER_AGENT_ID
+    target = str(spec.get("target_agent_id") or "").strip()
+    if target == "$current_agent":
+        return current_agent_id
+    if target and target in registered:
+        return target
+    if target:
+        raise ValueError(f"successor target_agent_id {target!r} is not registered for goal {goal_id!r}")
+    target_role_id = str(spec.get("target_role_id") or "").strip()
+    if target_role_id:
+        raise ValueError(
+            f"successor target_role_id {target_role_id!r} requires an explicit registered target_agent_id"
+        )
     for agent_id in registered:
         if agent_id != current_agent_id:
             return agent_id
     return current_agent_id
 
 
-def _maybe_add_holdout_followup_todo(
+def _maybe_add_role_successor_todos(
     *,
     registry_path: Path,
     goal_id: str,
     source_todo_id: str,
     agent_id: str,
+    role_id: str,
+    action: str,
     decision_summary: dict[str, object],
     execute: bool,
 ) -> dict[str, object]:
-    dev_candidate_count = int(decision_summary.get("dev_promotion_candidate_count") or 0)
-    validated_candidate_count = int(decision_summary.get("validated_promotion_candidate_count") or 0)
-    if not dev_candidate_count:
-        return {"needed": False, "reason": "no_dev_promotion_candidate"}
-    if validated_candidate_count:
-        return {"needed": False, "reason": "holdout_already_validated"}
-
-    claimed_by = _evidence_runner_agent_id(
-        registry_path=registry_path,
-        goal_id=goal_id,
-        current_agent_id=agent_id,
-    )
-    if not execute:
+    specs = auto_research_successor_specs_for_action(role_id=role_id, action=action)
+    if not specs:
         return {
-            "needed": True,
-            "executed": False,
-            "action_kind": "run_holdout_eval",
-            "claimed_by": claimed_by,
-            "unblocks_todo_id": source_todo_id,
+            "schema_version": "auto_research_role_successor_todos_v0",
+            "source": "role_profile_successor_todos",
+            "needed": False,
+            "reason": "no_role_successor_spec",
+            "role_id": role_id,
+            "action": action,
+            "successors": [],
         }
 
-    result = add_goal_todo(
-        registry_path=registry_path,
-        goal_id=goal_id,
-        role="agent",
-        text=HOLDOUT_FOLLOWUP_TEXT,
-        task_class="advancement_task",
-        action_kind="run_holdout_eval",
-        claimed_by=claimed_by,
-        unblocks_todo_id=source_todo_id,
-        dry_run=False,
-    )
+    successors: list[dict[str, object]] = []
+    skipped: list[dict[str, object]] = []
+    for index, spec in enumerate(specs):
+        condition = str(spec.get("when") or "always")
+        condition_met, reason = _successor_condition_met(
+            condition,
+            decision_summary=decision_summary,
+        )
+        action_kind = str(spec.get("action_kind") or "advance_todo")
+        claimed_by = _resolve_successor_target_agent(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            current_agent_id=agent_id,
+            spec=spec,
+        )
+        successor_preview = {
+            "index": index,
+            "needed": condition_met,
+            "executed": False,
+            "condition": condition,
+            "reason": reason,
+            "target_agent_id": claimed_by,
+            "target_role_id": spec.get("target_role_id"),
+            "action_kind": action_kind,
+            "task_class": spec.get("task_class") or "advancement_task",
+            "unblocks_todo_id": source_todo_id,
+            "source": "role_profile_successor_todos",
+        }
+        if not condition_met:
+            skipped.append(successor_preview)
+            continue
+        if not execute:
+            successors.append(successor_preview)
+            continue
+        result = add_goal_todo(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            role="agent",
+            text=str(spec.get("text") or f"Run {action_kind}."),
+            task_class=str(spec.get("task_class") or "advancement_task"),
+            action_kind=action_kind,
+            claimed_by=claimed_by,
+            unblocks_todo_id=source_todo_id,
+            dry_run=False,
+        )
+        successors.append(
+            successor_preview
+            | {
+                "executed": True,
+                "added": bool(result.get("added")),
+                "already_exists": bool(result.get("already_exists")),
+                "metadata_updated": bool(result.get("metadata_updated")),
+                "todo_id": result.get("todo_id"),
+                "claimed_by": result.get("claimed_by") or claimed_by,
+                "action_kind": result.get("action_kind") or action_kind,
+                "unblocks_todo_id": result.get("unblocks_todo_id") or source_todo_id,
+            }
+        )
     return {
-        "needed": True,
-        "executed": True,
-        "added": bool(result.get("added")),
-        "already_exists": bool(result.get("already_exists")),
-        "metadata_updated": bool(result.get("metadata_updated")),
-        "todo_id": result.get("todo_id"),
-        "action_kind": result.get("action_kind") or "run_holdout_eval",
-        "claimed_by": result.get("claimed_by") or claimed_by,
-        "unblocks_todo_id": result.get("unblocks_todo_id") or source_todo_id,
+        "schema_version": "auto_research_role_successor_todos_v0",
+        "source": "role_profile_successor_todos",
+        "needed": bool(successors),
+        "executed": bool(execute and successors),
+        "role_id": role_id,
+        "action": action,
+        "successors": successors,
+        "skipped": skipped,
+        "reason": None if successors else (skipped[0]["reason"] if skipped else "no_role_successor_spec"),
     }
 
 
-def _project_holdout_followup_after_dev_evidence(
-    *,
-    registry_path: Path,
-    runtime_root_arg: str | None,
-    output_path: Path,
-    goal_id: str,
-    todo_id: str,
-    agent_id: str,
-    execute: bool,
-) -> dict[str, object]:
-    """Project a dev-supported candidate into ordinary LoopX todo/frontier state."""
-
-    artifact = _write_evaluation_summary_artifact(
-        registry_path=registry_path,
-        runtime_root_arg=runtime_root_arg,
-        output_path=output_path,
-        goal_id=goal_id,
-        todo_id=todo_id,
-        agent_id=agent_id,
-    )
-    followup = _maybe_add_holdout_followup_todo(
-        registry_path=registry_path,
-        goal_id=goal_id,
-        source_todo_id=todo_id,
-        agent_id=agent_id,
-        decision_summary=artifact["decision_summary"],
-        execute=execute,
-    )
+def _legacy_followup_from_successor_todos(successor_todos: dict[str, object]) -> dict[str, object]:
+    successors = successor_todos.get("successors") if isinstance(successor_todos, dict) else []
+    if isinstance(successors, list) and successors:
+        first = dict(successors[0])
+        first["needed"] = True
+        return first
     return {
-        "schema_version": "auto_research_continuation_projection_v0",
-        "source": "loopx_state_todo_frontier",
-        "candidate_kind": "holdout_validation",
-        "decision_summary": artifact["decision_summary"],
-        "followup": followup,
-        "artifact": _artifact_summary(
-            "evaluation_summary",
-            filename="evaluation-summary.public.json",
-        ),
+        "needed": False,
+        "reason": successor_todos.get("reason") if isinstance(successor_todos, dict) else "no_successor",
     }
 
 
@@ -830,14 +873,18 @@ def run_auto_research_worker_turn(
             todo_id=todo_id,
             agent_id=agent_id,
         )
-        followup = _maybe_add_holdout_followup_todo(
+        role_id = auto_research_role_id_for_action(action)
+        successor_todos = _maybe_add_role_successor_todos(
             registry_path=registry_path,
             goal_id=goal_id,
             source_todo_id=todo_id,
             agent_id=agent_id,
+            role_id=role_id,
+            action=action,
             decision_summary=artifact["decision_summary"],
             execute=True,
         )
+        followup = _legacy_followup_from_successor_todos(successor_todos)
         completion = (
             _complete_selected_todo(
                 registry_path=registry_path,
@@ -864,6 +911,8 @@ def run_auto_research_worker_turn(
             "artifact_status": artifact["summary"]["status"],
             "claim_allowed": artifact["summary"]["claim_allowed"],
             "promotion_decision_made": artifact["summary"]["promotion_decision_made"],
+            "role_id": role_id,
+            "successor_todos": successor_todos,
             "followup": followup,
             "completion": completion,
             "frontier": frontier_packet,
@@ -1034,15 +1083,26 @@ def run_auto_research_worker_turn(
     _write_json(evidence_packet_path, packet)
     append_result = append_evidence(str(evidence_packet_path))
     _write_json(append_result_path, append_result)
-    continuation = _project_holdout_followup_after_dev_evidence(
+    summary_artifact = _write_evaluation_summary_artifact(
         registry_path=registry_path,
         runtime_root_arg=runtime_root_arg,
         output_path=evaluation_summary_path,
         goal_id=goal_id,
         todo_id=todo_id,
         agent_id=agent_id,
+    )
+    role_id = auto_research_role_id_for_action(action)
+    successor_todos = _maybe_add_role_successor_todos(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        source_todo_id=todo_id,
+        agent_id=agent_id,
+        role_id=role_id,
+        action=action,
+        decision_summary=summary_artifact["decision_summary"],
         execute=True,
     )
+    followup = _legacy_followup_from_successor_todos(successor_todos)
 
     live_evidence: dict[str, object] | None = None
     if visible_lanes_accepted:
@@ -1093,13 +1153,22 @@ def run_auto_research_worker_turn(
             "appended_count": append_result.get("appended_count"),
             "counts_by_kind": append_result.get("counts_by_kind"),
         },
+        "evaluation_summary": {
+            "claim_allowed": summary_artifact["summary"]["claim_allowed"],
+            "best_dev_metric": summary_artifact["evidence_graph_summary"]["best_dev_metric"],
+            "best_holdout_metric": summary_artifact["evidence_graph_summary"]["best_holdout_metric"],
+            "validated_promotion_candidate_count": summary_artifact["decision_summary"][
+                "validated_promotion_candidate_count"
+            ],
+        },
         "live_evidence": {
             "written": live_evidence is not None,
             "evidence_source": live_evidence.get("source") if live_evidence else None,
             "dev_metric": live_lane_evidence.get("dev_metric"),
         },
-        "continuation_projection": continuation,
-        "followup": continuation["followup"],
+        "role_id": role_id,
+        "successor_todos": successor_todos,
+        "followup": followup,
         "artifacts": {
             "paths_are_local_only": True,
             "evidence_packet": "evidence.public.json",

--- a/loopx/capabilities/auto_research/worker_skill/SKILL.md
+++ b/loopx/capabilities/auto_research/worker_skill/SKILL.md
@@ -47,6 +47,12 @@ If the launcher exported `LOOPX_ROLE_ID`, `LOOPX_ROLE_PROFILE_REF`,
 `LOOPX_ROLE_PHASE`, or a profile JSON path, compare those values with the quota
 and frontier packets. Stop when they disagree. Do not guess the intended role.
 
+If the role profile includes `successor_todos`, treat those declarations as the
+only role-local way to create the next agent todo. The worker-turn/tick may
+write the declared LoopX todo after a successful action and condition check.
+Do not invent an extra continuation plan in prose, and do not ask a leader pane
+to pick the next role.
+
 For a visible demo rehearsal, inspect the dry-run supervisor before execution:
 
 ```bash
@@ -158,7 +164,9 @@ Allowed actions:
 - claim the current frontier item selected for this agent;
 - edit only allowed solution or experiment scope;
 - run dev or holdout evaluation only when the contract permits it;
-- build an `auto_research_evidence_packet_v0` or equivalent public-safe event.
+- build an `auto_research_evidence_packet_v0` or equivalent public-safe event;
+- create only the role-declared successor todo, such as a holdout validation
+  todo, when the profile's `successor_todos` condition is satisfied.
 
 Useful command after a protected eval result exists:
 
@@ -221,7 +229,9 @@ Allowed actions:
   evidence;
 - request retry with a bounded reason and resumable ref;
 - create promotion, retirement, or gate candidates;
-- write compact validation notes for the next worker.
+- write compact validation notes for the next worker;
+- add only the role-declared successor todo when evidence needs another bounded
+  split.
 
 Verification checklist:
 


### PR DESCRIPTION
## Summary
- Move auto-research next-round work from runtime-specific continuation projection into role profile `successor_todos` declarations.
- Let worker-turn apply those role-local successor rules by writing normal LoopX todos with `claimed_by`, `action_kind`, and `unblocks_todo_id`.
- Fail closed when a role-declared `target_agent_id` is not registered; no fallback rerouting.

## Why
This keeps the three layers thin in the intended places:
- user layer: one open question / one-click start
- auto-research preset: role semantics and successor handoff hints
- generic kernel / LoopX state: real panes, tick, todo/frontier/evidence protocol

## Validation
- `python3 -m py_compile loopx/capabilities/auto_research/preset.py loopx/capabilities/auto_research/worker_runtime.py examples/auto-research-worker-turn-smoke.py examples/auto-research-demo-supervisor-smoke.py`
- `python3 examples/auto-research-demo-supervisor-smoke.py`
- `python3 examples/auto-research-worker-turn-smoke.py`
- `python3 examples/auto-research-demo-e2e-worker-loop-smoke.py`
- `python3 examples/auto-research-layered-e2e-acceptance-smoke.py`
- `python3 examples/auto-research-user-contract-entry-smoke.py`
- `python3 examples/auto-research-skill-contract-smoke.py`
- `python3 examples/decentralized-auto-research-protocol-smoke.py`
- `python3 examples/docs-governance-smoke.py`
- `python3 examples/generic-multi-agent-one-command-smoke.py`
- `python3 examples/visible-multi-agent-launcher-smoke.py`
- `python3 examples/multi-agent-product-recipe-smoke.py`
- `git diff --check origin/main...HEAD`
- public/private boundary scan on changed paths: clean
