### PR TITLE
Extract monitor poll policy seam

### DIFF
--- a/examples/control_plane/monitor-poll-policy-smoke.py
+++ b/examples/control_plane/monitor-poll-policy-smoke.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""Smoke-test monitor-poll policy extraction from quota into scheduler."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx.control_plane.scheduler.monitor_poll_policy import (  # noqa: E402
+    allows_due_monitor_poll,
+    allows_no_spend_external_monitor_poll,
+    quota_decision_due_monitor_item,
+    work_lane_reason_codes,
+)
+
+
+def assert_external_monitor_observation_policy() -> None:
+    base_decision = {
+        "should_run": True,
+        "work_lane_contract": {
+            "must_attempt_work": True,
+            "monitor_policy": "material_transition_only",
+            "reason_codes": [
+                "open_agent_todo",
+                "external_monitor_context",
+                "",
+                None,
+            ],
+        },
+    }
+    assert work_lane_reason_codes(base_decision["work_lane_contract"]) == {
+        "open_agent_todo",
+        "external_monitor_context",
+    }
+    assert allows_no_spend_external_monitor_poll(base_decision) is True
+
+    blocked_by_user_gate = dict(base_decision, requires_user_action=True)
+    assert allows_no_spend_external_monitor_poll(blocked_by_user_gate) is False
+
+    explicit_observation = {
+        "should_run": True,
+        "external_evidence_observation": {
+            "target": "remote job handle",
+        },
+        "work_lane_contract": {
+            "must_attempt_work": True,
+            "monitor_policy": "read_only_observation_then_no_spend_if_unchanged",
+            "reason_codes": ["open_agent_todo"],
+        },
+    }
+    assert allows_no_spend_external_monitor_poll(explicit_observation) is True
+
+    due_monitor_delivery = {
+        "should_run": True,
+        "work_lane_contract": {
+            "must_attempt_work": True,
+            "monitor_policy": "attempt_due_monitor_once_then_writeback_or_no_spend_if_unchanged",
+            "reason_codes": ["monitor_due"],
+        },
+    }
+    assert allows_no_spend_external_monitor_poll(due_monitor_delivery) is False
+
+
+def assert_due_monitor_policy_from_next_action() -> None:
+    decision = {
+        "work_lane_contract": {
+            "obligation": "attempt_due_monitor",
+            "must_attempt_work": True,
+            "monitor_due_items": [
+                {
+                    "todo_id": "todo_due_from_contract",
+                    "task_class": "continuous_monitor",
+                    "target_key": "contract-target",
+                }
+            ],
+        },
+        "agent_lane_next_action": {
+            "todo_id": "todo_due_from_next",
+            "task_class": "continuous_monitor",
+            "target_key": "next-target",
+        },
+    }
+    selected = quota_decision_due_monitor_item(decision)
+    assert selected["todo_id"] == "todo_due_from_next", selected
+    assert allows_due_monitor_poll(decision, todo_id="todo_due_from_next") is True
+    assert allows_due_monitor_poll(decision, target_key="next-target") is True
+    assert allows_due_monitor_poll(decision, todo_id="todo_due_from_contract") is False
+    assert allows_due_monitor_poll(decision, target_key="contract-target") is False
+
+
+def assert_due_monitor_policy_from_contract_selection() -> None:
+    decision = {
+        "work_lane_contract": {
+            "obligation": "attempt_due_monitor",
+            "must_attempt_work": True,
+            "selected_todo_id": "todo_due_selected",
+            "monitor_due_items": [
+                {
+                    "todo_id": "todo_advancement_decoy",
+                    "task_class": "advancement_task",
+                    "target_key": "wrong-kind",
+                },
+                {
+                    "todo_id": "todo_due_selected",
+                    "task_class": "continuous_monitor",
+                    "target_key": "selected-target",
+                },
+                {
+                    "todo_id": "todo_due_other",
+                    "task_class": "continuous_monitor",
+                    "target_key": "other-target",
+                },
+            ],
+        },
+        "agent_lane_next_action": {
+            "todo_id": "todo_advancement_next",
+            "task_class": "advancement_task",
+            "target_key": "next-decoy",
+        },
+    }
+    selected = quota_decision_due_monitor_item(decision)
+    assert selected["todo_id"] == "todo_due_selected", selected
+    assert allows_due_monitor_poll(decision, todo_id="todo_due_selected") is True
+    assert allows_due_monitor_poll(decision, target_key="selected-target") is True
+    assert allows_due_monitor_poll(decision, todo_id="todo_due_other") is False
+    assert allows_due_monitor_poll(decision, target_key="other-target") is False
+
+    not_attemptable = {
+        **decision,
+        "work_lane_contract": {
+            **decision["work_lane_contract"],
+            "must_attempt_work": False,
+        },
+    }
+    assert allows_due_monitor_poll(not_attemptable, todo_id="todo_due_selected") is False
+
+
+def main() -> int:
+    assert_external_monitor_observation_policy()
+    assert_due_monitor_policy_from_next_action()
+    assert_due_monitor_policy_from_contract_selection()
+    print("monitor-poll-policy-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/control_plane/monitor-poll-writeback-smoke.py
+++ b/examples/control_plane/monitor-poll-writeback-smoke.py
@@ -17,7 +17,6 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 import loopx.cli_commands.quota as quota_command  # noqa: E402
-from loopx import quota as quota_module  # noqa: E402
 from loopx.control_plane.scheduler.monitor_poll_writeback import (  # noqa: E402
     resolve_monitor_todo_item,
     write_monitor_poll_todo_state,
@@ -481,20 +480,18 @@ def assert_target_key_cannot_hijack_selected_due_monitor() -> None:
         assert monitor_poll_records(registry_path) == [], run_index_records(registry_path)
 
 
-def assert_writeback_helper_matches_quota_wrapper() -> None:
+def assert_writeback_helper_preview_contract() -> None:
     with tempfile.TemporaryDirectory(prefix="loopx-monitor-poll-helper-parity-") as tmp:
         registry_path, _state_file = write_fixture(Path(tmp))
-        assert resolve_monitor_todo_item(
-            registry_path=registry_path,
-            goal_id=GOAL_ID,
-            todo_id=TODO_ID,
-        ) == quota_module._resolve_monitor_todo_item(
+        resolved = resolve_monitor_todo_item(
             registry_path=registry_path,
             goal_id=GOAL_ID,
             todo_id=TODO_ID,
         )
+        assert resolved["todo_id"] == TODO_ID, resolved
+        assert resolved["target_key"] == TARGET_KEY, resolved
         generated_at = "2026-01-01T00:05:00+00:00"
-        helper_writeback = write_monitor_poll_todo_state(
+        preview = write_monitor_poll_todo_state(
             registry_path=registry_path,
             goal_id=GOAL_ID,
             generated_at=generated_at,
@@ -502,32 +499,17 @@ def assert_writeback_helper_matches_quota_wrapper() -> None:
             todo_id=TODO_ID,
             result_hash="old",
         )
-        wrapper_writeback = quota_module._write_monitor_poll_todo_state(
-            registry_path=registry_path,
-            goal_id=GOAL_ID,
-            generated_at=generated_at,
-            execute=False,
-            todo_id=TODO_ID,
-            result_hash="old",
-        )
-        compared_keys = {
-            "schema_version",
-            "dry_run",
-            "goal_id",
-            "todo_id",
-            "target_key",
-            "result_hash",
-            "material_change",
-            "consecutive_no_change",
-            "last_checked_at",
-            "next_due_at",
-            "cadence",
-        }
-        assert {
-            key: helper_writeback.get(key) for key in compared_keys
-        } == {
-            key: wrapper_writeback.get(key) for key in compared_keys
-        }, (helper_writeback, wrapper_writeback)
+        assert preview["schema_version"] == "monitor_poll_todo_writeback_v0", preview
+        assert preview["dry_run"] is True, preview
+        assert preview["goal_id"] == GOAL_ID, preview
+        assert preview["todo_id"] == TODO_ID, preview
+        assert preview["target_key"] == TARGET_KEY, preview
+        assert preview["result_hash"] == "old", preview
+        assert preview["material_change"] is False, preview
+        assert preview["consecutive_no_change"] == 2, preview
+        assert preview["last_checked_at"] == generated_at, preview
+        assert preview["next_due_at"] != "2026-01-01T00:00:00+00:00", preview
+        assert preview["cadence"] == "15m", preview
 
 
 def assert_cli_monitor_poll_uses_should_run_lookback() -> None:
@@ -599,7 +581,7 @@ def assert_cli_monitor_poll_uses_should_run_lookback() -> None:
 
 def main() -> int:
     assert_cli_monitor_poll_uses_should_run_lookback()
-    assert_writeback_helper_matches_quota_wrapper()
+    assert_writeback_helper_preview_contract()
     assert_unchanged_writeback()
     assert_material_transition_followup()
     assert_due_monitor_poll_allowed_with_open_user_gate()

--- a/examples/control_plane/monitor-todo-policy-seam-smoke.py
+++ b/examples/control_plane/monitor-todo-policy-seam-smoke.py
@@ -11,7 +11,6 @@ ROOT = Path(__file__).resolve().parents[2]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
-from loopx import quota as quota_module  # noqa: E402
 from loopx.control_plane.scheduler.monitor_todo import (  # noqa: E402
     monitor_cadence_delta,
     monitor_next_due_at,
@@ -55,19 +54,11 @@ def monitor_item(**overrides: object) -> dict[str, object]:
 def assert_policy_matches_wrappers(item: dict[str, object], *, due: bool, expired: bool) -> None:
     assert monitor_todo_is_due(item, now=NOW) is due, item
     assert todo_item_is_due_monitor(item, now=NOW) is due, item
-    assert quota_module._todo_item_is_due_monitor(item, now=NOW) is due, item
     assert monitor_todo_is_expired(item, now=NOW) is expired, item
     assert todo_item_is_expired_monitor(item, now=NOW) is expired, item
-    assert quota_module._todo_item_is_expired_monitor(item, now=NOW) is expired, item
     assert monitor_todo_next_due_at(item) == todo_item_next_due_at(item), item
-    assert monitor_todo_next_due_at(item) == quota_module._todo_item_next_due_at(item), item
     assert monitor_todo_is_actionable_open(item) == todo_item_is_actionable_open(item), item
-    assert monitor_todo_is_actionable_open(item) == quota_module._todo_item_is_actionable_open(item), item
     assert monitor_todo_missing_schedule(item, now=NOW) == todo_item_missing_monitor_schedule(
-        item,
-        now=NOW,
-    ), item
-    assert monitor_todo_missing_schedule(item, now=NOW) == quota_module._todo_item_missing_monitor_schedule(
         item,
         now=NOW,
     ), item
@@ -101,15 +92,16 @@ def main() -> int:
     assert_policy_matches_wrappers(unscheduled, due=False, expired=False)
     assert monitor_todo_missing_schedule(unscheduled, now=NOW) is True, unscheduled
     assert monitor_todo_next_due_at({"next_due_at": "2026-01-01T00:00:00"}) == NOW
-    assert parse_monitor_counter("3") == quota_module._parse_monitor_counter("3")
+    assert parse_monitor_counter("3") == 3
     assert parse_monitor_counter("not-a-number") == 0
-    assert monitor_cadence_delta("2h") == quota_module._monitor_cadence_delta("2h")
-    assert monitor_next_due_at(
+    assert monitor_cadence_delta("2h").total_seconds() == 7200
+    cadence_due_at = monitor_next_due_at(
         generated_at="2026-01-01T00:00:00+00:00",
         cadence="5m",
-    ) == quota_module._monitor_next_due_at(
-        generated_at="2026-01-01T00:00:00+00:00",
-        cadence="5m",
+    )
+    assert (
+        datetime.fromisoformat(cadence_due_at).astimezone(timezone.utc).isoformat()
+        == "2026-01-01T00:05:00+00:00"
     )
     assert monitor_next_due_at(
         generated_at="ignored",
@@ -122,13 +114,13 @@ def main() -> int:
         "recommended_action": " Observe due monitor without material transition. ",
     }
     assert monitor_target_summary("  Observe\n\nmonitor  ", limit=160) == "Observe monitor"
-    assert build_quota_monitor_target(
-        target_decision,
-        monitor_mode="due_monitor_observed_without_material_transition",
-    ) == quota_module._quota_monitor_target(
+    monitor_target = build_quota_monitor_target(
         target_decision,
         monitor_mode="due_monitor_observed_without_material_transition",
     )
+    assert monitor_target["schema_version"] == "quota_monitor_target_v0", monitor_target
+    assert monitor_target["monitor_mode"] == "due_monitor_observed_without_material_transition", monitor_target
+    assert monitor_target["action_summary"] == "Observe due monitor without material transition.", monitor_target
     print("monitor-todo-policy-seam-smoke ok")
     return 0
 

--- a/loopx/control_plane/scheduler/monitor_poll_policy.py
+++ b/loopx/control_plane/scheduler/monitor_poll_policy.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ..todos.contract import TODO_TASK_CLASS_MONITOR, normalize_todo_id
+from ..todos.projection import todo_item_task_class
+
+EXTERNAL_MONITOR_POLICIES = {
+    "material_transition_only",
+    "read_only_observation_then_no_spend_if_unchanged",
+}
+EXTERNAL_MONITOR_REASON_CODES = {
+    "external_monitor_context",
+    "external_evidence_poll_signal",
+}
+DUE_MONITOR_OBLIGATION = "attempt_due_monitor"
+
+
+def work_lane_reason_codes(work_lane_contract: dict[str, Any]) -> set[str]:
+    reason_codes = work_lane_contract.get("reason_codes")
+    if not isinstance(reason_codes, list):
+        return set()
+    return {str(value) for value in reason_codes if str(value or "").strip()}
+
+
+def allows_no_spend_external_monitor_poll(decision: dict[str, Any]) -> bool:
+    """Return true when should-run represents observation, not delivery completion."""
+
+    work_lane_contract = (
+        decision.get("work_lane_contract")
+        if isinstance(decision.get("work_lane_contract"), dict)
+        else {}
+    )
+    reason_codes = work_lane_reason_codes(work_lane_contract)
+    monitor_policy = str(work_lane_contract.get("monitor_policy") or "")
+    if decision.get("requires_user_action") is True:
+        return False
+    if decision.get("should_run") is not True:
+        return False
+    if work_lane_contract.get("must_attempt_work") is not True:
+        return False
+    if monitor_policy not in EXTERNAL_MONITOR_POLICIES:
+        return False
+    if reason_codes.intersection(EXTERNAL_MONITOR_REASON_CODES):
+        return True
+    return bool(decision.get("external_evidence_observation"))
+
+
+def quota_decision_due_monitor_item(decision: dict[str, Any]) -> dict[str, Any]:
+    item = (
+        decision.get("agent_lane_next_action")
+        if isinstance(decision.get("agent_lane_next_action"), dict)
+        else {}
+    )
+    if todo_item_task_class(item) != TODO_TASK_CLASS_MONITOR:
+        item = {}
+    if item:
+        return item
+    contract = (
+        decision.get("work_lane_contract")
+        if isinstance(decision.get("work_lane_contract"), dict)
+        else {}
+    )
+    selected_todo_id = normalize_todo_id(contract.get("selected_todo_id"))
+    due_items = (
+        contract.get("monitor_due_items")
+        if isinstance(contract.get("monitor_due_items"), list)
+        else []
+    )
+    for due_item in due_items:
+        if not isinstance(due_item, dict):
+            continue
+        if selected_todo_id and normalize_todo_id(due_item.get("todo_id")) != selected_todo_id:
+            continue
+        if todo_item_task_class(due_item) == TODO_TASK_CLASS_MONITOR:
+            return due_item
+    return item
+
+
+def allows_due_monitor_poll(
+    decision: dict[str, Any],
+    *,
+    todo_id: str | None = None,
+    target_key: str | None = None,
+) -> bool:
+    contract = (
+        decision.get("work_lane_contract")
+        if isinstance(decision.get("work_lane_contract"), dict)
+        else {}
+    )
+    if contract.get("obligation") != DUE_MONITOR_OBLIGATION:
+        return False
+    if contract.get("must_attempt_work") is not True:
+        return False
+    item = quota_decision_due_monitor_item(decision)
+    if not item:
+        return False
+    if todo_id and normalize_todo_id(item.get("todo_id")) != normalize_todo_id(todo_id):
+        return False
+    if target_key:
+        item_target_key = str(item.get("target_key") or "").strip()
+        if item_target_key != str(target_key).strip():
+            return False
+    return True

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -76,20 +76,12 @@ from .control_plane.scheduler.scheduler_hint import (
     build_scheduler_hint,
     build_scheduler_ack_plan,
 )
-from .control_plane.scheduler.monitor_todo import (
-    monitor_cadence_delta as scheduler_monitor_cadence_delta,
-    monitor_next_due_at as scheduler_monitor_next_due_at,
-    parse_monitor_counter as scheduler_parse_monitor_counter,
+from .control_plane.scheduler.monitor_poll_policy import (
+    allows_due_monitor_poll,
+    allows_no_spend_external_monitor_poll,
 )
-from .control_plane.scheduler.monitor_poll_writeback import (
-    resolve_monitor_todo_item as scheduler_resolve_monitor_todo_item,
-    write_monitor_poll_todo_state as scheduler_write_monitor_poll_todo_state,
-)
-from .control_plane.scheduler.monitor_target import (
-    QUOTA_MONITOR_TARGET_SCHEMA_VERSION,
-    build_quota_monitor_target as scheduler_build_quota_monitor_target,
-    monitor_target_summary as scheduler_monitor_target_summary,
-)
+from .control_plane.scheduler.monitor_poll_writeback import write_monitor_poll_todo_state
+from .control_plane.scheduler.monitor_target import build_quota_monitor_target
 from .control_plane.scheduler.state import (
     CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
     CODEX_APP_SURFACE,
@@ -5087,174 +5079,6 @@ def record_quota_scheduler_ack(
     }
 
 
-def _monitor_target_summary(value: Any, *, limit: int = 160) -> str:
-    return scheduler_monitor_target_summary(value, limit=limit)
-
-
-def _quota_monitor_target(before: dict[str, Any], *, monitor_mode: str) -> dict[str, Any]:
-    return scheduler_build_quota_monitor_target(before, monitor_mode=monitor_mode)
-
-
-def _work_lane_reason_codes(work_lane_contract: dict[str, Any]) -> set[str]:
-    reason_codes = work_lane_contract.get("reason_codes")
-    if not isinstance(reason_codes, list):
-        return set()
-    return {str(value) for value in reason_codes if str(value or "").strip()}
-
-
-def _allows_no_spend_external_monitor_poll(decision: dict[str, Any]) -> bool:
-    """Return True when should-run represents observation, not delivery completion."""
-
-    work_lane_contract = (
-        decision.get("work_lane_contract")
-        if isinstance(decision.get("work_lane_contract"), dict)
-        else {}
-    )
-    reason_codes = _work_lane_reason_codes(work_lane_contract)
-    monitor_policy = str(work_lane_contract.get("monitor_policy") or "")
-    if decision.get("requires_user_action") is True:
-        return False
-    if decision.get("should_run") is not True:
-        return False
-    if work_lane_contract.get("must_attempt_work") is not True:
-        return False
-    if monitor_policy not in {
-        "material_transition_only",
-        "read_only_observation_then_no_spend_if_unchanged",
-    }:
-        return False
-    if reason_codes.intersection({"external_monitor_context", "external_evidence_poll_signal"}):
-        return True
-    return bool(decision.get("external_evidence_observation"))
-
-
-def _parse_monitor_counter(value: Any) -> int:
-    return scheduler_parse_monitor_counter(value)
-
-
-def _monitor_cadence_delta(value: Any) -> timedelta | None:
-    return scheduler_monitor_cadence_delta(value)
-
-
-def _monitor_next_due_at(
-    *,
-    generated_at: str,
-    cadence: Any = None,
-    explicit_next_due_at: Any = None,
-) -> str | None:
-    return scheduler_monitor_next_due_at(
-        generated_at=generated_at,
-        cadence=cadence,
-        explicit_next_due_at=explicit_next_due_at,
-    )
-
-
-def _quota_decision_due_monitor_item(decision: dict[str, Any]) -> dict[str, Any]:
-    item = (
-        decision.get("agent_lane_next_action")
-        if isinstance(decision.get("agent_lane_next_action"), dict)
-        else {}
-    )
-    if _todo_task_class(item) != TODO_TASK_CLASS_MONITOR:
-        item = {}
-    if item:
-        return item
-    contract = (
-        decision.get("work_lane_contract")
-        if isinstance(decision.get("work_lane_contract"), dict)
-        else {}
-    )
-    selected_todo_id = normalize_todo_id(contract.get("selected_todo_id"))
-    due_items = contract.get("monitor_due_items") if isinstance(contract.get("monitor_due_items"), list) else []
-    for due_item in due_items:
-        if not isinstance(due_item, dict):
-            continue
-        if selected_todo_id and normalize_todo_id(due_item.get("todo_id")) != selected_todo_id:
-            continue
-        if _todo_task_class(due_item) == TODO_TASK_CLASS_MONITOR:
-            return due_item
-    return item
-
-
-def _allows_due_monitor_poll(
-    decision: dict[str, Any],
-    *,
-    todo_id: str | None = None,
-    target_key: str | None = None,
-) -> bool:
-    contract = (
-        decision.get("work_lane_contract")
-        if isinstance(decision.get("work_lane_contract"), dict)
-        else {}
-    )
-    if contract.get("obligation") != "attempt_due_monitor":
-        return False
-    if contract.get("must_attempt_work") is not True:
-        return False
-    item = _quota_decision_due_monitor_item(decision)
-    if not item:
-        return False
-    if todo_id and normalize_todo_id(item.get("todo_id")) != normalize_todo_id(todo_id):
-        return False
-    if target_key:
-        item_target_key = str(item.get("target_key") or "").strip()
-        if item_target_key != str(target_key).strip():
-            return False
-    return True
-
-
-def _resolve_monitor_todo_item(
-    *,
-    registry_path: Path,
-    goal_id: str,
-    todo_id: str | None = None,
-    target_key: str | None = None,
-) -> dict[str, Any]:
-    return scheduler_resolve_monitor_todo_item(
-        registry_path=registry_path,
-        goal_id=goal_id,
-        todo_id=todo_id,
-        target_key=target_key,
-    )
-
-
-def _write_monitor_poll_todo_state(
-    *,
-    registry_path: Path,
-    goal_id: str,
-    generated_at: str,
-    execute: bool,
-    todo_id: str | None = None,
-    target_key: str | None = None,
-    result_hash: str | None = None,
-    material_change: bool = False,
-    cadence: str | None = None,
-    next_due_at: str | None = None,
-    reason_summary: str | None = None,
-    next_agent_todo: str | None = None,
-    next_user_todo: str | None = None,
-    next_claimed_by: str | None = None,
-    agent_id: str | None = None,
-) -> dict[str, Any] | None:
-    return scheduler_write_monitor_poll_todo_state(
-        registry_path=registry_path,
-        goal_id=goal_id,
-        generated_at=generated_at,
-        execute=execute,
-        todo_id=todo_id,
-        target_key=target_key,
-        result_hash=result_hash,
-        material_change=material_change,
-        cadence=cadence,
-        next_due_at=next_due_at,
-        reason_summary=reason_summary,
-        next_agent_todo=next_agent_todo,
-        next_user_todo=next_user_todo,
-        next_claimed_by=next_claimed_by,
-        agent_id=agent_id,
-    )
-
-
 def build_quota_monitor_poll_event(
     before: dict[str, Any],
     *,
@@ -5269,8 +5093,8 @@ def build_quota_monitor_poll_event(
     safe_source = str(source or DEFAULT_SLOT_SPEND_SOURCE).strip()
     if safe_source not in VALID_SLOT_SPEND_SOURCES:
         raise ValueError(f"quota monitor-poll source must be one of: {', '.join(sorted(VALID_SLOT_SPEND_SOURCES))}")
-    external_monitor_poll = _allows_no_spend_external_monitor_poll(before)
-    due_monitor_poll = _allows_due_monitor_poll(
+    external_monitor_poll = allows_no_spend_external_monitor_poll(before)
+    due_monitor_poll = allows_due_monitor_poll(
         before,
         todo_id=todo_id,
         target_key=target_key,
@@ -5303,7 +5127,7 @@ def build_quota_monitor_poll_event(
             )
         )
     )
-    monitor_target = _quota_monitor_target(before, monitor_mode=monitor_mode)
+    monitor_target = build_quota_monitor_target(before, monitor_mode=monitor_mode)
     safe_reason_summary = str(reason_summary or "").strip()
     if not safe_reason_summary:
         safe_reason_summary = (
@@ -5573,14 +5397,14 @@ def record_quota_monitor_poll(
         return failure("`quota monitor-poll --material-change` requires --todo-id or --target-key")
     if (next_agent_todo or next_user_todo) and not material_change:
         return failure("`--next-agent-todo` and `--next-user-todo` require --material-change")
-    due_monitor_poll = _allows_due_monitor_poll(
+    due_monitor_poll = allows_due_monitor_poll(
         before,
         todo_id=normalized_todo_id,
         target_key=safe_target_key,
     )
     if (
         before.get("effective_action") != "monitor_quiet_skip"
-        and not _allows_no_spend_external_monitor_poll(before)
+        and not allows_no_spend_external_monitor_poll(before)
         and not due_monitor_poll
     ):
         return failure(
@@ -5593,7 +5417,7 @@ def record_quota_monitor_poll(
     if normalized_todo_id or safe_target_key:
         if registry_path is None:
             raise ValueError("monitor todo writeback requires registry_path")
-        todo_writeback = _write_monitor_poll_todo_state(
+        todo_writeback = write_monitor_poll_todo_state(
             registry_path=registry_path,
             goal_id=safe_goal_id,
             generated_at=generated_at,


### PR DESCRIPTION
## Summary
- Move monitor-poll permission policy out of quota.py into control_plane/scheduler/monitor_poll_policy.py.
- Keep quota.py as the orchestration caller for monitor-poll event/writeback paths.
- Add a direct monitor-poll policy canary and retarget existing monitor smokes away from quota private wrappers.

## Validation
- python3 -m py_compile changed Python files
- PYTHONPATH=. python3 examples/control_plane/monitor-poll-policy-smoke.py
- PYTHONPATH=. python3 examples/control_plane/monitor-poll-writeback-smoke.py
- PYTHONPATH=. python3 examples/control_plane/monitor-todo-policy-seam-smoke.py
- PYTHONPATH=. python3 examples/control_plane/quota-work-lane-policy-smoke.py
- PYTHONPATH=. python3 examples/control_plane/monitor-scheduler-contract-smoke.py
- PYTHONPATH=. python3 examples/control_plane/quota-agent-scoped-user-gate-smoke.py
- PYTHONPATH=. python3 examples/control_plane/control-plane-integrated-canary-smoke.py
- PYTHONPATH=. python3 -m loopx.cli canary premerge --from-git-diff --tier standard --timeout-seconds 120 --format json

## Boundary
- Changed surfaces: control_plane, public_boundary, python.
- No benchmark adapter/scoring changes, no Lark Kanban changes, no private/runtime state committed.
