### PR TITLE
fix: keep visible auto-research on role-frontier routing

### DIFF
--- a/examples/auto-research-worker-loop-smoke.py
+++ b/examples/auto-research-worker-loop-smoke.py
@@ -20,6 +20,7 @@ from loopx.capabilities.auto_research.demo_e2e import _seed_visible_demo_control
 from loopx.capabilities.auto_research.demo_supervisor import (  # noqa: E402
     build_auto_research_demo_supervisor_plan,
 )
+from loopx.state_projection import state_projection_gap_warning  # noqa: E402
 
 
 GOAL_ID = "loopx-auto-research-demo"
@@ -71,6 +72,28 @@ def main() -> int:
             objective="Verify worker-loop cannot manufacture auto-research evidence.",
             supervisor=supervisor,
         )
+        state_file = (
+            temp
+            / "visible-control-plane"
+            / ".codex"
+            / "goals"
+            / GOAL_ID
+            / "ACTIVE_GOAL_STATE.md"
+        )
+        state_text = state_file.read_text(encoding="utf-8")
+        assert "Run `loopx check` against the project registry" not in state_text
+        assert (
+            "Goal-level route delegates to role frontier; panes own execution."
+            in state_text
+        )
+        route_only_state = (
+            "## Agent Todo\n\n"
+            "- [x] Complete role-frontier auto-research work.\n\n"
+            "## Next Action\n\n"
+            "- Goal-level route delegates to role frontier; panes own execution.\n"
+        )
+        assert state_projection_gap_warning(route_only_state) is None
+
         workspace = temp / "shared-research-workspace"
         workspace.mkdir()
         env = os.environ.copy()

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -105,6 +105,7 @@ def _seed_visible_demo_control_plane(
 
     from ...bootstrap import bootstrap_project
     from ...configure_goal import configure_goal
+    from ...state_refresh import now_local, replace_next_action_section
     from ...todos import add_goal_todo
 
     control_project = demo_root / "visible-control-plane"
@@ -137,6 +138,17 @@ def _seed_visible_demo_control_plane(
         dry_run=False,
         sync_global=False,
     )
+    state_file = control_project / ".codex" / "goals" / goal_id / "ACTIVE_GOAL_STATE.md"
+    if state_file.exists():
+        updated_state, state_changed = replace_next_action_section(
+            state_file.read_text(encoding="utf-8"),
+            next_action=(
+                "Goal-level route delegates to role frontier; panes own execution."
+            ),
+            updated_at=now_local(),
+        )
+        if state_changed:
+            state_file.write_text(updated_state, encoding="utf-8")
 
     lanes = [lane for lane in supervisor.get("lanes") or [] if isinstance(lane, dict)]
     agents = sorted(


### PR DESCRIPTION
## Summary
- replace the generic bootstrap Next Action in the visible auto-research control plane with a role-frontier routing statement
- prevent completed role-frontier demos from being mistaken for state-projection gaps after all role todos are done
- extend the worker-loop smoke so this default route cannot regress back to an executable bootstrap command

## Context
A real visible KNN auto-research run completed the role chain and evaluator validation, but the seed state still carried the generic `Run loopx check...` Next Action. Once role todos were complete, projection classified that stale bootstrap line as an actionable gap. The fix keeps work routing in role frontier / Agent Todo state instead of goal-level bootstrap prose.

## Validation
- `python3 examples/auto-research-worker-loop-smoke.py`
- `python3 examples/state-projection-gap-smoke.py`
- `python3 examples/auto-research-worker-turn-smoke.py`
- `python3 -m compileall -q loopx/capabilities/auto_research/demo_e2e.py examples/auto-research-worker-loop-smoke.py`
- `scripts/loopx canary premerge --from-git-diff`
