### PR TITLE
Roll out benchmark launch observable handles

### DIFF
--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -785,6 +785,25 @@ def test_launcher_plan_only_uses_native_worker_route() -> None:
         plan["run_permission_policy"],
         expected_route=ROUTE,
     )
+    observable = plan["observable_handle_registration"]
+    assert observable["schema_version"] == "benchmark_launch_observable_handle_v0", (
+        observable
+    )
+    assert observable["benchmark_id"] == "skillsbench-1.1", observable
+    assert observable["launch_mode"] == "skillsbench_runner_launch_plan", observable
+    handle = observable["observable_handle"]
+    assert handle["kind"] == "job_basename", observable
+    assert handle["state"] == "not_started", observable
+    assert "/" not in handle["job_basename"], observable
+    assert handle["raw_handle_payload_recorded"] is False, observable
+    assert handle["private_handle_values_recorded"] is False, observable
+    assert observable["allowed_poll_command"]["command_label"] == (
+        "skillsbench_runner_status_snapshot"
+    ), observable
+    assert observable["allowed_poll_command"]["argv_recorded"] is False, observable
+    assert observable["read_boundary"]["compact_only"] is True, observable
+    assert observable["boundary"]["raw_logs_recorded"] is False, observable
+    assert observable["boundary"]["local_paths_recorded"] is False, observable
 
 
 def test_launcher_plan_only_marks_bridge_ready_when_explicit() -> None:

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -6999,6 +6999,25 @@ def test_skillsbench_runner_plan_supports_baseline_route() -> None:
         assert plan["schema_version"] == "skillsbench_runner_launch_plan_v0", plan
         assert plan["route"] == "codex-goal-mode-baseline", plan
         assert plan["include_task_skills"] is False, plan
+        observable = plan["observable_handle_registration"]
+        assert observable["schema_version"] == "benchmark_launch_observable_handle_v0", (
+            observable
+        )
+        assert observable["benchmark_id"] == "skillsbench-1.1", observable
+        assert observable["launch_mode"] == "skillsbench_runner_launch_plan", observable
+        handle = observable["observable_handle"]
+        assert handle["kind"] == "job_basename", observable
+        assert handle["state"] == "not_started", observable
+        assert "/" not in handle["job_basename"], observable
+        assert handle["raw_handle_payload_recorded"] is False, observable
+        assert handle["private_handle_values_recorded"] is False, observable
+        assert observable["allowed_poll_command"]["command_label"] == (
+            "skillsbench_runner_status_snapshot"
+        ), observable
+        assert observable["allowed_poll_command"]["argv_recorded"] is False, observable
+        assert observable["read_boundary"]["compact_only"] is True, observable
+        assert observable["boundary"]["raw_task_text_recorded"] is False, observable
+        assert observable["boundary"]["local_paths_recorded"] is False, observable
         assert plan["outer_timeout_sec"] == 7200, plan
         assert plan["sandbox_setup_timeout_sec"] == 7200, plan
         runner_prerequisites = plan["runner_prerequisites"]

--- a/examples/terminal-bench-private-runner-env-guard-smoke.py
+++ b/examples/terminal-bench-private-runner-env-guard-smoke.py
@@ -2493,6 +2493,39 @@ time.sleep(3)
     assert "loopx_mode=hardened_codex_baseline" in baseline_launch["argv"], baseline_launch["argv"]
     assert "--mounts" not in baseline_launch["argv"], baseline_launch["argv"]
     baseline_summary = summarize_terminal_bench_private_runner_launch(baseline_launch)
