### PR TITLE
Fix stale TUI timeout blocker detection

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -529,6 +529,7 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
         POST_BRIDGE_CLOSEOUT_ATTEMPT_LIMIT,
         POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT,
         PRE_BRIDGE_RECOVERY_ATTEMPT_LIMIT,
+        TUI_BLOCKER_RECENT_LINE_WINDOW,
         codex_cli_tui_post_bridge_blocker_stage,
         codex_cli_tui_post_bridge_closeout_recovery_action,
         codex_cli_tui_post_bridge_recovery_action,
@@ -545,6 +546,7 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
     assert POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT == 6
     assert POST_BRIDGE_CLOSEOUT_ATTEMPT_LIMIT == 8
     assert PRE_BRIDGE_RECOVERY_ATTEMPT_LIMIT == 2
+    assert TUI_BLOCKER_RECENT_LINE_WINDOW == 40
     assert "Close out the active SkillsBench goal" in (
         CODEX_CLI_GOAL_POST_BRIDGE_CLOSEOUT_PROMPT
     )
@@ -590,6 +592,38 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
             prompt_visible=True,
         )
         == "post_bridge_tui_model_timeout"
+    )
+    stale_timeout_scrollback = "\n".join(
+        [
+            "request timed out while waiting for model",
+            *[f"historical tui line {index}" for index in range(50)],
+            "Goal active",
+            "Pursuing goal",
+            "› ",
+        ]
+    )
+    assert (
+        codex_cli_tui_post_bridge_blocker_stage(
+            stale_timeout_scrollback,
+            prompt_visible=True,
+        )
+        == ""
+    )
+    stale_rate_limit_scrollback = "\n".join(
+        [
+            "rate limit reached; press enter to retry",
+            *[f"historical tui line {index}" for index in range(50)],
+            "Goal active",
+            "Pursuing goal",
+            "› ",
+        ]
+    )
+    assert (
+        codex_cli_tui_post_bridge_blocker_stage(
+            stale_rate_limit_scrollback,
+            prompt_visible=True,
+        )
+        == ""
     )
     assert (
         codex_cli_tui_post_bridge_recovery_action(

--- a/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
+++ b/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
@@ -18,10 +18,18 @@ CODEX_CLI_GOAL_POST_BRIDGE_CLOSEOUT_PROMPT = (
 )
 POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT = 6
 POST_BRIDGE_CLOSEOUT_ATTEMPT_LIMIT = 8
+TUI_BLOCKER_RECENT_LINE_WINDOW = 40
+
+
+def _recent_capture_region(capture: str) -> str:
+    lines = str(capture or "").splitlines()
+    if len(lines) <= TUI_BLOCKER_RECENT_LINE_WINDOW:
+        return "\n".join(lines)
+    return "\n".join(lines[-TUI_BLOCKER_RECENT_LINE_WINDOW:])
 
 
 def _capture_has_rate_limit(capture: str) -> bool:
-    lowered = str(capture or "").lower()
+    lowered = _recent_capture_region(capture).lower()
     return any(
         marker in lowered
         for marker in (
@@ -35,14 +43,14 @@ def _capture_has_rate_limit(capture: str) -> bool:
 
 
 def _capture_has_model_timeout(capture: str) -> bool:
-    lowered = str(capture or "").lower()
+    lowered = _recent_capture_region(capture).lower()
     return any(marker in lowered for marker in ("timed out", "timeout")) and any(
         marker in lowered for marker in ("model", "request", "error", "failed")
     )
 
 
 def _capture_has_retry_affordance(capture: str) -> bool:
-    lowered = str(capture or "").lower()
+    lowered = _recent_capture_region(capture).lower()
     return any(marker in lowered for marker in ("press enter", "press return"))
 
 
@@ -59,7 +67,7 @@ def codex_cli_tui_pre_bridge_blocker_stage(
         return "pre_bridge_tui_rate_limit"
     if _capture_has_model_timeout(capture):
         return "pre_bridge_tui_model_timeout"
-    lowered = str(capture or "").lower()
+    lowered = _recent_capture_region(capture).lower()
     if _capture_has_retry_affordance(capture) and any(
         marker in lowered
         for marker in ("error", "failed", "timed out", "timeout", "model")
@@ -122,7 +130,7 @@ def codex_cli_tui_post_bridge_blocker_stage(
         return "post_bridge_tui_rate_limit"
     if _capture_has_model_timeout(capture):
         return "post_bridge_tui_model_timeout"
-    lowered = str(capture or "").lower()
+    lowered = _recent_capture_region(capture).lower()
     if _capture_has_retry_affordance(capture) and any(
         marker in lowered
         for marker in ("error", "failed", "timed out", "timeout", "model")


### PR DESCRIPTION
## Summary

- Limit Codex CLI goal TUI blocker classification to the recent/current TUI region instead of scanning the full captured scrollback.
- Keep real current request/model timeout and rate-limit detection intact.
- Add regression coverage that stale historical timeout/rate-limit text above the current prompt no longer triggers post-bridge recovery.

## Surfaces

- `loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py`
- `examples/skillsbench-codex-cli-goal-route-smoke.py`

## Validation

- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 -m py_compile loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py loopx/benchmark_adapters/skillsbench_acp_relay.py loopx/codex_cli_goal_tui.py examples/skillsbench-codex-cli-goal-route-smoke.py`
- `git diff --check`
- `loopx canary premerge --from-git-diff`
  - direct checks passed
  - 6/6 selected catalog canaries passed
  - public boundary smoke passed
  - manual hold: `benchmark_sensitive`

## Manual Hold

`loopx canary premerge --from-git-diff` reports the standard benchmark-sensitive manual hold. This PR is a narrow benchmark helper/runtime classifier fix with focused smoke coverage. It does not change benchmark scoring, task semantics, leaderboard/submission behavior, permissions, or launch benchmark jobs. Owner has authorized benchmark-related self-merge for this lane.
