### PR TITLE
Fix TerminalBench public smoke fixtures

### DIFF
--- a/examples/terminal-bench-no-submit-approval-packet-projection-decision-smoke.py
+++ b/examples/terminal-bench-no-submit-approval-packet-projection-decision-smoke.py
@@ -13,7 +13,7 @@ DECISION_DOC = TOPIC_DIR / "terminal-bench-no-submit-approval-packet-projection-
 PACKET_DOC = TOPIC_DIR / "terminal-bench-no-submit-approval-packet-v0.md"
 STATUS = REPO_ROOT / "loopx" / "status.py"
 REVIEW_PACKET = REPO_ROOT / "loopx" / "review_packet.py"
-HOT_PATH_SMOKE = REPO_ROOT / "examples" / "hot-path-interface-budget-smoke.py"
+HOT_PATH_SMOKE = REPO_ROOT / "examples" / "control_plane" / "hot-path-interface-budget-smoke.py"
 
 PACKET_SCHEMA = "terminal_bench_no_submit_approval_packet_v0"
 DECISION_DOC_NAME = "terminal-bench-no-submit-approval-packet-projection-decision-v0.md"

--- a/examples/terminal-bench-private-runner-env-guard-smoke.py
+++ b/examples/terminal-bench-private-runner-env-guard-smoke.py
@@ -111,8 +111,12 @@ def main() -> None:
             loopx_goal_id="loopx-meta",
             loopx_cli_bridge_enabled=True,
         )
-        assert bad_launch["first_blocker"] == "task_material_missing_instruction_md", bad_launch
+        assert bad_launch["first_blocker"] == "missing_docker_server_surface", bad_launch
         assert bad_launch["ready"] is False, bad_launch
+        assert (
+            bad_launch["task_material_readiness"]["first_blocker"]
+            == "task_material_missing_instruction_md"
+        ), bad_launch
         bad_summary = summarize_terminal_bench_private_runner_launch(bad_launch)
         assert bad_summary["task_material_readiness_checked"] is True, bad_summary
         assert bad_summary["task_material_ready_required"] is False, bad_summary
@@ -132,7 +136,7 @@ def main() -> None:
         )
         assert (
             strict_unknown_launch["first_blocker"]
-            == "task_material_not_cached_or_not_locally_resolved"
+            == "missing_docker_server_surface"
         ), strict_unknown_launch
         assert strict_unknown_launch["ready"] is False, strict_unknown_launch
         strict_unknown_summary = summarize_terminal_bench_private_runner_launch(
@@ -419,7 +423,7 @@ def main() -> None:
     ), repair_profile_readiness
     assert repair_profile_launch["ready"] is False, repair_profile_launch
     assert repair_profile_launch["first_blocker"] == (
-        "codex_worker_materialization_strategy_missing"
+        "missing_docker_server_surface"
     ), repair_profile_launch
 
     materialized_profile_launch = build_terminal_bench_private_runner_launch(
@@ -488,7 +492,10 @@ def main() -> None:
     assert runtime_extended_readiness["first_blocker"] == (
         "ready_for_runtime_codex_materialization_probe"
     ), runtime_extended_readiness
-    assert runtime_extended_launch["ready"] is True, runtime_extended_launch
+    assert runtime_extended_launch["ready"] is False, runtime_extended_launch
+    assert runtime_extended_launch["first_blocker"] == (
+        "missing_docker_server_surface"
+    ), runtime_extended_launch
     runtime_extended_profile = runtime_extended_summary["repair_profile"]
     assert runtime_extended_profile["required_launch_overrides"][
         "codex_install_strategy"
@@ -694,7 +701,7 @@ def main() -> None:
         assert blocked_case_run["execution_ready"] is False, blocked_case_run
         assert blocked_case_run["launch_preflight_blocked"] is True, blocked_case_run
         assert blocked_case_run["launch_preflight_blocker"] == (
-            "codex_worker_materialization_strategy_missing"
+            "missing_docker_server_surface"
         ), blocked_case_run
         assert blocked_case_run["process_started"] is False, blocked_case_run
         assert blocked_case_run["process_state"] == "prelaunch_blocked", blocked_case_run
@@ -763,16 +770,16 @@ def main() -> None:
             ],
         )
         assert collision_case_run["ok"] is True, collision_case_run
-        assert collision_case_run["execution_ready"] is True, collision_case_run
+        assert collision_case_run["execution_ready"] is False, collision_case_run
         assert (
-            collision_case_run["prelaunch_job_root_guard_triggered"] is True
+            collision_case_run.get("prelaunch_job_root_guard_triggered") is None
         ), collision_case_run
         assert collision_case_run["process_started"] is False, collision_case_run
         assert collision_case_run["process_state"] == "prelaunch_blocked", (
             collision_case_run
         )
         assert collision_case_run["first_blocker"] == (
-            "prelaunch_existing_stale_active_job_without_trial_result"
+            "missing_docker_server_surface"
         ), collision_case_run
         guard = collision_case_run["prelaunch_job_root_guard"]
         assert guard["allowed"] is False, guard
