### PR TITLE
Extract status collection read model

### DIFF
--- a/docs/product/core-control-plane/rule-seam-map.md
+++ b/docs/product/core-control-plane/rule-seam-map.md
@@ -25,7 +25,7 @@ private evidence migration, production actions, or public first-screen copy.
 | File | Current responsibility | Refactor risk |
 | --- | --- | --- |
 | `loopx/quota.py` | Quota eligibility, work-lane routing, agent-lane selection, monitor-poll writeback, scheduler hints, interaction contracts, spend events, and quota markdown. | Policy, projection, writeback, and rendering rules can start depending on each other by accident. |
-| `loopx/status.py` | Active-state parsing, todo projections, event projection fallback, attention queue, task graph, project assets, status contract, and status markdown. | Read-model construction and display shaping can blur; Markdown parsing remains flexible but weakly typed. |
+| `loopx/status.py` | Compatibility entry points for active-state parsing, todo projections, event projection fallback, attention queue, task graph, project assets, status collection, and status markdown. | Read-model construction now has bounded homes, but Markdown parsing remains flexible and weakly typed. |
 
 ## Status/Quota Boundary Checkpoint
 
@@ -110,7 +110,7 @@ The next module-boundary PR should therefore:
 | Project assets | `build_project_asset` | Public-safe asset packer over status and run-history inputs. | Project-asset-backed queue items remain the only authority for owner/gate/stop-condition semantics. |
 | Attention queue | `loopx.control_plane.work_items.attention_queue.build_attention_queue` with `loopx.status.build_attention_queue` as the compatibility entry | Queue builder over normalized goal status, todos, gates, and project assets. | Queue ordering, project-asset enrichment, quota guards, and candidate lanes remain explicit and stable. |
 | Task graph projection | `loopx.control_plane.work_items.task_graph.build_task_graph_projection` with `loopx.status.build_task_graph_projection` as the status-facing wrapper | Read-only graph projection module. | Node caps include truncation metadata; full cold-path detail remains outside the hot graph. |
-| Status contract assembly | `build_status_contract`, `collect_status` | Thin collector/orchestrator that wires registry, runtime, state, and read models. | CLI status JSON shape remains compatible. |
+| Status collection assembly | `loopx.control_plane.status_collection.collect_status` with `loopx.status.collect_status` as the compatibility entry | Thin collector/orchestrator that wires registry, runtime, state, and read models. | CLI status JSON shape remains compatible; wrapper/direct parity stays covered by `examples/control_plane/status-collection-readmodel-smoke.py`. |
 | Markdown rendering | `loopx/presentation/renderers/status_markdown.py` with `loopx.status.render_status_markdown` as the compatibility entry | Render-only module/helpers over the status payload. | Rendering cannot become the source of scheduler or quota truth. |
 
 ## Proposed Extraction Order

