### PR TITLE
Add deterministic agent onboarding activation

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,11 @@ runtime dependencies outside the standard library.
 
 Start agent-first: paste one setup message for the surface you already use,
 then start real work through the LoopX command entry for that host.
+Agents and host integrations can make this deterministic with
+`loopx agent-onboard --list-agent-types`, then pass an exact runtime such as
+`codex-app`, `codex-cli`, or `claude-code`. Ambiguous values such as `codex`
+are intentionally rejected because Codex App automation and Codex CLI `/goal`
+use different host-loop activation paths.
 
 Choose your surface:
 
@@ -136,7 +141,9 @@ Choose your surface:
   <complex task>` or choose `loopx` from `/skills`.
 - **Codex CLI**: best when the visible TUI should stay primary while LoopX keeps
   the state. Run `codex`, paste the setup message, then invoke `$loopx
-  <complex task>` or choose `loopx` from `/skills`.
+  <complex task>` or choose `loopx` from `/skills`; after todos are written,
+  LoopX must activate the visible `/goal <task_body>` loop or show the exact
+  pasteable gate.
 - **Claude Code**: best when Claude Code's native `/loop` should drive each tick.
   Install the opt-in adapter, run `/loopx <task>`, then `/loop`.
 - **Manual shell / other agents**: best when you want LoopX state without a
@@ -227,7 +234,10 @@ project state clearly needs initialization. Ensure `.loopx/`, `.codex/goals/`,
 and `.local/` are ignored. Keep me in this TUI, do not use hidden headless
 execution. Then stop and report the project connection status, current user
 gate, top agent todo, and next safe action. After that I will start work with
-`$loopx <complex task>` or the `loopx` skill from `/skills`.
+`$loopx <complex task>` or the `loopx` skill from `/skills`. When that task
+writes LoopX todos, generate the thin task body and set this visible TUI to
+`/goal <task_body>`; if you cannot mutate `/goal`, show me the exact text to
+paste instead of saying the loop is active.
 ```
 
 That one message is the install, connect, and status check. The first useful
@@ -242,6 +252,8 @@ A successful connection looks like this:
 - the project has `.loopx/registry.json`;
 - the project has `.codex/goals/<goal-id>/ACTIVE_GOAL_STATE.md`;
 - `loopx status` shows who should act next;
+- Codex CLI has `/goal <task_body>` active, or the agent reported the exact
+  pasteable gate for setting it;
 - local runtime state is ignored, not committed.
 
 ### Claude Code

--- a/docs/reference/protocols/codex-app-host-command-registry-v0.md
+++ b/docs/reference/protocols/codex-app-host-command-registry-v0.md
@@ -24,7 +24,7 @@ The host registry should expose this minimal command set:
 | Command | Canonical target | Default authority |
 | --- | --- | --- |
 | `/loopx` | `loopx bootstrap-command-pack --project .` | Read/status-first. |
-| `/loopx <goal text>` | `loopx bootstrap-command-pack --project . --goal-text "<goal text>"` | Explicit project-local start intent. |
+| `/loopx <goal text>` | `loopx bootstrap-command-pack --project . --goal-text "<goal text>"` | Explicit project-local start intent; must activate or gate the host loop after todo writeback. |
 | `/loopx-global-summary` | `global_manager_command_v0` summary request | Read-only global control-plane digest. |
 | `/loopx-global-gates` | `global_manager_command_v0` gates request | Read-only gate inbox. |
 | `/loopx-global-todos` | `global_manager_command_v0` todos request | Read-only work queue view. |
@@ -67,6 +67,12 @@ Example registry entry:
   "unknown_command_policy": "fail_closed_with_slash_help"
 }
 ```
+
+Hosts that do not know their exact runtime type should first call
+`loopx agent-onboard --list-agent-types`, then pass a canonical value such as
+`codex-app`, `codex-cli`, or `claude-code`. Ambiguous values such as `codex`
+are invalid because Codex App heartbeat automation and Codex CLI `/goal` have
+different activation procedures.
 
 ## Host Parse Rules
 
@@ -145,8 +151,13 @@ visible user intent into the existing CLI lifecycle:
 - `/loopx` can read status and preview command packs. It stops before writes
   that need confirmation.
 - `/loopx <goal text>` is explicit intent to start project-local work: plan
-  first, write ordered todos, refresh state, run `quota should-run`, and
-  execute only when the guard allows.
+  first, write ordered todos, refresh state, activate the correct host loop
+  when missing/stale, run `quota should-run`, and execute only when the guard
+  allows.
+- Host loop activation is runtime-specific: Codex App uses heartbeat
+  automation, Codex CLI uses visible `/goal <task_body>`, Claude Code uses
+  native `/loop`, and custom agents must declare their loop driver through
+  `loopx agent-onboard`.
 - `/loopx-global-*` commands are read-only and must not approve gates, add
   todos, spend quota, merge PRs, publish externally, or pause/resume loops.
 - Destructive git, credentials, private material reads, production actions, and
