### PR TITLE
Move deferred resume lanes into todo context

### DIFF
--- a/examples/control_plane/todo-deferred-resume-lanes-smoke.py
+++ b/examples/control_plane/todo-deferred-resume-lanes-smoke.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Smoke-test todo deferred/resume-blocked lane projection helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.todos.deferred_resume import (  # noqa: E402
+    TODO_DEFERRED_RESUME_SELECTION_POLICY,
+    TODO_MONITOR_BLOCKED_RESUME_SELECTION_POLICY,
+    build_todo_deferred_visibility_lanes,
+    build_todo_resume_blocked_visibility_lanes,
+    todo_summary_monitor_blocked_resume_items,
+    todo_summary_resume_blocked_items,
+)
+
+
+CURRENT_AGENT = "codex-product-capability"
+OTHER_AGENT = "codex-main-control"
+
+
+def monitor_todo() -> dict:
+    return {
+        "index": 1,
+        "todo_id": "todo_monitor_open",
+        "text": "[P1 monitor] Watch the upstream signal.",
+        "status": "open",
+        "task_class": "continuous_monitor",
+        "claimed_by": CURRENT_AGENT,
+    }
+
+
+def blocked_advancement(
+    todo_id: str,
+    *,
+    index: int,
+    claimed_by: str | None,
+    target_task_class: str | None = "continuous_monitor",
+    target_status: str = "open",
+) -> dict:
+    condition = {
+        "target_todo_id": "todo_monitor_open",
+        "target_status": target_status,
+    }
+    if target_task_class is not None:
+        condition["target_task_class"] = target_task_class
+    item = {
+        "index": index,
+        "todo_id": todo_id,
+        "text": f"[P1] Resume blocked advancement {todo_id}.",
+        "status": "open",
+        "task_class": "advancement_task",
+        "claimed_by": claimed_by,
+        "resume_when": "todo_done:todo_monitor_open",
+        "resume_ready": False,
+        "resume_condition": condition,
+    }
+    return {key: value for key, value in item.items() if value is not None}
+
+
+def ready_deferred(todo_id: str, *, index: int, claimed_by: str | None) -> dict:
+    item = {
+        "index": index,
+        "todo_id": todo_id,
+        "text": f"[P1] Ready deferred candidate {todo_id}.",
+        "status": "deferred",
+        "task_class": "advancement_task",
+        "claimed_by": claimed_by,
+        "resume_when": "todo_done:todo_gate",
+        "resume_ready": True,
+        "required_write_scopes": [" loopx/** ", "loopx/**"],
+        "decision_scope": "direction:action:resume",
+    }
+    return {key: value for key, value in item.items() if value is not None}
+
+
+def assert_deferred_resume_lanes_filter_current_unclaimed_and_other_agents() -> None:
+    summary = {
+        "schema_version": "todo_summary_v0",
+        "items": [
+            {
+                "index": 0,
+                "todo_id": "todo_deferred_backlog",
+                "text": "[P2] Deferred backlog item.",
+                "status": "deferred",
+                "task_class": "advancement_task",
+            },
+        ],
+        "deferred_resume_candidates": [
+            ready_deferred("todo_current_ready", index=2, claimed_by=CURRENT_AGENT),
+            ready_deferred("todo_unclaimed_ready", index=3, claimed_by=None),
+            ready_deferred("todo_other_ready", index=4, claimed_by=OTHER_AGENT),
+            {
+                **ready_deferred("todo_not_ready", index=5, claimed_by=CURRENT_AGENT),
+                "resume_ready": False,
+            },
+        ],
+    }
+
+    lanes = build_todo_deferred_visibility_lanes(
+        summary,
+        agent_identity={"agent_id": CURRENT_AGENT},
+        item_limit=10,
+    )
+    assert lanes["deferred_count"] == 1, lanes
+    assert lanes["deferred_visibility_limit"] == 10, lanes
+    assert lanes["deferred_items"][0]["todo_id"] == "todo_deferred_backlog", lanes
+    assert [item["todo_id"] for item in lanes["deferred_resume_candidates"]] == [
+        "todo_current_ready",
+        "todo_unclaimed_ready",
+        "todo_other_ready",
+    ], lanes
+    assert lanes["current_agent_deferred_resume_count"] == 1, lanes
+    assert lanes["unclaimed_deferred_resume_count"] == 1, lanes
+    assert lanes["other_agent_deferred_resume_count"] == 1, lanes
+    current = lanes["current_agent_deferred_resume_candidates"][0]
+    assert current["required_write_scopes"] == ["loopx/**"], current
+    assert current["decision_scope"]["scope_key"] == "resume", current
+    assert lanes["deferred_resume_selection_policy"] == (
+        TODO_DEFERRED_RESUME_SELECTION_POLICY
+    ), lanes
+
+
+def assert_monitor_blocked_resume_lanes_filter_by_claim_and_monitor_target() -> None:
+    current = blocked_advancement(
+        "todo_current_blocked",
+        index=2,
+        claimed_by=CURRENT_AGENT,
+    )
+    unclaimed = blocked_advancement(
+        "todo_unclaimed_blocked",
+        index=3,
+        claimed_by=None,
+        target_task_class=None,
+    )
+    other = blocked_advancement(
+        "todo_other_blocked",
+        index=4,
+        claimed_by=OTHER_AGENT,
+    )
+    non_monitor = blocked_advancement(
+        "todo_non_monitor_blocked",
+        index=5,
+        claimed_by=CURRENT_AGENT,
+        target_task_class="advancement_task",
+    )
+    non_monitor["resume_condition"]["target_todo_id"] = "todo_regular_open"
+    summary = {
+        "schema_version": "todo_summary_v0",
+        "items": [monitor_todo(), current, unclaimed, other, non_monitor],
+        "backlog_items": [current],
+    }
+
+    resume_blocked = todo_summary_resume_blocked_items(summary)
+    assert [item["todo_id"] for item in resume_blocked] == [
+        "todo_current_blocked",
+        "todo_unclaimed_blocked",
+        "todo_other_blocked",
+        "todo_non_monitor_blocked",
+    ], resume_blocked
+    monitor_blocked = todo_summary_monitor_blocked_resume_items(summary)
+    assert [item["todo_id"] for item in monitor_blocked] == [
+        "todo_current_blocked",
+        "todo_unclaimed_blocked",
+        "todo_other_blocked",
+    ], monitor_blocked
+    assert all(
+        item["blocking_monitor_todo_id"] == "todo_monitor_open"
+        for item in monitor_blocked
+    ), monitor_blocked
+
+    lanes = build_todo_resume_blocked_visibility_lanes(
+        summary,
+        agent_identity={"agent_id": CURRENT_AGENT},
+        item_limit=10,
+    )
+    assert lanes["resume_blocked_count"] == 4, lanes
+    assert lanes["monitor_blocked_resume_count"] == 3, lanes
+    assert lanes["current_agent_monitor_blocked_resume_count"] == 1, lanes
+    assert lanes["unclaimed_monitor_blocked_resume_count"] == 1, lanes
+    assert lanes["other_agent_monitor_blocked_resume_count"] == 1, lanes
+    assert lanes["monitor_blocked_resume_selection_policy"] == (
+        TODO_MONITOR_BLOCKED_RESUME_SELECTION_POLICY
+    ), lanes
+
+
+def main() -> int:
+    assert_deferred_resume_lanes_filter_current_unclaimed_and_other_agents()
+    assert_monitor_blocked_resume_lanes_filter_by_claim_and_monitor_target()
+    print("todo-deferred-resume-lanes-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/control_plane/todo-projection-shared-helper-smoke.py
+++ b/examples/control_plane/todo-projection-shared-helper-smoke.py
@@ -15,7 +15,6 @@ if str(REPO_ROOT) not in sys.path:
 from loopx.quota import (  # noqa: E402
     _claimed_visibility_items as quota_claimed_visibility_items,
     _first_executable_todo_item as quota_first_executable_todo_item,
-    _todo_item_is_deferred as quota_todo_item_is_deferred,
     _todo_summary_monitor_items as quota_todo_summary_monitor_items,
     _todo_projection_sort_key as quota_todo_projection_sort_key,
     _todo_task_class as quota_todo_task_class,
@@ -278,7 +277,6 @@ def assert_deferred_helper_parity() -> None:
     for predicate in (
         shared_todo_item_is_deferred,
         status_todo_item_is_deferred,
-        quota_todo_item_is_deferred,
     ):
         assert predicate(deferred) is True, deferred
         assert predicate(open_item) is False, open_item

--- a/loopx/control_plane/todos/deferred_resume.py
+++ b/loopx/control_plane/todos/deferred_resume.py
@@ -1,0 +1,398 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .contract import (
+    TODO_STATUS_OPEN,
+    TODO_TASK_CLASS_ADVANCEMENT,
+    TODO_TASK_CLASS_MONITOR,
+    normalize_required_write_scopes,
+    normalize_todo_claimed_by,
+    normalize_todo_decision_scope,
+    normalize_todo_id,
+    normalize_todo_required_decision_scopes,
+    normalize_todo_resume_when,
+    normalize_todo_status,
+    normalize_todo_task_class,
+)
+from .projection import todo_item_is_deferred, todo_projection_sort_key
+
+
+TODO_DEFERRED_RESUME_SELECTION_POLICY = (
+    "quota may wake the current side-agent only for ready deferred todos "
+    "claimed by that agent or unclaimed; other-agent deferred todos remain "
+    "diagnostic visibility"
+)
+TODO_MONITOR_BLOCKED_RESUME_SELECTION_POLICY = (
+    "open advancement todos gated by todo_done:<continuous_monitor> must "
+    "project as successor replan/state repair instead of quiet monitor wait"
+)
+
+
+def _todo_task_class(item: dict[str, Any]) -> str:
+    text = " ".join(
+        str(value or "")
+        for value in (item.get("title"), item.get("text"))
+        if str(value or "").strip()
+    )
+    return normalize_todo_task_class(
+        item.get("task_class"),
+        text=text,
+        action_kind=item.get("action_kind"),
+    )
+
+
+def _compact_deferred_resume_item(
+    item: dict[str, Any],
+    *,
+    text: str,
+) -> dict[str, Any]:
+    compact: dict[str, Any] = {
+        "index": item.get("index"),
+        "text": text,
+    }
+    for key in (
+        "schema_version",
+        "todo_id",
+        "role",
+        "status",
+        "priority",
+        "title",
+        "archive_state",
+        "source_section",
+        "task_class",
+        "action_kind",
+        "required_write_scopes",
+        "required_capabilities",
+        "target_capabilities",
+        "decision_scope",
+        "required_decision_scopes",
+        "claimed_by",
+        "blocks_agent",
+        "unblocks_todo_id",
+        "resume_when",
+        "resume_condition",
+        "resume_ready",
+        "no_followup",
+        "successor_todo_ids",
+        "target_key",
+        "cadence",
+        "next_due_at",
+        "expires_at",
+        "last_checked_at",
+        "result_hash",
+        "consecutive_no_change",
+        "material_change",
+        "max_no_change_before_replan",
+        "route_continuation_replan_required",
+        "route_continuation_reason",
+        "route_id",
+        "route_key",
+        "completed_at",
+        "updated_at",
+        "superseded_by",
+    ):
+        if item.get(key) is not None:
+            compact[key] = item.get(key)
+    required_write_scopes = normalize_required_write_scopes(compact.get("required_write_scopes"))
+    if required_write_scopes:
+        compact["required_write_scopes"] = required_write_scopes
+    else:
+        compact.pop("required_write_scopes", None)
+    decision_scope = normalize_todo_decision_scope(compact.get("decision_scope"))
+    if decision_scope:
+        compact["decision_scope"] = decision_scope
+    else:
+        compact.pop("decision_scope", None)
+    required_decision_scopes = normalize_todo_required_decision_scopes(
+        compact.get("required_decision_scopes")
+    )
+    if required_decision_scopes:
+        compact["required_decision_scopes"] = required_decision_scopes
+    else:
+        compact.pop("required_decision_scopes", None)
+    compact["task_class"] = _todo_task_class(compact)
+    return compact
+
+
+def todo_summary_deferred_items(
+    value: dict[str, Any],
+    key: str,
+) -> list[dict[str, Any]]:
+    if not isinstance(value, dict):
+        return []
+    source_items = value.get(key) if isinstance(value.get(key), list) else []
+    if not source_items and key == "deferred_items":
+        source_items = [
+            item
+            for item in value.get("items", [])
+            if isinstance(item, dict) and todo_item_is_deferred(item)
+        ]
+    items: list[dict[str, Any]] = []
+    for item in source_items:
+        if not isinstance(item, dict):
+            continue
+        text = str(item.get("text") or "").strip()
+        if not text:
+            continue
+        compact = _compact_deferred_resume_item(item, text=text)
+        resume_when = normalize_todo_resume_when(item.get("resume_when"))
+        if resume_when:
+            compact["resume_when"] = resume_when
+        if item.get("resume_condition") is not None:
+            compact["resume_condition"] = item.get("resume_condition")
+        if item.get("resume_ready") is not None:
+            compact["resume_ready"] = bool(item.get("resume_ready"))
+        if todo_item_is_deferred(compact):
+            items.append(compact)
+    return sorted(items, key=todo_projection_sort_key)
+
+
+def _dedupe_todo_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    unique: list[dict[str, Any]] = []
+    seen: set[tuple[str, str, Any]] = set()
+    for item in items:
+        todo_id = normalize_todo_id(item.get("todo_id")) or ""
+        text = str(item.get("text") or "").strip()
+        identity = (todo_id, text, item.get("index"))
+        if identity in seen:
+            continue
+        seen.add(identity)
+        unique.append(item)
+    return unique
+
+
+def todo_summary_resume_blocked_items(value: dict[str, Any]) -> list[dict[str, Any]]:
+    if not isinstance(value, dict):
+        return []
+    source_items = (
+        value.get("resume_blocked_items")
+        if isinstance(value.get("resume_blocked_items"), list)
+        else []
+    )
+    if not source_items:
+        for key in ("items", "backlog_items", "first_open_items"):
+            raw_items = value.get(key) if isinstance(value.get(key), list) else []
+            source_items.extend(item for item in raw_items if isinstance(item, dict))
+    items: list[dict[str, Any]] = []
+    for item in source_items:
+        if not isinstance(item, dict):
+            continue
+        text = str(item.get("text") or "").strip()
+        if not text:
+            continue
+        if item.get("done") is True:
+            continue
+        if not normalize_todo_resume_when(item.get("resume_when")):
+            continue
+        if item.get("resume_ready") is not False:
+            continue
+        items.append(_compact_deferred_resume_item(item, text=text))
+    return sorted(_dedupe_todo_items(items), key=todo_projection_sort_key)
+
+
+def _monitor_target_todo_ids(value: dict[str, Any]) -> set[str]:
+    ids: set[str] = set()
+    for key in (
+        "monitor_open_items",
+        "current_agent_claimed_monitor_items",
+        "claimed_monitor_open_items",
+        "items",
+        "backlog_items",
+        "first_open_items",
+    ):
+        source_items = value.get(key) if isinstance(value.get(key), list) else []
+        for item in source_items:
+            if not isinstance(item, dict):
+                continue
+            todo_id = normalize_todo_id(item.get("todo_id"))
+            if not todo_id:
+                continue
+            if _todo_task_class(item) == TODO_TASK_CLASS_MONITOR:
+                ids.add(todo_id)
+    return ids
+
+
+def todo_summary_monitor_blocked_resume_items(
+    value: dict[str, Any],
+) -> list[dict[str, Any]]:
+    monitor_ids = _monitor_target_todo_ids(value)
+    candidates: list[dict[str, Any]] = []
+    for item in todo_summary_resume_blocked_items(value):
+        if _todo_task_class(item) != TODO_TASK_CLASS_ADVANCEMENT:
+            continue
+        condition = (
+            item.get("resume_condition")
+            if isinstance(item.get("resume_condition"), dict)
+            else {}
+        )
+        target_todo_id = normalize_todo_id(
+            condition.get("target_todo_id") or condition.get("target")
+        )
+        target_status = normalize_todo_status(condition.get("target_status"))
+        target_task_class = normalize_todo_task_class(
+            condition.get("target_task_class"),
+            text="",
+        )
+        if target_status != TODO_STATUS_OPEN:
+            continue
+        if target_task_class != TODO_TASK_CLASS_MONITOR and target_todo_id not in monitor_ids:
+            continue
+        candidate = dict(item)
+        if target_todo_id:
+            candidate["blocking_monitor_todo_id"] = target_todo_id
+        candidates.append(candidate)
+    return sorted(_dedupe_todo_items(candidates), key=todo_projection_sort_key)
+
+
+def _agent_claim_filtered_deferred_items(
+    items: list[dict[str, Any]],
+    *,
+    agent_id: str | None,
+    claim: str,
+) -> list[dict[str, Any]]:
+    selected: list[dict[str, Any]] = []
+    for item in items:
+        claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
+        if claim == "current" and claimed_by != agent_id:
+            continue
+        if claim == "unclaimed" and claimed_by:
+            continue
+        if claim == "other" and (not claimed_by or claimed_by == agent_id):
+            continue
+        selected.append(item)
+    return selected
+
+
+def build_todo_resume_blocked_visibility_lanes(
+    value: dict[str, Any],
+    *,
+    agent_identity: dict[str, Any] | None,
+    item_limit: int,
+) -> dict[str, Any]:
+    resume_blocked_items = todo_summary_resume_blocked_items(value)
+    monitor_blocked_items = todo_summary_monitor_blocked_resume_items(value)
+    if not resume_blocked_items and not monitor_blocked_items:
+        return {}
+    lanes: dict[str, Any] = {
+        "resume_blocked_count": len(resume_blocked_items),
+        "resume_blocked_items": resume_blocked_items[:item_limit],
+    }
+    if monitor_blocked_items:
+        lanes.update(
+            {
+                "monitor_blocked_resume_count": len(monitor_blocked_items),
+                "monitor_blocked_resume_candidates": monitor_blocked_items[
+                    :item_limit
+                ],
+            }
+        )
+    agent_id = (
+        normalize_todo_claimed_by(agent_identity.get("agent_id"))
+        if isinstance(agent_identity, dict)
+        else None
+    )
+    if agent_id and monitor_blocked_items:
+        current_agent_candidates = _agent_claim_filtered_deferred_items(
+            monitor_blocked_items,
+            agent_id=agent_id,
+            claim="current",
+        )
+        unclaimed_candidates = _agent_claim_filtered_deferred_items(
+            monitor_blocked_items,
+            agent_id=agent_id,
+            claim="unclaimed",
+        )
+        other_agent_candidates = _agent_claim_filtered_deferred_items(
+            monitor_blocked_items,
+            agent_id=agent_id,
+            claim="other",
+        )
+        lanes.update(
+            {
+                "current_agent_monitor_blocked_resume_candidates": (
+                    current_agent_candidates[:item_limit]
+                ),
+                "unclaimed_monitor_blocked_resume_candidates": (
+                    unclaimed_candidates[:item_limit]
+                ),
+                "other_agent_monitor_blocked_resume_candidates": (
+                    other_agent_candidates[:item_limit]
+                ),
+                "current_agent_monitor_blocked_resume_count": len(
+                    current_agent_candidates
+                ),
+                "unclaimed_monitor_blocked_resume_count": len(unclaimed_candidates),
+                "other_agent_monitor_blocked_resume_count": len(other_agent_candidates),
+                "monitor_blocked_resume_selection_policy": (
+                    TODO_MONITOR_BLOCKED_RESUME_SELECTION_POLICY
+                ),
+            }
+        )
+    return lanes
+
+
+def build_todo_deferred_visibility_lanes(
+    value: dict[str, Any],
+    *,
+    agent_identity: dict[str, Any] | None,
+    item_limit: int,
+) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    deferred_items = todo_summary_deferred_items(value, "deferred_items")
+    deferred_resume_candidates = [
+        item
+        for item in todo_summary_deferred_items(value, "deferred_resume_candidates")
+        if item.get("resume_ready") is True
+    ]
+    if not deferred_items and not deferred_resume_candidates and not value.get("deferred_count"):
+        return {}
+
+    lanes: dict[str, Any] = {
+        "deferred_count": value.get("deferred_count", len(deferred_items)),
+        "deferred_visibility_limit": item_limit,
+        "deferred_items": deferred_items[:item_limit],
+        "deferred_resume_candidates": deferred_resume_candidates[:item_limit],
+    }
+    agent_id = (
+        normalize_todo_claimed_by(agent_identity.get("agent_id"))
+        if isinstance(agent_identity, dict)
+        else None
+    )
+    if agent_id:
+        current_agent_candidates = _agent_claim_filtered_deferred_items(
+            deferred_resume_candidates,
+            agent_id=agent_id,
+            claim="current",
+        )
+        unclaimed_candidates = _agent_claim_filtered_deferred_items(
+            deferred_resume_candidates,
+            agent_id=agent_id,
+            claim="unclaimed",
+        )
+        other_agent_candidates = _agent_claim_filtered_deferred_items(
+            deferred_resume_candidates,
+            agent_id=agent_id,
+            claim="other",
+        )
+        lanes.update(
+            {
+                "current_agent_deferred_resume_candidates": (
+                    current_agent_candidates[:item_limit]
+                ),
+                "unclaimed_deferred_resume_candidates": (
+                    unclaimed_candidates[:item_limit]
+                ),
+                "other_agent_deferred_resume_candidates": (
+                    other_agent_candidates[:item_limit]
+                ),
+                "current_agent_deferred_resume_count": len(current_agent_candidates),
+                "unclaimed_deferred_resume_count": len(unclaimed_candidates),
+                "other_agent_deferred_resume_count": len(other_agent_candidates),
+                "deferred_resume_selection_policy": (
+                    TODO_DEFERRED_RESUME_SELECTION_POLICY
+                ),
+            }
+        )
+    return lanes

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -121,6 +121,10 @@ from .control_plane.todos.contract import (
     normalize_todo_status,
     normalize_todo_task_class,
 )
+from .control_plane.todos.deferred_resume import (
+    build_todo_deferred_visibility_lanes,
+    build_todo_resume_blocked_visibility_lanes,
+)
 from .control_plane.todos.handoff_gate import (
     build_todo_handoff_gate_lanes,
     handoff_ready_successor_todo_ids as todo_handoff_ready_successor_todo_ids,
@@ -132,7 +136,6 @@ from .control_plane.todos.projection import (
     todo_index_rank as projection_todo_index_rank,
     todo_item_expires_at as projection_todo_item_expires_at,
     todo_item_is_actionable_open as projection_todo_item_is_actionable_open,
-    todo_item_is_deferred as projection_todo_item_is_deferred,
     todo_item_is_due_monitor as projection_todo_item_is_due_monitor,
     todo_item_is_expired_monitor as projection_todo_item_is_expired_monitor,
     todo_item_missing_monitor_schedule as projection_todo_item_missing_monitor_schedule,
@@ -1430,275 +1433,6 @@ def _todo_summary_visibility_lanes(
     return lanes
 
 
-def _todo_item_is_deferred(item: dict[str, Any]) -> bool:
-    return projection_todo_item_is_deferred(item)
-
-
-def _todo_summary_deferred_items(value: dict[str, Any], key: str) -> list[dict[str, Any]]:
-    if not isinstance(value, dict):
-        return []
-    source_items = value.get(key) if isinstance(value.get(key), list) else []
-    if not source_items and key == "deferred_items":
-        source_items = [
-            item
-            for item in value.get("items", [])
-            if isinstance(item, dict) and _todo_item_is_deferred(item)
-        ]
-    items: list[dict[str, Any]] = []
-    for item in source_items:
-        if not isinstance(item, dict):
-            continue
-        text = str(item.get("text") or "").strip()
-        if not text:
-            continue
-        compact = _compact_todo_summary_item(item, text=text)
-        resume_when = normalize_todo_resume_when(item.get("resume_when"))
-        if resume_when:
-            compact["resume_when"] = resume_when
-        if item.get("resume_condition") is not None:
-            compact["resume_condition"] = item.get("resume_condition")
-        if item.get("resume_ready") is not None:
-            compact["resume_ready"] = bool(item.get("resume_ready"))
-        if _todo_item_is_deferred(compact):
-            items.append(compact)
-    return sorted(items, key=_todo_projection_sort_key)
-
-
-def _dedupe_todo_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
-    unique: list[dict[str, Any]] = []
-    seen: set[tuple[str, str, Any]] = set()
-    for item in items:
-        todo_id = normalize_todo_id(item.get("todo_id")) or ""
-        text = str(item.get("text") or "").strip()
-        identity = (todo_id, text, item.get("index"))
-        if identity in seen:
-            continue
-        seen.add(identity)
-        unique.append(item)
-    return unique
-
-
-def _todo_summary_resume_blocked_items(value: dict[str, Any]) -> list[dict[str, Any]]:
-    if not isinstance(value, dict):
-        return []
-    source_items = (
-        value.get("resume_blocked_items")
-        if isinstance(value.get("resume_blocked_items"), list)
-        else []
-    )
-    if not source_items:
-        for key in ("items", "backlog_items", "first_open_items"):
-            raw_items = value.get(key) if isinstance(value.get(key), list) else []
-            source_items.extend(item for item in raw_items if isinstance(item, dict))
-    items: list[dict[str, Any]] = []
-    for item in source_items:
-        if not isinstance(item, dict):
-            continue
-        text = str(item.get("text") or "").strip()
-        if not text:
-            continue
-        if item.get("done") is True:
-            continue
-        if not normalize_todo_resume_when(item.get("resume_when")):
-            continue
-        if item.get("resume_ready") is not False:
-            continue
-        items.append(_compact_todo_summary_item(item, text=text))
-    return sorted(_dedupe_todo_items(items), key=_todo_projection_sort_key)
-
-
-def _monitor_target_todo_ids(value: dict[str, Any]) -> set[str]:
-    ids: set[str] = set()
-    for key in (
-        "monitor_open_items",
-        "current_agent_claimed_monitor_items",
-        "claimed_monitor_open_items",
-        "items",
-        "backlog_items",
-        "first_open_items",
-    ):
-        source_items = value.get(key) if isinstance(value.get(key), list) else []
-        for item in source_items:
-            if not isinstance(item, dict):
-                continue
-            todo_id = normalize_todo_id(item.get("todo_id"))
-            if not todo_id:
-                continue
-            if _todo_task_class(item) == TODO_TASK_CLASS_MONITOR:
-                ids.add(todo_id)
-    return ids
-
-
-def _todo_summary_monitor_blocked_resume_items(value: dict[str, Any]) -> list[dict[str, Any]]:
-    monitor_ids = _monitor_target_todo_ids(value)
-    candidates: list[dict[str, Any]] = []
-    for item in _todo_summary_resume_blocked_items(value):
-        if _todo_task_class(item) != TODO_TASK_CLASS_ADVANCEMENT:
-            continue
-        condition = item.get("resume_condition") if isinstance(item.get("resume_condition"), dict) else {}
-        target_todo_id = normalize_todo_id(
-            condition.get("target_todo_id") or condition.get("target")
-        )
-        target_status = normalize_todo_status(condition.get("target_status"))
-        target_task_class = normalize_todo_task_class(
-            condition.get("target_task_class"),
-            text="",
-        )
-        if target_status != TODO_STATUS_OPEN:
-            continue
-        if target_task_class != TODO_TASK_CLASS_MONITOR and target_todo_id not in monitor_ids:
-            continue
-        candidate = dict(item)
-        if target_todo_id:
-            candidate["blocking_monitor_todo_id"] = target_todo_id
-        candidates.append(candidate)
-    return sorted(_dedupe_todo_items(candidates), key=_todo_projection_sort_key)
-
-
-def _agent_claim_filtered_deferred_items(
-    items: list[dict[str, Any]],
-    *,
-    agent_id: str | None,
-    claim: str,
-) -> list[dict[str, Any]]:
-    selected: list[dict[str, Any]] = []
-    for item in items:
-        claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
-        if claim == "current" and claimed_by != agent_id:
-            continue
-        if claim == "unclaimed" and claimed_by:
-            continue
-        if claim == "other" and (not claimed_by or claimed_by == agent_id):
-            continue
-        selected.append(item)
-    return selected
-
-
-def _resume_blocked_visibility_lanes(
-    value: dict[str, Any],
-    *,
-    agent_identity: dict[str, Any] | None,
-) -> dict[str, Any]:
-    resume_blocked_items = _todo_summary_resume_blocked_items(value)
-    monitor_blocked_items = _todo_summary_monitor_blocked_resume_items(value)
-    if not resume_blocked_items and not monitor_blocked_items:
-        return {}
-    lanes: dict[str, Any] = {
-        "resume_blocked_count": len(resume_blocked_items),
-        "resume_blocked_items": resume_blocked_items[:TODO_DEFERRED_VISIBILITY_LIMIT],
-    }
-    if monitor_blocked_items:
-        lanes.update(
-            {
-                "monitor_blocked_resume_count": len(monitor_blocked_items),
-                "monitor_blocked_resume_candidates": monitor_blocked_items[
-                    :TODO_DEFERRED_VISIBILITY_LIMIT
-                ],
-            }
-        )
-    agent_id = (
-        normalize_todo_claimed_by(agent_identity.get("agent_id"))
-        if isinstance(agent_identity, dict)
-        else None
-    )
-    if agent_id and monitor_blocked_items:
-        current_agent_candidates = _agent_claim_filtered_deferred_items(
-            monitor_blocked_items,
-            agent_id=agent_id,
-            claim="current",
-        )
-        unclaimed_candidates = _agent_claim_filtered_deferred_items(
-            monitor_blocked_items,
-            agent_id=agent_id,
-            claim="unclaimed",
-        )
-        other_agent_candidates = _agent_claim_filtered_deferred_items(
-            monitor_blocked_items,
-            agent_id=agent_id,
-            claim="other",
-        )
-        lanes.update(
-            {
-                "current_agent_monitor_blocked_resume_candidates": current_agent_candidates[
-                    :TODO_DEFERRED_VISIBILITY_LIMIT
-                ],
-                "unclaimed_monitor_blocked_resume_candidates": unclaimed_candidates[
-                    :TODO_DEFERRED_VISIBILITY_LIMIT
-                ],
-                "other_agent_monitor_blocked_resume_candidates": other_agent_candidates[
-                    :TODO_DEFERRED_VISIBILITY_LIMIT
-                ],
-                "current_agent_monitor_blocked_resume_count": len(current_agent_candidates),
-                "unclaimed_monitor_blocked_resume_count": len(unclaimed_candidates),
-                "other_agent_monitor_blocked_resume_count": len(other_agent_candidates),
-                "monitor_blocked_resume_selection_policy": (
-                    "open advancement todos gated by todo_done:<continuous_monitor> "
-                    "must project as successor replan/state repair instead of quiet monitor wait"
-                ),
-            }
-        )
-    return lanes
-
-
-def _deferred_visibility_lanes(
-    value: dict[str, Any],
-    *,
-    agent_identity: dict[str, Any] | None,
-) -> dict[str, Any]:
-    deferred_items = _todo_summary_deferred_items(value, "deferred_items")
-    deferred_resume_candidates = [
-        item
-        for item in _todo_summary_deferred_items(value, "deferred_resume_candidates")
-        if item.get("resume_ready") is True
-    ]
-    if not deferred_items and not deferred_resume_candidates and not value.get("deferred_count"):
-        return {}
-
-    lanes: dict[str, Any] = {
-        "deferred_count": value.get("deferred_count", len(deferred_items)),
-        "deferred_visibility_limit": TODO_DEFERRED_VISIBILITY_LIMIT,
-        "deferred_items": deferred_items[:TODO_DEFERRED_VISIBILITY_LIMIT],
-        "deferred_resume_candidates": deferred_resume_candidates[:TODO_DEFERRED_VISIBILITY_LIMIT],
-    }
-    agent_id = (
-        normalize_todo_claimed_by(agent_identity.get("agent_id"))
-        if isinstance(agent_identity, dict)
-        else None
-    )
-    if agent_id:
-        current_agent_candidates = _agent_claim_filtered_deferred_items(
-            deferred_resume_candidates,
-            agent_id=agent_id,
-            claim="current",
-        )
-        unclaimed_candidates = _agent_claim_filtered_deferred_items(
-            deferred_resume_candidates,
-            agent_id=agent_id,
-            claim="unclaimed",
-        )
-        other_agent_candidates = _agent_claim_filtered_deferred_items(
-            deferred_resume_candidates,
-            agent_id=agent_id,
-            claim="other",
-        )
-        lanes.update(
-            {
-                "current_agent_deferred_resume_candidates": current_agent_candidates[:TODO_DEFERRED_VISIBILITY_LIMIT],
-                "unclaimed_deferred_resume_candidates": unclaimed_candidates[:TODO_DEFERRED_VISIBILITY_LIMIT],
-                "other_agent_deferred_resume_candidates": other_agent_candidates[:TODO_DEFERRED_VISIBILITY_LIMIT],
-                "current_agent_deferred_resume_count": len(current_agent_candidates),
-                "unclaimed_deferred_resume_count": len(unclaimed_candidates),
-                "other_agent_deferred_resume_count": len(other_agent_candidates),
-                "deferred_resume_selection_policy": (
-                    "quota may wake the current side-agent only for ready deferred "
-                    "todos claimed by that agent or unclaimed; other-agent deferred "
-                    "todos remain diagnostic visibility"
-                ),
-            }
-        )
-    return lanes
-
-
 def _todo_summary_source_items(value: dict[str, Any]) -> list[dict[str, Any]]:
     source_keys = (
         "active_next_action_items",
@@ -1882,15 +1616,17 @@ def _summarize_user_todos(
         )
     )
     summary.update(
-        _deferred_visibility_lanes(
+        build_todo_deferred_visibility_lanes(
             value,
             agent_identity=agent_identity,
+            item_limit=TODO_DEFERRED_VISIBILITY_LIMIT,
         )
     )
     summary.update(
-        _resume_blocked_visibility_lanes(
+        build_todo_resume_blocked_visibility_lanes(
             value,
             agent_identity=agent_identity,
+            item_limit=TODO_DEFERRED_VISIBILITY_LIMIT,
         )
     )
     summary.update(
@@ -2046,9 +1782,10 @@ def _summarize_project_asset_todos(
         )
     )
     summary.update(
-        _deferred_visibility_lanes(
+        build_todo_deferred_visibility_lanes(
             value,
             agent_identity=agent_identity,
+            item_limit=TODO_DEFERRED_VISIBILITY_LIMIT,
         )
     )
     summary.update(


### PR DESCRIPTION
## Summary
- move deferred resume and monitor-blocked resume lane builders from quota into the todo bounded context
- keep quota as a consumer of todo read-model lanes for deferred/resume-blocked visibility
- add a direct canary for ready deferred filtering and advancement todos blocked by open continuous-monitor targets
- remove the old shared-helper smoke dependency on `quota._todo_item_is_deferred` instead of keeping a shim

## Validation
- `python3 -m py_compile loopx/control_plane/todos/deferred_resume.py loopx/quota.py examples/control_plane/todo-deferred-resume-lanes-smoke.py examples/control_plane/todo-projection-shared-helper-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/todo-deferred-resume-lanes-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/quota-resume-gated-open-todo-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/work-lane-contract-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/control-plane-risk-characterization-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/agent-scope-projection-characterization-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/todo-projection-shared-helper-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/quota-replan-decision-plane-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/monitor-scheduler-contract-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/todo-succession-contract-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/quota-cleared-blocker-successor-gate-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/bounded-context-namespace-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/check-public-boundary-smoke.py`
- `git diff --check`
- `PYTHONPATH=. python3 -m loopx.cli canary premerge --from-git-diff --tier standard --timeout-seconds 120 --format json`

Premerge gate passed locally with `merge_gate_passed=true` and `self_merge_allowed=true`.
