### PR TITLE
Support live auto-research pane bootstrap

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -309,6 +309,7 @@ def main() -> int:
             codex_bin="codex",
             tmux_bin="tmux",
             reasoning_effort="medium",
+            output_language="en",
             live_evidence_path=None,
             append_evidence=lambda _path: {"ok": True},
             visible_launcher=visible_launcher,

--- a/examples/auto-research-demo-supervisor-smoke.py
+++ b/examples/auto-research-demo-supervisor-smoke.py
@@ -185,6 +185,8 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
         ), profile
         assert profile["default_kernel_skills_owner"] == "generic_multi_agent_kernel", profile
         assert profile["fixed_a2a_wake_prompt_owner"] == "generic_multi_agent_kernel", profile
+        assert profile["output_language"] in {"en", "zh"}, profile
+        assert lane["output_language"] == profile["output_language"], lane
         assert profile["worker_skill_source"].endswith("auto_research/worker_skill/SKILL.md"), profile
         assert expected_action_hints[lane["role_id"]] in profile["allowed_actions"], profile
         assert profile["write_scope"], profile
@@ -218,11 +220,15 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
 
         command = lane["visible_launch_command"]
         assert "LOOPX_PANE_A2A_TICK" in command, lane
+        assert "LOOPX_PANE_BOOTSTRAP_PROMPT" in command, lane
+        assert "LOOPX_ROLE_PROFILE_ARTIFACT" in command, lane
         assert "LOOPX_PANE_WORKER_TURN" in command, lane
         assert "LOOPX_PANE_TICK_ROUNDS=3" in command, lane
         assert "LOOPX_PANE_TICK_SLEEP_SECONDS=3" in command, lane
         assert "pane-a2a-tick.output.txt" in command, lane
         assert "auto-research worker-turn" in command, lane
+        assert "LOOPX_AUTO_RESEARCH_OUTPUT_LANGUAGE" in command, lane
+        assert "LOOPX_PANE_LOOPX_JSON" in command, lane
         assert "--visible-lanes-accepted" in command, lane
         assert "LOOPX_VISIBLE_LANE_COUNT" in command, lane
         assert "live-codex-e2e-evidence.public.json" in command, lane
@@ -335,7 +341,9 @@ def main() -> int:
     payload = build_auto_research_demo_supervisor_plan(
         goal_id=GOAL_ID,
         agent_specs=LANES,
+        output_language="zh",
     )
+    assert payload["auto_research"]["output_language"] == "zh", payload
     assert_supervisor_contract(payload)
 
     try:

--- a/examples/auto-research-knn-continuation-smoke.py
+++ b/examples/auto-research-knn-continuation-smoke.py
@@ -45,6 +45,7 @@ def main() -> int:
             codex_bin="codex",
             tmux_bin="tmux",
             reasoning_effort="high",
+            output_language="en",
             live_evidence_path=None,
             append_evidence=lambda _packet: {},
         )

--- a/examples/auto-research-user-contract-entry-smoke.py
+++ b/examples/auto-research-user-contract-entry-smoke.py
@@ -19,6 +19,7 @@ if str(REPO_ROOT) not in sys.path:
 from loopx.capabilities.auto_research.user_contract import (  # noqa: E402
     AUTO_RESEARCH_USER_CONTRACT_SCHEMA_VERSION,
     build_auto_research_user_contract,
+    infer_auto_research_output_language,
 )
 from loopx.capabilities.auto_research.cli import (  # noqa: E402
     _default_auto_research_start_workspace,
@@ -55,6 +56,7 @@ def assert_contract(payload: dict[str, Any]) -> None:
     assert payload["mode"] == "user_contract", payload
     assert payload["product_id"] == "auto-research", payload
     assert payload["open_question"] == QUESTION, payload
+    assert payload["output_language"]["resolved"] in {"en", "zh"}, payload
 
     layering = payload["layering"]
     assert layering["user_layer"] == "one open question", layering
@@ -69,6 +71,7 @@ def assert_contract(payload: dict[str, Any]) -> None:
         == 'loopx auto-research start "<open question>" --execute'
     )
     assert command_contract["user_required_inputs"] == ["open_question"], command_contract
