### PR TITLE
Move claim visibility lanes into todo context

### DIFF
--- a/examples/control_plane/todo-claim-visibility-lanes-smoke.py
+++ b/examples/control_plane/todo-claim-visibility-lanes-smoke.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Smoke-test todo claim visibility lane projection helpers."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.todos.claim_visibility import (  # noqa: E402
+    TODO_AGENT_CLAIM_SCOPE_SCHEMA_VERSION,
+    build_agent_claim_scoped_open_items,
+    build_todo_claim_visibility_lanes,
+)
+
+
+CURRENT_AGENT = "codex-product-capability"
+OTHER_AGENT = "codex-main-control"
+
+
+def todo(
+    todo_id: str,
+    *,
+    index: int,
+    text: str,
+    task_class: str,
+    claimed_by: str | None = None,
+) -> dict:
+    item = {
+        "index": index,
+        "todo_id": todo_id,
+        "text": text,
+        "status": "open",
+        "task_class": task_class,
+        "claimed_by": claimed_by,
+        "required_write_scopes": [" loopx/** ", "loopx/**"],
+        "decision_scope": "direction:action:claim",
+    }
+    return {key: value for key, value in item.items() if value is not None}
+
+
+def assert_agent_claim_scope_prefers_current_then_unclaimed() -> None:
+    current_p2 = todo(
+        "todo_current_p2",
+        index=4,
+        text="[P2] Current agent lower priority.",
+        task_class="advancement_task",
+        claimed_by=CURRENT_AGENT,
+    )
+    current_p0 = todo(
+        "todo_current_p0",
+        index=5,
+        text="[P0] Current agent higher priority.",
+        task_class="advancement_task",
+        claimed_by=CURRENT_AGENT,
+    )
+    unclaimed_p0 = todo(
+        "todo_unclaimed_p0",
+        index=1,
+        text="[P0] Unclaimed high priority.",
+        task_class="advancement_task",
+    )
+    other_p0 = todo(
+        "todo_other_p0",
+        index=2,
+        text="[P0] Other agent work.",
+        task_class="advancement_task",
+        claimed_by=OTHER_AGENT,
+    )
+    open_items = [unclaimed_p0, other_p0, current_p2, current_p0]
+
+    selectable, claim_scope = build_agent_claim_scoped_open_items(
+        open_items,
+        agent_identity={
+            "agent_id": CURRENT_AGENT,
+            "role": "side-agent",
+            "primary_agent": OTHER_AGENT,
+        },
+        diagnostic_item_limit=3,
+    )
+    assert [item["todo_id"] for item in selectable] == [
+        "todo_current_p0",
+        "todo_current_p2",
+        "todo_unclaimed_p0",
+    ], selectable
+    assert claim_scope is not None, claim_scope
+    assert claim_scope["schema_version"] == TODO_AGENT_CLAIM_SCOPE_SCHEMA_VERSION
+    assert claim_scope["agent_id"] == CURRENT_AGENT
+    assert claim_scope["primary_agent"] == OTHER_AGENT
+    assert claim_scope["selection_order"] == "current_agent_claimed_then_unclaimed"
+    assert claim_scope["selectable_open_count"] == 3
+    assert claim_scope["current_agent_claimed_open_count"] == 2
+    assert claim_scope["unclaimed_open_count"] == 1
+    assert claim_scope["other_agent_claimed_open_count"] == 1
+    assert claim_scope["other_agent_claimed_weight"] == "diagnostic_only"
+    assert claim_scope["other_agent_claimed_items"][0]["todo_id"] == "todo_other_p0"
+    assert claim_scope["blocked_claimed_items"][0]["todo_id"] == "todo_other_p0"
+
+
+def assert_claim_visibility_lanes_split_current_other_and_task_class() -> None:
+    open_items = [
+        todo(
+            "todo_unclaimed_p0",
+            index=1,
+            text="[P0] Unclaimed high priority.",
+            task_class="advancement_task",
+        ),
+        todo(
+            "todo_current_advancement",
+            index=2,
+            text="[P1] Current advancement.",
+            task_class="advancement_task",
+            claimed_by=CURRENT_AGENT,
+        ),
+        todo(
+            "todo_current_monitor",
+            index=3,
+            text="[P1 monitor] Current monitor.",
+            task_class="continuous_monitor",
+            claimed_by=CURRENT_AGENT,
+        ),
+        todo(
+            "todo_other_advancement",
+            index=4,
+            text="[P1] Other advancement.",
+            task_class="advancement_task",
+            claimed_by=OTHER_AGENT,
+        ),
+    ]
+
+    lanes = build_todo_claim_visibility_lanes(
+        open_items,
+        agent_identity={"agent_id": CURRENT_AGENT},
+        backlog_item_limit=8,
+        visibility_lane_limit=16,
+    )
+    assert lanes["unclaimed_priority_open_items"][0]["todo_id"] == "todo_unclaimed_p0"
+    assert [item["todo_id"] for item in lanes["claimed_open_items"]] == [
+        "todo_current_advancement",
+        "todo_current_monitor",
+        "todo_other_advancement",
+    ], lanes
+    assert lanes["claimed_advancement_open_count"] == 2, lanes
+    assert lanes["claimed_monitor_open_count"] == 1, lanes
+    assert lanes["current_agent_claimed_open_count"] == 2, lanes
+    assert lanes["current_agent_claimed_advancement_count"] == 1, lanes
+    assert lanes["current_agent_claimed_monitor_count"] == 1, lanes
+    assert lanes["claimed_by_others_count"] == 1, lanes
+    current = lanes["current_agent_claimed_advancement_items"][0]
+    assert current["required_write_scopes"] == ["loopx/**"], current
+    assert current["decision_scope"]["scope_key"] == "claim", current
+    assert lanes["claimed_by_others_items"][0]["todo_id"] == "todo_other_advancement"
+
+
+def main() -> int:
+    assert_agent_claim_scope_prefers_current_then_unclaimed()
+    assert_claim_visibility_lanes_split_current_other_and_task_class()
+    print("todo-claim-visibility-lanes-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/control_plane/todo-projection-shared-helper-smoke.py
+++ b/examples/control_plane/todo-projection-shared-helper-smoke.py
@@ -13,7 +13,6 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.quota import (  # noqa: E402
-    _claimed_visibility_items as quota_claimed_visibility_items,
     _first_executable_todo_item as quota_first_executable_todo_item,
     _todo_summary_monitor_items as quota_todo_summary_monitor_items,
     _todo_projection_sort_key as quota_todo_projection_sort_key,
@@ -238,7 +237,6 @@ def assert_claimed_visibility_parity() -> None:
     for selector in (
         shared_claimed_visibility_items,
         status_claimed_visibility_items,
-        quota_claimed_visibility_items,
     ):
         selected_two = selector(items, limit=2)
         assert [item["todo_id"] for item in selected_two] == ["todo_a1", "todo_b1"], selected_two

--- a/loopx/control_plane/todos/claim_visibility.py
+++ b/loopx/control_plane/todos/claim_visibility.py
@@ -1,0 +1,288 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .contract import (
+    TODO_TASK_CLASS_ADVANCEMENT,
+    TODO_TASK_CLASS_MONITOR,
+    normalize_required_write_scopes,
+    normalize_todo_claimed_by,
+    normalize_todo_decision_scope,
+    normalize_todo_required_decision_scopes,
+    normalize_todo_task_class,
+)
+from .projection import (
+    todo_claimed_visibility_items,
+    todo_item_is_actionable_open,
+    todo_projection_sort_key,
+)
+
+
+TODO_AGENT_CLAIM_SCOPE_SCHEMA_VERSION = "agent_claim_scope_v0"
+
+
+def _todo_task_class(item: dict[str, Any]) -> str:
+    text = " ".join(
+        str(value or "")
+        for value in (item.get("title"), item.get("text"))
+        if str(value or "").strip()
+    )
+    return normalize_todo_task_class(
+        item.get("task_class"),
+        text=text,
+        action_kind=item.get("action_kind"),
+    )
+
+
+def _compact_claim_visibility_item(
+    item: dict[str, Any],
+    *,
+    text: str,
+) -> dict[str, Any]:
+    compact: dict[str, Any] = {
+        "index": item.get("index"),
+        "text": text,
+    }
+    for key in (
+        "schema_version",
+        "todo_id",
+        "role",
+        "status",
+        "priority",
+        "title",
+        "archive_state",
+        "source_section",
+        "task_class",
+        "action_kind",
+        "required_write_scopes",
+        "required_capabilities",
+        "target_capabilities",
+        "decision_scope",
+        "required_decision_scopes",
+        "claimed_by",
+        "blocks_agent",
+        "unblocks_todo_id",
+        "resume_when",
+        "resume_condition",
+        "resume_ready",
+        "no_followup",
+        "successor_todo_ids",
+        "target_key",
+        "cadence",
+        "next_due_at",
+        "expires_at",
+        "last_checked_at",
+        "result_hash",
+        "consecutive_no_change",
+        "material_change",
+        "max_no_change_before_replan",
+        "route_continuation_replan_required",
+        "route_continuation_reason",
+        "route_id",
+        "route_key",
+        "completed_at",
+        "updated_at",
+        "superseded_by",
+    ):
+        if item.get(key) is not None:
+            compact[key] = item.get(key)
+    required_write_scopes = normalize_required_write_scopes(compact.get("required_write_scopes"))
+    if required_write_scopes:
+        compact["required_write_scopes"] = required_write_scopes
+    else:
+        compact.pop("required_write_scopes", None)
+    decision_scope = normalize_todo_decision_scope(compact.get("decision_scope"))
+    if decision_scope:
+        compact["decision_scope"] = decision_scope
+    else:
+        compact.pop("decision_scope", None)
+    required_decision_scopes = normalize_todo_required_decision_scopes(
+        compact.get("required_decision_scopes")
+    )
+    if required_decision_scopes:
+        compact["required_decision_scopes"] = required_decision_scopes
+    else:
+        compact.pop("required_decision_scopes", None)
+    compact["task_class"] = _todo_task_class(compact)
+    return compact
+
+
+def _compact_items(
+    items: list[dict[str, Any]],
+    *,
+    limit: int,
+) -> list[dict[str, Any]]:
+    return [
+        _compact_claim_visibility_item(item, text=str(item.get("text") or "").strip())
+        for item in items[:limit]
+    ]
+
+
+def build_agent_claim_scoped_open_items(
+    open_items: list[dict[str, Any]],
+    *,
+    agent_identity: dict[str, Any] | None,
+    diagnostic_item_limit: int,
+) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+    if not isinstance(agent_identity, dict):
+        return open_items, None
+    agent_id = normalize_todo_claimed_by(agent_identity.get("agent_id"))
+    if not agent_id:
+        return open_items, None
+
+    def claim_bucket(item: dict[str, Any]) -> int:
+        claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
+        if claimed_by == agent_id:
+            return 0
+        if not claimed_by:
+            return 1
+        return 2
+
+    current_agent_items = [item for item in open_items if claim_bucket(item) == 0]
+    unclaimed_items = [item for item in open_items if claim_bucket(item) == 1]
+    other_agent_claimed_items = [item for item in open_items if claim_bucket(item) == 2]
+    selectable_items = sorted(
+        [*current_agent_items, *unclaimed_items],
+        key=lambda item: (claim_bucket(item), *todo_projection_sort_key(item)),
+    )
+    other_agent_visibility = todo_claimed_visibility_items(
+        other_agent_claimed_items,
+        limit=diagnostic_item_limit,
+    )
+    claim_scope = {
+        "schema_version": TODO_AGENT_CLAIM_SCOPE_SCHEMA_VERSION,
+        "agent_id": agent_id,
+        "agent_role": str(agent_identity.get("role") or ""),
+        "primary_agent": normalize_todo_claimed_by(agent_identity.get("primary_agent")),
+        "selection_order": "current_agent_claimed_then_unclaimed",
+        "selectable_open_count": len(selectable_items),
+        "current_agent_claimed_open_count": len(current_agent_items),
+        "unclaimed_open_count": len(unclaimed_items),
+        "other_agent_claimed_open_count": len(other_agent_claimed_items),
+        "other_agent_claimed_weight": "diagnostic_only",
+        "other_agent_claimed_items": _compact_items(
+            other_agent_visibility,
+            limit=diagnostic_item_limit,
+        ),
+        "blocked_claimed_open_count": len(other_agent_claimed_items),
+        "blocked_claimed_items": _compact_items(
+            other_agent_visibility,
+            limit=diagnostic_item_limit,
+        ),
+    }
+    return selectable_items, claim_scope
+
+
+def build_todo_claim_visibility_lanes(
+    open_items: list[dict[str, Any]],
+    *,
+    agent_identity: dict[str, Any] | None,
+    backlog_item_limit: int,
+    visibility_lane_limit: int,
+) -> dict[str, Any]:
+    claimed_items = [
+        item
+        for item in open_items
+        if normalize_todo_claimed_by(item.get("claimed_by"))
+    ]
+    unclaimed_items = [
+        item
+        for item in open_items
+        if not normalize_todo_claimed_by(item.get("claimed_by"))
+    ]
+    claimed_advancement_items = [
+        item
+        for item in claimed_items
+        if todo_item_is_actionable_open(item)
+        if _todo_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
+    ]
+    claimed_monitor_items = [
+        item
+        for item in claimed_items
+        if todo_item_is_actionable_open(item)
+        if _todo_task_class(item) == TODO_TASK_CLASS_MONITOR
+    ]
+
+    lanes: dict[str, Any] = {
+        "unclaimed_priority_open_items": _compact_items(
+            unclaimed_items,
+            limit=backlog_item_limit,
+        ),
+        "claimed_open_items": _compact_items(
+            todo_claimed_visibility_items(claimed_items, limit=visibility_lane_limit),
+            limit=visibility_lane_limit,
+        ),
+        "claimed_advancement_open_items": _compact_items(
+            todo_claimed_visibility_items(
+                claimed_advancement_items,
+                limit=visibility_lane_limit,
+            ),
+            limit=visibility_lane_limit,
+        ),
+        "claimed_monitor_open_items": _compact_items(
+            todo_claimed_visibility_items(
+                claimed_monitor_items,
+                limit=visibility_lane_limit,
+            ),
+            limit=visibility_lane_limit,
+        ),
+    }
+    if claimed_items:
+        lanes["claimed_advancement_open_count"] = len(claimed_advancement_items)
+        lanes["claimed_monitor_open_count"] = len(claimed_monitor_items)
+
+    agent_id = (
+        normalize_todo_claimed_by(agent_identity.get("agent_id"))
+        if isinstance(agent_identity, dict)
+        else None
+    )
+    if agent_id:
+        current_agent_items = [
+            item
+            for item in claimed_items
+            if normalize_todo_claimed_by(item.get("claimed_by")) == agent_id
+        ]
+        claimed_by_others_items = [
+            item
+            for item in claimed_items
+            if normalize_todo_claimed_by(item.get("claimed_by")) != agent_id
+        ]
+        current_agent_advancement_items = [
+            item
+            for item in current_agent_items
+            if todo_item_is_actionable_open(item)
+            if _todo_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
+        ]
+        current_agent_monitor_items = [
+            item
+            for item in current_agent_items
+            if todo_item_is_actionable_open(item)
+            if _todo_task_class(item) == TODO_TASK_CLASS_MONITOR
+        ]
+        lanes.update(
+            {
+                "current_agent_claimed_open_items": _compact_items(
+                    current_agent_items,
+                    limit=visibility_lane_limit,
+                ),
+                "current_agent_claimed_advancement_items": _compact_items(
+                    current_agent_advancement_items,
+                    limit=visibility_lane_limit,
+                ),
+                "current_agent_claimed_monitor_items": _compact_items(
+                    current_agent_monitor_items,
+                    limit=visibility_lane_limit,
+                ),
+                "claimed_by_others_items": _compact_items(
+                    claimed_by_others_items,
+                    limit=backlog_item_limit,
+                ),
+                "current_agent_claimed_open_count": len(current_agent_items),
+                "current_agent_claimed_advancement_count": len(
+                    current_agent_advancement_items
+                ),
+                "current_agent_claimed_monitor_count": len(current_agent_monitor_items),
+                "claimed_by_others_count": len(claimed_by_others_items),
+            }
+        )
+    return lanes

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -121,6 +121,10 @@ from .control_plane.todos.contract import (
     normalize_todo_status,
     normalize_todo_task_class,
 )
+from .control_plane.todos.claim_visibility import (
+    build_agent_claim_scoped_open_items,
+    build_todo_claim_visibility_lanes,
+)
 from .control_plane.todos.deferred_resume import (
     build_todo_deferred_visibility_lanes,
     build_todo_resume_blocked_visibility_lanes,
@@ -132,7 +136,6 @@ from .control_plane.todos.handoff_gate import (
 from .control_plane.todos.route_continuation import build_todo_route_continuation_lanes
 from .control_plane.todos.succession_warning import build_todo_succession_warning_lanes
 from .control_plane.todos.projection import (
-    todo_claimed_visibility_items as projection_todo_claimed_visibility_items,
     todo_index_rank as projection_todo_index_rank,
     todo_item_expires_at as projection_todo_item_expires_at,
     todo_item_is_actionable_open as projection_todo_item_is_actionable_open,
@@ -256,8 +259,6 @@ EXTERNAL_EVIDENCE_OBSERVATION_SCHEMA_VERSION = "external_evidence_observation_ob
 PROJECTED_MONITOR_HANDLE_SCHEMA_VERSION = "projected_monitor_handle_v0"
 AUTOMATION_LIVENESS_SCHEMA_VERSION = "automation_liveness_v0"
 CAPABILITY_GATE_SCHEMA_VERSION = "capability_gate_v0"
-AGENT_CLAIM_SCOPE_SCHEMA_VERSION = "agent_claim_scope_v0"
-SIDE_AGENT_CLAIM_SCOPE_SCHEMA_VERSION = AGENT_CLAIM_SCOPE_SCHEMA_VERSION
 DEFAULT_AVAILABLE_CAPABILITIES = (
     "shell",
     "filesystem_read",
@@ -1276,163 +1277,6 @@ def _todo_projection_sort_key(item: dict[str, Any]) -> tuple[int, int]:
     return projection_todo_projection_sort_key(item)
 
 
-def _claimed_visibility_items(items: list[dict[str, Any]], *, limit: int) -> list[dict[str, Any]]:
-    return projection_todo_claimed_visibility_items(items, limit=limit)
-
-
-def _agent_claim_scoped_open_items(
-    open_items: list[dict[str, Any]],
-    *,
-    agent_identity: dict[str, Any] | None,
-) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
-    if not isinstance(agent_identity, dict):
-        return open_items, None
-    agent_id = normalize_todo_claimed_by(agent_identity.get("agent_id"))
-    if not agent_id:
-        return open_items, None
-
-    def claim_bucket(item: dict[str, Any]) -> int:
-        claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
-        if claimed_by == agent_id:
-            return 0
-        if not claimed_by:
-            return 1
-        return 2
-
-    current_agent_items = [item for item in open_items if claim_bucket(item) == 0]
-    unclaimed_items = [item for item in open_items if claim_bucket(item) == 1]
-    other_agent_claimed_items = [item for item in open_items if claim_bucket(item) == 2]
-    selectable_items = sorted(
-        [*current_agent_items, *unclaimed_items],
-        key=lambda item: (claim_bucket(item), *_todo_projection_sort_key(item)),
-    )
-    claim_scope = {
-        "schema_version": AGENT_CLAIM_SCOPE_SCHEMA_VERSION,
-        "agent_id": agent_id,
-        "agent_role": str(agent_identity.get("role") or ""),
-        "primary_agent": normalize_todo_claimed_by(agent_identity.get("primary_agent")),
-        "selection_order": "current_agent_claimed_then_unclaimed",
-        "selectable_open_count": len(selectable_items),
-        "current_agent_claimed_open_count": len(current_agent_items),
-        "unclaimed_open_count": len(unclaimed_items),
-        "other_agent_claimed_open_count": len(other_agent_claimed_items),
-        "other_agent_claimed_weight": "diagnostic_only",
-        "other_agent_claimed_items": [
-            _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
-            for item in _claimed_visibility_items(other_agent_claimed_items, limit=3)
-        ],
-        "blocked_claimed_open_count": len(other_agent_claimed_items),
-        "blocked_claimed_items": [
-            _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
-            for item in _claimed_visibility_items(other_agent_claimed_items, limit=3)
-        ],
-    }
-    return selectable_items, claim_scope
-
-
-def _todo_summary_visibility_lanes(
-    open_items: list[dict[str, Any]],
-    *,
-    agent_identity: dict[str, Any] | None,
-) -> dict[str, Any]:
-    claimed_items = [item for item in open_items if normalize_todo_claimed_by(item.get("claimed_by"))]
-    unclaimed_items = [item for item in open_items if not normalize_todo_claimed_by(item.get("claimed_by"))]
-    claimed_advancement_items = [
-        item
-        for item in claimed_items
-        if _todo_item_is_actionable_open(item)
-        if _todo_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
-    ]
-    claimed_monitor_items = [
-        item
-        for item in claimed_items
-        if _todo_item_is_actionable_open(item)
-        if _todo_task_class(item) == TODO_TASK_CLASS_MONITOR
-    ]
-
-    def compact_items(items: list[dict[str, Any]], *, limit: int = TODO_BACKLOG_ITEM_LIMIT) -> list[dict[str, Any]]:
-        return [
-            _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
-            for item in items[:limit]
-        ]
-
-    lanes: dict[str, Any] = {
-        "unclaimed_priority_open_items": compact_items(unclaimed_items),
-        "claimed_open_items": compact_items(
-            _claimed_visibility_items(claimed_items, limit=TODO_VISIBILITY_LANE_LIMIT),
-            limit=TODO_VISIBILITY_LANE_LIMIT,
-        ),
-        "claimed_advancement_open_items": compact_items(
-            _claimed_visibility_items(
-                claimed_advancement_items,
-                limit=TODO_VISIBILITY_LANE_LIMIT,
-            ),
-            limit=TODO_VISIBILITY_LANE_LIMIT,
-        ),
-        "claimed_monitor_open_items": compact_items(
-            _claimed_visibility_items(
-                claimed_monitor_items,
-                limit=TODO_VISIBILITY_LANE_LIMIT,
-            ),
-            limit=TODO_VISIBILITY_LANE_LIMIT,
-        ),
-    }
-    if claimed_items:
-        lanes["claimed_advancement_open_count"] = len(claimed_advancement_items)
-        lanes["claimed_monitor_open_count"] = len(claimed_monitor_items)
-
-    agent_id = (
-        normalize_todo_claimed_by(agent_identity.get("agent_id"))
-        if isinstance(agent_identity, dict)
-        else None
-    )
-    if agent_id:
-        current_agent_items = [
-            item
-            for item in claimed_items
-            if normalize_todo_claimed_by(item.get("claimed_by")) == agent_id
-        ]
-        claimed_by_others_items = [
-            item
-            for item in claimed_items
-            if normalize_todo_claimed_by(item.get("claimed_by")) != agent_id
-        ]
-        current_agent_advancement_items = [
-            item
-            for item in current_agent_items
-            if _todo_item_is_actionable_open(item)
-            if _todo_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
-        ]
-        current_agent_monitor_items = [
-            item
-            for item in current_agent_items
-            if _todo_item_is_actionable_open(item)
-            if _todo_task_class(item) == TODO_TASK_CLASS_MONITOR
-        ]
-        lanes.update(
-            {
-                "current_agent_claimed_open_items": compact_items(
-                    current_agent_items,
-                    limit=TODO_VISIBILITY_LANE_LIMIT,
-                ),
-                "current_agent_claimed_advancement_items": compact_items(
-                    current_agent_advancement_items,
-                    limit=TODO_VISIBILITY_LANE_LIMIT,
-                ),
-                "current_agent_claimed_monitor_items": compact_items(
-                    current_agent_monitor_items,
-                    limit=TODO_VISIBILITY_LANE_LIMIT,
-                ),
-                "claimed_by_others_items": compact_items(claimed_by_others_items),
-                "current_agent_claimed_open_count": len(current_agent_items),
-                "current_agent_claimed_advancement_count": len(current_agent_advancement_items),
-                "current_agent_claimed_monitor_count": len(current_agent_monitor_items),
-                "claimed_by_others_count": len(claimed_by_others_items),
-            }
-        )
-    return lanes
-
-
 def _todo_summary_source_items(value: dict[str, Any]) -> list[dict[str, Any]]:
     source_keys = (
         "active_next_action_items",
@@ -1531,9 +1375,10 @@ def _summarize_user_todos(
             all_open_items,
             agent_identity=agent_identity,
         )
-    open_items, claim_scope = _agent_claim_scoped_open_items(
+    open_items, claim_scope = build_agent_claim_scoped_open_items(
         blocking_open_items,
         agent_identity=agent_identity,
+        diagnostic_item_limit=3,
     )
     executable_items = [
         item
@@ -1610,9 +1455,11 @@ def _summarize_user_todos(
     if monitor_writeback:
         summary["monitor_writeback"] = monitor_writeback
     summary.update(
-        _todo_summary_visibility_lanes(
+        build_todo_claim_visibility_lanes(
             blocking_open_items,
             agent_identity=agent_identity,
+            backlog_item_limit=TODO_BACKLOG_ITEM_LIMIT,
+            visibility_lane_limit=TODO_VISIBILITY_LANE_LIMIT,
         )
     )
     summary.update(
@@ -1711,9 +1558,10 @@ def _summarize_project_asset_todos(
             all_open_items,
             agent_identity=agent_identity,
         )
-    open_items, claim_scope = _agent_claim_scoped_open_items(
+    open_items, claim_scope = build_agent_claim_scoped_open_items(
         blocking_open_items,
         agent_identity=agent_identity,
+        diagnostic_item_limit=3,
     )
     executable_items = [
         item
@@ -1776,9 +1624,11 @@ def _summarize_project_asset_todos(
     if monitor_writeback:
         summary["monitor_writeback"] = monitor_writeback
     summary.update(
-        _todo_summary_visibility_lanes(
+        build_todo_claim_visibility_lanes(
             blocking_open_items,
             agent_identity=agent_identity,
+            backlog_item_limit=TODO_BACKLOG_ITEM_LIMIT,
+            visibility_lane_limit=TODO_VISIBILITY_LANE_LIMIT,
         )
     )
     summary.update(


### PR DESCRIPTION
## Summary
- move agent claim-scope and claimed/current/other-agent visibility lane builders from quota into the todo bounded context
- keep quota as a consumer of todo read-model claim visibility lanes
- add a direct canary for current-agent/unclaimed/other-agent claim-scope ordering and lane counts
- remove the old shared-helper smoke dependency on `quota._claimed_visibility_items` instead of keeping a shim

## Validation
- `git diff --cached --check`
- `python3 -m py_compile loopx/control_plane/todos/claim_visibility.py loopx/quota.py examples/control_plane/todo-claim-visibility-lanes-smoke.py examples/control_plane/todo-projection-shared-helper-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/todo-claim-visibility-lanes-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/todo-projection-shared-helper-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/todo-first-open-summary-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/quota-agent-scoped-user-gate-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/control-plane-risk-characterization-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/monitor-scheduler-contract-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/work-lane-contract-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/agent-scope-projection-characterization-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/quota-replan-decision-plane-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/bounded-context-namespace-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/check-public-boundary-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli canary premerge --from-git-diff --tier standard --timeout-seconds 120 --format json`

Premerge gate passed locally with `merge_gate_passed=true`, `self_merge_allowed=true`, and no manual holds. One dashboard browser sub-smoke inside canary promotion readiness reported missing npm dependencies and was skipped by that smoke; the standard premerge gate still passed.
