### PR TITLE
Preserve event-projected monitor metadata

### DIFF
--- a/examples/control_plane/event-sourced-downstream-read-path-smoke.py
+++ b/examples/control_plane/event-sourced-downstream-read-path-smoke.py
@@ -26,6 +26,8 @@ from loopx.status import active_state_todo_fields, project_asset_todo_summary  #
 GOAL_ID = "event-sourced-downstream-read-fixture"
 EVENT_TODO_ID = "todo_event_downstream_read"
 EVENT_TODO = "Use event projection for downstream read surfaces"
+EVENT_MONITOR_ID = "todo_event_monitor_readonly"
+EVENT_MONITOR = "Poll event-projected monitor metadata without writeback"
 MARKDOWN_TODO_ID = "todo_markdown_fallback"
 MARKDOWN_TODO = "Fallback Markdown todo for corrupted event logs"
 
@@ -81,6 +83,32 @@ def append_event_todos(event_log: Path) -> None:
             payload={"claimed_by": "codex-product-capability"},
             producer="event-sourced-downstream-read-path-smoke",
             recorded_at="2026-06-27T02:00:02Z",
+        )
+    )
+
+
+def append_event_todo_and_due_monitor(event_log: Path) -> None:
+    append_event_todos(event_log)
+    store = AppendOnlyStateEventStore(event_log)
+    store.append(
+        make_state_event(
+            event_id="evt-add-readonly-monitor",
+            goal_id=GOAL_ID,
+            event_type=TODO_ADDED,
+            refs={"todo_id": EVENT_MONITOR_ID},
+            payload={
+                "role": "agent",
+                "priority": "P0",
+                "title": EVENT_MONITOR,
+                "planner_order": 2,
+                "task_class": "continuous_monitor",
+                "action_kind": "poll",
+                "target_key": "event-projected-watch",
+                "cadence": "15m",
+                "next_due_at": "2026-01-01T00:00:00+00:00",
+            },
+            producer="event-sourced-downstream-read-path-smoke",
+            recorded_at="2026-06-27T02:00:03Z",
         )
     )
 
@@ -151,6 +179,14 @@ def agent_todo_ids(fields: dict) -> list[str]:
     return [str(item.get("todo_id") or "") for item in agent_todos.get("items") or []]
 
 
+def agent_todo_by_id(fields: dict, todo_id: str) -> dict:
+    agent_todos = fields.get("agent_todos") if isinstance(fields.get("agent_todos"), dict) else {}
+    for item in agent_todos.get("items") or []:
+        if isinstance(item, dict) and item.get("todo_id") == todo_id:
+            return item
+    raise AssertionError(f"missing todo {todo_id}: {fields}")
+
+
 def test_event_projection_feeds_quota_and_review_packet() -> None:
     with tempfile.TemporaryDirectory(prefix="loopx-event-downstream-") as tmp:
         project = Path(tmp)
@@ -189,6 +225,57 @@ def test_event_projection_feeds_quota_and_review_packet() -> None:
         assert MARKDOWN_TODO not in packet["project_agent_handoff"], packet
 
 
+def test_event_projected_due_monitor_is_read_only_for_writeback() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-event-readonly-monitor-") as tmp:
+        project = Path(tmp)
+        state_path = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+        write_active_state(state_path)
+        append_event_todo_and_due_monitor(state_path.with_name("events.jsonl"))
+
+        goal = {
+            "id": GOAL_ID,
+            "repo": str(project),
+            "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
+        }
+        fields = active_state_todo_fields(goal)
+        assert agent_todo_ids(fields) == [EVENT_TODO_ID, EVENT_MONITOR_ID], fields
+        monitor = agent_todo_by_id(fields, EVENT_MONITOR_ID)
+        assert monitor["target_key"] == "event-projected-watch", monitor
+        assert monitor["cadence"] == "15m", monitor
+        assert monitor["next_due_at"] == "2026-01-01T00:00:00+00:00", monitor
+        monitor_writeback = fields["agent_todos"]["monitor_writeback"]
+        assert monitor_writeback == {
+            "schema_version": "monitor_writeback_contract_v0",
+            "supported": False,
+            "source": "event_projection_read_model",
+        }, fields
+
+        status = status_payload_from_fields(project, fields)
+        status["run_history"]["goals"][0]["coordination"]["primary_agent"] = (
+            "codex-product-capability"
+        )
+        guard = build_quota_should_run(
+            status,
+            goal_id=GOAL_ID,
+            agent_id="codex-product-capability",
+        )
+        assert guard["decision"] == "run", guard
+        assert guard["agent_lane_next_action"]["todo_id"] == EVENT_TODO_ID, guard
+        lane = guard["work_lane_contract"]
+        assert lane["lane"] == "advancement_task", lane
+        assert "open_agent_todo" in lane["reason_codes"], lane
+        assert "external_monitor_context" in lane["reason_codes"], lane
+        assert "due_monitor_context" not in lane["reason_codes"], lane
+        assert lane.get("obligation") != "attempt_due_monitor", lane
+        summary = guard["agent_todo_summary"]
+        assert summary["monitor_due_count"] == 0, summary
+        assert summary["monitor_open_items"][0]["todo_id"] == EVENT_MONITOR_ID, summary
+        assert summary["monitor_writeback"] == {
+            "supported": False,
+            "source": "event_projection_read_model",
+        }, summary
+
+
 def test_corrupted_event_log_falls_back_to_markdown() -> None:
     with tempfile.TemporaryDirectory(prefix="loopx-event-downstream-fallback-") as tmp:
         project = Path(tmp)
