### PR TITLE
docs: add finance connector probe packet

### DIFF
--- a/docs/capabilities/value-connectors/README.md
+++ b/docs/capabilities/value-connectors/README.md
@@ -72,7 +72,7 @@ association, timestamp, and URL metadata, then emits either
 | `github_public_channel` | implemented starter | yes | none |
 | `github_public_reply_monitor` | implemented starter | yes | none |
 | `social_browser_x` | ego-browser-backed profile | install-check, public-handle packet, and gated plan | exact profile/post/reply gate required |
-| `finance_market_snapshot` | planned finance profile | plan and user prompt surface | account, private portfolio, trading, and paid-data gates required |
+| `finance_market_snapshot` | probed candidate profile | plan, user prompt surface, and [no-credential probe packet](finance-market-snapshot-probe.md) | account, private portfolio, trading, and paid-data gates required |
 | `botmail_identity` | host connector profile | install-check only | exact send gate required |
 | `community_channel` | host/browser connector profile | install-check and plan | exact account/message gate required |
 
@@ -191,6 +191,13 @@ loopx value-connectors plan \
   --kill-condition "source terms, freshness, or symbol mapping cannot be verified" \
   --format json
 ```
+
+See the [no-credential probe packet](finance-market-snapshot-probe.md) for the
+current source findings. The short version: Eastmoney public quote metadata is
+reachable as a `source_unverified` canary, GitHub OSS wrappers are fallback
+candidates that still need source-origin checks, and Futu/OpenD is gated until
+the user provides a local daemon, account permission, API agreements, and quote
+rights.
 
 ## Protocol
 

--- a/docs/capabilities/value-connectors/finance-market-snapshot-probe.md
+++ b/docs/capabilities/value-connectors/finance-market-snapshot-probe.md
@@ -1,0 +1,100 @@
+# Finance Market Snapshot Probe Packet
+
+Status: public-safe no-credential probe packet for `finance_market_snapshot`.
+
+This packet records what LoopX can safely learn before building a live finance
+connector. It is not a trading adapter, not an account adapter, and not an
+investment-advice surface.
+
+## Scope
+
+Allowed in this probe:
+
+- public, no-credential network reads;
+- source and endpoint metadata;
+- compact field-shape observations;
+- source freshness, terms, and uncertainty labels;
+- user gates for account, paid-data, private portfolio, or trading surfaces.
+
+Forbidden in this probe:
+
+- account login, Futu OpenD connection, private portfolio reads, account ids,
+  paid-data signup, captcha handling, credentials, or cookies;
+- trading, order placement, portfolio mutation, or production actions;
+- price targets, suitability claims, guaranteed-return wording, or personal
+  investment advice;
+- raw provider payloads or raw paid-provider responses in LoopX state.
+
+## Source Findings
+
+| Source | Probe result | Candidate use | Gate |
+| --- | --- | --- | --- |
+| Futu OpenAPI / OpenD | Official docs describe OpenD as the gateway program and require local/cloud OpenD setup before API use. Official quota docs also describe quote-right permissions and market-specific data rights. | High-quality user-owned terminal path when the user already has OpenD, API agreements, account permission, and quote rights. | Exact user gate before any connection, login, quote subscription, account metadata, portfolio, or trade API call. |
+| Eastmoney public quote endpoint | No-credential probe reached `https://push2.eastmoney.com/api/qt/stock/get` for two A-share examples and observed compact JSON with a `data` object plus allowlist-shaped quote fields. | First public metadata canary for A-share quote snapshots. | Treat as `source_unverified` until source terms, stability, throttling, symbol mapping, and freshness semantics are reviewed. |
+| Eastmoney quote page | No-credential probe reached `https://quote.eastmoney.com/sh600519.html` as public HTML. | Human-visible source URL and fallback inspection label. | Do not scrape hidden page state into LoopX; prefer compact endpoint field allowlists. |
+| AKShare | Public GitHub repo describes a broad Python financial data interface and explicitly warns that data is for academic/reference use and not investment advice. | GitHub OSS fallback for China-market quote, fund, news, and announcement connectors. | Preserve upstream data-risk and non-advice warnings; check source-origin and interface freshness per function. |
+| efinance | PyPI describes an Eastmoney-based open-source Python library for stock, fund, and futures data, with MIT metadata. | Lightweight Eastmoney-backed fallback candidate for China-market snapshots. | Same Eastmoney source-origin, freshness, and terms gate applies. |
+| yfinance | Public GitHub repo describes a Yahoo Finance API wrapper and says it is unaffiliated with Yahoo, for research/educational or personal-use contexts subject to Yahoo terms. | US-stock/ETF fallback candidate for non-China symbols. | Terms/use-right review required before automated or repeated use. |
+| py-futu-api | Public GitHub repo is the Futu OpenAPI Python SDK. | SDK layer after the Futu user gate, not a no-credential fallback. | Requires OpenD/account/quote-right gate first. |
+
+## Candidate Packet Shape
+
+```json
+{
+  "schema_version": "finance_market_snapshot_probe_packet_v0",
+  "connector_id": "finance_market_snapshot",
+  "external_reads_performed": true,
+  "external_writes_performed": false,
+  "account_signup_performed": false,
+  "private_source_content_read": false,
+  "raw_provider_payload_recorded": false,
+  "non_investment_advice": true,
+  "sources": [
+    {
+      "source_id": "eastmoney_public_quote",
+      "access_mode": "public_metadata_only",
+      "probe_status": "reachable",
+      "freshness_label": "source_unverified",
+      "observed_shape": ["symbol", "name", "quote_fields", "provider_timestamp"],
+      "missing_or_unverified": ["terms", "throttling", "official_field_map"]
+    },
+    {
+      "source_id": "futu_opend",
+      "access_mode": "user_owned_terminal_required",
+      "probe_status": "gated",
+      "freshness_label": "manual_review_required",
+      "missing_or_unverified": ["OpenD state", "API agreement", "quote rights"]
+    },
+    {
+      "source_id": "github_oss_fallbacks",
+      "access_mode": "public_metadata_only",
+      "probe_status": "candidate",
+      "freshness_label": "manual_review_required",
+      "missing_or_unverified": ["source terms", "function-level origin", "maintenance health"]
+    }
+  ]
+}
+```
+
+## Recommended Next Slice
+
+Implement a dry-run-only `finance_market_snapshot` canary before any live
+adapter:
+
+1. accept a tiny symbol allowlist such as `sh600519` and `sz000001`;
+2. call only the public Eastmoney quote endpoint with explicit timeout and user
+   agent;
+3. emit only compact allowlisted fields and field-presence metadata, not raw
+   provider payloads;
+4. label every result `source_unverified` until terms/freshness are reviewed;
+5. fail closed to a user gate for Futu/OpenD, private portfolio, paid data,
+   trading, captcha, or credential paths.
+
+## Sources
+
+- [Futu API introduction](https://openapi.futunn.com/futu-api-doc/en/intro/intro.html)
+- [Moomoo/Futu authorities and quota](https://openapi.moomoo.com/moomoo-api-doc/en/intro/authority.html)
+- [AKShare GitHub repository](https://github.com/akfamily/akshare)
+- [efinance PyPI package](https://pypi.org/project/efinance/)
+- [yfinance GitHub repository](https://github.com/ranaroussi/yfinance)
+- [Futu OpenAPI Python SDK](https://github.com/FutunnOpen/py-futu-api)

--- a/docs/reference/protocols/value-connector-plan-v0.md
+++ b/docs/reference/protocols/value-connector-plan-v0.md
@@ -77,6 +77,7 @@ loopx value-connectors plan \
 | `github_public_channel_probe_packet_v0` | Starter connector output for public GitHub issue/PR/discussion metadata. |
 | `github_public_reply_monitor_packet_v0` | Starter connector output for public maintainer reply detection after a LoopX comment. |
 | `finance_market_snapshot_profile_v0` | Candidate profile for quote/fund/news/announcement pulls with source, freshness, uncertainty, and no-investment-advice gates. |
+| `finance_market_snapshot_probe_packet_v0` | No-credential public-source probe packet for Eastmoney/Futu/GitHub OSS source readiness, gates, and fallback decisions. |
 | `value_connector_install_check_packet_v0` | Local install/use checklist for connector starters. |
 
 ## Boundaries

--- a/examples/value-connectors-finance-probe-doc-smoke.py
+++ b/examples/value-connectors-finance-probe-doc-smoke.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Smoke-test the public finance connector probe packet."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+PACKET = ROOT / "docs" / "capabilities" / "value-connectors" / "finance-market-snapshot-probe.md"
+README = ROOT / "docs" / "capabilities" / "value-connectors" / "README.md"
+PROTOCOL = ROOT / "docs" / "reference" / "protocols" / "value-connector-plan-v0.md"
+
+
+def main() -> int:
+    packet = PACKET.read_text(encoding="utf-8")
+    readme = README.read_text(encoding="utf-8")
+    protocol = PROTOCOL.read_text(encoding="utf-8")
+
+    required = [
+        "finance_market_snapshot_probe_packet_v0",
+        "Eastmoney public quote endpoint",
+        "Futu OpenAPI / OpenD",
+        "AKShare",
+        "efinance",
+        "yfinance",
+        "py-futu-api",
+        "source_unverified",
+        "manual_review_required",
+        "non_investment_advice",
+        "raw_provider_payload_recorded",
+    ]
+    for text in required:
+        assert text in packet, text
+
+    forbidden_claims = [
+        "is an investment advice engine",
+        "emits price targets",
+        "guarantees returns",
+        '"trading_enabled": true',
+    ]
+    lower_packet = packet.lower()
+    for text in forbidden_claims:
+        assert text not in lower_packet, text
+
+    assert "raw provider payloads or raw paid-provider responses" in packet
+    assert "account login" in packet and "credentials" in packet
+    assert "trading, order placement" in packet
+    assert "no-credential probe packet" in readme
+    assert "finance_market_snapshot_probe_packet_v0" in protocol
+
+    print("value-connectors-finance-probe-doc-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a public-safe no-credential finance_market_snapshot probe packet
- record Eastmoney public quote canary readiness, Futu/OpenD user gates, and GitHub OSS fallback candidates
- link the probe packet from the value connector README and protocol records
- add a focused doc smoke for the finance probe packet

## Validation
- python3 examples/value-connectors-finance-probe-doc-smoke.py
- ./scripts/loopx --format json check --scan-path docs/capabilities/value-connectors/README.md --scan-path docs/capabilities/value-connectors/finance-market-snapshot-probe.md --scan-path docs/reference/protocols/value-connector-plan-v0.md --scan-path examples/value-connectors-finance-probe-doc-smoke.py
- ./scripts/loopx --format json value-connectors plan --connector-id finance_market_snapshot --connector-kind custom_connector --channel "public finance metadata snapshot" --stage observe --target-ref "Eastmoney public quote canary and GitHub OSS fallback readiness" --target-url https://www.eastmoney.com --external-read --value-axis capability --money-metric "reduce analyst time spent collecting public market facts" --success-metric "probe packet records source readiness, freshness labels, and exact gates without raw provider payloads" --kill-condition "source terms, freshness, symbol mapping, or account-auth boundary is uncertain"
- git diff --check

Note: loopx check reported the pre-existing loopx-meta duplicate-index warning, with public boundary scan clean for the four changed files.