### PR TITLE
Extract handoff run read models

### DIFF
--- a/examples/control_plane/handoff-run-readmodel-smoke.py
+++ b/examples/control_plane/handoff-run-readmodel-smoke.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx import status as status_module  # noqa: E402
+from loopx.projections import handoff_runs as handoff_run_read_model  # noqa: E402
+
+
+def _projection_is_handoff_ready(run: dict[str, object]) -> bool:
+    return handoff_run_read_model.is_handoff_ready_run(
+        run,
+        handoff_ready_classifications=status_module.HANDOFF_READY_CLASSIFICATIONS,
+        compact_operator_gate=status_module.compact_operator_gate,
+    )
+
+
+def _projection_has_external_evidence(run: dict[str, object]) -> bool:
+    return handoff_run_read_model.run_has_external_evidence_watch_signal(
+        run,
+        legacy_external_evidence_classification_prefixes=(
+            status_module.LEGACY_EXTERNAL_EVIDENCE_CLASSIFICATION_PREFIXES
+        ),
+    )
+
+
+def _projection_is_custom_post_handoff(run: dict[str, object]) -> bool:
+    return handoff_run_read_model.is_custom_post_handoff_work_run(
+        run,
+        is_status_neutral_run=status_module.is_status_neutral_run,
+        is_handoff_ready_run=status_module.is_handoff_ready_run,
+        run_has_external_evidence_watch_signal=status_module.run_has_external_evidence_watch_signal,
+        codex_ready_classifications=status_module.CODEX_READY_CLASSIFICATIONS,
+        user_or_controller_classifications=status_module.USER_OR_CONTROLLER_CLASSIFICATIONS,
+        blocking_classifications=status_module.BLOCKING_CLASSIFICATIONS,
+    )
+
+
+def assert_handoff_run_wrapper_parity() -> None:
+    cases = [
+        {"classification": next(iter(status_module.HANDOFF_READY_CLASSIFICATIONS))},
+        {
+            "classification": "operator_gate_approved",
+            "operator_gate": {"decision": "approve", "agent_command": "continue"},
+        },
+        {"classification": "feature_monitoring_not_external"},
+        {"classification": "research_progress_written"},
+        {"classification": next(iter(status_module.CODEX_READY_CLASSIFICATIONS))},
+        {"classification": next(iter(status_module.USER_OR_CONTROLLER_CLASSIFICATIONS))},
+        {"classification": next(iter(status_module.BLOCKING_CLASSIFICATIONS))},
+        {"classification": "custom_delivery", "waiting_on": "external_evidence"},
+        {
+            "classification": "custom_delivery",
+            "monitor_event": {"monitor_mode": "external_signal_watch"},
+        },
+        {
+            "classification": (
+                f"{status_module.LEGACY_EXTERNAL_EVIDENCE_CLASSIFICATION_PREFIXES[0]}fixture"
+            ),
+        },
+        {"classification": "quota_monitor_poll"},
+        {},
+    ]
+
+    for run in cases:
+        assert status_module.is_handoff_ready_run(run) == _projection_is_handoff_ready(run), run
+        assert status_module.run_has_external_evidence_watch_signal(run) == _projection_has_external_evidence(
+            run
+        ), run
+        assert status_module.is_custom_post_handoff_work_run(run) == _projection_is_custom_post_handoff(run), run
+
+
+def main() -> None:
+    assert_handoff_run_wrapper_parity()
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/projections/handoff_runs.py
+++ b/loopx/projections/handoff_runs.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+
+def is_handoff_ready_run(
+    run: dict[str, Any],
+    *,
+    handoff_ready_classifications: set[str],
+    compact_operator_gate: Callable[[Any], dict[str, Any] | None],
+) -> bool:
+    classification = str(run.get("classification") or "")
+    if classification in handoff_ready_classifications:
+        return True
+    operator_gate = compact_operator_gate(run.get("operator_gate"))
+    return bool(
+        operator_gate
+        and operator_gate.get("decision") == "approve"
+        and operator_gate.get("agent_command")
+    )
+
+
+def run_has_external_evidence_watch_signal(
+    run: dict[str, Any],
+    *,
+    legacy_external_evidence_classification_prefixes: tuple[str, ...],
+) -> bool:
+    """Return true only for explicit external-evidence watch state."""
+
+    waiting_on = str(run.get("waiting_on") or "").strip()
+    execution_waiting_on = str(run.get("execution_waiting_on") or "").strip()
+    if waiting_on == "external_evidence" or execution_waiting_on == "external_evidence":
+        return True
+    if isinstance(run.get("external_evidence_observation"), dict):
+        return True
+    monitor_event = run.get("monitor_event")
+    if isinstance(monitor_event, dict):
+        event_waiting_on = str(monitor_event.get("waiting_on") or "").strip()
+        monitor_mode = str(monitor_event.get("monitor_mode") or "").strip()
+        monitor_kind = str(monitor_event.get("monitor_kind") or "").strip()
+        if event_waiting_on == "external_evidence":
+            return True
+        if monitor_mode.startswith("external_") or monitor_kind == "external_evidence":
+            return True
+    classification = str(run.get("classification") or "")
+    return classification.startswith(legacy_external_evidence_classification_prefixes)
+
+
+def is_custom_post_handoff_work_run(
+    run: dict[str, Any],
+    *,
+    is_status_neutral_run: Callable[[dict[str, Any]], bool],
+    is_handoff_ready_run: Callable[[dict[str, Any]], bool],
+    run_has_external_evidence_watch_signal: Callable[[dict[str, Any]], bool],
+    codex_ready_classifications: set[str],
+    user_or_controller_classifications: set[str],
+    blocking_classifications: set[str],
+) -> bool:
+    classification = str(run.get("classification") or "")
+    if not classification:
+        return False
+    if is_status_neutral_run(run) or is_handoff_ready_run(run):
+        return False
+    if classification in codex_ready_classifications:
+        return False
+    if classification in user_or_controller_classifications or classification in blocking_classifications:
+        return False
+    if run_has_external_evidence_watch_signal(run):
+        return False
+    return True

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -131,6 +131,11 @@ from .projections.run_compaction import (
     compact_operator_gate as _compact_operator_gate_read_model,
     compact_operator_gate_resume_contract as _compact_operator_gate_resume_contract_read_model,
 )
