### PR TITLE
Add visible auto-research worker hook validation

### DIFF
--- a/examples/auto-research-demo-supervisor-smoke.py
+++ b/examples/auto-research-demo-supervisor-smoke.py
@@ -229,7 +229,8 @@ def assert_supervisor_contract(payload: dict[str, Any]) -> None:
             successors = profile["successor_todos"]
             assert any(
                 item["after_action"] == "write_evaluation_summary"
-                and item["target_role_id"] == "hypothesis_proposer"
+                and item["target_role_id"] == "research_curator"
+                and item["action_kind"] == "review_research_contract"
                 for item in successors
             ), profile
 

--- a/examples/auto-research-visible-worker-hook-smoke.py
+++ b/examples/auto-research-visible-worker-hook-smoke.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Smoke-test the explicit visible auto-research worker-turn hook path."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.capabilities.auto_research.demo_e2e import run_auto_research_demo_e2e  # noqa: E402
+from loopx.capabilities.auto_research.demo_supervisor import (  # noqa: E402
+    build_auto_research_demo_supervisor_plan,
+    build_visible_worker_turn_command,
+)
+from loopx.capabilities.auto_research.user_contract import (  # noqa: E402
+    build_auto_research_preset_context,
+)
+
+
+GOAL_ID = "loopx-auto-research-visible-worker-hook-smoke"
+AGENT_ID = "auto-research-operator"
+QUESTION = "如何提升 KNN 精确近邻检索速度？"
+
+
+def assert_public_safe(payload: Any) -> None:
+    text = json.dumps(payload, sort_keys=True) if not isinstance(payload, str) else payload
+    forbidden = [
+        "/" + "Users/",
+        "/" + "private/",
+        "/" + "tmp/",
+        "http://",
+        "https://",
+        "api" + "_key",
+        "pass" + "word",
+        "sec" + "ret",
+        "raw transcript",
+    ]
+    leaked = [needle for needle in forbidden if needle.lower() in text.lower()]
+    assert not leaked, leaked
+
+
+def assert_worker_turn_command_shape() -> None:
+    command = build_visible_worker_turn_command(objective=QUESTION)
+    assert '"$LOOPX_PANE_LOOPX" --format json auto-research worker-turn' in command
+    assert '--goal-id "$LOOPX_GOAL_ID"' in command
+    assert '--agent-id "$LOOPX_AGENT_ID"' in command
+    assert '--lane-count "${LOOPX_VISIBLE_LANE_COUNT:-1}"' in command
+    assert "--visible-lanes-accepted" in command
+    assert "--complete-selected-todo" in command
+    assert "--execute" in command
+    assert_public_safe(command)
+
+
+def assert_supervisor_can_configure_worker_turn() -> None:
+    supervisor = build_auto_research_demo_supervisor_plan(
+        goal_id=GOAL_ID,
+        open_question=QUESTION,
+        preset_context=build_auto_research_preset_context("knn-demo"),
+        output_language="zh",
+        configure_visible_worker_turn=True,
+    )
+    assert supervisor["auto_research"]["visible_worker_turn_configured"] is True
+    assert supervisor["auto_research"]["worker_turn_owner"] == "generic_multi_agent_kernel"
+    assert supervisor["runner_contract"]["decentralized_a2a_driver"]["broadcaster"][
+        "runs_worker_turn"
+    ] is False
+    for lane in supervisor["lanes"]:
+        assert lane["pane_local_a2a"]["worker_turn_configured"] is True, lane
+        assert lane["pane_local_a2a"]["worker_loop_configured"] is False, lane
+        assert lane["pane_local_a2a"]["status_check_only"] is True, lane
+        assert lane["pane_local_a2a"]["counts_as_research_round"] is False, lane
+        assert "LOOPX_PANE_WORKER_TURN" in lane["visible_launch_command"], lane
+        assert "auto-research worker-turn" in lane["visible_launch_command"], lane
+        assert "--visible-lanes-accepted" in lane["visible_launch_command"], lane
+        assert "--complete-selected-todo" in lane["visible_launch_command"], lane
+        profile = lane["role_profile"]
+        assert profile["visible_worker_turn_configured"] is True, profile
+    assert_public_safe(supervisor)
+
+
+def assert_demo_e2e_exposes_validation_path() -> None:
+    captured: dict[str, object] = {}
+
+    def fake_visible_launcher(
+        supervisor: dict[str, object],
+        _registry_path: Path,
+        _runtime_root: str | None,
+        _demo_root: Path,
+    ) -> dict[str, object]:
+        captured["supervisor"] = supervisor
+        return {
+            "mode": "execute",
+            "launch_result": {
+                "session_name": "loopx-ar-visible-worker-hook-smoke",
+                "started_lanes": [
+                    str(lane.get("lane_id") or "")
+                    for lane in supervisor.get("lanes", [])
+                    if isinstance(lane, dict)
+                ],
+                "visible_acceptance": {"accepted": True},
+            },
+            "boundary": {
+                "starts_visible_processes": False,
+                "writes_loopx_state": False,
+                "public_safe_redaction": True,
+            },
+        }
+
+    with tempfile.TemporaryDirectory(prefix="loopx-ar-visible-worker-hook.") as temp_dir:
+        temp = Path(temp_dir)
+        registry = temp / "registry.json"
+        runtime_root = temp / "runtime"
+        registry.write_text(
+            json.dumps({"common_runtime_root": str(runtime_root), "goals": []}),
+            encoding="utf-8",
+        )
+        payload = run_auto_research_demo_e2e(
+            agent_id=AGENT_ID,
+            goal_id=GOAL_ID,
+            tracking_goal_id=None,
+            preset_id="knn-demo",
+            objective=QUESTION,
+            output_dir="auto_research_lightweight_kernel",
+            execute=True,
+            run_worker_loop=False,
+            worker_loop_rounds=1,
+            configure_visible_worker_turn=True,
+            launch_visible=True,
+            keep_workspace=False,
+            registry_path=registry,
+            runtime_root_arg=str(runtime_root),
+            session_name="loopx-ar-visible-worker-hook-smoke",
+            cli_bin="loopx",
+            codex_bin="codex",
+            tmux_bin="tmux",
+            reasoning_effort="high",
+            output_language="zh",
+            live_evidence_path=None,
+            append_evidence=lambda _path: {"ok": True, "appended_count": 0},
+            visible_launcher=fake_visible_launcher,
+            visible_wake=None,
+            visible_live_evidence_wait_seconds=0.0,
+        )
+    validation = payload["visible_worker_turn_validation"]
+    assert validation["configured"] is True, validation
+    assert validation["counts_as_research_evidence_without_role_output"] is False, validation
+    assert validation["manual_research_required_is_blocker_not_progress"] is True, validation
+    assert payload["visible_worker_proof"]["visible_lanes_accepted"] is True, payload
+    assert payload["visible_readiness"]["ready"] is False, payload["visible_readiness"]
+    assert "lane_authored_evidence_loaded" in payload["visible_readiness"]["missing_requirements"]
+    captured_supervisor = captured["supervisor"]
+    for lane in captured_supervisor["lanes"]:
+        assert lane["pane_local_a2a"]["worker_turn_configured"] is True, lane
+    assert_public_safe(payload)
+
+
+def main() -> None:
+    assert_worker_turn_command_shape()
+    assert_supervisor_can_configure_worker_turn()
+    assert_demo_e2e_exposes_validation_path()
+    print("auto-research-visible-worker-hook-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/capabilities/auto_research/cli.py
+++ b/loopx/capabilities/auto_research/cli.py
@@ -280,6 +280,11 @@ def register_auto_research_commands(
         help=argparse.SUPPRESS,
     )
     start_parser.add_argument(
+        "--configure-visible-worker-turn",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    start_parser.add_argument(
         "--session-name",
         default="loopx-auto-research",
         help="Public-safe tmux session name for visible lanes.",
@@ -741,6 +746,11 @@ def register_auto_research_commands(
         help=argparse.SUPPRESS,
     )
     demo_e2e_parser.add_argument(
+        "--configure-visible-worker-turn",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
+    demo_e2e_parser.add_argument(
         "--wake-visible-after-launch",
         action="store_true",
         help=(
@@ -1001,6 +1011,7 @@ def handle_auto_research_command(
                 execute=args.execute,
                 run_worker_loop=bool(args.execute and args.headless),
                 worker_loop_rounds=args.worker_loop_rounds,
+                configure_visible_worker_turn=args.configure_visible_worker_turn,
                 launch_visible=visible_policy.launch_visible,
                 keep_workspace=args.keep_workspace,
                 registry_path=registry_path,
@@ -1263,6 +1274,7 @@ def handle_auto_research_command(
                 execute=args.execute,
                 run_worker_loop=run_hidden_worker_loop,
                 worker_loop_rounds=args.worker_loop_rounds,
+                configure_visible_worker_turn=args.configure_visible_worker_turn,
                 launch_visible=visible_policy.launch_visible,
                 keep_workspace=args.keep_workspace,
                 registry_path=registry_path,

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -318,6 +318,7 @@ def _command_text(
     no_attach: bool = False,
     live_evidence: bool = False,
     wake_visible_after_launch: bool = False,
+    configure_visible_worker_turn: bool = False,
     tracking_goal_id: str | None = None,
     output_language: str = "en",
 ) -> str:
@@ -352,6 +353,8 @@ def _command_text(
         parts.extend(["--live-evidence", "<public-safe-live-evidence.json>"])
     if wake_visible_after_launch:
         parts.append("--wake-visible-after-launch")
+    if configure_visible_worker_turn:
+        parts.append("--configure-visible-worker-turn")
     return " ".join(parts)
 
 
@@ -1213,6 +1216,7 @@ def run_auto_research_demo_e2e(
     agent_specs: Sequence[str] | None = None,
     run_worker_loop: bool = False,
     worker_loop_rounds: int = 4,
+    configure_visible_worker_turn: bool = False,
     visible_live_evidence_wait_seconds: float = 30.0,
 ) -> dict[str, object]:
     if launch_visible and not execute:
@@ -1259,6 +1263,7 @@ def run_auto_research_demo_e2e(
         tmux_bin=tmux_bin,
         reasoning_effort=reasoning_effort,
         output_language=output_language,
+        configure_visible_worker_turn=configure_visible_worker_turn,
     )
     execution_kind = (
         "loopx_worker_loop"
@@ -1376,6 +1381,17 @@ def run_auto_research_demo_e2e(
                 tracking_goal_id=tracking_goal or None,
                 output_language=output_language,
             ),
+            "one_command_visible_worker_turn_validation": _command_text(
+                cli_bin=cli_bin,
+                goal_id=goal_id,
+                agent_id=agent_id,
+                execute=True,
+                launch_visible=True,
+                no_attach=True,
+                configure_visible_worker_turn=True,
+                tracking_goal_id=tracking_goal or None,
+                output_language=output_language,
+            ),
             "one_command_worker_loop_with_visible_lanes": _command_text(
                 cli_bin=cli_bin,
                 goal_id=goal_id,
@@ -1415,6 +1431,12 @@ def run_auto_research_demo_e2e(
         "visible_worker_proof": build_auto_research_live_worker_proof(
             launch_visible=launch_visible,
         ),
+        "visible_worker_turn_validation": {
+            "schema_version": "auto_research_visible_worker_turn_validation_v0",
+            "configured": bool(configure_visible_worker_turn),
+            "counts_as_research_evidence_without_role_output": False,
+            "manual_research_required_is_blocker_not_progress": True,
+        },
     }
     if not execute:
         payload["worker_loop_preview"] = {

--- a/loopx/capabilities/auto_research/demo_supervisor.py
+++ b/loopx/capabilities/auto_research/demo_supervisor.py
@@ -2,10 +2,15 @@
 
 from __future__ import annotations
 
+import shlex
 from collections.abc import Iterable
 from typing import Any
 
-from .defaults import AUTO_RESEARCH_DEFAULT_GOAL_ID, build_auto_research_layer_contract
+from .defaults import (
+    AUTO_RESEARCH_DEFAULT_GOAL_ID,
+    AUTO_RESEARCH_DEFAULT_OBJECTIVE,
+    build_auto_research_layer_contract,
+)
 from .preset import (
     AUTO_RESEARCH_PRESET_SCHEMA_VERSION,
     build_auto_research_preset_role,
@@ -16,6 +21,22 @@ from ...visible_multi_agent_launcher import build_visible_multi_agent_payload_fr
 
 
 AUTO_RESEARCH_DEMO_SUPERVISOR_SCHEMA_VERSION = "auto_research_demo_supervisor_plan_v0"
+
+
+def build_visible_worker_turn_command(*, objective: object | None = None) -> str:
+    """Return a pane-local worker-turn hook that still obeys visible evidence gates."""
+
+    clean_objective = str(objective or AUTO_RESEARCH_DEFAULT_OBJECTIVE).strip()
+    return (
+        '"$LOOPX_PANE_LOOPX" --format json auto-research worker-turn '
+        '--goal-id "$LOOPX_GOAL_ID" '
+        '--agent-id "$LOOPX_AGENT_ID" '
+        f"--objective {shlex.quote(clean_objective)} "
+        '--lane-count "${LOOPX_VISIBLE_LANE_COUNT:-1}" '
+        "--visible-lanes-accepted "
+        "--complete-selected-todo "
+        "--execute"
+    )
 
 
 def build_auto_research_demo_supervisor_plan(
@@ -30,6 +51,7 @@ def build_auto_research_demo_supervisor_plan(
     tmux_bin: str = "tmux",
     reasoning_effort: str = "high",
     output_language: str = "en",
+    configure_visible_worker_turn: bool = False,
 ) -> dict[str, Any]:
     """Build the auto-research visible TUI plan from a small role spec.
 
@@ -40,6 +62,11 @@ def build_auto_research_demo_supervisor_plan(
 
     goal = str(goal_id).strip() or AUTO_RESEARCH_DEFAULT_GOAL_ID
     lanes = auto_research_lane_specs(agent_specs)
+    worker_turn_command = (
+        build_visible_worker_turn_command(objective=open_question)
+        if configure_visible_worker_turn
+        else ""
+    )
     roles = [
         build_auto_research_preset_role(
             lane=lane,
@@ -51,6 +78,12 @@ def build_auto_research_demo_supervisor_plan(
         )
         for lane in lanes
     ]
+    if worker_turn_command:
+        for role in roles:
+            role["worker_turn_command"] = worker_turn_command
+            role_profile = role.get("role_profile")
+            if isinstance(role_profile, dict):
+                role_profile["visible_worker_turn_configured"] = True
 
     payload = build_visible_multi_agent_payload_from_spec(
         {
@@ -100,6 +133,7 @@ def build_auto_research_demo_supervisor_plan(
                     "todo_evidence_status_protocol",
                 ],
                 "worker_turn_owner": "generic_multi_agent_kernel",
+                "visible_worker_turn_configured": bool(worker_turn_command),
                 "output_language": output_language,
                 "presentation_layers_in_kernel": False,
             },


### PR DESCRIPTION
## Summary
- Add an explicit hidden CLI flag for visible auto-research worker-turn validation.
- Wire the hook through start and demo-e2e without changing the default visible lane behavior.
- Add a focused smoke proving configured worker-turn lanes remain evidence-gated, and update the supervisor smoke to match the current evaluator successor route.

## Validation
- python3 examples/auto-research-visible-worker-hook-smoke.py
- python3 examples/auto-research-layered-e2e-acceptance-smoke.py
- python3 examples/auto-research-demo-supervisor-smoke.py
- python3 -m py_compile loopx/capabilities/auto_research/demo_supervisor.py loopx/capabilities/auto_research/demo_e2e.py loopx/capabilities/auto_research/cli.py examples/auto-research-visible-worker-hook-smoke.py examples/auto-research-demo-supervisor-smoke.py
- git diff --check
- loopx check --scan-path loopx/capabilities/auto_research --scan-path examples/auto-research-visible-worker-hook-smoke.py --scan-path examples/auto-research-demo-supervisor-smoke.py

## Notes
Not self-merged: this touches auto-research runtime behavior. Next side-bypass step after review/merge is install plus live KNN visible rerun; wake ticks still do not count as executor/evaluator evidence.