### PR TITLE
Extract project asset builder helper

### DIFF
--- a/loopx/projections/project_asset.py
+++ b/loopx/projections/project_asset.py
@@ -195,6 +195,45 @@ def project_asset_next_safe_command(agent_command: str | None) -> str | None:
     return project_asset_public_safe_compact_text(agent_command, limit=320)
 
 
+def build_project_asset(
+    *,
+    status: str,
+    waiting_on: str,
+    recommended_action: str,
+    operator_question: str | None,
+    agent_command: str | None,
+    missing_gates: list[str] | None,
+    next_handoff_condition: str | None,
+) -> dict[str, Any]:
+    asset = {
+        "owner": project_asset_owner(waiting_on),
+        "gate": project_asset_gate(
+            waiting_on=waiting_on,
+            operator_question=operator_question,
+            missing_gates=missing_gates,
+            status=status,
+        ),
+        "support_mode": project_asset_support_mode(
+            waiting_on=waiting_on,
+            operator_question=operator_question,
+            missing_gates=missing_gates,
+            status=status,
+            recommended_action=recommended_action,
+            agent_command=agent_command,
+        ),
+        "next_action": recommended_action,
+        "stop_condition": project_asset_stop_condition(
+            waiting_on=waiting_on,
+            next_handoff_condition=next_handoff_condition,
+            agent_command=agent_command,
+        ),
+    }
+    next_safe_command = project_asset_next_safe_command(agent_command)
+    if next_safe_command:
+        asset["next_safe_command"] = next_safe_command
+    return asset
+
+
 def project_asset_todo_projection_metadata(
     *,
     role: str | None,

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -65,15 +65,11 @@ from .projections.project_asset import (
     SECRET_LIKE_SURFACE_PATTERN,
     TODO_PROJECTION_DETAIL_POINTER_SCHEMA_VERSION,
     TODO_PROJECTION_VIEW_SCHEMA_VERSION,
+    build_project_asset,
     completed_todo_archive_warning,
-    project_asset_gate,
     project_asset_latest_validation,
-    project_asset_next_safe_command,
-    project_asset_owner,
     project_asset_quota_summary,
     project_asset_summary_is_public_safe,
-    project_asset_stop_condition,
-    project_asset_support_mode,
     project_asset_todo_projection_metadata,
     project_asset_todo_projection_gap,
 )
@@ -8238,45 +8234,6 @@ def enrich_project_asset(
     )
     project_asset["long_task_cadence_hint"] = cadence_hint
     item["long_task_cadence_hint"] = cadence_hint
-
-
-def build_project_asset(
-    *,
-    status: str,
-    waiting_on: str,
-    recommended_action: str,
-    operator_question: str | None,
-    agent_command: str | None,
-    missing_gates: list[str] | None,
-    next_handoff_condition: str | None,
-) -> dict[str, Any]:
-    asset = {
-        "owner": project_asset_owner(waiting_on),
-        "gate": project_asset_gate(
-            waiting_on=waiting_on,
-            operator_question=operator_question,
-            missing_gates=missing_gates,
-            status=status,
-        ),
-        "support_mode": project_asset_support_mode(
-            waiting_on=waiting_on,
-            operator_question=operator_question,
-            missing_gates=missing_gates,
-            status=status,
-            recommended_action=recommended_action,
-            agent_command=agent_command,
-        ),
-        "next_action": recommended_action,
-        "stop_condition": project_asset_stop_condition(
-            waiting_on=waiting_on,
-            next_handoff_condition=next_handoff_condition,
-            agent_command=agent_command,
-        ),
-    }
-    next_safe_command = project_asset_next_safe_command(agent_command)
-    if next_safe_command:
-        asset["next_safe_command"] = next_safe_command
-    return asset
 
 
 def active_state_todo_fields(


### PR DESCRIPTION
## Summary
- move `build_project_asset` from `loopx.status` into `loopx.projections.project_asset`
- keep the existing status import surface and call sites intact
- remove now-unused project-asset helper imports from `status.py`

## Validation
- python3 -m compileall -q loopx
- python3 examples/project/project-asset-next-eye-smoke.py
- python3 examples/project/project-asset-todo-projection-gap-smoke.py
- python3 examples/control_plane/status-markdown-smoke.py
- python3 examples/control_plane/status-quota-review-packet-parity-smoke.py
- PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --script examples/project/project-asset-next-eye-smoke.py
- PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --script examples/project/project-asset-todo-projection-gap-smoke.py
- PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --script examples/control_plane/status-markdown-smoke.py
- PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --script examples/control_plane/status-quota-review-packet-parity-smoke.py
- git diff --check

## Known baseline
- python3 examples/control_plane/repo-python-line-budget-smoke.py remains red on inherited SkillsBench benchmark files: examples/skillsbench-benchmark-run-smoke.py and scripts/skillsbench_automation_loop.py. This PR does not touch benchmark files and reduces status.py by moving a pure helper to the projection module.
