### PR TITLE
docs: add finance value connector surface

### DIFF
--- a/docs/capabilities/value-connectors/README.md
+++ b/docs/capabilities/value-connectors/README.md
@@ -72,6 +72,7 @@ association, timestamp, and URL metadata, then emits either
 | `github_public_channel` | implemented starter | yes | none |
 | `github_public_reply_monitor` | implemented starter | yes | none |
 | `social_browser_x` | ego-browser-backed profile | install-check, public-handle packet, and gated plan | exact profile/post/reply gate required |
+| `finance_market_snapshot` | planned finance profile | plan and user prompt surface | account, private portfolio, trading, and paid-data gates required |
 | `botmail_identity` | host connector profile | install-check only | exact send gate required |
 | `community_channel` | host/browser connector profile | install-check and plan | exact account/message gate required |
 
@@ -129,6 +130,67 @@ install-check -> metadata probe -> value connector plan -> approval gate -> host
 LoopX owns the compact control packet and value metric. Host products or user
 connectors own account login, private reads, external sends, and production
 actions.
+
+## Finance Market Snapshot Profile
+
+`finance_market_snapshot` is a planned value connector profile for users who
+want an agent to pull market facts before analysis. It is useful when the user
+asks for a bounded snapshot such as:
+
+- 股票或 ETF 行情: 最新价、涨跌幅、成交额、市值、估值区间、更新时间;
+- 基金信息: 净值、费率、持仓摘要、同类排名、公告更新时间;
+- 新闻和公告: 公司公告、业绩预告、监管披露、重要新闻摘要;
+- 组合观察: 用户给出的公开标的清单的异动、风险提示、待复核项。
+
+Suggested source order:
+
+1. Futu OpenD or another user-owned market terminal when the user already has a
+   local daemon, account permission, and data entitlement.
+2. Eastmoney or other public finance pages/APIs for public quote, fund,
+   announcement, and news metadata.
+3. GitHub-hosted open-source finance API wrappers or public datasets only as a
+   fallback after freshness, terms, and data-origin checks.
+
+The profile should label every answer with freshness and confidence: `live`,
+`delayed`, `cached`, `source_unverified`, or `manual_review_required`. It should
+also say when a field is missing instead of filling it from a stale fallback.
+
+Safe user prompts:
+
+```text
+/loopx 拉取 AAPL、MSFT、NVDA 今日行情和近 7 天关键新闻，标出更新时间和数据源；不要给投资建议。
+/loopx 对 5 只沪深 ETF 做一个公开信息快照：净值、规模、费率、公告、异动；缺失字段列出来。
+/loopx 监控我给出的股票清单是否出现公告或大幅波动，只写 compact todo，不自动交易。
+```
+
+Boundaries:
+
+- no trading, order placement, portfolio mutation, paid-data signup, account
+  login, captcha handling, or private portfolio read without an exact user gate;
+- no investment advice, suitability claim, price target, or guaranteed-return
+  wording;
+- no hidden source mixing: every metric must carry source, timestamp, and
+  uncertainty label;
+- no raw credential, account id, private holding, or paid provider payload in
+  LoopX state.
+
+Example plan-only packet:
+
+```bash
+loopx value-connectors plan \
+  --connector-id finance_market_snapshot \
+  --connector-kind custom_connector \
+  --channel "public finance metadata snapshot" \
+  --stage observe \
+  --target-ref "AAPL/MSFT/NVDA quote and news snapshot" \
+  --target-url https://www.eastmoney.com \
+  --external-read \
+  --value-axis capability \
+  --money-metric "reduce analyst time spent collecting public market facts" \
+  --success-metric "fresh quote/news table with source, timestamp, and uncertainty labels" \
+  --kill-condition "source terms, freshness, or symbol mapping cannot be verified" \
+  --format json
+```
 
 ## Protocol
 

--- a/docs/reference/protocols/value-connector-plan-v0.md
+++ b/docs/reference/protocols/value-connector-plan-v0.md
@@ -111,6 +111,48 @@ comment author, author association, timestamps, and URL. It detects whether a
 public maintainer/member/collaborator replied after the LoopX comment and
 returns `prepare_public_triage_note`; otherwise it returns `wait_no_bump`.
 
+## Finance Market Snapshot Profile
+
+`finance_market_snapshot` is a planned finance profile for bounded market-fact
+pulls. The v0 surface is a plan and gate contract, not a live trading adapter
+and not an investment-advice engine.
+
+Supported pull intents:
+
+- quote snapshots for stocks, ETFs, and indexes;
+- fund snapshots such as NAV, fee, size, holding summary, and announcement
+  timestamp;
+- public news, company announcement, earnings, and regulatory-disclosure
+  snapshots;
+- compact watch todos for a user-provided public symbol list.
+
+Preferred source order:
+
+1. a user-owned terminal or daemon such as Futu OpenD when account permission,
+   local daemon state, and data entitlement are already available;
+2. public finance metadata pages/APIs such as Eastmoney for quote, fund, news,
+   and announcement facts;
+3. GitHub-hosted open-source wrappers or public datasets as fallback only after
+   terms, freshness, and source-origin checks.
+
+Every finance packet should project:
+
+- source id and source URL or provider label;
+- `observed_at` or provider timestamp;
+- freshness label: `live`, `delayed`, `cached`, `source_unverified`, or
+  `manual_review_required`;
+- missing-field list instead of silent fallback filling;
+- non-investment-advice disclaimer.
+
+Forbidden before an exact approval gate:
+
+- login, private portfolio reads, account identifiers, paid-data signup,
+  captcha handling, or credential collection;
+- trading, order placement, portfolio mutation, or production actions;
+- price targets, suitability claims, guaranteed-return language, or personal
+  investment advice;
+- raw paid-provider payloads or private account material in LoopX state.
+
 ## Browser Social Connector Profile
 
 `social_browser_x` is the first browser-backed value connector profile. It is


### PR DESCRIPTION
## Summary
- add a planned finance_market_snapshot value connector profile
- document supported pull intents for quotes, funds, news, announcements, and watch todos
- record source preference, freshness/uncertainty labels, sample prompts, and no-investment-advice boundaries

## Validation
- ./scripts/loopx value-connectors plan --connector-id finance_market_snapshot --connector-kind custom_connector --channel "public finance metadata snapshot" --stage observe --target-ref "AAPL/MSFT/NVDA quote and news snapshot" --target-url https://www.eastmoney.com --external-read --value-axis capability --money-metric "reduce analyst time spent collecting public market facts" --success-metric "fresh quote/news table with source, timestamp, and uncertainty labels" --kill-condition "source terms, freshness, or symbol mapping cannot be verified" --format json
- python3 examples/value-connectors-github-public-probe-smoke.py
- python3 examples/content-ops-private-connector-gate-smoke.py
- python3 -m loopx.cli --format json check --scan-path docs/capabilities/value-connectors/README.md --scan-path docs/reference/protocols/value-connector-plan-v0.md
- git diff --check

## Boundary
Docs-only; no live finance data adapter, no trading, no private portfolio read, no investment advice.