### PR TITLE
Add connector source-map packet for content ops

### DIFF
--- a/docs/capabilities/content-ops/README.md
+++ b/docs/capabilities/content-ops/README.md
@@ -24,3 +24,20 @@ or published.
 - Raw chats, transcripts, credentials, logs, and local paths are not copied into
   public packets.
 - Publishing remains blocked until an explicit user decision.
+
+## Connector-First Ops Pattern
+
+For social and creator operations, start with a connector source map instead of
+drafting from memory. The current reusable pattern is
+[`agent_reach_ops_source_map`](../value-connectors/agent-reach-ops-source-map.md):
+
+```text
+doctor -> read-only source map -> maturity score -> ops brief -> draft packet
+       -> publish/audit record -> compact monitor
+```
+
+The pattern lets a newly connected LoopX agent reuse external signals without
+turning LoopX into a raw platform archive or untracked publisher. Even when an
+owner grants broad posting discretion, the agent should still record the exact
+body, account/channel, source map, timing, and stop condition before an external
+post.

--- a/docs/capabilities/content-ops/README.md
+++ b/docs/capabilities/content-ops/README.md
@@ -28,8 +28,16 @@ or published.
 ## Connector-First Ops Pattern
 
 For social and creator operations, start with a connector source map instead of
-drafting from memory. The current reusable pattern is
-[`agent_reach_ops_source_map`](../value-connectors/agent-reach-ops-source-map.md):
+drafting from memory:
+
+```bash
+loopx value-connectors source-map --format json
+```
+
+This packet gives a newly connected agent the current read-first connector
+catalog, including public GitHub metadata, content-ops public handles,
+browser-backed X research, Agent-Reach source routing, and finance snapshot
+probes:
 
 ```text
 doctor -> read-only source map -> maturity score -> ops brief -> draft packet

--- a/docs/capabilities/value-connectors/README.md
+++ b/docs/capabilities/value-connectors/README.md
@@ -73,6 +73,7 @@ association, timestamp, and URL metadata, then emits either
 | `github_public_reply_monitor` | implemented starter | yes | none |
 | `social_browser_x` | ego-browser-backed profile | install-check, public-handle packet, and gated plan | exact profile/post/reply gate required |
 | `finance_market_snapshot` | probed candidate profile | plan, user prompt surface, and [no-credential probe packet](finance-market-snapshot-probe.md) | account, private portfolio, trading, and paid-data gates required |
+| `agent_reach_ops_source_map` | field-derived pattern | [read-only source-map profile](agent-reach-ops-source-map.md) | publish/audit record required for every external write |
 | `botmail_identity` | host connector profile | install-check only | exact send gate required |
 | `community_channel` | host/browser connector profile | install-check and plan | exact account/message gate required |
 
@@ -130,6 +131,20 @@ install-check -> metadata probe -> value connector plan -> approval gate -> host
 LoopX owns the compact control packet and value metric. Host products or user
 connectors own account login, private reads, external sends, and production
 actions.
+
+## Agent-Reach Ops Source Map
+
+`agent_reach_ops_source_map` is a reusable field pattern for connector-backed
+content operations. Agent-Reach is used as a source router: first run
+`agent-reach doctor --json`, then collect read-only signals from available
+routes such as GitHub, public web/RSS, V2EX, or Bilibili. LoopX stores compact
+evidence cards, maturity scores, the ops brief, draft packet, publish/audit
+record, and monitor state.
+
+This profile is intentionally source-first and action-gated. Broad posting
+discretion does not remove the need to record exact body, channel/account,
+time, source refs, and stop conditions. See the
+[Agent-Reach ops source-map profile](agent-reach-ops-source-map.md).
 
 ## Finance Market Snapshot Profile
 

--- a/docs/capabilities/value-connectors/README.md
+++ b/docs/capabilities/value-connectors/README.md
@@ -23,6 +23,12 @@ Check connector starter availability:
 loopx value-connectors install-check --format json
 ```
 
