### PR TITLE
Extract promotion readiness read model

### DIFF
--- a/examples/control_plane/promotion-readiness-readmodel-smoke.py
+++ b/examples/control_plane/promotion-readiness-readmodel-smoke.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Smoke-test promotion readiness read-model parity."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+import json
+from pathlib import Path
+import sys
+import tempfile
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx import status as status_module  # noqa: E402
+from loopx.control_plane.runtime import promotion_readiness as readiness_read_model  # noqa: E402
+
+
+def normalize_dynamic_freshness(payload: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(payload)
+    for key in ("freshness_reference_time", "age_seconds", "age_hours"):
+        normalized.pop(key, None)
+    return normalized
+
+
+def direct_summary(
+    history: dict[str, Any],
+    *,
+    runtime_root: Path | None = None,
+    goal_id_filter: str | None = None,
+) -> dict[str, Any]:
+    return readiness_read_model.build_promotion_readiness_summary(
+        history,
+        parse_timestamp=status_module.parse_timestamp,
+        readiness_classifications=status_module.PROMOTION_READINESS_CLASSIFICATIONS,
+        add_promotion_readiness_freshness=status_module.add_promotion_readiness_freshness,
+        latest_promotion_readiness_event=lambda root: status_module.latest_promotion_readiness_event(
+            root,
+            goal_id=goal_id_filter,
+        ),
+        freshness_hours=status_module.PROMOTION_READINESS_FRESHNESS_HOURS,
+        runtime_root=runtime_root,
+        proxy_note=status_module.PROMOTION_READINESS_PROXY_NOTE,
+    )
+
+
+def write_indexed_readiness_run(
+    runtime_root: Path,
+    *,
+    goal_id: str,
+    generated_at: str,
+    classification: str = "canary_promotion_readiness_smoke_group",
+) -> None:
+    run_dir = runtime_root / "goals" / goal_id / "runs"
+    run_dir.mkdir(parents=True, exist_ok=True)
+    json_path = run_dir / "readiness.json"
+    markdown_path = run_dir / "readiness.md"
+    json_path.write_text("{}\n", encoding="utf-8")
+    markdown_path.write_text("# readiness\n", encoding="utf-8")
+    record = {
+        "goal_id": goal_id,
+        "generated_at": generated_at,
+        "classification": classification,
+        "delivery_batch_scale": "multi_surface",
+        "delivery_outcome": "primary_goal_outcome",
+        "recommended_action": "promotion readiness smoke passed",
+        "json_path": str(json_path),
+        "markdown_path": str(markdown_path),
+    }
+    with (run_dir / "index.jsonl").open("a", encoding="utf-8") as f:
+        f.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def assert_parity(
+    history: dict[str, Any],
+    *,
+    runtime_root: Path | None = None,
+    goal_id_filter: str | None = None,
+) -> dict[str, Any]:
+    wrapper = status_module.build_promotion_readiness_summary(
+        history,
+        runtime_root=runtime_root,
+        goal_id_filter=goal_id_filter,
+    )
+    direct = direct_summary(
+        history,
+        runtime_root=runtime_root,
+        goal_id_filter=goal_id_filter,
+    )
+    assert normalize_dynamic_freshness(direct) == normalize_dynamic_freshness(wrapper), (direct, wrapper)
+    return wrapper
+
+
+def main() -> None:
+    now = datetime.now(timezone.utc)
+    sampled_history = {
+        "runs": [
+            {
+                "goal_id": "project-a",
+                "generated_at": (now - timedelta(hours=1)).isoformat(),
+                "classification": "canary_promotion_readiness_smoke_group",
+                "delivery_batch_scale": "multi_surface",
+                "delivery_outcome": "primary_goal_outcome",
+                "recommended_action": "promotion ready",
+                "json_exists": True,
+                "markdown_exists": True,
+            },
+            {
+                "goal_id": "project-a",
+                "generated_at": (now - timedelta(hours=3)).isoformat(),
+                "classification": "canary_promotion_readiness_smoke_group",
+                "delivery_batch_scale": "single_surface",
+                "delivery_outcome": "test_only",
+                "json_exists": False,
+                "markdown_exists": False,
+            },
+            {
+                "goal_id": "project-b",
+                "generated_at": "not-a-timestamp",
+                "classification": "canary_promotion_readiness_smoke_group",
+            },
+            {
+                "goal_id": "project-b",
+                "generated_at": (now - timedelta(minutes=10)).isoformat(),
+                "classification": "state_refreshed",
+            },
+        ]
+    }
+    sampled = assert_parity(sampled_history)
+    assert sampled["available"] is True, sampled
+    assert sampled["source"] == "run_history", sampled
+    assert sampled["goal_id"] == "project-a", sampled
+    assert sampled["sample_run_count"] == 3, sampled
+    assert sampled["freshness_status"] == "fresh", sampled
+    assert sampled["requires_readiness_run"] is False, sampled
+    assert sampled["delivery_outcome"] == "primary_goal_outcome", sampled
+    assert sampled["json_exists"] is True, sampled
+    assert sampled["markdown_exists"] is True, sampled
+
+    with tempfile.TemporaryDirectory(prefix="loopx-promotion-readiness-") as tmp:
+        runtime_root = Path(tmp) / "runtime"
+        generated_at = (now - timedelta(hours=2)).isoformat()
+        write_indexed_readiness_run(runtime_root, goal_id="project-c", generated_at=generated_at)
+        fallback = assert_parity({"runs": []}, runtime_root=runtime_root, goal_id_filter="project-c")
+        assert fallback["available"] is True, fallback
+        assert fallback["source"] == "run_history_full_scan", fallback
+        assert fallback["goal_id"] == "project-c", fallback
+        assert fallback["sample_run_count"] == 0, fallback
+        assert fallback["json_exists"] is True, fallback
+        assert fallback["markdown_exists"] is True, fallback
+
+        missing = assert_parity({"runs": []}, runtime_root=runtime_root / "empty", goal_id_filter="missing")
+        assert missing["available"] is False, missing
+        assert missing["source"] == "run_history", missing
+        assert missing["freshness_status"] == "missing", missing
+        assert missing["requires_readiness_run"] is True, missing
+        assert missing["reason"] == "no canary promotion readiness run found in full run history", missing
+
+    sampled_missing = assert_parity({"runs": []})
+    assert sampled_missing["reason"] == "no canary promotion readiness run found in sampled history", sampled_missing
+    print("promotion-readiness-readmodel-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/control_plane/runtime/promotion_readiness.py
+++ b/loopx/control_plane/runtime/promotion_readiness.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable
+
+
+PROMOTION_READINESS_PROXY_NOTE = (
+    "canary promotion-readiness projection from append-only run history; exact evidence stays in run artifacts"
+)
+
+ParseTimestamp = Callable[[Any], Any]
+FreshnessBuilder = Callable[[dict[str, Any]], dict[str, Any]]
+LatestReadinessEvent = Callable[[Path], dict[str, Any]]
+
+
+def build_promotion_readiness_summary(
+    history: dict[str, Any],
+    *,
+    parse_timestamp: ParseTimestamp,
+    readiness_classifications: set[str],
+    add_promotion_readiness_freshness: FreshnessBuilder,
+    latest_promotion_readiness_event: LatestReadinessEvent,
+    freshness_hours: int,
+    runtime_root: Path | None = None,
+    proxy_note: str = PROMOTION_READINESS_PROXY_NOTE,
+) -> dict[str, Any]:
+    latest: dict[str, Any] | None = None
+    latest_at = None
+    sample_count = 0
+    source = "run_history"
+    for run in history.get("runs") or []:
+        if not isinstance(run, dict):
+            continue
+        classification = str(run.get("classification") or "")
+        if classification not in readiness_classifications:
+            continue
+        sample_count += 1
+        generated_at = parse_timestamp(run.get("generated_at"))
+        if generated_at is None:
+            continue
+        if latest_at is None or generated_at > latest_at:
+            latest_at = generated_at
+            latest = run
+
+    if latest is None and runtime_root is not None:
+        full_scan_latest = latest_promotion_readiness_event(runtime_root)
+        if full_scan_latest.get("available"):
+            latest = full_scan_latest
+            source = "run_history_full_scan"
+
+    if latest is None:
+        readiness = add_promotion_readiness_freshness(
+            {
+                "available": False,
+                "source": source,
+                "reason": (
+                    "no canary promotion readiness run found in full run history"
+                    if runtime_root is not None
+                    else "no canary promotion readiness run found in sampled history"
+                ),
+            }
+        )
+    else:
+        readiness = add_promotion_readiness_freshness(
+            {
+                "available": True,
+                "source": source,
+                "goal_id": latest.get("goal_id"),
+                "generated_at": latest.get("generated_at"),
+                "classification": latest.get("classification"),
+                "delivery_batch_scale": latest.get("delivery_batch_scale"),
+                "delivery_outcome": latest.get("delivery_outcome"),
+                "recommended_action": latest.get("recommended_action"),
+                "json_exists": bool(latest.get("json_exists")),
+                "markdown_exists": bool(latest.get("markdown_exists")),
+            }
+        )
+    readiness.update(
+        {
+            "sample_run_count": sample_count,
+            "proxy_note": proxy_note,
+            "freshness_window_hours": freshness_hours,
+        }
+    )
+    return readiness

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -169,6 +169,10 @@ from .control_plane.runtime.decision_freshness import (
     decision_event_kinds as _decision_event_kinds_read_model,
     decision_freshness_reason as _decision_freshness_reason_read_model,
 )
+from .control_plane.runtime.promotion_readiness import (
+    PROMOTION_READINESS_PROXY_NOTE,
+    build_promotion_readiness_summary as _build_promotion_readiness_summary_read_model,
+)
 from .control_plane.handoff.handoff_runs import (
     is_custom_post_handoff_work_run as _is_custom_post_handoff_work_run_read_model,
     is_handoff_ready_run as _is_handoff_ready_run_read_model,
@@ -418,9 +422,6 @@ MINIMUM_DASHBOARD_STATUS_CONTRACT_SCHEMA_VERSION = 2
 STATUS_CONTRACT_RELOAD_HINT = "scripts/macos-dashboard-launchagent.sh restart"
 STATUS_CONTRACT_SIGNAL_LIMIT = 3
 MONITOR_WRITEBACK_CONTRACT_SCHEMA_VERSION = "monitor_writeback_contract_v0"
-PROMOTION_READINESS_PROXY_NOTE = (
-    "canary promotion-readiness projection from append-only run history; exact evidence stays in run artifacts"
-)
 EVENT_LEDGER_DECISION_CLASSIFICATIONS = USER_OR_CONTROLLER_CLASSIFICATIONS | {
     "operator_gate_approved",
 }
@@ -7723,68 +7724,19 @@ def build_promotion_readiness_summary(
     runtime_root: Path | None = None,
     goal_id_filter: str | None = None,
 ) -> dict[str, Any]:
-    latest: dict[str, Any] | None = None
-    latest_at: datetime | None = None
-    sample_count = 0
-    source = "run_history"
-    for run in history.get("runs") or []:
-        if not isinstance(run, dict):
-            continue
-        classification = str(run.get("classification") or "")
-        if classification not in PROMOTION_READINESS_CLASSIFICATIONS:
-            continue
-        sample_count += 1
-        generated_at = parse_timestamp(run.get("generated_at"))
-        if generated_at is None:
-            continue
-        if latest_at is None or generated_at > latest_at:
-            latest_at = generated_at
-            latest = run
-
-    if latest is None and runtime_root is not None:
-        full_scan_latest = latest_promotion_readiness_event(
-            runtime_root,
+    return _build_promotion_readiness_summary_read_model(
+        history,
+        parse_timestamp=parse_timestamp,
+        readiness_classifications=PROMOTION_READINESS_CLASSIFICATIONS,
+        add_promotion_readiness_freshness=add_promotion_readiness_freshness,
+        latest_promotion_readiness_event=lambda root: latest_promotion_readiness_event(
+            root,
             goal_id=goal_id_filter,
-        )
-        if full_scan_latest.get("available"):
-            latest = full_scan_latest
-            source = "run_history_full_scan"
-
-    if latest is None:
-        readiness = add_promotion_readiness_freshness(
-            {
-                "available": False,
-                "source": source,
-                "reason": (
-                    "no canary promotion readiness run found in full run history"
-                    if runtime_root is not None
-                    else "no canary promotion readiness run found in sampled history"
-                ),
-            }
-        )
-    else:
-        readiness = add_promotion_readiness_freshness(
-            {
-                "available": True,
-                "source": source,
-                "goal_id": latest.get("goal_id"),
-                "generated_at": latest.get("generated_at"),
-                "classification": latest.get("classification"),
-                "delivery_batch_scale": latest.get("delivery_batch_scale"),
-                "delivery_outcome": latest.get("delivery_outcome"),
-                "recommended_action": latest.get("recommended_action"),
-                "json_exists": bool(latest.get("json_exists")),
-                "markdown_exists": bool(latest.get("markdown_exists")),
-            }
-        )
-    readiness.update(
-        {
-            "sample_run_count": sample_count,
-            "proxy_note": PROMOTION_READINESS_PROXY_NOTE,
-            "freshness_window_hours": PROMOTION_READINESS_FRESHNESS_HOURS,
-        }
+        ),
+        freshness_hours=PROMOTION_READINESS_FRESHNESS_HOURS,
+        runtime_root=runtime_root,
+        proxy_note=PROMOTION_READINESS_PROXY_NOTE,
     )
-    return readiness
 
 
 def build_status_contract() -> dict[str, Any]:


### PR DESCRIPTION
Summary
- Move promotion readiness run-history summary logic from loopx/status.py into loopx/control_plane/runtime/promotion_readiness.py.
- Keep loopx.status build_promotion_readiness_summary as the compatibility wrapper, including goal-filter binding for full-scan fallback.
- Add a focused parity smoke for sampled history, full-scan fallback, and missing-readiness cases.

Validation
- python3 examples/control_plane/promotion-readiness-readmodel-smoke.py
- python3 examples/control_plane/decision-freshness-readmodel-smoke.py
- python3 examples/control_plane/event-ledger-readmodel-smoke.py
- python3 examples/usage-summary-smoke.py
- python3 examples/control_plane/status-quota-review-packet-parity-smoke.py
- python3 examples/control_plane/status-contract-readmodel-smoke.py
- python3 examples/control_plane/status-goal-filter-smoke.py
- python3 examples/control_plane/status-markdown-smoke.py
- loopx --format json status --goal-id loopx-meta --limit 1
- python3 -m compileall -q loopx/status.py loopx/control_plane/runtime/promotion_readiness.py examples/control_plane/promotion-readiness-readmodel-smoke.py
- git diff --check

Known existing red
- python3 examples/control_plane/repo-python-line-budget-smoke.py is still red on existing files examples/skillsbench-benchmark-run-smoke.py and scripts/skillsbench_automation_loop.py, outside this slice.

Boundary scan
- Candidate public paths scanned clean for private/local artifact markers.