### PR TITLE
Refactor status overview markdown renderer

### DIFF
--- a/examples/control_plane/status-overview-markdown-smoke.py
+++ b/examples/control_plane/status-overview-markdown-smoke.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Smoke-test the status markdown overview renderer seam."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.presentation.renderers.status_markdown import (  # noqa: E402
+    append_status_overview_markdown,
+)
+from loopx.status import render_status_markdown  # noqa: E402
+
+
+def overview_payload() -> dict:
+    return {
+        "ok": False,
+        "registry": "/tmp/loopx-registry.json",
+        "runtime_root": "/tmp/loopx-runtime",
+        "goal_count": 2,
+        "run_count": 7,
+        "status_contract": {
+            "schema_version": 2,
+            "minimum_dashboard_schema_version": 2,
+            "producer": "loopx status",
+        },
+        "goal_filter": "loopx-meta",
+        "contract": {
+            "ok": False,
+            "summary": {
+                "errors": 2,
+                "warnings": 1,
+                "checks": 8,
+            },
+            "errors": ["registry goals checked: 2"],
+            "warnings": ["public boundary scan clean: 0 files"],
+            "checks": ["status contract emitted"],
+        },
+        "contract_errors": [
+            "missing dashboard status_contract",
+            "stale registry pointer",
+        ],
+        "contract_errors_truncated": True,
+        "contract_errors_total_count": 4,
+        "contract_warnings": ["global registry has action findings"],
+        "contract_warnings_truncated": True,
+        "contract_warnings_total_count": 3,
+        "global_registry": {
+            "available": True,
+            "ok": True,
+            "summary": {
+                "findings": 0,
+                "high": 0,
+                "action": 0,
+                "info": 0,
+            },
+            "findings": [],
+        },
+        "attention_queue": {
+            "item_count": 0,
+            "needs_user_or_controller": 0,
+            "needs_controller": 0,
+            "needs_codex": 0,
+            "watching_external_evidence": 0,
+            "watching_monitor": 0,
+        },
+        "run_history": {
+            "goal_count": 0,
+            "run_count": 0,
+            "goals": [],
+        },
+    }
+
+
+def assert_overview(markdown: str) -> None:
+    assert markdown.startswith("# LoopX Status\n\n"), markdown
+    assert "- ok: `False`" in markdown, markdown
+    assert "- registry: `/tmp/loopx-registry.json`" in markdown, markdown
+    assert "- runtime_root: `/tmp/loopx-runtime`" in markdown, markdown
+    assert "- goals: `2`" in markdown, markdown
+    assert "- runs: `7`" in markdown, markdown
+    assert (
+        "- status_contract: schema_version=2, "
+        "minimum_dashboard_schema_version=2, producer=loopx status"
+    ) in markdown, markdown
+    assert "- goal_filter: `loopx-meta`" in markdown, markdown
+    assert "- contract: ok=False, errors=2, warnings=1, checks=8" in markdown, markdown
+    assert "## Status Contract Signals" in markdown, markdown
+    assert "- error: missing dashboard status_contract" in markdown, markdown
+    assert "- error: stale registry pointer" in markdown, markdown
+    assert "- contract_errors_truncated: total=4" in markdown, markdown
+    assert "- warning: global registry has action findings" in markdown, markdown
+    assert "- contract_warnings_truncated: total=3" in markdown, markdown
+
+
+def main() -> int:
+    payload = overview_payload()
+    lines: list[str] = []
+    append_status_overview_markdown(lines, payload)
+    assert_overview("\n".join(lines))
+    assert_overview(render_status_markdown(payload))
+    print("status-overview-markdown-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/presentation/renderers/status_markdown.py
+++ b/loopx/presentation/renderers/status_markdown.py
@@ -47,6 +47,70 @@ def authority_registry_markdown_summary(goal: dict[str, Any] | None) -> str | No
     )
 
 
