### PR TITLE
Release LoopX v0.1.10

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -115,6 +115,13 @@ path, and canary route rather than as a user-facing release baseline.
   research panes, wires agent-scoped evidence read hints into replan, and
   hardens successor/frontier recovery when completed advancement has no next
   executable todo.
+- `v0.1.10` on 2026-07-06 11:50 +08:00: scoped user-gate and agent-management
+  release at the matching `v0.1.10` tag. This release makes blocking owner
+  todos explicitly typed as `user_gate` or non-blocking `user_action`, scopes
+  per-agent gates with `blocks_agent`, adds read-only live agent-management
+  status projections, and continues moving quota, todo, scheduler, review
+  packet, and handoff rules into bounded control-plane contexts with focused
+  canary coverage.
 
 When a new public release is promoted, add it here only after the matching tag,
 release note, stable ref, update path, and focused release canary agree.

--- a/examples/control_plane/status-markdown-smoke.py
+++ b/examples/control_plane/status-markdown-smoke.py
@@ -62,7 +62,6 @@ DEPENDENCY_AGENT_TODO = "Continue the gate-independent P1/P2 product-hardening s
 DEPENDENCY_MONITOR_TODO = "Side-bypass dependency monitor: observe public-safe replay transitions only."
 DEPENDENCY_USER_TODO = "Confirm the sibling project evidence gate before its controller resumes delivery."
 
-
 def assert_handoff_budget_contract(readiness: dict, label: str) -> None:
     budget = readiness.get("handoff_interface_budget")
     assert isinstance(budget, dict), (label, readiness)
@@ -87,6 +86,7 @@ def write_planned_registry(root: Path) -> Path:
         "# Planned Main Control\n\n"
         "## User Todo / Owner Review Reading Queue\n\n"
         f"- [ ] {USER_TODO_TEXT}\n"
+        "  <!-- loopx:todo todo_id=todo_planned_user_gate task_class=user_gate global_gate=true -->\n"
         "- [x] Open owner worksheet.\n\n"
         "## Agent Todo\n\n"
         f"- [ ] {AGENT_TODO_TEXT}\n",
@@ -129,7 +129,6 @@ def mark_planned_todos_done(root: Path) -> None:
     state_text = state_text.replace(f"- [ ] {USER_TODO_TEXT}", f"- [x] {USER_TODO_TEXT}")
     state_text = state_text.replace(f"- [ ] {AGENT_TODO_TEXT}", f"- [x] {AGENT_TODO_TEXT}")
     state_path.write_text(state_text, encoding="utf-8")
-
 
 def write_connected_delivery_registry(root: Path) -> Path:
     project = root / "project"
@@ -334,7 +333,8 @@ def write_dependency_blocker_registry(root: Path) -> Path:
         "---\n\n"
         "# Dependency Owner Gate\n\n"
         "## User Todo / Owner Review Reading Queue\n\n"
-        f"- [ ] {DEPENDENCY_USER_TODO}\n",
+        f"- [ ] {DEPENDENCY_USER_TODO}\n"
+        "  <!-- loopx:todo todo_id=todo_dependency_user_gate task_class=user_gate global_gate=true -->\n",
         encoding="utf-8",
     )
     registry_path.parent.mkdir(parents=True, exist_ok=True)
@@ -1823,7 +1823,7 @@ def assert_planned_preview_is_not_runnable(payload: dict, markdown: str) -> None
     assert item["waiting_on"] == "controller", item
     assert item["recommended_action"] == USER_TODO_TEXT, item
     assert item["project_asset"]["owner"] == "controller", item
-    assert item["project_asset"]["gate"] == "active_state_user_todo", item
+    assert item["project_asset"]["gate"] == "active_state_user_gate", item
     assert item["project_asset"]["next_action"] == USER_TODO_TEXT, item
     assert "stop until the controller or owner resolves this gate" in item["project_asset"]["stop_condition"], item
     assert item["project_asset"]["user_todos"]["open"] == 1, item
@@ -1835,7 +1835,7 @@ def assert_planned_preview_is_not_runnable(payload: dict, markdown: str) -> None
     assert OLD_PLANNED_ACTION not in json.dumps(payload, ensure_ascii=False), payload
     assert OLD_PLANNED_ACTION not in markdown, markdown
     assert USER_TODO_TEXT in markdown, markdown
-    assert "project_asset: owner=controller gate=active_state_user_todo" in markdown, markdown
+    assert "project_asset: owner=controller gate=active_state_user_gate" in markdown, markdown
     assert f"asset_next_action: {USER_TODO_TEXT}" in markdown, markdown
     assert "asset_todos: user_open=1 agent_open=1" in markdown, markdown
     assert f"asset_user_todo: {USER_TODO_TEXT}" in markdown, markdown
@@ -1851,7 +1851,7 @@ def assert_planned_preview_is_not_runnable(payload: dict, markdown: str) -> None
         waiting_on="controller",
         expect_operator_question=False,
     )
-    assert quota_payload["status"] == "active_state_user_todo", quota_payload
+    assert quota_payload["status"] == "active_state_user_gate", quota_payload
 
 
 def assert_project_local_status_excludes_runtime_orphans(registry_path: Path) -> None:

--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.9"
+__version__ = "0.1.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.1.9"
+version = "0.1.10"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Release LoopX v0.1.10.

This bumps the package version from 0.1.9 to 0.1.10, records the public release-readiness timeline entry, and updates the status markdown fixture to use the typed `user_gate global_gate=true` contract required by the new user-todo state machine.

## Release Theme

- Scoped user-gate and agent-management release.
- User/owner todos are now explicitly typed as blocking `user_gate` or non-blocking `user_action`.
- Per-agent gates use `blocks_agent`; goal-wide operator gates use `global_gate=true`.
- Agent-management status projections and control-plane bounded-context refactors from v0.1.9..main are promoted into a named release.

## Validation

- `python3 -m py_compile loopx/*.py`
- `python3 examples/release/release-version-contract-smoke.py`
- `python3 examples/release/release-readiness-doc-smoke.py`
- `python3 examples/release/codex-cli-no-clone-release-verification-smoke.py`
- `python3 examples/fresh-clone-quickstart-smoke.py`
- `python3 examples/loopx-update-smoke.py`
- `python3 -m loopx.cli check --scan-path README.md --scan-path docs/ --scan-path examples/`
- `python3 examples/canary/canary-promotion-readiness-smoke.py --no-write-evidence`
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `loopx canary premerge --from-git-diff`

Notes:

- Promotion canary passed with dashboard browser checks skipped because local dashboard npm dependencies were not installed; this is the smoke's supported `--skip-browser` path.
- Public/private scan was clean. The only remaining `loopx check` warning is the pre-existing loopx-meta run-history duplicate-index warning, not introduced by this PR.
- While validating, local private active-state user todos from older goals were migrated to explicit `user_action` or `user_gate` metadata so the new contract does not misclassify stale local state.

## Self-Merge Rationale

This is a narrow release/version PR with focused fixture repair. It does not change benchmark scoring, launch benchmark jobs, alter permission boundaries, or include private/raw benchmark evidence. The premerge gate reports `self_merge_allowed=true`.
