### PR TITLE
Fix structured run index bundle classification

### DIFF
--- a/examples/contract-reward-overlay-smoke.py
+++ b/examples/contract-reward-overlay-smoke.py
@@ -46,6 +46,31 @@ def write_run(run_dir: Path, goal_id: str, *, duplicate_kind: str) -> None:
             {**record, "classification": "benchmark_run_v0"},
             {**record, "classification": "state_refreshed"},
         ]
+    elif duplicate_kind == "structured_artifact_bundle":
+        lines = [
+            {
+                **record,
+                "classification": "benchmark_run_v0",
+                "health_check": "benchmark_run_v0 compact event public-safe",
+                "benchmark_run": {
+                    "schema_version": "benchmark_run_v0",
+                    "mode": "codex_loopx",
+                    "job_name": "bundle_case_a",
+                    "official_task_score": {"kind": "fixture", "value": 0.0},
+                },
+            },
+            {
+                **record,
+                "classification": "benchmark_run_v0",
+                "health_check": "benchmark_run_v0 compact event public-safe",
+                "benchmark_run": {
+                    "schema_version": "benchmark_run_v0",
+                    "mode": "codex_loopx",
+                    "job_name": "bundle_case_b",
+                    "official_task_score": {"kind": "fixture", "value": 1.0},
+                },
+            },
+        ]
     else:
         raise ValueError(f"unknown duplicate_kind: {duplicate_kind}")
     (run_dir / "index.jsonl").write_text(
@@ -60,14 +85,17 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
     project.mkdir(parents=True)
     reward_state_file = project / ".codex" / "goals" / "reward-overlay-goal" / "ACTIVE_GOAL_STATE.md"
     duplicate_state_file = project / ".codex" / "goals" / "plain-duplicate-goal" / "ACTIVE_GOAL_STATE.md"
+    bundle_state_file = project / ".codex" / "goals" / "structured-bundle-goal" / "ACTIVE_GOAL_STATE.md"
     artifact_collision_state_file = (
         project / ".codex" / "goals" / "artifact-collision-goal" / "ACTIVE_GOAL_STATE.md"
     )
     reward_state_file.parent.mkdir(parents=True)
     duplicate_state_file.parent.mkdir(parents=True)
+    bundle_state_file.parent.mkdir(parents=True)
     artifact_collision_state_file.parent.mkdir(parents=True)
     reward_state_file.write_text("---\nupdated_at: 2026-01-01T00:00:00+00:00\n---\n", encoding="utf-8")
     duplicate_state_file.write_text("---\nupdated_at: 2026-01-01T00:00:00+00:00\n---\n", encoding="utf-8")
+    bundle_state_file.write_text("---\nupdated_at: 2026-01-01T00:00:00+00:00\n---\n", encoding="utf-8")
     artifact_collision_state_file.write_text("---\nupdated_at: 2026-01-01T00:00:00+00:00\n---\n", encoding="utf-8")
     local_private_doc = project / ".local" / "managed_doc" / "PRIVATE_DRAFT.md"
     local_private_doc.parent.mkdir(parents=True)
@@ -76,6 +104,11 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
 
     write_run(runtime_root / "goals" / "reward-overlay-goal" / "runs", "reward-overlay-goal", duplicate_kind="reward_overlay")
     write_run(runtime_root / "goals" / "plain-duplicate-goal" / "runs", "plain-duplicate-goal", duplicate_kind="plain_duplicate")
+    write_run(
+        runtime_root / "goals" / "structured-bundle-goal" / "runs",
+        "structured-bundle-goal",
+        duplicate_kind="structured_artifact_bundle",
+    )
     write_run(
         runtime_root / "goals" / "artifact-collision-goal" / "runs",
         "artifact-collision-goal",
@@ -100,6 +133,14 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
                         "id": "plain-duplicate-goal",
                         "repo": str(project),
                         "state_file": ".codex/goals/plain-duplicate-goal/ACTIVE_GOAL_STATE.md",
+                        "domain": "smoke",
+                        "status": "connected-read-only",
+                        "adapter": {"kind": "smoke", "status": "connected-read-only"},
+                    },
+                    {
+                        "id": "structured-bundle-goal",
+                        "repo": str(project),
+                        "state_file": ".codex/goals/structured-bundle-goal/ACTIVE_GOAL_STATE.md",
                         "domain": "smoke",
                         "status": "connected-read-only",
                         "adapter": {"kind": "smoke", "status": "connected-read-only"},
@@ -137,6 +178,8 @@ def main() -> None:
         assert payload["ok"] is True, payload
         assert "reward-overlay-goal: reward overlay rows raw=2 unique=1 overlays=1" in checks, payload
         assert "reward-overlay-goal: duplicate index rows" not in warnings, payload
+        assert "structured-bundle-goal: structured artifact bundle rows raw=2 unique=1 bundles=1" in checks, payload
+        assert "structured-bundle-goal: duplicate index rows" not in warnings, payload
         assert "plain-duplicate-goal: duplicate index rows raw=2 unique=1 unexpected=1 auto_repairable=1" in warnings, payload
         assert "loopx history --goal-id plain-duplicate-goal inspect-index-duplicates" in warnings, payload
         assert "loopx history --goal-id plain-duplicate-goal repair-index-duplicates" in warnings, payload

--- a/examples/history-index-duplicate-inspection-smoke.py
+++ b/examples/history-index-duplicate-inspection-smoke.py
@@ -63,6 +63,31 @@ def write_index_fixture(root: Path, goal_id: str, duplicate_kind: str) -> None:
                 "health_check": "state_file 1/1; registry_goal 1/1; authority_sources 0",
             },
         ]
