### PR TITLE
Keep auto-research round proof in generic ledger

### DIFF
--- a/examples/auto-research-knn-continuation-smoke.py
+++ b/examples/auto-research-knn-continuation-smoke.py
@@ -77,6 +77,7 @@ def main() -> int:
     assert kernel_ledger["owner_layer"] == "generic_multi_agent_kernel", kernel_ledger
     assert kernel_ledger["collective_round_count"] == 4, kernel_ledger
     assert kernel_ledger["multi_round_interaction_verified"] is True, kernel_ledger
+    assert kernel_ledger["collective_research_verification"]["verified"] is True, kernel_ledger
     assert kernel_ledger["successor_todo_count"] >= 1, kernel_ledger
     tonight = payload["tonight_experience"]
     assert tonight["coordination_pattern"] == "decentralized_state_a2a", tonight

--- a/examples/auto-research-layered-e2e-acceptance-smoke.py
+++ b/examples/auto-research-layered-e2e-acceptance-smoke.py
@@ -345,6 +345,12 @@ def assert_two_round_outcome(payload: dict[str, Any]) -> None:
     assert kernel_ledger["integrated_evidence"]["dev_metric"] == 4.8, kernel_ledger
     assert kernel_ledger["integrated_evidence"]["holdout_metric"] == 5.2, kernel_ledger
     assert kernel_ledger["integrated_evidence"]["holdout_improvement_count"] == 2, kernel_ledger
+    kernel_verification = kernel_ledger["collective_research_verification"]
+    assert kernel_verification["required_full_participation_round_count"] == 4, kernel_verification
+    assert kernel_verification["required_holdout_improvement_count"] == 2, kernel_verification
+    assert kernel_verification["full_participation_requirement_met"] is True, kernel_verification
+    assert kernel_verification["holdout_improvement_requirement_met"] is True, kernel_verification
+    assert kernel_verification["verified"] is True, kernel_verification
 
     tonight = payload["tonight_experience"]
     assert tonight["ready"] is True, tonight

--- a/examples/multi-agent-collective-round-ledger-smoke.py
+++ b/examples/multi-agent-collective-round-ledger-smoke.py
@@ -89,6 +89,9 @@ def main() -> int:
                 "action_kind": "run_holdout_eval",
             }
         ],
+        baseline_metric=1.0,
+        required_full_participation_round_count=1,
+        required_holdout_improvement_count=1,
     )
     assert ledger["schema_version"] == MULTI_AGENT_COLLECTIVE_ROUND_LEDGER_SCHEMA_VERSION
     assert ledger["owner_layer"] == "generic_multi_agent_kernel", ledger
@@ -109,6 +112,12 @@ def main() -> int:
     assert ledger["integrated_evidence"]["dev_metric_sequence"] == [4.0], ledger
     assert ledger["integrated_evidence"]["holdout_metric_sequence"] == [4.5], ledger
     assert ledger["integrated_evidence"]["holdout_improvement_count"] == 1, ledger
