### PR TITLE
Extract delivery signal read models

### DIFF
--- a/examples/control_plane/delivery-signals-readmodel-smoke.py
+++ b/examples/control_plane/delivery-signals-readmodel-smoke.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx import status as status_module  # noqa: E402
+from loopx.projections import delivery_signals as delivery_signal_read_model  # noqa: E402
+
+
+PROFILE = {
+    "outcome_floor": {
+        "outcome_markers": ["merged", "validated"],
+        "surface_only_hints": ["doc_only", "contract"],
+    }
+}
+
+
+def _projection_scale(run: dict[str, object]) -> str:
+    return delivery_signal_read_model.delivery_batch_scale_for_run(
+        run,
+        test_only_hints=status_module.DELIVERY_BATCH_SCALE_TEST_ONLY_CLASSIFICATION_HINTS,
+        multi_surface_hints=status_module.DELIVERY_BATCH_SCALE_MULTI_SURFACE_CLASSIFICATION_HINTS,
+        implementation_hints=status_module.DELIVERY_BATCH_SCALE_IMPLEMENTATION_CLASSIFICATION_HINTS,
+    )
+
+
+def _projection_outcome(run: dict[str, object], profile: dict[str, object] | None = None) -> str:
+    return delivery_signal_read_model.delivery_outcome_for_run(
+        run,
+        profile,
+        execution_profile_outcome_floor=status_module.execution_profile_outcome_floor,
+    )
+
+
+def _projection_outcome_floor_configured(profile: dict[str, object] | None) -> bool:
+    return delivery_signal_read_model.outcome_floor_configured(
+        profile,
+        execution_profile_outcome_floor=status_module.execution_profile_outcome_floor,
+    )
+
+
+def _projection_outcome_gap_streak(runs: list[dict[str, object]], profile: dict[str, object] | None) -> int:
+    return delivery_signal_read_model.outcome_gap_streak(
+        runs,
+        profile,
+        delivery_outcome_for_run=_projection_outcome,
+        outcome_floor_configured=_projection_outcome_floor_configured,
+    )
+
+
+def _projection_small_scale_streak(runs: list[dict[str, object]]) -> int:
+    return delivery_signal_read_model.small_delivery_batch_scale_streak(
+        runs,
+        delivery_batch_scale_for_run=_projection_scale,
+        small_delivery_batch_scales=status_module.SMALL_DELIVERY_BATCH_SCALES,
+    )
+
+
+def assert_delivery_signal_wrapper_parity() -> None:
+    scale_cases = [
+        {"delivery_batch_scale": "multi_surface", "classification": "ignored_smoke"},
+        {"delivery_batch_scale": "future_scale", "classification": "ignored_smoke"},
+        {"classification": "owner_handoff_consumer_test"},
+        {"classification": "delivery_ranker_readiness_batch"},
+        {"classification": "feedback_reranker_adapter_slice"},
+        {"classification": "single_note"},
+        {},
+    ]
+    for run in scale_cases:
+        assert status_module.delivery_batch_scale_for_run(run) == _projection_scale(run), run
+
+    outcome_cases = [
+        ({"delivery_outcome": "outcome_progress", "classification": "ignored"}, PROFILE),
+        ({"delivery_outcome": "future_outcome", "classification": "ignored"}, PROFILE),
+        ({"classification": "adapter_validated"}, PROFILE),
+        ({"classification": "doc_only_contract"}, PROFILE),
+        ({"classification": "needs_real_outcome"}, PROFILE),
+        ({"classification": "adapter_validated"}, None),
+        ({}, PROFILE),
+    ]
+    for run, profile in outcome_cases:
+        assert status_module.delivery_outcome_for_run(run, profile) == _projection_outcome(run, profile), run
+
+    assert status_module.outcome_floor_configured(PROFILE) == _projection_outcome_floor_configured(PROFILE)
+    assert status_module.outcome_floor_configured(None) == _projection_outcome_floor_configured(None)
+
+    runs = [
+        {"classification": "needs_real_outcome"},
+        {"classification": "doc_only_contract"},
+        {"classification": "adapter_validated"},
+        {"classification": "needs_real_outcome"},
+    ]
+    assert status_module.outcome_gap_streak(runs, PROFILE) == _projection_outcome_gap_streak(runs, PROFILE)
+    assert status_module.outcome_gap_streak(runs, None) == _projection_outcome_gap_streak(runs, None)
+
+    small_runs = [
+        {"classification": "single_note"},
+        {"classification": "owner_handoff_consumer_test"},
+        {"classification": "delivery_ranker_readiness_batch"},
+    ]
+    assert status_module.small_delivery_batch_scale_streak(small_runs) == _projection_small_scale_streak(
+        small_runs
+    )
+
+
+def main() -> None:
+    assert_delivery_signal_wrapper_parity()
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/projections/delivery_signals.py
+++ b/loopx/projections/delivery_signals.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from ..delivery_batch_scale import UNKNOWN_DELIVERY_BATCH_SCALE, DeliveryBatchScale, normalize_delivery_batch_scale
+from ..delivery_outcome import (
+    DELIVERY_OUTCOME_NOT_CONFIGURED,
+    DELIVERY_OUTCOME_UNKNOWN,
+    PROGRESS_DELIVERY_OUTCOMES,
+    DeliveryOutcome,
+    normalize_delivery_outcome,
+)
+
+
+def delivery_batch_scale_for_run(
+    run: dict[str, Any],
+    *,
+    test_only_hints: tuple[str, ...],
+    multi_surface_hints: tuple[str, ...],
+    implementation_hints: tuple[str, ...],
+) -> str:
+    explicit = normalize_delivery_batch_scale(run.get("delivery_batch_scale"))
+    if explicit:
+        return explicit.value
+    if str(run.get("delivery_batch_scale") or "").strip():
+        return UNKNOWN_DELIVERY_BATCH_SCALE
+    classification = str(run.get("classification") or "")
+    if not classification:
+        return UNKNOWN_DELIVERY_BATCH_SCALE
+    normalized = classification.lower()
+    if any(hint in normalized for hint in test_only_hints):
+        return DeliveryBatchScale.TEST_ONLY.value
+    if any(hint in normalized for hint in multi_surface_hints):
+        return DeliveryBatchScale.MULTI_SURFACE.value
+    if any(hint in normalized for hint in implementation_hints):
+        return DeliveryBatchScale.IMPLEMENTATION.value
+    return DeliveryBatchScale.SINGLE_SURFACE.value
+
+
+def classification_contains_any(classification: str, hints: list[Any]) -> bool:
+    normalized = classification.lower()
+    return any(str(hint or "").strip().lower() in normalized for hint in hints if str(hint or "").strip())
+
+
+def delivery_outcome_for_run(
+    run: dict[str, Any],
+    profile: dict[str, Any] | None = None,
+    *,
+    execution_profile_outcome_floor: Callable[[dict[str, Any] | None], dict[str, Any]],
+) -> str:
+    explicit = normalize_delivery_outcome(run.get("delivery_outcome"))
+    if explicit:
+        return explicit.value
+    if str(run.get("delivery_outcome") or "").strip():
+        return DELIVERY_OUTCOME_UNKNOWN
+    classification = str(run.get("classification") or "")
+    if not classification:
+        return DELIVERY_OUTCOME_UNKNOWN
+    floor = execution_profile_outcome_floor(profile)
+    outcome_markers = floor.get("outcome_markers") if isinstance(floor.get("outcome_markers"), list) else []
+    surface_hints = floor.get("surface_only_hints") if isinstance(floor.get("surface_only_hints"), list) else []
+    if not outcome_markers and not surface_hints:
+        return DELIVERY_OUTCOME_NOT_CONFIGURED
+    marker_hit = classification_contains_any(classification, outcome_markers)
+    surface_hit = classification_contains_any(classification, surface_hints)
+    if surface_hit:
+        return DeliveryOutcome.SURFACE_ONLY.value
+    if marker_hit:
+        return DeliveryOutcome.OUTCOME_PROGRESS.value
+    return DeliveryOutcome.OUTCOME_GAP.value
+
+
+def outcome_floor_configured(
+    profile: dict[str, Any] | None,
+    *,
+    execution_profile_outcome_floor: Callable[[dict[str, Any] | None], dict[str, Any]],
+) -> bool:
+    floor = execution_profile_outcome_floor(profile)
+    return bool(floor.get("outcome_markers") or floor.get("surface_only_hints"))
+
+
+def outcome_gap_streak(
+    runs: list[dict[str, Any]],
+    profile: dict[str, Any] | None = None,
+    *,
+    delivery_outcome_for_run: Callable[[dict[str, Any], dict[str, Any] | None], str],
+    outcome_floor_configured: Callable[[dict[str, Any] | None], bool],
+) -> int:
+    if not outcome_floor_configured(profile):
+        return 0
+    streak = 0
+    for run in runs:
+        outcome = delivery_outcome_for_run(run, profile)
+        normalized = normalize_delivery_outcome(outcome)
+        if normalized in PROGRESS_DELIVERY_OUTCOMES or outcome == DELIVERY_OUTCOME_NOT_CONFIGURED:
+            break
+        streak += 1
+    return streak
+
+
+def small_delivery_batch_scale_streak(
+    runs: list[dict[str, Any]],
+    *,
+    delivery_batch_scale_for_run: Callable[[dict[str, Any]], str],
+    small_delivery_batch_scales: set[str],
+) -> int:
+    streak = 0
+    for run in runs:
+        if delivery_batch_scale_for_run(run) not in small_delivery_batch_scales:
+            break
+        streak += 1
+    return streak

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -15,13 +15,9 @@ from .contract import check_contract
 from .delivery_batch_scale import (
     SMALL_DELIVERY_BATCH_SCALES as STRUCTURED_SMALL_DELIVERY_BATCH_SCALES,
     UNKNOWN_DELIVERY_BATCH_SCALE,
-    DeliveryBatchScale,
-    normalize_delivery_batch_scale,
 )
 from .delivery_outcome import (
     DELIVERY_OUTCOME_NOT_CONFIGURED,
-    DELIVERY_OUTCOME_UNKNOWN,
-    DeliveryOutcome,
     PROGRESS_DELIVERY_OUTCOMES,
     delivery_turn_kind_for_run,
     normalize_delivery_outcome,
@@ -117,6 +113,14 @@ from .projections.dreaming import (
     compact_dreaming_proposal as _compact_dreaming_proposal_read_model,
     compact_server_planning_contract as _compact_server_planning_contract_read_model,
     dreaming_attention_fields as _dreaming_attention_fields_read_model,
+)
+from .projections.delivery_signals import (
+    classification_contains_any as _classification_contains_any_read_model,
+    delivery_batch_scale_for_run as _delivery_batch_scale_for_run_read_model,
+    delivery_outcome_for_run as _delivery_outcome_for_run_read_model,
+    outcome_floor_configured as _outcome_floor_configured_read_model,
+    outcome_gap_streak as _outcome_gap_streak_read_model,
+    small_delivery_batch_scale_streak as _small_delivery_batch_scale_streak_read_model,
 )
 from .projections.monitor_display import (
     attention_item_is_monitor_quiet_display_candidate as _attention_item_is_monitor_quiet_display_candidate,
@@ -6404,68 +6408,40 @@ def is_custom_post_handoff_work_run(run: dict[str, Any]) -> bool:
 
 
 def delivery_batch_scale_for_run(run: dict[str, Any]) -> str:
-    explicit = normalize_delivery_batch_scale(run.get("delivery_batch_scale"))
-    if explicit:
-        return explicit.value
-    if str(run.get("delivery_batch_scale") or "").strip():
-        return UNKNOWN_DELIVERY_BATCH_SCALE
-    classification = str(run.get("classification") or "")
-    if not classification:
-        return UNKNOWN_DELIVERY_BATCH_SCALE
-    normalized = classification.lower()
-    if any(hint in normalized for hint in DELIVERY_BATCH_SCALE_TEST_ONLY_CLASSIFICATION_HINTS):
-        return DeliveryBatchScale.TEST_ONLY.value
-    if any(hint in normalized for hint in DELIVERY_BATCH_SCALE_MULTI_SURFACE_CLASSIFICATION_HINTS):
-        return DeliveryBatchScale.MULTI_SURFACE.value
-    if any(hint in normalized for hint in DELIVERY_BATCH_SCALE_IMPLEMENTATION_CLASSIFICATION_HINTS):
-        return DeliveryBatchScale.IMPLEMENTATION.value
-    return DeliveryBatchScale.SINGLE_SURFACE.value
+    return _delivery_batch_scale_for_run_read_model(
+        run,
+        test_only_hints=DELIVERY_BATCH_SCALE_TEST_ONLY_CLASSIFICATION_HINTS,
+        multi_surface_hints=DELIVERY_BATCH_SCALE_MULTI_SURFACE_CLASSIFICATION_HINTS,
+        implementation_hints=DELIVERY_BATCH_SCALE_IMPLEMENTATION_CLASSIFICATION_HINTS,
+    )
 
 
 def _classification_contains_any(classification: str, hints: list[Any]) -> bool:
-    normalized = classification.lower()
-    return any(str(hint or "").strip().lower() in normalized for hint in hints if str(hint or "").strip())
+    return _classification_contains_any_read_model(classification, hints)
 
 
 def delivery_outcome_for_run(run: dict[str, Any], profile: dict[str, Any] | None = None) -> str:
-    explicit = normalize_delivery_outcome(run.get("delivery_outcome"))
-    if explicit:
-        return explicit.value
-    if str(run.get("delivery_outcome") or "").strip():
-        return DELIVERY_OUTCOME_UNKNOWN
-    classification = str(run.get("classification") or "")
-    if not classification:
-        return DELIVERY_OUTCOME_UNKNOWN
-    floor = execution_profile_outcome_floor(profile)
-    outcome_markers = floor.get("outcome_markers") if isinstance(floor.get("outcome_markers"), list) else []
-    surface_hints = floor.get("surface_only_hints") if isinstance(floor.get("surface_only_hints"), list) else []
-    if not outcome_markers and not surface_hints:
-        return DELIVERY_OUTCOME_NOT_CONFIGURED
-    marker_hit = _classification_contains_any(classification, outcome_markers)
-    surface_hit = _classification_contains_any(classification, surface_hints)
-    if surface_hit:
-        return DeliveryOutcome.SURFACE_ONLY.value
-    if marker_hit:
-        return DeliveryOutcome.OUTCOME_PROGRESS.value
-    return DeliveryOutcome.OUTCOME_GAP.value
+    return _delivery_outcome_for_run_read_model(
+        run,
+        profile,
+        execution_profile_outcome_floor=execution_profile_outcome_floor,
+    )
 
 
 def outcome_floor_configured(profile: dict[str, Any] | None) -> bool:
-    floor = execution_profile_outcome_floor(profile)
-    return bool(floor.get("outcome_markers") or floor.get("surface_only_hints"))
+    return _outcome_floor_configured_read_model(
+        profile,
+        execution_profile_outcome_floor=execution_profile_outcome_floor,
+    )
 
 
 def outcome_gap_streak(runs: list[dict[str, Any]], profile: dict[str, Any] | None = None) -> int:
-    if not outcome_floor_configured(profile):
-        return 0
-    streak = 0
-    for run in runs:
-        outcome = delivery_outcome_for_run(run, profile)
-        normalized = normalize_delivery_outcome(outcome)
-        if normalized in PROGRESS_DELIVERY_OUTCOMES or outcome == DELIVERY_OUTCOME_NOT_CONFIGURED:
-            break
-        streak += 1
-    return streak
+    return _outcome_gap_streak_read_model(
+        runs,
+        profile,
+        delivery_outcome_for_run=delivery_outcome_for_run,
+        outcome_floor_configured=outcome_floor_configured,
+    )
 
 
 def compact_post_handoff_run(run: dict[str, Any], profile: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -6515,12 +6491,11 @@ def compact_post_handoff_run(run: dict[str, Any], profile: dict[str, Any] | None
 
 
 def small_delivery_batch_scale_streak(runs: list[dict[str, Any]]) -> int:
-    streak = 0
-    for run in runs:
-        if delivery_batch_scale_for_run(run) not in SMALL_DELIVERY_BATCH_SCALES:
-            break
-        streak += 1
-    return streak
+    return _small_delivery_batch_scale_streak_read_model(
+        runs,
+        delivery_batch_scale_for_run=delivery_batch_scale_for_run,
+        small_delivery_batch_scales=SMALL_DELIVERY_BATCH_SCALES,
+    )
 
 
 def project_asset_handoff_state(


### PR DESCRIPTION
## Summary

- Extract delivery batch scale, outcome, outcome-floor, and streak read-model helpers into `loopx.projections.delivery_signals`.
- Keep `loopx.status` compatibility wrappers for existing status/quota callers.
- Add a parity smoke covering explicit values, unknown values, classification hints, outcome floors, and streak calculations.

## Validation

- `python3 -m compileall -q loopx/status.py loopx/projections/delivery_signals.py examples/control_plane/delivery-signals-readmodel-smoke.py`
- `python3 examples/control_plane/delivery-signals-readmodel-smoke.py`
- `python3 examples/control_plane/status-markdown-smoke.py && python3 examples/control_plane/status-quota-review-packet-parity-smoke.py && python3 examples/control_plane/work-lane-contract-smoke.py && python3 examples/project/project-asset-next-eye-smoke.py`
- `python3 -m loopx.cli canary smoke-suite --profile core-control-plane` (134/134 passed)
- `git diff --check`
- public/private boundary scan over changed paths
