### PR TITLE
Extract work-item replan trigger read models

### DIFF
--- a/examples/control_plane/autonomous-replan-obligation-readmodel-smoke.py
+++ b/examples/control_plane/autonomous-replan-obligation-readmodel-smoke.py
@@ -12,13 +12,18 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.projections.autonomous_replan_obligation import (  # noqa: E402
+    autonomous_replan_obligation_from_state as direct_autonomous_replan_obligation_from_state,
     build_autonomous_replan_obligation as direct_build_autonomous_replan_obligation,
 )
 from loopx.status import (  # noqa: E402
+    AUTONOMOUS_REPLAN_SECTION_HEADINGS,
     AUTONOMOUS_REPLAN_SCHEMA_VERSION,
     AUTONOMOUS_REPLAN_STALL_THRESHOLD,
     DEAD_MONITOR_REPEAT_SCHEMA_VERSION,
     DEAD_MONITOR_REPEAT_THRESHOLD,
+    active_state_section_entries,
+    active_state_sections,
+    autonomous_replan_obligation,
     build_autonomous_replan_obligation,
     public_safe_compact_text,
 )
@@ -32,6 +37,18 @@ AGENT_TODOS = {
         }
     ]
 }
+
+STATE_TEXT = """# Goal
+
+## Next Action
+
+- Continue until no-progress streak is resolved.
+
+## Operating Lessons
+
+- Record mitigation when repeated action loop appears.
+- Keep a periodic review every few dozen runs.
+"""
 
 
 def direct(evidence: list[dict[str, object]]) -> dict[str, object] | None:
@@ -52,6 +69,18 @@ def assert_parity(evidence: list[dict[str, object]]) -> dict[str, object]:
     assert wrapper == direct_result, (wrapper, direct_result)
     assert wrapper is not None, wrapper
     return wrapper
+
+
+def direct_state_obligation() -> dict[str, object] | None:
+    return direct_autonomous_replan_obligation_from_state(
+        STATE_TEXT,
+        agent_todos=AGENT_TODOS,
+        section_headings=AUTONOMOUS_REPLAN_SECTION_HEADINGS,
+        section_parser=active_state_sections,
+        section_entries=active_state_section_entries,
+        public_safe_compact_text=public_safe_compact_text,
+        build_autonomous_replan_obligation=build_autonomous_replan_obligation,
+    )
 
 
 def main() -> int:
@@ -96,6 +125,18 @@ def main() -> int:
     assert "periodic review" in periodic["recommended_action"], periodic
 
     assert build_autonomous_replan_obligation([], agent_todos=AGENT_TODOS) is None
+
+    state_wrapper = autonomous_replan_obligation(STATE_TEXT, agent_todos=AGENT_TODOS)
+    state_direct = direct_state_obligation()
+    assert state_wrapper == state_direct, (state_wrapper, state_direct)
+    assert state_wrapper is not None, state_wrapper
+    assert state_wrapper["trigger_count"] == 3, state_wrapper
+    assert [item["kind"] for item in state_wrapper["triggers"]] == [
+        "no_progress_streak",
+        "repeated_action_loop",
+        "periodic_review",
+    ], state_wrapper
+
     print("autonomous-replan-obligation-readmodel-smoke ok")
     return 0
 

--- a/examples/control_plane/backlog-hygiene-readmodel-smoke.py
+++ b/examples/control_plane/backlog-hygiene-readmodel-smoke.py
@@ -18,7 +18,6 @@ from loopx.status import (  # noqa: E402
     BACKLOG_HYGIENE_BULLET_PATTERN,
     BACKLOG_HYGIENE_HINT_PATTERN,
     BACKLOG_HYGIENE_SECTION_HEADINGS,
-    MAX_BACKLOG_HYGIENE_EVIDENCE_ITEMS,
     active_state_sections,
     backlog_hygiene_warning,
     public_safe_compact_text,
@@ -47,7 +46,6 @@ def direct_warning(agent_todos: dict[str, object] | None) -> dict[str, object] |
         bullet_pattern=BACKLOG_HYGIENE_BULLET_PATTERN,
         hint_pattern=BACKLOG_HYGIENE_HINT_PATTERN,
         public_safe_compact_text=public_safe_compact_text,
-        max_evidence_items=MAX_BACKLOG_HYGIENE_EVIDENCE_ITEMS,
     )
 
 

