### PR TITLE
Refactor quota state-machine smoke fixtures

### DIFF
--- a/examples/control_plane/quota-action-scope-guard-smoke.py
+++ b/examples/control_plane/quota-action-scope-guard-smoke.py
@@ -12,8 +12,13 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.boundary_authority import build_checkpointed_boundary_authority_entry  # noqa: E402
+from loopx.control_plane.testing.quota_fixtures import (  # noqa: E402
+    quota_status_payload,
+    quota_todo_item,
+    quota_todo_summary,
+)
 from loopx.quota import build_quota_should_run, render_quota_should_run_markdown  # noqa: E402
-from loopx.status import compact_todo_group, project_asset_todo_summary  # noqa: E402
+from loopx.status import project_asset_todo_summary  # noqa: E402
 from loopx.control_plane.todos.contract import format_todo_metadata_line, parse_todo_metadata_line  # noqa: E402
 
 
@@ -28,70 +33,34 @@ def status_payload(
     todos: list[dict] | None = None,
 ) -> dict:
     todo_items = todos or [
-        {
-            "index": 1,
-            "done": False,
-            "status": "open",
-            "text": TODO_TEXT,
-            "task_class": "advancement_task",
-            "action_kind": "implement",
-            "required_write_scopes": ["runners/openviking/**"],
-        }
+        quota_todo_item(
+            todo_id="todo_required_scope",
+            text=TODO_TEXT,
+            action_kind="implement",
+            required_write_scopes=["runners/openviking/**"],
+        )
     ]
