### PR TITLE
Extract runtime freshness warning read models

### DIFF
--- a/examples/control_plane/runtime-freshness-warning-readmodel-smoke.py
+++ b/examples/control_plane/runtime-freshness-warning-readmodel-smoke.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python3
+"""Smoke-test runtime freshness warnings shared by quota and review packets."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.runtime.decision_freshness import (  # noqa: E402
+    DECISION_FRESHNESS_WARNING_ITEM_LIMIT,
+    decision_freshness_warning,
+)
+from loopx.control_plane.runtime.promotion_readiness import (  # noqa: E402
+    promotion_readiness_warning,
+)
+from loopx.review_packet import decision_freshness_packet_lines  # noqa: E402
+
+
+TARGET_GOAL = "loopx-meta"
+OTHER_GOAL = "other-goal"
+
+
+def decision_item(index: int, *, goal_id: str, requires_rebase: bool = True) -> dict:
+    return {
+        "goal_id": goal_id,
+        "decision_kind": f"human_reward_{index}",
+        "freshness_state": "stale_rebase_required" if requires_rebase else "fresh",
+        "decision_at": f"2026-01-0{index}T00:00:00+00:00",
+        "classification": "human_reward",
+        "age_days": 10 + index,
+        "newer_event_count_7d": index,
+        "requires_decision_point_rebase": requires_rebase,
+        "reason": "decision older than freshness window; rebase at decision point",
+    }
+
+
+def assert_decision_freshness_warning() -> None:
+    status_payload = {
+        "decision_freshness_summary": {
+            "source": "run_history",
+            "window_days": 7,
+            "summary": {
+                "rebase_required_count": 6,
+                "stale_count": 4,
+            },
+            "items": [
+                decision_item(1, goal_id=TARGET_GOAL),
+                decision_item(2, goal_id=OTHER_GOAL),
+                decision_item(3, goal_id=TARGET_GOAL, requires_rebase=False),
+                decision_item(4, goal_id=TARGET_GOAL),
+                decision_item(5, goal_id=TARGET_GOAL),
+                decision_item(6, goal_id=TARGET_GOAL),
+            ],
+        }
+    }
+
+    warning = decision_freshness_warning(status_payload, goal_id=TARGET_GOAL)
+    assert warning is not None, warning
+    assert warning["source"] == "run_history", warning
+    assert warning["window_days"] == 7, warning
+    assert warning["rebase_required_count"] == 4, warning
+    assert warning["global_rebase_required_count"] == 6, warning
+    assert warning["global_stale_count"] == 4, warning
+    assert len(warning["items"]) == DECISION_FRESHNESS_WARNING_ITEM_LIMIT, warning
+    assert {item["goal_id"] for item in warning["items"]} == {TARGET_GOAL}, warning
+    assert [item["decision_kind"] for item in warning["items"]] == [
+        "human_reward_1",
+        "human_reward_4",
+        "human_reward_5",
+    ], warning
+    assert "rebase required" in warning["message"], warning
+
+    packet_warning = decision_freshness_warning(
+        status_payload,
+        goal_id=TARGET_GOAL,
+        message="旧 reward/gate 决策复用前需重新对齐。",
+    )
+    packet_lines = decision_freshness_packet_lines(packet_warning)
+    assert "【决策 freshness 警告】" in "\n".join(packet_lines), packet_lines
+    assert "旧 reward/gate 决策复用前需重新对齐。" in "\n".join(packet_lines), packet_lines
+
+    assert decision_freshness_warning(status_payload, goal_id="fresh-only-goal") is None
+    assert decision_freshness_warning({"decision_freshness_summary": {"items": []}}, goal_id=TARGET_GOAL) is None
+
+
+def assert_promotion_readiness_warning() -> None:
+    fresh_status = {
+        "promotion_readiness_summary": {
+            "available": True,
+            "source": "run_history",
+            "freshness_status": "fresh",
+            "requires_readiness_run": False,
+            "freshness_window_hours": 24,
+        }
+    }
+    assert promotion_readiness_warning(fresh_status) is None
+
+    stale_status = {
+        "promotion_readiness_summary": {
+            "available": True,
+            "source": "run_history_full_scan",
+            "freshness_status": "stale",
+            "requires_readiness_run": True,
+            "freshness_window_hours": 24,
+            "age_hours": 31.5,
+            "sample_run_count": 2,
+            "goal_id": TARGET_GOAL,
+            "generated_at": "2026-01-01T00:00:00+00:00",
+            "classification": "canary_promotion_readiness_smoke_group",
+            "json_exists": True,
+            "markdown_exists": True,
+            "reason": "latest canary promotion readiness run is stale",
+        }
+    }
+    warning = promotion_readiness_warning(stale_status)
+    assert warning is not None, warning
+    assert warning["source"] == "run_history_full_scan", warning
+    assert warning["freshness_status"] == "stale", warning
+    assert warning["requires_readiness_run"] is True, warning
+    assert warning["goal_id"] == TARGET_GOAL, warning
+    assert warning["json_exists"] is True, warning
+    assert "promotion readiness evidence" in warning["message"], warning
+
+    missing_status = {
+        "promotion_readiness_summary": {
+            "available": False,
+            "source": "run_history",
+            "freshness_status": "unknown",
+            "requires_readiness_run": True,
+            "reason": "no canary promotion readiness run found in sampled history",
+        }
+    }
+    missing_warning = promotion_readiness_warning(missing_status)
+    assert missing_warning is not None, missing_warning
+    assert missing_warning["available"] is False, missing_warning
+    assert missing_warning["reason"] == "no canary promotion readiness run found in sampled history"
+
+
+def main() -> int:
+    assert_decision_freshness_warning()
+    assert_promotion_readiness_warning()
+    print("runtime-freshness-warning-readmodel-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/control_plane/runtime/decision_freshness.py
+++ b/loopx/control_plane/runtime/decision_freshness.py
@@ -6,8 +6,13 @@ from typing import Any, Callable
 
 DECISION_FRESHNESS_WINDOW_DAYS = 7
 DECISION_FRESHNESS_ITEM_LIMIT = 12
+DECISION_FRESHNESS_WARNING_ITEM_LIMIT = 3
 DECISION_FRESHNESS_PROXY_NOTE = (
     "checkpointed decision freshness projection; rebase old decisions at the decision point before reuse"
+)
+DECISION_FRESHNESS_WARNING_MESSAGE = (
+    "decision-point rebase required before reusing sampled reward/gate state; "
+    "refresh registry, ACTIVE_GOAL_STATE, quota, policy, and run status first"
 )
 DECISION_FRESHNESS_CLASSIFICATION_PREFIXES = (
     "human_reward",
@@ -145,5 +150,53 @@ def build_decision_freshness_summary(
             "rebase_required_count": rebase_required_count,
             "fresh_count": fresh_count,
         },
+        "items": items[:item_limit],
+    }
+
+
+def decision_freshness_warning(
+    status_payload: dict[str, Any],
+    *,
+    goal_id: str,
+    item_limit: int = DECISION_FRESHNESS_WARNING_ITEM_LIMIT,
+    message: str = DECISION_FRESHNESS_WARNING_MESSAGE,
+) -> dict[str, Any] | None:
+    freshness = (
+        status_payload.get("decision_freshness_summary")
+        if isinstance(status_payload.get("decision_freshness_summary"), dict)
+        else {}
+    )
+    raw_items = freshness.get("items") if isinstance(freshness.get("items"), list) else []
+    items: list[dict[str, Any]] = []
+    for item in raw_items:
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("goal_id") or "") != goal_id:
+            continue
+        if item.get("requires_decision_point_rebase") is not True:
+            continue
+        items.append(
+            {
+                "goal_id": item.get("goal_id"),
+                "decision_kind": item.get("decision_kind"),
+                "freshness_state": item.get("freshness_state"),
+                "decision_at": item.get("decision_at"),
+                "classification": item.get("classification"),
+                "age_days": item.get("age_days"),
+                "newer_event_count_7d": item.get("newer_event_count_7d"),
+                "reason": item.get("reason"),
+            }
+        )
+
+    if not items:
+        return None
+    summary = freshness.get("summary") if isinstance(freshness.get("summary"), dict) else {}
+    return {
+        "source": freshness.get("source") or "run_history",
+        "window_days": freshness.get("window_days"),
+        "message": message,
+        "rebase_required_count": len(items),
+        "global_rebase_required_count": summary.get("rebase_required_count"),
+        "global_stale_count": summary.get("stale_count"),
         "items": items[:item_limit],
     }

--- a/loopx/control_plane/runtime/promotion_readiness.py
+++ b/loopx/control_plane/runtime/promotion_readiness.py
@@ -7,6 +7,9 @@ from typing import Any, Callable
 PROMOTION_READINESS_PROXY_NOTE = (
     "canary promotion-readiness projection from append-only run history; exact evidence stays in run artifacts"
 )
+PROMOTION_READINESS_WARNING_MESSAGE = (
+    "promotion readiness evidence is missing, stale, or unknown; run canary readiness smoke"
+)
 
 ParseTimestamp = Callable[[Any], Any]
 FreshnessBuilder = Callable[[dict[str, Any]], dict[str, Any]]
@@ -83,3 +86,35 @@ def build_promotion_readiness_summary(
         }
     )
     return readiness
+
+
+def promotion_readiness_warning(status_payload: dict[str, Any]) -> dict[str, Any] | None:
+    readiness = (
+        status_payload.get("promotion_readiness_summary")
+        if isinstance(status_payload.get("promotion_readiness_summary"), dict)
+        else {}
+    )
+    if not readiness:
+        return None
+    freshness_status = str(readiness.get("freshness_status") or "unknown")
+    requires_readiness_run = readiness.get("requires_readiness_run") is True
+    available = readiness.get("available")
+    if available is not False and not requires_readiness_run and freshness_status == "fresh":
+        return None
+
+    return {
+        "source": readiness.get("source") or "run_history",
+        "available": available,
+        "freshness_status": freshness_status,
+        "requires_readiness_run": requires_readiness_run,
+        "freshness_window_hours": readiness.get("freshness_window_hours"),
+        "age_hours": readiness.get("age_hours"),
+        "sample_run_count": readiness.get("sample_run_count"),
+        "goal_id": readiness.get("goal_id"),
+        "generated_at": readiness.get("generated_at"),
+        "classification": readiness.get("classification"),
+        "json_exists": readiness.get("json_exists"),
+        "markdown_exists": readiness.get("markdown_exists"),
+        "reason": readiness.get("reason"),
+        "message": PROMOTION_READINESS_WARNING_MESSAGE,
+    }

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -73,6 +73,13 @@ from .control_plane.quota.projection_repair import (
     build_state_projection_gap,
     build_state_projection_gap_repair_hint,
 )
+from .control_plane.runtime.decision_freshness import (
+    DECISION_FRESHNESS_WARNING_ITEM_LIMIT,
+    decision_freshness_warning as _decision_freshness_warning,
+)
+from .control_plane.runtime.promotion_readiness import (
+    promotion_readiness_warning as _promotion_readiness_warning,
+)
 from .control_plane.work_items.goal_route_hint import build_goal_route_hint
 from .control_plane.work_items.work_lane_context import (
     build_work_lane_context_contract,
@@ -187,7 +194,6 @@ STALL_HEALTH_ITEM_COMPACT_FIELDS = (
     "source",
     "recommended_action",
 )
-DECISION_FRESHNESS_WARNING_ITEM_LIMIT = 3
 MONITOR_DUE_ITEM_LIMIT = 1
 
 def _now_local() -> str:
@@ -1659,85 +1665,6 @@ def _quota_plan_items(plan: dict[str, Any]) -> list[dict[str, Any]]:
             continue
         items.extend(item for item in state_items if isinstance(item, dict))
     return items
-
-
-def _decision_freshness_warning(status_payload: dict[str, Any], *, goal_id: str) -> dict[str, Any] | None:
-    freshness = (
-        status_payload.get("decision_freshness_summary")
-        if isinstance(status_payload.get("decision_freshness_summary"), dict)
-        else {}
-    )
-    raw_items = freshness.get("items") if isinstance(freshness.get("items"), list) else []
-    items: list[dict[str, Any]] = []
-    for item in raw_items:
-        if not isinstance(item, dict):
-            continue
-        if str(item.get("goal_id") or "") != goal_id:
-            continue
-        if item.get("requires_decision_point_rebase") is not True:
-            continue
-        items.append(
-            {
-                "goal_id": item.get("goal_id"),
-                "decision_kind": item.get("decision_kind"),
-                "freshness_state": item.get("freshness_state"),
-                "decision_at": item.get("decision_at"),
-                "classification": item.get("classification"),
-                "age_days": item.get("age_days"),
-                "newer_event_count_7d": item.get("newer_event_count_7d"),
-                "reason": item.get("reason"),
-            }
-        )
-
-    if not items:
-        return None
-    summary = freshness.get("summary") if isinstance(freshness.get("summary"), dict) else {}
-    return {
-        "source": freshness.get("source") or "run_history",
-        "window_days": freshness.get("window_days"),
-        "message": (
-            "decision-point rebase required before reusing sampled reward/gate state; "
-            "refresh registry, ACTIVE_GOAL_STATE, quota, policy, and run status first"
-        ),
-        "rebase_required_count": len(items),
-        "global_rebase_required_count": summary.get("rebase_required_count"),
-        "global_stale_count": summary.get("stale_count"),
-        "items": items[:DECISION_FRESHNESS_WARNING_ITEM_LIMIT],
-    }
-
-
-def _promotion_readiness_warning(status_payload: dict[str, Any]) -> dict[str, Any] | None:
-    readiness = (
-        status_payload.get("promotion_readiness_summary")
-        if isinstance(status_payload.get("promotion_readiness_summary"), dict)
-        else {}
-    )
-    if not readiness:
-        return None
-    freshness_status = str(readiness.get("freshness_status") or "unknown")
-    requires_readiness_run = readiness.get("requires_readiness_run") is True
-    available = readiness.get("available")
-    if available is not False and not requires_readiness_run and freshness_status == "fresh":
-        return None
-
-    return {
-        "source": readiness.get("source") or "run_history",
-        "available": available,
-        "freshness_status": freshness_status,
-        "requires_readiness_run": requires_readiness_run,
-        "freshness_window_hours": readiness.get("freshness_window_hours"),
-        "age_hours": readiness.get("age_hours"),
-        "sample_run_count": readiness.get("sample_run_count"),
-        "goal_id": readiness.get("goal_id"),
-        "generated_at": readiness.get("generated_at"),
-        "classification": readiness.get("classification"),
-        "json_exists": readiness.get("json_exists"),
-        "markdown_exists": readiness.get("markdown_exists"),
-        "reason": readiness.get("reason"),
-        "message": (
-            "promotion readiness evidence is missing, stale, or unknown; run canary readiness smoke"
-        ),
-    }
 
 
 def _recent_reward_lessons(status_payload: dict[str, Any], *, goal_id: str) -> list[dict[str, Any]]:

--- a/loopx/review_packet.py
+++ b/loopx/review_packet.py
@@ -4,6 +4,9 @@ import re
 import shlex
 from typing import Any
 
+from .control_plane.runtime.decision_freshness import (
+    decision_freshness_warning as runtime_decision_freshness_warning,
+)
 from .execution_profile import (
     compact_execution_profile,
     execution_profile_outcome_floor,
@@ -214,41 +217,6 @@ def find_queue_item(status_payload: dict[str, Any], goal_id: str) -> dict[str, A
         if isinstance(item, dict) and item.get("goal_id") == goal_id:
             return item
     return None
-
-
-def decision_freshness_warning(status_payload: dict[str, Any], goal_id: str) -> dict[str, Any] | None:
-    freshness = (
-        status_payload.get("decision_freshness_summary")
-        if isinstance(status_payload.get("decision_freshness_summary"), dict)
-        else {}
-    )
-    raw_items = freshness.get("items") if isinstance(freshness.get("items"), list) else []
-    items: list[dict[str, Any]] = []
-    for item in raw_items:
-        if not isinstance(item, dict):
-            continue
-        if str(item.get("goal_id") or "") != goal_id:
-            continue
-        if item.get("requires_decision_point_rebase") is not True:
-            continue
-        items.append(
-            {
-                "decision_kind": item.get("decision_kind"),
-                "freshness_state": item.get("freshness_state"),
-                "decision_at": item.get("decision_at"),
-                "classification": item.get("classification"),
-                "age_days": item.get("age_days"),
-                "newer_event_count_7d": item.get("newer_event_count_7d"),
-            }
-        )
-    if not items:
-        return None
-    return {
-        "source": freshness.get("source") or "run_history",
-        "window_days": freshness.get("window_days"),
-        "message": "旧 reward/gate 决策复用前需在当前 registry/state/quota/policy/run status 上重新对齐。",
-        "items": items[:3],
-    }
 
 
 def decision_freshness_packet_lines(warning: dict[str, Any] | None) -> list[str]:
@@ -1185,7 +1153,11 @@ def build_review_packet(
     chain_handoff = benchmark_report_chain_handoff(item)
     delivery_contract = handoff_delivery_contract(item)
     delivery_contract_text = handoff_delivery_contract_summary(delivery_contract)
-    freshness_warning = decision_freshness_warning(status_payload, goal_id)
+    freshness_warning = runtime_decision_freshness_warning(
+        status_payload,
+        goal_id=goal_id,
+        message="旧 reward/gate 决策复用前需在当前 registry/state/quota/policy/run status 上重新对齐。",
+    )
     freshness_warning_lines = decision_freshness_packet_lines(freshness_warning)
     stale_latest_run_warning = (
         item.get("stale_latest_run_warning")


### PR DESCRIPTION
## Summary

- Move decision freshness warning derivation into `control_plane/runtime/decision_freshness.py`.
- Move promotion readiness warning derivation into `control_plane/runtime/promotion_readiness.py`.
- Reuse the shared runtime read models from quota guard and review packet paths.
- Add a focused canary for the shared freshness warning read models.

## Product / Architecture Judgment

Motivation: quota and review-packet paths were deriving the same state-machine freshness warnings independently, which made future refactors more likely to drift.

Solved: this PR makes the runtime bounded context own the warning read models and keeps quota/review packet as consumers. The behavior remains read-path only; no runner, scoring, benchmark, permission, or write-path semantics change.

User/operator impact: pre-merge and handoff surfaces now use the same decision freshness semantics, so stale reward/gate reuse and promotion-readiness gaps are easier to validate consistently.

Main risk: core control-plane read path. Mitigation is direct canary coverage plus quota/status/review-packet parity and risk-based premerge gate.

Design judgment: this is a cohesive bounded-context extraction rather than a new generic helper layer. It removes duplicate local warning rules from hot files and adds one durable canary at the runtime seam.

## Validation

- `python3 examples/control_plane/runtime-freshness-warning-readmodel-smoke.py`
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 -m py_compile loopx/control_plane/runtime/decision_freshness.py loopx/control_plane/runtime/promotion_readiness.py loopx/quota.py loopx/review_packet.py examples/control_plane/runtime-freshness-warning-readmodel-smoke.py`
- `python3 examples/control_plane/quota-plan-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 examples/control_plane/heartbeat-quota-flow-smoke.py`
- `python3 examples/control_plane/quota-heartbeat-recommendation-state-machine-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `git diff --check`
- `PYTHONPATH="$PWD" loopx canary premerge --from-git-diff`

Premerge gate passed with changed surfaces `control_plane, public_boundary, python`, risk profiles `core-control-plane, canary-runner`, manual holds `0`, selected/executed catalog canaries `8/8`, risk-profile smokes `8/8`, public boundary `1/1`.
