### PR TITLE
Reuse canary harness in todo lifecycle smoke

### DIFF
--- a/examples/control_plane/todo-lifecycle-cli-smoke.py
+++ b/examples/control_plane/todo-lifecycle-cli-smoke.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 import json
-import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -14,6 +13,12 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from loopx.control_plane.testing.canary_harness import (  # noqa: E402
+    run_json_cli,
+    run_json_cli_result,
+    runtime_root_from_registry,
+    write_fixture_registry,
+)
 from loopx.status import parse_active_state_todos  # noqa: E402
 
 
@@ -51,77 +56,39 @@ def write_fixture(root: Path) -> tuple[Path, Path]:
         "- [ ] Legacy monitor-only placeholder.\n",
         encoding="utf-8",
     )
-    registry_path.parent.mkdir(parents=True)
-    registry_path.write_text(
-        json.dumps(
-            {
-                "schema_version": 1,
-                "updated_at": "2026-01-01T00:00:00+00:00",
-                "common_runtime_root": str(runtime),
-                "goals": [
-                    {
-                        "id": GOAL_ID,
-                        "domain": "todo-lifecycle-fixture",
-                        "status": "active",
-                        "repo": str(project),
-                        "state_file": ".codex/goals/todo-lifecycle-goal/ACTIVE_GOAL_STATE.md",
-                        "adapter": {"kind": "generic_project_goal_v0", "status": "connected"},
-                        "authority_sources": [],
-                        "coordination": {
-                            "registered_agents": ["codex-main-control", "codex-side-bypass"],
-                            "primary_agent": "codex-main-control",
-                        },
-                    }
-                ],
-            },
-            ensure_ascii=False,
-            indent=2,
-        )
-        + "\n",
-        encoding="utf-8",
+    write_fixture_registry(
+        project=project,
+        runtime_root=runtime,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        domain="todo-lifecycle-fixture",
+        adapter_kind="generic_project_goal_v0",
+        registered_agents=["codex-main-control", "codex-side-bypass"],
+        primary_agent="codex-main-control",
+        quota_allowed_slots=None,
     )
     return registry_path, state_file
 
 
 def run_cli(registry_path: Path, *args: str) -> dict:
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "loopx.cli",
-            "--registry",
-            str(registry_path),
-            "--format",
-            "json",
-            *args,
-        ],
+    return run_json_cli(
+        *args,
+        registry_path=registry_path,
+        runtime_root=runtime_root_from_registry(registry_path),
         cwd=REPO_ROOT,
-        check=True,
-        text=True,
-        capture_output=True,
+        include_returncode=False,
     )
-    return json.loads(result.stdout)
 
 
 def run_cli_error(registry_path: Path, *args: str) -> dict:
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "loopx.cli",
-            "--registry",
-            str(registry_path),
-            "--format",
-            "json",
-            *args,
-        ],
+    returncode, payload = run_json_cli_result(
+        *args,
+        registry_path=registry_path,
+        runtime_root=runtime_root_from_registry(registry_path),
         cwd=REPO_ROOT,
-        check=False,
-        text=True,
-        capture_output=True,
     )
-    assert result.returncode == 1, result.stdout + result.stderr
-    return json.loads(result.stdout)
+    assert returncode == 1, payload
+    return payload
 
 
 def parsed_items(state_file: Path) -> list[dict]:

--- a/loopx/control_plane/testing/canary_harness.py
+++ b/loopx/control_plane/testing/canary_harness.py
@@ -21,7 +21,7 @@ def project_state_path(project: Path, goal_id: str, *, state_file: str | None = 
 def run_json_cli(
     *args: str,
     registry_path: Path,
-    runtime_root: Path,
+    runtime_root: Path | None = None,
     cwd: Path | None = None,
     include_returncode: bool = True,
 ) -> dict[str, Any]:
@@ -31,12 +31,12 @@ def run_json_cli(
         "loopx.cli",
         "--registry",
         str(registry_path),
-        "--runtime-root",
-        str(runtime_root),
         "--format",
         "json",
         *args,
     ]
+    if runtime_root is not None:
+        command[5:5] = ["--runtime-root", str(runtime_root)]
     result = subprocess.run(
         command,
         cwd=cwd or REPO_ROOT,
@@ -56,6 +56,46 @@ def run_json_cli(
     return payload
 
 
+def run_json_cli_result(
+    *args: str,
+    registry_path: Path,
+    runtime_root: Path | None = None,
+    cwd: Path | None = None,
+) -> tuple[int, dict[str, Any]]:
+    command = [
+        sys.executable,
+        "-m",
+        "loopx.cli",
+        "--registry",
+        str(registry_path),
+        "--format",
+        "json",
+        *args,
+    ]
+    if runtime_root is not None:
+        command[5:5] = ["--runtime-root", str(runtime_root)]
+    result = subprocess.run(
+        command,
+        cwd=cwd or REPO_ROOT,
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if not result.stdout.strip():
+        raise AssertionError(f"empty CLI output for {command!r}: {result.stderr}")
+    payload = json.loads(result.stdout)
+    if not isinstance(payload, dict):
+        raise AssertionError(f"expected JSON object for {command!r}: {payload!r}")
+    payload["_returncode"] = result.returncode
+    return result.returncode, payload
+
+
+def runtime_root_from_registry(registry_path: Path) -> Path | None:
+    payload = json.loads(registry_path.read_text(encoding="utf-8"))
+    runtime_root = payload.get("common_runtime_root") if isinstance(payload, dict) else None
+    return Path(runtime_root) if runtime_root else None
+
+
 def write_fixture_registry(
     *,
     project: Path,
@@ -70,7 +110,7 @@ def write_fixture_registry(
     state_event_log: str | None = None,
     registered_agents: Iterable[str] = (),
     primary_agent: str | None = None,
-    quota_allowed_slots: int = 10,
+    quota_allowed_slots: int | None = 10,
     side_agent_independent_worktree_required: bool | None = None,
     extra_goal_fields: dict[str, Any] | None = None,
 ) -> Path:
@@ -92,15 +132,16 @@ def write_fixture_registry(
             "kind": adapter_kind,
             "status": adapter_status,
         },
-        "quota": {
+        "coordination": coordination,
+        "authority_sources": [],
+    }
+    if quota_allowed_slots is not None:
+        goal["quota"] = {
             "compute": 1.0,
             "window_hours": 24,
             "slot_minutes": 1,
             "allowed_slots": quota_allowed_slots,
-        },
-        "coordination": coordination,
-        "authority_sources": [],
-    }
+        }
     if state_event_log:
         goal["state_event_log"] = state_event_log
     if side_agent_independent_worktree_required is not None:


### PR DESCRIPTION
## Summary
- extend the control-plane canary harness with optional runtime-root execution, JSON error-result capture, registry runtime-root lookup, and quota-free fixture registries
- migrate `todo-lifecycle-cli-smoke.py` off hand-written subprocess/registry boilerplate while preserving its todo claim/completion/successor/handoff state-machine coverage
- keep the large todo lifecycle canary focused on durable behavior instead of local CLI plumbing

## Validation
- `python3 -m py_compile loopx/control_plane/testing/canary_harness.py examples/control_plane/todo-lifecycle-cli-smoke.py`
- `python3 examples/control_plane/todo-lifecycle-cli-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `python3 examples/control_plane/side-agent-self-iteration-state-machine-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `python3 examples/control_plane/todo-contract-smoke.py`
- `git diff --check` / `git diff --cached --check`
- changed-path private/local/raw-evidence scan: clean
- `python3 -m loopx.cli --format json canary premerge --from-git-diff` passed: 4 direct checks + 16 selected canary/boundary checks, 0 failures, 0 manual holds, self-merge allowed

## Changed surfaces
- `loopx/control_plane/testing/canary_harness.py`
- `examples/control_plane/todo-lifecycle-cli-smoke.py`

## Merge posture
This is a non-benchmark control-plane canary/refactor batch. It does not change runtime todo semantics; it consolidates fixture/CLI test plumbing under the canary harness and keeps the existing todo lifecycle state-machine assertions running.