### PR TITLE
Extract decision freshness read model

### DIFF
--- a/examples/control_plane/decision-freshness-readmodel-smoke.py
+++ b/examples/control_plane/decision-freshness-readmodel-smoke.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Smoke-test decision freshness read-model parity."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+import sys
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx import status as status_module  # noqa: E402
+from loopx.control_plane.runtime import decision_freshness as decision_read_model  # noqa: E402
+
+
+def direct_decision_kinds(run: dict[str, Any]) -> list[str]:
+    return decision_read_model.decision_event_kinds(
+        run,
+        decision_classifications=status_module.EVENT_LEDGER_DECISION_CLASSIFICATIONS,
+        classification_prefixes=status_module.DECISION_FRESHNESS_CLASSIFICATION_PREFIXES,
+    )
+
+
+def direct_summary(history: dict[str, Any]) -> dict[str, Any]:
+    return decision_read_model.build_decision_freshness_summary(
+        history,
+        parse_timestamp=status_module.parse_timestamp,
+        decision_event_kinds=direct_decision_kinds,
+        event_class_for_run=status_module.event_ledger_event_class,
+        blank_event_class_counts=status_module.blank_event_class_counts,
+        window_days=status_module.DECISION_FRESHNESS_WINDOW_DAYS,
+        item_limit=status_module.DECISION_FRESHNESS_ITEM_LIMIT,
+        proxy_note=status_module.DECISION_FRESHNESS_PROXY_NOTE,
+    )
+
+
+def normalize_generated_at(payload: dict[str, Any], reference: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(payload)
+    normalized["generated_at"] = reference["generated_at"]
+    return normalized
+
+
+def main() -> None:
+    now = datetime.now(timezone.utc)
+    runs = [
+        {
+            "goal_id": "project-a",
+            "generated_at": (now - timedelta(minutes=40)).isoformat(),
+            "classification": "operator_gate_approved",
+            "operator_gate": {"decision": "approved"},
+        },
+        {
+            "goal_id": "project-a",
+            "generated_at": (now - timedelta(minutes=20)).isoformat(),
+            "classification": "state_refreshed",
+        },
+        {
+            "goal_id": "project-b",
+            "generated_at": (now - timedelta(days=8)).isoformat(),
+            "classification": "human_reward_recorded",
+            "human_reward": {"decision": "continue"},
+        },
+        {
+            "goal_id": "project-b",
+            "generated_at": (now - timedelta(hours=3)).isoformat(),
+            "classification": "implementation_batch",
+        },
+        {
+            "goal_id": "project-b",
+            "generated_at": (now - timedelta(hours=2)).isoformat(),
+            "classification": "read_only_project_map",
+            "project_map": {"count": 2},
+        },
+        {
+            "goal_id": "project-b",
+            "generated_at": (now - timedelta(hours=1)).isoformat(),
+            "classification": "quota_slot_spent",
+            "quota_event": {"event_type": "quota_slot_spent", "slots": 1},
+        },
+        {
+            "goal_id": "project-c",
+            "generated_at": (now - timedelta(days=1)).isoformat(),
+            "classification": "reward_overlay_acknowledged",
+        },
+        {
+            "goal_id": "project-d",
+            "generated_at": "not-a-timestamp",
+            "classification": "operator_gate_approved",
+            "operator_gate": {"decision": "approved"},
+        },
+    ]
+    history = {"runs": runs}
+
+    assert status_module.decision_event_kinds(runs[0]) == direct_decision_kinds(runs[0]) == ["operator_gate"]
+    assert status_module.decision_event_kinds(runs[2]) == direct_decision_kinds(runs[2]) == ["human_reward"]
+    assert status_module.decision_event_kinds(runs[6]) == direct_decision_kinds(runs[6]) == [
+        "decision_classification"
+    ]
+    assert status_module.decision_freshness_reason(
+        stale_by_age=True,
+        newer_event_count=1,
+    ) == decision_read_model.decision_freshness_reason(stale_by_age=True, newer_event_count=1)
+
+    wrapper = status_module.build_decision_freshness_summary(history)
+    direct = direct_summary(history)
+    assert normalize_generated_at(direct, wrapper) == wrapper, (direct, wrapper)
+
+    summary = wrapper["summary"]
+    assert wrapper["available"] is True, wrapper
+    assert wrapper["source"] == "run_history", wrapper
+    assert wrapper["sample_run_count"] == len(runs), wrapper
+    assert wrapper["window_days"] == 7, wrapper
+    assert summary == {
+        "decision_count": 3,
+        "stale_count": 1,
+        "rebase_required_count": 2,
+        "fresh_count": 1,
+    }, summary
+
+    items = {
+        (item["goal_id"], item["decision_kind"]): item
+        for item in wrapper["items"]
+    }
+    project_a = items[("project-a", "operator_gate")]
+    assert project_a["freshness_state"] == "rebase_required", project_a
+    assert project_a["newer_event_count_7d"] == 1, project_a
+    assert project_a["newer_event_classes_7d"]["state"] == 1, project_a
+    assert project_a["stale_by_age"] is False, project_a
+
+    project_b = items[("project-b", "human_reward")]
+    assert project_b["freshness_state"] == "stale_rebase_required", project_b
+    assert project_b["stale_by_age"] is True, project_b
+    assert project_b["newer_event_count_7d"] == 3, project_b
+    assert project_b["newer_event_classes_7d"]["accounting"] == 1, project_b
+    assert project_b["newer_event_classes_7d"]["evidence"] == 1, project_b
+    assert project_b["newer_event_classes_7d"]["work"] == 1, project_b
+
+    project_c = items[("project-c", "decision_classification")]
+    assert project_c["freshness_state"] == "fresh", project_c
+    assert project_c["requires_decision_point_rebase"] is False, project_c
+
+    assert ("project-d", "operator_gate") not in items, items
+    print("decision-freshness-readmodel-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/control_plane/runtime/decision_freshness.py
+++ b/loopx/control_plane/runtime/decision_freshness.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable
+
+
+DECISION_FRESHNESS_WINDOW_DAYS = 7
+DECISION_FRESHNESS_ITEM_LIMIT = 12
+DECISION_FRESHNESS_PROXY_NOTE = (
+    "checkpointed decision freshness projection; rebase old decisions at the decision point before reuse"
+)
+DECISION_FRESHNESS_CLASSIFICATION_PREFIXES = (
+    "human_reward",
+    "reward_overlay",
+)
+
+ParseTimestamp = Callable[[Any], Any]
+DecisionKinds = Callable[[dict[str, Any]], list[str]]
+EventClassForRun = Callable[[dict[str, Any]], str]
+BlankEventClassCounts = Callable[[], dict[str, int]]
+
+
+def decision_event_kinds(
+    run: dict[str, Any],
+    *,
+    decision_classifications: set[str],
+    classification_prefixes: tuple[str, ...] = DECISION_FRESHNESS_CLASSIFICATION_PREFIXES,
+) -> list[str]:
+    kinds: list[str] = []
+    if isinstance(run.get("human_reward"), dict):
+        kinds.append("human_reward")
+    if isinstance(run.get("operator_gate"), dict):
+        kinds.append("operator_gate")
+    if isinstance(run.get("operator_gate_resume_contract"), dict):
+        kinds.append("operator_gate_resume_contract")
+
+    classification = str(run.get("classification") or "").lower()
+    if not kinds and (
+        classification in decision_classifications
+        or classification.startswith(classification_prefixes)
+    ):
+        kinds.append("decision_classification")
+    return kinds
+
+
+def decision_freshness_reason(*, stale_by_age: bool, newer_event_count: int) -> str:
+    if stale_by_age and newer_event_count:
+        return "decision older than freshness window and newer sampled events exist; rebase at decision point"
+    if stale_by_age:
+        return "decision older than freshness window; rebase at decision point"
+    if newer_event_count:
+        return "newer sampled events exist after decision; rebase at decision point"
+    return "no newer sampled events inside freshness window"
+
+
+def build_decision_freshness_summary(
+    history: dict[str, Any],
+    *,
+    parse_timestamp: ParseTimestamp,
+    decision_event_kinds: DecisionKinds,
+    event_class_for_run: EventClassForRun,
+    blank_event_class_counts: BlankEventClassCounts,
+    window_days: int = DECISION_FRESHNESS_WINDOW_DAYS,
+    item_limit: int = DECISION_FRESHNESS_ITEM_LIMIT,
+    proxy_note: str = DECISION_FRESHNESS_PROXY_NOTE,
+) -> dict[str, Any]:
+    now = datetime.now(timezone.utc)
+    cutoff = now - timedelta(days=window_days)
+    runs = [run for run in history.get("runs") or [] if isinstance(run, dict)]
+    items: list[dict[str, Any]] = []
+    stale_count = 0
+    rebase_required_count = 0
+    fresh_count = 0
+
+    indexed_runs: list[tuple[dict[str, Any], datetime, str]] = []
+    for run in runs:
+        generated_at = parse_timestamp(run.get("generated_at"))
+        if generated_at is None:
+            continue
+        indexed_runs.append((run, generated_at, str(run.get("goal_id") or "unknown-goal")))
+
+    for run, decision_at, goal_id in indexed_runs:
+        for decision_kind in decision_event_kinds(run):
+            newer_class_counts = blank_event_class_counts()
+            newer_event_count = 0
+            for other_run, other_at, other_goal_id in indexed_runs:
+                if other_goal_id != goal_id or other_at <= decision_at or other_at < cutoff:
+                    continue
+                newer_event_count += 1
+                newer_class_counts[event_class_for_run(other_run)] += 1
+
+            stale_by_age = decision_at < cutoff
+            if stale_by_age:
+                stale_count += 1
+            requires_rebase = stale_by_age or newer_event_count > 0
+            if requires_rebase:
+                rebase_required_count += 1
+            else:
+                fresh_count += 1
+            if stale_by_age:
+                freshness_state = "stale_rebase_required"
+            elif newer_event_count:
+                freshness_state = "rebase_required"
+            else:
+                freshness_state = "fresh"
+
+            items.append(
+                {
+                    "goal_id": goal_id,
+                    "decision_kind": decision_kind,
+                    "decision_at": decision_at.isoformat(),
+                    "classification": run.get("classification"),
+                    "age_days": round(max(0.0, (now - decision_at).total_seconds() / 86400), 2),
+                    "stale_by_age": stale_by_age,
+                    "newer_event_count_7d": newer_event_count,
+                    "newer_event_classes_7d": newer_class_counts,
+                    "freshness_state": freshness_state,
+                    "requires_decision_point_rebase": requires_rebase,
+                    "reason": decision_freshness_reason(
+                        stale_by_age=stale_by_age,
+                        newer_event_count=newer_event_count,
+                    ),
+                }
+            )
+
+    items.sort(
+        key=lambda item: (
+            1 if item["requires_decision_point_rebase"] else 0,
+            item["age_days"],
+            item["newer_event_count_7d"],
+            item["decision_at"],
+        ),
+        reverse=True,
+    )
+    return {
+        "available": True,
+        "source": "run_history",
+        "generated_at": now.isoformat(),
+        "sample_run_count": len(runs),
+        "window_days": window_days,
+        "proxy_note": proxy_note,
+        "summary": {
+            "decision_count": len(items),
+            "stale_count": stale_count,
+            "rebase_required_count": rebase_required_count,
+            "fresh_count": fresh_count,
+        },
+        "items": items[:item_limit],
+    }

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -160,6 +160,15 @@ from .control_plane.runtime.event_ledger import (
     build_event_ledger_summary as _build_event_ledger_summary_read_model,
     event_ledger_event_class as _event_ledger_event_class_read_model,
 )
+from .control_plane.runtime.decision_freshness import (
+    DECISION_FRESHNESS_CLASSIFICATION_PREFIXES,
+    DECISION_FRESHNESS_ITEM_LIMIT,
+    DECISION_FRESHNESS_PROXY_NOTE,
+    DECISION_FRESHNESS_WINDOW_DAYS,
+    build_decision_freshness_summary as _build_decision_freshness_summary_read_model,
+    decision_event_kinds as _decision_event_kinds_read_model,
+    decision_freshness_reason as _decision_freshness_reason_read_model,
+)
 from .control_plane.handoff.handoff_runs import (
     is_custom_post_handoff_work_run as _is_custom_post_handoff_work_run_read_model,
     is_handoff_ready_run as _is_handoff_ready_run_read_model,
@@ -409,17 +418,8 @@ MINIMUM_DASHBOARD_STATUS_CONTRACT_SCHEMA_VERSION = 2
 STATUS_CONTRACT_RELOAD_HINT = "scripts/macos-dashboard-launchagent.sh restart"
 STATUS_CONTRACT_SIGNAL_LIMIT = 3
 MONITOR_WRITEBACK_CONTRACT_SCHEMA_VERSION = "monitor_writeback_contract_v0"
-DECISION_FRESHNESS_WINDOW_DAYS = 7
-DECISION_FRESHNESS_ITEM_LIMIT = 12
-DECISION_FRESHNESS_PROXY_NOTE = (
-    "checkpointed decision freshness projection; rebase old decisions at the decision point before reuse"
-)
 PROMOTION_READINESS_PROXY_NOTE = (
     "canary promotion-readiness projection from append-only run history; exact evidence stays in run artifacts"
-)
-DECISION_FRESHNESS_CLASSIFICATION_PREFIXES = (
-    "human_reward",
-    "reward_overlay",
 )
 EVENT_LEDGER_DECISION_CLASSIFICATIONS = USER_OR_CONTROLLER_CLASSIFICATIONS | {
     "operator_gate_approved",
@@ -7811,117 +7811,31 @@ def build_contract_health_projection(contract: dict[str, Any]) -> dict[str, Any]
 
 
 def decision_event_kinds(run: dict[str, Any]) -> list[str]:
-    kinds: list[str] = []
-    if isinstance(run.get("human_reward"), dict):
-        kinds.append("human_reward")
-    if isinstance(run.get("operator_gate"), dict):
-        kinds.append("operator_gate")
-    if isinstance(run.get("operator_gate_resume_contract"), dict):
-        kinds.append("operator_gate_resume_contract")
-
-    classification = str(run.get("classification") or "").lower()
-    if not kinds and (
-        classification in EVENT_LEDGER_DECISION_CLASSIFICATIONS
-        or classification.startswith(DECISION_FRESHNESS_CLASSIFICATION_PREFIXES)
-    ):
-        kinds.append("decision_classification")
-    return kinds
+    return _decision_event_kinds_read_model(
+        run,
+        decision_classifications=EVENT_LEDGER_DECISION_CLASSIFICATIONS,
+        classification_prefixes=DECISION_FRESHNESS_CLASSIFICATION_PREFIXES,
+    )
 
 
 def decision_freshness_reason(*, stale_by_age: bool, newer_event_count: int) -> str:
-    if stale_by_age and newer_event_count:
-        return "decision older than freshness window and newer sampled events exist; rebase at decision point"
-    if stale_by_age:
-        return "decision older than freshness window; rebase at decision point"
-    if newer_event_count:
-        return "newer sampled events exist after decision; rebase at decision point"
-    return "no newer sampled events inside freshness window"
+    return _decision_freshness_reason_read_model(
+        stale_by_age=stale_by_age,
+        newer_event_count=newer_event_count,
+    )
 
 
 def build_decision_freshness_summary(history: dict[str, Any]) -> dict[str, Any]:
-    now = datetime.now(timezone.utc)
-    cutoff = now - timedelta(days=DECISION_FRESHNESS_WINDOW_DAYS)
-    runs = [run for run in history.get("runs") or [] if isinstance(run, dict)]
-    items: list[dict[str, Any]] = []
-    stale_count = 0
-    rebase_required_count = 0
-    fresh_count = 0
-
-    indexed_runs: list[tuple[dict[str, Any], datetime, str]] = []
-    for run in runs:
-        generated_at = parse_timestamp(run.get("generated_at"))
-        if generated_at is None:
-            continue
-        indexed_runs.append((run, generated_at, str(run.get("goal_id") or "unknown-goal")))
-
-    for run, decision_at, goal_id in indexed_runs:
-        for decision_kind in decision_event_kinds(run):
-            newer_class_counts = blank_event_class_counts()
-            newer_event_count = 0
-            for other_run, other_at, other_goal_id in indexed_runs:
-                if other_goal_id != goal_id or other_at <= decision_at or other_at < cutoff:
-                    continue
-                newer_event_count += 1
-                newer_class_counts[event_ledger_event_class(other_run)] += 1
-
-            stale_by_age = decision_at < cutoff
-            if stale_by_age:
-                stale_count += 1
-            requires_rebase = stale_by_age or newer_event_count > 0
-            if requires_rebase:
-                rebase_required_count += 1
-            else:
-                fresh_count += 1
-            if stale_by_age:
-                freshness_state = "stale_rebase_required"
-            elif newer_event_count:
-                freshness_state = "rebase_required"
-            else:
-                freshness_state = "fresh"
-
-            items.append(
-                {
-                    "goal_id": goal_id,
-                    "decision_kind": decision_kind,
-                    "decision_at": decision_at.isoformat(),
-                    "classification": run.get("classification"),
-                    "age_days": round(max(0.0, (now - decision_at).total_seconds() / 86400), 2),
-                    "stale_by_age": stale_by_age,
-                    "newer_event_count_7d": newer_event_count,
-                    "newer_event_classes_7d": newer_class_counts,
-                    "freshness_state": freshness_state,
-                    "requires_decision_point_rebase": requires_rebase,
-                    "reason": decision_freshness_reason(
-                        stale_by_age=stale_by_age,
-                        newer_event_count=newer_event_count,
-                    ),
-                }
-            )
-
-    items.sort(
-        key=lambda item: (
-            1 if item["requires_decision_point_rebase"] else 0,
-            item["age_days"],
-            item["newer_event_count_7d"],
-            item["decision_at"],
-        ),
-        reverse=True,
+    return _build_decision_freshness_summary_read_model(
+        history,
+        parse_timestamp=parse_timestamp,
+        decision_event_kinds=decision_event_kinds,
+        event_class_for_run=event_ledger_event_class,
+        blank_event_class_counts=blank_event_class_counts,
+        window_days=DECISION_FRESHNESS_WINDOW_DAYS,
+        item_limit=DECISION_FRESHNESS_ITEM_LIMIT,
+        proxy_note=DECISION_FRESHNESS_PROXY_NOTE,
     )
-    return {
-        "available": True,
-        "source": "run_history",
-        "generated_at": now.isoformat(),
-        "sample_run_count": len(runs),
-        "window_days": DECISION_FRESHNESS_WINDOW_DAYS,
-        "proxy_note": DECISION_FRESHNESS_PROXY_NOTE,
-        "summary": {
-            "decision_count": len(items),
-            "stale_count": stale_count,
-            "rebase_required_count": rebase_required_count,
-            "fresh_count": fresh_count,
-        },
-        "items": items[:DECISION_FRESHNESS_ITEM_LIMIT],
-    }
 
 
 def build_usage_summary(history: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
Summary:
- Move decision freshness run-history summary logic into loopx/control_plane/runtime/decision_freshness.py.
- Keep loopx.status decision freshness helpers as compatibility wrappers that bind the existing status event-class and decision classification policy.
- Add a focused control-plane parity smoke covering stale decisions, newer-event rebases, fresh decisions, and invalid timestamps.

Product and architecture judgment:
This is another bounded slice of the canary-gated status.py read-model cleanup. Decision freshness is runtime run-history read-model logic, so control_plane/runtime is the right bounded context. The public helper names in status.py remain stable, reducing installed-user risk while shrinking the status hot path.

Validation:
- python3 examples/control_plane/decision-freshness-readmodel-smoke.py
- python3 examples/control_plane/event-ledger-readmodel-smoke.py
- python3 examples/usage-summary-smoke.py
- python3 examples/control_plane/status-quota-review-packet-parity-smoke.py
- python3 examples/control_plane/status-contract-readmodel-smoke.py
- python3 examples/control_plane/status-goal-filter-smoke.py
- python3 examples/control_plane/status-markdown-smoke.py
- loopx --format json status --goal-id loopx-meta --limit 1
- python3 -m compileall -q loopx/status.py loopx/control_plane/runtime/decision_freshness.py examples/control_plane/decision-freshness-readmodel-smoke.py
- git diff --check origin/main...HEAD

Known existing red smoke:
- python3 examples/control_plane/repo-python-line-budget-smoke.py is red on current main for pre-existing files: examples/skillsbench-benchmark-run-smoke.py and scripts/skillsbench_automation_loop.py. This PR does not touch either file and keeps reducing loopx/status.py.

Boundary scan:
Candidate new files and added status diff were scanned for private paths, credentials, raw logs, trajectories, verifier output, and internal links; no new hits.