### PR TITLE
Enable auto-wake for auto-research demo launches

### DIFF
--- a/examples/auto-research-user-contract-entry-smoke.py
+++ b/examples/auto-research-user-contract-entry-smoke.py
@@ -178,6 +178,13 @@ def assert_start_wake_contract() -> None:
         1,
     )[0]
     assert "if args.codex_trust_workspace is None" not in start_source
+    demo_e2e_source = cli_source.split('elif args.auto_research_command == "demo-e2e":', 1)[1]
+    assert "default=True" in cli_source.split('"--auto-wake"', 1)[1].split(
+        '"--auto-wake-interval-seconds"',
+        1,
+    )[0]
+    assert "auto_wake=bool(visible_policy.launch_visible and args.auto_wake)" in demo_e2e_source
+    assert "auto_wake_interval_seconds=args.auto_wake_interval_seconds" in demo_e2e_source
 
     def start_policy(args: Namespace):
         return resolve_visible_launch_policy(

--- a/examples/control_plane/auto-research-role-successor-completion-smoke.py
+++ b/examples/control_plane/auto-research-role-successor-completion-smoke.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Canary auto-research role successors without weakening side-agent handoff."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.testing.canary_harness import (  # noqa: E402
+    run_json_cli,
+    run_json_cli_result,
+    write_fixture_registry,
+)
+
+
+GOAL_ID = "auto-research-role-successor-fixture"
+CURATOR = "research-curator"
+PROPOSER = "hypothesis-proposer"
+EXECUTOR = "research-executor"
+PROPOSER_TODO = "todo_auto_research_propose"
+EXECUTOR_TODO = "todo_auto_research_execute"
+
+
+def write_fixture(root: Path, *, auto_research: bool) -> tuple[Path, Path, Path]:
+    project = root / "project"
+    runtime = root / "runtime"
+    registry_path = project / ".loopx" / "registry.json"
+    state_path = project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+    state_path.parent.mkdir(parents=True)
+    state_path.write_text(
+        "---\n"
+        "status: active\n"
+        "owner_mode: goal\n"
+        'objective: "Exercise role successor completion."\n'
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Auto-Research Role Successor Fixture\n\n"
+        "## Objective\n\n"
+        "Exercise role successor completion.\n\n"
+        "## Next Action\n\n"
+        "- Let auto-research roles advance through existing successors.\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] [P1] Propose a public-safe research hypothesis.\n"
+        f"  <!-- loopx:todo todo_id={PROPOSER_TODO} status=open "
+        "task_class=advancement_task action_kind=auto_research_hypothesis_proposal "
+        f"claimed_by={PROPOSER} -->\n"
+        "- [ ] [P1] Execute the selected public-safe hypothesis.\n"
+        f"  <!-- loopx:todo todo_id={EXECUTOR_TODO} status=open "
+        "task_class=advancement_task action_kind=auto_research_executor_attempt "
+        f"claimed_by={EXECUTOR} resume_when={PROPOSER_TODO}:done -->\n",
+        encoding="utf-8",
+    )
+    write_fixture_registry(
+        project=project,
+        runtime_root=runtime,
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        domain="auto-research-demo" if auto_research else "side-agent-handoff-fixture",
+        adapter_kind=(
+            "auto_research_demo_local_queue"
+            if auto_research
+            else "side_agent_handoff_fixture_v0"
+        ),
+        adapter_status="connected",
+        registered_agents=[CURATOR, PROPOSER, EXECUTOR],
+        primary_agent=CURATOR,
+        side_agent_independent_worktree_required=False,
+    )
+    return project, runtime, registry_path
+
+
+def complete_proposer(registry_path: Path, runtime: Path) -> tuple[int, dict]:
+    return run_json_cli_result(
+        "todo",
+        "complete",
+        "--goal-id",
+        GOAL_ID,
+        "--role",
+        "agent",
+        "--todo-id",
+        PROPOSER_TODO,
+        "--claimed-by",
+        PROPOSER,
+        "--evidence",
+        "fixture produced a public-safe hypothesis packet",
+        "--successor-todo-id",
+        EXECUTOR_TODO,
+        registry_path=registry_path,
+        runtime_root=runtime,
+        cwd=REPO_ROOT,
+    )
+
+
+def assert_auto_research_role_successor_allowed() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-auto-research-role-successor-") as tmp:
+        _project, runtime, registry_path = write_fixture(Path(tmp), auto_research=True)
+        returncode, completed = complete_proposer(registry_path, runtime)
+        assert returncode == 0, completed
+        assert completed["ok"] is True, completed
+        assert completed["status"] == "done", completed
+        assert completed["linked_handoff_successor_id"] == EXECUTOR_TODO, completed
+        assert completed["successor_todo_ids"] == [EXECUTOR_TODO], completed
+        assert completed["next_todos"] == [], completed
+
+        successor_lookup = run_json_cli(
+            "todo",
+            "list",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            EXECUTOR_TODO,
+            registry_path=registry_path,
+            runtime_root=runtime,
+            cwd=REPO_ROOT,
+        )
+        assert successor_lookup["matched"] is True, successor_lookup
+        assert successor_lookup["todo"]["status"] == "open", successor_lookup
+        assert successor_lookup["todo"]["claimed_by"] == EXECUTOR, successor_lookup
+
+
+def assert_normal_side_agent_route_stays_strict() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-normal-role-successor-reject-") as tmp:
+        _project, runtime, registry_path = write_fixture(Path(tmp), auto_research=False)
+        returncode, rejected = complete_proposer(registry_path, runtime)
+        assert returncode != 0, rejected
+        assert rejected["ok"] is False, rejected
+        assert "handoff_agent='research-curator'" in rejected["error"], rejected
+
+
+def main() -> None:
+    assert_auto_research_role_successor_allowed()
+    assert_normal_side_agent_route_stays_strict()
+    print("auto-research-role-successor-completion-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -749,6 +749,21 @@ def register_auto_research_commands(
         ),
     )
     demo_e2e_parser.add_argument(
+        "--auto-wake",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Run a session-scoped background wake loop for visible auto-research lanes. "
+            "Use --no-auto-wake for full manual takeover."
+        ),
+    )
+    demo_e2e_parser.add_argument(
+        "--auto-wake-interval-seconds",
+        type=float,
+        default=45.0,
+        help=argparse.SUPPRESS,
+    )
+    demo_e2e_parser.add_argument(
         "--keep-workspace",
         action="store_true",
         help="Keep the temporary demo workspace after execution. The output payload still redacts its absolute path.",
@@ -1229,6 +1244,8 @@ def handle_auto_research_command(
                 attach=visible_policy.attach,
                 replace_existing=args.replace_existing,
                 workspace_policy=demo_workspace_policy,
+                auto_wake=bool(visible_policy.launch_visible and args.auto_wake),
+                auto_wake_interval_seconds=args.auto_wake_interval_seconds,
             )
 
             if visible_policy.launch_visible:

--- a/loopx/control_plane/todos/completion_policy.py
+++ b/loopx/control_plane/todos/completion_policy.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping
 
 from ...agent_registry import (
+    load_goal_from_registry,
     primary_agent_id_from_registry,
     registered_agent_ids_from_registry,
     require_registered_agent_id,
@@ -73,6 +74,46 @@ def _linked_handoff_successor_id(
     return None
 
 
+def _goal_allows_role_workflow_successors(registry_path: Path, goal_id: str) -> bool:
+    goal = load_goal_from_registry(registry_path, goal_id)
+    if not isinstance(goal, dict):
+        return False
+    adapter = goal.get("adapter")
+    adapter_kind = adapter.get("kind") if isinstance(adapter, dict) else None
+    return (
+        str(goal.get("domain") or "").strip() == "auto-research-demo"
+        or str(adapter_kind or "").strip() == "auto_research_demo_local_queue"
+    )
+
+
+def _linked_role_workflow_successor_id(
+    *,
+    successors: Iterable[LinkedSuccessor],
+    registered_agents: Iterable[str],
+    completing_agent: str | None,
+) -> str | None:
+    if not completing_agent:
+        return None
+    registered_agent_set = set(registered_agents)
+    if not registered_agent_set:
+        return None
+    for successor in successors:
+        if successor.role != "agent":
+            continue
+        if successor.status and successor.status != "open":
+            continue
+        if not successor.todo_id or not successor.claimed_by:
+            continue
+        if successor.claimed_by == completing_agent:
+            continue
+        if successor.claimed_by not in registered_agent_set:
+            continue
+        if is_primary_review_action_kind(successor.action_kind):
+            continue
+        return successor.todo_id
+    return None
+
+
 def resolve_completion_policy(
     *,
     registry_path: Path,
@@ -133,6 +174,16 @@ def resolve_completion_policy(
         handoff_agent=handoff_agent,
         completing_agent=effective_claimed_by,
     )
+    if (
+        side_agent_completion
+        and not linked_handoff_successor_id
+        and _goal_allows_role_workflow_successors(registry_path, goal_id)
+    ):
+        linked_handoff_successor_id = _linked_role_workflow_successor_id(
+            successors=linked_successors,
+            registered_agents=registered_agents,
+            completing_agent=effective_claimed_by,
+        )
     explicit_primary_review_handoff = bool(
         side_agent_completion
         and next_agent_todo
@@ -153,7 +204,8 @@ def resolve_completion_policy(
                 f"side-agent completion by {effective_claimed_by!r} requires "
                 "--next-agent-todo for independent handoff, verification, and merge; "
                 "--successor-todo-id pointing at an open agent successor claimed by "
-                f"handoff_agent={handoff_agent!r}; or --side-agent-self-merged "
+                f"handoff_agent={handoff_agent!r} or an allowed role-workflow agent; "
+                "or --side-agent-self-merged "
                 "with --evidence for a small validated self-merge"
             )
         if not side_agent_self_merged and handoff_agent == effective_claimed_by:


### PR DESCRIPTION
## Summary
- make `auto-research demo-e2e --execute` visible launches default to session-scoped `--auto-wake`, matching the `start` entrypoint
- allow auto-research demo role workflows to complete to an existing open successor claimed by the next registered role
- add focused smoke coverage for the role-successor path and keep ordinary side-agent handoff strict

## Validation
- `python3 -m py_compile loopx/capabilities/auto_research/cli.py loopx/control_plane/todos/completion_policy.py examples/auto-research-user-contract-entry-smoke.py examples/control_plane/auto-research-role-successor-completion-smoke.py`
- `python3 examples/auto-research-user-contract-entry-smoke.py`
- `python3 examples/control_plane/auto-research-role-successor-completion-smoke.py`
- `python3 examples/auto-research-visible-launch-policy-smoke.py`
- `python3 examples/control_plane/side-agent-self-iteration-state-machine-smoke.py`
- `python3 -m loopx.cli auto-research demo-e2e --help | rg -n "auto-wake|no-auto-wake"`
- `loopx canary premerge --from-git-diff`

## Notes
This fixes the product path the user called out: auto-research should continue through successor todos by default without an operator sending manual `loopx multi-agent wake`.
