### PR TITLE
Fix CLI goal pre-bridge terminal recovery

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -557,6 +557,21 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
         )
         == "pre_bridge_tui_model_timeout"
     )
+    first_turn_terminal_timeout_capture = "\n".join(
+        [
+            "Goal active",
+            "request timed out while waiting for model",
+            "Goal failed",
+            "› ",
+        ]
+    )
+    assert (
+        codex_cli_tui_pre_bridge_blocker_stage(
+            first_turn_terminal_timeout_capture,
+            prompt_visible=True,
+        )
+        == "pre_bridge_tui_model_timeout"
+    )
     assert (
         codex_cli_tui_pre_bridge_recovery_action(
             "request timed out while waiting for model\npress enter to retry\n› ",
@@ -925,8 +940,8 @@ def _assert_cli_goal_active_timeout_is_public_countability_stage() -> None:
         relay._publish_codex_cli_goal_trace(
             ok=False,
             stage="pre_bridge_tui_model_timeout",
-            goal_active_observed=False,
-            goal_terminal_observed=False,
+            goal_active_observed=True,
+            goal_terminal_observed=True,
             first_action_observed=False,
             bridge_summary_path=None,
             post_bridge_recovery_attempt_count=2,

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -1334,12 +1334,9 @@ class SkillsBenchLocalAcpRelay:
                     capture = tmux_capture(tmux_name)
                     if "Goal active" in capture or "Pursuing goal" in capture:
                         goal_active_observed = True
+                    goal_failed_now = "Goal failed" in capture or "Goal blocked" in capture
                     if "Goal achieved" in capture:
                         goal_terminal_observed = True
-                        break
-                    if "Goal failed" in capture or "Goal blocked" in capture:
-                        goal_terminal_observed = True
-                        goal_failed_observed = True
                         break
                     retryable_startup_blocker_stage = ""
                     if not goal_active_observed and not first_action_seen:
@@ -1371,7 +1368,6 @@ class SkillsBenchLocalAcpRelay:
                     pre_bridge_blocker_stage = ""
                     if (
                         bridge_summary_path is not None
-                        and not goal_active_observed
                         and not first_action_seen
                     ):
                         pre_bridge_blocker_stage = (
@@ -1465,6 +1461,10 @@ class SkillsBenchLocalAcpRelay:
                         return _recoverable_codex_turn_failure_message(
                             "codex_cli_goal_" + pre_bridge_blocker_stage
                         )
+                    if goal_failed_now:
+                        goal_terminal_observed = True
+                        goal_failed_observed = True
+                        break
                     if (
                         not goal_active_observed
                         and not first_action_seen


### PR DESCRIPTION
## Summary
- let codex-cli-goal TUI classify pre-bridge timeout/error prompts even after the goal becomes active but before the first bridge action
- defer generic Goal failed handling until after the pre-bridge recovery classifier can run
- add a public-safe regression smoke for Goal active -> model timeout -> Goal failed before first action

## Validation
- python3 examples/skillsbench-codex-cli-goal-route-smoke.py
- python3 examples/skillsbench-cli-goal-first-action-timeout-smoke.py
- python3 -m py_compile loopx/benchmark_adapters/skillsbench_acp_relay.py loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py scripts/skillsbench_automation_loop.py examples/skillsbench-codex-cli-goal-route-smoke.py examples/skillsbench-cli-goal-first-action-timeout-smoke.py
- git diff --check
- python3 examples/control_plane/repo-python-line-budget-smoke.py
- loopx canary premerge --from-git-diff

## Premerge note
# Pre-Merge Validation Gate

- status: `manual_review_required`
- ok: `false`
- merge_gate_passed: `false`
- self_merge_allowed: `false`
- tier: `standard`
- dry_run: `false`
- changed_files: `2`
- surfaces: `public_boundary, benchmark_sensitive, python`
- risk_profiles: ``
- manual_holds: `1`

Pre-merge validation is a risk-based gate: it runs diff hygiene, changed Python compile checks, catalog-selected canaries, risk-profile smokes, and public/private boundary checks. It reports manual holds for benchmark-sensitive or reviewer-gated surfaces instead of treating local smoke success as self-merge permission.

## Direct Checks
- `diff_check_committed`: `passed` `git diff --check origin/main...HEAD`
- `diff_check_staged`: `passed` `git diff --cached --check`
- `diff_check_unstaged`: `passed` `git diff --check`
- `changed_python_py_compile`: `passed` `python3 -m py_compile examples/skillsbench-codex-cli-goal-route-smoke.py loopx/benchmark_adapters/skillsbench_acp_relay.py`

## Catalog Canaries
- ok: `true`
- selected_checks: `6`
- executed_checks: `6`
- failures: `0`
- advisory_failures: `0`
- warnings: `0`
- `passed` python3 examples/control_plane/repo-python-line-budget-smoke.py
- `passed` python3 examples/terminal-bench-adapter-readiness-characterization-smoke.py
- `passed` python3 examples/benchmark-core-adapter-contract-smoke.py
- `passed` python3 examples/benchmark-artifact-path-filter-smoke.py
- `passed` python3 examples/benchmark-run-ledger-smoke.py
- `passed` python3 examples/benchmark-case-analysis-smoke.py

## Public Boundary
- ok: `true`
- selected_checks: `1`
- executed_checks: `1`
- failures: `0`
- advisory_failures: `0`
- warnings: `0`
- `passed` python3 examples/control_plane/check-public-boundary-smoke.py

## Manual Holds
- `benchmark_sensitive`: benchmark adapter, scoring, runner, or evidence paths require explicit maintainer review before self-merge passed all direct checks, catalog canaries, and public boundary checks. It still reports the standard benchmark_sensitive manual hold for benchmark adapter paths; owner has explicitly authorized benchmark-related self-merge for this workstream. No raw task text, trajectories, verifier tails, credentials, local private paths, or raw benchmark logs are included.