### PR TITLE
Refine line budget pins after overnight review

### DIFF
--- a/examples/control_plane/repo-python-line-budget-smoke.py
+++ b/examples/control_plane/repo-python-line-budget-smoke.py
@@ -14,6 +14,10 @@ DEFAULT_MAX_LINES = 2000
 # smoke fails, first split ownership or extract a module; only raise a legacy
 # budget with an explicit follow-up plan for retiring that whitelist entry.
 LEGACY_OVERSIZED_RETIREMENT_PLANS = {
+    "examples/skillsbench-app-server-goal-worker-smoke.py": (
+        "Split native app-server Goal lifecycle fixtures into focused launch, "
+        "resume, and closeout smokes, then lower this pin again."
+    ),
     "examples/skillsbench-benchmark-run-smoke.py": (
         "Extract SkillsBench ledger/reduce-only fixture groups into narrower "
         "smokes, then lower this pin again after the next stable split."
@@ -27,6 +31,11 @@ LEGACY_OVERSIZED_RETIREMENT_PLANS = {
         "Continue extracting SkillsBench discovery, counter, and reducer helpers "
         "into focused adapter modules, then lower this pin again."
     ),
+    "loopx/benchmark_adapters/terminal_bench.py": (
+        "Continue extracting TerminalBench runner setup, private-source guards, "
+        "and route attribution helpers into focused adapter modules, then lower "
+        "this pin again."
+    ),
     "scripts/skillsbench_automation_loop.py": (
         "Extract native app-server Goal/reduce-only closeout helpers into "
         "scripts or benchmark adapter modules, then lower this pin again."
@@ -36,19 +45,19 @@ LEGACY_OVERSIZED_RETIREMENT_PLANS = {
 LEGACY_OVERSIZED_LIMITS = {
     "examples/benchmark-run-ledger-smoke.py": 2106,
     "examples/control_plane/quota-plan-smoke.py": 2176,
-    "examples/skillsbench-app-server-goal-worker-smoke.py": 3056,
-    "examples/skillsbench-benchmark-run-smoke.py": 14430,
+    "examples/skillsbench-app-server-goal-worker-smoke.py": 3075,
+    "examples/skillsbench-benchmark-run-smoke.py": 14593,
     "examples/skillsbench-host-local-launch-plan-smoke.py": 2373,
     "examples/control_plane/status-markdown-smoke.py": 2607,
     "examples/terminal-bench-harbor-runner-ingest-smoke.py": 2759,
-    "examples/terminal-bench-private-runner-env-guard-smoke.py": 2586,
+    "examples/terminal-bench-private-runner-env-guard-smoke.py": 2619,
     "loopx/benchmark.py": 2875,
     "loopx/benchmark_adapters/agentissue.py": 2644,
     "loopx/benchmark_adapters/agents_last_exam.py": 3998,
-    "loopx/benchmark_adapters/skillsbench.py": 5817,
+    "loopx/benchmark_adapters/skillsbench.py": 5934,
     "examples/control_plane/work-lane-contract-smoke.py": 2336,
     "loopx/benchmark_adapters/skillsbench_acp_relay.py": 3144,
-    "loopx/benchmark_adapters/terminal_bench.py": 10045,
+    "loopx/benchmark_adapters/terminal_bench.py": 10083,
     "loopx/benchmark_ledger.py": 3745,
     "loopx/capabilities/content_ops/surface.py": 2549,
     "loopx/capabilities/lark/kanban.py": 3034,
@@ -58,7 +67,16 @@ LEGACY_OVERSIZED_LIMITS = {
     "loopx/terminal_bench_agent.py": 2056,
     "loopx/todos.py": 2105,
     "scripts/harbor_host_codex_goal_agent.py": 2140,
-    "scripts/skillsbench_automation_loop.py": 16682,
+    "scripts/skillsbench_automation_loop.py": 16900,
+}
+
+RETIREMENT_PLAN_REQUIRED_PATHS = {
+    "examples/skillsbench-app-server-goal-worker-smoke.py",
+    "examples/skillsbench-benchmark-run-smoke.py",
+    "examples/terminal-bench-private-runner-env-guard-smoke.py",
+    "loopx/benchmark_adapters/skillsbench.py",
+    "loopx/benchmark_adapters/terminal_bench.py",
+    "scripts/skillsbench_automation_loop.py",
 }
 
 
@@ -97,11 +115,7 @@ def main() -> None:
         path
         for path, limit in LEGACY_OVERSIZED_LIMITS.items()
         if limit > DEFAULT_MAX_LINES
-        and path in {
-            "examples/skillsbench-benchmark-run-smoke.py",
-            "loopx/benchmark_adapters/skillsbench.py",
-            "scripts/skillsbench_automation_loop.py",
-        }
+        and path in RETIREMENT_PLAN_REQUIRED_PATHS
         and not LEGACY_OVERSIZED_RETIREMENT_PLANS.get(path)
     )
     require(


### PR DESCRIPTION
## Summary
- reviewed the July 4 early-morning control-plane/read-model merge window and reran the core-control-plane smoke profile
- synchronized current legacy line-budget pins for oversized benchmark/SkillsBench files that grew during the overnight benchmark fixes
- added missing retirement plans for app-server Goal smoke and TerminalBench adapter, and made the plan-required path set explicit

## Review finding
The read-model extraction surface stayed behaviorally green under the core-control-plane profile. The concrete regression was that main had a red line-budget smoke after the benchmark-specific changes; this PR restores the guard without changing benchmark runtime behavior.

## Validation
- python3 -m compileall -q loopx examples scripts
- python3 examples/control_plane/repo-python-line-budget-smoke.py
- PYTHONPATH=. python3 -m loopx.cli canary smoke-suite --profile core-control-plane --timeout-seconds 45 --format json --no-progress  # 140/140 passed
- git diff --check
- public/private boundary scan on changed file