### PR TITLE
Refactor side-agent workspace guard

### DIFF
--- a/examples/control_plane/side-agent-workspace-guard-smoke.py
+++ b/examples/control_plane/side-agent-workspace-guard-smoke.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Exercise the side-agent workspace guard across real git worktrees."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GOAL_ID = "workspace-guard-canary"
+PRIMARY_AGENT_ID = "codex-main-control"
+SIDE_AGENT_ID = "codex-product-capability"
+
+
+def run_git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(cwd), *args], check=True, capture_output=True, text=True)
+
+
+def run_cli(cwd: Path, *args: str, registry_path: Path, runtime: Path) -> dict:
+    env = os.environ.copy()
+    python_path = str(REPO_ROOT)
+    if env.get("PYTHONPATH"):
+        python_path = f"{python_path}{os.pathsep}{env['PYTHONPATH']}"
+    env["PYTHONPATH"] = python_path
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(runtime),
+            "--format",
+            "json",
+            *args,
+        ],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    return json.loads(result.stdout)
+
+
+def write_fixture(root: Path) -> tuple[Path, Path, Path, Path]:
+    primary = root / "primary-project"
+    independent = root / "side-agent-worktree"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    state_path = primary / state_file
+    registry_path = primary / ".loopx" / "registry.json"
+
+    primary.mkdir(parents=True)
+    (primary / "README.md").write_text("# Workspace Guard Canary\n", encoding="utf-8")
+    run_git(primary, "init", "--initial-branch", "main")
+    run_git(primary, "add", "README.md")
+    run_git(
+        primary,
+        "-c",
+        "user.name=LoopX Canary",
+        "-c",
+        "user.email=loopx-canary@example.invalid",
+        "commit",
+        "-m",
+        "initial fixture",
+    )
+    run_git(primary, "worktree", "add", "-b", "side-agent-work", str(independent))
+
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        "---\n"
+        "status: active\n"
+        "owner_mode: goal\n"
+        'objective: "Exercise side-agent workspace guard."\n'
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Workspace Guard Canary\n\n"
+        "## Objective\n\n"
+        "Exercise side-agent workspace guard.\n\n"
+        "## Next Action\n\n"
+        "- Run one bounded side-agent delivery batch from an independent worktree.\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] [P1] Run one bounded side-agent delivery batch from an independent worktree.\n"
+        f"  <!-- loopx:todo todo_id=todo_workspace_guard status=open "
+        f"task_class=advancement_task action_kind=state_machine_canary_refactor "
+        f"claimed_by={SIDE_AGENT_ID} -->\n\n"
+        "## Progress Ledger\n\n"
+        "- Initialized workspace guard fixture.\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "workspace-guard-fixture",
+                        "status": "active",
+                        "repo": str(primary),
+                        "state_file": state_file,
+                        "adapter": {
+                            "kind": "workspace_guard_fixture_v0",
+                            "status": "connected-read-only",
+                        },
+                        "authority_sources": [],
+                        "quota": {
+                            "compute": 1.0,
+                            "window_hours": 24,
+                            "allowed_slots": 5,
+                        },
+                        "coordination": {
+                            "registered_agents": [PRIMARY_AGENT_ID, SIDE_AGENT_ID],
+                            "primary_agent": PRIMARY_AGENT_ID,
+                        },
+                        "workspace_guard_policy": {
+                            "side_agent_independent_worktree_required": True,
+                        },
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return primary, independent, runtime, registry_path
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-side-agent-workspace-guard-") as tmp:
+        root = Path(tmp)
+        primary, independent, runtime, registry_path = write_fixture(root)
+        side_from_primary = run_cli(
+            primary,
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            SIDE_AGENT_ID,
+            "--scan-path",
+            str(primary),
+            registry_path=registry_path,
+            runtime=runtime,
+        )
+        assert side_from_primary["ok"] is True, side_from_primary
+        assert side_from_primary["should_run"] is True, side_from_primary
+        assert side_from_primary["decision"] == "workspace_guard", side_from_primary
+        assert side_from_primary["effective_action"] == "side_agent_workspace_repair", side_from_primary
+        assert side_from_primary["normal_delivery_allowed"] is False, side_from_primary
+        guard = side_from_primary["workspace_guard"]
+        assert guard["blocks_delivery"] is True, guard
+        assert guard["current_workspace"] == "primary_checkout", guard
+        assert guard["required_workspace"] == "independent_git_worktree", guard
+        assert guard["agent_id"] == SIDE_AGENT_ID, guard
+
+        side_from_independent = run_cli(
+            independent,
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            SIDE_AGENT_ID,
+            "--scan-path",
+            str(primary),
+            registry_path=registry_path,
+            runtime=runtime,
+        )
+        assert side_from_independent["ok"] is True, side_from_independent
+        assert side_from_independent["should_run"] is True, side_from_independent
+        assert side_from_independent["decision"] == "run", side_from_independent
+        assert side_from_independent["effective_action"] == "normal_run", side_from_independent
+        assert side_from_independent["normal_delivery_allowed"] is True, side_from_independent
+        assert "workspace_guard" not in side_from_independent, side_from_independent
+
+        primary_from_primary = run_cli(
+            primary,
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            PRIMARY_AGENT_ID,
+            "--scan-path",
+            str(primary),
+            registry_path=registry_path,
+            runtime=runtime,
+        )
+        assert primary_from_primary["ok"] is True, primary_from_primary
+        assert primary_from_primary["agent_identity"]["role"] == "primary-agent", primary_from_primary
+        assert primary_from_primary["effective_action"] != "side_agent_workspace_repair", primary_from_primary
+        assert "workspace_guard" not in primary_from_primary, primary_from_primary
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/control_plane/agents/workspace_guard.py
+++ b/loopx/control_plane/agents/workspace_guard.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+from typing import Any
+
+
+SIDE_AGENT_WORKSPACE_GUARD_SCHEMA_VERSION = "side_agent_workspace_guard_v0"
+
+
+def _is_same_or_child_path(path: Path, root: Path) -> bool:
+    try:
+        current = path.expanduser().resolve()
+        target = root.expanduser().resolve()
+    except OSError:
+        return False
+    return current == target or target in current.parents
+
+
+def _git_command_output(path: Path, *args: str) -> str | None:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(path), *args],
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=1.5,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    output = result.stdout.strip()
+    return output or None
+
+
+def _git_worktree_root(path: Path) -> Path | None:
+    output = _git_command_output(path, "rev-parse", "--show-toplevel")
+    if not output:
+        return None
+    try:
+        return Path(output).expanduser().resolve()
+    except OSError:
+        return None
+
+
+def _git_common_dir(path: Path) -> Path | None:
+    root = _git_worktree_root(path)
+    if root is None:
+        return None
+    output = _git_command_output(root, "rev-parse", "--git-common-dir")
+    if not output:
+        return None
+    common = Path(output).expanduser()
+    if not common.is_absolute():
+        common = root / common
+    try:
+        return common.resolve()
+    except OSError:
+        return None
+
+
+def build_side_agent_workspace_guard(
+    goal: dict[str, Any],
+    agent_identity: dict[str, Any] | None,
+    *,
+    current_path: Path | None = None,
+) -> dict[str, Any] | None:
+    if not isinstance(agent_identity, dict) or agent_identity.get("role") != "side-agent":
+        return None
+    workspace_guard_policy = (
+        goal.get("workspace_guard_policy")
+        if isinstance(goal.get("workspace_guard_policy"), dict)
+        else {}
+    )
+    if workspace_guard_policy.get("side_agent_independent_worktree_required") is False:
+        return None
+    repo_value = goal.get("repo") or goal.get("project") or goal.get("root")
+    if not repo_value:
+        return None
+    repo_path = Path(str(repo_value)).expanduser()
+    if not repo_path.is_absolute():
+        return None
+    current_path = current_path or Path.cwd()
+    current_workspace = ""
+    if _is_same_or_child_path(current_path, repo_path):
+        current_workspace = "primary_checkout"
+    else:
+        primary_root = _git_worktree_root(repo_path) or repo_path
+        current_root = _git_worktree_root(current_path)
+        primary_common = _git_common_dir(primary_root)
+        current_common = _git_common_dir(current_path) if current_root else None
+        if current_root is None:
+            current_workspace = "not_git_worktree"
+        elif primary_common is None or current_common is None or current_common != primary_common:
+            current_workspace = "foreign_git_worktree"
+        elif current_root == primary_root:
+            current_workspace = "primary_checkout"
+    if not current_workspace:
+        return None
+    return {
+        "schema_version": SIDE_AGENT_WORKSPACE_GUARD_SCHEMA_VERSION,
+        "source": "quota.should-run",
+        "action": "move_to_independent_worktree",
+        "current_workspace": current_workspace,
+        "required_workspace": "independent_git_worktree",
+        "blocks_delivery": True,
+        "agent_id": agent_identity.get("agent_id"),
+        "primary_agent": agent_identity.get("primary_agent"),
+        "reason": (
+            "side-agent quota guard is not running from an independent worktree for "
+            "the registered project; normal delivery must move before repository edits"
+        ),
+        "required_action": (
+            "create or switch to an independent git worktree/branch for this side-agent "
+            "lane, then rerun quota should-run with the same --agent-id before editing files"
+        ),
+    }

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -4,7 +4,6 @@ from copy import deepcopy
 import fnmatch
 import json
 import re
