### PR TITLE
Refactor shared scheduler timestamp parsing

### DIFF
--- a/examples/control_plane/monitor-scheduler-contract-smoke.py
+++ b/examples/control_plane/monitor-scheduler-contract-smoke.py
@@ -10,6 +10,9 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.control_plane.testing.quota_fixtures import quota_status_payload  # noqa: E402
+from loopx.control_plane.scheduler import monitor_todo as monitor_todo_module  # noqa: E402
+from loopx.control_plane.scheduler import scheduler_hint as scheduler_hint_module  # noqa: E402
+from loopx.control_plane.scheduler import time as scheduler_time  # noqa: E402
 from loopx.quota import build_quota_should_run, render_quota_should_run_markdown  # noqa: E402
 
 
@@ -138,6 +141,16 @@ def guard_for(
         ),
         goal_id=GOAL_ID,
         agent_id=agent_id,
+    )
+
+
+def assert_scheduler_timestamp_parser_is_shared_and_utc_normalized() -> None:
+    assert monitor_todo_module.parse_monitor_timestamp is scheduler_time.parse_scheduler_timestamp
+    assert scheduler_hint_module._parse_monitor_timestamp("2026-01-01T08:00:00+08:00").isoformat() == (
+        "2026-01-01T00:00:00+00:00"
+    )
+    assert monitor_todo_module.parse_monitor_timestamp(" 2026-01-01T00:00:00Z ").isoformat() == (
+        "2026-01-01T00:00:00+00:00"
     )
 
 
@@ -486,6 +499,7 @@ def assert_other_agent_claimed_work_stays_diagnostic_when_no_current_lane() -> N
 
 
 def main() -> int:
+    assert_scheduler_timestamp_parser_is_shared_and_utc_normalized()
     assert_not_due_monitor_waits_quietly()
     assert_not_due_monitor_scheduler_honors_monitor_cadence()
     assert_unscheduled_monitor_requires_metadata_repair()

--- a/loopx/control_plane/scheduler/monitor_todo.py
+++ b/loopx/control_plane/scheduler/monitor_todo.py
@@ -11,6 +11,7 @@ from ..todos.contract import (
     normalize_todo_status,
     normalize_todo_task_class,
 )
+from .time import parse_scheduler_timestamp
 
 MONITOR_CADENCE_PATTERN = re.compile(
     r"^\s*(?P<count>[1-9][0-9]{0,4})\s*"
@@ -19,16 +20,7 @@ MONITOR_CADENCE_PATTERN = re.compile(
 )
 
 
-def parse_monitor_timestamp(value: Any) -> datetime | None:
-    if not value:
-        return None
-    try:
-        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=timezone.utc)
-    return parsed
+parse_monitor_timestamp = parse_scheduler_timestamp
 
 
 def parse_monitor_counter(value: Any) -> int:

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -15,6 +15,7 @@ from .state import (
     build_scheduler_state,
     rrule_for_minutes,
 )
+from .time import parse_scheduler_timestamp
 
 
 SCHEDULER_HINT_SCHEMA_VERSION = "scheduler_hint_v0"
@@ -187,16 +188,7 @@ def _int_number(value: Any, *, default: int) -> int:
 
 
 def _parse_monitor_timestamp(value: Any) -> datetime | None:
-    text = str(value or "").strip()
-    if not text:
-        return None
-    try:
-        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=timezone.utc)
-    return parsed
+    return parse_scheduler_timestamp(value)
 
 
 def _monitor_cadence_minutes(value: Any) -> int | None:

--- a/loopx/control_plane/scheduler/time.py
+++ b/loopx/control_plane/scheduler/time.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+
+def parse_scheduler_timestamp(value: Any) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)


### PR DESCRIPTION
## Summary
- add `control_plane.scheduler.time.parse_scheduler_timestamp` as the scheduler-owned timestamp parser
- route `scheduler_hint` monitor-wait caps and `monitor_todo` due/expiry checks through that shared helper
- extend `monitor-scheduler-contract-smoke` to assert the helper is shared and UTC-normalizes offset/`Z` timestamps

## Validation
- `python3 -m compileall -q loopx/control_plane/scheduler/time.py loopx/control_plane/scheduler/scheduler_hint.py loopx/control_plane/scheduler/monitor_todo.py examples/control_plane/monitor-scheduler-contract-smoke.py`
- `python3 examples/control_plane/monitor-scheduler-contract-smoke.py`
- `python3 examples/control_plane/quota-scheduler-hint-compaction-smoke.py`
- `python3 examples/control_plane/monitor-poll-writeback-smoke.py`
- `python3 examples/control_plane/heartbeat-quota-flow-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `python3 examples/canary/catalog-run-e2e-smoke.py`
- `git diff --cached --check`
- `loopx check --scan-path ...` (4 candidate paths, errors=0, warnings=0)
- `loopx canary premerge --from-git-diff` (`ok=true`)

## Boundary
Changed surfaces are scheduler timestamp parsing, monitor todo due/expiry routing, scheduler hint monitor-wait cadence caps, and focused monitor scheduler canary coverage. Private-boundary scan is clean; the only string scan hit was the existing public scheduler `reset_token` protocol field name, not a credential. No benchmark runner, scoring, raw logs, trajectories, verifier output, credentials, production action, or public evidence-policy changes.
