### PR TITLE
Extract todo read model helpers

### DIFF
--- a/examples/control_plane/todo-readmodel-boundary-smoke.py
+++ b/examples/control_plane/todo-readmodel-boundary-smoke.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx import status as status_module  # noqa: E402
+from loopx.projections import todo_summary as todo_read_model  # noqa: E402
+
+
+def fixture_todos() -> dict:
+    return {
+        "first_open_items": [
+            {
+                "index": 2,
+                "done": False,
+                "text": "[P2] Run focused canary smoke",
+                "task_class": "advancement_task",
+                "claimed_by": "codex-product-capability",
+            },
+            {
+                "index": 1,
+                "done": False,
+                "text": "[P1] Monitor quiet transition",
+                "task_class": "continuous_monitor",
+                "target_key": "monitor-gap",
+            },
+        ],
+        "items": [
+            {
+                "index": 2,
+                "done": False,
+                "text": "[P2] Run focused canary smoke",
+                "task_class": "advancement_task",
+                "claimed_by": "codex-product-capability",
+            },
+            {
+                "index": 3,
+                "done": True,
+                "text": "[P3] Completed old slice",
+            },
+            {
+                "index": 4,
+                "done": False,
+                "text": "  [P2]   Refactor todo read model   ",
+                "task_class": "advancement_task",
+            },
+        ],
+        "monitor_open_items": [
+            {
+                "index": 1,
+                "done": False,
+                "text": "[P1] Monitor quiet transition",
+                "task_class": "continuous_monitor",
+            }
+        ],
+    }
+
+
+def assert_wrapper_parity() -> None:
+    todos = fixture_todos()
+
+    assert status_module.open_todo_items(todos) == todo_read_model.open_todo_items(
+        todos,
+        limit=status_module.MAX_PROJECT_ASSET_TODO_ITEMS,
+        text_limit=220,
+    )
+    assert status_module.todo_lane_items(todos, "monitor_open_items") == todo_read_model.todo_lane_items(
+        todos,
+        "monitor_open_items",
+        limit=status_module.MAX_STATUS_TODOS_PER_ROLE,
+        text_limit=220,
+    )
+    assert status_module.first_open_todo_text(todos) == todo_read_model.first_open_todo_text(
+        todos,
+        item_limit=220,
+    )
+    assert status_module.project_asset_todo_summary(
+        todos,
+        role="agent",
+    ) == todo_read_model.project_asset_todo_summary(
+        todos,
+        role="agent",
+        item_limit=status_module.MAX_PROJECT_ASSET_TODO_ITEMS,
+        deferred_item_limit=status_module.MAX_DEFERRED_TODO_VISIBILITY_ITEMS,
+        advancement_task_class=status_module.TODO_TASK_CLASS_ADVANCEMENT,
+    )
+
+
+def assert_dependency_blocker_parity() -> None:
+    items = [
+        {
+            "goal_id": "current",
+            "status": "active",
+            "waiting_on": "codex",
+        },
+        {
+            "goal_id": "dependency",
+            "status": "blocked",
+            "waiting_on": "controller",
+            "severity": "action",
+            "user_todos": {
+                "items": [
+                    {
+                        "index": 5,
+                        "done": False,
+                        "text": "Approve rollout gate",
+                    },
+                    {
+                        "index": 6,
+                        "done": True,
+                        "text": "Old approval",
+                    },
+                ]
+            },
+        },
+    ]
+    assert status_module.dependency_blocker_summary(
+        items,
+        current_goal_id="current",
+    ) == todo_read_model.dependency_blocker_summary(
+        items,
+        current_goal_id="current",
+        limit=status_module.MAX_DEPENDENCY_BLOCKERS,
+    )
+
+    status_items = deepcopy(items)
+    direct_items = deepcopy(items)
+    status_module.attach_dependency_blockers(status_items)
+    todo_read_model.attach_dependency_blockers(
+        direct_items,
+        limit=status_module.MAX_DEPENDENCY_BLOCKERS,
+    )
+    assert status_items == direct_items
+
+
+def main() -> None:
+    assert_wrapper_parity()
+    assert_dependency_blocker_parity()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/mini-control-plane-interrupt-comparison-summary-smoke.py
+++ b/examples/mini-control-plane-interrupt-comparison-summary-smoke.py
@@ -161,6 +161,29 @@ def assert_contract_doc() -> None:
     assert_public_safe({"contract": text})
 
 
