### PR TITLE
Extract active-state todo output helpers

### DIFF
--- a/examples/control_plane/event-sourced-status-read-path-smoke.py
+++ b/examples/control_plane/event-sourced-status-read-path-smoke.py
@@ -100,14 +100,12 @@ def direct_active_state_todo_fields(goal: dict, *, runtime_root: Path | None = N
         rollout_event_log_path=status_module.rollout_event_log_path,
         max_todo_index_rollout_events_per_goal=status_module.MAX_TODO_INDEX_ROLLOUT_EVENTS_PER_GOAL,
         active_state_event_projection_fields=status_module.active_state_event_projection_fields,
-        attach_monitor_writeback_contract=status_module.attach_monitor_writeback_contract,
         parse_active_state_todos=status_module.parse_active_state_todos,
         parse_issue_meta_surface=status_module.parse_issue_meta_surface,
         backlog_hygiene_warning=status_module.backlog_hygiene_warning,
         completed_todo_archive_warning=status_module.completed_todo_archive_warning,
         autonomous_replan_obligation=status_module.autonomous_replan_obligation,
         state_projection_gap_warning=status_module.state_projection_gap_warning,
-        redacted_status_todo_fields=status_module.redacted_status_todo_fields,
     )
 
 

--- a/examples/control_plane/todo-readmodel-boundary-smoke.py
+++ b/examples/control_plane/todo-readmodel-boundary-smoke.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from copy import deepcopy
 from pathlib import Path
 import sys
+import tempfile
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -240,12 +241,51 @@ def assert_attention_item_parity() -> None:
     )
 
 
+def assert_active_state_todo_fields_redacts_review_material_paths() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-todo-redaction-") as tmp:
+        project = Path(tmp)
+        material = project / "docs" / "notes.md"
+        material.parent.mkdir(parents=True, exist_ok=True)
+        material.write_text("# Notes\n", encoding="utf-8")
+        state_path = project / ".codex" / "goals" / "loopx-meta" / "ACTIVE_GOAL_STATE.md"
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+        state_text = "\n".join(
+            [
+                "# Active State",
+                "## Agent Todos",
+                "- [ ] [P1] Review [notes](docs/notes.md)",
+                "",
+            ]
+        )
+        state_path.write_text(state_text, encoding="utf-8")
+        goal = {
+            "id": "loopx-meta",
+            "repo": str(project),
+            "state_file": ".codex/goals/loopx-meta/ACTIVE_GOAL_STATE.md",
+        }
+
+        raw_fields = status_module.parse_active_state_todos(
+            state_text,
+            goal=goal,
+            state_path=state_path,
+        )
+        raw_material = raw_fields["agent_todos"]["items"][0]["review_materials"][0]
+        assert raw_material["resolved_path"] == str(material.resolve()), raw_material
+
+        fields = status_module.active_state_todo_fields(goal)
+        material_projection = fields["agent_todos"]["items"][0]["review_materials"][0]
+        assert material_projection["path"] == "docs/notes.md", material_projection
+        assert material_projection["exists"] is True, material_projection
+        assert "resolved_path" not in material_projection, material_projection
+
+
 def main() -> None:
     assert_wrapper_parity()
     assert_dependency_blocker_parity()
     assert_autonomous_candidate_parity()
     assert_global_registry_shadow_parity()
     assert_attention_item_parity()
+    assert_active_state_todo_fields_redacts_review_material_paths()
 
 
 if __name__ == "__main__":

--- a/loopx/control_plane/todos/active_state_todos.py
+++ b/loopx/control_plane/todos/active_state_todos.py
@@ -3,6 +3,70 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any, Callable
 
