### PR TITLE
Refactor quota work-lane fixture helpers

### DIFF
--- a/examples/control_plane/monitor-scheduler-contract-smoke.py
+++ b/examples/control_plane/monitor-scheduler-contract-smoke.py
@@ -9,8 +9,8 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 
+from loopx.control_plane.testing.quota_fixtures import quota_status_payload  # noqa: E402
 from loopx.quota import build_quota_should_run, render_quota_should_run_markdown  # noqa: E402
-from loopx.status import compact_todo_group  # noqa: E402
 
 
 GOAL_ID = "monitor-scheduler-fixture"
@@ -44,65 +44,21 @@ def status_payload(
     coordination: dict | None = None,
     latest_runs: list[dict] | None = None,
 ) -> dict:
-    agent_todos = compact_todo_group(
-        agent_todo_items,
-        source_section="Agent Todo",
-        role="agent",
+    return quota_status_payload(
+        goal_id=GOAL_ID,
+        status=status,
+        agent_todo_items=agent_todo_items,
+        recommended_action="Route scheduled monitor todos from structured metadata.",
+        next_action="Route scheduled monitor todos from structured metadata.",
+        coordination=coordination
+        or {
+            "registered_agents": [AGENT_ID],
+            "primary_agent": AGENT_ID,
+        },
+        latest_runs=latest_runs
+        if latest_runs is not None
+        else FRONTIER_REPLAN_ACK_RUNS,
     )
-    return {
-        "ok": True,
-        "attention_queue": {
-            "items": [
-                {
-                    "goal_id": GOAL_ID,
-                    "status": status,
-                    "waiting_on": "codex",
-                    "severity": "info",
-                    "source": "project_asset",
-                    "recommended_action": "Route scheduled monitor todos from structured metadata.",
-                    "quota": {
-                        "compute": 1.0,
-                        "window_hours": 24,
-                        "slot_minutes": 1,
-                        "allowed_slots": 10,
-                        "spent_slots": 0,
-                        "state": "eligible",
-                        "reason": "eligible fixture",
-                    },
-                    "project_asset": {
-                        "next_action": "Route scheduled monitor todos from structured metadata.",
-                        "stop_condition": "stop on private material",
-                        "agent_todos": agent_todos,
-                    },
-                }
-            ]
-        },
-        "run_history": {
-            "goals": [
-                {
-                    "id": GOAL_ID,
-                    "registry_member": True,
-                    "status": status,
-                    "adapter_kind": "harness_self_improvement",
-                    "adapter_status": "connected-read-only",
-                    "quota": {
-                        "compute": 1.0,
-                        "window_hours": 24,
-                        "slot_minutes": 1,
-                        "allowed_slots": 10,
-                    },
-                    "coordination": coordination
-                    or {
-                        "registered_agents": [AGENT_ID],
-                        "primary_agent": AGENT_ID,
-                    },
-                    "latest_runs": latest_runs
-                    if latest_runs is not None
-                    else FRONTIER_REPLAN_ACK_RUNS,
-                }
-            ]
-        },
-    }
 
 
 def monitor_item(

--- a/examples/control_plane/private-boundary-monitor-priority-smoke.py
+++ b/examples/control_plane/private-boundary-monitor-priority-smoke.py
@@ -10,74 +10,33 @@ import sys
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 
+from loopx.control_plane.testing.quota_fixtures import quota_status_payload  # noqa: E402
 from loopx.quota import build_quota_should_run  # noqa: E402
 
 
 GOAL_ID = "private-boundary-monitor-priority-fixture"
+AGENT_ID = "codex-product-capability"
 PAST_DUE_AT = "2000-01-01T00:00:00+00:00"
 
 
 def status_payload(*, monitor_todo: dict, advancement_todo: dict) -> dict:
-    agent_todos = {
-        "schema_version": "todo_summary_v0",
-        "source_section": "Agent Todo",
-        "total_count": 2,
-        "open_count": 2,
-        "done_count": 0,
-        "first_open_items": [monitor_todo, advancement_todo],
-        "monitor_open_items": [monitor_todo],
-        "monitor_due_items": [monitor_todo],
-        "monitor_due_count": 1,
-        "first_executable_items": [advancement_todo],
-        "claim_scope": {"agent_id": "codex-product-capability"},
-    }
-    return {
-        "ok": True,
-        "attention_queue": {
-            "items": [
-                {
-                    "goal_id": GOAL_ID,
-                    "status": "eligible",
-                    "waiting_on": "codex",
-                    "severity": "info",
-                    "source": "project_asset",
-                    "recommended_action": advancement_todo["text"],
-                    "quota": {
-                        "compute": 1.0,
-                        "window_hours": 24,
-                        "slot_minutes": 1,
-                        "allowed_slots": 10,
-                        "spent_slots": 0,
-                        "state": "eligible",
-                        "reason": "eligible fixture",
-                    },
-                    "project_asset": {
-                        "next_action": advancement_todo["text"],
-                        "stop_condition": "stop on fixture boundary",
-                        "agent_todos": agent_todos,
-                    },
-                    "agent_todos": agent_todos,
-                }
-            ]
+    return quota_status_payload(
+        goal_id=GOAL_ID,
+        status="eligible",
+        registry_status="active",
+        agent_todo_items=[monitor_todo, advancement_todo],
+        recommended_action=advancement_todo["text"],
+        next_action=advancement_todo["text"],
+        claim_scope_agent_id=AGENT_ID,
+        coordination={
+            "primary_agent": "codex-main-control",
+            "registered_agents": [
+                "codex-main-control",
+                AGENT_ID,
+            ],
         },
-        "run_history": {
-            "goals": [
-                {
-                    "id": GOAL_ID,
-                    "registry_member": True,
-                    "status": "active",
-                    "coordination": {
-                        "primary_agent": "codex-main-control",
-                        "registered_agents": [
-                            "codex-main-control",
-                            "codex-product-capability",
-                        ],
-                    },
-                    "quota": {"compute": 1.0, "window_hours": 24},
-                }
-            ]
-        },
-    }
+        goal_extra={"quota": {"compute": 1.0, "window_hours": 24}},
+    )
 
 
 def test_private_boundary_due_monitor_is_context_only() -> None:
@@ -89,7 +48,7 @@ def test_private_boundary_due_monitor_is_context_only() -> None:
         "priority": "P0-LOCAL",
         "task_class": "continuous_monitor",
         "action_kind": "local_department_doc_todo_projection_monitor",
-        "claimed_by": "codex-product-capability",
+        "claimed_by": AGENT_ID,
         "next_due_at": PAST_DUE_AT,
         "result_hash": "private_boundary_no_authorized_read",
     }
@@ -101,7 +60,7 @@ def test_private_boundary_due_monitor_is_context_only() -> None:
         "priority": "P2",
         "task_class": "advancement_task",
         "action_kind": "continue_canary_refactor",
-        "claimed_by": "codex-product-capability",
+        "claimed_by": AGENT_ID,
     }
     guard = build_quota_should_run(
         status_payload(
@@ -109,17 +68,15 @@ def test_private_boundary_due_monitor_is_context_only() -> None:
             advancement_todo=advancement_todo,
         ),
         goal_id=GOAL_ID,
-        agent_id="codex-product-capability",
+        agent_id=AGENT_ID,
     )
     lane = guard["work_lane_contract"]
     assert guard["agent_todo_summary"]["monitor_due_count"] == 1, guard
     assert lane["lane"] == "advancement_task", lane
     assert lane["reason_codes"] == ["open_agent_todo", "due_monitor_context"], lane
     assert guard["recommended_action"] == advancement_todo["text"], guard
-    assert (
-        guard["interaction_contract"]["agent_channel"]["primary_action"]
-        == f"{advancement_todo['text']}"
-    ), guard
+    primary_action = guard["interaction_contract"]["agent_channel"]["primary_action"]
+    assert advancement_todo["text"] in primary_action, guard
 
 
 def test_public_due_monitor_priority_matrix() -> None:
@@ -131,7 +88,7 @@ def test_public_due_monitor_priority_matrix() -> None:
         "priority": "P0",
         "task_class": "continuous_monitor",
         "action_kind": "public_release_monitor",
-        "claimed_by": "codex-product-capability",
+        "claimed_by": AGENT_ID,
         "next_due_at": PAST_DUE_AT,
     }
     public_low_monitor = {
@@ -147,7 +104,7 @@ def test_public_due_monitor_priority_matrix() -> None:
         "priority": "P1",
         "task_class": "advancement_task",
         "action_kind": "continue_canary_refactor",
-        "claimed_by": "codex-product-capability",
+        "claimed_by": AGENT_ID,
     }
 
     high_guard = build_quota_should_run(
@@ -156,7 +113,7 @@ def test_public_due_monitor_priority_matrix() -> None:
             advancement_todo=advancement_todo,
         ),
         goal_id=GOAL_ID,
