### PR TITLE
Bound CLI goal prewarm timeout

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -1114,6 +1114,7 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     source = (
         REPO_ROOT / "loopx/benchmark_adapters/skillsbench_acp_relay.py"
     ).read_text(encoding="utf-8")
+    assert "CODEX_CLI_GOAL_THREAD_PREWARM_TIMEOUT_SEC = 120" in source
     assert "CODEX_CLI_GOAL_TASK_PROMPT_FILENAME" in source
     assert "prompt_instruction_path.write_text(" in source
     assert "build_codex_cli_goal_file_objective(" in source
@@ -1123,8 +1124,11 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert "if self._config.codex_cli_goal_thread_prewarm:" in source
     assert "prewarm_codex_cli_goal_thread(" in source
     assert "thread_prewarm_timeout" in source
-    assert "timeout_sec=max(" in source
-    assert "self._config.first_action_timeout_sec" in source
+    assert "timeout_sec=CODEX_CLI_GOAL_THREAD_PREWARM_TIMEOUT_SEC" in source
+    assert (
+        "max(90.0, float(self._config.first_action_timeout_sec or 0.0))"
+        not in source
+    )
     assert "post_bridge_recovery_attempt_count" in source
     assert "post_bridge_closeout_attempt_count" in source
     assert "POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT" in source
@@ -1162,6 +1166,32 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
         assert trace["goal_prompt_file_used"] is True, trace
         assert trace["goal_prompt_file_raw_path_recorded"] is False, trace
         assert trace["goal_command_submission_method"] == "typed", trace
+
+    with tempfile.TemporaryDirectory() as temp:
+        trace_dir = Path(temp) / "trace"
+        relay = SkillsBenchLocalAcpRelay(
+            CodexExecConfig(
+                codex_cli_goal_thread_prewarm=True,
+                first_action_timeout_sec=7200.0,
+                worker_public_trace_dir=str(trace_dir),
+            )
+        )
+        relay._publish_codex_cli_goal_trace(
+            ok=False,
+            stage="thread_prewarm_timeout",
+            goal_active_observed=False,
+            goal_terminal_observed=False,
+            first_action_observed=False,
+            bridge_summary_path=None,
+            thread_prewarm_observed=False,
+            goal_prompt_file_used=True,
+            goal_command_submission_method="typed",
+        )
+        traces = list(trace_dir.glob("*.compact.json"))
+        assert len(traces) == 1, traces
+        payload = json.loads(traces[0].read_text(encoding="utf-8"))
+        trace = payload["codex_cli_goal"]
+        assert trace["goal_thread_prewarm_timeout_sec"] == 120, trace
 
 
 def _assert_cli_goal_codex_api_proxy_is_runtime_only() -> None:

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -87,16 +87,12 @@ SKILLSBENCH_LOCAL_ACP_RELAY_PROBE_SCHEMA_VERSION = (
 SKILLSBENCH_HOST_LOCAL_ACP_TRANSPORT_PROBE_SCHEMA_VERSION = (
     "skillsbench_host_local_acp_transport_probe_v0"
 )
-SKILLSBENCH_LOCAL_ACP_RELAY_READY_MARKER = (
-    "LOOPX_SKILLSBENCH_LOCAL_ACP_RELAY_READY"
-)
+SKILLSBENCH_LOCAL_ACP_RELAY_READY_MARKER = "LOOPX_SKILLSBENCH_LOCAL_ACP_RELAY_READY"
 SKILLSBENCH_LOCAL_ACP_RELAY_HEALTH_PROMPT = (
     "LoopX relay health check. Reply exactly "
     f"{SKILLSBENCH_LOCAL_ACP_RELAY_READY_MARKER} and end the turn."
 )
-SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER = (
-    "LOOPX_SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_READY"
-)
+SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER = "LOOPX_SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_READY"
 SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_PROMPT = (
     "LoopX bridge action preflight. First use the private bridge command from "
     "the relay packet to run one JSON preflight request that does not require "
@@ -109,6 +105,7 @@ SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_PROMPT = (
     "After the bridge response returns, reply exactly "
     f"{SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER} and end the turn."
 )
+CODEX_CLI_GOAL_THREAD_PREWARM_TIMEOUT_SEC = 120
 
 
 @contextlib.contextmanager
@@ -1251,7 +1248,7 @@ class SkillsBenchLocalAcpRelay:
                     thread_prewarm_observed = prewarm_codex_cli_goal_thread(
                         tmux_name=tmux_name,
                         tmp_path=tmp_path,
-                        timeout_sec=max(90.0, float(self._config.first_action_timeout_sec or 0.0)),
+                        timeout_sec=CODEX_CLI_GOAL_THREAD_PREWARM_TIMEOUT_SEC,
                     )
                     if not thread_prewarm_observed:
                         tmux_kill_session(tmux_name)
@@ -1851,6 +1848,7 @@ class SkillsBenchLocalAcpRelay:
                 "stage": safe_stage,
                 "goal_slash_command_submitted": True,
                 "goal_thread_prewarm_observed": bool(thread_prewarm_observed),
+                "goal_thread_prewarm_timeout_sec": CODEX_CLI_GOAL_THREAD_PREWARM_TIMEOUT_SEC if self._config.codex_cli_goal_thread_prewarm else 0,
                 "goal_prompt_file_used": bool(goal_prompt_file_used),
                 "goal_prompt_file_raw_path_recorded": False,
                 "goal_command_submission_method": str(


### PR DESCRIPTION
## Summary
- cap codex-cli-goal TUI thread prewarm at a small startup timeout instead of inheriting the long first-action solver timeout
- include the bounded prewarm timeout in the public-safe codex_cli_goal TUI compact trace
- extend the codex-cli-goal route smoke so the prewarm path cannot regress back to first-action-timeout coupling

## Validation
- python3 examples/skillsbench-codex-cli-goal-route-smoke.py
- python3 -m py_compile loopx/benchmark_adapters/skillsbench_acp_relay.py examples/skillsbench-codex-cli-goal-route-smoke.py
- python3 examples/control_plane/repo-python-line-budget-smoke.py
- loopx canary premerge --from-git-diff: direct checks, catalog canaries, and public-boundary smoke passed; manual hold was benchmark_sensitive, covered by owner authorization for benchmark helper/runtime self-merge

## Boundary
No scoring, task semantics, leaderboard/submission behavior, raw benchmark logs, local paths, credentials, or production actions.