+Give a newly connected agent the read-first connector source map:
+
+```bash
+loopx value-connectors source-map --format json
+```
+
 Check the X/browser connector profile:
 
 ```bash
@@ -73,7 +79,7 @@ association, timestamp, and URL metadata, then emits either
 | `github_public_reply_monitor` | implemented starter | yes | none |
 | `social_browser_x` | ego-browser-backed profile | install-check, public-handle packet, and gated plan | exact profile/post/reply gate required |
 | `finance_market_snapshot` | probed candidate profile | plan, user prompt surface, and [no-credential probe packet](finance-market-snapshot-probe.md) | account, private portfolio, trading, and paid-data gates required |
-| `agent_reach_ops_source_map` | field-derived pattern | [read-only source-map profile](agent-reach-ops-source-map.md) | publish/audit record required for every external write |
+| `agent_reach_ops_source_map` | field-derived source profile | `loopx value-connectors source-map --connector agent_reach_ops_source_map --format json`; [profile note](agent-reach-ops-source-map.md) | publish/audit record required for every external write |
 | `botmail_identity` | host connector profile | install-check only | exact send gate required |
 | `community_channel` | host/browser connector profile | install-check and plan | exact account/message gate required |
 
@@ -134,12 +140,19 @@ actions.
 
 ## Agent-Reach Ops Source Map
 
-`agent_reach_ops_source_map` is a reusable field pattern for connector-backed
-content operations. Agent-Reach is used as a source router: first run
-`agent-reach doctor --json`, then collect read-only signals from available
-routes such as GitHub, public web/RSS, V2EX, or Bilibili. LoopX stores compact
-evidence cards, maturity scores, the ops brief, draft packet, publish/audit
-record, and monitor state.
+`loopx value-connectors source-map --format json` gives a newly connected agent
+the current read-first connector catalog without requiring it to read internal
+docs. It includes implemented or field-proven source profiles such as public
+GitHub metadata probes, GitHub reply monitors, content-ops public handles,
+browser-backed X research, Agent-Reach source routing, and the finance market
+snapshot probe profile. It also names action-gated profiles such as botmail and
+community replies so agents do not treat "can send" as "can freely read/write".
+
+`agent_reach_ops_source_map` is one profile in that packet. Agent-Reach is used
+as a source router: first run `agent-reach doctor --json`, then collect
+read-only signals from available routes such as GitHub, public web/RSS, V2EX,
+or Bilibili. LoopX stores compact evidence cards, maturity scores, the ops
+brief, draft packet, publish/audit record, and monitor state.
 
 This profile is intentionally source-first and action-gated. Broad posting
 discretion does not remove the need to record exact body, channel/account,

--- a/docs/capabilities/value-connectors/agent-reach-ops-source-map.md
+++ b/docs/capabilities/value-connectors/agent-reach-ops-source-map.md
@@ -2,11 +2,24 @@
 
 Status: public-safe field pattern for connector-backed content operations.
 
-This note turns the Agent-Reach value-explorer experiments into a reusable
-LoopX capability pattern. It is not a hard dependency on Agent-Reach and it does
-not grant permission to publish. It describes how a LoopX agent can use
-Agent-Reach as a source router, then let LoopX own evidence, gates, drafts,
-monitors, and handoff state.
+This note turns the Agent-Reach value-explorer experiments into one reusable
+LoopX source profile inside the broader connector source map. It is not a hard
+dependency on Agent-Reach and it does not grant permission to publish. It
+describes how a LoopX agent can use Agent-Reach as a source router, then let
+LoopX own evidence, gates, drafts, monitors, and handoff state.
+
+Agents do not need to read this document before acting. The executable
+entrypoint is:
+
+```bash
+loopx value-connectors source-map --connector agent_reach_ops_source_map --format json
+```
+
+For all currently surfaced connector profiles, use:
+
+```bash
+loopx value-connectors source-map --format json
+```
 
 ## When To Use It
 
@@ -159,7 +172,18 @@ monitor boundary.
 
 ## Reusable Agent Prompt
 
-When onboarding a new LoopX agent for creator/operator work, include:
+When onboarding a new LoopX agent for creator/operator work, the preferred
+instruction is to call the CLI packet:
+
+```text
+Run `loopx value-connectors source-map --format json` before drafting from
+external signals. Choose a read-only source profile, emit compact evidence
+cards, score maturity, and write an ops brief. Use `loopx value-connectors plan`
+before any signup, send, post, reply, upload, production action, credentialed
+read, or private-source expansion.
+```
+
+The longer fallback prompt is:
 
 ```text
 Before drafting social content, run connector-first source mapping.
@@ -190,10 +214,14 @@ reviewable: evidence cards, gates, draft packets, and monitors.
 
 ## Productization Boundary
 
-Keep early runs local until at least two successful batches prove the card
-shape and source boundaries. Productize only the stable parts:
+The first stable part is now productized as a packet:
 
-- `loopx value-connectors source-map --connector agent-reach ...`;
+- `loopx value-connectors source-map --connector agent_reach_ops_source_map ...`;
+
+Keep live collection and publish tooling local until at least two successful
+batches prove the card shape and source boundaries. Productize only the stable
+parts:
+
 - `loopx content-ops draft --from-source-map ...`;
 - `loopx content-ops publish-record --from-draft ...`;
 - `loopx content-ops monitor --published-url ...`.

