### PR TITLE
Refactor shared public safety presentation helpers

### DIFF
--- a/examples/control_plane/presentation-markdown-primitives-smoke.py
+++ b/examples/control_plane/presentation-markdown-primitives-smoke.py
@@ -29,6 +29,7 @@ from loopx.presentation.markdown import (  # noqa: E402
     markdown_table_row,
     markdown_table_separator,
 )
+from loopx.presentation.public_safety import public_safe_boundary, redact_public_text  # noqa: E402
 from loopx.presentation.renderers.status_markdown import (  # noqa: E402
     append_attention_queue_item_header_markdown,
 )
@@ -306,6 +307,36 @@ def assert_malformed_payloads_use_shared_coercion() -> None:
     assert "## Gates\n- none" in summary_markdown, summary_markdown
 
 
+def assert_shared_redaction() -> None:
+    local_user_path = "/" + "Users/example/private.txt"
+    local_tmp_path = "/" + "tmp/runtime"
+    raw = f"open {local_user_path} and {local_tmp_path}\nthen /loopx-summary-all"
+    assert redact_public_text(raw, limit=200) == (
+        "open <local-path-redacted> and <local-path-redacted> then /loopx-summary-all"
+    )
+    assert redact_public_text(
+        raw,
+        limit=200,
+        replacements={"/loopx-summary-all": "/loopx-global-summary"},
+    ) == "open <local-path-redacted> and <local-path-redacted> then /loopx-global-summary"
+    assert redact_public_text("abcdef", limit=4) == "abc..."
+
+
+def assert_public_safety_boundary() -> None:
+    boundary = public_safe_boundary()
+    assert set(boundary) == {
+        "raw_logs_recorded",
+        "raw_transcripts_recorded",
+        "raw_connector_payloads_recorded",
+        "credential_values_recorded",
+        "absolute_paths_recorded",
+        "private_source_bodies_recorded",
+    }
+    assert all(value is False for value in boundary.values())
+    boundary["absolute_paths_recorded"] = True
+    assert public_safe_boundary()["absolute_paths_recorded"] is False
+
+
 def main() -> int:
     assert as_dict({"ok": True}) == {"ok": True}
     assert as_dict(["not", "a", "dict"]) == {}
@@ -323,6 +354,8 @@ def main() -> int:
     else:
         raise AssertionError("markdown_table_separator should reject zero columns")
     assert_malformed_payloads_use_shared_coercion()
