### PR TITLE
Extract quota heartbeat recommendation state machine

### DIFF
--- a/examples/control_plane/quota-heartbeat-recommendation-state-machine-smoke.py
+++ b/examples/control_plane/quota-heartbeat-recommendation-state-machine-smoke.py
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+"""Canary the quota heartbeat recommendation state machine."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.quota.heartbeat_recommendation import (  # noqa: E402
+    build_heartbeat_recommendation,
+)
+from loopx.control_plane.work_items.delivery_outcome import DeliveryOutcome  # noqa: E402
+from loopx.control_plane.work_items.work_lane import build_work_lane_contract  # noqa: E402
+
+
+GOAL_ID = "heartbeat-recommendation-fixture"
+
+
+def user_todos(open_count: int) -> dict[str, Any]:
+    return {
+        "schema_version": "todo_summary_v0",
+        "source_section": "User Todo",
+        "open_count": open_count,
+        "first_open_items": [
+            {
+                "todo_id": f"todo_user_{index}",
+                "status": "open",
+                "task_class": "user_gate",
+                "text": "[P0-user] Decide the owner gate.",
+            }
+            for index in range(open_count)
+        ],
+    }
+
+
+def agent_todos(open_count: int) -> dict[str, Any]:
+    return {
+        "schema_version": "todo_summary_v0",
+        "source_section": "Agent Todo",
+        "open_count": open_count,
+        "first_open_items": [
+            {
+                "todo_id": f"todo_agent_{index}",
+                "status": "open",
+                "task_class": "advancement_task",
+                "text": "[P1] Advance the durable heartbeat canary.",
+            }
+            for index in range(open_count)
+        ],
+    }
+
+
+def work_lane(
+    *,
+    open_count: int,
+    advancement_count: int,
+    monitor_count: int,
+    monitor_due_count: int = 0,
+    progress_scope: str = "agent_lane",
+) -> dict[str, Any] | None:
+    due_items = [
+        {
+            "todo_id": "todo_monitor_due",
+            "status": "open",
+            "task_class": "continuous_monitor",
+            "next_due_at": "2000-01-01T00:00:00+00:00",
+            "text": "[P0-monitor] Observe a due material transition.",
+        }
+    ][:monitor_due_count]
+    return build_work_lane_contract(
+        progress_scope=progress_scope,
+        external_poll_signal=False,
+        todo_counts={
+            "open": open_count,
+            "advancement": advancement_count,
+            "monitor": monitor_count,
+        },
+        monitor_due_count=monitor_due_count,
+        due_monitor_items=due_items,
+        first_advancement=(
+            {
+                "todo_id": "todo_agent_advancement",
+                "status": "open",
+                "task_class": "advancement_task",
+                "text": "[P1] Advance the durable heartbeat canary.",
+            }
+            if advancement_count
+            else None
+        ),
+        due_monitor_preempts_advancement=monitor_due_count > 0 and advancement_count == 0,
+        outcome_followthrough=None,
+        next_action_requires_advancement=False,
+        monitor_due_item_limit=1,
+    )
+
+
+def recommendation(
+    item: dict[str, Any],
+    *,
+    state: str = "eligible",
+    should_run: bool = True,
+    user_summary: dict[str, Any] | None = None,
+    agent_summary: dict[str, Any] | None = None,
+    lane: dict[str, Any] | None = None,
+    stall_self_repair: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    return build_heartbeat_recommendation(
+        item,
+        goal_id=GOAL_ID,
+        state=state,
+        should_run=should_run,
+        user_todo_summary=user_summary or user_todos(0),
+        agent_todo_summary=agent_summary or agent_todos(0),
+        work_lane_contract=lane,
+        stall_self_repair=stall_self_repair,
+        select_replan_obligation=False,
+    )
+
+
+def assert_gate_and_repair_precedence() -> None:
+    operator = recommendation({}, state="operator_gate")
+    assert operator["recommended_mode"] == "ask_operator_gate", operator
+    assert operator["notify"] == "NOTIFY", operator
+
+    repair = recommendation(
+        {},
+        stall_self_repair={
+            "allowed": True,
+            "recommended_mode": "repair_control_plane_stall",
+            "repair_focus": "state projection is stale",
+        },
+    )
+    assert repair["recommended_mode"] == "repair_control_plane_stall", repair
+    assert repair["repair_focus"] == "state projection is stale", repair
+
+
+def assert_quota_skip_and_blocker_push() -> None:
+    skipped = recommendation({}, state="throttled", should_run=False)
+    assert skipped["recommended_mode"] == "quota_skip", skipped
+    assert "throttled" in skipped["reason"], skipped
+
+    blocker = recommendation(
+        {"waiting_on": "external_evidence"},
+        state="focus_wait",
+        user_summary=user_todos(1),
+    )
+    assert blocker["recommended_mode"] == "blocker_push_notify", blocker
+    assert blocker["repeat_notification_required"] is True, blocker
+    assert blocker["notify"] == "NOTIFY", blocker
+
+
+def assert_monitor_lanes_do_not_collapse_due_work() -> None:
+    quiet_lane = work_lane(open_count=1, advancement_count=0, monitor_count=1)
+    quiet = recommendation({}, lane=quiet_lane)
+    assert quiet_lane and quiet_lane["must_attempt_work"] is False, quiet_lane
+    assert quiet["recommended_mode"] == "monitor_quiet_until_material_transition", quiet
+    assert quiet["notify"] == "DONT_NOTIFY", quiet
+
+    due_lane = work_lane(
+        open_count=1,
+        advancement_count=0,
+        monitor_count=1,
+        monitor_due_count=1,
+    )
+    due = recommendation(
+        {
+            "handoff_readiness": {
+                "post_handoff_latest_run": {
+                    "classification": "dependency_observed",
+                    "delivery_outcome": "outcome_progress",
+                }
+            }
+        },
+        lane=due_lane,
+    )
+    assert due_lane and due_lane["must_attempt_work"] is True, due_lane
+    assert due_lane["obligation"] == "attempt_due_monitor", due_lane
+    assert due["recommended_mode"] == "follow_work_lane_contract", due
+    assert due["latest_run"]["progress_scope"] == "dependency_observation", due
+
+
+def assert_read_only_map_lifecycle_modes() -> None:
+    first = recommendation(
+        {
+            "status": "connected_without_run",
+            "adapter_kind": "docs_read_only_map_v0",
+        }
+    )
+    assert first["recommended_mode"] == "run_first_read_only_map", first
+    assert first["command"] == f"loopx read-only-map --goal-id {GOAL_ID}", first
+    assert first["notify"] == "NOTIFY", first
+
+    mapped = recommendation(
+        {
+            "status": "read_only_project_map",
+            "lifecycle_flags": ["mapped"],
+        }
+    )
+    assert mapped["recommended_mode"] == "mapped_noop_if_unchanged", mapped
+    assert mapped["stop_if_unchanged"] is True, mapped
+    assert mapped["notify"] == "DONT_NOTIFY", mapped
+
+
+def assert_post_handoff_primary_outcome_modes() -> None:
+    base_item = {
+        "status": "post_handoff_run_seen",
+        "adapter_kind": "harness_self_improvement",
+        "control_plane": {"self_repair": {"enabled": True}},
+        "handoff_readiness": {
+            "post_handoff_run_seen": True,
+            "handoff_status": "post_handoff_run_seen",
+            "post_handoff_latest_run": {
+                "classification": "implementation_merged",
+                "delivery_outcome": DeliveryOutcome.PRIMARY_GOAL_OUTCOME.value,
+            },
+        },
+    }
+    no_agent = recommendation(base_item)
+    assert no_agent["recommended_mode"] == "post_handoff_observe_if_unchanged", no_agent
+    assert no_agent["stop_if_unchanged"] is True, no_agent
+    assert no_agent["latest_run"]["progress_scope"] == "primary_goal", no_agent
+
+    dependency_item = {
+        **base_item,
+        "handoff_readiness": {
+            **base_item["handoff_readiness"],
+            "post_handoff_latest_run": {
+                **base_item["handoff_readiness"]["post_handoff_latest_run"],
+                "classification": "dependency_observed_after_merge",
+            },
+        },
+    }
+    with_agent = recommendation(
+        dependency_item,
+        agent_summary=agent_todos(1),
+        lane=work_lane(
+            open_count=1,
+            advancement_count=1,
+            monitor_count=0,
+            progress_scope="dependency_observation",
+        ),
+    )
+    assert with_agent["recommended_mode"] == "follow_work_lane_contract", with_agent
+    assert with_agent.get("stop_if_unchanged") is not True, with_agent
+    assert with_agent["latest_run"]["progress_scope"] == "dependency_observation", with_agent
+
+
+def assert_default_bounded_delivery_mode() -> None:
+    normal = recommendation(
+        {"status": "active-read-only"},
+        agent_summary=agent_todos(1),
+        lane=work_lane(open_count=1, advancement_count=1, monitor_count=0),
+    )
+    assert normal["recommended_mode"] == "steering_audit_then_one_step", normal
+    assert "bounded progress segment" in normal["spend_policy"], normal
+
+
+def main() -> int:
+    assert_gate_and_repair_precedence()
+    assert_quota_skip_and_blocker_push()
+    assert_monitor_lanes_do_not_collapse_due_work()
+    assert_read_only_map_lifecycle_modes()
+    assert_post_handoff_primary_outcome_modes()
+    assert_default_bounded_delivery_mode()
+    print("quota-heartbeat-recommendation-state-machine-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/control_plane/quota/heartbeat_recommendation.py
+++ b/loopx/control_plane/quota/heartbeat_recommendation.py
@@ -1,0 +1,430 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .. import compact_control_plane_policy
+from ..goals.goal_frontier import (
+    build_autonomous_replan_recommendation,
+    select_autonomous_replan_obligation,
+)
+from ..work_items.delivery_outcome import DeliveryOutcome, normalize_delivery_outcome
+from ..work_items.work_lane_context import (
+    build_work_lane_context_contract,
+    latest_run_progress_scope,
+)
+
+
+HEARTBEAT_READ_ONLY_MAP_ADAPTER_SUFFIX = "_read_only_map_v0"
+HEARTBEAT_HANDOFF_READINESS_COMPACT_FIELDS = (
+    "ready",
+    "codex_ready",
+    "source",
+    "quota_state",
+    "handoff_status",
+    "post_handoff_run_seen",
+    "post_handoff_small_scale_streak",
+    "post_handoff_outcome_gap_streak",
+    "handoff_interface_budget",
+)
+HEARTBEAT_POST_HANDOFF_RUN_COMPACT_FIELDS = (
+    "generated_at",
+    "classification",
+    "progress_scope",
+    "delivery_batch_scale",
+    "delivery_outcome",
+    "delivery_turn_kind",
+    "health_check",
+    "json_exists",
+    "markdown_exists",
+)
+
+
+def _open_todo_count(summary: dict[str, Any] | None) -> int:
+    if not isinstance(summary, dict):
+        return 0
+    try:
+        return max(0, int(summary.get("open_count") or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def open_todo_notify_reason(*, state: str, waiting_on: str) -> str:
+    if state == "focus_wait":
+        return "open user todo can unblock focus_wait after owner evidence, external eval, or a clean baseline changes"
+    if waiting_on == "external_evidence":
+        return "open user todo can provide or defer the external-evidence checkpoint"
+    if waiting_on in {"user_or_controller", "controller"}:
+        return "open user todo can resolve the user/controller blocker"
+    return "open user todo can resolve the current waiting lane"
+
+
+def _supports_read_only_project_map(adapter_kind: Any) -> bool:
+    kind = str(adapter_kind or "").strip()
+    return kind == "read_only_project_map_v0" or kind.endswith(
+        HEARTBEAT_READ_ONLY_MAP_ADAPTER_SUFFIX
+    )
+
+
+def _text_values(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, (list, tuple, set)):
+        values: list[str] = []
+        for item in value:
+            values.extend(_text_values(item))
+        return values
+    return [str(value)]
+
+
+def _has_lifecycle_marker(*values: Any, marker: str) -> bool:
+    target = marker.strip().lower()
+    for value in values:
+        for text in _text_values(value):
+            if text.strip().lower() == target:
+                return True
+    return False
+
+
+def _compact_latest_run(run: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: run.get(key)
+        for key in HEARTBEAT_POST_HANDOFF_RUN_COMPACT_FIELDS
+        if run.get(key) is not None
+    }
+
+
+def _control_plane_post_handoff_observation_hint(item: dict[str, Any]) -> dict[str, Any] | None:
+    control_plane = compact_control_plane_policy(item.get("control_plane"))
+    self_repair = (
+        control_plane.get("self_repair")
+        if isinstance(control_plane.get("self_repair"), dict)
+        else {}
+    )
+    if self_repair.get("enabled") is not True:
+        return None
+    if str(item.get("adapter_kind") or "") != "harness_self_improvement":
+        return None
+    if item.get("agent_command"):
+        return None
+
+    handoff_readiness = (
+        item.get("handoff_readiness")
+        if isinstance(item.get("handoff_readiness"), dict)
+        else {}
+    )
+    latest_run = (
+        handoff_readiness.get("post_handoff_latest_run")
+        if isinstance(handoff_readiness.get("post_handoff_latest_run"), dict)
+        else {}
+    )
+    if handoff_readiness.get("post_handoff_run_seen") is not True:
+        return None
+    if str(handoff_readiness.get("handoff_status") or "") != "post_handoff_run_seen":
+        return None
+    if normalize_delivery_outcome(latest_run.get("delivery_outcome")) != DeliveryOutcome.PRIMARY_GOAL_OUTCOME:
+        return None
+
+    return {
+        "source": "quota.should-run",
+        "recommended_mode": "post_handoff_observe_if_unchanged",
+        "stop_if_unchanged": True,
+        "notify": "DONT_NOTIFY",
+        "reason": (
+            "control-plane self-repair is enabled and the latest post-handoff "
+            "implementation run already reached the primary outcome; inspect "
+            "registry/status/run history/repo state, then stay quiet if no new "
+            "evidence or concrete safe work is found"
+        ),
+        "spend_policy": (
+            "do not append quota spend for an unchanged post-handoff observation; "
+            "spend only after a new validated artifact, repair, or durable state "
+            "writeback advances the control-plane contract"
+        ),
+        "latest_run": _compact_latest_run(latest_run),
+    }
+
+
+def build_heartbeat_recommendation(
+    item: dict[str, Any],
+    *,
+    goal_id: str,
+    state: str,
+    should_run: bool,
+    user_todo_summary: dict[str, Any] | None,
+    agent_todo_summary: dict[str, Any] | None,
+    work_lane_contract: dict[str, Any] | None = None,
+    stall_self_repair: dict[str, Any] | None = None,
+    replan_obligation: dict[str, Any] | None = None,
+    select_replan_obligation: bool = True,
+    monitor_due_item_limit: int = 1,
+) -> dict[str, Any]:
+    status = str(item.get("status") or "")
+    waiting_on = str(item.get("waiting_on") or "")
+    adapter_kind = str(item.get("adapter_kind") or "")
+    lifecycle_phase = item.get("lifecycle_phase")
+    lifecycle_flags = item.get("lifecycle_flags")
+    quota = item.get("quota") if isinstance(item.get("quota"), dict) else {}
+    project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
+    replan_obligation = (
+        replan_obligation
+        if isinstance(replan_obligation, dict)
+        else select_autonomous_replan_obligation(item, project_asset)
+        if select_replan_obligation
+        else None
+    )
+    has_user_todos = _open_todo_count(user_todo_summary) > 0
+    has_agent_todos = _open_todo_count(agent_todo_summary) > 0
+    work_lane_contract = work_lane_contract or build_work_lane_context_contract(
+        item,
+        agent_todo_summary=agent_todo_summary,
+        monitor_due_item_limit=monitor_due_item_limit,
+    )
+
+    base: dict[str, Any] = {
+        "source": "quota.should-run",
+        "recommended_mode": "skip",
+        "notify": "DONT_NOTIFY",
+        "spend_policy": "do not append quota spend unless a completed bounded progress segment produced substantive progress",
+    }
+
+    if state == "operator_gate":
+        return {
+            **base,
+            "recommended_mode": "ask_operator_gate",
+            "notify": "NOTIFY",
+            "spend_policy": "do not append quota spend while asking the operator gate",
+            "reason": "operator gate blocks the gated delivery path",
+        }
+    if stall_self_repair and stall_self_repair.get("allowed"):
+        return {
+            **base,
+            "recommended_mode": stall_self_repair.get("recommended_mode") or "repair_control_plane_stall",
+            "notify": stall_self_repair.get("notify") or "DONT_NOTIFY",
+            "spend_policy": stall_self_repair.get("spend_policy") or base["spend_policy"],
+            "reason": stall_self_repair.get("reason") or "control-plane stall requires bounded repair",
+            "repair_focus": stall_self_repair.get("repair_focus"),
+        }
+    if should_run and replan_obligation and replan_obligation.get("required"):
+        return {
+            **base,
+            **build_autonomous_replan_recommendation(replan_obligation),
+        }
+    if state in {"focus_wait", "waiting"} and has_user_todos:
+        return {
+            **base,
+            "recommended_mode": "blocker_push_notify",
+            "notify": "NOTIFY",
+            "repeat_notification_required": True,
+            "spend_policy": "do not append quota spend for the blocker-push turn",
+            "reason": open_todo_notify_reason(state=state, waiting_on=waiting_on),
+        }
+    if state == "focus_wait" and quota.get("handoff_outcome_floor_block"):
+        if quota.get("outcome_floor_blocker_projected"):
+            return {
+                **base,
+                "recommended_mode": "outcome_floor_blocker_projected_noop",
+                "notify": "DONT_NOTIFY",
+                "spend_policy": (
+                    "do not append quota spend while the same concrete outcome-floor "
+                    "blocker is already projected and no executable agent todo exists"
+                ),
+                "reason": str(
+                    quota.get("reason")
+                    or "outcome-floor blocker is already projected; wait for fresh outcome evidence"
+                ),
+            }
+        if quota.get("safe_bypass_allowed"):
+            return {
+                **base,
+                "recommended_mode": "outcome_floor_recovery",
+                "notify": "DONT_NOTIFY",
+                "spend_policy": (
+                    "append exactly one quota spend only after a validated "
+                    "ranker/cross-domain evidence artifact or concrete blocker writeback; "
+                    "do not spend for another surface-only report"
+                ),
+                "reason": str(quota.get("reason") or "handoff outcome floor is not met"),
+            }
+        return {
+            **base,
+            "recommended_mode": "report_handoff_outcome_blocker",
+            "notify": "NOTIFY",
+            "spend_policy": "do not append quota spend while reporting the handoff outcome-floor blocker",
+            "reason": str(quota.get("reason") or "handoff outcome floor is not met"),
+        }
+    if not should_run:
+        return {
+            **base,
+            "recommended_mode": "quota_skip",
+            "reason": f"quota state is {state}; skip delivery compute",
+        }
+
+    if item.get("agent_command"):
+        return {
+            **base,
+            "recommended_mode": "run_agent_command",
+            "command": str(item.get("agent_command")),
+            "notify": "DONT_NOTIFY",
+            "spend_policy": "append exactly one heartbeat spend after the command completes and validation/writeback are saved",
+            "reason": "current status exposes an approved project-agent command",
+        }
+
+    if (
+        work_lane_contract
+        and work_lane_contract.get("lane") == "continuous_monitor"
+        and work_lane_contract.get("must_attempt_work") is False
+        and has_user_todos
+    ):
+        return {
+            **base,
+            "recommended_mode": "monitor_quiet_until_material_transition",
+            "spend_policy": (
+                "do not append quota spend or repeat a blocker notification for a "
+                "monitor-only poll; keep the open user todo visible in the payload and "
+                "wait for a material monitor transition"
+            ),
+            "reason": (
+                "monitor-only polling has no material transition to write back; the "
+                "current open user todo is already part of the durable active state"
+            ),
+        }
+
+    if (
+        work_lane_contract
+        and work_lane_contract.get("lane") == "continuous_monitor"
+        and work_lane_contract.get("must_attempt_work") is False
+        and not has_user_todos
+    ):
+        return {
+            **base,
+            "recommended_mode": "monitor_quiet_until_material_transition",
+            "spend_policy": (
+                "do not append quota spend until a material monitor transition, regression, "
+                "or concrete blocker is validated and written back"
+            ),
+            "reason": "all visible open agent todos are monitor-class work with no material transition to record",
+        }
+
+    if (
+        work_lane_contract
+        and work_lane_contract.get("lane") == "continuous_monitor"
+        and work_lane_contract.get("must_attempt_work") is True
+        and not has_user_todos
+    ):
+        latest_run: dict[str, Any] = {}
+        handoff_readiness = (
+            item.get("handoff_readiness")
+            if isinstance(item.get("handoff_readiness"), dict)
+            else {}
+        )
+        latest_handoff_run = (
+            handoff_readiness.get("post_handoff_latest_run")
+            if isinstance(handoff_readiness.get("post_handoff_latest_run"), dict)
+            else {}
+        )
+        if latest_handoff_run:
+            latest_run = _compact_latest_run(latest_handoff_run)
+            latest_run["progress_scope"] = latest_run_progress_scope(latest_handoff_run)
+        payload = {
+            **base,
+            "recommended_mode": "follow_work_lane_contract",
+            "spend_policy": (
+                "follow work_lane_contract.obligation; spend only after validated "
+                "advancement, concrete blocker writeback, or a material monitor transition"
+            ),
+            "reason": (
+                "work_lane_contract is the machine contract for monitor-vs-advancement routing"
+            ),
+        }
+        if latest_run:
+            payload["latest_run"] = latest_run
+        return payload
+
+    if status == "connected_without_run" and _supports_read_only_project_map(adapter_kind):
+        return {
+            **base,
+            "recommended_mode": "run_first_read_only_map",
+            "command": f"loopx read-only-map --goal-id {goal_id}",
+            "notify": "NOTIFY",
+            "spend_policy": "append exactly one heartbeat spend after the read-only map run is saved and validated",
+            "reason": "connected read-only project has no saved compact run yet",
+        }
+
+    mapped = (
+        status == "read_only_project_map"
+        or _has_lifecycle_marker(lifecycle_phase, lifecycle_flags, marker="mapped")
+    )
+    if mapped and not any([has_user_todos, has_agent_todos, item.get("agent_command")]):
+        return {
+            **base,
+            "recommended_mode": "mapped_noop_if_unchanged",
+            "stop_if_unchanged": True,
+            "spend_policy": (
+                "do not run another dry-run or append quota spend when the latest read-only map is still current "
+                "and there is no new user instruction, owner evidence, agent todo, stale source, or safe handoff"
+            ),
+            "reason": "latest compact read-only map already exists; wait for new evidence or a concrete safe action",
+        }
+
+    post_handoff_observation = _control_plane_post_handoff_observation_hint(item)
+    if post_handoff_observation and not has_user_todos:
+        latest_observed_run = (
+            post_handoff_observation.get("latest_run")
+            if isinstance(post_handoff_observation.get("latest_run"), dict)
+            else {}
+        )
+        progress_scope = latest_run_progress_scope(latest_observed_run)
+        if isinstance(latest_observed_run, dict) and latest_observed_run:
+            latest_observed_run.setdefault("progress_scope", progress_scope)
+        if has_agent_todos and progress_scope == "dependency_observation":
+            return {
+                **base,
+                **{
+                    key: value
+                    for key, value in post_handoff_observation.items()
+                    if key != "stop_if_unchanged"
+                },
+                "recommended_mode": "follow_work_lane_contract",
+                "spend_policy": (
+                    "follow work_lane_contract.obligation; spend only after validated "
+                    "advancement, concrete blocker writeback, or a material monitor transition"
+                ),
+                "reason": (
+                    "latest post-handoff run was dependency observation; the work lane "
+                    "contract decides whether to advance backlog or record a material transition"
+                ),
+            }
+        if has_agent_todos:
+            active_observation = {
+                key: value
+                for key, value in post_handoff_observation.items()
+                if key != "stop_if_unchanged"
+            }
+            return {
+                **base,
+                **active_observation,
+                "recommended_mode": "post_handoff_observe_then_backlog_step",
+                "spend_policy": (
+                    "observe registry/status/run history/repo state first; if unchanged, "
+                    "advance exactly one bounded agent-todo backlog segment and append quota "
+                    "spend only after validation and durable writeback"
+                ),
+                "reason": (
+                    "latest post-handoff implementation reached the primary outcome, but "
+                    "an open agent todo remains; observe for new blockers first, then "
+                    "advance one bounded backlog step instead of quiet idling"
+                ),
+            }
+        return {
+            **base,
+            **post_handoff_observation,
+        }
+
+    return {
+        **base,
+        "recommended_mode": "steering_audit_then_one_step",
+        "spend_policy": "append exactly one heartbeat spend only after a bounded progress segment is validated and written back",
+        "reason": "eligible Codex-ready goal requires the standard steering audit before delivery",
+    }

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -62,16 +62,20 @@ from .control_plane.goals.goal_frontier import (
     acceptance_gaps_from_agent_vision,
     autonomous_replan_decision_allowed,
     autonomous_replan_scope_decision,
-    build_autonomous_replan_recommendation,
     build_goal_frontier_projection_from_summaries,
     derive_goal_frontier_replan_obligation_from_summaries,
     latest_agent_vision_from_status_payload,
     select_autonomous_replan_obligation,
 )
+from .control_plane.quota.heartbeat_recommendation import (
+    HEARTBEAT_HANDOFF_READINESS_COMPACT_FIELDS as HANDOFF_READINESS_COMPACT_FIELDS,
+    HEARTBEAT_POST_HANDOFF_RUN_COMPACT_FIELDS as POST_HANDOFF_RUN_COMPACT_FIELDS,
+    build_heartbeat_recommendation,
+    open_todo_notify_reason,
+)
 from .control_plane.work_items.goal_route_hint import build_goal_route_hint
 from .control_plane.work_items.work_lane_context import (
     build_work_lane_context_contract,
-    latest_run_progress_scope,
 )
 from .control_plane.scheduler.scheduler_hint import (
     build_codex_app_scheduler_ack_event,
@@ -189,29 +193,6 @@ FOCUS_WAIT_REASON = (
     "focus wait: delivery lane has a continuation boundary or missing novelty; "
     "wait for new evidence, owner input, external eval, or a clean baseline before "
     "spending delivery compute"
-)
-READ_ONLY_MAP_ADAPTER_SUFFIX = "_read_only_map_v0"
-HANDOFF_READINESS_COMPACT_FIELDS = (
-    "ready",
-    "codex_ready",
-    "source",
-    "quota_state",
-    "handoff_status",
-    "post_handoff_run_seen",
-    "post_handoff_small_scale_streak",
-    "post_handoff_outcome_gap_streak",
-    "handoff_interface_budget",
-)
-POST_HANDOFF_RUN_COMPACT_FIELDS = (
-    "generated_at",
-    "classification",
-    "progress_scope",
-    "delivery_batch_scale",
-    "delivery_outcome",
-    "delivery_turn_kind",
-    "health_check",
-    "json_exists",
-    "markdown_exists",
 )
 AUTONOMOUS_CANDIDATE_CONTEXT_FIELDS = (
     "source",
@@ -1968,21 +1949,6 @@ def _should_notify_user_on_open_todo(
     return waiting_on in {"user_or_controller", "controller", "external_evidence"}
 
 
-def _open_todo_notify_reason(*, state: str, waiting_on: str) -> str:
-    if state == "focus_wait":
-        return "open user todo can unblock focus_wait after owner evidence, external eval, or a clean baseline changes"
-    if waiting_on == "external_evidence":
-        return "open user todo can provide or defer the external-evidence checkpoint"
-    if waiting_on in {"user_or_controller", "controller"}:
-        return "open user todo can resolve the user/controller blocker"
-    return "open user todo can resolve the current waiting lane"
-
-
-def _supports_read_only_project_map(adapter_kind: Any) -> bool:
-    kind = str(adapter_kind or "").strip()
-    return kind == "read_only_project_map_v0" or kind.endswith(READ_ONLY_MAP_ADAPTER_SUFFIX)
-
-
 def _open_todo_count(summary: dict[str, Any] | None) -> int:
     if not isinstance(summary, dict):
         return 0
@@ -2103,15 +2069,6 @@ def _outcome_floor_blocker_already_projected(
         TODO_TASK_CLASS_BLOCKER in visible_classes
         and all(task_class != TODO_TASK_CLASS_ADVANCEMENT for task_class in visible_classes)
     )
-
-
-def _has_lifecycle_marker(*values: Any, marker: str) -> bool:
-    target = marker.strip().lower()
-    for value in values:
-        for text in _text_values(value):
-            if text.strip().lower() == target:
-                return True
-    return False
 
 
 def _compact_health_items(items: list[Any], *, limit: int = 3) -> list[dict[str, Any]]:
@@ -2416,344 +2373,6 @@ def _boundary_projection_repair_hint(
         if inactive_candidates:
             repair["inactive_authority_candidates"] = inactive_candidates[:3]
     return repair
-
-
-def _control_plane_post_handoff_observation_hint(item: dict[str, Any]) -> dict[str, Any] | None:
-    control_plane = compact_control_plane_policy(item.get("control_plane"))
-    self_repair = (
-        control_plane.get("self_repair")
-        if isinstance(control_plane.get("self_repair"), dict)
-        else {}
-    )
-    if self_repair.get("enabled") is not True:
-        return None
-    if str(item.get("adapter_kind") or "") != "harness_self_improvement":
-        return None
-    if item.get("agent_command"):
-        return None
-
-    handoff_readiness = (
-        item.get("handoff_readiness")
-        if isinstance(item.get("handoff_readiness"), dict)
-        else {}
-    )
-    latest_run = (
-        handoff_readiness.get("post_handoff_latest_run")
-        if isinstance(handoff_readiness.get("post_handoff_latest_run"), dict)
-        else {}
-    )
-    if handoff_readiness.get("post_handoff_run_seen") is not True:
-        return None
-    if str(handoff_readiness.get("handoff_status") or "") != "post_handoff_run_seen":
-        return None
-    if normalize_delivery_outcome(latest_run.get("delivery_outcome")) != DeliveryOutcome.PRIMARY_GOAL_OUTCOME:
-        return None
-
-    return {
-        "source": "quota.should-run",
-        "recommended_mode": "post_handoff_observe_if_unchanged",
-        "stop_if_unchanged": True,
-        "notify": "DONT_NOTIFY",
-        "reason": (
-            "control-plane self-repair is enabled and the latest post-handoff "
-            "implementation run already reached the primary outcome; inspect "
-            "registry/status/run history/repo state, then stay quiet if no new "
-            "evidence or concrete safe work is found"
-        ),
-        "spend_policy": (
-            "do not append quota spend for an unchanged post-handoff observation; "
-            "spend only after a new validated artifact, repair, or durable state "
-            "writeback advances the control-plane contract"
-        ),
-        "latest_run": {
-            key: latest_run.get(key)
-            for key in POST_HANDOFF_RUN_COMPACT_FIELDS
-            if latest_run.get(key) is not None
-        },
-    }
-
-
-def _heartbeat_recommendation(
-    item: dict[str, Any],
-    *,
-    goal_id: str,
-    state: str,
-    should_run: bool,
-    user_todo_summary: dict[str, Any] | None,
-    agent_todo_summary: dict[str, Any] | None,
-    work_lane_contract: dict[str, Any] | None = None,
-    stall_self_repair: dict[str, Any] | None = None,
-    replan_obligation: dict[str, Any] | None = None,
-    select_replan_obligation: bool = True,
-) -> dict[str, Any]:
-    status = str(item.get("status") or "")
-    waiting_on = str(item.get("waiting_on") or "")
-    adapter_kind = str(item.get("adapter_kind") or "")
-    lifecycle_phase = item.get("lifecycle_phase")
-    lifecycle_flags = item.get("lifecycle_flags")
-    quota = item.get("quota") if isinstance(item.get("quota"), dict) else {}
-    project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
-    replan_obligation = (
-        replan_obligation
-        if isinstance(replan_obligation, dict)
-        else select_autonomous_replan_obligation(item, project_asset)
-        if select_replan_obligation
-        else None
-    )
-    has_user_todos = _open_todo_count(user_todo_summary) > 0
-    has_agent_todos = _open_todo_count(agent_todo_summary) > 0
-    work_lane_contract = work_lane_contract or _work_lane_contract(item, agent_todo_summary=agent_todo_summary)
-
-    base: dict[str, Any] = {
-        "source": "quota.should-run",
-        "recommended_mode": "skip",
-        "notify": "DONT_NOTIFY",
-        "spend_policy": "do not append quota spend unless a completed bounded progress segment produced substantive progress",
-    }
-
-    if state == "operator_gate":
-        return {
-            **base,
-            "recommended_mode": "ask_operator_gate",
-            "notify": "NOTIFY",
-            "spend_policy": "do not append quota spend while asking the operator gate",
-            "reason": "operator gate blocks the gated delivery path",
-        }
-    if stall_self_repair and stall_self_repair.get("allowed"):
-        return {
-            **base,
-            "recommended_mode": stall_self_repair.get("recommended_mode") or "repair_control_plane_stall",
-            "notify": stall_self_repair.get("notify") or "DONT_NOTIFY",
-            "spend_policy": stall_self_repair.get("spend_policy") or base["spend_policy"],
-            "reason": stall_self_repair.get("reason") or "control-plane stall requires bounded repair",
-            "repair_focus": stall_self_repair.get("repair_focus"),
-        }
-    if should_run and replan_obligation and replan_obligation.get("required"):
-        return {
-            **base,
-            **build_autonomous_replan_recommendation(replan_obligation),
-        }
-    if state in {"focus_wait", "waiting"} and has_user_todos:
-        return {
-            **base,
-            "recommended_mode": "blocker_push_notify",
-            "notify": "NOTIFY",
-            "repeat_notification_required": True,
-            "spend_policy": "do not append quota spend for the blocker-push turn",
-            "reason": _open_todo_notify_reason(state=state, waiting_on=waiting_on),
-        }
-    if state == "focus_wait" and quota.get("handoff_outcome_floor_block"):
-        if quota.get("outcome_floor_blocker_projected"):
-            return {
-                **base,
-                "recommended_mode": "outcome_floor_blocker_projected_noop",
-                "notify": "DONT_NOTIFY",
-                "spend_policy": (
-                    "do not append quota spend while the same concrete outcome-floor "
-                    "blocker is already projected and no executable agent todo exists"
-                ),
-                "reason": str(
-                    quota.get("reason")
-                    or "outcome-floor blocker is already projected; wait for fresh outcome evidence"
-                ),
-            }
-        if quota.get("safe_bypass_allowed"):
-            return {
-                **base,
-                "recommended_mode": "outcome_floor_recovery",
-                "notify": "DONT_NOTIFY",
-                "spend_policy": (
-                    "append exactly one quota spend only after a validated "
-                    "ranker/cross-domain evidence artifact or concrete blocker writeback; "
-                    "do not spend for another surface-only report"
-                ),
-                "reason": str(quota.get("reason") or "handoff outcome floor is not met"),
-            }
-        return {
-            **base,
-            "recommended_mode": "report_handoff_outcome_blocker",
-            "notify": "NOTIFY",
-            "spend_policy": "do not append quota spend while reporting the handoff outcome-floor blocker",
-            "reason": str(quota.get("reason") or "handoff outcome floor is not met"),
-        }
-    if not should_run:
-        return {
-            **base,
-            "recommended_mode": "quota_skip",
-            "reason": f"quota state is {state}; skip delivery compute",
-        }
-
-    if item.get("agent_command"):
-        return {
-            **base,
-            "recommended_mode": "run_agent_command",
-            "command": str(item.get("agent_command")),
-            "notify": "DONT_NOTIFY",
-            "spend_policy": "append exactly one heartbeat spend after the command completes and validation/writeback are saved",
-            "reason": "current status exposes an approved project-agent command",
-        }
-
-    if (
-        work_lane_contract
-        and work_lane_contract.get("lane") == "continuous_monitor"
-        and work_lane_contract.get("must_attempt_work") is False
-        and has_user_todos
-    ):
-        return {
-            **base,
-            "recommended_mode": "monitor_quiet_until_material_transition",
-            "spend_policy": (
-                "do not append quota spend or repeat a blocker notification for a "
-                "monitor-only poll; keep the open user todo visible in the payload and "
-                "wait for a material monitor transition"
-            ),
-            "reason": (
-                "monitor-only polling has no material transition to write back; the "
-                "current open user todo is already part of the durable active state"
-            ),
-        }
-
-    if (
-        work_lane_contract
-        and work_lane_contract.get("lane") == "continuous_monitor"
-        and work_lane_contract.get("must_attempt_work") is False
-        and not has_user_todos
-    ):
-        return {
-            **base,
-            "recommended_mode": "monitor_quiet_until_material_transition",
-            "spend_policy": (
-                "do not append quota spend until a material monitor transition, regression, "
-                "or concrete blocker is validated and written back"
-            ),
-            "reason": "all visible open agent todos are monitor-class work with no material transition to record",
-        }
-
-    if (
-        work_lane_contract
-        and work_lane_contract.get("lane") == "continuous_monitor"
-        and work_lane_contract.get("must_attempt_work") is True
-        and not has_user_todos
-    ):
-        latest_run: dict[str, Any] = {}
-        handoff_readiness = (
-            item.get("handoff_readiness")
-            if isinstance(item.get("handoff_readiness"), dict)
-            else {}
-        )
-        latest_handoff_run = (
-            handoff_readiness.get("post_handoff_latest_run")
-            if isinstance(handoff_readiness.get("post_handoff_latest_run"), dict)
-            else {}
-        )
-        if latest_handoff_run:
-            latest_run = {
-                key: latest_handoff_run.get(key)
-                for key in POST_HANDOFF_RUN_COMPACT_FIELDS
-                if latest_handoff_run.get(key) is not None
-            }
-            latest_run["progress_scope"] = latest_run_progress_scope(latest_handoff_run)
-        payload = {
-            **base,
-            "recommended_mode": "follow_work_lane_contract",
-            "spend_policy": (
-                "follow work_lane_contract.obligation; spend only after validated "
-                "advancement, concrete blocker writeback, or a material monitor transition"
-            ),
-            "reason": (
-                "work_lane_contract is the machine contract for monitor-vs-advancement routing"
-            ),
-        }
-        if latest_run:
-            payload["latest_run"] = latest_run
-        return payload
-
-    if status == "connected_without_run" and _supports_read_only_project_map(adapter_kind):
-        return {
-            **base,
-            "recommended_mode": "run_first_read_only_map",
-            "command": f"loopx read-only-map --goal-id {goal_id}",
-            "notify": "NOTIFY",
-            "spend_policy": "append exactly one heartbeat spend after the read-only map run is saved and validated",
-            "reason": "connected read-only project has no saved compact run yet",
-        }
-
-    mapped = (
-        status == "read_only_project_map"
-        or _has_lifecycle_marker(lifecycle_phase, lifecycle_flags, marker="mapped")
-    )
-    if mapped and not any([has_user_todos, has_agent_todos, item.get("agent_command")]):
-        return {
-            **base,
-            "recommended_mode": "mapped_noop_if_unchanged",
-            "stop_if_unchanged": True,
-            "spend_policy": (
-                "do not run another dry-run or append quota spend when the latest read-only map is still current "
-                "and there is no new user instruction, owner evidence, agent todo, stale source, or safe handoff"
-            ),
-            "reason": "latest compact read-only map already exists; wait for new evidence or a concrete safe action",
-        }
-
-    post_handoff_observation = _control_plane_post_handoff_observation_hint(item)
-    if post_handoff_observation and not has_user_todos:
-        latest_observed_run = (
-            post_handoff_observation.get("latest_run")
-            if isinstance(post_handoff_observation.get("latest_run"), dict)
-            else {}
-        )
-        progress_scope = latest_run_progress_scope(latest_observed_run)
-        if isinstance(latest_observed_run, dict) and latest_observed_run:
-            latest_observed_run.setdefault("progress_scope", progress_scope)
-        if has_agent_todos and progress_scope == "dependency_observation":
-            return {
-                **base,
-                **{
-                    key: value
-                    for key, value in post_handoff_observation.items()
-                    if key != "stop_if_unchanged"
-                },
-                "recommended_mode": "follow_work_lane_contract",
-                "spend_policy": (
-                    "follow work_lane_contract.obligation; spend only after validated "
-                    "advancement, concrete blocker writeback, or a material monitor transition"
-                ),
-                "reason": (
-                    "latest post-handoff run was dependency observation; the work lane "
-                    "contract decides whether to advance backlog or record a material transition"
-                ),
-            }
-        if has_agent_todos:
-            active_observation = {
-                key: value
-                for key, value in post_handoff_observation.items()
-                if key != "stop_if_unchanged"
-            }
-            return {
-                **base,
-                **active_observation,
-                "recommended_mode": "post_handoff_observe_then_backlog_step",
-                "spend_policy": (
-                    "observe registry/status/run history/repo state first; if unchanged, "
-                    "advance exactly one bounded agent-todo backlog segment and append quota "
-                    "spend only after validation and durable writeback"
-                ),
-                "reason": (
-                    "latest post-handoff implementation reached the primary outcome, but "
-                    "an open agent todo remains; observe for new blockers first, then "
-                    "advance one bounded backlog step instead of quiet idling"
-                ),
-            }
-        return {
-            **base,
-            **post_handoff_observation,
-        }
-
-    return {
-        **base,
-        "recommended_mode": "steering_audit_then_one_step",
-        "spend_policy": "append exactly one heartbeat spend only after a bounded progress segment is validated and written back",
-        "reason": "eligible Codex-ready goal requires the standard steering audit before delivery",
-    }
 
 
 def _execution_obligation(
@@ -3543,7 +3162,7 @@ def build_quota_should_run(
             should_run = False
             effective_action = "automation_prompt_upgrade_required"
         recommendation_item = {**item, "quota": quota}
-        heartbeat_recommendation = _heartbeat_recommendation(
+        heartbeat_recommendation = build_heartbeat_recommendation(
             recommendation_item,
             goal_id=safe_goal_id,
             state=state,
@@ -3554,6 +3173,7 @@ def build_quota_should_run(
             stall_self_repair=stall_self_repair,
             replan_obligation=replan_obligation,
             select_replan_obligation=False,
+            monitor_due_item_limit=MONITOR_DUE_ITEM_LIMIT,
         )
         if capability_gate and capability_gate.get("action") == "repair_bridge":
             heartbeat_recommendation = {
@@ -3953,7 +3573,7 @@ def build_quota_should_run(
                 user_todo_summary=user_todo_summary,
             ) or repeat_open_todo_notification:
                 payload["notify_user_on_open_todo"] = True
-                payload["open_todo_notify_reason"] = _open_todo_notify_reason(
+                payload["open_todo_notify_reason"] = open_todo_notify_reason(
                     state=state,
                     waiting_on=str(item.get("waiting_on") or ""),
                 )


### PR DESCRIPTION
## Summary
- move quota heartbeat recommendation policy into `loopx.control_plane.quota.heartbeat_recommendation`
- keep `quota.py` as the should-run assembler while removing the old internal heartbeat implementation
- add a focused canary for operator gate, blocker push, monitor quiet vs due monitor, read-only-map lifecycle, and post-handoff primary/dependency modes

## Validation
- `python3 -m py_compile loopx/quota.py loopx/control_plane/quota/heartbeat_recommendation.py examples/control_plane/quota-heartbeat-recommendation-state-machine-smoke.py`
- `python3 examples/control_plane/quota-heartbeat-recommendation-state-machine-smoke.py`
- `python3 examples/control_plane/quota-work-lane-policy-smoke.py`
- `python3 examples/control_plane/quota-plan-smoke.py`
- `python3 examples/control_plane/heartbeat-quota-flow-smoke.py`
- `python3 examples/control_plane/bounded-context-namespace-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `python3 examples/control_plane/quota-scheduler-hint-compaction-smoke.py`
- `loopx check --scan-path loopx/quota.py --scan-path loopx/control_plane/quota/heartbeat_recommendation.py --scan-path examples/control_plane/quota-heartbeat-recommendation-state-machine-smoke.py` (one existing run-history duplicate-index warning)
- `loopx canary premerge --from-git-diff --tier standard --timeout-seconds 180`