--- a/loopx/control_plane/work_items/autonomous_replan_obligation.py
+++ b/loopx/control_plane/work_items/autonomous_replan_obligation.py
@@ -7,6 +7,41 @@ from typing import Any, Callable, Optional, Pattern
 PublicSafeText = Callable[..., Optional[str]]
 AckRecorded = Callable[[dict[str, Any]], bool]
 DeliveryOutcomeNormalizer = Callable[[Any], Any]
+SectionParser = Callable[[str, tuple[str, ...]], dict[str, list[str]]]
+SectionEntries = Callable[[list[str]], list[str]]
+
+
+MAX_AUTONOMOUS_REPLAN_TRIGGERS = 3
+AUTONOMOUS_REPLAN_TRIGGER_PATTERNS = (
+    (
+        "periodic_review",
+        re.compile(r"(?i)(?:periodic review|periodic replan|review cadence|规划复盘|周期复盘|每几十轮)"),
+    ),
+    (
+        "no_progress_streak",
+        re.compile(r"(?i)(?:no[- ]?progress|stalled?|stall streak|没有实质进展|停转|连续[^。；;]*无进展)"),
+    ),
+    (
+        "repeated_action_loop",
+        re.compile(r"(?i)(?:repeated[- ]?action|action loop|same action|looped|重复动作|循环观察|反复观察)"),
+    ),
+    (
+        "phase_transition",
+        re.compile(r"(?i)(?:phase transition|next phase|stage transition|readiness .*done|阶段切换|进入下一阶段)"),
+    ),
+    (
+        "backlog_mismatch",
+        re.compile(r"(?i)(?:backlog mismatch|todo mismatch|next action mismatch|todo.*淹没|待办.*不一致)"),
+    ),
+    (
+        "evidence_contradiction",
+        re.compile(r"(?i)(?:evidence contradiction|contradictory evidence|stale evidence|stale latest-run|证据矛盾|状态矛盾)"),
+    ),
+    (
+        "explicit_replan",
+        re.compile(r"(?i)(?:autonomous replan|replan obligation|planning[- ]?trigger|重新规划|重规划|规划触发)"),
+    ),
+)
 
 
 def normalized_run_history_stall_signature(value: str) -> str:
@@ -140,6 +175,41 @@ def autonomous_replan_periodic_review_from_runs(
             "oldest_counted_generated_at": str(durable_runs[-1].get("generated_at") or ""),
         }
     ]
+    return build_autonomous_replan_obligation(evidence, agent_todos=agent_todos)
+
+
+def autonomous_replan_obligation_from_state(
+    state_text: str,
+    *,
+    agent_todos: dict[str, Any] | None,
+    section_headings: tuple[str, ...],
+    section_parser: SectionParser,
+    section_entries: SectionEntries,
+    public_safe_compact_text: PublicSafeText,
+    build_autonomous_replan_obligation: Callable[..., dict[str, Any] | None],
+    trigger_patterns: tuple[tuple[str, Pattern[str]], ...] = AUTONOMOUS_REPLAN_TRIGGER_PATTERNS,
+    max_triggers: int = MAX_AUTONOMOUS_REPLAN_TRIGGERS,
+) -> dict[str, Any] | None:
+    evidence: list[dict[str, Any]] = []
+    seen_kinds: set[str] = set()
+    sections = section_parser(state_text, section_headings)
+    for section, lines in sections.items():
+        for entry in section_entries(lines):
+            text = public_safe_compact_text(entry, limit=160)
+            if not text:
+                continue
+            for kind, pattern in trigger_patterns:
+                if kind in seen_kinds or not pattern.search(text):
+                    continue
+                evidence.append({"kind": kind, "section": section, "text": text})
+                seen_kinds.add(kind)
+                if len(evidence) >= max_triggers:
+                    break
+            if len(evidence) >= max_triggers:
+                break
+        if len(evidence) >= max_triggers:
+            break
+
     return build_autonomous_replan_obligation(evidence, agent_todos=agent_todos)
 
 

--- a/loopx/control_plane/work_items/backlog_hygiene.py
+++ b/loopx/control_plane/work_items/backlog_hygiene.py
@@ -7,6 +7,8 @@ from typing import Any, Callable, Optional
 CompactText = Callable[..., Optional[str]]
 SectionParser = Callable[[str, tuple[str, ...]], dict[str, list[str]]]
 
