### PR TITLE
Extract global registry shadow projection

### DIFF
--- a/examples/control_plane/todo-readmodel-boundary-smoke.py
+++ b/examples/control_plane/todo-readmodel-boundary-smoke.py
@@ -12,6 +12,7 @@ if str(ROOT) not in sys.path:
 
 from loopx import status as status_module  # noqa: E402
 from loopx.projections import autonomous_candidates as autonomous_read_model  # noqa: E402
+from loopx.projections import global_registry_shadow as global_registry_shadow_read_model  # noqa: E402
 from loopx.projections import todo_summary as todo_read_model  # noqa: E402
 
 
@@ -189,10 +190,29 @@ def assert_autonomous_candidate_parity() -> None:
     )
 
 
+def assert_global_registry_shadow_parity() -> None:
+    finding = {
+        "kind": "state_shadow",
+        "severity": "warning",
+        "message": "registry points at stale projection",
+        "recommended_action": "refresh the public-safe state projection",
+    }
+    assert status_module.compact_global_registry_shadow_finding(
+        finding
+    ) == global_registry_shadow_read_model.compact_global_registry_shadow_finding(finding)
+
+    status_item = {"project_asset": {"goal_id": "loopx-meta"}}
+    direct_item = deepcopy(status_item)
+    status_module.attach_global_registry_shadow_finding(status_item, finding)
+    global_registry_shadow_read_model.attach_global_registry_shadow_finding(direct_item, finding)
+    assert status_item == direct_item
+
+
 def main() -> None:
     assert_wrapper_parity()
     assert_dependency_blocker_parity()
     assert_autonomous_candidate_parity()
+    assert_global_registry_shadow_parity()
 
 
 if __name__ == "__main__":

--- a/loopx/projections/global_registry_shadow.py
+++ b/loopx/projections/global_registry_shadow.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def compact_global_registry_shadow_finding(finding: dict[str, Any]) -> dict[str, Any]:
+    compact: dict[str, Any] = {
+        "kind": str(finding.get("kind") or "global_registry_finding"),
+        "severity": str(finding.get("severity") or "action"),
+        "source": "global_registry",
+    }
+    if finding.get("message"):
+        compact["message"] = str(finding.get("message"))
+    if finding.get("recommended_action"):
+        compact["recommended_action"] = str(finding.get("recommended_action"))
+    return compact
+
+
+def attach_global_registry_shadow_finding(item: dict[str, Any], finding: dict[str, Any]) -> None:
+    shadows = item.setdefault("global_registry_shadow_findings", [])
+    if isinstance(shadows, list):
+        shadows.append(compact_global_registry_shadow_finding(finding))
+    project_asset = item.get("project_asset")
+    if not isinstance(project_asset, dict):
+        return
+    summary = project_asset.setdefault("global_registry_shadow_findings", {"open": 0, "kinds": []})
+    if not isinstance(summary, dict):
+        return
+    summary["open"] = int(summary.get("open") or 0) + 1
+    kinds = summary.setdefault("kinds", [])
+    kind = str(finding.get("kind") or "global_registry_finding")
+    if isinstance(kinds, list) and kind not in kinds:
+        kinds.append(kind)

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -125,6 +125,10 @@ from .projections.monitor_display import (
     todo_summary_lane_items as _todo_summary_lane_items,
     todo_summary_open_count as _todo_summary_open_count,
 )
+from .projections.global_registry_shadow import (
+    attach_global_registry_shadow_finding as _attach_global_registry_shadow_finding_read_model,
+    compact_global_registry_shadow_finding as _compact_global_registry_shadow_finding_read_model,
+)
 from .projections.issue_meta_surface import (
     parse_issue_meta_surface as _parse_issue_meta_surface_read_model,
 )
@@ -6998,33 +7002,11 @@ def normalize_monitor_quiet_attention_display(item: dict[str, Any]) -> None:
 
 
 def compact_global_registry_shadow_finding(finding: dict[str, Any]) -> dict[str, Any]:
-    compact: dict[str, Any] = {
-        "kind": str(finding.get("kind") or "global_registry_finding"),
-        "severity": str(finding.get("severity") or "action"),
-        "source": "global_registry",
-    }
-    if finding.get("message"):
-        compact["message"] = str(finding.get("message"))
-    if finding.get("recommended_action"):
-        compact["recommended_action"] = str(finding.get("recommended_action"))
-    return compact
+    return _compact_global_registry_shadow_finding_read_model(finding)
 
 
 def attach_global_registry_shadow_finding(item: dict[str, Any], finding: dict[str, Any]) -> None:
-    shadows = item.setdefault("global_registry_shadow_findings", [])
-    if isinstance(shadows, list):
-        shadows.append(compact_global_registry_shadow_finding(finding))
-    project_asset = item.get("project_asset")
-    if not isinstance(project_asset, dict):
-        return
-    summary = project_asset.setdefault("global_registry_shadow_findings", {"open": 0, "kinds": []})
-    if not isinstance(summary, dict):
-        return
-    summary["open"] = int(summary.get("open") or 0) + 1
-    kinds = summary.setdefault("kinds", [])
-    kind = str(finding.get("kind") or "global_registry_finding")
-    if isinstance(kinds, list) and kind not in kinds:
-        kinds.append(kind)
+    _attach_global_registry_shadow_finding_read_model(item, finding)
 
 
 def parse_timestamp(value: Any) -> datetime | None:


### PR DESCRIPTION
## Summary
- move global registry shadow finding compaction/attachment into a projection helper module
- keep status.py compatibility wrappers for existing call sites
- extend the todo read-model boundary smoke with wrapper/direct parity for shadow finding projection

## Validation
- python3 -m compileall -q loopx/status.py loopx/projections/global_registry_shadow.py examples/control_plane/todo-readmodel-boundary-smoke.py
- python3 examples/control_plane/todo-readmodel-boundary-smoke.py
- python3 examples/control_plane/monitor-display-projection-smoke.py && python3 examples/control_plane/status-quota-review-packet-parity-smoke.py && python3 examples/control_plane/quota-work-lane-policy-smoke.py
- PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --profile core-control-plane (131/131)
- git diff --check
- public/private boundary scan on changed paths