### PR TITLE
Add CLI goal post-bridge closeout recovery

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -517,11 +517,15 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
     sys.path.insert(0, str(REPO_ROOT))
     from loopx.benchmark_adapters.skillsbench_acp_relay import (
         CodexExecConfig,
-        POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT,
         SkillsBenchLocalAcpRelay,
-        _codex_cli_tui_post_bridge_blocker_stage,
-        _codex_cli_tui_post_bridge_recovery_action,
-        _codex_cli_tui_post_bridge_recovery_skip_reason,
+    )
+    from loopx.benchmark_adapters.skillsbench_codex_goal_recovery import (
+        CODEX_CLI_GOAL_POST_BRIDGE_CLOSEOUT_PROMPT,
+        POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT,
+        codex_cli_tui_post_bridge_blocker_stage,
+        codex_cli_tui_post_bridge_closeout_recovery_action,
+        codex_cli_tui_post_bridge_recovery_action,
+        codex_cli_tui_post_bridge_recovery_skip_reason,
     )
     from scripts.skillsbench_automation_loop import (
         _merge_host_local_acp_relay_trace_summary,
@@ -529,29 +533,32 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
     )
 
     assert POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT == 4
+    assert "Close out the active SkillsBench goal" in (
+        CODEX_CLI_GOAL_POST_BRIDGE_CLOSEOUT_PROMPT
+    )
     assert (
-        _codex_cli_tui_post_bridge_blocker_stage(
+        codex_cli_tui_post_bridge_blocker_stage(
             "request timed out while waiting for model\n› ",
             prompt_visible=True,
         )
         == "post_bridge_tui_model_timeout"
     )
     assert (
-        _codex_cli_tui_post_bridge_recovery_action(
+        codex_cli_tui_post_bridge_recovery_action(
             "request timed out while waiting for model\npress enter to retry\n› ",
             stage="post_bridge_tui_model_timeout",
         )
         == "press_enter"
     )
     assert (
-        _codex_cli_tui_post_bridge_recovery_action(
+        codex_cli_tui_post_bridge_recovery_action(
             "request timed out while waiting for model\n› ",
             stage="post_bridge_tui_model_timeout",
         )
         == "typed_continue"
     )
     assert (
-        _codex_cli_tui_post_bridge_recovery_skip_reason(
+        codex_cli_tui_post_bridge_recovery_skip_reason(
             "request timed out while waiting for model\n› ",
             stage="post_bridge_tui_model_timeout",
             recovery_action="typed_continue",
@@ -559,14 +566,14 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
         == ""
     )
     assert (
-        _codex_cli_tui_post_bridge_recovery_action(
+        codex_cli_tui_post_bridge_recovery_action(
             "rate limit reached\npress enter to retry\n› ",
             stage="post_bridge_tui_rate_limit",
         )
         == ""
     )
     assert (
-        _codex_cli_tui_post_bridge_recovery_skip_reason(
+        codex_cli_tui_post_bridge_recovery_skip_reason(
             "rate limit reached\npress enter to retry\n› ",
             stage="post_bridge_tui_rate_limit",
             recovery_action="",
@@ -574,7 +581,7 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
         == "rate_limit_no_retry"
     )
     assert (
-        _codex_cli_tui_post_bridge_recovery_skip_reason(
+        codex_cli_tui_post_bridge_recovery_skip_reason(
             "request timed out while waiting for model\npress enter to retry\n› ",
             stage="post_bridge_tui_model_timeout",
             recovery_action="press_enter",
@@ -582,14 +589,30 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
         == ""
     )
     assert (
-        _codex_cli_tui_post_bridge_blocker_stage(
+        codex_cli_tui_post_bridge_closeout_recovery_action(
+            recovery_action="typed_continue",
+            recovery_attempt_count=POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT,
+            closeout_attempted=False,
+        )
+        == "typed_closeout"
+    )
+    assert (
+        codex_cli_tui_post_bridge_closeout_recovery_action(
+            recovery_action="typed_continue",
+            recovery_attempt_count=POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT,
+            closeout_attempted=True,
+        )
+        == ""
+    )
+    assert (
+        codex_cli_tui_post_bridge_blocker_stage(
             "rate limit reached\n› ",
             prompt_visible=True,
         )
         == "post_bridge_tui_rate_limit"
     )
     assert (
-        _codex_cli_tui_post_bridge_blocker_stage(
+        codex_cli_tui_post_bridge_blocker_stage(
             "rate limit reached\n",
             prompt_visible=False,
         )
@@ -800,6 +823,52 @@ def _assert_cli_goal_active_timeout_is_public_countability_stage() -> None:
     assert contract["goal_stage"] == "goal_active_timeout", contract
     assert contract["raw_material_recorded"] is False, contract
 
+    with tempfile.TemporaryDirectory() as temp:
+        trace_dir = Path(temp) / "trace"
+        bridge_summary = Path(temp) / "bridge-summary.jsonl"
+        bridge_summary.write_text(
+            json.dumps({"record_phase": "start", "task_facing_operation": True})
+            + "\n"
+            + json.dumps(
+                {
+                    "record_phase": "complete",
+                    "task_facing_operation": True,
+                    "success": True,
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        relay = SkillsBenchLocalAcpRelay(
+            CodexExecConfig(worker_public_trace_dir=str(trace_dir))
+        )
+        relay._publish_codex_cli_goal_trace(
+            ok=False,
+            stage="goal_failed",
+            goal_active_observed=True,
+            goal_terminal_observed=True,
+            first_action_observed=True,
+            bridge_summary_path=bridge_summary,
+            post_bridge_recovery_action="typed_closeout",
+        )
+        plan = {
+            "route": CODEX_CLI_GOAL_BASELINE_ROUTE,
+            "host_local_acp_relay_trace_dir": str(trace_dir),
+            "runner_prerequisites": {},
+        }
+        trace = {}
+        _merge_host_local_acp_relay_trace_summary(plan, trace)
+
+    compact = {
+        "route": CODEX_CLI_GOAL_BASELINE_ROUTE,
+        "official_score_status": "completed",
+        "interaction_counters": trace,
+        "runner_prerequisites": plan["runner_prerequisites"],
+        "failure_attribution_labels": ["official_score_zero_case_failure"],
+    }
+    assert _apply_codex_cli_goal_countability_guard_attribution(compact) is False
+    assert "codex_cli_goal_countability_contract" not in compact
+
 
 def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> None:
     sys.path.insert(0, str(REPO_ROOT))
@@ -865,6 +934,8 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert "self._config.first_action_timeout_sec" in source
     assert "post_bridge_recovery_attempt_count" in source
     assert "POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT" in source
+    assert "CODEX_CLI_GOAL_POST_BRIDGE_CLOSEOUT_PROMPT" in source
+    assert "typed_closeout" in source
     assert "post_bridge_recovery_attempt_count < 2" not in source
     assert "last_bridge_activity_at >= 30.0" in source
     tui_source = (REPO_ROOT / "loopx/codex_cli_goal_tui.py").read_text(

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -31,6 +31,15 @@ from loopx.benchmark_case_state import (
 from loopx.benchmark_adapters.skillsbench_remote_bridge import (
     run_skillsbench_remote_command_file_bridge_probe,
 )
+from loopx.benchmark_adapters.skillsbench_codex_goal_recovery import (
+    CODEX_CLI_GOAL_POST_BRIDGE_CLOSEOUT_PROMPT,
+    CODEX_CLI_GOAL_POST_BRIDGE_CONTINUE_PROMPT,
+    POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT,
+    codex_cli_tui_post_bridge_blocker_stage,
+    codex_cli_tui_post_bridge_closeout_recovery_action,
+    codex_cli_tui_post_bridge_recovery_action,
+    codex_cli_tui_post_bridge_recovery_skip_reason,
+)
 from loopx.codex_cli_goal_tui import (
     CODEX_CLI_GOAL_TASK_PROMPT_FILENAME,
     build_codex_cli_goal_file_objective,
@@ -96,13 +105,6 @@ SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_PROMPT = (
     "After the bridge response returns, reply exactly "
     f"{SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER} and end the turn."
 )
-CODEX_CLI_GOAL_POST_BRIDGE_CONTINUE_PROMPT = (
-    "Continue the active SkillsBench goal after the transient model timeout. "
-    "If ./skillsbench-task-prompt.md exists, read it before acting. Use the "
-    "private bridge command from the task instructions for one task-facing "
-    "action, then finish with compact status."
-)
-POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT = 4
 
 
 @contextlib.contextmanager
@@ -522,81 +524,6 @@ def _codex_cli_tui_retryable_startup_blocker_stage(capture: str) -> str:
     ):
         return "rate_limit_before_goal_active"
     return ""
-
-
-def _codex_cli_tui_post_bridge_blocker_stage(
-    capture: str,
-    *,
-    prompt_visible: bool,
-) -> str:
-    """Classify public-safe Codex CLI TUI blockers after bridge activity."""
-
-    if not prompt_visible:
-        return ""
-    lowered = str(capture or "").lower()
-    if any(
-        marker in lowered
-        for marker in (
-            "rate limit",
-            "rate_limit",
-            "too many requests",
-            "status 429",
-            "error 429",
-        )
-    ):
-        return "post_bridge_tui_rate_limit"
-    if any(marker in lowered for marker in ("timed out", "timeout")) and any(
-        marker in lowered for marker in ("model", "request", "error", "failed")
-    ):
-        return "post_bridge_tui_model_timeout"
-    if any(marker in lowered for marker in ("press enter", "press return")) and any(
-        marker in lowered
-        for marker in ("error", "failed", "timed out", "timeout", "model")
-    ):
-        return "post_bridge_tui_error_prompt"
-    return ""
-
-
-def _codex_cli_tui_post_bridge_recovery_action(capture: str, *, stage: str) -> str:
-    """Return a bounded public-safe recovery action for post-bridge TUI blockers."""
-
-    if stage not in {
-        "post_bridge_tui_model_timeout",
-        "post_bridge_tui_error_prompt",
-    }:
-        return ""
-    lowered = str(capture or "").lower()
-    if any(marker in lowered for marker in ("press enter", "press return")):
-        return "press_enter"
-    if (
-        stage == "post_bridge_tui_model_timeout"
-        and codex_cli_tui_input_prompt_visible(capture)
-    ):
-        return "typed_continue"
-    return ""
-
-
-def _codex_cli_tui_post_bridge_recovery_skip_reason(
-    capture: str,
-    *,
-    stage: str,
-    recovery_action: str,
-) -> str:
-    """Return why no post-bridge recovery action was taken."""
-
-    if recovery_action:
-        return ""
-    if stage == "post_bridge_tui_rate_limit":
-        return "rate_limit_no_retry"
-    if stage not in {
-        "post_bridge_tui_model_timeout",
-        "post_bridge_tui_error_prompt",
-    }:
-        return ""
-    lowered = str(capture or "").lower()
-    if not any(marker in lowered for marker in ("press enter", "press return")):
-        return "no_retry_affordance"
-    return "unsupported_recovery_action"
 
 
 def _write_process_stdin_async(
@@ -1279,6 +1206,7 @@ class SkillsBenchLocalAcpRelay:
             post_bridge_recovery_attempt_count = 0
             post_bridge_recovery_action = ""
             post_bridge_recovery_skip_reason = ""
+            post_bridge_closeout_attempted = False
             try:
                 subprocess.run(
                     [
@@ -1540,7 +1468,7 @@ class SkillsBenchLocalAcpRelay:
                         ) and (not post_bridge_recovery_attempt_count or now - last_bridge_activity_at >= 30.0)
                     ):
                         post_bridge_blocker_stage = (
-                            _codex_cli_tui_post_bridge_blocker_stage(
+                            codex_cli_tui_post_bridge_blocker_stage(
                                 capture,
                                 prompt_visible=(
                                     codex_cli_tui_input_prompt_visible(capture)
@@ -1548,7 +1476,7 @@ class SkillsBenchLocalAcpRelay:
                             )
                         )
                     if post_bridge_blocker_stage:
-                        recovery_action = _codex_cli_tui_post_bridge_recovery_action(
+                        recovery_action = codex_cli_tui_post_bridge_recovery_action(
                             capture,
                             stage=post_bridge_blocker_stage,
                         )
@@ -1576,8 +1504,30 @@ class SkillsBenchLocalAcpRelay:
                                 + max(1.0, self._config.stream_heartbeat_interval_sec)
                             )
                             continue
+                        closeout_action = (
+                            codex_cli_tui_post_bridge_closeout_recovery_action(
+                                recovery_action=recovery_action,
+                                recovery_attempt_count=(
+                                    post_bridge_recovery_attempt_count
+                                ),
+                                closeout_attempted=post_bridge_closeout_attempted,
+                            )
+                        )
+                        if closeout_action == "typed_closeout":
+                            post_bridge_closeout_attempted = True
+                            post_bridge_recovery_action = closeout_action
+                            tmux_type_text_and_submit(
+                                tmux_name=tmux_name,
+                                text=CODEX_CLI_GOAL_POST_BRIDGE_CLOSEOUT_PROMPT,
+                            )
+                            last_bridge_activity_at = now
+                            next_heartbeat = (
+                                now
+                                + max(1.0, self._config.stream_heartbeat_interval_sec)
+                            )
+                            continue
                         post_bridge_recovery_skip_reason = (
-                            _codex_cli_tui_post_bridge_recovery_skip_reason(
+                            codex_cli_tui_post_bridge_recovery_skip_reason(
                                 capture,
                                 stage=post_bridge_blocker_stage,
                                 recovery_action=recovery_action,

--- a/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
+++ b/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+from loopx.codex_cli_goal_tui import codex_cli_tui_input_prompt_visible
+
+
+CODEX_CLI_GOAL_POST_BRIDGE_CONTINUE_PROMPT = (
+    "Continue the active SkillsBench goal after the transient model timeout. "
+    "If ./skillsbench-task-prompt.md exists, read it before acting. Use the "
+    "private bridge command from the task instructions for one task-facing "
+    "action, then finish with compact status."
+)
+CODEX_CLI_GOAL_POST_BRIDGE_CLOSEOUT_PROMPT = (
+    "Close out the active SkillsBench goal after repeated post-bridge model "
+    "timeouts. Do not start a new investigation. If the task is complete, "
+    "finish the active goal now with compact status. If the task is not "
+    "complete, report the blocker compactly and end the active goal."
+)
+POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT = 4
+
+
+def codex_cli_tui_post_bridge_blocker_stage(
+    capture: str,
+    *,
+    prompt_visible: bool,
+) -> str:
+    """Classify public-safe Codex CLI TUI blockers after bridge activity."""
+
+    if not prompt_visible:
+        return ""
+    lowered = str(capture or "").lower()
+    if any(
+        marker in lowered
+        for marker in (
+            "rate limit",
+            "rate_limit",
+            "too many requests",
+            "status 429",
+            "error 429",
+        )
+    ):
+        return "post_bridge_tui_rate_limit"
+    if any(marker in lowered for marker in ("timed out", "timeout")) and any(
+        marker in lowered for marker in ("model", "request", "error", "failed")
+    ):
+        return "post_bridge_tui_model_timeout"
+    if any(marker in lowered for marker in ("press enter", "press return")) and any(
+        marker in lowered
+        for marker in ("error", "failed", "timed out", "timeout", "model")
+    ):
+        return "post_bridge_tui_error_prompt"
+    return ""
+
+
+def codex_cli_tui_post_bridge_recovery_action(capture: str, *, stage: str) -> str:
+    """Return a bounded public-safe recovery action for post-bridge TUI blockers."""
+
+    if stage not in {
+        "post_bridge_tui_model_timeout",
+        "post_bridge_tui_error_prompt",
+    }:
+        return ""
+    lowered = str(capture or "").lower()
+    if any(marker in lowered for marker in ("press enter", "press return")):
+        return "press_enter"
+    if (
+        stage == "post_bridge_tui_model_timeout"
+        and codex_cli_tui_input_prompt_visible(capture)
+    ):
+        return "typed_continue"
+    return ""
+
+
+def codex_cli_tui_post_bridge_recovery_skip_reason(
+    capture: str,
+    *,
+    stage: str,
+    recovery_action: str,
+) -> str:
+    """Return why no post-bridge recovery action was taken."""
+
+    if recovery_action:
+        return ""
+    if stage == "post_bridge_tui_rate_limit":
+        return "rate_limit_no_retry"
+    if stage not in {
+        "post_bridge_tui_model_timeout",
+        "post_bridge_tui_error_prompt",
+    }:
+        return ""
+    lowered = str(capture or "").lower()
+    if not any(marker in lowered for marker in ("press enter", "press return")):
+        return "no_retry_affordance"
+    return "unsupported_recovery_action"
+
+
+def codex_cli_tui_post_bridge_closeout_recovery_action(
+    *,
+    recovery_action: str,
+    recovery_attempt_count: int,
+    closeout_attempted: bool,
+) -> str:
+    """Return the final bounded closeout action after continue retries are spent."""
+
+    if closeout_attempted:
+        return ""
+    if recovery_action not in {"press_enter", "typed_continue"}:
+        return ""
+    if recovery_attempt_count < POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT:
+        return ""
+    return "typed_closeout"

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -4907,7 +4907,12 @@ def _apply_codex_cli_goal_countability_guard_attribution(
     )[:120]
 
     missing_task_activity = task_facing_count <= 0 or request_count <= 0
-    goal_failed = trace_present and ok_count <= 0
+    terminal_goal_failed_countable = (
+        goal_stage == "goal_failed"
+        and not missing_task_activity
+        and str(compact.get("official_score_status") or "") == "completed"
+    )
+    goal_failed = trace_present and ok_count <= 0 and not terminal_goal_failed_countable
     if not (missing_task_activity or goal_failed):
         return False
 


### PR DESCRIPTION
## Summary
- Extract Codex CLI `/goal` post-bridge timeout classification/recovery into a focused SkillsBench helper module, reducing the hot relay file while preserving the existing continue retry budget.
- Add a final bounded closeout prompt after repeated post-bridge model timeouts so a real `/goal` terminal state can be observed instead of killing the TUI as an uncountable timeout.
- Treat terminal `goal_failed` with task-facing bridge activity and completed official result as a countable solver failure, while keeping goal-active timeout and no-task-activity cases uncountable.

## Evidence
- civ6 source-locked main@e532ab82 after PR #1499: reverse tunnel and source guards passed, but recovery budget=4 still ended as `post_bridge_tui_model_timeout`, `retry_limit_reached`, countable=false.
- source-locked branch canary @89742bd4 with closeout recovery: reverse tunnel and source guards passed; TUI reached terminal `goal_failed`, action=`typed_closeout`, 21 bridge requests / 19 task-facing successes, official score 0.0.
- reduce-only with current reducer @52a289d6 on the same artifacts: `case_attempt_countable=true`, `solver_attempt_countable=true`, attribution=`official_verifier_solution_failure`, no raw task/log/trajectory material used.

## Validation
- `python3 -m py_compile loopx/benchmark_adapters/skillsbench_acp_relay.py loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py scripts/skillsbench_automation_loop.py examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 examples/skillsbench-host-local-launch-plan-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `loopx canary premerge --from-git-diff`: direct checks passed, catalog canaries 6/6 passed, public boundary passed; manual hold is benchmark_sensitive and owner has authorized benchmark-sensitive self-merge.