@@ -159,6 +170,8 @@ Every host command must expose a deterministic CLI fallback:
 ```bash
 loopx slash-commands
 loopx slash-commands --install
+loopx agent-onboard --list-agent-types
+loopx agent-onboard --agent-type codex-cli --project .
 loopx bootstrap-command-pack --project .
 loopx bootstrap-command-pack --project . --goal-text "<goal text>"
 loopx global-summary

--- a/docs/reference/protocols/loopx-goal-command-v0.md
+++ b/docs/reference/protocols/loopx-goal-command-v0.md
@@ -5,7 +5,7 @@
 | Command | Intent | Mutation policy |
 | --- | --- | --- |
 | `/loopx` | Inspect or preview project connection. | Read-first; ask before bootstrap/connect writes. |
-| `/loopx <goal text>` | Start a concrete goal, plan ranked todos, and enter the LoopX automation flow. | Explicit invocation may write project-local LoopX state and todos. |
+| `/loopx <goal text>` | Start a concrete goal, plan ranked todos, activate the host loop, and enter the LoopX automation flow. | Explicit invocation may write project-local LoopX state and todos, then must activate or gate the host loop. |
 
 This command is intentionally separate from `/loopx-global-*`: global commands
 summarize and manage visible control-plane state across projects, while
@@ -19,8 +19,27 @@ When the user provides text after `/loopx`, the host should:
 2. Connect project-local LoopX state if no matching registry goal exists.
 3. Plan before writing todos.
 4. Write planned todos in exact plan order.
-5. Run `refresh-state`, then `quota should-run`, then start the first bounded
-   segment only when the quota contract allows it.
+5. Run `refresh-state`.
+6. Activate the host loop if it is missing, unknown, or stale:
+   - `codex-app`: create or update the Codex App heartbeat automation from the
+     generated `heartbeat-prompt` task body.
+   - `codex-cli`: set the visible Codex CLI TUI to `/goal <task_body>`.
+   - `claude-code`: arm LoopX with `/loopx <task>`, then run native `/loop`.
+   - `manual` / `other-agent`: wire the external loop driver described by
+     `loopx agent-onboard`.
+7. If the host cannot mutate that surface, report the exact pasteable gate
+   instead of claiming autonomous setup complete.
+8. Run `quota should-run`, then start the first bounded segment only when the
+   quota contract allows it.
+
+New hosts should discover exact agent types with:
+
+```bash
+loopx agent-onboard --list-agent-types
+```
+
+Ambiguous values such as `codex` must fail closed because Codex App and Codex
+CLI use different host-loop activation paths.
 
 The command pack preview is still read-only. It describes the commands and
 contracts; the slash invocation is what authorizes project-local state writes.
@@ -93,4 +112,6 @@ Stop and ask the user instead of writing or executing when:
 - private source material must be read before a public-safe todo can be formed;
 - credentials or secrets are required;
 - destructive git or production actions are needed;
-- the host cannot execute shell/CLI/tool calls or persist LoopX state.
+- the host cannot execute shell/CLI/tool calls or persist LoopX state;
+- the host cannot activate or expose the required host loop and no concrete
+  pasteable gate can be shown.

--- a/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
+++ b/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""Smoke-test agent onboarding and host-loop activation routing."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.bootstrap_command_pack import build_loopx_bootstrap_command_pack  # noqa: E402
+from loopx.host_loop_activation import (  # noqa: E402
+    agent_type_for_host_surface,
+    build_agent_type_catalog,
+    build_host_loop_activation_packet,
+)
+
+
+def run_cli(*args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", "--format", "json", *args],
+        cwd=REPO_ROOT,
+        check=check,
+        text=True,
+        capture_output=True,
+    )
+
+
+def main() -> int:
+    catalog = build_agent_type_catalog()
+    agent_types = {item["agent_type"] for item in catalog["canonical_agent_types"]}
+    assert {"codex-app", "codex-cli", "claude-code", "manual", "other-agent"} <= agent_types
+    ambiguous = {item["input"]: item["use_one_of"] for item in catalog["ambiguous_inputs"]}
+    assert ambiguous["codex"] == ["codex-app", "codex-cli"], ambiguous
+
+    assert agent_type_for_host_surface("chat-box") == "codex-app"
+    assert agent_type_for_host_surface("codex-cli-tui") == "codex-cli"
+
+    codex_app = build_host_loop_activation_packet(agent_type="codex-app", goal_id="demo")
+    codex_cli = build_host_loop_activation_packet(agent_type="codex-cli", goal_id="demo")
+    claude_code = build_host_loop_activation_packet(agent_type="claude-code", goal_id="demo")
+    assert codex_app["activation_method"] == "create_or_update_codex_app_automation", codex_app
+    assert codex_cli["host_mutation"]["host_command"] == "/goal <task_body>", codex_cli
+    assert claude_code["host_mutation"]["host_command"] == "/loop", claude_code
+
+    list_result = run_cli("agent-onboard", "--list-agent-types")
+    list_payload = json.loads(list_result.stdout)
+    assert list_payload["schema_version"] == "loopx_agent_type_catalog_v0", list_payload
+
+    ambiguous_result = run_cli(
+        "agent-onboard",
+        "--agent-type",
+        "codex",
+        "--project",
+        ".",
+        check=False,
+    )
+    assert ambiguous_result.returncode == 2, ambiguous_result.stdout
+    ambiguous_payload = json.loads(ambiguous_result.stdout)
+    assert ambiguous_payload["ok"] is False, ambiguous_payload
+    assert ambiguous_payload["suggestions"] == ["codex-app", "codex-cli"], ambiguous_payload
+
+    with tempfile.TemporaryDirectory(prefix="loopx-agent-onboard-smoke-") as tmp:
+        project = Path(tmp) / "project"
+        project.mkdir()
+        payload = build_loopx_bootstrap_command_pack(
+            project=project,
+            goal_id="demo-goal",
+            agent_id="codex-value-explorer",
+            cli_bin="loopx",
+            host_surface="codex-cli-tui",
+            goal_text="build a deterministic onboarding path",
+        )
+    assert payload["agent_type"] == "codex-cli", payload
+    activation = payload["host_loop_activation"]
+    assert activation["host_surface"] == "codex_cli_visible_goal_mode", activation
+    contract = payload["goal_start_contract"]
+    assert contract["activation"]["host_loop_required_after_todo_writeback"] is True, contract
+    assert payload["safety_contract"]["explicit_goal_start_must_activate_host_loop"] is True, payload
+    message = payload["message"]
+    assert "/goal <task_body>" in message, message
+    assert "agent-onboard" in message, message
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/agent_onboarding.py
+++ b/loopx/agent_onboarding.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .bootstrap_command_pack import inspect_bootstrap_connection
+from .host_loop_activation import (
+    AgentTypeError,
+    build_agent_type_catalog,
+    build_host_loop_activation_packet,
+    normalize_agent_type,
+    render_agent_type_catalog_markdown,
+)
+from .project_prompt import (
+    render_codex_cli_no_clone_preflight,
+    render_quota_guard_command,
+    shell_arg,
+)
+
+
+SCHEMA_VERSION = "loopx_agent_onboarding_v0"
+
+
+def _surface_install_command(agent_type: str, cli_bin: str) -> str | None:
+    if agent_type in {"codex-app", "codex-cli"}:
+        return f"{shell_arg(cli_bin)} slash-commands --install --surface codex"
+    if agent_type == "claude-code":
+        return f"{shell_arg(cli_bin)} slash-commands --install --surface claude-code"
+    return None
+
+
+def _bootstrap_pack_command(
+    *,
+    project: str,
+    goal_id: str,
+    agent_id: str | None,
+    agent_type: str,
+    cli_bin: str,
+    task_text: str | None,
+) -> str:
+    surface_by_type = {
+        "codex-app": "codex-app",
+        "codex-cli": "codex-cli-tui",
+        "claude-code": "claude-code",
+        "manual": "shell",
+        "other-agent": "worker-bridge",
+    }
+    parts = [
+        shell_arg(cli_bin),
+        "bootstrap-command-pack",
+        "--project",
+        shell_arg(project),
+        "--goal-id",
+        shell_arg(goal_id),
+        "--host-surface",
+        shell_arg(surface_by_type.get(agent_type, "worker-bridge")),
+    ]
+    if agent_id:
+        parts.extend(["--agent-id", shell_arg(agent_id)])
+    if task_text:
+        parts.extend(["--goal-text", shell_arg(task_text)])
+    return " ".join(parts)
+
+
+def _start_instruction(agent_type: str) -> str:
+    if agent_type == "codex-app":
+        return "Use `$loopx <task>` or select the LoopX skill from `/skills`; Codex App should then create/update the heartbeat automation."
+    if agent_type == "codex-cli":
+        return "Use `$loopx <task>` or select the LoopX skill from `/skills`; after todos are written, set `/goal <task_body>` in the visible TUI."
+    if agent_type == "claude-code":
+        return "Run `/loopx <task>` to arm LoopX, then run native `/loop`."
+    if agent_type == "manual":
+        return "Use the CLI packet and wire an external scheduler, or run quota/status/todo commands manually."
+    return "Use the host's explicit LoopX command facade such as `@loopx <task>` or `$loopx <task>`, then wire its scheduler through this packet."
+
+
+def build_agent_onboarding_packet(
+    *,
+    project: Path,
+    agent_type: str,
+    goal_id: str | None = None,
+    agent_id: str | None = None,
+    cli_bin: str = "loopx",
+    task_text: str | None = None,
+) -> dict[str, Any]:
+    canonical_agent_type = normalize_agent_type(agent_type)
+    inspection = inspect_bootstrap_connection(project, goal_id=goal_id)
+    resolved_project = str(inspection["project"])
+    resolved_goal_id = str(inspection["goal_id"])
+    host_loop_activation = build_host_loop_activation_packet(
+        agent_type=canonical_agent_type,
+        goal_id=resolved_goal_id,
+        cli_bin=cli_bin,
+        agent_id=agent_id,
+    )
+    install_command = _surface_install_command(canonical_agent_type, cli_bin)
+    bootstrap_pack_command = _bootstrap_pack_command(
+        project=resolved_project,
+        goal_id=resolved_goal_id,
+        agent_id=agent_id,
+        agent_type=canonical_agent_type,
+        cli_bin=cli_bin,
+        task_text=task_text,
+    )
+    commands: dict[str, str] = {
+        "doctor_or_install": render_codex_cli_no_clone_preflight(cli_bin=cli_bin),
+        "bootstrap_command_pack": bootstrap_pack_command,
+        "quota_guard": render_quota_guard_command(
+            resolved_goal_id,
+            cli_bin=cli_bin,
+            agent_id=agent_id,
+        ),
+        "agent_onboard_recheck": (
+            f"{shell_arg(cli_bin)} agent-onboard "
+            f"--agent-type {shell_arg(canonical_agent_type)} "
+            f"--project {shell_arg(resolved_project)} "
+            f"--goal-id {shell_arg(resolved_goal_id)}"
+            + (f" --agent-id {shell_arg(agent_id)}" if agent_id else "")
+        ),
+    }
+    if install_command:
+        commands["install_command_facade"] = install_command
+    if canonical_agent_type == "codex-cli":
+        commands["codex_cli_bootstrap_message"] = (
+            f"{shell_arg(cli_bin)} codex-cli-bootstrap-message "
+            f"--project {shell_arg(resolved_project)} "
+            f"--goal-id {shell_arg(resolved_goal_id)}"
+            + (f" --agent-id {shell_arg(agent_id)}" if agent_id else "")
+        )
+    return {
+        "ok": True,
+        "schema_version": SCHEMA_VERSION,
+        "agent_type": canonical_agent_type,
+        "project": resolved_project,
+        "goal_id": resolved_goal_id,
+        "agent_id": agent_id,
+        "task_text": task_text,
+        "project_connection": inspection,
+        "host_loop_activation": host_loop_activation,
+        "recommended_start": _start_instruction(canonical_agent_type),
+        "commands": commands,
+        "cost_model": {
+            "onboarding": "run once during install/connect or when the active host loop is missing/stale",
+            "loopx_task_start": (
+                "`/loopx <task>` or the explicit skill should call this packet only when "
+                "host_loop_activation is missing, unknown, stale, or the agent type changed"
+            ),
+            "normal_ticks": "read quota/status/state directly; do not recompute onboarding every turn",
+        },
+        "slash_command_contract": {
+            "after_todo_writeback": (
+                "refresh state, activate the host loop through host_loop_activation, "
+                "or report the concrete host-tool gate; then run quota should-run"
+            ),
+            "connected_registry_is_not_enough": True,
+            "setup_complete_requires": [
+                "project-local LoopX state exists or was intentionally previewed",
+                "ordered todos are written when task text was supplied",
+                "host_loop_activation success criteria are satisfied or a concrete gate is reported",
+            ],
+        },
+    }
+
+
+def render_agent_onboarding_markdown(payload: dict[str, Any]) -> str:
+    if not payload.get("ok"):
+        return render_agent_type_catalog_markdown(payload)
+    commands = payload.get("commands") if isinstance(payload.get("commands"), dict) else {}
+    activation = (
+        payload.get("host_loop_activation")
+        if isinstance(payload.get("host_loop_activation"), dict)
+        else {}
+    )
+    steps = activation.get("activation_steps") if isinstance(activation.get("activation_steps"), list) else []
+    criteria = (
+        activation.get("success_criteria")
+        if isinstance(activation.get("success_criteria"), list)
+        else []
+    )
+    lines = [
+        "# LoopX Agent Onboarding",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- agent_type: `{payload.get('agent_type')}`",
+        f"- project: `{payload.get('project')}`",
+        f"- goal_id: `{payload.get('goal_id')}`",
+        f"- recommended_start: {payload.get('recommended_start')}",
+        "",
+        "## Commands",
+        "",
+        "```bash",
+        str(commands.get("doctor_or_install") or ""),
+        "```",
+    ]
+    if commands.get("install_command_facade"):
+        lines.extend(["", "```bash", str(commands.get("install_command_facade")), "```"])
+    lines.extend(["", "```bash", str(commands.get("bootstrap_command_pack") or ""), "```"])
+    if commands.get("codex_cli_bootstrap_message"):
+        lines.extend(["", "```bash", str(commands.get("codex_cli_bootstrap_message")), "```"])
+    lines.extend(
+        [
+            "",
+            "## Host Loop Activation",
+            "",
+            f"- host_surface: `{activation.get('host_surface')}`",
+            f"- activation_method: `{activation.get('activation_method')}`",
+            f"- activation_input_command: `{activation.get('activation_input_command')}`",
+            "",
+            "Steps:",
+        ]
+    )
+    lines.extend(f"- {step}" for step in steps)
+    lines.append("")
+    lines.append("Success criteria:")
+    lines.extend(f"- {item}" for item in criteria)
+    lines.extend(
+        [
+            "",
+            "## Recheck Policy",
+            "",
+            f"- {payload.get('cost_model', {}).get('loopx_task_start') if isinstance(payload.get('cost_model'), dict) else ''}",
+        ]
+    )
+    return "\n".join(lines)

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -5,11 +5,13 @@ from pathlib import Path
 from typing import Any
 
 from .bootstrap import default_goal_id
