### PR TITLE
Clarify SkillsBench app-server Goal aggregate semantics

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -8621,6 +8621,97 @@ def test_skillsbench_round_trace_records_best_round_score() -> None:
         ] is True, review
 
 
+def test_app_server_goal_round_semantics_survive_compact_and_ledger() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-app-goal-rounds-") as tmp:
+        root = Path(tmp)
+        controller_trace = {
+            "schema_version": "skillsbench_loopx_controller_trace_v0",
+            "route": "codex-app-server-goal-baseline",
+            "trace_publicness": "public_counts_only_no_task_text_no_verifier_output",
+            "max_rounds_budget": 16,
+            "native_goal_worker_route": True,
+            "native_goal_worker_connected": True,
+            "native_goal_worker_trace_dir_present": True,
+            "native_goal_worker_public_trace_read": True,
+            "native_goal_worker_trace_count": 1,
+            "native_goal_worker_ok_count": 1,
+            "native_goal_worker_goal_get_count": 1,
+            "native_goal_worker_turn_start_count": 1,
+            "native_goal_worker_turn_completed_observed_count": 1,
+            "native_goal_worker_assistant_message_present_count": 1,
+            "native_goal_worker_session_policy": "single_thread_with_blinded_followups",
+            "native_goal_worker_max_rounds_budget_applies_to": (
+                "benchflow_outer_controller_budget_not_native_goal_attempts"
+            ),
+            "native_goal_worker_initial_goal_turn_budget": 1,
+            "native_goal_worker_same_thread_followup_budget": 2,
+            "native_goal_worker_independent_attempt_budget": 3,
+            "native_goal_worker_fresh_goal_thread_per_independent_attempt": True,
+            "raw_task_text_recorded": False,
+            "raw_verifier_output_recorded": False,
+            "raw_agent_trajectory_recorded": False,
+        }
+        compact = compact_benchmark_run(
+            build_skillsbench_benchflow_result_benchmark_run(
+                write_official_skillsbench_result(
+                    root / "result",
+                    reward=0.0,
+                    task_id="bike-rebalance",
+                ),
+                route="codex-app-server-goal-baseline",
+                controller_trace=controller_trace,
+            )
+        )
+        assert compact is not None
+        round_semantics = compact["app_server_goal_round_semantics"]
+        assert round_semantics["session_policy"] == (
+            "single_thread_with_blinded_followups"
+        ), compact
+        assert round_semantics["benchflow_max_rounds_budget"] == 16, compact
+        assert round_semantics["max_rounds_budget_applies_to"] == (
+            "benchflow_outer_controller_budget_not_native_goal_attempts"
+        ), compact
+        assert round_semantics["initial_goal_turn_budget"] == 1, compact
+        assert round_semantics["same_thread_followup_budget"] == 2, compact
+        assert round_semantics["independent_attempt_budget"] == 3, compact
+        assert (
+            round_semantics["fresh_goal_thread_per_independent_attempt"] is True
+        ), compact
+
+        ledger_path = root / "ledger.json"
+        update_benchmark_run_ledger(
+            ledger_path=ledger_path,
+            benchmark_run=compact,
+            compact_artifact_ref="runs/public/compact-benchmark-run.json",
+        )
+        ledger = load_benchmark_run_ledger(ledger_path)
+        [run] = ledger["benchmarks"]["skillsbench@1.1"]["cases"]["bike-rebalance"][
+            "runs"
+        ]
+        assert run["max_rounds_budget"] == 16, run
+        assert run["native_goal_session_policy"] == (
+            "single_thread_with_blinded_followups"
+        ), run
+        assert run["max_rounds_budget_applies_to"] == (
+            "benchflow_outer_controller_budget_not_native_goal_attempts"
+        ), run
+        assert run["native_goal_initial_turn_budget"] == 1, run
+        assert run["native_goal_same_thread_followup_budget"] == 2, run
+        assert run["native_goal_independent_attempt_budget"] == 3, run
+        assert run["native_goal_fresh_thread_per_independent_attempt"] is True, run
+        from loopx.benchmark_ledger import build_benchmark_run_ledger_current_aggregate
+
+        current_aggregate = build_benchmark_run_ledger_current_aggregate(
+            ledger,
+            benchmark_id="skillsbench@1.1",
+            canonical_case_ids=["bike-rebalance"],
+        )
+        current = current_aggregate["case_best"]["bike-rebalance"]
+        assert current["max_rounds_budget_applies_to"] == (
+            "benchflow_outer_controller_budget_not_native_goal_attempts"
+        ), current
+
+
 def test_skillsbench_product_mode_declared_done_is_compacted() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-product-done-") as tmp:
         root = Path(tmp)
@@ -11656,6 +11747,9 @@ def test_skillsbench_run_group_ledger_inherits_and_syncs_global_ledger() -> None
         assert update["global_ledger_inheritance"]["inherited"] is True, update
         assert update["primary_ledger_update"]["updated"] is True, update
         assert update["global_ledger_update"]["updated"] is True, update
