### PR TITLE
Ensure full-participation auto-research rounds

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -511,24 +511,34 @@ def main() -> int:
         worker_loop = payload["worker_loop"]
         assert worker_loop["schema_version"] == "auto_research_worker_loop_v0", payload
         assert worker_loop["mode"] == "execute", payload
-        assert worker_loop["executed_turn_count"] == 10, payload
-        assert worker_loop["completed_turn_count"] == 10, payload
+        assert worker_loop["executed_turn_count"] == 16, payload
+        assert worker_loop["completed_turn_count"] == 16, payload
         assert worker_loop["selected_actions"] == [
             "write_research_contract",
             "propose_hypothesis",
             "run_dev_eval",
             "summarize_evidence",
+            "review_research_contract",
+            "review_hypothesis_frontier",
             "run_holdout_eval",
             "write_evaluation_summary",
+            "review_research_contract",
             "propose_hypothesis",
             "run_dev_eval",
+            "review_promotion_readiness",
+            "review_research_contract",
+            "review_hypothesis_frontier",
             "run_holdout_eval",
             "write_evaluation_summary",
         ], payload
+        assert all(turn["executed"] is True for turn in worker_loop["turns"]), worker_loop
+        assert all(turn["completion_status"] == "done" for turn in worker_loop["turns"]), worker_loop
         assert worker_loop["stop_reason"] == "max_rounds", payload
         collective_rounds = payload["collective_research_rounds"]
         assert collective_rounds["round_unit"] == "collective_agent_pass", collective_rounds
         assert collective_rounds["collective_round_count"] == 4, collective_rounds
+        assert collective_rounds["full_participation_round_count"] == 4, collective_rounds
+        assert collective_rounds["full_participation_verified"] is True, collective_rounds
         assert collective_rounds["multi_round_research_verified"] is True, collective_rounds
         assert collective_rounds["dev_metric_sequence"] == [4.0, 4.8], collective_rounds
         assert collective_rounds["holdout_metric_sequence"] == [4.5, 5.2], collective_rounds
@@ -540,6 +550,8 @@ def main() -> int:
         assert kernel_ledger["owner_layer"] == "generic_multi_agent_kernel", kernel_ledger
         assert kernel_ledger["expected_lane_count"] == 4, kernel_ledger
         assert kernel_ledger["collective_round_count"] == 4, kernel_ledger
+        assert kernel_ledger["full_participation_round_count"] == 4, kernel_ledger
+        assert kernel_ledger["full_participation_verified"] is True, kernel_ledger
         assert kernel_ledger["multi_round_interaction_verified"] is True, kernel_ledger
         assert kernel_ledger["successor_todo_count"] >= 1, kernel_ledger
         tonight = payload["tonight_experience"]
@@ -631,18 +643,19 @@ def main() -> int:
                 assert visible_proof["schema_version"] == "auto_research_visible_worker_proof_v0", visible_proof
                 assert visible_proof["owner_layer"] == "generic_multi_agent_kernel", visible_proof
                 assert visible_proof["user_facing_by_default"] is False, visible_proof
-                assert visible_proof["lane_authored_evidence_loaded"] is False, visible_proof
-                assert visible_proof["evidence_source"] == "visible_launcher", visible_proof
+                assert visible_proof["lane_authored_evidence_loaded"] is True, visible_proof
+                assert visible_proof["evidence_source"] == "visible_launcher_artifact", visible_proof
                 assert visible_proof["visible_lanes_launched"] is True, visible_proof
                 assert visible_proof["pane_local_a2a_rounds_loaded"] is True, visible_proof
                 assert visible_proof["pane_local_a2a_round_count"] >= 4, visible_proof
                 assert visible_proof["pane_local_a2a_multi_tick_verified"] is True, visible_proof
-                assert visible_proof.get("collective_research_rounds_loaded") in (None, False), visible_proof
+                assert visible_proof["collective_research_rounds_loaded"] is True, visible_proof
                 assert visible_proof["decentralized_a2a_rounds_verified"] is False, visible_proof
                 assert visible_proof["cadence_wake_loaded"] is True, visible_proof
                 assert visible_proof["cadence_wake_verified"] is True, visible_proof
                 live_evidence = visible_payload.get("live_worker_evidence", {"loaded": False})
