### PR TITLE
Continue auto-research after holdout evidence

### DIFF
--- a/examples/auto-research-knn-continuation-smoke.py
+++ b/examples/auto-research-knn-continuation-smoke.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Smoke-test KNN-style auto-research continuation through role-declared todos."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+
+from loopx.capabilities.auto_research.demo_e2e import run_auto_research_demo_e2e  # noqa: E402
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        registry = temp / "registry.global.json"
+        runtime_root = temp / "runtime"
+        registry.write_text(
+            json.dumps({"common_runtime_root": str(runtime_root), "goals": []}),
+            encoding="utf-8",
+        )
+
+        payload = run_auto_research_demo_e2e(
+            agent_id="auto-research-operator",
+            goal_id="loopx-auto-research-demo-knn-continuation-smoke",
+            tracking_goal_id=None,
+            objective=(
+                "Can a simple KNN baseline improve through multi-agent auto research "
+                "without leaking holdout claims?"
+            ),
+            output_dir="auto_research_lightweight_kernel",
+            execute=True,
+            run_worker_loop=True,
+            worker_loop_rounds=4,
+            launch_visible=False,
+            keep_workspace=False,
+            registry_path=registry,
+            runtime_root_arg=str(runtime_root),
+            session_name="loopx-ar-knn-continuation-smoke",
+            cli_bin="loopx",
+            codex_bin="codex",
+            tmux_bin="tmux",
+            reasoning_effort="high",
+            live_evidence_path=None,
+            append_evidence=lambda _packet: {},
+        )
+
+    worker_loop = payload["worker_loop"]
+    actions = worker_loop["selected_actions"]
+    assert "run_dev_eval" in actions, actions
+    assert "run_holdout_eval" in actions, actions
+    assert "write_evaluation_summary" in actions, actions
+    assert worker_loop["executed_turn_count"] >= 6, worker_loop
+    holdout_turns = [
+        turn
+        for turn in worker_loop["turns"]
+        if turn.get("selected_action") == "run_holdout_eval"
+    ]
+    assert holdout_turns, worker_loop
+    assert holdout_turns[0]["holdout_metric"] == 4.5, holdout_turns
+    assert holdout_turns[0]["live_evidence_written"] is True, holdout_turns
+    assert payload["public_boundary"]["raw_logs_recorded"] is False, payload
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -616,6 +616,7 @@ def _discover_visible_live_evidence(
             ):
                 candidates.extend(artifact_root.glob(f"*/{artifact_name}"))
             candidates = sorted(set(candidates))
+        loaded: list[dict[str, object]] = []
         for candidate in candidates:
             try:
                 raw = json.loads(candidate.read_text(encoding="utf-8"))