+def assert_baseline_pair_contract(
+    baseline: dict[str, Any],
+    without: dict[str, Any],
+    baseline_rows: list[dict[str, Any]],
+) -> None:
+    """Keep this smoke focused on the interrupt summary, not strict uplift scoring."""
+
+    assert baseline["scenario_id"] == "with_loopx", baseline
+    assert without["scenario_id"] == "without_loopx", without
+    assert baseline["terminal_state"] == "success", baseline
+    assert without["terminal_state"] == "success", without
+    assert baseline["official_task_score"]["value"] == 1.0, baseline
+    assert without["official_task_score"]["value"] == 1.0, without
+    assert baseline["writeback_count"] >= 1, baseline
+    assert baseline["spend_before_validation_count"] == 0, baseline
+    assert without["writeback_count"] == 0, without
+    assert without["spend_count"] == 0, without
+    assert baseline["control_plane_score"]["kind"] == "core_v0", baseline
+    assert without["control_plane_score"]["kind"] == "core_v0", without
+    assert len(baseline_rows) == baseline["step_count"], baseline_rows
+    assert_public_safe({"baseline": baseline, "without": without, "rows": baseline_rows})
+
+
 def main() -> int:
     module = load_benchmark_smoke()
     with tempfile.TemporaryDirectory(prefix="mini-control-plane-interrupt-comparison-") as raw_tmp:
@@ -171,7 +194,7 @@ def main() -> int:
         baseline, baseline_rows = module.run_harness_scenario(baseline_fixture)
         without = module.run_without_harness_scenario(without_fixture)
         interrupt, interrupt_rows = module.run_interrupt_harness_scenario(interrupt_fixture)
-        module.assert_result_contract([baseline, without], baseline_rows, module.comparison([baseline, without]))
+        assert_baseline_pair_contract(baseline, without, baseline_rows)
         module.assert_interrupt_contract(interrupt, interrupt_rows)
         summary = comparison_summary(module, baseline, interrupt)
 

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -58,6 +58,10 @@ FAMILY_CHECKS: dict[str, list[dict[str, str]]] = {
             "reason": "checks todo metadata shape consumed by status and quota",
         },
         {
+            "command": "python3 examples/control_plane/todo-readmodel-boundary-smoke.py",
+            "reason": "guards status wrapper parity for todo read-model extraction",
+        },
+        {
             "command": "python3 examples/control_plane/active-state-structured-projection-smoke.py",
             "reason": "guards active-state structured projection from Markdown drift",
         },

--- a/loopx/projections/todo_summary.py
+++ b/loopx/projections/todo_summary.py
@@ -39,6 +39,7 @@ from ..todo_projection import (
     todo_priority_rank as projection_todo_priority_rank,
     todo_projection_sort_key as projection_todo_projection_sort_key,
 )
+from .project_asset import build_project_asset_todo_summary
 
 
 MAX_STATUS_TODOS_PER_ROLE = 12
@@ -355,6 +356,150 @@ def claimed_visibility_items(items: list[dict[str, Any]], *, limit: int) -> list
 
 def todo_item_is_deferred(item: dict[str, Any]) -> bool:
     return projection_todo_item_is_deferred(item)
