### PR TITLE
Refactor control-plane status reverse imports

### DIFF
--- a/examples/control_plane/todo-readmodel-boundary-smoke.py
+++ b/examples/control_plane/todo-readmodel-boundary-smoke.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import ast
 from copy import deepcopy
 from pathlib import Path
 import sys
@@ -18,6 +19,7 @@ from loopx.control_plane.work_items import attention_item as attention_item_read
 from loopx.control_plane.work_items import autonomous_candidates as autonomous_read_model  # noqa: E402
 from loopx.control_plane.work_items import autonomous_replan_ack as replan_ack_read_model  # noqa: E402
 from loopx.control_plane.goals import global_registry_shadow as global_registry_shadow_read_model  # noqa: E402
+from loopx.control_plane.goals import path_resolution as path_resolution_read_model  # noqa: E402
 from loopx.control_plane.runtime import event_ledger as event_ledger_read_model  # noqa: E402
 from loopx.control_plane.runtime import run_compaction as run_compaction_read_model  # noqa: E402
 from loopx.control_plane.runtime import session_runtime as session_runtime_read_model  # noqa: E402
@@ -82,6 +84,8 @@ def fixture_todos() -> dict:
 def assert_direct_status_aliases() -> None:
     assert status_module.parse_state_frontmatter is active_state_metadata_read_model.parse_state_frontmatter
     assert status_module.todo_role_for_heading is active_state_metadata_read_model.todo_role_for_heading
+    assert status_module.same_path is path_resolution_read_model.same_path
+    assert status_module.resolve_goal_local_path is path_resolution_read_model.resolve_goal_local_path
     assert status_module.parse_active_state_todos is active_state_todo_parser_read_model.parse_active_state_todos
     assert status_module.attach_monitor_writeback_contract is active_state_todos_read_model.attach_monitor_writeback_contract
     assert status_module.redacted_status_todo_fields is active_state_todos_read_model.redacted_status_todo_fields
@@ -308,8 +312,28 @@ def assert_active_state_todo_fields_redacts_review_material_paths() -> None:
         assert "resolved_path" not in material_projection, material_projection
 
 
