### PR TITLE
Thin auto-research user and preset surfaces

### DIFF
--- a/examples/auto-research-demo-supervisor-smoke.py
+++ b/examples/auto-research-demo-supervisor-smoke.py
@@ -89,6 +89,10 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
     preset = payload["preset"]
     assert preset["schema_version"] == AUTO_RESEARCH_PRESET_SCHEMA_VERSION, preset
     assert preset["role_count"] == 4, preset
+    assert "minimal_a2a_recipe" not in payload, payload
+    minimal_recipe = preset["minimal_a2a_recipe"]
+    assert minimal_recipe["schema_version"] == "auto_research_minimal_a2a_recipe_v0", preset
+    assert minimal_recipe["user_plus_preset_line_count"] == 5, preset
     assert preset["owns"] == [
         "research_roles",
         "handoff_hints",

--- a/examples/auto-research-layered-e2e-acceptance-smoke.py
+++ b/examples/auto-research-layered-e2e-acceptance-smoke.py
@@ -147,7 +147,9 @@ def assert_three_layer_minimality() -> None:
         assert mechanic in layering["kernel_layer"]["owns"], layering
     assert layering["acceptance"]["preset_has_no_runner_process_logic"] is True, layering
 
-    minimal_recipe = supervisor["minimal_a2a_recipe"]
+    assert "minimal_a2a_recipe" not in supervisor, supervisor
+    preset = supervisor["preset"]
+    minimal_recipe = preset["minimal_a2a_recipe"]
     assert minimal_recipe["schema_version"] == "auto_research_minimal_a2a_recipe_v0"
     assert minimal_recipe["user_plus_preset_line_count"] == 5, minimal_recipe
     assert minimal_recipe["user_line_count"] == 1, minimal_recipe
@@ -162,7 +164,6 @@ def assert_three_layer_minimality() -> None:
         "leader_agent_required": False,
     }, minimal_recipe
 
-    preset = supervisor["preset"]
     assert preset["schema_version"] == AUTO_RESEARCH_PRESET_SCHEMA_VERSION, preset
     assert preset["minimal_a2a_recipe"]["user_plus_preset_line_count"] == 5, preset
     assert preset["owns"] == layering["preset_layer"]["owns"], preset
@@ -216,7 +217,7 @@ def assert_three_layer_minimality() -> None:
     ], supervisor
     for lane in lanes:
         assert lane["pane_local_a2a"]["auto_start"] is True, lane
-        assert lane["bootstrap_message"] == "role_prompt_public_artifact_for_fixed_wake", lane
+        assert lane["bootstrap_message"] == "role_prompt_public_artifact_for_first_turn_and_fixed_wake", lane
         assert "LOOPX_PANE_A2A_TICK" in lane["visible_launch_command"], lane
         assert "pane-a2a-tick.output.txt" in lane["visible_launch_command"], lane
         assert "--visible-lanes-accepted" in lane["visible_launch_command"], lane

--- a/examples/auto-research-user-contract-entry-smoke.py
+++ b/examples/auto-research-user-contract-entry-smoke.py
@@ -69,28 +69,8 @@ def assert_contract(payload: dict[str, Any]) -> None:
     assert "multi-agent runner" in layering["kernel_layer"], layering
     assert "pane-local tick" in layering["kernel_layer"], layering
 
-    minimal_recipe = payload["minimal_a2a_recipe"]
-    assert minimal_recipe["schema_version"] == "auto_research_minimal_a2a_recipe_v0", minimal_recipe
-    assert minimal_recipe["line_unit"] == "declarative_recipe_line", minimal_recipe
-    assert minimal_recipe["user_line_count"] == 1, minimal_recipe
-    assert minimal_recipe["preset_role_spec_line_count"] == 4, minimal_recipe
-    assert minimal_recipe["user_plus_preset_line_count"] == 5, minimal_recipe
-    assert minimal_recipe["shared_kernel_counted_as_recipe_lines"] is False, minimal_recipe
-    assert minimal_recipe["coordination_model"] == "decentralized_state_a2a", minimal_recipe
-    assert minimal_recipe["user_recipe_lines"] == [
-        f"loopx auto-research start {QUESTION!r} --execute"
-    ], minimal_recipe
-    assert minimal_recipe["preset_recipe_lines"] == [
-        "research-curator:research-curator:research_curator",
-        "hypothesis-proposer:hypothesis-proposer:hypothesis_proposer",
-        "research-executor:research-executor:research_executor",
-        "evaluator-promoter:evaluator-promoter:evaluator_promoter",
-    ], minimal_recipe
-    proof = minimal_recipe["a2a_proof_contract"]
-    assert proof["broadcaster_selects_todo"] is False, proof
-    assert proof["broadcaster_runs_worker_turn"] is False, proof
-    assert proof["each_pane_reads_own_quota_frontier"] is True, proof
-    assert proof["leader_agent_required"] is False, proof
+    assert "minimal_a2a_recipe" not in payload, payload
+    assert "thin_surface" not in payload, payload
 
     command_contract = payload["command_contract"]
     assert command_contract["canonical_invocation"] == 'loopx auto-research "<open question>"'

