### PR TITLE
Move route continuation lanes into todo context

### DIFF
--- a/examples/control_plane/quota-cleared-blocker-successor-gate-smoke.py
+++ b/examples/control_plane/quota-cleared-blocker-successor-gate-smoke.py
@@ -14,7 +14,9 @@ if str(REPO_ROOT) not in sys.path:
 from loopx.quota import build_quota_should_run  # noqa: E402
 from loopx.status import compact_todo_group  # noqa: E402
 from loopx.control_plane.todos.handoff_gate import (  # noqa: E402
+    build_todo_handoff_gate_lanes,
     build_todo_handoff_gate_states,
+    handoff_ready_successor_todo_ids,
 )
 
 
@@ -82,6 +84,45 @@ def agent_todo_summary(items: list[dict]) -> dict:
     if handoff_gates:
         summary["handoff_gates"] = handoff_gates
     return summary
+
+
+def assert_handoff_gate_lanes_and_ready_successors_are_todo_context_helpers() -> None:
+    review_gate = todo_item(
+        todo_id="todo_review_gate",
+        text="[P0] Review the completed launch slice.",
+        claimed_by=PRIMARY_AGENT,
+        status="done",
+        blocks_agent=BLOCKED_AGENT,
+    )
+    successor = todo_item(
+        todo_id="todo_followup_slice",
+        text="[P1] Continue the follow-up slice.",
+        claimed_by=BLOCKED_AGENT,
+        status="open",
+        unblocks_todo_id="todo_review_gate",
+    )
+    blocked_gate = todo_item(
+        todo_id="todo_unresolved_gate",
+        text="[P0] Still blocking the value explorer.",
+        claimed_by=PRIMARY_AGENT,
+        status="done",
+        blocks_agent=BLOCKED_AGENT,
+    )
+    summary = agent_todo_summary([review_gate, successor, blocked_gate])
+
+    assert handoff_ready_successor_todo_ids(summary) == {"todo_followup_slice"}, summary
+    lanes = build_todo_handoff_gate_lanes(
+        summary,
+        agent_identity={"agent_id": BLOCKED_AGENT},
+        item_limit=10,
+    )
+    assert lanes["handoff_gate_count"] == 2, lanes
+    assert lanes["current_agent_handoff_gate_count"] == 2, lanes
+    assert lanes["current_agent_cleared_without_successor_handoff_count"] == 1, lanes
+    assert (
+        lanes["current_agent_cleared_without_successor_handoff_gates"][0]["todo_id"]
+        == "todo_unresolved_gate"
+    ), lanes
 
 
 def status_payload(items: list[dict], *, recommended_action: str) -> dict:
@@ -372,6 +413,7 @@ def assert_no_followup_completed_blocker_does_not_wake_agent() -> None:
 
 
 def main() -> int:
+    assert_handoff_gate_lanes_and_ready_successors_are_todo_context_helpers()
     assert_open_blocker_waits_on_owner()
     assert_cleared_blocker_requires_successor_replan()
     assert_status_summary_projects_handoff_gate_state()

