### PR TITLE
Project goal vision gaps into replan frontier

### DIFF
--- a/docs/product/core-control-plane/state-machine.md
+++ b/docs/product/core-control-plane/state-machine.md
@@ -425,6 +425,11 @@ state. Those local states may remain visible, but they cannot clear a required
 replan. An acknowledgement without a vision, todo, acceptance, or no-follow-up
 delta is `replan_noop`.
 
+The same ordering applies when an agent records a bounded
+`replan_trigger_summary` in its vision packet. Status/quota exposes that trigger
+as a goal-frontier `acceptance_gaps[]` entry. If no advancement frontier remains,
+the gap becomes a replan trigger before the lane can quietly back off.
+
 See
 [`goal_vision_replan_contract_v0`](../../reference/protocols/goal-vision-replan-contract-v0.md)
 for the field budgets and projection contract.

--- a/docs/reference/protocols/goal-vision-replan-contract-v0.md
+++ b/docs/reference/protocols/goal-vision-replan-contract-v0.md
@@ -53,6 +53,14 @@ The first CLI write boundary is `loopx refresh-state --agent-vision-json
 counts as the machine-visible `goal_vision_patch` repair delta. An invalid or
 over-budget packet fails the command instead of recording a partial ACK.
 
+When a valid packet includes `replan_trigger_summary`, status/quota projects it
+as `goal_frontier_projection.acceptance_gaps[]`. If no runnable advancement
+frontier remains, that gap is evaluated before monitor quiet skip and can
+produce `autonomous_replan_required`. This is the intended self-discovery path:
+an agent records the bounded reason the current vision is still incomplete, and
+LoopX turns that reason into the next replan obligation without relying on chat
+memory or owner reminders.
+
 ## State Machine
 
 ```mermaid

--- a/examples/control_plane/quota-replan-decision-plane-smoke.py
+++ b/examples/control_plane/quota-replan-decision-plane-smoke.py
@@ -143,6 +143,29 @@ def status_payload(
     }
 
 
