### PR TITLE
Refactor shared markdown table primitives

### DIFF
--- a/examples/control_plane/presentation-markdown-primitives-smoke.py
+++ b/examples/control_plane/presentation-markdown-primitives-smoke.py
@@ -16,12 +16,26 @@ from loopx.control_plane.quota.markdown import (  # noqa: E402
     render_quota_should_run_markdown,
 )
 from loopx.diagnose import render_diagnosis_markdown  # noqa: E402
-from loopx.history import render_history_markdown  # noqa: E402
-from loopx.presentation.markdown import as_dict, as_list, markdown_scalar  # noqa: E402
+from loopx.history import (  # noqa: E402
+    render_history_markdown,
+    render_index_duplicate_inspection_markdown,
+    render_index_duplicate_repair_markdown,
+)
+from loopx.presentation.markdown import (  # noqa: E402
+    as_dict,
+    as_list,
+    markdown_code,
+    markdown_scalar,
+    markdown_table_row,
+    markdown_table_separator,
+)
 from loopx.presentation.renderers.status_markdown import (  # noqa: E402
     append_attention_queue_item_header_markdown,
 )
+from loopx.pr_review import render_pr_review_markdown  # noqa: E402
+from loopx.registry import render_registry_markdown  # noqa: E402
 from loopx.slash_commands import render_slash_command_catalog_markdown  # noqa: E402
+from loopx.summary_all import render_summary_all_markdown  # noqa: E402
 
 
 RAW_TEXT = "alpha|beta\nnext"
@@ -55,8 +69,8 @@ def quota_plan_markdown() -> str:
     return render_quota_markdown(
         {
             "ok": True,
-            "registry": "/tmp/registry.json",
-            "runtime_root": "/tmp/runtime",
+            "registry": "./fixtures/registry.json",
+            "runtime_root": "./fixtures/runtime",
             "goal_count": 1,
             "run_count": 0,
             "mode": "plan",
@@ -112,8 +126,8 @@ def diagnosis_markdown() -> str:
             "ok": True,
             "packet_kind": "agent_reasoning_evidence_packet",
             "agent_must_reason": True,
-            "registry": "/tmp/registry.json",
-            "runtime_root": "/tmp/runtime",
+            "registry": "./fixtures/registry.json",
+            "runtime_root": "./fixtures/runtime",
             "selected_goal_id": "presentation-fixture",
             "goal_count": 1,
             "goal_packet_count": 1,
@@ -141,8 +155,8 @@ def history_markdown() -> str:
     return render_history_markdown(
         {
             "ok": True,
-            "runtime_root": "/tmp/runtime",
-            "registry": "/tmp/registry.json",
+            "runtime_root": "./fixtures/runtime",
+            "registry": "./fixtures/registry.json",
             "goal_filter": "presentation-fixture",
             "goal_count": 1,
             "run_count": 1,
@@ -157,6 +171,92 @@ def history_markdown() -> str:
                 }
             ],
             "goals": [],
+        }
+    )
+
+
+def history_duplicate_repair_markdown() -> str:
+    return render_index_duplicate_repair_markdown(
+        {
+            "ok": True,
+            "dry_run": True,
+            "repaired": False,
+            "runtime_root": "./fixtures/runtime",
+            "registry": "./fixtures/registry.json",
+            "goal_filter": "presentation-fixture",
+            "checked_goal_count": 1,
+            "raw_index_records": 2,
+            "removed_row_count": 0,
+            "preserved_reward_overlay_rows": 0,
+            "preserved_structured_artifact_bundle_rows": 0,
+            "unrepaired_group_count": 1,
+            "truncated": False,
+            "groups": [
+                {
+                    "goal_id": "presentation-fixture",
+                    "generated_at": "2026-01-01T00:00:00+00:00",
+                    "action": "inspect",
+                    "repairable": True,
+                    "kept_line_numbers": [1],
+                    "removed_line_numbers": [],
+                    "reason": RAW_TEXT,
+                }
+            ],
+        }
+    )
+
+
+def history_duplicate_inspection_markdown() -> str:
+    return render_index_duplicate_inspection_markdown(
+        {
+            "ok": True,
+            "runtime_root": "./fixtures/runtime",
+            "registry": "./fixtures/registry.json",
+            "goal_filter": "presentation-fixture",
+            "checked_goal_count": 1,
+            "raw_index_records": 2,
+            "duplicate_group_count": 1,
+            "duplicate_row_count": 2,
+            "truncated": False,
+            "groups": [
+                {
+                    "goal_id": "presentation-fixture",
+                    "generated_at": "2026-01-01T00:00:00+00:00",
+                    "duplicate_kind": "same_action",
+                    "severity": "warning",
+                    "line_numbers": [1, 2],
+                    "classifications": ["fixture"],
+                    "repair_hint": RAW_TEXT,
+                }
+            ],
+        }
+    )
+
+
+def registry_markdown() -> str:
+    return render_registry_markdown(
+        {
+            "ok": True,
+            "registry": "./fixtures/registry.json",
+            "schema_version": "fixture",
+            "updated_at": "2026-01-01T00:00:00Z",
+            "common_runtime_root": "./fixtures/runtime",
+            "goal_count": 1,
+            "goals": [
+                {
+                    "id": "presentation-fixture",
+                    "role": "project",
+                    "parent_goal_id": "",
+                    "domain": "fixture",
+                    "status": "active",
+                    "repo_exists": True,
+                    "repo_goal_count": 1,
+                    "state_file_exists": True,
+                    "adapter_kind": "local",
+                    "adapter_status": "ok",
+                    "next_probe": RAW_TEXT,
+                }
+            ],
         }
     )
 
