### PR TITLE
Move scheduler ack validation into scheduler context

### DIFF
--- a/examples/control_plane/quota-scheduler-state-ack-smoke.py
+++ b/examples/control_plane/quota-scheduler-state-ack-smoke.py
@@ -16,7 +16,10 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from loopx.control_plane.scheduler.scheduler_hint import build_scheduler_hint  # noqa: E402
+from loopx.control_plane.scheduler.scheduler_hint import (  # noqa: E402
+    build_scheduler_ack_plan,
+    build_scheduler_hint,
+)
 from loopx.control_plane.scheduler.state import SCHEDULER_STATE_SCHEMA_VERSION  # noqa: E402
 from loopx.quota import AgentScopeFrontierAction  # noqa: E402
 from loopx.status import AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK  # noqa: E402
@@ -279,6 +282,102 @@ def assert_active_work_keeps_initial_cadence() -> None:
     assert "recommended_rrule" not in steady["codex_app"], steady
 
 
+def assert_scheduler_ack_plan_validation() -> None:
+    base = active_payload()
+    first = build_scheduler_hint(
+        deepcopy(base),
+        agent_scope_frontier_actions=AGENT_SCOPE_ACTIONS,
+    )
+    codex_app = first["codex_app"]
+    backoff = codex_app["stateful_backoff"]
+    plan = build_scheduler_ack_plan(
+        {"scheduler_hint": first},
+        agent_id="codex-side-agent",
+        state_key=backoff["state_key"],
+        applied_rrule=codex_app["recommended_rrule"],
+        reset_token=backoff["reset_token"],
+        identity_signature=backoff["identity_signature"],
+    )
+    assert plan == {
+        "ok": True,
+        "already_applied": False,
+        "applied_rrule": codex_app["recommended_rrule"],
+        "expected_rrule": codex_app["recommended_rrule"],
+    }, plan
+
+    missing_agent = build_scheduler_ack_plan(
+        {"scheduler_hint": first},
+        agent_id=None,
+        state_key=backoff["state_key"],
+        applied_rrule=codex_app["recommended_rrule"],
+    )
+    assert missing_agent["ok"] is False, missing_agent
+    assert "--agent-id" in missing_agent["reason"], missing_agent
+
+    wrong_state_key = build_scheduler_ack_plan(
+        {"scheduler_hint": first},
+        agent_id="codex-side-agent",
+        state_key="wrong.state.key",
+        applied_rrule=codex_app["recommended_rrule"],
+    )
+    assert wrong_state_key["ok"] is False, wrong_state_key
+    assert "--state-key" in wrong_state_key["reason"], wrong_state_key
+
+    wrong_reset_token = build_scheduler_ack_plan(
+        {"scheduler_hint": first},
+        agent_id="codex-side-agent",
+        state_key=backoff["state_key"],
+        applied_rrule=codex_app["recommended_rrule"],
+        reset_token="wrong-reset-token",
+    )
+    assert wrong_reset_token["ok"] is False, wrong_reset_token
+    assert "--reset-token" in wrong_reset_token["reason"], wrong_reset_token
+
+    wrong_identity = build_scheduler_ack_plan(
+        {"scheduler_hint": first},
+        agent_id="codex-side-agent",
+        state_key=backoff["state_key"],
+        applied_rrule=codex_app["recommended_rrule"],
+        identity_signature="wrong-identity",
+    )
+    assert wrong_identity["ok"] is False, wrong_identity
+    assert "--identity-signature" in wrong_identity["reason"], wrong_identity
+
+    missing_rrule = build_scheduler_ack_plan(
+        {"scheduler_hint": first},
+        agent_id="codex-side-agent",
+        state_key=backoff["state_key"],
+    )
+    assert missing_rrule["ok"] is False, missing_rrule
+    assert "--applied-rrule" in missing_rrule["reason"], missing_rrule
+
+    wrong_rrule = build_scheduler_ack_plan(
+        {"scheduler_hint": first},
+        agent_id="codex-side-agent",
+        state_key=backoff["state_key"],
+        applied_rrule="FREQ=MINUTELY;INTERVAL=99",
+    )
+    assert wrong_rrule["ok"] is False, wrong_rrule
+    assert "does not match expected" in wrong_rrule["reason"], wrong_rrule
+
+    steady = build_scheduler_hint(
+        deepcopy(base),
+        agent_scope_frontier_actions=AGENT_SCOPE_ACTIONS,
+        codex_app_scheduler_state=state_from(first),
+    )
+    steady_backoff = steady["codex_app"]["stateful_backoff"]
+    already_applied = build_scheduler_ack_plan(
+        {"scheduler_hint": steady},
+        agent_id="codex-side-agent",
+        state_key=steady_backoff["state_key"],
+    )
+    assert already_applied == {
+        "ok": True,
+        "already_applied": True,
+        "applied_rrule": "",
+    }, already_applied
+
+
 def run_cli(root: Path, *args: str, registry_path: Path, runtime: Path, project: Path) -> dict:
     command = [
         sys.executable,
@@ -479,6 +578,7 @@ def main() -> int:
     assert_policy_state_progression()
     assert_monitor_wait_progression_reaches_120()
     assert_active_work_keeps_initial_cadence()
+    assert_scheduler_ack_plan_validation()
     assert_cli_scheduler_ack_progression()
     assert_cli_scheduler_ack_uses_should_run_lookback()
     print("quota-scheduler-state-ack-smoke ok")

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -53,6 +53,76 @@ def scheduler_backoff_packet(
     return scheduler_hint, codex_app, stateful_backoff
 
 
+def build_scheduler_ack_plan(
+    before: dict[str, Any],
+    *,
+    agent_id: str | None,
+    state_key: str = CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
+    applied_rrule: str | None = None,
+    reset_token: str | None = None,
+    identity_signature: str | None = None,
+) -> dict[str, Any]:
+    safe_agent_id = str(agent_id or "").strip()
+    _, codex_app, stateful_backoff = scheduler_backoff_packet(before)
+    if not safe_agent_id:
+        return {
+            "ok": False,
+            "reason": "`loopx quota scheduler-ack` requires --agent-id",
+        }
+    if not stateful_backoff:
+        return {
+            "ok": False,
+            "reason": "current quota decision has no Codex App stateful scheduler packet",
+        }
+    if str(stateful_backoff.get("state_key") or "") != state_key:
+        return {
+            "ok": False,
+            "reason": "--state-key does not match scheduler_hint.codex_app.stateful_backoff.state_key",
+        }
+    if reset_token and str(reset_token).strip() != str(stateful_backoff.get("reset_token") or ""):
+        return {
+            "ok": False,
+            "reason": "--reset-token does not match the current scheduler hint",
+        }
+    if (
+        identity_signature
+        and str(identity_signature).strip() != str(stateful_backoff.get("identity_signature") or "")
+    ):
+        return {
+            "ok": False,
+            "reason": "--identity-signature does not match the current scheduler hint",
+        }
+    safe_applied_rrule = normalize_scheduler_rrule(applied_rrule)
+    if stateful_backoff.get("apply_needed") is not True:
+        return {
+            "ok": True,
+            "already_applied": True,
+            "applied_rrule": safe_applied_rrule,
+        }
+    expected_rrule = normalize_scheduler_rrule(
+        codex_app.get("recommended_rrule") or stateful_backoff.get("current_rrule")
+    )
+    if not safe_applied_rrule:
+        return {
+            "ok": False,
+            "reason": "`loopx quota scheduler-ack` requires --applied-rrule when apply_needed=true",
+        }
+    if expected_rrule and safe_applied_rrule != expected_rrule:
+        return {
+            "ok": False,
+            "reason": (
+                f"quota scheduler-ack applied_rrule {safe_applied_rrule!r} "
+                f"does not match expected {expected_rrule!r}"
+            ),
+        }
+    return {
+        "ok": True,
+        "already_applied": False,
+        "applied_rrule": safe_applied_rrule,
+        "expected_rrule": expected_rrule,
+    }
+
+
 def _int_number(value: Any, *, default: int) -> int:
     try:
         return int(value)

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -74,8 +74,7 @@ from .control_plane.work_items.outcome_followthrough import build_outcome_follow
 from .control_plane.scheduler.scheduler_hint import (
     build_codex_app_scheduler_ack_event,
     build_scheduler_hint,
-    normalize_scheduler_rrule,
-    scheduler_backoff_packet,
+    build_scheduler_ack_plan,
 )
 from .control_plane.scheduler.monitor_todo import (
     monitor_cadence_delta as scheduler_monitor_cadence_delta,
@@ -5722,19 +5721,15 @@ def record_quota_scheduler_ack(
     safe_surface = str(surface or CODEX_APP_SURFACE).strip() or CODEX_APP_SURFACE
     safe_state_key = str(state_key or CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).strip()
     before = build_quota_should_run(status_payload, goal_id=safe_goal_id, agent_id=safe_agent_id)
-    _, codex_app, stateful_backoff = scheduler_backoff_packet(before)
-    if not safe_agent_id:
-        return _scheduler_ack_failure(
-            goal_id=safe_goal_id,
-            agent_id=agent_id,
-            execute=execute,
-            surface=safe_surface,
-            state_key=safe_state_key,
-            applied_rrule=applied_rrule,
-            reason="`loopx quota scheduler-ack` requires --agent-id",
-            before=before,
-        )
-    if not stateful_backoff:
+    ack_plan = build_scheduler_ack_plan(
+        before,
+        agent_id=safe_agent_id,
+        state_key=safe_state_key,
+        applied_rrule=applied_rrule,
+        reset_token=reset_token,
+        identity_signature=identity_signature,
+    )
+    if not ack_plan.get("ok"):
         return _scheduler_ack_failure(
             goal_id=safe_goal_id,
             agent_id=safe_agent_id,
@@ -5742,43 +5737,10 @@ def record_quota_scheduler_ack(
             surface=safe_surface,
             state_key=safe_state_key,
             applied_rrule=applied_rrule,
-            reason="current quota decision has no Codex App stateful scheduler packet",
+            reason=str(ack_plan.get("reason") or "scheduler ack validation failed"),
             before=before,
         )
-    if safe_state_key != str(stateful_backoff.get("state_key") or ""):
-        return _scheduler_ack_failure(
-            goal_id=safe_goal_id,
-            agent_id=safe_agent_id,
-            execute=execute,
-            surface=safe_surface,
-            state_key=safe_state_key,
-            applied_rrule=applied_rrule,
-            reason="--state-key does not match scheduler_hint.codex_app.stateful_backoff.state_key",
-            before=before,
-        )
-    if reset_token and str(reset_token).strip() != str(stateful_backoff.get("reset_token") or ""):
-        return _scheduler_ack_failure(
-            goal_id=safe_goal_id,
-            agent_id=safe_agent_id,
-            execute=execute,
-            surface=safe_surface,
-            state_key=safe_state_key,
-            applied_rrule=applied_rrule,
-            reason="--reset-token does not match the current scheduler hint",
-            before=before,
-        )
-    if identity_signature and str(identity_signature).strip() != str(stateful_backoff.get("identity_signature") or ""):
-        return _scheduler_ack_failure(
-            goal_id=safe_goal_id,
-            agent_id=safe_agent_id,
-            execute=execute,
-            surface=safe_surface,
-            state_key=safe_state_key,
-            applied_rrule=applied_rrule,
-            reason="--identity-signature does not match the current scheduler hint",
-            before=before,
-        )
-    if stateful_backoff.get("apply_needed") is not True:
+    if ack_plan.get("already_applied"):
         return {
             "ok": True,
             "mode": "scheduler-ack",
@@ -5787,7 +5749,7 @@ def record_quota_scheduler_ack(
             "agent_id": safe_agent_id,
             "surface": safe_surface,
             "state_key": safe_state_key,
-            "applied_rrule": normalize_scheduler_rrule(applied_rrule),
+            "applied_rrule": ack_plan.get("applied_rrule"),
             "appended": False,
             "registry_mutated": False,
             "already_applied": True,
@@ -5795,17 +5757,6 @@ def record_quota_scheduler_ack(
             "after": before,
             "reason": "scheduler RRULE already applied; no ack write needed",
         }
-    if not normalize_scheduler_rrule(applied_rrule):
-        return _scheduler_ack_failure(
-            goal_id=safe_goal_id,
-            agent_id=safe_agent_id,
-            execute=execute,
-            surface=safe_surface,
-            state_key=safe_state_key,
-            applied_rrule=applied_rrule,
-            reason="`loopx quota scheduler-ack` requires --applied-rrule when apply_needed=true",
-            before=before,
-        )
 
     raw_runtime_root = status_payload.get("runtime_root")
     if not raw_runtime_root:


### PR DESCRIPTION
## Summary
- move scheduler-ack validation and plan construction into the scheduler bounded context
- keep quota responsible for quota decision, failure rendering, ack event creation, and state writeback
- expand the scheduler-state ack smoke with a complex canary for success, already-applied, state-key, reset-token, identity-signature, missing RRULE, and mismatched RRULE cases

## Validation
- python3 -m py_compile loopx/control_plane/scheduler/scheduler_hint.py loopx/quota.py examples/control_plane/quota-scheduler-state-ack-smoke.py
- PYTHONPATH=. python3 examples/control_plane/quota-scheduler-state-ack-smoke.py
- PYTHONPATH=. python3 examples/control_plane/quota-scheduler-hint-compaction-smoke.py
- PYTHONPATH=. python3 examples/control_plane/quota-scheduler-policy-smoke.py
- PYTHONPATH=. python3 examples/control_plane/monitor-scheduler-contract-smoke.py
- PYTHONPATH=. python3 examples/control_plane/side-agent-self-iteration-state-machine-smoke.py
- PYTHONPATH=. python3 examples/control_plane/control-plane-integrated-canary-smoke.py
- PYTHONPATH=. python3 examples/control_plane/control-plane-risk-characterization-smoke.py
- PYTHONPATH=. python3 examples/control_plane/bounded-context-namespace-smoke.py
- PYTHONPATH=. python3 examples/control_plane/check-public-boundary-smoke.py
- git diff --check
- PYTHONPATH=. python3 -m loopx.cli canary premerge --from-git-diff --tier standard --timeout-seconds 120 --format json

## Risk
Quota/scheduler hot path. No benchmark runner/scoring, production action, permission boundary, or public evidence-policy change.