### PR TITLE
Extract run compaction summary attachment

### DIFF
--- a/examples/canary/catalog-planner-smoke.py
+++ b/examples/canary/catalog-planner-smoke.py
@@ -205,10 +205,25 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     status_commands = [check["command"] for check in status_profiles["status-read-path"]["checks"]]
     assert "python3 examples/control_plane/status-goal-filter-smoke.py" in status_commands, status_payload
     assert "python3 examples/control_plane/status-quota-review-packet-parity-smoke.py" in status_commands, status_payload
-    assert "python3 examples/control_plane/goal-channel-readmodel-smoke.py" in status_commands, status_payload
+    assert "python3 examples/control_plane/run-compaction-readmodel-smoke.py" in status_commands, status_payload
     assert all(check["tier"] == "default" for check in status_profiles["status-read-path"]["checks"]), status_payload
     assert status_profiles["status-read-path"]["deep_checks_available"] is True, status_payload
     assert status_profiles["status-read-path"]["deep_checks_included"] is False, status_payload
+
+    status_wide_payload = build_catalog_canary_plan(
+        changed_files=["loopx/status.py"],
+        surfaces=["status --goal-id read-path"],
+        max_checks_per_profile=4,
+    )
+    status_wide_profiles = {
+        profile["id"]: profile for profile in status_wide_payload["domain_profiles"]
+    }
+    status_wide_commands = [
+        check["command"] for check in status_wide_profiles["status-read-path"]["checks"]
+    ]
+    assert "python3 examples/control_plane/goal-channel-readmodel-smoke.py" in status_wide_commands, (
+        status_wide_payload
+    )
 
     review_packet_payload = build_catalog_canary_plan(
         changed_files=["loopx/review_packet.py", "loopx/cli_commands/status.py"],

--- a/examples/control_plane/run-compaction-readmodel-smoke.py
+++ b/examples/control_plane/run-compaction-readmodel-smoke.py
@@ -11,6 +11,7 @@ if str(ROOT) not in sys.path:
 
 from loopx import status as status_module  # noqa: E402
 from loopx.projections import run_compaction as run_compaction_read_model  # noqa: E402
+from loopx.session_runtime import SESSION_RUNTIME_READONLY_PROJECTION_SCHEMA_VERSION  # noqa: E402
 
 
 def assert_run_compaction_wrapper_parity() -> None:
@@ -108,6 +109,30 @@ def _direct_compact_run_base(run: dict[str, object]) -> dict[str, object]:
     )
 
 
+def _direct_compact_run(run: dict[str, object]) -> dict[str, object]:
+    return run_compaction_read_model.attach_run_summary_projections(
+        _direct_compact_run_base(run),
+        run,
+        compact_benchmark_run=status_module.compact_benchmark_run,
+        worker_bridge_ingest_health_note=status_module.worker_bridge_ingest_health_note,
+        compact_benchmark_result=status_module.compact_benchmark_result,
+        compact_benchmark_comparison=status_module.compact_benchmark_comparison,
+        benchmark_comparison_decision_note=status_module.benchmark_comparison_decision_note,
+        compact_benchmark_learning_ledger=status_module.compact_benchmark_learning_ledger,
+        compact_benchmark_experiment_report=status_module.compact_benchmark_experiment_report,
+        benchmark_experiment_report_readiness_note=(
+            status_module.benchmark_experiment_report_readiness_note
+        ),
+        benchmark_experiment_report_replay_decision=(
+            status_module.benchmark_experiment_report_replay_decision
+        ),
+        compact_active_user_assisted_pilot=status_module.compact_active_user_assisted_pilot,
+        compact_session_runtime_projection_from_run=(
+            status_module.compact_session_runtime_projection_from_run
+        ),
+    )
+
+
 def assert_compact_run_base_parity() -> None:
     mapped_run = {
         "generated_at": "2026-07-04T00:02:00Z",
@@ -152,9 +177,67 @@ def assert_compact_run_base_parity() -> None:
     )
 
 
