### PR TITLE
Link existing successor todos on completion

### DIFF
--- a/examples/control_plane/todo-lifecycle-cli-smoke.py
+++ b/examples/control_plane/todo-lifecycle-cli-smoke.py
@@ -129,6 +129,11 @@ def parsed_items(state_file: Path) -> list[dict]:
     return fields["agent_todos"]["items"]
 
 
+def parsed_agent_summary(state_file: Path) -> dict:
+    fields = parse_active_state_todos(state_file.read_text(encoding="utf-8"))
+    return fields["agent_todos"]
+
+
 def assert_configured_side_agent_handoff() -> None:
     with tempfile.TemporaryDirectory(prefix="loopx-side-agent-handoff-smoke-") as tmp:
         root = Path(tmp)
@@ -451,9 +456,106 @@ def assert_no_followup_cli_metadata() -> None:
         assert item["no_followup"] is True, item
 
 
+def assert_complete_links_existing_successor() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-existing-successor-complete-smoke-") as tmp:
+        root = Path(tmp)
+        registry_path, state_file = write_fixture(root)
+        source = run_cli(
+            registry_path,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--text",
+            "Ship a side-agent slice that already has its next lane todo.",
+            "--claimed-by",
+            "codex-side-bypass",
+            "--task-class",
+            "advancement_task",
+            "--action-kind",
+            "contract_refine",
+        )
+        successor = run_cli(
+            registry_path,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--text",
+            SIDE_CONTINUATION_TODO,
+            "--claimed-by",
+            "codex-side-bypass",
+            "--task-class",
+            "advancement_task",
+            "--action-kind",
+            "contract_refine",
+        )
+        source_id = source["todo_id"]
+        successor_id = successor["todo_id"]
+
+        mixed_successor_modes = run_cli_error(
+            registry_path,
+            "todo",
+            "complete",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            source_id,
+            "--claimed-by",
+            "codex-side-bypass",
+            "--evidence",
+            "self-merged commit ghi789 after focused validation",
+            "--side-agent-self-merged",
+            "--successor-todo-id",
+            successor_id,
+            "--next-agent-todo",
+            "Duplicate successor should be rejected.",
+        )
+        assert "--successor-todo-id links existing work" in mixed_successor_modes["error"], (
+            mixed_successor_modes
+        )
+
+        completed = run_cli(
+            registry_path,
+            "todo",
+            "complete",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            source_id,
+            "--claimed-by",
+            "codex-side-bypass",
+            "--evidence",
+            "self-merged commit ghi789 after focused validation",
+            "--side-agent-self-merged",
+            "--successor-todo-id",
+            successor_id,
+        )
+        assert completed["changed"] is True, completed
+        assert completed["side_agent_self_merged"] is True, completed
+        assert completed["next_todos"] == [], completed
+        assert completed["successor_todo_ids"] == [successor_id], completed
+
+        source_item = next(item for item in parsed_items(state_file) if item["todo_id"] == source_id)
+        assert source_item["status"] == "done", source_item
+        assert source_item["successor_todo_ids"] == [successor_id], source_item
+        successor_item = next(item for item in parsed_items(state_file) if item["todo_id"] == successor_id)
+        assert successor_item["status"] == "open", successor_item
+        assert successor_item["claimed_by"] == "codex-side-bypass", successor_item
+
+        summary = parsed_agent_summary(state_file)
+        assert summary.get("completed_without_successor_count", 0) == 0, summary
+        assert "todo_succession_warning" not in summary, summary
+
+
 def main() -> int:
     assert_configured_side_agent_handoff()
     assert_no_followup_cli_metadata()
+    assert_complete_links_existing_successor()
 
     with tempfile.TemporaryDirectory(prefix="loopx-todo-lifecycle-smoke-") as tmp:
         root = Path(tmp)

