### PR TITLE
Cover control-plane runtime package in installer smoke

### DIFF
--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -202,6 +202,9 @@ def main() -> int:
         assert wrapper.resolve().name == "loopx", wrapper.resolve()
         release_root = wrapper.resolve().parents[1]
         assert (release_root / "loopx" / "cli.py").is_file(), release_root
+        runtime_package = release_root / "loopx" / "control_plane" / "runtime"
+        assert (runtime_package / "run_compaction.py").is_file(), release_root
+        assert (runtime_package / "session_runtime.py").is_file(), release_root
         dashboard_page = release_root / "apps" / "dashboard" / "src" / "views" / "dashboard-page.tsx"
         action_packet = release_root / "apps" / "dashboard" / "src" / "data" / "action-packet.ts"
         dashboard_node_modules = release_root / "apps" / "dashboard" / "node_modules"


### PR DESCRIPTION
## Summary
- add explicit installer-smoke assertions that release snapshots include `loopx/control_plane/runtime/run_compaction.py`
- add the matching assertion for `loopx/control_plane/runtime/session_runtime.py`

## Context
#1317 restored the missing runtime package after the bounded-context refactor. This follow-up makes the installer smoke fail directly if a future `.gitignore` or packaging change drops the runtime context from the release snapshot again.

## Validation
- `git diff --check`
- `python3 examples/install-local-smoke.py`
