### PR TITLE
Move goal channel HTML renderer into presentation

### DIFF
--- a/docs/frontstage-channel-lease-roadmap.md
+++ b/docs/frontstage-channel-lease-roadmap.md
@@ -155,8 +155,8 @@ The first product-path read model lives in
 stays read-only: callers pass already-compact status, quota, run-history,
 review-packet, artifact, and lease/claim payloads; the builder emits
 `source_warnings` when raw or private-looking fields appear instead of copying
-those values into the channel. The static HTML renderer in `loopx.frontstage`
-and fixture in
+those values into the channel. The static HTML renderer in
+`loopx/presentation/renderers/goal_channel_html.py` and fixture in
 `examples/goal-channel-frontstage-fixture.py` renders that projection into
 semantic panels with `data-panel` markers, no write controls, and a visible
 truth contract. `loopx --format json status` and the loopback

--- a/examples/goal-channel-frontstage-fixture.py
+++ b/examples/goal-channel-frontstage-fixture.py
@@ -16,7 +16,9 @@ if str(REPO_ROOT) not in sys.path:
 from loopx.control_plane.goals.goal_channel_projection import (  # noqa: E402
     build_goal_channel_projection,
 )
-from loopx.frontstage import render_goal_channel_projection_html  # noqa: E402
+from loopx.presentation.renderers.goal_channel_html import (  # noqa: E402
+    render_goal_channel_projection_html,
+)
 
 
 REDACTED_LOCAL_PATH = "/" + "Users/example/private-control-plane.md"

--- a/loopx/presentation/renderers/goal_channel_html.py
+++ b/loopx/presentation/renderers/goal_channel_html.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from html import escape
 from typing import Any, Mapping, Sequence
 
-from .control_plane.goals.goal_channel_projection import (
+from ...control_plane.goals.goal_channel_projection import (
     GOAL_CHANNEL_PROJECTION_SCHEMA_VERSION,
     compact_goal_channel_text,
 )


### PR DESCRIPTION
## Summary
- Move the read-only goal-channel HTML renderer from the historical `loopx.frontstage` module into `loopx.presentation.renderers.goal_channel_html`.
- Update the static goal-channel fixture import and roadmap anchor.
- Do not retain a compatibility shim: repo call sites now use the presentation renderer path directly.

## Validation
- `python3 examples/project/goal-channel-frontstage-fixture-smoke.py`
- `python3 examples/project/goal-channel-projection-smoke.py`
- `python3 examples/project/goal-channel-status-export-smoke.py`
- `python3 examples/control_plane/goal-channel-readmodel-smoke.py`
- `python3 -m compileall -q loopx/presentation/renderers/goal_channel_html.py examples/goal-channel-frontstage-fixture.py`
- `git diff --check`
- `loopx check --scan-path docs/frontstage-channel-lease-roadmap.md --scan-path examples/goal-channel-frontstage-fixture.py --scan-path loopx/presentation/renderers/goal_channel_html.py`
- `PYTHONPATH=. python3 -m loopx.cli canary premerge --from-git-diff` passed with `merge_gate_passed=true`, `self_merge_allowed=true`, `manual_holds=0`.

## Boundary
Public/private boundary checks are clean. This is a non-benchmark presentation/read-model ownership cleanup; no raw benchmark logs, task text, trajectories, verifier output, credentials, private state, or local evidence are included.