### PR TITLE
Extract project asset enrichment read model

### DIFF
--- a/examples/project/project-asset-next-eye-smoke.py
+++ b/examples/project/project-asset-next-eye-smoke.py
@@ -9,6 +9,7 @@ the shared project_asset contract.
 
 from __future__ import annotations
 
+import copy
 from pathlib import Path
 import sys
 
@@ -20,9 +21,17 @@ from loopx.status import (  # noqa: E402
     MONITOR_DISPLAY_STOP_CONDITION,
     MONITOR_SIGNAL_WAITING_ON,
     build_project_asset,
+    build_long_task_cadence_hint,
+    compact_execution_profile,
+    compact_orchestration_policy,
     enrich_project_asset,
+    project_asset_handoff_readiness,
+    project_asset_quota_summary,
     project_asset_summary_is_public_safe,
+    project_asset_todo_projection_gap,
+    project_asset_todo_summary,
 )
+from loopx.projections import project_asset as project_asset_read_model  # noqa: E402
 from loopx.projections.project_asset import (  # noqa: E402
     project_asset_quota_state,
     project_asset_user_todo_open_count,
@@ -35,6 +44,40 @@ NEXT_ACTION = "Use the current project asset to choose one bounded delivery step
 STOP_CONDITION = "stop until the user or controller decision is recorded"
 VALIDATION_SUMMARY = "fixture validation passed; authority_sources 1"
 SAFE_AGENT_COMMAND = "loopx read-only-map --goal-id next-eye-fixture --dry-run"
+
+
+def _enrich_with_projection(
+    item: dict,
+    *,
+    user_todos: dict | None,
+    agent_todos: dict | None,
+    quota: dict | None,
+    latest_validation: dict | None,
+    latest_runs: list[dict] | None,
+    execution_profile: dict | None,
+    orchestration: dict | None,
+) -> None:
+    project_asset_read_model.enrich_project_asset(
+        item,
+        user_todos=user_todos,
+        agent_todos=agent_todos,
+        quota=quota,
+        latest_validation=latest_validation,
+        latest_runs=latest_runs,
+        execution_profile=execution_profile,
+        orchestration=orchestration,
+        subagent_activity=None,
+        interface_budget_cadence=None,
+        project_asset_todo_summary=project_asset_todo_summary,
+        project_asset_todo_projection_gap=project_asset_todo_projection_gap,
+        project_asset_quota_summary=project_asset_quota_summary,
+        compact_execution_profile=compact_execution_profile,
+        compact_orchestration_policy=compact_orchestration_policy,
+        project_asset_handoff_readiness=project_asset_handoff_readiness,
+        project_asset_quota_state=project_asset_quota_state,
+        project_asset_user_todo_open_count=project_asset_user_todo_open_count,
+        build_long_task_cadence_hint=build_long_task_cadence_hint,
+    )
 
 
 def assert_status_project_asset_next_eye() -> None:
@@ -76,6 +119,7 @@ def assert_status_project_asset_next_eye() -> None:
         "summary": VALIDATION_SUMMARY,
     }
 
+    projection_item = copy.deepcopy(item)
     enrich_project_asset(
         item,
         user_todos=user_todos,
@@ -85,6 +129,17 @@ def assert_status_project_asset_next_eye() -> None:
         execution_profile={"minimum_scale": "implementation"},
         orchestration={"mode": "default", "allowed": False, "max_children": 3},
     )
+    _enrich_with_projection(
+        projection_item,
+        user_todos=user_todos,
+        agent_todos=agent_todos,
+        quota=quota,
+        latest_validation=latest_validation,
+        latest_runs=None,
+        execution_profile={"minimum_scale": "implementation"},
+        orchestration={"mode": "default", "allowed": False, "max_children": 3},
+    )
+    assert item == projection_item, projection_item
 
     asset = item["project_asset"]
     for field in ("owner", "gate", "support_mode", "next_action", "stop_condition"):

