### PR TITLE
Use auto-research start wake helpers

### DIFF
--- a/examples/auto-research-user-contract-entry-smoke.py
+++ b/examples/auto-research-user-contract-entry-smoke.py
@@ -149,6 +149,12 @@ def run_cli(temp_dir: Path, *args: str) -> str:
 
 
 def assert_start_wake_contract() -> None:
+    cli_source = (REPO_ROOT / "loopx/capabilities/auto_research/cli.py").read_text(
+        encoding="utf-8"
+    )
+    assert "wake_visible_after_launch=bool(args.wake_visible_after_launch)" not in cli_source
+    assert cli_source.count("wake_visible_after_launch = _start_wake_visible_after_launch(args)") == 2
+
     default_visible = Namespace(
         execute=True,
         headless=False,

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -1139,18 +1139,15 @@ def handle_auto_research_command(
             launch_visible = bool(args.launch_visible or auto_visible_launch)
             if args.no_attach and args.attach:
                 raise ValueError("--attach cannot be combined with --no-attach")
-            if args.wake_visible_after_launch and args.attach:
+            wake_visible_after_launch = _start_wake_visible_after_launch(args)
+            if args.wake_visible_after_launch is True and args.attach:
                 raise ValueError(
                     "--wake-visible-after-launch cannot be combined with --attach; "
                     "wake evidence must be recorded before operator takeover"
                 )
-            attach_visible = bool(
-                args.attach
-                or (
-                    auto_visible_launch
-                    and not args.no_attach
-                    and not args.wake_visible_after_launch
-                )
+            attach_visible = _start_attach_visible(
+                args,
+                wake_visible_after_launch=wake_visible_after_launch,
             )
             if launch_visible:
                 def visible_launcher(
@@ -1218,7 +1215,7 @@ def handle_auto_research_command(
                 append_evidence=append_demo_e2e_evidence,
                 visible_launcher=visible_launcher,
                 visible_wake=visible_wake,
-                wake_visible_after_launch=bool(args.wake_visible_after_launch),
+                wake_visible_after_launch=wake_visible_after_launch,
                 visible_live_evidence_wait_seconds=args.visible_live_evidence_wait_seconds,
             )
         else:


### PR DESCRIPTION
## Summary
- Route `auto-research start --execute` through the existing wake/attach helper contract.
- Preserve the intended default: evidence-first wake with no attach; `--attach` remains explicit operator takeover.
- Add smoke coverage so the handler cannot silently bool-coerce an unspecified wake flag again.

## Validation
- PYTHONPATH=. python3 examples/auto-research-user-contract-entry-smoke.py
- PYTHONPATH=. python3 examples/auto-research-start-markdown-commands-smoke.py
- python3 -m compileall -q loopx/capabilities/auto_research examples/auto-research-user-contract-entry-smoke.py
