### PR TITLE
Refactor shared control-plane timestamp parsing

### DIFF
--- a/examples/control_plane/todo-readmodel-boundary-smoke.py
+++ b/examples/control_plane/todo-readmodel-boundary-smoke.py
@@ -20,9 +20,12 @@ from loopx.control_plane.work_items import autonomous_candidates as autonomous_r
 from loopx.control_plane.work_items import autonomous_replan_ack as replan_ack_read_model  # noqa: E402
 from loopx.control_plane.goals import global_registry_shadow as global_registry_shadow_read_model  # noqa: E402
 from loopx.control_plane.goals import path_resolution as path_resolution_read_model  # noqa: E402
+from loopx.control_plane.agents import management_projection as management_projection_read_model  # noqa: E402
+from loopx.control_plane.runtime import agent_scoped_evidence_log as evidence_log_read_model  # noqa: E402
 from loopx.control_plane.runtime import event_ledger as event_ledger_read_model  # noqa: E402
 from loopx.control_plane.runtime import run_compaction as run_compaction_read_model  # noqa: E402
 from loopx.control_plane.runtime import session_runtime as session_runtime_read_model  # noqa: E402
+from loopx.control_plane.runtime import status_projection_cache as status_cache_read_model  # noqa: E402
 from loopx.control_plane.runtime import time as runtime_time_read_model  # noqa: E402
 from loopx.control_plane.quota import usage_summary as usage_summary_read_model  # noqa: E402
 from loopx.control_plane.todos import active_state_todo_parser as active_state_todo_parser_read_model  # noqa: E402
@@ -30,6 +33,7 @@ from loopx.control_plane.todos import active_state_todos as active_state_todos_r
 from loopx.control_plane.todos import monitor_metadata as monitor_metadata_read_model  # noqa: E402
 from loopx.control_plane.todos import projection as todo_projection_read_model  # noqa: E402
 from loopx.control_plane.todos import todo_summary as todo_read_model  # noqa: E402
+from loopx.control_plane.work_items import task_lease as task_lease_read_model  # noqa: E402
 
 
 def fixture_todos() -> dict:
@@ -107,6 +111,10 @@ def assert_direct_status_aliases() -> None:
     assert status_module.compact_controller_readiness is run_compaction_read_model.compact_controller_readiness
     assert status_module.parse_timestamp is runtime_time_read_model.parse_timestamp
     assert monitor_metadata_read_model.parse_timestamp is runtime_time_read_model.parse_timestamp
+    assert status_cache_read_model.parse_timestamp is runtime_time_read_model.parse_timestamp
+    assert evidence_log_read_model.parse_timestamp is runtime_time_read_model.parse_timestamp
+    assert management_projection_read_model.parse_timestamp is runtime_time_read_model.parse_timestamp
+    assert task_lease_read_model.parse_timestamp is runtime_time_read_model.parse_timestamp
     assert status_module.quota_spend_slots is usage_summary_read_model.quota_spend_slots
     assert status_module.is_automation_run is usage_summary_read_model.is_automation_run
     assert status_module.is_progress_signal_run is usage_summary_read_model.is_progress_signal_run
@@ -135,6 +143,9 @@ def assert_wrapper_parity() -> None:
     parsed = status_module.parse_timestamp("2026-01-01T00:00:00")
     assert parsed is not None
     assert parsed.tzinfo is not None
