### PR TITLE
Refactor status contract detail markdown

### DIFF
--- a/examples/control_plane/status-overview-markdown-smoke.py
+++ b/examples/control_plane/status-overview-markdown-smoke.py
@@ -98,12 +98,26 @@ def assert_overview(markdown: str) -> None:
     assert "- contract_warnings_truncated: total=3" in markdown, markdown
 
 
+def assert_contract_details(markdown: str) -> None:
+    assert "## Errors" in markdown, markdown
+    assert "- registry goals checked: 2" in markdown, markdown
+    assert "## Warnings" in markdown, markdown
+    assert "- public boundary scan clean: 0 files" in markdown, markdown
+    assert "## Checks" in markdown, markdown
+    assert "- status contract emitted" in markdown, markdown
+
+
 def main() -> int:
     payload = overview_payload()
     lines: list[str] = []
     append_status_overview_markdown(lines, payload)
-    assert_overview("\n".join(lines))
-    assert_overview(render_status_markdown(payload))
+    overview_markdown = "\n".join(lines)
+    assert_overview(overview_markdown)
+    assert "## Errors" not in overview_markdown, overview_markdown
+
+    full_markdown = render_status_markdown(payload)
+    assert_overview(full_markdown)
+    assert_contract_details(full_markdown)
     print("status-overview-markdown-smoke ok")
     return 0
 

--- a/loopx/presentation/renderers/status_markdown.py
+++ b/loopx/presentation/renderers/status_markdown.py
@@ -111,6 +111,17 @@ def append_status_overview_markdown(
             )
 
 
+def append_status_contract_detail_sections_markdown(
+    lines: list[str],
+    contract: dict[str, Any],
+) -> None:
+    for title, key in (("Errors", "errors"), ("Warnings", "warnings"), ("Checks", "checks")):
+        entries = contract.get(key) if isinstance(contract.get(key), list) else []
+        if entries:
+            lines.extend(["", f"## {title}"])
+            lines.extend(f"- {entry}" for entry in entries)
+
+
 def append_global_registry_summary_markdown(
     lines: list[str],
     global_registry: dict[str, Any],

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -326,6 +326,7 @@ from .presentation.renderers.status_markdown import (
     append_promotion_gate_markdown as _append_promotion_gate_markdown,
     append_promotion_readiness_summary_markdown as _append_promotion_readiness_summary_markdown,
     append_run_history_markdown as _append_run_history_markdown,
+    append_status_contract_detail_sections_markdown as _append_status_contract_detail_sections_markdown,
     append_status_overview_markdown as _append_status_overview_markdown,
     append_usage_summary_markdown as _append_usage_summary_markdown,
     attention_queue_goal_todo_scope_suffix as _attention_queue_goal_todo_scope_suffix,
@@ -7247,11 +7248,7 @@ def render_status_markdown(payload: dict[str, Any]) -> str:
     run_history = payload.get("run_history") if isinstance(payload.get("run_history"), dict) else {}
     _append_run_history_markdown(lines, run_history)
 
-    for title, key in (("Errors", "errors"), ("Warnings", "warnings"), ("Checks", "checks")):
-        entries = contract.get(key) if isinstance(contract.get(key), list) else []
-        if entries:
-            lines.extend(["", f"## {title}"])
-            lines.extend(f"- {entry}" for entry in entries)
+    _append_status_contract_detail_sections_markdown(lines, contract)
 
     _append_global_registry_findings_markdown(lines, global_registry)
 


### PR DESCRIPTION
## Summary
- Move the remaining status markdown contract detail sections (Errors, Warnings, Checks) into the presentation renderer.
- Keep `render_status_markdown` focused on orchestration after the overview seam extraction.
- Extend the focused overview smoke to prove full status markdown still emits contract detail sections while the overview helper does not.

## Validation
- `python3 -m py_compile loopx/status.py loopx/presentation/renderers/status_markdown.py examples/control_plane/status-overview-markdown-smoke.py`
- `python3 examples/control_plane/status-overview-markdown-smoke.py`
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `python3 examples/benchmark-run-v0-status-projection-smoke.py`
- `python3 examples/project/next-action-projection-contract-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `git diff --check`
- `loopx --format json check --scan-path loopx/status.py --scan-path loopx/presentation/renderers/status_markdown.py --scan-path examples/control_plane/status-overview-markdown-smoke.py`
- `loopx canary premerge --from-git-diff`