### PR TITLE
Honor bridge progress before TUI timeout recovery

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -1246,6 +1246,19 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert "typed_closeout" in source
     assert "post_bridge_recovery_attempt_count < 2" not in source
     assert "last_bridge_activity_at >= 30.0" in source
+    tui_loop_start = source.index(
+        "while time.monotonic() < deadline:",
+        source.index("goal_command_text = build_codex_cli_goal_tui_input"),
+    )
+    bridge_progress_index = source.index(
+        "current_bridge_summary_size = bridge_summary_path.stat().st_size",
+        tui_loop_start,
+    )
+    pre_bridge_timeout_index = source.index(
+        "pre_bridge_blocker_stage = \"\"",
+        tui_loop_start,
+    )
+    assert bridge_progress_index < pre_bridge_timeout_index
     tui_source = (REPO_ROOT / "loopx/codex_cli_goal_tui.py").read_text(
         encoding="utf-8"
     )

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -1332,6 +1332,28 @@ class SkillsBenchLocalAcpRelay:
                     if "Goal active" in capture or "Pursuing goal" in capture:
                         goal_active_observed = True
                     goal_failed_now = "Goal failed" in capture or "Goal blocked" in capture
+                    if bridge_summary_path is not None:
+                        try:
+                            current_bridge_summary_size = bridge_summary_path.stat().st_size
+                        except OSError:
+                            current_bridge_summary_size = 0
+                        if current_bridge_summary_size > last_bridge_summary_size:
+                            last_bridge_summary_size = current_bridge_summary_size
+                            last_bridge_activity_at = now
+                            bridge_activity_seen = True
+                            first_action_seen = True
+                        elif (
+                            not first_action_seen
+                            and current_bridge_summary_size > 0
+                        ):
+                            first_action_seen = True
+                        if not meaningful_progress_seen:
+                            meaningful_progress_seen = (
+                                _bridge_summary_has_meaningful_agent_progress(
+                                    bridge_summary_path,
+                                    allow_loopx_closeout=False,
+                                )
+                            )
                     if "Goal achieved" in capture:
                         goal_terminal_observed = True
                         break
@@ -1495,28 +1517,6 @@ class SkillsBenchLocalAcpRelay:
                         return _recoverable_codex_turn_failure_message(
                             "codex_cli_goal_goal_active_timeout"
                         )
-                    if bridge_summary_path is not None:
-                        try:
-                            current_bridge_summary_size = bridge_summary_path.stat().st_size
-                        except OSError:
-                            current_bridge_summary_size = 0
-                        if current_bridge_summary_size > last_bridge_summary_size:
-                            last_bridge_summary_size = current_bridge_summary_size
-                            last_bridge_activity_at = now
-                            bridge_activity_seen = True
-                            first_action_seen = True
-                        elif (
-                            not first_action_seen
-                            and current_bridge_summary_size > 0
-                        ):
-                            first_action_seen = True
-                        if not meaningful_progress_seen:
-                            meaningful_progress_seen = (
-                                _bridge_summary_has_meaningful_agent_progress(
-                                    bridge_summary_path,
-                                    allow_loopx_closeout=False,
-                                )
-                            )
                     if (
                         not first_action_seen
                         and first_action_deadline


### PR DESCRIPTION
## Summary
- update the Codex CLI goal TUI loop to consume bridge-summary progress before classifying visible TUI timeout text as a pre-bridge blocker
- keep model-timeout recovery available only when no bridge action has actually been observed
- add a focused route smoke that locks the bridge-progress-before-pre-bridge-timeout ordering

## Validation
- `python3 -m py_compile loopx/benchmark_adapters/skillsbench_acp_relay.py examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `git diff --check`
- `./scripts/loopx canary premerge --from-git-diff`

Premerge direct checks, selected catalog canaries, and public-boundary checks passed. The remaining gate is the expected `benchmark_sensitive` manual hold. Owner has explicitly authorized self-merge for benchmark helper/runtime work in this thread. This change does not alter scoring, task semantics, leaderboard/submission behavior, permission boundaries, or launch benchmark jobs.
