### PR TITLE
Extract project asset handoff check helper

### DIFF
--- a/examples/live-project-asset-handoff-readiness.py
+++ b/examples/live-project-asset-handoff-readiness.py
@@ -28,12 +28,23 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument("--goal-id", required=True, help="Live goal id to check.")
     parser.add_argument(
+        "--agent-id",
+        help=(
+            "Registered agent id to use for identity-scoped status, quota, "
+            "and handoff packet checks."
+        ),
+    )
+    parser.add_argument(
         "--registry",
         default=str(Path.home() / ".codex" / "loopx" / "registry.global.json"),
         help="LoopX registry path. Defaults to the shared global registry.",
     )
     parser.add_argument("--runtime-root", help="Optional LoopX runtime root.")
     return parser.parse_args()
+
+
+def agent_id_args(args: argparse.Namespace) -> list[str]:
+    return ["--agent-id", args.agent_id] if args.agent_id else []
 
 
 def run_loopx(args: argparse.Namespace, *command: str) -> dict[str, Any]:
@@ -68,7 +79,15 @@ def assert_public_safe_text(text: str, *, label: str) -> None:
 
 
 def assert_project_asset_handoff(args: argparse.Namespace) -> dict[str, Any]:
-    status_payload = run_loopx(args, "status", "--limit", "20")
+    status_payload = run_loopx(
+        args,
+        "status",
+        "--limit",
+        "20",
+        "--goal-id",
+        args.goal_id,
+        *agent_id_args(args),
+    )
     assert status_payload.get("ok") is True, status_payload
     item = attention_item(status_payload, args.goal_id)
     project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
@@ -91,10 +110,35 @@ def assert_project_asset_handoff(args: argparse.Namespace) -> dict[str, Any]:
     ):
         assert checks.get(check) is True, readiness
 
-    should_run = run_loopx(args, "quota", "should-run", "--goal-id", args.goal_id)
+    should_run = run_loopx(
+        args,
+        "quota",
+        "should-run",
+        "--goal-id",
+        args.goal_id,
+        *agent_id_args(args),
+    )
     assert should_run.get("ok") is True, should_run
     assert should_run.get("project_asset_source") == "project_asset", should_run
-    assert should_run.get("recommended_action") == project_asset.get("next_action"), should_run
+    agent_lane_next_action = (
+        item.get("agent_lane_next_action")
+        if isinstance(item.get("agent_lane_next_action"), dict)
+        else {}
+    )
+    expected_action = project_asset.get("next_action")
+    if args.agent_id and agent_lane_next_action:
+        expected_action = agent_lane_next_action.get("text")
+        should_run_agent_lane = (
+            should_run.get("agent_lane_next_action")
+            if isinstance(should_run.get("agent_lane_next_action"), dict)
+            else {}
+        )
+        assert should_run_agent_lane.get("todo_id") == agent_lane_next_action.get("todo_id"), should_run
+        assert str(should_run.get("recommended_action") or "").startswith(
+            str(expected_action or "")[:200]
+        ), should_run
+    else:
+        assert should_run.get("recommended_action") == expected_action, should_run
     assert should_run.get("state") == project_asset.get("quota", {}).get("state"), should_run
     assert should_run.get("quota", {}).get("compute") == project_asset.get("quota", {}).get("compute"), should_run
     assert should_run.get("goal_boundary", {}).get("stop_condition") == project_asset.get("stop_condition"), should_run
@@ -111,10 +155,23 @@ def assert_project_asset_handoff(args: argparse.Namespace) -> dict[str, Any]:
         if not asset_todos:
             continue
         summary = should_run.get(summary_key) if isinstance(should_run.get(summary_key), dict) else {}
+        if args.agent_id and field == "agent_todos":
+            assert summary.get("current_agent_claimed_open_count") is not None, should_run
+            assert summary.get("claim_scope", {}).get("agent_id") == args.agent_id, should_run
+            continue
         assert summary.get("open_count") == asset_todos.get("open"), should_run
         assert summary.get("total_count") == asset_todos.get("total"), should_run
 
-    handoff = run_loopx(args, "review-packet", "--goal-id", args.goal_id, "--handoff-only", "--limit", "20")
+    handoff = run_loopx(
+        args,
+        "review-packet",
+        "--goal-id",
+        args.goal_id,
+        "--handoff-only",
+        "--limit",
+        "20",
+        *agent_id_args(args),
+    )
     assert handoff.get("ok") is True, handoff
     assert handoff.get("handoff_only") is True, handoff
     handoff_text = str(handoff.get("handoff_text") or "")

