### PR TITLE
Extract project asset cadence input helpers

### DIFF
--- a/examples/project/project-asset-next-eye-smoke.py
+++ b/examples/project/project-asset-next-eye-smoke.py
@@ -23,6 +23,10 @@ from loopx.status import (  # noqa: E402
     enrich_project_asset,
     project_asset_summary_is_public_safe,
 )
+from loopx.projections.project_asset import (  # noqa: E402
+    project_asset_quota_state,
+    project_asset_user_todo_open_count,
+)
 
 
 USER_TODO = "Review the owner decision before approving delivery."
@@ -101,6 +105,39 @@ def assert_status_project_asset_next_eye() -> None:
     assert project_asset_summary_is_public_safe(asset), asset
 
 
+def assert_project_asset_cadence_input_fallbacks() -> None:
+    project_asset = {
+        "quota": {"state": "eligible"},
+        "user_todos": {"open_count": "2"},
+    }
+    assert project_asset_quota_state(quota=None, project_asset=project_asset) == "eligible"
+    assert (
+        project_asset_quota_state(
+            quota={"state": "operator_gate"},
+            project_asset=project_asset,
+        )
+        == "operator_gate"
+    )
+    assert (
+        project_asset_user_todo_open_count(user_todos=None, project_asset=project_asset)
+        == 2
+    )
+    assert (
+        project_asset_user_todo_open_count(
+            user_todos={"open_count": 0},
+            project_asset=project_asset,
+        )
+        == 0
+    )
+    assert (
+        project_asset_user_todo_open_count(
+            user_todos={"open_count": "not-an-int"},
+            project_asset=project_asset,
+        )
+        is None
+    )
+
+
 def assert_status_project_asset_safe_command_contract() -> None:
     item = {
         "goal_id": "next-eye-command-fixture",
@@ -164,6 +201,7 @@ def assert_dashboard_first_screen_render_contract() -> None:
 
 def main() -> int:
     assert_status_project_asset_next_eye()
+    assert_project_asset_cadence_input_fallbacks()
     assert_status_project_asset_safe_command_contract()
     assert_status_project_asset_monitor_display_contract()
     assert_dashboard_first_screen_render_contract()

--- a/loopx/projections/project_asset.py
+++ b/loopx/projections/project_asset.py
@@ -177,6 +177,38 @@ def project_asset_quota_summary(quota: dict[str, Any] | None) -> dict[str, Any] 
     return summary
 
 
+def _optional_int(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def project_asset_quota_state(
+    *,
+    quota: dict[str, Any] | None,
+    project_asset: dict[str, Any],
+) -> str | None:
+    quota_state = ""
+    if isinstance(quota, dict):
+        quota_state = str(quota.get("state") or "").strip()
+    if not quota_state and isinstance(project_asset.get("quota"), dict):
+        quota_state = str(project_asset["quota"].get("state") or "").strip()
+    return quota_state or None
+
+
+def project_asset_user_todo_open_count(
+    *,
+    user_todos: dict[str, Any] | None,
+    project_asset: dict[str, Any],
+) -> int | None:
+    if isinstance(user_todos, dict):
+        return _optional_int(user_todos.get("open_count"))
+    if isinstance(project_asset.get("user_todos"), dict):
+        return _optional_int(project_asset["user_todos"].get("open_count"))
+    return None
+
+
 def project_asset_latest_validation(run: dict[str, Any] | None) -> dict[str, Any] | None:
     if not isinstance(run, dict):
         return None

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -69,10 +69,12 @@ from .projections.project_asset import (
     completed_todo_archive_warning,
     project_asset_handoff_check_projection,
     project_asset_latest_validation,
+    project_asset_quota_state,
     project_asset_quota_summary,
     project_asset_summary_is_public_safe,
     project_asset_todo_projection_metadata,
     project_asset_todo_projection_gap,
+    project_asset_user_todo_open_count,
 )
 from .promotion_gate import build_promotion_gate
 from .quota import quota_status, quota_with_handoff_outcome_floor
@@ -8182,22 +8184,11 @@ def enrich_project_asset(
     readiness = project_asset_handoff_readiness(item, latest_runs=latest_runs)
     if readiness:
         item["handoff_readiness"] = readiness
-    quota_state = ""
-    if isinstance(quota, dict):
-        quota_state = str(quota.get("state") or "").strip()
-    if not quota_state and isinstance(project_asset.get("quota"), dict):
-        quota_state = str(project_asset["quota"].get("state") or "").strip()
-    user_todo_open_count = None
-    if isinstance(user_todos, dict):
-        try:
-            user_todo_open_count = int(user_todos.get("open_count"))
-        except (TypeError, ValueError):
-            user_todo_open_count = None
-    elif isinstance(project_asset.get("user_todos"), dict):
-        try:
-            user_todo_open_count = int(project_asset["user_todos"].get("open_count"))
-        except (TypeError, ValueError):
-            user_todo_open_count = None
+    quota_state = project_asset_quota_state(quota=quota, project_asset=project_asset)
+    user_todo_open_count = project_asset_user_todo_open_count(
+        user_todos=user_todos,
+        project_asset=project_asset,
+    )
     cadence_hint = build_long_task_cadence_hint(
         execution_profile=(
             project_asset.get("execution_profile")
@@ -8206,7 +8197,7 @@ def enrich_project_asset(
         ),
         latest_runs=latest_runs,
         handoff_readiness=readiness,
-        quota_state=quota_state or None,
+        quota_state=quota_state,
         user_todo_open_count=user_todo_open_count,
     )
     project_asset["long_task_cadence_hint"] = cadence_hint


### PR DESCRIPTION
## Summary
- Extract project-asset cadence input helpers for quota state and user-todo open-count fallback into `loopx.projections.project_asset`.
- Keep `status.py` responsible for calling `build_long_task_cadence_hint`, while delegating pure project-asset input extraction.
- Add direct characterization coverage in `project-asset-next-eye-smoke` for quota fallback and user todo open-count fallback behavior.

## Validation
- `python3 -m compileall -q loopx examples/project/project-asset-next-eye-smoke.py`
- `python3 examples/project/project-asset-next-eye-smoke.py`
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 examples/platform-migration-material-registry-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --script examples/project/project-asset-next-eye-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --script examples/control_plane/status-markdown-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --script examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `PYTHONPATH=. python3 examples/live-project-asset-handoff-readiness.py --goal-id loopx-meta --agent-id codex-product-capability`
- `git diff --check`

Known inherited baseline:
- `python3 examples/control_plane/repo-python-line-budget-smoke.py` remains red for benchmark-owned files `examples/skillsbench-benchmark-run-smoke.py` and `scripts/skillsbench_automation_loop.py`; this PR does not touch those files.

## Boundary scan
- Scanned changed paths for local paths, credentials, private/internal links. Only existing `threshold` false positives matched the broad `sk-` pattern in `loopx/status.py`.
