### PR TITLE
Surface completed todo succession warnings

### DIFF
--- a/examples/control_plane/todo-succession-contract-smoke.py
+++ b/examples/control_plane/todo-succession-contract-smoke.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Smoke-test completed todo succession warnings in status and quota views."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.quota import build_quota_should_run, render_quota_should_run_markdown  # noqa: E402
+from loopx.status import compact_todo_group  # noqa: E402
+
+
+GOAL_ID = "todo-succession-contract-fixture"
+AGENT_ID = "codex-product-capability"
+
+
+def todo_item(
+    *,
+    todo_id: str,
+    text: str,
+    status: str = "open",
+    action_kind: str | None = None,
+    claimed_by: str | None = None,
+    no_followup: bool = False,
+    resume_when: str | None = None,
+    unblocks_todo_id: str | None = None,
+    updated_at: str | None = None,
+) -> dict:
+    item = {
+        "schema_version": "todo_item_v0",
+        "todo_id": todo_id,
+        "index": 1,
+        "status": status,
+        "done": status == "done",
+        "role": "agent",
+        "source_section": "Agent Todo",
+        "task_class": "advancement_task",
+        "text": text,
+    }
+    if action_kind:
+        item["action_kind"] = action_kind
+    if claimed_by:
+        item["claimed_by"] = claimed_by
+    if no_followup:
+        item["no_followup"] = True
+    if resume_when:
+        item["resume_when"] = resume_when
+    if unblocks_todo_id:
+        item["unblocks_todo_id"] = unblocks_todo_id
+    if updated_at:
+        item["updated_at"] = updated_at
+    return item
+
+
+def build_agent_todos() -> dict:
+    summary = compact_todo_group(
+        [
+            todo_item(
+                todo_id="todo_open_next",
+                text="[P1] Continue the next canary-backed control-plane cleanup.",
+                claimed_by=AGENT_ID,
+            ),
+            todo_item(
+                todo_id="todo_missing_successor",
+                text="[P1] Complete a tracked canary cleanup without recording the next slice.",
+                status="done",
+                action_kind="canary_gated_control_plane_cleanup",
+                claimed_by=AGENT_ID,
+                updated_at="2026-07-04T20:00:00+08:00",
+            ),
+            todo_item(
+                todo_id="todo_no_followup",
+                text="[P2] Complete a tracked cleanup that intentionally needs no follow-up.",
+                status="done",
+                action_kind="documentation_cleanup",
+                claimed_by=AGENT_ID,
+                no_followup=True,
+                updated_at="2026-07-04T19:00:00+08:00",
+            ),
+            todo_item(
+                todo_id="todo_with_successor",
+                text="[P2] Complete a tracked cleanup and link the next slice.",
+                status="done",
+                action_kind="projection_cleanup",
+                claimed_by=AGENT_ID,
+                updated_at="2026-07-04T18:00:00+08:00",
+            ),
+            todo_item(
+                todo_id="todo_successor",
+                text="[P2] Continue after the linked cleanup.",
+                claimed_by=AGENT_ID,
+                resume_when="todo_done:todo_with_successor",
+            ),
+            {
+                "todo_id": "todo_legacy_done",
+                "index": 6,
+                "status": "done",
+                "done": True,
+                "role": "agent",
+                "task_class": "advancement_task",
+                "text": "[P3] Legacy markdown checkbox without tracking metadata.",
+            },
+        ],
+        source_section="Agent Todo",
+        role="agent",
+    )
+    assert summary is not None, summary
+    return summary
+
+
+def status_payload(agent_todos: dict) -> dict:
+    quota = {
+        "compute": 1.0,
+        "window_hours": 24,
+        "slot_minutes": 1,
+        "allowed_slots": 1440,
+        "spent_slots": 0,
+        "state": "eligible",
+        "reason": "eligible fixture",
+    }
+    return {
+        "ok": True,
+        "goal_count": 1,
+        "run_count": 0,
+        "attention_queue": {
+            "items": [
+                {
+                    "goal_id": GOAL_ID,
+                    "status": "active",
+                    "waiting_on": "codex",
+                    "severity": "action",
+                    "source": "active_state",
+                    "recommended_action": "Continue the next canary-backed cleanup.",
+                    "quota": quota,
+                    "user_todos": {
+                        "schema_version": "todo_summary_v0",
+                        "source_section": "User Todo",
+                        "total_count": 0,
+                        "open_count": 0,
+                        "done_count": 0,
+                        "first_open_items": [],
+                        "items": [],
+                    },
+                    "agent_todos": agent_todos,
+                }
+            ]
+        },
+        "run_history": {
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "registry_member": True,
+                    "status": "active",
+                    "adapter_kind": "fixture_adapter_v0",
+                    "adapter_status": "connected",
+                    "coordination": {
+                        "primary_agent": "codex-main-control",
+                        "registered_agents": ["codex-main-control", AGENT_ID],
+                    },
+                    "latest_runs": [],
+                }
+            ]
+        },
+    }
+
+
+def assert_status_summary_warning() -> None:
+    summary = build_agent_todos()
+    assert summary["completed_without_successor_count"] == 1, summary
+    warning = summary["todo_succession_warning"]
+    assert warning["schema_version"] == "todo_succession_warning_v0", warning
+    assert warning["reason_code"] == "completed_advancement_without_successor", warning
+    assert warning["items"][0]["todo_id"] == "todo_missing_successor", warning
+    assert warning["items"][0]["succession_tracked"] is True, warning
+    assert "todo_no_followup" not in {
+        item["todo_id"] for item in warning["items"] if item.get("todo_id")
+    }, warning
+    assert "todo_with_successor" not in {
+        item["todo_id"] for item in warning["items"] if item.get("todo_id")
+    }, warning
+    assert "todo_legacy_done" not in {
+        item["todo_id"] for item in warning["items"] if item.get("todo_id")
+    }, warning
+
+
+def assert_quota_projects_warning() -> None:
+    payload = build_quota_should_run(
+        status_payload(build_agent_todos()),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+    assert payload["decision"] == "run", payload
+    warning = payload["agent_todo_summary"]["todo_succession_warning"]
+    assert warning["count"] == 1, payload
+    assert warning["items"][0]["todo_id"] == "todo_missing_successor", payload
+    markdown = render_quota_should_run_markdown(payload)
+    assert "agent_todo_succession_warning" in markdown, markdown
+    assert "todo_missing_successor" in markdown, markdown
+
+
+def main() -> int:
+    assert_status_summary_warning()
+    assert_quota_projects_warning()
+    print("todo-succession-contract-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/control_plane/todos/todo_summary.py
+++ b/loopx/control_plane/todos/todo_summary.py
@@ -49,8 +49,10 @@ MAX_TODO_VISIBILITY_LANE_ITEMS = 16
 MAX_DEFERRED_TODO_VISIBILITY_ITEMS = 8
 MAX_MONITOR_DUE_ITEMS = 1
 MAX_DEPENDENCY_BLOCKERS = 4
+MAX_COMPLETED_SUCCESSION_WARNING_ITEMS = 5
 
 TODO_ITEM_SCHEMA_VERSION = "todo_item_v0"
+TODO_SUCCESSION_WARNING_SCHEMA_VERSION = "todo_succession_warning_v0"
 AttentionItemBuilder = Callable[..., dict[str, Any]]
 GoalLifecycleFields = Callable[[dict[str, Any], Optional[dict[str, Any]]], dict[str, Any]]
 PublicSafeText = Callable[..., Optional[str]]
@@ -285,6 +287,7 @@ def compact_todo_item(item: dict[str, Any]) -> dict[str, Any]:
         "resume_condition",
         "resume_ready",
         "no_followup",
+        "successor_todo_ids",
         "target_key",
         "cadence",
         "next_due_at",
@@ -662,6 +665,116 @@ def active_next_action_todo_ids(value: Any) -> set[str]:
     return todo_ids
 
 
+def _normalized_todo_id_list(value: Any) -> list[str]:
+    raw_values = value if isinstance(value, (list, tuple, set)) else [value]
+    todo_ids: list[str] = []
+    for raw_value in raw_values:
+        for match in re.findall(r"\btodo_[A-Za-z0-9_-]+\b", str(raw_value or "")):
+            todo_id = normalize_todo_id(match)
+            if todo_id and todo_id not in todo_ids:
+                todo_ids.append(todo_id)
+        todo_id = normalize_todo_id(raw_value)
+        if todo_id and todo_id not in todo_ids:
+            todo_ids.append(todo_id)
+    return todo_ids
+
+
+def todo_successor_todo_ids(
+    item: dict[str, Any],
+    *,
+    items: list[dict[str, Any]],
+) -> list[str]:
+    successor_ids = _normalized_todo_id_list(item.get("successor_todo_ids"))
+    superseded_by = normalize_todo_id(item.get("superseded_by"))
+    if superseded_by and superseded_by not in successor_ids:
+        successor_ids.append(superseded_by)
+
+    source_todo_id = normalize_todo_id(item.get("todo_id"))
+    if not source_todo_id:
+        return successor_ids
+
+    for candidate in items:
+        if not isinstance(candidate, dict):
+            continue
+        candidate_id = normalize_todo_id(candidate.get("todo_id"))
+        if not candidate_id or candidate_id == source_todo_id:
+            continue
+        if todo_item_task_class(candidate) != TODO_TASK_CLASS_ADVANCEMENT:
+            continue
+        resume_when = normalize_todo_resume_when(candidate.get("resume_when")) or ""
+        resume_kind, separator, resume_target = resume_when.partition(":")
+        candidate_unblocks = normalize_todo_id(candidate.get("unblocks_todo_id"))
+        if candidate_unblocks != source_todo_id and not (
+            separator
+            and resume_kind == TODO_RESUME_KIND_TODO_DONE
+            and normalize_todo_id(resume_target) == source_todo_id
+        ):
+            continue
+        if candidate_id not in successor_ids:
+            successor_ids.append(candidate_id)
+    return successor_ids
+
+
+def todo_item_is_succession_tracked_completion(item: dict[str, Any]) -> bool:
+    if not item.get("done"):
+        return False
+    if todo_item_is_deferred(item):
+        return False
+    if todo_item_task_class(item) != TODO_TASK_CLASS_ADVANCEMENT:
+        return False
+    return any(
+        item.get(key) is not None
+        for key in (
+            "action_kind",
+            "claimed_by",
+            "completed_at",
+            "updated_at",
+            "required_write_scopes",
+            "required_capabilities",
+            "target_capabilities",
+            "decision_scope",
+            "required_decision_scopes",
+            "unblocks_todo_id",
+            "resume_when",
+            "blocks_agent",
+            "global_gate",
+        )
+    )
+
+
+def _completed_succession_sort_key(item: dict[str, Any]) -> tuple[str, int]:
+    try:
+        index = int(item.get("index"))
+    except (TypeError, ValueError):
+        index = 0
+    timestamp = str(item.get("updated_at") or item.get("completed_at") or "")
+    return (timestamp, index)
+
+
+def completed_without_successor_items(
+    done_items: list[dict[str, Any]],
+    *,
+    all_items: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    gap_items: list[dict[str, Any]] = []
+    for item in done_items:
+        if not todo_item_is_succession_tracked_completion(item):
+            continue
+        if normalize_todo_no_followup(item.get("no_followup")) is True:
+            continue
+        if todo_successor_todo_ids(item, items=all_items):
+            continue
+        compact = compact_todo_item(item)
+        for key in ("note", "evidence", "reason"):
+            compact.pop(key, None)
+        compact["succession_tracked"] = True
+        compact["recommended_action"] = (
+            "record no_followup=true or add/link a successor todo"
+        )
+        gap_items.append(compact)
+    return sorted(gap_items, key=_completed_succession_sort_key, reverse=True)
+
+
 def compact_todo_group(
     items: list[dict[str, Any]],
     *,
@@ -771,6 +884,10 @@ def compact_todo_group(
         for item in executable_items
         if normalize_todo_id(item.get("todo_id")) in preferred_ids
     ]
+    successor_gap_items = completed_without_successor_items(
+        done_items,
+        all_items=items,
+    )
     summary = {
         "schema_version": "todo_summary_v0",
         "source_section": source_section,
@@ -850,6 +967,20 @@ def compact_todo_group(
     handoff_gates = build_todo_handoff_gate_states(items)
     if handoff_gates:
         summary["handoff_gates"] = handoff_gates
+    if successor_gap_items:
+        compact_gap_items = successor_gap_items[:MAX_COMPLETED_SUCCESSION_WARNING_ITEMS]
+        summary["completed_without_successor_count"] = len(successor_gap_items)
+        summary["completed_without_successor_items"] = compact_gap_items
+        summary["todo_succession_warning"] = {
+            "schema_version": TODO_SUCCESSION_WARNING_SCHEMA_VERSION,
+            "reason_code": "completed_advancement_without_successor",
+            "count": len(successor_gap_items),
+            "items": compact_gap_items,
+            "recommended_action": (
+                "record no_followup=true on completed tracked work, "
+                "or add/link a successor todo before closing the slice"
+            ),
+        }
     if active_next_action_items:
         summary["active_next_action_items"] = [
             compact_active_next_action_todo_item(item)

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -1035,6 +1035,7 @@ def _compact_todo_summary_item(item: dict[str, Any], *, text: str | None = None)
         "resume_condition",
         "resume_ready",
         "no_followup",
+        "successor_todo_ids",
         "target_key",
         "cadence",
         "next_due_at",
@@ -1048,6 +1049,9 @@ def _compact_todo_summary_item(item: dict[str, Any], *, text: str | None = None)
         "route_continuation_reason",
         "route_id",
         "route_key",
+        "completed_at",
+        "updated_at",
+        "superseded_by",
     ):
         if item.get(key) is not None:
             compact[key] = item.get(key)
@@ -1993,6 +1997,59 @@ def _is_user_gate_todo_item(item: dict[str, Any]) -> bool:
     return any(hint in action_kind for hint in USER_GATE_ACTION_KIND_HINTS)
 
 
+def _compact_todo_succession_warning_item(item: dict[str, Any]) -> dict[str, Any]:
+    compact = _compact_todo_summary_item(item)
+    for key in (
+        "done",
+        "succession_tracked",
+        "recommended_action",
+    ):
+        if item.get(key) is not None:
+            compact[key] = item.get(key)
+    return compact
+
+
+def _todo_succession_warning_lanes(value: dict[str, Any]) -> dict[str, Any]:
+    warning = value.get("todo_succession_warning")
+    warning = warning if isinstance(warning, dict) else {}
+    source_items = (
+        warning.get("items")
+        if isinstance(warning.get("items"), list)
+        else value.get("completed_without_successor_items")
+    )
+    items = [
+        _compact_todo_succession_warning_item(item)
+        for item in (source_items or [])
+        if isinstance(item, dict)
+    ][:TODO_BACKLOG_ITEM_LIMIT]
+    count = warning.get("count", value.get("completed_without_successor_count"))
+    try:
+        count = max(0, int(count))
+    except (TypeError, ValueError):
+        count = len(items)
+    if count <= 0 and not items:
+        return {}
+
+    payload = {
+        "schema_version": warning.get("schema_version", "todo_succession_warning_v0"),
+        "reason_code": warning.get(
+            "reason_code",
+            "completed_advancement_without_successor",
+        ),
+        "count": count,
+        "items": items,
+        "recommended_action": warning.get(
+            "recommended_action",
+            "record no_followup=true or add/link a successor todo",
+        ),
+    }
+    return {
+        "completed_without_successor_count": count,
+        "completed_without_successor_items": items,
+        "todo_succession_warning": payload,
+    }
+
+
 def _summarize_user_todos(
     value: Any,
     *,
@@ -2125,6 +2182,7 @@ def _summarize_user_todos(
             agent_identity=agent_identity,
         )
     )
+    summary.update(_todo_succession_warning_lanes(value))
     if claimed_open_items or value.get("claimed_open_count"):
         summary["claimed_open_count"] = value.get("claimed_open_count", len(claimed_open_items))
         summary["unclaimed_open_count"] = value.get(
@@ -8820,7 +8878,34 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             summary_parts.insert(2, f"unclaimed={summary.get('unclaimed_open_count', 0)}")
         if summary.get("monitor_due_count"):
             summary_parts.append(f"monitor_due={summary.get('monitor_due_count')}")
+        if summary.get("completed_without_successor_count"):
+            summary_parts.append(
+                f"succession_warning={summary.get('completed_without_successor_count')}"
+            )
         lines.append(f"- {label}_summary: {' '.join(summary_parts)}")
+        succession_warning = (
+            summary.get("todo_succession_warning")
+            if isinstance(summary.get("todo_succession_warning"), dict)
+            else {}
+        )
+        if succession_warning:
+            warning_items = (
+                succession_warning.get("items")
+                if isinstance(succession_warning.get("items"), list)
+                else []
+            )
+            todo_ids = [
+                str(item.get("todo_id"))
+                for item in warning_items[:3]
+                if isinstance(item, dict) and item.get("todo_id")
+            ]
+            todo_ids_text = ",".join(todo_ids) if todo_ids else "n/a"
+            lines.append(
+                f"- {label}_succession_warning: "
+                f"reason={succession_warning.get('reason_code')} "
+                f"count={succession_warning.get('count')} "
+                f"todo_ids={todo_ids_text}"
+            )
         first_open = summary.get("first_open_items") if isinstance(summary.get("first_open_items"), list) else []
         for todo in first_open[:3]:
             if not isinstance(todo, dict):


### PR DESCRIPTION
## Summary
- project completed tracked advancement todos without successor/no-follow-up into todo_summary warning lanes
- pass the warning through quota summaries and markdown rendering
- add a focused control-plane smoke for status + quota succession warnings

## Validation
- python3 -m py_compile loopx/control_plane/todos/todo_summary.py loopx/quota.py examples/control_plane/todo-succession-contract-smoke.py
- python3 examples/control_plane/todo-succession-contract-smoke.py
- python3 examples/control_plane/todo-projection-shared-helper-smoke.py
- python3 examples/control_plane/quota-cleared-blocker-successor-gate-smoke.py
- python3 examples/control_plane/todo-first-open-summary-smoke.py
- python3 examples/control_plane/todo-readmodel-boundary-smoke.py
- python3 examples/control_plane/work-lane-contract-smoke.py
- python3 examples/control_plane/monitor-scheduler-contract-smoke.py
- python3 examples/control_plane/quota-action-scope-guard-smoke.py
- git diff --cached --check
- staged private-boundary scan for local paths, credentials, raw logs, trajectories, verifier output