+    elif duplicate_kind == "structured_artifact_bundle":
+        rows = [
+            {
+                **base,
+                "classification": "benchmark_run_v0",
+                "health_check": "benchmark_run_v0 compact event public-safe",
+                "benchmark_run": {
+                    "schema_version": "benchmark_run_v0",
+                    "mode": "codex_loopx",
+                    "job_name": "bundle_case_a",
+                    "official_task_score": {"kind": "fixture", "value": 0.0},
+                },
+            },
+            {
+                **base,
+                "classification": "benchmark_run_v0",
+                "health_check": "benchmark_run_v0 compact event public-safe",
+                "benchmark_run": {
+                    "schema_version": "benchmark_run_v0",
+                    "mode": "codex_loopx",
+                    "job_name": "bundle_case_b",
+                    "official_task_score": {"kind": "fixture", "value": 1.0},
+                },
+            },
+        ]
     elif duplicate_kind == "artifact_identity_collision":
         rows = [
             {**base, "classification": "benchmark_run_v0", "health_check": "benchmark_run_v0 compact event public-safe"},
@@ -86,6 +111,7 @@ def write_registry(root: Path) -> Path:
         ("reward-overlay-goal", "reward_overlay"),
         ("plain-duplicate-goal", "plain_duplicate"),
         ("structured-artifact-goal", "structured_artifact_collision"),
+        ("structured-bundle-goal", "structured_artifact_bundle"),
         ("artifact-collision-goal", "artifact_identity_collision"),
     ):
         state_file = project / ".codex" / "goals" / goal_id / "ACTIVE_GOAL_STATE.md"
@@ -144,14 +170,16 @@ def main() -> None:
         registry_path = write_registry(Path(raw_tmp))
         payload = run_cli(registry_path, "history", "inspect-index-duplicates", "--limit", "10")
         assert payload["ok"] is True, payload
-        assert payload["duplicate_group_count"] == 4, payload
-        assert payload["duplicate_row_count"] == 4, payload
+        assert payload["duplicate_group_count"] == 5, payload
+        assert payload["duplicate_row_count"] == 5, payload
         by_goal = {group["goal_id"]: group for group in payload["groups"]}
         assert by_goal["reward-overlay-goal"]["duplicate_kind"] == "reward_overlay", payload
         assert by_goal["reward-overlay-goal"]["severity"] == "info", payload
         assert by_goal["plain-duplicate-goal"]["duplicate_kind"] == "plain_duplicate", payload
         assert by_goal["plain-duplicate-goal"]["severity"] == "warning", payload
         assert by_goal["structured-artifact-goal"]["duplicate_kind"] == "artifact_identity_collision", payload
+        assert by_goal["structured-bundle-goal"]["duplicate_kind"] == "structured_artifact_bundle", payload
+        assert by_goal["structured-bundle-goal"]["severity"] == "info", payload
         assert by_goal["artifact-collision-goal"]["duplicate_kind"] == "artifact_identity_collision", payload
         assert by_goal["artifact-collision-goal"]["classifications"] == ["benchmark_run_v0", "state_refreshed"], payload
         assert payload["groups"][0]["severity"] == "warning", payload
