### PR TITLE
Harden SkillsBench Codex CLI /goal route

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -58,6 +58,7 @@ def _assert_cli_goal_route_requires_materialized_solver_bridge() -> None:
 def _assert_cli_goal_plan_and_relay_command() -> None:
     sys.path.insert(0, str(REPO_ROOT))
     from loopx.benchmark_core.loop_protocol import CODEX_CLI_GOAL_BASELINE_ROUTE
+    from loopx.benchmark_adapters.skillsbench import skillsbench_route_contract
     from scripts.skillsbench_automation_loop import (
         _host_local_acp_launch_command,
         build_plan,
@@ -92,9 +93,16 @@ def _assert_cli_goal_plan_and_relay_command() -> None:
             ]
         )
         plan = build_plan(args)
+        assert plan["codex_api_egress_preflight"]["required"] is True, plan
+        assert plan["codex_api_egress_preflight"]["resolved_mode"] == (
+            "reverse-tunnel"
+        ), plan
+        contract = skillsbench_route_contract(CODEX_CLI_GOAL_BASELINE_ROUTE)
         prerequisites = plan["runner_prerequisites"]
         assert plan["route"] == CODEX_CLI_GOAL_BASELINE_ROUTE, plan
         assert plan["agent"] == "codex-cli-goal", plan
+        assert contract["arm_id"] == "codex_cli_goal_baseline", contract
+        assert contract["native_goal_mode_invoked"] is True, contract
         assert plan["codex_cli_reasoning_effort"] == "xhigh", plan
         assert prerequisites["container_codex_acp_install_skipped"] is True
         assert prerequisites["remote_command_file_bridge_command_configured"] is True
@@ -111,6 +119,37 @@ def _assert_cli_goal_plan_and_relay_command() -> None:
         assert "--remote-command-file-bridge-command" in command, command
         bridge_index = command.index("--remote-command-file-bridge-command")
         assert command[bridge_index + 1] == "python bridge.py", command
+
+        proxy_url = "http://127.0.0.1:18182"
+        args_with_proxy = parse_args(
+            [
+                "--route",
+                CODEX_CLI_GOAL_BASELINE_ROUTE,
+                "--host-local-acp-launch",
+                "--remote-command-file-bridge-ready",
+                "--remote-command-file-bridge-solver-command",
+                "python bridge.py",
+                "--reasoning-effort",
+                "xhigh",
+                "--codex-api-reverse-tunnel-proxy",
+                proxy_url,
+                "--plan-only",
+                "--skillsbench-root",
+                str(skillsbench_root),
+                "--jobs-dir",
+                str(temp_path / "jobs-with-proxy"),
+                "--ledger-path",
+                str(temp_path / "ledger-with-proxy.json"),
+                "--global-ledger-path",
+                str(temp_path / "global-ledger-with-proxy.json"),
+            ]
+        )
+        proxy_plan = build_plan(args_with_proxy)
+        proxy_command = _host_local_acp_launch_command(args_with_proxy, proxy_plan)
+        assert "--codex-api-proxy" in proxy_command, proxy_command
+        proxy_index = proxy_command.index("--codex-api-proxy")
+        assert proxy_command[proxy_index + 1] == proxy_url, proxy_command
+        assert proxy_url not in json.dumps(proxy_plan, sort_keys=True), proxy_plan
 
 
 def _assert_cli_goal_trace_merges_into_public_prerequisites() -> None:
@@ -193,11 +232,90 @@ def _assert_cli_goal_trace_merges_into_public_prerequisites() -> None:
     assert public_prerequisites["codex_cli_goal_tui_stages"] == ["goal_achieved"]
 
 
