### PR TITLE
Register LoopX slash commands across Codex and Claude hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 **Loop engineering for long-running AI agents.**
 
 <sub>Manage Codex, Claude Code, Cursor, and other agent runtimes like
-reviewable digital workers: goals, gates, todos, quota, evidence, and handoff
+reviewable digital workers: objectives, gates, todos, quota, evidence, and handoff
 state in one local control plane.</sub>
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
@@ -28,7 +28,7 @@ Use it when an agent is already useful for one session, but the work is too
 long, too gated, or too easy to lose across restarts. LoopX turns that agent
 surface into a reviewable Loop Agent: stable objective, explicit gates, scoped
 next actions, evidence, cost, and handoff state. The agent still needs a CLI,
-goal mode, automation hook, or loop scheduler; LoopX supplies the control
+task mode, automation hook, or loop scheduler; LoopX supplies the control
 plane, not hidden autonomy.
 
 [Quick Start](#quick-start) · [How It Works](#how-it-works) · [See It In Action](#see-it-in-action) ·
@@ -49,19 +49,19 @@ plane, not hidden autonomy.
 
 ## How It Works
 
-Under the hood, LoopX keeps goals, gates, todos, claims, scopes, evidence, run
+Under the hood, LoopX keeps objectives, gates, todos, claims, scopes, evidence, run
 history, quota, and human decisions in one compact layer. Product surfaces fold
-those mechanics into five questions a user can act on: what is the goal, what
+those mechanics into five questions a user can act on: what is the objective, what
 is next, what needs human judgment, what evidence changed, and whether the loop
 can be handed back to the agent.
 
-Short answer: LoopX is not another executor. Codex goal, Codex App
+Short answer: LoopX is not another executor. Codex `/goal`, Codex App
 automation, CLI scripts, cron jobs, or a human-visible TUI can trigger the next
-executor loop; LoopX keeps the goal, gate, evidence, quota, and handoff contract
+executor loop; LoopX keeps the objective, gate, evidence, quota, and handoff contract
 stable across those turns.
 
 ```text
-goal / issue / project
+objective / issue / project
    │
    ▼
 LoopX state: objective + gates + todos + scope + evidence + quota
@@ -80,7 +80,7 @@ write evidence + handoff + next todo ─▶ quota decides the next tick
 | Layer | Role |
 | --- | --- |
 | Codex / Claude Code / Cursor | Execute a bounded agent loop: read, write, run commands, and respond. |
-| Goal mode / automation / CLI scripts / TUI | Trigger or schedule the next executor loop. |
+| Task mode / automation / CLI scripts / TUI | Trigger or schedule the next executor loop. |
 | LoopX | Preserve the dynamic loop state: gates, todos, run history, quota, evidence, boundaries, and handoff state. |
 
 The product promise is not "more todo lists." It is a practical foundation for
@@ -94,7 +94,7 @@ and stale prompts. The technical contract underneath that promise is explicit:
 agent identity, todo ownership, scope, capability gates, quota, evidence
 writeback, and public/private boundaries stay visible to the next turn.
 
-LoopX 把一次静态 goal 变成能持续流转的动态 loop：该等人的地方明确等人，
+LoopX 把一次静态目标变成能持续流转的动态 loop：该等人的地方明确等人，
 不该空等的安全侧路继续推进，下一轮 agent 总能读到目标、边界、证据和交接。
 
 ![LoopX control-plane board](docs/assets/control-plane-board.svg)
@@ -106,7 +106,7 @@ need that work to continue without turning into stale chat memory.
 
 Start here if you are running:
 
-- multi-day engineering, research, benchmark, or experiment goals;
+- multi-day engineering, research, benchmark, or experiment objectives;
 - issue/PR fixing loops where the agent must preserve scope, evidence, and
   review state across turns;
 - recurring heartbeat or monitor-style agent work;
@@ -127,16 +127,16 @@ needed for contributor clone/canary workflows. The Python package has no
 runtime dependencies outside the standard library.
 
 Start agent-first: paste one setup message for the surface you already use,
-then start real work with `/loopx <complex task>`.
+then start real work through the LoopX command entry for that host.
 
 Choose your surface:
 
 - **Codex App**: best for a long-running agent that can wake up, re-check gates,
-  and keep moving. Paste the setup message below, then ask
-  `/loopx <complex task>`.
+  and keep moving. Paste the setup message below, then invoke `$loopx
+  <complex task>` or choose `loopx` from `/skills`.
 - **Codex CLI**: best when the visible TUI should stay primary while LoopX keeps
-  the state. Run `codex`, paste the setup message, then ask
-  `/loopx <complex task>`.
+  the state. Run `codex`, paste the setup message, then invoke `$loopx
+  <complex task>` or choose `loopx` from `/skills`.
 - **Claude Code**: best when Claude Code's native `/loop` should drive each tick.
   Install the opt-in adapter, run `/loopx <task>`, then `/loop`.
 - **Manual shell / other agents**: best when you want LoopX state without a
@@ -156,9 +156,9 @@ curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/ins
 export PATH="$HOME/.local/bin:$PATH"
 
 Then run `loopx doctor`. Work only from the current project root: if LoopX state
-already exists, reuse it and do not create or overwrite a goal; if the project
+already exists, reuse it and do not create or overwrite the active objective; if the project
 is not connected, prefer `loopx connect`, and use `loopx bootstrap` only when
-goal state clearly needs initialization. Ensure `.loopx/`, `.codex/goals/`,
+project state clearly needs initialization. Ensure `.loopx/`, `.codex/goals/`,
 and `.local/` are ignored. If this is Codex App, set the heartbeat automation to start at 3 minutes.
 Automatically refresh it from the LoopX generated task body; do not ask me to
 manually run `heartbeat-prompt`. Then stop and report the project connection
@@ -168,7 +168,7 @@ status, current user gate, top agent todo, and next safe action.
 Then start a real E2E exploration in normal language:
 
 ```text
-/loopx Explore an LLM semantic rerank slice for a recommendation or search
+$loopx Explore an LLM semantic rerank slice for a recommendation or search
 system: build an offline eval set, implement a minimal candidate -> semantic
 feature -> rerank -> eval path, add trace/cache/fallback/cost guardrails,
 compare baseline vs treatment, and stop for production traffic, private data,
@@ -221,17 +221,17 @@ curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/ins
 export PATH="$HOME/.local/bin:$PATH"
 
 Then run `loopx doctor`. Work only from this project root: if LoopX state
-already exists, reuse it and do not create or overwrite a goal; if the project
+already exists, reuse it and do not create or overwrite the active objective; if the project
 is not connected, prefer `loopx connect`, and use `loopx bootstrap` only when
-goal state clearly needs initialization. Ensure `.loopx/`, `.codex/goals/`,
+project state clearly needs initialization. Ensure `.loopx/`, `.codex/goals/`,
 and `.local/` are ignored. Keep me in this TUI, do not use hidden headless
 execution. Then stop and report the project connection status, current user
 gate, top agent todo, and next safe action. After that I will start work with
-`/loopx <complex task>`.
+`$loopx <complex task>` or the `loopx` skill from `/skills`.
 ```
 
 That one message is the install, connect, and status check. The first useful
-TUI response should show the current goal, any concrete user gate, top todos,
+TUI response should show the current objective, any concrete user gate, top todos,
 and next safe action. Hidden `codex exec` is not the default bootstrap path.
 Details for generated messages, later same-TUI automation, and proof capture
 live in [Getting Started](docs/guides/getting-started.md).
@@ -258,7 +258,7 @@ optional `--harden` gate, and uninstall are in
 For Cursor, another terminal agent, or a manual shell, use the
 same no-clone installer. Be cautious with non-Codex agents: LoopX can only
 drive the agent path if that surface has at least one usable control hook, such
-as shell/CLI execution, a goal/task command, an automation or heartbeat hook,
+as shell/CLI execution, a task command, an automation or heartbeat hook,
 or its own loop/scheduler. If the agent has none of those capabilities, LoopX
 can still track the project state, but the user must run the shell commands
 manually.
@@ -275,7 +275,7 @@ Then ask the agent to connect or run the command yourself:
 cd /path/to/your-project
 loopx bootstrap \
   --goal-id your-project-goal \
-  --objective "Improve this project through bounded, verified goal segments." \
+  --objective "Improve this project through bounded, verified segments." \
   --goal-doc GOAL.md
 ```
 
@@ -296,7 +296,7 @@ loopx quota spend-slot      # account for a completed automatic slice
 This is the shape used by advanced showcases such as
 [dynamic workflow orchestration](docs/showcases/cases/0619-dynamic-workflow-hardware-agent.html):
 your agents can orchestrate external tools, devices, domain-specific runners,
-or side agents, while LoopX keeps goals, gates, todos, evidence, quota, and
+or side agents, while LoopX keeps objectives, gates, todos, evidence, quota, and
 handoff state reviewable.
 
 Clone-based install is only for contributors who want the live canary wrapper:
@@ -333,24 +333,25 @@ full presenter material, see the experimental notes below.
 
 This is not replacing the first screen. It is an experimental entry point for
 users who already understand the control-plane idea and want to pick one useful
-LoopX capability today. Each path uses the same goal, todo, quota, evidence,
+LoopX capability today. Each path uses the same objective, todo, quota, evidence,
 and review contract, so users can feel the capability lift without learning a
 new control plane every time:
 
 | App path | Start with | Expected output | User-visible lift |
 | --- | --- | --- | --- |
-| Issue / PR fix loop | `/loopx Fix <github-issue-or-pr-url>`<br>`loopx issue-fix workflow-plan` | Branch-ready fix packet with repro, smoke result, remaining review owner, and PR-review-ready evidence. | Review comments and issues become a closed loop instead of reminders humans must shepherd by hand. |
-| PR-sized refactor loop | `/loopx <refactor goal>`<br>`loopx canary plan` | Reviewable slice list, validation notes, successor todo, and merge boundary. | More merged changes without turning the next morning into a giant diff audit. |
+| Issue / PR fix loop | LoopX slash entry: `Fix <github-issue-or-pr-url>`<br>`loopx issue-fix workflow-plan` | Branch-ready fix packet with repro, smoke result, remaining review owner, and PR-review-ready evidence. | Review comments and issues become a closed loop instead of reminders humans must shepherd by hand. |
+| PR-sized refactor loop | LoopX slash entry: `<refactor task>`<br>`loopx canary plan` | Reviewable slice list, validation notes, successor todo, and merge boundary. | More merged changes without turning the next morning into a giant diff audit. |
 | Research or experiment loop | `loopx auto-research`<br>`loopx ml-experiment preview --format json` | Hypothesis, source/evidence packet, replay or experiment boundary, and next validated question. | Research becomes a resumable long-horizon loop, not just a one-off report. |
-| Multi-agent work routing | `/loopx <goal text>`<br>`loopx quota should-run`<br>`loopx todo claim` | Claimed agent lanes with scope, lease, next action, quota decision, and handoff state. | Multiple agents can work in parallel without hiding ownership or stepping on the same todo. |
+| Multi-agent work routing | LoopX slash entry: `<task text>`<br>`loopx quota should-run`<br>`loopx todo claim` | Claimed agent lanes with scope, lease, next action, quota decision, and handoff state. | Multiple agents can work in parallel without hiding ownership or stepping on the same todo. |
 | Knowledge / workflow connector | `loopx connect`<br>`loopx lark-kanban`<br>`loopx value-connectors` | LoopX state projected into docs, boards, GitHub, or domain workflows while LoopX remains the source of truth. | Existing work surfaces become agent-aware without copying private state into public artifacts. |
-| P0 blocked -> safe fallback | `loopx quota should-run`<br>`loopx todo claim` | Kernel projection of the exact user gate, safe fallback todo, quota decision, and evidence boundary inside an active goal. | Less idle agent time while preserving human judgment on the blocked path. |
-| Candidate: Claude implements + Codex reviews | `/loopx <implementation goal>`<br>`loopx todo claim`<br>`loopx review-packet` | Role-scoped implementer todo, reviewer verdict, verifier command, evidence packet, and next handoff in one LoopX goal. | A [two-agent demo](docs/product/cross-runtime-impl-review-demo.md) can show collaboration without making either runtime the source of truth. |
-| Candidate: PR conflict resolution | `/loopx Resolve merge conflicts for <github-pr-url>` | Conflict patch, semantic risk note, focused validation, and review handoff before merge. | Less mechanical conflict work after high-throughput agent branches, with humans still judging risky merges. |
+| P0 blocked -> safe fallback | `loopx quota should-run`<br>`loopx todo claim` | Kernel projection of the exact user gate, safe fallback todo, quota decision, and evidence boundary inside an active project loop. | Less idle agent time while preserving human judgment on the blocked path. |
+| Candidate: Claude implements + Codex reviews | LoopX slash entry: `<implementation task>`<br>`loopx todo claim`<br>`loopx review-packet` | Role-scoped implementer todo, reviewer verdict, verifier command, evidence packet, and next handoff in one LoopX state thread. | A [two-agent demo](docs/product/cross-runtime-impl-review-demo.md) can show collaboration without making either runtime the source of truth. |
+| Candidate: PR conflict resolution | LoopX slash entry: `Resolve merge conflicts for <github-pr-url>` | Conflict patch, semantic risk note, focused validation, and review handoff before merge. | Less mechanical conflict work after high-throughput agent branches, with humans still judging risky merges. |
 
-Start the goal normally with `/loopx <goal text>`. The commands above are short
-entry points, not separate state systems: each adapter still writes into the
-same LoopX control-plane contract.
+Start through the host's LoopX slash-command entry point: `$loopx` or `/skills`
+in current Codex surfaces, `/loopx` where a host exposes native slash commands.
+The commands above are short entry points, not separate state systems: each
+adapter still writes into the same LoopX control-plane contract.
 
 ## User Mental Model
 
@@ -359,7 +360,7 @@ day. The product surface should collapse them into five questions:
 
 | User question | Kernel objects behind it | What the user should see |
 | --- | --- | --- |
-| Goal | goal state, scope | What are we trying to move, and what is out of bounds? |
+| Objective | objective state, scope | What are we trying to move, and what is out of bounds? |
 | Next step | todo, claim, quota | What small action can the agent or human take now? |
 | Judgment | user gate, boundary authority | What needs human approval, route choice, or reward feedback? |
 | Evidence | run history, artifacts, validation | Why should we believe the state changed? |
@@ -375,7 +376,7 @@ Long-running loops fail differently: state drifts.
 
 Loop engineering often begins with a timer, a long prompt, a shell script, or a
 visible TUI session. That can prove the idea, but it is not enough for real
-work. Once the goal changes, the user gives feedback, an owner gate appears, or
+work. Once the objective changes, the user gives feedback, an owner gate appears, or
 multiple agents touch the same repo, the loop needs shared state instead of
 chat memory.
 
@@ -408,9 +409,9 @@ or the
 
 ## What You Get
 
-- **Lifetime goals**: durable project intentions that outlive one chat thread,
-  run, todo, or implementation plan. A lifetime goal does not grant open-ended
-  autonomy: only the next bounded transition is executable.
+- **Lifetime objectives**: durable project intentions that outlive one chat
+  thread, run, todo, or implementation plan. A lifetime objective does not
+  grant open-ended autonomy: only the next bounded transition is executable.
 - **User gates**: concrete human decisions that stay visible instead of
   disappearing into chat.
 - **Safe fallback**: audited side paths that can continue when one lane is
@@ -520,9 +521,9 @@ loopx quota spend-slot --goal-id your-project-goal --slots 1 --source heartbeat 
 ```
 
 The `next_automatic_turn` reported by `quota plan` is only an advisory
-scheduling hint: it chooses the highest-compute eligible goal, while
+scheduling hint: it chooses the highest-compute eligible objective, while
 operator-gated, focus-waiting, waiting, throttled, paused, and health-blocked
-goals stay out of the eligible lane.
+objectives stay out of the eligible lane.
 
 For stalled control-plane repair, `control_plane.self_repair.enabled=true` lets
 `quota should-run` return a bounded `decision=self_repair` contract; missing
@@ -576,14 +577,14 @@ see the [dashboard guide](apps/dashboard/README.md).
 
 LoopX starts with AI coding, research, and benchmark loops because those
 workflows make state drift easy to see. The broader product direction is a
-dynamic goal control plane for any long-running agent work where humans need
+dynamic objective control plane for any long-running agent work where humans need
 clear progress, gates, feedback, and recovery without reading raw logs.
 
 The near-term open-source path is maintainer-first: help people manage agents
 that read issues, propose fixes, open PRs, resolve review feedback, run
 benchmarks, and keep evidence attached to the work. That path is valuable even
 before LoopX controls execution, because it gives maintainers a readable queue
-of goals, gates, todos, evidence, cost, and feedback.
+of objectives, gates, todos, evidence, cost, and feedback.
 
 The broader product shape is a Loop Agent: an agent with a relatively stable
 responsibility, a continuing stream of external signals, and a recurring need
@@ -591,7 +592,7 @@ to prove that its output quality, cost, and human-attention footprint are
 improving. A Loop Agent could be a coding maintainer, an experiment optimizer,
 a research assistant, or a creator/operator assistant. LoopX is the control
 plane that keeps those loops reviewable before they become more autonomous.
-LoopX makes the "digital worker" idea operational: goals, gates, evidence,
+LoopX makes the "digital worker" idea operational: objectives, gates, evidence,
 cost, and feedback stay reviewable over time.
 
 A medium-term productization case is a creator-operator workflow: a
@@ -616,7 +617,7 @@ contract.
 - [Release readiness](docs/product/release-readiness.md): v0.x install/update
   paths, compatibility smoke gate, release-note checklist, and safe-to-depend-on
   surfaces.
-- [Architecture](docs/architecture.md): lifetime-goal invariant and core
+- [Architecture](docs/architecture.md): lifetime-objective invariant and core
   control-plane shape.
 - [State interaction model](docs/state-interaction-model.md): actor boundaries,
   state stores, interaction contract, and writeback model.
@@ -651,7 +652,7 @@ External contributors should start with
 [CONTRIBUTOR_TASKS.md](CONTRIBUTOR_TASKS.md) for public, claimable work and
 [CONTRIBUTING.md](CONTRIBUTING.md) for setup, validation, and boundary rules.
 
-LoopX keeps local active goal state separate from the public repository:
+LoopX keeps local active objective state separate from the public repository:
 do not commit `.loopx/`, `.codex/goals/`, live
 `ACTIVE_GOAL_STATE.md`, raw benchmark traces, or private operator artifacts.
 
@@ -669,7 +670,7 @@ loopx check \
 LoopX is early. It is not a full agent platform and not an autonomous
 production controller.
 
-The current milestone is a useful local substrate for goal state, run history,
+The current milestone is a useful local substrate for objective state, run history,
 operator gates, human reward, structured todos, scoped claims, quota-aware
 heartbeats, read-only project maps, benchmark control-plane evidence, runtime
 bridges, collaboration projections, and a small multi-project dashboard.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -64,6 +64,32 @@ Success looks like this:
 - `loopx status` shows the goal and who should act next;
 - local runtime state is ignored, not committed.
 
+## Slash Command Registration
+
+The installer also registers the LoopX command family for the host surfaces
+that can discover user-installed prompts or skills:
+
+- Codex CLI / IDE: Markdown prompts under `~/.codex/prompts`, so `/loopx`
+  or the fallback `/prompts:loopx` can start from the slash menu after the host
+  refreshes its prompt list.
+- Codex App: lightweight command skills under `~/.codex/skills/loopx*`, while
+  the full LoopX skills such as `loopx-project` and `loopx-pr-review` keep the
+  richer workflow instructions.
+- Claude Code: lightweight user skills under `~/.claude/skills/loopx*`, so the
+  command family can appear as Claude Code slash commands without enabling the
+  opt-in MCP/hook adapter.
+
+To refresh those files after an upgrade, run:
+
+```bash
+loopx slash-commands --install
+```
+
+The command updates files that LoopX owns, including older LoopX-generated
+files with known legacy signatures. If a same-name file has no LoopX managed
+marker or legacy signature, LoopX leaves it untouched and reports
+`skipped_user_file`.
+
 ## Local State Backup
 
 Before risky migrations, local scheduler changes, or release-install repair,

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -64,17 +64,17 @@ Success looks like this:
 - `loopx status` shows the goal and who should act next;
 - local runtime state is ignored, not committed.
 
-## Slash Command Registration
+## Command Skill Registration
 
-The installer also registers the LoopX command family for the host surfaces
-that can discover user-installed prompts or skills:
+The installer also registers the LoopX command family for host surfaces that
+can discover user-installed skills:
 
-- Codex CLI / IDE: Markdown prompts under `~/.codex/prompts`, so `/loopx`
-  or the fallback `/prompts:loopx` can start from the slash menu after the host
-  refreshes its prompt list.
-- Codex App: lightweight command skills under `~/.codex/skills/loopx*`, while
-  the full LoopX skills such as `loopx-project` and `loopx-pr-review` keep the
-  richer workflow instructions.
+- Codex CLI / IDE / App: explicit LoopX command-facade skills under
+  `~/.codex/skills/loopx*`. Codex does not currently support user-defined
+  native top-level `/loopx` slash commands, so invoke these through `$loopx` or
+  `/skills`. Only these command facades include `agents/openai.yaml` with
+  `allow_implicit_invocation: false`; richer workflow skills such as
+  `loopx-project` and `loopx-pr-review` keep their normal implicit behavior.
 - Claude Code: lightweight user skills under `~/.claude/skills/loopx*`, so the
   command family can appear as Claude Code slash commands without enabling the
   opt-in MCP/hook adapter.

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -7,8 +7,8 @@ dashboard use, development checks, and command discovery.
 
 If you are new to LoopX, start with the shorter
 [Newcomer command path](newcomer-command-path.md): it reduces the product
-surface to `/loopx`, `/loopx <goal>`, and one manual CLI quickstart. This page
-keeps the full operator and contributor detail.
+surface to the host LoopX task entry, project connection, and one manual CLI
+quickstart. This page keeps the full operator and contributor detail.
 
 ## Codex App And Other Agent Setup
 
@@ -29,16 +29,16 @@ curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/ins
 export PATH="$HOME/.local/bin:$PATH"
 
 Then run `loopx doctor`. Work only from the current project root:
-1. If LoopX state already exists, reuse it and do not create or overwrite a
-   goal.
+1. If LoopX state already exists, reuse it and do not create or overwrite the
+   active objective.
 2. If the project is not connected, prefer `loopx connect`; use
-   `loopx bootstrap` only when goal state clearly needs initialization.
+   `loopx bootstrap` only when project state clearly needs initialization.
 3. Ensure `.loopx/`, `.codex/goals/`, and `.local/` are ignored.
 4. Set up the thin LoopX heartbeat for this surface. For Codex App, start the
    recurring automation at 3 minutes, then follow
    `quota should-run.scheduler_hint` for backoff and self-stop behavior.
-5. Stop after setup and report the goal id, current user gate, top agent todo,
-   and next safe action.
+5. Stop after setup and report the active state id, current user gate, top
+   agent todo, and next safe action.
 
 Do not commit `.loopx/`, `.codex/goals/`, `.local/`, live ACTIVE_GOAL_STATE
 files, runtime registries, raw logs, credentials, or private local paths. Do
@@ -132,18 +132,19 @@ it with the official no-clone installer:
 curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
 
 Then run `loopx doctor`. Work only from this project root: if LoopX state
-already exists, reuse it and do not create or overwrite a goal; if the project
+already exists, reuse it and do not create or overwrite the active objective; if the project
 is not connected, prefer `loopx connect`, and use `loopx bootstrap` only when
-goal state clearly needs initialization. Ensure `.loopx/`, `.codex/goals/`,
+project state clearly needs initialization. Ensure `.loopx/`, `.codex/goals/`,
 and `.local/` are ignored. Keep me in this TUI, do not use hidden headless
 execution. After the project is connected, generate the thin heartbeat prompt
-and set the current Codex CLI goal to `/goal <thin task_body>`. Then stop and
-report the goal id, current user gate, top agent todo, and next safe action.
+and set the current Codex CLI task body with `/goal <thin task_body>`. Then
+stop and report the active state id, current user gate, top agent todo, and
+next safe action.
 ```
 
 The generated paste block is a setup-first rewrite of the App onboarding
 experience, not the heartbeat body itself. The first useful response should
-show the current goal id, concrete user gate if one exists, top user todo if
+show the current state id, concrete user gate if one exists, top user todo if
 any, top agent todo, and next safe action before longer delivery work. The
 setup turn should not spend quota for delivery unless the user explicitly asks
 it to do delivery in the setup turn. The agent should still generate
@@ -449,7 +450,7 @@ your-project/
   goals/<goal-id>/runs/
 ```
 
-Treat live goal state and registries as local runtime data. Add these paths to
+Treat live objective state and registries as local runtime data. Add these paths to
 the connected project `.gitignore` before committing:
 
 ```gitignore
@@ -499,7 +500,7 @@ loopx demo
 Expected first-run signals:
 
 - the output contains `ok: True`;
-- a project-local registry and active goal state were created under
+- a project-local registry and active objective state were created under
   `/tmp/loopx-demo`;
 - one user todo and one agent todo are visible;
 - `refresh-state` appended a compact run;
@@ -757,7 +758,7 @@ Keep private:
 - task ids and internal document links;
 - production logs and raw experiment metrics;
 - credentials and auth material;
-- user-specific active goal state and local registries;
+- user-specific active objective state and local registries;
 - raw agent sessions or benchmark traces.
 
 Run the public/private scan before publishing docs or examples:

--- a/docs/guides/newcomer-command-path.md
+++ b/docs/guides/newcomer-command-path.md
@@ -34,7 +34,7 @@ matches the surface you already use:
 | --- | --- | --- |
 | Codex App | `/loopx <goal text>` in the project thread | The app heartbeat automation. Let the agent install or refresh the generated LoopX heartbeat body; start at the bootstrap cadence, then follow `quota should-run.scheduler_hint`. |
 | Codex CLI | `codex` from the project root, then `/loopx <goal text>` | The visible TUI goal. Use `loopx codex-cli-bootstrap-message --project .` when you need a generated setup prompt, and keep the executor visible to the user. |
-| Claude Code | Enable the opt-in LoopX adapter, then `/loopx <goal text>` | Claude Code's native `/loop`, gated by LoopX `should_run`, drives each tick. |
+| Claude Code | Install LoopX, then `/loopx <goal text>` | The installer registers lightweight slash-command skills. Enable the opt-in adapter only when Claude Code's native `/loop` should be gated by LoopX `should_run`. |
 | Other agent or shell | `loopx bootstrap-command-pack --project .` | A CLI, task, automation, heartbeat, or scheduler hook must run the next turn. If the surface has no such hook, LoopX can track state but the user drives it manually. |
 
 ## One CLI Quickstart
@@ -46,6 +46,7 @@ up a fresh terminal without an agent driving the first step:
 curl -fsSL https://raw.githubusercontent.com/huangruiteng/loopx/main/scripts/install-from-github.sh | bash
 export PATH="$HOME/.local/bin:$PATH"
 loopx doctor
+loopx slash-commands --install
 loopx bootstrap-command-pack --project .
 ```
 

--- a/docs/guides/newcomer-command-path.md
+++ b/docs/guides/newcomer-command-path.md
@@ -33,7 +33,7 @@ matches the surface you already use:
 | Surface | Start with | What keeps it moving |
 | --- | --- | --- |
 | Codex App | `/loopx <goal text>` in the project thread | The app heartbeat automation. Let the agent install or refresh the generated LoopX heartbeat body; start at the bootstrap cadence, then follow `quota should-run.scheduler_hint`. |
-| Codex CLI | `codex` from the project root, then `/loopx <goal text>` | The visible TUI goal. Use `loopx codex-cli-bootstrap-message --project .` when you need a generated setup prompt, and keep the executor visible to the user. |
+| Codex CLI | `codex` from the project root, then paste `loopx codex-cli-bootstrap-message --project .` output | Current verified Codex CLI builds do not load user-installed `/loopx` or `/prompts:loopx` commands. Keep the executor visible, then set the generated `/goal <thin task_body>`. |
 | Claude Code | Install LoopX, then `/loopx <goal text>` | The installer registers lightweight slash-command skills. Enable the opt-in adapter only when Claude Code's native `/loop` should be gated by LoopX `should_run`. |
 | Other agent or shell | `loopx bootstrap-command-pack --project .` | A CLI, task, automation, heartbeat, or scheduler hook must run the next turn. If the surface has no such hook, LoopX can track state but the user drives it manually. |
 

--- a/docs/guides/newcomer-command-path.md
+++ b/docs/guides/newcomer-command-path.md
@@ -5,7 +5,7 @@ For a first-time user, the default surface is:
 
 1. Install or repair the CLI.
 2. Ask an agent to connect the current project.
-3. Use `/loopx <goal>` to start useful work.
+3. Use the host's LoopX command entry to start useful work.
 
 The full command set remains available for operators and contributors, but it
 should not be the first thing a newcomer has to understand.
@@ -14,27 +14,31 @@ should not be the first thing a newcomer has to understand.
 
 | Need | Use | Expected result |
 | --- | --- | --- |
-| Check whether this project is connected and what is waiting. | `/loopx` | The agent reads LoopX status, gates, todos, and next safe action without starting a new delivery path. |
-| Start a concrete long-running goal. | `/loopx <goal text>` | The agent plans first, writes ordered todos, then advances one bounded, validated slice at a time. |
+| Check whether this project is connected and what is waiting. | LoopX status entry | The agent reads LoopX status, gates, todos, and next safe action without starting a new delivery path. |
+| Start concrete long-running work. | LoopX task entry with `<task text>` | The agent plans first, writes ordered todos, then advances one bounded, validated slice at a time. |
 
 Examples:
 
 ```text
-/loopx fix the open PR review feedback and keep the patch reviewable
-/loopx split this refactor into PR-sized slices and stop at unsafe gates
+$loopx fix the open PR review feedback and keep the patch reviewable
+$loopx split this refactor into PR-sized slices and stop at unsafe gates
 ```
+
+In current Codex surfaces, invoke the explicit `loopx` skill with `$loopx` or
+choose it from `/skills`. On hosts that expose native custom slash commands,
+the same task text may appear as `/loopx <task text>`.
 
 ## Choose The Loop Driver
 
-LoopX preserves goal state, gates, todos, quota, and evidence. It does not
+LoopX preserves objective state, gates, todos, quota, and evidence. It does not
 replace the app or CLI that runs the next agent turn. Pick the driver that
 matches the surface you already use:
 
 | Surface | Start with | What keeps it moving |
 | --- | --- | --- |
-| Codex App | `/loopx <goal text>` in the project thread | The app heartbeat automation. Let the agent install or refresh the generated LoopX heartbeat body; start at the bootstrap cadence, then follow `quota should-run.scheduler_hint`. |
+| Codex App | `$loopx <task text>` or `/skills` -> `loopx` in the project thread | The app heartbeat automation. Let the agent install or refresh the generated LoopX heartbeat body; start at the bootstrap cadence, then follow `quota should-run.scheduler_hint`. |
 | Codex CLI | `codex` from the project root, then paste `loopx codex-cli-bootstrap-message --project .` output | Current verified Codex CLI builds do not load user-installed `/loopx` or `/prompts:loopx` commands. Keep the executor visible, then set the generated `/goal <thin task_body>`. |
-| Claude Code | Install LoopX, then `/loopx <goal text>` | The installer registers lightweight slash-command skills. Enable the opt-in adapter only when Claude Code's native `/loop` should be gated by LoopX `should_run`. |
+| Claude Code | Install LoopX, then `/loopx <task text>` | The installer registers lightweight slash-command skills. Enable the opt-in adapter only when Claude Code's native `/loop` should be gated by LoopX `should_run`. |
 | Other agent or shell | `loopx bootstrap-command-pack --project .` | A CLI, task, automation, heartbeat, or scheduler hook must run the next turn. If the surface has no such hook, LoopX can track state but the user drives it manually. |
 
 ## One CLI Quickstart
@@ -67,18 +71,18 @@ than one LoopX project or agent lane:
 | See risks and blocked lanes. | `/loopx-global-risks` |
 
 These are manager views. They should summarize and route work across projects;
-they should not replace `/loopx <goal>` as the way to start useful work inside
-one repository.
+they should not replace the project-local LoopX task entry as the way to start
+useful work inside one repository.
 
 ## When To Use More Commands
 
 | If you are trying to... | Use this surface first | Only then reach for... |
 | --- | --- | --- |
-| Start work on a goal | `/loopx <goal text>` | `loopx bootstrap-command-pack --goal-text ...` when manually bootstrapping an agent. |
+| Start project-local work | LoopX task entry with `<task text>` | `loopx bootstrap-command-pack --goal-text ...` when manually bootstrapping an agent. |
 | Understand several LoopX projects at once | `/loopx-global-summary` | `/loopx-global-gates`, `/loopx-global-todos`, or `/loopx-global-risks` when you need a focused manager view. |
 | Understand why work is paused | `/loopx` | `loopx diagnose --goal-id <goal-id>` when the agent needs a deeper evidence packet. |
 | Review a handoff or gate | The agent's LoopX status summary | `loopx review-packet --goal-id <goal-id>` for a copyable operator packet. |
-| Operate recurring work | Codex App heartbeat or visible Codex CLI goal | `loopx heartbeat-prompt --thin --goal-id <goal-id>` when installing or repairing the loop. |
+| Operate recurring work | Codex App heartbeat or visible Codex CLI task body | `loopx heartbeat-prompt --thin --goal-id <goal-id>` when installing or repairing the loop. |
 | Debug the control plane | The specific error or blocked todo | `loopx status`, `loopx history`, `loopx quota should-run`, or `loopx check`. |
 
 ## Reference Boundary
@@ -87,8 +91,8 @@ The command catalog is reference material. Keep it useful, but keep it below
 the product path:
 
 - New users should not need to scan every command before trying LoopX.
-- Public examples should prefer `/loopx <goal>` unless they are teaching
-  installation, debugging, or maintainer workflows.
+- Public examples should prefer the host's LoopX task entry unless they are
+  teaching installation, debugging, or maintainer workflows.
 - Contributors may still use the full command reference in
   [Getting started](getting-started.md#command-reference).
 - Installed users can run `man loopx` or `loopx commands` when they need a

--- a/docs/product/codex-cli-packaged-install.md
+++ b/docs/product/codex-cli-packaged-install.md
@@ -29,9 +29,16 @@ snapshot under `~/.local/share/loopx/releases/`, installs the
 skills under `~/.codex/skills`. It also refreshes the lightweight slash-command
 facades:
 
-- `~/.codex/prompts/loopx*.md` for Codex CLI / IDE prompt discovery;
-- `~/.codex/skills/loopx*/SKILL.md` for Codex App skill discovery;
+- `~/.codex/skills/loopx*/SKILL.md` for explicit Codex command-facade
+  invocation through `$loopx` or `/skills`;
 - `~/.claude/skills/loopx*/SKILL.md` for Claude Code slash-command discovery.
+
+Current verified Codex CLI builds still reject user-installed `/loopx` and
+`/prompts:loopx` commands, so the packaged install reports Codex CLI as an
+unsupported native slash surface. For an explicit Codex skill invocation, use
+`$loopx` or choose `loopx` from `/skills`. For the visible long-running TUI
+loop, use `loopx codex-cli-bootstrap-message --project .`, paste the generated
+setup into the TUI, then set the generated `/goal <thin task_body>`.
 
 By default, the archive source is the public `stable` ref. Maintainers can
 override it with `LOOPX_REF=main` when intentionally testing or repairing from

--- a/docs/product/codex-cli-packaged-install.md
+++ b/docs/product/codex-cli-packaged-install.md
@@ -26,7 +26,12 @@ loopx doctor
 The installer downloads a GitHub archive, creates a stable local release
 snapshot under `~/.local/share/loopx/releases/`, installs the
 `loopx` wrapper under `~/.local/bin`, and installs the reusable Codex
-skills under `~/.codex/skills`.
+skills under `~/.codex/skills`. It also refreshes the lightweight slash-command
+facades:
+
+- `~/.codex/prompts/loopx*.md` for Codex CLI / IDE prompt discovery;
+- `~/.codex/skills/loopx*/SKILL.md` for Codex App skill discovery;
+- `~/.claude/skills/loopx*/SKILL.md` for Claude Code slash-command discovery.
 
 By default, the archive source is the public `stable` ref. Maintainers can
 override it with `LOOPX_REF=main` when intentionally testing or repairing from

--- a/docs/product/codex-cli-packaged-install.md
+++ b/docs/product/codex-cli-packaged-install.md
@@ -8,7 +8,7 @@ For Codex CLI users, the first successful path is:
 1. Open Codex CLI TUI in a project repo.
 2. Paste one LoopX start message.
 3. If `loopx` is missing, let the agent run the no-clone installer.
-4. Return to the same TUI with current goal, gate, todo, and next safe action.
+4. Return to the same TUI with current objective, gate, todo, and next safe action.
 
 The user should not have to clone this repository before learning whether
 LoopX helps their project.
@@ -55,7 +55,7 @@ The agent-first start message can now be stricter about install repair:
 ```text
 Start LoopX for this repo. If `loopx` is missing, install it with
 the official no-clone GitHub installer, then connect this project. Show me the
-current goal, concrete user gate if any, top todos, and next safe action before
+current objective, concrete user gate if any, top todos, and next safe action before
 running longer work. Keep me in this Codex CLI TUI unless I explicitly accept a
 headless fallback.
 ```

--- a/docs/reference/protocols/codex-app-host-command-registry-v0.md
+++ b/docs/reference/protocols/codex-app-host-command-registry-v0.md
@@ -158,6 +158,7 @@ Every host command must expose a deterministic CLI fallback:
 
 ```bash
 loopx slash-commands
+loopx slash-commands --install
 loopx bootstrap-command-pack --project .
 loopx bootstrap-command-pack --project . --goal-text "<goal text>"
 loopx global-summary
@@ -166,6 +167,24 @@ loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" quota s
 
 If host command parsing is unavailable, the user or a skill fallback can still
 run these commands and preserve the same LoopX state machine.
+
+## Userland Registration Fallback
+
+Until every host exposes a native command registry, LoopX installs slash-command
+facades into the user-level discovery locations that current hosts already
+support:
+
+- `~/.codex/prompts/loopx*.md` for Codex CLI / IDE prompt commands;
+- `~/.codex/skills/loopx*/SKILL.md` for Codex App skill-based command
+  discovery;
+- `~/.claude/skills/loopx*/SKILL.md` for Claude Code skill-based slash
+  commands.
+
+This fallback does not replace host parsing. It gives users a working `/loopx`
+entry point now, while preserving the same CLI baselines and permission
+boundaries defined above. The installer overwrites LoopX-managed files and
+known legacy LoopX-generated command files, but it skips same-name user files
+without a LoopX managed marker or legacy signature.
 
 ## Acceptance Checks
 

--- a/docs/reference/protocols/codex-app-host-command-registry-v0.md
+++ b/docs/reference/protocols/codex-app-host-command-registry-v0.md
@@ -174,17 +174,18 @@ Until every host exposes a native command registry, LoopX installs slash-command
 facades into the user-level discovery locations that current hosts already
 support:
 
-- `~/.codex/prompts/loopx*.md` for Codex CLI / IDE prompt commands;
-- `~/.codex/skills/loopx*/SKILL.md` for Codex App skill-based command
-  discovery;
+- `~/.codex/skills/loopx*/SKILL.md` for explicit Codex command-facade
+  invocation through `$loopx` or `/skills`;
 - `~/.claude/skills/loopx*/SKILL.md` for Claude Code skill-based slash
   commands.
 
-This fallback does not replace host parsing. It gives users a working `/loopx`
-entry point now, while preserving the same CLI baselines and permission
-boundaries defined above. The installer overwrites LoopX-managed files and
-known legacy LoopX-generated command files, but it skips same-name user files
-without a LoopX managed marker or legacy signature.
+This fallback does not replace host parsing. It gives users an explicit Codex
+skill entry point now, while preserving the same CLI baselines and permission
+boundaries defined above. The Codex command facades are explicit-only; the
+richer workflow skills remain available for implicit invocation. The installer
+overwrites LoopX-managed files and known legacy LoopX-generated command files,
+but it skips same-name user files without a LoopX managed marker or legacy
+signature.
 
 ## Acceptance Checks
 

--- a/docs/reference/protocols/codex-app-host-command-registry-v0.md
+++ b/docs/reference/protocols/codex-app-host-command-registry-v0.md
@@ -7,8 +7,8 @@ structured handoff packet. LoopX CLI remains the source of truth.
 
 This contract sits above:
 
-- [`loopx_goal_command_v0`](loopx-goal-command-v0.md) for project-local
-  `/loopx` and `/loopx <goal text>`.
+- [`loopx_goal_command_v0`](loopx-goal-command-v0.md) for the project-local
+  `/loopx` status entry and `/loopx <task text>` start entry.
 - [`global_manager_command_v0`](global-manager-command-v0.md) for read-only
   `/loopx-global-*` manager commands.
 - [`host_integration_surface_v0`](host-integration-surface-v0.md) for general
@@ -24,7 +24,7 @@ The host registry should expose this minimal command set:
 | Command | Canonical target | Default authority |
 | --- | --- | --- |
 | `/loopx` | `loopx bootstrap-command-pack --project .` | Read/status-first. |
-| `/loopx <goal text>` | `loopx bootstrap-command-pack --project . --goal-text "<goal text>"` | Explicit project-local goal-start intent. |
+| `/loopx <task text>` | `loopx bootstrap-command-pack --project . --goal-text "<task text>"` | Explicit project-local start intent. |
 | `/loopx-global-summary` | `global_manager_command_v0` summary request | Read-only global control-plane digest. |
 | `/loopx-global-gates` | `global_manager_command_v0` gates request | Read-only gate inbox. |
 | `/loopx-global-todos` | `global_manager_command_v0` todos request | Read-only work queue view. |
@@ -50,11 +50,11 @@ Example registry entry:
       "mutation_policy": "read_first"
     },
     {
-      "command": "/loopx <goal text>",
-      "kind": "project_goal_start",
+      "command": "/loopx <task text>",
+      "kind": "project_task_start",
       "protocol": "loopx_goal_command_v0",
-      "cli_baseline": "loopx bootstrap-command-pack --project . --goal-text \"<goal text>\"",
-      "mutation_policy": "explicit_goal_start"
+      "cli_baseline": "loopx bootstrap-command-pack --project . --goal-text \"<task text>\"",
+      "mutation_policy": "explicit_project_start"
     },
     {
       "command": "/loopx-global-summary",
@@ -77,8 +77,8 @@ message:
    message.
 2. Canonicalize legacy `/loop-global-*` aliases to `/loopx-global-*`.
 3. Treat `/loopx` with no trailing text as bootstrap/status preview.
-4. Treat text after `/loopx` as explicit goal-start text. Preserve the exact
-   user goal text in the handoff packet, but quote it safely for CLI display.
+4. Treat text after `/loopx` as explicit task text. Preserve the exact
+   user task text in the handoff packet, but quote it safely for CLI display.
 5. Fail closed for unknown `/loopx-*` commands and return `loopx slash-commands`
    help instead of falling through to ordinary chat.
 
@@ -98,11 +98,11 @@ Required fields:
 | --- | --- |
 | `project_root` | Absolute local root for CLI execution; omit from public packets. |
 | `project_root_label` | Public-safe label such as repo name or `current workspace`. |
-| `goal_id` | Use the registry goal id when known; otherwise let `bootstrap-command-pack` infer or propose one. |
+| `goal_id` | Existing runtime state id field; keep the field name for CLI compatibility, but present it to users as the active state id. |
 | `agent_id` | Registered LoopX agent id when the host is acting for an agent. |
 | `host_surface` | `chat_box`, `command_palette`, `codex_cli_tui`, or another compact host label. |
 
-If the host cannot resolve a project root, `/loopx` and `/loopx <goal text>`
+If the host cannot resolve a project root, `/loopx` and `/loopx <task text>`
 must produce a setup/help packet, not state writes. Global commands may still
 run against the shared global registry when available.
 
@@ -115,14 +115,14 @@ After parsing, the host hands the agent or CLI a compact packet:
   "schema_version": "codex_app_host_command_handoff_v0",
   "command": "/loopx",
   "raw_command": "/loopx design an issue-fix workflow",
-  "canonical_command": "/loopx <goal text>",
-  "goal_text": "design an issue-fix workflow",
+  "canonical_command": "/loopx <task text>",
+  "task_text": "design an issue-fix workflow",
   "host_surface": "chat_box",
   "project_root_label": "current workspace",
   "goal_id": "loopx-meta",
   "agent_id": "codex-product-capability",
   "protocol": "loopx_goal_command_v0",
-  "cli_preview": "loopx bootstrap-command-pack --project . --goal-text \"<goal text>\"",
+  "cli_preview": "loopx bootstrap-command-pack --project . --goal-text \"<task text>\"",
   "authority": {
     "read_allowed": true,
     "project_local_write_allowed": true,
@@ -144,8 +144,8 @@ visible user intent into the existing CLI lifecycle:
 
 - `/loopx` can read status and preview command packs. It stops before writes
   that need confirmation.
-- `/loopx <goal text>` is explicit intent to start a project-local LoopX goal:
-  plan first, write ordered todos, refresh state, run `quota should-run`, and
+- `/loopx <task text>` is explicit intent to start project-local work: plan
+  first, write ordered todos, refresh state, run `quota should-run`, and
   execute only when the guard allows.
 - `/loopx-global-*` commands are read-only and must not approve gates, add
   todos, spend quota, merge PRs, publish externally, or pause/resume loops.
@@ -160,7 +160,7 @@ Every host command must expose a deterministic CLI fallback:
 loopx slash-commands
 loopx slash-commands --install
 loopx bootstrap-command-pack --project .
-loopx bootstrap-command-pack --project . --goal-text "<goal text>"
+loopx bootstrap-command-pack --project . --goal-text "<task text>"
 loopx global-summary
 loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" quota should-run --goal-id <goal-id> --agent-id <agent-id>
 ```
@@ -191,12 +191,13 @@ signature.
 
 A host command registry implementation is acceptable when:
 
-1. `/loopx` and `/loopx <goal text>` route to `loopx_goal_command_v0`.
+1. `/loopx` and `/loopx <task text>` route to `loopx_goal_command_v0`.
 2. `/loopx-global-summary`, `/loopx-global-gates`, `/loopx-global-todos`, and
    `/loopx-global-risks` route to `global_manager_command_v0`.
 3. Legacy `/loop-global-*` inputs canonicalize to `/loopx-global-*`.
 4. Unknown `/loopx-*` commands fail closed with `loopx slash-commands` help.
-5. The handoff packet includes project root label, optional goal id, agent id,
-   protocol, authority, and CLI fallback, without public local absolute paths.
+5. The handoff packet includes project root label, optional active state id,
+   agent id, protocol, authority, and CLI fallback, without public local
+   absolute paths.
 6. Host parsing is treated as the preferred path, while skill-level recognition
    remains only a compatibility fallback.

--- a/examples/claude-install-optin-smoke.py
+++ b/examples/claude-install-optin-smoke.py
@@ -2,8 +2,10 @@
 """Smoke-test the Claude Code adapter install boundary.
 
 Proves the install-side review requirements:
-  1. the normal loopx install (`scripts/install-local.sh`) does NOT write
-     `~/.claude` unless the Claude adapter is explicitly opted in;
+  1. the normal loopx install (`scripts/install-local.sh`) may install
+     lightweight Claude Code slash-command skills, but does NOT install the
+     Claude adapter command/settings/hooks unless the adapter is explicitly
+     opted in;
   2. `install.py` requires a deliberate `--scope user|project` and confines
      project-scope writes to that project (no global side effect); hooks are
      opt-in via `--harden`, not the default;
@@ -35,7 +37,7 @@ def _install_py(args, **kw):
 
 
 def main() -> int:
-    # --- 1) the normal install never writes ~/.claude (opt-in) ----------------
+    # --- 1) default install only writes lightweight slash skills --------------
     with tempfile.TemporaryDirectory(prefix="loopx-claude-optin-smoke-") as tmp:
         home = Path(tmp) / "home"
         bin_dir = home / ".local" / "bin"
@@ -53,7 +55,15 @@ def main() -> int:
         env.pop("LOOPX_INSTALL_CLAUDE", None)  # default = off
         r = _run(["bash", str(INSTALL_SH)], env=env, cwd=str(REPO_ROOT), timeout=240)
         assert r.returncode == 0, f"install-local.sh failed:\n{r.stdout}\n{r.stderr}"
-        assert not (home / ".claude").exists(), "default install wrote ~/.claude — must be opt-in!"
+        assert (home / ".claude" / "skills" / "loopx" / "SKILL.md").is_file(), (
+            "default install should register the lightweight /loopx slash skill"
+        )
+        assert not (home / ".claude" / "commands" / "loopx.md").exists(), (
+            "default install must not install the Claude adapter command"
+        )
+        assert not (home / ".claude" / "settings.json").exists(), (
+            "default install must not write Claude adapter hooks/settings"
+        )
         assert "skipped (opt-in" in r.stdout, f"summary should mark the adapter opt-in:\n{r.stdout}"
 
     # --- 2) install.py requires an explicit scope; project scope is isolated ---

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -193,6 +193,9 @@ def main() -> int:
         assert f"- skill: {codex_home / 'skills' / 'loopx-pr-review'}" in install.stdout, install.stdout
         assert f"- skill: {codex_home / 'skills' / 'loopx-project'}" in install.stdout, install.stdout
         assert f"- skill: {codex_home / 'skills' / 'loopx-self-repair'}" in install.stdout, install.stdout
+        assert f"codex prompts: {codex_home / 'prompts'}" in install.stdout, install.stdout
+        assert f"codex skills: {codex_home / 'skills'}" in install.stdout, install.stdout
+        assert f"claude skills: {home / '.claude' / 'skills'}" in install.stdout, install.stdout
 
         wrapper = bin_dir / "loopx"
         assert wrapper.is_symlink(), wrapper
@@ -284,6 +287,25 @@ def main() -> int:
             assert phrase in pr_review_text, phrase
         auto_research_skill = codex_home / "skills" / "loopx-auto-research" / "SKILL.md"
         assert not auto_research_skill.exists(), auto_research_skill
+        loopx_prompt = codex_home / "prompts" / "loopx.md"
+        loopx_prompt_text = loopx_prompt.read_text(encoding="utf-8")
+        assert "loopx-managed-slash-command:v1 command=/loopx surface=codex-prompts" in loopx_prompt_text
+        assert "bootstrap-command-pack --project . --goal-text" in loopx_prompt_text
+        loopx_global_prompt = codex_home / "prompts" / "loopx-global-summary.md"
+        loopx_global_prompt_text = loopx_global_prompt.read_text(encoding="utf-8")
+        assert "loopx global-summary" in loopx_global_prompt_text, loopx_global_prompt_text
+        loopx_command_skill = codex_home / "skills" / "loopx" / "SKILL.md"
+        loopx_command_skill_text = loopx_command_skill.read_text(encoding="utf-8")
+        assert "surface=codex-skills" in loopx_command_skill_text, loopx_command_skill_text
+        claude_loopx_skill = home / ".claude" / "skills" / "loopx" / "SKILL.md"
+        claude_loopx_skill_text = claude_loopx_skill.read_text(encoding="utf-8")
+        assert "surface=claude-skills" in claude_loopx_skill_text, claude_loopx_skill_text
+        assert not (home / ".claude" / "commands" / "loopx.md").exists(), (
+            "default installer must not install the opt-in Claude adapter command"
+        )
+        assert not (home / ".claude" / "settings.json").exists(), (
+            "default installer must not install Claude adapter hooks/settings"
+        )
         doc_registry_skill = codex_home / "skills" / "loopx-doc-registry" / "SKILL.md"
         doc_registry_text = " ".join(doc_registry_skill.read_text(encoding="utf-8").split())
         for phrase in (

--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -193,7 +193,6 @@ def main() -> int:
         assert f"- skill: {codex_home / 'skills' / 'loopx-pr-review'}" in install.stdout, install.stdout
         assert f"- skill: {codex_home / 'skills' / 'loopx-project'}" in install.stdout, install.stdout
         assert f"- skill: {codex_home / 'skills' / 'loopx-self-repair'}" in install.stdout, install.stdout
-        assert f"codex prompts: {codex_home / 'prompts'}" in install.stdout, install.stdout
         assert f"codex skills: {codex_home / 'skills'}" in install.stdout, install.stdout
         assert f"claude skills: {home / '.claude' / 'skills'}" in install.stdout, install.stdout
 
@@ -288,15 +287,13 @@ def main() -> int:
         auto_research_skill = codex_home / "skills" / "loopx-auto-research" / "SKILL.md"
         assert not auto_research_skill.exists(), auto_research_skill
         loopx_prompt = codex_home / "prompts" / "loopx.md"
-        loopx_prompt_text = loopx_prompt.read_text(encoding="utf-8")
-        assert "loopx-managed-slash-command:v1 command=/loopx surface=codex-prompts" in loopx_prompt_text
-        assert "bootstrap-command-pack --project . --goal-text" in loopx_prompt_text
-        loopx_global_prompt = codex_home / "prompts" / "loopx-global-summary.md"
-        loopx_global_prompt_text = loopx_global_prompt.read_text(encoding="utf-8")
-        assert "loopx global-summary" in loopx_global_prompt_text, loopx_global_prompt_text
+        assert not loopx_prompt.exists(), loopx_prompt
         loopx_command_skill = codex_home / "skills" / "loopx" / "SKILL.md"
         loopx_command_skill_text = loopx_command_skill.read_text(encoding="utf-8")
         assert "surface=codex-skills" in loopx_command_skill_text, loopx_command_skill_text
+        loopx_openai_metadata = codex_home / "skills" / "loopx" / "agents" / "openai.yaml"
+        loopx_openai_metadata_text = loopx_openai_metadata.read_text(encoding="utf-8")
+        assert "allow_implicit_invocation: false" in loopx_openai_metadata_text, loopx_openai_metadata_text
         claude_loopx_skill = home / ".claude" / "skills" / "loopx" / "SKILL.md"
         claude_loopx_skill_text = claude_loopx_skill.read_text(encoding="utf-8")
         assert "surface=claude-skills" in claude_loopx_skill_text, claude_loopx_skill_text
@@ -342,6 +339,19 @@ def main() -> int:
         assert (
             codex_home / "skills" / "loopx-self-repair" / "agents" / "openai.yaml"
         ).is_file()
+        for implicit_skill_name in (
+            "loopx-project",
+            "loopx-pr-review",
+            "loopx-doc-registry",
+            "loopx-self-repair",
+        ):
+            implicit_metadata = codex_home / "skills" / implicit_skill_name / "agents" / "openai.yaml"
+            if implicit_metadata.exists():
+                implicit_metadata_text = implicit_metadata.read_text(encoding="utf-8")
+                assert "allow_implicit_invocation: false" not in implicit_metadata_text, (
+                    implicit_skill_name,
+                    implicit_metadata_text,
+                )
 
         cli_env = {**env, "PATH": f"{bin_dir}:{env['PATH']}"}
         runtime_run_dir = home / ".codex" / "loopx" / "goals" / "loopx-meta" / "runs"

--- a/examples/slash-command-install-smoke.py
+++ b/examples/slash-command-install-smoke.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Smoke-test LoopX slash-command prompt/skill installation."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *args],
+        cwd=REPO_ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+
+def statuses_for(payload: dict, path: Path) -> list[str]:
+    return [
+        str(item["status"])
+        for item in payload["installed"]
+        if item.get("path") == str(path)
+    ]
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-slash-install-smoke-") as tmp:
+        root = Path(tmp)
+        codex_home = root / ".codex"
+        claude_home = root / ".claude"
+
+        dry = json.loads(
+            run_cli(
+                "--format",
+                "json",
+                "slash-commands",
+                "--dry-run",
+                "--codex-home",
+                str(codex_home),
+                "--claude-home",
+                str(claude_home),
+            ).stdout
+        )
+        assert dry["schema_version"] == "loopx_slash_command_install_v0", dry
+        assert dry["execute"] is False, dry
+        assert dry["summary"]["status_counts"]["would_create"] >= 20, dry
+        assert not (codex_home / "prompts").exists(), dry
+        assert not (claude_home / "skills").exists(), dry
+
+        payload = json.loads(
+            run_cli(
+                "--format",
+                "json",
+                "slash-commands",
+                "--install",
+                "--codex-home",
+                str(codex_home),
+                "--claude-home",
+                str(claude_home),
+            ).stdout
+        )
+        assert payload["execute"] is True, payload
+        assert payload["summary"]["codex_prompt_dir"] == str(codex_home / "prompts"), payload
+        assert payload["summary"]["codex_skill_dir"] == str(codex_home / "skills"), payload
+        assert payload["summary"]["claude_skill_dir"] == str(claude_home / "skills"), payload
+        assert payload["summary"]["status_counts"]["created"] >= 20, payload
+        assert "skipped_user_file" not in payload["summary"]["status_counts"], payload
+
+        codex_prompt = codex_home / "prompts" / "loopx.md"
+        codex_prompt_text = codex_prompt.read_text(encoding="utf-8")
+        assert "loopx-managed-slash-command:v1 command=/loopx surface=codex-prompts" in codex_prompt_text
+        assert "bootstrap-command-pack --project . --goal-text" in codex_prompt_text
+        assert "argument-hint: \"[goal text]\"" in codex_prompt_text
+
+        codex_skill = codex_home / "skills" / "loopx" / "SKILL.md"
+        codex_skill_text = codex_skill.read_text(encoding="utf-8")
+        assert "name: \"loopx\"" in codex_skill_text
+        assert "surface=codex-skills" in codex_skill_text
+        assert "LoopX `/loopx`" in codex_skill_text
+
+        pr_review_prompt = codex_home / "prompts" / "loopx-pr-review.md"
+        pr_review_text = pr_review_prompt.read_text(encoding="utf-8")
+        assert "agent_response_contract" in pr_review_text
+        assert "Do not reconstruct the PR queue manually" in pr_review_text
+
+        claude_skill = claude_home / "skills" / "loopx-global-summary" / "SKILL.md"
+        claude_skill_text = claude_skill.read_text(encoding="utf-8")
+        assert "name: \"loopx-global-summary\"" in claude_skill_text
+        assert "surface=claude-skills" in claude_skill_text
+        assert "global-summary" in claude_skill_text
+
+        rerun = json.loads(
+            run_cli(
+                "--format",
+                "json",
+                "slash-commands",
+                "--install",
+                "--codex-home",
+                str(codex_home),
+                "--claude-home",
+                str(claude_home),
+            ).stdout
+        )
+        assert rerun["summary"]["status_counts"]["unchanged"] >= 20, rerun
+
+        user_owned = codex_home / "prompts" / "loopx-global-risks.md"
+        user_owned.write_text("# user-owned command\n", encoding="utf-8")
+        legacy_owned = codex_home / "prompts" / "loopx-global-todos.md"
+        legacy_owned.write_text(
+            "# old loopx command\n\nloopx goal-mode setup (NOT Claude Code's built-in /goal)\n",
+            encoding="utf-8",
+        )
+        capability_skill = codex_home / "skills" / "loopx-pr-review" / "SKILL.md"
+        capability_skill.write_text(
+            "# LoopX PR Review\n\nRun `loopx pr-review` first.\n",
+            encoding="utf-8",
+        )
+        mixed = json.loads(
+            run_cli(
+                "--format",
+                "json",
+                "slash-commands",
+                "--install",
+                "--codex-home",
+                str(codex_home),
+                "--claude-home",
+                str(claude_home),
+            ).stdout
+        )
+        assert statuses_for(mixed, user_owned) == ["skipped_user_file"], mixed
+        assert user_owned.read_text(encoding="utf-8") == "# user-owned command\n"
+        assert statuses_for(mixed, legacy_owned) == ["upgraded_legacy_managed"], mixed
+        assert "loopx-managed-slash-command:v1 command=/loopx-global-todos" in legacy_owned.read_text(
+            encoding="utf-8"
+        )
+        assert statuses_for(mixed, capability_skill) == ["preserved_existing_loopx_skill"], mixed
+        assert capability_skill.read_text(encoding="utf-8") == (
+            "# LoopX PR Review\n\nRun `loopx pr-review` first.\n"
+        )
+
+        markdown = run_cli(
+            "slash-commands",
+            "--install",
+            "--codex-home",
+            str(codex_home),
+            "--claude-home",
+            str(claude_home),
+        ).stdout
+        assert "# LoopX Slash Command Install" in markdown, markdown
+        assert "codex prompts:" in markdown, markdown
+        assert "codex skills:" in markdown, markdown
+        assert "claude skills:" in markdown, markdown
+        assert "Skipped user-owned files:" in markdown, markdown
+
+        codex_only = json.loads(
+            run_cli(
+                "--format",
+                "json",
+                "slash-commands",
+                "--install",
+                "--surface",
+                "codex-cli",
+                "--codex-home",
+                str(root / "codex-only"),
+                "--claude-home",
+                str(root / "claude-unused"),
+            ).stdout
+        )
+        assert codex_only["effective_surfaces"] == ["codex"], codex_only
+        assert codex_only["summary"]["claude_skill_dir"] is None, codex_only
+
+    print("slash-command-install-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/slash-command-install-smoke.py
+++ b/examples/slash-command-install-smoke.py
@@ -53,8 +53,10 @@ def main() -> int:
         assert dry["schema_version"] == "loopx_slash_command_install_v0", dry
         assert dry["execute"] is False, dry
         assert dry["summary"]["status_counts"]["would_create"] >= 20, dry
+        assert dry["summary"]["status_counts"]["unsupported_host_surface"] >= 1, dry
         assert not (codex_home / "prompts").exists(), dry
         assert not (claude_home / "skills").exists(), dry
+        assert dry["summary"]["codex_prompt_dir"] is None, dry
 
         payload = json.loads(
             run_cli(
@@ -69,28 +71,46 @@ def main() -> int:
             ).stdout
         )
         assert payload["execute"] is True, payload
-        assert payload["summary"]["codex_prompt_dir"] == str(codex_home / "prompts"), payload
+        assert payload["summary"]["codex_prompt_dir"] is None, payload
         assert payload["summary"]["codex_skill_dir"] == str(codex_home / "skills"), payload
         assert payload["summary"]["claude_skill_dir"] == str(claude_home / "skills"), payload
         assert payload["summary"]["status_counts"]["created"] >= 20, payload
+        assert payload["summary"]["status_counts"]["unsupported_host_surface"] >= 1, payload
         assert "skipped_user_file" not in payload["summary"]["status_counts"], payload
-
-        codex_prompt = codex_home / "prompts" / "loopx.md"
-        codex_prompt_text = codex_prompt.read_text(encoding="utf-8")
-        assert "loopx-managed-slash-command:v1 command=/loopx surface=codex-prompts" in codex_prompt_text
-        assert "bootstrap-command-pack --project . --goal-text" in codex_prompt_text
-        assert "argument-hint: \"[goal text]\"" in codex_prompt_text
+        codex_skill_rows = [
+            item
+            for item in payload["installed"]
+            if item.get("mechanism") == "codex_explicit_skills" and item.get("command") == "/loopx"
+        ]
+        assert codex_skill_rows, payload
+        assert codex_skill_rows[0]["invoke_as"] == ["$loopx", "/skills"], codex_skill_rows
+        assert "/loopx" not in codex_skill_rows[0]["invoke_as"], codex_skill_rows
+        codex_metadata_rows = [
+            item
+            for item in payload["installed"]
+            if item.get("mechanism") == "codex_skill_openai_metadata" and item.get("command") == "/loopx"
+        ]
+        assert codex_metadata_rows, payload
+        codex_cli_rows = [
+            item
+            for item in payload["installed"]
+            if item.get("mechanism") == "unsupported_native_slash_registry" and item.get("command") == "/loopx"
+        ]
+        assert codex_cli_rows, payload
+        assert codex_cli_rows[0]["status"] == "unsupported_host_surface", codex_cli_rows
+        assert "$loopx" in codex_cli_rows[0]["fallback"], codex_cli_rows
 
         codex_skill = codex_home / "skills" / "loopx" / "SKILL.md"
         codex_skill_text = codex_skill.read_text(encoding="utf-8")
         assert "name: \"loopx\"" in codex_skill_text
         assert "surface=codex-skills" in codex_skill_text
         assert "LoopX `/loopx`" in codex_skill_text
+        codex_metadata = codex_home / "skills" / "loopx" / "agents" / "openai.yaml"
+        codex_metadata_text = codex_metadata.read_text(encoding="utf-8")
+        assert "allow_implicit_invocation: false" in codex_metadata_text
+        assert "loopx-managed-slash-command:v1 command=/loopx surface=codex-skill-metadata" in codex_metadata_text
 
-        pr_review_prompt = codex_home / "prompts" / "loopx-pr-review.md"
-        pr_review_text = pr_review_prompt.read_text(encoding="utf-8")
-        assert "agent_response_contract" in pr_review_text
-        assert "Do not reconstruct the PR queue manually" in pr_review_text
+        assert not (codex_home / "prompts" / "loopx-pr-review.md").exists()
 
         claude_skill = claude_home / "skills" / "loopx-global-summary" / "SKILL.md"
         claude_skill_text = claude_skill.read_text(encoding="utf-8")
@@ -112,11 +132,13 @@ def main() -> int:
         )
         assert rerun["summary"]["status_counts"]["unchanged"] >= 20, rerun
 
-        user_owned = codex_home / "prompts" / "loopx-global-risks.md"
+        prompt_dir = codex_home / "prompts"
+        prompt_dir.mkdir(parents=True)
+        user_owned = prompt_dir / "loopx-global-risks.md"
         user_owned.write_text("# user-owned command\n", encoding="utf-8")
-        legacy_owned = codex_home / "prompts" / "loopx-global-todos.md"
-        legacy_owned.write_text(
-            "# old loopx command\n\nloopx goal-mode setup (NOT Claude Code's built-in /goal)\n",
+        managed_prompt = prompt_dir / "loopx-global-todos.md"
+        managed_prompt.write_text(
+            "<!-- loopx-managed-slash-command:v1 command=/loopx-global-todos surface=codex-prompts -->\n",
             encoding="utf-8",
         )
         capability_skill = codex_home / "skills" / "loopx-pr-review" / "SKILL.md"
@@ -124,6 +146,8 @@ def main() -> int:
             "# LoopX PR Review\n\nRun `loopx pr-review` first.\n",
             encoding="utf-8",
         )
+        capability_metadata = codex_home / "skills" / "loopx-pr-review" / "agents" / "openai.yaml"
+        assert capability_metadata.exists(), capability_metadata
         mixed = json.loads(
             run_cli(
                 "--format",
@@ -138,14 +162,14 @@ def main() -> int:
         )
         assert statuses_for(mixed, user_owned) == ["skipped_user_file"], mixed
         assert user_owned.read_text(encoding="utf-8") == "# user-owned command\n"
-        assert statuses_for(mixed, legacy_owned) == ["upgraded_legacy_managed"], mixed
-        assert "loopx-managed-slash-command:v1 command=/loopx-global-todos" in legacy_owned.read_text(
-            encoding="utf-8"
-        )
+        assert statuses_for(mixed, managed_prompt) == ["retired_managed_file"], mixed
+        assert not managed_prompt.exists()
         assert statuses_for(mixed, capability_skill) == ["preserved_existing_loopx_skill"], mixed
         assert capability_skill.read_text(encoding="utf-8") == (
             "# LoopX PR Review\n\nRun `loopx pr-review` first.\n"
         )
+        assert statuses_for(mixed, capability_metadata) == ["retired_managed_file"], mixed
+        assert not capability_metadata.exists(), capability_metadata
 
         markdown = run_cli(
             "slash-commands",
@@ -156,10 +180,10 @@ def main() -> int:
             str(claude_home),
         ).stdout
         assert "# LoopX Slash Command Install" in markdown, markdown
-        assert "codex prompts:" in markdown, markdown
         assert "codex skills:" in markdown, markdown
         assert "claude skills:" in markdown, markdown
         assert "Skipped user-owned files:" in markdown, markdown
+        assert "$loopx" in markdown and "command-facade skills" in markdown, markdown
 
         codex_only = json.loads(
             run_cli(
@@ -176,7 +200,10 @@ def main() -> int:
             ).stdout
         )
         assert codex_only["effective_surfaces"] == ["codex"], codex_only
+        assert codex_only["summary"]["codex_prompt_dir"] is None, codex_only
+        assert codex_only["summary"]["codex_skill_dir"] == str(root / "codex-only" / "skills"), codex_only
         assert codex_only["summary"]["claude_skill_dir"] is None, codex_only
+        assert codex_only["summary"]["status_counts"]["unsupported_host_surface"] == 10, codex_only
 
     print("slash-command-install-smoke ok")
     return 0

--- a/loopx/cli_commands/slash_commands.py
+++ b/loopx/cli_commands/slash_commands.py
@@ -39,20 +39,20 @@ def register_slash_commands_command(
     parser.add_argument(
         "--install",
         action="store_true",
-        help="Install LoopX slash-command prompt/skill files for supported hosts.",
+        help="Install LoopX command skill files for supported hosts.",
     )
     parser.add_argument(
         "--surface",
         action="append",
-        choices=["all", "codex", "codex-cli", "codex-app", "claude-code"],
+        choices=["all", "codex", "codex-cli", "codex-app", "codex-ide", "claude-code"],
         help=(
             "Host surface to install. Repeatable. Defaults to all "
-            "(Codex prompts plus Claude Code skills)."
+            "(Codex explicit skills plus Claude Code skills)."
         ),
     )
     parser.add_argument(
         "--codex-home",
-        help="Codex home for prompt installation. Defaults to CODEX_HOME or ~/.codex.",
+        help="Codex home for skill installation. Defaults to CODEX_HOME or ~/.codex.",
     )
     parser.add_argument(
         "--claude-home",

--- a/loopx/cli_commands/slash_commands.py
+++ b/loopx/cli_commands/slash_commands.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import argparse
 from collections.abc import Callable
 
+from ..slash_command_install import (
+    install_slash_commands,
+    render_slash_command_install_markdown,
+)
 from ..slash_commands import build_slash_command_catalog, render_slash_command_catalog_markdown
 
 
@@ -32,6 +36,33 @@ def register_slash_commands_command(
         action="store_true",
         help="Hide legacy /loop-global-* aliases from the command catalog.",
     )
+    parser.add_argument(
+        "--install",
+        action="store_true",
+        help="Install LoopX slash-command prompt/skill files for supported hosts.",
+    )
+    parser.add_argument(
+        "--surface",
+        action="append",
+        choices=["all", "codex", "codex-cli", "codex-app", "claude-code"],
+        help=(
+            "Host surface to install. Repeatable. Defaults to all "
+            "(Codex prompts plus Claude Code skills)."
+        ),
+    )
+    parser.add_argument(
+        "--codex-home",
+        help="Codex home for prompt installation. Defaults to CODEX_HOME or ~/.codex.",
+    )
+    parser.add_argument(
+        "--claude-home",
+        help="Claude Code home for skill installation. Defaults to CLAUDE_HOME or ~/.claude.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what slash-command files would be installed without writing them.",
+    )
 
 
 def handle_slash_commands_command(
@@ -42,6 +73,17 @@ def handle_slash_commands_command(
 ) -> int | None:
     if args.command != "slash-commands":
         return None
+    if args.install or args.dry_run:
+        payload = install_slash_commands(
+            execute=bool(args.install and not args.dry_run),
+            surfaces=args.surface,
+            cli_bin=args.cli_bin,
+            include_legacy_aliases=not bool(args.no_legacy_aliases),
+            codex_home=args.codex_home,
+            claude_home=args.claude_home,
+        )
+        print_payload(payload, output_format(args), render_slash_command_install_markdown)
+        return 0
     payload = build_slash_command_catalog(
         cli_bin=args.cli_bin,
         include_legacy_aliases=not bool(args.no_legacy_aliases),

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -28,6 +28,10 @@ COMMAND_GROUPS: list[dict[str, object]] = [
                 "command": "loopx bootstrap-command-pack --project .",
                 "purpose": "Generate a setup packet for a manual shell or first agent handoff.",
             },
+            {
+                "command": "loopx slash-commands --install",
+                "purpose": "Refresh host slash-command prompt and skill files.",
+            },
         ],
     },
     {
@@ -64,7 +68,7 @@ COMMAND_GROUPS: list[dict[str, object]] = [
             },
             {
                 "command": "Claude Code /loop",
-                "purpose": "Enable the opt-in adapter, start `/loopx <goal>`, then let Claude Code `/loop` tick it.",
+                "purpose": "Use installed slash skills for `/loopx`; enable the adapter only when native `/loop` should be gated by LoopX.",
             },
             {
                 "command": "Other agent or shell",
@@ -172,7 +176,7 @@ def render_concise_help(program: str = "loopx") -> str:
             "Run the loop:",
             "  Codex App      use /loopx <goal>; let the app set the heartbeat automation.",
             "  Codex CLI      keep visible TUI; run loopx codex-cli-bootstrap-message.",
-            "  Claude Code    enable the adapter, start /loopx <goal>, then run /loop.",
+            "  Claude Code    use installed /loopx skills; adapter only for gated native /loop.",
             "  Other agents   need a CLI/task/automation/loop hook, or run LoopX manually.",
             "",
             "Global options:",
@@ -180,6 +184,7 @@ def render_concise_help(program: str = "loopx") -> str:
             "",
             "More:",
             "  loopx commands                 Show grouped command reference.",
+            "  loopx slash-commands           Show/install slash command prompt and skill files.",
             "  loopx <command> --help         Show flags for one command.",
             "  man loopx                      Open the installed manual page.",
             "  docs/guides/newcomer-command-path.md",

--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -33,7 +33,7 @@ def _front_matter(*, fields: dict[str, str]) -> str:
     return "\n".join(lines)
 
 
-def _prompt_body(
+def _skill_body(
     *,
     command: str,
     title: str,
@@ -49,16 +49,31 @@ def _prompt_body(
     }
     if front_matter_name:
         fields = {"name": front_matter_name, **fields}
+    surface_label = "slash command" if surface == "claude-skills" else "explicit LoopX command skill"
     return "\n\n".join(
         [
             _front_matter(fields=fields),
             _managed_marker(command=command, surface=surface),
             f"# {title}",
-            f"Treat this as the LoopX `{command}` slash command.",
+            f"Treat this as the LoopX `{command}` {surface_label}.",
             "\n".join(instructions),
             "Keep public/private boundaries intact and do not perform external writes unless the active LoopX state or owner explicitly authorizes them.",
         ]
     ) + "\n"
+
+
+def _openai_skill_metadata(*, command: str, display_name: str, short_description: str) -> str:
+    return "\n".join(
+        [
+            f"# {_managed_marker(command=command, surface='codex-skill-metadata')}",
+            "interface:",
+            f'  display_name: "{display_name}"',
+            f'  short_description: "{short_description}"',
+            "policy:",
+            "  allow_implicit_invocation: false",
+            "",
+        ]
+    )
 
 
 def _command_prompt_specs(*, cli_bin: str, include_legacy_aliases: bool) -> list[dict[str, Any]]:
@@ -182,6 +197,17 @@ def _target_status(path: Path, content: str, *, execute: bool) -> str:
     return "created" if execute else "would_create"
 
 
+def _retire_managed_file(path: Path, *, execute: bool) -> str | None:
+    if not path.exists():
+        return None
+    existing = path.read_text(encoding="utf-8")
+    if MANAGED_MARKER_PREFIX not in existing:
+        return "skipped_user_file"
+    if execute:
+        path.unlink()
+    return "retired_managed_file" if execute else "would_retire_managed_file"
+
+
 def _codex_home(value: str | None = None) -> Path:
     raw = value or os.environ.get("CODEX_HOME") or str(Path.home() / ".codex")
     return Path(raw).expanduser()
@@ -198,7 +224,9 @@ def _normalize_surfaces(surfaces: list[str] | None) -> list[str]:
     for surface in requested:
         if surface == "all":
             candidates = ["codex", "claude-code"]
-        elif surface in {"codex-cli", "codex-app"}:
+        elif surface == "codex":
+            candidates = ["codex"]
+        elif surface in {"codex-app", "codex-ide", "codex-cli"}:
             candidates = ["codex"]
         else:
             candidates = [surface]
@@ -225,31 +253,26 @@ def install_slash_commands(
 
     if "codex" in effective_surfaces:
         prompt_dir = codex_root / "prompts"
+        for spec in specs:
+            prompt_path = prompt_dir / f"{spec['name']}.md"
+            retire_status = _retire_managed_file(prompt_path, execute=execute)
+            if retire_status:
+                installed.append(
+                    {
+                        "surface": "codex",
+                        "host_surfaces": ["codex-cli", "codex-ide", "codex-app"],
+                        "mechanism": "retired_codex_custom_prompt",
+                        "command": spec["command"],
+                        "path": str(prompt_path),
+                        "status": retire_status,
+                        "invoke_as": [],
+                    }
+                )
+
         skill_dir = codex_root / "skills"
         for spec in specs:
-            path = prompt_dir / f"{spec['name']}.md"
-            content = _prompt_body(
-                command=str(spec["command"]),
-                title=f"LoopX {spec['command']}",
-                description=str(spec["description"]),
-                argument_hint=str(spec["argument_hint"]),
-                instructions=list(spec["instructions"]),
-                surface="codex-prompts",
-            )
-            status = _target_status(path, content, execute=execute)
-            installed.append(
-                {
-                    "surface": "codex",
-                    "host_surfaces": ["codex-cli", "codex-ide", "codex-app"],
-                    "mechanism": "codex_custom_prompts",
-                    "command": spec["command"],
-                    "path": str(path),
-                    "status": status,
-                    "invoke_as": [str(spec["command"]), f"/prompts:{spec['name']}"],
-                }
-            )
             skill_path = skill_dir / str(spec["name"]) / "SKILL.md"
-            skill_content = _prompt_body(
+            skill_content = _skill_body(
                 command=str(spec["command"]),
                 title=f"LoopX {spec['command']}",
                 description=str(spec["description"]),
@@ -262,12 +285,62 @@ def install_slash_commands(
             installed.append(
                 {
                     "surface": "codex",
-                    "host_surfaces": ["codex-app"],
-                    "mechanism": "codex_skills",
+                    "host_surfaces": ["codex-cli", "codex-ide", "codex-app"],
+                    "mechanism": "codex_explicit_skills",
                     "command": spec["command"],
                     "path": str(skill_path),
                     "status": skill_status,
-                    "invoke_as": [str(spec["command"])],
+                    "invoke_as": [f"${spec['name']}", "/skills"],
+                }
+            )
+            metadata_path = skill_path.parent / "agents" / "openai.yaml"
+            if skill_status not in {"skipped_user_file", "preserved_existing_loopx_skill"}:
+                metadata = _openai_skill_metadata(
+                    command=str(spec["command"]),
+                    display_name=f"LoopX {spec['command']}",
+                    short_description=str(spec["description"]),
+                )
+                metadata_status = _target_status(metadata_path, metadata, execute=execute)
+                installed.append(
+                    {
+                        "surface": "codex",
+                        "host_surfaces": ["codex-cli", "codex-ide", "codex-app"],
+                        "mechanism": "codex_skill_openai_metadata",
+                        "command": spec["command"],
+                        "path": str(metadata_path),
+                        "status": metadata_status,
+                        "invoke_as": [f"${spec['name']}", "/skills"],
+                    }
+                )
+            elif skill_status == "preserved_existing_loopx_skill":
+                retire_status = _retire_managed_file(metadata_path, execute=execute)
+                if retire_status:
+                    installed.append(
+                        {
+                            "surface": "codex",
+                            "host_surfaces": ["codex-cli", "codex-ide", "codex-app"],
+                            "mechanism": "retired_codex_command_metadata",
+                            "command": spec["command"],
+                            "path": str(metadata_path),
+                            "status": retire_status,
+                            "invoke_as": [],
+                        }
+                    )
+        for spec in specs:
+            installed.append(
+                {
+                    "surface": "codex",
+                    "host_surfaces": ["codex-cli"],
+                    "mechanism": "unsupported_native_slash_registry",
+                    "command": spec["command"],
+                    "path": None,
+                    "status": "unsupported_host_surface",
+                    "invoke_as": [],
+                    "reason": (
+                        "Current Codex does not support user-defined native top-level slash "
+                        "commands. Use explicit skills instead."
+                    ),
+                    "fallback": "Use `$loopx` or `/skills` to explicitly invoke the LoopX skill; for the visible TUI loop, run `loopx codex-cli-bootstrap-message --project .`, paste the setup message, then set `/goal <thin task_body>`.",
                 }
             )
 
@@ -275,7 +348,7 @@ def install_slash_commands(
         skills_dir = claude_root / "skills"
         for spec in specs:
             path = skills_dir / str(spec["name"]) / "SKILL.md"
-            content = _prompt_body(
+            content = _skill_body(
                 command=str(spec["command"]),
                 title=f"LoopX {spec['command']}",
                 description=str(spec["description"]),
@@ -312,7 +385,7 @@ def install_slash_commands(
             include_legacy_aliases=include_legacy_aliases,
         )["schema_version"],
         "summary": {
-            "codex_prompt_dir": str(codex_root / "prompts") if "codex" in effective_surfaces else None,
+            "codex_prompt_dir": None,
             "codex_skill_dir": str(codex_root / "skills") if "codex" in effective_surfaces else None,
             "claude_skill_dir": str(claude_root / "skills") if "claude-code" in effective_surfaces else None,
             "status_counts": status_counts,
@@ -320,8 +393,8 @@ def install_slash_commands(
         },
         "installed": installed,
         "notes": [
-            "Codex CLI/IDE discover top-level Markdown custom prompts in CODEX_HOME/prompts; restart the host if the slash list is already open.",
-            "Codex App command discovery also includes installed Codex skills; prompt-file support depends on the host version.",
+            "Codex does not currently support user-defined native top-level slash commands; use explicit skill invocation through `$loopx` or `/skills`.",
+            "Only explicit LoopX command-facade skills are installed with agents/openai.yaml policy allow_implicit_invocation=false; richer workflow skills stay implicit.",
             "Claude Code discovers user skills from CLAUDE_HOME/skills and exposes each skill name as a slash command.",
         ],
     }
@@ -357,6 +430,12 @@ def render_slash_command_install_markdown(payload: dict[str, Any]) -> str:
         lines.append("Skipped user-owned files:")
         for item in skipped:
             lines.append(f"- `{item.get('command')}` at `{item.get('path')}`")
+    notes = [note for note in payload.get("notes") or [] if isinstance(note, str)]
+    if notes:
+        lines.append("")
+        lines.append("Notes:")
+        for note in notes:
+            lines.append(f"- {note}")
     lines.append("")
     lines.append("Restart the host if its slash-command menu was already open.")
     return "\n".join(lines)

--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -81,13 +81,13 @@ def _command_prompt_specs(*, cli_bin: str, include_legacy_aliases: bool) -> list
         {
             "command": "/loopx",
             "name": "loopx",
-            "description": "Inspect LoopX state, or start a concrete LoopX goal when arguments are provided.",
-            "argument_hint": "[goal text]",
+            "description": "Inspect LoopX state, or start concrete project work when arguments are provided.",
+            "argument_hint": "[task text]",
             "instructions": [
                 "Visible command arguments: `$ARGUMENTS`.",
-                f"If arguments are present, preserve them as the goal text and run `{cli_bin} bootstrap-command-pack --project . --goal-text \"$ARGUMENTS\"` before planning work.",
+                f"If arguments are present, preserve them as the task text and run `{cli_bin} bootstrap-command-pack --project . --goal-text \"$ARGUMENTS\"` before planning work.",
                 f"If arguments are empty, inspect `{cli_bin} bootstrap-command-pack --project .`, `{cli_bin} status`, and `{cli_bin} slash-commands` before changing files.",
-                "When a goal is started, plan ordered P0/P1/P2 todos, write them through LoopX todo state, refresh state, run quota, and take one bounded allowed step.",
+                "When project work is started, plan ordered P0/P1/P2 todos, write them through LoopX todo state, refresh state, run quota, and take one bounded allowed step.",
             ],
         },
         {
@@ -97,7 +97,7 @@ def _command_prompt_specs(*, cli_bin: str, include_legacy_aliases: bool) -> list
             "argument_hint": "[optional focus]",
             "instructions": [
                 "Visible command arguments: `$ARGUMENTS`.",
-                f"Run `{cli_bin} global-summary` first and summarize the visible goals, gates, monitor status, and next safe actions.",
+                f"Run `{cli_bin} global-summary` first and summarize visible projects, gates, monitor status, and next safe actions.",
                 "This command is read-only unless the user explicitly asks for a state update.",
             ],
         },
