### PR TITLE
Fail fast when Codex CLI goal mode does not activate

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -378,6 +378,73 @@ def _assert_cli_goal_rate_limit_is_public_safe_retryable_stage() -> None:
     ]
 
 
+def _assert_cli_goal_active_timeout_is_public_countability_stage() -> None:
+    sys.path.insert(0, str(REPO_ROOT))
+    from loopx.benchmark_adapters.skillsbench_acp_relay import (
+        CodexExecConfig,
+        SkillsBenchLocalAcpRelay,
+    )
+    from loopx.benchmark_core.loop_protocol import CODEX_CLI_GOAL_BASELINE_ROUTE
+    from scripts.skillsbench_automation_loop import (
+        _apply_codex_cli_goal_countability_guard_attribution,
+        _merge_host_local_acp_relay_trace_summary,
+        _public_runner_prerequisites,
+    )
+
+    assert CodexExecConfig().goal_active_timeout_sec > 0
+
+    with tempfile.TemporaryDirectory() as temp:
+        trace_dir = Path(temp) / "trace"
+        relay = SkillsBenchLocalAcpRelay(
+            CodexExecConfig(worker_public_trace_dir=str(trace_dir))
+        )
+        relay._publish_codex_cli_goal_trace(
+            ok=False,
+            stage="goal_active_timeout",
+            goal_active_observed=False,
+            goal_terminal_observed=False,
+            first_action_observed=False,
+            bridge_summary_path=None,
+        )
+        plan = {
+            "route": CODEX_CLI_GOAL_BASELINE_ROUTE,
+            "host_local_acp_relay_trace_dir": str(trace_dir),
+            "runner_prerequisites": {},
+        }
+        trace: dict[str, object] = {}
+        _merge_host_local_acp_relay_trace_summary(plan, trace)
+
+    prerequisites = plan["runner_prerequisites"]
+    assert trace["codex_cli_goal_tui_trace_present"] is True, trace
+    assert trace["codex_cli_goal_tui_stage"] == "goal_active_timeout", trace
+    assert trace["codex_cli_goal_tui_goal_active_observed_count"] == 0
+    assert trace["codex_cli_goal_tui_first_action_observed_count"] == 0
+    assert trace["codex_cli_goal_tui_raw_material_recorded"] is False, trace
+
+    public_prerequisites = _public_runner_prerequisites(prerequisites)
+    assert public_prerequisites["codex_cli_goal_tui_stage"] == (
+        "goal_active_timeout"
+    )
+    assert public_prerequisites["codex_cli_goal_tui_stages"] == [
+        "goal_active_timeout"
+    ]
+
+    compact = {
+        "route": CODEX_CLI_GOAL_BASELINE_ROUTE,
+        "official_score_status": "completed",
+        "interaction_counters": trace,
+        "runner_prerequisites": prerequisites,
+        "failure_attribution_labels": ["official_score_zero_case_failure"],
+    }
+    assert _apply_codex_cli_goal_countability_guard_attribution(compact) is True
+    assert compact["score_failure_attribution"] == (
+        "skillsbench_codex_cli_goal_uncountable_goal_active_timeout"
+    )
+    contract = compact["codex_cli_goal_countability_contract"]
+    assert contract["goal_stage"] == "goal_active_timeout", contract
+    assert contract["raw_material_recorded"] is False, contract
+
+
 def _assert_cli_goal_input_is_submitted_as_one_buffer() -> None:
     sys.path.insert(0, str(REPO_ROOT))
     from loopx.codex_cli_goal_tui import build_codex_cli_goal_tui_input
@@ -473,6 +540,7 @@ def main() -> int:
     _assert_cli_goal_trace_merges_into_public_prerequisites()
     _assert_cli_goal_tui_ready_wait_tolerates_startup_warnings()
     _assert_cli_goal_rate_limit_is_public_safe_retryable_stage()
+    _assert_cli_goal_active_timeout_is_public_countability_stage()
     _assert_cli_goal_input_is_submitted_as_one_buffer()
     _assert_cli_goal_codex_api_proxy_is_runtime_only()
     print("skillsbench-codex-cli-goal-route-smoke ok")

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -547,6 +547,7 @@ class CodexExecConfig:
     worker_script: str | None = None
     stream_heartbeat_interval_sec: float = 120.0
     first_action_timeout_sec: float = 0.0
+    goal_active_timeout_sec: float = 180.0
     app_server_goal_followup_max: int = 0
     app_server_goal_prompt_style: str = "bridge-only"
     bridge_idle_timeout_sec: float = 0.0
@@ -1206,6 +1207,16 @@ class SkillsBenchLocalAcpRelay:
                 time.sleep(0.8)
                 self._tmux_submit_enter(tmux_name)
                 deadline = time.monotonic() + self._config.timeout_sec
