### PR TITLE
Move public safety defaults into runtime read model

### DIFF
--- a/examples/control_plane/public-safety-readmodel-smoke.py
+++ b/examples/control_plane/public-safety-readmodel-smoke.py
@@ -11,32 +11,37 @@ if str(ROOT) not in sys.path:
 
 from loopx import status as status_module  # noqa: E402
 from loopx.control_plane.runtime import public_safety as public_safety_read_model  # noqa: E402
+from loopx.control_plane.runtime import session_runtime as session_runtime_read_model  # noqa: E402
+from loopx.control_plane.work_items import project_asset as project_asset_read_model  # noqa: E402
+from loopx.session_runtime import SESSION_RUNTIME_READONLY_PROJECTION_SCHEMA_VERSION  # noqa: E402
 
 
-def _direct_text(value: object, *, limit: int = 220) -> str | None:
-    return public_safety_read_model.public_safe_compact_text(
-        value,
-        limit=limit,
-        normalize_text=status_module.normalize_todo_text,
-        local_path_surface_pattern=status_module.LOCAL_PATH_SURFACE_PATTERN,
-        secret_like_surface_pattern=status_module.SECRET_LIKE_SURFACE_PATTERN,
+def assert_status_uses_direct_read_models() -> None:
+    assert status_module.public_safe_compact_text is public_safety_read_model.public_safe_compact_text
+    assert status_module.public_safe_compact_list is public_safety_read_model.public_safe_compact_list
+    assert (
+        status_module.compact_session_runtime_readonly_projection
+        is session_runtime_read_model.compact_session_runtime_readonly_projection
+    )
+    assert (
+        status_module.compact_session_runtime_projection_from_run
+        is session_runtime_read_model.compact_session_runtime_projection_from_run
     )
 
 
 def assert_public_safe_text_parity() -> None:
     assert status_module.public_safe_compact_text("  keep\nthis  value ") == "keep this value"
-    assert status_module.public_safe_compact_text("  keep\nthis  value ") == _direct_text(
+    assert project_asset_read_model.project_asset_public_safe_compact_text(
         "  keep\nthis  value "
-    )
+    ) == "keep this value"
     assert status_module.public_safe_compact_text("") is None
-    assert status_module.public_safe_compact_text("") == _direct_text("")
 
     local_path = "/" + "tmp" + "/loopx-public-boundary-probe.json"
     secret_like_text = "tok" + "en" + "=" + ("x" * 12)
     assert status_module.public_safe_compact_text(local_path) is None
-    assert status_module.public_safe_compact_text(local_path) == _direct_text(local_path)
+    assert project_asset_read_model.project_asset_public_safe_compact_text(local_path) is None
     assert status_module.public_safe_compact_text(secret_like_text) is None
-    assert status_module.public_safe_compact_text(secret_like_text) == _direct_text(secret_like_text)
+    assert project_asset_read_model.project_asset_public_safe_compact_text(secret_like_text) is None
 
 
 def assert_public_safe_list_parity() -> None:
@@ -44,17 +49,71 @@ def assert_public_safe_list_parity() -> None:
     values = ["first", local_path, "second", "third"]
     expected = ["first", "second"]
     assert status_module.public_safe_compact_list(values, limit=2) == expected
-    assert public_safety_read_model.public_safe_compact_list(
-        values,
-        limit=2,
-        compact_text=_direct_text,
-    ) == expected
+    assert public_safety_read_model.public_safe_compact_list(values, limit=2) == expected
     assert status_module.public_safe_compact_list("single", limit=4) == ["single"]
 
 
+def assert_session_runtime_defaults() -> None:
+    local_path = "/" + "tmp" + "/session-runtime-probe.json"
+    projection = {
+        "schema_version": SESSION_RUNTIME_READONLY_PROJECTION_SCHEMA_VERSION,
+        "goal_id": "loopx-meta",
+        "source": {
+            "host_kind": "codex",
+            "latest_fact_at": "2026-07-05T12:00:00Z",
+            "source_refs": {
+                "todos": ["todo_1", "todo_2"],
+            },
+        },
+        "boundary": {
+            "raw_material_key_names": ["safe-key", local_path],
+            "raw_logs_copied": False,
+        },
+        "first_screen": {
+            "waiting_on": "codex",
+            "latest_blocker": local_path,
+            "recommended_action": "  continue\nvalidated seam  ",
+            "agent_can_continue": True,
+        },
+        "work_lane_contract": {"lane": "advancement_task", "must_attempt_work": True},
+        "attention_item": {"kind": "todo", "title": "  Public\nTitle  "},
+    }
+
+    compact = status_module.compact_session_runtime_readonly_projection(projection)
+    assert compact == {
+        "schema_version": SESSION_RUNTIME_READONLY_PROJECTION_SCHEMA_VERSION,
+        "mode": "read_only",
+        "goal_id": "loopx-meta",
+        "source": {
+            "host_kind": "codex",
+            "latest_fact_at": "2026-07-05T12:00:00Z",
+            "source_ref_counts": {"todos": 2},
+        },
+        "boundary": {
+            "raw_logs_copied": False,
+            "raw_material_key_names": ["safe-key"],
+        },
+        "first_screen": {
+            "waiting_on": "codex",
+            "recommended_action": "continue validated seam",
+            "agent_can_continue": True,
+        },
+        "work_lane_contract": {
+            "lane": "advancement_task",
+            "must_attempt_work": True,
+        },
+        "attention_item": {"kind": "todo", "title": "Public Title"},
+    }
+    assert status_module.compact_session_runtime_projection_from_run(
+        {"session_runtime_readonly_projection": projection}
+    ) == compact
+
+
 def main() -> None:
+    assert_status_uses_direct_read_models()
     assert_public_safe_text_parity()
     assert_public_safe_list_parity()
+    assert_session_runtime_defaults()
 
 
 if __name__ == "__main__":

--- a/loopx/control_plane/runtime/public_safety.py
+++ b/loopx/control_plane/runtime/public_safety.py
@@ -1,21 +1,39 @@
 from __future__ import annotations
 
+import re
 from typing import Any, Callable, Optional
 
 
 NormalizeText = Callable[..., str]
 CompactText = Callable[..., Optional[str]]
+DEFAULT_PUBLIC_SAFE_LIST_LIMIT = 4
+LOCAL_PATH_SURFACE_PATTERN = re.compile(
+    r"(?<!<)/(?:Users|Volumes|var/folders|tmp|private/tmp)/[^\s`'\"<>]+"
+)
+SECRET_LIKE_SURFACE_PATTERN = re.compile(
+    r"(?i)(?:\bbearer\s+[a-z0-9._~+/=-]{16,}|"
+    r"(?<![a-z0-9_])(?:ak|sk)[-_=:][a-z0-9_=-]{10,}|"
+    r"\btoken\s*[=:]\s*[^\s`'\"<>]{12,})"
+)
+
+
+def compact_text(text: str, *, limit: int) -> str:
+    compact = " ".join(str(text or "").strip().split())
+    if len(compact) <= limit:
+        return compact
+    return compact[: limit - 1].rstrip() + "…"
 
 
 def public_safe_compact_text(
     value: Any,
     *,
     limit: int = 220,
-    normalize_text: NormalizeText,
-    local_path_surface_pattern: Any,
-    secret_like_surface_pattern: Any,
+    normalize_text: NormalizeText | None = None,
+    local_path_surface_pattern: Any = LOCAL_PATH_SURFACE_PATTERN,
+    secret_like_surface_pattern: Any = SECRET_LIKE_SURFACE_PATTERN,
 ) -> str | None:
-    text = normalize_text(str(value or ""), limit=limit)
+    normalize = normalize_text or compact_text
+    text = normalize(str(value or ""), limit=limit)
     if not text:
         return None
     if local_path_surface_pattern.search(text) or secret_like_surface_pattern.search(text):
@@ -26,14 +44,15 @@ def public_safe_compact_text(
 def public_safe_compact_list(
     value: Any,
     *,
-    limit: int,
-    compact_text: CompactText,
+    limit: int = DEFAULT_PUBLIC_SAFE_LIST_LIMIT,
+    compact_text: CompactText | None = None,
     item_limit: int = 160,
 ) -> list[str]:
     values = value if isinstance(value, list) else [value] if value else []
     result: list[str] = []
+    compact_item = compact_text or public_safe_compact_text
     for item in values:
-        text = compact_text(item, limit=item_limit)
+        text = compact_item(item, limit=item_limit)
         if not text:
             continue
         result.append(text)

--- a/loopx/control_plane/runtime/session_runtime.py
+++ b/loopx/control_plane/runtime/session_runtime.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from typing import AbstractSet, Any, Callable, Optional
 
 from ...session_runtime import SESSION_RUNTIME_READONLY_PROJECTION_SCHEMA_VERSION
+from .public_safety import (
+    public_safe_compact_list as _default_public_safe_compact_list,
+    public_safe_compact_text as _default_public_safe_compact_text,
+)
 
 
 SESSION_RUNTIME_READONLY_PROJECTION_KEYS = (
@@ -188,8 +192,8 @@ def compact_session_runtime_attention_item(
 def compact_session_runtime_readonly_projection(
     value: Any,
     *,
-    public_safe_compact_text: PublicSafeText,
-    public_safe_compact_list: PublicSafeList,
+    public_safe_compact_text: PublicSafeText = _default_public_safe_compact_text,
+    public_safe_compact_list: PublicSafeList = _default_public_safe_compact_list,
 ) -> dict[str, Any] | None:
     if not isinstance(value, dict):
         return None
@@ -238,8 +242,8 @@ def compact_session_runtime_readonly_projection(
 def compact_session_runtime_projection_from_run(
     run: dict[str, Any] | None,
     *,
-    public_safe_compact_text: PublicSafeText,
-    public_safe_compact_list: PublicSafeList,
+    public_safe_compact_text: PublicSafeText = _default_public_safe_compact_text,
+    public_safe_compact_list: PublicSafeList = _default_public_safe_compact_list,
 ) -> dict[str, Any] | None:
     if not isinstance(run, dict):
         return None

--- a/loopx/control_plane/work_items/project_asset.py
+++ b/loopx/control_plane/work_items/project_asset.py
@@ -1,7 +1,13 @@
 from __future__ import annotations
 
-import re
 from typing import Any, Callable
+
+from ..runtime.public_safety import (
+    LOCAL_PATH_SURFACE_PATTERN,
+    SECRET_LIKE_SURFACE_PATTERN,
+    compact_text as _compact_text,
+    public_safe_compact_text as _runtime_public_safe_compact_text,
+)
 
 
 DEFAULT_MONITOR_SIGNAL_WAITING_ON = "monitor_signal"
@@ -18,30 +24,8 @@ PROJECT_ASSET_HANDOFF_STATE_TRACE_CHECK_KEYS = (
     "handoff_has_stop_condition",
     "handoff_sanitized_surface",
 )
-LOCAL_PATH_SURFACE_PATTERN = re.compile(
-    r"(?<!<)/(?:Users|Volumes|var/folders|tmp|private/tmp)/[^\s`'\"<>]+"
-)
-SECRET_LIKE_SURFACE_PATTERN = re.compile(
-    r"(?i)(?:\bbearer\s+[a-z0-9._~+/=-]{16,}|"
-    r"(?<![a-z0-9_])(?:ak|sk)[-_=:][a-z0-9_=-]{10,}|"
-    r"\btoken\s*[=:]\s*[^\s`'\"<>]{12,})"
-)
-
-
-def _compact_text(text: str, *, limit: int) -> str:
-    compact = " ".join(text.strip().split())
-    if len(compact) <= limit:
-        return compact
-    return compact[: limit - 1].rstrip() + "…"
-
-
 def project_asset_public_safe_compact_text(value: Any, *, limit: int = 220) -> str | None:
-    text = _compact_text(str(value or ""), limit=limit)
-    if not text:
-        return None
-    if LOCAL_PATH_SURFACE_PATTERN.search(text) or SECRET_LIKE_SURFACE_PATTERN.search(text):
-        return None
-    return text
+    return _runtime_public_safe_compact_text(value, limit=limit)
 
 
 def project_asset_owner(

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -49,9 +49,7 @@ from .control_plane.work_items.task_graph import (
     build_task_graph_projection as _build_task_graph_projection_read_model,
 )
 from .control_plane.work_items.project_asset import (
-    LOCAL_PATH_SURFACE_PATTERN,
     PROJECT_ASSET_TODO_PROJECTION_GAP_SCHEMA_VERSION,
-    SECRET_LIKE_SURFACE_PATTERN,
     TODO_PROJECTION_DETAIL_POINTER_SCHEMA_VERSION,
     TODO_PROJECTION_VIEW_SCHEMA_VERSION,
     build_project_asset,
@@ -172,8 +170,8 @@ from .control_plane.runtime.run_compaction import (
     compact_run_base as _compact_run_base_read_model,
 )
 from .control_plane.runtime.public_safety import (
-    public_safe_compact_list as _public_safe_compact_list_read_model,
-    public_safe_compact_text as _public_safe_compact_text_read_model,
+    public_safe_compact_list,
+    public_safe_compact_text,
 )
 from .control_plane.runtime.run_history import (
     build_run_history as _build_run_history_read_model,
@@ -230,9 +228,9 @@ from .control_plane.work_items.lifecycle import (
     run_lifecycle_phase as _run_lifecycle_phase_read_model,
 )
 from .control_plane.runtime.session_runtime import (
-    compact_session_runtime_projection_from_run as _compact_session_runtime_projection_from_run_read_model,
-    compact_session_runtime_readonly_projection as _compact_session_runtime_readonly_projection_read_model,
     attach_session_runtime_projection,
+    compact_session_runtime_projection_from_run,
+    compact_session_runtime_readonly_projection,
     legacy_runtime_goal_attention as _legacy_runtime_goal_attention_read_model,
     session_runtime_projection_attention as _session_runtime_projection_attention_read_model,
     session_runtime_status_label as _session_runtime_status_label_read_model,
@@ -552,7 +550,6 @@ MAX_DEFERRED_TODO_VISIBILITY_ITEMS = _TODO_SUMMARY_MAX_DEFERRED_TODO_VISIBILITY_
 MAX_MONITOR_DUE_ITEMS = _TODO_SUMMARY_MAX_MONITOR_DUE_ITEMS
 MAX_DEPENDENCY_BLOCKERS = _TODO_SUMMARY_MAX_DEPENDENCY_BLOCKERS
 MAX_AUTONOMOUS_BACKLOG_CANDIDATES = _MAX_AUTONOMOUS_TODO_CANDIDATES
-MAX_SUBAGENT_SCOPE_ITEMS = 4
 MAX_BACKLOG_HYGIENE_EVIDENCE_ITEMS = _MAX_BACKLOG_HYGIENE_EVIDENCE_ITEMS_READ_MODEL
 MAX_AUTONOMOUS_REPLAN_TRIGGERS = _MAX_AUTONOMOUS_REPLAN_TRIGGERS_READ_MODEL
 AUTONOMOUS_REPLAN_STALL_THRESHOLD = 2
@@ -580,38 +577,6 @@ AUTONOMOUS_RUN_HISTORY_NEUTRAL_CLASSIFICATIONS = {
 AUTONOMOUS_RUN_HISTORY_STALL_PATTERN = re.compile(
     r"(?i)(?:monitor|observe|observation|poll|watch|quiet|no[-_ ]?op|no[-_ ]?progress|stalled?|unchanged|dependency|停转|无进展|重复|反复|观察|轮询)"
 )
-def public_safe_compact_text(value: Any, *, limit: int = 220) -> str | None:
-    return _public_safe_compact_text_read_model(
-        value,
-        limit=limit,
-        normalize_text=normalize_todo_text,
-        local_path_surface_pattern=LOCAL_PATH_SURFACE_PATTERN,
-        secret_like_surface_pattern=SECRET_LIKE_SURFACE_PATTERN,
-    )
-
-
-def public_safe_compact_list(value: Any, *, limit: int = MAX_SUBAGENT_SCOPE_ITEMS) -> list[str]:
-    return _public_safe_compact_list_read_model(
-        value,
-        limit=limit,
-        compact_text=public_safe_compact_text,
-    )
-
-
-def compact_session_runtime_readonly_projection(value: Any) -> dict[str, Any] | None:
-    return _compact_session_runtime_readonly_projection_read_model(
-        value,
-        public_safe_compact_text=public_safe_compact_text,
-        public_safe_compact_list=public_safe_compact_list,
-    )
-
-
-def compact_session_runtime_projection_from_run(run: dict[str, Any] | None) -> dict[str, Any] | None:
-    return _compact_session_runtime_projection_from_run_read_model(
-        run,
-        public_safe_compact_text=public_safe_compact_text,
-        public_safe_compact_list=public_safe_compact_list,
-    )
 
 
 def _compact_numeric_map(value: Any, *, keys: tuple[str, ...] | None = None) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- move public-safe text/list default compaction into `control_plane/runtime/public_safety.py`
- let session-runtime top-level compactors use those defaults directly
- remove `status.py` wrapper glue and extend the public-safety readmodel smoke to cover direct aliases plus runtime defaults

## Validation
- `PYTHONPATH="$PWD" python3 -m py_compile loopx/status.py loopx/control_plane/runtime/public_safety.py loopx/control_plane/work_items/project_asset.py loopx/control_plane/runtime/session_runtime.py examples/control_plane/public-safety-readmodel-smoke.py`
- `PYTHONPATH="$PWD" python3 examples/control_plane/public-safety-readmodel-smoke.py`
- `PYTHONPATH="$PWD" python3 examples/control_plane/status-markdown-smoke.py`
- `PYTHONPATH="$PWD" python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `PYTHONPATH="$PWD" python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `PYTHONPATH="$PWD" python3 examples/control_plane/todo-readmodel-boundary-smoke.py`
- `git diff --check`
- added-line public/private boundary scan
- `PYTHONPATH="$PWD" loopx canary premerge --from-git-diff`