@@ -179,12 +279,50 @@ def slash_command_markdown() -> str:
     )
 
 
+def assert_malformed_payloads_use_shared_coercion() -> None:
+    pr_markdown = render_pr_review_markdown(
+        {
+            "ok": True,
+            "summary": {"headline": "fixture"},
+            "request": "not-a-dict",
+            "review_groups": "not-a-dict",
+            "review_sequence": "not-a-list",
+            "pull_requests": "not-a-list",
+        }
+    )
+    assert "## Unmerged PRs\n- none" in pr_markdown, pr_markdown
+    assert "## Combined Review Sequence\n- none" in pr_markdown, pr_markdown
+
+    summary_markdown = render_summary_all_markdown(
+        {
+            "ok": True,
+            "summary": {"headline": "fixture"},
+            "request": "not-a-dict",
+            "lanes": "not-a-list",
+            "gates": "not-a-list",
+            "recent_progress": "not-a-list",
+        }
+    )
+    assert "## Gates\n- none" in summary_markdown, summary_markdown
+
+
 def main() -> int:
     assert as_dict({"ok": True}) == {"ok": True}
     assert as_dict(["not", "a", "dict"]) == {}
     assert as_list(["item"]) == ["item"]
     assert as_list({"not": "a list"}) == []
     assert markdown_scalar(RAW_TEXT) == ESCAPED_TEXT
+    assert markdown_code(RAW_TEXT) == f"`{ESCAPED_TEXT}`"
+    assert markdown_code(None) == "``"
+    assert markdown_table_row([RAW_TEXT, markdown_code(RAW_TEXT)]) == f"| {ESCAPED_TEXT} | `{ESCAPED_TEXT}` |"
+    assert markdown_table_separator(2) == "| --- | --- |"
+    try:
+        markdown_table_separator(0)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("markdown_table_separator should reject zero columns")
+    assert_malformed_payloads_use_shared_coercion()
 
     surfaces = {
         "status": status_markdown(),
@@ -192,6 +330,9 @@ def main() -> int:
         "quota_should_run": quota_should_run_markdown(),
         "diagnose": diagnosis_markdown(),
         "history": history_markdown(),
+        "history_duplicate_repair": history_duplicate_repair_markdown(),
+        "history_duplicate_inspection": history_duplicate_inspection_markdown(),
+        "registry": registry_markdown(),
         "slash_commands": slash_command_markdown(),
     }
     for label, markdown in surfaces.items():

--- a/loopx/history.py
+++ b/loopx/history.py
@@ -20,7 +20,12 @@ from .control_plane.work_items.delivery_outcome import require_delivery_outcome
 from .doctor import PROMOTION_READINESS_CLASSIFICATIONS
 from .execution_profile import compact_execution_profile
 from .paths import resolve_runtime_root
-from .presentation.markdown import markdown_scalar
+from .presentation.markdown import (
+    markdown_code,
+    markdown_scalar,
+    markdown_table_row,
+    markdown_table_separator,
+)
 from .quota import (
     QUOTA_MONITOR_POLL_CLASSIFICATION,
     QUOTA_SLOT_SPENT_CLASSIFICATION,
@@ -997,20 +1002,24 @@ def render_index_duplicate_repair_markdown(payload: dict[str, Any]) -> str:
         f"- unrepaired_groups: `{payload.get('unrepaired_group_count')}`",
         f"- truncated: `{payload.get('truncated')}`",
         "",
-        "| goal | generated_at | action | repairable | kept | removed | reason |",
-        "| --- | --- | --- | --- | --- | --- | --- |",
+        markdown_table_row(
+            ["goal", "generated_at", "action", "repairable", "kept", "removed", "reason"]
+        ),
+        markdown_table_separator(7),
     ]
     for group in payload.get("groups") or []:
-        reason = markdown_scalar(group.get("reason"))
         lines.append(
-            "| "
-            f"`{group.get('goal_id')}` | "
-            f"`{group.get('generated_at')}` | "
-            f"`{group.get('action')}` | "
-            f"`{group.get('repairable')}` | "
-            f"`{group.get('kept_line_numbers')}` | "
-            f"`{group.get('removed_line_numbers')}` | "
-            f"{reason} |"
+            markdown_table_row(
+                [
+                    markdown_code(group.get("goal_id")),
+                    markdown_code(group.get("generated_at")),
+                    markdown_code(group.get("action")),
+                    markdown_code(group.get("repairable")),
+                    markdown_code(group.get("kept_line_numbers")),
+                    markdown_code(group.get("removed_line_numbers")),
+                    group.get("reason"),
+                ]
+            )
         )
     return "\n".join(lines)
 
@@ -1028,18 +1037,20 @@ def render_history_markdown(payload: dict[str, Any]) -> str:
         f"- goals: `{payload.get('goal_count')}`",
         f"- unique_runs: `{payload.get('run_count')}`",
         "",
-        "| generated_at | goal | classification | files | action |",
-        "| --- | --- | --- | --- | --- |",
+        markdown_table_row(["generated_at", "goal", "classification", "files", "action"]),
+        markdown_table_separator(5),
     ]
     for run in payload.get("runs") or []:
-        action = markdown_scalar(run.get("recommended_action"))
         lines.append(
-            "| "
-            f"`{run.get('generated_at')}` | "
-            f"`{run.get('goal_id')}` | "
-            f"`{run.get('classification')}` | "
-            f"{run.get('json_exists')}/{run.get('markdown_exists')} | "
-            f"{action} |"
+            markdown_table_row(
+                [
+                    markdown_code(run.get("generated_at")),
+                    markdown_code(run.get("goal_id")),
+                    markdown_code(run.get("classification")),
+                    f"{run.get('json_exists')}/{run.get('markdown_exists')}",
+                    run.get("recommended_action"),
+                ]
+            )
         )
 
     lines.extend(["", "## Goals"])
@@ -1072,21 +1083,25 @@ def render_index_duplicate_inspection_markdown(payload: dict[str, Any]) -> str:
         f"- duplicate_rows: `{payload.get('duplicate_row_count')}`",
         f"- truncated: `{payload.get('truncated')}`",
         "",
-        "| goal | generated_at | kind | severity | rows | classifications | repair_hint |",
-        "| --- | --- | --- | --- | --- | --- | --- |",
+        markdown_table_row(
+            ["goal", "generated_at", "kind", "severity", "rows", "classifications", "repair_hint"]
+        ),
+        markdown_table_separator(7),
     ]
     for group in payload.get("groups") or []:
         classifications = ", ".join(str(item) for item in group.get("classifications") or [])
-        hint = markdown_scalar(group.get("repair_hint"))
         lines.append(
-            "| "
-            f"`{group.get('goal_id')}` | "
-            f"`{group.get('generated_at')}` | "
-            f"`{group.get('duplicate_kind')}` | "
-            f"`{group.get('severity')}` | "
-            f"`{group.get('line_numbers')}` | "
-            f"`{classifications}` | "
-            f"{hint} |"
+            markdown_table_row(
+                [
+                    markdown_code(group.get("goal_id")),
+                    markdown_code(group.get("generated_at")),
+                    markdown_code(group.get("duplicate_kind")),
+                    markdown_code(group.get("severity")),
+                    markdown_code(group.get("line_numbers")),
+                    markdown_code(classifications),
+                    group.get("repair_hint"),
+                ]
+            )
         )
     return "\n".join(lines)
 

--- a/loopx/pr_review.py
+++ b/loopx/pr_review.py
@@ -7,6 +7,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from .presentation.markdown import as_dict as _as_dict
+from .presentation.markdown import as_list as _as_list
+
 
 COMMAND = "/loopx-pr-review"
 SCHEMA_VERSION = "loopx_pr_review_command_response_v0"
