### PR TITLE
Refactor quota monitor poll into control plane

### DIFF
--- a/loopx/control_plane/quota/monitor_poll.py
+++ b/loopx/control_plane/quota/monitor_poll.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+
+from collections.abc import Callable
+from copy import deepcopy
+from datetime import datetime, timezone
+import json
+from pathlib import Path
+from typing import Any
+
+from .decision_summary import compact_quota_decision, quota_decision_agent_id
+from .spend_sources import DEFAULT_SLOT_SPEND_SOURCE, VALID_SLOT_SPEND_SOURCES
+from ..runtime.run_artifacts import run_file_stem, unique_run_artifact_paths
+from ..scheduler.monitor_poll_policy import (
+    allows_due_monitor_poll,
+    allows_no_spend_external_monitor_poll,
+)
+from ..scheduler.monitor_poll_writeback import write_monitor_poll_todo_state
+from ..scheduler.monitor_target import build_quota_monitor_target
+from ..todos.contract import normalize_todo_claimed_by, normalize_todo_id
+from ..work_items.delivery_outcome import DeliveryOutcome
+
+
+QUOTA_MONITOR_POLL_CLASSIFICATION = "quota_monitor_poll"
+
+
+def _now_local() -> str:
+    return datetime.now(timezone.utc).astimezone().replace(microsecond=0).isoformat()
+
+
+def build_quota_monitor_poll_event(
+    before: dict[str, Any],
+    *,
+    source: str = DEFAULT_SLOT_SPEND_SOURCE,
+    generated_at: str | None = None,
+    reason_summary: str | None = None,
+    todo_id: str | None = None,
+    target_key: str | None = None,
+    result_hash: str | None = None,
+    material_change: bool = False,
+) -> dict[str, Any]:
+    safe_source = str(source or DEFAULT_SLOT_SPEND_SOURCE).strip()
+    if safe_source not in VALID_SLOT_SPEND_SOURCES:
+        raise ValueError(f"quota monitor-poll source must be one of: {', '.join(sorted(VALID_SLOT_SPEND_SOURCES))}")
+    external_monitor_poll = allows_no_spend_external_monitor_poll(before)
+    due_monitor_poll = allows_due_monitor_poll(
+        before,
+        todo_id=todo_id,
+        target_key=target_key,
+    )
+    if before.get("effective_action") != "monitor_quiet_skip" and not external_monitor_poll and not due_monitor_poll:
+        raise ValueError(
+            "quota monitor-poll requires a monitor_quiet_skip, due monitor todo, or external monitor observation decision"
+        )
+    recommendation = (
+        before.get("heartbeat_recommendation")
+        if isinstance(before.get("heartbeat_recommendation"), dict)
+        else {}
+    )
+    if (
+        recommendation.get("recommended_mode") != "monitor_quiet_until_material_transition"
+        and not external_monitor_poll
+        and not due_monitor_poll
+    ):
+        raise ValueError("quota monitor-poll requires monitor_quiet_until_material_transition mode")
+    monitor_mode = (
+        "external_monitor_observed_without_material_transition"
+        if external_monitor_poll
+        else (
+            "due_monitor_material_transition"
+            if due_monitor_poll and material_change
+            else (
+                "due_monitor_observed_without_material_transition"
+                if due_monitor_poll
+                else "monitor_quiet_until_material_transition"
+            )
+        )
+    )
+    monitor_target = build_quota_monitor_target(before, monitor_mode=monitor_mode)
+    safe_reason_summary = str(reason_summary or "").strip()
+    if not safe_reason_summary:
+        safe_reason_summary = (
+            "external monitor observation produced no material transition"
+            if external_monitor_poll
+            else recommendation.get("reason")
+            or before.get("reason")
+            or "monitor-only poll had no material transition"
+        )
+    safe_agent_id = quota_decision_agent_id(before)
+
+    record = {
+        "generated_at": generated_at or _now_local(),
+        "goal_id": before.get("goal_id"),
+        "classification": QUOTA_MONITOR_POLL_CLASSIFICATION,
+        "recommended_action": before.get("recommended_action") or recommendation.get("reason") or before.get("reason"),
+        "health_check": (
+            "due monitor material transition observed; follow-up state updated; no quota spend by monitor-poll"
+            if due_monitor_poll and material_change
+            else (
+                "due monitor observation unchanged; no quota spend; next due updated"
+                if due_monitor_poll
+                else (
+                    "external monitor observation unchanged; no quota spend; no material transition"
+                    if external_monitor_poll
+                    else "monitor-only poll unchanged; no quota spend; no material transition"
+                )
+            )
+        ),
+        "delivery_outcome": (
+            DeliveryOutcome.OUTCOME_PROGRESS.value
+            if due_monitor_poll and material_change
+            else DeliveryOutcome.SURFACE_ONLY.value
+        ),
+        "monitor_target": monitor_target,
+        "monitor_event": {
+            "event_type": QUOTA_MONITOR_POLL_CLASSIFICATION,
+            "source": safe_source,
+            "monitor_mode": monitor_mode,
+            "monitor_target": monitor_target,
+            "reason_summary": safe_reason_summary,
+            "material_change": material_change,
+            "todo_id": normalize_todo_id(todo_id) if todo_id else None,
+            "target_key": str(target_key or "").strip() or None,
+            "result_hash": str(result_hash or "").strip() or None,
+            "before": compact_quota_decision(before),
+        },
+    }
+    if safe_agent_id:
+        record["agent_id"] = safe_agent_id
+        record["monitor_event"]["agent_id"] = safe_agent_id
+    return record
+
+
+def _monitor_poll_failure(
+    *,
+    goal_id: str,
+    execute: bool,
+    source: str,
+    agent_id: str | None,
+    todo_id: str | None,
+    target_key: str | None,
+    result_hash: str | None,
+    material_change: bool,
+    reason: str,
+    before: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "ok": False,
+        "mode": "monitor-poll",
+        "dry_run": not execute,
+        "goal_id": goal_id,
+        "appended": False,
+        "registry_mutated": False,
+        "source": str(source or DEFAULT_SLOT_SPEND_SOURCE).strip() or DEFAULT_SLOT_SPEND_SOURCE,
+        "agent_id": normalize_todo_claimed_by(agent_id),
+        "todo_id": todo_id,
+        "target_key": target_key,
+        "result_hash": result_hash,
+        "material_change": material_change,
+        "reason": reason,
+        "before": before,
+        "after": None,
+    }
+
+
+def record_quota_monitor_poll_for_decision(
+    before: dict[str, Any],
+    status_payload: dict[str, Any],
+    *,
+    goal_id: str,
+    after_decision: Callable[[dict[str, Any]], dict[str, Any]],
+    registry_path: Path | None = None,
+    execute: bool = False,
+    source: str = DEFAULT_SLOT_SPEND_SOURCE,
+    reason_summary: str | None = None,
+    agent_id: str | None = None,
+    todo_id: str | None = None,
+    target_key: str | None = None,
+    result_hash: str | None = None,
+    material_change: bool = False,
+    cadence: str | None = None,
+    next_due_at: str | None = None,
+    next_agent_todo: str | None = None,
+    next_user_todo: str | None = None,
+    next_claimed_by: str | None = None,
+) -> dict[str, Any]:
+    normalized_todo_id = normalize_todo_id(todo_id) if todo_id else None
+    safe_target_key = str(target_key or "").strip() or None
+    safe_result_hash = str(result_hash or "").strip() or None
+
+    def failure(reason: str) -> dict[str, Any]:
+        return _monitor_poll_failure(
+            goal_id=goal_id,
+            execute=execute,
+            source=source,
+            agent_id=agent_id,
+            todo_id=normalized_todo_id,
+            target_key=safe_target_key,
+            result_hash=safe_result_hash,
+            material_change=material_change,
+            reason=reason,
+            before=before,
+        )
+
+    if material_change and not (normalized_todo_id or safe_target_key):
+        return failure("`quota monitor-poll --material-change` requires --todo-id or --target-key")
+    if (next_agent_todo or next_user_todo) and not material_change:
+        return failure("`--next-agent-todo` and `--next-user-todo` require --material-change")
+    due_monitor_poll = allows_due_monitor_poll(
+        before,
+        todo_id=normalized_todo_id,
+        target_key=safe_target_key,
+    )
+    if (
+        before.get("effective_action") != "monitor_quiet_skip"
+        and not allows_no_spend_external_monitor_poll(before)
+        and not due_monitor_poll
+    ):
+        return failure(
+            "monitor-poll requires monitor_quiet_skip, due monitor todo, "
+            "or external monitor observation"
+        )
+
+    generated_at = _now_local()
+    todo_writeback = None
+    if normalized_todo_id or safe_target_key:
+        if registry_path is None:
+            raise ValueError("monitor todo writeback requires registry_path")
+        todo_writeback = write_monitor_poll_todo_state(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            generated_at=generated_at,
+            execute=execute,
+            todo_id=normalized_todo_id,
+            target_key=safe_target_key,
+            result_hash=result_hash,
+            material_change=material_change,
+            cadence=cadence,
+            next_due_at=next_due_at,
+            reason_summary=reason_summary,
+            next_agent_todo=next_agent_todo,
+            next_user_todo=next_user_todo,
+            next_claimed_by=next_claimed_by,
+            agent_id=agent_id,
+        )
+    record = build_quota_monitor_poll_event(
+        before,
+        source=source,
+        generated_at=generated_at,
+        reason_summary=reason_summary,
+        todo_id=(todo_writeback or {}).get("todo_id") or normalized_todo_id,
+        target_key=(todo_writeback or {}).get("target_key") or safe_target_key,
+        result_hash=(todo_writeback or {}).get("result_hash") or result_hash,
+        material_change=material_change,
+    )
+    if todo_writeback:
+        record["monitor_event"]["todo_writeback"] = {
+            key: value
+            for key, value in todo_writeback.items()
+            if key
+            in {
+                "schema_version",
+                "dry_run",
+                "goal_id",
+                "todo_id",
+                "target_key",
+                "result_hash",
+                "material_change",
+                "consecutive_no_change",
+                "last_checked_at",
+                "next_due_at",
+                "cadence",
+            }
+        }
+    raw_runtime_root = status_payload.get("runtime_root")
+    if not raw_runtime_root:
+        raise ValueError("status payload does not include runtime_root")
+    runtime_root = Path(str(raw_runtime_root)).expanduser()
+    runs_dir = runtime_root / "goals" / goal_id / "runs"
+    stem = run_file_stem(generated_at)
+    json_path, markdown_path = unique_run_artifact_paths(runs_dir, stem, "quota-monitor-poll")
+    index_path = runs_dir / "index.jsonl"
+    index_record = {
+        "generated_at": generated_at,
+        "goal_id": goal_id,
+        "classification": QUOTA_MONITOR_POLL_CLASSIFICATION,
+        "recommended_action": record["recommended_action"],
+        "health_check": record["health_check"],
+        "delivery_outcome": record["delivery_outcome"],
+        "monitor_target": record["monitor_target"],
+        "json_path": str(json_path),
+        "markdown_path": str(markdown_path),
+    }
+    if record.get("agent_id"):
+        index_record["agent_id"] = record["agent_id"]
+    if record["monitor_event"].get("todo_id"):
+        index_record["todo_id"] = record["monitor_event"]["todo_id"]
+    if record["monitor_event"].get("target_key"):
+        index_record["target_key"] = record["monitor_event"]["target_key"]
+    if record["monitor_event"].get("material_change"):
+        index_record["material_change"] = record["monitor_event"]["material_change"]
+
+    after_status = deepcopy(status_payload)
+    if execute:
+        runs_dir.mkdir(parents=True, exist_ok=True)
+        json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+        markdown_path.write_text(render_quota_monitor_poll_markdown(record) + "\n", encoding="utf-8")
+        with index_path.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(index_record, ensure_ascii=False) + "\n")
+        run_history = after_status.get("run_history") if isinstance(after_status.get("run_history"), dict) else {}
+        for goal in run_history.get("goals") if isinstance(run_history.get("goals"), list) else []:
+            if isinstance(goal, dict) and str(goal.get("id") or "") == goal_id:
+                latest_runs = goal.get("latest_runs") if isinstance(goal.get("latest_runs"), list) else []
+                goal["latest_runs"] = [index_record, *latest_runs]
+                runs = goal.get("runs") if isinstance(goal.get("runs"), list) else []
+                goal["runs"] = [index_record, *runs]
+        recent_runs = run_history.get("recent_runs") if isinstance(run_history.get("recent_runs"), list) else []
+        run_history["recent_runs"] = [index_record, *recent_runs]
+
+    after = after_decision(after_status)
+    return {
+        "ok": True,
+        "mode": "monitor-poll",
+        "dry_run": not execute,
+        "goal_id": goal_id,
+        "appended": execute,
+        "registry_mutated": False,
+        "source": record["monitor_event"]["source"],
+        "classification": QUOTA_MONITOR_POLL_CLASSIFICATION,
+        "generated_at": generated_at,
+        "agent_id": record.get("agent_id"),
+        "todo_id": record["monitor_event"].get("todo_id"),
+        "target_key": record["monitor_event"].get("target_key"),
+        "material_change": record["monitor_event"].get("material_change"),
+        "monitor_event": record["monitor_event"],
+        "todo_writeback": todo_writeback,
+        "health_check": record["health_check"],
+        "delivery_outcome": record["delivery_outcome"],
+        "json_path": str(json_path),
+        "markdown_path": str(markdown_path),
+        "index_path": str(index_path),
+        "before": before,
+        "after": after,
+        "reason": (
+            f"{'appended' if execute else 'dry-run preview'} monitor poll event: "
+            f"{goal_id} effective_action={before.get('effective_action')}"
+        ),
+    }
+
+
+def render_quota_monitor_poll_markdown(payload: dict[str, Any]) -> str:
+    event = payload.get("monitor_event") if isinstance(payload.get("monitor_event"), dict) else {}
+    before = event.get("before") if isinstance(event.get("before"), dict) else {}
+    todo_writeback = event.get("todo_writeback") if isinstance(event.get("todo_writeback"), dict) else {}
+    lines = [
+        "# LoopX Quota Monitor Poll",
+        "",
+        f"- goal_id: `{payload.get('goal_id')}`",
+        f"- classification: `{payload.get('classification')}`",
+        f"- agent_id: `{payload.get('agent_id') or event.get('agent_id') or ''}`",
+        f"- source: `{event.get('source')}`",
+        f"- effective_action: `{before.get('effective_action')}`",
+        f"- monitor_target: `{(event.get('monitor_target') or {}).get('target_id') if isinstance(event.get('monitor_target'), dict) else ''}`",
+        f"- todo_id: `{event.get('todo_id') or ''}`",
+        f"- target_key: `{event.get('target_key') or ''}`",
+        f"- material_change: `{event.get('material_change')}`",
+        f"- should_run: `{before.get('should_run')}`",
+        f"- self_repair_allowed: `{before.get('self_repair_allowed')}`",
+        f"- state: `{before.get('state')}`",
+        f"- health_check: {payload.get('health_check')}",
+        f"- reason: {event.get('reason_summary')}",
+    ]
+    if todo_writeback:
+        lines.append(
+            "- todo_writeback: "
+            f"dry_run={todo_writeback.get('dry_run')} "
+            f"consecutive_no_change={todo_writeback.get('consecutive_no_change')} "
+            f"last_checked_at={todo_writeback.get('last_checked_at')} "
+            f"next_due_at={todo_writeback.get('next_due_at')}"
+        )
+    return "\n".join(lines)

