### PR TITLE
Refine auto-research thin preset boundary

### DIFF
--- a/docs/guides/auto-research-command-path.md
+++ b/docs/guides/auto-research-command-path.md
@@ -16,7 +16,9 @@ multi-agent kernel. `loopx/capabilities/auto_research/preset.py` owns only the
 research roles, handoff hints, metric/evidence loop defaults, and seed todo
 phrasing. The generic kernel owns the real Codex TUI panes, pane-local A2A
 tick, workspace/trust-safe launch, todo/evidence/status protocol, and compact
-human status.
+human status. The developer-facing recipe proof also follows that boundary:
+`preset.py` calls the generic `multi_agent.recipe` helper instead of defining
+decentralized A2A proof mechanics itself.
 Use the [multi-agent product recipe](multi-agent-product-recipe.md) when a new
 product wants to copy the pattern without copying auto-research code.
 

--- a/docs/reference/protocols/multi-agent-three-layer-minimality-v0.md
+++ b/docs/reference/protocols/multi-agent-three-layer-minimality-v0.md
@@ -80,6 +80,20 @@ decentralized A2A research loop on the shared LoopX kernel. The slogan must not
 claim that tmux launch, Codex TUI bootstrap, quota/frontier, evidence routing,
 or status projection are reimplemented inside the auto-research preset.
 
+## Developer Implementation Budget
+
+The same split applies to source code, not only to command examples.
+`loopx/capabilities/auto_research/preset.py` should read like a small preset:
+role defaults, role profiles, successor declarations, seed todo wording, and
+thin wrappers around generic helpers. Reusable A2A proof fields such as
+`broadcaster_selects_todo=false`, `each_pane_reads_own_quota_frontier=true`,
+and `leader_agent_required=false` belong to
+`loopx/capabilities/multi_agent/recipe.py`.
+
+This keeps the developer-facing promise honest: future products should be able
+to copy the pattern by writing their own short preset, not by importing
+auto-research internals.
+
 ## Collective Round Ledger
 
 `multi_agent_collective_round_ledger_v0` is the kernel-owned proof surface for

