### PR TITLE
Harden SkillsBench bridge first-action prompt

### DIFF
--- a/examples/skillsbench-host-local-launch-plan-smoke.py
+++ b/examples/skillsbench-host-local-launch-plan-smoke.py
@@ -79,22 +79,6 @@ def main() -> int:
     assert "env=target_env" in source
     assert "local_acp_command = _set_option_value(" in source
     assert "del (\n            env," not in source
-    packet = SkillsBenchLocalAcpRelay(
-        CodexExecConfig(remote_command_file_bridge_command="/tmp/private-bridge")
-    )._prompt_with_remote_bridge_packet(
-        "Task",
-        bridge_probe={"operation_count": 1},
-        bridge_command_for_agent="/tmp/private-bridge",
-    )
-    first_action_block = packet.split("FIRST ACTION REQUIRED:", 1)[1].split(
-        "Request examples:", 1
-    )[0]
-    assert "pwd && ls -la" in first_action_block
-    assert "/tmp/private-bridge" in first_action_block
-    assert "<private bridge command>" not in first_action_block
-    assert '/root/answer.json' in packet, packet
-    assert '/root/task-input-or-data' in packet, packet
-    assert "`/app`, `/tmp`, and `/root`" in packet, packet
     assert _docker_bridge_safe_path("/app/.codex/goals/state.json") == (
         "/app/.codex/goals/state.json"
     )
@@ -119,18 +103,38 @@ def main() -> int:
             raise AssertionError(f"unexpected cleanup root: {protected_root}")
     with tempfile.TemporaryDirectory(prefix="skillsbench-agent-probe-count-") as tmp:
         tmp_path = Path(tmp)
+        observed_request = tmp_path / "observed-request.json"
         fake_bridge = tmp_path / "fake-bridge"
         fake_bridge.write_text(
-            """#!/usr/bin/env python3
-import json
-import sys
-
-json.loads(sys.stdin.read() or "{}")
-print(json.dumps({"ok": True, "stdout": "", "stderr": "", "exit_code": 0}))
-""",
+            "#!/usr/bin/env python3\n"
+            "import json, sys\n"
+            "from pathlib import Path\n"
+            f"raw = sys.stdin.read() or '{{}}'; json.loads(raw); Path({str(observed_request)!r}).write_text(raw, encoding='utf-8')\n"
+            "print(json.dumps({'ok': True, 'stdout': '', 'stderr': '', 'exit_code': 0}))\n",
             encoding="utf-8",
         )
         fake_bridge.chmod(0o755)
+        packet = SkillsBenchLocalAcpRelay(
+            CodexExecConfig(remote_command_file_bridge_command=str(fake_bridge))
+        )._prompt_with_remote_bridge_packet(
+            "Task",
+            bridge_probe={"operation_count": 1},
+            bridge_command_for_agent=str(fake_bridge),
+        )
+        first_action_block = packet.split("FIRST ACTION REQUIRED:", 1)[1].split(
+            "Request examples:", 1
+        )[0]
+        assert "pwd && ls -la" in first_action_block
+        assert str(fake_bridge) in first_action_block
+        assert "<private bridge command>" not in first_action_block
+        assert "```sh" in first_action_block
+        first_action_command = first_action_block.split("```sh", 1)[1].split("```", 1)[0].strip()
+        proc = subprocess.run(first_action_command, shell=True, capture_output=True, text=True, timeout=10)
+        assert proc.returncode == 0, proc.stderr or proc.stdout
+        request = json.loads(observed_request.read_text(encoding="utf-8"))
+        assert request == {"operation": "exec", "cwd": "/app", "command": "pwd && ls -la", "timeout_sec": 10}, request
+        assert '/root/answer.json' in packet and '/root/task-input-or-data' in packet, packet
+        assert "`/app`, `/tmp`, and `/root`" in packet, packet
         trace_dir = tmp_path / "traces"
         relay = SkillsBenchLocalAcpRelay(
             CodexExecConfig(

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -2271,11 +2271,12 @@ LoopX SkillsBench remote workspace bridge:
 - This local Codex process is outside the scored SkillsBench sandbox.
 - Use the command below as a private JSON bridge for sandbox exec, file write, file read, and cleanup operations.
 - Send one JSON request on stdin and read one private JSON response on stdout.
-- FIRST ACTION REQUIRED: before prose planning or final answer, copy and run
-  this exact shell command to prove task-facing sandbox access:
-  `{first_exec_command}`
-- Invoke additional bridge operations by piping JSON to the same private bridge
-  command shown below.
+- FIRST ACTION REQUIRED: before prose planning or final answer, run this exact
+  shell command without Markdown backticks; JSON must be piped on stdin:
+  ```sh
+  {first_exec_command}
+  ```
+- Invoke additional operations by piping JSON to the bridge; never pass JSON as argv.
 - Request examples:
   - {{"operation":"exec","cwd":"/app","command":"pwd","timeout_sec":10}}
   - {{"operation":"read_file","path":"/app/path/to/file","max_bytes":20000}}


### PR DESCRIPTION
## Summary
- clarify the SkillsBench remote bridge first-action prompt so the command is copied without Markdown backticks and JSON is piped on stdin, never passed as argv
- extend the host-local launch smoke to execute the rendered first-action command against a fake bridge and assert the bridge receives the expected JSON request on stdin

## Validation
- `python3 examples/skillsbench-host-local-launch-plan-smoke.py` (passed on rerun; one prior run hit the existing inflight-timeout race with `inflight_operation_count=2`)
- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `python3 -m py_compile loopx/benchmark_adapters/skillsbench_acp_relay.py examples/skillsbench-host-local-launch-plan-smoke.py`
- `git diff --check`
- `loopx check --scan-path loopx/benchmark_adapters/skillsbench_acp_relay.py`
- `loopx check --scan-path examples/skillsbench-host-local-launch-plan-smoke.py`
- `loopx canary premerge --from-git-diff` reported direct diff/compile checks passed and benchmark catalog canaries passed except the line-budget failure fixed before commit; full public-boundary smoke timed out at 120s; benchmark-sensitive manual hold remains, so this PR is not self-merged.

## Boundary
- public-safe prompt/smoke changes only
- no raw benchmark traces, verifier output, credentials, local private paths, or generated logs included
