### PR TITLE
refactor: extract active-state todo editing helpers

### DIFF
--- a/examples/control_plane/repo-python-line-budget-smoke.py
+++ b/examples/control_plane/repo-python-line-budget-smoke.py
@@ -41,10 +41,6 @@ LEGACY_OVERSIZED_RETIREMENT_PLANS = {
         "and route attribution helpers into focused adapter modules, then lower "
         "this pin again."
     ),
-    "loopx/todos.py": (
-        "Continue moving todo lifecycle read/write helpers into "
-        "loopx.control_plane.todos modules, then lower this pin again."
-    ),
     "scripts/skillsbench_automation_loop.py": (
         "Extract native app-server Goal/reduce-only closeout helpers into "
         "scripts or benchmark adapter modules, then lower this pin again."
@@ -74,7 +70,6 @@ LEGACY_OVERSIZED_LIMITS = {
     "loopx/quota.py": 10628,
     "loopx/status.py": 11758,
     "loopx/terminal_bench_agent.py": 2056,
-    "loopx/todos.py": 2119,
     "scripts/harbor_host_codex_goal_agent.py": 2140,
     "scripts/skillsbench_automation_loop.py": 17631,
 }
@@ -86,7 +81,6 @@ RETIREMENT_PLAN_REQUIRED_PATHS = {
     "loopx/benchmark_adapters/skillsbench.py",
     "loopx/benchmark_adapters/skillsbench_acp_relay.py",
     "loopx/benchmark_adapters/terminal_bench.py",
-    "loopx/todos.py",
     "scripts/skillsbench_automation_loop.py",
 }
 

--- a/loopx/control_plane/todos/active_state_editing.py
+++ b/loopx/control_plane/todos/active_state_editing.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from ..goals.active_state_metadata import todo_role_for_heading
+from .contract import (
+    TODO_STATUS_DONE,
+    TODO_STATUS_OPEN,
+    TODO_TASK_PATTERN,
+    build_todo_id,
+    normalize_todo_status,
+    parse_todo_metadata_line,
+    todo_done_for_status,
+    todo_status_from_marker,
+)
+from .todo_summary import normalize_todo_text
+
+
+TODO_SECTION_HEADINGS = {
+    "user": "User Todo / Owner Review Reading Queue",
+    "agent": "Agent Todo",
+}
+COMPLETED_WORK_ARCHIVE_HEADING = "Completed Work Archive"
+
+
+def section_bounds(lines: list[str], role: str) -> tuple[int, int, str] | None:
+    for index, line in enumerate(lines):
+        if not line.startswith("## "):
+            continue
+        heading = line.lstrip("#").strip()
+        if todo_role_for_heading(heading) != role:
+            continue
+        end = len(lines)
+        for next_index in range(index + 1, len(lines)):
+            if lines[next_index].startswith("## "):
+                end = next_index
+                break
+        return index, end, heading
+    return None
+
+
+def heading_index(lines: list[str], heading: str) -> int | None:
+    needle = f"## {heading}"
+    for index, line in enumerate(lines):
+        if line.strip() == needle:
+            return index
+    return None
+
+
+def insert_into_existing_section(lines: list[str], start: int, end: int, todo_line: str) -> None:
+    insert_at = end
+    while insert_at > start + 1 and not lines[insert_at - 1].strip():
+        insert_at -= 1
+    new_lines = todo_line.splitlines()
+    if insert_at == start + 1:
+        new_lines.insert(0, "")
+    if insert_at == end and end < len(lines) and lines[end].startswith("## "):
+        new_lines.append("")
+    lines[insert_at:insert_at] = new_lines
+
+
+def insertion_anchor(lines: list[str], role: str) -> int:
+    if role == "user":
+        agent_bounds = section_bounds(lines, "agent")
+        if agent_bounds:
+            return agent_bounds[0]
+    next_action = heading_index(lines, "Next Action")
+    if next_action is not None:
+        return next_action
+    return len(lines)
+
+
+def insert_new_section(lines: list[str], role: str, todo_line: str) -> None:
+    anchor = insertion_anchor(lines, role)
+    heading = TODO_SECTION_HEADINGS[role]
+    section = [f"## {heading}", "", *todo_line.splitlines(), ""]
+    if anchor > 0 and lines[anchor - 1].strip():
+        section.insert(0, "")
+    lines[anchor:anchor] = section
+
+
+def archive_section_bounds(lines: list[str]) -> tuple[int, int] | None:
+    start = heading_index(lines, COMPLETED_WORK_ARCHIVE_HEADING)
+    if start is None:
+        return None
+    end = len(lines)
+    for next_index in range(start + 1, len(lines)):
+        if lines[next_index].startswith("## "):
+            end = next_index
+            break
+    return start, end
+
+
+def ensure_archive_section(lines: list[str]) -> tuple[int, int]:
+    bounds = archive_section_bounds(lines)
+    if bounds:
+        return bounds
+    if lines and lines[-1].strip():
+        lines.append("")
+    start = len(lines)
+    lines.extend([f"## {COMPLETED_WORK_ARCHIVE_HEADING}", ""])
+    return start, len(lines)
+
+
+def ensure_block_identity(
+    block: dict[str, Any],
+    *,
+    role: str | None,
+    source_section: str | None,
+) -> dict[str, Any]:
+    if block.get("status"):
+        status = normalize_todo_status(block.get("status")) or TODO_STATUS_OPEN
+    else:
+        status = TODO_STATUS_DONE if block.get("done") else TODO_STATUS_OPEN
+    block["status"] = status
+    block["done"] = todo_done_for_status(status)
+    if not block.get("todo_id"):
+        block["todo_id"] = build_todo_id(
+            role=role,
+            source_section=source_section,
+            index=block.get("index"),
+            text=block.get("text"),
+        )
+    return block
+
+
+def todo_blocks(
+    lines: list[str],
+    start: int,
+    end: int,
+    *,
+    role: str | None = None,
+    source_section: str | None = None,
+) -> list[dict[str, Any]]:
+    blocks: list[dict[str, Any]] = []
+    current: dict[str, Any] | None = None
+    todo_index = 0
+    for index in range(start + 1, end):
+        match = TODO_TASK_PATTERN.match(lines[index])
+        if match:
+            if current is not None:
+                current["end"] = index
+                ensure_block_identity(current, role=role, source_section=source_section)
+                blocks.append(current)
+            marker, text = match.groups()
+            todo_index += 1
+            status = todo_status_from_marker(marker)
+            current = {
+                "start": index,
+                "end": end,
+                "index": todo_index,
+                "done": todo_done_for_status(status),
+                "status": status,
+                "text": normalize_todo_text(text),
+            }
+            continue
+        if current is not None and lines[index].startswith((" ", "\t")):
+            metadata = parse_todo_metadata_line(lines[index])
+            if metadata:
+                current.update(metadata)
+                continue
+            continuation = lines[index].strip()
+            if continuation:
+                current["text"] = normalize_todo_text(
+                    f"{current.get('text', '')} {continuation}"
+                )
+    if current is not None:
+        current["end"] = end
+        ensure_block_identity(current, role=role, source_section=source_section)
+        blocks.append(current)
+    return blocks
+
+
+def insert_archive_blocks(lines: list[str], blocks: list[list[str]]) -> None:
+    if not blocks:
+        return
+    bounds = ensure_archive_section(lines)
+    insert_at = bounds[1]
+    while insert_at > bounds[0] + 1 and not lines[insert_at - 1].strip():
+        insert_at -= 1
+    new_lines: list[str] = []
+    if insert_at == bounds[0] + 1:
+        new_lines.append("")
+    for block in blocks:
+        new_lines.extend(block)
+    if insert_at < len(lines) and lines[insert_at].startswith("## "):
+        new_lines.append("")
+    lines[insert_at:insert_at] = new_lines
+
+
+def replace_updated_at(text: str, updated_at: str) -> str:
+    if not text.startswith("---"):
+        return text
+    parts = text.split("---", 2)
+    if len(parts) < 3:
+        return text
+    frontmatter = parts[1]
+    body = parts[2]
+    if re.search(r"(?m)^updated_at:\s*.+$", frontmatter):
+        frontmatter = re.sub(
+            r"(?m)^updated_at:\s*.+$",
+            f"updated_at: {updated_at}",
+            frontmatter,
+            count=1,
+        )
+    else:
+        frontmatter = frontmatter.rstrip("\n") + f"\nupdated_at: {updated_at}\n"
+    return "---" + frontmatter + "---" + body

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -13,7 +13,6 @@ from .file_lock import exclusive_file_lock
 from .history import load_registry
 from .control_plane.runtime.local_state_write_correctness import build_todo_write_correctness_dry_run_packet
 from .state_refresh import now_local, resolve_goal_state
-from .control_plane.goals.active_state_metadata import todo_role_for_heading
 from .status import (
     MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE,
     active_state_event_projection_fields,
@@ -26,7 +25,6 @@ from .control_plane.todos.contract import (
     TODO_STATUS_DONE,
     TODO_STATUS_OPEN,
     TODO_TASK_CLASS_USER_GATE,
-    TODO_TASK_PATTERN,
     build_todo_id,
     format_todo_metadata_line,
     normalize_required_capabilities,
@@ -45,7 +43,16 @@ from .control_plane.todos.contract import (
     parse_todo_metadata_line,
     todo_done_for_status,
     todo_marker_for_status,
-    todo_status_from_marker,
+)
+from .control_plane.todos.active_state_editing import (
+    COMPLETED_WORK_ARCHIVE_HEADING,
+    TODO_SECTION_HEADINGS,
+    insert_archive_blocks,
+    insert_into_existing_section,
+    insert_new_section,
+    replace_updated_at,
+    section_bounds,
+    todo_blocks,
 )
 from .control_plane.todos.completion_policy import (
     linked_successor_from_todo,
@@ -59,16 +66,10 @@ from .control_plane.todos.monitor_metadata import require_monitor_metadata_scope
 from .control_plane.todos.text import (
     inherit_todo_priority,
     normalize_new_todo,
-    todo_priority_prefix,
 )
 from .control_plane.todos.write_policy import require_user_gate_scope, require_user_todo_task_class
 
 
-TODO_SECTION_HEADINGS = {
-    "user": "User Todo / Owner Review Reading Queue",
-    "agent": "Agent Todo",
-}
-COMPLETED_WORK_ARCHIVE_HEADING = "Completed Work Archive"
 TODO_METADATA_FIELDS = (
     "todo_id",
     "status",
@@ -152,149 +153,6 @@ def resolve_todo_state_path(
     if not resolved_state_file.exists():
         raise ValueError(f"active state file does not exist: {resolved_state_file}")
     return resolved_project, resolved_state_file
-
-
-def section_bounds(lines: list[str], role: str) -> tuple[int, int, str] | None:
-    for index, line in enumerate(lines):
-        if not line.startswith("## "):
-            continue
-        heading = line.lstrip("#").strip()
-        if todo_role_for_heading(heading) != role:
-            continue
-        end = len(lines)
-        for next_index in range(index + 1, len(lines)):
-            if lines[next_index].startswith("## "):
-                end = next_index
-                break
-        return index, end, heading
-    return None
-
-
-def heading_index(lines: list[str], heading: str) -> int | None:
-    needle = f"## {heading}"
-    for index, line in enumerate(lines):
-        if line.strip() == needle:
-            return index
-    return None
-
-
-def insert_into_existing_section(lines: list[str], start: int, end: int, todo_line: str) -> None:
-    insert_at = end
-    while insert_at > start + 1 and not lines[insert_at - 1].strip():
-        insert_at -= 1
-    new_lines = todo_line.splitlines()
-    if insert_at == start + 1:
-        new_lines.insert(0, "")
-    if insert_at == end and end < len(lines) and lines[end].startswith("## "):
-        new_lines.append("")
-    lines[insert_at:insert_at] = new_lines
-
-
-def insertion_anchor(lines: list[str], role: str) -> int:
-    if role == "user":
-        agent_bounds = section_bounds(lines, "agent")
-        if agent_bounds:
-            return agent_bounds[0]
-    next_action = heading_index(lines, "Next Action")
-    if next_action is not None:
-        return next_action
-    return len(lines)
-
-
-def insert_new_section(lines: list[str], role: str, todo_line: str) -> None:
-    anchor = insertion_anchor(lines, role)
-    heading = TODO_SECTION_HEADINGS[role]
-    section = [f"## {heading}", "", *todo_line.splitlines(), ""]
-    if anchor > 0 and lines[anchor - 1].strip():
-        section.insert(0, "")
-    lines[anchor:anchor] = section
-
-
-def archive_section_bounds(lines: list[str]) -> tuple[int, int] | None:
-    start = heading_index(lines, COMPLETED_WORK_ARCHIVE_HEADING)
-    if start is None:
-        return None
-    end = len(lines)
-    for next_index in range(start + 1, len(lines)):
-        if lines[next_index].startswith("## "):
-            end = next_index
-            break
-    return start, end
-
-
-def ensure_archive_section(lines: list[str]) -> tuple[int, int]:
-    bounds = archive_section_bounds(lines)
-    if bounds:
-        return bounds
-    if lines and lines[-1].strip():
-        lines.append("")
-    start = len(lines)
-    lines.extend([f"## {COMPLETED_WORK_ARCHIVE_HEADING}", ""])
-    return start, len(lines)
-
-
-def ensure_block_identity(block: dict[str, Any], *, role: str | None, source_section: str | None) -> dict[str, Any]:
-    if block.get("status"):
-        status = normalize_todo_status(block.get("status")) or TODO_STATUS_OPEN
-    else:
-        status = TODO_STATUS_DONE if block.get("done") else TODO_STATUS_OPEN
-    block["status"] = status
-    block["done"] = todo_done_for_status(status)
-    if not block.get("todo_id"):
-        block["todo_id"] = build_todo_id(
-            role=role,
-            source_section=source_section,
-            index=block.get("index"),
-            text=block.get("text"),
-        )
-    return block
-
-
-def todo_blocks(
-    lines: list[str],
-    start: int,
-    end: int,
-    *,
-    role: str | None = None,
-    source_section: str | None = None,
-) -> list[dict[str, Any]]:
-    blocks: list[dict[str, Any]] = []
-    current: dict[str, Any] | None = None
-    todo_index = 0
-    for index in range(start + 1, end):
-        match = TODO_TASK_PATTERN.match(lines[index])
-        if match:
-            if current is not None:
-                current["end"] = index
-                ensure_block_identity(current, role=role, source_section=source_section)
-                blocks.append(current)
-            marker, text = match.groups()
-            todo_index += 1
-            status = todo_status_from_marker(marker)
-            current = {
-                "start": index,
-                "end": end,
-                "index": todo_index,
-                "done": todo_done_for_status(status),
-                "status": status,
-                "text": normalize_todo_text(text),
-            }
-            continue
-        if current is not None and lines[index].startswith((" ", "\t")):
-            metadata = parse_todo_metadata_line(lines[index])
-            if metadata:
-                current.update(metadata)
-                continue
-            continuation = lines[index].strip()
-            if continuation:
-                current["text"] = normalize_todo_text(
-                    f"{current.get('text', '')} {continuation}"
-                )
-    if current is not None:
-        current["end"] = end
-        ensure_block_identity(current, role=role, source_section=source_section)
-        blocks.append(current)
-    return blocks
 
 
 def todo_item_status(item: dict[str, Any]) -> str:
@@ -585,38 +443,6 @@ def list_goal_todos(
     if projection_fields.get("state_event_projection_warning"):
         payload["state_event_projection_warning"] = projection_fields["state_event_projection_warning"]
     return payload
-
-
-def insert_archive_blocks(lines: list[str], blocks: list[list[str]]) -> None:
-    if not blocks:
-        return
-    bounds = ensure_archive_section(lines)
-    insert_at = bounds[1]
-    while insert_at > bounds[0] + 1 and not lines[insert_at - 1].strip():
-        insert_at -= 1
-    new_lines: list[str] = []
-    if insert_at == bounds[0] + 1:
-        new_lines.append("")
-    for block in blocks:
-        new_lines.extend(block)
-    if insert_at < len(lines) and lines[insert_at].startswith("## "):
-        new_lines.append("")
-    lines[insert_at:insert_at] = new_lines
-
-
-def replace_updated_at(text: str, updated_at: str) -> str:
-    if not text.startswith("---"):
-        return text
-    parts = text.split("---", 2)
-    if len(parts) < 3:
-        return text
-    frontmatter = parts[1]
-    body = parts[2]
-    if re.search(r"(?m)^updated_at:\s*.+$", frontmatter):
-        frontmatter = re.sub(r"(?m)^updated_at:\s*.+$", f"updated_at: {updated_at}", frontmatter, count=1)
-    else:
-        frontmatter = frontmatter.rstrip("\n") + f"\nupdated_at: {updated_at}\n"
-    return "---" + frontmatter + "---" + body
 
 
 def matching_todo_block(


### PR DESCRIPTION
## Summary
- Extract active-state Markdown section/block editing helpers from `loopx/todos.py` into `loopx/control_plane/todos/active_state_editing.py`.
- Keep shipped todo CLI behavior unchanged while giving todo active-state writeback a bounded-context home.
- Retire the `loopx/todos.py` legacy line-budget entry because the file is now below the default 2000-line cap.

## Validation
- `python3 -m py_compile loopx/todos.py loopx/control_plane/todos/active_state_editing.py examples/control_plane/repo-python-line-budget-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `python3 examples/control_plane/todo-archive-completed-smoke.py`
- `python3 examples/control_plane/todo-cli-smoke.py`
- `python3 examples/control_plane/todo-lifecycle-cli-smoke.py`
- `python3 examples/control_plane/todo-list-event-projection-smoke.py`
- `python3 examples/control_plane/todo-user-gate-scope-smoke.py`
- `python3 examples/control_plane/todo-contract-smoke.py`
- `loopx canary premerge --from-git-diff`

## Boundary
- Non-benchmark control-plane refactor only.
- No raw benchmark logs, trajectories, verifier output, credentials, or local/private paths in candidate paths.
