### PR TITLE
Fix Codex TUI pasted wake submit retry

### DIFF
--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -672,6 +672,21 @@ def main() -> int:
                 1,
             ], tail_retry_wake
             os.environ["FAKE_TMUX_CAPTURE_TEXT"] = (
+                "\n"
+                "› [Pasted Content 1010 chars]\n\n"
+                "  gpt-5.5 high · /tmp/loopx-visible-workspace\n"
+            )
+            pasted_content_retry_wake = wake_visible_multi_agent_panes(
+                session_name="loopx-visible-launcher-smoke",
+                tmux_bin="tmux",
+                lanes=["planner", "reviewer"],
+                execute=True,
+            )
+            assert [
+                item["retry_count"]
+                for item in pasted_content_retry_wake["prompt_submit_checks"]
+            ] == [1, 1], pasted_content_retry_wake
+            os.environ["FAKE_TMUX_CAPTURE_TEXT"] = (
                 "╭────────────────────────╮\n"
                 "│ >_ OpenAI Codex        │\n"
                 "│ model: gpt-5.5 high    │\n"

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -197,6 +197,8 @@ def _prompt_still_waiting_for_submit(capture: str, prompt: str) -> bool:
     current_view = capture[prompt_index:] if prompt_index >= 0 else capture
     if "Working (" in current_view or "Queued follow-up inputs" in current_view:
         return False
+    if "[Pasted Content" in current_view:
+        return True
     words = [part for part in prompt.split() if part]
     head = words[:4]
     tail = words[-4:]


### PR DESCRIPTION
## Summary
- Treat Codex TUI `[Pasted Content ...]` as a prompt that is still waiting for submission after tmux paste.
- Retry Enter once in that state so `loopx multi-agent wake` actually advances live panes instead of leaving the fixed wake prompt in the input box.
- Add focused smoke coverage for the pasted-content retry path.

## Validation
- `python3 examples/visible-multi-agent-launcher-smoke.py`
- `python3 examples/generic-multi-agent-one-command-smoke.py`
- `loopx canary premerge --from-git-diff` passed: standard tier, 2 changed files, public boundary clean, self-merge allowed.
- Real KNN visible run validation on `loopx-ar-second-knn-20260705T202208Z`: patched wake reported retry_count=1 for all four panes; evaluator-promoter resumed, read executor evidence, completed `todo_698a8575a770`, and wrote verdict from public evidence: dev speedup 1.73784, held-out/test speedup 1.760597, protected file hashes clean.

## Self-merge rationale
Small single-purpose runtime fix plus focused smoke. No scoring changes, fake metrics, credentials, raw logs, private artifacts, or public evidence-policy changes.
