### PR TITLE
Define agent management observability MVP

### DIFF
--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -114,6 +114,10 @@ runtime contract, benchmark route, or launch draft.
   maintainer-first product design for signal inbox, selected anchors, agent
   lanes, review feed, and performance review so long-running Loop Agents can be
   evaluated by value, quality, cost, and user attention.
+- [Agent management observability MVP](agent-management-observability-mvp.md):
+  read-only ops dashboard slice for registered agents, claimed todos, state
+  badges, evidence/handoff links, quota/cadence hints, and workspace hints
+  without introducing a dispatcher or second task runtime.
 - [Complex request planning intake](complex-request-planning-intake.md):
   bounded intake pattern for turning a large mixed strategy request into a
   small typed todo batch with claim decisions, safe summaries, and a visible

--- a/docs/product/agent-management-observability-mvp.md
+++ b/docs/product/agent-management-observability-mvp.md
@@ -1,0 +1,223 @@
+# Agent Management Observability MVP
+
+This note turns `agent_management_projection_v0` into a concrete first product
+slice for the LoopX dashboard. It is intentionally an observability MVP, not a
+new scheduler, dispatcher, task database, or browser write path.
+
+## Decision
+
+Use the mature agent-console direction for the real ops surface, and keep the
+LoopX dark showcase direction for public narrative pages.
+
+The MVP should feel like a dense operator console: rows, narrow badges,
+timestamps, evidence links, and stable filters. The dark showcase style can
+explain the same model on the public frontstage, but it should not be the
+default for live multi-agent operation because live operation needs scanning
+more than motion.
+
+## Source Inspiration And Reuse Boundary
+
+The closest public reference is NousResearch Hermes Agent:
+
+- Hermes Kanban documentation:
+  <https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/kanban.md>
+- Hermes delegation documentation:
+  <https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/delegation.md>
+- Hermes license:
+  <https://github.com/NousResearch/hermes-agent/blob/main/LICENSE>
+
+Hermes Agent is published under MIT license, so UI code can be considered for
+reuse in a later implementation PR if it is actually public, attribution is
+kept where required, and the copied code is isolated to presentation. This MVP
+does not copy Hermes source code.
+
+The useful ideas to borrow are:
+
+- dense task/agent rows;
+- visible assignee, status, workspace, timestamp, and liveness;
+- event-tail and attempt-history affordances;
+- comments or handoff notes as inspectable context;
+- fresh-context delegation as a warning against hidden inherited assumptions.
+
+The ideas not to borrow into LoopX runtime are:
+
+- a second durable task database;
+- automatic dispatch, cancel, reclaim, or retry;
+- worker profile runtime;
+- workspace allocation runtime;
+- browser writes that bypass LoopX CLI/API boundaries.
+
+LoopX already has the durable work unit: `todo_id` inside `goal_id`. The
+dashboard may render a todo as a task-like card for familiarity, but product
+and runtime names should keep `todo` or `work item` to avoid implying a second
+state machine.
+
+## MVP Surface
+
+Add an explicit Agent Management section to the ops/dashboard surface after the
+projection exists. It can live inside the existing `/frontstage?mode=ops`
+workspace or the main dashboard home; the first implementation should choose
+the route with the least duplication of status loading and URL filters.
+
+The first screen should answer five questions:
+
+1. Which registered agents are active for this goal?
+2. What is each agent currently claimed on?
+3. Is the agent running, waiting, blocked, monitoring, stale, or unknown?
+4. What evidence or handoff makes the next step reviewable?
+5. What quota, cadence, or workspace hint should the operator notice?
+
+## Agent Row
+
+Each row should map one `agent_management_projection_v0.agents[]` item into a
+compact row or card.
+
+Required visible fields:
+
+- agent id and role;
+- state badge;
+- current todo title and priority;
+- claim owner or "unclaimed";
+- next action, one or two lines;
+- last activity time;
+- evidence/handoff link count;
+- quota or scheduler hint when it changes operator behavior.
+
+Optional expandable fields:
+
+- required write scopes;
+- workspace hint;
+- stale claim hint;
+- recent event tail;
+- blocked-on decision;
+- related user todo count.
+
+## Status Badges
+
+Use a small, stable badge set:
+
+| State | Meaning | Operator posture |
+| --- | --- | --- |
+| `running` | LoopX expects the agent to keep working. | Watch evidence and quota. |
+| `waiting` | The lane is eligible later or waiting for another state transition. | No immediate action. |
+| `blocked` | Work cannot proceed without a blocker resolution. | Inspect blocker and decide if it is user-facing. |
+| `monitoring` | This is a continuous monitor lane. | Show only material transitions. |
+| `scope_wait` | The current item is outside the agent lane or write scope. | Check assignment or handoff. |
+| `stale` | The claim lacks fresh activity evidence. | Inspect evidence; do not auto-reclaim. |
+| `unknown` | Projection is missing enough data. | Show source warning. |
+
+These badges are read-only. They do not perform lifecycle transitions.
+
+## Evidence And Handoff Links
+
+Evidence links should be visible but thin:
+
+- latest run or refresh-state record;
+- linked docs or protocol files;
+- validation command labels;
+- handoff note ids;
+- review packet refs;
+- public-safe source warnings.
+
+Do not inline raw logs, raw trajectories, private documents, local absolute
+paths, credentials, or status JSON blobs. The row should show that evidence
+exists and let the operator drill into safe refs.
+
+Handoff notes should render as typed attachments to todos/history/evidence:
+
+- from agent;
+- to agent;
+- intent;
+- unresolved decision count;
+- suggested next action;
+- evidence refs.
+
+They are not a chat stream and they are not approval.
+
+## Quota, Cadence, And Workspace Hints
+
+The agent row should show quota/cadence only when it changes the operator's
+decision:
+
+- eligible now;
+- throttled or waiting;
+- no-spend monitor poll;
+- scheduler backoff applied;
+- stale due to missing activity evidence.
+
+Workspace hints are display-only:
+
+- `primary_checkout`;
+- `worktree`;
+- `external`;
+- `unknown`.
+
+Hosted or public surfaces should avoid local absolute paths. Local loopback ops
+surfaces may show a path only when the status payload already exposes it and
+the surface is explicitly local/operator-only.
+
+## Read-Only Operator Actions
+
+The MVP may expose read-only actions:
+
+- copy review packet command;
+- copy status/quota command;
+- open safe evidence ref;
+- filter by agent, state, or priority;
+- collapse monitor rows;
+- highlight stale or blocked rows;
+- switch between table and lane view.
+
+The MVP must not expose:
+
+- claim/reclaim;
+- cancel;
+- dispatch;
+- unblock;
+- priority mutation;
+- workspace creation;
+- reward append;
+- external production action.
+
+Future write actions must be introduced behind a separate capability gate and
+must call typed LoopX CLI/API transitions.
+
+## Implementation Shape
+
+Prefer a thin projection adapter over a new runtime model:
+
+```text
+loopx status/review-packet/evidence ledger
+  -> agent_management_projection_v0
+  -> dashboard read model
+  -> rows/cards/timeline
+```
+
+The dashboard should tolerate the projection being absent. If absent, show the
+current ops dashboard and a source warning; do not block the rest of the page.
+
+The first frontend PR should be allowed to build only a fixture-backed read
+model plus browser-visible anchors. Live status consumption can follow after
+the fixture validates the interaction model.
+
+## Acceptance Checks
+
+The first implementation should prove:
+
+- the surface consumes `agent_management_projection_v0` when present;
+- the dashboard still works when the projection is absent;
+- no browser write affordance is rendered;
+- `todo_id` remains the displayed work-item identity;
+- stale claim is a warning only;
+- evidence and handoff links render as refs, not raw logs;
+- public fixtures contain no credentials, private docs, raw trajectories, or
+  local absolute paths;
+- copied or adapted external UI code carries a license/attribution note, or the
+  implementation is native LoopX code.
+
+## Next Slice
+
+Implement a fixture-backed read-only Agent Management panel in
+`apps/dashboard` with the mature console style. Keep it behind an ops route or
+developer route until browser smokes prove desktop/mobile scanability and the
+public/private boundary.

