### PR TITLE
Make auto-research successor todos skill-driven

### DIFF
--- a/examples/auto-research-worker-turn-smoke.py
+++ b/examples/auto-research-worker-turn-smoke.py
@@ -277,14 +277,20 @@ def main() -> int:
         assert executed["live_evidence"]["written"] is True, executed
         assert executed["live_evidence"]["evidence_source"] == "live_codex_lane_output", executed
         assert executed["live_evidence"]["dev_metric"] == 4.0, executed
-        assert executed["successor_todos"]["source"] == "role_profile_successor_todos", executed
+        assert executed["successor_todos"]["source"] == "role_profile_todo_command_template", executed
         assert executed["successor_todos"]["role_id"] == "evidence_runner", executed
         assert executed["successor_todos"]["action"] == "run_dev_eval", executed
-        assert executed["successor_todos"]["successors"][0]["target_role_id"] == "evidence_runner", executed
+        successor = executed["successor_todos"]["successors"][0]
+        assert successor["target_role_id"] == "evidence_runner", executed
+        assert successor["condition"]["all"][0]["path"] == (
+            "decision_summary.dev_promotion_candidate_count"
+        ), executed
+        assert successor["todo_command"].startswith("loopx todo add "), executed
+        assert "--claimed-by codex-main-control" in successor["todo_command"], executed
         assert executed["followup"]["needed"] is True, executed
         assert executed["followup"]["action_kind"] == "run_holdout_eval", executed
         assert executed["followup"]["claimed_by"] == EVIDENCE_AGENT_ID, executed
-        assert executed["followup"]["source"] == "role_profile_successor_todos", executed
+        assert executed["followup"]["source"] == "role_profile_todo_command_template", executed
         assert executed["frontier"]["frontier"]["selected"]["claimed_by"] == EVIDENCE_AGENT_ID, executed
         assert payload["visible_launch"]["launch_result"]["worker_turn_executed"] is True, payload
         assert payload["visible_launch"]["launch_result"]["worker_turn_count"] == 3, payload

--- a/loopx/capabilities/auto_research/preset.py
+++ b/loopx/capabilities/auto_research/preset.py
@@ -18,6 +18,28 @@ AUTO_RESEARCH_HOLDOUT_SUCCESSOR_TEXT = (
     "[P0-auto-research-live] Run held-out validation for the dev-supported "
     "hypothesis, append public-safe evidence, and summarize promotion readiness."
 )
+AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION = {
+    "all": [
+        {
+            "path": "decision_summary.dev_promotion_candidate_count",
+            "op": "gt",
+            "value": 0,
+            "fail_reason": "no_dev_promotion_candidate",
+        },
+        {
+            "path": "decision_summary.validated_promotion_candidate_count",
+            "op": "eq",
+            "value": 0,
+            "fail_reason": "holdout_already_validated",
+        },
+    ]
+}
+AUTO_RESEARCH_SUCCESSOR_TODO_COMMAND_TEMPLATE = (
+    "loopx todo add --goal-id {goal_id_shell} --role agent "
+    "--text {text_shell} --task-class {task_class_shell} "
+    "--action-kind {action_kind_shell} --claimed-by {target_agent_id_shell} "
+    "--unblocks-todo-id {source_todo_id_shell}"
+)
 
 AUTO_RESEARCH_DEFAULT_LANES = (
     (
@@ -89,12 +111,13 @@ AUTO_RESEARCH_ROLE_PROFILES: dict[str, dict[str, object]] = {
         "successor_todos": [
             {
                 "after_action": "run_dev_eval",
-                "when": "dev_supported_without_holdout",
+                "condition": AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION,
                 "target_agent_id": "codex-main-control",
                 "target_role_id": "evidence_runner",
                 "task_class": "advancement_task",
                 "action_kind": "run_holdout_eval",
                 "text": AUTO_RESEARCH_HOLDOUT_SUCCESSOR_TEXT,
+                "todo_command_template": AUTO_RESEARCH_SUCCESSOR_TODO_COMMAND_TEMPLATE,
             }
         ],
     },
@@ -106,12 +129,13 @@ AUTO_RESEARCH_ROLE_PROFILES: dict[str, dict[str, object]] = {
         "successor_todos": [
             {
                 "after_action": "summarize_evidence",
-                "when": "dev_supported_without_holdout",
+                "condition": AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION,
                 "target_agent_id": "codex-main-control",
                 "target_role_id": "evidence_runner",
                 "task_class": "advancement_task",
                 "action_kind": "run_holdout_eval",
                 "text": AUTO_RESEARCH_HOLDOUT_SUCCESSOR_TEXT,
+                "todo_command_template": AUTO_RESEARCH_SUCCESSOR_TODO_COMMAND_TEMPLATE,
             }
         ],
     },

--- a/loopx/capabilities/auto_research/worker_runtime.py
+++ b/loopx/capabilities/auto_research/worker_runtime.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import re
+import shlex
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -56,7 +57,6 @@ SUPPORTED_WORKER_ACTIONS = {
     "summarize_evidence",
     "write_evaluation_summary",
 }
-DEFAULT_EVIDENCE_RUNNER_AGENT_ID = "codex-main-control"
 GENERIC_VERIFIER_HANDOFF_KEYWORDS = (
     "verify",
     "verifier",
@@ -350,20 +350,72 @@ def _select_holdout_candidate(graph: dict[str, object]) -> dict[str, object]:
     )[0]
 
 
-def _successor_condition_met(condition: str, *, decision_summary: dict[str, object]) -> tuple[bool, str]:
+def _value_at_path(payload: dict[str, object], path: str) -> object:
+    current: object = payload
+    for part in [part for part in path.split(".") if part]:
+        if not isinstance(current, dict) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def _compare_condition_value(actual: object, *, op: str, expected: object) -> bool:
+    if op in {"truthy", "exists"}:
+        return bool(actual)
+    if op in {"falsy", "missing"}:
+        return not bool(actual)
+    if op in {"eq", "=="}:
+        return actual == expected
+    if op in {"ne", "!="}:
+        return actual != expected
+    if op in {"gt", "gte", "lt", "lte", ">", ">=", "<", "<="}:
+        try:
+            actual_number = float(actual)  # type: ignore[arg-type]
+            expected_number = float(expected)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return False
+        return {
+            "gt": actual_number > expected_number,
+            ">": actual_number > expected_number,
+            "gte": actual_number >= expected_number,
+            ">=": actual_number >= expected_number,
+            "lt": actual_number < expected_number,
+            "<": actual_number < expected_number,
+            "lte": actual_number <= expected_number,
+            "<=": actual_number <= expected_number,
+        }[op]
+    return False
+
+
+def _successor_condition_met(
+    condition: object,
+    *,
+    decision_summary: dict[str, object],
+) -> tuple[bool, str]:
+    if not condition:
+        return True, "always"
     if condition == "always":
         return True, "always"
-    if condition == "dev_supported_without_holdout":
-        dev_candidate_count = int(decision_summary.get("dev_promotion_candidate_count") or 0)
-        validated_candidate_count = int(
-            decision_summary.get("validated_promotion_candidate_count") or 0
-        )
-        if not dev_candidate_count:
-            return False, "no_dev_promotion_candidate"
-        if validated_candidate_count:
-            return False, "holdout_already_validated"
-        return True, condition
-    return False, f"unsupported_successor_condition:{condition or 'missing'}"
+    if not isinstance(condition, dict):
+        return False, "unsupported_successor_condition_shape"
+
+    context: dict[str, object] = {"decision_summary": decision_summary}
+    predicates = condition.get("all")
+    if not isinstance(predicates, list):
+        return False, "unsupported_successor_condition_shape"
+    if not predicates:
+        return True, "all"
+
+    for raw_predicate in predicates:
+        if not isinstance(raw_predicate, dict):
+            return False, "unsupported_successor_predicate_shape"
+        path = str(raw_predicate.get("path") or "")
+        op = str(raw_predicate.get("op") or "truthy")
+        expected = raw_predicate.get("value")
+        actual = _value_at_path(context, path)
+        if not _compare_condition_value(actual, op=op, expected=expected):
+            return False, str(raw_predicate.get("fail_reason") or f"condition_failed:{path}")
+    return True, "condition_met"
 
 
 def _resolve_successor_target_agent(
@@ -392,6 +444,42 @@ def _resolve_successor_target_agent(
     return current_agent_id
 
 
+class _SafeFormatDict(dict[str, object]):
+    def __missing__(self, key: str) -> str:
+        return "{" + key + "}"
+
+
+def _render_successor_command_template(
+    *,
+    template: object,
+    goal_id: str,
+    source_todo_id: str,
+    target_agent_id: str,
+    task_class: str,
+    action_kind: str,
+    text: str,
+) -> str | None:
+    if not template:
+        return None
+    if not isinstance(template, str):
+        raise ValueError("successor todo_command_template must be a string")
+    values: dict[str, object] = {
+        "goal_id": goal_id,
+        "goal_id_shell": shlex.quote(goal_id),
+        "source_todo_id": source_todo_id,
+        "source_todo_id_shell": shlex.quote(source_todo_id),
+        "target_agent_id": target_agent_id,
+        "target_agent_id_shell": shlex.quote(target_agent_id),
+        "task_class": task_class,
+        "task_class_shell": shlex.quote(task_class),
+        "action_kind": action_kind,
+        "action_kind_shell": shlex.quote(action_kind),
+        "text": text,
+        "text_shell": shlex.quote(text),
+    }
+    return template.format_map(_SafeFormatDict(values))
+
+
 def _maybe_add_role_successor_todos(
     *,
     registry_path: Path,
@@ -407,7 +495,7 @@ def _maybe_add_role_successor_todos(
     if not specs:
         return {
             "schema_version": "auto_research_role_successor_todos_v0",
-            "source": "role_profile_successor_todos",
+            "source": "role_profile_todo_command_template",
             "needed": False,
             "reason": "no_role_successor_spec",
             "role_id": role_id,
@@ -418,17 +506,28 @@ def _maybe_add_role_successor_todos(
     successors: list[dict[str, object]] = []
     skipped: list[dict[str, object]] = []
     for index, spec in enumerate(specs):
-        condition = str(spec.get("when") or "always")
+        condition = spec.get("condition") or spec.get("when") or "always"
         condition_met, reason = _successor_condition_met(
             condition,
             decision_summary=decision_summary,
         )
         action_kind = str(spec.get("action_kind") or "advance_todo")
+        task_class = str(spec.get("task_class") or "advancement_task")
+        text = str(spec.get("text") or f"Run {action_kind}.")
         claimed_by = _resolve_successor_target_agent(
             registry_path=registry_path,
             goal_id=goal_id,
             current_agent_id=agent_id,
             spec=spec,
+        )
+        todo_command = _render_successor_command_template(
+            template=spec.get("todo_command_template"),
+            goal_id=goal_id,
+            source_todo_id=source_todo_id,
+            target_agent_id=claimed_by,
+            task_class=task_class,
+            action_kind=action_kind,
+            text=text,
         )
         successor_preview = {
             "index": index,
@@ -439,9 +538,10 @@ def _maybe_add_role_successor_todos(
             "target_agent_id": claimed_by,
             "target_role_id": spec.get("target_role_id"),
             "action_kind": action_kind,
-            "task_class": spec.get("task_class") or "advancement_task",
+            "task_class": task_class,
             "unblocks_todo_id": source_todo_id,
-            "source": "role_profile_successor_todos",
+            "todo_command": todo_command,
+            "source": "role_profile_todo_command_template",
         }
         if not condition_met:
             skipped.append(successor_preview)
@@ -453,8 +553,8 @@ def _maybe_add_role_successor_todos(
             registry_path=registry_path,
             goal_id=goal_id,
             role="agent",
-            text=str(spec.get("text") or f"Run {action_kind}."),
-            task_class=str(spec.get("task_class") or "advancement_task"),
+            text=text,
+            task_class=task_class,
             action_kind=action_kind,
             claimed_by=claimed_by,
             unblocks_todo_id=source_todo_id,
@@ -475,7 +575,7 @@ def _maybe_add_role_successor_todos(
         )
     return {
         "schema_version": "auto_research_role_successor_todos_v0",
-        "source": "role_profile_successor_todos",
+        "source": "role_profile_todo_command_template",
         "needed": bool(successors),
         "executed": bool(execute and successors),
         "role_id": role_id,

--- a/loopx/capabilities/auto_research/worker_skill/SKILL.md
+++ b/loopx/capabilities/auto_research/worker_skill/SKILL.md
@@ -48,10 +48,12 @@ If the launcher exported `LOOPX_ROLE_ID`, `LOOPX_ROLE_PROFILE_REF`,
 and frontier packets. Stop when they disagree. Do not guess the intended role.
 
 If the role profile includes `successor_todos`, treat those declarations as the
-only role-local way to create the next agent todo. The worker-turn/tick may
-write the declared LoopX todo after a successful action and condition check.
-Do not invent an extra continuation plan in prose, and do not ask a leader pane
-to pick the next role.
+only role-local way to create the next agent todo. A successor declaration must
+name the target agent and include a `todo_command_template` such as
+`loopx todo add ... --claimed-by {target_agent_id_shell}`. The worker-turn/tick
+may render and run that declared command after a successful action and generic
+condition check. Do not invent an extra continuation plan in prose, and do not
+ask a leader pane to pick the next role.
 
 For a visible demo rehearsal, inspect the dry-run supervisor before execution:
 
@@ -166,7 +168,21 @@ Allowed actions:
 - run dev or holdout evaluation only when the contract permits it;
 - build an `auto_research_evidence_packet_v0` or equivalent public-safe event;
 - create only the role-declared successor todo, such as a holdout validation
-  todo, when the profile's `successor_todos` condition is satisfied.
+  todo, when the profile's `successor_todos.condition` is satisfied.
+
+Successor todo command example:
+
+```bash
+loopx todo add --goal-id "$LOOPX_GOAL_ID" --role agent \
+  --text "$LOOPX_SUCCESSOR_TODO_TEXT" \
+  --task-class advancement_task \
+  --action-kind run_holdout_eval \
+  --claimed-by codex-main-control \
+  --unblocks-todo-id "$LOOPX_SELECTED_TODO_ID"
+```
+
+This skill owns the role-local routing intent; the kernel only validates the
+target agent and executes the normal LoopX todo writer.
 
 Useful command after a protected eval result exists:
 
@@ -231,7 +247,7 @@ Allowed actions:
 - create promotion, retirement, or gate candidates;
 - write compact validation notes for the next worker;
 - add only the role-declared successor todo when evidence needs another bounded
-  split.
+  split, using the profile's `todo_command_template`.
 
 Verification checklist:
 


### PR DESCRIPTION
## Summary
- Move auto-research successor routing from a runtime-specific semantic condition into role profile condition predicates plus todo command templates.
- Keep the worker runtime generic: validate target agent, evaluate simple profile predicates, render the declared LoopX todo command, then use the normal todo writer.
- Update the worker skill and smoke coverage so role-local successor handoff remains explicit and fail-closed.

## Validation
- python3 -m py_compile loopx/capabilities/auto_research/preset.py loopx/capabilities/auto_research/worker_runtime.py examples/auto-research-worker-turn-smoke.py
- python3 examples/auto-research-worker-turn-smoke.py
- python3 examples/auto-research-user-contract-entry-smoke.py
- python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- python3 examples/auto-research-layered-e2e-acceptance-smoke.py
- python3 examples/decentralized-auto-research-protocol-smoke.py
- python3 examples/generic-multi-agent-one-command-smoke.py
- python3 examples/auto-research-skill-contract-smoke.py
- python3 examples/visible-multi-agent-launcher-smoke.py
- git diff --check

## Boundary
Changed files are limited to auto-research preset/runtime/worker skill and one smoke. Public/private scan found no credentials, private paths, raw logs, or local evidence artifacts.