### PR TITLE
Document LoopX command registration recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,16 @@ Choose your surface:
   supported runtime bridge. Install from the no-clone installer, then run
   `loopx doctor` and `loopx bootstrap`.
 
+Command registration is host-specific, but the state path is not. Codex
+surfaces may expose LoopX through `$loopx` or `/skills` command facades before
+native `/loopx` exists; Claude Code can expose `/loopx <task>` after its opt-in
+adapter is installed. If a host command is missing, run `loopx slash-commands`
+for the current catalog or recover a project goal with
+`loopx bootstrap-command-pack --project . --goal-text "<task>"`. Full routing
+and recovery details live in [Getting Started](docs/guides/getting-started.md)
+and the
+[host command registry contract](docs/reference/protocols/codex-app-host-command-registry-v0.md).
+
 ### Codex App
 
 Best when you want a long-running or decentralized multi-agent workflow without

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -113,6 +113,14 @@ loopx bootstrap \
 `.codex/goals/<goal-id>/ACTIVE_GOAL_STATE.md`、`loopx status` 的下一步投影；
 这些本地状态必须被 gitignore，不要提交到公开仓库。
 
+命令注册是 host-specific 的，但状态路径不是。Codex 表面当前可通过 `$loopx`
+或 `/skills` 里的 `loopx` 命令 facade 进入；Claude Code 在 opt-in adapter
+安装后可用 `/loopx <任务>`，再用 `/loop` 推进。若某个 host 里看不到命令，先跑
+`loopx slash-commands` 查看当前命令清单；项目目标可用
+`loopx bootstrap-command-pack --project . --goal-text "<任务>"` 恢复同一语义。
+完整路由和恢复细节见 [Getting Started](docs/guides/getting-started.md) 与
+[host command registry contract](docs/reference/protocols/codex-app-host-command-registry-v0.md)。
+
 ## 看几个例子
 
 想先看证明，再读控制面细节，可以从三个短入口开始：

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -79,9 +79,24 @@ can discover user-installed skills:
   command family can appear as Claude Code slash commands without enabling the
   opt-in MCP/hook adapter.
 
+The command family is the same across surfaces, even when the host-specific
+entry point is different:
+
+| Command family | Host entry | CLI fallback |
+| --- | --- | --- |
+| Project goal start | `/loopx <goal text>` where the host exposes native slash commands; `$loopx <goal text>` or the `loopx` skill in Codex surfaces that use explicit skills. | `loopx bootstrap-command-pack --project . --goal-text "<goal text>"` |
+| Global manager views | `/loopx-global-summary`, `/loopx-global-gates`, `/loopx-global-todos`, `/loopx-global-risks`. | `loopx slash-commands`, then run the listed global manager command for the view you need. |
+| PR review queue | `/loopx-pr-review`. | `loopx pr-review` |
+
+Treat the slash or skill entry as a UI convenience. The CLI remains the source
+of truth, and recovery should use the CLI instead of inventing a second state
+path. If a command disappears after an upgrade, first inspect and refresh the
+registered command files:
+
 To refresh those files after an upgrade, run:
 
 ```bash
+loopx slash-commands
 loopx slash-commands --install
 ```
 
@@ -89,6 +104,19 @@ The command updates files that LoopX owns, including older LoopX-generated
 files with known legacy signatures. If a same-name file has no LoopX managed
 marker or legacy signature, LoopX leaves it untouched and reports
 `skipped_user_file`.
+
+If a project-local goal command still cannot be invoked through the host, run
+the equivalent command pack from the project root:
+
+```bash
+loopx bootstrap-command-pack --project . --goal-text "<goal text>"
+```
+
+That preserves the `/loopx <goal text>` semantics: preserve the exact task
+text, plan before todo writeback, refresh state, run `quota should-run`, and
+continue only when the guard allows. For global manager or PR review commands,
+use `loopx slash-commands` to print the current canonical command list and
+fallback CLI shapes.
 
 ## Local State Backup
 

--- a/docs/reference/protocols/codex-app-host-command-registry-v0.md
+++ b/docs/reference/protocols/codex-app-host-command-registry-v0.md
@@ -11,6 +11,8 @@ This contract sits above:
   `/loopx` status entry and `/loopx <goal text>` start entry.
 - [`global_manager_command_v0`](global-manager-command-v0.md) for read-only
   `/loopx-global-*` manager commands.
+- [`pr_review_command_v0`](pr-review-command-v0.md) for the `/loopx-pr-review`
+  review queue command.
 - [`host_integration_surface_v0`](host-integration-surface-v0.md) for general
   host lifecycle reads and controlled writes.
 