+def assert_compact_run_summary_projection_parity() -> None:
+    session_runtime_run = {
+        "generated_at": "2026-07-04T00:04:00Z",
+        "run_id": "run-session-runtime",
+        "goal_id": "loopx-meta",
+        "classification": "session_runtime_readonly_projection",
+        "session_runtime_readonly_projection": {
+            "schema_version": SESSION_RUNTIME_READONLY_PROJECTION_SCHEMA_VERSION,
+            "goal_id": "loopx-meta",
+            "source": {
+                "host_kind": "codex-app",
+                "latest_fact_at": "2026-07-04T00:03:30Z",
+                "source_refs": {"status": ["latest"], "quota": ["should-run"]},
+            },
+            "boundary": {
+                "runtime_writeback_allowed": True,
+                "runtime_mutation_allowed": False,
+                "raw_logs_copied": False,
+                "credentials_copied": False,
+                "raw_material_key_names": ["raw_logs", "credentials"],
+            },
+            "first_screen": {
+                "waiting_on": "codex",
+                "first_agent_todo": "continue status read-path cleanup",
+                "recommended_action": "run compact parity smoke",
+                "agent_can_continue": True,
+                "user_action_required": False,
+            },
+            "work_lane_contract": {
+                "lane": "advancement_task",
+                "must_attempt_work": True,
+                "monitor_only": False,
+            },
+            "attention_item": {
+                "kind": "agent_todo",
+                "priority": "P2",
+                "title": "Continue control-plane cleanup",
+                "waiting_on": "codex",
+            },
+            "private_note": "not compacted",
+        },
+    }
+    compact = status_module.compact_run(session_runtime_run)
+    assert compact == _direct_compact_run(session_runtime_run)
+    session_projection = compact["session_runtime_projection"]
+    assert session_projection["schema_version"] == SESSION_RUNTIME_READONLY_PROJECTION_SCHEMA_VERSION
+    assert session_projection["mode"] == "read_only"
+    assert session_projection["goal_id"] == "loopx-meta"
+    assert session_projection["source"]["source_ref_counts"] == {"status": 1, "quota": 1}
+    assert session_projection["boundary"]["runtime_writeback_allowed"] is True
+    assert session_projection["boundary"]["runtime_mutation_allowed"] is False
+    assert session_projection["first_screen"]["agent_can_continue"] is True
+    assert session_projection["work_lane_contract"]["lane"] == "advancement_task"
+    assert session_projection["attention_item"]["priority"] == "P2"
+    assert "private_note" not in session_projection
+
+
 def main() -> None:
     assert_run_compaction_wrapper_parity()
     assert_compact_run_base_parity()