@@ -115,11 +115,11 @@ def _command_prompt_specs(*, cli_bin: str, include_legacy_aliases: bool) -> list
         {
             "command": "/loopx-global-todos",
             "name": "loopx-global-todos",
-            "description": "List runnable, blocked, deferred-ready, and review LoopX todos across visible goals.",
+            "description": "List runnable, blocked, deferred-ready, and review LoopX todos across visible projects.",
             "argument_hint": "[optional focus]",
             "instructions": [
                 "Visible command arguments: `$ARGUMENTS`.",
-                f"Run `{cli_bin} global-summary` first, then focus the answer on prioritized todos and ownership across visible LoopX goals.",
+                f"Run `{cli_bin} global-summary` first, then focus the answer on prioritized todos and ownership across visible projects.",
                 "This command is read-only unless the user explicitly asks for a state update.",
             ],
         },

--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -1,0 +1,362 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+from .slash_commands import build_slash_command_catalog
+
+
+SCHEMA_VERSION = "loopx_slash_command_install_v0"
+MANAGED_MARKER_PREFIX = "<!-- loopx-managed-slash-command:v1"
+LEGACY_UPGRADABLE_SIGNATURES = (
+    "loopx goal-mode setup (NOT Claude Code's built-in /goal)",
+    "The output is loopx control-plane SETUP",
+    "goalmode_cmd.py",
+)
+EXISTING_LOOPX_CAPABILITY_SKILL_SIGNATURES = (
+    "# LoopX PR Review",
+    "Run `loopx pr-review` first",
+)
+
+
+def _managed_marker(*, command: str, surface: str) -> str:
+    return f"{MANAGED_MARKER_PREFIX} command={command} surface={surface} -->"
+
+
+def _front_matter(*, fields: dict[str, str]) -> str:
+    lines = ["---"]
+    for key, value in fields.items():
+        escaped = value.replace('"', '\\"')
+        lines.append(f'{key}: "{escaped}"')
+    lines.append("---")
+    return "\n".join(lines)
+
+
+def _prompt_body(
+    *,
+    command: str,
+    title: str,
+    description: str,
+    argument_hint: str,
+    instructions: list[str],
+    surface: str,
+    front_matter_name: str | None = None,
+) -> str:
+    fields = {
+        "description": description,
+        "argument-hint": argument_hint,
+    }
+    if front_matter_name:
+        fields = {"name": front_matter_name, **fields}
+    return "\n\n".join(
+        [
+            _front_matter(fields=fields),
+            _managed_marker(command=command, surface=surface),
+            f"# {title}",
+            f"Treat this as the LoopX `{command}` slash command.",
+            "\n".join(instructions),
+            "Keep public/private boundaries intact and do not perform external writes unless the active LoopX state or owner explicitly authorizes them.",
+        ]
+    ) + "\n"
+
+
+def _command_prompt_specs(*, cli_bin: str, include_legacy_aliases: bool) -> list[dict[str, Any]]:
+    specs: list[dict[str, Any]] = [
+        {
+            "command": "/loopx",
+            "name": "loopx",
+            "description": "Inspect LoopX state, or start a concrete LoopX goal when arguments are provided.",
+            "argument_hint": "[goal text]",
+            "instructions": [
+                "Visible command arguments: `$ARGUMENTS`.",
+                f"If arguments are present, preserve them as the goal text and run `{cli_bin} bootstrap-command-pack --project . --goal-text \"$ARGUMENTS\"` before planning work.",
+                f"If arguments are empty, inspect `{cli_bin} bootstrap-command-pack --project .`, `{cli_bin} status`, and `{cli_bin} slash-commands` before changing files.",
+                "When a goal is started, plan ordered P0/P1/P2 todos, write them through LoopX todo state, refresh state, run quota, and take one bounded allowed step.",
+            ],
+        },
+        {
+            "command": "/loopx-global-summary",
+            "name": "loopx-global-summary",
+            "description": "Read the compact global LoopX progress digest.",
+            "argument_hint": "[optional focus]",
+            "instructions": [
+                "Visible command arguments: `$ARGUMENTS`.",
+                f"Run `{cli_bin} global-summary` first and summarize the visible goals, gates, monitor status, and next safe actions.",
+                "This command is read-only unless the user explicitly asks for a state update.",
+            ],
+        },
+        {
+            "command": "/loopx-global-gates",
+            "name": "loopx-global-gates",
+            "description": "List open LoopX user/controller gates and what each blocks.",
+            "argument_hint": "[optional focus]",
+            "instructions": [
+                "Visible command arguments: `$ARGUMENTS`.",
+                f"Run `{cli_bin} global-summary` first, then focus the answer on open gates, blocked work, owner decisions, and exact next questions.",
+                "This command is read-only unless the user explicitly asks for a state update.",
+            ],
+        },
+        {
+            "command": "/loopx-global-todos",
+            "name": "loopx-global-todos",
+            "description": "List runnable, blocked, deferred-ready, and review LoopX todos across visible goals.",
+            "argument_hint": "[optional focus]",
+            "instructions": [
+                "Visible command arguments: `$ARGUMENTS`.",
+                f"Run `{cli_bin} global-summary` first, then focus the answer on prioritized todos and ownership across visible LoopX goals.",
+                "This command is read-only unless the user explicitly asks for a state update.",
+            ],
+        },
+        {
+            "command": "/loopx-global-risks",
+            "name": "loopx-global-risks",
+            "description": "Show stale LoopX runs, boundary risks, failing checks, and rollback candidates.",
+            "argument_hint": "[optional focus]",
+            "instructions": [
+                "Visible command arguments: `$ARGUMENTS`.",
+                f"Run `{cli_bin} global-summary` first, then focus the answer on stale work, public/private boundary risks, failing checks, and rollback candidates.",
+                "This command is read-only unless the user explicitly asks for a state update.",
+            ],
+        },
+        {
+            "command": "/loopx-pr-review",
+            "name": "loopx-pr-review",
+            "description": "Run the LoopX PR-review packet first, then review selected PR groups with evidence.",
+            "argument_hint": "[--repo owner/repo] [--state open|merged|all] [--since ISO]",
+            "instructions": [
+                "Visible command arguments: `$ARGUMENTS`.",
+                "Use the installed `loopx-pr-review` skill when available.",
+                f"Run `{cli_bin} --format json pr-review $ARGUMENTS` first and keep `agent_response_contract`, `review_groups`, `pull_requests[].review_template`, and `pull_requests[].evidence_commands` visible.",
+                "Do not reconstruct the PR queue manually from ad hoc GitHub calls before reading the LoopX packet.",
+                "This command is read-only; do not comment, approve, merge, rerun CI, or spend quota unless separately authorized.",
+            ],
+        },
+    ]
+    if include_legacy_aliases:
+        legacy_specs = []
+        for canonical in specs:
+            name = canonical["name"]
+            if not str(name).startswith("loopx-global-"):
+                continue
+            legacy_name = str(name).replace("loopx-global-", "loop-global-", 1)
+            legacy_specs.append(
+                {
+                    **canonical,
+                    "command": "/" + legacy_name,
+                    "name": legacy_name,
+                    "description": canonical["description"] + " Legacy alias for the canonical /loopx-global-* command.",
+                }
+            )
+        specs.extend(legacy_specs)
+    return specs
+
+
+def _is_legacy_upgradable_loopx_file(existing: str) -> bool:
+    return any(signature in existing for signature in LEGACY_UPGRADABLE_SIGNATURES)
+
+
+def _is_existing_loopx_capability_skill(existing: str) -> bool:
+    return any(signature in existing for signature in EXISTING_LOOPX_CAPABILITY_SKILL_SIGNATURES)
+
+
+def _target_status(path: Path, content: str, *, execute: bool) -> str:
+    if path.exists():
+        existing = path.read_text(encoding="utf-8")
+        if MANAGED_MARKER_PREFIX not in existing:
+            if _is_legacy_upgradable_loopx_file(existing):
+                if execute:
+                    path.write_text(content, encoding="utf-8")
+                return "upgraded_legacy_managed"
+            if path.name == "SKILL.md" and _is_existing_loopx_capability_skill(existing):
+                return "preserved_existing_loopx_skill"
+            return "skipped_user_file"
+        if existing == content:
+            return "unchanged"
+        if execute:
+            path.write_text(content, encoding="utf-8")
+        return "updated"
+    if execute:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+    return "created" if execute else "would_create"
+
+
+def _codex_home(value: str | None = None) -> Path:
+    raw = value or os.environ.get("CODEX_HOME") or str(Path.home() / ".codex")
+    return Path(raw).expanduser()
+
+
+def _claude_home(value: str | None = None) -> Path:
+    raw = value or os.environ.get("CLAUDE_HOME") or str(Path.home() / ".claude")
+    return Path(raw).expanduser()
+
+
+def _normalize_surfaces(surfaces: list[str] | None) -> list[str]:
+    requested = surfaces or ["all"]
+    normalized: list[str] = []
+    for surface in requested:
+        if surface == "all":
+            candidates = ["codex", "claude-code"]
+        elif surface in {"codex-cli", "codex-app"}:
+            candidates = ["codex"]
+        else:
+            candidates = [surface]
+        for candidate in candidates:
+            if candidate not in normalized:
+                normalized.append(candidate)
+    return normalized
+
+
+def install_slash_commands(
+    *,
+    execute: bool,
+    surfaces: list[str] | None = None,
+    cli_bin: str = "loopx",
+    include_legacy_aliases: bool = True,
+    codex_home: str | None = None,
+    claude_home: str | None = None,
+) -> dict[str, Any]:
+    specs = _command_prompt_specs(cli_bin=cli_bin, include_legacy_aliases=include_legacy_aliases)
+    effective_surfaces = _normalize_surfaces(surfaces)
+    codex_root = _codex_home(codex_home)
+    claude_root = _claude_home(claude_home)
+    installed: list[dict[str, Any]] = []
+
+    if "codex" in effective_surfaces:
+        prompt_dir = codex_root / "prompts"
+        skill_dir = codex_root / "skills"
+        for spec in specs:
+            path = prompt_dir / f"{spec['name']}.md"
+            content = _prompt_body(
+                command=str(spec["command"]),
+                title=f"LoopX {spec['command']}",
+                description=str(spec["description"]),
+                argument_hint=str(spec["argument_hint"]),
+                instructions=list(spec["instructions"]),
+                surface="codex-prompts",
+            )
+            status = _target_status(path, content, execute=execute)
+            installed.append(
+                {
+                    "surface": "codex",
+                    "host_surfaces": ["codex-cli", "codex-ide", "codex-app"],
+                    "mechanism": "codex_custom_prompts",
+                    "command": spec["command"],
+                    "path": str(path),
+                    "status": status,
+                    "invoke_as": [str(spec["command"]), f"/prompts:{spec['name']}"],
+                }
+            )
+            skill_path = skill_dir / str(spec["name"]) / "SKILL.md"
+            skill_content = _prompt_body(
+                command=str(spec["command"]),
+                title=f"LoopX {spec['command']}",
+                description=str(spec["description"]),
+                argument_hint=str(spec["argument_hint"]),
+                instructions=list(spec["instructions"]),
+                surface="codex-skills",
+                front_matter_name=str(spec["name"]),
+            )
+            skill_status = _target_status(skill_path, skill_content, execute=execute)
+            installed.append(
+                {
+                    "surface": "codex",
+                    "host_surfaces": ["codex-app"],
+                    "mechanism": "codex_skills",
+                    "command": spec["command"],
+                    "path": str(skill_path),
+                    "status": skill_status,
+                    "invoke_as": [str(spec["command"])],
+                }
+            )
+
+    if "claude-code" in effective_surfaces:
+        skills_dir = claude_root / "skills"
+        for spec in specs:
+            path = skills_dir / str(spec["name"]) / "SKILL.md"
+            content = _prompt_body(
+                command=str(spec["command"]),
+                title=f"LoopX {spec['command']}",
+                description=str(spec["description"]),
+                argument_hint=str(spec["argument_hint"]),
+                instructions=list(spec["instructions"]),
+                surface="claude-skills",
+                front_matter_name=str(spec["name"]),
+            )
+            status = _target_status(path, content, execute=execute)
+            installed.append(
+                {
+                    "surface": "claude-code",
+                    "mechanism": "claude_code_skills",
+                    "command": spec["command"],
+                    "path": str(path),
+                    "status": status,
+                    "invoke_as": [str(spec["command"])],
+                }
+            )
+
+    status_counts: dict[str, int] = {}
+    for item in installed:
+        status = str(item["status"])
+        status_counts[status] = status_counts.get(status, 0) + 1
+
+    return {
+        "ok": True,
+        "schema_version": SCHEMA_VERSION,
+        "execute": execute,
+        "requested_surfaces": surfaces or ["all"],
+        "effective_surfaces": effective_surfaces,
+        "catalog_schema_version": build_slash_command_catalog(
+            cli_bin=cli_bin,
+            include_legacy_aliases=include_legacy_aliases,
+        )["schema_version"],
+        "summary": {
+            "codex_prompt_dir": str(codex_root / "prompts") if "codex" in effective_surfaces else None,
+            "codex_skill_dir": str(codex_root / "skills") if "codex" in effective_surfaces else None,
+            "claude_skill_dir": str(claude_root / "skills") if "claude-code" in effective_surfaces else None,
+            "status_counts": status_counts,
+            "skip_policy": "LoopX-managed files are upgraded; same-name user files without a LoopX managed marker or legacy signature are never overwritten",
+        },
+        "installed": installed,
+        "notes": [
+            "Codex CLI/IDE discover top-level Markdown custom prompts in CODEX_HOME/prompts; restart the host if the slash list is already open.",
+            "Codex App command discovery also includes installed Codex skills; prompt-file support depends on the host version.",
+            "Claude Code discovers user skills from CLAUDE_HOME/skills and exposes each skill name as a slash command.",
+        ],
+    }
+
+
+def render_slash_command_install_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# LoopX Slash Command Install",
+        "",
+        f"- execute: `{payload.get('execute')}`",
+        f"- surfaces: `{','.join(payload.get('effective_surfaces') or [])}`",
+        f"- skip policy: `{payload.get('summary', {}).get('skip_policy')}`",
+    ]
+    codex_prompt_dir = payload.get("summary", {}).get("codex_prompt_dir")
+    codex_skill_dir = payload.get("summary", {}).get("codex_skill_dir")
+    claude_skill_dir = payload.get("summary", {}).get("claude_skill_dir")
+    if codex_prompt_dir:
+        lines.append(f"- codex prompts: `{codex_prompt_dir}`")
+    if codex_skill_dir:
+        lines.append(f"- codex skills: `{codex_skill_dir}`")
+    if claude_skill_dir:
+        lines.append(f"- claude skills: `{claude_skill_dir}`")
+    counts = payload.get("summary", {}).get("status_counts") or {}
+    if isinstance(counts, dict) and counts:
+        count_text = ", ".join(f"{key}={value}" for key, value in sorted(counts.items()))
+        lines.append(f"- statuses: `{count_text}`")
+    skipped = [
+        item for item in payload.get("installed") or []
+        if isinstance(item, dict) and item.get("status") == "skipped_user_file"
+    ]
+    if skipped:
+        lines.append("")
+        lines.append("Skipped user-owned files:")
+        for item in skipped:
+            lines.append(f"- `{item.get('command')}` at `{item.get('path')}`")
+    lines.append("")
+    lines.append("Restart the host if its slash-command menu was already open.")
+    return "\n".join(lines)

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -213,12 +213,50 @@ if [[ "$install_skill" != "0" && -d "$skills_source" ]]; then
   skill_line="${skill_line%$'\n'}"
 fi
 
