### PR TITLE
Summarize premerge validation coverage

### DIFF
--- a/examples/canary/premerge-validation-gate-smoke.py
+++ b/examples/canary/premerge-validation-gate-smoke.py
@@ -48,6 +48,12 @@ def assert_control_plane_change_selects_state_machine_validation() -> None:
     assert "canary-runner" in classification["risk_profiles"], payload
     catalog_commands = commands_from(payload["catalog_run"])
     risk_commands = commands_from(payload["risk_profile_run"])
+    summary = payload["validation_summary"]
+    assert summary["schema_version"] == "premerge_validation_summary_v0", payload
+    assert summary["selected_check_count"] >= len(catalog_commands), payload
+    assert "python3 examples/control_plane/interaction-contract-state-machine-smoke.py" in (
+        summary["selected_commands"]
+    ), payload
     assert any("interaction-contract-state-machine-smoke.py" in item for item in catalog_commands), payload
     assert any("control-plane-integrated-canary-smoke.py" in item for item in catalog_commands), payload
     assert any("bounded-context-namespace-smoke.py" in item for item in catalog_commands), payload
@@ -120,6 +126,17 @@ def assert_cli_json_preview() -> None:
     payload = json.loads(completed.stdout)
     assert payload["schema_version"] == "loopx_premerge_validation_gate_v0", payload
     assert payload["gate"]["status"] == "preview_only", payload
+    summary = payload["validation_summary"]
+    assert summary["schema_version"] == "premerge_validation_summary_v0", payload
+    assert summary["direct_check_count"] >= 4, payload
+    assert any("git diff --check" in command for command in summary["direct_commands"]), payload
+    assert "python3 examples/canary/premerge-validation-gate-smoke.py" in (
+        summary["selected_commands"]
+    ), payload
+    assert len(summary["all_commands"]) >= len(summary["direct_commands"]) + len(
+        summary["selected_commands"]
+    ), payload
+    assert summary["failed_commands"] == [], payload
     selector_sources = payload.get("selector_sources")
     assert selector_sources is None or isinstance(selector_sources, dict), payload
 

--- a/loopx/canary/premerge.py
+++ b/loopx/canary/premerge.py
@@ -11,6 +11,7 @@ from .runner import build_canary_smoke_suite_run
 
 
 PREMERGE_GATE_SCHEMA_VERSION = "loopx_premerge_validation_gate_v0"
+PREMERGE_VALIDATION_SUMMARY_SCHEMA_VERSION = "premerge_validation_summary_v0"
 
 PREMERGE_TIERS = {"quick", "standard", "deep"}
 
@@ -326,6 +327,90 @@ def _gate_status(
     }
 
 
