### PR TITLE
Align agent-lane status handoff read paths

### DIFF
--- a/examples/control_plane/control-plane-integrated-canary-smoke.py
+++ b/examples/control_plane/control-plane-integrated-canary-smoke.py
@@ -28,11 +28,13 @@ from loopx.event_sourced_state import (  # noqa: E402
 
 GOAL_ID = "control-plane-integrated-canary"
 MONITOR_GOAL_ID = "control-plane-integrated-monitor-canary"
+MARKDOWN_GOAL_ID = "control-plane-markdown-continuation-canary"
 AGENT_ID = "codex-product-capability"
 PRIMARY_AGENT_ID = "codex-main-control"
 CANARY_TODO_ID = "todo_integrated_canary"
 CANARY_TODO_TITLE = "Design bounded status/quota/review-packet/event/read-path canary"
 SUCCESSOR_TODO_TITLE = "Continue integrated event-sourced successor routing canary"
+MARKDOWN_CONTINUATION_TITLE = "Continue same-agent markdown continuation through status and quota."
 MONITOR_TODO_ID = "todo_integrated_due_monitor"
 MONITOR_TARGET_KEY = "integrated-due-monitor-watch"
 VALIDATED_PROGRESS_CLASSIFICATION = "integrated_canary_validated_progress"
@@ -168,6 +170,71 @@ def write_monitor_fixture(root: Path) -> tuple[Path, Path]:
     return registry_path, runtime
 
 
+def write_markdown_continuation_fixture(root: Path) -> tuple[Path, Path, Path]:
+    project = root / "markdown-project"
+    runtime = root / "markdown-runtime"
+    state_file = project / ".codex" / "goals" / MARKDOWN_GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".loopx" / "registry.json"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(
+        "---\n"
+        "status: active\n"
+        "updated_at: 2026-06-27T00:00:00+00:00\n"
+        "---\n\n"
+        "# Control Plane Markdown Continuation Canary\n\n"
+        "## Next Action\n\n"
+        "- Preserve same-agent markdown successor routing across status and quota.\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] [P2] Markdown placeholder that should lose to the claimed P1 todo.\n"
+        "  <!-- loopx:todo todo_id=todo_markdown_placeholder status=open "
+        "task_class=advancement_task action_kind=stale_markdown -->\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-06-27T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": MARKDOWN_GOAL_ID,
+                        "domain": "control-plane-canary",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": f".codex/goals/{MARKDOWN_GOAL_ID}/ACTIVE_GOAL_STATE.md",
+                        "adapter": {
+                            "kind": "generic_project_goal_v0",
+                            "status": "connected",
+                        },
+                        "quota": {
+                            "compute": 1.0,
+                            "window_hours": 24,
+                            "slot_minutes": 1,
+                            "allowed_slots": 10,
+                        },
+                        "coordination": {
+                            "registered_agents": [PRIMARY_AGENT_ID, AGENT_ID],
+                            "primary_agent": PRIMARY_AGENT_ID,
+                        },
+                        "workspace_guard_policy": {
+                            "side_agent_independent_worktree_required": False,
+                        },
+                        "authority_sources": [],
+                    }
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    runtime.mkdir(parents=True, exist_ok=True)
+    return registry_path, runtime, project
+
+
 def append_event_todos(event_log: Path) -> None:
     store = AppendOnlyStateEventStore(event_log)
 
@@ -250,13 +317,13 @@ def run_cli(registry_path: Path, runtime_root: Path, *args: str) -> dict[str, An
     return json.loads(result.stdout)
 
 
-def find_queue_item(status_payload: dict[str, Any]) -> dict[str, Any]:
+def find_queue_item(status_payload: dict[str, Any], *, goal_id: str = GOAL_ID) -> dict[str, Any]:
     queue = status_payload.get("attention_queue")
     assert isinstance(queue, dict), status_payload
     for item in queue.get("items") or []:
-        if isinstance(item, dict) and item.get("goal_id") == GOAL_ID:
+        if isinstance(item, dict) and item.get("goal_id") == goal_id:
             return item
-    raise AssertionError(f"{GOAL_ID} missing from attention queue: {status_payload}")
+    raise AssertionError(f"{goal_id} missing from attention queue: {status_payload}")
 
 
 def assert_event_projected_agent_todo(summary: dict[str, Any]) -> None:
@@ -633,6 +700,170 @@ def assert_due_monitor_poll_state_machine(root: Path) -> None:
     assert quiet_payload["scheduler_hint"]["cadence_class"] == "monitor_wait", quiet_payload
 
 
+def assert_markdown_same_agent_continuation_read_path(root: Path) -> None:
+    registry_path, runtime_root, project = write_markdown_continuation_fixture(root)
+    added = run_cli(
+        registry_path,
+        runtime_root,
+        "todo",
+        "add",
+        "--goal-id",
+        MARKDOWN_GOAL_ID,
+        "--role",
+        "agent",
+        "--text",
+        MARKDOWN_CONTINUATION_TITLE,
+        "--claimed-by",
+        AGENT_ID,
+        "--task-class",
+        "advancement_task",
+        "--action-kind",
+        "state_machine_canary_refactor",
+    )
+    assert added["ok"] is True, added
+    assert added["added"] is True, added
+    source_todo_id = added["todo_id"]
+
+    status_payload = run_cli(
+        registry_path,
+        runtime_root,
+        "status",
+        "--scan-root",
+        str(project),
+        "--agent-id",
+        AGENT_ID,
+        "--limit",
+        "3",
+    )
+    queue_item = find_queue_item(status_payload, goal_id=MARKDOWN_GOAL_ID)
+    assert queue_item["status"] in {"active_state_agent_todo", "connected_without_run"}, queue_item
+    assert queue_item["waiting_on"] == "codex", queue_item
+    assert MARKDOWN_CONTINUATION_TITLE in queue_item["recommended_action"], queue_item
+
+    source_quota = run_cli(
+        registry_path,
+        runtime_root,
+        "quota",
+        "should-run",
+        "--goal-id",
+        MARKDOWN_GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+    )
+    assert source_quota["decision"] == "run", source_quota
+    assert source_quota["agent_lane_next_action"]["todo_id"] == source_todo_id, source_quota
+    assert source_quota["interaction_contract"]["mode"] == "bounded_delivery", source_quota
+    assert source_quota["interaction_contract"]["agent_channel"]["must_attempt"] is True, source_quota
+
+    completed = run_cli(
+        registry_path,
+        runtime_root,
+        "todo",
+        "complete",
+        "--goal-id",
+        MARKDOWN_GOAL_ID,
+        "--role",
+        "agent",
+        "--todo-id",
+        source_todo_id,
+        "--claimed-by",
+        AGENT_ID,
+        "--side-agent-self-merged",
+        "--evidence",
+        "fixture same-agent markdown continuation passed",
+        "--next-agent-todo",
+        MARKDOWN_CONTINUATION_TITLE,
+        "--next-claimed-by",
+        AGENT_ID,
+        "--next-task-class",
+        "advancement_task",
+        "--next-action-kind",
+        "state_machine_canary_refactor",
+    )
+    assert completed["ok"] is True, completed
+    assert completed["completed"] is True, completed
+    assert completed["side_agent_self_merged"] is True, completed
+    assert len(completed["next_todos"]) == 1, completed
+    successor = completed["next_todos"][0]
+    successor_todo_id = successor["todo_id"]
+    assert successor["added"] is True, completed
+    assert successor["already_exists"] is False, completed
+    assert successor_todo_id != source_todo_id, completed
+    assert successor["unblocks_todo_id"] == source_todo_id, completed
+    assert successor["claimed_by"] == AGENT_ID, completed
+
+    listed = run_cli(
+        registry_path,
+        runtime_root,
+        "todo",
+        "list",
+        "--goal-id",
+        MARKDOWN_GOAL_ID,
+        "--role",
+        "agent",
+        "--agent-id",
+        AGENT_ID,
+    )
+    assert listed["source"] == "markdown_active_state", listed
+    by_id = {item["todo_id"]: item for item in listed["todos"]}
+    assert by_id[source_todo_id]["status"] == "done", listed
+    assert by_id[successor_todo_id]["status"] == "open", listed
+    assert by_id[successor_todo_id]["unblocks_todo_id"] == source_todo_id, listed
+    assert "todo_succession_warning" not in listed["agent_todos"], listed
+
+    successor_quota = run_cli(
+        registry_path,
+        runtime_root,
+        "quota",
+        "should-run",
+        "--goal-id",
+        MARKDOWN_GOAL_ID,
+        "--agent-id",
+        AGENT_ID,
+    )
+    assert successor_quota["decision"] == "run", successor_quota
+    assert successor_quota["effective_action"] == "normal_run", successor_quota
+    assert successor_quota["agent_lane_next_action"]["todo_id"] == successor_todo_id, successor_quota
+    assert successor_quota["agent_lane_next_action"]["text"] == MARKDOWN_CONTINUATION_TITLE, successor_quota
+    assert successor_quota["agent_lane_next_action"]["unblocks_todo_id"] == source_todo_id, successor_quota
+    assert successor_quota["interaction_contract"]["user_channel"]["action_required"] is False, successor_quota
+    assert successor_quota["interaction_contract"]["agent_channel"]["must_attempt"] is True, successor_quota
+    assert successor_quota["scheduler_hint"]["action"] == "run_now", successor_quota
+
+    refreshed_status = run_cli(
+        registry_path,
+        runtime_root,
+        "status",
+        "--scan-root",
+        str(project),
+        "--agent-id",
+        AGENT_ID,
+        "--limit",
+        "3",
+    )
+    refreshed_item = find_queue_item(refreshed_status, goal_id=MARKDOWN_GOAL_ID)
+    assert refreshed_item["waiting_on"] == "codex", refreshed_item
+    assert successor_todo_id in json.dumps(refreshed_item["agent_todos"], sort_keys=True), refreshed_item
+    assert source_todo_id not in refreshed_item["recommended_action"], refreshed_item
+
+    packet_payload = run_cli(
+        registry_path,
+        runtime_root,
+        "review-packet",
+        "--goal-id",
+        MARKDOWN_GOAL_ID,
+        "--format",
+        "json",
+        "--agent-id",
+        AGENT_ID,
+    )
+    assert packet_payload["ok"] is True, packet_payload
+    assert packet_payload["handoff_interface_budget"]["within_budget"] is True, packet_payload
+    assert MARKDOWN_CONTINUATION_TITLE in packet_payload["agent_todo_text"], packet_payload
+    assert successor_todo_id in packet_payload["project_agent_handoff"], packet_payload
+    assert source_todo_id not in packet_payload["project_agent_handoff"], packet_payload
+
+
 def run_fixture_canary(root: Path) -> None:
     registry_path, _, event_log = write_fixture(root)
     runtime_root = root / "runtime"
@@ -695,6 +926,7 @@ def run_fixture_canary(root: Path) -> None:
     assert SUCCESSOR_TODO_TITLE in packet_payload["project_agent_handoff"], packet_payload
     assert CANARY_TODO_TITLE not in packet_payload["project_agent_handoff"], packet_payload
     assert packet_payload["handoff_interface_budget"]["within_budget"] is True, packet_payload
+    assert_markdown_same_agent_continuation_read_path(root)
     assert_due_monitor_poll_state_machine(root)
 
 

--- a/loopx/cli_commands/status.py
+++ b/loopx/cli_commands/status.py
@@ -509,6 +509,52 @@ def _build_agent_member_projection(
     return member
 
 
+def _agent_lane_text(next_action: dict[str, Any]) -> str | None:
+    text = str(next_action.get("text") or next_action.get("title") or "").strip()
+    return text or None
+
+
+def _guard_allows_agent_lane_next_action(guard: dict[str, object]) -> bool:
+    interaction = guard.get("interaction_contract")
+    if not isinstance(interaction, dict):
+        return False
+    user_channel = interaction.get("user_channel")
+    agent_channel = interaction.get("agent_channel")
+    user_action_required = (
+        bool(user_channel.get("action_required"))
+        if isinstance(user_channel, dict)
+        else False
+    )
+    agent_must_attempt = (
+        bool(agent_channel.get("must_attempt"))
+        if isinstance(agent_channel, dict)
+        else False
+    )
+    return agent_must_attempt and not user_action_required
+
+
+def _sync_status_item_next_action_from_agent_lane(
+    item: dict[str, object],
+    *,
+    next_action: dict[str, Any],
+    guard: dict[str, object],
+) -> None:
+    if item.get("status") not in {"connected_without_run", "active_state_agent_todo"}:
+        return
+    if not _guard_allows_agent_lane_next_action(guard):
+        return
+    text = _agent_lane_text(next_action)
+    if not text:
+        return
+    item["recommended_action"] = text
+    project_asset = item.get("project_asset")
+    if isinstance(project_asset, dict):
+        project_asset["next_action"] = text
+    goal_channel = item.get("goal_channel_projection")
+    if isinstance(goal_channel, dict):
+        goal_channel["next_action"] = text
+
+
 def attach_agent_lane_next_actions(payload: dict[str, object], *, agent_id: str) -> dict[str, object]:
     safe_agent_id = str(agent_id or "").strip()
     if not safe_agent_id:
@@ -541,6 +587,11 @@ def attach_agent_lane_next_actions(payload: dict[str, object], *, agent_id: str)
             item["agent_lane_next_action"] = next_action
             if isinstance(project_asset, dict):
                 project_asset["agent_lane_next_action"] = next_action
+            _sync_status_item_next_action_from_agent_lane(
+                item,
+                next_action=next_action,
+                guard=guard,
+            )
             attached += 1
             changed = True
         frontier = guard.get("agent_scope_frontier")

--- a/loopx/control_plane/todos/todo_summary.py
+++ b/loopx/control_plane/todos/todo_summary.py
@@ -162,9 +162,23 @@ def sync_connected_attention_action_from_todos(
 ) -> None:
     if item.get("status") != "connected_without_run":
         return
-    agent_action = first_open_todo_text(
-        item.get("agent_todos") if isinstance(item.get("agent_todos"), dict) else None
+    agent_lane_action = (
+        item.get("agent_lane_next_action")
+        if isinstance(item.get("agent_lane_next_action"), dict)
+        else None
     )
+    if agent_lane_action is None and isinstance(item.get("project_asset"), dict):
+        project_asset = item["project_asset"]
+        agent_lane_action = (
+            project_asset.get("agent_lane_next_action")
+            if isinstance(project_asset.get("agent_lane_next_action"), dict)
+            else None
+        )
+    agent_action = normalize_todo_text(agent_lane_action.get("text")) if agent_lane_action else None
+    if not agent_action:
+        agent_action = first_open_todo_text(
+            item.get("agent_todos") if isinstance(item.get("agent_todos"), dict) else None
+        )
     if not agent_action:
         return
     item["recommended_action"] = agent_action

--- a/loopx/review_packet.py
+++ b/loopx/review_packet.py
@@ -371,6 +371,36 @@ def todo_texts_from_project_asset(item: dict[str, Any] | None, key: str, *, limi
     return open_todo_texts(item.get(key), limit=limit, rank_for_handoff=rank_for_handoff)
 
 
+def agent_lane_todo_text(item: dict[str, Any] | None) -> str | None:
+    if not isinstance(item, dict):
+        return None
+    project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
+    lane = (
+        project_asset.get("agent_lane_next_action")
+        if isinstance(project_asset.get("agent_lane_next_action"), dict)
+        else item.get("agent_lane_next_action")
+        if isinstance(item.get("agent_lane_next_action"), dict)
+        else None
+    )
+    if not isinstance(lane, dict):
+        return None
+    text = str(lane.get("text") or lane.get("title") or "").strip()
+    if not text:
+        return None
+    claimed_by = str(lane.get("claimed_by") or "").strip()
+    if claimed_by:
+        text = f"{text} claimed_by={claimed_by}"
+    return compact_packet_text(text)
+
+
+def agent_todo_texts_for_handoff(item: dict[str, Any] | None, *, limit: int = 3) -> list[str]:
+    items = todo_texts_from_project_asset(item, "agent_todos", limit=limit)
+    lane_text = agent_lane_todo_text(item)
+    if not lane_text:
+        return items
+    return [lane_text, *[text for text in items if text != lane_text]][:limit]
+
+
 def agent_member_from_item(item: dict[str, Any] | None) -> dict[str, Any] | None:
     if not isinstance(item, dict):
         return None
@@ -1145,7 +1175,7 @@ def build_review_packet(
     question = str(item.get("operator_question") or prompt["question"]) if isinstance(item, dict) else prompt["question"]
     summary = str(item.get("recommended_action") or "当前状态源没有对应的 action card。") if isinstance(item, dict) else "当前状态源没有对应的 action card。"
     user_todo_text = todo_text_from_project_asset(item, "user_todos")
-    agent_todo_items = todo_texts_from_project_asset(item, "agent_todos")
+    agent_todo_items = agent_todo_texts_for_handoff(item)
     agent_todo_text = agent_todo_items[0] if agent_todo_items else None
     asset_source = project_asset_source(item)
     asset_source_line = project_asset_source_line(asset_source)

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -7129,6 +7129,7 @@ def build_attention_queue(
                         subagent_activity=subagent_activity,
                         interface_budget_cadence=interface_budget_cadence,
                     )
+                sync_connected_attention_action_from_todos(item)
                 normalize_monitor_quiet_attention_display(item)
             if include_task_graph:
                 task_graph_projection = build_task_graph_projection(


### PR DESCRIPTION
## Summary
- add a markdown-backed same-agent continuation path to the integrated control-plane canary
- sync agent-lane selected next action into connected status/project_asset/goal-channel read paths without overriding primary-route status
- make review packets prefer the agent-lane selected todo for agent handoff while keeping other open todos visible as candidates

## Validation
- python3 -m py_compile loopx/cli_commands/status.py loopx/review_packet.py examples/control_plane/control-plane-integrated-canary-smoke.py loopx/control_plane/todos/todo_summary.py loopx/status.py
- git diff --check
- PYTHONPATH=. python3 examples/control_plane/status-markdown-smoke.py
- /Library/Developer/CommandLineTools/usr/bin/python3 examples/control_plane/status-markdown-smoke.py
- PYTHONPATH=. python3 examples/control_plane/status-quota-review-packet-parity-smoke.py
- PYTHONPATH=. python3 examples/control_plane/todo-lifecycle-cli-smoke.py
- PYTHONPATH=. python3 examples/control_plane/todo-succession-contract-smoke.py
- PYTHONPATH=. python3 examples/control_plane/control-plane-integrated-canary-smoke.py
- PYTHONPATH=. python3 -m loopx.cli --format json canary premerge --from-git-diff --tier standard --timeout-seconds 300
