### PR TITLE
Add slash command uninstall safety

### DIFF
--- a/examples/slash-command-install-smoke.py
+++ b/examples/slash-command-install-smoke.py
@@ -51,6 +51,7 @@ def main() -> int:
             ).stdout
         )
         assert dry["schema_version"] == "loopx_slash_command_install_v0", dry
+        assert dry["operation"] == "install", dry
         assert dry["execute"] is False, dry
         assert dry["summary"]["status_counts"]["would_create"] >= 20, dry
         assert dry["summary"]["status_counts"]["unsupported_host_surface"] >= 1, dry
@@ -71,6 +72,7 @@ def main() -> int:
             ).stdout
         )
         assert payload["execute"] is True, payload
+        assert payload["operation"] == "install", payload
         assert payload["summary"]["codex_prompt_dir"] is None, payload
         assert payload["summary"]["codex_skill_dir"] == str(codex_home / "skills"), payload
         assert payload["summary"]["claude_skill_dir"] == str(claude_home / "skills"), payload
@@ -98,6 +100,8 @@ def main() -> int:
         ]
         assert codex_cli_rows, payload
         assert codex_cli_rows[0]["status"] == "unsupported_host_surface", codex_cli_rows
+        assert codex_cli_rows[0]["native_registry_supported"] is False, codex_cli_rows
+        assert codex_cli_rows[0]["failure_policy"] == "fail_closed_to_explicit_skill", codex_cli_rows
         assert "$loopx" in codex_cli_rows[0]["fallback"], codex_cli_rows
 
         codex_skill = codex_home / "skills" / "loopx" / "SKILL.md"
@@ -204,6 +208,110 @@ def main() -> int:
         assert codex_only["summary"]["codex_skill_dir"] == str(root / "codex-only" / "skills"), codex_only
         assert codex_only["summary"]["claude_skill_dir"] is None, codex_only
         assert codex_only["summary"]["status_counts"]["unsupported_host_surface"] == 10, codex_only
