### PR TITLE
Fix codex cli goal closeout retry after bridge timeouts

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -526,6 +526,7 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
     )
     from loopx.benchmark_adapters.skillsbench_codex_goal_recovery import (
         CODEX_CLI_GOAL_POST_BRIDGE_CLOSEOUT_PROMPT,
+        POST_BRIDGE_CLOSEOUT_ATTEMPT_LIMIT,
         POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT,
         PRE_BRIDGE_RECOVERY_ATTEMPT_LIMIT,
         codex_cli_tui_post_bridge_blocker_stage,
@@ -542,6 +543,7 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
     )
 
     assert POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT == 4
+    assert POST_BRIDGE_CLOSEOUT_ATTEMPT_LIMIT == 3
     assert PRE_BRIDGE_RECOVERY_ATTEMPT_LIMIT == 2
     assert "Close out the active SkillsBench goal" in (
         CODEX_CLI_GOAL_POST_BRIDGE_CLOSEOUT_PROMPT
@@ -647,6 +649,15 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
             recovery_action="typed_continue",
             recovery_attempt_count=POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT,
             closeout_attempted=True,
+        )
+        == "typed_closeout"
+    )
+    assert (
+        codex_cli_tui_post_bridge_closeout_recovery_action(
+            recovery_action="typed_continue",
+            recovery_attempt_count=POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT,
+            closeout_attempted=True,
+            closeout_attempt_count=POST_BRIDGE_CLOSEOUT_ATTEMPT_LIMIT,
         )
         == ""
     )
@@ -765,8 +776,8 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
             first_action_observed=True,
             bridge_summary_path=bridge_summary,
             post_bridge_recovery_attempt_count=4,
-            post_bridge_recovery_action="typed_continue",
-            post_bridge_recovery_skip_reason="retry_limit_reached",
+            post_bridge_recovery_action="typed_closeout",
+            post_bridge_recovery_skip_reason="closeout_retry_limit_reached",
         )
         plan = {
             "route": "codex-cli-goal-baseline",
@@ -779,28 +790,28 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
     prerequisites = plan["runner_prerequisites"]
     assert trace["codex_cli_goal_tui_stage"] == "post_bridge_tui_model_timeout"
     assert trace["codex_cli_goal_tui_post_bridge_recovery_attempt_count"] == 4
-    assert trace["codex_cli_goal_tui_post_bridge_recovery_action"] == "typed_continue"
+    assert trace["codex_cli_goal_tui_post_bridge_recovery_action"] == "typed_closeout"
     assert (
         trace["codex_cli_goal_tui_post_bridge_recovery_skip_reason"]
-        == "retry_limit_reached"
+        == "closeout_retry_limit_reached"
     )
     assert trace["codex_cli_goal_tui_post_bridge_recovery_skip_reasons"] == [
-        "retry_limit_reached"
+        "closeout_retry_limit_reached"
     ]
     public_prerequisites = _public_runner_prerequisites(prerequisites)
     assert (
         public_prerequisites["codex_cli_goal_tui_post_bridge_recovery_action"]
-        == "typed_continue"
+        == "typed_closeout"
     )
     assert (
         public_prerequisites[
             "codex_cli_goal_tui_post_bridge_recovery_skip_reason"
         ]
-        == "retry_limit_reached"
+        == "closeout_retry_limit_reached"
     )
     assert public_prerequisites[
         "codex_cli_goal_tui_post_bridge_recovery_skip_reasons"
-    ] == ["retry_limit_reached"]
+    ] == ["closeout_retry_limit_reached"]
 
 
 def _assert_cli_goal_active_timeout_is_public_countability_stage() -> None:
@@ -1021,6 +1032,7 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert "timeout_sec=max(" in source
     assert "self._config.first_action_timeout_sec" in source
     assert "post_bridge_recovery_attempt_count" in source
+    assert "post_bridge_closeout_attempt_count" in source
     assert "POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT" in source
     assert "CODEX_CLI_GOAL_POST_BRIDGE_CLOSEOUT_PROMPT" in source
     assert "typed_closeout" in source

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -1213,7 +1213,7 @@ class SkillsBenchLocalAcpRelay:
             post_bridge_recovery_attempt_count = 0
             post_bridge_recovery_action = ""
             post_bridge_recovery_skip_reason = ""
