### PR TITLE
Remove scheduler policy compatibility shims

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,7 +148,10 @@ section, or abstraction, pass a scope-fit review:
   layers just because several files share a similar shape.
 - Treat large or hot files as warning signals. When a change would grow an
   already oversized module, first look for a narrow read model, domain helper,
-  or bounded-context home with a compatibility wrapper left behind.
+  or bounded-context home. For internal module moves, update active call sites
+  and delete the old entry point; leave a compatibility wrapper only when a
+  real external import, persisted state, CLI/API contract, or migration window
+  requires it.
 - Distinguish duplicate knowledge from duplicate-looking code. Collapse shared
   state rules, protocol semantics, serialization contracts, and lifecycle
   invariants; avoid a parameter-heavy abstraction when two callers merely look

--- a/examples/control_plane/monitor-todo-policy-seam-smoke.py
+++ b/examples/control_plane/monitor-todo-policy-seam-smoke.py
@@ -19,7 +19,6 @@ from loopx.control_plane.scheduler.monitor_todo import (  # noqa: E402
     monitor_todo_missing_schedule,
     monitor_todo_next_due_at,
 )
-from loopx.policies import monitor_todo as legacy_monitor_todo  # noqa: E402
 from loopx.status import (  # noqa: E402
     todo_item_is_actionable_open,
     todo_item_is_due_monitor,
@@ -68,7 +67,6 @@ def assert_policy_matches_wrappers(item: dict[str, object], *, due: bool, expire
 
 
 def main() -> int:
-    assert legacy_monitor_todo.monitor_todo_is_due is monitor_todo_is_due
     assert_policy_matches_wrappers(monitor_item(), due=True, expired=False)
     assert_policy_matches_wrappers(monitor_item(next_due_at=FUTURE), due=False, expired=False)
     assert_policy_matches_wrappers(

--- a/examples/control_plane/quota-scheduler-hint-compaction-smoke.py
+++ b/examples/control_plane/quota-scheduler-hint-compaction-smoke.py
@@ -17,7 +17,6 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.control_plane.scheduler.scheduler_hint import build_scheduler_hint  # noqa: E402
-from loopx.policies import scheduler_hint as legacy_scheduler_hint  # noqa: E402
 from loopx.quota import _scheduler_hint  # noqa: E402
 
 
@@ -252,7 +251,6 @@ def assert_cli_compact_and_detail_contract() -> None:
 
 
 def main() -> int:
-    assert legacy_scheduler_hint.build_scheduler_hint is build_scheduler_hint
     assert_compact_scheduler("active-work", payload(should_run=True))
     assert_compact_scheduler(
         "human-gate",

--- a/examples/control_plane/quota-scheduler-policy-smoke.py
+++ b/examples/control_plane/quota-scheduler-policy-smoke.py
@@ -13,7 +13,6 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.control_plane.scheduler.scheduler_hint import build_scheduler_hint  # noqa: E402
-from loopx.policies import scheduler_hint as legacy_scheduler_hint  # noqa: E402
 from loopx.quota import AgentScopeFrontierAction, _scheduler_hint  # noqa: E402
 
 
@@ -156,7 +155,6 @@ def assert_policy_case(
 
 
 def main() -> int:
-    assert legacy_scheduler_hint.build_scheduler_hint is build_scheduler_hint
     assert_policy_case(
         "active-work",
         payload(should_run=True, effective_action="normal_run"),

--- a/examples/control_plane/quota-scheduler-state-ack-smoke.py
+++ b/examples/control_plane/quota-scheduler-state-ack-smoke.py
@@ -17,7 +17,6 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.control_plane.scheduler.scheduler_hint import build_scheduler_hint  # noqa: E402
-from loopx.policies import scheduler_hint as legacy_scheduler_hint  # noqa: E402
 from loopx.quota import AgentScopeFrontierAction  # noqa: E402
 from loopx.scheduler_state import SCHEDULER_STATE_SCHEMA_VERSION  # noqa: E402
 from loopx.status import AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK  # noqa: E402
@@ -409,7 +408,6 @@ def assert_cli_scheduler_ack_uses_should_run_lookback() -> None:
 
 
 def main() -> int:
-    assert legacy_scheduler_hint.build_scheduler_hint is build_scheduler_hint
     assert_policy_state_progression()
     assert_active_work_keeps_initial_cadence()
     assert_cli_scheduler_ack_progression()

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -318,8 +318,6 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
             "successor",
             "loopx/control_plane/scheduler/monitor_todo.py",
             "loopx/control_plane/scheduler/scheduler_hint.py",
-            "loopx/policies/monitor_todo.py",
-            "loopx/policies/scheduler_hint.py",
             "loopx/todo_handoff_gate.py",
         ),
         "checks": [

--- a/loopx/policies/monitor_todo.py
+++ b/loopx/policies/monitor_todo.py
@@ -1,3 +1,0 @@
-"""Compatibility shim for loopx.control_plane.scheduler.monitor_todo."""
-
-from loopx.control_plane.scheduler.monitor_todo import *  # noqa: F401,F403

--- a/loopx/policies/scheduler_hint.py
+++ b/loopx/policies/scheduler_hint.py
@@ -1,3 +1,0 @@
-"""Compatibility shim for loopx.control_plane.scheduler.scheduler_hint."""
-
-from loopx.control_plane.scheduler.scheduler_hint import *  # noqa: F401,F403


### PR DESCRIPTION
## Summary

- remove `loopx.policies.scheduler_hint` and `loopx.policies.monitor_todo` compatibility shims
- remove smoke assertions that intentionally preserved legacy imports
- keep canary planner hints focused on the new `loopx/control_plane/scheduler/*` paths
- update `AGENTS.md` so internal bounded-context moves update callsites and delete old entry points unless a real external/persisted/API compatibility contract requires a wrapper

## Validation

- `python3 -m compileall -q loopx/control_plane/scheduler/scheduler_hint.py loopx/control_plane/scheduler/monitor_todo.py loopx/quota.py loopx/todo_projection.py examples/control_plane/quota-scheduler-policy-smoke.py examples/control_plane/quota-scheduler-hint-compaction-smoke.py examples/control_plane/quota-scheduler-state-ack-smoke.py examples/control_plane/monitor-todo-policy-seam-smoke.py examples/canary/catalog-planner-smoke.py examples/canary/catalog-run-e2e-smoke.py`
- `python3 examples/control_plane/quota-scheduler-policy-smoke.py`
- `python3 examples/control_plane/quota-scheduler-hint-compaction-smoke.py`
- `python3 examples/control_plane/quota-scheduler-state-ack-smoke.py`
- `python3 examples/control_plane/monitor-todo-policy-seam-smoke.py`
- `python3 examples/canary/catalog-planner-smoke.py`
- `python3 examples/canary/catalog-run-e2e-smoke.py`
- `PYTHONPATH="$PWD" python3 -m loopx.cli --format json canary plan --changed-file loopx/control_plane/scheduler/monitor_todo.py --changed-file loopx/control_plane/scheduler/scheduler_hint.py --surface "control-plane refactor scheduler monitor policy seam"`
- `git diff --check`
- added-line public/private scan