### PR TITLE
Avoid false pre-bridge TUI errors on model status

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -700,6 +700,30 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
         )
         == "pre_bridge_tui_model_timeout"
     )
+    normal_goal_pursuing_capture = "\n".join(
+        [
+            "model:       gpt-5.5 xhigh   /model to change",
+            "permissions: YOLO mode",
+            "• Goal active Objective: Complete the SkillsBench task.",
+            "• Working (2s • esc to interrupt)",
+            "› Implement {feature}",
+            "gpt-5.5 xhigh · workspace… Pursuing goal (0s)",
+        ]
+    )
+    assert (
+        codex_cli_tui_pre_bridge_blocker_stage(
+            normal_goal_pursuing_capture,
+            prompt_visible=True,
+        )
+        == ""
+    )
+    assert (
+        codex_cli_tui_pre_bridge_terminal_skip_reason(
+            normal_goal_pursuing_capture,
+            prompt_visible=True,
+        )
+        == "pre_bridge_terminal:p=1,timeout=0,rate=0,retry=0,error=0"
+    )
     assert (
         codex_cli_tui_pre_bridge_terminal_skip_reason(
             "Goal active\nGoal failed\n› ",

--- a/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
+++ b/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
@@ -91,6 +91,14 @@ def _capture_has_model_timeout(capture: str) -> bool:
     )
 
 
+def _capture_has_error_marker(capture: str) -> bool:
+    lowered = _recent_capture_region(capture).lower()
+    return any(
+        marker in lowered
+        for marker in ("error", "failed", "timed out", "timeout")
+    )
+
+
 def _capture_has_retry_affordance(capture: str) -> bool:
     lowered = _recent_capture_region(capture).lower()
     return any(marker in lowered for marker in ("press enter", "press return"))
@@ -109,11 +117,7 @@ def codex_cli_tui_pre_bridge_blocker_stage(
         return "pre_bridge_tui_rate_limit"
     if _capture_has_model_timeout(capture):
         return "pre_bridge_tui_model_timeout"
-    lowered = _recent_capture_region(capture).lower()
-    if any(
-        marker in lowered
-        for marker in ("error", "failed", "timed out", "timeout", "model")
-    ):
+    if _capture_has_error_marker(capture):
         return "pre_bridge_tui_error_prompt"
     return ""
 
@@ -170,8 +174,7 @@ def codex_cli_tui_pre_bridge_terminal_stage(
         return "pre_bridge_tui_rate_limit"
     if _capture_has_model_timeout(capture):
         return "pre_bridge_tui_model_timeout"
-    lowered = _recent_capture_region(capture).lower()
-    if any(marker in lowered for marker in ("error", "failed", "model")):
+    if _capture_has_error_marker(capture):
         return "pre_bridge_tui_error_prompt"
     return ""
 
@@ -183,11 +186,7 @@ def codex_cli_tui_pre_bridge_terminal_skip_reason(
 ) -> str:
     """Return public-safe flags for a terminal goal before bridge activity."""
 
-    lowered = _recent_capture_region(capture).lower()
-    has_error_marker = any(
-        marker in lowered
-        for marker in ("error", "failed", "timed out", "timeout", "model")
-    )
+    has_error_marker = _capture_has_error_marker(capture)
     return (
         f"pre_bridge_terminal:p={int(bool(prompt_visible))},"
         f"timeout={int(_capture_has_model_timeout(capture))},"
@@ -210,11 +209,7 @@ def codex_cli_tui_post_bridge_blocker_stage(
         return "post_bridge_tui_rate_limit"
     if _capture_has_model_timeout(capture):
         return "post_bridge_tui_model_timeout"
-    lowered = _recent_capture_region(capture).lower()
-    if _capture_has_retry_affordance(capture) and any(
-        marker in lowered
-        for marker in ("error", "failed", "timed out", "timeout", "model")
-    ):
+    if _capture_has_retry_affordance(capture) and _capture_has_error_marker(capture):
         return "post_bridge_tui_error_prompt"
     return ""
 


### PR DESCRIPTION
## Summary
- avoid classifying the normal Codex CLI `/model to change` status line as a pre-bridge TUI error
- keep model-timeout detection intact by requiring actual timeout/error wording
- add a focused codex-cli-goal route smoke for the normal `Goal active` / `Pursuing goal` TUI state

## Validation
- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 -m py_compile examples/skillsbench-codex-cli-goal-route-smoke.py loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py`
- `git diff --check`
- `loopx check --scan-path loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py`
- `loopx check --scan-path examples/skillsbench-codex-cli-goal-route-smoke.py`
- `loopx canary premerge --from-git-diff` was run; the catalog checks completed cleanly in the earlier pass for this patch family, while the full public-boundary subprocess later hung in the known full-repo boundary scan path. Targeted boundary checks for both changed files are clean.

## Risk / Boundary
- Touches only the codex-cli-goal TUI blocker classifier and its focused route smoke.
- Does not change benchmark scoring, task semantics, submission behavior, or launch benchmark jobs.
- No private tails, credentials, raw trajectories, verifier output, local run directories, or auth artifacts are committed.
