### PR TITLE
Guard SkillsBench app-server Goal unfinished turns

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -104,6 +104,7 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
     VERIFIER_UV_BOOTSTRAP_MIRROR_BEGIN,
     _tail,
     _apply_agent_message_only_no_tool_calls_attribution,
+    _apply_native_goal_worker_finish_guard_attribution,
     _blind_loop_persistent_continuation_clause,
     _build_goal_start_product_mode_control_score,
     _build_product_mode_user,
@@ -8623,6 +8624,149 @@ def test_skillsbench_round_trace_records_best_round_score() -> None:
         assert context_only_compact["attempt_accounting"][
             "failure_class"
         ] == "job_materialization_failed", context_only_compact
+
+        incomplete_no_activity_trace_dir = root / "native-worker-inprogress-no-activity"
+        incomplete_no_activity_trace_dir.mkdir()
+        write_json(
+            incomplete_no_activity_trace_dir / "worker-inprogress.compact.json",
+            {
+                "schema_version": "skillsbench_host_codex_goal_worker_public_trace_v0",
+                "ok": True,
+                "route": "codex-app-server-goal-baseline",
+                "benchmark_id": "skillsbench@1.1",
+                "task_id": "travel-planning",
+                "worker_contract": {
+                    "schema_version": "skillsbench_app_server_goal_worker_contract_v0",
+                    "route": "codex-app-server-goal-baseline",
+                    "ready": True,
+                    "runner_integration_ready": True,
+                    "first_blocker": "ready_for_skillsbench_app_server_goal_worker",
+                },
+                "turn": {
+                    "thread_id_present": True,
+                    "goal_get_present": True,
+                    "turn_id_present": True,
+                    "turn_status": "inProgress",
+                    "turn_completed_observed": True,
+                    "assistant_message_present": True,
+                    "assistant_message_chars": 4012,
+                    "raw_transcript_recorded": False,
+                    "raw_assistant_message_recorded": False,
+                },
+                "boundary": {
+                    "raw_task_text_recorded": False,
+                    "raw_logs_recorded": False,
+                    "raw_trajectory_recorded": False,
+                    "credential_values_recorded": False,
+                    "host_paths_recorded": False,
+                },
+            },
+        )
+        write_json(
+            incomplete_no_activity_trace_dir / "bridge-agent-empty.compact.json",
+            {
+                "schema_version": "skillsbench_host_local_acp_relay_public_trace_v0",
+                "ok": True,
+                "route": "codex-app-server-goal-baseline",
+                "trace_kind": "remote_command_file_bridge_agent_operations",
+                "benchmark_id": "skillsbench@1.1",
+                "task_id": "travel-planning",
+                "remote_command_file_bridge_agent_operations": {
+                    "schema_version": (
+                        "skillsbench_remote_command_file_bridge_agent_operations_v0"
+                    ),
+                    "request_count": 0,
+                    "success_count": 0,
+                    "failure_count": 0,
+                    "operation_counts": {},
+                    "returncode_counts": {},
+                    "failure_category_counts": {},
+                    "task_facing_operation_count": 0,
+                    "task_facing_success_count": 0,
+                    "task_facing_failure_count": 0,
+                    "raw_material_recorded": False,
+                },
+                "boundary": {
+                    "raw_command_recorded": False,
+                    "raw_stdout_recorded": False,
+                    "raw_stderr_recorded": False,
+                    "raw_task_text_recorded": False,
+                    "raw_logs_recorded": False,
+                    "raw_trajectory_recorded": False,
+                    "credential_values_recorded": False,
+                    "host_paths_recorded": False,
+                    "remote_paths_recorded": False,
+                    "upload_performed": False,
+                    "submit_performed": False,
+                },
+            },
+        )
+        incomplete_no_activity_trace = {
+            "schema_version": "skillsbench_loopx_controller_trace_v0",
+            "route": "codex-app-server-goal-baseline",
+            "trace_publicness": "public_counts_only_no_task_text_no_verifier_output",
+            "native_goal_worker_route": True,
+            "native_goal_worker_connected": True,
+            "native_goal_worker_connect_count": 1,
+            "raw_task_text_recorded": False,
+            "raw_verifier_output_recorded": False,
+            "raw_agent_trajectory_recorded": False,
+        }
+        _merge_app_server_goal_worker_trace_summary(
+            {
+                "route": "codex-app-server-goal-baseline",
+                "app_server_goal_worker_trace_dir": str(incomplete_no_activity_trace_dir),
+            },
+            incomplete_no_activity_trace,
+        )
+        _merge_host_local_acp_relay_trace_summary(
+            {
+                "route": "codex-app-server-goal-baseline",
+                "app_server_goal_worker_trace_dir": str(incomplete_no_activity_trace_dir),
+            },
+            incomplete_no_activity_trace,
+        )
+        incomplete_no_activity_compact = compact_benchmark_run(
+            build_skillsbench_benchflow_result_benchmark_run(
+                write_official_skillsbench_result(
+                    root / "native-worker-inprogress-no-activity-result",
+                    reward=0.0,
+                    task_id="travel-planning",
+                ),
+                route="codex-app-server-goal-baseline",
+                controller_trace=incomplete_no_activity_trace,
+            )
+        )
+        assert incomplete_no_activity_compact is not None
+        _apply_native_goal_worker_finish_guard_attribution(
+            incomplete_no_activity_compact
+        )
+        expected_finish_guard_failure = (
+            "skillsbench_native_goal_worker_incomplete_turn_without_task_activity"
+        )
+        assert (
+            incomplete_no_activity_compact["score_failure_attribution"]
+            == expected_finish_guard_failure
+        ), incomplete_no_activity_compact
+        assert "official_verifier_solution_failure" not in (
+            incomplete_no_activity_compact["failure_attribution_labels"]
+        ), incomplete_no_activity_compact
+        assert incomplete_no_activity_compact[
+            "official_score_comparable_to_native_codex"
+        ] is False, incomplete_no_activity_compact
+        finish_guard_counters = incomplete_no_activity_compact["interaction_counters"]
+        assert (
+            finish_guard_counters[
+                "native_goal_worker_incomplete_after_completion_event_count"
+            ]
+            == 1
+        ), incomplete_no_activity_compact
+        assert incomplete_no_activity_compact["native_goal_worker_contract"][
+            "countable_baseline"
+        ] is False, incomplete_no_activity_compact
+        assert incomplete_no_activity_compact["attempt_accounting"][
+            "case_attempt_countable"
+        ] is False, incomplete_no_activity_compact
 
         bridge_quiet_result_path = write_official_skillsbench_result(
             root / "native-worker-bridge-quiet-result",

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -2624,6 +2624,39 @@ def _skillsbench_controller_trace_counters(
         "native_goal_worker_context_only_followup_start_succeeded_count": count(
             "native_goal_worker_context_only_followup_start_succeeded_count"
         ),
+        "native_goal_worker_normal_followup_attempted_count": count(
+            "native_goal_worker_normal_followup_attempted_count"
+        ),
+        "native_goal_worker_normal_followup_succeeded_count": count(
+            "native_goal_worker_normal_followup_succeeded_count"
+        ),
+        "native_goal_worker_normal_followup_start_attempted_count": count(
+            "native_goal_worker_normal_followup_start_attempted_count"
+        ),
+        "native_goal_worker_normal_followup_start_succeeded_count": count(
+            "native_goal_worker_normal_followup_start_succeeded_count"
+        ),
+        "native_goal_worker_finish_guard_followup_attempted_count": count(
+            "native_goal_worker_finish_guard_followup_attempted_count"
+        ),
+        "native_goal_worker_finish_guard_followup_succeeded_count": count(
+            "native_goal_worker_finish_guard_followup_succeeded_count"
+        ),
+        "native_goal_worker_finish_guard_followup_start_attempted_count": count(
+            "native_goal_worker_finish_guard_followup_start_attempted_count"
+        ),
+        "native_goal_worker_finish_guard_followup_start_succeeded_count": count(
+            "native_goal_worker_finish_guard_followup_start_succeeded_count"
+        ),
+        "native_goal_worker_incomplete_turn_status_count": count(
+            "native_goal_worker_incomplete_turn_status_count"
+        ),
+        "native_goal_worker_incomplete_after_completion_event_count": count(
+            "native_goal_worker_incomplete_after_completion_event_count"
+        ),
+        "native_goal_worker_incomplete_turn_statuses": text_list(
+            "native_goal_worker_incomplete_turn_statuses"
+        ),
         "native_goal_worker_transport_reconnect_attempted_count": count(
             "native_goal_worker_transport_reconnect_attempted_count"
         ),
@@ -3829,6 +3862,40 @@ def build_skillsbench_benchflow_result_benchmark_run(
         "context_only_followup_start_succeeded_count": _controller_public_count(
             "native_goal_worker_context_only_followup_start_succeeded_count"
         ),
+        "normal_followup_attempted_count": _controller_public_count(
+            "native_goal_worker_normal_followup_attempted_count"
+        ),
+        "normal_followup_succeeded_count": _controller_public_count(
+            "native_goal_worker_normal_followup_succeeded_count"
+        ),
+        "normal_followup_start_attempted_count": _controller_public_count(
+            "native_goal_worker_normal_followup_start_attempted_count"
+        ),
+        "normal_followup_start_succeeded_count": _controller_public_count(
+            "native_goal_worker_normal_followup_start_succeeded_count"
+        ),
+        "finish_guard_followup_attempted_count": _controller_public_count(
+            "native_goal_worker_finish_guard_followup_attempted_count"
+        ),
+        "finish_guard_followup_succeeded_count": _controller_public_count(
+            "native_goal_worker_finish_guard_followup_succeeded_count"
+        ),
+        "finish_guard_followup_start_attempted_count": _controller_public_count(
+            "native_goal_worker_finish_guard_followup_start_attempted_count"
+        ),
+        "finish_guard_followup_start_succeeded_count": _controller_public_count(
+            "native_goal_worker_finish_guard_followup_start_succeeded_count"
+        ),
+        "incomplete_turn_status_count": _controller_public_count(
+            "native_goal_worker_incomplete_turn_status_count"
+        ),
+        "incomplete_after_completion_event_count": _controller_public_count(
+            "native_goal_worker_incomplete_after_completion_event_count"
+        ),
+        "incomplete_turn_statuses": controller_counters.get(
+            "native_goal_worker_incomplete_turn_statuses"
+        )
+        or [],
         "transport_reconnect_attempted_count": _controller_public_count(
             "native_goal_worker_transport_reconnect_attempted_count"
         ),
@@ -5449,6 +5516,56 @@ def build_skillsbench_benchflow_result_benchmark_run(
             "native_goal_worker_context_only_followup_start_succeeded_count": (
                 controller_counters.get(
                     "native_goal_worker_context_only_followup_start_succeeded_count", 0
+                )
+            ),
+            "native_goal_worker_normal_followup_attempted_count": (
+                controller_counters.get(
+                    "native_goal_worker_normal_followup_attempted_count", 0
+                )
+            ),
+            "native_goal_worker_normal_followup_succeeded_count": (
+                controller_counters.get(
+                    "native_goal_worker_normal_followup_succeeded_count", 0
+                )
+            ),
+            "native_goal_worker_normal_followup_start_attempted_count": (
+                controller_counters.get(
+                    "native_goal_worker_normal_followup_start_attempted_count", 0
+                )
+            ),
+            "native_goal_worker_normal_followup_start_succeeded_count": (
+                controller_counters.get(
+                    "native_goal_worker_normal_followup_start_succeeded_count", 0
+                )
+            ),
+            "native_goal_worker_finish_guard_followup_attempted_count": (
+                controller_counters.get(
+                    "native_goal_worker_finish_guard_followup_attempted_count", 0
+                )
+            ),
+            "native_goal_worker_finish_guard_followup_succeeded_count": (
+                controller_counters.get(
+                    "native_goal_worker_finish_guard_followup_succeeded_count", 0
+                )
+            ),
+            "native_goal_worker_finish_guard_followup_start_attempted_count": (
+                controller_counters.get(
+                    "native_goal_worker_finish_guard_followup_start_attempted_count", 0
+                )
+            ),
+            "native_goal_worker_finish_guard_followup_start_succeeded_count": (
+                controller_counters.get(
+                    "native_goal_worker_finish_guard_followup_start_succeeded_count", 0
+                )
+            ),
+            "native_goal_worker_incomplete_turn_status_count": (
+                controller_counters.get(
+                    "native_goal_worker_incomplete_turn_status_count", 0
+                )
+            ),
+            "native_goal_worker_incomplete_after_completion_event_count": (
+                controller_counters.get(
+                    "native_goal_worker_incomplete_after_completion_event_count", 0
                 )
             ),
             "native_goal_worker_transport_reconnect_attempted_count": (

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -1627,6 +1627,16 @@ def _compact_benchmark_interaction_counters(value: Any) -> dict[str, Any]:
         "native_goal_worker_context_only_recovery_succeeded_count",
         "native_goal_worker_context_only_followup_start_attempted_count",
         "native_goal_worker_context_only_followup_start_succeeded_count",
+        "native_goal_worker_normal_followup_attempted_count",
+        "native_goal_worker_normal_followup_succeeded_count",
+        "native_goal_worker_normal_followup_start_attempted_count",
+        "native_goal_worker_normal_followup_start_succeeded_count",
+        "native_goal_worker_finish_guard_followup_attempted_count",
+        "native_goal_worker_finish_guard_followup_succeeded_count",
+        "native_goal_worker_finish_guard_followup_start_attempted_count",
+        "native_goal_worker_finish_guard_followup_start_succeeded_count",
+        "native_goal_worker_incomplete_turn_status_count",
+        "native_goal_worker_incomplete_after_completion_event_count",
         "native_goal_worker_transport_reconnect_attempted_count",
         "native_goal_worker_transport_reconnect_succeeded_count",
         "native_goal_worker_goal_reactivation_attempted_count",
@@ -1890,6 +1900,16 @@ def _compact_native_goal_worker_contract(value: Any) -> dict[str, Any]:
         "context_only_recovery_succeeded_count",
         "context_only_followup_start_attempted_count",
         "context_only_followup_start_succeeded_count",
+        "normal_followup_attempted_count",
+        "normal_followup_succeeded_count",
+        "normal_followup_start_attempted_count",
+        "normal_followup_start_succeeded_count",
+        "finish_guard_followup_attempted_count",
+        "finish_guard_followup_succeeded_count",
+        "finish_guard_followup_start_attempted_count",
+        "finish_guard_followup_start_succeeded_count",
+        "incomplete_turn_status_count",
+        "incomplete_after_completion_event_count",
         "transport_reconnect_attempted_count",
         "transport_reconnect_succeeded_count",
         "goal_reactivation_attempted_count",
@@ -1917,6 +1937,12 @@ def _compact_native_goal_worker_contract(value: Any) -> dict[str, Any]:
         text = public_safe_compact_text(value.get(field), limit=140)
         if text:
             compact[field] = text
+    incomplete_statuses = public_safe_compact_list(
+        value.get("incomplete_turn_statuses"),
+        limit=MAX_BENCHMARK_RUN_LIST_ITEMS,
+    )
+    if incomplete_statuses:
+        compact["incomplete_turn_statuses"] = incomplete_statuses
     return compact
 
 
@@ -3978,6 +4004,16 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         "native_goal_worker_context_only_recovery_succeeded_count",
         "native_goal_worker_context_only_followup_start_attempted_count",
         "native_goal_worker_context_only_followup_start_succeeded_count",
+        "native_goal_worker_normal_followup_attempted_count",
+        "native_goal_worker_normal_followup_succeeded_count",
+        "native_goal_worker_normal_followup_start_attempted_count",
+        "native_goal_worker_normal_followup_start_succeeded_count",
+        "native_goal_worker_finish_guard_followup_attempted_count",
+        "native_goal_worker_finish_guard_followup_succeeded_count",
+        "native_goal_worker_finish_guard_followup_start_attempted_count",
+        "native_goal_worker_finish_guard_followup_start_succeeded_count",
+        "native_goal_worker_incomplete_turn_status_count",
+        "native_goal_worker_incomplete_after_completion_event_count",
         "native_goal_worker_transport_reconnect_attempted_count",
         "native_goal_worker_transport_reconnect_succeeded_count",
         "native_goal_worker_goal_reactivation_attempted_count",

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -4724,6 +4724,110 @@ def _apply_host_local_acp_prereq_failure_attribution(
     return True
 
 
+def _apply_native_goal_worker_finish_guard_attribution(
+    compact: dict[str, Any],
+) -> bool:
+    official_score = compact.get("official_score")
+    if (
+        isinstance(official_score, (int, float))
+        and not isinstance(official_score, bool)
+        and official_score >= 1.0
+    ):
+        return False
+    counters = compact.get("interaction_counters")
+    if not isinstance(counters, dict):
+        return False
+    worker_contract = compact.get("native_goal_worker_contract")
+    if not isinstance(worker_contract, dict):
+        worker_contract = {}
+    if counters.get("native_goal_worker_route") is not True:
+        return False
+    incomplete_count = counters.get(
+        "native_goal_worker_incomplete_after_completion_event_count"
+    )
+    if not isinstance(incomplete_count, int) or isinstance(incomplete_count, bool):
+        incomplete_count = worker_contract.get(
+            "incomplete_after_completion_event_count"
+        )
+    if not (
+        isinstance(incomplete_count, int)
+        and not isinstance(incomplete_count, bool)
+        and incomplete_count > 0
+    ):
+        return False
+    task_ops = counters.get(
+        "remote_command_file_bridge_agent_task_facing_operation_count"
+    )
+    task_success = counters.get(
+        "remote_command_file_bridge_agent_task_facing_success_count"
+    )
+    if (
+        isinstance(task_ops, int)
+        and not isinstance(task_ops, bool)
+        and task_ops > 0
+    ) or (
+        isinstance(task_success, int)
+        and not isinstance(task_success, bool)
+        and task_success > 0
+    ):
+        return False
+
+    label = "skillsbench_native_goal_worker_incomplete_turn_without_task_activity"
+    compact["score_failure_attribution"] = label
+    compact["first_blocker"] = label
+    compact["official_score_comparable_to_native_codex"] = False
+    compact["official_score_comparable_to_loopx_treatment"] = False
+    existing_labels = [
+        item
+        for item in compact.get("failure_attribution_labels", [])
+        if isinstance(item, str)
+        and item
+        not in {
+            "official_score_zero_case_failure",
+            "official_verifier_solution_failure",
+            "verifier_infrastructure_failure",
+        }
+    ]
+    for item in (label, "skillsbench_runner_setup_error"):
+        if item not in existing_labels:
+            existing_labels.append(item)
+    compact["failure_attribution_labels"] = existing_labels
+    runner_failure = compact.setdefault("runner_failure", {})
+    if isinstance(runner_failure, dict):
+        runner_failure["exception_type"] = label
+        runner_failure["failure_class"] = label
+        runner_failure["native_goal_worker"] = {
+            "failure_category": label,
+            "incomplete_after_completion_event_count": incomplete_count,
+            "task_facing_operation_count": max(0, int(task_ops or 0)),
+            "raw_material_recorded": False,
+        }
+    if isinstance(worker_contract, dict):
+        worker_contract["countable_baseline"] = False
+        worker_contract["failure_category"] = label
+        worker_contract["first_blocker"] = label
+        worker_contract["countability_source"] = "native_goal_worker_finish_guard"
+    attempt_accounting = compact.get("attempt_accounting")
+    if isinstance(attempt_accounting, dict):
+        attempt_accounting["failure_class"] = "job_materialization_failed"
+        attempt_accounting["failure_label"] = label
+        attempt_accounting["lifecycle_phase"] = "runner_accepted_args"
+        for key in (
+            "case_attempt_countable",
+            "solver_attempt_countable",
+            "verifier_attempt_countable",
+            "official_score_attempt_countable",
+        ):
+            attempt_accounting[key] = False
+        attempts = attempt_accounting.get("attempts")
+        if isinstance(attempts, dict):
+            for key in ("case", "solver", "verifier", "official_score"):
+                attempt = attempts.get(key)
+                if isinstance(attempt, dict):
+                    attempt["countable"] = False
+    return True
+
+
 def _case_timeline_safe_string(value: Any, *, limit: int = 140) -> str:
     if not isinstance(value, str):
         return ""
@@ -9857,6 +9961,13 @@ def _merge_app_server_goal_worker_trace_summary(
     normal_followup_succeeded_count = 0
     normal_followup_start_attempted_count = 0
     normal_followup_start_succeeded_count = 0
+    finish_guard_followup_attempted_count = 0
+    finish_guard_followup_succeeded_count = 0
+    finish_guard_followup_start_attempted_count = 0
+    finish_guard_followup_start_succeeded_count = 0
+    incomplete_turn_status_count = 0
+    incomplete_after_completion_event_count = 0
+    incomplete_turn_statuses: list[str] = []
     transport_reconnect_attempted_count = 0
     transport_reconnect_succeeded_count = 0
     goal_reactivation_attempted_count = 0
@@ -10001,6 +10112,58 @@ def _merge_app_server_goal_worker_trace_summary(
                 normal_successes, bool
             ):
                 normal_followup_start_succeeded_count += max(0, normal_successes)
+        finish_guard_followup = (
+            payload.get("finish_guard_followup")
+            if isinstance(payload.get("finish_guard_followup"), dict)
+            else {}
+        )
+        if (
+            turn.get("finish_guard_followup_attempted") is True
+            or finish_guard_followup.get("attempted") is True
+        ):
+            finish_guard_followup_attempted_count += 1
+        if (
+            turn.get("finish_guard_followup_succeeded") is True
+            or finish_guard_followup.get("succeeded") is True
+        ):
+            finish_guard_followup_succeeded_count += 1
+        finish_attempts = turn.get("finish_guard_followup_start_attempted_count")
+        if isinstance(finish_attempts, int) and not isinstance(
+            finish_attempts, bool
+        ):
+            finish_guard_followup_start_attempted_count += max(0, finish_attempts)
+        else:
+            finish_attempts = finish_guard_followup.get(
+                "followup_start_attempted_count"
+            )
+            if isinstance(finish_attempts, int) and not isinstance(
+                finish_attempts, bool
+            ):
+                finish_guard_followup_start_attempted_count += max(
+                    0, finish_attempts
+                )
+        finish_successes = turn.get("finish_guard_followup_start_succeeded_count")
+        if isinstance(finish_successes, int) and not isinstance(
+            finish_successes, bool
+        ):
+            finish_guard_followup_start_succeeded_count += max(0, finish_successes)
+        else:
+            finish_successes = finish_guard_followup.get(
+                "followup_start_succeeded_count"
+            )
+            if isinstance(finish_successes, int) and not isinstance(
+                finish_successes, bool
+            ):
+                finish_guard_followup_start_succeeded_count += max(
+                    0, finish_successes
+                )
+        turn_status = str(turn.get("turn_status") or "").strip()
+        if turn_status and turn_status != "completed":
+            incomplete_turn_status_count += 1
+            if turn_status[:80] not in incomplete_turn_statuses:
+                incomplete_turn_statuses.append(turn_status[:80])
+            if turn.get("turn_completed_observed") is True:
+                incomplete_after_completion_event_count += 1
         if turn.get("transport_reconnect_attempted") is True:
             transport_reconnect_attempted_count += 1
         if turn.get("transport_reconnect_succeeded") is True:
@@ -10156,6 +10319,25 @@ def _merge_app_server_goal_worker_trace_summary(
     trace["native_goal_worker_normal_followup_start_succeeded_count"] = (
         normal_followup_start_succeeded_count
     )
+    trace["native_goal_worker_finish_guard_followup_attempted_count"] = (
+        finish_guard_followup_attempted_count
+    )
+    trace["native_goal_worker_finish_guard_followup_succeeded_count"] = (
+        finish_guard_followup_succeeded_count
+    )
+    trace["native_goal_worker_finish_guard_followup_start_attempted_count"] = (
+        finish_guard_followup_start_attempted_count
+    )
+    trace["native_goal_worker_finish_guard_followup_start_succeeded_count"] = (
+        finish_guard_followup_start_succeeded_count
+    )
+    trace["native_goal_worker_incomplete_turn_status_count"] = (
+        incomplete_turn_status_count
+    )
+    trace["native_goal_worker_incomplete_after_completion_event_count"] = (
+        incomplete_after_completion_event_count
+    )
+    trace["native_goal_worker_incomplete_turn_statuses"] = incomplete_turn_statuses
     trace["native_goal_worker_transport_reconnect_attempted_count"] = (
         transport_reconnect_attempted_count
     )
@@ -10206,6 +10388,13 @@ def _merge_app_server_goal_worker_trace_summary(
         "native_goal_worker_normal_followup_succeeded_count",
         "native_goal_worker_normal_followup_start_attempted_count",
         "native_goal_worker_normal_followup_start_succeeded_count",
+        "native_goal_worker_finish_guard_followup_attempted_count",
+        "native_goal_worker_finish_guard_followup_succeeded_count",
+        "native_goal_worker_finish_guard_followup_start_attempted_count",
+        "native_goal_worker_finish_guard_followup_start_succeeded_count",
+        "native_goal_worker_incomplete_turn_status_count",
+        "native_goal_worker_incomplete_after_completion_event_count",
+        "native_goal_worker_incomplete_turn_statuses",
         "native_goal_worker_transport_reconnect_attempted_count",
         "native_goal_worker_transport_reconnect_succeeded_count",
         "native_goal_worker_goal_reactivation_attempted_count",
@@ -13881,6 +14070,7 @@ def reduce_result(
             compact,
             runner_prerequisites,
         )
+    _apply_native_goal_worker_finish_guard_attribution(compact)
     prereq_failure = _runner_prerequisite_failure_attribution(
         plan.get("runner_prerequisites")
     )

--- a/scripts/skillsbench_host_codex_goal_worker.py
+++ b/scripts/skillsbench_host_codex_goal_worker.py
@@ -43,6 +43,7 @@ NORMAL_FOLLOWUP_PROMPT = """Continue the same SkillsBench task in this existing 
 Do not use or infer verifier, reward, pass/fail, hidden-test, or gold-answer feedback; none is being provided.
 Review your prior work, improve the scored output if needed using only the visible task, workspace, and bridge context already available in this thread, and end the turn once the best task-required output exists."""
 APP_SERVER_GOAL_PROMPT_STYLES = ("bridge-only", "native-goal", "cli-exec-like")
+COMPLETE_TURN_STATUSES = {"completed"}
 
 
 def _json_default(value: Any) -> str:
@@ -210,6 +211,13 @@ def _terminal_app_server_failure(turn: Any) -> str:
     return ""
 
 
+def _turn_completion_shape_unclean(compact: dict[str, Any]) -> bool:
+    if compact.get("turn_completed_observed") is not True:
+        return True
+    status = str(compact.get("turn_status") or "").strip()
+    return bool(status and status not in COMPLETE_TURN_STATUSES)
+
+
 def _compact_worker_turn(
     turn: Any,
     *,
@@ -302,12 +310,18 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
     try:
         followup_budget = max(0, int(args.context_only_followup_max or 0))
         normal_followup_budget = max(0, int(args.normal_followup_max or 0))
+        finish_guard_followup_budget = max(
+            0, int(args.finish_guard_followup_max or 0)
+        )
         context_only_followup_start_attempted = False
         context_only_followup_start_succeeded = False
         context_only_followup_start_error_type = ""
         normal_followup_start_attempted_count = 0
         normal_followup_start_succeeded_count = 0
         normal_followup_start_error_type = ""
+        finish_guard_followup_start_attempted_count = 0
+        finish_guard_followup_start_succeeded_count = 0
+        finish_guard_followup_start_error_type = ""
         attempt_number = 1
         while True:
             if not args.no_wait_for_completion:
@@ -343,7 +357,17 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
             attempt_compacts.append(compact)
             if worker_error_type or args.no_wait_for_completion:
                 break
-            if compact.get("assistant_message_context_only") is True:
+            if _turn_completion_shape_unclean(compact):
+                if finish_guard_followup_budget <= 0:
+                    worker_error_type = (
+                        "codex_app_server_turn_incomplete_after_completion_event"
+                    )
+                    break
+                finish_guard_followup_budget -= 1
+                followup_prompt = NORMAL_FOLLOWUP_PROMPT
+                followup_error_kind = "finish_guard"
+                finish_guard_followup_start_attempted_count += 1
+            elif compact.get("assistant_message_context_only") is True:
                 if followup_budget <= 0:
                     worker_error_type = "codex_app_server_context_only_assistant_message"
                     break
@@ -377,6 +401,8 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
                 )
                 if followup_error_kind == "context_only":
                     context_only_followup_start_succeeded = True
+                elif followup_error_kind == "finish_guard":
+                    finish_guard_followup_start_succeeded_count += 1
                 else:
                     normal_followup_start_succeeded_count += 1
             except CodexAppServerGoalDriverError as exc:
@@ -385,10 +411,14 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
                     worker_error_type = detail
                 elif followup_error_kind == "context_only":
                     worker_error_type = "codex_app_server_context_only_followup_start_failed"
+                elif followup_error_kind == "finish_guard":
+                    worker_error_type = "codex_app_server_finish_guard_followup_start_failed"
                 else:
                     worker_error_type = "codex_app_server_normal_followup_start_failed"
                 if followup_error_kind == "context_only":
                     context_only_followup_start_error_type = worker_error_type
+                elif followup_error_kind == "finish_guard":
+                    finish_guard_followup_start_error_type = worker_error_type
                 else:
                     normal_followup_start_error_type = worker_error_type
                 break
@@ -461,6 +491,31 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
                     normal_followup_start_succeeded_count
                 ),
                 "normal_followup_start_error_type": normal_followup_start_error_type,
+                "finish_guard_followup_max": max(
+                    0, int(args.finish_guard_followup_max or 0)
+                ),
+                "finish_guard_followup_attempted": bool(
+                    finish_guard_followup_start_attempted_count
+                ),
+                "finish_guard_followup_succeeded": bool(
+                    finish_guard_followup_start_attempted_count
+                    and finish_guard_followup_start_succeeded_count
+                    == finish_guard_followup_start_attempted_count
+                    and not worker_error_type
+                    and not _turn_completion_shape_unclean(compact)
+                ),
+                "finish_guard_followup_start_attempted_count": (
+                    finish_guard_followup_start_attempted_count
+                ),
+                "finish_guard_followup_start_succeeded_count": (
+                    finish_guard_followup_start_succeeded_count
+                ),
+                "finish_guard_followup_start_error_type": (
+                    finish_guard_followup_start_error_type
+                ),
+                "turn_completion_shape_unclean": _turn_completion_shape_unclean(
+                    compact
+                ),
             }
         )
         if attempt_compacts:
@@ -479,6 +534,8 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
             worker_error_type = "codex_app_server_context_only_assistant_message"
         if worker_error_type and compact.get("normal_followup_attempted") is True:
             compact["normal_followup_succeeded"] = False
+        if worker_error_type and compact.get("finish_guard_followup_attempted") is True:
+            compact["finish_guard_followup_succeeded"] = False
         private_response_written = False
         if args.response_text_file and turn.assistant_message:
             response_path = Path(args.response_text_file).expanduser()
@@ -567,6 +624,24 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
             "reward_feedback_provided": False,
             "verifier_feedback_provided": False,
         },
+        "finish_guard_followup": {
+            "enabled": max(0, int(args.finish_guard_followup_max or 0)) > 0,
+            "max_followups": max(0, int(args.finish_guard_followup_max or 0)),
+            "attempted": bool(compact.get("finish_guard_followup_attempted")),
+            "succeeded": bool(compact.get("finish_guard_followup_succeeded")),
+            "followup_start_attempted_count": int(
+                compact.get("finish_guard_followup_start_attempted_count") or 0
+            ),
+            "followup_start_succeeded_count": int(
+                compact.get("finish_guard_followup_start_succeeded_count") or 0
+            ),
+            "followup_start_error_type": str(
+                compact.get("finish_guard_followup_start_error_type") or ""
+            ),
+            "turn_attempt_count": int(compact.get("turn_attempt_count") or 1),
+            "reward_feedback_provided": False,
+            "verifier_feedback_provided": False,
+        },
         "private_response_text": {
             "written": private_response_written,
             "path_recorded": False,
@@ -628,6 +703,18 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "completed app-server Goal turns. The continuation prompt provides "
             "no verifier, reward, pass/fail, hidden-test, or gold-answer "
             "feedback; default 0 preserves baseline single-turn behavior."
+        ),
+    )
+    parser.add_argument(
+        "--finish-guard-followup-max",
+        type=int,
+        default=1,
+        help=(
+            "Same-thread continuation budget when the app-server reports a "
+            "turn completion event but the public turn status is not completed. "
+            "This guard prevents in-progress turns from being scored as clean "
+            "solution attempts without verifier, reward, hidden-test, or gold "
+            "feedback."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
## Summary
- add a native app-server Goal finish guard that continues same-thread when the public turn completion shape is incomplete
- propagate finish-guard and incomplete-turn public counters through controller trace, SkillsBench compact adapter, native worker contract, and status compaction
- classify unresolved incomplete native Goal turns with zero task-facing bridge ops as runner/setup failures instead of countable verifier solution failures

## Validation
- python3 -m py_compile scripts/skillsbench_host_codex_goal_worker.py scripts/skillsbench_automation_loop.py loopx/status.py loopx/benchmark_adapters/skillsbench.py examples/skillsbench-benchmark-run-smoke.py
- focused: import examples/skillsbench-benchmark-run-smoke.py and run test_skillsbench_round_trace_records_best_round_score()
- git diff --check
- sensitive diff scan for proxy/IP/local-path/raw-evidence literals: no matches

Note: full examples/skillsbench-benchmark-run-smoke.py advances past the new focused regression and then fails in existing test_skillsbench_repeat_same_mode_keeps_distinct_ledger_runs, where repeat same-mode compact ledger entries collapse to one run.