### PR TITLE
Refactor control-plane canary fixture harness

### DIFF
--- a/examples/control_plane/control-plane-integrated-canary-smoke.py
+++ b/examples/control_plane/control-plane-integrated-canary-smoke.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import subprocess
 import sys
 import tempfile
 import time
@@ -23,6 +22,11 @@ from loopx.event_sourced_state import (  # noqa: E402
     TODO_CLAIMED,
     TODO_COMPLETED,
     make_state_event,
+)
+from loopx.control_plane.testing.canary_harness import (  # noqa: E402
+    read_run_index,
+    run_json_cli,
+    write_fixture_registry,
 )
 
 
@@ -62,49 +66,19 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
         "task_class=advancement_task action_kind=stale_markdown -->\n",
         encoding="utf-8",
     )
-    registry_path.parent.mkdir(parents=True)
-    registry_path.write_text(
-        json.dumps(
-            {
-                "schema_version": 1,
-                "updated_at": "2026-06-27T00:00:00+00:00",
-                "common_runtime_root": str(runtime),
-                "goals": [
-                    {
-                        "id": GOAL_ID,
-                        "domain": "control-plane-canary",
-                        "status": "active",
-                        "repo": str(project),
-                        "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
-                        "state_event_log": f".codex/goals/{GOAL_ID}/events.jsonl",
-                        "adapter": {
-                            "kind": "generic_project_goal_v0",
-                            "status": "connected",
-                        },
-                        "quota": {
-                            "compute": 1.0,
-                            "window_hours": 24,
-                            "slot_minutes": 1,
-                            "allowed_slots": 10,
-                        },
-                        "coordination": {
-                            "registered_agents": [PRIMARY_AGENT_ID, AGENT_ID],
-                            "primary_agent": PRIMARY_AGENT_ID,
-                        },
-                        "workspace_guard_policy": {
-                            "side_agent_independent_worktree_required": False,
-                        },
-                        "authority_sources": [],
-                    }
-                ],
-            },
-            ensure_ascii=False,
-            indent=2,
-        )
-        + "\n",
-        encoding="utf-8",
+    write_fixture_registry(
+        project=project,
+        runtime_root=runtime,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        domain="control-plane-canary",
+        adapter_kind="generic_project_goal_v0",
+        state_event_log=f".codex/goals/{GOAL_ID}/events.jsonl",
+        registered_agents=[PRIMARY_AGENT_ID, AGENT_ID],
+        primary_agent=PRIMARY_AGENT_ID,
+        quota_allowed_slots=10,
+        side_agent_independent_worktree_required=False,
     )
-    runtime.mkdir(parents=True, exist_ok=True)
     return registry_path, state_file, event_log
 
 
@@ -128,45 +102,17 @@ def write_monitor_fixture(root: Path) -> tuple[Path, Path]:
         "cadence=5m next_due_at=2000-01-01T00:00:00+00:00 -->\n",
         encoding="utf-8",
     )
-    registry_path.parent.mkdir(parents=True)
-    registry_path.write_text(
-        json.dumps(
-            {
-                "schema_version": 1,
-                "updated_at": "2026-06-27T00:00:00+00:00",
-                "common_runtime_root": str(runtime),
-                "goals": [
-                    {
-                        "id": MONITOR_GOAL_ID,
-                        "domain": "control-plane-canary",
-                        "status": "active",
-                        "repo": str(project),
-                        "state_file": f".codex/goals/{MONITOR_GOAL_ID}/ACTIVE_GOAL_STATE.md",
-                        "adapter": {
-                            "kind": "generic_project_goal_v0",
-                            "status": "connected",
-                        },
-                        "quota": {
-                            "compute": 1.0,
-                            "window_hours": 24,
-                            "slot_minutes": 1,
-                            "allowed_slots": 10,
-                        },
-                        "coordination": {
-                            "registered_agents": [AGENT_ID],
-                            "primary_agent": AGENT_ID,
-                        },
-                        "authority_sources": [],
-                    }
-                ],
-            },
-            ensure_ascii=False,
-            indent=2,
-        )
-        + "\n",
-        encoding="utf-8",
+    write_fixture_registry(
+        project=project,
+        runtime_root=runtime,
+        registry_path=registry_path,
+        goal_id=MONITOR_GOAL_ID,
+        domain="control-plane-canary",
+        adapter_kind="generic_project_goal_v0",
+        registered_agents=[AGENT_ID],
+        primary_agent=AGENT_ID,
+        quota_allowed_slots=10,
     )
-    runtime.mkdir(parents=True, exist_ok=True)
     return registry_path, runtime
 
 
@@ -190,48 +136,18 @@ def write_markdown_continuation_fixture(root: Path) -> tuple[Path, Path, Path]:
         "task_class=advancement_task action_kind=stale_markdown -->\n",
         encoding="utf-8",
     )
