### PR TITLE
Add CLI goal terminal observability flags

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -537,6 +537,7 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
         codex_cli_tui_pre_bridge_blocker_stage,
         codex_cli_tui_pre_bridge_recovery_action,
         codex_cli_tui_pre_bridge_recovery_skip_reason,
+        codex_cli_tui_pre_bridge_terminal_skip_reason,
     )
     from scripts.skillsbench_automation_loop import (
         _merge_host_local_acp_relay_trace_summary,
@@ -571,6 +572,13 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
             prompt_visible=True,
         )
         == "pre_bridge_tui_model_timeout"
+    )
+    assert (
+        codex_cli_tui_pre_bridge_terminal_skip_reason(
+            "Goal active\nGoal failed\n› ",
+            prompt_visible=True,
+        )
+        == "pre_bridge_terminal:p=1,timeout=0,rate=0,retry=0,error=1"
     )
     assert (
         codex_cli_tui_pre_bridge_recovery_action(

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -43,6 +43,7 @@ from loopx.benchmark_adapters.skillsbench_codex_goal_recovery import (
     codex_cli_tui_pre_bridge_blocker_stage,
     codex_cli_tui_pre_bridge_recovery_action,
     codex_cli_tui_pre_bridge_recovery_skip_reason,
+    codex_cli_tui_pre_bridge_terminal_skip_reason,
 )
 from loopx.codex_cli_goal_tui import (
     CODEX_CLI_GOAL_TASK_PROMPT_FILENAME,
@@ -60,7 +61,6 @@ from loopx.codex_cli_goal_tui import (
     tmux_type_text_and_submit,
     wait_for_codex_cli_tui_ready,
 )
-
 
 SAFE_LOOPX_TODO_ID_RE = re.compile(r"^todo_[A-Za-z0-9_-]{6,80}$")
 SAFE_LOOPX_GOAL_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,120}$")
@@ -118,7 +118,6 @@ def _temporary_directory_ignore_cleanup_errors(*, prefix: str):
         yield path
     finally:
         shutil.rmtree(path, ignore_errors=True)
-
 
 def _prompt_requires_bridge_first_action(prompt: str) -> bool:
     text = prompt or ""
@@ -1462,6 +1461,8 @@ class SkillsBenchLocalAcpRelay:
                             "codex_cli_goal_" + pre_bridge_blocker_stage
                         )
                     if goal_failed_now:
+                        if bridge_summary_path is not None and not first_action_seen:
+                            pre_bridge_recovery_skip_reason = codex_cli_tui_pre_bridge_terminal_skip_reason(capture, prompt_visible=codex_cli_tui_input_prompt_visible(capture))
                         goal_terminal_observed = True
                         goal_failed_observed = True
                         break

--- a/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
+++ b/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
@@ -117,6 +117,27 @@ def codex_cli_tui_pre_bridge_recovery_skip_reason(
     return "unsupported_recovery_action"
 
 
+def codex_cli_tui_pre_bridge_terminal_skip_reason(
+    capture: str,
+    *,
+    prompt_visible: bool,
+) -> str:
+    """Return public-safe flags for a terminal goal before bridge activity."""
+
+    lowered = _recent_capture_region(capture).lower()
+    has_error_marker = any(
+        marker in lowered
+        for marker in ("error", "failed", "timed out", "timeout", "model")
+    )
+    return (
+        f"pre_bridge_terminal:p={int(bool(prompt_visible))},"
+        f"timeout={int(_capture_has_model_timeout(capture))},"
+        f"rate={int(_capture_has_rate_limit(capture))},"
+        f"retry={int(_capture_has_retry_affordance(capture))},"
+        f"error={int(has_error_marker)}"
+    )
+
+
 def codex_cli_tui_post_bridge_blocker_stage(
     capture: str,
     *,


### PR DESCRIPTION
## Summary
- add a public-safe pre-bridge terminal classifier for Codex CLI goal failures before the first bridge action
- record compact boolean flags in the existing recovery skip reason field when `Goal failed` happens before bridge activity
- cover the flag string in the existing codex-cli-goal route smoke

## Why
Post-PR1548 official remote canary still showed `goal_failed` with `first_action=false` and zero bridge requests. The current public trace cannot distinguish model timeout/error prompt from a pure goal executor failure without raw TUI. This adds that distinction without recording raw TUI/task/log material.

## Validation
- python3 examples/skillsbench-codex-cli-goal-route-smoke.py
- python3 examples/skillsbench-cli-goal-first-action-timeout-smoke.py
- python3 -m py_compile loopx/benchmark_adapters/skillsbench_acp_relay.py loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py scripts/skillsbench_automation_loop.py examples/skillsbench-codex-cli-goal-route-smoke.py examples/skillsbench-cli-goal-first-action-timeout-smoke.py
- python3 examples/control_plane/repo-python-line-budget-smoke.py
- git diff --check
- loopx canary premerge --from-git-diff

## Premerge note
`loopx canary premerge --from-git-diff` passed direct checks, catalog canaries, and public boundary checks. It reports the standard benchmark_sensitive manual hold; owner has authorized benchmark-related self-merge for this workstream. No raw task text, trajectories, verifier tails, credentials, local private paths, or raw benchmark logs are included.