+
+        legacy_codex_home = root / "legacy-codex"
+        legacy_claude_home = root / "legacy-claude"
+        legacy_skill = legacy_codex_home / "skills" / "loopx" / "SKILL.md"
+        legacy_skill.parent.mkdir(parents=True)
+        legacy_skill.write_text(
+            "# Legacy LoopX\n\nloopx goal-mode setup (NOT Claude Code's built-in /goal)\n",
+            encoding="utf-8",
+        )
+        legacy_install = json.loads(
+            run_cli(
+                "--format",
+                "json",
+                "slash-commands",
+                "--install",
+                "--surface",
+                "codex",
+                "--codex-home",
+                str(legacy_codex_home),
+                "--claude-home",
+                str(legacy_claude_home),
+            ).stdout
+        )
+        assert statuses_for(legacy_install, legacy_skill) == ["upgraded_legacy_managed"], legacy_install
+        assert "loopx-managed-slash-command:v1 command=/loopx surface=codex-skills" in legacy_skill.read_text(encoding="utf-8")
+
+        uninstall_codex_home = root / "uninstall-codex"
+        uninstall_claude_home = root / "uninstall-claude"
+        uninstall_seed = json.loads(
+            run_cli(
+                "--format",
+                "json",
+                "slash-commands",
+                "--install",
+                "--codex-home",
+                str(uninstall_codex_home),
+                "--claude-home",
+                str(uninstall_claude_home),
+            ).stdout
+        )
+        assert uninstall_seed["summary"]["status_counts"]["created"] >= 20, uninstall_seed
+        uninstall_user_skill = uninstall_codex_home / "skills" / "loopx-global-risks" / "SKILL.md"
+        uninstall_user_skill.write_text("# user-owned LoopX helper\n", encoding="utf-8")
+        managed_legacy_prompt = uninstall_codex_home / "prompts" / "loopx.md"
+        managed_legacy_prompt.parent.mkdir(parents=True)
+        managed_legacy_prompt.write_text(
+            "<!-- loopx-managed-slash-command:v1 command=/loopx surface=codex-prompts -->\n",
+            encoding="utf-8",
+        )
+        dry_uninstall = json.loads(
+            run_cli(
+                "--format",
+                "json",
+                "slash-commands",
+                "--uninstall",
+                "--dry-run",
+                "--codex-home",
+                str(uninstall_codex_home),
+                "--claude-home",
+                str(uninstall_claude_home),
+            ).stdout
+        )
+        assert dry_uninstall["operation"] == "uninstall", dry_uninstall
+        assert dry_uninstall["execute"] is False, dry_uninstall
+        assert dry_uninstall["summary"]["status_counts"]["would_retire_managed_file"] >= 20, dry_uninstall
+        assert statuses_for(dry_uninstall, uninstall_user_skill) == ["skipped_user_file"], dry_uninstall
+        assert uninstall_user_skill.exists(), dry_uninstall
+
+        uninstall = json.loads(
+            run_cli(
+                "--format",
+                "json",
+                "slash-commands",
+                "--uninstall",
+                "--codex-home",
+                str(uninstall_codex_home),
+                "--claude-home",
+                str(uninstall_claude_home),
+            ).stdout
+        )
+        assert uninstall["operation"] == "uninstall", uninstall
+        assert uninstall["execute"] is True, uninstall
+        assert uninstall["summary"]["status_counts"]["retired_managed_file"] >= 20, uninstall
+        assert statuses_for(uninstall, uninstall_user_skill) == ["skipped_user_file"], uninstall
+        assert not (uninstall_codex_home / "skills" / "loopx" / "SKILL.md").exists()
+        assert not (uninstall_codex_home / "skills" / "loopx" / "agents" / "openai.yaml").exists()
+        assert not (uninstall_claude_home / "skills" / "loopx" / "SKILL.md").exists()
+        assert not managed_legacy_prompt.exists()
+        assert uninstall_user_skill.read_text(encoding="utf-8") == "# user-owned LoopX helper\n"
+        assert not (uninstall_user_skill.parent / "agents" / "openai.yaml").exists()
+
+        uninstall_again = json.loads(
+            run_cli(
+                "--format",
+                "json",
+                "slash-commands",
+                "--uninstall",
+                "--codex-home",
+                str(uninstall_codex_home),
+                "--claude-home",
+                str(uninstall_claude_home),
+            ).stdout
+        )
+        assert uninstall_again["summary"]["status_counts"]["absent"] >= 20, uninstall_again
 
     print("slash-command-install-smoke ok")
     return 0

--- a/loopx/cli_commands/slash_commands.py
+++ b/loopx/cli_commands/slash_commands.py
@@ -36,10 +36,16 @@ def register_slash_commands_command(
         action="store_true",
         help="Hide legacy /loop-global-* aliases from the command catalog.",
     )