+MONITOR_WRITEBACK_CONTRACT_SCHEMA_VERSION = "monitor_writeback_contract_v0"
+
+
+def _attach_monitor_writeback_contract(
+    fields: dict[str, Any],
+    *,
+    supported: bool,
+    source: str,
+) -> None:
+    if supported:
+        return
+    contract = {
+        "schema_version": MONITOR_WRITEBACK_CONTRACT_SCHEMA_VERSION,
+        "supported": False,
+        "source": source,
+    }
+    for key in ("user_todos", "agent_todos"):
+        summary = fields.get(key)
+        if isinstance(summary, dict):
+            summary["monitor_writeback"] = dict(contract)
+
+
+def attach_monitor_writeback_contract(
+    fields: dict[str, Any],
+    *,
+    supported: bool,
+    source: str,
+) -> None:
+    _attach_monitor_writeback_contract(fields, supported=supported, source=source)
+
+
+def _redacted_status_todo_fields(fields: dict[str, Any]) -> dict[str, Any]:
+    redacted = dict(fields)
+    for key in ("user_todos", "agent_todos"):
+        group = redacted.get(key)
+        if not isinstance(group, dict):
+            continue
+        group_copy = dict(group)
+        items: list[Any] = []
+        for item in group_copy.get("items") or []:
+            if not isinstance(item, dict):
+                items.append(item)
+                continue
+            item_copy = dict(item)
+            materials = item_copy.get("review_materials")
+            if isinstance(materials, list):
+                redacted_materials = []
+                for material in materials:
+                    if not isinstance(material, dict):
+                        redacted_materials.append(material)
+                        continue
+                    material_copy = dict(material)
+                    material_copy.pop("resolved_path", None)
+                    redacted_materials.append(material_copy)
+                item_copy["review_materials"] = redacted_materials
+            items.append(item_copy)
+        group_copy["items"] = items
+        redacted[key] = group_copy
+    return redacted
+
+
+def redacted_status_todo_fields(fields: dict[str, Any]) -> dict[str, Any]:
+    return _redacted_status_todo_fields(fields)
+
 
 def active_state_todo_fields(
     goal: dict[str, Any],
@@ -15,15 +79,17 @@ def active_state_todo_fields(
     rollout_event_log_path: Callable[[Path, str], Path],
     max_todo_index_rollout_events_per_goal: int,
     active_state_event_projection_fields: Callable[..., dict[str, Any]],
-    attach_monitor_writeback_contract: Callable[..., None],
     parse_active_state_todos: Callable[..., dict[str, Any]],
     parse_issue_meta_surface: Callable[[str], dict[str, Any] | None],
     backlog_hygiene_warning: Callable[..., dict[str, Any] | None],
     completed_todo_archive_warning: Callable[[dict[str, Any] | None], dict[str, Any] | None],
     autonomous_replan_obligation: Callable[..., dict[str, Any] | None],
     state_projection_gap_warning: Callable[..., dict[str, Any] | None],
-    redacted_status_todo_fields: Callable[[dict[str, Any]], dict[str, Any]],
+    attach_monitor_writeback_contract: Callable[..., None] | None = None,
+    redacted_status_todo_fields: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
+    monitor_writeback_contract_writer = attach_monitor_writeback_contract or _attach_monitor_writeback_contract
+    todo_field_redactor = redacted_status_todo_fields or _redacted_status_todo_fields
     state_path = resolve_goal_local_path(goal.get("state_file"), goal, fallback_base=Path.cwd())
     if state_path is None or not state_path.exists():
         return {}
@@ -50,7 +116,7 @@ def active_state_todo_fields(
     )
     if event_fields.get("user_todos") or event_fields.get("agent_todos"):
         fields = event_fields
-        attach_monitor_writeback_contract(
+        monitor_writeback_contract_writer(
             fields,
             supported=False,
             source="event_projection_read_model",
@@ -63,7 +129,7 @@ def active_state_todo_fields(
             preferred_todo_ids=preferred_todo_ids,
             rollout_events=rollout_events,
         )
-        attach_monitor_writeback_contract(
+        monitor_writeback_contract_writer(
             fields,
             supported=True,
             source="markdown_active_state",
@@ -101,5 +167,5 @@ def active_state_todo_fields(
     if projection_gap:
         fields["state_projection_gap"] = projection_gap
     if fields:
-        fields = redacted_status_todo_fields(fields)
+        fields = todo_field_redactor(fields)
     return fields

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -97,7 +97,10 @@ from .control_plane.goals.active_state_event_projection import (
     state_event_log_candidates as _state_event_log_candidates_read_model,
 )
 from .control_plane.todos.active_state_todos import (
+    MONITOR_WRITEBACK_CONTRACT_SCHEMA_VERSION as _MONITOR_WRITEBACK_CONTRACT_SCHEMA_VERSION,
     active_state_todo_fields as _active_state_todo_fields_read_model,
+    attach_monitor_writeback_contract as _attach_monitor_writeback_contract_read_model,
+    redacted_status_todo_fields as _redacted_status_todo_fields_read_model,
 )
 from .control_plane.todos.active_state_todo_parser import (
     parse_active_state_todos as _parse_active_state_todos_read_model,
@@ -427,7 +430,7 @@ STATUS_CONTRACT_SCHEMA_VERSION = 2
 MINIMUM_DASHBOARD_STATUS_CONTRACT_SCHEMA_VERSION = 2
 STATUS_CONTRACT_RELOAD_HINT = "scripts/macos-dashboard-launchagent.sh restart"
 STATUS_CONTRACT_SIGNAL_LIMIT = 3
-MONITOR_WRITEBACK_CONTRACT_SCHEMA_VERSION = "monitor_writeback_contract_v0"
+MONITOR_WRITEBACK_CONTRACT_SCHEMA_VERSION = _MONITOR_WRITEBACK_CONTRACT_SCHEMA_VERSION
 EVENT_LEDGER_DECISION_CLASSIFICATIONS = USER_OR_CONTROLLER_CLASSIFICATIONS | {
     "operator_gate_approved",
 }
@@ -5883,47 +5886,11 @@ def attach_monitor_writeback_contract(
     supported: bool,
     source: str,
 ) -> None:
-    if supported:
-        return
-    contract = {
-        "schema_version": MONITOR_WRITEBACK_CONTRACT_SCHEMA_VERSION,
-        "supported": False,
-        "source": source,
-    }
-    for key in ("user_todos", "agent_todos"):
-        summary = fields.get(key)
-        if isinstance(summary, dict):
-            summary["monitor_writeback"] = dict(contract)
+    _attach_monitor_writeback_contract_read_model(fields, supported=supported, source=source)
 
 
 def redacted_status_todo_fields(fields: dict[str, Any]) -> dict[str, Any]:
-    redacted = dict(fields)
-    for key in ("user_todos", "agent_todos"):
-        group = redacted.get(key)
-        if not isinstance(group, dict):
-            continue
-        group_copy = dict(group)
-        items: list[Any] = []
-        for item in group_copy.get("items") or []:
-            if not isinstance(item, dict):
-                items.append(item)
-                continue
-            item_copy = dict(item)
-            materials = item_copy.get("review_materials")
-            if isinstance(materials, list):
-                redacted_materials = []
-                for material in materials:
-                    if not isinstance(material, dict):
-                        redacted_materials.append(material)
-                        continue
-                    material_copy = dict(material)
-                    material_copy.pop("resolved_path", None)
-                    redacted_materials.append(material_copy)
-                item_copy["review_materials"] = redacted_materials
-            items.append(item_copy)
-        group_copy["items"] = items
-        redacted[key] = group_copy
-    return redacted
+    return _redacted_status_todo_fields_read_model(fields)
 
 
 def parse_active_state_todos(
@@ -6515,14 +6482,12 @@ def active_state_todo_fields(
         rollout_event_log_path=rollout_event_log_path,
         max_todo_index_rollout_events_per_goal=MAX_TODO_INDEX_ROLLOUT_EVENTS_PER_GOAL,
         active_state_event_projection_fields=active_state_event_projection_fields,
-        attach_monitor_writeback_contract=attach_monitor_writeback_contract,
         parse_active_state_todos=parse_active_state_todos,
         parse_issue_meta_surface=parse_issue_meta_surface,
         backlog_hygiene_warning=backlog_hygiene_warning,
         completed_todo_archive_warning=completed_todo_archive_warning,
         autonomous_replan_obligation=autonomous_replan_obligation,
         state_projection_gap_warning=state_projection_gap_warning,
-        redacted_status_todo_fields=redacted_status_todo_fields,
     )
 
 


### PR DESCRIPTION
## Summary
- move active-state todo monitor writeback and review material redaction helpers into the todo read-model module
- keep status.py compatibility wrappers while removing those helpers from the active_state_todo_fields injection path
- extend the todo read-model boundary smoke to assert resolved_path stays internal while public material fields remain projected

## Validation
- python3 examples/control_plane/todo-readmodel-boundary-smoke.py
- python3 examples/control_plane/event-sourced-status-read-path-smoke.py
- python3 examples/control_plane/event-sourced-downstream-read-path-smoke.py
- python3 examples/control_plane/monitor-poll-writeback-smoke.py
- python3 examples/control_plane/status-contract-readmodel-smoke.py
- python3 examples/control_plane/todo-first-open-summary-smoke.py
- python3 examples/control_plane/todo-cli-smoke.py
- python3 examples/control_plane/monitor-scheduler-contract-smoke.py
- python3 -m py_compile loopx/control_plane/todos/active_state_todos.py loopx/status.py examples/control_plane/event-sourced-status-read-path-smoke.py examples/control_plane/todo-readmodel-boundary-smoke.py
- git diff --check HEAD~1..HEAD