### PR TITLE
Move status markdown orchestration into presentation

### DIFF
--- a/docs/product/core-control-plane/rule-seam-map.md
+++ b/docs/product/core-control-plane/rule-seam-map.md
@@ -111,7 +111,7 @@ The next module-boundary PR should therefore:
 | Attention queue | `build_attention_queue` | Queue builder over normalized goal status, todos, gates, and project assets. | Queue ordering and truncation limits remain explicit and stable. |
 | Task graph projection | `loopx.control_plane.work_items.task_graph.build_task_graph_projection` with `loopx.status.build_task_graph_projection` as the status-facing wrapper | Read-only graph projection module. | Node caps include truncation metadata; full cold-path detail remains outside the hot graph. |
 | Status contract assembly | `build_status_contract`, `collect_status` | Thin collector/orchestrator that wires registry, runtime, state, and read models. | CLI status JSON shape remains compatible. |
-| Markdown rendering | `render_status_markdown` plus `loopx/presentation/renderers/status_markdown.py` | Render-only module/helpers over the status payload. | Rendering cannot become the source of scheduler or quota truth. |
+| Markdown rendering | `loopx/presentation/renderers/status_markdown.py` with `loopx.status.render_status_markdown` as the compatibility entry | Render-only module/helpers over the status payload. | Rendering cannot become the source of scheduler or quota truth. |
 
 ## Proposed Extraction Order
 

--- a/examples/control_plane/status-overview-markdown-smoke.py
+++ b/examples/control_plane/status-overview-markdown-smoke.py
@@ -13,6 +13,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from loopx.presentation.renderers.status_markdown import (  # noqa: E402
     append_status_overview_markdown,
+    render_status_markdown as render_presentation_status_markdown,
 )
 from loopx.status import render_status_markdown  # noqa: E402
 
@@ -118,6 +119,12 @@ def main() -> int:
     full_markdown = render_status_markdown(payload)
     assert_overview(full_markdown)
     assert_contract_details(full_markdown)
+
+    presentation_markdown = render_presentation_status_markdown(
+        payload,
+        event_classes=("accounting", "decision", "evidence", "state", "work"),
+    )
+    assert presentation_markdown == full_markdown, presentation_markdown
     print("status-overview-markdown-smoke ok")
     return 0
 

--- a/loopx/presentation/renderers/status_markdown.py
+++ b/loopx/presentation/renderers/status_markdown.py
@@ -914,6 +914,96 @@ def append_attention_queue_summary_markdown(
     )
 
 
