### PR TITLE
Refine quota state-machine fixture helpers

### DIFF
--- a/examples/control_plane/control-plane-risk-characterization-smoke.py
+++ b/examples/control_plane/control-plane-risk-characterization-smoke.py
@@ -19,76 +19,16 @@ if str(REPO_ROOT) not in sys.path:
 
 from loopx.quota import build_quota_should_run  # noqa: E402
 from loopx.review_packet import build_review_packet  # noqa: E402
-from loopx.status import compact_todo_group  # noqa: E402
+from loopx.control_plane.testing.quota_fixtures import (  # noqa: E402
+    quota_status_payload,
+    quota_todo_item as todo_item,
+    quota_todo_summary,
+)
 
 
 GOAL_ID = "control-plane-risk-characterization"
 AGENT_ID = "codex-product-capability"
 PRIMARY_AGENT_ID = "codex-main-control"
-
-
-def todo_item(
-    *,
-    todo_id: str,
-    title: str,
-    priority: str = "P0",
-    task_class: str = "advancement_task",
-    role: str = "agent",
-    status: str = "open",
-    claimed_by: str | None = None,
-    blocks_agent: str | None = None,
-    index: int = 1,
-    next_due_at: str | None = None,
-    cadence: str | None = None,
-    resume_when: str | None = None,
-) -> dict[str, Any]:
-    item: dict[str, Any] = {
-        "todo_id": todo_id,
-        "index": index,
-        "text": f"[{priority}] {title}",
-        "title": title,
-        "priority": priority,
-        "role": role,
-        "status": status,
-        "done": status == "done",
-        "task_class": task_class,
-    }
-    if claimed_by:
-        item["claimed_by"] = claimed_by
-    if blocks_agent:
-        item["blocks_agent"] = blocks_agent
-    if next_due_at:
-        item["next_due_at"] = next_due_at
-    if cadence:
-        item["cadence"] = cadence
-    if resume_when:
-        item["resume_when"] = resume_when
-    return item
-
-
-def todo_summary(items: list[dict[str, Any]], *, role: str) -> dict[str, Any]:
-    open_items = [item for item in items if item.get("status") == "open"]
-    executable_items = [
-        item for item in open_items if item.get("task_class") == "advancement_task"
-    ]
-    monitor_items = [
-        item for item in open_items if item.get("task_class") == "continuous_monitor"
-    ]
-    due_monitor_items = [item for item in monitor_items if item.get("next_due_at")]
-    return {
-        "schema_version": "todo_summary_v0",
-        "source_section": "Agent Todo" if role == "agent" else "User Todo",
-        "total_count": len(items),
-        "open_count": len(open_items),
-        "done_count": len(items) - len(open_items),
-        "items": items,
-        "first_open_items": open_items[:3],
-        "first_executable_items": executable_items[:3],
-        "executable_backlog_items": executable_items,
-        "monitor_open_items": monitor_items,
-        "monitor_due_items": due_monitor_items,
-        "monitor_due_count": len(due_monitor_items),
-    }
 
 
 def status_payload(
@@ -99,64 +39,31 @@ def status_payload(
     quota_state: str = "eligible",
     safe_bypass: bool = False,
 ) -> dict[str, Any]:
-    agent_todos = agent_todos or todo_summary(agent_items, role="agent")
-    user_todos = todo_summary(user_items or [], role="user")
-    quota = {
-        "state": quota_state,
-        "reason": "fixture quota",
-        "compute": 1.0,
-        "window_hours": 24,
-        "slot_minutes": 1,
-        "allowed_slots": 10,
-        "spent_slots": 0,
-    }
-    if safe_bypass:
-        quota.update(
-            {
-                "safe_bypass_allowed": True,
-                "safe_bypass_kind": "scoped_user_gate_fallback",
-                "safe_bypass_policy": "fixture safe bypass",
-            }
-        )
-    item = {
-        "goal_id": GOAL_ID,
-        "status": "operator_gate"
-        if quota_state == "operator_gate"
-        else "active_state_agent_todo",
-        "waiting_on": "controller" if quota_state == "operator_gate" else "codex",
-        "severity": "active",
-        "source": "active_state",
-        "recommended_action": "Goal-level route should remain human-facing.",
-        "active_state_next_action": "Goal-level route should remain human-facing.",
-        "quota": quota,
-        "agent_todos": agent_todos,
-        "user_todos": user_todos,
-        "project_asset": {
-            "agent_todos": agent_todos,
-            "user_todos": user_todos,
-            "next_action": "Goal-level route should remain human-facing.",
+    next_action = "Goal-level route should remain human-facing."
+    return quota_status_payload(
+        goal_id=GOAL_ID,
+        status=(
+            "operator_gate"
+            if quota_state == "operator_gate"
+            else "active_state_agent_todo"
+        ),
+        source="active_state",
+        project_asset_source="project_asset",
+        recommended_action=next_action,
+        next_action=next_action,
+        active_state_next_action=next_action,
+        agent_todo_items=agent_items,
+        agent_todos=agent_todos,
+        user_todo_items=user_items or [],
+        quota_state=quota_state,
+        safe_bypass=safe_bypass,
+        coordination={
+            "primary_agent": PRIMARY_AGENT_ID,
+            "registered_agents": [PRIMARY_AGENT_ID, AGENT_ID],
         },
-        "project_asset_source": "project_asset",
-    }
-    return {
-        "ok": True,
-        "goal_count": 1,
-        "attention_queue": {"items": [item]},
-        "run_history": {
-            "goals": [
-                {
-                    "id": GOAL_ID,
-                    "status": "active",
-                    "registry_member": True,
-                    "coordination": {
-                        "primary_agent": PRIMARY_AGENT_ID,
-                        "registered_agents": [PRIMARY_AGENT_ID, AGENT_ID],
-                    },
-                    "latest_runs": [],
-                }
-            ]
-        },
-    }
+        latest_runs=[],
+        registry_status="active",
+    )
 
 
 def assert_agent_lane_delivery() -> None:
@@ -408,7 +315,7 @@ def assert_monitor_only_frontier_quiets_until_material_transition() -> None:
 
 
 def assert_standing_monitor_gate_does_not_quiet_skip_gated_advancement() -> None:
-    agent_todos = compact_todo_group(
+    agent_todos = quota_todo_summary(
         [
             todo_item(
                 todo_id="todo_standing_gate",
@@ -428,7 +335,6 @@ def assert_standing_monitor_gate_does_not_quiet_skip_gated_advancement() -> None
                 resume_when="todo_done:todo_standing_gate",
             ),
         ],
-        source_section="Agent Todo",
         role="agent",
         item_limit=None,
     )

--- a/examples/control_plane/external-evidence-observation-smoke.py
+++ b/examples/control_plane/external-evidence-observation-smoke.py
@@ -19,6 +19,11 @@ from loopx.control_plane.scheduler.external_evidence_observation import (  # noq
 from loopx.control_plane.scheduler.monitor_poll_policy import (  # noqa: E402
     allows_no_spend_external_monitor_poll,
 )
+from loopx.control_plane.testing.quota_fixtures import (  # noqa: E402
+    quota_status_payload,
+    quota_todo_item,
+    quota_todo_summary,
+)
 from loopx.control_plane.todos.contract import (  # noqa: E402
     TODO_TASK_CLASS_ADVANCEMENT,
     TODO_TASK_CLASS_MONITOR,
@@ -27,7 +32,6 @@ from loopx.control_plane.todos.projection import (  # noqa: E402
     todo_summary_open_task_counts,
 )
 from loopx.quota import build_quota_should_run  # noqa: E402
-from loopx.status import compact_todo_group  # noqa: E402
 
 
 GOAL_ID = "external-evidence-observation-fixture"
@@ -44,34 +48,23 @@ def todo(
     todo_id: str,
     **metadata: Any,
 ) -> dict[str, Any]:
-    item = {
-        "schema_version": "todo_item_v0",
-        "todo_id": todo_id,
-        "role": "agent",
-        "source_section": "Agent Todo",
-        "status": "open",
-        "done": False,
-        "index": index,
-        "text": text,
-        "task_class": task_class,
-    }
-    item.update(metadata)
-    return item
+    return quota_todo_item(
+        todo_id=todo_id,
+        role="agent",
+        status="open",
+        index=index,
+        text=text,
+        task_class=task_class,
+        **metadata,
+    )
 
 
 def agent_todos(items: list[dict[str, Any]]) -> dict[str, Any]:
-    summary = compact_todo_group(items, source_section="Agent Todo", role="agent")
-    if summary is None:
-        summary = {
-            "schema_version": "todo_summary_v0",
-            "source_section": "Agent Todo",
-            "total_count": 0,
-            "open_count": 0,
-            "done_count": 0,
-            "first_open_items": [],
-        }
-    summary["claim_scope"] = {"agent_id": AGENT_ID}
-    return summary
+    return quota_todo_summary(
+        items,
+        role="agent",
+        claim_scope_agent_id=AGENT_ID,
+    )
 
 
 def monitor_todo(
@@ -108,51 +101,21 @@ def status_payload(
     waiting_on: str = "codex",
     next_action: str = "Observe compact result marker for remote job handle.",
 ) -> dict[str, Any]:
-    quota = {
-        "compute": 1.0,
-        "window_hours": 24,
-        "slot_minutes": 1,
-        "allowed_slots": 1440,
-        "spent_slots": 0,
-        "state": "eligible",
-        "reason": "fixture eligible quota",
-    }
-    return {
-        "ok": True,
-        "attention_queue": {
-            "items": [
-                {
-                    "goal_id": GOAL_ID,
-                    "status": status,
-                    "waiting_on": waiting_on,
-                    "severity": "info",
-                    "source": "project_asset",
-                    "recommended_action": next_action,
-                    "quota": quota,
-                    "agent_todos": summary,
-                    "project_asset": {
-                        "agent_todos": summary,
-                        "next_action": next_action,
-                    },
-                    "lifecycle_flags": ["launched polling result marker"],
-                }
-            ]
+    return quota_status_payload(
+        goal_id=GOAL_ID,
+        status=status,
+        waiting_on=waiting_on,
+        recommended_action=next_action,
+        next_action=next_action,
+        agent_todos=summary,
+        quota_extra={"allowed_slots": 1440},
+        coordination={
+            "primary_agent": "codex-main-control",
+            "registered_agents": ["codex-main-control", AGENT_ID],
         },
-        "run_history": {
-            "goals": [
-                {
-                    "id": GOAL_ID,
-                    "registry_member": True,
-                    "quota": quota,
-                    "latest_runs": [],
-                    "coordination": {
-                        "primary_agent": "codex-main-control",
-                        "registered_agents": ["codex-main-control", AGENT_ID],
-                    },
-                }
-            ]
-        },
-    }
+        latest_runs=[],
+        item_extra={"lifecycle_flags": ["launched polling result marker"]},
+    )
 
 
 def selected_item(payload: dict[str, Any]) -> dict[str, Any]:

--- a/loopx/control_plane/testing/quota_fixtures.py
+++ b/loopx/control_plane/testing/quota_fixtures.py
@@ -16,17 +16,78 @@ DEFAULT_FIXTURE_QUOTA = {
 }
 
 
+def quota_todo_item(
+    *,
+    todo_id: str,
+    index: int = 1,
+    role: str = "agent",
+    status: str = "open",
+    task_class: str = "advancement_task",
+    priority: str = "P0",
+    title: str | None = None,
+    text: str | None = None,
+    claimed_by: str | None = None,
+    blocks_agent: str | None = None,
+    action_kind: str | None = None,
+    **metadata: Any,
+) -> dict[str, Any]:
+    if text is None:
+        if title is None:
+            raise ValueError("quota_todo_item requires title or text")
+        text = f"[{priority}] {title}"
+    if title is None:
+        title = text
+    item: dict[str, Any] = {
+        "schema_version": "todo_item_v0",
+        "todo_id": todo_id,
+        "index": index,
+        "text": text,
+        "title": title,
+        "priority": priority,
+        "role": role,
+        "status": status,
+        "done": status == "done",
+        "task_class": task_class,
+        "source_section": "Agent Todo" if role == "agent" else "User Todo",
+    }
+    if claimed_by:
+        item["claimed_by"] = claimed_by
+    if blocks_agent:
+        item["blocks_agent"] = blocks_agent
+    if action_kind:
+        item["action_kind"] = action_kind
+    item.update(metadata)
+    return item
+
+
 def quota_todo_summary(
     items: list[dict[str, Any]],
     *,
     role: str = "agent",
     claim_scope_agent_id: str | None = None,
+    item_limit: int | None = None,
 ) -> dict[str, Any]:
+    source_section = "Agent Todo" if role == "agent" else "User Todo"
     summary = compact_todo_group(
         items,
-        source_section="Agent Todo" if role == "agent" else "User Todo",
+        source_section=source_section,
         role=role,
+        item_limit=item_limit,
     )
+    if summary is None:
+        summary = {
+            "schema_version": "todo_summary_v0",
+            "source_section": source_section,
+            "total_count": 0,
+            "open_count": 0,
+            "done_count": 0,
+            "first_open_items": [],
+            "first_executable_items": [],
+            "executable_backlog_items": [],
+            "monitor_open_items": [],
+            "monitor_due_items": [],
+            "monitor_due_count": 0,
+        }
     if claim_scope_agent_id:
         summary["claim_scope"] = {"agent_id": claim_scope_agent_id}
     return summary
@@ -36,38 +97,79 @@ def quota_status_payload(
     *,
     goal_id: str,
     status: str,
-    agent_todo_items: list[dict[str, Any]],
+    agent_todo_items: list[dict[str, Any]] | None = None,
     recommended_action: str,
     next_action: str | None = None,
+    agent_todos: dict[str, Any] | None = None,
+    user_todo_items: list[dict[str, Any]] | None = None,
+    user_todos: dict[str, Any] | None = None,
+    quota_state: str = "eligible",
+    quota_extra: dict[str, Any] | None = None,
+    safe_bypass: bool = False,
+    source: str = "project_asset",
+    waiting_on: str | None = None,
+    active_state_next_action: str | None = None,
+    project_asset_source: str | None = None,
     coordination: dict[str, Any] | None = None,
     latest_runs: list[dict[str, Any]] | None = None,
     post_handoff_latest_run: dict[str, Any] | None = None,
     claim_scope_agent_id: str | None = None,
     registry_status: str | None = None,
     goal_extra: dict[str, Any] | None = None,
+    item_extra: dict[str, Any] | None = None,
+    project_asset_extra: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    agent_todos = quota_todo_summary(
+    agent_todo_items = agent_todo_items or []
+    agent_todos = agent_todos or quota_todo_summary(
         agent_todo_items,
         role="agent",
         claim_scope_agent_id=claim_scope_agent_id,
     )
+    user_todos = user_todos or quota_todo_summary(
+        user_todo_items or [],
+        role="user",
+    )
     quota = dict(DEFAULT_FIXTURE_QUOTA)
+    quota["state"] = quota_state
+    if quota_state != "eligible":
+        quota["reason"] = f"{quota_state} fixture"
+    if quota_extra:
+        quota.update(quota_extra)
+    if safe_bypass:
+        quota.update(
+            {
+                "safe_bypass_allowed": True,
+                "safe_bypass_kind": "scoped_user_gate_fallback",
+                "safe_bypass_policy": "fixture safe bypass",
+            }
+        )
     action = next_action if next_action is not None else recommended_action
     item: dict[str, Any] = {
         "goal_id": goal_id,
         "status": status,
-        "waiting_on": "codex",
+        "waiting_on": waiting_on
+        or ("controller" if quota_state == "operator_gate" else "codex"),
         "severity": "info",
-        "source": "project_asset",
+        "source": source,
         "recommended_action": recommended_action,
         "quota": quota,
         "agent_todos": agent_todos,
+        "user_todos": user_todos,
         "project_asset": {
             "next_action": action,
             "stop_condition": "stop on private material",
             "agent_todos": agent_todos,
+            "user_todos": user_todos,
         },
     }
+    if active_state_next_action:
+        item["active_state_next_action"] = active_state_next_action
+    if project_asset_source:
+        item["project_asset_source"] = project_asset_source
+    if project_asset_extra:
+        item["project_asset"].update(project_asset_extra)
+    if item_extra:
+        item.update(item_extra)
     if post_handoff_latest_run:
         item["handoff_readiness"] = {
             "post_handoff_run_seen": True,


### PR DESCRIPTION
## Summary
- add shared quota todo/status fixture helpers for state-machine canaries
- migrate control-plane risk characterization and external-evidence observation smokes off local fixture builders
- reduce duplicate smoke setup while preserving quota/work-lane/external-evidence assertions

## Validation
- python3 -m py_compile loopx/control_plane/testing/quota_fixtures.py examples/control_plane/control-plane-risk-characterization-smoke.py examples/control_plane/external-evidence-observation-smoke.py
- python3 examples/control_plane/control-plane-risk-characterization-smoke.py
- python3 examples/control_plane/external-evidence-observation-smoke.py
- python3 examples/control_plane/quota-work-lane-policy-smoke.py
- python3 examples/control_plane/interaction-contract-state-machine-smoke.py
- python3 examples/control_plane/side-agent-self-iteration-state-machine-smoke.py
- python3 examples/control_plane/control-plane-integrated-canary-smoke.py
- python3 -m loopx.cli --format json canary premerge --from-git-diff
