### PR TITLE
Extract shared user gate todo read model

### DIFF
--- a/examples/control_plane/todo-user-gate-readmodel-smoke.py
+++ b/examples/control_plane/todo-user-gate-readmodel-smoke.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Smoke-test the shared user-gate todo read model."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.todos.quota_summary import (  # noqa: E402
+    is_user_gate_todo_item,
+    summarize_user_todos_for_quota,
+)
+from loopx.control_plane.todos.user_gate import (  # noqa: E402
+    build_gate_prompt,
+    has_open_user_gate_todo,
+    open_todo_count,
+    open_user_gate_todo_items,
+    should_notify_user_on_open_todo,
+    user_gate_todo_notify_reason,
+)
+
+
+AGENT_IDENTITY = {"agent_id": "codex-product-capability"}
+
+
+def raw_todos() -> dict:
+    return {
+        "schema_version": "todo_summary_v0",
+        "open_count": 3,
+        "items": [
+            {
+                "index": 1,
+                "todo_id": "todo_gate_current",
+                "text": "Approve product capability runtime write.",
+                "task_class": "user_gate",
+                "action_kind": "approval",
+                "blocks_agent": "codex-product-capability",
+            },
+            {
+                "index": 2,
+                "todo_id": "todo_gate_other",
+                "text": "Approve main-control production rollout.",
+                "task_class": "user_gate",
+                "action_kind": "production_rollout",
+                "blocks_agent": "codex-main-control",
+            },
+            {
+                "index": 3,
+                "todo_id": "todo_next",
+                "text": "Continue non-benchmark control-plane refactor.",
+                "task_class": "advancement_task",
+                "claimed_by": "codex-product-capability",
+            },
+        ],
+    }
+
+
+def assert_shared_gate_detection() -> None:
+    assert is_user_gate_todo_item(
+        {
+            "task_class": "advancement_task",
+            "action_kind": "public_claim_review",
+            "text": "Review the public claim.",
+        }
+    )
+    summary = summarize_user_todos_for_quota(
+        raw_todos(),
+        agent_identity=AGENT_IDENTITY,
+        filter_user_gate_blocks_agent=True,
+    )
+    assert summary is not None
+    assert summary["open_count"] == 2, summary
+    assert summary["all_open_count"] == 3, summary
+    assert summary["other_agent_scoped_open_count"] == 1, summary
+
+    with_duplicate = {
+        "open_count": "2",
+        "gate_open_items": [summary["gate_open_items"][0]],
+        "first_open_items": [
+            summary["gate_open_items"][0],
+            summary["first_executable_items"][0],
+        ],
+    }
+    gate_items = open_user_gate_todo_items(with_duplicate)
+    assert [item["todo_id"] for item in gate_items] == ["todo_gate_current"], gate_items
+    assert open_todo_count(with_duplicate) == 2
+    assert has_open_user_gate_todo(with_duplicate)
+    assert user_gate_todo_notify_reason(with_duplicate) == (
+        "open user_gate todo requires owner decision before approval"
+    )
+
+
+def assert_notification_policy() -> None:
+    summary = {"open_count": 1, "first_open_items": [{"text": "Need owner decision"}]}
+    assert should_notify_user_on_open_todo(
+        state="waiting",
+        waiting_on="codex",
+        user_todo_summary=summary,
+    )
+    assert should_notify_user_on_open_todo(
+        state="eligible",
+        waiting_on="external_evidence",
+        user_todo_summary=summary,
+    )
+    assert not should_notify_user_on_open_todo(
+        state="operator_gate",
+        waiting_on="controller",
+        user_todo_summary=summary,
+    )
+    assert not should_notify_user_on_open_todo(
+        state="eligible",
+        waiting_on="codex",
+        user_todo_summary={"open_count": 0},
+    )
+
+
+def assert_operator_gate_prompt() -> None:
+    prompt = build_gate_prompt(
+        {
+            "operator_question": "Can the side agent self-merge this refactor?",
+            "recommended_action": "Approve after premerge canary.",
+            "next_handoff_condition": "PR merged and successor todo linked.",
+            "missing_gates": ["owner_approval"],
+        },
+        user_todo_summary={
+            "open_count": 1,
+            "first_open_items": [
+                {
+                    "index": 1,
+                    "todo_id": "todo_gate_current",
+                    "text": "Approve the scoped refactor.",
+                    "task_class": "user_gate",
+                }
+            ],
+        },
+    )
+    assert prompt is not None
+    assert "Can the side agent self-merge this refactor?" in prompt, prompt
+    assert "owner_approval" in prompt, prompt
+    assert "Approve the scoped refactor." in prompt, prompt
+
+    other_agent_prompt = build_gate_prompt(
+        {},
+        user_todo_summary={
+            "open_count": 0,
+            "other_agent_scoped_open_count": 1,
+            "all_open_count": 2,
+            "other_agent_scoped_items": [
+                {
+                    "index": 7,
+                    "todo_id": "todo_other",
+                    "text": "Approve another agent boundary.",
+                }
+            ],
+        },
+    )
+    assert other_agent_prompt is not None
+    assert "其他 agent/global 用户待办" in other_agent_prompt, other_agent_prompt
+
+
+def main() -> None:
+    assert_shared_gate_detection()
+    assert_notification_policy()
+    assert_operator_gate_prompt()
+    print("todo user-gate read model smoke passed")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/control_plane/agents/agent_scope.py
+++ b/loopx/control_plane/agents/agent_scope.py
@@ -13,7 +13,6 @@ from ..todos.contract import (
     TODO_STATUS_OPEN,
     TODO_TASK_CLASS_ADVANCEMENT,
     TODO_TASK_CLASS_MONITOR,
-    TODO_TASK_CLASS_USER_GATE,
     normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
     normalize_todo_id,
@@ -29,24 +28,14 @@ from ..todos.projection import (
     todo_projection_sort_key,
 )
 from ..todos.summary_item import compact_todo_summary_item
+from ..todos.user_gate import (
+    open_todo_count as _open_todo_count,
+    open_user_gate_todo_items as _open_user_gate_todo_items,
+)
 
 
 AGENT_SCOPE_FRONTIER_SCHEMA_VERSION = "agent_scope_frontier_v0"
 AGENT_LANE_FRONTIER_HINT_SCHEMA_VERSION = "agent_lane_frontier_hint_v0"
-
-USER_GATE_ACTION_KIND_HINTS = (
-    "approval",
-    "approve",
-    "boundary",
-    "gate",
-    "blocker",
-    "credential",
-    "private",
-    "production",
-    "leaderboard",
-    "submission",
-    "public_claim",
-)
 
 _ACTION_SCOPE_STOPWORDS = {
     "a",
@@ -125,48 +114,6 @@ def _protocol_action_text(value: Any, *, limit: int = 220) -> str | None:
     if len(text) <= limit:
         return text
     return text[: max(0, limit - 3)].rstrip() + "..."
-
-
-def _open_todo_count(summary: dict[str, Any] | None) -> int:
-    if not isinstance(summary, dict):
-        return 0
-    try:
-        return max(0, int(summary.get("open_count") or 0))
-    except (TypeError, ValueError):
-        return 0
-
-
-def _is_user_gate_todo_item(item: dict[str, Any]) -> bool:
-    if _todo_task_class(item) == TODO_TASK_CLASS_USER_GATE:
-        return True
-    action_kind = str(item.get("action_kind") or "").strip().lower()
-    if not action_kind:
-        return False
-    return any(hint in action_kind for hint in USER_GATE_ACTION_KIND_HINTS)
-
-
-def _open_user_gate_todo_items(summary: dict[str, Any] | None) -> list[dict[str, Any]]:
-    if not isinstance(summary, dict):
-        return []
-    candidates: list[dict[str, Any]] = []
-    for key in ("gate_open_items", "first_open_items"):
-        values = summary.get(key)
-        if not isinstance(values, list):
-            continue
-        for item in values:
-            if not isinstance(item, dict) or item.get("done") is True:
-                continue
-            if not _is_user_gate_todo_item(item):
-                continue
-            item_key = (item.get("todo_id"), item.get("index"), item.get("text"))
-            if any(
-                (existing.get("todo_id"), existing.get("index"), existing.get("text"))
-                == item_key
-                for existing in candidates
-            ):
-                continue
-            candidates.append(item)
-    return candidates
 
 
 def _action_scope_tokens_from_text(text: str) -> set[str]:

--- a/loopx/control_plane/quota/heartbeat_recommendation.py
+++ b/loopx/control_plane/quota/heartbeat_recommendation.py
@@ -12,6 +12,7 @@ from ..work_items.work_lane_context import (
     build_work_lane_context_contract,
     latest_run_progress_scope,
 )
+from ..todos.user_gate import open_todo_count as _open_todo_count
 
 
 HEARTBEAT_READ_ONLY_MAP_ADAPTER_SUFFIX = "_read_only_map_v0"
@@ -37,15 +38,6 @@ HEARTBEAT_POST_HANDOFF_RUN_COMPACT_FIELDS = (
     "json_exists",
     "markdown_exists",
 )
-
-
-def _open_todo_count(summary: dict[str, Any] | None) -> int:
-    if not isinstance(summary, dict):
-        return 0
-    try:
-        return max(0, int(summary.get("open_count") or 0))
-    except (TypeError, ValueError):
-        return 0
 
 
 def open_todo_notify_reason(*, state: str, waiting_on: str) -> str:

--- a/loopx/control_plane/todos/quota_summary.py
+++ b/loopx/control_plane/todos/quota_summary.py
@@ -13,7 +13,6 @@ from .claim_visibility import (
 from .contract import (
     TODO_TASK_CLASS_ADVANCEMENT,
     TODO_TASK_CLASS_MONITOR,
-    TODO_TASK_CLASS_USER_GATE,
 )
 from .deferred_resume import (
     build_todo_deferred_visibility_lanes,
@@ -32,35 +31,13 @@ from .projection import (
 from .route_continuation import build_todo_route_continuation_lanes
 from .succession_warning import build_todo_succession_warning_lanes
 from .summary_item import compact_todo_summary_item, todo_summary_source_items
+from .user_gate import is_user_gate_todo_item
 
 
 MONITOR_DUE_ITEM_LIMIT = 1
 TODO_BACKLOG_ITEM_LIMIT = 8
 TODO_DEFERRED_VISIBILITY_LIMIT = 8
 TODO_VISIBILITY_LANE_LIMIT = 16
-
-USER_GATE_ACTION_KIND_HINTS = (
-    "approval",
-    "approve",
-    "boundary",
-    "gate",
-    "blocker",
-    "credential",
-    "private",
-    "production",
-    "leaderboard",
-    "submission",
-    "public_claim",
-)
-
-
-def is_user_gate_todo_item(item: dict[str, Any]) -> bool:
-    if todo_item_task_class(item) == TODO_TASK_CLASS_USER_GATE:
-        return True
-    action_kind = str(item.get("action_kind") or "").strip().lower()
-    if not action_kind:
-        return False
-    return any(hint in action_kind for hint in USER_GATE_ACTION_KIND_HINTS)
 
 
 def summarize_user_todos_for_quota(

--- a/loopx/control_plane/todos/user_gate.py
+++ b/loopx/control_plane/todos/user_gate.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .contract import TODO_TASK_CLASS_USER_GATE
+from .projection import todo_item_task_class
+
+
+USER_GATE_ACTION_KIND_HINTS = (
+    "approval",
+    "approve",
+    "boundary",
+    "gate",
+    "blocker",
+    "credential",
+    "private",
+    "production",
+    "leaderboard",
+    "submission",
+    "public_claim",
+)
+
+
+def open_todo_count(summary: dict[str, Any] | None) -> int:
+    if not isinstance(summary, dict):
+        return 0
+    try:
+        return max(0, int(summary.get("open_count") or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def is_user_gate_todo_item(item: dict[str, Any]) -> bool:
+    if todo_item_task_class(item) == TODO_TASK_CLASS_USER_GATE:
+        return True
+    action_kind = str(item.get("action_kind") or "").strip().lower()
+    if not action_kind:
+        return False
+    return any(hint in action_kind for hint in USER_GATE_ACTION_KIND_HINTS)
+
+
+def open_user_gate_todo_items(summary: dict[str, Any] | None) -> list[dict[str, Any]]:
+    if not isinstance(summary, dict):
+        return []
+    candidates: list[dict[str, Any]] = []
+    for key in ("gate_open_items", "first_open_items"):
+        values = summary.get(key)
+        if not isinstance(values, list):
+            continue
+        for item in values:
+            if not isinstance(item, dict) or item.get("done") is True:
+                continue
+            if not is_user_gate_todo_item(item):
+                continue
+            item_key = (item.get("todo_id"), item.get("index"), item.get("text"))
+            if any(
+                (existing.get("todo_id"), existing.get("index"), existing.get("text"))
+                == item_key
+                for existing in candidates
+            ):
+                continue
+            candidates.append(item)
+    return candidates
+
+
+def has_open_user_gate_todo(summary: dict[str, Any] | None) -> bool:
+    return bool(open_user_gate_todo_items(summary))
+
+
+def user_gate_todo_notify_reason(summary: dict[str, Any] | None) -> str:
+    items = open_user_gate_todo_items(summary)
+    if not items:
+        return "open user todo can resolve the current gate"
+    first = items[0]
+    action_kind = str(first.get("action_kind") or "").strip()
+    if action_kind:
+        return f"open user_gate todo requires owner decision before {action_kind}"
+    return "open user_gate todo requires owner decision before agent execution"
+
+
+def should_notify_user_on_open_todo(
+    *,
+    state: str,
+    waiting_on: str,
+    user_todo_summary: dict[str, Any] | None,
+) -> bool:
+    if state == "operator_gate":
+        return False
+    if open_todo_count(user_todo_summary) <= 0:
+        return False
+    if state in {"focus_wait", "waiting"}:
+        return True
+    return waiting_on in {"user_or_controller", "controller", "external_evidence"}
+
+
+def build_gate_prompt(
+    item: dict[str, Any],
+    *,
+    user_todo_summary: dict[str, Any] | None = None,
+) -> str | None:
+    question = str(item.get("operator_question") or "").strip()
+    recommended_action = str(item.get("recommended_action") or "").strip()
+    next_handoff_condition = str(item.get("next_handoff_condition") or "").strip()
+    missing_gates = [
+        str(gate).strip()
+        for gate in (item.get("missing_gates") if isinstance(item.get("missing_gates"), list) else [])
+        if str(gate).strip()
+    ]
+    if user_todo_summary is None:
+        from .quota_summary import summarize_user_todos_for_quota
+
+        user_todo_summary = summarize_user_todos_for_quota(item.get("user_todos"))
+    first_open = (
+        user_todo_summary.get("first_open_items")
+        if isinstance(user_todo_summary, dict)
+        and isinstance(user_todo_summary.get("first_open_items"), list)
+        else []
+    )
+    other_agent_scoped_items = (
+        user_todo_summary.get("other_agent_scoped_items")
+        if isinstance(user_todo_summary, dict)
+        and isinstance(user_todo_summary.get("other_agent_scoped_items"), list)
+        else []
+    )
+
+    if not any(
+        [
+            question,
+            recommended_action,
+            next_handoff_condition,
+            missing_gates,
+            first_open,
+            other_agent_scoped_items,
+        ]
+    ):
+        return None
+
+    lines = ["请用户/控制器确认当前 gate："]
+    if question:
+        lines.append(f"- 问题：{question}")
+    if recommended_action:
+        lines.append(f"- 当前建议：{recommended_action}")
+    if next_handoff_condition:
+        lines.append(f"- 放行条件：{next_handoff_condition}")
+    if missing_gates:
+        lines.append(f"- 缺失 gate：{', '.join(missing_gates)}")
+    if isinstance(user_todo_summary, dict) and first_open:
+        open_count = user_todo_summary.get("open_count")
+        lines.append(f"- 用户待办：{open_count} 项未完成，优先确认：")
+        for todo in first_open:
+            index = todo.get("index")
+            prefix = f"  {index}. " if index is not None else "  - "
+            lines.append(f"{prefix}{todo.get('text')}")
+    elif isinstance(user_todo_summary, dict) and other_agent_scoped_items:
+        scoped_count = user_todo_summary.get("other_agent_scoped_open_count")
+        all_open_count = user_todo_summary.get("all_open_count")
+        count = scoped_count if scoped_count is not None else len(other_agent_scoped_items)
+        suffix = f"（全局共 {all_open_count} 项）" if all_open_count is not None else ""
+        lines.append(f"- 当前 agent 无阻塞用户待办；其他 agent/global 用户待办：{count} 项{suffix}，优先确认：")
+        for todo in other_agent_scoped_items[:3]:
+            index = todo.get("index")
+            prefix = f"  {index}. " if index is not None else "  - "
+            lines.append(f"{prefix}{todo.get('text')}")
+    lines.append("- 建议回复格式：同意 / 不同意 / 已完成 / 仍待确认 + 一句话原因。")
+    return "\n".join(lines)

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -153,9 +153,15 @@ from .control_plane.todos.projection import (
     todo_summary_claim_scope_agent_id as projection_todo_summary_claim_scope_agent_id,
 )
 from .control_plane.todos.quota_summary import (
-    is_user_gate_todo_item,
     select_quota_todo_summary,
     summarize_user_todos_for_quota,
+)
+from .control_plane.todos.user_gate import (
+    build_gate_prompt as _build_gate_prompt,
+    has_open_user_gate_todo as _has_open_user_gate_todo,
+    open_todo_count as _open_todo_count,
+    should_notify_user_on_open_todo as _should_notify_user_on_open_todo,
+    user_gate_todo_notify_reason as _user_gate_todo_notify_reason,
 )
 
 
@@ -977,144 +983,6 @@ def _automation_prompt_upgrade(
         goal_id=goal_id,
         agent_identity=agent_identity,
     )
-
-
-def _build_gate_prompt(
-    item: dict[str, Any],
-    *,
-    user_todo_summary: dict[str, Any] | None = None,
-) -> str | None:
-    question = str(item.get("operator_question") or "").strip()
-    recommended_action = str(item.get("recommended_action") or "").strip()
-    next_handoff_condition = str(item.get("next_handoff_condition") or "").strip()
-    missing_gates = [
-        str(gate).strip()
-        for gate in (item.get("missing_gates") if isinstance(item.get("missing_gates"), list) else [])
-        if str(gate).strip()
-    ]
-    if user_todo_summary is None:
-        user_todo_summary = summarize_user_todos_for_quota(item.get("user_todos"))
-    first_open = (
-        user_todo_summary.get("first_open_items")
-        if isinstance(user_todo_summary, dict) and isinstance(user_todo_summary.get("first_open_items"), list)
-        else []
-    )
-    other_agent_scoped_items = (
-        user_todo_summary.get("other_agent_scoped_items")
-        if isinstance(user_todo_summary, dict)
-        and isinstance(user_todo_summary.get("other_agent_scoped_items"), list)
-        else []
-    )
-
-    if not any(
-        [
-            question,
-            recommended_action,
-            next_handoff_condition,
-            missing_gates,
-            first_open,
-            other_agent_scoped_items,
-        ]
-    ):
-        return None
-
-    lines = ["请用户/控制器确认当前 gate："]
-    if question:
-        lines.append(f"- 问题：{question}")
-    if recommended_action:
-        lines.append(f"- 当前建议：{recommended_action}")
-    if next_handoff_condition:
-        lines.append(f"- 放行条件：{next_handoff_condition}")
-    if missing_gates:
-        lines.append(f"- 缺失 gate：{', '.join(missing_gates)}")
-    if isinstance(user_todo_summary, dict) and first_open:
-        open_count = user_todo_summary.get("open_count")
-        lines.append(f"- 用户待办：{open_count} 项未完成，优先确认：")
-        for todo in first_open:
-            index = todo.get("index")
-            prefix = f"  {index}. " if index is not None else "  - "
-            lines.append(f"{prefix}{todo.get('text')}")
-    elif isinstance(user_todo_summary, dict) and other_agent_scoped_items:
-        scoped_count = user_todo_summary.get("other_agent_scoped_open_count")
-        all_open_count = user_todo_summary.get("all_open_count")
-        count = scoped_count if scoped_count is not None else len(other_agent_scoped_items)
-        suffix = f"（全局共 {all_open_count} 项）" if all_open_count is not None else ""
-        lines.append(f"- 当前 agent 无阻塞用户待办；其他 agent/global 用户待办：{count} 项{suffix}，优先确认：")
-        for todo in other_agent_scoped_items[:3]:
-            index = todo.get("index")
-            prefix = f"  {index}. " if index is not None else "  - "
-            lines.append(f"{prefix}{todo.get('text')}")
-    lines.append("- 建议回复格式：同意 / 不同意 / 已完成 / 仍待确认 + 一句话原因。")
-    return "\n".join(lines)
-
-
-def _should_notify_user_on_open_todo(
-    *,
-    state: str,
-    waiting_on: str,
-    user_todo_summary: dict[str, Any] | None,
-) -> bool:
-    if state == "operator_gate":
-        return False
-    if not isinstance(user_todo_summary, dict):
-        return False
-    try:
-        open_count = int(user_todo_summary.get("open_count") or 0)
-    except (TypeError, ValueError):
-        open_count = 0
-    if open_count <= 0:
-        return False
-    if state in {"focus_wait", "waiting"}:
-        return True
-    return waiting_on in {"user_or_controller", "controller", "external_evidence"}
-
-
-def _open_todo_count(summary: dict[str, Any] | None) -> int:
-    if not isinstance(summary, dict):
-        return 0
-    try:
-        return max(0, int(summary.get("open_count") or 0))
-    except (TypeError, ValueError):
-        return 0
-
-
-def _open_user_gate_todo_items(summary: dict[str, Any] | None) -> list[dict[str, Any]]:
-    if not isinstance(summary, dict):
-        return []
-    candidates: list[dict[str, Any]] = []
-    for key in ("gate_open_items", "first_open_items"):
-        values = summary.get(key)
-        if not isinstance(values, list):
-            continue
-        for item in values:
-            if not isinstance(item, dict) or item.get("done") is True:
-                continue
-            if not is_user_gate_todo_item(item):
-                continue
-            item_key = (item.get("todo_id"), item.get("index"), item.get("text"))
-            if any(
-                (existing.get("todo_id"), existing.get("index"), existing.get("text"))
-                == item_key
-                for existing in candidates
-            ):
-                continue
-            candidates.append(item)
-    return candidates
-
-
-def _has_open_user_gate_todo(summary: dict[str, Any] | None) -> bool:
-    return bool(_open_user_gate_todo_items(summary))
-
-
-def _user_gate_todo_notify_reason(summary: dict[str, Any] | None) -> str:
-    items = _open_user_gate_todo_items(summary)
-    if not items:
-        return "open user todo can resolve the current gate"
-    first = items[0]
-    action_kind = str(first.get("action_kind") or "").strip()
-    if action_kind:
-        return f"open user_gate todo requires owner decision before {action_kind}"
-    return "open user_gate todo requires owner decision before agent execution"
 
 
 def _todo_task_class(item: dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary
- Move user-gate todo read-model helpers into `loopx/control_plane/todos/user_gate.py`.
- Reuse the shared helper from quota, quota heartbeat recommendation, quota summary, and agent-scope fallback code.
- Add a focused control-plane smoke for user-gate detection, open todo notification policy, and operator gate prompt construction.

## Changed Surfaces
- `loopx/control_plane/todos/*`: shared user-gate read model and quota summary reuse.
- `loopx/control_plane/agents/agent_scope.py`: removes duplicated user-gate item selection/open-count logic.
- `loopx/control_plane/quota/heartbeat_recommendation.py`: reuses shared open todo counting.
- `loopx/quota.py`: removes local gate prompt/notification helpers and delegates to the bounded-context helper.
- `examples/control_plane/todo-user-gate-readmodel-smoke.py`: new focused regression coverage.

## Validation
- `python3 -m py_compile loopx/control_plane/todos/user_gate.py loopx/control_plane/todos/quota_summary.py loopx/control_plane/agents/agent_scope.py loopx/control_plane/quota/heartbeat_recommendation.py loopx/quota.py`
- `python3 examples/control_plane/todo-user-gate-readmodel-smoke.py`
- `python3 examples/control_plane/quota-todo-summary-readmodel-smoke.py`
- `python3 examples/control_plane/quota-agent-scoped-user-gate-smoke.py`
- `python3 examples/control_plane/quota-heartbeat-recommendation-state-machine-smoke.py`
- `python3 examples/control_plane/quota-resume-gated-open-todo-smoke.py`
- `python3 examples/control_plane/quota-plan-smoke.py`
- `python3 examples/control_plane/quota-contract-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 examples/control_plane/todo-user-gate-scope-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `loopx canary premerge --from-git-diff` after staging: direct 4/4, selected 17/17, failures 0
- post-rebase rerun: focused smokes, quota plan/contract/parity, integrated canary, and `loopx canary premerge --from-git-diff` direct 4/4, selected 17/17, failures 0
- `git diff --check`, `git diff --cached --check`, staged added-line private/boundary scan

## Boundary
Non-benchmark control-plane refactor only. No benchmark execution, raw logs, task text, trajectories, verifier output, credentials, private state, or local paths included.