--- a/examples/control_plane/todo-route-continuation-lanes-smoke.py
+++ b/examples/control_plane/todo-route-continuation-lanes-smoke.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Smoke-test todo route-continuation lane projection helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.todos.route_continuation import (  # noqa: E402
+    TODO_ROUTE_CONTINUATION_SELECTION_POLICY,
+    build_todo_route_continuation_lanes,
+)
+
+
+def assert_route_continuation_lanes_filter_current_unclaimed_and_other_agents() -> None:
+    summary = {
+        "schema_version": "todo_summary_v0",
+        "source_section": "Agent Todo",
+        "route_continuation_replan_candidates": [
+            {
+                "index": 2,
+                "todo_id": "todo_current_claimed_route",
+                "text": "[P1] Continue current claimed route.",
+                "task_class": "advancement_task",
+                "claimed_by": "codex-side-bypass",
+                "route_id": "current-route",
+                "route_continuation_replan_required": True,
+                "required_write_scopes": [" loopx/** ", "loopx/**"],
+                "decision_scope": "direction:action:route",
+            },
+            {
+                "index": 1,
+                "route_key": "unclaimed-route",
+                "recommended_action": "[P1] Continue unclaimed route.",
+                "task_class": "advancement_task",
+                "route_continuation_replan_required": True,
+            },
+            {
+                "index": 3,
+                "todo_id": "todo_other_agent_route",
+                "text": "[P1] Continue other agent route.",
+                "task_class": "advancement_task",
+                "claimed_by": "codex-main-control",
+                "route_id": "other-route",
+                "route_continuation_replan_required": True,
+            },
+            {
+                "index": 4,
+                "todo_id": "todo_false_route",
+                "text": "[P1] Do not project this route.",
+                "task_class": "advancement_task",
+                "route_continuation_replan_required": False,
+            },
+            {
+                "index": 5,
+                "todo_id": "todo_monitor_route",
+                "text": "[P1] Monitor route is not advancement replan.",
+                "task_class": "continuous_monitor",
+                "route_continuation_replan_required": True,
+            },
+        ],
+        "handoff_gates": [
+            {
+                "index": 0,
+                "todo_id": "todo_blocking_route_gate",
+                "text": "[P0-review] Review route gate.",
+                "task_class": "advancement_task",
+                "claimed_by": "codex-main-control",
+                "blocks_agent": "codex-side-bypass",
+                "route_id": "blocked-route",
+                "route_continuation_replan_required": True,
+                "route_continuation_reason": "same route has a next slice",
+            }
+        ],
+    }
+
+    lanes = build_todo_route_continuation_lanes(
+        summary,
+        agent_identity={"agent_id": "codex-side-bypass"},
+        item_limit=10,
+    )
+    assert lanes["route_continuation_replan_count"] == 4, lanes
+    assert [
+        item.get("route_id") or item.get("route_key")
+        for item in lanes["route_continuation_replan_candidates"]
+    ] == [
+        "blocked-route",
+        "unclaimed-route",
+        "current-route",
+        "other-route",
+    ], lanes
+    assert lanes["current_agent_route_continuation_replan_count"] == 3, lanes
+    assert [
+        item.get("route_id") or item.get("route_key")
+        for item in lanes["current_agent_route_continuation_replan_candidates"]
+    ] == ["blocked-route", "unclaimed-route", "current-route"], lanes
+    assert lanes["unclaimed_route_continuation_replan_count"] == 1, lanes
+    assert (
+        lanes["unclaimed_route_continuation_replan_candidates"][0]["route_key"]
+        == "unclaimed-route"
+    ), lanes
+    assert lanes["other_agent_route_continuation_replan_count"] == 1, lanes
+    assert lanes["other_agent_route_continuation_replan_candidates"][0]["route_id"] == (
+        "other-route"
+    ), lanes
+    current = lanes["current_agent_route_continuation_replan_candidates"][2]
+    assert current["required_write_scopes"] == ["loopx/**"], current
+    assert current["decision_scope"]["scope_key"] == "route", current
+    assert (
+        lanes["route_continuation_replan_selection_policy"]
+        == TODO_ROUTE_CONTINUATION_SELECTION_POLICY
+    ), lanes
+
+
+def main() -> int:
+    assert_route_continuation_lanes_filter_current_unclaimed_and_other_agents()
+    print("todo-route-continuation-lanes-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/control_plane/todos/handoff_gate.py
+++ b/loopx/control_plane/todos/handoff_gate.py
@@ -183,3 +183,73 @@ def build_todo_handoff_gate_states(items: Iterable[Any]) -> list[dict[str, Any]]
             str(item.get("todo_id") or ""),
         ),
     )
