### PR TITLE
Keep private monitors from preempting advancement

### DIFF
--- a/examples/control_plane/private-boundary-monitor-priority-smoke.py
+++ b/examples/control_plane/private-boundary-monitor-priority-smoke.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Guard private/local due monitors from preempting public advancement work."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.quota import build_quota_should_run  # noqa: E402
+
+
+GOAL_ID = "private-boundary-monitor-priority-fixture"
+PAST_DUE_AT = "2000-01-01T00:00:00+00:00"
+
+
+def status_payload(*, monitor_todo: dict, advancement_todo: dict) -> dict:
+    agent_todos = {
+        "schema_version": "todo_summary_v0",
+        "source_section": "Agent Todo",
+        "total_count": 2,
+        "open_count": 2,
+        "done_count": 0,
+        "first_open_items": [monitor_todo, advancement_todo],
+        "monitor_open_items": [monitor_todo],
+        "monitor_due_items": [monitor_todo],
+        "monitor_due_count": 1,
+        "first_executable_items": [advancement_todo],
+        "claim_scope": {"agent_id": "codex-product-capability"},
+    }
+    return {
+        "ok": True,
+        "attention_queue": {
+            "items": [
+                {
+                    "goal_id": GOAL_ID,
+                    "status": "eligible",
+                    "waiting_on": "codex",
+                    "severity": "info",
+                    "source": "project_asset",
+                    "recommended_action": advancement_todo["text"],
+                    "quota": {
+                        "compute": 1.0,
+                        "window_hours": 24,
+                        "slot_minutes": 1,
+                        "allowed_slots": 10,
+                        "spent_slots": 0,
+                        "state": "eligible",
+                        "reason": "eligible fixture",
+                    },
+                    "project_asset": {
+                        "next_action": advancement_todo["text"],
+                        "stop_condition": "stop on fixture boundary",
+                        "agent_todos": agent_todos,
+                    },
+                    "agent_todos": agent_todos,
+                }
+            ]
+        },
+        "run_history": {
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "registry_member": True,
+                    "status": "active",
+                    "coordination": {
+                        "primary_agent": "codex-main-control",
+                        "registered_agents": [
+                            "codex-main-control",
+                            "codex-product-capability",
+                        ],
+                    },
+                    "quota": {"compute": 1.0, "window_hours": 24},
+                }
+            ]
+        },
+    }
+
+
+def test_private_boundary_due_monitor_is_context_only() -> None:
+    monitor_todo = {
+        "index": 1,
+        "text": "[P0-local] Keep private planning material aligned without authorized read.",
+        "role": "agent",
+        "status": "open",
+        "priority": "P0-LOCAL",
+        "task_class": "continuous_monitor",
+        "action_kind": "local_department_doc_todo_projection_monitor",
+        "claimed_by": "codex-product-capability",
+        "next_due_at": PAST_DUE_AT,
+        "result_hash": "private_boundary_no_authorized_read",
+    }
+    advancement_todo = {
+        "index": 2,
+        "text": "[P2] Continue canary-gated read-model cleanup.",
+        "role": "agent",
+        "status": "open",
+        "priority": "P2",
+        "task_class": "advancement_task",
+        "action_kind": "continue_canary_refactor",
+        "claimed_by": "codex-product-capability",
+    }
+    guard = build_quota_should_run(
+        status_payload(
+            monitor_todo=monitor_todo,
+            advancement_todo=advancement_todo,
+        ),
+        goal_id=GOAL_ID,
+        agent_id="codex-product-capability",
+    )
+    lane = guard["work_lane_contract"]
+    assert guard["agent_todo_summary"]["monitor_due_count"] == 1, guard
+    assert lane["lane"] == "advancement_task", lane
+    assert lane["reason_codes"] == ["open_agent_todo", "due_monitor_context"], lane
+    assert guard["recommended_action"] == advancement_todo["text"], guard
+    assert (
+        guard["interaction_contract"]["agent_channel"]["primary_action"]
+        == f"{advancement_todo['text']}"
+    ), guard
+
+
+def main() -> int:
+    test_private_boundary_due_monitor_is_context_only()
+    print("private-boundary-monitor-priority-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -228,6 +228,13 @@ AGENT_CLAIM_SCOPE_SCHEMA_VERSION = "agent_claim_scope_v0"
 SIDE_AGENT_CLAIM_SCOPE_SCHEMA_VERSION = AGENT_CLAIM_SCOPE_SCHEMA_VERSION
 AGENT_LANE_NEXT_ACTION_SCHEMA_VERSION = "agent_lane_next_action_v0"
 QUOTA_MONITOR_TARGET_SCHEMA_VERSION = "quota_monitor_target_v0"
+PRIVATE_BOUNDARY_MONITOR_RESULT_HASHES = {
+    "private_boundary_no_authorized_read",
+}
+PRIVATE_BOUNDARY_MONITOR_ACTION_KIND_HINTS = (
+    "private",
+    "local_department_doc",
+)
 
 
 DEFAULT_AVAILABLE_CAPABILITIES = (
@@ -610,6 +617,7 @@ def _work_lane_contract(
     )
     due_monitor_preempts_advancement = bool(
         first_due_monitor
+        and _due_monitor_can_preempt_advancement(first_due_monitor)
         and (
             first_advancement is None
             or _todo_priority_rank(first_due_monitor) < _todo_priority_rank(first_advancement)
@@ -1235,6 +1243,26 @@ def _todo_priority_label(item: dict[str, Any]) -> str | None:
 
 def _todo_priority_rank(item: dict[str, Any]) -> int:
     return projection_todo_priority_rank(item)
+
+
+def _due_monitor_can_preempt_advancement(item: dict[str, Any]) -> bool:
+    """Return false for monitor work that requires private/local material.
+
+    A due monitor can remain visible as context, but it must not outrank a
+    public executable advancement slice when the monitor's own last writeback
+    says the agent has no authorized private read path.
+    """
+
+    result_hash = str(item.get("result_hash") or "").strip().lower()
+    if result_hash in PRIVATE_BOUNDARY_MONITOR_RESULT_HASHES:
+        return False
+    action_kind = str(item.get("action_kind") or "").strip().lower()
+    if any(hint in action_kind for hint in PRIVATE_BOUNDARY_MONITOR_ACTION_KIND_HINTS):
+        return False
+    priority = str(_todo_priority_label(item) or "").strip().upper()
+    if "LOCAL" in priority:
+        return False
+    return True
 
 
 def _todo_index_rank(item: dict[str, Any]) -> int:


### PR DESCRIPTION
## Summary
- prevent private/local-boundary due monitors from preempting public executable advancement todos
- keep due private monitors visible as context while routing primary action to the advancement lane
- add a focused smoke for the live regression shape

## Validation
- python3 examples/control_plane/private-boundary-monitor-priority-smoke.py
- PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --script examples/control_plane/private-boundary-monitor-priority-smoke.py
- PYTHONPATH=. python3 -m loopx.cli --format json --registry "/Users/bytedance/.codex/loopx/registry.global.json" --runtime-root "/Users/bytedance/.codex/loopx" quota should-run --goal-id loopx-meta --agent-id codex-product-capability
- python3 -m compileall -q loopx examples/control_plane/private-boundary-monitor-priority-smoke.py
- python3 examples/control_plane/work-lane-contract-smoke.py
- python3 examples/control_plane/monitor-scheduler-contract-smoke.py
- python3 examples/control_plane/status-quota-review-packet-parity-smoke.py
- git diff --check

Known inherited baseline: repo-python-line-budget-smoke remains red only for benchmark-owned examples/skillsbench-benchmark-run-smoke.py and scripts/skillsbench_automation_loop.py.