### PR TITLE
Guard SkillsBench runner source revision

### DIFF
--- a/examples/skillsbench-runner-source-fingerprint-smoke.py
+++ b/examples/skillsbench-runner-source-fingerprint-smoke.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import asyncio
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import scripts.skillsbench_automation_loop as skillsbench_loop  # noqa: E402
+from scripts.skillsbench_automation_loop import build_plan, parse_args  # noqa: E402
+
+
+def repo_head() -> str:
+    return subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "rev-parse", "HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def test_expected_head_match_is_public_safe() -> None:
+    head = repo_head()
+    args = parse_args(
+        [
+            "--route",
+            "codex-cli-goal-baseline",
+            "--expected-loopx-git-head",
+            head[:12],
+        ]
+    )
+    plan = build_plan(args)
+    fingerprint = plan["loopx_runner_source_fingerprint"]
+    assert fingerprint["status"] == "matched_expected", fingerprint
+    assert fingerprint["matches_expected"] is True, fingerprint
+    public = skillsbench_loop._public_runner_prerequisites(
+        plan["runner_prerequisites"]
+    )
+    assert public["loopx_runner_source_git_head"] == head
+    assert public["loopx_runner_source_matches_expected"] is True
+    assert public["loopx_runner_source_path_recorded"] is False
+    assert public["loopx_runner_source_raw_git_output_recorded"] is False
+
+
+def test_expected_head_mismatch_fails_before_benchflow() -> None:
+    args = parse_args(
+        [
+            "--route",
+            "codex-cli-goal-baseline",
+            "--expected-loopx-git-head",
+            "0" * 40,
+        ]
+    )
+    plan = build_plan(args)
+    assert plan["runner_prerequisites"]["loopx_runner_source_first_blocker"] == (
+        "loopx_runner_source_git_head_mismatch"
+    )
+    config = skillsbench_loop._public_runner_config(plan)
+    assert config["loopx_runner_source_fingerprint_status"] == (
+        "mismatched_expected"
+    )
+    assert config["loopx_runner_source_matches_expected"] is False
+    try:
+        asyncio.run(skillsbench_loop.run_benchflow_case(args, plan))
+    except RuntimeError as exc:
+        assert "loopx_runner_source_git_head_mismatch" in str(exc)
+    else:
+        raise AssertionError("stale source should fail before BenchFlow import")
+    assert plan["runner_prerequisites"]["benchflow_run_stage"] == (
+        "runner_source_fingerprint_check"
+    )
+
+
+def main() -> None:
+    test_expected_head_match_is_public_safe()
+    test_expected_head_mismatch_fails_before_benchflow()
+    print("skillsbench-runner-source-fingerprint-smoke: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/benchmark_adapters/skillsbench_runner_source.py
+++ b/loopx/benchmark_adapters/skillsbench_runner_source.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+
+def build_runner_source_fingerprint(
+    *,
+    repo_root: Path,
+    expected_git_head: str = "",
+) -> dict[str, Any]:
+    expected = str(expected_git_head or "").strip()
+    head = ""
+    error_kind = ""
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", "HEAD"],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=3,
+        )
+        if proc.returncode == 0:
+            head = proc.stdout.strip().splitlines()[0][:40]
+        else:
+            error_kind = "git_rev_parse_failed"
+    except Exception as exc:
+        error_kind = type(exc).__name__
+
+    matches_expected = bool(expected and head and head.startswith(expected))
+    status = "observed"
+    first_blocker = ""
+    if expected:
+        if matches_expected:
+            status = "matched_expected"
+        elif head:
+            status = "mismatched_expected"
+            first_blocker = "loopx_runner_source_git_head_mismatch"
+        else:
+            status = "unknown_expected"
+            first_blocker = "loopx_runner_source_git_head_unknown"
+    elif not head:
+        status = "unknown"
+
+    return {
+        "schema_version": "skillsbench_runner_source_fingerprint_v0",
+        "status": status,
+        "git_head": head,
+        "expected_git_head": expected[:40],
+        "matches_expected": matches_expected,
+        "first_blocker": first_blocker,
+        "error_kind": error_kind[:80],
+        "git_head_recorded": bool(head),
+        "expected_git_head_recorded": bool(expected),
+        "source_path_recorded": False,
+        "raw_git_output_recorded": False,
+    }
+
+
+def runner_source_prerequisite_fields(
+    fingerprint: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "loopx_runner_source_fingerprint_status": str(
+            fingerprint.get("status") or ""
+        ),
+        "loopx_runner_source_first_blocker": str(
+            fingerprint.get("first_blocker") or ""
+        ),
+        "loopx_runner_source_git_head": str(fingerprint.get("git_head") or ""),
+        "loopx_runner_source_expected_git_head": str(
+            fingerprint.get("expected_git_head") or ""
+        ),
+        "loopx_runner_source_error_kind": str(fingerprint.get("error_kind") or ""),
+        "loopx_runner_source_git_head_recorded": bool(
+            fingerprint.get("git_head_recorded")
+        ),
+        "loopx_runner_source_expected_git_head_recorded": bool(
+            fingerprint.get("expected_git_head_recorded")
+        ),
+        "loopx_runner_source_matches_expected": bool(
+            fingerprint.get("matches_expected")
+        ),
+        "loopx_runner_source_path_recorded": False,
+        "loopx_runner_source_raw_git_output_recorded": False,
+    }
+
+
+def compact_runner_source_public_fields(value: dict[str, Any]) -> dict[str, Any]:
+    compact: dict[str, Any] = {}
+    for key, raw in value.items():
+        if not key.startswith("loopx_runner_source_"):
+            continue
+        if isinstance(raw, str) and raw:
+            compact[key] = raw[:180]
+        elif isinstance(raw, bool):
+            compact[key] = raw
+    return compact

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -104,6 +104,7 @@ from loopx.benchmark_adapters.skillsbench import (  # noqa: E402
 from loopx.benchmark_adapters.skillsbench_verifier_bootstrap import (  # noqa: E402
     apply_skillsbench_verifier_bootstrap_missing_score_attribution,
 )
+from loopx.benchmark_adapters import skillsbench_runner_source as runner_source  # noqa: E402
 from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
     SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER,
     SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_PROMPT,
@@ -2949,6 +2950,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
     ):
         if isinstance(value.get(field), int) and not isinstance(value.get(field), bool):
             compact[field] = value[field]
