### PR TITLE
Refactor shared markdown presentation primitives

### DIFF
--- a/examples/control_plane/presentation-markdown-primitives-smoke.py
+++ b/examples/control_plane/presentation-markdown-primitives-smoke.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Smoke-test shared Markdown presentation primitives across CLI surfaces."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.quota.markdown import (  # noqa: E402
+    render_quota_markdown,
+    render_quota_should_run_markdown,
+)
+from loopx.diagnose import render_diagnosis_markdown  # noqa: E402
+from loopx.history import render_history_markdown  # noqa: E402
+from loopx.presentation.markdown import as_dict, as_list, markdown_scalar  # noqa: E402
+from loopx.presentation.renderers.status_markdown import (  # noqa: E402
+    append_attention_queue_item_header_markdown,
+)
+from loopx.slash_commands import render_slash_command_catalog_markdown  # noqa: E402
+
+
+RAW_TEXT = "alpha|beta\nnext"
+ESCAPED_TEXT = "alpha\\|beta next"
+
+
+def assert_escaped(label: str, markdown: str) -> None:
+    assert ESCAPED_TEXT in markdown, (label, markdown)
+    assert "alpha|beta" not in markdown, (label, markdown)
+    assert "alpha|beta\nnext" not in markdown, (label, markdown)
+
+
+def status_markdown() -> str:
+    lines: list[str] = []
+    append_attention_queue_item_header_markdown(
+        lines,
+        {
+            "goal_id": "presentation-fixture",
+            "status": "active",
+            "lifecycle_phase": "running",
+            "waiting_on": "codex",
+            "severity": "normal",
+            "source": "fixture",
+            "recommended_action": RAW_TEXT,
+        },
+    )
+    return "\n".join(lines)
+
+
+def quota_plan_markdown() -> str:
+    return render_quota_markdown(
+        {
+            "ok": True,
+            "registry": "/tmp/registry.json",
+            "runtime_root": "/tmp/runtime",
+            "goal_count": 1,
+            "run_count": 0,
+            "mode": "plan",
+            "summary": {
+                "registered_goals": 1,
+                "health_blockers": 0,
+                "states": {},
+            },
+            "groups": {
+                "eligible": [
+                    {
+                        "goal_id": "presentation-fixture",
+                        "waiting_on": "codex",
+                        "status": "active",
+                        "lifecycle_phase": "running",
+                        "quota": {},
+                        "recommended_action": RAW_TEXT,
+                    }
+                ]
+            },
+        }
+    )
+
+
+def quota_should_run_markdown() -> str:
+    return render_quota_should_run_markdown(
+        {
+            "ok": True,
+            "goal_id": "presentation-fixture",
+            "decision": "run",
+            "should_run": True,
+            "normal_delivery_allowed": True,
+            "recovery_delivery_allowed": False,
+            "self_repair_allowed": False,
+            "effective_action": "normal_run",
+            "actionable_by_codex": True,
+            "state": "eligible",
+            "waiting_on": "codex",
+            "status": "active",
+            "agent_lane_next_action": {
+                "todo_id": "todo_alpha",
+                "selected_by": "current_agent_claimed_todo",
+                "confidence": 1.0,
+                "text": RAW_TEXT,
+            },
+        }
+    )
+
+
+def diagnosis_markdown() -> str:
+    return render_diagnosis_markdown(
+        {
+            "ok": True,
+            "packet_kind": "agent_reasoning_evidence_packet",
+            "agent_must_reason": True,
+            "registry": "/tmp/registry.json",
+            "runtime_root": "/tmp/runtime",
+            "selected_goal_id": "presentation-fixture",
+            "goal_count": 1,
+            "goal_packet_count": 1,
+            "run_count": 0,
+            "selected": {
+                "machine_signal": "agent_work_attention",
+                "status": "active",
+                "waiting_on": "codex",
+                "severity": "normal",
+                "recommended_action": RAW_TEXT,
+                "user_question": RAW_TEXT,
+                "todo_evidence": {
+                    "user_open_count": 0,
+                    "agent_open_count": 1,
+                    "first_agent_todo": RAW_TEXT,
+                },
+            },
+            "status_summary": {},
+            "goals": [],
+        }
+    )
+
+
+def history_markdown() -> str:
+    return render_history_markdown(
+        {
+            "ok": True,
+            "runtime_root": "/tmp/runtime",
+            "registry": "/tmp/registry.json",
+            "goal_filter": "presentation-fixture",
+            "goal_count": 1,
+            "run_count": 1,
+            "runs": [
+                {
+                    "generated_at": "2026-01-01T00:00:00+00:00",
+                    "goal_id": "presentation-fixture",
+                    "classification": "fixture",
+                    "json_exists": True,
+                    "markdown_exists": True,
+                    "recommended_action": RAW_TEXT,
+                }
+            ],
+            "goals": [],
+        }
+    )
+
+
+def slash_command_markdown() -> str:
+    return render_slash_command_catalog_markdown(
+        {
+            "ok": True,
+            "onboarding": {"suggested_user_note": ""},
+            "commands": [
+                {
+                    "command": "/loopx-fixture",
+                    "scope": "project",
+                    "intent": RAW_TEXT,
+                    "mutation_policy": "read-only",
+                    "cli_reference": "loopx fixture",
+                }
+            ],
+        }
+    )
+
+
+def main() -> int:
+    assert as_dict({"ok": True}) == {"ok": True}
+    assert as_dict(["not", "a", "dict"]) == {}
+    assert as_list(["item"]) == ["item"]
+    assert as_list({"not": "a list"}) == []
+    assert markdown_scalar(RAW_TEXT) == ESCAPED_TEXT
+
+    surfaces = {
+        "status": status_markdown(),
+        "quota_plan": quota_plan_markdown(),
+        "quota_should_run": quota_should_run_markdown(),
+        "diagnose": diagnosis_markdown(),
+        "history": history_markdown(),
+        "slash_commands": slash_command_markdown(),
+    }
+    for label, markdown in surfaces.items():
+        assert_escaped(label, markdown)
+    print("presentation-markdown-primitives-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/control_plane/quota/markdown.py
+++ b/loopx/control_plane/quota/markdown.py
@@ -6,6 +6,7 @@ from ...control_plane import control_plane_policy_summary
 from ...execution_profile import execution_profile_summary
 from ...long_task_cadence import long_task_cadence_hint_summary
 from ...orchestration import orchestration_policy_summary
+from ...presentation.markdown import as_dict, as_list, markdown_scalar
 from ..runtime.decision_freshness import DECISION_FRESHNESS_WARNING_ITEM_LIMIT
 from .states import QUOTA_STATE_ORDER
 
@@ -21,8 +22,8 @@ def render_quota_markdown(payload: dict[str, Any]) -> str:
         f"- goals: `{payload.get('goal_count')}`",
         f"- runs: `{payload.get('run_count')}`",
     ]