--- a/examples/auto-research-dev-thin-preset-smoke.py
+++ b/examples/auto-research-dev-thin-preset-smoke.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Smoke-check that auto-research stays a thin developer-facing preset."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx.capabilities.auto_research.preset import (  # noqa: E402
+    build_auto_research_minimal_a2a_recipe,
+)
+from loopx.capabilities.multi_agent.recipe import (  # noqa: E402
+    DEFAULT_DECENTRALIZED_A2A_PROOF_CONTRACT,
+    build_minimal_decentralized_a2a_recipe,
+    parse_multi_agent_role_spec_lines,
+)
+
+
+def main() -> int:
+    preset_source = ROOT / "loopx" / "capabilities" / "auto_research" / "preset.py"
+    generic_source = ROOT / "loopx" / "capabilities" / "multi_agent" / "recipe.py"
+    preset_text = preset_source.read_text(encoding="utf-8")
+    generic_text = generic_source.read_text(encoding="utf-8")
+
+    for proof_key in DEFAULT_DECENTRALIZED_A2A_PROOF_CONTRACT:
+        assert proof_key not in preset_text, proof_key
+        assert proof_key in generic_text, proof_key
+
+    auto_recipe = build_auto_research_minimal_a2a_recipe(
+        open_question="Can decentralized A2A improve research quality?",
+        output_language="zh",
+    )
+    assert auto_recipe["schema_version"] == "auto_research_minimal_a2a_recipe_v0"
+    assert auto_recipe["product_id"] == "auto-research"
+    assert auto_recipe["user_line_count"] == 1
+    assert auto_recipe["preset_role_spec_line_count"] == 4
+    assert auto_recipe["user_plus_preset_line_count"] == 5
+    assert auto_recipe["shared_kernel_counted_as_recipe_lines"] is False
+    assert auto_recipe["a2a_proof_contract"] == DEFAULT_DECENTRALIZED_A2A_PROOF_CONTRACT
+    assert auto_recipe["owner_layers"]["preset_layer"] == (
+        "role_defaults_and_domain_handoff_only"
+    )
+
+    generic_recipe = build_minimal_decentralized_a2a_recipe(
+        product_id="custom-research",
+        claim="one command plus two roles starts decentralized A2A",
+        claim_boundary="count only user and preset recipe lines",
+        user_recipe_lines=["loopx custom-research start '<topic>' --execute"],
+        preset_recipe_lines=["agent-a:curator", "agent-b:runner"],
+    )
+    assert generic_recipe["schema_version"] == "generic_multi_agent_minimal_recipe_v0"
+    assert generic_recipe["user_plus_preset_line_count"] == 3
+    assert generic_recipe["a2a_proof_contract"] == DEFAULT_DECENTRALIZED_A2A_PROOF_CONTRACT
+
+    lanes = parse_multi_agent_role_spec_lines(
+        agent_specs=["agent-a:plan:planner:Plan a focused slice", "agent-b"],
+        default_agent_specs=[],
+        resolve_role_id=lambda raw, index: raw or f"role-{index}",
+        default_scope_by_lane={"lane-2": "Run the bounded work"},
+    )
+    assert lanes == [
+        {
+            "agent_id": "agent-a",
+            "lane_id": "plan",
+            "role_id": "planner",
+            "scope": "Plan a focused slice",
+        },
+        {
+            "agent_id": "agent-b",
+            "lane_id": "lane-2",
+            "role_id": "role-2",
+            "scope": "Run the bounded work",
+        },
+    ]
+
+    preset_line_count = len(preset_text.splitlines())
+    generic_line_count = len(generic_text.splitlines())
+    assert preset_line_count <= 430, preset_line_count
+    assert generic_line_count <= 120, generic_line_count
+
+    print("auto-research-dev-thin-preset-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/auto_research/preset.py
+++ b/loopx/capabilities/auto_research/preset.py
@@ -4,6 +4,10 @@ import shlex
 from collections.abc import Iterable
 
 from .defaults import AUTO_RESEARCH_DEFAULT_GOAL_ID
+from ..multi_agent.recipe import (
+    build_minimal_decentralized_a2a_recipe,
+    parse_multi_agent_role_spec_lines,
+)
 
 
 AUTO_RESEARCH_PRESET_SCHEMA_VERSION = "auto_research_thin_preset_v0"
@@ -234,46 +238,23 @@ def build_auto_research_minimal_a2a_recipe(
         "loopx auto-research start "
         f"{_quoted_open_question(open_question)}{language_flag} --execute"
     )
-    raw_role_specs = (
-        role_specs if role_specs is not None else default_auto_research_agent_specs()
-    )
-    preset_lines = [str(spec).strip() for spec in raw_role_specs if str(spec).strip()]
-    user_line_count = 1
-    preset_line_count = len(preset_lines)
-    return {
-        "schema_version": AUTO_RESEARCH_MINIMAL_A2A_RECIPE_SCHEMA_VERSION,
-        "claim": (
+    raw_role_specs = role_specs or default_auto_research_agent_specs()
+    return build_minimal_decentralized_a2a_recipe(
+        schema_version=AUTO_RESEARCH_MINIMAL_A2A_RECIPE_SCHEMA_VERSION,
+        product_id="auto-research",
+        claim=(
             "one user command plus the default four-line auto-research role spec "
             "starts decentralized A2A on the shared LoopX multi-agent kernel"
         ),
-        "line_unit": "declarative_recipe_line",
-        "user_line_count": user_line_count,
-        "preset_role_spec_line_count": preset_line_count,
-        "user_plus_preset_line_count": user_line_count + preset_line_count,
-        "shared_kernel_counted_as_recipe_lines": False,
-        "claim_boundary": (
+        claim_boundary=(
             "line count covers user intent and auto-research preset defaults only; "
             "the reusable kernel owns visible process launch, fixed wake prompt, "
             "pane-local quota/frontier tick, todo/evidence/status protocol, "
             "and public artifact routing"
         ),
-        "user_recipe_lines": [user_line],
-        "preset_recipe_lines": preset_lines,
-        "coordination_model": "decentralized_state_a2a",
-        "a2a_proof_contract": {
-            "broadcaster_selects_todo": False,
-            "broadcaster_runs_worker_turn": False,
-            "each_pane_reads_own_quota_frontier": True,
-            "successor_todos_declared_by_role_profile": True,
-            "leader_agent_required": False,
-        },
-        "kernel_reuse": [
-            "generic visible multi-agent runner",
-            "fixed prompt broadcast",
-            "pane-local A2A tick",
-            "LoopX todo/evidence/status protocol",
-        ],
-    }
+        user_recipe_lines=[user_line],
+        preset_recipe_lines=raw_role_specs,
+    )
 
 
 def auto_research_role_id(raw_role: str, *, index: int) -> str:
@@ -288,31 +269,18 @@ def auto_research_role_id(raw_role: str, *, index: int) -> str:
 
 
 def auto_research_lane_specs(agent_specs: Iterable[str] | None) -> list[dict[str, str]]:
-    parsed_specs = list(agent_specs or [])
-    if not parsed_specs:
-        parsed_specs = default_auto_research_agent_specs()
-
-    lanes: list[dict[str, str]] = []
     default_scope = {
         lane: scope for _agent, lane, _role, scope in AUTO_RESEARCH_DEFAULT_LANES
     }
-    for index, raw in enumerate(parsed_specs, start=1):
-        parts = [part.strip() for part in str(raw).split(":")]
-        if len(parts) not in {1, 2, 3, 4} or not parts[0]:
-            raise ValueError("agent specs must be agent_id[:lane_id[:role_id[:scope]]]")
-        agent_id = parts[0]
-        lane_id = parts[1] if len(parts) >= 2 and parts[1] else f"lane-{index}"
-        role_id = auto_research_role_id(parts[2] if len(parts) >= 3 else "", index=index)
-        scope = parts[3] if len(parts) >= 4 and parts[3] else default_scope.get(lane_id, role_id)
-        lanes.append(
-            {
-                "agent_id": agent_id,
-                "lane_id": lane_id,
-                "role_id": role_id,
-                "scope": scope,
-            }
-        )
-    return lanes
+    return parse_multi_agent_role_spec_lines(
+        agent_specs=agent_specs,
+        default_agent_specs=default_auto_research_agent_specs(),
+        resolve_role_id=lambda raw_role, index: auto_research_role_id(
+            raw_role,
+            index=index,
+        ),
+        default_scope_by_lane=default_scope,
+    )
 
 
 def auto_research_role_profile(*, role_id: str, goal_id: str, agent_id: str) -> dict[str, object]:

--- a/loopx/capabilities/multi_agent/recipe.py
+++ b/loopx/capabilities/multi_agent/recipe.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping
+
+
+GENERIC_MULTI_AGENT_MINIMAL_RECIPE_SCHEMA_VERSION = (
+    "generic_multi_agent_minimal_recipe_v0"
+)
+
+DEFAULT_DECENTRALIZED_A2A_PROOF_CONTRACT: dict[str, object] = {
+    "broadcaster_selects_todo": False,
+    "broadcaster_runs_worker_turn": False,
+    "each_pane_reads_own_quota_frontier": True,
+    "successor_todos_declared_by_role_profile": True,
+    "leader_agent_required": False,
+}
+
+DEFAULT_MULTI_AGENT_KERNEL_REUSE = (
+    "generic visible multi-agent runner",
+    "fixed prompt broadcast",
+    "pane-local A2A tick",
+    "LoopX todo/evidence/status protocol",
+)
+
+
+def _recipe_lines(lines: Iterable[object] | None) -> list[str]:
+    return [str(line).strip() for line in lines or [] if str(line).strip()]
+
+
+def build_minimal_decentralized_a2a_recipe(
+    *,
+    user_recipe_lines: Iterable[object],
+    preset_recipe_lines: Iterable[object],
+    product_id: str,
+    claim: str,
+    claim_boundary: str,
+    schema_version: str = GENERIC_MULTI_AGENT_MINIMAL_RECIPE_SCHEMA_VERSION,
+    line_unit: str = "declarative_recipe_line",
+    coordination_model: str = "decentralized_state_a2a",
+    a2a_proof_contract: Mapping[str, object] | None = None,
+    kernel_reuse: Iterable[object] | None = None,
+    shared_kernel_counted_as_recipe_lines: bool = False,
+) -> dict[str, object]:
+    """Return the generic line-count contract for a product preset.
+
+    Product presets provide only user and preset recipe lines. The generic
+    kernel owns decentralized A2A proof fields, process launch, pane-local
+    ticks, and LoopX state handoff mechanics.
+    """
+
+    user_lines = _recipe_lines(user_recipe_lines)
+    preset_lines = _recipe_lines(preset_recipe_lines)
+    proof = dict(a2a_proof_contract or DEFAULT_DECENTRALIZED_A2A_PROOF_CONTRACT)
+    kernel_lines = _recipe_lines(kernel_reuse or DEFAULT_MULTI_AGENT_KERNEL_REUSE)
+    return {
+        "schema_version": schema_version,
+        "product_id": str(product_id or "").strip() or "multi-agent-product",
+        "claim": claim,
+        "line_unit": line_unit,
+        "user_line_count": len(user_lines),
+        "preset_role_spec_line_count": len(preset_lines),
+        "user_plus_preset_line_count": len(user_lines) + len(preset_lines),
+        "shared_kernel_counted_as_recipe_lines": shared_kernel_counted_as_recipe_lines,
+        "claim_boundary": claim_boundary,
+        "user_recipe_lines": user_lines,
+        "preset_recipe_lines": preset_lines,
+        "coordination_model": coordination_model,
+        "a2a_proof_contract": proof,
+        "kernel_reuse": kernel_lines,
+        "owner_layers": {
+            "user_layer": "intent_lines_only",
+            "preset_layer": "role_defaults_and_domain_handoff_only",
+            "kernel_layer": "decentralized_a2a_runtime_and_state_protocol",
+        },
+    }
+
+
+def parse_multi_agent_role_spec_lines(
+    *,
+    agent_specs: Iterable[object] | None,
+    default_agent_specs: Iterable[object],
+    resolve_role_id: Callable[[str, int], str],
+    default_scope_by_lane: Mapping[str, object] | None = None,
+) -> list[dict[str, str]]:
+    """Parse `agent_id[:lane_id[:role_id[:scope]]]` recipe lines."""
+
+    parsed_specs = _recipe_lines(agent_specs) or _recipe_lines(default_agent_specs)
+    default_scope = {
+        str(lane_id): str(scope)
+        for lane_id, scope in (default_scope_by_lane or {}).items()
+        if str(lane_id).strip()
+    }
+    lanes: list[dict[str, str]] = []
+    for index, raw in enumerate(parsed_specs, start=1):
+        parts = [part.strip() for part in raw.split(":")]
+        if len(parts) not in {1, 2, 3, 4} or not parts[0]:
+            raise ValueError("agent specs must be agent_id[:lane_id[:role_id[:scope]]]")
+        agent_id = parts[0]
+        lane_id = parts[1] if len(parts) >= 2 and parts[1] else f"lane-{index}"
+        role_id = resolve_role_id(parts[2] if len(parts) >= 3 else "", index)
+        scope = parts[3] if len(parts) >= 4 and parts[3] else default_scope.get(lane_id, role_id)
+        lanes.append(
+            {
+                "agent_id": agent_id,
+                "lane_id": lane_id,
+                "role_id": role_id,
+                "scope": scope,
+            }
+        )
+    return lanes


### PR DESCRIPTION
## Summary\n- move the minimal decentralized A2A recipe/proof helper into the generic multi-agent kernel\n- reuse a generic role-spec parser so auto-research preset owns role defaults, not parsing mechanics\n- document the developer-facing implementation budget and add a thin-preset regression smoke\n\n## Validation\n- python3 -m py_compile loopx/capabilities/multi_agent/recipe.py loopx/capabilities/auto_research/preset.py examples/auto-research-dev-thin-preset-smoke.py\n- python3 examples/auto-research-dev-thin-preset-smoke.py\n- python3 examples/auto-research-user-contract-entry-smoke.py\n- python3 examples/auto-research-start-markdown-commands-smoke.py\n- python3 examples/multi-agent-product-recipe-smoke.py\n- python3 examples/auto-research-layered-e2e-acceptance-smoke.py\n- python3 examples/auto-research-demo-e2e-worker-loop-smoke.py\n- python3 examples/auto-research-knn-continuation-smoke.py\n- git diff --check\n\n## Boundary\nPublic-safe refactor only. No raw logs, private paths, credentials, or generated transcripts.