-    agent_todos = {
-        "schema_version": "todo_summary_v0",
-        "source_section": "Agent Todo",
-        "open_count": len(todo_items),
-        "done_count": 0,
-        "total_count": len(todo_items),
-        "first_open_items": todo_items,
-        "first_executable_items": todo_items,
-        "items": todo_items,
-    }
-    return {
-        "ok": True,
-        "goal_count": 1,
-        "run_count": 0,
-        "attention_queue": {
-            "items": [
-                {
-                    "goal_id": GOAL_ID,
-                    "status": "active",
-                    "waiting_on": "codex",
-                    "severity": "action",
-                    "source": "latest_run",
-                    "recommended_action": "Execute the first agent todo only if its required scope is inside goal_boundary.",
-                    "quota": {
-                        "compute": 1.0,
-                        "window_hours": 24,
-                        "slot_minutes": 1,
-                        "allowed_slots": 1440,
-                        "spent_slots": 0,
-                        "state": "eligible",
-                        "reason": "eligible fixture",
-                    },
-                    "agent_todos": agent_todos,
-                }
-            ]
+    agent_todos = quota_todo_summary(todo_items, role="agent")
+    return quota_status_payload(
+        goal_id=GOAL_ID,
+        status="active",
+        recommended_action=(
+            "Execute the first agent todo only if its required scope is inside goal_boundary."
+        ),
+        agent_todos=agent_todos,
+        source="latest_run",
+        registry_status="active",
+        coordination={
+            "write_scope": allowed_scopes,
+            "requires_parent_approval": ["publish", "production-action"],
+            "checkpointed_boundary_authority": checkpointed_boundary_authority or [],
         },
-        "run_history": {
-            "goals": [
-                {
-                    "id": GOAL_ID,
-                    "registry_member": True,
-                    "status": "active",
-                    "adapter_kind": "fixture_adapter_v0",
-                    "adapter_status": "connected",
-                    "coordination": {
-                        "write_scope": allowed_scopes,
-                        "requires_parent_approval": ["publish", "production-action"],
-                        "checkpointed_boundary_authority": checkpointed_boundary_authority or [],
-                    },
-                    "latest_runs": [],
-                }
-            ]
+        latest_runs=[],
+        goal_extra={
+            "adapter_kind": "fixture_adapter_v0",
+            "adapter_status": "connected",
         },
-    }
+    )
 
 
 def assert_missing_scope_repairs_boundary() -> None:
@@ -131,7 +100,7 @@ def assert_required_write_scope_metadata_roundtrip() -> None:
     parsed = parse_todo_metadata_line(metadata_line)
     assert parsed is not None, metadata_line
     assert parsed["required_write_scopes"] == ["runners/openviking/**", "docs/**"], parsed
-    group = compact_todo_group(
+    group = quota_todo_summary(
         [
             {
                 "index": 1,
@@ -140,7 +109,6 @@ def assert_required_write_scope_metadata_roundtrip() -> None:
                 **parsed,
             }
         ],
-        source_section="Agent Todo",
         role="agent",
     )
     assert group is not None, group

--- a/examples/control_plane/quota-resume-gated-open-todo-smoke.py
+++ b/examples/control_plane/quota-resume-gated-open-todo-smoke.py
@@ -9,8 +9,13 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 
+from loopx.control_plane.testing.quota_fixtures import (  # noqa: E402
+    quota_status_payload,
+    quota_todo_item,
+    quota_todo_summary,
+)
 from loopx.quota import build_quota_should_run  # noqa: E402
-from loopx.status import compact_todo_group, parse_active_state_todos  # noqa: E402
+from loopx.status import parse_active_state_todos  # noqa: E402
 
 
 GOAL_ID = "resume-gated-open-todo-fixture"
@@ -27,99 +32,51 @@ ARCHIVE_MONITOR_ACTION = "[P1] Monitor product refactor/catalog canary continuat
 
 
 def build_agent_todos(*, prerequisite_status: str) -> dict:
-    agent_todos = compact_todo_group(
+    agent_todos = quota_todo_summary(
         [
-            {
-                "index": 1,
-                "text": "[P0] Refresh the projection prerequisite.",
-                "role": "agent",
-                "status": prerequisite_status,
-                "priority": "P0",
-                "task_class": "continuous_monitor",
-                "claimed_by": "codex-side-bypass",
-                "todo_id": BLOCKING_TODO_ID,
-            },
-            {
-                "index": 2,
-                "text": GATED_ACTION,
-                "role": "agent",
-                "status": "open",
-                "priority": "P0",
-                "task_class": "advancement_task",
-                "claimed_by": AGENT_ID,
-                "todo_id": GATED_TODO_ID,
-                "required_capabilities": ["shell"],
-                "resume_when": f"todo_done:{BLOCKING_TODO_ID}",
-            },
-            {
-                "index": 3,
-                "text": FALLBACK_ACTION,
-                "role": "agent",
-                "status": "open",
-                "priority": "P1",
-                "task_class": "advancement_task",
-                "claimed_by": AGENT_ID,
-                "todo_id": FALLBACK_TODO_ID,
-                "required_capabilities": ["shell"],
-            },
+            quota_todo_item(
+                todo_id=BLOCKING_TODO_ID,
+                index=1,
+                text="[P0] Refresh the projection prerequisite.",
+                status=prerequisite_status,
+                task_class="continuous_monitor",
+                claimed_by="codex-side-bypass",
+            ),
+            quota_todo_item(
+                todo_id=GATED_TODO_ID,
+                index=2,
+                text=GATED_ACTION,
+                claimed_by=AGENT_ID,
+                required_capabilities=["shell"],
+                resume_when=f"todo_done:{BLOCKING_TODO_ID}",
+            ),
+            quota_todo_item(
+                todo_id=FALLBACK_TODO_ID,
+                index=3,
+                priority="P1",
+                text=FALLBACK_ACTION,
+                claimed_by=AGENT_ID,
+                required_capabilities=["shell"],
+            ),
         ],
-        source_section="Agent Todo",
         role="agent",
     )
-    assert agent_todos is not None, agent_todos
     return agent_todos
 
 
 def status_payload(agent_todos: dict, *, next_action: str) -> dict:
-    item = {
-        "goal_id": GOAL_ID,
-        "status": "resume_gated_open_todo_fixture",
-        "waiting_on": "codex",
-        "severity": "info",
-        "source": "project_asset",
-        "recommended_action": next_action,
-        "quota": {
-            "compute": 1.0,
-            "window_hours": 24,
-            "slot_minutes": 1,
-            "allowed_slots": 10,
-            "spent_slots": 0,
-            "state": "eligible",
-            "reason": "eligible fixture",
-        },
-        "coordination": {
-            "primary_agent": PRIMARY_AGENT,
-            "registered_agents": [PRIMARY_AGENT, "codex-side-bypass", AGENT_ID],
-        },
-        "project_asset": {
-            "next_action": next_action,
-            "stop_condition": "stop on private material",
-            "agent_todos": agent_todos,
-        },
-        "agent_todos": agent_todos,
+    coordination = {
+        "primary_agent": PRIMARY_AGENT,
+        "registered_agents": [PRIMARY_AGENT, "codex-side-bypass", AGENT_ID],
     }
-    return {
-        "ok": True,
-        "attention_queue": {"items": [item]},
-        "run_history": {
-            "goals": [
-                {
-                    "id": GOAL_ID,
-                    "registry_member": True,
-                    "status": "resume_gated_open_todo_fixture",
-                    "adapter_kind": "harness_self_improvement",
-                    "adapter_status": "connected-read-only",
-                    "quota": {
-                        "compute": 1.0,
-                        "window_hours": 24,
-                        "slot_minutes": 1,
-                        "allowed_slots": 10,
-                    },
-                    "coordination": item["coordination"],
-                }
-            ]
-        },
-    }
+    return quota_status_payload(
+        goal_id=GOAL_ID,
+        status="resume_gated_open_todo_fixture",
+        recommended_action=next_action,
+        next_action=next_action,
+        agent_todos=agent_todos,
+        coordination=coordination,
+    )
 
 
 def selected_todo_id(payload: dict) -> str:

--- a/examples/control_plane/todo-succession-contract-smoke.py
+++ b/examples/control_plane/todo-succession-contract-smoke.py
@@ -11,8 +11,12 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from loopx.control_plane.testing.quota_fixtures import (  # noqa: E402
+    quota_status_payload,
+    quota_todo_item,
+    quota_todo_summary,
+)
 from loopx.quota import build_quota_should_run, render_quota_should_run_markdown  # noqa: E402
-from loopx.status import compact_todo_group  # noqa: E402
 from loopx.control_plane.todos.succession_warning import (  # noqa: E402
     build_todo_succession_warning_lanes,
 )
@@ -22,98 +26,64 @@ GOAL_ID = "todo-succession-contract-fixture"
 AGENT_ID = "codex-product-capability"
 
 
-def todo_item(
-    *,
-    todo_id: str,
-    text: str,
-    status: str = "open",
-    action_kind: str | None = None,
-    claimed_by: str | None = None,
-    no_followup: bool = False,
-    successor_todo_ids: list[str] | None = None,
-    resume_when: str | None = None,
-    unblocks_todo_id: str | None = None,
-    updated_at: str | None = None,
-) -> dict:
-    item = {
-        "schema_version": "todo_item_v0",
-        "todo_id": todo_id,
-        "index": 1,
-        "status": status,
-        "done": status == "done",
-        "role": "agent",
-        "source_section": "Agent Todo",
-        "task_class": "advancement_task",
-        "text": text,
-    }
-    if action_kind:
-        item["action_kind"] = action_kind
-    if claimed_by:
-        item["claimed_by"] = claimed_by
-    if no_followup:
-        item["no_followup"] = True
-    if successor_todo_ids:
-        item["successor_todo_ids"] = successor_todo_ids
-    if resume_when:
-        item["resume_when"] = resume_when
-    if unblocks_todo_id:
-        item["unblocks_todo_id"] = unblocks_todo_id
-    if updated_at:
-        item["updated_at"] = updated_at
-    return item
-
-
 def build_agent_todos() -> dict:
-    summary = compact_todo_group(
+    summary = quota_todo_summary(
         [
-            todo_item(
+            quota_todo_item(
                 todo_id="todo_open_next",
                 text="[P1] Continue the next canary-backed control-plane cleanup.",
+                priority="P1",
                 claimed_by=AGENT_ID,
             ),
-            todo_item(
+            quota_todo_item(
                 todo_id="todo_missing_successor",
                 text="[P1] Complete a tracked canary cleanup without recording the next slice.",
                 status="done",
+                priority="P1",
                 action_kind="canary_gated_control_plane_cleanup",
                 claimed_by=AGENT_ID,
                 updated_at="2026-07-04T20:00:00+08:00",
             ),
-            todo_item(
+            quota_todo_item(
                 todo_id="todo_no_followup",
                 text="[P2] Complete a tracked cleanup that intentionally needs no follow-up.",
                 status="done",
+                priority="P2",
                 action_kind="documentation_cleanup",
                 claimed_by=AGENT_ID,
                 no_followup=True,
                 updated_at="2026-07-04T19:00:00+08:00",
             ),
-            todo_item(
+            quota_todo_item(
                 todo_id="todo_with_successor",
                 text="[P2] Complete a tracked cleanup and link the next slice.",
                 status="done",
+                priority="P2",
                 action_kind="projection_cleanup",
                 claimed_by=AGENT_ID,
                 updated_at="2026-07-04T18:00:00+08:00",
             ),
-            todo_item(
+            quota_todo_item(
                 todo_id="todo_with_explicit_successor",
                 text="[P2] Complete a tracked cleanup and link existing successor metadata.",
                 status="done",
+                priority="P2",
                 action_kind="projection_cleanup",
                 claimed_by=AGENT_ID,
                 successor_todo_ids=["todo_explicit_successor"],
                 updated_at="2026-07-04T17:30:00+08:00",
             ),
-            todo_item(
+            quota_todo_item(
                 todo_id="todo_successor",
                 text="[P2] Continue after the linked cleanup.",
+                priority="P2",
                 claimed_by=AGENT_ID,
                 resume_when="todo_done:todo_with_successor",
             ),
-            todo_item(
+            quota_todo_item(
                 todo_id="todo_explicit_successor",
                 text="[P2] Continue after the explicit successor link.",
+                priority="P2",
                 claimed_by=AGENT_ID,
             ),
             {
@@ -126,67 +96,29 @@ def build_agent_todos() -> dict:
                 "text": "[P3] Legacy markdown checkbox without tracking metadata.",
             },
         ],
-        source_section="Agent Todo",
         role="agent",
     )
-    assert summary is not None, summary
     return summary
 
 
 def status_payload(agent_todos: dict) -> dict:
-    quota = {
-        "compute": 1.0,
-        "window_hours": 24,
-        "slot_minutes": 1,
-        "allowed_slots": 1440,
-        "spent_slots": 0,
-        "state": "eligible",
-        "reason": "eligible fixture",
-    }
-    return {
-        "ok": True,
-        "goal_count": 1,
-        "run_count": 0,
-        "attention_queue": {
-            "items": [
-                {
-                    "goal_id": GOAL_ID,
-                    "status": "active",
-                    "waiting_on": "codex",
-                    "severity": "action",
-                    "source": "active_state",
-                    "recommended_action": "Continue the next canary-backed cleanup.",
-                    "quota": quota,
-                    "user_todos": {
-                        "schema_version": "todo_summary_v0",
-                        "source_section": "User Todo",
-                        "total_count": 0,
-                        "open_count": 0,
-                        "done_count": 0,
-                        "first_open_items": [],
-                        "items": [],
-                    },
-                    "agent_todos": agent_todos,
-                }
-            ]
+    return quota_status_payload(
+        goal_id=GOAL_ID,
+        status="active",
+        recommended_action="Continue the next canary-backed cleanup.",
+        agent_todos=agent_todos,
+        source="active_state",
+        registry_status="active",
+        coordination={
+            "primary_agent": "codex-main-control",
+            "registered_agents": ["codex-main-control", AGENT_ID],
         },
-        "run_history": {
-            "goals": [
-                {
-                    "id": GOAL_ID,
-                    "registry_member": True,
-                    "status": "active",
-                    "adapter_kind": "fixture_adapter_v0",
-                    "adapter_status": "connected",
-                    "coordination": {
-                        "primary_agent": "codex-main-control",
-                        "registered_agents": ["codex-main-control", AGENT_ID],
-                    },
-                    "latest_runs": [],
-                }
-            ]
+        latest_runs=[],
+        goal_extra={
+            "adapter_kind": "fixture_adapter_v0",
+            "adapter_status": "connected",
         },
-    }
+    )
 
 
 def assert_status_summary_warning() -> None:


### PR DESCRIPTION
## Summary
- migrate three quota/status state-machine smokes onto shared quota fixture helpers
- remove bespoke status/quota payload builders from action-scope, resume-gated todo, and succession warning smokes
- preserve existing behavioral assertions while reducing repeated fixture shape

## Validation
- python3 -m py_compile examples/control_plane/quota-action-scope-guard-smoke.py examples/control_plane/quota-resume-gated-open-todo-smoke.py examples/control_plane/todo-succession-contract-smoke.py
- python3 examples/control_plane/quota-action-scope-guard-smoke.py
- python3 examples/control_plane/quota-resume-gated-open-todo-smoke.py
- python3 examples/control_plane/todo-succession-contract-smoke.py
- python3 examples/control_plane/interaction-contract-state-machine-smoke.py
- python3 examples/control_plane/side-agent-self-iteration-state-machine-smoke.py
- python3 examples/control_plane/control-plane-integrated-canary-smoke.py
- python3 -m loopx.cli --format json canary premerge --from-git-diff

## Boundary
Public smoke-only cleanup. No runtime behavior, benchmark launch/scoring, credentials, private state, raw logs, trajectories, or local evidence.