+
+
+def open_todo_items(
+    todos: dict[str, Any] | None,
+    *,
+    limit: int,
+    text_limit: int,
+    source_keys: tuple[str, ...] = ("first_open_items", "items"),
+) -> list[dict[str, Any]]:
+    if not isinstance(todos, dict):
+        return []
+    result: list[dict[str, Any]] = []
+    seen: set[tuple[Any, str]] = set()
+    for source_key in source_keys:
+        source_items = todos.get(source_key)
+        if not isinstance(source_items, list):
+            continue
+        for item in source_items:
+            if not isinstance(item, dict) or item.get("done"):
+                continue
+            text = normalize_todo_text(str(item.get("text") or ""), limit=text_limit)
+            if not text:
+                continue
+            key = (item.get("index"), text)
+            if key in seen:
+                continue
+            seen.add(key)
+            compact = compact_todo_item(item)
+            compact["done"] = False
+            compact["text"] = text
+            result.append(compact)
+            if len(result) >= limit:
+                return sorted(result, key=todo_projection_sort_key)
+    return sorted(result, key=todo_projection_sort_key)
+
+
+def todo_lane_items(
+    todos: dict[str, Any] | None,
+    lane: str,
+    *,
+    limit: int,
+    text_limit: int,
+) -> list[dict[str, Any]]:
+    return open_todo_items(
+        todos,
+        limit=limit,
+        text_limit=text_limit,
+        source_keys=(lane,),
+    )
+
+
+def first_open_todo_text(
+    todos: dict[str, Any] | None,
+    *,
+    item_limit: int,
+) -> str | None:
+    items = open_todo_items(todos, limit=1, text_limit=item_limit)
+    if not items:
+        return None
+    return str(items[0].get("text") or "") or None
+
+
+def project_asset_todo_summary(
+    todos: dict[str, Any] | None,
+    *,
+    role: str | None = None,
+    item_limit: int,
+    deferred_item_limit: int,
+    advancement_task_class: str = TODO_TASK_CLASS_ADVANCEMENT,
+) -> dict[str, Any] | None:
+    return build_project_asset_todo_summary(
+        todos,
+        role=role,
+        item_limit=item_limit,
+        deferred_item_limit=deferred_item_limit,
+        advancement_task_class=advancement_task_class,
+        open_todo_items=lambda value, **kwargs: open_todo_items(
+            value,
+            limit=kwargs.get("limit", item_limit),
+            text_limit=kwargs.get("text_limit", 220),
+            source_keys=kwargs.get("source_keys", ("first_open_items", "items")),
+        ),
+        compact_todo_item=compact_todo_item,
+        todo_lane_items=lambda value, lane, **kwargs: todo_lane_items(
+            value,
+            lane,
+            limit=kwargs.get("limit", MAX_STATUS_TODOS_PER_ROLE),
+            text_limit=kwargs.get("text_limit", 220),
+        ),
+        todo_item_is_actionable_open=todo_item_is_actionable_open,
+        todo_item_task_class=todo_item_task_class,
+    )
+
+
+def dependency_blocker_summary(
+    items: list[dict[str, Any]],
+    *,
+    current_goal_id: str,
+    limit: int,
+) -> dict[str, Any] | None:
+    blockers: list[dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        goal_id = str(item.get("goal_id") or "")
+        if not goal_id or goal_id == current_goal_id:
+            continue
+        user_todos = item.get("user_todos") if isinstance(item.get("user_todos"), dict) else {}
+        for todo in user_todos.get("items") or []:
+            if not isinstance(todo, dict) or todo.get("done"):
+                continue
+            text = normalize_todo_text(str(todo.get("text") or ""), limit=220)
+            if not text:
+                continue
+            blockers.append(
+                {
+                    "goal_id": goal_id,
+                    "status": item.get("status"),
+                    "waiting_on": item.get("waiting_on"),
+                    "severity": item.get("severity"),
+                    "index": todo.get("index"),
+                    "text": text,
+                    "source": "user_todos",
+                }
+            )
+    if not blockers:
+        return None
+    return {
+        "source": "attention_queue.user_todos",
+        "open_count": len(blockers),
+        "items": blockers[:limit],
+    }
+
+
+def attach_dependency_blockers(items: list[dict[str, Any]], *, limit: int) -> None:
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        goal_id = str(item.get("goal_id") or "")
+        if not goal_id:
+            continue
+        blockers = dependency_blocker_summary(items, current_goal_id=goal_id, limit=limit)
+        if blockers:
+            item["dependency_blockers"] = blockers
 
 
 def normalized_pr_ref_parts(value: Any) -> dict[str, Any] | None:

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -66,7 +66,6 @@ from .projections.project_asset import (
     TODO_PROJECTION_DETAIL_POINTER_SCHEMA_VERSION,
     TODO_PROJECTION_VIEW_SCHEMA_VERSION,
     build_project_asset,
-    build_project_asset_todo_summary,
     completed_todo_archive_warning,
     project_asset_handoff_check_projection,
     project_asset_latest_validation,
@@ -157,17 +156,23 @@ from .projections.stale_latest_run import (
 from .projections.todo_summary import (
     active_state_todo_attention_item as _active_state_todo_attention_item_read_model,
     active_next_action_todo_ids,
+    attach_dependency_blockers as _attach_dependency_blockers_read_model,
     apply_resume_conditions,
     claimed_visibility_items,
     compact_active_next_action_todo_item,
     compact_todo_group,
     compact_todo_item,
+    dependency_blocker_summary as _dependency_blocker_summary_read_model,
+    first_open_todo_text as _first_open_todo_text_read_model,
     normalize_todo_text,
     normalized_pr_ref_parts,
+    open_todo_items as _open_todo_items_read_model,
     pr_merged_condition,
+    project_asset_todo_summary as _project_asset_todo_summary_read_model,
     rollout_event_pr_refs,
     structured_todo_item,
     sync_connected_attention_action_from_todos as _sync_connected_attention_action_from_todos_read_model,
+    todo_lane_items as _todo_lane_items_read_model,
     todo_item_expires_at,
     todo_item_is_actionable_open,
     todo_item_is_deferred,
@@ -6240,31 +6245,12 @@ def open_todo_items(
     text_limit: int = 220,
     source_keys: tuple[str, ...] = ("first_open_items", "items"),
 ) -> list[dict[str, Any]]:
-    if not isinstance(todos, dict):
-        return []
-    result: list[dict[str, Any]] = []
-    seen: set[tuple[Any, str]] = set()
-    for source_key in source_keys:
-        source_items = todos.get(source_key)
-        if not isinstance(source_items, list):
-            continue
-        for item in source_items:
-            if not isinstance(item, dict) or item.get("done"):
-                continue
-            text = normalize_todo_text(str(item.get("text") or ""), limit=text_limit)
-            if not text:
-                continue
-            key = (item.get("index"), text)
-            if key in seen:
-                continue
-            seen.add(key)
-            compact = compact_todo_item(item)
-            compact["done"] = False
-            compact["text"] = text
-            result.append(compact)
-            if len(result) >= limit:
-                return sorted(result, key=todo_projection_sort_key)
-    return sorted(result, key=todo_projection_sort_key)
+    return _open_todo_items_read_model(
+        todos,
+        limit=limit,
+        text_limit=text_limit,
+        source_keys=source_keys,
+    )
 
 
 def todo_lane_items(
@@ -6274,19 +6260,16 @@ def todo_lane_items(
     limit: int = MAX_STATUS_TODOS_PER_ROLE,
     text_limit: int = 220,
 ) -> list[dict[str, Any]]:
-    return open_todo_items(
+    return _todo_lane_items_read_model(
         todos,
+        lane,
         limit=limit,
         text_limit=text_limit,
-        source_keys=(lane,),
     )
 
 
 def first_open_todo_text(todos: dict[str, Any] | None) -> str | None:
-    items = open_todo_items(todos, limit=1)
-    if not items:
-        return None
-    return str(items[0].get("text") or "") or None
+    return _first_open_todo_text_read_model(todos, item_limit=220)
 
 
 def project_asset_todo_summary(
@@ -6294,17 +6277,12 @@ def project_asset_todo_summary(
     *,
     role: str | None = None,
 ) -> dict[str, Any] | None:
-    return build_project_asset_todo_summary(
+    return _project_asset_todo_summary_read_model(
         todos,
         role=role,
         item_limit=MAX_PROJECT_ASSET_TODO_ITEMS,
         deferred_item_limit=MAX_DEFERRED_TODO_VISIBILITY_ITEMS,
         advancement_task_class=TODO_TASK_CLASS_ADVANCEMENT,
-        open_todo_items=open_todo_items,
-        compact_todo_item=compact_todo_item,
-        todo_lane_items=todo_lane_items,
-        todo_item_is_actionable_open=todo_item_is_actionable_open,
-        todo_item_task_class=todo_item_task_class,
     )
 
 
@@ -6314,50 +6292,15 @@ def dependency_blocker_summary(
     current_goal_id: str,
     limit: int = MAX_DEPENDENCY_BLOCKERS,
 ) -> dict[str, Any] | None:
-    blockers: list[dict[str, Any]] = []
-    for item in items:
-        if not isinstance(item, dict):
-            continue
-        goal_id = str(item.get("goal_id") or "")
-        if not goal_id or goal_id == current_goal_id:
-            continue
-        user_todos = item.get("user_todos") if isinstance(item.get("user_todos"), dict) else {}
-        for todo in user_todos.get("items") or []:
-            if not isinstance(todo, dict) or todo.get("done"):
-                continue
-            text = normalize_todo_text(str(todo.get("text") or ""), limit=220)
-            if not text:
-                continue
-            blockers.append(
-                {
-                    "goal_id": goal_id,
-                    "status": item.get("status"),
-                    "waiting_on": item.get("waiting_on"),
-                    "severity": item.get("severity"),
-                    "index": todo.get("index"),
-                    "text": text,
-                    "source": "user_todos",
-                }
-            )
-    if not blockers:
-        return None
-    return {
-        "source": "attention_queue.user_todos",
-        "open_count": len(blockers),
-        "items": blockers[:limit],
-    }
+    return _dependency_blocker_summary_read_model(
+        items,
+        current_goal_id=current_goal_id,
+        limit=limit,
+    )
 
 
 def attach_dependency_blockers(items: list[dict[str, Any]]) -> None:
-    for item in items:
-        if not isinstance(item, dict):
-            continue
-        goal_id = str(item.get("goal_id") or "")
-        if not goal_id:
-            continue
-        blockers = dependency_blocker_summary(items, current_goal_id=goal_id)
-        if blockers:
-            item["dependency_blockers"] = blockers
+    _attach_dependency_blockers_read_model(items, limit=MAX_DEPENDENCY_BLOCKERS)
 
 
 def first_open_todo_item(todos: dict[str, Any] | None) -> dict[str, Any] | None:


### PR DESCRIPTION
## Summary
- move todo item/lane/first-open/dependency-blocker read-model helpers from status.py into loopx.projections.todo_summary with compatibility wrappers kept in status.py
- add todo-readmodel-boundary smoke and register it in the core control-plane canary family
- stabilize the mini-control-plane interrupt comparison summary smoke so it checks its own summary contract while leaving strict baseline uplift coverage in codex-cli-long-run-benchmark-smoke.py

## Validation
- python3 -m compileall -q examples/mini-control-plane-interrupt-comparison-summary-smoke.py loopx/projections/todo_summary.py loopx/status.py loopx/canary/planner.py
- python3 examples/control_plane/todo-readmodel-boundary-smoke.py
- python3 examples/control_plane/todo-first-open-summary-smoke.py
- python3 examples/control_plane/quota-work-lane-policy-smoke.py
- python3 examples/codex-cli-long-run-benchmark-smoke.py
- PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --profile core-control-plane --offset 88 --limit 10
- PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --profile core-control-plane (131/131)
- git diff --check
- public/private boundary scan clean; PRIVATE_MARKER_DO_NOT_COPY hit was the public smoke sentinel literal only