### PR TITLE
Refactor project asset todo status markdown

### DIFF
--- a/examples/platform-migration-material-registry-smoke.py
+++ b/examples/platform-migration-material-registry-smoke.py
@@ -48,9 +48,13 @@ def write_platform_migration_fixture(root: Path) -> Path:
         "---\n\n"
         "# Platform Migration Material Registry\n\n"
         "## User Todo\n\n"
-        "- [ ] Confirm whether owner review is fresh enough to resume delivery.\n\n"
+        "- [ ] Confirm whether owner review is fresh enough to resume delivery.\n"
+        "  <!-- loopx:todo todo_id=todo_owner_review_gate status=open "
+        "task_class=user_gate action_kind=owner_review_freshness global_gate=true -->\n\n"
         "## Agent Todo\n\n"
-        "- [ ] Run read-only map and report material freshness without internal links.\n\n"
+        "- [ ] Run read-only map and report material freshness without internal links.\n"
+        "  <!-- loopx:todo todo_id=todo_material_registry_map status=open "
+        "task_class=advancement_task action_kind=read_only_map -->\n\n"
         "## Next Action\n\n"
         "- Refresh the public-safe material registry summary.\n\n"
         "## Platform Migration Pilot Boundary\n\n"
@@ -228,7 +232,7 @@ def assert_material_counts(
 
 def assert_no_evidence_project_asset(project_asset: dict[str, object]) -> None:
     assert project_asset["owner"] == "controller", project_asset
-    assert project_asset["gate"] == "active_state_user_todo", project_asset
+    assert project_asset["gate"] == "active_state_user_gate", project_asset
     assert project_asset["next_action"] == EXPECTED_USER_TODO, project_asset
     assert project_asset["active_state_next_action"] == EXPECTED_NEXT_ACTION, project_asset
     assert project_asset["stop_condition"] == EXPECTED_STOP_CONDITION, project_asset
@@ -265,7 +269,7 @@ def assert_no_evidence_handoff_readiness(readiness: dict[str, object]) -> None:
 def assert_status_markdown_no_evidence_projection(status_markdown: str) -> None:
     expected_lines = [
         "project_asset_source: project_asset",
-        f"project_asset: owner=controller gate=active_state_user_todo stop={EXPECTED_STOP_CONDITION}",
+        f"project_asset: owner=controller gate=active_state_user_gate stop={EXPECTED_STOP_CONDITION}",
         f"asset_next_action: {EXPECTED_USER_TODO}",
         "asset_todos: user_open=1 agent_open=1",
         f"asset_user_todo: {EXPECTED_USER_TODO}",
@@ -331,7 +335,7 @@ def assert_handoff_only_json_projection(payload: dict[str, object]) -> None:
     assert "packet" not in payload, payload
     assert "operator_gate_preview" not in payload, payload
     assert payload["kind"] == "controller", payload
-    assert payload["status"] == "active_state_user_todo", payload
+    assert payload["status"] == "active_state_user_gate", payload
     assert payload["waiting_on"] == "controller", payload
     assert_handoff_only_no_evidence_projection(payload["handoff_text"])
     assert_public_safe(json.dumps(payload, ensure_ascii=False))
@@ -412,7 +416,7 @@ def main() -> int:
         assert "materials 6; repos 2; owner review 1; stale 1; risk medium" in html, html
         assert "Public-safe counts only; no source links or raw material text." in html, html
         assert "Project Asset" in html, html
-        assert "owner controller; gate active_state_user_todo" in html, html
+        assert "owner controller; gate active_state_user_gate" in html, html
         assert f"<b>Next</b> {EXPECTED_USER_TODO}" in html, html
         assert f"<b>Stop</b> {EXPECTED_STOP_CONDITION}" in html, html
         assert f"User todo: 1/1 open; next {EXPECTED_USER_TODO}" in html, html

--- a/loopx/renderers/status_markdown.py
+++ b/loopx/renderers/status_markdown.py
@@ -444,6 +444,85 @@ def append_project_asset_warning_markdown(
         )
 
 
+def append_project_asset_todo_quota_markdown(
+    lines: list[str],
+    project_asset: dict[str, Any],
+    *,
+    goal_todo_scope_suffix: str = "",
+) -> None:
+    asset_user_todos = (
+        project_asset.get("user_todos")
+        if isinstance(project_asset.get("user_todos"), dict)
+        else {}
+    )
+    asset_agent_todos = (
+        project_asset.get("agent_todos")
+        if isinstance(project_asset.get("agent_todos"), dict)
+        else {}
+    )
+    if asset_user_todos or asset_agent_todos:
+        todo_parts = []
+        if asset_user_todos:
+            todo_parts.append(f"user_open={asset_user_todos.get('open')}")
+            if asset_user_todos.get("claimed_open_count"):
+                todo_parts.append(f"user_claimed={asset_user_todos.get('claimed_open_count')}")
+        if asset_agent_todos:
+            todo_parts.append(f"agent_open={asset_agent_todos.get('open')}")
+            if asset_agent_todos.get("claimed_open_count"):
+                todo_parts.append(f"agent_claimed={asset_agent_todos.get('claimed_open_count')}")
+        lines.append(f"    - asset_todos: {' '.join(todo_parts)}")
+        if asset_user_todos.get("next"):
+            claimed = asset_user_todos.get("next_claimed_by")
+            claim_suffix = f" claimed_by={markdown_scalar(claimed)}" if claimed else ""
+            lines.append(
+                f"      - asset_user_todo: "
+                f"{markdown_scalar(asset_user_todos.get('next') or '')}"
+                f"{claim_suffix}"
+            )
+        for todo in (asset_user_todos.get("items") or [])[1:3]:
+            if isinstance(todo, dict) and todo.get("text"):
+                index = todo.get("index")
+                suffix = f"[{index}]" if index is not None else ""
+                claimed = todo.get("claimed_by")
+                claim_suffix = f" claimed_by={markdown_scalar(claimed)}" if claimed else ""
+                lines.append(
+                    f"      - asset_user_todo{suffix}: "
+                    f"{markdown_scalar(todo.get('text') or '')}"
+                    f"{claim_suffix}"
+                )
+        if asset_agent_todos.get("next"):
+            claimed = asset_agent_todos.get("next_claimed_by")
+            claim_suffix = f" claimed_by={markdown_scalar(claimed)}" if claimed else ""
+            lines.append(
+                f"      - asset_agent_todo: "
+                f"{markdown_scalar(asset_agent_todos.get('next') or '')}"
+                f"{claim_suffix}{goal_todo_scope_suffix}"
+            )
+        for todo in (asset_agent_todos.get("items") or [])[1:3]:
+            if isinstance(todo, dict) and todo.get("text"):
+                index = todo.get("index")
+                suffix = f"[{index}]" if index is not None else ""
+                claimed = todo.get("claimed_by")
+                claim_suffix = f" claimed_by={markdown_scalar(claimed)}" if claimed else ""
+                lines.append(
+                    f"      - asset_agent_todo{suffix}: "
+                    f"{markdown_scalar(todo.get('text') or '')}"
+                    f"{claim_suffix}{goal_todo_scope_suffix}"
+                )
+    asset_quota = (
+        project_asset.get("quota")
+        if isinstance(project_asset.get("quota"), dict)
+        else {}
+    )
+    if asset_quota:
+        lines.append(
+            "    - asset_quota: "
+            f"compute={asset_quota.get('compute')} "
+            f"state={asset_quota.get('state')} "
+            f"slots={asset_quota.get('spent_slots')}/{asset_quota.get('allowed_slots')}"
+        )
+
+
 def append_attention_queue_summary_markdown(
     lines: list[str],
     queue: dict[str, Any],

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -322,6 +322,7 @@ from .renderers.status_markdown import (
     append_event_ledger_summary_markdown as _append_event_ledger_summary_markdown,
     append_human_reward_markdown as _append_human_reward_markdown,
     append_operator_gate_resume_contract_markdown as _append_operator_gate_resume_contract_markdown,
+    append_project_asset_todo_quota_markdown as _append_project_asset_todo_quota_markdown,
     append_project_asset_warning_markdown as _append_project_asset_warning_markdown,
     append_promotion_gate_markdown as _append_promotion_gate_markdown,
     append_promotion_readiness_summary_markdown as _append_promotion_readiness_summary_markdown,
@@ -7501,69 +7502,11 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
                         f"      - child_run: role={role} state={state} "
                         f"run_id={run_id} parent_run_id={parent_run_id}"
                     )
-            asset_user_todos = (
-                project_asset.get("user_todos")
-                if isinstance(project_asset.get("user_todos"), dict)
-                else {}
+            _append_project_asset_todo_quota_markdown(
+                lines,
+                project_asset,
+                goal_todo_scope_suffix=goal_todo_scope_suffix,
             )
-            asset_agent_todos = (
-                project_asset.get("agent_todos")
-                if isinstance(project_asset.get("agent_todos"), dict)
-                else {}
-            )
-            if asset_user_todos or asset_agent_todos:
-                todo_parts = []
-                if asset_user_todos:
-                    todo_parts.append(f"user_open={asset_user_todos.get('open')}")
-                    if asset_user_todos.get("claimed_open_count"):
-                        todo_parts.append(f"user_claimed={asset_user_todos.get('claimed_open_count')}")
-                if asset_agent_todos:
-                    todo_parts.append(f"agent_open={asset_agent_todos.get('open')}")
-                    if asset_agent_todos.get("claimed_open_count"):
-                        todo_parts.append(f"agent_claimed={asset_agent_todos.get('claimed_open_count')}")
-                lines.append(f"    - asset_todos: {' '.join(todo_parts)}")
-                if asset_user_todos.get("next"):
-                    claimed = asset_user_todos.get("next_claimed_by")
-                    claim_suffix = f" claimed_by={_markdown_scalar(claimed)}" if claimed else ""
-                    lines.append(f"      - asset_user_todo: {_markdown_scalar(asset_user_todos.get('next') or '')}{claim_suffix}")
-                for todo in (asset_user_todos.get("items") or [])[1:3]:
-                    if isinstance(todo, dict) and todo.get("text"):
-                        index = todo.get("index")
-                        suffix = f"[{index}]" if index is not None else ""
-                        claimed = todo.get("claimed_by")
-                        claim_suffix = f" claimed_by={_markdown_scalar(claimed)}" if claimed else ""
-                        lines.append(f"      - asset_user_todo{suffix}: {_markdown_scalar(todo.get('text') or '')}{claim_suffix}")
-                if asset_agent_todos.get("next"):
-                    claimed = asset_agent_todos.get("next_claimed_by")
-                    claim_suffix = f" claimed_by={_markdown_scalar(claimed)}" if claimed else ""
-                    lines.append(
-                        f"      - asset_agent_todo: "
-                        f"{_markdown_scalar(asset_agent_todos.get('next') or '')}"
-                        f"{claim_suffix}{goal_todo_scope_suffix}"
-                    )
-                for todo in (asset_agent_todos.get("items") or [])[1:3]:
-                    if isinstance(todo, dict) and todo.get("text"):
-                        index = todo.get("index")
-                        suffix = f"[{index}]" if index is not None else ""
-                        claimed = todo.get("claimed_by")
-                        claim_suffix = f" claimed_by={_markdown_scalar(claimed)}" if claimed else ""
-                        lines.append(
-                            f"      - asset_agent_todo{suffix}: "
-                            f"{_markdown_scalar(todo.get('text') or '')}"
-                            f"{claim_suffix}{goal_todo_scope_suffix}"
-                        )
-            asset_quota = (
-                project_asset.get("quota")
-                if isinstance(project_asset.get("quota"), dict)
-                else {}
-            )
-            if asset_quota:
-                lines.append(
-                    "    - asset_quota: "
-                    f"compute={asset_quota.get('compute')} "
-                    f"state={asset_quota.get('state')} "
-                    f"slots={asset_quota.get('spent_slots')}/{asset_quota.get('allowed_slots')}"
-                )
             _append_project_asset_warning_markdown(lines, project_asset, item)
             session_projection = (
                 project_asset.get("session_runtime_projection")


### PR DESCRIPTION
## Summary
- move project-asset todo/quota markdown rendering out of `loopx/status.py` into `loopx/renderers/status_markdown.py`
- keep the emitted status markdown shape stable while shrinking the status hot path
- update the platform-migration material-registry smoke fixture to use explicit `task_class` metadata and assert `active_state_user_gate`

## Validation
- `python3 examples/platform-migration-material-registry-smoke.py`
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 -m py_compile loopx/status.py loopx/renderers/status_markdown.py examples/platform-migration-material-registry-smoke.py`
- `git diff --check`
- `loopx --format json check --scan-path loopx/status.py --scan-path loopx/renderers/status_markdown.py --scan-path examples/platform-migration-material-registry-smoke.py`
- `loopx canary premerge --from-git-diff`

## Premerge Gate
`loopx canary premerge --from-git-diff` passed with `merge_gate_passed=true`, `self_merge_allowed=true`, `manual_holds=0`. Changed surfaces were `control_plane, public_boundary, python`; risk profiles were `core-control-plane, canary-runner`.
