### PR TITLE
Extract monitor quiet display normalizer

### DIFF
--- a/examples/control_plane/monitor-display-projection-smoke.py
+++ b/examples/control_plane/monitor-display-projection-smoke.py
@@ -13,11 +13,19 @@ if str(REPO_ROOT) not in sys.path:
 
 from loopx.projections.monitor_display import (  # noqa: E402
     attention_item_is_monitor_quiet_display_candidate as direct_monitor_candidate,
+    normalize_monitor_quiet_attention_display as direct_normalize_monitor_display,
+    quiet_monitor_display_action as direct_quiet_monitor_display_action,
 )
 from loopx.status import (  # noqa: E402
     MAX_STATUS_TODOS_PER_ROLE,
+    MONITOR_DISPLAY_FALLBACK_ACTION,
+    MONITOR_DISPLAY_SCHEMA_VERSION,
+    MONITOR_DISPLAY_STOP_CONDITION,
+    MONITOR_SIGNAL_WAITING_ON,
     attention_item_is_monitor_quiet_display_candidate,
+    normalize_monitor_quiet_attention_display,
     open_todo_items,
+    quiet_monitor_display_action,
     todo_item_is_actionable_open,
 )
 
@@ -42,11 +50,13 @@ def monitor_item(*, with_advancement: bool = False, with_user_todo: bool = False
         "goal_id": "loopx-meta",
         "waiting_on": "codex",
         "severity": "action",
+        "recommended_action": "Quiet monitor only until a material transition appears.",
         "agent_todos": agent_todos,
         "user_todos": {
             "open_count": int(with_user_todo),
             "items": [todo(1, "[P0-user] Decide something.")] if with_user_todo else [],
         },
+        "project_asset": {},
     }
 
 
@@ -66,6 +76,35 @@ def main() -> int:
     assert_status_and_projection_agree(monitor_item(), True)
     assert_status_and_projection_agree(monitor_item(with_advancement=True), False)
     assert_status_and_projection_agree(monitor_item(with_user_todo=True), False)
+
+    assert quiet_monitor_display_action(None) == MONITOR_DISPLAY_FALLBACK_ACTION
+    assert direct_quiet_monitor_display_action(
+        "Wait quietly for the next due time.",
+        fallback_action=MONITOR_DISPLAY_FALLBACK_ACTION,
+    ) == quiet_monitor_display_action("Wait quietly for the next due time.")
+
+    status_item = monitor_item()
+    direct_item = monitor_item()
+    normalize_monitor_quiet_attention_display(status_item)
+    direct_normalize_monitor_display(
+        direct_item,
+        is_monitor_quiet_display_candidate=lambda item: direct_monitor_candidate(
+            item,
+            open_todo_items=open_todo_items,
+            todo_item_is_actionable_open=todo_item_is_actionable_open,
+            fallback_limit=MAX_STATUS_TODOS_PER_ROLE,
+        ),
+        display_fallback_action=MONITOR_DISPLAY_FALLBACK_ACTION,
+        monitor_signal_waiting_on=MONITOR_SIGNAL_WAITING_ON,
+        monitor_display_schema_version=MONITOR_DISPLAY_SCHEMA_VERSION,
+        monitor_display_stop_condition=MONITOR_DISPLAY_STOP_CONDITION,
+    )
+    assert status_item == direct_item, (status_item, direct_item)
+    assert status_item["waiting_on"] == MONITOR_SIGNAL_WAITING_ON, status_item
+    assert status_item["severity"] == "watch", status_item
+    assert status_item["project_asset"]["owner"] == MONITOR_SIGNAL_WAITING_ON, status_item
+    assert status_item["project_asset"]["stop_condition"] == MONITOR_DISPLAY_STOP_CONDITION, status_item
+
     print("monitor-display-projection-smoke ok")
     return 0
 

