### PR TITLE
Allow explicit primary review handoff overrides

### DIFF
--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -325,6 +325,12 @@ goal's `primary_agent`. A goal may set
 shared default route, and may override that default for a specific side agent
 with `coordination.agent_profiles.<agent_id>.review_policy.handoff_agent`.
 `--next-claimed-by` is allowed only when it matches the resolved handoff owner.
+An explicitly declared primary review successor is the narrow exception: when a
+side agent completes a todo with `--next-action-kind primary_review*` and
+`--next-claimed-by <primary_agent>`, that successor remains a primary-agent
+review handoff even if the goal has a broader `side_agent_handoff_agent`
+default. Use this only for real review/merge/publication decisions; ordinary
+side-agent continuation should follow the resolved handoff route.
 Existing registry fields named for review are not aliases for this route. This
 keeps broad side-agent handoff visible to the shared control plane without
 hard-coding a single follow-up surface for every side-agent lane.

--- a/examples/control_plane/todo-lifecycle-cli-smoke.py
+++ b/examples/control_plane/todo-lifecycle-cli-smoke.py
@@ -190,6 +190,63 @@ def assert_configured_side_agent_handoff() -> None:
         assert not side_handoff_successor.get("action_kind"), side_handoff_successor
         assert side_handoff_successor["claimed_by"] == "codex-side-reviewer", side_handoff_successor
 
+    with tempfile.TemporaryDirectory(prefix="loopx-explicit-primary-review-handoff-smoke-") as tmp:
+        root = Path(tmp)
+        registry_path, state_file = write_fixture(root)
+        registry = json.loads(registry_path.read_text(encoding="utf-8"))
+        coordination = registry["goals"][0]["coordination"]
+        coordination["registered_agents"].append("codex-side-reviewer")
+        coordination["side_agent_handoff_agent"] = "codex-side-reviewer"
+        registry_path.write_text(json.dumps(registry, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+        review_source_added = run_cli(
+            registry_path,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--text",
+            SIDE_HANDOFF_SOURCE_TODO,
+            "--claimed-by",
+            "codex-side-bypass",
+            "--task-class",
+            "advancement_task",
+            "--action-kind",
+            "contract_refine",
+        )
+        explicit_primary_review = run_cli(
+            registry_path,
+            "todo",
+            "complete",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            review_source_added["todo_id"],
+            "--claimed-by",
+            "codex-side-bypass",
+            "--evidence",
+            "side-worktree-contract-diff",
+            "--next-agent-todo",
+            REVIEW_TODO,
+            "--next-claimed-by",
+            "codex-main-control",
+            "--next-action-kind",
+            "primary_review_merge",
+        )
+        assert explicit_primary_review["changed"] is True, explicit_primary_review
+        review_successor = explicit_primary_review["next_todos"][0]
+        assert review_successor["claimed_by"] == "codex-main-control", explicit_primary_review
+        assert review_successor["action_kind"] == "primary_review_merge", explicit_primary_review
+        assert review_successor["blocks_agent"] == "codex-side-bypass", explicit_primary_review
+        assert review_successor["unblocks_todo_id"] == review_source_added["todo_id"], explicit_primary_review
+        review_successor_item = next(
+            item for item in parsed_items(state_file) if item["todo_id"] == review_successor["todo_id"]
+        )
+        assert review_successor_item["claimed_by"] == "codex-main-control", review_successor_item
+        assert review_successor_item["action_kind"] == "primary_review_merge", review_successor_item
+
     with tempfile.TemporaryDirectory(prefix="loopx-side-agent-handoff-self-smoke-") as tmp:
         root = Path(tmp)
         registry_path, _state_file = write_fixture(root)

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -89,6 +89,11 @@ TODO_METADATA_FIELDS = (
 )
 
 
+def _is_primary_review_action_kind(value: Any) -> bool:
+    action_kind = str(value or "").strip()
+    return action_kind == "primary_review" or action_kind.startswith("primary_review_")
+
+
 def _attach_todo_write_correctness_dry_run_packet(
     payload: dict[str, Any],
     *,
@@ -1639,6 +1644,14 @@ def complete_goal_todo(
         side_agent_completion = bool(
             effective_claimed_by and primary_agent and effective_claimed_by != primary_agent
         )
+        explicit_primary_review_handoff = bool(
+            side_agent_completion
+            and next_agent_todo
+            and not side_agent_self_merged
+            and primary_agent
+            and effective_next_claimed_by == primary_agent
+            and _is_primary_review_action_kind(next_action_kind)
+        )
         if side_agent_completion:
             if side_agent_self_merged and not evidence:
                 raise ValueError(
@@ -1661,11 +1674,12 @@ def complete_goal_todo(
                 not side_agent_self_merged
                 and effective_next_claimed_by
                 and effective_next_claimed_by != handoff_agent
+                and not explicit_primary_review_handoff
             ):
                 raise ValueError(
                     f"side-agent completion handoff todo must be claimed_by handoff_agent={handoff_agent!r}"
                 )
-            if next_agent_todo and not side_agent_self_merged:
+            if next_agent_todo and not side_agent_self_merged and not effective_next_claimed_by:
                 effective_next_claimed_by = handoff_agent
         if effective_next_claimed_by and not next_agent_todo:
             raise ValueError("--next-claimed-by requires --next-agent-todo")


### PR DESCRIPTION
## Summary
- allow side-agent completion to explicitly create a primary-agent review successor with `--next-action-kind primary_review*` and `--next-claimed-by <primary_agent>` even when a broader `coordination.side_agent_handoff_agent` default exists
- keep the existing broad handoff default for ordinary side-agent successors
- document the narrow policy and add a todo lifecycle regression smoke

## Product / Architecture Judgment
- Motivation: side-agent workflows can have a broad handoff default while still needing an explicit primary review/merge/publication successor for higher-risk work.
- Solved: the runtime now treats structured `primary_review*` action kinds as an explicit primary-agent handoff override; ordinary successors still resolve through the configured handoff agent.
- User/operator impact: primary review todos no longer conflict with broad side-agent handoff routing, so review/merge gates can remain visible to main control without weakening normal side-agent continuation routing.
- Main risk: todo lifecycle routing. The change is restricted to explicit metadata plus primary-agent claimed successors and is covered by the CLI smoke.
- Design judgment: this keeps the kernel route generic: broad handoff remains registry policy, while primary review is an explicit successor action kind rather than a second registry alias.

## Validation
- `python3 examples/control_plane/todo-lifecycle-cli-smoke.py`
- `python3 examples/control_plane/work-lane-contract-smoke.py`
- `python3 examples/control_plane/capability-gate-projection-smoke.py`
- `python3 examples/control_plane/heartbeat-prompt-smoke.py`
- `python3 examples/control_plane/quota-plan-smoke.py`
- `python3 -m py_compile loopx/todos.py loopx/cli_commands/todo.py loopx/agent_registry.py`
- `git diff --check`
- `git diff --check origin/main...HEAD`
- `loopx check --scan-path loopx/todos.py --scan-path examples/control_plane/todo-lifecycle-cli-smoke.py --scan-path docs/project-agent-todo-contract.md`

LoopX check reported only the existing duplicate-index warning; the public/private scan was clean for the three touched files.
