### PR TITLE
Fix SkillsBench missing-score aggregate attribution

### DIFF
--- a/examples/skillsbench-current-ledger-aggregate-smoke.py
+++ b/examples/skillsbench-current-ledger-aggregate-smoke.py
@@ -41,6 +41,8 @@ def run_entry(
     failure_class: str,
     failure_scope: str,
     labels: list[str] | None = None,
+    score_failure_attribution: str | None = None,
+    failure_attribution_labels: list[str] | None = None,
     task_setup_preflight: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     entry: dict[str, Any] = {
@@ -57,6 +59,10 @@ def run_entry(
         "failure_scope": failure_scope,
         "failure_labels": labels or [],
     }
+    if score_failure_attribution is not None:
+        entry["score_failure_attribution"] = score_failure_attribution
+    if failure_attribution_labels is not None:
+        entry["failure_attribution_labels"] = failure_attribution_labels
     if task_setup_preflight is not None:
         entry["task_setup_preflight"] = task_setup_preflight
     if score is not None:
@@ -131,6 +137,48 @@ def make_ledger(path: Path) -> None:
             failure_scope="score_missing",
         ),
         run_entry(
+            run_id="verifier-infra-missing",
+            case_id="flink-query",
+            recorded_at="2026-07-02T01:42:00+08:00",
+            score=None,
+            score_status="missing",
+            failure_class="none",
+            failure_scope="score_missing",
+            score_failure_attribution="verifier_infrastructure_failure",
+        ),
+        run_entry(
+            run_id="task-source-preflight-missing",
+            case_id="canonical-task-source-preflight",
+            recorded_at="2026-07-02T01:44:00+08:00",
+            score=None,
+            score_status="missing",
+            failure_class="none",
+            failure_scope="score_missing",
+            score_failure_attribution="skillsbench_task_source_preflight_blocked",
+        ),
+        run_entry(
+            run_id="docker-compose-apt-missing",
+            case_id="pddl-tpp-planning",
+            recorded_at="2026-07-02T01:46:00+08:00",
+            score=None,
+            score_status="missing",
+            failure_class="none",
+            failure_scope="score_missing",
+            failure_attribution_labels=[
+                "skillsbench_docker_compose_apt_repository_failure",
+            ],
+        ),
+        run_entry(
+            run_id="reward-missing-attribution",
+            case_id="reward-artifact-missing",
+            recorded_at="2026-07-02T01:48:00+08:00",
+            score=None,
+            score_status="missing",
+            failure_class="none",
+            failure_scope="score_missing",
+            score_failure_attribution="verifier_reward_missing",
+        ),
+        run_entry(
             run_id="sanity-task-preflight",
             case_id="hello-world",
             recorded_at="2026-07-02T01:50:00+08:00",
@@ -166,17 +214,21 @@ def test_current_aggregate_prefers_countable_results() -> None:
                 "manufacturing-codebook-normalization",
                 "lab-unit-harmonization",
                 "fix-druid-loophole-cve",
+                "flink-query",
+                "canonical-task-source-preflight",
+                "pddl-tpp-planning",
+                "reward-artifact-missing",
                 "never-run-case",
             ],
         )
-        assert aggregate["canonical_covered"] == 4, aggregate
+        assert aggregate["canonical_covered"] == 8, aggregate
         assert aggregate["distribution"] == {
             "missing": 1,
             "official_zero": 2,
             "partial": 1,
             "pass": 0,
-            "setup_runner_infra": 1,
-            "verifier_no_reward": 0,
+            "setup_runner_infra": 4,
+            "verifier_no_reward": 1,
         }, aggregate
         assert (
             aggregate["case_best"]["latex-formula-extraction"]["run_id"]
@@ -186,6 +238,15 @@ def test_current_aggregate_prefers_countable_results() -> None:
             aggregate["case_best"]["manufacturing-codebook-normalization"]["run_id"]
             == "manufacturing-official-zero"
         ), aggregate["case_best"]["manufacturing-codebook-normalization"]
+        assert aggregate["case_best"]["flink-query"]["effective_failure_class"] == (
+            "verifier_infrastructure_failure"
+        )
+        assert aggregate["case_best"]["pddl-tpp-planning"]["effective_failure_class"] == (
+            "skillsbench_docker_compose_apt_repository_failure"
+        )
+        assert aggregate["case_best"]["reward-artifact-missing"]["bucket"] == (
+            "verifier_no_reward"
+        )
         assert "hello-world" not in aggregate["case_best"], aggregate["case_best"]
 
 
@@ -198,9 +259,10 @@ def test_current_aggregate_default_inference_excludes_sanity_sources() -> None:
             ledger,
             benchmark_id=BENCHMARK_ID,
         )
