### PR TITLE
Add auto wake loop for visible multi-agent sessions

### DIFF
--- a/examples/auto-research-user-contract-entry-smoke.py
+++ b/examples/auto-research-user-contract-entry-smoke.py
@@ -171,6 +171,8 @@ def assert_start_wake_contract() -> None:
     assert "wake_visible_multi_agent_panes" not in cli_source
     assert "resolve_visible_launch_policy" in cli_source
     assert "make_visible_launcher_callback" in cli_source
+    assert "--auto-wake" in cli_source
+    assert "auto_wake=bool(visible_policy.launch_visible and args.auto_wake)" in cli_source
     start_source = cli_source.split('elif args.auto_research_command == "start":', 1)[1].split(
         'elif args.auto_research_command == "demo-supervisor":',
         1,
@@ -199,6 +201,7 @@ def assert_start_wake_contract() -> None:
         attach=False,
         no_attach=False,
         codex_trust_workspace=None,
+        auto_wake=True,
     )
     default_policy = start_policy(default_visible)
     assert default_policy.wake_visible_after_launch is False
@@ -212,6 +215,7 @@ def assert_start_wake_contract() -> None:
         attach=True,
         no_attach=False,
         codex_trust_workspace=None,
+        auto_wake=True,
     )
     takeover_policy = start_policy(attach_takeover)
     assert takeover_policy.wake_visible_after_launch is False
@@ -225,6 +229,7 @@ def assert_start_wake_contract() -> None:
         attach=False,
         no_attach=False,
         codex_trust_workspace=None,
+        auto_wake=True,
     )
     explicit_wake_policy = start_policy(explicit_wake)
     assert explicit_wake_policy.wake_visible_after_launch is True
@@ -238,6 +243,7 @@ def assert_start_wake_contract() -> None:
         attach=False,
         no_attach=False,
         codex_trust_workspace=None,
+        auto_wake=True,
     )
     manual_policy = start_policy(manual_takeover)
     assert manual_policy.wake_visible_after_launch is False
@@ -251,6 +257,7 @@ def assert_start_wake_contract() -> None:
         attach=False,
         no_attach=True,
         codex_trust_workspace=None,
+        auto_wake=False,
     )
     background_policy = start_policy(background_manual)
     assert background_policy.wake_visible_after_launch is False
@@ -264,6 +271,7 @@ def assert_start_wake_contract() -> None:
         attach=False,
         no_attach=False,
         codex_trust_workspace=None,
+        auto_wake=True,
     )
     headless_policy = start_policy(headless)
     assert headless_policy.wake_visible_after_launch is False
@@ -277,6 +285,7 @@ def assert_start_wake_contract() -> None:
         attach=False,
         no_attach=False,
         codex_trust_workspace=False,
+        auto_wake=True,
     )
     assert trust(explicit_no_trust) is False
 
@@ -287,6 +296,7 @@ def assert_start_wake_contract() -> None:
         attach=False,
         no_attach=False,
         codex_trust_workspace=True,
+        auto_wake=True,
     )
     assert trust(explicit_trust) is True
 

--- a/examples/auto-research-visible-launch-policy-smoke.py
+++ b/examples/auto-research-visible-launch-policy-smoke.py
@@ -125,6 +125,7 @@ def assert_auto_research_consumes_generic_policy() -> None:
         "resolve_visible_launch_policy",
         "resolve_codex_trust_workspace",
         "make_visible_wake_callback",
+        "--auto-wake",
     ):
         require(marker in source, f"auto-research CLI missing generic policy helper: {marker}")
     wake_callback = make_visible_wake_callback(tmux_bin="tmux")

--- a/examples/cli-multi-agent-command-modularization-smoke.py
+++ b/examples/cli-multi-agent-command-modularization-smoke.py
@@ -56,6 +56,7 @@ def main() -> None:
         "build_visible_multi_agent_payload_from_spec",
         "execute_visible_multi_agent_launcher",
         "generic_multi_agent_launch_spec_v0",
+        "--auto-wake",
     ):
         require(marker in module_source, f"multi-agent module missing {marker}")
 
@@ -65,6 +66,7 @@ def main() -> None:
         "--execute",
         "--workspace",
         "--attach",
+        "--auto-wake",
         "--codex-trust-workspace",
     ):
         require(option in help_text, f"multi-agent launch help omitted {option}")

--- a/examples/visible-multi-agent-launcher-smoke.py
+++ b/examples/visible-multi-agent-launcher-smoke.py
@@ -112,6 +112,8 @@ def main() -> int:
     assert "LOOPX_PANE_TICK_SUMMARY" in launcher_source
     assert "LOOPX_PANE_TICK_OUTPUT_ARTIFACT" in launcher_source
     assert "LOOPX_PANE_BOOTSTRAP_PROMPT" in launcher_source
