### PR TITLE
Extract quota agent identity read model

### DIFF
--- a/examples/control_plane/agent-identity-readmodel-smoke.py
+++ b/examples/control_plane/agent-identity-readmodel-smoke.py
@@ -1,0 +1,121 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+from loopx.control_plane.agents.identity import (  # noqa: E402
+    build_identity_aware_prompt_upgrade,
+    build_quota_agent_identity,
+    quota_primary_agent,
+    quota_registered_agents,
+)
+
+
+def sample_goal() -> dict:
+    return {
+        "id": "sample-goal",
+        "coordination": {
+            "registered_agents": [
+                "codex-main",
+                {"agent_id": "codex-side"},
+                {"name": "codex-reviewer"},
+                "codex-side",
+            ],
+            "primary_agent": "codex-main",
+            "side_agent_handoff_agent": "codex-reviewer",
+            "agent_profiles": {
+                "codex-profiled": {
+                    "review_policy": {
+                        "handoff_agent": "codex-profile-reviewer",
+                    }
+                }
+            },
+        },
+    }
+
+
+def assert_registered_agent_identity_contract() -> None:
+    goal = sample_goal()
+    goal["coordination"]["registered_agents"].extend(
+        ["codex-profiled", "codex-profile-reviewer"]
+    )
+
+    assert quota_registered_agents(goal) == [
+        "codex-main",
+        "codex-side",
+        "codex-reviewer",
+        "codex-profiled",
+        "codex-profile-reviewer",
+    ]
+    assert quota_primary_agent(goal) == "codex-main"
+
+    primary = build_quota_agent_identity(goal, agent_id="codex-main")
+    assert primary["role"] == "primary-agent", primary
+    assert primary["primary_agent"] == "codex-main", primary
+    assert primary["registered_agents"] == quota_registered_agents(goal), primary
+
+    side = build_quota_agent_identity(goal, agent_id="codex-side")
+    assert side["role"] == "side-agent", side
+    assert side["handoff_agent"] == "codex-reviewer", side
+
+    profiled = build_quota_agent_identity(goal, agent_id="codex-profiled")
+    assert profiled["handoff_agent"] == "codex-profile-reviewer", profiled
+
+
+def assert_identity_prompt_upgrade_contract() -> None:
+    upgrade = build_identity_aware_prompt_upgrade(
+        sample_goal(),
+        goal_id="sample-goal",
+        agent_identity=None,
+    )
+    assert upgrade["contract"] == "identity_aware_heartbeat_prompt_v1", upgrade
+    assert upgrade["blocks_should_run"] is True, upgrade
+    assert "codex-main" in upgrade["primary_example_command"], upgrade
+    assert "codex-side" in upgrade["side_agent_example_command"], upgrade
+
+    assert (
+        build_identity_aware_prompt_upgrade(
+            sample_goal(),
+            goal_id="sample-goal",
+            agent_identity={"agent_id": "codex-main"},
+        )
+        is None
+    )
+
+
+def assert_identity_errors_are_actionable() -> None:
+    try:
+        build_quota_agent_identity(sample_goal(), agent_id="codex-missing")
+    except ValueError as exc:
+        text = str(exc)
+        assert "codex-missing" in text, text
+        assert "registered_agents=" in text, text
+    else:
+        raise AssertionError("unregistered agent should fail")
+
+    goal = sample_goal()
+    goal["coordination"]["registered_agents"] = ["codex-main", "codex-side"]
+    try:
+        build_quota_agent_identity(goal, agent_id="codex-side")
+    except ValueError as exc:
+        text = str(exc)
+        assert "side_agent_handoff_agent" in text, text
+        assert "codex-reviewer" in text, text
+    else:
+        raise AssertionError("unregistered handoff agent should fail")
+
+
+def main() -> None:
+    assert_registered_agent_identity_contract()
+    assert_identity_prompt_upgrade_contract()
+    assert_identity_errors_are_actionable()
+    print("agent-identity-readmodel-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/control_plane/agents/identity.py
+++ b/loopx/control_plane/agents/identity.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ...agent_registry import (
+    primary_agent_id_for_goal,
+    registered_agent_ids_for_goal,
+    side_agent_handoff_agent_id_for_goal,
+)
+from ..todos.contract import normalize_todo_claimed_by
+
+
+def quota_registered_agents(goal: dict[str, Any]) -> list[str]:
+    return registered_agent_ids_for_goal(goal)
+
+
+def quota_primary_agent(goal: dict[str, Any]) -> str | None:
+    return primary_agent_id_for_goal(goal)
+
+
+def build_quota_agent_identity(
+    goal: dict[str, Any],
+    *,
+    agent_id: str | None,
+) -> dict[str, Any] | None:
+    normalized_agent_id = normalize_todo_claimed_by(agent_id) if agent_id else None
+    if agent_id and not normalized_agent_id:
+        raise ValueError("agent_id must be a public-safe registered agent id")
+    registered_agents = quota_registered_agents(goal)
+    if not normalized_agent_id:
+        return None
+    if not registered_agents:
+        raise ValueError(
+            "quota should-run --agent-id requires coordination.registered_agents; "
+            "register this agent identity first"
+        )
+    if normalized_agent_id not in registered_agents:
+        raise ValueError(
+            f"agent_id={normalized_agent_id!r} is not registered; "
+            f"registered_agents={', '.join(registered_agents)}"
+        )
+    primary_agent = quota_primary_agent(goal)
+    handoff_agent = side_agent_handoff_agent_id_for_goal(goal, agent_id=normalized_agent_id)
+    if handoff_agent:
+        if handoff_agent not in registered_agents:
+            raise ValueError(
+                f"side_agent_handoff_agent={handoff_agent!r} is not registered; "
+                f"registered_agents={', '.join(registered_agents)}"
+            )
+    return {
+        "agent_id": normalized_agent_id,
+        "registered": True,
+        "role": "primary-agent" if primary_agent and normalized_agent_id == primary_agent else "side-agent",
+        "primary_agent": primary_agent,
+        "handoff_agent": handoff_agent,
+        "registered_agents": registered_agents,
+    }
+
+
+def build_identity_aware_prompt_upgrade(
+    goal: dict[str, Any],
+    *,
+    goal_id: str,
+    agent_identity: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    registered_agents = quota_registered_agents(goal)
+    if not registered_agents or agent_identity:
+        return None
+    primary_agent = quota_primary_agent(goal)
+    primary_hint = primary_agent if primary_agent in registered_agents else registered_agents[0]
+    side_hint = next((agent for agent in registered_agents if agent != primary_hint), primary_hint)
+    return {
+        "contract": "identity_aware_heartbeat_prompt_v1",
+        "required": True,
+        "blocks_should_run": True,
+        "reason": (
+            "coordination.registered_agents is configured, but quota should-run "
+            "was called without --agent-id; the installed automation prompt is "
+            "likely stale or unscoped"
+        ),
+        "registered_agents": registered_agents,
+        "primary_agent": primary_agent,
+        "recommended_action": (
+            "Regenerate the installed heartbeat automation prompt with a "
+            "registered --agent-id and at least one --agent-scope, then rerun "
+            "quota should-run with the same --agent-id."
+        ),
+        "primary_example_command": (
+            f"loopx heartbeat-prompt --thin --goal-id {goal_id} "
+            f"--agent-id {primary_hint} --agent-scope "
+            "'primary review, verification, merge, and coordination'"
+        ),
+        "side_agent_example_command": (
+            f"loopx heartbeat-prompt --thin --goal-id {goal_id} "
+            f"--agent-id {side_hint} --agent-scope "
+            "'bounded side-agent work in an independent worktree'"
+        ),
+    }

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
-from .agent_registry import side_agent_handoff_agent_id_for_goal
 from .control_plane.agents.agent_scope import (
     AgentScopeFrontierAction,
     _action_scope_tokens_from_text,
@@ -27,6 +26,12 @@ from .control_plane.agents.capability_gate import (
     build_capability_gate,
 )
 from .control_plane.agents.workspace_guard import build_side_agent_workspace_guard
+from .control_plane.agents.identity import (
+    build_identity_aware_prompt_upgrade,
+    build_quota_agent_identity,
+    quota_primary_agent,
+    quota_registered_agents,
+)
 from .benchmark_core import compact_run_permission_policy_for_quota
 from .boundary_authority import checkpointed_boundary_authority_summary
 from .control_plane import (
@@ -961,109 +966,17 @@ def _goal_boundary(goal: dict[str, Any], item: dict[str, Any] | None = None) -> 
     return None
 
 
-def _quota_registered_agents(goal: dict[str, Any]) -> list[str]:
-    coordination = goal.get("coordination") if isinstance(goal.get("coordination"), dict) else {}
-    raw_values = coordination.get("registered_agents")
-    if raw_values is None:
-        raw_values = goal.get("registered_agents")
-    if isinstance(raw_values, str):
-        raw_values = [raw_values]
-    if not isinstance(raw_values, list):
-        return []
-    agents: list[str] = []
-    for value in raw_values:
-        candidate = value
-        if isinstance(candidate, dict):
-            candidate = candidate.get("id") or candidate.get("agent_id") or candidate.get("name")
-        normalized = normalize_todo_claimed_by(candidate)
-        if normalized and normalized not in agents:
-            agents.append(normalized)
-    return agents
-
-
-def _quota_primary_agent(goal: dict[str, Any]) -> str | None:
-    coordination = goal.get("coordination") if isinstance(goal.get("coordination"), dict) else {}
-    for candidate in (coordination.get("primary_agent"), goal.get("primary_agent")):
-        normalized = normalize_todo_claimed_by(candidate)
-        if normalized:
-            return normalized
-    return None
-
-
-def _quota_agent_identity(goal: dict[str, Any], *, agent_id: str | None) -> dict[str, Any] | None:
-    normalized_agent_id = normalize_todo_claimed_by(agent_id) if agent_id else None
-    if agent_id and not normalized_agent_id:
-        raise ValueError("agent_id must be a public-safe registered agent id")
-    registered_agents = _quota_registered_agents(goal)
-    if not normalized_agent_id:
-        return None
-    if not registered_agents:
-        raise ValueError(
-            "quota should-run --agent-id requires coordination.registered_agents; "
-            "register this agent identity first"
-        )
-    if normalized_agent_id not in registered_agents:
-        raise ValueError(
-            f"agent_id={normalized_agent_id!r} is not registered; "
-            f"registered_agents={', '.join(registered_agents)}"
-        )
-    primary_agent = _quota_primary_agent(goal)
-    handoff_agent = side_agent_handoff_agent_id_for_goal(goal, agent_id=normalized_agent_id)
-    if handoff_agent:
-        if handoff_agent not in registered_agents:
-            raise ValueError(
-                f"side_agent_handoff_agent={handoff_agent!r} is not registered; "
-                f"registered_agents={', '.join(registered_agents)}"
-            )
-    return {
-        "agent_id": normalized_agent_id,
-        "registered": True,
-        "role": "primary-agent" if primary_agent and normalized_agent_id == primary_agent else "side-agent",
-        "primary_agent": primary_agent,
-        "handoff_agent": handoff_agent,
-        "registered_agents": registered_agents,
-    }
-
-
 def _automation_prompt_upgrade(
     goal: dict[str, Any],
     *,
     goal_id: str,
     agent_identity: dict[str, Any] | None,
 ) -> dict[str, Any] | None:
-    registered_agents = _quota_registered_agents(goal)
-    if not registered_agents or agent_identity:
-        return None
-    primary_agent = _quota_primary_agent(goal)
-    primary_hint = primary_agent if primary_agent in registered_agents else registered_agents[0]
-    side_hint = next((agent for agent in registered_agents if agent != primary_hint), primary_hint)
-    return {
-        "contract": "identity_aware_heartbeat_prompt_v1",
-        "required": True,
-        "blocks_should_run": True,
-        "reason": (
-            "coordination.registered_agents is configured, but quota should-run "
-            "was called without --agent-id; the installed automation prompt is "
-            "likely stale or unscoped"
-        ),
-        "registered_agents": registered_agents,
-        "primary_agent": primary_agent,
-        "recommended_action": (
-            "Regenerate the installed heartbeat automation prompt with a "
-            "registered --agent-id and at least one --agent-scope, then rerun "
-            "quota should-run with the same --agent-id."
-        ),
-        "primary_example_command": (
-            f"loopx heartbeat-prompt --thin --goal-id {goal_id} "
-            f"--agent-id {primary_hint} --agent-scope "
-            "'primary review, verification, merge, and coordination'"
-        ),
-        "side_agent_example_command": (
-            f"loopx heartbeat-prompt --thin --goal-id {goal_id} "
-            f"--agent-id {side_hint} --agent-scope "
-            "'bounded side-agent work in an independent worktree'"
-        ),
-    }
+    return build_identity_aware_prompt_upgrade(
+        goal,
+        goal_id=goal_id,
+        agent_identity=agent_identity,
+    )
 
 
 def _build_gate_prompt(
@@ -1822,7 +1735,7 @@ def build_quota_should_run(
         if not plan.get("ok"):
             reason = "status or contract health is not ok; skip automatic compute"
         project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
-        agent_identity = _quota_agent_identity(item, agent_id=agent_id)
+        agent_identity = build_quota_agent_identity(item, agent_id=agent_id)
         user_todo_summary = select_quota_todo_summary(
             item.get("user_todos"),
             project_asset.get("user_todos") if project_asset else None,


### PR DESCRIPTION
## Summary

- Move quota agent identity and identity-aware automation prompt-upgrade projection into `loopx.control_plane.agents.identity`.
- Keep `loopx.quota` as the active caller while deleting the duplicate local registered-agent / primary-agent / side-agent handoff helper block.
- Add a focused readmodel smoke for primary/side-agent identity, handoff-agent validation, prompt-upgrade projection, and actionable error messages.

## Product / Architecture Judgment

Motivation: `quota.py` is a hot control-plane file. Agent identity is an agents bounded-context concern and should not live as ad hoc helper logic inside quota decision assembly.

Solved: this makes quota consume a reusable agent identity read model while preserving the active `quota should-run` behavior. The new readmodel also reuses the existing agent registry helpers instead of maintaining a second parser for registered/primary agents.

User/operator impact: side-agent guard, automation-prompt upgrade, and quota routing become easier to test and evolve without expanding `quota.py`.

Risk: moderate read-path risk because `quota should-run` consumes this projection. Coverage includes focused identity smoke, quota plan/contract smokes, side-agent workspace guard, status/quota/review-packet parity, integrated control-plane canary, and risk-selected premerge.

## Validation

- `python3 -m py_compile loopx/quota.py loopx/control_plane/agents/identity.py examples/control_plane/agent-identity-readmodel-smoke.py`
- `python3 examples/control_plane/agent-identity-readmodel-smoke.py`
- `python3 examples/control_plane/side-agent-workspace-guard-smoke.py`
- `python3 examples/control_plane/quota-plan-smoke.py`
- `python3 examples/control_plane/quota-contract-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `python3 -m loopx.cli --format json canary premerge --from-git-diff` selected/executed 17 checks with 0 failures, 0 warnings, 0 manual holds, and `self_merge_allowed=true`.
- `git diff --check origin/main...HEAD`
- Added-line public/private boundary scan over changed paths: no local absolute paths, credentials, raw benchmark evidence, trajectories, raw logs, task text, or verifier-output markers found.

## Merge Plan

Self-merge after PR creation because this is a cohesive non-benchmark control-plane readmodel extraction, has focused and aggregate canary coverage, and has a clean public/private boundary scan.
