### PR TITLE
Preserve per-agent vision context in run history

### DIFF
--- a/examples/control_plane/run-history-agent-context-retention-smoke.py
+++ b/examples/control_plane/run-history-agent-context-retention-smoke.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""Smoke-test per-agent vision/replan context survives latest-run truncation."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from loopx.control_plane.goals.goal_frontier import latest_agent_vision_from_status_payload
+from loopx.history import collect_history
+
+
+GOAL_ID = "agent-context-retention-goal"
+SIDE_AGENT = "codex-side-bypass"
+
+
+def write_fixture(root: Path) -> tuple[Path, Path]:
+    runtime = root / "runtime"
+    project = root / "project"
+    runs_dir = runtime / "goals" / GOAL_ID / "runs"
+    runs_dir.mkdir(parents=True)
+    registry_path = project / ".loopx" / "registry.json"
+    registry_path.parent.mkdir(parents=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "0.1",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": ".local/goals/fixture.md",
+                        "adapter": {"kind": "fixture", "status": "connected-read-only"},
+                        "coordination": {
+                            "primary_agent": "codex-main-control",
+                            "registered_agents": [
+                                "codex-main-control",
+                                SIDE_AGENT,
+                                "codex-product-capability",
+                            ],
+                        },
+                    }
+                ],
+            },
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    runs = [
+        ("2026-07-06T00:06:00+00:00", "codex-main-control", "latest main"),
+        ("2026-07-06T00:05:00+00:00", "codex-product-capability", "latest product"),
+        ("2026-07-06T00:04:00+00:00", "codex-main-control", "second main"),
+        (
+            "2026-07-06T00:03:00+00:00",
+            SIDE_AGENT,
+            "side vision",
+        ),
+        ("2026-07-06T00:02:00+00:00", SIDE_AGENT, "older side"),
+    ]
+    with (runs_dir / "index.jsonl").open("w", encoding="utf-8") as handle:
+        for generated_at, agent_id, action in runs:
+            record = {
+                "generated_at": generated_at,
+                "goal_id": GOAL_ID,
+                "classification": "state_refreshed",
+                "agent_id": agent_id,
+                "recommended_action": action,
+                "json_path": str(runs_dir / f"{generated_at}.json"),
+                "markdown_path": str(runs_dir / f"{generated_at}.md"),
+            }
+            if action == "side vision":
+                record["agent_vision"] = {
+                    "schema_version": "goal_vision_replan_contract_v0",
+                    "agent_id": SIDE_AGENT,
+                    "state": "active",
+                    "vision_patch": {
+                        "acceptance_summary": (
+                            "Keep side-lane auto-research multi-round work runnable."
+                        ),
+                        "replan_trigger_summary": (
+                            "Side-lane vision would otherwise fall out of the "
+                            "global run window."
+                        ),
+                    },
+                }
+                record["vision_checkpoint"] = {
+                    "schema_version": "vision_checkpoint_v0",
+                    "agent_id": SIDE_AGENT,
+                    "required": True,
+                    "satisfied": True,
+                    "decision": "patched",
+                }
+            handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+    return registry_path, runtime
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-agent-context-retention-") as raw_tmp:
+        registry_path, runtime = write_fixture(Path(raw_tmp))
+        history = collect_history(
+            registry_path=registry_path,
+            runtime_root=runtime,
+            goal_id=GOAL_ID,
+            limit=3,
+        )
+        goal = history["goals"][0]
+        latest_runs = goal["latest_runs"]
+        assert [run["recommended_action"] for run in latest_runs[:3]] == [
+            "latest main",
+            "latest product",
+            "second main",
+        ], latest_runs
+        assert any(
+            run.get("agent_id") == SIDE_AGENT and run.get("agent_vision")
+            for run in latest_runs
+        ), latest_runs
+        vision = latest_agent_vision_from_status_payload(
+            {"run_history": {"goals": history["goals"]}},
+            goal_id=GOAL_ID,
+            agent_id=SIDE_AGENT,
+        )
+        assert vision and vision["agent_id"] == SIDE_AGENT, vision
+        assert "global run window" in vision["vision_patch"]["replan_trigger_summary"], vision
+    print("run-history-agent-context-retention-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/history.py
+++ b/loopx/history.py
@@ -37,6 +37,11 @@ REGISTRY_ATTENTION_FIELDS = (
     "recommended_action",
     "next_handoff_condition",
 )
+PER_AGENT_CONTEXT_RUN_FIELDS = (
+    "agent_vision",
+    "vision_checkpoint",
+    "autonomous_replan_ack",
+)
 
 
 def now_local() -> str:
@@ -665,6 +670,31 @@ def latest_status_run(runs: list[dict[str, Any]]) -> dict[str, Any] | None:
     return None
 
 
+def latest_runs_with_agent_context(
+    runs: list[dict[str, Any]],
+    *,
+    limit: int,
+) -> list[dict[str, Any]]:
+    """Keep recent runs plus each agent's newest vision/replan context run."""
+
+    bounded = max(0, limit)
+    selected = list(runs[:bounded])
+    selected_ids = {id(run) for run in selected}
+    agents_with_context: set[str] = set()
+
+    for run in runs:
+        agent_id = str(run.get("agent_id") or "").strip()
+        if not agent_id or agent_id in agents_with_context:
+            continue
+        if not any(isinstance(run.get(field), dict) for field in PER_AGENT_CONTEXT_RUN_FIELDS):
+            continue
+        agents_with_context.add(agent_id)
+        if id(run) not in selected_ids:
+            selected.append(run)
+            selected_ids.add(id(run))
+    return selected
+
+
 def collect_history(
     *,
     registry_path: Path,
@@ -725,7 +755,7 @@ def collect_history(
             "raw_index_records": raw_count,
             "unique_runs": len(runs),
             "latest_status_run": latest_status_run(runs),
-            "latest_runs": runs[:limit],
+            "latest_runs": latest_runs_with_agent_context(runs, limit=limit),
         }
         if registry_member:
             for field in REGISTRY_ATTENTION_FIELDS:


### PR DESCRIPTION
## Summary
- Preserve each agent's latest vision/checkpoint/replan-ack run in goal latest-run context even when the global latest-run window is crowded by other agents.
- Add a focused control-plane smoke proving side-agent vision remains readable after global truncation.

## Why
The auto-research side lane had written per-agent vision, but subsequent high-frequency runs from other lanes pushed that vision out of the bounded latest-run window. Quota then saw agent_vision=null and fell back to agent_scope_wait instead of deriving the intended vision/replan gap.

## Validation
- python3 examples/control_plane/run-history-agent-context-retention-smoke.py
- python3 examples/control_plane/quota-replan-decision-plane-smoke.py
- python3 examples/control_plane/refresh-state-agent-lane-scope-smoke.py
- python3 -m compileall -q loopx/history.py examples/control_plane/run-history-agent-context-retention-smoke.py
- loopx canary premerge --from-git-diff
