### PR TITLE
Clarify auto-research wake pending status

### DIFF
--- a/examples/auto-research-visible-launch-policy-smoke.py
+++ b/examples/auto-research-visible-launch-policy-smoke.py
@@ -14,6 +14,7 @@ from loopx.capabilities.multi_agent.visible_launch_policy import (
     resolve_codex_trust_workspace,
     resolve_visible_launch_policy,
 )
+from loopx.capabilities.auto_research.demo_e2e import _load_visible_wake_into_payload
 
 
 AUTO_RESEARCH_CLI = ROOT / "loopx" / "capabilities" / "auto_research" / "cli.py"
@@ -132,11 +133,105 @@ def assert_auto_research_consumes_generic_policy() -> None:
     require(callable(wake_callback), "wake helper should return a callback")
 
 
+def assert_visible_wake_loader_requires_prompt_delivery() -> None:
+    delivered_payload: dict[str, object] = {"visible_worker_proof": {}}
+    _load_visible_wake_into_payload(
+        payload=delivered_payload,
+        wake={
+            "schema_version": "multi_agent_pane_a2a_wakeup_v0",
+            "mode": "execute",
+            "session_name": "fixture",
+            "target_lanes": ["research-executor"],
+            "coordination_model": "decentralized_state_a2a",
+            "wakeup_model": "fixed_prompt_broadcast",
+            "workflow_driver": False,
+            "broadcaster_reads_frontier": False,
+            "broadcaster_selects_todo": False,
+            "pane_decision_owner": "codex_tui_agent_via_loopx_state",
+            "pane_input_ready_verified": True,
+            "ready_lanes": ["research-executor"],
+            "not_ready_lanes": [],
+            "prompt_submit_checks": [{"target": "%2", "retry_count": 0}],
+            "prompt_delivery": "tmux_paste_buffer_after_codex_tui_first_turn_ready",
+            "driver_contract": {
+                "schema_version": "multi_agent_decentralized_a2a_driver_contract_v0",
+                "owner_layer": "generic_multi_agent_kernel",
+            },
+        },
+    )
+    delivered_proof = delivered_payload["visible_worker_proof"]
+    require(
+        delivered_proof["cadence_wake_verified"] is True,
+        "delivered wake should verify cadence wake",
+    )
+    require(
+        delivered_proof["cadence_wake_prompt_delivered"] is True,
+        "delivered wake should expose prompt delivery",
+    )
+
+    pending_payload: dict[str, object] = {"visible_worker_proof": {}}
+    _load_visible_wake_into_payload(
+        payload=pending_payload,
+        wake={
+            "schema_version": "multi_agent_pane_a2a_wakeup_v0",
+            "mode": "execute",
+            "session_name": "fixture",
+            "target_lanes": ["research-executor"],
+            "coordination_model": "decentralized_state_a2a",
+            "wakeup_model": "fixed_prompt_broadcast",
+            "workflow_driver": False,
+            "broadcaster_reads_frontier": False,
+            "broadcaster_selects_todo": False,
+            "pane_decision_owner": "codex_tui_agent_via_loopx_state",
+            "pane_input_ready_verified": False,
+            "pane_input_ready_checks": [
+                {
+                    "lane": "research-executor",
+                    "ready": False,
+                    "not_ready_reason": "codex_tui_busy_or_not_ready",
+                }
+            ],
+            "ready_lanes": [],
+            "not_ready_lanes": ["research-executor"],
+            "prompt_submit_checks": [],
+            "prompt_delivery": "skipped_no_input_ready_panes",
+            "driver_contract": {
+                "schema_version": "multi_agent_decentralized_a2a_driver_contract_v0",
+                "owner_layer": "generic_multi_agent_kernel",
+            },
+        },
+    )
+    pending_proof = pending_payload["visible_worker_proof"]
+    pending_wake = pending_payload["visible_wake"]
+    require(
+        pending_proof["cadence_wake_verified"] is False,
+        "busy/queued pane must not count as cadence wake verified",
+    )
+    require(
+        pending_proof["cadence_wake_prompt_delivered"] is False,
+        "busy/queued pane must expose no prompt delivery",
+    )
+    require(
+        pending_proof["cadence_wake_pending_reason"] == "pane_not_ready",
+        "busy/queued pane should expose a pending reason",
+    )
+    require(
+        pending_proof["cadence_wake_not_ready_reasons"] == ["codex_tui_busy_or_not_ready"],
+        "busy/queued pane should expose public-safe not-ready reasons",
+    )
+    require(
+        pending_wake["prompt_delivered"] is False
+        and pending_wake["not_ready_reasons"] == ["codex_tui_busy_or_not_ready"],
+        "visible wake payload should preserve public-safe pending diagnostics",
+    )
+
+
 def main() -> None:
     assert_start_policy()
     assert_demo_policy_preserves_headless_visible_mix()
     assert_conflicts()
     assert_auto_research_consumes_generic_policy()
