### PR TITLE
Gate auto-research role seeds by resume chain

### DIFF
--- a/examples/auto-research-knn-continuation-smoke.py
+++ b/examples/auto-research-knn-continuation-smoke.py
@@ -75,17 +75,27 @@ def main() -> int:
     assert preset["dev_eval_command"] == "bash eval.sh dev", preset
     assert preset["holdout_eval_command"] == "bash eval.sh test", preset
 
-    worker_loop = payload["worker_loop"]
-    assert worker_loop["selected_actions"] == [
+    seeded_todos = payload["visible_control_plane"]["seeded_todos"]
+    assert [todo["action_kind"] for todo in seeded_todos] == [
         "write_research_contract",
         "propose_hypothesis",
         "run_dev_eval",
-    ], worker_loop
-    evaluator_turn = next(
-        turn for turn in worker_loop["turns"] if turn["agent_id"] == "evaluator-promoter"
-    )
-    assert evaluator_turn["mode"] == "no_action", worker_loop
-    assert evaluator_turn["selected_action"] is None, worker_loop
+        "summarize_evidence",
+    ], seeded_todos
+    expected_resume = [None] + [
+        f"todo_done:{todo['todo_id']}" for todo in seeded_todos[:-1]
+    ]
+    actual_resume = [todo["resume_when"] for todo in seeded_todos]
+    assert actual_resume == expected_resume, seeded_todos
+
+    worker_loop = payload["worker_loop"]
+    assert worker_loop["selected_actions"] == ["write_research_contract"], worker_loop
+    for agent_id in ("hypothesis-proposer", "research-executor", "evaluator-promoter"):
+        waiting_turn = next(
+            turn for turn in worker_loop["turns"] if turn["agent_id"] == agent_id
+        )
+        assert waiting_turn["mode"] == "no_action", worker_loop
+        assert waiting_turn["selected_action"] is None, worker_loop
     assert all(turn.get("dev_metric") is None for turn in worker_loop["turns"]), worker_loop
     assert all(turn.get("holdout_metric") is None for turn in worker_loop["turns"]), worker_loop
 

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -35,6 +35,18 @@ VisibleLauncher = Callable[..., dict[str, object]]
 VisibleWake = Callable[[str, Sequence[str]], dict[str, object]]
 
 AUTO_RESEARCH_DEMO_E2E_SCHEMA_VERSION = "auto_research_demo_e2e_result_v0"
+AUTO_RESEARCH_SEED_ACTION_CHAIN = (
+    "write_research_contract",
+    "propose_hypothesis",
+    "run_dev_eval",
+    "summarize_evidence",
+)
+AUTO_RESEARCH_SEED_ACTION_ORDER = {
+    action: index for index, action in enumerate(AUTO_RESEARCH_SEED_ACTION_CHAIN)
+}
+AUTO_RESEARCH_SEED_PREREQUISITE_ACTION_BY_ACTION = dict(
+    zip(AUTO_RESEARCH_SEED_ACTION_CHAIN[1:], AUTO_RESEARCH_SEED_ACTION_CHAIN)
+)
 
 
 def _prepare_visible_demo_workspace_route(
@@ -170,15 +182,39 @@ def _seed_visible_demo_control_plane(
 
     seeded_todos: list[dict[str, object]] = []
     seeded_todo_ids_by_action: dict[str, str] = {}
+    seed_rows: list[tuple[str, str, str, str]] = []
     for lane in lanes:
         agent_id = str(lane.get("agent_id") or "").strip()
         role_id = str(lane.get("role_id") or "").strip()
         lane_id = str(lane.get("lane_id") or "").strip()
         action_kind = auto_research_seed_action_for_role(role_id)
+        seed_rows.append((action_kind, agent_id, role_id, lane_id))
+    seed_rows.sort(
+        key=lambda row: (
+            AUTO_RESEARCH_SEED_ACTION_ORDER.get(
+                row[0], len(AUTO_RESEARCH_SEED_ACTION_ORDER)
+            ),
+            row[1],
+        )
+    )
+    for action_kind, agent_id, role_id, lane_id in seed_rows:
         title = auto_research_seed_title(
             action_kind=action_kind,
             role_id=role_id,
             lane_id=lane_id,
+        )
+        prerequisite_action = AUTO_RESEARCH_SEED_PREREQUISITE_ACTION_BY_ACTION.get(
+            action_kind
+        )
+        prerequisite_todo_id = (
+            seeded_todo_ids_by_action.get(prerequisite_action)
+            if prerequisite_action
+            else None
+        )
+        resume_when = (
+            f"todo_done:{prerequisite_todo_id}"
+            if prerequisite_todo_id
+            else None
         )
         result = add_goal_todo(
             registry_path=control_registry,
@@ -188,12 +224,7 @@ def _seed_visible_demo_control_plane(
             task_class="advancement_task",
             action_kind=action_kind,
             claimed_by=agent_id or None,
-            resume_when=(
-                f"todo_done:{seeded_todo_ids_by_action['run_dev_eval']}"
-                if action_kind == "summarize_evidence"
-                and seeded_todo_ids_by_action.get("run_dev_eval")
-                else None
-            ),
+            resume_when=resume_when,
             project=control_project,
         )
         todo_id = result.get("todo_id")


### PR DESCRIPTION
## Summary
- make visible auto-research seed todos unlock in a LoopX state chain: contract -> hypothesis -> dev evidence -> evidence summary
- keep non-current roles non-runnable until their upstream todo is done, so frontier/replan drives the next step instead of all roles waking as a flat first pass
- update the KNN continuation smoke to assert the chain and prevent fake/simultaneous selected actions from returning

## Why
This addresses the bad case where a KNN auto-research run looked like a shallow single round. The issue was not only agent behavior: the demo seed layer made curator, proposer, and executor all runnable immediately, which bypassed the state/frontier handoff model that vision/replan should govern.

## Validation
- PYTHONPATH=. python3 examples/auto-research-knn-continuation-smoke.py
- PYTHONPATH=. python3 examples/auto-research-knn-preset-start-smoke.py
- PYTHONPATH=. python3 examples/decentralized-auto-research-frontier-smoke.py
- PYTHONPATH=. python3 examples/control_plane/quota-replan-decision-plane-smoke.py
- PYTHONPATH=. python3 examples/autonomous-replan-obligation-smoke.py
- PYTHONPATH=. python3 -m loopx.cli canary premerge --from-git-diff