-    registry_path.parent.mkdir(parents=True)
-    registry_path.write_text(
-        json.dumps(
-            {
-                "schema_version": 1,
-                "updated_at": "2026-06-27T00:00:00+00:00",
-                "common_runtime_root": str(runtime),
-                "goals": [
-                    {
-                        "id": MARKDOWN_GOAL_ID,
-                        "domain": "control-plane-canary",
-                        "status": "active",
-                        "repo": str(project),
-                        "state_file": f".codex/goals/{MARKDOWN_GOAL_ID}/ACTIVE_GOAL_STATE.md",
-                        "adapter": {
-                            "kind": "generic_project_goal_v0",
-                            "status": "connected",
-                        },
-                        "quota": {
-                            "compute": 1.0,
-                            "window_hours": 24,
-                            "slot_minutes": 1,
-                            "allowed_slots": 10,
-                        },
-                        "coordination": {
-                            "registered_agents": [PRIMARY_AGENT_ID, AGENT_ID],
-                            "primary_agent": PRIMARY_AGENT_ID,
-                        },
-                        "workspace_guard_policy": {
-                            "side_agent_independent_worktree_required": False,
-                        },
-                        "authority_sources": [],
-                    }
-                ],
-            },
-            ensure_ascii=False,
-            indent=2,
-        )
-        + "\n",
-        encoding="utf-8",
+    write_fixture_registry(
+        project=project,
+        runtime_root=runtime,
+        registry_path=registry_path,
+        goal_id=MARKDOWN_GOAL_ID,
+        domain="control-plane-canary",
+        adapter_kind="generic_project_goal_v0",
+        registered_agents=[PRIMARY_AGENT_ID, AGENT_ID],
+        primary_agent=PRIMARY_AGENT_ID,
+        quota_allowed_slots=10,
+        side_agent_independent_worktree_required=False,
     )
-    runtime.mkdir(parents=True, exist_ok=True)
     return registry_path, runtime, project
 
 
@@ -296,25 +212,13 @@ def append_event_todos(event_log: Path) -> None:
 
 
 def run_cli(registry_path: Path, runtime_root: Path, *args: str) -> dict[str, Any]:
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "loopx.cli",
-            "--registry",
-            str(registry_path),
-            "--runtime-root",
-            str(runtime_root),
-            "--format",
-            "json",
-            *args,
-        ],
+    return run_json_cli(
+        *args,
+        registry_path=registry_path,
+        runtime_root=runtime_root,
         cwd=REPO_ROOT,
-        check=True,
-        text=True,
-        capture_output=True,
+        include_returncode=False,
     )
-    return json.loads(result.stdout)
 
 
 def find_queue_item(status_payload: dict[str, Any], *, goal_id: str = GOAL_ID) -> dict[str, Any]:
@@ -346,17 +250,6 @@ def assert_event_projected_agent_todo(summary: dict[str, Any]) -> None:
     assert item["claimed_by"] == AGENT_ID, summary
     assert item["task_class"] == "advancement_task", summary
     assert "todo_markdown_fallback" not in json.dumps(summary, sort_keys=True), summary
-
-
-def read_run_index(runtime_root: Path) -> list[dict[str, Any]]:
-    index_path = runtime_root / "goals" / GOAL_ID / "runs" / "index.jsonl"
-    if not index_path.exists():
-        return []
-    return [
-        json.loads(line)
-        for line in index_path.read_text(encoding="utf-8").splitlines()
-        if line.strip()
-    ]
 
 
 def assert_bounded_delivery_state_machine_bundle(quota_payload: dict[str, Any]) -> None:
