### PR TITLE
Slim auto-research launch and successor helpers

### DIFF
--- a/examples/auto-research-user-contract-entry-smoke.py
+++ b/examples/auto-research-user-contract-entry-smoke.py
@@ -23,13 +23,14 @@ from loopx.capabilities.auto_research.user_contract import (  # noqa: E402
 )
 from loopx.capabilities.auto_research.cli import (  # noqa: E402
     _default_auto_research_start_workspace,
-    _start_attach_visible,
-    _start_codex_trust_workspace,
-    _start_wake_visible_after_launch,
 )
 from loopx.capabilities.auto_research.bootstrap_contract import (  # noqa: E402
     auto_research_start_command_text,
     build_auto_research_contract_acceptance,
+)
+from loopx.capabilities.multi_agent.visible_launch_policy import (  # noqa: E402
+    resolve_codex_trust_workspace,
+    resolve_visible_launch_policy,
 )
 
 
@@ -184,13 +185,32 @@ def assert_start_wake_contract() -> None:
         encoding="utf-8"
     )
     assert "wake_visible_after_launch=bool(args.wake_visible_after_launch)" not in cli_source
-    assert cli_source.count("wake_visible_after_launch = _start_wake_visible_after_launch(args)") == 2
-    assert "codex_trust_visible_workspace = _start_codex_trust_workspace(args)" in cli_source
+    assert "def _start_wake_visible_after_launch" not in cli_source
+    assert "def _start_attach_visible" not in cli_source
+    assert "def _start_codex_trust_workspace" not in cli_source
+    assert "wake_visible_multi_agent_panes" not in cli_source
+    assert "resolve_visible_launch_policy" in cli_source
+    assert "make_visible_launcher_callback" in cli_source
     start_source = cli_source.split('elif args.auto_research_command == "start":', 1)[1].split(
         'elif args.auto_research_command == "demo-supervisor":',
         1,
     )[0]
     assert "if args.codex_trust_workspace is None" not in start_source
+
+    def start_policy(args: Namespace):
+        return resolve_visible_launch_policy(
+            args,
+            launch_visible=bool(args.execute and not args.headless),
+            default_wake_allowed=bool(args.execute and not args.headless),
+            default_attach_allowed=bool(args.execute and not args.headless),
+        )
+
+    def trust(args: Namespace) -> bool:
+        return resolve_codex_trust_workspace(
+            args,
+            launch_visible=bool(args.execute and not args.headless),
+            default=True,
+        )
 
     default_visible = Namespace(
         execute=True,
@@ -200,15 +220,10 @@ def assert_start_wake_contract() -> None:
         no_attach=False,
         codex_trust_workspace=None,
     )
-    assert _start_wake_visible_after_launch(default_visible) is True
-    assert _start_codex_trust_workspace(default_visible) is True
-    assert (
-        _start_attach_visible(
-            default_visible,
-            wake_visible_after_launch=_start_wake_visible_after_launch(default_visible),
-        )
-        is False
-    )
+    default_policy = start_policy(default_visible)
+    assert default_policy.wake_visible_after_launch is True
+    assert trust(default_visible) is True
+    assert default_policy.attach is False
 
     attach_takeover = Namespace(
         execute=True,
@@ -218,15 +233,10 @@ def assert_start_wake_contract() -> None:
         no_attach=False,
         codex_trust_workspace=None,
     )
-    assert _start_wake_visible_after_launch(attach_takeover) is False
-    assert _start_codex_trust_workspace(attach_takeover) is True
-    assert (
-        _start_attach_visible(
-            attach_takeover,
-            wake_visible_after_launch=_start_wake_visible_after_launch(attach_takeover),
-        )
-        is True
-    )
+    takeover_policy = start_policy(attach_takeover)
+    assert takeover_policy.wake_visible_after_launch is False
+    assert trust(attach_takeover) is True
+    assert takeover_policy.attach is True
 
     explicit_wake = Namespace(
         execute=True,
@@ -236,15 +246,10 @@ def assert_start_wake_contract() -> None:
         no_attach=False,
         codex_trust_workspace=None,
     )
-    assert _start_wake_visible_after_launch(explicit_wake) is True
-    assert _start_codex_trust_workspace(explicit_wake) is True
-    assert (
-        _start_attach_visible(
-            explicit_wake,
-            wake_visible_after_launch=_start_wake_visible_after_launch(explicit_wake),
-        )
-        is False
-    )
+    explicit_wake_policy = start_policy(explicit_wake)
+    assert explicit_wake_policy.wake_visible_after_launch is True
+    assert trust(explicit_wake) is True
+    assert explicit_wake_policy.attach is False
 
     manual_takeover = Namespace(
         execute=True,
@@ -254,15 +259,10 @@ def assert_start_wake_contract() -> None:
         no_attach=False,
         codex_trust_workspace=None,
     )
-    assert _start_wake_visible_after_launch(manual_takeover) is False
-    assert _start_codex_trust_workspace(manual_takeover) is True
-    assert (
-        _start_attach_visible(
-            manual_takeover,
-            wake_visible_after_launch=_start_wake_visible_after_launch(manual_takeover),
-        )
-        is True
-    )
+    manual_policy = start_policy(manual_takeover)
+    assert manual_policy.wake_visible_after_launch is False
+    assert trust(manual_takeover) is True
+    assert manual_policy.attach is True
 
     background_manual = Namespace(
         execute=True,
@@ -272,15 +272,10 @@ def assert_start_wake_contract() -> None:
         no_attach=True,
         codex_trust_workspace=None,
     )
-    assert _start_wake_visible_after_launch(background_manual) is False
-    assert _start_codex_trust_workspace(background_manual) is True
-    assert (
-        _start_attach_visible(
-            background_manual,
-            wake_visible_after_launch=_start_wake_visible_after_launch(background_manual),
-        )
-        is False
-    )
+    background_policy = start_policy(background_manual)
+    assert background_policy.wake_visible_after_launch is False
+    assert trust(background_manual) is True
+    assert background_policy.attach is False
 
     headless = Namespace(
         execute=True,
@@ -290,15 +285,10 @@ def assert_start_wake_contract() -> None:
         no_attach=False,
         codex_trust_workspace=None,
     )
-    assert _start_wake_visible_after_launch(headless) is False
-    assert _start_codex_trust_workspace(headless) is False
-    assert (
-        _start_attach_visible(
-            headless,
-            wake_visible_after_launch=_start_wake_visible_after_launch(headless),
-        )
-        is False
-    )
+    headless_policy = start_policy(headless)
+    assert headless_policy.wake_visible_after_launch is False
+    assert trust(headless) is False
+    assert headless_policy.attach is False
 
     explicit_no_trust = Namespace(
         execute=True,
@@ -308,7 +298,7 @@ def assert_start_wake_contract() -> None:
         no_attach=False,
         codex_trust_workspace=False,
     )
-    assert _start_codex_trust_workspace(explicit_no_trust) is False
+    assert trust(explicit_no_trust) is False
 
     explicit_trust = Namespace(
         execute=True,
@@ -318,7 +308,7 @@ def assert_start_wake_contract() -> None:
         no_attach=False,
         codex_trust_workspace=True,
     )
