### PR TITLE
Refactor project asset active-state projection

### DIFF
--- a/examples/control_plane/project-asset-active-state-fields-smoke.py
+++ b/examples/control_plane/project-asset-active-state-fields-smoke.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Smoke-test active-state field projection into project_asset."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.work_items.project_asset import (  # noqa: E402
+    attach_active_state_project_asset_fields,
+)
+
+
+def main() -> int:
+    item = {
+        "project_asset": {"goal_id": "fixture-goal"},
+        "active_state_next_action": "[P1] Keep active-state projection stable.",
+        "latest_run_recommended_action": "[P1] Old run recommendation.",
+        "issue_meta_surface": {"issue_count": 1},
+        "backlog_hygiene_warning": {"requires_agent_todo": True},
+        "state_projection_gap": {"requires_todo_expansion": True},
+        "completed_todo_archive_warning": {"requires_archive": True},
+        "agent_todos": {"open_count": 1},
+    }
+
+    def warning_builder(**kwargs):
+        assert kwargs["active_state_next_action"] == item["active_state_next_action"]
+        assert kwargs["latest_run_recommended_action"] == item["latest_run_recommended_action"]
+        return {"kind": "next_action_projection_gap"}
+
+    def replan_from_runs(runs, *, agent_todos):
+        assert runs == [{"classification": "stalled_turn"}]
+        assert agent_todos == item["agent_todos"]
+        return {"required": True, "trigger_count": 1}
+
+    attached = attach_active_state_project_asset_fields(
+        item,
+        latest_runs=[{"classification": "stalled_turn"}],
+        next_action_projection_warning=warning_builder,
+        autonomous_replan_obligation_from_runs=replan_from_runs,
+    )
+    project_asset = item["project_asset"]
+    for key in (
+        "active_state_next_action",
+        "issue_meta_surface",
+        "next_action_projection_warning",
+        "backlog_hygiene_warning",
+        "state_projection_gap",
+        "completed_todo_archive_warning",
+        "autonomous_replan_obligation",
+    ):
+        assert attached[key] == project_asset[key], (key, attached, project_asset)
+    assert item["next_action_projection_warning"]["kind"] == "next_action_projection_gap"
+    assert item["autonomous_replan_obligation"]["required"] is True
+
+    no_asset = {"active_state_next_action": "ignored"}
+    assert attach_active_state_project_asset_fields(no_asset) == {}
+    assert "project_asset" not in no_asset
+
+    print("project-asset-active-state-fields-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/control_plane/work_items/project_asset.py
+++ b/loopx/control_plane/work_items/project_asset.py
@@ -252,6 +252,69 @@ def enrich_project_asset(
     item["long_task_cadence_hint"] = cadence_hint
 
 
+def attach_active_state_project_asset_fields(
+    item: dict[str, Any],
+    *,
+    latest_runs: list[dict[str, Any]] | None = None,
+    next_action_projection_warning: Callable[..., dict[str, Any] | None] | None = None,
+    autonomous_replan_obligation_from_runs: Callable[..., dict[str, Any] | None] | None = None,
+) -> dict[str, Any]:
+    project_asset = item.get("project_asset")
+    if not isinstance(project_asset, dict):
+        return {}
+
+    attached: dict[str, Any] = {}
+    active_next_action = item.get("active_state_next_action")
+    if active_next_action:
+        project_asset["active_state_next_action"] = active_next_action
+        attached["active_state_next_action"] = active_next_action
+
+    issue_meta_surface = (
+        item.get("issue_meta_surface") if isinstance(item.get("issue_meta_surface"), dict) else None
+    )
+    if issue_meta_surface:
+        project_asset["issue_meta_surface"] = issue_meta_surface
+        attached["issue_meta_surface"] = issue_meta_surface
+
+    if next_action_projection_warning is not None:
+        warning = next_action_projection_warning(
+            active_state_next_action=active_next_action,
+            latest_run_recommended_action=item.get("latest_run_recommended_action"),
+        )
+        if warning:
+            item["next_action_projection_warning"] = warning
+            project_asset["next_action_projection_warning"] = warning
+            attached["next_action_projection_warning"] = warning
+
+    for key in (
+        "backlog_hygiene_warning",
+        "state_projection_gap",
+        "completed_todo_archive_warning",
+    ):
+        value = item.get(key) if isinstance(item.get(key), dict) else None
+        if value:
+            project_asset[key] = value
+            attached[key] = value
+
+    replan_obligation = (
+        item.get("autonomous_replan_obligation")
+        if isinstance(item.get("autonomous_replan_obligation"), dict)
+        else None
+    )
+    if replan_obligation is None and autonomous_replan_obligation_from_runs is not None:
+        replan_obligation = autonomous_replan_obligation_from_runs(
+            latest_runs or [],
+            agent_todos=item.get("agent_todos") if isinstance(item.get("agent_todos"), dict) else None,
+        )
+        if replan_obligation:
+            item["autonomous_replan_obligation"] = replan_obligation
+    if replan_obligation:
+        project_asset["autonomous_replan_obligation"] = replan_obligation
+        attached["autonomous_replan_obligation"] = replan_obligation
+
+    return attached
+
+
 def project_asset_summary_is_public_safe(project_asset: dict[str, Any]) -> bool:
     text = repr(project_asset)
     return not LOCAL_PATH_SURFACE_PATTERN.search(text) and not SECRET_LIKE_SURFACE_PATTERN.search(text)

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -54,6 +54,7 @@ from .control_plane.work_items.project_asset import (
     PROJECT_ASSET_TODO_PROJECTION_GAP_SCHEMA_VERSION,
     TODO_PROJECTION_DETAIL_POINTER_SCHEMA_VERSION,
     TODO_PROJECTION_VIEW_SCHEMA_VERSION,
+    attach_active_state_project_asset_fields as _attach_active_state_project_asset_fields,
     build_project_asset,
     enrich_project_asset as _enrich_project_asset_read_model,
     project_asset_handoff_check_projection,
@@ -6845,62 +6846,13 @@ def build_attention_queue(
                 if active_state_fields is None:
                     active_state_fields = active_state_todo_fields(goal, runtime_root=runtime_root)
                 item.update(active_state_fields)
-                if isinstance(item.get("project_asset"), dict):
-                    active_next_action = item.get("active_state_next_action")
-                    if active_next_action:
-                        item["project_asset"]["active_state_next_action"] = active_next_action
-                    issue_meta_surface = (
-                        item.get("issue_meta_surface")
-                        if isinstance(item.get("issue_meta_surface"), dict)
-                        else None
-                    )
-                    if issue_meta_surface:
-                        item["project_asset"]["issue_meta_surface"] = issue_meta_surface
-                    next_action_warning = next_action_projection_warning(
-                        active_state_next_action=active_next_action,
-                        latest_run_recommended_action=item.get("latest_run_recommended_action"),
-                    )
-                    if next_action_warning:
-                        item["next_action_projection_warning"] = next_action_warning
-                        item["project_asset"]["next_action_projection_warning"] = next_action_warning
                 sync_connected_attention_action_from_todos(item)
-                backlog_warning = (
-                    item.get("backlog_hygiene_warning")
-                    if isinstance(item.get("backlog_hygiene_warning"), dict)
-                    else None
+                _attach_active_state_project_asset_fields(
+                    item,
+                    latest_runs=goal_latest_runs,
+                    next_action_projection_warning=next_action_projection_warning,
+                    autonomous_replan_obligation_from_runs=autonomous_replan_obligation_from_runs,
                 )
-                if backlog_warning and isinstance(item.get("project_asset"), dict):
-                    item["project_asset"]["backlog_hygiene_warning"] = backlog_warning
-                projection_gap = (
-                    item.get("state_projection_gap")
-                    if isinstance(item.get("state_projection_gap"), dict)
-                    else None
-                )
-                if projection_gap and isinstance(item.get("project_asset"), dict):
-                    item["project_asset"]["state_projection_gap"] = projection_gap
-                archive_warning = (
-                    item.get("completed_todo_archive_warning")
-                    if isinstance(item.get("completed_todo_archive_warning"), dict)
-                    else None
-                )
-                if archive_warning and isinstance(item.get("project_asset"), dict):
-                    item["project_asset"]["completed_todo_archive_warning"] = archive_warning
-                replan_obligation = (
-                    item.get("autonomous_replan_obligation")
-                    if isinstance(item.get("autonomous_replan_obligation"), dict)
-                    else None
-                )
-                if not replan_obligation:
-                    replan_obligation = autonomous_replan_obligation_from_runs(
-                        goal_latest_runs,
-                        agent_todos=item.get("agent_todos")
-                        if isinstance(item.get("agent_todos"), dict)
-                        else None,
-                    )
-                    if replan_obligation:
-                        item["autonomous_replan_obligation"] = replan_obligation
-                if replan_obligation and isinstance(item.get("project_asset"), dict):
-                    item["project_asset"]["autonomous_replan_obligation"] = replan_obligation
                 item["quota"] = quota_status(
                     goal,
                     waiting_on=str(item.get("waiting_on") or ""),


### PR DESCRIPTION
## Summary
- Move active-state project_asset projection from the status hot path into the project_asset read-model helper.
- Add a focused smoke for active-state fields, warnings, and run-derived replan obligation propagation.

## Validation
- python3 -m py_compile loopx/status.py loopx/control_plane/work_items/project_asset.py
- python3 examples/control_plane/project-asset-active-state-fields-smoke.py
- python3 examples/control_plane/status-quota-review-packet-parity-smoke.py
- python3 examples/control_plane/runtime-handoff-status-read-path-smoke.py
- git diff --check
- loopx --format json check --scan-path loopx/control_plane/work_items/project_asset.py --scan-path loopx/status.py --scan-path examples/control_plane/project-asset-active-state-fields-smoke.py
- loopx canary premerge --from-git-diff
