### PR TITLE
Extract active-state section read model

### DIFF
--- a/examples/control_plane/active-state-section-readmodel-smoke.py
+++ b/examples/control_plane/active-state-section-readmodel-smoke.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Smoke-test active-state section parsing read-model wrappers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.projections.active_state_sections import (  # noqa: E402
+    active_state_section_entries as direct_active_state_section_entries,
+    active_state_sections as direct_active_state_sections,
+)
+from loopx.status import (  # noqa: E402
+    BACKLOG_HYGIENE_BULLET_PATTERN,
+    SECTION_HEADING_PATTERN,
+    active_state_section_entries,
+    active_state_sections,
+    normalize_todo_text,
+)
+
+
+STATE_TEXT = """# Goal
+
+## Next Action
+
+- Continue canary-gated read-model cleanup
+  after PR #1284
+
+## Operating Lessons
+
+Plain observation
+1. First numbered item
+   continued
+
+### Nested Heading
+
+Should not land in requested sections
+"""
+
+
+def main() -> int:
+    headings = ("Next Action", "Operating Lessons", "Missing Section")
+    direct_sections = direct_active_state_sections(
+        STATE_TEXT,
+        headings,
+        section_heading_pattern=SECTION_HEADING_PATTERN,
+    )
+    wrapper_sections = active_state_sections(STATE_TEXT, headings)
+    assert wrapper_sections == direct_sections, (wrapper_sections, direct_sections)
+    assert wrapper_sections["Missing Section"] == [], wrapper_sections
+    assert "Continue canary-gated read-model cleanup" in "\n".join(
+        wrapper_sections["Next Action"]
+    ), wrapper_sections
+
+    direct_entries = direct_active_state_section_entries(
+        wrapper_sections["Operating Lessons"],
+        bullet_pattern=BACKLOG_HYGIENE_BULLET_PATTERN,
+        normalize_text=normalize_todo_text,
+    )
+    wrapper_entries = active_state_section_entries(wrapper_sections["Operating Lessons"])
+    assert wrapper_entries == direct_entries, (wrapper_entries, direct_entries)
+    assert wrapper_entries == [
+        "Plain observation",
+        "First numbered item continued",
+    ], wrapper_entries
+
+    next_entries = active_state_section_entries(wrapper_sections["Next Action"])
+    assert next_entries == [
+        "Continue canary-gated read-model cleanup after PR #1284",
+    ], next_entries
+
+    print("active-state-section-readmodel-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/projections/active_state_sections.py
+++ b/loopx/projections/active_state_sections.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import re
+from typing import Callable
+
+
+NormalizeText = Callable[..., str]
+
+
+def active_state_sections(
+    state_text: str,
+    headings: tuple[str, ...],
+    *,
+    section_heading_pattern: re.Pattern[str],
+) -> dict[str, list[str]]:
+    wanted = {heading.lower(): heading for heading in headings}
+    current: str | None = None
+    sections: dict[str, list[str]] = {heading: [] for heading in headings}
+    for line in state_text.splitlines():
+        match = section_heading_pattern.match(line)
+        if match:
+            normalized = match.group(1).strip().lower()
+            current = wanted.get(normalized)
+            continue
+        if current:
+            sections[current].append(line)
+    return sections
+
+
+def active_state_section_entries(
+    lines: list[str],
+    *,
+    bullet_pattern: re.Pattern[str],
+    normalize_text: NormalizeText,
+) -> list[str]:
+    entries: list[str] = []
+    current: list[str] = []
+    for line in lines:
+        bullet_match = bullet_pattern.match(line)
+        if bullet_match:
+            if current:
+                entries.append(normalize_text(" ".join(current)))
+            current = [bullet_match.group(1)]
+            continue
+        if current and line.startswith((" ", "\t")):
+            continuation = line.strip()
+            if continuation:
+                current.append(continuation)
+            continue
+        if current:
+            entries.append(normalize_text(" ".join(current)))
+            current = []
+        stripped = line.strip()
+        if stripped:
+            entries.append(stripped)
+    if current:
+        entries.append(normalize_text(" ".join(current)))
+    return entries

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -87,6 +87,10 @@ from .projections.agent_lane_recommendation import (
     latest_agent_lane_run as _latest_agent_lane_run_read_model,
     latest_run_recommended_action_for_projection as _latest_run_recommended_action_for_projection_read_model,
 )
+from .projections.active_state_sections import (
+    active_state_section_entries as _active_state_section_entries_read_model,
+    active_state_sections as _active_state_sections_read_model,
+)
 from .projections.attention_fields import (
     operator_gate_attention_fields as _operator_gate_attention_fields_read_model,
     readiness_attention_fields as _readiness_attention_fields_read_model,
@@ -6058,18 +6062,11 @@ def active_state_event_projection_fields(
 
 
 def active_state_sections(state_text: str, headings: tuple[str, ...]) -> dict[str, list[str]]:
-    wanted = {heading.lower(): heading for heading in headings}
-    current: str | None = None
-    sections: dict[str, list[str]] = {heading: [] for heading in headings}
-    for line in state_text.splitlines():
-        match = SECTION_HEADING_PATTERN.match(line)
-        if match:
-            normalized = match.group(1).strip().lower()
-            current = wanted.get(normalized)
-            continue
-        if current:
-            sections[current].append(line)
-    return sections
+    return _active_state_sections_read_model(
+        state_text,
+        headings,
+        section_heading_pattern=SECTION_HEADING_PATTERN,
+    )
 
 
 def parse_issue_meta_surface(state_text: str) -> dict[str, Any] | None:
@@ -6081,29 +6078,11 @@ def parse_issue_meta_surface(state_text: str) -> dict[str, Any] | None:
 
 
 def active_state_section_entries(lines: list[str]) -> list[str]:
-    entries: list[str] = []
-    current: list[str] = []
-    for line in lines:
-        bullet_match = BACKLOG_HYGIENE_BULLET_PATTERN.match(line)
-        if bullet_match:
-            if current:
-                entries.append(normalize_todo_text(" ".join(current)))
-            current = [bullet_match.group(1)]
-            continue
-        if current and line.startswith((" ", "\t")):
-            continuation = line.strip()
-            if continuation:
-                current.append(continuation)
-            continue
-        if current:
-            entries.append(normalize_todo_text(" ".join(current)))
-            current = []
-        stripped = line.strip()
-        if stripped:
-            entries.append(stripped)
-    if current:
-        entries.append(normalize_todo_text(" ".join(current)))
-    return entries
+    return _active_state_section_entries_read_model(
+        lines,
+        bullet_pattern=BACKLOG_HYGIENE_BULLET_PATTERN,
+        normalize_text=normalize_todo_text,
+    )
 
 
 def backlog_hygiene_warning(state_text: str, *, agent_todos: dict[str, Any] | None) -> dict[str, Any] | None:


### PR DESCRIPTION
## Summary
- extract active-state section/entry parsing into loopx.projections.active_state_sections
- keep status.py compatibility wrappers that inject existing regex and normalization contracts
- add a focused smoke covering wrapper/direct parity for headings, bullet continuations, and plain entries

## Validation
- python3 -m compileall -q loopx/status.py loopx/projections/active_state_sections.py
- python3 examples/control_plane/active-state-section-readmodel-smoke.py
- python3 examples/control_plane/monitor-display-projection-smoke.py
- python3 examples/control_plane/control-plane-integrated-canary-smoke.py
- python3 examples/control_plane/status-markdown-smoke.py
- PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --profile core-control-plane (128/128 passed)

## Boundary
- public-safe added-lines scan clean for private/local/raw evidence terms
