### PR TITLE
Link auto-research successor todos

### DIFF
--- a/examples/auto-research-worker-turn-smoke.py
+++ b/examples/auto-research-worker-turn-smoke.py
@@ -20,6 +20,24 @@ from loopx.capabilities.auto_research.demo_e2e import _seed_visible_demo_control
 from loopx.capabilities.auto_research.demo_supervisor import (  # noqa: E402
     build_auto_research_demo_supervisor_plan,
 )
+from loopx.capabilities.auto_research.evidence_packet import (  # noqa: E402
+    build_auto_research_evidence_packet,
+)
+from loopx.capabilities.auto_research.rollout_append import (  # noqa: E402
+    append_auto_research_rollout_events,
+)
+from loopx.todos import add_goal_todo  # noqa: E402
+
+from examples.auto_research_lightweight_fixture import (  # noqa: E402
+    AGENT_ID as EVIDENCE_AGENT_ID,
+    GROUNDING_REF,
+    HYPOTHESIS_ID,
+    HYPOTHESIS_TEXT,
+    MECHANISM_FAMILY,
+    TODO_ID as EVIDENCE_TODO_ID,
+    eval_result,
+    research_contract,
+)
 
 
 GOAL_ID = "loopx-auto-research-demo"
@@ -125,6 +143,79 @@ def assert_no_action(payload: dict[str, Any], *, agent_id: str) -> None:
     assert_public_safe(payload)
 
 
