### PR TITLE
Extract backlog hygiene read model

### DIFF
--- a/examples/control_plane/backlog-hygiene-readmodel-smoke.py
+++ b/examples/control_plane/backlog-hygiene-readmodel-smoke.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Smoke-test backlog hygiene warning read-model wrappers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.projections.backlog_hygiene import (  # noqa: E402
+    backlog_hygiene_warning as direct_backlog_hygiene_warning,
+)
+from loopx.status import (  # noqa: E402
+    BACKLOG_HYGIENE_BULLET_PATTERN,
+    BACKLOG_HYGIENE_HINT_PATTERN,
+    BACKLOG_HYGIENE_SECTION_HEADINGS,
+    MAX_BACKLOG_HYGIENE_EVIDENCE_ITEMS,
+    active_state_sections,
+    backlog_hygiene_warning,
+    public_safe_compact_text,
+)
+
+
+STATE_TEXT = """# Goal
+
+## Next Action
+
+- Continue canary-gated cleanup
+
+## Operating Lessons
+
+- keep this as a plain note
+- [P2] add a durable follow-up todo
+"""
+
+
+def direct_warning(agent_todos: dict[str, object] | None) -> dict[str, object] | None:
+    return direct_backlog_hygiene_warning(
+        STATE_TEXT,
+        agent_todos=agent_todos,
+        section_headings=BACKLOG_HYGIENE_SECTION_HEADINGS,
+        section_parser=active_state_sections,
+        bullet_pattern=BACKLOG_HYGIENE_BULLET_PATTERN,
+        hint_pattern=BACKLOG_HYGIENE_HINT_PATTERN,
+        public_safe_compact_text=public_safe_compact_text,
+        max_evidence_items=MAX_BACKLOG_HYGIENE_EVIDENCE_ITEMS,
+    )
+
+
+def main() -> int:
+    empty_agent_todos = {"open_count": 0}
+    wrapper = backlog_hygiene_warning(STATE_TEXT, agent_todos=empty_agent_todos)
+    direct = direct_warning(empty_agent_todos)
+    assert wrapper == direct, (wrapper, direct)
+    assert wrapper is not None, wrapper
+    assert wrapper["kind"] == "hidden_backlog_without_agent_todo", wrapper
+    assert wrapper["requires_agent_todo"] is True, wrapper
+    assert wrapper["source_sections"] == ["Next Action", "Operating Lessons"], wrapper
+    assert wrapper["evidence_count"] == 2, wrapper
+
+    assert backlog_hygiene_warning(STATE_TEXT, agent_todos={"open_count": 1}) is None
+    assert direct_warning({"open_count": 1}) is None
+
+    no_backlog = "## Operating Lessons\n\n- just a calm observation\n"
+    assert backlog_hygiene_warning(no_backlog, agent_todos={"open_count": 0}) is None
+
+    print("backlog-hygiene-readmodel-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/projections/backlog_hygiene.py
+++ b/loopx/projections/backlog_hygiene.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Callable, Optional
+
+
+CompactText = Callable[..., Optional[str]]
+SectionParser = Callable[[str, tuple[str, ...]], dict[str, list[str]]]
+
+
+def backlog_hygiene_warning(
+    state_text: str,
+    *,
+    agent_todos: dict[str, Any] | None,
+    section_headings: tuple[str, ...],
+    section_parser: SectionParser,
+    bullet_pattern: re.Pattern[str],
+    hint_pattern: re.Pattern[str],
+    public_safe_compact_text: CompactText,
+    max_evidence_items: int,
+) -> dict[str, Any] | None:
+    try:
+        agent_open_count = int(agent_todos.get("open_count") or 0) if isinstance(agent_todos, dict) else 0
+    except (TypeError, ValueError):
+        agent_open_count = 0
+    if agent_open_count > 0:
+        return None
+
+    evidence: list[dict[str, Any]] = []
+    sections = section_parser(state_text, section_headings)
+    for section, lines in sections.items():
+        for line in lines:
+            bullet_match = bullet_pattern.match(line)
+            if not bullet_match:
+                continue
+            text = public_safe_compact_text(bullet_match.group(1), limit=220)
+            if not text:
+                continue
+            if section.lower() == "next action" or hint_pattern.search(text):
+                evidence.append({"section": section, "text": text})
+
+    if not evidence:
+        return None
+
+    source_sections = sorted({str(item.get("section") or "") for item in evidence if item.get("section")})
+    return {
+        "kind": "hidden_backlog_without_agent_todo",
+        "requires_agent_todo": True,
+        "source_sections": source_sections,
+        "agent_open_count": agent_open_count,
+        "evidence_count": len(evidence),
+        "first_evidence": evidence[:max_evidence_items],
+        "recommended_action": (
+            "mirror durable follow-up work into Agent Todo before heartbeat scheduling relies on "
+            "Next Action or Operating Lessons"
+        ),
+    }

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -108,6 +108,9 @@ from .projections.autonomous_replan_obligation import (
     run_history_monitor_wait_already_acknowledged as _run_history_monitor_wait_already_acknowledged_read_model,
     run_history_stall_signal as _run_history_stall_signal_read_model,
 )
+from .projections.backlog_hygiene import (
+    backlog_hygiene_warning as _backlog_hygiene_warning_read_model,
+)
 from .projections.dreaming import (
     compact_dreaming_lane_badge as _compact_dreaming_lane_badge_read_model,
     compact_dreaming_proposal as _compact_dreaming_proposal_read_model,
@@ -6086,42 +6089,16 @@ def active_state_section_entries(lines: list[str]) -> list[str]:
 
 
 def backlog_hygiene_warning(state_text: str, *, agent_todos: dict[str, Any] | None) -> dict[str, Any] | None:
-    try:
-        agent_open_count = int(agent_todos.get("open_count") or 0) if isinstance(agent_todos, dict) else 0
-    except (TypeError, ValueError):
-        agent_open_count = 0
-    if agent_open_count > 0:
-        return None
-
-    evidence: list[dict[str, Any]] = []
-    sections = active_state_sections(state_text, BACKLOG_HYGIENE_SECTION_HEADINGS)
-    for section, lines in sections.items():
-        for line in lines:
-            bullet_match = BACKLOG_HYGIENE_BULLET_PATTERN.match(line)
-            if not bullet_match:
-                continue
-            text = public_safe_compact_text(bullet_match.group(1), limit=220)
-            if not text:
-                continue
-            if section.lower() == "next action" or BACKLOG_HYGIENE_HINT_PATTERN.search(text):
-                evidence.append({"section": section, "text": text})
-
-    if not evidence:
-        return None
-
-    source_sections = sorted({str(item.get("section") or "") for item in evidence if item.get("section")})
-    return {
-        "kind": "hidden_backlog_without_agent_todo",
-        "requires_agent_todo": True,
-        "source_sections": source_sections,
-        "agent_open_count": agent_open_count,
-        "evidence_count": len(evidence),
-        "first_evidence": evidence[:MAX_BACKLOG_HYGIENE_EVIDENCE_ITEMS],
-        "recommended_action": (
-            "mirror durable follow-up work into Agent Todo before heartbeat scheduling relies on "
-            "Next Action or Operating Lessons"
-        ),
-    }
+    return _backlog_hygiene_warning_read_model(
+        state_text,
+        agent_todos=agent_todos,
+        section_headings=BACKLOG_HYGIENE_SECTION_HEADINGS,
+        section_parser=active_state_sections,
+        bullet_pattern=BACKLOG_HYGIENE_BULLET_PATTERN,
+        hint_pattern=BACKLOG_HYGIENE_HINT_PATTERN,
+        public_safe_compact_text=public_safe_compact_text,
+        max_evidence_items=MAX_BACKLOG_HYGIENE_EVIDENCE_ITEMS,
+    )
 
 
 def autonomous_replan_obligation(


### PR DESCRIPTION
## Summary
- extract backlog hygiene warning construction into loopx.projections.backlog_hygiene
- keep status.py compatibility wrapper injecting existing active-state parser, regexes, and compact text contract
- add focused read-model smoke covering wrapper/direct parity and no-warning branches

## Validation
- python3 -m compileall -q loopx/status.py loopx/projections/backlog_hygiene.py
- python3 examples/control_plane/backlog-hygiene-readmodel-smoke.py
- python3 examples/backlog-hygiene-smoke.py
- python3 examples/control_plane/status-markdown-smoke.py
- python3 examples/control_plane/status-quota-review-packet-parity-smoke.py
- PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --profile core-control-plane (129/129 passed)
- git diff --check

## Boundary
- public-safe added-lines scan clean for private/local/raw evidence terms
