### PR TITLE
Fix SkillsBench final verifier watchdog override

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -1649,8 +1649,14 @@ def test_skillsbench_final_verifier_timeout_override_can_extend_timeout() -> Non
     class FakeRollout:
         def __init__(self) -> None:
             self._env = types.SimpleNamespace()
+            self._task = types.SimpleNamespace(
+                config=types.SimpleNamespace(
+                    verifier=types.SimpleNamespace(timeout_sec=300)
+                )
+            )
 
         async def verify(self) -> None:
+            assert self._task.config.verifier.timeout_sec == 1800
             return await self._env.exec("/verifier/test.sh", timeout_sec=900)
 
         async def soft_verify(self) -> None:
@@ -1680,10 +1686,14 @@ def test_skillsbench_final_verifier_timeout_override_can_extend_timeout() -> Non
         FakeRollout.soft_verify = original_soft_verify
 
     assert calls == [("/verifier/test.sh", {"timeout_sec": 1800})], calls
+    assert rollout._task.config.verifier.timeout_sec == 300
     prereqs = plan["runner_prerequisites"]
     assert prereqs["benchflow_final_verifier_timeout_enabled"] is True, prereqs
     assert prereqs["benchflow_final_verifier_timeout_sec"] == 1800, prereqs
     assert prereqs["benchflow_final_verifier_timeout_override_count"] == 1, prereqs
+    assert (
+        prereqs["benchflow_final_verifier_outer_timeout_override_count"] == 1
+    ), prereqs
     assert "benchflow_final_verifier_timeout_triggered" not in prereqs, prereqs
     assert prereqs["benchflow_final_verifier_timeout_raw_command_recorded"] is False
     assert "test.sh" not in json.dumps(prereqs)

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -2417,6 +2417,7 @@ def _compact_benchmark_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_verifier_prep_timeout_sec",
         "benchflow_final_verifier_timeout_sec",
         "benchflow_final_verifier_timeout_override_count",
+        "benchflow_final_verifier_outer_timeout_override_count",
         "benchflow_verifier_prep_timeout_override_count",
         "benchflow_verify_prep_timeout_override_count",
         "benchflow_soft_verify_prep_timeout_override_count",

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -2787,6 +2787,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_verifier_prep_timeout_sec",
         "benchflow_final_verifier_timeout_sec",
         "benchflow_final_verifier_timeout_override_count",
+        "benchflow_final_verifier_outer_timeout_override_count",
         "benchflow_verifier_prep_timeout_override_count",
         "benchflow_verify_prep_timeout_override_count",
         "benchflow_soft_verify_prep_timeout_override_count",
@@ -3556,6 +3557,7 @@ def install_benchflow_verifier_prep_timeout_override(
 
         override_count = 0
         final_timeout_override_count = 0
+        final_timeout_outer_override_count = 0
         soft_timeout_override_count = 0
 
         async def exec_with_verifier_prep_timeout(*args: Any, **kwargs: Any) -> Any:
@@ -3592,6 +3594,30 @@ def install_benchflow_verifier_prep_timeout_override(
             phase_timeout_sec = final_verifier_timeout_sec
         elif phase == "soft_verify" and soft_timeout_enabled:
             phase_timeout_sec = soft_verifier_timeout_sec
+
+        task_verifier_config = None
+        original_task_verifier_timeout_sec = None
+        task_verifier_timeout_overridden = False
+        if phase == "verify" and final_timeout_enabled:
+            task = getattr(self, "_task", None)
+            task_config = getattr(task, "config", None)
+            task_verifier_config = getattr(task_config, "verifier", None)
+            original_task_verifier_timeout_sec = getattr(
+                task_verifier_config,
+                "timeout_sec",
+                None,
+            )
+            if original_task_verifier_timeout_sec != final_verifier_timeout_sec:
+                try:
+                    setattr(
+                        task_verifier_config,
+                        "timeout_sec",
+                        final_verifier_timeout_sec,
+                    )
+                    task_verifier_timeout_overridden = True
+                    final_timeout_outer_override_count += 1
+                except Exception:
+                    task_verifier_config = None
 
         try:
             env.exec = exec_with_verifier_prep_timeout
@@ -3661,6 +3687,15 @@ def install_benchflow_verifier_prep_timeout_override(
             raise
         finally:
             env.exec = original_exec
+            if task_verifier_timeout_overridden and task_verifier_config is not None:
+                try:
+                    setattr(
+                        task_verifier_config,
+                        "timeout_sec",
+                        original_task_verifier_timeout_sec,
+                    )
+                except Exception:
+                    pass
             phase_key = f"benchflow_{phase}_prep_timeout_override_count"
             total_key = "benchflow_verifier_prep_timeout_override_count"
             prerequisites[phase_key] = (
@@ -3682,6 +3717,19 @@ def install_benchflow_verifier_prep_timeout_override(
                     trace[count_key] = (
                         int(trace.get(count_key) or 0)
                         + final_timeout_override_count
+                    )
+            if final_timeout_outer_override_count:
+                count_key = (
+                    "benchflow_final_verifier_outer_timeout_override_count"
+                )
+                prerequisites[count_key] = (
+                    int(prerequisites.get(count_key) or 0)
+                    + final_timeout_outer_override_count
+                )
+                if isinstance(trace, dict):
+                    trace[count_key] = (
+                        int(trace.get(count_key) or 0)
+                        + final_timeout_outer_override_count
                     )
             if soft_timeout_override_count:
                 count_key = (


### PR DESCRIPTION
## Summary
- extend the SkillsBench final verifier timeout override to the Benchflow task verifier watchdog, not only the inner /verifier/test.sh exec timeout
- record a public-safe outer-timeout override counter in runner prerequisites/status compaction
- tighten the existing timeout smoke so it proves the task verifier timeout is raised during verify and restored afterward

## Context
Public canary evidence after PR #1265 showed app-server Goal turns completing with task-facing bridge operations, but official score remained missing because Benchflow timed out the verifier at the task-declared budget (for example 300s/600s) despite the runner being configured with final_verifier_timeout_sec=1800. This patch keeps the existing final timeout cap while also covering that outer watchdog.

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py loopx/status.py examples/skillsbench-benchmark-run-smoke.py
- targeted skillsbench timeout smoke: test_skillsbench_final_verifier_timeout_override_can_extend_timeout
- python3 examples/benchmark-core-adapter-contract-smoke.py
- git diff --check
- loopx check --scan-path scripts/skillsbench_automation_loop.py --scan-path loopx/status.py --scan-path examples/skillsbench-benchmark-run-smoke.py
