### PR TITLE
Allow installer to replace existing loopx files

### DIFF
--- a/scripts/install-local.sh
+++ b/scripts/install-local.sh
@@ -91,14 +91,14 @@ install_symlink() {
   local link="$2"
   local tmp="$link.tmp.$$"
   rm -f "$tmp"
-  if [[ -e "$link" && ! -L "$link" && -d "$link" ]]; then
-    echo "loopx installer error: $link is a directory; remove it before installing" >&2
-    return 1
-  fi
-  ln -s "$target" "$tmp"
-  if [[ -L "$link" ]]; then
+  if [[ -e "$link" || -L "$link" ]]; then
+    if [[ ! -L "$link" && -d "$link" ]]; then
+      echo "loopx installer error: $link is a directory; remove it before installing" >&2
+      return 1
+    fi
     rm -f "$link"
   fi
+  ln -s "$target" "$tmp"
   mv -f "$tmp" "$link"
 }
 


### PR DESCRIPTION
## Summary
- make install-local replace existing loopx files or symlinks explicitly before installing the new symlink
- continue to refuse directory destinations so installer repair cannot clobber a directory

## Validation
- python3 examples/install-local-smoke.py
- python3 examples/loopx-update-smoke.py
- python3 examples/release/codex-cli-no-clone-release-verification-smoke.py
- git diff --check
- loopx check --scan-path scripts/install-local.sh
- PYTHONPATH=. python3 -m loopx.cli --format json canary premerge --from-git-diff