--- a/loopx/projections/project_asset.py
+++ b/loopx/projections/project_asset.py
@@ -12,6 +12,13 @@ DEFAULT_MONITOR_DISPLAY_STOP_CONDITION = (
 TODO_PROJECTION_VIEW_SCHEMA_VERSION = "todo_projection_view_v0"
 TODO_PROJECTION_DETAIL_POINTER_SCHEMA_VERSION = "todo_projection_detail_pointer_v0"
 PROJECT_ASSET_TODO_PROJECTION_GAP_SCHEMA_VERSION = "project_asset_todo_projection_gap_v0"
+PROJECT_ASSET_HANDOFF_STATE_TRACE_CHECK_KEYS = (
+    "project_asset_backed",
+    "same_source_should_run",
+    "handoff_has_next_action",
+    "handoff_has_stop_condition",
+    "handoff_sanitized_surface",
+)
 LOCAL_PATH_SURFACE_PATTERN = re.compile(
     r"(?<!<)/(?:Users|Volumes|var/folders|tmp|private/tmp)/[^\s`'\"<>]+"
 )
@@ -187,6 +194,41 @@ def project_asset_latest_validation(run: dict[str, Any] | None) -> dict[str, Any
 def project_asset_summary_is_public_safe(project_asset: dict[str, Any]) -> bool:
     text = repr(project_asset)
     return not LOCAL_PATH_SURFACE_PATTERN.search(text) and not SECRET_LIKE_SURFACE_PATTERN.search(text)
+
+
+def project_asset_handoff_check_projection(item: dict[str, Any]) -> dict[str, Any] | None:
+    project_asset = item.get("project_asset")
+    if not isinstance(project_asset, dict):
+        return None
+
+    quota = project_asset.get("quota") if isinstance(project_asset.get("quota"), dict) else {}
+    if not quota and isinstance(item.get("quota"), dict):
+        quota = item["quota"]
+
+    next_action = str(project_asset.get("next_action") or "").strip()
+    item_action = str(item.get("recommended_action") or "").strip()
+    stop_condition = str(project_asset.get("stop_condition") or "").strip()
+    quota_state = str(quota.get("state") or "").strip()
+    waiting_on = str(item.get("waiting_on") or "").strip()
+    codex_ready = waiting_on == "codex" and quota_state == "eligible"
+    checks = {
+        "project_asset_backed": True,
+        "same_source_should_run": bool(
+            quota and next_action and (not item_action or item_action == next_action)
+        ),
+        "codex_ready": codex_ready,
+        "handoff_has_next_action": bool(next_action),
+        "handoff_has_stop_condition": bool(stop_condition),
+        "handoff_sanitized_surface": project_asset_summary_is_public_safe(project_asset),
+    }
+    return {
+        "checks": checks,
+        "codex_ready": codex_ready,
+        "quota_state": quota_state or "unknown",
+        "state_trace_ready": all(
+            checks[key] for key in PROJECT_ASSET_HANDOFF_STATE_TRACE_CHECK_KEYS
+        ),
+    }
 
 
 def project_asset_next_safe_command(agent_command: str | None) -> str | None:

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -67,6 +67,7 @@ from .projections.project_asset import (
     TODO_PROJECTION_VIEW_SCHEMA_VERSION,
     build_project_asset,
     completed_todo_archive_warning,
+    project_asset_handoff_check_projection,
     project_asset_latest_validation,
     project_asset_quota_summary,
     project_asset_summary_is_public_safe,
@@ -8108,46 +8109,22 @@ def project_asset_handoff_readiness(
     if not isinstance(project_asset, dict):
         return None
 
-    quota = project_asset.get("quota") if isinstance(project_asset.get("quota"), dict) else {}
-    if not quota and isinstance(item.get("quota"), dict):
-        quota = item["quota"]
-
-    next_action = str(project_asset.get("next_action") or "").strip()
-    item_action = str(item.get("recommended_action") or "").strip()
-    stop_condition = str(project_asset.get("stop_condition") or "").strip()
-    quota_state = str(quota.get("state") or "").strip()
-    waiting_on = str(item.get("waiting_on") or "").strip()
+    check_projection = project_asset_handoff_check_projection(item)
+    if not check_projection:
+        return None
+    checks = check_projection["checks"]
     goal_id = str(item.get("goal_id") or "").strip()
-    codex_ready = waiting_on == "codex" and quota_state == "eligible"
-    checks = {
-        "project_asset_backed": True,
-        "same_source_should_run": bool(quota and next_action and (not item_action or item_action == next_action)),
-        "codex_ready": codex_ready,
-        "handoff_has_next_action": bool(next_action),
-        "handoff_has_stop_condition": bool(stop_condition),
-        "handoff_sanitized_surface": project_asset_summary_is_public_safe(project_asset),
-    }
-    state_trace_ready = all(
-        checks[key]
-        for key in (
-            "project_asset_backed",
-            "same_source_should_run",
-            "handoff_has_next_action",
-            "handoff_has_stop_condition",
-            "handoff_sanitized_surface",
-        )
-    )
     readiness: dict[str, Any] = {
         "ready": all(checks.values()),
-        "codex_ready": codex_ready,
+        "codex_ready": bool(check_projection.get("codex_ready")),
         "source": "project_asset",
-        "quota_state": quota_state or "unknown",
+        "quota_state": check_projection.get("quota_state") or "unknown",
         "handoff_interface_budget": handoff_budget_contract(),
         "checks": checks,
     }
     readiness.update(
         project_asset_handoff_state(
-            ready=state_trace_ready,
+            ready=bool(check_projection.get("state_trace_ready")),
             project_asset=project_asset,
             latest_runs=latest_runs,
         )


### PR DESCRIPTION
## Summary
- Extract project-asset handoff readiness checks into `loopx.projections.project_asset` as a pure projection helper.
- Keep `status.py` responsible for the readiness envelope and post-handoff state wiring.
- Update the live handoff readiness smoke to support identity-scoped `--agent-id` status/quota/review-packet checks and agent-lane recommended actions.

## Validation
- `python3 -m compileall -q loopx examples/live-project-asset-handoff-readiness.py`
- `python3 examples/project/project-asset-next-eye-smoke.py`
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 examples/platform-migration-material-registry-smoke.py`
- `PYTHONPATH=. python3 examples/live-project-asset-handoff-readiness.py --goal-id loopx-meta --agent-id codex-product-capability`
- `PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --script examples/project/project-asset-next-eye-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --script examples/control_plane/status-markdown-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --script examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `git diff --check`

Known inherited baseline:
- `python3 examples/control_plane/repo-python-line-budget-smoke.py` remains red for benchmark-owned files `examples/skillsbench-benchmark-run-smoke.py` and `scripts/skillsbench_automation_loop.py`; this PR does not touch those files.

## Boundary scan
- Scanned changed paths for local paths, credentials, private/internal links. Only existing `threshold` false positives matched the broad `sk-` pattern in `loopx/status.py`.
