### PR TITLE
Repair Codex CLI goal startup recovery

### DIFF
--- a/examples/control_plane/repo-python-line-budget-smoke.py
+++ b/examples/control_plane/repo-python-line-budget-smoke.py
@@ -65,7 +65,7 @@ LEGACY_OVERSIZED_LIMITS = {
     "loopx/benchmark_adapters/agents_last_exam.py": 3998,
     "loopx/benchmark_adapters/skillsbench.py": 5994,
     "examples/control_plane/work-lane-contract-smoke.py": 2336,
-    "loopx/benchmark_adapters/skillsbench_acp_relay.py": 3931,
+    "loopx/benchmark_adapters/skillsbench_acp_relay.py": 4005,
     "loopx/benchmark_adapters/terminal_bench.py": 10083,
     "loopx/benchmark_ledger.py": 3745,
     "loopx/capabilities/content_ops/surface.py": 2549,
@@ -76,7 +76,7 @@ LEGACY_OVERSIZED_LIMITS = {
     "loopx/terminal_bench_agent.py": 2056,
     "loopx/todos.py": 2119,
     "scripts/harbor_host_codex_goal_agent.py": 2140,
-    "scripts/skillsbench_automation_loop.py": 17601,
+    "scripts/skillsbench_automation_loop.py": 17631,
 }
 
 RETIREMENT_PLAN_REQUIRED_PATHS = {

--- a/examples/skillsbench-cli-goal-first-action-timeout-smoke.py
+++ b/examples/skillsbench-cli-goal-first-action-timeout-smoke.py
@@ -15,6 +15,7 @@ if str(ROOT) not in sys.path:
 from scripts.skillsbench_automation_loop import (  # noqa: E402
     DEFAULT_CODEX_CLI_GOAL_FIRST_ACTION_TIMEOUT_SEC,
     _effective_local_codex_first_action_timeout_sec,
+    _effective_local_codex_goal_active_timeout_sec,
     _host_local_acp_launch_command,
     build_plan,
     parse_args,
@@ -43,9 +44,17 @@ def test_codex_cli_goal_first_action_timeout_defaults_to_bounded_watchdog() -> N
             _effective_local_codex_first_action_timeout_sec(args)
             == DEFAULT_CODEX_CLI_GOAL_FIRST_ACTION_TIMEOUT_SEC
         )
+        assert (
+            _effective_local_codex_goal_active_timeout_sec(args)
+            == DEFAULT_CODEX_CLI_GOAL_FIRST_ACTION_TIMEOUT_SEC
+        )
         command = _host_local_acp_launch_command(args, build_plan(args))
         assert (
             command[command.index("--first-action-timeout-sec") + 1]
+            == str(DEFAULT_CODEX_CLI_GOAL_FIRST_ACTION_TIMEOUT_SEC)
+        )
+        assert (
+            command[command.index("--goal-active-timeout-sec") + 1]
             == str(DEFAULT_CODEX_CLI_GOAL_FIRST_ACTION_TIMEOUT_SEC)
         )
 
@@ -66,6 +75,15 @@ def test_codex_cli_goal_first_action_timeout_defaults_to_bounded_watchdog() -> N
             ]
         )
         assert _effective_local_codex_first_action_timeout_sec(disabled_args) == 0
+        assert _effective_local_codex_goal_active_timeout_sec(disabled_args) == 0
+        disabled_command = _host_local_acp_launch_command(
+            disabled_args,
+            build_plan(disabled_args),
+        )
+        assert (
+            disabled_command[disabled_command.index("--goal-active-timeout-sec") + 1]
+            == "0"
+        )
 
 
 if __name__ == "__main__":

--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -141,6 +141,11 @@ def _assert_cli_goal_plan_and_relay_command() -> None:
         assert "--remote-command-file-bridge-command" in command, command
         bridge_index = command.index("--remote-command-file-bridge-command")
         assert command[bridge_index + 1] == "python bridge.py", command
