### PR TITLE
Fix Codex CLI goal TUI objective submit

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -261,6 +261,24 @@ def _assert_cli_goal_tui_ready_wait_tolerates_startup_warnings() -> None:
     )
 
 
+def _assert_cli_goal_input_is_submitted_as_one_buffer() -> None:
+    sys.path.insert(0, str(REPO_ROOT))
+    from loopx.codex_cli_goal_tui import build_codex_cli_goal_tui_input
+
+    objective = "Solve the task.\nUse the private bridge."
+    assert build_codex_cli_goal_tui_input(objective) == (
+        "/goal Solve the task.\nUse the private bridge."
+    )
+    for relative in (
+        "loopx/benchmark_adapters/skillsbench_acp_relay.py",
+        "scripts/harbor_host_codex_goal_agent.py",
+        "scripts/terminal_bench_host_codex_goal_agent.py",
+    ):
+        source = (REPO_ROOT / relative).read_text(encoding="utf-8")
+        assert '"/goal", "C-m"' not in source, relative
+        assert '_tmux_send_literal(tmux_name, "/goal ")' not in source, relative
+
+
 def _assert_cli_goal_codex_api_proxy_is_runtime_only() -> None:
     sys.path.insert(0, str(REPO_ROOT))
     from loopx.benchmark_adapters.skillsbench_acp_relay import (
@@ -315,6 +333,7 @@ def main() -> int:
     _assert_cli_goal_plan_and_relay_command()
     _assert_cli_goal_trace_merges_into_public_prerequisites()
     _assert_cli_goal_tui_ready_wait_tolerates_startup_warnings()
+    _assert_cli_goal_input_is_submitted_as_one_buffer()
     _assert_cli_goal_codex_api_proxy_is_runtime_only()
     print("skillsbench-codex-cli-goal-route-smoke ok")
     return 0

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -31,6 +31,7 @@ from loopx.benchmark_case_state import (
 from loopx.benchmark_adapters.skillsbench_remote_bridge import (
     run_skillsbench_remote_command_file_bridge_probe,
 )
+from loopx.codex_cli_goal_tui import build_codex_cli_goal_tui_input
 
 
 SAFE_LOOPX_TODO_ID_RE = re.compile(r"^todo_[A-Za-z0-9_-]{6,80}$")
@@ -1115,7 +1116,10 @@ class SkillsBenchLocalAcpRelay:
                     bridge_command_for_agent=str(instrumented_bridge),
                 )
             prompt_path = tmp_path / "goal-prompt.txt"
-            prompt_path.write_text(prompt_for_codex, encoding="utf-8")
+            prompt_path.write_text(
+                build_codex_cli_goal_tui_input(prompt_for_codex),
+                encoding="utf-8",
+            )
             tmux_name = f"gh-sb-cli-goal-{uuid.uuid4().hex[:10]}"
             cmd = self._codex_cli_tui_command(cwd=cwd, model=session.get("model"))
             shell_command = self._codex_cli_tui_shell_command(cmd)
@@ -1157,8 +1161,6 @@ class SkillsBenchLocalAcpRelay:
                     return _recoverable_codex_turn_failure_message(
                         "codex_exec_first_action_timeout"
                     )
-                self._tmux_send_literal(tmux_name, "/goal ")
-                time.sleep(0.2)
                 subprocess.run(
                     ["tmux", "load-buffer", "-b", f"{tmux_name}-prompt", str(prompt_path)],
                     check=True,

--- a/loopx/codex_cli_goal_tui.py
+++ b/loopx/codex_cli_goal_tui.py
@@ -1,0 +1,17 @@
+"""Small helpers for driving the visible Codex CLI ``/goal`` TUI surface."""
+
+from __future__ import annotations
+
+
+CODEX_CLI_GOAL_COMMAND_PREFIX = "/goal "
+
+
+def build_codex_cli_goal_tui_input(objective: str) -> str:
+    """Return one pasteable TUI input that sets a Codex CLI goal.
+
+    The Codex TUI parses ``/goal`` as a slash command before later paste
+    buffers are associated with it, so the command and objective must be
+    submitted as one input buffer.
+    """
+
+    return f"{CODEX_CLI_GOAL_COMMAND_PREFIX}{objective}"

--- a/scripts/harbor_host_codex_goal_agent.py
+++ b/scripts/harbor_host_codex_goal_agent.py
@@ -61,6 +61,7 @@ from loopx.benchmark_core.loop_protocol import (
     render_loop_contract_packet_lines,
 )
 from loopx.control_plane.todos.contract import todo_terminal_for_status
+from loopx.codex_cli_goal_tui import build_codex_cli_goal_tui_input
 
 LONG_RUN_DEFAULT_GOAL_TIMEOUT_SEC = 21600.0
 
@@ -1479,7 +1480,10 @@ class HarborHostCodexGoalAgent(BaseAgent):
             task_workdir=self.task_workdir,
             loopx_access_packet=loopx_access_packet,
         )
-        prompt_path.write_text(prompt, encoding="utf-8")
+        prompt_path.write_text(
+            build_codex_cli_goal_tui_input(prompt),
+            encoding="utf-8",
+        )
 
         if self.goal_surface == "app_server":
             try:
@@ -2105,8 +2109,6 @@ class HarborHostCodexGoalAgent(BaseAgent):
         )
         await asyncio.sleep(self.startup_delay_sec)
         self._tmux("send-keys", "-t", tmux_name, "C-m", check=False)
