### PR TITLE
Keep auto-research agents role-named

### DIFF
--- a/docs/reference/protocols/auto-research-lane-contract-v1.md
+++ b/docs/reference/protocols/auto-research-lane-contract-v1.md
@@ -43,7 +43,7 @@ kernel API, but it must remain public-safe.
   "schema_version": "auto_research_lane_claim_v1",
   "goal_id": "loopx-auto-research-demo",
   "lane_role": "research_executor",
-  "agent_id": "codex-side-bypass",
+  "agent_id": "research-executor",
   "todo_id": "todo_auto_research_demo_001",
   "hypothesis_id": "hyp_state_a2a_round",
   "capability_token": "research_executor",
@@ -83,7 +83,7 @@ projection builders derive frontiers and product views afterward.
 Successor work should stay equally small. A role profile may declare a
 `successor_todos` rule such as "after `run_dev_eval`, if dev evidence is
 supported and no holdout exists, add `run_holdout_eval` for
-`codex-main-control`." The pane-local tick applies that declaration by writing a
+`research-executor`." The pane-local tick applies that declaration by writing a
 normal LoopX todo with `claimed_by`, `action_kind`, and `unblocks_todo_id`.
 The next agent still re-enters through its own `quota should-run` and frontier;
 there is no separate continuation projector or central research manager.

--- a/docs/reference/protocols/decentralized-auto-research-state-v0.md
+++ b/docs/reference/protocols/decentralized-auto-research-state-v0.md
@@ -96,8 +96,8 @@ agent.
   "hypothesis_id": "hyp_0004",
   "parent_hypothesis_id": "hyp_0002",
   "todo_id": "todo_123",
-  "lane_id": "agent:codex-side-bypass",
-  "claimed_by": "codex-side-bypass",
+  "lane_id": "agent:research-executor",
+  "claimed_by": "research-executor",
   "mechanism_family": "vectorized_distance_kernel",
   "hypothesis": "Batch query points through a shared index to reduce per-query overhead.",
   "status": "active",
@@ -129,7 +129,7 @@ Status vocabulary:
   "goal_id": "loopx-meta",
   "hypothesis_id": "hyp_0004",
   "todo_id": "todo_123",
-  "agent_id": "codex-side-bypass",
+  "agent_id": "research-executor",
   "attempt": 1,
   "split": "dev",
   "metric": {"name": "speedup", "value": 11.4, "direction": "maximize"},
