### PR TITLE
Mark split-control as experimental fallback

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -1424,7 +1424,8 @@ matter when credentials cannot move, and it produced adapter/reducer seams that
 can be reused for compact evidence. Do not continue adding split-control bridge
 layers when a cloud-host route can answer the benchmark question directly.
 
-Treat split-control assets as a retained research branch, not a live default:
+Treat split-control assets as a retained experimental fallback, not a live
+default:
 
 - keep durable contracts, reducers, and boundary smokes that still protect
   public behavior;
@@ -1434,6 +1435,9 @@ Treat split-control assets as a retained research branch, not a live default:
   experimental branch or research issue;
 - remove or defer mainline split-control code once the cloud-host route has
   equivalent compact evidence for the same benchmark family.
+- mark retained machine contracts as `experimental_fallback_not_default` so
+  operator-facing projections do not select them as a default cloud-host or
+  app-server route.
 
 See
 [`benchmark-split-control-remote-executor-v0.md`](research/long-horizon-agent-benchmarks/benchmark-split-control-remote-executor-v0.md)

--- a/examples/benchmark-split-control-remote-executor-smoke.py
+++ b/examples/benchmark-split-control-remote-executor-smoke.py
@@ -163,6 +163,16 @@ def test_remote_codex_is_not_required_for_split_control() -> None:
         payload["schema_version"]
         == BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_SCHEMA_VERSION
     ), payload
+    assert payload["route"]["status"] == "experimental_fallback_not_default", payload
+    assert payload["route"]["default_for_cloud_host_runs"] is False, payload
+    assert (
+        "default_cloud_host_or_app_server_benchmark_route"
+        in payload["route"]["not_for"]
+    ), payload
+    assert (
+        "new_bridge_layers_without_concrete_auth_policy_or_host_gate"
+        in payload["route"]["not_for"]
+    ), payload
     assert payload["ready"] is False, payload
     assert payload["first_blocker"] == "split_control_adapter_missing", payload
     assert payload["local_agent"]["ready"] is True, payload
@@ -289,6 +299,8 @@ def test_partial_ready_subset_can_launch_without_remote_codex() -> None:
         plan["schema_version"]
         == BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_LAUNCH_PLAN_SCHEMA_VERSION
     ), plan
+    assert plan["route_status"] == "experimental_fallback_not_default", plan
+    assert plan["default_for_cloud_host_runs"] is False, plan
     assert plan["ready_to_launch"] is True, plan
     assert [case["benchmark_id"] for case in plan["launch_cases"]] == [
         "terminal-bench@2.0",
@@ -333,6 +345,8 @@ def test_partial_ready_subset_can_launch_without_remote_codex() -> None:
         batch["schema_version"]
         == BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_RUNNER_BATCH_SCHEMA_VERSION
     ), batch
+    assert batch["route_status"] == "experimental_fallback_not_default", batch
+    assert batch["default_for_cloud_host_runs"] is False, batch
     assert batch["ready_to_execute"] is True, batch
     assert batch["ready_to_spend"] is False, batch
     assert batch["blockers"] == [], batch
@@ -381,6 +395,10 @@ def test_partial_ready_subset_can_launch_without_remote_codex() -> None:
         missing_seam["schema_version"]
         == BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_EXECUTION_SEAM_SCHEMA_VERSION
     ), missing_seam
+    assert (
+        missing_seam["route_status"] == "experimental_fallback_not_default"
+    ), missing_seam
+    assert missing_seam["default_for_cloud_host_runs"] is False, missing_seam
     assert missing_seam["ready_to_execute"] is False, missing_seam
     assert missing_seam["blockers"] == [
         "command_adapter_missing",
@@ -444,6 +462,54 @@ def test_partial_ready_subset_can_launch_without_remote_codex() -> None:
         for case in ready_seam["execution_cases"]
     ), ready_seam
     assert_public_safe(ready_seam)
+
+
+def test_split_control_retirement_policy_matches_workflow_docs() -> None:
+    workflow = (REPO_ROOT / "docs/benchmark-developer-workflow.md").read_text(
+        encoding="utf-8"
+    )
+    assert "The split-control route is now a fallback and research route" in workflow
+    assert "retained experimental fallback" in workflow
+    assert "do not add new bridge layers" in workflow
+    assert "cloud-host route can answer the benchmark question directly" in workflow
+    assert "default_cloud_host_or_app_server_benchmark_route" not in workflow
+
+    payload = build_split_control_remote_executor_readiness(
+        benchmark_ids=("terminal-bench@2.0",),
+        local_agent={
+            "codex_cli_available": True,
+            "loopx_available": True,
+            "codex_auth_ready": True,
+            "codex_auth_local_only": True,
+            "model_invocation_local": True,
+        },
+        remote_executor={
+            "docker_available": True,
+            "python_available": True,
+            "git_available": True,
+            "rsync_available": True,
+        },
+        adapter_readiness={
+            "terminal-bench@2.0": {
+                "split_control_adapter_ready": True,
+                "runner_tooling_ready": True,
+                "task_data_ready": True,
+            },
+        },
+    )
+    route = payload["route"]
+    assert route["status"] == "experimental_fallback_not_default", payload
+    assert route["default_for_cloud_host_runs"] is False, payload
+    assert route["allowed_use"] == [
+        "codex_auth_cannot_live_on_execution_host",
+        "shared_or_policy_restricted_execution_host",
+        "local_controller_remote_docker_substrate_research",
+    ], payload
+    assert route["not_for"] == [
+        "default_cloud_host_or_app_server_benchmark_route",
+        "new_bridge_layers_without_concrete_auth_policy_or_host_gate",
+    ], payload
+    assert_public_safe(payload)
 
 
 def test_terminal_bench_command_adapter_facts_feed_execution_seam() -> None:

--- a/loopx/benchmark_core/split_control.py
+++ b/loopx/benchmark_core/split_control.py
@@ -39,6 +39,16 @@ DEFAULT_SPLIT_CONTROL_LAUNCH_COMMAND_LABELS = {
     "skillsbench@1.1": "skillsbench compact no-upload remote-executor dry-run or mini-pair",
     "agents-last-exam@local-docker": "agents-last-exam provider/task-data validation gate",
 }
+SPLIT_CONTROL_ROUTE_STATUS = "experimental_fallback_not_default"
+SPLIT_CONTROL_ROUTE_ALLOWED_USE = (
+    "codex_auth_cannot_live_on_execution_host",
+    "shared_or_policy_restricted_execution_host",
+    "local_controller_remote_docker_substrate_research",
+)
+SPLIT_CONTROL_ROUTE_NOT_FOR = (
+    "default_cloud_host_or_app_server_benchmark_route",
+    "new_bridge_layers_without_concrete_auth_policy_or_host_gate",
+)
 
 PUBLIC_RUNNER_RESULT_FIELDS = (
     "status",
@@ -228,6 +238,15 @@ def build_split_control_remote_executor_readiness(
         "schema_version": BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_SCHEMA_VERSION,
         "route": {
             "mode": "local_agent_remote_executor",
+            "status": SPLIT_CONTROL_ROUTE_STATUS,
+            "default_for_cloud_host_runs": False,
+            "allowed_use": list(SPLIT_CONTROL_ROUTE_ALLOWED_USE),
+            "not_for": list(SPLIT_CONTROL_ROUTE_NOT_FOR),
+            "retirement_policy": (
+                "keep durable public contracts and reducers; defer or retire "
+                "transport-only bridge work once a cloud-host or app-server "
+                "route has equivalent compact evidence"
+            ),
             "local_agent_owns": [
                 "codex_cli",
                 "codex_auth",
@@ -339,6 +358,10 @@ def build_split_control_remote_executor_launch_plan(
     return {
         "schema_version": BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_LAUNCH_PLAN_SCHEMA_VERSION,
         "source_schema_version": readiness.get("schema_version"),
+        "route_status": route.get("status") or SPLIT_CONTROL_ROUTE_STATUS,
+        "default_for_cloud_host_runs": _truthy(
+            route.get("default_for_cloud_host_runs")
+        ),
         "ready_to_launch": bool(launch_cases),
         "launch_cases": launch_cases,
         "blocked_benchmark_ids": blocked_ids,
@@ -446,6 +469,11 @@ def build_split_control_remote_executor_runner_batch(
     return {
         "schema_version": BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_RUNNER_BATCH_SCHEMA_VERSION,
         "source_schema_version": launch_plan.get("schema_version"),
+        "route_status": launch_plan.get("route_status")
+        or SPLIT_CONTROL_ROUTE_STATUS,
+        "default_for_cloud_host_runs": _truthy(
+            launch_plan.get("default_for_cloud_host_runs")
+        ),
         "fresh_readiness_schema_version": fresh.get("schema_version"),
         "ready_to_execute": ready_to_execute,
         "blockers": blockers,
@@ -550,6 +578,10 @@ def build_split_control_remote_executor_execution_seam(
     return {
         "schema_version": BENCHMARK_SPLIT_CONTROL_REMOTE_EXECUTOR_EXECUTION_SEAM_SCHEMA_VERSION,
         "source_schema_version": batch.get("schema_version"),
+        "route_status": batch.get("route_status") or SPLIT_CONTROL_ROUTE_STATUS,
+        "default_for_cloud_host_runs": _truthy(
+            batch.get("default_for_cloud_host_runs")
+        ),
         "ready_to_execute": ready_to_execute,
         "ready_to_spend": ready_to_execute and _truthy(batch.get("ready_to_spend")),
         "blockers": seam_blockers,


### PR DESCRIPTION
## Summary
- mark the split-control remote-executor contract as an explicit experimental fallback, not the default cloud-host/app-server route
- propagate the route status through readiness, launch plan, runner batch, and execution seam payloads
- tighten the developer workflow docs and smoke coverage so future projections do not treat split-control as the default path

## Validation
- python3 examples/benchmark-split-control-remote-executor-smoke.py
- python3 -m py_compile loopx/benchmark_core/split_control.py examples/benchmark-split-control-remote-executor-smoke.py