-        assert aggregate["canonical_total"] == 4, aggregate
-        assert aggregate["canonical_covered"] == 4, aggregate
-        assert aggregate["distribution"]["setup_runner_infra"] == 1, aggregate
+        assert aggregate["canonical_total"] == 8, aggregate
+        assert aggregate["canonical_covered"] == 8, aggregate
+        assert aggregate["distribution"]["setup_runner_infra"] == 4, aggregate
+        assert aggregate["distribution"]["verifier_no_reward"] == 1, aggregate
         assert "hello-world" not in aggregate["case_best"], aggregate["case_best"]
         assert "hello-world" not in aggregate["cases_by_bucket"]["setup_runner_infra"]
 

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -3046,6 +3046,38 @@ def _ledger_score_value(run: dict[str, Any]) -> float | None:
     return None
 
 
+def _current_aggregate_failure_label_list(run: dict[str, Any]) -> list[str]:
+    labels: list[str] = []
+    seen: set[str] = set()
+    for key in ("failure_labels", "failure_attribution_labels"):
+        for label in _compact_list(run.get(key), limit=16):
+            if label not in seen:
+                seen.add(label)
+                labels.append(label)
+    return labels
+
+
+def _current_aggregate_failure_labels(run: dict[str, Any]) -> set[str]:
+    return set(_current_aggregate_failure_label_list(run))
+
+
+def _current_aggregate_effective_failure_class(run: dict[str, Any]) -> str:
+    for key in (
+        "failure_class",
+        "score_failure_attribution",
+        "attempt_failure_class",
+        "attempt_failure_label",
+        "first_blocker",
+    ):
+        value = _compact_text(run.get(key), limit=120)
+        if value and value not in {"none", "None", "null"}:
+            return value
+    for label in _current_aggregate_failure_label_list(run):
+        if label and label not in {"none", "None", "null"}:
+            return label
+    return ""
+
+
 def _current_aggregate_bucket(run: dict[str, Any] | None) -> str:
     if not isinstance(run, dict):
         return "missing"
@@ -3056,8 +3088,8 @@ def _current_aggregate_bucket(run: dict[str, Any] | None) -> str:
         if score > 0.0:
             return "partial"
         return "official_zero"
-    labels = set(_compact_list(run.get("failure_labels"), limit=16))
-    failure_class = _compact_text(run.get("failure_class"), limit=120)
+    labels = _current_aggregate_failure_labels(run)
+    failure_class = _current_aggregate_effective_failure_class(run)
     failure_scope = _compact_text(run.get("failure_scope"), limit=120)
     score_status = _compact_text(run.get("score_status"), limit=120)
     if (
@@ -3072,8 +3104,17 @@ def _current_aggregate_bucket(run: dict[str, Any] | None) -> str:
         or failure_scope == "score_missing"
         or "infrastructure" in failure_class
         or "setup" in failure_class
+        or "preflight" in failure_class
+        or "compose" in failure_class
+        or "docker" in failure_class
         or "runner" in failure_class
-        or any("infra" in label or "setup" in label for label in labels)
+        or any(
+            "infra" in label
+            or "setup" in label
+            or "compose" in label
+            or "docker" in label
+            for label in labels
+        )
     ):
         return "setup_runner_infra"
     if score_status == "missing":
@@ -3128,6 +3169,8 @@ def _current_aggregate_run_summary(run: dict[str, Any] | None) -> dict[str, Any]
         "failure_class",
         "failure_scope",
         "failure_labels",
+        "score_failure_attribution",
+        "failure_attribution_labels",
         "attempt_lifecycle_phase",
         "attempt_failure_label",
         "attempt_failure_class",
@@ -3144,6 +3187,9 @@ def _current_aggregate_run_summary(run: dict[str, Any] | None) -> dict[str, Any]
     )
     summary = {key: run[key] for key in keys if key in run}
     summary["bucket"] = _current_aggregate_bucket(run)
+    effective_failure_class = _current_aggregate_effective_failure_class(run)
+    if effective_failure_class:
+        summary["effective_failure_class"] = effective_failure_class
     return summary
 
 
@@ -3157,7 +3203,7 @@ def _current_aggregate_case_is_noncanonical_sanity_source(case: dict[str, Any]) 
     for run in runs:
         if _ledger_score_value(run) is not None:
             return False
-        if _compact_text(run.get("failure_class"), limit=120) != (
+        if _current_aggregate_effective_failure_class(run) != (
             "skillsbench_task_source_preflight_blocked"
         ):
             return False


### PR DESCRIPTION
## Summary
- classify SkillsBench current-aggregate missing-score rows from score_failure_attribution and failure attribution labels when failure_class is unset or none
- expose effective_failure_class in case summaries so reports do not collapse actionable missing-score rows into none
- extend the current-ledger aggregate smoke for verifier infra, reward missing, task-source preflight, and docker-compose setup attribution fallbacks

## Validation
- python3 examples/skillsbench-current-ledger-aggregate-smoke.py
- python3 -m py_compile loopx/benchmark_ledger.py examples/skillsbench-current-ledger-aggregate-smoke.py
- git diff --check

## Boundary
- public-safe compact ledger fields only; no raw logs, task text, trajectories, credentials, local paths, or verifier output included