@@ -583,7 +476,7 @@ def assert_refresh_and_spend_state_machine(registry_path: Path, runtime_root: Pa
     assert refresh_payload["delivery_outcome"] == "outcome_progress", refresh_payload
 
     matching_runs = [
-        run for run in read_run_index(runtime_root)
+        run for run in read_run_index(runtime_root, GOAL_ID)
         if run.get("classification") == VALIDATED_PROGRESS_CLASSIFICATION
     ]
     assert len(matching_runs) == 1, matching_runs

--- a/examples/control_plane/side-agent-self-iteration-state-machine-smoke.py
+++ b/examples/control_plane/side-agent-self-iteration-state-machine-smoke.py
@@ -3,14 +3,21 @@
 
 from __future__ import annotations
 
-import json
-import subprocess
 import sys
 import tempfile
 from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.testing.canary_harness import (  # noqa: E402
+    run_json_cli,
+    write_fixture_registry,
+)
+
+
 GOAL_ID = "side-agent-self-iteration-fixture"
 AGENT_ID = "codex-product-capability"
 PRIMARY_AGENT_ID = "codex-main-control"
@@ -32,32 +39,12 @@ def run_cli(
     registry_path: Path,
     runtime: Path,
 ) -> dict:
-    command = [
-        sys.executable,
-        "-m",
-        "loopx.cli",
-        "--registry",
-        str(registry_path),
-        "--runtime-root",
-        str(runtime),
-        "--format",
-        "json",
+    return run_json_cli(
         *args,
-    ]
-    result = subprocess.run(
-        command,
+        registry_path=registry_path,
+        runtime_root=runtime,
         cwd=REPO_ROOT,
-        check=False,
-        capture_output=True,
-        text=True,
     )
-    if result.returncode != 0:
-        raise AssertionError(result.stdout + result.stderr)
-    if not result.stdout.strip():
-        raise AssertionError(f"empty CLI output for {command!r}: {result.stderr}")
-    payload = json.loads(result.stdout)
-    payload["_returncode"] = result.returncode
-    return payload
 
 
 def write_registry(
@@ -67,45 +54,18 @@ def write_registry(
     registry_path: Path,
     adapter_kind: str,
 ) -> None:
-    registry_path.parent.mkdir(parents=True)
-    registry_path.write_text(
-        json.dumps(
-            {
-                "schema_version": "0.1",
-                "updated_at": "2026-01-01T00:00:00+00:00",
-                "common_runtime_root": str(runtime),
-                "goals": [
-                    {
-                        "id": GOAL_ID,
-                        "domain": "side-agent-self-iteration-fixture",
-                        "status": "active",
-                        "repo": str(project),
-                        "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
-                        "adapter": {
-                            "kind": adapter_kind,
-                            "status": "connected-read-only",
-                        },
-                        "authority_sources": [],
-                        "quota": {
-                            "compute": 1.0,
-                            "window_hours": 24,
-                            "allowed_slots": 5,
-                        },
-                        "coordination": {
-                            "registered_agents": [PRIMARY_AGENT_ID, AGENT_ID],
-                            "primary_agent": PRIMARY_AGENT_ID,
-                        },
-                        "workspace_guard_policy": {
-                            "side_agent_independent_worktree_required": False,
-                        },
-                    }
-                ],
-            },
-            indent=2,
-            sort_keys=True,
-        )
-        + "\n",
-        encoding="utf-8",
+    write_fixture_registry(
+        project=project,
+        runtime_root=runtime,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        domain="side-agent-self-iteration-fixture",
+        adapter_kind=adapter_kind,
+        adapter_status="connected-read-only",
+        registered_agents=[PRIMARY_AGENT_ID, AGENT_ID],
+        primary_agent=PRIMARY_AGENT_ID,
+        quota_allowed_slots=5,
+        side_agent_independent_worktree_required=False,
     )
 
 

--- a/loopx/control_plane/testing/__init__.py
+++ b/loopx/control_plane/testing/__init__.py
@@ -1,0 +1,1 @@
+"""Public control-plane test helpers."""

--- a/loopx/control_plane/testing/canary_harness.py
+++ b/loopx/control_plane/testing/canary_harness.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def default_state_file(goal_id: str) -> str:
+    return f".codex/goals/{goal_id}/ACTIVE_GOAL_STATE.md"
+
+
+def project_state_path(project: Path, goal_id: str, *, state_file: str | None = None) -> Path:
+    return project / (state_file or default_state_file(goal_id))
+
+
+def run_json_cli(
+    *args: str,
+    registry_path: Path,
+    runtime_root: Path,
+    cwd: Path | None = None,
+    include_returncode: bool = True,
+) -> dict[str, Any]:
+    command = [
+        sys.executable,
+        "-m",
+        "loopx.cli",
+        "--registry",
+        str(registry_path),
+        "--runtime-root",
+        str(runtime_root),
+        "--format",
+        "json",
+        *args,
+    ]
+    result = subprocess.run(
+        command,
+        cwd=cwd or REPO_ROOT,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if result.returncode != 0:
+        raise AssertionError(result.stdout + result.stderr)
+    if not result.stdout.strip():
+        raise AssertionError(f"empty CLI output for {command!r}: {result.stderr}")
+    payload = json.loads(result.stdout)
+    if not isinstance(payload, dict):
+        raise AssertionError(f"expected JSON object for {command!r}: {payload!r}")
+    if include_returncode:
+        payload["_returncode"] = result.returncode
+    return payload
+
+
+def write_fixture_registry(
+    *,
+    project: Path,
+    runtime_root: Path,
+    registry_path: Path,
+    goal_id: str,
+    domain: str,
+    adapter_kind: str,
+    adapter_status: str = "connected",
+    status: str = "active",
+    state_file: str | None = None,
+    state_event_log: str | None = None,
+    registered_agents: Iterable[str] = (),
+    primary_agent: str | None = None,
+    quota_allowed_slots: int = 10,
+    side_agent_independent_worktree_required: bool | None = None,
+    extra_goal_fields: dict[str, Any] | None = None,
+) -> Path:
+    state_file_value = state_file or default_state_file(goal_id)
+    agents = list(registered_agents)
+    coordination: dict[str, Any] = {"registered_agents": agents}
+    if primary_agent:
+        coordination["primary_agent"] = primary_agent
+    elif agents:
+        coordination["primary_agent"] = agents[0]
+
+    goal: dict[str, Any] = {
+        "id": goal_id,
+        "domain": domain,
+        "status": status,
+        "repo": str(project),
+        "state_file": state_file_value,
+        "adapter": {
+            "kind": adapter_kind,
+            "status": adapter_status,
+        },
+        "quota": {
+            "compute": 1.0,
+            "window_hours": 24,
+            "slot_minutes": 1,
+            "allowed_slots": quota_allowed_slots,
+        },
+        "coordination": coordination,
+        "authority_sources": [],
+    }
+    if state_event_log:
+        goal["state_event_log"] = state_event_log
+    if side_agent_independent_worktree_required is not None:
+        goal["workspace_guard_policy"] = {
+            "side_agent_independent_worktree_required": side_agent_independent_worktree_required,
+        }
+    if extra_goal_fields:
+        goal.update(extra_goal_fields)
+
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    runtime_root.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime_root),
+                "goals": [goal],
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path
+
+
+def read_run_index(runtime_root: Path, goal_id: str) -> list[dict[str, Any]]:
+    index_path = runtime_root / "goals" / goal_id / "runs" / "index.jsonl"
+    if not index_path.exists():
+        return []
+    return [
+        json.loads(line)
+        for line in index_path.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]


### PR DESCRIPTION
## Summary

- Add a narrow `loopx.control_plane.testing.canary_harness` for public control-plane canary fixtures.
- Refactor integrated and side-agent self-iteration state-machine canaries to reuse the harness for registry writing, JSON CLI invocation, and run-index reads.
- Preserve the existing state-machine assertions while reducing duplicated fixture/CLI glue.

## Validation

- `python3 -m py_compile loopx/control_plane/testing/canary_harness.py examples/control_plane/control-plane-integrated-canary-smoke.py examples/control_plane/side-agent-self-iteration-state-machine-smoke.py`
- `python3 examples/control_plane/side-agent-self-iteration-state-machine-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `python3 examples/control_plane/interaction-contract-state-machine-smoke.py`
- `python3 examples/control_plane/quota-scheduler-state-ack-smoke.py`
- `python3 examples/control_plane/hot-path-interface-budget-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `git diff --check`
- `git diff --cached --check`
- `loopx --format json check --scan-path examples/control_plane/control-plane-integrated-canary-smoke.py --scan-path examples/control_plane/side-agent-self-iteration-state-machine-smoke.py --scan-path loopx/control_plane/testing`
- `loopx canary premerge --from-git-diff`
