### PR TITLE
Extract quota capability gate read model

### DIFF
--- a/examples/control_plane/capability-gate-projection-smoke.py
+++ b/examples/control_plane/capability-gate-projection-smoke.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Smoke-test capability-gate projection helpers used by quota."""
+"""Smoke-test capability-gate projection and decision contracts used by quota."""
 
 from __future__ import annotations
 
@@ -15,6 +15,7 @@ from loopx.control_plane.agents.capability_gate import (  # noqa: E402
     _capability_candidate_item,
     _capability_missing_action,
     _sort_capability_runnable_candidates,
+    build_capability_gate,
 )
 
 
@@ -119,10 +120,105 @@ def assert_current_agent_candidate_order_contract() -> None:
     ], ordered
 
 
+def assert_gate_prefers_active_next_and_exposes_blocked_fallback() -> None:
+    blocked = todo(
+        "todo_needs_network",
+        1,
+        "P0",
+        claimed_by=AGENT_ID,
+        required_capabilities=["network"],
+    )
+    runnable = todo(
+        "todo_local_refactor",
+        2,
+        "P1",
+        claimed_by=AGENT_ID,
+        required_capabilities=["shell"],
+    )
+    gate = build_capability_gate(
+        {
+            "active_next_action_executable_items": [blocked, blocked],
+            "executable_backlog_items": [runnable],
+        },
+        available_capabilities=["shell"],
+        agent_identity={"agent_id": AGENT_ID, "primary_agent": PRIMARY_AGENT},
+    )
+    assert gate is not None
+    assert gate["schema_version"] == "capability_gate_v0", gate
+    assert gate["source"] == "agent_todo_summary.active_next_action_executable_items", gate
+    assert gate["action"] == "run", gate
+    assert gate["decision_owner"] == "agent", gate
+    assert gate["runnable_candidates"][0]["todo_id"] == "todo_local_refactor", gate
+    assert [item["todo_id"] for item in gate["blocked_candidates"]] == [
+        "todo_needs_network"
+    ], gate
+    assert gate["blocked_missing"] == ["network"], gate
+    assert gate["available"] == ["shell", "filesystem_read", "filesystem_write"], gate
+
+
+def assert_target_capability_creates_repair_hint_not_hard_block() -> None:
+    item = todo(
+        "todo_bridge_repair",
+        3,
+        "P1",
+        claimed_by=AGENT_ID,
+        required_capabilities=["shell", "benchmark_runner"],
+        target_capabilities=["benchmark_runner"],
+    )
+    gate = build_capability_gate(
+        {"executable_backlog_items": [item]},
+        available_capabilities=["shell"],
+        agent_identity={"agent_id": AGENT_ID, "primary_agent": PRIMARY_AGENT},
+    )
+    assert gate is not None
+    assert gate["action"] == "run", gate
+    assert gate["repair_candidate_count"] == 1, gate
+    assert gate["repair_missing"] == ["benchmark_runner"], gate
+    candidate = gate["runnable_candidates"][0]
+    assert candidate["todo_id"] == "todo_bridge_repair", gate
+    assert candidate["capability_repair_mode"] is True, gate
+    assert candidate["capability_action"] == "repair_bridge", gate
+
+
+def assert_all_blocked_owner_capability_stops_delivery() -> None:
+    item = todo(
+        "todo_live_fetch",
+        4,
+        "P0",
+        required_capabilities=["network"],
+    )
+    gate = build_capability_gate(
+        {"first_executable_items": [item]},
+        available_capabilities=["shell"],
+        agent_identity={"agent_id": AGENT_ID, "primary_agent": PRIMARY_AGENT},
+    )
+    assert gate is not None
+    assert gate["source"] == "agent_todo_summary.first_executable_items", gate
+    assert gate["action"] == "ask_owner", gate
+    assert gate["decision_owner"] == "capability_gate", gate
+    assert gate["blocks_delivery"] is True, gate
+    assert gate["missing"] == ["network"], gate
+    assert "provide an environment" in gate["owner_action"], gate
+
+
+def assert_requirement_free_advancement_does_not_create_gate() -> None:
+    item = todo("todo_plain_local", 5, "P2")
+    gate = build_capability_gate(
+        {"executable_backlog_items": [item]},
+        available_capabilities=[],
+        agent_identity={"agent_id": AGENT_ID, "primary_agent": PRIMARY_AGENT},
+    )
+    assert gate is None
+
+
 def main() -> int:
     assert_missing_action_contract()
     assert_candidate_compaction_contract()
     assert_current_agent_candidate_order_contract()
+    assert_gate_prefers_active_next_and_exposes_blocked_fallback()
+    assert_target_capability_creates_repair_hint_not_hard_block()
+    assert_all_blocked_owner_capability_stops_delivery()
+    assert_requirement_free_advancement_does_not_create_gate()
     print("capability-gate-projection-smoke ok")
     return 0
 

--- a/loopx/control_plane/agents/capability_gate.py
+++ b/loopx/control_plane/agents/capability_gate.py
@@ -3,15 +3,27 @@ from __future__ import annotations
 from typing import Any
 
 from ..todos.contract import (
+    TODO_TASK_CLASS_ADVANCEMENT,
     normalize_required_capabilities,
     normalize_target_capabilities,
     normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
 )
-from ..todos.projection import todo_index_rank, todo_priority_rank
+from ..todos.projection import (
+    todo_index_rank,
+    todo_item_is_actionable_open,
+    todo_item_task_class,
+    todo_priority_rank,
+)
 from ..todos.summary_item import compact_todo_summary_item
 
 
+CAPABILITY_GATE_SCHEMA_VERSION = "capability_gate_v0"
+DEFAULT_AVAILABLE_CAPABILITIES = (
+    "shell",
+    "filesystem_read",
+    "filesystem_write",
+)
 CAPABILITY_REPAIR_BRIDGE_HINTS = {
     "benchmark_runner",
     "external_evidence_poll",
@@ -34,6 +46,14 @@ def _capability_missing_action(missing: list[str]) -> str:
     if missing_set & CAPABILITY_OWNER_GATE_HINTS:
         return "ask_owner"
     return "skip"
+
+
+def available_capabilities_with_defaults(value: Any) -> list[str]:
+    capabilities = list(DEFAULT_AVAILABLE_CAPABILITIES)
+    for capability in normalize_required_capabilities(value):
+        if capability not in capabilities:
+            capabilities.append(capability)
+    return capabilities
 
 
 def _capability_candidate_item(
@@ -137,3 +157,168 @@ def _sort_capability_runnable_candidates(
         ),
         policy,
     )
+
+
+def build_capability_gate(
+    agent_todo_summary: dict[str, Any] | None,
+    *,
+    available_capabilities: list[str],
+    agent_identity: dict[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    if not isinstance(agent_todo_summary, dict):
+        return None
+    active_next_action_executable_items = agent_todo_summary.get(
+        "active_next_action_executable_items"
+    )
+    executable_backlog_items = agent_todo_summary.get("executable_backlog_items")
+    first_executable_items = agent_todo_summary.get("first_executable_items")
+    if (
+        isinstance(active_next_action_executable_items, list)
+        and active_next_action_executable_items
+    ):
+        raw_items = [
+            *active_next_action_executable_items,
+            *(
+                executable_backlog_items
+                if isinstance(executable_backlog_items, list)
+                else []
+            ),
+        ]
+        source = "agent_todo_summary.active_next_action_executable_items"
+    elif isinstance(executable_backlog_items, list) and executable_backlog_items:
+        raw_items = executable_backlog_items
+        source = "agent_todo_summary.executable_backlog_items"
+    elif isinstance(first_executable_items, list) and first_executable_items:
+        raw_items = first_executable_items
+        source = "agent_todo_summary.first_executable_items"
+    else:
+        raw_items = []
+        source = "agent_todo_summary.executable_backlog_items"
+    deduped_raw_items: list[Any] = []
+    seen_raw: set[tuple[str, str]] = set()
+    for item in raw_items:
+        if not isinstance(item, dict):
+            deduped_raw_items.append(item)
+            continue
+        identity = (
+            str(item.get("todo_id") or ""),
+            str(item.get("text") or "").strip(),
+        )
+        if identity in seen_raw:
+            continue
+        seen_raw.add(identity)
+        deduped_raw_items.append(item)
+    raw_items = deduped_raw_items
+    candidates = [
+        item
+        for item in raw_items
+        if isinstance(item, dict)
+        and todo_item_is_actionable_open(item)
+        and todo_item_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
+    ]
+    if not candidates:
+        return None
+
+    available = available_capabilities_with_defaults(available_capabilities)
+    blocked: list[dict[str, Any]] = []
+    runnable: list[dict[str, Any]] = []
+    saw_requirement = False
+    for item in candidates:
+        required = normalize_required_capabilities(item.get("required_capabilities"))
+        targets = normalize_target_capabilities(item.get("target_capabilities"))
+        if required or targets:
+            saw_requirement = True
+        hard_required = [
+            capability for capability in required if capability not in targets
+        ]
+        missing = [
+            capability for capability in hard_required if capability not in available
+        ]
+        missing_targets = [
+            capability for capability in targets if capability not in available
+        ]
+        if missing:
+            blocked.append(_capability_candidate_item(item, missing=missing))
+            continue
+        runnable.append(
+            _capability_candidate_item(
+                item,
+                missing=[],
+                missing_target_capabilities=missing_targets,
+            )
+        )
+
+    if not saw_requirement and not blocked:
+        return None
+    if runnable:
+        runnable, candidate_order_policy = _sort_capability_runnable_candidates(
+            runnable,
+            agent_identity=agent_identity,
+        )
+        runnable_required: list[str] = []
+        blocked_missing: list[str] = []
+        repair_missing: list[str] = []
+        for item in runnable:
+            for capability in item.get("required_capabilities") or []:
+                if capability not in runnable_required:
+                    runnable_required.append(str(capability))
+            if item.get("capability_repair_mode") is True:
+                for capability in item.get("missing_target_capabilities") or []:
+                    if capability not in repair_missing:
+                        repair_missing.append(str(capability))
+        for item in blocked:
+            for capability in item.get("missing_capabilities") or []:
+                if capability not in blocked_missing:
+                    blocked_missing.append(str(capability))
+        return {
+            "schema_version": CAPABILITY_GATE_SCHEMA_VERSION,
+            "source": source,
+            "required": runnable_required,
+            "available": available,
+            "missing": [],
+            "action": "run",
+            "decision_owner": "agent",
+            "selection_policy": "agent_steering_audit_over_runnable_candidates",
+            "candidate_order_policy": candidate_order_policy or "projection_order",
+            "runnable_count": len(runnable),
+            "runnable_candidates": runnable,
+            "blocked_candidates": blocked,
+            "blocked_missing": blocked_missing,
+            "repair_missing": repair_missing,
+            "repair_candidate_count": sum(
+                1 for item in runnable if item.get("capability_repair_mode") is True
+            ),
+            "reason": "capability gate projected runnable candidate set; agent chooses the actual todo",
+        }
+
+    missing_all: list[str] = []
+    required_all: list[str] = []
+    for item in blocked:
+        for capability in item.get("required_capabilities") or []:
+            if capability not in required_all:
+                required_all.append(str(capability))
+        for capability in item.get("missing_capabilities") or []:
+            if capability not in missing_all:
+                missing_all.append(str(capability))
+    action = _capability_missing_action(missing_all)
+    return {
+        "schema_version": CAPABILITY_GATE_SCHEMA_VERSION,
+        "source": source,
+        "required": required_all,
+        "available": available,
+        "missing": missing_all,
+        "action": action,
+        "decision_owner": "capability_gate",
+        "selection_policy": "no_runnable_candidate",
+        "runnable_count": 0,
+        "runnable_candidates": [],
+        "blocked_candidates": blocked,
+        "blocks_delivery": True,
+        "reason": "all visible executable todo candidates require unavailable capabilities",
+        "owner_action": (
+            "provide an environment with the missing capability, mark the todo blocked, "
+            "or add a lower-risk fallback todo"
+        )
+        if action == "ask_owner"
+        else None,
+    }

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -25,9 +25,7 @@ from .control_plane.agents.agent_lane_recommendation import (
     selected_recommended_action_from_work_lane,
 )
 from .control_plane.agents.capability_gate import (
-    _capability_candidate_item,
-    _capability_missing_action,
-    _sort_capability_runnable_candidates,
+    build_capability_gate,
 )
 from .control_plane.agents.workspace_guard import build_side_agent_workspace_guard
 from .benchmark_core import compact_run_permission_policy_for_quota
@@ -109,8 +107,6 @@ from .control_plane.todos.contract import (
     TODO_TASK_CLASS_BLOCKER,
     TODO_TASK_CLASS_MONITOR,
     TODO_TASK_CLASS_USER_GATE,
-    normalize_required_capabilities,
-    normalize_target_capabilities,
     normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
     normalize_todo_id,
@@ -220,12 +216,6 @@ STALL_HEALTH_ITEM_COMPACT_FIELDS = (
 )
 DECISION_FRESHNESS_WARNING_ITEM_LIMIT = 3
 AUTOMATION_LIVENESS_SCHEMA_VERSION = "automation_liveness_v0"
-CAPABILITY_GATE_SCHEMA_VERSION = "capability_gate_v0"
-DEFAULT_AVAILABLE_CAPABILITIES = (
-    "shell",
-    "filesystem_read",
-    "filesystem_write",
-)
 TODO_BACKLOG_ITEM_LIMIT = 8
 TODO_DEFERRED_VISIBILITY_LIMIT = 8
 TODO_VISIBILITY_LANE_LIMIT = 16
@@ -613,173 +603,6 @@ def _quota_sort_key(item: dict[str, Any]) -> tuple[int, float, int, str]:
     compute = _number(quota.get("compute"), default=DEFAULT_COMPUTE_QUOTA)
     spent_slots = _int_number(quota.get("spent_slots"), default=0)
     return (state_index, -compute, spent_slots, str(item.get("goal_id") or ""))
-
-
-def _available_capabilities(value: Any) -> list[str]:
-    capabilities = list(DEFAULT_AVAILABLE_CAPABILITIES)
-    for capability in normalize_required_capabilities(value):
-        if capability not in capabilities:
-            capabilities.append(capability)
-    return capabilities
-
-
-def _capability_gate(
-    agent_todo_summary: dict[str, Any] | None,
-    *,
-    available_capabilities: list[str],
-    agent_identity: dict[str, Any] | None = None,
-) -> dict[str, Any] | None:
-    if not isinstance(agent_todo_summary, dict):
-        return None
-    active_next_action_executable_items = agent_todo_summary.get(
-        "active_next_action_executable_items"
-    )
-    executable_backlog_items = agent_todo_summary.get("executable_backlog_items")
-    first_executable_items = agent_todo_summary.get("first_executable_items")
-    if (
-        isinstance(active_next_action_executable_items, list)
-        and active_next_action_executable_items
-    ):
-        raw_items = [
-            *active_next_action_executable_items,
-            *(
-                executable_backlog_items
-                if isinstance(executable_backlog_items, list)
-                else []
-            ),
-        ]
-        source = "agent_todo_summary.active_next_action_executable_items"
-    elif isinstance(executable_backlog_items, list) and executable_backlog_items:
-        raw_items = executable_backlog_items
-        source = "agent_todo_summary.executable_backlog_items"
-    elif isinstance(first_executable_items, list) and first_executable_items:
-        raw_items = first_executable_items
-        source = "agent_todo_summary.first_executable_items"
-    else:
-        raw_items = []
-        source = "agent_todo_summary.executable_backlog_items"
-    deduped_raw_items: list[Any] = []
-    seen_raw: set[tuple[str, str]] = set()
-    for item in raw_items:
-        if not isinstance(item, dict):
-            deduped_raw_items.append(item)
-            continue
-        identity = (
-            str(item.get("todo_id") or ""),
-            str(item.get("text") or "").strip(),
-        )
-        if identity in seen_raw:
-            continue
-        seen_raw.add(identity)
-        deduped_raw_items.append(item)
-    raw_items = deduped_raw_items
-    candidates = [
-        item
-        for item in raw_items
-        if isinstance(item, dict)
-        and _todo_item_is_actionable_open(item)
-        and _todo_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
-    ]
-    if not candidates:
-        return None
-
-    available = _available_capabilities(available_capabilities)
-    blocked: list[dict[str, Any]] = []
-    runnable: list[dict[str, Any]] = []
-    saw_requirement = False
-    for item in candidates:
-        required = normalize_required_capabilities(item.get("required_capabilities"))
-        targets = normalize_target_capabilities(item.get("target_capabilities"))
-        if required or targets:
-            saw_requirement = True
-        hard_required = [capability for capability in required if capability not in targets]
-        missing = [capability for capability in hard_required if capability not in available]
-        missing_targets = [capability for capability in targets if capability not in available]
-        if missing:
-            blocked.append(_capability_candidate_item(item, missing=missing))
-            continue
-        runnable.append(
-            _capability_candidate_item(
-                item,
-                missing=[],
-                missing_target_capabilities=missing_targets,
-            )
-        )
-
-    if not saw_requirement and not blocked:
-        return None
-    if runnable:
-        runnable, candidate_order_policy = _sort_capability_runnable_candidates(
-            runnable,
-            agent_identity=agent_identity,
-        )
-        runnable_required: list[str] = []
-        blocked_missing: list[str] = []
-        repair_missing: list[str] = []
-        for item in runnable:
-            for capability in item.get("required_capabilities") or []:
-                if capability not in runnable_required:
-                    runnable_required.append(str(capability))
-            if item.get("capability_repair_mode") is True:
-                for capability in item.get("missing_target_capabilities") or []:
-                    if capability not in repair_missing:
-                        repair_missing.append(str(capability))
-        for item in blocked:
-            for capability in item.get("missing_capabilities") or []:
-                if capability not in blocked_missing:
-                    blocked_missing.append(str(capability))
-        return {
-            "schema_version": CAPABILITY_GATE_SCHEMA_VERSION,
-            "source": source,
-            "required": runnable_required,
-            "available": available,
-            "missing": [],
-            "action": "run",
-            "decision_owner": "agent",
-            "selection_policy": "agent_steering_audit_over_runnable_candidates",
-            "candidate_order_policy": candidate_order_policy or "projection_order",
-            "runnable_count": len(runnable),
-            "runnable_candidates": runnable,
-            "blocked_candidates": blocked,
-            "blocked_missing": blocked_missing,
-            "repair_missing": repair_missing,
-            "repair_candidate_count": sum(
-                1 for item in runnable if item.get("capability_repair_mode") is True
-            ),
-            "reason": "capability gate projected runnable candidate set; agent chooses the actual todo",
-        }
-
-    missing_all: list[str] = []
-    required_all: list[str] = []
-    for item in blocked:
-        for capability in item.get("required_capabilities") or []:
-            if capability not in required_all:
-                required_all.append(str(capability))
-        for capability in item.get("missing_capabilities") or []:
-            if capability not in missing_all:
-                missing_all.append(str(capability))
-    action = _capability_missing_action(missing_all)
-    return {
-        "schema_version": CAPABILITY_GATE_SCHEMA_VERSION,
-        "source": source,
-        "required": required_all,
-        "available": available,
-        "missing": missing_all,
-        "action": action,
-        "decision_owner": "capability_gate",
-        "selection_policy": "no_runnable_candidate",
-        "runnable_count": 0,
-        "runnable_candidates": [],
-        "blocked_candidates": blocked,
-        "blocks_delivery": True,
-        "reason": "all visible executable todo candidates require unavailable capabilities",
-        "owner_action": (
-            "provide an environment with the missing capability, mark the todo blocked, "
-            "or add a lower-risk fallback todo"
-        )
-        if action == "ask_owner"
-        else None,
-    }
 
 
 def _todo_priority_label(item: dict[str, Any]) -> str | None:
@@ -2834,9 +2657,9 @@ def build_quota_should_run(
             replan_obligation=replan_obligation,
             acceptance_gaps=goal_frontier_acceptance_gaps,
         )
-        capability_gate = _capability_gate(
+        capability_gate = build_capability_gate(
             agent_todo_summary,
-            available_capabilities=_available_capabilities(available_capabilities),
+            available_capabilities=available_capabilities,
             agent_identity=agent_identity,
         )
         capability_repair_allowed = False


### PR DESCRIPTION
## Summary
- move quota capability-gate construction into the agents bounded context
- keep quota as the should-run integration caller only
- extend the capability-gate smoke with direct decision coverage for active-next fallback, target-capability repair hints, owner-gated missing capabilities, and requirement-free no-op behavior

## Validation
- python3 -m py_compile loopx/quota.py loopx/control_plane/agents/capability_gate.py examples/control_plane/capability-gate-projection-smoke.py
- python3 examples/control_plane/capability-gate-projection-smoke.py
- python3 examples/control_plane/quota-action-scope-guard-smoke.py
- python3 examples/control_plane/interaction-contract-state-machine-smoke.py
- python3 examples/control_plane/quota-plan-smoke.py
- python3 examples/control_plane/side-agent-self-iteration-state-machine-smoke.py
- python3 examples/control_plane/bounded-context-namespace-smoke.py
- python3 examples/control_plane/work-lane-contract-smoke.py
- python3 examples/control_plane/control-plane-integrated-canary-smoke.py
- python3 examples/control_plane/repo-python-line-budget-smoke.py
- python3 examples/control_plane/quota-projection-repair-state-machine-smoke.py
- loopx check --scan-path loopx/control_plane/agents/capability_gate.py --scan-path loopx/quota.py --scan-path examples/control_plane/capability-gate-projection-smoke.py
- loopx canary premerge --from-git-diff --tier standard --timeout-seconds 180

## Notes
- premerge gate passed with self_merge_allowed=true
- loopx check still reports the existing duplicate-index warning for loopx-meta; this PR does not touch history/index state