### PR TITLE
Extract work-lane due-monitor priority policy

### DIFF
--- a/examples/control_plane/private-boundary-monitor-priority-smoke.py
+++ b/examples/control_plane/private-boundary-monitor-priority-smoke.py
@@ -122,8 +122,68 @@ def test_private_boundary_due_monitor_is_context_only() -> None:
     ), guard
 
 
+def test_public_due_monitor_priority_matrix() -> None:
+    public_high_monitor = {
+        "index": 1,
+        "text": "[P0] Poll public release signal before implementation.",
+        "role": "agent",
+        "status": "open",
+        "priority": "P0",
+        "task_class": "continuous_monitor",
+        "action_kind": "public_release_monitor",
+        "claimed_by": "codex-product-capability",
+        "next_due_at": PAST_DUE_AT,
+    }
+    public_low_monitor = {
+        **public_high_monitor,
+        "text": "[P2] Poll public release signal after implementation.",
+        "priority": "P2",
+    }
+    advancement_todo = {
+        "index": 2,
+        "text": "[P1] Continue canary-gated read-model cleanup.",
+        "role": "agent",
+        "status": "open",
+        "priority": "P1",
+        "task_class": "advancement_task",
+        "action_kind": "continue_canary_refactor",
+        "claimed_by": "codex-product-capability",
+    }
+
+    high_guard = build_quota_should_run(
+        status_payload(
+            monitor_todo=public_high_monitor,
+            advancement_todo=advancement_todo,
+        ),
+        goal_id=GOAL_ID,
+        agent_id="codex-product-capability",
+    )
+    high_lane = high_guard["work_lane_contract"]
+    assert high_lane["lane"] == "continuous_monitor", high_lane
+    assert high_lane["monitor_kind"] == "todo_monitor_due", high_lane
+    assert high_lane["reason_codes"] == [
+        "monitor_due",
+        "due_monitor_priority_preempts_advancement",
+    ], high_lane
+    assert high_guard["recommended_action"] == public_high_monitor["text"], high_guard
+
+    low_guard = build_quota_should_run(
+        status_payload(
+            monitor_todo=public_low_monitor,
+            advancement_todo=advancement_todo,
+        ),
+        goal_id=GOAL_ID,
+        agent_id="codex-product-capability",
+    )
+    low_lane = low_guard["work_lane_contract"]
+    assert low_lane["lane"] == "advancement_task", low_lane
+    assert low_lane["reason_codes"] == ["open_agent_todo", "due_monitor_context"], low_lane
+    assert low_guard["recommended_action"] == advancement_todo["text"], low_guard
+
+
 def main() -> int:
     test_private_boundary_due_monitor_is_context_only()
+    test_public_due_monitor_priority_matrix()
     print("private-boundary-monitor-priority-smoke ok")
     return 0
 

--- a/examples/control_plane/quota-work-lane-policy-smoke.py
+++ b/examples/control_plane/quota-work-lane-policy-smoke.py
@@ -11,7 +11,11 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from loopx.control_plane.work_items.work_lane import build_work_lane_contract  # noqa: E402
+from loopx.control_plane.work_items.work_lane import (  # noqa: E402
+    build_work_lane_contract,
+    due_monitor_can_preempt_advancement,
+    due_monitor_preempts_advancement,
+)
 
 
 def assert_contract(name: str, contract: dict | None, **expected: object) -> None:
@@ -72,6 +76,37 @@ def main() -> int:
         selected_todo_id="todo_due",
     )
     assert len(due_monitor["monitor_due_items"]) == 1, due_monitor
