### PR TITLE
Fix visible auto-research wake readiness

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -628,12 +628,23 @@ def main() -> int:
                 assert visible_wake["workflow_driver"] is False, visible_wake
                 assert visible_wake["broadcaster_reads_frontier"] is False, visible_wake
                 assert visible_wake["broadcaster_selects_todo"] is False, visible_wake
-                assert visible_wake["pane_input_ready_verified"] is True, visible_wake
-                assert (
-                    visible_wake["prompt_delivery"]
-                    == "tmux_paste_buffer_after_codex_tui_first_turn_ready"
-                ), visible_wake
-                assert visible_wake["prompt_submit_checks"], visible_wake
+                assert visible_wake["prompt_delivery"] in {
+                    "tmux_paste_buffer_after_codex_tui_first_turn_ready",
+                    "tmux_paste_buffer_after_ready_subset",
+                    "skipped_no_input_ready_panes",
+                }, visible_wake
+                if visible_wake["pane_input_ready_verified"] is True:
+                    assert visible_wake["prompt_submit_checks"], visible_wake
+                    assert visible_wake["ready_lanes"], visible_wake
+                    assert visible_wake["not_ready_lanes"] == [], visible_wake
+                elif visible_wake["prompt_delivery"] == "tmux_paste_buffer_after_ready_subset":
+                    assert visible_wake["prompt_submit_checks"], visible_wake
+                    assert visible_wake["ready_lanes"], visible_wake
+                    assert visible_wake["not_ready_lanes"], visible_wake
+                else:
+                    assert visible_wake["prompt_submit_checks"] == [], visible_wake
+                    assert visible_wake["ready_lanes"] == [], visible_wake
+                    assert visible_wake["not_ready_lanes"], visible_wake
                 visible_readiness = visible_payload["visible_readiness"]
                 assert visible_readiness["schema_version"] == "auto_research_visible_readiness_v0", visible_readiness
                 assert visible_readiness["ready"] is True, visible_readiness

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -596,6 +596,30 @@ def main() -> int:
                 0,
                 0,
             ], wake
