### PR TITLE
Expose thin auto-research A2A recipe

### DIFF
--- a/docs/product/decentralized-auto-research-showcase.md
+++ b/docs/product/decentralized-auto-research-showcase.md
@@ -151,6 +151,24 @@ domain-specific problem code. The stable smoke metric still shows the product
 shape: baseline `1.0`, dev evidence `4.0`, holdout evidence `4.5`, and a clean
 public boundary.
 
+The public line-count claim is intentionally narrower than the kernel. The
+copyable recipe is one user command plus the four default auto-research role
+specs; the reusable kernel still owns the runner, visible Codex TUI panes,
+fixed wake prompt, pane-local A2A tick, todo/evidence/status protocol, and
+public artifact routing.
+
+```text
+loopx auto-research start "<open question>" --execute
+codex-product-capability:research-curator:research_curator
+codex-side-bypass:hypothesis-mapper:hypothesis_mapper
+codex-main-control:evidence-runner:evidence_runner
+codex-value-explorer:evidence-verifier:evidence_verifier
+```
+
+That is the marketing-safe claim: a five-line declarative recipe can start
+decentralized A2A communication because the generic LoopX kernel already knows
+how to wake each pane and let each pane read its own quota/frontier.
+
 The fixture-backed projection remains the read-only showcase state slice:
 
 ```bash

--- a/docs/reference/protocols/multi-agent-three-layer-minimality-v0.md
+++ b/docs/reference/protocols/multi-agent-three-layer-minimality-v0.md
@@ -62,6 +62,24 @@ or replan state transitions.
 This keeps the public promise honest: a small auto-research recipe should prove
 that other products can also reuse the same kernel with their own thin preset.
 
+## Public Line-Count Claim
+
+The public "few lines of auto-research" claim counts declarative recipe lines,
+not the shared kernel implementation.
+
+For the default auto-research demo, the bounded claim is:
+
+| Layer | Counted Lines | Meaning |
+| --- | ---: | --- |
+| User | 1 | `loopx auto-research start "<open question>" --execute` |
+| Auto-research preset | 4 | default role specs: curator, mapper, runner, verifier |
+| Generic kernel | 0 | shared runner, Codex TUI panes, fixed wake prompt, pane-local tick, todo/evidence/status protocol |
+
+So the honest slogan is: one user line plus a four-line preset can start a
+decentralized A2A research loop on the shared LoopX kernel. The slogan must not
+claim that tmux launch, Codex TUI bootstrap, quota/frontier, evidence routing,
+or status projection are reimplemented inside the auto-research preset.
+
 ## Acceptance
 
 A change satisfies this contract only when:

--- a/examples/auto-research-layered-e2e-acceptance-smoke.py
+++ b/examples/auto-research-layered-e2e-acceptance-smoke.py
@@ -137,8 +137,24 @@ def assert_three_layer_minimality() -> None:
         assert mechanic in layering["kernel_layer"]["owns"], layering
     assert layering["acceptance"]["preset_has_no_runner_process_logic"] is True, layering
 
+    minimal_recipe = supervisor["minimal_a2a_recipe"]
+    assert minimal_recipe["schema_version"] == "auto_research_minimal_a2a_recipe_v0"
+    assert minimal_recipe["user_plus_preset_line_count"] == 5, minimal_recipe
+    assert minimal_recipe["user_line_count"] == 1, minimal_recipe
+    assert minimal_recipe["preset_role_spec_line_count"] == 4, minimal_recipe
+    assert minimal_recipe["shared_kernel_counted_as_recipe_lines"] is False, minimal_recipe
+    assert minimal_recipe["coordination_model"] == "decentralized_state_a2a", minimal_recipe
+    assert minimal_recipe["a2a_proof_contract"] == {
+        "broadcaster_selects_todo": False,
+        "broadcaster_runs_worker_turn": False,
+        "each_pane_reads_own_quota_frontier": True,
+        "successor_todos_declared_by_role_profile": True,
+        "leader_agent_required": False,
+    }, minimal_recipe
+
     preset = supervisor["preset"]
     assert preset["schema_version"] == AUTO_RESEARCH_PRESET_SCHEMA_VERSION, preset
+    assert preset["minimal_a2a_recipe"]["user_plus_preset_line_count"] == 5, preset
     assert preset["owns"] == layering["preset_layer"]["owns"], preset
     assert "multi_agent_runner" in preset["forbidden"], preset
     assert "real_codex_tui_panes" in preset["forbidden"], preset

--- a/examples/auto-research-start-markdown-commands-smoke.py
+++ b/examples/auto-research-start-markdown-commands-smoke.py
@@ -47,6 +47,13 @@ def main() -> int:
     )
     markdown = result.stdout
     require("## Operator Commands", markdown)
+    require("## Minimal A2A Recipe", markdown)
+    require("- user_plus_preset_lines: `5`", markdown)
+    require("- shared_kernel_counted: `False`", markdown)
+    require(
+        "- preset: `codex-side-bypass:hypothesis-mapper:hypothesis_mapper`",
+        markdown,
+    )
     require(
         f"- evidence-first start: `loopx auto-research start '{QUESTION}' --execute`",
         markdown,

--- a/examples/auto-research-user-contract-entry-smoke.py
+++ b/examples/auto-research-user-contract-entry-smoke.py
@@ -68,6 +68,29 @@ def assert_contract(payload: dict[str, Any]) -> None:
     assert "multi-agent runner" in layering["kernel_layer"], layering
     assert "pane-local tick" in layering["kernel_layer"], layering
 
+    minimal_recipe = payload["minimal_a2a_recipe"]
+    assert minimal_recipe["schema_version"] == "auto_research_minimal_a2a_recipe_v0", minimal_recipe
+    assert minimal_recipe["line_unit"] == "declarative_recipe_line", minimal_recipe
+    assert minimal_recipe["user_line_count"] == 1, minimal_recipe
+    assert minimal_recipe["preset_role_spec_line_count"] == 4, minimal_recipe
+    assert minimal_recipe["user_plus_preset_line_count"] == 5, minimal_recipe
+    assert minimal_recipe["shared_kernel_counted_as_recipe_lines"] is False, minimal_recipe
+    assert minimal_recipe["coordination_model"] == "decentralized_state_a2a", minimal_recipe
+    assert minimal_recipe["user_recipe_lines"] == [
+        f"loopx auto-research start {QUESTION!r} --execute"
+    ], minimal_recipe
+    assert minimal_recipe["preset_recipe_lines"] == [
+        "codex-product-capability:research-curator:research_curator",
+        "codex-side-bypass:hypothesis-mapper:hypothesis_mapper",
+        "codex-main-control:evidence-runner:evidence_runner",
+        "codex-value-explorer:evidence-verifier:evidence_verifier",
+    ], minimal_recipe
+    proof = minimal_recipe["a2a_proof_contract"]
+    assert proof["broadcaster_selects_todo"] is False, proof
+    assert proof["broadcaster_runs_worker_turn"] is False, proof
+    assert proof["each_pane_reads_own_quota_frontier"] is True, proof
+    assert proof["leader_agent_required"] is False, proof
+
     command_contract = payload["command_contract"]
     assert command_contract["canonical_invocation"] == 'loopx auto-research "<open question>"'
     assert (

--- a/loopx/capabilities/auto_research/demo_supervisor.py
+++ b/loopx/capabilities/auto_research/demo_supervisor.py
@@ -10,6 +10,7 @@ from .preset import (
     AUTO_RESEARCH_PRESET_SCHEMA_VERSION,
     build_auto_research_preset_role,
     build_auto_research_preset_summary,
+    build_auto_research_minimal_a2a_recipe,
     auto_research_lane_specs,
 )
 from ...visible_multi_agent_launcher import build_visible_multi_agent_payload_from_spec
@@ -75,6 +76,13 @@ def build_auto_research_demo_supervisor_plan(
             "schema_version": AUTO_RESEARCH_DEMO_SUPERVISOR_SCHEMA_VERSION,
             "mode": "dry_run",
             "layer_minimality_contract": build_auto_research_layer_contract(),
+            "minimal_a2a_recipe": build_auto_research_minimal_a2a_recipe(
+                output_language=output_language,
+                role_specs=[
+                    f"{lane['agent_id']}:{lane['lane_id']}:{lane['role_id']}"
+                    for lane in lanes
+                ],
+            ),
             "preset": build_auto_research_preset_summary(role_count=len(roles)),
             "auto_research": {
                 "schema_version": AUTO_RESEARCH_PRESET_SCHEMA_VERSION,

--- a/loopx/capabilities/auto_research/human_view.py
+++ b/loopx/capabilities/auto_research/human_view.py
@@ -67,6 +67,11 @@ def _render_user_contract(payload: dict[str, object]) -> str:
     brief = payload.get("research_brief") if isinstance(payload.get("research_brief"), dict) else {}
     plan = payload.get("action_plan") if isinstance(payload.get("action_plan"), list) else []
     evidence = payload.get("evidence_refs") if isinstance(payload.get("evidence_refs"), dict) else {}
+    minimal_recipe = (
+        payload.get("minimal_a2a_recipe")
+        if isinstance(payload.get("minimal_a2a_recipe"), dict)
+        else {}
+    )
     one_click_start = (
         payload.get("one_click_start")
         if isinstance(payload.get("one_click_start"), dict)
@@ -121,8 +126,20 @@ def _render_user_contract(payload: dict[str, object]) -> str:
             f"- preview: `{one_click_start.get('preview_command')}`",
             f"- starts: `{one_click_start.get('starts')}`",
             f"- coordination_model: `{one_click_start.get('coordination_model')}`",
+            "",
+            "## Minimal A2A Recipe",
+            "",
+            f"- user_lines: `{minimal_recipe.get('user_line_count')}`",
+            f"- preset_role_spec_lines: `{minimal_recipe.get('preset_role_spec_line_count')}`",
+            f"- user_plus_preset_lines: `{minimal_recipe.get('user_plus_preset_line_count')}`",
+            f"- shared_kernel_counted: `{minimal_recipe.get('shared_kernel_counted_as_recipe_lines')}`",
+            f"- claim_boundary: {minimal_recipe.get('claim_boundary')}",
         ]
     )
+    for line in minimal_recipe.get("user_recipe_lines") or []:
+        lines.append(f"- user: `{line}`")
+    for line in minimal_recipe.get("preset_recipe_lines") or []:
+        lines.append(f"- preset: `{line}`")
     lines.extend(_render_operator_commands(payload))
     lines.extend(
         [
@@ -251,6 +268,16 @@ def _render_worker_loop(payload: dict[str, object]) -> str:
 
 def _render_demo_e2e(payload: dict[str, object]) -> str:
     worker_loop = payload.get("worker_loop") if isinstance(payload.get("worker_loop"), dict) else {}
+    user_contract = (
+        payload.get("user_contract")
+        if isinstance(payload.get("user_contract"), dict)
+        else {}
+    )
+    minimal_recipe = (
+        user_contract.get("minimal_a2a_recipe")
+        if isinstance(user_contract.get("minimal_a2a_recipe"), dict)
+        else {}
+    )
     tonight = (
         payload.get("tonight_experience")
         if isinstance(payload.get("tonight_experience"), dict)
@@ -299,6 +326,8 @@ def _render_demo_e2e(payload: dict[str, object]) -> str:
         f"- user_contract_accepted: `{contract_acceptance.get('accepted')}`",
         f"- one_question_contract: `{commands.get('one_question_contract')}`",
         f"- one_question_start: `{commands.get('one_question_start')}`",
+        f"- minimal_a2a_user_plus_preset_lines: `{minimal_recipe.get('user_plus_preset_line_count')}`",
+        f"- minimal_a2a_shared_kernel_counted: `{minimal_recipe.get('shared_kernel_counted_as_recipe_lines')}`",
         f"- reasoning_effort: `{payload.get('reasoning_effort')}`",
         f"- worker_loop_executed_turns: `{worker_loop.get('executed_turn_count')}`",
         f"- worker_loop_completed_turns: `{worker_loop.get('completed_turn_count')}`",
@@ -322,6 +351,21 @@ def _render_demo_e2e(payload: dict[str, object]) -> str:
         f"- visible_holdout_delta_over_dev: `{improvement.get('holdout_delta_over_dev')}`",
         f"- supervisor_lanes: `{supervisor.get('lane_count')}`",
     ]
+    if minimal_recipe:
+        lines.extend(
+            [
+                "",
+                "## Minimal A2A Recipe",
+                "",
+                f"- user_plus_preset_lines: `{minimal_recipe.get('user_plus_preset_line_count')}`",
+                f"- user_lines: `{minimal_recipe.get('user_line_count')}`",
+                f"- preset_role_spec_lines: `{minimal_recipe.get('preset_role_spec_line_count')}`",
+                f"- shared_kernel_counted: `{minimal_recipe.get('shared_kernel_counted_as_recipe_lines')}`",
+                f"- coordination_model: `{minimal_recipe.get('coordination_model')}`",
+            ]
+        )
+        for line in minimal_recipe.get("preset_recipe_lines") or []:
+            lines.append(f"- preset: `{line}`")
     lines.extend(_render_operator_commands(payload))
     return "\n".join(lines) + "\n"
 
@@ -362,6 +406,11 @@ def _render_live_evidence(payload: dict[str, object]) -> str:
 
 def _render_supervisor(payload: dict[str, object]) -> str:
     lanes = payload.get("lanes") if isinstance(payload.get("lanes"), list) else []
+    minimal_recipe = (
+        payload.get("minimal_a2a_recipe")
+        if isinstance(payload.get("minimal_a2a_recipe"), dict)
+        else {}
+    )
     route = payload.get("goal_surface_route") if isinstance(payload.get("goal_surface_route"), dict) else {}
     boundary = payload.get("boundary") if isinstance(payload.get("boundary"), dict) else {}
     coordination = (
@@ -436,6 +485,15 @@ def _render_supervisor(payload: dict[str, object]) -> str:
         lines.append(f"- `{lane.get('lane_id')}`: `{' -> '.join(str(item) for item in timeline)}`")
     lines.extend(
         [
+            "",
+            "## Minimal A2A Recipe",
+            "",
+            f"- user_plus_preset_lines: `{minimal_recipe.get('user_plus_preset_line_count')}`",
+            f"- user_lines: `{minimal_recipe.get('user_line_count')}`",
+            f"- preset_role_spec_lines: `{minimal_recipe.get('preset_role_spec_line_count')}`",
+            f"- shared_kernel_counted: `{minimal_recipe.get('shared_kernel_counted_as_recipe_lines')}`",
+            f"- coordination_model: `{minimal_recipe.get('coordination_model')}`",
+            "",
             "",
             "## One-Click Dry Run",
             "",

--- a/loopx/capabilities/auto_research/preset.py
+++ b/loopx/capabilities/auto_research/preset.py
@@ -7,6 +7,7 @@ from .defaults import AUTO_RESEARCH_DEFAULT_GOAL_ID
 
 
 AUTO_RESEARCH_PRESET_SCHEMA_VERSION = "auto_research_thin_preset_v0"
+AUTO_RESEARCH_MINIMAL_A2A_RECIPE_SCHEMA_VERSION = "auto_research_minimal_a2a_recipe_v0"
 AUTO_RESEARCH_ROLE_PROFILE_SCHEMA_VERSION = "auto_research_role_profile_v0"
 AUTO_RESEARCH_REQUIRED_SKILL = "loopx-auto-research"
 AUTO_RESEARCH_WORKER_SKILL_SOURCE = (
@@ -206,6 +207,75 @@ def default_auto_research_agent_specs() -> list[str]:
     ]
 
 
+def _quoted_open_question(open_question: object | None) -> str:
+    question = str(open_question or "").strip()
+    if not question:
+        return '"<open question>"'
+    return shlex.quote(question)
+
+
+def build_auto_research_minimal_a2a_recipe(
+    *,
+    open_question: object | None = None,
+    output_language: str = "en",
+    role_specs: Iterable[object] | None = None,
+) -> dict[str, object]:
+    """Return the public line-count claim for the thin auto-research preset.
+
+    The count is deliberately about declarative recipe lines, not the shared
+    LoopX kernel implementation. That keeps the public claim reusable and
+    honest: other products can replace the four role specs without owning the
+    runner, fixed wake prompt, pane-local tick, or state protocol.
+    """
+
+    language = str(output_language or "en").strip()
+    language_flag = f" --language {shlex.quote(language)}" if language != "en" else ""
+    user_line = (
+        "loopx auto-research start "
+        f"{_quoted_open_question(open_question)}{language_flag} --execute"
+    )
+    raw_role_specs = (
+        role_specs if role_specs is not None else default_auto_research_agent_specs()
+    )
+    preset_lines = [str(spec).strip() for spec in raw_role_specs if str(spec).strip()]
+    user_line_count = 1
+    preset_line_count = len(preset_lines)
+    return {
+        "schema_version": AUTO_RESEARCH_MINIMAL_A2A_RECIPE_SCHEMA_VERSION,
+        "claim": (
+            "one user command plus the default four-line auto-research role spec "
+            "starts decentralized A2A on the shared LoopX multi-agent kernel"
+        ),
+        "line_unit": "declarative_recipe_line",
+        "user_line_count": user_line_count,
+        "preset_role_spec_line_count": preset_line_count,
+        "user_plus_preset_line_count": user_line_count + preset_line_count,
+        "shared_kernel_counted_as_recipe_lines": False,
+        "claim_boundary": (
+            "line count covers user intent and auto-research preset defaults only; "
+            "the reusable kernel owns visible process launch, fixed wake prompt, "
+            "pane-local quota/frontier tick, todo/evidence/status protocol, "
+            "and public artifact routing"
+        ),
+        "user_recipe_lines": [user_line],
+        "preset_recipe_lines": preset_lines,
+        "coordination_model": "decentralized_state_a2a",
+        "a2a_proof_contract": {
+            "broadcaster_selects_todo": False,
+            "broadcaster_runs_worker_turn": False,
+            "each_pane_reads_own_quota_frontier": True,
+            "successor_todos_declared_by_role_profile": True,
+            "leader_agent_required": False,
+        },
+        "kernel_reuse": [
+            "generic visible multi-agent runner",
+            "fixed prompt broadcast",
+            "pane-local A2A tick",
+            "LoopX todo/evidence/status protocol",
+        ],
+    }
+
+
 def auto_research_role_id(raw_role: str, *, index: int) -> str:
     raw = raw_role.strip()
     role_id = AUTO_RESEARCH_ROLE_PROFILE_ALIASES.get(raw, raw)
@@ -364,6 +434,7 @@ def build_auto_research_preset_role(
 def build_auto_research_preset_summary(*, role_count: int) -> dict[str, object]:
     return {
         "schema_version": AUTO_RESEARCH_PRESET_SCHEMA_VERSION,
+        "minimal_a2a_recipe": build_auto_research_minimal_a2a_recipe(),
         "owns": [
             "research_roles",
             "handoff_hints",

--- a/loopx/capabilities/auto_research/user_contract.py
+++ b/loopx/capabilities/auto_research/user_contract.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import shlex
 from typing import Any
 
+from .preset import build_auto_research_minimal_a2a_recipe
+
 
 AUTO_RESEARCH_USER_CONTRACT_SCHEMA_VERSION = "auto_research_user_contract_v0"
 
@@ -90,6 +92,10 @@ def build_auto_research_user_contract(
             "auto_research_layer": "fixed output contract only",
             "kernel_layer": "multi-agent runner, Codex TUI panes, pane-local tick, todo/evidence/status protocol",
         },
+        "minimal_a2a_recipe": build_auto_research_minimal_a2a_recipe(
+            open_question=question,
+            output_language=resolved_language,
+        ),
         "command_contract": {
             "canonical_invocation": 'loopx auto-research "<open question>"',
             "explicit_invocation": 'loopx auto-research contract "<open question>"',


### PR DESCRIPTION
## Summary
- add a machine-readable minimal_a2a_recipe contract for the auto-research user contract and demo supervisor
- render the 1 user line + 4 preset role spec line-count claim in contract/start Markdown
- document the honest public boundary: the five-line recipe starts decentralized A2A on the shared LoopX kernel, but does not count kernel implementation lines

## Validation
- python3 -m py_compile loopx/capabilities/auto_research/preset.py loopx/capabilities/auto_research/user_contract.py loopx/capabilities/auto_research/demo_supervisor.py loopx/capabilities/auto_research/human_view.py examples/auto-research-user-contract-entry-smoke.py examples/auto-research-start-markdown-commands-smoke.py examples/auto-research-layered-e2e-acceptance-smoke.py
- python3 examples/auto-research-user-contract-entry-smoke.py
- python3 examples/auto-research-start-markdown-commands-smoke.py
- python3 examples/auto-research-layered-e2e-acceptance-smoke.py
- python3 examples/auto-research-knn-continuation-smoke.py
- python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- git diff --check
- Chinese start preview shows minimal_a2a_user_plus_preset_lines=5