+def agent_vision_gap_run() -> dict:
+    return {
+        "classification": "state_refreshed",
+        "generated_at": "2026-07-04T00:00:00+00:00",
+        "agent_id": SIDE_AGENT,
+        "progress_scope": "agent_lane",
+        "agent_vision": {
+            "schema_version": "goal_vision_replan_contract_v0",
+            "agent_id": SIDE_AGENT,
+            "state": "vision_drift_detected",
+            "vision_patch": {
+                "acceptance_summary": "Show the next runnable auto-research frontier without owner prompting.",
+                "replan_trigger_summary": "Auto-research evidence is still synthetic and needs a next-round live validation todo.",
+            },
+            "todo_delta": [],
+            "vision_budget": {
+                "schema_version": "goal_vision_budget_v0",
+                "status": "ok",
+            },
+        },
+    }
+
+
 def assert_replan_beats_monitor_quiet_skip() -> None:
     guard = build_quota_should_run(
         status_payload([monitor_item()]),
@@ -173,6 +196,30 @@ def assert_replan_beats_monitor_quiet_skip() -> None:
     assert "goal_frontier_projection: replan_required=True" in markdown, markdown
     assert "deferred_ready=0 acceptance_gaps=0" in markdown, markdown
     assert "autonomous_replan_decision: decision=autonomous_replan_required" in markdown, markdown
+
+
+def assert_agent_vision_gap_derives_replan() -> None:
+    guard = build_quota_should_run(
+        status_payload(
+            [monitor_item()],
+            replan_obligation=None,
+            latest_runs=[agent_vision_gap_run()],
+        ),
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+    )
+    assert guard["decision"] == "autonomous_replan_required", guard
+    assert guard["effective_action"] == "autonomous_replan_required", guard
+    assert guard["should_run"] is True, guard
+    obligation = guard["autonomous_replan_obligation"]
+    assert obligation["triggers"][0]["kind"] == "vision_acceptance_gap", guard
+    gaps = guard["goal_frontier_projection"]["acceptance_gaps"]
+    assert len(gaps) == 1, guard
+    assert gaps[0]["kind"] == "vision_acceptance_gap", guard
+    assert "synthetic" in gaps[0]["replan_trigger_summary"], guard
+    assert guard["goal_frontier_projection"]["replan_required"] is True, guard
+    markdown = render_quota_should_run_markdown(guard)
+    assert "deferred_ready=0 acceptance_gaps=1" in markdown, markdown
 
 
 def assert_replan_beats_agent_scope_wait() -> None:
@@ -291,6 +338,7 @@ def assert_blocking_handoff_gate_beats_derived_monitor_replan() -> None:
 
 def main() -> None:
     assert_replan_beats_monitor_quiet_skip()
+    assert_agent_vision_gap_derives_replan()
     assert_replan_beats_agent_scope_wait()
     assert_empty_monitor_frontier_derives_replan()
     assert_agent_ack_survives_other_agent_run_and_monitor_poll()

--- a/examples/project/goal-vision-refresh-state-budget-smoke.py
+++ b/examples/project/goal-vision-refresh-state-budget-smoke.py
@@ -71,35 +71,38 @@ def run_cli(
     *,
     vision_path: Path,
     check: bool,
+    dry_run: bool = True,
 ) -> subprocess.CompletedProcess[str]:
+    command = [
+        sys.executable,
+        "-m",
+        "loopx.cli",
+        "--registry",
+        str(registry_path),
+        "--runtime-root",
+        str(runtime),
+        "--format",
+        "json",
+        "refresh-state",
+        "--goal-id",
+        GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--classification",
+        "goal_vision_patch_recorded",
+        "--delivery-batch-scale",
+        "single_surface",
+        "--delivery-outcome",
+        "outcome_progress",
+        "--autonomous-replan-recorded",
+        "--agent-vision-json",
+        str(vision_path),
+        "--no-global-sync",
+    ]
+    if dry_run:
+        command.append("--dry-run")
     return subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "loopx.cli",
-            "--registry",
-            str(registry_path),
-            "--runtime-root",
-            str(runtime),
-            "--format",
-            "json",
-            "refresh-state",
-            "--goal-id",
-            GOAL_ID,
-            "--agent-id",
-            AGENT_ID,
-            "--classification",
-            "goal_vision_patch_recorded",
-            "--delivery-batch-scale",
-            "single_surface",
-            "--delivery-outcome",
-            "outcome_progress",
-            "--autonomous-replan-recorded",
-            "--agent-vision-json",
-            str(vision_path),
-            "--dry-run",
-            "--no-global-sync",
-        ],
+        command,
         cwd=REPO_ROOT,
         check=check,
         text=True,
@@ -150,6 +153,32 @@ def main() -> int:
         assert valid["agent_vision"]["vision_budget"]["status"] == "ok", valid
         assert valid["agent_vision"]["validation"]["budget_checked"] is True, valid
         assert valid["agent_vision"]["schema_version"] == "goal_vision_replan_contract_v0", valid
