### PR TITLE
Fix scoped monitor quiet projection

### DIFF
--- a/examples/control_plane/control-plane-integrated-canary-smoke.py
+++ b/examples/control_plane/control-plane-integrated-canary-smoke.py
@@ -608,7 +608,7 @@ def assert_due_monitor_poll_state_machine(root: Path) -> None:
     assert monitor_payload["todo_writeback"]["next_due_at"], monitor_payload
     assert monitor_payload["todo_writeback"]["consecutive_no_change"] == 1, monitor_payload
 
-    replan_payload = run_cli(
+    quiet_payload = run_cli(
         registry_path,
         runtime_root,
         "quota",
@@ -618,17 +618,19 @@ def assert_due_monitor_poll_state_machine(root: Path) -> None:
         "--agent-id",
         AGENT_ID,
     )
-    assert replan_payload["decision"] == "autonomous_replan_required", replan_payload
-    assert replan_payload["effective_action"] == "autonomous_replan_required", replan_payload
-    assert replan_payload["execution_obligation"]["must_attempt_work"] is True, replan_payload
-    assert replan_payload["execution_obligation"]["kind"] == "autonomous_replan_required", replan_payload
-    assert replan_payload["interaction_contract"]["mode"] == "autonomous_replan", replan_payload
-    assert replan_payload["work_lane_contract"]["obligation"] == "quiet_until_material_monitor_transition", replan_payload
-    assert replan_payload["work_lane_contract"]["must_attempt_work"] is False, replan_payload
-    assert replan_payload["goal_frontier_projection"]["monitor_only_lanes"]["present"] is True, replan_payload
-    assert replan_payload["goal_frontier_projection"]["replan_required"] is True, replan_payload
-    assert replan_payload["agent_todo_summary"]["monitor_due_count"] == 0, replan_payload
-    assert replan_payload["scheduler_hint"]["cadence_class"] == "active_work", replan_payload
+    assert quiet_payload["decision"] == "skip", quiet_payload
+    assert quiet_payload["effective_action"] == "monitor_quiet_skip", quiet_payload
+    assert quiet_payload["execution_obligation"]["must_attempt_work"] is False, quiet_payload
+    assert quiet_payload["execution_obligation"]["kind"] == "monitor_quiet_skip", quiet_payload
+    assert quiet_payload["interaction_contract"]["mode"] == "monitor_quiet_skip", quiet_payload
+    assert quiet_payload["work_lane_contract"]["obligation"] == (
+        "quiet_until_material_monitor_transition"
+    ), quiet_payload
+    assert quiet_payload["work_lane_contract"]["must_attempt_work"] is False, quiet_payload
+    assert quiet_payload["goal_frontier_projection"]["monitor_only_lanes"]["present"] is True, quiet_payload
+    assert quiet_payload["goal_frontier_projection"]["replan_required"] is False, quiet_payload
+    assert quiet_payload["agent_todo_summary"]["monitor_due_count"] == 0, quiet_payload
+    assert quiet_payload["scheduler_hint"]["cadence_class"] == "monitor_wait", quiet_payload
 
 
 def run_fixture_canary(root: Path) -> None:

--- a/examples/control_plane/control-plane-risk-characterization-smoke.py
+++ b/examples/control_plane/control-plane-risk-characterization-smoke.py
@@ -355,7 +355,7 @@ def assert_higher_priority_due_monitor_preempts_advancement() -> None:
     assert quota["recommended_action"] == "[P0] Poll the due monitor first.", quota
 
 
-def assert_monitor_only_frontier_replans_before_quiet_skip() -> None:
+def assert_monitor_only_frontier_quiets_until_material_transition() -> None:
     payload = status_payload(
         [
             todo_item(
@@ -369,33 +369,32 @@ def assert_monitor_only_frontier_replans_before_quiet_skip() -> None:
         ]
     )
     quota = build_quota_should_run(payload, goal_id=GOAL_ID, agent_id=AGENT_ID)
-    assert quota["decision"] == "autonomous_replan_required", quota
-    assert quota["should_run"] is True, quota
-    assert quota["effective_action"] == "autonomous_replan_required", quota
-    assert quota["autonomous_replan_decision"]["required"] is True, quota
+    assert quota["decision"] == "skip", quota
+    assert quota["should_run"] is False, quota
+    assert quota["effective_action"] == "monitor_quiet_skip", quota
+    assert quota.get("autonomous_replan_obligation") is None, quota
 
     lane = quota["work_lane_contract"]
     assert lane["lane"] == "continuous_monitor", lane
     assert lane["obligation"] == "quiet_until_material_monitor_transition", lane
     assert lane["must_attempt_work"] is False, lane
+    assert quota["goal_frontier_projection"]["replan_required"] is False, quota
 
     contract = quota["interaction_contract"]
-    assert contract["mode"] == "autonomous_replan", contract
+    assert contract["mode"] == "monitor_quiet_skip", contract
     assert contract["user_channel"]["action_required"] is False, contract
     assert contract["user_channel"]["notify"] == "DONT_NOTIFY", contract
-    assert contract["agent_channel"]["must_attempt"] is True, contract
-    assert contract["agent_channel"]["delivery_allowed"] is True, contract
-    assert contract["agent_channel"]["quiet_noop_allowed"] is False, contract
+    assert contract["agent_channel"]["must_attempt"] is False, contract
+    assert contract["agent_channel"]["delivery_allowed"] is False, contract
+    assert contract["agent_channel"]["quiet_noop_allowed"] is True, contract
     assert contract["cli_channel"]["spend_allowed_now"] is False, contract
-    assert contract["cli_channel"]["spend_after_validation"] is True, contract
+    assert contract["cli_channel"]["spend_after_validation"] is False, contract
 
     scheduler = quota["scheduler_hint"]
-    assert scheduler["action"] == "run_now", scheduler
-    assert scheduler["cadence_class"] == "active_work", scheduler
-    assert scheduler["codex_app"]["recommended_rrule"] == (
-        "FREQ=MINUTELY;INTERVAL=3"
-    ), scheduler
-    assert scheduler["codex_app"]["recommended_interval_minutes"] == 3, scheduler
+    assert scheduler["action"] == "backoff_until_material_transition", scheduler
+    assert scheduler["cadence_class"] == "monitor_wait", scheduler
+    assert scheduler["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=15", scheduler
+    assert scheduler["codex_app"]["recommended_interval_minutes"] == 15, scheduler
     assert scheduler["codex_app"]["stateful_backoff"]["apply_needed"] is True, scheduler
     assert scheduler["codex_app"]["no_spend_for_cadence_change"] is True, scheduler
 
@@ -524,7 +523,7 @@ def main() -> None:
     assert_due_monitor_context_does_not_steal_advancement()
     assert_current_agent_claimed_advancement_beats_other_agent_frontier()
     assert_higher_priority_due_monitor_preempts_advancement()
-    assert_monitor_only_frontier_replans_before_quiet_skip()
+    assert_monitor_only_frontier_quiets_until_material_transition()
     assert_standing_monitor_gate_does_not_quiet_skip_gated_advancement()
     assert_agent_scope_wait_scheduler_contract()
     print("control-plane-risk-characterization-smoke ok")

--- a/examples/control_plane/heartbeat-quota-flow-smoke.py
+++ b/examples/control_plane/heartbeat-quota-flow-smoke.py
@@ -422,6 +422,95 @@ def write_external_monitor_advancement_fixture(root: Path) -> tuple[Path, Path, 
     return project, runtime, registry_path
 
 
+def write_scoped_future_external_monitor_fixture(root: Path) -> tuple[Path, Path, Path]:
+    project = root / "scoped-future-external-monitor-project"
+    runtime = root / "scoped-future-external-monitor-runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    state_path = project / state_file
+    registry_path = project / ".loopx" / "registry.json"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        "---\n"
+        "status: external_worker_running_v0\n"
+        "owner_mode: goal\n"
+        'objective: "Exercise agent-scoped future monitor projection."\n'
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Scoped Future External Monitor Fixture\n\n"
+        "## Next Action\n\n"
+        "- Observe active external worker via compact public-safe markers only.\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] [P1-monitor] Observe active external worker via compact markers only; "
+        "if no new result exists, quiet no-op without quota spend.\n"
+        "  <!-- loopx:todo todo_id=todo_side_future_external_monitor status=open "
+        "task_class=continuous_monitor action_kind=monitor_external_worker "
+        "claimed_by=codex-side-bypass target_key=external-worker:fixture "
+        "cadence=1d next_due_at=2999-01-01T00:00:00+00:00 "
+        "last_checked_at=2026-01-01T00:00:00+00:00 material_change=false -->\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "heartbeat-flow-fixture",
+                        "status": "external_worker_running_v0",
+                        "repo": str(REPO_ROOT),
+                        "state_file": str(state_path),
+                        "adapter": {
+                            "kind": "harness_self_improvement",
+                            "status": "connected-read-only",
+                        },
+                        "coordination": {
+                            "registered_agents": [
+                                "codex-main-control",
+                                "codex-side-bypass",
+                            ],
+                            "primary_agent": "codex-main-control",
+                        },
+                        "authority_sources": [],
+                        "quota": {
+                            "compute": 1.0,
+                            "window_hours": 24,
+                            "allowed_slots": 5,
+                        },
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    runs_dir = runtime / "goals" / GOAL_ID / "runs"
+    runs_dir.mkdir(parents=True, exist_ok=True)
+    progress_record = {
+        "generated_at": "2026-01-01T00:00:00+00:00",
+        "goal_id": GOAL_ID,
+        "classification": "external_worker_running_v0",
+        "recommended_action": "Observe active external worker via compact public-safe markers only.",
+        "health_check": "state_file 1/1; registry_goal 1/1",
+        "delivery_batch_scale": "single_surface",
+        "json_path": str(runs_dir / "2026-01-01T00-00-00+00-00.json"),
+        "markdown_path": str(runs_dir / "2026-01-01T00-00-00+00-00.md"),
+    }
+    Path(progress_record["json_path"]).write_text(json.dumps(progress_record) + "\n", encoding="utf-8")
+    Path(progress_record["markdown_path"]).write_text(
+        "# Fixture Future External Monitor\n",
+        encoding="utf-8",
+    )
+    with (runs_dir / "index.jsonl").open("a", encoding="utf-8") as f:
+        f.write(json.dumps(progress_record) + "\n")
+    return project, runtime, registry_path
+
+
 def write_operator_gate_fixture(root: Path) -> tuple[Path, Path, Path]:
     project = root / "operator-gate-project"
     runtime = root / "operator-gate-runtime"
@@ -673,36 +762,35 @@ def main() -> int:
             registry_path=registry_path,
             runtime=runtime,
         )
-        assert first_guard["effective_action"] == "autonomous_replan_required", first_guard
-        assert first_guard["should_run"] is True, first_guard
-        assert first_guard["heartbeat_recommendation"]["recommended_mode"] == "autonomous_replan_required", first_guard
-        obligation = first_guard["autonomous_replan_obligation"]
-        assert obligation["triggers"][0]["kind"] == "frontier_exhausted_monitor_lane", obligation
-        assert obligation["stall_threshold"] == 1, obligation
-        assert obligation["guidance_actions"] == [
-            "create_successor",
-            "supersede_monitor",
-            "set_watch_expiry",
-            "record_no_followup",
-        ], obligation
-        assert "another monitor-only quiet poll" in obligation["recommended_action"], obligation
-        assert first_guard["execution_obligation"]["kind"] == "autonomous_replan_required", first_guard
-        assert first_guard["execution_obligation"]["must_attempt_work"] is True, first_guard
-        assert first_guard["automation_liveness"]["automation_action"] == "execute_bounded_work", first_guard
+        assert first_guard["decision"] == "skip", first_guard
+        assert first_guard["effective_action"] == "monitor_quiet_skip", first_guard
+        assert first_guard["should_run"] is False, first_guard
+        assert first_guard["heartbeat_recommendation"]["recommended_mode"] == (
+            "monitor_quiet_until_material_transition"
+        ), first_guard
+        assert first_guard.get("autonomous_replan_obligation") is None, first_guard
+        assert first_guard["execution_obligation"]["kind"] == "monitor_quiet_skip", first_guard
+        assert first_guard["execution_obligation"]["must_attempt_work"] is False, first_guard
+        assert first_guard["automation_liveness"]["automation_action"] == "keep_active_quiet", first_guard
         assert first_guard["automation_liveness"]["pause_allowed"] is False, first_guard
-        assert first_guard["scheduler_hint"]["action"] == "run_now", first_guard
-        assert first_guard["scheduler_hint"]["codex_app"]["recommended_interval_minutes"] == 3, first_guard
-        assert first_guard["scheduler_hint"]["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=3", first_guard
+        assert first_guard["scheduler_hint"]["action"] == "backoff_until_material_transition", first_guard
+        assert first_guard["scheduler_hint"]["cadence_class"] == "monitor_wait", first_guard
+        assert first_guard["scheduler_hint"]["codex_app"]["recommended_interval_minutes"] == 15, first_guard
+        assert first_guard["scheduler_hint"]["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=15", first_guard
         reset = first_guard["scheduler_hint"]["reset_policy"]
-        assert reset["codex_app_initial_rrule"] == "FREQ=MINUTELY;INTERVAL=3", reset
+        assert reset["codex_app_initial_rrule"] == "FREQ=MINUTELY;INTERVAL=15", reset
         assert "reset_condition_summary" not in reset, reset
-        assert "automation=execute_bounded_work" in first_guard["protocol_action_packet"]["summary"], first_guard
+        frontier = first_guard["goal_frontier_projection"]
+        assert frontier["monitor_only_lanes"]["present"] is True, frontier
+        assert frontier["monitor_only_lanes"]["quiet_until_material_transition"] is True, frontier
+        assert frontier["replan_required"] is False, frontier
+        assert "automation=keep_active_quiet" in first_guard["protocol_action_packet"]["summary"], first_guard
         assert count_events(runtime, "quota_monitor_poll") == 0, first_guard
         interaction = first_guard["interaction_contract"]
-        assert interaction["mode"] == "autonomous_replan", interaction
-        assert interaction["agent_channel"]["must_attempt"] is True, interaction
-        assert interaction["agent_channel"]["quiet_noop_allowed"] is False, interaction
-        assert interaction["cli_channel"]["spend_after_validation"] is True, interaction
+        assert interaction["mode"] == "monitor_quiet_skip", interaction
+        assert interaction["agent_channel"]["must_attempt"] is False, interaction
+        assert interaction["agent_channel"]["quiet_noop_allowed"] is True, interaction
+        assert interaction["cli_channel"]["spend_after_validation"] is False, interaction
 
         refresh = run_cli(
             root,
@@ -1005,6 +1093,41 @@ def main() -> int:
         assert poll["after"]["effective_action"] == "normal_run", poll
         assert count_spend_events(runtime) == 0, poll
         assert count_events(runtime, "quota_monitor_poll") == 1, poll
+
+    with tempfile.TemporaryDirectory(prefix="loopx-scoped-future-external-monitor-") as tmp:
+        root = Path(tmp)
+        project, runtime, registry_path = write_scoped_future_external_monitor_fixture(root)
+        guard = run_cli(
+            root,
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            "codex-side-bypass",
+            "--scan-path",
+            str(project),
+            registry_path=registry_path,
+            runtime=runtime,
+        )
+        assert guard["decision"] != "observe", guard
+        assert guard["effective_action"] != "external_evidence_observe", guard
+        assert "external_evidence_observation" not in guard, guard
+        lane = guard["work_lane_contract"]
+        assert lane["lane"] == "continuous_monitor", lane
+        assert lane["obligation"] == "quiet_until_material_monitor_transition", lane
+        assert lane["must_attempt_work"] is False, lane
+        hint = guard["agent_lane_frontier_hint"]
+        assert hint["decision"] == "quiet_noop_blocker", hint
+        assert hint["reason_code"] == "only_current_agent_monitor_work_remains", hint
+        if guard["effective_action"] == "monitor_quiet_skip":
+            interaction = guard["interaction_contract"]
+            assert interaction["mode"] == "monitor_quiet_skip", interaction
+            assert interaction["agent_channel"]["must_attempt"] is False, interaction
+            assert interaction["agent_channel"]["quiet_noop_allowed"] is True, interaction
+        else:
+            assert guard["effective_action"] == "side_agent_workspace_repair", guard
+            assert guard["workspace_guard"]["blocks_delivery"] is True, guard
 
     with tempfile.TemporaryDirectory(prefix="loopx-external-evidence-projection-") as tmp:
         root = Path(tmp)

--- a/examples/control_plane/monitor-poll-writeback-smoke.py
+++ b/examples/control_plane/monitor-poll-writeback-smoke.py
@@ -313,17 +313,26 @@ def assert_unchanged_writeback() -> None:
             "--agent-id",
             AGENT_ID,
         )
-        assert followup["decision"] == "autonomous_replan_required", followup
-        assert followup["effective_action"] == "autonomous_replan_required", followup
-        assert followup["scheduler_hint"]["cadence_class"] == "active_work", followup
+        assert followup["decision"] == "skip", followup
+        assert followup["effective_action"] == "monitor_quiet_skip", followup
+        assert followup["should_run"] is False, followup
+        assert followup["heartbeat_recommendation"]["recommended_mode"] == (
+            "monitor_quiet_until_material_transition"
+        ), followup
+        assert followup["scheduler_hint"]["cadence_class"] == "monitor_wait", followup
         lane = followup["work_lane_contract"]
         assert lane["lane"] == "continuous_monitor", lane
         assert lane["obligation"] == "quiet_until_material_monitor_transition", lane
         frontier = followup["goal_frontier_projection"]
         assert frontier["monitor_only_lanes"]["present"] is True, frontier
         assert frontier["monitor_only_lanes"]["quiet_until_material_transition"] is True, frontier
-        assert frontier["replan_required"] is True, frontier
-        assert followup["interaction_contract"]["mode"] == "autonomous_replan", followup
+        assert frontier["replan_required"] is False, frontier
+        assert followup.get("autonomous_replan_obligation") is None, followup
+        assert followup["interaction_contract"]["mode"] == "monitor_quiet_skip", followup
+        assert followup["interaction_contract"]["agent_channel"]["must_attempt"] is False, followup
+        assert followup["interaction_contract"]["agent_channel"]["quiet_noop_allowed"] is True, followup
+        assert followup["execution_obligation"]["kind"] == "monitor_quiet_skip", followup
+        assert followup["execution_obligation"]["must_attempt_work"] is False, followup
 
 
 def assert_material_transition_followup() -> None:

--- a/examples/control_plane/quota-replan-decision-plane-smoke.py
+++ b/examples/control_plane/quota-replan-decision-plane-smoke.py
@@ -38,8 +38,12 @@ SIDE_AGENT_REPLAN_OBLIGATION = {
 }
 
 
-def monitor_item() -> dict:
-    return {
+def monitor_item(
+    *,
+    cadence: str | None = "15m",
+    next_due_at: str | None = FUTURE_DUE_AT,
+) -> dict:
+    item = {
         "index": 1,
         "todo_id": "todo_monitor_wait",
         "text": "[P1-monitor] Monitor a fixture signal only when material transition appears.",
@@ -50,9 +54,12 @@ def monitor_item() -> dict:
         "action_kind": "monitor",
         "claimed_by": SIDE_AGENT,
         "target_key": "fixture-signal",
-        "cadence": "15m",
-        "next_due_at": FUTURE_DUE_AT,
     }
+    if cadence is not None:
+        item["cadence"] = cadence
+    if next_due_at is not None:
+        item["next_due_at"] = next_due_at
+    return item
 
 
 def primary_claimed_advancement() -> dict:
@@ -189,7 +196,7 @@ def agent_vision_gap_run() -> dict:
 
 def assert_replan_beats_monitor_quiet_skip() -> None:
     guard = build_quota_should_run(
-        status_payload([monitor_item()]),
+        status_payload([monitor_item()], replan_obligation=SIDE_AGENT_REPLAN_OBLIGATION),
         goal_id=GOAL_ID,
         agent_id=SIDE_AGENT,
     )
@@ -209,6 +216,7 @@ def assert_replan_beats_monitor_quiet_skip() -> None:
         "ready_todo_ids": [],
     }, guard
     assert guard["goal_frontier_projection"]["acceptance_gaps"] == [], guard
+    assert guard["autonomous_replan_scope"]["applies"] is True, guard
     assert guard["autonomous_replan_decision"]["decision_plane"] == (
         "goal_frontier_before_lane_quiet_or_agent_scope_wait"
     ), guard
@@ -217,6 +225,25 @@ def assert_replan_beats_monitor_quiet_skip() -> None:
     assert "goal_frontier_projection: replan_required=True" in markdown, markdown
     assert "deferred_ready=0 acceptance_gaps=0" in markdown, markdown
     assert "autonomous_replan_decision: decision=autonomous_replan_required" in markdown, markdown
+
+
+def assert_future_scheduled_monitor_quiets_without_generated_replan() -> None:
+    guard = build_quota_should_run(
+        status_payload([monitor_item()], replan_obligation=None),
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+    )
+    assert guard["decision"] == "skip", guard
+    assert guard["effective_action"] == "monitor_quiet_skip", guard
+    assert guard["should_run"] is False, guard
+    assert guard["heartbeat_recommendation"]["recommended_mode"] == (
+        "monitor_quiet_until_material_transition"
+    ), guard
+    assert guard["interaction_contract"]["mode"] == "monitor_quiet_skip", guard
+    assert guard["interaction_contract"]["agent_channel"]["must_attempt"] is False, guard
+    assert guard["interaction_contract"]["agent_channel"]["quiet_noop_allowed"] is True, guard
+    assert guard["goal_frontier_projection"]["replan_required"] is False, guard
+    assert guard.get("autonomous_replan_obligation") is None, guard
 
 
 def assert_replan_preserves_current_agent_runnable_frontier() -> None:
@@ -335,21 +362,28 @@ def assert_unscoped_replan_defaults_to_primary_agent() -> None:
     assert monitor_side_guard.get("autonomous_replan_obligation") is None, monitor_side_guard
 
 
-def assert_empty_monitor_frontier_derives_replan() -> None:
+def assert_monitor_schedule_gap_requires_bounded_repair() -> None:
     guard = build_quota_should_run(
-        status_payload([monitor_item()], replan_obligation=None),
+        status_payload([monitor_item(cadence=None, next_due_at=None)], replan_obligation=None),
         goal_id=GOAL_ID,
         agent_id=SIDE_AGENT,
     )
-    assert guard["decision"] == "autonomous_replan_required", guard
-    assert guard["effective_action"] == "autonomous_replan_required", guard
+    assert guard["decision"] == "run", guard
+    assert guard["effective_action"] == "normal_run", guard
     assert guard["should_run"] is True, guard
-    assert guard["interaction_contract"]["mode"] == "autonomous_replan", guard
+    assert guard["interaction_contract"]["mode"] == "bounded_delivery", guard
     assert guard["interaction_contract"]["agent_channel"]["must_attempt"] is True, guard
-    obligation = guard["autonomous_replan_obligation"]
-    assert obligation["required"] is True, guard
-    assert obligation["triggers"][0]["kind"] == "frontier_exhausted_monitor_lane", guard
-    assert guard["goal_frontier_projection"]["replan_required"] is True, guard
+    assert guard.get("autonomous_replan_obligation") is None, guard
+    assert guard["execution_obligation"]["kind"] == "work_lane_contract", guard
+    assert guard["execution_obligation"]["contract_obligation"] == (
+        "repair_monitor_schedule_metadata"
+    ), guard
+    lane = guard["work_lane_contract"]
+    assert lane["lane"] == "advancement_task", lane
+    assert lane["monitor_kind"] == "todo_monitor_schedule_gap", lane
+    assert lane["obligation"] == "repair_monitor_schedule_metadata", lane
+    assert lane["monitor_schedule_gap_count"] == 1, lane
+    assert guard["goal_frontier_projection"]["replan_required"] is False, guard
     assert guard["goal_frontier_projection"]["remaining_advancement_frontier"] == {
         "current_agent_claimed_advancement_count": 0,
         "unclaimed_advancement_count": 0,
@@ -429,11 +463,12 @@ def assert_blocking_handoff_gate_beats_derived_monitor_replan() -> None:
 
 def main() -> None:
     assert_replan_beats_monitor_quiet_skip()
+    assert_future_scheduled_monitor_quiets_without_generated_replan()
     assert_replan_preserves_current_agent_runnable_frontier()
     assert_agent_vision_gap_derives_replan()
     assert_agent_scoped_replan_beats_agent_scope_wait()
     assert_unscoped_replan_defaults_to_primary_agent()
-    assert_empty_monitor_frontier_derives_replan()
+    assert_monitor_schedule_gap_requires_bounded_repair()
     assert_agent_ack_survives_other_agent_run_and_monitor_poll()
     assert_blocking_handoff_gate_beats_derived_monitor_replan()
     print("quota-replan-decision-plane-smoke ok")

--- a/examples/control_plane/work-lane-contract-smoke.py
+++ b/examples/control_plane/work-lane-contract-smoke.py
@@ -743,7 +743,7 @@ def assert_mixed_monitor_and_advancement_routes_to_advancement() -> None:
     assert [item["task_class"] for item in first_items] == ["advancement_task", "continuous_monitor"], guard
 
 
-def assert_not_due_monitor_only_requires_replan_before_quiet() -> None:
+def assert_not_due_monitor_only_quiets_until_material_transition() -> None:
     guard = build_quota_should_run(
         status_payload(
             status="monitor_schedule_waiting",
@@ -763,13 +763,15 @@ def assert_not_due_monitor_only_requires_replan_before_quiet() -> None:
         goal_id=GOAL_ID,
     )
     lane = guard["work_lane_contract"]
-    assert guard["decision"] == "autonomous_replan_required", guard
-    assert guard["effective_action"] == "autonomous_replan_required", guard
+    assert guard["decision"] == "skip", guard
+    assert guard["effective_action"] == "monitor_quiet_skip", guard
     assert lane["lane"] == "continuous_monitor", lane
-    assert lane["monitor_kind"] == "todo_monitor", lane
-    assert lane["must_attempt_work"] is False, lane
-    assert guard["heartbeat_recommendation"]["recommended_mode"] == "autonomous_replan_required", guard
-    assert guard["interaction_contract"]["mode"] == "autonomous_replan", guard
+    assert lane["obligation"] == "quiet_until_material_monitor_transition", lane
+    assert guard["heartbeat_recommendation"]["recommended_mode"] == "monitor_quiet_until_material_transition", guard
+    assert guard["interaction_contract"]["mode"] == "monitor_quiet_skip", guard
+    assert guard["interaction_contract"]["agent_channel"]["quiet_noop_allowed"] is True, guard
+    assert guard["goal_frontier_projection"]["replan_required"] is False, guard
+    assert guard.get("autonomous_replan_obligation") is None, guard
     assert guard["agent_todo_summary"]["monitor_due_count"] == 0, guard
 
 
@@ -2299,7 +2301,7 @@ def main() -> int:
     assert_structured_todo_lane_registration_beats_text_fallback()
     assert_structured_monitor_registration_beats_action_text()
     assert_mixed_monitor_and_advancement_routes_to_advancement()
-    assert_not_due_monitor_only_requires_replan_before_quiet()
+    assert_not_due_monitor_only_quiets_until_material_transition()
     assert_due_monitor_only_requires_attempt()
     assert_due_monitor_lower_priority_does_not_preempt_advancement()
     assert_due_monitor_higher_priority_preempts_advancement()

--- a/loopx/control_plane/goals/goal_frontier.py
+++ b/loopx/control_plane/goals/goal_frontier.py
@@ -444,6 +444,23 @@ def _is_monitor_only_lane(
     )
 
 
+def _monitor_only_lane_has_future_schedule(
+    agent_todo_summary: dict[str, Any] | None,
+) -> bool:
+    if not isinstance(agent_todo_summary, dict):
+        return False
+    if "monitor_due_count" not in agent_todo_summary:
+        return False
+    if "monitor_schedule_gap_count" not in agent_todo_summary:
+        return False
+    if safe_non_negative_int(agent_todo_summary.get("monitor_due_count")) > 0:
+        return False
+    if safe_non_negative_int(agent_todo_summary.get("monitor_schedule_gap_count")) > 0:
+        return False
+    monitor_items = agent_todo_summary.get("monitor_open_items")
+    return isinstance(monitor_items, list) and len(monitor_items) > 0
+
+
 def _blocking_handoff_gate_count(
     agent_todo_summary: dict[str, Any] | None,
     *,
@@ -557,6 +574,8 @@ def derive_goal_frontier_replan_obligation_from_summaries(
     if agent_counts.get("monitor", 0) <= 0:
         return None
     if agent_counts.get("advancement", 0) > 0 or total_frontier_advancement > 0:
+        return None
+    if _monitor_only_lane_has_future_schedule(agent_todo_summary):
         return None
 
     return {

--- a/loopx/control_plane/todos/projection.py
+++ b/loopx/control_plane/todos/projection.py
@@ -468,6 +468,50 @@ def todo_summary_monitor_schedule_gap_count(
     )
 
 
+def todo_summary_has_only_future_scoped_monitor_work(summary: dict[str, Any] | None) -> bool:
+    """Return true when the scoped agent has only non-due monitor work left."""
+
+    agent_id = todo_summary_claim_scope_agent_id(summary)
+    if not agent_id or not isinstance(summary, dict):
+        return False
+    if not todo_summary_monitor_items(summary):
+        return False
+    if todo_summary_monitor_due_count(summary) > 0:
+        return False
+    if todo_summary_monitor_schedule_gap_count(summary) > 0:
+        return False
+    if _positive_int(summary.get("current_agent_claimed_advancement_count")) > 0:
+        return False
+
+    for key in (
+        "current_agent_claimed_advancement_items",
+        "unclaimed_priority_open_items",
+        "first_executable_items",
+        "executable_backlog_items",
+    ):
+        values = summary.get(key)
+        if not isinstance(values, list):
+            continue
+        for item in values:
+            if not isinstance(item, dict):
+                continue
+            if not todo_item_is_actionable_open(item):
+                continue
+            if todo_item_task_class(item) != TODO_TASK_CLASS_ADVANCEMENT:
+                continue
+            if todo_item_claimed_by_agent_or_unclaimed(item, agent_id=agent_id):
+                return False
+    return True
+
+
+def _positive_int(value: Any) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return max(0, parsed)
+
+
 def todo_summary_first_executable_item(
     summary: dict[str, Any] | None,
 ) -> dict[str, Any] | None:

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -135,6 +135,7 @@ from .control_plane.todos.projection import (
     todo_priority_label as projection_todo_priority_label,
     todo_priority_rank as projection_todo_priority_rank,
     todo_projection_sort_key as projection_todo_projection_sort_key,
+    todo_summary_has_only_future_scoped_monitor_work as projection_todo_summary_has_only_future_scoped_monitor_work,
     todo_summary_claim_scope_agent_id as projection_todo_summary_claim_scope_agent_id,
     todo_summary_first_executable_item as projection_todo_summary_first_executable_item,
     todo_summary_monitor_items as projection_todo_summary_monitor_items,
@@ -448,6 +449,8 @@ def _external_evidence_poll_signal(
 
     scoped_monitor_handle = _projected_monitor_handle(agent_todo_summary)
     scoped_monitor_watch = _scoped_monitor_watch_without_advancement(agent_todo_summary)
+    if _todo_summary_has_only_future_scoped_monitor_work(agent_todo_summary):
+        return None
     project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
     action_texts = [
         str(value or "").strip()
@@ -3675,6 +3678,10 @@ def _todo_summary_monitor_schedule_gap_count(
         summary,
         gap_items=gap_items,
     )
+
+
+def _todo_summary_has_only_future_scoped_monitor_work(summary: dict[str, Any] | None) -> bool:
+    return projection_todo_summary_has_only_future_scoped_monitor_work(summary)
 
 
 def _first_executable_todo_item(agent_todo_summary: dict[str, Any] | None) -> dict[str, Any] | None:


### PR DESCRIPTION
## Summary
- stop scoped external-evidence observation from reselecting monitor-only side-agent lanes that have no due monitor and no schedule gap
- keep generated autonomous replan from firing for monitor-only lanes that are already scheduled for a future quiet check
- update control-plane canaries to distinguish explicit replan, schedule metadata repair, due monitor attempts, and future monitor quiet/no-spend behavior

## Validation
- `python3 -m py_compile` on touched Python files
- focused control-plane smokes: heartbeat quota flow, monitor poll writeback, quota replan decision plane, work lane contract, scoped user gate, risk characterization, integrated canary, line budget
- real `loopx-meta` side-agent guard cross-check: `monitor_quiet_skip`, no external evidence observation, no autonomous replan
- `loopx canary premerge --from-git-diff --tier standard --timeout-seconds 300 --format json` passed with merge gate and self-merge allowed
- `git diff --check` and public/private boundary scan passed
