### PR TITLE
refactor: isolate completed todo archive transform

### DIFF
--- a/loopx/control_plane/todos/completed_archive.py
+++ b/loopx/control_plane/todos/completed_archive.py
@@ -2,6 +2,14 @@ from __future__ import annotations
 
 from typing import Any
 
+from .active_state_editing import (
+    COMPLETED_WORK_ARCHIVE_HEADING,
+    TODO_SECTION_HEADINGS,
+    insert_archive_blocks,
+    section_bounds,
+    todo_blocks,
+)
+
 
 DEFAULT_MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE = 12
 
@@ -26,7 +34,7 @@ def completed_todo_archive_warning(
     return {
         "kind": "completed_agent_todo_archive_required",
         "requires_archive": True,
-        "archive_section": "Completed Work Archive",
+        "archive_section": COMPLETED_WORK_ARCHIVE_HEADING,
         "active_done_count": done_count,
         "active_open_count": open_count,
         "max_active_done_count": max_active_done_todos,
@@ -34,4 +42,68 @@ def completed_todo_archive_warning(
             "move older completed Agent Todo entries into a dedicated Completed Work Archive "
             "until the active Agent Todo section keeps only current open work and a small recent-done tail"
         ),
+    }
+
+
+def archive_completed_todo_lines(
+    lines: list[str],
+    *,
+    role: str = "agent",
+    max_active_done: int = DEFAULT_MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE,
+) -> dict[str, Any]:
+    if role not in TODO_SECTION_HEADINGS:
+        raise ValueError("todo role must be one of: user, agent")
+    if max_active_done < 0:
+        raise ValueError("max_active_done must be non-negative")
+
+    updated_lines = list(lines)
+    bounds = section_bounds(updated_lines, role)
+    section = bounds[2] if bounds else TODO_SECTION_HEADINGS[role]
+    moved_blocks: list[list[str]] = []
+    active_done_count = 0
+    moved_count = 0
+    kept_done_count = 0
+
+    if bounds:
+        blocks = todo_blocks(updated_lines, bounds[0], bounds[1], role=role, source_section=section)
+        done_blocks = [block for block in blocks if block.get("done") is True]
+        active_done_count = len(done_blocks)
+        move_count = max(0, active_done_count - max_active_done)
+        move_starts = {int(block["start"]) for block in done_blocks[:move_count]}
+        kept_done_count = active_done_count - move_count
+        for block in done_blocks[:move_count]:
+            moved_blocks.append(updated_lines[int(block["start"]) : int(block["end"])])
+        if move_starts:
+            new_lines: list[str] = []
+            index = 0
+            while index < len(updated_lines):
+                if index in move_starts:
+                    matching = next(
+                        block for block in done_blocks[:move_count] if int(block["start"]) == index
+                    )
+                    index = int(matching["end"])
+                    while (
+                        new_lines
+                        and not new_lines[-1].strip()
+                        and index < len(updated_lines)
+                        and not updated_lines[index].strip()
+                    ):
+                        index += 1
+                    continue
+                new_lines.append(updated_lines[index])
+                index += 1
+            updated_lines = new_lines
+            insert_archive_blocks(updated_lines, moved_blocks)
+            moved_count = move_count
+
+    return {
+        "lines": updated_lines,
+        "changed": moved_count > 0,
+        "role": role,
+        "section": section,
+        "archive_section": COMPLETED_WORK_ARCHIVE_HEADING,
+        "active_done_before": active_done_count,
+        "active_done_after": kept_done_count,
+        "max_active_done": max_active_done,
+        "moved_count": moved_count,
     }

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -45,15 +45,14 @@ from .control_plane.todos.contract import (
     todo_marker_for_status,
 )
 from .control_plane.todos.active_state_editing import (
-    COMPLETED_WORK_ARCHIVE_HEADING,
     TODO_SECTION_HEADINGS,
-    insert_archive_blocks,
     insert_into_existing_section,
     insert_new_section,
     replace_updated_at,
     section_bounds,
     todo_blocks,
 )
+from .control_plane.todos.completed_archive import archive_completed_todo_lines
 from .control_plane.todos.completion_policy import (
     linked_successor_from_todo,
     resolve_completion_policy,
@@ -1669,49 +1668,15 @@ def archive_completed_todos(
     with exclusive_file_lock(resolved_state_file):
         original = resolved_state_file.read_text(encoding="utf-8")
         lines = original.splitlines()
-        bounds = section_bounds(lines, role)
-        section = bounds[2] if bounds else TODO_SECTION_HEADINGS[role]
-        moved_blocks: list[list[str]] = []
-        active_done_count = 0
-        moved_count = 0
-        kept_done_count = 0
-
-        if bounds:
-            blocks = todo_blocks(lines, bounds[0], bounds[1], role=role, source_section=section)
-            done_blocks = [block for block in blocks if block.get("done") is True]
-            active_done_count = len(done_blocks)
-            move_count = max(0, active_done_count - max_active_done)
-            move_starts = {int(block["start"]) for block in done_blocks[:move_count]}
-            kept_done_count = active_done_count - move_count
-            for block in done_blocks[:move_count]:
-                moved_blocks.append(lines[int(block["start"]) : int(block["end"])])
-            if move_starts:
-                new_lines: list[str] = []
-                index = 0
-                while index < len(lines):
-                    if index in move_starts:
-                        matching = next(
-                            block
-                            for block in done_blocks[:move_count]
-                            if int(block["start"]) == index
-                        )
-                        index = int(matching["end"])
-                        while (
-                            new_lines
-                            and not new_lines[-1].strip()
-                            and index < len(lines)
-                            and not lines[index].strip()
-                        ):
-                            index += 1
-                        continue
-                    new_lines.append(lines[index])
-                    index += 1
-                lines = new_lines
-                insert_archive_blocks(lines, moved_blocks)
-                moved_count = move_count
+        archive_result = archive_completed_todo_lines(
+            lines,
+            role=role,
+            max_active_done=max_active_done,
+        )
+        lines = archive_result.pop("lines")
 
         updated_at = now_local()
-        changed = moved_count > 0
+        changed = bool(archive_result["changed"])
         new_text = "\n".join(lines) + ("\n" if original.endswith("\n") else "")
         if changed:
             new_text = replace_updated_at(new_text, updated_at)
@@ -1721,15 +1686,8 @@ def archive_completed_todos(
     return {
         "ok": True,
         "dry_run": dry_run,
-        "changed": changed,
         "goal_id": goal_id,
-        "role": role,
-        "section": section,
-        "archive_section": COMPLETED_WORK_ARCHIVE_HEADING,
-        "active_done_before": active_done_count,
-        "active_done_after": kept_done_count,
-        "max_active_done": max_active_done,
-        "moved_count": moved_count,
+        **archive_result,
         "state_file": str(resolved_state_file),
         "project": str(resolved_project) if resolved_project else None,
         "updated_at": updated_at if changed else None,


### PR DESCRIPTION
## Summary
- Move completed-todo archive section/block transform into `loopx.control_plane.todos.completed_archive`.
- Keep `loopx/todos.py` responsible for CLI payload, path resolution, locking, timestamping, and file writeback.
- Reuse the active-state editing seam from PR #1525 so archive warning and archive write transform live in the todo bounded context.

## Validation
- `python3 -m py_compile loopx/todos.py loopx/control_plane/todos/completed_archive.py loopx/control_plane/todos/active_state_editing.py`
- `python3 examples/control_plane/todo-archive-completed-smoke.py`
- `python3 examples/control_plane/todo-lifecycle-cli-smoke.py`
- `python3 examples/control_plane/todo-cli-smoke.py`
- `python3 examples/control_plane/todo-list-event-projection-smoke.py`
- `python3 examples/control_plane/todo-user-gate-scope-smoke.py`
- `python3 examples/control_plane/todo-contract-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `git diff --check`
- `loopx canary premerge --from-git-diff`

## Boundary
- Non-benchmark control-plane refactor only.
- No raw benchmark logs, trajectories, verifier output, credentials, or local/private paths in candidate paths.