+    assert_compact_run_summary_projection_parity()
 
 
 if __name__ == "__main__":

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -407,6 +407,11 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
                 "reason": "guards scoped status, agent quota, review-packet handoff, and scheduler_hint parity on one fixture",
             },
             {
+                "command": "python3 examples/control_plane/run-compaction-readmodel-smoke.py",
+                "tier": "default",
+                "reason": "guards status wrapper parity for compact run read-model and summary projection attachment",
+            },
+            {
                 "command": "python3 examples/control_plane/goal-channel-readmodel-smoke.py",
                 "tier": "default",
                 "reason": "guards status wrapper parity for goal-channel projection attachment",

--- a/loopx/control_plane/runtime/run_compaction.py
+++ b/loopx/control_plane/runtime/run_compaction.py
@@ -178,3 +178,65 @@ def compact_run_base(
         compact["subagent_count"] = len(subagents)
 
     return compact
+
+
+def attach_run_summary_projections(
+    compact: dict[str, Any],
+    run: dict[str, Any],
+    *,
+    compact_benchmark_run: RunProjection,
+    worker_bridge_ingest_health_note: RunProjection,
+    compact_benchmark_result: RunProjection,
+    compact_benchmark_comparison: RunProjection,
+    benchmark_comparison_decision_note: RunProjection,
+    compact_benchmark_learning_ledger: RunProjection,
+    compact_benchmark_experiment_report: RunProjection,
+    benchmark_experiment_report_readiness_note: RunProjection,
+    benchmark_experiment_report_replay_decision: RunProjection,
+    compact_active_user_assisted_pilot: RunProjection,
+    compact_session_runtime_projection_from_run: RunProjection,
+) -> dict[str, Any]:
+    """Attach optional read-path summaries to a compact run payload."""
+    result = dict(compact)
+
+    benchmark_run = compact_benchmark_run(run)
+    if benchmark_run:
+        result["benchmark_run_summary"] = benchmark_run
+        health_note = worker_bridge_ingest_health_note(benchmark_run)
+        if health_note:
+            result["worker_bridge_ingest_health_note"] = health_note
+
+    benchmark_result = compact_benchmark_result(run)
+    if benchmark_result:
+        result["benchmark_result_summary"] = benchmark_result
+
+    benchmark_comparison = compact_benchmark_comparison(run)
+    if benchmark_comparison:
+        result["benchmark_comparison_summary"] = benchmark_comparison
+        decision_note = benchmark_comparison_decision_note(benchmark_comparison)
+        if decision_note:
+            result["benchmark_comparison_decision_note"] = decision_note
+
+    benchmark_learning_ledger = compact_benchmark_learning_ledger(run)
+    if benchmark_learning_ledger:
+        result["benchmark_learning_ledger_summary"] = benchmark_learning_ledger
+
+    benchmark_report = compact_benchmark_experiment_report(run)
+    if benchmark_report:
+        result["benchmark_experiment_report_summary"] = benchmark_report
+        readiness_note = benchmark_experiment_report_readiness_note(benchmark_report)
+        if readiness_note:
+            result["benchmark_experiment_report_readiness_note"] = readiness_note
+            replay_decision = benchmark_experiment_report_replay_decision(readiness_note)
+            if replay_decision:
+                result["benchmark_experiment_report_replay_decision"] = replay_decision
+
+    active_user_pilot = compact_active_user_assisted_pilot(run)
+    if active_user_pilot:
+        result["active_user_assisted_pilot_summary"] = active_user_pilot
+
+    session_projection = compact_session_runtime_projection_from_run(run)
+    if session_projection:
+        result["session_runtime_projection"] = session_projection
+
+    return result

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -163,6 +163,7 @@ from .control_plane.scheduler.monitor_display import (
     todo_summary_open_count as _todo_summary_open_count,
 )
 from .control_plane.runtime.run_compaction import (
+    attach_run_summary_projections as _attach_run_summary_projections_read_model,
     compact_controller_readiness as _compact_controller_readiness_read_model,
     compact_human_reward as _compact_human_reward_read_model,
     compact_operator_gate as _compact_operator_gate_read_model,
@@ -7216,40 +7217,21 @@ def compact_run(run: dict[str, Any]) -> dict[str, Any]:
         compact_subagent_run=compact_subagent_run,
         max_subagent_activity_items=MAX_SUBAGENT_ACTIVITY_ITEMS,
     )
-    benchmark_run = compact_benchmark_run(run)
-    if benchmark_run:
-        compact["benchmark_run_summary"] = benchmark_run
-        health_note = worker_bridge_ingest_health_note(benchmark_run)
-        if health_note:
-            compact["worker_bridge_ingest_health_note"] = health_note
-    benchmark_result = compact_benchmark_result(run)
-    if benchmark_result:
-        compact["benchmark_result_summary"] = benchmark_result
-    benchmark_comparison = compact_benchmark_comparison(run)
-    if benchmark_comparison:
-        compact["benchmark_comparison_summary"] = benchmark_comparison
-        decision_note = benchmark_comparison_decision_note(benchmark_comparison)
-        if decision_note:
-            compact["benchmark_comparison_decision_note"] = decision_note
-    benchmark_learning_ledger = compact_benchmark_learning_ledger(run)
-    if benchmark_learning_ledger:
-        compact["benchmark_learning_ledger_summary"] = benchmark_learning_ledger
-    benchmark_report = compact_benchmark_experiment_report(run)
-    if benchmark_report:
-        compact["benchmark_experiment_report_summary"] = benchmark_report
-        readiness_note = benchmark_experiment_report_readiness_note(benchmark_report)
-        if readiness_note:
-            compact["benchmark_experiment_report_readiness_note"] = readiness_note
-            replay_decision = benchmark_experiment_report_replay_decision(readiness_note)
-            if replay_decision:
-                compact["benchmark_experiment_report_replay_decision"] = replay_decision
-    active_user_pilot = compact_active_user_assisted_pilot(run)
-    if active_user_pilot:
-        compact["active_user_assisted_pilot_summary"] = active_user_pilot
-    session_projection = compact_session_runtime_projection_from_run(run)
-    if session_projection:
-        compact["session_runtime_projection"] = session_projection
-    return compact
+    return _attach_run_summary_projections_read_model(
+        compact,
+        run,
+        compact_benchmark_run=compact_benchmark_run,
+        worker_bridge_ingest_health_note=worker_bridge_ingest_health_note,
+        compact_benchmark_result=compact_benchmark_result,
+        compact_benchmark_comparison=compact_benchmark_comparison,
+        benchmark_comparison_decision_note=benchmark_comparison_decision_note,
+        compact_benchmark_learning_ledger=compact_benchmark_learning_ledger,
+        compact_benchmark_experiment_report=compact_benchmark_experiment_report,
+        benchmark_experiment_report_readiness_note=benchmark_experiment_report_readiness_note,
+        benchmark_experiment_report_replay_decision=benchmark_experiment_report_replay_decision,
+        compact_active_user_assisted_pilot=compact_active_user_assisted_pilot,
+        compact_session_runtime_projection_from_run=compact_session_runtime_projection_from_run,
+    )
 
 
 def build_run_history(history: dict[str, Any], *, display_limit: int | None = None) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- Move compact-run summary attachment from `loopx/status.py` into `loopx/control_plane/runtime/run_compaction.py` as a reusable read-path helper.
- Extend `run-compaction-readmodel-smoke.py` to cover base + summary projection parity with a public-safe session runtime fixture.
- Add the run-compaction smoke to the default `status-read-path` canary profile and preserve goal-channel coverage in the wider profile window.

## Validation
- `python3 -m compileall loopx/control_plane/runtime/run_compaction.py loopx/status.py loopx/canary/planner.py`
- `python3 examples/control_plane/run-compaction-readmodel-smoke.py`
- `python3 examples/canary/catalog-planner-smoke.py`
- `python3 examples/control_plane/run-history-readmodel-smoke.py`
- `python3 examples/control_plane/status-goal-filter-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 examples/control_plane/goal-channel-readmodel-smoke.py`
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 examples/control_plane/check-public-boundary-smoke.py`
- `git diff --check`
- `python3 -m loopx.cli canary plan --from-git-diff --git-diff-base origin/main --max-checks-per-profile 3 --format json`
- `python3 -m loopx.cli canary smoke-suite --from-git-diff --git-diff-base origin/main --timeout-seconds 30` -> 15/16 passed; known existing `repo-python-line-budget-smoke.py` failure remains limited to SkillsBench large-file allowlist deltas (`examples/skillsbench-app-server-goal-worker-smoke.py`, `examples/skillsbench-benchmark-run-smoke.py`, `scripts/skillsbench_automation_loop.py`).

## Boundary
No benchmark execution, raw logs, task text, trajectory, verifier output, credentials, or production action. This is status/read-path behavior plus canary selection only.