### PR TITLE
Extract run compaction read model

### DIFF
--- a/examples/control_plane/run-compaction-readmodel-smoke.py
+++ b/examples/control_plane/run-compaction-readmodel-smoke.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx import status as status_module  # noqa: E402
+from loopx.projections import run_compaction as run_compaction_read_model  # noqa: E402
+
+
+def assert_run_compaction_wrapper_parity() -> None:
+    reward = {
+        "recorded_at": "2026-07-04T00:00:00Z",
+        "decision": "approve",
+        "reward": 1,
+        "reason_summary": "validated bounded batch",
+        "follow_up": "continue read-model cleanup",
+        "lesson": {
+            "schema_version": "lesson_v0",
+            "kind": "process",
+            "summary": "keep parity smokes first",
+            "avoid": "large hot-path moves",
+            "prefer": "small projection helpers",
+            "private_note": "must not surface",
+        },
+        "ignored_field": "not compacted",
+    }
+    assert status_module.compact_human_reward(reward) == run_compaction_read_model.compact_human_reward(reward)
+
+    operator_gate = {
+        "recorded_at": "2026-07-04T00:01:00Z",
+        "gate": "review",
+        "decision": "approve",
+        "operator_question": "Proceed?",
+        "reason_summary": "owner approved",
+        "follow_up": "merge after validation",
+        "agent_command": "continue",
+        "ignored_field": "not compacted",
+    }
+    assert status_module.compact_operator_gate(
+        operator_gate
+    ) == run_compaction_read_model.compact_operator_gate(operator_gate)
+
+    resume_contract = {
+        "version": "v1",
+        "goal_id": "loopx-meta",
+        "run_id": "run-1",
+        "gate_id": "gate-1",
+        "created_state_ref": "state-a",
+        "created_policy_version": "policy-a",
+        "allowed_decisions": ["approve", "reject"],
+        "operator_decision": "approve",
+        "latest_state_ref": "state-b",
+        "freshness_check": "fresh",
+        "precondition_check": "ok",
+        "migration_or_rebase_result": "none",
+        "resulting_action": "continue",
+        "validation_after_resume": "required",
+        "interrupt_payload": {
+            "question": "Resume?",
+            "choices": ["yes", "no"],
+            "private_payload": "not compacted",
+        },
+        "ignored_field": "not compacted",
+    }
+    assert status_module.compact_operator_gate_resume_contract(
+        resume_contract
+    ) == run_compaction_read_model.compact_operator_gate_resume_contract(resume_contract)
+
+    readiness = {
+        "classification": "controller_ready",
+        "read_only_observer_ready": True,
+        "decision_advisor_ready": True,
+        "write_controller_ready": False,
+        "missing_gates": ["publish"],
+        "review_judgment": "ready",
+        "next_handoff_condition": "after smoke",
+        "gates": [
+            {"id": "smoke", "ok": True, "review": "passed", "private_note": "not compacted"},
+            "invalid",
+        ],
+        "ignored_field": "not compacted",
+    }
+    assert status_module.compact_controller_readiness(
+        readiness
+    ) == run_compaction_read_model.compact_controller_readiness(readiness)
+
+
+def main() -> None:
+    assert_run_compaction_wrapper_parity()
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/projections/run_compaction.py
+++ b/loopx/projections/run_compaction.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+HUMAN_REWARD_COMPACT_FIELDS = (
+    "recorded_at",
+    "decision",
+    "reward",
+    "reason_summary",
+    "follow_up",
+    "lesson",
+)
+OPERATOR_GATE_COMPACT_FIELDS = (
+    "recorded_at",
+    "gate",
+    "decision",
+    "operator_question",
+    "reason_summary",
+    "follow_up",
+    "agent_command",
+)
+OPERATOR_GATE_RESUME_CONTRACT_COMPACT_FIELDS = (
+    "version",
+    "goal_id",
+    "run_id",
+    "gate_id",
+    "created_state_ref",
+    "created_policy_version",
+    "allowed_decisions",
+    "operator_decision",
+    "latest_state_ref",
+    "freshness_check",
+    "precondition_check",
+    "migration_or_rebase_result",
+    "resulting_action",
+    "validation_after_resume",
+)
+CONTROLLER_READINESS_COMPACT_FIELDS = (
+    "classification",
+    "read_only_observer_ready",
+    "decision_advisor_ready",
+    "write_controller_ready",
+    "missing_gates",
+    "review_judgment",
+    "next_handoff_condition",
+)
+CONTROLLER_READINESS_GATE_FIELDS = (
+    "id",
+    "ok",
+    "review",
+)
+
+
+def compact_human_reward(reward: Any) -> dict[str, Any] | None:
+    if not isinstance(reward, dict):
+        return None
+    compact = {field: reward[field] for field in HUMAN_REWARD_COMPACT_FIELDS if field in reward}
+    lesson = compact.get("lesson")
+    if isinstance(lesson, dict):
+        compact["lesson"] = {
+            field: lesson[field]
+            for field in ("schema_version", "kind", "summary", "avoid", "prefer")
+            if field in lesson
+        }
+    return compact or None
+
+
+def compact_operator_gate(operator_gate: Any) -> dict[str, Any] | None:
+    if not isinstance(operator_gate, dict):
+        return None
+    compact = {field: operator_gate[field] for field in OPERATOR_GATE_COMPACT_FIELDS if field in operator_gate}
+    return compact or None
+
+
+def compact_operator_gate_resume_contract(contract: Any) -> dict[str, Any] | None:
+    if not isinstance(contract, dict):
+        return None
+    compact = {
+        field: contract[field]
+        for field in OPERATOR_GATE_RESUME_CONTRACT_COMPACT_FIELDS
+        if field in contract
+    }
+    interrupt = contract.get("interrupt_payload") if isinstance(contract.get("interrupt_payload"), dict) else {}
+    if interrupt:
+        compact["interrupt_payload"] = {
+            field: interrupt[field]
+            for field in ("question", "choices")
+            if field in interrupt
+        }
+    return compact or None
+
+
+def compact_controller_readiness(readiness: Any) -> dict[str, Any] | None:
+    if not isinstance(readiness, dict):
+        return None
+    compact = {
+        field: readiness[field]
+        for field in CONTROLLER_READINESS_COMPACT_FIELDS
+        if field in readiness
+    }
+    gates = []
+    for gate in readiness.get("gates") or []:
+        if not isinstance(gate, dict):
+            continue
+        gates.append({field: gate[field] for field in CONTROLLER_READINESS_GATE_FIELDS if field in gate})
+    if gates:
+        compact["gates"] = gates
+    return compact or None

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -125,6 +125,12 @@ from .projections.monitor_display import (
     todo_summary_lane_items as _todo_summary_lane_items,
     todo_summary_open_count as _todo_summary_open_count,
 )
