### PR TITLE
Allow auto-research demo to declare benchmark runner capability

### DIFF
--- a/examples/auto-research-knn-preset-start-smoke.py
+++ b/examples/auto-research-knn-preset-start-smoke.py
@@ -114,6 +114,7 @@ def main() -> int:
             if item["id"] == "loopx-auto-research-knn-smoke"
         )
         assert "solution.py" in goal["coordination"]["write_scope"], goal
+        assert "benchmark_runner" in goal["coordination"]["available_capabilities"], goal
 
     markdown_result = subprocess.run(
         [

--- a/examples/capability-gate-smoke.py
+++ b/examples/capability-gate-smoke.py
@@ -46,7 +46,11 @@ def todo(
     return item
 
 
-def status_payload(items: list[dict[str, Any]]) -> dict[str, Any]:
+def status_payload(
+    items: list[dict[str, Any]],
+    *,
+    available_capabilities: list[str] | None = None,
+) -> dict[str, Any]:
     summary = {
         "schema_version": "todo_summary_v0",
         "source_section": "Agent Todo",
@@ -78,6 +82,9 @@ def status_payload(items: list[dict[str, Any]]) -> dict[str, Any]:
                     "waiting_on": "codex",
                     "severity": "info",
                     "source": "project_asset",
+                    "coordination": {
+                        "available_capabilities": available_capabilities or [],
+                    },
                     "quota": quota,
                     "project_asset": {
                         "next_action": items[0]["text"] if items else "",
@@ -91,6 +98,9 @@ def status_payload(items: list[dict[str, Any]]) -> dict[str, Any]:
                 {
                     "id": GOAL_ID,
                     "registry_member": True,
+                    "coordination": {
+                        "available_capabilities": available_capabilities or [],
+                    },
                     "quota": quota,
                     "latest_runs": [],
                 }
@@ -214,6 +224,23 @@ def main() -> int:
         for item in benchmark_ready["capability_gate"]["runnable_candidates"]
     ] == ["todo_capability_1", "todo_capability_2", "todo_capability_5"], benchmark_ready
     assert benchmark_ready["capability_gate"]["blocked_candidates"] == [], benchmark_ready
+
+    benchmark_ready_from_goal = build_quota_should_run(
+        status_payload(
+            [p0_benchmark, p0_validate, p1_docs],
+            available_capabilities=["benchmark_runner"],
+        ),
+        goal_id=GOAL_ID,
+        available_capabilities=["shell", "filesystem_write"],
+    )
+    assert benchmark_ready_from_goal["capability_gate"]["action"] == "run", benchmark_ready_from_goal
+    assert [
+        item["todo_id"]
+        for item in benchmark_ready_from_goal["capability_gate"]["runnable_candidates"]
+    ] == ["todo_capability_1", "todo_capability_2", "todo_capability_5"], benchmark_ready_from_goal
+    assert benchmark_ready_from_goal["goal_boundary"]["available_capabilities"] == [
+        "benchmark_runner"
+    ], benchmark_ready_from_goal
 
     spend_preview = build_quota_slot_preview(
         status_payload([p0_benchmark, p0_validate, p1_docs]),

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -48,6 +48,7 @@ AUTO_RESEARCH_SEED_PREREQUISITE_ACTION_BY_ACTION = dict(
     zip(AUTO_RESEARCH_SEED_ACTION_CHAIN[1:], AUTO_RESEARCH_SEED_ACTION_CHAIN)
 )
 AUTO_RESEARCH_DEMO_CONTROL_WRITE_SCOPE = ("examples/**", "experiments/**", ".local/**")
+AUTO_RESEARCH_DEMO_AVAILABLE_CAPABILITIES = ("benchmark_runner",)
 
 
 def _prepare_visible_demo_workspace_route(
@@ -190,6 +191,17 @@ def _seed_visible_demo_control_plane(
     registry_payload = json.loads(control_registry.read_text(encoding="utf-8"))
     for goal in registry_payload.get("goals", []):
         if isinstance(goal, dict) and str(goal.get("id")) == goal_id:
+            coordination = goal.setdefault("coordination", {})
+            if isinstance(coordination, dict):
+                capabilities = [
+                    str(value).strip()
+                    for value in coordination.get("available_capabilities", [])
+                    if str(value).strip()
+                ]
+                for capability in AUTO_RESEARCH_DEMO_AVAILABLE_CAPABILITIES:
+                    if capability not in capabilities:
+                        capabilities.append(capability)
+                coordination["available_capabilities"] = capabilities
             goal["workspace_guard_policy"] = {
                 "schema_version": "loopx_workspace_guard_policy_v0",
                 "side_agent_independent_worktree_required": False,

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -144,6 +144,7 @@ from .control_plane.todos.contract import (
     TODO_STATUS_OPEN,
     TODO_TASK_CLASS_ADVANCEMENT,
     TODO_TASK_CLASS_BLOCKER,
+    normalize_required_capabilities,
     normalize_todo_claimed_by,
     normalize_todo_id,
     normalize_required_write_scopes,
@@ -850,6 +851,9 @@ def _goal_boundary(goal: dict[str, Any], item: dict[str, Any] | None = None) -> 
         boundary["checkpointed_boundary_authority"] = boundary_authority
     if normalized_write_scope:
         boundary["write_scope"] = normalized_write_scope
+    available_capabilities = _declared_available_capabilities(goal)
+    if available_capabilities:
+        boundary["available_capabilities"] = available_capabilities
     if requires_approval:
         boundary["requires_parent_approval"] = [
             str(value) for value in requires_approval if str(value).strip()
@@ -894,6 +898,50 @@ def _goal_boundary(goal: dict[str, Any], item: dict[str, Any] | None = None) -> 
         boundary["rule"] = "stay_in_scope_or_stop"
         return boundary
     return None
+
+
+def _declared_available_capabilities(source: Any) -> list[str]:
+    if not isinstance(source, dict):
+        return []
+    capabilities: list[str] = []
+
+    def append(raw: Any) -> None:
+        for capability in normalize_required_capabilities(raw):
+            if capability not in capabilities:
+                capabilities.append(capability)
+
+    append(source.get("available_capabilities"))
+    coordination = (
+        source.get("coordination")
+        if isinstance(source.get("coordination"), dict)
+        else {}
+    )
+    append(coordination.get("available_capabilities"))
+    project_asset = (
+        source.get("project_asset")
+        if isinstance(source.get("project_asset"), dict)
+        else {}
+    )
+    append(project_asset.get("available_capabilities"))
+    return capabilities
+
+
+def _effective_available_capabilities(
+    runtime_available_capabilities: Any,
+    *,
+    item: dict[str, Any],
+    project_asset: dict[str, Any],
+) -> list[str]:
+    capabilities: list[str] = []
+    for raw in (
+        _declared_available_capabilities(item),
+        _declared_available_capabilities(project_asset),
+        runtime_available_capabilities,
+    ):
+        for capability in normalize_required_capabilities(raw):
+            if capability not in capabilities:
+                capabilities.append(capability)
+    return capabilities
 
 
 def _automation_prompt_upgrade(
@@ -1669,9 +1717,14 @@ def build_quota_should_run(
             replan_obligation=replan_obligation,
             acceptance_gaps=goal_frontier_acceptance_gaps,
         )
+        effective_available_capabilities = _effective_available_capabilities(
+            available_capabilities,
+            item=item,
+            project_asset=project_asset,
+        )
         capability_gate = build_capability_gate(
             agent_todo_summary,
-            available_capabilities=available_capabilities,
+            available_capabilities=effective_available_capabilities,
             agent_identity=agent_identity,
         )
         capability_repair_allowed = False


### PR DESCRIPTION
## Summary
- Teach quota capability gating to merge available capabilities declared on the selected goal/item/project asset with runtime capabilities.
- Declare the KNN auto-research demo benchmark runner capability at goal coordination setup, while keeping the user command and pane prompt thin.
- Extend focused smokes so a benchmark-runner todo is runnable when the goal declares that capability.

## Why
Fresh visible KNN demos can produce a real executor todo requiring benchmark_runner after curator/hypothesis work. The local workspace provides that benchmark surface, but quota only considered runtime shell/filesystem capabilities and could route the lane to capability_bridge_repair instead of normal research flow.

## Validation
- python3 examples/capability-gate-smoke.py
- python3 examples/auto-research-knn-preset-start-smoke.py
- python3 examples/auto-research-worker-turn-smoke.py
- python3 examples/auto-research-knn-continuation-smoke.py
- python3 examples/auto-research-worker-loop-smoke.py
- python3 examples/auto-research-demo-e2e-worker-loop-smoke.py
- python3 examples/decentralized-auto-research-frontier-smoke.py
- loopx canary premerge --from-git-diff

## Notes
This does not add fake metrics or pane-local demo ticks. Maintainer validation remains smoke-only; visible agents still do real research and write public-safe evidence/todos.