### PR TITLE
Extract connected attention action helper

### DIFF
--- a/examples/control_plane/connected-attention-action-helper-smoke.py
+++ b/examples/control_plane/connected-attention-action-helper-smoke.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Smoke-test connected-without-run attention action sync helper."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.projections.todo_summary import sync_connected_attention_action_from_todos  # noqa: E402
+
+
+AGENT_ACTION = "[P2] Run the first read-only project map."
+
+
+def first_open_text(summary: dict[str, Any] | None) -> str | None:
+    if not isinstance(summary, dict):
+        return None
+    for item in summary.get("first_open_items") or []:
+        if isinstance(item, dict) and item.get("text"):
+            return str(item["text"])
+    return None
+
+
+def sync(item: dict[str, Any]) -> None:
+    sync_connected_attention_action_from_todos(
+        item,
+        first_open_todo_text=first_open_text,
+    )
+
+
+def main() -> None:
+    item = {
+        "status": "connected_without_run",
+        "recommended_action": "fallback action",
+        "agent_todos": {
+            "first_open_items": [{"text": AGENT_ACTION}],
+        },
+        "project_asset": {
+            "next_action": "fallback action",
+        },
+    }
+    sync(item)
+    assert item["recommended_action"] == AGENT_ACTION, item
+    assert item["project_asset"]["next_action"] == AGENT_ACTION, item
+
+    no_agent_action = {
+        "status": "connected_without_run",
+        "recommended_action": "fallback action",
+        "agent_todos": {"first_open_items": []},
+        "project_asset": {"next_action": "fallback action"},
+    }
+    sync(no_agent_action)
+    assert no_agent_action["recommended_action"] == "fallback action", no_agent_action
+    assert no_agent_action["project_asset"]["next_action"] == "fallback action", no_agent_action
+
+    other_status = {
+        "status": "active_state_agent_todo",
+        "recommended_action": "keep me",
+        "agent_todos": {"first_open_items": [{"text": AGENT_ACTION}]},
+        "project_asset": {"next_action": "keep me"},
+    }
+    sync(other_status)
+    assert other_status["recommended_action"] == "keep me", other_status
+    assert other_status["project_asset"]["next_action"] == "keep me", other_status
+
+    no_project_asset = {
+        "status": "connected_without_run",
+        "recommended_action": "fallback action",
+        "agent_todos": {"first_open_items": [{"text": AGENT_ACTION}]},
+    }
+    sync(no_project_asset)
+    assert no_project_asset["recommended_action"] == AGENT_ACTION, no_project_asset
+
+    print("connected-attention-action-helper-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/projections/todo_summary.py
+++ b/loopx/projections/todo_summary.py
@@ -149,6 +149,24 @@ def active_state_todo_attention_item(
     return None
 
 
+def sync_connected_attention_action_from_todos(
+    item: dict[str, Any],
+    *,
+    first_open_todo_text: FirstOpenTodoText,
+) -> None:
+    if item.get("status") != "connected_without_run":
+        return
+    agent_action = first_open_todo_text(
+        item.get("agent_todos") if isinstance(item.get("agent_todos"), dict) else None
+    )
+    if not agent_action:
+        return
+    item["recommended_action"] = agent_action
+    project_asset = item.get("project_asset")
+    if isinstance(project_asset, dict):
+        project_asset["next_action"] = agent_action
+
+
 def todo_priority_parts(text: str) -> tuple[str | None, str]:
     return projection_todo_priority_parts(text)
 

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -159,6 +159,7 @@ from .projections.todo_summary import (
     pr_merged_condition,
     rollout_event_pr_refs,
     structured_todo_item,
+    sync_connected_attention_action_from_todos as _sync_connected_attention_action_from_todos_read_model,
     todo_item_expires_at,
     todo_item_is_actionable_open,
     todo_item_is_deferred,
@@ -7158,17 +7159,10 @@ def attention_item(
 
 
 def sync_connected_attention_action_from_todos(item: dict[str, Any]) -> None:
-    if item.get("status") != "connected_without_run":
-        return
-    agent_action = first_open_todo_text(
-        item.get("agent_todos") if isinstance(item.get("agent_todos"), dict) else None
+    _sync_connected_attention_action_from_todos_read_model(
+        item,
+        first_open_todo_text=first_open_todo_text,
     )
-    if not agent_action:
-        return
-    item["recommended_action"] = agent_action
-    project_asset = item.get("project_asset")
-    if isinstance(project_asset, dict):
-        project_asset["next_action"] = agent_action
 
 
 def active_state_todo_attention_item(


### PR DESCRIPTION
## Summary
- Move connected-without-run attention action sync into `loopx/projections/todo_summary.py`.
- Keep the `loopx.status` compatibility wrapper with injected first-open-todo dependency.
- Add `examples/control_plane/connected-attention-action-helper-smoke.py` for action sync, quiet no-op, other-status, and missing-project-asset cases.

## Validation
- `python3 -m compileall -q loopx/status.py loopx/projections/todo_summary.py`
- `python3 examples/control_plane/connected-attention-action-helper-smoke.py`
- `python3 examples/control_plane/active-state-todo-attention-helper-smoke.py`
- `python3 examples/control_plane/active-state-todo-attention-fallback-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --script examples/control_plane/connected-attention-action-helper-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --profile core-control-plane` (127/127 passed)
- `git diff --check origin/main...HEAD`
- Boundary scan of touched helper, new smoke, and added lines for private paths, credentials, raw benchmark evidence, and local-only terms.
