### PR TITLE
Fix monitor-only frontier replan gating

### DIFF
--- a/docs/heartbeat-automation-prompt.md
+++ b/docs/heartbeat-automation-prompt.md
@@ -297,7 +297,8 @@ If the result says should_run=false:
 
   loopx --registry "$HOME/.codex/loopx/registry.global.json" quota monitor-poll --goal-id <GOAL_ID> --source heartbeat --execute
 
-  Then rerun quota should-run. If it remains monitor-only, return quiet
+  Then rerun quota should-run. If it remains monitor-only after an explicit
+  frontier delta such as watch-lane continuation or no-follow-up, return quiet
   DONT_NOTIFY: no delivery edits and no spend. Keep the automation active:
   unchanged monitor-only polls are not self-stop signals. If the next guard
   reports autonomous_replan_required or another hard

--- a/docs/product/core-control-plane/state-machine.md
+++ b/docs/product/core-control-plane/state-machine.md
@@ -431,7 +431,9 @@ The important ordering is goal-level first: required replan is evaluated before
 monitor quiet skip, scoped gate wait, or an individual agent's no-candidate
 state. Those local states may remain visible, but they cannot clear a required
 replan. An acknowledgement without a vision, todo, acceptance, or no-follow-up
-delta is `replan_noop`.
+delta is `replan_noop`. A future monitor `next_due_at` is scheduler metadata,
+not a frontier delta, and cannot by itself suppress a monitor-only empty-frontier
+replan.
 
 The same ordering applies when an agent records a bounded
 `replan_trigger_summary` in its vision packet. Status/quota exposes that trigger

--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -245,6 +245,12 @@ unchanged monitor polls are quiet no-spend checks with `should_run=false` and
 `effective_action=monitor_quiet_skip`. This keeps monitoring useful without
 letting it consume every eligible turn, and it keeps the hard routing rule in
 one small machine contract.
+When the current agent lane has only monitor work and no current, unclaimed, or
+other-agent advancement frontier, a future `next_due_at` is not enough to make
+the lane quiet. Quota must first project `autonomous_replan_required` unless a
+recent autonomous replan ACK carries a recognized frontier delta such as a
+runnable todo set, successor/supersede, blocker, watch-lane continuation,
+no-follow-up, active next action, or goal vision patch.
 
 Executable todos can also declare explicit write-scope requirements through
 todo metadata, for example `required_write_scopes=runner%2F%2A%2A` or the CLI

--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -248,9 +248,11 @@ one small machine contract.
 When the current agent lane has only monitor work and no current, unclaimed, or
 other-agent advancement frontier, a future `next_due_at` is not enough to make
 the lane quiet. Quota must first project `autonomous_replan_required` unless a
-recent autonomous replan ACK carries a recognized frontier delta such as a
-runnable todo set, successor/supersede, blocker, watch-lane continuation,
-no-follow-up, active next action, or goal vision patch.
+recent same-agent autonomous replan ACK carries a recognized frontier delta such
+as a runnable todo set, successor/supersede, blocker, watch-lane continuation,
+no-follow-up, active next action, or goal vision patch. Projected ACKs from a
+different agent lane are diagnostic only for this decision and cannot clear the
+current lane's empty-frontier obligation.
 
 Executable todos can also declare explicit write-scope requirements through
 todo metadata, for example `required_write_scopes=runner%2F%2A%2A` or the CLI

--- a/docs/reference/protocols/goal-vision-replan-contract-v0.md
+++ b/docs/reference/protocols/goal-vision-replan-contract-v0.md
@@ -124,11 +124,14 @@ For the same `agent_id`, a newer satisfied checkpoint with `patched`,
 `missing_required` checkpoints; `not_required` does not.
 
 Checkpoint and autonomous-replan ACK packets are protocol records, not semantic
-completion proof. A recent ACK may suppress duplicate monitor-only replan
-requests only after the current per-agent vision has no projected acceptance
-gap. If evidence, successor state, blocker state, or a superseding vision packet
-still shows the vision is unmet, the acceptance gap remains authoritative and
-quota must continue to project replan work.
+completion proof. A future monitor schedule is also not completion proof; it
+only says when to poll. A recent ACK may suppress duplicate monitor-only replan
+requests only after it carries a frontier delta such as runnable work,
+successor/supersede, blocker, watch-lane continuation, no-follow-up, or a
+vision patch, and after the current per-agent vision has no projected
+acceptance gap. If evidence, successor state, blocker state, or a superseding
+vision packet still shows the vision is unmet, the acceptance gap remains
+authoritative and quota must continue to project replan work.
 
 ## Vision Continuation Audit
 

--- a/docs/reference/protocols/goal-vision-replan-contract-v0.md
+++ b/docs/reference/protocols/goal-vision-replan-contract-v0.md
@@ -125,13 +125,14 @@ For the same `agent_id`, a newer satisfied checkpoint with `patched`,
 
 Checkpoint and autonomous-replan ACK packets are protocol records, not semantic
 completion proof. A future monitor schedule is also not completion proof; it
-only says when to poll. A recent ACK may suppress duplicate monitor-only replan
-requests only after it carries a frontier delta such as runnable work,
-successor/supersede, blocker, watch-lane continuation, no-follow-up, or a
-vision patch, and after the current per-agent vision has no projected
-acceptance gap. If evidence, successor state, blocker state, or a superseding
-vision packet still shows the vision is unmet, the acceptance gap remains
-authoritative and quota must continue to project replan work.
+only says when to poll. A recent same-agent ACK may suppress duplicate
+monitor-only replan requests only after it carries a frontier delta such as
+runnable work, successor/supersede, blocker, watch-lane continuation,
+no-follow-up, or a vision patch, and after the current per-agent vision has no
+projected acceptance gap. An ACK from another agent lane must not clear this
+lane's empty-frontier obligation. If evidence, successor state, blocker state,
+or a superseding vision packet still shows the vision is unmet, the acceptance
+gap remains authoritative and quota must continue to project replan work.
 
 ## Vision Continuation Audit
 

