### PR TITLE
Fix SkillsBench countable-zero debug gate attribution

### DIFF
--- a/examples/skillsbench-post-run-debug-gate-smoke.py
+++ b/examples/skillsbench-post-run-debug-gate-smoke.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Smoke-test SkillsBench post-run debug gate attribution edges."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.status import build_skillsbench_post_run_debug_gate  # noqa: E402
+
+
+def test_countable_zero_keeps_solution_attribution() -> None:
+    compact = {
+        "benchmark_id": "skillsbench@1.1",
+        "official_score": 0.0,
+        "official_score_status": "completed",
+        "official_task_score": {
+            "kind": "skillsbench_verifier_reward",
+            "passed": False,
+            "value": 0.0,
+        },
+        "score_failure_attribution": "official_verifier_solution_failure",
+        "failure_attribution_labels": ["official_verifier_solution_failure"],
+        "case_event_timeline": {
+            "schema_version": "skillsbench_case_event_timeline_v0",
+            "source": "compact_public_signals",
+            "raw_material_recorded": False,
+            "events": [
+                {
+                    "phase": "controller",
+                    "event": "controller_decision_loop",
+                    "status": "stopped_after_one_round",
+                },
+                {
+                    "phase": "scoring",
+                    "event": "official_score_closeout",
+                    "status": "completed",
+                    "official_score_passed": False,
+                },
+                {
+                    "phase": "closeout",
+                    "event": "agent_bridge_closeout",
+                    "status": "missing",
+                },
+            ],
+        },
+        "interaction_counters": {
+            "remote_command_file_bridge_agent_task_facing_operation_count": 15,
+            "remote_command_file_bridge_agent_task_facing_success_count": 15,
+        },
+    }
+
+    gate = build_skillsbench_post_run_debug_gate(compact)
+
+    assert gate["packet_complete"] is True, gate
+    assert gate["case_closeout_complete"] is True, gate
+    assert gate["normal_progress_allowed"] is True, gate
+    assert gate["next_case_gate"] == "open_with_attribution", gate
+    assert gate["attribution_layer"] == "solution_level_unknown", gate
+    assert gate["first_blocker"] == "official_verifier_solution_failure", gate
+    assert gate["missing_field_count"] == 0, gate
+
+
+def main() -> None:
+    test_countable_zero_keeps_solution_attribution()
+    print("skillsbench-post-run-debug-gate-smoke: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -1067,7 +1067,7 @@ def build_skillsbench_post_run_debug_gate(
                 public_safe_compact_text(lifecycle.get("missing_reason"), limit=140)
                 or "loopx_lifecycle_incomplete"
             )
-    elif closeout_status in {"missing", "partial"}:
+    elif closeout_status in {"missing", "partial"} and not case_closeout_complete:
         attribution_layer = "loopx_lifecycle"
         first_blocker = "loopx_closeout_incomplete"
     elif runner_recovery_blocked:


### PR DESCRIPTION
## Summary
- keep SkillsBench post-run debug gate solution attribution when a public packet is complete and the case is countable, even if a stale/missing closeout marker is present
- add a focused smoke for countable official-zero public compact attribution

## Evidence
- Observed tail4 codex-cli-goal xhigh public compacts: 4/4 launcher/case/solver/verifier/official-score countable, 4/4 official score completed with 0.0, and 4/4 public worker bridge activity present.
- Before this fix, the post-run debug gate still projected `first_blocker=loopx_closeout_incomplete` and `attribution_layer=loopx_lifecycle` despite `case_closeout_complete=true` and `missing_field_count=0`.

## Validation
- `python3 examples/skillsbench-post-run-debug-gate-smoke.py`
- targeted adjacent zero-score recovery check via `runpy` against `examples/skillsbench-benchmark-run-smoke.py`
- `loopx canary premerge --from-git-diff`
  - direct checks passed
  - catalog canaries passed
  - risk-profile smokes passed
  - public boundary check passed
  - manual hold: `benchmark_sensitive`

## Manual hold / self-merge note
This is benchmark-sensitive reducer/debug-gate behavior, so the premerge gate intentionally reports a manual hold. The change is narrow, public-safe, does not launch jobs, does not alter scoring or official verifier behavior, and the owner has authorized codex-main-control to self-merge benchmark helper/runtime PRs after focused validation.
