### PR TITLE
Extract issue meta surface projection helper

### DIFF
--- a/loopx/projections/issue_meta_surface.py
+++ b/loopx/projections/issue_meta_surface.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any, Callable, Optional
+
+
+MAX_ISSUE_META_SURFACE_ITEMS = 8
+MAX_ISSUE_META_LABELS = 8
+
+ISSUE_META_SURFACE_SCHEMA_VERSION = "issue_meta_surface_v0"
+ISSUE_META_SURFACE_ITEM_SCHEMA_VERSION = "issue_meta_surface_item_v0"
+ISSUE_META_SURFACE_SECTION_HEADINGS = ("Issue Meta Surface", "Issue/PR Meta Surface")
+ISSUE_META_SURFACE_FIELD_PATTERN = re.compile(
+    r"(?P<key>[a-z_][a-z0-9_-]*)=(?P<value>\"[^\"]+\"|'[^']+'|[^\s]+)"
+)
+
+PublicSafeText = Callable[..., Optional[str]]
+SectionParser = Callable[[str, tuple[str, ...]], dict[str, list[str]]]
+
+
+def issue_meta_surface_blocks(lines: list[str]) -> list[str]:
+    blocks: list[str] = []
+    current: list[str] = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith(("- ", "* ")):
+            if current:
+                blocks.append(" ".join(current))
+            current = [stripped[2:].strip()]
+            continue
+        if current and line.startswith((" ", "\t")):
+            current.append(stripped)
+    if current:
+        blocks.append(" ".join(current))
+    return blocks
+
+
+def issue_meta_public_value(
+    value: Any,
+    *,
+    public_safe_compact_text: PublicSafeText,
+    limit: int = 120,
+) -> str | None:
+    text = public_safe_compact_text(value, limit=limit)
+    if not text:
+        return None
+    if "<" in text or ">" in text:
+        return None
+    return text.strip("\"'")
+
+
+def issue_meta_list(
+    value: Any,
+    *,
+    public_safe_compact_text: PublicSafeText,
+    limit: int = MAX_ISSUE_META_LABELS,
+) -> list[str]:
+    if value is None:
+        return []
+    raw_values = re.split(r"[,;|]", str(value or ""))
+    items: list[str] = []
+    seen: set[str] = set()
+    for raw in raw_values:
+        item = issue_meta_public_value(raw, public_safe_compact_text=public_safe_compact_text, limit=80)
+        if not item or item in seen:
+            continue
+        seen.add(item)
+        items.append(item)
+        if len(items) >= limit:
+            break
+    return items
+
+
+def parse_issue_meta_surface_block(
+    block: str,
+    *,
+    index: int,
+    public_safe_compact_text: PublicSafeText,
+) -> dict[str, Any] | None:
+    fields: dict[str, str] = {}
+    for match in ISSUE_META_SURFACE_FIELD_PATTERN.finditer(block):
+        key = str(match.group("key") or "").strip().lower().replace("-", "_")
+        value = str(match.group("value") or "").strip().strip("\"'")
+        if key and value:
+            fields[key] = value
+    if not fields:
+        return None
+
+    item: dict[str, Any] = {
+        "schema_version": ISSUE_META_SURFACE_ITEM_SCHEMA_VERSION,
+        "index": index,
+    }
+    alias_map = {
+        "anchor_id": ("anchor_id", "id"),
+        "repo_handle": ("repo_handle", "repo"),
+        "issue_handle": ("issue_handle", "issue", "issue_or_pr", "issue_or_pr_handle"),
+        "owner_route": ("owner_route", "owner"),
+        "related_code_hint": ("related_code_hint", "related_code", "code"),
+        "validation_surface": ("validation_surface", "validation"),
+        "promotion_target": ("promotion_target", "promotion"),
+        "status": ("status",),
+        "freshness": ("freshness",),
+    }
+    for output_key, aliases in alias_map.items():
+        raw_value = next((fields[alias] for alias in aliases if alias in fields), None)
+        value = issue_meta_public_value(raw_value, public_safe_compact_text=public_safe_compact_text)
+        if value:
+            item[output_key] = value
+    labels = issue_meta_list(
+        fields.get("labels") or fields.get("label"),
+        public_safe_compact_text=public_safe_compact_text,
+    )
+    if labels:
+        item["labels"] = labels
+
+    required = ("repo_handle", "owner_route", "validation_surface", "promotion_target")
+    if not all(item.get(key) for key in required):
+        return None
+    if not item.get("anchor_id"):
+        repo = str(item.get("repo_handle") or "")
+        issue = str(item.get("issue_handle") or "")
+        anchor_basis = "|".join(part for part in (repo, issue, str(index)) if part)
+        item["anchor_id"] = f"issue_anchor_{hashlib.sha1(anchor_basis.encode('utf-8')).hexdigest()[:10]}"
+    return item
+
+
+def parse_issue_meta_surface(
+    state_text: str,
+    *,
+    section_parser: SectionParser,
+    public_safe_compact_text: PublicSafeText,
+) -> dict[str, Any] | None:
+    section_map = section_parser(state_text, ISSUE_META_SURFACE_SECTION_HEADINGS)
+    for heading in ISSUE_META_SURFACE_SECTION_HEADINGS:
+        lines = section_map.get(heading) or []
+        blocks = issue_meta_surface_blocks(lines)
+        items = [
+            item
+            for index, block in enumerate(blocks, start=1)
+            for item in [
+                parse_issue_meta_surface_block(
+                    block,
+                    index=index,
+                    public_safe_compact_text=public_safe_compact_text,
+                )
+            ]
+            if item
+        ]
+        if items:
+            return {
+                "schema_version": ISSUE_META_SURFACE_SCHEMA_VERSION,
+                "source_section": heading,
+                "item_count": len(items),
+                "items": items[:MAX_ISSUE_META_SURFACE_ITEMS],
+            }
+    return None

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -88,6 +88,9 @@ from .projections.monitor_display import (
     todo_summary_lane_items as _todo_summary_lane_items,
     todo_summary_open_count as _todo_summary_open_count,
 )
