### PR TITLE
Allow SkillsBench egress auto direct fallback

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -1382,8 +1382,11 @@ standard proxy variables only to the private BenchFlow subprocess and agent
 environment, runs a bounded HTTP CONNECT preflight, and records only
 source/scheme/endpoint-kind/port plus `proxy_url_recorded=false` in public
 artifacts. Use `--benchmark-egress-proxy-mode require` when the run must fail
-fast without that private proxy, and `--benchmark-egress-proxy-mode off` only
-for explicit no-proxy debugging.
+fast without that private proxy. The default `auto` mode validates a configured
+proxy first, but if that proxy is unavailable and direct egress to the public
+test host is reachable, the runner records a direct fallback and does not inject
+the stale proxy into the benchmark runtime. Use `--benchmark-egress-proxy-mode
+off` only for explicit no-proxy debugging.
 
 Keep upstream benchmark sources clean:
 

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -541,6 +541,70 @@ def test_benchmark_egress_proxy_require_mode_blocks_without_proxy() -> None:
                 os.environ["LOOPX_SKILLSBENCH_EGRESS_PROXY"] = previous
 
 
+def test_benchmark_egress_proxy_auto_falls_back_to_direct_without_leaking_proxy() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-benchmark-egress-auto-direct-") as tmp:
+        root = Path(tmp)
+        skillsbench_root = root / "skillsbench"
+        task_dir = skillsbench_root / "tasks" / "citation-check"
+        task_dir.mkdir(parents=True)
+        (task_dir / "task.toml").write_text("version = \"1.1\"\n", encoding="utf-8")
+
+        proxy_url = "http://benchmark-proxy.example.invalid:18080"
+        previous = os.environ.get("LOOPX_SKILLSBENCH_EGRESS_PROXY")
+        previous_proxy_probe = skillsbench_loop._probe_http_connect_proxy
+        previous_direct_probe = skillsbench_loop._probe_direct_tcp_egress
+        os.environ["LOOPX_SKILLSBENCH_EGRESS_PROXY"] = proxy_url
+        try:
+            skillsbench_loop._probe_http_connect_proxy = (  # type: ignore[assignment]
+                lambda **_kwargs: "proxy_connect_rejected"
+            )
+            skillsbench_loop._probe_direct_tcp_egress = (  # type: ignore[assignment]
+                lambda **_kwargs: "direct_tcp_ready"
+            )
+            args = parse_args(
+                [
+                    "--task-id",
+                    "citation-check",
+                    "--benchmark-egress-proxy-mode",
+                    "auto",
+                    "--skillsbench-root",
+                    str(skillsbench_root),
+                    "--jobs-dir",
+                    str(root / "jobs"),
+                ]
+            )
+            plan = build_plan(args)
+            egress = skillsbench_loop._run_benchmark_egress_proxy_preflight(args, plan)
+
+            assert egress["ready"] is True, egress
+            assert egress["status"] == "direct_tcp_ready_after_proxy_failure", egress
+            assert egress["effective_mode"] == "direct", egress
+            assert egress["direct_fallback_allowed"] is True, egress
+            assert egress["direct_fallback_active"] is True, egress
+            assert egress["proxy_url_recorded"] is False, egress
+            assert egress["raw_proxy_url_recorded"] is False, egress
+            assert proxy_url not in json.dumps(plan, sort_keys=True), plan
+
+            private_env = skillsbench_loop._benchmark_egress_proxy_env(args)
+            assert private_env == {}, private_env
+            target_env = skillsbench_loop._host_local_acp_target_env({}, args=args)
+            for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY"):
+                assert target_env.get(key) != proxy_url, target_env
+
+            prereqs = plan["runner_prerequisites"]
+            assert prereqs["benchmark_egress_proxy_ready"] is True, prereqs
+            assert prereqs["benchmark_egress_proxy_mode_requested"] == "auto", prereqs
+            assert prereqs["benchmark_egress_proxy_mode_effective"] == "direct", prereqs
+            assert prereqs["benchmark_egress_direct_fallback_active"] is True, prereqs
+        finally:
+            skillsbench_loop._probe_http_connect_proxy = previous_proxy_probe  # type: ignore[assignment]
+            skillsbench_loop._probe_direct_tcp_egress = previous_direct_probe  # type: ignore[assignment]
+            if previous is None:
+                os.environ.pop("LOOPX_SKILLSBENCH_EGRESS_PROXY", None)
+            else:
+                os.environ["LOOPX_SKILLSBENCH_EGRESS_PROXY"] = previous
+
+
 def test_codex_app_server_goal_rejects_non_http_codex_api_proxy_scheme() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-codex-api-proxy-scheme-") as tmp:
         root = Path(tmp)
