### PR TITLE
Classify post-bridge Codex CLI goal blockers

### DIFF
--- a/examples/benchmark-run-status-snapshot-smoke.py
+++ b/examples/benchmark-run-status-snapshot-smoke.py
@@ -37,6 +37,13 @@ def main() -> int:
         failure_run = root / "swe-case-terminal-failure-r1"
         failure_run.mkdir()
         (failure_run / "status.env").write_text("rc=1\n", encoding="utf-8")
+        exception_run = root / "skills-case-exception-r1"
+        exception_run.mkdir()
+        (exception_run / "status.env").write_text(
+            "exception=RuntimeError\n",
+            encoding="utf-8",
+        )
+        (exception_run / "pid.private").write_text(str(os.getpid()), encoding="utf-8")
         requests = work / "requests"
         requests.mkdir()
         (requests / "abc.request.json").write_text("{}", encoding="utf-8")
@@ -107,6 +114,8 @@ def main() -> int:
                 "skills-case-running-r1",
                 "--label",
                 "swe-case-terminal-failure-r1",
+                "--label",
+                "skills-case-exception-r1",
                 "--pattern",
                 "Working",
                 "--pretty",
@@ -127,6 +136,7 @@ def main() -> int:
         item = payload["runs"][0]
         running_item = payload["runs"][1]
         failure_item = payload["runs"][2]
+        exception_item = payload["runs"][3]
         assert item["status"] == "rc=0"
         assert item["run_dir_recorded"] is False
         assert item["pid_alive"] is True
@@ -176,6 +186,12 @@ def main() -> int:
         assert failure_policy["compact_failure_closeout"] is True
         assert failure_policy["cleanup_required"] is True
         assert failure_policy["blocker_required_before_rerun"] is False
+        exception_policy = exception_item["observable_handle_policy"]
+        assert exception_item["pid_alive"] is True
+        assert exception_policy["observable_handle"]["state"] == "ended"
+        assert exception_policy["terminal_closeout"] is False
+        assert exception_policy["cleanup_required"] is True
+        assert exception_policy["blocker_required_before_rerun"] is True
         assert "secret raw transcript" not in proc.stdout
         assert "TASK_PROMPT_SHOULD_NOT_APPEAR_IN_SNAPSHOT" not in proc.stdout
         assert str(root) not in proc.stdout

--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -404,6 +404,7 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
         SkillsBenchLocalAcpRelay,
         _codex_cli_tui_post_bridge_blocker_stage,
         _codex_cli_tui_post_bridge_recovery_action,
+        _codex_cli_tui_post_bridge_recovery_skip_reason,
     )
     from scripts.skillsbench_automation_loop import (
         _merge_host_local_acp_relay_trace_summary,
@@ -432,9 +433,33 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
         == ""
     )
     assert (
+        _codex_cli_tui_post_bridge_recovery_skip_reason(
+            "request timed out while waiting for model\n› ",
+            stage="post_bridge_tui_model_timeout",
+            recovery_action="",
+        )
+        == "no_retry_affordance"
+    )
+    assert (
         _codex_cli_tui_post_bridge_recovery_action(
             "rate limit reached\npress enter to retry\n› ",
             stage="post_bridge_tui_rate_limit",
+        )
+        == ""
+    )
+    assert (
+        _codex_cli_tui_post_bridge_recovery_skip_reason(
+            "rate limit reached\npress enter to retry\n› ",
+            stage="post_bridge_tui_rate_limit",
+            recovery_action="",
+        )
+        == "rate_limit_no_retry"
+    )
+    assert (
+        _codex_cli_tui_post_bridge_recovery_skip_reason(
+            "request timed out while waiting for model\npress enter to retry\n› ",
+            stage="post_bridge_tui_model_timeout",
+            recovery_action="press_enter",
         )
         == ""
     )
