### PR TITLE
Extract external evidence observation seam

### DIFF
--- a/examples/control_plane/external-evidence-observation-smoke.py
+++ b/examples/control_plane/external-evidence-observation-smoke.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python3
+"""Smoke-test external-evidence monitor observation as a scheduler seam."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx.control_plane.scheduler.external_evidence_observation import (  # noqa: E402
+    build_external_evidence_observation_obligation,
+    build_external_evidence_poll_signal,
+    projected_monitor_handle,
+    todo_summary_open_task_counts,
+)
+from loopx.control_plane.scheduler.monitor_poll_policy import (  # noqa: E402
+    allows_no_spend_external_monitor_poll,
+)
+from loopx.control_plane.todos.contract import (  # noqa: E402
+    TODO_TASK_CLASS_ADVANCEMENT,
+    TODO_TASK_CLASS_MONITOR,
+)
+from loopx.quota import build_quota_should_run  # noqa: E402
+from loopx.status import compact_todo_group  # noqa: E402
+
+
+GOAL_ID = "external-evidence-observation-fixture"
+AGENT_ID = "codex-product-capability"
+PAST_DUE_AT = "2000-01-01T00:00:00+00:00"
+FUTURE_DUE_AT = "2999-01-01T00:00:00+00:00"
+
+
+def todo(
+    index: int,
+    text: str,
+    *,
+    task_class: str,
+    todo_id: str,
+    **metadata: Any,
+) -> dict[str, Any]:
+    item = {
+        "schema_version": "todo_item_v0",
+        "todo_id": todo_id,
+        "role": "agent",
+        "source_section": "Agent Todo",
+        "status": "open",
+        "done": False,
+        "index": index,
+        "text": text,
+        "task_class": task_class,
+    }
+    item.update(metadata)
+    return item
+
+
+def agent_todos(items: list[dict[str, Any]]) -> dict[str, Any]:
+    summary = compact_todo_group(items, source_section="Agent Todo", role="agent")
+    if summary is None:
+        summary = {
+            "schema_version": "todo_summary_v0",
+            "source_section": "Agent Todo",
+            "total_count": 0,
+            "open_count": 0,
+            "done_count": 0,
+            "first_open_items": [],
+        }
+    summary["claim_scope"] = {"agent_id": AGENT_ID}
+    return summary
+
+
+def monitor_todo(
+    *,
+    todo_id: str = "todo_monitor_result",
+    priority: str = "P1",
+    next_due_at: str = PAST_DUE_AT,
+) -> dict[str, Any]:
+    return todo(
+        1,
+        f"[{priority}] Monitor compact result marker and write back only if it changed.",
+        task_class=TODO_TASK_CLASS_MONITOR,
+        todo_id=todo_id,
+        target_key="job:compact-result",
+        next_due_at=next_due_at,
+        claimed_by=AGENT_ID,
+    )
+
+
+def advancement_todo() -> dict[str, Any]:
+    return todo(
+        2,
+        "[P0] Advance the canary/refactor slice with a validated patch.",
+        task_class=TODO_TASK_CLASS_ADVANCEMENT,
+        todo_id="todo_advancement_now",
+        claimed_by=AGENT_ID,
+    )
+
+
+def status_payload(
+    summary: dict[str, Any],
+    *,
+    status: str = "launched_polling_result",
+    waiting_on: str = "codex",
+    next_action: str = "Observe compact result marker for remote job handle.",
+) -> dict[str, Any]:
+    quota = {
+        "compute": 1.0,
+        "window_hours": 24,
+        "slot_minutes": 1,
+        "allowed_slots": 1440,
+        "spent_slots": 0,
+        "state": "eligible",
+        "reason": "fixture eligible quota",
+    }
+    return {
+        "ok": True,
+        "attention_queue": {
+            "items": [
+                {
+                    "goal_id": GOAL_ID,
+                    "status": status,
+                    "waiting_on": waiting_on,
+                    "severity": "info",
+                    "source": "project_asset",
+                    "recommended_action": next_action,
+                    "quota": quota,
+                    "agent_todos": summary,
+                    "project_asset": {
+                        "agent_todos": summary,
+                        "next_action": next_action,
+                    },
+                    "lifecycle_flags": ["launched polling result marker"],
+                }
+            ]
+        },
+        "run_history": {
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "registry_member": True,
+                    "quota": quota,
+                    "latest_runs": [],
+                    "coordination": {
+                        "primary_agent": "codex-main-control",
+                        "registered_agents": ["codex-main-control", AGENT_ID],
+                    },
+                }
+            ]
+        },
+    }
+
+
+def selected_item(payload: dict[str, Any]) -> dict[str, Any]:
+    return payload["attention_queue"]["items"][0]
+
+
+def assert_monitor_only_launched_poll_requires_observation() -> None:
+    summary = agent_todos([monitor_todo()])
+    item = selected_item(status_payload(summary))
+
+    handle = projected_monitor_handle(summary)
+    assert handle and handle["todo_id"] == "todo_monitor_result", handle
+    assert handle["target_key"] == "job:compact-result", handle
+
+    signal = build_external_evidence_poll_signal(item, agent_todo_summary=summary)
+    assert signal and signal["matched_signal"] == "launched_wait", signal
+    assert signal["monitor_handle"]["todo_id"] == "todo_monitor_result", signal
+
+    obligation = build_external_evidence_observation_obligation(
+        item,
+        state="active",
+        agent_todo_summary=summary,
+        work_lane_contract={"lane": "continuous_monitor"},
+    )
+    assert obligation and obligation["kind"] == "launched_external_work_monitor", obligation
+    assert obligation["monitor_handle"]["target_key"] == "job:compact-result", obligation
+
+    guard = build_quota_should_run(status_payload(summary), goal_id=GOAL_ID, agent_id=AGENT_ID)
+    lane = guard["work_lane_contract"]
+    assert lane["lane"] == "continuous_monitor", guard
+    assert lane["monitor_kind"] == "external_evidence", guard
+    assert guard["effective_action"] == "external_evidence_observe", guard
+    assert guard["execution_obligation"]["kind"] == "external_evidence_observation_required", guard
+    assert allows_no_spend_external_monitor_poll(guard) is True, guard
+
+
+def assert_advancement_lane_keeps_external_monitor_as_context() -> None:
+    summary = agent_todos(
+        [
+            monitor_todo(todo_id="todo_monitor_context", priority="P2"),
+            advancement_todo(),
+        ]
+    )
+    item = selected_item(status_payload(summary))
+    assert build_external_evidence_poll_signal(item, agent_todo_summary=summary), item
+
+    guard = build_quota_should_run(status_payload(summary), goal_id=GOAL_ID, agent_id=AGENT_ID)
+    lane = guard["work_lane_contract"]
+    assert lane["lane"] == "advancement_task", guard
+    assert lane["obligation"] == "advance_one_bounded_segment", guard
+    assert "external_monitor_context" in lane["reason_codes"], guard
+    assert "external_evidence_observation" not in guard, guard
+    assert guard["execution_obligation"]["kind"] == "work_lane_contract", guard
+    assert guard["agent_lane_next_action"]["todo_id"] == "todo_advancement_now", guard
+
+
+def assert_future_scoped_monitor_does_not_fake_external_poll() -> None:
+    summary = agent_todos(
+        [
+            monitor_todo(
+                todo_id="todo_monitor_future",
+                priority="P1",
+                next_due_at=FUTURE_DUE_AT,
+            )
+        ]
+    )
+    item = selected_item(status_payload(summary))
+    counts = todo_summary_open_task_counts(summary)
+    assert counts["monitor"] == 1 and counts["advancement"] == 0, counts
+    assert build_external_evidence_poll_signal(item, agent_todo_summary=summary) is None
+
+    obligation = build_external_evidence_observation_obligation(
+        item,
+        state="active",
+        agent_todo_summary=summary,
+        work_lane_contract={"lane": "continuous_monitor"},
+    )
+    assert obligation is None, obligation
+
+    guard = build_quota_should_run(status_payload(summary), goal_id=GOAL_ID, agent_id=AGENT_ID)
+    lane = guard["work_lane_contract"]
+    assert lane["obligation"] == "quiet_until_material_monitor_transition", guard
+    assert lane["must_attempt_work"] is False, guard
+    assert "external_evidence_observation" not in guard, guard
+
+
+def assert_explicit_external_wait_builds_registry_obligation() -> None:
+    summary = agent_todos([])
+    payload = status_payload(
+        summary,
+        status="waiting",
+        waiting_on="external_evidence",
+        next_action="Wait for compact result marker before continuing.",
+    )
+    item = selected_item(payload)
+    obligation = build_external_evidence_observation_obligation(
+        item,
+        state="waiting",
+        agent_todo_summary=summary,
+        work_lane_contract=None,
+    )
+    assert obligation and obligation["kind"] == "external_evidence_monitor", obligation
+    assert obligation["trigger"] == "registry_waiting_on_external_evidence", obligation
+    assert obligation["signal_source"] == "registry", obligation
+
+
+def main() -> int:
+    assert_monitor_only_launched_poll_requires_observation()
+    assert_advancement_lane_keeps_external_monitor_as_context()
+    assert_future_scoped_monitor_does_not_fake_external_poll()
+    assert_explicit_external_wait_builds_registry_obligation()
+    print("external-evidence-observation-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/control_plane/todo-projection-shared-helper-smoke.py
+++ b/examples/control_plane/todo-projection-shared-helper-smoke.py
@@ -14,7 +14,6 @@ if str(REPO_ROOT) not in sys.path:
 
 from loopx.quota import (  # noqa: E402
     _first_executable_todo_item as quota_first_executable_todo_item,
-    _todo_summary_monitor_items as quota_todo_summary_monitor_items,
     _todo_projection_sort_key as quota_todo_projection_sort_key,
     _todo_task_class as quota_todo_task_class,
     build_quota_should_run,
@@ -39,6 +38,9 @@ from loopx.control_plane.todos.projection import (  # noqa: E402
     todo_projection_sort_key as shared_todo_projection_sort_key,
     todo_summary_first_executable_item as shared_first_executable_todo_item,
     todo_summary_monitor_items as shared_todo_summary_monitor_items,
+)
+from loopx.control_plane.scheduler.external_evidence_observation import (  # noqa: E402
+    projected_monitor_handle,
 )
 
 
@@ -83,6 +85,7 @@ def build_agent_todo_summary() -> dict[str, Any]:
                 "[P2] Monitor unscheduled public smoke signal after schedule metadata is added.",
                 task_class=TODO_TASK_CLASS_MONITOR,
                 todo_id="todo_monitor_unscheduled",
+                target_key="public-smoke:unscheduled",
             ),
             todo(
                 2,
@@ -90,6 +93,7 @@ def build_agent_todo_summary() -> dict[str, Any]:
                 task_class=TODO_TASK_CLASS_MONITOR,
                 todo_id="todo_monitor_p0",
                 next_due_at="2026-01-01T00:00:00+00:00",
+                target_key="public-smoke:due",
             ),
             todo(
                 3,
@@ -292,12 +296,13 @@ def assert_monitor_item_collection_parity(summary: dict[str, Any]) -> None:
         "todo_monitor_unscheduled",
         "todo_monitor_p0",
     ]
-    for selector in (
-        shared_todo_summary_monitor_items,
-        quota_todo_summary_monitor_items,
-    ):
-        selected_ids = [item["todo_id"] for item in selector(summary)]
-        assert selected_ids == expected_ids, selected_ids
+    selected_ids = [item["todo_id"] for item in shared_todo_summary_monitor_items(summary)]
+    assert selected_ids == expected_ids, selected_ids
+
+    handle = projected_monitor_handle(summary)
+    assert isinstance(handle, dict), summary
+    assert handle["schema_version"] == "projected_monitor_handle_v0", handle
+    assert handle["todo_id"] == "todo_monitor_p0", handle
 
 
 def assert_first_executable_item_parity(summary: dict[str, Any]) -> None:

--- a/loopx/control_plane/scheduler/external_evidence_observation.py
+++ b/loopx/control_plane/scheduler/external_evidence_observation.py
@@ -1,0 +1,401 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from ..todos.contract import (
+    TODO_TASK_CLASS_ADVANCEMENT,
+    TODO_TASK_CLASS_MONITOR,
+    normalize_todo_claimed_by,
+    normalize_todo_id,
+)
+from ..todos.projection import (
+    todo_item_is_actionable_open,
+    todo_item_task_class,
+    todo_summary_claim_scope_agent_id,
+    todo_summary_has_only_future_scoped_monitor_work,
+    todo_summary_monitor_due_count,
+    todo_summary_monitor_items,
+    todo_summary_monitor_schedule_gap_count,
+)
+
+
+EXTERNAL_EVIDENCE_OBSERVATION_SCHEMA_VERSION = "external_evidence_observation_obligation_v0"
+PROJECTED_MONITOR_HANDLE_SCHEMA_VERSION = "projected_monitor_handle_v0"
+
+EXTERNAL_EVIDENCE_OBSERVE_PATTERNS = (
+    re.compile(
+        r"(?i)\b(?:poll(?:ing)?|observ(?:e|ing)|watch(?:ing)?|await(?:ing)?|wait\s+for|monitor(?:ing)?)\b.*\b"
+        r"(?:compact|result|artifact|marker|job|thread|run[-_\s]?id|worker|controller|writeback|trial[_\s-]?result)\b"
+    ),
+    re.compile(
+        r"(?i)\bwhen\b.*\b(?:result|artifact|marker|trial[_\s-]?result)\b.*\b"
+        r"(?:ingest|write\s*back|writeback|validate|review)\b"
+    ),
+)
+EXTERNAL_EVIDENCE_LAUNCHED_PATTERNS = (
+    re.compile(r"(?i)\b(?:launched|started|spawned|running|alive|materialized)\b.*\b(?:polling|result|marker)\b"),
+    re.compile(r"(?i)(?:launched|started|spawned|running|alive|materialized)[_\s-]+(?:polling|result|marker)"),
+    re.compile(r"(?i)\bready_for_compact_polling\b"),
+    re.compile(r"(?i)\bcompact\b.*\bresult\b.*\b(?:not\s+ready|ingest\s+not\s+ready)\b"),
+)
+EXTERNAL_EVIDENCE_HANDLE_ABSENT_PATTERNS = (
+    re.compile(
+        r"(?i)\b(?:no|without|absent|missing)\b.*\b"
+        r"(?:observable\s+)?(?:handle|channel|writeback|launch\s+summary|run[-_\s]?id|job)\b"
+    ),
+    re.compile(
+        r"(?i)\b(?:handle|channel|writeback|launch\s+summary|run[-_\s]?id|job)\b.*\b"
+        r"(?:absent|missing|not\s+available|does\s+not\s+exist|exists\s+yet)\b"
+    ),
+)
+
+
+def todo_summary_open_count(summary: dict[str, Any] | None) -> int:
+    if not isinstance(summary, dict):
+        return 0
+    try:
+        return max(0, int(summary.get("open_count") or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def todo_summary_open_task_counts(summary: dict[str, Any] | None) -> dict[str, int]:
+    open_count = todo_summary_open_count(summary)
+    classified_items: list[dict[str, Any]] = []
+    seen: set[tuple[Any, str]] = set()
+    executable_backlog_items: list[dict[str, Any]] | None = None
+    monitor_open_items: list[dict[str, Any]] | None = None
+    if isinstance(summary, dict):
+        raw_executable_backlog = summary.get("executable_backlog_items")
+        if isinstance(raw_executable_backlog, list):
+            executable_backlog_items = [
+                item
+                for item in raw_executable_backlog
+                if isinstance(item, dict)
+                if todo_item_is_actionable_open(item)
+                if todo_item_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
+            ]
+        raw_monitor_open = summary.get("monitor_open_items")
+        if isinstance(raw_monitor_open, list):
+            monitor_open_items = [
+                item
+                for item in raw_monitor_open
+                if isinstance(item, dict)
+                if todo_item_is_actionable_open(item)
+                if todo_item_task_class(item) == TODO_TASK_CLASS_MONITOR
+            ]
+        for key in (
+            "first_executable_items",
+            "first_open_items",
+            "monitor_open_items",
+        ):
+            source_items = summary.get(key)
+            if not isinstance(source_items, list):
+                continue
+            for item in source_items:
+                if not isinstance(item, dict):
+                    continue
+                text = str(item.get("text") or "").strip()
+                if not text:
+                    continue
+                identity = (item.get("index"), text)
+                if identity in seen:
+                    continue
+                seen.add(identity)
+                classified_items.append(item)
+    if executable_backlog_items is not None:
+        advancement_count = len(executable_backlog_items)
+    else:
+        visible_open = min(open_count, len(classified_items))
+        advancement_visible_count = sum(
+            1
+            for item in classified_items[:visible_open]
+            if todo_item_is_actionable_open(item)
+            and todo_item_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
+        )
+        hidden_count = max(0, open_count - visible_open)
+        advancement_count = advancement_visible_count + hidden_count
+    if monitor_open_items is not None:
+        monitor_visible_count = len(monitor_open_items)
+    else:
+        visible_open = min(open_count, len(classified_items))
+        monitor_visible_count = sum(
+            1
+            for item in classified_items[:visible_open]
+            if todo_item_is_actionable_open(item)
+            and todo_item_task_class(item) == TODO_TASK_CLASS_MONITOR
+        )
+    hidden_count = max(0, open_count - len(classified_items))
+    return {
+        "open": open_count,
+        "advancement": advancement_count,
+        "monitor": monitor_visible_count,
+        "monitor_due": todo_summary_monitor_due_count(summary),
+        "monitor_schedule_gap": todo_summary_monitor_schedule_gap_count(summary),
+        "hidden": hidden_count,
+    }
+
+
+def projected_monitor_handle(summary: dict[str, Any] | None) -> dict[str, Any] | None:
+    for item in todo_summary_monitor_items(summary):
+        target_key = str(item.get("target_key") or "").strip()
+        if not target_key:
+            continue
+        handle: dict[str, Any] = {
+            "schema_version": PROJECTED_MONITOR_HANDLE_SCHEMA_VERSION,
+            "target_key": target_key,
+        }
+        todo_id = normalize_todo_id(item.get("todo_id"))
+        if todo_id:
+            handle["todo_id"] = todo_id
+        claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
+        if claimed_by:
+            handle["claimed_by"] = claimed_by
+        next_due_at = str(item.get("next_due_at") or "").strip()
+        if next_due_at:
+            handle["next_due_at"] = next_due_at
+        target_text = str(item.get("title") or item.get("text") or "").strip()
+        if target_text:
+            handle["target_text"] = target_text[:320]
+        return handle
+    return None
+
+
+def scoped_monitor_watch_without_advancement(summary: dict[str, Any] | None) -> bool:
+    if not isinstance(summary, dict):
+        return False
+    if not todo_summary_claim_scope_agent_id(summary):
+        return False
+    if not todo_summary_monitor_items(summary):
+        return False
+    return todo_summary_open_task_counts(summary).get("advancement", 0) <= 0
+
+
+def build_external_evidence_poll_signal(
+    item: dict[str, Any],
+    *,
+    agent_todo_summary: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Detect launched external work whose next safe step is observation."""
+
+    if (
+        isinstance(agent_todo_summary, dict)
+        and todo_summary_claim_scope_agent_id(agent_todo_summary)
+        and todo_summary_open_count(agent_todo_summary) <= 0
+    ):
+        return None
+
+    scoped_monitor_handle = projected_monitor_handle(agent_todo_summary)
+    scoped_monitor_watch = scoped_monitor_watch_without_advancement(agent_todo_summary)
+    if todo_summary_has_only_future_scoped_monitor_work(agent_todo_summary):
+        return None
+    project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
+    action_texts = [
+        str(value or "").strip()
+        for value in (
+            project_asset.get("next_action"),
+            project_asset.get("recommended_action"),
+            item.get("next_action"),
+            item.get("recommended_action"),
+        )
+        if str(value or "").strip()
+    ]
+    todo_texts: list[str] = []
+    launched_texts: list[str] = [
+        str(value or "").strip()
+        for value in (
+            item.get("status"),
+            item.get("latest_run_classification"),
+            item.get("lifecycle_phase"),
+        )
+        if str(value or "").strip()
+    ]
+    lifecycle_flags = item.get("lifecycle_flags")
+    if isinstance(lifecycle_flags, list):
+        launched_texts.extend(
+            str(value or "").strip()
+            for value in lifecycle_flags
+            if str(value or "").strip()
+        )
+    if isinstance(agent_todo_summary, dict):
+        items = agent_todo_summary.get("first_open_items")
+        if isinstance(items, list):
+            for item_value in items:
+                if not isinstance(item_value, dict):
+                    continue
+                for key in ("title", "text"):
+                    value = str(item_value.get(key) or "").strip()
+                    if value:
+                        todo_texts.append(value)
+                for key in ("note", "evidence", "reason"):
+                    value = str(item_value.get(key) or "").strip()
+                    if value:
+                        launched_texts.append(value)
+
+    all_texts = [*action_texts, *todo_texts, *launched_texts]
+    if not all_texts:
+        return None
+
+    direct_observe_action = any(
+        pattern.search(text)
+        for pattern in EXTERNAL_EVIDENCE_OBSERVE_PATTERNS
+        for text in action_texts
+    )
+    direct_observe_todo = any(
+        pattern.search(text)
+        for pattern in EXTERNAL_EVIDENCE_OBSERVE_PATTERNS
+        for text in todo_texts
+    )
+    direct_observe_state = any(
+        pattern.search(text)
+        for pattern in EXTERNAL_EVIDENCE_OBSERVE_PATTERNS
+        for text in launched_texts
+    )
+    launched_wait = bool(action_texts) and any(
+        pattern.search(text)
+        for pattern in EXTERNAL_EVIDENCE_LAUNCHED_PATTERNS
+        for text in launched_texts
+    )
+    handle_absent = any(
+        pattern.search(text)
+        for pattern in EXTERNAL_EVIDENCE_HANDLE_ABSENT_PATTERNS
+        for text in action_texts
+    )
+    if handle_absent and not launched_wait and not direct_observe_action and not direct_observe_state:
+        return None
+    direct_observe = direct_observe_action or direct_observe_todo or direct_observe_state
+    if not direct_observe and not launched_wait:
+        return None
+    if scoped_monitor_watch and not scoped_monitor_handle:
+        return None
+    if (
+        scoped_monitor_watch
+        and todo_summary_monitor_due_count(agent_todo_summary) <= 0
+        and todo_summary_monitor_schedule_gap_count(agent_todo_summary) <= 0
+    ):
+        return None
+
+    scoped_monitor_target = (
+        str(scoped_monitor_handle.get("target_text") or "").strip()
+        if isinstance(scoped_monitor_handle, dict)
+        else ""
+    )
+    observation_target = scoped_monitor_target or next(
+        (text for text in action_texts if text),
+        None,
+    ) or next((text for text in todo_texts if text), "")
+    signal = {
+        "source": "active_state_or_latest_run",
+        "trigger": "implicit_launched_external_poll",
+        "observation_target": observation_target,
+        "matched_signal": "launched_wait" if launched_wait else "direct_observe",
+        "matched_channel": (
+            "action"
+            if launched_wait or direct_observe_action
+            else "todo"
+            if direct_observe_todo
+            else "state"
+        ),
+    }
+    if scoped_monitor_handle:
+        signal["monitor_handle"] = scoped_monitor_handle
+    return signal
+
+
+def build_external_evidence_observation_obligation(
+    item: dict[str, Any],
+    *,
+    state: str,
+    agent_todo_summary: dict[str, Any] | None,
+    work_lane_contract: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Return the machine contract for a waiting external-evidence monitor."""
+
+    explicit_wait = state == "waiting" and str(item.get("waiting_on") or "") == "external_evidence"
+    poll_signal = build_external_evidence_poll_signal(item, agent_todo_summary=agent_todo_summary)
+    if not explicit_wait and not poll_signal:
+        return None
+    if (
+        not explicit_wait
+        and poll_signal
+        and isinstance(agent_todo_summary, dict)
+        and todo_summary_claim_scope_agent_id(agent_todo_summary)
+        and todo_summary_open_count(agent_todo_summary) <= 0
+    ):
+        return None
+    if (
+        not explicit_wait
+        and isinstance(work_lane_contract, dict)
+        and work_lane_contract.get("lane") == "advancement_task"
+    ):
+        return None
+    next_todo = ""
+    if isinstance(agent_todo_summary, dict):
+        next_todo = str(agent_todo_summary.get("next") or "").strip()
+        if not next_todo:
+            items = agent_todo_summary.get("first_open_items")
+            if isinstance(items, list):
+                for item_value in items:
+                    if isinstance(item_value, dict) and str(item_value.get("text") or "").strip():
+                        next_todo = str(item_value.get("text") or "").strip()
+                        break
+    project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
+    observation_target = next_todo or str(
+        project_asset.get("next_action") or item.get("recommended_action") or ""
+    ).strip()
+    if poll_signal and poll_signal.get("observation_target"):
+        observation_target = str(poll_signal.get("observation_target") or observation_target)
+
+    obligation = {
+        "schema_version": EXTERNAL_EVIDENCE_OBSERVATION_SCHEMA_VERSION,
+        "required": True,
+        "kind": "external_evidence_monitor" if explicit_wait else "launched_external_work_monitor",
+        "trigger": "registry_waiting_on_external_evidence"
+        if explicit_wait
+        else poll_signal.get("trigger"),
+        "signal_source": poll_signal.get("source") if poll_signal else "registry",
+        "scope": "read_only_observation",
+        "must_attempt_observation": True,
+        "delivery_allowed": False,
+        "requires_observable_handle": True,
+        "observable_handle_examples": [
+            "thread_id",
+            "automation_id",
+            "job_id",
+            "lock_or_result_marker",
+            "compact_writeback_path",
+        ],
+        "observation_sources": [
+            "active_state",
+            "recommended_action",
+            "goal_boundary.next_probe",
+            "project_asset.agent_todos.next",
+            "connected controller or thread status",
+        ],
+        "observation_target": _compact_protocol_text(observation_target, limit=320),
+        "if_handle_missing": (
+            "write a compact blocker or launch-readiness fault; do not treat the "
+            "missing worker/controller handle as unchanged external evidence"
+        ),
+        "if_handle_live_and_unchanged": "quiet_noop_no_spend",
+        "if_material_transition": (
+            "write back the compact result/blocker/state transition, validate, then "
+            "spend exactly once when the writeback is substantive"
+        ),
+        "spend_policy": (
+            "no spend for read-only unchanged observation; spend only after validated "
+            "compact transition or blocker writeback"
+        ),
+    }
+    monitor_handle = poll_signal.get("monitor_handle") if isinstance(poll_signal, dict) else None
+    if isinstance(monitor_handle, dict) and monitor_handle:
+        obligation["monitor_handle"] = monitor_handle
+    return obligation
+
+
+def _compact_protocol_text(value: Any, *, limit: int) -> str:
+    text = " ".join(str(value or "").split())
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 3)].rstrip() + "..."

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -80,6 +80,11 @@ from .control_plane.scheduler.monitor_poll_policy import (
     allows_due_monitor_poll,
     allows_no_spend_external_monitor_poll,
 )
+from .control_plane.scheduler.external_evidence_observation import (
+    build_external_evidence_observation_obligation,
+    build_external_evidence_poll_signal,
+    todo_summary_open_task_counts,
+)
 from .control_plane.scheduler.monitor_poll_writeback import write_monitor_poll_todo_state
 from .control_plane.scheduler.monitor_target import build_quota_monitor_target
 from .control_plane.scheduler.state import (
@@ -137,10 +142,8 @@ from .control_plane.todos.projection import (
     todo_priority_label as projection_todo_priority_label,
     todo_priority_rank as projection_todo_priority_rank,
     todo_projection_sort_key as projection_todo_projection_sort_key,
-    todo_summary_has_only_future_scoped_monitor_work as projection_todo_summary_has_only_future_scoped_monitor_work,
     todo_summary_claim_scope_agent_id as projection_todo_summary_claim_scope_agent_id,
     todo_summary_first_executable_item as projection_todo_summary_first_executable_item,
-    todo_summary_monitor_items as projection_todo_summary_monitor_items,
     todo_summary_monitor_due_count as projection_todo_summary_monitor_due_count,
     todo_summary_monitor_due_items as projection_todo_summary_monitor_due_items,
     todo_summary_monitor_schedule_gap_count as projection_todo_summary_monitor_schedule_gap_count,
@@ -245,8 +248,6 @@ DEPENDENCY_OBSERVATION_CLASSIFICATION_HINTS = (
     "dependency_observation",
     "dependency_monitor",
 )
-EXTERNAL_EVIDENCE_OBSERVATION_SCHEMA_VERSION = "external_evidence_observation_obligation_v0"
-PROJECTED_MONITOR_HANDLE_SCHEMA_VERSION = "projected_monitor_handle_v0"
 AUTOMATION_LIVENESS_SCHEMA_VERSION = "automation_liveness_v0"
 CAPABILITY_GATE_SCHEMA_VERSION = "capability_gate_v0"
 DEFAULT_AVAILABLE_CAPABILITIES = (
@@ -258,32 +259,6 @@ TODO_BACKLOG_ITEM_LIMIT = 8
 TODO_DEFERRED_VISIBILITY_LIMIT = 8
 TODO_VISIBILITY_LANE_LIMIT = 16
 MONITOR_DUE_ITEM_LIMIT = 1
-EXTERNAL_EVIDENCE_OBSERVE_PATTERNS = (
-    re.compile(
-        r"(?i)\b(?:poll(?:ing)?|observ(?:e|ing)|watch(?:ing)?|await(?:ing)?|wait\s+for|monitor(?:ing)?)\b.*\b"
-        r"(?:compact|result|artifact|marker|job|thread|run[-_\s]?id|worker|controller|writeback|trial[_\s-]?result)\b"
-    ),
-    re.compile(
-        r"(?i)\bwhen\b.*\b(?:result|artifact|marker|trial[_\s-]?result)\b.*\b"
-        r"(?:ingest|write\s*back|writeback|validate|review)\b"
-    ),
-)
-EXTERNAL_EVIDENCE_LAUNCHED_PATTERNS = (
-    re.compile(r"(?i)\b(?:launched|started|spawned|running|alive|materialized)\b.*\b(?:polling|result|marker)\b"),
-    re.compile(r"(?i)(?:launched|started|spawned|running|alive|materialized)[_\s-]+(?:polling|result|marker)"),
-    re.compile(r"(?i)\bready_for_compact_polling\b"),
-    re.compile(r"(?i)\bcompact\b.*\bresult\b.*\b(?:not\s+ready|ingest\s+not\s+ready)\b"),
-)
-EXTERNAL_EVIDENCE_HANDLE_ABSENT_PATTERNS = (
-    re.compile(
-        r"(?i)\b(?:no|without|absent|missing)\b.*\b"
-        r"(?:observable\s+)?(?:handle|channel|writeback|launch\s+summary|run[-_\s]?id|job)\b"
-    ),
-    re.compile(
-        r"(?i)\b(?:handle|channel|writeback|launch\s+summary|run[-_\s]?id|job)\b.*\b"
-        r"(?:absent|missing|not\s+available|does\s+not\s+exist|exists\s+yet)\b"
-    ),
-)
 
 def _now_local() -> str:
     return datetime.now(timezone.utc).astimezone().replace(microsecond=0).isoformat()
@@ -422,172 +397,6 @@ def _item_progress_scope(item: dict[str, Any]) -> str:
     )
 
 
-def _external_evidence_poll_signal(
-    item: dict[str, Any],
-    *,
-    agent_todo_summary: dict[str, Any] | None,
-) -> dict[str, Any] | None:
-    """Detect launched external work whose next safe step is observation."""
-
-    if (
-        isinstance(agent_todo_summary, dict)
-        and _todo_summary_claim_scope_agent_id(agent_todo_summary)
-        and _open_todo_count(agent_todo_summary) <= 0
-    ):
-        return None
-
-    scoped_monitor_handle = _projected_monitor_handle(agent_todo_summary)
-    scoped_monitor_watch = _scoped_monitor_watch_without_advancement(agent_todo_summary)
-    if _todo_summary_has_only_future_scoped_monitor_work(agent_todo_summary):
-        return None
-    project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
-    action_texts = [
-        str(value or "").strip()
-        for value in (
-            project_asset.get("next_action"),
-            project_asset.get("recommended_action"),
-            item.get("next_action"),
-            item.get("recommended_action"),
-        )
-        if str(value or "").strip()
-    ]
-    todo_texts: list[str] = []
-    launched_texts: list[str] = [
-        str(value or "").strip()
-        for value in (
-            item.get("status"),
-            item.get("latest_run_classification"),
-            item.get("lifecycle_phase"),
-        )
-        if str(value or "").strip()
-    ]
-    lifecycle_flags = item.get("lifecycle_flags")
-    if isinstance(lifecycle_flags, list):
-        launched_texts.extend(
-            str(value or "").strip()
-            for value in lifecycle_flags
-            if str(value or "").strip()
-        )
-    if isinstance(agent_todo_summary, dict):
-        items = agent_todo_summary.get("first_open_items")
-        if isinstance(items, list):
-            for item_value in items:
-                if not isinstance(item_value, dict):
-                    continue
-                for key in ("title", "text"):
-                    value = str(item_value.get(key) or "").strip()
-                    if value:
-                        todo_texts.append(value)
-                for key in ("note", "evidence", "reason"):
-                    value = str(item_value.get(key) or "").strip()
-                    if value:
-                        launched_texts.append(value)
-
-    all_texts = [*action_texts, *todo_texts, *launched_texts]
-    if not all_texts:
-        return None
-
-    direct_observe_action = any(
-        pattern.search(text)
-        for pattern in EXTERNAL_EVIDENCE_OBSERVE_PATTERNS
-        for text in action_texts
-    )
-    direct_observe_todo = any(
-        pattern.search(text)
-        for pattern in EXTERNAL_EVIDENCE_OBSERVE_PATTERNS
-        for text in todo_texts
-    )
-    direct_observe_state = any(
-        pattern.search(text)
-        for pattern in EXTERNAL_EVIDENCE_OBSERVE_PATTERNS
-        for text in launched_texts
-    )
-    launched_wait = bool(action_texts) and any(
-        pattern.search(text)
-        for pattern in EXTERNAL_EVIDENCE_LAUNCHED_PATTERNS
-        for text in launched_texts
-    )
-    handle_absent = any(
-        pattern.search(text)
-        for pattern in EXTERNAL_EVIDENCE_HANDLE_ABSENT_PATTERNS
-        for text in action_texts
-    )
-    if handle_absent and not launched_wait and not direct_observe_action and not direct_observe_state:
-        return None
-    direct_observe = direct_observe_action or direct_observe_todo or direct_observe_state
-    if not direct_observe and not launched_wait:
-        return None
-    if scoped_monitor_watch and not scoped_monitor_handle:
-        return None
-    if scoped_monitor_watch and _todo_summary_monitor_due_count(agent_todo_summary) <= 0:
-        return None
-
-    scoped_monitor_target = (
-        str(scoped_monitor_handle.get("target_text") or "").strip()
-        if isinstance(scoped_monitor_handle, dict)
-        else ""
-    )
-    observation_target = scoped_monitor_target or next(
-        (text for text in action_texts if text),
-        None,
-    ) or next((text for text in todo_texts if text), "")
-    signal = {
-        "source": "active_state_or_latest_run",
-        "trigger": "implicit_launched_external_poll",
-        "observation_target": observation_target,
-        "matched_signal": "launched_wait" if launched_wait else "direct_observe",
-        "matched_channel": (
-            "action"
-            if launched_wait or direct_observe_action
-            else "todo"
-            if direct_observe_todo
-            else "state"
-        ),
-    }
-    if scoped_monitor_handle:
-        signal["monitor_handle"] = scoped_monitor_handle
-    return signal
-
-
-def _todo_summary_monitor_items(summary: dict[str, Any] | None) -> list[dict[str, Any]]:
-    return projection_todo_summary_monitor_items(summary)
-
-
-def _projected_monitor_handle(summary: dict[str, Any] | None) -> dict[str, Any] | None:
-    for item in _todo_summary_monitor_items(summary):
-        target_key = str(item.get("target_key") or "").strip()
-        if not target_key:
-            continue
-        handle: dict[str, Any] = {
-            "schema_version": PROJECTED_MONITOR_HANDLE_SCHEMA_VERSION,
-            "target_key": target_key,
-        }
-        todo_id = normalize_todo_id(item.get("todo_id"))
-        if todo_id:
-            handle["todo_id"] = todo_id
-        claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
-        if claimed_by:
-            handle["claimed_by"] = claimed_by
-        next_due_at = str(item.get("next_due_at") or "").strip()
-        if next_due_at:
-            handle["next_due_at"] = next_due_at
-        target_text = str(item.get("title") or item.get("text") or "").strip()
-        if target_text:
-            handle["target_text"] = target_text[:320]
-        return handle
-    return None
-
-
-def _scoped_monitor_watch_without_advancement(summary: dict[str, Any] | None) -> bool:
-    if not isinstance(summary, dict):
-        return False
-    if not _todo_summary_claim_scope_agent_id(summary):
-        return False
-    if not _todo_summary_monitor_items(summary):
-        return False
-    return _open_todo_task_counts(summary).get("advancement", 0) <= 0
-
-
 def _post_handoff_latest_run(item: dict[str, Any]) -> dict[str, Any]:
     handoff_readiness = (
         item.get("handoff_readiness")
@@ -612,8 +421,11 @@ def _work_lane_contract(
     agent_todo_summary: dict[str, Any] | None,
 ) -> dict[str, Any] | None:
     progress_scope = _item_progress_scope(item)
-    external_poll_signal = _external_evidence_poll_signal(item, agent_todo_summary=agent_todo_summary)
-    todo_counts = _open_todo_task_counts(agent_todo_summary)
+    external_poll_signal = build_external_evidence_poll_signal(
+        item,
+        agent_todo_summary=agent_todo_summary,
+    )
+    todo_counts = todo_summary_open_task_counts(agent_todo_summary)
     due_monitor_items = _todo_summary_monitor_due_items(agent_todo_summary)
     due_monitor_count = _todo_summary_monitor_due_count(
         agent_todo_summary,
@@ -651,97 +463,6 @@ def _work_lane_contract(
         resume_blocked_by_monitor_count=len(monitor_blocked_resume_candidates),
         resume_blocked_by_monitor_items=monitor_blocked_resume_candidates,
     )
-
-
-def _external_evidence_observation_obligation(
-    item: dict[str, Any],
-    *,
-    state: str,
-    agent_todo_summary: dict[str, Any] | None,
-    work_lane_contract: dict[str, Any] | None,
-) -> dict[str, Any] | None:
-    """Return the machine contract for a waiting external-evidence monitor."""
-
-    explicit_wait = state == "waiting" and str(item.get("waiting_on") or "") == "external_evidence"
-    poll_signal = _external_evidence_poll_signal(item, agent_todo_summary=agent_todo_summary)
-    if not explicit_wait and not poll_signal:
-        return None
-    if (
-        not explicit_wait
-        and poll_signal
-        and isinstance(agent_todo_summary, dict)
-        and _todo_summary_claim_scope_agent_id(agent_todo_summary)
-        and _open_todo_count(agent_todo_summary) <= 0
-    ):
-        return None
-    if (
-        not explicit_wait
-        and isinstance(work_lane_contract, dict)
-        and work_lane_contract.get("lane") == "advancement_task"
-    ):
-        return None
-    next_todo = ""
-    if isinstance(agent_todo_summary, dict):
-        next_todo = str(agent_todo_summary.get("next") or "").strip()
-        if not next_todo:
-            items = agent_todo_summary.get("first_open_items")
-            if isinstance(items, list):
-                for item_value in items:
-                    if isinstance(item_value, dict) and str(item_value.get("text") or "").strip():
-                        next_todo = str(item_value.get("text") or "").strip()
-                        break
-    project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
-    observation_target = next_todo or str(
-        project_asset.get("next_action") or item.get("recommended_action") or ""
-    ).strip()
-    if poll_signal and poll_signal.get("observation_target"):
-        observation_target = str(poll_signal.get("observation_target") or observation_target)
-
-    obligation = {
-        "schema_version": EXTERNAL_EVIDENCE_OBSERVATION_SCHEMA_VERSION,
-        "required": True,
-        "kind": "external_evidence_monitor" if explicit_wait else "launched_external_work_monitor",
-        "trigger": "registry_waiting_on_external_evidence"
-        if explicit_wait
-        else poll_signal.get("trigger"),
-        "signal_source": poll_signal.get("source") if poll_signal else "registry",
-        "scope": "read_only_observation",
-        "must_attempt_observation": True,
-        "delivery_allowed": False,
-        "requires_observable_handle": True,
-        "observable_handle_examples": [
-            "thread_id",
-            "automation_id",
-            "job_id",
-            "lock_or_result_marker",
-            "compact_writeback_path",
-        ],
-        "observation_sources": [
-            "active_state",
-            "recommended_action",
-            "goal_boundary.next_probe",
-            "project_asset.agent_todos.next",
-            "connected controller or thread status",
-        ],
-        "observation_target": _protocol_action_text(observation_target, limit=320),
-        "if_handle_missing": (
-            "write a compact blocker or launch-readiness fault; do not treat the "
-            "missing worker/controller handle as unchanged external evidence"
-        ),
-        "if_handle_live_and_unchanged": "quiet_noop_no_spend",
-        "if_material_transition": (
-            "write back the compact result/blocker/state transition, validate, then "
-            "spend exactly once when the writeback is substantive"
-        ),
-        "spend_policy": (
-            "no spend for read-only unchanged observation; spend only after validated "
-            "compact transition or blocker writeback"
-        ),
-    }
-    monitor_handle = poll_signal.get("monitor_handle") if isinstance(poll_signal, dict) else None
-    if isinstance(monitor_handle, dict) and monitor_handle:
-        obligation["monitor_handle"] = monitor_handle
-    return obligation
 
 
 def _focus_wait_quota(payload: dict[str, Any]) -> dict[str, Any]:
@@ -2483,91 +2204,8 @@ def _todo_summary_monitor_schedule_gap_count(
     )
 
 
-def _todo_summary_has_only_future_scoped_monitor_work(summary: dict[str, Any] | None) -> bool:
-    return projection_todo_summary_has_only_future_scoped_monitor_work(summary)
-
-
 def _first_executable_todo_item(agent_todo_summary: dict[str, Any] | None) -> dict[str, Any] | None:
     return projection_todo_summary_first_executable_item(agent_todo_summary)
-
-
-def _open_todo_task_counts(summary: dict[str, Any] | None) -> dict[str, int]:
-    open_count = _open_todo_count(summary)
-    classified_items: list[dict[str, Any]] = []
-    seen: set[tuple[Any, str]] = set()
-    executable_backlog_items: list[dict[str, Any]] | None = None
-    monitor_open_items: list[dict[str, Any]] | None = None
-    if isinstance(summary, dict):
-        raw_executable_backlog = summary.get("executable_backlog_items")
-        if isinstance(raw_executable_backlog, list):
-            executable_backlog_items = [
-                item
-                for item in raw_executable_backlog
-                if isinstance(item, dict)
-                if _todo_item_is_actionable_open(item)
-                if _todo_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
-            ]
-        raw_monitor_open = summary.get("monitor_open_items")
-        if isinstance(raw_monitor_open, list):
-            monitor_open_items = [
-                item
-                for item in raw_monitor_open
-                if isinstance(item, dict)
-                if _todo_item_is_actionable_open(item)
-                if _todo_task_class(item) == TODO_TASK_CLASS_MONITOR
-            ]
-        for key in (
-            "first_executable_items",
-            "first_open_items",
-            "monitor_open_items",
-        ):
-            source_items = summary.get(key)
-            if not isinstance(source_items, list):
-                continue
-            for item in source_items:
-                if not isinstance(item, dict):
-                    continue
-                text = str(item.get("text") or "").strip()
-                if not text:
-                    continue
-                identity = (item.get("index"), text)
-                if identity in seen:
-                    continue
-                seen.add(identity)
-                classified_items.append(item)
-    if executable_backlog_items is not None:
-        advancement_count = len(executable_backlog_items)
-    else:
-        visible_open = min(open_count, len(classified_items))
-        advancement_visible_count = sum(
-            1
-            for item in classified_items[:visible_open]
-            if _todo_item_is_actionable_open(item)
-            and _todo_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
-        )
-        hidden_count = max(0, open_count - visible_open)
-        advancement_count = advancement_visible_count + hidden_count
-    if monitor_open_items is not None:
-        monitor_visible_count = len(monitor_open_items)
-    else:
-        visible_open = min(open_count, len(classified_items))
-        monitor_visible_count = sum(
-            1
-            for item in classified_items[:visible_open]
-            if _todo_item_is_actionable_open(item)
-            and _todo_task_class(item) == TODO_TASK_CLASS_MONITOR
-        )
-    monitor_due_count = _todo_summary_monitor_due_count(summary)
-    monitor_schedule_gap_count = _todo_summary_monitor_schedule_gap_count(summary)
-    hidden_count = max(0, open_count - len(classified_items))
-    return {
-        "open": open_count,
-        "advancement": advancement_count,
-        "monitor": monitor_visible_count,
-        "monitor_due": monitor_due_count,
-        "monitor_schedule_gap": monitor_schedule_gap_count,
-        "hidden": hidden_count,
-    }
 
 
 def _outcome_floor_blocker_already_projected(
@@ -4132,7 +3770,7 @@ def build_quota_should_run(
                     "reason": blocked_priority_fallback.get("reason")
                     or heartbeat_recommendation.get("reason"),
                 }
-        external_evidence_observation = _external_evidence_observation_obligation(
+        external_evidence_observation = build_external_evidence_observation_obligation(
             item,
             state=state,
             agent_todo_summary=agent_todo_summary,


### PR DESCRIPTION
## Summary
- move external-evidence monitor signal/obligation construction out of quota into the scheduler control-plane context
- add a complex external-evidence observation canary covering monitor-only observation, advancement-context routing, future monitor quieting, and explicit registry waits
- update todo projection smoke to stop depending on quota private monitor wrapper

## Validation
- python3 -m py_compile loopx/quota.py loopx/control_plane/scheduler/external_evidence_observation.py examples/control_plane/external-evidence-observation-smoke.py examples/control_plane/todo-projection-shared-helper-smoke.py
- python3 examples/control_plane/external-evidence-observation-smoke.py
- python3 examples/control_plane/todo-projection-shared-helper-smoke.py
- python3 examples/control_plane/monitor-poll-policy-smoke.py
- python3 examples/control_plane/work-lane-contract-smoke.py
- python3 examples/control_plane/control-plane-integrated-canary-smoke.py
- python3 examples/control_plane/check-public-boundary-smoke.py
- loopx check --scan-path loopx/quota.py --scan-path loopx/control_plane/scheduler/external_evidence_observation.py --scan-path examples/control_plane/external-evidence-observation-smoke.py --scan-path examples/control_plane/todo-projection-shared-helper-smoke.py
- loopx canary premerge --from-git-diff --tier standard --timeout-seconds 120