### PR TITLE
Stabilize SkillsBench CLI goal post-bridge recovery

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -693,7 +693,7 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
             goal_terminal_observed=False,
             first_action_observed=True,
             bridge_summary_path=bridge_summary,
-            post_bridge_recovery_attempt_count=1,
+            post_bridge_recovery_attempt_count=2,
             post_bridge_recovery_action="typed_continue",
             post_bridge_recovery_skip_reason="retry_limit_reached",
         )
@@ -707,7 +707,7 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
 
     prerequisites = plan["runner_prerequisites"]
     assert trace["codex_cli_goal_tui_stage"] == "post_bridge_tui_model_timeout"
-    assert trace["codex_cli_goal_tui_post_bridge_recovery_attempt_count"] == 1
+    assert trace["codex_cli_goal_tui_post_bridge_recovery_attempt_count"] == 2
     assert trace["codex_cli_goal_tui_post_bridge_recovery_action"] == "typed_continue"
     assert (
         trace["codex_cli_goal_tui_post_bridge_recovery_skip_reason"]
@@ -862,6 +862,7 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert "timeout_sec=max(" in source
     assert "self._config.first_action_timeout_sec" in source
     assert "post_bridge_recovery_attempt_count" in source
+    assert "post_bridge_recovery_attempt_count < 2" in source
     assert "last_bridge_activity_at >= 30.0" in source
     tui_source = (REPO_ROOT / "loopx/codex_cli_goal_tui.py").read_text(
         encoding="utf-8"

--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -861,6 +861,8 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert "thread_prewarm_timeout" in source
     assert "timeout_sec=max(" in source
     assert "self._config.first_action_timeout_sec" in source
+    assert "post_bridge_recovery_attempt_count" in source
+    assert "last_bridge_activity_at >= 30.0" in source
     tui_source = (REPO_ROOT / "loopx/codex_cli_goal_tui.py").read_text(
         encoding="utf-8"
     )

--- a/examples/skillsbench-verifier-bootstrap-missing-score-smoke.py
+++ b/examples/skillsbench-verifier-bootstrap-missing-score-smoke.py
@@ -223,6 +223,90 @@ def test_pre_agent_package_install_risk_overrides_bridge_trace_missing() -> None
     assert diagnostic["raw_trajectory_read"] is False, diagnostic
 
 
+def test_benchmark_egress_preflight_overrides_verifier_package_risk() -> None:
+    compact = _missing_score_compact()
+    plan = _package_install_pre_agent_plan()
+    compact.update(
+        {
+            "mode": "skillsbench_codex_cli_goal_baseline",
+            "route": "codex-cli-goal-baseline",
+            "task_id": "civ6-adjacency-optimizer",
+            "score_failure_attribution": (
+                "skillsbench_remote_bridge_agent_operation_trace_missing"
+            ),
+            "first_blocker": "skillsbench_remote_bridge_agent_operation_trace_missing",
+            "failure_attribution_labels": [
+                "skillsbench_remote_bridge_agent_operation_trace_missing",
+                "skillsbench_product_mode_uncountable_treatment",
+                "skillsbench_runner_setup_error",
+            ],
+            "runner_config": {
+                "schema_version": "skillsbench_runner_config_v0",
+                "benchmark_egress_proxy_required": True,
+                "benchmark_egress_proxy_ready": False,
+                "benchmark_egress_proxy_configured": False,
+                "benchmark_egress_proxy_status": "invalid_proxy_value",
+                "benchmark_egress_proxy_error_kind": "unexpanded_placeholder",
+                "benchmark_egress_proxy_mode_requested": "require",
+                "benchmark_egress_proxy_mode_effective": "require",
+                "benchmark_egress_proxy_url_recorded": False,
+                "fail_fast_on_verifier_bootstrap_risk": False,
+            },
+            "task_staging": plan["task_staging"],
+            "task_setup_preflight": plan["task_setup_preflight"],
+            "attempt_accounting": {
+                "schema_version": "skillsbench_attempt_accounting_v0",
+                "attempt_lifecycle_phase": "not_started",
+                "failure_class": "none",
+                "failure_label": "not_run_adapter_skeleton",
+            },
+            "runner_failure": {
+                "schema_version": "skillsbench_runner_failure_v0",
+                "exception_type": "SkillsBenchSetupPreflightBlocked",
+                "failure_class": (
+                    "skillsbench_remote_bridge_agent_operation_trace_missing"
+                ),
+                "raw_error_recorded": False,
+                "raw_logs_read": False,
+                "raw_task_text_read": False,
+                "raw_trajectory_read": False,
+            },
+        }
+    )
+
+    reduced = compact_benchmark_run(compact)
+
+    assert reduced is not None, compact
+    assert reduced["score_failure_attribution"] == (
+        "skillsbench_benchmark_egress_proxy_preflight_blocked"
+    ), reduced
+    assert reduced["first_blocker"] == (
+        "skillsbench_benchmark_egress_proxy_preflight_blocked"
+    ), reduced
+    assert reduced["runner_failure"]["failure_class"] == (
+        "skillsbench_benchmark_egress_proxy_preflight_blocked"
+    ), reduced
+    assert reduced["attempt_accounting"]["failure_class"] == (
+        "job_materialization_failed"
+    ), reduced
+    assert "skillsbench_remote_bridge_agent_operation_trace_missing" not in reduced[
+        "failure_attribution_labels"
+    ], reduced
+    assert "skillsbench_benchmark_egress_proxy_invalid_proxy_value" in reduced[
+        "failure_attribution_labels"
+    ], reduced
+    assert "verifier_bootstrap_diagnostic" not in reduced, reduced
+    diagnostic = reduced["benchmark_egress_proxy_diagnostic"]
+    assert diagnostic["proxy_required"] is True, diagnostic
+    assert diagnostic["proxy_ready"] is False, diagnostic
+    assert diagnostic["proxy_status"] == "invalid_proxy_value", diagnostic
+    assert diagnostic["proxy_error_kind"] == "unexpanded_placeholder", diagnostic
+    assert diagnostic["proxy_url_recorded"] is False, diagnostic
+    assert diagnostic["raw_logs_read"] is False, diagnostic
+    assert diagnostic["raw_task_text_read"] is False, diagnostic
+    assert diagnostic["raw_trajectory_read"] is False, diagnostic
+
+
 def test_completed_score_is_not_reclassified_by_bootstrap_risk() -> None:
     compact = _missing_score_compact()
     plan = _uv_bootstrap_plan()
@@ -256,5 +340,6 @@ def test_completed_score_is_not_reclassified_by_bootstrap_risk() -> None:
 if __name__ == "__main__":
     test_missing_score_uv_bootstrap_risk_gets_verifier_dependency_attribution()
     test_pre_agent_package_install_risk_overrides_bridge_trace_missing()
+    test_benchmark_egress_preflight_overrides_verifier_package_risk()
     test_completed_score_is_not_reclassified_by_bootstrap_risk()
     print("skillsbench-verifier-bootstrap-missing-score-smoke: ok")

--- a/examples/skillsbench-verifier-bootstrap-missing-score-smoke.py
+++ b/examples/skillsbench-verifier-bootstrap-missing-score-smoke.py
@@ -79,6 +79,43 @@ def _uv_bootstrap_plan() -> dict:
     }
 
 
+def _package_install_pre_agent_plan() -> dict:
+    return {
+        "task_staging": {
+            "schema_version": "skillsbench_task_staging_v0",
+            "staged": False,
+            "verifier_bootstrap_risk_detected": True,
+            "verifier_bootstrap_risk_preflight_blocked": False,
+            "verifier_package_install_risk_detected": True,
+            "verifier_uv_bootstrap_risk_detected": False,
+            "raw_task_text_read": False,
+            "raw_logs_read": False,
+            "raw_trajectory_read": False,
+        },
+        "task_setup_preflight": {
+            "schema_version": "skillsbench_task_setup_preflight_v0",
+            "status": "verifier_bootstrap_risk_detected",
+            "canonical_task_present": True,
+            "dockerfile_present": True,
+            "verifier_present": True,
+            "verifier_bootstrap_risk_detected": True,
+            "verifier_package_install_risk_detected": True,
+            "verifier_external_download_risk_detected": False,
+            "verifier_uv_bootstrap_risk_detected": False,
+            "verifier_bootstrap_risk_categories": ["package_install"],
+            "bootstrap_light_candidate_eligible": False,
+            "bootstrap_light_blocking_fields": [
+                "verifier_bootstrap_risk_detected",
+                "verifier_package_install_risk_detected",
+            ],
+            "selection_recommendation": "route_to_setup_repair_or_use_fail_fast_guard",
+            "raw_task_text_read": False,
+            "raw_logs_read": False,
+            "raw_trajectory_read": False,
+        },
+    }
+
+
 def test_missing_score_uv_bootstrap_risk_gets_verifier_dependency_attribution() -> None:
     compact = _missing_score_compact()
     plan = _uv_bootstrap_plan()
@@ -117,6 +154,75 @@ def test_missing_score_uv_bootstrap_risk_gets_verifier_dependency_attribution() 
     assert reduced["verifier_dependency_failure_count"] == 1, reduced
 
 
+def test_pre_agent_package_install_risk_overrides_bridge_trace_missing() -> None:
+    compact = _missing_score_compact()
+    plan = _package_install_pre_agent_plan()
+    compact.update(
+        {
+            "mode": "skillsbench_codex_cli_goal_baseline",
+            "route": "codex-cli-goal-baseline",
+            "task_id": "civ6-adjacency-optimizer",
+            "score_failure_attribution": (
+                "skillsbench_remote_bridge_agent_operation_trace_missing"
+            ),
+            "first_blocker": "skillsbench_remote_bridge_agent_operation_trace_missing",
+            "failure_attribution_labels": [
+                "skillsbench_remote_bridge_agent_operation_trace_missing",
+                "skillsbench_product_mode_uncountable_treatment",
+                "skillsbench_runner_setup_error",
+            ],
+            "task_staging": plan["task_staging"],
+            "task_setup_preflight": plan["task_setup_preflight"],
+            "attempt_accounting": {
+                "schema_version": "skillsbench_attempt_accounting_v0",
+                "attempt_lifecycle_phase": "not_started",
+                "failure_class": "none",
+                "failure_label": "not_run_adapter_skeleton",
+            },
+            "runner_failure": {
+                "schema_version": "skillsbench_runner_failure_v0",
+                "exception_type": "SkillsBenchSetupPreflightBlocked",
+                "failure_class": (
+                    "skillsbench_remote_bridge_agent_operation_trace_missing"
+                ),
+                "raw_error_recorded": False,
+                "raw_logs_read": False,
+                "raw_task_text_read": False,
+                "raw_trajectory_read": False,
+            },
+        }
+    )
+
+    reduced = compact_benchmark_run(compact)
+
+    assert reduced is not None, compact
+    assert reduced["score_failure_attribution"] == (
+        "verifier_dependency_install_failure"
+    ), reduced
+    assert reduced["first_blocker"] == "verifier_dependency_install_failure", reduced
+    assert reduced["runner_failure"]["failure_class"] == (
+        "verifier_dependency_install_failure"
+    ), reduced
+    assert reduced["attempt_accounting"]["failure_label"] == (
+        "verifier_dependency_install_failure"
+    ), reduced
+    assert reduced["attempt_accounting"]["failure_class"] == (
+        "job_materialization_failed"
+    ), reduced
+    assert "skillsbench_remote_bridge_agent_operation_trace_missing" not in reduced[
+        "failure_attribution_labels"
+    ], reduced
+    assert "skillsbench_verifier_package_install_risk" in reduced[
+        "failure_attribution_labels"
+    ], reduced
+    diagnostic = reduced["verifier_bootstrap_diagnostic"]
+    assert diagnostic["pre_agent_setup_blocked"] is True, diagnostic
+    assert diagnostic["verifier_package_install_risk_detected"] is True, diagnostic
+    assert diagnostic["raw_logs_read"] is False, diagnostic
+    assert diagnostic["raw_task_text_read"] is False, diagnostic
+    assert diagnostic["raw_trajectory_read"] is False, diagnostic
+
+
 def test_completed_score_is_not_reclassified_by_bootstrap_risk() -> None:
     compact = _missing_score_compact()
     plan = _uv_bootstrap_plan()
@@ -149,5 +255,6 @@ def test_completed_score_is_not_reclassified_by_bootstrap_risk() -> None:
 
 if __name__ == "__main__":
     test_missing_score_uv_bootstrap_risk_gets_verifier_dependency_attribution()
+    test_pre_agent_package_install_risk_overrides_bridge_trace_missing()
     test_completed_score_is_not_reclassified_by_bootstrap_risk()
     print("skillsbench-verifier-bootstrap-missing-score-smoke: ok")

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -1619,6 +1619,13 @@ def skillsbench_runner_error_attribution(error_text: str) -> tuple[str, str, lis
             "skillsbench_verifier_setup_preflight_blocked",
             "skillsbench_environment_setup_error",
         ]
+    if "benchmark egress proxy preflight blocked" in text:
+        label = "skillsbench_benchmark_egress_proxy_preflight_blocked"
+        return label, label, [
+            label,
+            "skillsbench_benchmark_egress_proxy_required",
+            "skillsbench_environment_setup_error",
+        ]
     if "docker compose command failed" in text:
         if (
             "cannot connect to the docker daemon" in text

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -1536,7 +1536,7 @@ class SkillsBenchLocalAcpRelay:
                         and bridge_summary_path is not None
                         and not _bridge_summary_has_inflight_operation(
                             bridge_summary_path
-                        )
+                        ) and (not post_bridge_recovery_attempt_count or now - last_bridge_activity_at >= 30.0)
                     ):
                         post_bridge_blocker_stage = (
                             _codex_cli_tui_post_bridge_blocker_stage(

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -1553,7 +1553,7 @@ class SkillsBenchLocalAcpRelay:
                         )
                         if (
                             recovery_action == "press_enter"
-                            and post_bridge_recovery_attempt_count < 1
+                            and post_bridge_recovery_attempt_count < 2
                         ):
                             post_bridge_recovery_attempt_count += 1
                             post_bridge_recovery_action = recovery_action
@@ -1567,7 +1567,7 @@ class SkillsBenchLocalAcpRelay:
                             continue
                         if (
                             recovery_action == "typed_continue"
-                            and post_bridge_recovery_attempt_count < 1
+                            and post_bridge_recovery_attempt_count < 2
                         ):
                             post_bridge_recovery_attempt_count += 1
                             post_bridge_recovery_action = recovery_action

--- a/loopx/benchmark_adapters/skillsbench_verifier_bootstrap.py
+++ b/loopx/benchmark_adapters/skillsbench_verifier_bootstrap.py
@@ -17,6 +17,11 @@ GENERIC_MISSING_ATTRIBUTIONS = {
     "skillsbench_verifier_reward_missing",
 }
 
+SETUP_PREFLIGHT_REPLACEABLE_ATTRIBUTIONS = GENERIC_MISSING_ATTRIBUTIONS | {
+    "skillsbench_product_mode_lifecycle_missing",
+    "skillsbench_remote_bridge_agent_operation_trace_missing",
+}
+
 GENERIC_MISSING_LABELS = {
     "official_score_missing",
     "skillsbench_result_json_missing_after_runner_exit",
@@ -25,6 +30,12 @@ GENERIC_MISSING_LABELS = {
     "skillsbench_runner_interrupted_before_official_result",
     "skillsbench_runner_setup_error",
     "skillsbench_verifier_reward_missing",
+}
+
+SETUP_PREFLIGHT_REPLACEABLE_LABELS = GENERIC_MISSING_LABELS | {
+    "skillsbench_product_mode_lifecycle_missing",
+    "skillsbench_product_mode_uncountable_treatment",
+    "skillsbench_remote_bridge_agent_operation_trace_missing",
 }
 
 
@@ -38,7 +49,7 @@ def apply_skillsbench_verifier_bootstrap_missing_score_attribution(
     task_staging: dict[str, Any] | None = None,
     setup_preflight: dict[str, Any] | None = None,
 ) -> bool:
-    """Classify missing official score when public preflight saw uv bootstrap risk."""
+    """Classify missing official score when public preflight saw bootstrap risk."""
 
     if compact.get("official_score_status") != "missing":
         return False
@@ -60,15 +71,49 @@ def apply_skillsbench_verifier_bootstrap_missing_score_attribution(
         task_staging.get("verifier_uv_bootstrap_risk_detected") is True
         or setup_preflight.get("verifier_uv_bootstrap_risk_detected") is True
     )
-    verifier_bootstrap_blocked = (
+    package_install_risk = (
+        task_staging.get("verifier_package_install_risk_detected") is True
+        or setup_preflight.get("verifier_package_install_risk_detected") is True
+    )
+    verifier_bootstrap_risk = (
+        task_staging.get("verifier_bootstrap_risk_detected") is True
+        or setup_preflight.get("verifier_bootstrap_risk_detected") is True
+    )
+    bootstrap_light_blocking_fields = setup_preflight.get(
+        "bootstrap_light_blocking_fields"
+    )
+    if not isinstance(bootstrap_light_blocking_fields, list):
+        bootstrap_light_blocking_fields = []
+    explicit_bootstrap_blocked = (
         task_staging.get("verifier_bootstrap_risk_preflight_blocked") is True
         or setup_preflight.get("first_blocker") == "verifier_bootstrap_risk"
     )
-    if not (uv_bootstrap_risk or verifier_bootstrap_blocked):
+    pre_agent_setup_blocked = (
+        explicit_bootstrap_blocked
+        or task_staging.get("staged") is False
+        or setup_preflight.get("bootstrap_light_candidate_eligible") is False
+        or "verifier_package_install_risk_detected" in bootstrap_light_blocking_fields
+        or "verifier_bootstrap_risk_detected" in bootstrap_light_blocking_fields
+    )
+    verifier_bootstrap_blocked = explicit_bootstrap_blocked or (
+        verifier_bootstrap_risk
+        and pre_agent_setup_blocked
+        and setup_preflight.get("status") == "verifier_bootstrap_risk_detected"
+    )
+    if not (
+        uv_bootstrap_risk
+        or verifier_bootstrap_blocked
+        or (package_install_risk and verifier_bootstrap_risk)
+    ):
         return False
 
     current_attribution = str(compact.get("score_failure_attribution") or "")
-    if current_attribution not in GENERIC_MISSING_ATTRIBUTIONS:
+    replaceable_attributions = (
+        SETUP_PREFLIGHT_REPLACEABLE_ATTRIBUTIONS
+        if pre_agent_setup_blocked
+        else GENERIC_MISSING_ATTRIBUTIONS
+    )
+    if current_attribution not in replaceable_attributions:
         return False
 
     existing_labels = [
@@ -76,7 +121,12 @@ def apply_skillsbench_verifier_bootstrap_missing_score_attribution(
         for label in compact.get("failure_attribution_labels", [])
         if isinstance(label, str) and label
     ]
-    if any(label not in GENERIC_MISSING_LABELS for label in existing_labels):
+    replaceable_labels = (
+        SETUP_PREFLIGHT_REPLACEABLE_LABELS
+        if pre_agent_setup_blocked
+        else GENERIC_MISSING_LABELS
+    )
+    if any(label not in replaceable_labels for label in existing_labels):
         return False
 
     attribution = "verifier_dependency_install_failure"
@@ -94,12 +144,21 @@ def apply_skillsbench_verifier_bootstrap_missing_score_attribution(
         _public_int(compact.get("verifier_dependency_failure_count")),
     )
 
-    labels = list(existing_labels)
+    labels = [
+        label for label in existing_labels if label not in SETUP_PREFLIGHT_REPLACEABLE_LABELS
+    ]
     for label in (
         attribution,
-        "verifier_uv_install_or_download_failure",
         "skillsbench_verifier_bootstrap_missing_official_score",
     ):
+        if label not in labels:
+            labels.append(label)
+    if uv_bootstrap_risk:
+        label = "verifier_uv_install_or_download_failure"
+        if label not in labels:
+            labels.append(label)
+    if package_install_risk:
+        label = "skillsbench_verifier_package_install_risk"
         if label not in labels:
             labels.append(label)
     if verifier_bootstrap_blocked:
@@ -120,12 +179,19 @@ def apply_skillsbench_verifier_bootstrap_missing_score_attribution(
         runner_failure["failure_class"] = attribution
         runner_failure["verifier_bootstrap_missing_score_attributed"] = True
 
+    attempt_accounting = compact.get("attempt_accounting")
+    if pre_agent_setup_blocked and isinstance(attempt_accounting, dict):
+        attempt_accounting["failure_label"] = attribution
+        attempt_accounting["failure_class"] = "job_materialization_failed"
+
     diagnostic: dict[str, Any] = {
         "schema_version": "skillsbench_verifier_bootstrap_missing_score_diagnostic_v0",
         "status": "missing_official_score_with_verifier_bootstrap_risk",
         "score_failure_attribution": attribution,
         "verifier_uv_bootstrap_risk_detected": uv_bootstrap_risk,
+        "verifier_package_install_risk_detected": package_install_risk,
         "verifier_bootstrap_risk_preflight_blocked": verifier_bootstrap_blocked,
+        "pre_agent_setup_blocked": pre_agent_setup_blocked,
         "verifier_uv_bootstrap_mirror_patch_required": task_staging.get(
             "verifier_uv_bootstrap_mirror_patch_required"
         )

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -2787,6 +2787,119 @@ def _apply_skillsbench_pre_agent_setup_compact_projection(
     compact["native_goal_worker_pre_agent_setup_blocked"] = True
 
 
+def _apply_skillsbench_benchmark_egress_preflight_compact_projection(
+    compact: dict[str, Any],
+    *,
+    source: dict[str, Any] | None = None,
+) -> None:
+    source = source if isinstance(source, dict) else {}
+    source_runner_config = (
+        source.get("runner_config")
+        if isinstance(source.get("runner_config"), dict)
+        else {}
+    )
+    proxy_required = (
+        compact.get("benchmark_egress_proxy_required") is True
+        or source_runner_config.get("benchmark_egress_proxy_required") is True
+    )
+    proxy_ready = (
+        compact.get("benchmark_egress_proxy_ready") is True
+        or source_runner_config.get("benchmark_egress_proxy_ready") is True
+    )
+    proxy_status = public_safe_compact_text(
+        compact.get("benchmark_egress_proxy_status")
+        or source_runner_config.get("benchmark_egress_proxy_status"),
+        limit=120,
+    )
+    if not proxy_required or proxy_ready:
+        return
+    if proxy_status not in {
+        "failed",
+        "invalid_proxy_value",
+        "missing_required_proxy",
+        "proxy_connect_rejected",
+        "unsupported_proxy_scheme",
+    }:
+        return
+    if not _skillsbench_compact_official_score_missing(compact):
+        return
+
+    label = "skillsbench_benchmark_egress_proxy_preflight_blocked"
+    compact["score_failure_attribution"] = label
+    compact["first_blocker"] = label
+    compact["repeat_blocked_by"] = label
+    compact["official_score_comparable_to_native_codex"] = False
+    compact["official_score_comparable_to_loopx_treatment"] = False
+
+    labels = [
+        item
+        for item in compact.get("failure_attribution_labels", [])
+        if isinstance(item, str)
+        and item
+        and item
+        not in {
+            "skillsbench_product_mode_uncountable_treatment",
+            "skillsbench_remote_bridge_agent_operation_trace_missing",
+        }
+    ]
+    for item in (
+        label,
+        "skillsbench_environment_setup_error",
+        f"skillsbench_benchmark_egress_proxy_{proxy_status}",
+    ):
+        if item not in labels:
+            labels.append(item)
+    compact["failure_attribution_labels"] = labels[:MAX_BENCHMARK_RUN_LIST_ITEMS]
+
+    attempt_accounting = compact.get("attempt_accounting")
+    if isinstance(attempt_accounting, dict):
+        attempt_accounting["failure_label"] = label
+        attempt_accounting["failure_class"] = "job_materialization_failed"
+    runner_failure = compact.get("runner_failure")
+    if isinstance(runner_failure, dict):
+        runner_failure["failure_class"] = label
+        runner_failure["benchmark_egress_proxy_preflight_blocked"] = True
+
+    validation = (
+        compact.get("validation")
+        if isinstance(compact.get("validation"), dict)
+        else {}
+    )
+    validation["benchmark_egress_proxy_preflight_blocked"] = True
+    validation["raw_verifier_output_read"] = False
+    validation["all_passed"] = False
+    compact["validation"] = validation
+
+    compact["benchmark_egress_proxy_diagnostic"] = {
+        "schema_version": "skillsbench_benchmark_egress_proxy_diagnostic_v0",
+        "status": "benchmark_egress_proxy_preflight_blocked",
+        "score_failure_attribution": label,
+        "proxy_required": True,
+        "proxy_ready": False,
+        "proxy_status": proxy_status,
+        "proxy_error_kind": public_safe_compact_text(
+            compact.get("benchmark_egress_proxy_error_kind")
+            or source_runner_config.get("benchmark_egress_proxy_error_kind"),
+            limit=120,
+        ),
+        "proxy_mode_requested": public_safe_compact_text(
+            compact.get("benchmark_egress_proxy_mode_requested")
+            or source_runner_config.get("benchmark_egress_proxy_mode_requested"),
+            limit=80,
+        ),
+        "proxy_mode_effective": public_safe_compact_text(
+            compact.get("benchmark_egress_proxy_mode_effective")
+            or source_runner_config.get("benchmark_egress_proxy_mode_effective"),
+            limit=80,
+        ),
+        "proxy_url_recorded": False,
+        "raw_logs_read": False,
+        "raw_task_text_read": False,
+        "raw_trajectory_read": False,
+        "next_diagnostic_action": "configure_valid_private_benchmark_egress_proxy",
+    }
+
+
 def _compact_benchmark_result_discovery(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict):
         return {}
@@ -4508,6 +4621,10 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
         compact["validation"] = compact_validation
         _apply_skillsbench_pre_agent_setup_compact_projection(compact)
 
+    _apply_skillsbench_benchmark_egress_preflight_compact_projection(
+        compact,
+        source=source,
+    )
     apply_skillsbench_verifier_bootstrap_missing_score_attribution(
         compact,
         task_staging=compact.get("task_staging"),

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -9,6 +9,9 @@ from typing import Any
 from .benchmark_adapters.skillsbench_signals import (
     build_skillsbench_solution_quality_signals,
 )
+from .benchmark_adapters.skillsbench_verifier_bootstrap import (
+    apply_skillsbench_verifier_bootstrap_missing_score_attribution,
+)
 from .control_plane import compact_control_plane_policy, control_plane_policy_summary
 from .contract import check_contract
 from .control_plane.work_items.delivery_batch_scale import (
@@ -4504,6 +4507,12 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
                 compact_validation[field] = validation[field]
         compact["validation"] = compact_validation
         _apply_skillsbench_pre_agent_setup_compact_projection(compact)
+
+    apply_skillsbench_verifier_bootstrap_missing_score_attribution(
+        compact,
+        task_staging=compact.get("task_staging"),
+        setup_preflight=compact.get("task_setup_preflight"),
+    )
 
     solution_quality = build_skillsbench_solution_quality_signals(compact)
     if solution_quality:


### PR DESCRIPTION
Summary
- avoid immediately reclassifying stale Codex CLI TUI timeout text after one post-bridge recovery action
- keep the guard public-safe by using existing bridge activity timing signals
- add a focused smoke assertion for the recovery cooldown contract

Validation
- python3 -m py_compile loopx/benchmark_adapters/skillsbench_acp_relay.py examples/skillsbench-codex-cli-goal-route-smoke.py
- python3 examples/skillsbench-codex-cli-goal-route-smoke.py
- python3 examples/control_plane/repo-python-line-budget-smoke.py
- git diff --check
- loopx check --scan-path loopx/benchmark_adapters/skillsbench_acp_relay.py --scan-path examples/skillsbench-codex-cli-goal-route-smoke.py
- loopx canary premerge --from-git-diff: direct/catalog/public-boundary checks passed; manual hold remains benchmark_sensitive

Hold
- Draft until a clean-root civ6 codex-cli-goal xhigh canary verifies the post-bridge recovery path on this branch.