-    assert _start_codex_trust_workspace(explicit_trust) is True
+    assert trust(explicit_trust) is True
 
 
 def main() -> None:

--- a/examples/auto-research-visible-launch-policy-smoke.py
+++ b/examples/auto-research-visible-launch-policy-smoke.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx.capabilities.multi_agent.visible_launch_policy import (
+    make_visible_wake_callback,
+    resolve_codex_trust_workspace,
+    resolve_visible_launch_policy,
+)
+
+
+AUTO_RESEARCH_CLI = ROOT / "loopx" / "capabilities" / "auto_research" / "cli.py"
+
+
+def ns(**values: object) -> argparse.Namespace:
+    defaults = {
+        "attach": False,
+        "no_attach": False,
+        "wake_visible_after_launch": None,
+        "codex_trust_workspace": None,
+    }
+    defaults.update(values)
+    return argparse.Namespace(**defaults)
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise AssertionError(message)
+
+
+def assert_start_policy() -> None:
+    policy = resolve_visible_launch_policy(
+        ns(),
+        launch_visible=True,
+        default_wake_allowed=True,
+        default_attach_allowed=True,
+    )
+    require(policy.launch_visible is True, "start should launch visible panes")
+    require(policy.wake_visible_after_launch is True, "start should default to evidence-first wake")
+    require(policy.attach is False, "start should not attach before the default wake")
+    require(
+        resolve_codex_trust_workspace(ns(), launch_visible=True, default=True) is True,
+        "start default workspace should be trusted to avoid first-screen trust prompt",
+    )
+
+    takeover = resolve_visible_launch_policy(
+        ns(attach=True),
+        launch_visible=True,
+        default_wake_allowed=True,
+        default_attach_allowed=True,
+    )
+    require(takeover.wake_visible_after_launch is False, "operator takeover should disable default wake")
+    require(takeover.attach is True, "explicit attach should attach")
+
+
+def assert_demo_policy_preserves_headless_visible_mix() -> None:
+    policy = resolve_visible_launch_policy(
+        ns(),
+        launch_visible=True,
+        default_wake_allowed=False,
+        default_attach_allowed=False,
+    )
+    require(policy.launch_visible is True, "explicit visible launch should still launch")
+    require(policy.wake_visible_after_launch is False, "headless visible mix should not default wake")
+    require(policy.attach is False, "headless visible mix should not default attach")
+
+    require(
+        resolve_codex_trust_workspace(ns(), launch_visible=True, default=False) is False,
+        "user-provided demo workspace should not be trusted by default",
+    )
+    require(
+        resolve_codex_trust_workspace(
+            ns(codex_trust_workspace=True),
+            launch_visible=True,
+            default=False,
+        )
+        is True,
+        "explicit trust flag should override the workspace default",
+    )
+
+
+def assert_conflicts() -> None:
+    try:
+        resolve_visible_launch_policy(
+            ns(attach=True, no_attach=True),
+            launch_visible=True,
+            default_wake_allowed=True,
+            default_attach_allowed=True,
+        )
+    except ValueError as exc:
+        require("--attach cannot be combined with --no-attach" in str(exc), str(exc))
+    else:
+        raise AssertionError("expected attach/no-attach conflict")
+
+    try:
+        resolve_visible_launch_policy(
+            ns(attach=True, wake_visible_after_launch=True),
+            launch_visible=True,
+            default_wake_allowed=True,
+            default_attach_allowed=True,
+        )
+    except ValueError as exc:
+        require("--wake-visible-after-launch" in str(exc), str(exc))
+    else:
+        raise AssertionError("expected attach/wake conflict")
+
+
+def assert_auto_research_consumes_generic_policy() -> None:
+    source = AUTO_RESEARCH_CLI.read_text(encoding="utf-8")
+    for removed in (
+        "def _start_wake_visible_after_launch",
+        "def _start_attach_visible",
+        "def _start_codex_trust_workspace",
+        "wake_visible_multi_agent_panes",
+    ):
+        require(removed not in source, f"auto-research CLI still owns generic visible policy: {removed}")
+    for marker in (
+        "resolve_visible_launch_policy",
+        "resolve_codex_trust_workspace",
+        "make_visible_wake_callback",
+    ):
+        require(marker in source, f"auto-research CLI missing generic policy helper: {marker}")
+    wake_callback = make_visible_wake_callback(tmux_bin="tmux")
+    require(callable(wake_callback), "wake helper should return a callback")
+
+
+def main() -> None:
+    assert_start_policy()
+    assert_demo_policy_preserves_headless_visible_mix()
+    assert_conflicts()
+    assert_auto_research_consumes_generic_policy()
+    print("auto-research-visible-launch-policy-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/auto-research-worker-loop-smoke.py
+++ b/examples/auto-research-worker-loop-smoke.py
@@ -116,8 +116,8 @@ def main() -> int:
         assert payload["ok"] is True, payload
         assert payload["schema_version"] == "auto_research_worker_loop_v0", payload
         assert payload["mode"] == "execute", payload
-        assert payload["executed_turn_count"] == 5, payload
-        assert payload["completed_turn_count"] == 5, payload
+        assert payload["executed_turn_count"] == 6, payload
+        assert payload["completed_turn_count"] == 6, payload
         assert payload["stop_reason"] == "no_runnable_frontier", payload
         assert payload["selected_actions"] == [
             "write_research_contract",
@@ -125,6 +125,7 @@ def main() -> int:
             "run_dev_eval",
             "summarize_evidence",
             "run_holdout_eval",
+            "write_evaluation_summary",
         ], payload
         evidence_turn = next(
             turn for turn in payload["turns"] if turn.get("selected_action") == "run_dev_eval"
@@ -143,6 +144,11 @@ def main() -> int:
         )
         assert holdout_turn["holdout_metric"] == 4.5, holdout_turn
         assert holdout_turn["completion_status"] == "done", holdout_turn
+        summary_turn = next(
+            turn for turn in payload["turns"] if turn.get("selected_action") == "write_evaluation_summary"
+        )
+        assert summary_turn["completion_status"] == "done", summary_turn
+        assert summary_turn["selected_todo_id"], summary_turn
         final_round = [turn for turn in payload["turns"] if turn.get("round") == 3]
         assert final_round and all(turn["mode"] == "no_action" for turn in final_round), payload
         assert_public_safe(payload)

--- a/examples/auto-research-worker-turn-smoke.py
+++ b/examples/auto-research-worker-turn-smoke.py
@@ -278,6 +278,7 @@ def main() -> int:
         assert executed["live_evidence"]["written"] is True, executed
         assert executed["live_evidence"]["evidence_source"] == "live_codex_lane_output", executed
         assert executed["live_evidence"]["dev_metric"] == 4.0, executed
+        assert executed["successor_todos"]["schema_version"] == "multi_agent_role_successor_todos_v0", executed
         assert executed["successor_todos"]["source"] == "role_profile_todo_command_template", executed
         assert executed["successor_todos"]["role_id"] == "evidence_runner", executed
         assert executed["successor_todos"]["action"] == "run_dev_eval", executed

--- a/examples/multi-agent-role-successor-todos-smoke.py
+++ b/examples/multi-agent-role-successor-todos-smoke.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Smoke-test generic role-declared successor todo execution."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.capabilities.multi_agent.role_successor import (  # noqa: E402
+    MULTI_AGENT_ROLE_SUCCESSOR_TODOS_SCHEMA_VERSION,
+    apply_role_successor_todos,
+    first_successor_followup,
+)
+
+
+GOAL_ID = "multi-agent-successor-smoke"
+SOURCE_TODO_ID = "todo_source123456"
+
+
+def write_minimal_state(path: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "# Multi-Agent Successor Smoke",
+                "",
+                "## User Todo / Owner Review Reading Queue",
+                "",
+                "## Agent Todo",
+                "",
+                "- [ ] [P0] Run source action. <!-- todo_id=todo_source123456 status=open task_class=advancement_task action_kind=run_dev_eval claimed_by=agent-a -->",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def write_registry(path: Path, *, project: Path, state_file: Path, runtime_root: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "common_runtime_root": str(runtime_root),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "repo": str(project),
+                        "state_file": str(state_file),
+                        "coordination": {
+                            "registered_agents": ["agent-a", "agent-b"],
+                        },
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+
+def successor_spec(*, target_agent_id: str = "agent-b", condition: object = "always") -> dict[str, object]:
+    return {
+        "condition": condition,
+        "target_agent_id": target_agent_id,
+        "target_role_id": "evidence_runner",
+        "task_class": "advancement_task",
+        "action_kind": "run_holdout_eval",
+        "text": "[P0] Run holdout evidence.",
+        "todo_command_template": (
+            "loopx todo add --goal-id {goal_id_shell} --role agent "
+            "--text {text_shell} --task-class {task_class_shell} "
+            "--action-kind {action_kind_shell} --claimed-by {target_agent_id_shell} "
+            "--unblocks-todo-id {source_todo_id_shell}"
+        ),
+    }
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        root = Path(temp_dir)
+        project = root / "project"
+        project.mkdir()
+        state_file = project / "ACTIVE_GOAL_STATE.md"
+        registry = root / "registry.json"
+        runtime_root = root / "runtime"
+        write_minimal_state(state_file)
+        write_registry(registry, project=project, state_file=state_file, runtime_root=runtime_root)
+
+        preview = apply_role_successor_todos(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            source_todo_id=SOURCE_TODO_ID,
+            current_agent_id="agent-a",
+            role_id="evidence_runner",
+            action="run_dev_eval",
+            successor_specs=[successor_spec()],
+            decision_summary={"dev_promotion_candidate_count": 1},
+            execute=False,
+        )
+        assert preview["schema_version"] == MULTI_AGENT_ROLE_SUCCESSOR_TODOS_SCHEMA_VERSION, preview
+        assert preview["source"] == "role_profile_todo_command_template", preview
+        assert preview["needed"] is True, preview
+        assert preview["executed"] is False, preview
+        successor = preview["successors"][0]
+        assert successor["target_agent_id"] == "agent-b", successor
+        assert "--claimed-by agent-b" in str(successor["todo_command"]), successor
+        assert first_successor_followup(preview)["action_kind"] == "run_holdout_eval", preview
+
+        skipped = apply_role_successor_todos(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            source_todo_id=SOURCE_TODO_ID,
+            current_agent_id="agent-a",
+            role_id="evidence_runner",
+            action="run_dev_eval",
+            successor_specs=[
+                successor_spec(
+                    condition={
+                        "all": [
+                            {
+                                "path": "decision_summary.dev_promotion_candidate_count",
+                                "op": "gt",
+                                "value": 1,
+                                "fail_reason": "no_second_candidate",
+                            }
+                        ]
+                    }
+                )
+            ],
+            decision_summary={"dev_promotion_candidate_count": 1},
+            execute=False,
+        )
+        assert skipped["needed"] is False, skipped
+        assert skipped["reason"] == "no_second_candidate", skipped
+
+        executed = apply_role_successor_todos(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            source_todo_id=SOURCE_TODO_ID,
+            current_agent_id="agent-a",
+            role_id="evidence_runner",
+            action="run_dev_eval",
+            successor_specs=[successor_spec()],
+            decision_summary={"dev_promotion_candidate_count": 1},
+            execute=True,
+        )
+        assert executed["executed"] is True, executed
+        added = executed["successors"][0]
+        assert added["added"] is True, added
+        assert added["claimed_by"] == "agent-b", added
+        state_text = state_file.read_text(encoding="utf-8")
+        assert "claimed_by=agent-b" in state_text, state_text
+        assert f"unblocks_todo_id={SOURCE_TODO_ID}" in state_text, state_text
+
+        try:
+            apply_role_successor_todos(
+                registry_path=registry,
+                goal_id=GOAL_ID,
+                source_todo_id=SOURCE_TODO_ID,
+                current_agent_id="agent-a",
+                role_id="evidence_runner",
+                action="run_dev_eval",
+                successor_specs=[successor_spec(target_agent_id="missing-agent")],
+                decision_summary={},
+                execute=False,
+            )
+        except ValueError as exc:
+            assert "successor target_agent_id 'missing-agent' is not registered" in str(exc), exc
+        else:
+            raise AssertionError("missing successor target agent should fail closed")
+
+    print("multi-agent-role-successor-todos-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -33,6 +33,12 @@ from .user_contract import (
     build_auto_research_user_contract,
     infer_auto_research_output_language,
 )
+from ..multi_agent.visible_launch_policy import (
+    make_visible_launcher_callback,
+    make_visible_wake_callback,
+    resolve_codex_trust_workspace,
+    resolve_visible_launch_policy,
+)
 from ...history import load_registry
 from ...paths import resolve_runtime_root
 from ...quota import build_quota_should_run
@@ -40,7 +46,6 @@ from ...rollout_event_log import load_rollout_events, rollout_event_log_path
 from ...status import collect_status
 from ...visible_multi_agent_launcher import (
     execute_visible_multi_agent_launcher,
-    wake_visible_multi_agent_panes,
 )
 
 
@@ -109,42 +114,6 @@ def _default_auto_research_start_workspace(goal_id: str) -> str:
         / _demo_goal_suffix(goal_id, fallback="run")
         / "visible-workspace"
     )
-
-
-def _start_wake_visible_after_launch(args: argparse.Namespace) -> bool:
-    """Return whether `auto-research start` should wake visible lanes after launch."""
-
-    if not args.execute or args.headless:
-        return False
-    wake_setting = getattr(args, "wake_visible_after_launch", None)
-    if wake_setting is None and getattr(args, "attach", False):
-        return False
-    return bool(wake_setting is not False)
-
-
-def _start_attach_visible(args: argparse.Namespace, *, wake_visible_after_launch: bool) -> bool:
-    """Return whether `auto-research start` should attach to visible lanes."""
-
-    launch_visible = bool(args.execute and not args.headless)
-    return bool(
-        args.attach
-        or (
-            launch_visible
-            and not args.no_attach
-            and not wake_visible_after_launch
-        )
-    )
-
-
-def _start_codex_trust_workspace(args: argparse.Namespace) -> bool:
-    """Return whether visible start should avoid Codex's workspace trust prompt."""
-
-    if not args.execute or args.headless:
-        return False
-    trust_setting = getattr(args, "codex_trust_workspace", None)
-    if trust_setting is None:
-        return True
-    return bool(trust_setting)
 
 
 def _resolve_demo_goal_surface(
@@ -892,14 +861,17 @@ def handle_auto_research_command(
                 output_language=args.language,
             )
         elif args.auto_research_command == "start":
-            if args.no_attach and args.attach:
-                raise ValueError("--attach cannot be combined with --no-attach")
-            wake_visible_after_launch = _start_wake_visible_after_launch(args)
-            if args.wake_visible_after_launch is True and args.attach:
-                raise ValueError(
+            launch_visible = bool(args.execute and not args.headless)
+            visible_policy = resolve_visible_launch_policy(
+                args,
+                launch_visible=launch_visible,
+                default_wake_allowed=launch_visible,
+                default_attach_allowed=launch_visible,
+                attach_wake_conflict_message=(
                     "--attach cannot be combined with --wake-visible-after-launch; "
                     "choose operator takeover (--attach) or evidence-first wake (--no-attach)"
-                )
+                ),
+            )
             goal_id, goal_surface_mode = _resolve_demo_goal_surface(
                 goal_id=args.goal_id,
                 demo_run_id=args.demo_run_id,
@@ -920,48 +892,36 @@ def handle_auto_research_command(
 
             visible_launcher: Callable[[dict[str, object], Path, str | None, Path], dict[str, object]] | None = None
             visible_wake: Callable[[str, list[str]], dict[str, object]] | None = None
-            launch_visible = bool(args.execute and not args.headless)
-            attach_visible = _start_attach_visible(
+            codex_trust_visible_workspace = resolve_codex_trust_workspace(
                 args,
-                wake_visible_after_launch=wake_visible_after_launch,
+                launch_visible=visible_policy.launch_visible,
+                default=True,
             )
-            codex_trust_visible_workspace = _start_codex_trust_workspace(args)
-            if launch_visible:
-                def visible_launcher(
-                    supervisor: dict[str, object],
-                    visible_registry_path: Path,
-                    visible_runtime_root_arg: str | None,
-                    _default_workspace: Path,
-                ) -> dict[str, object]:
-                    default_start_workspace = args.workspace is None
-                    visible_workspace = (
-                        _default_auto_research_start_workspace(goal_id)
-                        if default_start_workspace
-                        else args.workspace
-                    )
-                    create_visible_workspace = True if default_start_workspace else args.create_workspace
-                    return _execute_auto_research_demo_supervisor(
-                        supervisor,
-                        registry_path=visible_registry_path,
-                        runtime_root_arg=visible_runtime_root_arg,
-                        launcher=args.launcher,
-                        tmux_bin=args.tmux_bin,
-                        cli_bin=args.cli_bin,
-                        codex_bin=args.codex_bin,
-                        attach=attach_visible,
-                        replace_existing=args.replace_existing,
-                        workspace=visible_workspace,
-                        create_workspace=create_visible_workspace,
-                        codex_trust_workspace=codex_trust_visible_workspace,
-                    )
 
-                def visible_wake(session: str, lanes: list[str]) -> dict[str, object]:
-                    return wake_visible_multi_agent_panes(
-                        session_name=session,
-                        tmux_bin=args.tmux_bin,
-                        lanes=lanes,
-                        execute=True,
-                    )
+            def start_workspace_policy(_default_workspace: Path) -> tuple[str | None, bool, bool]:
+                default_start_workspace = args.workspace is None
+                return (
+                    _default_auto_research_start_workspace(goal_id)
+                    if default_start_workspace
+                    else args.workspace,
+                    True if default_start_workspace else args.create_workspace,
+                    codex_trust_visible_workspace,
+                )
+
+            visible_launcher = make_visible_launcher_callback(
+                launch_visible=visible_policy.launch_visible,
+                launch_executor=_execute_auto_research_demo_supervisor,
+                launcher=args.launcher,
+                tmux_bin=args.tmux_bin,
+                cli_bin=args.cli_bin,
+                codex_bin=args.codex_bin,
+                attach=visible_policy.attach,
+                replace_existing=args.replace_existing,
+                workspace_policy=start_workspace_policy,
+            )
+
+            if visible_policy.launch_visible:
+                visible_wake = make_visible_wake_callback(tmux_bin=args.tmux_bin)
 
             payload = run_auto_research_demo_e2e(
                 agent_id=AUTO_RESEARCH_START_AGENT_ID,
@@ -974,7 +934,7 @@ def handle_auto_research_command(
                 execute=args.execute,
                 run_worker_loop=bool(args.execute and args.headless),
                 worker_loop_rounds=args.worker_loop_rounds,
-                launch_visible=launch_visible,
+                launch_visible=visible_policy.launch_visible,
                 keep_workspace=args.keep_workspace,
                 registry_path=registry_path,
                 runtime_root_arg=runtime_root_arg,
@@ -988,7 +948,7 @@ def handle_auto_research_command(
                 append_evidence=append_start_evidence,
                 visible_launcher=visible_launcher,
                 visible_wake=visible_wake,
-                wake_visible_after_launch=wake_visible_after_launch,
+                wake_visible_after_launch=visible_policy.wake_visible_after_launch,
             )
         elif args.auto_research_command == "frontier":
             if bool(args.fixture) == bool(args.goal_id):
@@ -1181,58 +1141,44 @@ def handle_auto_research_command(
             visible_wake: Callable[[str, list[str]], dict[str, object]] | None = None
             auto_visible_launch = bool(args.execute and not args.headless)
             launch_visible = bool(args.launch_visible or auto_visible_launch)
-            if args.no_attach and args.attach:
-                raise ValueError("--attach cannot be combined with --no-attach")
-            wake_visible_after_launch = _start_wake_visible_after_launch(args)
-            if args.wake_visible_after_launch is True and args.attach:
-                raise ValueError(
+            visible_policy = resolve_visible_launch_policy(
+                args,
+                launch_visible=launch_visible,
+                default_wake_allowed=auto_visible_launch,
+                default_attach_allowed=auto_visible_launch,
+                attach_wake_conflict_message=(
                     "--wake-visible-after-launch cannot be combined with --attach; "
                     "wake evidence must be recorded before operator takeover"
-                )
-            attach_visible = _start_attach_visible(
-                args,
-                wake_visible_after_launch=wake_visible_after_launch,
+                ),
             )
-            if launch_visible:
-                def visible_launcher(
-                    supervisor: dict[str, object],
-                    visible_registry_path: Path,
-                    visible_runtime_root_arg: str | None,
-                    _default_workspace: Path,
-                ) -> dict[str, object]:
-                    demo_owned_workspace = args.workspace is None
-                    visible_workspace = (
-                        str(_default_workspace / "visible-user-workspace")
-                        if demo_owned_workspace
-                        else args.workspace
-                    )
-                    create_visible_workspace = True if demo_owned_workspace else args.create_workspace
-                    codex_trust_workspace = (
-                        demo_owned_workspace
-                        if args.codex_trust_workspace is None
-                        else bool(args.codex_trust_workspace)
-                    )
-                    return _execute_auto_research_demo_supervisor(
-                        supervisor,
-                        registry_path=visible_registry_path,
-                        runtime_root_arg=visible_runtime_root_arg,
-                        launcher=args.launcher,
-                        tmux_bin=args.tmux_bin,
-                        cli_bin=args.cli_bin,
-                        codex_bin=args.codex_bin,
-                        attach=attach_visible,
-                        replace_existing=args.replace_existing,
-                        workspace=visible_workspace,
-                        create_workspace=create_visible_workspace,
-                        codex_trust_workspace=codex_trust_workspace,
-                    )
-                def visible_wake(session: str, lanes: list[str]) -> dict[str, object]:
-                    return wake_visible_multi_agent_panes(
-                        session_name=session,
-                        tmux_bin=args.tmux_bin,
-                        lanes=lanes,
-                        execute=True,
-                    )
+            def demo_workspace_policy(default_workspace: Path) -> tuple[str | None, bool, bool]:
+                demo_owned_workspace = args.workspace is None
+                return (
+                    str(default_workspace / "visible-user-workspace")
+                    if demo_owned_workspace
+                    else args.workspace,
+                    True if demo_owned_workspace else args.create_workspace,
+                    resolve_codex_trust_workspace(
+                        args,
+                        launch_visible=visible_policy.launch_visible,
+                        default=demo_owned_workspace,
+                    ),
+                )
+
+            visible_launcher = make_visible_launcher_callback(
+                launch_visible=visible_policy.launch_visible,
+                launch_executor=_execute_auto_research_demo_supervisor,
+                launcher=args.launcher,
+                tmux_bin=args.tmux_bin,
+                cli_bin=args.cli_bin,
+                codex_bin=args.codex_bin,
+                attach=visible_policy.attach,
+                replace_existing=args.replace_existing,
+                workspace_policy=demo_workspace_policy,
+            )
+
+            if visible_policy.launch_visible:
+                visible_wake = make_visible_wake_callback(tmux_bin=args.tmux_bin)
 
             run_hidden_worker_loop = bool(args.execute and (args.headless or args.run_worker_loop))
             payload = run_auto_research_demo_e2e(
@@ -1246,7 +1192,7 @@ def handle_auto_research_command(
                 execute=args.execute,
                 run_worker_loop=run_hidden_worker_loop,
                 worker_loop_rounds=args.worker_loop_rounds,
-                launch_visible=launch_visible,
+                launch_visible=visible_policy.launch_visible,
                 keep_workspace=args.keep_workspace,
                 registry_path=registry_path,
                 runtime_root_arg=runtime_root_arg,
@@ -1263,7 +1209,7 @@ def handle_auto_research_command(
                 append_evidence=append_demo_e2e_evidence,
                 visible_launcher=visible_launcher,
                 visible_wake=visible_wake,
-                wake_visible_after_launch=wake_visible_after_launch,
+                wake_visible_after_launch=visible_policy.wake_visible_after_launch,
                 visible_live_evidence_wait_seconds=args.visible_live_evidence_wait_seconds,
             )
         else:

--- a/loopx/capabilities/auto_research/worker_runtime.py
+++ b/loopx/capabilities/auto_research/worker_runtime.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import re
-import shlex
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -36,13 +35,16 @@ from .research_state import (
     build_research_evidence_graph_from_rollout_events,
     normalize_auto_research_action,
 )
-from ...agent_registry import registered_agent_ids_from_registry
+from ..multi_agent.role_successor import (
+    apply_role_successor_todos,
+    first_successor_followup,
+)
 from ...history import load_registry
 from ...paths import resolve_runtime_root
 from ...quota import build_quota_should_run
 from ...rollout_event_log import load_rollout_events, rollout_event_log_path
 from ...status import collect_status
-from ...todos import add_goal_todo, complete_goal_todo
+from ...todos import complete_goal_todo
 
 
 AUTO_RESEARCH_WORKER_TURN_SCHEMA_VERSION = "auto_research_worker_turn_v0"
@@ -350,136 +352,6 @@ def _select_holdout_candidate(graph: dict[str, object]) -> dict[str, object]:
     )[0]
 
 
-def _value_at_path(payload: dict[str, object], path: str) -> object:
-    current: object = payload
-    for part in [part for part in path.split(".") if part]:
-        if not isinstance(current, dict) or part not in current:
-            return None
-        current = current[part]
-    return current
-
-
-def _compare_condition_value(actual: object, *, op: str, expected: object) -> bool:
-    if op in {"truthy", "exists"}:
-        return bool(actual)
-    if op in {"falsy", "missing"}:
-        return not bool(actual)
-    if op in {"eq", "=="}:
-        return actual == expected
-    if op in {"ne", "!="}:
-        return actual != expected
-    if op in {"gt", "gte", "lt", "lte", ">", ">=", "<", "<="}:
-        try:
-            actual_number = float(actual)  # type: ignore[arg-type]
-            expected_number = float(expected)  # type: ignore[arg-type]
-        except (TypeError, ValueError):
-            return False
-        return {
-            "gt": actual_number > expected_number,
-            ">": actual_number > expected_number,
-            "gte": actual_number >= expected_number,
-            ">=": actual_number >= expected_number,
-            "lt": actual_number < expected_number,
-            "<": actual_number < expected_number,
-            "lte": actual_number <= expected_number,
-            "<=": actual_number <= expected_number,
-        }[op]
-    return False
-
-
-def _successor_condition_met(
-    condition: object,
-    *,
-    decision_summary: dict[str, object],
-) -> tuple[bool, str]:
-    if not condition:
-        return True, "always"
-    if condition == "always":
-        return True, "always"
-    if not isinstance(condition, dict):
-        return False, "unsupported_successor_condition_shape"
-
-    context: dict[str, object] = {"decision_summary": decision_summary}
-    predicates = condition.get("all")
-    if not isinstance(predicates, list):
-        return False, "unsupported_successor_condition_shape"
-    if not predicates:
-        return True, "all"
-
-    for raw_predicate in predicates:
-        if not isinstance(raw_predicate, dict):
-            return False, "unsupported_successor_predicate_shape"
-        path = str(raw_predicate.get("path") or "")
-        op = str(raw_predicate.get("op") or "truthy")
-        expected = raw_predicate.get("value")
-        actual = _value_at_path(context, path)
-        if not _compare_condition_value(actual, op=op, expected=expected):
-            return False, str(raw_predicate.get("fail_reason") or f"condition_failed:{path}")
-    return True, "condition_met"
-
-
-def _resolve_successor_target_agent(
-    *,
-    registry_path: Path,
-    goal_id: str,
-    current_agent_id: str,
-    spec: dict[str, object],
-) -> str:
-    registered = registered_agent_ids_from_registry(registry_path, goal_id)
-    target = str(spec.get("target_agent_id") or "").strip()
-    if target == "$current_agent":
-        return current_agent_id
-    if target and target in registered:
-        return target
-    if target:
-        raise ValueError(f"successor target_agent_id {target!r} is not registered for goal {goal_id!r}")
-    target_role_id = str(spec.get("target_role_id") or "").strip()
-    if target_role_id:
-        raise ValueError(
-            f"successor target_role_id {target_role_id!r} requires an explicit registered target_agent_id"
-        )
-    for agent_id in registered:
-        if agent_id != current_agent_id:
-            return agent_id
-    return current_agent_id
-
-
-class _SafeFormatDict(dict[str, object]):
-    def __missing__(self, key: str) -> str:
-        return "{" + key + "}"
-
-
-def _render_successor_command_template(
-    *,
-    template: object,
-    goal_id: str,
-    source_todo_id: str,
-    target_agent_id: str,
-    task_class: str,
-    action_kind: str,
-    text: str,
-) -> str | None:
-    if not template:
-        return None
-    if not isinstance(template, str):
-        raise ValueError("successor todo_command_template must be a string")
-    values: dict[str, object] = {
-        "goal_id": goal_id,
-        "goal_id_shell": shlex.quote(goal_id),
-        "source_todo_id": source_todo_id,
-        "source_todo_id_shell": shlex.quote(source_todo_id),
-        "target_agent_id": target_agent_id,
-        "target_agent_id_shell": shlex.quote(target_agent_id),
-        "task_class": task_class,
-        "task_class_shell": shlex.quote(task_class),
-        "action_kind": action_kind,
-        "action_kind_shell": shlex.quote(action_kind),
-        "text": text,
-        "text_shell": shlex.quote(text),
-    }
-    return template.format_map(_SafeFormatDict(values))
-
-
 def _maybe_add_role_successor_todos(
     *,
     registry_path: Path,
@@ -491,111 +363,17 @@ def _maybe_add_role_successor_todos(
     decision_summary: dict[str, object],
     execute: bool,
 ) -> dict[str, object]:
-    specs = auto_research_successor_specs_for_action(role_id=role_id, action=action)
-    if not specs:
-        return {
-            "schema_version": "auto_research_role_successor_todos_v0",
-            "source": "role_profile_todo_command_template",
-            "needed": False,
-            "reason": "no_role_successor_spec",
-            "role_id": role_id,
-            "action": action,
-            "successors": [],
-        }
-
-    successors: list[dict[str, object]] = []
-    skipped: list[dict[str, object]] = []
-    for index, spec in enumerate(specs):
-        condition = spec.get("condition") or spec.get("when") or "always"
-        condition_met, reason = _successor_condition_met(
-            condition,
-            decision_summary=decision_summary,
-        )
-        action_kind = str(spec.get("action_kind") or "advance_todo")
-        task_class = str(spec.get("task_class") or "advancement_task")
-        text = str(spec.get("text") or f"Run {action_kind}.")
-        claimed_by = _resolve_successor_target_agent(
-            registry_path=registry_path,
-            goal_id=goal_id,
-            current_agent_id=agent_id,
-            spec=spec,
-        )
-        todo_command = _render_successor_command_template(
-            template=spec.get("todo_command_template"),
-            goal_id=goal_id,
-            source_todo_id=source_todo_id,
-            target_agent_id=claimed_by,
-            task_class=task_class,
-            action_kind=action_kind,
-            text=text,
-        )
-        successor_preview = {
-            "index": index,
-            "needed": condition_met,
-            "executed": False,
-            "condition": condition,
-            "reason": reason,
-            "target_agent_id": claimed_by,
-            "target_role_id": spec.get("target_role_id"),
-            "action_kind": action_kind,
-            "task_class": task_class,
-            "unblocks_todo_id": source_todo_id,
-            "todo_command": todo_command,
-            "source": "role_profile_todo_command_template",
-        }
-        if not condition_met:
-            skipped.append(successor_preview)
-            continue
-        if not execute:
-            successors.append(successor_preview)
-            continue
-        result = add_goal_todo(
-            registry_path=registry_path,
-            goal_id=goal_id,
-            role="agent",
-            text=text,
-            task_class=task_class,
-            action_kind=action_kind,
-            claimed_by=claimed_by,
-            unblocks_todo_id=source_todo_id,
-            dry_run=False,
-        )
-        successors.append(
-            successor_preview
-            | {
-                "executed": True,
-                "added": bool(result.get("added")),
-                "already_exists": bool(result.get("already_exists")),
-                "metadata_updated": bool(result.get("metadata_updated")),
-                "todo_id": result.get("todo_id"),
-                "claimed_by": result.get("claimed_by") or claimed_by,
-                "action_kind": result.get("action_kind") or action_kind,
-                "unblocks_todo_id": result.get("unblocks_todo_id") or source_todo_id,
-            }
-        )
-    return {
-        "schema_version": "auto_research_role_successor_todos_v0",
-        "source": "role_profile_todo_command_template",
-        "needed": bool(successors),
-        "executed": bool(execute and successors),
-        "role_id": role_id,
-        "action": action,
-        "successors": successors,
-        "skipped": skipped,
-        "reason": None if successors else (skipped[0]["reason"] if skipped else "no_role_successor_spec"),
-    }
-
-
-def _legacy_followup_from_successor_todos(successor_todos: dict[str, object]) -> dict[str, object]:
-    successors = successor_todos.get("successors") if isinstance(successor_todos, dict) else []
-    if isinstance(successors, list) and successors:
-        first = dict(successors[0])
-        first["needed"] = True
-        return first
-    return {
-        "needed": False,
-        "reason": successor_todos.get("reason") if isinstance(successor_todos, dict) else "no_successor",
-    }
+    return apply_role_successor_todos(
+        registry_path=registry_path,
+        goal_id=goal_id,
+        source_todo_id=source_todo_id,
+        current_agent_id=agent_id,
+        role_id=role_id,
+        action=action,
+        successor_specs=auto_research_successor_specs_for_action(role_id=role_id, action=action),
+        decision_summary=decision_summary,
+        execute=execute,
+    )
 
 
 def _generic_handoff_is_satisfied(
@@ -984,7 +762,7 @@ def run_auto_research_worker_turn(
             decision_summary=artifact["decision_summary"],
             execute=True,
         )
-        followup = _legacy_followup_from_successor_todos(successor_todos)
+        followup = first_successor_followup(successor_todos)
         completion = (
             _complete_selected_todo(
                 registry_path=registry_path,
@@ -1110,7 +888,7 @@ def run_auto_research_worker_turn(
             decision_summary=summary_artifact["decision_summary"],
             execute=True,
         )
-        followup = _legacy_followup_from_successor_todos(successor_todos)
+        followup = first_successor_followup(successor_todos)
         live_evidence: dict[str, object] | None = None
         if visible_lanes_accepted:
             live_evidence = build_live_codex_e2e_evidence_from_packet(
@@ -1237,7 +1015,7 @@ def run_auto_research_worker_turn(
         decision_summary=summary_artifact["decision_summary"],
         execute=True,
     )
-    followup = _legacy_followup_from_successor_todos(successor_todos)
+    followup = first_successor_followup(successor_todos)
 
     live_evidence: dict[str, object] | None = None
     if visible_lanes_accepted:

--- a/loopx/capabilities/multi_agent/role_successor.py
+++ b/loopx/capabilities/multi_agent/role_successor.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import shlex
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+
+from ...agent_registry import registered_agent_ids_from_registry
+from ...todos import add_goal_todo
+
+
+MULTI_AGENT_ROLE_SUCCESSOR_TODOS_SCHEMA_VERSION = "multi_agent_role_successor_todos_v0"
+ROLE_SUCCESSOR_SOURCE = "role_profile_todo_command_template"
+
+
+def _value_at_path(payload: Mapping[str, object], path: str) -> object:
+    current: object = payload
+    for part in [part for part in path.split(".") if part]:
+        if not isinstance(current, Mapping) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def _compare_condition_value(actual: object, *, op: str, expected: object) -> bool:
+    if op in {"truthy", "exists"}:
+        return bool(actual)
+    if op in {"falsy", "missing"}:
+        return not bool(actual)
+    if op in {"eq", "=="}:
+        return actual == expected
+    if op in {"ne", "!="}:
+        return actual != expected
+    if op in {"gt", "gte", "lt", "lte", ">", ">=", "<", "<="}:
+        try:
+            actual_number = float(actual)  # type: ignore[arg-type]
+            expected_number = float(expected)  # type: ignore[arg-type]
+        except (TypeError, ValueError):
+            return False
+        return {
+            "gt": actual_number > expected_number,
+            ">": actual_number > expected_number,
+            "gte": actual_number >= expected_number,
+            ">=": actual_number >= expected_number,
+            "lt": actual_number < expected_number,
+            "<": actual_number < expected_number,
+            "lte": actual_number <= expected_number,
+            "<=": actual_number <= expected_number,
+        }[op]
+    return False
+
+
+def _successor_condition_met(
+    condition: object,
+    *,
+    decision_summary: Mapping[str, object],
+) -> tuple[bool, str]:
+    if not condition:
+        return True, "always"
+    if condition == "always":
+        return True, "always"
+    if not isinstance(condition, Mapping):
+        return False, "unsupported_successor_condition_shape"
+
+    context: dict[str, object] = {"decision_summary": dict(decision_summary)}
+    predicates = condition.get("all")
+    if not isinstance(predicates, list):
+        return False, "unsupported_successor_condition_shape"
+    if not predicates:
+        return True, "all"
+
+    for raw_predicate in predicates:
+        if not isinstance(raw_predicate, Mapping):
+            return False, "unsupported_successor_predicate_shape"
+        path = str(raw_predicate.get("path") or "")
+        op = str(raw_predicate.get("op") or "truthy")
+        expected = raw_predicate.get("value")
+        actual = _value_at_path(context, path)
+        if not _compare_condition_value(actual, op=op, expected=expected):
+            return False, str(raw_predicate.get("fail_reason") or f"condition_failed:{path}")
+    return True, "condition_met"
+
+
+def _resolve_successor_target_agent(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    current_agent_id: str,
+    spec: Mapping[str, object],
+) -> str:
+    registered = registered_agent_ids_from_registry(registry_path, goal_id)
+    target = str(spec.get("target_agent_id") or "").strip()
+    if target == "$current_agent":
+        return current_agent_id
+    if target and target in registered:
+        return target
+    if target:
+        raise ValueError(f"successor target_agent_id {target!r} is not registered for goal {goal_id!r}")
+    target_role_id = str(spec.get("target_role_id") or "").strip()
+    if target_role_id:
+        raise ValueError(
+            f"successor target_role_id {target_role_id!r} requires an explicit registered target_agent_id"
+        )
+    for agent_id in registered:
+        if agent_id != current_agent_id:
+            return agent_id
+    return current_agent_id
+
+
+class _SafeFormatDict(dict[str, object]):
+    def __missing__(self, key: str) -> str:
+        return "{" + key + "}"
+
+
+def _render_successor_command_template(
+    *,
+    template: object,
+    goal_id: str,
+    source_todo_id: str,
+    target_agent_id: str,
+    task_class: str,
+    action_kind: str,
+    text: str,
+) -> str | None:
+    if not template:
+        return None
+    if not isinstance(template, str):
+        raise ValueError("successor todo_command_template must be a string")
+    values: dict[str, object] = {
+        "goal_id": goal_id,
+        "goal_id_shell": shlex.quote(goal_id),
+        "source_todo_id": source_todo_id,
+        "source_todo_id_shell": shlex.quote(source_todo_id),
+        "target_agent_id": target_agent_id,
+        "target_agent_id_shell": shlex.quote(target_agent_id),
+        "task_class": task_class,
+        "task_class_shell": shlex.quote(task_class),
+        "action_kind": action_kind,
+        "action_kind_shell": shlex.quote(action_kind),
+        "text": text,
+        "text_shell": shlex.quote(text),
+    }
+    return template.format_map(_SafeFormatDict(values))
+
+
+def apply_role_successor_todos(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    source_todo_id: str,
+    current_agent_id: str,
+    role_id: str,
+    action: str,
+    successor_specs: Iterable[object],
+    decision_summary: Mapping[str, object],
+    execute: bool,
+) -> dict[str, object]:
+    """Preview or create role-declared successor todos through LoopX state."""
+
+    specs = [dict(spec) for spec in successor_specs if isinstance(spec, Mapping)]
+    if not specs:
+        return {
+            "schema_version": MULTI_AGENT_ROLE_SUCCESSOR_TODOS_SCHEMA_VERSION,
+            "source": ROLE_SUCCESSOR_SOURCE,
+            "needed": False,
+            "reason": "no_role_successor_spec",
+            "role_id": role_id,
+            "action": action,
+            "successors": [],
+        }
+
+    successors: list[dict[str, object]] = []
+    skipped: list[dict[str, object]] = []
+    for index, spec in enumerate(specs):
+        condition = spec.get("condition") or spec.get("when") or "always"
+        condition_met, reason = _successor_condition_met(
+            condition,
+            decision_summary=decision_summary,
+        )
+        action_kind = str(spec.get("action_kind") or "advance_todo")
+        task_class = str(spec.get("task_class") or "advancement_task")
+        text = str(spec.get("text") or f"Run {action_kind}.")
+        claimed_by = _resolve_successor_target_agent(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            current_agent_id=current_agent_id,
+            spec=spec,
+        )
+        todo_command = _render_successor_command_template(
+            template=spec.get("todo_command_template"),
+            goal_id=goal_id,
+            source_todo_id=source_todo_id,
+            target_agent_id=claimed_by,
+            task_class=task_class,
+            action_kind=action_kind,
+            text=text,
+        )
+        successor_preview = {
+            "index": index,
+            "needed": condition_met,
+            "executed": False,
+            "condition": condition,
+            "reason": reason,
+            "target_agent_id": claimed_by,
+            "target_role_id": spec.get("target_role_id"),
+            "action_kind": action_kind,
+            "task_class": task_class,
+            "unblocks_todo_id": source_todo_id,
+            "todo_command": todo_command,
+            "source": ROLE_SUCCESSOR_SOURCE,
+        }
+        if not condition_met:
+            skipped.append(successor_preview)
+            continue
+        if not execute:
+            successors.append(successor_preview)
+            continue
+        result = add_goal_todo(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            role="agent",
+            text=text,
+            task_class=task_class,
+            action_kind=action_kind,
+            claimed_by=claimed_by,
+            unblocks_todo_id=source_todo_id,
+            dry_run=False,
+        )
+        successors.append(
+            successor_preview
+            | {
+                "executed": True,
+                "added": bool(result.get("added")),
+                "already_exists": bool(result.get("already_exists")),
+                "metadata_updated": bool(result.get("metadata_updated")),
+                "todo_id": result.get("todo_id"),
+                "claimed_by": result.get("claimed_by") or claimed_by,
+                "action_kind": result.get("action_kind") or action_kind,
+                "unblocks_todo_id": result.get("unblocks_todo_id") or source_todo_id,
+            }
+        )
+    return {
+        "schema_version": MULTI_AGENT_ROLE_SUCCESSOR_TODOS_SCHEMA_VERSION,
+        "source": ROLE_SUCCESSOR_SOURCE,
+        "needed": bool(successors),
+        "executed": bool(execute and successors),
+        "role_id": role_id,
+        "action": action,
+        "successors": successors,
+        "skipped": skipped,
+        "reason": None if successors else (skipped[0]["reason"] if skipped else "no_role_successor_spec"),
+    }
+
+
+def first_successor_followup(successor_todos: Mapping[str, object]) -> dict[str, object]:
+    successors = successor_todos.get("successors")
+    if isinstance(successors, list) and successors:
+        first = dict(successors[0])
+        first["needed"] = True
+        return first
+    return {
+        "needed": False,
+        "reason": successor_todos.get("reason") or "no_successor",
+    }

--- a/loopx/capabilities/multi_agent/visible_launch_policy.py
+++ b/loopx/capabilities/multi_agent/visible_launch_policy.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Tuple
+
+from ...visible_multi_agent_launcher import wake_visible_multi_agent_panes
+
+
+@dataclass(frozen=True)
+class VisibleLaunchPolicy:
+    """Generic visible-launch decisions shared by product presets."""
+
+    launch_visible: bool
+    wake_visible_after_launch: bool
+    attach: bool
+
+
+VisibleLauncherCallback = Callable[[dict[str, object], Path, Optional[str], Path], dict[str, object]]
+VisibleLaunchExecutor = Callable[..., dict[str, object]]
+VisibleWorkspacePolicy = Callable[[Path], Tuple[Optional[str], bool, bool]]
+
+
+def resolve_visible_launch_policy(
+    args: argparse.Namespace,
+    *,
+    launch_visible: bool,
+    default_wake_allowed: bool,
+    default_attach_allowed: bool,
+    attach_wake_conflict_message: str | None = None,
+) -> VisibleLaunchPolicy:
+    """Resolve attach/wake policy without product-specific runner logic."""
+
+    no_attach = bool(getattr(args, "no_attach", False))
+    attach_requested = bool(getattr(args, "attach", False))
+    if no_attach and attach_requested:
+        raise ValueError("--attach cannot be combined with --no-attach")
+
+    wake_setting = getattr(args, "wake_visible_after_launch", None)
+    if wake_setting is True and attach_requested:
+        raise ValueError(
+            attach_wake_conflict_message
+            or "--attach cannot be combined with --wake-visible-after-launch"
+        )
+
+    wake = False
+    if launch_visible and default_wake_allowed:
+        if wake_setting is None and attach_requested:
+            wake = False
+        else:
+            wake = bool(wake_setting is not False)
+
+    attach = bool(
+        attach_requested
+        or (
+            launch_visible
+            and default_attach_allowed
+            and not no_attach
+            and not wake
+        )
+    )
+    return VisibleLaunchPolicy(
+        launch_visible=bool(launch_visible),
+        wake_visible_after_launch=wake,
+        attach=attach,
+    )
+
+
+def resolve_codex_trust_workspace(
+    args: argparse.Namespace,
+    *,
+    launch_visible: bool,
+    default: bool,
+) -> bool:
+    """Resolve the optional Codex workspace trust default for visible launches."""
+
+    if not launch_visible:
+        return False
+    trust_setting = getattr(args, "codex_trust_workspace", None)
+    if trust_setting is None:
+        return bool(default)
+    return bool(trust_setting)
+
+
+def make_visible_launcher_callback(
+    *,
+    launch_visible: bool,
+    launch_executor: VisibleLaunchExecutor,
+    launcher: str,
+    tmux_bin: str,
+    cli_bin: str,
+    codex_bin: str,
+    attach: bool,
+    replace_existing: bool,
+    workspace_policy: VisibleWorkspacePolicy,
+) -> VisibleLauncherCallback | None:
+    """Create the generic callback shape expected by visible demo runners."""
+
+    if not launch_visible:
+        return None
+
+    def visible_launcher(
+        payload: dict[str, object],
+        registry_path: Path,
+        runtime_root_arg: str | None,
+        default_workspace: Path,
+    ) -> dict[str, object]:
+        workspace, create_workspace, codex_trust_workspace = workspace_policy(
+            default_workspace
+        )
+        return launch_executor(
+            payload,
+            registry_path=registry_path,
+            runtime_root_arg=runtime_root_arg,
+            launcher=launcher,
+            tmux_bin=tmux_bin,
+            cli_bin=cli_bin,
+            codex_bin=codex_bin,
+            attach=attach,
+            replace_existing=replace_existing,
+            workspace=workspace,
+            create_workspace=create_workspace,
+            codex_trust_workspace=codex_trust_workspace,
+        )
+
+    return visible_launcher
+
+
+def make_visible_wake_callback(
+    *,
+    tmux_bin: str,
+) -> Callable[[str, list[str]], dict[str, object]]:
+    """Return a pane-local A2A wake callback for visible launcher integrations."""
+
+    def visible_wake(session: str, lanes: Iterable[str]) -> dict[str, object]:
+        return wake_visible_multi_agent_panes(
+            session_name=session,
+            tmux_bin=tmux_bin,
+            lanes=lanes,
+            execute=True,
+        )
+
+    return visible_wake


### PR DESCRIPTION
## Summary
- Extract generic visible-launch CLI policy from `auto-research start` / `demo-e2e` into `loopx.capabilities.multi_agent.visible_launch_policy`.
- Move role-declared successor todo condition/render/target validation/execution into `loopx.capabilities.multi_agent.role_successor` so auto-research keeps only domain role specs.
- Preserve fail-closed behavior when an explicit successor target agent is not registered; no fallback is used for invalid explicit targets.
- Add focused smokes for visible launch policy and generic role successor todos.

## Validation
- `python3 -m py_compile loopx/capabilities/auto_research/cli.py loopx/capabilities/auto_research/worker_runtime.py loopx/capabilities/multi_agent/visible_launch_policy.py loopx/capabilities/multi_agent/role_successor.py`
- `python3 examples/multi-agent-role-successor-todos-smoke.py`
- `python3 examples/auto-research-visible-launch-policy-smoke.py`
- `python3 examples/auto-research-worker-turn-smoke.py`
- `python3 examples/auto-research-worker-loop-smoke.py`
- `python3 examples/auto-research-demo-e2e-worker-loop-smoke.py`
- `python3 examples/auto-research-demo-supervisor-smoke.py`
- `for f in examples/auto-research-*smoke.py examples/multi-agent-*smoke.py; do python3 "$f"; done`
- `git diff --check`

## Boundary
- Candidate private-material scan found only existing public-boundary booleans such as `credentials_recorded: False`.
- This keeps the user and auto-research preset layers thinner while moving reusable launch/handoff machinery into the generic multi-agent kernel.
