### PR TITLE
Extract goal attention routing read model

### DIFF
--- a/examples/control_plane/goal-attention-readmodel-smoke.py
+++ b/examples/control_plane/goal-attention-readmodel-smoke.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Smoke-test goal attention routing read-model parity."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx import status as status_module  # noqa: E402
+from loopx.control_plane.work_items import attention_routing as routing_read_model  # noqa: E402
+from loopx.session_runtime import SESSION_RUNTIME_READONLY_PROJECTION_SCHEMA_VERSION  # noqa: E402
+
+
+def direct_goal_attention(goal: dict) -> dict | None:
+    return routing_read_model.goal_attention(
+        goal,
+        latest_run=status_module.latest_run,
+        readiness_attention_fields=status_module.readiness_attention_fields,
+        operator_gate_attention_fields=status_module.operator_gate_attention_fields,
+        dreaming_attention_fields=status_module.dreaming_attention_fields,
+        goal_lifecycle_fields=status_module.goal_lifecycle_fields,
+        legacy_runtime_goal_attention=status_module.legacy_runtime_goal_attention,
+        compact_session_runtime_projection_from_run=status_module.compact_session_runtime_projection_from_run,
+        session_runtime_projection_attention=status_module.session_runtime_projection_attention,
+        attention_item=status_module.attention_item,
+        run_has_external_evidence_watch_signal=status_module.run_has_external_evidence_watch_signal,
+        default_operator_question=status_module.default_operator_question,
+        normalize_operator_question=status_module.normalize_operator_question,
+        default_operator_gate=status_module.DEFAULT_OPERATOR_GATE,
+        planned_controller_opt_in_recommended_action=status_module.PLANNED_CONTROLLER_OPT_IN_RECOMMENDED_ACTION,
+        connected_adapter_statuses=status_module.CONNECTED_ADAPTER_STATUSES,
+        connected_delivery_adapter_statuses=status_module.CONNECTED_DELIVERY_ADAPTER_STATUSES,
+        registry_waiting_on_overrides=status_module.REGISTRY_WAITING_ON_OVERRIDES,
+        blocking_classifications=status_module.BLOCKING_CLASSIFICATIONS,
+        user_or_controller_classifications=status_module.USER_OR_CONTROLLER_CLASSIFICATIONS,
+        codex_ready_classifications=status_module.CODEX_READY_CLASSIFICATIONS,
+    )
+
+
+def assert_parity(goal: dict) -> dict | None:
+    wrapper = status_module.goal_attention(goal)
+    direct = direct_goal_attention(goal)
+    assert wrapper == direct, (wrapper, direct)
+    return wrapper
+
+
+def run(
+    classification: str,
+    *,
+    recommended_action: str = "continue bounded delivery",
+    json_exists: bool = True,
+    markdown_exists: bool = True,
+    **extra: object,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "generated_at": "2026-07-04T00:00:00+00:00",
+        "classification": classification,
+        "recommended_action": recommended_action,
+        "json_exists": json_exists,
+        "markdown_exists": markdown_exists,
+    }
+    payload.update(extra)
+    return payload
+
+
+def goal(**extra: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "id": "goal-attention-smoke",
+        "status": "active",
+        "registry_member": True,
+    }
+    payload.update(extra)
+    return payload
+
+
+def assert_routed(goal_payload: dict, *, status: str, waiting_on: str, severity: str) -> dict:
+    item = assert_parity(goal_payload)
+    assert item is not None, goal_payload
+    assert item["status"] == status, item
+    assert item["waiting_on"] == waiting_on, item
+    assert item["severity"] == severity, item
+    return item
+
+
+def main() -> int:
+    connected = assert_routed(
+        goal(adapter_status="connected-read-only"),
+        status="connected_without_run",
+        waiting_on="codex",
+        severity="action",
+    )
+    assert connected["source"] == "run_history", connected
+
+    planned = assert_routed(
+        goal(adapter_status="planned", adapter_kind="demo_read_only_map_v0"),
+        status="active",
+        waiting_on="user_or_controller",
+        severity="action",
+    )
+    assert planned["agent_command"] == "loopx read-only-map --goal-id goal-attention-smoke --dry-run", planned
+
+    missing_artifact = assert_routed(
+        goal(latest_status_run=run("state_refreshed", markdown_exists=False)),
+        status="run_artifact_missing",
+        waiting_on="codex",
+        severity="high",
+    )
+    assert missing_artifact["source"] == "run_history", missing_artifact
+
+    registry_override = assert_routed(
+        goal(
+            waiting_on="external_evidence",
+            attention_status="waiting_for_remote",
+            recommended_action="observe remote public signal",
+            operator_question="Proceed?",
+            operator_gate="publish",
+            next_handoff_condition="after external signal",
+            latest_status_run=run("state_refreshed"),
+        ),
+        status="waiting_for_remote",
+        waiting_on="external_evidence",
+        severity="watch",
+    )
+    assert registry_override["source"] == "registry", registry_override
+    assert registry_override["next_handoff_condition"] == "after external signal", registry_override
+
+    assert_routed(
+        goal(latest_status_run=run("blocked_by_safety")),
+        status="blocked_by_safety",
+        waiting_on="user_or_controller",
+        severity="high",
+    )
+
+    assert_routed(
+        goal(latest_status_run=run("ready_for_controller_opt_in")),
+        status="ready_for_controller_opt_in",
+        waiting_on="user_or_controller",
+        severity="action",
+    )
+
+    assert_routed(
+        goal(latest_status_run=run("state_refreshed")),
+        status="state_refreshed",
+        waiting_on="codex",
+        severity="action",
+    )
+
+    external_signal = assert_routed(
+        goal(
+            latest_status_run=run(
+                "runtime_result_pending",
+                waiting_on="external_evidence",
+            )
+        ),
+        status="runtime_result_pending",
+        waiting_on="external_evidence",
+        severity="watch",
+    )
+    assert external_signal["source"] == "latest_run", external_signal
+
+    assert_routed(
+        goal(adapter_status="connected-delivery", latest_status_run=run("custom_delivery")),
+        status="custom_delivery",
+        waiting_on="codex",
+        severity="action",
+    )
+
+    session_runtime = assert_routed(
+        goal(
+            latest_status_run=run(
+                "runtime_result_pending",
+                session_runtime_projection={
+                    "schema_version": SESSION_RUNTIME_READONLY_PROJECTION_SCHEMA_VERSION,
+                    "goal_id": "goal-attention-smoke",
+                    "first_screen": {
+                        "recommended_action": "continue from session runtime",
+                        "agent_can_continue": True,
+                    },
+                    "work_lane_contract": {
+                        "lane": "advancement_task",
+                        "must_attempt_work": True,
+                    },
+                },
+            )
+        ),
+        status="session_runtime_advancement_task",
+        waiting_on="codex",
+        severity="action",
+    )
+    assert session_runtime["source"] == "session_runtime_projection", session_runtime
+
+    assert assert_parity(goal(adapter_status="planned", latest_status_run=run("custom_idle"))) is None
+
+    print("goal-attention-readmodel-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/control_plane/work_items/attention_routing.py
+++ b/loopx/control_plane/work_items/attention_routing.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+from typing import AbstractSet, Any, Callable, Optional
+
+
+AttentionItemBuilder = Callable[..., dict[str, Any]]
+AttentionFieldsBuilder = Callable[[Optional[dict[str, Any]]], dict[str, Any]]
+GoalLifecycleFields = Callable[[dict[str, Any], Optional[dict[str, Any]]], dict[str, Any]]
+LatestRun = Callable[[dict[str, Any]], Optional[dict[str, Any]]]
+LegacyRuntimeGoalAttention = Callable[
+    [dict[str, Any], Optional[dict[str, Any]], dict[str, Any]],
+    Optional[dict[str, Any]],
+]
+OperatorQuestionBuilder = Callable[[str, str], str]
+OperatorQuestionNormalizer = Callable[..., str]
+RunHasExternalEvidenceWatchSignal = Callable[[dict[str, Any]], bool]
+SessionRuntimeProjectionFromRun = Callable[[Optional[dict[str, Any]]], Optional[dict[str, Any]]]
+SessionRuntimeProjectionAttention = Callable[
+    [dict[str, Any], Optional[dict[str, Any]], dict[str, Any]],
+    dict[str, Any],
+]
+
+
+def goal_attention(
+    goal: dict[str, Any],
+    *,
+    latest_run: LatestRun,
+    readiness_attention_fields: AttentionFieldsBuilder,
+    operator_gate_attention_fields: AttentionFieldsBuilder,
+    dreaming_attention_fields: AttentionFieldsBuilder,
+    goal_lifecycle_fields: GoalLifecycleFields,
+    legacy_runtime_goal_attention: LegacyRuntimeGoalAttention,
+    compact_session_runtime_projection_from_run: SessionRuntimeProjectionFromRun,
+    session_runtime_projection_attention: SessionRuntimeProjectionAttention,
+    attention_item: AttentionItemBuilder,
+    run_has_external_evidence_watch_signal: RunHasExternalEvidenceWatchSignal,
+    default_operator_question: OperatorQuestionBuilder,
+    normalize_operator_question: OperatorQuestionNormalizer,
+    default_operator_gate: str,
+    planned_controller_opt_in_recommended_action: str,
+    connected_adapter_statuses: AbstractSet[str],
+    connected_delivery_adapter_statuses: AbstractSet[str],
+    registry_waiting_on_overrides: AbstractSet[str],
+    blocking_classifications: AbstractSet[str],
+    user_or_controller_classifications: AbstractSet[str],
+    codex_ready_classifications: AbstractSet[str],
+) -> dict[str, Any] | None:
+    goal_id = str(goal.get("id") or "unknown-goal")
+    adapter_status = str(goal.get("adapter_status") or "")
+    adapter_kind = str(goal.get("adapter_kind") or "")
+    current_run = latest_run(goal)
+    readiness_fields = readiness_attention_fields(current_run)
+    operator_gate_fields = operator_gate_attention_fields(current_run)
+    dreaming_fields = dreaming_attention_fields(current_run)
+    attention_fields = {**readiness_fields, **operator_gate_fields, **dreaming_fields}
+    lifecycle_fields = goal_lifecycle_fields(goal, current_run)
+
+    if goal.get("legacy_runtime_goal"):
+        return legacy_runtime_goal_attention(goal, current_run, readiness_fields)
+
+    if not current_run:
+        if adapter_status in connected_adapter_statuses:
+            return attention_item(
+                goal_id=goal_id,
+                status="connected_without_run",
+                waiting_on="codex",
+                severity="action",
+                recommended_action="run the first read-only adapter tick and save a compact run record",
+                source="run_history",
+                **lifecycle_fields,
+            )
+        if adapter_status == "planned" and adapter_kind.endswith("_read_only_map_v0"):
+            command = f"loopx read-only-map --goal-id {goal_id} --dry-run"
+            return attention_item(
+                goal_id=goal_id,
+                status=str(goal.get("status") or "planned"),
+                waiting_on="user_or_controller",
+                severity="action",
+                recommended_action=planned_controller_opt_in_recommended_action,
+                operator_question=default_operator_question(goal_id, default_operator_gate),
+                agent_command=command,
+                source="registry",
+                **lifecycle_fields,
+            )
+        return attention_item(
+            goal_id=goal_id,
+            status=str(goal.get("status") or "no_run"),
+            waiting_on="controller",
+            severity="action",
+            recommended_action="connect an adapter or run a read-only map before expecting runtime status",
+            source="registry",
+            **lifecycle_fields,
+        )
+
+    json_exists = bool(current_run.get("json_exists"))
+    markdown_exists = bool(current_run.get("markdown_exists"))
+    if not json_exists or not markdown_exists:
+        return attention_item(
+            goal_id=goal_id,
+            status="run_artifact_missing",
+            waiting_on="codex",
+            severity="high",
+            recommended_action="repair or regenerate the latest run artifacts before trusting status",
+            source="run_history",
+            **attention_fields,
+            **lifecycle_fields,
+        )
+
+    session_projection = compact_session_runtime_projection_from_run(current_run)
+    if session_projection:
+        return session_runtime_projection_attention(goal, current_run, session_projection)
+
+    classification = str(current_run.get("classification") or "unknown")
+    action = str(current_run.get("recommended_action") or "inspect the latest run and choose one next action")
+    registry_waiting_on = str(goal.get("waiting_on") or "")
+    if registry_waiting_on in registry_waiting_on_overrides:
+        registry_attention_fields = dict(attention_fields)
+        if goal.get("operator_question"):
+            registry_attention_fields["operator_question"] = normalize_operator_question(
+                str(goal.get("operator_question") or ""),
+                goal_id=goal_id,
+                gate=str(goal.get("operator_gate") or default_operator_gate),
+            )
+        if goal.get("next_handoff_condition"):
+            registry_attention_fields["next_handoff_condition"] = str(goal.get("next_handoff_condition") or "")
+        return attention_item(
+            goal_id=goal_id,
+            status=str(goal.get("attention_status") or classification),
+            waiting_on=registry_waiting_on,
+            severity="watch" if registry_waiting_on == "external_evidence" else "action",
+            recommended_action=str(goal.get("recommended_action") or action),
+            source="registry",
+            **registry_attention_fields,
+            **lifecycle_fields,
+        )
+    if classification in blocking_classifications:
+        return attention_item(
+            goal_id=goal_id,
+            status=classification,
+            waiting_on="user_or_controller",
+            severity="high",
+            recommended_action=action,
+            source="latest_run",
+            **attention_fields,
+            **lifecycle_fields,
+        )
+    if classification in user_or_controller_classifications:
+        return attention_item(
+            goal_id=goal_id,
+            status=classification,
+            waiting_on="user_or_controller",
+            severity="action",
+            recommended_action=action,
+            source="latest_run",
+            **attention_fields,
+            **lifecycle_fields,
+        )
+    if classification in codex_ready_classifications:
+        return attention_item(
+            goal_id=goal_id,
+            status=classification,
+            waiting_on="codex",
+            severity="action",
+            recommended_action=action,
+            source="latest_run",
+            **attention_fields,
+            **lifecycle_fields,
+        )
+    if adapter_status in connected_delivery_adapter_statuses:
+        return attention_item(
+            goal_id=goal_id,
+            status=classification,
+            waiting_on="codex",
+            severity="action",
+            recommended_action=action,
+            source="latest_run",
+            **attention_fields,
+            **lifecycle_fields,
+        )
+    if run_has_external_evidence_watch_signal(current_run):
+        return attention_item(
+            goal_id=goal_id,
+            status=classification,
+            waiting_on="external_evidence",
+            severity="watch",
+            recommended_action=action,
+            source="latest_run",
+            **attention_fields,
+            **lifecycle_fields,
+        )
+    if adapter_status in connected_adapter_statuses:
+        return attention_item(
+            goal_id=goal_id,
+            status=classification,
+            waiting_on="codex",
+            severity="action",
+            recommended_action=action,
+            source="latest_run",
+            **attention_fields,
+            **lifecycle_fields,
+        )
+    return None

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -109,6 +109,9 @@ from .control_plane.todos.active_state_todo_parser import (
 from .control_plane.work_items.attention_item import (
     attention_item as _attention_item_read_model,
 )
+from .control_plane.work_items.attention_routing import (
+    goal_attention as _goal_attention_read_model,
+)
 from .control_plane.work_items.attention_fields import (
     operator_gate_attention_fields as _operator_gate_attention_fields_read_model,
     readiness_attention_fields as _readiness_attention_fields_read_model,
@@ -6838,161 +6841,29 @@ def session_runtime_projection_attention(
 
 
 def goal_attention(goal: dict[str, Any]) -> dict[str, Any] | None:
-    goal_id = str(goal.get("id") or "unknown-goal")
-    adapter_status = str(goal.get("adapter_status") or "")
-    adapter_kind = str(goal.get("adapter_kind") or "")
-    current_run = latest_run(goal)
-    readiness_fields = readiness_attention_fields(current_run)
-    operator_gate_fields = operator_gate_attention_fields(current_run)
-    dreaming_fields = dreaming_attention_fields(current_run)
-    attention_fields = {**readiness_fields, **operator_gate_fields, **dreaming_fields}
-    lifecycle_fields = goal_lifecycle_fields(goal, current_run)
-
-    if goal.get("legacy_runtime_goal"):
-        return legacy_runtime_goal_attention(goal, current_run, readiness_fields)
-
-    if not current_run:
-        if adapter_status in CONNECTED_ADAPTER_STATUSES:
-            return attention_item(
-                goal_id=goal_id,
-                status="connected_without_run",
-                waiting_on="codex",
-                severity="action",
-                recommended_action="run the first read-only adapter tick and save a compact run record",
-                source="run_history",
-                **lifecycle_fields,
-            )
-        if adapter_status == "planned" and adapter_kind.endswith("_read_only_map_v0"):
-            command = f"loopx read-only-map --goal-id {goal_id} --dry-run"
-            return attention_item(
-                goal_id=goal_id,
-                status=str(goal.get("status") or "planned"),
-                waiting_on="user_or_controller",
-                severity="action",
-                recommended_action=PLANNED_CONTROLLER_OPT_IN_RECOMMENDED_ACTION,
-                operator_question=default_operator_question(goal_id, DEFAULT_OPERATOR_GATE),
-                agent_command=command,
-                source="registry",
-                **lifecycle_fields,
-            )
-        return attention_item(
-            goal_id=goal_id,
-            status=str(goal.get("status") or "no_run"),
-            waiting_on="controller",
-            severity="action",
-            recommended_action="connect an adapter or run a read-only map before expecting runtime status",
-            source="registry",
-            **lifecycle_fields,
-        )
-
-    json_exists = bool(current_run.get("json_exists"))
-    markdown_exists = bool(current_run.get("markdown_exists"))
-    if not json_exists or not markdown_exists:
-        return attention_item(
-            goal_id=goal_id,
-            status="run_artifact_missing",
-            waiting_on="codex",
-            severity="high",
-            recommended_action="repair or regenerate the latest run artifacts before trusting status",
-            source="run_history",
-            **attention_fields,
-            **lifecycle_fields,
-        )
-
-    session_projection = compact_session_runtime_projection_from_run(current_run)
-    if session_projection:
-        return session_runtime_projection_attention(goal, current_run, session_projection)
-
-    classification = str(current_run.get("classification") or "unknown")
-    action = str(current_run.get("recommended_action") or "inspect the latest run and choose one next action")
-    registry_waiting_on = str(goal.get("waiting_on") or "")
-    if registry_waiting_on in REGISTRY_WAITING_ON_OVERRIDES:
-        registry_attention_fields = dict(attention_fields)
-        if goal.get("operator_question"):
-            registry_attention_fields["operator_question"] = normalize_operator_question(
-                str(goal.get("operator_question") or ""),
-                goal_id=goal_id,
-                gate=str(goal.get("operator_gate") or DEFAULT_OPERATOR_GATE),
-            )
-        if goal.get("next_handoff_condition"):
-            registry_attention_fields["next_handoff_condition"] = str(goal.get("next_handoff_condition") or "")
-        return attention_item(
-            goal_id=goal_id,
-            status=str(goal.get("attention_status") or classification),
-            waiting_on=registry_waiting_on,
-            severity="watch" if registry_waiting_on == "external_evidence" else "action",
-            recommended_action=str(goal.get("recommended_action") or action),
-            source="registry",
-            **registry_attention_fields,
-            **lifecycle_fields,
-        )
-    if classification in BLOCKING_CLASSIFICATIONS:
-        return attention_item(
-            goal_id=goal_id,
-            status=classification,
-            waiting_on="user_or_controller",
-            severity="high",
-            recommended_action=action,
-            source="latest_run",
-            **attention_fields,
-            **lifecycle_fields,
-        )
-    if classification in USER_OR_CONTROLLER_CLASSIFICATIONS:
-        return attention_item(
-            goal_id=goal_id,
-            status=classification,
-            waiting_on="user_or_controller",
-            severity="action",
-            recommended_action=action,
-            source="latest_run",
-            **attention_fields,
-            **lifecycle_fields,
-        )
-    if classification in CODEX_READY_CLASSIFICATIONS:
-        return attention_item(
-            goal_id=goal_id,
-            status=classification,
-            waiting_on="codex",
-            severity="action",
-            recommended_action=action,
-            source="latest_run",
-            **attention_fields,
-            **lifecycle_fields,
-        )
-    if adapter_status in CONNECTED_DELIVERY_ADAPTER_STATUSES:
-        return attention_item(
-            goal_id=goal_id,
-            status=classification,
-            waiting_on="codex",
-            severity="action",
-            recommended_action=action,
-            source="latest_run",
-            **attention_fields,
-            **lifecycle_fields,
-        )
-    if run_has_external_evidence_watch_signal(current_run):
-        return attention_item(
-            goal_id=goal_id,
-            status=classification,
-            waiting_on="external_evidence",
-            severity="watch",
-            recommended_action=action,
-            source="latest_run",
-            **attention_fields,
-            **lifecycle_fields,
-        )
-    if adapter_status in CONNECTED_ADAPTER_STATUSES:
-        return attention_item(
-            goal_id=goal_id,
-            status=classification,
-            waiting_on="codex",
-            severity="action",
-            recommended_action=action,
-            source="latest_run",
-            **attention_fields,
-            **lifecycle_fields,
-        )
-    return None
+    return _goal_attention_read_model(
+        goal,
+        latest_run=latest_run,
+        readiness_attention_fields=readiness_attention_fields,
+        operator_gate_attention_fields=operator_gate_attention_fields,
+        dreaming_attention_fields=dreaming_attention_fields,
+        goal_lifecycle_fields=goal_lifecycle_fields,
+        legacy_runtime_goal_attention=legacy_runtime_goal_attention,
+        compact_session_runtime_projection_from_run=compact_session_runtime_projection_from_run,
+        session_runtime_projection_attention=session_runtime_projection_attention,
+        attention_item=attention_item,
+        run_has_external_evidence_watch_signal=run_has_external_evidence_watch_signal,
+        default_operator_question=default_operator_question,
+        normalize_operator_question=normalize_operator_question,
+        default_operator_gate=DEFAULT_OPERATOR_GATE,
+        planned_controller_opt_in_recommended_action=PLANNED_CONTROLLER_OPT_IN_RECOMMENDED_ACTION,
+        connected_adapter_statuses=CONNECTED_ADAPTER_STATUSES,
+        connected_delivery_adapter_statuses=CONNECTED_DELIVERY_ADAPTER_STATUSES,
+        registry_waiting_on_overrides=REGISTRY_WAITING_ON_OVERRIDES,
+        blocking_classifications=BLOCKING_CLASSIFICATIONS,
+        user_or_controller_classifications=USER_OR_CONTROLLER_CLASSIFICATIONS,
+        codex_ready_classifications=CODEX_READY_CLASSIFICATIONS,
+    )
 
 
 def build_task_graph_projection(


### PR DESCRIPTION
## Summary
- move goal attention routing from status.py into control_plane/work_items/attention_routing.py
- keep status.goal_attention as a thin injected wrapper for existing helper functions and constants
- add goal-attention read-model parity smoke across no-run, registry override, blocker, codex-ready, connected adapter, external evidence, and session-runtime branches

## Validation
- python3 examples/control_plane/goal-attention-readmodel-smoke.py
- python3 examples/control_plane/status-watch-routing-attribute-smoke.py
- python3 examples/control_plane/legacy-runtime-goal-attention-smoke.py
- python3 examples/canary/smoke-suite-runner-smoke.py
- python3 -m compileall loopx/control_plane/work_items/attention_routing.py loopx/status.py
- python3 -m loopx.cli canary smoke-suite --profile core-control-plane --timeout-seconds 20 --fail-fast (stopped at existing repo-python-line-budget-smoke for unchanged benchmark-heavy files)
- python3 -m loopx.cli canary smoke-suite --profile core-control-plane --timeout-seconds 20 --offset 64 --fail-fast

## Notes
- The only core-control-plane profile failure is the existing line-budget gate for unchanged benchmark-heavy files; this PR does not take benchmark line-budget cleanup.