### PR TITLE
fix: resume deferred successors before monitor quiet

### DIFF
--- a/examples/control_plane/quota-replan-decision-plane-smoke.py
+++ b/examples/control_plane/quota-replan-decision-plane-smoke.py
@@ -105,6 +105,38 @@ def completed_side_agent_advancement_without_successor() -> dict:
     }
 
 
+def completed_side_agent_prerequisite_with_successor() -> dict:
+    return {
+        "index": 3,
+        "todo_id": "todo_completed_with_deferred_successor",
+        "text": "[P1] Finish the visible auto-research tick honesty prerequisite.",
+        "role": "agent",
+        "status": "done",
+        "done": True,
+        "priority": "P1",
+        "task_class": "advancement_task",
+        "action_kind": "fix_visible_auto_research_tick",
+        "claimed_by": SIDE_AGENT,
+        "successor_todo_ids": ["todo_ready_deferred_successor"],
+        "completed_at": "2026-07-05T13:36:19+08:00",
+    }
+
+
+def ready_deferred_side_agent_successor() -> dict:
+    return {
+        "index": 4,
+        "todo_id": "todo_ready_deferred_successor",
+        "text": "[P2] Follow up with higher-value research artifacts for the KNN showcase.",
+        "role": "agent",
+        "status": "deferred",
+        "priority": "P2",
+        "task_class": "advancement_task",
+        "action_kind": "improve_auto_research_artifact_value",
+        "claimed_by": SIDE_AGENT,
+        "resume_when": "todo_done:todo_completed_with_deferred_successor",
+    }
+
+
 def blocking_handoff_review() -> dict:
     return {
         "index": 2,
@@ -283,6 +315,42 @@ def assert_future_scheduled_monitor_quiets_without_generated_replan() -> None:
     assert "required_reads" not in guard, guard
     assert "required_reads" not in guard["interaction_contract"]["agent_channel"], guard
     assert "required_reads" not in guard["interaction_contract"]["cli_channel"], guard
+
+
+def assert_ready_deferred_successor_beats_monitor_quiet_skip() -> None:
+    guard = build_quota_should_run(
+        status_payload(
+            [
+                monitor_item(),
+                completed_side_agent_prerequisite_with_successor(),
+                ready_deferred_side_agent_successor(),
+            ],
+            replan_obligation=None,
+        ),
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+    )
+    assert guard["decision"] == "successor_replan_required", guard
+    assert guard["effective_action"] == "successor_replan_required", guard
+    assert guard["should_run"] is True, guard
+    assert guard["normal_delivery_allowed"] is False, guard
+    assert guard["interaction_contract"]["mode"] == "successor_replan_required", guard
+    assert guard["interaction_contract"]["agent_channel"]["must_attempt"] is True, guard
+    assert guard["execution_obligation"]["contract"] == "deferred_resume_projection", guard
+    frontier = guard["agent_scope_frontier"]
+    assert frontier["deferred_resume_candidates"][0]["todo_id"] == (
+        "todo_ready_deferred_successor"
+    ), frontier
+    assert frontier["quiet_noop_allowed"] is False, frontier
+    assert frontier["requires_replan"] is True, frontier
+    goal_frontier = guard["goal_frontier_projection"]
+    assert goal_frontier["monitor_only_lanes"]["present"] is True, goal_frontier
+    assert goal_frontier["deferred_successors"]["ready_count"] == 1, goal_frontier
+    assert goal_frontier["deferred_successors"]["current_agent_ready_count"] == 1, goal_frontier
+    assert guard.get("autonomous_replan_obligation") is None, guard
+    markdown = render_quota_should_run_markdown(guard)
+    assert "agent_scope_frontier: action=successor_replan_required" in markdown, markdown
+    assert "agent_scope_deferred_resume_candidates" in markdown, markdown
 
 
 def assert_completed_advancement_without_successor_beats_monitor_quiet_skip() -> None:
@@ -547,6 +615,7 @@ def assert_blocking_handoff_gate_beats_derived_monitor_replan() -> None:
 def main() -> None:
     assert_replan_beats_monitor_quiet_skip()
     assert_future_scheduled_monitor_quiets_without_generated_replan()
+    assert_ready_deferred_successor_beats_monitor_quiet_skip()
     assert_completed_advancement_without_successor_beats_monitor_quiet_skip()
     assert_replan_preserves_current_agent_runnable_frontier()
     assert_agent_vision_gap_derives_replan()

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -12,6 +12,7 @@ from .control_plane.agents.agent_scope import (
     AgentScopeFrontierAction,
     _action_scope_tokens_from_text,
     _agent_lane_frontier_hint,
+    _agent_scope_deferred_resume_candidates,
     _agent_scope_frontier_action,
     _agent_scope_no_candidate_frontier,
     _agent_scoped_user_gate_override,
@@ -2141,6 +2142,16 @@ def build_quota_should_run(
             agent_todo_summary=agent_todo_summary,
             work_lane_contract=work_lane_contract,
         )
+        ready_deferred_resume_candidates: list[dict[str, Any]] = []
+        if (
+            isinstance(agent_identity, dict)
+            and agent_identity.get("role") == "side-agent"
+            and isinstance(agent_todo_summary, dict)
+        ):
+            ready_deferred_resume_candidates = _agent_scope_deferred_resume_candidates(
+                agent_todo_summary,
+                agent_id=normalize_todo_claimed_by(agent_identity.get("agent_id")),
+            )
         if external_evidence_observation and not workspace_guard:
             normal_delivery_allowed = False
             should_run = True
@@ -2167,6 +2178,7 @@ def build_quota_should_run(
             and work_lane_contract.get("must_attempt_work") is False
             and heartbeat_recommendation.get("recommended_mode") == "monitor_quiet_until_material_transition"
             and heartbeat_recommendation.get("notify") == "DONT_NOTIFY"
+            and not ready_deferred_resume_candidates
         )
         if monitor_quiet_skip:
             normal_delivery_allowed = False
@@ -2246,7 +2258,10 @@ def build_quota_should_run(
                 agent_todo_summary=agent_todo_summary,
                 agent_lane_next_action=agent_lane_next_action,
                 work_lane_contract=work_lane_contract,
-                candidate_should_run=bool(should_run and normal_delivery_allowed),
+                candidate_should_run=bool(
+                    (should_run and normal_delivery_allowed)
+                    or ready_deferred_resume_candidates
+                ),
             )
         agent_lane_frontier_hint = None
         if not replan_decision_allowed:


### PR DESCRIPTION
## Summary
- prevent monitor-only quiet skip from swallowing ready deferred successor work for the current side-agent
- let the existing `successor_replan_required` / `deferred_resume_projection` contract run when a deferred successor is `resume_ready=true`
- add a quota decision-plane regression for `monitor-only lane + ready deferred successor`

## Why
This is adjacent to, but different from, #1468.

#1468 fixed the upstream case where a completed advancement had no successor, so quota needed to create/select an autonomous replan obligation instead of treating the lane as monitor-only. This PR fixes the downstream case where replan already produced a ready deferred successor, but quota still chose `monitor_quiet_skip` before agent-scope frontier could consume that successor.

Observed live on `loopx-meta`: `todo_2b484b3a715b` was `resume_ready=true` and claimed by `codex-side-bypass`, yet quota returned `effective_action=monitor_quiet_skip`. With this patch, the same live projection returns `effective_action=successor_replan_required` and exposes the successor through `agent_scope_frontier.deferred_resume_candidates`.

## Validation
- `PYTHONPATH=. python3 examples/control_plane/quota-replan-decision-plane-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/work-lane-contract-smoke.py`
- `PYTHONPATH=. python3 examples/control_plane/quota-agent-scoped-user-gate-smoke.py`
- live `loopx-meta` quota projection with source CLI: `successor_replan_required` for `todo_2b484b3a715b`
- `PYTHONPATH=. python3 -m loopx.cli canary premerge --from-git-diff`

## Public/private boundary
- public control-plane code and public smoke only
- no raw run logs, credentials, local paths, private artifacts, or internal links