+from .host_loop_activation import agent_type_for_host_surface, build_host_loop_activation_packet
 from .project_alias import resolve_canonical_project_alias
 from .project_prompt import (
     DEFAULT_HANDOFF_ADAPTER_KIND,
     DEFAULT_HANDOFF_ADAPTER_STATUS,
     render_heartbeat_prompt_command,
+    render_heartbeat_prompt_json_command,
     render_quota_guard_command,
     shell_arg,
 )
@@ -213,7 +215,7 @@ def _goal_start_bootstrap_command(
     return "\n".join(lines)
 
 
-def _goal_start_contract(*, goal_text: str | None, connected: bool) -> dict[str, Any]:
+def _goal_start_contract(*, goal_text: str | None, connected: bool, agent_type: str) -> dict[str, Any]:
     return {
         "schema_version": GOAL_START_SCHEMA_VERSION,
         "slash_syntax": "/loopx <goal text>",
@@ -274,7 +276,25 @@ def _goal_start_contract(*, goal_text: str | None, connected: bool) -> dict[str,
             ),
         },
         "activation": {
-            "after_write": ["refresh-state", "quota should-run"],
+            "after_write": ["refresh-state", "host_loop_activation", "quota should-run"],
+            "host_loop_required_after_todo_writeback": True,
+            "agent_type": agent_type,
+            "agent_type_discovery": "loopx agent-onboard --list-agent-types",
+            "host_surfaces": {
+                "codex-app": "Codex App heartbeat automation",
+                "codex-cli": "visible Codex CLI `/goal <task_body>`",
+                "claude-code": "Claude Code native `/loop` after `/loopx <task>` arms LoopX",
+                "manual": "external scheduler or manual quota/status loop",
+                "other-agent": "custom host loop driver using the returned task body and quota guard",
+            },
+            "missing_host_loop_policy": (
+                "Do not claim autonomous setup complete from registry/quota identity alone. "
+                "If the host cannot mutate its loop surface, report the exact pasteable gate."
+            ),
+            "low_cost_recheck_policy": (
+                "Only recompute onboarding/activation when activation is missing, unknown, stale, "
+                "or the agent type changed; normal ticks should read quota/status/state directly."
+            ),
             "begin_automation_when_quota_allows": True,
             "spend_quota_after_writeback": True,
         },
@@ -298,6 +318,7 @@ def _goal_start_contract(*, goal_text: str | None, connected: bool) -> dict[str,
             "credentials or secrets are required",
             "destructive git or production operation would be needed",
             "the host cannot execute shell/CLI/tool calls or persist LoopX state",
+            "the host cannot activate or expose the required host loop and no concrete pasteable gate can be shown",
         ],
     }
 
