### PR TITLE
Extract autonomous replan ACK projection helper

### DIFF
--- a/loopx/projections/autonomous_replan_ack.py
+++ b/loopx/projections/autonomous_replan_ack.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def autonomous_replan_ack_recorded(run: dict[str, Any]) -> bool:
+    ack = run.get("autonomous_replan_ack")
+    if not isinstance(ack, dict) or ack.get("recorded") is not True:
+        return False
+    delta_contract = ack.get("delta_contract")
+    if not isinstance(delta_contract, dict):
+        return False
+    return delta_contract.get("delta_present") is True
+
+
+def compact_autonomous_replan_ack(run: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(run, dict) or not autonomous_replan_ack_recorded(run):
+        return None
+    ack = run.get("autonomous_replan_ack")
+    delta_contract = ack.get("delta_contract") if isinstance(ack, dict) else {}
+    if not isinstance(delta_contract, dict):
+        return None
+    compact_delta = {
+        "schema_version": delta_contract.get("schema_version"),
+        "delta_present": bool(delta_contract.get("delta_present")),
+        "delta_kinds": [
+            str(item)
+            for item in (delta_contract.get("delta_kinds") or [])
+            if str(item or "").strip()
+        ],
+    }
+    return {
+        "schema_version": ack.get("schema_version"),
+        "recorded": True,
+        "source": ack.get("source"),
+        "delta_contract": compact_delta,
+    }
+
+
+def latest_autonomous_replan_ack_for_projection(
+    latest_runs: list[dict[str, Any]] | None,
+    *,
+    neutral_classifications: set[str],
+) -> dict[str, Any] | None:
+    """Return the newest durable replan ACK, skipping neutral accounting runs."""
+
+    for run in latest_runs or []:
+        if not isinstance(run, dict):
+            continue
+        replan_ack = compact_autonomous_replan_ack(run)
+        if replan_ack:
+            return replan_ack
+        classification = str(run.get("classification") or "").strip()
+        if not classification:
+            continue
+        if classification in neutral_classifications:
+            continue
+        if classification == "quota_monitor_poll":
+            continue
+        return None
+    return None

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -81,6 +81,11 @@ from .projections.autonomous_candidates import (
     autonomous_priority_rank as _autonomous_priority_rank,
     autonomous_todo_candidates as _autonomous_todo_candidates,
 )
+from .projections.autonomous_replan_ack import (
+    autonomous_replan_ack_recorded as _autonomous_replan_ack_recorded_read_model,
+    compact_autonomous_replan_ack as _compact_autonomous_replan_ack_read_model,
+    latest_autonomous_replan_ack_for_projection as _latest_autonomous_replan_ack_for_projection_read_model,
+)
 from .projections.monitor_display import (
     attention_item_is_monitor_quiet_display_candidate as _attention_item_is_monitor_quiet_display_candidate,
     normalize_monitor_quiet_attention_display as _normalize_monitor_quiet_attention_display,
@@ -6341,59 +6346,20 @@ def run_history_monitor_wait_already_acknowledged(
 
 
 def autonomous_replan_ack_recorded(run: dict[str, Any]) -> bool:
-    ack = run.get("autonomous_replan_ack")
-    if not isinstance(ack, dict) or ack.get("recorded") is not True:
-        return False
-    delta_contract = ack.get("delta_contract")
-    if not isinstance(delta_contract, dict):
-        return False
-    return delta_contract.get("delta_present") is True
+    return _autonomous_replan_ack_recorded_read_model(run)
 
 
 def compact_autonomous_replan_ack(run: dict[str, Any] | None) -> dict[str, Any] | None:
-    if not isinstance(run, dict) or not autonomous_replan_ack_recorded(run):
-        return None
-    ack = run.get("autonomous_replan_ack")
-    delta_contract = ack.get("delta_contract") if isinstance(ack, dict) else {}
-    if not isinstance(delta_contract, dict):
-        return None
-    compact_delta = {
-        "schema_version": delta_contract.get("schema_version"),
-        "delta_present": bool(delta_contract.get("delta_present")),
-        "delta_kinds": [
-            str(item)
-            for item in (delta_contract.get("delta_kinds") or [])
-            if str(item or "").strip()
-        ],
-    }
-    return {
-        "schema_version": ack.get("schema_version"),
-        "recorded": True,
-        "source": ack.get("source"),
-        "delta_contract": compact_delta,
-    }
+    return _compact_autonomous_replan_ack_read_model(run)
 
 
 def latest_autonomous_replan_ack_for_projection(
     latest_runs: list[dict[str, Any]] | None,
 ) -> dict[str, Any] | None:
-    """Return the newest durable replan ACK, skipping neutral accounting runs."""
-
-    for run in latest_runs or []:
-        if not isinstance(run, dict):
-            continue
-        replan_ack = compact_autonomous_replan_ack(run)
-        if replan_ack:
-            return replan_ack
-        classification = str(run.get("classification") or "").strip()
-        if not classification:
-            continue
-        if classification in AUTONOMOUS_RUN_HISTORY_NEUTRAL_CLASSIFICATIONS:
-            continue
-        if classification == "quota_monitor_poll":
-            continue
-        return None
-    return None
+    return _latest_autonomous_replan_ack_for_projection_read_model(
+        latest_runs,
+        neutral_classifications=AUTONOMOUS_RUN_HISTORY_NEUTRAL_CLASSIFICATIONS,
+    )
 
 
 def autonomous_replan_periodic_review_from_runs(


### PR DESCRIPTION
## Summary
- Move autonomous replan ACK recorded/compact/latest projection into `loopx/projections/autonomous_replan_ack.py`.
- Keep `loopx.status` compatibility wrappers so existing call sites and projection behavior remain stable.
- Continue the canary-gated `status.py` read-model cleanup without changing monitor/replan scheduler semantics.

## Validation
- `python3 -m compileall -q loopx/status.py loopx/projections/autonomous_replan_ack.py`
- `python3 examples/control_plane/quota-replan-decision-plane-smoke.py`
- `python3 examples/control_plane/monitor-scheduler-contract-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --profile core-control-plane` (123/124 passed; only inherited benchmark-owned line-budget baseline failure in `examples/skillsbench-benchmark-run-smoke.py` and `scripts/skillsbench_automation_loop.py`)
- `git diff --check`
- boundary scan of the new helper for private paths, credentials, raw benchmark evidence, and local-only terms

## Boundary
Public control-plane read-model cleanup only. No private state, raw benchmark evidence, credentials, local paths, generated logs, or benchmark runner behavior changes.