### PR TITLE
Harden Codex TUI goal readiness

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -355,7 +355,12 @@ def _assert_cli_goal_tui_ready_wait_tolerates_startup_warnings() -> None:
     captures = iter(
         [
             "",
-            "Codex startup\nMCP server failed: HTTP request failed\n› \n",
+            (
+                "Codex startup\n"
+                "MCP server failed: HTTP request failed\n"
+                "│ model:     gpt-5.5 xhigh   /model to change │\n"
+                "› \n"
+            ),
         ]
     )
 
@@ -363,17 +368,57 @@ def _assert_cli_goal_tui_ready_wait_tolerates_startup_warnings() -> None:
         try:
             return next(captures)
         except StopIteration:
-            return "Codex startup\nMCP server failed: HTTP request failed\n› \n"
+            return (
+                "Codex startup\n"
+                "MCP server failed: HTTP request failed\n"
+                "│ model:     gpt-5.5 xhigh   /model to change │\n"
+                "› \n"
+            )
 
-    original_capture = goal_tui.tmux_capture
+    original_capture = goal_tui.tmux_capture_visible
     try:
-        goal_tui.tmux_capture = fake_capture  # type: ignore[assignment]
+        goal_tui.tmux_capture_visible = fake_capture  # type: ignore[assignment]
         assert goal_tui.wait_for_codex_cli_tui_ready(
             "fake-session",
-            timeout_sec=1.0,
+            timeout_sec=2.0,
+            startup_grace_sec=0.0,
+            stable_sec=0.0,
         )
     finally:
-        goal_tui.tmux_capture = original_capture  # type: ignore[assignment]
+        goal_tui.tmux_capture_visible = original_capture  # type: ignore[assignment]
+
+
+def _assert_cli_goal_tui_ready_wait_rejects_startup_artifacts() -> None:
+    sys.path.insert(0, str(REPO_ROOT))
+    import loopx.codex_cli_goal_tui as goal_tui
+
+    trust_prompt = (
+        "Do you trust the contents of this directory?\n"
+        "› 1. Yes, continue\n"
+        "  2. No, quit\n"
+        "Press enter to continue\n"
+    )
+    assert goal_tui.codex_cli_tui_startup_blocker(trust_prompt) == "trust_prompt"
+    assert not goal_tui.codex_cli_tui_input_prompt_visible(trust_prompt)
+
+    current_model_loading = (
+        "│ model:     loading   /model to change │\n"
+        "› Explain this codebase\n"
+    )
+    assert (
+        goal_tui.codex_cli_tui_startup_blocker(current_model_loading)
+        == "model_loading"
+    )
+
+    historical_loading_then_ready = (
+        "│ model:     loading   /model to change │\n"
+        "› Explain this codebase\n"
+        "│ model:     gpt-5.5 xhigh   /model to change │\n"
+        "› Explain this codebase\n"
+    )
+    assert goal_tui.codex_cli_tui_startup_blocker(historical_loading_then_ready) == ""
+    assert goal_tui.codex_cli_tui_input_prompt_visible(historical_loading_then_ready)
+    assert goal_tui.codex_cli_tui_input_prompt_visible("  > \n")
 
 
 def _assert_cli_goal_paste_submit_falls_back_to_plain_enter() -> None:
@@ -409,13 +454,13 @@ def _assert_cli_goal_paste_submit_falls_back_to_plain_enter() -> None:
     original_sleep = goal_tui.time.sleep
     original_submit = goal_tui.tmux_submit_enter
     original_plain_enter = goal_tui.tmux_send_plain_enter
-    original_capture = goal_tui.tmux_capture
+    original_capture = goal_tui.tmux_capture_visible
     try:
         goal_tui.subprocess.run = fake_run  # type: ignore[assignment]
         goal_tui.time.sleep = lambda _seconds: None  # type: ignore[assignment]
         goal_tui.tmux_submit_enter = fake_submit  # type: ignore[assignment]
         goal_tui.tmux_send_plain_enter = fake_plain_enter  # type: ignore[assignment]
-        goal_tui.tmux_capture = fake_capture  # type: ignore[assignment]
+        goal_tui.tmux_capture_visible = fake_capture  # type: ignore[assignment]
         with tempfile.TemporaryDirectory() as temp:
             prompt_path = Path(temp) / "prompt.txt"
             prompt_path.write_text(prompt_text, encoding="utf-8")
@@ -429,7 +474,7 @@ def _assert_cli_goal_paste_submit_falls_back_to_plain_enter() -> None:
         goal_tui.time.sleep = original_sleep  # type: ignore[assignment]
         goal_tui.tmux_submit_enter = original_submit  # type: ignore[assignment]
         goal_tui.tmux_send_plain_enter = original_plain_enter  # type: ignore[assignment]
