### PR TITLE
Sync benchmark adapter rollout matrix

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-core-adapter-contract-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-core-adapter-contract-v0.md
@@ -97,10 +97,10 @@ details must stay in the adapter column, not in `benchmark_core`.
 
 | Benchmark family | Adapter module | Current generic lifecycle coverage | Next migration slice |
 | --- | --- | --- | --- |
-| Terminal-Bench | `loopx.benchmark_adapters.terminal_bench` | First migration target. Public configuration, private-runner launch/materialization helpers, access packets, bridge traces, Harbor reducers, timeout policy, and compact validation policy are adapter-owned. | Adopt `benchmark_attempt_accounting_v0` and `run_permission_policy_v0` in the public launch/result packets before adding new Terminal-Bench runner behavior. |
-| SkillsBench | `loopx.benchmark_adapters.skillsbench` plus ACP relay helpers | Route contracts, arm semantics, job names, public-safe setup failure attribution, case-local product lifecycle, and compact reducer surfaces are adapter-owned. | Map goal-start `/loopx` raw/new runs into the same launch/observe/ingest/classify/ledger fields after solver output and new-arm compact artifacts are available. |
+| Terminal-Bench | `loopx.benchmark_adapters.terminal_bench` | First migration target. Public configuration, private-runner launch/materialization helpers, access packets, bridge traces, Harbor reducers, timeout policy, compact validation policy, `run_permission_policy_v0`, and `benchmark_attempt_accounting_v0` adoption are adapter-owned. | Adopt the same permission-policy and attempt-accounting fields in any new public launch/result packets before adding new Terminal-Bench runner behavior. |
+| SkillsBench | `loopx.benchmark_adapters.skillsbench` plus ACP relay helpers | Route contracts, arm semantics, job names, public-safe setup failure attribution, case-local product lifecycle, compact reducer surfaces, no-upload permission policy, and split attempt-accounting surfaces are adapter-owned. | Goal-start `/loopx` raw/new mapping remains blocked on transport monitor `todo_45357c108d81`: the latest compact monitor saw no solver output and no new-arm compact artifact, so it must not be promoted into launch/observe/ingest/classify/ledger fields yet. |
 | ALE | `loopx.benchmark_adapters.agents_last_exam` | Public configuration, local runner/source readiness, launch packets, validation gates, CUA/Codex-route helpers, and task-material/result-report helpers are adapter-owned. | Add attempt accounting and permission-policy fields to local launch/readiness packets before any new ALE run path is promoted. |
-| SWE-Marathon | no dedicated adapter yet | Current evidence remains in public-safe research packets and run ledger rows, not in a reusable adapter module. | Create the adapter only after a second SWE-Marathon route needs shared launch/observe/ingest behavior; until then, do not add SWE-specific conventions to `benchmark_core`. |
+| SWE-Marathon | no dedicated adapter yet | Current evidence remains in public-safe research packets and run ledger rows, not in a reusable adapter module. | Deferred: create the adapter only after a second SWE-Marathon route needs shared launch/observe/ingest behavior; until then, do not add SWE-specific conventions to `benchmark_core`. |
 
 Next slices:
 
@@ -109,8 +109,10 @@ Next slices:
 2. Split shared compact/result helper functions that are still only imported
    through the Terminal-Bench adapter into narrower `benchmark_core` modules
    when a second benchmark needs them.
-3. Adopt `run_permission_policy_v0` in each benchmark adapter's public launch
-   packet before relying on adapter-specific prose for authorization.
-4. Adopt `benchmark_attempt_accounting_v0` in Terminal-Bench, SkillsBench, and
-   ALE reducers so compact ledgers can compare startup, solver, verifier, and
-   official-score failures without benchmark-specific label drift.
+3. Adopt `run_permission_policy_v0` in any remaining benchmark adapter public
+   launch packet before relying on adapter-specific prose for authorization.
+4. Adopt `benchmark_attempt_accounting_v0` in remaining adapter reducers so
+   compact ledgers can compare startup, solver, verifier, and official-score
+   failures without benchmark-specific label drift.
+5. Keep SkillsBench goal-start matrix rows blocked until compact transport
+   monitor evidence includes solver output and a new-arm compact artifact.

--- a/examples/benchmark-core-adapter-contract-smoke.py
+++ b/examples/benchmark-core-adapter-contract-smoke.py
@@ -264,9 +264,13 @@ def test_adapter_rollout_matrix_records_current_migration_order() -> None:
     ).read_text(encoding="utf-8")
     assert "## Adapter Rollout Matrix" in doc
     assert "| Terminal-Bench | `loopx.benchmark_adapters.terminal_bench` | First migration target." in doc
-    assert "Map goal-start `/loopx` raw/new runs into the same launch/observe/ingest/classify/ledger fields" in doc
+    assert "`run_permission_policy_v0`, and `benchmark_attempt_accounting_v0` adoption" in doc
+    assert "Goal-start `/loopx` raw/new mapping remains blocked on transport monitor `todo_45357c108d81`" in doc
+    assert "no solver output and no new-arm compact artifact" in doc
     assert "| SWE-Marathon | no dedicated adapter yet |" in doc
+    assert "Deferred: create the adapter only after a second SWE-Marathon route" in doc
     assert "do not add SWE-specific conventions to `benchmark_core`" in doc
+    assert "Keep SkillsBench goal-start matrix rows blocked until compact transport" in doc
 
 
 def main() -> int:


### PR DESCRIPTION
## Summary
- Update the benchmark-core adapter rollout matrix for landed permission-policy and attempt-accounting adoption.
- Mark SkillsBench goal-start raw/new mapping blocked on transport monitor todo_45357c108d81 until compact evidence includes solver output and a new-arm artifact.
- Keep SWE-Marathon adapter creation explicitly deferred until a second route needs shared lifecycle behavior.

## Validation
- python3 examples/benchmark-core-adapter-contract-smoke.py
- python3 examples/benchmark-run-permission-policy-smoke.py
- python3 examples/benchmark-attempt-accounting-smoke.py
- python3 examples/docs-governance-smoke.py
- loopx check --scan-path docs/research/long-horizon-agent-benchmarks/benchmark-core-adapter-contract-v0.md --scan-path examples/benchmark-core-adapter-contract-smoke.py (passes; existing duplicate-index warning remains)