### PR TITLE
Extract stale latest-run projection helper

### DIFF
--- a/loopx/projections/stale_latest_run.py
+++ b/loopx/projections/stale_latest_run.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+
+PathResolver = Callable[[Any, dict[str, Any]], Optional[Path]]
+FrontmatterParser = Callable[[str], dict[str, str]]
+TimestampParser = Callable[[Any], Any]
+
+
+def active_state_projection_warning(
+    goal: dict[str, Any],
+    current_run: dict[str, Any] | None,
+    *,
+    agent_lane_progress_scope: str,
+    resolve_goal_local_path: PathResolver,
+    parse_state_frontmatter: FrontmatterParser,
+    parse_timestamp: TimestampParser,
+) -> dict[str, Any] | None:
+    if not isinstance(goal, dict) or not goal.get("registry_member") or not isinstance(current_run, dict):
+        return None
+    state_path = resolve_goal_local_path(goal.get("state_file"), goal)
+    if state_path is None or not state_path.exists():
+        return None
+    try:
+        state_text = state_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    frontmatter = parse_state_frontmatter(state_text)
+    active_updated_at = frontmatter.get("updated_at")
+    active_digest = hashlib.sha256(state_text.encode("utf-8")).hexdigest()[:16]
+    run_state = current_run.get("state") if isinstance(current_run.get("state"), dict) else {}
+    run_frontmatter = run_state.get("frontmatter") if isinstance(run_state.get("frontmatter"), dict) else {}
+    run_state_updated_at = run_frontmatter.get("updated_at")
+    run_state_digest = str(run_state.get("sha256_16") or "")
+    latest_run_generated_at = str(current_run.get("generated_at") or "")
+
+    active_dt = parse_timestamp(active_updated_at)
+    run_state_dt = parse_timestamp(run_state_updated_at)
+    run_generated_dt = parse_timestamp(latest_run_generated_at)
+    active_newer_than_run_state = bool(active_dt and run_state_dt and active_dt > run_state_dt)
+    active_newer_than_run = bool(active_dt and run_generated_dt and active_dt > run_generated_dt)
+    digest_mismatch = bool(run_state_digest and active_digest != run_state_digest)
+    if not (active_newer_than_run_state or active_newer_than_run or digest_mismatch):
+        return None
+    for run in goal.get("latest_runs") if isinstance(goal.get("latest_runs"), list) else []:
+        if not isinstance(run, dict):
+            continue
+        if str(run.get("progress_scope") or "") != agent_lane_progress_scope:
+            continue
+        agent_run_state = run.get("state") if isinstance(run.get("state"), dict) else {}
+        agent_run_frontmatter = (
+            agent_run_state.get("frontmatter")
+            if isinstance(agent_run_state.get("frontmatter"), dict)
+            else {}
+        )
+        agent_run_digest = str(agent_run_state.get("sha256_16") or "")
+        agent_run_updated_at = agent_run_frontmatter.get("updated_at")
+        agent_run_state_dt = parse_timestamp(agent_run_updated_at)
+        agent_run_generated_dt = parse_timestamp(str(run.get("generated_at") or ""))
+        if agent_run_digest and agent_run_digest == active_digest:
+            return None
+        if active_dt and agent_run_state_dt and active_dt <= agent_run_state_dt:
+            return None
+        if active_dt and not agent_run_state_dt and agent_run_generated_dt and active_dt <= agent_run_generated_dt:
+            return None
+
+    reasons: list[str] = []
+    if active_newer_than_run:
+        reasons.append("active_state_updated_after_latest_run")
+    if active_newer_than_run_state:
+        reasons.append("active_state_updated_after_latest_run_snapshot")
+    if digest_mismatch:
+        reasons.append("active_state_digest_differs_from_latest_run_snapshot")
+
+    return {
+        "kind": "stale_latest_run_projection",
+        "source": "active_state_vs_latest_run",
+        "severity": "warning",
+        "requires_refresh_state": True,
+        "reason": ",".join(reasons),
+        "active_state_updated_at": active_updated_at,
+        "latest_run_generated_at": latest_run_generated_at,
+        "latest_run_state_updated_at": run_state_updated_at,
+        "latest_run_classification": current_run.get("classification"),
+        "recommended_action": "run refresh-state before trusting latest_run-derived routing",
+    }

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -102,6 +102,9 @@ from .projections.subagent_activity import (
     subagent_quota_spend as _subagent_quota_spend_read_model,
     subagent_state as _subagent_state_read_model,
 )
