### PR TITLE
Share todo summary item projection helper

### DIFF
--- a/examples/control_plane/todo-summary-item-source-smoke.py
+++ b/examples/control_plane/todo-summary-item-source-smoke.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Smoke-test shared todo summary item compaction and source aggregation."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.todos.summary_item import (  # noqa: E402
+    compact_todo_summary_item,
+    todo_summary_source_items,
+)
+
+
+GATE_ID = "todo_gate_done"
+SUCCESSOR_ID = "todo_successor"
+SUCCESSOR_TEXT = "[P1] Resume after the handoff gate is cleared."
+DUPLICATE_TEXT = "[P2] Keep only one no-id duplicate."
+
+
+def successor_item(**overrides: object) -> dict:
+    item = {
+        "index": 2,
+        "todo_id": SUCCESSOR_ID,
+        "text": SUCCESSOR_TEXT,
+        "status": "open",
+        "task_class": "advancement_task",
+        "resume_when": f"todo_done:{GATE_ID}",
+        "unblocks_todo_id": GATE_ID,
+        "required_write_scopes": [" loopx/** ", "loopx/**"],
+        "decision_scope": "direction:action:claim",
+        "claimed_by": "codex-product-capability",
+    }
+    item.update(overrides)
+    return item
+
+
+def assert_compact_item_normalizes_shared_contract() -> None:
+    compact = compact_todo_summary_item(successor_item())
+    assert compact["todo_id"] == SUCCESSOR_ID, compact
+    assert compact["required_write_scopes"] == ["loopx/**"], compact
+    assert compact["decision_scope"]["scope_key"] == "claim", compact
+    assert compact["task_class"] == "advancement_task", compact
+
+
+def assert_source_items_dedupe_and_mark_handoff_successor_ready() -> None:
+    value = {
+        "first_open_items": [
+            successor_item(),
+            {
+                "index": 4,
+                "text": DUPLICATE_TEXT,
+                "status": "open",
+                "task_class": "advancement_task",
+            },
+            {
+                "index": 5,
+                "text": "   ",
+                "status": "open",
+            },
+        ],
+        "backlog_items": [
+            successor_item(text="[P1] Later duplicate must not replace first source."),
+            {
+                "index": 4,
+                "text": DUPLICATE_TEXT,
+                "status": "open",
+                "task_class": "advancement_task",
+            },
+        ],
+        "items": [
+            {
+                "index": 1,
+                "todo_id": GATE_ID,
+                "text": "[P0] Cleared handoff gate.",
+                "status": "done",
+                "done": True,
+                "task_class": "blocker",
+                "blocks_agent": "codex-product-capability",
+            },
+            successor_item(index=3),
+        ],
+    }
+
+    items = todo_summary_source_items(value)
+    assert [item.get("todo_id") for item in items] == [SUCCESSOR_ID, None], items
+    successor = items[0]
+    assert successor["text"] == SUCCESSOR_TEXT, successor
+    assert successor["resume_ready"] is True, successor
+    assert successor["resume_condition"] == {
+        "schema_version": "todo_resume_condition_v0",
+        "resume_when": f"todo_done:{GATE_ID}",
+        "satisfied": True,
+        "source": "handoff_gate_cleared_with_successor",
+    }, successor
+    assert items[1]["text"] == DUPLICATE_TEXT, items
+
+
+def main() -> int:
+    assert_compact_item_normalizes_shared_contract()
+    assert_source_items_dedupe_and_mark_handoff_successor_ready()
+    print("todo-summary-item-source-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/control_plane/agents/agent_lane_recommendation.py
+++ b/loopx/control_plane/agents/agent_lane_recommendation.py
@@ -9,9 +9,9 @@ from ..todos.contract import (
     normalize_todo_claimed_by,
     normalize_todo_id,
 )
+from ..todos.summary_item import compact_todo_summary_item
 from ..work_items.interaction_contract import protocol_action_text
 from .agent_scope import (
-    _compact_todo_summary_item,
     _todo_item_is_actionable_open,
     _todo_task_class,
 )
@@ -337,7 +337,7 @@ def build_agent_lane_next_action(
                 if claimed_by == agent_id
                 else "unclaimed_todo"
             )
-            payload = _compact_todo_summary_item(raw_item, text=text)
+            payload = compact_todo_summary_item(raw_item, text=text)
             if selected_by == "unclaimed_todo":
                 payload["claim_required_before_work"] = True
             lineage_source = source

--- a/loopx/control_plane/agents/agent_scope.py
+++ b/loopx/control_plane/agents/agent_scope.py
@@ -11,12 +11,9 @@ from ..todos.contract import (
     TODO_TASK_CLASS_ADVANCEMENT,
     TODO_TASK_CLASS_MONITOR,
     TODO_TASK_CLASS_USER_GATE,
-    normalize_required_write_scopes,
     normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
-    normalize_todo_decision_scope,
     normalize_todo_id,
-    normalize_todo_required_decision_scopes,
     normalize_todo_status,
     normalize_todo_task_class,
 )
@@ -28,6 +25,7 @@ from ..todos.projection import (
     todo_item_task_class,
     todo_projection_sort_key,
 )
+from ..todos.summary_item import compact_todo_summary_item
 
 
 AGENT_SCOPE_FRONTIER_SCHEMA_VERSION = "agent_scope_frontier_v0"
@@ -113,75 +111,6 @@ def _todo_projection_sort_key(item: dict[str, Any]) -> tuple[int, int, int, str]
 
 def _todo_item_is_actionable_open(item: dict[str, Any]) -> bool:
     return todo_item_is_actionable_open(item)
-
-
-def _compact_todo_summary_item(item: dict[str, Any], *, text: str | None = None) -> dict[str, Any]:
-    compact: dict[str, Any] = {
-        "index": item.get("index"),
-        "text": text if text is not None else item.get("text"),
-    }
-    for key in (
-        "schema_version",
-        "todo_id",
-        "role",
-        "status",
-        "priority",
-        "title",
-        "archive_state",
-        "source_section",
-        "task_class",
-        "action_kind",
-        "required_write_scopes",
-        "required_capabilities",
-        "target_capabilities",
-        "decision_scope",
-        "required_decision_scopes",
-        "claimed_by",
-        "blocks_agent",
-        "unblocks_todo_id",
-        "resume_when",
-        "resume_condition",
-        "resume_ready",
-        "no_followup",
-        "successor_todo_ids",
-        "target_key",
-        "cadence",
-        "next_due_at",
-        "expires_at",
-        "last_checked_at",
-        "result_hash",
-        "consecutive_no_change",
-        "material_change",
-        "max_no_change_before_replan",
-        "route_continuation_replan_required",
-        "route_continuation_reason",
-        "route_id",
-        "route_key",
-        "completed_at",
-        "updated_at",
-        "superseded_by",
-    ):
-        if item.get(key) is not None:
-            compact[key] = item.get(key)
-    required_write_scopes = normalize_required_write_scopes(compact.get("required_write_scopes"))
-    if required_write_scopes:
-        compact["required_write_scopes"] = required_write_scopes
-    else:
-        compact.pop("required_write_scopes", None)
-    decision_scope = normalize_todo_decision_scope(compact.get("decision_scope"))
-    if decision_scope:
-        compact["decision_scope"] = decision_scope
-    else:
-        compact.pop("decision_scope", None)
-    required_decision_scopes = normalize_todo_required_decision_scopes(
-        compact.get("required_decision_scopes")
-    )
-    if required_decision_scopes:
-        compact["required_decision_scopes"] = required_decision_scopes
-    else:
-        compact.pop("required_decision_scopes", None)
-    compact["task_class"] = _todo_task_class(compact)
-    return compact
 
 
 def _protocol_action_text(value: Any, *, limit: int = 220) -> str | None:
@@ -400,7 +329,7 @@ def _scoped_user_gate_fallback(
         if matching_gate:
             blocking_gate = blocking_gate or matching_gate
             text = str(item.get("text") or "").strip()
-            blocked_item = _compact_todo_summary_item(item, text=text)
+            blocked_item = compact_todo_summary_item(item, text=text)
             relation = _todo_gate_relation(matching_gate, item)
             if relation:
                 blocked_item["todo_gate_relation"] = relation
@@ -416,7 +345,7 @@ def _scoped_user_gate_fallback(
 
     selected_text = str(selected.get("text") or "").strip()
     gate_to_surface = blocking_gate or gates[0]
-    selected_item = _compact_todo_summary_item(selected, text=selected_text)
+    selected_item = compact_todo_summary_item(selected, text=selected_text)
     selected_relation = _todo_gate_relation(gate_to_surface, selected)
     if selected_relation:
         selected_item["todo_gate_relation"] = selected_relation
@@ -436,7 +365,7 @@ def _scoped_user_gate_fallback(
         "notify_user": True,
         "requires_user_action": True,
         "reason": reason,
-        "blocked_user_gate": _compact_todo_summary_item(gate_to_surface, text=gate_text),
+        "blocked_user_gate": compact_todo_summary_item(gate_to_surface, text=gate_text),
         "blocked_agent_items": blocked_items[:3],
         "selected_executable": selected_item,
         "recommended_action": (
@@ -814,7 +743,7 @@ def _agent_scope_deferred_resume_candidates(
         if identity in seen:
             continue
         seen.add(identity)
-        unique.append(_compact_todo_summary_item(item, text=str(item.get("text") or "").strip()))
+        unique.append(compact_todo_summary_item(item, text=str(item.get("text") or "").strip()))
     return sorted(unique, key=_todo_projection_sort_key)
 
 
@@ -864,7 +793,7 @@ def _agent_scope_monitor_blocked_resume_candidates(
         if identity in seen:
             continue
         seen.add(identity)
-        compact = _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
+        compact = compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
         if target_todo_id:
             compact["blocking_monitor_todo_id"] = target_todo_id
         unique.append(compact)
@@ -992,7 +921,7 @@ def _agent_scope_route_continuation_replan_candidates(
         if not identity or identity in seen:
             continue
         seen.add(identity)
-        compact = _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
+        compact = compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
         compact["route_continuation_replan_required"] = True
         if item.get("route_continuation_reason") is not None:
             compact["route_continuation_reason"] = item.get("route_continuation_reason")
@@ -1370,7 +1299,7 @@ def _agent_scope_no_candidate_frontier(
         "other_claimants": other_claimants,
         "blocking_review_claimants": blocking_review_claimants,
         "other_agent_claimed_items": [
-            _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
+            compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
             for item in other_advancement_items[:3]
         ],
     }

--- a/loopx/control_plane/agents/capability_gate.py
+++ b/loopx/control_plane/agents/capability_gate.py
@@ -9,7 +9,7 @@ from ..todos.contract import (
     normalize_todo_claimed_by,
 )
 from ..todos.projection import todo_index_rank, todo_priority_rank
-from .agent_scope import _compact_todo_summary_item
+from ..todos.summary_item import compact_todo_summary_item
 
 
 CAPABILITY_REPAIR_BRIDGE_HINTS = {
@@ -43,7 +43,7 @@ def _capability_candidate_item(
     missing_target_capabilities: list[str] | None = None,
 ) -> dict[str, Any]:
     text = str(item.get("text") or "").strip()
-    payload = _compact_todo_summary_item(item, text=text)
+    payload = compact_todo_summary_item(item, text=text)
     required = normalize_required_capabilities(item.get("required_capabilities"))
     targets = normalize_target_capabilities(item.get("target_capabilities"))
     payload["required_capabilities"] = required

--- a/loopx/control_plane/todos/claim_visibility.py
+++ b/loopx/control_plane/todos/claim_visibility.py
@@ -5,106 +5,18 @@ from typing import Any
 from .contract import (
     TODO_TASK_CLASS_ADVANCEMENT,
     TODO_TASK_CLASS_MONITOR,
-    normalize_required_write_scopes,
     normalize_todo_claimed_by,
-    normalize_todo_decision_scope,
-    normalize_todo_required_decision_scopes,
-    normalize_todo_task_class,
 )
 from .projection import (
     todo_claimed_visibility_items,
     todo_item_is_actionable_open,
+    todo_item_task_class,
     todo_projection_sort_key,
 )
+from .summary_item import compact_todo_summary_item
 
 
 TODO_AGENT_CLAIM_SCOPE_SCHEMA_VERSION = "agent_claim_scope_v0"
-
-
-def _todo_task_class(item: dict[str, Any]) -> str:
-    text = " ".join(
-        str(value or "")
-        for value in (item.get("title"), item.get("text"))
-        if str(value or "").strip()
-    )
-    return normalize_todo_task_class(
-        item.get("task_class"),
-        text=text,
-        action_kind=item.get("action_kind"),
-    )
-
-
-def _compact_claim_visibility_item(
-    item: dict[str, Any],
-    *,
-    text: str,
-) -> dict[str, Any]:
-    compact: dict[str, Any] = {
-        "index": item.get("index"),
-        "text": text,
-    }
-    for key in (
-        "schema_version",
-        "todo_id",
-        "role",
-        "status",
-        "priority",
-        "title",
-        "archive_state",
-        "source_section",
-        "task_class",
-        "action_kind",
-        "required_write_scopes",
-        "required_capabilities",
-        "target_capabilities",
-        "decision_scope",
-        "required_decision_scopes",
-        "claimed_by",
-        "blocks_agent",
-        "unblocks_todo_id",
-        "resume_when",
-        "resume_condition",
-        "resume_ready",
-        "no_followup",
-        "successor_todo_ids",
-        "target_key",
-        "cadence",
-        "next_due_at",
-        "expires_at",
-        "last_checked_at",
-        "result_hash",
-        "consecutive_no_change",
-        "material_change",
-        "max_no_change_before_replan",
-        "route_continuation_replan_required",
-        "route_continuation_reason",
-        "route_id",
-        "route_key",
-        "completed_at",
-        "updated_at",
-        "superseded_by",
-    ):
-        if item.get(key) is not None:
-            compact[key] = item.get(key)
-    required_write_scopes = normalize_required_write_scopes(compact.get("required_write_scopes"))
-    if required_write_scopes:
-        compact["required_write_scopes"] = required_write_scopes
-    else:
-        compact.pop("required_write_scopes", None)
-    decision_scope = normalize_todo_decision_scope(compact.get("decision_scope"))
-    if decision_scope:
-        compact["decision_scope"] = decision_scope
-    else:
-        compact.pop("decision_scope", None)
-    required_decision_scopes = normalize_todo_required_decision_scopes(
-        compact.get("required_decision_scopes")
-    )
-    if required_decision_scopes:
-        compact["required_decision_scopes"] = required_decision_scopes
-    else:
-        compact.pop("required_decision_scopes", None)
-    compact["task_class"] = _todo_task_class(compact)
-    return compact
 
 
 def _compact_items(
@@ -113,7 +25,7 @@ def _compact_items(
     limit: int,
 ) -> list[dict[str, Any]]:
     return [
-        _compact_claim_visibility_item(item, text=str(item.get("text") or "").strip())
+        compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
         for item in items[:limit]
     ]
 
@@ -194,13 +106,13 @@ def build_todo_claim_visibility_lanes(
         item
         for item in claimed_items
         if todo_item_is_actionable_open(item)
-        if _todo_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
+        if todo_item_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
     ]
     claimed_monitor_items = [
         item
         for item in claimed_items
         if todo_item_is_actionable_open(item)
-        if _todo_task_class(item) == TODO_TASK_CLASS_MONITOR
+        if todo_item_task_class(item) == TODO_TASK_CLASS_MONITOR
     ]
 
     lanes: dict[str, Any] = {
@@ -251,13 +163,13 @@ def build_todo_claim_visibility_lanes(
             item
             for item in current_agent_items
             if todo_item_is_actionable_open(item)
-            if _todo_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
+            if todo_item_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
         ]
         current_agent_monitor_items = [
             item
             for item in current_agent_items
             if todo_item_is_actionable_open(item)
-            if _todo_task_class(item) == TODO_TASK_CLASS_MONITOR
+            if todo_item_task_class(item) == TODO_TASK_CLASS_MONITOR
         ]
         lanes.update(
             {

--- a/loopx/control_plane/todos/summary_item.py
+++ b/loopx/control_plane/todos/summary_item.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .contract import (
+    normalize_required_write_scopes,
+    normalize_todo_decision_scope,
+    normalize_todo_id,
+    normalize_todo_required_decision_scopes,
+    normalize_todo_resume_when,
+)
+from .handoff_gate import handoff_ready_successor_todo_ids
+from .projection import todo_item_task_class
+
+
+TODO_SUMMARY_COMPACT_FIELDS = (
+    "schema_version",
+    "todo_id",
+    "role",
+    "status",
+    "priority",
+    "title",
+    "archive_state",
+    "source_section",
+    "task_class",
+    "action_kind",
+    "required_write_scopes",
+    "required_capabilities",
+    "target_capabilities",
+    "decision_scope",
+    "required_decision_scopes",
+    "claimed_by",
+    "blocks_agent",
+    "unblocks_todo_id",
+    "resume_when",
+    "resume_condition",
+    "resume_ready",
+    "no_followup",
+    "successor_todo_ids",
+    "target_key",
+    "cadence",
+    "next_due_at",
+    "expires_at",
+    "last_checked_at",
+    "result_hash",
+    "consecutive_no_change",
+    "material_change",
+    "max_no_change_before_replan",
+    "route_continuation_replan_required",
+    "route_continuation_reason",
+    "route_id",
+    "route_key",
+    "completed_at",
+    "updated_at",
+    "superseded_by",
+)
+
+TODO_SUMMARY_SOURCE_KEYS = (
+    "active_next_action_items",
+    "active_next_action_executable_items",
+    "first_open_items",
+    "backlog_items",
+    "unclaimed_priority_open_items",
+    "claimed_open_items",
+    "claimed_advancement_open_items",
+    "claimed_monitor_open_items",
+    "current_agent_claimed_open_items",
+    "current_agent_claimed_advancement_items",
+    "current_agent_claimed_monitor_items",
+    "resume_blocked_items",
+    "monitor_blocked_resume_candidates",
+    "current_agent_monitor_blocked_resume_candidates",
+    "unclaimed_monitor_blocked_resume_candidates",
+    "items",
+)
+
+
+def compact_todo_summary_item(
+    item: dict[str, Any],
+    *,
+    text: str | None = None,
+) -> dict[str, Any]:
+    compact: dict[str, Any] = {
+        "index": item.get("index"),
+        "text": text if text is not None else item.get("text"),
+    }
+    for key in TODO_SUMMARY_COMPACT_FIELDS:
+        if item.get(key) is not None:
+            compact[key] = item.get(key)
+    required_write_scopes = normalize_required_write_scopes(
+        compact.get("required_write_scopes")
+    )
+    if required_write_scopes:
+        compact["required_write_scopes"] = required_write_scopes
+    else:
+        compact.pop("required_write_scopes", None)
+    decision_scope = normalize_todo_decision_scope(compact.get("decision_scope"))
+    if decision_scope:
+        compact["decision_scope"] = decision_scope
+    else:
+        compact.pop("decision_scope", None)
+    required_decision_scopes = normalize_todo_required_decision_scopes(
+        compact.get("required_decision_scopes")
+    )
+    if required_decision_scopes:
+        compact["required_decision_scopes"] = required_decision_scopes
+    else:
+        compact.pop("required_decision_scopes", None)
+    compact["task_class"] = todo_item_task_class(compact)
+    return compact
+
+
+def todo_summary_source_items(value: dict[str, Any]) -> list[dict[str, Any]]:
+    ready_successor_todo_ids = handoff_ready_successor_todo_ids(value)
+    open_items: list[dict[str, Any]] = []
+    for key in TODO_SUMMARY_SOURCE_KEYS:
+        source_items = value.get(key) if isinstance(value.get(key), list) else []
+        for item in source_items:
+            if not isinstance(item, dict) or item.get("done") is True:
+                continue
+            text = str(item.get("text") or "").strip()
+            if not text:
+                continue
+            duplicate = any(
+                existing.get("todo_id") == item.get("todo_id")
+                if item.get("todo_id") and existing.get("todo_id")
+                else existing.get("index") == item.get("index")
+                and str(existing.get("text") or "").strip() == text
+                for existing in open_items
+            )
+            if duplicate:
+                continue
+            compact = compact_todo_summary_item(item, text=text)
+            todo_id = normalize_todo_id(compact.get("todo_id"))
+            if (
+                todo_id
+                and todo_id in ready_successor_todo_ids
+                and normalize_todo_resume_when(compact.get("resume_when"))
+                and "resume_ready" not in compact
+            ):
+                compact["resume_ready"] = True
+                compact["resume_condition"] = {
+                    "schema_version": "todo_resume_condition_v0",
+                    "resume_when": compact.get("resume_when"),
+                    "satisfied": True,
+                    "source": "handoff_gate_cleared_with_successor",
+                }
+            open_items.append(compact)
+    return open_items

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -113,10 +113,7 @@ from .control_plane.todos.contract import (
     normalize_target_capabilities,
     normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
-    normalize_todo_decision_scope,
     normalize_todo_id,
-    normalize_todo_required_decision_scopes,
-    normalize_todo_resume_when,
     normalize_required_write_scopes,
     normalize_todo_status,
     normalize_todo_task_class,
@@ -129,12 +126,13 @@ from .control_plane.todos.deferred_resume import (
     build_todo_deferred_visibility_lanes,
     build_todo_resume_blocked_visibility_lanes,
 )
-from .control_plane.todos.handoff_gate import (
-    build_todo_handoff_gate_lanes,
-    handoff_ready_successor_todo_ids as todo_handoff_ready_successor_todo_ids,
-)
+from .control_plane.todos.handoff_gate import build_todo_handoff_gate_lanes
 from .control_plane.todos.route_continuation import build_todo_route_continuation_lanes
 from .control_plane.todos.succession_warning import build_todo_succession_warning_lanes
+from .control_plane.todos.summary_item import (
+    compact_todo_summary_item,
+    todo_summary_source_items,
+)
 from .control_plane.todos.projection import (
     todo_index_rank as projection_todo_index_rank,
     todo_item_expires_at as projection_todo_item_expires_at,
@@ -1025,75 +1023,6 @@ def _quota_sort_key(item: dict[str, Any]) -> tuple[int, float, int, str]:
     return (state_index, -compute, spent_slots, str(item.get("goal_id") or ""))
 
 
-def _compact_todo_summary_item(item: dict[str, Any], *, text: str | None = None) -> dict[str, Any]:
-    compact: dict[str, Any] = {
-        "index": item.get("index"),
-        "text": text if text is not None else item.get("text"),
-    }
-    for key in (
-        "schema_version",
-        "todo_id",
-        "role",
-        "status",
-        "priority",
-        "title",
-        "archive_state",
-        "source_section",
-        "task_class",
-        "action_kind",
-        "required_write_scopes",
-        "required_capabilities",
-        "target_capabilities",
-        "decision_scope",
-        "required_decision_scopes",
-        "claimed_by",
-        "blocks_agent",
-        "unblocks_todo_id",
-        "resume_when",
-        "resume_condition",
-        "resume_ready",
-        "no_followup",
-        "successor_todo_ids",
-        "target_key",
-        "cadence",
-        "next_due_at",
-        "expires_at",
-        "last_checked_at",
-        "result_hash",
-        "consecutive_no_change",
-        "material_change",
-        "max_no_change_before_replan",
-        "route_continuation_replan_required",
-        "route_continuation_reason",
-        "route_id",
-        "route_key",
-        "completed_at",
-        "updated_at",
-        "superseded_by",
-    ):
-        if item.get(key) is not None:
-            compact[key] = item.get(key)
-    required_write_scopes = normalize_required_write_scopes(compact.get("required_write_scopes"))
-    if required_write_scopes:
-        compact["required_write_scopes"] = required_write_scopes
-    else:
-        compact.pop("required_write_scopes", None)
-    decision_scope = normalize_todo_decision_scope(compact.get("decision_scope"))
-    if decision_scope:
-        compact["decision_scope"] = decision_scope
-    else:
-        compact.pop("decision_scope", None)
-    required_decision_scopes = normalize_todo_required_decision_scopes(
-        compact.get("required_decision_scopes")
-    )
-    if required_decision_scopes:
-        compact["required_decision_scopes"] = required_decision_scopes
-    else:
-        compact.pop("required_decision_scopes", None)
-    compact["task_class"] = _todo_task_class(compact)
-    return compact
-
-
 def _available_capabilities(value: Any) -> list[str]:
     capabilities = list(DEFAULT_AVAILABLE_CAPABILITIES)
     for capability in normalize_required_capabilities(value):
@@ -1277,63 +1206,6 @@ def _todo_projection_sort_key(item: dict[str, Any]) -> tuple[int, int]:
     return projection_todo_projection_sort_key(item)
 
 
-def _todo_summary_source_items(value: dict[str, Any]) -> list[dict[str, Any]]:
-    source_keys = (
-        "active_next_action_items",
-        "active_next_action_executable_items",
-        "first_open_items",
-        "backlog_items",
-        "unclaimed_priority_open_items",
-        "claimed_open_items",
-        "claimed_advancement_open_items",
-        "claimed_monitor_open_items",
-        "current_agent_claimed_open_items",
-        "current_agent_claimed_advancement_items",
-        "current_agent_claimed_monitor_items",
-        "resume_blocked_items",
-        "monitor_blocked_resume_candidates",
-        "current_agent_monitor_blocked_resume_candidates",
-        "unclaimed_monitor_blocked_resume_candidates",
-        "items",
-    )
-    ready_successor_todo_ids = todo_handoff_ready_successor_todo_ids(value)
-    open_items: list[dict[str, Any]] = []
-    for key in source_keys:
-        source_items = value.get(key) if isinstance(value.get(key), list) else []
-        for item in source_items:
-            if not isinstance(item, dict) or item.get("done") is True:
-                continue
-            text = str(item.get("text") or "").strip()
-            if not text:
-                continue
-            duplicate = any(
-                existing.get("todo_id") == item.get("todo_id")
-                if item.get("todo_id") and existing.get("todo_id")
-                else existing.get("index") == item.get("index")
-                and str(existing.get("text") or "").strip() == text
-                for existing in open_items
-            )
-            if duplicate:
-                continue
-            compact = _compact_todo_summary_item(item, text=text)
-            todo_id = normalize_todo_id(compact.get("todo_id"))
-            if (
-                todo_id
-                and todo_id in ready_successor_todo_ids
-                and normalize_todo_resume_when(compact.get("resume_when"))
-                and "resume_ready" not in compact
-            ):
-                compact["resume_ready"] = True
-                compact["resume_condition"] = {
-                    "schema_version": "todo_resume_condition_v0",
-                    "resume_when": compact.get("resume_when"),
-                    "satisfied": True,
-                    "source": "handoff_gate_cleared_with_successor",
-                }
-            open_items.append(compact)
-    return open_items
-
-
 def _todo_summary_monitor_writeback_contract(value: dict[str, Any] | None) -> dict[str, Any] | None:
     return projection_todo_summary_monitor_writeback_contract(value)
 
@@ -1360,7 +1232,7 @@ def _summarize_user_todos(
     if not isinstance(value, dict):
         return None
     all_open_items = sorted(
-        _todo_summary_source_items(value),
+        todo_summary_source_items(value),
         key=_todo_projection_sort_key,
     )
     blocking_open_items = all_open_items
@@ -1416,13 +1288,13 @@ def _summarize_user_todos(
         if _is_user_gate_todo_item(item)
     ]
     active_next_action_items = [
-        _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
+        compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
         for item in (value.get("active_next_action_items") or [])
         if isinstance(item, dict)
         if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
     ] if isinstance(value.get("active_next_action_items"), list) else []
     active_next_action_executable_items = [
-        _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
+        compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
         for item in (value.get("active_next_action_executable_items") or [])
         if isinstance(item, dict)
         if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
@@ -1509,7 +1381,7 @@ def _summarize_user_todos(
         summary["all_open_count"] = value.get("open_count", len(all_open_items))
         summary["other_agent_scoped_open_count"] = len(other_agent_scoped_items)
         summary["other_agent_scoped_items"] = [
-            _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
+            compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
             for item in other_agent_scoped_items[:TODO_VISIBILITY_LANE_LIMIT]
         ]
     return summary
@@ -1536,7 +1408,7 @@ def _summarize_project_asset_todos(
         )
 
     all_open_items = sorted(
-        _todo_summary_source_items(value),
+        todo_summary_source_items(value),
         key=_todo_projection_sort_key,
     )
     if not all_open_items:
@@ -1587,13 +1459,13 @@ def _summarize_project_asset_todos(
         else []
     )
     active_next_action_items = [
-        _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
+        compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
         for item in (value.get("active_next_action_items") or [])
         if isinstance(item, dict)
         if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
     ] if isinstance(value.get("active_next_action_items"), list) else []
     active_next_action_executable_items = [
-        _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
+        compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
         for item in (value.get("active_next_action_executable_items") or [])
         if isinstance(item, dict)
         if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
@@ -1665,7 +1537,7 @@ def _summarize_project_asset_todos(
         summary["all_open_count"] = value.get("open", value.get("open_count", len(all_open_items)))
         summary["other_agent_scoped_open_count"] = len(other_agent_scoped_items)
         summary["other_agent_scoped_items"] = [
-            _compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
+            compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
             for item in other_agent_scoped_items[:TODO_VISIBILITY_LANE_LIMIT]
         ]
     return summary
@@ -1750,12 +1622,12 @@ def _blocked_priority_fallback(
         text = str(item.get("text") or "").strip()
         if not text:
             continue
-        blocked_items.append(_compact_todo_summary_item(item, text=text))
+        blocked_items.append(compact_todo_summary_item(item, text=text))
 
     if not blocked_items:
         return None
     selected_text = str(selected.get("text") or "").strip()
-    selected_item = _compact_todo_summary_item(selected, text=selected_text) if selected_text else dict(selected)
+    selected_item = compact_todo_summary_item(selected, text=selected_text) if selected_text else dict(selected)
     return {
         "schema_version": "blocked_priority_fallback_v0",
         "kind": "blocked_priority_fallback",


### PR DESCRIPTION
## Summary
- add `loopx.control_plane.todos.summary_item` as the shared compact todo summary item and source aggregation contract
- route quota todo-summary source merging, claim visibility lanes, agent scope fallback/frontier, capability candidates, and agent-lane recommendation through the same compact helper
- delete the duplicate compact helpers from quota, claim visibility, and agent scope
- add a direct canary for compact normalization, multi-source dedupe, and handoff-successor `resume_ready` projection

## Validation
- `git diff --cached --check`
- `python3 -m py_compile loopx/control_plane/todos/summary_item.py loopx/control_plane/todos/claim_visibility.py loopx/control_plane/agents/agent_scope.py loopx/control_plane/agents/capability_gate.py loopx/control_plane/agents/agent_lane_recommendation.py loopx/quota.py examples/control_plane/todo-summary-item-source-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/todo-summary-item-source-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/todo-claim-visibility-lanes-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/agent-scope-projection-characterization-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/quota-agent-scoped-user-gate-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/quota-resume-gated-open-todo-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/todo-first-open-summary-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/todo-projection-shared-helper-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/control-plane-risk-characterization-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/work-lane-contract-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/monitor-scheduler-contract-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/quota-replan-decision-plane-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/bounded-context-namespace-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/check-public-boundary-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli canary premerge --from-git-diff --tier standard --timeout-seconds 120 --format json`

Premerge gate passed locally with `merge_gate_passed=true`, `self_merge_allowed=true`, and no manual holds. One dashboard browser sub-smoke inside canary promotion readiness reported missing npm dependencies and was skipped by that smoke; the standard premerge gate still passed.