+def write_summary_state(path: Path) -> None:
+    path.write_text(
+        "\n".join(
+            [
+                "# Auto Research Worker Summary Smoke",
+                "",
+                "## User Todo / Owner Review Reading Queue",
+                "",
+                "## Agent Todo",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def write_registry(path: Path, *, project: Path, state_file: Path, runtime_root: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "common_runtime_root": str(runtime_root),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "auto_research_smoke",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": str(state_file),
+                        "coordination": {
+                            "primary_agent": CURATOR_AGENT_ID,
+                            "registered_agents": [
+                                CURATOR_AGENT_ID,
+                                "hypothesis-proposer",
+                                EXECUTOR_AGENT_ID,
+                                EVALUATOR_AGENT_ID,
+                            ]
+                        },
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def append_real_fixture_evidence(*, registry: Path, runtime_root: Path, temp: Path) -> None:
+    packet = build_auto_research_evidence_packet(
+        contract=research_contract(goal_id=GOAL_ID),
+        eval_results=[eval_result("dev"), eval_result("holdout")],
+        hypothesis_id=HYPOTHESIS_ID,
+        todo_id=EVIDENCE_TODO_ID,
+        agent_id=EVIDENCE_AGENT_ID,
+        claimed_by=EVIDENCE_AGENT_ID,
+        mechanism_family=MECHANISM_FAMILY,
+        hypothesis=HYPOTHESIS_TEXT,
+        grounding_refs=[GROUNDING_REF],
+        branch_ref="codex/auto-research-worker-turn-smoke",
+    )
+    packet_path = temp / "real-evidence-packet.public.json"
+    packet_path.write_text(json.dumps(packet, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    appended = append_auto_research_rollout_events(
+        packet_path=str(packet_path),
+        registry_path=registry,
+        runtime_root_arg=str(runtime_root),
+        dry_run=False,
+    )
+    assert appended["appended_count"] == 3, appended
+    assert_public_safe(appended)
+
+
 def main() -> int:
     with tempfile.TemporaryDirectory() as temp_dir:
         temp = Path(temp_dir)
@@ -189,6 +280,61 @@ def main() -> int:
             complete=False,
         )
         assert_no_action(evaluator_execute, agent_id=EVALUATOR_AGENT_ID)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        project = temp / "project"
+        project.mkdir()
+        state_file = project / "ACTIVE_GOAL_STATE.md"
+        registry = temp / "registry.json"
+        runtime_root = temp / "runtime"
+        write_summary_state(state_file)
+        write_registry(registry, project=project, state_file=state_file, runtime_root=runtime_root)
+        summary_todo = add_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            role="agent",
+            text=(
+                "[P0-auto-research-live] Summarize held-out validation and "
+                "open the next research round."
+            ),
+            task_class="advancement_task",
+            action_kind="write_evaluation_summary",
+            claimed_by=EVALUATOR_AGENT_ID,
+            dry_run=False,
+        )
+        summary_todo_id = summary_todo["todo_id"]
+        append_real_fixture_evidence(registry=registry, runtime_root=runtime_root, temp=temp)
+        workspace = project / "visible-workspace"
+        workspace.mkdir()
+
+        evaluator_summary = run_worker_turn(
+            registry=registry,
+            runtime_root=runtime_root,
+            workspace=workspace,
+            agent_id=EVALUATOR_AGENT_ID,
+            execute=True,
+            complete=True,
+        )
+        assert evaluator_summary["mode"] == "execute", evaluator_summary
+        assert evaluator_summary["selected_action"] == "write_evaluation_summary", evaluator_summary
+        successor_todos = evaluator_summary["successor_todos"]
+        assert successor_todos["executed"] is True, successor_todos
+        successor_ids = [
+            successor["todo_id"]
+            for successor in successor_todos["successors"]
+            if successor.get("todo_id")
+        ]
+        assert len(successor_ids) == 2, successor_todos
+        completion = evaluator_summary["completion"]
+        assert completion["executed"] is True, completion
+        assert completion["successor_todo_ids"] == successor_ids, evaluator_summary
+        state_text = state_file.read_text(encoding="utf-8")
+        assert f"todo_id={summary_todo_id} status=done" in state_text, state_text
+        assert "no_followup=true" not in state_text, state_text
+        for successor_id in successor_ids:
+            assert successor_id in state_text, state_text
+        assert_public_safe(evaluator_summary)
     return 0
 
 

--- a/loopx/capabilities/auto_research/worker_runtime.py
+++ b/loopx/capabilities/auto_research/worker_runtime.py
@@ -295,6 +295,20 @@ def _maybe_add_role_successor_todos(
     )
 
 
+def _executed_successor_todo_ids(successor_todos: dict[str, object]) -> list[str]:
+    successors = successor_todos.get("successors")
+    if not isinstance(successors, list):
+        return []
+    todo_ids: list[str] = []
+    for successor in successors:
+        if not isinstance(successor, dict):
+            continue
+        todo_id = successor.get("todo_id")
+        if isinstance(todo_id, str) and todo_id:
+            todo_ids.append(todo_id)
+    return todo_ids
+
+
 def _generic_handoff_is_satisfied(
     *,
     selected: dict[str, object],
@@ -387,9 +401,11 @@ def _complete_selected_todo(
     agent_id: str,
     action: str,
     execute: bool,
+    successor_todo_ids: list[str] | None = None,
 ) -> dict[str, object]:
     if not execute:
         return {"requested": True, "executed": False}
+    linked_successors = successor_todo_ids or []
     result = complete_goal_todo(
         registry_path=registry_path,
         goal_id=goal_id,
@@ -401,7 +417,8 @@ def _complete_selected_todo(
             f"state-summary agent={agent_id} action={action} wrote public-safe local artifact "
             "and obeyed quota/frontier before completion"
         ),
-        no_followup=True,
+        no_followup=not linked_successors,
+        successor_todo_ids=linked_successors or None,
         side_agent_self_merged=True,
         dry_run=False,
     )
@@ -413,6 +430,7 @@ def _complete_selected_todo(
         "todo_id": result.get("todo_id"),
         "status": "done" if result.get("completed") else None,
         "side_agent_self_merged": bool(result.get("side_agent_self_merged")),
+        "successor_todo_ids": result.get("successor_todo_ids") or linked_successors,
     }
 
 
@@ -609,6 +627,7 @@ def run_auto_research_worker_turn(
             decision_summary=artifact["decision_summary"],
             execute=True,
         )
+        successor_todo_ids = _executed_successor_todo_ids(successor_todos)
         followup = first_successor_followup(successor_todos)
         completion = (
             _complete_selected_todo(
@@ -618,6 +637,7 @@ def run_auto_research_worker_turn(
                 agent_id=agent_id,
                 action=action,
                 execute=True,
+                successor_todo_ids=successor_todo_ids,
             )
             if complete_selected_todo
             else {"requested": False}


### PR DESCRIPTION
## Summary
- link role-created auto-research successor todo ids when completing a selected worker todo
- only mark no-followup when no successor was created
- add a worker-turn regression with real rollout evidence proving evaluator completion leaves runnable successor todos

## Validation
- python3 examples/auto-research-worker-turn-smoke.py
- python3 examples/auto-research-knn-continuation-smoke.py
- python3 examples/auto-research-minimal-kernel-smoke.py
- python3 examples/multi-agent-role-successor-todos-smoke.py
- python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- python3 -m py_compile loopx/capabilities/auto_research/worker_runtime.py examples/auto-research-worker-turn-smoke.py
- git diff --check
- loopx canary premerge --from-git-diff (passed; self_merge_allowed=true)

## Self-merge rationale
Narrow runtime/smoke fix for auto-research successor visibility. It does not add fake metrics, does not touch benchmark scoring, and premerge/public-boundary checks passed.