+from .projections.issue_meta_surface import (
+    parse_issue_meta_surface as _parse_issue_meta_surface_read_model,
+)
 from .projections.todo_summary import (
     active_next_action_todo_ids,
     apply_resume_conditions,
@@ -466,12 +469,8 @@ MAX_PROJECT_ASSET_TODO_BACKLOG_ITEMS = 8
 MAX_TODO_VISIBILITY_LANE_ITEMS = 16
 MAX_DEFERRED_TODO_VISIBILITY_ITEMS = 8
 MAX_MONITOR_DUE_ITEMS = 1
-MAX_ISSUE_META_SURFACE_ITEMS = 8
-MAX_ISSUE_META_LABELS = 8
 MAX_TODO_INDEX_ITEMS = 240
 MAX_TODO_INDEX_ROLLOUT_EVENTS_PER_GOAL = 500
-ISSUE_META_SURFACE_SCHEMA_VERSION = "issue_meta_surface_v0"
-ISSUE_META_SURFACE_ITEM_SCHEMA_VERSION = "issue_meta_surface_item_v0"
 MAX_DEPENDENCY_BLOCKERS = 4
 MAX_AUTONOMOUS_BACKLOG_CANDIDATES = 6
 MAX_SUBAGENT_ACTIVITY_ITEMS = 5
@@ -484,10 +483,6 @@ AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD = 20
 AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK = 30
 BACKLOG_HYGIENE_SECTION_HEADINGS = ("Next Action", "Operating Lessons")
 BACKLOG_HYGIENE_BULLET_PATTERN = re.compile(r"^\s*(?:[-*]|\d+[.)])\s+(.+?)\s*$")
-ISSUE_META_SURFACE_SECTION_HEADINGS = ("Issue Meta Surface", "Issue/PR Meta Surface")
-ISSUE_META_SURFACE_FIELD_PATTERN = re.compile(
-    r"(?P<key>[a-z_][a-z0-9_-]*)=(?P<value>\"[^\"]+\"|'[^']+'|[^\s]+)"
-)
 BACKLOG_HYGIENE_HINT_PATTERN = re.compile(
     r"(?i)(?:\[p[0-4]\]|todo|backlog|follow[- ]?up|queue|audit|regression|smoke|cadence|mirror|monitor|sub-?agent|待办|回归|审计|修复|检查|推进)"
 )
@@ -6138,115 +6133,12 @@ def active_state_sections(state_text: str, headings: tuple[str, ...]) -> dict[st
     return sections
 
 
-def issue_meta_surface_blocks(lines: list[str]) -> list[str]:
-    blocks: list[str] = []
-    current: list[str] = []
-    for line in lines:
-        stripped = line.strip()
-        if not stripped:
-            continue
-        if stripped.startswith(("- ", "* ")):
-            if current:
-                blocks.append(" ".join(current))
-            current = [stripped[2:].strip()]
-            continue
-        if current and line.startswith((" ", "\t")):
-            current.append(stripped)
-    if current:
-        blocks.append(" ".join(current))
-    return blocks
-
-
-def issue_meta_public_value(value: Any, *, limit: int = 120) -> str | None:
-    text = public_safe_compact_text(value, limit=limit)
-    if not text:
-        return None
-    if "<" in text or ">" in text:
-        return None
-    return text.strip("\"'")
-
-
-def issue_meta_list(value: Any, *, limit: int = MAX_ISSUE_META_LABELS) -> list[str]:
-    if value is None:
-        return []
-    raw_values = re.split(r"[,;|]", str(value or ""))
-    items: list[str] = []
-    seen: set[str] = set()
-    for raw in raw_values:
-        item = issue_meta_public_value(raw, limit=80)
-        if not item or item in seen:
-            continue
-        seen.add(item)
-        items.append(item)
-        if len(items) >= limit:
-            break
-    return items
-
-
-def parse_issue_meta_surface_block(block: str, *, index: int) -> dict[str, Any] | None:
-    fields: dict[str, str] = {}
-    for match in ISSUE_META_SURFACE_FIELD_PATTERN.finditer(block):
-        key = str(match.group("key") or "").strip().lower().replace("-", "_")
-        value = str(match.group("value") or "").strip().strip("\"'")
-        if key and value:
-            fields[key] = value
-    if not fields:
-        return None
-
-    item: dict[str, Any] = {
-        "schema_version": ISSUE_META_SURFACE_ITEM_SCHEMA_VERSION,
-        "index": index,
-    }
-    alias_map = {
-        "anchor_id": ("anchor_id", "id"),
-        "repo_handle": ("repo_handle", "repo"),
-        "issue_handle": ("issue_handle", "issue", "issue_or_pr", "issue_or_pr_handle"),
-        "owner_route": ("owner_route", "owner"),
-        "related_code_hint": ("related_code_hint", "related_code", "code"),
-        "validation_surface": ("validation_surface", "validation"),
-        "promotion_target": ("promotion_target", "promotion"),
-        "status": ("status",),
-        "freshness": ("freshness",),
-    }
-    for output_key, aliases in alias_map.items():
-        raw_value = next((fields[alias] for alias in aliases if alias in fields), None)
-        value = issue_meta_public_value(raw_value)
-        if value:
-            item[output_key] = value
-    labels = issue_meta_list(fields.get("labels") or fields.get("label"))
-    if labels:
-        item["labels"] = labels
-
-    required = ("repo_handle", "owner_route", "validation_surface", "promotion_target")
-    if not all(item.get(key) for key in required):
-        return None
-    if not item.get("anchor_id"):
-        repo = str(item.get("repo_handle") or "")
-        issue = str(item.get("issue_handle") or "")
-        anchor_basis = "|".join(part for part in (repo, issue, str(index)) if part)
-        item["anchor_id"] = f"issue_anchor_{hashlib.sha1(anchor_basis.encode('utf-8')).hexdigest()[:10]}"
-    return item
-
-
 def parse_issue_meta_surface(state_text: str) -> dict[str, Any] | None:
-    section_map = active_state_sections(state_text, ISSUE_META_SURFACE_SECTION_HEADINGS)
-    for heading in ISSUE_META_SURFACE_SECTION_HEADINGS:
-        lines = section_map.get(heading) or []
-        blocks = issue_meta_surface_blocks(lines)
-        items = [
-            item
-            for index, block in enumerate(blocks, start=1)
-            for item in [parse_issue_meta_surface_block(block, index=index)]
-            if item
-        ]
-        if items:
-            return {
-                "schema_version": ISSUE_META_SURFACE_SCHEMA_VERSION,
-                "source_section": heading,
-                "item_count": len(items),
-                "items": items[:MAX_ISSUE_META_SURFACE_ITEMS],
-            }
-    return None
+    return _parse_issue_meta_surface_read_model(
+        state_text,
+        section_parser=active_state_sections,
+        public_safe_compact_text=public_safe_compact_text,
+    )
 
 
 def active_state_section_entries(lines: list[str]) -> list[str]:


### PR DESCRIPTION
## Summary
- Move Issue Meta Surface parsing into `loopx/projections/issue_meta_surface.py`.
- Keep `loopx.status.parse_issue_meta_surface(state_text)` as the compatibility wrapper.
- Leave generic active-state section/backlog helpers in `status.py` to avoid broad coupling.

## Validation
- `python3 -m compileall -q loopx/status.py loopx/projections/issue_meta_surface.py`
- `python3 examples/issue-meta-surface-smoke.py`
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 examples/control_plane/work-lane-contract-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --profile core-control-plane` -> 123/124 passed; the only failure is the pre-existing `repo-python-line-budget-smoke` on benchmark-owned `examples/skillsbench-benchmark-run-smoke.py` and `scripts/skillsbench_automation_loop.py`.
- `git diff --check`

## Boundary
- Public-safe projection-only refactor; no private state, raw benchmark evidence, credentials, or generated logs included.