### PR TITLE
Extract goal channel projection read model

### DIFF
--- a/examples/canary/catalog-planner-smoke.py
+++ b/examples/canary/catalog-planner-smoke.py
@@ -205,6 +205,7 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     status_commands = [check["command"] for check in status_profiles["status-read-path"]["checks"]]
     assert "python3 examples/control_plane/status-goal-filter-smoke.py" in status_commands, status_payload
     assert "python3 examples/control_plane/status-quota-review-packet-parity-smoke.py" in status_commands, status_payload
+    assert "python3 examples/control_plane/goal-channel-readmodel-smoke.py" in status_commands, status_payload
     assert all(check["tier"] == "default" for check in status_profiles["status-read-path"]["checks"]), status_payload
     assert status_profiles["status-read-path"]["deep_checks_available"] is True, status_payload
     assert status_profiles["status-read-path"]["deep_checks_included"] is False, status_payload

--- a/examples/control_plane/goal-channel-readmodel-smoke.py
+++ b/examples/control_plane/goal-channel-readmodel-smoke.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Smoke-test goal channel attachment read-model parity."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from pathlib import Path
+import sys
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx import status as status_module  # noqa: E402
+from loopx.control_plane.goals import goal_channel as goal_channel_read_model  # noqa: E402
+
+
+def _attach_direct(
+    item: dict[str, Any],
+    *,
+    goal: dict[str, Any],
+    goal_latest_runs: list[dict[str, Any]],
+) -> None:
+    goal_channel_read_model.attach_goal_channel_projection(
+        item,
+        goal=goal,
+        goal_latest_runs=goal_latest_runs,
+        build_goal_channel_projection=status_module.build_goal_channel_projection,
+    )
+
+
+def base_item() -> dict[str, Any]:
+    return {
+        "status": "state_refreshed",
+        "waiting_on": "codex",
+        "recommended_action": "continue bounded control-plane cleanup",
+        "quota": {
+            "state": "eligible",
+            "spent_slots": 7,
+            "allowed_slots": 100,
+        },
+        "project_asset": {
+            "display_name": "Goal channel read model",
+            "user_todos": {
+                "first_open_items": [
+                    {
+                        "todo_id": "todo_user_gate",
+                        "text": "Approve the visible route",
+                        "status": "open",
+                        "task_class": "user_gate",
+                    }
+                ]
+            },
+            "agent_todos": {
+                "first_open_items": [
+                    {
+                        "todo_id": "todo_agent_work",
+                        "text": "Keep the status projection read-only",
+                        "status": "open",
+                        "task_class": "advancement_task",
+                        "claimed_by": "codex-product-capability",
+                    }
+                ]
+            },
+        },
+    }
+
+
+def base_goal() -> dict[str, Any]:
+    return {
+        "id": "goal-channel-readmodel-smoke",
+        "domain": "control-plane",
+        "status": "active",
+    }
+
+
+def latest_runs() -> list[dict[str, Any]]:
+    private_path = "/" + "tmp" + "/goal-channel-private-trace.log"
+    return [
+        {
+            "generated_at": "2026-07-04T10:00:00Z",
+            "classification": "validated_progress",
+            "recommended_action": "continue bounded cleanup",
+            "raw_log_path": private_path,
+            "json_exists": True,
+            "markdown_exists": True,
+        }
+    ]
+
+
+def assert_attach_parity() -> None:
+    wrapper_item = base_item()
+    direct_item = deepcopy(wrapper_item)
+    goal = base_goal()
+    runs = latest_runs()
+
+    status_module.attach_goal_channel_projection(
+        wrapper_item,
+        goal=goal,
+        goal_latest_runs=deepcopy(runs),
+    )
+    _attach_direct(
+        direct_item,
+        goal=goal,
+        goal_latest_runs=deepcopy(runs),
+    )
+    assert wrapper_item == direct_item, (wrapper_item, direct_item)
+
+    projection = wrapper_item["goal_channel_projection"]
+    projection_text = str(projection)
+    assert projection["schema_version"] == "goal_channel_projection_v0", projection
+    assert projection["mode"] == "read_only", projection
+    assert projection["goal_id"] == "goal-channel-readmodel-smoke", projection
+    assert projection["quota"]["state"] == "eligible", projection
+    assert projection["user_todos"][0]["todo_id"] == "todo_user_gate", projection
+    assert projection["agent_todos"][0]["claimed_by"] == "codex-product-capability", projection
+    assert projection["recent_events"][0]["classification"] == "validated_progress", projection
+    assert projection["truth_contract"]["projection_is_writable"] is False, projection
+    assert projection["source_warnings"], projection
+    assert "goal-channel-private-trace.log" not in projection_text, projection
+
+
+def main() -> int:
+    assert_attach_parity()
+    print("goal-channel-readmodel-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -407,6 +407,11 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
                 "reason": "guards scoped status, agent quota, review-packet handoff, and scheduler_hint parity on one fixture",
             },
             {
+                "command": "python3 examples/control_plane/goal-channel-readmodel-smoke.py",
+                "tier": "default",
+                "reason": "guards status wrapper parity for goal-channel projection attachment",
+            },
+            {
                 "command": "python3 examples/control_plane/status-markdown-smoke.py",
                 "tier": "default",
                 "reason": "checks operator-facing markdown status rendering",

--- a/loopx/control_plane/goals/goal_channel.py
+++ b/loopx/control_plane/goals/goal_channel.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from typing import Any, Callable
+
+
+GoalChannelProjectionBuilder = Callable[..., dict[str, Any]]
+
+
+def attach_goal_channel_projection(
+    item: dict[str, Any],
+    *,
+    goal: dict[str, Any],
+    goal_latest_runs: list[dict[str, Any]],
+    build_goal_channel_projection: GoalChannelProjectionBuilder,
+) -> None:
+    """Attach a read-only frontstage projection to a status attention item."""
+
+    run_history_goal = dict(goal)
+    run_history_goal["latest_runs"] = goal_latest_runs
+    quota_payload: dict[str, Any] = {
+        "status": item.get("status"),
+        "waiting_on": item.get("waiting_on"),
+        "recommended_action": item.get("recommended_action"),
+    }
+    if isinstance(item.get("quota"), dict):
+        quota_payload["quota"] = item["quota"]
+    item["goal_channel_projection"] = build_goal_channel_projection(
+        goal_id=str(item.get("goal_id") or goal.get("id") or ""),
+        status_item=item,
+        quota_payload=quota_payload,
+        run_history_goal=run_history_goal,
+    )

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -211,6 +211,9 @@ from .control_plane.goals.global_registry_health import (
     collect_global_registry_health as _collect_global_registry_health_read_model,
     global_registry_finding as _global_registry_finding_read_model,
 )
+from .control_plane.goals.goal_channel import (
+    attach_goal_channel_projection as _attach_goal_channel_projection_read_model,
+)
 from .control_plane.work_items.issue_meta_surface import (
     parse_issue_meta_surface as _parse_issue_meta_surface_read_model,
 )
@@ -6932,22 +6935,11 @@ def attach_goal_channel_projection(
     goal: dict[str, Any],
     goal_latest_runs: list[dict[str, Any]],
 ) -> None:
-    """Attach a read-only frontstage projection to a status attention item."""
-
-    run_history_goal = dict(goal)
-    run_history_goal["latest_runs"] = goal_latest_runs
-    quota_payload: dict[str, Any] = {
-        "status": item.get("status"),
-        "waiting_on": item.get("waiting_on"),
-        "recommended_action": item.get("recommended_action"),
-    }
-    if isinstance(item.get("quota"), dict):
-        quota_payload["quota"] = item["quota"]
-    item["goal_channel_projection"] = build_goal_channel_projection(
-        goal_id=str(item.get("goal_id") or goal.get("id") or ""),
-        status_item=item,
-        quota_payload=quota_payload,
-        run_history_goal=run_history_goal,
+    _attach_goal_channel_projection_read_model(
+        item,
+        goal=goal,
+        goal_latest_runs=goal_latest_runs,
+        build_goal_channel_projection=build_goal_channel_projection,
     )
 
 


### PR DESCRIPTION
## Summary
- move goal-channel projection attachment from status.py into control_plane/goals/goal_channel.py
- keep status.py as a compatibility wrapper around the bounded read-model helper
- add goal-channel read-model parity smoke and include it in the status-read-path canary profile

## Validation
- python3 -m compileall loopx/control_plane/goals/goal_channel.py loopx/status.py loopx/canary/planner.py
- python3 examples/control_plane/goal-channel-readmodel-smoke.py
- python3 examples/project/goal-channel-status-export-smoke.py
- python3 examples/control_plane/status-markdown-smoke.py
- python3 examples/control_plane/check-public-boundary-smoke.py
- python3 examples/canary/catalog-planner-smoke.py
- python3 -m loopx.cli canary smoke-suite --profile status-read-path --timeout-seconds 20
- python3 -m loopx.cli canary smoke-suite --from-git-diff --git-diff-base origin/main --timeout-seconds 20: 15/16 passed; known existing repo-python-line-budget-smoke failure remains limited to SkillsBench large files (examples/skillsbench-app-server-goal-worker-smoke.py, examples/skillsbench-benchmark-run-smoke.py, scripts/skillsbench_automation_loop.py)
- git diff --check
