### PR TITLE
Extract review packet delivery contract

### DIFF
--- a/examples/control_plane/review-packet-handoff-delivery-contract-smoke.py
+++ b/examples/control_plane/review-packet-handoff-delivery-contract-smoke.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Smoke-test Review Packet handoff delivery-contract state transitions."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.handoff.delivery_contract import (  # noqa: E402
+    handoff_delivery_contract,
+    handoff_delivery_contract_summary,
+)
+
+
+def build_item(*, small_streak: int, outcome_gap_streak: int) -> dict:
+    return {
+        "project_asset": {
+            "execution_profile": {
+                "minimum_scale": "implementation",
+                "must_include": [
+                    "implementation_artifact",
+                    "targeted_validation",
+                    "state_writeback",
+                ],
+                "degradation_policy": {
+                    "small_scale_streak_threshold": 3,
+                },
+                "outcome_floor": {
+                    "surface_streak_threshold": 2,
+                    "must_advance": ["ranker_or_cross_domain_evidence"],
+                    "avoid": ["queue_only_update"],
+                },
+            }
+        },
+        "handoff_readiness": {
+            "post_handoff_small_scale_streak": small_streak,
+            "post_handoff_outcome_gap_streak": outcome_gap_streak,
+            "post_handoff_recent_runs": [
+                {"delivery_batch_scale": "test_only"},
+                {"delivery_batch_scale": "single_surface"},
+                {"delivery_batch_scale": "implementation"},
+            ],
+        },
+    }
+
+
+def assert_below_threshold_is_quiet() -> None:
+    assert handoff_delivery_contract(build_item(small_streak=2, outcome_gap_streak=1)) is None
+
+
+def assert_small_scale_contract() -> None:
+    contract = handoff_delivery_contract(build_item(small_streak=3, outcome_gap_streak=1))
+    assert contract is not None
+    assert contract["mode"] == "expand_after_repeated_small_delivery", contract
+    assert contract["minimum_scale"] == "implementation", contract
+    assert contract["must_include"] == [
+        "implementation_artifact",
+        "targeted_validation",
+        "state_writeback",
+    ], contract
+    assert contract["recent_scales"] == ["test_only", "single_surface", "implementation"], contract
+    summary = handoff_delivery_contract_summary(contract)
+    assert summary and "至少 implementation" in summary, summary
+    assert "targeted validation、state writeback" in summary, summary
+    assert "不 spend" in summary, summary
+
+
+def assert_outcome_floor_contract() -> None:
+    contract = handoff_delivery_contract(build_item(small_streak=1, outcome_gap_streak=2))
+    assert contract is not None
+    assert contract["mode"] == "expand_after_surface_progress_loop", contract
+    assert contract["post_handoff_outcome_gap_streak"] == 2, contract
+    assert contract["outcome_gap_streak_threshold"] == 2, contract
+    summary = handoff_delivery_contract_summary(contract)
+    assert summary and "ranker or cross domain evidence" in summary, summary
+    assert "queue only update" in summary, summary
+    assert "禁止 isolated test/surface-only propagation" in summary, summary
+
+
+def main() -> None:
+    assert_below_threshold_is_quiet()
+    assert_small_scale_contract()
+    assert_outcome_floor_contract()
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/control_plane/handoff/delivery_contract.py
+++ b/loopx/control_plane/handoff/delivery_contract.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ...execution_profile import (
+    compact_execution_profile,
+    execution_profile_outcome_floor,
+    execution_profile_threshold,
+    outcome_floor_threshold,
+)
+from ..runtime.public_safety import compact_text
+
+
+def compact_packet_text(value: str, limit: int = 180) -> str:
+    return compact_text(str(value), limit=limit)
+
+
+def _contract_minimum_text(value: str) -> str:
+    return value.replace("_or_", "/")
+
+
+def _contract_must_include_text(values: list[str]) -> str:
+    display = {
+        "coherent_artifact": "artifact",
+        "targeted_validation": "targeted validation",
+        "state_writeback": "state writeback",
+    }
+    return "、".join(display.get(value, value.replace("_", " ")) for value in values)
+
+
+def _contract_label_text(values: list[str]) -> str:
+    return "、".join(value.replace("_", " ") for value in values if value)
+
+
+def handoff_delivery_contract(item: dict[str, Any] | None) -> dict[str, Any] | None:
+    if not isinstance(item, dict):
+        return None
+    project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
+    profile = compact_execution_profile(
+        project_asset.get("execution_profile")
+        if isinstance(project_asset.get("execution_profile"), dict)
+        else None
+    )
+    threshold = execution_profile_threshold(profile)
+    readiness = (
+        item.get("handoff_readiness")
+        if isinstance(item.get("handoff_readiness"), dict)
+        else {}
+    )
+    streak = readiness.get("post_handoff_small_scale_streak")
+    outcome_floor = execution_profile_outcome_floor(profile)
+    outcome_threshold = outcome_floor_threshold(profile)
+    outcome_gap_streak = readiness.get("post_handoff_outcome_gap_streak")
+    small_degraded = isinstance(streak, int) and streak >= threshold
+    outcome_degraded = (
+        isinstance(outcome_gap_streak, int)
+        and outcome_gap_streak >= outcome_threshold
+    )
+    if not small_degraded and not outcome_degraded:
+        return None
+    recent_runs = readiness.get("post_handoff_recent_runs")
+    recent_scales = [
+        str(run.get("delivery_batch_scale") or "unknown").strip() or "unknown"
+        for run in recent_runs or []
+        if isinstance(run, dict)
+    ][:3]
+    minimum_scale = str(profile.get("minimum_scale") or "multi_surface_or_implementation")
+    must_include = [
+        str(value)
+        for value in (
+            profile.get("must_include")
+            if isinstance(profile.get("must_include"), list)
+            else []
+        )
+        if str(value).strip()
+    ] or ["coherent_artifact", "targeted_validation", "state_writeback"]
+    spend_rule = str(profile.get("spend_rule") or "spend_only_after_artifact_validation_writeback")
+    must_advance = [
+        str(value)
+        for value in (
+            outcome_floor.get("must_advance")
+            if isinstance(outcome_floor.get("must_advance"), list)
+            else []
+        )
+        if str(value).strip()
+    ]
+    avoid = [
+        str(value)
+        for value in (
+            outcome_floor.get("avoid")
+            if isinstance(outcome_floor.get("avoid"), list)
+            else []
+        )
+        if str(value).strip()
+    ]
+    mode = (
+        "expand_after_surface_progress_loop"
+        if outcome_degraded and not small_degraded
+        else "expand_after_repeated_small_delivery"
+    )
+    outcome_summary = (
+        f"outcome_gap_streak={outcome_gap_streak}; outcome_threshold={outcome_threshold}; "
+        if outcome_degraded
+        else ""
+    )
+    summary = compact_packet_text(
+        f"{mode}; "
+        f"minimum_scale={minimum_scale}; "
+        f"include={'+'.join(must_include)}; "
+        f"spend_rule={spend_rule}; "
+        f"{outcome_summary}"
+        f"small_threshold={threshold}; "
+        "if_blocked=report_blocker_without_spend",
+        limit=220,
+    )
+    floor_sentence = ""
+    if outcome_degraded and (must_advance or avoid):
+        floor_sentence = (
+            f"推进 floor={_contract_label_text(must_advance)}；"
+            f"避免 {_contract_label_text(avoid)}；"
+        )
+    instruction = compact_packet_text(
+        "下一轮回到 active state P0/P1 outcome 做 audit，"
+        f"选连贯段，至少 {_contract_minimum_text(minimum_scale)}；"
+        f"{floor_sentence}"
+        f"含真实 {_contract_must_include_text(must_include)}；"
+        "禁止 isolated test/surface-only propagation；"
+        "若只能小步/表面，blocker，不 spend。",
+        limit=260,
+    )
+    return {
+        "mode": mode,
+        "minimum_scale": minimum_scale,
+        "must_include": must_include,
+        "outcome_floor": outcome_floor,
+        "spend_rule": spend_rule,
+        "small_scale_streak_threshold": threshold,
+        "outcome_gap_streak_threshold": outcome_threshold,
+        "if_blocked": "report_blocker_without_spend",
+        "post_handoff_small_scale_streak": streak,
+        "post_handoff_outcome_gap_streak": outcome_gap_streak,
+        "recent_scales": recent_scales,
+        "execution_profile": profile,
+        "summary": summary,
+        "instruction": instruction,
+    }
+
+
+def handoff_delivery_contract_summary(contract: dict[str, Any] | None) -> str | None:
+    if not isinstance(contract, dict):
+        return None
+    instruction = str(contract.get("instruction") or "").strip()
+    if instruction:
+        return instruction
+    summary = str(contract.get("summary") or "").strip()
+    return summary or None

