### PR TITLE
fix: replan when advancement frontier loses successor

### DIFF
--- a/examples/control_plane/quota-replan-decision-plane-smoke.py
+++ b/examples/control_plane/quota-replan-decision-plane-smoke.py
@@ -89,6 +89,22 @@ def side_agent_claimed_advancement() -> dict:
     }
 
 
+def completed_side_agent_advancement_without_successor() -> dict:
+    return {
+        "index": 3,
+        "todo_id": "todo_completed_without_successor",
+        "text": "[P0] Complete a visible auto-research advancement slice.",
+        "role": "agent",
+        "status": "done",
+        "done": True,
+        "priority": "P0",
+        "task_class": "advancement_task",
+        "action_kind": "fix_visible_auto_research_tick",
+        "claimed_by": SIDE_AGENT,
+        "completed_at": "2026-07-05T13:36:19+08:00",
+    }
+
+
 def blocking_handoff_review() -> dict:
     return {
         "index": 2,
@@ -267,6 +283,50 @@ def assert_future_scheduled_monitor_quiets_without_generated_replan() -> None:
     assert "required_reads" not in guard, guard
     assert "required_reads" not in guard["interaction_contract"]["agent_channel"], guard
     assert "required_reads" not in guard["interaction_contract"]["cli_channel"], guard
+
+
+def assert_completed_advancement_without_successor_beats_monitor_quiet_skip() -> None:
+    guard = build_quota_should_run(
+        status_payload(
+            [
+                monitor_item(),
+                completed_side_agent_advancement_without_successor(),
+            ],
+            replan_obligation=None,
+        ),
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+    )
+    assert guard["decision"] == "autonomous_replan_required", guard
+    assert guard["effective_action"] == "autonomous_replan_required", guard
+    assert guard["should_run"] is True, guard
+    assert guard["heartbeat_recommendation"]["recommended_mode"] == (
+        "autonomous_replan_required"
+    ), guard
+    assert guard["execution_obligation"]["kind"] == "autonomous_replan_required", guard
+    assert guard["interaction_contract"]["mode"] == "autonomous_replan", guard
+    assert guard["interaction_contract"]["agent_channel"]["must_attempt"] is True, guard
+    warning = guard["agent_todo_summary"]["todo_succession_warning"]
+    assert warning["reason_code"] == "completed_advancement_without_successor", guard
+    assert warning["items"][0]["todo_id"] == "todo_completed_without_successor", guard
+    obligation = guard["autonomous_replan_obligation"]
+    assert obligation["agent_id"] == SIDE_AGENT, guard
+    assert obligation["triggers"][0]["kind"] == "completed_advancement_without_successor", guard
+    assert obligation["triggers"][0]["todo_id"] == "todo_completed_without_successor", guard
+    assert "record explicit no-follow-up" in obligation["recommended_action"], guard
+    assert guard["autonomous_replan_scope"]["scope"] == "explicit_agent_owner", guard
+    assert guard["autonomous_replan_scope"]["applies"] is True, guard
+    frontier = guard["goal_frontier_projection"]
+    assert frontier["replan_required"] is True, guard
+    assert frontier["monitor_only_lanes"]["present"] is True, guard
+    assert frontier["remaining_advancement_frontier"] == {
+        "current_agent_claimed_advancement_count": 0,
+        "unclaimed_advancement_count": 0,
+        "other_agent_claimed_advancement_count": 0,
+    }, guard
+    markdown = render_quota_should_run_markdown(guard)
+    assert "goal_frontier_projection: replan_required=True" in markdown, markdown
+    assert "autonomous_replan_decision: decision=autonomous_replan_required" in markdown, markdown
 
 
 def assert_replan_preserves_current_agent_runnable_frontier() -> None:
@@ -487,6 +547,7 @@ def assert_blocking_handoff_gate_beats_derived_monitor_replan() -> None:
 def main() -> None:
     assert_replan_beats_monitor_quiet_skip()
     assert_future_scheduled_monitor_quiets_without_generated_replan()
+    assert_completed_advancement_without_successor_beats_monitor_quiet_skip()
     assert_replan_preserves_current_agent_runnable_frontier()
     assert_agent_vision_gap_derives_replan()
     assert_agent_scoped_replan_beats_agent_scope_wait()

--- a/loopx/control_plane/goals/goal_frontier.py
+++ b/loopx/control_plane/goals/goal_frontier.py
@@ -10,6 +10,7 @@ AUTONOMOUS_REPLAN_OBLIGATION_SCHEMA_VERSION = "autonomous_replan_obligation_v0"
 AUTONOMOUS_REPLAN_REQUIRED_MODE = "autonomous_replan_required"
 FRONTIER_EXHAUSTED_MONITOR_TRIGGER = "frontier_exhausted_monitor_lane"
 VISION_ACCEPTANCE_GAP_TRIGGER = "vision_acceptance_gap"
+TODO_SUCCESSION_GAP_TRIGGER = "completed_advancement_without_successor"
 TODO_TASK_CLASS_ADVANCEMENT = "advancement_task"
 TODO_TASK_CLASS_MONITOR = "continuous_monitor"
 FRONTIER_REPLAN_ACK_DELTA_KINDS = {
@@ -484,6 +485,35 @@ def _blocking_handoff_gate_count(
     )
 
 
+def _succession_gap_items(
+    agent_todo_summary: dict[str, Any] | None,
+    *,
+    agent_id: str | None,
+) -> list[dict[str, Any]]:
+    if not isinstance(agent_todo_summary, dict):
+        return []
+    warning = (
+        agent_todo_summary.get("todo_succession_warning")
+        if isinstance(agent_todo_summary.get("todo_succession_warning"), dict)
+        else {}
+    )
+    source_items = (
+        warning.get("items")
+        if isinstance(warning.get("items"), list)
+        else agent_todo_summary.get("completed_without_successor_items")
+        if isinstance(agent_todo_summary.get("completed_without_successor_items"), list)
+        else []
+    )
+    items = [item for item in source_items if isinstance(item, dict)]
+    if not agent_id:
+        return items
+    return [
+        item
+        for item in items
+        if str(item.get("claimed_by") or "").strip() in {"", agent_id}
+    ]
+
+
 def derive_goal_frontier_replan_obligation_from_summaries(
     *,
     user_todo_summary: dict[str, Any] | None,
@@ -520,6 +550,62 @@ def derive_goal_frontier_replan_obligation_from_summaries(
     ]
     if user_counts.get("open", 0) > 0:
         return None
+    succession_gap_items = _succession_gap_items(
+        agent_todo_summary,
+        agent_id=agent_id,
+    )
+    if (
+        succession_gap_items
+        and agent_counts.get("advancement", 0) == 0
+        and total_frontier_advancement == 0
+    ):
+        triggers = [
+            {
+                "kind": TODO_SUCCESSION_GAP_TRIGGER,
+                "section": "agent_todo_summary.todo_succession_warning",
+                "todo_id": item.get("todo_id"),
+                "text": item.get("text")
+                or item.get("title")
+                or "completed advancement needs a successor or no-followup rationale",
+                "agent_id": agent_id,
+                "claimed_by": item.get("claimed_by"),
+            }
+            for item in succession_gap_items[:3]
+        ]
+        return {
+            "schema_version": AUTONOMOUS_REPLAN_OBLIGATION_SCHEMA_VERSION,
+            "required": True,
+            "agent_id": agent_id,
+            "stall_threshold": 1,
+            "trigger_count": len(succession_gap_items),
+            "triggers": triggers,
+            "guidance_actions": [
+                "create_successor",
+                "link_successor",
+                "record_no_followup",
+            ],
+            "todo_actions": [
+                {
+                    "action": "add",
+                    "role": "agent",
+                    "priority": "P0",
+                    "text": (
+                        "run a bounded successor replan: create or link the next "
+                        "runnable advancement todo, or record an explicit "
+                        "no-follow-up rationale"
+                    ),
+                }
+            ],
+            "next_validation_command": "python3 examples/control_plane/quota-replan-decision-plane-smoke.py",
+            "stop_condition": (
+                "stop if the successor decision requires private material, "
+                "credentials, destructive git, production actions, or owner-only decisions"
+            ),
+            "recommended_action": (
+                "run a bounded successor replan before another quiet poll: add/link "
+                "the next advancement todo, or record explicit no-follow-up"
+            ),
+        }
     if (
         compact_acceptance_gaps
         and agent_counts.get("advancement", 0) == 0


### PR DESCRIPTION
## Summary
- promote current-agent `completed_advancement_without_successor` warnings into a goal-frontier autonomous replan obligation when there is no runnable advancement frontier
- keep pure future-scheduled monitor lanes quiet when there is no succession gap
- add a regression to `quota-replan-decision-plane-smoke` for the exact monitor-quiet swallowing successor-gap shape

## Why
The bad case was: goal still active, monitor/blocker todos still open, but the actual advancement frontier was empty after a tracked advancement completed without a successor. Quota saw open monitor work and chose `monitor_quiet_skip`; it should instead require a bounded successor replan.

## Validation
- `python3 examples/control_plane/quota-replan-decision-plane-smoke.py`
- `python3 examples/control_plane/todo-succession-contract-smoke.py`
- `python3 examples/control_plane/work-lane-contract-smoke.py`
- `python3 examples/control_plane/interaction-contract-state-machine-smoke.py`
- `python3 examples/control_plane/quota-contract-smoke.py`
- `python3 examples/control_plane/heartbeat-quota-flow-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `python3 -m py_compile loopx/control_plane/goals/goal_frontier.py examples/control_plane/quota-replan-decision-plane-smoke.py`
- `git diff --check`

## Public/private boundary
- no local paths, raw run logs, credentials, or private artifacts
- control-plane read-model and public smoke only
