### PR TITLE
Refactor global registry status markdown

### DIFF
--- a/examples/control_plane/status-global-registry-markdown-smoke.py
+++ b/examples/control_plane/status-global-registry-markdown-smoke.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Smoke-test global registry status markdown rendering."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.status import render_status_markdown  # noqa: E402
+
+
+def main() -> None:
+    markdown = render_status_markdown(
+        {
+            "ok": False,
+            "registry": "./fixtures/registry.json",
+            "runtime_root": "./fixtures/runtime",
+            "goal_count": 1,
+            "run_count": 1,
+            "contract": {
+                "ok": True,
+                "summary": {"errors": 0, "warnings": 0, "checks": 8},
+            },
+            "global_registry": {
+                "available": True,
+                "ok": False,
+                "summary": {"findings": 2, "high": 1, "action": 1, "info": 0},
+                "findings": [
+                    {
+                        "severity": "action",
+                        "kind": "source_registry_missing",
+                        "goal_id": "fixture-goal",
+                        "message": "registry source missing",
+                        "recommended_action": "sync the source registry",
+                    },
+                    {
+                        "severity": "info",
+                        "kind": "global_registry_shadow",
+                        "goal_ids": ["shadow-a", "shadow-b"],
+                        "message": "shadow finding compacted",
+                    },
+                ],
+            },
+            "attention_queue": {"items": []},
+            "run_history": {"goals": []},
+        }
+    )
+
+    assert "global_registry: available=True, ok=False, findings=2" in markdown, markdown
+    assert "## Global Registry Findings" in markdown, markdown
+    assert "action source_registry_missing goal=fixture-goal: registry source missing" in markdown, markdown
+    assert "action: sync the source registry" in markdown, markdown
+    assert "info global_registry_shadow goal=['shadow-a', 'shadow-b']: shadow finding compacted" in markdown, markdown
+    print("status-global-registry-markdown-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/presentation/renderers/status_markdown.py
+++ b/loopx/presentation/renderers/status_markdown.py
@@ -47,6 +47,54 @@ def authority_registry_markdown_summary(goal: dict[str, Any] | None) -> str | No
     )
 
 
+def append_global_registry_summary_markdown(
+    lines: list[str],
+    global_registry: dict[str, Any],
+) -> None:
+    global_summary = (
+        global_registry.get("summary")
+        if isinstance(global_registry.get("summary"), dict)
+        else {}
+    )
+    lines.extend(
+        [
+            "- global_registry: "
+            f"available={global_registry.get('available')}, "
+            f"ok={global_registry.get('ok')}, "
+            f"findings={global_summary.get('findings')}, "
+            f"high={global_summary.get('high')}, "
+            f"action={global_summary.get('action')}, "
+            f"info={global_summary.get('info')}",
+        ]
+    )
+
+
+def append_global_registry_findings_markdown(
+    lines: list[str],
+    global_registry: dict[str, Any],
+) -> None:
+    findings = (
+        global_registry.get("findings")
+        if isinstance(global_registry.get("findings"), list)
+        else []
+    )
+    if not findings:
+        return
+    lines.extend(["", "## Global Registry Findings"])
+    for finding in findings:
+        if not isinstance(finding, dict):
+            continue
+        lines.append(
+            "- "
+            f"{finding.get('severity')} "
+            f"{finding.get('kind')} "
+            f"goal={finding.get('goal_id') or finding.get('goal_ids') or 'global'}: "
+            f"{finding.get('message')}"
+        )
+        if finding.get("recommended_action"):
+            lines.append(f"  - action: {finding.get('recommended_action')}")
+
+
 def append_human_reward_markdown(lines: list[str], goal_id: Any, reward: dict[str, Any]) -> None:
     headline_parts = []
     for field in ("recorded_at", "decision", "reward"):

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -321,6 +321,8 @@ from .presentation.renderers.status_markdown import (
     append_attention_queue_summary_markdown as _append_attention_queue_summary_markdown,
     append_decision_freshness_summary_markdown as _append_decision_freshness_summary_markdown,
     append_event_ledger_summary_markdown as _append_event_ledger_summary_markdown,
+    append_global_registry_findings_markdown as _append_global_registry_findings_markdown,
+    append_global_registry_summary_markdown as _append_global_registry_summary_markdown,
     append_promotion_gate_markdown as _append_promotion_gate_markdown,
     append_promotion_readiness_summary_markdown as _append_promotion_readiness_summary_markdown,
     append_run_history_markdown as _append_run_history_markdown,
@@ -7228,22 +7230,7 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
             )
 
     global_registry = payload.get("global_registry") if isinstance(payload.get("global_registry"), dict) else {}
-    global_summary = (
-        global_registry.get("summary")
-        if isinstance(global_registry.get("summary"), dict)
-        else {}
-    )
-    lines.extend(
-        [
-            "- global_registry: "
-            f"available={global_registry.get('available')}, "
-            f"ok={global_registry.get('ok')}, "
-            f"findings={global_summary.get('findings')}, "
-            f"high={global_summary.get('high')}, "
-            f"action={global_summary.get('action')}, "
-            f"info={global_summary.get('info')}",
-        ]
-    )
+    _append_global_registry_summary_markdown(lines, global_registry)
 
     event_ledger = (
         payload.get("event_ledger_summary")
@@ -7316,24 +7303,6 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
             lines.extend(["", f"## {title}"])
             lines.extend(f"- {entry}" for entry in entries)
 
-    findings = (
-        global_registry.get("findings")
-        if isinstance(global_registry.get("findings"), list)
-        else []
-    )
-    if findings:
-        lines.extend(["", "## Global Registry Findings"])
-        for finding in findings:
-            if not isinstance(finding, dict):
-                continue
-            lines.append(
-                "- "
-                f"{finding.get('severity')} "
-                f"{finding.get('kind')} "
-                f"goal={finding.get('goal_id') or finding.get('goal_ids') or 'global'}: "
-                f"{finding.get('message')}"
-            )
-            if finding.get("recommended_action"):
-                lines.append(f"  - action: {finding.get('recommended_action')}")
+    _append_global_registry_findings_markdown(lines, global_registry)
 
     return "\n".join(lines)


### PR DESCRIPTION
## Summary

- Move global registry status markdown summary/findings rendering from `loopx/status.py` into `loopx.presentation.renderers.status_markdown`.
- Add a thin focused smoke for global registry markdown output instead of growing the already line-budget-pinned status mega-smoke.
- Preserve existing markdown line shape for global registry summary, findings, and recommended action rows.

## Validation

- `python3 -m py_compile loopx/status.py loopx/presentation/renderers/status_markdown.py examples/control_plane/status-global-registry-markdown-smoke.py`
- `python3 examples/control_plane/status-global-registry-markdown-smoke.py`
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `python3 examples/benchmark-run-v0-status-projection-smoke.py`
- `python3 examples/project/next-action-projection-contract-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `git diff --check`
- `loopx --format json check --scan-path loopx/status.py --scan-path loopx/presentation/renderers/status_markdown.py --scan-path examples/control_plane/status-global-registry-markdown-smoke.py`
- Public/private diff scan for local paths, credentials, raw benchmark logs, trajectories, verifier output, and private markers
- `loopx canary premerge --from-git-diff`