--- a/examples/control_plane/control-plane-integrated-canary-smoke.py
+++ b/examples/control_plane/control-plane-integrated-canary-smoke.py
@@ -578,19 +578,22 @@ def assert_due_monitor_poll_state_machine(root: Path) -> None:
         "--agent-id",
         AGENT_ID,
     )
-    assert quiet_payload["decision"] == "skip", quiet_payload
-    assert quiet_payload["effective_action"] == "monitor_quiet_skip", quiet_payload
-    assert quiet_payload["execution_obligation"]["must_attempt_work"] is False, quiet_payload
-    assert quiet_payload["execution_obligation"]["kind"] == "monitor_quiet_skip", quiet_payload
-    assert quiet_payload["interaction_contract"]["mode"] == "monitor_quiet_skip", quiet_payload
+    assert quiet_payload["decision"] == "autonomous_replan_required", quiet_payload
+    assert quiet_payload["effective_action"] == "autonomous_replan_required", quiet_payload
+    assert quiet_payload["execution_obligation"]["must_attempt_work"] is True, quiet_payload
+    assert quiet_payload["execution_obligation"]["kind"] == "autonomous_replan_required", quiet_payload
+    assert quiet_payload["interaction_contract"]["mode"] == "autonomous_replan", quiet_payload
     assert quiet_payload["work_lane_contract"]["obligation"] == (
         "quiet_until_material_monitor_transition"
     ), quiet_payload
     assert quiet_payload["work_lane_contract"]["must_attempt_work"] is False, quiet_payload
     assert quiet_payload["goal_frontier_projection"]["monitor_only_lanes"]["present"] is True, quiet_payload
-    assert quiet_payload["goal_frontier_projection"]["replan_required"] is False, quiet_payload
+    assert quiet_payload["goal_frontier_projection"]["replan_required"] is True, quiet_payload
+    obligation = quiet_payload["autonomous_replan_obligation"]
+    assert obligation["triggers"][0]["kind"] == "frontier_exhausted_monitor_lane", quiet_payload
+    assert obligation["triggers"][0]["future_monitor_schedule_present"] is True, quiet_payload
     assert quiet_payload["agent_todo_summary"]["monitor_due_count"] == 0, quiet_payload
-    assert quiet_payload["scheduler_hint"]["cadence_class"] == "monitor_wait", quiet_payload
+    assert quiet_payload["scheduler_hint"]["cadence_class"] == "active_work", quiet_payload
 
 
 def assert_markdown_same_agent_continuation_read_path(root: Path) -> None:

--- a/examples/control_plane/control-plane-risk-characterization-smoke.py
+++ b/examples/control_plane/control-plane-risk-characterization-smoke.py
@@ -262,7 +262,7 @@ def assert_higher_priority_due_monitor_preempts_advancement() -> None:
     assert quota["recommended_action"] == "[P0] Poll the due monitor first.", quota
 
 
