### PR TITLE
Wire agent-scoped evidence reads into replan

### DIFF
--- a/examples/control_plane/quota-replan-decision-plane-smoke.py
+++ b/examples/control_plane/quota-replan-decision-plane-smoke.py
@@ -217,6 +217,19 @@ def assert_replan_beats_monitor_quiet_skip() -> None:
     }, guard
     assert guard["goal_frontier_projection"]["acceptance_gaps"] == [], guard
     assert guard["autonomous_replan_scope"]["applies"] is True, guard
+    required_reads = guard["required_reads"]
+    assert required_reads[0]["kind"] == "agent_scoped_evidence_log", required_reads
+    assert required_reads[0]["agent_id"] == SIDE_AGENT, required_reads
+    assert required_reads[0]["todo_id"] == "todo_monitor_wait", required_reads
+    assert "evidence-log" in required_reads[0]["command"], required_reads
+    assert " --agent-id codex-side-bypass " in f" {required_reads[0]['command']} ", required_reads
+    assert guard["autonomous_replan_obligation"]["required_reads"] == required_reads, guard
+    assert (
+        guard["interaction_contract"]["agent_channel"]["required_reads"] == required_reads
+    ), guard
+    assert (
+        guard["interaction_contract"]["cli_channel"]["required_reads"] == required_reads
+    ), guard
     assert guard["autonomous_replan_decision"]["decision_plane"] == (
         "goal_frontier_before_lane_quiet_or_agent_scope_wait"
     ), guard
@@ -225,6 +238,8 @@ def assert_replan_beats_monitor_quiet_skip() -> None:
     assert "goal_frontier_projection: replan_required=True" in markdown, markdown
     assert "deferred_ready=0 acceptance_gaps=0" in markdown, markdown
     assert "autonomous_replan_decision: decision=autonomous_replan_required" in markdown, markdown
+    assert "required_read: kind=agent_scoped_evidence_log" in markdown, markdown
+    assert "evidence-log --goal-id replan-decision-plane-fixture" in markdown, markdown
 
 
 def assert_future_scheduled_monitor_quiets_without_generated_replan() -> None:

--- a/examples/control_plane/review-packet-cli-smoke.py
+++ b/examples/control_plane/review-packet-cli-smoke.py
@@ -509,6 +509,11 @@ def assert_connected_delivery_surface_loop_requires_macro_evidence() -> None:
                         "gate": "none",
                         "next_action": "Attempt a ranker / cross-domain evidence segment or report blocker.",
                         "stop_condition": "stop if useful work needs unapproved scope",
