### PR TITLE
Extract public safety read model

### DIFF
--- a/examples/control_plane/public-safety-readmodel-smoke.py
+++ b/examples/control_plane/public-safety-readmodel-smoke.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx import status as status_module  # noqa: E402
+from loopx.control_plane.runtime import public_safety as public_safety_read_model  # noqa: E402
+
+
+def _direct_text(value: object, *, limit: int = 220) -> str | None:
+    return public_safety_read_model.public_safe_compact_text(
+        value,
+        limit=limit,
+        normalize_text=status_module.normalize_todo_text,
+        local_path_surface_pattern=status_module.LOCAL_PATH_SURFACE_PATTERN,
+        secret_like_surface_pattern=status_module.SECRET_LIKE_SURFACE_PATTERN,
+    )
+
+
+def assert_public_safe_text_parity() -> None:
+    assert status_module.public_safe_compact_text("  keep\nthis  value ") == "keep this value"
+    assert status_module.public_safe_compact_text("  keep\nthis  value ") == _direct_text(
+        "  keep\nthis  value "
+    )
+    assert status_module.public_safe_compact_text("") is None
+    assert status_module.public_safe_compact_text("") == _direct_text("")
+
+    local_path = "/" + "tmp" + "/loopx-public-boundary-probe.json"
+    secret_like_text = "tok" + "en" + "=" + ("x" * 12)
+    assert status_module.public_safe_compact_text(local_path) is None
+    assert status_module.public_safe_compact_text(local_path) == _direct_text(local_path)
+    assert status_module.public_safe_compact_text(secret_like_text) is None
+    assert status_module.public_safe_compact_text(secret_like_text) == _direct_text(secret_like_text)
+
+
+def assert_public_safe_list_parity() -> None:
+    local_path = "/" + "tmp" + "/loopx-public-boundary-probe.json"
+    values = ["first", local_path, "second", "third"]
+    expected = ["first", "second"]
+    assert status_module.public_safe_compact_list(values, limit=2) == expected
+    assert public_safety_read_model.public_safe_compact_list(
+        values,
+        limit=2,
+        compact_text=_direct_text,
+    ) == expected
+    assert status_module.public_safe_compact_list("single", limit=4) == ["single"]
+
+
+def main() -> None:
+    assert_public_safe_text_parity()
+    assert_public_safe_list_parity()
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/control_plane/runtime/public_safety.py
+++ b/loopx/control_plane/runtime/public_safety.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
+
+
+NormalizeText = Callable[..., str]
+CompactText = Callable[..., Optional[str]]
+
+
+def public_safe_compact_text(
+    value: Any,
+    *,
+    limit: int = 220,
+    normalize_text: NormalizeText,
+    local_path_surface_pattern: Any,
+    secret_like_surface_pattern: Any,
+) -> str | None:
+    text = normalize_text(str(value or ""), limit=limit)
+    if not text:
+        return None
+    if local_path_surface_pattern.search(text) or secret_like_surface_pattern.search(text):
+        return None
+    return text
+
+
+def public_safe_compact_list(
+    value: Any,
+    *,
+    limit: int,
+    compact_text: CompactText,
+    item_limit: int = 160,
+) -> list[str]:
+    values = value if isinstance(value, list) else [value] if value else []
+    result: list[str] = []
+    for item in values:
+        text = compact_text(item, limit=item_limit)
+        if not text:
+            continue
+        result.append(text)
+        if len(result) >= limit:
+            break
+    return result

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -169,6 +169,10 @@ from .control_plane.runtime.run_compaction import (
     compact_operator_gate_resume_contract as _compact_operator_gate_resume_contract_read_model,
     compact_run_base as _compact_run_base_read_model,
 )
+from .control_plane.runtime.public_safety import (
+    public_safe_compact_list as _public_safe_compact_list_read_model,
+    public_safe_compact_text as _public_safe_compact_text_read_model,
+)
 from .control_plane.runtime.run_history import (
     build_run_history as _build_run_history_read_model,
     latest_run as _latest_run_read_model,
@@ -596,25 +600,21 @@ AUTONOMOUS_RUN_HISTORY_STALL_PATTERN = re.compile(
     r"(?i)(?:monitor|observe|observation|poll|watch|quiet|no[-_ ]?op|no[-_ ]?progress|stalled?|unchanged|dependency|停转|无进展|重复|反复|观察|轮询)"
 )
 def public_safe_compact_text(value: Any, *, limit: int = 220) -> str | None:
-    text = normalize_todo_text(str(value or ""), limit=limit)
-    if not text:
-        return None
-    if LOCAL_PATH_SURFACE_PATTERN.search(text) or SECRET_LIKE_SURFACE_PATTERN.search(text):
-        return None
-    return text
+    return _public_safe_compact_text_read_model(
+        value,
+        limit=limit,
+        normalize_text=normalize_todo_text,
+        local_path_surface_pattern=LOCAL_PATH_SURFACE_PATTERN,
+        secret_like_surface_pattern=SECRET_LIKE_SURFACE_PATTERN,
+    )
 
 
 def public_safe_compact_list(value: Any, *, limit: int = MAX_SUBAGENT_SCOPE_ITEMS) -> list[str]:
-    values = value if isinstance(value, list) else [value] if value else []
-    result: list[str] = []
-    for item in values:
-        text = public_safe_compact_text(item, limit=160)
-        if not text:
-            continue
-        result.append(text)
-        if len(result) >= limit:
-            break
-    return result
+    return _public_safe_compact_list_read_model(
+        value,
+        limit=limit,
+        compact_text=public_safe_compact_text,
+    )
 
 
 def compact_session_runtime_readonly_projection(value: Any) -> dict[str, Any] | None:


### PR DESCRIPTION
## Summary
- Move generic public-safe text/list compaction into `loopx.control_plane.runtime.public_safety` while keeping `loopx.status` wrappers as the public callsite.
- Add a focused control-plane smoke that checks safe text retention, local-path and secret-like filtering, list limit semantics, and wrapper/read-model parity.

## Validation
- `python3 -m compileall loopx/control_plane/runtime/public_safety.py loopx/status.py`
- `python3 examples/control_plane/public-safety-readmodel-smoke.py`
- `python3 examples/control_plane/run-compaction-readmodel-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 examples/control_plane/status-goal-filter-smoke.py`
- `python3 examples/control_plane/status-contract-readmodel-smoke.py`
- `python3 examples/control_plane/check-public-boundary-smoke.py`
- `python3 -m loopx.cli canary smoke-suite --script examples/control_plane/public-safety-readmodel-smoke.py --timeout-seconds 20`

## Known pre-existing canary reds
- `python3 -m loopx.cli canary smoke-suite --profile core-control-plane --timeout-seconds 20 --offset 60 --limit 6 --fail-fast` still fails at `examples/control_plane/repo-python-line-budget-smoke.py` for existing benchmark-heavy files.
- `python3 -m loopx.cli canary smoke-suite --profile core-control-plane --timeout-seconds 20 --offset 66 --limit 46 --fail-fast` passes 45/46 then fails at existing `examples/multi-agent-visible-launcher-protocol-smoke.py`; the same smoke fails on current main because `docs/guides/auto-research-command-path.md` lacks `isolate only mutating evidence-runner attempts`.
