### PR TITLE
Refactor public safety compaction helpers

### DIFF
--- a/examples/control_plane/public-safety-readmodel-smoke.py
+++ b/examples/control_plane/public-safety-readmodel-smoke.py
@@ -19,6 +19,11 @@ from loopx.session_runtime import SESSION_RUNTIME_READONLY_PROJECTION_SCHEMA_VER
 def assert_status_uses_direct_read_models() -> None:
     assert status_module.public_safe_compact_text is public_safety_read_model.public_safe_compact_text
     assert status_module.public_safe_compact_list is public_safety_read_model.public_safe_compact_list
+    assert status_module._compact_numeric_map is public_safety_read_model.compact_numeric_map
+    assert (
+        status_module._compact_loopx_command_records
+        is public_safety_read_model.compact_loopx_command_records
+    )
     assert (
         status_module.compact_session_runtime_readonly_projection
         is session_runtime_read_model.compact_session_runtime_readonly_projection
@@ -51,6 +56,73 @@ def assert_public_safe_list_parity() -> None:
     assert status_module.public_safe_compact_list(values, limit=2) == expected
     assert public_safety_read_model.public_safe_compact_list(values, limit=2) == expected
     assert status_module.public_safe_compact_list("single", limit=4) == ["single"]
+
+
+def assert_numeric_map_compaction() -> None:
+    source = {
+        "count": "3",
+        "ratio": "2.5",
+        "native": 7,
+        "false_flag": False,
+        "truthy_flag": True,
+        "empty": "",
+        "word": "many",
+    }
+
+    assert public_safety_read_model.compact_numeric_map(source) == {
+        "count": 3,
+        "ratio": 2.5,
+        "native": 7,
+    }
+    assert public_safety_read_model.compact_numeric_map(
+        source,
+        keys=("ratio", "missing", "word", "native"),
+    ) == {"ratio": 2.5, "native": 7}
+    assert public_safety_read_model.compact_numeric_map(["not", "a", "map"]) == {}
+
+
+def assert_loopx_command_record_compaction() -> None:
+    local_path = "/" + "tmp" + "/loopx-command-record.json"
+    records = [
+        {
+            "subcommand": "quota should-run",
+            "todo_id": "todo_abc12345",
+            "goal_id": "loopx-meta",
+        },
+        {
+            "subcommand": "agent_command",
+            "todo_id": "todo_private",
+            "goal_id": "loopx-meta",
+        },
+        {
+            "subcommand": "todo complete",
+            "todo_id": local_path,
+            "goal_id": "loopx-meta",
+        },
+        {
+            "subcommand": "refresh-state",
+            "todo_id": "todo_followup123",
+            "goal_id": local_path,
+        },
+    ]
+
+    assert public_safety_read_model.compact_loopx_command_records(records, limit=8) == [
+        {
+            "subcommand": "quota should-run",
+            "todo_id": "todo_abc12345",
+            "goal_id": "loopx-meta",
+        },
+        {"subcommand": "todo complete", "goal_id": "loopx-meta"},
+        {"subcommand": "refresh-state", "todo_id": "todo_followup123"},
+    ]
+    assert public_safety_read_model.compact_loopx_command_records(records, limit=1) == [
+        {
+            "subcommand": "quota should-run",
+            "todo_id": "todo_abc12345",
+            "goal_id": "loopx-meta",
+        }
+    ]
+    assert public_safety_read_model.compact_loopx_command_records({"not": "a-list"}) == []
 
 
 def assert_session_runtime_defaults() -> None:
@@ -113,6 +185,8 @@ def main() -> None:
     assert_status_uses_direct_read_models()
     assert_public_safe_text_parity()
     assert_public_safe_list_parity()
+    assert_numeric_map_compaction()
+    assert_loopx_command_record_compaction()
     assert_session_runtime_defaults()
 
 

--- a/loopx/control_plane/runtime/public_safety.py
+++ b/loopx/control_plane/runtime/public_safety.py
@@ -15,6 +15,18 @@ SECRET_LIKE_SURFACE_PATTERN = re.compile(
     r"(?<![a-z0-9_])(?:ak|sk)[-_=:][a-z0-9_=-]{10,}|"
     r"\btoken\s*[=:]\s*[^\s`'\"<>]{12,})"
 )
+LOOPX_COMMAND_RECORD_ALLOWED_SUBCOMMANDS = {
+    "quota should-run",
+    "todo claim",
+    "todo update",
+    "todo complete",
+    "refresh-state",
+    "quota spend-slot",
+    "status",
+    "diagnose",
+}
+LOOPX_COMMAND_RECORD_TODO_ID_PATTERN = re.compile(r"^todo_[A-Za-z0-9_-]{6,80}$")
+LOOPX_COMMAND_RECORD_GOAL_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,120}$")
 
 
 def compact_text(text: str, *, limit: int) -> str:
@@ -59,3 +71,46 @@ def public_safe_compact_list(
         if len(result) >= limit:
             break
     return result
+
+
+def compact_numeric_map(value: Any, *, keys: tuple[str, ...] | None = None) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    selected_keys = keys or tuple(str(key) for key in value.keys())
+    compact: dict[str, Any] = {}
+    for key in selected_keys:
+        raw = value.get(key)
+        if isinstance(raw, bool) or raw is None:
+            continue
+        if isinstance(raw, (int, float)):
+            compact[key] = raw
+            continue
+        try:
+            if isinstance(raw, str) and raw.strip():
+                compact[key] = float(raw) if "." in raw else int(raw)
+        except ValueError:
+            continue
+    return compact
+
+
+def compact_loopx_command_records(value: Any, *, limit: int = 128) -> list[dict[str, str]]:
+    if not isinstance(value, list):
+        return []
+    records: list[dict[str, str]] = []
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        subcommand = public_safe_compact_text(item.get("subcommand"), limit=80)
+        if subcommand not in LOOPX_COMMAND_RECORD_ALLOWED_SUBCOMMANDS:
+            continue
+        record: dict[str, str] = {"subcommand": subcommand}
+        todo_id = public_safe_compact_text(item.get("todo_id"), limit=100)
+        if todo_id and LOOPX_COMMAND_RECORD_TODO_ID_PATTERN.match(todo_id):
+            record["todo_id"] = todo_id
+        goal_id = public_safe_compact_text(item.get("goal_id"), limit=140)
+        if goal_id and LOOPX_COMMAND_RECORD_GOAL_ID_PATTERN.match(goal_id):
+            record["goal_id"] = goal_id
+        records.append(record)
+        if len(records) >= limit:
+            break
+    return records

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -173,6 +173,8 @@ from .control_plane.runtime.run_compaction import (
     compact_run_base as _compact_run_base_read_model,
 )
 from .control_plane.runtime.public_safety import (
+    compact_loopx_command_records as _compact_loopx_command_records,
+    compact_numeric_map as _compact_numeric_map,
     public_safe_compact_list,
     public_safe_compact_text,
 )
@@ -581,60 +583,6 @@ AUTONOMOUS_RUN_HISTORY_NEUTRAL_CLASSIFICATIONS = {
 AUTONOMOUS_RUN_HISTORY_STALL_PATTERN = re.compile(
     r"(?i)(?:monitor|observe|observation|poll|watch|quiet|no[-_ ]?op|no[-_ ]?progress|stalled?|unchanged|dependency|停转|无进展|重复|反复|观察|轮询)"
 )
-
-
-def _compact_numeric_map(value: Any, *, keys: tuple[str, ...] | None = None) -> dict[str, Any]:
-    if not isinstance(value, dict):
-        return {}
-    source = value
-    selected_keys = keys or tuple(str(key) for key in source.keys())
-    compact: dict[str, Any] = {}
-    for key in selected_keys:
-        raw = source.get(key)
-        if isinstance(raw, bool) or raw is None:
-            continue
-        if isinstance(raw, (int, float)):
-            compact[key] = raw
-            continue
-        try:
-            if isinstance(raw, str) and raw.strip():
-                compact[key] = float(raw) if "." in raw else int(raw)
-        except ValueError:
-            continue
-    return compact
-
-
-def _compact_loopx_command_records(value: Any, *, limit: int = 128) -> list[dict[str, str]]:
-    if not isinstance(value, list):
-        return []
-    allowed_subcommands = {
-        "quota should-run",
-        "todo claim",
-        "todo update",
-        "todo complete",
-        "refresh-state",
-        "quota spend-slot",
-        "status",
-        "diagnose",
-    }
-    records: list[dict[str, str]] = []
-    for item in value:
-        if not isinstance(item, dict):
-            continue
-        subcommand = public_safe_compact_text(item.get("subcommand"), limit=80)
-        if subcommand not in allowed_subcommands:
-            continue
-        record: dict[str, str] = {"subcommand": subcommand}
-        todo_id = public_safe_compact_text(item.get("todo_id"), limit=100)
-        if todo_id and re.match(r"^todo_[A-Za-z0-9_-]{6,80}$", todo_id):
-            record["todo_id"] = todo_id
-        goal_id = public_safe_compact_text(item.get("goal_id"), limit=140)
-        if goal_id and re.match(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,120}$", goal_id):
-            record["goal_id"] = goal_id
-        records.append(record)
-        if len(records) >= limit:
-            break
-    return records
 
 
 def _compact_benchmark_case_event_timeline(value: Any) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
- move generic numeric-map and LoopX command-record compaction helpers from `loopx/status.py` into `loopx/control_plane/runtime/public_safety.py`
- keep `status.py` as a consumer of the bounded-context runtime readmodel helpers
- extend the public-safety readmodel smoke to cover numeric parsing, allowed command records, id/path filtering, and status helper identity

## Validation
- `python3 examples/control_plane/public-safety-readmodel-smoke.py`
- `python3 examples/control_plane/status-contract-readmodel-smoke.py`
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 examples/control_plane/run-compaction-readmodel-smoke.py`
- `python3 examples/control_plane/run-history-readmodel-smoke.py`
- `python3 -m compileall -q loopx/control_plane/runtime/public_safety.py loopx/status.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `loopx check --scan-path loopx/control_plane/runtime/public_safety.py --scan-path loopx/status.py --scan-path examples/control_plane/public-safety-readmodel-smoke.py`
- `loopx canary premerge --from-git-diff`

## Boundary
- Added-line private/material scan clean.
- Public boundary scan clean across the three changed files.
- No benchmark execution, raw logs, trajectories, verifier output, production actions, or credential material touched.
