### PR TITLE
Tighten codex CLI goal countability

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -10416,6 +10416,74 @@ def test_codex_cli_goal_worker_skips_plain_codex_exec_preflight() -> None:
         assert prereqs["container_codex_acp_install_skipped"] is True, prereqs
 
 
+def test_codex_cli_goal_official_score_without_task_activity_is_uncountable() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-cli-goal-countability-") as tmp:
+        root = Path(tmp)
+        result_path = write_official_skillsbench_result(root, reward=0.0)
+        args = parse_args(
+            [
+                "--task-id",
+                "azure-bgp-oscillation-route-leak",
+                "--route",
+                "codex-cli-goal-baseline",
+                "--host-local-acp-launch",
+                "--remote-command-file-bridge-ready",
+                "--remote-command-file-bridge-solver-command",
+                "/tmp/loopx-skillsbench-docker-bridge",
+                "--jobs-dir",
+                str(root / "jobs"),
+                "--job-name",
+                "skillsbench-cli-goal-countability-fixture",
+            ]
+        )
+        plan = build_plan(args)
+        plan["runner_prerequisites"].update(
+            {
+                "remote_command_file_bridge_agent_operation_trace_required": True,
+                "remote_command_file_bridge_agent_operation_trace_satisfied": False,
+                "remote_command_file_bridge_agent_operation_trace_status": (
+                    "agent_operation_trace_present_no_requests"
+                ),
+                "remote_command_file_bridge_agent_operation_trace_count": 1,
+                "remote_command_file_bridge_agent_request_count": 0,
+                "remote_command_file_bridge_agent_task_facing_operation_count": 0,
+                "remote_command_file_bridge_agent_task_facing_success_count": 0,
+                "codex_cli_goal_tui_trace_present": True,
+                "codex_cli_goal_tui_ok_count": 1,
+                "codex_cli_goal_tui_stage": "goal_achieved",
+                "codex_cli_goal_tui_task_facing_success_count": 0,
+                "codex_cli_goal_tui_raw_material_recorded": False,
+            }
+        )
+
+        compact = reduce_result(args, result_path, plan)
+
+        expected = "skillsbench_codex_cli_goal_uncountable_no_task_activity"
+        assert compact["official_score_status"] == "completed", compact
+        assert compact["official_score"] == 0.0, compact
+        assert compact["score_failure_attribution"] == expected, compact
+        assert compact["first_blocker"] == expected, compact
+        assert "official_verifier_solution_failure" not in compact[
+            "failure_attribution_labels"
+        ], compact
+        assert "skillsbench_codex_cli_goal_uncountable_baseline" in compact[
+            "failure_attribution_labels"
+        ], compact
+        contract = compact["codex_cli_goal_countability_contract"]
+        assert contract["countable_baseline"] is False, contract
+        assert contract["ok_count"] == 1, contract
+        assert contract["request_count"] == 0, contract
+        assert contract["task_facing_activity_count"] == 0, contract
+        assert contract["raw_material_recorded"] is False, contract
+        accounting = compact["attempt_accounting"]
+        assert accounting["failure_class"] == "job_materialization_failed", accounting
+        assert accounting["failure_label"] == expected, accounting
+        assert accounting["case_attempt_countable"] is False, accounting
+        assert accounting["solver_attempt_countable"] is False, accounting
+        assert accounting["verifier_attempt_countable"] is False, accounting
+        assert accounting["official_score_attempt_countable"] is False, accounting
+
+
 def test_app_server_goal_first_action_timeout_respects_agent_idle_timeout() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-app-server-timeout-") as tmp:
         args = parse_args(
@@ -14568,10 +14636,10 @@ def test_skillsbench_reduce_only_preserves_round_reward_trace() -> None:
         assert round_trace["records"][1]["passed"] is True, compact
         ledger = load_benchmark_run_ledger(Path(tmp) / "ledger.json")
         run = ledger["benchmarks"]["skillsbench@1.1"]["cases"]["sample-task"]["runs"][0]
-        assert run["round_reward_count"] == 0, run
-        assert run["round_success_observed"] is False, run
-        assert "round_rewards" not in run, run
-        assert "first_success_round" not in run, run
+        assert run["round_reward_count"] == 2, run
+        assert run["round_success_observed"] is True, run
+        assert [item["reward"] for item in run["round_rewards"]] == [0.0, 1.0], run
+        assert run["first_success_round"] == 2, run
 
 
 def test_skillsbench_reduce_only_preserves_persisted_public_prerequisites() -> None:
@@ -14801,6 +14869,8 @@ if __name__ == "__main__":
     test_product_mode_host_local_idle_no_output_progress_requires_new_trace()
     test_goal_start_host_local_defers_codex_exec_preflight_until_bridge_command()
     test_app_server_goal_worker_skips_plain_codex_exec_preflight()
+    test_codex_cli_goal_worker_skips_plain_codex_exec_preflight()
+    test_codex_cli_goal_official_score_without_task_activity_is_uncountable()
     test_app_server_goal_first_action_timeout_respects_agent_idle_timeout()
     test_goal_start_host_exec_failure_overrides_zero_score_recovery()
     test_skillsbench_product_mode_declared_done_below_passing_reward_is_compacted()

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -4810,6 +4810,137 @@ def _apply_native_goal_worker_finish_guard_attribution(
     return True
 
 
+def _apply_codex_cli_goal_countability_guard_attribution(
+    compact: dict[str, Any],
+) -> bool:
+    runner_config = compact.get("runner_config")
+    if not isinstance(runner_config, dict):
+        runner_config = {}
+    route = str(compact.get("route") or runner_config.get("route") or "")
+    mode = str(compact.get("mode") or "")
+    if (
+        route != CODEX_CLI_GOAL_BASELINE_ROUTE
+        and mode != "skillsbench_codex_cli_goal_baseline"
+    ):
+        return False
+    if compact.get("official_score_status") != "completed":
+        return False
+
+    counters = compact.get("interaction_counters")
+    if not isinstance(counters, dict):
+        counters = {}
+    runner_prerequisites = compact.get("runner_prerequisites")
+    if not isinstance(runner_prerequisites, dict):
+        runner_prerequisites = {}
+
+    def max_counter(*fields: str) -> int:
+        values: list[int] = []
+        for source in (counters, runner_prerequisites):
+            for field in fields:
+                value = source.get(field)
+                if isinstance(value, int) and not isinstance(value, bool):
+                    values.append(max(0, value))
+        return max(values, default=0)
+
+    task_facing_count = max_counter(
+        "remote_command_file_bridge_agent_task_facing_success_count",
+        "remote_command_file_bridge_agent_task_facing_operation_count",
+        "codex_cli_goal_tui_task_facing_success_count",
+    )
+    request_count = max_counter(
+        "remote_command_file_bridge_agent_request_count",
+        "codex_cli_goal_tui_bridge_request_count",
+    )
+    ok_count = max_counter("codex_cli_goal_tui_ok_count")
+    trace_present = bool(
+        counters.get("codex_cli_goal_tui_trace_present") is True
+        or runner_prerequisites.get("codex_cli_goal_tui_trace_present") is True
+    )
+    operation_trace_status = str(
+        counters.get("remote_command_file_bridge_agent_operation_trace_status")
+        or runner_prerequisites.get(
+            "remote_command_file_bridge_agent_operation_trace_status"
+        )
+        or ""
+    )[:120]
+
+    missing_task_activity = task_facing_count <= 0 or request_count <= 0
+    goal_failed = trace_present and ok_count <= 0
+    if not (missing_task_activity or goal_failed):
+        return False
+
+    label = "skillsbench_codex_cli_goal_uncountable_no_task_activity"
+    if goal_failed and not missing_task_activity:
+        label = "skillsbench_codex_cli_goal_uncountable_goal_failed"
+    compact["score_failure_attribution"] = label
+    compact["first_blocker"] = label
+    compact["repeat_blocked_by"] = label
+    compact["official_score_comparable_to_native_codex"] = False
+    compact["official_score_comparable_to_loopx_treatment"] = False
+    existing_labels = [
+        item
+        for item in compact.get("failure_attribution_labels", [])
+        if isinstance(item, str)
+        and item
+        not in {
+            "official_score_zero_case_failure",
+            "official_verifier_solution_failure",
+            "verifier_infrastructure_failure",
+        }
+    ]
+    for item in (
+        label,
+        "skillsbench_codex_cli_goal_uncountable_baseline",
+    ):
+        if item not in existing_labels:
+            existing_labels.append(item)
+    compact["failure_attribution_labels"] = existing_labels
+    compact["codex_cli_goal_countability_contract"] = {
+        "schema_version": "skillsbench_codex_cli_goal_countability_contract_v0",
+        "required": True,
+        "countable_baseline": False,
+        "failure_category": label,
+        "first_blocker": label,
+        "trace_present": trace_present,
+        "ok_count": ok_count,
+        "request_count": request_count,
+        "task_facing_activity_count": task_facing_count,
+        "operation_trace_status": operation_trace_status,
+        "raw_material_recorded": False,
+    }
+    runner_failure = compact.setdefault("runner_failure", {})
+    if isinstance(runner_failure, dict):
+        runner_failure["exception_type"] = label
+        runner_failure["failure_class"] = label
+        runner_failure["codex_cli_goal"] = {
+            "failure_category": label,
+            "trace_present": trace_present,
+            "ok_count": ok_count,
+            "request_count": request_count,
+            "task_facing_activity_count": task_facing_count,
+            "raw_material_recorded": False,
+        }
+    attempt_accounting = compact.get("attempt_accounting")
+    if isinstance(attempt_accounting, dict):
+        attempt_accounting["failure_class"] = "job_materialization_failed"
+        attempt_accounting["failure_label"] = label
+        attempt_accounting["lifecycle_phase"] = "runner_accepted_args"
+        for key in (
+            "case_attempt_countable",
+            "solver_attempt_countable",
+            "verifier_attempt_countable",
+            "official_score_attempt_countable",
+        ):
+            attempt_accounting[key] = False
+        attempts = attempt_accounting.get("attempts")
+        if isinstance(attempts, dict):
+            for key in ("case", "solver", "verifier", "official_score"):
+                attempt = attempts.get(key)
+                if isinstance(attempt, dict):
+                    attempt["countable"] = False
+    return True
+
+
 def _case_timeline_safe_string(value: Any, *, limit: int = 140) -> str:
     if not isinstance(value, str):
         return ""
@@ -14285,6 +14416,7 @@ def reduce_result(
             runner_prerequisites,
         )
     _apply_native_goal_worker_finish_guard_attribution(compact)
+    _apply_codex_cli_goal_countability_guard_attribution(compact)
     prereq_failure = _runner_prerequisite_failure_attribution(
         plan.get("runner_prerequisites")
     )
@@ -15234,6 +15366,7 @@ def build_runner_failure_compact(
     recovered = _recover_runner_failure_score_from_controller_trace(reduced, plan)
     if not recovered:
         _recover_runner_failure_score_from_verifier_artifact(reduced, plan)
+    _apply_codex_cli_goal_countability_guard_attribution(reduced)
     apply_skillsbench_verifier_bootstrap_missing_score_attribution(
         reduced,
         task_staging=_effective_public_task_staging(plan),


### PR DESCRIPTION
## Summary
- mark codex-cli-goal official-score rows non-countable when compact public counters show no task-facing worker activity or failed goal trace
- add a public countability contract and remove stale official-verifier-solution attribution for those rows
- wire the existing codex-cli-goal preflight smoke into the script entrypoint and update the round-reward ledger smoke to the current public ledger contract

## Validation
- python3 examples/skillsbench-benchmark-run-smoke.py
- python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py
- git diff --check origin/main..HEAD
- loopx check --scan-path scripts/skillsbench_automation_loop.py --scan-path examples/skillsbench-benchmark-run-smoke.py

## Notes
- This does not change official scoring; it prevents non-comparable codex-cli-goal rows from entering countable means when public worker activity evidence is missing.