+    assert command_contract["user_optional_inputs"] == ["output_language"], command_contract
     assert command_contract["max_action_plan_todos"] == 5, command_contract
     assert command_contract["auto_research_required_outputs"] == [
         "research_brief",
@@ -294,6 +297,12 @@ def assert_start_wake_contract() -> None:
 def main() -> None:
     payload = build_auto_research_user_contract(QUESTION)
     assert_contract(payload)
+    assert infer_auto_research_output_language("如何评估 multi-agent auto research 是否有收益?") == "zh"
+    zh_payload = build_auto_research_user_contract(
+        "如何评估 multi-agent auto research 是否有收益?"
+    )
+    assert zh_payload["output_language"]["resolved"] == "zh", zh_payload
+    assert " --language zh --execute" in zh_payload["one_click_start"]["command"], zh_payload
     assert_start_wake_contract()
     default_workspace = Path(
         _default_auto_research_start_workspace("loopx-auto-research-demo-smoke")

--- a/examples/auto-research-worker-turn-smoke.py
+++ b/examples/auto-research-worker-turn-smoke.py
@@ -235,6 +235,7 @@ def main() -> int:
             codex_bin="codex",
             tmux_bin="tmux",
             reasoning_effort="high",
+            output_language="en",
             live_evidence_path=None,
             append_evidence=fake_append_evidence,
             visible_launcher=fake_visible_launcher,
@@ -409,6 +410,17 @@ def main() -> int:
             complete=True,
         )
         assert cleanup["mode"] == "execute", cleanup
+        if cleanup["selected_action"] == "write_evaluation_summary":
+            assert cleanup["artifact_status"] == "evaluation_summary_written", cleanup
+            assert cleanup["claim_allowed"] is True, cleanup
+            cleanup = run_worker_turn(
+                registry=four_registry,
+                runtime_root=four_runtime_root,
+                workspace=four_workspace,
+                agent_id=VERIFIER_AGENT_ID,
+                execute=True,
+                complete=True,
+            )
         assert cleanup["selected_action"] == "advance_todo", cleanup
         assert cleanup["artifact_status"] == "satisfied_generic_handoff_closed", cleanup
         assert cleanup["completion"]["status"] == "done", cleanup

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -110,6 +110,12 @@ def main() -> int:
     assert "LOOPX_PANE_TICK_ROUNDS" in launcher_source
     assert "LOOPX_PANE_TICK_SUMMARY" in launcher_source
     assert "LOOPX_PANE_TICK_OUTPUT_ARTIFACT" in launcher_source
+    assert "LOOPX_PANE_BOOTSTRAP_PROMPT" in launcher_source
+    assert "loopx-build-codex-bootstrap-prompt" in runtime_source
+    assert "LoopX Agent Bootstrap Context" in runtime_source
+    assert "selected_todo_id" in runtime_source
+    assert "claim_allowed_rule" in runtime_source
+    assert "Honor the role prompt's human output language" in contract_source
     assert "The launcher runs `$LOOPX_PANE_A2A_TICK` before this Codex TUI opens." in contract_source
     assert "Treat `$LOOPX_PANE_TICK_SUMMARY` as previous evidence" in contract_source
     assert "not a gate that cancels later fixed wakes" in contract_source
@@ -599,6 +605,8 @@ def main() -> int:
                 capture_output=True,
                 text=True,
             )
+            prompt_artifact = temp / "bootstrap.prompt.txt"
+            prompt_artifact.write_text("planner prompt", encoding="utf-8")
             subprocess.run(
                 [sys.executable, "-c", _CODEX_TUI_EXEC_PY],
                 env={
@@ -606,7 +614,7 @@ def main() -> int:
                     "LOOPX_CODEX_BIN": str(fake_bin / "codex"),
                     "LOOPX_PROJECT": str(git_root_workspace),
                     "LOOPX_CODEX_REASONING_EFFORT": "high",
-                    "BOOTSTRAP_PROMPT": "planner prompt",
+                    "LOOPX_CODEX_TUI_PROMPT_ARTIFACT": str(prompt_artifact),
                     "LOOPX_CODEX_TRUST_WORKSPACE": "1",
                 },
                 check=True,
@@ -615,8 +623,7 @@ def main() -> int:
             )
             codex_args = json.loads(codex_argv_log.read_text(encoding="utf-8"))
             assert "-C" in codex_args and str(git_root_workspace) in codex_args, codex_args