-        await asyncio.sleep(self.startup_delay_sec)
-        self._tmux("send-keys", "-t", tmux_name, "/goal", "C-m", check=False)
         await asyncio.sleep(self.startup_delay_sec)
         self._tmux("load-buffer", "-b", f"gh_prompt_{run_id}", str(prompt_path), check=True)
         self._tmux("paste-buffer", "-d", "-b", f"gh_prompt_{run_id}", "-t", tmux_name, check=True)

--- a/scripts/terminal_bench_host_codex_goal_agent.py
+++ b/scripts/terminal_bench_host_codex_goal_agent.py
@@ -36,6 +36,7 @@ from loopx.benchmark_case_state import (
     build_benchmark_case_lifecycle_packet,
     benchmark_case_loopx_install_payload,
 )
+from loopx.codex_cli_goal_tui import build_codex_cli_goal_tui_input
 
 LONG_RUN_DEFAULT_GOAL_TIMEOUT_SEC = 21600.0
 
@@ -322,7 +323,10 @@ class HostCodexGoalAgent(BaseAgent):
             task_workdir=self.task_workdir,
             loopx_case_lifecycle_packet=loopx_packet,
         )
-        prompt_path.write_text(prompt, encoding="utf-8")
+        prompt_path.write_text(
+            build_codex_cli_goal_tui_input(prompt),
+            encoding="utf-8",
+        )
 
         if self.goal_surface == "app_server":
             try:
@@ -434,8 +438,6 @@ class HostCodexGoalAgent(BaseAgent):
         )
         time.sleep(self.startup_delay_sec)
         self._tmux("send-keys", "-t", tmux_name, "C-m", check=False)
-        time.sleep(self.startup_delay_sec)
-        self._tmux("send-keys", "-t", tmux_name, "/goal", "C-m", check=False)
         time.sleep(self.startup_delay_sec)
         self._tmux("load-buffer", "-b", f"gh_prompt_{run_id}", str(prompt_path), check=True)
         self._tmux("paste-buffer", "-d", "-b", f"gh_prompt_{run_id}", "-t", tmux_name, check=True)


### PR DESCRIPTION
## Summary
- submit Codex CLI `/goal <objective>` as one TUI input buffer instead of sending a bare `/goal` before pasting the objective
- share the input builder across SkillsBench, Harbor, and Terminal-Bench host goal agents
- add a SkillsBench route smoke regression for the one-buffer `/goal` contract

## Validation
- `python3 -m py_compile loopx/codex_cli_goal_tui.py loopx/benchmark_adapters/skillsbench_acp_relay.py scripts/harbor_host_codex_goal_agent.py scripts/terminal_bench_host_codex_goal_agent.py examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- remote Codex CLI TUI one-buffer canary: ready=true, target_seen=true, bare_goal_usage_seen=false

## Notes
- A direct SkillsBench one-case canary is currently blocked before Codex by benchmark egress/Docker apt setup, so it is not evidence against this TUI sequencing fix.
- Full `examples/skillsbench-benchmark-run-smoke.py` still hits the pre-existing `round_reward_count` assertion noted before this PR.