### PR TITLE
Increase CLI goal post-bridge recovery budget

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -517,6 +517,7 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
     sys.path.insert(0, str(REPO_ROOT))
     from loopx.benchmark_adapters.skillsbench_acp_relay import (
         CodexExecConfig,
+        POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT,
         SkillsBenchLocalAcpRelay,
         _codex_cli_tui_post_bridge_blocker_stage,
         _codex_cli_tui_post_bridge_recovery_action,
@@ -527,6 +528,7 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
         _public_runner_prerequisites,
     )
 
+    assert POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT == 4
     assert (
         _codex_cli_tui_post_bridge_blocker_stage(
             "request timed out while waiting for model\n› ",
@@ -693,7 +695,7 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
             goal_terminal_observed=False,
             first_action_observed=True,
             bridge_summary_path=bridge_summary,
-            post_bridge_recovery_attempt_count=2,
+            post_bridge_recovery_attempt_count=4,
             post_bridge_recovery_action="typed_continue",
             post_bridge_recovery_skip_reason="retry_limit_reached",
         )
@@ -707,7 +709,7 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
 
     prerequisites = plan["runner_prerequisites"]
     assert trace["codex_cli_goal_tui_stage"] == "post_bridge_tui_model_timeout"
-    assert trace["codex_cli_goal_tui_post_bridge_recovery_attempt_count"] == 2
+    assert trace["codex_cli_goal_tui_post_bridge_recovery_attempt_count"] == 4
     assert trace["codex_cli_goal_tui_post_bridge_recovery_action"] == "typed_continue"
     assert (
         trace["codex_cli_goal_tui_post_bridge_recovery_skip_reason"]
@@ -862,7 +864,8 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert "timeout_sec=max(" in source
     assert "self._config.first_action_timeout_sec" in source
     assert "post_bridge_recovery_attempt_count" in source
-    assert "post_bridge_recovery_attempt_count < 2" in source
+    assert "POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT" in source
+    assert "post_bridge_recovery_attempt_count < 2" not in source
     assert "last_bridge_activity_at >= 30.0" in source
     tui_source = (REPO_ROOT / "loopx/codex_cli_goal_tui.py").read_text(
         encoding="utf-8"

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -102,6 +102,7 @@ CODEX_CLI_GOAL_POST_BRIDGE_CONTINUE_PROMPT = (
     "private bridge command from the task instructions for one task-facing "
     "action, then finish with compact status."
 )
+POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT = 4
 
 
 @contextlib.contextmanager
@@ -1551,10 +1552,7 @@ class SkillsBenchLocalAcpRelay:
                             capture,
                             stage=post_bridge_blocker_stage,
                         )
-                        if (
-                            recovery_action == "press_enter"
-                            and post_bridge_recovery_attempt_count < 2
-                        ):
+                        if recovery_action == "press_enter" and post_bridge_recovery_attempt_count < POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT:
                             post_bridge_recovery_attempt_count += 1
                             post_bridge_recovery_action = recovery_action
                             tmux_submit_enter(tmux_name)
@@ -1565,10 +1563,7 @@ class SkillsBenchLocalAcpRelay:
                             )
                             time.sleep(1.0)
                             continue
-                        if (
-                            recovery_action == "typed_continue"
-                            and post_bridge_recovery_attempt_count < 2
-                        ):
+                        if recovery_action == "typed_continue" and post_bridge_recovery_attempt_count < POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT:
                             post_bridge_recovery_attempt_count += 1
                             post_bridge_recovery_action = recovery_action
                             tmux_type_text_and_submit(


### PR DESCRIPTION
## Summary
- increase the bounded Codex CLI `/goal` post-bridge recovery budget from 2 to 4 attempts
- keep recovery blocked for rate-limit stages; this only covers transient model timeout/error prompts after sandbox bridge activity is already observed
- update the focused SkillsBench CLI goal route smoke so the retry limit and public-safe trace aggregation stay covered

## Public-safe civ6 evidence
A source-locked civ6 canary on current main showed the route now reaches the real host-local CLI goal path:
- `loopx_runner_source_matches_expected=true`
- reverse-tunnel Codex API and benchmark egress preflights were `http_connect_ready`
- direct/local fallback was inactive
- sandbox bridge auto-wiring materialized in the scored BenchFlow sandbox
- 13 task-facing bridge exec operations succeeded
- the run remained uncountable because Codex CLI TUI hit `post_bridge_tui_model_timeout` after 2 recovery attempts (`retry_limit_reached`)

This PR addresses that observed recovery budget bottleneck. It does not change verifier scoring, task semantics, task prompts, raw evidence handling, uploads, or leaderboard behavior.

## Validation
- `python3 -m py_compile loopx/benchmark_adapters/skillsbench_acp_relay.py examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 examples/skillsbench-host-local-launch-plan-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `loopx canary premerge --from-git-diff`
  - direct checks: passed
  - catalog canaries: passed 6/6
  - public boundary: passed
  - manual hold: `benchmark_sensitive`, so self-merge is intentionally not performed from this agent turn
