### PR TITLE
Clarify auto-research attach takeover

### DIFF
--- a/docs/guides/auto-research-command-path.md
+++ b/docs/guides/auto-research-command-path.md
@@ -83,8 +83,8 @@ own LoopX state and tick when runnable work remains.
 
 The user still only supplies one open question; agent ids, pane-local tick
 commands, evidence schemas, and runner wiring stay inside the kernel. Pass
-`--no-wake-visible-after-launch --attach` only when you want to skip the default
-evidence-first wake and immediately enter the tmux session.
+`--attach` when you want to skip the default evidence-first wake and immediately
+enter the tmux session.
 By default, visible panes open in a stable user-owned workspace under
 `~/loopx-auto-research/<run>/visible-workspace` so the first screen does not
 land in a generated temp directory. Pass `--workspace` to choose a different
@@ -177,14 +177,14 @@ loopx --registry "$LOOPX_REGISTRY" \
 
 That command starts visible panes, wakes each pane with the fixed
 decentralized A2A prompt, and keeps the current shell available for the compact
-JSON result. To attach immediately instead, opt out of the default wake first:
+JSON result. To attach immediately instead, pass `--attach`; that means
+operator takeover first and skips the default evidence-first wake:
 
 ```bash
 loopx --registry "$LOOPX_REGISTRY" \
   --runtime-root "$LOOPX_RUNTIME_ROOT" \
   auto-research start "How should we evaluate autonomous research agents?" \
   --execute \
-  --no-wake-visible-after-launch \
   --attach
 ```
 

--- a/examples/auto-research-user-contract-entry-smoke.py
+++ b/examples/auto-research-user-contract-entry-smoke.py
@@ -84,6 +84,12 @@ def assert_contract(payload: dict[str, Any]) -> None:
     ), one_click_start
     assert one_click_start["command"].startswith("loopx auto-research start "), one_click_start
     assert one_click_start["command"].endswith(" --execute"), one_click_start
+    assert (
+        one_click_start["operator_takeover_command_template"]
+        == 'loopx auto-research start "<open question>" --execute --attach'
+    ), one_click_start
+    assert one_click_start["operator_takeover_command"].endswith(" --execute --attach")
+    assert "operator takeover first" in one_click_start["attach_semantics"], one_click_start
     assert one_click_start["preview_command"].startswith("loopx auto-research start "), one_click_start
     assert one_click_start["starts"] == "visible_codex_tui_lanes", one_click_start
     assert one_click_start["uses_generic_kernel"] is True, one_click_start
@@ -146,7 +152,7 @@ def assert_start_wake_contract() -> None:
     default_visible = Namespace(
         execute=True,
         headless=False,
-        wake_visible_after_launch=True,
+        wake_visible_after_launch=None,
         attach=False,
         no_attach=False,
     )
@@ -155,6 +161,38 @@ def assert_start_wake_contract() -> None:
         _start_attach_visible(
             default_visible,
             wake_visible_after_launch=_start_wake_visible_after_launch(default_visible),
+        )
+        is False
+    )
+
+    attach_takeover = Namespace(
+        execute=True,
+        headless=False,
+        wake_visible_after_launch=None,
+        attach=True,
+        no_attach=False,
+    )
+    assert _start_wake_visible_after_launch(attach_takeover) is False
+    assert (
+        _start_attach_visible(
+            attach_takeover,
+            wake_visible_after_launch=_start_wake_visible_after_launch(attach_takeover),
+        )
+        is True
+    )
+
+    explicit_wake = Namespace(
+        execute=True,
+        headless=False,
+        wake_visible_after_launch=True,
+        attach=False,
+        no_attach=False,
+    )
+    assert _start_wake_visible_after_launch(explicit_wake) is True
+    assert (
+        _start_attach_visible(
+            explicit_wake,
+            wake_visible_after_launch=_start_wake_visible_after_launch(explicit_wake),
         )
         is False
     )

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -111,11 +111,12 @@ def _default_auto_research_start_workspace(goal_id: str) -> str:
 def _start_wake_visible_after_launch(args: argparse.Namespace) -> bool:
     """Return whether `auto-research start` should wake visible lanes after launch."""
 
