### PR TITLE
Extract project asset safe command helper

### DIFF
--- a/loopx/projections/project_asset.py
+++ b/loopx/projections/project_asset.py
@@ -26,6 +26,15 @@ def _compact_text(text: str, *, limit: int) -> str:
     return compact[: limit - 1].rstrip() + "…"
 
 
+def project_asset_public_safe_compact_text(value: Any, *, limit: int = 220) -> str | None:
+    text = _compact_text(str(value or ""), limit=limit)
+    if not text:
+        return None
+    if LOCAL_PATH_SURFACE_PATTERN.search(text) or SECRET_LIKE_SURFACE_PATTERN.search(text):
+        return None
+    return text
+
+
 def completed_todo_archive_warning(
     agent_todos: dict[str, Any] | None,
     *,
@@ -175,3 +184,9 @@ def project_asset_latest_validation(run: dict[str, Any] | None) -> dict[str, Any
 def project_asset_summary_is_public_safe(project_asset: dict[str, Any]) -> bool:
     text = repr(project_asset)
     return not LOCAL_PATH_SURFACE_PATTERN.search(text) and not SECRET_LIKE_SURFACE_PATTERN.search(text)
+
+
+def project_asset_next_safe_command(agent_command: str | None) -> str | None:
+    if not agent_command:
+        return None
+    return project_asset_public_safe_compact_text(agent_command, limit=320)

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -65,6 +65,7 @@ from .projections.project_asset import (
     completed_todo_archive_warning,
     project_asset_gate,
     project_asset_latest_validation,
+    project_asset_next_safe_command,
     project_asset_owner,
     project_asset_quota_summary,
     project_asset_summary_is_public_safe,
@@ -7299,12 +7300,6 @@ def autonomous_replan_obligation_from_runs(
         }
     ]
     return build_autonomous_replan_obligation(evidence, agent_todos=agent_todos)
-
-
-def project_asset_next_safe_command(agent_command: str | None) -> str | None:
-    if not agent_command:
-        return None
-    return public_safe_compact_text(agent_command, limit=320)
 
 
 def open_todo_items(


### PR DESCRIPTION
## Summary\n- move project asset safe-command compacting into loopx.projections.project_asset\n- keep loopx.status as a compatibility import surface\n- reuse the same project-asset public-safety regexes for the command projection\n\n## Validation\n- python3 -m compileall -q loopx\n- python3 examples/project/project-asset-next-eye-smoke.py\n- python3 examples/issue-meta-surface-smoke.py\n- python3 examples/control_plane/status-markdown-smoke.py\n- python3 examples/project/subagent-status-projection-smoke.py\n- python3 examples/control_plane/repo-python-line-budget-smoke.py (passed before rebasing; after rebasing onto origin/main it fails due inherited #1252 SkillsBench line-budget baseline, reproduced on clean origin/main and unrelated to this diff)\n- PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --profile core-control-plane (122/122 before rebasing; after rebasing, inherited line-budget baseline is red on clean origin/main)\n- git diff --check\n\n## Inherited baseline note\nClean origin/main at #1252 currently fails examples/control_plane/repo-python-line-budget-smoke.py for examples/skillsbench-benchmark-run-smoke.py and scripts/skillsbench_automation_loop.py. This PR does not touch those files.