### PR TITLE
Add CLI goal prewarm canary flag

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -83,6 +83,7 @@ def _assert_cli_goal_plan_and_relay_command() -> None:
     from loopx.benchmark_adapters.skillsbench import skillsbench_route_contract
     from scripts.skillsbench_automation_loop import (
         _host_local_acp_launch_command,
+        _public_runner_config,
         build_plan,
         parse_args,
     )
@@ -135,6 +136,7 @@ def _assert_cli_goal_plan_and_relay_command() -> None:
 
         command = _host_local_acp_launch_command(args, plan)
         assert "--codex-cli-goal-worker" in command, command
+        assert "--codex-cli-goal-thread-prewarm" not in command, command
         assert "--app-server-goal-worker" not in command, command
         assert "--reasoning-effort" in command, command
         assert command[command.index("--reasoning-effort") + 1] == "xhigh", command
@@ -146,6 +148,36 @@ def _assert_cli_goal_plan_and_relay_command() -> None:
             command[command.index("--goal-active-timeout-sec") + 1]
             == command[command.index("--first-action-timeout-sec") + 1]
         ), command
+        default_config = _public_runner_config(plan)
+        assert default_config["codex_cli_goal_thread_prewarm"] is False
+
+        prewarm_args = parse_args(
+            [
+                "--route",
+                CODEX_CLI_GOAL_BASELINE_ROUTE,
+                "--host-local-acp-launch",
+                "--remote-command-file-bridge-ready",
+                "--remote-command-file-bridge-solver-command",
+                "python bridge.py",
+                "--reasoning-effort",
+                "xhigh",
+                "--codex-cli-goal-thread-prewarm",
+                "--plan-only",
+                "--skillsbench-root",
+                str(skillsbench_root),
+                "--jobs-dir",
+                str(temp_path / "jobs-with-prewarm"),
+                "--ledger-path",
+                str(temp_path / "ledger-with-prewarm.json"),
+                "--global-ledger-path",
+                str(temp_path / "global-ledger-with-prewarm.json"),
+            ]
+        )
+        prewarm_plan = build_plan(prewarm_args)
+        prewarm_command = _host_local_acp_launch_command(prewarm_args, prewarm_plan)
+        assert "--codex-cli-goal-thread-prewarm" in prewarm_command, prewarm_command
+        prewarm_config = _public_runner_config(prewarm_plan)
+        assert prewarm_config["codex_cli_goal_thread_prewarm"] is True
 
         proxy_url = "http://127.0.0.1:18182"
         args_with_proxy = parse_args(

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -957,6 +957,7 @@ def _host_local_acp_launch_command(
             command.extend(["--worker-public-trace-dir", worker_trace_dir])
     elif args.route == CODEX_CLI_GOAL_BASELINE_ROUTE:
         command.extend(["--codex-cli-goal-worker"])
+        if getattr(args, "codex_cli_goal_thread_prewarm", False): command.extend(["--codex-cli-goal-thread-prewarm"])
         proxy_url, _proxy_source = _codex_api_reverse_tunnel_proxy(args)
         if (
             proxy_url
@@ -8809,6 +8810,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         ),
         "include_task_skills": bool(args.include_task_skills),
         "host_local_acp_launch": bool(args.host_local_acp_launch),
+        "codex_cli_goal_thread_prewarm": bool(getattr(args, "codex_cli_goal_thread_prewarm", False)),
         "bootstrap_light_candidate_required": bool(
             _formal_app_server_goal_bootstrap_light_guard_required(args)
         ),
@@ -9351,6 +9353,7 @@ def _public_runner_config(plan: dict[str, Any]) -> dict[str, Any]:
     for field in (
         "include_task_skills",
         "host_local_acp_launch",
+        "codex_cli_goal_thread_prewarm",
         "bootstrap_light_candidate_required",
         "bootstrap_light_fail_fast_required",
         "allow_staged_bootstrap_repair_run",
@@ -16147,12 +16150,8 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
             "0 disables the watchdog."
         ),
     )
-    parser.add_argument(
-        "--local-codex-ping-timeout-sec",
-        type=int,
-        default=120,
-        help="Timeout for --local-codex-participant-ping.",
-    )
+    parser.add_argument("--local-codex-ping-timeout-sec", type=int, default=120, help="Timeout for --local-codex-participant-ping.")
+    parser.add_argument("--codex-cli-goal-thread-prewarm", action="store_true", help="Prewarm the Codex CLI TUI thread before codex-cli-goal /goal startup canaries.")
     parser.add_argument(
         "--local-driver-worker-handshake-preflight",
         action="store_true",


### PR DESCRIPTION
## Summary
- Add a public-safe `--codex-cli-goal-thread-prewarm` runner flag for codex-cli-goal startup-route canaries.
- Pass the flag through to the host-local ACP relay without changing the default codex-cli-goal route.
- Record the prewarm knob in public runner config and cover default/prewarm command construction in the codex-cli-goal smoke.

## Validation
- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-codex-cli-goal-route-smoke.py`
- `loopx canary premerge --from-git-diff` passed direct/catalog/public-boundary checks; manual hold: `benchmark_sensitive` because this touches benchmark runner plumbing. Owner has authorized benchmark helper/runtime self-merge for this investigation.

## Boundary
No raw task text, trajectories, verifier output, credentials, private paths, or generated benchmark logs are committed. This does not change scoring, task semantics, submission behavior, or default benchmark launch behavior.