### PR TITLE
Extract project handoff readiness read model

### DIFF
--- a/examples/project/project-handoff-readmodel-smoke.py
+++ b/examples/project/project-handoff-readmodel-smoke.py
@@ -43,6 +43,20 @@ def _projection_state(
     )
 
 
+def _projection_readiness(
+    item: dict[str, object],
+    *,
+    latest_runs: list[dict[str, object]] | None,
+) -> dict[str, object] | None:
+    return project_handoff_read_model.project_asset_handoff_readiness(
+        item,
+        latest_runs=latest_runs,
+        project_asset_handoff_check_projection=status_module.project_asset_handoff_check_projection,
+        handoff_budget_contract=status_module.handoff_budget_contract,
+        project_asset_handoff_state=status_module.project_asset_handoff_state,
+    )
+
+
 def assert_project_handoff_wrapper_parity() -> None:
     latest_runs = [
         {
@@ -112,8 +126,61 @@ def assert_project_handoff_wrapper_parity() -> None:
     )
 
 
+def assert_project_handoff_readiness_wrapper_parity() -> None:
+    latest_runs = [
+        {
+            "generated_at": "2026-07-04T00:08:00+00:00",
+            "classification": "controller_adapter_validated",
+        }
+    ]
+    item = {
+        "goal_id": "loopx-demo",
+        "waiting_on": "codex",
+        "recommended_action": "continue the current control-plane slice",
+        "project_asset": {
+            "next_action": "continue the current control-plane slice",
+            "stop_condition": "stop before private material",
+            "quota": {"state": "eligible"},
+            "execution_profile": PROFILE,
+        },
+    }
+    assert status_module.project_asset_handoff_readiness(
+        item,
+        latest_runs=latest_runs,
+    ) == _projection_readiness(
+        item,
+        latest_runs=latest_runs,
+    )
+
+    missing_asset = {"goal_id": "loopx-demo"}
+    assert status_module.project_asset_handoff_readiness(
+        missing_asset,
+        latest_runs=latest_runs,
+    ) == _projection_readiness(
+        missing_asset,
+        latest_runs=latest_runs,
+    )
+
+    incomplete_item = {
+        "goal_id": "loopx-demo",
+        "waiting_on": "codex",
+        "project_asset": {
+            "quota": {"state": "eligible"},
+            "execution_profile": PROFILE,
+        },
+    }
+    assert status_module.project_asset_handoff_readiness(
+        incomplete_item,
+        latest_runs=[],
+    ) == _projection_readiness(
+        incomplete_item,
+        latest_runs=[],
+    )
+
+
 def main() -> None:
     assert_project_handoff_wrapper_parity()
+    assert_project_handoff_readiness_wrapper_parity()
 
 
 if __name__ == "__main__":

--- a/loopx/projections/project_handoff.py
+++ b/loopx/projections/project_handoff.py
@@ -113,3 +113,43 @@ def project_asset_handoff_state(
                 profile,
             )
     return state
+
+
+def project_asset_handoff_readiness(
+    item: dict[str, Any],
+    *,
+    latest_runs: list[dict[str, Any]] | None,
+    project_asset_handoff_check_projection: Callable[[dict[str, Any]], dict[str, Any] | None],
+    handoff_budget_contract: Callable[[], dict[str, Any]],
+    project_asset_handoff_state: Callable[
+        ...,
+        dict[str, Any],
+    ],
+) -> dict[str, Any] | None:
+    project_asset = item.get("project_asset")
+    if not isinstance(project_asset, dict):
+        return None
+
+    check_projection = project_asset_handoff_check_projection(item)
+    if not check_projection:
+        return None
+    checks = check_projection["checks"]
+    goal_id = str(item.get("goal_id") or "").strip()
+    readiness: dict[str, Any] = {
+        "ready": all(checks.values()),
+        "codex_ready": bool(check_projection.get("codex_ready")),
+        "source": "project_asset",
+        "quota_state": check_projection.get("quota_state") or "unknown",
+        "handoff_interface_budget": handoff_budget_contract(),
+        "checks": checks,
+    }
+    readiness.update(
+        project_asset_handoff_state(
+            ready=bool(check_projection.get("state_trace_ready")),
+            project_asset=project_asset,
+            latest_runs=latest_runs,
+        )
+    )
+    if goal_id:
+        readiness["next_probe"] = f"loopx review-packet --goal-id {goal_id} --handoff-only"
+    return readiness

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -72,6 +72,7 @@ from .projections.project_asset import (
     project_asset_user_todo_open_count,
 )
 from .projections.project_handoff import (
+    project_asset_handoff_readiness as _project_asset_handoff_readiness_read_model,
     project_asset_handoff_state as _project_asset_handoff_state_read_model,
 )
 from .projections.autonomous_candidates import (
@@ -6528,33 +6529,13 @@ def project_asset_handoff_readiness(
     *,
     latest_runs: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any] | None:
-    project_asset = item.get("project_asset")
-    if not isinstance(project_asset, dict):
-        return None
-
-    check_projection = project_asset_handoff_check_projection(item)
-    if not check_projection:
-        return None
-    checks = check_projection["checks"]
-    goal_id = str(item.get("goal_id") or "").strip()
-    readiness: dict[str, Any] = {
-        "ready": all(checks.values()),
-        "codex_ready": bool(check_projection.get("codex_ready")),
-        "source": "project_asset",
-        "quota_state": check_projection.get("quota_state") or "unknown",
-        "handoff_interface_budget": handoff_budget_contract(),
-        "checks": checks,
-    }
-    readiness.update(
-        project_asset_handoff_state(
-            ready=bool(check_projection.get("state_trace_ready")),
-            project_asset=project_asset,
-            latest_runs=latest_runs,
-        )
+    return _project_asset_handoff_readiness_read_model(
+        item,
+        latest_runs=latest_runs,
+        project_asset_handoff_check_projection=project_asset_handoff_check_projection,
+        handoff_budget_contract=handoff_budget_contract,
+        project_asset_handoff_state=project_asset_handoff_state,
     )
-    if goal_id:
-        readiness["next_probe"] = f"loopx review-packet --goal-id {goal_id} --handoff-only"
-    return readiness
 
 
 def enrich_project_asset(


### PR DESCRIPTION
## Summary
- Extract project asset handoff readiness composition into `loopx.projections.project_handoff`.
- Keep `loopx.status` as a compatibility wrapper with existing status helpers injected.
- Extend project handoff parity smoke to cover readiness, missing asset, and incomplete check projection cases.

## Validation
- `python3 -m compileall -q loopx/status.py loopx/projections/project_handoff.py examples/project/project-handoff-readmodel-smoke.py`
- `python3 examples/project/project-handoff-readmodel-smoke.py`
- `python3 examples/project/project-asset-next-eye-smoke.py && python3 examples/control_plane/status-markdown-smoke.py && python3 examples/control_plane/status-quota-review-packet-parity-smoke.py && python3 examples/control_plane/work-lane-contract-smoke.py`
- `python3 -m loopx.cli canary smoke-suite --profile core-control-plane` (135/135 passed)
- `git diff --check`
- public/private boundary scan over changed paths