### PR TITLE
Allow CLI goal independent retries

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import json
+import contextlib
+import io
 import subprocess
 import sys
 import tempfile
@@ -150,6 +152,63 @@ def _assert_cli_goal_plan_and_relay_command() -> None:
         proxy_index = proxy_command.index("--codex-api-proxy")
         assert proxy_command[proxy_index + 1] == proxy_url, proxy_command
         assert proxy_url not in json.dumps(proxy_plan, sort_keys=True), proxy_plan
+
+        retry_args = parse_args(
+            [
+                "--route",
+                CODEX_CLI_GOAL_BASELINE_ROUTE,
+                "--host-local-acp-launch",
+                "--remote-command-file-bridge-ready",
+                "--remote-command-file-bridge-solver-command",
+                "python bridge.py",
+                "--independent-goal-retries",
+                "2",
+                "--plan-only",
+                "--skillsbench-root",
+                str(skillsbench_root),
+                "--jobs-dir",
+                str(temp_path / "jobs-with-retry"),
+                "--ledger-path",
+                str(temp_path / "ledger-with-retry.json"),
+                "--global-ledger-path",
+                str(temp_path / "global-ledger-with-retry.json"),
+            ]
+        )
+        retry_plan = build_plan(retry_args)
+        retry_config = retry_plan["independent_goal_retry"]
+        assert retry_config["enabled"] is True, retry_config
+        assert retry_config["attempt_budget"] == 2, retry_config
+        assert retry_config["route_supported"] is True, retry_config
+
+        try:
+            with contextlib.redirect_stderr(io.StringIO()):
+                parse_args(
+                    [
+                        "--route",
+                        CODEX_CLI_GOAL_BASELINE_ROUTE,
+                        "--host-local-acp-launch",
+                        "--remote-command-file-bridge-ready",
+                        "--remote-command-file-bridge-solver-command",
+                        "python bridge.py",
+                        "--independent-goal-retries",
+                        "2",
+                        "--task-ids",
+                        "react-performance-debugging,citation-check",
+                        "--plan-only",
+                        "--skillsbench-root",
+                        str(skillsbench_root),
+                        "--jobs-dir",
+                        str(temp_path / "jobs-with-invalid-retry"),
+                        "--ledger-path",
+                        str(temp_path / "ledger-with-invalid-retry.json"),
+                        "--global-ledger-path",
+                        str(temp_path / "global-ledger-with-invalid-retry.json"),
+                    ]
+                )
+        except SystemExit as exc:
+            assert exc.code == 2
+        else:
+            raise AssertionError("multi-case independent retries should be rejected")
 
 
 def _assert_cli_goal_trace_merges_into_public_prerequisites() -> None:

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -156,6 +156,11 @@ globals().update(
     }
 )
 
+INDEPENDENT_GOAL_RETRY_ROUTES = {
+    CODEX_APP_SERVER_GOAL_BASELINE_ROUTE,
+    CODEX_CLI_GOAL_BASELINE_ROUTE,
+}
+
 
 def _is_loopx_product_mode_route(route: str) -> bool:
     return route in LOOPX_PRODUCT_MODE_FAMILY_ROUTES
@@ -8548,7 +8553,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
     )
     independent_goal_attempt_budget = (
         max(1, int(getattr(args, "independent_goal_retries", 1) or 1))
-        if is_app_server_goal_route
+        if route in INDEPENDENT_GOAL_RETRY_ROUTES
         else 1
     )
     codex_api_egress_preflight = _public_codex_api_egress_contract(
@@ -8716,7 +8721,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
             "schema_version": "skillsbench_independent_goal_retry_config_v0",
             "enabled": bool(independent_goal_attempt_budget > 1),
             "attempt_budget": independent_goal_attempt_budget,
-            "route_supported": route == CODEX_APP_SERVER_GOAL_BASELINE_ROUTE,
+            "route_supported": route in INDEPENDENT_GOAL_RETRY_ROUTES,
             "fresh_goal_thread_per_attempt": True,
             "stop_policy": (
                 "stop_after_first_official_reward_1_or_first_terminal_"
@@ -15722,8 +15727,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         type=int,
         default=1,
         help=(
-            "Run the same codex-app-server-goal-baseline case as multiple "
-            "independent native Goal attempts. Each attempt gets a fresh "
+            "Run the same native Goal case as multiple independent attempts "
+            "for supported goal routes. Each attempt gets a fresh "
             "job/rollout/thread; official verifier reward is observed only by "
             "the runner to decide whether to stop before the retry budget, and "
             "is never forwarded to the worker."
@@ -16342,10 +16347,10 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     if args.independent_goal_retries < 1:
         parser.error("--independent-goal-retries must be >= 1")
     if args.independent_goal_retries > 1:
-        if args.route != "codex-app-server-goal-baseline":
+        if args.route not in INDEPENDENT_GOAL_RETRY_ROUTES:
             parser.error(
                 "--independent-goal-retries currently applies only to "
-                "codex-app-server-goal-baseline"
+                "native Goal routes"
             )
         if args.reduce_only:
             parser.error("--independent-goal-retries is not compatible with --reduce-only")


### PR DESCRIPTION
## Summary
- allow `--independent-goal-retries` for `codex-cli-goal-baseline` single-case runs
- keep retry support explicit and bounded to native Goal routes
- extend the CLI goal route smoke to cover retry plan projection and multi-case rejection

## Validation
- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-codex-cli-goal-route-smoke.py`
- `loopx check --scan-path scripts/skillsbench_automation_loop.py --scan-path examples/skillsbench-codex-cli-goal-route-smoke.py`
