### PR TITLE
Keep auto-research role skills thin

### DIFF
--- a/examples/auto-research-demo-supervisor-smoke.py
+++ b/examples/auto-research-demo-supervisor-smoke.py
@@ -76,8 +76,14 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
     assert "multi_agent_runner" in layering["preset_layer"]["forbidden"], layering
     assert "decentralized_a2a_driver" in layering["preset_layer"]["forbidden"], layering
     assert "pane_local_a2a_tick" in layering["preset_layer"]["forbidden"], layering
+    assert "default_loopx_skill_bootstrap" in layering["preset_layer"]["forbidden"], layering
+    assert "fixed_a2a_wake_prompt" in layering["preset_layer"]["forbidden"], layering
     assert "decentralized_a2a_driver" in layering["kernel_layer"]["owns"], layering
     assert "compact_human_status" in layering["kernel_layer"]["owns"], layering
+    assert layering["kernel_layer"]["default_skills"] == [
+        "loopx-project",
+        "loopx-doc-registry",
+    ], layering
     assert layering["acceptance"]["preset_has_no_runner_process_logic"] is True, layering
 
     preset = payload["preset"]
@@ -92,6 +98,10 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
     assert "multi_agent_runner" in preset["forbidden"], preset
     assert "decentralized_a2a_driver" in preset["forbidden"], preset
     assert "pane_local_a2a_tick" in preset["forbidden"], preset
+    assert "default_loopx_skill_bootstrap" in preset["forbidden"], preset
+    assert "fixed_a2a_wake_prompt" in preset["forbidden"], preset
+    assert preset["worker_skill_scope"] == "role_specific_semantics_and_successor_todos_only", preset
+    assert preset["successor_routing"] == "role_profile_successor_todos_with_target_agent", preset
 
     kernel = payload["auto_research"]
     assert kernel["schema_version"] == AUTO_RESEARCH_PRESET_SCHEMA_VERSION, payload
@@ -169,6 +179,12 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
         assert profile["role_id"] == lane["role_id"], profile
         assert profile["required_skill"] == "loopx-auto-research", profile
         assert profile["skill_distribution"] == "worker_local", profile
+        assert (
+            profile["worker_skill_scope"]
+            == "role_specific_semantics_and_successor_todos_only"
+        ), profile
+        assert profile["default_kernel_skills_owner"] == "generic_multi_agent_kernel", profile
+        assert profile["fixed_a2a_wake_prompt_owner"] == "generic_multi_agent_kernel", profile
         assert profile["worker_skill_source"].endswith("auto_research/worker_skill/SKILL.md"), profile
         assert expected_action_hints[lane["role_id"]] in profile["allowed_actions"], profile
         assert profile["write_scope"], profile

--- a/examples/auto-research-layered-e2e-acceptance-smoke.py
+++ b/examples/auto-research-layered-e2e-acceptance-smoke.py
@@ -144,6 +144,10 @@ def assert_three_layer_minimality() -> None:
     assert "real_codex_tui_panes" in preset["forbidden"], preset
     assert "decentralized_a2a_driver" in preset["forbidden"], preset
     assert "pane_local_a2a_tick" in preset["forbidden"], preset
+    assert "default_loopx_skill_bootstrap" in preset["forbidden"], preset
+    assert "fixed_a2a_wake_prompt" in preset["forbidden"], preset
+    assert preset["worker_skill_scope"] == "role_specific_semantics_and_successor_todos_only", preset
+    assert preset["successor_routing"] == "role_profile_successor_todos_with_target_agent", preset
 
     auto_research = supervisor["auto_research"]
     assert auto_research["schema_version"] == AUTO_RESEARCH_PRESET_SCHEMA_VERSION, auto_research

--- a/examples/auto-research-skill-contract-smoke.py
+++ b/examples/auto-research-skill-contract-smoke.py
@@ -64,8 +64,8 @@ def main() -> int:
         "not a global LoopX skill",
         "Identity comes from LoopX control-plane metadata",
         "Pane Tick Contract",
-        "$loopx-project",
-        "$loopx-doc-registry",
+        "generic multi-agent kernel owns the default LoopX project/doc-registry skills",
+        "fixed A2A wake prompt",
         "auto_research_role_profile_v0",
         'loopx --format json auto-research frontier --goal-id "$LOOPX_GOAL_ID" --agent-id "$LOOPX_AGENT_ID"',
         "No role owns the full graph",
@@ -95,6 +95,8 @@ def main() -> int:
         "coordinator owns the graph",
         "promote without evidence",
         "First Commands",
