### PR TITLE
Extract active state todo read model

### DIFF
--- a/examples/control_plane/event-sourced-status-read-path-smoke.py
+++ b/examples/control_plane/event-sourced-status-read-path-smoke.py
@@ -18,7 +18,9 @@ from loopx.event_sourced_state import (  # noqa: E402
     TODO_CLAIMED,
     make_state_event,
 )
+from loopx.projections import active_state_todos as active_state_todos_read_model  # noqa: E402
 from loopx.status import active_state_todo_fields  # noqa: E402
+from loopx import status as status_module  # noqa: E402
 
 
 GOAL_ID = "event-sourced-status-read-fixture"
@@ -84,6 +86,28 @@ def event_todo_ids(fields: dict) -> list[str]:
     return [str(item.get("todo_id") or "") for item in agent_todos.get("items") or []]
 
 
+def direct_active_state_todo_fields(goal: dict, *, runtime_root: Path | None = None) -> dict:
+    return active_state_todos_read_model.active_state_todo_fields(
+        goal,
+        runtime_root=runtime_root,
+        resolve_goal_local_path=status_module.resolve_goal_local_path,
+        active_state_next_action_entries=status_module.active_state_next_action_entries,
+        active_next_action_todo_ids=status_module.active_next_action_todo_ids,
+        load_rollout_events=status_module.load_rollout_events,
+        rollout_event_log_path=status_module.rollout_event_log_path,
+        max_todo_index_rollout_events_per_goal=status_module.MAX_TODO_INDEX_ROLLOUT_EVENTS_PER_GOAL,
+        active_state_event_projection_fields=status_module.active_state_event_projection_fields,
+        attach_monitor_writeback_contract=status_module.attach_monitor_writeback_contract,
+        parse_active_state_todos=status_module.parse_active_state_todos,
+        parse_issue_meta_surface=status_module.parse_issue_meta_surface,
+        backlog_hygiene_warning=status_module.backlog_hygiene_warning,
+        completed_todo_archive_warning=status_module.completed_todo_archive_warning,
+        autonomous_replan_obligation=status_module.autonomous_replan_obligation,
+        state_projection_gap_warning=status_module.state_projection_gap_warning,
+        redacted_status_todo_fields=status_module.redacted_status_todo_fields,
+    )
+
+
 def test_event_projection_preferred() -> None:
     with tempfile.TemporaryDirectory(prefix="loopx-event-status-") as tmp:
         project = Path(tmp)
@@ -97,6 +121,7 @@ def test_event_projection_preferred() -> None:
             "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
         }
         fields = active_state_todo_fields(goal)
+        assert fields == direct_active_state_todo_fields(goal), fields
         assert fields["state_event_projection"]["source"] == "event_log", fields
         assert fields["state_event_projection"]["last_append_sequence"] == 2, fields
         assert event_todo_ids(fields) == ["todo_event_status_read"], fields
@@ -116,11 +141,13 @@ def test_markdown_fallback_without_valid_event_log() -> None:
         }
 
         fields = active_state_todo_fields(goal)
+        assert fields == direct_active_state_todo_fields(goal), fields
         assert event_todo_ids(fields) == ["todo_markdown_stale"], fields
         assert "state_event_projection" not in fields, fields
 
         state_path.with_name("events.jsonl").write_text("{not json\n", encoding="utf-8")
         corrupted_fields = active_state_todo_fields(goal)