+from .projections.stale_latest_run import (
+    active_state_projection_warning as _active_state_projection_warning_read_model,
+)
 from .projections.todo_summary import (
     active_next_action_todo_ids,
     apply_resume_conditions,
@@ -6754,75 +6757,18 @@ def subagent_activity_for_goal(goal: dict[str, Any]) -> dict[str, Any] | None:
 
 
 def active_state_projection_warning(goal: dict[str, Any], current_run: dict[str, Any] | None) -> dict[str, Any] | None:
-    if not isinstance(goal, dict) or not goal.get("registry_member") or not isinstance(current_run, dict):
-        return None
-    state_path = resolve_goal_local_path(goal.get("state_file"), goal, fallback_base=Path.cwd())
-    if state_path is None or not state_path.exists():
-        return None
-    try:
-        state_text = state_path.read_text(encoding="utf-8")
-    except OSError:
-        return None
-
-    frontmatter = parse_state_frontmatter(state_text)
-    active_updated_at = frontmatter.get("updated_at")
-    active_digest = hashlib.sha256(state_text.encode("utf-8")).hexdigest()[:16]
-    run_state = current_run.get("state") if isinstance(current_run.get("state"), dict) else {}
-    run_frontmatter = run_state.get("frontmatter") if isinstance(run_state.get("frontmatter"), dict) else {}
-    run_state_updated_at = run_frontmatter.get("updated_at")
-    run_state_digest = str(run_state.get("sha256_16") or "")
-    latest_run_generated_at = str(current_run.get("generated_at") or "")
-
-    active_dt = parse_timestamp(active_updated_at)
-    run_state_dt = parse_timestamp(run_state_updated_at)
-    run_generated_dt = parse_timestamp(latest_run_generated_at)
-    active_newer_than_run_state = bool(active_dt and run_state_dt and active_dt > run_state_dt)
-    active_newer_than_run = bool(active_dt and run_generated_dt and active_dt > run_generated_dt)
-    digest_mismatch = bool(run_state_digest and active_digest != run_state_digest)
-    if not (active_newer_than_run_state or active_newer_than_run or digest_mismatch):
-        return None
-    for run in goal.get("latest_runs") if isinstance(goal.get("latest_runs"), list) else []:
-        if not isinstance(run, dict):
-            continue
-        if str(run.get("progress_scope") or "") != AGENT_LANE_PROGRESS_SCOPE:
-            continue
-        agent_run_state = run.get("state") if isinstance(run.get("state"), dict) else {}
-        agent_run_frontmatter = (
-            agent_run_state.get("frontmatter")
-            if isinstance(agent_run_state.get("frontmatter"), dict)
-            else {}
-        )
-        agent_run_digest = str(agent_run_state.get("sha256_16") or "")
-        agent_run_updated_at = agent_run_frontmatter.get("updated_at")
-        agent_run_state_dt = parse_timestamp(agent_run_updated_at)
-        agent_run_generated_dt = parse_timestamp(str(run.get("generated_at") or ""))
-        if agent_run_digest and agent_run_digest == active_digest:
-            return None
-        if active_dt and agent_run_state_dt and active_dt <= agent_run_state_dt:
-            return None
-        if active_dt and not agent_run_state_dt and agent_run_generated_dt and active_dt <= agent_run_generated_dt:
-            return None
-
-    reasons: list[str] = []
-    if active_newer_than_run:
-        reasons.append("active_state_updated_after_latest_run")
-    if active_newer_than_run_state:
-        reasons.append("active_state_updated_after_latest_run_snapshot")
-    if digest_mismatch:
-        reasons.append("active_state_digest_differs_from_latest_run_snapshot")
-
-    return {
-        "kind": "stale_latest_run_projection",
-        "source": "active_state_vs_latest_run",
-        "severity": "warning",
-        "requires_refresh_state": True,
-        "reason": ",".join(reasons),
-        "active_state_updated_at": active_updated_at,
-        "latest_run_generated_at": latest_run_generated_at,
-        "latest_run_state_updated_at": run_state_updated_at,
-        "latest_run_classification": current_run.get("classification"),
-        "recommended_action": "run refresh-state before trusting latest_run-derived routing",
-    }
+    return _active_state_projection_warning_read_model(
+        goal,
+        current_run,
+        agent_lane_progress_scope=AGENT_LANE_PROGRESS_SCOPE,
+        resolve_goal_local_path=lambda raw, goal_value: resolve_goal_local_path(
+            raw,
+            goal_value,
+            fallback_base=Path.cwd(),
+        ),
+        parse_state_frontmatter=parse_state_frontmatter,
+        parse_timestamp=parse_timestamp,
+    )
 
 
 def is_handoff_ready_run(run: dict[str, Any]) -> bool:


### PR DESCRIPTION
## Summary
- move stale latest-run active-state warning logic out of loopx/status.py into loopx/projections/stale_latest_run.py
- keep loopx.status.active_state_projection_warning as the compatibility wrapper
- preserve current status/quota/review-packet warning semantics, including agent-lane refresh suppression

## Validation
- python3 -m compileall -q loopx/status.py loopx/projections/stale_latest_run.py
- python3 examples/control_plane/status-markdown-smoke.py
- python3 examples/control_plane/refresh-state-agent-lane-scope-smoke.py
- python3 examples/control_plane/status-quota-review-packet-parity-smoke.py
- PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --profile core-control-plane (123/124; only inherited repo-python-line-budget-smoke failure on benchmark-owned examples/skillsbench-benchmark-run-smoke.py and scripts/skillsbench_automation_loop.py)
- git diff --check

## Boundary
- public control-plane read-model cleanup only
- no private state, raw benchmark logs/task text/trajectories/verifier output, credentials, or local evidence added