### PR TITLE
Define agent management projection contract

### DIFF
--- a/docs/reference/protocols/README.md
+++ b/docs/reference/protocols/README.md
@@ -16,6 +16,7 @@ Current contracts:
 - [Codex CLI wrapper action packet v0](protocol-action-packet-codex-cli-wrapper-v0.md)
 - [Action packet router comparison v0](protocol-action-packet-router-comparison-v0.md)
 - [task_graph_projection_v0](task-graph-projection-v0.md)
+- [agent_management_projection_v0](agent-management-projection-v0.md)
 - [todo_detail_cold_path_v0](todo-detail-cold-path-v0.md)
 - [long_horizon_agent_state_protocol_v0](long-horizon-agent-state-protocol-v0.md)
 - [decentralized_auto_research_state_v0](decentralized-auto-research-state-v0.md)

--- a/docs/reference/protocols/agent-management-projection-v0.md
+++ b/docs/reference/protocols/agent-management-projection-v0.md
@@ -1,0 +1,241 @@
+# agent_management_projection_v0
+
+`agent_management_projection_v0` is a read-only operator view over existing
+LoopX agent, todo, quota, history, and evidence state. It exists so dashboard
+and review-packet surfaces can show which agents are active, what each agent is
+claimed on, and what evidence makes the next turn safe.
+
+It does not introduce a runtime `task` object. In LoopX, `todo_id` remains the
+only durable work-item identity inside a `goal_id`.
+
+## Purpose
+
+The projection helps operators answer:
+
+- which registered agents exist for this goal;
+- which todo each agent should see as its current work item;
+- whether the agent is running, waiting, blocked, monitoring, or possibly
+  stale;
+- what evidence, handoff note, workspace, quota, and next action explain that
+  state.
+
+The first dashboard implementation should be an observability surface. It may
+render a mature agent-console layout or reuse compatible public UI code, but it
+must not become a dispatcher, lease manager, workspace manager, or write queue.
+
+## Sources Of Truth
+
+The projection is derived from:
+
+- `loopx status --format json`;
+- active-state `Agent Todo` and `User Todo` sections;
+- registered-agent and claim metadata;
+- quota `agent_lane_next_action`, `interaction_contract`, and scheduler hints;
+- compact run history and the agent-scoped evidence ledger;
+- task graph, handoff, and review-packet projections when present.
+
+The projection is stale after any lifecycle event until recomputed. Consumers
+must tolerate missing fields and fall back to existing status/review-packet
+payloads.
+
+## Non-Goals
+
+This contract intentionally does not add:
+
+- a new `task_id`;
+- a writable Kanban/task table;
+- automatic dispatch, cancel, or reclaim behavior;
+- a separate comment system;
+- a workspace allocation runtime;
+- a tool gateway or agent profile runtime.
+
+State changes still go through existing LoopX lifecycle commands such as
+`loopx todo ...`, `loopx refresh-state ...`, `loopx quota ...`, evidence-log
+writeback, and future APIs that preserve the same event-ledger semantics.
+
+## Shape
+
+```json
+{
+  "schema_version": "agent_management_projection_v0",
+  "mode": "read_only",
+  "goal_id": "loopx-meta",
+  "generated_at": "2026-07-06T00:00:00Z",
+  "style_hint": {
+    "preferred": "mature_agent_console_or_loopx_dark_showcase",
+    "license_boundary": "reuse_public_compatible_code_only"
+  },
+  "truth_contract": {
+    "todo_is_runtime_work_item": true,
+    "projection_is_writable": false,
+    "introduces_task_runtime": false,
+    "write_api": false
+  },
+  "agents": []
+}
+```
+
+## Agent Row
+
+Each agent row is a compact card or table row for one registered agent.
+
+Required fields:
+
+- `agent_id`;
+- `role`: for example `primary`, `side-agent`, `reviewer`, or `operator`;
+- `state`: one of `running`, `waiting`, `blocked`, `monitoring`,
+  `scope_wait`, `stale`, or `unknown`;
+- `current_todo`: a `todo_row_v0` object or `null`;
+- `next_action`: compact public-safe next action text;
+- `last_activity_at`: best known status, quota, todo, or run timestamp;
+- `evidence_refs`: compact evidence ids, doc paths, run ids, or review packet
+  refs.
+
+Optional fields:
+
+- `scope_summary`;
+- `quota_state`;
+- `scheduler_state`;
+- `workspace_ref`;
+- `handoff_refs`;
+- `stale_claim_hint`;
+- `blocked_on`;
+- `recent_events`;
+- `display_tone`.
+
+## Todo Row
+
+`todo_row_v0` is the dashboard/review-packet representation of an existing
+LoopX todo. It is not a runtime task object.
+
+Required fields:
+
+- `todo_id`;
+- `goal_id`;
+- `role`;
+- `status`;
+- `priority`;
+- `title`;
+- `task_class`;
+- `action_kind`;
+- `claimed_by`.
+
+Optional fields:
+
+- `required_write_scopes`;
+- `required_capabilities`;
+- `target_capabilities`;
+- `blocks_agent`;
+- `unblocks_todo_id`;
+- `successor_todo_ids`;
+- `resume_when`;
+- `evidence_refs`;
+- `handoff_refs`;
+- `workspace_ref`;
+- `updated_at`.
+
+The row may be rendered as a "task" card for operator familiarity, but API and
+state names should keep `todo` terminology to avoid implying a second runtime
+model.
+
+## Handoff Notes
+
+Inter-agent handoff should appear as a typed note attached to existing todo,
+history, and evidence refs:
+
+```json
+{
+  "schema_version": "handoff_note_v0",
+  "handoff_id": "handoff_123",
+  "todo_id": "todo_abc",
+  "from_agent": "codex-builder",
+  "to_agent": "codex-reviewer",
+  "intent": "review_before_merge",
+  "summary": "Implementation and focused smoke are ready for review.",
+  "evidence_refs": ["run_123", "docs/reference/protocols/example.md"],
+  "unresolved_decisions": [],
+  "blocked_on": null,
+  "suggested_next_action": "Read the diff and smoke output before merge."
+}
+```
+
+The projection may show the latest handoff note in the agent row, but the note
+does not create a chat stream, dispatcher queue, or approval mechanism.
+
+## Stale Claim Hint
+
+`stale_claim_hint` is an observability warning, not an automatic reclaim rule.
+It means a claimed todo has not received recent activity relative to the
+expected cadence, or the projection cannot find fresh evidence for a running
+claim.
+
+```json
+{
+  "state": "suspected_stale",
+  "claimed_by": "codex-value-explorer",
+  "last_activity_at": "2026-07-06T00:00:00Z",
+  "reason": "last activity is older than expected cadence",
+  "recommended_operator_action": "inspect evidence or ask the same agent to resume"
+}
+```
+
+The dashboard may display this as a warning badge. LoopX should not automatically
+clear the claim, reassign work, or discard evidence from this projection alone.
+
+## Workspace Ref
+
+`workspace_ref` is a display hint for where work is expected to happen:
+
+```json
+{
+  "kind": "primary_checkout|worktree|external|unknown",
+  "label": "codex/value-explorer",
+  "path_safe": false,
+  "branch": "codex/value-explorer-post702",
+  "write_scope": ["docs/**", "apps/dashboard/**"]
+}
+```
+
+Public or hosted dashboards should avoid local absolute paths. Local loopback
+dashboards may show paths when the source payload already exposes them and the
+surface is explicitly local/operator-only.
+
+## Frontend Style And Code Reuse
+
+The product surface may borrow from two visual directions:
+
+- a mature agent console style: dense rows, clear owner/state/timestamp
+  columns, subdued badges, and fast scanning;
+- the LoopX dark showcase style: dark rail, motion-light accents, evidence
+  trail, and high-contrast agent lanes.
+
+Before copying implementation code from Hermes or another project, the agent
+must verify:
+
+- the source is public or explicitly approved for this repository;
+- the license is compatible with LoopX distribution;
+- copied code keeps required attribution or notice text;
+- private/internal identifiers, comments, screenshots, URLs, and test data are
+  removed or generalized;
+- the copied code does not import a runtime dispatcher, profile system, tool
+  gateway, or task database that violates this projection contract.
+
+If those checks are not satisfied, borrow only the interaction pattern and
+write a native LoopX implementation.
+
+## Acceptance Checks
+
+A valid implementation or fixture should prove:
+
+- `schema_version` is exactly `agent_management_projection_v0`;
+- `mode` is `read_only`;
+- `truth_contract.projection_is_writable=false`;
+- `truth_contract.introduces_task_runtime=false`;
+- every `current_todo.todo_id` references an existing LoopX todo;
+- no writable task, dispatcher, cancel, reclaim, or workspace action is exposed
+  by this projection;
+- stale claim is rendered as a warning only;
+- handoff notes reference existing todo/history/evidence ids;
+- public fixtures do not include credentials, raw logs, private docs, raw
+  trajectories, local absolute paths, or internal-only source material;
+- dashboard consumers remain functional when the projection is absent.