+def append_status_overview_markdown(
+    lines: list[str],
+    payload: dict[str, Any],
+) -> None:
+    lines.extend(
+        [
+            "# LoopX Status",
+            "",
+            f"- ok: `{payload.get('ok')}`",
+            f"- registry: `{payload.get('registry')}`",
+            f"- runtime_root: `{payload.get('runtime_root')}`",
+            f"- goals: `{payload.get('goal_count')}`",
+            f"- runs: `{payload.get('run_count')}`",
+        ]
+    )
+
+    status_contract = (
+        payload.get("status_contract")
+        if isinstance(payload.get("status_contract"), dict)
+        else {}
+    )
+    if status_contract:
+        lines.append(
+            "- status_contract: "
+            f"schema_version={status_contract.get('schema_version')}, "
+            f"minimum_dashboard_schema_version={status_contract.get('minimum_dashboard_schema_version')}, "
+            f"producer={status_contract.get('producer')}"
+        )
+    if payload.get("goal_filter"):
+        lines.append(f"- goal_filter: `{payload.get('goal_filter')}`")
+
+    contract = payload.get("contract") if isinstance(payload.get("contract"), dict) else {}
+    summary = contract.get("summary") if isinstance(contract.get("summary"), dict) else {}
+    lines.append(
+        "- contract: "
+        f"ok={contract.get('ok')}, "
+        f"errors={summary.get('errors')}, "
+        f"warnings={summary.get('warnings')}, "
+        f"checks={summary.get('checks')}"
+    )
+    contract_errors = (
+        payload.get("contract_errors") if isinstance(payload.get("contract_errors"), list) else []
+    )
+    contract_warnings = (
+        payload.get("contract_warnings")
+        if isinstance(payload.get("contract_warnings"), list)
+        else []
+    )
+    if contract_errors or contract_warnings:
+        lines.extend(["", "## Status Contract Signals"])
+        for item in contract_errors:
+            lines.append(f"- error: {item}")
+        if payload.get("contract_errors_truncated"):
+            lines.append(
+                f"- contract_errors_truncated: total={payload.get('contract_errors_total_count')}"
+            )
+        for item in contract_warnings:
+            lines.append(f"- warning: {item}")
+        if payload.get("contract_warnings_truncated"):
+            lines.append(
+                f"- contract_warnings_truncated: total={payload.get('contract_warnings_total_count')}"
+            )
+
+
 def append_global_registry_summary_markdown(
     lines: list[str],
     global_registry: dict[str, Any],

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -326,6 +326,7 @@ from .presentation.renderers.status_markdown import (
     append_promotion_gate_markdown as _append_promotion_gate_markdown,
     append_promotion_readiness_summary_markdown as _append_promotion_readiness_summary_markdown,
     append_run_history_markdown as _append_run_history_markdown,
+    append_status_overview_markdown as _append_status_overview_markdown,
     append_usage_summary_markdown as _append_usage_summary_markdown,
     attention_queue_goal_todo_scope_suffix as _attention_queue_goal_todo_scope_suffix,
     authority_registry_markdown_summary as _authority_registry_markdown_summary,
@@ -7174,60 +7175,9 @@ def collect_status(
 
 
 def render_status_markdown(payload: dict[str, Any]) -> str:
-    lines = [
-        "# LoopX Status",
-        "",
-        f"- ok: `{payload.get('ok')}`",
-        f"- registry: `{payload.get('registry')}`",
-        f"- runtime_root: `{payload.get('runtime_root')}`",
-        f"- goals: `{payload.get('goal_count')}`",
-        f"- runs: `{payload.get('run_count')}`",
-    ]
-
-    status_contract = (
-        payload.get("status_contract")
-        if isinstance(payload.get("status_contract"), dict)
-        else {}
-    )
-    if status_contract:
-        lines.append(
-            "- status_contract: "
-            f"schema_version={status_contract.get('schema_version')}, "
-            f"minimum_dashboard_schema_version={status_contract.get('minimum_dashboard_schema_version')}, "
-            f"producer={status_contract.get('producer')}"
-        )
-    if payload.get("goal_filter"):
-        lines.append(f"- goal_filter: `{payload.get('goal_filter')}`")
-
+    lines: list[str] = []
+    _append_status_overview_markdown(lines, payload)
     contract = payload.get("contract") if isinstance(payload.get("contract"), dict) else {}
-    summary = contract.get("summary") if isinstance(contract.get("summary"), dict) else {}
-    lines.append(
-        "- contract: "
-        f"ok={contract.get('ok')}, "
-        f"errors={summary.get('errors')}, "
-        f"warnings={summary.get('warnings')}, "
-        f"checks={summary.get('checks')}"
-    )
-    contract_errors = (
-        payload.get("contract_errors") if isinstance(payload.get("contract_errors"), list) else []
-    )
-    contract_warnings = (
-        payload.get("contract_warnings") if isinstance(payload.get("contract_warnings"), list) else []
-    )
-    if contract_errors or contract_warnings:
-        lines.extend(["", "## Status Contract Signals"])
-        for item in contract_errors:
-            lines.append(f"- error: {item}")
-        if payload.get("contract_errors_truncated"):
-            lines.append(
-                f"- contract_errors_truncated: total={payload.get('contract_errors_total_count')}"
-            )
-        for item in contract_warnings:
-            lines.append(f"- warning: {item}")
-        if payload.get("contract_warnings_truncated"):
-            lines.append(
-                f"- contract_warnings_truncated: total={payload.get('contract_warnings_total_count')}"
-            )
 
     global_registry = payload.get("global_registry") if isinstance(payload.get("global_registry"), dict) else {}
     _append_global_registry_summary_markdown(lines, global_registry)


### PR DESCRIPTION
## Summary
- Extract the status markdown overview/header and contract-signal rendering into the presentation renderer seam.
- Keep `render_status_markdown` focused on orchestration while preserving contract/errors/warnings/check rendering.
- Add a focused status overview smoke for the public markdown contract.

## Validation
- `python3 -m py_compile loopx/status.py loopx/presentation/renderers/status_markdown.py examples/control_plane/status-overview-markdown-smoke.py`
- `python3 examples/control_plane/status-overview-markdown-smoke.py`
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `python3 examples/benchmark-run-v0-status-projection-smoke.py`
- `python3 examples/project/next-action-projection-contract-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `git diff --check`
- `loopx --format json check --scan-path loopx/status.py --scan-path loopx/presentation/renderers/status_markdown.py --scan-path examples/control_plane/status-overview-markdown-smoke.py`
- `loopx canary premerge --from-git-diff`