### PR TITLE
Refactor todo write policy

### DIFF
--- a/examples/control_plane/todo-cli-smoke.py
+++ b/examples/control_plane/todo-cli-smoke.py
@@ -141,6 +141,42 @@ def main() -> int:
         )
         assert "user todo requires explicit --task-class" in bare_user_error["error"], bare_user_error
 
+        agent_user_gate_error = run_cli_error(
+            registry_path,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--task-class",
+            "user_gate",
+            "--text",
+            AGENT_TODO,
+            "--dry-run",
+        )
+        assert (
+            "user_action and user_gate task_class are only valid for --role user"
+            in agent_user_gate_error["error"]
+        ), agent_user_gate_error
+
+        user_action_gate_error = run_cli_error(
+            registry_path,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "user",
+            "--task-class",
+            "user_action",
+            "--global-gate",
+            "--text",
+            USER_TODO,
+            "--dry-run",
+        )
+        assert "user_action is non-blocking" in user_action_gate_error["error"], user_action_gate_error
+
         dry_run = run_cli(
             registry_path,
             "todo",

--- a/loopx/control_plane/todos/write_policy.py
+++ b/loopx/control_plane/todos/write_policy.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from ...agent_registry import registered_agent_ids_from_registry
+from .contract import TODO_TASK_CLASS_USER_ACTION, TODO_TASK_CLASS_USER_GATE
+
+
+USER_TODO_TASK_CLASSES = {
+    TODO_TASK_CLASS_USER_ACTION,
+    TODO_TASK_CLASS_USER_GATE,
+}
+
+
+def require_user_todo_task_class(
+    *,
+    role: str,
+    task_class: str | None,
+    blocks_agent: str | None = None,
+    global_gate: bool | None = None,
+) -> None:
+    if role != "user":
+        if task_class in USER_TODO_TASK_CLASSES:
+            raise ValueError(
+                "user_action and user_gate task_class are only valid for --role user"
+            )
+        return
+    normalized = str(task_class or "").strip()
+    if normalized not in USER_TODO_TASK_CLASSES:
+        raise ValueError(
+            "user todo requires explicit --task-class user_gate or user_action; "
+            "use user_gate for blocking owner/controller decisions and user_action "
+            "for non-blocking user-visible todos"
+        )
+    if normalized == TODO_TASK_CLASS_USER_ACTION and (blocks_agent or global_gate):
+        raise ValueError(
+            "user_action is non-blocking and cannot set blocks_agent or global_gate; "
+            "use --task-class user_gate for blocking decisions"
+        )
+
+
+def require_user_gate_scope(
+    *,
+    registry_path: Path,
+    goal_id: str,
+    role: str,
+    task_class: str | None,
+    blocks_agent: str | None,
+    global_gate: bool | None,
+) -> None:
+    if role != "user" or task_class != TODO_TASK_CLASS_USER_GATE:
+        return
+    if global_gate and blocks_agent:
+        raise ValueError(
+            "user_gate cannot set both blocks_agent and global_gate=true; "
+            "use blocks_agent for one registered agent or global_gate=true for a goal-wide gate"
+        )
+    registered_agents = registered_agent_ids_from_registry(registry_path, goal_id)
+    if len(registered_agents) <= 1:
+        return
+    if blocks_agent or global_gate is True:
+        return
+    raise ValueError(
+        "multi-agent user_gate requires an explicit scope: pass --blocks-agent "
+        "<registered-agent> (or --agent-id <registered-agent> for authoring) "
+        "when the gate blocks one lane, or pass --global-gate when it genuinely "
+        "blocks every registered agent"
+    )

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -25,7 +25,6 @@ from .control_plane.todos.contract import (
     TODO_MONITOR_METADATA_FIELDS,
     TODO_STATUS_DONE,
     TODO_STATUS_OPEN,
-    TODO_TASK_CLASS_USER_ACTION,
     TODO_TASK_CLASS_USER_GATE,
     TODO_TASK_PATTERN,
     build_todo_id,
@@ -62,6 +61,7 @@ from .control_plane.todos.text import (
     normalize_new_todo,
     todo_priority_prefix,
 )
+from .control_plane.todos.write_policy import require_user_gate_scope, require_user_todo_task_class
 
 
 TODO_SECTION_HEADINGS = {
@@ -102,37 +102,6 @@ TODO_METADATA_FIELDS = (
     "updated_at",
     "superseded_by",
 )
-
-
-USER_TODO_TASK_CLASSES = {
-    TODO_TASK_CLASS_USER_ACTION,
-    TODO_TASK_CLASS_USER_GATE,
-}
-
-
-def require_user_todo_task_class(
-    *,
-    role: str,
-    task_class: str | None,
-    blocks_agent: str | None = None,
-    global_gate: bool | None = None,
-) -> None:
-    if role != "user":
-        if task_class in USER_TODO_TASK_CLASSES:
-            raise ValueError("user_action and user_gate task_class are only valid for --role user")
-        return
-    normalized = str(task_class or "").strip()
-    if normalized not in USER_TODO_TASK_CLASSES:
-        raise ValueError(
-            "user todo requires explicit --task-class user_gate or user_action; "
-            "use user_gate for blocking owner/controller decisions and user_action "
-            "for non-blocking user-visible todos"
-        )
-    if normalized == TODO_TASK_CLASS_USER_ACTION and (blocks_agent or global_gate):
-        raise ValueError(
-            "user_action is non-blocking and cannot set blocks_agent or global_gate; "
-            "use --task-class user_gate for blocking decisions"
-        )
 
 
 def _attach_todo_write_correctness_dry_run_packet(
@@ -1018,35 +987,6 @@ def add_todo_to_lines(
         "expires_at": effective_metadata.get("expires_at"),
         "evidence": effective_metadata.get("evidence") or evidence,
     }
-
-
-def require_user_gate_scope(
-    *,
-    registry_path: Path,
-    goal_id: str,
-    role: str,
-    task_class: str | None,
-    blocks_agent: str | None,
-    global_gate: bool | None,
-) -> None:
-    if role != "user" or task_class != TODO_TASK_CLASS_USER_GATE:
-        return
-    if global_gate and blocks_agent:
-        raise ValueError(
-            "user_gate cannot set both blocks_agent and global_gate=true; "
-            "use blocks_agent for one registered agent or global_gate=true for a goal-wide gate"
-        )
-    registered_agents = registered_agent_ids_from_registry(registry_path, goal_id)
-    if len(registered_agents) <= 1:
-        return
-    if blocks_agent or global_gate is True:
-        return
-    raise ValueError(
-        "multi-agent user_gate requires an explicit scope: pass --blocks-agent "
-        "<registered-agent> (or --agent-id <registered-agent> for authoring) "
-        "when the gate blocks one lane, or pass --global-gate when it genuinely "
-        "blocks every registered agent"
-    )
 
 
 def add_goal_todo(


### PR DESCRIPTION
## Summary
- move user todo/task_class and user_gate scope write policy into control_plane/todos/write_policy.py
- keep loopx/todos.py as the active-state mutation path while removing embedded policy helpers
- extend todo CLI smoke for user_gate task_class misuse and user_action/global_gate rejection

## Validation
- python3 -m py_compile loopx/todos.py loopx/control_plane/todos/write_policy.py examples/control_plane/todo-cli-smoke.py examples/control_plane/todo-user-gate-scope-smoke.py examples/control_plane/quota-agent-scoped-user-gate-smoke.py examples/control_plane/heartbeat-quota-flow-smoke.py
- python3 examples/control_plane/todo-cli-smoke.py
- python3 examples/control_plane/todo-user-gate-scope-smoke.py
- python3 examples/control_plane/quota-agent-scoped-user-gate-smoke.py
- python3 examples/control_plane/heartbeat-quota-flow-smoke.py
- python3 examples/control_plane/repo-python-line-budget-smoke.py
- git diff --check
- loopx canary premerge --from-git-diff (passed: catalog 8/8, risk 8/8, public boundary 1/1, holds 0)

## Boundary
- Public-safe control-plane refactor only; no benchmark execution, raw logs, trajectories, verifier output, credentials, or local/private evidence.