@@ -175,7 +175,7 @@ carry source refs and remain recomputable from source state.
 {
   "schema_version": "decentralized_research_frontier_v0",
   "goal_id": "loopx-meta",
-  "agent_id": "codex-side-bypass",
+  "agent_id": "research-executor",
   "selected": {
     "hypothesis_id": "hyp_0004",
     "todo_id": "todo_123",
@@ -185,7 +185,7 @@ carry source refs and remain recomputable from source state.
   "blocked": [
     {
       "hypothesis_id": "hyp_0002",
-      "blocked_by": "claimed_by:codex-product-capability",
+      "blocked_by": "claimed_by:research-curator",
       "visible_as_context": true
     }
   ],

--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -40,6 +40,10 @@ def main() -> int:
     sys.path.insert(0, str(REPO_ROOT))
     from loopx.capabilities.auto_research.demo_e2e import run_auto_research_demo_e2e
     from loopx.capabilities.auto_research.human_view import render_auto_research_markdown
+    from loopx.capabilities.auto_research.preset import (
+        auto_research_role_id,
+        default_auto_research_agent_specs,
+    )
 
     launcher_source = (REPO_ROOT / "loopx/visible_multi_agent_launcher.py").read_text(
         encoding="utf-8"
@@ -70,6 +74,28 @@ def main() -> int:
     assert "title_by_action" not in demo_e2e_source
     assert "AUTO_RESEARCH_DEFAULT_LANES" in preset_source
     assert "AUTO_RESEARCH_SEED_TITLES" in preset_source
+    assert "codex-product-capability" not in preset_source
+    assert "codex-side-bypass" not in preset_source
+    assert "codex-main-control" not in preset_source
+    assert "codex-value-explorer" not in preset_source
+    assert default_auto_research_agent_specs() == [
+        "research-curator:research-curator:research_curator",
+        "hypothesis-proposer:hypothesis-proposer:hypothesis_proposer",
+        "research-executor:research-executor:research_executor",
+        "evaluator-promoter:evaluator-promoter:evaluator_promoter",
+    ]
+    for legacy_agent_id in (
+        "codex-product-capability",
+        "codex-side-bypass",
+        "codex-main-control",
+        "codex-value-explorer",
+    ):
+        try:
+            auto_research_role_id(legacy_agent_id, index=1)
+        except ValueError as exc:
+            assert "unknown auto-research role_id" in str(exc), exc
+        else:
+            raise AssertionError(f"legacy agent id accepted as auto-research role: {legacy_agent_id}")
 
     worker_markdown = render_auto_research_markdown(
         {

--- a/loopx/capabilities/auto_research/preset.py
+++ b/loopx/capabilities/auto_research/preset.py
@@ -151,26 +151,22 @@ AUTO_RESEARCH_ROLE_PROFILE_ORDER = (
 AUTO_RESEARCH_ROLE_PROFILE_ALIASES = {
     "research-curator": "research_curator",
     "curator": "research_curator",
-    "codex-product-capability": "research_curator",
     "hypothesis-proposer": "hypothesis_proposer",
     "hypothesis_mapper": "hypothesis_proposer",
     "hypothesis-mapper": "hypothesis_proposer",
     "mapper": "hypothesis_proposer",
     "hypothesis-runner": "hypothesis_proposer",
-    "codex-side-bypass": "hypothesis_proposer",
     "research-executor": "research_executor",
     "research_executor": "research_executor",
     "evidence_runner": "research_executor",
     "evidence-runner": "research_executor",
     "runner": "research_executor",
-    "codex-main-control": "research_executor",
     "evaluator-promoter": "evaluator_promoter",
     "evaluator_promoter": "evaluator_promoter",
     "evidence_verifier": "evaluator_promoter",
     "evidence-verifier": "evaluator_promoter",
     "verifier": "evaluator_promoter",
     "evidence-promoter": "evaluator_promoter",
-    "codex-value-explorer": "evaluator_promoter",
 }
 
 AUTO_RESEARCH_ROLE_PROFILES: dict[str, dict[str, object]] = {


### PR DESCRIPTION
## Summary
- remove legacy `codex-*` aliases from auto-research role resolution so the preset uses research-role agent ids directly
- extend the durable auto-research worker-loop smoke to reject those legacy aliases and assert the four default research-role specs
- update auto-research protocol examples to use `research-curator`, `hypothesis-proposer`, `research-executor`, and `evaluator-promoter` as agent ids

## Validation
- `PYTHONPATH=. python3 examples/auto-research-demo-e2e-worker-loop-smoke.py`
- `PYTHONPATH=. python3 examples/multi-agent-collective-round-ledger-smoke.py`
- `PYTHONPATH=. python3 -m compileall -q loopx/capabilities/auto_research/preset.py`
- `git diff --check`
- `PYTHONPATH=. python3 -m loopx.cli check --scan-path loopx/capabilities/auto_research/preset.py --scan-path examples/auto-research-demo-e2e-worker-loop-smoke.py --scan-path docs/reference/protocols/auto-research-lane-contract-v1.md --scan-path docs/reference/protocols/decentralized-auto-research-state-v0.md`
- `PYTHONPATH=. python3 -m loopx.cli --format json auto-research start 'KNN demo：用中文验证 partial selection 是否优于 full sort' --language zh --execute --headless | jq '{ok, output_language: .user_contract.output_language.resolved, execution_kind, collective_round_count: .collective_research_rounds.collective_round_count, full_participation_round_count: .collective_research_rounds.full_participation_round_count, completed_turn_count_by_agent: .collective_research_rounds.full_participation_requirement_gap.completed_turn_count_by_agent, holdout_metric_sequence: .collective_research_rounds.holdout_metric_sequence, holdout_improvement_count: .collective_research_rounds.holdout_improvement_count, default_specs: .user_contract.minimal_a2a_recipe.preset_recipe_lines}'`

## Boundary
- no private state, credentials, raw logs, local paths, or generated artifacts committed
- `loopx check` public boundary scan is clean for all changed files
- repo warning about run-history duplicate index rows is pre-existing and unrelated
