### PR TITLE
Reuse canary harness in monitor scheduler smokes

### DIFF
--- a/examples/control_plane/monitor-poll-writeback-smoke.py
+++ b/examples/control_plane/monitor-poll-writeback-smoke.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import subprocess
 import sys
 import tempfile
 from datetime import datetime, timezone
@@ -20,6 +19,13 @@ import loopx.cli_commands.quota as quota_command  # noqa: E402
 from loopx.control_plane.scheduler.monitor_poll_writeback import (  # noqa: E402
     resolve_monitor_todo_item,
     write_monitor_poll_todo_state,
+)
+from loopx.control_plane.testing.canary_harness import (  # noqa: E402
+    read_run_index,
+    run_json_cli,
+    run_json_cli_result,
+    runtime_root_from_registry,
+    write_fixture_registry,
 )
 from loopx.status import AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK, parse_active_state_todos  # noqa: E402
 
@@ -141,79 +147,43 @@ def write_fixture(
         f"{user_gate}",
         encoding="utf-8",
     )
-    registry_path.parent.mkdir(parents=True)
-    registry_path.write_text(
-        json.dumps(
-            {
-                "schema_version": 1,
-                "updated_at": "2026-01-01T00:00:00+00:00",
-                "common_runtime_root": str(runtime),
-                "goals": [
-                    {
-                        "id": GOAL_ID,
-                        "domain": "monitor-poll-writeback",
-                        "status": "active",
-                        "repo": str(project),
-                        "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
-                        "adapter": {"kind": "generic_project_goal_v0", "status": "connected"},
-                        "coordination": {
-                            "registered_agents": [AGENT_ID],
-                            "primary_agent": AGENT_ID,
-                        },
-                    }
-                ],
-            },
-            indent=2,
-        )
-        + "\n",
-        encoding="utf-8",
+    write_fixture_registry(
+        project=project,
+        runtime_root=runtime,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        domain="monitor-poll-writeback",
+        adapter_kind="generic_project_goal_v0",
+        registered_agents=[AGENT_ID],
+        primary_agent=AGENT_ID,
+        quota_allowed_slots=None,
     )
     return registry_path, state_file
 
 
 def run_cli(registry_path: Path, *args: str) -> dict:
     scan_args = ["--scan-path", str(Path(__file__).resolve())] if args[:1] == ("quota",) else []
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "loopx.cli",
-            "--registry",
-            str(registry_path),
-            "--format",
-            "json",
-            *args,
-            *scan_args,
-        ],
+    return run_json_cli(
+        *args,
+        *scan_args,
+        registry_path=registry_path,
+        runtime_root=runtime_root_from_registry(registry_path),
         cwd=REPO_ROOT,
-        check=True,
-        text=True,
-        capture_output=True,
+        include_returncode=False,
     )
-    return json.loads(result.stdout)
 
 
-def run_cli_expect_error(registry_path: Path, *args: str) -> subprocess.CompletedProcess[str]:
+def run_cli_expect_error(registry_path: Path, *args: str) -> dict:
     scan_args = ["--scan-path", str(Path(__file__).resolve())] if args[:1] == ("quota",) else []
-    result = subprocess.run(
-        [
-            sys.executable,
-            "-m",
-            "loopx.cli",
-            "--registry",
-            str(registry_path),
-            "--format",
-            "json",
-            *args,
-            *scan_args,
-        ],
+    returncode, payload = run_json_cli_result(
+        *args,
+        *scan_args,
+        registry_path=registry_path,
+        runtime_root=runtime_root_from_registry(registry_path),
         cwd=REPO_ROOT,
-        check=False,
-        text=True,
-        capture_output=True,
     )
-    assert result.returncode != 0, result
-    return result
+    assert returncode != 0, payload
+    return payload
 
 
 def agent_todos(state_file: Path) -> list[dict]:
@@ -229,16 +199,9 @@ def find_todo(state_file: Path, todo_id: str) -> dict:
 
 
 def run_index_records(registry_path: Path) -> list[dict]:
-    registry = json.loads(registry_path.read_text(encoding="utf-8"))
-    runtime = Path(str(registry["common_runtime_root"]))
-    index_path = runtime / "goals" / GOAL_ID / "runs" / "index.jsonl"
-    if not index_path.exists():
-        return []
-    return [
-        json.loads(line)
-        for line in index_path.read_text(encoding="utf-8").splitlines()
-        if line.strip()
-    ]
+    runtime = runtime_root_from_registry(registry_path)
+    assert runtime is not None, registry_path
+    return read_run_index(runtime, GOAL_ID)
 
 
 def monitor_poll_records(registry_path: Path) -> list[dict]:
@@ -456,7 +419,7 @@ def assert_target_key_cannot_hijack_selected_due_monitor() -> None:
         )
         assert_due_monitor_selected(registry_path, due_count=2)
 