--- a/loopx/control_plane/quota/spend_sources.py
+++ b/loopx/control_plane/quota/spend_sources.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+
+DEFAULT_SLOT_SPEND_SOURCE = "heartbeat"
+VALID_SLOT_SPEND_SOURCES = {"heartbeat", "controller", "adapter"}

--- a/loopx/control_plane/runtime/run_artifacts.py
+++ b/loopx/control_plane/runtime/run_artifacts.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def run_file_stem(generated_at: str) -> str:
+    return re.sub(r"[^0-9A-Za-z-]+", "-", generated_at).strip("-")
+
+
+def unique_run_artifact_paths(runs_dir: Path, stem: str, suffix: str) -> tuple[Path, Path]:
+    candidate = runs_dir / f"{stem}-{suffix}.json"
+    markdown_candidate = runs_dir / f"{stem}-{suffix}.md"
+    if not candidate.exists() and not markdown_candidate.exists():
+        return candidate, markdown_candidate
+    index = 2
+    while True:
+        candidate = runs_dir / f"{stem}-{suffix}-{index}.json"
+        markdown_candidate = runs_dir / f"{stem}-{suffix}-{index}.md"
+        if not candidate.exists() and not markdown_candidate.exists():
+            return candidate, markdown_candidate
+        index += 1

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from copy import deepcopy
 import json
