### PR TITLE
Extract active-state todo attention helper

### DIFF
--- a/examples/control_plane/active-state-todo-attention-helper-smoke.py
+++ b/examples/control_plane/active-state-todo-attention-helper-smoke.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Smoke-test active-state todo attention helper branches."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.projections.todo_summary import active_state_todo_attention_item  # noqa: E402
+
+
+GOAL = {"id": "active-state-todo-attention-helper-goal"}
+CURRENT_RUN = {"classification": "state_refreshed"}
+
+
+def compact_text(value: Any, *, limit: int) -> str | None:
+    text = " ".join(str(value or "").strip().split())
+    if not text:
+        return None
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "..."
+
+
+def first_open_text(summary: dict[str, Any] | None) -> str | None:
+    if not isinstance(summary, dict):
+        return None
+    for item in summary.get("first_open_items") or []:
+        if isinstance(item, dict) and item.get("text"):
+            return str(item["text"])
+    return None
+
+
+def open_count(summary: dict[str, Any] | None) -> int:
+    if not isinstance(summary, dict):
+        return 0
+    return int(summary.get("open_count") or 0)
+
+
+def lifecycle_fields(goal: dict[str, Any], current_run: dict[str, Any] | None) -> dict[str, Any]:
+    return {
+        "lifecycle_phase": "fixture_phase",
+        "lifecycle_flags": ["fixture_flag"],
+    }
+
+
+def attention_item(**kwargs: Any) -> dict[str, Any]:
+    return dict(kwargs)
+
+
+def project(fields: dict[str, Any]) -> dict[str, Any] | None:
+    return active_state_todo_attention_item(
+        GOAL,
+        fields,
+        CURRENT_RUN,
+        public_safe_compact_text=compact_text,
+        first_open_todo_text=first_open_text,
+        todo_summary_open_count=open_count,
+        goal_lifecycle_fields=lifecycle_fields,
+        attention_item=attention_item,
+    )
+
+
+def main() -> None:
+    user_item = project(
+        {
+            "active_state_next_action": "fallback user next action",
+            "user_todos": {
+                "open_count": 1,
+                "first_open_items": [{"text": "[P1] Ask the owner for review."}],
+            },
+            "agent_todos": {
+                "open_count": 1,
+                "first_open_items": [{"text": "[P1] Continue implementation."}],
+            },
+        }
+    )
+    assert user_item is not None, user_item
+    assert user_item["status"] == "active_state_user_todo", user_item
+    assert user_item["waiting_on"] == "controller", user_item
+    assert user_item["recommended_action"] == "[P1] Ask the owner for review.", user_item
+    assert user_item["lifecycle_phase"] == "fixture_phase", user_item
+
+    agent_item = project(
+        {
+            "active_state_next_action": "fallback agent next action",
+            "agent_todos": {
+                "open_count": 1,
+                "first_open_items": [{"text": "[P2] Continue implementation."}],
+            },
+        }
+    )
+    assert agent_item is not None, agent_item
+    assert agent_item["status"] == "active_state_agent_todo", agent_item
+    assert agent_item["waiting_on"] == "codex", agent_item
+    assert agent_item["recommended_action"] == "[P2] Continue implementation.", agent_item
+
+    gap_item = project(
+        {
+            "state_projection_gap": {
+                "recommended_action": "expand the Next Action into parseable todos",
+            },
+        }
+    )
+    assert gap_item is not None, gap_item
+    assert gap_item["status"] == "state_projection_gap", gap_item
+    assert gap_item["waiting_on"] == "codex", gap_item
+    assert gap_item["recommended_action"] == "expand the Next Action into parseable todos", gap_item
+
+    assert project({}) is None
+
+    print("active-state-todo-attention-helper-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/projections/todo_summary.py
+++ b/loopx/projections/todo_summary.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import re
-from typing import Any
+from typing import Any, Callable, Optional
 
 from ..todo_contract import (
     TODO_RESUME_KIND_PR_MERGED,
@@ -48,6 +48,11 @@ MAX_DEFERRED_TODO_VISIBILITY_ITEMS = 8
 MAX_MONITOR_DUE_ITEMS = 1
 
 TODO_ITEM_SCHEMA_VERSION = "todo_item_v0"
+AttentionItemBuilder = Callable[..., dict[str, Any]]
+GoalLifecycleFields = Callable[[dict[str, Any], Optional[dict[str, Any]]], dict[str, Any]]
+PublicSafeText = Callable[..., Optional[str]]
+TodoOpenCount = Callable[[Optional[dict[str, Any]]], int]
+FirstOpenTodoText = Callable[[Optional[dict[str, Any]]], Optional[str]]
 GITHUB_PULL_URL_PATTERN = re.compile(
     r"https://github\.com/(?P<repo>[^/]+/[^/]+)/pull/(?P<number>[0-9]+)(?:\b|/|#|\?)",
     re.IGNORECASE,
@@ -70,6 +75,78 @@ def normalize_todo_text(text: str, *, limit: int = 500) -> str:
     if len(compact) <= limit:
         return compact
     return compact[: limit - 1].rstrip() + "…"
+
+
+def active_state_todo_attention_item(
+    goal: dict[str, Any],
+    fields: dict[str, Any],
+    current_run: dict[str, Any] | None,
+    *,
+    public_safe_compact_text: PublicSafeText,
+    first_open_todo_text: FirstOpenTodoText,
+    todo_summary_open_count: TodoOpenCount,
+    goal_lifecycle_fields: GoalLifecycleFields,
+    attention_item: AttentionItemBuilder,
+) -> dict[str, Any] | None:
+    """Surface active-state todos even when the latest run classification is passive."""
+
+    user_todos = fields.get("user_todos") if isinstance(fields.get("user_todos"), dict) else None
+    agent_todos = fields.get("agent_todos") if isinstance(fields.get("agent_todos"), dict) else None
+    active_next_action = public_safe_compact_text(
+        fields.get("active_state_next_action"),
+        limit=320,
+    )
+    user_action = public_safe_compact_text(first_open_todo_text(user_todos), limit=320)
+    agent_action = public_safe_compact_text(first_open_todo_text(agent_todos), limit=320)
+    lifecycle_fields = goal_lifecycle_fields(goal, current_run)
+    goal_id = str(goal.get("id") or "unknown-goal")
+
+    if user_action or todo_summary_open_count(user_todos) > 0:
+        return attention_item(
+            goal_id=goal_id,
+            status="active_state_user_todo",
+            waiting_on="controller",
+            severity="action",
+            recommended_action=(
+                user_action
+                or active_next_action
+                or "resolve the open user todo from the active goal state"
+            ),
+            source="active_state",
+            **lifecycle_fields,
+        )
+
+    if agent_action or todo_summary_open_count(agent_todos) > 0:
+        return attention_item(
+            goal_id=goal_id,
+            status="active_state_agent_todo",
+            waiting_on="codex",
+            severity="action",
+            recommended_action=(
+                agent_action
+                or active_next_action
+                or "run the open agent todo from the active goal state"
+            ),
+            source="active_state",
+            **lifecycle_fields,
+        )
+
+    projection_gap = fields.get("state_projection_gap")
+    if isinstance(projection_gap, dict):
+        return attention_item(
+            goal_id=goal_id,
+            status="state_projection_gap",
+            waiting_on="codex",
+            severity="action",
+            recommended_action=str(
+                projection_gap.get("recommended_action")
+                or "expand the active-state Next Action into parseable todos"
+            ),
+            source="active_state",
+            **lifecycle_fields,
+        )
+
+    return None
 
 
 def todo_priority_parts(text: str) -> tuple[str | None, str]:

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -147,6 +147,7 @@ from .projections.stale_latest_run import (
     active_state_projection_warning as _active_state_projection_warning_read_model,
 )
 from .projections.todo_summary import (
+    active_state_todo_attention_item as _active_state_todo_attention_item_read_model,
     active_next_action_todo_ids,
     apply_resume_conditions,
     claimed_visibility_items,
@@ -7175,65 +7176,16 @@ def active_state_todo_attention_item(
     fields: dict[str, Any],
     current_run: dict[str, Any] | None,
 ) -> dict[str, Any] | None:
-    """Surface active-state todos even when the latest run classification is passive."""
-
-    user_todos = fields.get("user_todos") if isinstance(fields.get("user_todos"), dict) else None
-    agent_todos = fields.get("agent_todos") if isinstance(fields.get("agent_todos"), dict) else None
-    active_next_action = public_safe_compact_text(
-        fields.get("active_state_next_action"),
-        limit=320,
+    return _active_state_todo_attention_item_read_model(
+        goal,
+        fields,
+        current_run,
+        public_safe_compact_text=public_safe_compact_text,
+        first_open_todo_text=first_open_todo_text,
+        todo_summary_open_count=todo_summary_open_count,
+        goal_lifecycle_fields=goal_lifecycle_fields,
+        attention_item=attention_item,
     )
-    user_action = public_safe_compact_text(first_open_todo_text(user_todos), limit=320)
-    agent_action = public_safe_compact_text(first_open_todo_text(agent_todos), limit=320)
-    lifecycle_fields = goal_lifecycle_fields(goal, current_run)
-    goal_id = str(goal.get("id") or "unknown-goal")
-
-    if user_action or todo_summary_open_count(user_todos) > 0:
-        return attention_item(
-            goal_id=goal_id,
-            status="active_state_user_todo",
-            waiting_on="controller",
-            severity="action",
-            recommended_action=(
-                user_action
-                or active_next_action
-                or "resolve the open user todo from the active goal state"
-            ),
-            source="active_state",
-            **lifecycle_fields,
-        )
-
-    if agent_action or todo_summary_open_count(agent_todos) > 0:
-        return attention_item(
-            goal_id=goal_id,
-            status="active_state_agent_todo",
-            waiting_on="codex",
-            severity="action",
-            recommended_action=(
-                agent_action
-                or active_next_action
-                or "run the open agent todo from the active goal state"
-            ),
-            source="active_state",
-            **lifecycle_fields,
-        )
-
-    projection_gap = fields.get("state_projection_gap")
-    if isinstance(projection_gap, dict):
-        return attention_item(
-            goal_id=goal_id,
-            status="state_projection_gap",
-            waiting_on="codex",
-            severity="action",
-            recommended_action=str(
-                projection_gap.get("recommended_action")
-                or "expand the active-state Next Action into parseable todos"
-            ),
-            source="active_state",
-            **lifecycle_fields,
-        )
-
-    return None
 
 
 def todo_summary_open_count(summary: dict[str, Any] | None) -> int:


### PR DESCRIPTION
## Summary
- Move active-state todo attention projection into `loopx/projections/todo_summary.py`.
- Keep the `loopx.status` compatibility wrapper with injected text, lifecycle, count, and attention-item dependencies.
- Add `examples/control_plane/active-state-todo-attention-helper-smoke.py` to characterize user todo, agent todo, projection-gap, and quiet cases.

## Validation
- `python3 -m compileall -q loopx/status.py loopx/projections/todo_summary.py`
- `python3 examples/control_plane/active-state-todo-attention-helper-smoke.py`
- `python3 examples/control_plane/active-state-todo-attention-fallback-smoke.py`
- `python3 examples/control_plane/todo-projection-shared-helper-smoke.py`
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --script examples/control_plane/active-state-todo-attention-helper-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --profile core-control-plane` (126 executed; new helper smoke passed; only inherited benchmark-owned line-budget baseline failed)
- `git diff --cached --check`
- Boundary scan of touched helper, new smoke, and added lines for private paths, credentials, raw benchmark evidence, and local-only terms.
