### PR TITLE
Extract autonomous candidate read models

### DIFF
--- a/examples/control_plane/todo-readmodel-boundary-smoke.py
+++ b/examples/control_plane/todo-readmodel-boundary-smoke.py
@@ -11,6 +11,7 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from loopx import status as status_module  # noqa: E402
+from loopx.projections import autonomous_candidates as autonomous_read_model  # noqa: E402
 from loopx.projections import todo_summary as todo_read_model  # noqa: E402
 
 
@@ -81,6 +82,11 @@ def assert_wrapper_parity() -> None:
         todos,
         item_limit=220,
     )
+    assert status_module.first_open_todo_item(todos) == todo_read_model.first_open_todo_item(
+        todos,
+        item_limit=status_module.MAX_PROJECT_ASSET_TODO_ITEMS,
+        text_limit=220,
+    )
     assert status_module.project_asset_todo_summary(
         todos,
         role="agent",
@@ -140,9 +146,53 @@ def assert_dependency_blocker_parity() -> None:
     assert status_items == direct_items
 
 
+def assert_autonomous_candidate_parity() -> None:
+    items = [
+        {
+            "goal_id": "goal-b",
+            "status": "active",
+            "waiting_on": "codex",
+            "quota": {"state": "eligible"},
+            "agent_todos": fixture_todos(),
+        },
+        {
+            "goal_id": "goal-a",
+            "status": "watching",
+            "waiting_on": status_module.MONITOR_SIGNAL_WAITING_ON,
+            "quota": {"state": "eligible"},
+            "agent_todos": fixture_todos(),
+        },
+        {
+            "goal_id": "goal-c",
+            "status": "blocked",
+            "waiting_on": "controller",
+            "quota": {"state": "eligible"},
+            "agent_todos": fixture_todos(),
+        },
+    ]
+    assert status_module.autonomous_backlog_candidates(items) == autonomous_read_model.autonomous_backlog_candidates(
+        items,
+        open_todo_items=status_module.open_todo_items,
+        todo_item_is_actionable_open=status_module.todo_item_is_actionable_open,
+        normalize_todo_text=status_module.normalize_todo_text,
+        advancement_task_class=status_module.TODO_TASK_CLASS_ADVANCEMENT,
+        limit=status_module.MAX_AUTONOMOUS_BACKLOG_CANDIDATES,
+    )
+    assert status_module.autonomous_monitor_candidates(items) == autonomous_read_model.autonomous_monitor_candidates(
+        items,
+        open_todo_items=status_module.open_todo_items,
+        todo_item_is_actionable_open=status_module.todo_item_is_actionable_open,
+        normalize_todo_text=status_module.normalize_todo_text,
+        monitor_task_class=status_module.TODO_TASK_CLASS_MONITOR,
+        monitor_signal_waiting_on=status_module.MONITOR_SIGNAL_WAITING_ON,
+        limit=status_module.MAX_AUTONOMOUS_BACKLOG_CANDIDATES,
+    )
+
+
 def main() -> None:
     assert_wrapper_parity()
     assert_dependency_blocker_parity()
+    assert_autonomous_candidate_parity()
 
 
 if __name__ == "__main__":

--- a/loopx/projections/autonomous_candidates.py
+++ b/loopx/projections/autonomous_candidates.py
@@ -91,3 +91,43 @@ def autonomous_todo_candidates(
         "task_class": task_class,
         "items": candidates[:limit],
     }
+
+
+def autonomous_backlog_candidates(
+    items: list[dict[str, Any]],
+    *,
+    open_todo_items: Callable[..., list[dict[str, Any]]],
+    todo_item_is_actionable_open: Callable[[dict[str, Any]], bool],
+    normalize_todo_text: Callable[..., str],
+    advancement_task_class: str,
+    limit: int,
+) -> dict[str, Any] | None:
+    return autonomous_todo_candidates(
+        items,
+        task_class=advancement_task_class,
+        open_todo_items=open_todo_items,
+        todo_item_is_actionable_open=todo_item_is_actionable_open,
+        normalize_todo_text=normalize_todo_text,
+        limit=limit,
+    )
+
+
+def autonomous_monitor_candidates(
+    items: list[dict[str, Any]],
+    *,
+    open_todo_items: Callable[..., list[dict[str, Any]]],
+    todo_item_is_actionable_open: Callable[[dict[str, Any]], bool],
+    normalize_todo_text: Callable[..., str],
+    monitor_task_class: str,
+    monitor_signal_waiting_on: str,
+    limit: int,
+) -> dict[str, Any] | None:
+    return autonomous_todo_candidates(
+        items,
+        task_class=monitor_task_class,
+        open_todo_items=open_todo_items,
+        todo_item_is_actionable_open=todo_item_is_actionable_open,
+        normalize_todo_text=normalize_todo_text,
+        allowed_waiting_on={"codex", monitor_signal_waiting_on},
+        limit=limit,
+    )

--- a/loopx/projections/todo_summary.py
+++ b/loopx/projections/todo_summary.py
@@ -418,6 +418,19 @@ def first_open_todo_text(
     return str(items[0].get("text") or "") or None
 
 
+def first_open_todo_item(
+    todos: dict[str, Any] | None,
+    *,
+    item_limit: int,
+    text_limit: int,
+) -> dict[str, Any] | None:
+    for todo in open_todo_items(todos, limit=item_limit, text_limit=text_limit):
+        if not isinstance(todo, dict) or todo.get("done"):
+            continue
+        return todo
+    return None
+
+
 def project_asset_todo_summary(
     todos: dict[str, Any] | None,
     *,

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -76,9 +76,10 @@ from .projections.project_asset import (
     project_asset_user_todo_open_count,
 )
 from .projections.autonomous_candidates import (
+    autonomous_backlog_candidates as _autonomous_backlog_candidates_read_model,
+    autonomous_monitor_candidates as _autonomous_monitor_candidates_read_model,
     autonomous_priority_label as _autonomous_priority_label,
     autonomous_priority_rank as _autonomous_priority_rank,
-    autonomous_todo_candidates as _autonomous_todo_candidates,
 )
 from .projections.agent_lane_recommendation import (
     compact_agent_lane_recommendation as _compact_agent_lane_recommendation_read_model,
@@ -163,6 +164,7 @@ from .projections.todo_summary import (
     compact_todo_group,
     compact_todo_item,
     dependency_blocker_summary as _dependency_blocker_summary_read_model,
+    first_open_todo_item as _first_open_todo_item_read_model,
     first_open_todo_text as _first_open_todo_text_read_model,
     normalize_todo_text,
     normalized_pr_ref_parts,
@@ -6304,11 +6306,11 @@ def attach_dependency_blockers(items: list[dict[str, Any]]) -> None:
 
 
 def first_open_todo_item(todos: dict[str, Any] | None) -> dict[str, Any] | None:
-    for todo in open_todo_items(todos):
-        if not isinstance(todo, dict) or todo.get("done"):
-            continue
-        return todo
-    return None
+    return _first_open_todo_item_read_model(
+        todos,
+        item_limit=MAX_PROJECT_ASSET_TODO_ITEMS,
+        text_limit=220,
+    )
 
 
 def autonomous_priority_label(text: str) -> str | None:
@@ -6319,32 +6321,17 @@ def autonomous_priority_rank(priority: str | None) -> int:
     return _autonomous_priority_rank(priority)
 
 
-def autonomous_todo_candidates(
-    items: list[dict[str, Any]],
-    *,
-    task_class: str,
-    allowed_waiting_on: set[str] | None = None,
-    limit: int = MAX_AUTONOMOUS_BACKLOG_CANDIDATES,
-) -> dict[str, Any] | None:
-    return _autonomous_todo_candidates(
-        items,
-        task_class=task_class,
-        open_todo_items=open_todo_items,
-        todo_item_is_actionable_open=todo_item_is_actionable_open,
-        normalize_todo_text=normalize_todo_text,
-        allowed_waiting_on=allowed_waiting_on,
-        limit=limit,
-    )
-
-
 def autonomous_backlog_candidates(
     items: list[dict[str, Any]],
     *,
     limit: int = MAX_AUTONOMOUS_BACKLOG_CANDIDATES,
 ) -> dict[str, Any] | None:
-    return autonomous_todo_candidates(
+    return _autonomous_backlog_candidates_read_model(
         items,
-        task_class=TODO_TASK_CLASS_ADVANCEMENT,
+        open_todo_items=open_todo_items,
+        todo_item_is_actionable_open=todo_item_is_actionable_open,
+        normalize_todo_text=normalize_todo_text,
+        advancement_task_class=TODO_TASK_CLASS_ADVANCEMENT,
         limit=limit,
     )
 
@@ -6354,10 +6341,13 @@ def autonomous_monitor_candidates(
     *,
     limit: int = MAX_AUTONOMOUS_BACKLOG_CANDIDATES,
 ) -> dict[str, Any] | None:
-    return autonomous_todo_candidates(
+    return _autonomous_monitor_candidates_read_model(
         items,
-        task_class=TODO_TASK_CLASS_MONITOR,
-        allowed_waiting_on={"codex", MONITOR_SIGNAL_WAITING_ON},
+        open_todo_items=open_todo_items,
+        todo_item_is_actionable_open=todo_item_is_actionable_open,
+        normalize_todo_text=normalize_todo_text,
+        monitor_task_class=TODO_TASK_CLASS_MONITOR,
+        monitor_signal_waiting_on=MONITOR_SIGNAL_WAITING_ON,
         limit=limit,
     )
 


### PR DESCRIPTION
## Summary
- move first-open todo item selection into the todo summary read model
- add read-model wrappers for autonomous backlog and monitor candidates
- keep status.py compatibility wrappers while extending the todo read-model boundary smoke

## Validation
- python3 -m compileall -q loopx/status.py loopx/projections/todo_summary.py loopx/projections/autonomous_candidates.py examples/control_plane/todo-readmodel-boundary-smoke.py
- python3 examples/control_plane/todo-readmodel-boundary-smoke.py
- python3 examples/control_plane/todo-first-open-summary-smoke.py && python3 examples/control_plane/quota-work-lane-policy-smoke.py && python3 examples/control_plane/status-quota-review-packet-parity-smoke.py
- PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --profile core-control-plane (131/131)
- git diff --check
- public/private boundary scan on changed paths (diff clean; existing status.py benchmark boundary field names unchanged)