--- a/loopx/projections/monitor_display.py
+++ b/loopx/projections/monitor_display.py
@@ -78,3 +78,66 @@ def attention_item_is_monitor_quiet_display_candidate(
     if any(todo_item_is_actionable_open(todo) for todo in executable_items):
         return False
     return len(monitor_items) == open_count
+
+
+def quiet_monitor_display_action(
+    raw_action: str | None,
+    *,
+    fallback_action: str,
+) -> str:
+    action = str(raw_action or "").strip()
+    if not action:
+        return fallback_action
+    lowered = action.lower()
+    if lowered.startswith("no immediate agent work"):
+        return action
+    if lowered.startswith("quiet monitor only until "):
+        suffix = action[len("Quiet monitor only until ") :].strip()
+        if suffix:
+            return f"No immediate agent work; keep the monitor quiet until {suffix}"
+    if lowered.startswith("wait quietly"):
+        return f"No immediate agent work; {action[0].lower()}{action[1:]}"
+    return f"No immediate agent work; monitor quietly. Context: {action}"
+
+
+def normalize_monitor_quiet_attention_display(
+    item: dict[str, Any],
+    *,
+    is_monitor_quiet_display_candidate: Callable[[dict[str, Any]], bool],
+    display_fallback_action: str,
+    monitor_signal_waiting_on: str,
+    monitor_display_schema_version: str,
+    monitor_display_stop_condition: str,
+) -> None:
+    if not is_monitor_quiet_display_candidate(item):
+        return
+    old_waiting_on = str(item.get("waiting_on") or "")
+    old_severity = str(item.get("severity") or "")
+    display_action = quiet_monitor_display_action(
+        str(item.get("recommended_action") or ""),
+        fallback_action=display_fallback_action,
+    )
+    item["execution_waiting_on"] = old_waiting_on
+    item["waiting_on"] = monitor_signal_waiting_on
+    item["severity"] = "watch"
+    item["recommended_action"] = display_action
+    item["monitor_display"] = {
+        "schema_version": monitor_display_schema_version,
+        "mode": "monitor_quiet",
+        "no_immediate_agent_work": True,
+        "execution_waiting_on": old_waiting_on,
+        "execution_severity": old_severity,
+        "waiting_on": monitor_signal_waiting_on,
+        "severity": "watch",
+        "material_transition": (
+            "write back only a material monitor transition, regression, or concrete blocker"
+        ),
+    }
+    project_asset = item.get("project_asset")
+    if isinstance(project_asset, dict):
+        project_asset["owner"] = monitor_signal_waiting_on
+        project_asset["gate"] = "none"
+        project_asset["support_mode"] = "read_only_observer"
+        project_asset["next_action"] = display_action
+        project_asset["stop_condition"] = monitor_display_stop_condition
+        project_asset["monitor_display"] = dict(item["monitor_display"])

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -83,6 +83,8 @@ from .projections.autonomous_candidates import (
 )
 from .projections.monitor_display import (
     attention_item_is_monitor_quiet_display_candidate as _attention_item_is_monitor_quiet_display_candidate,
+    normalize_monitor_quiet_attention_display as _normalize_monitor_quiet_attention_display,
+    quiet_monitor_display_action as _quiet_monitor_display_action,
     todo_summary_lane_items as _todo_summary_lane_items,
     todo_summary_open_count as _todo_summary_open_count,
 )
@@ -8343,51 +8345,21 @@ def attention_item_is_monitor_quiet_display_candidate(item: dict[str, Any]) -> b
 
 
 def quiet_monitor_display_action(raw_action: str | None) -> str:
-    action = str(raw_action or "").strip()
-    if not action:
-        return MONITOR_DISPLAY_FALLBACK_ACTION
-    lowered = action.lower()
-    if lowered.startswith("no immediate agent work"):
-        return action
-    if lowered.startswith("quiet monitor only until "):
-        suffix = action[len("Quiet monitor only until ") :].strip()
-        if suffix:
-            return f"No immediate agent work; keep the monitor quiet until {suffix}"
-    if lowered.startswith("wait quietly"):
-        return f"No immediate agent work; {action[0].lower()}{action[1:]}"
-    return f"No immediate agent work; monitor quietly. Context: {action}"
+    return _quiet_monitor_display_action(
+        raw_action,
+        fallback_action=MONITOR_DISPLAY_FALLBACK_ACTION,
+    )
 
 
 def normalize_monitor_quiet_attention_display(item: dict[str, Any]) -> None:
-    if not attention_item_is_monitor_quiet_display_candidate(item):
-        return
-    old_waiting_on = str(item.get("waiting_on") or "")
-    old_severity = str(item.get("severity") or "")
-    display_action = quiet_monitor_display_action(str(item.get("recommended_action") or ""))
-    item["execution_waiting_on"] = old_waiting_on
-    item["waiting_on"] = MONITOR_SIGNAL_WAITING_ON
-    item["severity"] = "watch"
-    item["recommended_action"] = display_action
-    item["monitor_display"] = {
-        "schema_version": MONITOR_DISPLAY_SCHEMA_VERSION,
-        "mode": "monitor_quiet",
-        "no_immediate_agent_work": True,
-        "execution_waiting_on": old_waiting_on,
-        "execution_severity": old_severity,
-        "waiting_on": MONITOR_SIGNAL_WAITING_ON,
-        "severity": "watch",
-        "material_transition": (
-            "write back only a material monitor transition, regression, or concrete blocker"
-        ),
-    }
-    project_asset = item.get("project_asset")
-    if isinstance(project_asset, dict):
-        project_asset["owner"] = MONITOR_SIGNAL_WAITING_ON
-        project_asset["gate"] = "none"
-        project_asset["support_mode"] = "read_only_observer"
-        project_asset["next_action"] = display_action
-        project_asset["stop_condition"] = MONITOR_DISPLAY_STOP_CONDITION
-        project_asset["monitor_display"] = dict(item["monitor_display"])
+    _normalize_monitor_quiet_attention_display(
+        item,
+        is_monitor_quiet_display_candidate=attention_item_is_monitor_quiet_display_candidate,
+        display_fallback_action=MONITOR_DISPLAY_FALLBACK_ACTION,
+        monitor_signal_waiting_on=MONITOR_SIGNAL_WAITING_ON,
+        monitor_display_schema_version=MONITOR_DISPLAY_SCHEMA_VERSION,
+        monitor_display_stop_condition=MONITOR_DISPLAY_STOP_CONDITION,
+    )
 
 
 def compact_global_registry_shadow_finding(finding: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- move monitor quiet display action normalization into loopx.projections.monitor_display
- keep status.py wrappers for compatibility
- extend monitor-display projection smoke to compare direct helper and status wrapper output, including project_asset mirroring

## Validation
- python3 -m compileall -q loopx examples/control_plane/monitor-display-projection-smoke.py
- python3 examples/control_plane/monitor-display-projection-smoke.py
- python3 examples/control_plane/status-markdown-smoke.py
- python3 examples/control_plane/monitor-scheduler-contract-smoke.py
- PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --script examples/control_plane/monitor-display-projection-smoke.py
- python3 examples/control_plane/monitor-todo-policy-seam-smoke.py
- python3 examples/control_plane/status-quota-review-packet-parity-smoke.py
- PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --profile core-control-plane (123/124 pass; inherited repo-python-line-budget-smoke failure for benchmark-owned examples/skillsbench-benchmark-run-smoke.py and scripts/skillsbench_automation_loop.py)
- git diff --check
- public/private boundary scan on changed files