### PR TITLE
Extract active-state todo parser read model

### DIFF
--- a/examples/control_plane/todo-first-open-summary-smoke.py
+++ b/examples/control_plane/todo-first-open-summary-smoke.py
@@ -12,6 +12,9 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.quota import build_quota_should_run, render_quota_should_run_markdown  # noqa: E402
+from loopx.control_plane.todos.active_state_todo_parser import (  # noqa: E402
+    parse_active_state_todos as parse_active_state_todos_read_model,
+)
 from loopx.projections.project_asset import build_project_asset_todo_summary  # noqa: E402
 from loopx.review_packet import build_review_packet  # noqa: E402
 from loopx.status import (  # noqa: E402
@@ -115,6 +118,7 @@ def parse_multiline_deep_open_todo() -> dict:
         f"- [ ] {THIRD_OPEN_TODO}\n"
         f"- [ ] {APPENDED_P0_TODO}\n"
     )
+    assert parse_active_state_todos(state_text) == parse_active_state_todos_read_model(state_text)
     group = parse_active_state_todos(state_text)["agent_todos"]
     assert len(group["items"]) == 12, group
     assert [item["index"] for item in group["items"][:3]] == [17, 14, 15], group

--- a/loopx/control_plane/todos/active_state_todo_parser.py
+++ b/loopx/control_plane/todos/active_state_todo_parser.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ...materials import extract_review_materials
+from ...todo_contract import (
+    TODO_TASK_PATTERN,
+    normalize_todo_id,
+    parse_todo_metadata_line,
+    todo_done_for_status,
+    todo_status_from_marker,
+)
+from ..goals.active_state_metadata import TODO_ARCHIVE_HEADER_MARKERS, todo_role_for_heading
+from .todo_summary import MAX_STATUS_TODOS_PER_ROLE, compact_todo_group, normalize_todo_text
+
+
+def parse_active_state_todos(
+    state_text: str,
+    *,
+    goal: dict[str, Any] | None = None,
+    state_path: Path | None = None,
+    preferred_todo_ids: set[str] | None = None,
+    rollout_events: list[dict[str, Any]] | None = None,
+    item_limit: int | None = MAX_STATUS_TODOS_PER_ROLE,
+) -> dict[str, Any]:
+    role: str | None = None
+    source_sections: dict[str, str | None] = {"user": None, "agent": None}
+    items: dict[str, list[dict[str, Any]]] = {"user": [], "agent": []}
+    archive_items: list[dict[str, Any]] = []
+    archive_mode = False
+    archive_source_section: str | None = None
+    current_todo: dict[str, Any] | None = None
+
+    for line in state_text.splitlines():
+        if line.startswith("## "):
+            heading = line.lstrip("#").strip()
+            normalized_heading = heading.strip().lower()
+            archive_mode = any(
+                marker in normalized_heading for marker in TODO_ARCHIVE_HEADER_MARKERS
+            )
+            archive_source_section = heading if archive_mode else None
+            role = todo_role_for_heading(heading)
+            current_todo = None
+            if role and source_sections[role] is None:
+                source_sections[role] = heading
+            continue
+        if role is None and not archive_mode:
+            continue
+        match = TODO_TASK_PATTERN.match(line)
+        if match:
+            marker, text = match.groups()
+            status = todo_status_from_marker(marker)
+            target_items = archive_items if archive_mode else items[str(role)]
+            todo: dict[str, Any] = {
+                "index": len(target_items) + 1,
+                "done": todo_done_for_status(status),
+                "status": status,
+                "text": normalize_todo_text(text),
+            }
+            if archive_mode:
+                todo["archive_state"] = "archive"
+                todo["source_section"] = archive_source_section
+            else:
+                todo["archive_state"] = "active"
+                todo["source_section"] = source_sections[str(role)]
+                todo["role"] = role
+            if goal is not None:
+                materials = extract_review_materials(text, goal=goal, state_path=state_path)
+                if materials:
+                    todo["review_materials"] = materials
+            target_items.append(todo)
+            current_todo = todo
+            continue
+        if current_todo is None or not line.startswith((" ", "\t")):
+            continue
+        metadata = parse_todo_metadata_line(line)
+        if metadata:
+            current_todo.update(metadata)
+            continue
+        continuation = line.strip()
+        if continuation:
+            current_todo["text"] = normalize_todo_text(
+                f"{current_todo.get('text', '')} {continuation}"
+            )
+
+    result: dict[str, Any] = {}
+    archived_resume_source_items = [
+        item for item in archive_items if normalize_todo_id(item.get("todo_id"))
+    ]
+    resume_source_items = [*items["user"], *items["agent"], *archived_resume_source_items]
+    user = compact_todo_group(
+        items["user"],
+        source_section=source_sections["user"],
+        role="user",
+        preferred_todo_ids=preferred_todo_ids,
+        resume_source_items=resume_source_items,
+        rollout_events=rollout_events,
+        item_limit=item_limit,
+    )
+    agent = compact_todo_group(
+        items["agent"],
+        source_section=source_sections["agent"],
+        role="agent",
+        preferred_todo_ids=preferred_todo_ids,
+        resume_source_items=resume_source_items,
+        rollout_events=rollout_events,
+        item_limit=item_limit,
+    )
+    if user:
+        result["user_todos"] = user
+    if agent:
+        result["agent_todos"] = agent
+    return result

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -99,6 +99,9 @@ from .control_plane.goals.active_state_event_projection import (
 from .control_plane.todos.active_state_todos import (
     active_state_todo_fields as _active_state_todo_fields_read_model,
 )
+from .control_plane.todos.active_state_todo_parser import (
+    parse_active_state_todos as _parse_active_state_todos_read_model,
+)
 from .control_plane.work_items.attention_item import (
     attention_item as _attention_item_read_model,
 )
@@ -5932,92 +5935,14 @@ def parse_active_state_todos(
     rollout_events: list[dict[str, Any]] | None = None,
     item_limit: int | None = MAX_STATUS_TODOS_PER_ROLE,
 ) -> dict[str, Any]:
-    role: str | None = None
-    source_sections: dict[str, str | None] = {"user": None, "agent": None}
-    items: dict[str, list[dict[str, Any]]] = {"user": [], "agent": []}
-    archive_items: list[dict[str, Any]] = []
-    archive_mode = False
-    archive_source_section: str | None = None
-    current_todo: dict[str, Any] | None = None
-
-    for line in state_text.splitlines():
-        if line.startswith("## "):
-            heading = line.lstrip("#").strip()
-            normalized_heading = heading.strip().lower()
-            archive_mode = any(
-                marker in normalized_heading for marker in TODO_ARCHIVE_HEADER_MARKERS
-            )
-            archive_source_section = heading if archive_mode else None
-            role = todo_role_for_heading(heading)
-            current_todo = None
-            if role and source_sections[role] is None:
-                source_sections[role] = heading
-            continue
-        if role is None and not archive_mode:
-            continue
-        match = TODO_TASK_PATTERN.match(line)
-        if match:
-            marker, text = match.groups()
-            status = todo_status_from_marker(marker)
-            target_items = archive_items if archive_mode else items[str(role)]
-            todo: dict[str, Any] = {
-                "index": len(target_items) + 1,
-                "done": todo_done_for_status(status),
-                "status": status,
-                "text": normalize_todo_text(text),
-            }
-            if archive_mode:
-                todo["archive_state"] = "archive"
-                todo["source_section"] = archive_source_section
-            else:
-                todo["archive_state"] = "active"
-                todo["source_section"] = source_sections[str(role)]
-                todo["role"] = role
-            if goal is not None:
-                materials = extract_review_materials(text, goal=goal, state_path=state_path)
-                if materials:
-                    todo["review_materials"] = materials
-            target_items.append(todo)
-            current_todo = todo
-            continue
-        if current_todo is None or not line.startswith((" ", "\t")):
-            continue
-        metadata = parse_todo_metadata_line(line)
-        if metadata:
-            current_todo.update(metadata)
-            continue
-        continuation = line.strip()
-        if continuation:
-            current_todo["text"] = normalize_todo_text(f"{current_todo.get('text', '')} {continuation}")
-
-    result: dict[str, Any] = {}
-    archived_resume_source_items = [
-        item for item in archive_items if normalize_todo_id(item.get("todo_id"))
-    ]
-    resume_source_items = [*items["user"], *items["agent"], *archived_resume_source_items]
-    user = compact_todo_group(
-        items["user"],
-        source_section=source_sections["user"],
-        role="user",
+    return _parse_active_state_todos_read_model(
+        state_text,
+        goal=goal,
+        state_path=state_path,
         preferred_todo_ids=preferred_todo_ids,
-        resume_source_items=resume_source_items,
         rollout_events=rollout_events,
         item_limit=item_limit,
     )
-    agent = compact_todo_group(
-        items["agent"],
-        source_section=source_sections["agent"],
-        role="agent",
-        preferred_todo_ids=preferred_todo_ids,
-        resume_source_items=resume_source_items,
-        rollout_events=rollout_events,
-        item_limit=item_limit,
-    )
-    if user:
-        result["user_todos"] = user
-    if agent:
-        result["agent_todos"] = agent
-    return result
 
 
 def state_event_log_candidates(goal: dict[str, Any], *, state_path: Path) -> list[Path]:


### PR DESCRIPTION
## Summary
- move active-state Markdown todo parsing into `loopx/control_plane/todos/active_state_todo_parser.py`
- keep `loopx.status.parse_active_state_todos` as the compatibility wrapper for existing callers
- extend `todo-first-open-summary-smoke` with wrapper-vs-readmodel parity

## Validation
- `python3 examples/control_plane/todo-first-open-summary-smoke.py`
- `python3 examples/control_plane/todo-cli-smoke.py`
- `python3 examples/control_plane/todo-durability-fixture-smoke.py`
- `python3 examples/control_plane/todo-archive-completed-smoke.py`
- `python3 examples/control_plane/event-sourced-status-read-path-smoke.py`
- `python3 examples/control_plane/event-sourced-downstream-read-path-smoke.py`
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 -m py_compile loopx/control_plane/todos/active_state_todo_parser.py loopx/status.py examples/control_plane/todo-first-open-summary-smoke.py`
- `python3 -m loopx.cli canary smoke-suite --format json --script examples/control_plane/todo-first-open-summary-smoke.py --script examples/control_plane/todo-cli-smoke.py --script examples/control_plane/todo-durability-fixture-smoke.py --script examples/control_plane/todo-archive-completed-smoke.py --script examples/control_plane/event-sourced-status-read-path-smoke.py --timeout-seconds 120 --no-progress`
- `git diff --check`

## Notes
- This continues the canary-gated non-benchmark `status.py` read-model cleanup lane.
- The change preserves the existing `loopx.status` import surface and does not touch benchmark adapters, raw benchmark logs, trajectories, verifier output, credentials, or local runtime state.
