### PR TITLE
Extract heartbeat automation liveness policy

### DIFF
--- a/examples/control_plane/automation-liveness-state-machine-smoke.py
+++ b/examples/control_plane/automation-liveness-state-machine-smoke.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Smoke-test heartbeat automation liveness decisions outside quota."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.agents.agent_scope import AgentScopeFrontierAction  # noqa: E402
+from loopx.control_plane.scheduler.automation_liveness import (  # noqa: E402
+    build_automation_liveness,
+)
+
+
+def payload(
+    *,
+    effective_action: str = "normal_run",
+    recommended_mode: str = "",
+    must_attempt_work: bool = False,
+    agent_scope_frontier: dict | None = None,
+) -> dict:
+    result = {
+        "effective_action": effective_action,
+        "heartbeat_recommendation": {
+            "recommended_mode": recommended_mode,
+        },
+        "execution_obligation": {
+            "must_attempt_work": must_attempt_work,
+        },
+    }
+    if agent_scope_frontier is not None:
+        result["agent_scope_frontier"] = agent_scope_frontier
+    return result
+
+
+def assert_common_liveness_fields(liveness: dict) -> None:
+    assert liveness["schema_version"] == "automation_liveness_v0", liveness
+    assert liveness["keep_active"] is True, liveness
+    assert liveness["pause_allowed"] is False, liveness
+    assert "pause/delete only after" in liveness["pause_policy"], liveness
+
+
+def assert_monitor_quiet_skip_keeps_heartbeat_active() -> None:
+    liveness = build_automation_liveness(
+        payload(
+            effective_action="monitor_quiet_skip",
+            recommended_mode="monitor_quiet_until_material_transition",
+        )
+    )
+    assert_common_liveness_fields(liveness)
+    assert liveness["automation_action"] == "keep_active_quiet", liveness
+    assert "material monitor transition" in liveness["next_trigger"], liveness
+    assert liveness["spend_policy"] == "no quota spend for unchanged monitor-only polls", liveness
+
+
+def assert_prompt_upgrade_repairs_identity_without_spend() -> None:
+    liveness = build_automation_liveness(
+        payload(effective_action="automation_prompt_upgrade_required")
+    )
+    assert_common_liveness_fields(liveness)
+    assert liveness["automation_action"] == "repair_automation_prompt_identity", liveness
+    assert "registered agent id" in liveness["reason"], liveness
+    assert liveness["spend_policy"] == "no quota spend for identity prompt upgrade preflight", liveness
+
+
+def assert_successor_replan_requires_bounded_work() -> None:
+    liveness = build_automation_liveness(
+        payload(effective_action=AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value)
+    )
+    assert_common_liveness_fields(liveness)
+    assert liveness["automation_action"] == "execute_bounded_work", liveness
+    assert "ready deferred successor" in liveness["reason"], liveness
+    assert liveness["next_trigger"] == "deferred successor replan writeback or fresh quota guard", liveness
+    assert liveness["spend_policy"] == "spend once only after validated successor replan/todo writeback", liveness
+
+
+def assert_monitor_blocked_successor_replan_uses_gate_repair_copy() -> None:
+    liveness = build_automation_liveness(
+        payload(
+            effective_action=AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value,
+            agent_scope_frontier={
+                "monitor_blocked_resume_candidates": [
+                    {"todo_id": "todo_monitor_gated_successor"}
+                ],
+            },
+        )
+    )
+    assert_common_liveness_fields(liveness)
+    assert liveness["automation_action"] == "execute_bounded_work", liveness
+    assert "open standing monitor" in liveness["reason"], liveness
+    assert liveness["next_trigger"] == "standing monitor gate repair writeback or fresh quota guard", liveness
+    assert liveness["spend_policy"] == "spend once only after validated gate repair/todo writeback", liveness
+
+
+def assert_agent_scope_no_candidate_is_quiet_no_spend() -> None:
+    liveness = build_automation_liveness(
+        payload(effective_action=AgentScopeFrontierAction.AGENT_SCOPE_WAIT.value)
+    )
+    assert_common_liveness_fields(liveness)
+    assert liveness["automation_action"] == "keep_active_quiet", liveness
+    assert "no in-scope runnable candidate" in liveness["reason"], liveness
+    assert liveness["spend_policy"] == "no quota spend for agent-scoped no-candidate checks", liveness
+
+
+def assert_must_attempt_or_autonomous_replan_executes_bounded_work() -> None:
+    must_attempt = build_automation_liveness(payload(must_attempt_work=True))
+    assert_common_liveness_fields(must_attempt)
+    assert must_attempt["automation_action"] == "execute_bounded_work", must_attempt
+    assert must_attempt["spend_policy"] == "spend once only after validation and durable writeback", must_attempt
+
+    autonomous = build_automation_liveness(
+        payload(recommended_mode="autonomous_replan_required")
+    )
+    assert_common_liveness_fields(autonomous)
+    assert autonomous["automation_action"] == "execute_bounded_work", autonomous
+    assert autonomous["spend_policy"] == "spend once only after validation and durable writeback", autonomous
+
+
+def assert_mapped_noop_and_default_keep_alive() -> None:
+    mapped = build_automation_liveness(payload(recommended_mode="mapped_noop_if_unchanged"))
+    assert_common_liveness_fields(mapped)
+    assert mapped["automation_action"] == "keep_active_noop_if_unchanged", mapped
+    assert mapped["spend_policy"] == "no quota spend for unchanged mapped no-op checks", mapped
+
+    default = build_automation_liveness(payload())
+    assert_common_liveness_fields(default)
+    assert default["automation_action"] == "keep_active", default
+    assert default["spend_policy"].startswith("follow heartbeat_recommendation"), default
+
+
+def main() -> int:
+    assert_monitor_quiet_skip_keeps_heartbeat_active()
+    assert_prompt_upgrade_repairs_identity_without_spend()
+    assert_successor_replan_requires_bounded_work()
+    assert_monitor_blocked_successor_replan_uses_gate_repair_copy()
+    assert_agent_scope_no_candidate_is_quiet_no_spend()
+    assert_must_attempt_or_autonomous_replan_executes_bounded_work()
+    assert_mapped_noop_and_default_keep_alive()
+    print("automation-liveness-state-machine-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/control_plane/scheduler/automation_liveness.py
+++ b/loopx/control_plane/scheduler/automation_liveness.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ..agents.agent_scope import AgentScopeFrontierAction, _agent_scope_frontier_action
+from ..goals.goal_frontier import AUTONOMOUS_REPLAN_REQUIRED_MODE
+
+
+AUTOMATION_LIVENESS_SCHEMA_VERSION = "automation_liveness_v0"
+
+
+def build_automation_liveness(payload: dict[str, Any]) -> dict[str, Any]:
+    heartbeat_recommendation = (
+        payload.get("heartbeat_recommendation")
+        if isinstance(payload.get("heartbeat_recommendation"), dict)
+        else {}
+    )
+    execution_obligation = (
+        payload.get("execution_obligation")
+        if isinstance(payload.get("execution_obligation"), dict)
+        else {}
+    )
+    effective_action = str(payload.get("effective_action") or "")
+    recommended_mode = str(heartbeat_recommendation.get("recommended_mode") or "")
+    must_attempt_work = bool(execution_obligation.get("must_attempt_work"))
+
+    base = {
+        "schema_version": AUTOMATION_LIVENESS_SCHEMA_VERSION,
+        "keep_active": True,
+        "pause_allowed": False,
+        "pause_policy": (
+            "pause/delete only after a bounded self-repair or replan path is itself "
+            "stuck for two more eligible turns"
+        ),
+    }
+    if (
+        effective_action == "monitor_quiet_skip"
+        or recommended_mode == "monitor_quiet_until_material_transition"
+    ):
+        return {
+            **base,
+            "automation_action": "keep_active_quiet",
+            "reason": (
+                "monitor-only quiet skip is a liveness-preserving no-op, not a "
+                "self-stop signal"
+            ),
+            "next_trigger": (
+                "material monitor transition, regression, concrete blocker, or "
+                f"{AUTONOMOUS_REPLAN_REQUIRED_MODE}"
+            ),
+            "spend_policy": "no quota spend for unchanged monitor-only polls",
+        }
+    if effective_action == "automation_prompt_upgrade_required":
+        return {
+            **base,
+            "automation_action": "repair_automation_prompt_identity",
+            "reason": (
+                "the installed automation is stale or unscoped; keep the automation "
+                "active but block delivery until it reruns with a registered agent id"
+            ),
+            "spend_policy": "no quota spend for identity prompt upgrade preflight",
+        }
+    if effective_action == AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value:
+        agent_scope_frontier = (
+            payload.get("agent_scope_frontier")
+            if isinstance(payload.get("agent_scope_frontier"), dict)
+            else {}
+        )
+        if agent_scope_frontier.get("monitor_blocked_resume_candidates"):
+            return {
+                **base,
+                "automation_action": "execute_bounded_work",
+                "reason": (
+                    "a current-agent advancement todo is gated by an open standing "
+                    "monitor; repair the gate model before another quiet no-op"
+                ),
+                "next_trigger": "standing monitor gate repair writeback or fresh quota guard",
+                "spend_policy": "spend once only after validated gate repair/todo writeback",
+            }
+        return {
+            **base,
+            "automation_action": "execute_bounded_work",
+            "reason": (
+                "a ready deferred successor is visible to this agent; run a bounded "
+                "successor replan or write a no-follow-up rationale before another quiet no-op"
+            ),
+            "next_trigger": "deferred successor replan writeback or fresh quota guard",
+            "spend_policy": "spend once only after validated successor replan/todo writeback",
+        }
+    if _agent_scope_frontier_action(effective_action) is not None:
+        return {
+            **base,
+            "automation_action": "keep_active_quiet",
+            "reason": (
+                "the current agent has no in-scope runnable candidate; this is a "
+                "liveness-preserving no-op until work is reassigned or projected"
+            ),
+            "next_trigger": (
+                "handoff owner progress, reassignment, or a current-agent/unclaimed "
+                "advancement todo"
+            ),
+            "spend_policy": "no quota spend for agent-scoped no-candidate checks",
+        }
+    if must_attempt_work or recommended_mode == AUTONOMOUS_REPLAN_REQUIRED_MODE:
+        return {
+            **base,
+            "automation_action": "execute_bounded_work",
+            "reason": (
+                "execution_obligation requires a bounded progress or replan segment "
+                "before another quiet no-op"
+            ),
+            "spend_policy": "spend once only after validation and durable writeback",
+        }
+    if recommended_mode == "mapped_noop_if_unchanged":
+        return {
+            **base,
+            "automation_action": "keep_active_noop_if_unchanged",
+            "reason": (
+                "unchanged mapped state should stay quiet and active until new evidence "
+                "or a concrete safe handoff appears"
+            ),
+            "spend_policy": "no quota spend for unchanged mapped no-op checks",
+        }
+    return {
+        **base,
+        "automation_action": "keep_active",
+        "reason": "heartbeat liveness should be preserved unless the repair path is stuck",
+        "spend_policy": (
+            "follow heartbeat_recommendation; spend only after validated delivery or "
+            "safe-bypass writeback"
+        ),
+    }

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -93,6 +93,7 @@ from .control_plane.scheduler.external_evidence_observation import (
 )
 from .control_plane.scheduler.monitor_poll_writeback import write_monitor_poll_todo_state
 from .control_plane.scheduler.monitor_target import build_quota_monitor_target
+from .control_plane.scheduler.automation_liveness import build_automation_liveness
 from .control_plane.scheduler.state import (
     CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
     CODEX_APP_SURFACE,
@@ -215,7 +216,6 @@ STALL_HEALTH_ITEM_COMPACT_FIELDS = (
     "recommended_action",
 )
 DECISION_FRESHNESS_WARNING_ITEM_LIMIT = 3
-AUTOMATION_LIVENESS_SCHEMA_VERSION = "automation_liveness_v0"
 TODO_BACKLOG_ITEM_LIMIT = 8
 TODO_DEFERRED_VISIBILITY_LIMIT = 8
 TODO_VISIBILITY_LANE_LIMIT = 16
@@ -1350,126 +1350,6 @@ def _compact_autonomous_candidate_context(
         compact["items"] = compact_items
         compact["open_count"] = len(compact_items)
     return compact or None
-
-
-def _automation_liveness(payload: dict[str, Any]) -> dict[str, Any]:
-    heartbeat_recommendation = (
-        payload.get("heartbeat_recommendation")
-        if isinstance(payload.get("heartbeat_recommendation"), dict)
-        else {}
-    )
-    execution_obligation = (
-        payload.get("execution_obligation")
-        if isinstance(payload.get("execution_obligation"), dict)
-        else {}
-    )
-    effective_action = str(payload.get("effective_action") or "")
-    recommended_mode = str(heartbeat_recommendation.get("recommended_mode") or "")
-    must_attempt_work = bool(execution_obligation.get("must_attempt_work"))
-
-    base = {
-        "schema_version": AUTOMATION_LIVENESS_SCHEMA_VERSION,
-        "keep_active": True,
-        "pause_allowed": False,
-        "pause_policy": (
-            "pause/delete only after a bounded self-repair or replan path is itself "
-            "stuck for two more eligible turns"
-        ),
-    }
-    if effective_action == "monitor_quiet_skip" or recommended_mode == "monitor_quiet_until_material_transition":
-        return {
-            **base,
-            "automation_action": "keep_active_quiet",
-            "reason": (
-                "monitor-only quiet skip is a liveness-preserving no-op, not a "
-                "self-stop signal"
-            ),
-            "next_trigger": (
-                "material monitor transition, regression, concrete blocker, or "
-                f"{AUTONOMOUS_REPLAN_REQUIRED_MODE}"
-            ),
-            "spend_policy": "no quota spend for unchanged monitor-only polls",
-        }
-    if effective_action == "automation_prompt_upgrade_required":
-        return {
-            **base,
-            "automation_action": "repair_automation_prompt_identity",
-            "reason": (
-                "the installed automation is stale or unscoped; keep the automation "
-                "active but block delivery until it reruns with a registered agent id"
-            ),
-            "spend_policy": "no quota spend for identity prompt upgrade preflight",
-        }
-    if effective_action == AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value:
-        agent_scope_frontier = (
-            payload.get("agent_scope_frontier")
-            if isinstance(payload.get("agent_scope_frontier"), dict)
-            else {}
-        )
-        if agent_scope_frontier.get("monitor_blocked_resume_candidates"):
-            return {
-                **base,
-                "automation_action": "execute_bounded_work",
-                "reason": (
-                    "a current-agent advancement todo is gated by an open standing "
-                    "monitor; repair the gate model before another quiet no-op"
-                ),
-                "next_trigger": "standing monitor gate repair writeback or fresh quota guard",
-                "spend_policy": "spend once only after validated gate repair/todo writeback",
-            }
-        return {
-            **base,
-            "automation_action": "execute_bounded_work",
-            "reason": (
-                "a ready deferred successor is visible to this agent; run a bounded "
-                "successor replan or write a no-follow-up rationale before another quiet no-op"
-            ),
-            "next_trigger": "deferred successor replan writeback or fresh quota guard",
-            "spend_policy": "spend once only after validated successor replan/todo writeback",
-        }
-    if _agent_scope_frontier_action(effective_action) is not None:
-        return {
-            **base,
-            "automation_action": "keep_active_quiet",
-            "reason": (
-                "the current agent has no in-scope runnable candidate; this is a "
-                "liveness-preserving no-op until work is reassigned or projected"
-            ),
-            "next_trigger": (
-                "handoff owner progress, reassignment, or a current-agent/unclaimed "
-                "advancement todo"
-            ),
-            "spend_policy": "no quota spend for agent-scoped no-candidate checks",
-        }
-    if must_attempt_work or recommended_mode == AUTONOMOUS_REPLAN_REQUIRED_MODE:
-        return {
-            **base,
-            "automation_action": "execute_bounded_work",
-            "reason": (
-                "execution_obligation requires a bounded progress or replan segment "
-                "before another quiet no-op"
-            ),
-            "spend_policy": "spend once only after validation and durable writeback",
-        }
-    if recommended_mode == "mapped_noop_if_unchanged":
-        return {
-            **base,
-            "automation_action": "keep_active_noop_if_unchanged",
-            "reason": (
-                "unchanged mapped state should stay quiet and active until new evidence "
-                "or a concrete safe handoff appears"
-            ),
-            "spend_policy": "no quota spend for unchanged mapped no-op checks",
-        }
-    return {
-        **base,
-        "automation_action": "keep_active",
-        "reason": "heartbeat liveness should be preserved unless the repair path is stuck",
-        "spend_policy": (
-            "follow heartbeat_recommendation; spend only after validated delivery or "
-            "safe-bypass writeback"
-        ),
-    }
 
 
 def _scheduler_hint(
@@ -3319,7 +3199,7 @@ def build_quota_should_run(
             payload["next_handoff_condition"] = item.get("next_handoff_condition")
         if should_run and item.get("agent_command"):
             payload["agent_command"] = item.get("agent_command")
-        payload["automation_liveness"] = _automation_liveness(payload)
+        payload["automation_liveness"] = build_automation_liveness(payload)
         payload["interaction_contract"] = build_interaction_contract(payload)
         payload["scheduler_hint"] = _scheduler_hint(
             payload,


### PR DESCRIPTION
## Summary
- move heartbeat automation-liveness decision policy out of quota into the scheduler bounded context
- keep quota as the should-run integration caller
- add a direct automation-liveness state-machine smoke covering monitor quiet skip, prompt identity repair, successor replan, monitor-gated replan, agent-scope no-candidate, autonomous/must-attempt execution, mapped no-op, and default keep-alive behavior

## Validation
- python3 -m py_compile loopx/quota.py loopx/control_plane/scheduler/automation_liveness.py examples/control_plane/automation-liveness-state-machine-smoke.py
- python3 examples/control_plane/automation-liveness-state-machine-smoke.py
- python3 examples/control_plane/quota-scheduler-policy-smoke.py
- python3 examples/control_plane/interaction-contract-state-machine-smoke.py
- python3 examples/control_plane/heartbeat-quota-flow-smoke.py
- python3 examples/control_plane/control-plane-integrated-canary-smoke.py
- python3 examples/control_plane/work-lane-contract-smoke.py
- python3 examples/control_plane/bounded-context-namespace-smoke.py
- python3 examples/control_plane/quota-plan-smoke.py
- python3 examples/control_plane/quota-scheduler-state-ack-smoke.py
- python3 examples/control_plane/quota-scheduler-hint-compaction-smoke.py
- python3 examples/control_plane/repo-python-line-budget-smoke.py
- loopx check --scan-path loopx/control_plane/scheduler/automation_liveness.py --scan-path loopx/quota.py --scan-path examples/control_plane/automation-liveness-state-machine-smoke.py
- loopx canary premerge --from-git-diff --tier standard --timeout-seconds 180

## Notes
- premerge gate passed with self_merge_allowed=true
- loopx check still reports the existing duplicate-index warning for loopx-meta; this PR does not touch run-history/index state