--- a/examples/control_plane/agent-management-observability-mvp-smoke.py
+++ b/examples/control_plane/agent-management-observability-mvp-smoke.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Smoke-test the Agent Management Observability MVP note."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOC_PATH = REPO_ROOT / "docs/product/agent-management-observability-mvp.md"
+PRODUCT_INDEX_PATH = REPO_ROOT / "docs/product/README.md"
+
+PRIVATE_PATTERNS = [
+    re.compile(r"/Users/[A-Za-z0-9._-]+/"),
+    re.compile(r"/home/[A-Za-z0-9._-]+/"),
+    re.compile(r"/private/"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._-]+"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+]
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def assert_contains(text: str, needle: str, label: str) -> None:
+    if needle not in text:
+        raise AssertionError(f"{label} missing {needle!r}")
+
+
+def assert_public_safe(text: str, label: str) -> None:
+    for pattern in PRIVATE_PATTERNS:
+        if pattern.search(text):
+            raise AssertionError(f"{label} matched private pattern {pattern.pattern!r}")
+
+
+def main() -> int:
+    doc = read(DOC_PATH)
+    product_index = read(PRODUCT_INDEX_PATH)
+
+    assert_public_safe(doc, "mvp doc")
+    assert_public_safe(product_index, "product index")
+
+    for needle in [
+        "Use the mature agent-console direction",
+        "does not copy Hermes source code",
+        "LoopX already has the durable work unit: `todo_id` inside `goal_id`.",
+        "The MVP must not expose:",
+        "claim/reclaim",
+        "dispatch",
+        "stale claim is a warning only",
+        "agent_management_projection_v0",
+        "fixture-backed read-only Agent Management panel",
+        "license/attribution note",
+    ]:
+        assert_contains(doc, needle, "mvp doc")
+
+    for url in [
+        "https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/kanban.md",
+        "https://github.com/NousResearch/hermes-agent/blob/main/website/docs/user-guide/features/delegation.md",
+        "https://github.com/NousResearch/hermes-agent/blob/main/LICENSE",
+    ]:
+        assert_contains(doc, url, "source links")
+
+    assert_contains(
+        product_index,
+        "Agent management observability MVP",
+        "product index",
+    )
+
+    print("agent-management-observability-mvp-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Summary:
- Define the read-only Agent Management observability MVP and visual direction.
- Record the Hermes public source/license reuse boundary without copying source code.
- Add a focused smoke covering public-safety and MVP contract text.

Validation:
- python3 examples/control_plane/agent-management-observability-mvp-smoke.py
- python3 -m py_compile examples/control_plane/agent-management-observability-mvp-smoke.py
- loopx check --scan-path docs/product/agent-management-observability-mvp.md --scan-path docs/product/README.md --scan-path examples/control_plane/agent-management-observability-mvp-smoke.py
- git diff --cached --check
- loopx canary premerge --from-git-diff

Risk:
- Docs/product planning plus a thin smoke only.
- No runtime task model, dispatcher, reclaim flow, browser writes, or copied Hermes implementation code.