### PR TITLE
Fix app-server Goal completed turn status

### DIFF
--- a/examples/codex-app-server-goal-driver-smoke.py
+++ b/examples/codex-app-server-goal-driver-smoke.py
@@ -147,6 +147,31 @@ for line in sys.stdin:
                 "payload": {"type": "task_complete"},
             }), flush=True)
             continue
+        if "stale completion status" in prompt_text:
+            result = {
+                "turn": {"id": "turn-stale-completion-status", "status": "inProgress"}
+            }
+            print(json.dumps({"id": mid, "result": result}), flush=True)
+            print(json.dumps({
+                "method": "item/agentMessage/delta",
+                "params": {
+                    "threadId": "thread-smoke",
+                    "turnId": "turn-stale-completion-status",
+                    "itemId": "item-stale-completion-status",
+                    "delta": "Stale status final answer.",
+                },
+            }), flush=True)
+            print(json.dumps({
+                "method": "turn/completed",
+                "params": {
+                    "threadId": "thread-smoke",
+                    "turn": {
+                        "id": "turn-stale-completion-status",
+                        "status": "inProgress",
+                    },
+                },
+            }), flush=True)
+            continue
         if "session-file completion" in prompt_text:
             result = {"turn": {"id": "turn-session-file-smoke", "status": "running"}}
             print(json.dumps({"id": mid, "result": result}), flush=True)
@@ -388,6 +413,26 @@ def main() -> int:
             assert "Event style final answer." not in json.dumps(compact), compact
         finally:
             event_completed_turn.terminate()
+
+        stale_completion_status_turn = module.start_codex_app_server_goal_turn(
+            codex_bin=str(fake),
+            work_dir=root / "work-stale-completion-status",
+            objective="Synthetic objective.",
+            prompt="Synthetic stale completion status prompt.",
+            model_name="gpt-5.5",
+            reasoning_effort="high",
+            response_timeout_sec=5,
+            wait_for_completion=True,
+            turn_timeout_sec=5,
+        )
+        try:
+            compact = module.compact_turn_metadata(stale_completion_status_turn)
+            assert compact["turn_completed_observed"] is True, compact
+            assert compact["turn_status"] == "completed", compact
+            assert compact["assistant_message_present"] is True, compact
+            assert "Stale status final answer." not in json.dumps(compact), compact
+        finally:
+            stale_completion_status_turn.terminate()
 
         session_completed_turn = module.start_codex_app_server_goal_turn(
             codex_bin=str(fake),

--- a/examples/skillsbench-app-server-goal-worker-smoke.py
+++ b/examples/skillsbench-app-server-goal-worker-smoke.py
@@ -112,7 +112,14 @@ for line in sys.stdin:
             "method": "turn/completed",
             "params": {
                 "threadId": "thread-skillsbench",
-                "turn": {"id": "turn-event-skillsbench"},
+                "turn": {
+                    "id": "turn-event-skillsbench",
+                    **(
+                        {"status": "inProgress"}
+                        if "stale completion status" in prompt_text
+                        else {}
+                    ),
+                },
             },
         }), flush=True)
         continue
@@ -1292,7 +1299,10 @@ def test_host_worker_waits_for_completion_and_keeps_public_json_compact() -> Non
         private_response = root / "private-response.txt"
         fake.write_text(FAKE_CODEX, encoding="utf-8")
         fake.chmod(0o755)
-        prompt.write_text("Private task instruction placeholder.", encoding="utf-8")
+        prompt.write_text(
+            "Private task instruction placeholder. stale completion status.",
+            encoding="utf-8",
+        )
         result = subprocess.run(
             [
                 sys.executable,
@@ -1343,6 +1353,7 @@ def test_host_worker_waits_for_completion_and_keeps_public_json_compact() -> Non
         public_json = json.dumps(payload)
         assert "private worker answer" not in public_json, payload
         assert "Private task instruction placeholder" not in public_json, payload
+        assert "stale completion status" not in public_json, payload
 
 
 def test_host_worker_recovers_when_first_turn_only_echoes_context() -> None:

--- a/scripts/codex_app_server_goal_driver.py
+++ b/scripts/codex_app_server_goal_driver.py
@@ -434,10 +434,12 @@ def _record_turn_event(
     if event_name == "response_item:reasoning":
         return False
     if event_name == "event_msg:task_started":
-        turn.turn_status = "inProgress"
+        if not turn.turn_completed_observed:
+            turn.turn_status = "inProgress"
         return False
     if method == "turn/started":
-        turn.turn_status = _extract_turn_status(params) or turn.turn_status
+        if not turn.turn_completed_observed:
+            turn.turn_status = _extract_turn_status(params) or turn.turn_status
         return False
     if method == "item/completed":
         turn.item_completed_count += 1
@@ -455,7 +457,7 @@ def _record_turn_event(
         return False
     if method == "turn/completed":
         turn.turn_completed_observed = True
-        turn.turn_status = _extract_turn_status(params) or "completed"
+        turn.turn_status = "completed"
         turn.assistant_message = "".join(turn._assistant_message_parts)
         return True
     if event_name in {
@@ -464,7 +466,7 @@ def _record_turn_event(
         "event_msg:turn_completed",
     }:
         turn.turn_completed_observed = True
-        turn.turn_status = _extract_turn_status(params) or "completed"
+        turn.turn_status = "completed"
         turn.assistant_message = "".join(turn._assistant_message_parts)
         return True
     if method == "error":


### PR DESCRIPTION
Summary:
- Treat turn/completed and task_complete events as final completed status, even when the event payload carries stale inProgress status.
- Prevent later started/task_started events from downgrading an already completed turn.
- Add driver and SkillsBench worker smokes for stale completion status.

Validation:
- python3 examples/codex-app-server-goal-driver-smoke.py
- python3 examples/skillsbench-app-server-goal-worker-smoke.py
- python3 -m py_compile scripts/codex_app_server_goal_driver.py scripts/skillsbench_host_codex_goal_worker.py
- git diff --check