+        "$loopx-project",
+        "$loopx-doc-registry",
     ]
     lowered = compact_skill.lower()
     for term in forbidden_skill_terms:

--- a/examples/generic-multi-agent-runner-kernel-smoke.py
+++ b/examples/generic-multi-agent-runner-kernel-smoke.py
@@ -66,6 +66,20 @@ def main() -> int:
     assert runner["coordination_model"]["leader_required"] is False, runner
     assert runner["pane_local_a2a"]["machine_json_policy"] == "file_or_explicit_machine_channel_only", runner
     assert runner["boundaries"]["domain_specific_research_logic"] is False, runner
+    role_prompt = runner["role_prompt_and_skill"]
+    assert role_prompt["default_kernel_skills"] == ["loopx-project", "loopx-doc-registry"], runner
+    assert (
+        role_prompt["default_kernel_skill_policy"]["owner_layer"]
+        == "generic_multi_agent_kernel"
+    ), runner
+    assert role_prompt["default_kernel_skill_policy"][
+        "preset_should_not_repeat_skill_playbooks"
+    ] is True, runner
+    assert role_prompt["fixed_wake_prompt_owner"] == "generic_multi_agent_kernel", runner
+    assert (
+        runner["decentralized_a2a_driver"]["prompt"]["owner_layer"]
+        == "generic_multi_agent_kernel"
+    ), runner
 
     compact = build_compact_human_status(
         {
@@ -112,7 +126,18 @@ def main() -> int:
     ), layering
     assert layering["user_layer"]["fields"] == ["inbox", "rounds"], layering
     assert "multi_agent_runner" in layering["kernel_layer"]["owns"], layering
+    assert layering["kernel_layer"]["default_skills"] == [
+        "loopx-project",
+        "loopx-doc-registry",
+    ], layering
+    assert layering["kernel_layer"]["fixed_wake_prompt"] == (
+        "PANE_LOCAL_A2A_WAKEUP_PROMPT"
+    ), layering
     assert "pane_local_a2a_tick" in layering["preset_layer"]["forbidden"], layering
+    assert (
+        layering["preset_layer"]["role_skill_limit"]
+        == "role_specific_semantics_and_successor_declarations_only"
+    ), layering
     assert layering["acceptance"]["other_multi_agent_products_can_reuse_kernel"] is True, layering
     assert "LoopX machine JSON hidden" in SCOPED_LOOPX_WRAPPER_PY
     assert "loopx-pane-a2a-tick" in SCOPED_LOOPX_WRAPPER_PY

--- a/loopx/capabilities/auto_research/defaults.py
+++ b/loopx/capabilities/auto_research/defaults.py
@@ -36,6 +36,9 @@ def build_auto_research_layer_contract() -> dict[str, object]:
             "pane_local_a2a_tick",
             "todo_evidence_status_protocol",
             "compact_human_status",
+            "default_loopx_skill_bootstrap",
+            "fixed_a2a_wake_prompt",
+            "kernel_default_skill_prompting",
         ],
         extension_points=[
             "role_overrides",

--- a/loopx/capabilities/auto_research/preset.py
+++ b/loopx/capabilities/auto_research/preset.py
@@ -255,6 +255,9 @@ def auto_research_role_profile(*, role_id: str, goal_id: str, agent_id: str) -> 
         "required_skill": AUTO_RESEARCH_REQUIRED_SKILL,
         "worker_skill_source": AUTO_RESEARCH_WORKER_SKILL_SOURCE,
         "skill_distribution": "worker_local",
+        "worker_skill_scope": "role_specific_semantics_and_successor_todos_only",
+        "default_kernel_skills_owner": "generic_multi_agent_kernel",
+        "fixed_a2a_wake_prompt_owner": "generic_multi_agent_kernel",
         "stop_conditions": [
             "quota says should_run=false or user_action_required=true",
             "frontier has no selected todo for this agent",
@@ -364,7 +367,12 @@ def build_auto_research_preset_summary(*, role_count: int) -> dict[str, object]:
             "pane_local_a2a_tick",
             "todo_evidence_status_protocol",
             "compact_human_status",
+            "default_loopx_skill_bootstrap",
+            "fixed_a2a_wake_prompt",
+            "kernel_default_skill_prompting",
         ],
+        "worker_skill_scope": "role_specific_semantics_and_successor_todos_only",
+        "successor_routing": "role_profile_successor_todos_with_target_agent",
         "role_count": role_count,
         "default_agent_specs": default_auto_research_agent_specs(),
     }

