### PR TITLE
Guard monitor project asset stop condition

### DIFF
--- a/examples/project/project-asset-next-eye-smoke.py
+++ b/examples/project/project-asset-next-eye-smoke.py
@@ -17,6 +17,8 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.status import (  # noqa: E402
+    MONITOR_DISPLAY_STOP_CONDITION,
+    MONITOR_SIGNAL_WAITING_ON,
     build_project_asset,
     enrich_project_asset,
     project_asset_summary_is_public_safe,
@@ -123,6 +125,23 @@ def assert_status_project_asset_safe_command_contract() -> None:
     assert project_asset_summary_is_public_safe(asset), asset
 
 
+def assert_status_project_asset_monitor_display_contract() -> None:
+    asset = build_project_asset(
+        status="monitor_quiet_skip",
+        waiting_on=MONITOR_SIGNAL_WAITING_ON,
+        recommended_action="No immediate agent work; keep monitoring quietly.",
+        operator_question=None,
+        agent_command=None,
+        missing_gates=None,
+        next_handoff_condition=None,
+    )
+    assert asset["owner"] == MONITOR_SIGNAL_WAITING_ON, asset
+    assert asset["gate"] == "none", asset
+    assert asset["support_mode"] == "read_only_observer", asset
+    assert asset["stop_condition"] == MONITOR_DISPLAY_STOP_CONDITION, asset
+    assert project_asset_summary_is_public_safe(asset), asset
+
+
 def assert_dashboard_first_screen_render_contract() -> None:
     dashboard = (REPO_ROOT / "apps/dashboard/src/views/dashboard-page.tsx").read_text(
         encoding="utf-8"
@@ -146,6 +165,7 @@ def assert_dashboard_first_screen_render_contract() -> None:
 def main() -> int:
     assert_status_project_asset_next_eye()
     assert_status_project_asset_safe_command_contract()
+    assert_status_project_asset_monitor_display_contract()
     assert_dashboard_first_screen_render_contract()
     print("project-asset-next-eye-smoke ok")
     return 0

--- a/loopx/projections/project_asset.py
+++ b/loopx/projections/project_asset.py
@@ -6,7 +6,7 @@ from typing import Any
 DEFAULT_MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE = 12
 DEFAULT_MONITOR_SIGNAL_WAITING_ON = "monitor_signal"
 DEFAULT_MONITOR_DISPLAY_STOP_CONDITION = (
-    "keep monitoring quietly until the observed signal changes or a user/controller gate appears"
+    "stop until a material monitor transition, regression, or concrete blocker appears"
 )
 
 


### PR DESCRIPTION
## Summary

- restore the monitor project-asset stop condition text to the existing canonical monitor display contract
- add a focused `project-asset-next-eye` characterization for `waiting_on=monitor_signal`
- prevent future project-asset projection helper moves from silently changing monitor quiet display semantics

## Validation

- `python3 -m compileall -q loopx`
- `python3 examples/project/project-asset-next-eye-smoke.py`
- `python3 examples/control_plane/status-watch-routing-attribute-smoke.py`
- `python3 examples/control_plane/monitor-scheduler-contract-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --profile core-control-plane` (122/122 passed)
- `git diff --check`

## Notes

This is a focused follow-up to the project-asset projection extraction. It fixes a monitor display default drift and adds the missing characterization. No private state, raw logs, benchmark evidence, or local artifacts are included.
