### PR TITLE
Align Codex App command registry syntax

### DIFF
--- a/docs/reference/protocols/codex-app-host-command-registry-v0.md
+++ b/docs/reference/protocols/codex-app-host-command-registry-v0.md
@@ -8,7 +8,7 @@ structured handoff packet. LoopX CLI remains the source of truth.
 This contract sits above:
 
 - [`loopx_goal_command_v0`](loopx-goal-command-v0.md) for the project-local
-  `/loopx` status entry and `/loopx <task text>` start entry.
+  `/loopx` status entry and `/loopx <goal text>` start entry.
 - [`global_manager_command_v0`](global-manager-command-v0.md) for read-only
   `/loopx-global-*` manager commands.
 - [`host_integration_surface_v0`](host-integration-surface-v0.md) for general
@@ -24,7 +24,7 @@ The host registry should expose this minimal command set:
 | Command | Canonical target | Default authority |
 | --- | --- | --- |
 | `/loopx` | `loopx bootstrap-command-pack --project .` | Read/status-first. |
-| `/loopx <task text>` | `loopx bootstrap-command-pack --project . --goal-text "<task text>"` | Explicit project-local start intent. |
+| `/loopx <goal text>` | `loopx bootstrap-command-pack --project . --goal-text "<goal text>"` | Explicit project-local start intent. |
 | `/loopx-global-summary` | `global_manager_command_v0` summary request | Read-only global control-plane digest. |
 | `/loopx-global-gates` | `global_manager_command_v0` gates request | Read-only gate inbox. |
 | `/loopx-global-todos` | `global_manager_command_v0` todos request | Read-only work queue view. |
@@ -50,11 +50,11 @@ Example registry entry:
       "mutation_policy": "read_first"
     },
     {
-      "command": "/loopx <task text>",
+      "command": "/loopx <goal text>",
       "kind": "project_task_start",
       "protocol": "loopx_goal_command_v0",
-      "cli_baseline": "loopx bootstrap-command-pack --project . --goal-text \"<task text>\"",
-      "mutation_policy": "explicit_project_start"
+      "cli_baseline": "loopx bootstrap-command-pack --project . --goal-text \"<goal text>\"",
+      "mutation_policy": "explicit_goal_start"
     },
     {
       "command": "/loopx-global-summary",
@@ -102,7 +102,7 @@ Required fields:
 | `agent_id` | Registered LoopX agent id when the host is acting for an agent. |
 | `host_surface` | `chat_box`, `command_palette`, `codex_cli_tui`, or another compact host label. |
 
-If the host cannot resolve a project root, `/loopx` and `/loopx <task text>`
+If the host cannot resolve a project root, `/loopx` and `/loopx <goal text>`
 must produce a setup/help packet, not state writes. Global commands may still
 run against the shared global registry when available.
 
@@ -115,14 +115,14 @@ After parsing, the host hands the agent or CLI a compact packet:
   "schema_version": "codex_app_host_command_handoff_v0",
   "command": "/loopx",
   "raw_command": "/loopx design an issue-fix workflow",
-  "canonical_command": "/loopx <task text>",
+  "canonical_command": "/loopx <goal text>",
   "task_text": "design an issue-fix workflow",
   "host_surface": "chat_box",
   "project_root_label": "current workspace",
   "goal_id": "loopx-meta",
   "agent_id": "codex-product-capability",
   "protocol": "loopx_goal_command_v0",
-  "cli_preview": "loopx bootstrap-command-pack --project . --goal-text \"<task text>\"",
+  "cli_preview": "loopx bootstrap-command-pack --project . --goal-text \"<goal text>\"",
   "authority": {
     "read_allowed": true,
     "project_local_write_allowed": true,
@@ -144,7 +144,7 @@ visible user intent into the existing CLI lifecycle:
 
 - `/loopx` can read status and preview command packs. It stops before writes
   that need confirmation.
-- `/loopx <task text>` is explicit intent to start project-local work: plan
+- `/loopx <goal text>` is explicit intent to start project-local work: plan
   first, write ordered todos, refresh state, run `quota should-run`, and
   execute only when the guard allows.
 - `/loopx-global-*` commands are read-only and must not approve gates, add
@@ -160,7 +160,7 @@ Every host command must expose a deterministic CLI fallback:
 loopx slash-commands
 loopx slash-commands --install
 loopx bootstrap-command-pack --project .
-loopx bootstrap-command-pack --project . --goal-text "<task text>"
+loopx bootstrap-command-pack --project . --goal-text "<goal text>"
 loopx global-summary
 loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" quota should-run --goal-id <goal-id> --agent-id <agent-id>
 ```
@@ -191,7 +191,7 @@ signature.
 
 A host command registry implementation is acceptable when:
 
-1. `/loopx` and `/loopx <task text>` route to `loopx_goal_command_v0`.
+1. `/loopx` and `/loopx <goal text>` route to `loopx_goal_command_v0`.
 2. `/loopx-global-summary`, `/loopx-global-gates`, `/loopx-global-todos`, and
    `/loopx-global-risks` route to `global_manager_command_v0`.
 3. Legacy `/loop-global-*` inputs canonicalize to `/loopx-global-*`.


### PR DESCRIPTION
## Summary
- align the Codex App host command registry protocol with the canonical `/loopx <goal text>` slash form
- align the example mutation policy with the goal-command smoke expectation

## Validation
- python3 examples/codex-app-host-command-registry-smoke.py
- python3 examples/slash-command-install-smoke.py
- python3 examples/slash-command-catalog-smoke.py
- python3 examples/install-local-smoke.py
- python3 -m py_compile loopx/slash_command_install.py loopx/slash_commands.py loopx/cli_commands/slash_commands.py
- git diff --check