### PR TITLE
Release LoopX v0.1.8

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -102,6 +102,12 @@ path, and canary route rather than as a user-facing release baseline.
   explicit: Codex installs LoopX command-facade skills such as `$loopx`, Claude
   Code gets matching skill entries, legacy prompt shims are retired, and the
   rich workflow skills remain available for implicit LoopX behavior.
+- `v0.1.8` on 2026-07-04 16:53 +08:00: deterministic host-loop activation
+  release at the matching `v0.1.8` tag. This release gives new agent hosts an explicit
+  `agent-onboard` contract for choosing `codex-app`, `codex-cli`,
+  `claude-code`, `manual`, or `other-agent`, rejects ambiguous inputs such as
+  `codex`, and makes `/loopx <task>` activate or gate the correct host loop
+  after todo writeback.
 
 When a new public release is promoted, add it here only after the matching tag,
 release note, stable ref, update path, and focused release canary agree.

--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.7"
+__version__ = "0.1.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.1.7"
+version = "0.1.8"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- bump LoopX package version to 0.1.8
- add the v0.1.8 public release timeline entry for deterministic host-loop activation

## Validation
- `python3 examples/release/release-version-contract-smoke.py`
- `python3 examples/release/release-readiness-doc-smoke.py`
- `python3 examples/control_plane/agent-onboard-host-loop-activation-smoke.py`
- `python3 -m py_compile loopx/__init__.py loopx/host_loop_activation.py loopx/agent_onboarding.py loopx/bootstrap_command_pack.py loopx/slash_commands.py loopx/slash_command_install.py loopx/cli_commands/starter_bootstrap.py loopx/cli.py examples/control_plane/agent-onboard-host-loop-activation-smoke.py`
- `python3 -m loopx.cli --format json version` reports 0.1.8
- `python3 -m loopx.cli check --scan-path pyproject.toml --scan-path loopx/__init__.py --scan-path docs/product/release-readiness.md` public boundary scan clean