### PR TITLE
Harden LoopX premerge canary wrapper gate

### DIFF
--- a/examples/canary/premerge-validation-gate-smoke.py
+++ b/examples/canary/premerge-validation-gate-smoke.py
@@ -4,8 +4,10 @@
 from __future__ import annotations
 
 import json
+import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -13,6 +15,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.canary.premerge import (  # noqa: E402
+    _gate_status,
     build_premerge_validation_gate,
     downgrade_inherited_baseline_failures,
 )
@@ -121,6 +124,51 @@ def assert_cli_json_preview() -> None:
     assert selector_sources is None or isinstance(selector_sources, dict), payload
 
 
+def assert_no_changes_does_not_mask_direct_failures() -> None:
+    status = _gate_status(
+        execute=True,
+        changed_files=[],
+        direct_checks=[{"ok": False, "status": "failed", "id": "diff_check_committed"}],
+        catalog_run={"ok": True},
+        risk_profile_run=None,
+        boundary_run=None,
+        manual_holds=[],
+    )
+    assert status["status"] == "failed", status
+    assert status["merge_gate_passed"] is False, status
+
+
+def assert_installed_wrapper_premerge_redirects_to_checkout() -> None:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        release_root = Path(temp_dir) / "release"
+        scripts_dir = release_root / "scripts"
+        scripts_dir.mkdir(parents=True)
+        wrapper = scripts_dir / "loopx"
+        shutil.copy2(REPO_ROOT / "scripts" / "loopx", wrapper)
+        completed = subprocess.run(
+            [
+                str(wrapper),
+                "--format",
+                "json",
+                "canary",
+                "premerge",
+                "--changed-file",
+                "loopx/canary/premerge.py",
+                "--no-execute",
+            ],
+            cwd=REPO_ROOT,
+            check=False,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+    assert completed.returncode == 0, completed.stderr or completed.stdout
+    payload = json.loads(completed.stdout)
+    assert payload["ok"] is True, payload
+    assert payload["gate"]["status"] == "preview_only", payload
+    assert Path(payload["repo_root"]).resolve() == REPO_ROOT.resolve(), payload
+
+
 def assert_inherited_line_budget_red_is_advisory_only() -> None:
     inherited_run = {
         "ok": False,
@@ -142,6 +190,24 @@ def assert_inherited_line_budget_red_is_advisory_only() -> None:
     assert downgraded["failure_count"] == 0, downgraded
     assert downgraded["advisory_failure_count"] == 1, downgraded
     assert downgraded["selected_checks"][0]["status"] == "advisory_inherited_failure", downgraded
+
+    extensionless_path_run = {
+        "ok": False,
+        "warning_count": 0,
+        "selected_checks": [
+            {
+                "ok": False,
+                "status": "failed",
+                "command": "python3 examples/control_plane/repo-python-line-budget-smoke.py",
+                "stderr_tail": "loopx/benchmark_adapters/skillsbench_acp_relay.py has 3775 lines",
+            }
+        ],
+    }
+    extensionless_path_downgraded = downgrade_inherited_baseline_failures(
+        extensionless_path_run,
+        changed_files=["scripts/loopx"],
+    )
+    assert extensionless_path_downgraded["ok"] is True, extensionless_path_downgraded
 
     current_diff_run = {
         "ok": False,
@@ -169,6 +235,8 @@ def main() -> None:
     assert_changed_python_gets_compile_check()
     assert_benchmark_sensitive_change_blocks_self_merge()
     assert_cli_json_preview()
+    assert_no_changes_does_not_mask_direct_failures()
+    assert_installed_wrapper_premerge_redirects_to_checkout()
     assert_inherited_line_budget_red_is_advisory_only()
     print("premerge-validation-gate-smoke ok")
 

--- a/loopx/canary/premerge.py
+++ b/loopx/canary/premerge.py
@@ -306,12 +306,12 @@ def _gate_status(
     for run in [catalog_run, risk_profile_run, boundary_run]:
         if isinstance(run, dict) and not run.get("ok"):
             run_failures.append(run)
-    if not changed_files:
+    if direct_failures or run_failures:
+        status = "failed"
+    elif not changed_files:
         status = "no_changes"
     elif manual_holds:
         status = "manual_review_required"
-    elif direct_failures or run_failures:
-        status = "failed"
     elif not execute:
         status = "preview_only"
     else:
@@ -355,7 +355,9 @@ def downgrade_inherited_baseline_failures(
     changed = {_norm_path(path) for path in changed_files if _norm_path(path)}
     changed_mentions = {path for path in changed}
     for path in list(changed):
-        changed_mentions.add(Path(path).name)
+        basename = Path(path).name
+        if Path(path).suffix:
+            changed_mentions.add(basename)
 
     changed_any = False
     for check in run.get("selected_checks", []):

--- a/scripts/loopx
+++ b/scripts/loopx
@@ -12,6 +12,42 @@ done
 script_dir="$(cd -P "$(dirname "$script_path")" && pwd)"
 repo_root="$(cd "$script_dir/.." && pwd)"
 
+loopx_command=""
+loopx_subcommand=""
+skip_next_arg=0
+for arg in "$@"; do
+  if [[ "$skip_next_arg" == "1" ]]; then
+    skip_next_arg=0
+    continue
+  fi
+  case "$arg" in
+    --format|--registry|--runtime-root|--goal-id|--agent-id|--git-diff-base|--tier|--timeout-seconds|--changed-file|--catalog|--surface|--family|--profile|--suite|--module|--exclude-module|--script|--limit|--offset|--max-checks-per-family|--max-checks-per-profile)
+      skip_next_arg=1
+      continue
+      ;;
+    --*)
+      continue
+      ;;
+  esac
+  if [[ -z "$loopx_command" ]]; then
+    loopx_command="$arg"
+  elif [[ -z "$loopx_subcommand" ]]; then
+    loopx_subcommand="$arg"
+    break
+  fi
+done
+
+if [[ "$loopx_command" == "canary" && "$loopx_subcommand" == "premerge" ]]; then
+  checkout_root=""
+  if command -v git >/dev/null 2>&1; then
+    checkout_root="$(git -C "$PWD" rev-parse --show-toplevel 2>/dev/null || true)"
+  fi
+  if [[ -n "$checkout_root" && -f "$checkout_root/loopx/cli.py" && -d "$checkout_root/examples" ]]; then
+    # Pre-merge validation must exercise the checkout under review, not a stale release snapshot.
+    repo_root="$checkout_root"
+  fi
+fi
+
 python_bin="${LOOPX_PYTHON:-}"
 if [[ -z "$python_bin" ]]; then
   python_bin="python3"


### PR DESCRIPTION
## Summary

Follow-up to #1413. This hardens the new premerge gate after installed-release verification exposed two issues:

- `no_changes` could mask direct diff-check failures, producing a false green gate.
- the installed `loopx` wrapper could run `canary premerge` from the release snapshot root instead of the checkout under review.

The wrapper now redirects only `canary premerge` invocations to the current LoopX checkout when one is detected. Other release commands keep release-snapshot behavior.

## Changed surfaces

- `canary_runner`: gate status ordering and inherited-baseline matching.
- `install_release`: `scripts/loopx` premerge-only checkout redirect.
- `public_boundary`: smoke/example path changed.
- `python`: updated premerge smoke and module compile.

## Validation

- `bash -n scripts/loopx`
- `python3 examples/canary/premerge-validation-gate-smoke.py`
- `python3 examples/canary/smoke-suite-runner-smoke.py`
- `python3 -m py_compile loopx/canary/premerge.py examples/canary/premerge-validation-gate-smoke.py`
- `git diff --check origin/main...HEAD && git diff --cached --check && git diff --check`
- `python3 -m loopx.cli --format json canary premerge --from-git-diff --tier standard --timeout-seconds 180`

Premerge gate result:

- status: `passed`
- self_merge_allowed: `true`
- catalog canaries: 7 selected / 7 executed / 0 blocking failures / 1 advisory inherited baseline failure
- risk profile smokes: 8 selected / 8 executed / 0 failures
- public/private boundary: 1 selected / 1 executed / 0 failures

The advisory inherited baseline failure is the repo Python line-budget smoke; it did not mention this PR's changed files after tightening extensionless path matching.

## Merge decision

Self-merge candidate. This is a narrow hardening follow-up for the premerge canary developer workflow, does not touch benchmark scoring/task semantics, does not change permission boundaries, and includes focused regression coverage for the false-green and wrapper redirect cases.