### PR TITLE
Expose multi-agent role cycle gaps

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -340,6 +340,17 @@ def main() -> int:
         assert visible_loaded_collective["collective_round_count"] == 4, visible_loaded_collective
         assert visible_loaded_collective["full_participation_verified"] is False, visible_loaded_collective
         assert visible_loaded_collective["multi_round_research_verified"] is False, visible_loaded_collective
+        assert visible_loaded_collective["full_participation_count_basis"] == (
+            "synchronous_and_asynchronous"
+        ), visible_loaded_collective
+        assert visible_loaded_collective["full_participation_requirement_gap"][
+            "shortfall_by_agent"
+        ] == {
+            "evaluator-promoter": 4,
+            "hypothesis-proposer": 4,
+            "research-curator": 4,
+            "research-executor": 4,
+        }, visible_loaded_collective
         assert visible_loaded_collective["holdout_improvement_count"] == 1, visible_loaded_collective
         assert visible_loaded_wake["wakeup_model"] == "fixed_prompt_broadcast", visible_loaded_wake
         assert visible_loaded_wake["coordination_model"] == "decentralized_state_a2a", visible_loaded_wake
@@ -372,6 +383,14 @@ def main() -> int:
         assert visible_loaded_readiness["rounds"]["counts_as_collective_research_round"] is False, visible_loaded_readiness
         assert visible_loaded_readiness["collective_research_rounds"]["count"] == 4, visible_loaded_readiness
         assert visible_loaded_readiness["collective_research_rounds"]["holdout_improvement_count"] == 1, visible_loaded_readiness
+        assert visible_loaded_readiness["collective_research_rounds"][
+            "full_participation_requirement_gap"
+        ]["shortfall_by_agent"] == {
+            "evaluator-promoter": 4,
+            "hypothesis-proposer": 4,
+            "research-curator": 4,
+            "research-executor": 4,
+        }, visible_loaded_readiness
         loaded_improvement = visible_loaded_readiness["improvement_summary"]
         assert loaded_improvement["baseline_metric"] == 1.0, loaded_improvement
         assert loaded_improvement["dev_metric_sequence"] == [4.0], loaded_improvement
@@ -561,6 +580,7 @@ def main() -> int:
         assert kernel_ledger["expected_lane_count"] == 4, kernel_ledger
         assert kernel_ledger["collective_round_count"] == 4, kernel_ledger
         assert kernel_ledger["full_participation_round_count"] == 4, kernel_ledger
+        assert kernel_ledger["full_participation_requirement_gap"]["shortfall_by_agent"] == {}, kernel_ledger
         assert kernel_ledger["full_participation_verified"] is True, kernel_ledger
         assert kernel_ledger["multi_round_interaction_verified"] is True, kernel_ledger
         assert kernel_ledger["successor_todo_count"] >= 1, kernel_ledger
@@ -744,6 +764,11 @@ def main() -> int:
                 assert visible_readiness["collective_research_rounds"]["count"] >= 8, visible_readiness
                 assert visible_readiness["collective_research_rounds"]["multi_round_verified"] is False, visible_readiness
                 assert visible_readiness["collective_research_rounds"]["holdout_improvement_count"] == 2, visible_readiness
+                visible_gap = visible_readiness["collective_research_rounds"][
+                    "full_participation_requirement_gap"
+                ]
+                assert visible_gap["missing_agent_count"] >= 1, visible_readiness
+                assert visible_gap["shortfall_by_agent"], visible_readiness
                 improvement = visible_readiness["improvement_summary"]
                 assert improvement["baseline_metric"] == 1.0, improvement
                 assert improvement["dev_metric_sequence"] == [4.0, 4.8], improvement

--- a/examples/multi-agent-collective-round-ledger-smoke.py
+++ b/examples/multi-agent-collective-round-ledger-smoke.py
@@ -104,14 +104,26 @@ def main() -> int:
     assert ledger["coordination_model"] == "decentralized_state_a2a", ledger
     assert ledger["round_unit"] == "collective_agent_pass", ledger
     assert ledger["expected_lane_count"] == 2, ledger
+    assert ledger["expected_agent_ids"] == ["agent-a", "agent-b"], ledger
     assert ledger["lane_outcome_count"] == 4, ledger
     assert ledger["completed_lane_turn_count"] == 3, ledger
+    assert ledger["completed_turn_count_by_agent"] == {"agent-a": 1, "agent-b": 2}, ledger
     assert ledger["collective_round_indexes"] == [1, 2], ledger
     assert ledger["collective_round_count"] == 2, ledger
     assert ledger["full_participation_round_indexes"] == [1], ledger
     assert ledger["synchronous_full_participation_round_count"] == 1, ledger
     assert ledger["asynchronous_full_participation_round_count"] == 1, ledger
     assert ledger["full_participation_round_count"] == 1, ledger