+slash_line="- slash commands: skipped"
+install_slash_commands="${LOOPX_INSTALL_SLASH_COMMANDS:-1}"
+slash_surfaces="${LOOPX_INSTALL_SLASH_COMMAND_SURFACES:-all}"
+if [[ "$install_slash_commands" != "0" ]]; then
+  slash_args=(slash-commands --install)
+  IFS=',' read -ra slash_surface_list <<<"$slash_surfaces"
+  for slash_surface in "${slash_surface_list[@]}"; do
+    if [[ -n "$slash_surface" ]]; then
+      slash_args+=(--surface "$slash_surface")
+    fi
+  done
+  if slash_json="$("$bin_dir/loopx" --format json "${slash_args[@]}" 2>/dev/null)"; then
+    slash_line="$(LOOPX_SLASH_INSTALL_JSON="$slash_json" "${LOOPX_PYTHON:-python3}" - <<'PY'
+import json
+import os
+
+payload = json.loads(os.environ["LOOPX_SLASH_INSTALL_JSON"])
+summary = payload.get("summary") or {}
+counts = summary.get("status_counts") or {}
+count_text = ",".join(f"{key}={counts[key]}" for key in sorted(counts)) or "none"
+parts = []
+if summary.get("codex_prompt_dir"):
+    parts.append(f"codex prompts: {summary['codex_prompt_dir']}")
+if summary.get("codex_skill_dir"):
+    parts.append(f"codex skills: {summary['codex_skill_dir']}")
+if summary.get("claude_skill_dir"):
+    parts.append(f"claude skills: {summary['claude_skill_dir']}")
+if not parts:
+    parts.append("no supported surfaces selected")
+print(f"- slash commands: {'; '.join(parts)} ({count_text})")
+PY
+)"
+  else
+    slash_line="- slash commands: install attempted; run manually: loopx slash-commands --install"
+  fi
+fi
+
 # loopx Claude Code adapter: OPT-IN, OFF by default — the normal loopx install
