### PR TITLE
Fix same-title todo successor routing

### DIFF
--- a/examples/control_plane/todo-lifecycle-cli-smoke.py
+++ b/examples/control_plane/todo-lifecycle-cli-smoke.py
@@ -552,10 +552,72 @@ def assert_complete_links_existing_successor() -> None:
         assert "todo_succession_warning" not in summary, summary
 
 
+def assert_same_title_completion_creates_fresh_successor() -> None:
+    title = "[P1] Continue the next non-benchmark LoopX state-machine canary/refactor slice."
+    with tempfile.TemporaryDirectory(prefix="loopx-same-title-successor-smoke-") as tmp:
+        root = Path(tmp)
+        registry_path, state_file = write_fixture(root)
+        added = run_cli(
+            registry_path,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--text",
+            title,
+            "--claimed-by",
+            "codex-side-bypass",
+            "--task-class",
+            "advancement_task",
+            "--action-kind",
+            "state_machine_canary_refactor",
+        )
+        completed = run_cli(
+            registry_path,
+            "todo",
+            "complete",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            added["todo_id"],
+            "--claimed-by",
+            "codex-side-bypass",
+            "--evidence",
+            "self-merged commit same-title after focused validation",
+            "--side-agent-self-merged",
+            "--next-agent-todo",
+            title,
+            "--next-claimed-by",
+            "codex-side-bypass",
+            "--next-action-kind",
+            "state_machine_canary_refactor",
+        )
+        assert completed["changed"] is True, completed
+        assert completed["next_todos"][0]["added"] is True, completed
+        successor_id = completed["next_todos"][0]["todo_id"]
+        assert successor_id != added["todo_id"], completed
+        assert completed["next_todos"][0]["unblocks_todo_id"] == added["todo_id"], completed
+
+        items = parsed_items(state_file)
+        source_item = next(item for item in items if item["todo_id"] == added["todo_id"])
+        successor_item = next(item for item in items if item["todo_id"] == successor_id)
+        assert source_item["status"] == "done", source_item
+        assert successor_item["status"] == "open", successor_item
+        assert successor_item["text"] == title, successor_item
+        assert successor_item["unblocks_todo_id"] == added["todo_id"], successor_item
+
+        summary = parsed_agent_summary(state_file)
+        assert summary.get("completed_without_successor_count", 0) == 0, summary
+        assert "todo_succession_warning" not in summary, summary
+
+
 def main() -> int:
     assert_configured_side_agent_handoff()
     assert_no_followup_cli_metadata()
     assert_complete_links_existing_successor()
+    assert_same_title_completion_creates_fresh_successor()
 
     with tempfile.TemporaryDirectory(prefix="loopx-todo-lifecycle-smoke-") as tmp:
         root = Path(tmp)

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -631,6 +631,8 @@ def matching_todo_block(
 ) -> dict[str, Any] | None:
     expected = normalize_todo_text(text)
     for block in todo_blocks(lines, start, end, role=role, source_section=source_section):
+        if todo_done_for_status(todo_item_status(block)):
+            continue
         if normalize_todo_text(str(block.get("text") or "")) == expected:
             return block
     return None
@@ -1688,10 +1690,13 @@ def complete_goal_todo(
         if next_agent_todo and not effective_next_claimed_by:
             effective_next_claimed_by = normalize_todo_claimed_by(update_result.get("claimed_by"))
         next_blocks_agent = None
-        next_unblocks_todo_id = None
+        next_unblocks_todo_id = (
+            normalize_todo_id(str(update_result.get("todo_id") or todo_id))
+            if next_agent_todo
+            else None
+        )
         if side_agent_completion and next_agent_todo and not side_agent_self_merged:
             next_blocks_agent = effective_claimed_by
-            next_unblocks_todo_id = normalize_todo_id(str(update_result.get("todo_id") or todo_id))
         next_user_blocks_agent = None
         if next_user_todo and len(registered_agents) > 1:
             next_user_blocks_agent = effective_claimed_by or primary_agent


### PR DESCRIPTION
## Summary
- Fix todo text de-duplication so completed/done todos do not absorb a fresh successor with the same title.
- Make `todo complete --next-agent-todo` persist `unblocks_todo_id=<completed todo>` for markdown active-state successors, matching event-projected completion behavior.
- Add a lifecycle smoke that reproduces the same-title self-merge continuation bug and verifies the successor projection does not emit a completed-without-successor warning.

## Product / Architecture Judgment
- Motivation: LoopX self-iteration can complete a todo and continue with the same human-facing title; before this, markdown active-state routing could reuse the completed source todo and leave the agent lane without a real successor.
- Solved: The runtime now only reuses open todos for text de-duplication, and generated successors are structurally linked via `unblocks_todo_id`.
- User/operator impact: Long-running agents get a cleaner continuation path after self-merge, and status/quota projections can see the successor instead of raising a misleading succession gap.
- Main risk: Todo add idempotency changes for exact-title done todos; this is intended because done work should not block a new open continuation.
- Design judgment: This keeps the fix in the existing todo lifecycle contract instead of adding a one-off writeback workaround.

## Validation
- `python3 -m py_compile loopx/todos.py examples/control_plane/todo-lifecycle-cli-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/todo-lifecycle-cli-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/todo-succession-contract-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `loopx canary premerge --from-git-diff --tier standard --timeout-seconds 300 --format json`
- `git diff --check`
- private/public boundary scan on changed files
