### PR TITLE
fix: keep archived handoff gates out of active readmodels

### DIFF
--- a/examples/control_plane/quota-cleared-blocker-successor-gate-smoke.py
+++ b/examples/control_plane/quota-cleared-blocker-successor-gate-smoke.py
@@ -215,6 +215,12 @@ def no_followup_handoff_review() -> dict:
     )
 
 
+def archived_handoff_review() -> dict:
+    item = handoff_review(status="done")
+    item["archive_state"] = "completed_archive"
+    return item
+
+
 def value_successor() -> dict:
     return todo_item(
         todo_id="todo_value_successor",
@@ -365,6 +371,32 @@ def assert_status_summary_projects_handoff_gate_state() -> None:
     assert gate["blocks_agent"] == BLOCKED_AGENT, gate
 
 
+def assert_archived_completed_blocker_does_not_wake_agent() -> None:
+    summary = compact_todo_group(
+        [archived_handoff_review()],
+        source_section="Agent Todo",
+        role="agent",
+    )
+    assert summary is not None
+    assert "handoff_gates" not in summary, summary
+
+    payload = build_quota_should_run(
+        status_payload(
+            [primary_owned_todo(), archived_handoff_review()],
+            recommended_action="Archived handoff history should not wake the blocked agent.",
+        ),
+        goal_id=GOAL_ID,
+        agent_id=BLOCKED_AGENT,
+    )
+    assert payload["decision"] == "agent_scope_wait", payload
+    assert payload["should_run"] is False, payload
+    assert payload["agent_scope_frontier"]["action"] == "agent_scope_wait", payload
+    assert "current_agent_handoff_gates" not in payload["agent_todo_summary"], payload
+    assert "current_agent_cleared_without_successor_handoff_count" not in (
+        payload["agent_todo_summary"]
+    ), payload
+
+
 def assert_existing_successor_runs_normally() -> None:
     payload = build_quota_should_run(
         status_payload(
@@ -459,6 +491,7 @@ def main() -> int:
     assert_cleared_blocker_requires_successor_replan()
     assert_stale_handoff_closeout_requires_route_continuation_replan()
     assert_status_summary_projects_handoff_gate_state()
+    assert_archived_completed_blocker_does_not_wake_agent()
     assert_existing_successor_runs_normally()
     assert_completed_successor_keeps_old_gate_cleared()
     assert_superseded_completed_blocker_does_not_wake_agent()

--- a/loopx/control_plane/todos/handoff_gate.py
+++ b/loopx/control_plane/todos/handoff_gate.py
@@ -21,6 +21,7 @@ from .contract import (
 
 
 TODO_HANDOFF_GATE_SCHEMA_VERSION = "todo_handoff_gate_v0"
+TODO_ARCHIVE_STATE_ACTIVE = "active"
 
 
 class HandoffGateState(str, Enum):
@@ -45,6 +46,11 @@ def _todo_done(item: dict[str, Any]) -> bool:
 
 def _todo_text(item: dict[str, Any]) -> str:
     return str(item.get("text") or "").strip()
+
+
+def _todo_archive_state(item: dict[str, Any]) -> str:
+    value = str(item.get("archive_state") or TODO_ARCHIVE_STATE_ACTIVE).strip()
+    return value or TODO_ARCHIVE_STATE_ACTIVE
 
 
 def _successor_todo_ids(
@@ -178,6 +184,8 @@ def build_todo_handoff_gate_states(items: Iterable[Any]) -> list[dict[str, Any]]
     gates: list[dict[str, Any]] = []
     seen: set[tuple[str, str]] = set()
     for item in todo_items:
+        if _todo_archive_state(item) != TODO_ARCHIVE_STATE_ACTIVE:
+            continue
         blocks_agent = normalize_todo_blocks_agent(item.get("blocks_agent"))
         if not blocks_agent:
             continue

--- a/loopx/control_plane/todos/todo_summary.py
+++ b/loopx/control_plane/todos/todo_summary.py
@@ -56,6 +56,7 @@ MAX_COMPLETED_SUCCESSION_WARNING_ITEMS = 5
 
 TODO_ITEM_SCHEMA_VERSION = "todo_item_v0"
 TODO_SUCCESSION_WARNING_SCHEMA_VERSION = "todo_succession_warning_v0"
+TODO_ARCHIVE_STATE_ACTIVE = "active"
 AttentionItemBuilder = Callable[..., dict[str, Any]]
 GoalLifecycleFields = Callable[[dict[str, Any], Optional[dict[str, Any]]], dict[str, Any]]
 PublicSafeText = Callable[..., Optional[str]]
@@ -83,6 +84,11 @@ def normalize_todo_text(text: str, *, limit: int = 500) -> str:
     if len(compact) <= limit:
         return compact
     return compact[: limit - 1].rstrip() + "…"
+
+
+def todo_archive_state(item: dict[str, Any]) -> str:
+    value = str(item.get("archive_state") or TODO_ARCHIVE_STATE_ACTIVE).strip()
+    return value or TODO_ARCHIVE_STATE_ACTIVE
 
 
 def active_state_todo_attention_item(
@@ -728,6 +734,8 @@ def todo_successor_todo_ids(
 
 
 def todo_item_is_succession_tracked_completion(item: dict[str, Any]) -> bool:
+    if todo_archive_state(item) != TODO_ARCHIVE_STATE_ACTIVE:
+        return False
     if not item.get("done"):
         return False
     if todo_item_is_deferred(item):
@@ -800,7 +808,12 @@ def compact_todo_group(
     if not items:
         return None
     items = [
-        structured_todo_item(item, role=role, source_section=source_section)
+        structured_todo_item(
+            item,
+            role=role,
+            source_section=source_section,
+            archive_state=todo_archive_state(item),
+        )
         if isinstance(item, dict)
         else item
         for item in items


### PR DESCRIPTION
## Summary

- Preserve `archive_state` when building compact todo summaries.
- Exclude non-active archived todos from handoff-gate state projection.
- Stop archived completed advancement todos from producing current succession warnings.
- Add a control-plane smoke proving archived handoff history does not wake a blocked side-agent.

## Product / Architecture Judgment

Motivation: completed user/review gates can be moved to `Completed Work Archive`, but the readmodel previously normalized archived rows back to active and could keep old handoff gates in quota/status hot paths.

Solved: the fix keeps archived rows as historical state, while active blocking gates, cleared gates without successors, no-followup gates, superseded gates, and real successor gates retain their existing behavior.

User/operator impact: LoopX agents are less likely to be woken by stale historical handoff gates after active-state cleanup, and quota/status summaries become closer to current executable truth.

Main risk: quota/status readmodel compatibility. The change is intentionally narrow and covered by targeted handoff/succession/durability smokes plus risk-based premerge canary.

## Validation

- `python3 -m py_compile loopx/control_plane/todos/handoff_gate.py loopx/control_plane/todos/todo_summary.py examples/control_plane/quota-cleared-blocker-successor-gate-smoke.py`
- `python3 examples/control_plane/quota-cleared-blocker-successor-gate-smoke.py`
- `python3 examples/control_plane/todo-succession-contract-smoke.py`
- `python3 examples/control_plane/todo-durability-fixture-smoke.py`
- `python3 examples/control_plane/todo-cli-smoke.py`
- `python3 examples/control_plane/todo-lifecycle-cli-smoke.py`
- `git diff --check`
- `loopx canary premerge --from-git-diff` after commit: gate passed, self_merge_allowed=true, direct failures 0, catalog 8/8 passed, risk profile 8/8 passed, manual holds 0.

## Boundary

No benchmark execution, scoring, runner behavior, production action, credential, private state, raw logs, trajectory, verifier output, first-screen surface, or Lark Kanban behavior is touched.