### PR TITLE
Extract monitor display projection helper

### DIFF
--- a/examples/control_plane/monitor-display-projection-smoke.py
+++ b/examples/control_plane/monitor-display-projection-smoke.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Smoke-test monitor-quiet display candidate projection."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.projections.monitor_display import (  # noqa: E402
+    attention_item_is_monitor_quiet_display_candidate as direct_monitor_candidate,
+)
+from loopx.status import (  # noqa: E402
+    MAX_STATUS_TODOS_PER_ROLE,
+    attention_item_is_monitor_quiet_display_candidate,
+    open_todo_items,
+    todo_item_is_actionable_open,
+)
+
+
+def todo(index: int, text: str) -> dict[str, object]:
+    return {"index": index, "done": False, "status": "open", "text": text}
+
+
+def monitor_item(*, with_advancement: bool = False, with_user_todo: bool = False) -> dict[str, object]:
+    agent_todos = {
+        "open_count": 1 + int(with_advancement),
+        "monitor_open_items": [todo(1, "[P1 monitor] Observe one bounded public-safe signal.")],
+        "first_executable_items": [],
+        "executable_backlog_items": [],
+        "claimed_advancement_open_items": [],
+    }
+    if with_advancement:
+        agent_todos["claimed_advancement_open_items"] = [
+            todo(2, "[P2] Continue canary-gated control-plane read-model cleanup.")
+        ]
+    return {
+        "goal_id": "loopx-meta",
+        "waiting_on": "codex",
+        "severity": "action",
+        "agent_todos": agent_todos,
+        "user_todos": {
+            "open_count": int(with_user_todo),
+            "items": [todo(1, "[P0-user] Decide something.")] if with_user_todo else [],
+        },
+    }
+
+
+def assert_status_and_projection_agree(item: dict[str, object], expected: bool) -> None:
+    direct = direct_monitor_candidate(
+        item,
+        open_todo_items=open_todo_items,
+        todo_item_is_actionable_open=todo_item_is_actionable_open,
+        fallback_limit=MAX_STATUS_TODOS_PER_ROLE,
+    )
+    wrapper = attention_item_is_monitor_quiet_display_candidate(item)
+    assert direct is expected, (direct, expected, item)
+    assert wrapper == direct, (wrapper, direct, item)
+
+
+def main() -> int:
+    assert_status_and_projection_agree(monitor_item(), True)
+    assert_status_and_projection_agree(monitor_item(with_advancement=True), False)
+    assert_status_and_projection_agree(monitor_item(with_user_todo=True), False)
+    print("monitor-display-projection-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/projections/monitor_display.py
+++ b/loopx/projections/monitor_display.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+
+def todo_summary_open_count(
+    summary: dict[str, Any] | None,
+    *,
+    open_todo_items: Callable[..., list[dict[str, Any]]],
+    todo_item_is_actionable_open: Callable[[dict[str, Any]], bool],
+    fallback_limit: int,
+) -> int:
+    if not isinstance(summary, dict):
+        return 0
+    for key in ("open_count", "open"):
+        value = summary.get(key)
+        if isinstance(value, int):
+            return max(0, value)
+    return len(
+        [
+            item
+            for item in open_todo_items(summary, limit=fallback_limit)
+            if todo_item_is_actionable_open(item)
+        ]
+    )
+
+
+def todo_summary_lane_items(summary: dict[str, Any] | None, lane: str) -> list[dict[str, Any]]:
+    if not isinstance(summary, dict):
+        return []
+    raw_items = summary.get(lane)
+    if not isinstance(raw_items, list):
+        return []
+    return [item for item in raw_items if isinstance(item, dict)]
+
+
+def attention_item_is_monitor_quiet_display_candidate(
+    item: dict[str, Any],
+    *,
+    open_todo_items: Callable[..., list[dict[str, Any]]],
+    todo_item_is_actionable_open: Callable[[dict[str, Any]], bool],
+    fallback_limit: int,
+) -> bool:
+    if item.get("waiting_on") != "codex" or item.get("severity") != "action":
+        return False
+    agent_todos = item.get("agent_todos") if isinstance(item.get("agent_todos"), dict) else None
+    if not agent_todos:
+        return False
+    user_todos = item.get("user_todos") if isinstance(item.get("user_todos"), dict) else None
+    if (
+        todo_summary_open_count(
+            user_todos,
+            open_todo_items=open_todo_items,
+            todo_item_is_actionable_open=todo_item_is_actionable_open,
+            fallback_limit=fallback_limit,
+        )
+        > 0
+    ):
+        return False
+    open_count = todo_summary_open_count(
+        agent_todos,
+        open_todo_items=open_todo_items,
+        todo_item_is_actionable_open=todo_item_is_actionable_open,
+        fallback_limit=fallback_limit,
+    )
+    if open_count <= 0:
+        return False
+    monitor_items = [
+        item
+        for item in todo_summary_lane_items(agent_todos, "monitor_open_items")
+        if todo_item_is_actionable_open(item)
+    ]
+    executable_items = [
+        *todo_summary_lane_items(agent_todos, "first_executable_items"),
+        *todo_summary_lane_items(agent_todos, "executable_backlog_items"),
+        *todo_summary_lane_items(agent_todos, "claimed_advancement_open_items"),
+    ]
+    if any(todo_item_is_actionable_open(todo) for todo in executable_items):
+        return False
+    return len(monitor_items) == open_count

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -81,6 +81,11 @@ from .projections.autonomous_candidates import (
     autonomous_priority_rank as _autonomous_priority_rank,
     autonomous_todo_candidates as _autonomous_todo_candidates,
 )
+from .projections.monitor_display import (
+    attention_item_is_monitor_quiet_display_candidate as _attention_item_is_monitor_quiet_display_candidate,
+    todo_summary_lane_items as _todo_summary_lane_items,
+    todo_summary_open_count as _todo_summary_open_count,
+)
 from .promotion_gate import build_promotion_gate
 from .quota import quota_status, quota_with_handoff_outcome_floor
 from .registry import registry_goals
@@ -8316,55 +8321,25 @@ def active_state_todo_attention_item(
 
 
 def todo_summary_open_count(summary: dict[str, Any] | None) -> int:
-    if not isinstance(summary, dict):
-        return 0
-    for key in ("open_count", "open"):
-        value = summary.get(key)
-        if isinstance(value, int):
-            return max(0, value)
-    return len(
-        [
-            item
-            for item in open_todo_items(summary, limit=MAX_STATUS_TODOS_PER_ROLE)
-            if todo_item_is_actionable_open(item)
-        ]
+    return _todo_summary_open_count(
+        summary,
+        open_todo_items=open_todo_items,
+        todo_item_is_actionable_open=todo_item_is_actionable_open,
+        fallback_limit=MAX_STATUS_TODOS_PER_ROLE,
     )
 
 
 def todo_summary_lane_items(summary: dict[str, Any] | None, lane: str) -> list[dict[str, Any]]:
-    if not isinstance(summary, dict):
-        return []
-    raw_items = summary.get(lane)
-    if not isinstance(raw_items, list):
-        return []
-    return [item for item in raw_items if isinstance(item, dict)]
+    return _todo_summary_lane_items(summary, lane)
 
 
 def attention_item_is_monitor_quiet_display_candidate(item: dict[str, Any]) -> bool:
-    if item.get("waiting_on") != "codex" or item.get("severity") != "action":
-        return False
-    agent_todos = item.get("agent_todos") if isinstance(item.get("agent_todos"), dict) else None
-    if not agent_todos:
-        return False
-    user_todos = item.get("user_todos") if isinstance(item.get("user_todos"), dict) else None
-    if todo_summary_open_count(user_todos) > 0:
-        return False
-    open_count = todo_summary_open_count(agent_todos)
-    if open_count <= 0:
-        return False
-    monitor_items = [
-        item
-        for item in todo_summary_lane_items(agent_todos, "monitor_open_items")
-        if todo_item_is_actionable_open(item)
-    ]
-    executable_items = [
-        *todo_summary_lane_items(agent_todos, "first_executable_items"),
-        *todo_summary_lane_items(agent_todos, "executable_backlog_items"),
-        *todo_summary_lane_items(agent_todos, "claimed_advancement_open_items"),
-    ]
-    if any(todo_item_is_actionable_open(todo) for todo in executable_items):
-        return False
-    return len(monitor_items) == open_count
+    return _attention_item_is_monitor_quiet_display_candidate(
+        item,
+        open_todo_items=open_todo_items,
+        todo_item_is_actionable_open=todo_item_is_actionable_open,
+        fallback_limit=MAX_STATUS_TODOS_PER_ROLE,
+    )
 
 
 def quiet_monitor_display_action(raw_action: str | None) -> str:


### PR DESCRIPTION
## Summary
- move monitor-quiet display candidate predicate helpers into loopx.projections.monitor_display
- keep status.py wrappers for compatibility
- add focused smoke coverage for monitor-only, advancement-present, and user-todo-present cases

## Validation
- python3 -m compileall -q loopx examples/control_plane/monitor-display-projection-smoke.py
- python3 examples/control_plane/monitor-display-projection-smoke.py
- python3 examples/control_plane/status-markdown-smoke.py
- python3 examples/control_plane/monitor-todo-policy-seam-smoke.py
- PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --script examples/control_plane/monitor-display-projection-smoke.py
- python3 examples/control_plane/status-quota-review-packet-parity-smoke.py
- python3 examples/control_plane/monitor-scheduler-contract-smoke.py
- PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --profile core-control-plane (123/124 pass; inherited repo-python-line-budget-smoke failure for benchmark-owned examples/skillsbench-benchmark-run-smoke.py and scripts/skillsbench_automation_loop.py)
- git diff --check
- public/private boundary scan on changed files