@@ -162,11 +190,13 @@ def main() -> None:
         assert repair_preview["repaired"] is False, repair_preview
         assert repair_preview["removed_row_count"] == 2, repair_preview
         assert repair_preview["preserved_reward_overlay_rows"] == 1, repair_preview
+        assert repair_preview["preserved_structured_artifact_bundle_rows"] == 1, repair_preview
         assert repair_preview["unrepaired_group_count"] == 1, repair_preview
         repair_actions = {group["goal_id"]: group["action"] for group in repair_preview["groups"]}
         assert repair_actions["reward-overlay-goal"] == "preserve_reward_overlay", repair_preview
         assert repair_actions["plain-duplicate-goal"] == "drop_plain_duplicate_rows", repair_preview
         assert repair_actions["structured-artifact-goal"] == "keep_structured_artifact_row", repair_preview
+        assert repair_actions["structured-bundle-goal"] == "preserve_structured_artifact_bundle", repair_preview
         assert repair_actions["artifact-collision-goal"] == "blocked_artifact_identity_collision", repair_preview
 
         repair_execute = run_cli(
@@ -184,11 +214,12 @@ def main() -> None:
 
         after_repair = run_cli(registry_path, "history", "inspect-index-duplicates", "--limit", "10")
         assert after_repair["ok"] is True, after_repair
-        assert after_repair["duplicate_group_count"] == 2, after_repair
+        assert after_repair["duplicate_group_count"] == 3, after_repair
         after_by_goal = {group["goal_id"]: group for group in after_repair["groups"]}
         assert "plain-duplicate-goal" not in after_by_goal, after_repair
         assert "structured-artifact-goal" not in after_by_goal, after_repair
         assert after_by_goal["reward-overlay-goal"]["duplicate_kind"] == "reward_overlay", after_repair
+        assert after_by_goal["structured-bundle-goal"]["duplicate_kind"] == "structured_artifact_bundle", after_repair
         assert after_by_goal["artifact-collision-goal"]["duplicate_kind"] == "artifact_identity_collision", after_repair
 
         filtered = run_cli(

--- a/loopx/contract.py
+++ b/loopx/contract.py
@@ -8,7 +8,11 @@ from pathlib import Path
 from typing import Any
 
 from .agent_registry import registered_agent_ids_for_goal
-from .history import STRUCTURED_INDEX_KEYS, collect_history, load_registry
+from .control_plane.runtime.run_index_duplicates import (
+    classify_index_duplicate_records,
+    index_identity,
+)
+from .history import collect_history, load_registry
 from .paths import DEFAULT_RUNTIME_ROOT, rel_or_abs, resolve_runtime_root
 from .registry import inspect_registry, inspect_registry_boundary, registry_goals, resolve_state_file
 from .control_plane.todos.contract import (
@@ -159,6 +163,7 @@ def _index_duplicate_summary(index_path: Path) -> dict[str, Any]:
         return {
             "duplicate_rows": 0,
             "reward_overlay_rows": 0,
+            "structured_artifact_bundle_rows": 0,
             "unexpected_duplicate_rows": 0,
             "repairable_duplicate_rows": 0,
             "artifact_identity_collision_rows": 0,
@@ -175,14 +180,10 @@ def _index_duplicate_summary(index_path: Path) -> dict[str, Any]:
                 continue
             if not isinstance(item, dict):
                 continue
-            key = (
-                str(item.get("generated_at") or ""),
-                str(item.get("json_path") or ""),
-                str(item.get("markdown_path") or ""),
-            )
-            groups.setdefault(key, []).append(item)
+            groups.setdefault(index_identity(item), []).append(item)
 
     reward_overlay_rows = 0
+    structured_artifact_bundle_rows = 0
     unexpected_duplicate_rows = 0
     repairable_duplicate_rows = 0
     artifact_identity_collision_rows = 0
@@ -191,16 +192,13 @@ def _index_duplicate_summary(index_path: Path) -> dict[str, Any]:
         if len(records) <= 1:
             continue
         duplicate_rows = len(records) - 1
-        normalized = []
-        reward_records = 0
-        for record in records:
-            if isinstance(record.get("human_reward"), dict):
-                reward_records += 1
-            normalized.append({key: value for key, value in record.items() if key != "human_reward"})
-        normalized_keys = {json.dumps(record, sort_keys=True, ensure_ascii=False) for record in normalized}
-        if reward_records and len(normalized_keys) == 1:
+        duplicate_classification = classify_index_duplicate_records(records)
+        duplicate_kind = duplicate_classification.get("duplicate_kind")
+        if duplicate_kind == "reward_overlay":
             reward_overlay_rows += duplicate_rows
-        elif len(normalized_keys) == 1 or _is_repairable_structured_artifact_duplicate(records):
+        elif duplicate_kind == "structured_artifact_bundle":
+            structured_artifact_bundle_rows += duplicate_rows
+        elif duplicate_classification.get("repairable"):
             unexpected_duplicate_rows += duplicate_rows
             repairable_duplicate_rows += duplicate_rows
         else:
@@ -209,33 +207,14 @@ def _index_duplicate_summary(index_path: Path) -> dict[str, Any]:
             artifact_identity_collision_groups += 1
 
     return {
-        "duplicate_rows": reward_overlay_rows + unexpected_duplicate_rows,
+        "duplicate_rows": reward_overlay_rows + structured_artifact_bundle_rows + unexpected_duplicate_rows,
         "reward_overlay_rows": reward_overlay_rows,
+        "structured_artifact_bundle_rows": structured_artifact_bundle_rows,
         "unexpected_duplicate_rows": unexpected_duplicate_rows,
         "repairable_duplicate_rows": repairable_duplicate_rows,
         "artifact_identity_collision_rows": artifact_identity_collision_rows,
         "artifact_identity_collision_groups": artifact_identity_collision_groups,
     }
-
-
-def _has_structured_index_payload(record: dict[str, Any]) -> bool:
-    return any(isinstance(record.get(key), dict) for key in STRUCTURED_INDEX_KEYS)
-
-
-def _is_repairable_structured_artifact_duplicate(records: list[dict[str, Any]]) -> bool:
-    classifications = {str(record.get("classification") or "") for record in records}
-    health_checks = {str(record.get("health_check") or "") for record in records if record.get("health_check")}
-    structured_rows = [record for record in records if _has_structured_index_payload(record)]
-    return (
-        len(structured_rows) == 1
-        and len(classifications) == 1
-        and len(health_checks) > 1
-        and all(
-            _has_structured_index_payload(record)
-            or all(key not in record for key in STRUCTURED_INDEX_KEYS)
-            for record in records
-        )
-    )
 
 
 def _index_duplicate_warning(
@@ -252,6 +231,7 @@ def _index_duplicate_warning(
     artifact_collision_rows = int(duplicate_summary.get("artifact_identity_collision_rows") or 0)
     artifact_collision_groups = int(duplicate_summary.get("artifact_identity_collision_groups") or 0)
     reward_overlay_rows = int(duplicate_summary.get("reward_overlay_rows") or 0)
+    structured_artifact_bundle_rows = int(duplicate_summary.get("structured_artifact_bundle_rows") or 0)
     if unexpected_rows:
         detail_parts.append(f"unexpected={unexpected_rows}")
     if repairable_rows:
@@ -262,6 +242,8 @@ def _index_duplicate_warning(
         detail_parts.append(f"artifact_collision_rows={artifact_collision_rows}")
     if reward_overlay_rows:
         detail_parts.append(f"reward_overlays={reward_overlay_rows}")
+    if structured_artifact_bundle_rows:
+        detail_parts.append(f"structured_artifact_bundles={structured_artifact_bundle_rows}")
     if not detail_parts and raw > unique:
         detail_parts.append(f"duplicates={raw - unique}")
     detail = f" {' '.join(detail_parts)}" if detail_parts else ""
@@ -572,13 +554,22 @@ def check_contract(
             duplicate_summary = _index_duplicate_summary(Path(str(item.get("index_path") or "")))
             if duplicate_summary.get("unexpected_duplicate_rows"):
                 warnings.append(_index_duplicate_warning(item.get("id"), raw, unique, duplicate_summary))
-            elif duplicate_summary.get("reward_overlay_rows"):
-                checks.append(
-                    f"{item.get('id')}: reward overlay rows raw={raw} unique={unique} "
-                    f"overlays={duplicate_summary.get('reward_overlay_rows')}"
-                )
             else:
-                warnings.append(_index_duplicate_warning(item.get("id"), raw, unique, duplicate_summary))
+                emitted_check = False
+                if duplicate_summary.get("reward_overlay_rows"):
+                    emitted_check = True
+                    checks.append(
+                        f"{item.get('id')}: reward overlay rows raw={raw} unique={unique} "
+                        f"overlays={duplicate_summary.get('reward_overlay_rows')}"
+                    )
+                if duplicate_summary.get("structured_artifact_bundle_rows"):
+                    emitted_check = True
+                    checks.append(
+                        f"{item.get('id')}: structured artifact bundle rows raw={raw} unique={unique} "
+                        f"bundles={duplicate_summary.get('structured_artifact_bundle_rows')}"
+                    )
+                if not emitted_check:
+                    warnings.append(_index_duplicate_warning(item.get("id"), raw, unique, duplicate_summary))
 
     boundary = scan_public_boundary(scan_roots, registry=registry)
     if boundary.get("ok"):

--- a/loopx/control_plane/runtime/run_index_duplicates.py
+++ b/loopx/control_plane/runtime/run_index_duplicates.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+STRUCTURED_INDEX_KEYS = (
+    "benchmark_run",
+    "benchmark_result",
+    "benchmark_comparison",
+    "benchmark_learning_ledger",
+    "benchmark_experiment_report",
+    "active_user_assisted_pilot",
+)
+
+
+def index_identity(record: dict[str, Any]) -> tuple[str, str, str]:
+    return (
+        str(record.get("generated_at") or ""),
+        str(record.get("json_path") or ""),
+        str(record.get("markdown_path") or ""),
+    )
+
+
+def structured_index_payload_keys(record: dict[str, Any]) -> list[str]:
+    return [key for key in STRUCTURED_INDEX_KEYS if isinstance(record.get(key), dict)]
+
+
+def has_structured_index_payload(record: dict[str, Any]) -> bool:
+    return bool(structured_index_payload_keys(record))
+
+
+def _normalized_index_record(record: dict[str, Any]) -> dict[str, Any]:
+    return {key: value for key, value in record.items() if key != "human_reward"}
+
+
+def _normalized_key(record: dict[str, Any]) -> str:
+    return json.dumps(record, sort_keys=True, ensure_ascii=False)
+
+
+def is_repairable_structured_artifact_duplicate(records: list[dict[str, Any]]) -> bool:
+    classifications = {str(record.get("classification") or "") for record in records}
+    health_checks = {str(record.get("health_check") or "") for record in records if record.get("health_check")}
+    structured_rows = [record for record in records if has_structured_index_payload(record)]
+    return (
+        len(structured_rows) == 1
+        and len(classifications) == 1
+        and len(health_checks) > 1
+        and all(
+            has_structured_index_payload(record)
+            or all(key not in record for key in STRUCTURED_INDEX_KEYS)
+            for record in records
+        )
+    )
+
+
+def is_structured_artifact_bundle(records: list[dict[str, Any]]) -> bool:
+    """Return true when one artifact intentionally indexes multiple compact rows."""
+
+    if len(records) <= 1:
+        return False
+    if any(isinstance(record.get("human_reward"), dict) for record in records):
+        return False
+    if not all(record.get("health_check") for record in records):
+        return False
+    if not all(len(structured_index_payload_keys(record)) == 1 for record in records):
+        return False
+    payload_fingerprints = {
+        _normalized_key({key: record[key] for key in structured_index_payload_keys(record)})
+        for record in records
+    }
+    return len(payload_fingerprints) == len(records)
+
+
+def classify_index_duplicate_records(records: list[dict[str, Any]]) -> dict[str, Any]:
+    normalized_keys = {_normalized_key(_normalized_index_record(record)) for record in records}
+    reward_records = sum(1 for record in records if isinstance(record.get("human_reward"), dict))
+    if reward_records and len(normalized_keys) == 1:
+        return {
+            "duplicate_kind": "reward_overlay",
+            "severity": "info",
+            "repair_hint": "no index repair needed; reward overlay rows merge into the base run",
+            "action": "preserve_reward_overlay",
+            "repairable": False,
+            "reason": "reward overlay rows are intentionally merged by status checks",
+        }
+
+    if len(normalized_keys) == 1:
+        return {
+            "duplicate_kind": "plain_duplicate",
+            "severity": "warning",
+            "repair_hint": "append-only ledger repair can archive or supersede the extra identical index row",
+            "action": "drop_plain_duplicate_rows",
+            "repairable": True,
+            "reason": "duplicate rows are byte-equivalent after reward fields are ignored",
+        }
+
+    if is_structured_artifact_bundle(records):
+        return {
+            "duplicate_kind": "structured_artifact_bundle",
+            "severity": "info",
+            "repair_hint": "no index repair needed; rows are compact projections from one reviewed artifact bundle",
+            "action": "preserve_structured_artifact_bundle",
+            "repairable": False,
+            "reason": "multiple compact structured rows share one artifact identity by design",
+        }
+
+    if is_repairable_structured_artifact_duplicate(records):
+        return {
+            "duplicate_kind": "artifact_identity_collision",
+            "severity": "warning",
+            "repair_hint": "append-only ledger repair can keep the row with compact structured payload",
+            "action": "keep_structured_artifact_row",
+            "repairable": True,
+            "reason": "one row carries the compact structured artifact payload and siblings only repeat the artifact identity",
+        }
+
+    return {
+        "duplicate_kind": "artifact_identity_collision",
+        "severity": "warning",
+        "repair_hint": (
+            "do not delete blindly; inspect artifacts and append an explicit repair/supersede event "
+            "or rebuild a reviewed index copy"
+        ),
+        "action": "blocked_artifact_identity_collision",
+        "repairable": False,
+        "reason": "artifact identity collision is not auto-repairable without reviewed merge semantics",
+    }
+
+
+def duplicate_repair_decision(records: list[tuple[int, dict[str, Any]]]) -> dict[str, Any]:
+    line_numbers = [line_number for line_number, _ in records]
+    payload = classify_index_duplicate_records([record for _, record in records])
+    action = payload.get("action")
+    kept_line_numbers = line_numbers
+    removed_line_numbers: list[int] = []
+    if action == "drop_plain_duplicate_rows":
+        kept_line_numbers = [line_numbers[0]]
+        removed_line_numbers = line_numbers[1:]
+    elif action == "keep_structured_artifact_row":
+        structured_lines = [
+            line_number
+            for line_number, record in records
+            if has_structured_index_payload(record)
+        ]
+        kept_line_numbers = [structured_lines[0]]
+        removed_line_numbers = [line_number for line_number in line_numbers if line_number != structured_lines[0]]
+
+    return {
+        "action": action,
+        "repairable": payload.get("repairable"),
+        "line_numbers": line_numbers,
+        "kept_line_numbers": kept_line_numbers,
+        "removed_line_numbers": removed_line_numbers,
+        "reason": payload.get("reason"),
+    }

--- a/loopx/history.py
+++ b/loopx/history.py
@@ -9,6 +9,12 @@ from typing import Any, Callable
 
 from .authority import goal_authority_registry_summary
 from .control_plane import compact_control_plane_policy
+from .control_plane.runtime.run_index_duplicates import (
+    STRUCTURED_INDEX_KEYS,
+    classify_index_duplicate_records,
+    duplicate_repair_decision,
+    index_identity,
+)
 from .control_plane.work_items.delivery_batch_scale import require_delivery_batch_scale
 from .control_plane.work_items.delivery_outcome import require_delivery_outcome
 from .doctor import PROMOTION_READINESS_CLASSIFICATIONS
@@ -820,29 +826,10 @@ def inspect_index_duplicates(
                 continue
             duplicate_row_count += len(records) - 1
             generated_at, json_path, markdown_path = key
-            normalized = [
-                {record_key: value for record_key, value in record.items() if record_key != "human_reward"}
-                for _, record in records
-            ]
-            normalized_keys = {json.dumps(record, sort_keys=True, ensure_ascii=False) for record in normalized}
             reward_records = sum(1 for _, record in records if isinstance(record.get("human_reward"), dict))
             classifications = sorted({str(record.get("classification") or "") for _, record in records})
             health_checks = sorted({str(record.get("health_check") or "") for _, record in records if record.get("health_check")})
-            if reward_records and len(normalized_keys) == 1:
-                duplicate_kind = "reward_overlay"
-                severity = "info"
-                repair_hint = "no index repair needed; reward overlay rows merge into the base run"
-            elif len(normalized_keys) == 1:
-                duplicate_kind = "plain_duplicate"
-                severity = "warning"
-                repair_hint = "append-only ledger repair can archive or supersede the extra identical index row"
-            else:
-                duplicate_kind = "artifact_identity_collision"
-                severity = "warning"
-                repair_hint = (
-                    "do not delete blindly; inspect artifacts and append an explicit repair/supersede event "
-                    "or rebuild a reviewed index copy"
-                )
+            duplicate_classification = classify_index_duplicate_records([record for _, record in records])
             groups.append(
                 {
                     "goal_id": current_goal_id,
@@ -855,12 +842,12 @@ def inspect_index_duplicates(
                     "line_numbers": [line_number for line_number, _ in records],
                     "raw_rows": len(records),
                     "duplicate_rows": len(records) - 1,
-                    "duplicate_kind": duplicate_kind,
-                    "severity": severity,
+                    "duplicate_kind": duplicate_classification.get("duplicate_kind"),
+                    "severity": duplicate_classification.get("severity"),
                     "classifications": classifications,
                     "health_checks": health_checks,
                     "reward_overlay_rows": reward_records,
-                    "repair_hint": repair_hint,
+                    "repair_hint": duplicate_classification.get("repair_hint"),
                 }
             )
 
@@ -888,96 +875,6 @@ def inspect_index_duplicates(
     }
 
 
-STRUCTURED_INDEX_KEYS = (
-    "benchmark_run",
-    "benchmark_result",
-    "benchmark_comparison",
-    "benchmark_learning_ledger",
-    "benchmark_experiment_report",
-    "active_user_assisted_pilot",
-)
-
-
-def _index_identity(record: dict[str, Any]) -> tuple[str, str, str]:
-    return (
-        str(record.get("generated_at") or ""),
-        str(record.get("json_path") or ""),
-        str(record.get("markdown_path") or ""),
-    )
-
-
-def _has_structured_index_payload(record: dict[str, Any]) -> bool:
-    return any(isinstance(record.get(key), dict) for key in STRUCTURED_INDEX_KEYS)
-
-
-def _duplicate_repair_decision(records: list[tuple[int, dict[str, Any]]]) -> dict[str, Any]:
-    line_numbers = [line_number for line_number, _ in records]
-    reward_records = sum(1 for _, record in records if isinstance(record.get("human_reward"), dict))
-    normalized = [
-        {record_key: value for record_key, value in record.items() if record_key != "human_reward"}
-        for _, record in records
-    ]
-    normalized_keys = {json.dumps(record, sort_keys=True, ensure_ascii=False) for record in normalized}
-    classifications = {str(record.get("classification") or "") for _, record in records}
-    health_checks = {str(record.get("health_check") or "") for _, record in records}
-
-    if reward_records and len(normalized_keys) == 1:
-        return {
-            "action": "preserve_reward_overlay",
-            "repairable": False,
-            "line_numbers": line_numbers,
-            "kept_line_numbers": line_numbers,
-            "removed_line_numbers": [],
-            "reason": "reward overlay rows are intentionally merged by status checks",
-        }
-
-    if len(normalized_keys) == 1:
-        return {
-            "action": "drop_plain_duplicate_rows",
-            "repairable": True,
-            "line_numbers": line_numbers,
-            "kept_line_numbers": [line_numbers[0]],
-            "removed_line_numbers": line_numbers[1:],
-            "reason": "duplicate rows are byte-equivalent after reward fields are ignored",
-        }
-
-    structured_rows = [
-        (line_number, record)
-        for line_number, record in records
-        if _has_structured_index_payload(record)
-    ]
-    if (
-        len(structured_rows) == 1
-        and len(classifications) == 1
-        and len(health_checks) > 1
-        and all(
-            (
-                _has_structured_index_payload(record)
-                or all(key not in record for key in STRUCTURED_INDEX_KEYS)
-            )
-            for _, record in records
-        )
-    ):
-        kept_line = structured_rows[0][0]
-        return {
-            "action": "keep_structured_artifact_row",
-            "repairable": True,
-            "line_numbers": line_numbers,
-            "kept_line_numbers": [kept_line],
-            "removed_line_numbers": [line_number for line_number in line_numbers if line_number != kept_line],
-            "reason": "one row carries the compact structured artifact payload and siblings only repeat the artifact identity",
-        }
-
-    return {
-        "action": "blocked_artifact_identity_collision",
-        "repairable": False,
-        "line_numbers": line_numbers,
-        "kept_line_numbers": line_numbers,
-        "removed_line_numbers": [],
-        "reason": "artifact identity collision is not auto-repairable without reviewed merge semantics",
-    }
-
-
 def repair_index_duplicates(
     *,
     registry_path: Path,
@@ -992,6 +889,7 @@ def repair_index_duplicates(
     raw_index_records = 0
     removed_row_count = 0
     preserved_reward_overlay_rows = 0
+    preserved_structured_artifact_bundle_rows = 0
     unrepaired_group_count = 0
     groups: list[dict[str, Any]] = []
 
@@ -1013,16 +911,18 @@ def repair_index_duplicates(
                 continue
             if not isinstance(item, dict):
                 continue
-            grouped.setdefault(_index_identity(item), []).append((line_number, item))
+            grouped.setdefault(index_identity(item), []).append((line_number, item))
 
         remove_lines: set[int] = set()
         for records in grouped.values():
             if len(records) <= 1:
                 continue
-            decision = _duplicate_repair_decision(records)
+            decision = duplicate_repair_decision(records)
             removed_lines = list(decision.get("removed_line_numbers") or [])
             if decision.get("action") == "preserve_reward_overlay":
                 preserved_reward_overlay_rows += len(records) - 1
+            elif decision.get("action") == "preserve_structured_artifact_bundle":
+                preserved_structured_artifact_bundle_rows += len(records) - 1
             elif decision.get("repairable"):
                 remove_lines.update(int(line_number) for line_number in removed_lines)
                 removed_row_count += len(removed_lines)
@@ -1068,6 +968,7 @@ def repair_index_duplicates(
         "raw_index_records": raw_index_records,
         "removed_row_count": removed_row_count,
         "preserved_reward_overlay_rows": preserved_reward_overlay_rows,
+        "preserved_structured_artifact_bundle_rows": preserved_structured_artifact_bundle_rows,
         "unrepaired_group_count": unrepaired_group_count,
         "groups": limited_groups,
         "truncated": len(groups) > len(limited_groups),
@@ -1091,6 +992,7 @@ def render_index_duplicate_repair_markdown(payload: dict[str, Any]) -> str:
         f"- raw_index_records: `{payload.get('raw_index_records')}`",
         f"- removed_rows: `{payload.get('removed_row_count')}`",
         f"- preserved_reward_overlay_rows: `{payload.get('preserved_reward_overlay_rows')}`",
+        f"- preserved_structured_artifact_bundle_rows: `{payload.get('preserved_structured_artifact_bundle_rows')}`",
         f"- unrepaired_groups: `{payload.get('unrepaired_group_count')}`",
         f"- truncated: `{payload.get('truncated')}`",
         "",


### PR DESCRIPTION
## Summary
- Extract run index duplicate classification into a runtime bounded-context helper.
- Treat multiple compact structured rows from one reviewed artifact as a structured artifact bundle instead of an artifact identity collision.
- Extend duplicate-index and contract canaries so status/check no longer warn on intentional artifact bundle rows.

## Validation
- `python3 -m py_compile loopx/control_plane/runtime/run_index_duplicates.py loopx/history.py loopx/contract.py`
- `python3 examples/history-index-duplicate-inspection-smoke.py`
- `python3 examples/contract-reward-overlay-smoke.py`
- `python3 examples/control_plane/run-history-readmodel-smoke.py`
- `PYTHONPATH="$PWD" python3 -m loopx.cli --format json --registry "$HOME/.codex/loopx/registry.global.json" --runtime-root "$HOME/.codex/loopx" status --goal-id loopx-meta`
- `PYTHONPATH="$PWD" python3 -m loopx.cli check --scan-path loopx/control_plane/runtime/run_index_duplicates.py --scan-path loopx/history.py --scan-path loopx/contract.py --scan-path examples/history-index-duplicate-inspection-smoke.py --scan-path examples/contract-reward-overlay-smoke.py`
- `loopx canary premerge --from-git-diff`

## Notes
- Existing stale smoke `examples/control_plane/status-contract-readmodel-smoke.py` still references a removed private status helper and was not part of this batch.
