### PR TITLE
test: align user gate readmodel smoke with typed todos

### DIFF
--- a/examples/control_plane/todo-user-gate-readmodel-smoke.py
+++ b/examples/control_plane/todo-user-gate-readmodel-smoke.py
@@ -53,7 +53,7 @@ def raw_todos() -> dict:
                 "index": 3,
                 "todo_id": "todo_next",
                 "text": "Continue non-benchmark control-plane refactor.",
-                "task_class": "advancement_task",
+                "task_class": "user_action",
                 "claimed_by": "codex-product-capability",
             },
         ],
@@ -63,9 +63,29 @@ def raw_todos() -> dict:
 def assert_shared_gate_detection() -> None:
     assert is_user_gate_todo_item(
         {
+            "action_kind": "public_claim_review",
+            "text": "Review the public claim.",
+        }
+    )
+    assert not is_user_gate_todo_item(
+        {
             "task_class": "advancement_task",
             "action_kind": "public_claim_review",
             "text": "Review the public claim.",
+        }
+    )
+    assert is_user_gate_todo_item(
+        {
+            "task_class": "user_gate",
+            "action_kind": "public_claim_review",
+            "text": "Review the public claim.",
+        }
+    )
+    assert not is_user_gate_todo_item(
+        {
+            "task_class": "user_action",
+            "action_kind": "approval",
+            "text": "Non-blocking user follow-up.",
         }
     )
     summary = summarize_user_todos_for_quota(
@@ -74,16 +94,17 @@ def assert_shared_gate_detection() -> None:
         filter_user_gate_blocks_agent=True,
     )
     assert summary is not None
-    assert summary["open_count"] == 2, summary
+    assert summary["open_count"] == 1, summary
     assert summary["all_open_count"] == 3, summary
     assert summary["other_agent_scoped_open_count"] == 1, summary
+    assert summary["user_action_open_count"] == 1, summary
 
     with_duplicate = {
         "open_count": "2",
         "gate_open_items": [summary["gate_open_items"][0]],
         "first_open_items": [
             summary["gate_open_items"][0],
-            summary["first_executable_items"][0],
+            summary["user_action_items"][0],
         ],
     }
     gate_items = open_user_gate_todo_items(with_duplicate)


### PR DESCRIPTION
## Summary
- Updates the user-gate readmodel smoke to match typed todo semantics after v0.1.10.
- Explicit `user_gate` remains blocking, explicit `user_action` remains non-blocking, and legacy action-kind inference is only exercised when `task_class` is absent.
- Adjusts scoped summary assertions so another agent's gate stays visible without blocking this agent.

## Validation
- python3 examples/control_plane/todo-user-gate-readmodel-smoke.py
- python3 examples/control_plane/todo-user-gate-scope-smoke.py
- python3 examples/control_plane/quota-agent-scoped-user-gate-smoke.py
- python3 examples/control_plane/control-plane-integrated-canary-smoke.py
- loopx canary premerge --from-git-diff
- compact quota should-run check for codex-main-control, codex-product-capability, codex-value-explorer, codex-side-bypass

## Boundary
- Smoke-only public test fixture change; no benchmark job launch, no raw benchmark evidence, no private state.