### PR TITLE
Extract session runtime projection helper

### DIFF
--- a/loopx/projections/session_runtime.py
+++ b/loopx/projections/session_runtime.py
@@ -1,0 +1,195 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+from ..session_runtime import SESSION_RUNTIME_READONLY_PROJECTION_SCHEMA_VERSION
+
+
+SESSION_RUNTIME_READONLY_PROJECTION_KEYS = (
+    "session_runtime_readonly_projection",
+    "session_runtime_projection",
+)
+
+PublicSafeText = Callable[..., Optional[str]]
+PublicSafeList = Callable[..., list[str]]
+
+
+def compact_session_runtime_source(
+    source: Any,
+    *,
+    public_safe_compact_text: PublicSafeText,
+) -> dict[str, Any]:
+    if not isinstance(source, dict):
+        return {}
+    compact: dict[str, Any] = {}
+    host_kind = public_safe_compact_text(source.get("host_kind"), limit=80)
+    if host_kind:
+        compact["host_kind"] = host_kind
+    latest_fact_at = public_safe_compact_text(source.get("latest_fact_at"), limit=80)
+    if latest_fact_at:
+        compact["latest_fact_at"] = latest_fact_at
+    source_refs = source.get("source_refs")
+    if isinstance(source_refs, dict):
+        counts = {
+            str(key): len(value)
+            for key, value in source_refs.items()
+            if isinstance(value, list) and value
+        }
+        if counts:
+            compact["source_ref_counts"] = counts
+    return compact
+
+
+def compact_session_runtime_boundary(
+    boundary: Any,
+    *,
+    public_safe_compact_list: PublicSafeList,
+) -> dict[str, Any]:
+    if not isinstance(boundary, dict):
+        return {}
+    compact: dict[str, Any] = {}
+    for field in (
+        "raw_transcript_copied",
+        "raw_logs_copied",
+        "credentials_copied",
+        "runtime_writeback_allowed",
+        "runtime_mutation_allowed",
+        "raw_material_detected",
+    ):
+        if field in boundary:
+            compact[field] = bool(boundary.get(field))
+    raw_keys = public_safe_compact_list(boundary.get("raw_material_key_names"), limit=8)
+    if raw_keys:
+        compact["raw_material_key_names"] = raw_keys
+    return compact
+
+
+def compact_session_runtime_first_screen(
+    first_screen: Any,
+    *,
+    public_safe_compact_text: PublicSafeText,
+) -> dict[str, Any]:
+    if not isinstance(first_screen, dict):
+        return {}
+    compact: dict[str, Any] = {}
+    for field in (
+        "waiting_on",
+        "first_user_todo",
+        "first_agent_todo",
+        "latest_validation",
+        "latest_blocker",
+        "gate_state",
+        "recommended_action",
+    ):
+        value = public_safe_compact_text(first_screen.get(field), limit=260)
+        if value:
+            compact[field] = value
+    for field in ("user_action_required", "agent_can_continue"):
+        if field in first_screen:
+            compact[field] = bool(first_screen.get(field))
+    return compact
+
+
+def compact_session_runtime_work_lane(
+    contract: Any,
+    *,
+    public_safe_compact_text: PublicSafeText,
+) -> dict[str, Any]:
+    if not isinstance(contract, dict):
+        return {}
+    compact: dict[str, Any] = {}
+    lane = public_safe_compact_text(contract.get("lane"), limit=80)
+    if lane:
+        compact["lane"] = lane
+    for field in ("must_attempt_work", "user_gate_blocks_delivery", "monitor_only"):
+        if field in contract:
+            compact[field] = bool(contract.get(field))
+    return compact
+
+
+def compact_session_runtime_attention_item(
+    attention_item: Any,
+    *,
+    public_safe_compact_text: PublicSafeText,
+) -> dict[str, Any]:
+    if not isinstance(attention_item, dict):
+        return {}
+    compact: dict[str, Any] = {}
+    for field in ("kind", "priority", "title", "waiting_on"):
+        value = public_safe_compact_text(attention_item.get(field), limit=220)
+        if value:
+            compact[field] = value
+    return compact
+
+
+def compact_session_runtime_readonly_projection(
+    value: Any,
+    *,
+    public_safe_compact_text: PublicSafeText,
+    public_safe_compact_list: PublicSafeList,
+) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    if value.get("schema_version") != SESSION_RUNTIME_READONLY_PROJECTION_SCHEMA_VERSION:
+        return None
+    compact: dict[str, Any] = {
+        "schema_version": SESSION_RUNTIME_READONLY_PROJECTION_SCHEMA_VERSION,
+        "mode": "read_only",
+    }
+    goal_id = public_safe_compact_text(value.get("goal_id"), limit=120)
+    if goal_id:
+        compact["goal_id"] = goal_id
+    source = compact_session_runtime_source(
+        value.get("source"),
+        public_safe_compact_text=public_safe_compact_text,
+    )
+    if source:
+        compact["source"] = source
+    boundary = compact_session_runtime_boundary(
+        value.get("boundary"),
+        public_safe_compact_list=public_safe_compact_list,
+    )
+    if boundary:
+        compact["boundary"] = boundary
+    first_screen = compact_session_runtime_first_screen(
+        value.get("first_screen"),
+        public_safe_compact_text=public_safe_compact_text,
+    )
+    if first_screen:
+        compact["first_screen"] = first_screen
+    work_lane = compact_session_runtime_work_lane(
+        value.get("work_lane_contract"),
+        public_safe_compact_text=public_safe_compact_text,
+    )
+    if work_lane:
+        compact["work_lane_contract"] = work_lane
+    attention = compact_session_runtime_attention_item(
+        value.get("attention_item"),
+        public_safe_compact_text=public_safe_compact_text,
+    )
+    if attention:
+        compact["attention_item"] = attention
+    return compact
+
+
+def compact_session_runtime_projection_from_run(
+    run: dict[str, Any] | None,
+    *,
+    public_safe_compact_text: PublicSafeText,
+    public_safe_compact_list: PublicSafeList,
+) -> dict[str, Any] | None:
+    if not isinstance(run, dict):
+        return None
+    for key in SESSION_RUNTIME_READONLY_PROJECTION_KEYS:
+        projection = compact_session_runtime_readonly_projection(
+            run.get(key),
+            public_safe_compact_text=public_safe_compact_text,
+            public_safe_compact_list=public_safe_compact_list,
+        )
+        if projection:
+            return projection
+    return compact_session_runtime_readonly_projection(
+        run,
+        public_safe_compact_text=public_safe_compact_text,
+        public_safe_compact_list=public_safe_compact_list,
+    )

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -91,6 +91,10 @@ from .projections.monitor_display import (
 from .projections.issue_meta_surface import (
     parse_issue_meta_surface as _parse_issue_meta_surface_read_model,
 )
+from .projections.session_runtime import (
+    compact_session_runtime_projection_from_run as _compact_session_runtime_projection_from_run_read_model,
+    compact_session_runtime_readonly_projection as _compact_session_runtime_readonly_projection_read_model,
+)
 from .projections.todo_summary import (
     active_next_action_todo_ids,
     apply_resume_conditions,
@@ -132,7 +136,6 @@ from .renderers.status_markdown import (
     markdown_scalar as _markdown_scalar,
 )
 from .rollout_event_log import load_rollout_events, rollout_event_log_path
-from .session_runtime import SESSION_RUNTIME_READONLY_PROJECTION_SCHEMA_VERSION
 from .state_projection import (
     active_state_next_action_entries,
     actions_are_projection_aligned,
@@ -385,10 +388,6 @@ RUN_COMPACT_FIELDS = (
     "json_exists",
     "markdown_exists",
 )
-SESSION_RUNTIME_READONLY_PROJECTION_KEYS = (
-    "session_runtime_readonly_projection",
-    "session_runtime_projection",
-)
 USAGE_PROXY_NOTE = "run-history proxy; excludes token counts and raw thread logs"
 HUMAN_REWARD_COMPACT_FIELDS = (
     "recorded_at",
@@ -561,132 +560,20 @@ def public_safe_compact_list(value: Any, *, limit: int = MAX_SUBAGENT_SCOPE_ITEM
     return result
 
 
-def compact_session_runtime_source(source: Any) -> dict[str, Any]:
-    if not isinstance(source, dict):
-        return {}
-    compact: dict[str, Any] = {}
-    host_kind = public_safe_compact_text(source.get("host_kind"), limit=80)
-    if host_kind:
-        compact["host_kind"] = host_kind
-    latest_fact_at = public_safe_compact_text(source.get("latest_fact_at"), limit=80)
-    if latest_fact_at:
-        compact["latest_fact_at"] = latest_fact_at
-    source_refs = source.get("source_refs")
-    if isinstance(source_refs, dict):
-        counts = {
-            str(key): len(value)
-            for key, value in source_refs.items()
-            if isinstance(value, list) and value
-        }
-        if counts:
-            compact["source_ref_counts"] = counts
-    return compact
-
-
-def compact_session_runtime_boundary(boundary: Any) -> dict[str, Any]:
-    if not isinstance(boundary, dict):
-        return {}
-    compact: dict[str, Any] = {}
-    for field in (
-        "raw_transcript_copied",
-        "raw_logs_copied",
-        "credentials_copied",
-        "runtime_writeback_allowed",
-        "runtime_mutation_allowed",
-        "raw_material_detected",
-    ):
-        if field in boundary:
-            compact[field] = bool(boundary.get(field))
-    raw_keys = public_safe_compact_list(boundary.get("raw_material_key_names"), limit=8)
-    if raw_keys:
-        compact["raw_material_key_names"] = raw_keys
-    return compact
-
-
-def compact_session_runtime_first_screen(first_screen: Any) -> dict[str, Any]:
-    if not isinstance(first_screen, dict):
-        return {}
-    compact: dict[str, Any] = {}
-    for field in (
-        "waiting_on",
-        "first_user_todo",
-        "first_agent_todo",
-        "latest_validation",
-        "latest_blocker",
-        "gate_state",
-        "recommended_action",
-    ):
-        value = public_safe_compact_text(first_screen.get(field), limit=260)
-        if value:
-            compact[field] = value
-    for field in ("user_action_required", "agent_can_continue"):
-        if field in first_screen:
-            compact[field] = bool(first_screen.get(field))
-    return compact
-
-
-def compact_session_runtime_work_lane(contract: Any) -> dict[str, Any]:
-    if not isinstance(contract, dict):
-        return {}
-    compact: dict[str, Any] = {}
-    lane = public_safe_compact_text(contract.get("lane"), limit=80)
-    if lane:
-        compact["lane"] = lane
-    for field in ("must_attempt_work", "user_gate_blocks_delivery", "monitor_only"):
-        if field in contract:
-            compact[field] = bool(contract.get(field))
-    return compact
-
-
-def compact_session_runtime_attention_item(attention_item: Any) -> dict[str, Any]:
-    if not isinstance(attention_item, dict):
-        return {}
-    compact: dict[str, Any] = {}
-    for field in ("kind", "priority", "title", "waiting_on"):
-        value = public_safe_compact_text(attention_item.get(field), limit=220)
-        if value:
-            compact[field] = value
-    return compact
-
-
 def compact_session_runtime_readonly_projection(value: Any) -> dict[str, Any] | None:
-    if not isinstance(value, dict):
-        return None
-    if value.get("schema_version") != SESSION_RUNTIME_READONLY_PROJECTION_SCHEMA_VERSION:
-        return None
-    compact: dict[str, Any] = {
-        "schema_version": SESSION_RUNTIME_READONLY_PROJECTION_SCHEMA_VERSION,
-        "mode": "read_only",
-    }
-    goal_id = public_safe_compact_text(value.get("goal_id"), limit=120)
-    if goal_id:
-        compact["goal_id"] = goal_id
-    source = compact_session_runtime_source(value.get("source"))
-    if source:
-        compact["source"] = source
-    boundary = compact_session_runtime_boundary(value.get("boundary"))
-    if boundary:
-        compact["boundary"] = boundary
-    first_screen = compact_session_runtime_first_screen(value.get("first_screen"))
-    if first_screen:
-        compact["first_screen"] = first_screen
-    work_lane = compact_session_runtime_work_lane(value.get("work_lane_contract"))
-    if work_lane:
-        compact["work_lane_contract"] = work_lane
-    attention = compact_session_runtime_attention_item(value.get("attention_item"))
-    if attention:
-        compact["attention_item"] = attention
-    return compact
+    return _compact_session_runtime_readonly_projection_read_model(
+        value,
+        public_safe_compact_text=public_safe_compact_text,
+        public_safe_compact_list=public_safe_compact_list,
+    )
 
 
 def compact_session_runtime_projection_from_run(run: dict[str, Any] | None) -> dict[str, Any] | None:
-    if not isinstance(run, dict):
-        return None
-    for key in SESSION_RUNTIME_READONLY_PROJECTION_KEYS:
-        projection = compact_session_runtime_readonly_projection(run.get(key))
-        if projection:
-            return projection
-    return compact_session_runtime_readonly_projection(run)
+    return _compact_session_runtime_projection_from_run_read_model(
+        run,
+        public_safe_compact_text=public_safe_compact_text,
+        public_safe_compact_list=public_safe_compact_list,
+    )
 
 
 def _compact_numeric_map(value: Any, *, keys: tuple[str, ...] | None = None) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- Move session-runtime read-only projection compaction helpers into `loopx/projections/session_runtime.py`.
- Keep `loopx.status.compact_session_runtime_readonly_projection(...)` and `compact_session_runtime_projection_from_run(...)` as compatibility wrappers.
- Leave status attention/routing logic in `status.py`; this PR only extracts the compact read-model helper.

## Validation
- `python3 -m compileall -q loopx/status.py loopx/projections/session_runtime.py`
- `python3 examples/session_runtime/session-runtime-readonly-projection-smoke.py`
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --profile core-control-plane` -> 123/124 passed; the only failure is the pre-existing `repo-python-line-budget-smoke` on benchmark-owned `examples/skillsbench-benchmark-run-smoke.py` and `scripts/skillsbench_automation_loop.py`.
- `git diff --check`

## Boundary
- Public-safe projection-only refactor; no private state, raw benchmark evidence, credentials, local paths, or generated logs included.
- New helper contains only compact schema fields such as `credentials_copied` booleans; no credential values.