### PR TITLE
Move completed todo archive warning to todos context

### DIFF
--- a/examples/control_plane/todo-archive-completed-smoke.py
+++ b/examples/control_plane/todo-archive-completed-smoke.py
@@ -14,6 +14,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.status import parse_active_state_todos  # noqa: E402
+from loopx.control_plane.todos.completed_archive import completed_todo_archive_warning  # noqa: E402
 
 
 GOAL_ID = "todo-archive-completed-goal"
@@ -108,6 +109,11 @@ def main() -> int:
         parsed = parse_active_state_todos(original)
         assert parsed["agent_todos"]["done_count"] == 14, parsed
         assert parsed["agent_todos"]["open_count"] == 2, parsed
+        warning = completed_todo_archive_warning(parsed["agent_todos"])
+        assert warning is not None, parsed
+        assert warning["kind"] == "completed_agent_todo_archive_required", warning
+        assert warning["active_done_count"] == 14, warning
+        assert warning["active_open_count"] == 2, warning
 
         dry_run = run_cli(
             registry_path,
@@ -147,6 +153,7 @@ def main() -> int:
         parsed_after = parse_active_state_todos(updated)
         assert parsed_after["agent_todos"]["done_count"] == 12, parsed_after
         assert parsed_after["agent_todos"]["open_count"] == 2, parsed_after
+        assert completed_todo_archive_warning(parsed_after["agent_todos"]) is None, parsed_after
         assert updated.index("## Completed Work Archive") < updated.index("[P1] Completed implementation lane 1.")
         assert "Continuation detail must move with the archived item." in updated
         assert updated.count("[P1] Completed implementation lane 1.") == 1

--- a/examples/derived-state-boundary-smoke.py
+++ b/examples/derived-state-boundary-smoke.py
@@ -19,9 +19,11 @@ from loopx.status import (  # noqa: E402
     MAX_TODO_VISIBILITY_LANE_ITEMS,
     TODO_PROJECTION_DETAIL_POINTER_SCHEMA_VERSION,
     TODO_PROJECTION_VIEW_SCHEMA_VERSION,
-    completed_todo_archive_warning,
     parse_active_state_todos,
     project_asset_todo_summary,
+)
+from loopx.control_plane.todos.completed_archive import (  # noqa: E402
+    completed_todo_archive_warning,
 )
 
 

--- a/loopx/control_plane/todos/completed_archive.py
+++ b/loopx/control_plane/todos/completed_archive.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+DEFAULT_MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE = 12
+
+
+def completed_todo_archive_warning(
+    agent_todos: dict[str, Any] | None,
+    *,
+    max_active_done_todos: int = DEFAULT_MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE,
+) -> dict[str, Any] | None:
+    if not isinstance(agent_todos, dict):
+        return None
+    try:
+        done_count = int(agent_todos.get("done_count") or 0)
+    except (TypeError, ValueError):
+        done_count = 0
+    if done_count <= max_active_done_todos:
+        return None
+    try:
+        open_count = int(agent_todos.get("open_count") or 0)
+    except (TypeError, ValueError):
+        open_count = 0
+    return {
+        "kind": "completed_agent_todo_archive_required",
+        "requires_archive": True,
+        "archive_section": "Completed Work Archive",
+        "active_done_count": done_count,
+        "active_open_count": open_count,
+        "max_active_done_count": max_active_done_todos,
+        "recommended_action": (
+            "move older completed Agent Todo entries into a dedicated Completed Work Archive "
+            "until the active Agent Todo section keeps only current open work and a small recent-done tail"
+        ),
+    }

--- a/loopx/control_plane/work_items/project_asset.py
+++ b/loopx/control_plane/work_items/project_asset.py
@@ -4,7 +4,6 @@ import re
 from typing import Any, Callable
 
 
-DEFAULT_MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE = 12
 DEFAULT_MONITOR_SIGNAL_WAITING_ON = "monitor_signal"
 DEFAULT_MONITOR_DISPLAY_STOP_CONDITION = (
     "stop until a material monitor transition, regression, or concrete blocker appears"
@@ -43,37 +42,6 @@ def project_asset_public_safe_compact_text(value: Any, *, limit: int = 220) -> s
     if LOCAL_PATH_SURFACE_PATTERN.search(text) or SECRET_LIKE_SURFACE_PATTERN.search(text):
         return None
     return text
-
-
-def completed_todo_archive_warning(
-    agent_todos: dict[str, Any] | None,
-    *,
-    max_active_done_todos: int = DEFAULT_MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE,
-) -> dict[str, Any] | None:
-    if not isinstance(agent_todos, dict):
-        return None
-    try:
-        done_count = int(agent_todos.get("done_count") or 0)
-    except (TypeError, ValueError):
-        done_count = 0
-    if done_count <= max_active_done_todos:
-        return None
-    try:
-        open_count = int(agent_todos.get("open_count") or 0)
-    except (TypeError, ValueError):
-        open_count = 0
-    return {
-        "kind": "completed_agent_todo_archive_required",
-        "requires_archive": True,
-        "archive_section": "Completed Work Archive",
-        "active_done_count": done_count,
-        "active_open_count": open_count,
-        "max_active_done_count": max_active_done_todos,
-        "recommended_action": (
-            "move older completed Agent Todo entries into a dedicated Completed Work Archive "
-            "until the active Agent Todo section keeps only current open work and a small recent-done tail"
-        ),
-    }
 
 
 def project_asset_owner(

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -55,7 +55,6 @@ from .control_plane.work_items.project_asset import (
     TODO_PROJECTION_DETAIL_POINTER_SCHEMA_VERSION,
     TODO_PROJECTION_VIEW_SCHEMA_VERSION,
     build_project_asset,
-    completed_todo_archive_warning,
     enrich_project_asset as _enrich_project_asset_read_model,
     project_asset_handoff_check_projection,
     project_asset_latest_validation,
@@ -65,6 +64,7 @@ from .control_plane.work_items.project_asset import (
     project_asset_todo_projection_gap,
     project_asset_user_todo_open_count,
 )
+from .control_plane.todos.completed_archive import completed_todo_archive_warning
 from .control_plane.handoff.project_handoff import (
     project_asset_handoff_readiness as _project_asset_handoff_readiness_read_model,
     project_asset_handoff_state as _project_asset_handoff_state_read_model,


### PR DESCRIPTION
## Summary
- move completed Agent Todo archive warning logic from work_items/project_asset into control_plane/todos/completed_archive
- keep status/quota read paths stable by importing the helper from the todo bounded context
- extend archive-completed smoke to prove warning trigger and clearing across the archive state transition

## Validation
- python3 -m py_compile loopx/control_plane/todos/completed_archive.py loopx/control_plane/work_items/project_asset.py loopx/status.py examples/backlog-hygiene-smoke.py examples/derived-state-boundary-smoke.py examples/control_plane/todo-archive-completed-smoke.py examples/control_plane/event-sourced-status-read-path-smoke.py
- PYTHONPATH=. python3 examples/control_plane/todo-archive-completed-smoke.py
- PYTHONPATH=. python3 examples/derived-state-boundary-smoke.py
- PYTHONPATH=. python3 examples/backlog-hygiene-smoke.py
- PYTHONPATH=. python3 examples/control_plane/event-sourced-status-read-path-smoke.py
- PYTHONPATH=. python3 examples/control_plane/bounded-context-namespace-smoke.py
- PYTHONPATH=. python3 examples/control_plane/control-plane-risk-characterization-smoke.py
- PYTHONPATH=. python3 examples/control_plane/hot-path-interface-budget-smoke.py
- PYTHONPATH=. python3 examples/control_plane/check-public-boundary-smoke.py
- PYTHONPATH=. python3 -m loopx.cli canary premerge --from-git-diff --tier standard --timeout-seconds 120 --format json

## Risk
- changed surfaces: todo/status read path and public control-plane smokes
- no benchmark runner/scoring behavior, no production actions, no private evidence