### PR TITLE
Harden scheduler ack state scope validation

### DIFF
--- a/examples/control_plane/quota-scheduler-state-ack-smoke.py
+++ b/examples/control_plane/quota-scheduler-state-ack-smoke.py
@@ -20,7 +20,11 @@ from loopx.control_plane.scheduler.scheduler_hint import (  # noqa: E402
     build_scheduler_ack_plan,
     build_scheduler_hint,
 )
-from loopx.control_plane.scheduler.state import SCHEDULER_STATE_SCHEMA_VERSION  # noqa: E402
+from loopx.control_plane.scheduler.state import (  # noqa: E402
+    SCHEDULER_STATE_SCHEMA_VERSION,
+    load_scheduler_state,
+    write_scheduler_state,
+)
 from loopx.quota import AgentScopeFrontierAction  # noqa: E402
 from loopx.status import AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK  # noqa: E402
 
@@ -378,6 +382,53 @@ def assert_scheduler_ack_plan_validation() -> None:
     }, already_applied
 
 
+def assert_scheduler_state_scope_validation() -> None:
+    base = active_payload()
+    first = build_scheduler_hint(
+        deepcopy(base),
+        agent_scope_frontier_actions=AGENT_SCOPE_ACTIONS,
+    )
+    valid_state = state_from(first)
+    with tempfile.TemporaryDirectory(prefix="loopx-scheduler-state-scope-") as tmp:
+        runtime = Path(tmp)
+        state_path = write_scheduler_state(
+            runtime,
+            valid_state,
+            goal_id="scheduler-state-ack-smoke",
+            agent_id="codex-side-agent",
+        )
+        loaded = load_scheduler_state(
+            runtime,
+            goal_id="scheduler-state-ack-smoke",
+            agent_id="codex-side-agent",
+        )
+        assert loaded == valid_state, loaded
+
+        corrupt_state = dict(valid_state)
+        corrupt_state["agent_id"] = "codex-other-agent"
+        state_path.write_text(json.dumps(corrupt_state, sort_keys=True) + "\n", encoding="utf-8")
+        assert (
+            load_scheduler_state(
+                runtime,
+                goal_id="scheduler-state-ack-smoke",
+                agent_id="codex-side-agent",
+            )
+            is None
+        )
+
+        try:
+            write_scheduler_state(
+                runtime,
+                corrupt_state,
+                goal_id="scheduler-state-ack-smoke",
+                agent_id="codex-side-agent",
+            )
+        except ValueError as exc:
+            assert "target scope or schema" in str(exc), exc
+        else:
+            raise AssertionError("write_scheduler_state accepted cross-agent scheduler state")
+
+
 def run_cli(root: Path, *args: str, registry_path: Path, runtime: Path, project: Path) -> dict:
     command = [
         sys.executable,
@@ -502,6 +553,63 @@ def assert_cli_scheduler_ack_progression() -> None:
         assert "recommended_rrule" not in final_app, current
 
 
+def assert_cli_ignores_corrupt_scheduler_state() -> None:
+    fixture = _load_quota_plan_fixture_module()
+    with tempfile.TemporaryDirectory(prefix="loopx-quota-scheduler-corrupt-") as tmp:
+        root = Path(tmp)
+        registry_path, runtime, project = fixture.write_cli_fixture(root, scoped_agents=True)
+        agent_id = fixture.SCOPED_AGENT_ID
+        first = run_cli(
+            root,
+            "quota",
+            "should-run",
+            "--goal-id",
+            "needs-operator",
+            "--agent-id",
+            agent_id,
+            registry_path=registry_path,
+            runtime=runtime,
+            project=project,
+        )
+        first_rrule = first["scheduler_hint"]["codex_app"]["recommended_rrule"]
+        ack = run_cli(
+            root,
+            "quota",
+            "scheduler-ack",
+            "--goal-id",
+            "needs-operator",
+            "--agent-id",
+            agent_id,
+            "--applied-rrule",
+            first_rrule,
+            "--execute",
+            registry_path=registry_path,
+            runtime=runtime,
+            project=project,
+        )
+        state_path = Path(ack["scheduler_state_path"])
+        persisted_state = json.loads(state_path.read_text(encoding="utf-8"))
+        persisted_state["agent_id"] = "codex-other-agent"
+        state_path.write_text(json.dumps(persisted_state, sort_keys=True) + "\n", encoding="utf-8")
+
+        repaired = run_cli(
+            root,
+            "quota",
+            "should-run",
+            "--goal-id",
+            "needs-operator",
+            "--agent-id",
+            agent_id,
+            registry_path=registry_path,
+            runtime=runtime,
+            project=project,
+        )
+        app = repaired["scheduler_hint"]["codex_app"]
+        assert app["recommended_rrule"] == first_rrule, repaired
+        assert app["stateful_backoff"]["state_status"] == "missing", repaired
+        assert app["stateful_backoff"]["apply_needed"] is True, repaired
+
+
 def assert_cli_scheduler_ack_uses_should_run_lookback() -> None:
     from argparse import Namespace
     from loopx.cli_commands import quota as quota_command
@@ -579,7 +687,9 @@ def main() -> int:
     assert_monitor_wait_progression_reaches_120()
     assert_active_work_keeps_initial_cadence()
     assert_scheduler_ack_plan_validation()
+    assert_scheduler_state_scope_validation()
     assert_cli_scheduler_ack_progression()
+    assert_cli_ignores_corrupt_scheduler_state()
     assert_cli_scheduler_ack_uses_should_run_lookback()
     print("quota-scheduler-state-ack-smoke ok")
     return 0

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -12,7 +12,7 @@ from ..work_items.delivery_outcome import DeliveryOutcome
 from .state import (
     CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
     CODEX_APP_SURFACE,
-    SCHEDULER_STATE_SCHEMA_VERSION,
+    build_scheduler_state,
     rrule_for_minutes,
 )
 
@@ -244,20 +244,19 @@ def build_codex_app_scheduler_ack_event(
     )
     progression_index = max(0, _int_number(stateful_backoff.get("progression_index"), default=0))
     safe_generated_at = generated_at or ""
-    scheduler_state = {
-        "schema_version": SCHEDULER_STATE_SCHEMA_VERSION,
-        "goal_id": before.get("goal_id"),
-        "agent_id": safe_agent_id,
-        "surface": surface,
-        "state_key": state_key,
-        "reset_token": stateful_backoff.get("reset_token"),
-        "identity_signature": stateful_backoff.get("identity_signature"),
-        "progression_index": progression_index,
-        "progression_minutes": progression_minutes,
-        "last_applied_rrule": expected_rrule,
-        "updated_at": safe_generated_at,
-        "source": classification,
-    }
+    scheduler_state = build_scheduler_state(
+        goal_id=before.get("goal_id"),
+        agent_id=safe_agent_id,
+        surface=surface,
+        state_key=state_key,
+        reset_token=stateful_backoff.get("reset_token"),
+        identity_signature=stateful_backoff.get("identity_signature"),
+        progression_index=progression_index,
+        progression_minutes=progression_minutes,
+        last_applied_rrule=expected_rrule,
+        updated_at=safe_generated_at,
+        source=classification,
+    )
     reason = str(reason_summary or "").strip() or (
         f"acknowledged Codex App scheduler RRULE {expected_rrule}; no quota spend"
     )

--- a/loopx/control_plane/scheduler/state.py
+++ b/loopx/control_plane/scheduler/state.py
@@ -21,6 +21,106 @@ def _safe_segment(value: str) -> str:
     return safe or "default"
 
 
+def _positive_int_list(value: Any) -> list[int] | None:
+    if not isinstance(value, list):
+        return None
+    result: list[int] = []
+    for item in value:
+        try:
+            number = int(item)
+        except (TypeError, ValueError):
+            return None
+        if number <= 0:
+            return None
+        result.append(number)
+    return result or None
+
+
+def normalize_scheduler_state(
+    state: dict[str, Any],
+    *,
+    goal_id: str,
+    agent_id: str,
+    surface: str = CODEX_APP_SURFACE,
+    state_key: str = CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
+) -> dict[str, Any] | None:
+    if not isinstance(state, dict):
+        return None
+    expected = {
+        "schema_version": SCHEDULER_STATE_SCHEMA_VERSION,
+        "goal_id": str(goal_id or "").strip(),
+        "agent_id": str(agent_id or "").strip(),
+        "surface": str(surface or CODEX_APP_SURFACE).strip() or CODEX_APP_SURFACE,
+        "state_key": str(state_key or CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).strip(),
+    }
+    for key, expected_value in expected.items():
+        if str(state.get(key) or "").strip() != expected_value:
+            return None
+    reset_token = str(state.get("reset_token") or "").strip()
+    identity_signature = str(state.get("identity_signature") or "").strip()
+    last_applied_rrule = str(state.get("last_applied_rrule") or "").strip()
+    if not reset_token or not identity_signature or not last_applied_rrule:
+        return None
+    try:
+        progression_index = int(state.get("progression_index"))
+    except (TypeError, ValueError):
+        return None
+    if progression_index < 0:
+        return None
+    progression_minutes = _positive_int_list(state.get("progression_minutes"))
+    if progression_minutes is None:
+        return None
+    normalized = dict(state)
+    normalized.update(expected)
+    normalized["reset_token"] = reset_token
+    normalized["identity_signature"] = identity_signature
+    normalized["progression_index"] = progression_index
+    normalized["progression_minutes"] = progression_minutes
+    normalized["last_applied_rrule"] = last_applied_rrule
+    return normalized
+
+
+def build_scheduler_state(
+    *,
+    goal_id: Any,
+    agent_id: str,
+    surface: str = CODEX_APP_SURFACE,
+    state_key: str = CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
+    reset_token: Any,
+    identity_signature: Any,
+    progression_index: int,
+    progression_minutes: list[Any],
+    last_applied_rrule: Any,
+    updated_at: str,
+    source: str | None = None,
+) -> dict[str, Any]:
+    state = {
+        "schema_version": SCHEDULER_STATE_SCHEMA_VERSION,
+        "goal_id": str(goal_id or "").strip(),
+        "agent_id": str(agent_id or "").strip(),
+        "surface": str(surface or CODEX_APP_SURFACE).strip() or CODEX_APP_SURFACE,
+        "state_key": str(state_key or CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).strip(),
+        "reset_token": reset_token,
+        "identity_signature": identity_signature,
+        "progression_index": progression_index,
+        "progression_minutes": progression_minutes,
+        "last_applied_rrule": last_applied_rrule,
+        "updated_at": str(updated_at or ""),
+    }
+    if source:
+        state["source"] = str(source)
+    normalized = normalize_scheduler_state(
+        state,
+        goal_id=state["goal_id"],
+        agent_id=state["agent_id"],
+        surface=state["surface"],
+        state_key=state["state_key"],
+    )
+    if normalized is None:
+        raise ValueError("scheduler state is missing required persisted-state fields")
+    return normalized
+
+
 def scheduler_state_path(
     runtime_root: Path,
     *,
@@ -64,9 +164,13 @@ def load_scheduler_state(
         return None
     if not isinstance(parsed, dict):
         return None
-    if parsed.get("schema_version") != SCHEDULER_STATE_SCHEMA_VERSION:
-        return None
-    return parsed
+    return normalize_scheduler_state(
+        parsed,
+        goal_id=goal_id,
+        agent_id=agent_id,
+        surface=surface,
+        state_key=state_key,
+    )
 
 
 def write_scheduler_state(
@@ -78,6 +182,15 @@ def write_scheduler_state(
     surface: str = CODEX_APP_SURFACE,
     state_key: str = CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
 ) -> Path:
+    normalized = normalize_scheduler_state(
+        state,
+        goal_id=goal_id,
+        agent_id=agent_id,
+        surface=surface,
+        state_key=state_key,
+    )
+    if normalized is None:
+        raise ValueError("scheduler state does not match target scope or schema")
     path = scheduler_state_path(
         runtime_root,
         goal_id=goal_id,
@@ -87,6 +200,6 @@ def write_scheduler_state(
     )
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = path.with_suffix(path.suffix + ".tmp")
-    tmp_path.write_text(json.dumps(state, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    tmp_path.write_text(json.dumps(normalized, ensure_ascii=False, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     tmp_path.replace(path)
     return path


### PR DESCRIPTION
## Summary
- move persisted Codex App scheduler-state construction into the scheduler bounded context
- validate persisted scheduler state against goal, agent, surface, state key, reset token, identity signature, progression index, progression minutes, and applied RRULE before load/write
- extend the scheduler ack canary so corrupt cross-agent state is ignored and quota cadence returns to the initial missing-state path

## Product / architecture judgment
This closes a scheduler/quota state-machine seam: quota should consume only scheduler-owned, scoped persisted state. The implementation keeps command orchestration in quota, but gives scheduler/state the schema and scope authority, so corrupt or cross-scope files cannot silently advance a heartbeat cadence.

## Validation
- PYTHONPATH="/private/tmp/loopx-product-capability-state-seam-20260705T120807" python3 examples/control_plane/quota-scheduler-state-ack-smoke.py
- PYTHONPATH="/private/tmp/loopx-product-capability-state-seam-20260705T120807" python3 examples/control_plane/quota-heartbeat-recommendation-state-machine-smoke.py
- PYTHONPATH="/private/tmp/loopx-product-capability-state-seam-20260705T120807" python3 examples/control_plane/control-plane-integrated-canary-smoke.py
- PYTHONPATH="/private/tmp/loopx-product-capability-state-seam-20260705T120807" loopx canary premerge --from-git-diff
- private/credential/local-path scan over changed files

## Merge posture
Self-merge candidate: single-purpose control-plane scheduler state hardening, no benchmark execution/scoring, no permission boundary change, no public evidence-policy change, no manual holds in premerge gate.