+def _assert_cli_goal_tui_ready_wait_tolerates_startup_warnings() -> None:
+    sys.path.insert(0, str(REPO_ROOT))
+    from loopx.benchmark_adapters.skillsbench_acp_relay import (
+        CodexExecConfig,
+        SkillsBenchLocalAcpRelay,
+    )
+
+    relay = SkillsBenchLocalAcpRelay(CodexExecConfig())
+    captures = iter(
+        [
+            "",
+            "Codex startup\nMCP server failed: HTTP request failed\n› \n",
+        ]
+    )
+
+    def fake_capture(_tmux_name: str) -> str:
+        try:
+            return next(captures)
+        except StopIteration:
+            return "Codex startup\nMCP server failed: HTTP request failed\n› \n"
+
+    relay._tmux_capture = fake_capture  # type: ignore[method-assign]
+    assert relay._wait_for_codex_cli_tui_ready(
+        "fake-session",
+        timeout_sec=1.0,
+        settle_sec=0.0,
+    )
+
+
+def _assert_cli_goal_codex_api_proxy_is_runtime_only() -> None:
+    sys.path.insert(0, str(REPO_ROOT))
+    from loopx.benchmark_adapters.skillsbench_acp_relay import (
+        CodexExecConfig,
+        SkillsBenchLocalAcpRelay,
+    )
+
+    proxy_url = "http://127.0.0.1:18182"
+    with tempfile.TemporaryDirectory() as temp:
+        trace_dir = Path(temp) / "trace"
+        relay = SkillsBenchLocalAcpRelay(
+            CodexExecConfig(
+                codex_api_proxy=proxy_url,
+                worker_public_trace_dir=str(trace_dir),
+            )
+        )
+        env = relay._codex_cli_tui_environment()
+        for key in (
+            "HTTPS_PROXY",
+            "HTTP_PROXY",
+            "ALL_PROXY",
+            "https_proxy",
+            "http_proxy",
+            "all_proxy",
+        ):
+            assert env[key] == proxy_url, env
+        assert "127.0.0.1" in env["NO_PROXY"], env
+
+        shell_command = relay._codex_cli_tui_shell_command(["codex", "--version"])
+        assert shell_command.startswith("env "), shell_command
+        assert "HTTPS_PROXY=" in shell_command, shell_command
+
+        relay._publish_codex_cli_goal_trace(
+            ok=False,
+            stage="goal_failed",
+            goal_active_observed=False,
+            goal_terminal_observed=True,
+            first_action_observed=False,
+            bridge_summary_path=None,
+        )
+        traces = list(trace_dir.glob("*.compact.json"))
+        assert len(traces) == 1, traces
+        payload = json.loads(traces[0].read_text(encoding="utf-8"))
+        assert proxy_url not in json.dumps(payload, sort_keys=True), payload
+        assert payload["codex_cli_goal"]["codex_api_proxy_env_injected"] is True
+        assert payload["codex_cli_goal"]["codex_api_proxy_raw_url_recorded"] is False
+
+
 def main() -> int:
     _assert_app_server_goal_route_deprecated()
     _assert_cli_goal_route_requires_materialized_solver_bridge()
     _assert_cli_goal_plan_and_relay_command()
     _assert_cli_goal_trace_merges_into_public_prerequisites()
