### PR TITLE
Expose evidence-log read hints

### DIFF
--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -6,3 +6,8 @@ stable enough to test, lint, or link from implementation.
 Current groups:
 
 - [Protocol contracts](protocols/README.md)
+
+High-traffic read paths:
+
+- [agent_scoped_evidence_ledger_v0](protocols/agent-scoped-evidence-ledger-v0.md):
+  thin, per-agent evidence chronology used before replan or handoff.

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -182,6 +182,13 @@ also carries compact `handoff_readiness` with `handoff_status` and
 `post_handoff_run_seen`. Heartbeat jobs can therefore tell whether the selected
 goal is still waiting for a target run or has already seen post-handoff work
 without parsing the full status payload.
+For replan and handoff, the guard and review packet may also carry
+`required_reads` / `project_agent_required_reads` entries that point to
+`loopx evidence-log --goal-id <goal-id> --agent-id <agent-id> --thin`. Treat
+that command as the cold-path chronology for the selected agent lane: it expands
+the current agent's public-safe events, keeps other agents compressed to
+frontier context, and does not replace status, quota, review packets, or the
+append-only event sources.
 The same guard may include `work_lane_contract`. Schema
 `work_lane_contract_v1` is the single machine contract for monitor versus
 advancement routing. It distinguishes `lane=continuous_monitor` from

--- a/examples/cli-help-manpage-smoke.py
+++ b/examples/cli-help-manpage-smoke.py
@@ -30,6 +30,7 @@ def assert_concise_default_help(output: str) -> None:
     assert "Codex App" in output, output
     assert "Claude Code" in output, output
     assert "loopx commands" in output, output
+    assert "evidence-log --goal-id ID --agent-id AGENT --thin" in output, output
     assert "man loopx" in output, output
     assert LONG_TAIL_COMMAND not in output, output
     assert len(output.splitlines()) <= 36, output
@@ -52,6 +53,8 @@ def assert_command_reference_surface() -> None:
     assert result.returncode == 0, (result.returncode, result.stdout, result.stderr)
     assert "LoopX command reference" in result.stdout, result.stdout
     assert "Daily operator commands" in result.stdout, result.stdout
+    assert "required evidence-log reads" in result.stdout, result.stdout
+    assert "before replan or handoff" in result.stdout, result.stdout
     assert "Loop driver hints" in result.stdout, result.stdout
     assert "Claude Code /loop" in result.stdout, result.stdout
     assert "Maintainer and adapter commands" in result.stdout, result.stdout
@@ -114,10 +117,13 @@ def assert_installer_manpage_surface() -> None:
         assert manpage.is_file(), manpage
         with gzip.open(manpage, "rt", encoding="utf-8") as handle:
             man_text = handle.read()
+        compact_man_text = " ".join(man_text.split())
         assert ".TH LOOPX 1" in man_text, man_text
         assert ".SH LOOP DRIVERS" in man_text, man_text
         assert "Codex App automation" in man_text, man_text
         assert "loopx commands" in man_text, man_text
+        assert "loopx evidence-log --goal-id" in man_text, man_text
+        assert "before replan or handoff" in compact_man_text, man_text
         assert "loopx COMMAND --help" in man_text, man_text
 
         profile_text = profile.read_text(encoding="utf-8")

--- a/examples/control_plane/review-packet-cli-smoke.py
+++ b/examples/control_plane/review-packet-cli-smoke.py
@@ -641,6 +641,7 @@ def assert_connected_delivery_surface_loop_requires_macro_evidence() -> None:
     handoff_only = review_packet_handoff_only_payload(payload)
     assert_handoff_interface_budget(handoff_only, "connected-delivery handoff-only payload")
     assert_handoff_only_top_level_budget(handoff_only, "connected-delivery handoff-only payload")
+    assert handoff_only["project_agent_required_reads"] == required_reads, handoff_only
     agent_contract = handoff_only["handoff_delivery_contract"]
     assert set(agent_contract) == {"mode", "instruction", "minimum_scale", "must_include", "if_blocked"}, handoff_only
     assert agent_contract["mode"] == "expand_after_surface_progress_loop", handoff_only