+    assert ledger["full_participation_count_basis"] == "synchronous_and_asynchronous", ledger
+    assert ledger["full_participation_requirement_gap"] == {
+        "schema_version": "multi_agent_full_participation_gap_v0",
+        "required_count": 1,
+        "count_basis": "synchronous_and_asynchronous",
+        "completed_turn_count_by_agent": {"agent-a": 1, "agent-b": 2},
+        "shortfall_by_agent": {},
+        "missing_agent_count": 0,
+        "met": True,
+    }, ledger
     assert ledger["full_participation_verified"] is False, ledger
     assert ledger["multi_round_interaction_verified"] is True, ledger
     assert ledger["integrated_evidence"]["evidence_event_count"] == 3, ledger
@@ -123,6 +135,8 @@ def main() -> int:
     verification = ledger["collective_research_verification"]
     assert verification["schema_version"] == "multi_agent_collective_research_verification_v0"
     assert verification["baseline_metric"] == 1.0, ledger
+    assert verification["completed_turn_count_by_agent"] == {"agent-a": 1, "agent-b": 2}
+    assert verification["full_participation_requirement_gap"]["met"] is True
     assert verification["full_participation_requirement_met"] is True, ledger
     assert verification["holdout_improvement_requirement_met"] is True, ledger
     assert verification["verified"] is True, ledger
@@ -135,6 +149,65 @@ def main() -> int:
         "credentials_recorded": False,
     }, ledger
     assert_public_safe(ledger)
+
+    gap_ledger = build_multi_agent_collective_round_ledger(
+        source="smoke-gap",
+        expected_lanes=[
+            {"agent_id": "agent-a", "lane_id": "curator", "role_id": "research_curator"},
+            {"agent_id": "agent-b", "lane_id": "runner", "role_id": "research_executor"},
+        ],
+        lane_outcomes=[
+            {
+                "round": 1,
+                "agent_id": "agent-a",
+                "selected_todo_id": "todo_contract",
+                "selected_action": "write_research_contract",
+                "executed": True,
+                "completion_status": "done",
+            },
+            {
+                "round": 1,
+                "agent_id": "agent-b",
+                "selected_todo_id": "todo_dev",
+                "selected_action": "run_dev_eval",
+                "executed": True,
+                "completion_status": "done",
+            },
+            {
+                "round": 2,
+                "agent_id": "agent-a",
+                "selected_todo_id": "todo_review",
+                "selected_action": "review_research_contract",
+                "executed": True,
+                "completion_status": "done",
+            },
+            {
+                "round": 2,
+                "agent_id": "agent-b",
+                "executed": True,
+                "completion_status": "done",
+            },
+        ],
+        baseline_metric=1.0,
+        required_full_participation_round_count=2,
+    )
+    assert gap_ledger["completed_turn_count_by_agent"] == {
+        "agent-a": 2,
+        "agent-b": 1,
+    }, gap_ledger
+    assert gap_ledger["full_participation_round_count"] == 1, gap_ledger
+    gap = gap_ledger["full_participation_requirement_gap"]
+    assert gap["count_basis"] == "synchronous_and_asynchronous", gap_ledger
+    assert gap["shortfall_by_agent"] == {"agent-b": 1}, gap_ledger
+    assert gap["missing_agent_count"] == 1, gap_ledger
+    assert gap["met"] is False, gap_ledger
+    assert (
+        gap_ledger["collective_research_verification"][
+            "full_participation_requirement_met"
+        ]
+        is False
+    ), gap_ledger
+    assert_public_safe(gap_ledger)
     print("multi-agent-collective-round-ledger-smoke ok")
     return 0
 

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -451,6 +451,14 @@ def _build_collective_round_summary(
     ):
         full_participation_round_count = 0
     full_participation_verified = kernel_ledger.get("full_participation_verified") is True
+    full_participation_gap = (
+        kernel_ledger.get("full_participation_requirement_gap")
+        if isinstance(kernel_ledger.get("full_participation_requirement_gap"), dict)
+        else {}
+    )
+    full_participation_count_basis = str(
+        kernel_ledger.get("full_participation_count_basis") or ""
+    )
     multi_round_research_verified = (
         verification.get("verified") is True
         and verification.get("dev_metric_over_baseline") is True
@@ -472,6 +480,8 @@ def _build_collective_round_summary(
         "required_holdout_improvement_count": 2,
         "collective_round_count": collective_round_count,
         "full_participation_round_count": full_participation_round_count,
+        "full_participation_count_basis": full_participation_count_basis,
+        "full_participation_requirement_gap": full_participation_gap,
         "full_participation_verified": full_participation_verified,
         "evidence_stage_count": len(dev_sequence) + len(holdout_sequence),
         "multi_round_research_verified": multi_round_research_verified,
@@ -967,6 +977,15 @@ def _build_visible_readiness(payload: dict[str, object]) -> dict[str, object]:
                 "multi_round_research_verified"
             )
             is True,
+            "full_participation_round_count": collective_rounds.get(
+                "full_participation_round_count"
+            ),
+            "full_participation_count_basis": collective_rounds.get(
+                "full_participation_count_basis"
+            ),
+            "full_participation_requirement_gap": collective_rounds.get(
+                "full_participation_requirement_gap"
+            ),
             "stages": collective_rounds.get("stages") or [],
             "holdout_improvement_count": holdout_improvement_count,
         },