+    assert "auto-wake.public.jsonl" in launcher_source
+    assert "AUTO_WAKE_LOOP_SCHEMA_VERSION" in launcher_source
     assert "loopx-build-codex-bootstrap-prompt" in runtime_source
     assert "LoopX Agent Bootstrap Context" in runtime_source
     assert "### Role First Move" in runtime_source
@@ -597,6 +599,8 @@ def main() -> int:
                 create_workspace=True,
                 cwd=temp,
                 codex_trust_workspace=True,
+                auto_wake=True,
+                auto_wake_interval_seconds=5.0,
             )
             os.environ["FAKE_TMUX_CAPTURE_TEXT"] = (
                 "╭────────────────────────╮\n"
@@ -815,6 +819,14 @@ def main() -> int:
         assert launch["surviving_lanes"] == ["planner", "reviewer"], launch
         assert launch["script_mode"] == "runtime_local_files", launch
         assert launch["launcher_script_count"] == 2, launch
+        assert launch["auto_wake"]["schema_version"] == "multi_agent_auto_wake_loop_v0", launch
+        assert launch["auto_wake"]["enabled"] is True, launch
+        assert launch["auto_wake"]["interval_seconds"] == 5.0, launch
+        assert launch["auto_wake"]["target_lanes"] == ["planner", "reviewer"], launch
+        assert launch["auto_wake"]["workflow_driver"] is False, launch
+        assert launch["auto_wake"]["broadcaster_reads_frontier"] is False, launch
+        assert launch["auto_wake"]["broadcaster_selects_todo"] is False, launch
+        assert launch["auto_wake"]["artifact"] == "auto-wake.public.jsonl", launch
         acceptance = launch["visible_acceptance"]
         assert acceptance["schema_version"] == "multi_agent_visible_launch_acceptance_v0", acceptance
         assert acceptance["accepted"] is True, acceptance

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -233,6 +233,22 @@ def register_auto_research_commands(
         ),
     )
     start_parser.add_argument(
+        "--auto-wake",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Run a session-scoped background wake loop so successor todos can be picked up "
+            "without a human sending `loopx multi-agent wake`. Use --no-auto-wake for full "
+            "manual takeover."
+        ),
+    )
+    start_parser.add_argument(
+        "--auto-wake-interval-seconds",
+        type=float,
+        default=45.0,
+        help=argparse.SUPPRESS,
+    )
+    start_parser.add_argument(
         "--no-attach",
         action="store_true",
         help="With visible --execute, start tmux in the background instead of attaching.",
@@ -808,6 +824,8 @@ def _execute_auto_research_demo_supervisor(
     workspace: str | None,
     create_workspace: bool,
     codex_trust_workspace: bool,
+    auto_wake: bool = False,
+    auto_wake_interval_seconds: float = 45.0,
 ) -> dict[str, object]:
     registry = load_registry(registry_path)
     runtime_root = resolve_runtime_root(registry, runtime_root_arg)
@@ -825,6 +843,8 @@ def _execute_auto_research_demo_supervisor(
         create_workspace=create_workspace,
         cwd=Path.cwd(),
         codex_trust_workspace=codex_trust_workspace,
+        auto_wake=auto_wake,
+        auto_wake_interval_seconds=auto_wake_interval_seconds,
         launch_result_schema="auto_research_demo_launch_result_v0",
         lane_default="research-lane",
     )
@@ -948,6 +968,8 @@ def handle_auto_research_command(
                 attach=visible_policy.attach,
                 replace_existing=args.replace_existing,
                 workspace_policy=start_workspace_policy,
+                auto_wake=bool(visible_policy.launch_visible and args.auto_wake),
+                auto_wake_interval_seconds=args.auto_wake_interval_seconds,
             )
 
             if visible_policy.launch_visible:

--- a/loopx/capabilities/multi_agent/visible_launch_policy.py
+++ b/loopx/capabilities/multi_agent/visible_launch_policy.py
@@ -95,6 +95,8 @@ def make_visible_launcher_callback(
     attach: bool,
     replace_existing: bool,
     workspace_policy: VisibleWorkspacePolicy,
+    auto_wake: bool = False,
+    auto_wake_interval_seconds: float = 45.0,
 ) -> VisibleLauncherCallback | None:
     """Create the generic callback shape expected by visible demo runners."""
 
@@ -123,6 +125,8 @@ def make_visible_launcher_callback(
             workspace=workspace,
             create_workspace=create_workspace,
             codex_trust_workspace=codex_trust_workspace,
+            auto_wake=auto_wake,
+            auto_wake_interval_seconds=auto_wake_interval_seconds,
         )
 
     return visible_launcher

--- a/loopx/cli_commands/multi_agent.py
+++ b/loopx/cli_commands/multi_agent.py
@@ -49,6 +49,21 @@ def register_multi_agent_commands(
     launch.add_argument("--attach", action="store_true", help="Attach to the session after launch.")
     launch.add_argument("--replace-existing", action="store_true", help="Replace an existing session of the same name.")
     launch.add_argument(
+        "--auto-wake",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help=(
+            "Run a session-scoped background wake loop. The loop only broadcasts "
+            "the fixed pane-local A2A prompt; each pane still reads its own state."
+        ),
+    )
+    launch.add_argument(
+        "--auto-wake-interval-seconds",
+        type=float,
+        default=45.0,
+        help=argparse.SUPPRESS,
+    )
+    launch.add_argument(
         "--codex-trust-workspace",
         action=argparse.BooleanOptionalAction,
         default=False,
@@ -178,6 +193,8 @@ def handle_multi_agent_command(
                 cwd=Path.cwd(),
                 codex_trust_workspace=bool(args.codex_trust_workspace),
                 source_root=spec_path.parent,
+                auto_wake=bool(args.auto_wake),
+                auto_wake_interval_seconds=args.auto_wake_interval_seconds,
             )
             payload["mode"] = "execute"
             payload["chosen_launcher"] = chosen

--- a/loopx/visible_multi_agent_launcher.py
+++ b/loopx/visible_multi_agent_launcher.py
@@ -37,6 +37,7 @@ def _q(value: object) -> str:
 PANE_A2A_WAKEUP_SCHEMA_VERSION = "multi_agent_pane_a2a_wakeup_v0"
 PANE_A2A_WAKEUP_PROMPT = PANE_LOCAL_A2A_WAKEUP_PROMPT
 PANE_A2A_INPUT_READY_TIMEOUT_SECONDS = 5.0
+AUTO_WAKE_LOOP_SCHEMA_VERSION = "multi_agent_auto_wake_loop_v0"
 TMUX_LANE_ID_OPTION = "@loopx_lane_id"
 
 
@@ -1043,6 +1044,74 @@ def _write_tmux_script(*, script_dir: Path, name: str, command: str) -> Path:
     return script
 
 
+def _start_auto_wake_loop(
+    *,
+    script_dir: Path,
+    project: Path,
+    registry: Path,
+    runtime_root: Path,
+    session: str,
+    lanes: list[str],
+    tmux_bin: str,
+    cli_bin: str,
+    interval_seconds: float,
+    env: dict[str, str],
+) -> dict[str, object]:
+    interval = max(5.0, float(interval_seconds or 0))
+    lane_flags = " ".join(f"--lane {_q(lane)}" for lane in lanes if lane)
+    wake_command = (
+        'WAKE_LOG="$LOOPX_VISIBLE_ARTIFACT_DIR/auto-wake.public.jsonl"; '
+        f"while {_q(tmux_bin)} has-session -t \"$LOOPX_VISIBLE_SESSION\" >/dev/null 2>&1; do "
+        f"sleep {_q(f'{interval:g}')}; "
+        f"{_q(cli_bin)} --format json multi-agent wake "
+        '--session-name "$LOOPX_VISIBLE_SESSION" '
+        f"--tmux-bin {_q(tmux_bin)} "
+        f"{lane_flags} --execute >> \"$WAKE_LOG\" 2>&1 || true; "
+        "done"
+    )
+    script = _write_tmux_script(
+        script_dir=script_dir,
+        name="auto-wake-loop",
+        command=runtime_shell_command(
+            wake_command,
+            project=project,
+            registry=registry,
+            runtime_root=runtime_root,
+            visible_session=session,
+            errexit=False,
+        ),
+    )
+    subprocess.Popen(
+        ["bash", str(script)],
+        env=env,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+    return {
+        "schema_version": AUTO_WAKE_LOOP_SCHEMA_VERSION,
+        "enabled": True,
+        "mode": "background_process",
+        "interval_seconds": interval,
+        "target_lanes": lanes,
+        "wakeup_model": "fixed_prompt_broadcast",
+        "workflow_driver": False,
+        "broadcaster_reads_frontier": False,
+        "broadcaster_selects_todo": False,
+        "pane_decision_owner": "codex_tui_agent_via_loopx_state",
+        "artifact": "auto-wake.public.jsonl",
+        "process_started": True,
+        "pid_recorded": False,
+        "boundary": {
+            "writes_loopx_state": False,
+            "spends_loopx_quota": False,
+            "reads_raw_transcripts": False,
+            "reads_credentials": False,
+            "runs_worker_turn_directly": False,
+        },
+    }
+
+
 def execute_visible_multi_agent_launcher(
     *,
     payload: dict[str, object],
@@ -1059,6 +1128,8 @@ def execute_visible_multi_agent_launcher(
     cwd: Path,
     codex_trust_workspace: bool = False,
     source_root: Path | None = None,
+    auto_wake: bool = False,
+    auto_wake_interval_seconds: float = 45.0,
     launch_result_schema: str = "multi_agent_visible_launch_result_v0",
     acceptance_schema: str = "multi_agent_visible_launch_acceptance_v0",
     lane_default: str = "agent-lane",
@@ -1085,6 +1156,7 @@ def execute_visible_multi_agent_launcher(
         registry=registry,
         runtime_root=runtime_root,
         tmux_bin=tmux_bin,
+        cli_bin=cli_bin,
         codex_bin=codex_bin,
         attach=attach,
         replace_existing=replace_existing,
@@ -1092,6 +1164,8 @@ def execute_visible_multi_agent_launcher(
         acceptance_schema=acceptance_schema,
         lane_default=lane_default,
         codex_trust_workspace=codex_trust_workspace,
+        auto_wake=auto_wake,
+        auto_wake_interval_seconds=auto_wake_interval_seconds,
     )
     result["worker_skill_materialization"] = worker_skills
     return result, chosen, workspace_mode
@@ -1105,6 +1179,7 @@ def _launch_with_tmux(
     registry: Path,
     runtime_root: Path,
     tmux_bin: str,
+    cli_bin: str,
     codex_bin: str,
     attach: bool,
     replace_existing: bool,
@@ -1112,6 +1187,8 @@ def _launch_with_tmux(
     acceptance_schema: str,
     lane_default: str,
     codex_trust_workspace: bool,
+    auto_wake: bool,
+    auto_wake_interval_seconds: float,
 ) -> dict[str, object]:
     session = str(payload.get("session_name") or "loopx-visible-agents")
     lanes = [item for item in payload.get("lanes", []) if isinstance(item, dict)]
@@ -1245,6 +1322,23 @@ def _launch_with_tmux(
         started_lanes.append(lane_id)
         lane_targets[lane_id] = pane_id
         launcher_scripts[lane_id] = str(lane_script)
+    auto_wake_result: dict[str, object] = {
+        "schema_version": AUTO_WAKE_LOOP_SCHEMA_VERSION,
+        "enabled": False,
+    }
+    if auto_wake:
+        auto_wake_result = _start_auto_wake_loop(
+            script_dir=script_dir,
+            project=project,
+            registry=registry,
+            runtime_root=runtime_root,
+            session=session,
+            lanes=started_lanes,
+            tmux_bin=tmux_bin,
+            cli_bin=cli_bin,
+            interval_seconds=auto_wake_interval_seconds,
+            env=env,
+        )
     if attach:
         subprocess.run([tmux_bin, "attach", "-t", session], check=True, env=env)
     acceptance = _tmux_acceptance(
@@ -1281,6 +1375,7 @@ def _launch_with_tmux(
         "launcher_script_count": len(launcher_scripts),
         "attach_requested": attach,
         "operator_takeover": "attach to the tmux session, interrupt any lane, or kill the session",
+        "auto_wake": auto_wake_result,
         "visible_acceptance": acceptance,
         "tmux_layout": {
             "window_name": window_name,


### PR DESCRIPTION
## Summary
- add a session-scoped background auto-wake loop to the generic visible multi-agent launcher
- expose the generic loop through `loopx multi-agent launch --auto-wake` and enable it by default for visible `auto-research start`
- keep the wake loop as a fixed prompt broadcaster only: panes still read their own LoopX quota/frontier and decide work locally

## Validation
- `python3 -m py_compile loopx/visible_multi_agent_launcher.py loopx/capabilities/multi_agent/visible_launch_policy.py loopx/capabilities/auto_research/cli.py loopx/cli_commands/multi_agent.py`
- `python3 examples/visible-multi-agent-launcher-smoke.py`
- `python3 examples/auto-research-visible-launch-policy-smoke.py`
- `python3 examples/auto-research-user-contract-entry-smoke.py`
- `python3 examples/cli-multi-agent-command-modularization-smoke.py`
- `python3 examples/auto-research-demo-supervisor-smoke.py`
- `python3 examples/auto-research-worker-turn-smoke.py`
- `python3 -m loopx.cli check --scan-path loopx/visible_multi_agent_launcher.py --scan-path loopx/capabilities/auto_research/cli.py --scan-path loopx/capabilities/multi_agent/visible_launch_policy.py --scan-path loopx/cli_commands/multi_agent.py --scan-path examples/visible-multi-agent-launcher-smoke.py --scan-path examples/auto-research-visible-launch-policy-smoke.py --scan-path examples/auto-research-user-contract-entry-smoke.py --scan-path examples/cli-multi-agent-command-modularization-smoke.py`
- `python3 -m loopx.cli canary premerge --from-git-diff`