### PR TITLE
Skip exec preflight for CLI goal route

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -10388,6 +10388,34 @@ def test_app_server_goal_worker_skips_plain_codex_exec_preflight() -> None:
         ), prereqs
 
 
+def test_codex_cli_goal_worker_skips_plain_codex_exec_preflight() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-cli-goal-preflight-") as tmp:
+        args = parse_args(
+            [
+                "--task-id",
+                "3d-scan-calc",
+                "--route",
+                "codex-cli-goal-baseline",
+                "--host-local-acp-launch",
+                "--host-local-acp-codex-exec-preflight",
+                "--remote-command-file-bridge-ready",
+                "--jobs-dir",
+                str(Path(tmp) / "jobs"),
+                "--job-name",
+                "skillsbench-cli-goal-preflight-fixture",
+            ]
+        )
+        plan = build_plan(args)
+        prereqs = plan["runner_prerequisites"]
+        assert prereqs["host_local_acp_codex_exec_preflight_requested"] is False, (
+            prereqs
+        )
+        assert prereqs["host_local_acp_codex_exec_preflight_status"] == "not_requested", (
+            prereqs
+        )
+        assert prereqs["container_codex_acp_install_skipped"] is True, prereqs
+
+
 def test_app_server_goal_first_action_timeout_respects_agent_idle_timeout() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-app-server-timeout-") as tmp:
         args = parse_args(

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -2102,11 +2102,11 @@ def _host_local_acp_codex_exec_preflight_should_run(
 ) -> bool:
     """Return whether the host-local Codex exec path must be probed first."""
 
-    if (
-        bool(getattr(args, "host_local_acp_launch", False))
-        and str(getattr(args, "route", "") or "")
-        == CODEX_APP_SERVER_GOAL_BASELINE_ROUTE
-    ):
+    route = str(getattr(args, "route", "") or "")
+    if bool(getattr(args, "host_local_acp_launch", False)) and route in {
+        CODEX_APP_SERVER_GOAL_BASELINE_ROUTE,
+        CODEX_CLI_GOAL_BASELINE_ROUTE,
+    }:
         return False
     if bool(getattr(args, "host_local_acp_codex_exec_preflight", False)):
         return True


### PR DESCRIPTION
## Summary
- skip the plain host-local Codex exec preflight for codex-cli-goal-baseline, matching Goal-worker routes that do not execute through codex exec
- keep product-mode bridge-action preflight behavior unchanged
- add a focused smoke fixture for the CLI Goal route preflight contract

## Validation
- python3 - <<'PY' ... targeted preflight smoke fixture calls ... PY
- python3 examples/skillsbench-codex-cli-goal-route-smoke.py
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py examples/skillsbench-codex-cli-goal-route-smoke.py
- git diff --check