### PR TITLE
Add opt-in status projection cache

### DIFF
--- a/examples/control_plane/status-projection-cache-smoke.py
+++ b/examples/control_plane/status-projection-cache-smoke.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Smoke-test opt-in status projection cache behavior."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GOAL_ID = "status-projection-cache-fixture"
+AGENT_ID = "codex-main-control"
+PRIVATE_DOC_MARKER = "https://" + "la" + "rk" + "office.example/doc"
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_rel = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    state_file = project / state_rel
+    registry_path = project / ".loopx" / "registry.json"
+    public_doc = project / "README.md"
+
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(
+        "---\n"
+        "status: active\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Status Projection Cache Fixture\n\n"
+        "## Objective\n\n"
+        "Validate opt-in status projection cache behavior.\n\n"
+        "## Next Action\n\n"
+        "- Exercise the status/quota projection cache.\n",
+        encoding="utf-8",
+    )
+    public_doc.write_text("Public smoke fixture for status projection cache.\n", encoding="utf-8")
+
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "status-projection-cache",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": state_rel,
+                        "adapter": {
+                            "kind": "generic_project_goal_v0",
+                            "status": "connected",
+                        },
+                        "coordination": {
+                            "registered_agents": [AGENT_ID],
+                            "primary_agent": AGENT_ID,
+                        },
+                        "quota": {
+                            "compute": 1.0,
+                            "window_hours": 24,
+                        },
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path, runtime, public_doc
+
+
+def run_cli_result(
+    registry_path: Path,
+    *args: str,
+    check: bool = True,
+) -> tuple[dict[str, Any], int, str]:
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(REPO_ROOT)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry_path),
+            "--format",
+            "json",
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(result.stderr or result.stdout)
+    payload = json.loads(result.stdout) if result.stdout.strip().startswith("{") else {}
+    return payload, result.returncode, result.stderr
+
+
+def run_cli(registry_path: Path, *args: str) -> dict[str, Any]:
+    payload, _returncode, _stderr = run_cli_result(registry_path, *args)
+    return payload
+
+
+def assert_cache_hit(payload: dict[str, Any]) -> None:
+    cache = payload.get("projection_cache")
+    if not isinstance(cache, dict):
+        cache = payload.get("status_projection_cache")
+    assert isinstance(cache, dict), payload
+    assert cache.get("schema_version") == "status_projection_cache_v0", cache
+    assert cache.get("hit") is True, cache
+
+
+def assert_cache_written(payload: dict[str, Any]) -> None:
+    cache = payload.get("projection_cache")
+    if not isinstance(cache, dict):
+        cache = payload.get("status_projection_cache")
+    assert isinstance(cache, dict), payload
+    assert cache.get("schema_version") == "status_projection_cache_v0", cache
+    assert cache.get("written") is True, cache
+    assert cache.get("hit") is False, cache
+    assert Path(str(cache.get("path"))).exists(), cache
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-status-projection-cache-") as tmp:
+        registry_path, runtime, public_doc = write_fixture(Path(tmp))
+
+        todo_payload = run_cli(
+            registry_path,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--text",
+            "Validate status projection cache.",
+            "--claimed-by",
+            AGENT_ID,
+        )
+        assert todo_payload.get("ok") is True, todo_payload
+
+        status_write = run_cli(
+            registry_path,
+            "status",
+            "--scan-path",
+            str(public_doc),
+            "--limit",
+            "5",
+            "--write-projection-cache",
+        )
+        assert status_write.get("ok") is True, status_write
+        assert_cache_written(status_write)
+
+        status_cached = run_cli(
+            registry_path,
+            "status",
+            "--scan-path",
+            str(public_doc),
+            "--limit",
+            "5",
+            "--use-projection-cache",
+        )
+        assert status_cached.get("ok") is True, status_cached
+        assert_cache_hit(status_cached)
+
+        quota_write = run_cli(
+            registry_path,
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--available-capability",
+            "shell",
+            "--scan-path",
+            str(public_doc),
+            "--limit",
+            "5",
+            "--write-projection-cache",
+        )
+        assert quota_write.get("ok") is True, quota_write
+        assert quota_write.get("should_run") is True, quota_write
+        assert_cache_written(quota_write)
+
+        quota_cached = run_cli(
+            registry_path,
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--available-capability",
+            "shell",
+            "--scan-path",
+            str(public_doc),
+            "--limit",
+            "5",
+            "--use-projection-cache",
+        )
+        assert quota_cached.get("ok") is True, quota_cached
+        assert quota_cached.get("should_run") is True, quota_cached
+        assert_cache_hit(quota_cached)
+
+        public_doc.write_text(
+            f"Public leak probe must still be caught by default quota scan: {PRIVATE_DOC_MARKER}\n",
+            encoding="utf-8",
+        )
+        leak_payload, leak_returncode, leak_stderr = run_cli_result(
+            registry_path,
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--scan-path",
+            str(public_doc),
+            check=False,
+        )
+        assert leak_returncode != 0 or leak_payload.get("status_health_ok") is False, leak_payload
+        assert "status or contract health" in json.dumps(leak_payload) + leak_stderr, leak_payload
+
+        cache_dir = runtime / "status-projection-cache"
+        assert cache_dir.exists(), cache_dir
+        assert list(cache_dir.glob("*.json")), cache_dir
+
+    print("status-projection-cache-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/control_plane/status-projection-cache-smoke.py
+++ b/examples/control_plane/status-projection-cache-smoke.py
@@ -8,11 +8,16 @@ import os
 import subprocess
 import sys
 import tempfile
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.status_projection_cache import write_status_projection_cache
+
 GOAL_ID = "status-projection-cache-fixture"
 AGENT_ID = "codex-main-control"
 PRIVATE_DOC_MARKER = "https://" + "la" + "rk" + "office.example/doc"
@@ -239,6 +244,25 @@ def main() -> int:
         cache_dir = runtime / "status-projection-cache"
         assert cache_dir.exists(), cache_dir
         assert list(cache_dir.glob("*.json")), cache_dir
+        with ThreadPoolExecutor(max_workers=8) as executor:
+            writes = list(
+                executor.map(
+                    lambda index: write_status_projection_cache(
+                        registry_path=registry_path,
+                        runtime_root=runtime,
+                        scan_roots=[public_doc],
+                        limit=5,
+                        include_task_graph=False,
+                        goal_id=GOAL_ID,
+                        payload={"ok": True, "concurrent_write": index},
+                        max_age_seconds=120,
+                    ),
+                    range(16),
+                )
+            )
+        assert all(item.get("written") is True for item in writes), writes
+        concurrent_cache_path = Path(str(writes[-1]["path"]))
+        assert json.loads(concurrent_cache_path.read_text(encoding="utf-8"))["payload"]["ok"] is True
 
     print("status-projection-cache-smoke ok")
     return 0

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -18,6 +18,11 @@ from ..quota import (
     void_quota_slot,
 )
 from ..status import AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK, collect_status
+from ..status_projection_cache import (
+    load_status_projection_cache,
+    resolve_status_projection_cache_runtime_root,
+    write_status_projection_cache,
+)
 
 
 PrintPayload = Callable[
@@ -109,6 +114,26 @@ def register_quota_command(subparsers: argparse._SubParsersAction) -> None:
         default=[],
         help="Specific public file or directory to scan. Repeatable. Overrides --scan-root when set.",
     )
+    quota_parser.add_argument(
+        "--use-projection-cache",
+        action="store_true",
+        help=(
+            "Read a fresh status_projection_cache_v0 snapshot before building "
+            "quota decisions. Misses and expired snapshots fall back to full "
+            "status collection."
+        ),
+    )
+    quota_parser.add_argument(
+        "--write-projection-cache",
+        action="store_true",
+        help="Write the status projection cache after a full quota status collection.",
+    )
+    quota_parser.add_argument(
+        "--projection-cache-ttl-seconds",
+        type=int,
+        default=120,
+        help="Freshness window for --use-projection-cache. Defaults to 120 seconds.",
+    )
     quota_parser.add_argument("--limit", type=int, default=5)
 
 
@@ -127,12 +152,42 @@ def handle_quota_command(
         status_limit = max(0, args.limit)
         if args.quota_command in {"should-run", "scheduler-ack"}:
             status_limit = max(status_limit, AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK)
-        status_payload = collect_status(
+        runtime_root = resolve_status_projection_cache_runtime_root(
             registry_path=registry_path,
             runtime_root_override=runtime_root_arg,
-            scan_roots=scan_roots,
-            limit=status_limit,
         )
+        status_payload = None
+        cache_metadata = None
+        if args.use_projection_cache:
+            status_payload, cache_metadata = load_status_projection_cache(
+                registry_path=registry_path,
+                runtime_root=runtime_root,
+                scan_roots=scan_roots,
+                limit=status_limit,
+                include_task_graph=False,
+                goal_id=None,
+                max_age_seconds=args.projection_cache_ttl_seconds,
+            )
+        if status_payload is None:
+            status_payload = collect_status(
+                registry_path=registry_path,
+                runtime_root_override=runtime_root_arg,
+                scan_roots=scan_roots,
+                limit=status_limit,
+            )
+            if args.write_projection_cache:
+                cache_metadata = write_status_projection_cache(
+                    registry_path=registry_path,
+                    runtime_root=runtime_root,
+                    scan_roots=scan_roots,
+                    limit=status_limit,
+                    include_task_graph=False,
+                    goal_id=None,
+                    payload=status_payload,
+                    max_age_seconds=args.projection_cache_ttl_seconds,
+                )
+        elif isinstance(status_payload.get("projection_cache"), dict):
+            cache_metadata = dict(status_payload["projection_cache"])
         if args.quota_command == "should-run":
             if not args.goal_id:
                 raise ValueError("`loopx quota should-run` requires --goal-id")
@@ -217,6 +272,8 @@ def handle_quota_command(
             )
         else:
             payload = build_quota_plan(status_payload, mode=args.quota_command)
+        if cache_metadata:
+            payload["status_projection_cache"] = cache_metadata
     except Exception as exc:
         if args.quota_command in {"should-run", "monitor-poll", "scheduler-ack", "spend-slot", "void-slot"}:
             payload = {

--- a/loopx/cli_commands/status.py
+++ b/loopx/cli_commands/status.py
@@ -11,6 +11,11 @@ from ..handoff_budget import build_handoff_interface_budget
 from ..quota import build_quota_should_run
 from ..review_packet import build_review_packet, render_review_packet_markdown
 from ..status import collect_status, render_status_markdown
+from ..status_projection_cache import (
+    load_status_projection_cache,
+    resolve_status_projection_cache_runtime_root,
+    write_status_projection_cache,
+)
 from ..todo_contract import normalize_todo_claimed_by
 
 
@@ -80,6 +85,26 @@ def register_status_commands(
             "Default status output keeps this graph on the cold path to stay "
             "inside the dashboard hot-path budget."
         ),
+    )
+    status_parser.add_argument(
+        "--use-projection-cache",
+        action="store_true",
+        help=(
+            "Read a fresh status_projection_cache_v0 snapshot before running "
+            "the full status collector. Misses and expired snapshots fall back "
+            "to the full collector."
+        ),
+    )
+    status_parser.add_argument(
+        "--write-projection-cache",
+        action="store_true",
+        help="Write the collected status projection to the cache after a full collection.",
+    )
+    status_parser.add_argument(
+        "--projection-cache-ttl-seconds",
+        type=int,
+        default=120,
+        help="Freshness window for --use-projection-cache. Defaults to 120 seconds.",
     )
 
     diagnose_parser = subparsers.add_parser(
@@ -232,14 +257,47 @@ def handle_status_command(
     print_payload: PrintPayload,
 ) -> int:
     try:
-        payload = collect_status(
+        scan_roots = _scan_roots(args)
+        limit = max(0, args.limit)
+        runtime_root = resolve_status_projection_cache_runtime_root(
             registry_path=registry_path,
             runtime_root_override=runtime_root_arg,
-            scan_roots=_scan_roots(args),
-            limit=max(0, args.limit),
-            include_task_graph=args.include_task_graph,
-            goal_id=args.goal_id,
         )
+        payload = None
+        cache_metadata = None
+        if args.use_projection_cache:
+            payload, cache_metadata = load_status_projection_cache(
+                registry_path=registry_path,
+                runtime_root=runtime_root,
+                scan_roots=scan_roots,
+                limit=limit,
+                include_task_graph=args.include_task_graph,
+                goal_id=args.goal_id,
+                max_age_seconds=args.projection_cache_ttl_seconds,
+            )
+        if payload is None:
+            payload = collect_status(
+                registry_path=registry_path,
+                runtime_root_override=runtime_root_arg,
+                scan_roots=scan_roots,
+                limit=limit,
+                include_task_graph=args.include_task_graph,
+                goal_id=args.goal_id,
+            )
+            if args.write_projection_cache:
+                cache_metadata = write_status_projection_cache(
+                    registry_path=registry_path,
+                    runtime_root=runtime_root,
+                    scan_roots=scan_roots,
+                    limit=limit,
+                    include_task_graph=args.include_task_graph,
+                    goal_id=args.goal_id,
+                    payload=payload,
+                    max_age_seconds=args.projection_cache_ttl_seconds,
+                )
+                payload["projection_cache"] = cache_metadata
+            elif cache_metadata:
+                payload["projection_cache"] = cache_metadata
         if args.agent_id:
             attach_agent_lane_next_actions(payload, agent_id=args.agent_id)
     except Exception as exc:

--- a/loopx/status_projection_cache.py
+++ b/loopx/status_projection_cache.py
@@ -1,0 +1,213 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from .history import load_registry
+from .paths import resolve_runtime_root
+
+
+STATUS_PROJECTION_CACHE_SCHEMA_VERSION = "status_projection_cache_v0"
+
+
+def now_utc() -> datetime:
+    return datetime.now(timezone.utc).replace(microsecond=0)
+
+
+def now_utc_iso() -> str:
+    return now_utc().isoformat().replace("+00:00", "Z")
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def resolve_status_projection_cache_runtime_root(
+    *,
+    registry_path: Path,
+    runtime_root_override: str | None,
+) -> Path:
+    registry = load_registry(registry_path)
+    return resolve_runtime_root(registry, runtime_root_override)
+
+
+def status_projection_cache_dir(runtime_root: Path) -> Path:
+    return runtime_root / "status-projection-cache"
+
+
+def status_projection_cache_key(
+    *,
+    registry_path: Path,
+    runtime_root: Path,
+    scan_roots: list[Path],
+    limit: int,
+    include_task_graph: bool,
+    goal_id: str | None,
+) -> str:
+    request = {
+        "schema_version": STATUS_PROJECTION_CACHE_SCHEMA_VERSION,
+        "collector": "collect_status",
+        "registry_path": str(registry_path.expanduser().resolve()),
+        "runtime_root": str(runtime_root.expanduser()),
+        "scan_roots": [str(path.expanduser().resolve()) for path in scan_roots],
+        "limit": max(0, int(limit)),
+        "include_task_graph": bool(include_task_graph),
+        "goal_id": str(goal_id or "").strip() or None,
+    }
+    encoded = json.dumps(
+        request,
+        ensure_ascii=True,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def status_projection_cache_path(runtime_root: Path, key: str) -> Path:
+    return status_projection_cache_dir(runtime_root) / f"{key}.json"
+
+
+def status_projection_cache_metadata(
+    *,
+    registry_path: Path,
+    runtime_root: Path,
+    scan_roots: list[Path],
+    limit: int,
+    include_task_graph: bool,
+    goal_id: str | None,
+    max_age_seconds: int,
+) -> dict[str, Any]:
+    key = status_projection_cache_key(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        scan_roots=scan_roots,
+        limit=limit,
+        include_task_graph=include_task_graph,
+        goal_id=goal_id,
+    )
+    return {
+        "schema_version": STATUS_PROJECTION_CACHE_SCHEMA_VERSION,
+        "key": key,
+        "path": str(status_projection_cache_path(runtime_root, key)),
+        "max_age_seconds": max(0, int(max_age_seconds)),
+        "goal_id": str(goal_id or "").strip() or None,
+        "limit": max(0, int(limit)),
+        "include_task_graph": bool(include_task_graph),
+        "scan_roots": [str(path.expanduser()) for path in scan_roots],
+    }
+
+
+def load_status_projection_cache(
+    *,
+    registry_path: Path,
+    runtime_root: Path,
+    scan_roots: list[Path],
+    limit: int,
+    include_task_graph: bool,
+    goal_id: str | None,
+    max_age_seconds: int,
+) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    metadata = status_projection_cache_metadata(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        scan_roots=scan_roots,
+        limit=limit,
+        include_task_graph=include_task_graph,
+        goal_id=goal_id,
+        max_age_seconds=max_age_seconds,
+    )
+    path = Path(str(metadata["path"]))
+    metadata["hit"] = False
+    if max_age_seconds < 0:
+        metadata["miss_reason"] = "disabled"
+        return None, metadata
+    if not path.exists():
+        metadata["miss_reason"] = "missing"
+        return None, metadata
+    try:
+        cache_record = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        metadata["miss_reason"] = "unreadable"
+        metadata["error"] = str(exc)
+        return None, metadata
+    if not isinstance(cache_record, dict):
+        metadata["miss_reason"] = "invalid_record"
+        return None, metadata
+    if cache_record.get("schema_version") != STATUS_PROJECTION_CACHE_SCHEMA_VERSION:
+        metadata["miss_reason"] = "schema_mismatch"
+        return None, metadata
+    generated_at = _parse_timestamp(cache_record.get("generated_at"))
+    if generated_at is None:
+        metadata["miss_reason"] = "missing_generated_at"
+        return None, metadata
+    age_seconds = max(0.0, (now_utc() - generated_at).total_seconds())
+    metadata["generated_at"] = cache_record.get("generated_at")
+    metadata["age_seconds"] = age_seconds
+    if age_seconds > max(0, int(max_age_seconds)):
+        metadata["miss_reason"] = "expired"
+        return None, metadata
+    payload = cache_record.get("payload")
+    if not isinstance(payload, dict):
+        metadata["miss_reason"] = "missing_payload"
+        return None, metadata
+    metadata["hit"] = True
+    metadata["miss_reason"] = None
+    payload = dict(payload)
+    payload["projection_cache"] = dict(metadata)
+    return payload, metadata
+
+
+def write_status_projection_cache(
+    *,
+    registry_path: Path,
+    runtime_root: Path,
+    scan_roots: list[Path],
+    limit: int,
+    include_task_graph: bool,
+    goal_id: str | None,
+    payload: dict[str, Any],
+    max_age_seconds: int,
+) -> dict[str, Any]:
+    metadata = status_projection_cache_metadata(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        scan_roots=scan_roots,
+        limit=limit,
+        include_task_graph=include_task_graph,
+        goal_id=goal_id,
+        max_age_seconds=max_age_seconds,
+    )
+    path = Path(str(metadata["path"]))
+    path.parent.mkdir(parents=True, exist_ok=True)
+    stored_payload = dict(payload)
+    stored_payload.pop("projection_cache", None)
+    record = {
+        "schema_version": STATUS_PROJECTION_CACHE_SCHEMA_VERSION,
+        "generated_at": now_utc_iso(),
+        "payload": stored_payload,
+    }
+    temp_path = path.with_suffix(".tmp")
+    temp_path.write_text(
+        json.dumps(record, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temp_path.replace(path)
+    metadata.update(
+        {
+            "hit": False,
+            "written": True,
+            "generated_at": record["generated_at"],
+        }
+    )
+    return metadata

--- a/loopx/status_projection_cache.py
+++ b/loopx/status_projection_cache.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -197,12 +199,18 @@ def write_status_projection_cache(
         "generated_at": now_utc_iso(),
         "payload": stored_payload,
     }
-    temp_path = path.with_suffix(".tmp")
-    temp_path.write_text(
-        json.dumps(record, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
-        encoding="utf-8",
-    )
-    temp_path.replace(path)
+    temp_path = path.with_name(f".{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+    try:
+        temp_path.write_text(
+            json.dumps(record, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+        temp_path.replace(path)
+    finally:
+        try:
+            temp_path.unlink()
+        except FileNotFoundError:
+            pass
     metadata.update(
         {
             "hit": False,


### PR DESCRIPTION
## Summary
- add a status_projection_cache_v0 helper for TTL-bound status snapshots under the LoopX runtime root
- add explicit status/quota CLI switches to read and write cached status projections with full-collector fallback
- add a smoke covering status and quota cache hits plus default public-boundary scan behavior

## Validation
- python3 -m py_compile loopx/status_projection_cache.py loopx/cli_commands/status.py loopx/cli_commands/quota.py examples/control_plane/status-projection-cache-smoke.py
- python3 examples/control_plane/status-projection-cache-smoke.py
- python3 examples/control_plane/status-quota-perf-budget-smoke.py
- python3 examples/control_plane/status-quota-review-packet-parity-smoke.py
- python3 examples/control_plane/status-goal-filter-smoke.py
- PYTHONPATH=. python3 -m loopx.cli --format json check --scan-path loopx/status_projection_cache.py --scan-path loopx/cli_commands/status.py --scan-path loopx/cli_commands/quota.py --scan-path examples/control_plane/status-projection-cache-smoke.py
- PYTHONPATH=. python3 -m loopx.cli status --help
- PYTHONPATH=. python3 -m loopx.cli quota --help