### PR TITLE
Require visible evidence for auto-research round claims

### DIFF
--- a/examples/auto-research-demo-e2e-worker-loop-smoke.py
+++ b/examples/auto-research-demo-e2e-worker-loop-smoke.py
@@ -33,7 +33,10 @@ def assert_public_safe(payload: Any) -> None:
 
 def main() -> int:
     sys.path.insert(0, str(REPO_ROOT))
-    from loopx.capabilities.auto_research.demo_e2e import run_auto_research_demo_e2e
+    from loopx.capabilities.auto_research.demo_e2e import (
+        _build_collective_round_summary,
+        run_auto_research_demo_e2e,
+    )
     from loopx.capabilities.auto_research.human_view import render_auto_research_markdown
     from loopx.capabilities.auto_research.preset import default_auto_research_agent_specs
 
@@ -156,6 +159,51 @@ def main() -> int:
     assert tonight["dev_metric"] is None, tonight
     assert tonight["holdout_metric"] is None, tonight
     assert_public_safe(payload)
+
+    headless_with_metrics = _build_collective_round_summary(
+        source="worker_loop_collective_agent_passes",
+        agent_count=4,
+        collective_round_count=4,
+        dev_metric=4.8,
+        holdout_metric=5.2,
+        dev_metric_sequence=[4.0, 4.8],
+        holdout_metric_sequence=[4.5, 5.2],
+        holdout_improvement_count=2,
+        expected_lanes=[
+            {"agent_id": "research-curator"},
+            {"agent_id": "hypothesis-proposer"},
+            {"agent_id": "research-executor"},
+            {"agent_id": "evaluator-promoter"},
+        ],
+        lane_outcomes=[
+            {
+                "round": round_index,
+                "agent_id": agent_id,
+                "selected_todo_id": f"todo_{round_index}_{agent_id}",
+                "selected_action": "summarize_evidence",
+                "executed": True,
+                "completion_status": "done",
+            }
+            for round_index in range(1, 5)
+            for agent_id in (
+                "research-curator",
+                "hypothesis-proposer",
+                "research-executor",
+                "evaluator-promoter",
+            )
+        ],
+        visible_role_participation_verified=False,
+        visible_role_participation_basis="headless_worker_loop_summary_only",
+    )
+    assert headless_with_metrics["kernel_ledger"]["collective_research_verification"][
+        "verified"
+    ] is True, headless_with_metrics
+    assert headless_with_metrics["multi_round_research_verified"] is False, (
+        headless_with_metrics
+    )
+    assert headless_with_metrics["claim_boundary"].startswith(
+        "worker-loop summaries are control-plane plumbing evidence only"
+    ), headless_with_metrics
 
     print("auto-research-demo-e2e-worker-loop-smoke ok")
     return 0

--- a/examples/auto-research-minimal-kernel-smoke.py
+++ b/examples/auto-research-minimal-kernel-smoke.py
@@ -126,7 +126,6 @@ def assert_evidence_packet_boundary() -> None:
     assert "RESEARCH_HYPOTHESIS_SCHEMA_VERSION" not in worker_text
     assert "load_auto_research_evidence_packet_inputs" not in worker_text
     assert "AUTO_RESEARCH_MANUAL_RESEARCH_REQUIRED_MODE" in worker_text
-    assert "fake_metrics_recorded" in worker_text
     assert "from .evidence_packet import load_auto_research_evidence_packet_inputs" in cli_text
     assert "from .research_state import (" in cli_text
     assert "auto-research quickstart" not in cli_text

--- a/examples/auto-research-worker-turn-smoke.py
+++ b/examples/auto-research-worker-turn-smoke.py
@@ -178,7 +178,7 @@ def main() -> int:
             execute=True,
             complete=True,
         )
-        assert_manual_research_required(executor_execute, action="run_dev_eval")
+        assert_no_action(executor_execute, agent_id=EXECUTOR_AGENT_ID)
 
         evaluator_execute = run_worker_turn(
             registry=registry,

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -539,6 +539,7 @@ def _build_collective_round_summary(
         verification.get("verified") is True
         and verification.get("dev_metric_over_baseline") is True
         and holdout_metric is not None
+        and visible_role_participation_verified
     )
     return {
         "schema_version": "auto_research_collective_round_summary_v0",


### PR DESCRIPTION
## Summary
- require visible role participation before auto-research reports multi_round_research_verified
- add a regression case where a headless worker loop has metrics but still cannot claim visible multi-round research
- align worker-turn smoke with the manual-research-required contract so hidden turns do not advance downstream roles

## Real observation
- sampled existing real KNN visible sessions: curator/proposer/executor/evaluator authored role-specific work; executor changed solution.py and ran dev/test; evaluator wrote a verdict in the second run
- observed the remaining product gap is successor/replan after first complete pass, not fake metric generation

## Validation
- python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- python3 examples/auto-research-worker-turn-smoke.py
- python3 examples/auto-research-layered-e2e-acceptance-smoke.py
- python3 examples/auto-research-knn-continuation-smoke.py
- python3 examples/auto-research-minimal-kernel-smoke.py
- git diff --check
- loopx canary premerge --from-git-diff

Self-merge rationale: narrow auto-research claim-boundary fix plus focused smokes; premerge canary passed and reported self_merge_allowed=true.