### PR TITLE
Centralize agent-scope routing helpers

### DIFF
--- a/examples/control_plane/todo-projection-shared-helper-smoke.py
+++ b/examples/control_plane/todo-projection-shared-helper-smoke.py
@@ -22,7 +22,13 @@ from loopx.control_plane.testing.quota_fixtures import (  # noqa: E402
     quota_todo_summary,
 )
 from loopx.control_plane.agents.agent_scope import (  # noqa: E402
-    _todo_item_claimed_by_agent_or_unclaimed as agent_scope_todo_item_claimed_by_agent_or_unclaimed,
+    agent_scope_blocking_handoff_gates,
+    agent_scope_count_advancement_items,
+    agent_scope_item_claimed_by_agent_or_unclaimed,
+    agent_scope_item_matches_agent_or_unclaimed,
+)
+from loopx.control_plane.goals.goal_frontier import (  # noqa: E402
+    build_goal_frontier_projection_from_summaries,
 )
 from loopx.status import (  # noqa: E402
     claimed_visibility_items as status_claimed_visibility_items,
@@ -208,11 +214,132 @@ def assert_claimed_visibility_parity() -> None:
     unclaimed = items[3]
     for predicate in (
         shared_todo_item_claimed_by_agent_or_unclaimed,
-        agent_scope_todo_item_claimed_by_agent_or_unclaimed,
+        agent_scope_item_claimed_by_agent_or_unclaimed,
     ):
         assert predicate(claimed_by_current, agent_id="agent-a") is True, claimed_by_current
         assert predicate(claimed_by_other, agent_id="agent-a") is False, claimed_by_other
         assert predicate(unclaimed, agent_id="agent-a") is True, unclaimed
+
+
+def assert_agent_scope_frontier_routing_parity() -> None:
+    current = {
+        "todo_id": "todo_current_spaced_claim",
+        "index": 1,
+        "priority": "P1",
+        "text": "[P1] Current agent with whitespace-normalized claim.",
+        "task_class": TODO_TASK_CLASS_ADVANCEMENT,
+        "claimed_by": " agent-a ",
+    }
+    other = {
+        "todo_id": "todo_other",
+        "index": 2,
+        "priority": "P1",
+        "text": "[P1] Other agent work.",
+        "task_class": TODO_TASK_CLASS_ADVANCEMENT,
+        "claimed_by": "agent-b",
+    }
+    unclaimed = {
+        "todo_id": "todo_unclaimed_scope",
+        "index": 3,
+        "priority": "P1",
+        "text": "[P1] Unclaimed shared lane work.",
+        "task_class": TODO_TASK_CLASS_ADVANCEMENT,
+    }
+    blocked_for_current = {
+        "todo_id": "todo_blocks_current",
+        "index": 4,
+        "priority": "P1",
+        "text": "[P1] Handoff work blocking the current agent.",
+        "task_class": TODO_TASK_CLASS_ADVANCEMENT,
+        "claimed_by": "agent-b",
+        "blocks_agent": "agent-a",
+    }
+    blocked_for_other = {
+        "todo_id": "todo_blocks_other",
+        "index": 5,
+        "priority": "P1",
+        "text": "[P1] Handoff work blocking a different agent.",
+        "task_class": TODO_TASK_CLASS_ADVANCEMENT,
+        "claimed_by": "agent-a",
+        "blocks_agent": "agent-b",
+    }
+    assert agent_scope_count_advancement_items(
+        [current, other, unclaimed],
+        claimed_by="agent-a",
+    ) == 1
+    assert agent_scope_count_advancement_items(
+        [current, other, unclaimed],
+        claimed_by="__unclaimed__",
+    ) == 1
+    assert agent_scope_item_matches_agent_or_unclaimed(
+        blocked_for_current,
+        agent_id="agent-a",
+    ) is True
+    assert agent_scope_item_matches_agent_or_unclaimed(
+        blocked_for_other,
+        agent_id="agent-a",
+    ) is False
+
+    agent_summary = {
+        "executable_backlog_items": [current, other, unclaimed],
+        "unclaimed_priority_open_items": [unclaimed],
+        "claim_scope": {"other_agent_claimed_items": [other]},
+        "deferred_resume_candidates": [
+            {
+                "todo_id": "todo_deferred_current",
+                "text": "[P1] Current agent deferred successor.",
+                "task_class": TODO_TASK_CLASS_ADVANCEMENT,
+                "claimed_by": " agent-a ",
+            },
+            {
+                "todo_id": "todo_deferred_other",
+                "text": "[P1] Other agent deferred successor.",
+                "task_class": TODO_TASK_CLASS_ADVANCEMENT,
+                "claimed_by": "agent-b",
+            },
+        ],
+        "handoff_gates": [
+            {
+                "todo_id": "todo_gate_current",
+                "index": 6,
+                "text": "[P1] Current agent blocking handoff.",
+                "task_class": TODO_TASK_CLASS_ADVANCEMENT,
+                "blocks_agent": " agent-a ",
+                "gate_state": "blocking",
+            },
+            {
+                "todo_id": "todo_gate_other",
+                "index": 7,
+                "text": "[P1] Other agent blocking handoff.",
+                "task_class": TODO_TASK_CLASS_ADVANCEMENT,
+                "blocks_agent": "agent-b",
+                "gate_state": "blocking",
+            },
+            {
+                "todo_id": "todo_gate_cleared",
+                "index": 8,
+                "text": "[P1] Current agent cleared handoff.",
+                "task_class": TODO_TASK_CLASS_ADVANCEMENT,
+                "blocks_agent": "agent-a",
+                "gate_state": "cleared_without_successor",
+            },
+        ],
+    }
+    projection = build_goal_frontier_projection_from_summaries(
+        goal_id=GOAL_ID,
+        agent_id="agent-a",
+        user_todo_summary={"open_count": 0},
+        agent_todo_summary=agent_summary,
+        work_lane_contract={"lane": TODO_TASK_CLASS_ADVANCEMENT},
+        replan_obligation=None,
+    )
+    frontier = projection["remaining_advancement_frontier"]
+    assert frontier["current_agent_claimed_advancement_count"] == 1, projection
+    assert frontier["unclaimed_advancement_count"] == 1, projection
+    assert frontier["other_agent_claimed_advancement_count"] == 1, projection
+    assert projection["deferred_successors"]["current_agent_ready_count"] == 1, projection
+    blocking = agent_scope_blocking_handoff_gates(agent_summary, agent_id="agent-a")
+    assert [item["todo_id"] for item in blocking] == ["todo_gate_current"], blocking
 
 
 def assert_deferred_helper_parity() -> None:
@@ -351,6 +478,7 @@ def main() -> int:
     assert_status_summary_lanes(summary)
     assert_shared_ordering_parity(summary)
     assert_claimed_visibility_parity()
+    assert_agent_scope_frontier_routing_parity()
     assert_deferred_helper_parity()
     assert_monitor_item_collection_parity(summary)
     assert_open_task_count_state_machine(summary)

--- a/loopx/control_plane/agents/agent_lane_recommendation.py
+++ b/loopx/control_plane/agents/agent_lane_recommendation.py
@@ -5,7 +5,6 @@ from typing import Any, Callable, Optional
 
 from ..todos.contract import (
     TODO_TASK_CLASS_ADVANCEMENT,
-    normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
     normalize_todo_id,
 )
@@ -15,6 +14,9 @@ from ..work_items.work_lane import work_lane_contract_is_due_monitor_attempt
 from .agent_scope import (
     _todo_item_is_actionable_open,
     _todo_task_class,
+    agent_scope_item_blocks_agent,
+    agent_scope_item_claimed_by,
+    agent_scope_item_claimed_by_agent_or_unclaimed,
 )
 from .capability_gate import _agent_lane_candidate_sort_key
 
@@ -217,12 +219,15 @@ def build_agent_lane_next_action(
         selected = scoped_user_gate_fallback.get("selected_executable")
         if isinstance(selected, dict):
             text = protocol_action_text(selected.get("text"), limit=500)
-            claimed_by = normalize_todo_claimed_by(selected.get("claimed_by"))
+            claimed_by = agent_scope_item_claimed_by(selected)
             if (
                 text
                 and _todo_item_is_actionable_open(selected)
                 and _todo_task_class(selected) == TODO_TASK_CLASS_ADVANCEMENT
-                and (not claimed_by or claimed_by == agent_id)
+                and agent_scope_item_claimed_by_agent_or_unclaimed(
+                    selected,
+                    agent_id=agent_id,
+                )
             ):
                 payload = dict(selected)
                 payload.update(
@@ -310,8 +315,10 @@ def build_agent_lane_next_action(
             identity = (str(raw_item.get("todo_id") or ""), text)
             if identity in seen:
                 continue
-            claimed_by = normalize_todo_claimed_by(raw_item.get("claimed_by"))
-            if claimed_by and claimed_by != agent_id:
+            if not agent_scope_item_claimed_by_agent_or_unclaimed(
+                raw_item,
+                agent_id=agent_id,
+            ):
                 continue
             seen.add(identity)
             source_candidates.append(raw_item)
@@ -325,7 +332,7 @@ def build_agent_lane_next_action(
             ),
         ):
             text = protocol_action_text(raw_item.get("text"), limit=500)
-            claimed_by = normalize_todo_claimed_by(raw_item.get("claimed_by"))
+            claimed_by = agent_scope_item_claimed_by(raw_item)
             todo_id = str(raw_item.get("todo_id") or "").strip()
             selected_by = (
                 "active_next_action_todo"
@@ -344,7 +351,7 @@ def build_agent_lane_next_action(
                 and normalize_todo_id(todo_id) in active_next_action_todo_ids
             ):
                 lineage_source = "agent_todo_summary.active_next_action_executable_items"
-            blocks_agent = normalize_todo_blocks_agent(raw_item.get("blocks_agent"))
+            blocks_agent = agent_scope_item_blocks_agent(raw_item)
             unblocks_todo_id = normalize_todo_id(raw_item.get("unblocks_todo_id"))
             if blocks_agent:
                 payload["unblock_handoff"] = {"blocks_agent": blocks_agent}

--- a/loopx/control_plane/agents/agent_scope.py
+++ b/loopx/control_plane/agents/agent_scope.py
@@ -106,6 +106,71 @@ def _todo_item_is_actionable_open(item: dict[str, Any]) -> bool:
     return todo_item_is_actionable_open(item)
 
 
+def agent_scope_item_claimed_by(item: dict[str, Any]) -> str | None:
+    return normalize_todo_claimed_by(item.get("claimed_by"))
+
+
+def agent_scope_item_blocks_agent(item: dict[str, Any]) -> str | None:
+    return normalize_todo_blocks_agent(item.get("blocks_agent"))
+
+
+def agent_scope_item_claimed_by_agent_or_unclaimed(
+    item: dict[str, Any],
+    *,
+    agent_id: str | None,
+) -> bool:
+    return todo_item_claimed_by_agent_or_unclaimed(item, agent_id=agent_id)
+
+
+def agent_scope_item_matches_agent_or_unclaimed(
+    item: dict[str, Any],
+    *,
+    agent_id: str | None,
+) -> bool:
+    normalized_agent_id = normalize_todo_claimed_by(agent_id)
+    if not normalized_agent_id:
+        return True
+    blocks_agent = agent_scope_item_blocks_agent(item)
+    if blocks_agent:
+        return blocks_agent == normalized_agent_id
+    return agent_scope_item_claimed_by_agent_or_unclaimed(
+        item,
+        agent_id=normalized_agent_id,
+    )
+
+
+def agent_scope_count_advancement_items(
+    items: Any,
+    *,
+    claimed_by: str | None = None,
+) -> int:
+    if not isinstance(items, list):
+        return 0
+    normalized_claimed_by = (
+        "__unclaimed__"
+        if claimed_by == "__unclaimed__"
+        else normalize_todo_claimed_by(claimed_by)
+        if claimed_by is not None
+        else None
+    )
+    count = 0
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if not _todo_item_is_actionable_open(item):
+            continue
+        if _todo_task_class(item) != TODO_TASK_CLASS_ADVANCEMENT:
+            continue
+        item_claimed_by = agent_scope_item_claimed_by(item)
+        if normalized_claimed_by == "__unclaimed__":
+            if item_claimed_by:
+                continue
+        elif normalized_claimed_by is not None and item_claimed_by != normalized_claimed_by:
+            continue
+        count += 1
+    return count
+
+
 def _protocol_action_text(value: Any, *, limit: int = 220) -> str | None:
     if value is None:
         return None
@@ -169,7 +234,7 @@ def _user_gate_blocks_agent_item(gate: dict[str, Any], agent_item: dict[str, Any
 
 
 def _todo_item_claimed_by_agent_or_unclaimed(item: dict[str, Any], *, agent_id: str) -> bool:
-    return todo_item_claimed_by_agent_or_unclaimed(item, agent_id=agent_id)
+    return agent_scope_item_claimed_by_agent_or_unclaimed(item, agent_id=agent_id)
 
 
 def _agent_scope_selectable_todo_item(
@@ -182,7 +247,7 @@ def _agent_scope_selectable_todo_item(
     agent_id = normalize_todo_claimed_by(agent_identity.get("agent_id"))
     if not agent_id:
         return True
-    blocks_agent = normalize_todo_blocks_agent(item.get("blocks_agent"))
+    blocks_agent = agent_scope_item_blocks_agent(item)
     if blocks_agent and blocks_agent != agent_id:
         return False
     return _todo_item_claimed_by_agent_or_unclaimed(item, agent_id=agent_id)
@@ -205,14 +270,14 @@ def _agent_scope_filter_user_gate_items(
         if normalize_todo_global_gate(item.get("global_gate")):
             current_agent_items.append(item)
             continue
-        blocks_agent = normalize_todo_blocks_agent(item.get("blocks_agent"))
+        blocks_agent = agent_scope_item_blocks_agent(item)
         if blocks_agent:
             if blocks_agent != agent_id:
                 other_agent_scoped_items.append(item)
                 continue
             current_agent_items.append(item)
             continue
-        claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
+        claimed_by = agent_scope_item_claimed_by(item)
         if claimed_by and claimed_by != agent_id:
             other_agent_scoped_items.append(item)
             continue
@@ -272,7 +337,7 @@ def _scoped_user_gate_fallback(
         executable_items = [
             item
             for item in executable_items
-            if normalize_todo_claimed_by(item.get("claimed_by")) in {"", agent_id}
+            if agent_scope_item_claimed_by_agent_or_unclaimed(item, agent_id=agent_id)
         ]
     blocked_items: list[dict[str, Any]] = []
     selected: dict[str, Any] | None = None
@@ -415,24 +480,7 @@ def _agent_scoped_user_gate_override(
 
 
 def _count_advancement_items(items: Any, *, claimed_by: str | None = None) -> int:
-    if not isinstance(items, list):
-        return 0
-    count = 0
-    for item in items:
-        if not isinstance(item, dict):
-            continue
-        if not _todo_item_is_actionable_open(item):
-            continue
-        if _todo_task_class(item) != TODO_TASK_CLASS_ADVANCEMENT:
-            continue
-        item_claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
-        if claimed_by == "__unclaimed__":
-            if item_claimed_by:
-                continue
-        elif claimed_by is not None and item_claimed_by != claimed_by:
-            continue
-        count += 1
-    return count
+    return agent_scope_count_advancement_items(items, claimed_by=claimed_by)
 
 
 def _agent_scope_frontier_action(value: Any) -> AgentScopeFrontierAction | None:
@@ -675,8 +723,10 @@ def _agent_scope_deferred_resume_candidates(
             for item in value:
                 if not isinstance(item, dict):
                     continue
-                claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
-                if claimed_by and claimed_by != agent_id:
+                if not agent_scope_item_claimed_by_agent_or_unclaimed(
+                    item,
+                    agent_id=agent_id,
+                ):
                     continue
                 candidates.append(item)
 
@@ -753,33 +803,12 @@ def _agent_scope_cleared_without_successor_handoff_gates(
     *,
     agent_id: str,
 ) -> list[dict[str, Any]]:
-    candidates: list[dict[str, Any]] = []
-    for key in (
-        "current_agent_cleared_without_successor_handoff_gates",
-        "handoff_gates",
-    ):
-        value = agent_todo_summary.get(key)
-        if not isinstance(value, list):
-            continue
-        for item in value:
-            if not isinstance(item, dict):
-                continue
-            if normalize_todo_blocks_agent(item.get("blocks_agent")) != agent_id:
-                continue
-            if item.get("gate_state") != HandoffGateState.CLEARED_WITHOUT_SUCCESSOR.value:
-                continue
-            candidates.append(item)
-
-    unique: list[dict[str, Any]] = []
-    seen: set[str] = set()
-    for item in candidates:
-        identity = str(item.get("todo_id") or item.get("index") or item.get("text") or "")
-        if identity in seen:
-            continue
-        seen.add(identity)
-        compact = dict(item)
-        compact["text"] = str(item.get("text") or "").strip()
-        unique.append(compact)
+    unique = _agent_scope_handoff_gates_by_state(
+        agent_todo_summary,
+        agent_id=agent_id,
+        gate_state=HandoffGateState.CLEARED_WITHOUT_SUCCESSOR.value,
+        preferred_key="current_agent_cleared_without_successor_handoff_gates",
+    )
     return sorted(
         unique,
         key=lambda item: (
@@ -789,12 +818,16 @@ def _agent_scope_cleared_without_successor_handoff_gates(
     )
 
 
-def _agent_scope_blocking_handoff_gates(
+def _agent_scope_handoff_gates_by_state(
     agent_todo_summary: dict[str, Any],
     *,
-    agent_id: str,
+    agent_id: str | None,
+    gate_state: str,
+    preferred_key: str,
 ) -> list[dict[str, Any]]:
-    gates = agent_todo_summary.get("current_agent_handoff_gates")
+    if not agent_id:
+        return []
+    gates = agent_todo_summary.get(preferred_key)
     if not isinstance(gates, list):
         gates = agent_todo_summary.get("handoff_gates")
     if not isinstance(gates, list):
@@ -804,9 +837,9 @@ def _agent_scope_blocking_handoff_gates(
     for item in gates:
         if not isinstance(item, dict):
             continue
-        if normalize_todo_blocks_agent(item.get("blocks_agent")) != agent_id:
+        if agent_scope_item_blocks_agent(item) != agent_id:
             continue
-        if item.get("gate_state") != HandoffGateState.BLOCKING.value:
+        if item.get("gate_state") != gate_state:
             continue
         identity = str(item.get("todo_id") or item.get("index") or item.get("text") or "")
         if identity in seen:
@@ -815,7 +848,29 @@ def _agent_scope_blocking_handoff_gates(
         compact = dict(item)
         compact["text"] = str(item.get("text") or "").strip()
         selected.append(compact)
+    return selected
+
+
+def agent_scope_blocking_handoff_gates(
+    agent_todo_summary: dict[str, Any],
+    *,
+    agent_id: str | None,
+) -> list[dict[str, Any]]:
+    selected = _agent_scope_handoff_gates_by_state(
+        agent_todo_summary,
+        agent_id=agent_id,
+        gate_state=HandoffGateState.BLOCKING.value,
+        preferred_key="current_agent_handoff_gates",
+    )
     return sorted(selected, key=_todo_projection_sort_key)
+
+
+def _agent_scope_blocking_handoff_gates(
+    agent_todo_summary: dict[str, Any],
+    *,
+    agent_id: str,
+) -> list[dict[str, Any]]:
+    return agent_scope_blocking_handoff_gates(agent_todo_summary, agent_id=agent_id)
 
 
 def _route_continuation_candidate_matches_agent(
@@ -823,11 +878,7 @@ def _route_continuation_candidate_matches_agent(
     *,
     agent_id: str,
 ) -> bool:
-    blocks_agent = normalize_todo_blocks_agent(item.get("blocks_agent"))
-    if blocks_agent:
-        return blocks_agent == agent_id
-    claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
-    return not claimed_by or claimed_by == agent_id
+    return agent_scope_item_matches_agent_or_unclaimed(item, agent_id=agent_id)
 
 
 def _agent_scope_route_continuation_replan_candidates(
@@ -1065,7 +1116,7 @@ def _agent_scope_no_candidate_frontier(
             {
                 claimed_by
                 for item in blocking_handoff_gates
-                for claimed_by in [normalize_todo_claimed_by(item.get("claimed_by"))]
+                for claimed_by in [agent_scope_item_claimed_by(item)]
                 if claimed_by
             }
         )
@@ -1154,26 +1205,26 @@ def _agent_scope_no_candidate_frontier(
         if isinstance(item, dict)
         and _todo_item_is_actionable_open(item)
         and _todo_task_class(item) == TODO_TASK_CLASS_ADVANCEMENT
-        and normalize_todo_claimed_by(item.get("claimed_by")) not in {None, "", agent_id}
+        and agent_scope_item_claimed_by(item) not in {None, "", agent_id}
     ]
     other_claimants = sorted(
         {
             claimed_by
             for item in other_advancement_items
-            for claimed_by in [normalize_todo_claimed_by(item.get("claimed_by"))]
+            for claimed_by in [agent_scope_item_claimed_by(item)]
             if claimed_by
         }
     )
     blocking_review_items = [
         item
         for item in other_advancement_items
-        if normalize_todo_blocks_agent(item.get("blocks_agent")) == agent_id
+        if agent_scope_item_blocks_agent(item) == agent_id
     ]
     blocking_review_claimants = sorted(
         {
             claimed_by
             for item in blocking_review_items
-            for claimed_by in [normalize_todo_claimed_by(item.get("claimed_by"))]
+            for claimed_by in [agent_scope_item_claimed_by(item)]
             if claimed_by
         }
     )

--- a/loopx/control_plane/agents/capability_gate.py
+++ b/loopx/control_plane/agents/capability_gate.py
@@ -6,7 +6,6 @@ from ..todos.contract import (
     TODO_TASK_CLASS_ADVANCEMENT,
     normalize_required_capabilities,
     normalize_target_capabilities,
-    normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
 )
 from ..todos.projection import (
@@ -16,6 +15,7 @@ from ..todos.projection import (
     todo_priority_rank,
 )
 from ..todos.summary_item import compact_todo_summary_item
+from .agent_scope import agent_scope_item_blocks_agent, agent_scope_item_claimed_by
 
 
 CAPABILITY_GATE_SCHEMA_VERSION = "capability_gate_v0"
@@ -85,8 +85,8 @@ def _unblock_handoff_rank(
     *,
     agent_id: str | None,
 ) -> int:
-    claimed_by = normalize_todo_claimed_by(raw_item.get("claimed_by"))
-    blocks_agent = normalize_todo_blocks_agent(raw_item.get("blocks_agent"))
+    claimed_by = agent_scope_item_claimed_by(raw_item)
+    blocks_agent = agent_scope_item_blocks_agent(raw_item)
     return (
         0
         if agent_id
@@ -98,7 +98,7 @@ def _unblock_handoff_rank(
 
 
 def _primary_review_rank(raw_item: dict[str, Any], *, agent_id: str | None) -> int:
-    claimed_by = normalize_todo_claimed_by(raw_item.get("claimed_by"))
+    claimed_by = agent_scope_item_claimed_by(raw_item)
     action_kind = str(raw_item.get("action_kind") or "").strip()
     return (
         0
@@ -120,7 +120,7 @@ def _agent_lane_candidate_sort_key(
     preferred_todo_ids = preferred_todo_ids or set()
     todo_id = str(raw_item.get("todo_id") or "").strip()
     active_next_rank = 0 if todo_id and todo_id in preferred_todo_ids else 1
-    claimed_by = normalize_todo_claimed_by(raw_item.get("claimed_by"))
+    claimed_by = agent_scope_item_claimed_by(raw_item)
     claim_rank = 0 if agent_id and claimed_by == agent_id else 1
     repair_rank = 0 if raw_item.get("capability_repair_mode") is True else 1
     return (

--- a/loopx/control_plane/goals/goal_frontier.py
+++ b/loopx/control_plane/goals/goal_frontier.py
@@ -2,6 +2,13 @@ from __future__ import annotations
 
 from typing import Any
 
+from ..agents.agent_scope import (
+    agent_scope_blocking_handoff_gates,
+    agent_scope_count_advancement_items,
+    agent_scope_item_claimed_by,
+    agent_scope_item_claimed_by_agent_or_unclaimed,
+)
+
 
 GOAL_FRONTIER_PROJECTION_SCHEMA_VERSION = "goal_frontier_projection_v0"
 VISION_CONTINUATION_AUDIT_SCHEMA_VERSION = "vision_continuation_audit_v0"
@@ -527,24 +534,7 @@ def _todo_task_class(item: dict[str, Any]) -> str:
 
 
 def _count_advancement_items(items: Any, *, claimed_by: str | None = None) -> int:
-    if not isinstance(items, list):
-        return 0
-    count = 0
-    for item in items:
-        if not isinstance(item, dict):
-            continue
-        if not _todo_item_is_actionable_open(item):
-            continue
-        if _todo_task_class(item) != TODO_TASK_CLASS_ADVANCEMENT:
-            continue
-        item_claimed_by = str(item.get("claimed_by") or "").strip()
-        if claimed_by == "__unclaimed__":
-            if item_claimed_by:
-                continue
-        elif claimed_by is not None and item_claimed_by != claimed_by:
-            continue
-        count += 1
-    return count
+    return agent_scope_count_advancement_items(items, claimed_by=claimed_by)
 
 
 def _summary_task_counts(summary: dict[str, Any] | None) -> dict[str, int]:
@@ -722,7 +712,7 @@ def _deferred_successors(
     current_agent_ready_items = [
         item
         for item in ready_items
-        if agent_id and str(item.get("claimed_by") or "").strip() == agent_id
+        if agent_id and agent_scope_item_claimed_by(item) == agent_id
     ]
     ready_todo_ids = [
         todo_id for todo_id in (_compact_todo_id(item) for item in ready_items[:5]) if todo_id
@@ -772,20 +762,7 @@ def _blocking_handoff_gate_count(
 ) -> int:
     if not agent_id or not isinstance(agent_todo_summary, dict):
         return 0
-    gates = agent_todo_summary.get("current_agent_handoff_gates")
-    if not isinstance(gates, list):
-        gates = agent_todo_summary.get("handoff_gates")
-    if not isinstance(gates, list):
-        return 0
-    return len(
-        [
-            item
-            for item in gates
-            if isinstance(item, dict)
-            and str(item.get("blocks_agent") or "").strip() == agent_id
-            and str(item.get("gate_state") or "").strip() == "blocking"
-        ]
-    )
+    return len(agent_scope_blocking_handoff_gates(agent_todo_summary, agent_id=agent_id))
 
 
 def _succession_gap_items(
@@ -813,7 +790,7 @@ def _succession_gap_items(
     return [
         item
         for item in items
-        if str(item.get("claimed_by") or "").strip() in {"", agent_id}
+        if agent_scope_item_claimed_by_agent_or_unclaimed(item, agent_id=agent_id)
     ]
 
 


### PR DESCRIPTION
## Summary
- expose canonical agent-scope helpers for normalized claimed_by, blocks_agent, current/unclaimed matching, advancement counts, and blocking handoff gates
- reuse those helpers in goal-frontier projections, capability-gate ranking, and agent-lane next-action selection
- extend the shared todo projection smoke to pin routing/frontier parity for normalized claims, unclaimed advancement counts, deferred successors, and handoff gates

## Validation
- python3 -m py_compile loopx/control_plane/agents/agent_scope.py loopx/control_plane/agents/agent_lane_recommendation.py loopx/control_plane/agents/capability_gate.py loopx/control_plane/goals/goal_frontier.py
- python3 examples/control_plane/todo-projection-shared-helper-smoke.py
- python3 examples/control_plane/quota-agent-scoped-user-gate-smoke.py
- python3 examples/control_plane/quota-todo-summary-readmodel-smoke.py
- python3 examples/control_plane/todo-claim-visibility-lanes-smoke.py
- python3 examples/control_plane/run-compaction-readmodel-smoke.py
- python3 examples/control_plane/status-quota-review-packet-parity-smoke.py
- git diff --check
- loopx canary premerge --from-git-diff

## Premerge gate
- surfaces: control_plane, public_boundary, python
- risk profiles: core-control-plane, canary-runner
- manual holds: 0
- merge gate: passed
- self-merge allowed: true