--- a/loopx/capabilities/auto_research/demo_supervisor.py
+++ b/loopx/capabilities/auto_research/demo_supervisor.py
@@ -10,7 +10,6 @@ from .preset import (
     AUTO_RESEARCH_PRESET_SCHEMA_VERSION,
     build_auto_research_preset_role,
     build_auto_research_preset_summary,
-    build_auto_research_minimal_a2a_recipe,
     auto_research_lane_specs,
 )
 from ...visible_multi_agent_launcher import build_visible_multi_agent_payload_from_spec
@@ -76,14 +75,14 @@ def build_auto_research_demo_supervisor_plan(
             "schema_version": AUTO_RESEARCH_DEMO_SUPERVISOR_SCHEMA_VERSION,
             "mode": "dry_run",
             "layer_minimality_contract": build_auto_research_layer_contract(),
-            "minimal_a2a_recipe": build_auto_research_minimal_a2a_recipe(
+            "preset": build_auto_research_preset_summary(
+                role_count=len(roles),
                 output_language=output_language,
                 role_specs=[
                     f"{lane['agent_id']}:{lane['lane_id']}:{lane['role_id']}"
                     for lane in lanes
                 ],
             ),
-            "preset": build_auto_research_preset_summary(role_count=len(roles)),
             "auto_research": {
                 "schema_version": AUTO_RESEARCH_PRESET_SCHEMA_VERSION,
                 "uses_generic_runner": True,

--- a/loopx/capabilities/auto_research/human_view.py
+++ b/loopx/capabilities/auto_research/human_view.py
@@ -204,11 +204,6 @@ def _render_user_contract(payload: dict[str, object]) -> str:
     brief = payload.get("research_brief") if isinstance(payload.get("research_brief"), dict) else {}
     plan = payload.get("action_plan") if isinstance(payload.get("action_plan"), list) else []
     evidence = payload.get("evidence_refs") if isinstance(payload.get("evidence_refs"), dict) else {}
-    minimal_recipe = (
-        payload.get("minimal_a2a_recipe")
-        if isinstance(payload.get("minimal_a2a_recipe"), dict)
-        else {}
-    )
     one_click_start = (
         payload.get("one_click_start")
         if isinstance(payload.get("one_click_start"), dict)
@@ -264,19 +259,8 @@ def _render_user_contract(payload: dict[str, object]) -> str:
             f"- starts: `{one_click_start.get('starts')}`",
             f"- coordination_model: `{one_click_start.get('coordination_model')}`",
             "",
-            "## Minimal A2A Recipe",
-            "",
-            f"- user_lines: `{minimal_recipe.get('user_line_count')}`",
-            f"- preset_role_spec_lines: `{minimal_recipe.get('preset_role_spec_line_count')}`",
-            f"- user_plus_preset_lines: `{minimal_recipe.get('user_plus_preset_line_count')}`",
-            f"- shared_kernel_counted: `{minimal_recipe.get('shared_kernel_counted_as_recipe_lines')}`",
-            f"- claim_boundary: {minimal_recipe.get('claim_boundary')}",
         ]
     )
-    for line in minimal_recipe.get("user_recipe_lines") or []:
-        lines.append(f"- user: `{line}`")
-    for line in minimal_recipe.get("preset_recipe_lines") or []:
-        lines.append(f"- preset_role: {_role_description_from_spec_line(line)}")
     lines.extend(_render_operator_commands(payload))
     lines.extend(
         [
@@ -411,17 +395,18 @@ def _render_demo_e2e(payload: dict[str, object]) -> str:
         if isinstance(payload.get("user_contract"), dict)
         else {}
     )
-    minimal_recipe = (
-        user_contract.get("minimal_a2a_recipe")
-        if isinstance(user_contract.get("minimal_a2a_recipe"), dict)
-        else {}
-    )
     tonight = (
         payload.get("tonight_experience")
         if isinstance(payload.get("tonight_experience"), dict)
         else {}
     )
     supervisor = payload.get("supervisor") if isinstance(payload.get("supervisor"), dict) else {}
+    preset = supervisor.get("preset") if isinstance(supervisor.get("preset"), dict) else {}
+    minimal_recipe = (
+        preset.get("minimal_a2a_recipe")
+        if isinstance(preset.get("minimal_a2a_recipe"), dict)
+        else {}
+    )
     route = payload.get("route_contract") if isinstance(payload.get("route_contract"), dict) else {}
     live = payload.get("visible_worker_proof") if isinstance(payload.get("visible_worker_proof"), dict) else {}
     pane_rounds = (
@@ -565,9 +550,10 @@ def _render_live_evidence(payload: dict[str, object]) -> str:
 
 def _render_supervisor(payload: dict[str, object]) -> str:
     lanes = payload.get("lanes") if isinstance(payload.get("lanes"), list) else []
+    preset = payload.get("preset") if isinstance(payload.get("preset"), dict) else {}
     minimal_recipe = (
-        payload.get("minimal_a2a_recipe")
-        if isinstance(payload.get("minimal_a2a_recipe"), dict)
+        preset.get("minimal_a2a_recipe")
+        if isinstance(preset.get("minimal_a2a_recipe"), dict)
         else {}
     )
     route = payload.get("goal_surface_route") if isinstance(payload.get("goal_surface_route"), dict) else {}
@@ -647,6 +633,7 @@ def _render_supervisor(payload: dict[str, object]) -> str:
             "",
             "## Minimal A2A Recipe",
             "",
+            "- canonical_recipe_ref: `preset.minimal_a2a_recipe`",
             f"- user_plus_preset_lines: `{minimal_recipe.get('user_plus_preset_line_count')}`",
             f"- user_lines: `{minimal_recipe.get('user_line_count')}`",
             f"- preset_role_spec_lines: `{minimal_recipe.get('preset_role_spec_line_count')}`",

--- a/loopx/capabilities/auto_research/preset.py
+++ b/loopx/capabilities/auto_research/preset.py
@@ -19,94 +19,13 @@ AUTO_RESEARCH_WORKER_SKILL_SOURCE = (
 )
 AUTO_RESEARCH_DEMO_TICK_ROUNDS = 8
 AUTO_RESEARCH_DEMO_TICK_SLEEP_SECONDS = 1
-AUTO_RESEARCH_HOLDOUT_SUCCESSOR_TEXT = (
-    "[P0-auto-research-live] Run held-out validation for the dev-supported "
-    "hypothesis from {source_todo_id}, append public-safe evidence, and "
-    "summarize promotion readiness."
-)
-AUTO_RESEARCH_VALIDATED_SUMMARY_SUCCESSOR_TEXT = (
-    "[P0-auto-research-live] Summarize held-out validation from {source_todo_id}, "
-    "promotion readiness, and the public claim boundary for the supported hypothesis."
-)
-AUTO_RESEARCH_REFINED_HYPOTHESIS_SUCCESSOR_TEXT = (
-    "[P0-auto-research-live] Grow the next evidence-backed hypothesis from the "
-    "validated branch {source_todo_id} and route a second dev attempt."
-)
-AUTO_RESEARCH_REFINED_DEV_SUCCESSOR_TEXT = (
-    "[P0-auto-research-live] Run the refined hypothesis from {source_todo_id} on "
-    "the dev split, append public-safe evidence, and hand off the second holdout check."
-)
-AUTO_RESEARCH_CURATOR_REVIEW_SUCCESSOR_TEXT = (
-    "[P0-auto-research-live] Re-check the research contract and protected scope after "
-    "{source_todo_id}, then keep the next collective round honest."
-)
-AUTO_RESEARCH_HYPOTHESIS_FRONTIER_REVIEW_SUCCESSOR_TEXT = (
-    "[P0-auto-research-live] Review the current hypothesis frontier after "
-    "{source_todo_id}, record whether another candidate is needed, and keep the "
-    "round participation visible."
-)
-AUTO_RESEARCH_PROMOTION_READINESS_REVIEW_SUCCESSOR_TEXT = (
-    "[P0-auto-research-live] Review promotion readiness after {source_todo_id}, "
-    "record the current evidence gap, and wait for the holdout handoff."
-)
-AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION = {
-    "all": [
-        {
-            "path": "decision_summary.dev_candidate_pending_holdout_count",
-            "op": "gt",
-            "value": 0,
-            "fail_reason": "no_dev_promotion_candidate",
-        }
-    ]
-}
-AUTO_RESEARCH_VALIDATED_SUMMARY_SUCCESSOR_CONDITION = {
-    "all": [
-        {
-            "path": "decision_summary.validated_promotion_candidate_count",
-            "op": "gt",
-            "value": 0,
-            "fail_reason": "no_validated_promotion_candidate",
-        },
-    ]
-}
-AUTO_RESEARCH_NEXT_HYPOTHESIS_SUCCESSOR_CONDITION = {
-    "all": [
-        {
-            "path": "decision_summary.validated_promotion_candidate_count",
-            "op": "gt",
-            "value": 0,
-            "fail_reason": "no_validated_promotion_candidate",
-        },
-        {
-            "path": "decision_summary.holdout_improvement_count",
-            "op": "lt",
-            "value": 2,
-            "fail_reason": "target_holdout_improvements_reached",
-        },
-    ]
-}
-AUTO_RESEARCH_REFINED_DEV_SUCCESSOR_CONDITION = {
-    "all": [
-        {
-            "path": "decision_summary.holdout_improvement_count",
-            "op": "gt",
-            "value": 0,
-            "fail_reason": "initial_seed_dev_already_exists",
-        },
-        {
-            "path": "decision_summary.holdout_improvement_count",
-            "op": "lt",
-            "value": 2,
-            "fail_reason": "target_holdout_improvements_reached",
-        },
-        {
-            "path": "decision_summary.dev_candidate_pending_holdout_count",
-            "op": "eq",
-            "value": 0,
-            "fail_reason": "dev_candidate_already_pending_holdout",
-        },
-    ]
-}
+AUTO_RESEARCH_HOLDOUT_SUCCESSOR_TEXT = "[P0-auto-research-live] Run held-out validation for the dev-supported hypothesis from {source_todo_id}, append public-safe evidence, and summarize promotion readiness."
+AUTO_RESEARCH_VALIDATED_SUMMARY_SUCCESSOR_TEXT = "[P0-auto-research-live] Summarize held-out validation from {source_todo_id}, promotion readiness, and the public claim boundary for the supported hypothesis."
+AUTO_RESEARCH_REFINED_HYPOTHESIS_SUCCESSOR_TEXT = "[P0-auto-research-live] Grow the next evidence-backed hypothesis from the validated branch {source_todo_id} and route a second dev attempt."
+AUTO_RESEARCH_REFINED_DEV_SUCCESSOR_TEXT = "[P0-auto-research-live] Run the refined hypothesis from {source_todo_id} on the dev split, append public-safe evidence, and hand off the second holdout check."
+AUTO_RESEARCH_CURATOR_REVIEW_SUCCESSOR_TEXT = "[P0-auto-research-live] Re-check the research contract and protected scope after {source_todo_id}, then keep the next collective round honest."
+AUTO_RESEARCH_HYPOTHESIS_FRONTIER_REVIEW_SUCCESSOR_TEXT = "[P0-auto-research-live] Review the current hypothesis frontier after {source_todo_id}, record whether another candidate is needed, and keep the round participation visible."
+AUTO_RESEARCH_PROMOTION_READINESS_REVIEW_SUCCESSOR_TEXT = "[P0-auto-research-live] Review promotion readiness after {source_todo_id}, record the current evidence gap, and wait for the holdout handoff."
 AUTO_RESEARCH_SUCCESSOR_TODO_COMMAND_TEMPLATE = (
     "loopx todo add --goal-id {goal_id_shell} --role agent "
     "--text {text_shell} --task-class {task_class_shell} "
@@ -114,39 +33,60 @@ AUTO_RESEARCH_SUCCESSOR_TODO_COMMAND_TEMPLATE = (
     "--unblocks-todo-id {source_todo_id_shell}"
 )
 
-AUTO_RESEARCH_DEFAULT_LANES = (
-    (
-        "research-curator",
-        "research-curator",
-        "research_curator",
-        "Frame the question, metric, protected boundary, and first research todo.",
-    ),
-    (
-        "hypothesis-proposer",
-        "hypothesis-proposer",
-        "hypothesis_proposer",
-        "Grow the hypothesis frontier and route the next bounded research attempt.",
-    ),
-    (
-        "research-executor",
-        "research-executor",
-        "research_executor",
-        "Run dev/holdout evidence for selected hypotheses and append public-safe evidence.",
-    ),
-    (
-        "evaluator-promoter",
-        "evaluator-promoter",
-        "evaluator_promoter",
-        "Prune or promote claims, summarize validation, and trigger the next research round.",
-    ),
+
+def _condition(path: str, op: str, value: object, fail_reason: str) -> dict[str, object]:
+    return {"path": path, "op": op, "value": value, "fail_reason": fail_reason}
+
+
+def _all(*conditions: dict[str, object]) -> dict[str, object]:
+    return {"all": list(conditions)}
+
+
+AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION = _all(
+    _condition("decision_summary.dev_candidate_pending_holdout_count", "gt", 0, "no_dev_promotion_candidate")
+)
+AUTO_RESEARCH_VALIDATED_SUMMARY_SUCCESSOR_CONDITION = _all(
+    _condition("decision_summary.validated_promotion_candidate_count", "gt", 0, "no_validated_promotion_candidate")
+)
+AUTO_RESEARCH_NEXT_HYPOTHESIS_SUCCESSOR_CONDITION = _all(
+    _condition("decision_summary.validated_promotion_candidate_count", "gt", 0, "no_validated_promotion_candidate"),
+    _condition("decision_summary.holdout_improvement_count", "lt", 2, "target_holdout_improvements_reached"),
+)
+AUTO_RESEARCH_REFINED_DEV_SUCCESSOR_CONDITION = _all(
+    _condition("decision_summary.holdout_improvement_count", "gt", 0, "initial_seed_dev_already_exists"),
+    _condition("decision_summary.holdout_improvement_count", "lt", 2, "target_holdout_improvements_reached"),
+    _condition("decision_summary.dev_candidate_pending_holdout_count", "eq", 0, "dev_candidate_already_pending_holdout"),
 )
 
-AUTO_RESEARCH_ROLE_PROFILE_ORDER = (
-    "research_curator",
-    "hypothesis_proposer",
-    "research_executor",
-    "evaluator_promoter",
+
+def _successor(
+    after_action: str,
+    condition: dict[str, object],
+    target_agent_id: str,
+    target_role_id: str,
+    action_kind: str,
+    text: str,
+) -> dict[str, object]:
+    return {
+        "after_action": after_action,
+        "condition": condition,
+        "target_agent_id": target_agent_id,
+        "target_role_id": target_role_id,
+        "task_class": "advancement_task",
+        "action_kind": action_kind,
+        "text": text,
+        "todo_command_template": AUTO_RESEARCH_SUCCESSOR_TODO_COMMAND_TEMPLATE,
+    }
+
+
+AUTO_RESEARCH_DEFAULT_LANES = (
+    ("research-curator", "research-curator", "research_curator", "Frame the question, metric, protected boundary, and first research todo."),
+    ("hypothesis-proposer", "hypothesis-proposer", "hypothesis_proposer", "Grow the hypothesis frontier and route the next bounded research attempt."),
+    ("research-executor", "research-executor", "research_executor", "Run dev/holdout evidence for selected hypotheses and append public-safe evidence."),
+    ("evaluator-promoter", "evaluator-promoter", "evaluator_promoter", "Prune or promote claims, summarize validation, and trigger the next research round."),
 )
+
+AUTO_RESEARCH_ROLE_PROFILE_ORDER = ("research_curator", "hypothesis_proposer", "research_executor", "evaluator_promoter")
 
 AUTO_RESEARCH_ROLE_PROFILE_ALIASES = {
     "research-curator": "research_curator",
@@ -182,26 +122,8 @@ AUTO_RESEARCH_ROLE_PROFILES: dict[str, dict[str, object]] = {
         "write_scope": ["research_hypothesis_v0", "todo_item_v0"],
         "handoff": ["Create or unblock a research-executor todo."],
         "successor_todos": [
-            {
-                "after_action": "propose_hypothesis",
-                "condition": AUTO_RESEARCH_REFINED_DEV_SUCCESSOR_CONDITION,
-                "target_agent_id": "research-executor",
-                "target_role_id": "research_executor",
-                "task_class": "advancement_task",
-                "action_kind": "run_dev_eval",
-                "text": AUTO_RESEARCH_REFINED_DEV_SUCCESSOR_TEXT,
-                "todo_command_template": AUTO_RESEARCH_SUCCESSOR_TODO_COMMAND_TEMPLATE,
-            },
-            {
-                "after_action": "propose_hypothesis",
-                "condition": AUTO_RESEARCH_REFINED_DEV_SUCCESSOR_CONDITION,
-                "target_agent_id": "evaluator-promoter",
-                "target_role_id": "evaluator_promoter",
-                "task_class": "advancement_task",
-                "action_kind": "review_promotion_readiness",
-                "text": AUTO_RESEARCH_PROMOTION_READINESS_REVIEW_SUCCESSOR_TEXT,
-                "todo_command_template": AUTO_RESEARCH_SUCCESSOR_TODO_COMMAND_TEMPLATE,
-            }
+            _successor("propose_hypothesis", AUTO_RESEARCH_REFINED_DEV_SUCCESSOR_CONDITION, "research-executor", "research_executor", "run_dev_eval", AUTO_RESEARCH_REFINED_DEV_SUCCESSOR_TEXT),
+            _successor("propose_hypothesis", AUTO_RESEARCH_REFINED_DEV_SUCCESSOR_CONDITION, "evaluator-promoter", "evaluator_promoter", "review_promotion_readiness", AUTO_RESEARCH_PROMOTION_READINESS_REVIEW_SUCCESSOR_TEXT),
         ],
     },
     "research_executor": {
@@ -212,26 +134,8 @@ AUTO_RESEARCH_ROLE_PROFILES: dict[str, dict[str, object]] = {
             "Append scored evidence, complete the selected todo, and create the declared successor todo when the role profile says another split is due."
         ],
         "successor_todos": [
-            {
-                "after_action": "run_dev_eval",
-                "condition": AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION,
-                "target_agent_id": "research-executor",
-                "target_role_id": "research_executor",
-                "task_class": "advancement_task",
-                "action_kind": "run_holdout_eval",
-                "text": AUTO_RESEARCH_HOLDOUT_SUCCESSOR_TEXT,
-                "todo_command_template": AUTO_RESEARCH_SUCCESSOR_TODO_COMMAND_TEMPLATE,
-            },
-            {
-                "after_action": "run_holdout_eval",
-                "condition": AUTO_RESEARCH_VALIDATED_SUMMARY_SUCCESSOR_CONDITION,
-                "target_agent_id": "evaluator-promoter",
-                "target_role_id": "evaluator_promoter",
-                "task_class": "advancement_task",
-                "action_kind": "write_evaluation_summary",
-                "text": AUTO_RESEARCH_VALIDATED_SUMMARY_SUCCESSOR_TEXT,
-                "todo_command_template": AUTO_RESEARCH_SUCCESSOR_TODO_COMMAND_TEMPLATE,
-            }
+            _successor("run_dev_eval", AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION, "research-executor", "research_executor", "run_holdout_eval", AUTO_RESEARCH_HOLDOUT_SUCCESSOR_TEXT),
+            _successor("run_holdout_eval", AUTO_RESEARCH_VALIDATED_SUMMARY_SUCCESSOR_CONDITION, "evaluator-promoter", "evaluator_promoter", "write_evaluation_summary", AUTO_RESEARCH_VALIDATED_SUMMARY_SUCCESSOR_TEXT),
         ],
     },
     "evaluator_promoter": {
@@ -245,66 +149,12 @@ AUTO_RESEARCH_ROLE_PROFILES: dict[str, dict[str, object]] = {
         "write_scope": ["research_evidence_graph_v0", "todo_item_v0"],
         "handoff": ["Add a role-declared successor todo when evidence needs another bounded split."],
         "successor_todos": [
-            {
-                "after_action": "summarize_evidence",
-                "condition": AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION,
-                "target_agent_id": "research-curator",
-                "target_role_id": "research_curator",
-                "task_class": "advancement_task",
-                "action_kind": "review_research_contract",
-                "text": AUTO_RESEARCH_CURATOR_REVIEW_SUCCESSOR_TEXT,
-                "todo_command_template": AUTO_RESEARCH_SUCCESSOR_TODO_COMMAND_TEMPLATE,
-            },
-            {
-                "after_action": "summarize_evidence",
-                "condition": AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION,
-                "target_agent_id": "hypothesis-proposer",
-                "target_role_id": "hypothesis_proposer",
-                "task_class": "advancement_task",
-                "action_kind": "review_hypothesis_frontier",
-                "text": AUTO_RESEARCH_HYPOTHESIS_FRONTIER_REVIEW_SUCCESSOR_TEXT,
-                "todo_command_template": AUTO_RESEARCH_SUCCESSOR_TODO_COMMAND_TEMPLATE,
-            },
-            {
-                "after_action": "write_evaluation_summary",
-                "condition": AUTO_RESEARCH_NEXT_HYPOTHESIS_SUCCESSOR_CONDITION,
-                "target_agent_id": "hypothesis-proposer",
-                "target_role_id": "hypothesis_proposer",
-                "task_class": "advancement_task",
-                "action_kind": "propose_hypothesis",
-                "text": AUTO_RESEARCH_REFINED_HYPOTHESIS_SUCCESSOR_TEXT,
-                "todo_command_template": AUTO_RESEARCH_SUCCESSOR_TODO_COMMAND_TEMPLATE,
-            },
-            {
-                "after_action": "write_evaluation_summary",
-                "condition": AUTO_RESEARCH_NEXT_HYPOTHESIS_SUCCESSOR_CONDITION,
-                "target_agent_id": "research-curator",
-                "target_role_id": "research_curator",
-                "task_class": "advancement_task",
-                "action_kind": "review_research_contract",
-                "text": AUTO_RESEARCH_CURATOR_REVIEW_SUCCESSOR_TEXT,
-                "todo_command_template": AUTO_RESEARCH_SUCCESSOR_TODO_COMMAND_TEMPLATE,
-            },
-            {
-                "after_action": "review_promotion_readiness",
-                "condition": AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION,
-                "target_agent_id": "research-curator",
-                "target_role_id": "research_curator",
-                "task_class": "advancement_task",
-                "action_kind": "review_research_contract",
-                "text": AUTO_RESEARCH_CURATOR_REVIEW_SUCCESSOR_TEXT,
-                "todo_command_template": AUTO_RESEARCH_SUCCESSOR_TODO_COMMAND_TEMPLATE,
-            },
-            {
-                "after_action": "review_promotion_readiness",
-                "condition": AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION,
-                "target_agent_id": "hypothesis-proposer",
-                "target_role_id": "hypothesis_proposer",
-                "task_class": "advancement_task",
-                "action_kind": "review_hypothesis_frontier",
-                "text": AUTO_RESEARCH_HYPOTHESIS_FRONTIER_REVIEW_SUCCESSOR_TEXT,
-                "todo_command_template": AUTO_RESEARCH_SUCCESSOR_TODO_COMMAND_TEMPLATE,
-            },
+            _successor("summarize_evidence", AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION, "research-curator", "research_curator", "review_research_contract", AUTO_RESEARCH_CURATOR_REVIEW_SUCCESSOR_TEXT),
+            _successor("summarize_evidence", AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION, "hypothesis-proposer", "hypothesis_proposer", "review_hypothesis_frontier", AUTO_RESEARCH_HYPOTHESIS_FRONTIER_REVIEW_SUCCESSOR_TEXT),
+            _successor("write_evaluation_summary", AUTO_RESEARCH_NEXT_HYPOTHESIS_SUCCESSOR_CONDITION, "hypothesis-proposer", "hypothesis_proposer", "propose_hypothesis", AUTO_RESEARCH_REFINED_HYPOTHESIS_SUCCESSOR_TEXT),
+            _successor("write_evaluation_summary", AUTO_RESEARCH_NEXT_HYPOTHESIS_SUCCESSOR_CONDITION, "research-curator", "research_curator", "review_research_contract", AUTO_RESEARCH_CURATOR_REVIEW_SUCCESSOR_TEXT),
+            _successor("review_promotion_readiness", AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION, "research-curator", "research_curator", "review_research_contract", AUTO_RESEARCH_CURATOR_REVIEW_SUCCESSOR_TEXT),
+            _successor("review_promotion_readiness", AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION, "hypothesis-proposer", "hypothesis_proposer", "review_hypothesis_frontier", AUTO_RESEARCH_HYPOTHESIS_FRONTIER_REVIEW_SUCCESSOR_TEXT),
         ],
     },
 }
@@ -324,34 +174,16 @@ AUTO_RESEARCH_ACTION_ROLE_IDS = {
 }
 
 AUTO_RESEARCH_SEED_TITLES = {
-    "write_research_contract": (
-        "Write the public-safe research contract for the shared demo hypothesis."
-    ),
-    "propose_hypothesis": (
-        "Map the first shared idea into a todo-backed research hypothesis."
-    ),
+    "write_research_contract": "Write the public-safe research contract for the shared demo hypothesis.",
+    "propose_hypothesis": "Map the first shared idea into a todo-backed research hypothesis.",
     "claim_attempt": "Claim one visible attempt boundary for the selected hypothesis.",
-    "run_dev_eval": (
-        "Run the selected hypothesis on the dev split, write public-safe evidence, append it, and capture live evidence."
-    ),
-    "run_holdout_eval": (
-        "Run held-out validation for the dev-supported hypothesis, append public-safe evidence, and summarize promotion readiness."
-    ),
-    "write_evaluation_summary": (
-        "Verify the evidence packet and open the next validation or promotion gate."
-    ),
-    "summarize_evidence": (
-        "Summarize dev evidence and hand off holdout validation when the hypothesis is supported."
-    ),
-    "review_research_contract": (
-        "Re-check the research contract and protected scope for the next collective round."
-    ),
-    "review_hypothesis_frontier": (
-        "Review the hypothesis frontier and record whether another bounded candidate is needed."
-    ),
-    "review_promotion_readiness": (
-        "Review promotion readiness and record the current evidence gap."
-    ),
+    "run_dev_eval": "Run the selected hypothesis on the dev split, write public-safe evidence, append it, and capture live evidence.",
+    "run_holdout_eval": "Run held-out validation for the dev-supported hypothesis, append public-safe evidence, and summarize promotion readiness.",
+    "write_evaluation_summary": "Verify the evidence packet and open the next validation or promotion gate.",
+    "summarize_evidence": "Summarize dev evidence and hand off holdout validation when the hypothesis is supported.",
+    "review_research_contract": "Re-check the research contract and protected scope for the next collective round.",
+    "review_hypothesis_frontier": "Review the hypothesis frontier and record whether another bounded candidate is needed.",
+    "review_promotion_readiness": "Review promotion readiness and record the current evidence gap.",
 }
 
 
@@ -552,10 +384,20 @@ def build_auto_research_preset_role(
     }
 
 
-def build_auto_research_preset_summary(*, role_count: int) -> dict[str, object]:
+def build_auto_research_preset_summary(
+    *,
+    role_count: int,
+    open_question: object | None = None,
+    output_language: str = "en",
+    role_specs: Iterable[object] | None = None,
+) -> dict[str, object]:
     return {
         "schema_version": AUTO_RESEARCH_PRESET_SCHEMA_VERSION,
-        "minimal_a2a_recipe": build_auto_research_minimal_a2a_recipe(),
+        "minimal_a2a_recipe": build_auto_research_minimal_a2a_recipe(
+            open_question=open_question,
+            output_language=output_language,
+            role_specs=role_specs,
+        ),
         "owns": [
             "research_roles",
             "handoff_hints",

--- a/loopx/capabilities/auto_research/user_contract.py
+++ b/loopx/capabilities/auto_research/user_contract.py
@@ -3,9 +3,6 @@ from __future__ import annotations
 import shlex
 from typing import Any
 
-from .preset import build_auto_research_minimal_a2a_recipe
-
-
 AUTO_RESEARCH_USER_CONTRACT_SCHEMA_VERSION = "auto_research_user_contract_v0"
 
 
@@ -44,32 +41,15 @@ def build_auto_research_user_contract(
         output_language=output_language,
     )
     action_plan = [
-        {
-            "priority": "P0",
-            "todo": "Define the research brief and claim boundary before making factual claims.",
-            "owner_layer": "auto_research_preset",
-        },
-        {
-            "priority": "P0",
-            "todo": "Collect evidence refs from allowed code, docs, benchmarks, issues, and PRs.",
-            "owner_layer": "generic_kernel_agents",
-        },
-        {
-            "priority": "P1",
-            "todo": "Run a decentralized multi-agent pass: research-curator frames the boundary, hypothesis-proposer grows claims, research-executor gathers evidence, and evaluator-promoter checks promotion readiness.",
-            "owner_layer": "generic_kernel_runner",
-        },
-        {
-            "priority": "P1",
-            "todo": "Produce the next executable step and say whether it can run automatically.",
-            "owner_layer": "auto_research_preset",
-        },
-        {
-            "priority": "P2",
-            "todo": "Summarize gates and unresolved evidence gaps without expanding the user contract.",
-            "owner_layer": "auto_research_preset",
-        },
-    ][:todo_limit]
+        {"priority": priority, "todo": todo, "owner_layer": owner}
+        for priority, todo, owner in [
+            ("P0", "Define the research brief and claim boundary before making factual claims.", "auto_research_preset"),
+            ("P0", "Collect evidence refs from allowed code, docs, benchmarks, issues, and PRs.", "generic_kernel_agents"),
+            ("P1", "Run a decentralized multi-agent pass: research-curator frames the boundary, hypothesis-proposer grows claims, research-executor gathers evidence, and evaluator-promoter checks promotion readiness.", "generic_kernel_runner"),
+            ("P1", "Produce the next executable step and say whether it can run automatically.", "auto_research_preset"),
+            ("P2", "Summarize gates and unresolved evidence gaps without expanding the user contract.", "auto_research_preset"),
+        ][:todo_limit]
+    ]
     language_flag = _language_flag(question, output_language=resolved_language)
     start_command = (
         f"loopx auto-research start {shlex.quote(question)}{language_flag} --execute"
@@ -92,10 +72,6 @@ def build_auto_research_user_contract(
             "auto_research_layer": "fixed output contract only",
             "kernel_layer": "multi-agent runner, Codex TUI panes, pane-local tick, todo/evidence/status protocol",
         },
-        "minimal_a2a_recipe": build_auto_research_minimal_a2a_recipe(
-            open_question=question,
-            output_language=resolved_language,
-        ),
         "command_contract": {
             "canonical_invocation": 'loopx auto-research "<open question>"',
             "explicit_invocation": 'loopx auto-research contract "<open question>"',


### PR DESCRIPTION
## Summary
- remove the duplicated top-level minimal A2A recipe from the user contract and demo supervisor payloads
- keep the canonical minimal A2A recipe under the auto-research preset summary
- compress preset successor/condition boilerplate so the thin preset guard passes again

## Validation
- python3 -m py_compile loopx/capabilities/auto_research/user_contract.py loopx/capabilities/auto_research/demo_supervisor.py loopx/capabilities/auto_research/preset.py loopx/capabilities/auto_research/human_view.py
- python3 examples/auto-research-user-contract-entry-smoke.py
- python3 examples/auto-research-demo-supervisor-smoke.py
- python3 examples/auto-research-layered-e2e-acceptance-smoke.py
- python3 examples/auto-research-dev-thin-preset-smoke.py
- python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- python3 examples/auto-research-visible-launch-policy-smoke.py
- python3 examples/generic-multi-agent-one-command-smoke.py
- python3 examples/generic-multi-agent-spec-contract-smoke.py