### PR TITLE
Bump LoopX release version to 0.1.7

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -93,6 +93,15 @@ path, and canary route rather than as a user-facing release baseline.
   commit `c036d60e`. This release improved quota/status/runtime routing,
   monitor and scheduler projection, release packaging coverage, and
   outcome-floor recovery for stuck or low-progress loops.
+- `v0.1.6` on 2026-07-03 17:07 +08:00: visible multi-agent startup hardening
+  at commit `1e3df9df`. This release made auto-research startup easier to see
+  and trigger, clarified decentralized pane routing, tightened monitor and
+  scheduler projection, and expanded the Codex CLI first-run release checks.
+- `v0.1.7` on 2026-07-04 12:52 +08:00: command-entry integration release at
+  the matching `v0.1.7` tag. This release made the supported entry layer
+  explicit: Codex installs LoopX command-facade skills such as `$loopx`, Claude
+  Code gets matching skill entries, legacy prompt shims are retired, and the
+  rich workflow skills remain available for implicit LoopX behavior.
 
 When a new public release is promoted, add it here only after the matching tag,
 release note, stable ref, update path, and focused release canary agree.

--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.1.6"
+version = "0.1.7"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

- bump LoopX package version from 0.1.6 to 0.1.7
- add the missing v0.1.6 public release timeline entry
- add the v0.1.7 release timeline entry for the command-entry integration layer

## Validation

- `python3 -m compileall -q loopx`
- `python3 examples/release/release-version-contract-smoke.py`
- `python3 examples/release/release-readiness-doc-smoke.py`
- `python3 examples/slash-command-install-smoke.py`
- `python3 examples/slash-command-catalog-smoke.py`
- `python3 examples/claude-install-optin-smoke.py`
- `python3 examples/release/codex-cli-no-clone-release-verification-smoke.py`
- `python3 examples/fresh-clone-quickstart-smoke.py`
- `python3 examples/loopx-update-smoke.py`
- `python3 examples/install-local-smoke.py`
- `python3 examples/cli-help-manpage-smoke.py`
- `python3 examples/canary/canary-promotion-readiness-smoke.py --no-write-evidence`
- `PYTHONPATH=. python3 -m loopx.cli --format json check --scan-path README.md --scan-path docs/ --scan-path examples/ --scan-path loopx/slash_command_install.py --scan-path skills/`
- `git diff --check`

`loopx check` and canary reported the pre-existing `loopx-meta` duplicate-index warning; public boundary scan was clean. Canary skipped dashboard browser checks because local dashboard npm dependencies are unavailable, matching the existing optional dashboard skip behavior.
