### PR TITLE
Extract global registry health read model

### DIFF
--- a/examples/control_plane/global-registry-health-readmodel-smoke.py
+++ b/examples/control_plane/global-registry-health-readmodel-smoke.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Smoke-test global registry health read-model parity."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx import status as status_module  # noqa: E402
+from loopx.projections import global_registry_health as health_read_model  # noqa: E402
+
+
+def direct_collect(
+    *,
+    registry_path: Path,
+    runtime_root: Path,
+    current_registry: dict[str, Any],
+) -> dict[str, Any]:
+    return health_read_model.collect_global_registry_health(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        current_registry=current_registry,
+        global_registry_path=status_module.global_registry_path,
+        load_registry=status_module.load_registry,
+        registry_goals=status_module.registry_goals,
+        same_path=status_module.same_path,
+        resolve_goal_local_path=status_module.resolve_goal_local_path,
+        parse_timestamp=status_module.parse_timestamp,
+    )
+
+
+def assert_parity(
+    *,
+    registry_path: Path,
+    runtime_root: Path,
+    current_registry: dict[str, Any],
+) -> dict[str, Any]:
+    wrapper = status_module.collect_global_registry_health(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        current_registry=current_registry,
+    )
+    direct = direct_collect(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        current_registry=current_registry,
+    )
+    assert wrapper == direct, (wrapper, direct)
+    return wrapper
+
+
+def write_json(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-global-registry-health-") as raw_tmp:
+        root = Path(raw_tmp)
+        runtime = root / "runtime"
+        current_registry_path = root / "project" / ".loopx" / "registry.json"
+        missing = assert_parity(
+            registry_path=current_registry_path,
+            runtime_root=runtime,
+            current_registry={"goals": []},
+        )
+        assert missing["available"] is False, missing
+        assert missing["summary"] == {
+            "high": 0,
+            "action": 0,
+            "info": 0,
+            "checks": 0,
+            "findings": 0,
+        }, missing
+
+        source_registry = root / "source" / ".loopx" / "registry.json"
+        source_registry.parent.mkdir(parents=True)
+        source_registry.write_text("{}\n", encoding="utf-8")
+        state_file = root / "source" / ".codex" / "goals" / "fresh" / "ACTIVE_GOAL_STATE.md"
+        state_file.parent.mkdir(parents=True)
+        state_file.write_text("---\nupdated_at: 2026-07-04T00:00:00+00:00\n---\n", encoding="utf-8")
+
+        current_registry = {
+            "goals": [
+                {
+                    "id": "fresh",
+                    "repo": str(root / "source"),
+                    "state_file": ".codex/goals/fresh/ACTIVE_GOAL_STATE.md",
+                }
+            ]
+        }
+        global_registry = {
+            "goals": [
+                {
+                    "id": "fresh",
+                    "repo": str(root / "source"),
+                    "source_registry": ".loopx/registry.json",
+                    "state_file": ".codex/goals/fresh/ACTIVE_GOAL_STATE.md",
+                    "synced_at": "2026-07-04T00:00:00+00:00",
+                },
+                {
+                    "id": "duplicate",
+                    "repo": str(root / "missing-a"),
+                    "state_file": ".codex/goals/duplicate/ACTIVE_GOAL_STATE.md",
+                },
+                {
+                    "id": "duplicate",
+                    "repo": str(root / "missing-b"),
+                    "source_registry": ".loopx/registry.json",
+                },
+                {
+                    "id": "global-only",
+                    "repo": str(root / "missing-c"),
+                    "source_registry": ".loopx/registry.json",
+                    "state_file": ".codex/goals/global-only/ACTIVE_GOAL_STATE.md",
+                },
+            ]
+        }
+        write_json(status_module.global_registry_path(runtime), global_registry)
+
+        health = assert_parity(
+            registry_path=current_registry_path,
+            runtime_root=runtime,
+            current_registry=current_registry,
+        )
+        kinds = {str(finding.get("kind")) for finding in health["findings"]}
+        assert health["available"] is True, health
+        assert health["ok"] is False, health
+        assert health["summary"]["high"] == 1, health
+        assert "duplicate_goal_id" in kinds, health
+        assert "source_registry_missing" in kinds, health
+        assert "state_file_missing" in kinds, health
+        assert "state_file_not_declared" in kinds, health
+        assert "current_registry_scope_excludes_global_goals" in kinds, health
+        assert health["source_registry_count"] == 3, health
+
+        finding = status_module.global_registry_finding(
+            kind="fixture",
+            severity="info",
+            message="fixture finding",
+            recommended_action="keep parity",
+            goal_id="fresh",
+            path=state_file,
+            goal_ids=["fresh"],
+        )
+        assert finding == health_read_model.global_registry_finding(
+            kind="fixture",
+            severity="info",
+            message="fixture finding",
+            recommended_action="keep parity",
+            goal_id="fresh",
+            path=state_file,
+            goal_ids=["fresh"],
+        )
+
+    print("global-registry-health-readmodel-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -158,7 +158,10 @@ def handle_quota_command(
         )
         status_payload = None
         cache_metadata = None
-        if args.use_projection_cache:
+        use_projection_cache = bool(getattr(args, "use_projection_cache", False))
+        write_projection_cache_enabled = bool(getattr(args, "write_projection_cache", False))
+        projection_cache_ttl_seconds = int(getattr(args, "projection_cache_ttl_seconds", 120))
+        if use_projection_cache:
             status_payload, cache_metadata = load_status_projection_cache(
                 registry_path=registry_path,
                 runtime_root=runtime_root,
@@ -166,7 +169,7 @@ def handle_quota_command(
                 limit=status_limit,
                 include_task_graph=False,
                 goal_id=None,
-                max_age_seconds=args.projection_cache_ttl_seconds,
+                max_age_seconds=projection_cache_ttl_seconds,
             )
         if status_payload is None:
             status_payload = collect_status(
@@ -175,7 +178,7 @@ def handle_quota_command(
                 scan_roots=scan_roots,
                 limit=status_limit,
             )
-            if args.write_projection_cache:
+            if write_projection_cache_enabled:
                 cache_metadata = write_status_projection_cache(
                     registry_path=registry_path,
                     runtime_root=runtime_root,
@@ -184,7 +187,7 @@ def handle_quota_command(
                     include_task_graph=False,
                     goal_id=None,
                     payload=status_payload,
-                    max_age_seconds=args.projection_cache_ttl_seconds,
+                    max_age_seconds=projection_cache_ttl_seconds,
                 )
         elif isinstance(status_payload.get("projection_cache"), dict):
             cache_metadata = dict(status_payload["projection_cache"])

--- a/loopx/projections/global_registry_health.py
+++ b/loopx/projections/global_registry_health.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+from collections import Counter
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+
+def global_registry_finding(
+    *,
+    kind: str,
+    severity: str,
+    message: str,
+    recommended_action: str,
+    goal_id: str | None = None,
+    path: Path | None = None,
+    goal_ids: list[str] | None = None,
+) -> dict[str, Any]:
+    finding: dict[str, Any] = {
+        "kind": kind,
+        "severity": severity,
+        "message": message,
+        "recommended_action": recommended_action,
+    }
+    if goal_id:
+        finding["goal_id"] = goal_id
+    if path:
+        finding["path"] = str(path)
+    if goal_ids:
+        finding["goal_ids"] = goal_ids
+    return finding
+
+
+def collect_global_registry_health(
+    *,
+    registry_path: Path,
+    runtime_root: Path,
+    current_registry: dict[str, Any],
+    global_registry_path: Callable[[Path], Path],
+    load_registry: Callable[[Path], dict[str, Any]],
+    registry_goals: Callable[[dict[str, Any]], list[dict[str, Any]]],
+    same_path: Callable[[Path, Path], bool],
+    resolve_goal_local_path: Callable[..., Path | None],
+    parse_timestamp: Callable[[Any], datetime | None],
+) -> dict[str, Any]:
+    global_path = global_registry_path(runtime_root)
+    if not global_path.exists():
+        return {
+            "available": False,
+            "ok": True,
+            "registry": str(global_path),
+            "current_registry": str(registry_path),
+            "current_registry_is_global": False,
+            "summary": {"high": 0, "action": 0, "info": 0, "checks": 0, "findings": 0},
+            "findings": [],
+            "checks": [],
+        }
+
+    global_registry = load_registry(global_path)
+    global_goals = registry_goals(global_registry)
+    current_goals = registry_goals(current_registry)
+    current_ids = {str(goal.get("id")) for goal in current_goals if goal.get("id")}
+    global_ids = [str(goal.get("id")) for goal in global_goals if goal.get("id")]
+    global_id_set = set(global_ids)
+    source_registries: set[str] = set()
+    findings: list[dict[str, Any]] = []
+    checks: list[str] = []
+
+    current_is_global = same_path(registry_path, global_path)
+    id_counts = Counter(global_ids)
+    for goal_id, count in sorted(id_counts.items()):
+        if count <= 1:
+            continue
+        findings.append(
+            global_registry_finding(
+                kind="duplicate_goal_id",
+                severity="high",
+                goal_id=goal_id,
+                message=f"global registry contains {count} entries for `{goal_id}`",
+                recommended_action="deduplicate the global registry before trusting multi-project routing",
+            )
+        )
+
+    for goal in global_goals:
+        goal_id = str(goal.get("id") or "unknown-goal")
+        source_path = resolve_goal_local_path(
+            goal.get("source_registry"),
+            goal,
+            fallback_base=global_path.parent,
+        )
+        if source_path:
+            source_registries.add(str(source_path))
+            if not source_path.exists():
+                findings.append(
+                    global_registry_finding(
+                        kind="source_registry_missing",
+                        severity="action",
+                        goal_id=goal_id,
+                        path=source_path,
+                        message=f"`{goal_id}` source registry is missing",
+                        recommended_action=f"reconnect `{goal_id}` from its project or archive it if the project is obsolete",
+                    )
+                )
+            else:
+                synced_at = parse_timestamp(goal.get("synced_at"))
+                if synced_at:
+                    source_mtime = datetime.fromtimestamp(source_path.stat().st_mtime, tz=timezone.utc)
+                    if source_mtime > synced_at.astimezone(timezone.utc) + timedelta(seconds=5):
+                        findings.append(
+                            global_registry_finding(
+                                kind="stale_source_registry",
+                                severity="action",
+                                goal_id=goal_id,
+                                path=source_path,
+                                message=f"`{goal_id}` source registry changed after its last global sync",
+                                recommended_action=(
+                                    f"run `loopx sync-global --goal-id {goal_id}` from the source project"
+                                ),
+                            )
+                        )
+
+        state_path = resolve_goal_local_path(
+            goal.get("state_file"),
+            goal,
+            fallback_base=global_path.parent,
+        )
+        if state_path and not state_path.exists():
+            findings.append(
+                global_registry_finding(
+                    kind="state_file_missing",
+                    severity="action",
+                    goal_id=goal_id,
+                    path=state_path,
+                    message=f"`{goal_id}` active state file is missing",
+                    recommended_action=f"repair `{goal_id}` state_file or reconnect the project",
+                )
+            )
+        if not state_path:
+            findings.append(
+                global_registry_finding(
+                    kind="state_file_not_declared",
+                    severity="action",
+                    goal_id=goal_id,
+                    message=f"`{goal_id}` does not declare a state_file",
+                    recommended_action=f"reconnect `{goal_id}` with a durable active goal state file",
+                )
+            )
+
+    missing_from_current = sorted(global_id_set - current_ids)
+    if not current_is_global and missing_from_current:
+        shown = missing_from_current[:8]
+        findings.append(
+            global_registry_finding(
+                kind="current_registry_scope_excludes_global_goals",
+                severity="info",
+                message=f"current registry excludes {len(missing_from_current)} global goal(s)",
+                recommended_action=(
+                    "for multi-project dashboard/controller status, run `loopx status` "
+                    "without `--registry`, pass the global registry, or start `serve-status --global-registry`"
+                ),
+                goal_ids=shown,
+            )
+        )
+
+    checks.append(f"global registry goals checked: {len(global_goals)}")
+    checks.append(f"global source registries checked: {len(source_registries)}")
+    severity_counts = Counter(str(finding.get("severity") or "info") for finding in findings)
+    return {
+        "available": True,
+        "ok": severity_counts.get("high", 0) == 0,
+        "registry": str(global_path),
+        "current_registry": str(registry_path),
+        "current_registry_is_global": current_is_global,
+        "global_goal_count": len(global_goals),
+        "current_goal_count": len(current_goals),
+        "source_registry_count": len(source_registries),
+        "summary": {
+            "high": severity_counts.get("high", 0),
+            "action": severity_counts.get("action", 0),
+            "info": severity_counts.get("info", 0),
+            "checks": len(checks),
+            "findings": len(findings),
+        },
+        "findings": findings,
+        "checks": checks,
+    }

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections import Counter
 from datetime import datetime, timedelta, timezone
 import hashlib
 from pathlib import Path
@@ -154,6 +153,10 @@ from .projections.handoff_runs import (
 from .projections.global_registry_shadow import (
     attach_global_registry_shadow_finding as _attach_global_registry_shadow_finding_read_model,
     compact_global_registry_shadow_finding as _compact_global_registry_shadow_finding_read_model,
+)
+from .projections.global_registry_health import (
+    collect_global_registry_health as _collect_global_registry_health_read_model,
+    global_registry_finding as _global_registry_finding_read_model,
 )
 from .projections.issue_meta_surface import (
     parse_issue_meta_surface as _parse_issue_meta_surface_read_model,
@@ -6760,19 +6763,15 @@ def global_registry_finding(
     path: Path | None = None,
     goal_ids: list[str] | None = None,
 ) -> dict[str, Any]:
-    finding: dict[str, Any] = {
-        "kind": kind,
-        "severity": severity,
-        "message": message,
-        "recommended_action": recommended_action,
-    }
-    if goal_id:
-        finding["goal_id"] = goal_id
-    if path:
-        finding["path"] = str(path)
-    if goal_ids:
-        finding["goal_ids"] = goal_ids
-    return finding
+    return _global_registry_finding_read_model(
+        kind=kind,
+        severity=severity,
+        message=message,
+        recommended_action=recommended_action,
+        goal_id=goal_id,
+        path=path,
+        goal_ids=goal_ids,
+    )
 
 
 def collect_global_registry_health(
@@ -6781,139 +6780,17 @@ def collect_global_registry_health(
     runtime_root: Path,
     current_registry: dict[str, Any],
 ) -> dict[str, Any]:
-    global_path = global_registry_path(runtime_root)
-    if not global_path.exists():
-        return {
-            "available": False,
-            "ok": True,
-            "registry": str(global_path),
-            "current_registry": str(registry_path),
-            "current_registry_is_global": False,
-            "summary": {"high": 0, "action": 0, "info": 0, "checks": 0, "findings": 0},
-            "findings": [],
-            "checks": [],
-        }
-
-    global_registry = load_registry(global_path)
-    global_goals = registry_goals(global_registry)
-    current_goals = registry_goals(current_registry)
-    current_ids = {str(goal.get("id")) for goal in current_goals if goal.get("id")}
-    global_ids = [str(goal.get("id")) for goal in global_goals if goal.get("id")]
-    global_id_set = set(global_ids)
-    source_registries: set[str] = set()
-    findings: list[dict[str, Any]] = []
-    checks: list[str] = []
-
-    current_is_global = same_path(registry_path, global_path)
-    id_counts = Counter(global_ids)
-    for goal_id, count in sorted(id_counts.items()):
-        if count <= 1:
-            continue
-        findings.append(
-            global_registry_finding(
-                kind="duplicate_goal_id",
-                severity="high",
-                goal_id=goal_id,
-                message=f"global registry contains {count} entries for `{goal_id}`",
-                recommended_action="deduplicate the global registry before trusting multi-project routing",
-            )
-        )
-
-    for goal in global_goals:
-        goal_id = str(goal.get("id") or "unknown-goal")
-        source_path = resolve_goal_local_path(goal.get("source_registry"), goal, fallback_base=global_path.parent)
-        if source_path:
-            source_registries.add(str(source_path))
-            if not source_path.exists():
-                findings.append(
-                    global_registry_finding(
-                        kind="source_registry_missing",
-                        severity="action",
-                        goal_id=goal_id,
-                        path=source_path,
-                        message=f"`{goal_id}` source registry is missing",
-                        recommended_action=f"reconnect `{goal_id}` from its project or archive it if the project is obsolete",
-                    )
-                )
-            else:
-                synced_at = parse_timestamp(goal.get("synced_at"))
-                if synced_at:
-                    source_mtime = datetime.fromtimestamp(source_path.stat().st_mtime, tz=timezone.utc)
-                    if source_mtime > synced_at.astimezone(timezone.utc) + timedelta(seconds=5):
-                        findings.append(
-                            global_registry_finding(
-                                kind="stale_source_registry",
-                                severity="action",
-                                goal_id=goal_id,
-                                path=source_path,
-                                message=f"`{goal_id}` source registry changed after its last global sync",
-                                recommended_action=(
-                                    f"run `loopx sync-global --goal-id {goal_id}` from the source project"
-                                ),
-                            )
-                        )
-
-        state_path = resolve_goal_local_path(goal.get("state_file"), goal, fallback_base=global_path.parent)
-        if state_path and not state_path.exists():
-            findings.append(
-                global_registry_finding(
-                    kind="state_file_missing",
-                    severity="action",
-                    goal_id=goal_id,
-                    path=state_path,
-                    message=f"`{goal_id}` active state file is missing",
-                    recommended_action=f"repair `{goal_id}` state_file or reconnect the project",
-                )
-            )
-        if not state_path:
-            findings.append(
-                global_registry_finding(
-                    kind="state_file_not_declared",
-                    severity="action",
-                    goal_id=goal_id,
-                    message=f"`{goal_id}` does not declare a state_file",
-                    recommended_action=f"reconnect `{goal_id}` with a durable active goal state file",
-                )
-            )
-
-    missing_from_current = sorted(global_id_set - current_ids)
-    if not current_is_global and missing_from_current:
-        shown = missing_from_current[:8]
-        findings.append(
-            global_registry_finding(
-                kind="current_registry_scope_excludes_global_goals",
-                severity="info",
-                message=f"current registry excludes {len(missing_from_current)} global goal(s)",
-                recommended_action=(
-                    "for multi-project dashboard/controller status, run `loopx status` "
-                    "without `--registry`, pass the global registry, or start `serve-status --global-registry`"
-                ),
-                goal_ids=shown,
-            )
-        )
-
-    checks.append(f"global registry goals checked: {len(global_goals)}")
-    checks.append(f"global source registries checked: {len(source_registries)}")
-    severity_counts = Counter(str(finding.get("severity") or "info") for finding in findings)
-    return {
-        "available": True,
-        "ok": severity_counts.get("high", 0) == 0,
-        "registry": str(global_path),
-        "current_registry": str(registry_path),
-        "current_registry_is_global": current_is_global,
-        "global_goal_count": len(global_goals),
-        "current_goal_count": len(current_goals),
-        "source_registry_count": len(source_registries),
-        "summary": {
-            "high": severity_counts.get("high", 0),
-            "action": severity_counts.get("action", 0),
-            "info": severity_counts.get("info", 0),
-            "checks": len(checks),
-            "findings": len(findings),
-        },
-        "findings": findings,
-        "checks": checks,
-    }
+    return _collect_global_registry_health_read_model(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        current_registry=current_registry,
+        global_registry_path=global_registry_path,
+        load_registry=load_registry,
+        registry_goals=registry_goals,
+        same_path=same_path,
+        resolve_goal_local_path=resolve_goal_local_path,
+        parse_timestamp=parse_timestamp,
+    )
 
 
 def is_status_neutral_run(run: dict[str, Any]) -> bool:


### PR DESCRIPTION
## Summary
- Extract global registry health projection into `loopx.projections.global_registry_health`, leaving `status.py` as a dependency-injection wrapper.
- Add `global-registry-health-readmodel-smoke` to pin wrapper/direct parity for missing global registry and populated registry findings.
- Make quota command cache flags backward-compatible for direct handler calls that construct older `argparse.Namespace` objects, fixing the monitor-poll and scheduler-ack smoke regressions introduced by the projection-cache CLI options.

## Product / architecture judgment
This continues the canary-gated `status.py` read-model cleanup: global registry health is a stable projection boundary used by status/dashboard attention, and moving it behind a direct read model reduces the size of `status.py` without changing the public status contract. The quota handler change is a narrow compatibility fix for internal/direct callers while preserving the new projection-cache CLI behavior.

## Validation
- `python3 -m compileall -q loopx/cli_commands/quota.py loopx/status.py loopx/projections/global_registry_health.py examples/control_plane/global-registry-health-readmodel-smoke.py`
- `python3 examples/control_plane/global-registry-health-readmodel-smoke.py`
- `python3 examples/control_plane/monitor-poll-writeback-smoke.py`
- `python3 examples/control_plane/quota-scheduler-state-ack-smoke.py`
- `python3 examples/control_plane/status-projection-cache-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `git diff --check origin/main...HEAD`
- public/private boundary scan over changed paths
- `python3 -m loopx.cli canary smoke-suite --profile core-control-plane` (`138/138` passed before the final benchmark-only main rebase); focused status/quota validations were rerun after rebasing onto latest `origin/main`.

## Boundary
No benchmark raw logs, task text, trajectories, verifier output, credentials, or private local state are included.