### PR TITLE
Add operator simulator ledger compaction

### DIFF
--- a/examples/benchmark-run-ledger-operator-simulator-smoke.py
+++ b/examples/benchmark-run-ledger-operator-simulator-smoke.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Smoke-test operator-simulator rows in the common benchmark run ledger."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.benchmark_ledger import load_benchmark_run_ledger, update_benchmark_run_ledger
+
+
+BENCHMARK_ID = "operator-simulator-ledger@v0"
+CASE_ID = "minimal-assisted-case"
+
+
+def main() -> None:
+    operator_run = {
+        "schema_version": "operator_simulator_run_v0",
+        "benchmark_id": BENCHMARK_ID,
+        "case_id": CASE_ID,
+        "mode": "assisted_operator_simulator",
+        "simulator_setting": "deterministic_operator_fixture",
+        "intervention_count": 1,
+        "proactive_intervention_count": 1,
+        "assisted_score": 0.75,
+        "claim_boundary": {
+            "official_score_claim_allowed": False,
+            "leaderboard_claim_allowed": False,
+            "assisted_collaboration_claim_allowed": True,
+            "assisted_score_kept_separate_from_official": True,
+        },
+    }
+    benchmark_run = {
+        "schema_version": "benchmark_run_v0",
+        "source_runner": "operator_simulator_ledger_smoke",
+        "benchmark_id": BENCHMARK_ID,
+        "case_id": CASE_ID,
+        "job_name": "operator_simulator_ledger_fixture",
+        "mode": "assisted_operator_simulator",
+        "route": "operator-simulator-ledger-fixture",
+        "runner_return_status": "completed",
+        "submit_eligible": False,
+        "leaderboard_evidence": False,
+        "operator_simulator_run": operator_run,
+    }
+
+    with tempfile.TemporaryDirectory(prefix="benchmark-run-ledger-operator-simulator-") as tmp:
+        ledger_path = Path(tmp) / "benchmark-run-ledger.json"
+        update = update_benchmark_run_ledger(
+            ledger_path=ledger_path,
+            benchmark_run=benchmark_run,
+            run_group_id="operator-simulator-ledger-fixture",
+            arm_id="deterministic_operator_fixture",
+            dry_run=False,
+        )
+        assert update["updated"] is True, update
+        entry = update["entry"]
+        assert entry["score_status"] == "missing", entry
+
+        ledger = load_benchmark_run_ledger(ledger_path)
+        run = ledger["benchmarks"][BENCHMARK_ID]["cases"][CASE_ID]["runs"][0]
+        for record in (entry, run):
+            compact = record["operator_simulator_run"]
+            assert "official_score" not in record, record
+            assert "official_score" not in compact, compact
+            assert compact["schema_version"] == "operator_simulator_run_v0", compact
+            assert compact["assisted_score"] == 0.75, compact
+            assert compact["official_score_claim_allowed"] is False, compact
+            assert compact["assisted_score_kept_separate_from_official"] is True, compact
+
+    print("benchmark-run-ledger-operator-simulator-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -21,6 +21,7 @@ BENCHMARK_RUN_LEDGER_SCHEMA_VERSION = "benchmark_run_ledger_v0"
 BENCHMARK_RUN_LEDGER_CURRENT_AGGREGATE_SCHEMA_VERSION = (
     "benchmark_run_ledger_current_aggregate_v0"
 )
+OPERATOR_SIMULATOR_RUN_SCHEMA_VERSION = "operator_simulator_run_v0"
 BENCHMARK_RUN_LEDGER_DEFAULT_PATH = Path(
     "docs/research/long-horizon-agent-benchmarks/benchmark-run-ledger.json"
 )
@@ -707,6 +708,60 @@ def _compact_skillsbench_solution_quality_signals(value: Any) -> dict[str, Any]:
             compact_worker_activity[field] = max(0, raw)
     if compact_worker_activity:
         compact["worker_activity"] = compact_worker_activity
+    return compact
+
+
+def _compact_operator_simulator_run(value: Any) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    schema_version = _compact_text(value.get("schema_version"), limit=120)
+    if schema_version != OPERATOR_SIMULATOR_RUN_SCHEMA_VERSION:
+        return {}
+    compact: dict[str, Any] = {"schema_version": OPERATOR_SIMULATOR_RUN_SCHEMA_VERSION}
+    simulator_identity = (
+        value.get("simulator_identity")
+        if isinstance(value.get("simulator_identity"), dict)
+        else {}
+    )
+    for field in (
+        "arm_schema_version",
+        "benchmark_id",
+        "case_id",
+        "task_id",
+        "mode",
+        "simulator_setting",
+    ):
+        raw = (
+            simulator_identity.get("setting")
+            if field == "simulator_setting" and value.get(field) is None
+            else value.get(field)
+        )
+        text = _compact_text(raw, limit=140)
+        if text:
+            compact[field] = text
+    claim_boundary = (
+        value.get("claim_boundary")
+        if isinstance(value.get("claim_boundary"), dict)
+        else {}
+    )
+    for field in (
+        "rubric_generated_before_solver_start",
+        "official_score_claim_allowed",
+        "leaderboard_claim_allowed",
+        "assisted_collaboration_claim_allowed",
+        "assisted_score_kept_separate_from_official",
+    ):
+        if isinstance(value.get(field), bool):
+            compact[field] = value[field]
+        elif isinstance(claim_boundary.get(field), bool):
+            compact[field] = claim_boundary[field]
+    for field in ("intervention_count", "proactive_intervention_count"):
+        raw = value.get(field)
+        if isinstance(raw, int) and not isinstance(raw, bool) and raw >= 0:
+            compact[field] = raw
+    assisted_score = value.get("assisted_score")
+    if isinstance(assisted_score, (int, float)) and not isinstance(assisted_score, bool):
+        compact["assisted_score"] = float(assisted_score)
     return compact
 
 
@@ -1951,6 +2006,11 @@ def build_benchmark_run_ledger_entry(
     )
     if solution_quality_signals:
         entry["solution_quality_signals"] = solution_quality_signals
+    operator_simulator_run = _compact_operator_simulator_run(
+        benchmark_run.get("operator_simulator_run")
+    )
+    if operator_simulator_run:
+        entry["operator_simulator_run"] = operator_simulator_run
     attempt_accounting = (
         benchmark_run.get("attempt_accounting")
         if isinstance(benchmark_run.get("attempt_accounting"), dict)


### PR DESCRIPTION
## Summary
- add minimal common-ledger support for `operator_simulator_run_v0`
- keep `assisted_score` as assisted evidence, separate from missing `official_score`
- replace the SkillsBench-specific arm/builder smoke with a direct minimal fixture

## Validation
- `python3 -m py_compile loopx/benchmark_ledger.py loopx/worker_bridge.py examples/benchmark-run-ledger-operator-simulator-smoke.py`
- `python3 examples/benchmark-run-ledger-operator-simulator-smoke.py`
- `python3 examples/benchmark-run-ledger-smoke.py`
- `git diff --check origin/main...HEAD`

## Boundary
This PR only adds common benchmark-ledger compaction for operator-simulator rows. It does not add a runner/CLI builder, does not change SkillsBench scoring/task/verifier behavior, and does not touch `loopx/worker_bridge.py`.

Follow-up, if needed: add a generic `build_operator_simulator_run(setting=...)` builder in a separate PR when a runner/CLI actually emits a rubric-derived simulator arm.