+
+        written = payload(
+            run_cli(
+                registry_path,
+                runtime,
+                vision_path=valid_path,
+                check=True,
+                dry_run=False,
+            )
+        )
+        assert written["ok"] is True, written
+        index_path = runtime / "goals" / GOAL_ID / "runs" / "index.jsonl"
+        index_rows = [
+            json.loads(line)
+            for line in index_path.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+        assert index_rows, written
+        indexed_vision = index_rows[-1]["agent_vision"]
+        assert indexed_vision["vision_patch"]["acceptance_summary"] == (
+            "One successor todo plus evidence references."
+        ), indexed_vision
+        assert indexed_vision["vision_patch"]["replan_trigger_summary"] == (
+            "Frontier exhausted while acceptance remains open."
+        ), indexed_vision
+        assert indexed_vision["todo_delta"] == ["create_successor"], indexed_vision
 
         write_json(
             invalid_path,

--- a/loopx/policies/goal_frontier.py
+++ b/loopx/policies/goal_frontier.py
@@ -8,6 +8,7 @@ AUTONOMOUS_REPLAN_DECISION_SCHEMA_VERSION = "autonomous_replan_decision_v0"
 AUTONOMOUS_REPLAN_OBLIGATION_SCHEMA_VERSION = "autonomous_replan_obligation_v0"
 AUTONOMOUS_REPLAN_REQUIRED_MODE = "autonomous_replan_required"
 FRONTIER_EXHAUSTED_MONITOR_TRIGGER = "frontier_exhausted_monitor_lane"
+VISION_ACCEPTANCE_GAP_TRIGGER = "vision_acceptance_gap"
 TODO_TASK_CLASS_ADVANCEMENT = "advancement_task"
 TODO_TASK_CLASS_MONITOR = "continuous_monitor"
 FRONTIER_REPLAN_ACK_DELTA_KINDS = {
@@ -73,6 +74,98 @@ def autonomous_replan_decision_allowed(
         and not workspace_blocked
         and not automation_prompt_upgrade_required
     )
+
+
+def _compact_projection_text(value: Any, *, limit: int = 360) -> str | None:
+    text = " ".join(str(value or "").strip().split())
+    if not text:
+        return None
+    return text[:limit]
+
+
+def _latest_runs_for_goal(
+    status_payload: dict[str, Any],
+    *,
+    goal_id: str,
+) -> list[dict[str, Any]]:
+    run_history = (
+        status_payload.get("run_history")
+        if isinstance(status_payload.get("run_history"), dict)
+        else {}
+    )
+    goals = run_history.get("goals") if isinstance(run_history.get("goals"), list) else []
+    goal = next(
+        (
+            item
+            for item in goals
+            if isinstance(item, dict) and str(item.get("id") or "") == goal_id
+        ),
+        None,
+    )
+    latest_runs = goal.get("latest_runs") if isinstance(goal, dict) else None
+    return [item for item in latest_runs if isinstance(item, dict)] if isinstance(latest_runs, list) else []
+
+
+def latest_agent_vision_from_status_payload(
+    status_payload: dict[str, Any],
+    *,
+    goal_id: str,
+    agent_id: str | None,
+) -> dict[str, Any] | None:
+    """Return the newest compact agent vision packet visible in run history."""
+
+    for run in _latest_runs_for_goal(status_payload, goal_id=goal_id):
+        vision = run.get("agent_vision")
+        if not isinstance(vision, dict):
+            continue
+        vision_agent_id = str(vision.get("agent_id") or run.get("agent_id") or "").strip()
+        if agent_id and vision_agent_id and vision_agent_id != agent_id:
+            continue
+        patch = vision.get("vision_patch") if isinstance(vision.get("vision_patch"), dict) else {}
+        if not patch:
+            continue
+        return {
+            "schema_version": vision.get("schema_version"),
+            "goal_id": goal_id,
+            "agent_id": vision_agent_id or agent_id,
+            "state": vision.get("state"),
+            "vision_patch": patch,
+            "todo_delta": vision.get("todo_delta")
+            if isinstance(vision.get("todo_delta"), list)
+            else [],
+            "vision_budget": vision.get("vision_budget")
+            if isinstance(vision.get("vision_budget"), dict)
+            else None,
+            "generated_at": run.get("generated_at"),
+        }
+    return None
+
+
+def acceptance_gaps_from_agent_vision(
+    agent_vision: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    """Convert bounded vision replan triggers into goal-frontier gap records."""
+
+    if not isinstance(agent_vision, dict):
+        return []
+    patch = agent_vision.get("vision_patch") if isinstance(agent_vision.get("vision_patch"), dict) else {}
+    trigger = _compact_projection_text(patch.get("replan_trigger_summary"), limit=240)
+    if not trigger:
+        return []
+    gap: dict[str, Any] = {
+        "kind": VISION_ACCEPTANCE_GAP_TRIGGER,
+        "source": "latest_agent_vision",
+        "agent_id": agent_vision.get("agent_id"),
+        "state": agent_vision.get("state"),
+        "replan_trigger_summary": trigger,
+    }
+    acceptance = _compact_projection_text(patch.get("acceptance_summary"), limit=420)
+    if acceptance:
+        gap["acceptance_summary"] = acceptance
+    generated_at = _compact_projection_text(agent_vision.get("generated_at"), limit=80)
+    if generated_at:
+        gap["generated_at"] = generated_at
+    return [gap]
 
 
 def _open_todo_count(summary: dict[str, Any] | None) -> int:
@@ -292,6 +385,7 @@ def derive_goal_frontier_replan_obligation_from_summaries(
     agent_id: str | None,
     existing_replan_obligation: dict[str, Any] | None,
     latest_replan_ack: dict[str, Any] | None = None,
+    acceptance_gaps: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any] | None:
     """Return a compact replan obligation when the goal frontier has no advancement.
 
@@ -314,8 +408,60 @@ def derive_goal_frontier_replan_obligation_from_summaries(
         agent_id=agent_id,
     )
     total_frontier_advancement = sum(frontier_counts.values())
+    compact_acceptance_gaps = [
+        item for item in (acceptance_gaps or []) if isinstance(item, dict)
+    ]
     if user_counts.get("open", 0) > 0:
         return None
+    if (
+        compact_acceptance_gaps
+        and agent_counts.get("advancement", 0) == 0
+        and total_frontier_advancement == 0
+    ):
+        return {
+            "schema_version": AUTONOMOUS_REPLAN_OBLIGATION_SCHEMA_VERSION,
+            "required": True,
+            "stall_threshold": 1,
+            "trigger_count": len(compact_acceptance_gaps),
+            "triggers": [
+                {
+                    "kind": VISION_ACCEPTANCE_GAP_TRIGGER,
+                    "section": "goal_frontier_projection.acceptance_gaps",
+                    "text": gap.get("replan_trigger_summary")
+                    or "bounded agent vision reports an open acceptance gap",
+                    "agent_id": agent_id,
+                    "acceptance_summary": gap.get("acceptance_summary"),
+                }
+                for gap in compact_acceptance_gaps[:3]
+            ],
+            "guidance_actions": [
+                "create_successor",
+                "update_agent_vision",
+                "record_evidence_gap",
+                "record_no_followup",
+            ],
+            "todo_actions": [
+                {
+                    "action": "add",
+                    "role": "agent",
+                    "priority": "P0",
+                    "text": (
+                        "run a bounded vision-gap replan: create the next runnable "
+                        "advancement todo or record an explicit no-follow-up rationale"
+                    ),
+                }
+            ],
+            "next_validation_command": "python3 examples/control_plane/quota-replan-decision-plane-smoke.py",
+            "stop_condition": (
+                "stop if the gap requires private material, credentials, destructive git, "
+                "production actions, or owner-only decisions"
+            ),
+            "recommended_action": (
+                "run a bounded vision-gap replan before another quiet poll: create "
+                "successor work, update the agent vision, record evidence gap, or "
+                "record no-follow-up"
+            ),
+        }
     if not _is_monitor_only_lane(work_lane_contract):
         return None
     if agent_counts.get("monitor", 0) <= 0:
@@ -380,6 +526,7 @@ def build_goal_frontier_projection_from_summaries(
     agent_todo_summary: dict[str, Any] | None,
     work_lane_contract: dict[str, Any] | None,
     replan_obligation: dict[str, Any] | None,
+    acceptance_gaps: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     user_counts = _summary_task_counts(user_todo_summary)
     agent_counts = _summary_task_counts(agent_todo_summary)
@@ -402,6 +549,7 @@ def build_goal_frontier_projection_from_summaries(
         ],
         monitor_only_lane=monitor_only_lane,
         replan_obligation=replan_obligation,
+        acceptance_gaps=acceptance_gaps,
         deferred_successors=_deferred_successors(
             agent_todo_summary,
             agent_id=agent_id,
@@ -477,6 +625,7 @@ def build_goal_frontier_projection(
     other_agent_claimed_advancement_count: int,
     monitor_only_lane: bool,
     replan_obligation: dict[str, Any] | None,
+    acceptance_gaps: list[dict[str, Any]] | None = None,
     deferred_successors: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     replan_required = autonomous_replan_is_required(replan_obligation)
@@ -492,6 +641,9 @@ def build_goal_frontier_projection(
     if replan_required:
         blockers.append("autonomous_replan_obligation")
 
+    compact_acceptance_gaps = [
+        item for item in (acceptance_gaps or []) if isinstance(item, dict)
+    ]
     projection: dict[str, Any] = {
         "schema_version": GOAL_FRONTIER_PROJECTION_SCHEMA_VERSION,
         "goal_id": goal_id,
@@ -521,7 +673,7 @@ def build_goal_frontier_projection(
             "current_agent_ready_count": 0,
             "ready_todo_ids": [],
         },
-        "acceptance_gaps": [],
+        "acceptance_gaps": compact_acceptance_gaps[:5],
         "autonomy_blockers": blockers,
         "replan_required": replan_required,
     }

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -51,10 +51,12 @@ from .orchestration import compact_orchestration_policy, orchestration_policy_su
 from .policies.execution_obligation import build_execution_obligation
 from .policies.goal_frontier import (
     AUTONOMOUS_REPLAN_REQUIRED_MODE,
+    acceptance_gaps_from_agent_vision,
     autonomous_replan_decision_allowed,
     build_autonomous_replan_recommendation,
     build_goal_frontier_projection_from_summaries,
     derive_goal_frontier_replan_obligation_from_summaries,
+    latest_agent_vision_from_status_payload,
     select_autonomous_replan_obligation,
 )
 from .policies.goal_route_hint import build_goal_route_hint
@@ -5818,6 +5820,14 @@ def build_quota_should_run(
             goal_id=safe_goal_id,
             agent_id=agent_frontier_id,
         )
+        latest_agent_vision = latest_agent_vision_from_status_payload(
+            status_payload,
+            goal_id=safe_goal_id,
+            agent_id=agent_frontier_id,
+        )
+        goal_frontier_acceptance_gaps = acceptance_gaps_from_agent_vision(
+            latest_agent_vision
+        )
         frontier_replan_obligation = derive_goal_frontier_replan_obligation_from_summaries(
             user_todo_summary=user_todo_summary,
             agent_todo_summary=agent_todo_summary,
@@ -5832,6 +5842,7 @@ def build_quota_should_run(
                 if isinstance(project_asset.get("autonomous_replan_ack"), dict)
                 else None
             ),
+            acceptance_gaps=goal_frontier_acceptance_gaps,
         )
         if frontier_replan_obligation:
             replan_obligation = frontier_replan_obligation
@@ -5842,6 +5853,7 @@ def build_quota_should_run(
             agent_todo_summary=agent_todo_summary,
             work_lane_contract=work_lane_contract,
             replan_obligation=replan_obligation,
+            acceptance_gaps=goal_frontier_acceptance_gaps,
         )
         capability_gate = _capability_gate(
             agent_todo_summary,

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -884,6 +884,12 @@ def refresh_state_run(
             "schema_version": agent_vision.get("schema_version"),
             "agent_id": agent_vision.get("agent_id"),
             "state": agent_vision.get("state"),
+            "vision_patch": agent_vision.get("vision_patch")
+            if isinstance(agent_vision.get("vision_patch"), dict)
+            else {},
+            "todo_delta": agent_vision.get("todo_delta")
+            if isinstance(agent_vision.get("todo_delta"), list)
+            else [],
             "vision_budget": agent_vision.get("vision_budget"),
         }
     if normalized_progress_scope:


### PR DESCRIPTION
## Summary
- persist bounded agent vision patches in the refresh-state run index
- project vision replan triggers as goal-frontier acceptance gaps
- let vision gaps derive autonomous replan before monitor quiet skip when no advancement frontier remains

## Validation
- python3 examples/control_plane/quota-replan-decision-plane-smoke.py
- python3 examples/project/goal-vision-refresh-state-budget-smoke.py
- python3 examples/project/goal-vision-replan-contract-smoke.py
- python3 -m loopx.cli --format json auto-research demo-e2e --agent-id codex-side-bypass --objective '中文测试：如何评估 multi-agent auto research 是否真的有收益？' --language zh --headless --execute --worker-loop-rounds 4