--- a/examples/control_plane/todo-succession-contract-smoke.py
+++ b/examples/control_plane/todo-succession-contract-smoke.py
@@ -27,6 +27,7 @@ def todo_item(
     action_kind: str | None = None,
     claimed_by: str | None = None,
     no_followup: bool = False,
+    successor_todo_ids: list[str] | None = None,
     resume_when: str | None = None,
     unblocks_todo_id: str | None = None,
     updated_at: str | None = None,
@@ -48,6 +49,8 @@ def todo_item(
         item["claimed_by"] = claimed_by
     if no_followup:
         item["no_followup"] = True
+    if successor_todo_ids:
+        item["successor_todo_ids"] = successor_todo_ids
     if resume_when:
         item["resume_when"] = resume_when
     if unblocks_todo_id:
@@ -91,10 +94,24 @@ def build_agent_todos() -> dict:
                 updated_at="2026-07-04T18:00:00+08:00",
             ),
             todo_item(
+                todo_id="todo_with_explicit_successor",
+                text="[P2] Complete a tracked cleanup and link existing successor metadata.",
+                status="done",
+                action_kind="projection_cleanup",
+                claimed_by=AGENT_ID,
+                successor_todo_ids=["todo_explicit_successor"],
+                updated_at="2026-07-04T17:30:00+08:00",
+            ),
+            todo_item(
                 todo_id="todo_successor",
                 text="[P2] Continue after the linked cleanup.",
                 claimed_by=AGENT_ID,
                 resume_when="todo_done:todo_with_successor",
+            ),
+            todo_item(
+                todo_id="todo_explicit_successor",
+                text="[P2] Continue after the explicit successor link.",
+                claimed_by=AGENT_ID,
             ),
             {
                 "todo_id": "todo_legacy_done",
@@ -181,6 +198,9 @@ def assert_status_summary_warning() -> None:
         item["todo_id"] for item in warning["items"] if item.get("todo_id")
     }, warning
     assert "todo_with_successor" not in {
+        item["todo_id"] for item in warning["items"] if item.get("todo_id")
+    }, warning
+    assert "todo_with_explicit_successor" not in {
         item["todo_id"] for item in warning["items"] if item.get("todo_id")
     }, warning
     assert "todo_legacy_done" not in {

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -163,6 +163,15 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
         ),
     )
     todo_parser.add_argument(
+        "--successor-todo-id",
+        dest="successor_todo_ids",
+        action="append",
+        help=(
+            "For todo update/complete, link an existing successor todo to the "
+            "current todo. Repeat for multiple successors."
+        ),
+    )
+    todo_parser.add_argument(
         "--resume-when",
         help=(
             "For deferred todo add/update, declare a machine-readable resume condition "
@@ -340,6 +349,7 @@ def handle_todo_command(
                     ("--blocks-agent", args.blocks_agent),
                     ("--global-gate", args.global_gate),
                     ("--unblocks-todo-id", args.unblocks_todo_id),
+                    ("--successor-todo-id", args.successor_todo_ids),
                     ("--resume-when", args.resume_when),
                     ("--monitor-target-key", args.monitor_target_key),
                     ("--cadence", args.cadence),
@@ -391,6 +401,8 @@ def handle_todo_command(
                 raise ValueError("todo add does not support --side-agent-self-merged")
             if args.no_follow_up:
                 raise ValueError("todo add does not support --no-follow-up")
+            if args.successor_todo_ids:
+                raise ValueError("todo add does not support --successor-todo-id; use todo update/complete to link existing successor work")
             payload = add_goal_todo(
                 registry_path=registry_path,
                 goal_id=args.goal_id,
@@ -444,6 +456,7 @@ def handle_todo_command(
                     ("--blocks-agent", args.blocks_agent),
                     ("--global-gate", args.global_gate),
                     ("--unblocks-todo-id", args.unblocks_todo_id),
+                    ("--successor-todo-id", args.successor_todo_ids),
                     ("--resume-when", args.resume_when),
                     ("--monitor-target-key", args.monitor_target_key),
                     ("--cadence", args.cadence),
@@ -500,6 +513,7 @@ def handle_todo_command(
                 args.blocks_agent,
                 args.global_gate,
                 args.unblocks_todo_id,
+                args.successor_todo_ids,
                 args.resume_when,
                 args.no_follow_up,
                 args.monitor_target_key,
@@ -508,7 +522,7 @@ def handle_todo_command(
                 args.expires_at,
                 args.clear_claim,
             ]):
-                raise ValueError("todo update requires at least one of --text, --status, --note, --evidence, --reason, --task-class, --action-kind, --required-write-scope, --required-capability, --target-capability, --decision-scope, --required-decision-scope, --claimed-by, --blocks-agent, --global-gate, --unblocks-todo-id, --resume-when, --monitor-target-key, --cadence, --next-due-at, --expires-at, --no-follow-up, or --clear-claim")
+                raise ValueError("todo update requires at least one of --text, --status, --note, --evidence, --reason, --task-class, --action-kind, --required-write-scope, --required-capability, --target-capability, --decision-scope, --required-decision-scope, --claimed-by, --blocks-agent, --global-gate, --unblocks-todo-id, --successor-todo-id, --resume-when, --monitor-target-key, --cadence, --next-due-at, --expires-at, --no-follow-up, or --clear-claim")
             if args.no_follow_up and not (args.note or args.reason or args.evidence):
                 raise ValueError("--no-follow-up requires --note, --reason, or --evidence")
             if args.followups:
@@ -539,6 +553,7 @@ def handle_todo_command(
                 global_gate=bool(args.global_gate),
                 agent_id=args.agent_id,
                 unblocks_todo_id=args.unblocks_todo_id,
+                successor_todo_ids=args.successor_todo_ids,
                 resume_when=args.resume_when,
                 no_followup=True if args.no_follow_up else None,
                 monitor_metadata={
@@ -563,6 +578,10 @@ def handle_todo_command(
                 raise ValueError("todo complete does not support monitor schedule metadata; use todo update before completion")
             if args.no_follow_up and (args.next_agent_todo or args.next_user_todo):
                 raise ValueError("--no-follow-up cannot be combined with successor todos")
+            if args.no_follow_up and args.successor_todo_ids:
+                raise ValueError("--no-follow-up cannot be combined with successor todos")
+            if args.successor_todo_ids and (args.next_agent_todo or args.next_user_todo):
+                raise ValueError("--successor-todo-id links existing work and cannot be combined with --next-agent-todo or --next-user-todo")
             if args.no_follow_up and not (args.note or args.evidence):
                 raise ValueError("--no-follow-up requires --note or --evidence")
             if args.followups:
@@ -575,6 +594,7 @@ def handle_todo_command(
                 evidence=args.evidence,
                 note=args.note,
                 no_followup=bool(args.no_follow_up),
+                successor_todo_ids=args.successor_todo_ids,
                 claimed_by=args.claimed_by,
                 clear_claim=bool(args.clear_claim),
                 next_agent_todo=args.next_agent_todo,
@@ -606,6 +626,8 @@ def handle_todo_command(
                 raise ValueError("todo supersede does not support --follow-up; use `todo capture-followups`")
             if args.blocks_agent or args.global_gate or args.unblocks_todo_id or args.resume_when:
                 raise ValueError("todo supersede does not support --blocks-agent, --global-gate, --unblocks-todo-id, or --resume-when; update the source todo first so the successor can inherit dependency metadata")
+            if args.successor_todo_ids:
+                raise ValueError("todo supersede does not support --successor-todo-id; use --next-agent-todo or update the source todo before supersede")
             if args.monitor_target_key or args.cadence or args.next_due_at or args.expires_at:
                 raise ValueError("todo supersede does not support monitor schedule metadata; use todo update before supersede")
             payload = supersede_goal_todo(
@@ -634,6 +656,8 @@ def handle_todo_command(
                 raise ValueError("todo archive-completed does not support --no-follow-up")
             if args.followups:
                 raise ValueError("todo archive-completed does not support --follow-up; use `todo capture-followups`")
+            if args.successor_todo_ids:
+                raise ValueError("todo archive-completed does not support --successor-todo-id")
             payload = archive_completed_todos(
                 registry_path=registry_path,
                 goal_id=args.goal_id,
@@ -665,6 +689,7 @@ def handle_todo_command(
                     ("--blocks-agent", args.blocks_agent),
                     ("--global-gate", args.global_gate),
                     ("--unblocks-todo-id", args.unblocks_todo_id),
+                    ("--successor-todo-id", args.successor_todo_ids),
                     ("--resume-when", args.resume_when),
                     ("--monitor-target-key", args.monitor_target_key),
                     ("--cadence", args.cadence),
@@ -715,6 +740,7 @@ def handle_todo_command(
                     ("--blocks-agent", args.blocks_agent),
                     ("--global-gate", args.global_gate),
                     ("--unblocks-todo-id", args.unblocks_todo_id),
+                    ("--successor-todo-id", args.successor_todo_ids),
                     ("--resume-when", args.resume_when),
                     ("--monitor-target-key", args.monitor_target_key),
                     ("--cadence", args.cadence),

--- a/loopx/control_plane/todos/contract.py
+++ b/loopx/control_plane/todos/contract.py
@@ -229,6 +229,22 @@ def normalize_todo_id(value: Any) -> str | None:
     return None
 
 
+def normalize_todo_id_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    raw_values = value if isinstance(value, (list, tuple, set)) else [value]
+    todo_ids: list[str] = []
+    for raw_value in raw_values:
+        for match in re.findall(r"\btodo_[A-Za-z0-9_-]+\b", str(raw_value or "")):
+            todo_id = normalize_todo_id(match)
+            if todo_id and todo_id not in todo_ids:
+                todo_ids.append(todo_id)
+        todo_id = normalize_todo_id(raw_value)
+        if todo_id and todo_id not in todo_ids:
+            todo_ids.append(todo_id)
+    return todo_ids
+
+
 def normalize_required_write_scopes(value: Any) -> list[str]:
     if value is None:
         return []
@@ -489,6 +505,10 @@ def parse_todo_metadata_line(line: str) -> dict[str, Any] | None:
             todo_id = normalize_todo_id(value)
             if todo_id:
                 metadata["unblocks_todo_id"] = todo_id
+        elif key in {"successor_todo_id", "successor_todo_ids"}:
+            todo_ids = normalize_todo_id_list(value)
+            if todo_ids:
+                metadata["successor_todo_ids"] = todo_ids
         elif key == "resume_when":
             resume_when = normalize_todo_resume_when(value)
             if resume_when:
@@ -525,6 +545,7 @@ def format_todo_metadata_line(
     blocks_agent: str | None = None,
     global_gate: bool | None = None,
     unblocks_todo_id: str | None = None,
+    successor_todo_ids: Any = None,
     resume_when: str | None = None,
     no_followup: bool | None = None,
     target_key: str | None = None,
@@ -618,6 +639,14 @@ def format_todo_metadata_line(
         raise ValueError("unblocks_todo_id must use the public token shape todo_<letters-digits-underscore-hyphen>")
     if normalized_unblocks_todo_id:
         fields.append(f"unblocks_todo_id={encode_metadata_value(normalized_unblocks_todo_id)}")
+    normalized_successor_todo_ids = normalize_todo_id_list(successor_todo_ids)
+    if successor_todo_ids and not normalized_successor_todo_ids:
+        raise ValueError("successor_todo_ids must contain public todo_<letters-digits-underscore-hyphen> tokens")
+    if normalized_successor_todo_ids:
+        fields.append(
+            "successor_todo_ids="
+            f"{encode_metadata_value(','.join(normalized_successor_todo_ids))}"
+        )
     normalized_resume_when = normalize_todo_resume_when(resume_when)
     if resume_when and not normalized_resume_when:
         raise ValueError("resume_when must be public-safe, e.g. todo_done:todo_ab12cd34ef56 or pr_merged:#532")

--- a/loopx/control_plane/todos/event_writeback.py
+++ b/loopx/control_plane/todos/event_writeback.py
@@ -20,6 +20,7 @@ from .contract import (
     build_todo_id,
     normalize_todo_claimed_by,
     normalize_todo_id,
+    normalize_todo_id_list,
     todo_done_for_status,
 )
 from .text import (
@@ -210,6 +211,7 @@ def complete_event_projected_goal_todo(
     evidence: str | None,
     note: str | None,
     no_followup: bool,
+    successor_todo_ids: list[str] | None,
     claimed_by: str | None,
     clear_claim: bool,
     next_agent_todo: str | None,
@@ -242,6 +244,9 @@ def complete_event_projected_goal_todo(
         completion_payload["note"] = note
     if no_followup:
         completion_payload["no_followup"] = "true"
+    normalized_successor_todo_ids = normalize_todo_id_list(successor_todo_ids)
+    if normalized_successor_todo_ids:
+        completion_payload["successor_todo_ids"] = normalized_successor_todo_ids
     store = AppendOnlyStateEventStore(Path(context["event_log_path"]))
     already_done = todo_done_for_status(str(item.get("status") or TODO_STATUS_OPEN))
     completion_event = make_state_event(
@@ -323,6 +328,7 @@ def complete_event_projected_goal_todo(
         "claimed_by": normalize_todo_claimed_by(effective_claimed_by),
         "task_class": item.get("task_class"),
         "action_kind": item.get("action_kind"),
+        "successor_todo_ids": normalized_successor_todo_ids,
         "next_todos": next_results,
         "side_agent_self_merged": bool(side_agent_completion and side_agent_self_merged),
         "state_file": str(context.get("state_file") or ""),

--- a/loopx/control_plane/todos/todo_summary.py
+++ b/loopx/control_plane/todos/todo_summary.py
@@ -18,6 +18,7 @@ from .contract import (
     normalize_todo_decision_scope,
     normalize_todo_global_gate,
     normalize_todo_id,
+    normalize_todo_id_list,
     normalize_todo_no_followup,
     normalize_todo_required_decision_scopes,
     normalize_todo_resume_when,
@@ -666,17 +667,7 @@ def active_next_action_todo_ids(value: Any) -> set[str]:
 
 
 def _normalized_todo_id_list(value: Any) -> list[str]:
-    raw_values = value if isinstance(value, (list, tuple, set)) else [value]
-    todo_ids: list[str] = []
-    for raw_value in raw_values:
-        for match in re.findall(r"\btodo_[A-Za-z0-9_-]+\b", str(raw_value or "")):
-            todo_id = normalize_todo_id(match)
-            if todo_id and todo_id not in todo_ids:
-                todo_ids.append(todo_id)
-        todo_id = normalize_todo_id(raw_value)
-        if todo_id and todo_id not in todo_ids:
-            todo_ids.append(todo_id)
-    return todo_ids
+    return normalize_todo_id_list(value)
 
 
 def todo_successor_todo_ids(

--- a/loopx/event_sourced_state.py
+++ b/loopx/event_sourced_state.py
@@ -22,6 +22,7 @@ from .control_plane.todos.contract import (
     normalize_todo_action_kind,
     normalize_todo_claimed_by,
     normalize_todo_id,
+    normalize_todo_id_list,
     normalize_todo_status,
     parse_todo_metadata_line,
     todo_done_for_status,
@@ -611,6 +612,9 @@ def _update_todo_from_event(todo: dict[str, Any], event: dict[str, Any]) -> None
         ):
             if payload.get(key) is not None:
                 todo[key] = compact_text(payload[key])
+        successor_todo_ids = normalize_todo_id_list(payload.get("successor_todo_ids"))
+        if successor_todo_ids:
+            todo["successor_todo_ids"] = successor_todo_ids
     todo["last_event_id"] = event.get("event_id")
     todo["last_append_sequence"] = event.get("append_sequence")
 
@@ -711,6 +715,7 @@ def render_todo_markdown(item: dict[str, Any]) -> list[str]:
         action_kind=item.get("action_kind"),
         claimed_by=item.get("claimed_by"),
         unblocks_todo_id=item.get("unblocks_todo_id"),
+        successor_todo_ids=item.get("successor_todo_ids"),
         no_followup=True if item.get("no_followup") == "true" else None,
         **monitor_metadata,
         note=item.get("note"),

--- a/loopx/state_projection.py
+++ b/loopx/state_projection.py
@@ -16,6 +16,7 @@ from .control_plane.todos.contract import (
     normalize_todo_claimed_by,
     normalize_todo_global_gate,
     normalize_todo_id,
+    normalize_todo_id_list,
     normalize_todo_no_followup,
     normalize_todo_required_decision_scopes,
     normalize_todo_resume_when,
@@ -86,6 +87,7 @@ TODO_METADATA_KEYS = (
     "blocks_agent",
     "global_gate",
     "unblocks_todo_id",
+    "successor_todo_ids",
     "resume_when",
     "no_followup",
     "target_key",
@@ -393,6 +395,9 @@ def _normalize_structured_todo_item(
     unblocks_todo_id = normalize_todo_id(item.get("unblocks_todo_id"))
     if unblocks_todo_id:
         normalized["unblocks_todo_id"] = unblocks_todo_id
+    successor_todo_ids = normalize_todo_id_list(item.get("successor_todo_ids"))
+    if successor_todo_ids:
+        normalized["successor_todo_ids"] = successor_todo_ids
     resume_when = normalize_todo_resume_when(item.get("resume_when"))
     if resume_when:
         normalized["resume_when"] = resume_when

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -38,6 +38,7 @@ from .control_plane.todos.contract import (
     normalize_todo_decision_scope,
     normalize_todo_global_gate,
     normalize_todo_id,
+    normalize_todo_id_list,
     normalize_todo_no_followup,
     normalize_todo_required_decision_scopes,
     normalize_todo_resume_when,
@@ -78,6 +79,7 @@ TODO_METADATA_FIELDS = (
     "blocks_agent",
     "global_gate",
     "unblocks_todo_id",
+    "successor_todo_ids",
     "resume_when",
     "no_followup",
     "target_key",
@@ -371,6 +373,7 @@ def todo_item_relations(item: dict[str, Any]) -> dict[str, Any]:
         "blocks_agent",
         "global_gate",
         "unblocks_todo_id",
+        "successor_todo_ids",
         "superseded_by",
         "resume_when",
         "resume_condition",
@@ -720,6 +723,12 @@ def metadata_line_for_block(block: dict[str, Any], updates: dict[str, Any]) -> s
             no_followup = normalize_todo_no_followup(value)
             if no_followup is not None:
                 metadata[key] = no_followup
+            else:
+                metadata.pop(key, None)
+        elif key == "successor_todo_ids":
+            todo_ids = normalize_todo_id_list(value)
+            if todo_ids:
+                metadata[key] = todo_ids
             else:
                 metadata.pop(key, None)
         elif key == "global_gate":
@@ -1203,6 +1212,7 @@ def apply_todo_update_to_lines(
     blocks_agent: str | None = None,
     global_gate: bool | None = None,
     unblocks_todo_id: str | None = None,
+    successor_todo_ids: list[str] | None = None,
     resume_when: str | None = None,
     no_followup: bool | None = None,
     monitor_metadata: dict[str, Any] | None = None,
@@ -1274,6 +1284,8 @@ def apply_todo_update_to_lines(
         updates["global_gate"] = global_gate
     if unblocks_todo_id:
         updates["unblocks_todo_id"] = unblocks_todo_id
+    if successor_todo_ids is not None:
+        updates["successor_todo_ids"] = successor_todo_ids
     if resume_when:
         updates["resume_when"] = resume_when
     if no_followup is not None:
@@ -1314,6 +1326,7 @@ def apply_todo_update_to_lines(
         "blocks_agent": normalize_todo_blocks_agent(effective_metadata.get("blocks_agent")),
         "global_gate": normalize_todo_global_gate(effective_metadata.get("global_gate")),
         "unblocks_todo_id": normalize_todo_id(effective_metadata.get("unblocks_todo_id")),
+        "successor_todo_ids": normalize_todo_id_list(effective_metadata.get("successor_todo_ids")),
         "resume_when": normalize_todo_resume_when(effective_metadata.get("resume_when")),
         "no_followup": normalize_todo_no_followup(effective_metadata.get("no_followup")),
         "target_key": effective_metadata.get("target_key"),
@@ -1346,6 +1359,7 @@ def update_goal_todo(
     global_gate: bool = False,
     agent_id: str | None = None,
     unblocks_todo_id: str | None = None,
+    successor_todo_ids: list[str] | None = None,
     resume_when: str | None = None,
     no_followup: bool | None = None,
     monitor_metadata: dict[str, Any] | None = None,
@@ -1445,6 +1459,9 @@ def update_goal_todo(
         normalized_unblocks_todo_id = normalize_todo_id(unblocks_todo_id) if unblocks_todo_id else None
         if unblocks_todo_id and not normalized_unblocks_todo_id:
             raise ValueError("unblocks_todo_id must use the public token shape todo_<letters-digits-underscore-hyphen>")
+        normalized_successor_todo_ids = normalize_todo_id_list(successor_todo_ids)
+        if successor_todo_ids and not normalized_successor_todo_ids:
+            raise ValueError("successor_todo_ids must contain public todo_<letters-digits-underscore-hyphen> tokens")
         normalized_resume_when = normalize_todo_resume_when(resume_when) if resume_when else None
         if resume_when and not normalized_resume_when:
             raise ValueError("resume_when must be public-safe, e.g. todo_done:todo_ab12cd34ef56 or pr_merged:#532")
@@ -1473,6 +1490,7 @@ def update_goal_todo(
             blocks_agent=effective_blocks_agent,
             global_gate=True if global_gate else None,
             unblocks_todo_id=normalized_unblocks_todo_id,
+            successor_todo_ids=normalized_successor_todo_ids if successor_todo_ids is not None else None,
             resume_when=normalized_resume_when,
             no_followup=no_followup,
             monitor_metadata=normalized_monitor_metadata,
@@ -1515,6 +1533,7 @@ def complete_goal_todo(
     evidence: str | None = None,
     note: str | None = None,
     no_followup: bool = False,
+    successor_todo_ids: list[str] | None = None,
     claimed_by: str | None = None,
     clear_claim: bool = False,
     next_agent_todo: str | None = None,
@@ -1618,6 +1637,9 @@ def complete_goal_todo(
                 effective_next_claimed_by = handoff_agent
         if effective_next_claimed_by and not next_agent_todo:
             raise ValueError("--next-claimed-by requires --next-agent-todo")
+        normalized_successor_todo_ids = normalize_todo_id_list(successor_todo_ids)
+        if successor_todo_ids and not normalized_successor_todo_ids:
+            raise ValueError("successor_todo_ids must contain public todo_<letters-digits-underscore-hyphen> tokens")
         if not find_todo_block(lines, todo_id=todo_id, role=role):
             event_context = event_projection_todo_context(
                 registry_path=registry_path,
@@ -1635,6 +1657,7 @@ def complete_goal_todo(
                     evidence=evidence,
                     note=note,
                     no_followup=no_followup,
+                    successor_todo_ids=normalized_successor_todo_ids,
                     claimed_by=effective_claimed_by,
                     clear_claim=clear_claim,
                     next_agent_todo=next_agent_todo,
@@ -1659,6 +1682,7 @@ def complete_goal_todo(
             claimed_by=effective_claimed_by,
             clear_claim=clear_claim,
             no_followup=True if no_followup else None,
+            successor_todo_ids=normalized_successor_todo_ids if successor_todo_ids is not None else None,
             updated_at=updated_at,
         )
         if next_agent_todo and not effective_next_claimed_by:


### PR DESCRIPTION
## Summary
- add `successor_todo_ids` as structured todo metadata for explicit existing-successor links
- expose `loopx todo update/complete --successor-todo-id` while keeping `--next-agent-todo` for creating new successor work
- preserve the relation through markdown, event-sourced completion, status summaries, and active-state structured projection
- extend lifecycle/succession smokes for side-agent self-merge with a pre-existing successor todo

## Product / architecture judgment
Motivation: side-agent self-iteration sometimes already has the next work item, but completion previously forced either duplicate successor creation or a no-follow-up/succession-warning workaround. This keeps `unblocks_todo_id` directional and adds an explicit source-todo -> successor relation for existing work.

Impact: long-running agent lanes can finish a bounded slice and link the already-open next slice without confusing quota/status succession warnings. The change is a reusable todo metadata contract, not a quota/status special case.

Risk: narrow CLI/read-model change on todo lifecycle; no benchmark adapter, scoring, private evidence, or permission-boundary change.

## Validation
- `python3 -m py_compile loopx/control_plane/todos/contract.py loopx/control_plane/todos/todo_summary.py loopx/todos.py loopx/control_plane/todos/event_writeback.py loopx/event_sourced_state.py loopx/state_projection.py loopx/cli_commands/todo.py examples/control_plane/todo-lifecycle-cli-smoke.py examples/control_plane/todo-succession-contract-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/todo-succession-contract-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/todo-lifecycle-cli-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/event-sourced-status-read-path-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/event-sourced-downstream-read-path-smoke.py`
- `loopx canary premerge --from-git-diff --tier standard --timeout-seconds 300 --format json` (passed; merge_gate_passed=true, self_merge_allowed=true)