--- a/loopx/review_packet.py
+++ b/loopx/review_packet.py
@@ -16,11 +16,9 @@ from .control_plane.handoff.review_packet_context import (
     project_asset_source_line,
     todo_text_from_project_asset,
 )
-from .execution_profile import (
-    compact_execution_profile,
-    execution_profile_outcome_floor,
-    execution_profile_threshold,
-    outcome_floor_threshold,
+from .control_plane.handoff.delivery_contract import (
+    handoff_delivery_contract,
+    handoff_delivery_contract_summary,
 )
 from .handoff_budget import build_handoff_interface_budget
 
@@ -505,136 +503,6 @@ def benchmark_report_chain_handoff(item: dict[str, Any] | None) -> dict[str, Any
         "negative_evidence_layers": [str(layer) for layer in layers if str(layer).strip()],
         "must_not_claim": [str(claim) for claim in must_not_claim if str(claim).strip()],
     }
-
-
-def _contract_minimum_text(value: str) -> str:
-    return value.replace("_or_", "/")
-
-
-def _contract_must_include_text(values: list[str]) -> str:
-    display = {
-        "coherent_artifact": "artifact",
-        "targeted_validation": "targeted validation",
-        "state_writeback": "state writeback",
-    }
-    return "、".join(display.get(value, value.replace("_", " ")) for value in values)
-
-
-def _contract_label_text(values: list[str]) -> str:
-    return "、".join(value.replace("_", " ") for value in values if value)
-
-
-def handoff_delivery_contract(item: dict[str, Any] | None) -> dict[str, Any] | None:
-    if not isinstance(item, dict):
-        return None
-    project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
-    profile = compact_execution_profile(
-        project_asset.get("execution_profile")
-        if isinstance(project_asset.get("execution_profile"), dict)
-        else None
-    )
-    threshold = execution_profile_threshold(profile)
-    readiness = item.get("handoff_readiness") if isinstance(item.get("handoff_readiness"), dict) else {}
-    streak = readiness.get("post_handoff_small_scale_streak")
-    outcome_floor = execution_profile_outcome_floor(profile)
-    outcome_threshold = outcome_floor_threshold(profile)
-    outcome_gap_streak = readiness.get("post_handoff_outcome_gap_streak")
-    small_degraded = isinstance(streak, int) and streak >= threshold
-    outcome_degraded = isinstance(outcome_gap_streak, int) and outcome_gap_streak >= outcome_threshold
-    if not small_degraded and not outcome_degraded:
-        return None
-    recent_runs = readiness.get("post_handoff_recent_runs")
-    recent_scales = [
-        str(run.get("delivery_batch_scale") or "unknown").strip() or "unknown"
-        for run in recent_runs or []
-        if isinstance(run, dict)
-    ][:3]
-    minimum_scale = str(profile.get("minimum_scale") or "multi_surface_or_implementation")
-    must_include = [
-        str(value)
-        for value in (profile.get("must_include") if isinstance(profile.get("must_include"), list) else [])
-        if str(value).strip()
-    ] or ["coherent_artifact", "targeted_validation", "state_writeback"]
-    spend_rule = str(profile.get("spend_rule") or "spend_only_after_artifact_validation_writeback")
-    must_advance = [
-        str(value)
-        for value in (
-            outcome_floor.get("must_advance")
-            if isinstance(outcome_floor.get("must_advance"), list)
-            else []
-        )
-        if str(value).strip()
-    ]
-    avoid = [
-        str(value)
-        for value in (
-            outcome_floor.get("avoid")
-            if isinstance(outcome_floor.get("avoid"), list)
-            else []
-        )
-        if str(value).strip()
-    ]
-    mode = (
-        "expand_after_surface_progress_loop"
-        if outcome_degraded and not small_degraded
-        else "expand_after_repeated_small_delivery"
-    )
-    outcome_summary = (
-        f"outcome_gap_streak={outcome_gap_streak}; outcome_threshold={outcome_threshold}; "
-        if outcome_degraded
-        else ""
-    )
-    summary = compact_packet_text(
-        f"{mode}; "
-        f"minimum_scale={minimum_scale}; "
-        f"include={'+'.join(must_include)}; "
-        f"spend_rule={spend_rule}; "
-        f"{outcome_summary}"
-        f"small_threshold={threshold}; "
-        "if_blocked=report_blocker_without_spend",
-        limit=220,
-    )
-    floor_sentence = ""
-    if outcome_degraded and (must_advance or avoid):
-        floor_sentence = (
-            f"推进 floor={_contract_label_text(must_advance)}；"
-            f"避免 {_contract_label_text(avoid)}；"
-        )
-    instruction = compact_packet_text(
-        "下一轮回到 active state P0/P1 outcome 做 audit，"
-        f"选连贯段，至少 {_contract_minimum_text(minimum_scale)}；"
-        f"{floor_sentence}"
-        f"含真实 {_contract_must_include_text(must_include)}；"
-        "禁止 isolated test/surface-only propagation；"
-        "若只能小步/表面，blocker，不 spend。",
-        limit=260,
-    )
-    return {
-        "mode": mode,
-        "minimum_scale": minimum_scale,
-        "must_include": must_include,
-        "outcome_floor": outcome_floor,
-        "spend_rule": spend_rule,
-        "small_scale_streak_threshold": threshold,
-        "outcome_gap_streak_threshold": outcome_threshold,
-        "if_blocked": "report_blocker_without_spend",
-        "post_handoff_small_scale_streak": streak,
-        "post_handoff_outcome_gap_streak": outcome_gap_streak,
-        "recent_scales": recent_scales,
-        "execution_profile": profile,
-        "summary": summary,
-        "instruction": instruction,
-    }
-
-
-def handoff_delivery_contract_summary(contract: dict[str, Any] | None) -> str | None:
-    if not isinstance(contract, dict):
-        return None
-    instruction = str(contract.get("instruction") or "").strip()
-    if instruction:
-        return instruction
-    summary = str(contract.get("summary") or "").strip()
-    return summary or None
 
 
 def authority_material_summary(goal: dict[str, Any] | None) -> str | None:


### PR DESCRIPTION
## Summary

- Move review-packet handoff delivery-contract rules into `loopx.control_plane.handoff.delivery_contract`.
- Keep `loopx.review_packet` as the active caller, but remove the local helper/state-machine block from the large module.
- Add a focused canary for the delivery-contract transitions covered by repeated small-delivery and outcome-floor states.

## Product / Architecture Judgment

Motivation: `review_packet.py` is a hot, oversized module. The handoff delivery contract is a cohesive control-plane handoff rule and belongs with handoff bounded-context code, not inline in review-packet assembly.

Solved: this is a behavior-preserving extraction with a direct canary and broader review-packet/premerge coverage. It deliberately leaves benchmark-specific followthrough summary logic in place because benchmark-specific canary/refactor work is owned by the main-control path.

Risk: low-to-moderate read-path risk. It touches review-packet output assembly, but keeps the public function names imported by the active caller and validates the changed surface through focused and aggregate canaries.

## Validation

- `python3 -m py_compile loopx/review_packet.py loopx/control_plane/handoff/delivery_contract.py examples/control_plane/review-packet-handoff-delivery-contract-smoke.py`
- `python3 examples/control_plane/review-packet-handoff-delivery-contract-smoke.py`
- `python3 examples/control_plane/review-packet-cli-smoke.py`
- `python3 examples/control_plane/review-packet-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `python3 -m loopx.cli --format json canary premerge --from-git-diff` selected 17 checks, executed 17, with 0 failures, 0 warnings, 0 manual holds, and `self_merge_allowed=true`.
- `git diff --check origin/main...HEAD`
- public/private boundary scan over changed paths: no local absolute paths, credentials, raw benchmark evidence, trajectories, raw logs, task text, or verifier-output markers found.

## Merge Plan

Self-merge after PR creation because the change is single-purpose, validated by direct and risk-selected canaries, avoids benchmark-owned execution/canary work, and has no private-state or evidence-policy surface.
