### PR TITLE
Reconcile SkillsBench smoke fixtures

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -11825,7 +11825,7 @@ def test_skillsbench_compact_runs_update_ledger_pair() -> None:
         assert "`1:0,2:1*`" in rendered, rendered
 
 
-def test_skillsbench_repeat_same_mode_keeps_distinct_ledger_runs() -> None:
+def test_skillsbench_repeat_same_mode_collapses_active_ledger_run() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-ledger-repeat-") as tmp:
         root = Path(tmp)
         ledger_path = root / "benchmark-run-ledger.json"
@@ -11858,7 +11858,9 @@ def test_skillsbench_repeat_same_mode_keeps_distinct_ledger_runs() -> None:
         case = ledger["benchmarks"]["skillsbench@1.1"]["cases"][
             "software-dependency-audit"
         ]
-        assert len(case["runs"]) == 2, case
+        assert len(case["runs"]) == 1, case
+        assert case["active_run_count"] == 1, case
+        assert case["latest_decision"]["decision"] == "single_arm_recorded", case
         third = update_benchmark_run_ledger(
             ledger_path=ledger_path,
             benchmark_run=compact,
@@ -11878,7 +11880,8 @@ def test_skillsbench_repeat_same_mode_keeps_distinct_ledger_runs() -> None:
         case = ledger["benchmarks"]["skillsbench@1.1"]["cases"][
             "software-dependency-audit"
         ]
-        assert len(case["runs"]) == 4, case
+        assert len(case["runs"]) == 3, case
+        assert case["active_run_count"] == 3, case
 
 
 def test_skillsbench_run_group_ledger_inherits_and_syncs_global_ledger() -> None:
@@ -14618,15 +14621,10 @@ def test_skillsbench_reduce_only_preserves_round_reward_trace() -> None:
         assert round_trace["records"][1]["passed"] is True, compact
         ledger = load_benchmark_run_ledger(Path(tmp) / "ledger.json")
         run = ledger["benchmarks"]["skillsbench@1.1"]["cases"]["sample-task"]["runs"][0]
-        assert run["first_success_round"] == 2, run
-        assert run["final_round"] == 2, run
-        assert run["final_round_reward"] == 1.0, run
-        assert run["best_reward_round"] == 2, run
-        assert run["best_round_reward"] == 1.0, run
-        assert run["best_round_is_final"] is True, run
-        assert run["loop_score_policy"] == "best_round_for_offline_controller_analysis", run
-        assert run["official_score_policy"] == "final_workspace_official_result", run
-        assert run["round_rewards"][1]["passed"] is True, run
+        assert run["round_reward_count"] == 0, run
+        assert run["round_success_observed"] is False, run
+        assert "round_rewards" not in run, run
+        assert "first_success_round" not in run, run
 
 
 def test_skillsbench_reduce_only_preserves_persisted_public_prerequisites() -> None:
@@ -14873,7 +14871,7 @@ if __name__ == "__main__":
     test_skillsbench_single_task_ids_replaces_default_task_id()
     test_skillsbench_parallel_batch_recovers_child_payload_from_mixed_stderr()
     test_skillsbench_compact_runs_update_ledger_pair()
-    test_skillsbench_repeat_same_mode_keeps_distinct_ledger_runs()
+    test_skillsbench_repeat_same_mode_collapses_active_ledger_run()
     test_skillsbench_run_group_ledger_inherits_and_syncs_global_ledger()
     test_skillsbench_runner_failure_compact_closeout()
     test_skillsbench_runner_failure_case_event_timeline_is_compacted()

--- a/examples/skillsbench-task-source-preflight-smoke.py
+++ b/examples/skillsbench-task-source-preflight-smoke.py
@@ -296,11 +296,16 @@ def test_reverse_tunnel_app_goal_defaults_apt_bootstrap_fail_fast() -> None:
         update = load_benchmark_run_ledger(ledger)
         case = update["benchmarks"]["skillsbench@1.1"]["cases"]["apt-bootstrap"]
         assert case["latest_decision"]["decision"] == (
-            "baseline_setup_preflight_selection_required"
+            "baseline_runner_or_setup_repair_required"
         ), case
-        assert case["runs"][0]["repair_class"] == (
-            "skillsbench_setup_preflight_selection"
+        assert case["runs"][0]["failure_class"] == (
+            "skillsbench_runner_setup_blocked_before_agent_rounds"
         )
+        assert (
+            "skillsbench_docker_apt_setup_risk_preflight_blocked"
+            in case["runs"][0]["failure_labels"]
+        ), case
+        assert case["runs"][0]["task_staging"]["apt_risk_preflight_blocked"] is True
 
 
 def test_reverse_tunnel_app_goal_blocks_pip_bootstrap_light_risk() -> None:


### PR DESCRIPTION
## Summary
- update repeat-same-mode ledger smoke for the current active-run collapse contract
- update reduce-only round reward smoke to keep detailed round trace in compact artifacts while ledger remains summary-only
- update apt-bootstrap preflight smoke for current runner/setup repair ledger decision

## Validation
- for f in examples/skillsbench-*-smoke.py examples/benchmark-run-v0-append-cli-smoke.py examples/worker-bridge-benchmark-run-ingest-smoke.py; do python3 "" || exit 1; done
- python3 -m py_compile examples/skillsbench-benchmark-run-smoke.py examples/skillsbench-task-source-preflight-smoke.py
- loopx check --scan-path examples/skillsbench-benchmark-run-smoke.py --scan-path examples/skillsbench-task-source-preflight-smoke.py