### PR TITLE
Extract todo succession warning lanes

### DIFF
--- a/examples/control_plane/todo-succession-contract-smoke.py
+++ b/examples/control_plane/todo-succession-contract-smoke.py
@@ -13,6 +13,9 @@ if str(REPO_ROOT) not in sys.path:
 
 from loopx.quota import build_quota_should_run, render_quota_should_run_markdown  # noqa: E402
 from loopx.status import compact_todo_group  # noqa: E402
+from loopx.control_plane.todos.succession_warning import (  # noqa: E402
+    build_todo_succession_warning_lanes,
+)
 
 
 GOAL_ID = "todo-succession-contract-fixture"
@@ -223,9 +226,54 @@ def assert_quota_projects_warning() -> None:
     assert "todo_missing_successor" in markdown, markdown
 
 
+def assert_quota_warning_lanes_strip_transient_evidence() -> None:
+    lanes = build_todo_succession_warning_lanes(
+        {
+            "todo_succession_warning": {
+                "count": 1,
+                "items": [
+                    {
+                        "todo_id": "todo_missing_successor",
+                        "text": "[P1] Missing successor.",
+                        "note": "operator-only note should not project",
+                        "evidence": "local run evidence should not project",
+                        "reason": "local rationale should not project",
+                        "required_write_scopes": "loopx/quota.py,../unsafe-scope.txt",
+                        "decision_scope": "write_scope:goal:loopx-meta",
+                        "required_decision_scopes": (
+                            "private_read:goal:loopx-meta,private_read:goal:loopx-meta"
+                        ),
+                        "action_kind": "monitor",
+                        "succession_tracked": True,
+                    }
+                ],
+            }
+        },
+        item_limit=8,
+    )
+    item = lanes["todo_succession_warning"]["items"][0]
+    assert item["todo_id"] == "todo_missing_successor", lanes
+    assert item["succession_tracked"] is True, lanes
+    assert "note" not in item, lanes
+    assert "evidence" not in item, lanes
+    assert "reason" not in item, lanes
+    assert item["required_write_scopes"] == ["loopx/quota.py"], lanes
+    assert item["decision_scope"]["kind"] == "write_scope", lanes
+    assert item["required_decision_scopes"] == [
+        {
+            "schema_version": "decision_scope_v0",
+            "kind": "private_read",
+            "granularity": "goal",
+            "scope_key": "loopx-meta",
+        }
+    ], lanes
+    assert item["task_class"] == "continuous_monitor", lanes
+
+
 def main() -> int:
     assert_status_summary_warning()
     assert_quota_projects_warning()
+    assert_quota_warning_lanes_strip_transient_evidence()
     print("todo-succession-contract-smoke ok")
     return 0
 

--- a/loopx/control_plane/todos/succession_warning.py
+++ b/loopx/control_plane/todos/succession_warning.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .contract import (
+    normalize_required_write_scopes,
+    normalize_todo_decision_scope,
+    normalize_todo_required_decision_scopes,
+    normalize_todo_task_class,
+)
+
+
+TODO_SUCCESSION_WARNING_SCHEMA_VERSION = "todo_succession_warning_v0"
+
+
+def _compact_succession_warning_item(item: dict[str, Any]) -> dict[str, Any]:
+    compact: dict[str, Any] = {
+        "index": item.get("index"),
+        "text": item.get("text"),
+    }
+    for key in (
+        "schema_version",
+        "todo_id",
+        "role",
+        "status",
+        "priority",
+        "title",
+        "archive_state",
+        "source_section",
+        "task_class",
+        "action_kind",
+        "required_write_scopes",
+        "required_capabilities",
+        "target_capabilities",
+        "decision_scope",
+        "required_decision_scopes",
+        "claimed_by",
+        "blocks_agent",
+        "unblocks_todo_id",
+        "resume_when",
+        "resume_condition",
+        "resume_ready",
+        "no_followup",
+        "successor_todo_ids",
+        "target_key",
+        "cadence",
+        "next_due_at",
+        "expires_at",
+        "last_checked_at",
+        "result_hash",
+        "consecutive_no_change",
+        "material_change",
+        "max_no_change_before_replan",
+        "route_continuation_replan_required",
+        "route_continuation_reason",
+        "route_id",
+        "route_key",
+        "completed_at",
+        "updated_at",
+        "superseded_by",
+        "done",
+        "succession_tracked",
+        "recommended_action",
+    ):
+        if item.get(key) is not None:
+            compact[key] = item.get(key)
+    required_write_scopes = normalize_required_write_scopes(compact.get("required_write_scopes"))
+    if required_write_scopes:
+        compact["required_write_scopes"] = required_write_scopes
+    else:
+        compact.pop("required_write_scopes", None)
+    decision_scope = normalize_todo_decision_scope(compact.get("decision_scope"))
+    if decision_scope:
+        compact["decision_scope"] = decision_scope
+    else:
+        compact.pop("decision_scope", None)
+    required_decision_scopes = normalize_todo_required_decision_scopes(
+        compact.get("required_decision_scopes")
+    )
+    if required_decision_scopes:
+        compact["required_decision_scopes"] = required_decision_scopes
+    else:
+        compact.pop("required_decision_scopes", None)
+    compact["task_class"] = normalize_todo_task_class(
+        compact.get("task_class"),
+        text=str(compact.get("text") or ""),
+        action_kind=compact.get("action_kind"),
+    )
+    return compact
+
+
+def build_todo_succession_warning_lanes(
+    summary: dict[str, Any],
+    *,
+    item_limit: int,
+) -> dict[str, Any]:
+    warning = summary.get("todo_succession_warning")
+    warning = warning if isinstance(warning, dict) else {}
+    source_items = (
+        warning.get("items")
+        if isinstance(warning.get("items"), list)
+        else summary.get("completed_without_successor_items")
+    )
+    items = [
+        _compact_succession_warning_item(item)
+        for item in (source_items or [])
+        if isinstance(item, dict)
+    ][:item_limit]
+    count = warning.get("count", summary.get("completed_without_successor_count"))
+    try:
+        count = max(0, int(count))
+    except (TypeError, ValueError):
+        count = len(items)
+    if count <= 0 and not items:
+        return {}
+
+    payload = {
+        "schema_version": warning.get(
+            "schema_version",
+            TODO_SUCCESSION_WARNING_SCHEMA_VERSION,
+        ),
+        "reason_code": warning.get(
+            "reason_code",
+            "completed_advancement_without_successor",
+        ),
+        "count": count,
+        "items": items,
+        "recommended_action": warning.get(
+            "recommended_action",
+            "record no_followup=true or add/link a successor todo",
+        ),
+    }
+    return {
+        "completed_without_successor_count": count,
+        "completed_without_successor_items": items,
+        "todo_succession_warning": payload,
+    }

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -126,6 +126,7 @@ from .control_plane.todos.handoff_gate import (
     HandoffGateState,
     build_todo_handoff_gate_states,
 )
