### PR TITLE
Add live agent management status projection

### DIFF
--- a/apps/dashboard/src/data/status.ts
+++ b/apps/dashboard/src/data/status.ts
@@ -108,6 +108,54 @@ export const todoIndexSchema = z.object({
   items: z.array(todoIndexItemSchema).optional().default([]),
 });
 
+export const agentManagementTodoRowSchema = z.object({
+  schema_version: z.string().optional().nullable(),
+  todo_id: z.string().optional().nullable(),
+  goal_id: z.string().optional().nullable(),
+  role: z.string().optional().nullable(),
+  status: z.string().optional().nullable(),
+  priority: z.string().optional().nullable(),
+  title: z.string().optional().nullable(),
+  task_class: z.string().optional().nullable(),
+  action_kind: z.string().optional().nullable(),
+  claimed_by: z.string().optional().nullable(),
+}).passthrough();
+
+export const agentManagementRowSchema = z.object({
+  agent_id: z.string(),
+  role: z.string().optional().nullable(),
+  state: z.string().optional().nullable(),
+  current_todo: agentManagementTodoRowSchema.optional().nullable(),
+  next_action: z.string().optional().nullable(),
+  last_activity_at: z.string().optional().nullable(),
+  evidence_refs: z.array(z.string()).optional().default([]),
+  handoff_refs: z.array(z.string()).optional().default([]),
+  goal_ids: z.array(z.string()).optional().default([]),
+}).passthrough();
+
+export const agentManagementProjectionSchema = z.object({
+  schema_version: z.string().optional().nullable(),
+  mode: z.string().optional().nullable(),
+  goal_id: z.string().optional().nullable(),
+  generated_at: z.string().optional().nullable(),
+  style_hint: z.object({
+    preferred: z.string().optional().nullable(),
+    license_boundary: z.string().optional().nullable(),
+  }).optional().nullable(),
+  truth_contract: z.object({
+    todo_is_runtime_work_item: z.boolean().optional().default(true),
+    projection_is_writable: z.boolean().optional().default(false),
+    introduces_task_runtime: z.boolean().optional().default(false),
+    write_api: z.boolean().optional().default(false),
+  }).optional().nullable(),
+  source_summary: z.object({
+    registered_agent_count: z.number().optional().default(0),
+    projected_agent_count: z.number().optional().default(0),
+    todo_source: z.string().optional().nullable(),
+  }).optional().nullable(),
+  agents: z.array(agentManagementRowSchema).optional().default([]),
+}).passthrough();
+
 export const projectAssetTodoSummarySchema = z.object({
   source_section: z.string().optional().nullable(),
   open: z.number().optional().default(0),
@@ -675,6 +723,7 @@ export const statusPayloadSchema = z.object({
   decision_freshness_summary: decisionFreshnessSummarySchema.default(null),
   usage_summary: usageSummarySchema.default(null),
   todo_index: todoIndexSchema.optional().nullable().default(null),
+  agent_management_projection: agentManagementProjectionSchema.optional().nullable().default(null),
 });
 
 export const rewardDryRunResponseSchema = z.object({
@@ -721,6 +770,7 @@ export type TodoGroup = z.infer<typeof todoGroupSchema>;
 export type TodoItem = z.infer<typeof todoItemSchema>;
 export type TodoIndexItem = z.infer<typeof todoIndexItemSchema>;
 export type TodoIndexSummary = z.infer<typeof todoIndexSchema>;
+export type AgentManagementProjection = z.infer<typeof agentManagementProjectionSchema>;
 export type ReviewMaterial = z.infer<typeof reviewMaterialSchema>;
 export type ProjectMap = z.infer<typeof projectMapSchema>;
 export type GlobalRegistryHealth = z.infer<typeof globalRegistryHealthSchema>;

--- a/docs/reference/protocols/agent-management-projection-v0.md
+++ b/docs/reference/protocols/agent-management-projection-v0.md
@@ -38,6 +38,10 @@ The projection is stale after any lifecycle event until recomputed. Consumers
 must tolerate missing fields and fall back to existing status/review-packet
 payloads.
 
+When available, `loopx status --format json` exposes this view at the top-level
+`agent_management_projection` key. Consumers should still treat the key as
+optional so older status producers and cached snapshots remain readable.
+
 ## Non-Goals
 
 This contract intentionally does not add:

--- a/examples/control_plane/agent-management-live-status-smoke.py
+++ b/examples/control_plane/agent-management-live-status-smoke.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Smoke-test the live status agent management projection."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.agents.management_projection import (  # noqa: E402
+    AGENT_MANAGEMENT_PROJECTION_SCHEMA_VERSION,
+    AGENT_MANAGEMENT_MODE,
+    TODO_ROW_SCHEMA_VERSION,
+    build_agent_management_projection,
+)
+
+
+FORBIDDEN_ACTION_KEYS = {
+    "task_id",
+    "action_url",
+    "claim_url",
+    "dispatch_url",
+    "reclaim_url",
+    "cancel_url",
+    "unblock_url",
+    "write_command",
+    "delete_command",
+    "archive_command",
+    "merge_command",
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Validate that agent_management_projection_v0 is available from "
+            "status as a read-only view over existing todos/evidence/handoffs."
+        )
+    )
+    parser.add_argument(
+        "--goal-id",
+        help="Optional live goal id. When omitted, only the synthetic fixture is checked.",
+    )
+    parser.add_argument("--agent-id", help="Expected agent row in the live status projection.")
+    parser.add_argument(
+        "--registry",
+        default=str(Path.home() / ".codex" / "loopx" / "registry.global.json"),
+        help="LoopX registry path. Defaults to the shared global registry.",
+    )
+    parser.add_argument("--runtime-root", help="Optional LoopX runtime root.")
+    return parser.parse_args()
+
+
+def assert_no_write_action_keys(value: Any, *, path: str = "$") -> None:
+    if isinstance(value, dict):
+        for key, child in value.items():
+            child_path = f"{path}.{key}"
+            if key in FORBIDDEN_ACTION_KEYS:
+                raise AssertionError(f"projection exposed writable action key {child_path}")
+            if key == "write_api" and child is not False:
+                raise AssertionError(f"projection write_api must be false at {child_path}")
+            assert_no_write_action_keys(child, path=child_path)
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            assert_no_write_action_keys(child, path=f"{path}[{index}]")
+
+
+def assert_projection_shape(
+    projection: dict[str, Any],
+    *,
+    expected_agent_id: str | None = None,
+    require_handoff: bool = False,
+) -> None:
+    assert projection.get("schema_version") == AGENT_MANAGEMENT_PROJECTION_SCHEMA_VERSION, projection
+    assert projection.get("mode") == AGENT_MANAGEMENT_MODE, projection
+    truth = projection.get("truth_contract") if isinstance(projection.get("truth_contract"), dict) else {}
+    assert truth.get("todo_is_runtime_work_item") is True, truth
+    assert truth.get("projection_is_writable") is False, truth
+    assert truth.get("introduces_task_runtime") is False, truth
+    assert truth.get("write_api") is False, truth
+    assert_no_write_action_keys(projection)
+
+    agents = projection.get("agents") if isinstance(projection.get("agents"), list) else []
+    assert agents, "projection should include at least one agent row"
+    if expected_agent_id:
+        assert any(row.get("agent_id") == expected_agent_id for row in agents if isinstance(row, dict)), agents
+
+    current_rows = [
+        row
+        for row in agents
+        if isinstance(row, dict)
+        and isinstance(row.get("current_todo"), dict)
+        and row["current_todo"].get("todo_id")
+    ]
+    assert current_rows, "projection should include a current_todo with the source todo_id"
+    for row in current_rows:
+        assert row["current_todo"].get("schema_version") == TODO_ROW_SCHEMA_VERSION, row
+
+    if require_handoff:
+        assert any(
+            isinstance(row, dict) and row.get("handoff_refs")
+            for row in agents
+        ), "live projection should carry at least one handoff ref from existing todo/evidence state"
+
+
+def fixture_status_payload() -> dict[str, Any]:
+    return {
+        "goal_filter": "fixture-goal",
+        "run_history": {
+            "goals": [
+                {
+                    "id": "fixture-goal",
+                    "coordination": {
+                        "primary_agent": "agent-main",
+                        "registered_agents": ["agent-main", "agent-reviewer"],
+                    },
+                }
+            ]
+        },
+        "attention_queue": {
+            "items": [
+                {
+                    "goal_id": "fixture-goal",
+                    "agent_todos": {
+                        "items": [
+                            {
+                                "index": 1,
+                                "done": False,
+                                "text": "Review the read-only projection.",
+                                "todo_id": "todo_live_handoff",
+                                "role": "agent",
+                                "status": "open",
+                                "priority": "P1",
+                                "title": "Review the read-only projection.",
+                                "task_class": "advancement_task",
+                                "action_kind": "review_projection",
+                                "claimed_by": "agent-reviewer",
+                                "updated_at": "2026-07-05T00:00:00Z",
+                                "handoff_note": {
+                                    "schema_version": "handoff_note_v0",
+                                    "handoff_id": "handoff_live_handoff",
+                                    "todo_id": "todo_live_handoff",
+                                    "from_agent": "agent-main",
+                                    "to_agent": "agent-reviewer",
+                                    "intent": "review_projection",
+                                    "summary": "Display-only review.",
+                                    "evidence_refs": ["run:fixture-refresh"],
+                                    "suggested_next_action": "Read the display-only row.",
+                                },
+                            }
+                        ]
+                    },
+                }
+            ]
+        },
+        "todo_index": {
+            "items": [
+                {
+                    "goal_id": "fixture-goal",
+                    "index": 2,
+                    "done": False,
+                    "text": "Agent-id fallback row.",
+                    "todo_id": "todo_agent_id_fallback",
+                    "role": "agent",
+                    "status": "open",
+                    "priority": "P2",
+                    "title": "Agent-id fallback row.",
+                    "task_class": "advancement_task",
+                    "action_kind": "agent_id_fallback",
+                    "agent_id": "agent-main",
+                    "latest_event_kind": "todo_update",
+                    "latest_event_at": "2026-07-05T00:01:00Z",
+                }
+            ]
+        },
+    }
+
+
+def assert_synthetic_projection() -> None:
+    projection = build_agent_management_projection(fixture_status_payload())
+    assert_projection_shape(projection, expected_agent_id="agent-reviewer", require_handoff=True)
+    by_agent = {
+        row.get("agent_id"): row
+        for row in projection.get("agents", [])
+        if isinstance(row, dict)
+    }
+    assert by_agent["agent-main"]["role"] == "primary", by_agent
+    assert by_agent["agent-main"]["current_todo"]["todo_id"] == "todo_agent_id_fallback", by_agent
+    assert by_agent["agent-reviewer"]["current_todo"]["todo_id"] == "todo_live_handoff", by_agent
+    assert by_agent["agent-reviewer"]["handoff_refs"] == ["handoff_live_handoff"], by_agent
+    assert "run:fixture-refresh" in by_agent["agent-reviewer"]["evidence_refs"], by_agent
+
+
+def run_loopx_status(args: argparse.Namespace) -> dict[str, Any]:
+    cli = [sys.executable, "-m", "loopx.cli", "--registry", args.registry]
+    if args.runtime_root:
+        cli.extend(["--runtime-root", args.runtime_root])
+    cli.extend(["--format", "json", "status", "--limit", "20"])
+    if args.goal_id:
+        cli.extend(["--goal-id", args.goal_id])
+    if args.agent_id:
+        cli.extend(["--agent-id", args.agent_id])
+    result = subprocess.run(
+        cli,
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return json.loads(result.stdout)
+
+
+def assert_live_projection(args: argparse.Namespace) -> dict[str, Any]:
+    payload = run_loopx_status(args)
+    assert payload.get("ok") is True, payload
+    projection = payload.get("agent_management_projection")
+    assert isinstance(projection, dict), "status should expose agent_management_projection"
+    assert_projection_shape(
+        projection,
+        expected_agent_id=args.agent_id,
+        require_handoff=False,
+    )
+    if args.agent_id:
+        expected = next(
+            (
+                row
+                for row in projection.get("agents", [])
+                if isinstance(row, dict) and row.get("agent_id") == args.agent_id
+            ),
+            {},
+        )
+        assert isinstance(expected.get("current_todo"), dict), expected
+        assert expected["current_todo"].get("todo_id"), expected
+    return {
+        "goal_id": args.goal_id,
+        "agent_id": args.agent_id,
+        "agent_rows": len(projection.get("agents") or []),
+        "current_todo_rows": sum(
+            1
+            for row in projection.get("agents", [])
+            if isinstance(row, dict) and isinstance(row.get("current_todo"), dict)
+        ),
+        "handoff_rows": sum(
+            1
+            for row in projection.get("agents", [])
+            if isinstance(row, dict) and row.get("handoff_refs")
+        ),
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    assert_synthetic_projection()
+    result: dict[str, Any] = {"synthetic": "ok"}
+    if args.goal_id:
+        result["live"] = assert_live_projection(args)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/control_plane/agent-management-projection-contract-smoke.py
+++ b/examples/control_plane/agent-management-projection-contract-smoke.py
@@ -55,6 +55,7 @@ def main() -> int:
         "reuse_public_compatible_code_only",
         "copied code keeps required attribution or notice text",
         "dashboard consumers remain functional when the projection is absent",
+        "top-level\n`agent_management_projection` key",
     ]:
         assert_contains(contract, needle, "contract")
 

--- a/loopx/control_plane/agents/management_projection.py
+++ b/loopx/control_plane/agents/management_projection.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, Iterable
+
+from ..runtime.public_safety import public_safe_compact_text
+from ..todos.contract import normalize_todo_claimed_by, normalize_todo_id
+
+
+AGENT_MANAGEMENT_PROJECTION_SCHEMA_VERSION = "agent_management_projection_v0"
+TODO_ROW_SCHEMA_VERSION = "todo_row_v0"
+AGENT_MANAGEMENT_MODE = "read_only"
+MAX_AGENT_ROWS = 24
+MAX_AGENT_TODOS = 8
+MAX_REFS = 1
+
+_PRIORITY_RANK = {
+    "P0": 0,
+    "P0-LOCAL": 0,
+    "P0-USER": 0,
+    "P0-DECISION": 0,
+    "P1": 1,
+    "P2": 2,
+}
+def _compact(value: Any, *, limit: int = 220) -> str | None:
+    return public_safe_compact_text(value, limit=limit)
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return list(value) if isinstance(value, list) else []
+
+
+def _todo_status(todo: dict[str, Any]) -> str:
+    status = str(todo.get("status") or "").strip().lower()
+    if status:
+        return status
+    return "done" if todo.get("done") else "open"
+
+
+def _is_done(todo: dict[str, Any]) -> bool:
+    return bool(todo.get("done")) or _todo_status(todo) in {"done", "archive", "archived"}
+
+
+def _priority_rank(todo: dict[str, Any]) -> int:
+    return _PRIORITY_RANK.get(str(todo.get("priority") or "").strip().upper(), 9)
+
+
+def _index_rank(todo: dict[str, Any]) -> int:
+    try:
+        return int(todo.get("index"))
+    except (TypeError, ValueError):
+        return 999_999
+
+
+def _todo_sort_key(todo: dict[str, Any]) -> tuple[int, int, int, str]:
+    done_rank = 1 if _is_done(todo) else 0
+    return (done_rank, _priority_rank(todo), _index_rank(todo), str(todo.get("todo_id") or ""))
+
+
+def _registered_agents(status_payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    rows: dict[str, dict[str, Any]] = {}
+    run_history = _as_dict(status_payload.get("run_history"))
+    for goal in _as_list(run_history.get("goals")):
+        if not isinstance(goal, dict):
+            continue
+        goal_id = _compact(goal.get("id"), limit=180)
+        coordination = _as_dict(goal.get("coordination"))
+        primary = normalize_todo_claimed_by(coordination.get("primary_agent"))
+        for raw_agent in _as_list(coordination.get("registered_agents")):
+            agent_id = normalize_todo_claimed_by(raw_agent)
+            if not agent_id:
+                continue
+            row = rows.setdefault(
+                agent_id,
+                {
+                    "agent_id": agent_id,
+                    "role": "primary" if agent_id == primary else "side-agent",
+                    "_goal_ids": [],
+                    "_todos": [],
+                },
+            )
+            if goal_id and goal_id not in row["_goal_ids"]:
+                row["_goal_ids"].append(goal_id)
+    return rows
+
+
+def _iter_status_todos(status_payload: dict[str, Any]) -> Iterable[dict[str, Any]]:
+    queue = _as_dict(status_payload.get("attention_queue"))
+    for item in _as_list(queue.get("items")):
+        if not isinstance(item, dict):
+            continue
+        goal_id = _compact(item.get("goal_id"), limit=180)
+        for source_name in ("agent_todos",):
+            group = _as_dict(item.get(source_name))
+            for todo in _as_list(group.get("items")):
+                if isinstance(todo, dict):
+                    row = dict(todo)
+                    row.setdefault("goal_id", goal_id)
+                    row.setdefault("source", f"attention_queue.{source_name}")
+                    yield row
+        project_asset = _as_dict(item.get("project_asset"))
+        group = _as_dict(project_asset.get("agent_todos"))
+        for todo in _as_list(group.get("items")):
+            if isinstance(todo, dict):
+                row = dict(todo)
+                row.setdefault("goal_id", goal_id)
+                row.setdefault("source", "project_asset.agent_todos")
+                yield row
+
+    todo_index = _as_dict(status_payload.get("todo_index"))
+    for todo in _as_list(todo_index.get("items")):
+        if isinstance(todo, dict) and str(todo.get("role") or "") == "agent":
+            row = dict(todo)
+            row.setdefault("source", "todo_index")
+            yield row
+
+
+def _todo_agent_id(todo: dict[str, Any]) -> str | None:
+    return (
+        normalize_todo_claimed_by(todo.get("claimed_by"))
+        or normalize_todo_claimed_by(todo.get("agent_id"))
+    )
+
+
+def _todo_identity(todo: dict[str, Any]) -> tuple[str, str, str, str]:
+    return (
+        str(todo.get("goal_id") or ""),
+        str(todo.get("todo_id") or ""),
+        str(todo.get("index") or ""),
+        str(todo.get("text") or todo.get("title") or ""),
+    )
+
+
+def _todo_row(todo: dict[str, Any]) -> dict[str, Any]:
+    todo_id = normalize_todo_id(todo.get("todo_id"))
+    row: dict[str, Any] = {
+        "schema_version": TODO_ROW_SCHEMA_VERSION,
+        "todo_id": todo_id,
+        "goal_id": _compact(todo.get("goal_id"), limit=180),
+        "role": "agent",
+        "status": _todo_status(todo),
+        "priority": _compact(todo.get("priority"), limit=40),
+        "title": _compact(todo.get("title") or todo.get("text"), limit=96),
+        "task_class": _compact(todo.get("task_class"), limit=80),
+        "action_kind": _compact(todo.get("action_kind"), limit=100),
+        "claimed_by": normalize_todo_claimed_by(todo.get("claimed_by")),
+    }
+    for key in (
+        "required_capabilities",
+        "target_capabilities",
+        "blocks_agent",
+        "unblocks_todo_id",
+        "successor_todo_ids",
+        "resume_when",
+        "updated_at",
+    ):
+        value = todo.get(key)
+        if value not in (None, "", [], {}):
+            row[key] = value
+    return {key: value for key, value in row.items() if value not in (None, "", [], {})}
+
+
+def _refs_from_todo(todo: dict[str, Any]) -> tuple[list[str], list[str]]:
+    evidence_refs: list[str] = []
+    handoff_refs: list[str] = []
+    handoff = _as_dict(todo.get("handoff_note"))
+    handoff_id = _compact(handoff.get("handoff_id"), limit=140)
+    if handoff_id:
+        handoff_refs.append(handoff_id)
+    for raw_ref in _as_list(handoff.get("evidence_refs")):
+        ref = _compact(raw_ref, limit=180)
+        if ref and ref not in evidence_refs:
+            evidence_refs.append(ref)
+    todo_id = normalize_todo_id(todo.get("todo_id"))
+    if todo.get("evidence") and todo_id:
+        evidence_refs.append(f"todo:{todo_id}:evidence")
+    if todo.get("note") and todo_id:
+        evidence_refs.append(f"todo:{todo_id}:note")
+    latest_event_kind = _compact(todo.get("latest_event_kind"), limit=80)
+    if latest_event_kind and todo_id:
+        evidence_refs.append(f"rollout_event:{latest_event_kind}:{todo_id}")
+    for material in _as_list(todo.get("review_materials")):
+        if isinstance(material, dict):
+            ref = _compact(material.get("label") or material.get("path"), limit=180)
+            if ref:
+                evidence_refs.append(ref)
+    return evidence_refs[:MAX_REFS], handoff_refs[:MAX_REFS]
+
+
+def _agent_state(todos: list[dict[str, Any]]) -> str:
+    open_todos = [todo for todo in todos if not _is_done(todo)]
+    if not open_todos:
+        return "waiting" if todos else "unknown"
+    if any(_todo_status(todo) == "blocked" or todo.get("task_class") == "blocker" for todo in open_todos):
+        return "blocked"
+    if any(
+        todo.get("task_class") == "continuous_monitor"
+        or "monitor" in str(todo.get("action_kind") or "").lower()
+        for todo in open_todos
+    ):
+        return "monitoring"
+    return "running"
+
+
+def _last_activity(todos: list[dict[str, Any]]) -> str | None:
+    candidates = [
+        _compact(todo.get("updated_at") or todo.get("latest_event_at"), limit=80)
+        for todo in todos
+    ]
+    return sorted([item for item in candidates if item], reverse=True)[0] if any(candidates) else None
+
+
+def _safe_next_action(todo: dict[str, Any] | None) -> str:
+    if not todo:
+        return "Inspect status projection before taking work."
+    todo_id = normalize_todo_id(todo.get("todo_id"))
+    if todo_id:
+        return f"Continue projected todo {todo_id}."
+    return "Inspect projected todo."
+
+
+def build_agent_management_projection(status_payload: dict[str, Any]) -> dict[str, Any]:
+    """Build a read-only agent management view from a status payload.
+
+    This is a projection over existing LoopX status/todo/history state. It does
+    not allocate tasks, dispatch agents, reclaim stale claims, or expose write
+    actions.
+    """
+
+    rows_by_agent = _registered_agents(status_payload)
+    seen_todos: set[tuple[str, str, str, str]] = set()
+    for todo in _iter_status_todos(status_payload):
+        agent_id = _todo_agent_id(todo)
+        if not agent_id:
+            continue
+        identity = _todo_identity(todo)
+        if identity in seen_todos:
+            continue
+        seen_todos.add(identity)
+        row = rows_by_agent.setdefault(
+            agent_id,
+            {
+                "agent_id": agent_id,
+                "role": "agent",
+                "_goal_ids": [],
+                "_todos": [],
+            },
+        )
+        goal_id = _compact(todo.get("goal_id"), limit=180)
+        if goal_id and goal_id not in row["_goal_ids"]:
+            row["_goal_ids"].append(goal_id)
+        row["_todos"].append(todo)
+
+    agents: list[dict[str, Any]] = []
+    for agent_id, raw_row in sorted(rows_by_agent.items()):
+        todos = sorted(_as_list(raw_row.get("_todos")), key=_todo_sort_key)[:MAX_AGENT_TODOS]
+        current = next((todo for todo in todos if not _is_done(todo)), None)
+        evidence_refs: list[str] = []
+        handoff_refs: list[str] = []
+        for todo in todos:
+            todo_evidence, todo_handoffs = _refs_from_todo(todo)
+            for ref in todo_evidence:
+                if ref not in evidence_refs:
+                    evidence_refs.append(ref)
+            for ref in todo_handoffs:
+                if ref not in handoff_refs:
+                    handoff_refs.append(ref)
+        agent_row: dict[str, Any] = {
+            "agent_id": agent_id,
+            "role": raw_row.get("role") or "agent",
+            "state": _agent_state(todos),
+            "current_todo": _todo_row(current) if current else None,
+            "next_action": _safe_next_action(current),
+            "last_activity_at": _last_activity(todos),
+            "evidence_refs": evidence_refs[:MAX_REFS],
+            "handoff_refs": handoff_refs[:MAX_REFS],
+            "goal_ids": _as_list(raw_row.get("_goal_ids"))[:MAX_REFS],
+        }
+        agents.append(
+            {
+                key: value
+                for key, value in agent_row.items()
+                if value not in (None, "", [], {})
+            }
+        )
+        if len(agents) >= MAX_AGENT_ROWS:
+            break
+
+    goal_filter = _compact(status_payload.get("goal_filter"), limit=180)
+    projection: dict[str, Any] = {
+        "schema_version": AGENT_MANAGEMENT_PROJECTION_SCHEMA_VERSION,
+        "mode": AGENT_MANAGEMENT_MODE,
+        "goal_id": goal_filter,
+        "generated_at": _now_iso(),
+        "truth_contract": {
+            "todo_is_runtime_work_item": True,
+            "projection_is_writable": False,
+            "introduces_task_runtime": False,
+            "write_api": False,
+        },
+        "source_summary": {
+            "registered_agent_count": len(rows_by_agent),
+            "projected_agent_count": len(agents),
+            "todo_source": "status.attention_queue + status.todo_index",
+        },
+        "agents": agents,
+    }
+    return {
+        key: value
+        for key, value in projection.items()
+        if value not in (None, "", [], {})
+    }

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -244,6 +244,9 @@ from .control_plane.agents.subagent_activity import (
     compact_subagent_run,
     subagent_activity_for_goal,
 )
+from .control_plane.agents.management_projection import (
+    build_agent_management_projection as _build_agent_management_projection_read_model,
+)
 from .control_plane.runtime.stale_latest_run import (
     stale_latest_run_projection_warning as _stale_latest_run_projection_warning_read_model,
 )
@@ -7263,7 +7266,7 @@ def collect_status(
         runtime_root=runtime_root,
         limit=max(MAX_TODO_INDEX_ITEMS, display_limit),
     )
-    return {
+    payload = {
         "ok": bool(contract.get("ok")) and bool(global_registry.get("ok", True)),
         "registry": str(registry_path),
         "runtime_root": str(runtime_root),
@@ -7289,6 +7292,10 @@ def collect_status(
         "usage_summary": usage_summary,
         "todo_index": todo_index,
     }
+    agent_management_projection = _build_agent_management_projection_read_model(payload)
+    if agent_management_projection.get("agents"):
+        payload["agent_management_projection"] = agent_management_projection
+    return payload
 
 
 def render_status_markdown(payload: dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary
- Add read-only agent_management_projection_v0 from live status/todo/history state when agent rows are present.
- Teach the dashboard status schema to tolerate the optional projection.
- Add synthetic + live smoke coverage for current agent rows without introducing a runtime task model.

## Validation
- python3 -m py_compile loopx/control_plane/agents/management_projection.py loopx/status.py examples/control_plane/agent-management-live-status-smoke.py
- python3 examples/control_plane/agent-management-projection-contract-smoke.py
- python3 examples/control_plane/agent-management-live-status-smoke.py --goal-id loopx-meta --agent-id codex-value-explorer --registry "/Users/bytedance/.codex/loopx/registry.global.json" --runtime-root "/Users/bytedance/.codex/loopx"
- python3 examples/control_plane/hot-path-interface-budget-smoke.py
- python3 -m loopx.cli check --scan-path loopx/control_plane/agents/management_projection.py --scan-path loopx/status.py --scan-path apps/dashboard/src/data/status.ts --scan-path examples/control_plane/agent-management-live-status-smoke.py --scan-path examples/control_plane/agent-management-projection-contract-smoke.py --scan-path docs/reference/protocols/agent-management-projection-v0.md --limit 10
- python3 -m loopx.cli canary premerge --from-git-diff

## Notes
- Dashboard npm build was skipped locally because this worktree has no installed TypeScript binary (tsc: command not found); this PR only adds a Zod schema extension, and Python/control-plane canaries passed.
- The status hot-path budget remains within limit: dashboard_status_json 18130/18200 chars in the canary.