### PR TITLE
Increase Codex CLI goal post-bridge recovery budget

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -542,8 +542,8 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
         _public_runner_prerequisites,
     )
 
-    assert POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT == 4
-    assert POST_BRIDGE_CLOSEOUT_ATTEMPT_LIMIT == 3
+    assert POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT == 6
+    assert POST_BRIDGE_CLOSEOUT_ATTEMPT_LIMIT == 8
     assert PRE_BRIDGE_RECOVERY_ATTEMPT_LIMIT == 2
     assert "Close out the active SkillsBench goal" in (
         CODEX_CLI_GOAL_POST_BRIDGE_CLOSEOUT_PROMPT
@@ -775,7 +775,7 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
             goal_terminal_observed=False,
             first_action_observed=True,
             bridge_summary_path=bridge_summary,
-            post_bridge_recovery_attempt_count=4,
+            post_bridge_recovery_attempt_count=POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT,
             post_bridge_recovery_action="typed_closeout",
             post_bridge_recovery_skip_reason="closeout_retry_limit_reached",
         )
@@ -789,7 +789,10 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
 
     prerequisites = plan["runner_prerequisites"]
     assert trace["codex_cli_goal_tui_stage"] == "post_bridge_tui_model_timeout"
-    assert trace["codex_cli_goal_tui_post_bridge_recovery_attempt_count"] == 4
+    assert (
+        trace["codex_cli_goal_tui_post_bridge_recovery_attempt_count"]
+        == POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT
+    )
     assert trace["codex_cli_goal_tui_post_bridge_recovery_action"] == "typed_closeout"
     assert (
         trace["codex_cli_goal_tui_post_bridge_recovery_skip_reason"]

--- a/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
+++ b/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
@@ -16,8 +16,8 @@ CODEX_CLI_GOAL_POST_BRIDGE_CLOSEOUT_PROMPT = (
     "finish the active goal now with compact status. If the task is not "
     "complete, report the blocker compactly and end the active goal."
 )
-POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT = 4
-POST_BRIDGE_CLOSEOUT_ATTEMPT_LIMIT = 3
+POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT = 6
+POST_BRIDGE_CLOSEOUT_ATTEMPT_LIMIT = 8
 
 
 def _capture_has_rate_limit(capture: str) -> bool:


### PR DESCRIPTION
## Summary
- increase Codex CLI goal post-bridge recovery attempts from 4 to 6
- increase post-bridge closeout attempts from 3 to 8 for xhigh TUI timeout recovery
- update the route smoke so the closeout fixture follows the recovery budget constant

## Validation
- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 -m py_compile loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py loopx/benchmark_adapters/skillsbench_acp_relay.py scripts/skillsbench_automation_loop.py`
- `loopx canary premerge --from-git-diff`
  - direct checks passed
  - catalog canaries passed
  - public boundary passed
  - manual hold: `benchmark_sensitive`

## Self-merge note
Benchmark helper/runtime self-merge is owner-authorized. This PR only changes bounded Codex CLI goal TUI recovery budget and matching smoke assertions; it does not change scoring, task semantics, leaderboard/submission behavior, permission boundaries, or launch a benchmark job.
