### PR TITLE
Add benchmark ledger countable score summary

### DIFF
--- a/examples/skillsbench-current-ledger-aggregate-smoke.py
+++ b/examples/skillsbench-current-ledger-aggregate-smoke.py
@@ -17,6 +17,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from loopx.benchmark_ledger import (  # noqa: E402
     BENCHMARK_RUN_LEDGER_SCHEMA_VERSION,
+    build_benchmark_run_ledger_entry,
     build_benchmark_run_ledger_current_aggregate,
     load_benchmark_run_ledger,
     upsert_benchmark_run_ledger_entry,
@@ -43,6 +44,7 @@ def run_entry(
     labels: list[str] | None = None,
     score_failure_attribution: str | None = None,
     failure_attribution_labels: list[str] | None = None,
+    official_score_attempt_countable: bool | None = None,
     task_setup_preflight: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     entry: dict[str, Any] = {
@@ -63,6 +65,8 @@ def run_entry(
         entry["score_failure_attribution"] = score_failure_attribution
     if failure_attribution_labels is not None:
         entry["failure_attribution_labels"] = failure_attribution_labels
+    if official_score_attempt_countable is not None:
+        entry["official_score_attempt_countable"] = official_score_attempt_countable
     if task_setup_preflight is not None:
         entry["task_setup_preflight"] = task_setup_preflight
     if score is not None:
@@ -126,6 +130,18 @@ def make_ledger(path: Path) -> None:
             score_status="completed",
             failure_class="task_solution_partial",
             failure_scope="solution",
+        ),
+        run_entry(
+            run_id="pre-bridge-rate-limit-score",
+            case_id="fix-erlang-ssh-cve",
+            recorded_at="2026-07-02T01:35:00+08:00",
+            score=0.0,
+            score_status="completed",
+            failure_class="skillsbench_codex_cli_goal_uncountable_pre_bridge_rate_limit",
+            failure_scope="runner_or_setup",
+            score_failure_attribution=(
+                "skillsbench_codex_cli_goal_uncountable_pre_bridge_rate_limit"
+            ),
         ),
         run_entry(
             run_id="setup-score-missing",
@@ -218,19 +234,37 @@ def test_current_aggregate_prefers_countable_results() -> None:
                 "canonical-task-source-preflight",
                 "pddl-tpp-planning",
                 "reward-artifact-missing",
+                "fix-erlang-ssh-cve",
                 "hello-world",
                 "never-run-case",
             ],
         )
-        assert aggregate["canonical_covered"] == 8, aggregate
+        assert aggregate["canonical_covered"] == 9, aggregate
         assert aggregate["distribution"] == {
             "missing": 1,
             "official_zero": 2,
             "partial": 1,
             "pass": 0,
             "setup_runner_infra": 4,
+            "uncountable_official_score": 1,
             "verifier_no_reward": 1,
         }, aggregate
+        assert aggregate["countable_score_summary"] == {
+            "schema_version": "benchmark_run_ledger_countable_score_summary_v0",
+            "countable_case_count": 3,
+            "countable_score_sum": 0.5,
+            "countable_score_mean": 0.166667,
+            "pass_count": 0,
+            "partial_count": 1,
+            "official_zero_count": 2,
+            "uncountable_numeric_case_count": 1,
+            "countable_case_ids": [
+                "lab-unit-harmonization",
+                "latex-formula-extraction",
+                "manufacturing-codebook-normalization",
+            ],
+            "uncountable_numeric_case_ids": ["fix-erlang-ssh-cve"],
+        }, aggregate["countable_score_summary"]
         assert (
             aggregate["case_best"]["latex-formula-extraction"]["run_id"]
             == "latex-official-zero"
@@ -248,8 +282,57 @@ def test_current_aggregate_prefers_countable_results() -> None:
         assert aggregate["case_best"]["reward-artifact-missing"]["bucket"] == (
             "verifier_no_reward"
         )
+        assert aggregate["case_best"]["fix-erlang-ssh-cve"]["bucket"] == (
+            "uncountable_official_score"
+        )
+        assert aggregate["case_best"]["fix-erlang-ssh-cve"][
+            "official_score_countable"
+        ] is False
+        assert aggregate["case_best"]["fix-erlang-ssh-cve"][
+            "official_score_countability_reason"
+        ] == "uncountable_attribution"
         assert "hello-world" not in aggregate["case_best"], aggregate["case_best"]
         assert "hello-world" not in aggregate["cases_by_bucket"]["setup_runner_infra"]
+
+
+def test_ledger_marks_uncountable_numeric_scores_noncountable() -> None:
+    pre_bridge_rate_limit = {
+        "schema_version": "benchmark_run_v0",
+        "benchmark_id": BENCHMARK_ID,
+        "case_id": "fix-erlang-ssh-cve",
+        "job_name": "skillsbench_1_1_fix_erlang_ssh_cve_codex_cli_goal_baseline",
+        "route": "codex-cli-goal-baseline",
+        "official_score_status": "completed",
+        "official_score": 0.0,
+        "score_failure_attribution": (
+            "skillsbench_codex_cli_goal_uncountable_pre_bridge_rate_limit"
+        ),
+    }
+    entry = build_benchmark_run_ledger_entry(pre_bridge_rate_limit)
+    assert entry["official_score"] == 0.0, entry
+    assert entry["score_failure_attribution"] == (
+        "skillsbench_codex_cli_goal_uncountable_pre_bridge_rate_limit"
+    ), entry
+    assert entry["official_score_countable"] is False, entry
+    assert entry["official_score_countability_reason"] == "uncountable_attribution", entry
+    assert "countable_score" not in entry, entry
+
+    explicit_noncountable = {
+        "schema_version": "benchmark_run_v0",
+        "benchmark_id": BENCHMARK_ID,
+        "case_id": "goal-active-timeout",
+        "job_name": "skillsbench_1_1_goal_active_timeout_codex_cli_goal_baseline",
+        "route": "codex-cli-goal-baseline",
+        "official_score_status": "completed",
+        "official_score": 0.0,
+        "official_score_attempt_countable": False,
+    }
+    entry = build_benchmark_run_ledger_entry(explicit_noncountable)
+    assert entry["official_score_attempt_countable"] is False, entry
+    assert entry["official_score_countable"] is False, entry
+    assert entry["official_score_countability_reason"] == (
+        "official_score_attempt_not_countable"
+    ), entry
 
 
 def test_current_aggregate_default_inference_excludes_sanity_sources() -> None:
@@ -261,10 +344,13 @@ def test_current_aggregate_default_inference_excludes_sanity_sources() -> None:
             ledger,
             benchmark_id=BENCHMARK_ID,
         )
-        assert aggregate["canonical_total"] == 8, aggregate
-        assert aggregate["canonical_covered"] == 8, aggregate
+        assert aggregate["canonical_total"] == 9, aggregate
+        assert aggregate["canonical_covered"] == 9, aggregate
         assert aggregate["distribution"]["setup_runner_infra"] == 4, aggregate
         assert aggregate["distribution"]["verifier_no_reward"] == 1, aggregate
+        assert aggregate["distribution"]["uncountable_official_score"] == 1, aggregate
+        assert aggregate["countable_score_summary"]["countable_case_count"] == 3, aggregate
+        assert aggregate["countable_score_summary"]["countable_score_mean"] == 0.166667, aggregate
         assert "hello-world" not in aggregate["case_best"], aggregate["case_best"]
         assert "hello-world" not in aggregate["cases_by_bucket"]["setup_runner_infra"]
 
@@ -319,6 +405,8 @@ def test_current_aggregate_cli_writes_public_safe_json() -> None:
         assert aggregate["canonical_total"] == 5, aggregate
         assert aggregate["case_best"]["latex-formula-extraction"]["bucket"] == "official_zero"
         assert aggregate["case_best"]["fix-druid-loophole-cve"]["bucket"] == "setup_runner_infra"
+        assert aggregate["countable_score_summary"]["countable_case_count"] == 3
+        assert aggregate["countable_score_summary"]["countable_score_mean"] == 0.166667
         assert "hello-world" not in aggregate["case_best"]
         assert aggregate["selection_policy"]["source_paths_recorded"] is False
         assert ".local" not in output_path.read_text(encoding="utf-8")
@@ -326,6 +414,7 @@ def test_current_aggregate_cli_writes_public_safe_json() -> None:
 
 if __name__ == "__main__":
     test_current_aggregate_prefers_countable_results()
+    test_ledger_marks_uncountable_numeric_scores_noncountable()
     test_current_aggregate_default_inference_excludes_sanity_sources()
     test_current_aggregate_cli_writes_public_safe_json()
     print("skillsbench-current-ledger-aggregate-smoke: ok")

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -385,6 +385,110 @@ def _compact_number(value: Any) -> float | None:
     return None
 
 
+def _numeric_score_value(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _score_countability_label_values(run: dict[str, Any]) -> list[str]:
+    labels: list[str] = []
+    for key in (
+        "score_failure_attribution",
+        "failure_class",
+        "attempt_failure_label",
+        "attempt_failure_class",
+        "first_blocker",
+        "runner_return_status",
+    ):
+        text = _compact_text(run.get(key), limit=180)
+        if text:
+            labels.append(text)
+    for key in ("failure_labels", "failure_attribution_labels", "setup_blockers"):
+        for label in _compact_list(run.get(key), limit=16):
+            labels.append(label)
+    accounting = (
+        run.get("attempt_accounting")
+        if isinstance(run.get("attempt_accounting"), dict)
+        else {}
+    )
+    for key in ("failure_label", "failure_class"):
+        text = _compact_text(accounting.get(key), limit=180)
+        if text:
+            labels.append(text)
+    return labels
+
+
+def benchmark_run_official_score_countability(run: dict[str, Any]) -> dict[str, Any]:
+    """Classify whether a compact/ledger run's official score is aggregate-countable."""
+
+    score = _numeric_score_value(run.get("official_score"))
+    if score is None:
+        official = (
+            run.get("official_task_score")
+            if isinstance(run.get("official_task_score"), dict)
+            else {}
+        )
+        score = _numeric_score_value(official.get("value"))
+    if score is None:
+        return {
+            "countable": False,
+            "reason": "score_missing",
+            "score": None,
+        }
+
+    explicit_attempt_countable = run.get("official_score_attempt_countable")
+    accounting = (
+        run.get("attempt_accounting")
+        if isinstance(run.get("attempt_accounting"), dict)
+        else {}
+    )
+    if explicit_attempt_countable is None:
+        explicit_attempt_countable = accounting.get("official_score_attempt_countable")
+    if explicit_attempt_countable is False:
+        return {
+            "countable": False,
+            "reason": "official_score_attempt_not_countable",
+            "score": score,
+        }
+
+    score_status = _compact_text(
+        run.get("official_score_status") or run.get("score_status"),
+        limit=80,
+    )
+    if score_status and score_status not in {
+        "completed",
+        "passed",
+        "failed",
+    }:
+        return {
+            "countable": False,
+            "reason": "official_score_status_not_countable",
+            "score": score,
+        }
+
+    labels = _score_countability_label_values(run)
+    if any("uncountable" in label.lower() for label in labels):
+        return {
+            "countable": False,
+            "reason": "uncountable_attribution",
+            "score": score,
+        }
+
+    return {
+        "countable": True,
+        "reason": "countable_official_score",
+        "score": score,
+    }
+
+
 def _round_reward_best_stats(records: list[dict[str, Any]]) -> dict[str, Any]:
     numeric_records: list[dict[str, Any]] = []
     for record in records:
@@ -1907,6 +2011,10 @@ def build_benchmark_run_ledger_entry(
         else None,
         "failure_class": failure_class,
         "failure_scope": failure_scope,
+        "score_failure_attribution": _compact_text(
+            benchmark_run.get("score_failure_attribution"),
+            limit=120,
+        ),
         "failure_labels": _compact_list(
             benchmark_run.get("failure_attribution_labels"),
             limit=8,
@@ -2051,6 +2159,15 @@ def build_benchmark_run_ledger_entry(
         ):
             if isinstance(attempt_accounting.get(field), bool):
                 entry[field] = attempt_accounting[field]
+    for field in (
+        "launcher_attempt_countable",
+        "case_attempt_countable",
+        "solver_attempt_countable",
+        "verifier_attempt_countable",
+        "official_score_attempt_countable",
+    ):
+        if field not in entry and isinstance(benchmark_run.get(field), bool):
+            entry[field] = benchmark_run[field]
     if source_schema == "terminal_bench_post_launch_materialization_v0":
         marker = (
             benchmark_run.get("compact_failure_marker")
@@ -2138,6 +2255,11 @@ def build_benchmark_run_ledger_entry(
     note = _compact_text(notes, limit=220)
     if note:
         entry["notes"] = note
+    countability = benchmark_run_official_score_countability(entry)
+    entry["official_score_countable"] = countability["countable"]
+    entry["official_score_countability_reason"] = countability["reason"]
+    if countability["countable"] is True and countability.get("score") is not None:
+        entry["countable_score"] = countability["score"]
     return {key: value for key, value in entry.items() if value not in (None, "", [])}
 
 
@@ -2230,6 +2352,13 @@ def _normalize_ledger_run(run: dict[str, Any], *, fallback_benchmark_id: str) ->
     for key in ("repair_priority", "repair_class", "next_action", "repair_profile"):
         normalized.pop(key, None)
     normalized.update(repair_route)
+    countability = benchmark_run_official_score_countability(normalized)
+    normalized["official_score_countable"] = countability["countable"]
+    normalized["official_score_countability_reason"] = countability["reason"]
+    if countability["countable"] is True and countability.get("score") is not None:
+        normalized["countable_score"] = countability["score"]
+    else:
+        normalized.pop("countable_score", None)
     archive_state = _compact_text(normalized.get("archive_state"), limit=40)
     if archive_state == "archived":
         normalized["archive_state"] = "archived"

--- a/loopx/benchmark_ledger_current.py
+++ b/loopx/benchmark_ledger_current.py
@@ -44,6 +44,14 @@ def _ledger_score_value(run: dict[str, Any]) -> float | None:
     return None
 
 
+def _official_score_countability(run: dict[str, Any]) -> dict[str, Any]:
+    return _ledger_module().benchmark_run_official_score_countability(run)
+
+
+def _official_score_countable(run: dict[str, Any]) -> bool:
+    return _official_score_countability(run).get("countable") is True
+
+
 def _current_aggregate_failure_label_list(run: dict[str, Any]) -> list[str]:
     labels: list[str] = []
     seen: set[str] = set()
@@ -81,6 +89,8 @@ def _current_aggregate_bucket(run: dict[str, Any] | None) -> str:
         return "missing"
     score = _ledger_score_value(run)
     if score is not None:
+        if not _official_score_countable(run):
+            return "uncountable_official_score"
         if score >= 1.0:
             return "pass"
         if score > 0.0:
@@ -124,9 +134,10 @@ _CURRENT_AGGREGATE_BUCKET_RANK = {
     "missing": 0,
     "setup_runner_infra": 1,
     "verifier_no_reward": 2,
-    "official_zero": 3,
-    "partial": 4,
-    "pass": 5,
+    "uncountable_official_score": 3,
+    "official_zero": 4,
+    "partial": 5,
+    "pass": 6,
 }
 
 
@@ -159,6 +170,9 @@ def _current_aggregate_run_summary(run: dict[str, Any] | None) -> dict[str, Any]
         "score_status",
         "official_score",
         "official_passed",
+        "official_score_countable",
+        "official_score_countability_reason",
+        "countable_score",
         "round_reward_count",
         "round_success_observed",
         "max_rounds_budget",
@@ -194,6 +208,11 @@ def _current_aggregate_run_summary(run: dict[str, Any] | None) -> dict[str, Any]
     )
     summary = {key: run[key] for key in keys if key in run}
     summary["bucket"] = _current_aggregate_bucket(run)
+    countability = _official_score_countability(run)
+    summary["official_score_countable"] = countability["countable"]
+    summary["official_score_countability_reason"] = countability["reason"]
+    if countability["countable"] is True and countability.get("score") is not None:
+        summary["countable_score"] = countability["score"]
     effective_failure_class = _current_aggregate_effective_failure_class(run)
     if effective_failure_class:
         summary["effective_failure_class"] = effective_failure_class
@@ -282,6 +301,7 @@ def build_benchmark_run_ledger_current_aggregate(
         "missing": 0,
         "setup_runner_infra": 0,
         "verifier_no_reward": 0,
+        "uncountable_official_score": 0,
         "official_zero": 0,
         "partial": 0,
         "pass": 0,
@@ -289,6 +309,9 @@ def build_benchmark_run_ledger_current_aggregate(
     cases_by_bucket = {bucket: [] for bucket in distribution}
     case_best: dict[str, dict[str, Any]] = {}
     deduped_run_ids: set[str] = set()
+    countable_case_ids: list[str] = []
+    countable_scores: list[float] = []
+    uncountable_numeric_case_ids: list[str] = []
     for case in cases.values():
         if not isinstance(case, dict):
             continue
@@ -311,6 +334,16 @@ def build_benchmark_run_ledger_current_aggregate(
         distribution[bucket] = distribution.get(bucket, 0) + 1
         cases_by_bucket.setdefault(bucket, []).append(case_id)
         case_best[case_id] = summary
+        score = _ledger_score_value(summary)
+        if summary.get("official_score_countable") is True and score is not None:
+            countable_case_ids.append(case_id)
+            countable_scores.append(score)
+        elif score is not None:
+            uncountable_numeric_case_ids.append(case_id)
+    countable_score_sum = sum(countable_scores)
+    countable_score_mean = (
+        countable_score_sum / len(countable_scores) if countable_scores else None
+    )
     return {
         "schema_version": BENCHMARK_RUN_LEDGER_CURRENT_AGGREGATE_SCHEMA_VERSION,
         "benchmark_id": benchmark_id,
@@ -318,6 +351,22 @@ def build_benchmark_run_ledger_current_aggregate(
         "canonical_covered": sum(
             count for bucket, count in distribution.items() if bucket != "missing"
         ),
+        "countable_score_summary": {
+            "schema_version": "benchmark_run_ledger_countable_score_summary_v0",
+            "countable_case_count": len(countable_scores),
+            "countable_score_sum": round(countable_score_sum, 6),
+            "countable_score_mean": round(countable_score_mean, 6)
+            if countable_score_mean is not None
+            else None,
+            "pass_count": sum(1 for score in countable_scores if score >= 1.0),
+            "partial_count": sum(
+                1 for score in countable_scores if 0.0 < score < 1.0
+            ),
+            "official_zero_count": sum(1 for score in countable_scores if score == 0.0),
+            "uncountable_numeric_case_count": len(uncountable_numeric_case_ids),
+            "countable_case_ids": sorted(countable_case_ids),
+            "uncountable_numeric_case_ids": sorted(uncountable_numeric_case_ids),
+        },
         "distribution": distribution,
         "cases_by_bucket": {
             bucket: sorted(case_ids) for bucket, case_ids in cases_by_bucket.items()
@@ -332,6 +381,7 @@ def build_benchmark_run_ledger_current_aggregate(
                 "pass",
                 "partial",
                 "official_zero",
+                "uncountable_official_score",
                 "verifier_no_reward",
                 "setup_runner_infra",
                 "missing",


### PR DESCRIPTION
## Summary
- add ledger-level official score countability classification so numeric but uncountable attempts do not pollute scored aggregates
- add current aggregate countable_score_summary with unique case count, mean, pass/partial/zero counts, and uncountable numeric case ids
- extend SkillsBench aggregate smoke to cover uncountable pre-bridge numeric scores and top-level official_score_attempt_countable=false

## Validation
- python3 examples/skillsbench-current-ledger-aggregate-smoke.py
- python3 examples/benchmark-run-ledger-smoke.py
- python3 examples/control_plane/repo-python-line-budget-smoke.py
- python3 -m py_compile loopx/benchmark_ledger.py loopx/benchmark_ledger_current.py examples/skillsbench-current-ledger-aggregate-smoke.py
- git diff --check
- loopx check --scan-path loopx/benchmark_ledger.py --scan-path loopx/benchmark_ledger_current.py --scan-path examples/skillsbench-current-ledger-aggregate-smoke.py
- loopx canary premerge --from-git-diff: all checks passed, but status=manual_review_required due benchmark_sensitive hold; self_merge_allowed=false

## Boundary
No runner launch, no leaderboard/upload/submission behavior, no raw task text, raw trajectory, verifier output, credentials, or private artifact paths are added.
