### PR TITLE
Remove generic auto-research handoff auto-close

### DIFF
--- a/examples/auto-research-worker-turn-smoke.py
+++ b/examples/auto-research-worker-turn-smoke.py
@@ -335,6 +335,48 @@ def main() -> int:
         for successor_id in successor_ids:
             assert successor_id in state_text, state_text
         assert_public_safe(evaluator_summary)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        project = temp / "project"
+        project.mkdir()
+        state_file = project / "ACTIVE_GOAL_STATE.md"
+        registry = temp / "registry.json"
+        runtime_root = temp / "runtime"
+        write_summary_state(state_file)
+        write_registry(registry, project=project, state_file=state_file, runtime_root=runtime_root)
+        generic_todo = add_goal_todo(
+            registry_path=registry,
+            goal_id=GOAL_ID,
+            role="agent",
+            text=(
+                "[P1] Fix auto-research completion projection after validated "
+                "promotion and holdout evidence."
+            ),
+            task_class="advancement_task",
+            claimed_by=EVALUATOR_AGENT_ID,
+            dry_run=False,
+        )
+        generic_todo_id = generic_todo["todo_id"]
+        append_real_fixture_evidence(registry=registry, runtime_root=runtime_root, temp=temp)
+        workspace = project / "visible-workspace"
+        workspace.mkdir()
+
+        generic_turn = run_worker_turn(
+            registry=registry,
+            runtime_root=runtime_root,
+            workspace=workspace,
+            agent_id=EVALUATOR_AGENT_ID,
+            execute=True,
+            complete=True,
+        )
+        assert generic_turn["mode"] == "unsupported_action", generic_turn
+        assert generic_turn["selected_action"] == "advance_todo", generic_turn
+        assert generic_turn["executed"] is False, generic_turn
+        state_text = state_file.read_text(encoding="utf-8")
+        assert f"todo_id={generic_todo_id} status=done" not in state_text, state_text
+        assert "satisfied_generic_handoff_closed" not in json.dumps(generic_turn), generic_turn
+        assert_public_safe(generic_turn)
     return 0
 
 

--- a/loopx/capabilities/auto_research/worker_runtime.py
+++ b/loopx/capabilities/auto_research/worker_runtime.py
@@ -49,17 +49,6 @@ SUPPORTED_WORKER_ACTIONS = {
     "write_evaluation_summary",
     "review_promotion_readiness",
 }
-GENERIC_VERIFIER_HANDOFF_KEYWORDS = (
-    "verify",
-    "verifier",
-    "validate",
-    "validation",
-    "evidence",
-    "holdout",
-    "promotion",
-    "promote",
-)
-
 AppendEvidence = Callable[[str], dict[str, object]]
 AUTO_RESEARCH_STATE_SUMMARY_MODE = "rollout_evidence_summary"
 AUTO_RESEARCH_MANUAL_RESEARCH_REQUIRED_MODE = "manual_research_required"