-                assert live_evidence["loaded"] is False, live_evidence
+                assert live_evidence["loaded"] is True, live_evidence
+                assert live_evidence["holdout_metric"] == 4.5, live_evidence
                 visible_rounds = visible_payload["visible_pane_a2a_rounds"]
                 assert visible_rounds["source"] == "visible_launcher_artifact", visible_rounds
                 assert visible_rounds["coordination_model"] == "decentralized_state_a2a", visible_rounds
@@ -703,17 +716,14 @@ def main() -> int:
                     "cadence_wake_verified": True,
                     "pane_local_tick_loaded": True,
                     "collective_research_multi_round_verified": False,
-                    "lane_authored_evidence_loaded": False,
-                    "protected_scope_clean": False,
-                    "positive_metric_over_baseline": False,
+                    "lane_authored_evidence_loaded": True,
+                    "protected_scope_clean": True,
+                    "positive_metric_over_baseline": True,
                     "workflow_driver_false": True,
                     "kernel_driver_contract_loaded": True,
                 }, visible_readiness
                 assert visible_readiness["missing_requirements"] == [
                     "collective_research_multi_round_verified",
-                    "lane_authored_evidence_loaded",
-                    "protected_scope_clean",
-                    "positive_metric_over_baseline",
                 ], visible_readiness
                 assert visible_readiness["rounds"]["max_completed"] >= 4, visible_readiness
                 assert visible_readiness["rounds"]["counts_as_collective_research_round"] is False, visible_readiness
@@ -721,11 +731,11 @@ def main() -> int:
                 improvement = visible_readiness["improvement_summary"]
                 assert improvement["baseline_metric"] == 1.0, improvement
                 assert improvement["dev_metric_sequence"] == [], improvement
-                assert improvement["holdout_metric_sequence"] == [], improvement
-                assert improvement["holdout_improvement_count"] == 0, improvement
-                assert improvement["best_metric"] is None, improvement
-                assert improvement["best_metric_source"] is None, improvement
-                assert improvement["improved_over_baseline"] is False, improvement
+                assert improvement["holdout_metric_sequence"] == [4.5], improvement
+                assert improvement["holdout_improvement_count"] == 1, improvement
+                assert improvement["best_metric"] == 4.5, improvement
+                assert improvement["best_metric_source"] == "final_holdout", improvement
+                assert improvement["improved_over_baseline"] is True, improvement
                 assert improvement["holdout_delta_over_dev"] is None, improvement
                 assert "auto-research start" in visible_readiness["one_command"], visible_readiness
                 assert visible_readiness["one_command"].endswith("--execute"), visible_readiness

--- a/examples/auto-research-layered-e2e-acceptance-smoke.py
+++ b/examples/auto-research-layered-e2e-acceptance-smoke.py
@@ -25,10 +25,16 @@ EXPECTED_ACTIONS = [
     "propose_hypothesis",
     "run_dev_eval",
     "summarize_evidence",
+    "review_research_contract",
+    "review_hypothesis_frontier",
     "run_holdout_eval",
     "write_evaluation_summary",
+    "review_research_contract",
     "propose_hypothesis",
     "run_dev_eval",
+    "review_promotion_readiness",
+    "review_research_contract",
+    "review_hypothesis_frontier",
     "run_holdout_eval",
     "write_evaluation_summary",
 ]
@@ -266,12 +272,14 @@ def assert_two_round_outcome(payload: dict[str, Any]) -> None:
     assert worker_loop["schema_version"] == "auto_research_worker_loop_v0", worker_loop
     assert worker_loop["mode"] == "execute", worker_loop
     assert worker_loop["selected_actions"] == EXPECTED_ACTIONS, worker_loop
-    assert worker_loop["executed_turn_count"] == 10, worker_loop
-    assert worker_loop["completed_turn_count"] == 10, worker_loop
+    assert worker_loop["executed_turn_count"] == 16, worker_loop
+    assert worker_loop["completed_turn_count"] == 16, worker_loop
     assert worker_loop["stop_reason"] == "max_rounds", worker_loop
 
     turns = worker_loop["turns"]
     executed = [turn for turn in turns if turn["executed"]]