-        goal_tui.tmux_capture = original_capture  # type: ignore[assignment]
+        goal_tui.tmux_capture_visible = original_capture  # type: ignore[assignment]
 
     assert ("kitty-enter", "fake-session") in calls, calls
     assert ("plain-enter", "fake-session") in calls, calls
@@ -459,13 +504,13 @@ def _assert_cli_goal_typed_submit_avoids_paste_buffer() -> None:
     original_sleep = goal_tui.time.sleep
     original_submit = goal_tui.tmux_submit_enter
     original_plain_enter = goal_tui.tmux_send_plain_enter
-    original_capture = goal_tui.tmux_capture
+    original_capture = goal_tui.tmux_capture_visible
     try:
         goal_tui.subprocess.run = fake_run  # type: ignore[assignment]
         goal_tui.time.sleep = lambda _seconds: None  # type: ignore[assignment]
         goal_tui.tmux_submit_enter = fake_submit  # type: ignore[assignment]
         goal_tui.tmux_send_plain_enter = fake_plain_enter  # type: ignore[assignment]
-        goal_tui.tmux_capture = fake_capture  # type: ignore[assignment]
+        goal_tui.tmux_capture_visible = fake_capture  # type: ignore[assignment]
         goal_tui.tmux_type_text_and_submit(
             tmux_name="fake-session",
             text=goal_text,
@@ -475,7 +520,7 @@ def _assert_cli_goal_typed_submit_avoids_paste_buffer() -> None:
         goal_tui.time.sleep = original_sleep  # type: ignore[assignment]
         goal_tui.tmux_submit_enter = original_submit  # type: ignore[assignment]
         goal_tui.tmux_send_plain_enter = original_plain_enter  # type: ignore[assignment]
-        goal_tui.tmux_capture = original_capture  # type: ignore[assignment]
+        goal_tui.tmux_capture_visible = original_capture  # type: ignore[assignment]
 
     assert any(
         isinstance(call, list)
@@ -1280,6 +1325,7 @@ def main() -> int:
     _assert_cli_goal_plan_and_relay_command()
     _assert_cli_goal_trace_merges_into_public_prerequisites()
     _assert_cli_goal_tui_ready_wait_tolerates_startup_warnings()
+    _assert_cli_goal_tui_ready_wait_rejects_startup_artifacts()
     _assert_cli_goal_paste_submit_falls_back_to_plain_enter()
     _assert_cli_goal_typed_submit_avoids_paste_buffer()
     _assert_cli_goal_rate_limit_is_public_safe_retryable_stage()

--- a/loopx/codex_cli_goal_tui.py
+++ b/loopx/codex_cli_goal_tui.py
@@ -19,6 +19,8 @@ CODEX_CLI_GOAL_THREAD_PREWARM_PROMPT = (
     "joining LOOPX, GOAL, THREAD, and READY with underscores. Do not use tools."
 )
 CODEX_CLI_GOAL_TASK_PROMPT_FILENAME = "skillsbench-task-prompt.md"
+CODEX_CLI_TUI_READY_STARTUP_GRACE_SEC = 15.0
+CODEX_CLI_TUI_READY_STABLE_SEC = 2.0
 
 
 def build_codex_cli_goal_tui_input(objective: str) -> str:
@@ -148,6 +150,17 @@ def tmux_capture(tmux_name: str) -> str:
     return proc.stdout or ""
 
 
+def tmux_capture_visible(tmux_name: str) -> str:
+    proc = subprocess.run(
+        ["tmux", "capture-pane", "-p", "-J", "-t", tmux_name],
+        check=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    return proc.stdout or ""
+
+
 def tmux_kill_session(tmux_name: str) -> None:
     subprocess.run(
         ["tmux", "kill-session", "-t", tmux_name],
@@ -246,7 +259,10 @@ def tmux_paste_file_and_submit(
     tmux_submit_enter(tmux_name)
     prompt_text = prompt_path.read_text(encoding="utf-8", errors="ignore")
     time.sleep(1.0)
-    if codex_cli_tui_active_input_prompt_contains(tmux_capture(tmux_name), prompt_text):
+    if codex_cli_tui_active_input_prompt_contains(
+        tmux_capture_visible(tmux_name),
+        prompt_text,
+    ):
         tmux_send_plain_enter(tmux_name)
 
 
@@ -257,35 +273,82 @@ def tmux_type_text_and_submit(*, tmux_name: str, text: str) -> None:
     time.sleep(0.2)
     tmux_submit_enter(tmux_name)
     time.sleep(1.0)
-    if codex_cli_tui_active_input_prompt_contains(tmux_capture(tmux_name), text):
+    if codex_cli_tui_active_input_prompt_contains(
+        tmux_capture_visible(tmux_name),
+        text,
+    ):
         tmux_send_plain_enter(tmux_name)
+
+
+def codex_cli_tui_trust_prompt_visible(capture: str) -> bool:
+    lowered = (capture or "").lower()
+    return (
+        "do you trust the contents of this directory" in lowered
+        or ("yes, continue" in lowered and "press enter to continue" in lowered)
+    )
+
+
+def codex_cli_tui_latest_model_line(capture: str) -> str:
+    model_lines = [
+        line.strip()
+        for line in (capture or "").splitlines()
+        if "model:" in line.lower()
+    ]
+    return model_lines[-1] if model_lines else ""
+
+
+def codex_cli_tui_startup_blocker(capture: str) -> str:
+    if not (capture or "").strip():
+        return "empty_capture"
+    if codex_cli_tui_trust_prompt_visible(capture):
+        return "trust_prompt"
+    latest_model_line = codex_cli_tui_latest_model_line(capture)
+    if "loading" in latest_model_line.lower():
+        return "model_loading"
+    if "queued follow-up inputs" in capture.lower():
+        return "queued_followup"
+    return ""
 
 
 def codex_cli_tui_input_prompt_visible(capture: str) -> bool:
     if not capture:
         return False
-    if "›" in capture:
-        return True
-    return bool(re.search(r"(?m)^\\s*[>❯]\\s*(?:$|\\[)", capture))
+    if codex_cli_tui_trust_prompt_visible(capture):
+        return False
+    for raw_line in reversed(capture.splitlines()[-20:]):
+        line = raw_line.strip()
+        if not line:
+            continue
+        if line.startswith("›"):
+            return True
+        if re.match(r"^[>❯]\s*(?:$|\S)", line):
+            return True
+    return False
 
 
 def wait_for_codex_cli_tui_ready(
     tmux_name: str,
     *,
-    timeout_sec: float = 30.0,
+    timeout_sec: float = 60.0,
+    startup_grace_sec: float = CODEX_CLI_TUI_READY_STARTUP_GRACE_SEC,
+    stable_sec: float = CODEX_CLI_TUI_READY_STABLE_SEC,
 ) -> bool:
     """Wait until Codex TUI startup noise has settled before pasting input."""
 
-    deadline = time.monotonic() + max(1.0, float(timeout_sec or 0.0))
+    timeout = max(1.0, float(timeout_sec or 0.0))
+    deadline = time.monotonic() + timeout
+    grace = max(0.0, min(float(startup_grace_sec or 0.0), max(0.0, timeout - 1.0)))
+    if grace:
+        time.sleep(grace)
+    stable_ready_since = 0.0
     while time.monotonic() < deadline:
-        capture = tmux_capture(tmux_name)
+        capture = tmux_capture_visible(tmux_name)
         lowered = capture.lower()
-        if not capture.strip():
+        if codex_cli_tui_startup_blocker(capture):
+            stable_ready_since = 0.0
             time.sleep(0.5)
             continue
-        if codex_cli_tui_input_prompt_visible(capture):
-            return True
-        if any(
+        ready = codex_cli_tui_input_prompt_visible(capture) or any(
             marker in lowered
             for marker in (
                 "what can i help",
@@ -294,7 +357,15 @@ def wait_for_codex_cli_tui_ready(
                 "send a message",
                 "type a message",
             )
-        ):
+        )
+        if not ready:
+            stable_ready_since = 0.0
+            time.sleep(0.5)
+            continue
+        now = time.monotonic()
+        if not stable_ready_since:
+            stable_ready_since = now
+        if now - stable_ready_since >= max(0.0, float(stable_sec or 0.0)):
             return True
         time.sleep(0.5)
     return False


### PR DESCRIPTION
## Summary
- wait for Codex TUI startup with a fixed grace period plus a stable-ready window before submitting `/goal`
- use current visible tmux pane for readiness/submission checks while preserving full scrollback capture for diagnostics
- reject trust prompts, queued follow-up prompts, and latest `model: loading` as not ready
- add route smoke coverage for trust prompt rejection, current-model loading, historical loading scrollback, and visible-pane submission fallback

## Validation
- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 -m py_compile loopx/codex_cli_goal_tui.py loopx/benchmark_adapters/skillsbench_acp_relay.py`
- local minimal TUI `/goal` probe with patched helper: ready=true, `Goal active` observed, marker output observed, no queued follow-up, no timeout
- `loopx canary premerge --from-git-diff`
  - direct checks passed
  - 4 catalog canaries passed
  - public-boundary smoke passed
  - manual hold: `benchmark_sensitive`

## Manual Hold
`loopx canary premerge --from-git-diff` reports the expected benchmark-sensitive manual hold. User authorization in this thread allows benchmark helper/runtime PR self-merge when focused validation passes and no scoring/task semantics/leaderboard behavior changes are present. This PR only changes Codex TUI startup/readiness handling and route smoke coverage.