+        aggregate_update = update["current_aggregate_update"]
+        assert aggregate_update["updated"] is True, aggregate_update
+        assert aggregate_update["canonical_covered"] == 2, aggregate_update
 
         local_ledger = load_benchmark_run_ledger(run_group_ledger)
         global_payload = load_benchmark_run_ledger(global_ledger)
@@ -11664,6 +11758,13 @@ def test_skillsbench_run_group_ledger_inherits_and_syncs_global_ledger() -> None
         assert "3d-scan-calc" in local_cases, local_cases
         assert "tictoc-unnecessary-abort-detection" in local_cases, local_cases
         assert "tictoc-unnecessary-abort-detection" in global_cases, global_cases
+        aggregate_path = global_ledger.parent / "current-aggregate-status.v3.json"
+        assert aggregate_path.exists(), aggregate_path
+        aggregate = json.loads(aggregate_path.read_text(encoding="utf-8"))
+        assert aggregate["distribution"]["pass"] == 2, aggregate
+        assert aggregate["case_best"]["tictoc-unnecessary-abort-detection"][
+            "bucket"
+        ] == "pass", aggregate
         assert ".local" not in json.dumps(update, sort_keys=True), update
 
 
@@ -14493,6 +14594,7 @@ if __name__ == "__main__":
     test_product_mode_declared_done_requires_case_state_depth()
     test_product_mode_declared_done_requires_solver_activity_after_driver_lifecycle()
     test_product_mode_declared_done_stops_after_two_no_open_todo_rounds()
+    test_app_server_goal_round_semantics_survive_compact_and_ledger()
     test_product_mode_closeout_without_done_stops_after_two_low_score_rounds()
     test_product_mode_declared_done_missing_reward_continues()
     test_product_mode_missing_lifecycle_prompts_exact_checkpoint()

--- a/examples/skillsbench-current-ledger-aggregate-smoke.py
+++ b/examples/skillsbench-current-ledger-aggregate-smoke.py
@@ -218,6 +218,7 @@ def test_current_aggregate_prefers_countable_results() -> None:
                 "canonical-task-source-preflight",
                 "pddl-tpp-planning",
                 "reward-artifact-missing",
+                "hello-world",
                 "never-run-case",
             ],
         )
@@ -248,6 +249,7 @@ def test_current_aggregate_prefers_countable_results() -> None:
             "verifier_no_reward"
         )
         assert "hello-world" not in aggregate["case_best"], aggregate["case_best"]
