### PR TITLE
Move autonomous candidate limit into read model

### DIFF
--- a/examples/control_plane/todo-readmodel-boundary-smoke.py
+++ b/examples/control_plane/todo-readmodel-boundary-smoke.py
@@ -159,7 +159,6 @@ def assert_autonomous_candidate_parity() -> None:
         todo_item_is_actionable_open=status_module.todo_item_is_actionable_open,
         normalize_todo_text=status_module.normalize_todo_text,
         advancement_task_class=status_module.TODO_TASK_CLASS_ADVANCEMENT,
-        limit=status_module.MAX_AUTONOMOUS_BACKLOG_CANDIDATES,
     )
     assert status_module.autonomous_monitor_candidates(items) == autonomous_read_model.autonomous_monitor_candidates(
         items,
@@ -168,7 +167,6 @@ def assert_autonomous_candidate_parity() -> None:
         normalize_todo_text=status_module.normalize_todo_text,
         monitor_task_class=status_module.TODO_TASK_CLASS_MONITOR,
         monitor_signal_waiting_on=status_module.MONITOR_SIGNAL_WAITING_ON,
-        limit=status_module.MAX_AUTONOMOUS_BACKLOG_CANDIDATES,
     )
 
 

--- a/examples/maintenance-latest-run-routing-smoke.py
+++ b/examples/maintenance-latest-run-routing-smoke.py
@@ -86,7 +86,6 @@ def main() -> int:
         open_todo_items=open_todo_items,
         todo_item_is_actionable_open=todo_item_is_actionable_open,
         normalize_todo_text=normalize_todo_text,
-        limit=6,
     )
     assert direct_backlog == backlog, (direct_backlog, backlog)
     status_payload = {

--- a/loopx/control_plane/work_items/autonomous_candidates.py
+++ b/loopx/control_plane/work_items/autonomous_candidates.py
@@ -7,6 +7,8 @@ from ...todo_contract import normalize_todo_action_kind, normalize_todo_task_cla
 
 
 AUTONOMOUS_PRIORITY_PATTERN = re.compile(r"^\s*\[(P[0-4][^\]]*)\]\s*(.+)$", re.I)
+MAX_AUTONOMOUS_TODO_CANDIDATES = 6
+MAX_AUTONOMOUS_BACKLOG_CANDIDATES = MAX_AUTONOMOUS_TODO_CANDIDATES
 
 
 def autonomous_priority_label(text: str) -> str | None:
@@ -33,7 +35,7 @@ def autonomous_todo_candidates(
     todo_item_is_actionable_open: Callable[[dict[str, Any]], bool],
     normalize_todo_text: Callable[..., str],
     allowed_waiting_on: set[str] | None = None,
-    limit: int,
+    limit: int = MAX_AUTONOMOUS_TODO_CANDIDATES,
 ) -> dict[str, Any] | None:
     allowed_waiting_on = allowed_waiting_on or {"codex"}
     candidates: list[dict[str, Any]] = []
@@ -100,7 +102,7 @@ def autonomous_backlog_candidates(
     todo_item_is_actionable_open: Callable[[dict[str, Any]], bool],
     normalize_todo_text: Callable[..., str],
     advancement_task_class: str,
-    limit: int,
+    limit: int = MAX_AUTONOMOUS_TODO_CANDIDATES,
 ) -> dict[str, Any] | None:
     return autonomous_todo_candidates(
         items,
@@ -120,7 +122,7 @@ def autonomous_monitor_candidates(
     normalize_todo_text: Callable[..., str],
     monitor_task_class: str,
     monitor_signal_waiting_on: str,
-    limit: int,
+    limit: int = MAX_AUTONOMOUS_TODO_CANDIDATES,
 ) -> dict[str, Any] | None:
     return autonomous_todo_candidates(
         items,

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -70,6 +70,7 @@ from .control_plane.handoff.project_handoff import (
     project_asset_handoff_state as _project_asset_handoff_state_read_model,
 )
 from .control_plane.work_items.autonomous_candidates import (
+    MAX_AUTONOMOUS_TODO_CANDIDATES as _MAX_AUTONOMOUS_TODO_CANDIDATES,
     autonomous_backlog_candidates as _autonomous_backlog_candidates_read_model,
     autonomous_monitor_candidates as _autonomous_monitor_candidates_read_model,
     autonomous_priority_label as _autonomous_priority_label,
@@ -554,7 +555,7 @@ MAX_TODO_VISIBILITY_LANE_ITEMS = _TODO_SUMMARY_MAX_TODO_VISIBILITY_LANE_ITEMS
 MAX_DEFERRED_TODO_VISIBILITY_ITEMS = _TODO_SUMMARY_MAX_DEFERRED_TODO_VISIBILITY_ITEMS
 MAX_MONITOR_DUE_ITEMS = _TODO_SUMMARY_MAX_MONITOR_DUE_ITEMS
 MAX_DEPENDENCY_BLOCKERS = _TODO_SUMMARY_MAX_DEPENDENCY_BLOCKERS
-MAX_AUTONOMOUS_BACKLOG_CANDIDATES = 6
+MAX_AUTONOMOUS_BACKLOG_CANDIDATES = _MAX_AUTONOMOUS_TODO_CANDIDATES
 MAX_SUBAGENT_SCOPE_ITEMS = 4
 MAX_BACKLOG_HYGIENE_EVIDENCE_ITEMS = 3
 MAX_AUTONOMOUS_REPLAN_TRIGGERS = 3


### PR DESCRIPTION
## Summary

- move the autonomous todo candidate default limit into `control_plane/work_items/autonomous_candidates.py`
- keep `status.py`'s existing `MAX_AUTONOMOUS_BACKLOG_CANDIDATES` as a compatibility alias
- update parity smokes so direct read-model calls use their own defaults instead of receiving status-layer constants

## Validation

- `python3 examples/control_plane/todo-readmodel-boundary-smoke.py`
- `python3 examples/maintenance-latest-run-routing-smoke.py`
- `python3 -m py_compile loopx/control_plane/work_items/autonomous_candidates.py loopx/status.py examples/control_plane/todo-readmodel-boundary-smoke.py examples/maintenance-latest-run-routing-smoke.py`
- `python3 examples/control_plane/status-contract-readmodel-smoke.py`
- `python3 examples/control_plane/event-sourced-status-read-path-smoke.py`
- `python3 examples/control_plane/event-sourced-downstream-read-path-smoke.py`
- `python3 examples/control_plane/monitor-scheduler-contract-smoke.py`
- `python3 examples/control_plane/todo-first-open-summary-smoke.py`
- `git diff --check`
- added-line private/local/credential/raw evidence scan: clean
