### PR TITLE
Move subagent compaction defaults into agents read model

### DIFF
--- a/loopx/control_plane/agents/subagent_activity.py
+++ b/loopx/control_plane/agents/subagent_activity.py
@@ -2,6 +2,11 @@ from __future__ import annotations
 
 from typing import Any, Callable, Optional
 
+from ..runtime.public_safety import (
+    public_safe_compact_list as _default_public_safe_compact_list,
+    public_safe_compact_text as _default_public_safe_compact_text,
+)
+
 
 MAX_SUBAGENT_ACTIVITY_ITEMS = 5
 
@@ -12,7 +17,7 @@ PublicSafeList = Callable[..., list[str]]
 def subagent_state(
     run: dict[str, Any],
     *,
-    public_safe_compact_text: PublicSafeText,
+    public_safe_compact_text: PublicSafeText = _default_public_safe_compact_text,
 ) -> str | None:
     for field in ("result_status", "state", "status", "classification"):
         value = public_safe_compact_text(run.get(field), limit=80)
@@ -43,8 +48,8 @@ def compact_subagent_run(
     *,
     parent_goal_id: str | None = None,
     parent_run_id: str | None = None,
-    public_safe_compact_text: PublicSafeText,
-    public_safe_compact_list: PublicSafeList,
+    public_safe_compact_text: PublicSafeText = _default_public_safe_compact_text,
+    public_safe_compact_list: PublicSafeList = _default_public_safe_compact_list,
 ) -> dict[str, Any] | None:
     if not isinstance(raw, dict):
         return None
@@ -98,8 +103,8 @@ def compact_subagent_run(
 def subagent_activity_for_goal(
     goal: dict[str, Any],
     *,
-    public_safe_compact_text: PublicSafeText,
-    public_safe_compact_list: PublicSafeList,
+    public_safe_compact_text: PublicSafeText = _default_public_safe_compact_text,
+    public_safe_compact_list: PublicSafeList = _default_public_safe_compact_list,
 ) -> dict[str, Any] | None:
     if not isinstance(goal, dict):
         return None

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -238,10 +238,8 @@ from .control_plane.runtime.session_runtime import (
 )
 from .control_plane.agents.subagent_activity import (
     MAX_SUBAGENT_ACTIVITY_ITEMS,
-    compact_subagent_run as _compact_subagent_run_read_model,
-    subagent_activity_for_goal as _subagent_activity_for_goal_read_model,
-    subagent_quota_spend as _subagent_quota_spend_read_model,
-    subagent_state as _subagent_state_read_model,
+    compact_subagent_run,
+    subagent_activity_for_goal,
 )
 from .control_plane.runtime.stale_latest_run import (
     stale_latest_run_projection_warning as _stale_latest_run_projection_warning_read_model,
@@ -6017,40 +6015,6 @@ def build_attention_queue_projection(
         autonomous_backlog_candidates=autonomous_backlog_candidates,
         autonomous_monitor_candidates=autonomous_monitor_candidates,
         monitor_signal_waiting_on=MONITOR_SIGNAL_WAITING_ON,
-    )
-
-
-def _subagent_state(run: dict[str, Any]) -> str | None:
-    return _subagent_state_read_model(
-        run,
-        public_safe_compact_text=public_safe_compact_text,
-    )
-
-
-def _subagent_quota_spend(run: dict[str, Any]) -> int:
-    return _subagent_quota_spend_read_model(run)
-
-
-def compact_subagent_run(
-    raw: dict[str, Any],
-    *,
-    parent_goal_id: str | None = None,
-    parent_run_id: str | None = None,
-) -> dict[str, Any] | None:
-    return _compact_subagent_run_read_model(
-        raw,
-        parent_goal_id=parent_goal_id,
-        parent_run_id=parent_run_id,
-        public_safe_compact_text=public_safe_compact_text,
-        public_safe_compact_list=public_safe_compact_list,
-    )
-
-
-def subagent_activity_for_goal(goal: dict[str, Any]) -> dict[str, Any] | None:
-    return _subagent_activity_for_goal_read_model(
-        goal,
-        public_safe_compact_text=public_safe_compact_text,
-        public_safe_compact_list=public_safe_compact_list,
     )
 
 


### PR DESCRIPTION
## Summary
- move public-safe compaction defaults into `control_plane/agents/subagent_activity.py`
- delete the `status.py` subagent wrapper functions that only injected those defaults
- keep the public status API names by importing the bounded-context functions directly

## Validation
- `python3 -m py_compile loopx/status.py loopx/control_plane/agents/subagent_activity.py loopx/control_plane/runtime/run_compaction.py loopx/control_plane/runtime/run_history.py`
- `python3 examples/control_plane/run-compaction-readmodel-smoke.py`
- `python3 examples/control_plane/run-history-readmodel-smoke.py`
- `python3 examples/project/subagent-status-projection-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 examples/control_plane/public-safety-readmodel-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py --max-seconds 120`
- `git diff --check`
- added-line public/private boundary scan
- `loopx canary premerge --from-git-diff` passed with 8 catalog canaries, 8 risk-profile smokes, 0 failures, 0 advisory failures, 0 manual holds

## Self-Merge Fit
This is a narrow cleanup on the control-plane agents/status read path. It removes unused wrapper code, does not change benchmark scoring/runner behavior, permissions, public docs, or evidence policy, and has risk-based premerge coverage.
