### PR TITLE
Refactor timestamp parsing into runtime readmodel

### DIFF
--- a/examples/control_plane/todo-readmodel-boundary-smoke.py
+++ b/examples/control_plane/todo-readmodel-boundary-smoke.py
@@ -21,9 +21,11 @@ from loopx.control_plane.goals import global_registry_shadow as global_registry_
 from loopx.control_plane.runtime import event_ledger as event_ledger_read_model  # noqa: E402
 from loopx.control_plane.runtime import run_compaction as run_compaction_read_model  # noqa: E402
 from loopx.control_plane.runtime import session_runtime as session_runtime_read_model  # noqa: E402
+from loopx.control_plane.runtime import time as runtime_time_read_model  # noqa: E402
 from loopx.control_plane.quota import usage_summary as usage_summary_read_model  # noqa: E402
 from loopx.control_plane.todos import active_state_todo_parser as active_state_todo_parser_read_model  # noqa: E402
 from loopx.control_plane.todos import active_state_todos as active_state_todos_read_model  # noqa: E402
+from loopx.control_plane.todos import monitor_metadata as monitor_metadata_read_model  # noqa: E402
 from loopx.control_plane.todos import projection as todo_projection_read_model  # noqa: E402
 from loopx.control_plane.todos import todo_summary as todo_read_model  # noqa: E402
 
@@ -99,6 +101,8 @@ def assert_direct_status_aliases() -> None:
     assert status_module.compact_operator_gate is run_compaction_read_model.compact_operator_gate
     assert status_module.compact_operator_gate_resume_contract is run_compaction_read_model.compact_operator_gate_resume_contract
     assert status_module.compact_controller_readiness is run_compaction_read_model.compact_controller_readiness
+    assert status_module.parse_timestamp is runtime_time_read_model.parse_timestamp
+    assert monitor_metadata_read_model.parse_timestamp is runtime_time_read_model.parse_timestamp
     assert status_module.quota_spend_slots is usage_summary_read_model.quota_spend_slots
     assert status_module.is_automation_run is usage_summary_read_model.is_automation_run
     assert status_module.is_progress_signal_run is usage_summary_read_model.is_progress_signal_run
@@ -124,6 +128,13 @@ def assert_wrapper_parity() -> None:
         todos,
         role="agent",
     )
+    parsed = status_module.parse_timestamp("2026-01-01T00:00:00")
+    assert parsed is not None
+    assert parsed.tzinfo is not None
+    assert status_module.parse_timestamp("not-a-time") is None
+    assert monitor_metadata_read_model.normalize_monitor_metadata(
+        {"next_due_at": "2026-01-01T00:00:00Z"}
+    ) == {"next_due_at": "2026-01-01T00:00:00Z"}
 
 
 def assert_dependency_blocker_parity() -> None:

--- a/loopx/control_plane/runtime/time.py
+++ b/loopx/control_plane/runtime/time.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+
+def parse_timestamp(value: Any) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed

--- a/loopx/control_plane/todos/monitor_metadata.py
+++ b/loopx/control_plane/todos/monitor_metadata.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import re
 from typing import Any
 
-from ...status import parse_timestamp
+from ..runtime.time import parse_timestamp
 from .contract import TODO_MONITOR_METADATA_FIELDS
 
 

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
 import hashlib
 from pathlib import Path
 import re
@@ -178,6 +177,7 @@ from .control_plane.runtime.public_safety import (
     public_safe_compact_list,
     public_safe_compact_text,
 )
+from .control_plane.runtime.time import parse_timestamp
 from .control_plane.runtime.run_history import (
     build_run_history as _build_run_history_read_model,
     latest_run as _latest_run_read_model,
@@ -6454,18 +6454,6 @@ def merge_global_registry_attention_findings(
         attention_item=attention_item,
         attach_global_registry_shadow_finding=attach_global_registry_shadow_finding,
     )
-
-
-def parse_timestamp(value: Any) -> datetime | None:
-    if not value:
-        return None
-    try:
-        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=timezone.utc)
-    return parsed
 
 
 def same_path(left: Path, right: Path) -> bool:


### PR DESCRIPTION
## Summary
- add `loopx/control_plane/runtime/time.py` as the shared control-plane timestamp parsing home
- make `status.py` import `parse_timestamp` from the runtime readmodel instead of defining it locally
- make todo monitor metadata validation import timestamp parsing from the runtime bounded context instead of importing the hot top-level `status.py` aggregator
- extend the todo readmodel boundary smoke to pin the alias and monitor metadata behavior

## Validation
- `python3 examples/control_plane/todo-readmodel-boundary-smoke.py`
- `python3 examples/control_plane/monitor-todo-policy-seam-smoke.py`
- `python3 examples/control_plane/todo-cli-smoke.py`
- `python3 examples/control_plane/todo-user-gate-readmodel-smoke.py`
- `python3 -m compileall -q loopx/control_plane/runtime/time.py loopx/control_plane/todos/monitor_metadata.py loopx/status.py`
- `python3 examples/control_plane/status-contract-readmodel-smoke.py`
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 examples/control_plane/quota-todo-summary-readmodel-smoke.py`
- `python3 examples/control_plane/monitor-poll-writeback-smoke.py`
- `python3 examples/control_plane/todo-projection-shared-helper-smoke.py`
- `python3 examples/control_plane/run-history-readmodel-smoke.py`
- `python3 examples/control_plane/event-ledger-readmodel-smoke.py`
- `python3 examples/control_plane/decision-freshness-readmodel-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `loopx check --scan-path loopx/control_plane/runtime/time.py --scan-path loopx/control_plane/todos/monitor_metadata.py --scan-path loopx/status.py --scan-path examples/control_plane/todo-readmodel-boundary-smoke.py`
- `loopx canary premerge --from-git-diff`

## Boundary
- Added-line private/material scan clean.
- Public boundary scan clean across all four changed files.
- No benchmark execution, raw logs, trajectories, verifier output, production actions, or credential material touched.