-    summary = payload.get("summary") if isinstance(payload.get("summary"), dict) else {}
-    states = summary.get("states") if isinstance(summary.get("states"), dict) else {}
+    summary = as_dict(payload.get("summary"))
+    states = as_dict(summary.get("states"))
     state_text = ", ".join(f"{state}={states.get(state, 0)}" for state in QUOTA_STATE_ORDER)
     lines.append(
         "- summary: "
@@ -32,10 +33,10 @@ def render_quota_markdown(payload: dict[str, Any]) -> str:
     )
     lines.append(f"- states: {state_text}")
 
-    next_turn = payload.get("next_automatic_turn") if isinstance(payload.get("next_automatic_turn"), dict) else {}
+    next_turn = as_dict(payload.get("next_automatic_turn"))
     lines.extend(["", "## Next Automatic Turn"])
     if next_turn:
-        quota = next_turn.get("quota") if isinstance(next_turn.get("quota"), dict) else {}
+        quota = as_dict(next_turn.get("quota"))
         lines.append(
             "- "
             f"`{next_turn.get('goal_id')}` "
@@ -47,7 +48,7 @@ def render_quota_markdown(payload: dict[str, Any]) -> str:
     else:
         lines.append("- none")
 
-    health_items = payload.get("health_items") if isinstance(payload.get("health_items"), list) else []
+    health_items = as_list(payload.get("health_items"))
     if health_items:
         lines.extend(["", "## Health Items"])
         for item in health_items:
@@ -61,13 +62,13 @@ def render_quota_markdown(payload: dict[str, Any]) -> str:
                 f"action={item.get('recommended_action')}"
             )
 
