### PR TITLE
Extend monitor state-machine canary

### DIFF
--- a/examples/control_plane/control-plane-integrated-canary-smoke.py
+++ b/examples/control_plane/control-plane-integrated-canary-smoke.py
@@ -27,9 +27,12 @@ from loopx.event_sourced_state import (  # noqa: E402
 
 
 GOAL_ID = "control-plane-integrated-canary"
+MONITOR_GOAL_ID = "control-plane-integrated-monitor-canary"
 AGENT_ID = "codex-product-capability"
 CANARY_TODO_ID = "todo_integrated_canary"
 CANARY_TODO_TITLE = "Design bounded status/quota/review-packet/event/read-path canary"
+MONITOR_TODO_ID = "todo_integrated_due_monitor"
+MONITOR_TARGET_KEY = "integrated-due-monitor-watch"
 VALIDATED_PROGRESS_CLASSIFICATION = "integrated_canary_validated_progress"
 DEFAULT_MAX_SECONDS = 120.0
 
@@ -96,6 +99,68 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
     )
     runtime.mkdir(parents=True, exist_ok=True)
     return registry_path, state_file, event_log
+
+
+def write_monitor_fixture(root: Path) -> tuple[Path, Path]:
+    project = root / "monitor-project"
+    runtime = root / "monitor-runtime"
+    state_file = project / ".codex" / "goals" / MONITOR_GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".loopx" / "registry.json"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(
+        "---\n"
+        "status: active\n"
+        "updated_at: 2026-06-27T00:00:00+00:00\n"
+        "---\n\n"
+        "# Control Plane Monitor Canary\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] [P1-monitor] Monitor integrated state-machine transition and write back only material transitions.\n"
+        f"  <!-- loopx:todo todo_id={MONITOR_TODO_ID} status=open "
+        "task_class=continuous_monitor action_kind=monitor "
+        f"claimed_by={AGENT_ID} target_key={MONITOR_TARGET_KEY} "
+        "cadence=5m next_due_at=2000-01-01T00:00:00+00:00 -->\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-06-27T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": MONITOR_GOAL_ID,
+                        "domain": "control-plane-canary",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": f".codex/goals/{MONITOR_GOAL_ID}/ACTIVE_GOAL_STATE.md",
+                        "adapter": {
+                            "kind": "generic_project_goal_v0",
+                            "status": "connected",
+                        },
+                        "quota": {
+                            "compute": 1.0,
+                            "window_hours": 24,
+                            "slot_minutes": 1,
+                            "allowed_slots": 10,
+                        },
+                        "coordination": {
+                            "registered_agents": [AGENT_ID],
+                            "primary_agent": AGENT_ID,
+                        },
+                        "authority_sources": [],
+                    }
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    runtime.mkdir(parents=True, exist_ok=True)
+    return registry_path, runtime
 
 
 def append_event_todos(event_log: Path) -> None:
