### PR TITLE
Repair CLI goal pre-bridge error retry

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -715,6 +715,20 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
         == "pre_bridge_tui_error_prompt"
     )
     assert (
+        codex_cli_tui_pre_bridge_blocker_stage(
+            "Goal active\nGoal failed\n› ",
+            prompt_visible=True,
+        )
+        == "pre_bridge_tui_error_prompt"
+    )
+    assert (
+        codex_cli_tui_pre_bridge_recovery_action(
+            "Goal active\nGoal failed\n› ",
+            stage="pre_bridge_tui_error_prompt",
+        )
+        == "typed_goal_resubmit"
+    )
+    assert (
         codex_cli_tui_pre_bridge_terminal_stage(
             first_turn_terminal_timeout_capture,
             prompt_visible=True,
@@ -1289,6 +1303,41 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
         assert trace["goal_prompt_file_used"] is True, trace
         assert trace["goal_prompt_file_raw_path_recorded"] is False, trace
         assert trace["goal_command_submission_method"] == "typed", trace
+        assert trace["private_tui_tail_recorded"] is False, trace
+
+    with tempfile.TemporaryDirectory() as temp:
+        trace_dir = Path(temp) / "trace"
+        relay = SkillsBenchLocalAcpRelay(
+            CodexExecConfig(worker_public_trace_dir=str(trace_dir))
+        )
+        final_capture = "\n".join(
+            [f"old line {index}" for index in range(20)]
+            + ["Goal active", "Goal failed", "› "]
+        )
+        relay._last_codex_cli_goal_tui_capture = final_capture
+        relay._publish_codex_cli_goal_trace(
+            ok=False,
+            stage="pre_bridge_tui_error_prompt",
+            goal_active_observed=True,
+            goal_terminal_observed=True,
+            first_action_observed=False,
+            bridge_summary_path=None,
+            goal_prompt_file_used=True,
+            goal_command_submission_method="typed",
+        )
+        traces = list(trace_dir.glob("*.compact.json"))
+        assert len(traces) == 1, traces
+        payload = json.loads(traces[0].read_text(encoding="utf-8"))
+        trace = payload["codex_cli_goal"]
+        assert trace["private_tui_tail_recorded"] is True, trace
+        assert trace["private_tui_tail_ref"].startswith("private/"), trace
+        assert trace["private_tui_tail_line_count"] == 23, trace
+        assert trace["raw_tui_capture_recorded"] is False, trace
+        private_tail = trace_dir / trace["private_tui_tail_ref"]
+        assert private_tail.exists(), private_tail
+        private_tail_text = private_tail.read_text(encoding="utf-8")
+        assert "Goal failed" in private_tail_text
+        assert "old line 0" in private_tail_text
 
     with tempfile.TemporaryDirectory() as temp:
         trace_dir = Path(temp) / "trace"

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -45,6 +45,7 @@ from loopx.benchmark_adapters.skillsbench_codex_goal_recovery import (
     codex_cli_tui_pre_bridge_recovery_skip_reason,
     codex_cli_tui_pre_bridge_terminal_stage,
     codex_cli_tui_pre_bridge_terminal_skip_reason,
+    write_private_codex_cli_goal_tui_tail,
 )
 from loopx.codex_cli_goal_tui import (
     CODEX_CLI_GOAL_TASK_PROMPT_FILENAME,
@@ -1328,7 +1329,7 @@ class SkillsBenchLocalAcpRelay:
                 )
                 while time.monotonic() < deadline:
                     now = time.monotonic()
-                    capture = tmux_capture(tmux_name)
+                    capture = self._last_codex_cli_goal_tui_capture = tmux_capture(tmux_name)
                     if "Goal active" in capture or "Pursuing goal" in capture:
                         goal_active_observed = True
                     goal_failed_now = "Goal failed" in capture or "Goal blocked" in capture
@@ -1810,6 +1811,7 @@ class SkillsBenchLocalAcpRelay:
             ch if ch.isalnum() or ch == "_" else "_"
             for ch in str(stage or "").strip().lower()
         ) or "unknown"
+        private_tui_tail = write_private_codex_cli_goal_tui_tail(self._config.worker_public_trace_dir, safe_stage, getattr(self, "_last_codex_cli_goal_tui_capture", ""))
         bridge_request_count = 0
         task_facing_success_count = 0
         if bridge_summary_path is not None and bridge_summary_path.exists():
@@ -1872,6 +1874,7 @@ class SkillsBenchLocalAcpRelay:
                     codex_cli_tui_environment(self._config.codex_api_proxy)
                 ),
                 "codex_api_proxy_raw_url_recorded": False,
+                **private_tui_tail,
                 "raw_tui_capture_recorded": False,
                 "raw_task_text_recorded": False,
                 "raw_stdout_recorded": False,

--- a/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
+++ b/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
+from pathlib import Path
+import uuid
+
 from loopx.codex_cli_goal_tui import codex_cli_tui_input_prompt_visible
 
 
 PRE_BRIDGE_RECOVERY_ATTEMPT_LIMIT = 2