+                goal_active_deadline = 0.0
+                if (
+                    bridge_summary_path is not None
+                    and self._config.goal_active_timeout_sec > 0
+                    and _prompt_requires_bridge_first_action(prompt_for_codex)
+                ):
+                    goal_active_deadline = (
+                        time.monotonic()
+                        + max(1.0, self._config.goal_active_timeout_sec)
+                    )
                 first_action_deadline = 0.0
                 if (
                     bridge_summary_path is not None
@@ -1272,6 +1283,28 @@ class SkillsBenchLocalAcpRelay:
                         )
                         return _recoverable_codex_turn_failure_message(
                             "codex_cli_goal_" + retryable_startup_blocker_stage
+                        )
+                    if (
+                        not goal_active_observed
+                        and not first_action_seen
+                        and goal_active_deadline
+                        and now >= goal_active_deadline
+                    ):
+                        self._tmux_kill_session(tmux_name)
+                        if bridge_summary_path is not None:
+                            self._publish_remote_bridge_agent_operations_trace(
+                                bridge_summary_path=bridge_summary_path,
+                            )
+                        self._publish_codex_cli_goal_trace(
+                            ok=False,
+                            stage="goal_active_timeout",
+                            goal_active_observed=False,
+                            goal_terminal_observed=goal_terminal_observed,
+                            first_action_observed=False,
+                            bridge_summary_path=bridge_summary_path,
+                        )
+                        return _recoverable_codex_turn_failure_message(
+                            "codex_cli_goal_goal_active_timeout"
                         )
                     if bridge_summary_path is not None:
                         try:

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -4861,6 +4861,11 @@ def _apply_codex_cli_goal_countability_guard_attribution(
         counters.get("codex_cli_goal_tui_trace_present") is True
         or runner_prerequisites.get("codex_cli_goal_tui_trace_present") is True
     )
+    goal_stage = str(
+        counters.get("codex_cli_goal_tui_stage")
+        or runner_prerequisites.get("codex_cli_goal_tui_stage")
+        or ""
+    )[:120]
     operation_trace_status = str(
         counters.get("remote_command_file_bridge_agent_operation_trace_status")
         or runner_prerequisites.get(
@@ -4875,6 +4880,8 @@ def _apply_codex_cli_goal_countability_guard_attribution(
         return False
 
     label = "skillsbench_codex_cli_goal_uncountable_no_task_activity"
+    if goal_stage == "goal_active_timeout":
+        label = "skillsbench_codex_cli_goal_uncountable_goal_active_timeout"
     if goal_failed and not missing_task_activity:
         label = "skillsbench_codex_cli_goal_uncountable_goal_failed"
     compact["score_failure_attribution"] = label
@@ -4908,6 +4915,7 @@ def _apply_codex_cli_goal_countability_guard_attribution(
         "first_blocker": label,
         "trace_present": trace_present,
         "ok_count": ok_count,
+        "goal_stage": goal_stage,
         "request_count": request_count,
         "task_facing_activity_count": task_facing_count,
         "operation_trace_status": operation_trace_status,
@@ -4921,6 +4929,7 @@ def _apply_codex_cli_goal_countability_guard_attribution(
             "failure_category": label,
             "trace_present": trace_present,
             "ok_count": ok_count,
+            "goal_stage": goal_stage,
             "request_count": request_count,
             "task_facing_activity_count": task_facing_count,
             "raw_material_recorded": False,


### PR DESCRIPTION
Summary
- Add a Codex CLI /goal worker goal-active timeout before bridge first-action waiting, so long benchmark packets fail fast when the TUI never enters goal mode.
- Preserve the new goal_active_timeout stage in public compact trace and countability attribution.
- Extend the SkillsBench codex-cli-goal route smoke with a public synthetic trace contract.

Validation
- python3 examples/skillsbench-codex-cli-goal-route-smoke.py
- python3 -m py_compile loopx/benchmark_adapters/skillsbench_acp_relay.py scripts/skillsbench_automation_loop.py examples/skillsbench-codex-cli-goal-route-smoke.py
- loopx check --scan-path loopx/benchmark_adapters/skillsbench_acp_relay.py --scan-path scripts/skillsbench_automation_loop.py --scan-path examples/skillsbench-codex-cli-goal-route-smoke.py
- loopx canary premerge --from-git-diff: technical checks passed, but merge gate returned benchmark_sensitive manual_review_required.

Boundary
- No raw task text, raw TUI capture, raw stdout/stderr, raw trajectory, verifier output, credentials, or local private artifacts added.
- Not self-merged because the premerge gate marked this as benchmark-sensitive and requiring explicit review.