### PR TITLE
Make local installer overwrite existing wrappers

### DIFF
--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -157,6 +157,12 @@ def main() -> int:
         legacy_canary.chmod(0o755)
         (bin_dir / "goal-harness").symlink_to(legacy_goal_harness)
         (bin_dir / "goal-harness-canary").symlink_to(legacy_canary)
+        stale_loopx = bin_dir / "loopx"
+        stale_loopx.write_text("#!/usr/bin/env bash\nexit 99\n", encoding="utf-8")
+        stale_loopx.chmod(0o755)
+        stale_canary_target = root / "stale-canary-target"
+        stale_canary_target.mkdir()
+        (bin_dir / "loopx-canary").symlink_to(stale_canary_target)
         codex_home = home / ".codex"
         profile = home / ".zshrc"
         assert_release_snapshot_source_fallback(root)
@@ -232,6 +238,7 @@ def main() -> int:
         assert release_manifest["skills"]["items"]["loopx-project"]["sha256"], release_manifest
         canary_wrapper = bin_dir / "loopx-canary"
         assert canary_wrapper.is_symlink(), canary_wrapper
+        assert not (stale_canary_target / "loopx-canary").exists(), stale_canary_target
         assert not (bin_dir / "goal-harness-canary").exists()
         assert (bin_dir / "goal-harness-canary.legacy-disabled").is_symlink()
         assert canary_wrapper.resolve() == REPO_ROOT / "scripts" / "loopx", canary_wrapper.resolve()

--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -86,6 +86,22 @@ disable_legacy_shim() {
   append_legacy_line "legacy command disabled: $disabled"
 }
 
+install_symlink() {
+  local target="$1"
+  local link="$2"
+  local tmp="$link.tmp.$$"
+  rm -f "$tmp"
+  if [[ -e "$link" && ! -L "$link" && -d "$link" ]]; then
+    echo "loopx installer error: $link is a directory; remove it before installing" >&2
+    return 1
+  fi
+  ln -s "$target" "$tmp"
+  if [[ -L "$link" ]]; then
+    rm -f "$link"
+  fi
+  mv -f "$tmp" "$link"
+}
+
 if [[ -z "$shell_profile" ]]; then
   case "${SHELL:-}" in
     */zsh) shell_profile="$HOME/.zshrc" ;;
@@ -135,12 +151,12 @@ if [[ -e "$release_dir" ]]; then
 else
   mv "$release_tmp" "$release_dir"
 fi
-ln -sfn "$release_dir/scripts/loopx" "$bin_dir/loopx"
+install_symlink "$release_dir/scripts/loopx" "$bin_dir/loopx"
 
 canary_line="- canary executable: skipped"
 if [[ "$install_canary" != "0" ]]; then
   chmod +x "$repo_root/scripts/loopx"
-  ln -sfn "$repo_root/scripts/loopx" "$bin_dir/loopx-canary"
+  install_symlink "$repo_root/scripts/loopx" "$bin_dir/loopx-canary"
   canary_line="- canary executable: $bin_dir/loopx-canary"
 fi
 


### PR DESCRIPTION
## Summary
- Replace `ln -sfn` wrapper updates with an installer-owned `install_symlink` helper.
- Allow existing `loopx`/`loopx-canary` regular files and symlinks to be replaced during install, including symlinks that point at directories.
- Refuse to overwrite a real directory at the wrapper path and emit an actionable installer error.
- Extend `install-local-smoke.py` to preseed stale `loopx` and `loopx-canary` wrappers before install.

## Validation
- `bash -n scripts/install-local.sh`
- `git diff --check`
- `loopx check --scan-path scripts/install-local.sh --scan-path examples/install-local-smoke.py`
- `python3 examples/install-local-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli --format json canary premerge --from-git-diff`

## Premerge Gate
- Gate passed with `merge_gate_passed=true`, `self_merge_allowed=true`, no manual holds, and no failed commands.
- Catalog/risk checks included installer, packaged install, update smoke, public-entry/release smoke, repo line budget, and public-boundary smoke.