+
+    private_due_monitor = {
+        "todo_id": "todo_private_due",
+        "priority": "P0-LOCAL",
+        "action_kind": "local_department_doc_todo_projection_monitor",
+        "result_hash": "private_boundary_no_authorized_read",
+    }
+    public_due_monitor = {
+        "todo_id": "todo_public_due",
+        "priority": "P0",
+        "action_kind": "monitor",
+    }
+    lower_priority_due_monitor = {
+        "todo_id": "todo_lower_due",
+        "priority": "P2",
+        "action_kind": "monitor",
+    }
+    first_advancement = {"todo_id": "todo_adv", "priority": "P1"}
+    assert not due_monitor_can_preempt_advancement(private_due_monitor), private_due_monitor
+    assert not due_monitor_preempts_advancement(
+        private_due_monitor,
+        first_advancement=first_advancement,
+    )
+    assert due_monitor_preempts_advancement(
+        public_due_monitor,
+        first_advancement=first_advancement,
+    )
+    assert not due_monitor_preempts_advancement(
+        lower_priority_due_monitor,
+        first_advancement=first_advancement,
+    )
 
     quiet_monitor = build_work_lane_contract(
         progress_scope="agent_lane",

--- a/loopx/control_plane/agents/agent_lane_recommendation.py
+++ b/loopx/control_plane/agents/agent_lane_recommendation.py
@@ -286,6 +286,16 @@ def build_agent_lane_next_action(
 
     preferred_todo_ids = _todo_ids_from_action(active_next_action)
     primary_agent = normalize_todo_claimed_by(agent_identity.get("primary_agent"))
+    active_next_action_items = (
+        agent_todo_summary.get("active_next_action_executable_items")
+        if isinstance(agent_todo_summary.get("active_next_action_executable_items"), list)
+        else []
+    )
+    active_next_action_todo_ids = {
+        normalize_todo_id(item.get("todo_id"))
+        for item in active_next_action_items
+        if isinstance(item, dict)
+    }
 
     seen: set[tuple[str, str]] = set()
     for source, raw_items in candidate_sources:
@@ -330,6 +340,13 @@ def build_agent_lane_next_action(
             payload = _compact_todo_summary_item(raw_item, text=text)
             if selected_by == "unclaimed_todo":
                 payload["claim_required_before_work"] = True
+            lineage_source = source
+            if (
+                source == "capability_gate.runnable_candidates"
+                and selected_by == "active_next_action_todo"
+                and normalize_todo_id(todo_id) in active_next_action_todo_ids
+            ):
+                lineage_source = "agent_todo_summary.active_next_action_executable_items"
             blocks_agent = normalize_todo_blocks_agent(raw_item.get("blocks_agent"))
             unblocks_todo_id = normalize_todo_id(raw_item.get("unblocks_todo_id"))
             if blocks_agent:
@@ -351,7 +368,7 @@ def build_agent_lane_next_action(
                     "primary_agent": normalize_todo_claimed_by(
                         agent_identity.get("primary_agent")
                     ),
-                    "source": source,
+                    "source": lineage_source,
                     "selected_by": selected_by,
                     "confidence": (
                         "selected"

--- a/loopx/control_plane/work_items/work_lane.py
+++ b/loopx/control_plane/work_items/work_lane.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from ..todos.projection import todo_priority_label, todo_priority_rank
+
 
 WORK_LANE_CONTRACT_SCHEMA_VERSION = "work_lane_contract_v1"
 WORK_LANE_CURRENT_AGENT_MONITOR_REPAIR_OBLIGATIONS = {
@@ -9,6 +11,42 @@ WORK_LANE_CURRENT_AGENT_MONITOR_REPAIR_OBLIGATIONS = {
     "repair_monitor_schedule_metadata",
     "repair_resume_gate_or_close_standing_monitor",
 }
+PRIVATE_BOUNDARY_MONITOR_RESULT_HASHES = {
+    "private_boundary_no_authorized_read",
+}
+PRIVATE_BOUNDARY_MONITOR_ACTION_KIND_HINTS = (
+    "private",
+    "local_department_doc",
+)
+
+
+def due_monitor_can_preempt_advancement(item: dict[str, Any]) -> bool:
+    """Return false for monitor work that requires private/local material."""
+
+    result_hash = str(item.get("result_hash") or "").strip().lower()
+    if result_hash in PRIVATE_BOUNDARY_MONITOR_RESULT_HASHES:
+        return False
+    action_kind = str(item.get("action_kind") or "").strip().lower()
+    if any(hint in action_kind for hint in PRIVATE_BOUNDARY_MONITOR_ACTION_KIND_HINTS):
+        return False
+    priority = str(todo_priority_label(item) or "").strip().upper()
+    if "LOCAL" in priority:
+        return False
+    return True
+
+
+def due_monitor_preempts_advancement(
+    due_monitor: dict[str, Any] | None,
+    *,
+    first_advancement: dict[str, Any] | None,
+) -> bool:
+    if not due_monitor:
+        return False
+    if not due_monitor_can_preempt_advancement(due_monitor):
+        return False
+    return first_advancement is None or (
+        todo_priority_rank(due_monitor) < todo_priority_rank(first_advancement)
+    )
 
 
 def work_lane_contract_requires_current_agent_attempt(

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -100,6 +100,7 @@ from .control_plane.scheduler.state import (
 )
 from .control_plane.work_items.work_lane import (
     build_work_lane_contract as build_work_lane_contract_policy,
+    due_monitor_preempts_advancement as work_lane_due_monitor_preempts_advancement,
 )
 from .state_projection import is_user_wait_text, next_action_projection_warning
 from .control_plane.todos.contract import (
@@ -254,15 +255,6 @@ CAPABILITY_GATE_SCHEMA_VERSION = "capability_gate_v0"
 SIDE_AGENT_WORKSPACE_GUARD_SCHEMA_VERSION = "side_agent_workspace_guard_v0"
 AGENT_CLAIM_SCOPE_SCHEMA_VERSION = "agent_claim_scope_v0"
 SIDE_AGENT_CLAIM_SCOPE_SCHEMA_VERSION = AGENT_CLAIM_SCOPE_SCHEMA_VERSION
-PRIVATE_BOUNDARY_MONITOR_RESULT_HASHES = {
-    "private_boundary_no_authorized_read",
-}
-PRIVATE_BOUNDARY_MONITOR_ACTION_KIND_HINTS = (
-    "private",
-    "local_department_doc",
-)
-
-
 DEFAULT_AVAILABLE_CAPABILITIES = (
     "shell",
     "filesystem_read",
@@ -643,13 +635,9 @@ def _work_lane_contract(
         agent_todo_summary,
         agent_id=agent_id,
     )
-    due_monitor_preempts_advancement = bool(
-        first_due_monitor
-        and _due_monitor_can_preempt_advancement(first_due_monitor)
-        and (
-            first_advancement is None
-            or _todo_priority_rank(first_due_monitor) < _todo_priority_rank(first_advancement)
-        )
+    due_monitor_preempts_advancement = work_lane_due_monitor_preempts_advancement(
+        first_due_monitor,
+        first_advancement=first_advancement,
     )
     return build_work_lane_contract_policy(
         progress_scope=progress_scope,
@@ -1275,26 +1263,6 @@ def _todo_priority_label(item: dict[str, Any]) -> str | None:
 
 def _todo_priority_rank(item: dict[str, Any]) -> int:
     return projection_todo_priority_rank(item)
-
-
-def _due_monitor_can_preempt_advancement(item: dict[str, Any]) -> bool:
-    """Return false for monitor work that requires private/local material.
-
-    A due monitor can remain visible as context, but it must not outrank a
-    public executable advancement slice when the monitor's own last writeback
-    says the agent has no authorized private read path.
-    """
-
-    result_hash = str(item.get("result_hash") or "").strip().lower()
-    if result_hash in PRIVATE_BOUNDARY_MONITOR_RESULT_HASHES:
-        return False
-    action_kind = str(item.get("action_kind") or "").strip().lower()
-    if any(hint in action_kind for hint in PRIVATE_BOUNDARY_MONITOR_ACTION_KIND_HINTS):
-        return False
-    priority = str(_todo_priority_label(item) or "").strip().upper()
-    if "LOCAL" in priority:
-        return False
-    return True
 
 
 def _todo_index_rank(item: dict[str, Any]) -> int:


### PR DESCRIPTION
## Summary
- move due-monitor preemption/private-boundary policy from quota into the work-lane bounded context
- preserve active-next-action lineage when capability-gate runnable candidates select the active todo
- extend durable canaries for private/public due-monitor priority routing and work-lane policy helper behavior

## Validation
- python3 -m py_compile loopx/control_plane/agents/agent_lane_recommendation.py loopx/control_plane/work_items/work_lane.py loopx/quota.py
- PYTHONPATH=. python3 examples/control_plane/work-lane-contract-smoke.py
- PYTHONPATH=. python3 examples/control_plane/quota-work-lane-policy-smoke.py
- PYTHONPATH=. python3 examples/control_plane/private-boundary-monitor-priority-smoke.py
- PYTHONPATH=. python3 examples/control_plane/control-plane-risk-characterization-smoke.py
- PYTHONPATH=. python3 examples/control_plane/monitor-scheduler-contract-smoke.py
- PYTHONPATH=. python3 examples/control_plane/agent-scope-projection-characterization-smoke.py
- PYTHONPATH=. python3 examples/control_plane/side-agent-self-iteration-state-machine-smoke.py
- PYTHONPATH=. python3 examples/control_plane/status-neutral-run-window-smoke.py
- PYTHONPATH=. python3 examples/control_plane/todo-projection-shared-helper-smoke.py
- PYTHONPATH=. python3 examples/control_plane/control-plane-integrated-canary-smoke.py
- git diff --check
- private/local/raw evidence keyword scan on staged diff