### PR TITLE
Add status projection cache canary profile

### DIFF
--- a/examples/canary/catalog-planner-smoke.py
+++ b/examples/canary/catalog-planner-smoke.py
@@ -50,6 +50,7 @@ def assert_profiles_come_from_catalog_matrix() -> None:
         "repo-architecture-budget",
         "control-plane-state-machine",
         "status-read-path",
+        "status-projection-cache",
         "review-packet-read-path",
         "event-sourced-read-path",
         "cli-command-contract",
@@ -347,6 +348,22 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     )
     assert "python3 examples/control_plane/goal-channel-readmodel-smoke.py" in status_wide_commands, (
         status_wide_payload
+    )
+
+    status_cache_payload = build_catalog_canary_plan(
+        changed_files=["loopx/control_plane/runtime/status_projection_cache.py"],
+        surfaces=["status_projection_cache projection-cache read-path"],
+        max_checks_per_profile=4,
+    )
+    status_cache_profiles = {
+        profile["id"]: profile for profile in status_cache_payload["domain_profiles"]
+    }
+    assert "status-projection-cache" in status_cache_profiles, status_cache_payload
+    status_cache_commands = [
+        check["command"] for check in status_cache_profiles["status-projection-cache"]["checks"]
+    ]
+    assert "python3 examples/control_plane/status-projection-cache-smoke.py" in status_cache_commands, (
+        status_cache_payload
     )
 
     runtime_handoff_payload = build_catalog_canary_plan(

--- a/examples/control_plane/status-projection-cache-smoke.py
+++ b/examples/control_plane/status-projection-cache-smoke.py
@@ -120,23 +120,47 @@ def run_cli(registry_path: Path, *args: str) -> dict[str, Any]:
 
 
 def assert_cache_hit(payload: dict[str, Any]) -> None:
-    cache = payload.get("projection_cache")
-    if not isinstance(cache, dict):
-        cache = payload.get("status_projection_cache")
+    cache = cache_metadata(payload)
     assert isinstance(cache, dict), payload
     assert cache.get("schema_version") == "status_projection_cache_v0", cache
     assert cache.get("hit") is True, cache
 
 
 def assert_cache_written(payload: dict[str, Any]) -> None:
-    cache = payload.get("projection_cache")
-    if not isinstance(cache, dict):
-        cache = payload.get("status_projection_cache")
+    cache = cache_metadata(payload)
     assert isinstance(cache, dict), payload
     assert cache.get("schema_version") == "status_projection_cache_v0", cache
     assert cache.get("written") is True, cache
     assert cache.get("hit") is False, cache
     assert Path(str(cache.get("path"))).exists(), cache
+
+
+def cache_metadata(payload: dict[str, Any]) -> dict[str, Any]:
+    cache = payload.get("projection_cache")
+    if not isinstance(cache, dict):
+        cache = payload.get("status_projection_cache")
+    assert isinstance(cache, dict), payload
+    return cache
+
+
+def expire_cache_record(payload: dict[str, Any]) -> None:
+    path = Path(str(cache_metadata(payload).get("path")))
+    record = json.loads(path.read_text(encoding="utf-8"))
+    record["generated_at"] = "2000-01-01T00:00:00Z"
+    path.write_text(json.dumps(record, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def assert_cache_expired(payload: dict[str, Any]) -> None:
+    cache = cache_metadata(payload)
+    assert cache.get("schema_version") == "status_projection_cache_v0", cache
+    assert cache.get("hit") is False, cache
+    assert cache.get("miss_reason") == "expired", cache
+
+
+def assert_next_action(payload: dict[str, Any], expected_todo_id: str) -> None:
+    next_action = payload.get("agent_lane_next_action")
+    assert isinstance(next_action, dict), payload
+    assert next_action.get("todo_id") == expected_todo_id, payload
 
 
 def main() -> int:
@@ -157,6 +181,7 @@ def main() -> int:
             AGENT_ID,
         )
         assert todo_payload.get("ok") is True, todo_payload
+        initial_todo_id = str(todo_payload["todo_id"])
 
         status_write = run_cli(
             registry_path,
@@ -221,6 +246,133 @@ def main() -> int:
         assert quota_cached.get("ok") is True, quota_cached
         assert quota_cached.get("should_run") is True, quota_cached
         assert_cache_hit(quota_cached)
+        assert_next_action(quota_cached, initial_todo_id)
+
+        completed = run_cli(
+            registry_path,
+            "todo",
+            "complete",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--todo-id",
+            initial_todo_id,
+            "--claimed-by",
+            AGENT_ID,
+            "--evidence",
+            "fixture cache state transition",
+            "--next-agent-todo",
+            "Continue after status projection cache invalidation.",
+            "--next-claimed-by",
+            AGENT_ID,
+            "--next-task-class",
+            "advancement_task",
+            "--next-action-kind",
+            "status_projection_cache_successor",
+        )
+        assert completed.get("ok") is True, completed
+        successor_id = completed["next_todos"][0]["todo_id"]
+
+        live_status = run_cli(
+            registry_path,
+            "status",
+            "--scan-path",
+            str(public_doc),
+            "--limit",
+            "5",
+        )
+        live_status_text = json.dumps(live_status, sort_keys=True)
+        assert successor_id in live_status_text, live_status
+        assert "projection_cache" not in live_status, live_status
+
+        live_quota = run_cli(
+            registry_path,
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--available-capability",
+            "shell",
+            "--scan-path",
+            str(public_doc),
+            "--limit",
+            "5",
+        )
+        assert live_quota.get("ok") is True, live_quota
+        assert_next_action(live_quota, successor_id)
+        assert "status_projection_cache" not in live_quota, live_quota
+
+        stale_status = run_cli(
+            registry_path,
+            "status",
+            "--scan-path",
+            str(public_doc),
+            "--limit",
+            "5",
+            "--use-projection-cache",
+        )
+        assert_cache_hit(stale_status)
+        stale_status_text = json.dumps(stale_status, sort_keys=True)
+        assert initial_todo_id in stale_status_text, stale_status
+        assert successor_id not in stale_status_text, stale_status
+
+        stale_quota = run_cli(
+            registry_path,
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--available-capability",
+            "shell",
+            "--scan-path",
+            str(public_doc),
+            "--limit",
+            "5",
+            "--use-projection-cache",
+        )
+        assert stale_quota.get("ok") is True, stale_quota
+        assert_cache_hit(stale_quota)
+        assert_next_action(stale_quota, initial_todo_id)
+
+        expire_cache_record(stale_status)
+        expire_cache_record(stale_quota)
+
+        expired_status = run_cli(
+            registry_path,
+            "status",
+            "--scan-path",
+            str(public_doc),
+            "--limit",
+            "5",
+            "--use-projection-cache",
+        )
+        assert_cache_expired(expired_status)
+        assert successor_id in json.dumps(expired_status, sort_keys=True), expired_status
+
+        expired_quota = run_cli(
+            registry_path,
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--available-capability",
+            "shell",
+            "--scan-path",
+            str(public_doc),
+            "--limit",
+            "5",
+            "--use-projection-cache",
+        )
+        assert expired_quota.get("ok") is True, expired_quota
+        assert_cache_expired(expired_quota)
+        assert_next_action(expired_quota, successor_id)
 
         public_doc.write_text(
             f"Public leak probe must still be caught by default quota scan: {PRIVATE_DOC_MARKER}\n",

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -536,6 +536,34 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
         ],
     },
     {
+        "id": "status-projection-cache",
+        "title": "Status projection cache contract",
+        "purpose": (
+            "Check opt-in status projection cache freshness, expiration fallback, "
+            "and quota next-action isolation before cache-path changes ship."
+        ),
+        "catalog_families": ["Work Routing", "State And Boundary"],
+        "trigger_hints": (
+            "projection-cache",
+            "status_projection_cache",
+            "use-projection-cache",
+            "write-projection-cache",
+            "status projection cache",
+            "loopx/control_plane/runtime/status_projection_cache.py",
+            "examples/control_plane/status-projection-cache-smoke.py",
+        ),
+        "checks": [
+            {
+                "command": "python3 examples/control_plane/status-projection-cache-smoke.py",
+                "tier": "default",
+                "reason": (
+                    "guards opt-in status projection cache freshness, expiration fallback, "
+                    "and quota next-action read-path isolation"
+                ),
+            },
+        ],
+    },
+    {
         "id": "review-packet-read-path",
         "title": "Review-packet read-path contract",
         "purpose": "Check operator review packets, handoff-only payloads, and task-graph lineage before review-packet/read-path changes ship.",


### PR DESCRIPTION
## Summary
- extend the status projection cache smoke into a state-transition canary: cache hit, live default status/quota, stale opt-in cache, and expired-cache fallback to current successor todo
- add a dedicated status-projection-cache canary domain profile so cache-path changes select the smoke in premerge
- update catalog planner coverage assertions for the new profile

## Validation
- python3 examples/control_plane/status-projection-cache-smoke.py
- python3 examples/canary/catalog-planner-smoke.py
- python3 -m py_compile examples/control_plane/status-projection-cache-smoke.py examples/canary/catalog-planner-smoke.py loopx/canary/planner.py
- git diff --check
- python3 -m loopx.cli --format json canary plan --changed-file loopx/control_plane/runtime/status_projection_cache.py --surface status_projection_cache --surface projection-cache --max-checks-per-profile 3
- python3 -m loopx.cli --format json canary premerge --from-git-diff --tier standard --timeout-seconds 180

Premerge gate passed and self_merge_allowed=true. Advisory only: existing repo-python-line-budget baseline failures in unrelated oversized files; gate marked them inherited advisory, not blocking this diff.

## Boundary
- added-line scan found no private paths, credentials, raw benchmark logs, trajectories, verifier output, or benchmark task text in changed lines.