### PR TITLE
Supersede stale vision checkpoint gaps

### DIFF
--- a/docs/reference/protocols/goal-vision-replan-contract-v0.md
+++ b/docs/reference/protocols/goal-vision-replan-contract-v0.md
@@ -119,6 +119,9 @@ Valid checkpoint decisions are:
 history, quota filters it by current `agent_id`, and goal-frontier projection
 turns it into `acceptance_gaps[]`. If the current agent has no runnable
 advancement frontier, that gap can trigger `autonomous_replan_required`.
+For the same `agent_id`, a newer satisfied checkpoint with `patched`,
+`unchanged_with_reason`, or `retired_or_superseded` supersedes older
+`missing_required` checkpoints; `not_required` does not.
 
 Checkpoint and autonomous-replan ACK packets are protocol records, not semantic
 completion proof. A recent ACK may suppress duplicate monitor-only replan

--- a/examples/control_plane/quota-replan-decision-plane-smoke.py
+++ b/examples/control_plane/quota-replan-decision-plane-smoke.py
@@ -269,6 +269,34 @@ def missing_vision_checkpoint_run(*, agent_id: str = SIDE_AGENT) -> dict:
     }
 
 
+def satisfied_vision_checkpoint_run(*, decision: str, agent_id: str = SIDE_AGENT) -> dict:
+    checkpoint: dict = {
+        "schema_version": "vision_checkpoint_v0",
+        "agent_id": agent_id,
+        "required": True,
+        "satisfied": True,
+        "decision": decision,
+        "triggers": [
+            {
+                "kind": "material_delivery_outcome",
+                "delivery_outcome": "outcome_progress",
+            }
+        ],
+    }
+    if decision == "unchanged_with_reason":
+        checkpoint["unchanged_reason"] = "The current per-agent vision still applies."
+    if decision == "retired_or_superseded":
+        checkpoint["repair_delta_kinds"] = ["no_followup"]
+    return {
+        "classification": f"vision_checkpoint_{decision}",
+        "generated_at": "2026-07-04T00:10:00+00:00",
+        "agent_id": agent_id,
+        "progress_scope": "agent_lane",
+        "delivery_outcome": "outcome_progress",
+        "vision_checkpoint": checkpoint,
+    }
+
+
 def assert_replan_beats_monitor_quiet_skip() -> None:
     payload = status_payload([monitor_item()], replan_obligation=SIDE_AGENT_REPLAN_OBLIGATION)
     guard = build_quota_should_run(payload, goal_id=GOAL_ID, agent_id=SIDE_AGENT)
@@ -540,6 +568,30 @@ def assert_missing_vision_checkpoint_derives_agent_scoped_replan() -> None:
     assert primary_guard.get("autonomous_replan_obligation") is None, primary_guard
 
 
+def assert_satisfied_vision_checkpoint_supersedes_older_missing() -> None:
+    for decision in ("patched", "unchanged_with_reason", "retired_or_superseded"):
+        guard = build_quota_should_run(
+            status_payload(
+                [monitor_item()],
+                replan_obligation=None,
+                latest_runs=[
+                    satisfied_vision_checkpoint_run(decision=decision),
+                    missing_vision_checkpoint_run(),
+                ],
+            ),
+            goal_id=GOAL_ID,
+            agent_id=SIDE_AGENT,
+        )
+        assert guard["decision"] == "skip", guard
+        assert guard["effective_action"] == "monitor_quiet_skip", guard
+        assert guard["should_run"] is False, guard
+        assert guard["interaction_contract"]["mode"] == "monitor_quiet_skip", guard
+        assert guard["goal_frontier_projection"]["acceptance_gaps"] == [], guard
+        assert guard["goal_frontier_projection"]["replan_required"] is False, guard
+        assert guard.get("vision_continuation_audit") is None, guard
+        assert guard.get("autonomous_replan_obligation") is None, guard
+
+
 def assert_agent_scoped_replan_beats_agent_scope_wait() -> None:
     guard = build_quota_should_run(
         status_payload(
@@ -745,6 +797,7 @@ def main() -> None:
     assert_replan_preserves_current_agent_runnable_frontier()
     assert_agent_vision_gap_derives_replan()
     assert_missing_vision_checkpoint_derives_agent_scoped_replan()
+    assert_satisfied_vision_checkpoint_supersedes_older_missing()
     assert_agent_scoped_replan_beats_agent_scope_wait()
     assert_unscoped_replan_defaults_to_primary_agent()
     assert_monitor_schedule_gap_requires_bounded_repair()

--- a/loopx/control_plane/goals/goal_frontier.py
+++ b/loopx/control_plane/goals/goal_frontier.py
@@ -15,6 +15,11 @@ VISION_CHECKPOINT_MISSING_TRIGGER = "vision_checkpoint_missing"
 TODO_SUCCESSION_GAP_TRIGGER = "completed_advancement_without_successor"
 TODO_TASK_CLASS_ADVANCEMENT = "advancement_task"
 TODO_TASK_CLASS_MONITOR = "continuous_monitor"
+VISION_CHECKPOINT_SATISFIED_DECISIONS = {
+    "patched",
+    "retired_or_superseded",
+    "unchanged_with_reason",
+}
 FRONTIER_REPLAN_ACK_DELTA_KINDS = {
     "active_state_next_action",
     "blocker",
@@ -253,11 +258,17 @@ def latest_missing_vision_checkpoint_from_status_payload(
             continue
         if not agent_id and checkpoint_agent_id:
             continue
+        decision = str(checkpoint.get("decision") or "").strip()
+        if (
+            checkpoint.get("satisfied") is True
+            and decision in VISION_CHECKPOINT_SATISFIED_DECISIONS
+        ):
+            return None
         if checkpoint.get("required") is not True:
             continue
         if checkpoint.get("satisfied") is not False:
             continue
-        if str(checkpoint.get("decision") or "") != "missing_required":
+        if decision != "missing_required":
             continue
         return {
             "schema_version": checkpoint.get("schema_version"),


### PR DESCRIPTION
## Summary
- stop older same-agent `vision_checkpoint_missing` gaps from staying active after a newer satisfied checkpoint
- treat `patched`, `unchanged_with_reason`, and `retired_or_superseded` as superseding decisions, while leaving `not_required` non-authoritative
- extend the quota replan decision-plane smoke and protocol text for the checkpoint supersession invariant

## Why
`quota should-run --agent-id codex-value-explorer` could keep projecting an older `vision_checkpoint_missing` as active even after the same agent wrote a newer satisfied vision checkpoint. That incorrectly woke a monitor-only side-agent into `autonomous_replan_required`.

## Validation
- `python3 examples/control_plane/quota-replan-decision-plane-smoke.py`
- `python3 examples/project/goal-vision-replan-contract-smoke.py`
- `loopx check --scan-path docs/reference/protocols/goal-vision-replan-contract-v0.md`
- source-run real guard: `PYTHONPATH="$PWD" python3 -m loopx.cli --format json --registry "$HOME/.codex/loopx/registry.global.json" --runtime-root "$HOME/.codex/loopx" quota should-run --goal-id loopx-meta --agent-id codex-value-explorer` now returns `effective_action=monitor_quiet_skip`, `acceptance_gaps=[]`, `replan_required=false`
- `loopx canary premerge --from-git-diff` passed: direct checks, 8 catalog canaries, 8 risk-profile smokes, public boundary check; `self_merge_allowed=true`, `manual_holds=0`