### PR TITLE
Route summarized evidence back into the auto-research ring

### DIFF
--- a/examples/auto-research-worker-turn-smoke.py
+++ b/examples/auto-research-worker-turn-smoke.py
@@ -300,11 +300,11 @@ def main() -> int:
             goal_id=GOAL_ID,
             role="agent",
             text=(
-                "[P0-auto-research-live] Summarize held-out validation and "
+                "[P0-auto-research-live] Summarize visible held-out evidence and "
                 "open the next research round."
             ),
             task_class="advancement_task",
-            action_kind="write_evaluation_summary",
+            action_kind="summarize_evidence",
             claimed_by=EVALUATOR_AGENT_ID,
             dry_run=False,
         )
@@ -322,7 +322,7 @@ def main() -> int:
             complete=True,
         )
         assert evaluator_summary["mode"] == "execute", evaluator_summary
-        assert evaluator_summary["selected_action"] == "write_evaluation_summary", evaluator_summary
+        assert evaluator_summary["selected_action"] == "summarize_evidence", evaluator_summary
         successor_todos = evaluator_summary["successor_todos"]
         assert successor_todos["executed"] is True, successor_todos
         successor_ids = [

--- a/loopx/capabilities/auto_research/preset.py
+++ b/loopx/capabilities/auto_research/preset.py
@@ -152,6 +152,7 @@ AUTO_RESEARCH_ROLE_PROFILES: dict[str, dict[str, object]] = {
         "successor_todos": [
             _successor("summarize_evidence", AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION, "research-curator", "research_curator", "review_research_contract", AUTO_RESEARCH_CURATOR_REVIEW_SUCCESSOR_TEXT),
             _successor("summarize_evidence", AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION, "hypothesis-proposer", "hypothesis_proposer", "review_hypothesis_frontier", AUTO_RESEARCH_HYPOTHESIS_FRONTIER_REVIEW_SUCCESSOR_TEXT),
+            _successor("summarize_evidence", AUTO_RESEARCH_NEXT_HYPOTHESIS_SUCCESSOR_CONDITION, "research-curator", "research_curator", "review_research_contract", AUTO_RESEARCH_CURATOR_REVIEW_SUCCESSOR_TEXT),
             _successor("write_evaluation_summary", AUTO_RESEARCH_NEXT_HYPOTHESIS_SUCCESSOR_CONDITION, "research-curator", "research_curator", "review_research_contract", AUTO_RESEARCH_CURATOR_REVIEW_SUCCESSOR_TEXT),
             _successor("review_promotion_readiness", AUTO_RESEARCH_NEXT_HYPOTHESIS_SUCCESSOR_CONDITION, "research-curator", "research_curator", "review_research_contract", AUTO_RESEARCH_CURATOR_REVIEW_SUCCESSOR_TEXT),
             _successor("review_promotion_readiness", AUTO_RESEARCH_HOLDOUT_SUCCESSOR_CONDITION, "research-curator", "research_curator", "review_research_contract", AUTO_RESEARCH_CURATOR_REVIEW_SUCCESSOR_TEXT),


### PR DESCRIPTION
## Summary\n- add the next-hypothesis successor to the initial evaluator summarize_evidence path\n- make the worker-turn smoke cover the real seeded summarize_evidence action, not only later evaluation-summary actions\n\n## Why\nThe visible KNN run now completes one real dev+holdout improvement, but the initial evaluator seed action can end in promotion review instead of returning to the first role for the next research round. This keeps the ring lightweight: last role -> curator review -> hypothesis proposer, without adding automatic replan or heavier auto-research code.\n\n## Validation\n- python3 examples/auto-research-worker-turn-smoke.py\n- python3 examples/auto-research-knn-continuation-smoke.py\n- python3 examples/auto-research-knn-preset-start-smoke.py\n- loopx canary premerge --from-git-diff\n\n## Boundary\n- role successor metadata and smoke only\n- no fake metrics, no pre-tick, no heartbeat prompt changes\n