### PR TITLE
Fix app-server Goal completed turn status fallback

### DIFF
--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -112,7 +112,7 @@ for line in sys.stdin:
             "method": "turn/completed",
             "params": {
                 "threadId": "thread-skillsbench",
-                "turn": {"id": "turn-event-skillsbench", "status": "completed"},
+                "turn": {"id": "turn-event-skillsbench"},
             },
         }), flush=True)
         continue
@@ -1323,6 +1323,8 @@ def test_host_worker_waits_for_completion_and_keeps_public_json_compact() -> Non
         payload = json.loads(output.read_text(encoding="utf-8"))
         assert payload["ok"] is True, payload
         assert payload["turn"]["turn_completed_observed"] is True, payload
+        assert payload["turn"]["turn_status"] == "completed", payload
+        assert payload["turn"]["turn_completion_shape_unclean"] is False, payload
         assert payload["turn"]["completion_source_of_truth"] == "codex_turn_completion", payload
         assert payload["turn"]["turn_id_source"] == "event_stream", payload
         assert payload["turn"]["turn_start_response_turn_id_present"] is True, payload

--- a/scripts/codex_app_server_goal_driver.py
+++ b/scripts/codex_app_server_goal_driver.py
@@ -455,7 +455,7 @@ def _record_turn_event(
         return False
     if method == "turn/completed":
         turn.turn_completed_observed = True
-        turn.turn_status = _extract_turn_status(params) or turn.turn_status
+        turn.turn_status = _extract_turn_status(params) or "completed"
         turn.assistant_message = "".join(turn._assistant_message_parts)
         return True
     if event_name in {


### PR DESCRIPTION
## Summary
- Treat `turn/completed` events without an explicit status as completed in the app-server Goal driver.
- Update the SkillsBench app-server Goal worker smoke to exercise that event shape and assert the turn remains countable-clean.

## Validation
- `python3 examples/skillsbench-app-server-goal-worker-smoke.py`
- `python3 examples/codex-app-server-goal-driver-smoke.py`

## Boundary
- Public-safe compact smoke only; no raw task text, raw trajectories, verifier output, credentials, or local benchmark logs are added.