### PR TITLE
Slim auto-research start defaults

### DIFF
--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -927,7 +927,6 @@ def handle_auto_research_command(
                 agent_id=AUTO_RESEARCH_START_AGENT_ID,
                 goal_id=goal_id,
                 goal_surface_mode=goal_surface_mode,
-                agent_specs=[],
                 tracking_goal_id=args.tracking_goal_id,
                 objective=args.open_question,
                 output_dir="auto_research_lightweight_kernel",


### PR DESCRIPTION
## Summary
- remove the explicit empty agent_specs override from auto-research start
- let the shared demo-e2e runner inject default research-role specs for visible/headless execution
- keep start as a thin one-question entrypoint instead of a separate role-default branch

## Validation
- python3 -m py_compile loopx/capabilities/auto_research/cli.py loopx/capabilities/auto_research/demo_e2e.py
- PYTHONPATH=. python3 examples/auto-research-user-contract-entry-smoke.py
- PYTHONPATH=. python3 examples/auto-research-start-markdown-commands-smoke.py
- PYTHONPATH=. python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- git diff --check
- loopx check --scan-path loopx/capabilities/auto_research/cli.py --limit 20

## Boundary
- Changed path: loopx/capabilities/auto_research/cli.py
- No untracked artifacts staged
- Public/private scan clean for the touched file
- Existing LoopX run-history duplicate-index warning is unrelated to this PR