+            os.environ["FAKE_TMUX_CAPTURE_TEXT"] = (
+                "╭────────────────────────╮\n"
+                "│ >_ OpenAI Codex        │\n"
+                "│ model: gpt-5.5 high    │\n"
+                "╰────────────────────────╯\n\n"
+                "• Working (12s • esc to interrupt)\n"
+            )
+            busy_wake = wake_visible_multi_agent_panes(
+                session_name="loopx-visible-launcher-smoke",
+                tmux_bin="tmux",
+                lanes=["planner", "reviewer"],
+                execute=True,
+                input_ready_timeout_seconds=0.25,
+            )
+            assert busy_wake["ok"] is True, busy_wake
+            assert busy_wake["pane_input_ready_verified"] is False, busy_wake
+            assert busy_wake["prompt_delivery"] == "skipped_no_input_ready_panes", busy_wake
+            assert busy_wake["prompt_submit_checks"] == [], busy_wake
+            assert busy_wake["ready_lanes"] == [], busy_wake
+            assert busy_wake["not_ready_lanes"] == ["planner", "reviewer"], busy_wake
+            assert all(
+                item["not_ready_reason"] == "codex_tui_busy_or_not_ready"
+                for item in busy_wake["pane_input_ready_checks"]
+            ), busy_wake
 
             git_root_workspace = temp / "git-root" / "lanes" / "planner"
             git_root_workspace.mkdir(parents=True, exist_ok=True)

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -707,6 +707,9 @@ def _load_visible_wake_into_payload(
         "pane_decision_owner": wake.get("pane_decision_owner"),
         "pane_input_ready_verified": wake.get("pane_input_ready_verified") is True,
         "pane_input_ready_checks": wake.get("pane_input_ready_checks") or [],
+        "pane_input_ready_timeout_seconds": wake.get("pane_input_ready_timeout_seconds"),
+        "ready_lanes": wake.get("ready_lanes") or [],
+        "not_ready_lanes": wake.get("not_ready_lanes") or [],
         "prompt_submit_checks": wake.get("prompt_submit_checks") or [],
         "prompt_delivery": wake.get("prompt_delivery"),
         "driver_contract_schema": driver.get("schema_version"),
@@ -716,6 +719,7 @@ def _load_visible_wake_into_payload(
     visible_proof = payload["visible_worker_proof"]
     if isinstance(visible_proof, dict):
         visible_proof["cadence_wake_loaded"] = True
+        prompt_delivery = wake.get("prompt_delivery")
         visible_proof["cadence_wake_verified"] = (
             wake.get("mode") == "execute"
             and wake.get("coordination_model") == "decentralized_state_a2a"
@@ -723,7 +727,12 @@ def _load_visible_wake_into_payload(
             and wake.get("workflow_driver") is False
             and wake.get("broadcaster_reads_frontier") is False
             and wake.get("broadcaster_selects_todo") is False
-            and wake.get("pane_input_ready_verified") is True
+            and prompt_delivery
+            in {
+                "tmux_paste_buffer_after_codex_tui_first_turn_ready",
+                "tmux_paste_buffer_after_ready_subset",
+                "skipped_no_input_ready_panes",
+            }
         )
 
 

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -37,7 +37,7 @@ def _q(value: object) -> str:
 
 PANE_A2A_WAKEUP_SCHEMA_VERSION = "multi_agent_pane_a2a_wakeup_v0"
 PANE_A2A_WAKEUP_PROMPT = PANE_LOCAL_A2A_WAKEUP_PROMPT
-PANE_A2A_INPUT_READY_TIMEOUT_SECONDS = 90.0
+PANE_A2A_INPUT_READY_TIMEOUT_SECONDS = 5.0
 
 
 def require_executable(command: str, *, field: str) -> str:
@@ -104,6 +104,7 @@ def _wait_for_tmux_pane_input_ready(
                 "attempt_count": attempts,
                 "capture_ok": capture.returncode == 0,
                 "ready_marker": None,
+                "not_ready_reason": "codex_tui_busy_or_not_ready",
             }
         time.sleep(0.25)
 
@@ -182,6 +183,7 @@ def wake_visible_multi_agent_panes(
     lanes: Iterable[str] | None = None,
     execute: bool = False,
     prompt: str | None = None,
+    input_ready_timeout_seconds: float | None = None,
 ) -> dict[str, object]:
     """Broadcast the fixed A2A prompt; each pane still decides via LoopX state."""
 
@@ -217,36 +219,54 @@ def wake_visible_multi_agent_panes(
                 session=session,
                 lane=lane,
                 env=env,
+                timeout_seconds=(
+                    PANE_A2A_INPUT_READY_TIMEOUT_SECONDS
+                    if input_ready_timeout_seconds is None
+                    else input_ready_timeout_seconds
+                ),
             )
             for lane in target_lanes
         ]
+        ready_lanes = [
+            str(check.get("lane"))
+            for check in input_ready_checks
+            if check.get("ready") is True
+        ]
+        if ready_lanes:
+            buffer_name = f"loopx-pane-a2a-wakeup-{prompt_hash}"
+            subprocess.run(
+                [tmux_bin, "set-buffer", "-b", buffer_name, "--", prompt_text],
+                check=True,
+                env=env,
+            )
+            for lane in ready_lanes:
+                target = f"{session}:{lane}"
+                prompt_submit_checks.append(
+                    _paste_and_submit_tmux_prompt(
+                        tmux_bin=tmux_bin,
+                        target=target,
+                        buffer_name=buffer_name,
+                        prompt=prompt_text,
+                        env=env,
+                    )
+                )
         not_ready = [
             str(check.get("lane"))
             for check in input_ready_checks
             if check.get("ready") is not True
         ]
-        if not_ready:
-            raise ValueError(
-                "multi-agent wake target pane input was not ready: "
-                + ", ".join(not_ready)
-            )
-        buffer_name = f"loopx-pane-a2a-wakeup-{prompt_hash}"
-        subprocess.run(
-            [tmux_bin, "set-buffer", "-b", buffer_name, "--", prompt_text],
-            check=True,
-            env=env,
-        )
-        for lane in target_lanes:
-            target = f"{session}:{lane}"
-            prompt_submit_checks.append(
-                _paste_and_submit_tmux_prompt(
-                    tmux_bin=tmux_bin,
-                    target=target,
-                    buffer_name=buffer_name,
-                    prompt=prompt_text,
-                    env=env,
-                )
-            )
+    else:
+        ready_lanes = []
+        not_ready = []
+
+    if not execute:
+        prompt_delivery = "dry_run"
+    elif not prompt_submit_checks:
+        prompt_delivery = "skipped_no_input_ready_panes"
+    elif not_ready:
+        prompt_delivery = "tmux_paste_buffer_after_ready_subset"
+    else:
+        prompt_delivery = "tmux_paste_buffer_after_codex_tui_first_turn_ready"
 
     return {
         "ok": True,
@@ -270,10 +290,17 @@ def wake_visible_multi_agent_panes(
         if execute
         else False,
         "pane_input_ready_checks": input_ready_checks,
+        "pane_input_ready_timeout_seconds": (
+            PANE_A2A_INPUT_READY_TIMEOUT_SECONDS
+            if input_ready_timeout_seconds is None
+            else input_ready_timeout_seconds
+        )
+        if execute
+        else None,
+        "ready_lanes": ready_lanes,
+        "not_ready_lanes": not_ready,
         "prompt_submit_checks": prompt_submit_checks,
-        "prompt_delivery": (
-            "tmux_paste_buffer_after_codex_tui_first_turn_ready" if execute else "dry_run"
-        ),
+        "prompt_delivery": prompt_delivery,
         "boundary": {
             "writes_loopx_state": False,
             "spends_loopx_quota": False,


### PR DESCRIPTION
## Summary
- make visible multi-agent wake non-blocking when Codex panes are busy or not yet input-ready
- broadcast only to ready panes and return structured ready/not-ready lane metadata
- treat fixed wake as verified when it follows the decentralized non-blocking contract, even if some panes continue from their bootstrap/pre-tick state

## Validation
- python3 -m py_compile loopx/visible_multi_agent_launcher.py loopx/capabilities/auto_research/demo_e2e.py
- python3 examples/visible-multi-agent-launcher-smoke.py
- python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- python3 examples/auto-research-layered-e2e-acceptance-smoke.py
- PYTHONPATH=. scripts/loopx --format json multi-agent wake --session-name loopx-ar-zh-knn-visible-20260704T1136 --execute
- loopx check --scan-path loopx/visible_multi_agent_launcher.py --scan-path loopx/capabilities/auto_research/demo_e2e.py --scan-path examples/visible-multi-agent-launcher-smoke.py --scan-path examples/auto-research-demo-e2e-worker-loop-smoke.py
