### PR TITLE
Extract active state metadata read model

### DIFF
--- a/examples/control_plane/active-state-metadata-readmodel-smoke.py
+++ b/examples/control_plane/active-state-metadata-readmodel-smoke.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Smoke-test active-state metadata read-model parity."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx import status as status_module  # noqa: E402
+from loopx.projections import active_state_metadata as metadata_read_model  # noqa: E402
+
+
+def main() -> None:
+    state_text = """---
+updated_at: "2026-07-04T10:00:00+08:00"
+owner: codex
+malformed
+---
+
+## Agent Todo
+- [ ] keep working
+"""
+    assert status_module.parse_state_frontmatter(state_text) == metadata_read_model.parse_state_frontmatter(
+        state_text
+    )
+    assert status_module.parse_state_frontmatter("no frontmatter") == {}
+    assert status_module.parse_state_frontmatter("---\nmissing close") == {}
+
+    headings = {
+        "User Todo / Owner Review Reading Queue": "user",
+        "Project Agent Todo": "agent",
+        "Completed Work Archive": None,
+        "普通章节": None,
+    }
+    for heading, expected in headings.items():
+        assert status_module.todo_role_for_heading(heading) == expected, heading
+        assert metadata_read_model.todo_role_for_heading(heading) == expected, heading
+
+    print("active-state-metadata-readmodel-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/projections/active_state_metadata.py
+++ b/loopx/projections/active_state_metadata.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+
+USER_TODO_HEADER_MARKERS = (
+    "user todo",
+    "owner review reading queue",
+    "owner reading queue",
+)
+AGENT_TODO_HEADER_MARKERS = (
+    "agent todo",
+    "codex todo",
+    "project agent todo",
+)
+TODO_ARCHIVE_HEADER_MARKERS = (
+    "todo archive",
+    "work archive",
+    "completed archive",
+    "completed work",
+    "完成归档",
+    "待办归档",
+)
+
+
+def parse_state_frontmatter(state_text: str) -> dict[str, str]:
+    if not state_text.startswith("---"):
+        return {}
+    parts = state_text.split("---", 2)
+    if len(parts) < 3:
+        return {}
+    result: dict[str, str] = {}
+    for line in parts[1].splitlines():
+        if ":" not in line:
+            continue
+        key, value = line.split(":", 1)
+        result[key.strip()] = value.strip().strip('"')
+    return result
+
+
+def todo_role_for_heading(heading: str) -> str | None:
+    normalized = heading.strip().lower()
+    if any(marker in normalized for marker in TODO_ARCHIVE_HEADER_MARKERS):
+        return None
+    if any(marker in normalized for marker in USER_TODO_HEADER_MARKERS):
+        return "user"
+    if any(marker in normalized for marker in AGENT_TODO_HEADER_MARKERS):
+        return "agent"
+    return None

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -91,6 +91,13 @@ from .projections.active_state_sections import (
     active_state_section_entries as _active_state_section_entries_read_model,
     active_state_sections as _active_state_sections_read_model,
 )
+from .projections.active_state_metadata import (
+    AGENT_TODO_HEADER_MARKERS,
+    TODO_ARCHIVE_HEADER_MARKERS,
+    USER_TODO_HEADER_MARKERS,
+    parse_state_frontmatter as _parse_state_frontmatter_read_model,
+    todo_role_for_heading as _todo_role_for_heading_read_model,
+)
 from .projections.active_state_todos import (
     active_state_todo_fields as _active_state_todo_fields_read_model,
 )
@@ -510,16 +517,6 @@ LIFECYCLE_PRIORITY = (
     "run_recorded",
 )
 SECTION_HEADING_PATTERN = re.compile(r"^##+\s+(.+?)\s*$")
-USER_TODO_HEADER_MARKERS = (
-    "user todo",
-    "owner review reading queue",
-    "owner reading queue",
-)
-AGENT_TODO_HEADER_MARKERS = (
-    "agent todo",
-    "codex todo",
-    "project agent todo",
-)
 MAX_STATUS_TODOS_PER_ROLE = 12
 MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE = MAX_STATUS_TODOS_PER_ROLE
 MAX_PROJECT_ASSET_TODO_ITEMS = 3
@@ -587,14 +584,6 @@ AUTONOMOUS_RUN_HISTORY_NEUTRAL_CLASSIFICATIONS = {
 }
 AUTONOMOUS_RUN_HISTORY_STALL_PATTERN = re.compile(
     r"(?i)(?:monitor|observe|observation|poll|watch|quiet|no[-_ ]?op|no[-_ ]?progress|stalled?|unchanged|dependency|停转|无进展|重复|反复|观察|轮询)"
-)
-TODO_ARCHIVE_HEADER_MARKERS = (
-    "todo archive",
-    "work archive",
-    "completed archive",
-    "completed work",
-    "完成归档",
-    "待办归档",
 )
 def public_safe_compact_text(value: Any, *, limit: int = 220) -> str | None:
     text = normalize_todo_text(str(value or ""), limit=limit)
@@ -5818,29 +5807,11 @@ def compact_active_user_assisted_pilot(run: dict[str, Any]) -> dict[str, Any] | 
 
 
 def parse_state_frontmatter(state_text: str) -> dict[str, str]:
-    if not state_text.startswith("---"):
-        return {}
-    parts = state_text.split("---", 2)
-    if len(parts) < 3:
-        return {}
-    result: dict[str, str] = {}
-    for line in parts[1].splitlines():
-        if ":" not in line:
-            continue
-        key, value = line.split(":", 1)
-        result[key.strip()] = value.strip().strip('"')
-    return result
+    return _parse_state_frontmatter_read_model(state_text)
 
 
 def todo_role_for_heading(heading: str) -> str | None:
-    normalized = heading.strip().lower()
-    if any(marker in normalized for marker in TODO_ARCHIVE_HEADER_MARKERS):
-        return None
-    if any(marker in normalized for marker in USER_TODO_HEADER_MARKERS):
-        return "user"
-    if any(marker in normalized for marker in AGENT_TODO_HEADER_MARKERS):
-        return "agent"
-    return None
+    return _todo_role_for_heading_read_model(heading)
 
 
 def todo_item_is_expired_monitor(item: dict[str, Any], *, now: datetime | None = None) -> bool:

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -14,6 +14,7 @@ from .file_lock import exclusive_file_lock
 from .history import load_registry
 from .local_state_write_correctness import build_todo_write_correctness_dry_run_packet
 from .state_refresh import now_local, resolve_goal_state
+from .projections.active_state_metadata import todo_role_for_heading
 from .status import (
     MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE,
     active_state_event_projection_fields,
@@ -21,7 +22,6 @@ from .status import (
     normalize_todo_text,
     parse_active_state_todos,
     parse_timestamp,
-    todo_role_for_heading,
 )
 from .todo_contract import (
     TODO_MONITOR_METADATA_FIELDS,


### PR DESCRIPTION
## Summary
- extract active-state frontmatter and todo-heading role parsing into `loopx.projections.active_state_metadata`
- keep `status.py` wrapper functions for compatibility while reducing status.py parsing logic
- point `todos.py` at the extracted heading helper and add wrapper/direct parity smoke

## Validation
- python3 -m compileall -q loopx/status.py loopx/todos.py loopx/projections/active_state_metadata.py examples/control_plane/active-state-metadata-readmodel-smoke.py
- python3 examples/control_plane/active-state-metadata-readmodel-smoke.py
- python3 examples/control_plane/active-state-section-readmodel-smoke.py
- python3 examples/control_plane/todo-cli-smoke.py
- python3 examples/control_plane/todo-readmodel-boundary-smoke.py
- python3 examples/control_plane/status-markdown-smoke.py
- python3 examples/control_plane/status-projection-cache-smoke.py
- python3 examples/control_plane/status-quota-review-packet-parity-smoke.py
- python3 examples/control_plane/work-lane-contract-smoke.py
- python3 examples/control_plane/todo-write-correctness-smoke.py
- git diff --check
- public/private boundary scan on touched files

## Canary note
- Full `core-control-plane` remains known-red from current main due inherited `repo-python-line-budget-smoke` failures in benchmark files introduced before this PR. This PR does not touch those paths and reduces status.py line count.