@@ -320,7 +341,7 @@ Planning rules:
 3. Every new todo starts with `[P0]`, `[P1]`, or `[P2]`; include at least one `[P0]` unless the first useful step is blocked by a user gate.
 4. If several todos share the same priority, their listed order is their relative priority. Preserve that exact order when writing them.
 5. Prefer executable Agent Todo items with `task_class=advancement_task`; use User Todo only for concrete owner decisions or private-material gates.
-6. After writing todos, run `loopx refresh-state --goal-id {goal_id}`, then `loopx quota should-run --goal-id {goal_id}` and begin the first allowed bounded segment.
+6. After writing todos, run `loopx refresh-state --goal-id {goal_id}`, activate the host loop if it is missing, unknown, or stale (Codex App automation, Codex CLI `/goal <task_body>`, Claude Code `/loop`, or a custom host-loop gate), then run `loopx quota should-run --goal-id {goal_id}` and begin the first allowed bounded segment.
 7. If the goal is a GitHub issue/PR fix, first preview `loopx issue-fix workflow-plan --url <github-issue-or-pr-url> --repo-path <approved-repo> --validation-label '<validation command>' --format json`; convert accepted preview candidates into ordered todos and keep private repro material, body/comment reads, external comments, PR creation, merge, publish, destructive git, and production actions as explicit gates.
 """
 
@@ -341,6 +362,7 @@ def build_loopx_bootstrap_command_pack(
     mutation_confirmation_required = bool(inspection.get("mutation_confirmation_required"))
     normalized_goal_text = " ".join(goal_text.split()) if goal_text else None
     explicit_goal_start = bool(normalized_goal_text)
+    agent_type = agent_type_for_host_surface(host_surface)
 
     bootstrap_preview_command = _bootstrap_command(
         project=resolved_project,
@@ -359,6 +381,18 @@ def build_loopx_bootstrap_command_pack(
         cli_bin=cli_bin,
         agent_id=agent_id,
         agent_scope=f"{host_surface} LoopX command pack",
+    )
+    heartbeat_prompt_json_command = render_heartbeat_prompt_json_command(
+        resolved_goal_id,
+        cli_bin=cli_bin,
+        agent_id=agent_id,
+        agent_scope=f"{host_surface} LoopX command pack",
+    )
+    host_loop_activation = build_host_loop_activation_packet(
+        agent_type=agent_type,
+        goal_id=resolved_goal_id,
+        cli_bin=cli_bin,
+        agent_id=agent_id,
     )
     quota_guard_command = render_quota_guard_command(resolved_goal_id, cli_bin=cli_bin, agent_id=agent_id)
     status_command = _project_command(resolved_project, f"{shell_arg(cli_bin)} status")
@@ -382,7 +416,8 @@ def build_loopx_bootstrap_command_pack(
             "confirmation_source": "/loopx <goal text>",
             "summary": (
                 "The slash command includes an explicit goal. Connect the project if needed, plan ranked todos, "
-                "write them in exact plan order, refresh state, and enter the quota-gated automation flow."
+                "write them in exact plan order, refresh state, activate the host loop if missing/stale, "
+                "and enter the quota-gated automation flow."
             ),
             "connect_command_if_needed": goal_start_bootstrap_command,
             "plan_prompt": goal_start_plan_prompt,
@@ -418,22 +453,37 @@ def build_loopx_bootstrap_command_pack(
         "project": resolved_project,
         "goal_id": resolved_goal_id,
         "agent_id": agent_id,
+        "agent_type": agent_type,
         "host_surface": host_surface,
         "project_connection": inspection,
+        "host_loop_activation": host_loop_activation,
         "available_slash_commands": slash_command_catalog,
         "onboarding_hint": slash_command_catalog["onboarding"],
         "recommended_next_step": recommended_next_step,
-        "goal_start_contract": _goal_start_contract(goal_text=normalized_goal_text, connected=connected),
+        "goal_start_contract": _goal_start_contract(
+            goal_text=normalized_goal_text,
+            connected=connected,
+            agent_type=agent_type,
+        ),
         "commands": {
             "doctor": f"{shell_arg(cli_bin)} doctor",
             "status": status_command,
             "quota_guard": quota_guard_command,
             "heartbeat_prompt": heartbeat_prompt_command,
+            "heartbeat_prompt_json": heartbeat_prompt_json_command,
             "bootstrap_dry_run_preview": bootstrap_preview_command,
             "bootstrap_after_user_confirmation": bootstrap_after_confirmation_command,
             "goal_start_connect_if_needed": goal_start_bootstrap_command,
             "goal_start_plan_prompt": goal_start_plan_prompt,
             "goal_start_refresh_state": f"{shell_arg(cli_bin)} refresh-state --goal-id {shell_arg(resolved_goal_id)}",
+            "goal_start_host_loop_activation": host_loop_activation.get("activation_input_command"),
+            "goal_start_agent_onboard_recheck": (
+                f"{shell_arg(cli_bin)} agent-onboard "
+                f"--agent-type {shell_arg(agent_type)} "
+                f"--project {shell_arg(resolved_project)} "
+                f"--goal-id {shell_arg(resolved_goal_id)}"
+                + (f" --agent-id {shell_arg(agent_id)}" if agent_id else "")
+            ),
             "goal_start_quota_should_run": (
                 f"{shell_arg(cli_bin)} quota should-run --goal-id {shell_arg(resolved_goal_id)}"
                 + (f" --agent-id {shell_arg(agent_id)}" if agent_id else "")
@@ -455,6 +505,7 @@ def build_loopx_bootstrap_command_pack(
             "mutation_requires_user_confirmation": mutation_confirmation_required and not explicit_goal_start,
             "bare_command_mutation_requires_user_confirmation": mutation_confirmation_required,
             "explicit_goal_start_may_write_project_local_state": explicit_goal_start,
+            "explicit_goal_start_must_activate_host_loop": explicit_goal_start,
         },
     }
     payload["message"] = render_loopx_bootstrap_command_pack_message(payload)
@@ -486,6 +537,8 @@ def render_loopx_bootstrap_command_pack_message(payload: dict[str, Any]) -> str:
     goal_start_contract = goal_start_contract if isinstance(goal_start_contract, dict) else {}
     onboarding = payload.get("onboarding_hint")
     onboarding = onboarding if isinstance(onboarding, dict) else {}
+    activation = payload.get("host_loop_activation")
+    activation = activation if isinstance(activation, dict) else {}
 
     if goal_text:
         action = f"""This is an explicit goal-start invocation. Connect project-local LoopX state if needed:
@@ -514,8 +567,22 @@ After todo writeback:
 
 ```bash
 {commands.get("goal_start_refresh_state", "")}
+{commands.get("goal_start_host_loop_activation", "")}
 {commands.get("goal_start_quota_should_run", "")}
-```"""
+```
+
+Host loop activation is part of setup, not a nice-to-have:
+- agent_type: `{payload.get("agent_type")}`
+- host_surface: `{activation.get("host_surface")}`
+- activation_method: `{activation.get("activation_method")}`
+
+If the host loop is already proven current, skip the mutation. If it is missing,
+unknown, or stale, use the command above to obtain `task_body` and activate the
+right host loop: Codex App automation, Codex CLI `/goal <task_body>`, Claude
+Code `/loop`, or the custom host-loop gate. If this session cannot mutate that
+host surface, report the exact gate; do not claim autonomous setup complete.
+Use `{commands.get("goal_start_agent_onboard_recheck", "")}` only when
+activation state is missing/unknown/stale or the agent type changed."""
     elif requires_confirmation:
         action = f"""First show this dry-run preview, then ask me before running the mutation:
 
@@ -552,7 +619,7 @@ Detected state: `{state}` ({reason})
 Rules:
 - This command pack preview is read-only. Do not run bootstrap/connect, create heartbeat automation, or spend quota while only previewing it.
 - Bare `/loopx` is read/status-first: if the project is not fully connected, ask for explicit user confirmation before any command that writes `.loopx/` or `.codex/goals/`.
-- `/loopx <goal text>` is explicit goal-start intent: it may create project-local LoopX state, but it must run the profile-appropriate planning checkpoint before writing todos.
+- `/loopx <goal text>` is explicit goal-start intent: it may create project-local LoopX state, but it must run the profile-appropriate planning checkpoint before writing todos, then activate the correct host loop if missing/stale.
 - Same-priority todos are ranked by planner order, then by `todo add` write order; preserve the order exactly.
 - If the project is connected, reuse the existing state and show the status/gate/todo snapshot.
 
@@ -589,6 +656,8 @@ def render_loopx_bootstrap_command_pack_markdown(payload: dict[str, Any]) -> str
     slash_catalog = slash_catalog if isinstance(slash_catalog, dict) else {}
     goal_start = payload.get("goal_start_contract")
     goal_start = goal_start if isinstance(goal_start, dict) else {}
+    activation = payload.get("host_loop_activation")
+    activation = activation if isinstance(activation, dict) else {}
     ordering = goal_start.get("priority_ordering")
     ordering = ordering if isinstance(ordering, dict) else {}
     return f"""# /loopx Bootstrap Command Pack
@@ -601,6 +670,7 @@ Supported forms: `/loopx`, `/loopx <goal text>`
 - project: `{payload.get("project")}`
 - input_project: `{connection.get("input_project")}`
 - goal_id: `{payload.get("goal_id")}`
+- agent_type: `{payload.get("agent_type")}`
 - goal_text: `{payload.get("goal_text") or ""}`
 - connection_state: `{connection.get("connection_state")}`
 - reason: `{connection.get("reason")}`
@@ -634,6 +704,15 @@ Supported forms: `/loopx`, `/loopx <goal text>`
 - planner_required_before_todo_write: `{(goal_start.get("planner") or {}).get("required_before_todo_write") if isinstance(goal_start.get("planner"), dict) else None}`
 - same_priority_tie_breaker: `{ordering.get("same_priority_tie_breaker")}`
 - prompt_constraint: {ordering.get("prompt_constraint")}
+- host_loop_required_after_todo_writeback: `{(goal_start.get("activation") or {}).get("host_loop_required_after_todo_writeback") if isinstance(goal_start.get("activation"), dict) else None}`
+
+## Host Loop Activation
+
+- host_surface: `{activation.get("host_surface")}`
+- activation_method: `{activation.get("activation_method")}`
+- entry_command_hint: `{activation.get("entry_command_hint")}`
+- activation_input_command: `{activation.get("activation_input_command")}`
+- recheck_command: `{commands.get("goal_start_agent_onboard_recheck")}`
 
 ## Key Commands
 
@@ -661,4 +740,5 @@ Supported forms: `/loopx`, `/loopx <goal text>`
 - creates_heartbeat: `{safety.get("creates_heartbeat")}`
 - spends_quota: `{safety.get("spends_quota")}`
 - explicit_goal_start_may_write_project_local_state: `{safety.get("explicit_goal_start_may_write_project_local_state")}`
