### PR TITLE
Extract project handoff read model

### DIFF
--- a/examples/project/project-handoff-readmodel-smoke.py
+++ b/examples/project/project-handoff-readmodel-smoke.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx import status as status_module  # noqa: E402
+from loopx.projections import project_handoff as project_handoff_read_model  # noqa: E402
+
+
+PROFILE = {
+    "outcome_floor": {
+        "outcome_markers": ["validated"],
+        "surface_only_hints": ["doc_only"],
+    }
+}
+
+
+def _projection_state(
+    *,
+    ready: bool,
+    project_asset: dict[str, object],
+    latest_runs: list[dict[str, object]] | None,
+) -> dict[str, object]:
+    return project_handoff_read_model.project_asset_handoff_state(
+        ready=ready,
+        project_asset=project_asset,
+        latest_runs=latest_runs,
+        compact_execution_profile=status_module.compact_execution_profile,
+        parse_timestamp=status_module.parse_timestamp,
+        is_handoff_ready_run=status_module.is_handoff_ready_run,
+        is_custom_post_handoff_work_run=status_module.is_custom_post_handoff_work_run,
+        is_status_neutral_run=status_module.is_status_neutral_run,
+        compact_post_handoff_run=status_module.compact_post_handoff_run,
+        small_delivery_batch_scale_streak=status_module.small_delivery_batch_scale_streak,
+        outcome_floor_configured=status_module.outcome_floor_configured,
+        outcome_gap_streak=status_module.outcome_gap_streak,
+    )
+
+
+def assert_project_handoff_wrapper_parity() -> None:
+    latest_runs = [
+        {
+            "generated_at": "2026-07-04T00:03:00+00:00",
+            "classification": "doc_only_contract",
+        },
+        {
+            "generated_at": "2026-07-04T00:02:00+00:00",
+            "classification": "adapter_validated",
+        },
+        {
+            "generated_at": "2026-07-04T00:01:00+00:00",
+            "classification": "handoff_ready",
+        },
+        {
+            "generated_at": "not-a-date",
+            "classification": "ignored_bad_timestamp",
+        },
+    ]
+    project_asset = {"execution_profile": PROFILE}
+    assert status_module.project_asset_handoff_state(
+        ready=False,
+        project_asset=project_asset,
+        latest_runs=latest_runs,
+    ) == _projection_state(
+        ready=False,
+        project_asset=project_asset,
+        latest_runs=latest_runs,
+    )
+
+    ready_runs = [
+        {
+            "generated_at": "2026-07-04T00:05:00+00:00",
+            "classification": "custom_small_note",
+        },
+        {
+            "generated_at": "2026-07-04T00:04:00+00:00",
+            "classification": "feedback_reranker_adapter_slice",
+        },
+    ]
+    ready_asset = {"execution_profile": PROFILE}
+    assert status_module.project_asset_handoff_state(
+        ready=True,
+        project_asset=ready_asset,
+        latest_runs=ready_runs,
+    ) == _projection_state(
+        ready=True,
+        project_asset=ready_asset,
+        latest_runs=ready_runs,
+    )
+
+    validation_asset = {
+        "execution_profile": PROFILE,
+        "latest_validation": {
+            "generated_at": "2026-07-04T00:06:00+00:00",
+            "classification": "adapter_validated",
+        },
+    }
+    assert status_module.project_asset_handoff_state(
+        ready=True,
+        project_asset=validation_asset,
+        latest_runs=[],
+    ) == _projection_state(
+        ready=True,
+        project_asset=validation_asset,
+        latest_runs=[],
+    )
+
+
+def main() -> None:
+    assert_project_handoff_wrapper_parity()
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/projections/project_handoff.py
+++ b/loopx/projections/project_handoff.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Callable
+
+
+def project_asset_handoff_state(
+    *,
+    ready: bool,
+    project_asset: dict[str, Any],
+    latest_runs: list[dict[str, Any]] | None,
+    compact_execution_profile: Callable[[dict[str, Any] | None], dict[str, Any]],
+    parse_timestamp: Callable[[Any], datetime | None],
+    is_handoff_ready_run: Callable[[dict[str, Any]], bool],
+    is_custom_post_handoff_work_run: Callable[[dict[str, Any]], bool],
+    is_status_neutral_run: Callable[[dict[str, Any]], bool],
+    compact_post_handoff_run: Callable[[dict[str, Any], dict[str, Any] | None], dict[str, Any]],
+    small_delivery_batch_scale_streak: Callable[[list[dict[str, Any]]], int],
+    outcome_floor_configured: Callable[[dict[str, Any] | None], bool],
+    outcome_gap_streak: Callable[[list[dict[str, Any]], dict[str, Any] | None], int],
+) -> dict[str, Any]:
+    runs = [run for run in latest_runs or [] if isinstance(run, dict)]
+    profile = compact_execution_profile(
+        project_asset.get("execution_profile")
+        if isinstance(project_asset.get("execution_profile"), dict)
+        else None
+    )
+    parsed_runs = [
+        (run, parse_timestamp(run.get("generated_at")))
+        for run in runs
+    ]
+    parsed_runs = [(run, generated_at) for run, generated_at in parsed_runs if generated_at]
+    parsed_runs.sort(key=lambda item: item[1], reverse=True)
+
+    handoff_run: dict[str, Any] | None = None
+    handoff_at: datetime | None = None
+    for run, generated_at in parsed_runs:
+        if is_handoff_ready_run(run):
+            handoff_run = run
+            handoff_at = generated_at
+            break
+
+    post_handoff_run: dict[str, Any] | None = None
+    recent_post_handoff_runs: list[dict[str, Any]] = []
+    if handoff_at is None and ready:
+        recent_post_handoff_runs = [
+            run
+            for run, _generated_at in parsed_runs
+            if is_custom_post_handoff_work_run(run)
+        ]
+        if recent_post_handoff_runs:
+            post_handoff_run = recent_post_handoff_runs[0]
+        latest_validation = (
+            project_asset.get("latest_validation")
+            if isinstance(project_asset.get("latest_validation"), dict)
+            else {}
+        )
+        if latest_validation and post_handoff_run is None:
+            latest_validation_run = {
+                "generated_at": latest_validation.get("generated_at"),
+                "classification": latest_validation.get("classification"),
+            }
+            if is_custom_post_handoff_work_run(latest_validation_run):
+                post_handoff_run = latest_validation_run
+                recent_post_handoff_runs = [latest_validation_run]
+            else:
+                handoff_at = parse_timestamp(latest_validation.get("generated_at"))
+                handoff_run = latest_validation_run
+
+    if handoff_at is not None and post_handoff_run is None:
+        for run, generated_at in parsed_runs:
+            if generated_at <= handoff_at:
+                continue
+            if is_status_neutral_run(run) or is_handoff_ready_run(run):
+                continue
+            recent_post_handoff_runs.append(run)
+        if recent_post_handoff_runs:
+            post_handoff_run = recent_post_handoff_runs[0]
+
+    if post_handoff_run and not recent_post_handoff_runs:
+        recent_post_handoff_runs = [post_handoff_run]
+    if len(recent_post_handoff_runs) > 3:
+        recent_post_handoff_runs = recent_post_handoff_runs[:3]
+
+    if post_handoff_run:
+        handoff_status = "post_handoff_run_seen"
+    elif ready:
+        handoff_status = "ready_waiting_for_run"
+    else:
+        handoff_status = "not_ready"
+
+    state: dict[str, Any] = {
+        "handoff_status": handoff_status,
+        "post_handoff_run_seen": bool(post_handoff_run),
+    }
+    if handoff_run and handoff_run.get("generated_at"):
+        state["handoff_ready_at"] = handoff_run.get("generated_at")
+    if handoff_run and handoff_run.get("classification"):
+        state["handoff_ready_classification"] = handoff_run.get("classification")
+    if post_handoff_run:
+        state["post_handoff_latest_run"] = compact_post_handoff_run(post_handoff_run, profile)
+    if recent_post_handoff_runs:
+        state["post_handoff_recent_runs"] = [
+            compact_post_handoff_run(run, profile)
+            for run in recent_post_handoff_runs
+        ]
+        state["post_handoff_small_scale_streak"] = small_delivery_batch_scale_streak(
+            recent_post_handoff_runs
+        )
+        if outcome_floor_configured(profile):
+            state["post_handoff_outcome_gap_streak"] = outcome_gap_streak(
+                recent_post_handoff_runs,
+                profile,
+            )
+    return state

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -71,6 +71,9 @@ from .projections.project_asset import (
     project_asset_todo_projection_gap,
     project_asset_user_todo_open_count,
 )
