### PR TITLE
release: prepare v0.1.11

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -122,6 +122,15 @@ path, and canary route rather than as a user-facing release baseline.
   status projections, and continues moving quota, todo, scheduler, review
   packet, and handoff rules into bounded control-plane contexts with focused
   canary coverage.
+- `v0.1.11` on 2026-07-06 19:38 +08:00: vision-replan and recovery-routing
+  release at the matching `v0.1.11` tag. This release makes goal-vision gaps
+  participate in the quota/replan decision plane, preserves continuation audits
+  in quota and interaction contracts, supersedes stale vision checkpoint gaps
+  when newer evidence closes them, and adds judge guidance for when a vision
+  gap is real work versus stale state. It also promotes the latest control-plane
+  bounded-context cleanup, auto-research successor/evidence fixes, connector
+  source-map packets, structured run-index classification, and Codex CLI/TUI
+  recovery fixes.
 
 When a new public release is promoted, add it here only after the matching tag,
 release note, stable ref, update path, and focused release canary agree.

--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.10"
+__version__ = "0.1.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.1.10"
+version = "0.1.11"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Prepare LoopX v0.1.11 as the vision-replan and recovery-routing stable release.

This release bump highlights the recent goal-vision replan iteration: goal-vision gaps now participate in quota/replan routing, continuation audits are visible in quota and interaction contracts, stale checkpoint gaps can be superseded by newer closure evidence, and judge guidance distinguishes real vision work from stale state.

It also summarizes the other changes promoted since v0.1.10: control-plane bounded-context cleanup, auto-research successor/evidence fixes, connector source-map packets, structured run-index classification, and Codex CLI/TUI recovery fixes.

## Changed files

- `loopx/__init__.py`: bump package version to `0.1.11`
- `pyproject.toml`: mirror package version as `0.1.11`
- `docs/product/release-readiness.md`: add v0.1.11 release timeline entry

## Validation

- `python3 -m py_compile loopx/*.py`
- `python3 examples/release/release-version-contract-smoke.py`
- `python3 examples/release/release-readiness-doc-smoke.py`
- `python3 examples/release/codex-cli-no-clone-release-verification-smoke.py`
- `python3 examples/fresh-clone-quickstart-smoke.py`
- `python3 examples/loopx-update-smoke.py`
- `git diff --check`
- `python3 -m loopx.cli check --scan-path README.md --scan-path docs/ --scan-path examples/`
- `python3 examples/canary/canary-promotion-readiness-smoke.py --no-write-evidence`
- `loopx canary premerge --from-git-diff`

Dashboard demo-readiness followed the supported source-checkout skip path because local dashboard npm dependencies were unavailable.