-            assert "planner prompt" not in codex_args, codex_args
-            assert codex_args[-1] == str(git_root_workspace), codex_args
+            assert codex_args[-1] == "planner prompt", codex_args
             trust_args = [
                 item
                 for index, item in enumerate(codex_args)

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -29,7 +29,10 @@ from .worker_runtime import run_auto_research_worker_turn
 from .rollout_append import (
     append_auto_research_rollout_events as _append_auto_research_rollout_events,
 )
-from .user_contract import build_auto_research_user_contract
+from .user_contract import (
+    build_auto_research_user_contract,
+    infer_auto_research_output_language,
+)
 from ...history import load_registry
 from ...paths import resolve_runtime_root
 from ...quota import build_quota_should_run
@@ -194,6 +197,12 @@ def register_auto_research_commands(
         default=5,
         help="Maximum action-plan todos, capped at 5.",
     )
+    contract_parser.add_argument(
+        "--language",
+        choices=["auto", "zh", "en"],
+        default="auto",
+        help="Human-readable output language for the research process.",
+    )
 
     start_parser = auto_research_sub.add_parser(
         "start",
@@ -201,6 +210,12 @@ def register_auto_research_commands(
     )
     add_subcommand_format(start_parser)
     start_parser.add_argument("open_question", help="Quoted open research question.")
+    start_parser.add_argument(
+        "--language",
+        choices=["auto", "zh", "en"],
+        default="auto",
+        help="Human-readable output language for visible role panes.",
+    )
     start_parser.add_argument(
         "--execute",
         action="store_true",
@@ -568,6 +583,12 @@ def register_auto_research_commands(
         help="Reasoning effort passed to visible Codex lanes through model_reasoning_effort.",
     )
     demo_supervisor_parser.add_argument(
+        "--language",
+        choices=["auto", "zh", "en"],
+        default="auto",
+        help="Human-readable output language for visible role panes.",
+    )
+    demo_supervisor_parser.add_argument(
         "--execute",
         action="store_true",
         help=(
@@ -659,6 +680,12 @@ def register_auto_research_commands(
         "--objective",
         default=AUTO_RESEARCH_DEFAULT_OBJECTIVE,
         help="Compact public-safe research objective for the generated contract.",
+    )
+    demo_e2e_parser.add_argument(
+        "--language",
+        choices=["auto", "zh", "en"],
+        default="auto",
+        help="Human-readable output language for visible role panes.",
     )
     demo_e2e_parser.add_argument(
         "--output-dir",
@@ -862,6 +889,7 @@ def handle_auto_research_command(
             payload = build_auto_research_user_contract(
                 args.open_question,
                 max_todos=args.max_todos,
+                output_language=args.language,
             )
         elif args.auto_research_command == "start":
             if args.no_attach and args.attach:
@@ -876,6 +904,10 @@ def handle_auto_research_command(
                 goal_id=args.goal_id,
                 demo_run_id=args.demo_run_id,
                 inherit_default_goal=False,
+            )
+            output_language = infer_auto_research_output_language(
+                args.open_question,
+                output_language=args.language,
             )
 
             def append_start_evidence(packet_path: str) -> dict[str, object]:
@@ -951,6 +983,7 @@ def handle_auto_research_command(
                 codex_bin=args.codex_bin,
                 tmux_bin=args.tmux_bin,
                 reasoning_effort=args.reasoning_effort,
+                output_language=output_language,
                 live_evidence_path=None,
                 append_evidence=append_start_evidence,
                 visible_launcher=visible_launcher,
@@ -1099,6 +1132,10 @@ def handle_auto_research_command(
                 codex_bin=args.codex_bin,
                 tmux_bin=args.tmux_bin,
                 reasoning_effort=args.reasoning_effort,
+                output_language=infer_auto_research_output_language(
+                    "",
+                    output_language=args.language,
+                ),
             )
             payload["goal_surface_route"] = {
                 "schema_version": "auto_research_demo_goal_surface_v0",
@@ -1218,6 +1255,10 @@ def handle_auto_research_command(
                 codex_bin=args.codex_bin,
                 tmux_bin=args.tmux_bin,
                 reasoning_effort=args.reasoning_effort,
+                output_language=infer_auto_research_output_language(
+                    args.objective,
+                    output_language=args.language,
+                ),
                 live_evidence_path=args.live_evidence,
                 append_evidence=append_demo_e2e_evidence,
                 visible_launcher=visible_launcher,

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -230,6 +230,7 @@ def _command_text(
     live_evidence: bool = False,
     wake_visible_after_launch: bool = False,
     tracking_goal_id: str | None = None,
+    output_language: str = "en",
 ) -> str:
     parts = [
         shlex.quote(cli_bin),
@@ -244,6 +245,8 @@ def _command_text(
     ]
     if tracking_goal_id:
         parts.extend(["--tracking-goal-id", shlex.quote(tracking_goal_id)])
+    if output_language and output_language != "en":
+        parts.extend(["--language", shlex.quote(output_language)])
     if execute:
         parts.append("--execute")
     if run_worker_loop:
@@ -275,6 +278,7 @@ def _start_command_text(
     headless: bool = False,
     no_attach: bool = False,
     wake_visible_after_launch: bool = False,
+    output_language: str = "en",
 ) -> str:
     parts = [
         shlex.quote(cli_bin),
@@ -284,6 +288,8 @@ def _start_command_text(
     ]
     if execute:
         parts.append("--execute")
+    if output_language and output_language != "en":
+        parts.extend(["--language", shlex.quote(output_language)])
     if headless:
         parts.append("--headless")
     if no_attach:
@@ -863,6 +869,7 @@ def run_auto_research_demo_e2e(
     codex_bin: str,
     tmux_bin: str,
     reasoning_effort: str,
+    output_language: str,
     live_evidence_path: str | None,
     append_evidence: AppendEvidence,
     visible_launcher: VisibleLauncher | None = None,
@@ -896,7 +903,10 @@ def run_auto_research_demo_e2e(
     effective_agent_specs = list(agent_specs or [])
     if (run_worker_loop or launch_visible) and not effective_agent_specs:
         effective_agent_specs = default_auto_research_agent_specs()
-    user_contract = build_auto_research_user_contract(objective)
+    user_contract = build_auto_research_user_contract(
+        objective,
+        output_language=output_language,
+    )
     contract_acceptance = _contract_acceptance(user_contract)
     supervisor = build_auto_research_demo_supervisor_plan(
         goal_id=goal_id,
@@ -906,6 +916,7 @@ def run_auto_research_demo_e2e(
         codex_bin=codex_bin,
         tmux_bin=tmux_bin,
         reasoning_effort=reasoning_effort,
+        output_language=output_language,
     )
     execution_kind = (
         "loopx_worker_loop"
@@ -950,6 +961,7 @@ def run_auto_research_demo_e2e(
         },
         "agent_id": agent_id,
         "reasoning_effort": reasoning_effort,
+        "output_language": output_language,
         "user_contract": user_contract,
         "contract_acceptance": contract_acceptance,
         "commands": {
@@ -961,15 +973,18 @@ def run_auto_research_demo_e2e(
                 cli_bin=cli_bin,
                 objective=objective,
                 execute=True,
+                output_language=output_language,
             ),
             "one_question_start_preview": _start_command_text(
                 cli_bin=cli_bin,
                 objective=objective,
+                output_language=output_language,
             ),
             "one_question_start_with_visible_wake": _start_command_text(
                 cli_bin=cli_bin,
                 objective=objective,
                 execute=True,
+                output_language=output_language,
             ),
             "one_command_worker_loop": _command_text(
                 cli_bin=cli_bin,
@@ -978,6 +993,7 @@ def run_auto_research_demo_e2e(
                 execute=True,
                 run_worker_loop=True,
                 tracking_goal_id=tracking_goal or None,
+                output_language=output_language,
             ),
             "headless_worker_loop": _command_text(
                 cli_bin=cli_bin,
@@ -987,6 +1003,7 @@ def run_auto_research_demo_e2e(
                 run_worker_loop=True,
                 headless=True,
                 tracking_goal_id=tracking_goal or None,
+                output_language=output_language,
             ),
             "start_visible_lanes_without_attach": _command_text(
                 cli_bin=cli_bin,
@@ -996,6 +1013,7 @@ def run_auto_research_demo_e2e(
                 launch_visible=True,
                 no_attach=True,
                 tracking_goal_id=tracking_goal or None,
+                output_language=output_language,
             ),
             "one_command_visible_wake_demo": _command_text(
                 cli_bin=cli_bin,
@@ -1006,6 +1024,7 @@ def run_auto_research_demo_e2e(
                 no_attach=True,
                 wake_visible_after_launch=True,
                 tracking_goal_id=tracking_goal or None,
+                output_language=output_language,
             ),
             "one_command_worker_loop_with_visible_lanes": _command_text(
                 cli_bin=cli_bin,
@@ -1016,6 +1035,7 @@ def run_auto_research_demo_e2e(
                 launch_visible=True,
                 attach=True,
                 tracking_goal_id=tracking_goal or None,
+                output_language=output_language,
             ),
             "load_live_worker_evidence": _command_text(
                 cli_bin=cli_bin,
@@ -1024,6 +1044,7 @@ def run_auto_research_demo_e2e(
                 execute=True,
                 live_evidence=True,
                 tracking_goal_id=tracking_goal or None,
+                output_language=output_language,
             ),
             "wake_visible_lanes": (
                 f"{shlex.quote(cli_bin)} --format json multi-agent wake --session-name "

--- a/loopx/capabilities/auto_research/demo_supervisor.py
+++ b/loopx/capabilities/auto_research/demo_supervisor.py
@@ -27,6 +27,7 @@ def build_auto_research_demo_supervisor_plan(
     codex_bin: str = "codex",
     tmux_bin: str = "tmux",
     reasoning_effort: str = "high",
+    output_language: str = "en",
 ) -> dict[str, Any]:
     """Build the auto-research visible TUI plan from a small role spec.
 
@@ -42,6 +43,7 @@ def build_auto_research_demo_supervisor_plan(
             lane=lane,
             goal_id=goal,
             reasoning_effort=reasoning_effort,
+            output_language=output_language,
         )
         for lane in lanes
     ]
@@ -87,6 +89,7 @@ def build_auto_research_demo_supervisor_plan(
                     "todo_evidence_status_protocol",
                 ],
                 "worker_turn_owner": "generic_multi_agent_kernel",
+                "output_language": output_language,
                 "presentation_layers_in_kernel": False,
             },
             "coordination_model": {

--- a/loopx/capabilities/auto_research/preset.py
+++ b/loopx/capabilities/auto_research/preset.py
@@ -284,9 +284,16 @@ def auto_research_successor_specs_for_action(*, role_id: str, action: str) -> li
     ]
 
 
-def auto_research_worker_turn_command(*, goal_id: str, agent_id: str, objective: str) -> str:
+def auto_research_worker_turn_command(
+    *,
+    goal_id: str,
+    agent_id: str,
+    objective: str,
+    output_language: str = "en",
+) -> str:
     return (
-        "$LOOPX_PANE_LOOPX auto-research worker-turn "
+        f"LOOPX_AUTO_RESEARCH_OUTPUT_LANGUAGE={shlex.quote(output_language)} "
+        '"${LOOPX_PANE_LOOPX_JSON:-$LOOPX_PANE_LOOPX}" auto-research worker-turn '
         f"--goal-id {shlex.quote(goal_id)} "
         f"--agent-id {shlex.quote(agent_id)} "
         f"--objective {shlex.quote(objective)} "
@@ -318,6 +325,7 @@ def build_auto_research_preset_role(
     lane: dict[str, str],
     goal_id: str = AUTO_RESEARCH_DEFAULT_GOAL_ID,
     reasoning_effort: str = "high",
+    output_language: str = "en",
 ) -> dict[str, object]:
     role_id = lane["role_id"]
     agent_id = lane["agent_id"]
@@ -326,12 +334,14 @@ def build_auto_research_preset_role(
         goal_id=goal_id,
         agent_id=agent_id,
     )
+    role_profile["output_language"] = output_language
     return {
         "agent_id": agent_id,
         "lane_id": lane["lane_id"],
         "role_id": role_id,
         "scope": lane["scope"],
         "responsibility": lane["scope"],
+        "output_language": output_language,
         "role_profile_ref": f"{AUTO_RESEARCH_ROLE_PROFILE_SCHEMA_VERSION}:{role_id}",
         "role_profile": role_profile,
         "skill": {
@@ -343,6 +353,7 @@ def build_auto_research_preset_role(
             goal_id=goal_id,
             agent_id=agent_id,
             objective="Run the next bounded auto-research frontier item.",
+            output_language=output_language,
         ),
         "tick_rounds": AUTO_RESEARCH_DEMO_TICK_ROUNDS,
         "tick_sleep_seconds": AUTO_RESEARCH_DEMO_TICK_SLEEP_SECONDS,

--- a/loopx/capabilities/auto_research/user_contract.py
+++ b/loopx/capabilities/auto_research/user_contract.py
@@ -7,15 +7,40 @@ from typing import Any
 AUTO_RESEARCH_USER_CONTRACT_SCHEMA_VERSION = "auto_research_user_contract_v0"
 
 
+def infer_auto_research_output_language(
+    open_question: str,
+    *,
+    output_language: str = "auto",
+) -> str:
+    requested = str(output_language or "auto").strip().lower()
+    if requested in {"zh", "en"}:
+        return requested
+    question = str(open_question or "")
+    return "zh" if any("\u4e00" <= char <= "\u9fff" for char in question) else "en"
+
+
+def _language_flag(question: str, *, output_language: str) -> str:
+    resolved = infer_auto_research_output_language(
+        question,
+        output_language=output_language,
+    )
+    return f" --language {shlex.quote(resolved)}" if resolved != "en" else ""
+
+
 def build_auto_research_user_contract(
     open_question: str,
     *,
     max_todos: int = 5,
+    output_language: str = "auto",
 ) -> dict[str, Any]:
     question = " ".join(str(open_question or "").strip().split())
     if not question:
         raise ValueError('auto-research requires an open question, e.g. loopx auto-research "..."')
     todo_limit = min(max(1, int(max_todos)), 5)
+    resolved_language = infer_auto_research_output_language(
+        question,
+        output_language=output_language,
+    )
     action_plan = [
         {
             "priority": "P0",
@@ -43,7 +68,10 @@ def build_auto_research_user_contract(
             "owner_layer": "auto_research_preset",
         },
     ][:todo_limit]
-    start_command = f"loopx auto-research start {shlex.quote(question)} --execute"
+    language_flag = _language_flag(question, output_language=resolved_language)
+    start_command = (
+        f"loopx auto-research start {shlex.quote(question)}{language_flag} --execute"
+    )
     takeover_command = f"{start_command} --attach"
     return {
         "ok": True,
@@ -51,6 +79,12 @@ def build_auto_research_user_contract(
         "mode": "user_contract",
         "product_id": "auto-research",
         "open_question": question,
+        "output_language": {
+            "requested": str(output_language or "auto"),
+            "resolved": resolved_language,
+            "human_process_language": "Chinese" if resolved_language == "zh" else "English",
+            "machine_schema_language": "English",
+        },
         "layering": {
             "user_layer": "one open question",
             "auto_research_layer": "fixed output contract only",
@@ -61,6 +95,7 @@ def build_auto_research_user_contract(
             "explicit_invocation": 'loopx auto-research contract "<open question>"',
             "one_click_start_invocation": 'loopx auto-research start "<open question>" --execute',
             "user_required_inputs": ["open_question"],
+            "user_optional_inputs": ["output_language"],
             "auto_research_required_outputs": [
                 "research_brief",
                 "action_plan",
@@ -79,7 +114,9 @@ def build_auto_research_user_contract(
             ),
             "operator_takeover_command": takeover_command,
             "preview_command_template": 'loopx auto-research start "<open question>"',
-            "preview_command": f"loopx auto-research start {shlex.quote(question)}",
+            "preview_command": (
+                f"loopx auto-research start {shlex.quote(question)}{language_flag}"
+            ),
             "starts": "visible_codex_tui_lanes",
             "attach_semantics": (
                 "--attach means operator takeover first; it skips the default evidence-first wake."

--- a/loopx/capabilities/multi_agent/contract.py
+++ b/loopx/capabilities/multi_agent/contract.py
@@ -27,6 +27,7 @@ PANE_LOCAL_A2A_WAKEUP_PROMPT = (
     "Use only your own LOOPX_GOAL_ID/LOOPX_AGENT_ID quota/frontier; "
     "if no runnable frontier remains, stay quiet with a brief no-action note; "
     "if advanced, summarize public evidence and next handoff. "
+    "Honor the role prompt's human output language for summaries while keeping machine artifact schema keys unchanged. "
     "Do not ask the broadcaster for direction; LoopX state is the source of truth."
 )
 
@@ -113,6 +114,7 @@ def generic_role_prompt(
     scope: str,
     handoff_hints: list[str],
     skill_name: str | None,
+    output_language: str | None = None,
 ) -> str:
     lines = [
         "LoopX multi-agent role",
@@ -124,6 +126,19 @@ def generic_role_prompt(
         lines.extend(["", "Scope:", scope])
     if skill_name:
         lines.extend(["", "Local skill:", f"Use ${skill_name} when it applies to this role."])
+    if output_language:
+        language_label = "Chinese" if output_language == "zh" else "English"
+        lines.extend(
+            [
+                "",
+                "Human output language:",
+                (
+                    f"- Use {language_label} for human-readable progress, summaries, "
+                    "and blockers in this pane."
+                ),
+                "- Keep LoopX commands, schema keys, todo ids, and artifact filenames unchanged.",
+            ]
+        )
     lines.extend(
         [
             "",
@@ -269,6 +284,7 @@ def build_tui_multi_agent_runner_contract(
             "role_identity": [
                 "LOOPX_ROLE_ID",
                 "LOOPX_ROLE_PROFILE_REF",
+                "LOOPX_ROLE_PROFILE_ARTIFACT",
                 "LOOPX_GOAL_ID",
                 "LOOPX_AGENT_ID",
             ],
@@ -277,6 +293,7 @@ def build_tui_multi_agent_runner_contract(
                 "LOOPX_PANE_LOOPX_JSON",
                 "LOOPX_PANE_ARTIFACT_DIR",
                 "LOOPX_PANE_A2A_TICK",
+                "LOOPX_PANE_BOOTSTRAP_PROMPT",
                 "LOOPX_PANE_TICK_SUMMARY",
                 "LOOPX_PANE_TICK_OUTPUT_ARTIFACT",
                 "LOOPX_PANE_WORKER_TURN",

--- a/loopx/capabilities/multi_agent/runtime_scripts.py
+++ b/loopx/capabilities/multi_agent/runtime_scripts.py
@@ -78,10 +78,82 @@ human_target.write_text(
 )
 human_target.chmod(0o700)
 
+prompt_target = bin_dir / "loopx-build-codex-bootstrap-prompt"
+prompt_target.write_text(
+    "#!/usr/bin/env python3\n"
+    "import json, os, sys\n"
+    "from pathlib import Path\n"
+    "def load_json_path(value):\n"
+    "    if not value:\n"
+    "        return {}\n"
+    "    try:\n"
+    "        return json.loads(Path(value).read_text(encoding='utf-8'))\n"
+    "    except Exception:\n"
+    "        return {}\n"
+    "def compact(value, *, default=''):\n"
+    "    text = ' '.join(str(value or '').split())\n"
+    "    return text[:240] if text else default\n"
+    "def latest_selected_round(summary):\n"
+    "    rounds = summary.get('rounds') if isinstance(summary, dict) else []\n"
+    "    if not isinstance(rounds, list):\n"
+    "        return {}\n"
+    "    for item in reversed(rounds):\n"
+    "        if isinstance(item, dict) and (item.get('selected_todo_id') or item.get('selected_action')):\n"
+    "            return item\n"
+    "    return {}\n"
+    "artifact = Path(sys.argv[1]) if len(sys.argv) > 1 else Path(os.environ.get('LOOPX_CODEX_TUI_PROMPT_ARTIFACT', ''))\n"
+    "if not str(artifact):\n"
+    "    raise SystemExit(2)\n"
+    "base = artifact.read_text(encoding='utf-8') if artifact.exists() else ''\n"
+    "profile = load_json_path(os.environ.get('LOOPX_ROLE_PROFILE_ARTIFACT'))\n"
+    "summary = load_json_path(os.environ.get('LOOPX_PANE_TICK_SUMMARY'))\n"
+    "round_item = latest_selected_round(summary)\n"
+    "artifact_dir = Path(os.environ.get('LOOPX_PANE_ARTIFACT_DIR') or '.')\n"
+    "live_evidence = load_json_path(artifact_dir / 'live-codex-e2e-evidence.public.json')\n"
+    "lane_evidence = live_evidence.get('lane_evidence') if isinstance(live_evidence.get('lane_evidence'), dict) else {}\n"
+    "visible_lanes = live_evidence.get('visible_lanes') if isinstance(live_evidence.get('visible_lanes'), dict) else {}\n"
+    "protected_scope_clean = lane_evidence.get('protected_scope_clean')\n"
+    "visible_accepted = visible_lanes.get('accepted')\n"
+    "proof_satisfied = bool(live_evidence.get('ok') is True and protected_scope_clean is True and visible_accepted is True)\n"
+    "language = compact(profile.get('output_language') or os.environ.get('LOOPX_AUTO_RESEARCH_OUTPUT_LANGUAGE'))\n"
+    "language_note = ''\n"
+    "if language == 'zh':\n"
+    "    language_note = 'use Chinese for human-readable progress; keep machine keys unchanged'\n"
+    "elif language:\n"
+    "    language_note = 'use this language for human-readable progress; keep machine keys unchanged'\n"
+    "lines = ['', '## LoopX Agent Bootstrap Context']\n"
+    "lines.append('- audience: role-local Codex agent; keep user-facing summaries compact.')\n"
+    "lines.append(f\"- agent_id: {compact(profile.get('agent_id') or os.environ.get('LOOPX_AGENT_ID'), default='unknown')}\")\n"
+    "lines.append(f\"- role_id: {compact(profile.get('role_id') or os.environ.get('LOOPX_ROLE_ID'), default='unknown')}\")\n"
+    "responsibility = compact(profile.get('responsibility') or profile.get('agent_scope'))\n"
+    "if responsibility:\n"
+    "    lines.append(f'- responsibility: {responsibility}')\n"
+    "if language_note:\n"
+    "    lines.append(f'- human_output_language: {language}; {language_note}.')\n"
+    "lines.extend(['', '### Current Frontier'])\n"
+    "if round_item:\n"
+    "    lines.append(f\"- selected_todo_id: {compact(round_item.get('selected_todo_id'), default='unknown')}\")\n"
+    "    lines.append(f\"- selected_action: {compact(round_item.get('selected_action'), default='unknown')}\")\n"
+    "    lines.append(f\"- worker_status: {compact(round_item.get('worker_status'), default='unknown')}\")\n"
+    "else:\n"
+    "    lines.append('- selected_frontier: none observed in launcher pre-tick; re-read own quota/frontier before acting.')\n"
+    "lines.extend(['', '### Safety Contract'])\n"
+    "lines.append('- protected_scope_rule: do not edit protected evaluator/data, credentials, private material, or raw logs.')\n"
+    "lines.append('- claim_allowed_rule: false until live evidence validates; do not promote from dev-only evidence.')\n"
+    "lines.append('- successor_rule: create only role-declared successor todos through normal LoopX todo commands.')\n"
+    "lines.extend(['', '### Live Evidence Proof'])\n"
+    "lines.append('- expected_artifact: $LOOPX_PANE_ARTIFACT_DIR/live-codex-e2e-evidence.public.json')\n"
+    "lines.append('- proof_check: schema auto_research_live_codex_lane_e2e_evidence_v0; visible_lanes.accepted=true; lane_evidence.protected_scope_clean=true')\n"
+    "lines.append(f'- proof_satisfied: {str(proof_satisfied).lower()}')\n"
+    "artifact.write_text(base.rstrip() + '\\n\\n' + '\\n'.join(lines).strip() + '\\n', encoding='utf-8')\n",
+    encoding="utf-8",
+)
+prompt_target.chmod(0o700)
+
 tick_target = bin_dir / "loopx-pane-a2a-tick"
 tick_target.write_text(
     "#!/usr/bin/env python3\n"
-    "import json, os, shlex, subprocess\n"
+    "import json, os, shlex, subprocess, sys\n"
     "from pathlib import Path\n"
     "loopx = os.environ.get('LOOPX_PANE_LOOPX') or str(Path(os.environ.get('LOOPX_PROJECT', '.')) / '.local' / 'bin' / 'loopx')\n"
     "goal = os.environ.get('LOOPX_GOAL_ID', '').strip()\n"
@@ -133,6 +205,35 @@ tick_target.write_text(
     "def run(args):\n"
     "    print('\\n[LoopX pane A2A] ' + ' '.join(shlex.quote(str(arg)) for arg in args), flush=True)\n"
     "    return subprocess.call([str(arg) for arg in args])\n"
+    "def parse_worker_payload(text):\n"
+    "    if not text:\n"
+    "        return {}\n"
+    "    try:\n"
+    "        payload = json.loads(text)\n"
+    "        return payload if isinstance(payload, dict) else {}\n"
+    "    except Exception:\n"
+    "        pass\n"
+    "    start = text.find('{')\n"
+    "    end = text.rfind('}')\n"
+    "    if start >= 0 and end > start:\n"
+    "        try:\n"
+    "            payload = json.loads(text[start:end + 1])\n"
+    "            return payload if isinstance(payload, dict) else {}\n"
+    "        except Exception:\n"
+    "            return {}\n"
+    "    return {}\n"
+    "def attach_worker_payload(round_record, payload):\n"
+    "    if not payload:\n"
+    "        return\n"
+    "    evaluation = payload.get('evaluation_summary') if isinstance(payload.get('evaluation_summary'), dict) else {}\n"
+    "    live = payload.get('live_evidence') if isinstance(payload.get('live_evidence'), dict) else {}\n"
+    "    for key in ('selected_todo_id', 'selected_action', 'role_id'):\n"
+    "        if payload.get(key) is not None:\n"
+    "            round_record[key] = payload.get(key)\n"
+    "    if evaluation.get('claim_allowed') is not None:\n"
+    "        round_record['claim_allowed'] = bool(evaluation.get('claim_allowed'))\n"
+    "    if live.get('written') is not None:\n"
+    "        round_record['live_evidence_written'] = bool(live.get('written'))\n"
     "print(f'\\n[LoopX pane A2A] role={role} agent={agent}\\n', flush=True)\n"
     "turn = os.environ.get('LOOPX_PANE_WORKER_TURN', '').strip()\n"
     "loop = os.environ.get('LOOPX_PANE_WORKER_LOOP', '').strip()\n"
@@ -157,9 +258,17 @@ tick_target.write_text(
     "        write_rounds_summary(ok=False, status='quota_failed', rounds_requested=rounds, worker_label=label, worker_configured=True)\n"
     "        raise SystemExit(status)\n"
     "    print(f'\\n[LoopX pane A2A {label}]\\n{command}\\n', flush=True)\n"
-    "    result = subprocess.call(command, shell=True, executable=os.environ.get('SHELL') or '/bin/bash')\n"
+    "    worker_env = os.environ.copy()\n"
+    "    worker_env['LOOPX_MACHINE_JSON'] = '1'\n"
+    "    worker = subprocess.run(command, shell=True, executable=os.environ.get('SHELL') or '/bin/bash', capture_output=True, text=True, env=worker_env)\n"
+    "    if worker.stdout:\n"
+    "        print(worker.stdout, end='' if worker.stdout.endswith('\\n') else '\\n', flush=True)\n"
+    "    if worker.stderr:\n"
+    "        print(worker.stderr, end='' if worker.stderr.endswith('\\n') else '\\n', file=sys.stderr, flush=True)\n"
+    "    result = worker.returncode\n"
     "    round_record['worker_executed'] = True\n"
     "    round_record['worker_status'] = result\n"
+    "    attach_worker_payload(round_record, parse_worker_payload(worker.stdout))\n"
     "    write_rounds_summary(ok=result == 0, status='running' if result == 0 else 'worker_failed', rounds_requested=rounds, worker_label=label, worker_configured=True)\n"
     "    if result != 0:\n"
     "        raise SystemExit(result)\n"
@@ -178,6 +287,7 @@ CODEX_TUI_EXEC_PY = r"""
 import json
 import os
 import subprocess
+from pathlib import Path
 
 codex = os.environ["LOOPX_CODEX_BIN"]
 project = os.environ["LOOPX_PROJECT"]
@@ -202,5 +312,13 @@ if os.environ.get("LOOPX_CODEX_TRUST_WORKSPACE") == "1":
         args.extend(["-c", f"projects.{json.dumps(path)}.trust_level=\"trusted\""])
 
 args.extend(["-c", f"model_reasoning_effort={reasoning_effort}", "-C", project])
+prompt_path = os.environ.get("LOOPX_CODEX_TUI_PROMPT_ARTIFACT")
+if prompt_path:
+    try:
+        prompt = Path(prompt_path).read_text(encoding="utf-8").strip()
+    except Exception:
+        prompt = ""
+    if prompt:
+        args.append(prompt)
 os.execvp(codex, args)
 """

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -430,9 +430,11 @@ def build_visible_lane_command(
         'chmod +x "$LOOPX_PROJECT/.local/bin/loopx"; '
         'chmod +x "$LOOPX_PROJECT/.local/bin/loopx-json"; '
         'chmod +x "$LOOPX_PROJECT/.local/bin/loopx-pane-a2a-tick"; '
+        'chmod +x "$LOOPX_PROJECT/.local/bin/loopx-build-codex-bootstrap-prompt"; '
         'export LOOPX_PANE_LOOPX="$LOOPX_PROJECT/.local/bin/loopx"; '
         'export LOOPX_PANE_LOOPX_JSON="$LOOPX_PROJECT/.local/bin/loopx-json"; '
         'export LOOPX_PANE_A2A_TICK="$LOOPX_PROJECT/.local/bin/loopx-pane-a2a-tick"; '
+        'export LOOPX_PANE_BOOTSTRAP_PROMPT="$LOOPX_PROJECT/.local/bin/loopx-build-codex-bootstrap-prompt"; '
         'export LOOPX_VISIBLE_FORCE_MARKDOWN="${LOOPX_VISIBLE_FORCE_MARKDOWN:-1}"; '
         'export PATH="$LOOPX_PROJECT/.local/bin:$PATH"; '
     )
@@ -481,6 +483,7 @@ def build_visible_lane_command(
         "printf '\\n[LoopX pane A2A blocked]\\n'; "
         "printf 'tick_exit=%s artifact=%s\\n' \"$PANE_A2A_TICK_STATUS\" \"$LOOPX_PANE_TICK_OUTPUT_ARTIFACT\"; "
         "fi; "
+        '"$LOOPX_PANE_BOOTSTRAP_PROMPT" "$BOOTSTRAP_ARTIFACT"; '
         "export LOOPX_CODEX_TUI_MODE=interactive; "
         "export LOOPX_CODEX_TUI_PROMPT_ARTIFACT=\"$BOOTSTRAP_ARTIFACT\"; "
         f"{codex_exec_env}"
@@ -668,6 +671,15 @@ def build_visible_multi_agent_payload_from_spec(
         reasoning_effort = str(raw_role.get("reasoning_effort") or default_reasoning_effort)
         worker_turn_command = str(raw_role.get("worker_turn_command") or "").strip()
         worker_loop_command = str(raw_role.get("worker_loop_command") or "").strip()
+        output_language = str(
+            raw_role.get("output_language")
+            or (
+                raw_role.get("role_profile", {}).get("output_language")
+                if isinstance(raw_role.get("role_profile"), dict)
+                else ""
+            )
+            or ""
+        ).strip()
         tick_rounds = _positive_int_value(
             raw_role.get("tick_rounds") or raw_role.get("auto_tick_rounds"),
             default=1,
@@ -686,8 +698,9 @@ def build_visible_multi_agent_payload_from_spec(
         role_profile_json = json.dumps(role_profile, ensure_ascii=False, sort_keys=True)
         role_profile_command = (
             "mkdir -p \"$LOOPX_VISIBLE_ARTIFACT_DIR\"; "
+            f"export LOOPX_ROLE_PROFILE_ARTIFACT=\"$LOOPX_VISIBLE_ARTIFACT_DIR/{lane_slug}.role-profile.public.json\"; "
             f"printf '%s\\n' {_q(role_profile_json)} "
-            f"> \"$LOOPX_VISIBLE_ARTIFACT_DIR/{lane_slug}.role-profile.public.json\"; "
+            "> \"$LOOPX_ROLE_PROFILE_ARTIFACT\"; "
         )
         prompt = _generic_role_prompt(
             goal_id=goal_id,
@@ -696,6 +709,7 @@ def build_visible_multi_agent_payload_from_spec(
             scope=scope,
             handoff_hints=handoff_hints,
             skill_name=skill_profile.get("required_skill"),
+            output_language=output_language or None,
         )
         bootstrap_command = f"printf '%s\\n' {_q(prompt)}"
         lane = {
@@ -707,6 +721,7 @@ def build_visible_multi_agent_payload_from_spec(
             "handoff_hints": handoff_hints,
             "role_profile": role_profile,
             "role_profile_ref": role_profile_ref,
+            "output_language": output_language or None,
             "quota_guard": (
                 "mkdir -p \"$LOOPX_PANE_ARTIFACT_DIR\" && "
                 "$LOOPX_PANE_LOOPX_JSON quota should-run "
@@ -767,6 +782,7 @@ def build_visible_multi_agent_payload_from_spec(
                     "scope",
                     "skill",
                     "handoff_hints",
+                    "output_language",
                     "reasoning_effort",
                     "worker_turn_command",
                     "worker_loop_command",


### PR DESCRIPTION
## Summary

- pass compact role/frontier/proof context from launcher pre-tick into the live Codex TUI prompt
- keep auto-research thin by routing language preference through role specs while generic multi-agent kernel owns prompt/tick mechanics
- support Chinese human-readable auto-research start flows with stable English machine schemas
- record selected worker frontier in pane-local A2A summaries without exposing raw private logs

## Validation

- `python3 -m py_compile loopx/capabilities/multi_agent/runtime_scripts.py loopx/visible_multi_agent_launcher.py loopx/capabilities/multi_agent/contract.py loopx/capabilities/auto_research/user_contract.py loopx/capabilities/auto_research/preset.py loopx/capabilities/auto_research/demo_supervisor.py loopx/capabilities/auto_research/demo_e2e.py loopx/capabilities/auto_research/cli.py`
- `python3 examples/auto-research-user-contract-entry-smoke.py`
- `python3 examples/auto-research-demo-supervisor-smoke.py`
- `python3 examples/visible-multi-agent-launcher-smoke.py`
- `python3 examples/auto-research-start-markdown-commands-smoke.py`
- `python3 examples/auto-research-layered-e2e-acceptance-smoke.py`
- `python3 examples/auto-research-demo-e2e-worker-loop-smoke.py`
- `python3 examples/auto-research-worker-turn-smoke.py`
- `python3 examples/auto-research-knn-continuation-smoke.py`
- `python3 examples/auto-research-skill-contract-smoke.py`
- `python3 examples/auto-research-live-evidence-capture-smoke.py`
- `python3 -m loopx.cli --format json auto-research start '如何评估 multi-agent auto research 是否真的有收益?' --language zh | python3 -c 'import json,sys; p=json.load(sys.stdin); assert p["output_language"] == "zh"; assert p["user_contract"]["output_language"]["resolved"] == "zh"; assert "--language zh" in p["user_contract"]["one_click_start"]["command"]; assert "--language zh" in p["commands"]["one_question_start"]; print("auto-research-zh-start-cli ok")'`
- `loopx check --scan-path loopx/capabilities/auto_research --scan-path loopx/capabilities/multi_agent --scan-path loopx/visible_multi_agent_launcher.py --scan-path examples/auto-research-user-contract-entry-smoke.py --scan-path examples/auto-research-demo-supervisor-smoke.py --scan-path examples/visible-multi-agent-launcher-smoke.py`

`loopx check` passed with the existing run-history duplicate-index warning only.