+from .projections.handoff_runs import (
+    is_custom_post_handoff_work_run as _is_custom_post_handoff_work_run_read_model,
+    is_handoff_ready_run as _is_handoff_ready_run_read_model,
+    run_has_external_evidence_watch_signal as _run_has_external_evidence_watch_signal_read_model,
+)
 from .projections.global_registry_shadow import (
     attach_global_registry_shadow_finding as _attach_global_registry_shadow_finding_read_model,
     compact_global_registry_shadow_finding as _compact_global_registry_shadow_finding_read_model,
@@ -6365,14 +6370,10 @@ def active_state_projection_warning(goal: dict[str, Any], current_run: dict[str,
 
 
 def is_handoff_ready_run(run: dict[str, Any]) -> bool:
-    classification = str(run.get("classification") or "")
-    if classification in HANDOFF_READY_CLASSIFICATIONS:
-        return True
-    operator_gate = compact_operator_gate(run.get("operator_gate"))
-    return bool(
-        operator_gate
-        and operator_gate.get("decision") == "approve"
-        and operator_gate.get("agent_command")
+    return _is_handoff_ready_run_read_model(
+        run,
+        handoff_ready_classifications=HANDOFF_READY_CLASSIFICATIONS,
+        compact_operator_gate=compact_operator_gate,
     )
 
 
@@ -6384,38 +6385,22 @@ def run_has_external_evidence_watch_signal(run: dict[str, Any]) -> bool:
     legacy external-evidence classifications, not broad classification prefixes.
     """
 
-    waiting_on = str(run.get("waiting_on") or "").strip()
-    execution_waiting_on = str(run.get("execution_waiting_on") or "").strip()
-    if waiting_on == "external_evidence" or execution_waiting_on == "external_evidence":
-        return True
-    if isinstance(run.get("external_evidence_observation"), dict):
-        return True
-    monitor_event = run.get("monitor_event")
-    if isinstance(monitor_event, dict):
-        event_waiting_on = str(monitor_event.get("waiting_on") or "").strip()
-        monitor_mode = str(monitor_event.get("monitor_mode") or "").strip()
-        monitor_kind = str(monitor_event.get("monitor_kind") or "").strip()
-        if event_waiting_on == "external_evidence":
-            return True
-        if monitor_mode.startswith("external_") or monitor_kind == "external_evidence":
-            return True
-    classification = str(run.get("classification") or "")
-    return classification.startswith(LEGACY_EXTERNAL_EVIDENCE_CLASSIFICATION_PREFIXES)
+    return _run_has_external_evidence_watch_signal_read_model(
+        run,
+        legacy_external_evidence_classification_prefixes=LEGACY_EXTERNAL_EVIDENCE_CLASSIFICATION_PREFIXES,
+    )
 
 
 def is_custom_post_handoff_work_run(run: dict[str, Any]) -> bool:
-    classification = str(run.get("classification") or "")
-    if not classification:
-        return False
-    if is_status_neutral_run(run) or is_handoff_ready_run(run):
-        return False
-    if classification in CODEX_READY_CLASSIFICATIONS:
-        return False
-    if classification in USER_OR_CONTROLLER_CLASSIFICATIONS or classification in BLOCKING_CLASSIFICATIONS:
-        return False
-    if run_has_external_evidence_watch_signal(run):
-        return False
-    return True
+    return _is_custom_post_handoff_work_run_read_model(
+        run,
+        is_status_neutral_run=is_status_neutral_run,
+        is_handoff_ready_run=is_handoff_ready_run,
+        run_has_external_evidence_watch_signal=run_has_external_evidence_watch_signal,
+        codex_ready_classifications=CODEX_READY_CLASSIFICATIONS,
+        user_or_controller_classifications=USER_OR_CONTROLLER_CLASSIFICATIONS,
+        blocking_classifications=BLOCKING_CLASSIFICATIONS,
+    )
 
 
 def delivery_batch_scale_for_run(run: dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary

- Extract handoff-ready, external-evidence watch, and custom post-handoff run predicates into `loopx.projections.handoff_runs`.
- Keep `loopx.status` compatibility wrappers so existing callers and status routing semantics stay stable.
- Add a focused parity smoke for the new read-model seam.

## Validation

- `python3 -m compileall -q loopx/status.py loopx/projections/handoff_runs.py examples/control_plane/handoff-run-readmodel-smoke.py`
- `python3 examples/control_plane/handoff-run-readmodel-smoke.py`
- `python3 examples/control_plane/run-compaction-readmodel-smoke.py && python3 examples/control_plane/status-quota-review-packet-parity-smoke.py && python3 examples/control_plane/work-lane-contract-smoke.py`
- `python3 -m loopx.cli canary smoke-suite --profile core-control-plane` (133/133 passed)
- `git diff --check`
- public/private boundary scan over changed paths
