### PR TITLE
Allow monitor heartbeat backoff to reach 120 minutes

### DIFF
--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -729,6 +729,9 @@ After a successful host RRULE update, the agent records that fact with
 which lets LoopX advance the per goal/agent scheduler state without spending
 quota. Human gates can move to `[30, 60, 120]` after the concrete user todo has
 been surfaced.
+Monitor-only quiet waits move through `[15, 30, 60, 120]` while preserving the
+same no-spend monitor-poll contract, unless a monitor cadence or due time caps
+the progression earlier.
 Agent-scope waits use a more conservative adjustment curve such as
 `[10, 20, 30, 60]`, so a 600-second local tick stays close to the existing
 agent-to-agent interaction cadence before cooling further.

--- a/examples/control_plane/quota-scheduler-policy-smoke.py
+++ b/examples/control_plane/quota-scheduler-policy-smoke.py
@@ -203,6 +203,7 @@ def main() -> int:
         ),
         expected_action="backoff_until_material_transition",
         expected_rrule="FREQ=MINUTELY;INTERVAL=15",
+        expected_progression=[15, 30, 60, 120],
     )
     assert_policy_case(
         "quiet-wait",

--- a/examples/control_plane/quota-scheduler-state-ack-smoke.py
+++ b/examples/control_plane/quota-scheduler-state-ack-smoke.py
@@ -61,6 +61,33 @@ def payload(*, recommended_action: str = "Wait for reassignment.") -> dict:
     }
 
 
+def monitor_payload(*, recommended_action: str = "Wait for material monitor evidence.") -> dict:
+    return {
+        "goal_id": "scheduler-state-ack-smoke",
+        "agent_identity": {"agent_id": "codex-side-agent"},
+        "should_run": False,
+        "effective_action": "monitor_quiet_skip",
+        "recommended_action": recommended_action,
+        "heartbeat_recommendation": {
+            "recommended_mode": "monitor_quiet_until_material_transition",
+            "notify": "DONT_NOTIFY",
+            "spend_policy": "no spend while the monitor target is unchanged",
+        },
+        "execution_obligation": {
+            "must_attempt_work": False,
+            "spend_policy": "do not spend",
+        },
+        "automation_liveness": {
+            "automation_action": "keep_active_quiet",
+            "spend_policy": "no quota spend for unchanged monitor-only polls",
+        },
+        "interaction_contract": {
+            "mode": "monitor_quiet_skip",
+            "user_channel": {"action_required": False},
+        },
+    }
+
+
 def active_payload() -> dict:
     return {
         "goal_id": "scheduler-state-ack-smoke",
@@ -164,6 +191,47 @@ def assert_policy_state_progression() -> None:
     )
     assert reset["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=10", reset
     assert reset["codex_app"]["stateful_backoff"]["state_status"] == "reset_required", reset
+
+
+def assert_monitor_wait_progression_reaches_120() -> None:
+    base = monitor_payload()
+    first = build_scheduler_hint(
+        deepcopy(base),
+        agent_scope_frontier_actions=AGENT_SCOPE_ACTIONS,
+    )
+    assert first["action"] == "backoff_until_material_transition", first
+    assert first["codex_app"]["example_progression_minutes"] == [15, 30, 60, 120], first
+    assert first["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=15", first
+
+    second = build_scheduler_hint(
+        deepcopy(base),
+        agent_scope_frontier_actions=AGENT_SCOPE_ACTIONS,
+        codex_app_scheduler_state=state_from(first),
+    )
+    assert second["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=30", second
+
+    third = build_scheduler_hint(
+        deepcopy(base),
+        agent_scope_frontier_actions=AGENT_SCOPE_ACTIONS,
+        codex_app_scheduler_state=state_from(second),
+    )
+    assert third["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=60", third
+
+    fourth = build_scheduler_hint(
+        deepcopy(base),
+        agent_scope_frontier_actions=AGENT_SCOPE_ACTIONS,
+        codex_app_scheduler_state=state_from(third),
+    )
+    assert fourth["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=120", fourth
+
+    quiet = build_scheduler_hint(
+        deepcopy(base),
+        agent_scope_frontier_actions=AGENT_SCOPE_ACTIONS,
+        codex_app_scheduler_state=state_from(fourth),
+    )
+    assert quiet["codex_app"]["stateful_backoff"]["apply_needed"] is False, quiet
+    assert quiet["codex_app"]["host_action"] == "none", quiet
+    assert "recommended_rrule" not in quiet["codex_app"], quiet
 
 
 def assert_active_work_keeps_initial_cadence() -> None:
@@ -409,6 +477,7 @@ def assert_cli_scheduler_ack_uses_should_run_lookback() -> None:
 
 def main() -> int:
     assert_policy_state_progression()
+    assert_monitor_wait_progression_reaches_120()
     assert_active_work_keeps_initial_cadence()
     assert_cli_scheduler_ack_progression()
     assert_cli_scheduler_ack_uses_should_run_lookback()

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -22,6 +22,7 @@ SCHEDULER_RESET_POLICY_SCHEMA_VERSION = "scheduler_reset_policy_v0"
 SCHEDULER_HINT_DETAIL_SCHEMA_VERSION = "scheduler_hint_detail_v0"
 CODEX_APP_STATEFUL_BACKOFF_SCHEMA_VERSION = "codex_app_stateful_backoff_v0"
 MONITOR_CADENCE_PATTERN = re.compile(r"^\s*(\d+)\s*([mhd])\s*$", re.IGNORECASE)
+MONITOR_WAIT_PROGRESSION_MINUTES = [15, 30, 60, 120]
 
 
 def normalize_scheduler_rrule(value: Any) -> str:
@@ -126,7 +127,7 @@ def _monitor_wait_cadence_progression(payload: dict[str, Any]) -> list[int] | No
     if not caps:
         return None
     cap = max(1, min(caps))
-    return [min(interval, cap) for interval in (15, 30, 60)]
+    return [min(interval, cap) for interval in MONITOR_WAIT_PROGRESSION_MINUTES]
 
 
 def build_codex_app_scheduler_ack_event(
@@ -619,10 +620,12 @@ def build_scheduler_hint(
                 "cadence until material evidence, a blocker, or replan obligation appears"
             ),
             codex_interval=15,
-            codex_max=60,
+            codex_max=120,
             cli_limit=3,
             claude_limit=3,
-            cadence_progression_override=monitor_progression,
+            cadence_progression_override=(
+                monitor_progression or MONITOR_WAIT_PROGRESSION_MINUTES
+            ),
         )
 
     if payload.get("should_run") is False:


### PR DESCRIPTION
## Summary
- extend Codex App monitor-only quiet heartbeat backoff from `[15, 30, 60]` to `[15, 30, 60, 120]`
- keep agent-scope wait cadence unchanged at `[10, 20, 30, 60]`
- document the monitor wait cadence and add focused scheduler state coverage so the fourth same-identity ack emits 120 minutes before quieting

## Validation
- `python3 examples/control_plane/quota-scheduler-policy-smoke.py`
- `python3 examples/control_plane/quota-scheduler-state-ack-smoke.py`
- `python3 examples/control_plane/quota-scheduler-hint-compaction-smoke.py`
- `python3 examples/control_plane/quota-plan-smoke.py`
- `python3 -m py_compile loopx/control_plane/scheduler/scheduler_hint.py examples/control_plane/quota-scheduler-policy-smoke.py examples/control_plane/quota-scheduler-state-ack-smoke.py`
- `git diff --check`

## Boundary
Public scheduler/runtime contract change only. No private state, credentials, raw logs, local paths, benchmark trajectories, or production actions.
