### PR TITLE
Refactor todo completion policy

### DIFF
--- a/examples/control_plane/heartbeat-quota-flow-smoke.py
+++ b/examples/control_plane/heartbeat-quota-flow-smoke.py
@@ -529,9 +529,13 @@ def write_operator_gate_fixture(root: Path) -> tuple[Path, Path, Path]:
         "## Next Action\n\n"
         "- Ask the owner whether this planned adapter may run.\n\n"
         "## User Todo / Owner Review Reading Queue\n\n"
-        "- [ ] [P1] Approve or defer the planned adapter opt-in.\n\n"
+        "- [ ] [P1] Approve or defer the planned adapter opt-in.\n"
+        "  <!-- loopx:todo todo_id=todo_operator_gate_opt_in status=open "
+        "task_class=user_gate action_kind=controller_opt_in global_gate=true -->\n\n"
         "## Agent Todo\n\n"
-        "- [ ] [P2] If the gate is already surfaced, prepare a read-only checklist that does not execute the gated adapter.\n",
+        "- [ ] [P2] If the gate is already surfaced, prepare a read-only checklist that does not execute the gated adapter.\n"
+        "  <!-- loopx:todo todo_id=todo_operator_gate_readonly_checklist status=open "
+        "task_class=advancement_task action_kind=read_only_checklist -->\n",
         encoding="utf-8",
     )
     registry_path.parent.mkdir(parents=True, exist_ok=True)

--- a/examples/control_plane/side-agent-self-iteration-state-machine-smoke.py
+++ b/examples/control_plane/side-agent-self-iteration-state-machine-smoke.py
@@ -14,6 +14,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from loopx.control_plane.testing.canary_harness import (  # noqa: E402
     run_json_cli,
+    run_json_cli_result,
     write_fixture_registry,
 )
 
@@ -32,6 +33,11 @@ CAPABILITY_FALLBACK_TODO_ID = "todo_self_iter_filesystem_fallback"
 CAPABILITY_FALLBACK_TEXT = (
     "Run the public-safe filesystem fallback while network capability is unavailable."
 )