@@ -483,7 +508,7 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
         )
         relay._publish_codex_cli_goal_trace(
             ok=False,
-            stage="post_bridge_tui_rate_limit",
+            stage="post_bridge_tui_error_prompt",
             goal_active_observed=False,
             goal_terminal_observed=False,
             first_action_observed=True,
@@ -501,19 +526,21 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
 
     prerequisites = plan["runner_prerequisites"]
     assert trace["codex_cli_goal_tui_trace_present"] is True, trace
-    assert trace["codex_cli_goal_tui_stage"] == "post_bridge_tui_rate_limit"
+    assert trace["codex_cli_goal_tui_stage"] == "post_bridge_tui_error_prompt"
+    assert trace["codex_cli_goal_tui_stages"] == ["post_bridge_tui_error_prompt"]
     assert trace["codex_cli_goal_tui_first_action_observed_count"] == 1
     assert trace["codex_cli_goal_tui_task_facing_success_count"] == 1
     assert trace["codex_cli_goal_tui_post_bridge_recovery_attempt_count"] == 1
     assert trace["codex_cli_goal_tui_post_bridge_recovery_action"] == "press_enter"
+    assert trace["codex_cli_goal_tui_post_bridge_recovery_skip_reason"] == ""
     assert trace["codex_cli_goal_tui_raw_material_recorded"] is False, trace
 
     public_prerequisites = _public_runner_prerequisites(prerequisites)
     assert public_prerequisites["codex_cli_goal_tui_stage"] == (
-        "post_bridge_tui_rate_limit"
+        "post_bridge_tui_error_prompt"
     )
     assert public_prerequisites["codex_cli_goal_tui_stages"] == [
-        "post_bridge_tui_rate_limit"
+        "post_bridge_tui_error_prompt"
     ]
     assert public_prerequisites["codex_cli_goal_tui_task_facing_success_count"] == 1
     assert (
@@ -524,6 +551,63 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
         public_prerequisites["codex_cli_goal_tui_post_bridge_recovery_action"]
         == "press_enter"
     )
+
+    with tempfile.TemporaryDirectory() as temp:
+        temp_path = Path(temp)
+        trace_dir = temp_path / "trace"
+        bridge_summary = temp_path / "remote-bridge-agent-ops.jsonl"
+        bridge_summary.write_text(
+            json.dumps(
+                {
+                    "record_phase": "complete",
+                    "task_facing_operation": True,
+                    "success": True,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        relay = SkillsBenchLocalAcpRelay(
+            CodexExecConfig(worker_public_trace_dir=str(trace_dir))
+        )
+        relay._publish_codex_cli_goal_trace(
+            ok=False,
+            stage="post_bridge_tui_model_timeout",
+            goal_active_observed=False,
+            goal_terminal_observed=False,
+            first_action_observed=True,
+            bridge_summary_path=bridge_summary,
+            post_bridge_recovery_skip_reason="no_retry_affordance",
+        )
+        plan = {
+            "route": "codex-cli-goal-baseline",
+            "host_local_acp_relay_trace_dir": str(trace_dir),
+            "runner_prerequisites": {},
+        }
+        trace = {}
+        _merge_host_local_acp_relay_trace_summary(plan, trace)
+
+    prerequisites = plan["runner_prerequisites"]
+    assert trace["codex_cli_goal_tui_stage"] == "post_bridge_tui_model_timeout"
+    assert trace["codex_cli_goal_tui_post_bridge_recovery_attempt_count"] == 0
+    assert trace["codex_cli_goal_tui_post_bridge_recovery_action"] == ""
+    assert (
+        trace["codex_cli_goal_tui_post_bridge_recovery_skip_reason"]
+        == "no_retry_affordance"
+    )
+    assert trace["codex_cli_goal_tui_post_bridge_recovery_skip_reasons"] == [
+        "no_retry_affordance"
+    ]
+    public_prerequisites = _public_runner_prerequisites(prerequisites)
+    assert (
+        public_prerequisites[
+            "codex_cli_goal_tui_post_bridge_recovery_skip_reason"
+        ]
+        == "no_retry_affordance"
+    )
+    assert public_prerequisites[
+        "codex_cli_goal_tui_post_bridge_recovery_skip_reasons"
+    ] == ["no_retry_affordance"]
 
 
 def _assert_cli_goal_active_timeout_is_public_countability_stage() -> None:

--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -47,14 +47,34 @@ def _assert_cli_goal_route_requires_materialized_solver_bridge() -> None:
         "--route",
         "codex-cli-goal-baseline",
         "--host-local-acp-launch",
-        "--remote-command-file-bridge-ready",
     )
     assert proc.returncode == 2, proc
     payload = _json_from_stderr(proc)
     assert payload["error_type"] == "SkillsBenchCodexCliGoalDriverRequired", payload
     assert payload["host_local_acp_launch"] is True, payload
-    assert payload["remote_command_file_bridge_ready"] is True, payload
+    assert payload["remote_command_file_bridge_ready"] is False, payload
     assert payload["remote_command_file_bridge_solver_command_configured"] is False
+    assert payload["remote_command_file_bridge_sandbox_auto_wiring_pending"] is False
+
+    # The real Docker bridge command is only available after BenchFlow creates
+    # the scored sandbox, so this route must allow the auto-wiring state.
+    proc = _run_runner(
+        "--route",
+        "codex-cli-goal-baseline",
+        "--host-local-acp-launch",
+        "--remote-command-file-bridge-ready",
+        "--plan-only",
+    )
+    assert proc.returncode == 0, proc
+    payload = json.loads(proc.stdout)
+    assert payload["ok"] is True, payload
+    prereq = payload["launch_plan"]["runner_prerequisites"]
+    assert prereq["remote_command_file_bridge_materialized"] is True, prereq
+    assert (
+        prereq["remote_command_file_bridge_consumption_status"]
+        == "sandbox_bridge_auto_wiring_pending"
+    ), prereq
+    assert prereq["remote_command_file_bridge_agent_operation_trace_required"] is True
 
 
 def _assert_cli_goal_plan_and_relay_command() -> None:

--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -383,6 +383,7 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
         CodexExecConfig,
         SkillsBenchLocalAcpRelay,
         _codex_cli_tui_post_bridge_blocker_stage,
+        _codex_cli_tui_post_bridge_recovery_action,
     )
     from scripts.skillsbench_automation_loop import (
         _merge_host_local_acp_relay_trace_summary,
@@ -395,6 +396,27 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
             prompt_visible=True,
         )
         == "post_bridge_tui_model_timeout"
+    )
+    assert (
+        _codex_cli_tui_post_bridge_recovery_action(
+            "request timed out while waiting for model\npress enter to retry\n› ",
+            stage="post_bridge_tui_model_timeout",
+        )
+        == "press_enter"
+    )
+    assert (
+        _codex_cli_tui_post_bridge_recovery_action(
+            "request timed out while waiting for model\n› ",
+            stage="post_bridge_tui_model_timeout",
+        )
+        == ""
+    )
+    assert (
+        _codex_cli_tui_post_bridge_recovery_action(
+            "rate limit reached\npress enter to retry\n› ",
+            stage="post_bridge_tui_rate_limit",
+        )
+        == ""
     )
     assert (
         _codex_cli_tui_post_bridge_blocker_stage(
@@ -446,6 +468,8 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
             goal_terminal_observed=False,
             first_action_observed=True,
             bridge_summary_path=bridge_summary,
+            post_bridge_recovery_attempt_count=1,
+            post_bridge_recovery_action="press_enter",
         )
         plan = {
             "route": "codex-cli-goal-baseline",
@@ -460,6 +484,8 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
     assert trace["codex_cli_goal_tui_stage"] == "post_bridge_tui_rate_limit"
     assert trace["codex_cli_goal_tui_first_action_observed_count"] == 1
     assert trace["codex_cli_goal_tui_task_facing_success_count"] == 1
+    assert trace["codex_cli_goal_tui_post_bridge_recovery_attempt_count"] == 1
+    assert trace["codex_cli_goal_tui_post_bridge_recovery_action"] == "press_enter"
     assert trace["codex_cli_goal_tui_raw_material_recorded"] is False, trace
 
     public_prerequisites = _public_runner_prerequisites(prerequisites)
@@ -470,6 +496,14 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
         "post_bridge_tui_rate_limit"
     ]
     assert public_prerequisites["codex_cli_goal_tui_task_facing_success_count"] == 1
+    assert (
+        public_prerequisites["codex_cli_goal_tui_post_bridge_recovery_attempt_count"]
+        == 1
+    )
+    assert (
+        public_prerequisites["codex_cli_goal_tui_post_bridge_recovery_action"]
+        == "press_enter"
+    )
 
 
 def _assert_cli_goal_active_timeout_is_public_countability_stage() -> None:

--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -377,6 +377,101 @@ def _assert_cli_goal_rate_limit_is_public_safe_retryable_stage() -> None:
     ]
 
 
+def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
+    sys.path.insert(0, str(REPO_ROOT))
+    from loopx.benchmark_adapters.skillsbench_acp_relay import (
+        CodexExecConfig,
+        SkillsBenchLocalAcpRelay,
+        _codex_cli_tui_post_bridge_blocker_stage,
+    )
+    from scripts.skillsbench_automation_loop import (
+        _merge_host_local_acp_relay_trace_summary,
+        _public_runner_prerequisites,
+    )
+
+    assert (
+        _codex_cli_tui_post_bridge_blocker_stage(
+            "request timed out while waiting for model\n› ",
+            prompt_visible=True,
+        )
+        == "post_bridge_tui_model_timeout"
+    )
+    assert (
+        _codex_cli_tui_post_bridge_blocker_stage(
+            "rate limit reached\n› ",
+            prompt_visible=True,
+        )
+        == "post_bridge_tui_rate_limit"
+    )
+    assert (
+        _codex_cli_tui_post_bridge_blocker_stage(
+            "rate limit reached\n",
+            prompt_visible=False,
+        )
+        == ""
+    )
+
+    with tempfile.TemporaryDirectory() as temp:
+        temp_path = Path(temp)
+        trace_dir = temp_path / "trace"
+        bridge_summary = temp_path / "remote-bridge-agent-ops.jsonl"
+        bridge_summary.write_text(
+            "\n".join(
+                [
+                    json.dumps(
+                        {
+                            "record_phase": "start",
+                            "task_facing_operation": True,
+                        }
+                    ),
+                    json.dumps(
+                        {
+                            "record_phase": "complete",
+                            "task_facing_operation": True,
+                            "success": True,
+                        }
+                    ),
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        relay = SkillsBenchLocalAcpRelay(
+            CodexExecConfig(worker_public_trace_dir=str(trace_dir))
+        )
+        relay._publish_codex_cli_goal_trace(
+            ok=False,
+            stage="post_bridge_tui_rate_limit",
+            goal_active_observed=False,
+            goal_terminal_observed=False,
+            first_action_observed=True,
+            bridge_summary_path=bridge_summary,
+        )
+        plan = {
+            "route": "codex-cli-goal-baseline",
+            "host_local_acp_relay_trace_dir": str(trace_dir),
+            "runner_prerequisites": {},
+        }
+        trace: dict[str, object] = {}
+        _merge_host_local_acp_relay_trace_summary(plan, trace)
+
+    prerequisites = plan["runner_prerequisites"]
+    assert trace["codex_cli_goal_tui_trace_present"] is True, trace
+    assert trace["codex_cli_goal_tui_stage"] == "post_bridge_tui_rate_limit"
+    assert trace["codex_cli_goal_tui_first_action_observed_count"] == 1
+    assert trace["codex_cli_goal_tui_task_facing_success_count"] == 1
+    assert trace["codex_cli_goal_tui_raw_material_recorded"] is False, trace
+
+    public_prerequisites = _public_runner_prerequisites(prerequisites)
+    assert public_prerequisites["codex_cli_goal_tui_stage"] == (
+        "post_bridge_tui_rate_limit"
+    )
+    assert public_prerequisites["codex_cli_goal_tui_stages"] == [
+        "post_bridge_tui_rate_limit"
+    ]
+    assert public_prerequisites["codex_cli_goal_tui_task_facing_success_count"] == 1
+
+
 def _assert_cli_goal_active_timeout_is_public_countability_stage() -> None:
     sys.path.insert(0, str(REPO_ROOT))
     from loopx.benchmark_adapters.skillsbench_acp_relay import (
@@ -587,6 +682,7 @@ def main() -> int:
     _assert_cli_goal_trace_merges_into_public_prerequisites()
     _assert_cli_goal_tui_ready_wait_tolerates_startup_warnings()
     _assert_cli_goal_rate_limit_is_public_safe_retryable_stage()
+    _assert_cli_goal_post_bridge_blocker_is_public_safe_stage()
     _assert_cli_goal_active_timeout_is_public_countability_stage()
     _assert_cli_goal_input_is_submitted_as_one_buffer()
     _assert_cli_goal_codex_api_proxy_is_runtime_only()

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -512,6 +512,39 @@ def _codex_cli_tui_retryable_startup_blocker_stage(capture: str) -> str:
     return ""
 
 
+def _codex_cli_tui_post_bridge_blocker_stage(
+    capture: str,
+    *,
+    prompt_visible: bool,
+) -> str:
+    """Classify public-safe Codex CLI TUI blockers after bridge activity."""
+
+    if not prompt_visible:
+        return ""
+    lowered = str(capture or "").lower()
+    if any(
+        marker in lowered
+        for marker in (
+            "rate limit",
+            "rate_limit",
+            "too many requests",
+            "status 429",
+            "error 429",
+        )
+    ):
+        return "post_bridge_tui_rate_limit"
+    if any(marker in lowered for marker in ("timed out", "timeout")) and any(
+        marker in lowered for marker in ("model", "request", "error", "failed")
+    ):
+        return "post_bridge_tui_model_timeout"
+    if any(marker in lowered for marker in ("press enter", "press return")) and any(
+        marker in lowered
+        for marker in ("error", "failed", "timed out", "timeout", "model")
+    ):
+        return "post_bridge_tui_error_prompt"
+    return ""
+
+
 def _write_process_stdin_async(
     proc: subprocess.Popen[str],
     stdin_text: str | None,
@@ -1393,6 +1426,38 @@ class SkillsBenchLocalAcpRelay:
                         )
                         return _recoverable_codex_turn_failure_message(
                             "codex_exec_first_action_timeout"
+                        )
+                    post_bridge_blocker_stage = ""
+                    if (
+                        bridge_activity_seen
+                        and bridge_summary_path is not None
+                        and not _bridge_summary_has_inflight_operation(
+                            bridge_summary_path
+                        )
+                    ):
+                        post_bridge_blocker_stage = (
+                            _codex_cli_tui_post_bridge_blocker_stage(
+                                capture,
+                                prompt_visible=(
+                                    self._codex_cli_tui_input_prompt_visible(capture)
+                                ),
+                            )
+                        )
+                    if post_bridge_blocker_stage:
+                        self._tmux_kill_session(tmux_name)
+                        self._publish_remote_bridge_agent_operations_trace(
+                            bridge_summary_path=bridge_summary_path,
+                        )
+                        self._publish_codex_cli_goal_trace(
+                            ok=False,
+                            stage=post_bridge_blocker_stage,
+                            goal_active_observed=goal_active_observed,
+                            goal_terminal_observed=goal_terminal_observed,
+                            first_action_observed=first_action_seen,
+                            bridge_summary_path=bridge_summary_path,
+                        )
+                        return _recoverable_codex_turn_failure_message(
+                            "codex_cli_goal_" + post_bridge_blocker_stage
                         )
                     if (
                         bridge_activity_seen

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -36,10 +36,12 @@ from loopx.codex_cli_goal_tui import (
     build_codex_cli_tui_command,
     codex_cli_tui_environment,
     codex_cli_tui_shell_command,
+    codex_cli_tui_input_prompt_visible,
     prewarm_codex_cli_goal_thread,
     tmux_capture,
     tmux_kill_session,
     tmux_paste_file_and_submit,
+    tmux_submit_enter,
     wait_for_codex_cli_tui_ready,
 )
 
@@ -542,6 +544,20 @@ def _codex_cli_tui_post_bridge_blocker_stage(
         for marker in ("error", "failed", "timed out", "timeout", "model")
     ):
         return "post_bridge_tui_error_prompt"
+    return ""
+
+
+def _codex_cli_tui_post_bridge_recovery_action(capture: str, *, stage: str) -> str:
+    """Return a bounded public-safe recovery action for post-bridge TUI blockers."""
+
+    if stage not in {
+        "post_bridge_tui_model_timeout",
+        "post_bridge_tui_error_prompt",
+    }:
+        return ""
+    lowered = str(capture or "").lower()
+    if any(marker in lowered for marker in ("press enter", "press return")):
+        return "press_enter"
     return ""
 
 
@@ -1205,6 +1221,8 @@ class SkillsBenchLocalAcpRelay:
             last_bridge_summary_size = 0
             last_bridge_activity_at = time.monotonic()
             meaningful_progress_seen = False
+            post_bridge_recovery_attempt_count = 0
+            post_bridge_recovery_action = ""
             try:
                 subprocess.run(
                     [
@@ -1439,12 +1457,30 @@ class SkillsBenchLocalAcpRelay:
                             _codex_cli_tui_post_bridge_blocker_stage(
                                 capture,
                                 prompt_visible=(
-                                    self._codex_cli_tui_input_prompt_visible(capture)
+                                    codex_cli_tui_input_prompt_visible(capture)
                                 ),
                             )
                         )
                     if post_bridge_blocker_stage:
-                        self._tmux_kill_session(tmux_name)
+                        recovery_action = _codex_cli_tui_post_bridge_recovery_action(
+                            capture,
+                            stage=post_bridge_blocker_stage,
+                        )
+                        if (
+                            recovery_action == "press_enter"
+                            and post_bridge_recovery_attempt_count < 1
+                        ):
+                            post_bridge_recovery_attempt_count += 1
+                            post_bridge_recovery_action = recovery_action
+                            tmux_submit_enter(tmux_name)
+                            last_bridge_activity_at = now
+                            next_heartbeat = (
+                                now
+                                + max(1.0, self._config.stream_heartbeat_interval_sec)
+                            )
+                            time.sleep(1.0)
+                            continue
+                        tmux_kill_session(tmux_name)
                         self._publish_remote_bridge_agent_operations_trace(
                             bridge_summary_path=bridge_summary_path,
                         )
@@ -1455,6 +1491,11 @@ class SkillsBenchLocalAcpRelay:
                             goal_terminal_observed=goal_terminal_observed,
                             first_action_observed=first_action_seen,
                             bridge_summary_path=bridge_summary_path,
+                            thread_prewarm_observed=thread_prewarm_observed,
+                            post_bridge_recovery_attempt_count=(
+                                post_bridge_recovery_attempt_count
+                            ),
+                            post_bridge_recovery_action=post_bridge_recovery_action,
                         )
                         return _recoverable_codex_turn_failure_message(
                             "codex_cli_goal_" + post_bridge_blocker_stage
@@ -1480,6 +1521,10 @@ class SkillsBenchLocalAcpRelay:
                             first_action_observed=first_action_seen,
                             bridge_summary_path=bridge_summary_path,
                             thread_prewarm_observed=thread_prewarm_observed,
+                            post_bridge_recovery_attempt_count=(
+                                post_bridge_recovery_attempt_count
+                            ),
+                            post_bridge_recovery_action=post_bridge_recovery_action,
                         )
                         return _recoverable_codex_turn_failure_message(
                             "codex_exec_bridge_idle_timeout"
@@ -1513,6 +1558,8 @@ class SkillsBenchLocalAcpRelay:
                     first_action_observed=first_action_seen,
                     bridge_summary_path=bridge_summary_path,
                     thread_prewarm_observed=thread_prewarm_observed,
+                    post_bridge_recovery_attempt_count=post_bridge_recovery_attempt_count,
+                    post_bridge_recovery_action=post_bridge_recovery_action,
                 )
                 if goal_terminal_observed and not goal_failed_observed:
                     return "codex cli /goal completed"
@@ -1550,6 +1597,8 @@ class SkillsBenchLocalAcpRelay:
         first_action_observed: bool,
         bridge_summary_path: Path | None,
         thread_prewarm_observed: bool = False,
+        post_bridge_recovery_attempt_count: int = 0,
+        post_bridge_recovery_action: str = "",
     ) -> None:
         if not self._config.worker_public_trace_dir:
             return
@@ -1598,6 +1647,13 @@ class SkillsBenchLocalAcpRelay:
                 "first_action_observed": bool(first_action_observed),
                 "bridge_request_count": bridge_request_count,
                 "task_facing_success_count": task_facing_success_count,
+                "post_bridge_recovery_attempt_count": max(
+                    0,
+                    int(post_bridge_recovery_attempt_count or 0),
+                ),
+                "post_bridge_recovery_action": str(
+                    post_bridge_recovery_action or ""
+                )[:40],
                 "reasoning_effort": str(self._config.reasoning_effort or "")[:40],
                 "codex_api_proxy_env_injected": bool(
                     codex_cli_tui_environment(self._config.codex_api_proxy)

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -561,6 +561,29 @@ def _codex_cli_tui_post_bridge_recovery_action(capture: str, *, stage: str) -> s
     return ""
 
 
+def _codex_cli_tui_post_bridge_recovery_skip_reason(
+    capture: str,
+    *,
+    stage: str,
+    recovery_action: str,
+) -> str:
+    """Return why no post-bridge recovery action was taken."""
+
+    if recovery_action:
+        return ""
+    if stage == "post_bridge_tui_rate_limit":
+        return "rate_limit_no_retry"
+    if stage not in {
+        "post_bridge_tui_model_timeout",
+        "post_bridge_tui_error_prompt",
+    }:
+        return ""
+    lowered = str(capture or "").lower()
+    if not any(marker in lowered for marker in ("press enter", "press return")):
+        return "no_retry_affordance"
+    return "unsupported_recovery_action"
+
+
 def _write_process_stdin_async(
     proc: subprocess.Popen[str],
     stdin_text: str | None,
@@ -1223,6 +1246,7 @@ class SkillsBenchLocalAcpRelay:
             meaningful_progress_seen = False
             post_bridge_recovery_attempt_count = 0
             post_bridge_recovery_action = ""
+            post_bridge_recovery_skip_reason = ""
             try:
                 subprocess.run(
                     [
@@ -1480,6 +1504,18 @@ class SkillsBenchLocalAcpRelay:
                             )
                             time.sleep(1.0)
                             continue
+                        post_bridge_recovery_skip_reason = (
+                            _codex_cli_tui_post_bridge_recovery_skip_reason(
+                                capture,
+                                stage=post_bridge_blocker_stage,
+                                recovery_action=recovery_action,
+                            )
+                        )
+                        if (
+                            not post_bridge_recovery_skip_reason
+                            and recovery_action == "press_enter"
+                        ):
+                            post_bridge_recovery_skip_reason = "retry_limit_reached"
                         tmux_kill_session(tmux_name)
                         self._publish_remote_bridge_agent_operations_trace(
                             bridge_summary_path=bridge_summary_path,
@@ -1496,6 +1532,9 @@ class SkillsBenchLocalAcpRelay:
                                 post_bridge_recovery_attempt_count
                             ),
                             post_bridge_recovery_action=post_bridge_recovery_action,
+                            post_bridge_recovery_skip_reason=(
+                                post_bridge_recovery_skip_reason
+                            ),
                         )
                         return _recoverable_codex_turn_failure_message(
                             "codex_cli_goal_" + post_bridge_blocker_stage
@@ -1525,6 +1564,9 @@ class SkillsBenchLocalAcpRelay:
                                 post_bridge_recovery_attempt_count
                             ),
                             post_bridge_recovery_action=post_bridge_recovery_action,
+                            post_bridge_recovery_skip_reason=(
+                                post_bridge_recovery_skip_reason
+                            ),
                         )
                         return _recoverable_codex_turn_failure_message(
                             "codex_exec_bridge_idle_timeout"
@@ -1560,6 +1602,7 @@ class SkillsBenchLocalAcpRelay:
                     thread_prewarm_observed=thread_prewarm_observed,
                     post_bridge_recovery_attempt_count=post_bridge_recovery_attempt_count,
                     post_bridge_recovery_action=post_bridge_recovery_action,
+                    post_bridge_recovery_skip_reason=post_bridge_recovery_skip_reason,
                 )
                 if goal_terminal_observed and not goal_failed_observed:
                     return "codex cli /goal completed"
@@ -1599,6 +1642,7 @@ class SkillsBenchLocalAcpRelay:
         thread_prewarm_observed: bool = False,
         post_bridge_recovery_attempt_count: int = 0,
         post_bridge_recovery_action: str = "",
+        post_bridge_recovery_skip_reason: str = "",
     ) -> None:
         if not self._config.worker_public_trace_dir:
             return
@@ -1654,6 +1698,9 @@ class SkillsBenchLocalAcpRelay:
                 "post_bridge_recovery_action": str(
                     post_bridge_recovery_action or ""
                 )[:40],
+                "post_bridge_recovery_skip_reason": str(
+                    post_bridge_recovery_skip_reason or ""
+                )[:80],
                 "reasoning_effort": str(self._config.reasoning_effort or "")[:40],
                 "codex_api_proxy_env_injected": bool(
                     codex_cli_tui_environment(self._config.codex_api_proxy)

--- a/loopx/benchmark_core/__init__.py
+++ b/loopx/benchmark_core/__init__.py
@@ -67,6 +67,7 @@ from .observable_handles import (
     BENCHMARK_OBSERVABLE_HANDLE_POLICY_SCHEMA_VERSION,
     build_benchmark_launch_observable_handle,
     build_benchmark_observable_handle_policy,
+    write_benchmark_run_observable_status,
 )
 from .parity import (
     CODEX_APP_PARITY_REQUIRED_CLI_CALLS,
@@ -131,6 +132,7 @@ __all__ = [
     "build_benchmark_loop_controller_trace",
     "build_benchmark_launch_observable_handle",
     "build_benchmark_observable_handle_policy",
+    "write_benchmark_run_observable_status",
     "build_round_artifact_restore_plan",
     "build_benchmark_candidate_source_boundary",
     "build_blind_loop_continuation_prompt",

--- a/loopx/benchmark_core/observable_handles.py
+++ b/loopx/benchmark_core/observable_handles.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import os
 import re
+from pathlib import Path
 from typing import Any, Mapping
 
 
@@ -172,6 +174,36 @@ _RESULT_CLOSEOUT_STATUS_VALUES = {
 }
 
 
+def write_benchmark_run_observable_status(
+    *,
+    jobs_dir: Any,
+    job_name: Any,
+    status: str,
+    record_pid: bool = False,
+) -> None:
+    """Write compact run-handle files used by public-safe status snapshots."""
+
+    jobs_dir_text = str(jobs_dir or "").strip()
+    job_name_text = str(job_name or "").strip()
+    if not jobs_dir_text or not job_name_text:
+        return
+    try:
+        job_dir = Path(jobs_dir_text).expanduser() / job_name_text
+        job_dir.mkdir(parents=True, exist_ok=True)
+        safe_status = re.sub(r"[^A-Za-z0-9_.=:-]+", "-", str(status).strip())
+        (job_dir / "status.env").write_text(
+            (safe_status or "unknown") + "\n",
+            encoding="utf-8",
+        )
+        if record_pid:
+            (job_dir / "pid.private").write_text(
+                f"{os.getpid()}\n",
+                encoding="utf-8",
+            )
+    except OSError:
+        return
+
+
 def _summary_items(run_snapshot: Mapping[str, Any]) -> list[dict[str, Any]]:
     items: list[dict[str, Any]] = []
     compact_results = run_snapshot.get("compact_results")
@@ -240,7 +272,21 @@ def build_benchmark_observable_handle_policy(
     terminal_closeout = compact_result_closeout or compact_failure_closeout
     exists = run_snapshot.get("exists") is True
     pid_present = bool(str(run_snapshot.get("pid") or "").strip())
-    pid_alive = run_snapshot.get("pid_alive") is True
+    status_text = str(run_snapshot.get("status") or "").strip().lower()
+    terminal_status = (
+        status_text.startswith("rc=")
+        or status_text.startswith("exception=")
+        or status_text
+        in {
+            "complete",
+            "completed",
+            "done",
+            "failed",
+            "interrupted",
+            "terminated",
+        }
+    )
+    pid_alive = run_snapshot.get("pid_alive") is True and not terminal_status
 
     if pid_alive:
         handle_state = "running"

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -2668,6 +2668,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "host_local_acp_codex_exec_preflight_first_blocker",
         "host_local_acp_codex_exec_failure_category",
         "codex_cli_goal_tui_stage",
+        "codex_cli_goal_tui_post_bridge_recovery_action",
         "codex_cli_goal_tui_reasoning_effort",
         "codex_api_egress_preflight_status",
         "codex_api_egress_preflight_error_kind",
@@ -2912,6 +2913,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "codex_cli_goal_tui_first_action_observed_count",
         "codex_cli_goal_tui_bridge_request_count",
         "codex_cli_goal_tui_task_facing_success_count",
+        "codex_cli_goal_tui_post_bridge_recovery_attempt_count",
         "host_local_acp_sandbox_bridge_compose_file_count",
         "host_local_acp_target_env_key_count",
         "host_local_acp_pwd_probe_rc",
@@ -2993,6 +2995,13 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         compact["codex_cli_goal_tui_stages"] = [
             stage[:80] for stage in stages if isinstance(stage, str) and stage
         ][:16]
+    recovery_actions = value.get("codex_cli_goal_tui_post_bridge_recovery_actions")
+    if isinstance(recovery_actions, list):
+        compact["codex_cli_goal_tui_post_bridge_recovery_actions"] = [
+            action[:40]
+            for action in recovery_actions
+            if isinstance(action, str) and action
+        ][:8]
     reasoning_efforts = value.get("codex_cli_goal_tui_reasoning_efforts")
     if isinstance(reasoning_efforts, list):
         compact["codex_cli_goal_tui_reasoning_efforts"] = [
@@ -10721,6 +10730,8 @@ def _merge_host_local_acp_relay_trace_summary(
     codex_cli_goal_first_action_count = 0
     codex_cli_goal_bridge_request_count = 0
     codex_cli_goal_task_facing_success_count = 0
+    codex_cli_goal_post_bridge_recovery_attempt_count = 0
+    codex_cli_goal_post_bridge_recovery_actions: list[str] = []
     codex_cli_goal_stages: list[str] = []
     codex_cli_goal_reasoning_efforts: list[str] = []
     raw_material_recorded = False
@@ -10941,6 +10952,25 @@ def _merge_host_local_acp_relay_trace_summary(
                     0,
                     task_facing_successes,
                 )
+            recovery_attempts = goal_trace.get("post_bridge_recovery_attempt_count")
+            if isinstance(recovery_attempts, int) and not isinstance(
+                recovery_attempts,
+                bool,
+            ):
+                codex_cli_goal_post_bridge_recovery_attempt_count += max(
+                    0,
+                    recovery_attempts,
+                )
+            recovery_action = goal_trace.get("post_bridge_recovery_action")
+            if isinstance(recovery_action, str) and recovery_action:
+                safe_recovery_action = recovery_action[:40]
+                if (
+                    safe_recovery_action
+                    not in codex_cli_goal_post_bridge_recovery_actions
+                ):
+                    codex_cli_goal_post_bridge_recovery_actions.append(
+                        safe_recovery_action
+                    )
             stage = goal_trace.get("stage")
             if isinstance(stage, str) and stage:
                 safe_stage = stage[:80]
@@ -11215,6 +11245,17 @@ def _merge_host_local_acp_relay_trace_summary(
     trace["codex_cli_goal_tui_task_facing_success_count"] = (
         codex_cli_goal_task_facing_success_count
     )
+    trace["codex_cli_goal_tui_post_bridge_recovery_attempt_count"] = (
+        codex_cli_goal_post_bridge_recovery_attempt_count
+    )
+    trace["codex_cli_goal_tui_post_bridge_recovery_actions"] = (
+        codex_cli_goal_post_bridge_recovery_actions
+    )
+    trace["codex_cli_goal_tui_post_bridge_recovery_action"] = (
+        codex_cli_goal_post_bridge_recovery_actions[0]
+        if codex_cli_goal_post_bridge_recovery_actions
+        else ""
+    )
     trace["codex_cli_goal_tui_stages"] = codex_cli_goal_stages
     trace["codex_cli_goal_tui_stage"] = (
         codex_cli_goal_stages[0] if codex_cli_goal_stages else ""
@@ -11400,6 +11441,17 @@ def _merge_host_local_acp_relay_trace_summary(
     )
     prerequisites["codex_cli_goal_tui_task_facing_success_count"] = (
         codex_cli_goal_task_facing_success_count
+    )
+    prerequisites["codex_cli_goal_tui_post_bridge_recovery_attempt_count"] = (
+        codex_cli_goal_post_bridge_recovery_attempt_count
+    )
+    prerequisites["codex_cli_goal_tui_post_bridge_recovery_actions"] = (
+        codex_cli_goal_post_bridge_recovery_actions
+    )
+    prerequisites["codex_cli_goal_tui_post_bridge_recovery_action"] = (
+        codex_cli_goal_post_bridge_recovery_actions[0]
+        if codex_cli_goal_post_bridge_recovery_actions
+        else ""
     )
     prerequisites["codex_cli_goal_tui_stages"] = codex_cli_goal_stages
     prerequisites["codex_cli_goal_tui_stage"] = (

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -17137,10 +17137,15 @@ def main(argv: list[str] | None = None) -> int:
             or args.remote_command_file_bridge_probe
         )
         bridge_command_configured = bool(args.remote_command_file_bridge_solver_command)
+        bridge_sandbox_auto_wiring_pending = bool(
+            args.host_local_acp_launch
+            and bridge_ready
+            and not bridge_command_configured
+        )
         if (
             not args.host_local_acp_launch
             or not bridge_ready
-            or not bridge_command_configured
+            or not (bridge_command_configured or bridge_sandbox_auto_wiring_pending)
         ):
             payload = {
                 "ok": False,
@@ -17166,6 +17171,9 @@ def main(argv: list[str] | None = None) -> int:
                 "remote_command_file_bridge_ready": bridge_ready,
                 "remote_command_file_bridge_solver_command_configured": (
                     bridge_command_configured
+                ),
+                "remote_command_file_bridge_sandbox_auto_wiring_pending": (
+                    bridge_sandbox_auto_wiring_pending
                 ),
             }
             print(json.dumps(payload, indent=2, sort_keys=True), file=sys.stderr)

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -116,7 +116,10 @@ from loopx.benchmark_adapters.skillsbench_remote_bridge import (  # noqa: E402
     run_skillsbench_remote_command_file_bridge_probe,
     skillsbench_remote_command_file_bridge_command_is_fixture_probe,
 )
-from loopx.benchmark_core import build_benchmark_launch_observable_handle  # noqa: E402
+from loopx.benchmark_core import (  # noqa: E402
+    build_benchmark_launch_observable_handle,
+    write_benchmark_run_observable_status,
+)
 from loopx.benchmark_core.loop_protocol import (  # noqa: E402
     BLIND_LOOP_DEFAULT_MAX_ROUNDS,
     CODEX_ACP_BLIND_LOOP_BASELINE_ROUTE,
@@ -16450,6 +16453,38 @@ async def async_main(
         plan = build_plan(args)
     if args.plan_only:
         return {"ok": True, "plan_only": True, "launch_plan": plan}
+    if not args.reduce_only:
+        write_benchmark_run_observable_status(
+            jobs_dir=plan.get("jobs_dir"),
+            job_name=plan.get("job_name"),
+            status="running",
+            record_pid=True,
+        )
+    runner_status_written = False
+    try:
+        return await _async_main_with_observable_handle(args, plan)
+    except BaseException as exc:
+        if not args.reduce_only:
+            write_benchmark_run_observable_status(
+                jobs_dir=plan.get("jobs_dir"),
+                job_name=plan.get("job_name"),
+                status=f"exception={type(exc).__name__}",
+            )
+            runner_status_written = True
+        raise
+    finally:
+        if not args.reduce_only and not runner_status_written:
+            write_benchmark_run_observable_status(
+                jobs_dir=plan.get("jobs_dir"),
+                job_name=plan.get("job_name"),
+                status="rc=0",
+            )
+
+
+async def _async_main_with_observable_handle(
+    args: argparse.Namespace,
+    plan: dict[str, Any],
+) -> dict[str, Any]:
     runtime_layer = (
         plan.get("benchflow_agent_runtime_layer")
         if isinstance(plan.get("benchflow_agent_runtime_layer"), dict)

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -2672,6 +2672,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "host_local_acp_codex_exec_failure_category",
         "codex_cli_goal_tui_stage",
         "codex_cli_goal_tui_post_bridge_recovery_action",
+        "codex_cli_goal_tui_post_bridge_recovery_skip_reason",
         "codex_cli_goal_tui_reasoning_effort",
         "codex_api_egress_preflight_status",
         "codex_api_egress_preflight_error_kind",
@@ -3004,6 +3005,15 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
             action[:40]
             for action in recovery_actions
             if isinstance(action, str) and action
+        ][:8]
+    recovery_skip_reasons = value.get(
+        "codex_cli_goal_tui_post_bridge_recovery_skip_reasons"
+    )
+    if isinstance(recovery_skip_reasons, list):
+        compact["codex_cli_goal_tui_post_bridge_recovery_skip_reasons"] = [
+            reason[:80]
+            for reason in recovery_skip_reasons
+            if isinstance(reason, str) and reason
         ][:8]
     reasoning_efforts = value.get("codex_cli_goal_tui_reasoning_efforts")
     if isinstance(reasoning_efforts, list):
@@ -10735,6 +10745,7 @@ def _merge_host_local_acp_relay_trace_summary(
     codex_cli_goal_task_facing_success_count = 0
     codex_cli_goal_post_bridge_recovery_attempt_count = 0
     codex_cli_goal_post_bridge_recovery_actions: list[str] = []
+    codex_cli_goal_post_bridge_recovery_skip_reasons: list[str] = []
     codex_cli_goal_stages: list[str] = []
     codex_cli_goal_reasoning_efforts: list[str] = []
     raw_material_recorded = False
@@ -10973,6 +10984,16 @@ def _merge_host_local_acp_relay_trace_summary(
                 ):
                     codex_cli_goal_post_bridge_recovery_actions.append(
                         safe_recovery_action
+                    )
+            recovery_skip_reason = goal_trace.get("post_bridge_recovery_skip_reason")
+            if isinstance(recovery_skip_reason, str) and recovery_skip_reason:
+                safe_skip_reason = recovery_skip_reason[:80]
+                if (
+                    safe_skip_reason
+                    not in codex_cli_goal_post_bridge_recovery_skip_reasons
+                ):
+                    codex_cli_goal_post_bridge_recovery_skip_reasons.append(
+                        safe_skip_reason
                     )
             stage = goal_trace.get("stage")
             if isinstance(stage, str) and stage:
@@ -11259,6 +11280,14 @@ def _merge_host_local_acp_relay_trace_summary(
         if codex_cli_goal_post_bridge_recovery_actions
         else ""
     )
+    trace["codex_cli_goal_tui_post_bridge_recovery_skip_reasons"] = (
+        codex_cli_goal_post_bridge_recovery_skip_reasons
+    )
+    trace["codex_cli_goal_tui_post_bridge_recovery_skip_reason"] = (
+        codex_cli_goal_post_bridge_recovery_skip_reasons[0]
+        if codex_cli_goal_post_bridge_recovery_skip_reasons
+        else ""
+    )
     trace["codex_cli_goal_tui_stages"] = codex_cli_goal_stages
     trace["codex_cli_goal_tui_stage"] = (
         codex_cli_goal_stages[0] if codex_cli_goal_stages else ""
@@ -11454,6 +11483,14 @@ def _merge_host_local_acp_relay_trace_summary(
     prerequisites["codex_cli_goal_tui_post_bridge_recovery_action"] = (
         codex_cli_goal_post_bridge_recovery_actions[0]
         if codex_cli_goal_post_bridge_recovery_actions
+        else ""
+    )
+    prerequisites["codex_cli_goal_tui_post_bridge_recovery_skip_reasons"] = (
+        codex_cli_goal_post_bridge_recovery_skip_reasons
+    )
+    prerequisites["codex_cli_goal_tui_post_bridge_recovery_skip_reason"] = (
+        codex_cli_goal_post_bridge_recovery_skip_reasons[0]
+        if codex_cli_goal_post_bridge_recovery_skip_reasons
         else ""
     )
     prerequisites["codex_cli_goal_tui_stages"] = codex_cli_goal_stages


### PR DESCRIPTION
## Summary
- keep the original one-buffer large /goal input path for SkillsBench Codex CLI goal runs
- add a public-safe post-bridge TUI blocker classifier for rate-limit/model-timeout/error-prompt screens after bridge activity has already happened
- publish a distinct codex_cli_goal stage instead of letting these runs drift into generic goal-active/startup timeout or full outer timeout

## Validation
- python3 examples/skillsbench-codex-cli-goal-route-smoke.py
- python3 -m py_compile loopx/benchmark_adapters/skillsbench_acp_relay.py loopx/codex_cli_goal_tui.py scripts/skillsbench_automation_loop.py examples/skillsbench-codex-cli-goal-route-smoke.py
- public/private diff scan: no new raw task text, trajectory, verifier output, credentials, private paths, or proxy values in the diff

## Pending
- rerun the civ6 single-case with this branch before using it for the next 5-case batch
