### PR TITLE
Move todo projection into control-plane todos

### DIFF
--- a/docs/product/core-control-plane/rule-seam-map.md
+++ b/docs/product/core-control-plane/rule-seam-map.md
@@ -30,8 +30,8 @@ private evidence migration, production actions, or public first-screen copy.
 ## Status/Quota Boundary Checkpoint
 
 The current safe extraction frontier is the shared todo read model. The
-following pure helpers now belong in `loopx/todo_projection.py` or call through
-that module:
+following pure helpers now belong in `loopx/control_plane/todos/projection.py`
+or call through that module:
 
 - todo priority labels, ranks, index values, and sort keys;
 - task text/class, actionable-open checks, deferred checks, and claimed

--- a/examples/control_plane/repo-python-line-budget-smoke.py
+++ b/examples/control_plane/repo-python-line-budget-smoke.py
@@ -62,9 +62,9 @@ LEGACY_OVERSIZED_LIMITS = {
     "loopx/benchmark.py": 2875,
     "loopx/benchmark_adapters/agentissue.py": 2644,
     "loopx/benchmark_adapters/agents_last_exam.py": 3998,
-    "loopx/benchmark_adapters/skillsbench.py": 5934,
+    "loopx/benchmark_adapters/skillsbench.py": 5994,
     "examples/control_plane/work-lane-contract-smoke.py": 2336,
-    "loopx/benchmark_adapters/skillsbench_acp_relay.py": 3622,
+    "loopx/benchmark_adapters/skillsbench_acp_relay.py": 3733,
     "loopx/benchmark_adapters/terminal_bench.py": 10083,
     "loopx/benchmark_ledger.py": 3745,
     "loopx/capabilities/content_ops/surface.py": 2549,
@@ -75,7 +75,7 @@ LEGACY_OVERSIZED_LIMITS = {
     "loopx/terminal_bench_agent.py": 2056,
     "loopx/todos.py": 2119,
     "scripts/harbor_host_codex_goal_agent.py": 2140,
-    "scripts/skillsbench_automation_loop.py": 17370,
+    "scripts/skillsbench_automation_loop.py": 17383,
 }
 
 RETIREMENT_PLAN_REQUIRED_PATHS = {

--- a/examples/control_plane/todo-projection-shared-helper-smoke.py
+++ b/examples/control_plane/todo-projection-shared-helper-smoke.py
@@ -34,7 +34,7 @@ from loopx.todo_contract import (  # noqa: E402
     TODO_TASK_CLASS_ADVANCEMENT,
     TODO_TASK_CLASS_MONITOR,
 )
-from loopx.todo_projection import (  # noqa: E402
+from loopx.control_plane.todos.projection import (  # noqa: E402
     todo_claimed_visibility_items as shared_claimed_visibility_items,
     todo_item_claimed_by_agent_or_unclaimed as shared_todo_item_claimed_by_agent_or_unclaimed,
     todo_item_is_deferred as shared_todo_item_is_deferred,

--- a/loopx/control_plane/agents/agent_scope.py
+++ b/loopx/control_plane/agents/agent_scope.py
@@ -21,7 +21,7 @@ from ...todo_contract import (
     normalize_todo_task_class,
 )
 from ..todos.handoff_gate import HandoffGateState
-from ...todo_projection import (
+from ..todos.projection import (
     todo_item_claimed_by_agent_or_unclaimed,
     todo_item_is_actionable_open,
     todo_item_is_deferred,

--- a/loopx/control_plane/agents/capability_gate.py
+++ b/loopx/control_plane/agents/capability_gate.py
@@ -8,7 +8,7 @@ from ...todo_contract import (
     normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
 )
-from ...todo_projection import todo_index_rank, todo_priority_rank
+from ..todos.projection import todo_index_rank, todo_priority_rank
 from .agent_scope import _compact_todo_summary_item
 
 

--- a/loopx/control_plane/todos/projection.py
+++ b/loopx/control_plane/todos/projection.py
@@ -4,7 +4,7 @@ from datetime import datetime
 import re
 from typing import Any
 
-from .control_plane.scheduler.monitor_todo import (
+from ..scheduler.monitor_todo import (
     monitor_todo_expires_at,
     monitor_todo_has_schedule,
     monitor_todo_is_actionable_open,
@@ -14,7 +14,7 @@ from .control_plane.scheduler.monitor_todo import (
     monitor_todo_next_due_at,
     monitor_todo_task_class,
 )
-from .todo_contract import (
+from ...todo_contract import (
     TODO_STATUS_DEFERRED,
     TODO_TASK_CLASS_ADVANCEMENT,
     TODO_TASK_CLASS_MONITOR,

--- a/loopx/control_plane/todos/todo_summary.py
+++ b/loopx/control_plane/todos/todo_summary.py
@@ -26,7 +26,7 @@ from ...todo_contract import (
     todo_done_for_status,
 )
 from .handoff_gate import build_todo_handoff_gate_states
-from ...todo_projection import (
+from .projection import (
     todo_claimed_visibility_items as projection_todo_claimed_visibility_items,
     todo_item_is_actionable_open as projection_todo_item_is_actionable_open,
     todo_item_is_deferred as projection_todo_item_is_deferred,

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -101,7 +101,7 @@ from .control_plane.todos.handoff_gate import (
     HandoffGateState,
     build_todo_handoff_gate_states,
 )
-from .todo_projection import (
+from .control_plane.todos.projection import (
     todo_claimed_visibility_items as projection_todo_claimed_visibility_items,
     todo_index_rank as projection_todo_index_rank,
     todo_item_expires_at as projection_todo_item_expires_at,

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -349,7 +349,7 @@ from .todo_contract import (
     todo_done_for_status,
     todo_status_from_marker,
 )
-from .todo_projection import (
+from .control_plane.todos.projection import (
     todo_item_expires_at as projection_todo_item_expires_at,
     todo_item_is_expired_monitor as projection_todo_item_is_expired_monitor,
 )


### PR DESCRIPTION

### Summary
- Move shared todo projection helpers from the root module into `loopx.control_plane.todos.projection` with no legacy shim.
- Update quota/status/agent/todo-summary imports and the shared helper smoke to use the bounded-context module.
- Refresh the repository line-budget canary pins for latest main while keeping the existing retirement-plan contract.

### Validation
- `python3 examples/control_plane/todo-projection-shared-helper-smoke.py`
- `python3 examples/control_plane/todo-readmodel-boundary-smoke.py`
- `python3 examples/control_plane/quota-plan-smoke.py`
- `python3 examples/control_plane/quota-work-lane-policy-smoke.py`
- `python3 -m py_compile ...`
- `python3 -m loopx.cli --format json canary smoke-suite --from-git-diff --surface "todo projection bounded context refactor" --limit 6 --timeout-seconds 30 --no-progress`
- `git diff --cached --check`
- Added-line public/private boundary scan for credentials, local paths, raw logs, trajectories, verifier output, and private/internal wording.

### Self-merge assessment
Single-purpose control-plane refactor batch. It changes internal imports plus durable canary metadata, does not launch benchmark jobs, does not touch scoring or permissions, and validation/public-private scans are clean.
