### PR TITLE
Move status projection cache into runtime context

### DIFF
--- a/examples/control_plane/bounded-context-namespace-smoke.py
+++ b/examples/control_plane/bounded-context-namespace-smoke.py
@@ -19,9 +19,11 @@ LEGACY_ROOT_MODULES = {
     "loopx/delivery_batch_scale.py": "loopx.control_plane.work_items.delivery_batch_scale",
     "loopx/delivery_outcome.py": "loopx.control_plane.work_items.delivery_outcome",
     "loopx/scheduler_state.py": "loopx.control_plane.scheduler.state",
+    "loopx/status_projection_cache.py": "loopx.control_plane.runtime.status_projection_cache",
     "loopx/task_lease.py": "loopx.control_plane.work_items.task_lease",
 }
 CANONICAL_MODULES = {
+    "loopx.control_plane.runtime.status_projection_cache",
     "loopx.control_plane.todos.decision_scope",
     "loopx.control_plane.scheduler.state",
     "loopx.control_plane.work_items.delivery_batch_scale",

--- a/examples/control_plane/status-projection-cache-smoke.py
+++ b/examples/control_plane/status-projection-cache-smoke.py
@@ -16,7 +16,7 @@ from typing import Any
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 
-from loopx.status_projection_cache import write_status_projection_cache
+from loopx.control_plane.runtime.status_projection_cache import write_status_projection_cache
 
 GOAL_ID = "status-projection-cache-fixture"
 AGENT_ID = "codex-main-control"

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -18,7 +18,7 @@ from ..quota import (
     void_quota_slot,
 )
 from ..status import AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK, collect_status
-from ..status_projection_cache import (
+from ..control_plane.runtime.status_projection_cache import (
     load_status_projection_cache,
     resolve_status_projection_cache_runtime_root,
     write_status_projection_cache,

--- a/loopx/cli_commands/status.py
+++ b/loopx/cli_commands/status.py
@@ -11,7 +11,7 @@ from ..handoff_budget import build_handoff_interface_budget
 from ..quota import build_quota_should_run
 from ..review_packet import build_review_packet, render_review_packet_markdown
 from ..status import collect_status, render_status_markdown
-from ..status_projection_cache import (
+from ..control_plane.runtime.status_projection_cache import (
     load_status_projection_cache,
     resolve_status_projection_cache_runtime_root,
     write_status_projection_cache,

--- a/loopx/control_plane/runtime/status_projection_cache.py
+++ b/loopx/control_plane/runtime/status_projection_cache.py
@@ -8,8 +8,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
-from .history import load_registry
-from .paths import resolve_runtime_root
+from ...history import load_registry
+from ...paths import resolve_runtime_root
 
 
 STATUS_PROJECTION_CACHE_SCHEMA_VERSION = "status_projection_cache_v0"


### PR DESCRIPTION
## Summary

- Move the status projection cache implementation from the package root into `loopx.control_plane.runtime.status_projection_cache`.
- Update `status`/`quota` CLI cache read/write paths and the status projection cache smoke to use the bounded-context module.
- Extend the bounded-context namespace smoke so the old root import is not kept as a shim.

## Validation

- `python3 examples/control_plane/status-projection-cache-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 examples/control_plane/quota-contract-smoke.py`
- `python3 examples/control_plane/bounded-context-namespace-smoke.py`
- `python3 -m py_compile loopx/control_plane/runtime/status_projection_cache.py loopx/cli_commands/status.py loopx/cli_commands/quota.py examples/control_plane/status-projection-cache-smoke.py examples/control_plane/bounded-context-namespace-smoke.py`
- import-boundary check: old `loopx.status_projection_cache` absent; canonical `loopx.control_plane.runtime.status_projection_cache` present
- real CLI cache read/write check for `status --write/--use-projection-cache` and `quota should-run --write/--use-projection-cache`
- explicit canary smoke-suite for status cache, parity, quota contract, namespace guard: passed 4/4
- `git diff --check` and `git diff --cached --check`
- added-line public/private boundary scan

## Known Existing Red

`python3 -m loopx.cli --format json canary smoke-suite --from-git-diff --surface "status projection cache bounded-context move" --limit 12 --timeout-seconds 60 --no-progress` selected 12 checks. 11 passed; the only failure is the inherited `repo-python-line-budget-smoke.py` on two untouched files (`loopx/benchmark_adapters/skillsbench_acp_relay.py` and `scripts/harbor_host_codex_goal_agent.py`) already being 2 lines above their current budgets.
