### PR TITLE
Route agent-lane fallback through agents context

### DIFF
--- a/examples/control_plane/side-agent-self-iteration-state-machine-smoke.py
+++ b/examples/control_plane/side-agent-self-iteration-state-machine-smoke.py
@@ -20,6 +20,11 @@ NEXT_TODO_TEXT = (
     "Continue the side-agent self-iteration canary with scheduler and quota coverage."
 )
 GOAL_NEXT_ACTION = "Keep the primary goal route stable while the side-agent lane advances."
+CAPABILITY_BLOCKED_TODO_ID = "todo_self_iter_network_only"
+CAPABILITY_FALLBACK_TODO_ID = "todo_self_iter_filesystem_fallback"
+CAPABILITY_FALLBACK_TEXT = (
+    "Run the public-safe filesystem fallback while network capability is unavailable."
+)
 
 
 def run_cli(
@@ -55,6 +60,55 @@ def run_cli(
     return payload
 
 
+def write_registry(
+    *,
+    project: Path,
+    runtime: Path,
+    registry_path: Path,
+    adapter_kind: str,
+) -> None:
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "side-agent-self-iteration-fixture",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
+                        "adapter": {
+                            "kind": adapter_kind,
+                            "status": "connected-read-only",
+                        },
+                        "authority_sources": [],
+                        "quota": {
+                            "compute": 1.0,
+                            "window_hours": 24,
+                            "allowed_slots": 5,
+                        },
+                        "coordination": {
+                            "registered_agents": [PRIMARY_AGENT_ID, AGENT_ID],
+                            "primary_agent": PRIMARY_AGENT_ID,
+                        },
+                        "workspace_guard_policy": {
+                            "side_agent_independent_worktree_required": False,
+                        },
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
 def write_fixture(root: Path) -> tuple[Path, Path, Path]:
     project = root / "project"
     runtime = root / "runtime"
@@ -81,45 +135,50 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
         f"claimed_by={AGENT_ID} -->\n",
         encoding="utf-8",
     )
-    registry_path.parent.mkdir(parents=True)
-    registry_path.write_text(
-        json.dumps(
-            {
-                "schema_version": "0.1",
-                "updated_at": "2026-01-01T00:00:00+00:00",
-                "common_runtime_root": str(runtime),
-                "goals": [
-                    {
-                        "id": GOAL_ID,
-                        "domain": "side-agent-self-iteration-fixture",
-                        "status": "active",
-                        "repo": str(project),
-                        "state_file": state_file,
-                        "adapter": {
-                            "kind": "side_agent_self_iteration_fixture_v0",
-                            "status": "connected-read-only",
-                        },
-                        "authority_sources": [],
-                        "quota": {
-                            "compute": 1.0,
-                            "window_hours": 24,
-                            "allowed_slots": 5,
-                        },
-                        "coordination": {
-                            "registered_agents": [PRIMARY_AGENT_ID, AGENT_ID],
-                            "primary_agent": PRIMARY_AGENT_ID,
-                        },
-                        "workspace_guard_policy": {
-                            "side_agent_independent_worktree_required": False,
-                        },
-                    }
-                ],
-            },
-            indent=2,
-            sort_keys=True,
-        )
-        + "\n",
+    write_registry(
+        project=project,
+        runtime=runtime,
+        registry_path=registry_path,
+        adapter_kind="side_agent_self_iteration_fixture_v0",
+    )
+    return project, runtime, registry_path
+
+
+def write_capability_fallback_fixture(root: Path) -> tuple[Path, Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    state_path = project / state_file
+    registry_path = project / ".loopx" / "registry.json"
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(
+        "---\n"
+        "status: active\n"
+        "owner_mode: goal\n"
+        'objective: "Exercise side-agent capability fallback routing."\n'
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Side-Agent Capability Fallback Fixture\n\n"
+        "## Objective\n\n"
+        "Exercise side-agent capability fallback routing.\n\n"
+        "## Next Action\n\n"
+        f"- Run {CAPABILITY_BLOCKED_TODO_ID} before fallback work.\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] [P0] Run the network-only side-agent canary path.\n"
+        f"  <!-- loopx:todo todo_id={CAPABILITY_BLOCKED_TODO_ID} status=open "
+        "task_class=advancement_task action_kind=state_machine_canary_refactor "
+        f"required_capabilities=network claimed_by={AGENT_ID} -->\n"
+        f"- [ ] [P1] {CAPABILITY_FALLBACK_TEXT}\n"
+        f"  <!-- loopx:todo todo_id={CAPABILITY_FALLBACK_TODO_ID} status=open "
+        "task_class=advancement_task action_kind=state_machine_canary_refactor "
+        f"required_capabilities=shell claimed_by={AGENT_ID} -->\n",
         encoding="utf-8",
+    )
+    write_registry(
+        project=project,
+        runtime=runtime,
+        registry_path=registry_path,
+        adapter_kind="side_agent_capability_fallback_fixture_v0",
     )
     return project, runtime, registry_path
 
@@ -305,8 +364,56 @@ def assert_self_iteration_flow() -> None:
         assert third["active_state_next_action"] == GOAL_NEXT_ACTION, third
 
 
+def assert_capability_fallback_preserves_frontier_and_scheduler() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-side-agent-capability-fallback-") as tmp:
+        project, runtime, registry_path = write_capability_fallback_fixture(Path(tmp))
+
+        guard = should_run(registry_path, runtime, project)
+        assert guard["decision"] == "run", guard
+        assert guard["normal_delivery_allowed"] is True, guard
+        assert guard["active_state_next_action"] == (
+            f"Run {CAPABILITY_BLOCKED_TODO_ID} before fallback work."
+        ), guard
+
+        capability = guard["capability_gate"]
+        assert capability["action"] == "run", guard
+        assert capability["runnable_count"] == 1, capability
+        assert capability["runnable_candidates"][0]["todo_id"] == CAPABILITY_FALLBACK_TODO_ID, capability
+        assert capability["blocked_candidates"][0]["todo_id"] == CAPABILITY_BLOCKED_TODO_ID, capability
+        assert capability["blocked_missing"] == ["network"], capability
+
+        lane = guard["agent_lane_next_action"]
+        assert lane["todo_id"] == CAPABILITY_FALLBACK_TODO_ID, guard
+        assert lane["source"] == "capability_gate.runnable_candidates", guard
+        assert lane["selected_by"] == "current_agent_claimed_todo", guard
+        assert lane["required_capabilities"] == ["shell"], guard
+        assert lane["preserves_goal_next_action"] is True, guard
+        assert guard["recommended_action"].endswith(CAPABILITY_FALLBACK_TEXT), guard
+
+        frontier = guard["goal_frontier_projection"]
+        assert frontier["remaining_advancement_frontier"] == {
+            "current_agent_claimed_advancement_count": 2,
+            "unclaimed_advancement_count": 0,
+            "other_agent_claimed_advancement_count": 0,
+        }, frontier
+        assert frontier["replan_required"] is False, frontier
+
+        scheduler = guard["scheduler_hint"]
+        assert scheduler["action"] == "run_now", guard
+        assert scheduler["cadence_class"] == "active_work", guard
+        assert scheduler["codex_app"]["stateful_backoff"]["apply_needed"] is True, guard
+
+        assert_scheduler_ack_round_trip(
+            registry_path=registry_path,
+            runtime=runtime,
+            project=project,
+            guard=guard,
+        )
+
+
 def main() -> int:
     assert_self_iteration_flow()
+    assert_capability_fallback_preserves_frontier_and_scheduler()
     print("side-agent-self-iteration-state-machine-smoke ok")
     return 0
 

--- a/loopx/control_plane/agents/agent_lane_recommendation.py
+++ b/loopx/control_plane/agents/agent_lane_recommendation.py
@@ -1,11 +1,27 @@
 from __future__ import annotations
 
+import re
 from typing import Any, Callable, Optional
+
+from ..todos.contract import (
+    TODO_TASK_CLASS_ADVANCEMENT,
+    normalize_todo_blocks_agent,
+    normalize_todo_claimed_by,
+    normalize_todo_id,
+)
+from ..work_items.interaction_contract import protocol_action_text
+from .agent_scope import (
+    _compact_todo_summary_item,
+    _todo_item_is_actionable_open,
+    _todo_task_class,
+)
+from .capability_gate import _agent_lane_candidate_sort_key
 
 
 PublicSafeText = Callable[..., Optional[str]]
 ActionAlignment = Callable[[Any, Any], bool]
 TimestampParser = Callable[[Any], Any]
+AGENT_LANE_NEXT_ACTION_SCHEMA_VERSION = "agent_lane_next_action_v0"
 
 
 def is_status_neutral_run(
@@ -118,3 +134,259 @@ def latest_run_recommended_action_for_projection(
     if not latest_action or not latest_aligned:
         return lane_action, "agent_lane_recommendation"
     return latest_action, "latest_status_run"
+
+
+def _first_executable_todo_text(agent_todo_summary: dict[str, Any] | None) -> str | None:
+    if not isinstance(agent_todo_summary, dict):
+        return None
+    items = (
+        agent_todo_summary.get("first_executable_items")
+        if isinstance(agent_todo_summary.get("first_executable_items"), list)
+        else []
+    )
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if not _todo_item_is_actionable_open(item):
+            continue
+        if _todo_task_class(item) != TODO_TASK_CLASS_ADVANCEMENT:
+            continue
+        text = protocol_action_text(item.get("text"), limit=320)
+        if text:
+            return text
+    return None
+
+
+def _todo_ids_from_action(value: Any) -> set[str]:
+    text = str(value or "")
+    if not text:
+        return set()
+    return set(re.findall(r"\btodo_[A-Za-z0-9_]+\b", text))
+
+
+def selected_recommended_action_from_work_lane(
+    item: dict[str, Any],
+    *,
+    agent_todo_summary: dict[str, Any] | None,
+    work_lane_contract: dict[str, Any] | None,
+) -> Any:
+    raw_action = item.get("recommended_action")
+    if (
+        isinstance(work_lane_contract, dict)
+        and work_lane_contract.get("monitor_kind") == "todo_monitor_due"
+        and work_lane_contract.get("must_attempt_work") is True
+    ):
+        due_items = (
+            work_lane_contract.get("monitor_due_items")
+            if isinstance(work_lane_contract.get("monitor_due_items"), list)
+            else []
+        )
+        for due_item in due_items:
+            if not isinstance(due_item, dict):
+                continue
+            text = protocol_action_text(due_item.get("text"), limit=320)
+            if text:
+                return text
+        return raw_action
+    if (
+        isinstance(work_lane_contract, dict)
+        and work_lane_contract.get("lane") == "advancement_task"
+        and "open_agent_todo"
+        in (
+            work_lane_contract.get("reason_codes")
+            if isinstance(work_lane_contract.get("reason_codes"), list)
+            else []
+        )
+    ):
+        return _first_executable_todo_text(agent_todo_summary) or raw_action
+    return raw_action
+
+
+def build_agent_lane_next_action(
+    *,
+    agent_identity: dict[str, Any] | None,
+    agent_todo_summary: dict[str, Any] | None,
+    capability_gate: dict[str, Any] | None,
+    active_next_action: Any = None,
+    scoped_user_gate_fallback: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    if not isinstance(agent_identity, dict):
+        return None
+    agent_id = normalize_todo_claimed_by(agent_identity.get("agent_id"))
+    if not agent_id or not isinstance(agent_todo_summary, dict):
+        return None
+
+    if isinstance(scoped_user_gate_fallback, dict):
+        selected = scoped_user_gate_fallback.get("selected_executable")
+        if isinstance(selected, dict):
+            text = protocol_action_text(selected.get("text"), limit=500)
+            claimed_by = normalize_todo_claimed_by(selected.get("claimed_by"))
+            if (
+                text
+                and _todo_item_is_actionable_open(selected)
+                and _todo_task_class(selected) == TODO_TASK_CLASS_ADVANCEMENT
+                and (not claimed_by or claimed_by == agent_id)
+            ):
+                payload = dict(selected)
+                payload.update(
+                    {
+                        "schema_version": AGENT_LANE_NEXT_ACTION_SCHEMA_VERSION,
+                        "agent_id": agent_id,
+                        "primary_agent": normalize_todo_claimed_by(
+                            agent_identity.get("primary_agent")
+                        ),
+                        "source": "scoped_user_gate_fallback.selected_executable",
+                        "selected_by": "scoped_user_gate_fallback",
+                        "confidence": "selected",
+                        "preserves_goal_next_action": False,
+                        "replaces_gated_goal_next_action": True,
+                    }
+                )
+                if not claimed_by:
+                    payload["claim_required_before_work"] = True
+                return payload
+
+    candidate_sources: list[tuple[str, list[Any]]] = []
+    if isinstance(capability_gate, dict) and capability_gate.get("action") == "run":
+        candidate_sources.append(
+            (
+                "capability_gate.runnable_candidates",
+                capability_gate.get("runnable_candidates")
+                if isinstance(capability_gate.get("runnable_candidates"), list)
+                else [],
+            )
+        )
+    else:
+        candidate_sources.append(
+            (
+                "agent_todo_summary.active_next_action_executable_items",
+                agent_todo_summary.get("active_next_action_executable_items")
+                if isinstance(
+                    agent_todo_summary.get("active_next_action_executable_items"), list
+                )
+                else [],
+            )
+        )
+    candidate_sources.append(
+        (
+            "agent_todo_summary.first_executable_items",
+            agent_todo_summary.get("first_executable_items")
+            if isinstance(agent_todo_summary.get("first_executable_items"), list)
+            else [],
+        )
+    )
+    candidate_sources.append(
+        (
+            "agent_todo_summary.executable_backlog_items",
+            agent_todo_summary.get("executable_backlog_items")
+            if isinstance(agent_todo_summary.get("executable_backlog_items"), list)
+            else [],
+        )
+    )
+
+    preferred_todo_ids = _todo_ids_from_action(active_next_action)
+    primary_agent = normalize_todo_claimed_by(agent_identity.get("primary_agent"))
+
+    seen: set[tuple[str, str]] = set()
+    for source, raw_items in candidate_sources:
+        source_candidates: list[dict[str, Any]] = []
+        for raw_item in raw_items:
+            if not isinstance(raw_item, dict):
+                continue
+            if not _todo_item_is_actionable_open(raw_item):
+                continue
+            if _todo_task_class(raw_item) != TODO_TASK_CLASS_ADVANCEMENT:
+                continue
+            text = protocol_action_text(raw_item.get("text"), limit=500)
+            if not text:
+                continue
+            identity = (str(raw_item.get("todo_id") or ""), text)
+            if identity in seen:
+                continue
+            claimed_by = normalize_todo_claimed_by(raw_item.get("claimed_by"))
+            if claimed_by and claimed_by != agent_id:
+                continue
+            seen.add(identity)
+            source_candidates.append(raw_item)
+        for raw_item in sorted(
+            source_candidates,
+            key=lambda candidate: _agent_lane_candidate_sort_key(
+                candidate,
+                agent_id=agent_id,
+                primary_agent=primary_agent,
+                preferred_todo_ids=preferred_todo_ids,
+            ),
+        ):
+            text = protocol_action_text(raw_item.get("text"), limit=500)
+            claimed_by = normalize_todo_claimed_by(raw_item.get("claimed_by"))
+            todo_id = str(raw_item.get("todo_id") or "").strip()
+            selected_by = (
+                "active_next_action_todo"
+                if todo_id and todo_id in preferred_todo_ids
+                else "current_agent_claimed_todo"
+                if claimed_by == agent_id
+                else "unclaimed_todo"
+            )
+            payload = _compact_todo_summary_item(raw_item, text=text)
+            if selected_by == "unclaimed_todo":
+                payload["claim_required_before_work"] = True
+            blocks_agent = normalize_todo_blocks_agent(raw_item.get("blocks_agent"))
+            unblocks_todo_id = normalize_todo_id(raw_item.get("unblocks_todo_id"))
+            if blocks_agent:
+                payload["unblock_handoff"] = {"blocks_agent": blocks_agent}
+                if unblocks_todo_id:
+                    payload["unblock_handoff"]["unblocks_todo_id"] = unblocks_todo_id
+            for key in (
+                "missing_capabilities",
+                "missing_target_capabilities",
+                "capability_action",
+                "capability_repair_mode",
+            ):
+                if raw_item.get(key) is not None:
+                    payload[key] = raw_item.get(key)
+            payload.update(
+                {
+                    "schema_version": AGENT_LANE_NEXT_ACTION_SCHEMA_VERSION,
+                    "agent_id": agent_id,
+                    "primary_agent": normalize_todo_claimed_by(
+                        agent_identity.get("primary_agent")
+                    ),
+                    "source": source,
+                    "selected_by": selected_by,
+                    "confidence": (
+                        "selected"
+                        if selected_by
+                        in {"active_next_action_todo", "current_agent_claimed_todo"}
+                        else "candidate"
+                    ),
+                    "preserves_goal_next_action": True,
+                }
+            )
+            return payload
+    return None
+
+
+def selected_action_with_agent_lane(
+    selected_action: Any,
+    *,
+    agent_lane_next_action: dict[str, Any] | None,
+) -> Any:
+    if not isinstance(agent_lane_next_action, dict):
+        return selected_action
+    if agent_lane_next_action.get("source") not in {
+        "capability_gate.runnable_candidates",
+        "agent_todo_summary.active_next_action_executable_items",
+    }:
+        return selected_action
+    selected_by = agent_lane_next_action.get("selected_by")
+    confidence = agent_lane_next_action.get("confidence")
+    if selected_by not in {
+        "active_next_action_todo",
+        "current_agent_claimed_todo",
+        "unclaimed_todo",
+    }:
+        return selected_action
+    if confidence not in {"selected", "candidate"}:
+        return selected_action
+    lane_text = str(agent_lane_next_action.get("text") or "").strip()
+    return lane_text or selected_action

--- a/loopx/control_plane/agents/agent_scope.py
+++ b/loopx/control_plane/agents/agent_scope.py
@@ -143,6 +143,7 @@ def _compact_todo_summary_item(item: dict[str, Any], *, text: str | None = None)
         "resume_condition",
         "resume_ready",
         "no_followup",
+        "successor_todo_ids",
         "target_key",
         "cadence",
         "next_due_at",
@@ -156,6 +157,9 @@ def _compact_todo_summary_item(item: dict[str, Any], *, text: str | None = None)
         "route_continuation_reason",
         "route_id",
         "route_key",
+        "completed_at",
+        "updated_at",
+        "superseded_by",
     ):
         if item.get(key) is not None:
             compact[key] = item.get(key)

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -22,8 +22,12 @@ from .control_plane.agents.agent_scope import (
     _agent_scoped_user_gate_override,
     _scoped_user_gate_fallback,
 )
+from .control_plane.agents.agent_lane_recommendation import (
+    build_agent_lane_next_action,
+    selected_action_with_agent_lane,
+    selected_recommended_action_from_work_lane,
+)
 from .control_plane.agents.capability_gate import (
-    _agent_lane_candidate_sort_key,
     _capability_candidate_item,
     _capability_missing_action,
     _sort_capability_runnable_candidates,
@@ -250,7 +254,6 @@ CAPABILITY_GATE_SCHEMA_VERSION = "capability_gate_v0"
 SIDE_AGENT_WORKSPACE_GUARD_SCHEMA_VERSION = "side_agent_workspace_guard_v0"
 AGENT_CLAIM_SCOPE_SCHEMA_VERSION = "agent_claim_scope_v0"
 SIDE_AGENT_CLAIM_SCOPE_SCHEMA_VERSION = AGENT_CLAIM_SCOPE_SCHEMA_VERSION
-AGENT_LANE_NEXT_ACTION_SCHEMA_VERSION = "agent_lane_next_action_v0"
 PRIVATE_BOUNDARY_MONITOR_RESULT_HASHES = {
     "private_boundary_no_authorized_read",
 }
@@ -2479,262 +2482,12 @@ def _blocked_priority_fallback(
     }
 
 
-def _first_executable_todo_text(agent_todo_summary: dict[str, Any] | None) -> str | None:
-    if not isinstance(agent_todo_summary, dict):
-        return None
-    items = (
-        agent_todo_summary.get("first_executable_items")
-        if isinstance(agent_todo_summary.get("first_executable_items"), list)
-        else []
-    )
-    for item in items:
-        if not isinstance(item, dict):
-            continue
-        if not _todo_item_is_actionable_open(item):
-            continue
-        if _todo_task_class(item) != TODO_TASK_CLASS_ADVANCEMENT:
-            continue
-        text = _protocol_action_text(item.get("text"), limit=320)
-        if text:
-            return text
-    return None
-
-
-def _agent_lane_next_action(
-    *,
-    agent_identity: dict[str, Any] | None,
-    agent_todo_summary: dict[str, Any] | None,
-    capability_gate: dict[str, Any] | None,
-    active_next_action: Any = None,
-    scoped_user_gate_fallback: dict[str, Any] | None = None,
-) -> dict[str, Any] | None:
-    if not isinstance(agent_identity, dict):
-        return None
-    agent_id = normalize_todo_claimed_by(agent_identity.get("agent_id"))
-    if not agent_id or not isinstance(agent_todo_summary, dict):
-        return None
-
-    if isinstance(scoped_user_gate_fallback, dict):
-        selected = scoped_user_gate_fallback.get("selected_executable")
-        if isinstance(selected, dict):
-            text = _protocol_action_text(selected.get("text"), limit=500)
-            claimed_by = normalize_todo_claimed_by(selected.get("claimed_by"))
-            if (
-                text
-                and _todo_item_is_actionable_open(selected)
-                and _todo_task_class(selected) == TODO_TASK_CLASS_ADVANCEMENT
-                and (not claimed_by or claimed_by == agent_id)
-            ):
-                payload = dict(selected)
-                payload.update(
-                    {
-                        "schema_version": AGENT_LANE_NEXT_ACTION_SCHEMA_VERSION,
-                        "agent_id": agent_id,
-                        "primary_agent": normalize_todo_claimed_by(
-                            agent_identity.get("primary_agent")
-                        ),
-                        "source": "scoped_user_gate_fallback.selected_executable",
-                        "selected_by": "scoped_user_gate_fallback",
-                        "confidence": "selected",
-                        "preserves_goal_next_action": False,
-                        "replaces_gated_goal_next_action": True,
-                    }
-                )
-                if not claimed_by:
-                    payload["claim_required_before_work"] = True
-                return payload
-
-    candidate_sources: list[tuple[str, list[Any]]] = []
-    candidate_sources.append(
-        (
-            "agent_todo_summary.active_next_action_executable_items",
-            agent_todo_summary.get("active_next_action_executable_items")
-            if isinstance(agent_todo_summary.get("active_next_action_executable_items"), list)
-            else [],
-        )
-    )
-    if isinstance(capability_gate, dict) and capability_gate.get("action") == "run":
-        candidate_sources.append(
-            (
-                "capability_gate.runnable_candidates",
-                capability_gate.get("runnable_candidates")
-                if isinstance(capability_gate.get("runnable_candidates"), list)
-                else [],
-            )
-        )
-    candidate_sources.append(
-        (
-            "agent_todo_summary.first_executable_items",
-            agent_todo_summary.get("first_executable_items")
-            if isinstance(agent_todo_summary.get("first_executable_items"), list)
-            else [],
-        )
-    )
-    candidate_sources.append(
-        (
-            "agent_todo_summary.executable_backlog_items",
-            agent_todo_summary.get("executable_backlog_items")
-            if isinstance(agent_todo_summary.get("executable_backlog_items"), list)
-            else [],
-        )
-    )
-
-    preferred_todo_ids = _todo_ids_from_action(active_next_action)
-
-    primary_agent = normalize_todo_claimed_by(agent_identity.get("primary_agent"))
-
-    seen: set[tuple[str, str]] = set()
-    for source, raw_items in candidate_sources:
-        source_candidates: list[dict[str, Any]] = []
-        for raw_item in raw_items:
-            if not isinstance(raw_item, dict):
-                continue
-            if not _todo_item_is_actionable_open(raw_item):
-                continue
-            if _todo_task_class(raw_item) != TODO_TASK_CLASS_ADVANCEMENT:
-                continue
-            text = _protocol_action_text(raw_item.get("text"), limit=500)
-            if not text:
-                continue
-            identity = (str(raw_item.get("todo_id") or ""), text)
-            if identity in seen:
-                continue
-            claimed_by = normalize_todo_claimed_by(raw_item.get("claimed_by"))
-            if claimed_by and claimed_by != agent_id:
-                continue
-            seen.add(identity)
-            source_candidates.append(raw_item)
-        for raw_item in sorted(
-            source_candidates,
-            key=lambda item: _agent_lane_candidate_sort_key(
-                item,
-                agent_id=agent_id,
-                primary_agent=primary_agent,
-                preferred_todo_ids=preferred_todo_ids,
-            ),
-        ):
-            text = _protocol_action_text(raw_item.get("text"), limit=500)
-            claimed_by = normalize_todo_claimed_by(raw_item.get("claimed_by"))
-            todo_id = str(raw_item.get("todo_id") or "").strip()
-            selected_by = (
-                "active_next_action_todo"
-                if todo_id and todo_id in preferred_todo_ids
-                else
-                "current_agent_claimed_todo"
-                if claimed_by == agent_id
-                else "unclaimed_todo"
-            )
-            payload = _compact_todo_summary_item(raw_item, text=text)
-            if selected_by == "unclaimed_todo":
-                payload["claim_required_before_work"] = True
-            blocks_agent = normalize_todo_blocks_agent(raw_item.get("blocks_agent"))
-            unblocks_todo_id = normalize_todo_id(raw_item.get("unblocks_todo_id"))
-            if blocks_agent:
-                payload["unblock_handoff"] = {"blocks_agent": blocks_agent}
-                if unblocks_todo_id:
-                    payload["unblock_handoff"]["unblocks_todo_id"] = unblocks_todo_id
-            for key in (
-                "missing_capabilities",
-                "missing_target_capabilities",
-                "capability_action",
-                "capability_repair_mode",
-            ):
-                if raw_item.get(key) is not None:
-                    payload[key] = raw_item.get(key)
-            payload.update(
-                {
-                    "schema_version": AGENT_LANE_NEXT_ACTION_SCHEMA_VERSION,
-                    "agent_id": agent_id,
-                    "primary_agent": normalize_todo_claimed_by(
-                        agent_identity.get("primary_agent")
-                    ),
-                    "source": source,
-                    "selected_by": selected_by,
-                    "confidence": (
-                        "selected"
-                        if selected_by
-                        in {"active_next_action_todo", "current_agent_claimed_todo"}
-                        else "candidate"
-                    ),
-                    "preserves_goal_next_action": True,
-                }
-            )
-            return payload
-    return None
-
-
-def _todo_ids_from_action(value: Any) -> set[str]:
-    text = str(value or "")
-    if not text:
-        return set()
-    return set(re.findall(r"\btodo_[A-Za-z0-9_]+\b", text))
-
-
-def _selected_recommended_action(
-    item: dict[str, Any],
-    *,
-    agent_todo_summary: dict[str, Any] | None,
-    work_lane_contract: dict[str, Any] | None,
-) -> Any:
-    raw_action = item.get("recommended_action")
-    if (
-        isinstance(work_lane_contract, dict)
-        and work_lane_contract.get("monitor_kind") == "todo_monitor_due"
-        and work_lane_contract.get("must_attempt_work") is True
-    ):
-        due_items = (
-            work_lane_contract.get("monitor_due_items")
-            if isinstance(work_lane_contract.get("monitor_due_items"), list)
-            else []
-        )
-        for due_item in due_items:
-            if not isinstance(due_item, dict):
-                continue
-            text = _protocol_action_text(due_item.get("text"), limit=320)
-            if text:
-                return text
-        return raw_action
-    if (
-        isinstance(work_lane_contract, dict)
-        and work_lane_contract.get("lane") == "advancement_task"
-        and "open_agent_todo" in (
-            work_lane_contract.get("reason_codes")
-            if isinstance(work_lane_contract.get("reason_codes"), list)
-            else []
-        )
-    ):
-        return _first_executable_todo_text(agent_todo_summary) or raw_action
-    return raw_action
-
-
 def _work_lane_due_monitor_attempt(work_lane_contract: dict[str, Any] | None) -> bool:
     return bool(
         isinstance(work_lane_contract, dict)
         and work_lane_contract.get("monitor_kind") == "todo_monitor_due"
         and work_lane_contract.get("must_attempt_work") is True
     )
-
-
-def _selected_action_with_agent_lane(
-    selected_action: Any,
-    *,
-    agent_lane_next_action: dict[str, Any] | None,
-) -> Any:
-    if not isinstance(agent_lane_next_action, dict):
-        return selected_action
-    if agent_lane_next_action.get("source") not in {
-        "capability_gate.runnable_candidates",
-        "agent_todo_summary.active_next_action_executable_items",
-    }:
-        return selected_action
-    selected_by = agent_lane_next_action.get("selected_by")
-    confidence = agent_lane_next_action.get("confidence")
-    if selected_by not in {"active_next_action_todo", "current_agent_claimed_todo", "unclaimed_todo"}:
-        return selected_action
-    if confidence not in {"selected", "candidate"}:
-        return selected_action
-    lane_text = str(agent_lane_next_action.get("text") or "").strip()
-    return lane_text or selected_action
 
 
 def _selected_action_with_capability_gate(
@@ -5370,7 +5123,7 @@ def build_quota_should_run(
                 heartbeat_recommendation.get("reason")
                 or "monitor-only polling has no material transition; skip delivery compute"
             )
-        selected_recommended_action = _selected_recommended_action(
+        selected_recommended_action = selected_recommended_action_from_work_lane(
             item,
             agent_todo_summary=agent_todo_summary,
             work_lane_contract=work_lane_contract,
@@ -5414,7 +5167,7 @@ def build_quota_should_run(
         )
         agent_lane_next_action = None
         if not due_monitor_attempt:
-            agent_lane_next_action = _agent_lane_next_action(
+            agent_lane_next_action = build_agent_lane_next_action(
                 agent_identity=agent_identity,
                 agent_todo_summary=agent_todo_summary,
                 capability_gate=capability_gate,
@@ -5429,7 +5182,7 @@ def build_quota_should_run(
                 ),
             )
             if not replan_decision_allowed:
-                selected_recommended_action = _selected_action_with_agent_lane(
+                selected_recommended_action = selected_action_with_agent_lane(
                     selected_recommended_action,
                     agent_lane_next_action=agent_lane_next_action,
                 )


### PR DESCRIPTION
## Summary
- move agent-lane next-action selection and selected-action override out of quota.py into the agents bounded context
- prefer capability-gate runnable candidates before blocked active-next-action items when a fallback is available
- extend the side-agent self-iteration CLI canary with capability fallback + frontier + scheduler-ack coverage

## Validation
- python3 -m py_compile loopx/quota.py loopx/control_plane/agents/agent_lane_recommendation.py loopx/control_plane/agents/agent_scope.py examples/control_plane/side-agent-self-iteration-state-machine-smoke.py
- PYTHONPATH=. python3 examples/control_plane/side-agent-self-iteration-state-machine-smoke.py
- PYTHONPATH=. python3 examples/control_plane/control-plane-risk-characterization-smoke.py
- PYTHONPATH=. python3 examples/control_plane/quota-agent-scoped-user-gate-smoke.py
- PYTHONPATH=. python3 examples/control_plane/quota-replan-decision-plane-smoke.py
- PYTHONPATH=. python3 examples/control_plane/status-markdown-smoke.py
- PYTHONPATH=. python3 examples/control_plane/monitor-poll-writeback-smoke.py
- PYTHONPATH=. python3 examples/control_plane/control-plane-integrated-canary-smoke.py
- PYTHONPATH=. python3 -m loopx.cli --format json canary premerge --from-git-diff --tier standard --timeout-seconds 300

## Risk / boundary
- Surfaces: control-plane agents, quota read-path, side-agent canary.
- No benchmark execution/scoring path changes.
- Public/private boundary scan covered by premerge gate; manual scan found no new private paths, credentials, raw logs, trajectories, or verifier output.