@@ -14640,6 +14704,7 @@ if __name__ == "__main__":
     test_codex_app_server_goal_blocks_without_codex_api_egress()
     test_benchmark_egress_proxy_env_is_public_safe_and_forwarded()
     test_benchmark_egress_proxy_require_mode_blocks_without_proxy()
+    test_benchmark_egress_proxy_auto_falls_back_to_direct_without_leaking_proxy()
     test_skillsbench_plan_only_batch_parallel_case_contract()
     test_skillsbench_formal_product_mode_rejects_tiny_round_budget()
     test_skillsbench_product_mode_soft_verify_default_is_every_round()

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -1592,6 +1592,17 @@ def _probe_http_connect_proxy(
     return "proxy_connect_rejected"
 
 
+def _probe_direct_tcp_egress(
+    *,
+    host: str,
+    port: int,
+    timeout_sec: float,
+) -> str:
+    with socket.create_connection((host, port), timeout=timeout_sec):
+        pass
+    return "direct_tcp_ready"
+
+
 def _run_codex_api_egress_preflight(
     args: argparse.Namespace,
     plan: dict[str, Any],
@@ -1640,12 +1651,11 @@ def _run_codex_api_egress_preflight(
                     status = "unsupported_proxy_scheme"
                     ready = False
         elif mode == "direct":
-            with socket.create_connection(
-                (CODEX_API_EGRESS_TEST_HOST, CODEX_API_EGRESS_TEST_PORT),
-                timeout=timeout_sec,
-            ):
-                pass
-            status = "direct_tcp_ready"
+            status = _probe_direct_tcp_egress(
+                host=CODEX_API_EGRESS_TEST_HOST,
+                port=CODEX_API_EGRESS_TEST_PORT,
+                timeout_sec=timeout_sec,
+            )
             ready = True
         else:
             status = "unsupported_egress_mode"
@@ -1753,6 +1763,11 @@ def _public_benchmark_egress_proxy_contract(
     return {
         "schema_version": "skillsbench_benchmark_egress_proxy_v0",
         "requested_mode": proxy_mode,
+        "effective_mode": (
+            "direct"
+            if status == "direct_tcp_ready_after_proxy_failure"
+            else ("proxy" if ready and configured and proxy_mode != "off" else proxy_mode)
+        ),
         "ready": bool(ready),
         "status": status,
         "error_kind": error_kind or parse_error,
@@ -1775,6 +1790,8 @@ def _public_benchmark_egress_proxy_contract(
         "proxy_url_recorded": False,
         "raw_proxy_url_recorded": False,
         "raw_probe_output_recorded": False,
+        "direct_fallback_allowed": proxy_mode == "auto",
+        "direct_fallback_active": status == "direct_tcp_ready_after_proxy_failure",
         "test_host": BENCHMARK_EGRESS_TEST_HOST,
         "test_host_public_only": True,
     }
@@ -1800,6 +1817,7 @@ def _run_benchmark_egress_proxy_preflight(
     status = "pending"
     ready = False
     error_kind = ""
+    direct_fallback_active = False
     try:
         if proxy_mode == "off":
             status = "disabled"
@@ -1827,10 +1845,38 @@ def _run_benchmark_egress_proxy_preflight(
                     target_port=BENCHMARK_EGRESS_TEST_PORT,
                 )
                 ready = status == "http_connect_ready"
+                if not ready and proxy_mode == "auto":
+                    fallback_status = _probe_direct_tcp_egress(
+                        host=BENCHMARK_EGRESS_TEST_HOST,
+                        port=BENCHMARK_EGRESS_TEST_PORT,
+                        timeout_sec=timeout_sec,
+                    )
+                    if fallback_status == "direct_tcp_ready":
+                        status = "direct_tcp_ready_after_proxy_failure"
+                        ready = True
+                        direct_fallback_active = True
     except Exception as exc:
         status = "failed"
         ready = False
         error_kind = type(exc).__name__
+        if proxy_mode == "auto":
+            try:
+                fallback_status = _probe_direct_tcp_egress(
+                    host=BENCHMARK_EGRESS_TEST_HOST,
+                    port=BENCHMARK_EGRESS_TEST_PORT,
+                    timeout_sec=timeout_sec,
+                )
+                if fallback_status == "direct_tcp_ready":
+                    status = "direct_tcp_ready_after_proxy_failure"
+                    ready = True
+                    direct_fallback_active = True
+            except Exception:
+                pass
+    setattr(
+        args,
+        "_benchmark_egress_proxy_direct_fallback_active",
+        direct_fallback_active,
+    )
     contract = _public_benchmark_egress_proxy_contract(
         args,
         status=status,
@@ -1867,6 +1913,15 @@ def _sync_benchmark_egress_proxy_contract(
     target["benchmark_egress_proxy_mode_requested"] = str(
         contract.get("requested_mode") or ""
     )
+    target["benchmark_egress_proxy_mode_effective"] = str(
+        contract.get("effective_mode") or ""
+    )
+    target["benchmark_egress_direct_fallback_allowed"] = bool(
+        contract.get("direct_fallback_allowed")
+    )
+    target["benchmark_egress_direct_fallback_active"] = bool(
+        contract.get("direct_fallback_active")
+    )
     target["benchmark_egress_proxy_source"] = str(
         contract.get("proxy_source") or ""
     )
@@ -1900,6 +1955,8 @@ def _sync_benchmark_egress_proxy_contract(
 
 def _benchmark_egress_proxy_env(args: argparse.Namespace | None) -> dict[str, str]:
     if args is None or _benchmark_egress_proxy_requested_mode(args) == "off":
+        return {}
+    if getattr(args, "_benchmark_egress_proxy_direct_fallback_active", False):
         return {}
     proxy_url, _source = _benchmark_egress_proxy(args)
     if not proxy_url:
@@ -2715,6 +2772,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchmark_egress_proxy_status",
         "benchmark_egress_proxy_error_kind",
         "benchmark_egress_proxy_mode_requested",
+        "benchmark_egress_proxy_mode_effective",
         "benchmark_egress_proxy_source",
         "benchmark_egress_proxy_env_key",
         "benchmark_egress_proxy_scheme",
@@ -2754,6 +2812,8 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchmark_egress_proxy_configured",
         "benchmark_egress_proxy_required",
         "benchmark_egress_proxy_url_recorded",
+        "benchmark_egress_direct_fallback_allowed",
+        "benchmark_egress_direct_fallback_active",
         "benchmark_egress_no_proxy_configured",
         "benchmark_egress_no_proxy_raw_value_recorded",
         "benchmark_egress_proxy_agent_env_injected",
@@ -8976,6 +9036,8 @@ def _public_runner_config(plan: dict[str, Any]) -> dict[str, Any]:
             "benchmark_egress_proxy_configured",
             "benchmark_egress_proxy_required",
             "benchmark_egress_proxy_url_recorded",
+            "benchmark_egress_direct_fallback_allowed",
+            "benchmark_egress_direct_fallback_active",
             "benchmark_egress_no_proxy_configured",
             "benchmark_egress_no_proxy_raw_value_recorded",
             "benchmark_egress_proxy_agent_env_injected",
@@ -8997,6 +9059,7 @@ def _public_runner_config(plan: dict[str, Any]) -> dict[str, Any]:
             "benchmark_egress_proxy_status",
             "benchmark_egress_proxy_error_kind",
             "benchmark_egress_proxy_mode_requested",
+            "benchmark_egress_proxy_mode_effective",
             "benchmark_egress_proxy_source",
             "benchmark_egress_proxy_env_key",
             "benchmark_egress_proxy_scheme",


### PR DESCRIPTION
## Summary
- add a direct TCP egress probe and let SkillsBench benchmark-egress proxy mode auto fall back to direct egress when a configured proxy is unavailable but direct access is verified
- prevent stale proxy env injection after direct fallback and project fallback state into public runner prerequisites/config
- document auto/require/off semantics and add a focused public-safe smoke

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py
- targeted benchmark-egress smokes: env forwarding, require-mode block, auto direct fallback
- loopx check --scan-path scripts/skillsbench_automation_loop.py --scan-path examples/skillsbench-benchmark-run-smoke.py --scan-path docs/benchmark-developer-workflow.md

## Boundary
- no real proxy endpoint, local path, raw trajectory, verifier output, or private run artifact is committed
- require mode remains fail-closed; only auto mode can direct-fallback after a successful public test-host probe