@@ -29,6 +31,7 @@ The host registry should expose this minimal command set:
 | `/loopx-global-gates` | `global_manager_command_v0` gates request | Read-only gate inbox. |
 | `/loopx-global-todos` | `global_manager_command_v0` todos request | Read-only work queue view. |
 | `/loopx-global-risks` | `global_manager_command_v0` risks request | Read-only risk view. |
+| `/loopx-pr-review` | `pr_review_command_v0` review request | Must run the PR review CLI first; cannot be answered as a generic chat summary. |
 
 Legacy `/loop-global-*` forms may be accepted during migration, but the host
 must canonicalize packets, help, and user-visible labels to `/loopx-global-*`.
@@ -62,6 +65,13 @@ Example registry entry:
       "protocol": "global_manager_command_v0",
       "legacy_aliases": ["/loop-global-summary"],
       "mutation_policy": "read_only"
+    },
+    {
+      "command": "/loopx-pr-review",
+      "kind": "repo_pr_review",
+      "protocol": "pr_review_command_v0",
+      "cli_baseline": "loopx pr-review",
+      "mutation_policy": "must_run_cli_first"
     }
   ],
   "unknown_command_policy": "fail_closed_with_slash_help"
@@ -85,7 +95,9 @@ message:
 3. Treat `/loopx` with no trailing text as bootstrap/status preview.
 4. Treat text after `/loopx` as explicit task text. Preserve the exact
    user task text in the handoff packet, but quote it safely for CLI display.
-5. Fail closed for unknown `/loopx-*` commands and return `loopx slash-commands`
+5. Route `/loopx-pr-review` to the PR review command contract. Do not send it
+   through the project bootstrap command.
+6. Fail closed for unknown `/loopx-*` commands and return `loopx slash-commands`
    help instead of falling through to ordinary chat.
 
 Skill-level recognition may remain a fallback, but the preferred product path
@@ -160,6 +172,10 @@ visible user intent into the existing CLI lifecycle:
   `loopx agent-onboard`.
 - `/loopx-global-*` commands are read-only and must not approve gates, add
   todos, spend quota, merge PRs, publish externally, or pause/resume loops.
+- `/loopx-pr-review` must run the PR review CLI first and then review PRs under
+  the `pr_review_command_v0` response contract. It is not a project bootstrap
+  command and should not mutate project state unless the review contract
+  explicitly records a public-safe follow-up.
 - Destructive git, credentials, private material reads, production actions, and
   external publication still require explicit user/controller approval.
 
@@ -174,6 +190,7 @@ loopx agent-onboard --list-agent-types
 loopx agent-onboard --agent-type codex-cli --project .
 loopx bootstrap-command-pack --project .
 loopx bootstrap-command-pack --project . --goal-text "<goal text>"
+loopx pr-review
 loopx global-summary
 loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" quota should-run --goal-id <goal-id> --agent-id <agent-id>
 ```
@@ -207,10 +224,11 @@ A host command registry implementation is acceptable when:
 1. `/loopx` and `/loopx <goal text>` route to `loopx_goal_command_v0`.
 2. `/loopx-global-summary`, `/loopx-global-gates`, `/loopx-global-todos`, and
    `/loopx-global-risks` route to `global_manager_command_v0`.
-3. Legacy `/loop-global-*` inputs canonicalize to `/loopx-global-*`.
-4. Unknown `/loopx-*` commands fail closed with `loopx slash-commands` help.
-5. The handoff packet includes project root label, optional active state id,
+3. `/loopx-pr-review` routes to `pr_review_command_v0` and runs the CLI first.
+4. Legacy `/loop-global-*` inputs canonicalize to `/loopx-global-*`.
+5. Unknown `/loopx-*` commands fail closed with `loopx slash-commands` help.
+6. The handoff packet includes project root label, optional active state id,
    agent id, protocol, authority, and CLI fallback, without public local
    absolute paths.
-6. Host parsing is treated as the preferred path, while skill-level recognition
+7. Host parsing is treated as the preferred path, while skill-level recognition
    remains only a compatibility fallback.


### PR DESCRIPTION
## Summary
- Document host-specific LoopX command registration in the English and Chinese Quick Start paths.
- Expand Getting Started with command-family routing for project goals, global manager commands, and PR review.
- Add /loopx-pr-review to the host command registry contract and CLI fallback list.

## Validation
- git diff --check
- python3 examples/codex-app-host-command-registry-smoke.py
- python3 examples/slash-command-catalog-smoke.py
- python3 examples/pr-review-command-smoke.py
- python3 examples/fresh-clone-quickstart-smoke.py
- loopx check --scan-path README.md --scan-path README.zh-CN.md --scan-path docs/guides/getting-started.md --scan-path docs/reference/protocols/codex-app-host-command-registry-v0.md