### PR TITLE
Fix AgentIssue modular smoke contracts

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md
@@ -95,11 +95,13 @@ this packet.
 python3 examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py
 python3 -m py_compile \
   loopx/benchmark.py \
-  loopx/cli.py \
+  loopx/benchmark_adapters/agentissue.py \
+  loopx/cli_commands/agentissue_runner_flow.py \
   examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py
 loopx check \
   --scan-path loopx/benchmark.py \
-  --scan-path loopx/cli.py \
+  --scan-path loopx/benchmark_adapters/agentissue.py \
+  --scan-path loopx/cli_commands/agentissue_runner_flow.py \
   --scan-path examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py \
   --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md \
   --scan-path docs/research/long-horizon-agent-benchmarks/README.md

--- a/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-publication-change-set-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-publication-change-set-v0.md
@@ -61,6 +61,7 @@ Stage only the AgentIssue hunks from these mixed tracked files:
 loopx/benchmark.py
 loopx/benchmark_adapters/agentissue.py
 loopx/cli.py
+loopx/cli_commands/agentissue_runner_flow.py
 loopx/status.py
 docs/research/long-horizon-agent-benchmarks/README.md
 ```
@@ -68,7 +69,7 @@ docs/research/long-horizon-agent-benchmarks/README.md
 These files currently contain unrelated dirty hunks from other benchmark lanes,
 so do not stage them with a whole-file `git add`. Use hunk-level staging or an
 equivalent cached patch that selects only the AgentIssue runner-flow symbols,
-CLI command, compact `read_boundary` preservation, README bullets, and
+CLI command module, compact `read_boundary` preservation, README bullets, and
 smoke/doc index entries. In a clean PR worktree based directly on `origin/main`,
 these same hunks may appear as whole-file staged changes because no unrelated
 local hunks are present.
@@ -159,6 +160,7 @@ python3 -m py_compile \
   loopx/benchmark.py \
   loopx/benchmark_adapters/agentissue.py \
   loopx/cli.py \
+  loopx/cli_commands/agentissue_runner_flow.py \
   loopx/status.py \
   examples/agentissue-bench-codex-cli-runner-contract-smoke.py \
   examples/agentissue-bench-codex-cli-runner-flow-smoke.py \
@@ -176,6 +178,7 @@ loopx check \
   --scan-path loopx/benchmark.py \
   --scan-path loopx/benchmark_adapters/agentissue.py \
   --scan-path loopx/cli.py \
+  --scan-path loopx/cli_commands/agentissue_runner_flow.py \
   --scan-path loopx/status.py \
   --scan-path docs/research/long-horizon-agent-benchmarks/README.md \
   --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-contract-v0.md \

--- a/examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py
+++ b/examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py
@@ -11,7 +11,8 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 TOPIC_DIR = REPO_ROOT / "docs" / "research" / "long-horizon-agent-benchmarks"
 README = TOPIC_DIR / "README.md"
 BENCHMARK = REPO_ROOT / "loopx" / "benchmark.py"
-CLI = REPO_ROOT / "loopx" / "cli.py"
+AGENTISSUE_ADAPTER = REPO_ROOT / "loopx" / "benchmark_adapters" / "agentissue.py"
+AGENTISSUE_RUNNER_FLOW = REPO_ROOT / "loopx" / "cli_commands" / "agentissue_runner_flow.py"
 
 DOCS = [
     "agentissue-bench-codex-cli-runner-contract-v0.md",
@@ -114,7 +115,7 @@ def assert_packet_contract() -> None:
 
 
 def assert_source_contract() -> None:
-    source = read(BENCHMARK) + "\n" + read(CLI)
+    source = read(BENCHMARK) + "\n" + read(AGENTISSUE_ADAPTER) + "\n" + read(AGENTISSUE_RUNNER_FLOW)
     missing = [snippet for snippet in REQUIRED_SOURCE_SNIPPETS if snippet not in source]
     assert not missing, missing
     assert source.count("real_codex_invoked") >= 1, "missing Codex no-run flag"

--- a/examples/agentissue-bench-codex-cli-runner-publication-change-set-smoke.py
+++ b/examples/agentissue-bench-codex-cli-runner-publication-change-set-smoke.py
@@ -14,6 +14,7 @@ PACKET = TOPIC_DIR / "agentissue-bench-codex-cli-runner-publication-change-set-v
 BENCHMARK = REPO_ROOT / "loopx" / "benchmark.py"
 CLI = REPO_ROOT / "loopx" / "cli.py"
 AGENTISSUE_ADAPTER = REPO_ROOT / "loopx" / "benchmark_adapters" / "agentissue.py"
+AGENTISSUE_RUNNER_FLOW = REPO_ROOT / "loopx" / "cli_commands" / "agentissue_runner_flow.py"
 
 DOCS = [
     "agentissue-bench-codex-cli-runner-contract-v0.md",
@@ -47,6 +48,7 @@ MIXED_TRACKED_FILES = [
     "loopx/benchmark.py",
     "loopx/benchmark_adapters/agentissue.py",
     "loopx/cli.py",
+    "loopx/cli_commands/agentissue_runner_flow.py",
     "loopx/status.py",
     "docs/research/long-horizon-agent-benchmarks/README.md",
 ]
@@ -160,8 +162,12 @@ def git_changed_lines(path: str) -> list[str] | None:
 
 def agentissue_cli_behavior_changed() -> bool:
     changed_lines = git_changed_lines("loopx/cli.py")
+    module_changed_lines = git_changed_lines("loopx/cli_commands/agentissue_runner_flow.py")
     if changed_lines is None:
         return True
+    if module_changed_lines is None:
+        return True
+    changed_lines.extend(module_changed_lines)
     return any(
         marker in line
         for line in changed_lines
@@ -189,7 +195,7 @@ def assert_include_lists() -> None:
 
 
 def assert_source_and_readme_contract() -> None:
-    source = read(BENCHMARK) + "\n" + read(CLI) + "\n" + read(AGENTISSUE_ADAPTER)
+    source = read(BENCHMARK) + "\n" + read(AGENTISSUE_ADAPTER) + "\n" + read(AGENTISSUE_RUNNER_FLOW)
     missing = [snippet for snippet in REQUIRED_SOURCE_SNIPPETS if snippet not in source]
     assert not missing, missing
     readme = read(README)


### PR DESCRIPTION
## Summary
- point AgentIssue PR-ready/publication aggregate smokes at the modular runner-flow command source
- update runner-flow packet validation paths to include the command module

## Validation
- python3 examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py
- python3 examples/agentissue-bench-codex-cli-runner-publication-change-set-smoke.py
- python3 examples/agentissue-bench-codex-cli-runner-first-run-handoff-smoke.py
- python3 examples/agentissue-bench-codex-cli-runner-workflow-check-smoke.py
- python3 examples/agentissue-bench-codex-cli-runner-run-gate-smoke.py
- python3 examples/agentissue-bench-codex-cli-runner-target-handoff-smoke.py
- python3 examples/cli-agentissue-runner-flow-command-modularization-smoke.py
- python3 -m py_compile examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py examples/agentissue-bench-codex-cli-runner-publication-change-set-smoke.py
- loopx check --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-pr-ready-packet-v0.md --scan-path docs/research/long-horizon-agent-benchmarks/agentissue-bench-codex-cli-runner-publication-change-set-v0.md --scan-path examples/agentissue-bench-codex-cli-runner-pr-ready-packet-smoke.py --scan-path examples/agentissue-bench-codex-cli-runner-publication-change-set-smoke.py