+                        "agent_member": {
+                            "agent_id": "codex-side-bypass",
+                            "role": "side-agent",
+                            "scope_summary": "delivery-side-bypass",
+                        },
                         "agent_todos": {
                             "items": [
                                 {
@@ -604,6 +609,11 @@ def assert_connected_delivery_surface_loop_requires_macro_evidence() -> None:
     contract = payload["handoff_delivery_contract"]
     assert payload["ok"] is True, payload
     assert payload["connected_delivery_handoff"] is True, payload
+    required_reads = payload["project_agent_required_reads"]
+    assert required_reads[0]["kind"] == "agent_scoped_evidence_log", required_reads
+    assert required_reads[0]["agent_id"] == "codex-side-bypass", required_reads
+    assert "evidence-log" in required_reads[0]["command"], required_reads
+    assert " --agent-id codex-side-bypass " in f" {required_reads[0]['command']} ", required_reads
     assert "quota should-run" in payload["project_agent_command"], payload
     assert "--goal-id delivery-side-bypass" in payload["project_agent_command"], payload
     assert contract["mode"] == "expand_after_surface_progress_loop", payload
@@ -612,6 +622,9 @@ def assert_connected_delivery_surface_loop_requires_macro_evidence() -> None:
     assert "connected-delivery" in handoff, handoff
     assert "真实 delivery" in handoff, handoff
     assert "可改文件、验证、写回、spend" in handoff, handoff
+    assert "必读流水账" in handoff, handoff
+    assert "evidence-log" in handoff, handoff
+    assert "codex-side-bypass" in handoff, handoff
     assert "surface-only 下游传播" in handoff, handoff
     assert "只读或 dry-run 路径" not in handoff, handoff
     assert "Agent 待办候选 2" in handoff, handoff

--- a/loopx/control_plane/runtime/agent_scoped_evidence_log.py
+++ b/loopx/control_plane/runtime/agent_scoped_evidence_log.py
@@ -1,12 +1,14 @@
 from __future__ import annotations
 
 import re
+import shlex
 from collections.abc import Iterable, Mapping
 from datetime import datetime, timezone
 from typing import Any
 
 
 SCHEMA_VERSION = "agent_scoped_evidence_log_v0"
+REQUIRED_READ_SCHEMA_VERSION = "loopx_agent_required_read_v0"
 
 _AK_SK_PATTERN = re.compile(r"(?i)\b(?:ak|sk|access[_-]?key|secret[_-]?key)\b\s*[:=]\s*\S+")
 
@@ -145,6 +147,72 @@ def _run_matches(
 
 def _sort_key(row: Mapping[str, Any]) -> tuple[str, str]:
     return (str(row.get("recorded_at") or ""), str(row.get("source") or ""))
+
+
+def build_agent_scoped_evidence_log_command(
+    *,
+    goal_id: str,
+    agent_id: str,
+    todo_id: str | None = None,
+    cli_bin: str = "loopx",
+    output_format: str = "json",
+    limit: int = 24,
+) -> str:
+    safe_goal_id = _compact_text(goal_id, limit=180)
+    safe_agent_id = _compact_text(agent_id, limit=180)
+    if not safe_goal_id:
+        raise ValueError("goal_id is required")
+    if not safe_agent_id:
+        raise ValueError("agent_id is required")
+    safe_todo_id = _compact_text(todo_id, limit=180) if todo_id else None
+    parts = [
+        cli_bin or "loopx",
+        "--format",
+        output_format or "json",
+        "evidence-log",
+        "--goal-id",
+        safe_goal_id,
+        "--agent-id",
+        safe_agent_id,
+        "--thin",
+        "--limit",
+        str(max(0, int(limit))),
+    ]
+    if safe_todo_id:
+        parts.extend(["--todo-id", safe_todo_id])
+    return " ".join(shlex.quote(part) for part in parts)
+
+
+def build_agent_scoped_required_read(
+    *,
+    goal_id: str,
+    agent_id: str | None,
+    todo_id: str | None = None,
+    reason: str = "read this agent's thin public-safe evidence ledger before replan",
+    cli_bin: str = "loopx",
+    limit: int = 24,
+) -> dict[str, Any] | None:
+    safe_agent_id = _compact_text(agent_id, limit=180) if agent_id else None
+    if not safe_agent_id:
+        return None
+    command = build_agent_scoped_evidence_log_command(
+        goal_id=goal_id,
+        agent_id=safe_agent_id,
+        todo_id=todo_id,
+        cli_bin=cli_bin,
+        limit=limit,
+    )
+    return {
+        "schema_version": REQUIRED_READ_SCHEMA_VERSION,
+        "kind": "agent_scoped_evidence_log",
+        "goal_id": _compact_text(goal_id, limit=180),
+        "agent_id": safe_agent_id,
+        "todo_id": _compact_text(todo_id, limit=180) if todo_id else None,
+        "mode": "thin",
+        "command": command,
+        "reason": _compact_text(reason, limit=180),
+        "other_agent_policy": "frontier_only",
+    }
 
 
 def _other_agent_frontier(

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -654,6 +654,21 @@ def interaction_next_cli_actions(payload: dict[str, Any], *, mode: str) -> list[
     return ["no quota spend without validated transition/blocker writeback"]
 
 
+def _interaction_required_reads(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    reads = payload.get("required_reads")
+    if not isinstance(reads, list):
+        return []
+    result: list[dict[str, Any]] = []
+    for item in reads:
+        if not isinstance(item, dict):
+            continue
+        command = protocol_action_text(item.get("command"), limit=360)
+        if not command:
+            continue
+        result.append({**item, "command": command})
+    return result
+
+
 def _interaction_spend_policy(
     execution_obligation: dict[str, Any],
     heartbeat_recommendation: dict[str, Any],
@@ -794,6 +809,7 @@ def build_interaction_contract(payload: dict[str, Any]) -> dict[str, Any]:
     )
     if user_reason:
         user_channel["reason"] = user_reason
+    required_reads = _interaction_required_reads(payload)
 
     contract = {
         "schema_version": INTERACTION_CONTRACT_SCHEMA_VERSION,
@@ -817,6 +833,9 @@ def build_interaction_contract(payload: dict[str, Any]) -> dict[str, Any]:
             ),
         },
     }
+    if required_reads:
+        contract["agent_channel"]["required_reads"] = required_reads
+        contract["cli_channel"]["required_reads"] = required_reads
     if mode in {
         "user_gate",
         "user_todo_blocker_push",

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -77,6 +77,9 @@ from .control_plane.runtime.decision_freshness import (
     DECISION_FRESHNESS_WARNING_ITEM_LIMIT,
     decision_freshness_warning as _decision_freshness_warning,
 )
+from .control_plane.runtime.agent_scoped_evidence_log import (
+    build_agent_scoped_required_read,
+)
 from .control_plane.runtime.promotion_readiness import (
     promotion_readiness_warning as _promotion_readiness_warning,
 )
@@ -2619,6 +2622,14 @@ def build_quota_should_run(
             payload["next_handoff_condition"] = item.get("next_handoff_condition")
         if should_run and item.get("agent_command"):
             payload["agent_command"] = item.get("agent_command")
+        required_reads = _quota_required_reads(payload)
+        if required_reads:
+            payload["required_reads"] = required_reads
+            if isinstance(payload.get("autonomous_replan_obligation"), dict):
+                payload["autonomous_replan_obligation"] = {
+                    **payload["autonomous_replan_obligation"],
+                    "required_reads": required_reads,
+                }
         payload["automation_liveness"] = build_automation_liveness(payload)
         payload["interaction_contract"] = build_interaction_contract(payload)
         payload["scheduler_hint"] = _scheduler_hint(
@@ -2884,6 +2895,52 @@ def _compact_quota_decision(decision: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _first_todo_id_from_items(value: Any) -> str | None:
+    if not isinstance(value, list):
+        return None
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        todo_id = normalize_todo_id(item.get("todo_id") or item.get("id"))
+        if todo_id:
+            return todo_id
+    return None
+
+
+def _required_read_todo_id(decision: dict[str, Any]) -> str | None:
+    lane_action = (
+        decision.get("agent_lane_next_action")
+        if isinstance(decision.get("agent_lane_next_action"), dict)
+        else {}
+    )
+    todo_id = normalize_todo_id(lane_action.get("todo_id") or lane_action.get("id"))
+    if todo_id:
+        return todo_id
+    agent_scope_frontier = (
+        decision.get("agent_scope_frontier")
+        if isinstance(decision.get("agent_scope_frontier"), dict)
+        else {}
+    )
+    for key in (
+        "deferred_resume_candidates",
+        "route_continuation_replan_candidates",
+        "monitor_blocked_resume_candidates",
+    ):
+        todo_id = _first_todo_id_from_items(agent_scope_frontier.get(key))
+        if todo_id:
+            return todo_id
+    agent_todos = (
+        decision.get("agent_todo_summary")
+        if isinstance(decision.get("agent_todo_summary"), dict)
+        else {}
+    )
+    for key in ("first_executable_items", "first_open_items"):
+        todo_id = _first_todo_id_from_items(agent_todos.get(key))
+        if todo_id:
+            return todo_id
+    return None
+
+
 def _quota_decision_agent_id(decision: dict[str, Any]) -> str | None:
     agent_identity = (
         decision.get("agent_identity")
@@ -2891,6 +2948,26 @@ def _quota_decision_agent_id(decision: dict[str, Any]) -> str | None:
         else {}
     )
     return normalize_todo_claimed_by(agent_identity.get("agent_id"))
+
+
+def _quota_required_reads(decision: dict[str, Any]) -> list[dict[str, Any]]:
+    effective_action = str(decision.get("effective_action") or "")
+    replan_required = effective_action in {
+        AUTONOMOUS_REPLAN_REQUIRED_MODE,
+        AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value,
+    } or isinstance(decision.get("autonomous_replan_obligation"), dict)
+    if not replan_required:
+        return []
+    read = build_agent_scoped_required_read(
+        goal_id=str(decision.get("goal_id") or ""),
+        agent_id=_quota_decision_agent_id(decision),
+        todo_id=_required_read_todo_id(decision),
+        reason=(
+            "read this agent's thin public-safe evidence ledger before autonomous "
+            "replan; other agents stay frontier-only"
+        ),
+    )
+    return [read] if read else []
 
 
 def _scheduler_ack_failure(
@@ -4464,6 +4541,19 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
         )
         if replan_obligation.get("next_validation_command"):
             lines.append(f"- autonomous_replan_validation: `{replan_obligation.get('next_validation_command')}`")
+    required_reads = payload.get("required_reads") if isinstance(payload.get("required_reads"), list) else []
+    for read in required_reads[:3]:
+        if not isinstance(read, dict):
+            continue
+        command = str(read.get("command") or "").strip()
+        if command:
+            lines.append(
+                "- required_read: "
+                f"kind={read.get('kind')} "
+                f"agent_id={read.get('agent_id')} "
+                f"todo_id={read.get('todo_id') or ''} "
+                f"command=`{command}`"
+            )
     work_lane_contract = (
         payload.get("work_lane_contract")
         if isinstance(payload.get("work_lane_contract"), dict)

--- a/loopx/review_packet.py
+++ b/loopx/review_packet.py
@@ -7,6 +7,9 @@ from typing import Any
 from .control_plane.runtime.decision_freshness import (
     decision_freshness_warning as runtime_decision_freshness_warning,
 )
+from .control_plane.runtime.agent_scoped_evidence_log import (
+    build_agent_scoped_required_read,
+)
 from .execution_profile import (
     compact_execution_profile,
     execution_profile_outcome_floor,
@@ -402,6 +405,25 @@ def agent_member_summary(item: dict[str, Any] | None) -> str | None:
     if member.get("handoff_agent"):
         parts.append(f"handoff_agent={member.get('handoff_agent')}")
     return compact_packet_text(" ".join(str(part) for part in parts if part))
+
+
+def project_agent_required_reads(
+    goal_id: str,
+    item: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    member = agent_member_from_item(item)
+    if not member:
+        return []
+    agent_id = str(member.get("agent_id") or member.get("handoff_agent") or "").strip()
+    read = build_agent_scoped_required_read(
+        goal_id=goal_id,
+        agent_id=agent_id,
+        reason=(
+            "read this target agent's thin evidence ledger before replan or "
+            "handoff continuation; other agents stay frontier-only"
+        ),
+    )
+    return [read] if read else []
 
 
 def project_asset_source(item: dict[str, Any] | None) -> str:
@@ -1001,6 +1023,7 @@ def project_agent_section(
     agent_member_text: str | None = None,
     handoff_followthrough_text: str | None = None,
     handoff_delivery_contract_text: str | None = None,
+    required_reads: list[dict[str, Any]] | None = None,
     approved_operator_gate: bool = False,
     connected_delivery: bool = False,
 ) -> str:
@@ -1017,12 +1040,28 @@ def project_agent_section(
     member_line = f"Agent 成员：{agent_member_text}" if agent_member_text else None
     followthrough_line = f"交付观测：{handoff_followthrough_text}" if handoff_followthrough_text else None
     delivery_contract_line = f"交付合同：{handoff_delivery_contract_text}" if handoff_delivery_contract_text else None
+    first_required_read = next(
+        (
+            item
+            for item in (required_reads or [])
+            if isinstance(item, dict) and item.get("command")
+        ),
+        None,
+    )
+    required_read_line = (
+        "必读流水账：replan/接力前运行 "
+        f"`{compact_shell_command(str(first_required_read.get('command') or ''))}`；"
+        "只展开本 agent，其他 agent 只看 frontier。"
+        if first_required_read
+        else None
+    )
     if approved_operator_gate:
         lines = [
             goal_guard,
             context_rule,
             source_line,
             member_line,
+            required_read_line,
             todo_line,
             *extra_todo_lines,
             authority_line,
@@ -1040,6 +1079,7 @@ def project_agent_section(
             context_rule,
             source_line,
             member_line,
+            required_read_line,
             todo_line,
             *extra_todo_lines,
             authority_line,
@@ -1057,6 +1097,7 @@ def project_agent_section(
             context_rule,
             source_line,
             member_line,
+            required_read_line,
             todo_line,
             *extra_todo_lines,
             authority_line,
@@ -1074,6 +1115,7 @@ def project_agent_section(
             context_rule,
             source_line,
             member_line,
+            required_read_line,
             todo_line,
             *extra_todo_lines,
             authority_line,
@@ -1091,6 +1133,7 @@ def project_agent_section(
             context_rule,
             source_line,
             member_line,
+            required_read_line,
             todo_line,
             *extra_todo_lines,
             authority_line,
@@ -1108,6 +1151,7 @@ def project_agent_section(
             context_rule,
             source_line,
             member_line,
+            required_read_line,
             todo_line,
             *extra_todo_lines,
             authority_line,
@@ -1153,6 +1197,7 @@ def build_review_packet(
     chain_handoff = benchmark_report_chain_handoff(item)
     delivery_contract = handoff_delivery_contract(item)
     delivery_contract_text = handoff_delivery_contract_summary(delivery_contract)
+    required_reads = project_agent_required_reads(goal_id, item)
     freshness_warning = runtime_decision_freshness_warning(
         status_payload,
         goal_id=goal_id,
@@ -1198,6 +1243,7 @@ def build_review_packet(
         agent_member_text=member_summary,
         handoff_followthrough_text=followthrough_summary,
         handoff_delivery_contract_text=delivery_contract_text,
+        required_reads=required_reads,
         approved_operator_gate=approved_handoff,
         connected_delivery=delivery_handoff,
     )
@@ -1273,6 +1319,7 @@ def build_review_packet(
         "handoff_followthrough_summary": followthrough_summary,
         "benchmark_report_chain_handoff": chain_handoff,
         "handoff_delivery_contract": delivery_contract,
+        "project_agent_required_reads": required_reads,
         "handoff_interface_budget": handoff_interface_budget,
         "decision_freshness_warning": freshness_warning,
         "stale_latest_run_warning": stale_latest_run_warning,


### PR DESCRIPTION
## Summary
- add an agent-scoped evidence-log required_read builder for thin per-agent ledger reads
- surface required_reads on autonomous replan quota payloads and mirror them into interaction contracts
- include the same required read in review-packet project-agent handoff text
- cover quota and review-packet required-read contracts with focused smokes

## Validation
- PYTHONPATH=/Users/bytedance/goal-harness-evidence-log-required-reads python3 -m loopx.cli canary premerge --from-git-diff
- premerge gate passed: merge_gate_passed=true, self_merge_allowed=true, manual_holds=0
- changed Python py_compile passed through premerge
- catalog canaries passed: 8/8
- risk profile smokes passed: 8/8
- public boundary smoke passed: 1/1

## Boundary
- changed files are limited to loopx/** and examples/**
- required_read commands intentionally omit registry/runtime absolute paths
- public/private keyword scan found no internal links, local paths, credentials, or private artifacts