+
+
+def todo_summary_handoff_gates(value: dict[str, Any]) -> list[dict[str, Any]]:
+    projected = value.get("handoff_gates")
+    if isinstance(projected, list):
+        return [item for item in projected if isinstance(item, dict)]
+    source_items = value.get("items") if isinstance(value.get("items"), list) else []
+    return build_todo_handoff_gate_states(source_items)
+
+
+def handoff_ready_successor_todo_ids(value: dict[str, Any]) -> set[str]:
+    ready: set[str] = set()
+    for gate in todo_summary_handoff_gates(value):
+        if not isinstance(gate, dict):
+            continue
+        if str(gate.get("gate_state") or "") != HandoffGateState.CLEARED_WITH_SUCCESSOR.value:
+            continue
+        successor_ids = gate.get("successor_todo_ids")
+        if not isinstance(successor_ids, list):
+            continue
+        for todo_id in successor_ids:
+            normalized = normalize_todo_id(todo_id)
+            if normalized:
+                ready.add(normalized)
+    return ready
+
+
+def build_todo_handoff_gate_lanes(
+    value: dict[str, Any],
+    *,
+    agent_identity: dict[str, Any] | None,
+    item_limit: int,
+) -> dict[str, Any]:
+    handoff_gates = todo_summary_handoff_gates(value)
+    if not handoff_gates:
+        return {}
+    lanes: dict[str, Any] = {
+        "handoff_gate_count": len(handoff_gates),
+        "handoff_gates": handoff_gates[:item_limit],
+    }
+    agent_id = (
+        normalize_todo_claimed_by(agent_identity.get("agent_id"))
+        if isinstance(agent_identity, dict)
+        else None
+    )
+    if agent_id:
+        current_agent_items = [
+            item
+            for item in handoff_gates
+            if normalize_todo_blocks_agent(item.get("blocks_agent")) == agent_id
+        ]
+        cleared_without_successor = [
+            item
+            for item in current_agent_items
+            if item.get("gate_state")
+            == HandoffGateState.CLEARED_WITHOUT_SUCCESSOR.value
+        ]
+        lanes.update(
+            {
+                "current_agent_handoff_gate_count": len(current_agent_items),
+                "current_agent_handoff_gates": current_agent_items[:item_limit],
+                "current_agent_cleared_without_successor_handoff_count": len(
+                    cleared_without_successor
+                ),
+                "current_agent_cleared_without_successor_handoff_gates": (
+                    cleared_without_successor[:item_limit]
+                ),
+            }
+        )
+    return lanes