+from .control_plane.todos.succession_warning import build_todo_succession_warning_lanes
 from .control_plane.todos.projection import (
     todo_claimed_visibility_items as projection_todo_claimed_visibility_items,
     todo_index_rank as projection_todo_index_rank,
@@ -1990,59 +1991,6 @@ def _is_user_gate_todo_item(item: dict[str, Any]) -> bool:
     return any(hint in action_kind for hint in USER_GATE_ACTION_KIND_HINTS)
 
 
-def _compact_todo_succession_warning_item(item: dict[str, Any]) -> dict[str, Any]:
-    compact = _compact_todo_summary_item(item)
-    for key in (
-        "done",
-        "succession_tracked",
-        "recommended_action",
-    ):
-        if item.get(key) is not None:
-            compact[key] = item.get(key)
-    return compact
-
-
-def _todo_succession_warning_lanes(value: dict[str, Any]) -> dict[str, Any]:
-    warning = value.get("todo_succession_warning")
-    warning = warning if isinstance(warning, dict) else {}
-    source_items = (
-        warning.get("items")
-        if isinstance(warning.get("items"), list)
-        else value.get("completed_without_successor_items")
-    )
-    items = [
-        _compact_todo_succession_warning_item(item)
-        for item in (source_items or [])
-        if isinstance(item, dict)
-    ][:TODO_BACKLOG_ITEM_LIMIT]
-    count = warning.get("count", value.get("completed_without_successor_count"))
-    try:
-        count = max(0, int(count))
-    except (TypeError, ValueError):
-        count = len(items)
-    if count <= 0 and not items:
-        return {}
-
-    payload = {
-        "schema_version": warning.get("schema_version", "todo_succession_warning_v0"),
-        "reason_code": warning.get(
-            "reason_code",
-            "completed_advancement_without_successor",
-        ),
-        "count": count,
-        "items": items,
-        "recommended_action": warning.get(
-            "recommended_action",
-            "record no_followup=true or add/link a successor todo",
-        ),
-    }
-    return {
-        "completed_without_successor_count": count,
-        "completed_without_successor_items": items,
-        "todo_succession_warning": payload,
-    }
-
-
 def _summarize_user_todos(
     value: Any,
     *,
@@ -2175,7 +2123,12 @@ def _summarize_user_todos(
             agent_identity=agent_identity,
         )
     )
-    summary.update(_todo_succession_warning_lanes(value))
+    summary.update(
+        build_todo_succession_warning_lanes(
+            value,
+            item_limit=TODO_BACKLOG_ITEM_LIMIT,
+        )
+    )
     if claimed_open_items or value.get("claimed_open_count"):
         summary["claimed_open_count"] = value.get("claimed_open_count", len(claimed_open_items))
         summary["unclaimed_open_count"] = value.get(


### PR DESCRIPTION
## Summary
- Move todo succession warning lane construction out of quota.py into the todos bounded context.
- Preserve quota-facing completed-without-successor payloads while normalizing todo write scopes, decision scopes, and task_class inside the new helper.
- Extend the todo succession contract smoke to cover transient evidence stripping and normalized quota-facing warning lanes.

## Validation
- python3 -m py_compile loopx/control_plane/todos/succession_warning.py loopx/quota.py examples/control_plane/todo-succession-contract-smoke.py
- PYTHONPATH=. python3 examples/control_plane/todo-succession-contract-smoke.py
- PYTHONPATH=. python3 examples/control_plane/todo-lifecycle-cli-smoke.py
- PYTHONPATH=. python3 examples/control_plane/quota-plan-smoke.py
- PYTHONPATH=. python3 examples/control_plane/quota-work-lane-policy-smoke.py
- PYTHONPATH=. python3 examples/control_plane/heartbeat-quota-flow-smoke.py
- PYTHONPATH=. python3 examples/control_plane/bounded-context-namespace-smoke.py
- PYTHONPATH=. python3 examples/control_plane/control-plane-risk-characterization-smoke.py
- PYTHONPATH=. python3 examples/control_plane/hot-path-interface-budget-smoke.py
- PYTHONPATH=. python3 examples/control_plane/check-public-boundary-smoke.py
- PYTHONPATH=. python3 examples/control_plane/control-plane-integrated-canary-smoke.py
- PYTHONPATH=. python3 -m loopx.cli canary premerge --from-git-diff --tier standard --timeout-seconds 120 --format json

Premerge gate: passed; self_merge_allowed=true; manual_holds=0.