+    _assert_cli_goal_tui_ready_wait_tolerates_startup_warnings()
+    _assert_cli_goal_codex_api_proxy_is_runtime_only()
     print("skillsbench-codex-cli-goal-route-smoke ok")
     return 0
 

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -44,6 +44,7 @@ SKILLSBENCH_LOOPX_PRODUCT_MODE_TREATMENT_ROUTES = frozenset(
 )
 SKILLSBENCH_ROUTES = (
     "codex-acp-blind-loop-baseline",
+    "codex-cli-goal-baseline",
     "loopx-blind-loop-treatment",
     "loopx-prompt-polling-test",
     "codex-app-server-goal-baseline",
@@ -215,6 +216,37 @@ def skillsbench_route_contract(route: str) -> dict[str, Any]:
                 "run LoopX outer automation with a fixed blind loop budget; "
                 "do not return official reward, pass/fail, verifier error, or "
                 "verifier output to the in-case agent during the loop"
+            ),
+        }
+    if route == "codex-cli-goal-baseline":
+        return {
+            "mode": "skillsbench_codex_cli_goal_baseline",
+            "arm_id": "codex_cli_goal_baseline",
+            "source_runner": "loopx_skillsbench_host_codex_cli_goal_worker",
+            "inner_codex_goal_mode": True,
+            "native_goal_mode_requested": True,
+            "native_goal_mode_invoked": True,
+            "native_goal_mode_confirmation_status": (
+                "requires_cli_slash_goal_compact_proof"
+            ),
+            "codex_acp_protocol_used": False,
+            "skillsbench_route_semantics": (
+                "host_codex_cli_tui_slash_goal_no_reward_feedback"
+            ),
+            "curated_skills_visible": False,
+            "loopx_automation_loop": False,
+            "loopx_inside_case": False,
+            "blind_loop": False,
+            "official_feedback_blinded": True,
+            "reward_feedback_forwarded": False,
+            "case_semantics_changed_by_harness": False,
+            "official_score_comparable_to_native_codex": True,
+            "official_score_comparable_to_loopx_treatment": True,
+            "first_blocker": "skillsbench_codex_cli_goal_tui_compact_proof_missing",
+            "next_action": (
+                "launch SkillsBench through the host Codex CLI TUI /goal "
+                "surface, ingest compact no-upload evidence, and require "
+                "goal-active plus task-facing bridge evidence for route health"
             ),
         }
     if route == SKILLSBENCH_RAW_CODEX_AUTONOMOUS_ROUTE:
@@ -1849,6 +1881,14 @@ def build_skillsbench_benchmark_run(
                 ]
                 if route == "codex-app-server-goal-baseline"
                 else [
+                    "codex_cli_goal_worker",
+                    "cli_tui_slash_goal",
+                    "fixture_only",
+                    "no_upload",
+                    "single_task_planned",
+                ]
+                if route == "codex-cli-goal-baseline"
+                else [
                     "ordinary_codex_cli_actor",
                     "fixed_blind_loop_budget",
                     "fixture_only",
@@ -1986,6 +2026,8 @@ def build_skillsbench_benchmark_run(
                 if route == "codex-acp-blind-loop-baseline"
                 else "codex_app_server_goal_worker"
                 if route == "codex-app-server-goal-baseline"
+                else "codex_cli_goal_tui_worker"
+                if route == "codex-cli-goal-baseline"
                 else "runner_only"
             ),
             "inner_case_actor": (
@@ -2002,6 +2044,8 @@ def build_skillsbench_benchmark_run(
                 if route == "codex-goal-mode-baseline"
                 else "host_codex_app_server_goal_worker"
                 if route == "codex-app-server-goal-baseline"
+                else "host_codex_cli_goal_tui_worker"
+                if route == "codex-cli-goal-baseline"
                 else "codex_acp_with_curated_skills"
             ),
             "blind_loop": contract["blind_loop"],
@@ -3428,18 +3472,30 @@ def build_skillsbench_benchflow_result_benchmark_run(
         if is_oracle_runner
         else contract["official_score_comparable_to_loopx_treatment"]
     )
-    agent_kwargs_keys = [
-        "benchflow_agent=oracle",
-        "sandbox=docker",
-        "no_upload",
-        "single_task",
-        "no_model_api",
-    ] if is_oracle_runner else [
-        "benchflow_agent=codex-acp",
-        "sandbox=docker",
-        "no_upload",
-        "single_task",
-    ]
+    agent_kwargs_keys = (
+        [
+            "benchflow_agent=oracle",
+            "sandbox=docker",
+            "no_upload",
+            "single_task",
+            "no_model_api",
+        ]
+        if is_oracle_runner
+        else [
+            "benchflow_agent=codex-cli-goal",
+            "cli_tui_slash_goal",
+            "sandbox=docker",
+            "no_upload",
+            "single_task",
+        ]
+        if route == "codex-cli-goal-baseline"
+        else [
+            "benchflow_agent=codex-acp",
+            "sandbox=docker",
+            "no_upload",
+            "single_task",
+        ]
+    )
     outer_controller = (
         "official_skillsbench_oracle_validation"
         if is_oracle_runner
@@ -3453,6 +3509,8 @@ def build_skillsbench_benchflow_result_benchmark_run(
         if route == "raw-codex-autonomous-max5"
         else "fixed_blind_loop_runner"
         if route == "codex-acp-blind-loop-baseline"
+        else "codex_cli_goal_tui_worker"
+        if route == "codex-cli-goal-baseline"
         else "runner_only"
     )
     inner_case_actor = (
@@ -3469,6 +3527,8 @@ def build_skillsbench_benchflow_result_benchmark_run(
         }
         else "codex_acp_goal_prompt_request_unconfirmed_native_goal_mode"
         if route == "codex-goal-mode-baseline"
+        else "host_codex_cli_goal_tui_worker"
+        if route == "codex-cli-goal-baseline"
         else "codex_acp_with_curated_skills"
     )
 

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -531,6 +531,7 @@ class CodexExecConfig:
     bridge_idle_timeout_sec: float = 0.0
     task_output_quiet_timeout_sec: float = 0.0
     reasoning_effort: str | None = None
+    codex_api_proxy: str | None = None
     worker_public_trace_dir: str | None = None
     remote_command_file_bridge_command: str | None = None
     remote_command_file_bridge_agent_command: str | None = None
@@ -1117,7 +1118,7 @@ class SkillsBenchLocalAcpRelay:
             prompt_path.write_text(prompt_for_codex, encoding="utf-8")
             tmux_name = f"gh-sb-cli-goal-{uuid.uuid4().hex[:10]}"
             cmd = self._codex_cli_tui_command(cwd=cwd, model=session.get("model"))
-            shell_command = " ".join(shlex.quote(part) for part in cmd)
+            shell_command = self._codex_cli_tui_shell_command(cmd)
             goal_active_observed = False
             goal_terminal_observed = False
             goal_failed_observed = False
@@ -1143,8 +1144,21 @@ class SkillsBenchLocalAcpRelay:
                     stderr=subprocess.PIPE,
                     text=True,
                 )
-                time.sleep(1.0)
+                if not self._wait_for_codex_cli_tui_ready(tmux_name):
+                    self._tmux_kill_session(tmux_name)
+                    self._publish_codex_cli_goal_trace(
+                        ok=False,
+                        stage="tui_ready_timeout",
+                        goal_active_observed=False,
+                        goal_terminal_observed=False,
+                        first_action_observed=False,
+                        bridge_summary_path=bridge_summary_path,
+                    )
+                    return _recoverable_codex_turn_failure_message(
+                        "codex_exec_first_action_timeout"
+                    )
                 self._tmux_send_literal(tmux_name, "/goal ")
+                time.sleep(0.2)
                 subprocess.run(
                     ["tmux", "load-buffer", "-b", f"{tmux_name}-prompt", str(prompt_path)],
                     check=True,
@@ -1167,6 +1181,7 @@ class SkillsBenchLocalAcpRelay:
                     stderr=subprocess.DEVNULL,
                     text=True,
                 )
+                time.sleep(0.8)
                 self._tmux_submit_enter(tmux_name)
                 deadline = time.monotonic() + self._config.timeout_sec
                 first_action_deadline = 0.0
@@ -1394,6 +1409,52 @@ class SkillsBenchLocalAcpRelay:
             cmd.extend(["-m", str(resolved_model)])
         return cmd
 
+    def _codex_cli_tui_environment(self) -> dict[str, str]:
+        proxy_url = (self._config.codex_api_proxy or "").strip()
+        if not proxy_url:
+            for key in (
+                "HTTPS_PROXY",
+                "HTTP_PROXY",
+                "ALL_PROXY",
+                "https_proxy",
+                "http_proxy",
+                "all_proxy",
+            ):
+                value = os.environ.get(key)
+                if value:
+                    proxy_url = value.strip()
+                    break
+        if not proxy_url:
+            return {}
+        env = {
+            "HTTPS_PROXY": proxy_url,
+            "HTTP_PROXY": proxy_url,
+            "ALL_PROXY": proxy_url,
+            "https_proxy": proxy_url,
+            "http_proxy": proxy_url,
+            "all_proxy": proxy_url,
+        }
+        no_proxy_entries: list[str] = []
+        for raw in (os.environ.get("NO_PROXY") or os.environ.get("no_proxy") or "").split(","):
+            entry = raw.strip()
+            if entry and entry not in no_proxy_entries:
+                no_proxy_entries.append(entry)
+        for entry in ("localhost", "127.0.0.1", "::1"):
+            if entry not in no_proxy_entries:
+                no_proxy_entries.append(entry)
+        no_proxy = ",".join(no_proxy_entries)
+        env["NO_PROXY"] = no_proxy
+        env["no_proxy"] = no_proxy
+        return env
+
+    def _codex_cli_tui_shell_command(self, cmd: list[str]) -> str:
+        env = self._codex_cli_tui_environment()
+        if not env:
+            return " ".join(shlex.quote(part) for part in cmd)
+        env_parts = [shlex.quote(f"{key}={value}") for key, value in sorted(env.items())]
+        cmd_parts = [shlex.quote(part) for part in cmd]
+        return " ".join(["env", *env_parts, *cmd_parts])
+
     def _tmux_send_literal(self, tmux_name: str, text: str) -> None:
         subprocess.run(
             ["tmux", "send-keys", "-t", tmux_name, "-l", text],
@@ -1416,6 +1477,52 @@ class SkillsBenchLocalAcpRelay:
                 stderr=subprocess.DEVNULL,
                 text=True,
             )
+
+    def _wait_for_codex_cli_tui_ready(
+        self,
+        tmux_name: str,
+        *,
+        timeout_sec: float = 30.0,
+        settle_sec: float = 5.0,
+    ) -> bool:
+        """Wait until Codex TUI startup noise has settled before pasting /goal."""
+
+        deadline = time.monotonic() + max(1.0, float(timeout_sec or 0.0))
+        first_nonempty_at = 0.0
+        while time.monotonic() < deadline:
+            now = time.monotonic()
+            capture = self._tmux_capture(tmux_name)
+            lowered = capture.lower()
+            if not capture.strip():
+                time.sleep(0.5)
+                continue
+            if not first_nonempty_at:
+                first_nonempty_at = now
+            if self._codex_cli_tui_input_prompt_visible(capture):
+                return True
+            if any(
+                marker in lowered
+                for marker in (
+                    "what can i help",
+                    "ask codex",
+                    "message codex",
+                    "send a message",
+                    "type a message",
+                )
+            ):
+                return True
+            # Startup MCP warnings can occupy the TUI before the input box is
+            # ready. Seeing only those warnings is not enough; wait until the
+            # actual prompt marker appears.
+            time.sleep(0.5)
+        return False
+
+    def _codex_cli_tui_input_prompt_visible(self, capture: str) -> bool:
+        if not capture:
+            return False
+        if "›" in capture:
+            return True
+        return bool(re.search(r"(?m)^\\s*[>❯]\\s*(?:$|\\[)", capture))
 
     def _tmux_capture(self, tmux_name: str) -> str:
         proc = subprocess.run(
@@ -1493,6 +1600,10 @@ class SkillsBenchLocalAcpRelay:
                 "bridge_request_count": bridge_request_count,
                 "task_facing_success_count": task_facing_success_count,
                 "reasoning_effort": str(self._config.reasoning_effort or "")[:40],
+                "codex_api_proxy_env_injected": bool(
+                    self._codex_cli_tui_environment()
+                ),
+                "codex_api_proxy_raw_url_recorded": False,
                 "raw_tui_capture_recorded": False,
                 "raw_task_text_recorded": False,
                 "raw_stdout_recorded": False,

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -956,6 +956,13 @@ def _host_local_acp_launch_command(
             command.extend(["--worker-public-trace-dir", worker_trace_dir])
     elif args.route == CODEX_CLI_GOAL_BASELINE_ROUTE:
         command.extend(["--codex-cli-goal-worker"])
+        proxy_url, _proxy_source = _codex_api_reverse_tunnel_proxy(args)
+        if (
+            proxy_url
+            and args.host_local_acp_launch
+            and _codex_api_egress_resolved_mode(args) == "reverse-tunnel"
+        ):
+            command.extend(["--codex-api-proxy", proxy_url])
         if relay_trace_dir:
             command.extend(["--worker-public-trace-dir", relay_trace_dir])
     elif relay_trace_dir:
@@ -1207,7 +1214,10 @@ def _codex_api_egress_preflight_required(args: argparse.Namespace) -> bool:
     requested = _codex_api_egress_requested_mode(args)
     if requested in {"reverse-tunnel", "direct"}:
         return True
-    return getattr(args, "route", "") == "codex-app-server-goal-baseline"
+    return getattr(args, "route", "") in {
+        "codex-app-server-goal-baseline",
+        CODEX_CLI_GOAL_BASELINE_ROUTE,
+    }
 
 
 def _codex_api_egress_requested_mode(args: argparse.Namespace | None) -> str:
@@ -1224,9 +1234,12 @@ def _codex_api_egress_resolved_mode(args: argparse.Namespace | None) -> str:
         return "not_required"
     requested = _codex_api_egress_requested_mode(args)
     if requested == "auto":
-        # Formal remote app-server benchmark runs must use the reverse tunnel
-        # path by default; direct egress is only for explicit local debugging.
-        if getattr(args, "route", "") == "codex-app-server-goal-baseline":
+        # Formal remote Goal benchmark runs must use the reverse tunnel path by
+        # default; direct egress is only for explicit local debugging.
+        if getattr(args, "route", "") in {
+            "codex-app-server-goal-baseline",
+            CODEX_CLI_GOAL_BASELINE_ROUTE,
+        }:
             return "reverse-tunnel"
         return "not_required"
     return requested

--- a/scripts/skillsbench_local_acp_relay.py
+++ b/scripts/skillsbench_local_acp_relay.py
@@ -91,6 +91,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--codex-api-proxy",
+        default=None,
+        help=(
+            "Private HTTP proxy URL injected into the Codex CLI /goal process "
+            "environment. The raw URL must not be written to public compact "
+            "artifacts."
+        ),
+    )
+    parser.add_argument(
         "--response-timeout-sec",
         type=float,
         default=30.0,
@@ -228,6 +237,7 @@ def main(argv: list[str] | None = None) -> int:
             rollout_name=args.rollout_name,
             approval_policy=args.approval_policy,
             reasoning_effort=args.reasoning_effort,
+            codex_api_proxy=args.codex_api_proxy,
             response_timeout_sec=args.response_timeout_sec,
             worker_script=args.worker_script,
             stream_heartbeat_interval_sec=args.stream_heartbeat_interval_sec,


### PR DESCRIPTION
## Summary
- make `codex-cli-goal-baseline` a formal host-local Goal route with reverse-tunnel Codex API egress by default
- inject the private Codex API proxy into the actual Codex CLI TUI process launched under tmux, while keeping raw proxy URLs out of compact traces
- keep the deprecated app-server Goal route fail-closed and extend the CLI /goal smoke coverage

## Validation
- `python3 -m py_compile loopx/benchmark_adapters/skillsbench.py loopx/benchmark_adapters/skillsbench_acp_relay.py scripts/skillsbench_local_acp_relay.py scripts/skillsbench_automation_loop.py`
- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 examples/skillsbench-app-server-goal-worker-smoke.py`
- remote citation-check canary: `codex-cli-goal-baseline`, xhigh, `/goal` trace `goal_achieved`, bridge request/task-facing success 6/6, official score 1.0

## Boundary
- no raw task text, trajectories, verifier output, private proxy URL, or raw command/stdout/stderr are written to public compact artifacts
- raw proxy URL remains private runtime environment only
