### PR TITLE
docs: require Chinese release summary

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -267,6 +267,11 @@ Every public release note or update note should answer:
 - Which surfaces are still experimental or intentionally excluded?
 - Did the public/private scan run on the changed docs, examples, and workflow
   files?
+- For Chinese-speaking operators, include a compact `## 中文摘要` section that
+  mirrors the release highlights in neutral product language. Keep it shorter
+  than the full English notes, avoid overfitting the release to one feature
+  area, and name both the user-visible improvement and the control-plane
+  reliability work when both shipped.
 
 The note should link to durable docs or PRs when useful, but public git history
 and shipped CLI behavior remain the source of truth.

--- a/examples/release/release-readiness-doc-smoke.py
+++ b/examples/release/release-readiness-doc-smoke.py
@@ -76,6 +76,8 @@ def main() -> None:
         "benchmark runner behavior, scoring, upload",
         "## Release Note Checklist",
         "public/private scan",
+        "## 中文摘要",
+        "avoid overfitting the release to one feature area",
     ]:
         assert_contains(doc, required, "release-readiness doc")
 


### PR DESCRIPTION
## Summary

Make the release-note checklist require a compact `## 中文摘要` section for Chinese-speaking operators.

This also keeps the release-readiness doc smoke pinned to the new expectation so future release notes do not lose the section by accident.

## Validation

- `python3 examples/release/release-readiness-doc-smoke.py`
- `python3 -m py_compile examples/release/release-readiness-doc-smoke.py`
- `git diff --check`
- `PYTHONPATH=. python3 -m loopx.cli canary premerge --from-git-diff`

## Notes

The rule explicitly asks for neutral product language and warns against overfitting release notes to one feature area.
