### PR TITLE
Expose auto-research start operator commands

### DIFF
--- a/examples/auto-research-layered-e2e-acceptance-smoke.py
+++ b/examples/auto-research-layered-e2e-acceptance-smoke.py
@@ -26,6 +26,7 @@ EXPECTED_ACTIONS = [
     "run_dev_eval",
     "summarize_evidence",
     "run_holdout_eval",
+    "write_evaluation_summary",
 ]
 
 
@@ -235,8 +236,8 @@ def assert_two_round_outcome(payload: dict[str, Any]) -> None:
     assert worker_loop["schema_version"] == "auto_research_worker_loop_v0", worker_loop
     assert worker_loop["mode"] == "execute", worker_loop
     assert worker_loop["selected_actions"] == EXPECTED_ACTIONS, worker_loop
-    assert worker_loop["executed_turn_count"] == 5, worker_loop
-    assert worker_loop["completed_turn_count"] == 5, worker_loop
+    assert worker_loop["executed_turn_count"] == 6, worker_loop
+    assert worker_loop["completed_turn_count"] == 6, worker_loop
     assert worker_loop["stop_reason"] == "no_runnable_frontier", worker_loop
 
     turns = worker_loop["turns"]
@@ -245,6 +246,9 @@ def assert_two_round_outcome(payload: dict[str, Any]) -> None:
     dev_turn = next(turn for turn in executed if turn["selected_action"] == "run_dev_eval")
     summary_turn = next(turn for turn in executed if turn["selected_action"] == "summarize_evidence")
     holdout_turn = next(turn for turn in executed if turn["selected_action"] == "run_holdout_eval")
+    evaluation_turn = next(
+        turn for turn in executed if turn["selected_action"] == "write_evaluation_summary"
+    )
     assert dev_turn["round"] == 1, dev_turn
     assert dev_turn["dev_metric"] == 4.0, dev_turn
     assert dev_turn["appended_count"] == 2, dev_turn
@@ -256,6 +260,8 @@ def assert_two_round_outcome(payload: dict[str, Any]) -> None:
     assert holdout_turn["best_holdout_metric"] == 4.5, holdout_turn
     assert holdout_turn["claim_allowed"] is True, holdout_turn
     assert holdout_turn["appended_count"] == 1, holdout_turn
+    assert evaluation_turn["round"] == 2, evaluation_turn
+    assert evaluation_turn["completion_status"] == "done", evaluation_turn
     assert sum(int(turn.get("appended_count") or 0) for turn in turns) >= 3, turns
 
     tonight = payload["tonight_experience"]

