### PR TITLE
Move todo visibility defaults into read model

### DIFF
--- a/examples/control_plane/todo-readmodel-boundary-smoke.py
+++ b/examples/control_plane/todo-readmodel-boundary-smoke.py
@@ -70,35 +70,19 @@ def fixture_todos() -> dict:
 def assert_wrapper_parity() -> None:
     todos = fixture_todos()
 
-    assert status_module.open_todo_items(todos) == todo_read_model.open_todo_items(
-        todos,
-        limit=status_module.MAX_PROJECT_ASSET_TODO_ITEMS,
-        text_limit=220,
-    )
+    assert status_module.open_todo_items(todos) == todo_read_model.open_todo_items(todos)
     assert status_module.todo_lane_items(todos, "monitor_open_items") == todo_read_model.todo_lane_items(
         todos,
         "monitor_open_items",
-        limit=status_module.MAX_STATUS_TODOS_PER_ROLE,
-        text_limit=220,
     )
-    assert status_module.first_open_todo_text(todos) == todo_read_model.first_open_todo_text(
-        todos,
-        item_limit=220,
-    )
-    assert status_module.first_open_todo_item(todos) == todo_read_model.first_open_todo_item(
-        todos,
-        item_limit=status_module.MAX_PROJECT_ASSET_TODO_ITEMS,
-        text_limit=220,
-    )
+    assert status_module.first_open_todo_text(todos) == todo_read_model.first_open_todo_text(todos)
+    assert status_module.first_open_todo_item(todos) == todo_read_model.first_open_todo_item(todos)
     assert status_module.project_asset_todo_summary(
         todos,
         role="agent",
     ) == todo_read_model.project_asset_todo_summary(
         todos,
         role="agent",
-        item_limit=status_module.MAX_PROJECT_ASSET_TODO_ITEMS,
-        deferred_item_limit=status_module.MAX_DEFERRED_TODO_VISIBILITY_ITEMS,
-        advancement_task_class=status_module.TODO_TASK_CLASS_ADVANCEMENT,
     )
 
 
@@ -136,16 +120,12 @@ def assert_dependency_blocker_parity() -> None:
     ) == todo_read_model.dependency_blocker_summary(
         items,
         current_goal_id="current",
-        limit=status_module.MAX_DEPENDENCY_BLOCKERS,
     )
 
     status_items = deepcopy(items)
     direct_items = deepcopy(items)
     status_module.attach_dependency_blockers(status_items)
-    todo_read_model.attach_dependency_blockers(
-        direct_items,
-        limit=status_module.MAX_DEPENDENCY_BLOCKERS,
-    )
+    todo_read_model.attach_dependency_blockers(direct_items)
     assert status_items == direct_items
 
 

--- a/loopx/control_plane/todos/todo_summary.py
+++ b/loopx/control_plane/todos/todo_summary.py
@@ -43,10 +43,12 @@ from ..work_items.project_asset import build_project_asset_todo_summary
 
 
 MAX_STATUS_TODOS_PER_ROLE = 12
+MAX_PROJECT_ASSET_TODO_ITEMS = 3
 MAX_PROJECT_ASSET_TODO_BACKLOG_ITEMS = 8
 MAX_TODO_VISIBILITY_LANE_ITEMS = 16
 MAX_DEFERRED_TODO_VISIBILITY_ITEMS = 8
 MAX_MONITOR_DUE_ITEMS = 1
+MAX_DEPENDENCY_BLOCKERS = 4
 
 TODO_ITEM_SCHEMA_VERSION = "todo_item_v0"
 AttentionItemBuilder = Callable[..., dict[str, Any]]
@@ -361,8 +363,8 @@ def todo_item_is_deferred(item: dict[str, Any]) -> bool:
 def open_todo_items(
     todos: dict[str, Any] | None,
     *,
-    limit: int,
-    text_limit: int,
+    limit: int = MAX_PROJECT_ASSET_TODO_ITEMS,
+    text_limit: int = 220,
     source_keys: tuple[str, ...] = ("first_open_items", "items"),
 ) -> list[dict[str, Any]]:
     if not isinstance(todos, dict):
