### PR TITLE
Preserve agent lane during autonomous replan

### DIFF
--- a/examples/control_plane/quota-replan-decision-plane-smoke.py
+++ b/examples/control_plane/quota-replan-decision-plane-smoke.py
@@ -61,6 +61,20 @@ def primary_claimed_advancement() -> dict:
     }
 
 
+def side_agent_claimed_advancement() -> dict:
+    return {
+        "index": 2,
+        "todo_id": "todo_side_canary_refactor",
+        "text": "[P1] Continue the next non-benchmark canary/refactor batch.",
+        "role": "agent",
+        "status": "open",
+        "priority": "P1",
+        "task_class": "advancement_task",
+        "action_kind": "canary_refactor_next_batch",
+        "claimed_by": SIDE_AGENT,
+    }
+
+
 def blocking_handoff_review() -> dict:
     return {
         "index": 2,
@@ -196,6 +210,34 @@ def assert_replan_beats_monitor_quiet_skip() -> None:
     assert "goal_frontier_projection: replan_required=True" in markdown, markdown
     assert "deferred_ready=0 acceptance_gaps=0" in markdown, markdown
     assert "autonomous_replan_decision: decision=autonomous_replan_required" in markdown, markdown
+
+
+def assert_replan_preserves_current_agent_runnable_frontier() -> None:
+    guard = build_quota_should_run(
+        status_payload([monitor_item(), side_agent_claimed_advancement()]),
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+    )
+    assert guard["decision"] == "autonomous_replan_required", guard
+    assert guard["effective_action"] == "autonomous_replan_required", guard
+    assert guard["should_run"] is True, guard
+    assert guard["interaction_contract"]["mode"] == "autonomous_replan", guard
+    lane_action = guard["agent_lane_next_action"]
+    assert lane_action["todo_id"] == "todo_side_canary_refactor", guard
+    assert lane_action["selected_by"] == "current_agent_claimed_todo", guard
+    assert lane_action["preserves_goal_next_action"] is True, guard
+    primary_action = guard["interaction_contract"]["agent_channel"]["primary_action"]
+    assert "todo_side_canary_refactor" in primary_action, guard
+    assert "bounded autonomous replan" in primary_action, guard
+    cli_actions = guard["interaction_contract"]["cli_channel"]["next_cli_actions"]
+    assert "todo_side_canary_refactor" in cli_actions[0], guard
+    frontier = guard["goal_frontier_projection"]["remaining_advancement_frontier"]
+    assert frontier["current_agent_claimed_advancement_count"] == 1, guard
+    assert guard["goal_route_hint"]["current_agent_next_action"]["todo_id"] == (
+        "todo_side_canary_refactor"
+    ), guard
+    markdown = render_quota_should_run_markdown(guard)
+    assert "agent_lane_next_action: todo_id=todo_side_canary_refactor" in markdown, markdown
 
 
 def assert_agent_vision_gap_derives_replan() -> None:
@@ -338,6 +380,7 @@ def assert_blocking_handoff_gate_beats_derived_monitor_replan() -> None:
 
 def main() -> None:
     assert_replan_beats_monitor_quiet_skip()
+    assert_replan_preserves_current_agent_runnable_frontier()
     assert_agent_vision_gap_derives_replan()
     assert_replan_beats_agent_scope_wait()
     assert_empty_monitor_frontier_derives_replan()

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -3459,6 +3459,9 @@ def _interaction_primary_agent_action(payload: dict[str, Any], *, mode: str) -> 
             "write a compact blocker when it is absent"
         )
     if mode == "autonomous_replan":
+        lane_action = _protocol_first_candidate_action(payload)
+        if lane_action:
+            return f"run one bounded autonomous replan slice around {lane_action}"
         return "run one bounded self-repair or replan segment before another quiet no-op"
     if mode == "monitor_quiet_skip":
         return "record at most one no-spend monitor-poll event, rerun the guard, then stay quiet if unchanged"