+EXISTING_SUCCESSOR_START_TODO_ID = "todo_self_iter_existing_start"
+EXISTING_SUCCESSOR_HANDOFF_TODO_ID = "todo_self_iter_existing_handoff"
+EXISTING_SUCCESSOR_SAME_AGENT_TODO_ID = "todo_self_iter_existing_same_agent"
+EXISTING_SUCCESSOR_START_TEXT = "Finish a side-agent slice with an already-created handoff successor."
+EXISTING_SUCCESSOR_HANDOFF_TEXT = "Review and merge the completed side-agent slice."
 
 
 def run_cli(
@@ -40,6 +46,19 @@ def run_cli(
     runtime: Path,
 ) -> dict:
     return run_json_cli(
+        *args,
+        registry_path=registry_path,
+        runtime_root=runtime,
+        cwd=REPO_ROOT,
+    )
+
+
+def run_cli_result(
+    *args: str,
+    registry_path: Path,
+    runtime: Path,
+) -> tuple[int, dict]:
+    return run_json_cli_result(
         *args,
         registry_path=registry_path,
         runtime_root=runtime,
@@ -100,6 +119,50 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
         runtime=runtime,
         registry_path=registry_path,
         adapter_kind="side_agent_self_iteration_fixture_v0",
+    )
+    return project, runtime, registry_path
+
+
+def write_existing_successor_fixture(
+    root: Path,
+    *,
+    successor_todo_id: str,
+    successor_claimed_by: str,
+) -> tuple[Path, Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    state_path = project / state_file
+    registry_path = project / ".loopx" / "registry.json"
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(
+        "---\n"
+        "status: active\n"
+        "owner_mode: goal\n"
+        'objective: "Exercise existing successor completion."\n'
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Existing Successor Completion Fixture\n\n"
+        "## Objective\n\n"
+        "Exercise existing successor completion.\n\n"
+        "## Next Action\n\n"
+        f"- {GOAL_NEXT_ACTION}\n\n"
+        "## Agent Todo\n\n"
+        f"- [ ] [P1] {EXISTING_SUCCESSOR_START_TEXT}\n"
+        f"  <!-- loopx:todo todo_id={EXISTING_SUCCESSOR_START_TODO_ID} status=open "
+        "task_class=advancement_task action_kind=state_machine_canary_refactor "
+        f"claimed_by={AGENT_ID} -->\n"
+        f"- [ ] [P1] {EXISTING_SUCCESSOR_HANDOFF_TEXT}\n"
+        f"  <!-- loopx:todo todo_id={successor_todo_id} status=open "
+        "task_class=advancement_task action_kind=primary_review "
+        f"claimed_by={successor_claimed_by} -->\n",
+        encoding="utf-8",
+    )
+    write_registry(
+        project=project,
+        runtime=runtime,
+        registry_path=registry_path,
+        adapter_kind="side_agent_existing_successor_fixture_v0",
     )
     return project, runtime, registry_path
 
@@ -324,6 +387,107 @@ def assert_self_iteration_flow() -> None:
         assert third["active_state_next_action"] == GOAL_NEXT_ACTION, third
 
 
+def assert_existing_handoff_successor_flow() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-side-agent-existing-successor-") as tmp:
+        project, runtime, registry_path = write_existing_successor_fixture(
+            Path(tmp),
+            successor_todo_id=EXISTING_SUCCESSOR_HANDOFF_TODO_ID,
+            successor_claimed_by=PRIMARY_AGENT_ID,
+        )
+
+        first = should_run(registry_path, runtime, project)
+        assert_initial_side_agent_lane(first, expected_todo_id=EXISTING_SUCCESSOR_START_TODO_ID)
+
+        completed = run_cli(
+            "todo",
+            "complete",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--todo-id",
+            EXISTING_SUCCESSOR_START_TODO_ID,
+            "--claimed-by",
+            AGENT_ID,
+            "--evidence",
+            "fixture linked an existing public handoff successor",
+            "--successor-todo-id",
+            EXISTING_SUCCESSOR_HANDOFF_TODO_ID,
+            registry_path=registry_path,
+            runtime=runtime,
+        )
+        assert completed["ok"] is True, completed
+        assert completed["status"] == "done", completed
+        assert completed["side_agent_self_merged"] is False, completed
+        assert completed["linked_handoff_successor_id"] == EXISTING_SUCCESSOR_HANDOFF_TODO_ID, completed
+        assert completed["successor_todo_ids"] == [EXISTING_SUCCESSOR_HANDOFF_TODO_ID], completed
+        assert completed["next_todos"] == [], completed
+
+        successor_lookup = run_cli(
+            "todo",
+            "list",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            EXISTING_SUCCESSOR_HANDOFF_TODO_ID,
+            registry_path=registry_path,
+            runtime=runtime,
+        )
+        assert successor_lookup["matched"] is True, successor_lookup
+        assert successor_lookup["todo"]["status"] == "open", successor_lookup
+        assert successor_lookup["todo"]["claimed_by"] == PRIMARY_AGENT_ID, successor_lookup
+
+        primary_guard = run_cli(
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            PRIMARY_AGENT_ID,
+            "--scan-path",
+            str(project),
+            registry_path=registry_path,
+            runtime=runtime,
+        )
+        assert primary_guard["decision"] == "run", primary_guard
+        assert primary_guard["effective_action"] == "normal_run", primary_guard
+        assert primary_guard["agent_identity"]["role"] == "primary-agent", primary_guard
+        primary_next_action = primary_guard["agent_lane_next_action"]
+        assert primary_next_action["todo_id"] == EXISTING_SUCCESSOR_HANDOFF_TODO_ID, primary_guard
+        assert primary_next_action["claimed_by"] == PRIMARY_AGENT_ID, primary_guard
+
+
+def assert_same_agent_existing_successor_still_requires_self_merge_or_handoff() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-side-agent-same-successor-") as tmp:
+        _project, runtime, registry_path = write_existing_successor_fixture(
+            Path(tmp),
+            successor_todo_id=EXISTING_SUCCESSOR_SAME_AGENT_TODO_ID,
+            successor_claimed_by=AGENT_ID,
+        )
+
+        returncode, rejected = run_cli_result(
+            "todo",
+            "complete",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--todo-id",
+            EXISTING_SUCCESSOR_START_TODO_ID,
+            "--claimed-by",
+            AGENT_ID,
+            "--evidence",
+            "fixture attempted same-agent successor link",
+            "--successor-todo-id",
+            EXISTING_SUCCESSOR_SAME_AGENT_TODO_ID,
+            registry_path=registry_path,
+            runtime=runtime,
+        )
+        assert returncode != 0, rejected
+        assert "handoff_agent='codex-main-control'" in rejected["error"], rejected
+        assert "--side-agent-self-merged" in rejected["error"], rejected
+
+
 def assert_capability_fallback_preserves_frontier_and_scheduler() -> None:
     with tempfile.TemporaryDirectory(prefix="loopx-side-agent-capability-fallback-") as tmp:
         project, runtime, registry_path = write_capability_fallback_fixture(Path(tmp))
@@ -373,6 +537,8 @@ def assert_capability_fallback_preserves_frontier_and_scheduler() -> None:
 
 def main() -> int:
     assert_self_iteration_flow()
+    assert_existing_handoff_successor_flow()
+    assert_same_agent_existing_successor_still_requires_self_merge_or_handoff()
     assert_capability_fallback_preserves_frontier_and_scheduler()
     print("side-agent-self-iteration-state-machine-smoke ok")
     return 0

--- a/loopx/control_plane/todos/completion_policy.py
+++ b/loopx/control_plane/todos/completion_policy.py
@@ -1,0 +1,188 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+from ...agent_registry import (
+    primary_agent_id_from_registry,
+    registered_agent_ids_from_registry,
+    require_registered_agent_id,
+    side_agent_handoff_agent_id_from_registry,
+)
+from .contract import normalize_todo_claimed_by
+
+
+@dataclass(frozen=True)
+class LinkedSuccessor:
+    todo_id: str
+    role: str | None = None
+    status: str | None = None
+    task_class: str | None = None
+    action_kind: str | None = None
+    claimed_by: str | None = None
+
+
+@dataclass(frozen=True)
+class CompletionPolicy:
+    effective_claimed_by: str | None
+    primary_agent: str | None
+    registered_agents: list[str]
+    handoff_agent: str | None
+    effective_next_claimed_by: str | None
+    side_agent_completion: bool
+    side_agent_self_merged: bool
+    linked_handoff_successor_id: str | None = None
+
+
+def is_primary_review_action_kind(value: Any) -> bool:
+    action_kind = str(value or "").strip()
+    return action_kind == "primary_review" or action_kind.startswith("primary_review_")
+
+
+def linked_successor_from_todo(todo: Mapping[str, Any]) -> LinkedSuccessor:
+    return LinkedSuccessor(
+        todo_id=str(todo.get("todo_id") or ""),
+        role=str(todo.get("role") or "").strip() or None,
+        status=str(todo.get("status") or "").strip() or None,
+        task_class=str(todo.get("task_class") or "").strip() or None,
+        action_kind=str(todo.get("action_kind") or "").strip() or None,
+        claimed_by=normalize_todo_claimed_by(todo.get("claimed_by")),
+    )
+
+
+def _linked_handoff_successor_id(
+    *,
+    successors: Iterable[LinkedSuccessor],
+    handoff_agent: str | None,
+    completing_agent: str | None,
+) -> str | None:
+    if not handoff_agent or not completing_agent:
+        return None
+    for successor in successors:
+        if successor.role != "agent":
+            continue
+        if successor.status and successor.status != "open":
+            continue
+        if successor.claimed_by != handoff_agent:
+            continue
+        if successor.claimed_by == completing_agent:
+            continue
+        if successor.todo_id:
+            return successor.todo_id
+    return None
+
+
+def resolve_completion_policy(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    claimed_by: str | None = None,
+    next_claimed_by: str | None = None,
+    next_agent_todo: str | None = None,
+    next_action_kind: str | None = None,
+    side_agent_self_merged: bool = False,
+    evidence: str | None = None,
+    linked_successors: Iterable[LinkedSuccessor] = (),
+) -> CompletionPolicy:
+    effective_claimed_by = (
+        require_registered_agent_id(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            agent_id=claimed_by,
+        )
+        if claimed_by
+        else None
+    )
+    primary_agent = primary_agent_id_from_registry(registry_path, goal_id)
+    registered_agents = registered_agent_ids_from_registry(registry_path, goal_id)
+    configured_handoff_agent = side_agent_handoff_agent_id_from_registry(
+        registry_path,
+        goal_id,
+        agent_id=effective_claimed_by,
+    )
+    handoff_agent = configured_handoff_agent or primary_agent
+    if configured_handoff_agent:
+        handoff_agent = require_registered_agent_id(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            agent_id=configured_handoff_agent,
+            field="side_agent_handoff_agent",
+        )
+    effective_next_claimed_by = (
+        require_registered_agent_id(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            agent_id=next_claimed_by,
+            field="next_claimed_by",
+        )
+        if next_claimed_by
+        else None
+    )
+    if effective_claimed_by and not primary_agent:
+        raise ValueError(
+            "todo complete with --claimed-by requires coordination.primary_agent "
+            "so LoopX can distinguish the primary agent from side agents"
+        )
+
+    side_agent_completion = bool(
+        effective_claimed_by and primary_agent and effective_claimed_by != primary_agent
+    )
+    linked_handoff_successor_id = _linked_handoff_successor_id(
+        successors=linked_successors,
+        handoff_agent=handoff_agent,
+        completing_agent=effective_claimed_by,
+    )
+    explicit_primary_review_handoff = bool(
+        side_agent_completion
+        and next_agent_todo
+        and not side_agent_self_merged
+        and primary_agent
+        and effective_next_claimed_by == primary_agent
+        and is_primary_review_action_kind(next_action_kind)
+    )
+
+    if side_agent_completion:
+        if side_agent_self_merged and not evidence:
+            raise ValueError(
+                "--side-agent-self-merged requires --evidence with a public-safe "
+                "self-merge, commit, and validation summary"
+            )
+        if not side_agent_self_merged and not next_agent_todo and not linked_handoff_successor_id:
+            raise ValueError(
+                f"side-agent completion by {effective_claimed_by!r} requires "
+                "--next-agent-todo for independent handoff, verification, and merge; "
+                "--successor-todo-id pointing at an open agent successor claimed by "
+                f"handoff_agent={handoff_agent!r}; or --side-agent-self-merged "
+                "with --evidence for a small validated self-merge"
+            )
+        if not side_agent_self_merged and handoff_agent == effective_claimed_by:
+            raise ValueError(
+                "side-agent handoff todo cannot be claimed by the completing side agent; "
+                "use --side-agent-self-merged with --evidence for same-agent delivery, "
+                "or configure side_agent_handoff_agent to another registered agent"
+            )
+        if (
+            not side_agent_self_merged
+            and effective_next_claimed_by
+            and effective_next_claimed_by != handoff_agent
+            and not explicit_primary_review_handoff
+        ):
+            raise ValueError(
+                f"side-agent completion handoff todo must be claimed_by handoff_agent={handoff_agent!r}"
+            )
+        if next_agent_todo and not side_agent_self_merged and not effective_next_claimed_by:
+            effective_next_claimed_by = handoff_agent
+    if effective_next_claimed_by and not next_agent_todo:
+        raise ValueError("--next-claimed-by requires --next-agent-todo")
+
+    return CompletionPolicy(
+        effective_claimed_by=effective_claimed_by,
+        primary_agent=primary_agent,
+        registered_agents=registered_agents,
+        handoff_agent=handoff_agent,
+        effective_next_claimed_by=effective_next_claimed_by,
+        side_agent_completion=side_agent_completion,
+        side_agent_self_merged=bool(side_agent_completion and side_agent_self_merged),
+        linked_handoff_successor_id=linked_handoff_successor_id,
+    )

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -8,7 +8,6 @@ from .agent_registry import (
     primary_agent_id_from_registry,
     registered_agent_ids_from_registry,
     require_registered_agent_id,
-    side_agent_handoff_agent_id_from_registry,
 )
 from .file_lock import exclusive_file_lock
 from .history import load_registry
@@ -48,6 +47,10 @@ from .control_plane.todos.contract import (
     todo_done_for_status,
     todo_marker_for_status,
     todo_status_from_marker,
+)
+from .control_plane.todos.completion_policy import (
+    linked_successor_from_todo,
+    resolve_completion_policy,
 )
 from .control_plane.todos.event_writeback import (
     complete_event_projected_goal_todo,
@@ -130,11 +133,6 @@ def require_user_todo_task_class(
             "user_action is non-blocking and cannot set blocks_agent or global_gate; "
             "use --task-class user_gate for blocking decisions"
         )
-
-
-def _is_primary_review_action_kind(value: Any) -> bool:
-    action_kind = str(value or "").strip()
-    return action_kind == "primary_review" or action_kind.startswith("primary_review_")
 
 
 def _attach_todo_write_correctness_dry_run_packet(
@@ -1608,90 +1606,34 @@ def complete_goal_todo(
         original = resolved_state_file.read_text(encoding="utf-8")
         lines = original.splitlines()
         updated_at = now_local()
-        effective_claimed_by = (
-            require_registered_agent_id(
-                registry_path=registry_path,
-                goal_id=goal_id,
-                agent_id=claimed_by,
-            )
-            if claimed_by
-            else None
-        )
-        primary_agent = primary_agent_id_from_registry(registry_path, goal_id)
-        registered_agents = registered_agent_ids_from_registry(registry_path, goal_id)
-        configured_handoff_agent = side_agent_handoff_agent_id_from_registry(
-            registry_path,
-            goal_id,
-            agent_id=effective_claimed_by,
-        )
-        handoff_agent = configured_handoff_agent or primary_agent
-        if configured_handoff_agent:
-            handoff_agent = require_registered_agent_id(
-                registry_path=registry_path,
-                goal_id=goal_id,
-                agent_id=configured_handoff_agent,
-                field="side_agent_handoff_agent",
-            )
-        effective_next_claimed_by = (
-            require_registered_agent_id(
-                registry_path=registry_path,
-                goal_id=goal_id,
-                agent_id=next_claimed_by,
-                field="next_claimed_by",
-            )
-            if next_claimed_by
-            else None
-        )
-        if effective_claimed_by and not primary_agent:
-            raise ValueError(
-                "todo complete with --claimed-by requires coordination.primary_agent "
-                "so LoopX can distinguish the primary agent from side agents"
-            )
-        side_agent_completion = bool(
-            effective_claimed_by and primary_agent and effective_claimed_by != primary_agent
-        )
-        explicit_primary_review_handoff = bool(
-            side_agent_completion
-            and next_agent_todo
-            and not side_agent_self_merged
-            and primary_agent
-            and effective_next_claimed_by == primary_agent
-            and _is_primary_review_action_kind(next_action_kind)
-        )
-        if side_agent_completion:
-            if side_agent_self_merged and not evidence:
-                raise ValueError(
-                    "--side-agent-self-merged requires --evidence with a public-safe "
-                    "self-merge, commit, and validation summary"
-                )
-            if not side_agent_self_merged and not next_agent_todo:
-                raise ValueError(
-                    f"side-agent completion by {effective_claimed_by!r} requires "
-                    "--next-agent-todo for independent handoff, verification, and merge, "
-                    "or --side-agent-self-merged with --evidence for a small validated self-merge"
-                )
-            if not side_agent_self_merged and handoff_agent == effective_claimed_by:
-                raise ValueError(
-                    "side-agent handoff todo cannot be claimed by the completing side agent; "
-                    "use --side-agent-self-merged with --evidence for same-agent delivery, "
-                    "or configure side_agent_handoff_agent to another registered agent"
-                )
-            if (
-                not side_agent_self_merged
-                and effective_next_claimed_by
-                and effective_next_claimed_by != handoff_agent
-                and not explicit_primary_review_handoff
-            ):
-                raise ValueError(
-                    f"side-agent completion handoff todo must be claimed_by handoff_agent={handoff_agent!r}"
-                )
-            if next_agent_todo and not side_agent_self_merged and not effective_next_claimed_by:
-                effective_next_claimed_by = handoff_agent
-        if effective_next_claimed_by and not next_agent_todo:
-            raise ValueError("--next-claimed-by requires --next-agent-todo")
         normalized_successor_todo_ids = normalize_todo_id_list(successor_todo_ids)
         if successor_todo_ids and not normalized_successor_todo_ids:
             raise ValueError("successor_todo_ids must contain public todo_<letters-digits-underscore-hyphen> tokens")
+        linked_successors = []
+        for successor_todo_id in normalized_successor_todo_ids:
+            successor_match = find_todo_block(lines, todo_id=successor_todo_id)
+            if successor_match:
+                successor_role, _section, _start, _end, successor_block = successor_match
+                successor_item = dict(successor_block)
+                successor_item["role"] = successor_role
+                linked_successors.append(linked_successor_from_todo(successor_item))
+        completion_policy = resolve_completion_policy(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            claimed_by=claimed_by,
+            next_claimed_by=next_claimed_by,
+            next_agent_todo=next_agent_todo,
+            next_action_kind=next_action_kind,
+            side_agent_self_merged=side_agent_self_merged,
+            evidence=evidence,
+            linked_successors=linked_successors,
+        )
+        effective_claimed_by = completion_policy.effective_claimed_by
+        primary_agent = completion_policy.primary_agent
+        registered_agents = completion_policy.registered_agents
+        effective_next_claimed_by = completion_policy.effective_next_claimed_by
+        side_agent_completion = completion_policy.side_agent_completion
+        effective_side_agent_self_merged = completion_policy.side_agent_self_merged
         if not find_todo_block(lines, todo_id=todo_id, role=role):
             event_context = event_projection_todo_context(
                 registry_path=registry_path,
@@ -1718,7 +1660,7 @@ def complete_goal_todo(
                     next_task_class=next_task_class,
                     next_action_kind=next_action_kind,
                     side_agent_completion=side_agent_completion,
-                    side_agent_self_merged=side_agent_self_merged,
+                    side_agent_self_merged=effective_side_agent_self_merged,
                     registered_agents=registered_agents,
                     primary_agent=primary_agent,
                     updated_at=updated_at,
@@ -1745,7 +1687,7 @@ def complete_goal_todo(
             if next_agent_todo
             else None
         )
-        if side_agent_completion and next_agent_todo and not side_agent_self_merged:
+        if side_agent_completion and next_agent_todo and not effective_side_agent_self_merged:
             next_blocks_agent = effective_claimed_by
         next_user_blocks_agent = None
         if next_user_todo and len(registered_agents) > 1:
@@ -1800,7 +1742,8 @@ def complete_goal_todo(
         **update_result,
         "changed": changed,
         "next_todos": next_results,
-        "side_agent_self_merged": bool(side_agent_completion and side_agent_self_merged),
+        "side_agent_self_merged": effective_side_agent_self_merged,
+        "linked_handoff_successor_id": completion_policy.linked_handoff_successor_id,
         "state_file": str(resolved_state_file),
         "project": str(resolved_project) if resolved_project else None,
         "updated_at": updated_at if changed else None,


### PR DESCRIPTION
## Summary
- Move side-agent todo completion/handoff policy out of `loopx/todos.py` into `control_plane/todos/completion_policy.py`.
- Allow `todo complete --successor-todo-id` to satisfy side-agent completion only when the linked open agent successor is claimed by the configured handoff agent.
- Extend side-agent self-iteration canary for existing handoff successors and tighten the heartbeat operator-gate fixture with explicit `task_class` metadata.

## Changed Surfaces
- control_plane/todos completion policy
- todo completion CLI behavior through existing `--successor-todo-id` path
- control-plane canary fixtures

## Validation
- `python3 -m py_compile loopx/todos.py loopx/control_plane/todos/completion_policy.py examples/control_plane/side-agent-self-iteration-state-machine-smoke.py examples/control_plane/heartbeat-quota-flow-smoke.py`
- `python3 examples/control_plane/side-agent-self-iteration-state-machine-smoke.py`
- `python3 examples/control_plane/todo-cli-smoke.py`
- `python3 examples/control_plane/todo-user-gate-scope-smoke.py`
- `python3 examples/control_plane/quota-agent-scoped-user-gate-smoke.py`
- `python3 examples/control_plane/todo-lifecycle-cli-smoke.py`
- `python3 examples/control_plane/todo-succession-contract-smoke.py`
- `python3 examples/control_plane/heartbeat-quota-flow-smoke.py`
- `loopx canary premerge --from-git-diff` passed: catalog canaries 8/8, risk profile smokes 8/8, public boundary 1/1; manual holds 0; self_merge_allowed=true.

## Boundary
No credentials, private state, local paths, raw benchmark logs, trajectories, verifier output, or benchmark task text are included.