+CODEX_CLI_GOAL_PRIVATE_TUI_TAIL_MAX_LINES = 160
+CODEX_CLI_GOAL_PRIVATE_TUI_TAIL_MAX_CHARS = 60000
 CODEX_CLI_GOAL_POST_BRIDGE_CONTINUE_PROMPT = (
     "Continue the active SkillsBench goal after the transient model timeout. "
     "If ./skillsbench-task-prompt.md exists, read it before acting. Use the "
@@ -19,6 +24,43 @@ CODEX_CLI_GOAL_POST_BRIDGE_CLOSEOUT_PROMPT = (
 POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT = 6
 POST_BRIDGE_CLOSEOUT_ATTEMPT_LIMIT = 8
 TUI_BLOCKER_RECENT_LINE_WINDOW = 40
+
+
+def write_private_codex_cli_goal_tui_tail(
+    trace_dir_value: object,
+    safe_stage: str,
+    capture: object,
+) -> dict[str, object]:
+    """Persist a bounded private TUI tail and return public-safe metadata."""
+
+    metadata: dict[str, object] = {
+        "private_tui_tail_recorded": False,
+        "private_tui_tail_ref": "",
+        "private_tui_tail_line_count": 0,
+    }
+    if not trace_dir_value or not capture:
+        return metadata
+    tail_lines = str(capture).splitlines()[-CODEX_CLI_GOAL_PRIVATE_TUI_TAIL_MAX_LINES:]
+    tail_text = "\n".join(tail_lines)
+    if len(tail_text) > CODEX_CLI_GOAL_PRIVATE_TUI_TAIL_MAX_CHARS:
+        tail_text = tail_text[-CODEX_CLI_GOAL_PRIVATE_TUI_TAIL_MAX_CHARS:]
+    tail_text = tail_text.rstrip()
+    if not tail_text:
+        return metadata
+    stage = "".join(
+        ch if ch.isalnum() or ch == "_" else "_" for ch in str(safe_stage or "")
+    ) or "unknown"
+    tail_name = f"codex-cli-goal-tui-tail-{stage}-{uuid.uuid4().hex[:12]}.txt"
+    try:
+        private_dir = Path(str(trace_dir_value)).expanduser() / "private"
+        private_dir.mkdir(parents=True, exist_ok=True)
+        (private_dir / tail_name).write_text(tail_text + "\n", encoding="utf-8")
+    except OSError:
+        return metadata
+    metadata["private_tui_tail_recorded"] = True
+    metadata["private_tui_tail_ref"] = f"private/{tail_name}"
+    metadata["private_tui_tail_line_count"] = len(tail_text.splitlines())
+    return metadata
 
 
 def _recent_capture_region(capture: str) -> str:
@@ -68,7 +110,7 @@ def codex_cli_tui_pre_bridge_blocker_stage(
     if _capture_has_model_timeout(capture):
         return "pre_bridge_tui_model_timeout"
     lowered = _recent_capture_region(capture).lower()
-    if _capture_has_retry_affordance(capture) and any(
+    if any(
         marker in lowered
         for marker in ("error", "failed", "timed out", "timeout", "model")
     ):
@@ -86,9 +128,7 @@ def codex_cli_tui_pre_bridge_recovery_action(capture: str, *, stage: str) -> str
         return ""
     if _capture_has_retry_affordance(capture):
         return "press_enter"
-    if stage == "pre_bridge_tui_model_timeout" and codex_cli_tui_input_prompt_visible(
-        capture
-    ):
+    if codex_cli_tui_input_prompt_visible(capture):
         return "typed_goal_resubmit"
     return ""
 


### PR DESCRIPTION
## Summary
- classify pre-bridge visible-prompt error states without requiring an explicit retry affordance
- allow visible prompt pre-bridge error states to resubmit the goal, reusing the existing bounded recovery path
- persist a bounded final Codex CLI TUI tail as a private sidecar under the local trace directory for debugging terminal pre-bridge failures; public compact traces keep only a relative private ref and keep raw public flags false
- add focused SkillsBench CLI goal route smoke coverage for Goal failed + visible prompt before first bridge action and private TUI tail sidecar retention

## Validation
- python3 examples/skillsbench-codex-cli-goal-route-smoke.py
- python3 -m compileall loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py loopx/benchmark_adapters/skillsbench_acp_relay.py
- git diff --check / git diff --cached --check
- changed-file private-boundary scan: no credentials, raw task text, raw benchmark logs, local paths, or verifier output added; TUI tail body is private sidecar only

## Benchmark impact
This is a runner/countability repair for codex-cli-goal xhigh pre-bridge TUI failures. It does not change scoring, task semantics, or launch new benchmark jobs. After merge/install, resume only unscored tail cases with one compact/public canary first and avoid rerunning already-scored successes.