+MAX_BACKLOG_HYGIENE_EVIDENCE_ITEMS = 3
+
 
 def backlog_hygiene_warning(
     state_text: str,
@@ -17,7 +19,7 @@ def backlog_hygiene_warning(
     bullet_pattern: re.Pattern[str],
     hint_pattern: re.Pattern[str],
     public_safe_compact_text: CompactText,
-    max_evidence_items: int,
+    max_evidence_items: int = MAX_BACKLOG_HYGIENE_EVIDENCE_ITEMS,
 ) -> dict[str, Any] | None:
     try:
         agent_open_count = int(agent_todos.get("open_count") or 0) if isinstance(agent_todos, dict) else 0

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -119,6 +119,9 @@ from .control_plane.work_items.autonomous_replan_ack import (
     latest_autonomous_replan_ack_for_projection as _latest_autonomous_replan_ack_for_projection_read_model,
 )
 from .control_plane.work_items.autonomous_replan_obligation import (
+    AUTONOMOUS_REPLAN_TRIGGER_PATTERNS as _AUTONOMOUS_REPLAN_TRIGGER_PATTERNS_READ_MODEL,
+    MAX_AUTONOMOUS_REPLAN_TRIGGERS as _MAX_AUTONOMOUS_REPLAN_TRIGGERS_READ_MODEL,
+    autonomous_replan_obligation_from_state as _autonomous_replan_obligation_from_state_read_model,
     autonomous_replan_obligation_from_runs as _autonomous_replan_obligation_from_runs_read_model,
     autonomous_replan_periodic_review_from_runs as _autonomous_replan_periodic_review_from_runs_read_model,
     build_autonomous_replan_obligation as _build_autonomous_replan_obligation_read_model,
@@ -128,6 +131,7 @@ from .control_plane.work_items.autonomous_replan_obligation import (
     run_history_stall_signal as _run_history_stall_signal_read_model,
 )
 from .control_plane.work_items.backlog_hygiene import (
+    MAX_BACKLOG_HYGIENE_EVIDENCE_ITEMS as _MAX_BACKLOG_HYGIENE_EVIDENCE_ITEMS_READ_MODEL,
     backlog_hygiene_warning as _backlog_hygiene_warning_read_model,
 )
 from .control_plane.goals.dreaming import (
@@ -557,8 +561,8 @@ MAX_MONITOR_DUE_ITEMS = _TODO_SUMMARY_MAX_MONITOR_DUE_ITEMS
 MAX_DEPENDENCY_BLOCKERS = _TODO_SUMMARY_MAX_DEPENDENCY_BLOCKERS
 MAX_AUTONOMOUS_BACKLOG_CANDIDATES = _MAX_AUTONOMOUS_TODO_CANDIDATES
 MAX_SUBAGENT_SCOPE_ITEMS = 4
-MAX_BACKLOG_HYGIENE_EVIDENCE_ITEMS = 3
-MAX_AUTONOMOUS_REPLAN_TRIGGERS = 3
+MAX_BACKLOG_HYGIENE_EVIDENCE_ITEMS = _MAX_BACKLOG_HYGIENE_EVIDENCE_ITEMS_READ_MODEL
+MAX_AUTONOMOUS_REPLAN_TRIGGERS = _MAX_AUTONOMOUS_REPLAN_TRIGGERS_READ_MODEL
 AUTONOMOUS_REPLAN_STALL_THRESHOLD = 2
 DEAD_MONITOR_REPEAT_THRESHOLD = 6
 AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD = 20
@@ -574,36 +578,7 @@ AUTONOMOUS_REPLAN_SECTION_HEADINGS = (
     "Next Action",
     "Operating Lessons",
 )
-AUTONOMOUS_REPLAN_TRIGGER_PATTERNS = (
-    (
-        "periodic_review",
-        re.compile(r"(?i)(?:periodic review|periodic replan|review cadence|规划复盘|周期复盘|每几十轮)"),
-    ),
-    (
-        "no_progress_streak",
-        re.compile(r"(?i)(?:no[- ]?progress|stalled?|stall streak|没有实质进展|停转|连续[^。；;]*无进展)"),
-    ),
-    (
-        "repeated_action_loop",
-        re.compile(r"(?i)(?:repeated[- ]?action|action loop|same action|looped|重复动作|循环观察|反复观察)"),
-    ),
-    (
-        "phase_transition",
-        re.compile(r"(?i)(?:phase transition|next phase|stage transition|readiness .*done|阶段切换|进入下一阶段)"),
-    ),
-    (
-        "backlog_mismatch",
-        re.compile(r"(?i)(?:backlog mismatch|todo mismatch|next action mismatch|todo.*淹没|待办.*不一致)"),
-    ),
-    (
-        "evidence_contradiction",
-        re.compile(r"(?i)(?:evidence contradiction|contradictory evidence|stale evidence|stale latest-run|证据矛盾|状态矛盾)"),
-    ),
-    (
-        "explicit_replan",
-        re.compile(r"(?i)(?:autonomous replan|replan obligation|planning[- ]?trigger|重新规划|重规划|规划触发)"),
-    ),
-)
+AUTONOMOUS_REPLAN_TRIGGER_PATTERNS = _AUTONOMOUS_REPLAN_TRIGGER_PATTERNS_READ_MODEL
 AUTONOMOUS_RUN_HISTORY_PROGRESS_OUTCOMES = PROGRESS_DELIVERY_OUTCOMES
 AUTONOMOUS_RUN_HISTORY_NEUTRAL_CLASSIFICATIONS = {
     "quota_slot_spent",
@@ -5991,27 +5966,15 @@ def autonomous_replan_obligation(
     *,
     agent_todos: dict[str, Any] | None,
 ) -> dict[str, Any] | None:
-    evidence: list[dict[str, Any]] = []
-    seen_kinds: set[str] = set()
-    sections = active_state_sections(state_text, AUTONOMOUS_REPLAN_SECTION_HEADINGS)
-    for section, lines in sections.items():
-        for entry in active_state_section_entries(lines):
-            text = public_safe_compact_text(entry, limit=160)
-            if not text:
-                continue
-            for kind, pattern in AUTONOMOUS_REPLAN_TRIGGER_PATTERNS:
-                if kind in seen_kinds or not pattern.search(text):
-                    continue
-                evidence.append({"kind": kind, "section": section, "text": text})
-                seen_kinds.add(kind)
-                if len(evidence) >= MAX_AUTONOMOUS_REPLAN_TRIGGERS:
-                    break
-            if len(evidence) >= MAX_AUTONOMOUS_REPLAN_TRIGGERS:
-                break
-        if len(evidence) >= MAX_AUTONOMOUS_REPLAN_TRIGGERS:
-            break
-
-    return build_autonomous_replan_obligation(evidence, agent_todos=agent_todos)
+    return _autonomous_replan_obligation_from_state_read_model(
+        state_text,
+        agent_todos=agent_todos,
+        section_headings=AUTONOMOUS_REPLAN_SECTION_HEADINGS,
+        section_parser=active_state_sections,
+        section_entries=active_state_section_entries,
+        public_safe_compact_text=public_safe_compact_text,
+        build_autonomous_replan_obligation=build_autonomous_replan_obligation,
+    )
 
 
 def build_autonomous_replan_obligation(


### PR DESCRIPTION
## Summary

- move backlog hygiene evidence-limit policy into the work-item read model
- move autonomous replan trigger patterns and state-text trigger scanning into `control_plane/work_items/autonomous_replan_obligation.py`
- keep `status.py` as a compatibility facade for existing constants/wrappers
- extend read-model smokes so direct work-item helpers own the defaults and state-scan behavior

## Validation

- `python3 examples/control_plane/backlog-hygiene-readmodel-smoke.py`
- `python3 examples/control_plane/autonomous-replan-obligation-readmodel-smoke.py`
- `python3 -m py_compile loopx/control_plane/work_items/backlog_hygiene.py loopx/control_plane/work_items/autonomous_replan_obligation.py loopx/status.py examples/control_plane/backlog-hygiene-readmodel-smoke.py examples/control_plane/autonomous-replan-obligation-readmodel-smoke.py`
- `python3 examples/control_plane/status-contract-readmodel-smoke.py`
- `python3 examples/control_plane/event-sourced-status-read-path-smoke.py`
- `python3 examples/control_plane/event-sourced-downstream-read-path-smoke.py`
- `python3 examples/control_plane/todo-readmodel-boundary-smoke.py`
- `python3 examples/control_plane/todo-first-open-summary-smoke.py`
- `git diff --check`
- added-line private/local/credential/raw evidence scan: clean