+def assert_control_plane_has_no_status_reverse_imports() -> None:
+    control_plane_root = ROOT / "loopx" / "control_plane"
+    offenders: list[str] = []
+    for path in sorted(control_plane_root.rglob("*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    if alias.name == "loopx.status":
+                        offenders.append(f"{path.relative_to(ROOT)}:{node.lineno} import {alias.name}")
+            elif isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                if module == "loopx.status" or (module == "status" and node.level > 0):
+                    offenders.append(
+                        f"{path.relative_to(ROOT)}:{node.lineno} from {'.' * node.level}{module} import",
+                    )
+    assert offenders == [], offenders
+
+
 def main() -> None:
     assert_direct_status_aliases()
+    assert_control_plane_has_no_status_reverse_imports()
     assert_wrapper_parity()
     assert_dependency_blocker_parity()
     assert_autonomous_candidate_parity()

--- a/loopx/control_plane/goals/path_resolution.py
+++ b/loopx/control_plane/goals/path_resolution.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+def same_path(left: Path, right: Path) -> bool:
+    return left.expanduser().resolve() == right.expanduser().resolve()
+
+
+def resolve_goal_local_path(raw: Any, goal: dict[str, Any], *, fallback_base: Path) -> Path | None:
+    if not raw:
+        return None
+    path = Path(str(raw)).expanduser()
+    if path.is_absolute():
+        return path
+    repo = goal.get("repo")
+    if repo:
+        return Path(str(repo)).expanduser() / path
+    return fallback_base / path

--- a/loopx/control_plane/testing/quota_fixtures.py
+++ b/loopx/control_plane/testing/quota_fixtures.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from ...status import compact_todo_group
+from ..todos.todo_summary import compact_todo_group
 
 
 DEFAULT_FIXTURE_QUOTA = {

--- a/loopx/control_plane/todos/event_writeback.py
+++ b/loopx/control_plane/todos/event_writeback.py
@@ -13,7 +13,12 @@ from ...event_sourced_state import (
     make_state_event,
 )
 from ...history import load_registry
-from ...status import active_state_event_projection_fields, state_event_log_candidates
+from ..goals.active_state_event_projection import (
+    active_state_event_projection_fields,
+    state_event_log_candidates,
+)
+from ..goals.path_resolution import resolve_goal_local_path
+from .active_state_todo_parser import parse_active_state_todos
 from .contract import (
     TODO_STATUS_DONE,
     TODO_STATUS_OPEN,
@@ -59,6 +64,8 @@ def event_projection_todo_context(
     fields = active_state_event_projection_fields(
         goal,
         state_path=state_path,
+        resolve_goal_local_path=resolve_goal_local_path,
+        parse_active_state_todos=parse_active_state_todos,
         item_limit=None,
     )
     if not fields.get("state_event_projection"):
@@ -86,7 +93,15 @@ def event_projection_todo_context(
     if not matched_item or matched_role is None:
         return None
     event_log_path = next(
-        (path for path in state_event_log_candidates(goal, state_path=state_path) if path.exists()),
+        (
+            path
+            for path in state_event_log_candidates(
+                goal,
+                state_path=state_path,
+                resolve_goal_local_path=resolve_goal_local_path,
+            )
+            if path.exists()
+        ),
         None,
     )
     if event_log_path is None:

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -216,6 +216,7 @@ from .control_plane.goals.global_registry_health import (
     collect_global_registry_health as _collect_global_registry_health_read_model,
     global_registry_finding,
 )
+from .control_plane.goals.path_resolution import resolve_goal_local_path, same_path
 from .control_plane.goals.goal_channel import (
     attach_goal_channel_projection as _attach_goal_channel_projection_read_model,
 )
@@ -6454,22 +6455,6 @@ def merge_global_registry_attention_findings(
         attention_item=attention_item,
         attach_global_registry_shadow_finding=attach_global_registry_shadow_finding,
     )
-
-
-def same_path(left: Path, right: Path) -> bool:
-    return left.expanduser().resolve() == right.expanduser().resolve()
-
-
-def resolve_goal_local_path(raw: Any, goal: dict[str, Any], *, fallback_base: Path) -> Path | None:
-    if not raw:
-        return None
-    path = Path(str(raw)).expanduser()
-    if path.is_absolute():
-        return path
-    repo = goal.get("repo")
-    if repo:
-        return Path(str(repo)).expanduser() / path
-    return fallback_base / path
 
 
 def collect_global_registry_health(


### PR DESCRIPTION
## Summary
- move goal-local path resolution into `loopx.control_plane.goals.path_resolution` and keep `loopx.status` as the compatibility facade
- make event-projected todo writeback use the active-state event projection read model directly instead of importing through `loopx.status`
- update quota fixtures and add a canary assertion that `loopx/control_plane` has no reverse imports of `loopx.status`

## Validation
- `rg "from \\.{2,3}status import|from loopx\\.status import|import loopx\\.status|from \\.status import" loopx/control_plane -n || true`
- `python3 -m compileall -q loopx/control_plane/goals/path_resolution.py loopx/control_plane/todos/event_writeback.py loopx/control_plane/testing/quota_fixtures.py loopx/status.py examples/control_plane/todo-readmodel-boundary-smoke.py`
- `python3 examples/control_plane/todo-readmodel-boundary-smoke.py`
- `python3 examples/control_plane/event-sourced-status-read-path-smoke.py`
- `python3 examples/control_plane/event-sourced-downstream-read-path-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `loopx check --scan-path loopx/control_plane/goals/path_resolution.py --scan-path loopx/control_plane/todos/event_writeback.py --scan-path loopx/control_plane/testing/quota_fixtures.py --scan-path loopx/status.py --scan-path examples/control_plane/todo-readmodel-boundary-smoke.py`
- `loopx canary premerge --from-git-diff` passed with `self_merge_allowed=true`, surfaces `control_plane, public_boundary, python`, risk profiles `core-control-plane, canary-runner`, manual holds 0