@@ -393,6 +458,81 @@ def assert_refresh_and_spend_state_machine(registry_path: Path, runtime_root: Pa
     assert spent_payload["quota"]["state"] == "eligible", spent_payload
 
 
+def assert_due_monitor_poll_state_machine(root: Path) -> None:
+    registry_path, runtime_root = write_monitor_fixture(root)
+
+    quota_payload = run_cli(
+        registry_path,
+        runtime_root,
+        "quota",
+        "should-run",
+        "--goal-id",
+        MONITOR_GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+    )
+    assert quota_payload["ok"] is True, quota_payload
+    assert quota_payload["should_run"] is True, quota_payload
+    assert quota_payload["effective_action"] == "normal_run", quota_payload
+    lane = quota_payload["work_lane_contract"]
+    assert lane["monitor_kind"] == "todo_monitor_due", lane
+    assert lane["obligation"] == "attempt_due_monitor", lane
+    assert lane["selected_todo_id"] == MONITOR_TODO_ID, lane
+    contract = quota_payload["interaction_contract"]
+    assert contract["agent_channel"]["must_attempt"] is True, contract
+    assert contract["agent_channel"]["quiet_noop_allowed"] is False, contract
+    assert contract["cli_channel"]["spend_allowed_now"] is False, contract
+
+    monitor_payload = run_cli(
+        registry_path,
+        runtime_root,
+        "quota",
+        "monitor-poll",
+        "--goal-id",
+        MONITOR_GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+        "--todo-id",
+        MONITOR_TODO_ID,
+        "--result-hash",
+        "unchanged-integrated-monitor",
+        "--cadence",
+        "5m",
+        "--execute",
+    )
+    assert monitor_payload["ok"] is True, monitor_payload
+    assert monitor_payload["appended"] is True, monitor_payload
+    assert monitor_payload["dry_run"] is False, monitor_payload
+    assert monitor_payload["delivery_outcome"] == "surface_only", monitor_payload
+    assert monitor_payload["material_change"] is False, monitor_payload
+    assert monitor_payload["monitor_event"]["material_change"] is False, monitor_payload
+    assert monitor_payload["todo_writeback"]["todo_id"] == MONITOR_TODO_ID, monitor_payload
+    assert monitor_payload["todo_writeback"]["next_due_at"], monitor_payload
+    assert monitor_payload["todo_writeback"]["consecutive_no_change"] == 1, monitor_payload
+
+    replan_payload = run_cli(
+        registry_path,
+        runtime_root,
+        "quota",
+        "should-run",
+        "--goal-id",
+        MONITOR_GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+    )
+    assert replan_payload["decision"] == "autonomous_replan_required", replan_payload
+    assert replan_payload["effective_action"] == "autonomous_replan_required", replan_payload
+    assert replan_payload["execution_obligation"]["must_attempt_work"] is True, replan_payload
+    assert replan_payload["execution_obligation"]["kind"] == "autonomous_replan_required", replan_payload
+    assert replan_payload["interaction_contract"]["mode"] == "autonomous_replan", replan_payload
+    assert replan_payload["work_lane_contract"]["obligation"] == "quiet_until_material_monitor_transition", replan_payload
+    assert replan_payload["work_lane_contract"]["must_attempt_work"] is False, replan_payload
+    assert replan_payload["goal_frontier_projection"]["monitor_only_lanes"]["present"] is True, replan_payload
+    assert replan_payload["goal_frontier_projection"]["replan_required"] is True, replan_payload
+    assert replan_payload["agent_todo_summary"]["monitor_due_count"] == 0, replan_payload
+    assert replan_payload["scheduler_hint"]["cadence_class"] == "active_work", replan_payload
+
+
 def run_fixture_canary(root: Path) -> None:
     registry_path, _, event_log = write_fixture(root)
     runtime_root = root / "runtime"
@@ -453,6 +593,7 @@ def run_fixture_canary(root: Path) -> None:
     assert packet_payload["project_asset_source"] == "project_asset", packet_payload
     assert CANARY_TODO_TITLE in packet_payload["project_agent_handoff"], packet_payload
     assert packet_payload["handoff_interface_budget"]["within_budget"] is True, packet_payload
+    assert_due_monitor_poll_state_machine(root)
 
 
 def parse_args() -> argparse.Namespace:

--- a/examples/control_plane/monitor-todo-policy-seam-smoke.py
+++ b/examples/control_plane/monitor-todo-policy-seam-smoke.py
@@ -13,11 +13,14 @@ if str(ROOT) not in sys.path:
 
 from loopx import quota as quota_module  # noqa: E402
 from loopx.control_plane.scheduler.monitor_todo import (  # noqa: E402
+    monitor_cadence_delta,
+    monitor_next_due_at,
     monitor_todo_is_actionable_open,
     monitor_todo_is_due,
     monitor_todo_is_expired,
     monitor_todo_missing_schedule,
     monitor_todo_next_due_at,
+    parse_monitor_counter,
 )
 from loopx.status import (  # noqa: E402
     todo_item_is_actionable_open,
@@ -94,6 +97,20 @@ def main() -> int:
     assert_policy_matches_wrappers(unscheduled, due=False, expired=False)
     assert monitor_todo_missing_schedule(unscheduled, now=NOW) is True, unscheduled
     assert monitor_todo_next_due_at({"next_due_at": "2026-01-01T00:00:00"}) == NOW
+    assert parse_monitor_counter("3") == quota_module._parse_monitor_counter("3")
+    assert parse_monitor_counter("not-a-number") == 0
+    assert monitor_cadence_delta("2h") == quota_module._monitor_cadence_delta("2h")
+    assert monitor_next_due_at(
+        generated_at="2026-01-01T00:00:00+00:00",
+        cadence="5m",
+    ) == quota_module._monitor_next_due_at(
+        generated_at="2026-01-01T00:00:00+00:00",
+        cadence="5m",
+    )
+    assert monitor_next_due_at(
+        generated_at="ignored",
+        explicit_next_due_at="2026-01-01T00:05:00+00:00",
+    ) == "2026-01-01T00:05:00+00:00"
     print("monitor-todo-policy-seam-smoke ok")
     return 0
 

--- a/loopx/control_plane/scheduler/monitor_todo.py
+++ b/loopx/control_plane/scheduler/monitor_todo.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+import re
+from datetime import datetime, timedelta, timezone
 from typing import Any
 
 from ..todos.contract import (
@@ -9,6 +10,12 @@ from ..todos.contract import (
     normalize_todo_resume_when,
     normalize_todo_status,
     normalize_todo_task_class,
+)
+
+MONITOR_CADENCE_PATTERN = re.compile(
+    r"^\s*(?P<count>[1-9][0-9]{0,4})\s*"
+    r"(?P<unit>s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)\s*$",
+    re.IGNORECASE,
 )
 
 
@@ -22,6 +29,51 @@ def parse_monitor_timestamp(value: Any) -> datetime | None:
     if parsed.tzinfo is None:
         return parsed.replace(tzinfo=timezone.utc)
     return parsed
+
+
+def parse_monitor_counter(value: Any) -> int:
+    try:
+        return max(0, int(str(value or "0").strip()))
+    except ValueError:
+        return 0
+
+
+def monitor_cadence_delta(value: Any) -> timedelta | None:
+    candidate = str(value or "").strip()
+    if not candidate:
+        return None
+    match = MONITOR_CADENCE_PATTERN.match(candidate)
+    if not match:
+        return None
+    count = int(match.group("count"))
+    unit = match.group("unit").lower()
+    if unit.startswith("s"):
+        return timedelta(seconds=count)
+    if unit.startswith("m"):
+        return timedelta(minutes=count)
+    if unit.startswith("h"):
+        return timedelta(hours=count)
+    return timedelta(days=count)
+
+
+def monitor_next_due_at(
+    *,
+    generated_at: str,
+    cadence: Any = None,
+    explicit_next_due_at: Any = None,
+) -> str | None:
+    explicit = str(explicit_next_due_at or "").strip()
+    if explicit:
+        if parse_monitor_timestamp(explicit) is None:
+            raise ValueError("--next-due-at must be an ISO timestamp")
+        return explicit
+    delta = monitor_cadence_delta(cadence)
+    if delta is None:
+        return None
+    checked_at = parse_monitor_timestamp(generated_at)
+    if checked_at is None:
+        checked_at = datetime.now(timezone.utc)
+    return (checked_at + delta).astimezone().replace(microsecond=0).isoformat()
 
 
 def monitor_todo_task_class(item: dict[str, Any], *, task_text: str | None = None) -> str:

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -68,6 +68,11 @@ from .control_plane.scheduler.scheduler_hint import (
     normalize_scheduler_rrule,
     scheduler_backoff_packet,
 )
+from .control_plane.scheduler.monitor_todo import (
+    monitor_cadence_delta as scheduler_monitor_cadence_delta,
+    monitor_next_due_at as scheduler_monitor_next_due_at,
+    parse_monitor_counter as scheduler_parse_monitor_counter,
+)
 from .control_plane.scheduler.state import (
     CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
     CODEX_APP_SURFACE,
@@ -7184,36 +7189,12 @@ def _allows_no_spend_external_monitor_poll(decision: dict[str, Any]) -> bool:
     return bool(decision.get("external_evidence_observation"))
 
 
-MONITOR_CADENCE_PATTERN = re.compile(
-    r"^\s*(?P<count>[1-9][0-9]{0,4})\s*"
-    r"(?P<unit>s|sec|secs|second|seconds|m|min|mins|minute|minutes|h|hr|hrs|hour|hours|d|day|days)\s*$",
-    re.IGNORECASE,
-)
-
-
 def _parse_monitor_counter(value: Any) -> int:
-    try:
-        return max(0, int(str(value or "0").strip()))
-    except ValueError:
-        return 0
+    return scheduler_parse_monitor_counter(value)
 
 
 def _monitor_cadence_delta(value: Any) -> timedelta | None:
-    candidate = str(value or "").strip()
-    if not candidate:
-        return None
-    match = MONITOR_CADENCE_PATTERN.match(candidate)
-    if not match:
-        return None
-    count = int(match.group("count"))
-    unit = match.group("unit").lower()
-    if unit.startswith("s"):
-        return timedelta(seconds=count)
-    if unit.startswith("m"):
-        return timedelta(minutes=count)
-    if unit.startswith("h"):
-        return timedelta(hours=count)
-    return timedelta(days=count)
+    return scheduler_monitor_cadence_delta(value)
 
 
 def _monitor_next_due_at(
@@ -7222,18 +7203,11 @@ def _monitor_next_due_at(
     cadence: Any = None,
     explicit_next_due_at: Any = None,
 ) -> str | None:
-    explicit = str(explicit_next_due_at or "").strip()
-    if explicit:
-        if _parse_timestamp(explicit) is None:
-            raise ValueError("--next-due-at must be an ISO timestamp")
-        return explicit
-    delta = _monitor_cadence_delta(cadence)
-    if delta is None:
-        return None
-    checked_at = _parse_timestamp(generated_at)
-    if checked_at is None:
-        checked_at = datetime.now(timezone.utc)
-    return (checked_at + delta).astimezone().replace(microsecond=0).isoformat()
+    return scheduler_monitor_next_due_at(
+        generated_at=generated_at,
+        cadence=cadence,
+        explicit_next_due_at=explicit_next_due_at,
+    )
 
 
 def _quota_decision_due_monitor_item(decision: dict[str, Any]) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- move monitor cadence / next-due calculation into the scheduler monitor-todo bounded context while keeping quota wrappers compatible
- extend the integrated control-plane canary with a due-monitor -> monitor-poll -> monitor-only autonomous-replan path
- strengthen the monitor policy seam smoke to assert scheduler helper and quota wrapper parity

## Validation
- python3 -m py_compile loopx/quota.py loopx/control_plane/scheduler/monitor_todo.py examples/control_plane/control-plane-integrated-canary-smoke.py examples/control_plane/monitor-todo-policy-seam-smoke.py
- python3 examples/control_plane/control-plane-integrated-canary-smoke.py
- python3 examples/control_plane/monitor-todo-policy-seam-smoke.py
- python3 examples/control_plane/monitor-scheduler-contract-smoke.py
- python3 examples/control_plane/monitor-poll-writeback-smoke.py
- python3 examples/control_plane/quota-scheduler-state-ack-smoke.py
- python3 examples/control_plane/heartbeat-quota-flow-smoke.py
- python3 examples/control_plane/quota-plan-smoke.py
- python3 examples/control_plane/quota-work-lane-policy-smoke.py
- python3 examples/autonomous-replan-obligation-smoke.py
- python3 examples/control_plane/bounded-context-namespace-smoke.py
- python3 examples/canary/catalog-planner-smoke.py
- python3 examples/control_plane/hot-path-interface-budget-smoke.py
- git diff --check

Known pre-existing red: repo-python-line-budget-smoke still fails only on inherited benchmark-heavy files: examples/skillsbench-benchmark-run-smoke.py, loopx/benchmark_adapters/skillsbench_acp_relay.py, scripts/harbor_host_codex_goal_agent.py.