--- a/loopx/capabilities/auto_research/human_view.py
+++ b/loopx/capabilities/auto_research/human_view.py
@@ -114,6 +114,11 @@ def _render_collective_round_summary(
 
     completed_turns = worker_loop.get("completed_turn_count")
     expected_turns = kernel.get("lane_outcome_count")
+    participation_gap = (
+        collective_rounds.get("full_participation_requirement_gap")
+        if isinstance(collective_rounds.get("full_participation_requirement_gap"), dict)
+        else {}
+    )
     lines = [
         "",
         "## Collective Rounds / 集体研究轮次",
@@ -122,7 +127,12 @@ def _render_collective_round_summary(
             f"- verified: `{collective_rounds.get('multi_round_research_verified')}`; "
             f"rounds: `{collective_rounds.get('collective_round_count')}`; "
             f"full_participation_rounds: `{collective_rounds.get('full_participation_round_count')}`; "
+            f"basis: `{collective_rounds.get('full_participation_count_basis')}`; "
             f"completed_turns: `{completed_turns}/{expected_turns}`"
+        ),
+        (
+            f"- role_cycle_gap: `{participation_gap.get('shortfall_by_agent') or {}}` "
+            f"(required `{participation_gap.get('required_count')}`)"
         ),
         (
             f"- dev_metric_sequence: `{_metric_sequence(collective_rounds.get('dev_metric_sequence'))}`; "
@@ -440,6 +450,12 @@ def _render_demo_e2e(payload: dict[str, object]) -> str:
         if isinstance(readiness.get("improvement_summary"), dict)
         else {}
     )
+    participation_gap = (
+        collective_rounds.get("full_participation_requirement_gap")
+        if isinstance(collective_rounds.get("full_participation_requirement_gap"), dict)
+        else {}
+    )
+    role_cycle_shortfall = participation_gap.get("shortfall_by_agent") or {}
     lines = [
         "# LoopX Auto Research Minimal E2E Demo",
         "",
@@ -472,6 +488,7 @@ def _render_demo_e2e(payload: dict[str, object]) -> str:
         f"- pane_ticks_count_as_research_rounds: `{pane_rounds.get('counts_as_collective_research_round')}`",
         f"- collective_research_rounds: `{collective_rounds.get('collective_round_count')}`",
         f"- collective_research_rounds_verified: `{collective_rounds.get('multi_round_research_verified')}`",
+        f"- collective_research_role_cycle_gap: `{role_cycle_shortfall}`",
         f"- holdout_metric_sequence: `{collective_rounds.get('holdout_metric_sequence')}`",
         f"- holdout_improvement_count: `{collective_rounds.get('holdout_improvement_count')}`",
         f"- decentralized_a2a_rounds_verified: `{live.get('decentralized_a2a_rounds_verified')}`",

--- a/loopx/capabilities/multi_agent/collective_round_ledger.py
+++ b/loopx/capabilities/multi_agent/collective_round_ledger.py
@@ -217,6 +217,23 @@ def _normalize_successor(todo: Mapping[str, object]) -> dict[str, object]:
     }
 
 
+def _sorted_count_map(counts: Mapping[str, int]) -> dict[str, int]:
+    return {key: int(counts.get(key, 0)) for key in sorted(counts)}
+
+
+def _full_participation_count_basis(
+    *,
+    synchronous_count: int,
+    asynchronous_count: int,
+    effective_count: int,
+) -> str:
+    if effective_count == synchronous_count == asynchronous_count:
+        return "synchronous_and_asynchronous"
+    if effective_count == asynchronous_count:
+        return "asynchronous_role_cycle"
+    return "synchronous_round_index"
+
+
 def build_multi_agent_collective_round_ledger(
     *,
     source: str,
@@ -259,6 +276,7 @@ def build_multi_agent_collective_round_ledger(
         for lane in lanes
         if str(lane.get("agent_id") or "").strip()
     }
+    expected_agent_id_list = sorted(expected_agent_ids)
     completed_agents_by_round: dict[int, set[str]] = {}
     completed_turn_count_by_agent: dict[str, int] = {}
     for outcome in completed_outcomes:
@@ -281,9 +299,15 @@ def build_multi_agent_collective_round_ledger(
         if expected_agent_ids
         else 0
     )
+    synchronous_full_participation_round_count = len(full_participation_round_indexes)
     effective_full_participation_round_count = max(
-        len(full_participation_round_indexes),
+        synchronous_full_participation_round_count,
         asynchronous_full_participation_round_count,
+    )
+    count_basis = _full_participation_count_basis(
+        synchronous_count=synchronous_full_participation_round_count,
+        asynchronous_count=asynchronous_full_participation_round_count,
+        effective_count=effective_full_participation_round_count,
     )
     evidence_event_count = _int_or_none(evidence.get("evidence_event_count"))
     if evidence_event_count is None:
@@ -329,6 +353,30 @@ def build_multi_agent_collective_round_ledger(
         if full_rounds_required is None
         else effective_full_participation_round_count >= full_rounds_required
     )
+    completed_turn_counts = _sorted_count_map(
+        {
+            agent_id: completed_turn_count_by_agent.get(agent_id, 0)
+            for agent_id in expected_agent_id_list
+        }
+    )
+    full_round_shortfall_by_agent = (
+        {}
+        if full_rounds_required is None
+        else {
+            agent_id: full_rounds_required - count
+            for agent_id, count in completed_turn_counts.items()
+            if count < full_rounds_required
+        }
+    )
+    full_participation_requirement_gap = {
+        "schema_version": "multi_agent_full_participation_gap_v0",
+        "required_count": full_rounds_required,
+        "count_basis": count_basis,
+        "completed_turn_count_by_agent": completed_turn_counts,
+        "shortfall_by_agent": full_round_shortfall_by_agent,
+        "missing_agent_count": len(full_round_shortfall_by_agent),
+        "met": full_round_requirement_met,
+    }
     holdout_improvement_requirement_met = (
         None
         if holdout_improvements_required is None
@@ -355,17 +403,21 @@ def build_multi_agent_collective_round_ledger(
         ),
         "expected_lanes": lanes,
         "expected_lane_count": len(lanes),
+        "expected_agent_ids": expected_agent_id_list,
         "lane_outcomes": outcomes,
         "lane_outcome_count": len(outcomes),
         "completed_lane_turn_count": len(completed_outcomes),
+        "completed_turn_count_by_agent": completed_turn_counts,
         "collective_round_indexes": round_indexes,
         "collective_round_count": len(round_indexes),
         "full_participation_round_indexes": full_participation_round_indexes,
-        "synchronous_full_participation_round_count": len(full_participation_round_indexes),
+        "synchronous_full_participation_round_count": synchronous_full_participation_round_count,
         "asynchronous_full_participation_round_count": (
             asynchronous_full_participation_round_count
         ),
         "full_participation_round_count": effective_full_participation_round_count,
+        "full_participation_count_basis": count_basis,
+        "full_participation_requirement_gap": full_participation_requirement_gap,
         "full_participation_verified": (
             bool(round_indexes)
             and len(full_participation_round_indexes) == len(round_indexes)
@@ -394,6 +446,9 @@ def build_multi_agent_collective_round_ledger(
             "asynchronous_full_participation_round_count": (
                 asynchronous_full_participation_round_count
             ),
+            "full_participation_count_basis": count_basis,
+            "completed_turn_count_by_agent": completed_turn_counts,
+            "full_participation_requirement_gap": full_participation_requirement_gap,
             "full_participation_requirement_met": full_round_requirement_met,
             "dev_metric_over_baseline": (
                 None


### PR DESCRIPTION
## Summary
- expose per-agent productive turn counts and full-participation shortfalls in the generic multi-agent collective-round ledger
- surface the role-cycle gap through auto-research visible readiness and markdown summaries without adding an auto-research-specific coordinator
- extend ledger and auto-research demo smokes so no-op pane ticks cannot be mistaken for productive research rounds

## Validation
- PYTHONPATH=. python3 examples/multi-agent-collective-round-ledger-smoke.py
- PYTHONPATH=. python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- PYTHONPATH=. python3 -m compileall -q loopx/capabilities/multi_agent/collective_round_ledger.py loopx/capabilities/auto_research/demo_e2e.py loopx/capabilities/auto_research/human_view.py examples/multi-agent-collective-round-ledger-smoke.py examples/auto-research-demo-e2e-worker-loop-smoke.py
- PYTHONPATH=. python3 -m loopx.cli check --scan-path loopx/capabilities/multi_agent/collective_round_ledger.py --scan-path loopx/capabilities/auto_research/demo_e2e.py --scan-path loopx/capabilities/auto_research/human_view.py --scan-path examples/multi-agent-collective-round-ledger-smoke.py --scan-path examples/auto-research-demo-e2e-worker-loop-smoke.py

LoopX check warning is the pre-existing loopx-meta duplicate index rows warning; candidate file public-boundary scan is clean.