### PR TITLE
Link public LoopX user manual

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ next actions, evidence, cost, and handoff state. The agent still needs a CLI,
 task mode, automation hook, or loop scheduler; LoopX supplies the control
 plane, not hidden autonomy.
 
-[Quick Start](#quick-start) · [How It Works](#how-it-works) · [See It In Action](#see-it-in-action) ·
+[Quick Start](#quick-start) · [User Manual](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [How It Works](#how-it-works) · [See It In Action](#see-it-in-action) ·
 [Hosted Frontstage](https://huangruiteng.github.io/loopx/frontstage/) · [Architecture](docs/architecture.md) ·
 [简体中文](README.zh-CN.md)
 
@@ -39,6 +39,7 @@ plane, not hidden autonomy.
 <summary>More docs and project links</summary>
 
 [Capability Surface](#capability-surface) · [Getting Started](docs/guides/getting-started.md) ·
+[User Manual](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) ·
 [Showcases](docs/showcases/README.md) · [Release Readiness](docs/product/release-readiness.md) ·
 [Update Notes](docs/update-notes/README.md) · [Community](#community--feedback) ·
 [Product Vision](docs/product/vision.md) · [Dashboard](apps/dashboard/README.md)
@@ -335,9 +336,12 @@ command-reference workflow, read
 
 ## See It In Action
 
-Want proof before reading the control-plane details? Use three short entry
-points:
+Want proof before reading the control-plane details? Start with the public
+manual, then use the short proof surfaces:
 
+- [User Manual (Feishu/Lark)](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg):
+  the public onboarding manual with Quick Start, product concepts, technical
+  concepts, FAQ, and selected real-world cases.
 - [Hosted Frontstage](https://huangruiteng.github.io/loopx/frontstage/):
   the public showcase homepage with the canonical case cards.
 - [Blocked P0 with safe P1/P2 rotation](docs/showcases/cases/0617-blocked-p0-safe-rotation.md):
@@ -633,6 +637,9 @@ contract.
 - [Getting started](docs/guides/getting-started.md): install, connect,
   diagnose, daily workflow, heartbeats, dashboard, development, and command
   reference.
+- [User manual](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg):
+  public Feishu/Lark onboarding guide with Quick Start, concepts, FAQ, and
+  selected cases.
 - [Documentation index](docs/README.md): stable docs grouped by audience.
 - [Update notes](docs/update-notes/README.md): public-safe two-week progress
   notes, archive, and publication automation plan.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -19,7 +19,7 @@ loop 状态：目标、用户决策、agent todo、认领关系、scope、证据
 同一份状态也会投影到本地管理面：用户可以先看项目、agent lane、user gate、
 todo、证据和 review 信号，再决定是否给 agent 更多自主权。
 
-[English](README.md) · [快速开始](#快速开始) · [看几个例子](#看几个例子) ·
+[English](README.md) · [快速开始](#快速开始) · [用户手册](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg) · [看几个例子](#看几个例子) ·
 [Showcases](docs/showcases/README.md) · [用户群与反馈](#用户群与反馈) ·
 [产品愿景](docs/product/vision.md) · [架构](docs/architecture.md)
 
@@ -123,8 +123,10 @@ loopx bootstrap \
 
 ## 看几个例子
 
-想先看证明，再读控制面细节，可以从三个短入口开始：
+想先看完整说明或证明，再读控制面细节，可以从这几个入口开始：
 
+- [飞书用户手册](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg)：
+  公开 onboarding 手册，包含 Quick Start、技术/产品要点、FAQ 和精选案例。
 - [Hosted Frontstage](https://huangruiteng.github.io/loopx/frontstage/)：
   公开 showcase 首页，用 canonical case cards 解释 LoopX 解决什么问题。
 - [Blocked P0 with safe P1/P2 rotation](docs/showcases/cases/0617-blocked-p0-safe-rotation.md)：

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,9 @@ incident report, or launch draft.
 
 - [Project README](../README.md): product positioning, showcases, and the
   shortest quick start.
+- [User manual (Feishu/Lark)](https://my.feishu.cn/wiki/CaL5wMk9ui17ngkWzeUcMlAYnZg):
+  public onboarding guide with Quick Start, product/technical concepts, FAQ,
+  and selected cases.
 - [Getting started](guides/getting-started.md): agent-first start, manual
   installation, project connection, diagnosis, daily workflow, heartbeats,
   dashboard, development, and command reference.


### PR DESCRIPTION
## Summary
- add the public Feishu/Lark user manual to the README first-screen nav
- add the same manual to the Chinese README examples section
- surface the manual from the docs index as a start-here entry

## Validation
- git diff --check origin/main..HEAD
- loopx check --scan-path README.md --scan-path README.zh-CN.md --scan-path docs/README.md

## Notes
- Public docs only; no private state, runtime evidence, or generated artifacts included.