### PR TITLE
Extract run history read model

### DIFF
--- a/examples/control_plane/run-history-readmodel-smoke.py
+++ b/examples/control_plane/run-history-readmodel-smoke.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Smoke-test run history read-model parity."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx import status as status_module  # noqa: E402
+from loopx.control_plane.runtime import run_history as run_history_read_model  # noqa: E402
+
+
+def direct_history(history: dict, *, display_limit: int | None = None) -> dict:
+    return run_history_read_model.build_run_history(
+        history,
+        latest_run=status_module.latest_run,
+        goal_lifecycle_fields=status_module.goal_lifecycle_fields,
+        subagent_activity_for_goal=status_module.subagent_activity_for_goal,
+        compact_run=status_module.compact_run,
+        quota_status=status_module.quota_status,
+        display_limit=display_limit,
+    )
+
+
+def assert_parity(history: dict, *, display_limit: int | None = None) -> dict:
+    wrapper = status_module.build_run_history(history, display_limit=display_limit)
+    direct = direct_history(history, display_limit=display_limit)
+    assert direct == wrapper, (direct, wrapper)
+    return wrapper
+
+
+def main() -> None:
+    history = {
+        "goal_count": 2,
+        "run_count": 4,
+        "goals": [
+            {
+                "id": "loopx-meta",
+                "domain": "loopx-platform",
+                "status": "active-read-only",
+                "registry_member": True,
+                "legacy_runtime_goal": False,
+                "adapter_kind": "harness_self_improvement",
+                "adapter_status": "connected-read-only",
+                "coordination": {"primary_agent": "codex-main-control"},
+                "guards": [{"kind": "private_boundary"}],
+                "next_probe": "continue",
+                "authority_registry": {"present": True},
+                "index_exists": True,
+                "raw_index_records": 3,
+                "unique_runs": 2,
+                "latest_status_run": {
+                    "goal_id": "loopx-meta",
+                    "generated_at": "2026-07-04T00:05:00+00:00",
+                    "classification": "implementation_batch",
+                    "recommended_action": "continue",
+                    "human_reward": {
+                        "recorded_at": "2026-07-04T00:06:00+00:00",
+                        "decision": "continue",
+                        "reward": 1,
+                        "lesson": {
+                            "schema_version": "lesson_v0",
+                            "kind": "process",
+                            "summary": "preserve parity",
+                            "private_note": "must not surface",
+                        },
+                    },
+                    "ignored_field": "not compacted",
+                },
+                "latest_runs": [
+                    {
+                        "goal_id": "loopx-meta",
+                        "run_id": "run-2",
+                        "generated_at": "2026-07-04T00:05:00+00:00",
+                        "classification": "implementation_batch",
+                        "operator_gate": {
+                            "recorded_at": "2026-07-04T00:04:00+00:00",
+                            "decision": "approved",
+                            "private_note": "must not surface",
+                        },
+                        "subagents": [
+                            {
+                                "run_id": "child-1",
+                                "agent_role": "product-capability",
+                                "classification": "completed",
+                                "quota_slots": 1,
+                            }
+                        ],
+                    },
+                    "invalid-run",
+                    {
+                        "goal_id": "loopx-meta",
+                        "run_id": "run-1",
+                        "generated_at": "2026-07-04T00:00:00+00:00",
+                        "classification": "state_refreshed",
+                    },
+                ],
+            },
+            "invalid-goal",
+            {
+                "id": "local-only",
+                "domain": "local",
+                "status": "inactive",
+                "registry_member": False,
+                "coordination": "not-a-dict",
+                "guards": "not-a-list",
+                "latest_runs": [
+                    {
+                        "goal_id": "local-only",
+                        "run_id": "local-run",
+                        "generated_at": "2026-07-04T00:01:00+00:00",
+                        "classification": "state_refreshed",
+                    }
+                ],
+            },
+        ],
+        "runs": [
+            {
+                "goal_id": "loopx-meta",
+                "run_id": "recent-1",
+                "generated_at": "2026-07-04T00:05:00+00:00",
+                "classification": "implementation_batch",
+            },
+            "invalid-run",
+            {
+                "goal_id": "local-only",
+                "run_id": "recent-2",
+                "generated_at": "2026-07-04T00:01:00+00:00",
+                "classification": "state_refreshed",
+            },
+        ],
+    }
+
+    full = assert_parity(history)
+    assert full["available"] is True, full
+    assert full["goal_count"] == 2, full
+    assert full["run_count"] == 4, full
+    assert [goal["id"] for goal in full["goals"]] == ["loopx-meta", "local-only"], full
+    assert len(full["recent_runs"]) == 2, full
+
+    meta = full["goals"][0]
+    assert meta["quota"] is not None, meta
+    assert meta["coordination"] == {"primary_agent": "codex-main-control"}, meta
+    assert meta["guards"] == [{"kind": "private_boundary"}], meta
+    assert meta["latest_status_run"]["human_reward"]["lesson"] == {
+        "schema_version": "lesson_v0",
+        "kind": "process",
+        "summary": "preserve parity",
+    }, meta
+    assert "private_note" not in str(meta), meta
+    assert len(meta["latest_runs"]) == 2, meta
+    assert meta["subagent_activity"]["child_count"] == 1, meta
+    assert meta["subagent_activity"]["items"][0]["agent_role"] == "product-capability", meta
+    assert meta["subagent_activity"]["quota_spend_slots"] == 1, meta
+
+    local = full["goals"][1]
+    assert local["quota"] is None, local
+    assert local["coordination"] is None, local
+    assert local["guards"] == [], local
+
+    limited = assert_parity(history, display_limit=1)
+    assert len(limited["recent_runs"]) == 1, limited
+    assert len(limited["goals"][0]["latest_runs"]) == 1, limited
+
+    empty_limit = assert_parity(history, display_limit=-5)
+    assert empty_limit["recent_runs"] == [], empty_limit
+    assert empty_limit["goals"][0]["latest_runs"] == [], empty_limit
+
+    print("run-history-readmodel-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/control_plane/runtime/run_history.py
+++ b/loopx/control_plane/runtime/run_history.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+
+LatestRun = Callable[[dict[str, Any]], Optional[dict[str, Any]]]
+GoalLifecycleFields = Callable[[dict[str, Any], Optional[dict[str, Any]]], dict[str, Any]]
+GoalProjection = Callable[[dict[str, Any]], Optional[dict[str, Any]]]
+RunCompactor = Callable[[dict[str, Any]], dict[str, Any]]
+QuotaStatus = Callable[[dict[str, Any]], dict[str, Any]]
+
+
+def build_run_history(
+    history: dict[str, Any],
+    *,
+    latest_run: LatestRun,
+    goal_lifecycle_fields: GoalLifecycleFields,
+    subagent_activity_for_goal: GoalProjection,
+    compact_run: RunCompactor,
+    quota_status: QuotaStatus,
+    display_limit: int | None = None,
+) -> dict[str, Any]:
+    display_limit = None if display_limit is None else max(0, display_limit)
+    goals: list[dict[str, Any]] = []
+    for goal in history.get("goals") or []:
+        if not isinstance(goal, dict):
+            continue
+        current_run = latest_run(goal)
+        lifecycle_fields = goal_lifecycle_fields(goal, current_run)
+        subagent_activity = subagent_activity_for_goal(goal)
+        latest_runs = [
+            compact_run(run)
+            for run in goal.get("latest_runs") or []
+            if isinstance(run, dict)
+        ]
+        if display_limit is not None:
+            latest_runs = latest_runs[:display_limit]
+        goals.append(
+            {
+                "id": goal.get("id"),
+                "domain": goal.get("domain"),
+                "status": goal.get("status"),
+                "lifecycle_phase": lifecycle_fields["lifecycle_phase"],
+                "lifecycle_flags": lifecycle_fields["lifecycle_flags"],
+                "registry_member": goal.get("registry_member"),
+                "legacy_runtime_goal": goal.get("legacy_runtime_goal"),
+                "adapter_kind": goal.get("adapter_kind"),
+                "adapter_status": goal.get("adapter_status"),
+                "coordination": goal.get("coordination") if isinstance(goal.get("coordination"), dict) else None,
+                "guards": goal.get("guards") if isinstance(goal.get("guards"), list) else [],
+                "next_probe": goal.get("next_probe"),
+                "authority_registry": goal.get("authority_registry"),
+                "quota": quota_status(goal) if goal.get("registry_member") else None,
+                "index_exists": goal.get("index_exists"),
+                "raw_index_records": goal.get("raw_index_records"),
+                "unique_runs": goal.get("unique_runs"),
+                "subagent_activity": subagent_activity,
+                "latest_status_run": compact_run(current_run) if current_run else None,
+                "latest_runs": latest_runs,
+            }
+        )
+
+    recent_runs = [
+        compact_run(run)
+        for run in history.get("runs") or []
+        if isinstance(run, dict)
+    ]
+    if display_limit is not None:
+        recent_runs = recent_runs[:display_limit]
+    return {
+        "available": True,
+        "goal_count": history.get("goal_count"),
+        "run_count": history.get("run_count"),
+        "goals": goals,
+        "recent_runs": recent_runs,
+    }

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -152,6 +152,9 @@ from .control_plane.runtime.run_compaction import (
     compact_operator_gate as _compact_operator_gate_read_model,
     compact_operator_gate_resume_contract as _compact_operator_gate_resume_contract_read_model,
 )
+from .control_plane.runtime.run_history import (
+    build_run_history as _build_run_history_read_model,
+)
 from .control_plane.runtime.event_ledger import (
     EVENT_LEDGER_CLASSES,
     EVENT_LEDGER_PROXY_NOTE,
@@ -7612,60 +7615,15 @@ def compact_run(run: dict[str, Any]) -> dict[str, Any]:
 
 
 def build_run_history(history: dict[str, Any], *, display_limit: int | None = None) -> dict[str, Any]:
-    display_limit = None if display_limit is None else max(0, display_limit)
-    goals: list[dict[str, Any]] = []
-    for goal in history.get("goals") or []:
-        if not isinstance(goal, dict):
-            continue
-        current_run = latest_run(goal)
-        lifecycle_fields = goal_lifecycle_fields(goal, current_run)
-        subagent_activity = subagent_activity_for_goal(goal)
-        latest_runs = [
-            compact_run(run)
-            for run in goal.get("latest_runs") or []
-            if isinstance(run, dict)
-        ]
-        if display_limit is not None:
-            latest_runs = latest_runs[:display_limit]
-        goals.append(
-            {
-                "id": goal.get("id"),
-                "domain": goal.get("domain"),
-                "status": goal.get("status"),
-                "lifecycle_phase": lifecycle_fields["lifecycle_phase"],
-                "lifecycle_flags": lifecycle_fields["lifecycle_flags"],
-                "registry_member": goal.get("registry_member"),
-                "legacy_runtime_goal": goal.get("legacy_runtime_goal"),
-                "adapter_kind": goal.get("adapter_kind"),
-                "adapter_status": goal.get("adapter_status"),
-                "coordination": goal.get("coordination") if isinstance(goal.get("coordination"), dict) else None,
-                "guards": goal.get("guards") if isinstance(goal.get("guards"), list) else [],
-                "next_probe": goal.get("next_probe"),
-                "authority_registry": goal.get("authority_registry"),
-                "quota": quota_status(goal) if goal.get("registry_member") else None,
-                "index_exists": goal.get("index_exists"),
-                "raw_index_records": goal.get("raw_index_records"),
-                "unique_runs": goal.get("unique_runs"),
-                "subagent_activity": subagent_activity,
-                "latest_status_run": compact_run(current_run) if current_run else None,
-                "latest_runs": latest_runs,
-            }
-        )
-
-    recent_runs = [
-        compact_run(run)
-        for run in history.get("runs") or []
-        if isinstance(run, dict)
-    ]
-    if display_limit is not None:
-        recent_runs = recent_runs[:display_limit]
-    return {
-        "available": True,
-        "goal_count": history.get("goal_count"),
-        "run_count": history.get("run_count"),
-        "goals": goals,
-        "recent_runs": recent_runs,
-    }
+    return _build_run_history_read_model(
+        history,
+        latest_run=latest_run,
+        goal_lifecycle_fields=goal_lifecycle_fields,
+        subagent_activity_for_goal=subagent_activity_for_goal,
+        compact_run=compact_run,
+        quota_status=quota_status,
+        display_limit=display_limit,
+    )
 
 
 def quota_spend_slots(run: dict[str, Any]) -> int:


### PR DESCRIPTION
Summary
- Move run-history shaping logic out of loopx/status.py into loopx/control_plane/runtime/run_history.py.
- Keep loopx.status build_run_history as the compatibility wrapper with injected dependencies.
- Add run-history-readmodel parity smoke covering wrapper/direct parity, display limits, non-dict filtering, registry-member quota projection, compact private-field filtering, and subagent activity shaping.

Product and architecture judgment
- Motivation: continue canary-gated status.py read-model cleanup without broad hot-path rewrites.
- Solved: this slice removes another status.py projection boundary while preserving the public status payload contract through parity smoke and existing status smokes.
- Operator impact: lower status.py coupling and more durable canary coverage for run_history, which quota/review/status consumers use as drill-down evidence.
- Main risk: status hot path compatibility. Mitigated by wrapper preservation, focused status/quota/markdown smokes, and repo-local canary smoke-suite execution.
- Design: bounded-context runtime read model with dependency injection, consistent with recent control_plane/runtime extracts.

Validation
- python3 examples/control_plane/run-history-readmodel-smoke.py
- python3 -m loopx.cli canary smoke-suite --suite full-public --script examples/control_plane/run-history-readmodel-smoke.py --timeout-seconds 60 --no-progress
- python3 examples/control_plane/status-contract-readmodel-smoke.py
- python3 examples/control_plane/status-quota-review-packet-parity-smoke.py
- python3 examples/control_plane/status-goal-filter-smoke.py
- python3 examples/control_plane/status-markdown-smoke.py
- python3 examples/control_plane/decision-freshness-readmodel-smoke.py
- python3 examples/control_plane/event-ledger-readmodel-smoke.py
- python3 examples/control_plane/promotion-readiness-readmodel-smoke.py
- loopx --format json status --goal-id loopx-meta --limit 1
- python3 -m compileall -q loopx/status.py loopx/control_plane/runtime/run_history.py examples/control_plane/run-history-readmodel-smoke.py
- git diff --check origin/main...HEAD

Known existing red
- python3 examples/control_plane/repo-python-line-budget-smoke.py remains red on existing SkillsBench files only: examples/skillsbench-benchmark-run-smoke.py and scripts/skillsbench_automation_loop.py. This PR does not touch those files.

Boundary scan
- Candidate public paths scanned clean for private/local artifact markers.