### PR TITLE
Extract latest run selector

### DIFF
--- a/examples/control_plane/run-history-readmodel-smoke.py
+++ b/examples/control_plane/run-history-readmodel-smoke.py
@@ -15,6 +15,13 @@ from loopx import status as status_module  # noqa: E402
 from loopx.control_plane.runtime import run_history as run_history_read_model  # noqa: E402
 
 
+def direct_latest_run(goal: dict) -> dict | None:
+    return run_history_read_model.latest_run(
+        goal,
+        is_status_neutral_run=status_module.is_status_neutral_run,
+    )
+
+
 def direct_history(history: dict, *, display_limit: int | None = None) -> dict:
     return run_history_read_model.build_run_history(
         history,
@@ -35,6 +42,25 @@ def assert_parity(history: dict, *, display_limit: int | None = None) -> dict:
 
 
 def main() -> None:
+    active_run = {"run_id": "active", "classification": "implementation_batch"}
+    neutral_status_run = {"run_id": "status-only", "classification": "quota_slot_spent"}
+    neutral_latest_run = {"run_id": "neutral", "classification": "quota_slot_spent"}
+    latest_run_goal = {
+        "latest_status_run": neutral_status_run,
+        "latest_runs": [
+            "invalid",
+            neutral_latest_run,
+            active_run,
+        ],
+    }
+    assert status_module.latest_run(latest_run_goal) == direct_latest_run(latest_run_goal) == active_run
+    assert status_module.latest_run({"latest_status_run": active_run}) == direct_latest_run(
+        {"latest_status_run": active_run}
+    ) == active_run
+    assert status_module.latest_run({"latest_runs": [neutral_latest_run]}) == direct_latest_run(
+        {"latest_runs": [neutral_latest_run]}
+    ) is None
+
     history = {
         "goal_count": 2,
         "run_count": 4,

--- a/loopx/control_plane/runtime/run_history.py
+++ b/loopx/control_plane/runtime/run_history.py
@@ -8,6 +8,28 @@ GoalLifecycleFields = Callable[[dict[str, Any], Optional[dict[str, Any]]], dict[
 GoalProjection = Callable[[dict[str, Any]], Optional[dict[str, Any]]]
 RunCompactor = Callable[[dict[str, Any]], dict[str, Any]]
 QuotaStatus = Callable[[dict[str, Any]], dict[str, Any]]
+StatusNeutralRun = Callable[[dict[str, Any]], bool]
+
+
+def latest_run(
+    goal: dict[str, Any],
+    *,
+    is_status_neutral_run: StatusNeutralRun,
+) -> dict[str, Any] | None:
+    status_run = goal.get("latest_status_run")
+    if isinstance(status_run, dict) and not is_status_neutral_run(status_run):
+        return status_run
+
+    runs = goal.get("latest_runs")
+    if not isinstance(runs, list) or not runs:
+        return None
+    for run in runs:
+        if not isinstance(run, dict):
+            continue
+        if is_status_neutral_run(run):
+            continue
+        return run
+    return None
 
 
 def build_run_history(

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -154,6 +154,7 @@ from .control_plane.runtime.run_compaction import (
 )
 from .control_plane.runtime.run_history import (
     build_run_history as _build_run_history_read_model,
+    latest_run as _latest_run_read_model,
 )
 from .control_plane.runtime.event_ledger import (
     EVENT_LEDGER_CLASSES,
@@ -6869,20 +6870,10 @@ def latest_run_recommended_action_for_projection(
 
 
 def latest_run(goal: dict[str, Any]) -> dict[str, Any] | None:
-    status_run = goal.get("latest_status_run")
-    if isinstance(status_run, dict) and not is_status_neutral_run(status_run):
-        return status_run
-
-    runs = goal.get("latest_runs")
-    if not isinstance(runs, list) or not runs:
-        return None
-    for run in runs:
-        if not isinstance(run, dict):
-            continue
-        if is_status_neutral_run(run):
-            continue
-        return run
-    return None
+    return _latest_run_read_model(
+        goal,
+        is_status_neutral_run=is_status_neutral_run,
+    )
 
 
 def ordered_lifecycle_flags(flags: list[str]) -> list[str]:


### PR DESCRIPTION
Summary
- Move latest_run selection logic from loopx/status.py into loopx/control_plane/runtime/run_history.py.
- Keep loopx.status latest_run as a compatibility wrapper with the existing status-neutral predicate.
- Extend the run-history readmodel smoke to cover latest_status_run fallback, neutral run skipping, invalid run skipping, and direct/wrapper parity.

Product and architecture judgment
- Motivation: continue canary-gated status.py read-model cleanup in small, reversible slices.
- Solved: this slice moves a focused run-history selection rule into the runtime read model without changing status payloads.
- Operator impact: run_history current-run selection is now covered by the same durable parity smoke used by status/quota/review consumers.
- Main risk: status hot-path compatibility. Mitigated by preserving the status.py wrapper, injecting the status-neutral predicate, and running focused status/quota/markdown smokes.
- Design: bounded runtime read model with dependency injection for status-neutral semantics, consistent with the run_history module created in #1332.

Validation
- python3 examples/control_plane/run-history-readmodel-smoke.py
- python3 -m loopx.cli canary smoke-suite --suite full-public --script examples/control_plane/run-history-readmodel-smoke.py --timeout-seconds 60 --no-progress
- python3 examples/control_plane/status-contract-readmodel-smoke.py
- python3 examples/control_plane/status-quota-review-packet-parity-smoke.py
- python3 examples/control_plane/status-goal-filter-smoke.py
- python3 examples/control_plane/status-markdown-smoke.py
- python3 examples/control_plane/decision-freshness-readmodel-smoke.py
- python3 examples/control_plane/event-ledger-readmodel-smoke.py
- python3 examples/control_plane/promotion-readiness-readmodel-smoke.py
- loopx --format json status --goal-id loopx-meta --limit 1
- python3 -m compileall -q loopx/status.py loopx/control_plane/runtime/run_history.py examples/control_plane/run-history-readmodel-smoke.py
- git diff --check origin/main...HEAD

Known existing red
- python3 examples/control_plane/repo-python-line-budget-smoke.py remains red on existing SkillsBench files only: examples/skillsbench-benchmark-run-smoke.py and scripts/skillsbench_automation_loop.py. This PR does not touch those files.

Boundary scan
- Candidate public paths scanned clean for private/local artifact markers.