+- explicit_goal_start_must_activate_host_loop: `{safety.get("explicit_goal_start_must_activate_host_loop")}`
 """

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -190,6 +190,7 @@ def main(argv: list[str] | None = None) -> int:
         not in {
             "bootstrap",
             "bootstrap-command-pack",
+            "agent-onboard",
             "connect",
             "codex-cli-bootstrap-message",
             "codex-cli-bounded-visible-pilot-adapter",

--- a/loopx/cli_commands/starter_bootstrap.py
+++ b/loopx/cli_commands/starter_bootstrap.py
@@ -5,6 +5,13 @@ from collections.abc import Callable
 from pathlib import Path
 
 from ..codex_cli_probe import DEFAULT_CODEX_BIN
+from ..agent_onboarding import (
+    AgentTypeError,
+    build_agent_onboarding_packet,
+    build_agent_type_catalog,
+    render_agent_onboarding_markdown,
+    render_agent_type_catalog_markdown,
+)
 from ..bootstrap_command_pack import (
     build_loopx_bootstrap_command_pack,
     render_loopx_bootstrap_command_pack_markdown,
@@ -30,6 +37,38 @@ PrintPayload = Callable[
 
 
 def register_starter_bootstrap_commands(subparsers: argparse._SubParsersAction) -> None:
+    agent_onboard_parser = subparsers.add_parser(
+        "agent-onboard",
+        help=(
+            "Generate a deterministic LoopX setup and host-loop activation packet "
+            "for one agent runtime."
+        ),
+    )
+    agent_onboard_parser.add_argument(
+        "--agent-type",
+        help="Agent runtime type: codex-app, codex-cli, claude-code, manual, or other-agent.",
+    )
+    agent_onboard_parser.add_argument(
+        "--list-agent-types",
+        action="store_true",
+        help="List canonical agent_type values, accepted aliases, and ambiguous inputs.",
+    )
+    agent_onboard_parser.add_argument("--project", default=".", help="Project directory to inspect.")
+    agent_onboard_parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
+    agent_onboard_parser.add_argument(
+        "--agent-id",
+        help="Registered LoopX agent id to include in quota/heartbeat commands.",
+    )
+    agent_onboard_parser.add_argument(
+        "--cli-bin",
+        default="loopx",
+        help="LoopX CLI binary name embedded in generated commands.",
+    )
+    agent_onboard_parser.add_argument(
+        "--task-text",
+        help="Optional first task text to include in the bootstrap command pack.",
+    )
+
     bootstrap_command_pack_parser = subparsers.add_parser(
         "bootstrap-command-pack",
         help="Preview the /loopx project bootstrap command pack without mutating state.",
@@ -171,6 +210,37 @@ def handle_new_project_prompt_command(
     return 0
 
 
+def handle_agent_onboard_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    if bool(getattr(args, "list_agent_types", False)):
+        print_payload(build_agent_type_catalog(), args.format, render_agent_type_catalog_markdown)
+        return 0
+    if not args.agent_type:
+        exc = AgentTypeError(
+            value=None,
+            reason="--agent-type is required unless --list-agent-types is used",
+            suggestions=["codex-app", "codex-cli", "claude-code", "manual", "other-agent"],
+        )
+        print_payload(exc.to_payload(), args.format, render_agent_onboarding_markdown)
+        return 2
+    try:
+        payload = build_agent_onboarding_packet(
+            project=Path(args.project),
+            agent_type=args.agent_type,
+            goal_id=args.goal_id,
+            agent_id=args.agent_id,
+            cli_bin=args.cli_bin,
+            task_text=args.task_text,
+        )
+    except AgentTypeError as exc:
+        print_payload(exc.to_payload(), args.format, render_agent_onboarding_markdown)
+        return 2
+    print_payload(payload, args.format, render_agent_onboarding_markdown)
+    return 0
+
+
 def handle_loopx_bootstrap_command_pack_command(
     args: argparse.Namespace,
     print_payload: PrintPayload,
@@ -241,6 +311,7 @@ def handle_starter_bootstrap_command(
     print_payload: PrintPayload,
 ) -> int | None:
     handlers: dict[str, Callable[[argparse.Namespace, PrintPayload], int]] = {
+        "agent-onboard": handle_agent_onboard_command,
         "bootstrap-command-pack": handle_loopx_bootstrap_command_pack_command,
         "new-project-prompt": handle_new_project_prompt_command,
         "codex-cli-bootstrap-message": handle_codex_cli_bootstrap_message_command,

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -29,6 +29,10 @@ COMMAND_GROUPS: list[dict[str, object]] = [
                 "purpose": "Generate a setup packet for a manual shell or first agent handoff.",
             },
             {
+                "command": "loopx agent-onboard --agent-type codex-cli --project .",
+                "purpose": "Generate the exact host-loop activation packet for one agent runtime.",
+            },
+            {
                 "command": "loopx slash-commands --install",
                 "purpose": "Refresh host slash-command prompt and skill files.",
             },
@@ -165,6 +169,8 @@ def render_concise_help(program: str = "loopx") -> str:
             "  loopx doctor                   Check install, PATH, release snapshot, and skills.",
             "  loopx bootstrap-command-pack --project .",
             "                                  Generate a setup packet for a manual shell path.",
+            "  loopx agent-onboard --list-agent-types",
+            "                                  Pick the exact host runtime before activation.",
             "",
             "Daily operator commands:",
             "  loopx status                   Show current goals, gates, and next action.",

--- a/loopx/host_loop_activation.py
+++ b/loopx/host_loop_activation.py
@@ -1,0 +1,386 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .project_prompt import (
+    render_heartbeat_prompt_command,
+    render_heartbeat_prompt_json_command,
+)
+
+
+SCHEMA_VERSION = "loopx_host_loop_activation_v1"
+AGENT_TYPE_CATALOG_SCHEMA_VERSION = "loopx_agent_type_catalog_v0"
+
+SUPPORTED_AGENT_TYPES = ["codex-app", "codex-cli", "claude-code", "manual", "other-agent"]
+
+AGENT_TYPE_CATALOG: dict[str, dict[str, Any]] = {
+    "codex-app": {
+        "display_name": "Codex App",
+        "host_loop": "Codex App heartbeat automation",
+        "entry": "$loopx <task> or the explicit LoopX skill from /skills",
+        "accepted_inputs": ["codex-app", "codex_app", "codex app", "codex-desktop", "codex desktop"],
+    },
+    "codex-cli": {
+        "display_name": "Codex CLI TUI",
+        "host_loop": "visible Codex CLI /goal",
+        "entry": "$loopx <task> or the explicit LoopX skill from /skills",
+        "accepted_inputs": [
+            "codex-cli",
+            "codex_cli",
+            "codex cli",
+            "codex-cli-tui",
+            "codex_cli_tui",
+            "codex tui",
+        ],
+    },
+    "claude-code": {
+        "display_name": "Claude Code",
+        "host_loop": "native /loop gated by LoopX",
+        "entry": "/loopx <task> then /loop",
+        "accepted_inputs": ["claude-code", "claude_code", "claude code", "cc"],
+    },
+    "manual": {
+        "display_name": "Manual shell / external scheduler",
+        "host_loop": "external scheduler or manual quota/status loop",
+        "entry": "CLI packet plus an external loop driver",
+        "accepted_inputs": ["manual", "shell", "manual-shell", "external-scheduler"],
+    },
+    "other-agent": {
+        "display_name": "Other explicit agent host",
+        "host_loop": "custom agent loop driver",
+        "entry": "@loopx <task>, $loopx <task>, or another host facade",
+        "accepted_inputs": ["other-agent", "other_agent", "custom-agent", "custom agent"],
+    },
+}
+
+AMBIGUOUS_AGENT_TYPE_INPUTS: dict[str, list[str]] = {
+    "codex": ["codex-app", "codex-cli"],
+    "openai-codex": ["codex-app", "codex-cli"],
+    "openai codex": ["codex-app", "codex-cli"],
+    "cli": ["codex-cli", "manual", "other-agent"],
+}
+
+
+def _agent_type_key(value: str | None) -> str:
+    return (value or "").strip().lower().replace("_", "-")
+
+
+AGENT_TYPE_ALIASES = {
+    _agent_type_key(alias): canonical
+    for canonical, metadata in AGENT_TYPE_CATALOG.items()
+    for alias in metadata["accepted_inputs"]
+}
+
+
+class AgentTypeError(ValueError):
+    def __init__(self, *, value: str | None, reason: str, suggestions: list[str] | None = None) -> None:
+        self.value = value
+        self.reason = reason
+        self.suggestions = suggestions or []
+        super().__init__(reason)
+
+    def to_payload(self) -> dict[str, Any]:
+        return {
+            "ok": False,
+            "schema_version": "loopx_agent_type_error_v0",
+            "error_kind": "ambiguous_or_unsupported_agent_type",
+            "agent_type": self.value,
+            "reason": self.reason,
+            "suggestions": self.suggestions,
+            "agent_type_catalog": build_agent_type_catalog(),
+        }
+
+
+HOST_SURFACE_TO_AGENT_TYPE = {
+    "codex-app": "codex-app",
+    "chat-box": "codex-app",
+    "codex-cli-tui": "codex-cli",
+    "claude-code": "claude-code",
+    "shell": "manual",
+    "http": "other-agent",
+    "worker-bridge": "other-agent",
+}
+
+
+def build_agent_type_catalog() -> dict[str, Any]:
+    return {
+        "ok": True,
+        "schema_version": AGENT_TYPE_CATALOG_SCHEMA_VERSION,
+        "canonical_agent_types": [
+            {
+                "agent_type": agent_type,
+                "display_name": metadata["display_name"],
+                "host_loop": metadata["host_loop"],
+                "entry": metadata["entry"],
+                "accepted_inputs": metadata["accepted_inputs"],
+            }
+            for agent_type, metadata in AGENT_TYPE_CATALOG.items()
+        ],
+        "ambiguous_inputs": [
+            {"input": value, "use_one_of": choices}
+            for value, choices in AMBIGUOUS_AGENT_TYPE_INPUTS.items()
+        ],
+        "selection_rule": (
+            "Agents should pass a canonical agent_type. Ambiguous values such as "
+            "`codex` are rejected because Codex App and Codex CLI have different "
+            "host-loop activation paths."
+        ),
+    }
+
+
+def render_agent_type_catalog_markdown(payload: dict[str, Any]) -> str:
+    if not payload.get("ok") and isinstance(payload.get("agent_type_catalog"), dict):
+        catalog = payload["agent_type_catalog"]
+        header = [
+            "# LoopX Agent Type Error",
+            "",
+            f"- ok: `{payload.get('ok')}`",
+            f"- error_kind: `{payload.get('error_kind')}`",
+            f"- agent_type: `{payload.get('agent_type')}`",
+            f"- reason: {payload.get('reason')}",
+            f"- suggestions: `{', '.join(payload.get('suggestions') or [])}`",
+            "",
+        ]
+        return "\n".join(header) + render_agent_type_catalog_markdown(catalog)
+    lines = [
+        "# LoopX Agent Types",
+        "",
+        str(payload.get("selection_rule") or ""),
+        "",
+        "| agent_type | Host loop | Entry | Accepted inputs |",
+        "| --- | --- | --- | --- |",
+    ]
+    for item in payload.get("canonical_agent_types") or []:
+        if not isinstance(item, dict):
+            continue
+        aliases = ", ".join(f"`{value}`" for value in item.get("accepted_inputs") or [])
+        lines.append(
+            "| "
+            f"`{item.get('agent_type')}` | "
+            f"{item.get('host_loop')} | "
+            f"{item.get('entry')} | "
+            f"{aliases} |"
+        )
+    lines.extend(["", "Ambiguous inputs:"])
+    for item in payload.get("ambiguous_inputs") or []:
+        if isinstance(item, dict):
+            choices = ", ".join(f"`{value}`" for value in item.get("use_one_of") or [])
+            lines.append(f"- `{item.get('input')}` -> use one of {choices}")
+    return "\n".join(lines)
+
+
+def normalize_agent_type(value: str | None) -> str:
+    key = _agent_type_key(value)
+    if not key:
+        raise AgentTypeError(
+            value=value,
+            reason="agent_type is required",
+            suggestions=SUPPORTED_AGENT_TYPES,
+        )
+    if key in AMBIGUOUS_AGENT_TYPE_INPUTS:
+        suggestions = AMBIGUOUS_AGENT_TYPE_INPUTS[key]
+        raise AgentTypeError(
+            value=value,
+            reason=(
+                f"agent_type {value!r} is ambiguous; choose the exact host runtime "
+                f"because each one has a different host_loop_activation"
+            ),
+            suggestions=suggestions,
+        )
+    try:
+        return AGENT_TYPE_ALIASES[key]
+    except KeyError as exc:
+        raise AgentTypeError(
+            value=value,
+            reason=f"unsupported agent_type {value!r}",
+            suggestions=SUPPORTED_AGENT_TYPES,
+        ) from exc
+
+
+def agent_type_for_host_surface(value: str | None) -> str:
+    key = (value or "chat-box").strip().lower()
+    if key in HOST_SURFACE_TO_AGENT_TYPE:
+        return HOST_SURFACE_TO_AGENT_TYPE[key]
+    return normalize_agent_type(key)
+
+
+def _heartbeat_commands(
+    *,
+    goal_id: str,
+    agent_type: str,
+    cli_bin: str,
+    agent_id: str | None,
+) -> dict[str, str]:
+    scope_by_type = {
+        "codex-app": "Codex App heartbeat automation",
+        "codex-cli": "Codex CLI /goal visible TUI loop",
+        "claude-code": "Claude Code native /loop gated by LoopX",
+        "manual": "External scheduler or manual shell LoopX poll",
+        "other-agent": "Custom agent host loop gated by LoopX",
+    }
+    agent_scope = scope_by_type.get(agent_type, scope_by_type["other-agent"])
+    return {
+        "heartbeat_prompt_json": render_heartbeat_prompt_json_command(
+            goal_id,
+            cli_bin=cli_bin,
+            agent_id=agent_id,
+            agent_scope=agent_scope,
+        ),
+        "heartbeat_prompt": render_heartbeat_prompt_command(
+            goal_id,
+            cli_bin=cli_bin,
+            agent_id=agent_id,
+            agent_scope=agent_scope,
+        ),
+    }
+
+
+def _codex_app_activation(commands: dict[str, str]) -> dict[str, Any]:
+    return {
+        "host_surface": "codex_app_heartbeat_automation",
+        "entry_command_hint": "$loopx <task> or the explicit LoopX skill from /skills",
+        "activation_method": "create_or_update_codex_app_automation",
+        "activation_input_command": commands["heartbeat_prompt_json"],
+        "host_mutation": {
+            "owner": "Codex App host",
+            "preferred_tool": "automation_update",
+            "cli_can_mutate_directly": False,
+            "missing_host_tool_gate": (
+                "Codex App automation_update is unavailable; surface a pasteable "
+                "heartbeat task_body gate instead of claiming autonomous setup."
+            ),
+        },
+        "activation_steps": [
+            "Run the heartbeat-prompt JSON command after project state and todos are written.",
+            "Read task_body from the JSON payload.",
+            "Create or update a Codex App heartbeat automation starting at 3 minutes.",
+            "On later ticks, follow quota should-run scheduler_hint for backoff, reset, and scheduler-ack.",
+        ],
+        "success_criteria": [
+            "A Codex App heartbeat automation exists for this goal and uses the generated task_body.",
+            "The next wakeup starts from LoopX quota/status/state, not stale chat memory.",
+        ],
+    }
+
+
+def _codex_cli_activation(commands: dict[str, str]) -> dict[str, Any]:
+    return {
+        "host_surface": "codex_cli_visible_goal_mode",
+        "entry_command_hint": "$loopx <task> or the explicit LoopX skill from /skills",
+        "activation_method": "set_visible_tui_goal",
+        "activation_input_command": commands["heartbeat_prompt_json"],
+        "host_mutation": {
+            "owner": "Codex CLI TUI",
+            "host_command": "/goal <task_body>",
+            "cli_can_mutate_directly": False,
+            "missing_host_tool_gate": (
+                "Current session cannot set Codex CLI /goal; show the exact "
+                "`/goal <task_body>` text for the user to paste."
+            ),
+        },
+        "activation_steps": [
+            "Run the heartbeat-prompt JSON command after project state and todos are written.",
+            "Read task_body from the JSON payload.",
+            "Set the visible Codex CLI TUI goal to `/goal <task_body>`.",
+            "Keep delivery in the visible TUI; do not switch to hidden headless execution.",
+        ],
+        "success_criteria": [
+            "The visible Codex CLI TUI has `/goal <task_body>` active for this goal.",
+            "Future TUI turns enter through LoopX quota/status/state before delivery work.",
+        ],
+    }
+
+
+def _claude_code_activation(commands: dict[str, str], cli_bin: str) -> dict[str, Any]:
+    return {
+        "host_surface": "claude_code_native_loop",
+        "entry_command_hint": "/loopx <task> then /loop",
+        "activation_method": "arm_loopx_then_run_native_loop",
+        "activation_input_command": commands["heartbeat_prompt_json"],
+        "setup_command": f"{cli_bin} slash-commands --install --surface claude-code",
+        "host_mutation": {
+            "owner": "Claude Code",
+            "host_command": "/loop",
+            "cli_can_mutate_directly": False,
+            "missing_host_tool_gate": (
+                "Claude Code adapter or native /loop is unavailable; install the "
+                "Claude Code LoopX surface or report the exact gate."
+            ),
+        },
+        "activation_steps": [
+            "Install or refresh the Claude Code LoopX surface when needed.",
+            "Run `/loopx <task>` to arm LoopX state for the task.",
+            "Run native `/loop`; the adapter gates each tick through LoopX should_run.",
+        ],
+        "success_criteria": [
+            "Claude Code has the LoopX command surface installed.",
+            "Native `/loop` is running with LoopX should_run gating, not an unrelated free-running loop.",
+        ],
+    }
+
+
+def _manual_activation(commands: dict[str, str]) -> dict[str, Any]:
+    return {
+        "host_surface": "external_scheduler_or_manual_shell",
+        "entry_command_hint": "run loopx agent-onboard, then wire a scheduler or invoke quota manually",
+        "activation_method": "external_loop_driver",
+        "activation_input_command": commands["heartbeat_prompt_json"],
+        "host_mutation": {
+            "owner": "external agent or operator",
+            "cli_can_mutate_directly": False,
+            "missing_host_tool_gate": (
+                "No host loop is declared. Wire a cron/task/agent loop that starts "
+                "from quota should-run, or run LoopX manually."
+            ),
+        },
+        "activation_steps": [
+            "Generate the heartbeat-prompt JSON task body or equivalent lifecycle prompt.",
+            "Configure the external loop driver to call quota should-run before each delivery slice.",
+            "Record evidence/writeback and spend quota only after validated delivery work.",
+        ],
+        "success_criteria": [
+            "An external loop driver reliably starts from the LoopX quota/status contract.",
+            "The driver has an explicit stop/backoff policy for no-progress or unchanged polls.",
+        ],
+    }
+
+
+def build_host_loop_activation_packet(
+    *,
+    agent_type: str,
+    goal_id: str,
+    cli_bin: str = "loopx",
+    agent_id: str | None = None,
+) -> dict[str, Any]:
+    canonical = normalize_agent_type(agent_type)
+    commands = _heartbeat_commands(
+        goal_id=goal_id,
+        agent_type=canonical,
+        cli_bin=cli_bin,
+        agent_id=agent_id,
+    )
+    if canonical == "codex-app":
+        surface = _codex_app_activation(commands)
+    elif canonical == "codex-cli":
+        surface = _codex_cli_activation(commands)
+    elif canonical == "claude-code":
+        surface = _claude_code_activation(commands, cli_bin)
+    else:
+        surface = _manual_activation(commands)
+        if canonical == "other-agent":
+            surface["entry_command_hint"] = "@loopx <task>, $loopx <task>, or another explicit host command facade"
+            surface["host_surface"] = "custom_agent_loop_driver"
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "agent_type": canonical,
+        "goal_id": goal_id,
+        "agent_id": agent_id,
+        "activation_required_after_todo_write": True,
+        "status_probe_policy": {
+            "check_once_during_onboarding": True,
+            "cheap_recheck_on_loopx": "only when activation is missing, unknown, stale, or the agent is newly installed",
+            "do_not_recompute_every_loopx_turn": True,
+        },
+        "commands": commands,
+        **surface,
+    }

--- a/loopx/slash_command_install.py
+++ b/loopx/slash_command_install.py
@@ -87,7 +87,10 @@ def _command_prompt_specs(*, cli_bin: str, include_legacy_aliases: bool) -> list
                 "Visible command arguments: `$ARGUMENTS`.",
                 f"If arguments are present, preserve them as the task text and run `{cli_bin} bootstrap-command-pack --project . --goal-text \"$ARGUMENTS\"` before planning work.",
                 f"If arguments are empty, inspect `{cli_bin} bootstrap-command-pack --project .`, `{cli_bin} status`, and `{cli_bin} slash-commands` before changing files.",
-                "When project work is started, plan ordered P0/P1/P2 todos, write them through LoopX todo state, refresh state, run quota, and take one bounded allowed step.",
+                f"Use `{cli_bin} agent-onboard --list-agent-types` when the host runtime is unclear; pass an exact type such as `codex-app`, `codex-cli`, or `claude-code`, never ambiguous `codex`.",
+                "When project work is started, plan ordered P0/P1/P2 todos, write them through LoopX todo state, refresh state, activate the host loop if missing/stale, run quota, and take one bounded allowed step.",
+                "Host loop activation means Codex App heartbeat automation, Codex CLI visible `/goal <task_body>`, Claude Code native `/loop`, or a custom host-loop gate from `loopx agent-onboard`.",
+                "If this session cannot mutate the host loop surface, surface the exact pasteable gate instead of saying LoopX is autonomously connected.",
             ],
         },
         {

--- a/loopx/slash_commands.py
+++ b/loopx/slash_commands.py
@@ -52,9 +52,31 @@ def build_slash_command_catalog(
         _command(
             command="/loopx <goal text>",
             scope="project",
-            intent="Start a concrete project goal: plan ordered todos, write them in priority order, then enter the quota-gated loop.",
-            mutation_policy="explicit goal-start intent may write project-local LoopX state after planning",
+            intent="Start a concrete project goal: plan ordered todos, write them in priority order, activate the host loop when needed, then enter the quota-gated loop.",
+            mutation_policy="explicit goal-start intent may write project-local LoopX state after planning and must activate/report the host loop",
             cli_reference=f"{cli_bin} bootstrap-command-pack --project . --goal-text '<goal text>'",
+            agent_contract={
+                "schema_version": "loopx_goal_start_agent_contract_v0",
+                "planner_required_before_todo_write": True,
+                "todo_write_order_defines_same_priority_rank": True,
+                "host_loop_activation_required_after_todo_writeback": True,
+                "host_loop_activation_catalog": f"{cli_bin} agent-onboard --list-agent-types",
+                "host_loop_activation_by_agent_type": {
+                    "codex-app": "create/update Codex App heartbeat automation from heartbeat-prompt task_body",
+                    "codex-cli": "set visible Codex CLI TUI `/goal <task_body>`",
+                    "claude-code": "arm LoopX with `/loopx <task>`, then run native `/loop`",
+                    "manual": "wire an external scheduler or run quota/status manually",
+                    "other-agent": "use the custom host loop driver declared by `loopx agent-onboard`",
+                },
+                "setup_complete_requires": (
+                    "registry/state plus ordered todos plus host_loop_activation current, "
+                    "or a concrete host-tool gate; registry/quota identity alone is insufficient"
+                ),
+                "low_cost_recheck_policy": (
+                    "Run `agent-onboard` only when activation is missing, unknown, stale, "
+                    "or the agent type changed; normal ticks read quota/status/state directly."
+                ),
+            },
         ),
         _command(
             command="/loopx-global-summary",
@@ -179,6 +201,7 @@ def render_onboarding_slash_command_note(commands: list[dict[str, Any]], *, cli_
             "LoopX command surface is available. Useful commands:",
             f"- `/loopx`: {project.get('intent', 'inspect this project')}",
             f"- `/loopx <goal text>`: {goal.get('intent', 'start a concrete project goal')}",
+            f"  New hosts should choose an exact agent type with `{cli_bin} agent-onboard --list-agent-types`; do not pass ambiguous values such as `codex`.",
             "- `/loopx-global-summary`: read the global progress digest.",
             "- `/loopx-global-gates`, `/loopx-global-todos`, `/loopx-global-risks`: inspect manager-level gates, work, and risks.",
             "- `/loopx-pr-review`: run `loopx pr-review` first, then review its unmerged and merged PR groups one by one.",
@@ -212,6 +235,8 @@ def render_slash_command_catalog_markdown(payload: dict[str, Any]) -> str:
         agent_contract = item.get("agent_contract") if isinstance(item.get("agent_contract"), dict) else {}
         if agent_contract.get("must_run_cli_first"):
             intent += " Agent contract: run the CLI reference first; do not rebuild the queue manually."
+        if agent_contract.get("host_loop_activation_required_after_todo_writeback"):
+            intent += " Agent contract: after todo writeback, activate the host loop or report the concrete host-tool gate."
         lines.append(
             "| "
             f"`{_markdown_table_cell(item.get('command'))}` | "


### PR DESCRIPTION
## Summary
- add a canonical agent type catalog and agent-onboard packet for host-loop activation
- reject ambiguous inputs such as `codex` so Codex App and Codex CLI do not route through the wrong activation path
- require `/loopx <task>` command packs to activate or gate the host loop after todo writeback

## Validation
- `python3 examples/control_plane/agent-onboard-host-loop-activation-smoke.py`
- `python3 -m py_compile loopx/host_loop_activation.py loopx/agent_onboarding.py loopx/bootstrap_command_pack.py loopx/slash_commands.py loopx/slash_command_install.py loopx/cli_commands/starter_bootstrap.py loopx/cli.py examples/control_plane/agent-onboard-host-loop-activation-smoke.py`
- `python3 -m loopx.cli --format json agent-onboard --agent-type codex --project .` returns code 2 with codex-app/codex-cli suggestions
- `python3 -m loopx.cli check ...` public boundary scan clean