### PR TITLE
Handle SkillsBench CLI goal rate-limit startup

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -261,6 +261,64 @@ def _assert_cli_goal_tui_ready_wait_tolerates_startup_warnings() -> None:
     )
 
 
+def _assert_cli_goal_rate_limit_is_public_safe_retryable_stage() -> None:
+    sys.path.insert(0, str(REPO_ROOT))
+    from loopx.benchmark_adapters.skillsbench_acp_relay import (
+        CodexExecConfig,
+        SkillsBenchLocalAcpRelay,
+        _codex_cli_tui_retryable_startup_blocker_stage,
+    )
+    from scripts.skillsbench_automation_loop import (
+        _merge_host_local_acp_relay_trace_summary,
+        _public_runner_prerequisites,
+    )
+
+    assert (
+        _codex_cli_tui_retryable_startup_blocker_stage(
+            "Codex CLI\nrate limit reached\n› "
+        )
+        == "rate_limit_before_goal_active"
+    )
+    assert _codex_cli_tui_retryable_startup_blocker_stage("Goal active") == ""
+
+    with tempfile.TemporaryDirectory() as temp:
+        trace_dir = Path(temp) / "trace"
+        relay = SkillsBenchLocalAcpRelay(
+            CodexExecConfig(worker_public_trace_dir=str(trace_dir))
+        )
+        relay._publish_codex_cli_goal_trace(
+            ok=False,
+            stage="rate_limit_before_goal_active",
+            goal_active_observed=False,
+            goal_terminal_observed=False,
+            first_action_observed=False,
+            bridge_summary_path=None,
+        )
+        plan = {
+            "route": "codex-cli-goal-baseline",
+            "host_local_acp_relay_trace_dir": str(trace_dir),
+            "runner_prerequisites": {},
+        }
+        trace: dict[str, object] = {}
+        _merge_host_local_acp_relay_trace_summary(plan, trace)
+
+    prerequisites = plan["runner_prerequisites"]
+    assert trace["codex_cli_goal_tui_trace_present"] is True, trace
+    assert trace["codex_cli_goal_tui_ok_count"] == 0, trace
+    assert trace["codex_cli_goal_tui_stage"] == "rate_limit_before_goal_active"
+    assert trace["codex_cli_goal_tui_goal_active_observed_count"] == 0
+    assert trace["codex_cli_goal_tui_first_action_observed_count"] == 0
+    assert trace["codex_cli_goal_tui_raw_material_recorded"] is False, trace
+
+    public_prerequisites = _public_runner_prerequisites(prerequisites)
+    assert public_prerequisites["codex_cli_goal_tui_stage"] == (
+        "rate_limit_before_goal_active"
+    )
+    assert public_prerequisites["codex_cli_goal_tui_stages"] == [
+        "rate_limit_before_goal_active"
+    ]
+
+
 def _assert_cli_goal_input_is_submitted_as_one_buffer() -> None:
     sys.path.insert(0, str(REPO_ROOT))
     from loopx.codex_cli_goal_tui import build_codex_cli_goal_tui_input
@@ -333,6 +391,7 @@ def main() -> int:
     _assert_cli_goal_plan_and_relay_command()
     _assert_cli_goal_trace_merges_into_public_prerequisites()
     _assert_cli_goal_tui_ready_wait_tolerates_startup_warnings()
+    _assert_cli_goal_rate_limit_is_public_safe_retryable_stage()
     _assert_cli_goal_input_is_submitted_as_one_buffer()
     _assert_cli_goal_codex_api_proxy_is_runtime_only()
     print("skillsbench-codex-cli-goal-route-smoke ok")

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -482,6 +482,24 @@ def _recoverable_codex_turn_failure_message(category: str) -> str:
     )
 
 
+def _codex_cli_tui_retryable_startup_blocker_stage(capture: str) -> str:
+    """Classify public-safe Codex CLI TUI startup blockers from screen text."""
+
+    lowered = str(capture or "").lower()
+    if any(
+        marker in lowered
+        for marker in (
+            "rate limit",
+            "rate_limit",
+            "too many requests",
+            "status 429",
+            "error 429",
+        )
+    ):
+        return "rate_limit_before_goal_active"
+    return ""
+
+
 def _write_process_stdin_async(
     proc: subprocess.Popen[str],
     stdin_text: str | None,
@@ -1231,6 +1249,28 @@ class SkillsBenchLocalAcpRelay:
                         goal_terminal_observed = True
                         goal_failed_observed = True
                         break
+                    retryable_startup_blocker_stage = ""
+                    if not goal_active_observed and not first_action_seen:
+                        retryable_startup_blocker_stage = (
+                            _codex_cli_tui_retryable_startup_blocker_stage(capture)
+                        )
+                    if retryable_startup_blocker_stage:
+                        self._tmux_kill_session(tmux_name)
+                        if bridge_summary_path is not None:
+                            self._publish_remote_bridge_agent_operations_trace(
+                                bridge_summary_path=bridge_summary_path,
+                            )
+                        self._publish_codex_cli_goal_trace(
+                            ok=False,
+                            stage=retryable_startup_blocker_stage,
+                            goal_active_observed=goal_active_observed,
+                            goal_terminal_observed=goal_terminal_observed,
+                            first_action_observed=first_action_seen,
+                            bridge_summary_path=bridge_summary_path,
+                        )
+                        return _recoverable_codex_turn_failure_message(
+                            "codex_cli_goal_" + retryable_startup_blocker_stage
+                        )
                     if bridge_summary_path is not None:
                         try:
                             current_bridge_summary_size = bridge_summary_path.stat().st_size


### PR DESCRIPTION
## Summary
- classify Codex CLI /goal TUI startup rate limits as a retryable public-safe stage
- close out before the long first-action timeout when no goal/action has started
- extend the CLI goal route smoke to verify the stage is exported without raw TUI/task/log material

## Validation
- python3 examples/skillsbench-codex-cli-goal-route-smoke.py
- python3 -m py_compile loopx/benchmark_adapters/skillsbench_acp_relay.py examples/skillsbench-codex-cli-goal-route-smoke.py
- git diff --check