-            post_bridge_closeout_attempted = False
+            post_bridge_closeout_attempt_count = 0
             try:
                 subprocess.run(
                     [
@@ -1618,14 +1618,13 @@ class SkillsBenchLocalAcpRelay:
                         closeout_action = (
                             codex_cli_tui_post_bridge_closeout_recovery_action(
                                 recovery_action=recovery_action,
-                                recovery_attempt_count=(
-                                    post_bridge_recovery_attempt_count
-                                ),
-                                closeout_attempted=post_bridge_closeout_attempted,
+                                recovery_attempt_count=post_bridge_recovery_attempt_count,
+                                closeout_attempted=post_bridge_closeout_attempt_count > 0,
+                                closeout_attempt_count=post_bridge_closeout_attempt_count,
                             )
                         )
                         if closeout_action == "typed_closeout":
-                            post_bridge_closeout_attempted = True
+                            post_bridge_closeout_attempt_count += 1
                             post_bridge_recovery_action = closeout_action
                             tmux_type_text_and_submit(
                                 tmux_name=tmux_name,
@@ -1648,7 +1647,7 @@ class SkillsBenchLocalAcpRelay:
                             not post_bridge_recovery_skip_reason
                             and recovery_action in {"press_enter", "typed_continue"}
                         ):
-                            post_bridge_recovery_skip_reason = "retry_limit_reached"
+                            post_bridge_recovery_skip_reason = "closeout_retry_limit_reached" if post_bridge_closeout_attempt_count else "retry_limit_reached"
                         tmux_kill_session(tmux_name)
                         self._publish_remote_bridge_agent_operations_trace(
                             bridge_summary_path=bridge_summary_path,

--- a/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
+++ b/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
@@ -17,6 +17,7 @@ CODEX_CLI_GOAL_POST_BRIDGE_CLOSEOUT_PROMPT = (
     "complete, report the blocker compactly and end the active goal."
 )
 POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT = 4
+POST_BRIDGE_CLOSEOUT_ATTEMPT_LIMIT = 3
 
 
 def _capture_has_rate_limit(capture: str) -> bool:
@@ -175,13 +176,18 @@ def codex_cli_tui_post_bridge_closeout_recovery_action(
     recovery_action: str,
     recovery_attempt_count: int,
     closeout_attempted: bool,
+    closeout_attempt_count: int = 0,
 ) -> str:
     """Return the final bounded closeout action after continue retries are spent."""
 
-    if closeout_attempted:
-        return ""
     if recovery_action not in {"press_enter", "typed_continue"}:
         return ""
     if recovery_attempt_count < POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT:
+        return ""
+    effective_closeout_count = max(
+        int(closeout_attempted),
+        max(0, int(closeout_attempt_count or 0)),
+    )
+    if effective_closeout_count >= POST_BRIDGE_CLOSEOUT_ATTEMPT_LIMIT:
         return ""
     return "typed_closeout"


### PR DESCRIPTION
## Summary
- Let codex-cli-goal post-bridge closeout retry use its own bounded counter after continue retries are exhausted.
- Keep the hot relay path within the existing line budget by leaving aggregation unchanged and validating the final action/skip reason instead.
- Update the codex cli goal route smoke for the new closeout retry contract.

## Validation
- python3 -m py_compile examples/skillsbench-codex-cli-goal-route-smoke.py loopx/benchmark_adapters/skillsbench_acp_relay.py loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
- python3 examples/skillsbench-codex-cli-goal-route-smoke.py
- python3 examples/control_plane/repo-python-line-budget-smoke.py
- loopx canary premerge --from-git-diff --format json --timeout-seconds 120

## Premerge Gate
Changed surfaces: benchmark-sensitive Python adapter/helper and focused public smoke.
Catalog canaries: repo line budget, Terminal-Bench adapter readiness characterization, benchmark core adapter contract, benchmark artifact path filter, benchmark run ledger, benchmark case analysis all passed.
Public/private boundary: check-public-boundary-smoke passed; no raw task text, raw trajectories, verifier output, credentials, local artifact paths, or proxy URLs are added.
Manual holds: one benchmark-sensitive hold remains because this touches benchmark adapter/runtime recovery. This PR does not change scoring, task semantics, leaderboard/submission behavior, permission boundaries, or launch benchmark jobs. Owner authorization allows benchmark helper/runtime PRs to be self-merged after focused validation.
Merge decision: self-merge after PR creation under the standing benchmark-related authorization.