### PR TITLE
Extract legacy runtime attention projection helper

### DIFF
--- a/examples/control_plane/legacy-runtime-goal-attention-smoke.py
+++ b/examples/control_plane/legacy-runtime-goal-attention-smoke.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Smoke-test legacy runtime goal attention projection."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.status import build_attention_queue  # noqa: E402
+
+
+def build_queue(*, classification: str, json_exists: bool = True, markdown_exists: bool = True) -> dict:
+    run = {
+        "generated_at": "2026-01-01T00:00:00Z",
+        "goal_id": "legacy-demo",
+        "classification": classification,
+        "json_exists": json_exists,
+        "markdown_exists": markdown_exists,
+    }
+    history = {
+        "goal_count": 1,
+        "run_count": 1,
+        "goals": [
+            {
+                "id": "legacy-demo",
+                "status": "active",
+                "registry_member": False,
+                "legacy_runtime_goal": True,
+                "latest_runs": [run],
+            }
+        ],
+        "runs": [run],
+    }
+    return build_attention_queue(
+        contract={"ok": True},
+        history=history,
+        global_registry={"ok": True, "findings": []},
+    )
+
+
+def test_missing_artifact_projects_high_attention() -> None:
+    queue = build_queue(classification="state_refreshed", markdown_exists=False)
+    item = queue["items"][0]
+    assert item["status"] == "unregistered_runtime_goal", item
+    assert item["waiting_on"] == "controller", item
+    assert item["severity"] == "high", item
+    assert "archive-runtime" in item["recommended_action"], item
+
+
+def test_blocking_classification_projects_high_attention() -> None:
+    queue = build_queue(classification="blocked_by_safety")
+    item = queue["items"][0]
+    assert item["status"] == "unregistered_runtime_goal", item
+    assert item["severity"] == "high", item
+    assert "blocked_by_safety" in item["recommended_action"], item
+
+
+def test_neutral_complete_legacy_runtime_goal_stays_quiet() -> None:
+    queue = build_queue(classification="neutral_complete")
+    assert queue["items"] == [], queue
+
+
+def main() -> int:
+    test_missing_artifact_projects_high_attention()
+    test_blocking_classification_projects_high_attention()
+    test_neutral_complete_legacy_runtime_goal_stays_quiet()
+    print("legacy-runtime-goal-attention-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/projections/session_runtime.py
+++ b/loopx/projections/session_runtime.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Optional
+from typing import AbstractSet, Any, Callable, Optional
 
 from ..session_runtime import SESSION_RUNTIME_READONLY_PROJECTION_SCHEMA_VERSION
 
@@ -14,6 +14,67 @@ PublicSafeText = Callable[..., Optional[str]]
 PublicSafeList = Callable[..., list[str]]
 AttentionItemBuilder = Callable[..., dict[str, Any]]
 GoalLifecycleFields = Callable[[dict[str, Any], Optional[dict[str, Any]]], dict[str, Any]]
+
+
+def legacy_runtime_goal_attention(
+    goal: dict[str, Any],
+    current_run: dict[str, Any] | None,
+    readiness_fields: dict[str, Any],
+    *,
+    attention_item: AttentionItemBuilder,
+    goal_lifecycle_fields: GoalLifecycleFields,
+    blocking_classifications: AbstractSet[str],
+    user_or_controller_classifications: AbstractSet[str],
+    codex_ready_classifications: AbstractSet[str],
+) -> dict[str, Any] | None:
+    if not goal.get("legacy_runtime_goal") or not current_run:
+        return None
+
+    goal_id = str(goal.get("id") or "unknown-goal")
+    json_exists = bool(current_run.get("json_exists"))
+    markdown_exists = bool(current_run.get("markdown_exists"))
+    classification = str(current_run.get("classification") or "unknown")
+    lifecycle_fields = goal_lifecycle_fields(goal, current_run)
+
+    actionable_classification = (
+        classification in blocking_classifications
+        or classification in user_or_controller_classifications
+        or classification in codex_ready_classifications
+    )
+    if not actionable_classification and json_exists and markdown_exists:
+        return None
+
+    if not json_exists or not markdown_exists:
+        severity = "high"
+        action = (
+            "repair this unregistered runtime goal or preview cleanup with "
+            f"`loopx archive-runtime --goal-id {goal_id}` before trusting multi-project status"
+        )
+    elif classification in blocking_classifications:
+        severity = "high"
+        action = (
+            f"latest classification is {classification}; add this runtime goal to the registry "
+            f"or preview cleanup with `loopx archive-runtime --goal-id {goal_id}` "
+            "so multi-project status stays authoritative"
+        )
+    else:
+        severity = "action"
+        action = (
+            f"latest classification is {classification}; add this runtime goal to the registry "
+            f"or preview cleanup with `loopx archive-runtime --goal-id {goal_id}` "
+            "so multi-project status stays authoritative"
+        )
+
+    return attention_item(
+        goal_id=goal_id,
+        status="unregistered_runtime_goal",
+        waiting_on="controller",
+        severity=severity,
+        recommended_action=action,
+        source="run_history",
+        **readiness_fields,
+        **lifecycle_fields,
+    )
 
 
 def compact_session_runtime_source(

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -131,6 +131,7 @@ from .projections.session_runtime import (
     compact_session_runtime_projection_from_run as _compact_session_runtime_projection_from_run_read_model,
     compact_session_runtime_readonly_projection as _compact_session_runtime_readonly_projection_read_model,
     attach_session_runtime_projection as _attach_session_runtime_projection_read_model,
+    legacy_runtime_goal_attention as _legacy_runtime_goal_attention_read_model,
     session_runtime_projection_attention as _session_runtime_projection_attention_read_model,
     session_runtime_status_label as _session_runtime_status_label_read_model,
     session_runtime_status_waiting_on as _session_runtime_status_waiting_on_read_model,
@@ -7659,53 +7660,15 @@ def legacy_runtime_goal_attention(
     current_run: dict[str, Any] | None,
     readiness_fields: dict[str, Any],
 ) -> dict[str, Any] | None:
-    if not goal.get("legacy_runtime_goal") or not current_run:
-        return None
-
-    goal_id = str(goal.get("id") or "unknown-goal")
-    json_exists = bool(current_run.get("json_exists"))
-    markdown_exists = bool(current_run.get("markdown_exists"))
-    classification = str(current_run.get("classification") or "unknown")
-    lifecycle_fields = goal_lifecycle_fields(goal, current_run)
-
-    actionable_classification = (
-        classification in BLOCKING_CLASSIFICATIONS
-        or classification in USER_OR_CONTROLLER_CLASSIFICATIONS
-        or classification in CODEX_READY_CLASSIFICATIONS
-    )
-    if not actionable_classification and json_exists and markdown_exists:
-        return None
-
-    if not json_exists or not markdown_exists:
-        severity = "high"
-        action = (
-            "repair this unregistered runtime goal or preview cleanup with "
-            f"`loopx archive-runtime --goal-id {goal_id}` before trusting multi-project status"
-        )
-    elif classification in BLOCKING_CLASSIFICATIONS:
-        severity = "high"
-        action = (
-            f"latest classification is {classification}; add this runtime goal to the registry "
-            f"or preview cleanup with `loopx archive-runtime --goal-id {goal_id}` "
-            "so multi-project status stays authoritative"
-        )
-    else:
-        severity = "action"
-        action = (
-            f"latest classification is {classification}; add this runtime goal to the registry "
-            f"or preview cleanup with `loopx archive-runtime --goal-id {goal_id}` "
-            "so multi-project status stays authoritative"
-        )
-
-    return attention_item(
-        goal_id=goal_id,
-        status="unregistered_runtime_goal",
-        waiting_on="controller",
-        severity=severity,
-        recommended_action=action,
-        source="run_history",
-        **readiness_fields,
-        **lifecycle_fields,
+    return _legacy_runtime_goal_attention_read_model(
+        goal,
+        current_run,
+        readiness_fields,
+        attention_item=attention_item,
+        goal_lifecycle_fields=goal_lifecycle_fields,
+        blocking_classifications=BLOCKING_CLASSIFICATIONS,
+        user_or_controller_classifications=USER_OR_CONTROLLER_CLASSIFICATIONS,
+        codex_ready_classifications=CODEX_READY_CLASSIFICATIONS,
     )
 
 


### PR DESCRIPTION
## Summary
- Move legacy runtime goal attention projection into `loopx/projections/session_runtime.py`.
- Keep `loopx.status` compatibility wrapper and inject attention/lifecycle/classification dependencies.
- Add `examples/control_plane/legacy-runtime-goal-attention-smoke.py` to characterize missing-artifact, blocking-classification, and quiet neutral cases.

## Validation
- `python3 -m compileall -q loopx/status.py loopx/projections/session_runtime.py`
- `python3 examples/control_plane/legacy-runtime-goal-attention-smoke.py`
- `python3 examples/session_runtime/session-runtime-readonly-projection-smoke.py`
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 examples/project/project-asset-next-eye-smoke.py`
- `python3 examples/mini-control-plane-interrupt-comparison-summary-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --script examples/mini-control-plane-interrupt-comparison-summary-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --profile core-control-plane` (125 executed; new legacy-runtime smoke passed; only inherited benchmark-owned line-budget baseline failed)
- `git diff --cached --check`
- Boundary scan of touched helper, new smoke, and added lines for private paths, credentials, raw benchmark evidence, and local-only terms.
