### PR TITLE
Refactor review packet handoff context

### DIFF
--- a/examples/control_plane/review-packet-handoff-context-smoke.py
+++ b/examples/control_plane/review-packet-handoff-context-smoke.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Smoke-test the Review Packet project-agent handoff context read model."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.handoff.review_packet_context import (  # noqa: E402
+    agent_member_from_item,
+    agent_member_summary,
+    agent_todo_texts_for_handoff,
+    project_agent_required_reads,
+    project_asset_source,
+    project_asset_source_line,
+    todo_text_from_project_asset,
+)
+
+
+GOAL_ID = "review-packet-handoff-context"
+AGENT_ID = "codex-product-capability"
+
+
+def build_project_asset_item() -> dict:
+    return {
+        "goal_id": GOAL_ID,
+        "summary": "legacy summary should not become source authority",
+        "project_asset": {
+            "agent_lane_next_action": {
+                "text": "[P1] Continue the active project-agent implementation lane.",
+                "claimed_by": AGENT_ID,
+            },
+            "agent_member": {
+                "agent_id": AGENT_ID,
+                "role": "product-capability",
+                "scope_summary": "handoff contracts",
+                "worktree_policy": "clean-worktree",
+                "current_claims": ["rp-context", "canary"],
+                "handoff_agent": "codex-product-capability",
+            },
+            "agent_todos": {
+                "items": [
+                    {
+                        "index": 0,
+                        "text": "[P0] Monitor owner readiness before broad delivery.",
+                        "task_class": "continuous_monitor",
+                        "claimed_by": "codex-monitor",
+                    },
+                    {
+                        "index": 1,
+                        "text": "[P2] Move handoff context into the handoff bounded context.",
+                        "task_class": "advancement_task",
+                        "claimed_by": AGENT_ID,
+                    },
+                    {
+                        "index": 2,
+                        "text": "[P1] Watch readiness while waiting.",
+                    },
+                ]
+            },
+            "user_todos": {
+                "next": "Approve the public-safe handoff packet if the owner gate changes."
+            },
+        },
+    }
+
+
+def assert_project_asset_source_contract(item: dict) -> None:
+    source = project_asset_source(item)
+    assert source == "project_asset", source
+    assert "attention_queue.project_asset" in project_asset_source_line(source)
+    assert project_asset_source({"summary": "legacy"}) == "legacy_raw_fallback"
+    assert "legacy/raw fallback" in project_asset_source_line("legacy_raw_fallback")
+    assert todo_text_from_project_asset(item, "user_todos") == (
+        "Approve the public-safe handoff packet if the owner gate changes."
+    )
+
+
+def assert_agent_todo_priority_contract(item: dict) -> None:
+    todos = agent_todo_texts_for_handoff(item, limit=3)
+    assert todos[0] == (
+        "[P1] Continue the active project-agent implementation lane. "
+        f"claimed_by={AGENT_ID}"
+    ), todos
+    assert "Move handoff context" in todos[1], todos
+    assert "claimed_by=codex-product-capability" in todos[1], todos
+    assert "Monitor owner readiness" in todos[2], todos
+    assert "Monitor owner readiness" not in todos[1], todos
+
+
+def assert_agent_member_contract(item: dict) -> None:
+    member = agent_member_from_item(item)
+    assert member and member["agent_id"] == AGENT_ID, member
+    summary = agent_member_summary(item)
+    assert summary is not None, item
+    assert "authority=advisory_projection" in summary, summary
+    assert "worktree_policy=clean-worktree" in summary, summary
+    assert "claims=rp-context,canary" in summary, summary
+
+    reads = project_agent_required_reads(GOAL_ID, item)
+    assert len(reads) == 1, reads
+    read = reads[0]
+    assert read["kind"] == "agent_scoped_evidence_log", read
+    assert read["goal_id"] == GOAL_ID, read
+    assert read["agent_id"] == AGENT_ID, read
+    assert read["other_agent_policy"] == "frontier_only", read
+    assert "evidence-log" in read["command"], read
+    assert f"--goal-id {GOAL_ID}" in read["command"], read
+    assert f"--agent-id {AGENT_ID}" in read["command"], read
+
+
+def main() -> None:
+    item = build_project_asset_item()
+    assert_project_asset_source_contract(item)
+    assert_agent_todo_priority_contract(item)
+    assert_agent_member_contract(item)
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/control_plane/handoff/review_packet_context.py
+++ b/loopx/control_plane/handoff/review_packet_context.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from ..runtime.agent_scoped_evidence_log import build_agent_scoped_required_read
+from ..runtime.public_safety import compact_text
+
+
+HANDOFF_TODO_PRIORITY_PATTERN = re.compile(r"^\s*\[(P[0-4])", re.IGNORECASE)
+HANDOFF_MONITOR_TASK_CLASSES = {"blocker", "continuous_monitor", "monitor", "user_gate"}
+HANDOFF_ADVANCEMENT_TASK_CLASSES = {"advancement_task", "execution_task", "delivery_task"}
+HANDOFF_MONITOR_MARKERS = (
+    "monitor",
+    "observation",
+    "readiness",
+    "watch",
+    "poll",
+    "dependency monitor",
+    "观察",
+    "监控",
+    "等待",
+)
+
+
+def compact_packet_text(value: str, limit: int = 180) -> str:
+    return compact_text(str(value), limit=limit)
+
+
+def handoff_todo_priority_rank(text: str) -> int:
+    match = HANDOFF_TODO_PRIORITY_PATTERN.match(text)
+    if not match:
+        return 50
+    return int(match.group(1)[1])
+
+
+def handoff_todo_task_rank(item: dict[str, Any], text: str) -> int:
+    task_class = str(item.get("task_class") or "").strip().lower()
+    if task_class in HANDOFF_ADVANCEMENT_TASK_CLASSES:
+        return 0
+    if task_class in HANDOFF_MONITOR_TASK_CLASSES:
+        return 1
+    lowered = text.lower()
+    if any(marker in lowered for marker in HANDOFF_MONITOR_MARKERS):
+        return 1
+    return 0
+
+
+def handoff_todo_rank(item: dict[str, Any], text: str, ordinal: int) -> tuple[int, int, int]:
+    index = item.get("index")
+    stable_index = index if isinstance(index, int) else ordinal
+    return (
+        handoff_todo_task_rank(item, text),
+        handoff_todo_priority_rank(text),
+        stable_index,
+    )
+
+
+def open_todo_texts(todos: Any, *, limit: int = 3, rank_for_handoff: bool = False) -> list[str]:
+    if not isinstance(todos, dict):
+        return []
+    items = todos.get("items") if isinstance(todos.get("items"), list) else []
+    if not items and isinstance(todos.get("first_open_items"), list):
+        items = todos.get("first_open_items") or []
+    result: list[str] = []
+    ranked_result: list[tuple[tuple[int, int, int], str]] = []
+    for ordinal, item in enumerate(items):
+        if not isinstance(item, dict) or item.get("done"):
+            continue
+        text = str(item.get("text") or "").strip()
+        if text:
+            claimed_by = str(item.get("claimed_by") or "").strip()
+            display_text = text
+            if claimed_by:
+                display_text = f"{display_text} claimed_by={claimed_by}"
+            if rank_for_handoff:
+                ranked_result.append(
+                    (handoff_todo_rank(item, text, ordinal), compact_packet_text(display_text))
+                )
+                continue
+            result.append(compact_packet_text(display_text))
+            if len(result) >= limit:
+                return result
+    if rank_for_handoff:
+        return [text for _, text in sorted(ranked_result, key=lambda ranked: ranked[0])[:limit]]
+    return result
+
+
+def todo_text_from_project_asset(item: dict[str, Any] | None, key: str) -> str | None:
+    items = todo_texts_from_project_asset(item, key, limit=1)
+    return items[0] if items else None
+
+
+def todo_texts_from_project_asset(
+    item: dict[str, Any] | None,
+    key: str,
+    *,
+    limit: int = 3,
+) -> list[str]:
+    if not isinstance(item, dict):
+        return []
+    project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
+    summary = project_asset.get(key) if isinstance(project_asset.get(key), dict) else {}
+    rank_for_handoff = key == "agent_todos"
+    summary_items = open_todo_texts(summary, limit=limit, rank_for_handoff=rank_for_handoff)
+    if summary_items:
+        return summary_items
+    next_text = str(summary.get("next") or "").strip()
+    if next_text:
+        return [compact_packet_text(next_text)]
+    return open_todo_texts(item.get(key), limit=limit, rank_for_handoff=rank_for_handoff)
+
+
+def agent_lane_todo_text(item: dict[str, Any] | None) -> str | None:
+    if not isinstance(item, dict):
+        return None
+    project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
+    lane = (
+        project_asset.get("agent_lane_next_action")
+        if isinstance(project_asset.get("agent_lane_next_action"), dict)
+        else item.get("agent_lane_next_action")
+        if isinstance(item.get("agent_lane_next_action"), dict)
+        else None
+    )
+    if not isinstance(lane, dict):
+        return None
+    text = str(lane.get("text") or lane.get("title") or "").strip()
+    if not text:
+        return None
+    claimed_by = str(lane.get("claimed_by") or "").strip()
+    if claimed_by:
+        text = f"{text} claimed_by={claimed_by}"
+    return compact_packet_text(text)
+
+
+def agent_todo_texts_for_handoff(item: dict[str, Any] | None, *, limit: int = 3) -> list[str]:
+    items = todo_texts_from_project_asset(item, "agent_todos", limit=limit)
+    lane_text = agent_lane_todo_text(item)
+    if not lane_text:
+        return items
+    return [lane_text, *[text for text in items if text != lane_text]][:limit]
+
+
+def agent_member_from_item(item: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(item, dict):
+        return None
+    project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
+    member = (
+        project_asset.get("agent_member")
+        if isinstance(project_asset.get("agent_member"), dict)
+        else None
+    )
+    if member is None and isinstance(item.get("agent_member"), dict):
+        member = item["agent_member"]
+    return member if isinstance(member, dict) else None
+
+
+def agent_member_summary(item: dict[str, Any] | None) -> str | None:
+    member = agent_member_from_item(item)
+    if not member:
+        return None
+    claims = [
+        str(claim).strip()
+        for claim in (member.get("current_claims") or [])
+        if str(claim).strip()
+    ]
+    parts = [
+        f"agent={member.get('agent_id')}",
+        f"role={member.get('role')}",
+        "authority=advisory_projection",
+    ]
+    if member.get("scope_summary"):
+        parts.append(f"scope={member.get('scope_summary')}")
+    if member.get("worktree_policy"):
+        parts.append(f"worktree_policy={member.get('worktree_policy')}")
+    if claims:
+        parts.append(f"claims={','.join(claims[:5])}")
+    if member.get("handoff_agent"):
+        parts.append(f"handoff_agent={member.get('handoff_agent')}")
+    return compact_packet_text(" ".join(str(part) for part in parts if part))
+
+
+def project_agent_required_reads(
+    goal_id: str,
+    item: dict[str, Any] | None,
+) -> list[dict[str, Any]]:
+    member = agent_member_from_item(item)
+    if not member:
+        return []
+    agent_id = str(member.get("agent_id") or member.get("handoff_agent") or "").strip()
+    read = build_agent_scoped_required_read(
+        goal_id=goal_id,
+        agent_id=agent_id,
+        reason=(
+            "read this target agent's thin evidence ledger before replan or "
+            "handoff continuation; other agents stay frontier-only"
+        ),
+    )
+    return [read] if read else []
+
+
+def project_asset_source(item: dict[str, Any] | None) -> str:
+    if isinstance(item, dict) and isinstance(item.get("project_asset"), dict):
+        return "project_asset"
+    return "legacy_raw_fallback"
+
+
+def project_asset_source_line(source: str) -> str:
+    if source == "project_asset":
+        return "project_asset（owner/gate/next/stop 来自 attention_queue.project_asset）"
+    return (
+        "legacy/raw fallback（未收到 project_asset；summary/action/todos "
+        "来自 raw queue/status 降级判断，不能当 owner/gate/stop authority）"
+    )

--- a/loopx/review_packet.py
+++ b/loopx/review_packet.py
@@ -7,8 +7,14 @@ from typing import Any
 from .control_plane.runtime.decision_freshness import (
     decision_freshness_warning as runtime_decision_freshness_warning,
 )
-from .control_plane.runtime.agent_scoped_evidence_log import (
-    build_agent_scoped_required_read,
+from .control_plane.handoff.review_packet_context import (
+    agent_member_from_item,
+    agent_member_summary,
+    agent_todo_texts_for_handoff,
+    project_agent_required_reads,
+    project_asset_source,
+    project_asset_source_line,
+    todo_text_from_project_asset,
 )
 from .execution_profile import (
     compact_execution_profile,
@@ -20,21 +26,6 @@ from .handoff_budget import build_handoff_interface_budget
 
 
 BENCHMARK_REPORT_CHAIN_MAP_DOC = "benchmark-report-chain-map-v0.md"
-HANDOFF_TODO_PRIORITY_PATTERN = re.compile(r"^\s*\[(P[0-4])", re.IGNORECASE)
-HANDOFF_MONITOR_TASK_CLASSES = {"blocker", "continuous_monitor", "monitor", "user_gate"}
-HANDOFF_ADVANCEMENT_TASK_CLASSES = {"advancement_task", "execution_task", "delivery_task"}
-HANDOFF_MONITOR_MARKERS = (
-    "monitor",
-    "observation",
-    "readiness",
-    "watch",
-    "poll",
-    "dependency monitor",
-    "观察",
-    "监控",
-    "等待",
-)
-
 LOCAL_ABSOLUTE_PATH_PATTERN = re.compile(
     r"(^|[\s`'\"=:(])(?:/[A-Za-z0-9._-]+(?:/[^\s`'\",)]+)+|[A-Za-z]:[\\/][^\s`'\",)]+)"
 )
@@ -258,184 +249,6 @@ def stale_latest_run_packet_lines(warning: dict[str, Any] | None) -> list[str]:
         f"reason={compact_packet_text(str(warning.get('reason') or ''), limit=120)}",
     ]
     return [redact_local_absolute_paths(line) for line in lines]
-
-
-def handoff_todo_priority_rank(text: str) -> int:
-    match = HANDOFF_TODO_PRIORITY_PATTERN.match(text)
-    if not match:
-        return 50
-    return int(match.group(1)[1])
-
-
-def handoff_todo_task_rank(item: dict[str, Any], text: str) -> int:
-    task_class = str(item.get("task_class") or "").strip().lower()
-    if task_class in HANDOFF_ADVANCEMENT_TASK_CLASSES:
-        return 0
-    if task_class in HANDOFF_MONITOR_TASK_CLASSES:
-        return 1
-    lowered = text.lower()
-    if any(marker in lowered for marker in HANDOFF_MONITOR_MARKERS):
-        return 1
-    return 0
-
-
-def handoff_todo_rank(item: dict[str, Any], text: str, ordinal: int) -> tuple[int, int, int]:
-    index = item.get("index")
-    stable_index = index if isinstance(index, int) else ordinal
-    return (
-        handoff_todo_task_rank(item, text),
-        handoff_todo_priority_rank(text),
-        stable_index,
-    )
-
-
-def open_todo_texts(todos: Any, *, limit: int = 3, rank_for_handoff: bool = False) -> list[str]:
-    if not isinstance(todos, dict):
-        return []
-    items = todos.get("items") if isinstance(todos.get("items"), list) else []
-    if not items and isinstance(todos.get("first_open_items"), list):
-        items = todos.get("first_open_items") or []
-    result: list[str] = []
-    ranked_result: list[tuple[tuple[int, int, int], str]] = []
-    for ordinal, item in enumerate(items):
-        if not isinstance(item, dict) or item.get("done"):
-            continue
-        text = str(item.get("text") or "").strip()
-        if text:
-            claimed_by = str(item.get("claimed_by") or "").strip()
-            display_text = text
-            if claimed_by:
-                display_text = f"{display_text} claimed_by={claimed_by}"
-            if rank_for_handoff:
-                ranked_result.append((handoff_todo_rank(item, text, ordinal), compact_packet_text(display_text)))
-                continue
-            result.append(compact_packet_text(display_text))
-            if len(result) >= limit:
-                return result
-    if rank_for_handoff:
-        return [text for _, text in sorted(ranked_result, key=lambda ranked: ranked[0])[:limit]]
-    return result
-
-
-def first_open_todo_text(todos: Any) -> str | None:
-    items = open_todo_texts(todos, limit=1)
-    return items[0] if items else None
-
-
-def todo_text_from_project_asset(item: dict[str, Any] | None, key: str) -> str | None:
-    items = todo_texts_from_project_asset(item, key, limit=1)
-    return items[0] if items else None
-
-
-def todo_texts_from_project_asset(item: dict[str, Any] | None, key: str, *, limit: int = 3) -> list[str]:
-    if not isinstance(item, dict):
-        return []
-    project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
-    summary = project_asset.get(key) if isinstance(project_asset.get(key), dict) else {}
-    rank_for_handoff = key == "agent_todos"
-    summary_items = open_todo_texts(summary, limit=limit, rank_for_handoff=rank_for_handoff)
-    if summary_items:
-        return summary_items
-    next_text = str(summary.get("next") or "").strip()
-    if next_text:
-        return [compact_packet_text(next_text)]
-    return open_todo_texts(item.get(key), limit=limit, rank_for_handoff=rank_for_handoff)
-
-
-def agent_lane_todo_text(item: dict[str, Any] | None) -> str | None:
-    if not isinstance(item, dict):
-        return None
-    project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
-    lane = (
-        project_asset.get("agent_lane_next_action")
-        if isinstance(project_asset.get("agent_lane_next_action"), dict)
-        else item.get("agent_lane_next_action")
-        if isinstance(item.get("agent_lane_next_action"), dict)
-        else None
-    )
-    if not isinstance(lane, dict):
-        return None
-    text = str(lane.get("text") or lane.get("title") or "").strip()
-    if not text:
-        return None
-    claimed_by = str(lane.get("claimed_by") or "").strip()
-    if claimed_by:
-        text = f"{text} claimed_by={claimed_by}"
-    return compact_packet_text(text)
-
-
-def agent_todo_texts_for_handoff(item: dict[str, Any] | None, *, limit: int = 3) -> list[str]:
-    items = todo_texts_from_project_asset(item, "agent_todos", limit=limit)
-    lane_text = agent_lane_todo_text(item)
-    if not lane_text:
-        return items
-    return [lane_text, *[text for text in items if text != lane_text]][:limit]
-
-
-def agent_member_from_item(item: dict[str, Any] | None) -> dict[str, Any] | None:
-    if not isinstance(item, dict):
-        return None
-    project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
-    member = project_asset.get("agent_member") if isinstance(project_asset.get("agent_member"), dict) else None
-    if member is None and isinstance(item.get("agent_member"), dict):
-        member = item["agent_member"]
-    return member if isinstance(member, dict) else None
-
-
-def agent_member_summary(item: dict[str, Any] | None) -> str | None:
-    member = agent_member_from_item(item)
-    if not member:
-        return None
-    claims = [
-        str(claim).strip()
-        for claim in (member.get("current_claims") or [])
-        if str(claim).strip()
-    ]
-    parts = [
-        f"agent={member.get('agent_id')}",
-        f"role={member.get('role')}",
-        "authority=advisory_projection",
-    ]
-    if member.get("scope_summary"):
-        parts.append(f"scope={member.get('scope_summary')}")
-    if member.get("worktree_policy"):
-        parts.append(f"worktree_policy={member.get('worktree_policy')}")
-    if claims:
-        parts.append(f"claims={','.join(claims[:5])}")
-    if member.get("handoff_agent"):
-        parts.append(f"handoff_agent={member.get('handoff_agent')}")
-    return compact_packet_text(" ".join(str(part) for part in parts if part))
-
-
-def project_agent_required_reads(
-    goal_id: str,
-    item: dict[str, Any] | None,
-) -> list[dict[str, Any]]:
-    member = agent_member_from_item(item)
-    if not member:
-        return []
-    agent_id = str(member.get("agent_id") or member.get("handoff_agent") or "").strip()
-    read = build_agent_scoped_required_read(
-        goal_id=goal_id,
-        agent_id=agent_id,
-        reason=(
-            "read this target agent's thin evidence ledger before replan or "
-            "handoff continuation; other agents stay frontier-only"
-        ),
-    )
-    return [read] if read else []
-
-
-def project_asset_source(item: dict[str, Any] | None) -> str:
-    if isinstance(item, dict) and isinstance(item.get("project_asset"), dict):
-        return "project_asset"
-    return "legacy_raw_fallback"
-
-
-def project_asset_source_line(source: str) -> str:
-    if source == "project_asset":
-        return "project_asset（owner/gate/next/stop 来自 attention_queue.project_asset）"
-    return "legacy/raw fallback（未收到 project_asset；summary/action/todos 来自 raw queue/status 降级判断，不能当 owner/gate/stop authority）"
 
 
 def handoff_followthrough_summary(item: dict[str, Any] | None) -> str | None:


### PR DESCRIPTION
## Summary
- Move project-agent handoff todo selection, project_asset source labeling, agent member summary, and required-read construction out of loopx/review_packet.py into loopx/control_plane/handoff/review_packet_context.py.
- Keep review_packet.py focused on packet assembly while the handoff bounded context owns handoff read-model details.
- Add a focused canary for project_asset source authority, agent lane/todo priority, and agent-scoped evidence required reads.

## Validation
- python3 examples/control_plane/review-packet-handoff-context-smoke.py
- python3 examples/control_plane/review-packet-cli-smoke.py
- python3 examples/control_plane/review-packet-smoke.py
- python3 examples/control_plane/status-quota-review-packet-parity-smoke.py
- python3 examples/control_plane/work-lane-contract-smoke.py
- python3 examples/control_plane/control-plane-integrated-canary-smoke.py
- git diff --cached --check
- python3 -m loopx.cli --format json canary premerge --from-git-diff

## Boundary
- Public/private scan found no credentials, private paths, raw benchmark logs, task text, trajectories, or verifier output in changed paths.
- Premerge gate reported manual_holds=0 and self_merge_allowed=true.