### PR TITLE
Extract usage summary read model

### DIFF
--- a/examples/usage-summary-smoke.py
+++ b/examples/usage-summary-smoke.py
@@ -15,7 +15,9 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from loopx.status import collect_status  # noqa: E402
+from loopx import status as status_module  # noqa: E402
+from loopx.control_plane.quota.usage_summary import build_usage_summary as build_usage_summary_read_model  # noqa: E402
+from loopx.history import collect_history  # noqa: E402
 
 
 FORBIDDEN_USAGE_KEYS = {
@@ -183,10 +185,16 @@ def main() -> int:
             delivery_outcome="primary_goal_outcome",
         )
 
-        payload = collect_status(
+        payload = status_module.collect_status(
             registry_path=registry_path,
             runtime_root_override=str(runtime),
             scan_roots=[root / "project"],
+            limit=20,
+        )
+        history = collect_history(
+            registry_path=registry_path,
+            runtime_root=runtime,
+            goal_id=None,
             limit=20,
         )
         status_contract = payload["status_contract"]
@@ -196,6 +204,15 @@ def main() -> int:
         assert status_contract["reload_hint"] == "scripts/macos-dashboard-launchagent.sh restart", status_contract
 
         usage = payload["usage_summary"]
+        wrapper_usage = status_module.build_usage_summary(history)
+        direct_usage = build_usage_summary_read_model(
+            history,
+            parse_timestamp=status_module.parse_timestamp,
+        )
+        wrapper_usage["generated_at"] = usage["generated_at"]
+        direct_usage["generated_at"] = usage["generated_at"]
+        assert wrapper_usage == usage, (wrapper_usage, usage)
+        assert direct_usage == usage, (direct_usage, usage)
         totals = usage["totals"]
         assert usage["available"] is True, usage
         assert usage["source"] == "run_history", usage

--- a/loopx/control_plane/quota/usage_summary.py
+++ b/loopx/control_plane/quota/usage_summary.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable
+
+
+USAGE_PROXY_NOTE = "run-history proxy; excludes token counts and raw thread logs"
+
+ParseTimestamp = Callable[[Any], Any]
+
+
+def quota_spend_slots(run: dict[str, Any]) -> int:
+    classification = str(run.get("classification") or "")
+    if classification not in {"quota_slot_spent", "quota_slot_voided"}:
+        return 0
+    quota_event = run.get("quota_event") if isinstance(run.get("quota_event"), dict) else {}
+    raw_slots = quota_event.get("slots", 1)
+    try:
+        slots = max(0, int(raw_slots))
+    except (TypeError, ValueError):
+        slots = 1
+    if classification == "quota_slot_voided" or str(quota_event.get("event_type") or "") == "quota_slot_voided":
+        return -slots
+    return slots
+
+
+def is_automation_run(run: dict[str, Any]) -> bool:
+    quota_event = run.get("quota_event") if isinstance(run.get("quota_event"), dict) else {}
+    source = str(quota_event.get("source") or run.get("source") or "").lower()
+    if source in {"heartbeat", "automation", "cron"}:
+        return True
+    if "heartbeat" in source or "automation" in source:
+        return True
+    return str(run.get("classification") or "") in {"quota_slot_spent", "quota_slot_voided"}
+
+
+def is_progress_signal_run(run: dict[str, Any]) -> bool:
+    classification = str(run.get("classification") or "")
+    return bool(classification and classification not in {"quota_slot_spent", "quota_slot_voided", "state_refreshed"})
+
+
+def blank_usage_goal(goal_id: str) -> dict[str, Any]:
+    return {
+        "goal_id": goal_id,
+        "runs_24h": 0,
+        "runs_7d": 0,
+        "quota_spend_slots_24h": 0,
+        "quota_spend_slots_7d": 0,
+        "automation_run_count_24h": 0,
+        "automation_run_count_7d": 0,
+        "progress_signal_run_count_24h": 0,
+        "progress_signal_run_count_7d": 0,
+        "project_share_24h": 0.0,
+    }
+
+
+def build_usage_summary(
+    history: dict[str, Any],
+    *,
+    parse_timestamp: ParseTimestamp,
+) -> dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    cutoff_24h = now - timedelta(hours=24)
+    cutoff_7d = now - timedelta(days=7)
+    totals = {
+        "runs_24h": 0,
+        "runs_7d": 0,
+        "quota_spend_slots_24h": 0,
+        "quota_spend_slots_7d": 0,
+        "automation_run_count_24h": 0,
+        "automation_run_count_7d": 0,
+        "progress_signal_run_count_24h": 0,
+        "progress_signal_run_count_7d": 0,
+    }
+    goals: dict[str, dict[str, Any]] = {}
+    sample_count = 0
+
+    for run in history.get("runs") or []:
+        if not isinstance(run, dict):
+            continue
+        sample_count += 1
+        generated_at = parse_timestamp(run.get("generated_at"))
+        if generated_at is None:
+            continue
+        goal_id = str(run.get("goal_id") or "unknown-goal")
+        goal = goals.setdefault(goal_id, blank_usage_goal(goal_id))
+        slots = quota_spend_slots(run)
+        automation_event = is_automation_run(run)
+        progress_signal = is_progress_signal_run(run)
+
+        if generated_at >= cutoff_7d:
+            totals["runs_7d"] += 1
+            goal["runs_7d"] += 1
+            totals["quota_spend_slots_7d"] += slots
+            goal["quota_spend_slots_7d"] += slots
+            if automation_event:
+                totals["automation_run_count_7d"] += 1
+                goal["automation_run_count_7d"] += 1
+            if progress_signal:
+                totals["progress_signal_run_count_7d"] += 1
+                goal["progress_signal_run_count_7d"] += 1
+        if generated_at >= cutoff_24h:
+            totals["runs_24h"] += 1
+            goal["runs_24h"] += 1
+            totals["quota_spend_slots_24h"] += slots
+            goal["quota_spend_slots_24h"] += slots
+            if automation_event:
+                totals["automation_run_count_24h"] += 1
+                goal["automation_run_count_24h"] += 1
+            if progress_signal:
+                totals["progress_signal_run_count_24h"] += 1
+                goal["progress_signal_run_count_24h"] += 1
+
+    if totals["runs_24h"]:
+        for goal in goals.values():
+            goal["project_share_24h"] = round(goal["runs_24h"] / totals["runs_24h"], 3)
+
+    goal_rows = sorted(
+        goals.values(),
+        key=lambda item: (
+            item["runs_24h"],
+            item["quota_spend_slots_24h"],
+            item["runs_7d"],
+            item["goal_id"],
+        ),
+        reverse=True,
+    )
+    return {
+        "available": True,
+        "source": "run_history",
+        "generated_at": now.isoformat(),
+        "sample_run_count": sample_count,
+        "proxy_note": USAGE_PROXY_NOTE,
+        "totals": totals,
+        "goals": goal_rows,
+    }

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -238,6 +238,14 @@ from .control_plane.todos.todo_index import (
     TODO_INDEX_SCHEMA_VERSION,
     build_todo_index as _build_todo_index_read_model,
 )
+from .control_plane.quota.usage_summary import (
+    USAGE_PROXY_NOTE,
+    blank_usage_goal as _blank_usage_goal_read_model,
+    build_usage_summary as _build_usage_summary_read_model,
+    is_automation_run as _is_automation_run_read_model,
+    is_progress_signal_run as _is_progress_signal_run_read_model,
+    quota_spend_slots as _quota_spend_slots_read_model,
+)
 from .promotion_gate import build_promotion_gate
 from .quota import quota_status, quota_with_handoff_outcome_floor
 from .registry import registry_goals
@@ -506,7 +514,6 @@ RUN_COMPACT_FIELDS = (
     "json_exists",
     "markdown_exists",
 )
-USAGE_PROXY_NOTE = "run-history proxy; excludes token counts and raw thread logs"
 LIFECYCLE_PRIORITY = (
     "controller_ready",
     "reward_judged",
@@ -7656,48 +7663,19 @@ def build_run_history(history: dict[str, Any], *, display_limit: int | None = No
 
 
 def quota_spend_slots(run: dict[str, Any]) -> int:
-    classification = str(run.get("classification") or "")
-    if classification not in {"quota_slot_spent", "quota_slot_voided"}:
-        return 0
-    quota_event = run.get("quota_event") if isinstance(run.get("quota_event"), dict) else {}
-    raw_slots = quota_event.get("slots", 1)
-    try:
-        slots = max(0, int(raw_slots))
-    except (TypeError, ValueError):
-        slots = 1
-    if classification == "quota_slot_voided" or str(quota_event.get("event_type") or "") == "quota_slot_voided":
-        return -slots
-    return slots
+    return _quota_spend_slots_read_model(run)
 
 
 def is_automation_run(run: dict[str, Any]) -> bool:
-    quota_event = run.get("quota_event") if isinstance(run.get("quota_event"), dict) else {}
-    source = str(quota_event.get("source") or run.get("source") or "").lower()
-    if source in {"heartbeat", "automation", "cron"}:
-        return True
-    if "heartbeat" in source or "automation" in source:
-        return True
-    return str(run.get("classification") or "") in {"quota_slot_spent", "quota_slot_voided"}
+    return _is_automation_run_read_model(run)
 
 
 def is_progress_signal_run(run: dict[str, Any]) -> bool:
-    classification = str(run.get("classification") or "")
-    return bool(classification and classification not in {"quota_slot_spent", "quota_slot_voided", "state_refreshed"})
+    return _is_progress_signal_run_read_model(run)
 
 
 def blank_usage_goal(goal_id: str) -> dict[str, Any]:
-    return {
-        "goal_id": goal_id,
-        "runs_24h": 0,
-        "runs_7d": 0,
-        "quota_spend_slots_24h": 0,
-        "quota_spend_slots_7d": 0,
-        "automation_run_count_24h": 0,
-        "automation_run_count_7d": 0,
-        "progress_signal_run_count_24h": 0,
-        "progress_signal_run_count_7d": 0,
-        "project_share_24h": 0.0,
-    }
+    return _blank_usage_goal_read_model(goal_id)
 
 
 def blank_event_class_counts() -> dict[str, int]:
@@ -8055,81 +8033,10 @@ def build_decision_freshness_summary(history: dict[str, Any]) -> dict[str, Any]:
 
 
 def build_usage_summary(history: dict[str, Any]) -> dict[str, Any]:
-    now = datetime.now(timezone.utc)
-    cutoff_24h = now - timedelta(hours=24)
-    cutoff_7d = now - timedelta(days=7)
-    totals = {
-        "runs_24h": 0,
-        "runs_7d": 0,
-        "quota_spend_slots_24h": 0,
-        "quota_spend_slots_7d": 0,
-        "automation_run_count_24h": 0,
-        "automation_run_count_7d": 0,
-        "progress_signal_run_count_24h": 0,
-        "progress_signal_run_count_7d": 0,
-    }
-    goals: dict[str, dict[str, Any]] = {}
-    sample_count = 0
-
-    for run in history.get("runs") or []:
-        if not isinstance(run, dict):
-            continue
-        sample_count += 1
-        generated_at = parse_timestamp(run.get("generated_at"))
-        if generated_at is None:
-            continue
-        goal_id = str(run.get("goal_id") or "unknown-goal")
-        goal = goals.setdefault(goal_id, blank_usage_goal(goal_id))
-        slots = quota_spend_slots(run)
-        automation_event = is_automation_run(run)
-        progress_signal = is_progress_signal_run(run)
-
-        if generated_at >= cutoff_7d:
-            totals["runs_7d"] += 1
-            goal["runs_7d"] += 1
-            totals["quota_spend_slots_7d"] += slots
-            goal["quota_spend_slots_7d"] += slots
-            if automation_event:
-                totals["automation_run_count_7d"] += 1
-                goal["automation_run_count_7d"] += 1
-            if progress_signal:
-                totals["progress_signal_run_count_7d"] += 1
-                goal["progress_signal_run_count_7d"] += 1
-        if generated_at >= cutoff_24h:
-            totals["runs_24h"] += 1
-            goal["runs_24h"] += 1
-            totals["quota_spend_slots_24h"] += slots
-            goal["quota_spend_slots_24h"] += slots
-            if automation_event:
-                totals["automation_run_count_24h"] += 1
-                goal["automation_run_count_24h"] += 1
-            if progress_signal:
-                totals["progress_signal_run_count_24h"] += 1
-                goal["progress_signal_run_count_24h"] += 1
-
-    if totals["runs_24h"]:
-        for goal in goals.values():
-            goal["project_share_24h"] = round(goal["runs_24h"] / totals["runs_24h"], 3)
-
-    goal_rows = sorted(
-        goals.values(),
-        key=lambda item: (
-            item["runs_24h"],
-            item["quota_spend_slots_24h"],
-            item["runs_7d"],
-            item["goal_id"],
-        ),
-        reverse=True,
+    return _build_usage_summary_read_model(
+        history,
+        parse_timestamp=parse_timestamp,
     )
-    return {
-        "available": True,
-        "source": "run_history",
-        "generated_at": now.isoformat(),
-        "sample_run_count": sample_count,
-        "proxy_note": USAGE_PROXY_NOTE,
-        "totals": totals,
-        "goals": goal_rows,
-    }
 
 
 def build_todo_index(


### PR DESCRIPTION
## Summary
- Move run-history usage summary construction from status.py into control_plane/quota/usage_summary.py.
- Keep loopx.status usage helper names as compatibility wrappers.
- Extend usage-summary smoke to assert collect_status, status wrapper, and direct read-model parity.

## Product / Architecture Judgment
- Motivation: continue the canary-gated status.py cleanup by placing quota/run-history usage projection in the quota bounded context instead of the status hot path.
- Solved: the status payload still exposes the same usage_summary shape, while implementation now lives in a focused read-model module.
- User/operator impact: reduces status.py size and makes usage accounting behavior easier to test independently before further status refactors.
- Main risk: compatibility of usage summary totals and public-safe proxy fields; mitigated by direct/wrapper/collect_status parity smoke and focused status smokes.
- Design judgment: this follows the bounded-context direction rather than growing a generic projections bucket; timestamp parsing stays injected from status to preserve existing semantics.

## Validation
- python3 examples/usage-summary-smoke.py
- python3 examples/control_plane/status-quota-review-packet-parity-smoke.py
- python3 examples/control_plane/status-contract-readmodel-smoke.py
- python3 examples/control_plane/status-goal-filter-smoke.py
- python3 -m compileall -q loopx/status.py loopx/control_plane/quota/usage_summary.py examples/usage-summary-smoke.py
- loopx --format json status --goal-id loopx-meta --limit 1
- git diff --check origin/main...HEAD

## Boundary Scan
- Candidate paths scanned for private/internal markers, local paths, credentials, raw benchmark logs, trajectories, verifier output, and internal links. New hits are expected public-safe fixture/proxy terms; pre-existing status.py benchmark field names remain unchanged.