+    assert_visible_wake_loader_requires_prompt_delivery()
     print("auto-research-visible-launch-policy-smoke ok")
 
 

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -914,6 +914,16 @@ def _load_visible_wake_into_payload(
         if isinstance(wake.get("driver_contract"), dict)
         else {}
     )
+    prompt_submit_checks = wake.get("prompt_submit_checks") or []
+    pane_input_ready_checks = wake.get("pane_input_ready_checks") or []
+    not_ready_reasons = sorted(
+        {
+            str(check.get("not_ready_reason"))
+            for check in pane_input_ready_checks
+            if isinstance(check, dict) and check.get("not_ready_reason")
+        }
+    )
+    prompt_delivered = bool(prompt_submit_checks)
     payload["visible_wake"] = {
         "schema_version": wake.get("schema_version"),
         "mode": wake.get("mode"),
@@ -927,12 +937,15 @@ def _load_visible_wake_into_payload(
         "broadcaster_selects_todo": bool(wake.get("broadcaster_selects_todo")),
         "pane_decision_owner": wake.get("pane_decision_owner"),
         "pane_input_ready_verified": wake.get("pane_input_ready_verified") is True,
-        "pane_input_ready_checks": wake.get("pane_input_ready_checks") or [],
+        "pane_input_ready_checks": pane_input_ready_checks,
         "pane_input_ready_timeout_seconds": wake.get("pane_input_ready_timeout_seconds"),
         "ready_lanes": wake.get("ready_lanes") or [],
         "not_ready_lanes": wake.get("not_ready_lanes") or [],
-        "prompt_submit_checks": wake.get("prompt_submit_checks") or [],
+        "not_ready_reasons": not_ready_reasons,
+        "prompt_submit_checks": prompt_submit_checks,
+        "prompt_delivered": prompt_delivered,
         "prompt_delivery": wake.get("prompt_delivery"),
+        "auto_wake_backoff_recommended": wake.get("auto_wake_backoff_recommended") is True,
         "driver_contract_schema": driver.get("schema_version"),
         "driver_owner_layer": driver.get("owner_layer"),
         "boundary": wake.get("boundary"),
@@ -941,6 +954,12 @@ def _load_visible_wake_into_payload(
     if isinstance(visible_proof, dict):
         visible_proof["cadence_wake_loaded"] = True
         prompt_delivery = wake.get("prompt_delivery")
+        cadence_wake_pending_reason = None
+        if not prompt_delivered:
+            if prompt_delivery == "skipped_no_input_ready_panes":
+                cadence_wake_pending_reason = "pane_not_ready"
+            elif prompt_delivery == "skipped_terminal_pane_backoff":
+                cadence_wake_pending_reason = "terminal_backoff"
         visible_proof["cadence_wake_verified"] = (
             wake.get("mode") == "execute"
             and wake.get("coordination_model") == "decentralized_state_a2a"
@@ -952,9 +971,12 @@ def _load_visible_wake_into_payload(
             in {
                 "tmux_paste_buffer_after_codex_tui_first_turn_ready",
                 "tmux_paste_buffer_after_ready_subset",
-                "skipped_no_input_ready_panes",
             }
+            and prompt_delivered
         )
+        visible_proof["cadence_wake_prompt_delivered"] = prompt_delivered
+        visible_proof["cadence_wake_pending_reason"] = cadence_wake_pending_reason
+        visible_proof["cadence_wake_not_ready_reasons"] = not_ready_reasons
 
 
 def _numeric_metric(value: object) -> float | None:


### PR DESCRIPTION
## Summary
- stop counting `skipped_no_input_ready_panes` as verified auto-research cadence wake
- expose public-safe pending diagnostics when visible panes are busy or queued before prompt delivery
- add smoke coverage for delivered vs pending wake payloads

## Validation
- `python3 examples/auto-research-visible-launch-policy-smoke.py`
- `python3 examples/visible-multi-agent-launcher-smoke.py`
- `python3 examples/auto-research-demo-e2e-worker-loop-smoke.py`
- `python3 -m compileall loopx/capabilities/auto_research/demo_e2e.py examples/auto-research-visible-launch-policy-smoke.py`
- `git diff --check`
- `loopx check --scan-path loopx/capabilities/auto_research/demo_e2e.py --scan-path examples/auto-research-visible-launch-policy-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli --format json canary premerge --from-git-diff`