+    assert_shared_redaction()
+    assert_public_safety_boundary()
 
     surfaces = {
         "status": status_markdown(),

--- a/loopx/pr_review.py
+++ b/loopx/pr_review.py
@@ -9,19 +9,13 @@ from typing import Any
 
 from .presentation.markdown import as_dict as _as_dict
 from .presentation.markdown import as_list as _as_list
+from .presentation.public_safety import public_safe_boundary, redact_public_text
 
 
 COMMAND = "/loopx-pr-review"
 SCHEMA_VERSION = "loopx_pr_review_command_response_v0"
 
-BOUNDARY = {
-    "raw_logs_recorded": False,
-    "raw_transcripts_recorded": False,
-    "raw_connector_payloads_recorded": False,
-    "credential_values_recorded": False,
-    "absolute_paths_recorded": False,
-    "private_source_bodies_recorded": False,
-}
+BOUNDARY = public_safe_boundary()
 
 SOURCE_SURFACES = [
     "GitHub pull request metadata",
@@ -29,11 +23,6 @@ SOURCE_SURFACES = [
     "GitHub pull request changed-file list",
     "GitHub pull request status check rollup",
 ]
-
-LOCAL_PATH_PATTERNS = (
-    re.compile(r"/(?:Users|home|private|tmp|var)/[^\s`|,)]+"),
-    re.compile(r"[A-Za-z]:\\\\Users\\\\[^\s`|,)]+"),
-)
 
 RUNTIME_OR_CLI_PREFIXES = (
     "src/",
@@ -95,13 +84,7 @@ def _now_iso() -> str:
 
 
 def _redact_text(value: object, *, limit: int = 320) -> str:
-    text = str(value or "").strip()
-    for pattern in LOCAL_PATH_PATTERNS:
-        text = pattern.sub("<local-path-redacted>", text)
-    text = re.sub(r"\s+", " ", text)
-    if len(text) > limit:
-        return text[: max(0, limit - 1)].rstrip() + "..."
-    return text
+    return redact_public_text(value, limit=limit)
 
 
 def _join_short(items: list[str], *, limit: int = 3, fallback: str = "未提供") -> str:

--- a/loopx/presentation/public_safety.py
+++ b/loopx/presentation/public_safety.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+
+PUBLIC_SAFE_BOUNDARY_FIELDS = (
+    "raw_logs_recorded",
+    "raw_transcripts_recorded",
+    "raw_connector_payloads_recorded",
+    "credential_values_recorded",
+    "absolute_paths_recorded",
+    "private_source_bodies_recorded",
+)
+
+LOCAL_PATH_PATTERNS = (
+    re.compile(r"/(?:Users|home|private|tmp|var)/[^\s`|,)]+"),
+    re.compile(r"[A-Za-z]:\\\\Users\\\\[^\s`|,)]+"),
+)
+
+
+def public_safe_boundary() -> dict[str, bool]:
+    return {field: False for field in PUBLIC_SAFE_BOUNDARY_FIELDS}
+
+
+def redact_public_text(
+    value: Any,
+    *,
+    limit: int,
+    replacements: Mapping[str, str] | None = None,
+    truncation_marker: str = "...",
+) -> str:
+    text = str(value or "").strip()
+    for source, target in (replacements or {}).items():
+        text = text.replace(source, target)
+    for pattern in LOCAL_PATH_PATTERNS:
+        text = pattern.sub("<local-path-redacted>", text)
+    text = re.sub(r"\s+", " ", text)
+    if len(text) > limit:
+        return text[: max(0, limit - 1)].rstrip() + truncation_marker
+    return text

--- a/loopx/summary_all.py
+++ b/loopx/summary_all.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import re
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
@@ -9,6 +8,7 @@ from .history import collect_history, load_registry
 from .paths import resolve_runtime_root
 from .presentation.markdown import as_dict as _as_dict
 from .presentation.markdown import as_list as _as_list
+from .presentation.public_safety import public_safe_boundary, redact_public_text
 from .quota import build_quota_should_run
 from .status import collect_status
 
@@ -20,14 +20,7 @@ LEGACY_COMMAND_ALIASES = {
 }
 SCHEMA_VERSION = "global_manager_command_response_v0"
 
-BOUNDARY = {
-    "raw_logs_recorded": False,
-    "raw_transcripts_recorded": False,
-    "raw_connector_payloads_recorded": False,
-    "credential_values_recorded": False,
-    "absolute_paths_recorded": False,
-    "private_source_bodies_recorded": False,
-}
+BOUNDARY = public_safe_boundary()
 
 SOURCE_SURFACES = [
     "global registry compact status",
@@ -48,12 +41,6 @@ LANE_PRIORITY = {
     "paused": 4,
     "quota_unavailable": 5,
 }
-
-LOCAL_PATH_PATTERNS = (
-    re.compile(r"/(?:Users|home|private|tmp|var)/[^\s`|,)]+"),
-    re.compile(r"[A-Za-z]:\\\\Users\\\\[^\s`|,)]+"),
-)
-
 
 def _now_iso() -> str:
     return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
@@ -80,15 +67,12 @@ def _parse_datetime(value: object) -> datetime | None:
 
 
 def _redact_text(value: object, *, limit: int = 260) -> str:
-    text = str(value or "").strip()
-    for alias, canonical in LEGACY_COMMAND_ALIASES.items():
-        text = text.replace(alias, canonical)
-    for pattern in LOCAL_PATH_PATTERNS:
-        text = pattern.sub("<local-path-redacted>", text)
-    text = re.sub(r"\s+", " ", text)
-    if len(text) > limit:
-        return text[: max(0, limit - 1)].rstrip() + "…"
-    return text
+    return redact_public_text(
+        value,
+        limit=limit,
+        replacements=LEGACY_COMMAND_ALIASES,
+        truncation_marker="…",
+    )
 
 
 def _first_open_todo(quota_payload: dict[str, Any]) -> dict[str, Any] | None:


### PR DESCRIPTION
## Summary
- add shared `loopx.presentation.public_safety` helpers for public-safe boundary maps and local-path redaction
- migrate PR review and global summary surfaces off duplicated boundary/redaction regex blocks
- extend the presentation smoke to cover public-safe boundary copies, redaction replacements, whitespace normalization, and truncation behavior

## Validation
- `python3 examples/control_plane/presentation-markdown-primitives-smoke.py`
- `python3 examples/pr-review-command-smoke.py`
- `python3 examples/project/global-manager-command-cli-smoke.py`
- `python3 examples/project/global-manager-command-protocol-smoke.py`
- `python3 examples/control_plane/check-public-boundary-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `python3 -m py_compile loopx/presentation/public_safety.py loopx/pr_review.py loopx/summary_all.py examples/control_plane/presentation-markdown-primitives-smoke.py`
- `git diff --check`
- `loopx canary premerge --from-git-diff` passed with merge_gate_passed=true, self_merge_allowed=true, manual_holds=0

## Boundary
Non-benchmark presentation/control-plane refactor only. No benchmark execution, scoring, raw task text, trajectories, verifier output, credentials, or local private state are included.