@@ -309,90 +298,6 @@ def _executed_successor_todo_ids(successor_todos: dict[str, object]) -> list[str
     return todo_ids
 
 
-def _generic_handoff_is_satisfied(
-    *,
-    selected: dict[str, object],
-    evidence_graph: dict[str, object],
-    decisions: dict[str, list[dict[str, object]]],
-) -> bool:
-    if not decisions.get("validated_promotion_candidates"):
-        return False
-    if not evidence_graph.get("holdout_improved"):
-        return False
-    selected_text = " ".join(
-        str(selected.get(key) or "")
-        for key in ("title", "mechanism_family", "source_kind", "todo_id")
-    ).lower()
-    return any(keyword in selected_text for keyword in GENERIC_VERIFIER_HANDOFF_KEYWORDS)
-
-
-def _maybe_close_satisfied_generic_handoff(
-    *,
-    registry_path: Path,
-    runtime_root_arg: str | None,
-    goal_id: str,
-    todo_id: str,
-    agent_id: str,
-    selected: dict[str, object],
-    action: str,
-    execute: bool,
-    complete_selected_todo: bool,
-    frontier_packet: dict[str, object],
-) -> dict[str, object] | None:
-    if action != "advance_todo":
-        return None
-    registry = load_registry(registry_path)
-    runtime_root = resolve_runtime_root(registry, runtime_root_arg)
-    graph = build_research_evidence_graph_from_rollout_events(
-        goal_id=goal_id,
-        rollout_events=load_rollout_events(rollout_event_log_path(runtime_root, goal_id)),
-    )
-    decisions = build_research_decision_candidates(graph)
-    if not _generic_handoff_is_satisfied(
-        selected=selected,
-        evidence_graph=graph,
-        decisions=decisions,
-    ):
-        return None
-
-    completion = (
-        _complete_selected_todo(
-            registry_path=registry_path,
-            goal_id=goal_id,
-            todo_id=todo_id,
-            agent_id=agent_id,
-            action="satisfied_generic_handoff",
-            execute=True,
-        )
-        if execute and complete_selected_todo
-        else {"requested": complete_selected_todo, "executed": False}
-    )
-    return {
-        "ok": True,
-        "schema_version": AUTO_RESEARCH_WORKER_TURN_SCHEMA_VERSION,
-        "mode": "execute" if execute else "dry_run",
-        "goal_id": goal_id,
-        "agent_id": agent_id,
-        "selected_todo_id": todo_id,
-        "selected_action": action,
-        "executed": bool(execute and complete_selected_todo),
-        "artifact_status": "satisfied_generic_handoff_closed",
-        "decision_summary": {
-            "validated_promotion_candidate_count": len(decisions.get("validated_promotion_candidates") or []),
-            "holdout_improved": bool(graph.get("holdout_improved")),
-        },
-        "completion": completion,
-        "frontier": frontier_packet,
-        "public_boundary": {
-            "source": "rollout_event_log_and_todo_projection",
-            "raw_logs_recorded": False,
-            "private_artifacts_recorded": False,
-            "absolute_paths_recorded": False,
-            "credentials_recorded": False,
-        },
-    }
-
-
 def _complete_selected_todo(
     *,
     registry_path: Path,
@@ -541,20 +446,6 @@ def run_auto_research_worker_turn(
             "executed": False,
             "frontier": frontier_packet,
         }
-    cleanup = _maybe_close_satisfied_generic_handoff(
-        registry_path=registry_path,
-        runtime_root_arg=runtime_root_arg,
-        goal_id=goal_id,
-        todo_id=todo_id,
-        agent_id=agent_id,
-        selected=selected,
-        action=action,
-        execute=execute,
-        complete_selected_todo=complete_selected_todo,
-        frontier_packet=frontier_packet,
-    )
-    if cleanup is not None:
-        return cleanup
     if action not in SUPPORTED_WORKER_ACTIONS:
         return {
             "ok": True,


### PR DESCRIPTION
## Summary
- remove the broad auto-research worker shortcut that closed any generic advance_todo when validated promotion evidence existed
- keep explicit auto-research summary actions on the real evidence/successor path
- add a regression where promotion/holdout wording plus real evidence must not auto-complete a generic advancement todo

## Changed surfaces
- loopx/capabilities/auto_research/worker_runtime.py
- examples/auto-research-worker-turn-smoke.py

## Validation
- python3 examples/auto-research-worker-turn-smoke.py
- python3 examples/auto-research-rollout-readpath-smoke.py
- python3 examples/control_plane/quota-replan-decision-plane-smoke.py
- python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- python3 examples/auto-research-worker-loop-smoke.py
- loopx canary premerge --from-git-diff

## Self-merge rationale
Small public-safe cleanup: net code reduction, no benchmark scoring or production action changes, focused runtime behavior and durable smoke coverage. Premerge gate passed with self_merge_allowed=true and public/private boundary checks clean.