### PR TITLE
Extract compact run base read model

### DIFF
--- a/examples/control_plane/run-compaction-readmodel-smoke.py
+++ b/examples/control_plane/run-compaction-readmodel-smoke.py
@@ -91,8 +91,70 @@ def assert_run_compaction_wrapper_parity() -> None:
     ) == run_compaction_read_model.compact_controller_readiness(readiness)
 
 
+def _direct_compact_run_base(run: dict[str, object]) -> dict[str, object]:
+    return run_compaction_read_model.compact_run_base(
+        run,
+        run_compact_fields=status_module.RUN_COMPACT_FIELDS,
+        run_lifecycle_flags=status_module.run_lifecycle_flags,
+        primary_lifecycle_phase=status_module.primary_lifecycle_phase,
+        compact_human_reward=status_module.compact_human_reward,
+        compact_operator_gate=status_module.compact_operator_gate,
+        compact_autonomous_replan_ack=status_module.compact_autonomous_replan_ack,
+        compact_operator_gate_resume_contract=status_module.compact_operator_gate_resume_contract,
+        compact_controller_readiness=status_module.compact_controller_readiness,
+        public_safe_compact_text=status_module.public_safe_compact_text,
+        compact_subagent_run=status_module.compact_subagent_run,
+        max_subagent_activity_items=status_module.MAX_SUBAGENT_ACTIVITY_ITEMS,
+    )
+
+
+def assert_compact_run_base_parity() -> None:
+    mapped_run = {
+        "generated_at": "2026-07-04T00:02:00Z",
+        "run_id": "run-base",
+        "goal_id": "loopx-meta",
+        "classification": "read_only_project_map",
+        "recommended_action": "continue bounded cleanup",
+        "merge_decision": "self-merged after focused validation",
+        "human_reward": {"decision": "approve", "reward": 1, "private_note": "not compacted"},
+        "operator_gate": {"decision": "approve", "operator_question": "Proceed?"},
+        "operator_gate_resume_contract": {
+            "version": "v1",
+            "goal_id": "loopx-meta",
+            "interrupt_payload": {"question": "Resume?", "private_payload": "not compacted"},
+        },
+        "controller_readiness": {
+            "classification": "controller_ready",
+            "decision_advisor_ready": True,
+            "gates": [{"id": "smoke", "ok": True, "review": "passed", "private_note": "not compacted"}],
+        },
+        "subagents": [
+            {
+                "run_id": "child-1",
+                "agent_role": "review",
+                "status": "completed",
+                "changed_files": ["AGENTS.md", "loopx/status.py"],
+                "private_note": "not compacted",
+            }
+        ],
+        "ignored_field": "not compacted",
+    }
+    assert status_module.compact_run(mapped_run) == _direct_compact_run_base(mapped_run)
+
+    explicit_lifecycle_run = {
+        "generated_at": "2026-07-04T00:03:00Z",
+        "classification": "custom_event",
+        "lifecycle_phase": "controller_gated",
+        "lifecycle_flags": ["controller_gated"],
+    }
+    assert status_module.compact_run(explicit_lifecycle_run) == _direct_compact_run_base(
+        explicit_lifecycle_run
+    )
+
+
 def main() -> None:
     assert_run_compaction_wrapper_parity()
+    assert_compact_run_base_parity()
 
 
 if __name__ == "__main__":