+    verification = ledger["collective_research_verification"]
+    assert verification["schema_version"] == "multi_agent_collective_research_verification_v0"
+    assert verification["baseline_metric"] == 1.0, ledger
+    assert verification["full_participation_requirement_met"] is True, ledger
+    assert verification["holdout_improvement_requirement_met"] is True, ledger
+    assert verification["verified"] is True, ledger
     assert ledger["successor_todo_count"] == 1, ledger
     assert ledger["role_declared_successor_todos"][0]["target_agent_id"] == "agent-b"
     assert ledger["public_boundary"] == {

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -448,28 +448,44 @@ def _build_collective_round_summary(
     holdout_sequence = list(
         holdout_metric_sequence or ([] if holdout_metric is None else [holdout_metric])
     )
-    if holdout_improvement_count is None:
-        previous = baseline
-        holdout_improvements = 0
-        for metric in holdout_sequence:
-            if metric > previous:
-                holdout_improvements += 1
-            previous = metric
-    else:
-        holdout_improvements = holdout_improvement_count
+    integrated_evidence: dict[str, object] = {
+        "dev_metric": dev_metric,
+        "holdout_metric": holdout_metric,
+        "dev_metric_sequence": dev_sequence,
+        "holdout_metric_sequence": holdout_sequence,
+        "evidence_event_count": evidence_event_count,
+    }
+    if holdout_improvement_count is not None:
+        integrated_evidence["holdout_improvement_count"] = holdout_improvement_count
     kernel_ledger = build_multi_agent_collective_round_ledger(
         source=source,
         expected_lanes=expected_lanes,
         lane_outcomes=lane_outcomes,
-        integrated_evidence={
-            "dev_metric": dev_metric,
-            "holdout_metric": holdout_metric,
-            "dev_metric_sequence": dev_sequence,
-            "holdout_metric_sequence": holdout_sequence,
-            "holdout_improvement_count": holdout_improvements,
-            "evidence_event_count": evidence_event_count,
-        },
+        integrated_evidence=integrated_evidence,
         role_declared_successor_todos=role_declared_successor_todos,
+        baseline_metric=baseline,
+        required_full_participation_round_count=4,
+        required_holdout_improvement_count=2,
+    )
+    kernel_evidence = (
+        kernel_ledger.get("integrated_evidence")
+        if isinstance(kernel_ledger.get("integrated_evidence"), dict)
+        else {}
+    )
+    verification = (
+        kernel_ledger.get("collective_research_verification")
+        if isinstance(kernel_ledger.get("collective_research_verification"), dict)
+        else {}
+    )
+    dev_metric = _numeric_metric(kernel_evidence.get("dev_metric"))
+    holdout_metric = _numeric_metric(kernel_evidence.get("holdout_metric"))
+    dev_sequence = _numeric_sequence(kernel_evidence.get("dev_metric_sequence"))
+    holdout_sequence = _numeric_sequence(kernel_evidence.get("holdout_metric_sequence"))
+    holdout_improvements = (
+        int(kernel_evidence.get("holdout_improvement_count"))
+        if isinstance(kernel_evidence.get("holdout_improvement_count"), int)
+        and not isinstance(kernel_evidence.get("holdout_improvement_count"), bool)
+        else 0
     )
     full_participation_round_count = kernel_ledger.get("full_participation_round_count")
     if not isinstance(full_participation_round_count, int) or isinstance(
@@ -478,12 +494,9 @@ def _build_collective_round_summary(
         full_participation_round_count = 0
     full_participation_verified = kernel_ledger.get("full_participation_verified") is True
     multi_round_research_verified = (
-        full_participation_round_count >= 4
-        and full_participation_verified
-        and dev_metric is not None
+        verification.get("verified") is True
+        and verification.get("dev_metric_over_baseline") is True
         and holdout_metric is not None
-        and dev_metric > baseline
-        and holdout_improvements >= 2
     )
     return {
         "schema_version": "auto_research_collective_round_summary_v0",

--- a/loopx/capabilities/multi_agent/collective_round_ledger.py
+++ b/loopx/capabilities/multi_agent/collective_round_ledger.py
@@ -43,6 +43,16 @@ def _number_list(values: object) -> list[float]:
     return numbers
 
 
+def _improvement_count(metrics: list[float], *, baseline: float) -> int:
+    previous = baseline
+    count = 0
+    for metric in metrics:
+        if metric > previous:
+            count += 1
+        previous = metric
+    return count
+
+
 def _dicts(values: Iterable[object] | None) -> list[dict[str, Any]]:
     return [dict(item) for item in values or [] if isinstance(item, Mapping)]
 
@@ -66,8 +76,11 @@ def _normalize_lane(lane: Mapping[str, object]) -> dict[str, object]:
 def _normalize_outcome(outcome: Mapping[str, object]) -> dict[str, object]:
     completion_status = _string(outcome.get("completion_status"))
     executed = _bool_or_none(outcome.get("executed"))
+    round_index = _int_or_none(outcome.get("round"))
+    if round_index is None:
+        round_index = _int_or_none(outcome.get("round_index"))
     return {
-        "round": _int_or_none(outcome.get("round")),
+        "round": round_index,
         "agent_id": _string(outcome.get("agent_id")),
         "lane_id": _string(outcome.get("lane_id")),
         "role_id": _string(outcome.get("role_id")),
@@ -113,6 +126,9 @@ def build_multi_agent_collective_round_ledger(
     lane_outcomes: Iterable[object] | None = None,
     integrated_evidence: Mapping[str, object] | None = None,
     role_declared_successor_todos: Iterable[object] | None = None,
+    baseline_metric: float | None = None,
+    required_full_participation_round_count: int | None = None,
+    required_holdout_improvement_count: int | None = None,
 ) -> dict[str, object]:
     """Build a domain-neutral ledger for decentralized multi-agent rounds.
 
@@ -161,6 +177,46 @@ def build_multi_agent_collective_round_ledger(
     if evidence_event_count is None:
         evidence_events = evidence.get("events")
         evidence_event_count = len(evidence_events) if isinstance(evidence_events, list) else 0
+    dev_metric = _number_or_none(evidence.get("dev_metric"))
+    holdout_metric = _number_or_none(evidence.get("holdout_metric"))
+    dev_metric_sequence = _number_list(evidence.get("dev_metric_sequence"))
+    holdout_metric_sequence = _number_list(evidence.get("holdout_metric_sequence"))
+    if dev_metric is None and dev_metric_sequence:
+        dev_metric = dev_metric_sequence[-1]
+    if holdout_metric is None and holdout_metric_sequence:
+        holdout_metric = holdout_metric_sequence[-1]
+    if not dev_metric_sequence and dev_metric is not None:
+        dev_metric_sequence = [dev_metric]
+    if not holdout_metric_sequence and holdout_metric is not None:
+        holdout_metric_sequence = [holdout_metric]
+    holdout_improvement_count = _int_or_none(evidence.get("holdout_improvement_count"))
+    baseline = _number_or_none(baseline_metric)
+    if holdout_improvement_count is None and baseline is not None:
+        holdout_improvement_count = _improvement_count(
+            holdout_metric_sequence,
+            baseline=baseline,
+        )
+    full_rounds_required = _int_or_none(required_full_participation_round_count)
+    holdout_improvements_required = _int_or_none(required_holdout_improvement_count)
+    full_round_requirement_met = (
+        None
+        if full_rounds_required is None
+        else len(full_participation_round_indexes) >= full_rounds_required
+    )
+    holdout_improvement_requirement_met = (
+        None
+        if holdout_improvements_required is None
+        else (holdout_improvement_count or 0) >= holdout_improvements_required
+    )
+    verification_checks = [
+        check
+        for check in (
+            full_round_requirement_met,
+            holdout_improvement_requirement_met,
+        )
+        if check is not None
+    ]
+    collective_research_verified = bool(verification_checks) and all(verification_checks)
     return {
         "schema_version": MULTI_AGENT_COLLECTIVE_ROUND_LEDGER_SCHEMA_VERSION,
         "source": _string(source, default="unknown"),
@@ -188,15 +244,34 @@ def build_multi_agent_collective_round_ledger(
         "integrated_evidence": {
             "loaded": bool(evidence),
             "evidence_event_count": evidence_event_count,
-            "dev_metric": _number_or_none(evidence.get("dev_metric")),
-            "holdout_metric": _number_or_none(evidence.get("holdout_metric")),
-            "dev_metric_sequence": _number_list(evidence.get("dev_metric_sequence")),
-            "holdout_metric_sequence": _number_list(evidence.get("holdout_metric_sequence")),
-            "holdout_improvement_count": _int_or_none(
-                evidence.get("holdout_improvement_count")
-            ),
+            "dev_metric": dev_metric,
+            "holdout_metric": holdout_metric,
+            "dev_metric_sequence": dev_metric_sequence,
+            "holdout_metric_sequence": holdout_metric_sequence,
+            "holdout_improvement_count": holdout_improvement_count,
             "result_status": _string(evidence.get("result_status")),
             "protected_scope_clean": _bool_or_none(evidence.get("protected_scope_clean")),
+        },
+        "collective_research_verification": {
+            "schema_version": "multi_agent_collective_research_verification_v0",
+            "baseline_metric": baseline,
+            "required_full_participation_round_count": full_rounds_required,
+            "required_holdout_improvement_count": holdout_improvements_required,
+            "full_participation_round_count": len(full_participation_round_indexes),
+            "full_participation_requirement_met": full_round_requirement_met,
+            "dev_metric_over_baseline": (
+                None
+                if baseline is None or dev_metric is None
+                else dev_metric > baseline
+            ),
+            "holdout_metric_over_baseline": (
+                None
+                if baseline is None or holdout_metric is None
+                else holdout_metric > baseline
+            ),
+            "holdout_improvement_count": holdout_improvement_count,
+            "holdout_improvement_requirement_met": holdout_improvement_requirement_met,
+            "verified": collective_research_verified,
         },
         "role_declared_successor_todos": successors,
         "successor_todo_count": len(successors),


### PR DESCRIPTION
## Summary

- move the 4-round / holdout-improvement verification policy into the generic multi-agent collective round ledger
- keep auto-research demo-e2e as a thin wrapper that consumes the generic ledger proof
- extend focused smokes so KNN continuation and layered acceptance assert the proof belongs to `generic_multi_agent_kernel`

## Why

This keeps the user entry and auto-research preset lightweight: user + preset define the research question and roles; the generic multi-agent kernel owns decentralized round evidence and proof readiness.

## Validation

- `python3 examples/multi-agent-collective-round-ledger-smoke.py`
- `python3 examples/auto-research-knn-continuation-smoke.py`
- `python3 examples/auto-research-layered-e2e-acceptance-smoke.py`
- `python3 examples/auto-research-demo-e2e-worker-loop-smoke.py`
- `python3 examples/auto-research-worker-loop-smoke.py`
- `python3 examples/auto-research-user-contract-entry-smoke.py`
- `python3 -m compileall -q loopx/capabilities/multi_agent/collective_round_ledger.py loopx/capabilities/auto_research/demo_e2e.py`
- `loopx check --scan-path ...` (5 touched files; public boundary clean, existing global history duplicate-index warning only)