-        result = run_cli_expect_error(
+        payload = run_cli_expect_error(
             registry_path,
             "quota",
             "monitor-poll",
@@ -470,7 +433,6 @@ def assert_target_key_cannot_hijack_selected_due_monitor() -> None:
             "new",
             "--execute",
         )
-        payload = json.loads(result.stdout)
         assert payload["ok"] is False, payload
         assert "monitor-poll requires" in payload["reason"], payload
         selected = find_todo(state_file, TODO_ID)

--- a/examples/control_plane/quota-scheduler-state-ack-smoke.py
+++ b/examples/control_plane/quota-scheduler-state-ack-smoke.py
@@ -7,7 +7,6 @@ from copy import deepcopy
 import importlib.util
 import json
 from pathlib import Path
-import subprocess
 import sys
 import tempfile
 
@@ -16,6 +15,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from loopx.control_plane.testing.canary_harness import run_json_cli  # noqa: E402
 from loopx.control_plane.scheduler.scheduler_hint import (  # noqa: E402
     build_scheduler_ack_plan,
     build_scheduler_hint,
@@ -446,28 +446,15 @@ def assert_scheduler_state_scope_validation() -> None:
 
 
 def run_cli(root: Path, *args: str, registry_path: Path, runtime: Path, project: Path) -> dict:
-    command = [
-        sys.executable,
-        "-m",
-        "loopx.cli",
-        "--registry",
-        str(registry_path),
-        "--runtime-root",
-        str(runtime),
-        "--format",
-        "json",
+    return run_json_cli(
         *args,
         "--scan-path",
         str(project),
-    ]
-    result = subprocess.run(
-        command,
+        registry_path=registry_path,
+        runtime_root=runtime,
         cwd=REPO_ROOT,
-        check=True,
-        capture_output=True,
-        text=True,
+        include_returncode=False,
     )
-    return json.loads(result.stdout)
 
 
 def assert_cli_scheduler_ack_progression() -> None:


### PR DESCRIPTION
## Summary
- migrate `quota-scheduler-state-ack-smoke.py` from a local subprocess CLI runner to the shared control-plane canary harness
- migrate `monitor-poll-writeback-smoke.py` to shared JSON CLI helpers, quota-free fixture registry writing, and shared run-index reading
- remove duplicate registry/CLI boilerplate while preserving scheduler ack and monitor-poll state-machine assertions

## Validation
- `python3 -m py_compile examples/control_plane/quota-scheduler-state-ack-smoke.py examples/control_plane/monitor-poll-writeback-smoke.py loopx/control_plane/testing/canary_harness.py`
- `python3 examples/control_plane/quota-scheduler-state-ack-smoke.py`
- `python3 examples/control_plane/monitor-poll-writeback-smoke.py`
- `python3 examples/control_plane/quota-plan-smoke.py`
- `python3 examples/control_plane/todo-lifecycle-cli-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `git diff --check` / `git diff --cached --check`
- changed-path private/local/raw-evidence scan: clean; scheduler `reset_token` hits are expected public protocol field names/test values
- `python3 -m loopx.cli --format json canary premerge --from-git-diff` passed: 4 direct checks + 8 selected canary/boundary checks, 0 failures, 0 manual holds, self-merge allowed

## Changed surfaces
- `examples/control_plane/quota-scheduler-state-ack-smoke.py`
- `examples/control_plane/monitor-poll-writeback-smoke.py`

## Merge posture
This is a non-benchmark control-plane canary/refactor batch. It does not change runtime quota, monitor, or scheduler semantics; it consolidates test plumbing under `loopx.control_plane.testing.canary_harness` and keeps the existing state-machine coverage running.