--- a/loopx/control_plane/runtime/run_compaction.py
+++ b/loopx/control_plane/runtime/run_compaction.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Callable, Optional
 
 
 HUMAN_REWARD_COMPACT_FIELDS = (
@@ -50,6 +50,13 @@ CONTROLLER_READINESS_GATE_FIELDS = (
     "ok",
     "review",
 )
+
+CompactProjection = Callable[[Any], Optional[dict[str, Any]]]
+LifecycleFlags = Callable[[Optional[dict[str, Any]]], list[str]]
+PrimaryLifecyclePhase = Callable[..., str]
+TextCompactor = Callable[..., Any]
+RunProjection = Callable[[dict[str, Any]], Optional[dict[str, Any]]]
+SubagentRunCompactor = Callable[..., Optional[dict[str, Any]]]
 
 
 def compact_human_reward(reward: Any) -> dict[str, Any] | None:
@@ -107,3 +114,67 @@ def compact_controller_readiness(readiness: Any) -> dict[str, Any] | None:
     if gates:
         compact["gates"] = gates
     return compact or None
+
+
+def compact_run_base(
+    run: dict[str, Any],
+    *,
+    run_compact_fields: tuple[str, ...],
+    run_lifecycle_flags: LifecycleFlags,
+    primary_lifecycle_phase: PrimaryLifecyclePhase,
+    compact_human_reward: CompactProjection,
+    compact_operator_gate: CompactProjection,
+    compact_autonomous_replan_ack: RunProjection,
+    compact_operator_gate_resume_contract: CompactProjection,
+    compact_controller_readiness: CompactProjection,
+    public_safe_compact_text: TextCompactor,
+    compact_subagent_run: SubagentRunCompactor,
+    max_subagent_activity_items: int,
+) -> dict[str, Any]:
+    compact = {field: run[field] for field in run_compact_fields if field in run}
+    flags = run_lifecycle_flags(run)
+    compact.setdefault("lifecycle_phase", primary_lifecycle_phase(flags, fallback="run_recorded"))
+    compact.setdefault("lifecycle_flags", flags)
+
+    reward = compact_human_reward(run.get("human_reward"))
+    if reward:
+        compact["human_reward"] = reward
+
+    operator_gate = compact_operator_gate(run.get("operator_gate"))
+    if operator_gate:
+        compact["operator_gate"] = operator_gate
+
+    replan_ack = compact_autonomous_replan_ack(run)
+    if replan_ack:
+        compact["autonomous_replan_ack"] = replan_ack
+
+    resume_contract = compact_operator_gate_resume_contract(run.get("operator_gate_resume_contract"))
+    if resume_contract:
+        compact["operator_gate_resume_contract"] = resume_contract
+
+    readiness = compact_controller_readiness(run.get("controller_readiness"))
+    if readiness:
+        compact["controller_readiness"] = readiness
+
+    merge_decision = public_safe_compact_text(run.get("merge_decision"), limit=240)
+    if merge_decision:
+        compact["merge_decision"] = merge_decision
+
+    subagents = [
+        child
+        for child in (
+            compact_subagent_run(
+                child_run,
+                parent_goal_id=str(run.get("goal_id") or ""),
+                parent_run_id=str(run.get("run_id") or run.get("generated_at") or ""),
+            )
+            for child_run in (run.get("subagents") or [])
+            if isinstance(child_run, dict)
+        )
+        if child
+    ]
+    if subagents:
+        compact["subagents"] = subagents[:max_subagent_activity_items]
+        compact["subagent_count"] = len(subagents)
+
+    return compact

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -151,6 +151,7 @@ from .control_plane.runtime.run_compaction import (
     compact_human_reward as _compact_human_reward_read_model,
     compact_operator_gate as _compact_operator_gate_read_model,
     compact_operator_gate_resume_contract as _compact_operator_gate_resume_contract_read_model,
+    compact_run_base as _compact_run_base_read_model,
 )
 from .control_plane.runtime.run_history import (
     build_run_history as _build_run_history_read_model,
@@ -7531,44 +7532,20 @@ def compact_controller_readiness(readiness: Any) -> dict[str, Any] | None:
 
 
 def compact_run(run: dict[str, Any]) -> dict[str, Any]:
-    compact = {field: run[field] for field in RUN_COMPACT_FIELDS if field in run}
-    flags = run_lifecycle_flags(run)
-    compact.setdefault("lifecycle_phase", primary_lifecycle_phase(flags, fallback="run_recorded"))
-    compact.setdefault("lifecycle_flags", flags)
-    reward = compact_human_reward(run.get("human_reward"))
-    if reward:
-        compact["human_reward"] = reward
-    operator_gate = compact_operator_gate(run.get("operator_gate"))
-    if operator_gate:
-        compact["operator_gate"] = operator_gate
-    replan_ack = compact_autonomous_replan_ack(run)
-    if replan_ack:
-        compact["autonomous_replan_ack"] = replan_ack
-    resume_contract = compact_operator_gate_resume_contract(run.get("operator_gate_resume_contract"))
-    if resume_contract:
-        compact["operator_gate_resume_contract"] = resume_contract
-    readiness = compact_controller_readiness(run.get("controller_readiness"))
-    if readiness:
-        compact["controller_readiness"] = readiness
-    merge_decision = public_safe_compact_text(run.get("merge_decision"), limit=240)
-    if merge_decision:
-        compact["merge_decision"] = merge_decision
-    subagents = [
-        child
-        for child in (
-            compact_subagent_run(
-                child_run,
-                parent_goal_id=str(run.get("goal_id") or ""),
-                parent_run_id=str(run.get("run_id") or run.get("generated_at") or ""),
-            )
-            for child_run in (run.get("subagents") or [])
-            if isinstance(child_run, dict)
-        )
-        if child
-    ]
-    if subagents:
-        compact["subagents"] = subagents[:MAX_SUBAGENT_ACTIVITY_ITEMS]
-        compact["subagent_count"] = len(subagents)
+    compact = _compact_run_base_read_model(
+        run,
+        run_compact_fields=RUN_COMPACT_FIELDS,
+        run_lifecycle_flags=run_lifecycle_flags,
+        primary_lifecycle_phase=primary_lifecycle_phase,
+        compact_human_reward=compact_human_reward,
+        compact_operator_gate=compact_operator_gate,
+        compact_autonomous_replan_ack=compact_autonomous_replan_ack,
+        compact_operator_gate_resume_contract=compact_operator_gate_resume_contract,
+        compact_controller_readiness=compact_controller_readiness,
+        public_safe_compact_text=public_safe_compact_text,
+        compact_subagent_run=compact_subagent_run,
+        max_subagent_activity_items=MAX_SUBAGENT_ACTIVITY_ITEMS,
+    )
     benchmark_run = compact_benchmark_run(run)
     if benchmark_run:
         compact["benchmark_run_summary"] = benchmark_run


### PR DESCRIPTION
Summary
- Add compact_run_base to control_plane/runtime/run_compaction.py for the public run-history compaction skeleton.
- Keep status.compact_run as the compatibility wrapper and leave benchmark/session-specific append logic in status.py.
- Extend run-compaction readmodel smoke to prove status.compact_run parity with the new base helper for common run fields, lifecycle defaults, operator/reward/readiness projections, merge decision, and subagent compaction.

Product and architecture judgment
- Motivation: continue canary-gated status.py read-model cleanup while applying the new AGENTS.md minimality guidance.
- Solved: the common compact-run skeleton now has a bounded runtime read-model home. This trims status.py without moving benchmark/session behavior into the generic helper.
- User/operator impact: run-history row compaction becomes easier to test and localize, reducing future status hot-path refactor risk.
- Main risk: compatibility drift in compact_run output. Mitigated by direct read-model parity smoke, run-history/status smokes, status CLI validation, and clean-start canary smoke-suite execution.
- Design judgment: this is deliberately smaller than moving all of compact_run. Benchmark summaries, learning ledgers, active-user pilot summaries, and session runtime projection stay in status.py until their real bounded-context call sites justify a separate extraction.

Validation
- python3 examples/control_plane/run-compaction-readmodel-smoke.py
- python3 -m loopx.cli canary smoke-suite --suite full-public --script examples/control_plane/run-compaction-readmodel-smoke.py --timeout-seconds 60 --no-progress
- python3 examples/control_plane/run-history-readmodel-smoke.py
- python3 examples/control_plane/status-contract-readmodel-smoke.py
- python3 examples/control_plane/status-quota-review-packet-parity-smoke.py
- python3 examples/control_plane/status-goal-filter-smoke.py
- python3 examples/control_plane/status-markdown-smoke.py
- loopx --format json status --goal-id loopx-meta --limit 1
- python3 -m compileall -q loopx/status.py loopx/control_plane/runtime/run_compaction.py examples/control_plane/run-compaction-readmodel-smoke.py
- git diff --check origin/main...HEAD

Boundary scan
- Added lines scanned clean for local paths, credentials, raw logs, trajectories, verifier text, and internal markers.

Notes
- status.py decreased from 8732 lines before the previous latest_run extraction work to 8709 lines in this branch.
- This PR does not run benchmark jobs and does not touch benchmark raw evidence, scoring, adapter semantics, or production actions.