--- a/examples/control_plane/agent-management-projection-contract-smoke.py
+++ b/examples/control_plane/agent-management-projection-contract-smoke.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Smoke-test the agent_management_projection_v0 contract."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CONTRACT_PATH = REPO_ROOT / "docs/reference/protocols/agent-management-projection-v0.md"
+PROTOCOL_INDEX_PATH = REPO_ROOT / "docs/reference/protocols/README.md"
+
+PRIVATE_PATTERNS = [
+    re.compile(r"/Users/[A-Za-z0-9._-]+/"),
+    re.compile(r"/home/[A-Za-z0-9._-]+/"),
+    re.compile(r"/private/"),
+    re.compile(r"[A-Za-z]:\\\\Users\\\\"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._-]+"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+]
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def assert_contains(text: str, needle: str, label: str) -> None:
+    if needle not in text:
+        raise AssertionError(f"{label} missing {needle!r}")
+
+
+def assert_public_safe(text: str, label: str) -> None:
+    for pattern in PRIVATE_PATTERNS:
+        if pattern.search(text):
+            raise AssertionError(f"{label} matched private pattern {pattern.pattern!r}")
+
+
+def main() -> int:
+    contract = read(CONTRACT_PATH)
+    protocol_index = read(PROTOCOL_INDEX_PATH)
+
+    assert_public_safe(contract, "contract")
+    assert_public_safe(protocol_index, "protocol index")
+
+    for needle in [
+        "agent_management_projection_v0",
+        "`todo_id` remains the",
+        "read-only operator view",
+        "does not introduce a runtime `task` object",
+        '"mode": "read_only"',
+        '"projection_is_writable": false',
+        '"introduces_task_runtime": false',
+        "not an automatic reclaim rule",
+        "reuse_public_compatible_code_only",
+        "copied code keeps required attribution or notice text",
+        "dashboard consumers remain functional when the projection is absent",
+    ]:
+        assert_contains(contract, needle, "contract")
+
+    for forbidden in [
+        "new `task_id`",
+        "automatic dispatch",
+        "workspace allocation runtime",
+        "clear the claim, reassign work, or discard evidence",
+    ]:
+        assert_contains(contract, forbidden, "contract non-goals")
+
+    assert_contains(protocol_index, "agent_management_projection_v0", "protocol index")
+    print("agent-management-projection-contract-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- define agent_management_projection_v0 as a read-only operator projection over existing LoopX agent/todo/quota/history/evidence state
- keep todo_id as the only runtime work-item identity and explicitly avoid a second task runtime
- add a focused smoke covering contract invariants, protocol index registration, public-safety patterns, stale-claim warning semantics, handoff note attachment, and code-reuse license guardrails

## Validation
- python3 examples/control_plane/agent-management-projection-contract-smoke.py
- loopx check --scan-path docs/reference/protocols/agent-management-projection-v0.md --scan-path docs/reference/protocols/README.md --scan-path examples/control_plane/agent-management-projection-contract-smoke.py
- git diff --cached --check
- loopx canary premerge --from-git-diff

## Risk
Docs/protocol + thin smoke only. No runtime task model, dispatcher, workspace manager, reclaim behavior, or frontend write path is introduced.