+    stripped = status_module.parse_timestamp(" 2026-01-01T08:00:00+08:00 ")
+    assert stripped is not None
+    assert stripped.isoformat() == "2026-01-01T00:00:00+00:00", stripped
     assert status_module.parse_timestamp("not-a-time") is None
     assert monitor_metadata_read_model.normalize_monitor_metadata(
         {"next_due_at": "2026-01-01T00:00:00Z"}

--- a/loopx/control_plane/agents/management_projection.py
+++ b/loopx/control_plane/agents/management_projection.py
@@ -4,6 +4,7 @@ from datetime import datetime, timezone
 from typing import Any, Iterable
 
 from ..runtime.public_safety import public_safe_compact_text
+from ..runtime.time import parse_timestamp
 from ..todos.contract import normalize_todo_claimed_by, normalize_todo_id
 
 
@@ -224,18 +225,6 @@ def _workspace_ref_from_todo(todo: dict[str, Any] | None) -> dict[str, Any] | No
     return {key: value for key, value in workspace.items() if value not in (None, "", [], {})}
 
 
-def _parse_timestamp(value: str | None) -> datetime | None:
-    if not value:
-        return None
-    text = value.strip()
-    if not text:
-        return None
-    try:
-        return datetime.fromisoformat(text.replace("Z", "+00:00"))
-    except ValueError:
-        return None
-
-
 def _stale_claim_hint(todo: dict[str, Any] | None, *, agent_id: str) -> dict[str, Any] | None:
     if not todo or _is_done(todo):
         return None
@@ -256,7 +245,7 @@ def _stale_claim_hint(todo: dict[str, Any] | None, *, agent_id: str) -> dict[str
             "reason": "claimed open todo has no projected activity timestamp",
             "recommended_operator_action": "inspect evidence before considering reassignment",
         }
-    parsed = _parse_timestamp(last_activity)
+    parsed = parse_timestamp(last_activity)
     if not parsed:
         return {
             "state": "activity_unparsed",

--- a/loopx/control_plane/runtime/agent_scoped_evidence_log.py
+++ b/loopx/control_plane/runtime/agent_scoped_evidence_log.py
@@ -3,26 +3,16 @@ from __future__ import annotations
 import re
 import shlex
 from collections.abc import Iterable, Mapping
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any
+
+from .time import parse_timestamp
 
 
 SCHEMA_VERSION = "agent_scoped_evidence_log_v0"
 REQUIRED_READ_SCHEMA_VERSION = "loopx_agent_required_read_v0"
 
 _AK_SK_PATTERN = re.compile(r"(?i)\b(?:ak|sk|access[_-]?key|secret[_-]?key)\b\s*[:=]\s*\S+")
-
-
-def _parse_timestamp(value: Any) -> datetime | None:
-    if not value:
-        return None
-    try:
-        parsed = datetime.fromisoformat(str(value).strip().replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=timezone.utc)
-    return parsed
 
 
 def _compact_text(value: Any, *, limit: int = 220) -> str | None:
@@ -108,7 +98,7 @@ def _event_matches(
     if event_kinds and _normalize_event_kind(str(event.get("event_kind") or "")) not in event_kinds:
         return False
     if since is not None:
-        recorded_at = _parse_timestamp(event.get("recorded_at"))
+        recorded_at = parse_timestamp(event.get("recorded_at"))
         if recorded_at is None or recorded_at < since:
             return False
     return True
@@ -139,7 +129,7 @@ def _run_matches(
     if todo_id and not _run_mentions_todo(run, todo_id):
         return False
     if since is not None:
-        recorded_at = _parse_timestamp(run.get("generated_at"))
+        recorded_at = parse_timestamp(run.get("generated_at"))
         if recorded_at is None or recorded_at < since:
             return False
     return True
@@ -263,7 +253,7 @@ def build_agent_scoped_evidence_log(
     if not safe_agent_id:
         raise ValueError("agent_id is required")
     safe_todo_id = _compact_text(todo_id, limit=180) if todo_id else None
-    since_dt = _parse_timestamp(since)
+    since_dt = parse_timestamp(since)
     if since and since_dt is None:
         raise ValueError(f"invalid --since timestamp: {since}")
     normalized_kinds = {

--- a/loopx/control_plane/runtime/status_projection_cache.py
+++ b/loopx/control_plane/runtime/status_projection_cache.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from ...history import load_registry
 from ...paths import resolve_runtime_root
+from .time import parse_timestamp
 
 
 STATUS_PROJECTION_CACHE_SCHEMA_VERSION = "status_projection_cache_v0"
@@ -21,18 +22,6 @@ def now_utc() -> datetime:
 
 def now_utc_iso() -> str:
     return now_utc().isoformat().replace("+00:00", "Z")
-
-
-def _parse_timestamp(value: Any) -> datetime | None:
-    if not isinstance(value, str) or not value.strip():
-        return None
-    try:
-        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
 
 
 def resolve_status_projection_cache_runtime_root(
@@ -149,7 +138,7 @@ def load_status_projection_cache(
     if cache_record.get("schema_version") != STATUS_PROJECTION_CACHE_SCHEMA_VERSION:
         metadata["miss_reason"] = "schema_mismatch"
         return None, metadata
-    generated_at = _parse_timestamp(cache_record.get("generated_at"))
+    generated_at = parse_timestamp(cache_record.get("generated_at"))
     if generated_at is None:
         metadata["miss_reason"] = "missing_generated_at"
         return None, metadata

--- a/loopx/control_plane/runtime/time.py
+++ b/loopx/control_plane/runtime/time.py
@@ -7,10 +7,13 @@ from typing import Any
 def parse_timestamp(value: Any) -> datetime | None:
     if not value:
         return None
+    text = str(value).strip()
+    if not text:
+        return None
     try:
-        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
     except ValueError:
         return None
     if parsed.tzinfo is None:
         return parsed.replace(tzinfo=timezone.utc)
-    return parsed
+    return parsed.astimezone(timezone.utc)

--- a/loopx/control_plane/work_items/task_lease.py
+++ b/loopx/control_plane/work_items/task_lease.py
@@ -9,6 +9,7 @@ from typing import Any
 from ...file_lock import exclusive_file_lock
 from ...history import load_registry
 from ...paths import resolve_runtime_root
+from ..runtime.time import parse_timestamp
 from ..todos.contract import (
     normalize_required_write_scopes,
     normalize_todo_claimed_by,
@@ -35,21 +36,6 @@ def now_utc() -> datetime:
 
 def isoformat(value: datetime) -> str:
     return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
-
-
-def parse_timestamp(value: Any) -> datetime | None:
-    candidate = str(value or "").strip()
-    if not candidate:
-        return None
-    if candidate.endswith("Z"):
-        candidate = candidate[:-1] + "+00:00"
-    try:
-        parsed = datetime.fromisoformat(candidate)
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
 
 
 def normalize_idempotency_key(value: Any) -> str:


### PR DESCRIPTION
## Summary
- reuse `control_plane.runtime.time.parse_timestamp` across status projection cache, agent-scoped evidence log, agent management projection, and task leases
- strengthen `parse_timestamp` to strip surrounding whitespace and normalize aware timestamps to UTC
- extend the todo readmodel boundary smoke so these active read/runtime paths keep using the shared parser

## Validation
- duplicate parser scan now leaves only scheduler-local parsers plus `runtime.time`
- `python3 -m compileall -q` on changed Python files
- `python3 examples/control_plane/todo-readmodel-boundary-smoke.py`
- `python3 examples/control_plane/status-projection-cache-smoke.py`
- `python3 examples/control_plane/agent-scoped-evidence-log-smoke.py`
- `python3 examples/control_plane/agent-management-projection-contract-smoke.py`
- `python3 examples/control_plane/agent-management-live-status-smoke.py`
- `python3 examples/control_plane/task-lease-runtime-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `loopx check` on the six changed files passed with errors=0, warnings=0 and public boundary clean
- `loopx canary premerge --from-git-diff` passed with `self_merge_allowed=true`, surfaces `control_plane, public_boundary, python`, risk profiles `core-control-plane, canary-runner`, manual holds 0