+        assert "--goal-active-timeout-sec" in command, command
+        assert (
+            command[command.index("--goal-active-timeout-sec") + 1]
+            == command[command.index("--first-action-timeout-sec") + 1]
+        ), command
 
         proxy_url = "http://127.0.0.1:18182"
         args_with_proxy = parse_args(
@@ -522,10 +527,14 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
     from loopx.benchmark_adapters.skillsbench_codex_goal_recovery import (
         CODEX_CLI_GOAL_POST_BRIDGE_CLOSEOUT_PROMPT,
         POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT,
+        PRE_BRIDGE_RECOVERY_ATTEMPT_LIMIT,
         codex_cli_tui_post_bridge_blocker_stage,
         codex_cli_tui_post_bridge_closeout_recovery_action,
         codex_cli_tui_post_bridge_recovery_action,
         codex_cli_tui_post_bridge_recovery_skip_reason,
+        codex_cli_tui_pre_bridge_blocker_stage,
+        codex_cli_tui_pre_bridge_recovery_action,
+        codex_cli_tui_pre_bridge_recovery_skip_reason,
     )
     from scripts.skillsbench_automation_loop import (
         _merge_host_local_acp_relay_trace_summary,
@@ -533,8 +542,45 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
     )
 
     assert POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT == 4
+    assert PRE_BRIDGE_RECOVERY_ATTEMPT_LIMIT == 2
     assert "Close out the active SkillsBench goal" in (
         CODEX_CLI_GOAL_POST_BRIDGE_CLOSEOUT_PROMPT
+    )
+    assert (
+        codex_cli_tui_pre_bridge_blocker_stage(
+            "request timed out while waiting for model\n› ",
+            prompt_visible=True,
+        )
+        == "pre_bridge_tui_model_timeout"
+    )
+    assert (
+        codex_cli_tui_pre_bridge_recovery_action(
+            "request timed out while waiting for model\npress enter to retry\n› ",
+            stage="pre_bridge_tui_model_timeout",
+        )
+        == "press_enter"
+    )
+    assert (
+        codex_cli_tui_pre_bridge_recovery_action(
+            "request timed out while waiting for model\n› ",
+            stage="pre_bridge_tui_model_timeout",
+        )
+        == "typed_goal_resubmit"
+    )
+    assert (
+        codex_cli_tui_pre_bridge_recovery_skip_reason(
+            "rate limit reached\npress enter to retry\n› ",
+            stage="pre_bridge_tui_rate_limit",
+            recovery_action="",
+        )
+        == "rate_limit_no_retry"
+    )
+    assert (
+        codex_cli_tui_pre_bridge_blocker_stage(
+            "request timed out while waiting for model\n",
+            prompt_visible=False,
+        )
+        == ""
     )
     assert (
         codex_cli_tui_post_bridge_blocker_stage(
@@ -822,6 +868,48 @@ def _assert_cli_goal_active_timeout_is_public_countability_stage() -> None:
     contract = compact["codex_cli_goal_countability_contract"]
     assert contract["goal_stage"] == "goal_active_timeout", contract
     assert contract["raw_material_recorded"] is False, contract
+
+    with tempfile.TemporaryDirectory() as temp:
+        trace_dir = Path(temp) / "trace"
+        relay = SkillsBenchLocalAcpRelay(
+            CodexExecConfig(worker_public_trace_dir=str(trace_dir))
+        )
+        relay._publish_codex_cli_goal_trace(
+            ok=False,
+            stage="pre_bridge_tui_model_timeout",
+            goal_active_observed=False,
+            goal_terminal_observed=False,
+            first_action_observed=False,
+            bridge_summary_path=None,
+            post_bridge_recovery_attempt_count=2,
+            post_bridge_recovery_action="typed_goal_resubmit",
+            post_bridge_recovery_skip_reason="retry_limit_reached",
+        )
+        plan = {
+            "route": CODEX_CLI_GOAL_BASELINE_ROUTE,
+            "host_local_acp_relay_trace_dir": str(trace_dir),
+            "runner_prerequisites": {},
+        }
+        trace = {}
+        _merge_host_local_acp_relay_trace_summary(plan, trace)
+
+    compact = {
+        "route": CODEX_CLI_GOAL_BASELINE_ROUTE,
+        "official_score_status": "completed",
+        "interaction_counters": trace,
+        "runner_prerequisites": plan["runner_prerequisites"],
+        "failure_attribution_labels": ["official_score_zero_case_failure"],
+    }
+    assert _apply_codex_cli_goal_countability_guard_attribution(compact) is True
+    assert compact["score_failure_attribution"] == (
+        "skillsbench_codex_cli_goal_uncountable_pre_bridge_model_timeout"
+    )
+    assert (
+        trace["codex_cli_goal_tui_post_bridge_recovery_action"]
+        == "typed_goal_resubmit"
+    )
+    contract = compact["codex_cli_goal_countability_contract"]
+    assert contract["goal_stage"] == "pre_bridge_tui_model_timeout", contract
 
     with tempfile.TemporaryDirectory() as temp:
         trace_dir = Path(temp) / "trace"

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -35,10 +35,14 @@ from loopx.benchmark_adapters.skillsbench_codex_goal_recovery import (
     CODEX_CLI_GOAL_POST_BRIDGE_CLOSEOUT_PROMPT,
     CODEX_CLI_GOAL_POST_BRIDGE_CONTINUE_PROMPT,
     POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT,
+    PRE_BRIDGE_RECOVERY_ATTEMPT_LIMIT,
     codex_cli_tui_post_bridge_blocker_stage,
     codex_cli_tui_post_bridge_closeout_recovery_action,
     codex_cli_tui_post_bridge_recovery_action,
     codex_cli_tui_post_bridge_recovery_skip_reason,
+    codex_cli_tui_pre_bridge_blocker_stage,
+    codex_cli_tui_pre_bridge_recovery_action,
+    codex_cli_tui_pre_bridge_recovery_skip_reason,
 )
 from loopx.codex_cli_goal_tui import (
     CODEX_CLI_GOAL_TASK_PROMPT_FILENAME,
@@ -1203,6 +1207,9 @@ class SkillsBenchLocalAcpRelay:
             last_bridge_summary_size = 0
             last_bridge_activity_at = time.monotonic()
             meaningful_progress_seen = False
+            pre_bridge_recovery_attempt_count = 0
+            pre_bridge_recovery_action = ""
+            pre_bridge_recovery_skip_reason = ""
             post_bridge_recovery_attempt_count = 0
             post_bridge_recovery_action = ""
             post_bridge_recovery_skip_reason = ""
@@ -1281,9 +1288,13 @@ class SkillsBenchLocalAcpRelay:
                     and self._config.goal_active_timeout_sec > 0
                     and _prompt_requires_bridge_first_action(prompt_for_codex)
                 ):
+                    goal_active_timeout_sec = max(
+                        1.0,
+                        float(self._config.goal_active_timeout_sec or 0.0),
+                        float(self._config.first_action_timeout_sec or 0.0),
+                    )
                     goal_active_deadline = (
-                        time.monotonic()
-                        + max(1.0, self._config.goal_active_timeout_sec)
+                        time.monotonic() + goal_active_timeout_sec
                     )
                 first_action_deadline = 0.0
                 if (
@@ -1357,6 +1368,103 @@ class SkillsBenchLocalAcpRelay:
                         return _recoverable_codex_turn_failure_message(
                             "codex_cli_goal_" + retryable_startup_blocker_stage
                         )
+                    pre_bridge_blocker_stage = ""
+                    if (
+                        bridge_summary_path is not None
+                        and not goal_active_observed
+                        and not first_action_seen
+                    ):
+                        pre_bridge_blocker_stage = (
+                            codex_cli_tui_pre_bridge_blocker_stage(
+                                capture,
+                                prompt_visible=(
+                                    codex_cli_tui_input_prompt_visible(capture)
+                                ),
+                            )
+                        )
+                    if pre_bridge_blocker_stage:
+                        recovery_action = codex_cli_tui_pre_bridge_recovery_action(
+                            capture,
+                            stage=pre_bridge_blocker_stage,
+                        )
+                        if recovery_action in {
+                            "press_enter",
+                            "typed_goal_resubmit",
+                        } and (
+                            pre_bridge_recovery_attempt_count
+                            < PRE_BRIDGE_RECOVERY_ATTEMPT_LIMIT
+                        ):
+                            pre_bridge_recovery_attempt_count += 1
+                            pre_bridge_recovery_action = recovery_action
+                            if recovery_action == "press_enter":
+                                tmux_submit_enter(tmux_name)
+                            else:
+                                tmux_type_text_and_submit(
+                                    tmux_name=tmux_name,
+                                    text=goal_command_text,
+                                )
+                            first_action_timeout_sec = max(
+                                1.0,
+                                float(self._config.first_action_timeout_sec or 0.0),
+                            )
+                            if goal_active_deadline:
+                                goal_active_deadline = now + max(
+                                    1.0,
+                                    float(self._config.goal_active_timeout_sec or 0.0),
+                                    first_action_timeout_sec,
+                                )
+                            if first_action_deadline:
+                                first_action_deadline = now + first_action_timeout_sec
+                            if meaningful_progress_deadline:
+                                meaningful_progress_deadline = now + max(
+                                    1.0,
+                                    first_action_timeout_sec,
+                                )
+                            if recovery_action == "typed_goal_resubmit":
+                                next_heartbeat = now + max(
+                                    1.0,
+                                    self._config.stream_heartbeat_interval_sec,
+                                )
+                            else:
+                                time.sleep(1.0)
+                            continue
+                        pre_bridge_recovery_skip_reason = (
+                            codex_cli_tui_pre_bridge_recovery_skip_reason(
+                                capture,
+                                stage=pre_bridge_blocker_stage,
+                                recovery_action=recovery_action,
+                            )
+                        )
+                        if (
+                            not pre_bridge_recovery_skip_reason
+                            and recovery_action
+                            in {"press_enter", "typed_goal_resubmit"}
+                        ):
+                            pre_bridge_recovery_skip_reason = "retry_limit_reached"
+                        tmux_kill_session(tmux_name)
+                        if bridge_summary_path is not None:
+                            self._publish_remote_bridge_agent_operations_trace(
+                                bridge_summary_path=bridge_summary_path,
+                            )
+                        self._publish_codex_cli_goal_trace(
+                            ok=False,
+                            stage=pre_bridge_blocker_stage,
+                            goal_active_observed=goal_active_observed,
+                            goal_terminal_observed=goal_terminal_observed,
+                            first_action_observed=first_action_seen,
+                            bridge_summary_path=bridge_summary_path,
+                            thread_prewarm_observed=thread_prewarm_observed,
+                            goal_prompt_file_used=goal_prompt_file_used,
+                            goal_command_submission_method=(
+                                goal_command_submission_method
+                            ),
+                            post_bridge_recovery_attempt_count=pre_bridge_recovery_attempt_count,
+                            post_bridge_recovery_action=pre_bridge_recovery_action,
+                            post_bridge_recovery_skip_reason=pre_bridge_recovery_skip_reason,
+                        )
+                        return _recoverable_codex_turn_failure_message(
+                            "codex_cli_goal_" + pre_bridge_blocker_stage
+                        )
                     if (
                         not goal_active_observed
                         and not first_action_seen
@@ -1380,6 +1488,9 @@ class SkillsBenchLocalAcpRelay:
                             goal_command_submission_method=(
                                 goal_command_submission_method
                             ),
+                            post_bridge_recovery_attempt_count=pre_bridge_recovery_attempt_count,
+                            post_bridge_recovery_action=pre_bridge_recovery_action,
+                            post_bridge_recovery_skip_reason=pre_bridge_recovery_skip_reason,
                         )
                         return _recoverable_codex_turn_failure_message(
                             "codex_cli_goal_goal_active_timeout"
@@ -1555,11 +1666,16 @@ class SkillsBenchLocalAcpRelay:
                                 goal_command_submission_method
                             ),
                             post_bridge_recovery_attempt_count=(
-                                post_bridge_recovery_attempt_count
+                                pre_bridge_recovery_attempt_count
+                                + post_bridge_recovery_attempt_count
                             ),
-                            post_bridge_recovery_action=post_bridge_recovery_action,
+                            post_bridge_recovery_action=(
+                                post_bridge_recovery_action
+                                or pre_bridge_recovery_action
+                            ),
                             post_bridge_recovery_skip_reason=(
                                 post_bridge_recovery_skip_reason
+                                or pre_bridge_recovery_skip_reason
                             ),
                         )
                         return _recoverable_codex_turn_failure_message(
@@ -1591,11 +1707,16 @@ class SkillsBenchLocalAcpRelay:
                                 goal_command_submission_method
                             ),
                             post_bridge_recovery_attempt_count=(
-                                post_bridge_recovery_attempt_count
+                                pre_bridge_recovery_attempt_count
+                                + post_bridge_recovery_attempt_count
                             ),
-                            post_bridge_recovery_action=post_bridge_recovery_action,
+                            post_bridge_recovery_action=(
+                                post_bridge_recovery_action
+                                or pre_bridge_recovery_action
+                            ),
                             post_bridge_recovery_skip_reason=(
                                 post_bridge_recovery_skip_reason
+                                or pre_bridge_recovery_skip_reason
                             ),
                         )
                         return _recoverable_codex_turn_failure_message(
@@ -1632,9 +1753,17 @@ class SkillsBenchLocalAcpRelay:
                     thread_prewarm_observed=thread_prewarm_observed,
                     goal_prompt_file_used=goal_prompt_file_used,
                     goal_command_submission_method=goal_command_submission_method,
-                    post_bridge_recovery_attempt_count=post_bridge_recovery_attempt_count,
-                    post_bridge_recovery_action=post_bridge_recovery_action,
-                    post_bridge_recovery_skip_reason=post_bridge_recovery_skip_reason,
+                    post_bridge_recovery_attempt_count=(
+                        pre_bridge_recovery_attempt_count
+                        + post_bridge_recovery_attempt_count
+                    ),
+                    post_bridge_recovery_action=(
+                        post_bridge_recovery_action or pre_bridge_recovery_action
+                    ),
+                    post_bridge_recovery_skip_reason=(
+                        post_bridge_recovery_skip_reason
+                        or pre_bridge_recovery_skip_reason
+                    ),
                 )
                 if goal_terminal_observed and not goal_failed_observed:
                     return "codex cli /goal completed"

--- a/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
+++ b/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from loopx.codex_cli_goal_tui import codex_cli_tui_input_prompt_visible
 
 
+PRE_BRIDGE_RECOVERY_ATTEMPT_LIMIT = 2
 CODEX_CLI_GOAL_POST_BRIDGE_CONTINUE_PROMPT = (
     "Continue the active SkillsBench goal after the transient model timeout. "
     "If ./skillsbench-task-prompt.md exists, read it before acting. Use the "
@@ -18,6 +19,95 @@ CODEX_CLI_GOAL_POST_BRIDGE_CLOSEOUT_PROMPT = (
 POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT = 4
 
 
+def _capture_has_rate_limit(capture: str) -> bool:
+    lowered = str(capture or "").lower()
+    return any(
+        marker in lowered
+        for marker in (
+            "rate limit",
+            "rate_limit",
+            "too many requests",
+            "status 429",
+            "error 429",
+        )
+    )
+
+
+def _capture_has_model_timeout(capture: str) -> bool:
+    lowered = str(capture or "").lower()
+    return any(marker in lowered for marker in ("timed out", "timeout")) and any(
+        marker in lowered for marker in ("model", "request", "error", "failed")
+    )
+
+
+def _capture_has_retry_affordance(capture: str) -> bool:
+    lowered = str(capture or "").lower()
+    return any(marker in lowered for marker in ("press enter", "press return"))
+
+
+def codex_cli_tui_pre_bridge_blocker_stage(
+    capture: str,
+    *,
+    prompt_visible: bool,
+) -> str:
+    """Classify public-safe Codex CLI TUI blockers before bridge activity."""
+
+    if not prompt_visible:
+        return ""
+    if _capture_has_rate_limit(capture):
+        return "pre_bridge_tui_rate_limit"
+    if _capture_has_model_timeout(capture):
+        return "pre_bridge_tui_model_timeout"
+    lowered = str(capture or "").lower()
+    if _capture_has_retry_affordance(capture) and any(
+        marker in lowered
+        for marker in ("error", "failed", "timed out", "timeout", "model")
+    ):
+        return "pre_bridge_tui_error_prompt"
+    return ""
+
+
+def codex_cli_tui_pre_bridge_recovery_action(capture: str, *, stage: str) -> str:
+    """Return a bounded recovery action before the first bridge request."""
+
+    if stage not in {
+        "pre_bridge_tui_model_timeout",
+        "pre_bridge_tui_error_prompt",
+    }:
+        return ""
+    if _capture_has_retry_affordance(capture):
+        return "press_enter"
+    if stage == "pre_bridge_tui_model_timeout" and codex_cli_tui_input_prompt_visible(
+        capture
+    ):
+        return "typed_goal_resubmit"
+    return ""
+
+
+def codex_cli_tui_pre_bridge_recovery_skip_reason(
+    capture: str,
+    *,
+    stage: str,
+    recovery_action: str,
+) -> str:
+    """Return why no pre-bridge recovery action was taken."""
+
+    if recovery_action:
+        return ""
+    if stage == "pre_bridge_tui_rate_limit":
+        return "rate_limit_no_retry"
+    if stage not in {
+        "pre_bridge_tui_model_timeout",
+        "pre_bridge_tui_error_prompt",
+    }:
+        return ""
+    if not _capture_has_retry_affordance(capture) and not codex_cli_tui_input_prompt_visible(
+        capture
+    ):
+        return "no_retry_affordance"
+    return "unsupported_recovery_action"
+
+
 def codex_cli_tui_post_bridge_blocker_stage(
     capture: str,
     *,
@@ -27,23 +117,12 @@ def codex_cli_tui_post_bridge_blocker_stage(
 
     if not prompt_visible:
         return ""
-    lowered = str(capture or "").lower()
-    if any(
-        marker in lowered
-        for marker in (
-            "rate limit",
-            "rate_limit",
-            "too many requests",
-            "status 429",
-            "error 429",
-        )
-    ):
+    if _capture_has_rate_limit(capture):
         return "post_bridge_tui_rate_limit"
-    if any(marker in lowered for marker in ("timed out", "timeout")) and any(
-        marker in lowered for marker in ("model", "request", "error", "failed")
-    ):
+    if _capture_has_model_timeout(capture):
         return "post_bridge_tui_model_timeout"
-    if any(marker in lowered for marker in ("press enter", "press return")) and any(
+    lowered = str(capture or "").lower()
+    if _capture_has_retry_affordance(capture) and any(
         marker in lowered
         for marker in ("error", "failed", "timed out", "timeout", "model")
     ):
@@ -59,8 +138,7 @@ def codex_cli_tui_post_bridge_recovery_action(capture: str, *, stage: str) -> st
         "post_bridge_tui_error_prompt",
     }:
         return ""
-    lowered = str(capture or "").lower()
-    if any(marker in lowered for marker in ("press enter", "press return")):
+    if _capture_has_retry_affordance(capture):
         return "press_enter"
     if (
         stage == "post_bridge_tui_model_timeout"
@@ -87,8 +165,7 @@ def codex_cli_tui_post_bridge_recovery_skip_reason(
         "post_bridge_tui_error_prompt",
     }:
         return ""
-    lowered = str(capture or "").lower()
-    if not any(marker in lowered for marker in ("press enter", "press return")):
+    if not _capture_has_retry_affordance(capture):
         return "no_retry_affordance"
     return "unsupported_recovery_action"
 

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -990,6 +990,8 @@ def _host_local_acp_launch_command(
             str(_effective_local_codex_exec_timeout_sec(args)),
             "--first-action-timeout-sec",
             str(_effective_local_codex_first_action_timeout_sec(args)),
+            "--goal-active-timeout-sec",
+            str(_effective_local_codex_goal_active_timeout_sec(args)),
             "--bridge-idle-timeout-sec",
             str(_effective_local_codex_bridge_idle_timeout_sec(args)),
             "--task-output-quiet-timeout-sec",
@@ -1193,6 +1195,18 @@ def _effective_local_codex_first_action_timeout_sec(args: argparse.Namespace) ->
         if idle_timeout > 0:
             return min(idle_timeout, DEFAULT_APP_SERVER_GOAL_FIRST_ACTION_TIMEOUT_SEC)
         return DEFAULT_APP_SERVER_GOAL_FIRST_ACTION_TIMEOUT_SEC
+    return 0
+
+
+def _effective_local_codex_goal_active_timeout_sec(args: argparse.Namespace) -> int:
+    configured = getattr(args, "local_codex_goal_active_timeout_sec", None)
+    if configured is not None:
+        return max(0, int(configured or 0))
+    if (
+        bool(getattr(args, "host_local_acp_launch", False))
+        and getattr(args, "route", "") == CODEX_CLI_GOAL_BASELINE_ROUTE
+    ):
+        return _effective_local_codex_first_action_timeout_sec(args)
     return 0
 
 
@@ -4919,6 +4933,12 @@ def _apply_codex_cli_goal_countability_guard_attribution(
     label = "skillsbench_codex_cli_goal_uncountable_no_task_activity"
     if goal_stage == "goal_active_timeout":
         label = "skillsbench_codex_cli_goal_uncountable_goal_active_timeout"
+    elif goal_stage == "pre_bridge_tui_model_timeout":
+        label = "skillsbench_codex_cli_goal_uncountable_pre_bridge_model_timeout"
+    elif goal_stage == "pre_bridge_tui_error_prompt":
+        label = "skillsbench_codex_cli_goal_uncountable_pre_bridge_tui_error"
+    elif goal_stage == "pre_bridge_tui_rate_limit":
+        label = "skillsbench_codex_cli_goal_uncountable_pre_bridge_rate_limit"
     if goal_failed and not missing_task_activity:
         label = "skillsbench_codex_cli_goal_uncountable_goal_failed"
     compact["score_failure_attribution"] = label
@@ -16092,6 +16112,17 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "codex-cli-goal-baseline, or the app-server Goal default "
             f"({DEFAULT_APP_SERVER_GOAL_FIRST_ACTION_TIMEOUT_SEC}s) for "
             "codex-app-server-goal-baseline; 0 disables the watchdog."
+        ),
+    )
+    parser.add_argument(
+        "--local-codex-goal-active-timeout-sec",
+        type=int,
+        default=None,
+        help=(
+            "Optional watchdog for observing Codex CLI /goal active state before "
+            "the first sandbox bridge operation. Omit to match the "
+            "codex-cli-goal-baseline first-action watchdog; 0 disables this "
+            "startup watchdog."
         ),
     )
     parser.add_argument(

--- a/scripts/skillsbench_local_acp_relay.py
+++ b/scripts/skillsbench_local_acp_relay.py
@@ -124,6 +124,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--goal-active-timeout-sec",
+        type=float,
+        default=CodexExecConfig.goal_active_timeout_sec,
+        help=(
+            "Optional timeout for observing Codex CLI /goal active state before "
+            "the first sandbox bridge operation. 0 disables the startup watchdog."
+        ),
+    )
+    parser.add_argument(
         "--app-server-goal-followup-max",
         type=int,
         default=0,
@@ -242,6 +251,7 @@ def main(argv: list[str] | None = None) -> int:
             worker_script=args.worker_script,
             stream_heartbeat_interval_sec=args.stream_heartbeat_interval_sec,
             first_action_timeout_sec=args.first_action_timeout_sec,
+            goal_active_timeout_sec=args.goal_active_timeout_sec,
             app_server_goal_followup_max=args.app_server_goal_followup_max,
             app_server_goal_prompt_style=args.app_server_goal_prompt_style,
             bridge_idle_timeout_sec=args.bridge_idle_timeout_sec,


### PR DESCRIPTION
## Summary
- Align codex-cli-goal /goal active startup watchdog with the first-action watchdog for host-local runs.
- Add bounded pre-bridge TUI recovery for model timeout/error prompts before the first sandbox bridge action.
- Attribute pre-bridge TUI blockers separately in compact countability, and cover the path with durable smokes.
- Raise the two touched legacy line-budget pins to the current count while retaining their existing retirement plans.

## Validation
- python3 examples/skillsbench-codex-cli-goal-route-smoke.py
- python3 examples/skillsbench-cli-goal-first-action-timeout-smoke.py
- python3 examples/skillsbench-host-local-launch-plan-smoke.py
- python3 examples/control_plane/repo-python-line-budget-smoke.py
- python3 -m py_compile examples/control_plane/repo-python-line-budget-smoke.py loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py loopx/benchmark_adapters/skillsbench_acp_relay.py scripts/skillsbench_local_acp_relay.py scripts/skillsbench_automation_loop.py examples/skillsbench-cli-goal-first-action-timeout-smoke.py examples/skillsbench-codex-cli-goal-route-smoke.py
- loopx canary premerge --from-git-diff: direct checks/catalog canaries/public boundary passed; benchmark_sensitive manual hold remains and is covered by owner authorization for benchmark helper/runtime self-merge.

## Boundary
No raw benchmark trajectories, raw TUI capture, private auth, credentials, or local private evidence are committed.