--- a/loopx/cli_commands/status.py
+++ b/loopx/cli_commands/status.py
@@ -135,7 +135,10 @@ def register_status_commands(
 
     review_packet_parser = subparsers.add_parser(
         "review-packet",
-        help="Generate a CLI-visible Review Packet from the current status contract.",
+        help=(
+            "Generate a CLI-visible Review Packet from the current status contract, "
+            "including agent-scoped evidence-log read hints when available."
+        ),
     )
     review_packet_parser.add_argument("--goal-id", required=True, help="Goal id to package for review or handoff.")
     review_packet_parser.add_argument(
@@ -205,6 +208,7 @@ def review_packet_handoff_only_payload(payload: dict[str, object]) -> dict[str, 
             "project_agent_handoff": handoff_text,
             "handoff_text": handoff_text,
             "benchmark_report_chain_handoff": payload.get("benchmark_report_chain_handoff"),
+            "project_agent_required_reads": payload.get("project_agent_required_reads") or [],
             "operator_gate_approved_handoff": payload.get("operator_gate_approved_handoff"),
             "connected_delivery_handoff": payload.get("connected_delivery_handoff"),
             "handoff_delivery_contract": agent_contract,

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -48,11 +48,11 @@ COMMAND_GROUPS: list[dict[str, object]] = [
             },
             {
                 "command": "loopx review-packet --goal-id <goal-id>",
-                "purpose": "Render a handoff or review packet for operator judgment.",
+                "purpose": "Render a handoff or review packet with any required evidence-log reads.",
             },
             {
                 "command": "loopx evidence-log --goal-id <goal-id> --agent-id <agent-id> --thin",
-                "purpose": "Read the current agent's public-safe evidence ledger before replan.",
+                "purpose": "Read the current agent's thin public-safe ledger before replan or handoff.",
             },
             {"command": "loopx todo --help", "purpose": "Show todo lifecycle commands."},
             {
@@ -180,7 +180,7 @@ def render_concise_help(program: str = "loopx") -> str:
             "  loopx status                   Show current goals, gates, and next action.",
             "  loopx diagnose --goal-id ID    Build a compact evidence packet.",
             "  loopx evidence-log --goal-id ID --agent-id AGENT --thin",
-            "                                  Read this agent's thin evidence ledger.",
+            "                                  Read this agent's thin ledger before replan.",
             "  loopx todo --help              Add, claim, complete, update, or archive todos.",
             "  loopx task-lease --help        Manage a hard per-todo lease.",
             "  loopx quota should-run         Decide whether the next agent turn should run.",
@@ -191,15 +191,11 @@ def render_concise_help(program: str = "loopx") -> str:
             "  Claude Code    use installed /loopx skills; adapter only for gated native /loop.",
             "  Other agents   need a CLI/task/automation/loop hook, or run LoopX manually.",
             "",
-            "Global options:",
-            "  --registry PATH   --runtime-root PATH   --format markdown|json",
-            "",
+            "Global options: --registry PATH   --runtime-root PATH   --format markdown|json",
             "More:",
             "  loopx commands                 Show grouped command reference.",
-            "  loopx slash-commands           Show/install slash command prompt and skill files.",
             "  loopx <command> --help         Show flags for one command.",
             "  man loopx                      Open the installed manual page.",
-            "  docs/guides/newcomer-command-path.md",
             "",
         ]
     )

--- a/man/loopx.1
+++ b/man/loopx.1
@@ -43,7 +43,12 @@ Show current goals, gates, attention queue, and next action.
 Build a compact evidence packet when behavior is surprising.
 .TP
 .B loopx review-packet --goal-id <goal-id>
-Render a handoff or review packet for operator judgment.
+Render a handoff or review packet for operator judgment, including required
+agent-scoped evidence reads when available.
+.TP
+.B loopx evidence-log --goal-id <goal-id> --agent-id <agent-id> --thin
+Read the current agent's bounded public-safe evidence ledger before replan or
+handoff. Other agents remain compressed to frontier context.
 .TP
 .B loopx todo --help
 Show todo add, claim, complete, update, supersede, and archive forms.


### PR DESCRIPTION
## Summary
- carry project_agent_required_reads through handoff-only review-packet JSON
- make evidence-log discoverable in CLI help, manpage, and reference/status docs
- extend existing help and review-packet smokes for the discoverability contract

## Validation
- python3 -m py_compile loopx/cli_commands/status.py loopx/help_surface.py examples/cli-help-manpage-smoke.py examples/control_plane/review-packet-cli-smoke.py
- python3 examples/cli-help-manpage-smoke.py
- python3 examples/control_plane/review-packet-cli-smoke.py
- python3 examples/control_plane/agent-scoped-evidence-log-smoke.py
- git diff --check origin/main...HEAD
- loopx check --scan-path docs/reference/README.md --scan-path docs/status-data-contract.md --scan-path man/loopx.1 --scan-path loopx/cli_commands/status.py --scan-path loopx/help_surface.py --scan-path examples/cli-help-manpage-smoke.py --scan-path examples/control_plane/review-packet-cli-smoke.py
- PYTHONPATH=/Users/bytedance/goal-harness-evidence-log-discoverability python3 -m loopx.cli canary premerge --from-git-diff

## Boundary
Public docs/help/control-plane discoverability only. No private state, local evidence, raw logs, credentials, or production actions.