### PR TITLE
Fix Codex CLI goal prewarm default

### DIFF
--- a/examples/skillsbench-cli-goal-first-action-timeout-smoke.py
+++ b/examples/skillsbench-cli-goal-first-action-timeout-smoke.py
@@ -57,6 +57,7 @@ def test_codex_cli_goal_first_action_timeout_defaults_to_bounded_watchdog() -> N
             command[command.index("--goal-active-timeout-sec") + 1]
             == str(DEFAULT_CODEX_CLI_GOAL_FIRST_ACTION_TIMEOUT_SEC)
         )
+        assert "--codex-cli-goal-thread-prewarm" not in command
 
         disabled_args = parse_args(
             [

--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -1027,6 +1027,8 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert "build_codex_cli_goal_file_objective(" in source
     assert "tmux_type_text_and_submit(" in source
     assert "build_codex_cli_goal_tui_input(prompt_for_codex)" not in source
+    assert "codex_cli_goal_thread_prewarm: bool = False" in source
+    assert "if self._config.codex_cli_goal_thread_prewarm:" in source
     assert "prewarm_codex_cli_goal_thread(" in source
     assert "thread_prewarm_timeout" in source
     assert "timeout_sec=max(" in source

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -582,6 +582,7 @@ class CodexExecConfig:
     task_output_quiet_timeout_sec: float = 0.0
     reasoning_effort: str | None = None
     codex_api_proxy: str | None = None
+    codex_cli_goal_thread_prewarm: bool = False
     worker_public_trace_dir: str | None = None
     remote_command_file_bridge_command: str | None = None
     remote_command_file_bridge_agent_command: str | None = None
@@ -1246,30 +1247,29 @@ class SkillsBenchLocalAcpRelay:
                     return _recoverable_codex_turn_failure_message(
                         "codex_exec_first_action_timeout"
                     )
-                thread_prewarm_observed = prewarm_codex_cli_goal_thread(
-                    tmux_name=tmux_name,
-                    tmp_path=tmp_path,
-                    timeout_sec=max(
-                        90.0,
-                        float(self._config.first_action_timeout_sec or 0.0),
-                    ),
-                )
-                if not thread_prewarm_observed:
-                    tmux_kill_session(tmux_name)
-                    self._publish_codex_cli_goal_trace(
-                        ok=False,
-                        stage="thread_prewarm_timeout",
-                        goal_active_observed=False,
-                        goal_terminal_observed=False,
-                        first_action_observed=False,
-                        bridge_summary_path=bridge_summary_path,
-                        thread_prewarm_observed=False,
-                        goal_prompt_file_used=goal_prompt_file_used,
-                        goal_command_submission_method=goal_command_submission_method,
+                thread_prewarm_observed = False
+                if self._config.codex_cli_goal_thread_prewarm:
+                    thread_prewarm_observed = prewarm_codex_cli_goal_thread(
+                        tmux_name=tmux_name,
+                        tmp_path=tmp_path,
+                        timeout_sec=max(90.0, float(self._config.first_action_timeout_sec or 0.0)),
                     )
-                    return _recoverable_codex_turn_failure_message(
-                        "codex_exec_first_action_timeout"
-                    )
+                    if not thread_prewarm_observed:
+                        tmux_kill_session(tmux_name)
+                        self._publish_codex_cli_goal_trace(
+                            ok=False,
+                            stage="thread_prewarm_timeout",
+                            goal_active_observed=False,
+                            goal_terminal_observed=False,
+                            first_action_observed=False,
+                            bridge_summary_path=bridge_summary_path,
+                            thread_prewarm_observed=False,
+                            goal_prompt_file_used=goal_prompt_file_used,
+                            goal_command_submission_method=goal_command_submission_method,
+                        )
+                        return _recoverable_codex_turn_failure_message(
+                            "codex_exec_first_action_timeout"
+                        )
                 if goal_prompt_file_used:
                     tmux_type_text_and_submit(
                         tmux_name=tmux_name,

--- a/scripts/skillsbench_local_acp_relay.py
+++ b/scripts/skillsbench_local_acp_relay.py
@@ -100,6 +100,16 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--codex-cli-goal-thread-prewarm",
+        action="store_true",
+        help=(
+            "Opt into the legacy Codex CLI TUI thread prewarm prompt before "
+            "submitting /goal. The default path submits the file-backed /goal "
+            "objective directly so model startup latency is attributed to the "
+            "real goal/bridge watchdogs."
+        ),
+    )
+    parser.add_argument(
         "--response-timeout-sec",
         type=float,
         default=30.0,
@@ -247,6 +257,7 @@ def main(argv: list[str] | None = None) -> int:
             approval_policy=args.approval_policy,
             reasoning_effort=args.reasoning_effort,
             codex_api_proxy=args.codex_api_proxy,
+            codex_cli_goal_thread_prewarm=args.codex_cli_goal_thread_prewarm,
             response_timeout_sec=args.response_timeout_sec,
             worker_script=args.worker_script,
             stream_heartbeat_interval_sec=args.stream_heartbeat_interval_sec,


### PR DESCRIPTION
## Summary
- submit the Codex CLI `/goal` file-backed objective directly by default for SkillsBench codex-cli-goal runs
- keep the legacy TUI thread prewarm behind explicit `--codex-cli-goal-thread-prewarm`
- update focused smokes so the default launch command cannot depend on prewarm

## Validation
- `python3 examples/skillsbench-cli-goal-first-action-timeout-smoke.py`
- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 -m py_compile loopx/benchmark_adapters/skillsbench_acp_relay.py scripts/skillsbench_local_acp_relay.py`
- `loopx canary premerge --from-git-diff`
  - direct checks passed
  - catalog canaries passed
  - public boundary passed
  - manual hold: `benchmark_sensitive`

## Benchmark-sensitive hold
This PR touches benchmark helper/runtime code, so the canary correctly emitted the `benchmark_sensitive` manual hold. Owner instruction in the active thread authorizes codex-main-control to self-merge benchmark-related helper/runtime PRs when validation passes and the public/private boundary is clean. This change does not alter scoring, task semantics, leaderboard/submission behavior, credentials, private evidence, or launch a benchmark job.