@@ -214,6 +301,7 @@ def test_corrupted_event_log_falls_back_to_markdown() -> None:
 
 def main() -> int:
     test_event_projection_feeds_quota_and_review_packet()
+    test_event_projected_due_monitor_is_read_only_for_writeback()
     test_corrupted_event_log_falls_back_to_markdown()
     print("event-sourced-downstream-read-path-smoke ok")
     return 0

--- a/loopx/event_sourced_state.py
+++ b/loopx/event_sourced_state.py
@@ -10,6 +10,7 @@ from typing import Any, Iterable
 
 from .file_lock import exclusive_file_lock
 from .control_plane.todos.contract import (
+    TODO_MONITOR_METADATA_FIELDS,
     TODO_STATUS_DONE,
     TODO_STATUS_BLOCKED,
     TODO_STATUS_DEFERRED,
@@ -555,6 +556,9 @@ def _todo_from_added_event(event: dict[str, Any]) -> dict[str, Any]:
         todo["task_class"] = task_class
     if action_kind:
         todo["action_kind"] = action_kind
+    for key in TODO_MONITOR_METADATA_FIELDS:
+        if payload.get(key):
+            todo[key] = compact_text(payload[key])
     if claimed_by:
         todo["claimed_by"] = claimed_by
     return todo
@@ -569,6 +573,9 @@ def _update_todo_from_event(todo: dict[str, Any], event: dict[str, Any]) -> None
             todo["claimed_by"] = claimed_by
     elif event_type == TODO_UPDATED:
         for key in ("priority", "role", "title", "task_class", "action_kind"):
+            if payload.get(key):
+                todo[key] = compact_text(payload[key])
+        for key in TODO_MONITOR_METADATA_FIELDS:
             if payload.get(key):
                 todo[key] = compact_text(payload[key])
         if payload.get("text") or payload.get("title"):
@@ -684,12 +691,17 @@ def render_todo_markdown(item: dict[str, Any]) -> list[str]:
     if not text.startswith("[") and item.get("priority"):
         text = f"[{compact_text(item.get('priority'))}] {text}"
     lines = [f"- [{marker}] {text}"]
+    monitor_metadata = {
+        key: item.get(key)
+        for key in TODO_MONITOR_METADATA_FIELDS
+    }
     metadata = format_todo_metadata_line(
         todo_id=item.get("todo_id"),
         status=status,
         task_class=item.get("task_class"),
         action_kind=item.get("action_kind"),
         claimed_by=item.get("claimed_by"),
+        **monitor_metadata,
         note=item.get("note"),
         evidence=item.get("evidence"),
         reason=item.get("reason"),


### PR DESCRIPTION
## Summary
- preserve monitor metadata fields when replaying event-sourced todo projections
- render preserved monitor metadata back into active-state projection markdown
- extend downstream read-path smoke to prove event-projected monitor metadata remains read-only for monitor writeback while quota advances the advancement todo

## Validation
- `python3 examples/control_plane/event-sourced-state-api-smoke.py`
- `python3 examples/control_plane/event-sourced-status-read-path-smoke.py`
- `python3 examples/control_plane/event-sourced-downstream-read-path-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 examples/control_plane/runtime-handoff-status-read-path-smoke.py`
- `python3 examples/control_plane/event-store-migration-bridge-smoke.py`
- `python3 examples/control_plane/monitor-scheduler-contract-smoke.py`
- `python3 -m py_compile loopx/event_sourced_state.py examples/control_plane/event-sourced-downstream-read-path-smoke.py`
- `git diff --check`
- added-line private/credential/local-path scan: clean
- `loopx canary plan --from-git-diff --max-checks-per-profile 5`
- `loopx canary premerge --from-git-diff --tier standard --timeout-seconds 180`