+def _check_command(check: dict[str, Any]) -> str:
+    normalized = (
+        check.get("normalized")
+        if isinstance(check.get("normalized"), dict)
+        else {}
+    )
+    display_argv = normalized.get("display_argv")
+    if isinstance(display_argv, list) and display_argv:
+        return " ".join(str(part) for part in display_argv)
+    return str(check.get("command") or "")
+
+
+def _run_summary(run: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(run, dict):
+        return None
+    selected_checks = [
+        check for check in run.get("selected_checks", [])
+        if isinstance(check, dict)
+    ]
+    executed_checks = [
+        check for check in selected_checks
+        if str(check.get("status") or "") not in {"", "ready", "skipped"}
+    ]
+    failures = [check for check in selected_checks if check.get("ok") is False]
+    return {
+        "ok": bool(run.get("ok")),
+        "selected_check_count": int(run.get("selected_check_count") or len(selected_checks)),
+        "executed_check_count": int(run.get("executed_check_count") or len(executed_checks)),
+        "failure_count": int(run.get("failure_count") or len(failures)),
+        "warning_count": int(run.get("warning_count") or 0),
+        "advisory_failure_count": int(run.get("advisory_failure_count") or 0),
+        "selected_commands": [_check_command(check) for check in selected_checks],
+        "failed_commands": [_check_command(check) for check in failures],
+    }
+
+
+def build_validation_summary(
+    *,
+    direct_checks: list[dict[str, Any]],
+    catalog_run: dict[str, Any],
+    risk_profile_run: dict[str, Any] | None,
+    boundary_run: dict[str, Any] | None,
+) -> dict[str, Any]:
+    direct_failures = [check for check in direct_checks if check.get("ok") is False]
+    direct_commands = [str(check.get("command") or "") for check in direct_checks]
+    run_summaries = {
+        "catalog_run": _run_summary(catalog_run),
+        "risk_profile_run": _run_summary(risk_profile_run),
+        "boundary_run": _run_summary(boundary_run),
+    }
+    active_run_summaries = [
+        summary for summary in run_summaries.values()
+        if isinstance(summary, dict)
+    ]
+    selected_commands: list[str] = []
+    failed_commands: list[str] = []
+    for summary in active_run_summaries:
+        selected_commands.extend(summary["selected_commands"])
+        failed_commands.extend(summary["failed_commands"])
+    failed_commands.extend(str(check.get("command") or "") for check in direct_failures)
+    return {
+        "schema_version": PREMERGE_VALIDATION_SUMMARY_SCHEMA_VERSION,
+        "direct_check_count": len(direct_checks),
+        "direct_failure_count": len(direct_failures),
+        "selected_check_count": sum(
+            int(summary["selected_check_count"]) for summary in active_run_summaries
+        ),
+        "executed_check_count": sum(
+            int(summary["executed_check_count"]) for summary in active_run_summaries
+        ),
+        "failure_count": len(direct_failures)
+        + sum(int(summary["failure_count"]) for summary in active_run_summaries),
+        "warning_count": sum(int(summary["warning_count"]) for summary in active_run_summaries),
+        "advisory_failure_count": sum(
+            int(summary["advisory_failure_count"]) for summary in active_run_summaries
+        ),
+        "direct_commands": [command for command in direct_commands if command],
+        "selected_commands": selected_commands,
+        "all_commands": [command for command in [*direct_commands, *selected_commands] if command],
+        "failed_commands": [command for command in failed_commands if command],
+        "runs": run_summaries,
+    }
+
+
 def _recompute_smoke_run_status(run: dict[str, Any]) -> None:
     results = [
         item for item in run.get("selected_checks", [])
@@ -482,6 +567,12 @@ def build_premerge_validation_gate(
         boundary_run=boundary_run,
         manual_holds=list(classification["manual_holds"]),
     )
+    validation_summary = build_validation_summary(
+        direct_checks=direct_checks,
+        catalog_run=catalog_run,
+        risk_profile_run=risk_profile_run,
+        boundary_run=boundary_run,
+    )
     ok = gate["status"] in {"passed", "no_changes"} or (
         not execute and gate["status"] in {"preview_only", "manual_review_required", "no_changes"}
     )
@@ -501,6 +592,7 @@ def build_premerge_validation_gate(
         "catalog_run": catalog_run,
         "risk_profile_run": risk_profile_run,
         "boundary_run": boundary_run,
+        "validation_summary": validation_summary,
         "gate": gate,
         "recommended_pr_comment_fields": [
             "changed_surfaces",


### PR DESCRIPTION
## Summary
- add a top-level `validation_summary` read model to `loopx canary premerge` JSON
- summarize direct hygiene checks plus catalog, risk-profile, and boundary canary runs in one stable contract
- expose direct, selected, all, and failed commands so PR merge/self-merge tooling does not need to understand nested run internals

## Validation
- `python3 examples/canary/premerge-validation-gate-smoke.py`
- `python3 -m py_compile loopx/canary/premerge.py examples/canary/premerge-validation-gate-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli --format json canary premerge --changed-file loopx/canary/premerge.py --no-execute`
- `python3 examples/canary/catalog-planner-smoke.py`
- `python3 examples/canary/catalog-run-e2e-smoke.py`
- `python3 examples/canary/smoke-suite-runner-smoke.py`
- `git diff --check`
- `loopx canary premerge --from-git-diff` passed: direct 4, selected 16, executed 16, all_commands 20, failures 0, warnings 0

## Boundary
- Public-safe canary/premerge interface change only. No benchmark raw logs, task text, trajectories, verifier output, credentials, or local private paths included.