-# never touches ~/.claude. The run loop is Claude Code's native /loop; loopx
-# provides the should_run protocol (MCP) + a /loopx setup helper, and NO global
-# hooks by default. Enable explicitly with LOOPX_INSTALL_CLAUDE=1 (installs at
-# USER scope: MCP + /loopx command). Add the optional should_run gate later with
-# `install.py --scope <user|project> --harden`. Prefer PROJECT scope:
+# does not install MCP, hooks, or settings. The lightweight slash-command
+# skills above may write ~/.claude/skills so Claude Code can discover /loopx,
+# while the run-loop adapter remains explicit. Enable the adapter with
+# LOOPX_INSTALL_CLAUDE=1 (installs at USER scope: MCP + /loopx command). Add
+# the optional should_run gate later with `install.py --scope <user|project>
+# --harden`. Prefer PROJECT scope:
 # `python <release>/loopx/claude_goal_mode/scripts/install.py --scope project`.
 claude_installer="$release_dir/loopx/claude_goal_mode/scripts/install.py"
 install_claude="${LOOPX_INSTALL_CLAUDE:-0}"
@@ -248,6 +286,7 @@ $canary_line
 $legacy_line
 - profile: $shell_profile
 $skill_line
+$slash_line
 $claude_line
 
 Current shell can use it with:


