### PR TITLE
Fix expired monitor scheduler backoff cap

### DIFF
--- a/examples/control_plane/monitor-scheduler-contract-smoke.py
+++ b/examples/control_plane/monitor-scheduler-contract-smoke.py
@@ -305,6 +305,11 @@ def assert_expired_monitor_does_not_catch_up() -> None:
     monitor_items = guard["agent_todo_summary"]["monitor_open_items"]
     assert monitor_items[0]["todo_id"] == "todo_monitor_expired", monitor_items
     assert monitor_items[0]["expires_at"] == EXPIRED_AT, monitor_items
+    scheduler = guard["scheduler_hint"]
+    codex_app = scheduler["codex_app"]
+    assert scheduler["cadence_class"] == "monitor_wait", scheduler
+    assert codex_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=15", scheduler
+    assert codex_app["example_progression_minutes"] == [15, 30, 60, 120], scheduler
 
 
 def assert_due_monitor_priority_does_not_steal_advancement_lane() -> None:

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -233,12 +233,15 @@ def _monitor_wait_cadence_progression(payload: dict[str, Any]) -> list[int] | No
     current_time = now_utc()
     caps: list[int] = []
     for item in _monitor_wait_items(payload):
+        expires_at = _parse_monitor_timestamp(item.get("expires_at"))
+        if expires_at is not None and expires_at <= current_time:
+            continue
         item_caps: list[int] = []
         cadence_minutes = _monitor_cadence_minutes(item.get("cadence"))
         if cadence_minutes is not None:
             item_caps.append(cadence_minutes)
         next_due_at = _parse_monitor_timestamp(item.get("next_due_at"))
-        if next_due_at is not None:
+        if next_due_at is not None and next_due_at > current_time:
             seconds_until_due = (next_due_at - current_time).total_seconds()
             item_caps.append(max(1, int(math.ceil(seconds_until_due / 60))))
         if item_caps:


### PR DESCRIPTION
Summary
- Ignore expired monitor todos when deriving monitor-wait scheduler caps.
- Ignore past next_due_at values on the quiet monitor-wait path so stale/expired watches do not force 1 minute polling.
- Extend monitor scheduler smoke coverage for expired monitor quiet-skip cadence.

Validation
- python3 examples/control_plane/monitor-scheduler-contract-smoke.py
- python3 examples/control_plane/quota-scheduler-state-ack-smoke.py
- python3 examples/control_plane/monitor-poll-policy-smoke.py
- python3 examples/control_plane/automation-liveness-state-machine-smoke.py
- PYTHONPATH=. python3 -m loopx.cli check --scan-path loopx/control_plane/scheduler/scheduler_hint.py --scan-path examples/control_plane/monitor-scheduler-contract-smoke.py
- PYTHONPATH=. python3 -m loopx.cli --format json --registry $HOME/.codex/loopx/registry.global.json quota should-run --goal-id loopx-meta --agent-id codex-value-explorer --include-scheduler-detail

Notes
- The patched live guard projection changes the current value-explorer monitor wait recommendation from 1 minute to 15 minutes, with progression capped by the next unexpired monitor due horizon.
- A broad quick premerge canary was stopped after selecting 193 risk-profile smokes; this PR relies on the focused scheduler/quota checks above.