### PR TITLE
Add generic multi-agent collective round ledger

### DIFF
--- a/docs/reference/protocols/multi-agent-three-layer-minimality-v0.md
+++ b/docs/reference/protocols/multi-agent-three-layer-minimality-v0.md
@@ -80,6 +80,14 @@ decentralized A2A research loop on the shared LoopX kernel. The slogan must not
 claim that tmux launch, Codex TUI bootstrap, quota/frontier, evidence routing,
 or status projection are reimplemented inside the auto-research preset.
 
+## Collective Round Ledger
+
+`multi_agent_collective_round_ledger_v0` is the kernel-owned proof surface for
+multi-agent rounds. It records expected lanes, per-lane quota/frontier/turn
+outcomes, integrated evidence, and role-declared successor todos. Product
+presets may wrap the ledger with domain metrics, but they should not fork its
+round definition or introduce a coordinator to decide work.
+
 ## Acceptance
 
 A change satisfies this contract only when:

--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -528,6 +528,13 @@ def main() -> int:
         assert collective_rounds["multi_round_research_verified"] is True, collective_rounds
         assert collective_rounds["dev_metric"] == 4.0, collective_rounds
         assert collective_rounds["holdout_metric"] == 4.5, collective_rounds
+        kernel_ledger = collective_rounds["kernel_ledger"]
+        assert kernel_ledger["schema_version"] == "multi_agent_collective_round_ledger_v0"
+        assert kernel_ledger["owner_layer"] == "generic_multi_agent_kernel", kernel_ledger
+        assert kernel_ledger["expected_lane_count"] == 4, kernel_ledger
+        assert kernel_ledger["collective_round_count"] == 2, kernel_ledger
+        assert kernel_ledger["multi_round_interaction_verified"] is True, kernel_ledger
+        assert kernel_ledger["successor_todo_count"] >= 1, kernel_ledger
         tonight = payload["tonight_experience"]
         assert tonight["ready"] is True, tonight
         assert tonight["positive_result"] is True, tonight

--- a/examples/auto-research-knn-continuation-smoke.py
+++ b/examples/auto-research-knn-continuation-smoke.py
@@ -67,6 +67,12 @@ def main() -> int:
     collective_rounds = payload["collective_research_rounds"]
     assert collective_rounds["collective_round_count"] == 2, collective_rounds
     assert collective_rounds["multi_round_research_verified"] is True, collective_rounds
+    kernel_ledger = collective_rounds["kernel_ledger"]
+    assert kernel_ledger["schema_version"] == "multi_agent_collective_round_ledger_v0"
+    assert kernel_ledger["owner_layer"] == "generic_multi_agent_kernel", kernel_ledger
+    assert kernel_ledger["collective_round_count"] == 2, kernel_ledger
+    assert kernel_ledger["multi_round_interaction_verified"] is True, kernel_ledger
+    assert kernel_ledger["successor_todo_count"] >= 1, kernel_ledger
     tonight = payload["tonight_experience"]
     assert tonight["coordination_pattern"] == "decentralized_state_a2a", tonight
     assert tonight["dev_metric"] == 4.0, tonight

--- a/examples/auto-research-layered-e2e-acceptance-smoke.py
+++ b/examples/auto-research-layered-e2e-acceptance-smoke.py
@@ -287,6 +287,13 @@ def assert_two_round_outcome(payload: dict[str, Any]) -> None:
     assert collective_rounds["round_unit"] == "collective_agent_pass", collective_rounds
     assert collective_rounds["collective_round_count"] == 2, collective_rounds
     assert collective_rounds["multi_round_research_verified"] is True, collective_rounds
+    kernel_ledger = collective_rounds["kernel_ledger"]
+    assert kernel_ledger["schema_version"] == "multi_agent_collective_round_ledger_v0"
+    assert kernel_ledger["owner_layer"] == "generic_multi_agent_kernel", kernel_ledger
+    assert kernel_ledger["expected_lane_count"] == 4, kernel_ledger
+    assert kernel_ledger["collective_round_count"] == 2, kernel_ledger
+    assert kernel_ledger["integrated_evidence"]["dev_metric"] == 4.0, kernel_ledger
+    assert kernel_ledger["integrated_evidence"]["holdout_metric"] == 4.5, kernel_ledger
 
     tonight = payload["tonight_experience"]
     assert tonight["ready"] is True, tonight