+    assert len(executed) == 16, executed
+    assert all(turn["completion_status"] == "done" for turn in turns), turns
     assert {turn["round"] for turn in executed} == {1, 2, 3, 4}, executed
     dev_turn = next(
         turn
@@ -321,6 +329,8 @@ def assert_two_round_outcome(payload: dict[str, Any]) -> None:
     collective_rounds = payload["collective_research_rounds"]
     assert collective_rounds["round_unit"] == "collective_agent_pass", collective_rounds
     assert collective_rounds["collective_round_count"] == 4, collective_rounds
+    assert collective_rounds["full_participation_round_count"] == 4, collective_rounds
+    assert collective_rounds["full_participation_verified"] is True, collective_rounds
     assert collective_rounds["multi_round_research_verified"] is True, collective_rounds
     assert collective_rounds["dev_metric_sequence"] == [4.0, 4.8], collective_rounds
     assert collective_rounds["holdout_metric_sequence"] == [4.5, 5.2], collective_rounds
@@ -330,6 +340,8 @@ def assert_two_round_outcome(payload: dict[str, Any]) -> None:
     assert kernel_ledger["owner_layer"] == "generic_multi_agent_kernel", kernel_ledger
     assert kernel_ledger["expected_lane_count"] == 4, kernel_ledger
     assert kernel_ledger["collective_round_count"] == 4, kernel_ledger
+    assert kernel_ledger["full_participation_round_count"] == 4, kernel_ledger
+    assert kernel_ledger["full_participation_verified"] is True, kernel_ledger
     assert kernel_ledger["integrated_evidence"]["dev_metric"] == 4.8, kernel_ledger
     assert kernel_ledger["integrated_evidence"]["holdout_metric"] == 5.2, kernel_ledger
     assert kernel_ledger["integrated_evidence"]["holdout_improvement_count"] == 2, kernel_ledger
@@ -395,11 +407,14 @@ def assert_markdown_explains_research_rounds(payload: dict[str, Any]) -> None:
         assert role in markdown, markdown
     assert "## Collective Rounds / 集体研究轮次" in markdown, markdown
     assert "rounds: `4`" in markdown, markdown
-    assert "completed_turns: `10/16`" in markdown, markdown
+    assert "full_participation_rounds: `4`" in markdown, markdown
+    assert "completed_turns: `16/16`" in markdown, markdown
     assert "dev_metric_sequence: `4.0 -> 4.8`" in markdown, markdown
     assert "holdout_metric_sequence: `4.5 -> 5.2`" in markdown, markdown
     assert "holdout_improvement_count: `2` (required `2`)" in markdown, markdown
-    assert "Round 4: executed `research-executor:run_holdout_eval holdout=5.2" in markdown, markdown
+    assert "Round 4: executed `" in markdown, markdown
+    assert "research-executor:run_holdout_eval holdout=5.2" in markdown, markdown
+    assert "Round 4:" in markdown and "no_op `none`" in markdown, markdown
     assert "round_semantics: one round is one quota/frontier opportunity" in markdown, markdown
     assert_public_safe(markdown)
 

--- a/examples/auto-research-worker-loop-smoke.py
+++ b/examples/auto-research-worker-loop-smoke.py
@@ -116,21 +116,29 @@ def main() -> int:
         assert payload["ok"] is True, payload
         assert payload["schema_version"] == "auto_research_worker_loop_v0", payload
         assert payload["mode"] == "execute", payload
-        assert payload["executed_turn_count"] == 10, payload
-        assert payload["completed_turn_count"] == 10, payload
+        assert payload["executed_turn_count"] == 16, payload
+        assert payload["completed_turn_count"] == 16, payload
         assert payload["stop_reason"] == "max_rounds", payload
         assert payload["selected_actions"] == [
             "write_research_contract",
             "propose_hypothesis",
             "run_dev_eval",
             "summarize_evidence",
+            "review_research_contract",
+            "review_hypothesis_frontier",
             "run_holdout_eval",
             "write_evaluation_summary",
+            "review_research_contract",
             "propose_hypothesis",
             "run_dev_eval",
+            "review_promotion_readiness",
+            "review_research_contract",
+            "review_hypothesis_frontier",
             "run_holdout_eval",
             "write_evaluation_summary",
         ], payload
+        assert all(turn["executed"] is True for turn in payload["turns"]), payload
+        assert all(turn["completion_status"] == "done" for turn in payload["turns"]), payload
         evidence_turns = [
             turn for turn in payload["turns"] if turn.get("selected_action") == "run_dev_eval"
         ]

--- a/examples/multi-agent-collective-round-ledger-smoke.py
+++ b/examples/multi-agent-collective-round-ledger-smoke.py
@@ -99,6 +99,9 @@ def main() -> int:
     assert ledger["completed_lane_turn_count"] == 3, ledger
     assert ledger["collective_round_indexes"] == [1, 2], ledger
     assert ledger["collective_round_count"] == 2, ledger
+    assert ledger["full_participation_round_indexes"] == [1], ledger
+    assert ledger["full_participation_round_count"] == 1, ledger
+    assert ledger["full_participation_verified"] is False, ledger
     assert ledger["multi_round_interaction_verified"] is True, ledger
     assert ledger["integrated_evidence"]["evidence_event_count"] == 3, ledger
     assert ledger["integrated_evidence"]["dev_metric"] == 4.0, ledger

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -457,13 +457,6 @@ def _build_collective_round_summary(
             previous = metric
     else:
         holdout_improvements = holdout_improvement_count
-    multi_round_research_verified = (
-        collective_round_count >= 4
-        and dev_metric is not None
-        and holdout_metric is not None
-        and dev_metric > baseline
-        and holdout_improvements >= 2
-    )
     kernel_ledger = build_multi_agent_collective_round_ledger(
         source=source,
         expected_lanes=expected_lanes,
@@ -477,6 +470,20 @@ def _build_collective_round_summary(
             "evidence_event_count": evidence_event_count,
         },
         role_declared_successor_todos=role_declared_successor_todos,
+    )
+    full_participation_round_count = kernel_ledger.get("full_participation_round_count")
+    if not isinstance(full_participation_round_count, int) or isinstance(
+        full_participation_round_count, bool
+    ):
+        full_participation_round_count = 0
+    full_participation_verified = kernel_ledger.get("full_participation_verified") is True
+    multi_round_research_verified = (
+        full_participation_round_count >= 4
+        and full_participation_verified
+        and dev_metric is not None
+        and holdout_metric is not None
+        and dev_metric > baseline
+        and holdout_improvements >= 2
     )
     return {
         "schema_version": "auto_research_collective_round_summary_v0",
@@ -493,6 +500,8 @@ def _build_collective_round_summary(
         "required_collective_round_count": 4,
         "required_holdout_improvement_count": 2,
         "collective_round_count": collective_round_count,
+        "full_participation_round_count": full_participation_round_count,
+        "full_participation_verified": full_participation_verified,
         "evidence_stage_count": len(dev_sequence) + len(holdout_sequence),
         "multi_round_research_verified": multi_round_research_verified,
         "improvement_over_rounds": multi_round_research_verified,

--- a/loopx/capabilities/auto_research/human_view.py
+++ b/loopx/capabilities/auto_research/human_view.py
@@ -121,6 +121,7 @@ def _render_collective_round_summary(
         (
             f"- verified: `{collective_rounds.get('multi_round_research_verified')}`; "
             f"rounds: `{collective_rounds.get('collective_round_count')}`; "
+            f"full_participation_rounds: `{collective_rounds.get('full_participation_round_count')}`; "
             f"completed_turns: `{completed_turns}/{expected_turns}`"
         ),
         (
@@ -133,7 +134,7 @@ def _render_collective_round_summary(
         ),
         (
             "- round_semantics: one round is one quota/frontier opportunity for each "
-            "research role; empty lanes are shown as no-op instead of hidden."
+            "research role; lanes without a selected todo are shown as no-op instead of hidden."
         ),
         "",
     ]

--- a/loopx/capabilities/auto_research/preset.py
+++ b/loopx/capabilities/auto_research/preset.py
@@ -36,6 +36,19 @@ AUTO_RESEARCH_REFINED_DEV_SUCCESSOR_TEXT = (
     "[P0-auto-research-live] Run the refined hypothesis from {source_todo_id} on "
     "the dev split, append public-safe evidence, and hand off the second holdout check."
 )
+AUTO_RESEARCH_CURATOR_REVIEW_SUCCESSOR_TEXT = (
+    "[P0-auto-research-live] Re-check the research contract and protected scope after "
+    "{source_todo_id}, then keep the next collective round honest."
+)
+AUTO_RESEARCH_HYPOTHESIS_FRONTIER_REVIEW_SUCCESSOR_TEXT = (
+    "[P0-auto-research-live] Review the current hypothesis frontier after "
+    "{source_todo_id}, record whether another candidate is needed, and keep the "
+    "round participation visible."
+)
+AUTO_RESEARCH_PROMOTION_READINESS_REVIEW_SUCCESSOR_TEXT = (
+    "[P0-auto-research-live] Review promotion readiness after {source_todo_id}, "
+    "record the current evidence gap, and wait for the holdout handoff."
+)
 AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION = {
     "all": [
         {
@@ -163,13 +176,13 @@ AUTO_RESEARCH_ROLE_PROFILE_ALIASES = {
 AUTO_RESEARCH_ROLE_PROFILES: dict[str, dict[str, object]] = {
     "research_curator": {
         "phase": "contract",
-        "allowed_actions": ["write_research_contract"],
+        "allowed_actions": ["write_research_contract", "review_research_contract"],
         "write_scope": ["research_contract_v0", "todo_item_v0"],
         "handoff": ["Create the first hypothesis-proposer todo."],
     },
     "hypothesis_proposer": {
         "phase": "hypothesis",
-        "allowed_actions": ["propose_hypothesis"],
+        "allowed_actions": ["propose_hypothesis", "review_hypothesis_frontier"],
         "write_scope": ["research_hypothesis_v0", "todo_item_v0"],
         "handoff": ["Create or unblock a research-executor todo."],
         "successor_todos": [
@@ -181,6 +194,16 @@ AUTO_RESEARCH_ROLE_PROFILES: dict[str, dict[str, object]] = {
                 "task_class": "advancement_task",
                 "action_kind": "run_dev_eval",
                 "text": AUTO_RESEARCH_REFINED_DEV_SUCCESSOR_TEXT,
+                "todo_command_template": AUTO_RESEARCH_SUCCESSOR_TODO_COMMAND_TEMPLATE,
+            },
+            {
+                "after_action": "propose_hypothesis",
+                "condition": AUTO_RESEARCH_REFINED_DEV_SUCCESSOR_CONDITION,
+                "target_agent_id": "evaluator-promoter",
+                "target_role_id": "evaluator_promoter",
+                "task_class": "advancement_task",
+                "action_kind": "review_promotion_readiness",
+                "text": AUTO_RESEARCH_PROMOTION_READINESS_REVIEW_SUCCESSOR_TEXT,
                 "todo_command_template": AUTO_RESEARCH_SUCCESSOR_TODO_COMMAND_TEMPLATE,
             }
         ],
@@ -217,10 +240,35 @@ AUTO_RESEARCH_ROLE_PROFILES: dict[str, dict[str, object]] = {
     },
     "evaluator_promoter": {
         "phase": "verify",
-        "allowed_actions": ["summarize_evidence", "write_evaluation_summary", "classify_evidence"],
+        "allowed_actions": [
+            "summarize_evidence",
+            "write_evaluation_summary",
+            "classify_evidence",
+            "review_promotion_readiness",
+        ],
         "write_scope": ["research_evidence_graph_v0", "todo_item_v0"],
         "handoff": ["Add a role-declared successor todo when evidence needs another bounded split."],
         "successor_todos": [
+            {
+                "after_action": "summarize_evidence",
+                "condition": AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION,
+                "target_agent_id": "research-curator",
+                "target_role_id": "research_curator",
+                "task_class": "advancement_task",
+                "action_kind": "review_research_contract",
+                "text": AUTO_RESEARCH_CURATOR_REVIEW_SUCCESSOR_TEXT,
+                "todo_command_template": AUTO_RESEARCH_SUCCESSOR_TODO_COMMAND_TEMPLATE,
+            },
+            {
+                "after_action": "summarize_evidence",
+                "condition": AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION,
+                "target_agent_id": "hypothesis-proposer",
+                "target_role_id": "hypothesis_proposer",
+                "task_class": "advancement_task",
+                "action_kind": "review_hypothesis_frontier",
+                "text": AUTO_RESEARCH_HYPOTHESIS_FRONTIER_REVIEW_SUCCESSOR_TEXT,
+                "todo_command_template": AUTO_RESEARCH_SUCCESSOR_TODO_COMMAND_TEMPLATE,
+            },
             {
                 "after_action": "write_evaluation_summary",
                 "condition": AUTO_RESEARCH_NEXT_HYPOTHESIS_SUCCESSOR_CONDITION,
@@ -231,19 +279,52 @@ AUTO_RESEARCH_ROLE_PROFILES: dict[str, dict[str, object]] = {
                 "text": AUTO_RESEARCH_REFINED_HYPOTHESIS_SUCCESSOR_TEXT,
                 "todo_command_template": AUTO_RESEARCH_SUCCESSOR_TODO_COMMAND_TEMPLATE,
             },
+            {
+                "after_action": "write_evaluation_summary",
+                "condition": AUTO_RESEARCH_NEXT_HYPOTHESIS_SUCCESSOR_CONDITION,
+                "target_agent_id": "research-curator",
+                "target_role_id": "research_curator",
+                "task_class": "advancement_task",
+                "action_kind": "review_research_contract",
+                "text": AUTO_RESEARCH_CURATOR_REVIEW_SUCCESSOR_TEXT,
+                "todo_command_template": AUTO_RESEARCH_SUCCESSOR_TODO_COMMAND_TEMPLATE,
+            },
+            {
+                "after_action": "review_promotion_readiness",
+                "condition": AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION,
+                "target_agent_id": "research-curator",
+                "target_role_id": "research_curator",
+                "task_class": "advancement_task",
+                "action_kind": "review_research_contract",
+                "text": AUTO_RESEARCH_CURATOR_REVIEW_SUCCESSOR_TEXT,
+                "todo_command_template": AUTO_RESEARCH_SUCCESSOR_TODO_COMMAND_TEMPLATE,
+            },
+            {
+                "after_action": "review_promotion_readiness",
+                "condition": AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION,
+                "target_agent_id": "hypothesis-proposer",
+                "target_role_id": "hypothesis_proposer",
+                "task_class": "advancement_task",
+                "action_kind": "review_hypothesis_frontier",
+                "text": AUTO_RESEARCH_HYPOTHESIS_FRONTIER_REVIEW_SUCCESSOR_TEXT,
+                "todo_command_template": AUTO_RESEARCH_SUCCESSOR_TODO_COMMAND_TEMPLATE,
+            },
         ],
     },
 }
 
 AUTO_RESEARCH_ACTION_ROLE_IDS = {
     "write_research_contract": "research_curator",
+    "review_research_contract": "research_curator",
     "propose_hypothesis": "hypothesis_proposer",
+    "review_hypothesis_frontier": "hypothesis_proposer",
     "run_dev_eval": "research_executor",
     "run_holdout_eval": "research_executor",
     "write_evidence": "research_executor",
     "classify_evidence": "evaluator_promoter",
     "summarize_evidence": "evaluator_promoter",
     "write_evaluation_summary": "evaluator_promoter",
+    "review_promotion_readiness": "evaluator_promoter",
 }
 
 AUTO_RESEARCH_SEED_TITLES = {
@@ -265,6 +346,15 @@ AUTO_RESEARCH_SEED_TITLES = {
     ),
     "summarize_evidence": (
         "Summarize dev evidence and hand off holdout validation when the hypothesis is supported."
+    ),
+    "review_research_contract": (
+        "Re-check the research contract and protected scope for the next collective round."
+    ),
+    "review_hypothesis_frontier": (
+        "Review the hypothesis frontier and record whether another bounded candidate is needed."
+    ),
+    "review_promotion_readiness": (
+        "Review promotion readiness and record the current evidence gap."
     ),
 }
 

--- a/loopx/capabilities/auto_research/worker_runtime.py
+++ b/loopx/capabilities/auto_research/worker_runtime.py
@@ -51,13 +51,16 @@ AUTO_RESEARCH_WORKER_TURN_SCHEMA_VERSION = "auto_research_worker_turn_v0"
 AUTO_RESEARCH_WORKER_FRONTIER_SCHEMA_VERSION = "auto_research_worker_frontier_v0"
 SUPPORTED_WORKER_ACTIONS = {
     "write_research_contract",
+    "review_research_contract",
     "propose_hypothesis",
+    "review_hypothesis_frontier",
     "run_dev_eval",
     "run_holdout_eval",
     "write_evidence",
     "classify_evidence",
     "summarize_evidence",
     "write_evaluation_summary",
+    "review_promotion_readiness",
 }
 GENERIC_VERIFIER_HANDOFF_KEYWORDS = (
     "verify",
@@ -764,6 +767,7 @@ def run_auto_research_worker_turn(
             todo_id=todo_id,
             agent_id=agent_id,
         )
+        role_id = auto_research_role_id_for_action(action)
         completion = (
             _complete_selected_todo(
                 registry_path=registry_path,
@@ -788,6 +792,7 @@ def run_auto_research_worker_turn(
             "kernel_mode": AUTO_RESEARCH_BUILTIN_KERNEL_MODE,
             "artifact": _artifact_summary("research_contract", filename="research-contract.public.json"),
             "artifact_status": artifact["summary"]["status"],
+            "role_id": role_id,
             "completion": completion,
             "frontier": frontier_packet,
             "public_boundary": {
@@ -869,7 +874,14 @@ def run_auto_research_worker_turn(
             },
         }
 
-    if action in {"classify_evidence", "summarize_evidence", "write_evaluation_summary"}:
+    if action in {
+        "classify_evidence",
+        "summarize_evidence",
+        "write_evaluation_summary",
+        "review_research_contract",
+        "review_hypothesis_frontier",
+        "review_promotion_readiness",
+    }:
         artifact = _write_evaluation_summary_artifact(
             registry_path=registry_path,
             runtime_root_arg=runtime_root_arg,

--- a/loopx/capabilities/multi_agent/collective_round_ledger.py
+++ b/loopx/capabilities/multi_agent/collective_round_ledger.py
@@ -140,6 +140,23 @@ def build_multi_agent_collective_round_ledger(
     completed_outcomes = [
         outcome for outcome in outcomes if outcome.get("completed") is True
     ]
+    expected_agent_ids = {
+        str(lane.get("agent_id") or "")
+        for lane in lanes
+        if str(lane.get("agent_id") or "").strip()
+    }
+    completed_agents_by_round: dict[int, set[str]] = {}
+    for outcome in completed_outcomes:
+        round_index = outcome.get("round")
+        agent_id = str(outcome.get("agent_id") or "").strip()
+        if isinstance(round_index, int) and agent_id:
+            completed_agents_by_round.setdefault(round_index, set()).add(agent_id)
+    full_participation_round_indexes = [
+        round_index
+        for round_index in round_indexes
+        if expected_agent_ids
+        and expected_agent_ids <= completed_agents_by_round.get(round_index, set())
+    ]
     evidence_event_count = _int_or_none(evidence.get("evidence_event_count"))
     if evidence_event_count is None:
         evidence_events = evidence.get("events")
@@ -161,6 +178,12 @@ def build_multi_agent_collective_round_ledger(
         "completed_lane_turn_count": len(completed_outcomes),
         "collective_round_indexes": round_indexes,
         "collective_round_count": len(round_indexes),
+        "full_participation_round_indexes": full_participation_round_indexes,
+        "full_participation_round_count": len(full_participation_round_indexes),
+        "full_participation_verified": (
+            bool(round_indexes)
+            and len(full_participation_round_indexes) == len(round_indexes)
+        ),
         "multi_round_interaction_verified": len(round_indexes) >= 2,
         "integrated_evidence": {
             "loaded": bool(evidence),


### PR DESCRIPTION
## Summary
- add lightweight role-declared review actions so all four auto-research roles complete one todo in each of four collective rounds
- expose full_participation_round_* fields in the generic collective-round ledger and require them for auto-research multi-round verification
- update visible/demo smokes to assert 16/16 completed worker turns, two holdout improvements, and no hidden no-op lanes

## Validation
- python3 -m py_compile loopx/capabilities/auto_research/preset.py loopx/capabilities/auto_research/worker_runtime.py loopx/capabilities/auto_research/demo_e2e.py loopx/capabilities/auto_research/human_view.py loopx/capabilities/multi_agent/collective_round_ledger.py
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. python3 examples/auto-research-worker-loop-smoke.py
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. python3 examples/auto-research-layered-e2e-acceptance-smoke.py
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. python3 examples/multi-agent-collective-round-ledger-smoke.py
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. python3 examples/auto-research-user-contract-entry-smoke.py
- PYTHONDONTWRITEBYTECODE=1 PYTHONPATH=. python3 examples/auto-research-start-markdown-commands-smoke.py