### PR TITLE
Fix stale handoff closeout replan routing

### DIFF
--- a/docs/interaction-pattern-catalog.md
+++ b/docs/interaction-pattern-catalog.md
@@ -1000,6 +1000,8 @@ flowchart TD
   S -->|"done + no successor"| R["handoff gate: cleared_without_successor"]
   R --> L["successor_replan_required"]
   L --> F["reopen / supersede / no-follow-up rationale"]
+  S -->|"open + stale closeout"| X["route continuation replan required"]
+  X --> L
   S -->|"superseded_by"| H["handoff gate: superseded"]
   H --> I["historical only"]
   S -->|"deferred"| D["handoff gate: deferred"]
@@ -1013,6 +1015,11 @@ the blocked agent falls into a vague `agent_scope_wait`. The opposite bad smell
 is also harmful: a stale done handoff outranks a live open review blocker, so
 the agent replans while a real reviewer-owned gate is still open. Both are
 state-machine bugs, not prompt wording bugs.
+
+A third bad smell is an open handoff gate whose action is already a stale
+handoff closeout. That gate is no longer a live reviewer decision. It should
+project `route_continuation_replan_required` so quota wakes successor replan to
+reopen, supersede, or close the stale route with a no-follow-up rationale.
 
 **Validation**
 

--- a/examples/control_plane/quota-cleared-blocker-successor-gate-smoke.py
+++ b/examples/control_plane/quota-cleared-blocker-successor-gate-smoke.py
@@ -31,6 +31,7 @@ def todo_item(
     text: str,
     claimed_by: str | None = None,
     status: str = "open",
+    action_kind: str | None = None,
     blocks_agent: str | None = None,
     unblocks_todo_id: str | None = None,
     resume_when: str | None = None,
@@ -48,6 +49,8 @@ def todo_item(
     }
     if claimed_by:
         item["claimed_by"] = claimed_by
+    if action_kind:
+        item["action_kind"] = action_kind
     if blocks_agent:
         item["blocks_agent"] = blocks_agent
     if unblocks_todo_id:
@@ -231,6 +234,20 @@ def completed_value_successor() -> dict:
     )
 
 
+def stale_handoff_closeout() -> dict:
+    return todo_item(
+        todo_id="todo_stale_review_closeout",
+        text=(
+            "[P2] Close or supersede the stale PR review handoff now that the "
+            "blocked slice is complete."
+        ),
+        claimed_by=PRIMARY_AGENT,
+        action_kind="stale_pr_review_handoff_closeout",
+        blocks_agent=BLOCKED_AGENT,
+        unblocks_todo_id="todo_value_explorer_slice",
+    )
+
+
 def followup_review_gate() -> dict:
     return todo_item(
         todo_id="todo_followup_review_gate",
@@ -309,6 +326,30 @@ def assert_cleared_blocker_requires_successor_replan() -> None:
     assert scheduler["codex_app"]["recommended_interval_minutes"] == 3, scheduler
     assert scheduler["codex_app"]["stateful_backoff"]["apply_needed"] is True, scheduler
     assert scheduler["codex_app"]["no_spend_for_cadence_change"] is True, scheduler
+
+
+def assert_stale_handoff_closeout_requires_route_continuation_replan() -> None:
+    payload = build_quota_should_run(
+        status_payload(
+            [primary_owned_todo(), stale_handoff_closeout()],
+            recommended_action="Continue after the blocked side-agent target completed.",
+        ),
+        goal_id=GOAL_ID,
+        agent_id=BLOCKED_AGENT,
+    )
+    assert payload["decision"] == "successor_replan_required", payload
+    assert payload["should_run"] is True, payload
+    assert payload["effective_action"] == "successor_replan_required", payload
+    frontier = payload["agent_scope_frontier"]
+    assert frontier["action"] == "successor_replan_required", frontier
+    assert "blocking_handoff_gates" not in frontier, frontier
+    gate = frontier["route_continuation_replan_candidates"][0]
+    assert gate["todo_id"] == "todo_stale_review_closeout", frontier
+    assert gate["status"] == "open", frontier
+    assert gate["unblocks_todo_id"] == "todo_value_explorer_slice", frontier
+    assert gate["route_continuation_replan_required"] is True, frontier
+    assert "stale handoff closeout" in gate["route_continuation_reason"], frontier
+    assert payload["agent_todo_summary"]["current_agent_route_continuation_replan_count"] == 1, payload
 
 
 def assert_status_summary_projects_handoff_gate_state() -> None:
@@ -416,6 +457,7 @@ def main() -> int:
     assert_handoff_gate_lanes_and_ready_successors_are_todo_context_helpers()
     assert_open_blocker_waits_on_owner()
     assert_cleared_blocker_requires_successor_replan()
+    assert_stale_handoff_closeout_requires_route_continuation_replan()
     assert_status_summary_projects_handoff_gate_state()
     assert_existing_successor_runs_normally()
     assert_completed_successor_keeps_old_gate_cleared()

--- a/loopx/control_plane/todos/handoff_gate.py
+++ b/loopx/control_plane/todos/handoff_gate.py
@@ -87,6 +87,17 @@ def _successor_todo_ids(
     return successor_ids
 
 
+def _stale_handoff_closeout_replan_required(gate: dict[str, Any]) -> bool:
+    if _todo_done(gate):
+        return False
+    label = " ".join(
+        str(gate.get(key) or "")
+        for key in ("action_kind", "title", "text")
+        if str(gate.get(key) or "").strip()
+    ).lower()
+    return "stale" in label and "handoff" in label and "closeout" in label
+
+
 def _handoff_gate_state(
     gate: dict[str, Any],
     *,
@@ -149,6 +160,12 @@ def _compact_handoff_gate(
     superseded_by = normalize_todo_id(payload.get("superseded_by"))
     if superseded_by:
         payload["superseded_by"] = superseded_by
+    if _stale_handoff_closeout_replan_required(gate):
+        payload["route_continuation_replan_required"] = True
+        payload.setdefault(
+            "route_continuation_reason",
+            "stale handoff closeout requires a bounded route continuation replan",
+        )
     if successor_ids:
         payload["successor_todo_ids"] = successor_ids
     return {key: value for key, value in payload.items() if value not in (None, "")}


### PR DESCRIPTION
## Summary
- project stale handoff closeout gates as route-continuation replan candidates instead of leaving side agents in monitor-only wait
- add a quota regression smoke covering stale handoff closeout routing while preserving live review-gate blocking behavior
- document the IP-029 stale-closeout bad smell and expected route-continuation path

## Why
A side-agent lane could be blocked by an open stale handoff closeout even after the route it referenced had already completed. Because the gate still projected as blocking, quota never reached the vision/frontier replan branch and the agent stayed quiet.

## Validation
- python3 examples/control_plane/quota-cleared-blocker-successor-gate-smoke.py
- python3 examples/control_plane/todo-route-continuation-lanes-smoke.py
- python3 examples/control_plane/hot-path-interface-budget-smoke.py
- git diff --check origin/main...HEAD
- loopx canary premerge --from-git-diff
- local worktree quota should-run for loopx-meta/codex-side-bypass now returns successor_replan_required with route_candidate_count=1 and blocking_handoff_gate_count=0