### PR TITLE
Extract project asset surface safety helper

### DIFF
--- a/loopx/projections/project_asset.py
+++ b/loopx/projections/project_asset.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from typing import Any
 
 
@@ -7,6 +8,14 @@ DEFAULT_MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE = 12
 DEFAULT_MONITOR_SIGNAL_WAITING_ON = "monitor_signal"
 DEFAULT_MONITOR_DISPLAY_STOP_CONDITION = (
     "stop until a material monitor transition, regression, or concrete blocker appears"
+)
+LOCAL_PATH_SURFACE_PATTERN = re.compile(
+    r"(?<!<)/(?:Users|Volumes|var/folders|tmp|private/tmp)/[^\s`'\"<>]+"
+)
+SECRET_LIKE_SURFACE_PATTERN = re.compile(
+    r"(?i)(?:\bbearer\s+[a-z0-9._~+/=-]{16,}|"
+    r"(?<![a-z0-9_])(?:ak|sk)[-_=:][a-z0-9_=-]{10,}|"
+    r"\btoken\s*[=:]\s*[^\s`'\"<>]{12,})"
 )
 
 
@@ -161,3 +170,8 @@ def project_asset_latest_validation(run: dict[str, Any] | None) -> dict[str, Any
     if summary:
         signal["summary"] = _compact_text(str(summary), limit=260)
     return signal or None
+
+
+def project_asset_summary_is_public_safe(project_asset: dict[str, Any]) -> bool:
+    text = repr(project_asset)
+    return not LOCAL_PATH_SURFACE_PATTERN.search(text) and not SECRET_LIKE_SURFACE_PATTERN.search(text)

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -60,11 +60,14 @@ from .projections.task_graph import (
     build_task_graph_projection as _build_task_graph_projection_read_model,
 )
 from .projections.project_asset import (
+    LOCAL_PATH_SURFACE_PATTERN,
+    SECRET_LIKE_SURFACE_PATTERN,
     completed_todo_archive_warning,
     project_asset_gate,
     project_asset_latest_validation,
     project_asset_owner,
     project_asset_quota_summary,
+    project_asset_summary_is_public_safe,
     project_asset_stop_condition,
     project_asset_support_mode,
 )
@@ -427,10 +430,6 @@ LIFECYCLE_PRIORITY = (
     "run_recorded",
 )
 SECTION_HEADING_PATTERN = re.compile(r"^##+\s+(.+?)\s*$")
-LOCAL_PATH_SURFACE_PATTERN = re.compile(r"(?<!<)/(?:Users|Volumes|var/folders|tmp|private/tmp)/[^\s`'\"<>]+")
-SECRET_LIKE_SURFACE_PATTERN = re.compile(
-    r"(?i)(?:\bbearer\s+[a-z0-9._~+/=-]{16,}|(?<![a-z0-9_])(?:ak|sk)[-_=:][a-z0-9_=-]{10,}|\btoken\s*[=:]\s*[^\s`'\"<>]{12,})"
-)
 USER_TODO_HEADER_MARKERS = (
     "user todo",
     "owner review reading queue",
@@ -7867,11 +7866,6 @@ def active_state_projection_warning(goal: dict[str, Any], current_run: dict[str,
         "latest_run_classification": current_run.get("classification"),
         "recommended_action": "run refresh-state before trusting latest_run-derived routing",
     }
-
-
-def project_asset_summary_is_public_safe(project_asset: dict[str, Any]) -> bool:
-    text = repr(project_asset)
-    return not LOCAL_PATH_SURFACE_PATTERN.search(text) and not SECRET_LIKE_SURFACE_PATTERN.search(text)
 
 
 def is_handoff_ready_run(run: dict[str, Any]) -> bool:


### PR DESCRIPTION
## Summary\n- move project asset surface-safety regexes and helper into loopx.projections.project_asset\n- keep loopx.status as the compatibility import surface while reusing the projection helper\n\n## Validation\n- python3 -m compileall -q loopx\n- python3 examples/project/project-asset-next-eye-smoke.py\n- python3 examples/project/subagent-status-projection-smoke.py\n- python3 examples/issue-meta-surface-smoke.py\n- python3 examples/control_plane/status-markdown-smoke.py\n- python3 examples/derived-state-boundary-smoke.py\n- python3 examples/control_plane/repo-python-line-budget-smoke.py\n- PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --profile core-control-plane (122/122)\n- git diff --check