-import re
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -85,10 +84,20 @@ from .control_plane.quota.decision_summary import (
     compact_quota_decision,
     quota_decision_agent_id,
 )
+from .control_plane.quota.monitor_poll import (
+    QUOTA_MONITOR_POLL_CLASSIFICATION,
+    build_quota_monitor_poll_event,
+    record_quota_monitor_poll_for_decision,
+    render_quota_monitor_poll_markdown,
+)
 from .control_plane.quota.scheduler_ack import (
     QUOTA_SCHEDULER_ACK_CLASSIFICATION,
     build_quota_scheduler_ack_event,
     record_quota_scheduler_ack_for_decision,
+)
+from .control_plane.quota.spend_sources import (
+    DEFAULT_SLOT_SPEND_SOURCE,
+    VALID_SLOT_SPEND_SOURCES,
 )
 from .control_plane.runtime.decision_freshness import (
     DECISION_FRESHNESS_WARNING_ITEM_LIMIT,
@@ -110,21 +119,16 @@ from .control_plane.work_items.work_lane import (
 from .control_plane.scheduler.scheduler_hint import (
     build_scheduler_hint,
 )
-from .control_plane.scheduler.monitor_poll_policy import (
-    allows_due_monitor_poll,
-    allows_no_spend_external_monitor_poll,
-)
 from .control_plane.scheduler.external_evidence_observation import (
     build_external_evidence_observation_obligation,
 )
-from .control_plane.scheduler.monitor_poll_writeback import write_monitor_poll_todo_state
-from .control_plane.scheduler.monitor_target import build_quota_monitor_target
 from .control_plane.scheduler.automation_liveness import build_automation_liveness
 from .control_plane.scheduler.state import (
     CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
     CODEX_APP_SURFACE,
     load_scheduler_state,
 )
+from .control_plane.runtime.run_artifacts import run_file_stem, unique_run_artifact_paths
 from .state_projection import (
     actions_are_projection_aligned,
     next_action_projection_warning,
@@ -184,15 +188,12 @@ QUOTA_STATE_ORDER = (
 )
 QUOTA_SLOT_SPENT_CLASSIFICATION = "quota_slot_spent"
 QUOTA_SLOT_VOIDED_CLASSIFICATION = "quota_slot_voided"
-QUOTA_MONITOR_POLL_CLASSIFICATION = "quota_monitor_poll"
 AUTONOMOUS_REPLAN_ACK_NEUTRAL_CLASSIFICATIONS = {
     QUOTA_SLOT_SPENT_CLASSIFICATION,
     QUOTA_SLOT_VOIDED_CLASSIFICATION,
     QUOTA_SCHEDULER_ACK_CLASSIFICATION,
     "delivery_completion_spend_accounted_v0",
 }
-DEFAULT_SLOT_SPEND_SOURCE = "heartbeat"
-VALID_SLOT_SPEND_SOURCES = {"heartbeat", "controller", "adapter"}
 FOCUS_WAIT_LIFECYCLE_MARKERS = {
     "continuation_boundary",
     "focus_wait",
@@ -238,24 +239,6 @@ def _parse_timestamp(value: Any) -> datetime | None:
     if parsed.tzinfo is None:
         return parsed.replace(tzinfo=timezone.utc)
     return parsed
-
-
-def _run_file_stem(generated_at: str) -> str:
-    return re.sub(r"[^0-9A-Za-z-]+", "-", generated_at).strip("-")
-
-
-def _unique_run_artifact_paths(runs_dir: Path, stem: str, suffix: str) -> tuple[Path, Path]:
-    candidate = runs_dir / f"{stem}-{suffix}.json"
-    markdown_candidate = runs_dir / f"{stem}-{suffix}.md"
-    if not candidate.exists() and not markdown_candidate.exists():
-        return candidate, markdown_candidate
-    index = 2
-    while True:
-        candidate = runs_dir / f"{stem}-{suffix}-{index}.json"
-        markdown_candidate = runs_dir / f"{stem}-{suffix}-{index}.md"
-        if not candidate.exists() and not markdown_candidate.exists():
-            return candidate, markdown_candidate
-        index += 1
 
 
 def _validate_goal_id_path_segment(goal_id: str) -> str:
@@ -2779,109 +2762,6 @@ def record_quota_scheduler_ack(
     )
 
 
-def build_quota_monitor_poll_event(
-    before: dict[str, Any],
-    *,
-    source: str = DEFAULT_SLOT_SPEND_SOURCE,
-    generated_at: str | None = None,
-    reason_summary: str | None = None,
-    todo_id: str | None = None,
-    target_key: str | None = None,
-    result_hash: str | None = None,
-    material_change: bool = False,
-) -> dict[str, Any]:
-    safe_source = str(source or DEFAULT_SLOT_SPEND_SOURCE).strip()
-    if safe_source not in VALID_SLOT_SPEND_SOURCES:
-        raise ValueError(f"quota monitor-poll source must be one of: {', '.join(sorted(VALID_SLOT_SPEND_SOURCES))}")
-    external_monitor_poll = allows_no_spend_external_monitor_poll(before)
-    due_monitor_poll = allows_due_monitor_poll(
-        before,
-        todo_id=todo_id,
-        target_key=target_key,
-    )
-    if before.get("effective_action") != "monitor_quiet_skip" and not external_monitor_poll and not due_monitor_poll:
-        raise ValueError(
-            "quota monitor-poll requires a monitor_quiet_skip, due monitor todo, or external monitor observation decision"
-        )
-    recommendation = (
-        before.get("heartbeat_recommendation")
-        if isinstance(before.get("heartbeat_recommendation"), dict)
-        else {}
-    )
-    if (
-        recommendation.get("recommended_mode") != "monitor_quiet_until_material_transition"
-        and not external_monitor_poll
-        and not due_monitor_poll
-    ):
-        raise ValueError("quota monitor-poll requires monitor_quiet_until_material_transition mode")
-    monitor_mode = (
-        "external_monitor_observed_without_material_transition"
-        if external_monitor_poll
-        else (
-            "due_monitor_material_transition"
-            if due_monitor_poll and material_change
-            else (
-                "due_monitor_observed_without_material_transition"
-                if due_monitor_poll
-                else "monitor_quiet_until_material_transition"
-            )
-        )
-    )
-    monitor_target = build_quota_monitor_target(before, monitor_mode=monitor_mode)
-    safe_reason_summary = str(reason_summary or "").strip()
-    if not safe_reason_summary:
-        safe_reason_summary = (
-            "external monitor observation produced no material transition"
-            if external_monitor_poll
-            else recommendation.get("reason")
-            or before.get("reason")
-            or "monitor-only poll had no material transition"
-        )
-    safe_agent_id = quota_decision_agent_id(before)
-
-    record = {
-        "generated_at": generated_at or _now_local(),
-        "goal_id": before.get("goal_id"),
-        "classification": QUOTA_MONITOR_POLL_CLASSIFICATION,
-        "recommended_action": before.get("recommended_action") or recommendation.get("reason") or before.get("reason"),
-        "health_check": (
-            "due monitor material transition observed; follow-up state updated; no quota spend by monitor-poll"
-            if due_monitor_poll and material_change
-            else (
-                "due monitor observation unchanged; no quota spend; next due updated"
-                if due_monitor_poll
-                else (
-                    "external monitor observation unchanged; no quota spend; no material transition"
-            if external_monitor_poll
-            else "monitor-only poll unchanged; no quota spend; no material transition"
-                )
-            )
-        ),
-        "delivery_outcome": (
-            DeliveryOutcome.OUTCOME_PROGRESS.value
-            if due_monitor_poll and material_change
-            else DeliveryOutcome.SURFACE_ONLY.value
-        ),
-        "monitor_target": monitor_target,
-        "monitor_event": {
-            "event_type": QUOTA_MONITOR_POLL_CLASSIFICATION,
-            "source": safe_source,
-            "monitor_mode": monitor_mode,
-            "monitor_target": monitor_target,
-            "reason_summary": safe_reason_summary,
-            "material_change": material_change,
-            "todo_id": normalize_todo_id(todo_id) if todo_id else None,
-            "target_key": str(target_key or "").strip() or None,
-            "result_hash": str(result_hash or "").strip() or None,
-            "before": compact_quota_decision(before),
-        },
-    }
-    if safe_agent_id:
-        record["agent_id"] = safe_agent_id
-        record["monitor_event"]["agent_id"] = safe_agent_id
-    return record
-
-
 def build_quota_slot_spend_event(
     preview: dict[str, Any],
     *,
@@ -3070,173 +2950,30 @@ def record_quota_monitor_poll(
 ) -> dict[str, Any]:
     safe_goal_id = _validate_goal_id_path_segment(str(goal_id or ""))
     before = build_quota_should_run(status_payload, goal_id=safe_goal_id, agent_id=agent_id)
-    normalized_todo_id = normalize_todo_id(todo_id) if todo_id else None
-    safe_target_key = str(target_key or "").strip() or None
-    safe_result_hash = str(result_hash or "").strip() or None
-
-    def failure(reason: str) -> dict[str, Any]:
-        return {
-            "ok": False,
-            "mode": "monitor-poll",
-            "dry_run": not execute,
-            "goal_id": safe_goal_id,
-            "appended": False,
-            "registry_mutated": False,
-            "source": str(source or DEFAULT_SLOT_SPEND_SOURCE).strip() or DEFAULT_SLOT_SPEND_SOURCE,
-            "agent_id": normalize_todo_claimed_by(agent_id),
-            "todo_id": normalized_todo_id,
-            "target_key": safe_target_key,
-            "result_hash": safe_result_hash,
-            "material_change": material_change,
-            "reason": reason,
-            "before": before,
-            "after": None,
-        }
-
-    if material_change and not (normalized_todo_id or safe_target_key):
-        return failure("`quota monitor-poll --material-change` requires --todo-id or --target-key")
-    if (next_agent_todo or next_user_todo) and not material_change:
-        return failure("`--next-agent-todo` and `--next-user-todo` require --material-change")
-    due_monitor_poll = allows_due_monitor_poll(
+    return record_quota_monitor_poll_for_decision(
         before,
-        todo_id=normalized_todo_id,
-        target_key=safe_target_key,
-    )
-    if (
-        before.get("effective_action") != "monitor_quiet_skip"
-        and not allows_no_spend_external_monitor_poll(before)
-        and not due_monitor_poll
-    ):
-        return failure(
-            "monitor-poll requires monitor_quiet_skip, due monitor todo, "
-            "or external monitor observation"
-        )
-
-    generated_at = _now_local()
-    todo_writeback = None
-    if normalized_todo_id or safe_target_key:
-        if registry_path is None:
-            raise ValueError("monitor todo writeback requires registry_path")
-        todo_writeback = write_monitor_poll_todo_state(
-            registry_path=registry_path,
+        status_payload,
+        goal_id=safe_goal_id,
+        after_decision=lambda after_status: build_quota_should_run(
+            after_status,
             goal_id=safe_goal_id,
-            generated_at=generated_at,
-            execute=execute,
-            todo_id=normalized_todo_id,
-            target_key=safe_target_key,
-            result_hash=result_hash,
-            material_change=material_change,
-            cadence=cadence,
-            next_due_at=next_due_at,
-            reason_summary=reason_summary,
-            next_agent_todo=next_agent_todo,
-            next_user_todo=next_user_todo,
-            next_claimed_by=next_claimed_by,
             agent_id=agent_id,
-        )
-    record = build_quota_monitor_poll_event(
-        before,
-        source=source,
-        generated_at=generated_at,
-        reason_summary=reason_summary,
-        todo_id=(todo_writeback or {}).get("todo_id") or normalized_todo_id,
-        target_key=(todo_writeback or {}).get("target_key") or safe_target_key,
-        result_hash=(todo_writeback or {}).get("result_hash") or result_hash,
-        material_change=material_change,
-    )
-    if todo_writeback:
-        record["monitor_event"]["todo_writeback"] = {
-            key: value
-            for key, value in todo_writeback.items()
-            if key
-            in {
-                "schema_version",
-                "dry_run",
-                "goal_id",
-                "todo_id",
-                "target_key",
-                "result_hash",
-                "material_change",
-                "consecutive_no_change",
-                "last_checked_at",
-                "next_due_at",
-                "cadence",
-            }
-        }
-    raw_runtime_root = status_payload.get("runtime_root")
-    if not raw_runtime_root:
-        raise ValueError("status payload does not include runtime_root")
-    runtime_root = Path(str(raw_runtime_root)).expanduser()
-    runs_dir = runtime_root / "goals" / safe_goal_id / "runs"
-    stem = _run_file_stem(generated_at)
-    json_path, markdown_path = _unique_run_artifact_paths(runs_dir, stem, "quota-monitor-poll")
-    index_path = runs_dir / "index.jsonl"
-    index_record = {
-        "generated_at": generated_at,
-        "goal_id": safe_goal_id,
-        "classification": QUOTA_MONITOR_POLL_CLASSIFICATION,
-        "recommended_action": record["recommended_action"],
-        "health_check": record["health_check"],
-        "delivery_outcome": record["delivery_outcome"],
-        "monitor_target": record["monitor_target"],
-        "json_path": str(json_path),
-        "markdown_path": str(markdown_path),
-    }
-    if record.get("agent_id"):
-        index_record["agent_id"] = record["agent_id"]
-    if record["monitor_event"].get("todo_id"):
-        index_record["todo_id"] = record["monitor_event"]["todo_id"]
-    if record["monitor_event"].get("target_key"):
-        index_record["target_key"] = record["monitor_event"]["target_key"]
-    if record["monitor_event"].get("material_change"):
-        index_record["material_change"] = record["monitor_event"]["material_change"]
-
-    after_status = deepcopy(status_payload)
-    if execute:
-        runs_dir.mkdir(parents=True, exist_ok=True)
-        json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
-        markdown_path.write_text(render_quota_monitor_poll_markdown(record) + "\n", encoding="utf-8")
-        with index_path.open("a", encoding="utf-8") as f:
-            f.write(json.dumps(index_record, ensure_ascii=False) + "\n")
-        run_history = after_status.get("run_history") if isinstance(after_status.get("run_history"), dict) else {}
-        for goal in run_history.get("goals") if isinstance(run_history.get("goals"), list) else []:
-            if isinstance(goal, dict) and str(goal.get("id") or "") == safe_goal_id:
-                latest_runs = goal.get("latest_runs") if isinstance(goal.get("latest_runs"), list) else []
-                goal["latest_runs"] = [index_record, *latest_runs]
-                runs = goal.get("runs") if isinstance(goal.get("runs"), list) else []
-                goal["runs"] = [index_record, *runs]
-        recent_runs = run_history.get("recent_runs") if isinstance(run_history.get("recent_runs"), list) else []
-        run_history["recent_runs"] = [index_record, *recent_runs]
-
-    after = build_quota_should_run(after_status, goal_id=safe_goal_id, agent_id=agent_id)
-    return {
-        "ok": True,
-        "mode": "monitor-poll",
-        "dry_run": not execute,
-        "goal_id": safe_goal_id,
-        "appended": execute,
-        "registry_mutated": False,
-        "source": record["monitor_event"]["source"],
-        "classification": QUOTA_MONITOR_POLL_CLASSIFICATION,
-        "generated_at": generated_at,
-        "agent_id": record.get("agent_id"),
-        "todo_id": record["monitor_event"].get("todo_id"),
-        "target_key": record["monitor_event"].get("target_key"),
-        "material_change": record["monitor_event"].get("material_change"),
-        "monitor_event": record["monitor_event"],
-        "todo_writeback": todo_writeback,
-        "health_check": record["health_check"],
-        "delivery_outcome": record["delivery_outcome"],
-        "json_path": str(json_path),
-        "markdown_path": str(markdown_path),
-        "index_path": str(index_path),
-        "before": before,
-        "after": after,
-        "reason": (
-            f"{'appended' if execute else 'dry-run preview'} monitor poll event: "
-            f"{safe_goal_id} effective_action={before.get('effective_action')}"
         ),
-    }
+        registry_path=registry_path,
+        execute=execute,
+        source=source,
+        reason_summary=reason_summary,
+        agent_id=agent_id,
+        todo_id=todo_id,
+        target_key=target_key,
+        result_hash=result_hash,
+        material_change=material_change,
+        cadence=cadence,
+        next_due_at=next_due_at,
+        next_agent_todo=next_agent_todo,
+        next_user_todo=next_user_todo,
+        next_claimed_by=next_claimed_by,
+    )
 
 
 def _find_quota_spend_run(
@@ -3401,8 +3138,8 @@ def void_quota_slot(
         raise ValueError("status payload does not include runtime_root")
     runtime_root = Path(str(raw_runtime_root)).expanduser()
     runs_dir = runtime_root / "goals" / safe_goal_id / "runs"
-    stem = _run_file_stem(generated_at)
-    json_path, markdown_path = _unique_run_artifact_paths(runs_dir, stem, "quota-slot-voided")
+    stem = run_file_stem(generated_at)
+    json_path, markdown_path = unique_run_artifact_paths(runs_dir, stem, "quota-slot-voided")
     index_path = runs_dir / "index.jsonl"
     index_record = {
         "generated_at": generated_at,
@@ -3471,8 +3208,8 @@ def spend_quota_slot(
         raise ValueError("status payload does not include runtime_root")
     runtime_root = Path(str(raw_runtime_root)).expanduser()
     runs_dir = runtime_root / "goals" / safe_goal_id / "runs"
-    stem = _run_file_stem(generated_at)
-    json_path, markdown_path = _unique_run_artifact_paths(runs_dir, stem, "quota-slot-spent")
+    stem = run_file_stem(generated_at)
+    json_path, markdown_path = unique_run_artifact_paths(runs_dir, stem, "quota-slot-spent")
     index_path = runs_dir / "index.jsonl"
     index_record = {
         "generated_at": generated_at,
@@ -3651,39 +3388,6 @@ def render_quota_slot_preview_markdown(payload: dict[str, Any]) -> str:
             lines.append(f"- after_plan_next_automatic_turn: {summary.get('next_automatic_turn') or 'none'}")
     if payload.get("rolling_window_note"):
         lines.append(f"- rolling_window_note: {payload.get('rolling_window_note')}")
-    return "\n".join(lines)
-
-
-def render_quota_monitor_poll_markdown(payload: dict[str, Any]) -> str:
-    event = payload.get("monitor_event") if isinstance(payload.get("monitor_event"), dict) else {}
-    before = event.get("before") if isinstance(event.get("before"), dict) else {}
-    todo_writeback = event.get("todo_writeback") if isinstance(event.get("todo_writeback"), dict) else {}
-    lines = [
-        "# LoopX Quota Monitor Poll",
-        "",
-        f"- goal_id: `{payload.get('goal_id')}`",
-        f"- classification: `{payload.get('classification')}`",
-        f"- agent_id: `{payload.get('agent_id') or event.get('agent_id') or ''}`",
-        f"- source: `{event.get('source')}`",
-        f"- effective_action: `{before.get('effective_action')}`",
-        f"- monitor_target: `{(event.get('monitor_target') or {}).get('target_id') if isinstance(event.get('monitor_target'), dict) else ''}`",
-        f"- todo_id: `{event.get('todo_id') or ''}`",
-        f"- target_key: `{event.get('target_key') or ''}`",
-        f"- material_change: `{event.get('material_change')}`",
-        f"- should_run: `{before.get('should_run')}`",
-        f"- self_repair_allowed: `{before.get('self_repair_allowed')}`",
-        f"- state: `{before.get('state')}`",
-        f"- health_check: {payload.get('health_check')}",
-        f"- reason: {event.get('reason_summary')}",
-    ]
-    if todo_writeback:
-        lines.append(
-            "- todo_writeback: "
-            f"dry_run={todo_writeback.get('dry_run')} "
-            f"consecutive_no_change={todo_writeback.get('consecutive_no_change')} "
-            f"last_checked_at={todo_writeback.get('last_checked_at')} "
-            f"next_due_at={todo_writeback.get('next_due_at')}"
-        )
     return "\n".join(lines)
 
 


### PR DESCRIPTION
## Summary
- move quota monitor-poll event construction, writeback/runtime recording, and markdown rendering into `loopx.control_plane.quota.monitor_poll`
- share slot-spend source constants through `loopx.control_plane.quota.spend_sources`
- move run artifact path naming into `loopx.control_plane.runtime.run_artifacts`
- keep the existing `loopx.quota` import/API surface as thin wrappers for compatibility

## Validation
- `python3 -m py_compile loopx/quota.py loopx/control_plane/quota/monitor_poll.py loopx/control_plane/quota/spend_sources.py loopx/control_plane/runtime/run_artifacts.py`
- `python3 examples/control_plane/quota-plan-smoke.py`
- `python3 examples/control_plane/monitor-poll-writeback-smoke.py`
- `python3 examples/control_plane/monitor-poll-policy-smoke.py`
- `python3 examples/control_plane/status-neutral-run-window-smoke.py`
- `python3 examples/control_plane/heartbeat-quota-flow-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli canary premerge --from-git-diff` (rerun after rebase onto latest `origin/main`)

## Boundary
- no benchmark jobs, scoring changes, raw logs, trajectories, verifier output, private state, credentials, or local paths included
- touches only public core product code under `loopx/**`