-def assert_monitor_only_frontier_quiets_until_material_transition() -> None:
+def assert_monitor_only_frontier_requires_replan_without_delta() -> None:
     payload = status_payload(
         [
             todo_item(
@@ -276,34 +276,33 @@ def assert_monitor_only_frontier_quiets_until_material_transition() -> None:
         ]
     )
     quota = build_quota_should_run(payload, goal_id=GOAL_ID, agent_id=AGENT_ID)
-    assert quota["decision"] == "skip", quota
-    assert quota["should_run"] is False, quota
-    assert quota["effective_action"] == "monitor_quiet_skip", quota
-    assert quota.get("autonomous_replan_obligation") is None, quota
+    assert quota["decision"] == "autonomous_replan_required", quota
+    assert quota["should_run"] is True, quota
+    assert quota["effective_action"] == "autonomous_replan_required", quota
 
     lane = quota["work_lane_contract"]
     assert lane["lane"] == "continuous_monitor", lane
     assert lane["obligation"] == "quiet_until_material_monitor_transition", lane
     assert lane["must_attempt_work"] is False, lane
-    assert quota["goal_frontier_projection"]["replan_required"] is False, quota
+    frontier = quota["goal_frontier_projection"]
+    assert frontier["replan_required"] is True, quota
+    obligation = quota["autonomous_replan_obligation"]
+    assert obligation["triggers"][0]["kind"] == "frontier_exhausted_monitor_lane", quota
+    assert obligation["triggers"][0]["future_monitor_schedule_present"] is True, quota
 
     contract = quota["interaction_contract"]
-    assert contract["mode"] == "monitor_quiet_skip", contract
+    assert contract["mode"] == "autonomous_replan", contract
     assert contract["user_channel"]["action_required"] is False, contract
     assert contract["user_channel"]["notify"] == "DONT_NOTIFY", contract
-    assert contract["agent_channel"]["must_attempt"] is False, contract
-    assert contract["agent_channel"]["delivery_allowed"] is False, contract
-    assert contract["agent_channel"]["quiet_noop_allowed"] is True, contract
+    assert contract["agent_channel"]["must_attempt"] is True, contract
+    assert contract["agent_channel"]["delivery_allowed"] is True, contract
+    assert contract["agent_channel"]["quiet_noop_allowed"] is False, contract
     assert contract["cli_channel"]["spend_allowed_now"] is False, contract
-    assert contract["cli_channel"]["spend_after_validation"] is False, contract
+    assert contract["cli_channel"]["spend_after_validation"] is True, contract
 
     scheduler = quota["scheduler_hint"]
-    assert scheduler["action"] == "backoff_until_material_transition", scheduler
-    assert scheduler["cadence_class"] == "monitor_wait", scheduler
-    assert scheduler["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=15", scheduler
-    assert scheduler["codex_app"]["recommended_interval_minutes"] == 15, scheduler
-    assert scheduler["codex_app"]["stateful_backoff"]["apply_needed"] is True, scheduler
-    assert scheduler["codex_app"]["no_spend_for_cadence_change"] is True, scheduler
+    assert scheduler["action"] == "run_now", scheduler
+    assert scheduler["cadence_class"] == "active_work", scheduler
 
     packet = build_review_packet(payload, goal_id=GOAL_ID)
     assert packet["ok"] is True, packet
@@ -429,7 +428,7 @@ def main() -> None:
     assert_due_monitor_context_does_not_steal_advancement()
     assert_current_agent_claimed_advancement_beats_other_agent_frontier()
     assert_higher_priority_due_monitor_preempts_advancement()
-    assert_monitor_only_frontier_quiets_until_material_transition()
+    assert_monitor_only_frontier_requires_replan_without_delta()
     assert_standing_monitor_gate_does_not_quiet_skip_gated_advancement()
     assert_agent_scope_wait_scheduler_contract()
     print("control-plane-risk-characterization-smoke ok")

--- a/examples/control_plane/quota-replan-decision-plane-smoke.py
+++ b/examples/control_plane/quota-replan-decision-plane-smoke.py
@@ -301,6 +301,26 @@ def satisfied_vision_checkpoint_run(*, decision: str, agent_id: str = SIDE_AGENT
     }
 
 
+def projected_autonomous_replan_ack(
+    delta_kinds: list[str],
+    *,
+    agent_id: str | None = None,
+) -> dict:
+    ack = {
+        "schema_version": "autonomous_replan_ack_v0",
+        "recorded": True,
+        "source": "refresh_state",
+        "delta_contract": {
+            "schema_version": "repair_delta_contract_v0",
+            "delta_present": True,
+            "delta_kinds": delta_kinds,
+        },
+    }
+    if agent_id:
+        ack["agent_id"] = agent_id
+    return ack
+
+
 def assert_replan_beats_monitor_quiet_skip() -> None:
     payload = status_payload([monitor_item()], replan_obligation=SIDE_AGENT_REPLAN_OBLIGATION)
     guard = build_quota_should_run(payload, goal_id=GOAL_ID, agent_id=SIDE_AGENT)
@@ -862,6 +882,43 @@ def assert_non_frontier_replan_ack_does_not_clear_monitor_replan() -> None:
         assert obligation["triggers"][0]["kind"] == "frontier_exhausted_monitor_lane", guard
 
 
+def assert_projected_replan_ack_is_agent_scoped() -> None:
+    unscoped_payload = status_payload([monitor_item()], replan_obligation=None)
+    unscoped_item = unscoped_payload["attention_queue"]["items"][0]
+    unscoped_item["autonomous_replan_ack"] = projected_autonomous_replan_ack(
+        ["no_followup"]
+    )
+    unscoped_item["project_asset"]["autonomous_replan_ack"] = projected_autonomous_replan_ack(
+        ["no_followup"],
+        agent_id=PRIMARY_AGENT,
+    )
+    guard = build_quota_should_run(
+        unscoped_payload,
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+    )
+    assert guard["decision"] == "autonomous_replan_required", guard
+    assert guard["effective_action"] == "autonomous_replan_required", guard
+    assert guard["goal_frontier_projection"]["replan_required"] is True, guard
+
+    scoped_payload = status_payload([monitor_item()], replan_obligation=None)
+    scoped_item = scoped_payload["attention_queue"]["items"][0]
+    scoped_ack = projected_autonomous_replan_ack(
+        ["watch_lane_continuation"],
+        agent_id=SIDE_AGENT,
+    )
+    scoped_item["autonomous_replan_ack"] = scoped_ack
+    scoped_item["project_asset"]["autonomous_replan_ack"] = scoped_ack
+    scoped_guard = build_quota_should_run(
+        scoped_payload,
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+    )
+    assert scoped_guard["decision"] == "skip", scoped_guard
+    assert scoped_guard["effective_action"] == "monitor_quiet_skip", scoped_guard
+    assert scoped_guard["goal_frontier_projection"]["replan_required"] is False, scoped_guard
+
+
 def assert_agent_vision_gap_beats_replan_ack() -> None:
     guard = build_quota_should_run(
         status_payload(
@@ -930,6 +987,7 @@ def main() -> None:
     assert_monitor_schedule_gap_requires_bounded_repair()
     assert_agent_ack_survives_other_agent_run_and_monitor_poll()
     assert_non_frontier_replan_ack_does_not_clear_monitor_replan()
+    assert_projected_replan_ack_is_agent_scoped()
     assert_agent_vision_gap_beats_replan_ack()
     assert_blocking_handoff_gate_beats_derived_monitor_replan()
     print("quota-replan-decision-plane-smoke ok")

--- a/examples/control_plane/quota-replan-decision-plane-smoke.py
+++ b/examples/control_plane/quota-replan-decision-plane-smoke.py
@@ -354,27 +354,28 @@ def assert_replan_beats_monitor_quiet_skip() -> None:
     ), repeat_guard
 
 
-def assert_future_scheduled_monitor_quiets_without_generated_replan() -> None:
+def assert_future_scheduled_monitor_requires_replan_without_frontier_delta() -> None:
     guard = build_quota_should_run(
         status_payload([monitor_item()], replan_obligation=None),
         goal_id=GOAL_ID,
         agent_id=SIDE_AGENT,
     )
-    assert guard["decision"] == "skip", guard
-    assert guard["effective_action"] == "monitor_quiet_skip", guard
-    assert guard["should_run"] is False, guard
+    assert guard["decision"] == "autonomous_replan_required", guard
+    assert guard["effective_action"] == "autonomous_replan_required", guard
+    assert guard["should_run"] is True, guard
     assert guard["heartbeat_recommendation"]["recommended_mode"] == (
-        "monitor_quiet_until_material_transition"
+        "autonomous_replan_required"
     ), guard
-    assert guard["interaction_contract"]["mode"] == "monitor_quiet_skip", guard
-    assert guard["interaction_contract"]["agent_channel"]["must_attempt"] is False, guard
-    assert guard["interaction_contract"]["agent_channel"]["quiet_noop_allowed"] is True, guard
-    assert guard["goal_frontier_projection"]["replan_required"] is False, guard
-    assert "vision_continuation_audit" not in guard, guard
-    assert guard.get("autonomous_replan_obligation") is None, guard
-    assert "required_reads" not in guard, guard
-    assert "required_reads" not in guard["interaction_contract"]["agent_channel"], guard
-    assert "required_reads" not in guard["interaction_contract"]["cli_channel"], guard
+    assert guard["interaction_contract"]["mode"] == "autonomous_replan", guard
+    assert guard["interaction_contract"]["agent_channel"]["must_attempt"] is True, guard
+    assert guard["goal_frontier_projection"]["replan_required"] is True, guard
+    obligation = guard["autonomous_replan_obligation"]
+    assert obligation["triggers"][0]["kind"] == "frontier_exhausted_monitor_lane", guard
+    assert obligation["triggers"][0]["future_monitor_schedule_present"] is True, guard
+    assert "watch-lane continuation" in obligation["recommended_action"], guard
+    assert "required_reads" in guard, guard
+    assert "required_reads" in guard["interaction_contract"]["agent_channel"], guard
+    assert "required_reads" in guard["interaction_contract"]["cli_channel"], guard
 
 
 def assert_ready_deferred_successor_beats_monitor_quiet_skip() -> None:
@@ -657,7 +658,7 @@ def assert_missing_vision_checkpoint_derives_agent_scoped_replan() -> None:
     assert primary_guard.get("autonomous_replan_obligation") is None, primary_guard
 
 
-def assert_satisfied_vision_checkpoint_supersedes_older_missing() -> None:
+def assert_satisfied_vision_checkpoint_supersedes_older_missing_but_not_empty_frontier() -> None:
     for decision in ("patched", "unchanged_with_reason", "retired_or_superseded"):
         guard = build_quota_should_run(
             status_payload(
@@ -671,14 +672,16 @@ def assert_satisfied_vision_checkpoint_supersedes_older_missing() -> None:
             goal_id=GOAL_ID,
             agent_id=SIDE_AGENT,
         )
-        assert guard["decision"] == "skip", guard
-        assert guard["effective_action"] == "monitor_quiet_skip", guard
-        assert guard["should_run"] is False, guard
-        assert guard["interaction_contract"]["mode"] == "monitor_quiet_skip", guard
+        assert guard["decision"] == "autonomous_replan_required", guard
+        assert guard["effective_action"] == "autonomous_replan_required", guard
+        assert guard["should_run"] is True, guard
+        assert guard["interaction_contract"]["mode"] == "autonomous_replan", guard
         assert guard["goal_frontier_projection"]["acceptance_gaps"] == [], guard
-        assert guard["goal_frontier_projection"]["replan_required"] is False, guard
+        assert guard["goal_frontier_projection"]["replan_required"] is True, guard
+        assert guard["autonomous_replan_obligation"]["triggers"][0]["kind"] == (
+            "frontier_exhausted_monitor_lane"
+        ), guard
         assert guard.get("vision_continuation_audit") is None, guard
-        assert guard.get("autonomous_replan_obligation") is None, guard
 
 
 def assert_agent_scoped_replan_beats_agent_scope_wait() -> None:
@@ -825,6 +828,40 @@ def assert_agent_ack_survives_other_agent_run_and_monitor_poll() -> None:
     assert guard.get("autonomous_replan_obligation") is None, guard
 
 
+def assert_non_frontier_replan_ack_does_not_clear_monitor_replan() -> None:
+    for delta_kinds in (["interaction_contract"], ["unknown_delta_kind"], []):
+        guard = build_quota_should_run(
+            status_payload(
+                [monitor_item()],
+                replan_obligation=None,
+                latest_runs=[
+                    {
+                        "classification": "monitor_poll_autonomous_replan_recorded_v0",
+                        "agent_id": SIDE_AGENT,
+                        "progress_scope": "agent_lane",
+                        "autonomous_replan_ack": {
+                            "schema_version": "autonomous_replan_ack_v0",
+                            "recorded": True,
+                            "source": "refresh_state",
+                            "delta_contract": {
+                                "schema_version": "repair_delta_contract_v0",
+                                "delta_present": True,
+                                "delta_kinds": delta_kinds,
+                            },
+                        },
+                    },
+                ],
+            ),
+            goal_id=GOAL_ID,
+            agent_id=SIDE_AGENT,
+        )
+        assert guard["decision"] == "autonomous_replan_required", guard
+        assert guard["effective_action"] == "autonomous_replan_required", guard
+        assert guard["goal_frontier_projection"]["replan_required"] is True, guard
+        obligation = guard["autonomous_replan_obligation"]
+        assert obligation["triggers"][0]["kind"] == "frontier_exhausted_monitor_lane", guard
+
+
 def assert_agent_vision_gap_beats_replan_ack() -> None:
     guard = build_quota_should_run(
         status_payload(
@@ -880,18 +917,19 @@ def assert_blocking_handoff_gate_beats_derived_monitor_replan() -> None:
 
 def main() -> None:
     assert_replan_beats_monitor_quiet_skip()
-    assert_future_scheduled_monitor_quiets_without_generated_replan()
+    assert_future_scheduled_monitor_requires_replan_without_frontier_delta()
     assert_ready_deferred_successor_beats_monitor_quiet_skip()
     assert_completed_advancement_without_successor_beats_monitor_quiet_skip()
     assert_replan_preserves_current_agent_runnable_frontier()
     assert_long_agent_todo_chain_derives_replan_before_linear_delivery()
     assert_agent_vision_gap_derives_replan()
     assert_missing_vision_checkpoint_derives_agent_scoped_replan()
-    assert_satisfied_vision_checkpoint_supersedes_older_missing()
+    assert_satisfied_vision_checkpoint_supersedes_older_missing_but_not_empty_frontier()
     assert_agent_scoped_replan_beats_agent_scope_wait()
     assert_unscoped_replan_defaults_to_primary_agent()
     assert_monitor_schedule_gap_requires_bounded_repair()
     assert_agent_ack_survives_other_agent_run_and_monitor_poll()
+    assert_non_frontier_replan_ack_does_not_clear_monitor_replan()
     assert_agent_vision_gap_beats_replan_ack()
     assert_blocking_handoff_gate_beats_derived_monitor_replan()
     print("quota-replan-decision-plane-smoke ok")

--- a/examples/control_plane/work-lane-contract-smoke.py
+++ b/examples/control_plane/work-lane-contract-smoke.py
@@ -33,7 +33,6 @@ def status_payload(
     next_action: str = "Observe dependency state and then advance backlog if unchanged.",
     post_handoff_latest_run: dict | None = None,
     coordination: dict | None = None,
-    latest_runs: list[dict] | None = None,
 ) -> dict:
     if agent_todo_items is None:
         agent_todo_items = [
@@ -109,8 +108,6 @@ def status_payload(
     }
     if coordination:
         goal_history_item["coordination"] = coordination
-    if latest_runs is not None:
-        goal_history_item["latest_runs"] = latest_runs
     return {
         "ok": True,
         "attention_queue": {
@@ -768,14 +765,9 @@ def assert_not_due_monitor_only_requires_frontier_replan_without_delta() -> None
     lane = guard["work_lane_contract"]
     assert guard["decision"] == "autonomous_replan_required", guard
     assert guard["effective_action"] == "autonomous_replan_required", guard
-    assert guard["should_run"] is True, guard
     assert lane["lane"] == "continuous_monitor", lane
     assert lane["obligation"] == "quiet_until_material_monitor_transition", lane
-    assert guard["heartbeat_recommendation"]["recommended_mode"] == (
-        "autonomous_replan_required"
-    ), guard
     assert guard["interaction_contract"]["mode"] == "autonomous_replan", guard
-    assert guard["interaction_contract"]["agent_channel"]["must_attempt"] is True, guard
     assert guard["goal_frontier_projection"]["replan_required"] is True, guard
     obligation = guard["autonomous_replan_obligation"]
     assert obligation["triggers"][0]["kind"] == "frontier_exhausted_monitor_lane", guard
@@ -2269,24 +2261,8 @@ def assert_active_next_action_todo_survives_compact_candidate_limits() -> None:
             "registered_agents": ["codex-main-control"],
         },
         agent_todo_items=[],
-        latest_runs=[
-            {
-                "classification": "candidate_limit_fixture_frontier_delta",
-                "agent_id": "codex-main-control",
-                "progress_scope": "agent_lane",
-                "autonomous_replan_ack": {
-                    "schema_version": "autonomous_replan_ack_v0",
-                    "recorded": True,
-                    "source": "refresh_state",
-                    "delta_contract": {
-                        "schema_version": "repair_delta_contract_v0",
-                        "delta_present": True,
-                        "delta_kinds": ["runnable_todo_set"],
-                    },
-                },
-            },
-        ],
     )
+    payload["run_history"]["goals"][0]["latest_runs"] = [{"agent_id": "codex-main-control", "autonomous_replan_ack": {"recorded": True, "delta_contract": {"delta_present": True, "delta_kinds": ["runnable_todo_set"]}}}]
     item = payload["attention_queue"]["items"][0]
     item["agent_todos"] = agent_todos
     item["project_asset"]["agent_todos"] = agent_todos

--- a/examples/control_plane/work-lane-contract-smoke.py
+++ b/examples/control_plane/work-lane-contract-smoke.py
@@ -33,6 +33,7 @@ def status_payload(
     next_action: str = "Observe dependency state and then advance backlog if unchanged.",
     post_handoff_latest_run: dict | None = None,
     coordination: dict | None = None,
+    latest_runs: list[dict] | None = None,
 ) -> dict:
     if agent_todo_items is None:
         agent_todo_items = [
@@ -108,6 +109,8 @@ def status_payload(
     }
     if coordination:
         goal_history_item["coordination"] = coordination
+    if latest_runs is not None:
+        goal_history_item["latest_runs"] = latest_runs
     return {
         "ok": True,
         "attention_queue": {
@@ -743,7 +746,7 @@ def assert_mixed_monitor_and_advancement_routes_to_advancement() -> None:
     assert [item["task_class"] for item in first_items] == ["advancement_task", "continuous_monitor"], guard
 
 
-def assert_not_due_monitor_only_quiets_until_material_transition() -> None:
+def assert_not_due_monitor_only_requires_frontier_replan_without_delta() -> None:
     guard = build_quota_should_run(
         status_payload(
             status="monitor_schedule_waiting",
@@ -763,15 +766,20 @@ def assert_not_due_monitor_only_quiets_until_material_transition() -> None:
         goal_id=GOAL_ID,
     )
     lane = guard["work_lane_contract"]
-    assert guard["decision"] == "skip", guard
-    assert guard["effective_action"] == "monitor_quiet_skip", guard
+    assert guard["decision"] == "autonomous_replan_required", guard
+    assert guard["effective_action"] == "autonomous_replan_required", guard
+    assert guard["should_run"] is True, guard
     assert lane["lane"] == "continuous_monitor", lane
     assert lane["obligation"] == "quiet_until_material_monitor_transition", lane
-    assert guard["heartbeat_recommendation"]["recommended_mode"] == "monitor_quiet_until_material_transition", guard
-    assert guard["interaction_contract"]["mode"] == "monitor_quiet_skip", guard
-    assert guard["interaction_contract"]["agent_channel"]["quiet_noop_allowed"] is True, guard
-    assert guard["goal_frontier_projection"]["replan_required"] is False, guard
-    assert guard.get("autonomous_replan_obligation") is None, guard
+    assert guard["heartbeat_recommendation"]["recommended_mode"] == (
+        "autonomous_replan_required"
+    ), guard
+    assert guard["interaction_contract"]["mode"] == "autonomous_replan", guard
+    assert guard["interaction_contract"]["agent_channel"]["must_attempt"] is True, guard
+    assert guard["goal_frontier_projection"]["replan_required"] is True, guard
+    obligation = guard["autonomous_replan_obligation"]
+    assert obligation["triggers"][0]["kind"] == "frontier_exhausted_monitor_lane", guard
+    assert obligation["triggers"][0]["future_monitor_schedule_present"] is True, guard
     assert guard["agent_todo_summary"]["monitor_due_count"] == 0, guard
 
 
@@ -2261,6 +2269,23 @@ def assert_active_next_action_todo_survives_compact_candidate_limits() -> None:
             "registered_agents": ["codex-main-control"],
         },
         agent_todo_items=[],
+        latest_runs=[
+            {
+                "classification": "candidate_limit_fixture_frontier_delta",
+                "agent_id": "codex-main-control",
+                "progress_scope": "agent_lane",
+                "autonomous_replan_ack": {
+                    "schema_version": "autonomous_replan_ack_v0",
+                    "recorded": True,
+                    "source": "refresh_state",
+                    "delta_contract": {
+                        "schema_version": "repair_delta_contract_v0",
+                        "delta_present": True,
+                        "delta_kinds": ["runnable_todo_set"],
+                    },
+                },
+            },
+        ],
     )
     item = payload["attention_queue"]["items"][0]
     item["agent_todos"] = agent_todos
@@ -2301,7 +2326,7 @@ def main() -> int:
     assert_structured_todo_lane_registration_beats_text_fallback()
     assert_structured_monitor_registration_beats_action_text()
     assert_mixed_monitor_and_advancement_routes_to_advancement()
-    assert_not_due_monitor_only_quiets_until_material_transition()
+    assert_not_due_monitor_only_requires_frontier_replan_without_delta()
     assert_due_monitor_only_requires_attempt()
     assert_due_monitor_lower_priority_does_not_preempt_advancement()
     assert_due_monitor_higher_priority_preempts_advancement()

--- a/loopx/control_plane/goals/goal_frontier.py
+++ b/loopx/control_plane/goals/goal_frontier.py
@@ -8,6 +8,7 @@ from ..agents.agent_scope import (
     agent_scope_item_claimed_by,
     agent_scope_item_claimed_by_agent_or_unclaimed,
 )
+from ..work_items.repair_delta import repair_delta_kinds_have_frontier_delta
 
 
 GOAL_FRONTIER_PROJECTION_SCHEMA_VERSION = "goal_frontier_projection_v0"
@@ -30,15 +31,6 @@ VISION_CHECKPOINT_SATISFIED_DECISIONS = {
     "patched",
     "retired_or_superseded",
     "unchanged_with_reason",
-}
-FRONTIER_REPLAN_ACK_DELTA_KINDS = {
-    "active_state_next_action",
-    "blocker",
-    "goal_vision_patch",
-    "no_followup",
-    "runnable_todo_set",
-    "successor_or_supersede",
-    "watch_lane_continuation",
 }
 
 
@@ -73,12 +65,7 @@ def autonomous_replan_ack_has_frontier_delta(ack: dict[str, Any] | None) -> bool
     delta_contract = ack.get("delta_contract")
     if not isinstance(delta_contract, dict) or delta_contract.get("delta_present") is not True:
         return False
-    delta_kinds = {
-        str(item or "").strip()
-        for item in (delta_contract.get("delta_kinds") or [])
-        if str(item or "").strip()
-    }
-    return bool(delta_kinds & FRONTIER_REPLAN_ACK_DELTA_KINDS)
+    return repair_delta_kinds_have_frontier_delta(delta_contract.get("delta_kinds"))
 
 
 def autonomous_replan_decision_allowed(
@@ -765,6 +752,36 @@ def _blocking_handoff_gate_count(
     return len(agent_scope_blocking_handoff_gates(agent_todo_summary, agent_id=agent_id))
 
 
+def _ready_deferred_successor_count(
+    agent_todo_summary: dict[str, Any] | None,
+    *,
+    agent_id: str | None,
+) -> int:
+    if not isinstance(agent_todo_summary, dict):
+        return 0
+    current_count = safe_non_negative_int(
+        agent_todo_summary.get("current_agent_deferred_resume_count")
+    )
+    unclaimed_count = safe_non_negative_int(
+        agent_todo_summary.get("unclaimed_deferred_resume_count")
+    )
+    if current_count or unclaimed_count:
+        return current_count + unclaimed_count
+    candidates = (
+        agent_todo_summary.get("deferred_resume_candidates")
+        if isinstance(agent_todo_summary.get("deferred_resume_candidates"), list)
+        else []
+    )
+    return len(
+        [
+            item
+            for item in candidates
+            if isinstance(item, dict)
+            and agent_scope_item_claimed_by_agent_or_unclaimed(item, agent_id=agent_id)
+        ]
+    )
+
+
 def _succession_gap_items(
     agent_todo_summary: dict[str, Any] | None,
     *,
@@ -814,6 +831,8 @@ def derive_goal_frontier_replan_obligation_from_summaries(
     if autonomous_replan_is_required(existing_replan_obligation):
         return None
     if _blocking_handoff_gate_count(agent_todo_summary, agent_id=agent_id) > 0:
+        return None
+    if _ready_deferred_successor_count(agent_todo_summary, agent_id=agent_id) > 0:
         return None
 
     user_counts = _summary_task_counts(user_todo_summary)
@@ -995,8 +1014,7 @@ def derive_goal_frontier_replan_obligation_from_summaries(
         return None
     if agent_counts.get("advancement", 0) > 0 or total_frontier_advancement > 0:
         return None
-    if _monitor_only_lane_has_future_schedule(agent_todo_summary):
-        return None
+    future_schedule_present = _monitor_only_lane_has_future_schedule(agent_todo_summary)
 
     return {
         "schema_version": AUTONOMOUS_REPLAN_OBLIGATION_SCHEMA_VERSION,
@@ -1014,6 +1032,7 @@ def derive_goal_frontier_replan_obligation_from_summaries(
                 "agent_id": agent_id,
                 "agent_open_count": agent_counts.get("open", 0),
                 "agent_monitor_open_count": agent_counts.get("monitor", 0),
+                "future_monitor_schedule_present": future_schedule_present,
             }
         ],
         "guidance_actions": [
@@ -1041,7 +1060,7 @@ def derive_goal_frontier_replan_obligation_from_summaries(
         "recommended_action": (
             "run a bounded goal-frontier replan before another monitor-only quiet "
             "poll: create successor work, supersede the monitor lane, set an expiry, "
-            "or record no-follow-up"
+            "record watch-lane continuation, or record no-follow-up"
         ),
     }
 

--- a/loopx/control_plane/work_items/autonomous_replan_ack.py
+++ b/loopx/control_plane/work_items/autonomous_replan_ack.py
@@ -29,12 +29,30 @@ def compact_autonomous_replan_ack(run: dict[str, Any] | None) -> dict[str, Any] 
             if str(item or "").strip()
         ],
     }
-    return {
+    result = {
         "schema_version": ack.get("schema_version"),
         "recorded": True,
         "source": ack.get("source"),
         "delta_contract": compact_delta,
     }
+    agent_id = str(run.get("agent_id") or "").strip()
+    if agent_id:
+        result["agent_id"] = agent_id
+    return result
+
+
+def autonomous_replan_ack_matches_agent(
+    ack: dict[str, Any] | None,
+    *,
+    agent_id: str | None,
+) -> bool:
+    if not isinstance(ack, dict):
+        return False
+    normalized_agent_id = str(agent_id or "").strip()
+    if not normalized_agent_id:
+        return True
+    ack_agent_id = str(ack.get("agent_id") or "").strip()
+    return bool(ack_agent_id and ack_agent_id == normalized_agent_id)
 
 
 def latest_autonomous_replan_ack_for_projection(

--- a/loopx/control_plane/work_items/repair_delta.py
+++ b/loopx/control_plane/work_items/repair_delta.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Iterable
+
+
+REPAIR_DELTA_KIND_CHOICES = (
+    "effective_action",
+    "interaction_contract",
+    "runnable_todo_set",
+    "user_gate",
+    "blocker",
+    "successor_or_supersede",
+    "capability_gate",
+    "monitor_target",
+    "active_state_next_action",
+    "goal_vision_patch",
+    "goal_boundary_projection",
+    "no_followup",
+    "watch_lane_continuation",
+)
+
+FRONTIER_REPLAN_ACK_DELTA_KINDS = frozenset(
+    {
+        "active_state_next_action",
+        "blocker",
+        "goal_vision_patch",
+        "no_followup",
+        "runnable_todo_set",
+        "successor_or_supersede",
+        "watch_lane_continuation",
+    }
+)
+
+
+def normalize_repair_delta_kinds(values: Iterable[str] | None) -> list[str]:
+    normalized: list[str] = []
+    seen: set[str] = set()
+    allowed = set(REPAIR_DELTA_KIND_CHOICES)
+    for value in values or []:
+        item = str(value or "").strip()
+        if not item:
+            continue
+        if item not in allowed:
+            raise ValueError(
+                "repair_delta_kind must be one of: "
+                + ", ".join(REPAIR_DELTA_KIND_CHOICES)
+            )
+        if item in seen:
+            continue
+        seen.add(item)
+        normalized.append(item)
+    return normalized
+
+
+def repair_delta_kinds_have_frontier_delta(values: Iterable[str] | None) -> bool:
+    return bool(
+        {
+            str(item or "").strip()
+            for item in (values or [])
+            if str(item or "").strip()
+        }
+        & FRONTIER_REPLAN_ACK_DELTA_KINDS
+    )

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -48,6 +48,9 @@ from .control_plane.work_items.interaction_contract import (
     protocol_action_text as _protocol_action_text,
     user_channel_action_required as _user_channel_action_required,
 )
+from .control_plane.work_items.autonomous_replan_ack import (
+    autonomous_replan_ack_matches_agent,
+)
 from .control_plane.goals.goal_frontier import (
     AUTONOMOUS_REPLAN_REQUIRED_MODE,
     acceptance_gaps_from_agent_vision,
@@ -1498,6 +1501,19 @@ def _latest_autonomous_replan_ack_for_agent(
     return None
 
 
+def _projected_autonomous_replan_ack_for_agent(
+    item: dict[str, Any],
+    project_asset: dict[str, Any],
+    *,
+    agent_id: str | None,
+) -> dict[str, Any] | None:
+    for candidate in (item.get("autonomous_replan_ack"), project_asset.get("autonomous_replan_ack")):
+        if not autonomous_replan_ack_matches_agent(candidate, agent_id=agent_id):
+            continue
+        return candidate
+    return None
+
+
 def _recovery_delivery_allowed(quota: dict[str, Any], *, plan_ok: bool) -> bool:
     return (
         bool(plan_ok)
@@ -1691,13 +1707,13 @@ def build_quota_should_run(
             work_lane_contract=work_lane_contract,
             agent_id=agent_frontier_id,
             existing_replan_obligation=replan_obligation,
-            latest_replan_ack=latest_agent_replan_ack
-            or (
-                item.get("autonomous_replan_ack")
-                if isinstance(item.get("autonomous_replan_ack"), dict)
-                else project_asset.get("autonomous_replan_ack")
-                if isinstance(project_asset.get("autonomous_replan_ack"), dict)
-                else None
+            latest_replan_ack=(
+                latest_agent_replan_ack
+                or _projected_autonomous_replan_ack_for_agent(
+                    item,
+                    project_asset,
+                    agent_id=agent_frontier_id,
+                )
             ),
             acceptance_gaps=goal_frontier_acceptance_gaps,
         )

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -9,6 +9,10 @@ from typing import Any
 from .control_plane.runtime.time import now_local_iso
 from .control_plane.work_items.delivery_batch_scale import DELIVERY_BATCH_SCALE_CHOICES, require_delivery_batch_scale
 from .control_plane.work_items.delivery_outcome import DELIVERY_OUTCOME_CHOICES, require_delivery_outcome
+from .control_plane.work_items.repair_delta import (
+    REPAIR_DELTA_KIND_CHOICES,
+    normalize_repair_delta_kinds,
+)
 from .feedback import validate_local_control_text, validate_public_safe_text
 from .file_lock import exclusive_file_lock
 from .global_registry import sync_project_registry_to_global
@@ -43,21 +47,6 @@ CHECKBOX_PREFIX_RE = re.compile(r"^\[(?P<mark>[ xX])\]\s+")
 ACTIVE_STATE_NEXT_ACTION_UPDATE_SCHEMA_VERSION = "active_state_next_action_update_v0"
 REPAIR_DELTA_CONTRACT_SCHEMA_VERSION = "repair_delta_contract_v0"
 REPAIR_NOOP_SCHEMA_VERSION = "repair_noop_v0"
-REPAIR_DELTA_KIND_CHOICES = (
-    "effective_action",
-    "interaction_contract",
-    "runnable_todo_set",
-    "user_gate",
-    "blocker",
-    "successor_or_supersede",
-    "capability_gate",
-    "monitor_target",
-    "active_state_next_action",
-    "goal_vision_patch",
-    "goal_boundary_projection",
-    "no_followup",
-    "watch_lane_continuation",
-)
 VISION_CHECKPOINT_SCHEMA_VERSION = "vision_checkpoint_v0"
 VISION_CHECKPOINT_MATERIAL_OUTCOMES = {
     "outcome_gap",
@@ -134,25 +123,6 @@ def normalize_next_action_text(value: str) -> str:
         raise ValueError("next_action must not be empty")
     validate_public_safe_text("active_state_next_action", text)
     return text
-
-
-def normalize_repair_delta_kinds(values: list[str] | None) -> list[str]:
-    normalized: list[str] = []
-    seen: set[str] = set()
-    allowed = set(REPAIR_DELTA_KIND_CHOICES)
-    for value in values or []:
-        item = str(value or "").strip()
-        if not item:
-            continue
-        if item not in allowed:
-            raise ValueError(
-                "repair_delta_kind must be one of: " + ", ".join(REPAIR_DELTA_KIND_CHOICES)
-            )
-        if item in seen:
-            continue
-        seen.add(item)
-        normalized.append(item)
-    return normalized
 
 
 def registered_agents_for_goal(registry_goal: dict[str, Any] | None) -> list[str]:


### PR DESCRIPTION
## Summary

- Project `autonomous_replan_required` when the current agent lane is monitor-only and the advancement frontier is empty, even if the monitor has a future `next_due_at`.
- Centralize repair delta kind definitions and use only recognized frontier deltas to clear duplicate monitor-frontier replans.
- Scope projected autonomous replan ACKs to the matching agent lane so another agent's `goal_vision_patch`/`no_followup` cannot clear this lane's empty-frontier obligation.
- Update quota/work-lane smokes and public protocol docs for the new contract.

## Validation

- `python3 examples/control_plane/quota-replan-decision-plane-smoke.py`
- `python3 examples/control_plane/work-lane-contract-smoke.py`
- `python3 examples/control_plane/autonomous-replan-obligation-readmodel-smoke.py`
- `python3 examples/control_plane/quota-work-lane-policy-smoke.py`
- `python3 examples/control_plane/monitor-poll-policy-smoke.py`
- `python3 examples/control_plane/quota-contract-smoke.py`
- `python3 examples/control_plane/refresh-state-write-correctness-smoke.py`
- `python3 -m compileall loopx/quota.py loopx/control_plane/work_items/autonomous_replan_ack.py loopx/control_plane/goals/goal_frontier.py loopx/state_refresh.py loopx/control_plane/work_items/repair_delta.py examples/control_plane/quota-replan-decision-plane-smoke.py`
- `git diff --check`
- `PYTHONPATH=/private/tmp/loopx-product-capability-vision-replan-20260707Tlocal python3 -m loopx.cli check --scan-path ...` reported errors=0, warnings=0, public boundary scan clean for 11 files.
- Source-path real quota check for `loopx-meta` + `codex-product-capability` now reports `decision=autonomous_replan_required`, `replan_required=true`, trigger `frontier_exhausted_monitor_lane`, frontier counts 0/0/0.

## Notes

- This PR does not add a manual product-capability todo. It fixes the projection mechanism so the lane enters replan when the state actually has monitor-only work and no advancement frontier.
- No raw benchmark logs, trajectories, verifier output, credentials, local private state, or production actions are included.