+def render_status_markdown(
+    payload: dict[str, Any],
+    *,
+    event_classes: Collection[str],
+) -> str:
+    lines: list[str] = []
+    append_status_overview_markdown(lines, payload)
+    contract = payload.get("contract") if isinstance(payload.get("contract"), dict) else {}
+
+    global_registry = (
+        payload.get("global_registry")
+        if isinstance(payload.get("global_registry"), dict)
+        else {}
+    )
+    append_global_registry_summary_markdown(lines, global_registry)
+
+    event_ledger = (
+        payload.get("event_ledger_summary")
+        if isinstance(payload.get("event_ledger_summary"), dict)
+        else {}
+    )
+    append_event_ledger_summary_markdown(
+        lines,
+        event_ledger,
+        event_classes=event_classes,
+    )
+
+    promotion_readiness = (
+        payload.get("promotion_readiness_summary")
+        if isinstance(payload.get("promotion_readiness_summary"), dict)
+        else {}
+    )
+    append_promotion_readiness_summary_markdown(lines, promotion_readiness)
+
+    promotion_gate = (
+        payload.get("promotion_gate")
+        if isinstance(payload.get("promotion_gate"), dict)
+        else {}
+    )
+    append_promotion_gate_markdown(lines, promotion_gate)
+
+    decision_freshness = (
+        payload.get("decision_freshness_summary")
+        if isinstance(payload.get("decision_freshness_summary"), dict)
+        else {}
+    )
+    append_decision_freshness_summary_markdown(lines, decision_freshness)
+
+    usage = payload.get("usage_summary") if isinstance(payload.get("usage_summary"), dict) else {}
+    append_usage_summary_markdown(lines, usage)
+
+    queue = payload.get("attention_queue") if isinstance(payload.get("attention_queue"), dict) else {}
+    append_attention_queue_summary_markdown(lines, queue)
+    items = queue.get("items") if isinstance(queue.get("items"), list) else []
+    goals = goals_by_id(payload)
+    if not items:
+        lines.append("- none")
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        authority_summary = authority_registry_markdown_summary(
+            goals.get(str(item.get("goal_id") or ""))
+        )
+        append_attention_queue_item_header_markdown(
+            lines,
+            item,
+            authority_summary=authority_summary,
+        )
+        goal_todo_scope_suffix = attention_queue_goal_todo_scope_suffix(item)
+        append_attention_queue_project_asset_markdown(
+            lines,
+            item,
+            goal_todo_scope_suffix=goal_todo_scope_suffix,
+        )
+        append_attention_queue_item_operational_markdown(
+            lines,
+            item,
+            goal_todo_scope_suffix=goal_todo_scope_suffix,
+        )
+
+    run_history = payload.get("run_history") if isinstance(payload.get("run_history"), dict) else {}
+    append_run_history_markdown(lines, run_history)
+
+    append_status_contract_detail_sections_markdown(lines, contract)
+
+    append_global_registry_findings_markdown(lines, global_registry)
+
+    return "\n".join(lines)
+
+
 def append_attention_queue_candidate_group_markdown(
     lines: list[str],
     candidates: dict[str, Any],

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -315,23 +315,7 @@ from .promotion_gate import build_promotion_gate
 from .quota import quota_status, quota_with_handoff_outcome_floor
 from .registry import registry_goals
 from .presentation.renderers.status_markdown import (
-    append_attention_queue_item_header_markdown as _append_attention_queue_item_header_markdown,
-    append_attention_queue_item_operational_markdown as _append_attention_queue_item_operational_markdown,
-    append_attention_queue_project_asset_markdown as _append_attention_queue_project_asset_markdown,
-    append_attention_queue_summary_markdown as _append_attention_queue_summary_markdown,
-    append_decision_freshness_summary_markdown as _append_decision_freshness_summary_markdown,
-    append_event_ledger_summary_markdown as _append_event_ledger_summary_markdown,
-    append_global_registry_findings_markdown as _append_global_registry_findings_markdown,
-    append_global_registry_summary_markdown as _append_global_registry_summary_markdown,
-    append_promotion_gate_markdown as _append_promotion_gate_markdown,
-    append_promotion_readiness_summary_markdown as _append_promotion_readiness_summary_markdown,
-    append_run_history_markdown as _append_run_history_markdown,
-    append_status_contract_detail_sections_markdown as _append_status_contract_detail_sections_markdown,
-    append_status_overview_markdown as _append_status_overview_markdown,
-    append_usage_summary_markdown as _append_usage_summary_markdown,
-    attention_queue_goal_todo_scope_suffix as _attention_queue_goal_todo_scope_suffix,
-    authority_registry_markdown_summary as _authority_registry_markdown_summary,
-    goals_by_id as _goals_by_id,
+    render_status_markdown as _render_status_markdown,
 )
 from .rollout_event_log import load_rollout_events, rollout_event_log_path
 from .state_projection import (
@@ -7176,80 +7160,4 @@ def collect_status(
 
 
 def render_status_markdown(payload: dict[str, Any]) -> str:
-    lines: list[str] = []
-    _append_status_overview_markdown(lines, payload)
-    contract = payload.get("contract") if isinstance(payload.get("contract"), dict) else {}
-
-    global_registry = payload.get("global_registry") if isinstance(payload.get("global_registry"), dict) else {}
-    _append_global_registry_summary_markdown(lines, global_registry)
-
-    event_ledger = (
-        payload.get("event_ledger_summary")
-        if isinstance(payload.get("event_ledger_summary"), dict)
-        else {}
-    )
-    _append_event_ledger_summary_markdown(
-        lines,
-        event_ledger,
-        event_classes=EVENT_LEDGER_CLASSES,
-    )
-
-    promotion_readiness = (
-        payload.get("promotion_readiness_summary")
-        if isinstance(payload.get("promotion_readiness_summary"), dict)
-        else {}
-    )
-    _append_promotion_readiness_summary_markdown(lines, promotion_readiness)
-
-    promotion_gate = (
-        payload.get("promotion_gate")
-        if isinstance(payload.get("promotion_gate"), dict)
-        else {}
-    )
-    _append_promotion_gate_markdown(lines, promotion_gate)
-
-    decision_freshness = (
-        payload.get("decision_freshness_summary")
-        if isinstance(payload.get("decision_freshness_summary"), dict)
-        else {}
-    )
-    _append_decision_freshness_summary_markdown(lines, decision_freshness)
-
-    usage = payload.get("usage_summary") if isinstance(payload.get("usage_summary"), dict) else {}
-    _append_usage_summary_markdown(lines, usage)
-
-    queue = payload.get("attention_queue") if isinstance(payload.get("attention_queue"), dict) else {}
-    _append_attention_queue_summary_markdown(lines, queue)
-    items = queue.get("items") if isinstance(queue.get("items"), list) else []
-    goals = _goals_by_id(payload)
-    if not items:
-        lines.append("- none")
-    for item in items:
-        if not isinstance(item, dict):
-            continue
-        authority_summary = _authority_registry_markdown_summary(goals.get(str(item.get("goal_id") or "")))
-        _append_attention_queue_item_header_markdown(
-            lines,
-            item,
-            authority_summary=authority_summary,
-        )
-        goal_todo_scope_suffix = _attention_queue_goal_todo_scope_suffix(item)
-        _append_attention_queue_project_asset_markdown(
-            lines,
-            item,
-            goal_todo_scope_suffix=goal_todo_scope_suffix,
-        )
-        _append_attention_queue_item_operational_markdown(
-            lines,
-            item,
-            goal_todo_scope_suffix=goal_todo_scope_suffix,
-        )
-
-    run_history = payload.get("run_history") if isinstance(payload.get("run_history"), dict) else {}
-    _append_run_history_markdown(lines, run_history)
-
-    _append_status_contract_detail_sections_markdown(lines, contract)
-
-    _append_global_registry_findings_markdown(lines, global_registry)
-
-    return "\n".join(lines)
+    return _render_status_markdown(payload, event_classes=EVENT_LEDGER_CLASSES)


### PR DESCRIPTION
## Summary
- Move the full status markdown orchestration into `loopx.presentation.renderers.status_markdown`.
- Keep `loopx.status.render_status_markdown` as the existing compatibility entry while shrinking `loopx/status.py` back toward status collection/read-model wiring.
- Add a direct presentation-renderer parity assertion in the status overview smoke and update the control-plane seam map.

## Validation
- `python3 examples/control_plane/status-overview-markdown-smoke.py`
- `python3 examples/control_plane/status-global-registry-markdown-smoke.py`
- `python3 examples/control_plane/presentation-markdown-primitives-smoke.py`
- `python3 examples/control_plane/status-markdown-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli --format json --registry "$HOME/.codex/loopx/registry.global.json" status --goal-id loopx-meta`
- `python3 -m compileall -q loopx/status.py loopx/presentation/renderers/status_markdown.py examples/control_plane/status-overview-markdown-smoke.py`
- `git diff --check`
- `loopx check --scan-path docs/product/core-control-plane/rule-seam-map.md --scan-path examples/control_plane/status-overview-markdown-smoke.py --scan-path loopx/presentation/renderers/status_markdown.py --scan-path loopx/status.py`
- `PYTHONPATH=. python3 -m loopx.cli canary premerge --from-git-diff`

## Boundary
- Public-safe code/docs/smoke-only refactor.
- No benchmark task text, raw logs, credentials, private paths, production actions, or scoring behavior changes.
