### PR TITLE
release: prepare LoopX v0.1.9

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -108,6 +108,13 @@ path, and canary route rather than as a user-facing release baseline.
   `claude-code`, `manual`, or `other-agent`, rejects ambiguous inputs such as
   `codex`, and makes `/loopx <task>` activate or gate the correct host loop
   after todo writeback.
+- `v0.1.9` on 2026-07-05 21:45 +08:00: real auto-research and agent-scoped
+  evidence release at the matching `v0.1.9` tag. This release removes fake
+  auto-research demo metrics, makes the KNN preset use a real benchmark
+  workspace with public-safe evidence writeback, exposes role-named visible
+  research panes, wires agent-scoped evidence read hints into replan, and
+  hardens successor/frontier recovery when completed advancement has no next
+  executable todo.
 
 When a new public release is promoted, add it here only after the matching tag,
 release note, stable ref, update path, and focused release canary agree.

--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.1.8"
+version = "0.1.9"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Prepare the LoopX v0.1.9 release from the current `main` head.

Changes since v0.1.8 are grouped around five release themes:

- real auto-research UX: removed fake demo metrics, kept user/auto-research surfaces thin, added explicit KNN preset support, role-named visible panes, and real benchmark workspace/evidence writeback;
- agent-scoped evidence and replan: added the evidence-log protocol/CLI/read hints, wired required reads into replan, and fixed completed advancement frontiers that had no successor todo;
- bounded control-plane read models: moved quota/status/todo/scheduler/runtime/public-safety/projection seams into `loopx/control_plane/*` with focused smokes;
- Codex CLI and benchmark route reliability: hardened CLI goal startup, rate-limit/countability handling, app-goal setup, host-local SkillsBench fixtures, and post-bridge blocker classification;
- release/canary hardening: added premerge canary gates, release-safe namespace checks, and broader public-boundary/install/update coverage.

## Validation

- `python3 -m py_compile loopx/*.py`
- `python3 examples/release/release-version-contract-smoke.py`
- `python3 examples/release/release-readiness-doc-smoke.py`
- `python3 examples/release/codex-cli-no-clone-release-verification-smoke.py`
- `python3 examples/fresh-clone-quickstart-smoke.py`
- `python3 examples/loopx-update-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli check --scan-path README.md --scan-path docs/ --scan-path examples/`
- `python3 examples/canary/canary-promotion-readiness-smoke.py --no-write-evidence`
- `PYTHONPATH=. python3 -m loopx.cli canary premerge --from-git-diff`

Notes:

- public/private scan was clean for the release files and public docs/examples scan;
- global run-history duplicate-index warning is pre-existing local state, not from this release diff;
- dashboard canary path was explicitly skipped because local npm dashboard dependencies are unavailable, while the release canary still passed under its default dashboard `auto` policy.
