### PR TITLE
Extract quota todo summary read model

### DIFF
--- a/examples/control_plane/quota-todo-summary-readmodel-smoke.py
+++ b/examples/control_plane/quota-todo-summary-readmodel-smoke.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Smoke-test the quota-facing todo summary read model."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.todos.quota_summary import (  # noqa: E402
+    is_user_gate_todo_item,
+    select_quota_todo_summary,
+    summarize_project_asset_todos_for_quota,
+    summarize_user_todos_for_quota,
+)
+
+
+AGENT_IDENTITY = {"agent_id": "codex-product-capability"}
+
+
+def canonical_todo_summary() -> dict:
+    return {
+        "schema_version": "todo_summary_v0",
+        "source_section": "agent todo",
+        "total_count": 6,
+        "open_count": 5,
+        "done_count": 1,
+        "monitor_writeback": {"supported": True, "source": "active_state"},
+        "items": [
+            {
+                "index": 1,
+                "todo_id": "todo_gate_current",
+                "text": "Owner approval before product capability write",
+                "task_class": "user_gate",
+                "action_kind": "approval",
+                "blocks_agent": "codex-product-capability",
+            },
+            {
+                "index": 2,
+                "todo_id": "todo_gate_other",
+                "text": "Owner approval before main-control write",
+                "task_class": "user_gate",
+                "action_kind": "approval",
+                "blocks_agent": "codex-main-control",
+            },
+            {
+                "index": 3,
+                "todo_id": "todo_monitor_due",
+                "text": "Monitor scheduler transition",
+                "task_class": "continuous_monitor",
+                "claimed_by": "codex-product-capability",
+                "next_due_at": "2000-01-01T00:00:00+00:00",
+                "target_key": "scheduler_transition",
+            },
+            {
+                "index": 4,
+                "todo_id": "todo_monitor_gap",
+                "text": "Monitor missing schedule metadata",
+                "task_class": "continuous_monitor",
+                "claimed_by": "codex-product-capability",
+                "target_key": "schedule_gap",
+            },
+            {
+                "index": 5,
+                "todo_id": "todo_refactor_next",
+                "text": "[P1] Continue quota/todo state-machine refactor",
+                "task_class": "advancement_task",
+                "claimed_by": "codex-product-capability",
+            },
+        ],
+        "active_next_action_items": [
+            {
+                "index": 5,
+                "todo_id": "todo_refactor_next",
+                "text": "[P1] Continue quota/todo state-machine refactor",
+                "task_class": "advancement_task",
+                "claimed_by": "codex-product-capability",
+            },
+            {
+                "index": 6,
+                "todo_id": "todo_other_agent_next",
+                "text": "[P1] Other agent active-next item",
+                "task_class": "advancement_task",
+                "claimed_by": "codex-main-control",
+            },
+        ],
+        "todo_succession_warning": {
+            "schema_version": "todo_succession_warning_v0",
+            "reason_code": "completed_advancement_without_successor",
+            "count": 1,
+            "items": [
+                {
+                    "index": 7,
+                    "todo_id": "todo_done_without_successor",
+                    "text": "[P1] Finished state-machine canary without successor",
+                    "status": "done",
+                    "done": True,
+                    "task_class": "advancement_task",
+                    "action_kind": "state_machine_canary_refactor",
+                    "claimed_by": "codex-product-capability",
+                }
+            ],
+        },
+    }
+
+
+def assert_agent_scoped_user_gate_and_monitor_state() -> None:
+    summary = summarize_user_todos_for_quota(
+        canonical_todo_summary(),
+        agent_identity=AGENT_IDENTITY,
+        filter_user_gate_blocks_agent=True,
+    )
+    assert summary is not None
+    assert summary["open_count"] == 4, summary
+    assert summary["all_open_count"] == 5, summary
+    assert summary["other_agent_scoped_open_count"] == 2, summary
+    assert summary["gate_open_items"][0]["todo_id"] == "todo_gate_current", summary
+    assert {
+        item.get("todo_id")
+        for item in summary["other_agent_scoped_items"]
+    } == {"todo_gate_other", "todo_other_agent_next"}, summary
+
+    assert summary["monitor_due_count"] == 1, summary
+    assert summary["monitor_due_items"][0]["todo_id"] == "todo_monitor_due", summary
+    assert summary["monitor_schedule_gap_count"] == 1, summary
+    assert summary["monitor_schedule_gap_items"][0]["todo_id"] == "todo_monitor_gap", summary
+    assert summary["active_next_action_items"][0]["todo_id"] == "todo_refactor_next", summary
+    assert all(
+        item.get("todo_id") != "todo_other_agent_next"
+        for item in summary["active_next_action_items"]
+    ), summary
+    assert summary["todo_succession_warning"]["count"] == 1, summary
+
+
+def assert_project_asset_fallback_and_canonical_precedence() -> None:
+    raw_canonical = {
+        "source_section": "raw legacy queue",
+        "items": [
+            {
+                "index": 1,
+                "text": "raw fallback should not outrank project asset",
+            }
+        ],
+    }
+    project_asset = {
+        "next": "[P1] Project asset selected todo",
+        "next_index": 9,
+        "next_claimed_by": "codex-product-capability",
+    }
+    selected = select_quota_todo_summary(
+        raw_canonical,
+        project_asset,
+        agent_identity=AGENT_IDENTITY,
+    )
+    assert selected is not None
+    assert selected["source_section"] == "project_asset", selected
+    assert selected["first_open_items"][0]["index"] == 9, selected
+    assert "Project asset selected todo" in selected["first_open_items"][0]["text"], selected
+
+    canonical = canonical_todo_summary()
+    selected = select_quota_todo_summary(
+        canonical,
+        {"next": "[P1] Project asset should lose"},
+        agent_identity=AGENT_IDENTITY,
+    )
+    assert selected is not None
+    assert selected["source_section"] == "agent todo", selected
+    assert any(
+        item.get("todo_id") == "todo_gate_current"
+        for item in selected["gate_open_items"]
+    ), selected
+    assert selected["first_executable_items"][0]["todo_id"] == "todo_refactor_next", selected
+
+
+def assert_project_asset_summary_reuses_canonical_shape() -> None:
+    canonical_shape = canonical_todo_summary()
+    summary = summarize_project_asset_todos_for_quota(
+        canonical_shape,
+        agent_identity=AGENT_IDENTITY,
+        filter_user_gate_blocks_agent=True,
+    )
+    assert summary is not None
+    assert summary["source_section"] == "agent todo", summary
+    assert summary["monitor_due_count"] == 1, summary
+    assert summary["other_agent_scoped_open_count"] == 2, summary
+
+
+def assert_user_gate_hint_detection_is_preserved() -> None:
+    assert is_user_gate_todo_item(
+        {
+            "text": "Credential decision",
+            "task_class": "advancement_task",
+            "action_kind": "credential_rotation",
+        }
+    )
+    assert is_user_gate_todo_item(
+        {
+            "text": "Public claim decision",
+            "task_class": "advancement_task",
+            "action_kind": "public_claim_review",
+        }
+    )
+
+
+def main() -> None:
+    assert_agent_scoped_user_gate_and_monitor_state()
+    assert_project_asset_fallback_and_canonical_precedence()
+    assert_project_asset_summary_reuses_canonical_shape()
+    assert_user_gate_hint_detection_is_preserved()
+    print("quota todo summary read model smoke passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/control_plane/todos/quota_summary.py
+++ b/loopx/control_plane/todos/quota_summary.py
@@ -1,0 +1,432 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ..agents.agent_scope import (
+    _agent_scope_filter_user_gate_items,
+    _agent_scope_selectable_todo_item,
+)
+from .claim_visibility import (
+    build_agent_claim_scoped_open_items,
+    build_todo_claim_visibility_lanes,
+)
+from .contract import (
+    TODO_TASK_CLASS_ADVANCEMENT,
+    TODO_TASK_CLASS_MONITOR,
+    TODO_TASK_CLASS_USER_GATE,
+)
+from .deferred_resume import (
+    build_todo_deferred_visibility_lanes,
+    build_todo_resume_blocked_visibility_lanes,
+)
+from .handoff_gate import build_todo_handoff_gate_lanes
+from .projection import (
+    todo_item_is_actionable_open,
+    todo_item_is_due_monitor,
+    todo_item_task_class,
+    todo_projection_sort_key,
+    todo_summary_monitor_schedule_gap_items,
+    todo_summary_monitor_writeback_contract,
+    todo_summary_monitor_writeback_supported,
+)
+from .route_continuation import build_todo_route_continuation_lanes
+from .succession_warning import build_todo_succession_warning_lanes
+from .summary_item import compact_todo_summary_item, todo_summary_source_items
+
+
+MONITOR_DUE_ITEM_LIMIT = 1
+TODO_BACKLOG_ITEM_LIMIT = 8
+TODO_DEFERRED_VISIBILITY_LIMIT = 8
+TODO_VISIBILITY_LANE_LIMIT = 16
+
+USER_GATE_ACTION_KIND_HINTS = (
+    "approval",
+    "approve",
+    "boundary",
+    "gate",
+    "blocker",
+    "credential",
+    "private",
+    "production",
+    "leaderboard",
+    "submission",
+    "public_claim",
+)
+
+
+def is_user_gate_todo_item(item: dict[str, Any]) -> bool:
+    if todo_item_task_class(item) == TODO_TASK_CLASS_USER_GATE:
+        return True
+    action_kind = str(item.get("action_kind") or "").strip().lower()
+    if not action_kind:
+        return False
+    return any(hint in action_kind for hint in USER_GATE_ACTION_KIND_HINTS)
+
+
+def summarize_user_todos_for_quota(
+    value: Any,
+    *,
+    agent_identity: dict[str, Any] | None = None,
+    filter_user_gate_blocks_agent: bool = False,
+) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    all_open_items = sorted(
+        todo_summary_source_items(value),
+        key=todo_projection_sort_key,
+    )
+    blocking_open_items = all_open_items
+    other_agent_scoped_items: list[dict[str, Any]] = []
+    agent_scope_filter: dict[str, Any] | None = None
+    if filter_user_gate_blocks_agent:
+        (
+            blocking_open_items,
+            other_agent_scoped_items,
+            agent_scope_filter,
+        ) = _agent_scope_filter_user_gate_items(
+            all_open_items,
+            agent_identity=agent_identity,
+        )
+    open_items, claim_scope = build_agent_claim_scoped_open_items(
+        blocking_open_items,
+        agent_identity=agent_identity,
+        diagnostic_item_limit=3,
+    )
+    executable_items = [
+        item
+        for item in open_items
+        if todo_item_is_actionable_open(item)
+        if todo_item_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
+    ]
+    monitor_items = [
+        item
+        for item in open_items
+        if todo_item_is_actionable_open(item)
+        if todo_item_task_class(item) == TODO_TASK_CLASS_MONITOR
+    ]
+    monitor_writeback_supported = todo_summary_monitor_writeback_supported(value)
+    monitor_due_items = (
+        [
+            item
+            for item in monitor_items
+            if todo_item_is_due_monitor(item)
+            if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
+        ]
+        if monitor_writeback_supported
+        else []
+    )
+    monitor_schedule_gap_items = todo_summary_monitor_schedule_gap_items(
+        {
+            "monitor_open_items": monitor_items,
+            "monitor_writeback": value.get("monitor_writeback"),
+        }
+    )
+    claimed_open_items = [item for item in blocking_open_items if item.get("claimed_by")]
+    gate_items = [
+        item
+        for item in open_items
+        if is_user_gate_todo_item(item)
+    ]
+    active_next_action_items = (
+        [
+            compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
+            for item in (value.get("active_next_action_items") or [])
+            if isinstance(item, dict)
+            if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
+        ]
+        if isinstance(value.get("active_next_action_items"), list)
+        else []
+    )
+    active_next_action_executable_items = (
+        [
+            compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
+            for item in (value.get("active_next_action_executable_items") or [])
+            if isinstance(item, dict)
+            if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
+        ]
+        if isinstance(value.get("active_next_action_executable_items"), list)
+        else []
+    )
+    open_count = value.get("open_count", len(all_open_items))
+    if claim_scope is not None:
+        open_count = len(open_items)
+    if agent_scope_filter is not None:
+        open_count = len(blocking_open_items)
+    summary = {
+        "schema_version": value.get("schema_version"),
+        "source_section": value.get("source_section"),
+        "total_count": value.get("total_count"),
+        "open_count": open_count,
+        "done_count": value.get("done_count"),
+        "first_open_items": open_items[:3],
+        "first_executable_items": executable_items[:3],
+        "gate_open_items": gate_items[:3],
+        "monitor_open_items": monitor_items,
+        "monitor_due_count": len(monitor_due_items),
+        "monitor_due_items": monitor_due_items[:MONITOR_DUE_ITEM_LIMIT],
+        "monitor_schedule_gap_count": len(monitor_schedule_gap_items),
+        "monitor_schedule_gap_items": monitor_schedule_gap_items[:MONITOR_DUE_ITEM_LIMIT],
+        "active_next_action_items": active_next_action_items,
+        "active_next_action_executable_items": active_next_action_executable_items,
+        "backlog_items": open_items[:TODO_BACKLOG_ITEM_LIMIT],
+        "executable_backlog_items": executable_items[:TODO_BACKLOG_ITEM_LIMIT],
+    }
+    monitor_writeback = todo_summary_monitor_writeback_contract(value)
+    if monitor_writeback:
+        summary["monitor_writeback"] = monitor_writeback
+    summary.update(
+        build_todo_claim_visibility_lanes(
+            blocking_open_items,
+            agent_identity=agent_identity,
+            backlog_item_limit=TODO_BACKLOG_ITEM_LIMIT,
+            visibility_lane_limit=TODO_VISIBILITY_LANE_LIMIT,
+        )
+    )
+    summary.update(
+        build_todo_deferred_visibility_lanes(
+            value,
+            agent_identity=agent_identity,
+            item_limit=TODO_DEFERRED_VISIBILITY_LIMIT,
+        )
+    )
+    summary.update(
+        build_todo_resume_blocked_visibility_lanes(
+            value,
+            agent_identity=agent_identity,
+            item_limit=TODO_DEFERRED_VISIBILITY_LIMIT,
+        )
+    )
+    summary.update(
+        build_todo_handoff_gate_lanes(
+            value,
+            agent_identity=agent_identity,
+            item_limit=TODO_BACKLOG_ITEM_LIMIT,
+        )
+    )
+    summary.update(
+        build_todo_route_continuation_lanes(
+            value,
+            agent_identity=agent_identity,
+            item_limit=TODO_BACKLOG_ITEM_LIMIT,
+        )
+    )
+    summary.update(
+        build_todo_succession_warning_lanes(
+            value,
+            item_limit=TODO_BACKLOG_ITEM_LIMIT,
+        )
+    )
+    if claimed_open_items or value.get("claimed_open_count"):
+        summary["claimed_open_count"] = value.get("claimed_open_count", len(claimed_open_items))
+        summary["unclaimed_open_count"] = value.get(
+            "unclaimed_open_count",
+            max(0, int(open_count or 0) - len(claimed_open_items)),
+        )
+    if claim_scope:
+        summary["claim_scope"] = claim_scope
+    if agent_scope_filter:
+        summary["agent_scope_filter"] = agent_scope_filter
+        summary["all_open_count"] = value.get("open_count", len(all_open_items))
+        summary["other_agent_scoped_open_count"] = len(other_agent_scoped_items)
+        summary["other_agent_scoped_items"] = [
+            compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
+            for item in other_agent_scoped_items[:TODO_VISIBILITY_LANE_LIMIT]
+        ]
+    return summary
+
+
+def summarize_project_asset_todos_for_quota(
+    value: Any,
+    *,
+    agent_identity: dict[str, Any] | None = None,
+    filter_user_gate_blocks_agent: bool = False,
+) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+    if (
+        isinstance(value.get("items"), list)
+        or isinstance(value.get("first_open_items"), list)
+    ) and (
+        "total_count" in value or "open_count" in value or "done_count" in value
+    ):
+        return summarize_user_todos_for_quota(
+            value,
+            agent_identity=agent_identity,
+            filter_user_gate_blocks_agent=filter_user_gate_blocks_agent,
+        )
+
+    all_open_items = sorted(
+        todo_summary_source_items(value),
+        key=todo_projection_sort_key,
+    )
+    if not all_open_items:
+        next_text = str(value.get("next") or "").strip()
+        next_index = value.get("next_index", 1)
+        all_open_items = [{"index": next_index, "text": next_text}] if next_text else []
+        next_claimed_by = str(value.get("next_claimed_by") or "").strip()
+        if all_open_items and next_claimed_by:
+            all_open_items[0]["claimed_by"] = next_claimed_by
+    blocking_open_items = all_open_items
+    other_agent_scoped_items: list[dict[str, Any]] = []
+    agent_scope_filter: dict[str, Any] | None = None
+    if filter_user_gate_blocks_agent:
+        (
+            blocking_open_items,
+            other_agent_scoped_items,
+            agent_scope_filter,
+        ) = _agent_scope_filter_user_gate_items(
+            all_open_items,
+            agent_identity=agent_identity,
+        )
+    open_items, claim_scope = build_agent_claim_scoped_open_items(
+        blocking_open_items,
+        agent_identity=agent_identity,
+        diagnostic_item_limit=3,
+    )
+    executable_items = [
+        item
+        for item in open_items
+        if todo_item_is_actionable_open(item)
+        if todo_item_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
+    ]
+    monitor_items = [
+        item
+        for item in open_items
+        if todo_item_is_actionable_open(item)
+        if todo_item_task_class(item) == TODO_TASK_CLASS_MONITOR
+    ]
+    monitor_writeback_supported = todo_summary_monitor_writeback_supported(value)
+    monitor_due_items = (
+        [
+            item
+            for item in monitor_items
+            if todo_item_is_due_monitor(item)
+            if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
+        ]
+        if monitor_writeback_supported
+        else []
+    )
+    active_next_action_items = (
+        [
+            compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
+            for item in (value.get("active_next_action_items") or [])
+            if isinstance(item, dict)
+            if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
+        ]
+        if isinstance(value.get("active_next_action_items"), list)
+        else []
+    )
+    active_next_action_executable_items = (
+        [
+            compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
+            for item in (value.get("active_next_action_executable_items") or [])
+            if isinstance(item, dict)
+            if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
+        ]
+        if isinstance(value.get("active_next_action_executable_items"), list)
+        else []
+    )
+    claimed_open_items = [item for item in blocking_open_items if item.get("claimed_by")]
+    open_count = value.get("open", value.get("open_count", len(all_open_items)))
+    if claim_scope is not None:
+        open_count = len(open_items)
+    if agent_scope_filter is not None:
+        open_count = len(blocking_open_items)
+    summary = {
+        "schema_version": value.get("schema_version"),
+        "source_section": value.get("source_section") or "project_asset",
+        "total_count": value.get("total", value.get("total_count")),
+        "open_count": open_count,
+        "done_count": value.get("done", value.get("done_count")),
+        "first_open_items": open_items[:3],
+        "first_executable_items": executable_items[:3],
+        "monitor_open_items": monitor_items,
+        "monitor_due_count": len(monitor_due_items),
+        "monitor_due_items": monitor_due_items[:MONITOR_DUE_ITEM_LIMIT],
+        "active_next_action_items": active_next_action_items,
+        "active_next_action_executable_items": active_next_action_executable_items,
+        "backlog_items": open_items[:TODO_BACKLOG_ITEM_LIMIT],
+        "executable_backlog_items": executable_items[:TODO_BACKLOG_ITEM_LIMIT],
+    }
+    monitor_writeback = todo_summary_monitor_writeback_contract(value)
+    if monitor_writeback:
+        summary["monitor_writeback"] = monitor_writeback
+    summary.update(
+        build_todo_claim_visibility_lanes(
+            blocking_open_items,
+            agent_identity=agent_identity,
+            backlog_item_limit=TODO_BACKLOG_ITEM_LIMIT,
+            visibility_lane_limit=TODO_VISIBILITY_LANE_LIMIT,
+        )
+    )
+    summary.update(
+        build_todo_deferred_visibility_lanes(
+            value,
+            agent_identity=agent_identity,
+            item_limit=TODO_DEFERRED_VISIBILITY_LIMIT,
+        )
+    )
+    summary.update(
+        build_todo_handoff_gate_lanes(
+            value,
+            agent_identity=agent_identity,
+            item_limit=TODO_BACKLOG_ITEM_LIMIT,
+        )
+    )
+    summary.update(
+        build_todo_route_continuation_lanes(
+            value,
+            agent_identity=agent_identity,
+            item_limit=TODO_BACKLOG_ITEM_LIMIT,
+        )
+    )
+    if claimed_open_items or value.get("claimed_open_count"):
+        summary["claimed_open_count"] = value.get("claimed_open_count", len(claimed_open_items))
+        summary["unclaimed_open_count"] = value.get(
+            "unclaimed_open_count",
+            max(0, int(open_count or 0) - len(claimed_open_items)),
+        )
+    if claim_scope:
+        summary["claim_scope"] = claim_scope
+    if agent_scope_filter:
+        summary["agent_scope_filter"] = agent_scope_filter
+        summary["all_open_count"] = value.get("open", value.get("open_count", len(all_open_items)))
+        summary["other_agent_scoped_open_count"] = len(other_agent_scoped_items)
+        summary["other_agent_scoped_items"] = [
+            compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
+            for item in other_agent_scoped_items[:TODO_VISIBILITY_LANE_LIMIT]
+        ]
+    return summary
+
+
+def is_canonical_attention_todo_summary(value: Any) -> bool:
+    if not isinstance(value, dict):
+        return False
+    if value.get("schema_version") == "todo_summary_v0":
+        return True
+    source_section = str(value.get("source_section") or "").strip().lower()
+    if source_section.startswith("raw "):
+        return False
+    return source_section in {"agent todo", "user todo"}
+
+
+def select_quota_todo_summary(
+    canonical_value: Any,
+    project_asset_value: Any,
+    *,
+    agent_identity: dict[str, Any] | None = None,
+    filter_user_gate_blocks_agent: bool = False,
+) -> dict[str, Any] | None:
+    canonical_summary = summarize_user_todos_for_quota(
+        canonical_value,
+        agent_identity=agent_identity,
+        filter_user_gate_blocks_agent=filter_user_gate_blocks_agent,
+    )
+    project_asset_summary = summarize_project_asset_todos_for_quota(
+        project_asset_value,
+        agent_identity=agent_identity,
+        filter_user_gate_blocks_agent=filter_user_gate_blocks_agent,
+    )
+    if is_canonical_attention_todo_summary(canonical_value):
+        return canonical_summary or project_asset_summary
+    return project_asset_summary or canonical_summary

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -12,10 +12,8 @@ from .control_plane.agents.agent_scope import (
     AgentScopeFrontierAction,
     _action_scope_tokens_from_text,
     _agent_lane_frontier_hint,
-    _agent_scope_filter_user_gate_items,
     _agent_scope_frontier_action,
     _agent_scope_no_candidate_frontier,
-    _agent_scope_selectable_todo_item,
     _agent_scoped_user_gate_override,
     _scoped_user_gate_fallback,
 )
@@ -106,29 +104,14 @@ from .control_plane.todos.contract import (
     TODO_STATUS_OPEN,
     TODO_TASK_CLASS_ADVANCEMENT,
     TODO_TASK_CLASS_BLOCKER,
-    TODO_TASK_CLASS_MONITOR,
-    TODO_TASK_CLASS_USER_GATE,
-    normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
     normalize_todo_id,
     normalize_required_write_scopes,
     normalize_todo_status,
     normalize_todo_task_class,
 )
-from .control_plane.todos.claim_visibility import (
-    build_agent_claim_scoped_open_items,
-    build_todo_claim_visibility_lanes,
-)
-from .control_plane.todos.deferred_resume import (
-    build_todo_deferred_visibility_lanes,
-    build_todo_resume_blocked_visibility_lanes,
-)
-from .control_plane.todos.handoff_gate import build_todo_handoff_gate_lanes
-from .control_plane.todos.route_continuation import build_todo_route_continuation_lanes
-from .control_plane.todos.succession_warning import build_todo_succession_warning_lanes
 from .control_plane.todos.summary_item import (
     compact_todo_summary_item,
-    todo_summary_source_items,
 )
 from .control_plane.todos.projection import (
     todo_index_rank as projection_todo_index_rank,
@@ -143,9 +126,11 @@ from .control_plane.todos.projection import (
     todo_priority_rank as projection_todo_priority_rank,
     todo_projection_sort_key as projection_todo_projection_sort_key,
     todo_summary_claim_scope_agent_id as projection_todo_summary_claim_scope_agent_id,
-    todo_summary_monitor_schedule_gap_items as projection_todo_summary_monitor_schedule_gap_items,
-    todo_summary_monitor_writeback_contract as projection_todo_summary_monitor_writeback_contract,
-    todo_summary_monitor_writeback_supported as projection_todo_summary_monitor_writeback_supported,
+)
+from .control_plane.todos.quota_summary import (
+    is_user_gate_todo_item,
+    select_quota_todo_summary,
+    summarize_user_todos_for_quota,
 )
 
 
@@ -173,19 +158,6 @@ AUTONOMOUS_REPLAN_ACK_NEUTRAL_CLASSIFICATIONS = {
 }
 DEFAULT_SLOT_SPEND_SOURCE = "heartbeat"
 VALID_SLOT_SPEND_SOURCES = {"heartbeat", "controller", "adapter"}
-USER_GATE_ACTION_KIND_HINTS = (
-    "approval",
-    "approve",
-    "boundary",
-    "gate",
-    "blocker",
-    "credential",
-    "private",
-    "production",
-    "leaderboard",
-    "submission",
-    "public_claim",
-)
 FOCUS_WAIT_LIFECYCLE_MARKERS = {
     "continuation_boundary",
     "focus_wait",
@@ -216,9 +188,6 @@ STALL_HEALTH_ITEM_COMPACT_FIELDS = (
     "recommended_action",
 )
 DECISION_FRESHNESS_WARNING_ITEM_LIMIT = 3
-TODO_BACKLOG_ITEM_LIMIT = 8
-TODO_DEFERRED_VISIBILITY_LIMIT = 8
-TODO_VISIBILITY_LANE_LIMIT = 16
 MONITOR_DUE_ITEM_LIMIT = 1
 
 def _now_local() -> str:
@@ -619,376 +588,6 @@ def _todo_index_rank(item: dict[str, Any]) -> int:
 
 def _todo_projection_sort_key(item: dict[str, Any]) -> tuple[int, int]:
     return projection_todo_projection_sort_key(item)
-
-
-def _todo_summary_monitor_writeback_contract(value: dict[str, Any] | None) -> dict[str, Any] | None:
-    return projection_todo_summary_monitor_writeback_contract(value)
-
-
-def _todo_summary_monitor_writeback_supported(value: dict[str, Any] | None) -> bool:
-    return projection_todo_summary_monitor_writeback_supported(value)
-
-
-def _is_user_gate_todo_item(item: dict[str, Any]) -> bool:
-    if _todo_task_class(item) == TODO_TASK_CLASS_USER_GATE:
-        return True
-    action_kind = str(item.get("action_kind") or "").strip().lower()
-    if not action_kind:
-        return False
-    return any(hint in action_kind for hint in USER_GATE_ACTION_KIND_HINTS)
-
-
-def _summarize_user_todos(
-    value: Any,
-    *,
-    agent_identity: dict[str, Any] | None = None,
-    filter_user_gate_blocks_agent: bool = False,
-) -> dict[str, Any] | None:
-    if not isinstance(value, dict):
-        return None
-    all_open_items = sorted(
-        todo_summary_source_items(value),
-        key=_todo_projection_sort_key,
-    )
-    blocking_open_items = all_open_items
-    other_agent_scoped_items: list[dict[str, Any]] = []
-    agent_scope_filter: dict[str, Any] | None = None
-    if filter_user_gate_blocks_agent:
-        (
-            blocking_open_items,
-            other_agent_scoped_items,
-            agent_scope_filter,
-        ) = _agent_scope_filter_user_gate_items(
-            all_open_items,
-            agent_identity=agent_identity,
-        )
-    open_items, claim_scope = build_agent_claim_scoped_open_items(
-        blocking_open_items,
-        agent_identity=agent_identity,
-        diagnostic_item_limit=3,
-    )
-    executable_items = [
-        item
-        for item in open_items
-        if _todo_item_is_actionable_open(item)
-        if _todo_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
-    ]
-    monitor_items = [
-        item
-        for item in open_items
-        if _todo_item_is_actionable_open(item)
-        if _todo_task_class(item) == TODO_TASK_CLASS_MONITOR
-    ]
-    monitor_writeback_supported = _todo_summary_monitor_writeback_supported(value)
-    monitor_due_items = (
-        [
-            item
-            for item in monitor_items
-            if _todo_item_is_due_monitor(item)
-            if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
-        ]
-        if monitor_writeback_supported
-        else []
-    )
-    monitor_schedule_gap_items = projection_todo_summary_monitor_schedule_gap_items(
-        {
-            "monitor_open_items": monitor_items,
-            "monitor_writeback": value.get("monitor_writeback"),
-        }
-    )
-    claimed_open_items = [item for item in blocking_open_items if item.get("claimed_by")]
-    gate_items = [
-        item
-        for item in open_items
-        if _is_user_gate_todo_item(item)
-    ]
-    active_next_action_items = [
-        compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
-        for item in (value.get("active_next_action_items") or [])
-        if isinstance(item, dict)
-        if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
-    ] if isinstance(value.get("active_next_action_items"), list) else []
-    active_next_action_executable_items = [
-        compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
-        for item in (value.get("active_next_action_executable_items") or [])
-        if isinstance(item, dict)
-        if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
-    ] if isinstance(value.get("active_next_action_executable_items"), list) else []
-    open_count = value.get("open_count", len(all_open_items))
-    if claim_scope is not None:
-        open_count = len(open_items)
-    if agent_scope_filter is not None:
-        open_count = len(blocking_open_items)
-    summary = {
-        "schema_version": value.get("schema_version"),
-        "source_section": value.get("source_section"),
-        "total_count": value.get("total_count"),
-        "open_count": open_count,
-        "done_count": value.get("done_count"),
-        "first_open_items": open_items[:3],
-        "first_executable_items": executable_items[:3],
-        "gate_open_items": gate_items[:3],
-        "monitor_open_items": monitor_items,
-        "monitor_due_count": len(monitor_due_items),
-        "monitor_due_items": monitor_due_items[:MONITOR_DUE_ITEM_LIMIT],
-        "monitor_schedule_gap_count": len(monitor_schedule_gap_items),
-        "monitor_schedule_gap_items": monitor_schedule_gap_items[:MONITOR_DUE_ITEM_LIMIT],
-        "active_next_action_items": active_next_action_items,
-        "active_next_action_executable_items": active_next_action_executable_items,
-        "backlog_items": open_items[:TODO_BACKLOG_ITEM_LIMIT],
-        "executable_backlog_items": executable_items[:TODO_BACKLOG_ITEM_LIMIT],
-    }
-    monitor_writeback = _todo_summary_monitor_writeback_contract(value)
-    if monitor_writeback:
-        summary["monitor_writeback"] = monitor_writeback
-    summary.update(
-        build_todo_claim_visibility_lanes(
-            blocking_open_items,
-            agent_identity=agent_identity,
-            backlog_item_limit=TODO_BACKLOG_ITEM_LIMIT,
-            visibility_lane_limit=TODO_VISIBILITY_LANE_LIMIT,
-        )
-    )
-    summary.update(
-        build_todo_deferred_visibility_lanes(
-            value,
-            agent_identity=agent_identity,
-            item_limit=TODO_DEFERRED_VISIBILITY_LIMIT,
-        )
-    )
-    summary.update(
-        build_todo_resume_blocked_visibility_lanes(
-            value,
-            agent_identity=agent_identity,
-            item_limit=TODO_DEFERRED_VISIBILITY_LIMIT,
-        )
-    )
-    summary.update(
-        build_todo_handoff_gate_lanes(
-            value,
-            agent_identity=agent_identity,
-            item_limit=TODO_BACKLOG_ITEM_LIMIT,
-        )
-    )
-    summary.update(
-        build_todo_route_continuation_lanes(
-            value,
-            agent_identity=agent_identity,
-            item_limit=TODO_BACKLOG_ITEM_LIMIT,
-        )
-    )
-    summary.update(
-        build_todo_succession_warning_lanes(
-            value,
-            item_limit=TODO_BACKLOG_ITEM_LIMIT,
-        )
-    )
-    if claimed_open_items or value.get("claimed_open_count"):
-        summary["claimed_open_count"] = value.get("claimed_open_count", len(claimed_open_items))
-        summary["unclaimed_open_count"] = value.get(
-            "unclaimed_open_count",
-            max(0, int(open_count or 0) - len(claimed_open_items)),
-        )
-    if claim_scope:
-        summary["claim_scope"] = claim_scope
-    if agent_scope_filter:
-        summary["agent_scope_filter"] = agent_scope_filter
-        summary["all_open_count"] = value.get("open_count", len(all_open_items))
-        summary["other_agent_scoped_open_count"] = len(other_agent_scoped_items)
-        summary["other_agent_scoped_items"] = [
-            compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
-            for item in other_agent_scoped_items[:TODO_VISIBILITY_LANE_LIMIT]
-        ]
-    return summary
-
-
-def _summarize_project_asset_todos(
-    value: Any,
-    *,
-    agent_identity: dict[str, Any] | None = None,
-    filter_user_gate_blocks_agent: bool = False,
-) -> dict[str, Any] | None:
-    if not isinstance(value, dict):
-        return None
-    if (
-        isinstance(value.get("items"), list)
-        or isinstance(value.get("first_open_items"), list)
-    ) and (
-        "total_count" in value or "open_count" in value or "done_count" in value
-    ):
-        return _summarize_user_todos(
-            value,
-            agent_identity=agent_identity,
-            filter_user_gate_blocks_agent=filter_user_gate_blocks_agent,
-        )
-
-    all_open_items = sorted(
-        todo_summary_source_items(value),
-        key=_todo_projection_sort_key,
-    )
-    if not all_open_items:
-        next_text = str(value.get("next") or "").strip()
-        next_index = value.get("next_index", 1)
-        all_open_items = [{"index": next_index, "text": next_text}] if next_text else []
-        next_claimed_by = str(value.get("next_claimed_by") or "").strip()
-        if all_open_items and next_claimed_by:
-            all_open_items[0]["claimed_by"] = next_claimed_by
-    blocking_open_items = all_open_items
-    other_agent_scoped_items: list[dict[str, Any]] = []
-    agent_scope_filter: dict[str, Any] | None = None
-    if filter_user_gate_blocks_agent:
-        (
-            blocking_open_items,
-            other_agent_scoped_items,
-            agent_scope_filter,
-        ) = _agent_scope_filter_user_gate_items(
-            all_open_items,
-            agent_identity=agent_identity,
-        )
-    open_items, claim_scope = build_agent_claim_scoped_open_items(
-        blocking_open_items,
-        agent_identity=agent_identity,
-        diagnostic_item_limit=3,
-    )
-    executable_items = [
-        item
-        for item in open_items
-        if _todo_item_is_actionable_open(item)
-        if _todo_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
-    ]
-    monitor_items = [
-        item
-        for item in open_items
-        if _todo_item_is_actionable_open(item)
-        if _todo_task_class(item) == TODO_TASK_CLASS_MONITOR
-    ]
-    monitor_writeback_supported = _todo_summary_monitor_writeback_supported(value)
-    monitor_due_items = (
-        [
-            item
-            for item in monitor_items
-            if _todo_item_is_due_monitor(item)
-            if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
-        ]
-        if monitor_writeback_supported
-        else []
-    )
-    active_next_action_items = [
-        compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
-        for item in (value.get("active_next_action_items") or [])
-        if isinstance(item, dict)
-        if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
-    ] if isinstance(value.get("active_next_action_items"), list) else []
-    active_next_action_executable_items = [
-        compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
-        for item in (value.get("active_next_action_executable_items") or [])
-        if isinstance(item, dict)
-        if _agent_scope_selectable_todo_item(item, agent_identity=agent_identity)
-    ] if isinstance(value.get("active_next_action_executable_items"), list) else []
-    claimed_open_items = [item for item in blocking_open_items if item.get("claimed_by")]
-    open_count = value.get("open", value.get("open_count", len(all_open_items)))
-    if claim_scope is not None:
-        open_count = len(open_items)
-    if agent_scope_filter is not None:
-        open_count = len(blocking_open_items)
-    summary = {
-        "schema_version": value.get("schema_version"),
-        "source_section": value.get("source_section") or "project_asset",
-        "total_count": value.get("total", value.get("total_count")),
-        "open_count": open_count,
-        "done_count": value.get("done", value.get("done_count")),
-        "first_open_items": open_items[:3],
-        "first_executable_items": executable_items[:3],
-        "monitor_open_items": monitor_items,
-        "monitor_due_count": len(monitor_due_items),
-        "monitor_due_items": monitor_due_items[:MONITOR_DUE_ITEM_LIMIT],
-        "active_next_action_items": active_next_action_items,
-        "active_next_action_executable_items": active_next_action_executable_items,
-        "backlog_items": open_items[:TODO_BACKLOG_ITEM_LIMIT],
-        "executable_backlog_items": executable_items[:TODO_BACKLOG_ITEM_LIMIT],
-    }
-    monitor_writeback = _todo_summary_monitor_writeback_contract(value)
-    if monitor_writeback:
-        summary["monitor_writeback"] = monitor_writeback
-    summary.update(
-        build_todo_claim_visibility_lanes(
-            blocking_open_items,
-            agent_identity=agent_identity,
-            backlog_item_limit=TODO_BACKLOG_ITEM_LIMIT,
-            visibility_lane_limit=TODO_VISIBILITY_LANE_LIMIT,
-        )
-    )
-    summary.update(
-        build_todo_deferred_visibility_lanes(
-            value,
-            agent_identity=agent_identity,
-            item_limit=TODO_DEFERRED_VISIBILITY_LIMIT,
-        )
-    )
-    summary.update(
-        build_todo_handoff_gate_lanes(
-            value,
-            agent_identity=agent_identity,
-            item_limit=TODO_BACKLOG_ITEM_LIMIT,
-        )
-    )
-    summary.update(
-        build_todo_route_continuation_lanes(
-            value,
-            agent_identity=agent_identity,
-            item_limit=TODO_BACKLOG_ITEM_LIMIT,
-        )
-    )
-    if claimed_open_items or value.get("claimed_open_count"):
-        summary["claimed_open_count"] = value.get("claimed_open_count", len(claimed_open_items))
-        summary["unclaimed_open_count"] = value.get(
-            "unclaimed_open_count",
-            max(0, int(open_count or 0) - len(claimed_open_items)),
-        )
-    if claim_scope:
-        summary["claim_scope"] = claim_scope
-    if agent_scope_filter:
-        summary["agent_scope_filter"] = agent_scope_filter
-        summary["all_open_count"] = value.get("open", value.get("open_count", len(all_open_items)))
-        summary["other_agent_scoped_open_count"] = len(other_agent_scoped_items)
-        summary["other_agent_scoped_items"] = [
-            compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
-            for item in other_agent_scoped_items[:TODO_VISIBILITY_LANE_LIMIT]
-        ]
-    return summary
-
-
-def _is_canonical_attention_todo_summary(value: Any) -> bool:
-    if not isinstance(value, dict):
-        return False
-    if value.get("schema_version") == "todo_summary_v0":
-        return True
-    source_section = str(value.get("source_section") or "").strip().lower()
-    if source_section.startswith("raw "):
-        return False
-    return source_section in {"agent todo", "user todo"}
-
-
-def _select_todo_summary(
-    canonical_value: Any,
-    project_asset_value: Any,
-    *,
-    agent_identity: dict[str, Any] | None = None,
-    filter_user_gate_blocks_agent: bool = False,
-) -> dict[str, Any] | None:
-    canonical_summary = _summarize_user_todos(
-        canonical_value,
-        agent_identity=agent_identity,
-        filter_user_gate_blocks_agent=filter_user_gate_blocks_agent,
-    )
-    project_asset_summary = _summarize_project_asset_todos(
-        project_asset_value,
-        agent_identity=agent_identity,
-        filter_user_gate_blocks_agent=filter_user_gate_blocks_agent,
-    )
-    if _is_canonical_attention_todo_summary(canonical_value):
-        return canonical_summary or project_asset_summary
-    return project_asset_summary or canonical_summary
 
 
 def _same_todo_identity(left: dict[str, Any], right: dict[str, Any]) -> bool:
@@ -1580,7 +1179,7 @@ def _build_gate_prompt(
         if str(gate).strip()
     ]
     if user_todo_summary is None:
-        user_todo_summary = _summarize_user_todos(item.get("user_todos"))
+        user_todo_summary = summarize_user_todos_for_quota(item.get("user_todos"))
     first_open = (
         user_todo_summary.get("first_open_items")
         if isinstance(user_todo_summary, dict) and isinstance(user_todo_summary.get("first_open_items"), list)
@@ -1676,7 +1275,7 @@ def _open_user_gate_todo_items(summary: dict[str, Any] | None) -> list[dict[str,
         for item in values:
             if not isinstance(item, dict) or item.get("done") is True:
                 continue
-            if not _is_user_gate_todo_item(item):
+            if not is_user_gate_todo_item(item):
                 continue
             item_key = (item.get("todo_id"), item.get("index"), item.get("text"))
             if any(
@@ -2402,13 +2001,13 @@ def build_quota_should_run(
             reason = "status or contract health is not ok; skip automatic compute"
         project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
         agent_identity = _quota_agent_identity(item, agent_id=agent_id)
-        user_todo_summary = _select_todo_summary(
+        user_todo_summary = select_quota_todo_summary(
             item.get("user_todos"),
             project_asset.get("user_todos") if project_asset else None,
             agent_identity=agent_identity,
             filter_user_gate_blocks_agent=True,
         )
-        agent_todo_summary = _select_todo_summary(
+        agent_todo_summary = select_quota_todo_summary(
             item.get("agent_todos"),
             project_asset.get("agent_todos") if project_asset else None,
             agent_identity=agent_identity,


### PR DESCRIPTION
## Summary
- move quota-facing todo summary selection into loopx/control_plane/todos/quota_summary.py
- keep loopx/quota.py as the quota integration caller instead of owning canonical/project_asset/user-gate/monitor summary rules
- add a direct public-safe read-model smoke for canonical precedence, project_asset fallback, agent-scoped user gates, monitor due/schedule gaps, and succession warnings

## Validation
- python3 -m py_compile loopx/quota.py loopx/control_plane/todos/quota_summary.py examples/control_plane/quota-todo-summary-readmodel-smoke.py
- python3 examples/control_plane/quota-todo-summary-readmodel-smoke.py
- python3 examples/control_plane/quota-scheduler-policy-smoke.py
- python3 examples/control_plane/interaction-contract-state-machine-smoke.py
- python3 examples/control_plane/heartbeat-quota-flow-smoke.py
- python3 examples/control_plane/control-plane-integrated-canary-smoke.py
- python3 examples/control_plane/work-lane-contract-smoke.py
- python3 examples/control_plane/bounded-context-namespace-smoke.py
- python3 examples/control_plane/quota-plan-smoke.py
- python3 examples/control_plane/quota-scheduler-state-ack-smoke.py
- python3 examples/control_plane/quota-scheduler-hint-compaction-smoke.py
- python3 examples/control_plane/repo-python-line-budget-smoke.py
- git diff --check
- loopx check --scan-path loopx/quota.py --scan-path loopx/control_plane/todos/quota_summary.py --scan-path examples/control_plane/quota-todo-summary-readmodel-smoke.py
- loopx canary premerge --from-git-diff --tier standard --timeout-seconds 180

## Self-Merge Gate
- changed surfaces: control_plane, public_boundary, python
- premerge status: passed; merge_gate_passed=true; self_merge_allowed=true; manual_holds=0
- public/private scan: clean; only credential string is a public action-kind hint, not a secret