--- a/loopx/projections/project_asset.py
+++ b/loopx/projections/project_asset.py
@@ -223,6 +223,83 @@ def project_asset_latest_validation(run: dict[str, Any] | None) -> dict[str, Any
     return signal or None
 
 
+def enrich_project_asset(
+    item: dict[str, Any],
+    *,
+    user_todos: dict[str, Any] | None,
+    agent_todos: dict[str, Any] | None,
+    quota: dict[str, Any] | None,
+    latest_validation: dict[str, Any] | None,
+    latest_runs: list[dict[str, Any]] | None,
+    execution_profile: dict[str, Any] | None,
+    orchestration: dict[str, Any] | None,
+    subagent_activity: dict[str, Any] | None,
+    interface_budget_cadence: dict[str, Any] | None,
+    project_asset_todo_summary: Callable[..., dict[str, Any] | None],
+    project_asset_todo_projection_gap: Callable[..., dict[str, Any] | None],
+    project_asset_quota_summary: Callable[[dict[str, Any] | None], dict[str, Any] | None],
+    compact_execution_profile: Callable[[dict[str, Any] | None], dict[str, Any]],
+    compact_orchestration_policy: Callable[[dict[str, Any]], dict[str, Any]],
+    project_asset_handoff_readiness: Callable[..., dict[str, Any] | None],
+    project_asset_quota_state: Callable[..., str | None],
+    project_asset_user_todo_open_count: Callable[..., int | None],
+    build_long_task_cadence_hint: Callable[..., dict[str, Any]],
+) -> None:
+    project_asset = item.get("project_asset")
+    if not isinstance(project_asset, dict):
+        return
+    user_summary = project_asset_todo_summary(user_todos, role="user")
+    if user_summary:
+        project_asset["user_todos"] = user_summary
+    agent_summary = project_asset_todo_summary(agent_todos, role="agent")
+    if agent_summary:
+        project_asset["agent_todos"] = agent_summary
+    todo_projection_gap = project_asset_todo_projection_gap(
+        user_todos=user_todos,
+        agent_todos=agent_todos,
+    )
+    if todo_projection_gap:
+        project_asset["todo_projection_gap"] = todo_projection_gap
+        item["todo_projection_gap"] = todo_projection_gap
+    else:
+        project_asset.pop("todo_projection_gap", None)
+        item.pop("todo_projection_gap", None)
+    quota_summary = project_asset_quota_summary(quota)
+    if quota_summary:
+        project_asset["quota"] = quota_summary
+    if execution_profile is not None:
+        project_asset["execution_profile"] = compact_execution_profile(execution_profile)
+    if orchestration is not None:
+        project_asset["orchestration"] = compact_orchestration_policy(orchestration)
+    if subagent_activity:
+        project_asset["subagent_activity"] = subagent_activity
+    if interface_budget_cadence:
+        project_asset["interface_budget_cadence"] = interface_budget_cadence
+    if latest_validation:
+        project_asset["latest_validation"] = latest_validation
+    readiness = project_asset_handoff_readiness(item, latest_runs=latest_runs)
+    if readiness:
+        item["handoff_readiness"] = readiness
+    quota_state = project_asset_quota_state(quota=quota, project_asset=project_asset)
+    user_todo_open_count = project_asset_user_todo_open_count(
+        user_todos=user_todos,
+        project_asset=project_asset,
+    )
+    cadence_hint = build_long_task_cadence_hint(
+        execution_profile=(
+            project_asset.get("execution_profile")
+            if isinstance(project_asset.get("execution_profile"), dict)
+            else None
+        ),
+        latest_runs=latest_runs,
+        handoff_readiness=readiness,
+        quota_state=quota_state,
+        user_todo_open_count=user_todo_open_count,
+    )
+    project_asset["long_task_cadence_hint"] = cadence_hint
+    item["long_task_cadence_hint"] = cadence_hint
+
+
 def project_asset_summary_is_public_safe(project_asset: dict[str, Any]) -> bool:
     text = repr(project_asset)
     return not LOCAL_PATH_SURFACE_PATTERN.search(text) and not SECRET_LIKE_SURFACE_PATTERN.search(text)

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -63,6 +63,7 @@ from .projections.project_asset import (
     TODO_PROJECTION_VIEW_SCHEMA_VERSION,
     build_project_asset,
     completed_todo_archive_warning,
+    enrich_project_asset as _enrich_project_asset_read_model,
     project_asset_handoff_check_projection,
     project_asset_latest_validation,
     project_asset_quota_state,
@@ -6551,59 +6552,27 @@ def enrich_project_asset(
     subagent_activity: dict[str, Any] | None = None,
     interface_budget_cadence: dict[str, Any] | None = None,
 ) -> None:
-    project_asset = item.get("project_asset")
-    if not isinstance(project_asset, dict):
-        return
-    user_summary = project_asset_todo_summary(user_todos, role="user")
-    if user_summary:
-        project_asset["user_todos"] = user_summary
-    agent_summary = project_asset_todo_summary(agent_todos, role="agent")
-    if agent_summary:
-        project_asset["agent_todos"] = agent_summary
-    todo_projection_gap = project_asset_todo_projection_gap(
+    _enrich_project_asset_read_model(
+        item,
         user_todos=user_todos,
         agent_todos=agent_todos,
-    )
-    if todo_projection_gap:
-        project_asset["todo_projection_gap"] = todo_projection_gap
-        item["todo_projection_gap"] = todo_projection_gap
-    else:
-        project_asset.pop("todo_projection_gap", None)
-        item.pop("todo_projection_gap", None)
-    quota_summary = project_asset_quota_summary(quota)
-    if quota_summary:
-        project_asset["quota"] = quota_summary
-    if execution_profile is not None:
-        project_asset["execution_profile"] = compact_execution_profile(execution_profile)
-    if orchestration is not None:
-        project_asset["orchestration"] = compact_orchestration_policy(orchestration)
-    if subagent_activity:
-        project_asset["subagent_activity"] = subagent_activity
-    if interface_budget_cadence:
-        project_asset["interface_budget_cadence"] = interface_budget_cadence
-    if latest_validation:
-        project_asset["latest_validation"] = latest_validation
-    readiness = project_asset_handoff_readiness(item, latest_runs=latest_runs)
-    if readiness:
-        item["handoff_readiness"] = readiness
-    quota_state = project_asset_quota_state(quota=quota, project_asset=project_asset)
-    user_todo_open_count = project_asset_user_todo_open_count(
-        user_todos=user_todos,
-        project_asset=project_asset,
-    )
-    cadence_hint = build_long_task_cadence_hint(
-        execution_profile=(
-            project_asset.get("execution_profile")
-            if isinstance(project_asset.get("execution_profile"), dict)
-            else None
-        ),
+        quota=quota,
+        latest_validation=latest_validation,
         latest_runs=latest_runs,
-        handoff_readiness=readiness,
-        quota_state=quota_state,
-        user_todo_open_count=user_todo_open_count,
+        execution_profile=execution_profile,
+        orchestration=orchestration,
+        subagent_activity=subagent_activity,
+        interface_budget_cadence=interface_budget_cadence,
+        project_asset_todo_summary=project_asset_todo_summary,
+        project_asset_todo_projection_gap=project_asset_todo_projection_gap,
+        project_asset_quota_summary=project_asset_quota_summary,
+        compact_execution_profile=compact_execution_profile,
+        compact_orchestration_policy=compact_orchestration_policy,
+        project_asset_handoff_readiness=project_asset_handoff_readiness,
+        project_asset_quota_state=project_asset_quota_state,
+        project_asset_user_todo_open_count=project_asset_user_todo_open_count,
+        build_long_task_cadence_hint=build_long_task_cadence_hint,
     )
-    project_asset["long_task_cadence_hint"] = cadence_hint
-    item["long_task_cadence_hint"] = cadence_hint
 
 
 def active_state_todo_fields(


### PR DESCRIPTION
## Summary
- Extract project asset enrichment composition into `loopx.projections.project_asset`.
- Keep `loopx.status.enrich_project_asset` as a compatibility wrapper with existing dependencies injected.
- Extend `project-asset-next-eye` smoke with direct read-model parity for the mutating enrichment output.

## Validation
- `python3 -m compileall -q loopx/status.py loopx/projections/project_asset.py examples/project/project-asset-next-eye-smoke.py`
- `python3 examples/project/project-asset-next-eye-smoke.py`
- `python3 examples/project/project-asset-next-eye-smoke.py && python3 examples/project/project-handoff-readmodel-smoke.py && python3 examples/control_plane/status-markdown-smoke.py && python3 examples/control_plane/status-quota-review-packet-parity-smoke.py && python3 examples/control_plane/work-lane-contract-smoke.py`
- `python3 -m loopx.cli canary smoke-suite --profile core-control-plane` (135/135 passed)
- `git diff --check`
- public/private boundary scan over changed paths