+    compact.update(runner_source.compact_runner_source_public_fields(value))
     target_keys = value.get("host_local_acp_target_env_keys")
     if isinstance(target_keys, list):
         compact["host_local_acp_target_env_keys"] = [
@@ -8575,6 +8577,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
     )
     agent_runtime_layer = _benchflow_agent_runtime_layer_contract(args)
     loopx_source_mount = _loopx_source_mount_contract(args)
+    runner_source_fingerprint = runner_source.build_runner_source_fingerprint(repo_root=REPO_ROOT, expected_git_head=getattr(args, "expected_loopx_git_head", ""))
     requires_preinstalled_runtime = bool(agent_runtime_layer.get("required"))
     is_app_server_goal_route = route == CODEX_APP_SERVER_GOAL_BASELINE_ROUTE
     is_codex_cli_goal_route = route == CODEX_CLI_GOAL_BASELINE_ROUTE
@@ -8808,6 +8811,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         ),
         "benchflow_agent_runtime_layer": agent_runtime_layer,
         "loopx_source_mount": loopx_source_mount,
+        "loopx_runner_source_fingerprint": runner_source_fingerprint,
         "skillsbench_root": str(Path(args.skillsbench_root).expanduser()),
         "jobs_dir": str(jobs_dir),
         "job_name": job_name,
@@ -9148,6 +9152,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
             "loopx_source_mount_injected": False,
             "loopx_source_mount_read_only": bool(loopx_source_mount.get("read_only")),
             "loopx_source_mount_source_recorded": False,