+        assert "hello-world" not in aggregate["cases_by_bucket"]["setup_runner_infra"]
 
 
 def test_current_aggregate_default_inference_excludes_sanity_sources() -> None:

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -2540,6 +2540,25 @@ def _skillsbench_controller_trace_counters(
         "loopx_case_state_writes": count("loopx_case_state_writes"),
         "native_goal_worker_route": controller_trace.get("native_goal_worker_route")
         is True,
+        "native_goal_worker_session_policy": text_value(
+            "native_goal_worker_session_policy"
+        ),
+        "native_goal_worker_max_rounds_budget_applies_to": text_value(
+            "native_goal_worker_max_rounds_budget_applies_to"
+        ),
+        "native_goal_worker_initial_goal_turn_budget": count(
+            "native_goal_worker_initial_goal_turn_budget"
+        ),
+        "native_goal_worker_same_thread_followup_budget": count(
+            "native_goal_worker_same_thread_followup_budget"
+        ),
+        "native_goal_worker_independent_attempt_budget": count(
+            "native_goal_worker_independent_attempt_budget"
+        ),
+        "native_goal_worker_fresh_goal_thread_per_independent_attempt": controller_trace.get(
+            "native_goal_worker_fresh_goal_thread_per_independent_attempt"
+        )
+        is True,
         "native_goal_worker_connected": controller_trace.get(
             "native_goal_worker_connected"
         )
@@ -3743,6 +3762,40 @@ def build_skillsbench_benchflow_result_benchmark_run(
     native_goal_worker_contract = {
         "schema_version": "skillsbench_native_goal_worker_contract_v0",
         "required": controller_counters.get("native_goal_worker_route") is True,
+        "session_policy": (
+            controller_counters.get("native_goal_worker_session_policy")
+            or (
+                "single_initial_goal_turn"
+                if controller_counters.get("native_goal_worker_route") is True
+                else ""
+            )
+        ),
+        "max_rounds_budget_applies_to": (
+            controller_counters.get("native_goal_worker_max_rounds_budget_applies_to")
+            or (
+                "benchflow_outer_controller_budget_not_native_goal_attempts"
+                if controller_counters.get("native_goal_worker_route") is True
+                else ""
+            )
+        ),
+        "benchflow_max_rounds_budget": controller_counters.get("max_rounds_budget"),
+        "initial_goal_turn_budget": (
+            controller_counters.get("native_goal_worker_initial_goal_turn_budget")
+            or (1 if controller_counters.get("native_goal_worker_route") is True else 0)
+        ),
+        "same_thread_followup_budget": controller_counters.get(
+            "native_goal_worker_same_thread_followup_budget"
+        ),
+        "independent_attempt_budget": (
+            controller_counters.get("native_goal_worker_independent_attempt_budget")
+            or (1 if controller_counters.get("native_goal_worker_route") is True else 0)
+        ),
+        "fresh_goal_thread_per_independent_attempt": controller_counters.get(
+            "native_goal_worker_fresh_goal_thread_per_independent_attempt"
+        )
+        is True,
+        "official_reward_feedback_forwarded_to_worker": False,
+        "verifier_output_forwarded_to_worker": False,
         "countable_baseline": native_goal_worker_countable,
         "countability_source": (
             "remote_command_file_bridge_task_facing_success"
@@ -3813,6 +3866,45 @@ def build_skillsbench_benchflow_result_benchmark_run(
         )[:120],
         "failure_label": native_goal_worker_failure_label,
     }
+    app_server_goal_round_semantics: dict[str, Any] = {}
+    if route == "codex-app-server-goal-baseline":
+        same_thread_followup_budget = native_goal_worker_contract.get(
+            "same_thread_followup_budget"
+        )
+        if not isinstance(same_thread_followup_budget, int) or isinstance(
+            same_thread_followup_budget, bool
+        ):
+            same_thread_followup_budget = 0
+        independent_attempt_budget = native_goal_worker_contract.get(
+            "independent_attempt_budget"
+        )
+        if not isinstance(independent_attempt_budget, int) or isinstance(
+            independent_attempt_budget, bool
+        ):
+            independent_attempt_budget = 1
+        app_server_goal_round_semantics = {
+            "schema_version": "skillsbench_app_server_goal_round_semantics_v0",
+            "route": route,
+            "session_policy": native_goal_worker_contract.get("session_policy")
+            or "single_initial_goal_turn",
+            "benchflow_max_rounds_budget": controller_max_rounds_budget,
+            "max_rounds_budget_applies_to": native_goal_worker_contract.get(
+                "max_rounds_budget_applies_to"
+            )
+            or "benchflow_outer_controller_budget_not_native_goal_attempts",
+            "initial_goal_turn_budget": native_goal_worker_contract.get(
+                "initial_goal_turn_budget"
+            )
+            or 1,
+            "same_thread_followup_budget": max(0, same_thread_followup_budget),
+            "independent_attempt_budget": max(1, independent_attempt_budget),
+            "fresh_goal_thread_per_independent_attempt": native_goal_worker_contract.get(
+                "fresh_goal_thread_per_independent_attempt"
+            )
+            is True,
+            "official_reward_feedback_forwarded_to_worker": False,
+            "verifier_output_forwarded_to_worker": False,
+        }
 
     product_mode_lifecycle_required = _is_skillsbench_loopx_product_mode_treatment_route(
         route
@@ -5628,6 +5720,7 @@ def build_skillsbench_benchflow_result_benchmark_run(
         },
         "product_mode_lifecycle_contract": product_mode_lifecycle_contract,
         "native_goal_worker_contract": native_goal_worker_contract,
+        "app_server_goal_round_semantics": app_server_goal_round_semantics,
         "trials": [
             {
                 "task_id": task_id,

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -35,6 +35,15 @@ LEDGER_LOGICAL_BACKFILL_FIELDS = (
     "round_reward_count",
     "round_success_observed",
     "max_rounds_budget",
+    "app_server_goal_round_semantics",
+    "native_goal_session_policy",
+    "max_rounds_budget_applies_to",
+    "native_goal_initial_turn_budget",
+    "native_goal_same_thread_followup_budget",
+    "native_goal_independent_attempt_budget",
+    "native_goal_fresh_thread_per_independent_attempt",
+    "native_goal_official_reward_feedback_forwarded_to_worker",
+    "native_goal_verifier_output_forwarded_to_worker",
     "official_feedback_blinded",
     "reward_feedback_forwarded",
     "task_setup_preflight",
@@ -347,6 +356,12 @@ def _compact_positive_int(value: Any) -> int | None:
     return None
 
 
+def _compact_nonnegative_int(value: Any) -> int | None:
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+        return value
+    return None
+
+
 def _compact_number(value: Any) -> float | None:
     if isinstance(value, (int, float)) and not isinstance(value, bool):
         return float(value)
@@ -605,6 +620,38 @@ def _compact_product_mode_lifecycle_contract(value: Any) -> dict[str, Any]:
     execution_style = _compact_text(value.get("execution_style"), limit=120)
     if execution_style:
         compact["execution_style"] = execution_style
+    return compact
+
+
+def _compact_app_server_goal_round_semantics(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    compact: dict[str, Any] = {}
+    for field in (
+        "schema_version",
+        "route",
+        "session_policy",
+        "max_rounds_budget_applies_to",
+    ):
+        text = _compact_text(value.get(field), limit=140)
+        if text:
+            compact[field] = text
+    for field in (
+        "benchflow_max_rounds_budget",
+        "initial_goal_turn_budget",
+        "same_thread_followup_budget",
+        "independent_attempt_budget",
+    ):
+        number = _compact_nonnegative_int(value.get(field))
+        if number is not None:
+            compact[field] = number
+    for field in (
+        "fresh_goal_thread_per_independent_attempt",
+        "official_reward_feedback_forwarded_to_worker",
+        "verifier_output_forwarded_to_worker",
+    ):
+        if isinstance(value.get(field), bool):
+            compact[field] = value[field]
     return compact
 
 
@@ -1614,6 +1661,36 @@ def build_benchmark_run_ledger_entry(
         best_round_passed = round_reward_stats.get("best_round_passed")
     if not isinstance(best_round_is_final, bool):
         best_round_is_final = round_reward_stats.get("best_round_is_final")
+    native_goal_worker_contract = (
+        benchmark_run.get("native_goal_worker_contract")
+        if isinstance(benchmark_run.get("native_goal_worker_contract"), dict)
+        else {}
+    )
+    raw_app_server_goal_round_semantics = (
+        benchmark_run.get("app_server_goal_round_semantics")
+        if isinstance(benchmark_run.get("app_server_goal_round_semantics"), dict)
+        else {}
+    )
+    if not raw_app_server_goal_round_semantics and (
+        benchmark_run.get("route") == "codex-app-server-goal-baseline"
+        or native_goal_worker_contract.get("required") is True
+    ):
+        raw_app_server_goal_round_semantics = native_goal_worker_contract
+    app_server_goal_round_semantics = _compact_app_server_goal_round_semantics(
+        raw_app_server_goal_round_semantics
+    )
+    if (
+        not isinstance(max_rounds_budget, int)
+        or isinstance(max_rounds_budget, bool)
+    ) and (
+        isinstance(app_server_goal_round_semantics.get("benchflow_max_rounds_budget"), int)
+        and not isinstance(
+            app_server_goal_round_semantics.get("benchflow_max_rounds_budget"), bool
+        )
+    ):
+        max_rounds_budget = app_server_goal_round_semantics.get(
+            "benchflow_max_rounds_budget"
+        )
     runner_prerequisites = (
         benchmark_run.get("runner_prerequisites")
         if isinstance(benchmark_run.get("runner_prerequisites"), dict)
@@ -1696,6 +1773,59 @@ def build_benchmark_run_ledger_entry(
         "max_rounds_budget": max_rounds_budget
         if isinstance(max_rounds_budget, int) and not isinstance(max_rounds_budget, bool)
         else None,
+        "app_server_goal_round_semantics": app_server_goal_round_semantics or None,
+        "native_goal_session_policy": _compact_text(
+            app_server_goal_round_semantics.get("session_policy"), limit=120
+        ),
+        "max_rounds_budget_applies_to": _compact_text(
+            app_server_goal_round_semantics.get("max_rounds_budget_applies_to"),
+            limit=140,
+        ),
+        "native_goal_initial_turn_budget": _compact_nonnegative_int(
+            app_server_goal_round_semantics.get("initial_goal_turn_budget")
+        ),
+        "native_goal_same_thread_followup_budget": _compact_nonnegative_int(
+            app_server_goal_round_semantics.get("same_thread_followup_budget")
+        ),
+        "native_goal_independent_attempt_budget": _compact_nonnegative_int(
+            app_server_goal_round_semantics.get("independent_attempt_budget")
+        ),
+        "native_goal_fresh_thread_per_independent_attempt": (
+            app_server_goal_round_semantics.get(
+                "fresh_goal_thread_per_independent_attempt"
+            )
+            if isinstance(
+                app_server_goal_round_semantics.get(
+                    "fresh_goal_thread_per_independent_attempt"
+                ),
+                bool,
+            )
+            else None
+        ),
+        "native_goal_official_reward_feedback_forwarded_to_worker": (
+            app_server_goal_round_semantics.get(
+                "official_reward_feedback_forwarded_to_worker"
+            )
+            if isinstance(
+                app_server_goal_round_semantics.get(
+                    "official_reward_feedback_forwarded_to_worker"
+                ),
+                bool,
+            )
+            else None
+        ),
+        "native_goal_verifier_output_forwarded_to_worker": (
+            app_server_goal_round_semantics.get(
+                "verifier_output_forwarded_to_worker"
+            )
+            if isinstance(
+                app_server_goal_round_semantics.get(
+                    "verifier_output_forwarded_to_worker"
+                ),
+                bool,
+            )
+            else None
+        ),
         "official_feedback_blinded": round_reward_trace.get("official_feedback_blinded")
         if isinstance(round_reward_trace, dict)
         and isinstance(round_reward_trace.get("official_feedback_blinded"), bool)
@@ -3164,6 +3294,15 @@ def _current_aggregate_run_summary(run: dict[str, Any] | None) -> dict[str, Any]
         "round_reward_count",
         "round_success_observed",
         "max_rounds_budget",
+        "app_server_goal_round_semantics",
+        "native_goal_session_policy",
+        "max_rounds_budget_applies_to",
+        "native_goal_initial_turn_budget",
+        "native_goal_same_thread_followup_budget",
+        "native_goal_independent_attempt_budget",
+        "native_goal_fresh_thread_per_independent_attempt",
+        "native_goal_official_reward_feedback_forwarded_to_worker",
+        "native_goal_verifier_output_forwarded_to_worker",
         "official_feedback_blinded",
         "reward_feedback_forwarded",
         "failure_class",
@@ -3232,6 +3371,7 @@ def build_benchmark_run_ledger_current_aggregate(
     benchmark_id: str = "skillsbench@1.1",
     canonical_case_ids: list[str] | None = None,
     source_ledger_count: int = 1,
+    exclude_noncanonical_sanity_sources: bool = True,
 ) -> dict[str, Any]:
     """Build a current-case aggregate, preferring countable results over missing rows."""
 
@@ -3250,6 +3390,17 @@ def build_benchmark_run_ledger_current_aggregate(
             for case_id in canonical_case_ids
             if _compact_text(case_id, limit=160)
         ]
+        if exclude_noncanonical_sanity_sources:
+            canonical_ids = [
+                case_id
+                for case_id in canonical_ids
+                if not (
+                    isinstance(cases.get(case_id), dict)
+                    and _current_aggregate_case_is_noncanonical_sanity_source(
+                        cases[case_id]
+                    )
+                )
+            ]
     else:
         canonical_ids = sorted(
             case_id

--- a/loopx/cli_commands/benchmark_run_ledger_maintenance.py
+++ b/loopx/cli_commands/benchmark_run_ledger_maintenance.py
@@ -498,6 +498,15 @@ def register_benchmark_run_ledger_maintenance_commands(
         ),
     )
     benchmark_run_ledger_aggregate_parser.add_argument(
+        "--include-noncanonical-sanity-sources",
+        action="store_true",
+        help=(
+            "Keep explicit canonical ids whose ledger rows prove they came from "
+            "sanity/noncanonical task sources. Formal SkillsBench aggregates "
+            "leave this off so sanity fixtures do not enter the denominator."
+        ),
+    )
+    benchmark_run_ledger_aggregate_parser.add_argument(
         "--output-json",
         help="Optional output JSON path for the aggregate.",
     )
@@ -783,6 +792,9 @@ def handle_benchmark_run_ledger_maintenance_command(
                 benchmark_id=args.benchmark_id,
                 canonical_case_ids=canonical_case_ids or None,
                 source_ledger_count=source_ledger_count,
+                exclude_noncanonical_sanity_sources=not bool(
+                    args.include_noncanonical_sanity_sources
+                ),
             )
             output_json = Path(args.output_json).expanduser() if args.output_json else None
             if args.execute:

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -993,6 +993,12 @@ def _benchmark_positive_int(value: Any) -> int:
     return 0
 
 
+def _benchmark_nonnegative_int(value: Any) -> int | None:
+    if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+        return value
+    return None
+
+
 def build_skillsbench_post_run_debug_gate(
     run: dict[str, Any],
 ) -> dict[str, Any]:
@@ -1839,10 +1845,20 @@ def _compact_native_goal_worker_contract(value: Any) -> dict[str, Any]:
     schema = public_safe_compact_text(value.get("schema_version"), limit=100)
     if schema:
         compact["schema_version"] = schema
-    for field in ("required", "countable_baseline"):
+    for field in (
+        "required",
+        "countable_baseline",
+        "fresh_goal_thread_per_independent_attempt",
+        "official_reward_feedback_forwarded_to_worker",
+        "verifier_output_forwarded_to_worker",
+    ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
     for field in (
+        "benchflow_max_rounds_budget",
+        "initial_goal_turn_budget",
+        "same_thread_followup_budget",
+        "independent_attempt_budget",
         "trace_count",
         "ok_count",
         "goal_get_count",
@@ -1868,6 +1884,8 @@ def _compact_native_goal_worker_contract(value: Any) -> dict[str, Any]:
         if isinstance(field_value, int) and not isinstance(field_value, bool):
             compact[field] = field_value
     for field in (
+        "session_policy",
+        "max_rounds_budget_applies_to",
         "countability_source",
         "trace_status",
         "reasoning_effort",
@@ -1878,6 +1896,39 @@ def _compact_native_goal_worker_contract(value: Any) -> dict[str, Any]:
         text = public_safe_compact_text(value.get(field), limit=140)
         if text:
             compact[field] = text
+    return compact
+
+
+def _compact_app_server_goal_round_semantics(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+
+    compact: dict[str, Any] = {}
+    for field in (
+        "schema_version",
+        "route",
+        "session_policy",
+        "max_rounds_budget_applies_to",
+    ):
+        text = public_safe_compact_text(value.get(field), limit=140)
+        if text:
+            compact[field] = text
+    for field in (
+        "benchflow_max_rounds_budget",
+        "initial_goal_turn_budget",
+        "same_thread_followup_budget",
+        "independent_attempt_budget",
+    ):
+        number = _benchmark_nonnegative_int(value.get(field))
+        if number is not None:
+            compact[field] = number
+    for field in (
+        "fresh_goal_thread_per_independent_attempt",
+        "official_reward_feedback_forwarded_to_worker",
+        "verifier_output_forwarded_to_worker",
+    ):
+        if isinstance(value.get(field), bool):
+            compact[field] = value[field]
     return compact
 
 
@@ -4291,6 +4342,11 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
     )
     if native_goal_worker_contract:
         compact["native_goal_worker_contract"] = native_goal_worker_contract
+    app_server_goal_round_semantics = _compact_app_server_goal_round_semantics(
+        source.get("app_server_goal_round_semantics")
+    )
+    if app_server_goal_round_semantics:
+        compact["app_server_goal_round_semantics"] = app_server_goal_round_semantics
 
     case_event_timeline = _compact_benchmark_case_event_timeline(
         source.get("case_event_timeline")

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -159,6 +159,7 @@ DEFAULT_PRIVATE_LEDGER = (
     / "skillsbench-current-global-ledger/benchmark-run-ledger.json"
 )
 DEFAULT_LEDGER = DEFAULT_PRIVATE_LEDGER
+DEFAULT_CURRENT_AGGREGATE_FILENAME = "current-aggregate-status.v3.json"
 TERMINAL_OFFICIAL_NONPASSING_ATTRIBUTIONS = {
     "official_score_zero_case_failure",
     "official_verifier_solution_failure",
@@ -7936,6 +7937,16 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         getattr(args, "app_server_goal_prompt_style", "bridge-only")
         or "bridge-only"
     )
+    app_server_goal_followup_budget = (
+        max(0, int(getattr(args, "app_server_goal_followup_max", 0) or 0))
+        if is_app_server_goal_route
+        else 0
+    )
+    independent_goal_attempt_budget = (
+        max(1, int(getattr(args, "independent_goal_retries", 1) or 1))
+        if is_app_server_goal_route
+        else 1
+    )
     codex_api_egress_preflight = _public_codex_api_egress_contract(
         args,
         status=(
@@ -8038,6 +8049,29 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         route=route,
         max_wall_time_minutes=max(480, (int(args.outer_timeout_sec) + 59) // 60),
     )
+    app_server_goal_round_semantics = (
+        {
+            "schema_version": "skillsbench_app_server_goal_round_semantics_v0",
+            "route": "codex-app-server-goal-baseline",
+            "session_policy": (
+                "single_thread_with_blinded_followups"
+                if app_server_goal_followup_budget
+                else "single_initial_goal_turn"
+            ),
+            "benchflow_max_rounds_budget": args.max_rounds,
+            "max_rounds_budget_applies_to": (
+                "benchflow_outer_controller_budget_not_native_goal_attempts"
+            ),
+            "initial_goal_turn_budget": 1,
+            "same_thread_followup_budget": app_server_goal_followup_budget,
+            "independent_attempt_budget": independent_goal_attempt_budget,
+            "fresh_goal_thread_per_independent_attempt": True,
+            "official_reward_feedback_forwarded_to_worker": False,
+            "verifier_output_forwarded_to_worker": False,
+        }
+        if is_app_server_goal_route
+        else {}
+    )
     launch_plan = {
         "schema_version": "skillsbench_runner_launch_plan_v0",
         "benchmark_id": args.dataset,
@@ -8056,11 +8090,8 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         "app_server_reasoning_effort": (
             app_server_reasoning_effort if is_app_server_goal_route else ""
         ),
-        "app_server_goal_followup_max": (
-            max(0, int(args.app_server_goal_followup_max or 0))
-            if is_app_server_goal_route
-            else 0
-        ),
+        "app_server_goal_followup_max": app_server_goal_followup_budget,
+        "app_server_goal_round_semantics": app_server_goal_round_semantics,
         "app_server_goal_prompt_style": (
             app_server_goal_prompt_style
             if is_app_server_goal_route
@@ -8071,10 +8102,8 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         "max_rounds": args.max_rounds,
         "independent_goal_retry": {
             "schema_version": "skillsbench_independent_goal_retry_config_v0",
-            "enabled": bool(int(getattr(args, "independent_goal_retries", 1) or 1) > 1),
-            "attempt_budget": max(
-                1, int(getattr(args, "independent_goal_retries", 1) or 1)
-            ),
+            "enabled": bool(independent_goal_attempt_budget > 1),
+            "attempt_budget": independent_goal_attempt_budget,
             "route_supported": route == "codex-app-server-goal-baseline",
             "fresh_goal_thread_per_attempt": True,
             "stop_policy": (
@@ -8753,6 +8782,39 @@ def _app_server_goal_worker_observability(
     summary: dict[str, Any] = {
         "schema_version": "skillsbench_app_server_goal_worker_observability_v0",
         "route": "codex-app-server-goal-baseline",
+        "session_policy": str(
+            trace_summary.get("native_goal_worker_session_policy")
+            or (
+                "single_thread_with_blinded_followups"
+                if max(0, int(plan.get("app_server_goal_followup_max") or 0))
+                else "single_initial_goal_turn"
+            )
+        )[:120],
+        "max_rounds_budget_applies_to": str(
+            trace_summary.get("native_goal_worker_max_rounds_budget_applies_to")
+            or "benchflow_outer_controller_budget_not_native_goal_attempts"
+        )[:120],
+        "initial_goal_turn_budget": _int_field(
+            "native_goal_worker_initial_goal_turn_budget"
+        )
+        or 1,
+        "same_thread_followup_budget": max(
+            0, int(plan.get("app_server_goal_followup_max") or 0)
+        ),
+        "independent_attempt_budget": (
+            max(
+                1,
+                int(
+                    (
+                        plan.get("independent_goal_retry")
+                        if isinstance(plan.get("independent_goal_retry"), dict)
+                        else {}
+                    ).get("attempt_budget")
+                    or 1
+                ),
+            )
+        ),
+        "fresh_goal_thread_per_independent_attempt": True,
         "requested_reasoning_effort": requested_effort,
         "observed_reasoning_effort": observed_effort,
         "reasoning_effort_observation_status": effort_status,
@@ -9334,6 +9396,26 @@ def _new_controller_trace(route: str, *, max_rounds: int | None = None) -> dict[
         "loopx_case_state_reads": 0,
         "loopx_case_state_writes": 0,
         "native_goal_worker_route": route == CODEX_APP_SERVER_GOAL_BASELINE_ROUTE,
+        "native_goal_worker_session_policy": (
+            "single_initial_goal_turn"
+            if route == CODEX_APP_SERVER_GOAL_BASELINE_ROUTE
+            else ""
+        ),
+        "native_goal_worker_max_rounds_budget_applies_to": (
+            "benchflow_outer_controller_budget_not_native_goal_attempts"
+            if route == CODEX_APP_SERVER_GOAL_BASELINE_ROUTE
+            else ""
+        ),
+        "native_goal_worker_initial_goal_turn_budget": (
+            1 if route == CODEX_APP_SERVER_GOAL_BASELINE_ROUTE else 0
+        ),
+        "native_goal_worker_same_thread_followup_budget": 0,
+        "native_goal_worker_independent_attempt_budget": (
+            1 if route == CODEX_APP_SERVER_GOAL_BASELINE_ROUTE else 0
+        ),
+        "native_goal_worker_fresh_goal_thread_per_independent_attempt": (
+            route == CODEX_APP_SERVER_GOAL_BASELINE_ROUTE
+        ),
         "native_goal_worker_connected": False,
         "native_goal_worker_connect_count": 0,
         "native_goal_worker_trace_dir_present": False,
@@ -9604,7 +9686,63 @@ def _merge_app_server_goal_worker_trace_summary(
             turn.get("raw_transcript_recorded") is True
             or turn.get("raw_assistant_message_recorded") is True
         )
-    trace["native_goal_worker_route"] = plan.get("route") == "codex-app-server-goal-baseline"
+    is_native_goal_route = plan.get("route") == "codex-app-server-goal-baseline"
+    round_semantics = (
+        plan.get("app_server_goal_round_semantics")
+        if isinstance(plan.get("app_server_goal_round_semantics"), dict)
+        else {}
+    )
+    independent_retry = (
+        plan.get("independent_goal_retry")
+        if isinstance(plan.get("independent_goal_retry"), dict)
+        else {}
+    )
+    requested_followup_budget = max(
+        0,
+        int(
+            round_semantics.get("same_thread_followup_budget")
+            if isinstance(round_semantics.get("same_thread_followup_budget"), int)
+            and not isinstance(round_semantics.get("same_thread_followup_budget"), bool)
+            else plan.get("app_server_goal_followup_max")
+            or 0
+        ),
+    )
+    independent_attempt_budget = max(
+        1,
+        int(
+            round_semantics.get("independent_attempt_budget")
+            if isinstance(round_semantics.get("independent_attempt_budget"), int)
+            and not isinstance(round_semantics.get("independent_attempt_budget"), bool)
+            else independent_retry.get("attempt_budget")
+            or 1
+        ),
+    )
+    trace["native_goal_worker_route"] = is_native_goal_route
+    trace["native_goal_worker_session_policy"] = str(
+        round_semantics.get("session_policy")
+        or (
+            "single_thread_with_blinded_followups"
+            if requested_followup_budget
+            else "single_initial_goal_turn"
+        )
+    )[:120] if is_native_goal_route else ""
+    trace["native_goal_worker_max_rounds_budget_applies_to"] = str(
+        round_semantics.get("max_rounds_budget_applies_to")
+        or "benchflow_outer_controller_budget_not_native_goal_attempts"
+    )[:120] if is_native_goal_route else ""
+    trace["native_goal_worker_initial_goal_turn_budget"] = (
+        1 if is_native_goal_route else 0
+    )
+    trace["native_goal_worker_same_thread_followup_budget"] = (
+        requested_followup_budget if is_native_goal_route else 0
+    )
+    trace["native_goal_worker_independent_attempt_budget"] = (
+        independent_attempt_budget if is_native_goal_route else 0
+    )
+    trace["native_goal_worker_fresh_goal_thread_per_independent_attempt"] = bool(
+        is_native_goal_route
+        and round_semantics.get("fresh_goal_thread_per_independent_attempt") is not False
+    )
     trace["native_goal_worker_trace_dir_present"] = trace_dir.exists()
     trace["native_goal_worker_trace_count"] = worker_trace_count
     trace["native_goal_worker_lifecycle_trace_count"] = lifecycle_trace_count
@@ -14334,7 +14472,11 @@ def update_ledger(
     *,
     compact_path: Path | None = None,
 ) -> dict[str, Any]:
-    from loopx.benchmark_ledger import update_benchmark_run_ledger
+    from loopx.benchmark_ledger import (
+        build_benchmark_run_ledger_current_aggregate,
+        load_benchmark_run_ledger,
+        update_benchmark_run_ledger,
+    )
 
     note_route = (
         "LoopX prompt-driven polling test"
@@ -14390,6 +14532,51 @@ def update_ledger(
             dry_run=dry_run,
         )
 
+    current_aggregate_update: dict[str, Any] = {
+        "schema_version": "skillsbench_current_aggregate_update_v0",
+        "requested": bool(args.update_current_aggregate),
+        "updated": False,
+    }
+    if args.update_current_aggregate:
+        current_aggregate_path = _expanded_path(args.current_aggregate_path)
+        current_aggregate_update.update(
+            {
+                "output_path": str(current_aggregate_path),
+                "raw_logs_read": False,
+                "raw_task_text_read": False,
+                "raw_trajectory_read": False,
+            }
+        )
+        if dry_run:
+            current_aggregate_update["status"] = "dry_run"
+        else:
+            ledger_for_aggregate_path = (
+                global_ledger_path
+                if not args.skip_global_ledger_sync
+                else primary_ledger_path
+            )
+            ledger_for_aggregate = load_benchmark_run_ledger(ledger_for_aggregate_path)
+            aggregate = build_benchmark_run_ledger_current_aggregate(
+                ledger_for_aggregate,
+                benchmark_id="skillsbench@1.1",
+                source_ledger_count=1,
+            )
+            current_aggregate_path.parent.mkdir(parents=True, exist_ok=True)
+            current_aggregate_path.write_text(
+                json.dumps(aggregate, ensure_ascii=False, indent=2, sort_keys=True)
+                + "\n",
+                encoding="utf-8",
+            )
+            current_aggregate_update.update(
+                {
+                    "status": "updated",
+                    "updated": True,
+                    "canonical_total": aggregate.get("canonical_total"),
+                    "canonical_covered": aggregate.get("canonical_covered"),
+                    "distribution": aggregate.get("distribution"),
+                }
+            )
+
     result = dict(primary_update)
     result["ledger_scope"] = _ledger_scope_label(primary_ledger_path, global_ledger_path)
     result["primary_ledger_update"] = primary_update
@@ -14397,6 +14584,7 @@ def update_ledger(
     result["global_ledger_sync_enabled"] = not bool(args.skip_global_ledger_sync)
     result["global_ledger_update"] = global_update
     result["global_ledger_inheritance"] = ledger_inheritance
+    result["current_aggregate_update"] = current_aggregate_update
     return result
 
 
@@ -14796,6 +14984,22 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         action="store_true",
         help="Do not initialize a missing run-group/local ledger from --global-ledger-path.",
     )
+    parser.add_argument(
+        "--current-aggregate-path",
+        default=None,
+        help=(
+            "Path for the public-safe current aggregate projection refreshed "
+            "after --update-ledger. Defaults to current-aggregate-status.v3.json "
+            "next to --global-ledger-path."
+        ),
+    )
+    parser.add_argument(
+        "--skip-current-aggregate-update",
+        dest="update_current_aggregate",
+        action="store_false",
+        help="Do not refresh the current aggregate projection after writing the run ledger.",
+    )
+    parser.set_defaults(update_current_aggregate=True)
     parser.add_argument("--goal-id", default=DEFAULT_GOAL_ID)
     parser.add_argument("--registry", default=str(REPO_ROOT / ".loopx/registry.json"))
     parser.add_argument("--runtime-root", default=str(REPO_ROOT / ".local"))
@@ -15180,6 +15384,11 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         args.ledger_path = str(default_ledger)
     if args.global_ledger_path is None:
         args.global_ledger_path = str(default_ledger)
+    if args.current_aggregate_path is None:
+        args.current_aggregate_path = str(
+            Path(args.global_ledger_path).expanduser().parent
+            / DEFAULT_CURRENT_AGGREGATE_FILENAME
+        )
     args.apt_risk_fail_fast_defaulted = False
     args.verifier_bootstrap_fail_fast_defaulted = False
     args.bootstrap_light_fail_fast_defaulted = False


### PR DESCRIPTION
## Summary
- make app-server Goal round semantics explicit in runner plans, compact benchmark runs, status compaction, and run ledgers
- refresh current aggregate projections after ledger writes so later countable results are not hidden behind stale setup rows
- exclude proven noncanonical sanity-source rows from formal current aggregates unless explicitly requested

## Validation
- `python3 -m py_compile scripts/skillsbench_automation_loop.py loopx/status.py loopx/benchmark_adapters/skillsbench.py loopx/benchmark_ledger.py loopx/cli_commands/benchmark_run_ledger_maintenance.py examples/skillsbench-benchmark-run-smoke.py examples/skillsbench-current-ledger-aggregate-smoke.py`
- `python3 examples/skillsbench-current-ledger-aggregate-smoke.py`
- focused SkillsBench smoke functions:
  - `test_app_server_goal_round_semantics_survive_compact_and_ledger`
  - `test_skillsbench_run_group_ledger_inherits_and_syncs_global_ledger`
  - `test_skillsbench_default_ledger_is_private_unless_published`
- `loopx check --scan-path ...` (public boundary clean; existing duplicate-index warning unrelated)
