### PR TITLE
Add hard task lease runtime

### DIFF
--- a/examples/control_plane/task-lease-runtime-smoke.py
+++ b/examples/control_plane/task-lease-runtime-smoke.py
@@ -1,0 +1,272 @@
+#!/usr/bin/env python3
+"""Smoke-test the task_lease_v0 runtime and CLI contract."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GOAL_ID = "task-lease-runtime-goal"
+TODO_A = "todo_taskleasea"
+TODO_B = "todo_taskleaseb"
+TODO_C = "todo_taskleasec"
+
+
+def write_fixture(root: Path) -> Path:
+    project = root / "project"
+    runtime = root / "runtime"
+    registry_path = project / ".loopx" / "registry.json"
+    state_file = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(
+        "---\n"
+        "status: active\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Active Goal State\n\n"
+        "## Agent Todo\n\n"
+        f"- [ ] First independently claimable todo.\n"
+        f"  <!-- loopx: todo_id={TODO_A} status=open -->\n"
+        f"- [ ] Second independently claimable todo.\n"
+        f"  <!-- loopx: todo_id={TODO_B} status=open -->\n"
+        f"- [ ] Conflicting write-scope todo.\n"
+        f"  <!-- loopx: todo_id={TODO_C} status=open -->\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
+                        "adapter": {"kind": "generic_project_goal_v0", "status": "connected"},
+                        "authority_sources": [],
+                        "coordination": {
+                            "registered_agents": ["codex-main-control", "codex-side-bypass"],
+                            "primary_agent": "codex-main-control",
+                        },
+                    }
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path
+
+
+def cli(registry_path: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry_path),
+            "--format",
+            "json",
+            "task-lease",
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        check=check,
+        text=True,
+        capture_output=True,
+    )
+
+
+def payload(result: subprocess.CompletedProcess[str]) -> dict[str, Any]:
+    return json.loads(result.stdout)
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-task-lease-smoke-") as tmp:
+        registry_path = write_fixture(Path(tmp))
+
+        first = payload(
+            cli(
+                registry_path,
+                "acquire",
+                "--goal-id",
+                GOAL_ID,
+                "--todo-id",
+                TODO_A,
+                "--owner",
+                "codex-main-control",
+                "--idempotency-key",
+                "turn-1",
+                "--ttl-seconds",
+                "120",
+                "--write-scope",
+                "loopx/**",
+            )
+        )
+        assert first["ok"] is True and first["acquired"] is True, first
+        assert first["lease"]["schema_version"] == "task_lease_v0", first
+        assert first["lease"]["version"] == 1, first
+
+        idempotent = payload(
+            cli(
+                registry_path,
+                "acquire",
+                "--goal-id",
+                GOAL_ID,
+                "--todo-id",
+                TODO_A,
+                "--owner",
+                "codex-main-control",
+                "--idempotency-key",
+                "turn-1",
+                "--ttl-seconds",
+                "120",
+                "--write-scope",
+                "loopx/**",
+            )
+        )
+        assert idempotent["ok"] is True and idempotent["idempotent"] is True, idempotent
+        assert idempotent["lease"]["version"] == 1, idempotent
+
+        same_goal_different_scope = payload(
+            cli(
+                registry_path,
+                "acquire",
+                "--goal-id",
+                GOAL_ID,
+                "--todo-id",
+                TODO_B,
+                "--owner",
+                "codex-side-bypass",
+                "--idempotency-key",
+                "side-1",
+                "--ttl-seconds",
+                "120",
+                "--write-scope",
+                "docs/**",
+            )
+        )
+        assert same_goal_different_scope["ok"] is True, same_goal_different_scope
+
+        conflict = cli(
+            registry_path,
+            "acquire",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            TODO_C,
+            "--owner",
+            "codex-side-bypass",
+            "--idempotency-key",
+            "side-2",
+            "--ttl-seconds",
+            "120",
+            "--write-scope",
+            "loopx/cli_commands/**",
+            check=False,
+        )
+        assert conflict.returncode == 1, conflict.stdout
+        conflict_payload = payload(conflict)
+        assert conflict_payload["error_code"] == "write_scope_conflict", conflict_payload
+        assert conflict_payload["conflicts"][0]["todo_id"] == TODO_A, conflict_payload
+
+        mismatch = cli(
+            registry_path,
+            "renew",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            TODO_A,
+            "--owner",
+            "codex-main-control",
+            "--idempotency-key",
+            "turn-1",
+            "--expected-version",
+            "99",
+            check=False,
+        )
+        assert mismatch.returncode == 1, mismatch.stdout
+        assert payload(mismatch)["error_code"] == "version_mismatch", mismatch.stdout
+
+        renewed = payload(
+            cli(
+                registry_path,
+                "renew",
+                "--goal-id",
+                GOAL_ID,
+                "--todo-id",
+                TODO_A,
+                "--owner",
+                "codex-main-control",
+                "--idempotency-key",
+                "turn-1",
+                "--expected-version",
+                "1",
+            )
+        )
+        assert renewed["ok"] is True and renewed["lease"]["version"] == 2, renewed
+
+        transferred = payload(
+            cli(
+                registry_path,
+                "transfer",
+                "--goal-id",
+                GOAL_ID,
+                "--todo-id",
+                TODO_A,
+                "--owner",
+                "codex-main-control",
+                "--idempotency-key",
+                "turn-1",
+                "--new-owner",
+                "codex-side-bypass",
+                "--new-idempotency-key",
+                "side-transfer",
+                "--expected-version",
+                "2",
+            )
+        )
+        assert transferred["lease"]["owner"] == "codex-side-bypass", transferred
+        assert transferred["lease"]["version"] == 3, transferred
+
+        inspected = payload(cli(registry_path, "inspect", "--goal-id", GOAL_ID, "--todo-id", TODO_A))
+        assert inspected["active"] is True and inspected["lease"]["version"] == 3, inspected
+
+        released = payload(
+            cli(
+                registry_path,
+                "release",
+                "--goal-id",
+                GOAL_ID,
+                "--todo-id",
+                TODO_A,
+                "--owner",
+                "codex-side-bypass",
+                "--idempotency-key",
+                "side-transfer",
+                "--expected-version",
+                "3",
+            )
+        )
+        assert released["released"] is True, released
+        assert payload(cli(registry_path, "inspect", "--goal-id", GOAL_ID, "--todo-id", TODO_A))["active"] is False
+
+    print("task-lease-runtime-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -46,6 +46,7 @@ from .cli_commands import (
     handle_starter_command,
     handle_summary_all_command,
     handle_support_control_command,
+    handle_task_lease_command,
     handle_todo_command,
     handle_version_command,
     handle_worker_bridge_command,
@@ -68,6 +69,7 @@ from .cli_commands import (
     register_status_commands,
     register_summary_all_command,
     register_support_control_commands,
+    register_task_lease_command,
     register_todo_command,
     register_version_command,
     register_worker_bridge_commands,
@@ -178,6 +180,7 @@ def main(argv: list[str] | None = None) -> int:
     register_slash_commands_command(sub, add_subcommand_format)
     register_dreaming_commands(sub, add_subcommand_format)
     register_todo_command(sub)
+    register_task_lease_command(sub, add_subcommand_format)
     register_quota_command(sub)
 
     args = parser.parse_args(raw_argv)
@@ -438,6 +441,16 @@ def main(argv: list[str] | None = None) -> int:
             print_payload=print_payload,
             append_cli_rollout_event=append_cli_rollout_event,
         )
+
+    task_lease_result = handle_task_lease_command(
+        args,
+        registry_path=registry_path,
+        runtime_root_arg=args.runtime_root,
+        output_format=output_format,
+        print_payload=print_payload,
+    )
+    if task_lease_result is not None:
+        return task_lease_result
 
     if args.command == "quota":
         return handle_quota_command(

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -150,6 +150,7 @@ from .support_control import (
     handle_support_control_command,
     register_support_control_commands,
 )
+from .task_lease import handle_task_lease_command, register_task_lease_command
 from .terminal_bench_adapter import (
     handle_terminal_bench_adapter_command,
     register_terminal_bench_adapter_commands,
@@ -224,6 +225,7 @@ __all__ = [
     "handle_starter_visible_pilot_command",
     "handle_summary_all_command",
     "handle_support_control_command",
+    "handle_task_lease_command",
     "handle_terminal_bench_adapter_command",
     "handle_terminal_bench_environment_result_command",
     "handle_todo_command",
@@ -268,6 +270,7 @@ __all__ = [
     "register_summary_all_command",
     "register_status_commands",
     "register_support_control_commands",
+    "register_task_lease_command",
     "register_terminal_bench_adapter_commands",
     "register_terminal_bench_environment_result_commands",
     "register_todo_command",

--- a/loopx/cli_commands/task_lease.py
+++ b/loopx/cli_commands/task_lease.py
@@ -1,0 +1,212 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+from ..task_lease import (
+    TaskLeaseError,
+    acquire_task_lease,
+    inspect_task_lease,
+    release_task_lease,
+    renew_task_lease,
+    runtime_root_from_registry,
+    transfer_task_lease,
+)
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+
+
+def render_task_lease_markdown(payload: dict[str, object]) -> str:
+    lines = [
+        "# LoopX Task Lease",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- action: `{payload.get('action')}`",
+    ]
+    if payload.get("error"):
+        lines.append(f"- error: {payload.get('error')}")
+    if payload.get("error_code"):
+        lines.append(f"- error_code: `{payload.get('error_code')}`")
+    lease = payload.get("lease")
+    if isinstance(lease, dict):
+        lines.extend(
+            [
+                f"- goal_id: `{lease.get('goal_id')}`",
+                f"- todo_id: `{lease.get('todo_id')}`",
+                f"- owner: `{lease.get('owner')}`",
+                f"- version: `{lease.get('version')}`",
+                f"- expires_at: `{lease.get('expires_at')}`",
+                f"- write_scopes: `{', '.join(lease.get('write_scopes') or [])}`",
+            ]
+        )
+    if payload.get("lease_path"):
+        lines.append(f"- lease_path: `{payload.get('lease_path')}`")
+    conflicts = payload.get("conflicts")
+    if isinstance(conflicts, list) and conflicts:
+        lines.append("- conflicts:")
+        for conflict in conflicts:
+            if not isinstance(conflict, dict):
+                continue
+            lines.append(
+                f"  - `{conflict.get('todo_id')}` owner=`{conflict.get('owner')}` "
+                f"expires_at=`{conflict.get('expires_at')}` "
+                f"write_scopes=`{', '.join(conflict.get('write_scopes') or [])}`"
+            )
+    return "\n".join(lines)
+
+
+def register_task_lease_command(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+) -> None:
+    parser = subparsers.add_parser(
+        "task-lease",
+        help="Acquire, renew, transfer, release, or inspect a per-(goal_id,todo_id) hard task lease.",
+    )
+    add_subcommand_format(parser)
+    parser.add_argument(
+        "task_lease_command",
+        choices=["acquire", "renew", "transfer", "release", "inspect"],
+        help="Lease lifecycle action.",
+    )
+    parser.add_argument("--goal-id", required=True, help="Goal id that owns the todo.")
+    parser.add_argument("--todo-id", required=True, help="Structured todo id such as todo_ab12cd34ef56.")
+    parser.add_argument("--owner", help="Registered public-safe agent id that owns the lease.")
+    parser.add_argument("--idempotency-key", help="Public-safe token used for idempotent retries and CAS.")
+    parser.add_argument("--new-owner", help="For transfer, target registered public-safe agent id.")
+    parser.add_argument("--new-idempotency-key", help="For transfer, target idempotency key.")
+    parser.add_argument(
+        "--ttl-seconds",
+        type=int,
+        help="Lease TTL in seconds. Defaults to 45 minutes and is capped at 24 hours.",
+    )
+    parser.add_argument(
+        "--write-scope",
+        dest="write_scopes",
+        action="append",
+        help="Relative write scope protected by this lease, such as loopx/**. Repeatable.",
+    )
+    parser.add_argument(
+        "--expected-version",
+        type=int,
+        help="Optional CAS version that must match the current lease version.",
+    )
+
+
+def _requires_owner(args: argparse.Namespace) -> bool:
+    return args.task_lease_command in {"acquire", "renew", "transfer", "release"}
+
+
+def handle_task_lease_command(
+    args: argparse.Namespace,
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    output_format: Callable[..., str],
+    print_payload: PrintPayload,
+) -> int | None:
+    if args.command != "task-lease":
+        return None
+    try:
+        if _requires_owner(args) and not args.owner:
+            raise ValueError("task-lease action requires --owner")
+        if _requires_owner(args) and not args.idempotency_key:
+            raise ValueError("task-lease action requires --idempotency-key")
+        runtime_root = runtime_root_from_registry(registry_path, runtime_root_arg)
+        if args.task_lease_command == "acquire":
+            payload = acquire_task_lease(
+                runtime_root=runtime_root,
+                goal_id=args.goal_id,
+                todo_id=args.todo_id,
+                owner=args.owner,
+                idempotency_key=args.idempotency_key,
+                ttl_seconds=args.ttl_seconds,
+                write_scopes=args.write_scopes,
+                expected_version=args.expected_version,
+            )
+        elif args.task_lease_command == "renew":
+            if args.write_scopes:
+                raise ValueError("task-lease renew does not accept --write-scope")
+            payload = renew_task_lease(
+                runtime_root=runtime_root,
+                goal_id=args.goal_id,
+                todo_id=args.todo_id,
+                owner=args.owner,
+                idempotency_key=args.idempotency_key,
+                ttl_seconds=args.ttl_seconds,
+                expected_version=args.expected_version,
+            )
+        elif args.task_lease_command == "transfer":
+            if args.write_scopes:
+                raise ValueError("task-lease transfer does not accept --write-scope")
+            if not args.new_owner or not args.new_idempotency_key:
+                raise ValueError("task-lease transfer requires --new-owner and --new-idempotency-key")
+            payload = transfer_task_lease(
+                runtime_root=runtime_root,
+                goal_id=args.goal_id,
+                todo_id=args.todo_id,
+                owner=args.owner,
+                idempotency_key=args.idempotency_key,
+                new_owner=args.new_owner,
+                new_idempotency_key=args.new_idempotency_key,
+                ttl_seconds=args.ttl_seconds,
+                expected_version=args.expected_version,
+            )
+        elif args.task_lease_command == "release":
+            if args.write_scopes:
+                raise ValueError("task-lease release does not accept --write-scope")
+            if args.ttl_seconds is not None:
+                raise ValueError("task-lease release does not accept --ttl-seconds")
+            payload = release_task_lease(
+                runtime_root=runtime_root,
+                goal_id=args.goal_id,
+                todo_id=args.todo_id,
+                owner=args.owner,
+                idempotency_key=args.idempotency_key,
+                expected_version=args.expected_version,
+            )
+        else:
+            unsupported = [
+                flag
+                for flag, value in (
+                    ("--owner", args.owner),
+                    ("--idempotency-key", args.idempotency_key),
+                    ("--new-owner", args.new_owner),
+                    ("--new-idempotency-key", args.new_idempotency_key),
+                    ("--ttl-seconds", args.ttl_seconds),
+                    ("--write-scope", args.write_scopes),
+                    ("--expected-version", args.expected_version),
+                )
+                if value
+            ]
+            if unsupported:
+                raise ValueError("task-lease inspect only accepts --goal-id and --todo-id; unsupported: " + ", ".join(unsupported))
+            payload = inspect_task_lease(
+                runtime_root=runtime_root,
+                goal_id=args.goal_id,
+                todo_id=args.todo_id,
+            )
+    except TaskLeaseError as exc:
+        payload = {
+            "ok": False,
+            "schema_version": "task_lease_v0",
+            "action": getattr(args, "task_lease_command", None),
+            "error": str(exc),
+            "error_code": exc.code,
+            **exc.payload,
+        }
+    except Exception as exc:
+        payload = {
+            "ok": False,
+            "schema_version": "task_lease_v0",
+            "action": getattr(args, "task_lease_command", None),
+            "error": str(exc),
+            "error_code": exc.__class__.__name__,
+        }
+    print_payload(payload, output_format(args), render_task_lease_markdown)
+    return 0 if payload.get("ok") else 1

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -43,6 +43,10 @@ COMMAND_GROUPS: list[dict[str, object]] = [
                 "purpose": "Render a handoff or review packet for operator judgment.",
             },
             {"command": "loopx todo --help", "purpose": "Show todo lifecycle commands."},
+            {
+                "command": "loopx task-lease --help",
+                "purpose": "Acquire, renew, transfer, release, or inspect a hard per-todo lease.",
+            },
             {"command": "loopx quota should-run", "purpose": "Decide whether the next agent turn should run."},
             {"command": "loopx history --goal-id <goal-id>", "purpose": "Read compact run history."},
         ],
@@ -162,6 +166,7 @@ def render_concise_help(program: str = "loopx") -> str:
             "  loopx status                   Show current goals, gates, and next action.",
             "  loopx diagnose --goal-id ID    Build a compact evidence packet.",
             "  loopx todo --help              Add, claim, complete, update, or archive todos.",
+            "  loopx task-lease --help        Manage a hard per-todo lease.",
             "  loopx quota should-run         Decide whether the next agent turn should run.",
             "",
             "Run the loop:",

--- a/loopx/task_lease.py
+++ b/loopx/task_lease.py
@@ -1,0 +1,492 @@
+from __future__ import annotations
+
+import json
+import re
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+from .file_lock import exclusive_file_lock
+from .history import load_registry
+from .paths import resolve_runtime_root
+from .todo_contract import (
+    normalize_required_write_scopes,
+    normalize_todo_claimed_by,
+    normalize_todo_id,
+)
+
+
+TASK_LEASE_SCHEMA_VERSION = "task_lease_v0"
+DEFAULT_TASK_LEASE_TTL_SECONDS = 45 * 60
+MAX_TASK_LEASE_TTL_SECONDS = 24 * 60 * 60
+IDEMPOTENCY_KEY_PATTERN = re.compile(r"^[A-Za-z0-9_.:@/-]{1,160}$")
+
+
+class TaskLeaseError(ValueError):
+    def __init__(self, message: str, *, code: str, payload: dict[str, Any] | None = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.payload = payload or {}
+
+
+def now_utc() -> datetime:
+    return datetime.now(timezone.utc).replace(microsecond=0)
+
+
+def isoformat(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def parse_timestamp(value: Any) -> datetime | None:
+    candidate = str(value or "").strip()
+    if not candidate:
+        return None
+    if candidate.endswith("Z"):
+        candidate = candidate[:-1] + "+00:00"
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def normalize_idempotency_key(value: Any) -> str:
+    candidate = str(value or "").strip()
+    if not candidate or not IDEMPOTENCY_KEY_PATTERN.match(candidate):
+        raise TaskLeaseError(
+            "idempotency key must be a public-safe token",
+            code="invalid_idempotency_key",
+        )
+    return candidate
+
+
+def normalize_owner(value: Any) -> str:
+    owner = normalize_todo_claimed_by(value)
+    if not owner:
+        raise TaskLeaseError("owner must be a public-safe agent id", code="invalid_owner")
+    return owner
+
+
+def normalize_ttl_seconds(value: int | None) -> int:
+    ttl = DEFAULT_TASK_LEASE_TTL_SECONDS if value is None else int(value)
+    if ttl <= 0 or ttl > MAX_TASK_LEASE_TTL_SECONDS:
+        raise TaskLeaseError(
+            f"ttl seconds must be between 1 and {MAX_TASK_LEASE_TTL_SECONDS}",
+            code="invalid_ttl",
+        )
+    return ttl
+
+
+def normalize_goal_id(value: Any) -> str:
+    goal_id = str(value or "").strip()
+    if not goal_id or goal_id in {".", ".."} or "/" in goal_id or "\\" in goal_id:
+        raise TaskLeaseError("goal id must be a single path segment", code="invalid_goal_id")
+    if Path(goal_id).name != goal_id:
+        raise TaskLeaseError("goal id must not include path traversal", code="invalid_goal_id")
+    return goal_id
+
+
+def normalize_lease_todo_id(value: Any) -> str:
+    todo_id = normalize_todo_id(value)
+    if not todo_id:
+        raise TaskLeaseError("todo id must use the todo_<token> shape", code="invalid_todo_id")
+    return todo_id
+
+
+def task_lease_dir(*, runtime_root: Path, goal_id: str) -> Path:
+    return runtime_root / "goals" / normalize_goal_id(goal_id) / "task-leases"
+
+
+def task_lease_path(*, runtime_root: Path, goal_id: str, todo_id: str) -> Path:
+    return task_lease_dir(runtime_root=runtime_root, goal_id=goal_id) / f"{normalize_lease_todo_id(todo_id)}.json"
+
+
+def task_lease_lock_path(*, runtime_root: Path, goal_id: str) -> Path:
+    return task_lease_dir(runtime_root=runtime_root, goal_id=goal_id) / ".task-leases"
+
+
+def runtime_root_from_registry(registry_path: Path, runtime_root_override: str | None) -> Path:
+    registry = load_registry(registry_path)
+    return resolve_runtime_root(registry, runtime_root_override)
+
+
+def read_lease(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
+        return None
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        raise TaskLeaseError(
+            f"lease file is not valid JSON: {path}",
+            code="corrupt_lease",
+            payload={"lease_path": str(path), "error": str(exc)},
+        ) from exc
+    if not isinstance(payload, dict):
+        raise TaskLeaseError(
+            f"lease file must contain an object: {path}",
+            code="corrupt_lease",
+            payload={"lease_path": str(path)},
+        )
+    return payload
+
+
+def write_lease(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temp_path = path.with_name(f".{path.name}.{id(payload)}.tmp")
+    temp_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    temp_path.replace(path)
+
+
+def remove_lease(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def lease_expires_at(lease: dict[str, Any] | None) -> datetime | None:
+    return parse_timestamp((lease or {}).get("expires_at"))
+
+
+def lease_is_active(lease: dict[str, Any] | None, *, at: datetime | None = None) -> bool:
+    if not lease or lease.get("schema_version") != TASK_LEASE_SCHEMA_VERSION:
+        return False
+    expires_at = lease_expires_at(lease)
+    return bool(expires_at and expires_at > (at or now_utc()))
+
+
+def scope_root(scope: str) -> str:
+    value = scope.strip()
+    if value in {"*", "**", "./"}:
+        return ""
+    wildcard_indexes = [index for index in (value.find("*"), value.find("?"), value.find("[")) if index >= 0]
+    if wildcard_indexes:
+        value = value[: min(wildcard_indexes)]
+    if "/" in value:
+        value = value[: value.rfind("/") + 1]
+    return value.rstrip("/")
+
+
+def write_scopes_overlap(left: list[str], right: list[str]) -> bool:
+    left_scopes = normalize_required_write_scopes(left)
+    right_scopes = normalize_required_write_scopes(right)
+    if not left_scopes or not right_scopes:
+        return False
+    for left_scope in left_scopes:
+        for right_scope in right_scopes:
+            if left_scope == right_scope:
+                return True
+            left_root = scope_root(left_scope)
+            right_root = scope_root(right_scope)
+            if not left_root or not right_root:
+                return True
+            if left_root.startswith(right_root.rstrip("/") + "/"):
+                return True
+            if right_root.startswith(left_root.rstrip("/") + "/"):
+                return True
+    return False
+
+
+def active_conflicts(
+    *,
+    runtime_root: Path,
+    goal_id: str,
+    todo_id: str,
+    write_scopes: list[str],
+    at: datetime,
+) -> list[dict[str, Any]]:
+    conflicts: list[dict[str, Any]] = []
+    lease_dir = task_lease_dir(runtime_root=runtime_root, goal_id=goal_id)
+    if not lease_dir.exists():
+        return conflicts
+    for path in sorted(lease_dir.glob("todo_*.json")):
+        lease = read_lease(path)
+        if not lease_is_active(lease, at=at):
+            continue
+        if normalize_lease_todo_id(lease.get("todo_id")) == todo_id:
+            continue
+        if write_scopes_overlap(write_scopes, normalize_required_write_scopes(lease.get("write_scopes"))):
+            conflicts.append(
+                {
+                    "todo_id": lease.get("todo_id"),
+                    "owner": lease.get("owner"),
+                    "expires_at": lease.get("expires_at"),
+                    "write_scopes": lease.get("write_scopes") or [],
+                    "lease_path": str(path),
+                }
+            )
+    return conflicts
+
+
+def assert_expected_version(lease: dict[str, Any] | None, expected_version: int | None) -> None:
+    if expected_version is None:
+        return
+    actual = int((lease or {}).get("version") or 0)
+    if actual != expected_version:
+        raise TaskLeaseError(
+            f"lease version mismatch: expected {expected_version}, got {actual}",
+            code="version_mismatch",
+            payload={"expected_version": expected_version, "actual_version": actual},
+        )
+
+
+def build_lease(
+    *,
+    goal_id: str,
+    todo_id: str,
+    owner: str,
+    idempotency_key: str,
+    write_scopes: list[str],
+    version: int,
+    acquired_at: str,
+    updated_at: str,
+    expires_at: str,
+) -> dict[str, Any]:
+    return {
+        "schema_version": TASK_LEASE_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "todo_id": todo_id,
+        "owner": owner,
+        "idempotency_key": idempotency_key,
+        "write_scopes": write_scopes,
+        "version": version,
+        "acquired_at": acquired_at,
+        "updated_at": updated_at,
+        "expires_at": expires_at,
+        "status": "active",
+    }
+
+
+def acquire_task_lease(
+    *,
+    runtime_root: Path,
+    goal_id: str,
+    todo_id: str,
+    owner: str,
+    idempotency_key: str,
+    ttl_seconds: int | None = None,
+    write_scopes: list[str] | None = None,
+    expected_version: int | None = None,
+) -> dict[str, Any]:
+    goal_id = normalize_goal_id(goal_id)
+    todo_id = normalize_lease_todo_id(todo_id)
+    owner = normalize_owner(owner)
+    idempotency_key = normalize_idempotency_key(idempotency_key)
+    ttl = normalize_ttl_seconds(ttl_seconds)
+    normalized_write_scopes = normalize_required_write_scopes(write_scopes)
+    lease_dir = task_lease_dir(runtime_root=runtime_root, goal_id=goal_id)
+    lock_target = task_lease_lock_path(runtime_root=runtime_root, goal_id=goal_id)
+    lease_path = task_lease_path(runtime_root=runtime_root, goal_id=goal_id, todo_id=todo_id)
+    at = now_utc()
+    with exclusive_file_lock(lock_target):
+        existing = read_lease(lease_path)
+        assert_expected_version(existing, expected_version)
+        if lease_is_active(existing, at=at):
+            if (
+                existing.get("owner") == owner
+                and existing.get("idempotency_key") == idempotency_key
+            ):
+                return {
+                    "ok": True,
+                    "schema_version": TASK_LEASE_SCHEMA_VERSION,
+                    "action": "acquire",
+                    "acquired": False,
+                    "idempotent": True,
+                    "lease": existing,
+                    "lease_path": str(lease_path),
+                }
+            raise TaskLeaseError(
+                "todo already has an active lease",
+                code="todo_lease_conflict",
+                payload={"lease": existing, "lease_path": str(lease_path)},
+            )
+        conflicts = active_conflicts(
+            runtime_root=runtime_root,
+            goal_id=goal_id,
+            todo_id=todo_id,
+            write_scopes=normalized_write_scopes,
+            at=at,
+        )
+        if conflicts:
+            raise TaskLeaseError(
+                "write scope overlaps another active task lease",
+                code="write_scope_conflict",
+                payload={"conflicts": conflicts},
+            )
+        updated_at = isoformat(at)
+        expires_at = isoformat(at + timedelta(seconds=ttl))
+        lease = build_lease(
+            goal_id=goal_id,
+            todo_id=todo_id,
+            owner=owner,
+            idempotency_key=idempotency_key,
+            write_scopes=normalized_write_scopes,
+            version=int((existing or {}).get("version") or 0) + 1,
+            acquired_at=updated_at,
+            updated_at=updated_at,
+            expires_at=expires_at,
+        )
+        lease_dir.mkdir(parents=True, exist_ok=True)
+        write_lease(lease_path, lease)
+        return {
+            "ok": True,
+            "schema_version": TASK_LEASE_SCHEMA_VERSION,
+            "action": "acquire",
+            "acquired": True,
+            "idempotent": False,
+            "lease": lease,
+            "lease_path": str(lease_path),
+        }
+
+
+def renew_task_lease(
+    *,
+    runtime_root: Path,
+    goal_id: str,
+    todo_id: str,
+    owner: str,
+    idempotency_key: str,
+    ttl_seconds: int | None = None,
+    expected_version: int | None = None,
+) -> dict[str, Any]:
+    goal_id = normalize_goal_id(goal_id)
+    todo_id = normalize_lease_todo_id(todo_id)
+    owner = normalize_owner(owner)
+    idempotency_key = normalize_idempotency_key(idempotency_key)
+    ttl = normalize_ttl_seconds(ttl_seconds)
+    lock_target = task_lease_lock_path(runtime_root=runtime_root, goal_id=goal_id)
+    lease_path = task_lease_path(runtime_root=runtime_root, goal_id=goal_id, todo_id=todo_id)
+    at = now_utc()
+    with exclusive_file_lock(lock_target):
+        lease = read_lease(lease_path)
+        assert_expected_version(lease, expected_version)
+        if not lease_is_active(lease, at=at):
+            raise TaskLeaseError("lease is missing or expired", code="lease_not_active")
+        if lease.get("owner") != owner or lease.get("idempotency_key") != idempotency_key:
+            raise TaskLeaseError("lease owner or idempotency key mismatch", code="lease_cas_mismatch")
+        lease = dict(lease)
+        lease["version"] = int(lease.get("version") or 0) + 1
+        lease["updated_at"] = isoformat(at)
+        lease["expires_at"] = isoformat(at + timedelta(seconds=ttl))
+        write_lease(lease_path, lease)
+        return {
+            "ok": True,
+            "schema_version": TASK_LEASE_SCHEMA_VERSION,
+            "action": "renew",
+            "renewed": True,
+            "lease": lease,
+            "lease_path": str(lease_path),
+        }
+
+
+def transfer_task_lease(
+    *,
+    runtime_root: Path,
+    goal_id: str,
+    todo_id: str,
+    owner: str,
+    idempotency_key: str,
+    new_owner: str,
+    new_idempotency_key: str,
+    ttl_seconds: int | None = None,
+    expected_version: int | None = None,
+) -> dict[str, Any]:
+    goal_id = normalize_goal_id(goal_id)
+    todo_id = normalize_lease_todo_id(todo_id)
+    owner = normalize_owner(owner)
+    idempotency_key = normalize_idempotency_key(idempotency_key)
+    new_owner = normalize_owner(new_owner)
+    new_idempotency_key = normalize_idempotency_key(new_idempotency_key)
+    ttl = normalize_ttl_seconds(ttl_seconds)
+    lock_target = task_lease_lock_path(runtime_root=runtime_root, goal_id=goal_id)
+    lease_path = task_lease_path(runtime_root=runtime_root, goal_id=goal_id, todo_id=todo_id)
+    at = now_utc()
+    with exclusive_file_lock(lock_target):
+        lease = read_lease(lease_path)
+        assert_expected_version(lease, expected_version)
+        if not lease_is_active(lease, at=at):
+            raise TaskLeaseError("lease is missing or expired", code="lease_not_active")
+        if lease.get("owner") != owner or lease.get("idempotency_key") != idempotency_key:
+            raise TaskLeaseError("lease owner or idempotency key mismatch", code="lease_cas_mismatch")
+        lease = dict(lease)
+        lease["owner"] = new_owner
+        lease["idempotency_key"] = new_idempotency_key
+        lease["version"] = int(lease.get("version") or 0) + 1
+        lease["updated_at"] = isoformat(at)
+        lease["expires_at"] = isoformat(at + timedelta(seconds=ttl))
+        write_lease(lease_path, lease)
+        return {
+            "ok": True,
+            "schema_version": TASK_LEASE_SCHEMA_VERSION,
+            "action": "transfer",
+            "transferred": True,
+            "lease": lease,
+            "lease_path": str(lease_path),
+        }
+
+
+def release_task_lease(
+    *,
+    runtime_root: Path,
+    goal_id: str,
+    todo_id: str,
+    owner: str,
+    idempotency_key: str,
+    expected_version: int | None = None,
+) -> dict[str, Any]:
+    goal_id = normalize_goal_id(goal_id)
+    todo_id = normalize_lease_todo_id(todo_id)
+    owner = normalize_owner(owner)
+    idempotency_key = normalize_idempotency_key(idempotency_key)
+    lock_target = task_lease_lock_path(runtime_root=runtime_root, goal_id=goal_id)
+    lease_path = task_lease_path(runtime_root=runtime_root, goal_id=goal_id, todo_id=todo_id)
+    at = now_utc()
+    with exclusive_file_lock(lock_target):
+        lease = read_lease(lease_path)
+        assert_expected_version(lease, expected_version)
+        if not lease:
+            return {
+                "ok": True,
+                "schema_version": TASK_LEASE_SCHEMA_VERSION,
+                "action": "release",
+                "released": False,
+                "missing": True,
+                "lease_path": str(lease_path),
+            }
+        if lease_is_active(lease, at=at) and (
+            lease.get("owner") != owner or lease.get("idempotency_key") != idempotency_key
+        ):
+            raise TaskLeaseError("lease owner or idempotency key mismatch", code="lease_cas_mismatch")
+        remove_lease(lease_path)
+        return {
+            "ok": True,
+            "schema_version": TASK_LEASE_SCHEMA_VERSION,
+            "action": "release",
+            "released": True,
+            "lease": lease,
+            "lease_path": str(lease_path),
+        }
+
+
+def inspect_task_lease(
+    *,
+    runtime_root: Path,
+    goal_id: str,
+    todo_id: str,
+) -> dict[str, Any]:
+    goal_id = normalize_goal_id(goal_id)
+    todo_id = normalize_lease_todo_id(todo_id)
+    lease_path = task_lease_path(runtime_root=runtime_root, goal_id=goal_id, todo_id=todo_id)
+    lease = read_lease(lease_path)
+    return {
+        "ok": True,
+        "schema_version": TASK_LEASE_SCHEMA_VERSION,
+        "action": "inspect",
+        "goal_id": goal_id,
+        "todo_id": todo_id,
+        "active": lease_is_active(lease),
+        "lease": lease,
+        "lease_path": str(lease_path),
+    }


### PR DESCRIPTION
## Summary
- Add task_lease_v0 runtime records under the LoopX runtime root, scoped by (goal_id, todo_id)
- Add loopx task-lease acquire/renew/transfer/release/inspect with TTL, idempotency key, version CAS, and overlapping write-scope conflict checks
- Add command help-surface entries and a focused control-plane smoke

## Validation
- python3 -m py_compile loopx/task_lease.py loopx/cli_commands/task_lease.py loopx/cli.py loopx/cli_commands/__init__.py loopx/help_surface.py examples/control_plane/task-lease-runtime-smoke.py
- python3 examples/control_plane/task-lease-runtime-smoke.py
- python3 examples/control_plane/todo-claim-lease-roadmap-smoke.py
- python3 examples/control_plane/todo-concurrent-write-lock-smoke.py
- python3 -m loopx.cli task-lease --help >/tmp/task-lease-help.txt
- python3 -m loopx.cli commands --format json >/tmp/loopx-commands.json plus assertion that task-lease appears
- python3 -m loopx.cli --format json check --scan-path loopx/task_lease.py --scan-path loopx/cli_commands/task_lease.py --scan-path loopx/cli.py --scan-path loopx/cli_commands/__init__.py --scan-path loopx/help_surface.py --scan-path examples/control_plane/task-lease-runtime-smoke.py

Note: loopx check reported the existing loopx-meta duplicate run-history index warning; public boundary scan for the six candidate files was clean.