### PR TITLE
Extract quota projection repair rules

### DIFF
--- a/examples/control_plane/quota-projection-repair-state-machine-smoke.py
+++ b/examples/control_plane/quota-projection-repair-state-machine-smoke.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Canary the quota projection-repair state machines."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.quota.projection_repair import (  # noqa: E402
+    build_boundary_projection_repair_hint,
+    build_state_projection_gap,
+    build_state_projection_gap_repair_hint,
+    write_scope_allowed,
+)
+
+
+def state_gap(evidence: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "schema_version": "state_projection_gap_v0",
+        "kind": "state_projection_gap",
+        "severity": "warning",
+        "requires_todo_expansion": True,
+        "target_roles": sorted(
+            {
+                str(item.get("target_role") or "").strip()
+                for item in evidence
+                if str(item.get("target_role") or "").strip()
+            }
+        ),
+        "evidence_count": len(evidence),
+        "first_evidence": evidence,
+    }
+
+
+def agent_todo(
+    *,
+    todo_id: str = "todo_projection",
+    required_write_scopes: list[str] | None = None,
+    task_class: str = "advancement_task",
+) -> dict[str, Any]:
+    return {
+        "todo_id": todo_id,
+        "index": 1,
+        "status": "open",
+        "task_class": task_class,
+        "action_kind": "implement",
+        "text": f"[P1] Advance {todo_id}.",
+        "required_write_scopes": required_write_scopes or [],
+    }
+
+
+def agent_summary(items: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "schema_version": "todo_summary_v0",
+        "open_count": len(items),
+        "first_open_items": items,
+        "first_executable_items": items,
+        "items": items,
+    }
+
+
+def assert_state_gap_revalidation_drops_stale_user_waits() -> None:
+    stale_user_only = state_gap(
+        [
+            {
+                "kind": "next_action_waits_without_user_todo",
+                "target_role": "user",
+                "section": "Next Action",
+                "text": "Extract the quota projection-repair helper.",
+            }
+        ]
+    )
+    assert build_state_projection_gap({"state_projection_gap": stale_user_only}, {}) is None
+
+    retained_agent = {
+        "kind": "next_action_requires_agent_todo",
+        "target_role": "agent",
+        "section": "Next Action",
+        "text": "Extract the quota projection-repair helper.",
+    }
+    mixed = state_gap([stale_user_only["first_evidence"][0], retained_agent])
+    revised = build_state_projection_gap({}, {"state_projection_gap": mixed})
+    assert revised is not None, mixed
+    assert revised["target_roles"] == ["agent"], revised
+    assert revised["evidence_count"] == 1, revised
+    assert revised["first_evidence"] == [retained_agent], revised
+
+
+def assert_state_gap_repair_requires_empty_todo_projection_or_must_attempt() -> None:
+    gap = state_gap(
+        [
+            {
+                "kind": "next_action_requires_agent_todo",
+                "target_role": "agent",
+                "section": "Next Action",
+                "text": "Create the missing agent todo.",
+            }
+        ]
+    )
+    repair = build_state_projection_gap_repair_hint(
+        gap,
+        candidate_should_run=True,
+        user_todo_summary={"open_count": 0},
+        agent_todo_summary={"open_count": 0},
+        work_lane_contract=None,
+    )
+    assert repair is not None, gap
+    assert repair["effective_action"] == "state_projection_gap_repair", repair
+    assert build_state_projection_gap_repair_hint(
+        gap,
+        candidate_should_run=True,
+        user_todo_summary={"open_count": 1},
+        agent_todo_summary={"open_count": 0},
+        work_lane_contract=None,
+    ) is None
+    must_attempt_repair = build_state_projection_gap_repair_hint(
+        gap,
+        candidate_should_run=False,
+        user_todo_summary={"open_count": 0},
+        agent_todo_summary={"open_count": 0},
+        work_lane_contract={"must_attempt_work": True},
+    )
+    assert must_attempt_repair is not None, gap
+
+
+def assert_boundary_repair_reports_missing_scope_and_authority_lineage() -> None:
+    todo = agent_todo(required_write_scopes=["src/runtime/**"])
+    repair = build_boundary_projection_repair_hint(
+        {
+            "write_scope": ["docs/**"],
+            "checkpointed_boundary_authority": {
+                "schema_version": "checkpointed_boundary_authority_v0",
+                "active_count": 0,
+                "inactive_count": 1,
+                "active_write_scope": [],
+                "entries": [
+                    {
+                        "decision_id": "decision-runtime-expired",
+                        "source": "operator_gate_fixture",
+                        "active": False,
+                        "freshness": "expired",
+                        "inactive_reasons": ["expired"],
+                        "write_scope": ["src/**"],
+                    }
+                ],
+            },
+        },
+        agent_summary([todo]),
+        candidate_should_run=True,
+        capability_gate={"action": "run"},
+    )
+    assert repair is not None, todo
+    assert repair["effective_action"] == "boundary_projection_repair", repair
+    assert repair["missing_write_scopes"] == ["src/runtime/**"], repair
+    assert repair["allowed_write_scopes"] == ["docs/**"], repair
+    assert repair["inactive_authority_candidates"][0]["decision_id"] == (
+        "decision-runtime-expired"
+    ), repair
+
+
+def assert_boundary_repair_respects_scope_patterns_and_capability_gate() -> None:
+    todo = agent_todo(required_write_scopes=["src/runtime/**"])
+    assert write_scope_allowed("src/runtime/**", ["src/**"])
+    assert not write_scope_allowed("src/runtime/**", ["docs/**"])
+    assert build_boundary_projection_repair_hint(
+        {"write_scope": ["src/**"]},
+        agent_summary([todo]),
+        candidate_should_run=True,
+        capability_gate={"action": "run"},
+    ) is None
+    assert build_boundary_projection_repair_hint(
+        {"write_scope": ["docs/**"]},
+        agent_summary([todo]),
+        candidate_should_run=True,
+        capability_gate={"action": "ask_owner"},
+    ) is None
+
+
+def assert_boundary_repair_prefers_capability_runnable_candidate() -> None:
+    blocked_first = agent_todo(
+        todo_id="todo_blocked",
+        required_write_scopes=["blocked/**"],
+    )
+    runnable = agent_todo(
+        todo_id="todo_runnable",
+        required_write_scopes=["scripts/**"],
+    )
+    summary = agent_summary([blocked_first, runnable])
+    repair = build_boundary_projection_repair_hint(
+        {"write_scope": ["scripts/**"]},
+        summary,
+        candidate_should_run=True,
+        capability_gate={"action": "run", "runnable_candidates": [runnable]},
+    )
+    assert repair is None, repair
+
+    repair_without_gate = build_boundary_projection_repair_hint(
+        {"write_scope": ["scripts/**"]},
+        summary,
+        candidate_should_run=True,
+    )
+    assert repair_without_gate is not None, summary
+    assert repair_without_gate["missing_write_scopes"] == ["blocked/**"], repair_without_gate
+
+
+def main() -> int:
+    assert_state_gap_revalidation_drops_stale_user_waits()
+    assert_state_gap_repair_requires_empty_todo_projection_or_must_attempt()
+    assert_boundary_repair_reports_missing_scope_and_authority_lineage()
+    assert_boundary_repair_respects_scope_patterns_and_capability_gate()
+    assert_boundary_repair_prefers_capability_runnable_candidate()
+    print("quota-projection-repair-state-machine-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/control_plane/quota/projection_repair.py
+++ b/loopx/control_plane/quota/projection_repair.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import fnmatch
+from typing import Any
+
+from ...state_projection import is_user_wait_text
+from ..todos.contract import (
+    TODO_TASK_CLASS_ADVANCEMENT,
+    normalize_required_write_scopes,
+)
+from ..todos.projection import (
+    todo_item_is_actionable_open,
+    todo_item_task_class,
+)
+from ..work_items.interaction_contract import protocol_action_text
+
+
+def open_todo_count(summary: dict[str, Any] | None) -> int:
+    if not isinstance(summary, dict):
+        return 0
+    try:
+        return max(0, int(summary.get("open_count") or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def build_state_projection_gap(
+    item: dict[str, Any],
+    project_asset: dict[str, Any],
+) -> dict[str, Any] | None:
+    gap = (
+        item.get("state_projection_gap")
+        if isinstance(item.get("state_projection_gap"), dict)
+        else project_asset.get("state_projection_gap")
+        if isinstance(project_asset.get("state_projection_gap"), dict)
+        else None
+    )
+    if not isinstance(gap, dict):
+        return None
+    if gap.get("requires_todo_expansion") is not True:
+        return None
+    return revalidate_state_projection_gap(gap)
+
+
+def revalidate_state_projection_gap(gap: dict[str, Any]) -> dict[str, Any] | None:
+    if not isinstance(gap, dict):
+        return None
+    evidence_items = gap.get("first_evidence")
+    if not isinstance(evidence_items, list) or not evidence_items:
+        return gap
+
+    retained: list[dict[str, Any]] = []
+    removed_user_wait = False
+    for item in evidence_items:
+        if not isinstance(item, dict):
+            continue
+        is_user_wait_evidence = (
+            item.get("target_role") == "user"
+            and item.get("kind") == "next_action_waits_without_user_todo"
+        )
+        if is_user_wait_evidence and not is_user_wait_text(item.get("text")):
+            removed_user_wait = True
+            continue
+        retained.append(item)
+
+    if not removed_user_wait:
+        return gap
+    if not retained:
+        target_roles = {
+            str(role).strip()
+            for role in gap.get("target_roles", [])
+            if str(role or "").strip()
+        }
+        return None if target_roles <= {"user"} else gap
+
+    revised = dict(gap)
+    revised["first_evidence"] = retained
+    revised["evidence_count"] = len(retained)
+    revised["target_roles"] = sorted(
+        {
+            str(item.get("target_role") or "").strip()
+            for item in retained
+            if str(item.get("target_role") or "").strip()
+        }
+    )
+    return revised
+
+
+def build_state_projection_gap_repair_hint(
+    gap: dict[str, Any] | None,
+    *,
+    candidate_should_run: bool,
+    user_todo_summary: dict[str, Any] | None,
+    agent_todo_summary: dict[str, Any] | None,
+    work_lane_contract: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if not gap:
+        return None
+    if open_todo_count(user_todo_summary) > 0 or open_todo_count(agent_todo_summary) > 0:
+        return None
+    must_attempt = bool(
+        work_lane_contract
+        and work_lane_contract.get("must_attempt_work") is True
+    )
+    if not candidate_should_run and not must_attempt:
+        return None
+    return {
+        "source": "quota.should-run",
+        "trigger": "state_projection_gap",
+        "recommended_mode": "repair_state_projection_gap",
+        "effective_action": "state_projection_gap_repair",
+        "allowed": True,
+        "notify": "DONT_NOTIFY",
+        "reason": (
+            "active state has actionable Next Action / gate prose but no open "
+            "User Todo or Agent Todo projection"
+        ),
+        "repair_focus": (
+            "run one replan/todo-expansion/blocker-writeback slice: convert executable "
+            "Next Action into concrete Agent Todo, or convert owner/user gates into "
+            "User Todo, then refresh state before normal delivery"
+        ),
+        "spend_policy": (
+            "append exactly one heartbeat spend only after the projection repair is "
+            "validated and written back; do not spend for merely reporting the gap"
+        ),
+        "state_projection_gap": gap,
+    }
+
+
+def write_scope_allowed(required_scope: str, allowed_scopes: list[str]) -> bool:
+    required = str(required_scope or "").strip()
+    if not required:
+        return True
+    for allowed in allowed_scopes:
+        pattern = str(allowed or "").strip()
+        if not pattern:
+            continue
+        if required == pattern:
+            return True
+        if fnmatch.fnmatchcase(required, pattern):
+            return True
+    return False
+
+
+def build_boundary_projection_repair_hint(
+    goal_boundary: dict[str, Any] | None,
+    agent_todo_summary: dict[str, Any] | None,
+    *,
+    candidate_should_run: bool,
+    capability_gate: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    if not candidate_should_run or not isinstance(agent_todo_summary, dict):
+        return None
+    candidate_items: list[dict[str, Any]] = []
+    if isinstance(capability_gate, dict):
+        if capability_gate.get("action") != "run":
+            return None
+        runnable_candidates = capability_gate.get("runnable_candidates")
+        if isinstance(runnable_candidates, list) and runnable_candidates:
+            candidate_items.extend(
+                item for item in runnable_candidates if isinstance(item, dict)
+            )
+    if not candidate_items:
+        for key in ("first_executable_items", "first_open_items"):
+            value = agent_todo_summary.get(key)
+            if isinstance(value, list):
+                candidate_items.extend(item for item in value if isinstance(item, dict))
+    selected: dict[str, Any] | None = None
+    for item in candidate_items:
+        if not todo_item_is_actionable_open(item):
+            continue
+        if todo_item_task_class(item) != TODO_TASK_CLASS_ADVANCEMENT:
+            continue
+        required = normalize_required_write_scopes(item.get("required_write_scopes"))
+        if required:
+            selected = item
+            break
+    if not selected:
+        return None
+
+    required_scopes = normalize_required_write_scopes(selected.get("required_write_scopes"))
+    boundary = goal_boundary if isinstance(goal_boundary, dict) else {}
+    allowed_scopes = normalize_required_write_scopes(boundary.get("write_scope"))
+    missing_scopes = [
+        scope
+        for scope in required_scopes
+        if not write_scope_allowed(scope, allowed_scopes)
+    ]
+    if not missing_scopes:
+        return None
+    selected_text = protocol_action_text(selected.get("text"), limit=220)
+    boundary_authority = (
+        boundary.get("checkpointed_boundary_authority")
+        if isinstance(boundary.get("checkpointed_boundary_authority"), dict)
+        else None
+    )
+    repair: dict[str, Any] = {
+        "source": "quota.should-run",
+        "trigger": "required_write_scope_missing_from_goal_boundary",
+        "recommended_mode": "repair_boundary_projection",
+        "effective_action": "boundary_projection_repair",
+        "blocked_action_scope": "boundary_projection",
+        "allowed": True,
+        "notify": "DONT_NOTIFY",
+        "reason": (
+            "selected executable todo requires write scope not present in "
+            "goal_boundary.write_scope"
+        ),
+        "repair_focus": (
+            "repair the checkpointed decision projection: either add the approved "
+            "scope to goal_boundary.write_scope, rewrite the todo inside the current "
+            "boundary, or create a concrete user/controller gate"
+        ),
+        "spend_policy": (
+            "append exactly one heartbeat spend only after boundary projection repair, "
+            "todo rewrite, or blocker writeback is validated"
+        ),
+        "required_write_scopes": required_scopes,
+        "allowed_write_scopes": allowed_scopes,
+        "missing_write_scopes": missing_scopes,
+        "selected_todo": {
+            key: selected.get(key)
+            for key in ("todo_id", "index", "priority", "task_class", "action_kind")
+            if selected.get(key) is not None
+        },
+        "selected_todo_text": selected_text,
+    }
+    if boundary_authority:
+        repair["checkpointed_boundary_authority"] = {
+            "schema_version": boundary_authority.get("schema_version"),
+            "active_count": boundary_authority.get("active_count"),
+            "inactive_count": boundary_authority.get("inactive_count"),
+            "active_write_scope": boundary_authority.get("active_write_scope"),
+        }
+        inactive_candidates = []
+        for entry in boundary_authority.get("entries") or []:
+            if not isinstance(entry, dict) or entry.get("active") is True:
+                continue
+            scopes = normalize_required_write_scopes(entry.get("write_scope"))
+            if any(write_scope_allowed(scope, scopes) for scope in missing_scopes):
+                inactive_candidates.append(
+                    {
+                        key: entry.get(key)
+                        for key in (
+                            "decision_id",
+                            "source",
+                            "recorded_at",
+                            "expires_at",
+                            "freshness",
+                            "inactive_reasons",
+                            "write_scope",
+                        )
+                        if entry.get(key) is not None
+                    }
+                )
+        if inactive_candidates:
+            repair["inactive_authority_candidates"] = inactive_candidates[:3]
+    return repair

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from copy import deepcopy
-import fnmatch
 import json
 import re
 from datetime import datetime, timedelta, timezone
@@ -73,6 +72,11 @@ from .control_plane.quota.heartbeat_recommendation import (
     build_heartbeat_recommendation,
     open_todo_notify_reason,
 )
+from .control_plane.quota.projection_repair import (
+    build_boundary_projection_repair_hint,
+    build_state_projection_gap,
+    build_state_projection_gap_repair_hint,
+)
 from .control_plane.work_items.goal_route_hint import build_goal_route_hint
 from .control_plane.work_items.work_lane_context import (
     build_work_lane_context_contract,
@@ -98,7 +102,7 @@ from .control_plane.scheduler.state import (
     scheduler_state_path,
     write_scheduler_state,
 )
-from .state_projection import is_user_wait_text, next_action_projection_warning
+from .state_projection import next_action_projection_warning
 from .control_plane.todos.contract import (
     TODO_STATUS_OPEN,
     TODO_TASK_CLASS_ADVANCEMENT,
@@ -2143,238 +2147,6 @@ def _stall_self_repair_hint(
     return None
 
 
-def _state_projection_gap(item: dict[str, Any], project_asset: dict[str, Any]) -> dict[str, Any] | None:
-    gap = (
-        item.get("state_projection_gap")
-        if isinstance(item.get("state_projection_gap"), dict)
-        else project_asset.get("state_projection_gap")
-        if isinstance(project_asset.get("state_projection_gap"), dict)
-        else None
-    )
-    if not isinstance(gap, dict):
-        return None
-    if gap.get("requires_todo_expansion") is not True:
-        return None
-    return _revalidate_state_projection_gap(gap)
-
-
-def _revalidate_state_projection_gap(gap: dict[str, Any]) -> dict[str, Any] | None:
-    if not isinstance(gap, dict):
-        return None
-    evidence_items = gap.get("first_evidence")
-    if not isinstance(evidence_items, list) or not evidence_items:
-        return gap
-
-    retained: list[dict[str, Any]] = []
-    removed_user_wait = False
-    for item in evidence_items:
-        if not isinstance(item, dict):
-            continue
-        is_user_wait_evidence = (
-            item.get("target_role") == "user"
-            and item.get("kind") == "next_action_waits_without_user_todo"
-        )
-        if is_user_wait_evidence and not is_user_wait_text(item.get("text")):
-            removed_user_wait = True
-            continue
-        retained.append(item)
-
-    if not removed_user_wait:
-        return gap
-    if not retained:
-        target_roles = {
-            str(role).strip()
-            for role in gap.get("target_roles", [])
-            if str(role or "").strip()
-        }
-        return None if target_roles <= {"user"} else gap
-
-    revised = dict(gap)
-    revised["first_evidence"] = retained
-    revised["evidence_count"] = len(retained)
-    revised["target_roles"] = sorted(
-        {
-            str(item.get("target_role") or "").strip()
-            for item in retained
-            if str(item.get("target_role") or "").strip()
-        }
-    )
-    return revised
-
-
-def _state_projection_gap_repair_hint(
-    gap: dict[str, Any] | None,
-    *,
-    candidate_should_run: bool,
-    user_todo_summary: dict[str, Any] | None,
-    agent_todo_summary: dict[str, Any] | None,
-    work_lane_contract: dict[str, Any] | None,
-) -> dict[str, Any] | None:
-    if not gap:
-        return None
-    if _open_todo_count(user_todo_summary) > 0 or _open_todo_count(agent_todo_summary) > 0:
-        return None
-    must_attempt = bool(
-        work_lane_contract
-        and work_lane_contract.get("must_attempt_work") is True
-    )
-    if not candidate_should_run and not must_attempt:
-        return None
-    return {
-        "source": "quota.should-run",
-        "trigger": "state_projection_gap",
-        "recommended_mode": "repair_state_projection_gap",
-        "effective_action": "state_projection_gap_repair",
-        "allowed": True,
-        "notify": "DONT_NOTIFY",
-        "reason": (
-            "active state has actionable Next Action / gate prose but no open "
-            "User Todo or Agent Todo projection"
-        ),
-        "repair_focus": (
-            "run one replan/todo-expansion/blocker-writeback slice: convert executable "
-            "Next Action into concrete Agent Todo, or convert owner/user gates into "
-            "User Todo, then refresh state before normal delivery"
-        ),
-        "spend_policy": (
-            "append exactly one heartbeat spend only after the projection repair is "
-            "validated and written back; do not spend for merely reporting the gap"
-        ),
-        "state_projection_gap": gap,
-    }
-
-
-def _write_scope_allowed(required_scope: str, allowed_scopes: list[str]) -> bool:
-    required = str(required_scope or "").strip()
-    if not required:
-        return True
-    for allowed in allowed_scopes:
-        pattern = str(allowed or "").strip()
-        if not pattern:
-            continue
-        if required == pattern:
-            return True
-        if fnmatch.fnmatchcase(required, pattern):
-            return True
-    return False
-
-
-def _boundary_projection_repair_hint(
-    goal_boundary: dict[str, Any] | None,
-    agent_todo_summary: dict[str, Any] | None,
-    *,
-    candidate_should_run: bool,
-    capability_gate: dict[str, Any] | None = None,
-) -> dict[str, Any] | None:
-    if not candidate_should_run or not isinstance(agent_todo_summary, dict):
-        return None
-    candidate_items: list[dict[str, Any]] = []
-    if isinstance(capability_gate, dict):
-        if capability_gate.get("action") != "run":
-            return None
-        runnable_candidates = capability_gate.get("runnable_candidates")
-        if isinstance(runnable_candidates, list) and runnable_candidates:
-            candidate_items.extend(
-                item for item in runnable_candidates if isinstance(item, dict)
-            )
-    if not candidate_items:
-        for key in ("first_executable_items", "first_open_items"):
-            value = agent_todo_summary.get(key)
-            if isinstance(value, list):
-                candidate_items.extend(item for item in value if isinstance(item, dict))
-    selected: dict[str, Any] | None = None
-    for item in candidate_items:
-        if not _todo_item_is_actionable_open(item):
-            continue
-        if _todo_task_class(item) != TODO_TASK_CLASS_ADVANCEMENT:
-            continue
-        required = normalize_required_write_scopes(item.get("required_write_scopes"))
-        if required:
-            selected = item
-            break
-    if not selected:
-        return None
-
-    required_scopes = normalize_required_write_scopes(selected.get("required_write_scopes"))
-    boundary = goal_boundary if isinstance(goal_boundary, dict) else {}
-    allowed_scopes = normalize_required_write_scopes(boundary.get("write_scope"))
-    missing_scopes = [
-        scope
-        for scope in required_scopes
-        if not _write_scope_allowed(scope, allowed_scopes)
-    ]
-    if not missing_scopes:
-        return None
-    selected_text = _protocol_action_text(selected.get("text"), limit=220)
-    boundary_authority = (
-        boundary.get("checkpointed_boundary_authority")
-        if isinstance(boundary.get("checkpointed_boundary_authority"), dict)
-        else None
-    )
-    repair: dict[str, Any] = {
-        "source": "quota.should-run",
-        "trigger": "required_write_scope_missing_from_goal_boundary",
-        "recommended_mode": "repair_boundary_projection",
-        "effective_action": "boundary_projection_repair",
-        "blocked_action_scope": "boundary_projection",
-        "allowed": True,
-        "notify": "DONT_NOTIFY",
-        "reason": (
-            "selected executable todo requires write scope not present in "
-            "goal_boundary.write_scope"
-        ),
-        "repair_focus": (
-            "repair the checkpointed decision projection: either add the approved "
-            "scope to goal_boundary.write_scope, rewrite the todo inside the current "
-            "boundary, or create a concrete user/controller gate"
-        ),
-        "spend_policy": (
-            "append exactly one heartbeat spend only after boundary projection repair, "
-            "todo rewrite, or blocker writeback is validated"
-        ),
-        "required_write_scopes": required_scopes,
-        "allowed_write_scopes": allowed_scopes,
-        "missing_write_scopes": missing_scopes,
-        "selected_todo": {
-            key: selected.get(key)
-            for key in ("todo_id", "index", "priority", "task_class", "action_kind")
-            if selected.get(key) is not None
-        },
-        "selected_todo_text": selected_text,
-    }
-    if boundary_authority:
-        repair["checkpointed_boundary_authority"] = {
-            "schema_version": boundary_authority.get("schema_version"),
-            "active_count": boundary_authority.get("active_count"),
-            "inactive_count": boundary_authority.get("inactive_count"),
-            "active_write_scope": boundary_authority.get("active_write_scope"),
-        }
-        inactive_candidates = []
-        for entry in boundary_authority.get("entries") or []:
-            if not isinstance(entry, dict) or entry.get("active") is True:
-                continue
-            scopes = normalize_required_write_scopes(entry.get("write_scope"))
-            if any(_write_scope_allowed(scope, scopes) for scope in missing_scopes):
-                inactive_candidates.append(
-                    {
-                        key: entry.get(key)
-                        for key in (
-                            "decision_id",
-                            "source",
-                            "recorded_at",
-                            "expires_at",
-                            "freshness",
-                            "inactive_reasons",
-                            "write_scope",
-                        )
-                        if entry.get(key) is not None
-                    }
-                )
-        if inactive_candidates:
-            repair["inactive_authority_candidates"] = inactive_candidates[:3]
-    return repair
-
-
 def _execution_obligation(
     *,
     should_run: bool,
@@ -3069,8 +2841,8 @@ def build_quota_should_run(
         )
         capability_repair_allowed = False
         workspace_repair_allowed = False
-        projection_gap = _state_projection_gap(item, project_asset)
-        projection_gap_repair = _state_projection_gap_repair_hint(
+        projection_gap = build_state_projection_gap(item, project_asset)
+        projection_gap_repair = build_state_projection_gap_repair_hint(
             projection_gap,
             candidate_should_run=bool(
                 normal_delivery_allowed or recovery_allowed or self_repair_allowed
@@ -3085,7 +2857,7 @@ def build_quota_should_run(
             normal_delivery_allowed = False
             recovery_allowed = False
             reason = str(projection_gap_repair.get("reason") or reason)
-        boundary_projection_repair = _boundary_projection_repair_hint(
+        boundary_projection_repair = build_boundary_projection_repair_hint(
             goal_boundary,
             agent_todo_summary,
             candidate_should_run=bool(


### PR DESCRIPTION
## Summary
- Move quota state-projection and boundary-projection repair rules into loopx/control_plane/quota/projection_repair.py.
- Keep loopx/quota.py as the orchestration caller for those repair hints.
- Add quota-projection-repair-state-machine smoke coverage for stale user-wait revalidation, empty todo projection repair gating, required write-scope repair, inactive authority lineage, and capability runnable-candidate selection.

## Validation
- python3 -m py_compile loopx/quota.py loopx/control_plane/quota/projection_repair.py examples/control_plane/quota-projection-repair-state-machine-smoke.py
- python3 examples/control_plane/quota-projection-repair-state-machine-smoke.py
- python3 examples/state-projection-gap-smoke.py
- python3 examples/control_plane/quota-action-scope-guard-smoke.py
- python3 examples/control_plane/quota-plan-smoke.py
- python3 examples/control_plane/interaction-contract-state-machine-smoke.py
- python3 examples/control_plane/control-plane-integrated-canary-smoke.py
- python3 examples/control_plane/bounded-context-namespace-smoke.py
- python3 examples/control_plane/repo-python-line-budget-smoke.py
- git diff --check
- loopx check --scan-path loopx/quota.py --scan-path loopx/control_plane/quota/projection_repair.py --scan-path examples/control_plane/quota-projection-repair-state-machine-smoke.py
- loopx canary premerge --from-git-diff --tier standard --timeout-seconds 180

Premerge reported merge_gate_passed=true, self_merge_allowed=true, changed surfaces control_plane/public_boundary/python, manual holds=0. loopx check had only the existing global history duplicate-index warning, not a changed-path issue.