--- a/examples/control_plane/status-collection-readmodel-smoke.py
+++ b/examples/control_plane/status-collection-readmodel-smoke.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Smoke-test status collection read-model orchestration parity."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+import tempfile
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx import status as status_module  # noqa: E402
+from loopx.control_plane import status_collection as collection_read_model  # noqa: E402
+
+
+GOAL_ID = "status-collection-fixture"
+
+
+def write_registry(root: Path) -> Path:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".loopx" / "registry.json"
+
+    state_path = project / state_file
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text(
+        "---\n"
+        "status: active\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Status Collection Fixture\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] [P1] Keep status collection orchestration behind the read-model boundary.\n"
+        "  <!-- loopx:todo todo_id=todo_status_collection_fixture status=open "
+        "task_class=advancement_task action_kind=status_collection_refactor "
+        "claimed_by=codex-product-capability -->\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "domain": "loopx-platform",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": state_file,
+                        "adapter": {
+                            "kind": "harness_self_improvement",
+                            "status": "connected-read-only",
+                        },
+                        "quota": {
+                            "compute": 1,
+                            "window_hours": 24,
+                        },
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path
+
+
+def scrub_volatile(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: "<generated_at>"
+            if key == "generated_at"
+            else scrub_volatile(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [scrub_volatile(item) for item in value]
+    return value
+
+
+def assert_wrapper_parity(registry_path: Path, runtime_root: Path, scan_root: Path) -> None:
+    kwargs: dict[str, Any] = {
+        "registry_path": registry_path,
+        "runtime_root_override": str(runtime_root),
+        "scan_roots": [scan_root],
+        "limit": 3,
+        "include_task_graph": True,
+        "goal_id": GOAL_ID,
+    }
+    wrapper = status_module.collect_status(**kwargs)
+    direct = collection_read_model.collect_status(
+        **kwargs,
+        context=status_module.build_status_collection_context(),
+    )
+
+    assert scrub_volatile(wrapper) == scrub_volatile(direct), (wrapper, direct)
+    assert wrapper["ok"] is True, wrapper
+    assert wrapper["goal_filter"] == GOAL_ID, wrapper
+    assert wrapper["attention_queue"]["item_count"] == 1, wrapper
+    item = wrapper["attention_queue"]["items"][0]
+    assert item["goal_id"] == GOAL_ID, item
+    assert wrapper["todo_index"]["total_count"] >= 1, wrapper["todo_index"]
+
+
+def assert_context_orchestration() -> None:
+    calls: list[tuple[str, dict[str, Any]]] = []
+    runtime_root = Path("/tmp/status-collection-runtime")
+
+    def record(name: str, value: Any) -> Any:
+        calls.append((name, value if isinstance(value, dict) else {"value": value}))
+        return value
+
+    def load_registry(path: Path) -> dict[str, Any]:
+        return record("load_registry", {"common_runtime_root": str(runtime_root), "path": str(path)})
+
+    def resolve_runtime_root(registry: dict[str, Any], override: str | None) -> Path:
+        assert registry["common_runtime_root"] == str(runtime_root), registry
+        assert override == "runtime-override", override
+        return runtime_root
+
+    def collect_history(**kwargs: Any) -> dict[str, Any]:
+        assert kwargs["limit"] == 20, kwargs
+        assert kwargs["goal_id"] == GOAL_ID, kwargs
+        assert kwargs["include_runtime_goals"] is True, kwargs
+        return record("collect_history", {"goal_count": 1, "run_count": 0, "goals": []})
+
+    def check_contract(**kwargs: Any) -> dict[str, Any]:
+        assert kwargs["limit"] == 2, kwargs
+        return record("check_contract", {"ok": True, "summary": "ok", "warnings": [], "errors": [], "checks": []})
+
+    def build_attention_queue(**kwargs: Any) -> dict[str, Any]:
+        assert kwargs["include_task_graph"] is False, kwargs
+        assert kwargs["goal_id_filter"] == GOAL_ID, kwargs
+        return record("build_attention_queue", {"items": [], "item_count": 0})
+
+    context = collection_read_model.StatusCollectionContext(
+        load_registry=load_registry,
+        resolve_runtime_root=resolve_runtime_root,
+        collect_global_registry_health=lambda **kwargs: record(
+            "collect_global_registry_health",
+            {"ok": True, "current_registry_is_global": True},
+        ),
+        collect_history=collect_history,
+        check_contract=check_contract,
+        build_attention_queue=build_attention_queue,
+        build_run_history=lambda history, *, display_limit=None: record(
+            "build_run_history",
+            {"display_limit": display_limit, "goals": [], "recent_runs": []},
+        ),
+        build_event_ledger_summary=lambda history: record("build_event_ledger_summary", {}),
+        build_promotion_readiness_summary=lambda history, **kwargs: record(
+            "build_promotion_readiness_summary",
+            {"goal_id_filter": kwargs.get("goal_id_filter")},
+        ),
+        build_promotion_gate=lambda **kwargs: record("build_promotion_gate", {}),
+        build_decision_freshness_summary=lambda history: record("build_decision_freshness_summary", {}),
+        build_usage_summary=lambda history: record("build_usage_summary", {}),
+        build_todo_index=lambda **kwargs: record("build_todo_index", {"limit": kwargs.get("limit"), "items": []}),
+        build_status_contract=lambda: record("build_status_contract", {"schema_version": "fixture"}),
+        build_contract_health_projection=lambda contract: record("build_contract_health_projection", {}),
+        build_agent_management_projection=lambda payload: record("build_agent_management_projection", {"agents": []}),
+        status_control_plane_context_limit=20,
+        max_todo_index_items=240,
+    )
+
+    payload = collection_read_model.collect_status(
+        registry_path=Path("registry.json"),
+        runtime_root_override="runtime-override",
+        scan_roots=[Path("project")],
+        limit=2,
+        goal_id=GOAL_ID,
+        context=context,
+    )
+
+    assert payload["runtime_root"] == str(runtime_root), payload
+    assert payload["run_history"]["display_limit"] == 2, payload
+    assert payload["todo_index"]["limit"] == 240, payload
+    assert "agent_management_projection" not in payload, payload
+    assert [name for name, _ in calls][:4] == [
+        "load_registry",
+        "collect_global_registry_health",
+        "collect_history",
+        "check_contract",
+    ], calls
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as raw_root:
+        root = Path(raw_root)
+        registry_path = write_registry(root)
+        assert_wrapper_parity(registry_path, root / "runtime", root / "project")
+    assert_context_orchestration()
+    print("status-collection-readmodel-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/control_plane/status_collection.py
+++ b/loopx/control_plane/status_collection.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable
+
+
+StatusCallback = Callable[..., Any]
+
+
+@dataclass(frozen=True)
+class StatusCollectionContext:
+    load_registry: StatusCallback
+    resolve_runtime_root: StatusCallback
+    collect_global_registry_health: StatusCallback
+    collect_history: StatusCallback
+    check_contract: StatusCallback
+    build_attention_queue: StatusCallback
+    build_run_history: StatusCallback
+    build_event_ledger_summary: StatusCallback
+    build_promotion_readiness_summary: StatusCallback
+    build_promotion_gate: StatusCallback
+    build_decision_freshness_summary: StatusCallback
+    build_usage_summary: StatusCallback
+    build_todo_index: StatusCallback
+    build_status_contract: StatusCallback
+    build_contract_health_projection: StatusCallback
+    build_agent_management_projection: StatusCallback
+    status_control_plane_context_limit: int
+    max_todo_index_items: int
+
+
+def collect_status(
+    *,
+    registry_path: Path,
+    runtime_root_override: str | None,
+    scan_roots: list[Path],
+    limit: int,
+    context: StatusCollectionContext,
+    include_task_graph: bool = False,
+    goal_id: str | None = None,
+) -> dict[str, Any]:
+    display_limit = max(0, limit)
+    control_plane_limit = max(display_limit, context.status_control_plane_context_limit)
+    goal_filter = str(goal_id or "").strip() or None
+    registry = context.load_registry(registry_path)
+    runtime_root = context.resolve_runtime_root(registry, runtime_root_override)
+    global_registry = context.collect_global_registry_health(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        current_registry=registry,
+    )
+    include_runtime_goals = bool(global_registry.get("current_registry_is_global"))
+    history = context.collect_history(
+        registry_path=registry_path,
+        runtime_root=runtime_root,
+        goal_id=goal_filter,
+        limit=control_plane_limit,
+        include_runtime_goals=include_runtime_goals,
+    )
+    contract = context.check_contract(
+        registry_path=registry_path,
+        runtime_root_override=runtime_root_override,
+        scan_roots=scan_roots,
+        limit=limit,
+    )
+    queue = context.build_attention_queue(
+        contract=contract,
+        history=history,
+        global_registry=global_registry,
+        runtime_root=runtime_root,
+        include_task_graph=include_task_graph,
+        goal_id_filter=goal_filter,
+    )
+    run_history = context.build_run_history(history, display_limit=display_limit)
+    event_ledger_summary = context.build_event_ledger_summary(history)
+    promotion_readiness_summary = context.build_promotion_readiness_summary(
+        history,
+        runtime_root=runtime_root,
+        goal_id_filter=goal_filter,
+    )
+    promotion_gate = context.build_promotion_gate(
+        registry_path=registry_path,
+        runtime_root_override=str(runtime_root),
+    )
+    decision_freshness_summary = context.build_decision_freshness_summary(history)
+    usage_summary = context.build_usage_summary(history)
+    todo_index = context.build_todo_index(
+        queue=queue,
+        history=history,
+        runtime_root=runtime_root,
+        limit=max(context.max_todo_index_items, display_limit),
+    )
+    payload = {
+        "ok": bool(contract.get("ok")) and bool(global_registry.get("ok", True)),
+        "registry": str(registry_path),
+        "runtime_root": str(runtime_root),
+        "goal_count": history.get("goal_count"),
+        "run_count": history.get("run_count"),
+        "status_contract": context.build_status_contract(),
+        "goal_filter": goal_filter,
+        **context.build_contract_health_projection(contract),
+        "contract": {
+            "ok": contract.get("ok"),
+            "summary": contract.get("summary"),
+            "errors": contract.get("errors") or [],
+            "warnings": contract.get("warnings") or [],
+            "checks": contract.get("checks") or [],
+        },
+        "global_registry": global_registry,
+        "attention_queue": queue,
+        "run_history": run_history,
+        "event_ledger_summary": event_ledger_summary,
+        "promotion_readiness_summary": promotion_readiness_summary,
+        "promotion_gate": promotion_gate,
+        "decision_freshness_summary": decision_freshness_summary,
+        "usage_summary": usage_summary,
+        "todo_index": todo_index,
+    }
+    agent_management_projection = context.build_agent_management_projection(payload)
+    if agent_management_projection.get("agents"):
+        payload["agent_management_projection"] = agent_management_projection
+    return payload

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -12,6 +12,10 @@ from .benchmark_adapters.skillsbench_verifier_bootstrap import (
     apply_skillsbench_verifier_bootstrap_missing_score_attribution,
 )
 from .control_plane import compact_control_plane_policy
+from .control_plane.status_collection import (
+    StatusCollectionContext,
+    collect_status as _collect_status_read_model,
+)
 from .contract import check_contract
 from .control_plane.work_items.delivery_batch_scale import (
     SMALL_DELIVERY_BATCH_SCALES as STRUCTURED_SMALL_DELIVERY_BATCH_SCALES,
@@ -6927,6 +6931,29 @@ def build_todo_index(
     )
 
 
+def build_status_collection_context() -> StatusCollectionContext:
+    return StatusCollectionContext(
+        load_registry=load_registry,
+        resolve_runtime_root=resolve_runtime_root,
+        collect_global_registry_health=collect_global_registry_health,
+        collect_history=collect_history,
+        check_contract=check_contract,
+        build_attention_queue=build_attention_queue,
+        build_run_history=build_run_history,
+        build_event_ledger_summary=build_event_ledger_summary,
+        build_promotion_readiness_summary=build_promotion_readiness_summary,
+        build_promotion_gate=build_promotion_gate,
+        build_decision_freshness_summary=build_decision_freshness_summary,
+        build_usage_summary=build_usage_summary,
+        build_todo_index=build_todo_index,
+        build_status_contract=build_status_contract,
+        build_contract_health_projection=build_contract_health_projection,
+        build_agent_management_projection=_build_agent_management_projection_read_model,
+        status_control_plane_context_limit=STATUS_CONTROL_PLANE_CONTEXT_LIMIT,
+        max_todo_index_items=MAX_TODO_INDEX_ITEMS,
+    )
+
+
 def collect_status(
     *,
     registry_path: Path,
@@ -6936,87 +6963,15 @@ def collect_status(
     include_task_graph: bool = False,
     goal_id: str | None = None,
 ) -> dict[str, Any]:
-    display_limit = max(0, limit)
-    control_plane_limit = max(display_limit, STATUS_CONTROL_PLANE_CONTEXT_LIMIT)
-    goal_filter = str(goal_id or "").strip() or None
-    registry = load_registry(registry_path)
-    runtime_root = resolve_runtime_root(registry, runtime_root_override)
-    global_registry = collect_global_registry_health(
-        registry_path=registry_path,
-        runtime_root=runtime_root,
-        current_registry=registry,
-    )
-    include_runtime_goals = bool(global_registry.get("current_registry_is_global"))
-    history = collect_history(
-        registry_path=registry_path,
-        runtime_root=runtime_root,
-        goal_id=goal_filter,
-        limit=control_plane_limit,
-        include_runtime_goals=include_runtime_goals,
-    )
-    contract = check_contract(
+    return _collect_status_read_model(
         registry_path=registry_path,
         runtime_root_override=runtime_root_override,
         scan_roots=scan_roots,
         limit=limit,
-    )
-    queue = build_attention_queue(
-        contract=contract,
-        history=history,
-        global_registry=global_registry,
-        runtime_root=runtime_root,
         include_task_graph=include_task_graph,
-        goal_id_filter=goal_filter,
+        goal_id=goal_id,
+        context=build_status_collection_context(),
     )
-    run_history = build_run_history(history, display_limit=display_limit)
-    event_ledger_summary = build_event_ledger_summary(history)
-    promotion_readiness_summary = build_promotion_readiness_summary(
-        history,
-        runtime_root=runtime_root,
-        goal_id_filter=goal_filter,
-    )
-    promotion_gate = build_promotion_gate(
-        registry_path=registry_path,
-        runtime_root_override=str(runtime_root),
-    )
-    decision_freshness_summary = build_decision_freshness_summary(history)
-    usage_summary = build_usage_summary(history)
-    todo_index = build_todo_index(
-        queue=queue,
-        history=history,
-        runtime_root=runtime_root,
-        limit=max(MAX_TODO_INDEX_ITEMS, display_limit),
-    )
-    payload = {
-        "ok": bool(contract.get("ok")) and bool(global_registry.get("ok", True)),
-        "registry": str(registry_path),
-        "runtime_root": str(runtime_root),
-        "goal_count": history.get("goal_count"),
-        "run_count": history.get("run_count"),
-        "status_contract": build_status_contract(),
-        "goal_filter": goal_filter,
-        **build_contract_health_projection(contract),
-        "contract": {
-            "ok": contract.get("ok"),
-            "summary": contract.get("summary"),
-            "errors": contract.get("errors") or [],
-            "warnings": contract.get("warnings") or [],
-            "checks": contract.get("checks") or [],
-        },
-        "global_registry": global_registry,
-        "attention_queue": queue,
-        "run_history": run_history,
-        "event_ledger_summary": event_ledger_summary,
-        "promotion_readiness_summary": promotion_readiness_summary,
-        "promotion_gate": promotion_gate,
-        "decision_freshness_summary": decision_freshness_summary,
-        "usage_summary": usage_summary,
-        "todo_index": todo_index,
-    }
-    agent_management_projection = _build_agent_management_projection_read_model(payload)
-    if agent_management_projection.get("agents"):
-        payload["agent_management_projection"] = agent_management_projection
-    return payload
 
 
 def render_status_markdown(payload: dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary
- move status payload orchestration into `loopx.control_plane.status_collection`
- keep `loopx.status.collect_status` as the compatibility entry via `StatusCollectionContext`
- add `status-collection-readmodel-smoke.py` for wrapper/direct parity and context orchestration checks
- update the control-plane seam map to point at the new status collection boundary

## Validation
- `python3 examples/control_plane/status-collection-readmodel-smoke.py`
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 examples/control_plane/status-goal-filter-smoke.py`
- `python3 examples/control_plane/quota-plan-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 examples/control_plane/status-neutral-run-window-smoke.py`
- `python3 examples/control_plane/hot-path-interface-budget-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli --format json --registry "$HOME/.codex/loopx/registry.global.json" --runtime-root "$HOME/.codex/loopx" status --goal-id loopx-meta`
- `PYTHONPATH=. python3 -m loopx.cli --format json --registry "$HOME/.codex/loopx/registry.global.json" --runtime-root "$HOME/.codex/loopx" quota should-run --goal-id loopx-meta --agent-id codex-product-capability`
- `git diff --check`
- `loopx check --scan-path loopx/status.py --scan-path loopx/control_plane/status_collection.py --scan-path examples/control_plane/status-collection-readmodel-smoke.py --scan-path docs/product/core-control-plane/rule-seam-map.md`
- `PYTHONPATH=. python3 -m loopx.cli --format json canary premerge --from-git-diff` (gate passed; direct 4/4, selected 17/17, manual holds 0)
