### PR TITLE
Improve KNN auto-research artifact prompts

### DIFF
--- a/examples/auto-research-knn-preset-start-smoke.py
+++ b/examples/auto-research-knn-preset-start-smoke.py
@@ -16,6 +16,12 @@ sys.path.insert(0, str(REPO_ROOT))
 from loopx.capabilities.auto_research.knn_demo_workspace import (  # noqa: E402
     materialize_knn_demo_workspace,
 )
+from loopx.capabilities.auto_research.demo_supervisor import (  # noqa: E402
+    build_auto_research_demo_supervisor_plan,
+)
+from loopx.capabilities.auto_research.user_contract import (  # noqa: E402
+    build_auto_research_preset_context,
+)
 
 QUESTION = "如何提升 KNN 精确近邻检索速度?"
 
@@ -62,6 +68,32 @@ def main() -> int:
     assert "--preset knn-demo" in contract["one_click_start"]["command"], contract
     assert "--preset knn-demo" in payload["commands"]["one_question_start"], payload
     assert payload["contract_acceptance"]["accepted"] is True, payload
+
+    supervisor = build_auto_research_demo_supervisor_plan(
+        goal_id="loopx-auto-research-knn-smoke",
+        open_question=QUESTION,
+        preset_context=build_auto_research_preset_context("knn-demo"),
+        output_language="zh",
+    )
+    role_steps = {
+        role["role_id"]: role["role_profile"]["visible_first_steps"]
+        for role in supervisor["lanes"]
+    }
+    assert "role-specific public-safe artifact" in " ".join(
+        role_steps["research_curator"]
+    ), role_steps
+    assert "two-row hypothesis table" in " ".join(
+        role_steps["hypothesis_proposer"]
+    ), role_steps
+    assert "save the last JSON line as baseline dev evidence" in " ".join(
+        role_steps["research_executor"]
+    ), role_steps
+    assert "feed the real evaluator JSON" in " ".join(
+        role_steps["research_executor"]
+    ), role_steps
+    assert "protected-scope cleanliness" in " ".join(
+        role_steps["evaluator_promoter"]
+    ), role_steps
 
     markdown_result = subprocess.run(
         [

--- a/loopx/capabilities/auto_research/knn_demo_workspace.py
+++ b/loopx/capabilities/auto_research/knn_demo_workspace.py
@@ -34,6 +34,12 @@ Commands:
 Evidence rule:
 - Record the command, split, score, mechanism, and changed file before claiming an improvement.
 - Do not edit protected files to improve the score.
+
+Recording-friendly artifact checklist:
+- Curator: metric, editable/protected boundary, and promotion rule.
+- Hypothesis proposer: two exact-KNN speedup hypotheses with mechanism and risk.
+- Executor: baseline dev score, changed mechanism, post-change dev score, and held-out score when dev improves.
+- Evaluator: split-aware verdict and the next role todo or retry reason.
 """
 
 
@@ -44,6 +50,9 @@ Only edit `solution.py`.
 Do not edit `task.py`, `eval.py`, or `eval.sh`.
 
 Run `bash eval.sh dev` for development evidence and `bash eval.sh test` for held-out evidence.
+
+For visible auto-research, do not stop at a status/tick summary. Leave one compact
+public-safe artifact, todo update, or evidence packet that another role can use.
 """
 
 

--- a/loopx/capabilities/auto_research/preset.py
+++ b/loopx/capabilities/auto_research/preset.py
@@ -188,25 +188,59 @@ AUTO_RESEARCH_SEED_TITLES = {
 KNN_DEMO_VISIBLE_FIRST_STEP_COMMON = (
     "Read research_contract.public.json before claiming scope or metric facts.",
     "Do not treat $LOOPX_PANE_A2A_TICK output as research evidence.",
+    (
+        "Before claiming progress, leave one role-specific public-safe artifact, "
+        "todo update, or evidence packet that another pane can use."
+    ),
 )
 
 KNN_DEMO_VISIBLE_FIRST_STEPS_BY_ROLE = {
     "research_curator": (
-        "Inspect README.md, solution.py, and eval.py; summarize metric, editable scope, protected scope, and evidence gate.",
-        "If the first hypothesis todo is missing, add a hypothesis-proposer todo for two exact-KNN speedup hypotheses.",
+        (
+            "Write a compact contract note: metric direction, editable file, "
+            "protected files, dev/test gates, and promotion rule."
+        ),
+        (
+            "If the first hypothesis todo is missing, add a hypothesis-proposer "
+            "todo for two exact-KNN speedup hypotheses and cite the contract note."
+        ),
     ),
     "hypothesis_proposer": (
-        "Inspect solution.py, task.py, and eval.py; propose two bounded exact-KNN hypotheses with mechanism and risk.",
-        "Route exactly one dev-attempt todo to research-executor; keep alternatives visible.",
+        (
+            "Inspect solution.py, task.py, and eval.py; produce a two-row "
+            "hypothesis table with mechanism, expected speed source, correctness "
+            "risk, and eval command."
+        ),
+        (
+            "Route exactly one dev-attempt todo to research-executor and keep "
+            "the rejected/backup hypothesis visible as a retry candidate."
+        ),
     ),
     "research_executor": (
-        "Run `bash eval.sh dev` to record the current score before editing.",
-        "Edit only solution.py for one exact-KNN optimization, rerun `bash eval.sh dev`, then record command plus score.",
-        "After a dev improvement, run `bash eval.sh test`, save both JSON outputs, and feed them to `loopx auto-research evidence`.",
+        (
+            "Run `bash eval.sh dev` before editing and save the last JSON line "
+            "as baseline dev evidence."
+        ),
+        (
+            "Edit only solution.py for one exact-KNN optimization, rerun "
+            "`bash eval.sh dev`, and record the command, score, and diff summary."
+        ),
+        (
+            "After a dev improvement, run `bash eval.sh test`, save both JSON "
+            "outputs, and feed the real evaluator JSON to `loopx auto-research evidence`."
+        ),
     ),
     "evaluator_promoter": (
-        "Only when your own evaluator todo is runnable, classify current evidence; if no todo is selected, wait for research-executor evidence instead of closing the evaluator todo.",
-        "Classify claims as dev-only, held-out-supported, retry-needed, or blocked; do not promote without `bash eval.sh test` output.",
+        (
+            "Only when your own evaluator todo is runnable, read executor evidence "
+            "and classify it; if no todo is selected, wait for research-executor "
+            "evidence instead of closing the evaluator todo."
+        ),
+        (
+            "Write a verdict with split label, metric direction, protected-scope "
+            "cleanliness, and next successor/retry todo; do not promote without "
+            "`bash eval.sh test` output."
+        ),
     ),
 }
 


### PR DESCRIPTION
## Summary

This keeps the auto-research/user surface thin while making the KNN visible demo less status-like and more artifact-driven.

Changed surfaces:
- `loopx/capabilities/auto_research/preset.py`: KNN role first-move prompts now require each visible pane to leave a role-specific public-safe artifact, todo update, or real evidence packet.
- `loopx/capabilities/auto_research/knn_demo_workspace.py`: generated README/AGENTS now explain the recording-friendly artifact checklist.
- `examples/auto-research-knn-preset-start-smoke.py`: locks the KNN role hints into the launcher payload.

## Validation

Focused checks:
- `PYTHONPATH=. PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-knn-preset-start-smoke.py`
- `PYTHONPATH=. PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-knn-continuation-smoke.py`

Premerge gate:
- `PYTHONPATH=. PYTHONDONTWRITEBYTECODE=1 python3 -m loopx.cli --format json canary premerge --from-git-diff`

Canary selected and passed:
- diff hygiene and changed Python compile checks
- `examples/control_plane/repo-python-line-budget-smoke.py`
- `examples/auto-research-minimal-kernel-smoke.py`
- `examples/decentralized-auto-research-frontier-smoke.py`
- `examples/control_plane/check-public-boundary-smoke.py`

## Boundary

No fake metric path was added. The headless/worker-turn fake metric guard remains intact; the continuation smoke still expects no dev/holdout metrics without visible lane-authored evidence. Public/private scan only hit existing safety wording about raw logs and credentials.

## Self-merge rationale

Small single-purpose KNN demo prompt/workspace guidance plus focused smoke. No benchmark scoring change, no generated logs, no raw transcripts, no local paths, no credentials, and premerge gate reports `self_merge_allowed=true` with no manual holds.