+    baseline_observable = baseline_launch["observable_handle_registration"]
+    assert baseline_observable["schema_version"] == (
+        "benchmark_launch_observable_handle_v0"
+    ), baseline_observable
+    assert baseline_observable["benchmark_id"] == "terminal-bench-2.0", (
+        baseline_observable
+    )
+    assert baseline_observable["launch_mode"] == (
+        "terminal_bench_private_runner_hardened-codex"
+    ), baseline_observable
+    baseline_handle = baseline_observable["observable_handle"]
+    assert baseline_handle["kind"] == "job_basename", baseline_observable
+    assert baseline_handle["state"] == "not_started", baseline_observable
+    assert "/" not in baseline_handle["job_basename"], baseline_observable
+    assert baseline_handle["raw_handle_payload_recorded"] is False, baseline_observable
+    assert baseline_handle["private_handle_values_recorded"] is False, (
+        baseline_observable
+    )
+    assert baseline_observable["allowed_poll_command"]["command_label"] == (
+        "terminal_bench_run_status_snapshot"
+    ), baseline_observable
+    assert baseline_observable["allowed_poll_command"]["argv_recorded"] is False, (
+        baseline_observable
+    )
+    assert baseline_observable["read_boundary"]["compact_only"] is True, (
+        baseline_observable
+    )
+    assert baseline_observable["boundary"]["raw_logs_recorded"] is False, (
+        baseline_observable
+    )
+    assert baseline_summary["observable_handle_registration"] == baseline_observable, (
+        baseline_summary
+    )
     assert baseline_summary["ready"] == baseline_launch["ready"], baseline_summary
     assert baseline_summary["first_blocker"] == baseline_launch["first_blocker"], baseline_summary
     assert baseline_summary["no_upload_boundary"] is True, baseline_summary

--- a/loopx/benchmark_adapters/terminal_bench.py
+++ b/loopx/benchmark_adapters/terminal_bench.py
@@ -14,6 +14,7 @@ from typing import Any, Iterable, Mapping, Sequence
 from ..benchmark_core import (
     BenchmarkFailureClass,
     build_benchmark_attempt_accounting,
+    build_benchmark_launch_observable_handle,
     build_run_permission_policy,
     canonical_lifecycle,
     compact_run_permission_policy_for_quota,
@@ -6590,6 +6591,37 @@ def build_terminal_bench_private_runner_launch(**command_kwargs: Any) -> dict[st
             if codex_app_server_goal_mode
             else ""
         ),
+        "observable_handle_registration": build_benchmark_launch_observable_handle(
+            benchmark_id=TERMINAL_BENCH_DEFAULT_DATASET,
+            launch_mode=f"terminal_bench_private_runner_{mode or 'codex-loopx'}",
+            run_label=str(
+                resolved_command_kwargs.get("job_name")
+                or "terminal_bench_private_runner_launch"
+            ),
+            job_basename=str(
+                resolved_command_kwargs.get("job_name")
+                or "terminal_bench_private_runner_launch"
+            ),
+            process_state="not_started",
+            compact_artifact_refs=(
+                "benchmark-run.compact.json",
+                "job-result.compact.json",
+                "trial-result.compact.json",
+            ),
+            allowed_poll_command="terminal_bench_run_status_snapshot",
+            scheduler_kind="terminal_bench_private_runner",
+            will_execute=bool(argv)
+            and first_blocker == "ready_for_private_managed_no_upload_pilot_review",
+            read_boundary={
+                "compact_only": True,
+                "task_text_read": False,
+                "raw_logs_read": False,
+                "raw_artifacts_read": False,
+                "trajectory_read": False,
+                "local_paths_recorded": False,
+                "private_handle_values_recorded": False,
+            },
+        ),
         "first_blocker": first_blocker,
         "ready": first_blocker == "ready_for_private_managed_no_upload_pilot_review",
     }