-    return bool(
-        args.execute
-        and not args.headless
-        and getattr(args, "wake_visible_after_launch", True)
-    )
+    if not args.execute or args.headless:
+        return False
+    wake_setting = getattr(args, "wake_visible_after_launch", None)
+    if wake_setting is None and getattr(args, "attach", False):
+        return False
+    return bool(wake_setting is not False)
 
 
 def _start_attach_visible(args: argparse.Namespace, *, wake_visible_after_launch: bool) -> bool:
@@ -205,7 +206,7 @@ def register_auto_research_commands(
     start_parser.add_argument(
         "--wake-visible-after-launch",
         action="store_true",
-        default=True,
+        default=None,
         help=(
             "After launching visible panes, broadcast the fixed decentralized A2A wake prompt. "
             "This is the default for visible --execute and is kept for explicitness."
@@ -216,8 +217,8 @@ def register_auto_research_commands(
         dest="wake_visible_after_launch",
         action="store_false",
         help=(
-            "Disable the default fixed-prompt wake after visible launch. "
-            "Use this when you want to attach immediately and let lanes wait for manual input."
+            "Disable the default fixed-prompt wake after visible launch while keeping "
+            "the tmux session in the background unless --attach is also passed."
         ),
     )
     start_parser.add_argument(
@@ -229,8 +230,8 @@ def register_auto_research_commands(
         "--attach",
         action="store_true",
         help=(
-            "With visible --execute, attach to tmux after launch. "
-            "Default wake records evidence first; pass --no-wake-visible-after-launch to attach immediately."
+            "With visible --execute, attach to tmux after launch and skip the default wake so "
+            "operator takeover happens first."
         ),
     )
     start_parser.add_argument(
@@ -855,10 +856,10 @@ def handle_auto_research_command(
             if args.no_attach and args.attach:
                 raise ValueError("--attach cannot be combined with --no-attach")
             wake_visible_after_launch = _start_wake_visible_after_launch(args)
-            if wake_visible_after_launch and args.attach:
+            if args.wake_visible_after_launch is True and args.attach:
                 raise ValueError(
-                    "--attach cannot be combined with the default visible wake; "
-                    "pass --no-wake-visible-after-launch when operator takeover should happen first"
+                    "--attach cannot be combined with --wake-visible-after-launch; "
+                    "choose operator takeover (--attach) or evidence-first wake (--no-attach)"
                 )
             goal_id, goal_surface_mode = _resolve_demo_goal_surface(
                 goal_id=args.goal_id,

--- a/loopx/capabilities/auto_research/user_contract.py
+++ b/loopx/capabilities/auto_research/user_contract.py
@@ -44,6 +44,7 @@ def build_auto_research_user_contract(
         },
     ][:todo_limit]
     start_command = f"loopx auto-research start {shlex.quote(question)} --execute"
+    takeover_command = f"{start_command} --attach"
     return {
         "ok": True,
         "schema_version": AUTO_RESEARCH_USER_CONTRACT_SCHEMA_VERSION,
@@ -73,9 +74,16 @@ def build_auto_research_user_contract(
             "schema_version": "auto_research_one_click_start_v0",
             "command_template": 'loopx auto-research start "<open question>" --execute',
             "command": start_command,
+            "operator_takeover_command_template": (
+                'loopx auto-research start "<open question>" --execute --attach'
+            ),
+            "operator_takeover_command": takeover_command,
             "preview_command_template": 'loopx auto-research start "<open question>"',
             "preview_command": f"loopx auto-research start {shlex.quote(question)}",
             "starts": "visible_codex_tui_lanes",
+            "attach_semantics": (
+                "--attach means operator takeover first; it skips the default evidence-first wake."
+            ),
             "uses_generic_kernel": True,
             "coordination_model": "decentralized_state_a2a",
             "user_does_not_choose": [


### PR DESCRIPTION
## Summary
- make `loopx auto-research start ... --execute --attach` mean immediate operator takeover instead of conflicting with the default evidence-first wake
- expose the takeover command in the user contract output
- update the auto-research command guide and smoke coverage for default wake, attach takeover, and explicit wake modes

## Validation
- `python3 examples/auto-research-user-contract-entry-smoke.py`
- `python3 -m compileall -q loopx/capabilities/auto_research`
- `python3 -m loopx.cli --format json auto-research "How should LoopX make visible multi-agent auto research useful?" | jq '.one_click_start | {command_template, operator_takeover_command_template, attach_semantics}'`
- `python3 -m loopx.cli --format json auto-research start "How should LoopX make visible multi-agent auto research useful?" --execute --attach --wake-visible-after-launch` returns the intended clear conflict error
