### PR TITLE
Centralize control-plane time helpers

### DIFF
--- a/examples/control_plane/monitor-scheduler-contract-smoke.py
+++ b/examples/control_plane/monitor-scheduler-contract-smoke.py
@@ -13,6 +13,7 @@ from loopx.control_plane.testing.quota_fixtures import quota_status_payload  # n
 from loopx.control_plane.scheduler import monitor_todo as monitor_todo_module  # noqa: E402
 from loopx.control_plane.scheduler import scheduler_hint as scheduler_hint_module  # noqa: E402
 from loopx.control_plane.scheduler import time as scheduler_time  # noqa: E402
+from loopx.control_plane.runtime import time as runtime_time  # noqa: E402
 from loopx.quota import build_quota_should_run, render_quota_should_run_markdown  # noqa: E402
 
 
@@ -145,6 +146,7 @@ def guard_for(
 
 
 def assert_scheduler_timestamp_parser_is_shared_and_utc_normalized() -> None:
+    assert scheduler_time.parse_timestamp is runtime_time.parse_timestamp
     assert monitor_todo_module.parse_monitor_timestamp is scheduler_time.parse_scheduler_timestamp
     assert scheduler_hint_module._parse_monitor_timestamp("2026-01-01T08:00:00+08:00").isoformat() == (
         "2026-01-01T00:00:00+00:00"

--- a/examples/control_plane/todo-readmodel-boundary-smoke.py
+++ b/examples/control_plane/todo-readmodel-boundary-smoke.py
@@ -30,6 +30,7 @@ from loopx.control_plane.runtime import run_compaction as run_compaction_read_mo
 from loopx.control_plane.runtime import session_runtime as session_runtime_read_model  # noqa: E402
 from loopx.control_plane.runtime import status_projection_cache as status_cache_read_model  # noqa: E402
 from loopx.control_plane.runtime import time as runtime_time_read_model  # noqa: E402
+from loopx.control_plane.scheduler import time as scheduler_time_read_model  # noqa: E402
 from loopx.control_plane.quota import usage_summary as usage_summary_read_model  # noqa: E402
 from loopx.control_plane.todos import active_state_todo_parser as active_state_todo_parser_read_model  # noqa: E402
 from loopx.control_plane.todos import active_state_todos as active_state_todos_read_model  # noqa: E402
@@ -114,6 +115,7 @@ def assert_direct_status_aliases() -> None:
     assert status_module.compact_controller_readiness is run_compaction_read_model.compact_controller_readiness
     assert status_module.parse_timestamp is runtime_time_read_model.parse_timestamp
     assert monitor_metadata_read_model.parse_timestamp is runtime_time_read_model.parse_timestamp
+    assert scheduler_time_read_model.parse_timestamp is runtime_time_read_model.parse_timestamp
     assert status_cache_read_model.parse_timestamp is runtime_time_read_model.parse_timestamp
     assert evidence_log_read_model.parse_timestamp is runtime_time_read_model.parse_timestamp
     assert management_projection_read_model.parse_timestamp is runtime_time_read_model.parse_timestamp

--- a/loopx/authority.py
+++ b/loopx/authority.py
@@ -5,10 +5,11 @@ import hashlib
 import json
 import os
 import re
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
+
+from .control_plane.runtime.time import now_local_iso
 
 
 AUTHORITY_SOURCE_REGISTRATION_VERSION = "authority_source_registration_v0"
@@ -49,7 +50,7 @@ AUTHORITY_REGISTRY_SUMMARY_FIELDS = (
 
 
 def now_local() -> str:
-    return datetime.now(timezone.utc).astimezone().replace(microsecond=0).isoformat()
+    return now_local_iso()
 
 
 def read_json(path: Path) -> dict[str, Any]:

--- a/loopx/bootstrap.py
+++ b/loopx/bootstrap.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import json
 import re
 import shlex
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from .control_plane.runtime.time import now_local_iso
 from .execution_profile import (
     build_execution_profile,
     compact_execution_profile,
@@ -66,7 +66,7 @@ def default_goal_id(project: Path) -> str:
 
 
 def now_iso() -> str:
-    return datetime.now(timezone.utc).astimezone().replace(microsecond=0).isoformat()
+    return now_local_iso()
 
 
 def read_json_if_exists(path: Path) -> dict[str, Any]:

--- a/loopx/control_plane/agents/management_projection.py
+++ b/loopx/control_plane/agents/management_projection.py
@@ -1,10 +1,9 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from typing import Any, Iterable
 
 from ..runtime.public_safety import public_safe_compact_text
-from ..runtime.time import parse_timestamp
+from ..runtime.time import now_utc, now_utc_iso, parse_timestamp
 from ..todos.contract import normalize_todo_claimed_by, normalize_todo_id
 
 
@@ -30,7 +29,7 @@ def _compact(value: Any, *, limit: int = 220) -> str | None:
 
 
 def _now_iso() -> str:
-    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return now_utc_iso()
 
 
 def _as_dict(value: Any) -> dict[str, Any]:
@@ -254,7 +253,7 @@ def _stale_claim_hint(todo: dict[str, Any] | None, *, agent_id: str) -> dict[str
             "reason": "projected activity timestamp could not be parsed",
             "recommended_operator_action": "inspect status/evidence before considering reassignment",
         }
-    age_hours = (datetime.now(timezone.utc) - parsed.astimezone(timezone.utc)).total_seconds() / 3600
+    age_hours = (now_utc() - parsed).total_seconds() / 3600
     if age_hours <= STALE_CLAIM_THRESHOLD_HOURS:
         return None
     return {

--- a/loopx/control_plane/quota/monitor_poll.py
+++ b/loopx/control_plane/quota/monitor_poll.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from copy import deepcopy
-from datetime import datetime, timezone
 import json
 from pathlib import Path
 from typing import Any
 
 from .decision_summary import compact_quota_decision, quota_decision_agent_id
 from .spend_sources import DEFAULT_SLOT_SPEND_SOURCE, VALID_SLOT_SPEND_SOURCES
+from ..runtime.time import now_local_iso
 from ..runtime.run_artifacts import run_file_stem, unique_run_artifact_paths
 from ..scheduler.monitor_poll_policy import (
     allows_due_monitor_poll,
@@ -24,7 +24,7 @@ QUOTA_MONITOR_POLL_CLASSIFICATION = "quota_monitor_poll"
 
 
 def _now_local() -> str:
-    return datetime.now(timezone.utc).astimezone().replace(microsecond=0).isoformat()
+    return now_local_iso()
 
 
 def build_quota_monitor_poll_event(

--- a/loopx/control_plane/quota/scheduler_ack.py
+++ b/loopx/control_plane/quota/scheduler_ack.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from .decision_summary import compact_quota_decision, quota_decision_agent_id
+from ..runtime.time import now_local_iso
 from ..scheduler.scheduler_hint import (
     build_codex_app_scheduler_ack_event,
     build_scheduler_ack_plan,
@@ -22,7 +22,7 @@ QUOTA_SCHEDULER_ACK_CLASSIFICATION = "quota_scheduler_ack"
 
 
 def _now_local() -> str:
-    return datetime.now(timezone.utc).astimezone().replace(microsecond=0).isoformat()
+    return now_local_iso()
 
 
 def scheduler_ack_failure(

--- a/loopx/control_plane/quota/slot_accounting.py
+++ b/loopx/control_plane/quota/slot_accounting.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 from copy import deepcopy
 import json
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
 from .decision_summary import compact_quota_decision, quota_decision_agent_id
 from .monitor_poll import QUOTA_MONITOR_POLL_CLASSIFICATION
 from .spend_sources import DEFAULT_SLOT_SPEND_SOURCE, VALID_SLOT_SPEND_SOURCES
+from ..runtime.time import now_local_iso
 from ..runtime.run_artifacts import run_file_stem, unique_run_artifact_paths
 from ..todos.contract import normalize_todo_claimed_by
 from ..work_items.delivery_outcome import (
@@ -25,7 +25,7 @@ QuotaStatusBuilder = Callable[..., dict[str, Any]]
 
 
 def _now_local() -> str:
-    return datetime.now(timezone.utc).astimezone().replace(microsecond=0).isoformat()
+    return now_local_iso()
 
 
 def _validate_goal_id_path_segment(goal_id: str) -> str:

--- a/loopx/control_plane/quota/usage_summary.py
+++ b/loopx/control_plane/quota/usage_summary.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import timedelta
 from typing import Any, Callable
 
+from ..runtime.time import now_utc
 
 USAGE_PROXY_NOTE = "run-history proxy; excludes token counts and raw thread logs"
 
@@ -59,7 +60,7 @@ def build_usage_summary(
     *,
     parse_timestamp: ParseTimestamp,
 ) -> dict[str, Any]:
-    now = datetime.now(timezone.utc)
+    now = now_utc()
     cutoff_24h = now - timedelta(hours=24)
     cutoff_7d = now - timedelta(days=7)
     totals = {

--- a/loopx/control_plane/runtime/decision_freshness.py
+++ b/loopx/control_plane/runtime/decision_freshness.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Any, Callable
 
+from .time import now_utc
 
 DECISION_FRESHNESS_WINDOW_DAYS = 7
 DECISION_FRESHNESS_ITEM_LIMIT = 12
@@ -69,7 +70,7 @@ def build_decision_freshness_summary(
     item_limit: int = DECISION_FRESHNESS_ITEM_LIMIT,
     proxy_note: str = DECISION_FRESHNESS_PROXY_NOTE,
 ) -> dict[str, Any]:
-    now = datetime.now(timezone.utc)
+    now = now_utc()
     cutoff = now - timedelta(days=window_days)
     runs = [run for run in history.get("runs") or [] if isinstance(run, dict)]
     items: list[dict[str, Any]] = []

--- a/loopx/control_plane/runtime/event_ledger.py
+++ b/loopx/control_plane/runtime/event_ledger.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Any, Callable, Iterable, Optional
 
+from .time import now_utc
 
 EVENT_LEDGER_CLASSES = (
     "accounting",
@@ -113,7 +114,7 @@ def build_event_ledger_summary(
     event_classes: tuple[str, ...] = EVENT_LEDGER_CLASSES,
     proxy_note: str = EVENT_LEDGER_PROXY_NOTE,
 ) -> dict[str, Any]:
-    now = datetime.now(timezone.utc)
+    now = now_utc()
     cutoff_24h = now - timedelta(hours=24)
     cutoff_7d = now - timedelta(days=7)
     totals = {

--- a/loopx/control_plane/runtime/status_projection_cache.py
+++ b/loopx/control_plane/runtime/status_projection_cache.py
@@ -4,12 +4,14 @@ import hashlib
 import json
 import os
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 from ...history import load_registry
 from ...paths import resolve_runtime_root
+from .time import now_utc as runtime_now_utc
+from .time import now_utc_iso as runtime_now_utc_iso
 from .time import parse_timestamp
 
 
@@ -17,11 +19,11 @@ STATUS_PROJECTION_CACHE_SCHEMA_VERSION = "status_projection_cache_v0"
 
 
 def now_utc() -> datetime:
-    return datetime.now(timezone.utc).replace(microsecond=0)
+    return runtime_now_utc()
 
 
 def now_utc_iso() -> str:
-    return now_utc().isoformat().replace("+00:00", "Z")
+    return runtime_now_utc_iso()
 
 
 def resolve_status_projection_cache_runtime_root(

--- a/loopx/control_plane/runtime/time.py
+++ b/loopx/control_plane/runtime/time.py
@@ -17,3 +17,23 @@ def parse_timestamp(value: Any) -> datetime | None:
     if parsed.tzinfo is None:
         return parsed.replace(tzinfo=timezone.utc)
     return parsed.astimezone(timezone.utc)
+
+
+def now_utc() -> datetime:
+    return datetime.now(timezone.utc).replace(microsecond=0)
+
+
+def now_utc_iso() -> str:
+    return utc_isoformat(now_utc())
+
+
+def now_local_iso() -> str:
+    return datetime.now(timezone.utc).astimezone().replace(microsecond=0).isoformat()
+
+
+def utc_isoformat(value: datetime) -> str:
+    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+def utc_timestamp() -> str:
+    return now_utc().strftime("%Y%m%dT%H%M%SZ")

--- a/loopx/control_plane/scheduler/monitor_todo.py
+++ b/loopx/control_plane/scheduler/monitor_todo.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
 import re
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from typing import Any
 
+from ..runtime.time import now_utc
 from ..todos.contract import (
     TODO_STATUS_OPEN,
     TODO_TASK_CLASS_MONITOR,
@@ -64,7 +65,7 @@ def monitor_next_due_at(
         return None
     checked_at = parse_monitor_timestamp(generated_at)
     if checked_at is None:
-        checked_at = datetime.now(timezone.utc)
+        checked_at = now_utc()
     return (checked_at + delta).astimezone().replace(microsecond=0).isoformat()
 
 
@@ -107,7 +108,7 @@ def monitor_todo_is_expired(item: dict[str, Any], *, now: datetime | None = None
     expires_at = monitor_todo_expires_at(item)
     if expires_at is None:
         return False
-    current_time = now or datetime.now(timezone.utc)
+    current_time = now or now_utc()
     return expires_at <= current_time
 
 
@@ -126,7 +127,7 @@ def monitor_todo_is_due(
     next_due_at = monitor_todo_next_due_at(item)
     if next_due_at is None:
         return False
-    current_time = now or datetime.now(timezone.utc)
+    current_time = now or now_utc()
     return next_due_at <= current_time
 
 

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -5,9 +5,10 @@ import json
 import math
 import re
 from collections.abc import Collection
-from datetime import datetime, timezone
+from datetime import datetime
 from typing import Any
 
+from ..runtime.time import now_utc
 from ..work_items.delivery_outcome import DeliveryOutcome
 from .state import (
     CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
@@ -229,7 +230,7 @@ def _monitor_wait_items(payload: dict[str, Any]) -> list[dict[str, Any]]:
 def _monitor_wait_cadence_progression(payload: dict[str, Any]) -> list[int] | None:
     """Cap monitor quiet backoff so the host does not sleep past monitor due."""
 
-    current_time = datetime.now(timezone.utc)
+    current_time = now_utc()
     caps: list[int] = []
     for item in _monitor_wait_items(payload):
         item_caps: list[int] = []
@@ -238,7 +239,7 @@ def _monitor_wait_cadence_progression(payload: dict[str, Any]) -> list[int] | No
             item_caps.append(cadence_minutes)
         next_due_at = _parse_monitor_timestamp(item.get("next_due_at"))
         if next_due_at is not None:
-            seconds_until_due = (next_due_at.astimezone(timezone.utc) - current_time).total_seconds()
+            seconds_until_due = (next_due_at - current_time).total_seconds()
             item_caps.append(max(1, int(math.ceil(seconds_until_due / 60))))
         if item_caps:
             caps.append(min(item_caps))

--- a/loopx/control_plane/scheduler/time.py
+++ b/loopx/control_plane/scheduler/time.py
@@ -1,17 +1,9 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
 from typing import Any
+
+from ..runtime.time import parse_timestamp
 
 
 def parse_scheduler_timestamp(value: Any) -> datetime | None:
-    text = str(value or "").strip()
-    if not text:
-        return None
-    try:
-        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
-    except ValueError:
-        return None
-    if parsed.tzinfo is None:
-        parsed = parsed.replace(tzinfo=timezone.utc)
-    return parsed.astimezone(timezone.utc)
+    return parse_timestamp(value)

--- a/loopx/control_plane/work_items/task_graph.py
+++ b/loopx/control_plane/work_items/task_graph.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
 import hashlib
 import re
 from typing import Any, Callable
 
+from ..runtime.time import now_utc_iso
 
 TASK_GRAPH_PROJECTION_SCHEMA_VERSION = "task_graph_projection_v0"
 TASK_GRAPH_SOURCE_OF_TRUTH = [
@@ -107,7 +107,7 @@ def _task_graph_generated_at(
         generated_at = public_safe_compact_text(run.get("generated_at"), limit=80)
         if generated_at:
             return generated_at
-    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return now_utc_iso()
 
 
 def _task_graph_active_state_updated_at(

--- a/loopx/control_plane/work_items/task_lease.py
+++ b/loopx/control_plane/work_items/task_lease.py
@@ -2,14 +2,15 @@ from __future__ import annotations
 
 import json
 import re
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta
 from pathlib import Path
 from typing import Any
 
 from ...file_lock import exclusive_file_lock
 from ...history import load_registry
 from ...paths import resolve_runtime_root
-from ..runtime.time import parse_timestamp
+from ..runtime.time import now_utc as runtime_now_utc
+from ..runtime.time import parse_timestamp, utc_isoformat
 from ..todos.contract import (
     normalize_required_write_scopes,
     normalize_todo_claimed_by,
@@ -31,11 +32,11 @@ class TaskLeaseError(ValueError):
 
 
 def now_utc() -> datetime:
-    return datetime.now(timezone.utc).replace(microsecond=0)
+    return runtime_now_utc()
 
 
 def isoformat(value: datetime) -> str:
-    return value.astimezone(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return utc_isoformat(value)
 
 
 def normalize_idempotency_key(value: Any) -> str:

--- a/loopx/event_sourced_state.py
+++ b/loopx/event_sourced_state.py
@@ -4,10 +4,10 @@ import hashlib
 import json
 import re
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable
 
+from .control_plane.runtime.time import now_utc_iso as runtime_now_utc_iso
 from .file_lock import exclusive_file_lock
 from .control_plane.todos.contract import (
     TODO_MONITOR_METADATA_FIELDS,
@@ -93,7 +93,7 @@ class StateEventConflictError(StateEventError):
 
 
 def now_utc_iso() -> str:
-    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return runtime_now_utc_iso()
 
 
 def compact_text(value: Any) -> str:

--- a/loopx/global_registry.py
+++ b/loopx/global_registry.py
@@ -4,11 +4,11 @@ import copy
 import errno
 import json
 import os
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 from .authority import compact_authority_registry
+from .control_plane.runtime.time import now_local_iso
 from .history import load_registry
 from .paths import DEFAULT_RUNTIME_ROOT, global_registry_path, resolve_runtime_root
 from .registry import registry_goals
@@ -27,7 +27,7 @@ ROUTE_FIELDS = ("source_registry", "repo", "state_file")
 
 
 def now_local() -> str:
-    return datetime.now(timezone.utc).astimezone().replace(microsecond=0).isoformat()
+    return now_local_iso()
 
 
 def read_json_if_exists(path: Path) -> dict[str, Any]:

--- a/loopx/history.py
+++ b/loopx/history.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 import json
 import os
 import re
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
 from .authority import goal_authority_registry_summary
 from .control_plane import compact_control_plane_policy
+from .control_plane.runtime.time import now_local_iso
 from .control_plane.runtime.run_index_duplicates import (
     STRUCTURED_INDEX_KEYS,
     classify_index_duplicate_records,
@@ -57,7 +57,7 @@ PER_AGENT_CONTEXT_RUN_FIELDS = (
 
 
 def now_local() -> str:
-    return datetime.now(timezone.utc).astimezone().replace(microsecond=0).isoformat()
+    return now_local_iso()
 
 
 def _normalize_optional_delivery_outcome(value: str | None) -> str | None:

--- a/loopx/pr_review.py
+++ b/loopx/pr_review.py
@@ -7,6 +7,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from .control_plane.runtime.time import now_utc_iso
 from .presentation.markdown import as_dict as _as_dict
 from .presentation.markdown import as_list as _as_list
 from .presentation.public_safety import public_safe_boundary, redact_public_text
@@ -80,7 +81,7 @@ UI_PREFIXES = (
 
 
 def _now_iso() -> str:
-    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return now_utc_iso()
 
 
 def _redact_text(value: object, *, limit: int = 320) -> str:

--- a/loopx/project_uninstall.py
+++ b/loopx/project_uninstall.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import json
 import os
 import shutil
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from .control_plane.runtime.time import now_local_iso, utc_timestamp
 from .history import load_registry
 from .paths import DEFAULT_RUNTIME_ROOT, global_registry_path, resolve_runtime_root
 from .registry import registry_goals
@@ -14,11 +14,11 @@ from .runtime import validate_goal_id_path_segment
 
 
 def _now_local() -> str:
-    return datetime.now(timezone.utc).astimezone().replace(microsecond=0).isoformat()
+    return now_local_iso()
 
 
 def _timestamp() -> str:
-    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    return utc_timestamp()
 
 
 def _write_json(path: Path, payload: dict[str, Any]) -> None:

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 import hashlib
 import json
 import re
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from .control_plane.runtime.time import now_local_iso
 from .control_plane.work_items.delivery_batch_scale import DELIVERY_BATCH_SCALE_CHOICES, require_delivery_batch_scale
 from .control_plane.work_items.delivery_outcome import DELIVERY_OUTCOME_CHOICES, require_delivery_outcome
 from .feedback import validate_local_control_text, validate_public_safe_text
@@ -68,7 +68,7 @@ VISION_UNCHANGED_REASON_LIMIT = 240
 
 
 def now_local() -> str:
-    return datetime.now(timezone.utc).astimezone().replace(microsecond=0).isoformat()
+    return now_local_iso()
 
 
 def run_file_stem(generated_at: str) -> str:

--- a/loopx/summary_all.py
+++ b/loopx/summary_all.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any
 
+from .control_plane.runtime.time import now_utc, now_utc_iso
 from .history import collect_history, load_registry
 from .paths import resolve_runtime_root
 from .presentation.markdown import as_dict as _as_dict
@@ -43,12 +44,12 @@ LANE_PRIORITY = {
 }
 
 def _now_iso() -> str:
-    return datetime.now(timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    return now_utc_iso()
 
 
 def _parse_time_range(value: str) -> tuple[str, datetime | None]:
     normalized = (value or "24h").strip().lower()
-    now = datetime.now(timezone.utc)
+    now = now_utc()
     if normalized.endswith("h") and normalized[:-1].isdigit():
         return normalized, now - timedelta(hours=int(normalized[:-1]))
     if normalized.endswith("d") and normalized[:-1].isdigit():


### PR DESCRIPTION
## Summary
- Centralizes shared control-plane time helpers in `loopx.control_plane.runtime.time` for UTC parsing, UTC ISO strings, local ISO strings, and UTC timestamp ids.
- Routes scheduler, monitor todo, quota ack/poll/slot accounting, runtime status cache, event ledger, decision freshness, task lease/graph, agent management, and top-level history/registry/state refresh surfaces through the shared helper.
- Extends readmodel/scheduler smokes so parser sharing remains explicit.

## Validation
- `python3 -m py_compile $(git diff --name-only -- '*.py')`
- `python3 examples/control_plane/todo-readmodel-boundary-smoke.py`
- `python3 examples/control_plane/monitor-scheduler-contract-smoke.py`
- `python3 examples/control_plane/quota-scheduler-policy-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 examples/pr-review-command-smoke.py`
- `python3 examples/project/global-manager-command-cli-smoke.py`
- `python3 examples/project/global-manager-command-protocol-smoke.py`
- `python3 examples/control_plane/check-public-boundary-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli --format json --registry "$HOME/.codex/loopx/registry.global.json" --runtime-root "$HOME/.codex/loopx" quota should-run --goal-id loopx-meta --agent-id codex-product-capability`
- `loopx canary premerge --from-git-diff` passed with `merge_gate_passed=true`, `self_merge_allowed=true`, `manual_holds=0`.
