### PR TITLE
Filter internal aggregate flag from SkillsBench batch children

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -773,6 +773,34 @@ def test_skillsbench_plan_only_batch_parallel_case_contract() -> None:
         ] is True, result
 
 
+def test_skillsbench_batch_case_cli_filters_internal_aggregate_flag() -> None:
+    args = parse_args(
+        [
+            "--task-ids",
+            "citation-check,3d-scan-calc",
+            "--parallel-cases",
+            "2",
+            "--route",
+            "codex-app-server-goal-baseline",
+            "--update-ledger",
+            "--plan-only",
+        ]
+    )
+    case_args = skillsbench_loop._clone_args_for_batch_case(
+        args,
+        task_id="citation-check",
+        index=0,
+        total=2,
+        run_group_id="skillsbench-batch-cli-fixture",
+    )
+    child_cli = skillsbench_loop._batch_case_args_to_cli(case_args)
+
+    assert "--update-current-aggregate" not in child_cli, child_cli
+    assert "--skip-current-aggregate-update" not in child_cli, child_cli
+    assert "--current-aggregate-path" in child_cli, child_cli
+    assert child_cli[child_cli.index("--parallel-cases") + 1] == "1", child_cli
+
+
 def test_skillsbench_formal_product_mode_rejects_tiny_round_budget() -> None:
     try:
         with contextlib.redirect_stderr(io.StringIO()):
@@ -14706,6 +14734,7 @@ if __name__ == "__main__":
     test_benchmark_egress_proxy_require_mode_blocks_without_proxy()
     test_benchmark_egress_proxy_auto_falls_back_to_direct_without_leaking_proxy()
     test_skillsbench_plan_only_batch_parallel_case_contract()
+    test_skillsbench_batch_case_cli_filters_internal_aggregate_flag()
     test_skillsbench_formal_product_mode_rejects_tiny_round_budget()
     test_skillsbench_product_mode_soft_verify_default_is_every_round()
     test_reverse_channel_first_action_timeout_stops_codex_process()

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -16073,6 +16073,7 @@ BATCH_CASE_INTERNAL_ARG_KEYS = frozenset(
     {
         "apt_risk_fail_fast_defaulted",
         "bootstrap_light_fail_fast_defaulted",
+        "update_current_aggregate",
         "verifier_bootstrap_fail_fast_defaulted",
     }
 )


### PR DESCRIPTION
## Summary
- exclude the internal current-aggregate update boolean from SkillsBench batch child argv
- add a focused smoke asserting child argv does not emit the unrecognized aggregate flag and still forces child parallelism to 1

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py
- targeted batch smokes: plan-only parallel case contract and child argv filter
- reproduced the 5-case parallel plan-only command; it now returns ok=true instead of child payload errors
- loopx check on changed runner and smoke paths

## Boundary
- no real proxy endpoint, raw trajectory, verifier output, local/private run artifact, or task text is committed