--- a/loopx/control_plane/todos/route_continuation.py
+++ b/loopx/control_plane/todos/route_continuation.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .contract import (
+    TODO_TASK_CLASS_ADVANCEMENT,
+    normalize_required_write_scopes,
+    normalize_todo_blocks_agent,
+    normalize_todo_claimed_by,
+    normalize_todo_decision_scope,
+    normalize_todo_required_decision_scopes,
+    normalize_todo_task_class,
+)
+from .handoff_gate import todo_summary_handoff_gates
+from .projection import todo_projection_sort_key
+
+
+TODO_ROUTE_CONTINUATION_SELECTION_POLICY = (
+    "quota may wake the current side-agent for route continuation replan "
+    "candidates claimed by that agent or unclaimed; other-agent route "
+    "candidates remain diagnostic visibility"
+)
+
+
+def _todo_task_class(item: dict[str, Any]) -> str:
+    text = " ".join(
+        str(value or "")
+        for value in (item.get("title"), item.get("text"))
+        if str(value or "").strip()
+    )
+    return normalize_todo_task_class(
+        item.get("task_class"),
+        text=text,
+        action_kind=item.get("action_kind"),
+    )
+
+
+def _compact_route_continuation_item(
+    item: dict[str, Any],
+    *,
+    text: str,
+) -> dict[str, Any]:
+    compact: dict[str, Any] = {
+        "index": item.get("index"),
+        "text": text,
+    }
+    for key in (
+        "schema_version",
+        "todo_id",
+        "role",
+        "status",
+        "priority",
+        "title",
+        "archive_state",
+        "source_section",
+        "task_class",
+        "action_kind",
+        "required_write_scopes",
+        "required_capabilities",
+        "target_capabilities",
+        "decision_scope",
+        "required_decision_scopes",
+        "claimed_by",
+        "blocks_agent",
+        "unblocks_todo_id",
+        "resume_when",
+        "resume_condition",
+        "resume_ready",
+        "no_followup",
+        "successor_todo_ids",
+        "target_key",
+        "cadence",
+        "next_due_at",
+        "expires_at",
+        "last_checked_at",
+        "result_hash",
+        "consecutive_no_change",
+        "material_change",
+        "max_no_change_before_replan",
+        "route_continuation_replan_required",
+        "route_continuation_reason",
+        "route_id",
+        "route_key",
+        "completed_at",
+        "updated_at",
+        "superseded_by",
+    ):
+        if item.get(key) is not None:
+            compact[key] = item.get(key)
+    required_write_scopes = normalize_required_write_scopes(compact.get("required_write_scopes"))
+    if required_write_scopes:
+        compact["required_write_scopes"] = required_write_scopes
+    else:
+        compact.pop("required_write_scopes", None)
+    decision_scope = normalize_todo_decision_scope(compact.get("decision_scope"))
+    if decision_scope:
+        compact["decision_scope"] = decision_scope
+    else:
+        compact.pop("decision_scope", None)
+    required_decision_scopes = normalize_todo_required_decision_scopes(
+        compact.get("required_decision_scopes")
+    )
+    if required_decision_scopes:
+        compact["required_decision_scopes"] = required_decision_scopes
+    else:
+        compact.pop("required_decision_scopes", None)
+    compact["task_class"] = _todo_task_class(compact)
+    return compact
+
+
+def todo_summary_route_continuation_candidates(
+    value: dict[str, Any],
+) -> list[dict[str, Any]]:
+    if not isinstance(value, dict):
+        return []
+    source_items: list[dict[str, Any]] = []
+    for key in (
+        "route_continuation_replan_candidates",
+        "route_continuation_candidates",
+    ):
+        raw_items = value.get(key) if isinstance(value.get(key), list) else []
+        source_items.extend(item for item in raw_items if isinstance(item, dict))
+
+    source_items.extend(
+        item
+        for item in todo_summary_handoff_gates(value)
+        if isinstance(item, dict)
+        and item.get("route_continuation_replan_required") is True
+    )
+    if not source_items:
+        return []
+
+    candidates: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in source_items:
+        if item.get("route_continuation_replan_required") is False:
+            continue
+        task_class = item.get("task_class")
+        if task_class is not None and _todo_task_class(item) != TODO_TASK_CLASS_ADVANCEMENT:
+            continue
+        text = str(
+            item.get("text")
+            or item.get("title")
+            or item.get("recommended_action")
+            or item.get("route_continuation_reason")
+            or ""
+        ).strip()
+        identity = str(
+            item.get("todo_id")
+            or item.get("route_id")
+            or item.get("route_key")
+            or item.get("index")
+            or text
+        )
+        if not identity or identity in seen:
+            continue
+        seen.add(identity)
+        compact = _compact_route_continuation_item(item, text=text)
+        compact["route_continuation_replan_required"] = True
+        if item.get("route_continuation_reason") is not None:
+            compact["route_continuation_reason"] = item.get("route_continuation_reason")
+        if item.get("route_id") is not None:
+            compact["route_id"] = item.get("route_id")
+        if item.get("route_key") is not None:
+            compact["route_key"] = item.get("route_key")
+        candidates.append(compact)
+    return sorted(candidates, key=todo_projection_sort_key)
+
+
+def route_continuation_candidate_matches_agent(
+    item: dict[str, Any],
+    *,
+    agent_id: str,
+) -> bool:
+    blocks_agent = normalize_todo_blocks_agent(item.get("blocks_agent"))
+    if blocks_agent:
+        return blocks_agent == agent_id
+    claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
+    return not claimed_by or claimed_by == agent_id
+
+
+def _agent_filtered_route_continuation_items(
+    items: list[dict[str, Any]],
+    *,
+    agent_id: str | None,
+    claim: str,
+) -> list[dict[str, Any]]:
+    selected: list[dict[str, Any]] = []
+    for item in items:
+        blocks_agent = normalize_todo_blocks_agent(item.get("blocks_agent"))
+        claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
+        if claim == "current":
+            if not agent_id or not route_continuation_candidate_matches_agent(
+                item,
+                agent_id=agent_id,
+            ):
+                continue
+        elif claim == "unclaimed":
+            if blocks_agent or claimed_by:
+                continue
+        elif claim == "other":
+            if not agent_id:
+                continue
+            if route_continuation_candidate_matches_agent(item, agent_id=agent_id):
+                continue
+        selected.append(item)
+    return selected
+
+
+def build_todo_route_continuation_lanes(
+    value: dict[str, Any],
+    *,
+    agent_identity: dict[str, Any] | None,
+    item_limit: int,
+) -> dict[str, Any]:
+    candidates = todo_summary_route_continuation_candidates(value)
+    if not candidates:
+        return {}
+    lanes: dict[str, Any] = {
+        "route_continuation_replan_count": len(candidates),
+        "route_continuation_replan_candidates": candidates[:item_limit],
+    }
+    agent_id = (
+        normalize_todo_claimed_by(agent_identity.get("agent_id"))
+        if isinstance(agent_identity, dict)
+        else None
+    )
+    if agent_id:
+        current_agent_candidates = _agent_filtered_route_continuation_items(
+            candidates,
+            agent_id=agent_id,
+            claim="current",
+        )
+        unclaimed_candidates = _agent_filtered_route_continuation_items(
+            candidates,
+            agent_id=agent_id,
+            claim="unclaimed",
+        )
+        other_agent_candidates = _agent_filtered_route_continuation_items(
+            candidates,
+            agent_id=agent_id,
+            claim="other",
+        )
+        lanes.update(
+            {
+                "current_agent_route_continuation_replan_candidates": (
+                    current_agent_candidates[:item_limit]
+                ),
+                "unclaimed_route_continuation_replan_candidates": (
+                    unclaimed_candidates[:item_limit]
+                ),
+                "other_agent_route_continuation_replan_candidates": (
+                    other_agent_candidates[:item_limit]
+                ),
+                "current_agent_route_continuation_replan_count": len(
+                    current_agent_candidates
+                ),
+                "unclaimed_route_continuation_replan_count": len(unclaimed_candidates),
+                "other_agent_route_continuation_replan_count": len(other_agent_candidates),
+                "route_continuation_replan_selection_policy": (
+                    TODO_ROUTE_CONTINUATION_SELECTION_POLICY
+                ),
+            }
+        )
+    return lanes

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -122,9 +122,10 @@ from .control_plane.todos.contract import (
     normalize_todo_task_class,
 )
 from .control_plane.todos.handoff_gate import (
-    HandoffGateState,
-    build_todo_handoff_gate_states,
+    build_todo_handoff_gate_lanes,
+    handoff_ready_successor_todo_ids as todo_handoff_ready_successor_todo_ids,
 )