@@ -106,14 +109,6 @@ def _join_short(items: list[str], *, limit: int = 3, fallback: str = "未提供"
     if not compact:
         return fallback
     return "、".join(compact[:limit])
-
-
-def _as_dict(value: object) -> dict[str, Any]:
-    return value if isinstance(value, dict) else {}
-
-
-def _as_list(value: object) -> list[Any]:
-    return value if isinstance(value, list) else []
 
 
 def _run_gh_json(args: list[str], *, cwd: Path | None = None) -> Any:

--- a/loopx/presentation/markdown.py
+++ b/loopx/presentation/markdown.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import Any
+
+
+class _MarkdownCell(str):
+    pass
 
 
 def as_dict(value: Any) -> dict[str, Any]:
@@ -13,3 +18,21 @@ def as_list(value: Any) -> list[Any]:
 
 def markdown_scalar(value: Any) -> str:
     return str(value or "").replace("\r", " ").replace("\n", " ").replace("|", "\\|").strip()
+
+
+def markdown_code(value: Any) -> str:
+    return _MarkdownCell(f"`{markdown_scalar(value)}`")
+
+
+def markdown_table_row(cells: Iterable[Any]) -> str:
+    rendered = (
+        str(cell) if isinstance(cell, _MarkdownCell) else markdown_scalar(cell)
+        for cell in cells
+    )
+    return "| " + " | ".join(rendered) + " |"
+
+
+def markdown_table_separator(column_count: int) -> str:
+    if column_count < 1:
+        raise ValueError("markdown table must have at least one column")
+    return markdown_table_row(["---"] * column_count)

--- a/loopx/registry.py
+++ b/loopx/registry.py
@@ -11,6 +11,7 @@ from .authority import authority_registry_summary
 from .control_plane import compact_control_plane_policy, control_plane_policy_summary
 from .execution_profile import compact_execution_profile, execution_profile_summary
 from .orchestration import compact_orchestration_policy, orchestration_policy_summary
+from .presentation.markdown import markdown_code, markdown_table_row, markdown_table_separator
 from .quota import goal_quota_config
 
 
@@ -413,8 +414,22 @@ def render_registry_markdown(payload: dict[str, Any]) -> str:
             f"- common_runtime_root: `{payload.get('common_runtime_root')}`",
             f"- goals: `{payload.get('goal_count')}`",
             "",
-            "| goal | role | parent | domain | status | repo_exists | repo_goals | state_exists | spawn | adapter | next_probe |",
-            "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+            markdown_table_row(
+                [
+                    "goal",
+                    "role",
+                    "parent",
+                    "domain",
+                    "status",
+                    "repo_exists",
+                    "repo_goals",
+                    "state_exists",
+                    "spawn",
+                    "adapter",
+                    "next_probe",
+                ]
+            ),
+            markdown_table_separator(11),
         ]
     )
     for goal in payload.get("goals") or []:
@@ -422,7 +437,6 @@ def render_registry_markdown(payload: dict[str, Any]) -> str:
         spawn = orchestration_policy_summary(
             goal.get("orchestration") if isinstance(goal.get("orchestration"), dict) else None
         )
-        next_probe = str(goal.get("next_probe") or "").replace("|", "\\|")
         authority_suffix = ""
         if goal.get("authority_source_count"):
             authority_suffix = f" authorities={goal.get('authority_source_count')}"
@@ -454,18 +468,21 @@ def render_registry_markdown(payload: dict[str, Any]) -> str:
             else ""
         )
         lines.append(
-            "| "
-            f"`{goal.get('id')}` | "
-            f"{goal.get('role')} | "
-            f"{goal.get('parent_goal_id') or ''} | "
-            f"{goal.get('domain')} | "
-            f"{goal.get('status')} | "
-            f"{goal.get('repo_exists')} | "
-            f"{goal.get('repo_goal_count')} | "
-            f"{goal.get('state_file_exists')} | "
-            f"{spawn} | "
-            f"{adapter}{authority_suffix}{quota_suffix}{execution_suffix}{control_plane_suffix} | "
-            f"{next_probe} |"
+            markdown_table_row(
+                [
+                    markdown_code(goal.get("id")),
+                    goal.get("role"),
+                    goal.get("parent_goal_id") or "",
+                    goal.get("domain"),
+                    goal.get("status"),
+                    goal.get("repo_exists"),
+                    goal.get("repo_goal_count"),
+                    goal.get("state_file_exists"),
+                    spawn,
+                    f"{adapter}{authority_suffix}{quota_suffix}{execution_suffix}{control_plane_suffix}",
+                    goal.get("next_probe"),
+                ]
+            )
         )
 
     problems = payload.get("problems") or []