@@ -627,13 +628,20 @@ def _discover_visible_live_evidence(
             if not lane_agent_id:
                 continue
             try:
-                return load_live_codex_e2e_evidence(
-                    evidence_path=str(candidate),
-                    goal_id=goal_id,
-                    agent_id=lane_agent_id,
+                loaded.append(
+                    load_live_codex_e2e_evidence(
+                        evidence_path=str(candidate),
+                        goal_id=goal_id,
+                        agent_id=lane_agent_id,
+                    )
                 )
             except ValueError:
                 continue
+        for evidence in loaded:
+            if evidence.get("holdout_metric") is not None:
+                return evidence
+        if loaded and time.monotonic() >= deadline:
+            return loaded[0]
         if time.monotonic() >= deadline:
             return None
         time.sleep(0.5)

--- a/loopx/capabilities/auto_research/preset.py
+++ b/loopx/capabilities/auto_research/preset.py
@@ -18,6 +18,10 @@ AUTO_RESEARCH_HOLDOUT_SUCCESSOR_TEXT = (
     "[P0-auto-research-live] Run held-out validation for the dev-supported "
     "hypothesis, append public-safe evidence, and summarize promotion readiness."
 )
+AUTO_RESEARCH_VALIDATED_SUMMARY_SUCCESSOR_TEXT = (
+    "[P0-auto-research-live] Summarize held-out validation, promotion readiness, "
+    "and the public claim boundary for the supported hypothesis."
+)
 AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION = {
     "all": [
         {
@@ -31,6 +35,16 @@ AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION = {
             "op": "eq",
             "value": 0,
             "fail_reason": "holdout_already_validated",
+        },
+    ]
+}
+AUTO_RESEARCH_VALIDATED_SUMMARY_SUCCESSOR_CONDITION = {
+    "all": [
+        {
+            "path": "decision_summary.validated_promotion_candidate_count",
+            "op": "gt",
+            "value": 0,
+            "fail_reason": "no_validated_promotion_candidate",
         },
     ]
 }
@@ -117,6 +131,16 @@ AUTO_RESEARCH_ROLE_PROFILES: dict[str, dict[str, object]] = {
                 "task_class": "advancement_task",
                 "action_kind": "run_holdout_eval",
                 "text": AUTO_RESEARCH_HOLDOUT_SUCCESSOR_TEXT,
+                "todo_command_template": AUTO_RESEARCH_SUCCESSOR_TODO_COMMAND_TEMPLATE,
+            },
+            {
+                "after_action": "run_holdout_eval",
+                "condition": AUTO_RESEARCH_VALIDATED_SUMMARY_SUCCESSOR_CONDITION,
+                "target_agent_id": "codex-value-explorer",
+                "target_role_id": "evidence_verifier",
+                "task_class": "advancement_task",
+                "action_kind": "write_evaluation_summary",
+                "text": AUTO_RESEARCH_VALIDATED_SUMMARY_SUCCESSOR_TEXT,
                 "todo_command_template": AUTO_RESEARCH_SUCCESSOR_TODO_COMMAND_TEMPLATE,
             }
         ],

--- a/loopx/capabilities/auto_research/worker_runtime.py
+++ b/loopx/capabilities/auto_research/worker_runtime.py
@@ -1099,6 +1099,33 @@ def run_auto_research_worker_turn(
             todo_id=todo_id,
             agent_id=agent_id,
         )
+        role_id = auto_research_role_id_for_action(action)
+        successor_todos = _maybe_add_role_successor_todos(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            source_todo_id=todo_id,
+            agent_id=agent_id,
+            role_id=role_id,
+            action=action,
+            decision_summary=summary_artifact["decision_summary"],
+            execute=True,
+        )
+        followup = _legacy_followup_from_successor_todos(successor_todos)
+        live_evidence: dict[str, object] | None = None
+        if visible_lanes_accepted:
+            live_evidence = build_live_codex_e2e_evidence_from_packet(
+                packet=packet,
+                append_result=append_result,
+                agent_id=agent_id,
+                lane_count=lane_count,
+                visible_lanes_accepted=True,
+            )
+            _write_json(live_evidence_path, live_evidence)
+        live_lane_evidence = (
+            live_evidence.get("lane_evidence")
+            if isinstance(live_evidence, dict) and isinstance(live_evidence.get("lane_evidence"), dict)
+            else {}
+        )
         completion = (
             _complete_selected_todo(
                 registry_path=registry_path,
@@ -1141,6 +1168,14 @@ def run_auto_research_worker_turn(
                     "validated_promotion_candidate_count"
                 ],
             },
+            "live_evidence": {
+                "written": live_evidence is not None,
+                "evidence_source": live_evidence.get("source") if live_evidence else None,
+                "holdout_metric": live_lane_evidence.get("holdout_metric"),
+            },
+            "role_id": role_id,
+            "successor_todos": successor_todos,
+            "followup": followup,
             "artifact": _artifact_summary("holdout_validation", filename="evaluation-summary.public.json"),
             "artifact_status": "holdout_evidence_appended",
             "completion": completion,

--- a/loopx/capabilities/auto_research/worker_skill/SKILL.md
+++ b/loopx/capabilities/auto_research/worker_skill/SKILL.md
@@ -154,7 +154,8 @@ Allowed actions:
 - run dev or holdout evaluation only when the contract permits it;
 - build an `auto_research_evidence_packet_v0` or equivalent public-safe event;
 - create only the role-declared successor todo, such as a holdout validation
-  todo, when the profile's `successor_todos.condition` is satisfied.
+  todo or post-holdout verifier summary todo, when the profile's
+  `successor_todos.condition` is satisfied.
 
 Successor routing belongs here, not in a central projector: the role profile
 must name the target agent and provide the `todo_command_template`, typically a


### PR DESCRIPTION
## Summary
- add a role-declared successor from holdout validation to verifier summary
- write live evidence for holdout turns and prefer holdout live evidence in visible readiness
- add a KNN continuation smoke proving dev -> holdout -> verifier summary via LoopX todo/frontier

## Validation
- python3 examples/auto-research-knn-continuation-smoke.py
- python3 examples/visible-multi-agent-launcher-smoke.py
- python3 -m compileall -q loopx/capabilities/auto_research
- PYTHONPATH=. python3 -m loopx.cli --format json auto-research start "Can a simple KNN baseline be improved through multi-agent auto research over multiple decentralized A2A rounds, while keeping user and preset layers minimal and avoiding holdout/public-claim leakage?" --execute --headless --demo-run-id knn-headless-continuation-20260703T2115 --worker-loop-rounds 4

## Notes
This keeps continuation routing in role profiles and normal LoopX todo writes; it does not add a central continuation projector or touch quota/scheduler.