+from .control_plane.todos.route_continuation import build_todo_route_continuation_lanes
 from .control_plane.todos.succession_warning import build_todo_succession_warning_lanes
 from .control_plane.todos.projection import (
     todo_claimed_visibility_items as projection_todo_claimed_visibility_items,
@@ -1698,155 +1699,6 @@ def _deferred_visibility_lanes(
     return lanes
 
 
-def _todo_summary_route_continuation_candidates(value: dict[str, Any]) -> list[dict[str, Any]]:
-    if not isinstance(value, dict):
-        return []
-    source_items: list[dict[str, Any]] = []
-    for key in (
-        "route_continuation_replan_candidates",
-        "route_continuation_candidates",
-    ):
-        raw_items = value.get(key) if isinstance(value.get(key), list) else []
-        source_items.extend(item for item in raw_items if isinstance(item, dict))
-
-    handoff_gates = _todo_summary_handoff_gates(value)
-    source_items.extend(
-        item
-        for item in handoff_gates
-        if isinstance(item, dict)
-        and item.get("route_continuation_replan_required") is True
-    )
-    if not source_items:
-        return []
-
-    candidates: list[dict[str, Any]] = []
-    seen: set[str] = set()
-    for item in source_items:
-        if item.get("route_continuation_replan_required") is False:
-            continue
-        task_class = item.get("task_class")
-        if task_class is not None and _todo_task_class(item) != TODO_TASK_CLASS_ADVANCEMENT:
-            continue
-        text = str(
-            item.get("text")
-            or item.get("title")
-            or item.get("recommended_action")
-            or item.get("route_continuation_reason")
-            or ""
-        ).strip()
-        identity = str(
-            item.get("todo_id")
-            or item.get("route_id")
-            or item.get("route_key")
-            or item.get("index")
-            or text
-        )
-        if not identity or identity in seen:
-            continue
-        seen.add(identity)
-        compact = _compact_todo_summary_item(item, text=text)
-        compact["route_continuation_replan_required"] = True
-        if item.get("route_continuation_reason") is not None:
-            compact["route_continuation_reason"] = item.get("route_continuation_reason")
-        if item.get("route_id") is not None:
-            compact["route_id"] = item.get("route_id")
-        if item.get("route_key") is not None:
-            compact["route_key"] = item.get("route_key")
-        candidates.append(compact)
-    return sorted(candidates, key=_todo_projection_sort_key)
-
-
-def _route_continuation_candidate_matches_agent(
-    item: dict[str, Any],
-    *,
-    agent_id: str,
-) -> bool:
-    blocks_agent = normalize_todo_blocks_agent(item.get("blocks_agent"))
-    if blocks_agent:
-        return blocks_agent == agent_id
-    claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
-    return not claimed_by or claimed_by == agent_id
-
-
-def _agent_filtered_route_continuation_items(
-    items: list[dict[str, Any]],
-    *,
-    agent_id: str | None,
-    claim: str,
-) -> list[dict[str, Any]]:
-    selected: list[dict[str, Any]] = []
-    for item in items:
-        blocks_agent = normalize_todo_blocks_agent(item.get("blocks_agent"))
-        claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
-        if claim == "current":
-            if not agent_id or not _route_continuation_candidate_matches_agent(
-                item,
-                agent_id=agent_id,
-            ):
-                continue
-        elif claim == "unclaimed":
-            if blocks_agent or claimed_by:
-                continue
-        elif claim == "other":
-            if not agent_id:
-                continue
-            if _route_continuation_candidate_matches_agent(item, agent_id=agent_id):
-                continue
-        selected.append(item)
-    return selected
-
-
-def _route_continuation_replan_lanes(
-    value: dict[str, Any],
-    *,
-    agent_identity: dict[str, Any] | None,
-) -> dict[str, Any]:
-    candidates = _todo_summary_route_continuation_candidates(value)
-    if not candidates:
-        return {}
-    lanes: dict[str, Any] = {
-        "route_continuation_replan_count": len(candidates),
-        "route_continuation_replan_candidates": candidates[:TODO_BACKLOG_ITEM_LIMIT],
-    }
-    agent_id = (
-        normalize_todo_claimed_by(agent_identity.get("agent_id"))
-        if isinstance(agent_identity, dict)
-        else None
-    )
-    if agent_id:
-        current_agent_candidates = _agent_filtered_route_continuation_items(
-            candidates,
-            agent_id=agent_id,
-            claim="current",
-        )
-        unclaimed_candidates = _agent_filtered_route_continuation_items(
-            candidates,
-            agent_id=agent_id,
-            claim="unclaimed",
-        )
-        other_agent_candidates = _agent_filtered_route_continuation_items(
-            candidates,
-            agent_id=agent_id,
-            claim="other",
-        )
-        lanes.update(
-            {
-                "current_agent_route_continuation_replan_candidates": current_agent_candidates[:TODO_BACKLOG_ITEM_LIMIT],
-                "unclaimed_route_continuation_replan_candidates": unclaimed_candidates[:TODO_BACKLOG_ITEM_LIMIT],
-                "other_agent_route_continuation_replan_candidates": other_agent_candidates[:TODO_BACKLOG_ITEM_LIMIT],
-                "current_agent_route_continuation_replan_count": len(current_agent_candidates),
-                "unclaimed_route_continuation_replan_count": len(unclaimed_candidates),
-                "other_agent_route_continuation_replan_count": len(other_agent_candidates),
-                "route_continuation_replan_selection_policy": (
-                    "quota may wake the current side-agent for route continuation "
-                    "replan candidates claimed by that agent or unclaimed; other-agent "
-                    "route candidates remain diagnostic visibility"
-                ),
-            }
-        )
-    return lanes
-
-
 def _todo_summary_source_items(value: dict[str, Any]) -> list[dict[str, Any]]:
     source_keys = (
         "active_next_action_items",
@@ -1866,7 +1718,7 @@ def _todo_summary_source_items(value: dict[str, Any]) -> list[dict[str, Any]]:
         "unclaimed_monitor_blocked_resume_candidates",
         "items",
     )
-    ready_successor_todo_ids = _handoff_ready_successor_todo_ids(value)
+    ready_successor_todo_ids = todo_handoff_ready_successor_todo_ids(value)
     open_items: list[dict[str, Any]] = []
     for key in source_keys:
         source_items = value.get(key) if isinstance(value.get(key), list) else []
@@ -1910,75 +1762,6 @@ def _todo_summary_monitor_writeback_contract(value: dict[str, Any] | None) -> di
 
 def _todo_summary_monitor_writeback_supported(value: dict[str, Any] | None) -> bool:
     return projection_todo_summary_monitor_writeback_supported(value)
-
-
-def _handoff_ready_successor_todo_ids(value: dict[str, Any]) -> set[str]:
-    ready: set[str] = set()
-    for gate in _todo_summary_handoff_gates(value):
-        if not isinstance(gate, dict):
-            continue
-        if str(gate.get("gate_state") or "") != HandoffGateState.CLEARED_WITH_SUCCESSOR.value:
-            continue
-        successor_ids = gate.get("successor_todo_ids")
-        if not isinstance(successor_ids, list):
-            continue
-        for todo_id in successor_ids:
-            normalized = normalize_todo_id(todo_id)
-            if normalized:
-                ready.add(normalized)
-    return ready
-
-
-def _todo_summary_handoff_gates(value: dict[str, Any]) -> list[dict[str, Any]]:
-    projected = value.get("handoff_gates")
-    if isinstance(projected, list):
-        return [item for item in projected if isinstance(item, dict)]
-    source_items = value.get("items") if isinstance(value.get("items"), list) else []
-    return build_todo_handoff_gate_states(source_items)
-
-
-def _handoff_gate_lanes(
-    value: dict[str, Any],
-    *,
-    agent_identity: dict[str, Any] | None,
-) -> dict[str, Any]:
-    handoff_gates = _todo_summary_handoff_gates(value)
-    if not handoff_gates:
-        return {}
-    lanes: dict[str, Any] = {
-        "handoff_gate_count": len(handoff_gates),
-        "handoff_gates": handoff_gates[:TODO_BACKLOG_ITEM_LIMIT],
-    }
-    agent_id = (
-        normalize_todo_claimed_by(agent_identity.get("agent_id"))
-        if isinstance(agent_identity, dict)
-        else None
-    )
-    if agent_id:
-        current_agent_items = [
-            item
-            for item in handoff_gates
-            if normalize_todo_blocks_agent(item.get("blocks_agent")) == agent_id
-        ]
-        cleared_without_successor = [
-            item
-            for item in current_agent_items
-            if item.get("gate_state")
-            == HandoffGateState.CLEARED_WITHOUT_SUCCESSOR.value
-        ]
-        lanes.update(
-            {
-                "current_agent_handoff_gate_count": len(current_agent_items),
-                "current_agent_handoff_gates": current_agent_items[:TODO_BACKLOG_ITEM_LIMIT],
-                "current_agent_cleared_without_successor_handoff_count": len(
-                    cleared_without_successor
-                ),
-                "current_agent_cleared_without_successor_handoff_gates": (
-                    cleared_without_successor[:TODO_BACKLOG_ITEM_LIMIT]
-                ),
-            }
-        )
-    return lanes
 
 
 def _is_user_gate_todo_item(item: dict[str, Any]) -> bool:
@@ -2111,15 +1894,17 @@ def _summarize_user_todos(
         )
     )
     summary.update(
-        _handoff_gate_lanes(
+        build_todo_handoff_gate_lanes(
             value,
             agent_identity=agent_identity,
+            item_limit=TODO_BACKLOG_ITEM_LIMIT,
         )
     )
     summary.update(
-        _route_continuation_replan_lanes(
+        build_todo_route_continuation_lanes(
             value,
             agent_identity=agent_identity,
+            item_limit=TODO_BACKLOG_ITEM_LIMIT,
         )
     )
     summary.update(
@@ -2267,15 +2052,17 @@ def _summarize_project_asset_todos(
         )
     )
     summary.update(
-        _handoff_gate_lanes(
+        build_todo_handoff_gate_lanes(
             value,
             agent_identity=agent_identity,
+            item_limit=TODO_BACKLOG_ITEM_LIMIT,
         )
     )
     summary.update(
-        _route_continuation_replan_lanes(
+        build_todo_route_continuation_lanes(
             value,
             agent_identity=agent_identity,
+            item_limit=TODO_BACKLOG_ITEM_LIMIT,
         )
     )
     if claimed_open_items or value.get("claimed_open_count"):


### PR DESCRIPTION
## Summary
- move handoff gate summary/lane helpers and route-continuation lane projection into the todo bounded context
- keep quota as a consumer of todo read-model lanes instead of owning the route-continuation state-machine helper logic
- add direct todo-context canaries for handoff gate ready successors and route-continuation current/unclaimed/other-agent filtering

## Validation
- python3 -m py_compile loopx/control_plane/todos/handoff_gate.py loopx/control_plane/todos/route_continuation.py loopx/quota.py examples/control_plane/work-lane-contract-smoke.py examples/control_plane/quota-cleared-blocker-successor-gate-smoke.py
- PYTHONPATH=. python3 examples/control_plane/quota-cleared-blocker-successor-gate-smoke.py
- PYTHONPATH=. python3 examples/control_plane/work-lane-contract-smoke.py
- PYTHONPATH=. python3 examples/control_plane/quota-replan-decision-plane-smoke.py
- PYTHONPATH=. python3 examples/control_plane/quota-resume-gated-open-todo-smoke.py
- PYTHONPATH=. python3 examples/control_plane/todo-succession-contract-smoke.py
- PYTHONPATH=. python3 examples/control_plane/agent-scope-projection-characterization-smoke.py
- PYTHONPATH=. python3 examples/control_plane/todo-projection-shared-helper-smoke.py
- PYTHONPATH=. python3 examples/control_plane/control-plane-risk-characterization-smoke.py
- PYTHONPATH=. python3 examples/control_plane/control-plane-integrated-canary-smoke.py
- PYTHONPATH=. python3 examples/control_plane/monitor-scheduler-contract-smoke.py
- PYTHONPATH=. python3 examples/control_plane/bounded-context-namespace-smoke.py
- PYTHONPATH=. python3 examples/control_plane/check-public-boundary-smoke.py
- PYTHONPATH=. python3 examples/control_plane/repo-python-line-budget-smoke.py
- PYTHONPATH=. python3 examples/control_plane/todo-route-continuation-lanes-smoke.py
- git diff --check
- PYTHONPATH=. python3 -m loopx.cli canary premerge --from-git-diff --tier standard --timeout-seconds 120 --format json

Premerge gate passed locally with merge_gate_passed=true and self_merge_allowed=true.