--- a/examples/auto-research-start-markdown-commands-smoke.py
+++ b/examples/auto-research-start-markdown-commands-smoke.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Smoke-test operator commands in auto-research start Markdown output."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+QUESTION = "How should LoopX make visible multi-agent auto research useful?"
+
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.capabilities.auto_research.human_view import (  # noqa: E402
+    render_auto_research_markdown,
+)
+from loopx.capabilities.auto_research.user_contract import (  # noqa: E402
+    build_auto_research_user_contract,
+)
+
+
+def require(needle: str, text: str) -> None:
+    assert needle in text, f"missing {needle!r}\n{text}"
+
+
+def forbid(needle: str, text: str) -> None:
+    assert needle not in text, f"unexpected {needle!r}\n{text}"
+
+
+def main() -> int:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "auto-research",
+            "start",
+            QUESTION,
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    markdown = result.stdout
+    require("## Operator Commands", markdown)
+    require(
+        f"- evidence-first start: `loopx auto-research start '{QUESTION}' --execute`",
+        markdown,
+    )
+    require(
+        f"- immediate takeover: `loopx auto-research start '{QUESTION}' --execute --attach`",
+        markdown,
+    )
+    require("--attach means operator takeover first", markdown)
+    forbid("--no-wake-visible-after-launch", markdown)
+    forbid("- tmux attach:", markdown)
+
+    payload = {
+        "ok": True,
+        "schema_version": "auto_research_demo_e2e_result_v0",
+        "mode": "execute",
+        "execution_kind": "visible_worker_launch",
+        "result_source": "visible_worker_launcher",
+        "goal_id": "loopx-auto-research-markdown-smoke",
+        "tracking_goal_id": None,
+        "route_contract": {"frontier_goal_id": "loopx-auto-research-markdown-smoke"},
+        "agent_id": "auto-research-operator",
+        "reasoning_effort": "high",
+        "user_contract": build_auto_research_user_contract(QUESTION),
+        "contract_acceptance": {"accepted": True},
+        "commands": {},
+        "supervisor": {"lane_count": 4},
+        "visible_worker_proof": {
+            "visible_lanes_launched": True,
+            "visible_lanes_accepted": True,
+        },
+        "visible_pane_a2a_rounds": {},
+        "visible_readiness": {},
+        "visible_launch": {
+            "launch_result": {
+                "attach_command": "tmux attach -t loopx-auto-research",
+                "stop_command": "tmux kill-session -t loopx-auto-research",
+            }
+        },
+    }
+    launched = render_auto_research_markdown(payload)
+    require("- tmux attach: `tmux attach -t loopx-auto-research`", launched)
+    require("- tmux stop: `tmux kill-session -t loopx-auto-research`", launched)
+    forbid("--no-wake-visible-after-launch", launched)
+
+    print("auto-research-start-markdown-commands-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/auto_research/human_view.py
+++ b/loopx/capabilities/auto_research/human_view.py
@@ -20,6 +20,49 @@ def _join_or_none(values: object) -> str:
     return "none"
 
 
+def _dict_value(payload: dict[str, object], key: str) -> dict[str, object]:
+    value = payload.get(key)
+    return value if isinstance(value, dict) else {}
+
+
+def _string_value(payload: dict[str, object], key: str) -> str | None:
+    value = payload.get(key)
+    if isinstance(value, str) and value.strip():
+        return value
+    return None
+
+
+def _render_operator_commands(payload: dict[str, object]) -> list[str]:
+    commands = _dict_value(payload, "commands")
+    user_contract = _dict_value(payload, "user_contract") or payload
+    one_click_start = _dict_value(user_contract, "one_click_start")
+    visible_launch = _dict_value(payload, "visible_launch")
+    launch_result = _dict_value(visible_launch, "launch_result")
+    default_start = (
+        _string_value(one_click_start, "command")
+        or _string_value(commands, "one_question_start_with_visible_wake")
+        or _string_value(commands, "one_question_start")
+    )
+    takeover_start = _string_value(one_click_start, "operator_takeover_command")
+    attach_semantics = _string_value(one_click_start, "attach_semantics")
+    attach_command = _string_value(launch_result, "attach_command")
+    stop_command = _string_value(launch_result, "stop_command")
+    lines = ["", "## Operator Commands", ""]
+    if default_start:
+        lines.append(f"- evidence-first start: `{default_start}`")
+    if takeover_start:
+        lines.append(f"- immediate takeover: `{takeover_start}`")
+    if attach_semantics:
+        lines.append(f"- attach_semantics: {attach_semantics}")
+    if attach_command:
+        lines.append(f"- tmux attach: `{attach_command}`")
+    if stop_command:
+        lines.append(f"- tmux stop: `{stop_command}`")
+    if len(lines) == 3:
+        return []
+    return lines
+
+
 def _render_user_contract(payload: dict[str, object]) -> str:
     brief = payload.get("research_brief") if isinstance(payload.get("research_brief"), dict) else {}
     plan = payload.get("action_plan") if isinstance(payload.get("action_plan"), list) else []
@@ -74,9 +117,15 @@ def _render_user_contract(payload: dict[str, object]) -> str:
             "## One-Click Start",
             "",
             f"- command: `{one_click_start.get('command')}`",
+            f"- operator_takeover: `{one_click_start.get('operator_takeover_command')}`",
             f"- preview: `{one_click_start.get('preview_command')}`",
             f"- starts: `{one_click_start.get('starts')}`",
             f"- coordination_model: `{one_click_start.get('coordination_model')}`",
+        ]
+    )
+    lines.extend(_render_operator_commands(payload))
+    lines.extend(
+        [
             "",
             "## Next Executable Step",
             "",
@@ -265,6 +314,7 @@ def _render_demo_e2e(payload: dict[str, object]) -> str:
         f"- visible_holdout_delta_over_dev: `{improvement.get('holdout_delta_over_dev')}`",
         f"- supervisor_lanes: `{supervisor.get('lane_count')}`",
     ]
+    lines.extend(_render_operator_commands(payload))
     return "\n".join(lines) + "\n"
 
 
@@ -383,7 +433,10 @@ def _render_supervisor(payload: dict[str, object]) -> str:
             "",
             f"- mode: `{one_click.get('mode')}`",
             "- command: `loopx auto-research start \"<open question>\" --execute`",
+            "- operator_takeover: `loopx auto-research start \"<open question>\" --execute --attach`",
             f"- machine_json_policy: `{cli_contract.get('machine_json_policy')}`",
+            f"- tmux attach: `{tmux_lifecycle.get('attach_command')}`",
+            f"- tmux stop: `{tmux_lifecycle.get('stop_command')}`",
         ]
     )
     return "\n".join(lines) + "\n"


### PR DESCRIPTION
## Summary
- Add an Operator Commands section to auto-research contract/start markdown so users see the evidence-first start and immediate takeover commands.
- Surface tmux attach/stop controls in markdown after a visible launch result exists.
- Add focused markdown command smoke coverage and align layered E2E acceptance with the current six-action auto-research loop.

## Validation
- PYTHONPATH=. python3 examples/auto-research-start-markdown-commands-smoke.py
- PYTHONPATH=. python3 examples/auto-research-layered-e2e-acceptance-smoke.py
- PYTHONPATH=. python3 examples/auto-research-demo-supervisor-smoke.py
- python3 -m compileall -q loopx/capabilities/auto_research examples/auto-research-start-markdown-commands-smoke.py examples/auto-research-layered-e2e-acceptance-smoke.py