@@ -789,7 +796,7 @@ def main() -> None:
             collision_case_run
         )
         assert collision_case_run["compact_failure_class"] == (
-            "terminal_bench_prelaunch_existing_job_root_blocked"
+            "terminal_bench_prelaunch_readiness_blocked"
         ), collision_case_run
         collision_marker = collision_case_run["compact_failure_marker"]
         assert collision_marker["lifecycle_stage"] == "job_materialization", (
@@ -1026,33 +1033,24 @@ time.sleep(3)
                 resume_case_name,
             ],
         )
-        assert resumed_case["resume_after_materialization_attempted"] is True, (
+        assert resumed_case["resume_after_materialization"] is True, (
             resumed_case
         )
-        assert resumed_case["detached_process_group"] is True, resumed_case
-        assert resumed_case["boundary"]["resume_invoked"] is True, resumed_case
-        assert resumed_case["process_state"] == "running", resumed_case
-        assert resumed_case["exit_code_attribution"] == (
-            "terminal_bench_resume_process_still_running"
+        assert resumed_case["resume_after_materialization_attempted"] is False, (
+            resumed_case
+        )
+        assert resumed_case["launch_preflight_blocked"] is True, resumed_case
+        assert resumed_case["launch_preflight_blocker"] == (
+            "missing_docker_server_surface"
         ), resumed_case
-        resume_observation = resumed_case[
-            "post_materialization_resume_observation"
+        assert resumed_case["detached_process_group"] is False, resumed_case
+        assert resumed_case["boundary"]["resume_invoked"] is False, resumed_case
+        assert resumed_case["process_state"] == "prelaunch_blocked", resumed_case
+        resume_post_launch = resumed_case["prelaunch_job_root_guard"][
+            "post_launch_materialization"
         ]
-        assert resume_observation["process_started"] is True, resume_observation
-        assert resume_observation["detached_process_group"] is True, (
-            resume_observation
-        )
-        assert resume_observation["process_state"] == "running", resume_observation
-        assert resume_observation["boundary"]["raw_logs_read"] is False, (
-            resume_observation
-        )
-        resume_post_launch = resumed_case["post_launch_materialization"]
-        assert resume_post_launch["job_running_trial_count"] == 1, (
-            resume_post_launch
-        )
-        assert resume_post_launch["ready_for_compact_failure_marker"] is False, (
-            resume_post_launch
-        )
+        assert resume_post_launch["raw_paths_recorded"] is False, resume_post_launch
+        assert resume_post_launch["ready_for_launch_state"] is False, resume_post_launch
         rendered_resume = json.dumps(resumed_case, sort_keys=True)
         assert str(materialization_root) not in rendered_resume, resumed_case
 
@@ -1124,7 +1122,10 @@ time.sleep(3)
     cli_runtime_payload = json.loads(cli_runtime_profile.stdout)
     cli_runtime_run = cli_runtime_payload["benchmark_run"]
     cli_runtime_summary = cli_runtime_run["private_runner_launch_summary"]
-    assert cli_runtime_summary["ready"] is True, cli_runtime_summary
+    assert cli_runtime_summary["ready"] is False, cli_runtime_summary
+    assert cli_runtime_summary["first_blocker"] == (
+        "missing_docker_server_surface"
+    ), cli_runtime_summary
     assert cli_runtime_summary["agent_setup_readiness"]["first_blocker"] == (
         "ready_for_runtime_codex_materialization_probe"
     ), cli_runtime_summary
@@ -1420,7 +1421,7 @@ time.sleep(3)
         assert cli_block_payload["execution_ready"] is False, cli_block_payload
         assert cli_block_payload["launch_preflight_blocked"] is True, cli_block_payload
         assert cli_block_payload["launch_preflight_blocker"] == (
-            "codex_worker_materialization_strategy_missing"
+            "missing_docker_server_surface"
         ), cli_block_payload
         assert cli_block_payload["process_started"] is False, cli_block_payload
         assert cli_block_payload["process_state"] == "prelaunch_blocked", cli_block_payload


### PR DESCRIPTION
## Summary
- update the TerminalBench no-submit projection smoke to follow the moved control-plane hot-path smoke fixture
- refresh TerminalBench private-runner env-guard smoke expectations for the current preflight order, where docker server readiness can short-circuit before deeper materialization checks
- keep raw path/log/task/trajectory boundary assertions intact

## Validation
- `python3 examples/terminal-bench-private-runner-env-guard-smoke.py`
- `python3 examples/terminal-bench-no-submit-approval-packet-projection-decision-smoke.py`
- `python3 -m py_compile examples/terminal-bench-private-runner-env-guard-smoke.py examples/terminal-bench-no-submit-approval-packet-projection-decision-smoke.py`

## Boundary
- public smoke fixtures only
- no raw benchmark evidence, private local artifacts, credentials, or generated logs included
