### PR TITLE
Extract status contract read model

### DIFF
--- a/examples/control_plane/status-contract-readmodel-smoke.py
+++ b/examples/control_plane/status-contract-readmodel-smoke.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Smoke-test status contract read-model parity."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx import status as status_module  # noqa: E402
+from loopx.projections import status_contract as status_contract_read_model  # noqa: E402
+
+
+def direct_status_contract() -> dict[str, Any]:
+    return status_contract_read_model.build_status_contract(
+        schema_version=status_module.STATUS_CONTRACT_SCHEMA_VERSION,
+        minimum_dashboard_schema_version=status_module.MINIMUM_DASHBOARD_STATUS_CONTRACT_SCHEMA_VERSION,
+        reload_hint=status_module.STATUS_CONTRACT_RELOAD_HINT,
+    )
+
+
+def direct_compact_signals(value: Any, *, limit: int | None = None) -> dict[str, Any]:
+    return status_contract_read_model.compact_status_contract_signals(
+        value,
+        limit=status_module.STATUS_CONTRACT_SIGNAL_LIMIT if limit is None else limit,
+    )
+
+
+def direct_contract_health(contract: dict[str, Any]) -> dict[str, Any]:
+    return status_contract_read_model.build_contract_health_projection(
+        contract,
+        signal_limit=status_module.STATUS_CONTRACT_SIGNAL_LIMIT,
+    )
+
+
+def main() -> None:
+    assert status_module.build_status_contract() == direct_status_contract()
+
+    signals = [" first ", "", None, "second", "third"]
+    assert status_module._compact_status_contract_signals(signals, limit=2) == direct_compact_signals(
+        signals,
+        limit=2,
+    )
+    assert status_module._compact_status_contract_signals(signals, limit=0) == {
+        "items": [],
+        "total_count": 4,
+        "truncated": True,
+    }
+
+    contract = {
+        "summary": {"errors": 3, "warnings": 2, "checks": 5},
+        "errors": ["error-a", "error-b", "error-c"],
+        "warnings": ["warning-a", "warning-b"],
+    }
+    assert status_module.build_contract_health_projection(contract) == direct_contract_health(contract)
+
+    empty_contract = {"summary": {"errors": 0, "warnings": 0, "checks": 1}}
+    assert status_module.build_contract_health_projection(empty_contract) == direct_contract_health(empty_contract)
+
+    print("status-contract-readmodel-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/projections/status_contract.py
+++ b/loopx/projections/status_contract.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def build_status_contract(
+    *,
+    schema_version: int,
+    minimum_dashboard_schema_version: int,
+    reload_hint: str,
+) -> dict[str, Any]:
+    return {
+        "schema_version": schema_version,
+        "minimum_dashboard_schema_version": minimum_dashboard_schema_version,
+        "producer": "loopx status",
+        "reload_hint": reload_hint,
+    }
+
+
+def compact_status_contract_signals(
+    value: Any,
+    *,
+    limit: int,
+) -> dict[str, Any]:
+    items = [str(item).strip() for item in value or [] if str(item).strip()]
+    bounded = items[: max(0, limit)]
+    return {
+        "items": bounded,
+        "total_count": len(items),
+        "truncated": len(items) > len(bounded),
+    }
+
+
+def build_contract_health_projection(
+    contract: dict[str, Any],
+    *,
+    signal_limit: int,
+) -> dict[str, Any]:
+    errors = compact_status_contract_signals(contract.get("errors"), limit=signal_limit)
+    warnings = compact_status_contract_signals(contract.get("warnings"), limit=signal_limit)
+    return {
+        "contract_summary": contract.get("summary"),
+        "contract_errors": errors["items"],
+        "contract_errors_total_count": errors["total_count"],
+        "contract_errors_truncated": errors["truncated"],
+        "contract_warnings": warnings["items"],
+        "contract_warnings_total_count": warnings["total_count"],
+        "contract_warnings_truncated": warnings["truncated"],
+    }

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -187,6 +187,11 @@ from .projections.subagent_activity import (
 from .projections.stale_latest_run import (
     active_state_projection_warning as _active_state_projection_warning_read_model,
 )
+from .projections.status_contract import (
+    build_contract_health_projection as _build_contract_health_projection_read_model,
+    build_status_contract as _build_status_contract_read_model,
+    compact_status_contract_signals as _compact_status_contract_signals_read_model,
+)
 from .projections.todo_summary import (
     active_state_todo_attention_item as _active_state_todo_attention_item_read_model,
     active_next_action_todo_ids,
@@ -7902,12 +7907,11 @@ def build_promotion_readiness_summary(
 
 
 def build_status_contract() -> dict[str, Any]:
-    return {
-        "schema_version": STATUS_CONTRACT_SCHEMA_VERSION,
-        "minimum_dashboard_schema_version": MINIMUM_DASHBOARD_STATUS_CONTRACT_SCHEMA_VERSION,
-        "producer": "loopx status",
-        "reload_hint": STATUS_CONTRACT_RELOAD_HINT,
-    }
+    return _build_status_contract_read_model(
+        schema_version=STATUS_CONTRACT_SCHEMA_VERSION,
+        minimum_dashboard_schema_version=MINIMUM_DASHBOARD_STATUS_CONTRACT_SCHEMA_VERSION,
+        reload_hint=STATUS_CONTRACT_RELOAD_HINT,
+    )
 
 
 def _compact_status_contract_signals(
@@ -7915,27 +7919,14 @@ def _compact_status_contract_signals(
     *,
     limit: int = STATUS_CONTRACT_SIGNAL_LIMIT,
 ) -> dict[str, Any]:
-    items = [str(item).strip() for item in value or [] if str(item).strip()]
-    bounded = items[: max(0, limit)]
-    return {
-        "items": bounded,
-        "total_count": len(items),
-        "truncated": len(items) > len(bounded),
-    }
+    return _compact_status_contract_signals_read_model(value, limit=limit)
 
 
 def build_contract_health_projection(contract: dict[str, Any]) -> dict[str, Any]:
-    errors = _compact_status_contract_signals(contract.get("errors"))
-    warnings = _compact_status_contract_signals(contract.get("warnings"))
-    return {
-        "contract_summary": contract.get("summary"),
-        "contract_errors": errors["items"],
-        "contract_errors_total_count": errors["total_count"],
-        "contract_errors_truncated": errors["truncated"],
-        "contract_warnings": warnings["items"],
-        "contract_warnings_total_count": warnings["total_count"],
-        "contract_warnings_truncated": warnings["truncated"],
-    }
+    return _build_contract_health_projection_read_model(
+        contract,
+        signal_limit=STATUS_CONTRACT_SIGNAL_LIMIT,
+    )
 
 
 def decision_event_kinds(run: dict[str, Any]) -> list[str]:


### PR DESCRIPTION
## Summary
- extract status contract projection helpers from status.py into loopx.projections.status_contract
- keep status.py as thin wrappers for the public status contract and contract-health projection
- add status-contract wrapper/direct parity smoke

## Validation
- python3 -m compileall -q loopx/status.py loopx/projections/status_contract.py examples/control_plane/status-contract-readmodel-smoke.py
- python3 examples/control_plane/status-contract-readmodel-smoke.py
- python3 examples/control_plane/status-markdown-smoke.py
- python3 examples/control_plane/status-projection-cache-smoke.py
- python3 examples/control_plane/status-quota-review-packet-parity-smoke.py
- git diff --check
- public/private boundary scan on touched files

## Canary note
- python3 -m loopx.cli canary smoke-suite --profile core-control-plane ran 139 checks: 138 passed, 1 inherited failure in repo-python-line-budget-smoke. The failing paths were benchmark files changed by current origin/main (#1301): examples/skillsbench-app-server-goal-worker-smoke.py, examples/skillsbench-benchmark-run-smoke.py, examples/terminal-bench-private-runner-env-guard-smoke.py, loopx/benchmark_adapters/terminal_bench.py, and scripts/skillsbench_automation_loop.py. This PR does not touch those paths and reduces status.py line count.