### PR TITLE
docs: index finance value connector candidate

### DIFF
--- a/docs/capabilities/README.md
+++ b/docs/capabilities/README.md
@@ -12,7 +12,8 @@ Current capability paths:
   into reviewable source, angle, draft, feedback, and publish-gate packets.
 - [value-connectors](value-connectors/README.md): install and run public-safe
   external-value connector starters, beginning with body-free GitHub public
-  channel metadata probes.
+  channel metadata probes, plus gated candidate profiles such as X/browser
+  social work and finance market snapshots.
 
 Do not add a capability path until there is at least one real CLI entrypoint and
 one smoke test. Future ideas belong in product planning docs until they have

--- a/docs/reference/protocols/value-connector-plan-v0.md
+++ b/docs/reference/protocols/value-connector-plan-v0.md
@@ -76,6 +76,7 @@ loopx value-connectors plan \
 | `connector_approval_gate_v0` | Exact-call approval gate for account setup, external writes, sends, publishing, or private expansion. |
 | `github_public_channel_probe_packet_v0` | Starter connector output for public GitHub issue/PR/discussion metadata. |
 | `github_public_reply_monitor_packet_v0` | Starter connector output for public maintainer reply detection after a LoopX comment. |
+| `finance_market_snapshot_profile_v0` | Candidate profile for quote/fund/news/announcement pulls with source, freshness, uncertainty, and no-investment-advice gates. |
 | `value_connector_install_check_packet_v0` | Local install/use checklist for connector starters. |
 
 ## Boundaries


### PR DESCRIPTION
## Summary
- promote the validated finance value connector packet into the public capability index
- add finance_market_snapshot_profile_v0 to the value connector protocol record table

## Validation
- python3 -m loopx.cli --format json check --scan-path docs/capabilities/README.md --scan-path docs/reference/protocols/value-connector-plan-v0.md
- ./scripts/loopx value-connectors plan ... finance_market_snapshot ... --format json
- git diff --check

## Boundary
Docs-only catalog/index change. It does not add live finance data execution, account access, trading, private portfolio reads, or investment-advice behavior.