-    parser.add_argument(
+    install_group = parser.add_mutually_exclusive_group()
+    install_group.add_argument(
         "--install",
         action="store_true",
         help="Install LoopX command skill files for supported hosts.",
+    )
+    install_group.add_argument(
+        "--uninstall",
+        action="store_true",
+        help="Remove LoopX-managed command skill files for supported hosts while preserving user-owned files.",
     )
     parser.add_argument(
         "--surface",
@@ -73,9 +79,10 @@ def handle_slash_commands_command(
 ) -> int | None:
     if args.command != "slash-commands":
         return None
-    if args.install or args.dry_run:
+    if args.install or args.uninstall or args.dry_run:
         payload = install_slash_commands(
-            execute=bool(args.install and not args.dry_run),
+            execute=bool((args.install or args.uninstall) and not args.dry_run),
+            uninstall=bool(args.uninstall),
             surfaces=args.surface,
             cli_bin=args.cli_bin,
             include_legacy_aliases=not bool(args.no_legacy_aliases),

--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -208,6 +208,10 @@ def _retire_managed_file(path: Path, *, execute: bool) -> str | None:
     return "retired_managed_file" if execute else "would_retire_managed_file"
 
 
+def _retire_status(path: Path, *, execute: bool) -> str:
+    return _retire_managed_file(path, execute=execute) or "absent"
+
+
 def _codex_home(value: str | None = None) -> Path:
     raw = value or os.environ.get("CODEX_HOME") or str(Path.home() / ".codex")
     return Path(raw).expanduser()
@@ -239,6 +243,7 @@ def _normalize_surfaces(surfaces: list[str] | None) -> list[str]:
 def install_slash_commands(
     *,
     execute: bool,
+    uninstall: bool = False,
     surfaces: list[str] | None = None,
     cli_bin: str = "loopx",
     include_legacy_aliases: bool = True,
@@ -255,6 +260,20 @@ def install_slash_commands(
         prompt_dir = codex_root / "prompts"
         for spec in specs:
             prompt_path = prompt_dir / f"{spec['name']}.md"
+            if uninstall:
+                retire_status = _retire_status(prompt_path, execute=execute)
+                installed.append(
+                    {
+                        "surface": "codex",
+                        "host_surfaces": ["codex-cli", "codex-ide", "codex-app"],
+                        "mechanism": "retired_codex_custom_prompt",
+                        "command": spec["command"],
+                        "path": str(prompt_path),
+                        "status": retire_status,
+                        "invoke_as": [],
+                    }
+                )
+                continue
             retire_status = _retire_managed_file(prompt_path, execute=execute)
             if retire_status:
                 installed.append(
@@ -272,6 +291,33 @@ def install_slash_commands(
         skill_dir = codex_root / "skills"
         for spec in specs:
             skill_path = skill_dir / str(spec["name"]) / "SKILL.md"
+            metadata_path = skill_path.parent / "agents" / "openai.yaml"
+            if uninstall:
+                skill_status = _retire_status(skill_path, execute=execute)
+                installed.append(
+                    {
+                        "surface": "codex",
+                        "host_surfaces": ["codex-cli", "codex-ide", "codex-app"],
+                        "mechanism": "codex_explicit_skills",
+                        "command": spec["command"],
+                        "path": str(skill_path),
+                        "status": skill_status,
+                        "invoke_as": [f"${spec['name']}", "/skills"],
+                    }
+                )
+                metadata_status = _retire_status(metadata_path, execute=execute)
+                installed.append(
+                    {
+                        "surface": "codex",
+                        "host_surfaces": ["codex-cli", "codex-ide", "codex-app"],
+                        "mechanism": "codex_skill_openai_metadata",
+                        "command": spec["command"],
+                        "path": str(metadata_path),
+                        "status": metadata_status,
+                        "invoke_as": [f"${spec['name']}", "/skills"],
+                    }
+                )
+                continue
             skill_content = _skill_body(
                 command=str(spec["command"]),
                 title=f"LoopX {spec['command']}",
@@ -293,7 +339,6 @@ def install_slash_commands(
                     "invoke_as": [f"${spec['name']}", "/skills"],
                 }
             )
-            metadata_path = skill_path.parent / "agents" / "openai.yaml"
             if skill_status not in {"skipped_user_file", "preserved_existing_loopx_skill"}:
                 metadata = _openai_skill_metadata(
                     command=str(spec["command"]),
@@ -340,6 +385,8 @@ def install_slash_commands(
                         "Current Codex does not support user-defined native top-level slash "
                         "commands. Use explicit skills instead."
                     ),
+                    "native_registry_supported": False,
+                    "failure_policy": "fail_closed_to_explicit_skill",
                     "fallback": "Use `$loopx` or `/skills` to explicitly invoke the LoopX skill; for the visible TUI loop, run `loopx codex-cli-bootstrap-message --project .`, paste the setup message, then set `/goal <thin task_body>`.",
                 }
             )
@@ -348,6 +395,19 @@ def install_slash_commands(
         skills_dir = claude_root / "skills"
         for spec in specs:
             path = skills_dir / str(spec["name"]) / "SKILL.md"
+            if uninstall:
+                status = _retire_status(path, execute=execute)
+                installed.append(
+                    {
+                        "surface": "claude-code",
+                        "mechanism": "claude_code_skills",
+                        "command": spec["command"],
+                        "path": str(path),
+                        "status": status,
+                        "invoke_as": [str(spec["command"])],
+                    }
+                )
+                continue
             content = _skill_body(
                 command=str(spec["command"]),
                 title=f"LoopX {spec['command']}",
@@ -377,6 +437,7 @@ def install_slash_commands(
     return {
         "ok": True,
         "schema_version": SCHEMA_VERSION,
+        "operation": "uninstall" if uninstall else "install",
         "execute": execute,
         "requested_surfaces": surfaces or ["all"],
         "effective_surfaces": effective_surfaces,
@@ -389,21 +450,28 @@ def install_slash_commands(
             "codex_skill_dir": str(codex_root / "skills") if "codex" in effective_surfaces else None,
             "claude_skill_dir": str(claude_root / "skills") if "claude-code" in effective_surfaces else None,
             "status_counts": status_counts,
-            "skip_policy": "LoopX-managed files are upgraded; same-name user files without a LoopX managed marker or legacy signature are never overwritten",
+            "skip_policy": (
+                "Uninstall removes only LoopX-managed files; user files without a LoopX managed marker are preserved"
+                if uninstall
+                else "LoopX-managed files are upgraded; same-name user files without a LoopX managed marker or legacy signature are never overwritten"
+            ),
         },
         "installed": installed,
         "notes": [
             "Codex does not currently support user-defined native top-level slash commands; use explicit skill invocation through `$loopx` or `/skills`.",
             "Only explicit LoopX command-facade skills are installed with agents/openai.yaml policy allow_implicit_invocation=false; richer workflow skills stay implicit.",
             "Claude Code discovers user skills from CLAUDE_HOME/skills and exposes each skill name as a slash command.",
+            "Uninstall is fail-closed: it retires only files carrying the LoopX managed marker and leaves user-owned files in place.",
         ],
     }
 
 
 def render_slash_command_install_markdown(payload: dict[str, Any]) -> str:
+    operation = str(payload.get("operation") or "install")
     lines = [
-        "# LoopX Slash Command Install",
+        "# LoopX Slash Command Uninstall" if operation == "uninstall" else "# LoopX Slash Command Install",
         "",
+        f"- operation: `{operation}`",
         f"- execute: `{payload.get('execute')}`",
         f"- surfaces: `{','.join(payload.get('effective_surfaces') or [])}`",
         f"- skip policy: `{payload.get('summary', {}).get('skip_policy')}`",


### PR DESCRIPTION
## Summary
- add `loopx slash-commands --uninstall` with managed-marker-only removal for Codex and Claude skill files
- preserve user-owned same-name files and expose native Codex slash registry as explicit fail-closed metadata
- extend slash-command install smoke for legacy migration, uninstall dry-run/execute/idempotency, and user-file preservation

## Validation
- `python3 -m py_compile loopx/slash_command_install.py loopx/cli_commands/slash_commands.py examples/slash-command-install-smoke.py`
- `python3 examples/slash-command-install-smoke.py`
- `python3 examples/slash-command-catalog-smoke.py`
- `python3 examples/codex-app-host-command-registry-smoke.py`
- `git diff --check`
- `loopx check --scan-path loopx/slash_command_install.py --scan-path loopx/cli_commands/slash_commands.py --scan-path examples/slash-command-install-smoke.py`

## Notes
- Not self-merged in this heartbeat because it changes CLI install/uninstall behavior, not just docs or narrow cleanup.
- The flink-query app-server xhigh rerun is separately blocked on local Kerberos and reverse-proxy readiness; that blocker was written to LoopX user todo `todo_269b8d424951`.
