### PR TITLE
Reuse run summary projections for post-handoff runs

### DIFF
--- a/examples/control_plane/run-compaction-readmodel-smoke.py
+++ b/examples/control_plane/run-compaction-readmodel-smoke.py
@@ -312,6 +312,10 @@ def assert_compact_run_summary_projection_parity() -> None:
     assert session_projection["attention_item"]["priority"] == "P2"
     assert "private_note" not in session_projection
 
+    post_handoff_compact = status_module.compact_post_handoff_run(session_runtime_run)
+    assert post_handoff_compact["session_runtime_projection"] == session_projection
+    assert "delivery_turn_kind" in post_handoff_compact
+
 
 def assert_goal_readmodel_direct_imports() -> None:
     assert callable(compact_goal_vision_packet)

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -6180,37 +6180,27 @@ def compact_post_handoff_run(run: dict[str, Any], profile: dict[str, Any] | None
         run,
         delivery_outcome=outcome,
     )
-    benchmark_run = compact_benchmark_run(run)
-    if benchmark_run:
-        compact["benchmark_run_summary"] = benchmark_run
-        health_note = worker_bridge_ingest_health_note(benchmark_run)
-        if health_note:
-            compact["worker_bridge_ingest_health_note"] = health_note
-    benchmark_result = compact_benchmark_result(run)
-    if benchmark_result:
-        compact["benchmark_result_summary"] = benchmark_result
-    benchmark_comparison = compact_benchmark_comparison(run)
-    if benchmark_comparison:
-        compact["benchmark_comparison_summary"] = benchmark_comparison
-        decision_note = benchmark_comparison_decision_note(benchmark_comparison)
-        if decision_note:
-            compact["benchmark_comparison_decision_note"] = decision_note
-    benchmark_learning_ledger = compact_benchmark_learning_ledger(run)
-    if benchmark_learning_ledger:
-        compact["benchmark_learning_ledger_summary"] = benchmark_learning_ledger
-    benchmark_report = compact_benchmark_experiment_report(run)
-    if benchmark_report:
-        compact["benchmark_experiment_report_summary"] = benchmark_report
-        readiness_note = benchmark_experiment_report_readiness_note(benchmark_report)
-        if readiness_note:
-            compact["benchmark_experiment_report_readiness_note"] = readiness_note
-            replay_decision = benchmark_experiment_report_replay_decision(readiness_note)
-            if replay_decision:
-                compact["benchmark_experiment_report_replay_decision"] = replay_decision
-    active_user_pilot = compact_active_user_assisted_pilot(run)
-    if active_user_pilot:
-        compact["active_user_assisted_pilot_summary"] = active_user_pilot
-    return compact
+    return _attach_run_summary_projections_read_model(
+        compact,
+        run,
+        compact_benchmark_run=compact_benchmark_run,
+        worker_bridge_ingest_health_note=worker_bridge_ingest_health_note,
+        compact_benchmark_result=compact_benchmark_result,
+        compact_benchmark_comparison=compact_benchmark_comparison,
+        benchmark_comparison_decision_note=benchmark_comparison_decision_note,
+        compact_benchmark_learning_ledger=compact_benchmark_learning_ledger,
+        compact_benchmark_experiment_report=compact_benchmark_experiment_report,
+        benchmark_experiment_report_readiness_note=(
+            benchmark_experiment_report_readiness_note
+        ),
+        benchmark_experiment_report_replay_decision=(
+            benchmark_experiment_report_replay_decision
+        ),
+        compact_active_user_assisted_pilot=compact_active_user_assisted_pilot,
+        compact_session_runtime_projection_from_run=(
+            compact_session_runtime_projection_from_run
+        ),
+    )
 
 
 def small_delivery_batch_scale_streak(runs: list[dict[str, Any]]) -> int:


### PR DESCRIPTION
## Summary
- Reuse the existing run summary projection helper from compact_post_handoff_run instead of duplicating benchmark/active-user summary attachment logic.
- Extend the run-compaction read-model smoke so post-handoff compaction carries session_runtime_projection through the same projection path.

## Validation
- python3 examples/control_plane/run-compaction-readmodel-smoke.py
- python3 examples/control_plane/status-runtime-summaries-readmodel-smoke.py
- python3 examples/control_plane/status-markdown-smoke.py
- python3 examples/project/project-handoff-readmodel-smoke.py
- python3 examples/delivery-turn-kind-enum-smoke.py
- python3 -m compileall loopx/status.py loopx/control_plane/runtime/run_compaction.py examples/control_plane/run-compaction-readmodel-smoke.py
- git diff --check
- loopx check --scan-path loopx/status.py --scan-path examples/control_plane/run-compaction-readmodel-smoke.py
- PYTHONPATH=. python3 -m loopx.cli --format json canary premerge --from-git-diff

## Notes
- A broad unrelated work-lane smoke currently fails on its autonomous-replan fixture recommended_action assertion; this PR does not touch that route or fixture path, and the risk-based premerge canary did not select it.