--- a/examples/multi-agent-collective-round-ledger-smoke.py
+++ b/examples/multi-agent-collective-round-ledger-smoke.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Smoke-test the generic multi-agent collective-round ledger."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.capabilities.multi_agent.collective_round_ledger import (  # noqa: E402
+    MULTI_AGENT_COLLECTIVE_ROUND_LEDGER_SCHEMA_VERSION,
+    build_multi_agent_collective_round_ledger,
+)
+
+
+def assert_public_safe(payload: dict[str, object]) -> None:
+    text = json.dumps(payload, sort_keys=True)
+    forbidden = [
+        "/" + "Users/",
+        "/" + "private/",
+        "/" + "tmp/",
+        "http://",
+        "https://",
+        "api" + "_key",
+        "pass" + "word",
+        "sec" + "ret",
+    ]
+    leaked = [needle for needle in forbidden if needle.lower() in text.lower()]
+    assert not leaked, leaked
+
+
+def main() -> int:
+    ledger = build_multi_agent_collective_round_ledger(
+        source="smoke",
+        expected_lanes=[
+            {"agent_id": "agent-a", "lane_id": "curator", "role_id": "research_curator"},
+            {"agent_id": "agent-b", "lane_id": "runner", "role_id": "evidence_runner"},
+        ],
+        lane_outcomes=[
+            {
+                "round": 1,
+                "agent_id": "agent-a",
+                "selected_todo_id": "todo_contract",
+                "selected_action": "write_research_contract",
+                "executed": True,
+                "completion_status": "done",
+            },
+            {
+                "round": 1,
+                "agent_id": "agent-b",
+                "selected_todo_id": "todo_dev",
+                "selected_action": "run_dev_eval",
+                "executed": True,
+                "completion_status": "done",
+                "dev_metric": 4.0,
+                "appended_count": 2,
+            },
+            {
+                "round": 2,
+                "agent_id": "agent-b",
+                "selected_todo_id": "todo_holdout",
+                "selected_action": "run_holdout_eval",
+                "executed": True,
+                "completion_status": "done",
+                "holdout_metric": 4.5,
+                "appended_count": 1,
+            },
+        ],
+        integrated_evidence={
+            "evidence_event_count": 3,
+            "dev_metric": 4.0,
+            "holdout_metric": 4.5,
+            "protected_scope_clean": True,
+        },
+        role_declared_successor_todos=[
+            {
+                "todo_id": "todo_holdout",
+                "target_agent_id": "agent-b",
+                "target_role_id": "evidence_runner",
+                "source_todo_id": "todo_dev",
+                "action_kind": "run_holdout_eval",
+            }
+        ],
+    )
+    assert ledger["schema_version"] == MULTI_AGENT_COLLECTIVE_ROUND_LEDGER_SCHEMA_VERSION
+    assert ledger["owner_layer"] == "generic_multi_agent_kernel", ledger
+    assert ledger["coordination_model"] == "decentralized_state_a2a", ledger
+    assert ledger["round_unit"] == "collective_agent_pass", ledger
+    assert ledger["expected_lane_count"] == 2, ledger
+    assert ledger["lane_outcome_count"] == 3, ledger
+    assert ledger["completed_lane_turn_count"] == 3, ledger
+    assert ledger["collective_round_indexes"] == [1, 2], ledger
+    assert ledger["collective_round_count"] == 2, ledger
+    assert ledger["multi_round_interaction_verified"] is True, ledger
+    assert ledger["integrated_evidence"]["evidence_event_count"] == 3, ledger
+    assert ledger["integrated_evidence"]["dev_metric"] == 4.0, ledger
+    assert ledger["integrated_evidence"]["holdout_metric"] == 4.5, ledger
+    assert ledger["successor_todo_count"] == 1, ledger
+    assert ledger["role_declared_successor_todos"][0]["target_agent_id"] == "agent-b"
+    assert ledger["public_boundary"] == {
+        "raw_logs_recorded": False,
+        "private_artifacts_recorded": False,
+        "absolute_paths_recorded": False,
+        "credentials_recorded": False,
+    }, ledger
+    assert_public_safe(ledger)
+    print("multi-agent-collective-round-ledger-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -24,6 +24,9 @@ from .preset import (
 from .rollout_append import append_auto_research_rollout_events
 from .user_contract import build_auto_research_user_contract
 from .worker_loop import run_auto_research_worker_loop
+from ..multi_agent.collective_round_ledger import (
+    build_multi_agent_collective_round_ledger,
+)
 
 
 AppendEvidence = Callable[[str], dict[str, object]]
@@ -433,6 +436,9 @@ def _build_collective_round_summary(
     dev_metric: float | None,
     holdout_metric: float | None,
     evidence_event_count: int | None = None,
+    expected_lanes: list[dict[str, object]] | None = None,
+    lane_outcomes: list[dict[str, object]] | None = None,
+    role_declared_successor_todos: list[dict[str, object]] | None = None,
 ) -> dict[str, object]:
     baseline = 1.0
     multi_round_research_verified = (
@@ -442,11 +448,23 @@ def _build_collective_round_summary(
         and dev_metric > baseline
         and holdout_metric > dev_metric
     )
+    kernel_ledger = build_multi_agent_collective_round_ledger(
+        source=source,
+        expected_lanes=expected_lanes,
+        lane_outcomes=lane_outcomes,
+        integrated_evidence={
+            "dev_metric": dev_metric,
+            "holdout_metric": holdout_metric,
+            "evidence_event_count": evidence_event_count,
+        },
+        role_declared_successor_todos=role_declared_successor_todos,
+    )
     return {
         "schema_version": "auto_research_collective_round_summary_v0",
         "loaded": collective_round_count > 0 or dev_metric is not None or holdout_metric is not None,
         "source": source,
         "round_unit": "collective_agent_pass",
+        "kernel_ledger": kernel_ledger,
         "definition": (
             "one collective research round means each configured research lane has "
             "one quota/frontier/worker-turn opportunity; pane-local tick loops are "
@@ -506,12 +524,26 @@ def _collective_summary_from_worker_loop(
         ),
         None,
     )
+    successors = [
+        successor
+        for turn in turns
+        if isinstance(turn, dict) and isinstance(turn.get("successor_todos"), list)
+        for successor in turn.get("successor_todos", [])
+        if isinstance(successor, dict)
+    ]
     return _build_collective_round_summary(
         source="worker_loop_collective_agent_passes",
         agent_count=agent_count,
         collective_round_count=len(round_indexes),
         dev_metric=dev_metric,
         holdout_metric=holdout_metric,
+        expected_lanes=[
+            {"agent_id": turn.get("agent_id")}
+            for turn in turns
+            if isinstance(turn, dict) and turn.get("round") == 1
+        ],
+        lane_outcomes=[turn for turn in turns if isinstance(turn, dict)],
+        role_declared_successor_todos=successors,
     )
 
 
@@ -538,6 +570,9 @@ def _collective_summary_from_visible_panes_and_evidence(
             if isinstance(evidence.get("evidence_event_count"), int)
             and not isinstance(evidence.get("evidence_event_count"), bool)
             else None
+        ),
+        expected_lanes=(
+            pane_rounds.get("lanes") if isinstance(pane_rounds.get("lanes"), list) else None
         ),
     )
 

--- a/loopx/capabilities/auto_research/worker_loop.py
+++ b/loopx/capabilities/auto_research/worker_loop.py
@@ -18,6 +18,14 @@ def _compact_turn(turn: dict[str, object], *, round_index: int) -> dict[str, obj
     evaluation_summary = (
         turn.get("evaluation_summary") if isinstance(turn.get("evaluation_summary"), dict) else {}
     )
+    successor_todos = (
+        turn.get("successor_todos") if isinstance(turn.get("successor_todos"), dict) else {}
+    )
+    successors = (
+        successor_todos.get("successors")
+        if isinstance(successor_todos.get("successors"), list)
+        else []
+    )
     return {
         "round": round_index,
         "agent_id": turn.get("agent_id"),
@@ -32,6 +40,19 @@ def _compact_turn(turn: dict[str, object], *, round_index: int) -> dict[str, obj
         "claim_allowed": evaluation_summary.get("claim_allowed"),
         "best_holdout_metric": evaluation_summary.get("best_holdout_metric"),
         "live_evidence_written": bool(live_evidence.get("written")),
+        "successor_todo_count": len(successors),
+        "successor_todos": [
+            {
+                "todo_id": successor.get("todo_id"),
+                "target_agent_id": successor.get("target_agent_id")
+                or successor.get("claimed_by"),
+                "target_role_id": successor.get("target_role_id"),
+                "source_todo_id": successor.get("unblocks_todo_id"),
+                "action_kind": successor.get("action_kind"),
+            }
+            for successor in successors
+            if isinstance(successor, dict)
+        ],
     }
 
 

--- a/loopx/capabilities/multi_agent/collective_round_ledger.py
+++ b/loopx/capabilities/multi_agent/collective_round_ledger.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+
+MULTI_AGENT_COLLECTIVE_ROUND_LEDGER_SCHEMA_VERSION = (
+    "multi_agent_collective_round_ledger_v0"
+)
+
+
+def _string(value: object, *, default: str = "") -> str:
+    text = str(value or "").strip()
+    return text or default
+
+
+def _bool_or_none(value: object) -> bool | None:
+    return value if isinstance(value, bool) else None
+
+
+def _int_or_none(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+    return value if isinstance(value, int) else None
+
+
+def _number_or_none(value: object) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def _dicts(values: Iterable[object] | None) -> list[dict[str, Any]]:
+    return [dict(item) for item in values or [] if isinstance(item, Mapping)]
+
+
+def _lane_key(lane: Mapping[str, object]) -> tuple[str, str, str]:
+    return (
+        _string(lane.get("agent_id")),
+        _string(lane.get("lane_id")),
+        _string(lane.get("role_id")),
+    )
+
+
+def _normalize_lane(lane: Mapping[str, object]) -> dict[str, object]:
+    return {
+        "agent_id": _string(lane.get("agent_id")),
+        "lane_id": _string(lane.get("lane_id")),
+        "role_id": _string(lane.get("role_id")),
+    }
+
+
+def _normalize_outcome(outcome: Mapping[str, object]) -> dict[str, object]:
+    completion_status = _string(outcome.get("completion_status"))
+    executed = _bool_or_none(outcome.get("executed"))
+    return {
+        "round": _int_or_none(outcome.get("round")),
+        "agent_id": _string(outcome.get("agent_id")),
+        "lane_id": _string(outcome.get("lane_id")),
+        "role_id": _string(outcome.get("role_id")),
+        "selected_todo_id": _string(outcome.get("selected_todo_id")),
+        "selected_action": _string(outcome.get("selected_action")),
+        "executed": executed,
+        "completion_status": completion_status or None,
+        "completed": executed is True or completion_status == "done",
+        "dev_metric": _number_or_none(outcome.get("dev_metric")),
+        "holdout_metric": _number_or_none(outcome.get("holdout_metric")),
+        "appended_count": _int_or_none(outcome.get("appended_count")),
+        "successor_todo_declared": bool(outcome.get("successor_todo_declared")),
+    }
+
+
+def _derive_lanes(outcomes: list[dict[str, object]]) -> list[dict[str, object]]:
+    lanes: list[dict[str, object]] = []
+    seen: set[tuple[str, str, str]] = set()
+    for outcome in outcomes:
+        lane = _normalize_lane(outcome)
+        key = _lane_key(lane)
+        if key == ("", "", "") or key in seen:
+            continue
+        seen.add(key)
+        lanes.append(lane)
+    return lanes
+
+
+def _normalize_successor(todo: Mapping[str, object]) -> dict[str, object]:
+    return {
+        "todo_id": _string(todo.get("todo_id")),
+        "target_agent_id": _string(todo.get("target_agent_id") or todo.get("claimed_by")),
+        "target_role_id": _string(todo.get("target_role_id")),
+        "source_todo_id": _string(todo.get("source_todo_id") or todo.get("unblocks_todo_id")),
+        "action_kind": _string(todo.get("action_kind")),
+    }
+
+
+def build_multi_agent_collective_round_ledger(
+    *,
+    source: str,
+    expected_lanes: Iterable[object] | None = None,
+    lane_outcomes: Iterable[object] | None = None,
+    integrated_evidence: Mapping[str, object] | None = None,
+    role_declared_successor_todos: Iterable[object] | None = None,
+) -> dict[str, object]:
+    """Build a domain-neutral ledger for decentralized multi-agent rounds.
+
+    A collective round is only an observation over normal LoopX state: each lane
+    gets a chance to read its own quota/frontier and run one bounded turn. This
+    helper deliberately does not select work, wake panes, write todos, or decide
+    promotion. Product presets may wrap the ledger with domain-specific metrics.
+    """
+
+    outcomes = [_normalize_outcome(item) for item in _dicts(lane_outcomes)]
+    lanes = [_normalize_lane(item) for item in _dicts(expected_lanes)]
+    if not lanes:
+        lanes = _derive_lanes(outcomes)
+    evidence = dict(integrated_evidence or {})
+    successors = [
+        _normalize_successor(item) for item in _dicts(role_declared_successor_todos)
+    ]
+    round_indexes = sorted(
+        {
+            int(outcome["round"])
+            for outcome in outcomes
+            if isinstance(outcome.get("round"), int) and outcome.get("executed") is True
+        }
+    )
+    completed_outcomes = [
+        outcome for outcome in outcomes if outcome.get("completed") is True
+    ]
+    evidence_event_count = _int_or_none(evidence.get("evidence_event_count"))
+    if evidence_event_count is None:
+        evidence_events = evidence.get("events")
+        evidence_event_count = len(evidence_events) if isinstance(evidence_events, list) else 0
+    return {
+        "schema_version": MULTI_AGENT_COLLECTIVE_ROUND_LEDGER_SCHEMA_VERSION,
+        "source": _string(source, default="unknown"),
+        "coordination_model": "decentralized_state_a2a",
+        "round_unit": "collective_agent_pass",
+        "definition": (
+            "one collective round means each expected lane has one normal "
+            "LoopX quota/frontier/turn opportunity; pane-local tick loops are "
+            "evidence, not a central workflow"
+        ),
+        "expected_lanes": lanes,
+        "expected_lane_count": len(lanes),
+        "lane_outcomes": outcomes,
+        "lane_outcome_count": len(outcomes),
+        "completed_lane_turn_count": len(completed_outcomes),
+        "collective_round_indexes": round_indexes,
+        "collective_round_count": len(round_indexes),
+        "multi_round_interaction_verified": len(round_indexes) >= 2,
+        "integrated_evidence": {
+            "loaded": bool(evidence),
+            "evidence_event_count": evidence_event_count,
+            "dev_metric": _number_or_none(evidence.get("dev_metric")),
+            "holdout_metric": _number_or_none(evidence.get("holdout_metric")),
+            "result_status": _string(evidence.get("result_status")),
+            "protected_scope_clean": _bool_or_none(evidence.get("protected_scope_clean")),
+        },
+        "role_declared_successor_todos": successors,
+        "successor_todo_count": len(successors),
+        "source_of_truth": [
+            "loopx_quota_should_run",
+            "agent_scoped_frontier",
+            "todo_claims",
+            "public_safe_evidence",
+        ],
+        "owner_layer": "generic_multi_agent_kernel",
+        "public_boundary": {
+            "raw_logs_recorded": False,
+            "private_artifacts_recorded": False,
+            "absolute_paths_recorded": False,
+            "credentials_recorded": False,
+        },
+    }


### PR DESCRIPTION
## Summary
- add a generic kernel-owned multi_agent_collective_round_ledger_v0 helper
- preserve auto-research behavior while embedding the kernel ledger in collective_research_rounds
- keep role-declared successor todo evidence in worker-loop compact turns

## Validation
- python3 -m py_compile loopx/capabilities/multi_agent/collective_round_ledger.py loopx/capabilities/auto_research/demo_e2e.py loopx/capabilities/auto_research/worker_loop.py examples/multi-agent-collective-round-ledger-smoke.py examples/auto-research-knn-continuation-smoke.py examples/auto-research-demo-e2e-worker-loop-smoke.py examples/auto-research-layered-e2e-acceptance-smoke.py
- python3 examples/multi-agent-collective-round-ledger-smoke.py
- python3 examples/auto-research-knn-continuation-smoke.py
- python3 examples/auto-research-layered-e2e-acceptance-smoke.py
- python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- python3 examples/auto-research-user-contract-entry-smoke.py
- python3 examples/auto-research-start-markdown-commands-smoke.py
- git diff --check
- public/private boundary scan of changed files