+from .projections.project_handoff import (
+    project_asset_handoff_state as _project_asset_handoff_state_read_model,
+)
 from .projections.autonomous_candidates import (
     autonomous_backlog_candidates as _autonomous_backlog_candidates_read_model,
     autonomous_monitor_candidates as _autonomous_monitor_candidates_read_model,
@@ -6504,100 +6507,20 @@ def project_asset_handoff_state(
     project_asset: dict[str, Any],
     latest_runs: list[dict[str, Any]] | None,
 ) -> dict[str, Any]:
-    runs = [run for run in latest_runs or [] if isinstance(run, dict)]
-    profile = compact_execution_profile(
-        project_asset.get("execution_profile")
-        if isinstance(project_asset.get("execution_profile"), dict)
-        else None
+    return _project_asset_handoff_state_read_model(
+        ready=ready,
+        project_asset=project_asset,
+        latest_runs=latest_runs,
+        compact_execution_profile=compact_execution_profile,
+        parse_timestamp=parse_timestamp,
+        is_handoff_ready_run=is_handoff_ready_run,
+        is_custom_post_handoff_work_run=is_custom_post_handoff_work_run,
+        is_status_neutral_run=is_status_neutral_run,
+        compact_post_handoff_run=compact_post_handoff_run,
+        small_delivery_batch_scale_streak=small_delivery_batch_scale_streak,
+        outcome_floor_configured=outcome_floor_configured,
+        outcome_gap_streak=outcome_gap_streak,
     )
-    parsed_runs = [
-        (run, parse_timestamp(run.get("generated_at")))
-        for run in runs
-    ]
-    parsed_runs = [(run, generated_at) for run, generated_at in parsed_runs if generated_at]
-    parsed_runs.sort(key=lambda item: item[1], reverse=True)
-
-    handoff_run: dict[str, Any] | None = None
-    handoff_at: datetime | None = None
-    for run, generated_at in parsed_runs:
-        if is_handoff_ready_run(run):
-            handoff_run = run
-            handoff_at = generated_at
-            break
-
-    post_handoff_run: dict[str, Any] | None = None
-    recent_post_handoff_runs: list[dict[str, Any]] = []
-    if handoff_at is None and ready:
-        recent_post_handoff_runs = [
-            run
-            for run, _generated_at in parsed_runs
-            if is_custom_post_handoff_work_run(run)
-        ]
-        if recent_post_handoff_runs:
-            post_handoff_run = recent_post_handoff_runs[0]
-        latest_validation = (
-            project_asset.get("latest_validation")
-            if isinstance(project_asset.get("latest_validation"), dict)
-            else {}
-        )
-        if latest_validation and post_handoff_run is None:
-            latest_validation_run = {
-                "generated_at": latest_validation.get("generated_at"),
-                "classification": latest_validation.get("classification"),
-            }
-            if is_custom_post_handoff_work_run(latest_validation_run):
-                post_handoff_run = latest_validation_run
-                recent_post_handoff_runs = [latest_validation_run]
-            else:
-                handoff_at = parse_timestamp(latest_validation.get("generated_at"))
-                handoff_run = latest_validation_run
-
-    if handoff_at is not None and post_handoff_run is None:
-        for run, generated_at in parsed_runs:
-            if generated_at <= handoff_at:
-                continue
-            if is_status_neutral_run(run) or is_handoff_ready_run(run):
-                continue
-            recent_post_handoff_runs.append(run)
-        if recent_post_handoff_runs:
-            post_handoff_run = recent_post_handoff_runs[0]
-
-    if post_handoff_run and not recent_post_handoff_runs:
-        recent_post_handoff_runs = [post_handoff_run]
-    if len(recent_post_handoff_runs) > 3:
-        recent_post_handoff_runs = recent_post_handoff_runs[:3]
-
-    if post_handoff_run:
-        handoff_status = "post_handoff_run_seen"
-    elif ready:
-        handoff_status = "ready_waiting_for_run"
-    else:
-        handoff_status = "not_ready"
-
-    state: dict[str, Any] = {
-        "handoff_status": handoff_status,
-        "post_handoff_run_seen": bool(post_handoff_run),
-    }
-    if handoff_run and handoff_run.get("generated_at"):
-        state["handoff_ready_at"] = handoff_run.get("generated_at")
-    if handoff_run and handoff_run.get("classification"):
-        state["handoff_ready_classification"] = handoff_run.get("classification")
-    if post_handoff_run:
-        state["post_handoff_latest_run"] = compact_post_handoff_run(post_handoff_run, profile)
-    if recent_post_handoff_runs:
-        state["post_handoff_recent_runs"] = [
-            compact_post_handoff_run(run, profile)
-            for run in recent_post_handoff_runs
-        ]
-        state["post_handoff_small_scale_streak"] = small_delivery_batch_scale_streak(
-            recent_post_handoff_runs
-        )
-        if outcome_floor_configured(profile):
-            state["post_handoff_outcome_gap_streak"] = outcome_gap_streak(
-                recent_post_handoff_runs,
-                profile,
-            )
-    return state
 
 
 def project_asset_handoff_readiness(


### PR DESCRIPTION
## Summary
- Extract project asset handoff state selection into `loopx.projections.project_handoff`.
- Keep `loopx.status` compatibility wrapper and inject existing compactors/classifiers.
- Add parity smoke covering handoff-ready ordering, ready/post-handoff selection, invalid timestamp filtering, and latest-validation fallback.

## Validation
- `python3 -m compileall -q loopx/status.py loopx/projections/project_handoff.py examples/project/project-handoff-readmodel-smoke.py`
- `python3 examples/project/project-handoff-readmodel-smoke.py`
- `python3 examples/project/project-asset-next-eye-smoke.py && python3 examples/control_plane/status-markdown-smoke.py && python3 examples/control_plane/status-quota-review-packet-parity-smoke.py && python3 examples/control_plane/work-lane-contract-smoke.py`
- `python3 -m loopx.cli canary smoke-suite --profile core-control-plane` (135/135 passed)
- `git diff --check`
- public/private boundary scan over changed paths