### PR TITLE
Extract todo index read model

### DIFF
--- a/examples/control_plane/todo-index-rollout-status-smoke.py
+++ b/examples/control_plane/todo-index-rollout-status-smoke.py
@@ -10,7 +10,8 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from loopx.status import build_todo_index
+from loopx import status as status_module
+from loopx.control_plane.todos.todo_index import build_todo_index as build_todo_index_read_model
 
 
 def write_event(path: Path, payload: dict[str, object]) -> None:
@@ -47,16 +48,55 @@ def main() -> None:
             },
         )
 
-        index = build_todo_index(
+        history = {"goals": [{"id": "loopx-meta"}]}
+        event_only_index = status_module.build_todo_index(
             queue={"items": []},
-            history={"goals": [{"id": "loopx-meta"}]},
+            history=history,
             runtime_root=runtime_root,
         )
+        queue = {
+            "items": [
+                {
+                    "goal_id": "loopx-meta",
+                    "agent_todos": {
+                        "items": [
+                            {
+                                "todo_id": "todo_done_status",
+                                "status": "open",
+                                "title": "Confirm rollout status merge",
+                                "text": "Confirm rollout status merge",
+                            }
+                        ]
+                    },
+                }
+            ]
+        }
+        index = status_module.build_todo_index(
+            queue=queue,
+            history=history,
+            runtime_root=runtime_root,
+        )
+        read_model_index = build_todo_index_read_model(
+            queue=queue,
+            history=history,
+            runtime_root=runtime_root,
+            public_safe_compact_text=status_module.public_safe_compact_text,
+        )
 
+    event_only_items = event_only_index["items"]
+    assert len(event_only_items) == 1, event_only_items
+    assert event_only_items[0]["source"] == "rollout_event_log", event_only_items[0]
+
+    assert read_model_index == index, (read_model_index, index)
+    assert index["current_projected_count"] == 1, index
+    assert index["rollout_event_count"] == 2, index
     items = index["items"]
     assert len(items) == 1, items
     item = items[0]
     assert item["todo_id"] == "todo_done_status", item
+    assert item["source"] == "attention_queue", item
+    assert item["event_count"] == 2, item
+    assert item["event_kinds"] == ["todo_add", "todo_complete"], item
     assert item["latest_event_kind"] == "todo_complete", item
     assert item["latest_event_status"] == "done", item
     assert item["status"] == "done", item

--- a/loopx/control_plane/todos/todo_index.py
+++ b/loopx/control_plane/todos/todo_index.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+from ...rollout_event_log import load_rollout_events, rollout_event_log_path
+from ...todo_contract import normalize_todo_id, normalize_todo_status, todo_done_for_status
+from .todo_summary import compact_todo_item
+
+
+TODO_INDEX_SCHEMA_VERSION = "todo_index_v0"
+TODO_INDEX_ITEM_SCHEMA_VERSION = "todo_index_item_v0"
+MAX_TODO_INDEX_ITEMS = 240
+MAX_TODO_INDEX_ROLLOUT_EVENTS_PER_GOAL = 500
+
+CompactText = Callable[..., Any]
+
+
+def _todo_index_key(goal_id: str, todo: dict[str, Any]) -> tuple[str, str]:
+    todo_id = normalize_todo_id(todo.get("todo_id")) or ""
+    if todo_id:
+        return goal_id, todo_id
+    return goal_id, f"synthetic:{todo.get('role') or ''}:{todo.get('index') or ''}:{todo.get('text') or ''}"
+
+
+def _indexed_status_todo(
+    *,
+    goal_id: str,
+    role: str,
+    todo: dict[str, Any],
+    source: str,
+    public_safe_compact_text: CompactText,
+) -> dict[str, Any] | None:
+    text = public_safe_compact_text(todo.get("title") or todo.get("text"), limit=320)
+    if not text:
+        return None
+    item = compact_todo_item(todo)
+    item.update(
+        {
+            "schema_version": TODO_INDEX_ITEM_SCHEMA_VERSION,
+            "goal_id": goal_id,
+            "role": role,
+            "source": source,
+            "text": text,
+            "title": public_safe_compact_text(todo.get("title"), limit=320) or text,
+        }
+    )
+    return item
+
+
+def _rollout_event_todo_status(event: dict[str, Any]) -> str:
+    status = normalize_todo_status(event.get("status"))
+    if status:
+        return status
+    kind = str(event.get("event_kind") or "")
+    if kind in {"todo_complete", "todo_archive_completed"}:
+        return "done"
+    if kind == "todo_supersede":
+        return "deferred"
+    return "open"
+
+
+def _indexed_rollout_todo_event(
+    event: dict[str, Any],
+    *,
+    public_safe_compact_text: CompactText,
+) -> dict[str, Any] | None:
+    todo_id = normalize_todo_id(event.get("todo_id"))
+    goal_id = str(event.get("goal_id") or "").strip()
+    if not goal_id or not todo_id:
+        return None
+    details = event.get("details") if isinstance(event.get("details"), dict) else {}
+    role = str(details.get("role") or "agent").strip().lower()
+    if role not in {"user", "agent"}:
+        role = "agent"
+    status = _rollout_event_todo_status(event)
+    summary = public_safe_compact_text(
+        event.get("summary") or f"{event.get('event_kind') or 'todo_event'} recorded for {todo_id}",
+        limit=320,
+    )
+    if not summary:
+        summary = f"todo event recorded for {todo_id}"
+    return {
+        "schema_version": TODO_INDEX_ITEM_SCHEMA_VERSION,
+        "goal_id": goal_id,
+        "todo_id": todo_id,
+        "role": role,
+        "status": status,
+        "done": todo_done_for_status(status),
+        "index": 0,
+        "text": summary,
+        "title": summary,
+        "source": "rollout_event_log",
+        "event_count": 1,
+        "event_kinds": [str(event.get("event_kind") or "todo_event")],
+        "latest_event_kind": str(event.get("event_kind") or "todo_event"),
+        "latest_event_at": public_safe_compact_text(event.get("recorded_at"), limit=80),
+        "latest_event_status": status,
+        "agent_id": public_safe_compact_text(event.get("agent_id"), limit=120),
+    }
+
+
+def build_todo_index(
+    *,
+    queue: dict[str, Any],
+    history: dict[str, Any],
+    runtime_root: Path,
+    public_safe_compact_text: CompactText,
+    limit: int = MAX_TODO_INDEX_ITEMS,
+    max_rollout_events_per_goal: int = MAX_TODO_INDEX_ROLLOUT_EVENTS_PER_GOAL,
+) -> dict[str, Any]:
+    indexed: dict[tuple[str, str], dict[str, Any]] = {}
+    current_count = 0
+    for item in queue.get("items") or []:
+        if not isinstance(item, dict):
+            continue
+        goal_id = str(item.get("goal_id") or "")
+        if not goal_id:
+            continue
+        for role in ("user", "agent"):
+            todos = item.get(f"{role}_todos")
+            if not isinstance(todos, dict):
+                continue
+            for todo in todos.get("items") or []:
+                if not isinstance(todo, dict):
+                    continue
+                indexed_item = _indexed_status_todo(
+                    goal_id=goal_id,
+                    role=role,
+                    todo=todo,
+                    source="attention_queue",
+                    public_safe_compact_text=public_safe_compact_text,
+                )
+                if indexed_item is None:
+                    continue
+                indexed[_todo_index_key(goal_id, indexed_item)] = indexed_item
+                current_count += 1
+
+    rollout_event_count = 0
+    goal_ids = [
+        str(goal.get("id") or "")
+        for goal in history.get("goals") or []
+        if isinstance(goal, dict) and str(goal.get("id") or "")
+    ]
+    for goal_id in sorted(set(goal_ids)):
+        events = load_rollout_events(
+            rollout_event_log_path(runtime_root, goal_id),
+            limit=max_rollout_events_per_goal,
+        )
+        for event in events:
+            if not isinstance(event, dict) or not str(event.get("event_kind") or "").startswith("todo_"):
+                continue
+            rollout_event_count += 1
+            event_item = _indexed_rollout_todo_event(
+                event,
+                public_safe_compact_text=public_safe_compact_text,
+            )
+            if event_item is None:
+                continue
+            key = _todo_index_key(goal_id, event_item)
+            existing = indexed.get(key)
+            if existing:
+                existing["event_count"] = int(existing.get("event_count") or 0) + 1
+                kinds = list(existing.get("event_kinds") or [])
+                latest_kind = event_item.get("latest_event_kind")
+                if latest_kind and latest_kind not in kinds:
+                    kinds.append(latest_kind)
+                existing["event_kinds"] = kinds
+                existing["latest_event_kind"] = latest_kind
+                existing["latest_event_at"] = event_item.get("latest_event_at")
+                existing["latest_event_status"] = event_item.get("latest_event_status")
+                if event_item.get("status"):
+                    existing["status"] = event_item.get("status")
+                    existing["done"] = bool(event_item.get("done"))
+                if event_item.get("agent_id"):
+                    existing["agent_id"] = event_item.get("agent_id")
+                continue
+            indexed[key] = event_item
+
+    items = sorted(
+        indexed.values(),
+        key=lambda item: (
+            0 if not item.get("done") else 1,
+            str(item.get("goal_id") or ""),
+            str(item.get("todo_id") or ""),
+            str(item.get("latest_event_at") or ""),
+        ),
+    )
+    return {
+        "schema_version": TODO_INDEX_SCHEMA_VERSION,
+        "source": "attention_queue_and_rollout_event_log",
+        "total_count": len(items),
+        "current_projected_count": current_count,
+        "rollout_event_count": rollout_event_count,
+        "item_limit": limit,
+        "items": items[: max(0, limit)],
+    }

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -231,6 +231,13 @@ from .control_plane.todos.todo_summary import (
     todo_priority_rank,
     todo_projection_sort_key,
 )
+from .control_plane.todos.todo_index import (
+    MAX_TODO_INDEX_ITEMS,
+    MAX_TODO_INDEX_ROLLOUT_EVENTS_PER_GOAL,
+    TODO_INDEX_ITEM_SCHEMA_VERSION,
+    TODO_INDEX_SCHEMA_VERSION,
+    build_todo_index as _build_todo_index_read_model,
+)
 from .promotion_gate import build_promotion_gate
 from .quota import quota_status, quota_with_handoff_outcome_floor
 from .registry import registry_goals
@@ -394,8 +401,6 @@ MINIMUM_DASHBOARD_STATUS_CONTRACT_SCHEMA_VERSION = 2
 STATUS_CONTRACT_RELOAD_HINT = "scripts/macos-dashboard-launchagent.sh restart"
 STATUS_CONTRACT_SIGNAL_LIMIT = 3
 MONITOR_WRITEBACK_CONTRACT_SCHEMA_VERSION = "monitor_writeback_contract_v0"
-TODO_INDEX_SCHEMA_VERSION = "todo_index_v0"
-TODO_INDEX_ITEM_SCHEMA_VERSION = "todo_index_item_v0"
 DECISION_FRESHNESS_WINDOW_DAYS = 7
 DECISION_FRESHNESS_ITEM_LIMIT = 12
 DECISION_FRESHNESS_PROXY_NOTE = (
@@ -524,8 +529,6 @@ MAX_PROJECT_ASSET_TODO_BACKLOG_ITEMS = 8
 MAX_TODO_VISIBILITY_LANE_ITEMS = 16
 MAX_DEFERRED_TODO_VISIBILITY_ITEMS = 8
 MAX_MONITOR_DUE_ITEMS = 1
-MAX_TODO_INDEX_ITEMS = 240
-MAX_TODO_INDEX_ROLLOUT_EVENTS_PER_GOAL = 500
 MAX_DEPENDENCY_BLOCKERS = 4
 MAX_AUTONOMOUS_BACKLOG_CANDIDATES = 6
 MAX_SUBAGENT_SCOPE_ITEMS = 4
@@ -8129,85 +8132,6 @@ def build_usage_summary(history: dict[str, Any]) -> dict[str, Any]:
     }
 
 
-def _todo_index_key(goal_id: str, todo: dict[str, Any]) -> tuple[str, str]:
-    todo_id = normalize_todo_id(todo.get("todo_id")) or ""
-    if todo_id:
-        return goal_id, todo_id
-    return goal_id, f"synthetic:{todo.get('role') or ''}:{todo.get('index') or ''}:{todo.get('text') or ''}"
-
-
-def _indexed_status_todo(
-    *,
-    goal_id: str,
-    role: str,
-    todo: dict[str, Any],
-    source: str,
-) -> dict[str, Any] | None:
-    text = public_safe_compact_text(todo.get("title") or todo.get("text"), limit=320)
-    if not text:
-        return None
-    item = compact_todo_item(todo)
-    item.update(
-        {
-            "schema_version": TODO_INDEX_ITEM_SCHEMA_VERSION,
-            "goal_id": goal_id,
-            "role": role,
-            "source": source,
-            "text": text,
-            "title": public_safe_compact_text(todo.get("title"), limit=320) or text,
-        }
-    )
-    return item
-
-
-def _rollout_event_todo_status(event: dict[str, Any]) -> str:
-    status = normalize_todo_status(event.get("status"))
-    if status:
-        return status
-    kind = str(event.get("event_kind") or "")
-    if kind in {"todo_complete", "todo_archive_completed"}:
-        return "done"
-    if kind == "todo_supersede":
-        return "deferred"
-    return "open"
-
-
-def _indexed_rollout_todo_event(event: dict[str, Any]) -> dict[str, Any] | None:
-    todo_id = normalize_todo_id(event.get("todo_id"))
-    goal_id = str(event.get("goal_id") or "").strip()
-    if not goal_id or not todo_id:
-        return None
-    details = event.get("details") if isinstance(event.get("details"), dict) else {}
-    role = str(details.get("role") or "agent").strip().lower()
-    if role not in {"user", "agent"}:
-        role = "agent"
-    status = _rollout_event_todo_status(event)
-    summary = public_safe_compact_text(
-        event.get("summary") or f"{event.get('event_kind') or 'todo_event'} recorded for {todo_id}",
-        limit=320,
-    )
-    if not summary:
-        summary = f"todo event recorded for {todo_id}"
-    return {
-        "schema_version": TODO_INDEX_ITEM_SCHEMA_VERSION,
-        "goal_id": goal_id,
-        "todo_id": todo_id,
-        "role": role,
-        "status": status,
-        "done": todo_done_for_status(status),
-        "index": 0,
-        "text": summary,
-        "title": summary,
-        "source": "rollout_event_log",
-        "event_count": 1,
-        "event_kinds": [str(event.get("event_kind") or "todo_event")],
-        "latest_event_kind": str(event.get("event_kind") or "todo_event"),
-        "latest_event_at": public_safe_compact_text(event.get("recorded_at"), limit=80),
-        "latest_event_status": status,
-        "agent_id": public_safe_compact_text(event.get("agent_id"), limit=120),
-    }
-
-
 def build_todo_index(
     *,
     queue: dict[str, Any],
@@ -8215,88 +8139,13 @@ def build_todo_index(
     runtime_root: Path,
     limit: int = MAX_TODO_INDEX_ITEMS,
 ) -> dict[str, Any]:
-    indexed: dict[tuple[str, str], dict[str, Any]] = {}
-    current_count = 0
-    for item in queue.get("items") or []:
-        if not isinstance(item, dict):
-            continue
-        goal_id = str(item.get("goal_id") or "")
-        if not goal_id:
-            continue
-        for role in ("user", "agent"):
-            todos = item.get(f"{role}_todos")
-            if not isinstance(todos, dict):
-                continue
-            for todo in todos.get("items") or []:
-                if not isinstance(todo, dict):
-                    continue
-                indexed_item = _indexed_status_todo(
-                    goal_id=goal_id,
-                    role=role,
-                    todo=todo,
-                    source="attention_queue",
-                )
-                if indexed_item is None:
-                    continue
-                indexed[_todo_index_key(goal_id, indexed_item)] = indexed_item
-                current_count += 1
-
-    rollout_event_count = 0
-    goal_ids = [
-        str(goal.get("id") or "")
-        for goal in history.get("goals") or []
-        if isinstance(goal, dict) and str(goal.get("id") or "")
-    ]
-    for goal_id in sorted(set(goal_ids)):
-        events = load_rollout_events(
-            rollout_event_log_path(runtime_root, goal_id),
-            limit=MAX_TODO_INDEX_ROLLOUT_EVENTS_PER_GOAL,
-        )
-        for event in events:
-            if not isinstance(event, dict) or not str(event.get("event_kind") or "").startswith("todo_"):
-                continue
-            rollout_event_count += 1
-            event_item = _indexed_rollout_todo_event(event)
-            if event_item is None:
-                continue
-            key = _todo_index_key(goal_id, event_item)
-            existing = indexed.get(key)
-            if existing:
-                existing["event_count"] = int(existing.get("event_count") or 0) + 1
-                kinds = list(existing.get("event_kinds") or [])
-                latest_kind = event_item.get("latest_event_kind")
-                if latest_kind and latest_kind not in kinds:
-                    kinds.append(latest_kind)
-                existing["event_kinds"] = kinds
-                existing["latest_event_kind"] = latest_kind
-                existing["latest_event_at"] = event_item.get("latest_event_at")
-                existing["latest_event_status"] = event_item.get("latest_event_status")
-                if event_item.get("status"):
-                    existing["status"] = event_item.get("status")
-                    existing["done"] = bool(event_item.get("done"))
-                if event_item.get("agent_id"):
-                    existing["agent_id"] = event_item.get("agent_id")
-                continue
-            indexed[key] = event_item
-
-    items = sorted(
-        indexed.values(),
-        key=lambda item: (
-            0 if not item.get("done") else 1,
-            str(item.get("goal_id") or ""),
-            str(item.get("todo_id") or ""),
-            str(item.get("latest_event_at") or ""),
-        ),
+    return _build_todo_index_read_model(
+        queue=queue,
+        history=history,
+        runtime_root=runtime_root,
+        public_safe_compact_text=public_safe_compact_text,
+        limit=limit,
     )
-    return {
-        "schema_version": TODO_INDEX_SCHEMA_VERSION,
-        "source": "attention_queue_and_rollout_event_log",
-        "total_count": len(items),
-        "current_projected_count": current_count,
-        "rollout_event_count": rollout_event_count,
-        "item_limit": limit,
-        "items": items[: max(0, limit)],
-    }
 
 
 def collect_status(


### PR DESCRIPTION
## Summary
- Move todo index construction from status.py into control_plane/todos/todo_index.py.
- Keep loopx.status.build_todo_index as a compatibility wrapper.
- Extend todo-index rollout smoke to assert status wrapper/read-model parity and queue+rollout event merge semantics.

## Product / Architecture Judgment
- Motivation: continue the canary-gated control-plane read-model cleanup by moving todo-owned projection logic out of the status hot path.
- Solved: the PR keeps the public status wrapper and constants available while relocating implementation into the todos bounded context.
- User/operator impact: reduces status.py surface area and makes todo delivery-state projection easier to validate and refactor independently.
- Main risk: status payload compatibility; mitigated by wrapper parity smoke and focused status/todo smokes.
- Design judgment: this is a bounded-context module rather than another generic projections bucket; public-safe text policy remains injected from status to avoid reverse dependencies.

## Validation
- python3 examples/control_plane/todo-index-rollout-status-smoke.py
- python3 examples/control_plane/status-quota-review-packet-parity-smoke.py
- python3 examples/control_plane/status-contract-readmodel-smoke.py
- python3 examples/control_plane/todo-readmodel-boundary-smoke.py
- python3 examples/control_plane/status-goal-filter-smoke.py
- python3 examples/control_plane/todo-cli-smoke.py
- python3 -m compileall -q loopx/status.py loopx/control_plane/todos/todo_index.py examples/control_plane/todo-index-rollout-status-smoke.py
- loopx --format json status --goal-id loopx-meta --limit 1
- git diff --check origin/main...HEAD

## Boundary Scan
- Candidate paths scanned for private/internal markers, local paths, credentials, raw benchmark logs/trajectories/verifier output. New/changed public artifacts are public-safe; only pre-existing status.py benchmark field names matched the broad scan.