### PR TITLE
Extract event ledger read model

### DIFF
--- a/examples/control_plane/event-ledger-readmodel-smoke.py
+++ b/examples/control_plane/event-ledger-readmodel-smoke.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Smoke-test event ledger read-model parity outside benchmark fixtures."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import sys
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx import status as status_module  # noqa: E402
+from loopx.control_plane.runtime import event_ledger as event_ledger_read_model  # noqa: E402
+
+
+def direct_event_class(run: dict[str, Any]) -> str:
+    return event_ledger_read_model.event_ledger_event_class(
+        run,
+        compact_benchmark_run=status_module.compact_benchmark_run,
+        compact_benchmark_result=status_module.compact_benchmark_result,
+        compact_benchmark_comparison=status_module.compact_benchmark_comparison,
+        compact_benchmark_learning_ledger=status_module.compact_benchmark_learning_ledger,
+        compact_benchmark_experiment_report=status_module.compact_benchmark_experiment_report,
+        compact_active_user_assisted_pilot=status_module.compact_active_user_assisted_pilot,
+        run_has_external_evidence_watch_signal=status_module.run_has_external_evidence_watch_signal,
+        decision_classifications=status_module.EVENT_LEDGER_DECISION_CLASSIFICATIONS,
+        evidence_classifications=status_module.EVENT_LEDGER_EVIDENCE_CLASSIFICATIONS,
+        evidence_hints=status_module.EVENT_LEDGER_EVIDENCE_HINTS,
+        state_classifications=status_module.EVENT_LEDGER_STATE_CLASSIFICATIONS,
+    )
+
+
+def direct_summary(history: dict[str, Any]) -> dict[str, Any]:
+    return event_ledger_read_model.build_event_ledger_summary(
+        history,
+        parse_timestamp=status_module.parse_timestamp,
+        event_class_for_run=direct_event_class,
+        compact_benchmark_run=status_module.compact_benchmark_run,
+    )
+
+
+def normalize_generated_at(payload: dict[str, Any], reference: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(payload)
+    normalized["generated_at"] = reference["generated_at"]
+    return normalized
+
+
+def main() -> None:
+    now = datetime.now(timezone.utc)
+    runs = [
+        {
+            "goal_id": "project-a",
+            "generated_at": (now - timedelta(minutes=10)).isoformat(),
+            "classification": "quota_slot_spent",
+            "quota_event": {"event_type": "quota_slot_spent", "source": "heartbeat", "slots": 1},
+        },
+        {
+            "goal_id": "project-a",
+            "generated_at": (now - timedelta(minutes=20)).isoformat(),
+            "classification": "operator_gate_approved",
+            "operator_gate": {"decision": "approved"},
+        },
+        {
+            "goal_id": "project-b",
+            "generated_at": (now - timedelta(hours=2)).isoformat(),
+            "classification": "read_only_project_map",
+            "project_map": {"count": 2},
+        },
+        {
+            "goal_id": "project-b",
+            "generated_at": (now - timedelta(hours=3)).isoformat(),
+            "classification": "state_refreshed",
+        },
+        {
+            "goal_id": "project-b",
+            "generated_at": (now - timedelta(hours=4)).isoformat(),
+            "classification": "implementation_batch",
+        },
+        {
+            "goal_id": "project-a",
+            "generated_at": (now - timedelta(days=2)).isoformat(),
+            "classification": "cache_check",
+            "cache_check": {"status": "hit"},
+        },
+        {
+            "goal_id": "project-c",
+            "generated_at": (now - timedelta(days=8)).isoformat(),
+            "classification": "old_work",
+        },
+        {
+            "goal_id": "project-c",
+            "generated_at": "not-a-timestamp",
+            "classification": "ignored_bad_time",
+        },
+    ]
+    history = {"runs": runs}
+
+    for run in runs:
+        assert status_module.event_ledger_event_class(run) == direct_event_class(run), run
+
+    wrapper = status_module.build_event_ledger_summary(history)
+    direct = direct_summary(history)
+    assert normalize_generated_at(direct, wrapper) == wrapper, (direct, wrapper)
+
+    assert status_module.blank_event_class_counts() == event_ledger_read_model.blank_event_class_counts()
+    assert status_module.blank_event_ledger_goal("project-z") == event_ledger_read_model.blank_event_ledger_goal(
+        "project-z"
+    )
+
+    totals = wrapper["totals"]
+    assert wrapper["available"] is True, wrapper
+    assert wrapper["source"] == "run_history", wrapper
+    assert wrapper["sample_run_count"] == len(runs), wrapper
+    assert wrapper["event_classes"] == ["accounting", "decision", "evidence", "state", "work"], wrapper
+    assert totals["events_24h"] == 5, totals
+    assert totals["events_7d"] == 6, totals
+    assert totals["benchmark_runs_24h"] == 0, totals
+    assert totals["benchmark_runs_7d"] == 0, totals
+    assert totals["by_class_24h"] == {
+        "accounting": 1,
+        "decision": 1,
+        "evidence": 1,
+        "state": 1,
+        "work": 1,
+    }, totals
+    assert totals["by_class_7d"] == {
+        "accounting": 1,
+        "decision": 1,
+        "evidence": 2,
+        "state": 1,
+        "work": 1,
+    }, totals
+
+    goals = {goal["goal_id"]: goal for goal in wrapper["goals"]}
+    assert goals["project-a"]["events_24h"] == 2, goals
+    assert goals["project-a"]["events_7d"] == 3, goals
+    assert goals["project-a"]["latest_event_class"] == "accounting", goals
+    assert goals["project-b"]["by_class_24h"] == {
+        "accounting": 0,
+        "decision": 0,
+        "evidence": 1,
+        "state": 1,
+        "work": 1,
+    }, goals
+    assert goals["project-c"]["events_7d"] == 0, goals
+
+    print("event-ledger-readmodel-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/control_plane/runtime/event_ledger.py
+++ b/loopx/control_plane/runtime/event_ledger.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable, Iterable, Optional
+
+
+EVENT_LEDGER_CLASSES = (
+    "accounting",
+    "decision",
+    "evidence",
+    "state",
+    "work",
+)
+EVENT_LEDGER_PROXY_NOTE = "append-only run-history projection; compact event-class counts only"
+
+ParseTimestamp = Callable[[Any], Any]
+RunCompactor = Callable[[dict[str, Any]], Optional[dict[str, Any]]]
+RunPredicate = Callable[[dict[str, Any]], bool]
+
+
+def blank_event_class_counts(
+    event_classes: Iterable[str] = EVENT_LEDGER_CLASSES,
+) -> dict[str, int]:
+    return {event_class: 0 for event_class in event_classes}
+
+
+def blank_event_ledger_goal(
+    goal_id: str,
+    *,
+    event_classes: Iterable[str] = EVENT_LEDGER_CLASSES,
+) -> dict[str, Any]:
+    return {
+        "goal_id": goal_id,
+        "events_24h": 0,
+        "events_7d": 0,
+        "benchmark_runs_24h": 0,
+        "benchmark_runs_7d": 0,
+        "by_class_24h": blank_event_class_counts(event_classes),
+        "by_class_7d": blank_event_class_counts(event_classes),
+        "latest_event_class": None,
+        "latest_event_at": None,
+        "latest_benchmark_run": None,
+    }
+
+
+def event_ledger_event_class(
+    run: dict[str, Any],
+    *,
+    compact_benchmark_run: RunCompactor,
+    compact_benchmark_result: RunCompactor,
+    compact_benchmark_comparison: RunCompactor,
+    compact_benchmark_learning_ledger: RunCompactor,
+    compact_benchmark_experiment_report: RunCompactor,
+    compact_active_user_assisted_pilot: RunCompactor,
+    run_has_external_evidence_watch_signal: RunPredicate,
+    decision_classifications: set[str],
+    evidence_classifications: set[str],
+    evidence_hints: tuple[str, ...],
+    state_classifications: set[str],
+) -> str:
+    classification = str(run.get("classification") or "").lower()
+    if classification == "quota_slot_spent" or isinstance(run.get("quota_event"), dict):
+        return "accounting"
+    if (
+        compact_benchmark_run(run)
+        or compact_benchmark_result(run)
+        or compact_benchmark_comparison(run)
+        or compact_benchmark_learning_ledger(run)
+        or compact_benchmark_experiment_report(run)
+        or compact_active_user_assisted_pilot(run)
+    ):
+        return "evidence"
+    if (
+        classification in decision_classifications
+        or "operator_gate" in classification
+        or "human_reward" in classification
+        or "reward" in classification
+        or isinstance(run.get("human_reward"), dict)
+        or isinstance(run.get("operator_gate"), dict)
+        or isinstance(run.get("operator_gate_resume_contract"), dict)
+    ):
+        return "decision"
+    if classification in evidence_classifications:
+        return "evidence"
+    if run_has_external_evidence_watch_signal(run):
+        return "evidence"
+    if any(hint in classification for hint in evidence_hints):
+        return "evidence"
+    if any(
+        key in run
+        for key in (
+            "active_priorities",
+            "active_task_count",
+            "artifact",
+            "artifacts",
+            "cache_check",
+            "controller_readiness",
+            "project_map",
+        )
+    ):
+        return "evidence"
+    if classification in state_classifications or classification.endswith("_refreshed"):
+        return "state"
+    return "work"
+
+
+def build_event_ledger_summary(
+    history: dict[str, Any],
+    *,
+    parse_timestamp: ParseTimestamp,
+    event_class_for_run: Callable[[dict[str, Any]], str],
+    compact_benchmark_run: RunCompactor,
+    event_classes: tuple[str, ...] = EVENT_LEDGER_CLASSES,
+    proxy_note: str = EVENT_LEDGER_PROXY_NOTE,
+) -> dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    cutoff_24h = now - timedelta(hours=24)
+    cutoff_7d = now - timedelta(days=7)
+    totals = {
+        "events_24h": 0,
+        "events_7d": 0,
+        "benchmark_runs_24h": 0,
+        "benchmark_runs_7d": 0,
+        "by_class_24h": blank_event_class_counts(event_classes),
+        "by_class_7d": blank_event_class_counts(event_classes),
+    }
+    goals: dict[str, dict[str, Any]] = {}
+    sample_count = 0
+
+    for run in history.get("runs") or []:
+        if not isinstance(run, dict):
+            continue
+        sample_count += 1
+        generated_at = parse_timestamp(run.get("generated_at"))
+        if generated_at is None:
+            continue
+        event_class = event_class_for_run(run)
+        goal_id = str(run.get("goal_id") or "unknown-goal")
+        goal = goals.setdefault(
+            goal_id,
+            blank_event_ledger_goal(goal_id, event_classes=event_classes),
+        )
+        latest_event_at = parse_timestamp(goal.get("latest_event_at"))
+        if latest_event_at is None or generated_at > latest_event_at:
+            goal["latest_event_class"] = event_class
+            goal["latest_event_at"] = generated_at.isoformat()
+        benchmark_run = compact_benchmark_run(run)
+        if benchmark_run:
+            latest_benchmark_at = parse_timestamp(
+                (goal.get("latest_benchmark_run") or {}).get("generated_at")
+                if isinstance(goal.get("latest_benchmark_run"), dict)
+                else None
+            )
+            if latest_benchmark_at is None or generated_at > latest_benchmark_at:
+                goal["latest_benchmark_run"] = {
+                    "generated_at": generated_at.isoformat(),
+                    "classification": run.get("classification"),
+                    **benchmark_run,
+                }
+
+        if generated_at >= cutoff_7d:
+            totals["events_7d"] += 1
+            totals["by_class_7d"][event_class] += 1
+            goal["events_7d"] += 1
+            goal["by_class_7d"][event_class] += 1
+            if benchmark_run:
+                totals["benchmark_runs_7d"] += 1
+                goal["benchmark_runs_7d"] += 1
+        if generated_at >= cutoff_24h:
+            totals["events_24h"] += 1
+            totals["by_class_24h"][event_class] += 1
+            goal["events_24h"] += 1
+            goal["by_class_24h"][event_class] += 1
+            if benchmark_run:
+                totals["benchmark_runs_24h"] += 1
+                goal["benchmark_runs_24h"] += 1
+
+    goal_rows = sorted(
+        goals.values(),
+        key=lambda item: (
+            item["events_24h"],
+            item["events_7d"],
+            item["goal_id"],
+        ),
+        reverse=True,
+    )
+    return {
+        "available": True,
+        "source": "run_history",
+        "generated_at": now.isoformat(),
+        "sample_run_count": sample_count,
+        "proxy_note": proxy_note,
+        "event_classes": list(event_classes),
+        "totals": totals,
+        "goals": goal_rows,
+    }

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -152,6 +152,14 @@ from .control_plane.runtime.run_compaction import (
     compact_operator_gate as _compact_operator_gate_read_model,
     compact_operator_gate_resume_contract as _compact_operator_gate_resume_contract_read_model,
 )
+from .control_plane.runtime.event_ledger import (
+    EVENT_LEDGER_CLASSES,
+    EVENT_LEDGER_PROXY_NOTE,
+    blank_event_class_counts as _blank_event_class_counts_read_model,
+    blank_event_ledger_goal as _blank_event_ledger_goal_read_model,
+    build_event_ledger_summary as _build_event_ledger_summary_read_model,
+    event_ledger_event_class as _event_ledger_event_class_read_model,
+)
 from .control_plane.handoff.handoff_runs import (
     is_custom_post_handoff_work_run as _is_custom_post_handoff_work_run_read_model,
     is_handoff_ready_run as _is_handoff_ready_run_read_model,
@@ -371,14 +379,6 @@ BENCHMARK_VALIDATION_NEUTRAL_FALSE_FIELDS = {
     "probe_contract_result_present",
     "assisted_collaboration_claim_allowed",
 }
-EVENT_LEDGER_CLASSES = (
-    "accounting",
-    "decision",
-    "evidence",
-    "state",
-    "work",
-)
-EVENT_LEDGER_PROXY_NOTE = "append-only run-history projection; compact event-class counts only"
 BENCHMARK_RUN_SCHEMA_VERSION = "benchmark_run_v0"
 BENCHMARK_RESULT_SCHEMA_VERSION = "benchmark_result_v0"
 BENCHMARK_COMPARISON_SCHEMA_VERSION = "benchmark_comparison_v0"
@@ -7679,150 +7679,37 @@ def blank_usage_goal(goal_id: str) -> dict[str, Any]:
 
 
 def blank_event_class_counts() -> dict[str, int]:
-    return {event_class: 0 for event_class in EVENT_LEDGER_CLASSES}
+    return _blank_event_class_counts_read_model()
 
 
 def blank_event_ledger_goal(goal_id: str) -> dict[str, Any]:
-    return {
-        "goal_id": goal_id,
-        "events_24h": 0,
-        "events_7d": 0,
-        "benchmark_runs_24h": 0,
-        "benchmark_runs_7d": 0,
-        "by_class_24h": blank_event_class_counts(),
-        "by_class_7d": blank_event_class_counts(),
-        "latest_event_class": None,
-        "latest_event_at": None,
-        "latest_benchmark_run": None,
-    }
+    return _blank_event_ledger_goal_read_model(goal_id)
 
 
 def event_ledger_event_class(run: dict[str, Any]) -> str:
-    classification = str(run.get("classification") or "").lower()
-    if classification == "quota_slot_spent" or isinstance(run.get("quota_event"), dict):
-        return "accounting"
-    if (
-        compact_benchmark_run(run)
-        or compact_benchmark_result(run)
-        or compact_benchmark_comparison(run)
-        or compact_benchmark_learning_ledger(run)
-        or compact_benchmark_experiment_report(run)
-        or compact_active_user_assisted_pilot(run)
-    ):
-        return "evidence"
-    if (
-        classification in EVENT_LEDGER_DECISION_CLASSIFICATIONS
-        or "operator_gate" in classification
-        or "human_reward" in classification
-        or "reward" in classification
-        or isinstance(run.get("human_reward"), dict)
-        or isinstance(run.get("operator_gate"), dict)
-        or isinstance(run.get("operator_gate_resume_contract"), dict)
-    ):
-        return "decision"
-    if classification in EVENT_LEDGER_EVIDENCE_CLASSIFICATIONS:
-        return "evidence"
-    if run_has_external_evidence_watch_signal(run):
-        return "evidence"
-    if any(hint in classification for hint in EVENT_LEDGER_EVIDENCE_HINTS):
-        return "evidence"
-    if any(
-        key in run
-        for key in (
-            "active_priorities",
-            "active_task_count",
-            "artifact",
-            "artifacts",
-            "cache_check",
-            "controller_readiness",
-            "project_map",
-        )
-    ):
-        return "evidence"
-    if classification in EVENT_LEDGER_STATE_CLASSIFICATIONS or classification.endswith("_refreshed"):
-        return "state"
-    return "work"
+    return _event_ledger_event_class_read_model(
+        run,
+        compact_benchmark_run=compact_benchmark_run,
+        compact_benchmark_result=compact_benchmark_result,
+        compact_benchmark_comparison=compact_benchmark_comparison,
+        compact_benchmark_learning_ledger=compact_benchmark_learning_ledger,
+        compact_benchmark_experiment_report=compact_benchmark_experiment_report,
+        compact_active_user_assisted_pilot=compact_active_user_assisted_pilot,
+        run_has_external_evidence_watch_signal=run_has_external_evidence_watch_signal,
+        decision_classifications=EVENT_LEDGER_DECISION_CLASSIFICATIONS,
+        evidence_classifications=EVENT_LEDGER_EVIDENCE_CLASSIFICATIONS,
+        evidence_hints=EVENT_LEDGER_EVIDENCE_HINTS,
+        state_classifications=EVENT_LEDGER_STATE_CLASSIFICATIONS,
+    )
 
 
 def build_event_ledger_summary(history: dict[str, Any]) -> dict[str, Any]:
-    now = datetime.now(timezone.utc)
-    cutoff_24h = now - timedelta(hours=24)
-    cutoff_7d = now - timedelta(days=7)
-    totals = {
-        "events_24h": 0,
-        "events_7d": 0,
-        "benchmark_runs_24h": 0,
-        "benchmark_runs_7d": 0,
-        "by_class_24h": blank_event_class_counts(),
-        "by_class_7d": blank_event_class_counts(),
-    }
-    goals: dict[str, dict[str, Any]] = {}
-    sample_count = 0
-
-    for run in history.get("runs") or []:
-        if not isinstance(run, dict):
-            continue
-        sample_count += 1
-        generated_at = parse_timestamp(run.get("generated_at"))
-        if generated_at is None:
-            continue
-        event_class = event_ledger_event_class(run)
-        goal_id = str(run.get("goal_id") or "unknown-goal")
-        goal = goals.setdefault(goal_id, blank_event_ledger_goal(goal_id))
-        latest_event_at = parse_timestamp(goal.get("latest_event_at"))
-        if latest_event_at is None or generated_at > latest_event_at:
-            goal["latest_event_class"] = event_class
-            goal["latest_event_at"] = generated_at.isoformat()
-        benchmark_run = compact_benchmark_run(run)
-        if benchmark_run:
-            latest_benchmark_at = parse_timestamp(
-                (goal.get("latest_benchmark_run") or {}).get("generated_at")
-                if isinstance(goal.get("latest_benchmark_run"), dict)
-                else None
-            )
-            if latest_benchmark_at is None or generated_at > latest_benchmark_at:
-                goal["latest_benchmark_run"] = {
-                    "generated_at": generated_at.isoformat(),
-                    "classification": run.get("classification"),
-                    **benchmark_run,
-                }
-
-        if generated_at >= cutoff_7d:
-            totals["events_7d"] += 1
-            totals["by_class_7d"][event_class] += 1
-            goal["events_7d"] += 1
-            goal["by_class_7d"][event_class] += 1
-            if benchmark_run:
-                totals["benchmark_runs_7d"] += 1
-                goal["benchmark_runs_7d"] += 1
-        if generated_at >= cutoff_24h:
-            totals["events_24h"] += 1
-            totals["by_class_24h"][event_class] += 1
-            goal["events_24h"] += 1
-            goal["by_class_24h"][event_class] += 1
-            if benchmark_run:
-                totals["benchmark_runs_24h"] += 1
-                goal["benchmark_runs_24h"] += 1
-
-    goal_rows = sorted(
-        goals.values(),
-        key=lambda item: (
-            item["events_24h"],
-            item["events_7d"],
-            item["goal_id"],
-        ),
-        reverse=True,
+    return _build_event_ledger_summary_read_model(
+        history,
+        parse_timestamp=parse_timestamp,
+        event_class_for_run=event_ledger_event_class,
+        compact_benchmark_run=compact_benchmark_run,
     )
-    return {
-        "available": True,
-        "source": "run_history",
-        "generated_at": now.isoformat(),
-        "sample_run_count": sample_count,
-        "proxy_note": EVENT_LEDGER_PROXY_NOTE,
-        "event_classes": list(EVENT_LEDGER_CLASSES),
-        "totals": totals,
-        "goals": goal_rows,
-    }
 
 
 def build_promotion_readiness_summary(


### PR DESCRIPTION
Summary:
- Move event ledger run-history summary logic into loopx/control_plane/runtime/event_ledger.py.
- Keep loopx.status event ledger helpers as compatibility wrappers that bind existing status-specific classification and benchmark compactors.
- Add a focused non-benchmark control-plane read-model parity smoke for accounting, decision, evidence, state, work classes and 24h/7d totals.

Product / architecture judgment:
This continues the canary-gated status.py read-model cleanup under bounded contexts. Event ledger is runtime/run-history read-model logic, so control_plane/runtime is a cleaner home than the status hot path. The public status.py helper API remains stable, lowering installed-user risk while shrinking the status module by another small slice.

Validation:
- python3 examples/control_plane/event-ledger-readmodel-smoke.py
- python3 examples/usage-summary-smoke.py
- python3 examples/control_plane/status-quota-review-packet-parity-smoke.py
- python3 examples/control_plane/status-contract-readmodel-smoke.py
- python3 examples/control_plane/status-goal-filter-smoke.py
- python3 examples/control_plane/status-markdown-smoke.py
- loopx --format json status --goal-id loopx-meta --limit 1
- python3 -m compileall -q loopx/status.py loopx/control_plane/runtime/event_ledger.py examples/control_plane/event-ledger-readmodel-smoke.py
- git diff --check origin/main...HEAD

Known existing red smoke:
- python3 examples/control_plane/repo-python-line-budget-smoke.py is red on current main for pre-existing files: examples/skillsbench-benchmark-run-smoke.py and scripts/skillsbench_automation_loop.py. This PR does not touch either file and reduces loopx/status.py to 8912 lines.

Boundary scan:
Candidate new files and added status diff were scanned for private paths, credentials, raw logs, trajectories, verifier output, and internal links; no new hits.