### PR TITLE
Move stale latest-run freshness into runtime

### DIFF
--- a/examples/control_plane/runtime-stale-latest-run-readmodel-smoke.py
+++ b/examples/control_plane/runtime-stale-latest-run-readmodel-smoke.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Smoke-test stale latest-run freshness as a runtime read model."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import hashlib
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.goals.active_state_metadata import parse_state_frontmatter  # noqa: E402
+from loopx.control_plane.runtime.stale_latest_run import (  # noqa: E402
+    stale_latest_run_projection_warning,
+)
+
+
+AGENT_LANE_PROGRESS_SCOPE = "agent_lane"
+
+
+def parse_timestamp(value: Any) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def resolve_goal_local_path(raw: Any, goal: dict[str, Any]) -> Path | None:
+    if not raw:
+        return None
+    path = Path(str(raw))
+    if path.is_absolute():
+        return path
+    repo = goal.get("repo")
+    return (Path(str(repo)) if repo else Path.cwd()) / path
+
+
+def state_text(updated_at: str, body: str) -> str:
+    return (
+        "---\n"
+        "status: active\n"
+        f"updated_at: {updated_at}\n"
+        "---\n\n"
+        "# Active State\n\n"
+        f"{body}\n"
+    )
+
+
+def digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+def warning_for(goal: dict[str, Any], current_run: dict[str, Any]) -> dict[str, Any] | None:
+    return stale_latest_run_projection_warning(
+        goal,
+        current_run,
+        agent_lane_progress_scope=AGENT_LANE_PROGRESS_SCOPE,
+        resolve_goal_local_path=resolve_goal_local_path,
+        parse_state_frontmatter=parse_state_frontmatter,
+        parse_timestamp=parse_timestamp,
+    )
+
+
+def base_goal(project: Path, state_file: str, runs: list[dict[str, Any]] | None = None) -> dict[str, Any]:
+    return {
+        "id": "runtime-freshness",
+        "registry_member": True,
+        "repo": str(project),
+        "state_file": state_file,
+        "latest_runs": runs or [],
+    }
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-runtime-stale-latest-run-") as tmp:
+        project = Path(tmp) / "project"
+        state_file = ".codex/goals/runtime-freshness/ACTIVE_GOAL_STATE.md"
+        state_path = project / state_file
+        state_path.parent.mkdir(parents=True, exist_ok=True)
+
+        old_text = state_text("2026-01-01T00:01:00+00:00", "old snapshot")
+        active_text = state_text("2026-01-01T00:03:00+00:00", "new active state")
+        state_path.write_text(active_text, encoding="utf-8")
+        stale_status_run = {
+            "classification": "state_refreshed",
+            "generated_at": "2026-01-01T00:02:00+00:00",
+            "state": {
+                "sha256_16": digest(old_text),
+                "frontmatter": {"updated_at": "2026-01-01T00:01:00+00:00"},
+            },
+        }
+
+        warning = warning_for(base_goal(project, state_file), stale_status_run)
+        assert warning is not None, warning
+        assert warning["requires_refresh_state"] is True, warning
+        assert warning["active_state_updated_at"] == "2026-01-01T00:03:00+00:00", warning
+        assert warning["latest_run_generated_at"] == "2026-01-01T00:02:00+00:00", warning
+        assert "active_state_updated_after_latest_run" in warning["reason"], warning
+        assert "active_state_updated_after_latest_run_snapshot" in warning["reason"], warning
+        assert "active_state_digest_differs_from_latest_run_snapshot" in warning["reason"], warning
+
+        agent_lane_current = {
+            "classification": "side_lane_refresh",
+            "generated_at": "2026-01-01T00:03:30+00:00",
+            "progress_scope": AGENT_LANE_PROGRESS_SCOPE,
+            "state": {
+                "sha256_16": digest(active_text),
+                "frontmatter": {"updated_at": "2026-01-01T00:03:00+00:00"},
+            },
+        }
+        assert warning_for(base_goal(project, state_file, [agent_lane_current]), stale_status_run) is None
+
+        agent_lane_stale = {
+            "classification": "side_lane_old_refresh",
+            "generated_at": "2026-01-01T00:02:30+00:00",
+            "progress_scope": AGENT_LANE_PROGRESS_SCOPE,
+            "state": {
+                "sha256_16": digest(old_text),
+                "frontmatter": {"updated_at": "2026-01-01T00:01:00+00:00"},
+            },
+        }
+        stale_lane_warning = warning_for(base_goal(project, state_file, [agent_lane_stale]), stale_status_run)
+        assert stale_lane_warning is not None, stale_lane_warning
+        assert stale_lane_warning["requires_refresh_state"] is True, stale_lane_warning
+
+        non_registry_goal = base_goal(project, state_file)
+        non_registry_goal["registry_member"] = False
+        assert warning_for(non_registry_goal, stale_status_run) is None
+
+    print("runtime-stale-latest-run-readmodel-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/control_plane/runtime/stale_latest_run.py
+++ b/loopx/control_plane/runtime/stale_latest_run.py
@@ -10,7 +10,7 @@ FrontmatterParser = Callable[[str], dict[str, str]]
 TimestampParser = Callable[[Any], Any]
 
 
-def active_state_projection_warning(
+def stale_latest_run_projection_warning(
     goal: dict[str, Any],
     current_run: dict[str, Any] | None,
     *,

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -245,8 +245,8 @@ from .control_plane.agents.subagent_activity import (
     subagent_quota_spend as _subagent_quota_spend_read_model,
     subagent_state as _subagent_state_read_model,
 )
-from .control_plane.work_items.stale_latest_run import (
-    active_state_projection_warning as _active_state_projection_warning_read_model,
+from .control_plane.runtime.stale_latest_run import (
+    stale_latest_run_projection_warning as _stale_latest_run_projection_warning_read_model,
 )
 from .control_plane.work_items.status_contract import (
     build_contract_health_projection as _build_contract_health_projection_read_model,
@@ -6226,7 +6226,7 @@ def subagent_activity_for_goal(goal: dict[str, Any]) -> dict[str, Any] | None:
 
 
 def active_state_projection_warning(goal: dict[str, Any], current_run: dict[str, Any] | None) -> dict[str, Any] | None:
-    return _active_state_projection_warning_read_model(
+    return _stale_latest_run_projection_warning_read_model(
         goal,
         current_run,
         agent_lane_progress_scope=AGENT_LANE_PROGRESS_SCOPE,


### PR DESCRIPTION
## Summary
- Move stale latest-run freshness from the work-items bounded context into runtime read models.
- Keep the existing status wrapper API while removing the legacy work_items module path.
- Add a focused runtime canary for stale active-state snapshots, current agent-lane refresh suppression, stale agent-lane non-suppression, and non-registry no-op behavior.

## Changed surfaces
- `loopx/control_plane/runtime/stale_latest_run.py`
- `loopx/status.py`
- `examples/control_plane/runtime-stale-latest-run-readmodel-smoke.py`

## Validation
- `python3 -m py_compile loopx/status.py loopx/control_plane/runtime/stale_latest_run.py examples/control_plane/runtime-stale-latest-run-readmodel-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/runtime-stale-latest-run-readmodel-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/status-markdown-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/refresh-state-agent-lane-scope-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/run-history-readmodel-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/status-neutral-run-window-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/bounded-context-namespace-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/control-plane-risk-characterization-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/hot-path-interface-budget-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/status-goal-filter-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/runtime-handoff-status-read-path-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/quota-plan-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/quota-work-lane-policy-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/todo-contract-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/todo-readmodel-boundary-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/active-state-structured-projection-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/monitor-scheduler-contract-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/check-public-boundary-smoke.py`
- `git diff --check`, `git diff --cached --check`, and added-line public/private scan.

## Premerge gate
- Previewed `loopx canary premerge --from-git-diff --tier standard --no-execute --format json`; it selected control-plane/status/public-boundary surfaces with no manual holds.
- Attempted actual standard and quick premerge execution; both stayed silent for multiple polling windows and were interrupted rather than leaving the automation stuck.
- The manual checks above cover the selected risk surfaces for this diff: bounded-context namespace, status read path, quota/review-packet parity, work-lane policy, active-state projection, runtime freshness, and public/private boundary.

## Merge note
- No benchmark adapter, benchmark scoring, raw benchmark evidence, production action, permission boundary, or public first-screen surface is touched.