@@ -3606,8 +3609,15 @@ def _interaction_next_cli_actions(payload: dict[str, Any], *, mode: str) -> list
             f"loopx --format json quota should-run --goal-id {goal_id}{agent_arg}",
         ]
     if mode == "autonomous_replan":
+        lane_action = _protocol_first_candidate_action(payload)
+        first_action = (
+            "run one bounded autonomous replan slice around "
+            f"{lane_action}; write back the selected todo/frontier changes"
+            if lane_action
+            else "run one bounded autonomous replan slice and write back the selected next action/todo changes"
+        )
         return [
-            "run one bounded autonomous replan slice and write back the selected next action/todo changes",
+            first_action,
             f"loopx refresh-state --goal-id {goal_id} --classification autonomous_replan_recorded --autonomous-replan-recorded --repair-delta-kind <delta_kind> --delivery-batch-scale <scale> --delivery-outcome <outcome>",
             f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute",
         ]
@@ -6171,7 +6181,7 @@ def build_quota_should_run(
             allow_unrelated_gate=bool(quota.get("safe_bypass_allowed")),
         )
         agent_lane_next_action = None
-        if not due_monitor_attempt and not replan_decision_allowed:
+        if not due_monitor_attempt:
             agent_lane_next_action = _agent_lane_next_action(
                 agent_identity=agent_identity,
                 agent_todo_summary=agent_todo_summary,
@@ -6186,10 +6196,11 @@ def build_quota_should_run(
                     )
                 ),
             )
-            selected_recommended_action = _selected_action_with_agent_lane(
-                selected_recommended_action,
-                agent_lane_next_action=agent_lane_next_action,
-            )
+            if not replan_decision_allowed:
+                selected_recommended_action = _selected_action_with_agent_lane(
+                    selected_recommended_action,
+                    agent_lane_next_action=agent_lane_next_action,
+                )
         agent_scope_frontier = None
         if not replan_decision_allowed:
             agent_scope_frontier = _agent_scope_no_candidate_frontier(


### PR DESCRIPTION
## Summary
- Preserve `agent_lane_next_action` when `quota should-run` is in `autonomous_replan_required` mode.
- Make the interaction contract's autonomous replan primary action and first CLI action point at the selected current-agent todo when one exists.
- Add a regression fixture proving replan still wins over monitor quiet/agent-scope wait while keeping the current agent's runnable canary/refactor frontier visible.

## Validation
- `python3 examples/control_plane/quota-replan-decision-plane-smoke.py`
- `python3 examples/autonomous-replan-obligation-smoke.py`
- `python3 examples/control_plane/work-lane-contract-smoke.py`
- `python3 examples/control_plane/control-plane-risk-characterization-smoke.py`
- `python3 examples/control_plane/quota-plan-smoke.py`
- `python3 examples/control_plane/quota-work-lane-policy-smoke.py`
- `python3 -m py_compile loopx/quota.py examples/control_plane/quota-replan-decision-plane-smoke.py`
- `git diff --check`
- Source-tree CLI check against the live registry: `loopx-meta/codex-product-capability` remains `autonomous_replan_required` and now exposes `agent_lane_next_action.todo_id=todo_312d113cf650`.

## Canary note
`python3 -m loopx.cli --format json canary smoke-suite --from-git-diff --surface "autonomous replan agent lane projection repair" --limit 12 --timeout-seconds 60 --no-progress` selected and ran 12 checks; 10 passed. Two failures appear unrelated to this diff:
- `examples/control_plane/repo-python-line-budget-smoke.py` reports existing over-budget files outside this PR (`loopx/benchmark_adapters/skillsbench_acp_relay.py`, `scripts/harbor_host_codex_goal_agent.py`).
- `examples/control_plane/monitor-scheduler-contract-smoke.py` expects `[3, 3, 3]` but current scheduler projection emits `[3, 3, 3, 3]`; this PR does not touch scheduler code.

## Boundary
Public quota contract and public smoke fixture only. No raw benchmark logs, trajectories, verifier output, credentials, local state, or private paths added.
