### PR TITLE
Extract project asset summary helpers

### DIFF
--- a/loopx/projections/project_asset.py
+++ b/loopx/projections/project_asset.py
@@ -10,6 +10,13 @@ DEFAULT_MONITOR_DISPLAY_STOP_CONDITION = (
 )
 
 
+def _compact_text(text: str, *, limit: int) -> str:
+    compact = " ".join(text.strip().split())
+    if len(compact) <= limit:
+        return compact
+    return compact[: limit - 1].rstrip() + "…"
+
+
 def completed_todo_archive_warning(
     agent_todos: dict[str, Any] | None,
     *,
@@ -126,3 +133,31 @@ def project_asset_support_mode(
     if agent_command or waiting_on == "codex":
         return "selective_assist"
     return "read_only_observer"
+
+
+def project_asset_quota_summary(quota: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(quota, dict):
+        return None
+    summary: dict[str, Any] = {
+        "compute": quota.get("compute"),
+        "state": quota.get("state"),
+        "spent_slots": quota.get("spent_slots"),
+        "allowed_slots": quota.get("allowed_slots"),
+    }
+    if quota.get("reason"):
+        summary["reason"] = _compact_text(str(quota.get("reason") or ""), limit=220)
+    return summary
+
+
+def project_asset_latest_validation(run: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(run, dict):
+        return None
+    signal: dict[str, Any] = {}
+    for field in ("generated_at", "classification"):
+        value = run.get(field)
+        if value:
+            signal[field] = value
+    summary = run.get("health_check") or run.get("recommended_action")
+    if summary:
+        signal["summary"] = _compact_text(str(summary), limit=260)
+    return signal or None

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -62,7 +62,9 @@ from .projections.task_graph import (
 from .projections.project_asset import (
     completed_todo_archive_warning,
     project_asset_gate,
+    project_asset_latest_validation,
     project_asset_owner,
+    project_asset_quota_summary,
     project_asset_stop_condition,
     project_asset_support_mode,
 )
@@ -7655,34 +7657,6 @@ def autonomous_monitor_candidates(
         allowed_waiting_on={"codex", MONITOR_SIGNAL_WAITING_ON},
         limit=limit,
     )
-
-
-def project_asset_quota_summary(quota: dict[str, Any] | None) -> dict[str, Any] | None:
-    if not isinstance(quota, dict):
-        return None
-    summary: dict[str, Any] = {
-        "compute": quota.get("compute"),
-        "state": quota.get("state"),
-        "spent_slots": quota.get("spent_slots"),
-        "allowed_slots": quota.get("allowed_slots"),
-    }
-    if quota.get("reason"):
-        summary["reason"] = normalize_todo_text(str(quota.get("reason") or ""), limit=220)
-    return summary
-
-
-def project_asset_latest_validation(run: dict[str, Any] | None) -> dict[str, Any] | None:
-    if not isinstance(run, dict):
-        return None
-    signal: dict[str, Any] = {}
-    for field in ("generated_at", "classification"):
-        value = run.get(field)
-        if value:
-            signal[field] = value
-    summary = run.get("health_check") or run.get("recommended_action")
-    if summary:
-        signal["summary"] = normalize_todo_text(str(summary), limit=260)
-    return signal or None
 
 
 def _subagent_state(run: dict[str, Any]) -> str | None:


### PR DESCRIPTION
## Summary

- move `project_asset_quota_summary` and `project_asset_latest_validation` from `status.py` into `loopx/projections/project_asset.py`
- keep `status.py` as the read-path composition layer while continuing the canary-gated project-asset projection cleanup
- add a local projection text compactor to avoid a reverse import from projection helpers back into `status.py`

## Validation

- `python3 -m compileall -q loopx`
- `python3 examples/project/project-asset-next-eye-smoke.py`
- `python3 examples/derived-state-boundary-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --profile core-control-plane` (122/122 passed)
- `git diff --check`

## Notes

No private state, raw logs, benchmark evidence, or generated artifacts are included.
