### PR TITLE
Refactor shared root timestamp parsing

### DIFF
--- a/examples/control_plane/todo-readmodel-boundary-smoke.py
+++ b/examples/control_plane/todo-readmodel-boundary-smoke.py
@@ -13,6 +13,9 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from loopx import status as status_module  # noqa: E402
+from loopx import boundary_authority as boundary_authority_module  # noqa: E402
+from loopx import interface_budget as interface_budget_module  # noqa: E402
+from loopx import quota as quota_module  # noqa: E402
 from loopx.control_plane.goals import active_state_metadata as active_state_metadata_read_model  # noqa: E402
 from loopx.control_plane.goals import global_registry_health as global_registry_health_read_model  # noqa: E402
 from loopx.control_plane.work_items import attention_item as attention_item_read_model  # noqa: E402
@@ -115,6 +118,9 @@ def assert_direct_status_aliases() -> None:
     assert evidence_log_read_model.parse_timestamp is runtime_time_read_model.parse_timestamp
     assert management_projection_read_model.parse_timestamp is runtime_time_read_model.parse_timestamp
     assert task_lease_read_model.parse_timestamp is runtime_time_read_model.parse_timestamp
+    assert quota_module._parse_timestamp is runtime_time_read_model.parse_timestamp
+    assert boundary_authority_module._parse_timestamp is runtime_time_read_model.parse_timestamp
+    assert interface_budget_module.parse_timestamp is runtime_time_read_model.parse_timestamp
     assert status_module.quota_spend_slots is usage_summary_read_model.quota_spend_slots
     assert status_module.is_automation_run is usage_summary_read_model.is_automation_run
     assert status_module.is_progress_signal_run is usage_summary_read_model.is_progress_signal_run

--- a/loopx/boundary_authority.py
+++ b/loopx/boundary_authority.py
@@ -4,6 +4,7 @@ import re
 from datetime import datetime, timezone
 from typing import Any
 
+from .control_plane.runtime.time import parse_timestamp as _parse_timestamp
 from .control_plane.todos.contract import normalize_required_write_scopes
 
 
@@ -26,19 +27,6 @@ PRIVATE_TEXT_PATTERNS = (
 
 def _now() -> datetime:
     return datetime.now(timezone.utc).astimezone()
-
-
-def _parse_timestamp(value: Any) -> datetime | None:
-    text = str(value or "").strip()
-    if not text:
-        return None
-    try:
-        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=timezone.utc)
-    return parsed
 
 
 def _validate_public_safe_text(label: str, value: str | None) -> None:

--- a/loopx/interface_budget.py
+++ b/loopx/interface_budget.py
@@ -3,30 +3,11 @@ from __future__ import annotations
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+from .control_plane.runtime.time import parse_timestamp
+
 
 DEFAULT_INTERFACE_BUDGET_FRESHNESS_HOURS = 24
 INTERFACE_BUDGET_CADENCE_SOURCE = "interface_budget_drift_check"
-
-
-def parse_timestamp(value: Any) -> datetime | None:
-    if not value:
-        return None
-    if isinstance(value, datetime):
-        if value.tzinfo is None:
-            return value.replace(tzinfo=timezone.utc)
-        return value.astimezone(timezone.utc)
-    text = str(value).strip()
-    if not text:
-        return None
-    if text.endswith("Z"):
-        text = text[:-1] + "+00:00"
-    try:
-        parsed = datetime.fromisoformat(text)
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
 
 
 def _number(value: Any) -> float | None:

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -109,6 +109,7 @@ from .control_plane.quota.states import QUOTA_STATE_ORDER
 from .control_plane.runtime.decision_freshness import (
     decision_freshness_warning as _decision_freshness_warning,
 )
+from .control_plane.runtime.time import parse_timestamp as _parse_timestamp
 from .control_plane.runtime.agent_scoped_evidence_log import (
     build_agent_scoped_required_read,
 )
@@ -219,18 +220,6 @@ STALL_HEALTH_ITEM_COMPACT_FIELDS = (
     "recommended_action",
 )
 MONITOR_DUE_ITEM_LIMIT = 1
-
-def _parse_timestamp(value: Any) -> datetime | None:
-    if not value:
-        return None
-    try:
-        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        return parsed.replace(tzinfo=timezone.utc)
-    return parsed
-
 
 def _validate_goal_id_path_segment(goal_id: str) -> str:
     value = goal_id.strip()


### PR DESCRIPTION
## Summary
- route root hot-path timestamp parsing through `control_plane.runtime.time.parse_timestamp`
- remove duplicate parsers from `quota.py`, `boundary_authority.py`, and `interface_budget.py`
- extend `todo-readmodel-boundary-smoke` so quota, boundary authority, and interface budget stay bound to the runtime parser

## Validation
- `python3 -m compileall -q loopx/quota.py loopx/boundary_authority.py loopx/interface_budget.py examples/control_plane/todo-readmodel-boundary-smoke.py`
- `python3 examples/control_plane/todo-readmodel-boundary-smoke.py`
- `python3 examples/control_plane/hot-path-interface-budget-smoke.py`
- `python3 examples/control_plane/quota-action-scope-guard-smoke.py`
- `python3 examples/control_plane/quota-contract-smoke.py`
- `python3 examples/control_plane/quota-plan-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 examples/control_plane/status-quota-perf-budget-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `python3 examples/canary/catalog-run-e2e-smoke.py`
- `git diff --cached --check`
- `loopx check --scan-path ...` on all 4 candidate paths: errors=0, warnings=0
- `loopx canary premerge --from-git-diff`: ok=true

## Boundary
Changed surfaces are quota spend ledger timestamp parsing, checkpointed boundary authority freshness, interface budget cadence freshness, and the readmodel boundary smoke assertion. This intentionally leaves `pr_review`, benchmark adapters, connector-local, and diagnostic-only parsers in their own bounded contexts for later characterization. Private-boundary scan is clean; the only string scan hit was the existing public `reset_token` protocol field name, not a credential. No benchmark runner/scoring jobs, raw logs, trajectories, verifier output, credentials, production actions, or public evidence-policy changes.