+            **runner_source.runner_source_prerequisite_fields(runner_source_fingerprint),
             "benchflow_agent_timeout_original_sec": 0,
             "benchflow_agent_timeout_effective_sec": 0,
             "benchflow_agent_timeout_overridden": False,
@@ -9401,6 +9406,7 @@ def _public_runner_config(plan: dict[str, Any]) -> dict[str, Any]:
             value = prerequisites.get(field)
             if isinstance(value, str) and value:
                 config[field] = value[:80]
+        config.update(runner_source.compact_runner_source_public_fields(prerequisites))
         value = prerequisites.get("codex_api_reverse_tunnel_proxy_endpoint_port")
         if isinstance(value, int) and not isinstance(value, bool):
             config["codex_api_reverse_tunnel_proxy_endpoint_port"] = value
@@ -13520,6 +13526,10 @@ def _build_product_mode_user(
 async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> Path:
     prerequisites = plan.setdefault("runner_prerequisites", {})
     prerequisites["benchflow_run_stage"] = "entered"
+    source_fingerprint = plan.get("loopx_runner_source_fingerprint")
+    if isinstance(source_fingerprint, dict) and source_fingerprint.get("first_blocker"):
+        prerequisites["benchflow_run_stage"] = "runner_source_fingerprint_check"
+        raise RuntimeError(str(source_fingerprint["first_blocker"]))
     skillsbench_root = Path(args.skillsbench_root).expanduser().resolve()
     prerequisites["benchflow_run_stage"] = "task_path_check"
     task_path = skillsbench_root / "tasks" / args.task_id
@@ -15957,25 +15967,9 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     )
     parser.add_argument("--max-verifier-output-chars", type=int, default=0)
     parser.add_argument("--skillsbench-root", default=str(DEFAULT_SKILLSBENCH_ROOT))
-    parser.add_argument(
-        "--loopx-source-dir",
-        default=str(REPO_ROOT),
-        help=(
-            "Local LoopX checkout mounted read-only into docker product-mode "
-            "runs, or uploaded as a source fallback for older BenchFlow "
-            "host-local sandboxes, and executed with the real loopx.cli module. "
-            "Public compact artifacts record only the target/status, not this "
-            "host path."
-        ),
-    )
-    parser.add_argument(
-        "--no-loopx-source-mount",
-        action="store_true",
-        help=(
-            "Do not mount the local LoopX checkout for product-mode runs; the "
-            "case init falls back to the README GitHub installer."
-        ),
-    )
+    parser.add_argument("--loopx-source-dir", default=str(REPO_ROOT), help="Local LoopX checkout for product-mode source mount/upload; the path is not recorded.")
+    parser.add_argument("--expected-loopx-git-head", default="", help="Fail before task execution unless runner LoopX checkout HEAD starts with this public commit prefix.")
+    parser.add_argument("--no-loopx-source-mount", action="store_true", help="Disable product-mode LoopX source mount/upload and use the public installer path.")
     parser.add_argument(
         "--jobs-dir",
         default=str(REPO_ROOT / ".local/private-benchmark-jobs"),


### PR DESCRIPTION
## Summary
- add a public-safe SkillsBench runner source fingerprint helper
- add --expected-loopx-git-head so remote canaries fail before task execution when the runner checkout is stale or unknown
- expose only commit/status/boundary booleans in runner prerequisites/config and cover the guard with a focused smoke

## Validation
- python3 examples/skillsbench-runner-source-fingerprint-smoke.py
- python3 examples/control_plane/repo-python-line-budget-smoke.py
- python3 -m py_compile scripts/skillsbench_automation_loop.py loopx/benchmark_adapters/skillsbench_runner_source.py examples/skillsbench-runner-source-fingerprint-smoke.py
- git diff --cached --check
- loopx canary premerge --from-git-diff: all direct/catalog/public-boundary checks passed; manual hold: benchmark_sensitive

## Boundary
No benchmark scoring or task semantics changed. No raw logs, task text, trajectories, credentials, host paths, command argv, or private artifacts are recorded.