+from .projections.run_compaction import (
+    compact_controller_readiness as _compact_controller_readiness_read_model,
+    compact_human_reward as _compact_human_reward_read_model,
+    compact_operator_gate as _compact_operator_gate_read_model,
+    compact_operator_gate_resume_contract as _compact_operator_gate_resume_contract_read_model,
+)
 from .projections.global_registry_shadow import (
     attach_global_registry_shadow_finding as _attach_global_registry_shadow_finding_read_model,
     compact_global_registry_shadow_finding as _compact_global_registry_shadow_finding_read_model,
@@ -461,53 +467,6 @@ RUN_COMPACT_FIELDS = (
     "markdown_exists",
 )
 USAGE_PROXY_NOTE = "run-history proxy; excludes token counts and raw thread logs"
-HUMAN_REWARD_COMPACT_FIELDS = (
-    "recorded_at",
-    "decision",
-    "reward",
-    "reason_summary",
-    "follow_up",
-    "lesson",
-)
-OPERATOR_GATE_COMPACT_FIELDS = (
-    "recorded_at",
-    "gate",
-    "decision",
-    "operator_question",
-    "reason_summary",
-    "follow_up",
-    "agent_command",
-)
-OPERATOR_GATE_RESUME_CONTRACT_COMPACT_FIELDS = (
-    "version",
-    "goal_id",
-    "run_id",
-    "gate_id",
-    "created_state_ref",
-    "created_policy_version",
-    "allowed_decisions",
-    "operator_decision",
-    "latest_state_ref",
-    "freshness_check",
-    "precondition_check",
-    "migration_or_rebase_result",
-    "resulting_action",
-    "validation_after_resume",
-)
-CONTROLLER_READINESS_COMPACT_FIELDS = (
-    "classification",
-    "read_only_observer_ready",
-    "decision_advisor_ready",
-    "write_controller_ready",
-    "missing_gates",
-    "review_judgment",
-    "next_handoff_condition",
-)
-CONTROLLER_READINESS_GATE_FIELDS = (
-    "id",
-    "ok",
-    "review",
-)
 LIFECYCLE_PRIORITY = (
     "controller_ready",
     "reward_judged",
@@ -7895,60 +7854,19 @@ def build_attention_queue(
 
 
 def compact_human_reward(reward: Any) -> dict[str, Any] | None:
-    if not isinstance(reward, dict):
-        return None
-    compact = {field: reward[field] for field in HUMAN_REWARD_COMPACT_FIELDS if field in reward}
-    lesson = compact.get("lesson")
-    if isinstance(lesson, dict):
-        compact["lesson"] = {
-            field: lesson[field]
-            for field in ("schema_version", "kind", "summary", "avoid", "prefer")
-            if field in lesson
-        }
-    return compact or None
+    return _compact_human_reward_read_model(reward)
 
 
 def compact_operator_gate(operator_gate: Any) -> dict[str, Any] | None:
-    if not isinstance(operator_gate, dict):
-        return None
-    compact = {field: operator_gate[field] for field in OPERATOR_GATE_COMPACT_FIELDS if field in operator_gate}
-    return compact or None
+    return _compact_operator_gate_read_model(operator_gate)
 
 
 def compact_operator_gate_resume_contract(contract: Any) -> dict[str, Any] | None:
-    if not isinstance(contract, dict):
-        return None
-    compact = {
-        field: contract[field]
-        for field in OPERATOR_GATE_RESUME_CONTRACT_COMPACT_FIELDS
-        if field in contract
-    }
-    interrupt = contract.get("interrupt_payload") if isinstance(contract.get("interrupt_payload"), dict) else {}
-    if interrupt:
-        compact["interrupt_payload"] = {
-            field: interrupt[field]
-            for field in ("question", "choices")
-            if field in interrupt
-        }
-    return compact or None
+    return _compact_operator_gate_resume_contract_read_model(contract)
 
 
 def compact_controller_readiness(readiness: Any) -> dict[str, Any] | None:
-    if not isinstance(readiness, dict):
-        return None
-    compact = {
-        field: readiness[field]
-        for field in CONTROLLER_READINESS_COMPACT_FIELDS
-        if field in readiness
-    }
-    gates = []
-    for gate in readiness.get("gates") or []:
-        if not isinstance(gate, dict):
-            continue
-        gates.append({field: gate[field] for field in CONTROLLER_READINESS_GATE_FIELDS if field in gate})
-    if gates:
-        compact["gates"] = gates
-    return compact or None
+    return _compact_controller_readiness_read_model(readiness)
 
 
 def compact_run(run: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- move human reward, operator gate, operator gate resume, and controller readiness compactors into a run compaction projection helper
- keep status.py compatibility wrappers for existing lifecycle/attention/status call sites
- add a focused run-compaction read-model parity smoke

## Validation
- python3 -m compileall -q loopx/status.py loopx/projections/run_compaction.py examples/control_plane/run-compaction-readmodel-smoke.py
- python3 examples/control_plane/run-compaction-readmodel-smoke.py
- python3 examples/control_plane/work-lane-contract-smoke.py && python3 examples/control_plane/status-quota-review-packet-parity-smoke.py && python3 examples/control_plane/status-markdown-smoke.py && python3 examples/control_plane/active-state-todo-attention-helper-smoke.py
- PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --profile core-control-plane (132/132)
- git diff --check
- public/private boundary scan on changed paths