--- a/docs/capabilities/value-connectors/agent-reach-ops-source-map.md
+++ b/docs/capabilities/value-connectors/agent-reach-ops-source-map.md
@@ -1,0 +1,202 @@
+# Agent-Reach Ops Source Map
+
+Status: public-safe field pattern for connector-backed content operations.
+
+This note turns the Agent-Reach value-explorer experiments into a reusable
+LoopX capability pattern. It is not a hard dependency on Agent-Reach and it does
+not grant permission to publish. It describes how a LoopX agent can use
+Agent-Reach as a source router, then let LoopX own evidence, gates, drafts,
+monitors, and handoff state.
+
+## When To Use It
+
+Use this pattern when a LoopX agent needs to:
+
+- find public signals for a post, reply, launch note, or contributor-facing
+  update;
+- compare whether an idea is a mature category, an emerging phrase, or weak
+  noise;
+- build a source-backed draft without copying raw timelines, private chats,
+  credentials, or local logs into LoopX state;
+- keep publishing auditable even when the owner grants broad posting
+  discretion.
+
+Do not use it for credential collection, account setup, private timeline dumps,
+mass outreach, captcha bypass, trading, paid data, or production actions.
+
+## Operating Loop
+
+Every connector-backed content run should use this sequence:
+
+```text
+doctor -> route selection -> read-only source map -> maturity scoring
+       -> ops brief -> draft packet -> publish/audit gate -> compact monitor
+```
+
+The important rule is that Agent-Reach is the source router, not the source of
+truth for action. LoopX keeps the compact action contract:
+
+- what source was read;
+- whether the boundary is public, logged-in read-only, private-needs-review, or
+  forbidden;
+- what claim the source supports;
+- what draft was produced;
+- what publish authority exists;
+- what monitor or stop condition follows.
+
+## Route Selection
+
+Start with:
+
+```bash
+agent-reach doctor --json
+```
+
+Treat the doctor output as capability evidence. A route is usable only when the
+active backend is available and the access boundary is clear.
+
+Suggested route mapping:
+
+| Route | Typical backend | Boundary | Safe use |
+| --- | --- | --- | --- |
+| GitHub | `gh CLI` | logged-in read | repo/search metadata, public stars, descriptions, issues/PR metadata when explicitly routed |
+| Web | Jina Reader | public no-login | public docs and articles, with light quoting only |
+| RSS | feedparser | public no-login | feed titles, links, timestamps, summaries |
+| V2EX | public API | public no-login | hot topics and public replies as community signal, usually monitor-grade |
+| Bilibili | public search API or `bili-cli` | public no-login | video title, author, play count, public URL |
+| X/Reddit/Xiaohongshu/Facebook/Instagram | platform CLI or OpenCLI | logged-in read | read-only public or account-visible metadata only; no posting without a separate publish action record |
+
+If a route needs browser cookies, platform login, private groups, DMs, account
+setup, or raw body expansion, stop at metadata-only and project a gate.
+
+## Evidence Card Shape
+
+Agents should emit compact cards before drafting:
+
+```yaml
+agent_reach_ops_signal_v0:
+  channel: github | web | rss | v2ex | bilibili | x | reddit | xiaohongshu | other
+  backend: gh CLI | Jina Reader | feedparser | V2EX API | Bilibili public search API | ...
+  query: string
+  title: string
+  url: string | null
+  summary: string
+  boundary: public_no_login | logged_in_read | private_needs_review | forbidden
+  operation: read
+  observed_at: ISO-8601 timestamp
+  confidence: doctor_status | source_metadata | source_body_reviewed
+  maturity_score: 0 | 1 | 2 | 3
+  maturity_reason: string
+```
+
+`operation` must be `read`. A connector run that creates `external_write`
+cards is invalid for this source-map stage.
+
+## Maturity Scoring
+
+Keep the scoring deliberately simple so the next agent can reuse it:
+
+| Score | Meaning | Example signal |
+| --- | --- | --- |
+| 0 | Noise or unavailable route | unrelated hot topic, route missing, or stale source |
+| 1 | Weak exploratory signal | exact phrase appears but with little adoption |
+| 2 | Emerging signal | repeated usage, modest stars, replies, or public attention |
+| 3 | Mature signal | strong adoption, many stars/views/replies, or multiple independent sources |
+
+For public GitHub search, stars can be a first-pass proxy:
+
+- `>= 1000`: mature category signal;
+- `>= 100`: emerging category signal;
+- `>= 10`: weak but visible;
+- `< 10`: exploratory unless other sources corroborate it.
+
+For public video/community sources, use attention only as a clue. Do not copy
+unverified claims from drama, rumor, or account-risk videos into LoopX claims.
+
+## Ops Brief
+
+Before drafting, produce a short brief:
+
+```yaml
+ops_brief:
+  source_batch: evidence-card file or packet id
+  mature_signals:
+    - claim:
+      supporting_cards:
+      why_it_matters_for_loopx:
+  weak_signals:
+    - claim:
+      reason_to_monitor_instead_of_draft:
+  recommended_angles:
+    - audience:
+      body_angle:
+      evidence_refs:
+  stop_conditions:
+    - account boundary unclear
+    - source only supports metadata, not body quote
+    - post would repeat unverified platform drama
+```
+
+The brief is the handoff point. A different agent should be able to draft or
+review from it without reading raw connector output.
+
+## Content-Ops Drafting
+
+A draft is valid only when it has:
+
+- a named angle and target reader;
+- a source map with public/private status;
+- exact body text;
+- media plan;
+- repo or docs link when the post is about LoopX;
+- account/channel/timing record when publishing is allowed;
+- stop condition and first monitor plan.
+
+Broad owner permission may allow an agent to publish according to judgment, but
+it does not remove the audit requirement. The publish record still needs the
+final body, active account or channel, source refs, timestamp, and follow-up
+monitor boundary.
+
+## Reusable Agent Prompt
+
+When onboarding a new LoopX agent for creator/operator work, include:
+
+```text
+Before drafting social content, run connector-first source mapping.
+Use Agent-Reach routes only for read-only signal collection unless a separate
+LoopX gate authorizes a publish action. Emit compact evidence cards, score
+maturity, write an ops brief, and draft from the brief. If publishing is
+authorized, record the exact body/account/time/source-map/stop-condition before
+posting. If the active account or source boundary is unclear, stop with a
+no-send packet.
+```
+
+## Example Finding
+
+A value-explorer run using Agent-Reach routes found:
+
+- mature GitHub signals for `long-running AI agent`, `AI agent control plane`,
+  and `agent loop engineering`;
+- high Bilibili attention around Claude Code and AI Agent setup/tutorial
+  content;
+- weak V2EX hot-topic relevance for this exact LoopX angle at that moment.
+
+The reusable conclusion is:
+
+```text
+Connector-backed agents can find the trend. LoopX should make the action
+reviewable: evidence cards, gates, draft packets, and monitors.
+```
+
+## Productization Boundary
+
+Keep early runs local until at least two successful batches prove the card
+shape and source boundaries. Productize only the stable parts:
+
+- `loopx value-connectors source-map --connector agent-reach ...`;
+- `loopx content-ops draft --from-source-map ...`;
+- `loopx content-ops publish-record --from-draft ...`;
+- `loopx content-ops monitor --published-url ...`.
+
+Do not productize raw provider payload retention, platform-specific cookies, or
+publish shortcuts.