--- a/loopx/capabilities/auto_research/worker_skill/SKILL.md
+++ b/loopx/capabilities/auto_research/worker_skill/SKILL.md
@@ -29,9 +29,10 @@ tmux window name, or the section of this skill that happens to be visible.
 
 ## Pane Tick Contract
 
-The generic multi-agent kernel prompt already points panes at `$loopx-project`
-and `$loopx-doc-registry`. This skill should stay role-specific: use it after
-the pane-local tick has resolved identity, quota, and frontier from LoopX.
+The generic multi-agent kernel owns the default LoopX project/doc-registry
+skills and the fixed A2A wake prompt. This skill should stay role-specific:
+use it after the pane-local tick has resolved identity, quota, and frontier
+from LoopX.
 
 Compact frontier command: `loopx --format json auto-research frontier --goal-id "$LOOPX_GOAL_ID" --agent-id "$LOOPX_AGENT_ID"`. Also honor `quota should-run`.
 

--- a/loopx/capabilities/multi_agent/contract.py
+++ b/loopx/capabilities/multi_agent/contract.py
@@ -169,6 +169,7 @@ def build_decentralized_a2a_driver_contract(
         "driver_model": "fixed_prompt_broadcast_plus_pane_local_state_tick",
         "coordination_pattern": "decentralized_state_a2a",
         "prompt": {
+            "owner_layer": "generic_multi_agent_kernel",
             "trigger": PANE_LOCAL_A2A_WAKEUP_PROMPT,
             "instruction_only": True,
             "frontier_embedded": False,
@@ -290,6 +291,13 @@ def build_tui_multi_agent_runner_contract(
             "bootstrap_prompt": "written_to_public_artifact_for_fixed_wake_context",
             "role_profile": "role-local public json artifact",
             "default_kernel_skills": list(GENERIC_MULTI_AGENT_DEFAULT_KERNEL_SKILLS),
+            "default_kernel_skill_policy": {
+                "owner_layer": "generic_multi_agent_kernel",
+                "injected_via": "generic_role_prompt",
+                "preset_should_not_repeat_skill_playbooks": True,
+                "worker_skill_scope": "role_specific_semantics_and_successor_declarations",
+            },
+            "fixed_wake_prompt_owner": "generic_multi_agent_kernel",
             "skill_materialization": ".codex/skills/<skill>/SKILL.md",
             "worker_local_skill_scope": "role_specific_semantics_only",
         },
@@ -379,10 +387,13 @@ def build_three_layer_minimality_contract(
         "preset_layer": {
             "owns": preset_owns,
             "forbidden": forbidden,
+            "role_skill_limit": "role_specific_semantics_and_successor_declarations_only",
             "must_remain_reusable": True,
         },
         "kernel_layer": {
             "owns": kernel_owns,
+            "default_skills": list(GENERIC_MULTI_AGENT_DEFAULT_KERNEL_SKILLS),
+            "fixed_wake_prompt": "PANE_LOCAL_A2A_WAKEUP_PROMPT",
             "cross_product_reuse_required": True,
         },
         "extension_points": extensions,


### PR DESCRIPTION
## Summary
- Make the generic multi-agent kernel explicitly own default LoopX skills and the fixed A2A wake prompt.
- Mark auto-research preset/role profiles as role-specific only, with successor todo routing declared in role profiles.
- Slim the auto-research worker skill so it no longer carries default LoopX skill prompt details.

## Validation
- `PYTHONPATH=. python3 examples/generic-multi-agent-runner-kernel-smoke.py`
- `PYTHONPATH=. python3 examples/auto-research-skill-contract-smoke.py`
- `PYTHONPATH=. python3 examples/auto-research-demo-supervisor-smoke.py`
- `PYTHONPATH=. python3 examples/auto-research-layered-e2e-acceptance-smoke.py`
- `PYTHONPATH=. python3 examples/auto-research-start-markdown-commands-smoke.py`
- `python3 -m compileall -q loopx/capabilities/multi_agent loopx/capabilities/auto_research examples/generic-multi-agent-runner-kernel-smoke.py examples/auto-research-skill-contract-smoke.py examples/auto-research-demo-supervisor-smoke.py examples/auto-research-layered-e2e-acceptance-smoke.py examples/auto-research-start-markdown-commands-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli auto-research start "KNN demo: prove partial selection improves over full sort"`
- `loopx check --scan-path ...` on changed public files

## Boundary
Public product/runtime contracts and durable smokes only. No private evidence, local state, credentials, or raw logs included.
