### PR TITLE
Move todo open counts into todo projection

### DIFF
--- a/examples/control_plane/external-evidence-observation-smoke.py
+++ b/examples/control_plane/external-evidence-observation-smoke.py
@@ -15,7 +15,6 @@ from loopx.control_plane.scheduler.external_evidence_observation import (  # noq
     build_external_evidence_observation_obligation,
     build_external_evidence_poll_signal,
     projected_monitor_handle,
-    todo_summary_open_task_counts,
 )
 from loopx.control_plane.scheduler.monitor_poll_policy import (  # noqa: E402
     allows_no_spend_external_monitor_poll,
@@ -23,6 +22,9 @@ from loopx.control_plane.scheduler.monitor_poll_policy import (  # noqa: E402
 from loopx.control_plane.todos.contract import (  # noqa: E402
     TODO_TASK_CLASS_ADVANCEMENT,
     TODO_TASK_CLASS_MONITOR,
+)
+from loopx.control_plane.todos.projection import (  # noqa: E402
+    todo_summary_open_task_counts,
 )
 from loopx.quota import build_quota_should_run  # noqa: E402
 from loopx.status import compact_todo_group  # noqa: E402

--- a/examples/control_plane/todo-projection-shared-helper-smoke.py
+++ b/examples/control_plane/todo-projection-shared-helper-smoke.py
@@ -38,6 +38,7 @@ from loopx.control_plane.todos.projection import (  # noqa: E402
     todo_projection_sort_key as shared_todo_projection_sort_key,
     todo_summary_first_executable_item as shared_first_executable_todo_item,
     todo_summary_monitor_items as shared_todo_summary_monitor_items,
+    todo_summary_open_task_counts as shared_todo_summary_open_task_counts,
 )
 from loopx.control_plane.scheduler.external_evidence_observation import (  # noqa: E402
     projected_monitor_handle,
@@ -305,6 +306,60 @@ def assert_monitor_item_collection_parity(summary: dict[str, Any]) -> None:
     assert handle["todo_id"] == "todo_monitor_p0", handle
 
 
+def assert_open_task_count_state_machine(summary: dict[str, Any]) -> None:
+    counts = shared_todo_summary_open_task_counts(summary)
+    assert counts == {
+        "open": 5,
+        "advancement": 3,
+        "monitor": 2,
+        "monitor_due": 1,
+        "monitor_schedule_gap": 1,
+        "hidden": 0,
+    }, counts
+
+    hidden_summary = {
+        "open_count": 3,
+        "first_open_items": [
+            todo(
+                1,
+                "[P1] Visible advancement work.",
+                task_class=TODO_TASK_CLASS_ADVANCEMENT,
+                todo_id="todo_visible_advancement",
+            )
+        ],
+    }
+    hidden_counts = shared_todo_summary_open_task_counts(hidden_summary)
+    assert hidden_counts["open"] == 3, hidden_counts
+    assert hidden_counts["advancement"] == 3, hidden_counts
+    assert hidden_counts["monitor"] == 0, hidden_counts
+    assert hidden_counts["hidden"] == 2, hidden_counts
+
+    explicit_backlog_summary = {
+        "open_count": 4,
+        "executable_backlog_items": [
+            todo(
+                4,
+                "[P2] Explicit executable backlog item.",
+                task_class=TODO_TASK_CLASS_ADVANCEMENT,
+                todo_id="todo_explicit_backlog",
+            )
+        ],
+        "monitor_open_items": [
+            todo(
+                5,
+                "[P2] Explicit monitor backlog item.",
+                task_class=TODO_TASK_CLASS_MONITOR,
+                todo_id="todo_explicit_monitor",
+                target_key="public-smoke:explicit",
+            )
+        ],
+    }
+    explicit_counts = shared_todo_summary_open_task_counts(explicit_backlog_summary)
+    assert explicit_counts["open"] == 4, explicit_counts
+    assert explicit_counts["advancement"] == 1, explicit_counts
+    assert explicit_counts["monitor"] == 1, explicit_counts
+
+
 def assert_first_executable_item_parity(summary: dict[str, Any]) -> None:
     for selector in (
         shared_first_executable_todo_item,
@@ -345,6 +400,7 @@ def main() -> int:
     assert_claimed_visibility_parity()
     assert_deferred_helper_parity()
     assert_monitor_item_collection_parity(summary)
+    assert_open_task_count_state_machine(summary)
     assert_first_executable_item_parity(summary)
     assert_quota_uses_executable_advancement(summary)
     return 0

--- a/loopx/control_plane/scheduler/external_evidence_observation.py
+++ b/loopx/control_plane/scheduler/external_evidence_observation.py
@@ -3,20 +3,15 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from ..todos.contract import (
-    TODO_TASK_CLASS_ADVANCEMENT,
-    TODO_TASK_CLASS_MONITOR,
-    normalize_todo_claimed_by,
-    normalize_todo_id,
-)
+from ..todos.contract import normalize_todo_claimed_by, normalize_todo_id
 from ..todos.projection import (
-    todo_item_is_actionable_open,
-    todo_item_task_class,
     todo_summary_claim_scope_agent_id,
     todo_summary_has_only_future_scoped_monitor_work,
     todo_summary_monitor_due_count,
     todo_summary_monitor_items,
     todo_summary_monitor_schedule_gap_count,
+    todo_summary_open_count,
+    todo_summary_open_task_counts,
 )
 
 
@@ -49,92 +44,6 @@ EXTERNAL_EVIDENCE_HANDLE_ABSENT_PATTERNS = (
         r"(?:absent|missing|not\s+available|does\s+not\s+exist|exists\s+yet)\b"
     ),
 )
-
-
-def todo_summary_open_count(summary: dict[str, Any] | None) -> int:
-    if not isinstance(summary, dict):
-        return 0
-    try:
-        return max(0, int(summary.get("open_count") or 0))
-    except (TypeError, ValueError):
-        return 0
-
-
-def todo_summary_open_task_counts(summary: dict[str, Any] | None) -> dict[str, int]:
-    open_count = todo_summary_open_count(summary)
-    classified_items: list[dict[str, Any]] = []
-    seen: set[tuple[Any, str]] = set()
-    executable_backlog_items: list[dict[str, Any]] | None = None
-    monitor_open_items: list[dict[str, Any]] | None = None
-    if isinstance(summary, dict):
-        raw_executable_backlog = summary.get("executable_backlog_items")
-        if isinstance(raw_executable_backlog, list):
-            executable_backlog_items = [
-                item
-                for item in raw_executable_backlog
-                if isinstance(item, dict)
-                if todo_item_is_actionable_open(item)
-                if todo_item_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
-            ]
-        raw_monitor_open = summary.get("monitor_open_items")
-        if isinstance(raw_monitor_open, list):
-            monitor_open_items = [
-                item
-                for item in raw_monitor_open
-                if isinstance(item, dict)
-                if todo_item_is_actionable_open(item)
-                if todo_item_task_class(item) == TODO_TASK_CLASS_MONITOR
-            ]
-        for key in (
-            "first_executable_items",
-            "first_open_items",
-            "monitor_open_items",
-        ):
-            source_items = summary.get(key)
-            if not isinstance(source_items, list):
-                continue
-            for item in source_items:
-                if not isinstance(item, dict):
-                    continue
-                text = str(item.get("text") or "").strip()
-                if not text:
-                    continue
-                identity = (item.get("index"), text)
-                if identity in seen:
-                    continue
-                seen.add(identity)
-                classified_items.append(item)
-    if executable_backlog_items is not None:
-        advancement_count = len(executable_backlog_items)
-    else:
-        visible_open = min(open_count, len(classified_items))
-        advancement_visible_count = sum(
-            1
-            for item in classified_items[:visible_open]
-            if todo_item_is_actionable_open(item)
-            and todo_item_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
-        )
-        hidden_count = max(0, open_count - visible_open)
-        advancement_count = advancement_visible_count + hidden_count
-    if monitor_open_items is not None:
-        monitor_visible_count = len(monitor_open_items)
-    else:
-        visible_open = min(open_count, len(classified_items))
-        monitor_visible_count = sum(
-            1
-            for item in classified_items[:visible_open]
-            if todo_item_is_actionable_open(item)
-            and todo_item_task_class(item) == TODO_TASK_CLASS_MONITOR
-        )
-    hidden_count = max(0, open_count - len(classified_items))
-    return {
-        "open": open_count,
-        "advancement": advancement_count,
-        "monitor": monitor_visible_count,
-        "monitor_due": todo_summary_monitor_due_count(summary),
-        "monitor_schedule_gap": todo_summary_monitor_schedule_gap_count(summary),
-        "hidden": hidden_count,
-    }
 
 
 def projected_monitor_handle(summary: dict[str, Any] | None) -> dict[str, Any] | None:

--- a/loopx/control_plane/todos/projection.py
+++ b/loopx/control_plane/todos/projection.py
@@ -468,6 +468,92 @@ def todo_summary_monitor_schedule_gap_count(
     )
 
 
+def todo_summary_open_count(summary: dict[str, Any] | None) -> int:
+    if not isinstance(summary, dict):
+        return 0
+    try:
+        return max(0, int(summary.get("open_count") or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def todo_summary_open_task_counts(summary: dict[str, Any] | None) -> dict[str, int]:
+    open_count = todo_summary_open_count(summary)
+    classified_items: list[dict[str, Any]] = []
+    seen: set[tuple[Any, str]] = set()
+    executable_backlog_items: list[dict[str, Any]] | None = None
+    monitor_open_items: list[dict[str, Any]] | None = None
+    if isinstance(summary, dict):
+        raw_executable_backlog = summary.get("executable_backlog_items")
+        if isinstance(raw_executable_backlog, list):
+            executable_backlog_items = [
+                item
+                for item in raw_executable_backlog
+                if isinstance(item, dict)
+                if todo_item_is_actionable_open(item)
+                if todo_item_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
+            ]
+        raw_monitor_open = summary.get("monitor_open_items")
+        if isinstance(raw_monitor_open, list):
+            monitor_open_items = [
+                item
+                for item in raw_monitor_open
+                if isinstance(item, dict)
+                if todo_item_is_actionable_open(item)
+                if todo_item_task_class(item) == TODO_TASK_CLASS_MONITOR
+            ]
+        for key in (
+            "first_executable_items",
+            "first_open_items",
+            "monitor_open_items",
+        ):
+            source_items = summary.get(key)
+            if not isinstance(source_items, list):
+                continue
+            for item in source_items:
+                if not isinstance(item, dict):
+                    continue
+                text = str(item.get("text") or "").strip()
+                if not text:
+                    continue
+                identity = (item.get("index"), text)
+                if identity in seen:
+                    continue
+                seen.add(identity)
+                classified_items.append(item)
+    if executable_backlog_items is not None:
+        advancement_count = len(executable_backlog_items)
+    else:
+        visible_open = min(open_count, len(classified_items))
+        advancement_visible_count = sum(
+            1
+            for item in classified_items[:visible_open]
+            if todo_item_is_actionable_open(item)
+            and todo_item_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
+        )
+        hidden_count = max(0, open_count - visible_open)
+        advancement_count = advancement_visible_count + hidden_count
+    if monitor_open_items is not None:
+        monitor_visible_count = len(monitor_open_items)
+    else:
+        visible_open = min(open_count, len(classified_items))
+        monitor_visible_count = sum(
+            1
+            for item in classified_items[:visible_open]
+            if todo_item_is_actionable_open(item)
+            and todo_item_task_class(item) == TODO_TASK_CLASS_MONITOR
+        )
+    hidden_count = max(0, open_count - len(classified_items))
+    return {
+        "open": open_count,
+        "advancement": advancement_count,
+        "monitor": monitor_visible_count,
+        "monitor_due": todo_summary_monitor_due_count(summary),
+        "monitor_schedule_gap": todo_summary_monitor_schedule_gap_count(summary),
+        "hidden": hidden_count,
+    }
+
+
 def todo_summary_has_only_future_scoped_monitor_work(summary: dict[str, Any] | None) -> bool:
     """Return true when the scoped agent has only non-due monitor work left."""
 

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -83,6 +83,8 @@ from .control_plane.scheduler.monitor_poll_policy import (
 from .control_plane.scheduler.external_evidence_observation import (
     build_external_evidence_observation_obligation,
     build_external_evidence_poll_signal,
+)
+from .control_plane.todos.projection import (
     todo_summary_open_task_counts,
 )
 from .control_plane.scheduler.monitor_poll_writeback import write_monitor_poll_todo_state


### PR DESCRIPTION
## Summary
- Move shared todo open/task count helpers from the scheduler external-evidence seam into `loopx.control_plane.todos.projection`.
- Keep scheduler and quota behavior unchanged by importing the helper from the todo bounded context.
- Extend the shared todo projection smoke to cover open/advancement/monitor/due/schedule-gap/hidden count transitions.

## Product / Architecture Judgment
Motivation: the previous external-evidence extraction left generic todo projection state-machine logic inside a scheduler module.
Solved: this PR relocates that generic read model to the todo bounded context while the scheduler remains a consumer.
Impact: future quota/scheduler/runtime work can reuse the same todo count contract without depending on external-evidence scheduler internals.
Risk: low; behavior-preserving move plus focused and risk-based validation.
Design judgment: this is a cleaner bounded-context placement, not a new protocol surface or speculative framework.

## Validation
- `python3 -m py_compile loopx/control_plane/todos/projection.py loopx/control_plane/scheduler/external_evidence_observation.py loopx/quota.py examples/control_plane/external-evidence-observation-smoke.py examples/control_plane/todo-projection-shared-helper-smoke.py`
- `python3 examples/control_plane/todo-projection-shared-helper-smoke.py`
- `python3 examples/control_plane/external-evidence-observation-smoke.py`
- `python3 examples/control_plane/work-lane-contract-smoke.py`
- `python3 examples/control_plane/monitor-poll-policy-smoke.py`
- `python3 examples/control_plane/heartbeat-quota-flow-smoke.py`
- `git diff --check`
- `loopx check --scan-path ...` (public boundary clean; existing run-history duplicate-index warning only)
- `loopx canary premerge --from-git-diff --tier standard --timeout-seconds 120` (passed; 8 catalog canaries, 8 risk-profile smokes, public-boundary smoke)

## Merge Decision
Self-merge eligible: single-purpose control-plane cleanup, no benchmark execution/scoring change, no public evidence-policy change, no private/local state, and premerge gate passed with `self_merge_allowed=true`.