--- a/loopx/slash_commands.py
+++ b/loopx/slash_commands.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from .presentation.markdown import markdown_scalar
+from .presentation.markdown import markdown_code, markdown_table_row, markdown_table_separator
 
 
 SCHEMA_VERSION = "loopx_slash_command_catalog_v0"
@@ -212,10 +212,6 @@ def render_onboarding_slash_command_note(commands: list[dict[str, Any]], *, cli_
     )
 
 
-def _markdown_table_cell(value: Any) -> str:
-    return markdown_scalar(value)
-
-
 def render_slash_command_catalog_markdown(payload: dict[str, Any]) -> str:
     if not payload.get("ok"):
         return "# LoopX Slash Commands\n\n- ok: `False`"
@@ -224,8 +220,8 @@ def render_slash_command_catalog_markdown(payload: dict[str, Any]) -> str:
         "",
         str(payload.get("onboarding", {}).get("suggested_user_note") or ""),
         "",
-        "| Command | Scope | Intent | Mutation policy | CLI reference |",
-        "| --- | --- | --- | --- | --- |",
+        markdown_table_row(["Command", "Scope", "Intent", "Mutation policy", "CLI reference"]),
+        markdown_table_separator(5),
     ]
     for item in payload.get("commands") or []:
         if not isinstance(item, dict):
@@ -240,12 +236,15 @@ def render_slash_command_catalog_markdown(payload: dict[str, Any]) -> str:
         if agent_contract.get("host_loop_activation_required_after_todo_writeback"):
             intent += " Agent contract: after todo writeback, activate the host loop or report the concrete host-tool gate."
         lines.append(
-            "| "
-            f"`{_markdown_table_cell(item.get('command'))}` | "
-            f"{_markdown_table_cell(item.get('scope'))} | "
-            f"{_markdown_table_cell(intent)} | "
-            f"{_markdown_table_cell(item.get('mutation_policy'))} | "
-            f"`{_markdown_table_cell(item.get('cli_reference'))}` |"
+            markdown_table_row(
+                [
+                    markdown_code(item.get("command")),
+                    item.get("scope"),
+                    intent,
+                    item.get("mutation_policy"),
+                    markdown_code(item.get("cli_reference")),
+                ]
+            )
         )
     lines.extend(
         [

--- a/loopx/summary_all.py
+++ b/loopx/summary_all.py
@@ -7,6 +7,8 @@ from typing import Any
 
 from .history import collect_history, load_registry
 from .paths import resolve_runtime_root
+from .presentation.markdown import as_dict as _as_dict
+from .presentation.markdown import as_list as _as_list
 from .quota import build_quota_should_run
 from .status import collect_status
 
@@ -87,14 +89,6 @@ def _redact_text(value: object, *, limit: int = 260) -> str:
     if len(text) > limit:
         return text[: max(0, limit - 1)].rstrip() + "…"
     return text
-
-
-def _as_dict(value: object) -> dict[str, Any]:
-    return value if isinstance(value, dict) else {}
-
-
-def _as_list(value: object) -> list[Any]:
-    return value if isinstance(value, list) else []
 
 
 def _first_open_todo(quota_payload: dict[str, Any]) -> dict[str, Any] | None:


### PR DESCRIPTION
## Summary
- add shared Markdown table/code-cell primitives in `loopx.presentation.markdown`
- migrate non-benchmark operator tables in registry, slash command catalog, and history index/repair renderers
- retire duplicate `_as_dict` / `_as_list` implementations in PR review and global summary surfaces
- extend the presentation markdown smoke to cover table rows, code cells, registry/history/slash surfaces, and malformed payload coercion

## Validation
- `python3 examples/control_plane/presentation-markdown-primitives-smoke.py`
- `python3 examples/pr-review-command-smoke.py`
- `python3 examples/control_plane/status-global-registry-markdown-smoke.py`
- `python3 examples/codex-app-host-command-registry-smoke.py`
- `python3 examples/usage-summary-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `python3 -m py_compile loopx/presentation/markdown.py loopx/registry.py loopx/slash_commands.py loopx/history.py loopx/pr_review.py loopx/summary_all.py examples/control_plane/presentation-markdown-primitives-smoke.py`
- `git diff --check`
- `loopx canary premerge --from-git-diff` passed with merge gate passed, self_merge_allowed=true, manual_holds=0

## Boundary
Non-benchmark presentation/refactor only. Public/private boundary canary passed; no raw benchmark logs, task text, trajectories, verifier output, credentials, or local absolute paths were added.
