### PR TITLE
Move task lease into work-items bounded context

### DIFF
--- a/examples/canary/catalog-planner-smoke.py
+++ b/examples/canary/catalog-planner-smoke.py
@@ -68,6 +68,7 @@ def assert_profiles_come_from_catalog_matrix() -> None:
     state_write_commands = [
         check["command"] for check in domain_profiles["state-write-correctness"]["checks"]
     ]
+    assert "python3 examples/control_plane/task-lease-runtime-smoke.py" in state_write_commands
     assert "python3 examples/control_plane/todo-write-correctness-smoke.py" in state_write_commands
 
 

--- a/examples/control_plane/bounded-context-namespace-smoke.py
+++ b/examples/control_plane/bounded-context-namespace-smoke.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Guard repo-local control-plane code against legacy projection shims."""
+"""Guard repo-local control-plane code against legacy root/shim namespaces."""
 
 from __future__ import annotations
 
@@ -10,6 +10,9 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 LEGACY_IMPORT = "loopx.projections"
 LEGACY_PACKAGE_PREFIX = "loopx/projections/"
+LEGACY_ROOT_MODULES = {
+    "loopx/task_lease.py": "loopx.control_plane.work_items.task_lease",
+}
 TEXT_SUFFIXES = {".py", ".md"}
 SKIP_DIRS = {"__pycache__", ".git", ".pytest_cache"}
 
@@ -74,6 +77,16 @@ def assert_no_tracked_legacy_projection_package() -> None:
     )
 
 
+def assert_moved_root_modules_stay_in_bounded_contexts() -> None:
+    files = set(tracked_files())
+    offenders = sorted(path for path in LEGACY_ROOT_MODULES if path in files)
+    assert offenders == [], {
+        "reason": "moved root control-plane modules should stay in their owning bounded contexts",
+        "offenders": offenders,
+        "expected_modules": {path: LEGACY_ROOT_MODULES[path] for path in offenders},
+    }
+
+
 def assert_repo_local_imports_use_bounded_contexts() -> None:
     offenders: list[str] = []
     for path in tracked_text_files():
@@ -91,6 +104,7 @@ def assert_repo_local_imports_use_bounded_contexts() -> None:
 
 def main() -> int:
     assert_no_tracked_legacy_projection_package()
+    assert_moved_root_modules_stay_in_bounded_contexts()
     assert_repo_local_imports_use_bounded_contexts()
     print("bounded-context-namespace-smoke ok")
     return 0

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -634,6 +634,11 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
         "trigger_hints": ("state write", "refresh-state", "todo write", "idempotency", "revision", "lease"),
         "checks": [
             {
+                "command": "python3 examples/control_plane/task-lease-runtime-smoke.py",
+                "tier": "default",
+                "reason": "guards shipped task_lease_v0 CLI/runtime ownership, TTL, conflict, transfer, and release behavior",
+            },
+            {
                 "command": "python3 examples/control_plane/local-state-write-correctness-contract-smoke.py",
                 "tier": "default",
                 "reason": "checks local state write correctness contract fixtures",

--- a/loopx/cli_commands/task_lease.py
+++ b/loopx/cli_commands/task_lease.py
@@ -4,7 +4,7 @@ import argparse
 from collections.abc import Callable
 from pathlib import Path
 
-from ..task_lease import (
+from ..control_plane.work_items.task_lease import (
     TaskLeaseError,
     acquire_task_lease,
     inspect_task_lease,

--- a/loopx/control_plane/work_items/task_lease.py
+++ b/loopx/control_plane/work_items/task_lease.py
@@ -6,10 +6,10 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-from .file_lock import exclusive_file_lock
-from .history import load_registry
-from .paths import resolve_runtime_root
-from .control_plane.todos.contract import (
+from ...file_lock import exclusive_file_lock
+from ...history import load_registry
+from ...paths import resolve_runtime_root
+from ..todos.contract import (
     normalize_required_write_scopes,
     normalize_todo_claimed_by,
     normalize_todo_id,


### PR DESCRIPTION
## Summary
- Move task lease runtime implementation from root `loopx.task_lease` into `loopx.control_plane.work_items.task_lease` without a legacy root shim.
- Update the `task-lease` CLI command import to the new bounded-context module.
- Extend `bounded-context-namespace-smoke` so moved root control-plane modules stay out of `loopx/`.
- Add `task-lease-runtime-smoke` to the state-write/lease canary profile so future lease changes exercise shipped CLI/runtime behavior by default.

## Validation
- `python3 examples/control_plane/task-lease-runtime-smoke.py`
- `python3 examples/control_plane/todo-claim-lease-roadmap-smoke.py`
- `python3 examples/control_plane/local-state-write-correctness-contract-smoke.py`
- `python3 examples/control_plane/todo-write-correctness-smoke.py`
- `python3 examples/control_plane/bounded-context-namespace-smoke.py`
- `python3 examples/canary/catalog-planner-smoke.py`
- `python3 -m py_compile` over changed Python files
- `python3 -m loopx.cli --format json canary smoke-suite --from-git-diff --surface "task lease bounded context refactor" --limit 10 --timeout-seconds 45 --no-progress`
- `git diff --check`
- Added-line private material scan over the diff.