### PR TITLE
Extract active-state event projection read model

### DIFF
--- a/examples/control_plane/event-sourced-status-read-path-smoke.py
+++ b/examples/control_plane/event-sourced-status-read-path-smoke.py
@@ -18,6 +18,9 @@ from loopx.event_sourced_state import (  # noqa: E402
     TODO_CLAIMED,
     make_state_event,
 )
+from loopx.control_plane.goals.active_state_event_projection import (  # noqa: E402
+    active_state_event_projection_fields as active_state_event_projection_fields_read_model,
+)
 from loopx.projections import active_state_todos as active_state_todos_read_model  # noqa: E402
 from loopx.status import active_state_todo_fields  # noqa: E402
 from loopx import status as status_module  # noqa: E402
@@ -108,6 +111,17 @@ def direct_active_state_todo_fields(goal: dict, *, runtime_root: Path | None = N
     )
 
 
+def direct_active_state_event_projection_fields(goal: dict, *, state_path: Path) -> dict:
+    return active_state_event_projection_fields_read_model(
+        goal,
+        state_path=state_path,
+        resolve_goal_local_path=status_module.resolve_goal_local_path,
+        parse_active_state_todos=status_module.parse_active_state_todos,
+        item_limit=status_module.MAX_STATUS_TODOS_PER_ROLE,
+        event_log_basename=status_module.STATE_EVENT_LOG_BASENAME,
+    )
+
+
 def test_event_projection_preferred() -> None:
     with tempfile.TemporaryDirectory(prefix="loopx-event-status-") as tmp:
         project = Path(tmp)
@@ -120,6 +134,10 @@ def test_event_projection_preferred() -> None:
             "repo": str(project),
             "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
         }
+        projection_fields = status_module.active_state_event_projection_fields(goal, state_path=state_path)
+        assert projection_fields == direct_active_state_event_projection_fields(goal, state_path=state_path), (
+            projection_fields
+        )
         fields = active_state_todo_fields(goal)
         assert fields == direct_active_state_todo_fields(goal), fields
         assert fields["state_event_projection"]["source"] == "event_log", fields
@@ -140,12 +158,24 @@ def test_markdown_fallback_without_valid_event_log() -> None:
             "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
         }
 
+        projection_fields = status_module.active_state_event_projection_fields(goal, state_path=state_path)
+        assert projection_fields == direct_active_state_event_projection_fields(goal, state_path=state_path), (
+            projection_fields
+        )
         fields = active_state_todo_fields(goal)
         assert fields == direct_active_state_todo_fields(goal), fields
         assert event_todo_ids(fields) == ["todo_markdown_stale"], fields
         assert "state_event_projection" not in fields, fields
 
         state_path.with_name("events.jsonl").write_text("{not json\n", encoding="utf-8")
+        corrupted_projection_fields = status_module.active_state_event_projection_fields(
+            goal,
+            state_path=state_path,
+        )
+        assert corrupted_projection_fields == direct_active_state_event_projection_fields(
+            goal,
+            state_path=state_path,
+        ), corrupted_projection_fields
         corrupted_fields = active_state_todo_fields(goal)
         assert corrupted_fields == direct_active_state_todo_fields(goal), corrupted_fields
         assert event_todo_ids(corrupted_fields) == ["todo_markdown_stale"], corrupted_fields

