### PR TITLE
Fix app-server Goal status and followup trace parity

### DIFF
--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -1459,11 +1459,21 @@ def test_host_worker_can_run_normal_no_reward_followup() -> None:
         assert payload["turn"]["normal_followup_succeeded"] is True, payload
         assert payload["turn"]["normal_followup_start_attempted_count"] == 1, payload
         assert payload["turn"]["normal_followup_start_succeeded_count"] == 1, payload
+        assert payload["turn"]["post_turn_goal_refresh_attempted"] is True, payload
+        assert payload["turn"]["post_turn_goal_refresh_succeeded"] is True, payload
+        assert payload["turn"]["post_turn_goal_status"] == "active", payload
+        assert (
+            payload["turn"]["post_turn_goal_active_after_completed_turn"] is True
+        ), payload
+        assert payload["turn"]["turn_completion_shape_unclean"] is False, payload
         assert payload["normal_followup"]["enabled"] is True, payload
         assert payload["normal_followup"]["verifier_feedback_provided"] is False, payload
         assert payload["normal_followup"]["reward_feedback_provided"] is False, payload
         assert len(payload["turn_attempts"]) == 2, payload
         assert payload["turn_attempts"][0]["assistant_message_context_only"] is False, payload
+        assert (
+            payload["turn_attempts"][0]["post_turn_goal_refresh_succeeded"] is True
+        ), payload
         assert payload["turn_attempts"][1]["selected_final_turn"] is True, payload
         assert private_response.read_text(encoding="utf-8") == (
             "private worker answer after normal followup"

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -122,6 +122,7 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
     VERIFIER_BENCHMARK_EGRESS_PROXY_BEGIN,
     VERIFIER_UV_BOOTSTRAP_MIRROR_BEGIN,
     _tail,
+    _apply_app_server_goal_round_semantics_to_controller_trace,
     _apply_agent_message_only_no_tool_calls_attribution,
     _apply_native_goal_worker_finish_guard_attribution,
     _blind_loop_persistent_continuation_clause,
@@ -141,6 +142,7 @@ from scripts.skillsbench_automation_loop import (  # noqa: E402
     _merge_acp_trajectory_summary,
     _merge_final_result_round_reward,
     _merge_host_local_acp_relay_trace_summary,
+    _new_controller_trace,
     _summarize_host_local_acp_preflight_bridge_trace,
     _round_result_declared_done,
     build_compose_setup_diagnostic,
@@ -8675,6 +8677,32 @@ def test_app_server_goal_round_semantics_survive_compact_and_ledger() -> None:
         assert current["max_rounds_budget_applies_to"] == (
             "benchflow_outer_controller_budget_not_native_goal_attempts"
         ), current
+
+
+def test_app_server_goal_round_semantics_seed_controller_trace_from_plan() -> None:
+    trace = _new_controller_trace(
+        "codex-app-server-goal-baseline",
+        max_rounds=16,
+    )
+    plan = {
+        "route": "codex-app-server-goal-baseline",
+        "app_server_goal_followup_max": 2,
+        "app_server_goal_round_semantics": {
+            "session_policy": "single_thread_with_blinded_followups",
+            "same_thread_followup_budget": 2,
+            "independent_attempt_budget": 3,
+        },
+        "independent_goal_retry": {"attempt_budget": 3},
+    }
+
+    _apply_app_server_goal_round_semantics_to_controller_trace(trace, plan)
+
+    assert trace["native_goal_worker_route"] is True, trace
+    assert trace["native_goal_worker_session_policy"] == (
+        "single_thread_with_blinded_followups"
+    ), trace
+    assert trace["native_goal_worker_same_thread_followup_budget"] == 2, trace
+    assert trace["native_goal_worker_independent_attempt_budget"] == 3, trace
 
 
 def test_skillsbench_product_mode_declared_done_is_compacted() -> None:

--- a/scripts/codex_app_server_goal_driver.py
+++ b/scripts/codex_app_server_goal_driver.py
@@ -52,6 +52,10 @@ class CodexAppServerGoalTurn:
     goal_reactivation_succeeded: bool = False
     goal_reactivation_previous_status: str = ""
     goal_reactivation_result_status: str = ""
+    post_turn_goal_refresh_attempted: bool = False
+    post_turn_goal_refresh_succeeded: bool = False
+    post_turn_goal_status: str = ""
+    post_turn_goal_refresh_error_type: str = ""
     notifications: list[str] = field(default_factory=list)
     _responses: "queue.Queue[dict[str, Any] | Exception] | None" = field(
         default=None,
@@ -567,6 +571,59 @@ def _wait_for_turn_completion(
         raise CodexAppServerGoalDriverError("timed out waiting for turn completion")
 
 
+def refresh_codex_app_server_goal_status(
+    turn: CodexAppServerGoalTurn,
+    *,
+    response_timeout_sec: float = 5.0,
+) -> bool:
+    """Refresh goal status after turn completion without recording raw output."""
+    turn.post_turn_goal_refresh_attempted = True
+    if turn._responses is None:
+        turn.post_turn_goal_refresh_error_type = "codex_app_server_no_response_queue"
+        return False
+    if not turn.thread_id:
+        turn.post_turn_goal_refresh_error_type = "codex_app_server_thread_id_missing"
+        return False
+    request_id = int(turn.next_request_id or 6)
+    turn.next_request_id = request_id + 1
+    side_events: list[dict[str, Any]] = []
+    try:
+        _send_json(
+            turn.process,
+            {
+                "id": request_id,
+                "method": "thread/goal/get",
+                "params": {"threadId": turn.thread_id},
+            },
+        )
+        goal_result = _wait_for_response(
+            turn.process,
+            turn._responses,
+            request_id,
+            notifications=turn.notifications,
+            timeout_sec=max(0.1, float(response_timeout_sec or 0.1)),
+            side_events=side_events,
+        )
+    except CodexAppServerGoalDriverError as exc:
+        detail = str(exc)
+        turn.post_turn_goal_refresh_error_type = (
+            detail
+            if detail.startswith("codex_app_server_")
+            else "codex_app_server_goal_refresh_failed"
+        )
+        return False
+    for event in side_events:
+        _record_turn_event(turn, event, raise_on_error=False)
+    goal_status = _extract_goal_status(goal_result)
+    turn.post_turn_goal_status = goal_status
+    if not goal_status:
+        turn.post_turn_goal_refresh_error_type = "codex_app_server_goal_status_missing"
+        return False
+    turn.post_turn_goal_refresh_succeeded = True
+    turn.post_turn_goal_refresh_error_type = ""
+    return True
+
+
 def start_codex_app_server_goal_turn(
     *,
     codex_bin: str,
@@ -1063,6 +1120,15 @@ def compact_turn_metadata(turn: CodexAppServerGoalTurn) -> dict[str, Any]:
         "goal_reactivation_succeeded": bool(turn.goal_reactivation_succeeded),
         "goal_reactivation_previous_status": turn.goal_reactivation_previous_status,
         "goal_reactivation_result_status": turn.goal_reactivation_result_status,
+        "post_turn_goal_refresh_attempted": bool(
+            turn.post_turn_goal_refresh_attempted
+        ),
+        "post_turn_goal_refresh_succeeded": bool(
+            turn.post_turn_goal_refresh_succeeded
+        ),
+        "post_turn_goal_get_present": bool(turn.post_turn_goal_status),
+        "post_turn_goal_status": turn.post_turn_goal_status,
+        "post_turn_goal_refresh_error_type": turn.post_turn_goal_refresh_error_type,
         "assistant_message_present": bool(assistant_message),
         "assistant_message_chars": len(assistant_message),
         "assistant_message_sha256": sha256(assistant_message.encode()).hexdigest()

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -9906,6 +9906,57 @@ def _new_controller_trace(route: str, *, max_rounds: int | None = None) -> dict[
     return trace
 
 
+def _apply_app_server_goal_round_semantics_to_controller_trace(
+    trace: dict[str, Any],
+    plan: dict[str, Any],
+) -> None:
+    round_semantics = (
+        plan.get("app_server_goal_round_semantics")
+        if isinstance(plan.get("app_server_goal_round_semantics"), dict)
+        else {}
+    )
+    independent_retry = (
+        plan.get("independent_goal_retry")
+        if isinstance(plan.get("independent_goal_retry"), dict)
+        else {}
+    )
+    same_thread_followup_budget = max(
+        0,
+        int(
+            round_semantics.get("same_thread_followup_budget")
+            if isinstance(round_semantics.get("same_thread_followup_budget"), int)
+            and not isinstance(round_semantics.get("same_thread_followup_budget"), bool)
+            else plan.get("app_server_goal_followup_max")
+            or 0
+        ),
+    )
+    independent_attempt_budget = max(
+        1,
+        int(
+            round_semantics.get("independent_attempt_budget")
+            if isinstance(round_semantics.get("independent_attempt_budget"), int)
+            and not isinstance(round_semantics.get("independent_attempt_budget"), bool)
+            else independent_retry.get("attempt_budget")
+            or 1
+        ),
+    )
+    trace["native_goal_worker_route"] = True
+    trace["native_goal_worker_session_policy"] = str(
+        round_semantics.get("session_policy")
+        or (
+            "single_thread_with_blinded_followups"
+            if same_thread_followup_budget
+            else "single_initial_goal_turn"
+        )
+    )[:120]
+    trace["native_goal_worker_same_thread_followup_budget"] = (
+        same_thread_followup_budget
+    )
+    trace["native_goal_worker_independent_attempt_budget"] = (
+        independent_attempt_budget
+    )
+
+
 def _write_controller_trace(plan: dict[str, Any], trace: dict[str, Any] | None) -> None:
     if not trace:
         return
@@ -13813,7 +13864,10 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
         controller_user = _build_codex_goal_mode_baseline_user()
     elif args.route == "codex-app-server-goal-baseline":
         controller_trace = _new_controller_trace(args.route, max_rounds=args.max_rounds)
-        controller_trace["native_goal_worker_route"] = True
+        _apply_app_server_goal_round_semantics_to_controller_trace(
+            controller_trace,
+            plan,
+        )
         controller_trace["last_decision"] = "host_app_server_goal_worker_selected"
 
     original_user_loop = install_benchflow_user_loop_final_verify_recovery(

--- a/scripts/skillsbench_host_codex_goal_worker.py
+++ b/scripts/skillsbench_host_codex_goal_worker.py
@@ -34,6 +34,7 @@ from scripts.codex_app_server_goal_driver import (  # noqa: E402
     CodexAppServerGoalDriverError,
     compact_turn_metadata,
     observe_codex_app_server_goal_turn,
+    refresh_codex_app_server_goal_status,
     start_codex_app_server_goal_followup_turn,
     start_codex_app_server_goal_turn,
 )
@@ -215,7 +216,18 @@ def _turn_completion_shape_unclean(compact: dict[str, Any]) -> bool:
     if compact.get("turn_completed_observed") is not True:
         return True
     status = str(compact.get("turn_status") or "").strip()
+    if not status and compact.get("post_turn_goal_refresh_succeeded") is True:
+        status = str(compact.get("post_turn_goal_status") or "").strip()
     return bool(status and status not in COMPLETE_TURN_STATUSES)
+
+
+def _refresh_completed_turn_goal_status(turn: Any, args: argparse.Namespace) -> None:
+    if getattr(turn, "turn_completed_observed", False) is not True:
+        return
+    refresh_codex_app_server_goal_status(
+        turn,
+        response_timeout_sec=max(0.1, float(args.response_timeout_sec or 0.1)),
+    )
 
 
 def _compact_worker_turn(
@@ -226,10 +238,17 @@ def _compact_worker_turn(
     lifecycle_contract: dict[str, object] | None,
 ) -> dict[str, Any]:
     compact = compact_turn_metadata(turn)
+    post_turn_goal_status = str(compact.get("post_turn_goal_status") or "").strip()
+    turn_status = str(compact.get("turn_status") or "").strip()
     compact.update(
         {
             "completion_hard_gate": False,
             "completion_source_of_truth": "codex_turn_completion",
+            "post_turn_goal_active_after_completed_turn": bool(
+                compact.get("turn_completed_observed") is True
+                and turn_status in COMPLETE_TURN_STATUSES
+                and post_turn_goal_status == "active"
+            ),
             "first_action_timeout_sec": max(
                 0.0, float(args.first_action_timeout_sec or 0.0)
             ),
@@ -335,6 +354,7 @@ def run_worker(args: argparse.Namespace) -> dict[str, Any]:
                         raise TimeoutError(
                             "timed out waiting for app-server worker turn completion"
                         )
+                    _refresh_completed_turn_goal_status(active_turn, args)
                 except (TimeoutError, CodexAppServerGoalDriverError) as exc:
                     if str(exc) == "codex_exec_first_action_timeout":
                         worker_error_type = "codex_exec_first_action_timeout"


### PR DESCRIPTION
## Summary
- refresh Codex app-server Goal status after observed turn completion and record only public-safe compact status fields
- keep completed turns countable when the post-turn goal remains active, while exposing that state for attribution
- seed app-server Goal controller trace from the configured followup/independent-attempt semantics instead of defaulting to single-turn/zero-followup fields

## Validation
- python3 -m py_compile scripts/codex_app_server_goal_driver.py scripts/skillsbench_host_codex_goal_worker.py scripts/skillsbench_automation_loop.py examples/skillsbench-app-server-goal-worker-smoke.py examples/skillsbench-benchmark-run-smoke.py
- python3 examples/skillsbench-app-server-goal-worker-smoke.py
- targeted app-server round-semantics smoke via importlib
- loopx check --scan-path scripts/codex_app_server_goal_driver.py --scan-path scripts/skillsbench_host_codex_goal_worker.py --scan-path scripts/skillsbench_automation_loop.py --scan-path examples/skillsbench-app-server-goal-worker-smoke.py --scan-path examples/skillsbench-benchmark-run-smoke.py

Note: full examples/skillsbench-benchmark-run-smoke.py still hits an existing reduce-only round_reward_count assertion unrelated to these touched paths; targeted round-semantics coverage passed.