### PR TITLE
Add explicit KNN auto-research preset

### DIFF
--- a/docs/guides/auto-research-command-path.md
+++ b/docs/guides/auto-research-command-path.md
@@ -239,7 +239,8 @@ Concrete KNN proof command:
 
 ```bash
 loopx --format json auto-research start \
-  "KNN demo: prove partial selection improves over full sort" \
+  "How can the KNN baseline improve holdout metric?" \
+  --preset knn-demo \
   --execute \
   --headless \
   --worker-loop-rounds 4 \
@@ -251,9 +252,15 @@ operator experience. The matching visible path is still the one-command start:
 
 ```bash
 loopx auto-research start \
-  "KNN demo: prove partial selection improves over full sort" \
+  "How can the KNN baseline improve holdout metric?" \
+  --preset knn-demo \
   --execute
 ```
+
+`--preset knn-demo` is the public signal that the baseline metric, holdout
+split, and protected metric scope come from the built-in KNN demo fixture. The
+open question names the research topic; it does not smuggle the baseline into
+the system through natural-language inference.
 
 The validated KNN run demonstrates that the second round is carried by LoopX
 state and role-declared successor todos: the evidence runner owns

--- a/examples/auto-research-knn-preset-start-smoke.py
+++ b/examples/auto-research-knn-preset-start-smoke.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Smoke-test the explicit KNN demo preset on auto-research start."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+QUESTION = "如何提升 KNN holdout metric?"
+
+
+def main() -> int:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "auto-research",
+            "start",
+            QUESTION,
+            "--preset",
+            "knn-demo",
+            "--language",
+            "zh",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+    contract = payload["user_contract"]
+    preset = contract["preset_context"]
+    assert preset["preset_id"] == "knn-demo", preset
+    assert preset["baseline_source"] == "preset_fixture_not_question_text", preset
+    assert preset["question_text_supplies_baseline"] is False, preset
+    assert preset["metric_name"] == "holdout_metric", preset
+    assert preset["baseline_metric"] == 1.0, preset
+    assert payload["preset_context"] == preset, payload
+    assert payload["route_contract"]["preset_id"] == "knn-demo", payload
+    assert payload["route_contract"]["preset_baseline_source"] == (
+        "preset_fixture_not_question_text"
+    ), payload
+    assert "--preset knn-demo" in contract["one_click_start"]["command"], contract
+    assert "--preset knn-demo" in payload["commands"]["one_question_start"], payload
+    assert payload["contract_acceptance"]["accepted"] is True, payload
+
+    markdown_result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "auto-research",
+            "start",
+            QUESTION,
+            "--preset",
+            "knn-demo",
+            "--language",
+            "zh",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    markdown = markdown_result.stdout
+    assert "## Preset Context" in markdown, markdown
+    assert "- preset_id: `knn-demo`" in markdown, markdown
+    assert "- baseline_source: `preset_fixture_not_question_text`" in markdown, markdown
+    assert "- question_text_supplies_baseline: `False`" in markdown, markdown
+    assert "--preset knn-demo" in markdown, markdown
+
+    print("auto-research-knn-preset-start-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/auto_research/bootstrap_contract.py
+++ b/loopx/capabilities/auto_research/bootstrap_contract.py
@@ -14,6 +14,7 @@ def auto_research_start_command_text(
     *,
     cli_bin: str,
     objective: str,
+    preset_id: str | None = None,
     execute: bool = False,
     headless: bool = False,
     no_attach: bool = False,
@@ -26,6 +27,8 @@ def auto_research_start_command_text(
         "start",
         shlex.quote(str(objective).strip()),
     ]
+    if preset_id:
+        parts.extend(["--preset", shlex.quote(str(preset_id).strip())])
     if output_language and output_language != "en":
         parts.extend(["--language", shlex.quote(output_language)])
     if execute:
@@ -76,6 +79,17 @@ def build_auto_research_contract_acceptance(
         if isinstance(user_contract.get("one_click_start"), dict)
         else {}
     )
+    preset_context = (
+        user_contract.get("preset_context")
+        if isinstance(user_contract.get("preset_context"), dict)
+        else {}
+    )
+    preset_id = str(preset_context.get("preset_id") or "").strip()
+    expected_start_template = (
+        f'loopx auto-research start "<open question>" --preset {preset_id} --execute'
+        if preset_id
+        else 'loopx auto-research start "<open question>" --execute'
+    )
     checks = {
         "one_question_input": user_contract.get("open_question") not in (None, ""),
         "required_outputs_present": len(present_outputs) == len(required_outputs),
@@ -86,8 +100,7 @@ def build_auto_research_contract_acceptance(
             command.get("canonical_invocation") == 'loopx auto-research "<open question>"'
         ),
         "one_click_start_present": (
-            one_click_start.get("command_template")
-            == 'loopx auto-research start "<open question>" --execute'
+            one_click_start.get("command_template") == expected_start_template
         ),
         "one_click_start_uses_generic_kernel": (
             one_click_start.get("uses_generic_kernel") is True

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -18,6 +18,7 @@ from .evidence_packet import load_auto_research_evidence_packet_inputs
 from .defaults import (
     AUTO_RESEARCH_DEFAULT_GOAL_ID,
     AUTO_RESEARCH_DEFAULT_OBJECTIVE,
+    AUTO_RESEARCH_SUPPORTED_PRESET_IDS,
 )
 from .demo_e2e import run_auto_research_demo_e2e
 from .live_evidence import (
@@ -32,6 +33,7 @@ from .rollout_append import (
 from .user_contract import (
     build_auto_research_user_contract,
     infer_auto_research_output_language,
+    normalize_auto_research_preset_id,
 )
 from ..multi_agent.visible_launch_policy import (
     make_visible_launcher_callback,
@@ -172,6 +174,11 @@ def register_auto_research_commands(
         default="auto",
         help="Human-readable output language for the research process.",
     )
+    contract_parser.add_argument(
+        "--preset",
+        choices=AUTO_RESEARCH_SUPPORTED_PRESET_IDS,
+        help="Explicit domain demo context, e.g. knn-demo supplies the KNN baseline fixture.",
+    )
 
     start_parser = auto_research_sub.add_parser(
         "start",
@@ -184,6 +191,14 @@ def register_auto_research_commands(
         choices=["auto", "zh", "en"],
         default="auto",
         help="Human-readable output language for visible role panes.",
+    )
+    start_parser.add_argument(
+        "--preset",
+        choices=AUTO_RESEARCH_SUPPORTED_PRESET_IDS,
+        help=(
+            "Explicit domain demo context. Use knn-demo when the baseline/metric "
+            "come from the built-in KNN demo fixture rather than the question text."
+        ),
     )
     start_parser.add_argument(
         "--execute",
@@ -858,8 +873,10 @@ def handle_auto_research_command(
                 args.open_question,
                 max_todos=args.max_todos,
                 output_language=args.language,
+                preset_id=args.preset,
             )
         elif args.auto_research_command == "start":
+            preset_id = normalize_auto_research_preset_id(args.preset)
             launch_visible = bool(args.execute and not args.headless)
             visible_policy = resolve_visible_launch_policy(
                 args,
@@ -927,6 +944,7 @@ def handle_auto_research_command(
                 goal_id=goal_id,
                 goal_surface_mode=goal_surface_mode,
                 tracking_goal_id=args.tracking_goal_id,
+                preset_id=preset_id,
                 objective=args.open_question,
                 output_dir="auto_research_lightweight_kernel",
                 execute=args.execute,

--- a/loopx/capabilities/auto_research/defaults.py
+++ b/loopx/capabilities/auto_research/defaults.py
@@ -8,6 +8,23 @@ AUTO_RESEARCH_DEFAULT_OBJECTIVE = (
     "Improve a bounded research candidate through public-safe multi-agent evidence."
 )
 AUTO_RESEARCH_PRESET_ID = "auto_research_thin_preset"
+AUTO_RESEARCH_KNN_DEMO_PRESET_ID = "knn-demo"
+AUTO_RESEARCH_SUPPORTED_PRESET_IDS = (AUTO_RESEARCH_KNN_DEMO_PRESET_ID,)
+
+AUTO_RESEARCH_KNN_DEMO_CONTEXT = {
+    "schema_version": "auto_research_preset_context_v0",
+    "preset_id": AUTO_RESEARCH_KNN_DEMO_PRESET_ID,
+    "source": "built_in_demo_preset",
+    "baseline_source": "preset_fixture_not_question_text",
+    "question_text_supplies_baseline": False,
+    "metric_name": "holdout_metric",
+    "baseline_metric": 1.0,
+    "protected_scope": ["metric_definition", "baseline_metric", "holdout_split"],
+    "claim_boundary": (
+        "The KNN baseline and holdout split come from the explicit demo preset; "
+        "improvement claims still require public-safe evidence."
+    ),
+}
 
 
 def build_auto_research_layer_contract() -> dict[str, object]:

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -1025,6 +1025,7 @@ def run_auto_research_demo_e2e(
     goal_id: str,
     tracking_goal_id: str | None,
     objective: str,
+    preset_id: str | None = None,
     output_dir: str,
     execute: bool,
     launch_visible: bool,
@@ -1073,6 +1074,12 @@ def run_auto_research_demo_e2e(
     user_contract = build_auto_research_user_contract(
         objective,
         output_language=output_language,
+        preset_id=preset_id,
+    )
+    preset_context = (
+        user_contract.get("preset_context")
+        if isinstance(user_contract.get("preset_context"), dict)
+        else None
     )
     contract_acceptance = build_auto_research_contract_acceptance(user_contract)
     supervisor = build_auto_research_demo_supervisor_plan(
@@ -1112,6 +1119,10 @@ def run_auto_research_demo_e2e(
             "goal_surface_mode": goal_surface_mode,
             "frontier_goal_id": goal_id,
             "tracking_goal_id": tracking_goal or None,
+            "preset_id": preset_context.get("preset_id") if preset_context else None,
+            "preset_baseline_source": (
+                preset_context.get("baseline_source") if preset_context else None
+            ),
             "tracking_goal_drives_frontier": False,
             "visible_lanes_read_goal_id": goal_id,
             "fresh_goal_default": goal_surface_mode == "fresh_demo_goal",
@@ -1130,6 +1141,7 @@ def run_auto_research_demo_e2e(
         "reasoning_effort": reasoning_effort,
         "output_language": output_language,
         "user_contract": user_contract,
+        "preset_context": preset_context,
         "contract_acceptance": contract_acceptance,
         "commands": {
             "one_question_contract": auto_research_contract_command_text(
@@ -1139,17 +1151,20 @@ def run_auto_research_demo_e2e(
             "one_question_start": auto_research_start_command_text(
                 cli_bin=cli_bin,
                 objective=objective,
+                preset_id=preset_id,
                 execute=True,
                 output_language=output_language,
             ),
             "one_question_start_preview": auto_research_start_command_text(
                 cli_bin=cli_bin,
                 objective=objective,
+                preset_id=preset_id,
                 output_language=output_language,
             ),
             "one_question_start_with_visible_wake": auto_research_start_command_text(
                 cli_bin=cli_bin,
                 objective=objective,
+                preset_id=preset_id,
                 execute=True,
                 output_language=output_language,
             ),

--- a/loopx/capabilities/auto_research/human_view.py
+++ b/loopx/capabilities/auto_research/human_view.py
@@ -208,6 +208,7 @@ def _render_user_contract(payload: dict[str, object]) -> str:
     one_click_start = _dict_value(payload, "one_click_start")
     next_step = _dict_value(payload, "next_executable_step")
     gate = _dict_value(payload, "gate")
+    preset_context = _dict_value(payload, "preset_context")
     gates = gate.get("user_judgment_needed") if isinstance(gate.get("user_judgment_needed"), list) else []
     lines = [
         "# LoopX Auto Research",
@@ -221,9 +222,23 @@ def _render_user_contract(payload: dict[str, object]) -> str:
         f"- not_read: `{_join_or_none(brief.get('not_read'))}`",
         f"- claim_boundary: {brief.get('claim_boundary')}",
         "",
-        "## Action Plan",
-        "",
     ]
+    if preset_context:
+        lines.extend(
+            [
+                "## Preset Context",
+                "",
+                f"- preset_id: `{preset_context.get('preset_id')}`",
+                f"- baseline_source: `{preset_context.get('baseline_source')}`",
+                f"- question_text_supplies_baseline: `{preset_context.get('question_text_supplies_baseline')}`",
+                f"- metric_name: `{preset_context.get('metric_name')}`",
+                f"- baseline_metric: `{preset_context.get('baseline_metric')}`",
+                f"- protected_scope: `{_join_or_none(preset_context.get('protected_scope'))}`",
+                f"- claim_boundary: {preset_context.get('claim_boundary')}",
+                "",
+            ]
+        )
+    lines.extend(["## Action Plan", ""])
     if not plan:
         lines.append("- none")
     for item in plan:
@@ -387,6 +402,7 @@ def _render_demo_e2e(payload: dict[str, object]) -> str:
             output_language=str(language_payload.get("resolved") or payload.get("output_language") or "en"),
         )
     route = _dict_value(payload, "route_contract")
+    preset_context = _dict_value(payload, "preset_context")
     live = _dict_value(payload, "visible_worker_proof")
     pane_rounds = _dict_value(payload, "visible_pane_a2a_rounds")
     collective_rounds = _dict_value(payload, "collective_research_rounds")
@@ -406,6 +422,9 @@ def _render_demo_e2e(payload: dict[str, object]) -> str:
         f"- goal_id: `{payload.get('goal_id')}`",
         f"- tracking_goal_id: `{payload.get('tracking_goal_id')}`",
         f"- frontier_goal_id: `{route.get('frontier_goal_id')}`",
+        f"- preset_id: `{preset_context.get('preset_id')}`",
+        f"- preset_baseline_source: `{preset_context.get('baseline_source')}`",
+        f"- baseline_metric: `{preset_context.get('baseline_metric')}`",
         f"- agent_id: `{payload.get('agent_id')}`",
         f"- user_contract_accepted: `{contract_acceptance.get('accepted')}`",
         f"- one_question_contract: `{commands.get('one_question_contract')}`",
@@ -438,6 +457,21 @@ def _render_demo_e2e(payload: dict[str, object]) -> str:
         f"- visible_holdout_delta_over_dev: `{improvement.get('holdout_delta_over_dev')}`",
         f"- supervisor_lanes: `{supervisor.get('lane_count')}`",
     ]
+    if preset_context:
+        lines.extend(
+            [
+                "",
+                "## Preset Context",
+                "",
+                f"- preset_id: `{preset_context.get('preset_id')}`",
+                f"- baseline_source: `{preset_context.get('baseline_source')}`",
+                f"- question_text_supplies_baseline: `{preset_context.get('question_text_supplies_baseline')}`",
+                f"- metric_name: `{preset_context.get('metric_name')}`",
+                f"- baseline_metric: `{preset_context.get('baseline_metric')}`",
+                f"- protected_scope: `{_join_or_none(preset_context.get('protected_scope'))}`",
+                f"- claim_boundary: {preset_context.get('claim_boundary')}",
+            ]
+        )
     lines.extend(
         _render_research_roles(
             minimal_recipe=minimal_recipe,

--- a/loopx/capabilities/auto_research/user_contract.py
+++ b/loopx/capabilities/auto_research/user_contract.py
@@ -2,7 +2,30 @@ from __future__ import annotations
 
 import shlex
 
+from .defaults import (
+    AUTO_RESEARCH_KNN_DEMO_CONTEXT,
+    AUTO_RESEARCH_KNN_DEMO_PRESET_ID,
+    AUTO_RESEARCH_SUPPORTED_PRESET_IDS,
+)
+
 AUTO_RESEARCH_USER_CONTRACT_SCHEMA_VERSION = "auto_research_user_contract_v0"
+
+
+def normalize_auto_research_preset_id(preset_id: str | None) -> str | None:
+    text = str(preset_id or "").strip()
+    if not text:
+        return None
+    if text not in AUTO_RESEARCH_SUPPORTED_PRESET_IDS:
+        supported = ", ".join(AUTO_RESEARCH_SUPPORTED_PRESET_IDS)
+        raise ValueError(f"unsupported auto-research preset {text!r}; supported: {supported}")
+    return text
+
+
+def build_auto_research_preset_context(preset_id: str | None) -> dict[str, object] | None:
+    normalized = normalize_auto_research_preset_id(preset_id)
+    if normalized == AUTO_RESEARCH_KNN_DEMO_PRESET_ID:
+        return dict(AUTO_RESEARCH_KNN_DEMO_CONTEXT)
+    return None
 
 
 def infer_auto_research_output_language(
@@ -22,10 +45,15 @@ def build_auto_research_user_contract(
     *,
     max_todos: int = 5,
     output_language: str = "auto",
+    preset_id: str | None = None,
 ) -> dict[str, object]:
     question = " ".join(str(open_question or "").strip().split())
     if not question:
         raise ValueError('auto-research requires an open question, e.g. loopx auto-research "..."')
+    preset_context = build_auto_research_preset_context(preset_id)
+    normalized_preset_id = (
+        str(preset_context.get("preset_id")) if preset_context else None
+    )
     todo_limit = min(max(1, int(max_todos)), 5)
     resolved_language = infer_auto_research_output_language(
         question,
@@ -41,11 +69,20 @@ def build_auto_research_user_contract(
             ("P2", "Summarize gates and unresolved evidence gaps without expanding the user contract.", "auto_research_preset"),
         ][:todo_limit]
     ]
+    preset_flag = (
+        f" --preset {shlex.quote(normalized_preset_id)}"
+        if normalized_preset_id
+        else ""
+    )
     language_flag = f" --language {shlex.quote(resolved_language)}" if resolved_language != "en" else ""
     start_command = (
-        f"loopx auto-research start {shlex.quote(question)}{language_flag} --execute"
+        f"loopx auto-research start {shlex.quote(question)}{preset_flag}{language_flag} --execute"
     )
     takeover_command = f"{start_command} --attach"
+    command_template = (
+        f'loopx auto-research start "<open question>"{preset_flag} --execute'
+    )
+    preview_template = f'loopx auto-research start "<open question>"{preset_flag}'
     return {
         "ok": True,
         "schema_version": AUTO_RESEARCH_USER_CONTRACT_SCHEMA_VERSION,
@@ -66,9 +103,9 @@ def build_auto_research_user_contract(
         "command_contract": {
             "canonical_invocation": 'loopx auto-research "<open question>"',
             "explicit_invocation": 'loopx auto-research contract "<open question>"',
-            "one_click_start_invocation": 'loopx auto-research start "<open question>" --execute',
+            "one_click_start_invocation": command_template,
             "user_required_inputs": ["open_question"],
-            "user_optional_inputs": ["output_language"],
+            "user_optional_inputs": ["output_language", "preset"],
             "auto_research_required_outputs": [
                 "research_brief",
                 "action_plan",
@@ -80,15 +117,15 @@ def build_auto_research_user_contract(
         },
         "one_click_start": {
             "schema_version": "auto_research_one_click_start_v0",
-            "command_template": 'loopx auto-research start "<open question>" --execute',
+            "command_template": command_template,
             "command": start_command,
             "operator_takeover_command_template": (
-                'loopx auto-research start "<open question>" --execute --attach'
+                f"{command_template} --attach"
             ),
             "operator_takeover_command": takeover_command,
-            "preview_command_template": 'loopx auto-research start "<open question>"',
+            "preview_command_template": preview_template,
             "preview_command": (
-                f"loopx auto-research start {shlex.quote(question)}{language_flag}"
+                f"loopx auto-research start {shlex.quote(question)}{preset_flag}{language_flag}"
             ),
             "starts": "visible_codex_tui_lanes",
             "attach_semantics": (
@@ -104,6 +141,7 @@ def build_auto_research_user_contract(
                 "frontier_protocol",
             ],
         },
+        **({"preset_context": preset_context} if preset_context else {}),
         "research_brief": {
             "read": [],
             "not_read": [


### PR DESCRIPTION
## Summary
- add `--preset knn-demo` to `loopx auto-research contract/start` so KNN baseline context is explicit
- expose preset context in JSON/Markdown: baseline source, metric name, baseline metric, protected scope
- update the KNN command-path docs and add a focused start smoke

## Validation
- python3 examples/auto-research-knn-preset-start-smoke.py
- python3 examples/auto-research-knn-continuation-smoke.py
- python3 examples/auto-research-layered-e2e-acceptance-smoke.py
- python3 examples/auto-research-start-markdown-commands-smoke.py
- python3 examples/auto-research-dev-thin-preset-smoke.py
- loopx check --scan-path ... (8 changed files; public boundary clean, existing loopx-meta duplicate-index warning only)
- loopx canary premerge --from-git-diff --tier standard --max-checks-per-profile 4 --timeout-seconds 60

## Boundary
The user layer remains one open question. `--preset knn-demo` only declares the demo context; baseline/holdout metadata is not inferred from the question text, and no new runner or workflow layer is added.