-import subprocess
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -32,6 +31,7 @@ from .control_plane.agents.capability_gate import (
     _capability_missing_action,
     _sort_capability_runnable_candidates,
 )
+from .control_plane.agents.workspace_guard import build_side_agent_workspace_guard
 from .benchmark_core import compact_run_permission_policy_for_quota
 from .boundary_authority import checkpointed_boundary_authority_summary
 from .control_plane import (
@@ -252,7 +252,6 @@ EXTERNAL_EVIDENCE_OBSERVATION_SCHEMA_VERSION = "external_evidence_observation_ob
 PROJECTED_MONITOR_HANDLE_SCHEMA_VERSION = "projected_monitor_handle_v0"
 AUTOMATION_LIVENESS_SCHEMA_VERSION = "automation_liveness_v0"
 CAPABILITY_GATE_SCHEMA_VERSION = "capability_gate_v0"
-SIDE_AGENT_WORKSPACE_GUARD_SCHEMA_VERSION = "side_agent_workspace_guard_v0"
 AGENT_CLAIM_SCOPE_SCHEMA_VERSION = "agent_claim_scope_v0"
 SIDE_AGENT_CLAIM_SCOPE_SCHEMA_VERSION = AGENT_CLAIM_SCOPE_SCHEMA_VERSION
 DEFAULT_AVAILABLE_CAPABILITIES = (
@@ -3033,115 +3032,6 @@ def _quota_agent_identity(goal: dict[str, Any], *, agent_id: str | None) -> dict
     }
 
 
-def _is_same_or_child_path(path: Path, root: Path) -> bool:
-    try:
-        current = path.expanduser().resolve()
-        target = root.expanduser().resolve()
-    except OSError:
-        return False
-    return current == target or target in current.parents
-
-
-def _git_command_output(path: Path, *args: str) -> str | None:
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(path), *args],
-            check=False,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-            text=True,
-            timeout=1.5,
-        )
-    except (OSError, subprocess.TimeoutExpired):
-        return None
-    if result.returncode != 0:
-        return None
-    output = result.stdout.strip()
-    return output or None
-
-
-def _git_worktree_root(path: Path) -> Path | None:
-    output = _git_command_output(path, "rev-parse", "--show-toplevel")
-    if not output:
-        return None
-    try:
-        return Path(output).expanduser().resolve()
-    except OSError:
-        return None
-
-
-def _git_common_dir(path: Path) -> Path | None:
-    root = _git_worktree_root(path)
-    if root is None:
-        return None
-    output = _git_command_output(root, "rev-parse", "--git-common-dir")
-    if not output:
-        return None
-    common = Path(output).expanduser()
-    if not common.is_absolute():
-        common = root / common
-    try:
-        return common.resolve()
-    except OSError:
-        return None
-
-
-def _side_agent_workspace_guard(
-    goal: dict[str, Any],
-    agent_identity: dict[str, Any] | None,
-) -> dict[str, Any] | None:
-    if not isinstance(agent_identity, dict) or agent_identity.get("role") != "side-agent":
-        return None
-    workspace_guard_policy = (
-        goal.get("workspace_guard_policy")
-        if isinstance(goal.get("workspace_guard_policy"), dict)
-        else {}
-    )
-    if workspace_guard_policy.get("side_agent_independent_worktree_required") is False:
-        return None
-    repo_value = goal.get("repo") or goal.get("project") or goal.get("root")
-    if not repo_value:
-        return None
-    repo_path = Path(str(repo_value)).expanduser()
-    if not repo_path.is_absolute():
-        return None
-    current_path = Path.cwd()
-    current_workspace = ""
-    if _is_same_or_child_path(current_path, repo_path):
-        current_workspace = "primary_checkout"
-    else:
-        primary_root = _git_worktree_root(repo_path) or repo_path
-        current_root = _git_worktree_root(current_path)
-        primary_common = _git_common_dir(primary_root)
-        current_common = _git_common_dir(current_path) if current_root else None
-        if current_root is None:
-            current_workspace = "not_git_worktree"
-        elif primary_common is None or current_common is None or current_common != primary_common:
-            current_workspace = "foreign_git_worktree"
-        elif current_root == primary_root:
-            current_workspace = "primary_checkout"
-    if not current_workspace:
-        return None
-    return {
-        "schema_version": SIDE_AGENT_WORKSPACE_GUARD_SCHEMA_VERSION,
-        "source": "quota.should-run",
-        "action": "move_to_independent_worktree",
-        "current_workspace": current_workspace,
-        "required_workspace": "independent_git_worktree",
-        "blocks_delivery": True,
-        "agent_id": agent_identity.get("agent_id"),
-        "primary_agent": agent_identity.get("primary_agent"),
-        "reason": (
-            "side-agent quota guard is not running from an independent worktree for "
-            "the registered project; normal delivery must move before repository edits"
-        ),
-        "required_action": (
-            "create or switch to an independent git worktree/branch for this side-agent "
-            "lane, then rerun quota should-run with the same --agent-id before editing files"
-        ),
-    }
-
-
 def _automation_prompt_upgrade(
     goal: dict[str, Any],
     *,
@@ -4792,7 +4682,7 @@ def build_quota_should_run(
             recovery_allowed = False
             reason = str(quota["reason"])
         goal_boundary = _goal_boundary(item)
-        workspace_guard = _side_agent_workspace_guard(item, agent_identity)
+        workspace_guard = build_side_agent_workspace_guard(item, agent_identity)
         automation_prompt_upgrade = _automation_prompt_upgrade(
             item,
             goal_id=safe_goal_id,


### PR DESCRIPTION
## Summary
- Move the side-agent workspace guard read model out of `loopx/quota.py` into `loopx/control_plane/agents/workspace_guard.py`.
- Keep quota as the final should-run decision point while making the agent/workspace state-machine seam owned by the agents bounded context.
- Add a real git-worktree CLI canary that verifies side agents are blocked from the primary checkout, allowed from a linked independent worktree, and that the primary agent is not blocked by the side-agent guard.

## Validation
- `python3 -m py_compile loopx/control_plane/agents/workspace_guard.py loopx/quota.py examples/control_plane/side-agent-workspace-guard-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/side-agent-workspace-guard-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/quota-plan-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/quota-work-lane-policy-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/control-plane-risk-characterization-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/bounded-context-namespace-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/heartbeat-quota-flow-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/side-agent-self-iteration-state-machine-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/hot-path-interface-budget-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/check-public-boundary-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli canary premerge --from-git-diff --tier standard --timeout-seconds 120 --format json`

Premerge gate passed with `merge_gate_passed=true` and `self_merge_allowed=true`. The canary promotion readiness smoke reported the existing dashboard dependency skip for browser checks, while the selected no-browser/no-evidence readiness path passed.

## Boundary
- No benchmark scoring/runner behavior changes.
- No raw benchmark logs, trajectories, verifier output, credentials, or local private state added.
- Public/private boundary smoke passed.