--- a/examples/value-connectors-github-public-probe-smoke.py
+++ b/examples/value-connectors-github-public-probe-smoke.py
@@ -25,6 +25,9 @@ from loopx.capabilities.value_connectors.github_public import (  # noqa: E402
 from loopx.capabilities.value_connectors.planner import (  # noqa: E402
     VALUE_CONNECTOR_PLAN_PACKET_SCHEMA_VERSION,
 )
+from loopx.capabilities.value_connectors.source_map import (  # noqa: E402
+    VALUE_CONNECTOR_SOURCE_MAP_PACKET_SCHEMA_VERSION,
+)
 
 
 PRIVATE_PATTERNS = [
@@ -84,9 +87,54 @@ def main() -> int:
     assert install["schema_version"] == VALUE_CONNECTOR_INSTALL_CHECK_PACKET_SCHEMA_VERSION
     connector_ids = {item["connector_id"] for item in install["checks"]}
     assert "github_public_channel" in connector_ids, connector_ids
+    assert "agent_reach_ops_source_map" in connector_ids, connector_ids
+    assert "finance_market_snapshot" in connector_ids, connector_ids
     assert "botmail_identity" in connector_ids, connector_ids
     assert "social_browser_x" in connector_ids, connector_ids
     assert_public_safe(install)
+
+    source_map = json.loads(
+        run_cli(["--format", "json", "value-connectors", "source-map"]).stdout
+    )
+    assert source_map["ok"] is True, source_map
+    assert source_map["schema_version"] == VALUE_CONNECTOR_SOURCE_MAP_PACKET_SCHEMA_VERSION
+    assert source_map["external_reads_performed"] is False, source_map
+    assert source_map["external_writes_performed"] is False, source_map
+    assert source_map["projection"]["agent_can_start_without_docs"] is True, source_map
+    profile_ids = {item["connector_id"] for item in source_map["source_profiles"]}
+    assert "github_public_channel" in profile_ids, profile_ids
+    assert "github_public_reply_monitor" in profile_ids, profile_ids
+    assert "content_ops_public_handle" in profile_ids, profile_ids
+    assert "social_browser_x" in profile_ids, profile_ids
+    assert "agent_reach_ops_source_map" in profile_ids, profile_ids
+    assert "finance_market_snapshot" in profile_ids, profile_ids
+    action_ids = {item["connector_id"] for item in source_map["action_gated_profiles"]}
+    assert "botmail_identity" in action_ids, action_ids
+    assert "community_channel" in action_ids, action_ids
+    assert source_map["generic_evidence_card_schema"]["operation"] == "read", source_map
+    assert "loopx value-connectors plan" in source_map["agent_prompt"], source_map
+    assert_public_safe(source_map)
+
+    agent_reach_map = json.loads(
+        run_cli(
+            [
+                "--format",
+                "json",
+                "value-connectors",
+                "source-map",
+                "--connector",
+                "agent_reach_ops_source_map",
+            ]
+        ).stdout
+    )
+    assert agent_reach_map["ok"] is True, agent_reach_map
+    assert len(agent_reach_map["source_profiles"]) == 1, agent_reach_map
+    agent_reach_profile = agent_reach_map["source_profiles"][0]
+    assert agent_reach_profile["connector_id"] == "agent_reach_ops_source_map", agent_reach_profile
+    assert agent_reach_profile["external_reads_allowed"] is True, agent_reach_profile
+    assert agent_reach_profile["external_writes_allowed"] is False, agent_reach_profile
+    assert not agent_reach_map["action_gated_profiles"], agent_reach_map
+    assert_public_safe(agent_reach_map)
 
     x_install = json.loads(
         run_cli(
@@ -394,6 +442,13 @@ def main() -> int:
     assert "LoopX GitHub Public Channel Probe" in markdown, markdown
     assert "external_writes_performed: `False`" in markdown, markdown
     assert_public_safe(markdown)
+
+    source_map_markdown = run_cli(["value-connectors", "source-map"]).stdout
+    assert "LoopX Value Connector Source Map" in source_map_markdown, source_map_markdown
+    assert "agent_can_start_without_docs: `True`" in source_map_markdown, source_map_markdown
+    assert "`github_public_channel`" in source_map_markdown, source_map_markdown
+    assert "`finance_market_snapshot`" in source_map_markdown, source_map_markdown
+    assert_public_safe(source_map_markdown)
 
     reply_markdown = run_cli(
         [

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -211,12 +211,17 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
             "channel metadata into LoopX value signals while gating account "
             "setup, sends, posts, and private reads."
         ),
-        "entry_command": "loopx value-connectors install-check --format json",
+        "entry_command": "loopx value-connectors source-map --format json",
         "commands": [
             {
                 "command": "loopx value-connectors install-check --format json",
                 "purpose": "Show connector starter install/use commands and local dependency status.",
                 "write_boundary": "local check only; no external read or write",
+            },
+            {
+                "command": "loopx value-connectors source-map --format json",
+                "purpose": "Give agents a read-first source-map packet for all currently surfaced connector profiles.",
+                "write_boundary": "packet only; no external read, write, account setup, or raw payload capture",
             },
             {
                 "command": "loopx value-connectors github-public-probe --url <github-issue-or-pr-url> --format json",
@@ -269,6 +274,11 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "schema_version": "value_connector_install_check_packet_v0",
                 "module": "loopx.capabilities.value_connectors.github_public",
                 "doc": "docs/reference/protocols/value-connector-plan-v0.md",
+            },
+            {
+                "schema_version": "value_connector_source_map_packet_v0",
+                "module": "loopx.capabilities.value_connectors.source_map",
+                "doc": "docs/capabilities/value-connectors/agent-reach-ops-source-map.md",
             },
         ],
         "smokes": [

--- a/loopx/capabilities/value_connectors/cli.py
+++ b/loopx/capabilities/value_connectors/cli.py
@@ -23,6 +23,11 @@ from .planner import (
     build_value_connector_plan_packet,
     render_value_connector_plan_markdown,
 )
+from .source_map import (
+    SOURCE_PROFILE_IDS,
+    build_value_connector_source_map_packet,
+    render_value_connector_source_map_markdown,
+)
 
 
 PrintPayload = Callable[
@@ -61,6 +66,8 @@ def register_value_connector_commands(
         "--connector",
         choices=[
             "all",
+            "agent_reach_ops_source_map",
+            "finance_market_snapshot",
             "github_public_channel",
             "botmail_identity",
             "community_channel",
@@ -68,6 +75,20 @@ def register_value_connector_commands(
         ],
         default="all",
         help="Connector profile to check.",
+    )
+    source_map_parser = sub.add_parser(
+        "source-map",
+        help=(
+            "Render a read-first source-map packet so agents can use proven "
+            "connectors without opening internal docs."
+        ),
+    )
+    add_subcommand_format(source_map_parser)
+    source_map_parser.add_argument(
+        "--connector",
+        choices=sorted(SOURCE_PROFILE_IDS),
+        default="all",
+        help="Connector source profile to render.",
     )
     plan_parser = sub.add_parser(
         "plan",
@@ -220,6 +241,16 @@ def handle_value_connector_command(
                 render_value_connector_install_check_markdown,
             )
             return 0
+        if args.value_connectors_command == "source-map":
+            payload = build_value_connector_source_map_packet(
+                connector=args.connector,
+            )
+            print_payload(
+                payload,
+                output_format(args),
+                render_value_connector_source_map_markdown,
+            )
+            return 0
         if args.value_connectors_command == "github-public-probe":
             payload = build_github_public_channel_probe_packet(
                 url=args.url,
@@ -253,7 +284,7 @@ def handle_value_connector_command(
         if args.value_connectors_command != "plan":
             raise ValueError(
                 "value-connectors requires `install-check`, `plan`, "
-                "`github-public-probe`, or `github-reply-monitor`"
+                "`source-map`, `github-public-probe`, or `github-reply-monitor`"
             )
         if args.connector_id:
             missing = [

--- a/loopx/capabilities/value_connectors/github_public.py
+++ b/loopx/capabilities/value_connectors/github_public.py
@@ -594,6 +594,41 @@ def build_value_connector_install_check_packet(
             "external_write_capability": False,
         },
         {
+            "connector_id": "agent_reach_ops_source_map",
+            "status": "ready" if shutil.which("agent-reach") else "needs_agent_reach",
+            "install": [
+                "Install Agent-Reach when available, then run `agent-reach doctor --json`.",
+                "Use `loopx value-connectors source-map --connector agent_reach_ops_source_map --format json` before drafting from external signals.",
+                "Keep Agent-Reach routes read-only; use LoopX evidence cards, maturity scores, and publish/audit gates for action.",
+            ],
+            "optional_tools": [
+                {
+                    "tool": "agent-reach",
+                    "installed": shutil.which("agent-reach") is not None,
+                    "needed_for": "source routing across public/read-only external channels",
+                    "install_hint": "Install Agent-Reach in the active agent environment and rerun `agent-reach doctor --json`.",
+                },
+                {
+                    "tool": "gh",
+                    "installed": shutil.which("gh") is not None,
+                    "needed_for": "GitHub-backed source routes and public repository search",
+                    "install_hint": "Install GitHub CLI and authenticate if GitHub source routes are needed.",
+                },
+            ],
+            "external_write_capability": False,
+        },
+        {
+            "connector_id": "finance_market_snapshot",
+            "status": "probed_candidate",
+            "install": [
+                "Use `loopx value-connectors source-map --connector finance_market_snapshot --format json` for the boundary packet.",
+                "Plan finance information pulls as public/reference snapshots, not advice or trading actions.",
+                "Stop for credentials, AK/SK, paid feeds, private portfolio data, or trading intent.",
+            ],
+            "optional_tools": [],
+            "external_write_capability": False,
+        },
+        {
             "connector_id": "botmail_identity",
             "status": "host_connector_required",
             "install": [

--- a/loopx/capabilities/value_connectors/source_map.py
+++ b/loopx/capabilities/value_connectors/source_map.py
@@ -1,0 +1,355 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+
+VALUE_CONNECTOR_SOURCE_MAP_PACKET_SCHEMA_VERSION = "value_connector_source_map_packet_v0"
+VALUE_CONNECTOR_SOURCE_PROFILE_SCHEMA_VERSION = "value_connector_source_profile_v0"
+VALUE_CONNECTOR_SOURCE_MAP_PROJECTION_SCHEMA_VERSION = "value_connector_source_map_projection_v0"
+
+
+SOURCE_PROFILE_IDS = {
+    "all",
+    "github_public_channel",
+    "github_public_reply_monitor",
+    "content_ops_public_handle",
+    "social_browser_x",
+    "agent_reach_ops_source_map",
+    "finance_market_snapshot",
+}
+
+
+def _source_profile(
+    *,
+    connector_id: str,
+    status: str,
+    route_type: str,
+    boundary: str,
+    safe_uses: list[str],
+    commands: list[str],
+    evidence_schema: str,
+    maturity_hint: str,
+    write_gate: str | None = None,
+    stop_conditions: list[str] | None = None,
+) -> dict[str, Any]:
+    return {
+        "schema_version": VALUE_CONNECTOR_SOURCE_PROFILE_SCHEMA_VERSION,
+        "connector_id": connector_id,
+        "status": status,
+        "route_type": route_type,
+        "boundary": boundary,
+        "safe_uses": safe_uses,
+        "commands": commands,
+        "evidence_schema": evidence_schema,
+        "maturity_hint": maturity_hint,
+        "external_reads_allowed": boundary in {
+            "public_metadata_only",
+            "public_no_login",
+            "logged_in_read",
+            "route_specific_read_only",
+        },
+        "external_writes_allowed": False,
+        "write_gate": write_gate,
+        "stop_conditions": stop_conditions or [
+            "source boundary is unclear",
+            "requested action would capture raw private content",
+            "requested action would perform an external write without an audit gate",
+        ],
+    }
+
+
+def _source_profiles() -> list[dict[str, Any]]:
+    return [
+        _source_profile(
+            connector_id="github_public_channel",
+            status="implemented_starter",
+            route_type="public metadata probe",
+            boundary="public_metadata_only",
+            safe_uses=[
+                "validate public GitHub issue, PR, or discussion URLs",
+                "collect allowlisted metadata such as title, state, count, and update time",
+                "prepare demand or maintainer-interest evidence without copying body text",
+            ],
+            commands=[
+                "loopx value-connectors github-public-probe --url <github-issue-or-pr-url> --format json",
+                "loopx value-connectors github-public-probe --url <github-issue-or-pr-url> --fetch-metadata --format json",
+            ],
+            evidence_schema="github_public_channel_probe_packet_v0",
+            maturity_hint="Use public metadata and maintainer/project fit; never infer intent from private body content.",
+            stop_conditions=[
+                "URL has query, fragment, auth material, or non-GitHub host",
+                "the claim requires issue, PR, comment, or discussion body text",
+                "the next action would comment, label, close, or mutate GitHub state",
+            ],
+        ),
+        _source_profile(
+            connector_id="github_public_reply_monitor",
+            status="implemented_starter",
+            route_type="public metadata monitor",
+            boundary="public_metadata_only",
+            safe_uses=[
+                "detect public replies after a known LoopX comment anchor",
+                "classify maintainer association metadata without comment bodies",
+                "decide whether to prepare a public triage note or wait",
+            ],
+            commands=[
+                "loopx value-connectors github-reply-monitor --issue-url <github-issue-or-pr-url> --after-comment-url <github-comment-url> --format json",
+                "loopx value-connectors github-reply-monitor --issue-url <github-issue-or-pr-url> --after-comment-url <github-comment-url> --fetch-metadata --format json",
+            ],
+            evidence_schema="github_public_reply_monitor_packet_v0",
+            maturity_hint="Treat maintainer/member replies after the anchor as stronger signal than generic public comments.",
+            stop_conditions=[
+                "anchor comment cannot be found",
+                "provider payload contains raw body fields that would be copied forward",
+                "agent would bump or reply to the thread without an exact gate",
+            ],
+        ),
+        _source_profile(
+            connector_id="content_ops_public_handle",
+            status="implemented_starter",
+            route_type="public handle observation",
+            boundary="public_metadata_only",
+            safe_uses=[
+                "turn a public handle or profile URL into a compact source item",
+                "start content-ops review from metadata before deeper connector reads",
+                "record a no-fetch packet when the browser/account boundary is not ready",
+            ],
+            commands=[
+                "loopx content-ops observe-public-handle --url <public-profile-url> --source-item-id <stable-source-id> --no-fetch --format json",
+            ],
+            evidence_schema="content_ops_public_handle_observation_packet_v0",
+            maturity_hint="Use as a source-item anchor; require another source before making trend or demand claims.",
+            stop_conditions=[
+                "profile requires login-only body access",
+                "the handle identity or account boundary is ambiguous",
+                "the next step would scrape private timeline material",
+            ],
+        ),
+        _source_profile(
+            connector_id="social_browser_x",
+            status="profile_ready_when_browser_available",
+            route_type="browser-backed public/social channel",
+            boundary="logged_in_read",
+            safe_uses=[
+                "read public or account-visible X metadata through an owner-approved browser profile",
+                "prepare source-mapped drafts for LoopX posts or replies",
+                "monitor published posts after an audited publish record exists",
+            ],
+            commands=[
+                "loopx content-ops observe-public-handle --url https://x.com/<handle> --source-item-id <stable-source-id> --no-fetch --format json",
+                "loopx value-connectors plan --connector-id social_browser_x --connector-kind browser_social_channel --channel 'X public post via browser' --stage external_write_request --target-ref '<exact post>' --target-url https://x.com/<handle> --external-write-requested --money-metric '<demand metric>' --success-metric '<success metric>' --kill-condition '<stop condition>' --format json",
+            ],
+            evidence_schema="x_draft_packet_v0 or content_ops_public_handle_observation_packet_v0",
+            maturity_hint="Use repeated public signals and concrete workflow-owner replies; avoid platform drama as proof.",
+            write_gate="exact account, final body, media/link plan, timing, source refs, and stop condition required",
+            stop_conditions=[
+                "active account identity is unclear",
+                "source requires private DMs, private lists, or hidden timeline expansion",
+                "post/reply/media upload would execute without an audit record",
+            ],
+        ),
+        _source_profile(
+            connector_id="agent_reach_ops_source_map",
+            status="field_derived_pattern",
+            route_type="source router",
+            boundary="route_specific_read_only",
+            safe_uses=[
+                "run connector doctor and choose available public/read-only routes",
+                "collect public GitHub, web/RSS, V2EX, Bilibili, or similar signals into evidence cards",
+                "score category maturity before drafting content",
+            ],
+            commands=[
+                "agent-reach doctor --json",
+                "loopx value-connectors source-map --connector agent_reach_ops_source_map --format json",
+            ],
+            evidence_schema="agent_reach_ops_signal_v0",
+            maturity_hint="Score 0 noise, 1 weak, 2 emerging, 3 mature; corroborate source routes before drafting.",
+            stop_conditions=[
+                "doctor route is unavailable or boundary is unclear",
+                "route needs cookies, private groups, DMs, captcha, or account setup",
+                "draft would quote raw provider bodies beyond public-safe excerpts",
+            ],
+        ),
+        _source_profile(
+            connector_id="finance_market_snapshot",
+            status="probed_candidate_profile",
+            route_type="public market snapshot probe",
+            boundary="public_no_login",
+            safe_uses=[
+                "plan finance information pulls as public/reference snapshots",
+                "compare public source availability such as official docs, public APIs, or OSS wrappers",
+                "surface a user gate before credentials, paid feeds, trading, or portfolio reads",
+            ],
+            commands=[
+                "loopx value-connectors plan --connector-id finance_market_snapshot --connector-kind custom_connector --channel 'public finance snapshot' --stage observe --target-ref '<market or symbol scope>' --external-read --money-metric '<research or decision-support value>' --success-metric '<fresh public snapshot with source warnings>' --kill-condition '<stale source, paid gate, credential need, or trading intent>' --format json",
+            ],
+            evidence_schema="finance_market_snapshot_probe_v0",
+            maturity_hint="Treat market data as reference evidence, not financial advice; source freshness and license matter.",
+            stop_conditions=[
+                "request needs account credentials, AK/SK, portfolio data, paid provider data, or trading action",
+                "source freshness or license cannot be stated",
+                "user asks for investment advice instead of source-backed information retrieval",
+            ],
+        ),
+    ]
+
+
+def _action_gated_profiles() -> list[dict[str, Any]]:
+    return [
+        {
+            "connector_id": "botmail_identity",
+            "boundary": "external_write_gated",
+            "purpose": "email or botmail identity for replies and outreach",
+            "safe_prepare_command": "loopx value-connectors plan --connector-id botmail_identity --connector-kind botmail_identity ... --format json",
+            "write_gate": "exact sender, recipient, subject, body, metric, and stop condition required",
+        },
+        {
+            "connector_id": "community_channel",
+            "boundary": "external_write_gated",
+            "purpose": "community reply or post after channel-rule review",
+            "safe_prepare_command": "loopx value-connectors plan --connector-id community_channel --connector-kind community_channel ... --format json",
+            "write_gate": "exact channel, account identity, message, value metric, and channel-rule fit required",
+        },
+    ]
+
+
+def _generic_evidence_card_schema() -> dict[str, Any]:
+    return {
+        "schema_version": "connector_source_signal_v0",
+        "connector_id": "<source profile id>",
+        "channel": "github | x | web | rss | v2ex | bilibili | finance | other",
+        "backend": "public-safe backend name",
+        "query_or_target": "public-safe query, handle, symbol, URL, or topic",
+        "title": "public-safe title or compact label",
+        "url": "public URL or null",
+        "summary": "one short public-safe summary of what the source supports",
+        "boundary": "public_metadata_only | public_no_login | logged_in_read | route_specific_read_only",
+        "operation": "read",
+        "observed_at": "ISO-8601 timestamp",
+        "confidence": "doctor_status | source_metadata | source_body_reviewed",
+        "maturity_score": "0 | 1 | 2 | 3",
+        "maturity_reason": "why the signal is noise, weak, emerging, or mature",
+        "claims_supported": ["short claim this source can support"],
+        "forbidden_next_actions": [
+            "copy raw private body",
+            "external write without publish/audit gate",
+        ],
+    }
+
+
+def _maturity_scale() -> list[dict[str, Any]]:
+    return [
+        {"score": 0, "meaning": "noise or unavailable route"},
+        {"score": 1, "meaning": "weak exploratory signal"},
+        {"score": 2, "meaning": "emerging repeated signal"},
+        {"score": 3, "meaning": "mature signal with strong adoption or multiple independent sources"},
+    ]
+
+
+def build_value_connector_source_map_packet(*, connector: str = "all") -> dict[str, Any]:
+    if connector not in SOURCE_PROFILE_IDS:
+        raise ValueError(f"unknown connector source map {connector!r}")
+    profiles = [
+        profile
+        for profile in _source_profiles()
+        if connector == "all" or profile["connector_id"] == connector
+    ]
+    action_gated = [] if connector != "all" else _action_gated_profiles()
+    projection = {
+        "schema_version": VALUE_CONNECTOR_SOURCE_MAP_PROJECTION_SCHEMA_VERSION,
+        "agent_can_start_without_docs": True,
+        "recommended_first_command": "loopx value-connectors source-map --format json",
+        "source_profile_count": len(profiles),
+        "action_gated_profile_count": len(action_gated),
+        "external_write_blocked_by_default": True,
+        "read_first_loop": [
+            "choose source profile",
+            "run only the read/metadata command",
+            "emit connector_source_signal_v0 cards",
+            "score maturity",
+            "write ops brief or no-send packet",
+            "use value-connectors plan before any external write",
+        ],
+    }
+    return {
+        "ok": True,
+        "schema_version": VALUE_CONNECTOR_SOURCE_MAP_PACKET_SCHEMA_VERSION,
+        "mode": "value-connectors-source-map",
+        "connector": connector,
+        "external_reads_performed": False,
+        "external_writes_performed": False,
+        "account_signup_performed": False,
+        "restricted_material_recorded": False,
+        "private_source_content_read": False,
+        "autopublish_allowed": False,
+        "source_profiles": profiles,
+        "action_gated_profiles": action_gated,
+        "generic_evidence_card_schema": _generic_evidence_card_schema(),
+        "maturity_scale": _maturity_scale(),
+        "projection": projection,
+        "agent_prompt": (
+            "Before drafting or posting from external signals, run `loopx "
+            "value-connectors source-map --format json`, choose a read-only "
+            "source profile, emit compact evidence cards, score maturity, and "
+            "write an ops brief. Use `loopx value-connectors plan` for any "
+            "signup, send, post, reply, upload, production action, credentialed "
+            "read, or private-source expansion. Stop with a no-send packet when "
+            "the active account, source boundary, body, or link state is unclear."
+        ),
+    }
+
+
+def render_value_connector_source_map_markdown(payload: dict[str, Any]) -> str:
+    projection = payload.get("projection") if isinstance(payload.get("projection"), Mapping) else {}
+    lines = [
+        "# LoopX Value Connector Source Map",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- connector: `{payload.get('connector')}`",
+        f"- external_reads_performed: `{payload.get('external_reads_performed')}`",
+        f"- external_writes_performed: `{payload.get('external_writes_performed')}`",
+        f"- agent_can_start_without_docs: `{projection.get('agent_can_start_without_docs')}`",
+        f"- source_profile_count: `{projection.get('source_profile_count')}`",
+        f"- action_gated_profile_count: `{projection.get('action_gated_profile_count')}`",
+        "",
+        "## Read-First Loop",
+        "",
+    ]
+    for step in projection.get("read_first_loop") or []:
+        lines.append(f"- {step}")
+    lines.extend(["", "## Source Profiles", ""])
+    for profile in payload.get("source_profiles") or []:
+        if not isinstance(profile, Mapping):
+            continue
+        lines.extend(
+            [
+                f"### `{profile.get('connector_id')}`",
+                "",
+                f"- status: `{profile.get('status')}`",
+                f"- boundary: `{profile.get('boundary')}`",
+                f"- evidence_schema: `{profile.get('evidence_schema')}`",
+                f"- maturity_hint: {profile.get('maturity_hint')}",
+                "- commands:",
+            ]
+        )
+        for command in profile.get("commands") or []:
+            lines.append(f"  - `{command}`")
+        if profile.get("write_gate"):
+            lines.append(f"- write_gate: {profile.get('write_gate')}")
+        lines.append("")
+    action_gated = payload.get("action_gated_profiles")
+    if isinstance(action_gated, list) and action_gated:
+        lines.extend(["## Action-Gated Profiles", ""])
+        for profile in action_gated:
+            if not isinstance(profile, Mapping):
+                continue
+            lines.extend(
+                [
+                    f"- `{profile.get('connector_id')}`: {profile.get('purpose')}",
+                    f"  - gate: {profile.get('write_gate')}",
+                ]
+            )
+        lines.append("")
+    lines.extend(["## Agent Prompt", "", str(payload.get("agent_prompt") or "")])
+    return "\n".join(lines).rstrip() + "\n"


### PR DESCRIPTION
## Summary
- add `loopx value-connectors source-map --format json` as the read-first packet for newly connected agents
- cover currently surfaced connector profiles: GitHub public metadata, GitHub reply monitor, content-ops public handle, browser-backed X, Agent-Reach source routing, and finance market snapshot probes
- keep botmail/community as action-gated profiles so agents do not treat send/post channels as free source routes
- index the packet from capability catalog, value-connectors docs, and content-ops docs

## Validation
- `python3 examples/value-connectors-github-public-probe-smoke.py`
- `python3 -m py_compile loopx/capabilities/value_connectors/source_map.py loopx/capabilities/value_connectors/cli.py loopx/capabilities/value_connectors/github_public.py loopx/capabilities/catalog.py`
- `loopx check --scan-path docs/capabilities/value-connectors --scan-path docs/capabilities/content-ops --scan-path loopx/capabilities/value_connectors --scan-path loopx/capabilities/catalog.py --scan-path examples/value-connectors-github-public-probe-smoke.py`

## Notes
- `source-map` is packet-only: no external read, write, account setup, or raw payload capture
- `black` was not available in this environment (`No module named black`), so validation used compile + focused smoke + LoopX boundary check