+        assert corrupted_fields == direct_active_state_todo_fields(goal), corrupted_fields
         assert event_todo_ids(corrupted_fields) == ["todo_markdown_stale"], corrupted_fields
         assert corrupted_fields["state_event_projection_warning"]["fallback"] == "markdown_active_state", (
             corrupted_fields

--- a/loopx/projections/active_state_todos.py
+++ b/loopx/projections/active_state_todos.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+
+def active_state_todo_fields(
+    goal: dict[str, Any],
+    *,
+    runtime_root: Path | None = None,
+    resolve_goal_local_path: Callable[..., Path | None],
+    active_state_next_action_entries: Callable[..., list[str]],
+    active_next_action_todo_ids: Callable[[str], set[str]],
+    load_rollout_events: Callable[..., list[dict[str, Any]]],
+    rollout_event_log_path: Callable[[Path, str], Path],
+    max_todo_index_rollout_events_per_goal: int,
+    active_state_event_projection_fields: Callable[..., dict[str, Any]],
+    attach_monitor_writeback_contract: Callable[..., None],
+    parse_active_state_todos: Callable[..., dict[str, Any]],
+    parse_issue_meta_surface: Callable[[str], dict[str, Any] | None],
+    backlog_hygiene_warning: Callable[..., dict[str, Any] | None],
+    completed_todo_archive_warning: Callable[[dict[str, Any] | None], dict[str, Any] | None],
+    autonomous_replan_obligation: Callable[..., dict[str, Any] | None],
+    state_projection_gap_warning: Callable[..., dict[str, Any] | None],
+    redacted_status_todo_fields: Callable[[dict[str, Any]], dict[str, Any]],
+) -> dict[str, Any]:
+    state_path = resolve_goal_local_path(goal.get("state_file"), goal, fallback_base=Path.cwd())
+    if state_path is None or not state_path.exists():
+        return {}
+    try:
+        state_text = state_path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+    next_action_entries = active_state_next_action_entries(state_text, limit=3)
+    preferred_todo_ids: set[str] = set()
+    for entry in next_action_entries:
+        preferred_todo_ids.update(active_next_action_todo_ids(entry))
+    rollout_events: list[dict[str, Any]] = []
+    goal_id = str(goal.get("id") or "").strip()
+    if runtime_root is not None and goal_id:
+        rollout_events = load_rollout_events(
+            rollout_event_log_path(runtime_root, goal_id),
+            limit=max_todo_index_rollout_events_per_goal,
+        )
+    event_fields = active_state_event_projection_fields(
+        goal,
+        state_path=state_path,
+        preferred_todo_ids=preferred_todo_ids,
+        rollout_events=rollout_events,
+    )
+    if event_fields.get("user_todos") or event_fields.get("agent_todos"):
+        fields = event_fields
+        attach_monitor_writeback_contract(
+            fields,
+            supported=False,
+            source="event_projection_read_model",
+        )
+    else:
+        fields = parse_active_state_todos(
+            state_text,
+            goal=goal,
+            state_path=state_path,
+            preferred_todo_ids=preferred_todo_ids,
+            rollout_events=rollout_events,
+        )
+        attach_monitor_writeback_contract(
+            fields,
+            supported=True,
+            source="markdown_active_state",
+        )
+        if event_fields:
+            fields.update(event_fields)
+    issue_meta_surface = parse_issue_meta_surface(state_text)
+    if issue_meta_surface:
+        fields["issue_meta_surface"] = issue_meta_surface
+    if next_action_entries:
+        fields["active_state_next_action"] = next_action_entries[0]
+        fields["active_state_next_action_entries"] = next_action_entries
+    warning = backlog_hygiene_warning(
+        state_text,
+        agent_todos=fields.get("agent_todos") if isinstance(fields.get("agent_todos"), dict) else None,
+    )
+    if warning:
+        fields["backlog_hygiene_warning"] = warning
+    archive_warning = completed_todo_archive_warning(
+        fields.get("agent_todos") if isinstance(fields.get("agent_todos"), dict) else None
+    )
+    if archive_warning:
+        fields["completed_todo_archive_warning"] = archive_warning
+    replan_obligation = autonomous_replan_obligation(
+        state_text,
+        agent_todos=fields.get("agent_todos") if isinstance(fields.get("agent_todos"), dict) else None,
+    )
+    if replan_obligation:
+        fields["autonomous_replan_obligation"] = replan_obligation
+    projection_gap = state_projection_gap_warning(
+        state_text,
+        user_todos=fields.get("user_todos") if isinstance(fields.get("user_todos"), dict) else None,
+        agent_todos=fields.get("agent_todos") if isinstance(fields.get("agent_todos"), dict) else None,
+    )
+    if projection_gap:
+        fields["state_projection_gap"] = projection_gap
+    if fields:
+        fields = redacted_status_todo_fields(fields)
+    return fields

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -92,6 +92,9 @@ from .projections.active_state_sections import (
     active_state_section_entries as _active_state_section_entries_read_model,
     active_state_sections as _active_state_sections_read_model,
 )
+from .projections.active_state_todos import (
+    active_state_todo_fields as _active_state_todo_fields_read_model,
+)
 from .projections.attention_item import (
     attention_item as _attention_item_read_model,
 )
@@ -6583,85 +6586,25 @@ def active_state_todo_fields(
     *,
     runtime_root: Path | None = None,
 ) -> dict[str, Any]:
-    state_path = resolve_goal_local_path(goal.get("state_file"), goal, fallback_base=Path.cwd())
-    if state_path is None or not state_path.exists():
-        return {}
-    try:
-        state_text = state_path.read_text(encoding="utf-8")
-    except OSError:
-        return {}
-    next_action_entries = active_state_next_action_entries(state_text, limit=3)
-    preferred_todo_ids: set[str] = set()
-    for entry in next_action_entries:
-        preferred_todo_ids.update(active_next_action_todo_ids(entry))
-    rollout_events: list[dict[str, Any]] = []
-    goal_id = str(goal.get("id") or "").strip()
-    if runtime_root is not None and goal_id:
-        rollout_events = load_rollout_events(
-            rollout_event_log_path(runtime_root, goal_id),
-            limit=MAX_TODO_INDEX_ROLLOUT_EVENTS_PER_GOAL,
-        )
-    event_fields = active_state_event_projection_fields(
+    return _active_state_todo_fields_read_model(
         goal,
-        state_path=state_path,
-        preferred_todo_ids=preferred_todo_ids,
-        rollout_events=rollout_events,
+        runtime_root=runtime_root,
+        resolve_goal_local_path=resolve_goal_local_path,
+        active_state_next_action_entries=active_state_next_action_entries,
+        active_next_action_todo_ids=active_next_action_todo_ids,
+        load_rollout_events=load_rollout_events,
+        rollout_event_log_path=rollout_event_log_path,
+        max_todo_index_rollout_events_per_goal=MAX_TODO_INDEX_ROLLOUT_EVENTS_PER_GOAL,
+        active_state_event_projection_fields=active_state_event_projection_fields,
+        attach_monitor_writeback_contract=attach_monitor_writeback_contract,
+        parse_active_state_todos=parse_active_state_todos,
+        parse_issue_meta_surface=parse_issue_meta_surface,
+        backlog_hygiene_warning=backlog_hygiene_warning,
+        completed_todo_archive_warning=completed_todo_archive_warning,
+        autonomous_replan_obligation=autonomous_replan_obligation,
+        state_projection_gap_warning=state_projection_gap_warning,
+        redacted_status_todo_fields=redacted_status_todo_fields,
     )
-    if event_fields.get("user_todos") or event_fields.get("agent_todos"):
-        fields = event_fields
-        attach_monitor_writeback_contract(
-            fields,
-            supported=False,
-            source="event_projection_read_model",
-        )
-    else:
-        fields = parse_active_state_todos(
-            state_text,
-            goal=goal,
-            state_path=state_path,
-            preferred_todo_ids=preferred_todo_ids,
-            rollout_events=rollout_events,
-        )
-        attach_monitor_writeback_contract(
-            fields,
-            supported=True,
-            source="markdown_active_state",
-        )
-        if event_fields:
-            fields.update(event_fields)
-    issue_meta_surface = parse_issue_meta_surface(state_text)
-    if issue_meta_surface:
-        fields["issue_meta_surface"] = issue_meta_surface
-    if next_action_entries:
-        fields["active_state_next_action"] = next_action_entries[0]
-        fields["active_state_next_action_entries"] = next_action_entries
-    warning = backlog_hygiene_warning(
-        state_text,
-        agent_todos=fields.get("agent_todos") if isinstance(fields.get("agent_todos"), dict) else None,
-    )
-    if warning:
-        fields["backlog_hygiene_warning"] = warning
-    archive_warning = completed_todo_archive_warning(
-        fields.get("agent_todos") if isinstance(fields.get("agent_todos"), dict) else None
-    )
-    if archive_warning:
-        fields["completed_todo_archive_warning"] = archive_warning
-    replan_obligation = autonomous_replan_obligation(
-        state_text,
-        agent_todos=fields.get("agent_todos") if isinstance(fields.get("agent_todos"), dict) else None,
-    )
-    if replan_obligation:
-        fields["autonomous_replan_obligation"] = replan_obligation
-    projection_gap = state_projection_gap_warning(
-        state_text,
-        user_todos=fields.get("user_todos") if isinstance(fields.get("user_todos"), dict) else None,
-        agent_todos=fields.get("agent_todos") if isinstance(fields.get("agent_todos"), dict) else None,
-    )
-    if projection_gap:
-        fields["state_projection_gap"] = projection_gap
-    if fields:
-        fields = redacted_status_todo_fields(fields)
-    return fields
 
 
 def attention_item(


### PR DESCRIPTION
## Summary
- Extract `active_state_todo_fields` active-state todo read-path composition into `loopx.projections.active_state_todos`, leaving `status.py` as a dependency-injection compatibility wrapper.
- Extend the event-sourced status read-path smoke with wrapper/direct read-model parity across event projection, Markdown fallback, and corrupted event-log fallback.

## Product / architecture judgment
This is a canary-gated control-plane cleanup: the product behavior stays the same, but another projection boundary moves out of the oversized `status.py` module. The direct parity smoke keeps event projection preference, Markdown fallback, monitor writeback contract attachment, warnings, and redaction behavior pinned while enabling the next smaller read-model extractions.

## Validation
- `python3 -m compileall -q loopx/status.py loopx/projections/active_state_todos.py examples/control_plane/event-sourced-status-read-path-smoke.py`
- `python3 examples/control_plane/event-sourced-status-read-path-smoke.py`
- `python3 examples/control_plane/todo-readmodel-boundary-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `git diff --check`
- public/private boundary scan over changed paths
- `python3 -m loopx.cli canary smoke-suite --profile core-control-plane` (`136/136` passed)

## Boundary
No benchmark raw logs, task text, trajectories, verifier output, credentials, or private local state are included.