-    groups = payload.get("groups") if isinstance(payload.get("groups"), dict) else {}
+    groups = as_dict(payload.get("groups"))
     lines.extend(["", "## Groups"])
     render_states = list(QUOTA_STATE_ORDER)
     if groups.get("unknown"):
         render_states.append("unknown")
     for state in render_states:
-        items = groups.get(state) if isinstance(groups.get(state), list) else []
+        items = as_list(groups.get(state))
         if payload.get("mode") == "plan" and not items:
             continue
         lines.extend(["", f"### {state}"])
@@ -77,8 +78,8 @@ def render_quota_markdown(payload: dict[str, Any]) -> str:
         for item in items:
             if not isinstance(item, dict):
                 continue
-            quota = item.get("quota") if isinstance(item.get("quota"), dict) else {}
-            action = str(item.get("recommended_action") or "").replace("|", "\\|")
+            quota = as_dict(item.get("quota"))
+            action = markdown_scalar(item.get("recommended_action") or "")
             lines.append(
                 "- "
                 f"`{item.get('goal_id')}`: "
@@ -94,7 +95,7 @@ def render_quota_markdown(payload: dict[str, Any]) -> str:
                 lines.append(f"  - reason: {reason}")
             if action:
                 lines.append(f"  - action: {action}")
-            control_plane = item.get("control_plane") if isinstance(item.get("control_plane"), dict) else None
+            control_plane = as_dict(item.get("control_plane"))
             if control_plane:
                 lines.append(f"  - control_plane: {control_plane_policy_summary(control_plane)}")
             if item.get("agent_command"):
@@ -105,9 +106,9 @@ def render_quota_markdown(payload: dict[str, Any]) -> str:
 
 
 def render_quota_scheduler_ack_markdown(payload: dict[str, Any]) -> str:
-    event = payload.get("scheduler_ack_event") if isinstance(payload.get("scheduler_ack_event"), dict) else {}
-    state = event.get("scheduler_state") if isinstance(event.get("scheduler_state"), dict) else {}
-    before = event.get("before") if isinstance(event.get("before"), dict) else {}
+    event = as_dict(payload.get("scheduler_ack_event"))
+    state = as_dict(event.get("scheduler_state"))
+    before = as_dict(event.get("before"))
     lines = [
         "# LoopX Quota Scheduler Ack",
         "",
@@ -135,7 +136,7 @@ def render_quota_scheduler_ack_markdown(payload: dict[str, Any]) -> str:
 
 
 def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
-    quota = payload.get("quota") if isinstance(payload.get("quota"), dict) else {}
+    quota = as_dict(payload.get("quota"))
     lines = [
         "# LoopX Quota Should Run",
         "",
@@ -154,11 +155,7 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
     ]
     if payload.get("project_asset_source"):
         lines.append(f"- project_asset_source: {payload.get('project_asset_source')}")
-    agent_identity = (
-        payload.get("agent_identity")
-        if isinstance(payload.get("agent_identity"), dict)
-        else {}
-    )
+    agent_identity = as_dict(payload.get("agent_identity"))
     if agent_identity:
         lines.append(
             "- agent_identity: "
@@ -168,16 +165,12 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             f"handoff_agent={agent_identity.get('handoff_agent')}"
         )
     if payload.get("active_state_next_action"):
-        lines.append(f"- active_state_next_action: {payload.get('active_state_next_action')}")
+        lines.append(f"- active_state_next_action: {markdown_scalar(payload.get('active_state_next_action'))}")
     if payload.get("latest_run_recommended_action"):
         lines.append(
-            f"- latest_run_recommended_action: {payload.get('latest_run_recommended_action')}"
+            f"- latest_run_recommended_action: {markdown_scalar(payload.get('latest_run_recommended_action'))}"
         )
-    agent_lane_next_action = (
-        payload.get("agent_lane_next_action")
-        if isinstance(payload.get("agent_lane_next_action"), dict)
-        else {}
-    )
+    agent_lane_next_action = as_dict(payload.get("agent_lane_next_action"))
     if agent_lane_next_action:
         lines.append(
             "- agent_lane_next_action: "
@@ -186,12 +179,10 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             f"confidence={agent_lane_next_action.get('confidence')}"
         )
         if agent_lane_next_action.get("text"):
-            lines.append(f"- agent_lane_next_action_text: {agent_lane_next_action.get('text')}")
-    agent_lane_frontier_hint = (
-        payload.get("agent_lane_frontier_hint")
-        if isinstance(payload.get("agent_lane_frontier_hint"), dict)
-        else {}
-    )
+            lines.append(
+                f"- agent_lane_next_action_text: {markdown_scalar(agent_lane_next_action.get('text'))}"
+            )
+    agent_lane_frontier_hint = as_dict(payload.get("agent_lane_frontier_hint"))
     if agent_lane_frontier_hint:
         lines.append(
             "- agent_lane_frontier_hint: "
@@ -200,17 +191,9 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             f"reason_code={agent_lane_frontier_hint.get('reason_code')} "
             f"target_todo_id={agent_lane_frontier_hint.get('target_todo_id')}"
         )
-    goal_route_hint = (
-        payload.get("goal_route_hint")
-        if isinstance(payload.get("goal_route_hint"), dict)
-        else {}
-    )
+    goal_route_hint = as_dict(payload.get("goal_route_hint"))
     if goal_route_hint:
-        counts = (
-            goal_route_hint.get("counts")
-            if isinstance(goal_route_hint.get("counts"), dict)
-            else {}
-        )
+        counts = as_dict(goal_route_hint.get("counts"))
         lines.append(
             "- goal_route_hint: "
             f"decision={goal_route_hint.get('route_decision')} "
@@ -218,22 +201,14 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             f"preserves_goal_next_action={goal_route_hint.get('preserves_goal_next_action')} "
             f"other_agent_claimed_advancement_count={counts.get('other_agent_claimed_advancement_count')}"
         )
-        current_action = (
-            goal_route_hint.get("current_agent_next_action")
-            if isinstance(goal_route_hint.get("current_agent_next_action"), dict)
-            else {}
-        )
+        current_action = as_dict(goal_route_hint.get("current_agent_next_action"))
         if current_action:
             lines.append(
                 "- goal_route_hint_current_action: "
                 f"todo_id={current_action.get('todo_id')} "
                 f"selected_by={current_action.get('selected_by')}"
             )
-    agent_scope_frontier = (
-        payload.get("agent_scope_frontier")
-        if isinstance(payload.get("agent_scope_frontier"), dict)
-        else {}
-    )
+    agent_scope_frontier = as_dict(payload.get("agent_scope_frontier"))
     if agent_scope_frontier:
         lines.append(
             "- agent_scope_frontier: "
@@ -242,12 +217,10 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             f"quiet_noop_allowed={agent_scope_frontier.get('quiet_noop_allowed')}"
         )
         if agent_scope_frontier.get("reason"):
-            lines.append(f"- agent_scope_frontier_reason: {agent_scope_frontier.get('reason')}")
-        deferred_resume_candidates = (
-            agent_scope_frontier.get("deferred_resume_candidates")
-            if isinstance(agent_scope_frontier.get("deferred_resume_candidates"), list)
-            else []
-        )
+            lines.append(
+                f"- agent_scope_frontier_reason: {markdown_scalar(agent_scope_frontier.get('reason'))}"
+            )
+        deferred_resume_candidates = as_list(agent_scope_frontier.get("deferred_resume_candidates"))
         if deferred_resume_candidates:
             first_candidate = (
                 deferred_resume_candidates[0]
@@ -259,10 +232,8 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
                 f"`{len(deferred_resume_candidates)}` "
                 f"top_todo_id={first_candidate.get('todo_id')}"
             )
-        route_continuation_candidates = (
+        route_continuation_candidates = as_list(
             agent_scope_frontier.get("route_continuation_replan_candidates")
-            if isinstance(agent_scope_frontier.get("route_continuation_replan_candidates"), list)
-            else []
         )
         if route_continuation_candidates:
             first_candidate = (
@@ -276,27 +247,11 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
                 f"top_todo_id={first_candidate.get('todo_id')} "
                 f"route={first_candidate.get('route_id') or first_candidate.get('route_key') or ''}"
             )
-    goal_frontier = (
-        payload.get("goal_frontier_projection")
-        if isinstance(payload.get("goal_frontier_projection"), dict)
-        else {}
-    )
+    goal_frontier = as_dict(payload.get("goal_frontier_projection"))
     if goal_frontier:
-        remaining = (
-            goal_frontier.get("remaining_advancement_frontier")
-            if isinstance(goal_frontier.get("remaining_advancement_frontier"), dict)
-            else {}
-        )
-        deferred_successors = (
-            goal_frontier.get("deferred_successors")
-            if isinstance(goal_frontier.get("deferred_successors"), dict)
-            else {}
-        )
-        acceptance_gaps = (
-            goal_frontier.get("acceptance_gaps")
-            if isinstance(goal_frontier.get("acceptance_gaps"), list)
-            else []
-        )
+        remaining = as_dict(goal_frontier.get("remaining_advancement_frontier"))
+        deferred_successors = as_dict(goal_frontier.get("deferred_successors"))
+        acceptance_gaps = as_list(goal_frontier.get("acceptance_gaps"))
         lines.append(
             "- goal_frontier_projection: "
             f"replan_required={goal_frontier.get('replan_required')} "
@@ -306,11 +261,7 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             f"deferred_ready={deferred_successors.get('ready_count')} "
             f"acceptance_gaps={len(acceptance_gaps)}"
         )
-        vision_audit = (
-            goal_frontier.get("vision_continuation_audit")
-            if isinstance(goal_frontier.get("vision_continuation_audit"), dict)
-            else {}
-        )
+        vision_audit = as_dict(goal_frontier.get("vision_continuation_audit"))
         if vision_audit:
             lines.append(
                 "- vision_continuation_audit: "
@@ -318,11 +269,7 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
                 f"decision={vision_audit.get('decision')} "
                 f"trigger_count={vision_audit.get('trigger_count')}"
             )
-            vision_gap_judge = (
-                vision_audit.get("vision_gap_judge")
-                if isinstance(vision_audit.get("vision_gap_judge"), dict)
-                else {}
-            )
+            vision_gap_judge = as_dict(vision_audit.get("vision_gap_judge"))
             if vision_gap_judge:
                 lines.append(
                     "- vision_gap_judge: "

--- a/loopx/diagnose.py
+++ b/loopx/diagnose.py
@@ -4,6 +4,9 @@ import shlex
 from pathlib import Path
 from typing import Any
 
+from .presentation.markdown import as_dict as _as_dict
+from .presentation.markdown import as_list as _as_list
+from .presentation.markdown import markdown_scalar
 from .quota import build_quota_should_run
 from .status import collect_status
 
@@ -29,14 +32,6 @@ AGENT_REASONING_CHECKLIST = [
     "判断是否应先自修复：state_projection_gap、boundary_projection_gap、stale action、todo 投影缺口优先于普通 delivery。",
     "向用户汇报时给出自己的结论，不要把 machine_signals 当成最终裁决；引用具体 evidence 字段说明理由。",
 ]
-
-
-def _as_dict(value: Any) -> dict[str, Any]:
-    return value if isinstance(value, dict) else {}
-
-
-def _as_list(value: Any) -> list[Any]:
-    return value if isinstance(value, list) else []
 
 
 def _compact_text_signals(value: Any, *, limit: int = STATUS_CONTRACT_SIGNAL_LIMIT) -> dict[str, Any]:
@@ -499,15 +494,15 @@ def render_diagnosis_markdown(payload: dict[str, Any]) -> str:
         f"- status: `{selected.get('status')}`",
         f"- waiting_on: `{selected.get('waiting_on')}`",
         f"- severity: `{selected.get('severity')}`",
-        f"- recommended_action: {selected.get('recommended_action')}",
-        f"- user_question: {selected.get('user_question')}",
+        f"- recommended_action: {markdown_scalar(selected.get('recommended_action'))}",
+        f"- user_question: {markdown_scalar(selected.get('user_question'))}",
         f"- user_todo_open_count: `{todo_evidence.get('user_open_count')}`",
         f"- agent_todo_open_count: `{todo_evidence.get('agent_open_count')}`",
     ]
     if todo_evidence.get("first_user_todo"):
-        lines.append(f"- first_user_todo: {todo_evidence.get('first_user_todo')}")
+        lines.append(f"- first_user_todo: {markdown_scalar(todo_evidence.get('first_user_todo'))}")
     if todo_evidence.get("first_agent_todo"):
-        lines.append(f"- first_agent_todo: {todo_evidence.get('first_agent_todo')}")
+        lines.append(f"- first_agent_todo: {markdown_scalar(todo_evidence.get('first_agent_todo'))}")
     if quota:
         lines.extend(
             [
@@ -518,7 +513,7 @@ def render_diagnosis_markdown(payload: dict[str, Any]) -> str:
                 f"- normal_delivery_allowed: `{quota.get('normal_delivery_allowed')}`",
                 f"- self_repair_allowed: `{quota.get('self_repair_allowed')}`",
                 f"- safe_bypass_allowed: `{quota.get('safe_bypass_allowed')}`",
-                f"- quota_reason: {quota.get('reason')}",
+                f"- quota_reason: {markdown_scalar(quota.get('reason'))}",
             ]
         )
         goal_frontier_line = _goal_frontier_projection_line(
@@ -535,13 +530,13 @@ def render_diagnosis_markdown(payload: dict[str, Any]) -> str:
     if contract_errors or contract_warnings:
         lines.extend(["", "## Status Contract Signals", ""])
         for item in contract_errors:
-            lines.append(f"- contract_error: {item}")
+            lines.append(f"- contract_error: {markdown_scalar(item)}")
         if status_summary.get("contract_errors_truncated"):
             lines.append(
                 f"- contract_errors_truncated: total={status_summary.get('contract_errors_total_count')}"
             )
         for item in contract_warnings:
-            lines.append(f"- contract_warning: {item}")
+            lines.append(f"- contract_warning: {markdown_scalar(item)}")
         if status_summary.get("contract_warnings_truncated"):
             lines.append(
                 f"- contract_warnings_truncated: total={status_summary.get('contract_warnings_total_count')}"
@@ -551,7 +546,7 @@ def render_diagnosis_markdown(payload: dict[str, Any]) -> str:
     if checklist:
         lines.extend(["", "## Agent Reasoning Checklist", ""])
         for item in checklist:
-            lines.append(f"- {item}")
+            lines.append(f"- {markdown_scalar(item)}")
 
     commands = _as_list(selected.get("agent_commands"))
     if commands:

--- a/loopx/history.py
+++ b/loopx/history.py
@@ -20,6 +20,7 @@ from .control_plane.work_items.delivery_outcome import require_delivery_outcome
 from .doctor import PROMOTION_READINESS_CLASSIFICATIONS
 from .execution_profile import compact_execution_profile
 from .paths import resolve_runtime_root
+from .presentation.markdown import markdown_scalar
 from .quota import (
     QUOTA_MONITOR_POLL_CLASSIFICATION,
     QUOTA_SLOT_SPENT_CLASSIFICATION,
@@ -1000,7 +1001,7 @@ def render_index_duplicate_repair_markdown(payload: dict[str, Any]) -> str:
         "| --- | --- | --- | --- | --- | --- | --- |",
     ]
     for group in payload.get("groups") or []:
-        reason = str(group.get("reason") or "").replace("|", "\\|")
+        reason = markdown_scalar(group.get("reason"))
         lines.append(
             "| "
             f"`{group.get('goal_id')}` | "
@@ -1031,7 +1032,7 @@ def render_history_markdown(payload: dict[str, Any]) -> str:
         "| --- | --- | --- | --- | --- |",
     ]
     for run in payload.get("runs") or []:
-        action = str(run.get("recommended_action") or "").replace("|", "\\|")
+        action = markdown_scalar(run.get("recommended_action"))
         lines.append(
             "| "
             f"`{run.get('generated_at')}` | "
@@ -1076,7 +1077,7 @@ def render_index_duplicate_inspection_markdown(payload: dict[str, Any]) -> str:
     ]
     for group in payload.get("groups") or []:
         classifications = ", ".join(str(item) for item in group.get("classifications") or [])
-        hint = str(group.get("repair_hint") or "").replace("|", "\\|")
+        hint = markdown_scalar(group.get("repair_hint"))
         lines.append(
             "| "
             f"`{group.get('goal_id')}` | "

--- a/loopx/presentation/README.md
+++ b/loopx/presentation/README.md
@@ -11,6 +11,10 @@ surfaces. It must not become the control-plane source of truth.
 | `sinks/` | External display sinks such as Lark/Feishu tables and cards. | Connector login authority, private reads, or production actions. |
 | `projections/` | Future display-specific intermediate read models that join or reshape public-safe LoopX evidence for surfaces. | Persistent control state or benchmark scoring. |
 
+Shared Markdown primitives such as scalar escaping and payload shape guards live
+in `loopx.presentation.markdown`. Renderers should reuse those helpers instead
+of defining local table-cell or scalar escaping rules.
+
 Python code that starts as a user-visible capability may keep a thin facade
 under `loopx.capabilities.*`, but the reusable display implementation should
 live here.

--- a/loopx/presentation/markdown.py
+++ b/loopx/presentation/markdown.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def markdown_scalar(value: Any) -> str:
+    return str(value or "").replace("\r", " ").replace("\n", " ").replace("|", "\\|").strip()

--- a/loopx/presentation/renderers/status_markdown.py
+++ b/loopx/presentation/renderers/status_markdown.py
@@ -7,15 +7,12 @@ from ...control_plane import control_plane_policy_summary
 from ...execution_profile import execution_profile_summary
 from ...long_task_cadence import long_task_cadence_hint_summary
 from ...orchestration import orchestration_policy_summary
-
-
-def markdown_scalar(value: Any) -> str:
-    return str(value).replace("\n", " ").replace("|", "\\|").strip()
+from ..markdown import as_dict, as_list, markdown_scalar
 
 
 def goals_by_id(payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
-    run_history = payload.get("run_history") if isinstance(payload.get("run_history"), dict) else {}
-    goals = run_history.get("goals") if isinstance(run_history.get("goals"), list) else []
+    run_history = as_dict(payload.get("run_history"))
+    goals = as_list(run_history.get("goals"))
     result: dict[str, dict[str, Any]] = {}
     for goal in goals:
         if not isinstance(goal, dict):
@@ -27,8 +24,8 @@ def goals_by_id(payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
 
 
 def authority_registry_markdown_summary(goal: dict[str, Any] | None) -> str | None:
-    registry = goal.get("authority_registry") if isinstance(goal, dict) else None
-    if not isinstance(registry, dict) or not registry.get("declared"):
+    registry = as_dict(as_dict(goal).get("authority_registry"))
+    if not registry.get("declared"):
         return None
     materials = int(registry.get("project_material_count") or 0)
     topics = int(registry.get("topic_authority_count") or 0)
@@ -63,11 +60,7 @@ def append_status_overview_markdown(
         ]
     )
 
-    status_contract = (
-        payload.get("status_contract")
-        if isinstance(payload.get("status_contract"), dict)
-        else {}
-    )
+    status_contract = as_dict(payload.get("status_contract"))
     if status_contract:
         lines.append(
             "- status_contract: "
@@ -78,8 +71,8 @@ def append_status_overview_markdown(
     if payload.get("goal_filter"):
         lines.append(f"- goal_filter: `{payload.get('goal_filter')}`")
 
-    contract = payload.get("contract") if isinstance(payload.get("contract"), dict) else {}
-    summary = contract.get("summary") if isinstance(contract.get("summary"), dict) else {}
+    contract = as_dict(payload.get("contract"))
+    summary = as_dict(contract.get("summary"))
     lines.append(
         "- contract: "
         f"ok={contract.get('ok')}, "
@@ -87,14 +80,8 @@ def append_status_overview_markdown(
         f"warnings={summary.get('warnings')}, "
         f"checks={summary.get('checks')}"
     )
-    contract_errors = (
-        payload.get("contract_errors") if isinstance(payload.get("contract_errors"), list) else []
-    )
-    contract_warnings = (
-        payload.get("contract_warnings")
-        if isinstance(payload.get("contract_warnings"), list)
-        else []
-    )
+    contract_errors = as_list(payload.get("contract_errors"))
+    contract_warnings = as_list(payload.get("contract_warnings"))
     if contract_errors or contract_warnings:
         lines.extend(["", "## Status Contract Signals"])
         for item in contract_errors:
@@ -126,11 +113,7 @@ def append_global_registry_summary_markdown(
     lines: list[str],
     global_registry: dict[str, Any],
 ) -> None:
-    global_summary = (
-        global_registry.get("summary")
-        if isinstance(global_registry.get("summary"), dict)
-        else {}
-    )
+    global_summary = as_dict(global_registry.get("summary"))
     lines.extend(
         [
             "- global_registry: "
@@ -148,11 +131,7 @@ def append_global_registry_findings_markdown(
     lines: list[str],
     global_registry: dict[str, Any],
 ) -> None:
-    findings = (
-        global_registry.get("findings")
-        if isinstance(global_registry.get("findings"), list)
-        else []
-    )
+    findings = as_list(global_registry.get("findings"))
     if not findings:
         return
     lines.extend(["", "## Global Registry Findings"])
@@ -185,7 +164,7 @@ def append_human_reward_markdown(lines: list[str], goal_id: Any, reward: dict[st
     follow_up = reward.get("follow_up")
     if follow_up:
         lines.append(f"      - follow_up: {markdown_scalar(follow_up)}")
-    lesson = reward.get("lesson") if isinstance(reward.get("lesson"), dict) else {}
+    lesson = as_dict(reward.get("lesson"))
     if lesson:
         lines.append(
             "      - lesson: "
@@ -193,7 +172,7 @@ def append_human_reward_markdown(lines: list[str], goal_id: Any, reward: dict[st
             f"summary={markdown_scalar(lesson.get('summary') or '')}"
         )
         for field in ("avoid", "prefer"):
-            values = lesson.get(field) if isinstance(lesson.get(field), list) else []
+            values = as_list(lesson.get(field))
             if values:
                 lines.append(
                     f"        - lesson_{field}: "
@@ -970,7 +949,7 @@ def append_attention_queue_item_header_markdown(
     *,
     authority_summary: str | None = None,
 ) -> None:
-    action = str(item.get("recommended_action") or "").replace("|", "\\|")
+    action = markdown_scalar(item.get("recommended_action") or "")
     lines.append(
         "- "
         f"`{item.get('goal_id')}`: "

--- a/loopx/slash_commands.py
+++ b/loopx/slash_commands.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from .presentation.markdown import markdown_scalar
+
 
 SCHEMA_VERSION = "loopx_slash_command_catalog_v0"
 
@@ -211,7 +213,7 @@ def render_onboarding_slash_command_note(commands: list[dict[str, Any]], *, cli_
 
 
 def _markdown_table_cell(value: Any) -> str:
-    return str(value or "").replace("\n", " ").replace("|", "\\|")
+    return markdown_scalar(value)
 
 
 def render_slash_command_catalog_markdown(payload: dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary
- Add `loopx.presentation.markdown` as the shared home for Markdown scalar escaping and payload shape guards.
- Migrate status, quota, diagnose, history, and slash-command markdown renderers away from local duplicate escaping/dict/list guards.
- Add a cross-surface smoke that proves the same primitive protects status, quota, diagnose, history, and slash-command markdown output.

## Validation
- `python3 examples/control_plane/presentation-markdown-primitives-smoke.py`
- `python3 examples/control_plane/status-overview-markdown-smoke.py`
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 examples/control_plane/monitor-scheduler-contract-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 examples/control_plane/quota-contract-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `loopx canary premerge --from-git-diff` passed standard tier, 8 selected catalog canaries, 8 risk-profile smokes, and public-boundary check.

## Scale Note
This deliberately closes a complete presentation primitive group instead of another one-helper status tail extraction: the diff touches multiple renderer surfaces, removes duplicate guard code, and keeps the new abstraction limited to active call sites.