### PR DESCRIPTION
## Summary

- Install LoopX command-entry facades through `loopx slash-commands --install`: Codex gets explicit `$loopx` / `/skills` command skills, and Claude Code gets lightweight slash-command skills.
- Stop relying on Codex custom prompts for `/loopx` or `/prompts:loopx`; current verified Codex builds do not support user-defined native slash commands, so the installer reports Codex native slash as unsupported and installs explicit skills instead.
- Add `agents/openai.yaml` with `allow_implicit_invocation: false` only for explicit command-facade skills; preserve richer implicit workflow skills such as `loopx-project`, `loopx-pr-review`, `loopx-doc-registry`, and `loopx-self-repair`.
- Retire old LoopX-managed Codex prompt files and old command-facade metadata on preserved workflow skills, while still skipping user-owned files without a LoopX marker.
- Update README/getting-started/newcomer/protocol docs to describe host LoopX command entries, task text, and objectives instead of presenting “LoopX goal” as a user-facing product concept.

## Product / Architecture Judgment

- Motivation: make LoopX discoverable from Codex/Claude host surfaces without pretending Codex currently supports custom native slash commands.
- Solved: the installer now gives Codex an explicit skill path and Claude Code a skill/slash path, with smoke coverage for install, upgrade, opt-in Claude boundaries, and command catalog behavior.
- Existing-user risk: low and bounded. LoopX-managed old prompt files are retired; same-name user files are skipped; richer implicit workflow skills keep implicit invocation.
- Design judgment: this is a compatibility facade around current host capabilities, not a new state machine. Future native slash support can target the same command catalog/protocol.

## Validation

- `python3 examples/slash-command-install-smoke.py`
- `python3 examples/install-local-smoke.py`
- `python3 examples/claude-install-optin-smoke.py`
- `python3 examples/slash-command-catalog-smoke.py`
- `python3 examples/cli-help-manpage-smoke.py`
- `python3 -m py_compile loopx/slash_command_install.py loopx/cli_commands/slash_commands.py examples/slash-command-install-smoke.py examples/install-local-smoke.py`
- `git diff --check`
- public/private boundary scan over changed runtime, docs, and smoke paths

## Merge Decision

Self-merge approved by owner. This PR is a single-purpose host command-entry compatibility update with focused validation and no Lark Kanban, benchmark scoring, permission, production-action, or external-write behavior changes.