--- a/loopx/control_plane/goals/active_state_event_projection.py
+++ b/loopx/control_plane/goals/active_state_event_projection.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from loopx.event_sourced_state import (
+    AppendOnlyStateEventStore,
+    StateEventError,
+    build_state_projection,
+    render_active_state_sections,
+)
+
+
+DEFAULT_STATE_EVENT_LOG_BASENAME = "events.jsonl"
+STATE_EVENT_PROJECTION_SCHEMA_VERSION = "event_sourced_state_status_projection_v0"
+STATE_EVENT_READ_WARNING_SCHEMA_VERSION = "event_sourced_state_read_warning_v0"
+
+ResolveGoalLocalPath = Callable[..., Optional[Path]]
+ParseActiveStateTodos = Callable[..., dict[str, Any]]
+
+
+def state_event_log_candidates(
+    goal: dict[str, Any],
+    *,
+    state_path: Path,
+    resolve_goal_local_path: ResolveGoalLocalPath,
+    event_log_basename: str = DEFAULT_STATE_EVENT_LOG_BASENAME,
+) -> list[Path]:
+    candidates: list[Path] = []
+    for key in ("state_event_log", "state_events_file", "event_log"):
+        resolved = resolve_goal_local_path(goal.get(key), goal, fallback_base=state_path.parent)
+        if resolved is not None:
+            candidates.append(resolved)
+    candidates.append(state_path.with_name(event_log_basename))
+
+    unique: list[Path] = []
+    seen: set[str] = set()
+    for path in candidates:
+        key = str(path.expanduser())
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(path)
+    return unique
+
+
+def active_state_event_projection_fields(
+    goal: dict[str, Any],
+    *,
+    state_path: Path,
+    resolve_goal_local_path: ResolveGoalLocalPath,
+    parse_active_state_todos: ParseActiveStateTodos,
+    preferred_todo_ids: set[str] | None = None,
+    rollout_events: list[dict[str, Any]] | None = None,
+    item_limit: int | None = None,
+    event_log_basename: str = DEFAULT_STATE_EVENT_LOG_BASENAME,
+) -> dict[str, Any]:
+    goal_id = str(goal.get("id") or "").strip()
+    for event_log_path in state_event_log_candidates(
+        goal,
+        state_path=state_path,
+        resolve_goal_local_path=resolve_goal_local_path,
+        event_log_basename=event_log_basename,
+    ):
+        if not event_log_path.exists():
+            continue
+        try:
+            events = AppendOnlyStateEventStore(event_log_path).load()
+            if not events:
+                continue
+            projection = build_state_projection(events, goal_id=goal_id or None)
+            projection_markdown = render_active_state_sections(projection)
+            fields = parse_active_state_todos(
+                projection_markdown,
+                goal=goal,
+                state_path=state_path,
+                preferred_todo_ids=preferred_todo_ids,
+                rollout_events=rollout_events,
+                item_limit=item_limit,
+            )
+        except (OSError, StateEventError) as exc:
+            return {
+                "state_event_projection_warning": {
+                    "schema_version": STATE_EVENT_READ_WARNING_SCHEMA_VERSION,
+                    "source": "event_log",
+                    "event_log": event_log_path.name,
+                    "fallback": "markdown_active_state",
+                    "reason": type(exc).__name__,
+                }
+            }
+        if fields:
+            fields["state_event_projection"] = {
+                "schema_version": STATE_EVENT_PROJECTION_SCHEMA_VERSION,
+                "source": "event_log",
+                "event_log": event_log_path.name,
+                "source_event_count": projection.get("source_event_count"),
+                "source_checksum": projection.get("source_checksum"),
+                "last_event_id": projection.get("last_event_id"),
+                "last_append_sequence": projection.get("last_append_sequence"),
+                "projection_version": projection.get("projection_version"),
+            }
+            return fields
+    return {}

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -32,12 +32,6 @@ from .execution_profile import (
     execution_profile_outcome_floor,
     execution_profile_summary,
 )
-from .event_sourced_state import (
-    AppendOnlyStateEventStore,
-    StateEventError,
-    build_state_projection,
-    render_active_state_sections,
-)
 from .frontstage import build_goal_channel_projection
 from .handoff_budget import handoff_budget_contract
 from .history import collect_history, load_registry
