### PR TITLE
Extract attention queue read model

### DIFF
--- a/examples/control_plane/attention-queue-readmodel-smoke.py
+++ b/examples/control_plane/attention-queue-readmodel-smoke.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Smoke-test attention queue read-model parity."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx import status as status_module  # noqa: E402
+from loopx.control_plane.work_items import attention_queue as queue_read_model  # noqa: E402
+
+
+def direct_queue(
+    items: list[dict[str, Any]],
+    *,
+    goal_id_filter: str | None,
+    backlog: dict[str, Any] | None,
+    monitors: dict[str, Any] | None,
+) -> dict[str, Any]:
+    return queue_read_model.build_attention_queue_projection(
+        items=items,
+        goal_id_filter=goal_id_filter,
+        autonomous_backlog_candidates=backlog,
+        autonomous_monitor_candidates=monitors,
+        monitor_signal_waiting_on=status_module.MONITOR_SIGNAL_WAITING_ON,
+    )
+
+
+def direct_merge_global_registry(
+    *,
+    health_items: list[dict[str, Any]],
+    history_items: list[dict[str, Any]],
+    findings: list[Any],
+    goal_id_filter: str | None,
+) -> None:
+    queue_read_model.merge_global_registry_findings(
+        health_items=health_items,
+        history_items=history_items,
+        findings=findings,
+        goal_id_filter=goal_id_filter,
+        source_registry_shadow_findings=status_module.SOURCE_REGISTRY_SHADOW_FINDINGS,
+        attention_item=status_module.attention_item,
+        attach_global_registry_shadow_finding=status_module.attach_global_registry_shadow_finding,
+    )
+
+
+def open_agent_todos(*items: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "first_open_items": [
+            {
+                "index": index,
+                "text": item["text"],
+                "status": "open",
+                "task_class": item["task_class"],
+                "action_kind": item.get("action_kind"),
+            }
+            for index, item in enumerate(items, start=1)
+        ]
+    }
+
+
+def queue_item(goal_id: str, waiting_on: str, *, agent_todos: dict[str, Any] | None = None) -> dict[str, Any]:
+    item: dict[str, Any] = {
+        "goal_id": goal_id,
+        "status": "state_refreshed",
+        "waiting_on": waiting_on,
+        "severity": "action",
+        "recommended_action": "continue bounded work",
+        "source": "latest_run",
+        "quota": {"state": "eligible"},
+        "project_asset": {},
+    }
+    if agent_todos:
+        item["agent_todos"] = agent_todos
+    return item
+
+
+def assert_projection_parity() -> None:
+    items = [
+        queue_item(
+            "goal-a",
+            "codex",
+            agent_todos=open_agent_todos(
+                {
+                    "text": "[P1] Extract another durable read-model seam",
+                    "task_class": "advancement_task",
+                    "action_kind": "read_model_refactor",
+                }
+            ),
+        ),
+        queue_item("goal-b", "controller"),
+        queue_item("goal-c", "external_evidence"),
+        queue_item(
+            "goal-d",
+            status_module.MONITOR_SIGNAL_WAITING_ON,
+            agent_todos=open_agent_todos(
+                {
+                    "text": "[P2] Monitor compact status drift",
+                    "task_class": "continuous_monitor",
+                    "action_kind": "monitor",
+                }
+            ),
+        ),
+    ]
+    backlog = status_module.autonomous_backlog_candidates(items)
+    monitors = status_module.autonomous_monitor_candidates(items)
+
+    wrapper = status_module.build_attention_queue_projection(
+        items=deepcopy(items),
+        goal_id_filter="goal-a",
+        autonomous_backlog_candidates=deepcopy(backlog),
+        autonomous_monitor_candidates=deepcopy(monitors),
+    )
+    direct = direct_queue(
+        deepcopy(items),
+        goal_id_filter="goal-a",
+        backlog=deepcopy(backlog),
+        monitors=deepcopy(monitors),
+    )
+
+    assert wrapper == direct, (wrapper, direct)
+    assert wrapper["item_count"] == 4, wrapper
+    assert wrapper["needs_user_or_controller"] == 1, wrapper
+    assert wrapper["needs_controller"] == 1, wrapper
+    assert wrapper["needs_codex"] == 1, wrapper
+    assert wrapper["watching_external_evidence"] == 1, wrapper
+    assert wrapper["watching_monitor"] == 1, wrapper
+    assert wrapper["goal_filter"] == "goal-a", wrapper
+    assert wrapper["autonomous_backlog_candidates"]["open_count"] == 1, wrapper
+    assert wrapper["autonomous_monitor_candidates"]["open_count"] == 1, wrapper
+
+
+def assert_global_registry_merge_parity() -> None:
+    findings: list[Any] = [
+        {
+            "kind": "source_registry_missing",
+            "goal_id": "goal-shadow",
+            "severity": "high",
+            "message": "source registry missing",
+            "recommended_action": "restore source registry",
+        },
+        {
+            "kind": "registry_contract_failed",
+            "goal_id": "goal-health",
+            "severity": "action",
+            "recommended_action": "repair registry contract",
+        },
+        {
+            "kind": "filtered_registry_issue",
+            "goal_id": "other-goal",
+            "goal_ids": ["goal-filter"],
+            "severity": "action",
+            "recommended_action": "inspect filtered goal reference",
+        },
+        {
+            "kind": "ignored_info",
+            "goal_id": "ignored",
+            "severity": "info",
+            "recommended_action": "do not surface",
+        },
+    ]
+    wrapper_health: list[dict[str, Any]] = []
+    wrapper_history = [queue_item("goal-shadow", "codex")]
+    direct_health: list[dict[str, Any]] = []
+    direct_history = [queue_item("goal-shadow", "codex")]
+
+    status_module.merge_global_registry_attention_findings(
+        health_items=wrapper_health,
+        history_items=wrapper_history,
+        findings=deepcopy(findings),
+        goal_id_filter="goal-filter",
+    )
+    direct_merge_global_registry(
+        health_items=direct_health,
+        history_items=direct_history,
+        findings=deepcopy(findings),
+        goal_id_filter="goal-filter",
+    )
+    assert wrapper_health == direct_health, (wrapper_health, direct_health)
+    assert wrapper_history == direct_history, (wrapper_history, direct_history)
+    assert not wrapper_history[0].get("global_registry_shadow_findings"), wrapper_history
+    assert [item["goal_id"] for item in wrapper_health] == ["other-goal"], wrapper_health
+
+    wrapper_health = []
+    wrapper_history = [queue_item("goal-shadow", "codex")]
+    status_module.merge_global_registry_attention_findings(
+        health_items=wrapper_health,
+        history_items=wrapper_history,
+        findings=deepcopy(findings),
+        goal_id_filter=None,
+    )
+    assert wrapper_history[0]["global_registry_shadow_findings"][0]["kind"] == "source_registry_missing"
+    assert wrapper_history[0]["project_asset"]["global_registry_shadow_findings"]["open"] == 1
+    assert [item["goal_id"] for item in wrapper_health] == ["goal-health", "other-goal"], wrapper_health
+
+
+def main() -> int:
+    assert_projection_parity()
+    assert_global_registry_merge_parity()
+    print("attention-queue-readmodel-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/control_plane/work_items/attention_queue.py
+++ b/loopx/control_plane/work_items/attention_queue.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from typing import AbstractSet, Any, Callable, Optional
+
+
+AttentionItemBuilder = Callable[..., dict[str, Any]]
+GlobalRegistryShadowAttacher = Callable[[dict[str, Any], dict[str, Any]], None]
+
+
+def merge_global_registry_findings(
+    *,
+    health_items: list[dict[str, Any]],
+    history_items: list[dict[str, Any]],
+    findings: list[Any],
+    goal_id_filter: Optional[str],
+    source_registry_shadow_findings: AbstractSet[str],
+    attention_item: AttentionItemBuilder,
+    attach_global_registry_shadow_finding: GlobalRegistryShadowAttacher,
+) -> None:
+    live_quota_items_by_goal: dict[str, list[dict[str, Any]]] = {}
+    for item in history_items:
+        if isinstance(item.get("quota"), dict):
+            live_quota_items_by_goal.setdefault(str(item.get("goal_id") or ""), []).append(item)
+
+    for finding in findings:
+        if not isinstance(finding, dict):
+            continue
+        if finding.get("severity") not in {"high", "action"}:
+            continue
+        goal_id = str(finding.get("goal_id") or "global-registry")
+        if goal_id_filter:
+            finding_goal_ids = [
+                str(item)
+                for item in (finding.get("goal_ids") or [])
+                if str(item or "").strip()
+            ]
+            if goal_id != goal_id_filter and goal_id_filter not in finding_goal_ids:
+                continue
+        live_items = live_quota_items_by_goal.get(goal_id, [])
+        if finding.get("kind") in source_registry_shadow_findings and live_items:
+            for item in live_items:
+                attach_global_registry_shadow_finding(item, finding)
+            continue
+        health_items.append(
+            attention_item(
+                goal_id=goal_id,
+                status=str(finding.get("kind") or "global_registry_finding"),
+                waiting_on="codex",
+                severity=str(finding.get("severity") or "action"),
+                recommended_action=str(finding.get("recommended_action") or "inspect global registry health"),
+                source="global_registry",
+            )
+        )
+
+
+def build_attention_queue_projection(
+    *,
+    items: list[dict[str, Any]],
+    goal_id_filter: Optional[str],
+    autonomous_backlog_candidates: Optional[dict[str, Any]],
+    autonomous_monitor_candidates: Optional[dict[str, Any]],
+    monitor_signal_waiting_on: str,
+) -> dict[str, Any]:
+    queue: dict[str, Any] = {
+        "available": True,
+        "item_count": len(items),
+        "needs_user_or_controller": sum(
+            1 for item in items if item["waiting_on"] in {"user_or_controller", "controller"}
+        ),
+        "needs_controller": sum(1 for item in items if item["waiting_on"] == "controller"),
+        "needs_codex": sum(1 for item in items if item["waiting_on"] == "codex"),
+        "watching_external_evidence": sum(1 for item in items if item["waiting_on"] == "external_evidence"),
+        "watching_monitor": sum(1 for item in items if item["waiting_on"] == monitor_signal_waiting_on),
+        "items": items,
+    }
+    if goal_id_filter:
+        queue["goal_filter"] = goal_id_filter
+        queue["goal_filter_applied"] = True
+    if autonomous_backlog_candidates:
+        queue["autonomous_backlog_candidates"] = autonomous_backlog_candidates
+    if autonomous_monitor_candidates:
+        queue["autonomous_monitor_candidates"] = autonomous_monitor_candidates
+    return queue

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -109,6 +109,10 @@ from .control_plane.todos.active_state_todo_parser import (
 from .control_plane.work_items.attention_item import (
     attention_item as _attention_item_read_model,
 )
+from .control_plane.work_items.attention_queue import (
+    build_attention_queue_projection as _build_attention_queue_projection_read_model,
+    merge_global_registry_findings as _merge_global_registry_findings_read_model,
+)
 from .control_plane.work_items.attention_routing import (
     goal_attention as _goal_attention_read_model,
 )
@@ -6188,6 +6192,22 @@ def autonomous_monitor_candidates(
     )
 
 
+def build_attention_queue_projection(
+    *,
+    items: list[dict[str, Any]],
+    goal_id_filter: str | None,
+    autonomous_backlog_candidates: dict[str, Any] | None,
+    autonomous_monitor_candidates: dict[str, Any] | None,
+) -> dict[str, Any]:
+    return _build_attention_queue_projection_read_model(
+        items=items,
+        goal_id_filter=goal_id_filter,
+        autonomous_backlog_candidates=autonomous_backlog_candidates,
+        autonomous_monitor_candidates=autonomous_monitor_candidates,
+        monitor_signal_waiting_on=MONITOR_SIGNAL_WAITING_ON,
+    )
+
+
 def _subagent_state(run: dict[str, Any]) -> str | None:
     return _subagent_state_read_model(
         run,
@@ -6571,6 +6591,24 @@ def compact_global_registry_shadow_finding(finding: dict[str, Any]) -> dict[str,
 
 def attach_global_registry_shadow_finding(item: dict[str, Any], finding: dict[str, Any]) -> None:
     _attach_global_registry_shadow_finding_read_model(item, finding)
+
+
+def merge_global_registry_attention_findings(
+    *,
+    health_items: list[dict[str, Any]],
+    history_items: list[dict[str, Any]],
+    findings: list[Any],
+    goal_id_filter: str | None,
+) -> None:
+    _merge_global_registry_findings_read_model(
+        health_items=health_items,
+        history_items=history_items,
+        findings=findings,
+        goal_id_filter=goal_id_filter,
+        source_registry_shadow_findings=SOURCE_REGISTRY_SHADOW_FINDINGS,
+        attention_item=attention_item,
+        attach_global_registry_shadow_finding=attach_global_registry_shadow_finding,
+    )
 
 
 def parse_timestamp(value: Any) -> datetime | None:
@@ -7135,66 +7173,24 @@ def build_attention_queue(
             )
             history_items.append(item)
 
-    live_quota_items_by_goal: dict[str, list[dict[str, Any]]] = {}
-    for item in history_items:
-        if isinstance(item.get("quota"), dict):
-            live_quota_items_by_goal.setdefault(str(item.get("goal_id") or ""), []).append(item)
-
-    for finding in global_registry.get("findings") or []:
-        if not isinstance(finding, dict):
-            continue
-        if finding.get("severity") not in {"high", "action"}:
-            continue
-        goal_id = str(finding.get("goal_id") or "global-registry")
-        if goal_id_filter:
-            finding_goal_ids = [
-                str(item)
-                for item in (finding.get("goal_ids") or [])
-                if str(item or "").strip()
-            ]
-            if goal_id != goal_id_filter and goal_id_filter not in finding_goal_ids:
-                continue
-        live_items = live_quota_items_by_goal.get(goal_id, [])
-        if finding.get("kind") in SOURCE_REGISTRY_SHADOW_FINDINGS and live_items:
-            for item in live_items:
-                attach_global_registry_shadow_finding(item, finding)
-            continue
-        health_items.append(
-            attention_item(
-                goal_id=goal_id,
-                status=str(finding.get("kind") or "global_registry_finding"),
-                waiting_on="codex",
-                severity=str(finding.get("severity") or "action"),
-                recommended_action=str(finding.get("recommended_action") or "inspect global registry health"),
-                source="global_registry",
-            )
-        )
+    merge_global_registry_attention_findings(
+        health_items=health_items,
+        history_items=history_items,
+        findings=global_registry.get("findings") or [],
+        goal_id_filter=goal_id_filter,
+    )
 
     items = [*health_items, *history_items]
     attach_dependency_blockers(items)
     backlog_candidates = autonomous_backlog_candidates(items)
     monitor_candidates = autonomous_monitor_candidates(items)
 
-    queue = {
-        "available": True,
-        "item_count": len(items),
-        "needs_user_or_controller": sum(
-            1 for item in items if item["waiting_on"] in {"user_or_controller", "controller"}
-        ),
-        "needs_controller": sum(1 for item in items if item["waiting_on"] == "controller"),
-        "needs_codex": sum(1 for item in items if item["waiting_on"] == "codex"),
-        "watching_external_evidence": sum(1 for item in items if item["waiting_on"] == "external_evidence"),
-        "watching_monitor": sum(1 for item in items if item["waiting_on"] == MONITOR_SIGNAL_WAITING_ON),
-        "items": items,
-    }
-    if goal_id_filter:
-        queue["goal_filter"] = goal_id_filter
-        queue["goal_filter_applied"] = True
-    if backlog_candidates:
-        queue["autonomous_backlog_candidates"] = backlog_candidates
-    if monitor_candidates:
-        queue["autonomous_monitor_candidates"] = monitor_candidates
-    return queue
+    return build_attention_queue_projection(
+        items=items,
+        goal_id_filter=goal_id_filter,
+        autonomous_backlog_candidates=backlog_candidates,
+        autonomous_monitor_candidates=monitor_candidates,
+    )
 
 
 def compact_human_reward(reward: Any) -> dict[str, Any] | None:


### PR DESCRIPTION
Summary
- Move attention queue final projection and global registry finding merge into loopx/control_plane/work_items/attention_queue.py.
- Keep loopx/status.py as the orchestration layer for goal enrichment and wrapper compatibility.
- Add a focused attention-queue read-model smoke covering counters, candidates, goal filtering, source-registry shadow findings, and global health findings.

Validation
- python3 -m compileall loopx/control_plane/work_items/attention_queue.py loopx/status.py
- python3 examples/control_plane/attention-queue-readmodel-smoke.py
- python3 examples/control_plane/status-markdown-smoke.py
- python3 examples/control_plane/status-goal-filter-smoke.py
- python3 examples/control_plane/status-neutral-run-window-smoke.py
- python3 examples/control_plane/status-quota-review-packet-parity-smoke.py
- python3 examples/canary/smoke-suite-runner-smoke.py
- Earlier on this branch before the auto-research-only rebase: core-control-plane smoke-suite first window passed until the existing repo-python-line-budget smoke, which still fails only on unchanged benchmark-heavy files; offset 65 passed 83/83.

Scope note
- This intentionally does not touch benchmark line-budget cleanup; that remains outside the product-capability lane unless reassigned.