### PR TITLE
Move todo handoff gate into control-plane todos

### DIFF
--- a/docs/interaction-pattern-catalog.md
+++ b/docs/interaction-pattern-catalog.md
@@ -1016,7 +1016,8 @@ state-machine bugs, not prompt wording bugs.
 
 **Validation**
 
-- `loopx/todo_handoff_gate.py` owns the `todo_handoff_gate_v0` projection.
+- `loopx/control_plane/todos/handoff_gate.py` owns the
+  `todo_handoff_gate_v0` projection.
 - `examples/control_plane/quota-cleared-blocker-successor-gate-smoke.py` covers
   `blocking`, `cleared_without_successor`, `cleared_with_successor`, and
   `superseded` gate states.

--- a/docs/product/core-control-plane/state-machine.md
+++ b/docs/product/core-control-plane/state-machine.md
@@ -21,8 +21,8 @@ public-safe map over the current repository contracts, especially:
   for cadence/backoff/reset-token behavior;
 - [`goal_vision_replan_contract_v0`](../../reference/protocols/goal-vision-replan-contract-v0.md)
   for bounded per-agent vision, replan transitions, and goal-route projection;
-- [`loopx/todo_handoff_gate.py`](../../../loopx/todo_handoff_gate.py) for
-  cross-agent handoff gate states;
+- cross-agent handoff gate states in
+  [`loopx/control_plane/todos/handoff_gate.py`](../../../loopx/control_plane/todos/handoff_gate.py);
 - [`loopx/project_map.py`](../../../loopx/project_map.py) and
   [`loopx/bootstrap.py`](../../../loopx/bootstrap.py) for project registration,
   read-only-map opt-in, global sync, and host-loop activation.
@@ -197,7 +197,8 @@ Multi-agent routing is modeled with todo ownership and handoff gates. Review is
 not a separate kernel state. It is a todo/gate relation that can block a named
 agent until an owner route completes, reassigns, or records no follow-up.
 
-`loopx/todo_handoff_gate.py` currently projects `blocks_agent` todos into:
+`loopx/control_plane/todos/handoff_gate.py` currently projects `blocks_agent`
+todos into:
 `blocking`, `cleared_without_successor`, `cleared_with_successor`,
 `cleared_no_followup`, `superseded`, and `deferred`.
 

--- a/examples/control_plane/quota-cleared-blocker-successor-gate-smoke.py
+++ b/examples/control_plane/quota-cleared-blocker-successor-gate-smoke.py
@@ -13,7 +13,9 @@ if str(REPO_ROOT) not in sys.path:
 
 from loopx.quota import build_quota_should_run  # noqa: E402
 from loopx.status import compact_todo_group  # noqa: E402
-from loopx.todo_handoff_gate import build_todo_handoff_gate_states  # noqa: E402
+from loopx.control_plane.todos.handoff_gate import (  # noqa: E402
+    build_todo_handoff_gate_states,
+)
 
 
 GOAL_ID = "cleared-blocker-successor-gate-fixture"

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -318,7 +318,7 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
             "successor",
             "loopx/control_plane/scheduler/monitor_todo.py",
             "loopx/control_plane/scheduler/scheduler_hint.py",
-            "loopx/todo_handoff_gate.py",
+            "loopx/control_plane/todos/handoff_gate.py",
         ),
         "checks": [
             {

--- a/loopx/control_plane/agents/agent_scope.py
+++ b/loopx/control_plane/agents/agent_scope.py
@@ -20,7 +20,7 @@ from ...todo_contract import (
     normalize_todo_status,
     normalize_todo_task_class,
 )
-from ...todo_handoff_gate import HandoffGateState
+from ..todos.handoff_gate import HandoffGateState
 from ...todo_projection import (
     todo_item_claimed_by_agent_or_unclaimed,
     todo_item_is_actionable_open,

--- a/loopx/control_plane/todos/handoff_gate.py
+++ b/loopx/control_plane/todos/handoff_gate.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import Any, Iterable
 
-from .todo_contract import (
+from ...todo_contract import (
     TODO_RESUME_KIND_TODO_DONE,
     TODO_STATUS_DEFERRED,
     TODO_STATUS_DONE,

--- a/loopx/control_plane/todos/todo_summary.py
+++ b/loopx/control_plane/todos/todo_summary.py
@@ -25,7 +25,7 @@ from ...todo_contract import (
     normalize_todo_task_class,
     todo_done_for_status,
 )
-from ...todo_handoff_gate import build_todo_handoff_gate_states
+from .handoff_gate import build_todo_handoff_gate_states
 from ...todo_projection import (
     todo_claimed_visibility_items as projection_todo_claimed_visibility_items,
     todo_item_is_actionable_open as projection_todo_item_is_actionable_open,

--- a/loopx/policies/goal_route_hint.py
+++ b/loopx/policies/goal_route_hint.py
@@ -12,7 +12,7 @@ from ..todo_contract import (
     normalize_todo_status,
     normalize_todo_task_class,
 )
-from ..todo_handoff_gate import HandoffGateState
+from ..control_plane.todos.handoff_gate import HandoffGateState
 
 
 GOAL_ROUTE_HINT_SCHEMA_VERSION = "goal_route_hint_v0"

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -97,7 +97,10 @@ from .todo_contract import (
     normalize_todo_status,
     normalize_todo_task_class,
 )
-from .todo_handoff_gate import HandoffGateState, build_todo_handoff_gate_states
+from .control_plane.todos.handoff_gate import (
+    HandoffGateState,
+    build_todo_handoff_gate_states,
+)
 from .todo_projection import (
     todo_claimed_visibility_items as projection_todo_claimed_visibility_items,
     todo_index_rank as projection_todo_index_rank,


### PR DESCRIPTION
## Summary
- move the todo handoff gate state machine from the loopx root into `loopx.control_plane.todos.handoff_gate`
- update quota, todo summary, agent scope, policy, canary planner, docs, and the handoff gate smoke to use the canonical bounded-context module
- do not keep a legacy `loopx.todo_handoff_gate` shim, matching the bounded-context refactor direction

## Validation
- `python3 examples/control_plane/quota-cleared-blocker-successor-gate-smoke.py`
- `python3 examples/control_plane/bounded-context-namespace-smoke.py`
- `python3 -m py_compile loopx/control_plane/todos/handoff_gate.py loopx/quota.py loopx/status.py loopx/control_plane/todos/todo_summary.py loopx/control_plane/agents/agent_scope.py loopx/policies/goal_route_hint.py loopx/canary/planner.py examples/control_plane/quota-cleared-blocker-successor-gate-smoke.py`
- `python3 -m loopx.cli --format json canary plan --from-git-diff --surface 'todo handoff bounded context refactor'`
- `python3 -m loopx.cli --format json canary smoke-suite --from-git-diff --surface 'todo handoff bounded context refactor' --limit 5 --timeout-seconds 30 --no-progress`
- `python3 examples/control_plane/quota-plan-smoke.py`
- `python3 examples/control_plane/todo-readmodel-boundary-smoke.py`
- `python3 examples/control_plane/todo-contract-smoke.py`
- `python3 examples/control_plane/quota-work-lane-policy-smoke.py`
- `git diff --check`
