### PR TITLE
Add agent-scoped evidence log CLI

### DIFF
--- a/examples/control_plane/agent-scoped-evidence-log-smoke.py
+++ b/examples/control_plane/agent-scoped-evidence-log-smoke.py
@@ -1,0 +1,186 @@
+#!/usr/bin/env python3
+"""Smoke-test the read-only agent-scoped evidence-log CLI."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+GOAL_ID = "agent-evidence-fixture"
+AGENT_ID = "agent-a"
+TODO_ID = "todo_target"
+
+
+def write_jsonl(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(row, ensure_ascii=False, sort_keys=True) for row in rows) + "\n")
+
+
+def write_fixture(root: Path) -> Path:
+    runtime = root / "runtime"
+    registry_path = root / "registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "fixture",
+                        "status": "active-read-only",
+                        "adapter": {"kind": "fixture", "status": "connected-read-only"},
+                    }
+                ],
+            },
+            ensure_ascii=False,
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    write_jsonl(
+        runtime / "goals" / GOAL_ID / "rollout-event-log.jsonl",
+        [
+            {
+                "schema_version": "loopx_rollout_event_v0",
+                "goal_id": GOAL_ID,
+                "event_id": "evt-agent-a",
+                "event_kind": "todo_update",
+                "recorded_at": "2026-07-05T00:00:01Z",
+                "agent_id": AGENT_ID,
+                "todo_id": TODO_ID,
+                "status": "open",
+                "summary": "authorization token label is safe as prose",
+                "boundary": {
+                    "raw_task_text_recorded": False,
+                    "raw_logs_recorded": False,
+                    "raw_trajectory_recorded": False,
+                    "raw_session_transcript_recorded": False,
+                    "credential_values_recorded": False,
+                    "absolute_paths_recorded": False,
+                },
+            },
+            {
+                "schema_version": "loopx_rollout_event_v0",
+                "goal_id": GOAL_ID,
+                "event_id": "evt-aksk",
+                "event_kind": "todo_update",
+                "recorded_at": "2026-07-05T00:00:02Z",
+                "agent_id": AGENT_ID,
+                "todo_id": TODO_ID,
+                "status": "open",
+                "summary": "sk=should-not-surface",
+                "boundary": {
+                    "raw_task_text_recorded": False,
+                    "raw_logs_recorded": False,
+                    "raw_trajectory_recorded": False,
+                    "raw_session_transcript_recorded": False,
+                    "credential_values_recorded": False,
+                    "absolute_paths_recorded": False,
+                },
+            },
+            {
+                "schema_version": "loopx_rollout_event_v0",
+                "goal_id": GOAL_ID,
+                "event_id": "evt-other-agent",
+                "event_kind": "todo_update",
+                "recorded_at": "2026-07-05T00:00:03Z",
+                "agent_id": "agent-b",
+                "todo_id": TODO_ID,
+                "status": "open",
+                "summary": "other agent private stream should not expand",
+                "boundary": {
+                    "raw_task_text_recorded": False,
+                    "raw_logs_recorded": False,
+                    "raw_trajectory_recorded": False,
+                    "raw_session_transcript_recorded": False,
+                    "credential_values_recorded": False,
+                    "absolute_paths_recorded": False,
+                },
+            },
+        ],
+    )
+    write_jsonl(
+        runtime / "goals" / GOAL_ID / "runs" / "index.jsonl",
+        [
+            {
+                "goal_id": GOAL_ID,
+                "generated_at": "2026-07-05T00:00:04+00:00",
+                "agent_id": AGENT_ID,
+                "classification": "agent_a_progress",
+                "recommended_action": f"continue {TODO_ID}",
+                "health_check": "compact only",
+            },
+            {
+                "goal_id": GOAL_ID,
+                "generated_at": "2026-07-05T00:00:05+00:00",
+                "agent_id": "agent-b",
+                "classification": "agent_b_frontier",
+                "recommended_action": "other agent top todo only",
+                "health_check": "compact only",
+            },
+        ],
+    )
+    return registry_path
+
+
+def run_cli(registry_path: Path) -> dict:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry_path),
+            "--format",
+            "json",
+            "evidence-log",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--todo-id",
+            TODO_ID,
+            "--thin",
+            "--limit",
+            "10",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return json.loads(result.stdout)
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        payload = run_cli(write_fixture(Path(tmp)))
+    assert payload["ok"] is True
+    assert payload["schema_version"] == "agent_scoped_evidence_log_v0"
+    assert payload["goal_id"] == GOAL_ID
+    assert payload["agent_id"] == AGENT_ID
+    assert payload["todo_id"] == TODO_ID
+    assert payload["rollout_event_count"] == 2
+    assert payload["run_history_ref_count"] == 1
+    rendered = json.dumps(payload, ensure_ascii=False)
+    assert "authorization token label is safe as prose" in rendered
+    assert "sk=should-not-surface" not in rendered
+    assert "other agent private stream should not expand" not in rendered
+    assert payload["other_agent_frontier"]["item_count"] == 1
+    assert payload["other_agent_frontier"]["items"][0]["agent_id"] == "agent-b"
+    assert payload["boundary"]["other_agent_event_stream_expanded"] is False
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -32,6 +32,7 @@ from .cli_commands import (
     handle_diagnose_command,
     handle_doctor_command,
     handle_dreaming_command,
+    handle_evidence_log_command,
     handle_history_command,
     handle_lark_kanban_command,
     handle_ml_experiment_command,
@@ -56,6 +57,7 @@ from .cli_commands import (
     register_capability_commands,
     register_doctor_command,
     register_dreaming_commands,
+    register_evidence_log_command,
     register_history_command,
     register_lark_kanban_commands,
     register_ml_experiment_commands,
@@ -179,6 +181,7 @@ def main(argv: list[str] | None = None) -> int:
     register_pr_review_command(sub, add_subcommand_format)
     register_slash_commands_command(sub, add_subcommand_format)
     register_dreaming_commands(sub, add_subcommand_format)
+    register_evidence_log_command(sub, add_subcommand_format)
     register_todo_command(sub)
     register_task_lease_command(sub, add_subcommand_format)
     register_quota_command(sub)
@@ -433,6 +436,16 @@ def main(argv: list[str] | None = None) -> int:
             output_format=output_format,
             print_payload=print_payload,
         )
+
+    evidence_log_result = handle_evidence_log_command(
+        args,
+        registry_path=registry_path,
+        runtime_root_arg=args.runtime_root,
+        output_format=output_format,
+        print_payload=print_payload,
+    )
+    if evidence_log_result is not None:
+        return evidence_log_result
 
     if args.command == "todo":
         return handle_todo_command(

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -80,6 +80,7 @@ from .canary import handle_canary_command, register_canary_commands
 from .capability import handle_capability_command, register_capability_commands
 from .doctor import handle_doctor_command, register_doctor_command
 from .dreaming import handle_dreaming_command, register_dreaming_commands
+from .evidence_log import handle_evidence_log_command, register_evidence_log_command
 from .history import handle_history_command, register_history_command
 from .lark_kanban import handle_lark_kanban_command, register_lark_kanban_commands
 from .ml_experiment import handle_ml_experiment_command, register_ml_experiment_commands
@@ -205,6 +206,7 @@ __all__ = [
     "handle_demo_command",
     "handle_doctor_command",
     "handle_dreaming_command",
+    "handle_evidence_log_command",
     "handle_history_command",
     "handle_lark_kanban_command",
     "handle_ml_experiment_command",
@@ -252,6 +254,7 @@ __all__ = [
     "register_capability_commands",
     "register_doctor_command",
     "register_dreaming_commands",
+    "register_evidence_log_command",
     "register_history_command",
     "register_lark_kanban_commands",
     "register_ml_experiment_commands",

--- a/loopx/cli_commands/evidence_log.py
+++ b/loopx/cli_commands/evidence_log.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from ..control_plane.runtime.agent_scoped_evidence_log import build_agent_scoped_evidence_log
+from ..history import collect_history, load_registry
+from ..paths import resolve_runtime_root
+from ..rollout_event_log import load_rollout_events, rollout_event_log_path
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+FormatSelector = Callable[..., str]
+
+
+def register_evidence_log_command(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+) -> None:
+    parser = subparsers.add_parser(
+        "evidence-log",
+        help="Read a public-safe, agent-scoped evidence ledger for replan and handoff.",
+    )
+    add_subcommand_format(parser)
+    parser.add_argument("--goal-id", required=True, help="Goal id whose evidence should be read.")
+    parser.add_argument(
+        "--agent-id",
+        required=True,
+        help="Registered agent id. The ledger expands only this agent's event stream.",
+    )
+    parser.add_argument("--todo-id", help="Optional todo id filter for the current replan/work slice.")
+    parser.add_argument("--since", help="Optional ISO timestamp lower bound.")
+    parser.add_argument(
+        "--event-kind",
+        action="append",
+        default=[],
+        help="Optional rollout event kind filter. Repeatable.",
+    )
+    parser.add_argument("--limit", type=int, default=24, help="Maximum merged ledger rows to return.")
+    parser.add_argument(
+        "--history-limit",
+        type=int,
+        default=80,
+        help="Maximum compact run-history rows to scan before agent/todo filtering.",
+    )
+    parser.add_argument(
+        "--rollout-limit",
+        type=int,
+        default=400,
+        help="Maximum rollout-event rows to scan from the tail before filtering.",
+    )
+    parser.add_argument(
+        "--thin",
+        action="store_true",
+        help="Return the thin public-safe shape. This is the only current mode and is accepted for clarity.",
+    )
+
+
+def _goal_runs(history_payload: dict[str, Any], goal_id: str) -> list[dict[str, Any]]:
+    goals = history_payload.get("goals") if isinstance(history_payload.get("goals"), list) else []
+    for goal in goals:
+        if isinstance(goal, dict) and str(goal.get("id") or "") == goal_id:
+            latest_runs = goal.get("latest_runs")
+            return [dict(item) for item in latest_runs if isinstance(item, dict)] if isinstance(latest_runs, list) else []
+    runs = history_payload.get("runs") if isinstance(history_payload.get("runs"), list) else []
+    return [dict(item) for item in runs if isinstance(item, dict) and str(item.get("goal_id") or "") == goal_id]
+
+
+def render_evidence_log_markdown(payload: dict[str, object]) -> str:
+    if not payload.get("ok"):
+        return "\n".join(
+            [
+                "# LoopX Evidence Log",
+                "",
+                f"- ok: `{payload.get('ok')}`",
+                f"- error: `{payload.get('error')}`",
+                "",
+            ]
+        )
+    lines = [
+        "# LoopX Evidence Log",
+        "",
+        f"- goal_id: `{payload.get('goal_id')}`",
+        f"- agent_id: `{payload.get('agent_id')}`",
+        f"- todo_id: `{payload.get('todo_id') or ''}`",
+        f"- mode: `{payload.get('mode')}`",
+        f"- rollout_events: `{payload.get('rollout_event_count')}`",
+        f"- run_history_refs: `{payload.get('run_history_ref_count')}`",
+        "",
+        "## Ledger",
+        "",
+    ]
+    ledger = payload.get("ledger") if isinstance(payload.get("ledger"), list) else []
+    if not ledger:
+        lines.append("- No matching public-safe evidence rows.")
+    for row in ledger:
+        if not isinstance(row, dict):
+            continue
+        source = str(row.get("source") or "unknown")
+        when = str(row.get("recorded_at") or "")
+        if source == "rollout_event_log":
+            title = str(row.get("event_kind") or "event")
+            suffix = str(row.get("status") or row.get("classification") or "")
+        else:
+            title = str(row.get("classification") or "run")
+            suffix = str(row.get("delivery_outcome") or row.get("progress_scope") or "")
+        summary = str(row.get("summary") or row.get("recommended_action") or row.get("health_check") or "")
+        line = f"- `{when}` `{source}` {title}"
+        if suffix:
+            line += f" ({suffix})"
+        if summary:
+            line += f": {summary}"
+        lines.append(line)
+    frontier = payload.get("other_agent_frontier") if isinstance(payload.get("other_agent_frontier"), dict) else {}
+    items = frontier.get("items") if isinstance(frontier.get("items"), list) else []
+    if items:
+        lines.extend(["", "## Other Agent Frontier", ""])
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            agent = str(item.get("agent_id") or "")
+            classification = str(item.get("classification") or "latest run")
+            lines.append(f"- `{agent}`: {classification}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def handle_evidence_log_command(
+    args: argparse.Namespace,
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    output_format: FormatSelector,
+    print_payload: PrintPayload,
+) -> int | None:
+    if args.command != "evidence-log":
+        return None
+    try:
+        registry = load_registry(registry_path)
+        runtime_root = resolve_runtime_root(registry, runtime_root_arg)
+        rollout_events = load_rollout_events(
+            rollout_event_log_path(runtime_root, args.goal_id),
+            limit=max(0, int(args.rollout_limit)),
+        )
+        history_payload = collect_history(
+            registry_path=registry_path,
+            runtime_root=runtime_root,
+            goal_id=args.goal_id,
+            limit=max(0, int(args.history_limit)),
+        )
+        payload = build_agent_scoped_evidence_log(
+            goal_id=args.goal_id,
+            agent_id=args.agent_id,
+            todo_id=args.todo_id,
+            since=args.since,
+            event_kinds=args.event_kind,
+            limit=max(0, int(args.limit)),
+            rollout_events=rollout_events,
+            history_runs=_goal_runs(history_payload, args.goal_id),
+        )
+    except Exception as exc:
+        payload = {
+            "ok": False,
+            "schema_version": "agent_scoped_evidence_log_v0",
+            "goal_id": getattr(args, "goal_id", None),
+            "agent_id": getattr(args, "agent_id", None),
+            "error": str(exc),
+        }
+    selected_format = output_format(args)
+    print_payload(payload, selected_format, render_evidence_log_markdown)
+    return 0 if payload.get("ok") else 1

--- a/loopx/control_plane/runtime/agent_scoped_evidence_log.py
+++ b/loopx/control_plane/runtime/agent_scoped_evidence_log.py
@@ -1,0 +1,265 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable, Mapping
+from datetime import datetime, timezone
+from typing import Any
+
+
+SCHEMA_VERSION = "agent_scoped_evidence_log_v0"
+
+_AK_SK_PATTERN = re.compile(r"(?i)\b(?:ak|sk|access[_-]?key|secret[_-]?key)\b\s*[:=]\s*\S+")
+
+
+def _parse_timestamp(value: Any) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).strip().replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _compact_text(value: Any, *, limit: int = 220) -> str | None:
+    text = " ".join(str(value or "").split())
+    if not text:
+        return None
+    if _AK_SK_PATTERN.search(text):
+        return None
+    return text[:limit]
+
+
+def _normalize_event_kind(value: str) -> str:
+    return str(value or "").strip().lower().replace("-", "_")
+
+
+def _safe_rollout_event_row(event: Mapping[str, Any]) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "source": "rollout_event_log",
+        "recorded_at": event.get("recorded_at"),
+        "event_id": event.get("event_id"),
+        "event_kind": event.get("event_kind"),
+    }
+    for key in (
+        "status",
+        "agent_id",
+        "todo_id",
+        "classification",
+        "delivery_outcome",
+        "benchmark_id",
+        "case_id",
+        "run_id",
+    ):
+        safe = _compact_text(event.get(key), limit=180)
+        if safe:
+            row[key] = safe
+    summary = _compact_text(event.get("summary"), limit=360)
+    if summary:
+        row["summary"] = summary
+    for key in ("lane", "state_transition", "causality", "code_refs", "handoff"):
+        value = event.get(key)
+        if isinstance(value, dict):
+            row[key] = value
+    return row
+
+
+def _safe_run_history_row(run: Mapping[str, Any]) -> dict[str, Any]:
+    row: dict[str, Any] = {
+        "source": "run_history",
+        "recorded_at": run.get("generated_at"),
+        "run_ref": run.get("generated_at"),
+    }
+    for key in (
+        "goal_id",
+        "agent_id",
+        "agent_lane",
+        "classification",
+        "delivery_outcome",
+        "delivery_batch_scale",
+        "progress_scope",
+        "health_check",
+    ):
+        safe = _compact_text(run.get(key), limit=260 if key == "health_check" else 180)
+        if safe:
+            row[key] = safe
+    action = _compact_text(run.get("recommended_action"), limit=360)
+    if action:
+        row["recommended_action"] = action
+    return row
+
+
+def _event_matches(
+    event: Mapping[str, Any],
+    *,
+    agent_id: str,
+    todo_id: str | None,
+    event_kinds: set[str],
+    since: datetime | None,
+) -> bool:
+    if str(event.get("agent_id") or "") != agent_id:
+        return False
+    if todo_id and str(event.get("todo_id") or "") != todo_id:
+        return False
+    if event_kinds and _normalize_event_kind(str(event.get("event_kind") or "")) not in event_kinds:
+        return False
+    if since is not None:
+        recorded_at = _parse_timestamp(event.get("recorded_at"))
+        if recorded_at is None or recorded_at < since:
+            return False
+    return True
+
+
+def _run_mentions_todo(run: Mapping[str, Any], todo_id: str) -> bool:
+    needles = (
+        run.get("todo_id"),
+        run.get("classification"),
+        run.get("recommended_action"),
+        run.get("health_check"),
+    )
+    return any(todo_id in str(value or "") for value in needles)
+
+
+def _run_matches(
+    run: Mapping[str, Any],
+    *,
+    goal_id: str,
+    agent_id: str,
+    todo_id: str | None,
+    since: datetime | None,
+) -> bool:
+    if str(run.get("goal_id") or goal_id) != goal_id:
+        return False
+    if str(run.get("agent_id") or "") != agent_id:
+        return False
+    if todo_id and not _run_mentions_todo(run, todo_id):
+        return False
+    if since is not None:
+        recorded_at = _parse_timestamp(run.get("generated_at"))
+        if recorded_at is None or recorded_at < since:
+            return False
+    return True
+
+
+def _sort_key(row: Mapping[str, Any]) -> tuple[str, str]:
+    return (str(row.get("recorded_at") or ""), str(row.get("source") or ""))
+
+
+def _other_agent_frontier(
+    runs: Iterable[Mapping[str, Any]],
+    *,
+    goal_id: str,
+    agent_id: str,
+    limit: int,
+) -> dict[str, Any]:
+    latest_by_agent: dict[str, dict[str, Any]] = {}
+    for run in runs:
+        if str(run.get("goal_id") or goal_id) != goal_id:
+            continue
+        other_agent = _compact_text(run.get("agent_id"), limit=120)
+        if not other_agent or other_agent == agent_id:
+            continue
+        current = latest_by_agent.get(other_agent)
+        if current is None or str(run.get("generated_at") or "") > str(current.get("recorded_at") or ""):
+            row = _safe_run_history_row(run)
+            row["agent_id"] = other_agent
+            latest_by_agent[other_agent] = row
+    rows = sorted(latest_by_agent.values(), key=_sort_key, reverse=True)[: max(0, limit)]
+    return {
+        "schema_version": "other_agent_frontier_v0",
+        "policy": "goal_frontier_only",
+        "item_count": len(rows),
+        "items": rows,
+    }
+
+
+def build_agent_scoped_evidence_log(
+    *,
+    goal_id: str,
+    agent_id: str,
+    rollout_events: Iterable[Mapping[str, Any]],
+    history_runs: Iterable[Mapping[str, Any]],
+    todo_id: str | None = None,
+    since: str | None = None,
+    event_kinds: Iterable[str] | None = None,
+    limit: int = 24,
+) -> dict[str, Any]:
+    """Build a public-safe, agent-scoped ledger for replan and handoff reads."""
+
+    safe_goal_id = _compact_text(goal_id, limit=180)
+    safe_agent_id = _compact_text(agent_id, limit=180)
+    if not safe_goal_id:
+        raise ValueError("goal_id is required")
+    if not safe_agent_id:
+        raise ValueError("agent_id is required")
+    safe_todo_id = _compact_text(todo_id, limit=180) if todo_id else None
+    since_dt = _parse_timestamp(since)
+    if since and since_dt is None:
+        raise ValueError(f"invalid --since timestamp: {since}")
+    normalized_kinds = {
+        _normalize_event_kind(kind)
+        for kind in event_kinds or []
+        if _normalize_event_kind(kind)
+    }
+    max_rows = max(0, int(limit))
+
+    event_rows = [
+        _safe_rollout_event_row(event)
+        for event in rollout_events
+        if _event_matches(
+            event,
+            agent_id=safe_agent_id,
+            todo_id=safe_todo_id,
+            event_kinds=normalized_kinds,
+            since=since_dt,
+        )
+    ]
+    run_list = [dict(run) for run in history_runs]
+    run_rows = [
+        _safe_run_history_row(run)
+        for run in run_list
+        if _run_matches(
+            run,
+            goal_id=safe_goal_id,
+            agent_id=safe_agent_id,
+            todo_id=safe_todo_id,
+            since=since_dt,
+        )
+    ]
+    ledger_rows = sorted([*event_rows, *run_rows], key=_sort_key, reverse=True)[:max_rows]
+
+    return {
+        "ok": True,
+        "schema_version": SCHEMA_VERSION,
+        "mode": "thin",
+        "goal_id": safe_goal_id,
+        "agent_id": safe_agent_id,
+        "todo_id": safe_todo_id,
+        "since": since if since_dt else None,
+        "event_kinds": sorted(normalized_kinds),
+        "limit": max_rows,
+        "source_refs": [
+            "rollout_event_log.public_safe_view",
+            "compact_run_history.public_refs",
+        ],
+        "rollout_event_count": len(event_rows),
+        "run_history_ref_count": len(run_rows),
+        "ledger": ledger_rows,
+        "other_agent_frontier": _other_agent_frontier(
+            run_list,
+            goal_id=safe_goal_id,
+            agent_id=safe_agent_id,
+            limit=3,
+        ),
+        "boundary": {
+            "raw_task_text_recorded": False,
+            "raw_logs_recorded": False,
+            "raw_trajectory_recorded": False,
+            "raw_session_transcript_recorded": False,
+            "credential_values_recorded": False,
+            "absolute_paths_recorded": False,
+            "other_agent_event_stream_expanded": False,
+        },
+    }

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -50,6 +50,10 @@ COMMAND_GROUPS: list[dict[str, object]] = [
                 "command": "loopx review-packet --goal-id <goal-id>",
                 "purpose": "Render a handoff or review packet for operator judgment.",
             },
+            {
+                "command": "loopx evidence-log --goal-id <goal-id> --agent-id <agent-id> --thin",
+                "purpose": "Read the current agent's public-safe evidence ledger before replan.",
+            },
             {"command": "loopx todo --help", "purpose": "Show todo lifecycle commands."},
             {
                 "command": "loopx task-lease --help",
@@ -175,6 +179,8 @@ def render_concise_help(program: str = "loopx") -> str:
             "Daily operator commands:",
             "  loopx status                   Show current goals, gates, and next action.",
             "  loopx diagnose --goal-id ID    Build a compact evidence packet.",
+            "  loopx evidence-log --goal-id ID --agent-id AGENT --thin",
+            "                                  Read this agent's thin evidence ledger.",
             "  loopx todo --help              Add, claim, complete, update, or archive todos.",
             "  loopx task-lease --help        Manage a hard per-todo lease.",
             "  loopx quota should-run         Decide whether the next agent turn should run.",


### PR DESCRIPTION
## Summary
- Add `loopx evidence-log --goal-id <id> --agent-id <id> --thin` as a read-only agent-scoped evidence ledger.
- Merge public-safe rollout-event rows with compact run-history refs for the current agent/todo.
- Keep other agents compressed as goal-frontier latest-run refs instead of expanding their event streams.
- Keep this read model's redaction narrow: filter AK/SK-style credential values, while avoiding broad token/authorization prose redaction.

## Validation
- `python3 -m py_compile loopx/control_plane/runtime/agent_scoped_evidence_log.py loopx/cli_commands/evidence_log.py loopx/cli.py examples/control_plane/agent-scoped-evidence-log-smoke.py`
- `python3 examples/control_plane/agent-scoped-evidence-log-smoke.py`
- `python3 examples/control_plane/event-ledger-readmodel-smoke.py`
- `python3 examples/control_plane/run-history-readmodel-smoke.py`
- `python3 examples/control_plane/review-packet-cli-smoke.py`
- live read: `python3 -m loopx.cli --registry "$HOME/.codex/loopx/registry.global.json" --runtime-root "$HOME/.codex/loopx" --format json evidence-log --goal-id loopx-meta --agent-id codex-value-explorer --todo-id todo_f046e5f8b757 --thin --limit 5`
- `python3 -m loopx.cli check --scan-path loopx/cli.py --scan-path loopx/cli_commands/__init__.py --scan-path loopx/help_surface.py --scan-path loopx/cli_commands/evidence_log.py --scan-path loopx/control_plane/runtime/agent_scoped_evidence_log.py --scan-path examples/control_plane/agent-scoped-evidence-log-smoke.py --limit 20` (clean; one pre-existing runtime index duplicate warning)
- `loopx canary premerge --from-git-diff` (passed; self_merge_allowed=true; manual_holds=0)
