### PR TITLE
Project typed handoff notes from todos

### DIFF
--- a/docs/reference/protocols/agent-management-projection-v0.md
+++ b/docs/reference/protocols/agent-management-projection-v0.md
@@ -159,8 +159,16 @@ history, and evidence refs:
 }
 ```
 
+LoopX derives this note from existing todo, history, and evidence rows. Current
+signals include `blocks_agent`, `claimed_by`, `unblocks_todo_id`,
+`successor_todo_ids`, `resume_when`, `note`, `evidence`, and compact rollout
+event refs. The same `handoff_note_v0` object can therefore appear inside
+`agent_todo_summary` items, `todo_index` rows, or future dashboard rows without
+introducing a second task model.
+
 The projection may show the latest handoff note in the agent row, but the note
-does not create a chat stream, dispatcher queue, or approval mechanism.
+does not create a chat stream, dispatcher queue, approval mechanism, or runtime
+task separate from the source todo.
 
 ## Stale Claim Hint
 

--- a/examples/control_plane/todo-durability-fixture-smoke.py
+++ b/examples/control_plane/todo-durability-fixture-smoke.py
@@ -76,7 +76,8 @@ def state_text() -> str:
         "  <!-- loopx:todo todo_id=todo_deferred_surface status=deferred task_class=advancement_task claimed_by=codex-product-capability resume_when=todo_done:todo_done_cli -->\n"
         f"- [-] {PR_DEFERRED_TODO}\n"
         "  <!-- loopx:todo todo_id=todo_pr_deferred status=deferred task_class=advancement_task claimed_by=codex-side-bypass resume_when=pr_merged:#532 -->\n"
-        f"- [ ] {SECOND_OPEN_TODO}\n\n"
+        f"- [ ] {SECOND_OPEN_TODO}\n"
+        "  <!-- loopx:todo todo_id=todo_handoff_review status=open task_class=advancement_task action_kind=review_pr claimed_by=codex-builder blocks_agent=codex-reviewer evidence=smoke_handoff_note -->\n\n"
         "## Completed Work Archive\n\n"
         f"{archived_lines}"
     )
@@ -157,6 +158,13 @@ def assert_parseable_agent_todos(agent_todos: dict) -> None:
     assert second_open["priority"] == "P2", second_open
     assert second_open["status"] == "open", second_open
     assert second_open["text"] == SECOND_OPEN_TODO, second_open
+    handoff_note = second_open["handoff_note"]
+    assert handoff_note["schema_version"] == "handoff_note_v0", handoff_note
+    assert handoff_note["todo_id"] == "todo_handoff_review", handoff_note
+    assert handoff_note["from_agent"] == "codex-builder", handoff_note
+    assert handoff_note["to_agent"] == "codex-reviewer", handoff_note
+    assert handoff_note["intent"] == "review_pr", handoff_note
+    assert handoff_note["evidence_refs"] == ["todo:todo_handoff_review:evidence"], handoff_note
 
     deferred = agent_todos["deferred_items"][0]
     deferred_by_id = {item["todo_id"]: item for item in agent_todos["deferred_items"]}
@@ -220,6 +228,13 @@ def main() -> int:
         ), item
         assert item["project_asset"]["agent_todos"]["next"] == FIRST_OPEN_TODO, item
         assert item["project_asset"]["agent_todos"]["next_index"] == 1, item
+        indexed_handoff = next(
+            row
+            for row in status_payload["todo_index"]["items"]
+            if row.get("todo_id") == "todo_handoff_review"
+        )
+        assert indexed_handoff["handoff_note"]["goal_id"] == GOAL_ID, indexed_handoff
+        assert indexed_handoff["handoff_note"]["to_agent"] == "codex-reviewer", indexed_handoff
 
         guard = run_cli("quota", "should-run", "--goal-id", GOAL_ID, registry_path=registry_path, runtime=runtime)
         assert guard["should_run"] is True, guard

--- a/loopx/control_plane/todos/handoff_note.py
+++ b/loopx/control_plane/todos/handoff_note.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Any
+
+from .contract import (
+    normalize_todo_action_kind,
+    normalize_todo_blocks_agent,
+    normalize_todo_claimed_by,
+    normalize_todo_decision_scope,
+    normalize_todo_id,
+    normalize_todo_id_list,
+    normalize_todo_required_decision_scopes,
+    normalize_todo_resume_when,
+)
+
+
+TODO_HANDOFF_NOTE_SCHEMA_VERSION = "handoff_note_v0"
+_AK_SK_PATTERN = re.compile(r"(?i)\b(?:ak|sk|access[_-]?key|secret[_-]?key)\b\s*[:=]\s*\S+")
+
+
+def _compact_text(value: Any, *, limit: int = 220) -> str | None:
+    text = " ".join(str(value or "").strip().split())
+    if not text or _AK_SK_PATTERN.search(text):
+        return None
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "..."
+
+
+def _raw_handoff(item: dict[str, Any]) -> dict[str, Any]:
+    handoff = item.get("handoff") or item.get("handoff_note")
+    return handoff if isinstance(handoff, dict) else {}
+
+
+def _handoff_id(item: dict[str, Any]) -> str:
+    todo_id = normalize_todo_id(item.get("todo_id"))
+    if todo_id:
+        return f"handoff_{todo_id.removeprefix('todo_')}"
+    digest = hashlib.sha1(
+        str(
+            (
+                item.get("goal_id"),
+                item.get("role"),
+                item.get("index"),
+                item.get("text") or item.get("title"),
+            )
+        ).encode("utf-8")
+    ).hexdigest()[:12]
+    return f"handoff_{digest}"
+
+
+def _first_text(item: dict[str, Any], *keys: str, limit: int = 220) -> str | None:
+    handoff = _raw_handoff(item)
+    for key in keys:
+        value = handoff.get(key) if key in handoff else item.get(key)
+        text = _compact_text(value, limit=limit)
+        if text:
+            return text
+    return None
+
+
+def _evidence_refs(item: dict[str, Any], *, todo_id: str | None) -> list[str]:
+    refs: list[str] = []
+    handoff = _raw_handoff(item)
+    raw_refs = handoff.get("evidence_refs") or item.get("evidence_refs")
+    if isinstance(raw_refs, (list, tuple, set)):
+        for raw in raw_refs:
+            ref = _compact_text(raw, limit=180)
+            if ref and ref not in refs:
+                refs.append(ref)
+
+    if item.get("evidence") and todo_id:
+        refs.append(f"todo:{todo_id}:evidence")
+    if item.get("note") and todo_id:
+        refs.append(f"todo:{todo_id}:note")
+    latest_event_kind = _compact_text(item.get("latest_event_kind"), limit=80)
+    if latest_event_kind and todo_id:
+        refs.append(f"rollout_event:{latest_event_kind}:{todo_id}")
+    return refs[:6]
+
+
+def _unresolved_decisions(item: dict[str, Any]) -> list[dict[str, str]]:
+    decisions: list[dict[str, str]] = []
+    for scope in normalize_todo_required_decision_scopes(item.get("required_decision_scopes")):
+        decisions.append(scope)
+    single = normalize_todo_decision_scope(item.get("decision_scope"))
+    if single:
+        identity = (single.get("kind"), single.get("granularity"), single.get("scope_key"))
+        if not any(
+            (item.get("kind"), item.get("granularity"), item.get("scope_key")) == identity
+            for item in decisions
+        ):
+            decisions.append(single)
+    return decisions
+
+
+def build_todo_handoff_note(
+    item: dict[str, Any],
+    *,
+    goal_id: str | None = None,
+    source: str | None = None,
+) -> dict[str, Any] | None:
+    """Project an existing todo/history/evidence row into a typed handoff note.
+
+    The note is a read model: it does not create a dispatcher queue, comment
+    stream, approval state, or runtime task separate from the source todo.
+    """
+
+    if not isinstance(item, dict):
+        return None
+    handoff = _raw_handoff(item)
+    todo_id = normalize_todo_id(item.get("todo_id"))
+    from_agent = (
+        normalize_todo_claimed_by(handoff.get("from_agent"))
+        or normalize_todo_claimed_by(item.get("claimed_by"))
+        or normalize_todo_claimed_by(item.get("agent_id"))
+    )
+    to_agent = (
+        normalize_todo_blocks_agent(handoff.get("to_agent"))
+        or normalize_todo_blocks_agent(item.get("blocks_agent"))
+    )
+    successor_todo_ids = normalize_todo_id_list(item.get("successor_todo_ids"))
+    unblocks_todo_id = normalize_todo_id(item.get("unblocks_todo_id"))
+    superseded_by = normalize_todo_id(item.get("superseded_by"))
+    has_handoff_signal = bool(
+        handoff
+        or to_agent
+        or successor_todo_ids
+        or unblocks_todo_id
+        or superseded_by
+    )
+    if not has_handoff_signal:
+        return None
+
+    intent = (
+        _first_text(item, "intent", limit=80)
+        or normalize_todo_action_kind(item.get("action_kind"))
+        or _compact_text(item.get("task_class"), limit=80)
+        or "continue"
+    )
+    blocked_on = (
+        _first_text(item, "blocked_on", limit=180)
+        or normalize_todo_resume_when(item.get("resume_when"))
+        or (f"todo:{unblocks_todo_id}" if unblocks_todo_id else None)
+        or (f"todo:{superseded_by}" if superseded_by else None)
+    )
+    payload: dict[str, Any] = {
+        "schema_version": TODO_HANDOFF_NOTE_SCHEMA_VERSION,
+        "handoff_id": _handoff_id(item),
+        "todo_id": todo_id,
+        "goal_id": _compact_text(goal_id or item.get("goal_id"), limit=180),
+        "from_agent": from_agent,
+        "to_agent": to_agent,
+        "intent": intent,
+        "summary": _first_text(item, "summary", "note", "reason", "evidence", "title", "text", limit=280),
+        "evidence_refs": _evidence_refs(item, todo_id=todo_id),
+        "unresolved_decisions": _unresolved_decisions(item),
+        "blocked_on": blocked_on,
+        "suggested_next_action": _first_text(item, "suggested_next_action", "title", "text", limit=260),
+        "source": _compact_text(source or item.get("source"), limit=120),
+    }
+    if successor_todo_ids:
+        payload["successor_todo_ids"] = successor_todo_ids
+    if unblocks_todo_id:
+        payload["unblocks_todo_id"] = unblocks_todo_id
+    return {
+        key: value
+        for key, value in payload.items()
+        if value not in (None, "", [], {})
+    }
+
+
+def attach_todo_handoff_note(
+    item: dict[str, Any],
+    *,
+    goal_id: str | None = None,
+    source: str | None = None,
+) -> dict[str, Any]:
+    note = build_todo_handoff_note(item, goal_id=goal_id, source=source)
+    if note:
+        item["handoff_note"] = note
+    return item

--- a/loopx/control_plane/todos/summary_item.py
+++ b/loopx/control_plane/todos/summary_item.py
@@ -10,6 +10,7 @@ from .contract import (
     normalize_todo_resume_when,
 )
 from .handoff_gate import handoff_ready_successor_todo_ids
+from .handoff_note import attach_todo_handoff_note
 from .projection import todo_item_task_class
 
 
@@ -53,6 +54,7 @@ TODO_SUMMARY_COMPACT_FIELDS = (
     "completed_at",
     "updated_at",
     "superseded_by",
+    "handoff_note",
 )
 
 TODO_SUMMARY_SOURCE_KEYS = (
@@ -107,6 +109,7 @@ def compact_todo_summary_item(
     else:
         compact.pop("required_decision_scopes", None)
     compact["task_class"] = todo_item_task_class(compact)
+    attach_todo_handoff_note(compact)
     return compact
 
 

--- a/loopx/control_plane/todos/todo_index.py
+++ b/loopx/control_plane/todos/todo_index.py
@@ -5,6 +5,7 @@ from typing import Any, Callable
 
 from ...rollout_event_log import load_rollout_events, rollout_event_log_path
 from .contract import normalize_todo_id, normalize_todo_status, todo_done_for_status
+from .handoff_note import attach_todo_handoff_note
 from .todo_summary import compact_todo_item
 
 
@@ -45,6 +46,7 @@ def _indexed_status_todo(
             "title": public_safe_compact_text(todo.get("title"), limit=320) or text,
         }
     )
+    attach_todo_handoff_note(item, goal_id=goal_id, source=source)
     return item
 
 
@@ -80,7 +82,7 @@ def _indexed_rollout_todo_event(
     )
     if not summary:
         summary = f"todo event recorded for {todo_id}"
-    return {
+    item = {
         "schema_version": TODO_INDEX_ITEM_SCHEMA_VERSION,
         "goal_id": goal_id,
         "todo_id": todo_id,
@@ -98,6 +100,11 @@ def _indexed_rollout_todo_event(
         "latest_event_status": status,
         "agent_id": public_safe_compact_text(event.get("agent_id"), limit=120),
     }
+    handoff = event.get("handoff") or details.get("handoff")
+    if isinstance(handoff, dict):
+        item["handoff"] = handoff
+    attach_todo_handoff_note(item, goal_id=goal_id, source="rollout_event_log")
+    return item
 
 
 def build_todo_index(

--- a/loopx/control_plane/todos/todo_summary.py
+++ b/loopx/control_plane/todos/todo_summary.py
@@ -27,6 +27,7 @@ from .contract import (
     todo_done_for_status,
 )
 from .handoff_gate import build_todo_handoff_gate_states
+from .handoff_note import attach_todo_handoff_note
 from .projection import (
     todo_claimed_visibility_items as projection_todo_claimed_visibility_items,
     todo_item_is_actionable_open as projection_todo_item_is_actionable_open,
@@ -321,6 +322,7 @@ def compact_todo_item(item: dict[str, Any]) -> dict[str, Any]:
     ):
         if item.get(key) is not None:
             compact[key] = item.get(key)
+    attach_todo_handoff_note(compact)
     return compact
 
 


### PR DESCRIPTION
## Summary
- add a lightweight `handoff_note_v0` read-model projection derived from existing todo/history/evidence rows
- surface the projection through todo summaries and todo_index without introducing a new runtime task or comment system
- extend the todo durability fixture to cover status/quota/todo_index propagation

## Validation
- python3 examples/control_plane/todo-durability-fixture-smoke.py
- python3 -m compileall loopx/control_plane/todos loopx/control_plane/work_items loopx/status.py loopx/quota.py
- python3 -m loopx.cli check --scan-path loopx/control_plane/todos/handoff_note.py --scan-path loopx/control_plane/todos/summary_item.py --scan-path loopx/control_plane/todos/todo_index.py --scan-path loopx/control_plane/todos/todo_summary.py --scan-path examples/control_plane/todo-durability-fixture-smoke.py --scan-path docs/reference/protocols/agent-management-projection-v0.md
- python3 examples/control_plane/status-markdown-smoke.py
- python3 examples/interaction-pattern-catalog-smoke.py
- python3 -m loopx.cli canary premerge --from-git-diff

## Boundary
- public/private boundary scan clean for touched files
- no runtime scheduler, claim/reclaim, approval, benchmark scoring, or production behavior changes
- canary premerge returned `self_merge_allowed=true`

LoopX todo: todo_cc33dd73097f