@@ -396,8 +398,8 @@ def todo_lane_items(
     todos: dict[str, Any] | None,
     lane: str,
     *,
-    limit: int,
-    text_limit: int,
+    limit: int = MAX_STATUS_TODOS_PER_ROLE,
+    text_limit: int = 220,
 ) -> list[dict[str, Any]]:
     return open_todo_items(
         todos,
@@ -410,7 +412,7 @@ def todo_lane_items(
 def first_open_todo_text(
     todos: dict[str, Any] | None,
     *,
-    item_limit: int,
+    item_limit: int = 220,
 ) -> str | None:
     items = open_todo_items(todos, limit=1, text_limit=item_limit)
     if not items:
@@ -421,8 +423,8 @@ def first_open_todo_text(
 def first_open_todo_item(
     todos: dict[str, Any] | None,
     *,
-    item_limit: int,
-    text_limit: int,
+    item_limit: int = MAX_PROJECT_ASSET_TODO_ITEMS,
+    text_limit: int = 220,
 ) -> dict[str, Any] | None:
     for todo in open_todo_items(todos, limit=item_limit, text_limit=text_limit):
         if not isinstance(todo, dict) or todo.get("done"):
@@ -435,8 +437,8 @@ def project_asset_todo_summary(
     todos: dict[str, Any] | None,
     *,
     role: str | None = None,
-    item_limit: int,
-    deferred_item_limit: int,
+    item_limit: int = MAX_PROJECT_ASSET_TODO_ITEMS,
+    deferred_item_limit: int = MAX_DEFERRED_TODO_VISIBILITY_ITEMS,
     advancement_task_class: str = TODO_TASK_CLASS_ADVANCEMENT,
 ) -> dict[str, Any] | None:
     return build_project_asset_todo_summary(
@@ -467,7 +469,7 @@ def dependency_blocker_summary(
     items: list[dict[str, Any]],
     *,
     current_goal_id: str,
-    limit: int,
+    limit: int = MAX_DEPENDENCY_BLOCKERS,
 ) -> dict[str, Any] | None:
     blockers: list[dict[str, Any]] = []
     for item in items:
@@ -503,7 +505,11 @@ def dependency_blocker_summary(
     }
 
 
-def attach_dependency_blockers(items: list[dict[str, Any]], *, limit: int) -> None:
+def attach_dependency_blockers(
+    items: list[dict[str, Any]],
+    *,
+    limit: int = MAX_DEPENDENCY_BLOCKERS,
+) -> None:
     for item in items:
         if not isinstance(item, dict):
             continue

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -230,6 +230,13 @@ from .control_plane.work_items.status_contract import (
     compact_status_contract_signals as _compact_status_contract_signals_read_model,
 )
 from .control_plane.todos.todo_summary import (
+    MAX_DEFERRED_TODO_VISIBILITY_ITEMS as _TODO_SUMMARY_MAX_DEFERRED_TODO_VISIBILITY_ITEMS,
+    MAX_DEPENDENCY_BLOCKERS as _TODO_SUMMARY_MAX_DEPENDENCY_BLOCKERS,
+    MAX_MONITOR_DUE_ITEMS as _TODO_SUMMARY_MAX_MONITOR_DUE_ITEMS,
+    MAX_PROJECT_ASSET_TODO_BACKLOG_ITEMS as _TODO_SUMMARY_MAX_PROJECT_ASSET_TODO_BACKLOG_ITEMS,
+    MAX_PROJECT_ASSET_TODO_ITEMS as _TODO_SUMMARY_MAX_PROJECT_ASSET_TODO_ITEMS,
+    MAX_STATUS_TODOS_PER_ROLE as _TODO_SUMMARY_MAX_STATUS_TODOS_PER_ROLE,
+    MAX_TODO_VISIBILITY_LANE_ITEMS as _TODO_SUMMARY_MAX_TODO_VISIBILITY_LANE_ITEMS,
     active_state_todo_attention_item as _active_state_todo_attention_item_read_model,
     active_next_action_todo_ids,
     attach_dependency_blockers as _attach_dependency_blockers_read_model,
@@ -539,14 +546,14 @@ LIFECYCLE_PRIORITY = (
     "run_recorded",
 )
 SECTION_HEADING_PATTERN = re.compile(r"^##+\s+(.+?)\s*$")
-MAX_STATUS_TODOS_PER_ROLE = 12
+MAX_STATUS_TODOS_PER_ROLE = _TODO_SUMMARY_MAX_STATUS_TODOS_PER_ROLE
 MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE = MAX_STATUS_TODOS_PER_ROLE
-MAX_PROJECT_ASSET_TODO_ITEMS = 3
-MAX_PROJECT_ASSET_TODO_BACKLOG_ITEMS = 8
-MAX_TODO_VISIBILITY_LANE_ITEMS = 16
-MAX_DEFERRED_TODO_VISIBILITY_ITEMS = 8
-MAX_MONITOR_DUE_ITEMS = 1
-MAX_DEPENDENCY_BLOCKERS = 4
+MAX_PROJECT_ASSET_TODO_ITEMS = _TODO_SUMMARY_MAX_PROJECT_ASSET_TODO_ITEMS
+MAX_PROJECT_ASSET_TODO_BACKLOG_ITEMS = _TODO_SUMMARY_MAX_PROJECT_ASSET_TODO_BACKLOG_ITEMS
+MAX_TODO_VISIBILITY_LANE_ITEMS = _TODO_SUMMARY_MAX_TODO_VISIBILITY_LANE_ITEMS
+MAX_DEFERRED_TODO_VISIBILITY_ITEMS = _TODO_SUMMARY_MAX_DEFERRED_TODO_VISIBILITY_ITEMS
+MAX_MONITOR_DUE_ITEMS = _TODO_SUMMARY_MAX_MONITOR_DUE_ITEMS
+MAX_DEPENDENCY_BLOCKERS = _TODO_SUMMARY_MAX_DEPENDENCY_BLOCKERS
 MAX_AUTONOMOUS_BACKLOG_CANDIDATES = 6
 MAX_SUBAGENT_SCOPE_ITEMS = 4
 MAX_BACKLOG_HYGIENE_EVIDENCE_ITEMS = 3
@@ -6140,7 +6147,7 @@ def todo_lane_items(
 
 
 def first_open_todo_text(todos: dict[str, Any] | None) -> str | None:
-    return _first_open_todo_text_read_model(todos, item_limit=220)
+    return _first_open_todo_text_read_model(todos)
 
 
 def project_asset_todo_summary(
@@ -6151,9 +6158,6 @@ def project_asset_todo_summary(
     return _project_asset_todo_summary_read_model(
         todos,
         role=role,
-        item_limit=MAX_PROJECT_ASSET_TODO_ITEMS,
-        deferred_item_limit=MAX_DEFERRED_TODO_VISIBILITY_ITEMS,
-        advancement_task_class=TODO_TASK_CLASS_ADVANCEMENT,
     )
 
 
@@ -6171,15 +6175,11 @@ def dependency_blocker_summary(
 
 
 def attach_dependency_blockers(items: list[dict[str, Any]]) -> None:
-    _attach_dependency_blockers_read_model(items, limit=MAX_DEPENDENCY_BLOCKERS)
+    _attach_dependency_blockers_read_model(items)
 
 
 def first_open_todo_item(todos: dict[str, Any] | None) -> dict[str, Any] | None:
-    return _first_open_todo_item_read_model(
-        todos,
-        item_limit=MAX_PROJECT_ASSET_TODO_ITEMS,
-        text_limit=220,
-    )
+    return _first_open_todo_item_read_model(todos)
 
 
 def autonomous_priority_label(text: str) -> str | None:


### PR DESCRIPTION
## Summary
- move todo visibility default limits into `control_plane/todos/todo_summary.py`
- keep `status.py` public constants as compatibility aliases to the todo read model
- update the todo read-model boundary smoke so default behavior is validated directly from the read model, not re-specified by `status.py`

## Validation
- python3 examples/control_plane/todo-readmodel-boundary-smoke.py
- python3 examples/control_plane/todo-first-open-summary-smoke.py
- python3 examples/control_plane/todo-cli-smoke.py
- python3 examples/project/project-asset-todo-projection-gap-smoke.py
- python3 examples/control_plane/event-sourced-status-read-path-smoke.py
- python3 examples/control_plane/event-sourced-downstream-read-path-smoke.py
- python3 examples/control_plane/status-contract-readmodel-smoke.py
- python3 examples/control_plane/monitor-scheduler-contract-smoke.py
- python3 examples/control_plane/monitor-poll-writeback-smoke.py
- python3 -m py_compile loopx/control_plane/todos/todo_summary.py loopx/status.py examples/control_plane/todo-readmodel-boundary-smoke.py
- git diff --check HEAD~1..HEAD