-        agent_id="codex-product-capability",
+        agent_id=AGENT_ID,
     )
     high_lane = high_guard["work_lane_contract"]
     assert high_lane["lane"] == "continuous_monitor", high_lane
@@ -173,7 +130,7 @@ def test_public_due_monitor_priority_matrix() -> None:
             advancement_todo=advancement_todo,
         ),
         goal_id=GOAL_ID,
-        agent_id="codex-product-capability",
+        agent_id=AGENT_ID,
     )
     low_lane = low_guard["work_lane_contract"]
     assert low_lane["lane"] == "advancement_task", low_lane

--- a/examples/control_plane/quota-work-lane-policy-smoke.py
+++ b/examples/control_plane/quota-work-lane-policy-smoke.py
@@ -21,6 +21,7 @@ from loopx.control_plane.work_items.work_lane_context import (  # noqa: E402
     item_progress_scope,
     latest_run_progress_scope,
 )
+from loopx.control_plane.testing.quota_fixtures import quota_status_payload  # noqa: E402
 from loopx.quota import build_quota_should_run  # noqa: E402
 
 
@@ -51,63 +52,14 @@ def status_payload(
                 "priority": "P1",
             }
         ]
-    agent_todos = {
-        "schema_version": "todo_summary_v0",
-        "source_section": "Agent Todo",
-        "total_count": len(agent_todo_items),
-        "open_count": len(agent_todo_items),
-        "done_count": 0,
-        "first_open_items": agent_todo_items,
-    }
-    item = {
-        "goal_id": GOAL_ID,
-        "status": status,
-        "waiting_on": "codex",
-        "severity": "info",
-        "source": "project_asset",
-        "recommended_action": next_action,
-        "quota": {
-            "compute": 1.0,
-            "window_hours": 24,
-            "slot_minutes": 1,
-            "allowed_slots": 10,
-            "spent_slots": 0,
-            "state": "eligible",
-            "reason": "eligible fixture",
-        },
-        "project_asset": {
-            "next_action": next_action,
-            "stop_condition": "stop on private material",
-            "agent_todos": agent_todos,
-        },
-    }
-    if post_handoff_latest_run:
-        item["handoff_readiness"] = {
-            "post_handoff_run_seen": True,
-            "handoff_status": "post_handoff_run_seen",
-            "post_handoff_latest_run": post_handoff_latest_run,
-        }
-    return {
-        "ok": True,
-        "attention_queue": {"items": [item]},
-        "run_history": {
-            "goals": [
-                {
-                    "id": GOAL_ID,
-                    "registry_member": True,
-                    "status": status,
-                    "adapter_kind": "harness_self_improvement",
-                    "adapter_status": "connected-read-only",
-                    "quota": {
-                        "compute": 1.0,
-                        "window_hours": 24,
-                        "slot_minutes": 1,
-                        "allowed_slots": 10,
-                    },
-                }
-            ]
-        },
-    }
+    return quota_status_payload(
+        goal_id=GOAL_ID,
+        status=status,
+        agent_todo_items=agent_todo_items,
+        recommended_action=next_action,
+        next_action=next_action,
+        post_handoff_latest_run=post_handoff_latest_run,
+    )
 
 
 def assert_work_lane_context_matches_quota_state_machine_cases() -> None:

--- a/loopx/control_plane/agents/agent_lane_recommendation.py
+++ b/loopx/control_plane/agents/agent_lane_recommendation.py
@@ -11,6 +11,7 @@ from ..todos.contract import (
 )
 from ..todos.summary_item import compact_todo_summary_item
 from ..work_items.interaction_contract import protocol_action_text
+from ..work_items.work_lane import work_lane_contract_is_due_monitor_attempt
 from .agent_scope import (
     _todo_item_is_actionable_open,
     _todo_task_class,
@@ -171,11 +172,7 @@ def selected_recommended_action_from_work_lane(
     work_lane_contract: dict[str, Any] | None,
 ) -> Any:
     raw_action = item.get("recommended_action")
-    if (
-        isinstance(work_lane_contract, dict)
-        and work_lane_contract.get("monitor_kind") == "todo_monitor_due"
-        and work_lane_contract.get("must_attempt_work") is True
-    ):
+    if work_lane_contract_is_due_monitor_attempt(work_lane_contract):
         due_items = (
             work_lane_contract.get("monitor_due_items")
             if isinstance(work_lane_contract.get("monitor_due_items"), list)

--- a/loopx/control_plane/agents/agent_scope.py
+++ b/loopx/control_plane/agents/agent_scope.py
@@ -5,7 +5,10 @@ import re
 from typing import Any
 
 from ..todos.decision_scope import todo_gate_relation, todo_gate_relation_blocks_agent
-from ..work_items.work_lane import work_lane_contract_requires_current_agent_attempt
+from ..work_items.work_lane import (
+    work_lane_contract_is_due_monitor_attempt,
+    work_lane_contract_requires_current_agent_attempt,
+)
 from ..todos.contract import (
     TODO_STATUS_OPEN,
     TODO_TASK_CLASS_ADVANCEMENT,
@@ -498,14 +501,6 @@ def _first_compact_todo_id(items: Any) -> str | None:
     return None
 
 
-def _work_lane_due_monitor_attempt(work_lane_contract: dict[str, Any] | None) -> bool:
-    return bool(
-        isinstance(work_lane_contract, dict)
-        and work_lane_contract.get("monitor_kind") == "todo_monitor_due"
-        and work_lane_contract.get("must_attempt_work") is True
-    )
-
-
 def _agent_lane_frontier_hint(
     *,
     goal_id: str,
@@ -567,7 +562,7 @@ def _agent_lane_frontier_hint(
                 next_cli_action=action,
             )
 
-    if _work_lane_due_monitor_attempt(work_lane_contract):
+    if work_lane_contract_is_due_monitor_attempt(work_lane_contract):
         return None
     if work_lane_contract_requires_current_agent_attempt(work_lane_contract):
         return None
@@ -950,7 +945,7 @@ def _agent_scope_no_candidate_frontier(
         return None
     if isinstance(agent_lane_next_action, dict):
         return None
-    if _work_lane_due_monitor_attempt(work_lane_contract):
+    if work_lane_contract_is_due_monitor_attempt(work_lane_contract):
         return None
     if work_lane_contract_requires_current_agent_attempt(work_lane_contract):
         return None

--- a/loopx/control_plane/testing/quota_fixtures.py
+++ b/loopx/control_plane/testing/quota_fixtures.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ...status import compact_todo_group
+
+
+DEFAULT_FIXTURE_QUOTA = {
+    "compute": 1.0,
+    "window_hours": 24,
+    "slot_minutes": 1,
+    "allowed_slots": 10,
+    "spent_slots": 0,
+    "state": "eligible",
+    "reason": "eligible fixture",
+}
+
+
+def quota_todo_summary(
+    items: list[dict[str, Any]],
+    *,
+    role: str = "agent",
+    claim_scope_agent_id: str | None = None,
+) -> dict[str, Any]:
+    summary = compact_todo_group(
+        items,
+        source_section="Agent Todo" if role == "agent" else "User Todo",
+        role=role,
+    )
+    if claim_scope_agent_id:
+        summary["claim_scope"] = {"agent_id": claim_scope_agent_id}
+    return summary
+
+
+def quota_status_payload(
+    *,
+    goal_id: str,
+    status: str,
+    agent_todo_items: list[dict[str, Any]],
+    recommended_action: str,
+    next_action: str | None = None,
+    coordination: dict[str, Any] | None = None,
+    latest_runs: list[dict[str, Any]] | None = None,
+    post_handoff_latest_run: dict[str, Any] | None = None,
+    claim_scope_agent_id: str | None = None,
+    registry_status: str | None = None,
+    goal_extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    agent_todos = quota_todo_summary(
+        agent_todo_items,
+        role="agent",
+        claim_scope_agent_id=claim_scope_agent_id,
+    )
+    quota = dict(DEFAULT_FIXTURE_QUOTA)
+    action = next_action if next_action is not None else recommended_action
+    item: dict[str, Any] = {
+        "goal_id": goal_id,
+        "status": status,
+        "waiting_on": "codex",
+        "severity": "info",
+        "source": "project_asset",
+        "recommended_action": recommended_action,
+        "quota": quota,
+        "agent_todos": agent_todos,
+        "project_asset": {
+            "next_action": action,
+            "stop_condition": "stop on private material",
+            "agent_todos": agent_todos,
+        },
+    }
+    if post_handoff_latest_run:
+        item["handoff_readiness"] = {
+            "post_handoff_run_seen": True,
+            "handoff_status": "post_handoff_run_seen",
+            "post_handoff_latest_run": post_handoff_latest_run,
+        }
+    if coordination:
+        item["coordination"] = coordination
+
+    goal: dict[str, Any] = {
+        "id": goal_id,
+        "registry_member": True,
+        "status": registry_status or status,
+        "adapter_kind": "harness_self_improvement",
+        "adapter_status": "connected-read-only",
+        "quota": {
+            "compute": quota.get("compute", 1.0),
+            "window_hours": quota.get("window_hours", 24),
+            "slot_minutes": quota.get("slot_minutes", 1),
+            "allowed_slots": quota.get("allowed_slots", 10),
+        },
+    }
+    if coordination:
+        goal["coordination"] = coordination
+    if latest_runs is not None:
+        goal["latest_runs"] = latest_runs
+    if goal_extra:
+        goal.update(goal_extra)
+
+    return {
+        "ok": True,
+        "attention_queue": {"items": [item]},
+        "run_history": {"goals": [goal]},
+    }

--- a/loopx/control_plane/work_items/work_lane.py
+++ b/loopx/control_plane/work_items/work_lane.py
@@ -11,6 +11,7 @@ WORK_LANE_CURRENT_AGENT_MONITOR_REPAIR_OBLIGATIONS = {
     "repair_monitor_schedule_metadata",
     "repair_resume_gate_or_close_standing_monitor",
 }
+WORK_LANE_TODO_MONITOR_DUE_KIND = "todo_monitor_due"
 PRIVATE_BOUNDARY_MONITOR_RESULT_HASHES = {
     "private_boundary_no_authorized_read",
 }
@@ -70,6 +71,16 @@ def work_lane_contract_requires_current_agent_attempt(
     return obligation in WORK_LANE_CURRENT_AGENT_MONITOR_REPAIR_OBLIGATIONS
 
 
+def work_lane_contract_is_due_monitor_attempt(
+    contract: dict[str, Any] | None,
+) -> bool:
+    return bool(
+        isinstance(contract, dict)
+        and contract.get("monitor_kind") == WORK_LANE_TODO_MONITOR_DUE_KIND
+        and contract.get("must_attempt_work") is True
+    )
+
+
 def build_work_lane_contract(
     *,
     progress_scope: str,
@@ -112,7 +123,7 @@ def build_work_lane_contract(
         return {
             "schema_version": WORK_LANE_CONTRACT_SCHEMA_VERSION,
             "lane": "continuous_monitor",
-            "monitor_kind": "todo_monitor_due",
+            "monitor_kind": WORK_LANE_TODO_MONITOR_DUE_KIND,
             "next_lane": "advancement_task" if has_advancement_todos else "continuous_monitor",
             "obligation": "attempt_due_monitor",
             "must_attempt_work": True,

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -87,6 +87,9 @@ from .control_plane.work_items.goal_route_hint import build_goal_route_hint
 from .control_plane.work_items.work_lane_context import (
     build_work_lane_context_contract,
 )
+from .control_plane.work_items.work_lane import (
+    work_lane_contract_is_due_monitor_attempt,
+)
 from .control_plane.scheduler.scheduler_hint import (
     build_codex_app_scheduler_ack_event,
     build_scheduler_hint,
@@ -672,14 +675,6 @@ def _blocked_priority_fallback(
             "continue the fallback only if it still matches the latest user priority."
         ),
     }
-
-
-def _work_lane_due_monitor_attempt(work_lane_contract: dict[str, Any] | None) -> bool:
-    return bool(
-        isinstance(work_lane_contract, dict)
-        and work_lane_contract.get("monitor_kind") == "todo_monitor_due"
-        and work_lane_contract.get("must_attempt_work") is True
-    )
 
 
 def _selected_action_with_capability_gate(
@@ -2181,7 +2176,7 @@ def build_quota_should_run(
             agent_todo_summary=agent_todo_summary,
             work_lane_contract=work_lane_contract,
         )
-        due_monitor_attempt = _work_lane_due_monitor_attempt(work_lane_contract)
+        due_monitor_attempt = work_lane_contract_is_due_monitor_attempt(work_lane_contract)
         if capability_gate and not due_monitor_attempt:
             if capability_gate.get("action") in {"repair_bridge", "ask_owner", "skip"}:
                 selected_recommended_action = (


### PR DESCRIPTION
## Summary
- add a narrow control-plane testing helper for quota/status fixture payloads
- migrate work-lane, monitor-scheduler, and private-boundary monitor smokes to reuse the shared fixture path
- move the due-monitor work-lane predicate into the work-lane bounded context and reuse it from quota/agent routing

## Validation
- python3 examples/control_plane/quota-work-lane-policy-smoke.py
- python3 examples/control_plane/private-boundary-monitor-priority-smoke.py
- python3 examples/control_plane/monitor-scheduler-contract-smoke.py
- python3 examples/control_plane/work-lane-contract-smoke.py
- python3 -m py_compile loopx/control_plane/testing/quota_fixtures.py loopx/control_plane/work_items/work_lane.py loopx/quota.py loopx/control_plane/agents/agent_scope.py loopx/control_plane/agents/agent_lane_recommendation.py
- git diff --check
- python3 -m loopx.cli --format json canary premerge --from-git-diff (passed; surfaces: control_plane, public_boundary, python; profiles: core-control-plane, canary-runner; no manual holds)
