### PR TITLE
Fix CLI goal bridge action watchdog

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -322,10 +322,32 @@ def _assert_cli_goal_rate_limit_is_public_safe_retryable_stage() -> None:
 def _assert_cli_goal_input_is_submitted_as_one_buffer() -> None:
     sys.path.insert(0, str(REPO_ROOT))
     from loopx.codex_cli_goal_tui import build_codex_cli_goal_tui_input
+    from loopx.benchmark_adapters.skillsbench_acp_relay import (
+        CodexExecConfig,
+        SkillsBenchLocalAcpRelay,
+        _prompt_requires_bridge_first_action,
+        _prompt_requires_meaningful_bridge_progress,
+    )
 
     objective = "Solve the task.\nUse the private bridge."
     assert build_codex_cli_goal_tui_input(objective) == (
         "/goal Solve the task.\nUse the private bridge."
+    )
+    packet = SkillsBenchLocalAcpRelay(
+        CodexExecConfig(remote_command_file_bridge_command="/tmp/private-bridge")
+    )._prompt_with_remote_bridge_packet(
+        "Task",
+        bridge_probe={"operation_count": 1},
+        bridge_command_for_agent="/tmp/private-bridge",
+    )
+    assert "FIRST ACTION REQUIRED" in packet, packet
+    assert _prompt_requires_bridge_first_action(packet) is True
+    assert (
+        _prompt_requires_meaningful_bridge_progress(
+            packet,
+            route="codex-cli-goal-baseline",
+        )
+        is True
     )
     for relative in (
         "loopx/benchmark_adapters/skillsbench_acp_relay.py",

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -102,6 +102,7 @@ def _prompt_requires_bridge_first_action(prompt: str) -> bool:
         "mandatory product-mode solver checkpoint",
         "mandatory product-mode closeout checkpoint",
         "must start with either a task-facing sandbox bridge operation",
+        "first action required",
         "your first tool action should be a shell",
         "your first agent action must be a shell/tool call",
         "your first agent action must be a task-facing shell/tool call",
@@ -321,6 +322,7 @@ def _prompt_requires_meaningful_bridge_progress(prompt: str, *, route: str) -> b
         marker in lowered
         for marker in (
             "--- task instruction ---",
+            "first action required",
             "mandatory product-mode solver checkpoint",
             "mandatory host-local bridge recovery checkpoint",
             "must start with either a task-facing sandbox bridge operation",


### PR DESCRIPTION
## Summary
- Make the SkillsBench Codex CLI /goal watchdog recognize the remote bridge packet's `FIRST ACTION REQUIRED` marker.
- Cover that marker in the canonical `skillsbench-codex-cli-goal-route-smoke.py` so bridge packets trigger first-action and meaningful-progress guards.

## Validation
- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 -m py_compile loopx/benchmark_adapters/skillsbench_acp_relay.py examples/skillsbench-codex-cli-goal-route-smoke.py`
- focused marker contract snippet for `_prompt_requires_bridge_first_action` and `_prompt_requires_meaningful_bridge_progress`

## Context
A single-case codex-cli-goal xhigh backfill reached the explicit first-action timeout window without producing task-facing compact output. The runner prompt contained `FIRST ACTION REQUIRED`, but the watchdog marker list did not recognize that phrase, so the TUI route could wait for goal terminal state instead of closing out on missing bridge progress. No raw trajectory, task text, verifier output, credentials, or private run logs are included.