### PR TITLE
Fix auto-research quiet completion frontier

### DIFF
--- a/examples/auto-research-worker-turn-smoke.py
+++ b/examples/auto-research-worker-turn-smoke.py
@@ -221,6 +221,43 @@ def append_real_fixture_evidence(*, registry: Path, runtime_root: Path, temp: Pa
     assert_public_safe(appended)
 
 
+def append_fixture_evidence(
+    *,
+    registry: Path,
+    runtime_root: Path,
+    temp: Path,
+    hypothesis_id: str,
+    todo_id: str,
+    dev_metric: float,
+    holdout_metric: float,
+) -> None:
+    packet = build_auto_research_evidence_packet(
+        contract=research_contract(goal_id=GOAL_ID),
+        eval_results=[
+            eval_result("dev", value=dev_metric),
+            eval_result("holdout", value=holdout_metric),
+        ],
+        hypothesis_id=hypothesis_id,
+        todo_id=todo_id,
+        agent_id=EVIDENCE_AGENT_ID,
+        claimed_by=EVIDENCE_AGENT_ID,
+        mechanism_family=MECHANISM_FAMILY,
+        hypothesis=f"{HYPOTHESIS_TEXT} Variant {hypothesis_id}.",
+        grounding_refs=[GROUNDING_REF],
+        branch_ref="codex/auto-research-worker-turn-smoke",
+    )
+    packet_path = temp / f"{hypothesis_id}.public.json"
+    packet_path.write_text(json.dumps(packet, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    appended = append_auto_research_rollout_events(
+        packet_path=str(packet_path),
+        registry_path=registry,
+        runtime_root_arg=str(runtime_root),
+        dry_run=False,
+    )
+    assert appended["appended_count"] == 3, appended
+    assert_public_safe(appended)
+
+
 def main() -> int:
     with tempfile.TemporaryDirectory() as temp_dir:
         temp = Path(temp_dir)
@@ -488,6 +525,56 @@ def main() -> int:
         assert f"todo_id={generic_todo_id} status=done" not in state_text, state_text
         assert "satisfied_generic_handoff_closed" not in json.dumps(generic_turn), generic_turn
         assert_public_safe(generic_turn)
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        project = temp / "project"
+        project.mkdir()
+        state_file = project / "ACTIVE_GOAL_STATE.md"
+        registry = temp / "registry.json"
+        runtime_root = temp / "runtime"
+        write_summary_state(state_file)
+        write_registry(registry, project=project, state_file=state_file, runtime_root=runtime_root)
+        append_fixture_evidence(
+            registry=registry,
+            runtime_root=runtime_root,
+            temp=temp,
+            hypothesis_id="hyp_target_reached_first",
+            todo_id="todo_auto_research_target_first",
+            dev_metric=1.4,
+            holdout_metric=1.5,
+        )
+        append_fixture_evidence(
+            registry=registry,
+            runtime_root=runtime_root,
+            temp=temp,
+            hypothesis_id="hyp_target_reached_second",
+            todo_id="todo_auto_research_target_second",
+            dev_metric=2.0,
+            holdout_metric=2.1,
+        )
+        workspace = project / "visible-workspace"
+        workspace.mkdir()
+
+        target_reached = run_worker_turn(
+            registry=registry,
+            runtime_root=runtime_root,
+            workspace=workspace,
+            agent_id=EVALUATOR_AGENT_ID,
+            execute=True,
+            complete=False,
+        )
+        assert target_reached["mode"] == "quiet_completion", target_reached
+        completion = target_reached["completion"]
+        assert completion["status"] == "target_reached", target_reached
+        assert completion["quiet_completion_allowed"] is True, target_reached
+        assert completion["next_action"] == "quiet_completion", target_reached
+        assert completion["holdout_improvement_count"] == 2, target_reached
+        assert completion["required_holdout_improvement_count"] == 2, target_reached
+        frontier_completion = target_reached["frontier"]["frontier"]["completion"]
+        assert frontier_completion["status"] == "target_reached", target_reached
+        assert target_reached["frontier"]["frontier"]["selected"] is None, target_reached
+        assert_public_safe(target_reached)
     return 0
 
 

--- a/loopx/capabilities/auto_research/research_state.py
+++ b/loopx/capabilities/auto_research/research_state.py
@@ -32,12 +32,14 @@ from .evidence_packet import (
     validate_research_evidence_event,
     validate_research_hypothesis,
 )
+from .preset import AUTO_RESEARCH_REQUIRED_HOLDOUT_IMPROVEMENTS
 
 
 AUTO_RESEARCH_FIXTURE_SCHEMA_VERSION = "decentralized_auto_research_fixture_v0"
 AUTO_RESEARCH_PROJECTION_SCHEMA_VERSION = "decentralized_auto_research_projection_v0"
 RESEARCH_EVIDENCE_GRAPH_SCHEMA_VERSION = "research_evidence_graph_v0"
 RESEARCH_FRONTIER_SCHEMA_VERSION = "decentralized_research_frontier_v0"
+AUTO_RESEARCH_COMPLETION_STATUS_SCHEMA_VERSION = "auto_research_completion_status_v0"
 ROLLOUT_EVIDENCE_GRAPH_SOURCE_KIND = "loopx_rollout_event_log"
 AUTO_RESEARCH_ACTION_ALIASES = {
     "run_read_only_adapter_tick": "run_dev_eval",
@@ -519,6 +521,105 @@ def build_research_decision_candidates(evidence_graph: dict[str, Any]) -> dict[s
     }
 
 
+def _holdout_metric_sequence_from_graph(evidence_graph: dict[str, Any]) -> list[float]:
+    sequence: list[float] = []
+    for raw_node in evidence_graph.get("nodes") or []:
+        if not isinstance(raw_node, dict):
+            continue
+        value = raw_node.get("best_holdout_metric")
+        if value is None or isinstance(value, bool):
+            continue
+        number = _finite_float(value, field="node.best_holdout_metric")
+        if number is not None:
+            sequence.append(number)
+    return sequence
+
+
+def _metric_sequence_improvement_count(
+    sequence: list[float],
+    *,
+    baseline: float | None,
+    direction: str,
+) -> int:
+    if baseline is None:
+        return 0
+    count = 0
+    previous = baseline
+    minimize = direction == "minimize"
+    for metric in sequence:
+        improved = metric < previous if minimize else metric > previous
+        if improved:
+            count += 1
+        previous = metric
+    return count
+
+
+def build_auto_research_completion_status(
+    evidence_graph: dict[str, Any],
+    decision_candidates: dict[str, list[dict[str, Any]]] | None = None,
+) -> dict[str, Any]:
+    graph = _json_obj(evidence_graph, field="evidence_graph")
+    decisions = decision_candidates or build_research_decision_candidates(graph)
+    metric = graph.get("metric") if isinstance(graph.get("metric"), dict) else {}
+    direction = str(metric.get("direction") or "maximize")
+    if direction not in METRIC_DIRECTIONS:
+        direction = "maximize"
+    baseline = _finite_float(metric.get("baseline"), field="evidence_graph.metric.baseline")
+    holdout_sequence = _holdout_metric_sequence_from_graph(graph)
+    holdout_improvement_count = _metric_sequence_improvement_count(
+        holdout_sequence,
+        baseline=baseline,
+        direction=direction,
+    )
+    required_holdout_improvement_count = AUTO_RESEARCH_REQUIRED_HOLDOUT_IMPROVEMENTS
+    dev_pending_count = len(decisions.get("dev_promotion_candidates") or [])
+    validated_count = len(decisions.get("validated_promotion_candidates") or [])
+    promotion_count = len(decisions.get("promotion_candidates") or [])
+    retirement_count = len(decisions.get("retirement_candidates") or [])
+
+    status = "active"
+    next_action = "continue_frontier"
+    required_actions: list[str] = []
+    quiet_completion_allowed = False
+    reason = "frontier_still_active"
+    if validated_count and holdout_improvement_count >= required_holdout_improvement_count:
+        status = "target_reached"
+        next_action = "quiet_completion"
+        quiet_completion_allowed = True
+        reason = "required_holdout_improvements_reached"
+    elif dev_pending_count:
+        status = "holdout_eval_required"
+        next_action = "run_holdout_eval"
+        required_actions = ["holdout_eval", "boundary_scan"]
+        reason = "dev_promotion_candidate_pending_holdout"
+    elif validated_count or promotion_count:
+        status = "promotion_review_required"
+        next_action = "review_promotion_readiness"
+        required_actions = ["boundary_scan", "promotion_decision"]
+        reason = "validated_promotion_candidate_pending_decision"
+    elif retirement_count:
+        status = "retirement_review_required"
+        next_action = "review_retirement_candidate"
+        required_actions = ["retirement_decision"]
+        reason = "retirement_candidate_pending_decision"
+
+    return {
+        "schema_version": AUTO_RESEARCH_COMPLETION_STATUS_SCHEMA_VERSION,
+        "status": status,
+        "next_action": next_action,
+        "reason": reason,
+        "quiet_completion_allowed": quiet_completion_allowed,
+        "required_actions": required_actions,
+        "required_holdout_improvement_count": required_holdout_improvement_count,
+        "holdout_improvement_count": holdout_improvement_count,
+        "holdout_metric_sequence": holdout_sequence,
+        "validated_promotion_candidate_count": validated_count,
+        "dev_candidate_pending_holdout_count": dev_pending_count,
+        "promotion_candidate_count": promotion_count,
+        "retirement_candidate_count": retirement_count,
+    }
+
+
 def build_auto_research_projection(
     fixture: dict[str, Any],
     *,
@@ -530,6 +631,7 @@ def build_auto_research_projection(
     hypotheses = fixture["hypotheses"]
     evidence_graph = build_research_evidence_graph(fixture)
     decision_candidates = build_research_decision_candidates(evidence_graph)
+    completion = build_auto_research_completion_status(evidence_graph, decision_candidates)
 
     runnable_statuses = {"active", "needs_retry"}
     selected = None
@@ -560,6 +662,7 @@ def build_auto_research_projection(
         "blocked": blocked,
         "promotion_candidates": decision_candidates["promotion_candidates"],
         "retirement_candidates": decision_candidates["retirement_candidates"],
+        "completion": completion,
     }
     return {
         "ok": True,
@@ -567,6 +670,7 @@ def build_auto_research_projection(
         "source_schema_version": fixture["schema_version"],
         "frontier": frontier,
         "evidence_graph": evidence_graph,
+        "completion": completion,
         "public_boundary": {
             "raw_logs_recorded": False,
             "private_artifacts_recorded": False,
@@ -676,6 +780,7 @@ def build_live_auto_research_projection(
         else todo_graph
     )
     decisions = build_research_decision_candidates(evidence_graph)
+    completion = build_auto_research_completion_status(evidence_graph, decisions)
     frontier = {
         "schema_version": RESEARCH_FRONTIER_SCHEMA_VERSION,
         "goal_id": goal,
@@ -685,6 +790,7 @@ def build_live_auto_research_projection(
         "blocked": blocked,
         "promotion_candidates": decisions["promotion_candidates"],
         "retirement_candidates": decisions["retirement_candidates"],
+        "completion": completion,
         "source_kind": "loopx_live_quota_status",
     }
     return {
@@ -694,6 +800,7 @@ def build_live_auto_research_projection(
         "frontier": frontier,
         "evidence_graph": evidence_graph,
         "decision_candidates": decisions,
+        "completion": completion,
         "public_boundary": {
             "raw_logs_recorded": False,
             "private_artifacts_recorded": False,

--- a/loopx/capabilities/auto_research/worker_runtime.py
+++ b/loopx/capabilities/auto_research/worker_runtime.py
@@ -371,6 +371,7 @@ def load_auto_research_worker_frontier(
     )
     frontier = projection["frontier"]
     selected = frontier.get("selected") if isinstance(frontier, dict) else None
+    completion = frontier.get("completion") if isinstance(frontier, dict) else None
     return {
         "ok": True,
         "schema_version": AUTO_RESEARCH_WORKER_FRONTIER_SCHEMA_VERSION,
@@ -391,6 +392,7 @@ def load_auto_research_worker_frontier(
             "runnable_count": len(frontier.get("runnable") or []) if isinstance(frontier, dict) else 0,
             "blocked_count": len(frontier.get("blocked") or []) if isinstance(frontier, dict) else 0,
             "source_kind": frontier.get("source_kind") if isinstance(frontier, dict) else None,
+            "completion": completion if isinstance(completion, dict) else None,
         },
         "public_boundary": {
             "source": "loopx_quota_and_auto_research_frontier",
@@ -437,6 +439,28 @@ def run_auto_research_worker_turn(
     action = normalize_auto_research_action(raw_action)
     todo_id = str((selected or {}).get("todo_id") or "")
     if not selected or not todo_id:
+        completion = (
+            frontier_packet["frontier"].get("completion")
+            if isinstance(frontier_packet.get("frontier"), dict)
+            else None
+        )
+        if isinstance(completion, dict) and completion.get("quiet_completion_allowed") is True:
+            return {
+                "ok": True,
+                "schema_version": AUTO_RESEARCH_WORKER_TURN_SCHEMA_VERSION,
+                "mode": "quiet_completion",
+                "goal_id": goal_id,
+                "agent_id": agent_id,
+                "executed": False,
+                "completion": completion,
+                "frontier": frontier_packet,
+                "public_boundary": {
+                    "raw_logs_recorded": False,
+                    "private_artifacts_recorded": False,
+                    "absolute_paths_recorded": False,
+                    "credentials_recorded": False,
+                },
+            }
         return {
             "ok": True,
             "schema_version": AUTO_RESEARCH_WORKER_TURN_SCHEMA_VERSION,


### PR DESCRIPTION
## Summary
- Add an auto-research completion status to the live/public frontier projection.
- Return `quiet_completion` from worker-turn when target evidence is reached with no selected todo.
- Extend the worker-turn smoke for two public fixture holdout improvements and no open todo.

## Validation
- `python3 -m py_compile loopx/capabilities/auto_research/research_state.py loopx/capabilities/auto_research/worker_runtime.py examples/auto-research-worker-turn-smoke.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 examples/auto-research-worker-turn-smoke.py`
- `PYTHONDONTWRITEBYTECODE=1 python3 examples/decentralized-auto-research-frontier-smoke.py`
- `loopx check --scan-path loopx/capabilities/auto_research/research_state.py --scan-path loopx/capabilities/auto_research/worker_runtime.py --scan-path examples/auto-research-worker-turn-smoke.py`
- `loopx canary premerge --from-git-diff`
- Live worker-hook cross-check: selected remains null, completion status is `target_reached`, mode is `quiet_completion`, holdout improvements are 2.

## Boundary
- Public boundary scan clean.
- No raw logs, credentials, local paths, or private evidence added.

## Self-merge rationale
This is a narrow auto-research status/runtime sufficiency fix plus a focused public smoke. It does not change benchmark scoring, task semantics, permission boundaries, or launch jobs. The diff-based canary reported `self_merge_allowed=true`.