@@ -7344,6 +7376,11 @@ def summarize_terminal_bench_private_runner_launch(
         codex_goal_mode_baseline_claim_blocker = "missing_codex_app_server_goal_proof"
     else:
         codex_goal_mode_baseline_claim_blocker = ""
+    observable_handle_registration = (
+        launch.get("observable_handle_registration")
+        if isinstance(launch.get("observable_handle_registration"), dict)
+        else {}
+    )
     summary = {
         "schema_version": "terminal_bench_private_runner_launch_summary_v0",
         "launch_schema_version": str(launch.get("schema_version") or ""),
@@ -7449,6 +7486,7 @@ def summarize_terminal_bench_private_runner_launch(
             setup_timeout_repair_profile=setup_timeout_repair_profile,
         ),
         "closeout_command_templates": _terminal_bench_run_ledger_closeout_templates(),
+        "observable_handle_registration": observable_handle_registration,
         "auth_values_recorded": False,
         "raw_env_recorded": False,
         "raw_paths_recorded": False,

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -123,6 +123,7 @@ from loopx.benchmark_adapters.skillsbench_remote_bridge import (  # noqa: E402
     run_skillsbench_remote_command_file_bridge_probe,
     skillsbench_remote_command_file_bridge_command_is_fixture_probe,
 )
+from loopx.benchmark_core import build_benchmark_launch_observable_handle  # noqa: E402
 from loopx.benchmark_core.loop_protocol import (  # noqa: E402
     BLIND_LOOP_DEFAULT_MAX_ROUNDS,
     CODEX_ACP_BLIND_LOOP_BASELINE_ROUTE,
@@ -8917,6 +8918,33 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         launch_plan["app_server_goal_worker_contract"] = (
             app_server_goal_worker_contract
         )
+    launch_plan["observable_handle_registration"] = (
+        build_benchmark_launch_observable_handle(
+            benchmark_id=args.dataset,
+            launch_mode="skillsbench_runner_launch_plan",
+            run_label=rollout_name or job_name,
+            job_basename=job_name,
+            process_state="not_started",
+            compact_artifact_refs=(
+                "result.json",
+                "compact-benchmark-run.json",
+                "controller-trace.json",
+                RUNNER_PREREQUISITES_PUBLIC_FILENAME,
+            ),
+            allowed_poll_command="skillsbench_runner_status_snapshot",
+            scheduler_kind="skillsbench_automation_loop",
+            will_execute=not bool(args.plan_only),
+            read_boundary={
+                "compact_only": True,
+                "task_text_read": False,
+                "raw_logs_read": False,
+                "raw_artifacts_read": False,
+                "trajectory_read": False,
+                "local_paths_recorded": False,
+                "private_handle_values_recorded": False,
+            },
+        )
+    )
     launch_plan["runner_config"] = _public_runner_config(launch_plan)
     return launch_plan
 


### PR DESCRIPTION
## Summary
- add benchmark_launch_observable_handle_v0 registration to SkillsBench runner launch plans
- add the same public-safe observable handle registration to Terminal-Bench private runner launch contracts and summaries
- extend focused smoke coverage for SkillsBench app-server/baseline plans and Terminal-Bench launch summaries

## Validation
- python3 examples/skillsbench-app-server-goal-worker-smoke.py
- python3 -m py_compile scripts/skillsbench_automation_loop.py loopx/benchmark_adapters/terminal_bench.py examples/skillsbench-app-server-goal-worker-smoke.py examples/skillsbench-benchmark-run-smoke.py examples/terminal-bench-private-runner-env-guard-smoke.py
- direct SkillsBench observable-handle plan smoke
- direct Terminal-Bench observable-handle launch smoke
- python3 examples/benchmark-core-adapter-contract-smoke.py
- loopx check --scan-path scripts/skillsbench_automation_loop.py --scan-path loopx/benchmark_adapters/terminal_bench.py --scan-path examples/skillsbench-app-server-goal-worker-smoke.py --scan-path examples/skillsbench-benchmark-run-smoke.py --scan-path examples/terminal-bench-private-runner-env-guard-smoke.py

## Notes
- Full terminal-bench-private-runner-env-guard smoke is currently environment-sensitive here because Docker server is unavailable and reports missing_docker_server_surface before later launch assertions.
- Full skillsbench-benchmark-run smoke reaches an existing reducer/round-reward assertion mismatch after the new launch-plan assertion path passes.
- No raw commands, private handles, local paths, credentials, task text, logs, trajectories, uploads, or submissions are added to the observable handle registration.