@@ -97,6 +91,10 @@ from .control_plane.goals.active_state_metadata import (
     USER_TODO_HEADER_MARKERS,
     parse_state_frontmatter as _parse_state_frontmatter_read_model,
     todo_role_for_heading as _todo_role_for_heading_read_model,
+)
+from .control_plane.goals.active_state_event_projection import (
+    active_state_event_projection_fields as _active_state_event_projection_fields_read_model,
+    state_event_log_candidates as _state_event_log_candidates_read_model,
 )
 from .control_plane.todos.active_state_todos import (
     active_state_todo_fields as _active_state_todo_fields_read_model,
@@ -6023,22 +6021,12 @@ def parse_active_state_todos(
 
 
 def state_event_log_candidates(goal: dict[str, Any], *, state_path: Path) -> list[Path]:
-    candidates: list[Path] = []
-    for key in ("state_event_log", "state_events_file", "event_log"):
-        resolved = resolve_goal_local_path(goal.get(key), goal, fallback_base=state_path.parent)
-        if resolved is not None:
-            candidates.append(resolved)
-    candidates.append(state_path.with_name(STATE_EVENT_LOG_BASENAME))
-
-    unique: list[Path] = []
-    seen: set[str] = set()
-    for path in candidates:
-        key = str(path.expanduser())
-        if key in seen:
-            continue
-        seen.add(key)
-        unique.append(path)
-    return unique
+    return _state_event_log_candidates_read_model(
+        goal,
+        state_path=state_path,
+        resolve_goal_local_path=resolve_goal_local_path,
+        event_log_basename=STATE_EVENT_LOG_BASENAME,
+    )
 
 
 def active_state_event_projection_fields(
@@ -6049,47 +6037,16 @@ def active_state_event_projection_fields(
     rollout_events: list[dict[str, Any]] | None = None,
     item_limit: int | None = MAX_STATUS_TODOS_PER_ROLE,
 ) -> dict[str, Any]:
-    goal_id = str(goal.get("id") or "").strip()
-    for event_log_path in state_event_log_candidates(goal, state_path=state_path):
-        if not event_log_path.exists():
-            continue
-        try:
-            events = AppendOnlyStateEventStore(event_log_path).load()
-            if not events:
-                continue
-            projection = build_state_projection(events, goal_id=goal_id or None)
-            projection_markdown = render_active_state_sections(projection)
-            fields = parse_active_state_todos(
-                projection_markdown,
-                goal=goal,
-                state_path=state_path,
-                preferred_todo_ids=preferred_todo_ids,
-                rollout_events=rollout_events,
-                item_limit=item_limit,
-            )
-        except (OSError, StateEventError) as exc:
-            return {
-                "state_event_projection_warning": {
-                    "schema_version": "event_sourced_state_read_warning_v0",
-                    "source": "event_log",
-                    "event_log": event_log_path.name,
-                    "fallback": "markdown_active_state",
-                    "reason": type(exc).__name__,
-                }
-            }
-        if fields:
-            fields["state_event_projection"] = {
-                "schema_version": "event_sourced_state_status_projection_v0",
-                "source": "event_log",
-                "event_log": event_log_path.name,
-                "source_event_count": projection.get("source_event_count"),
-                "source_checksum": projection.get("source_checksum"),
-                "last_event_id": projection.get("last_event_id"),
-                "last_append_sequence": projection.get("last_append_sequence"),
-                "projection_version": projection.get("projection_version"),
-            }
-            return fields
-    return {}
+    return _active_state_event_projection_fields_read_model(
+        goal,
+        state_path=state_path,
+        resolve_goal_local_path=resolve_goal_local_path,
+        parse_active_state_todos=parse_active_state_todos,
+        preferred_todo_ids=preferred_todo_ids,
+        rollout_events=rollout_events,
+        item_limit=item_limit,
+        event_log_basename=STATE_EVENT_LOG_BASENAME,
+    )
 
 
 def active_state_sections(state_text: str, headings: tuple[str, ...]) -> dict[str, list[str]]:


### PR DESCRIPTION
## Summary
- move active-state event-log candidate selection and event projection field construction into `loopx/control_plane/goals/active_state_event_projection.py`
- keep `loopx.status` public wrappers intact for existing callers
- extend the event-sourced status smoke with wrapper-vs-readmodel parity assertions

## Validation
- `python3 examples/control_plane/event-sourced-status-read-path-smoke.py`
- `python3 examples/control_plane/event-sourced-downstream-read-path-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `python3 -m py_compile loopx/control_plane/goals/active_state_event_projection.py loopx/status.py examples/control_plane/event-sourced-status-read-path-smoke.py`
- `python3 examples/control_plane/todo-list-event-projection-smoke.py`
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 -m loopx.cli canary smoke-suite --format json --script examples/control_plane/event-sourced-status-read-path-smoke.py --script examples/control_plane/event-sourced-downstream-read-path-smoke.py --script examples/control_plane/todo-list-event-projection-smoke.py --timeout-seconds 120 --no-progress`
- `git diff --check`

## Notes
- This is a bounded read-model extraction for the canary-gated control-plane cleanup lane.
- No benchmark raw logs, trajectories, verifier output, credentials, or local runtime state are included.
