### PR TITLE
Fix open vision frontier replan gating

### DIFF
--- a/examples/control_plane/heartbeat-quota-flow-smoke.py
+++ b/examples/control_plane/heartbeat-quota-flow-smoke.py
@@ -766,35 +766,43 @@ def main() -> int:
             registry_path=registry_path,
             runtime=runtime,
         )
-        assert first_guard["decision"] == "skip", first_guard
-        assert first_guard["effective_action"] == "monitor_quiet_skip", first_guard
-        assert first_guard["should_run"] is False, first_guard
+        assert first_guard["decision"] == "autonomous_replan_required", first_guard
+        assert first_guard["effective_action"] == "autonomous_replan_required", first_guard
+        assert first_guard["should_run"] is True, first_guard
         assert first_guard["heartbeat_recommendation"]["recommended_mode"] == (
-            "monitor_quiet_until_material_transition"
+            "autonomous_replan_required"
         ), first_guard
-        assert first_guard.get("autonomous_replan_obligation") is None, first_guard
-        assert first_guard["execution_obligation"]["kind"] == "monitor_quiet_skip", first_guard
-        assert first_guard["execution_obligation"]["must_attempt_work"] is False, first_guard
-        assert first_guard["automation_liveness"]["automation_action"] == "keep_active_quiet", first_guard
+        assert first_guard["autonomous_replan_obligation"]["triggers"][0]["kind"] == (
+            "frontier_exhausted_monitor_lane"
+        ), first_guard
+        assert first_guard["execution_obligation"]["kind"] == (
+            "autonomous_replan_required"
+        ), first_guard
+        assert first_guard["execution_obligation"]["must_attempt_work"] is True, first_guard
+        assert first_guard["automation_liveness"]["automation_action"] == (
+            "execute_bounded_work"
+        ), first_guard
         assert first_guard["automation_liveness"]["pause_allowed"] is False, first_guard
-        assert first_guard["scheduler_hint"]["action"] == "backoff_until_material_transition", first_guard
-        assert first_guard["scheduler_hint"]["cadence_class"] == "monitor_wait", first_guard
-        assert first_guard["scheduler_hint"]["codex_app"]["recommended_interval_minutes"] == 15, first_guard
-        assert first_guard["scheduler_hint"]["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=15", first_guard
+        assert first_guard["scheduler_hint"]["action"] == "run_now", first_guard
+        assert first_guard["scheduler_hint"]["cadence_class"] == "active_work", first_guard
+        assert first_guard["scheduler_hint"]["codex_app"]["recommended_interval_minutes"] == 3, first_guard
+        assert first_guard["scheduler_hint"]["codex_app"]["recommended_rrule"] == (
+            "FREQ=MINUTELY;INTERVAL=3"
+        ), first_guard
         reset = first_guard["scheduler_hint"]["reset_policy"]
-        assert reset["codex_app_initial_rrule"] == "FREQ=MINUTELY;INTERVAL=15", reset
+        assert reset["codex_app_initial_rrule"] == "FREQ=MINUTELY;INTERVAL=3", reset
         assert "reset_condition_summary" not in reset, reset
         frontier = first_guard["goal_frontier_projection"]
         assert frontier["monitor_only_lanes"]["present"] is True, frontier
         assert frontier["monitor_only_lanes"]["quiet_until_material_transition"] is True, frontier
-        assert frontier["replan_required"] is False, frontier
-        assert "automation=keep_active_quiet" in first_guard["protocol_action_packet"]["summary"], first_guard
+        assert frontier["replan_required"] is True, frontier
+        assert "automation=execute_bounded_work" in first_guard["protocol_action_packet"]["summary"], first_guard
         assert count_events(runtime, "quota_monitor_poll") == 0, first_guard
         interaction = first_guard["interaction_contract"]
-        assert interaction["mode"] == "monitor_quiet_skip", interaction
-        assert interaction["agent_channel"]["must_attempt"] is False, interaction
-        assert interaction["agent_channel"]["quiet_noop_allowed"] is True, interaction
-        assert interaction["cli_channel"]["spend_after_validation"] is False, interaction
+        assert interaction["mode"] == "autonomous_replan", interaction
+        assert interaction["agent_channel"]["must_attempt"] is True, interaction
+        assert interaction["agent_channel"]["quiet_noop_allowed"] is False, interaction
+        assert interaction["cli_channel"]["spend_after_validation"] is True, interaction
 
         refresh = run_cli(
             root,

--- a/examples/control_plane/quota-replan-decision-plane-smoke.py
+++ b/examples/control_plane/quota-replan-decision-plane-smoke.py
@@ -246,6 +246,49 @@ def agent_vision_gap_run() -> dict:
     }
 
 
+def agent_vision_acceptance_only_run() -> dict:
+    return {
+        "classification": "state_refreshed",
+        "generated_at": "2026-07-04T00:00:00+00:00",
+        "agent_id": SIDE_AGENT,
+        "progress_scope": "agent_lane",
+        "agent_vision": {
+            "schema_version": "goal_vision_replan_contract_v0",
+            "agent_id": SIDE_AGENT,
+            "state": "vision_patch_proposed",
+            "vision_patch": {
+                "acceptance_summary": "A visible successor frontier must exist before the lane is monitor-only.",
+            },
+            "todo_delta": [],
+            "vision_budget": {
+                "schema_version": "goal_vision_budget_v0",
+                "status": "ok",
+            },
+        },
+    }
+
+
+def watch_lane_continuation_ack_run(
+    *,
+    delta_kinds: list[str] | None = None,
+) -> dict:
+    return {
+        "classification": "monitor_poll_autonomous_replan_recorded_v0",
+        "agent_id": SIDE_AGENT,
+        "progress_scope": "agent_lane",
+        "autonomous_replan_ack": {
+            "schema_version": "autonomous_replan_ack_v0",
+            "recorded": True,
+            "source": "refresh_state",
+            "delta_contract": {
+                "schema_version": "repair_delta_contract_v0",
+                "delta_present": True,
+                "delta_kinds": delta_kinds or ["watch_lane_continuation"],
+            },
+        },
+    }
+
+
 def missing_vision_checkpoint_run(*, agent_id: str = SIDE_AGENT) -> dict:
     return {
         "classification": "state_refreshed",
@@ -628,6 +671,60 @@ def assert_agent_vision_gap_derives_replan() -> None:
     assert "vision_gap_judge: done=False decision=continue" in markdown, markdown
 
 
+def assert_open_agent_vision_beats_watch_lane_continuation_ack() -> None:
+    guard = build_quota_should_run(
+        status_payload(
+            [monitor_item()],
+            replan_obligation=None,
+            latest_runs=[
+                watch_lane_continuation_ack_run(),
+                agent_vision_acceptance_only_run(),
+            ],
+        ),
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+    )
+    assert guard["decision"] == "autonomous_replan_required", guard
+    assert guard["effective_action"] == "autonomous_replan_required", guard
+    gaps = guard["goal_frontier_projection"]["acceptance_gaps"]
+    assert len(gaps) == 1, guard
+    assert gaps[0]["kind"] == "vision_acceptance_gap", guard
+    assert gaps[0]["acceptance_summary"].startswith("A visible successor"), guard
+    assert "open without a runnable advancement frontier" in (
+        gaps[0]["replan_trigger_summary"]
+    ), guard
+    obligation = guard["autonomous_replan_obligation"]
+    assert obligation["triggers"][0]["kind"] == "vision_acceptance_gap", guard
+    assert guard["vision_continuation_audit"]["required"] is True, guard
+    assert guard["interaction_contract"]["agent_channel"]["quiet_noop_allowed"] is False, (
+        guard
+    )
+
+
+def assert_retired_agent_vision_allows_bounded_monitor_wait() -> None:
+    retired_run = satisfied_vision_checkpoint_run(decision="retired_or_superseded")
+    retired_run["autonomous_replan_ack"] = watch_lane_continuation_ack_run(
+        delta_kinds=["watch_lane_continuation", "no_followup"]
+    )["autonomous_replan_ack"]
+    guard = build_quota_should_run(
+        status_payload(
+            [monitor_item()],
+            replan_obligation=None,
+            latest_runs=[
+                retired_run,
+                agent_vision_acceptance_only_run(),
+            ],
+        ),
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+    )
+    assert guard["decision"] == "skip", guard
+    assert guard["effective_action"] == "monitor_quiet_skip", guard
+    assert guard["goal_frontier_projection"]["acceptance_gaps"] == [], guard
+    assert guard["goal_frontier_projection"]["replan_required"] is False, guard
+    assert guard.get("autonomous_replan_obligation") is None, guard
+
+
 def assert_missing_vision_checkpoint_derives_agent_scoped_replan() -> None:
     side_guard = build_quota_should_run(
         status_payload(
@@ -980,6 +1077,8 @@ def main() -> None:
     assert_replan_preserves_current_agent_runnable_frontier()
     assert_long_agent_todo_chain_derives_replan_before_linear_delivery()
     assert_agent_vision_gap_derives_replan()
+    assert_open_agent_vision_beats_watch_lane_continuation_ack()
+    assert_retired_agent_vision_allows_bounded_monitor_wait()
     assert_missing_vision_checkpoint_derives_agent_scoped_replan()
     assert_satisfied_vision_checkpoint_supersedes_older_missing_but_not_empty_frontier()
     assert_agent_scoped_replan_beats_agent_scope_wait()

--- a/loopx/control_plane/goals/goal_frontier.py
+++ b/loopx/control_plane/goals/goal_frontier.py
@@ -27,6 +27,15 @@ TODO_TASK_CLASS_ADVANCEMENT = "advancement_task"
 TODO_TASK_CLASS_MONITOR = "continuous_monitor"
 LONG_TODO_CHAIN_ADVANCEMENT_THRESHOLD = 15
 LONG_TODO_CHAIN_OPEN_THRESHOLD = 20
+AGENT_VISION_CLOSED_STATES = {
+    "closed",
+    "satisfied",
+    "retired",
+    "retired_or_superseded",
+    "superseded",
+    "no_followup",
+    "no-followup",
+}
 VISION_CHECKPOINT_SATISFIED_DECISIONS = {
     "patched",
     "retired_or_superseded",
@@ -202,6 +211,39 @@ def _latest_runs_for_goal(
     return [item for item in latest_runs if isinstance(item, dict)] if isinstance(latest_runs, list) else []
 
 
+def _run_agent_id_matches(run: dict[str, Any], *, agent_id: str | None) -> bool:
+    if not agent_id:
+        return True
+    run_agent_id = str(run.get("agent_id") or "").strip()
+    return not run_agent_id or run_agent_id == agent_id
+
+
+def _run_retires_prior_agent_vision(
+    run: dict[str, Any],
+    *,
+    agent_id: str | None,
+) -> bool:
+    if not _run_agent_id_matches(run, agent_id=agent_id):
+        return False
+    checkpoint = (
+        run.get("vision_checkpoint")
+        if isinstance(run.get("vision_checkpoint"), dict)
+        else {}
+    )
+    if isinstance(checkpoint, dict) and checkpoint:
+        checkpoint_agent_id = str(
+            checkpoint.get("agent_id") or run.get("agent_id") or ""
+        ).strip()
+        if agent_id and checkpoint_agent_id and checkpoint_agent_id != agent_id:
+            return False
+        if (
+            checkpoint.get("satisfied") is True
+            and str(checkpoint.get("decision") or "").strip() == "retired_or_superseded"
+        ):
+            return True
+    return False
+
+
 def latest_agent_vision_from_status_payload(
     status_payload: dict[str, Any],
     *,
@@ -213,6 +255,8 @@ def latest_agent_vision_from_status_payload(
     for run in _latest_runs_for_goal(status_payload, goal_id=goal_id):
         vision = run.get("agent_vision")
         if not isinstance(vision, dict):
+            if _run_retires_prior_agent_vision(run, agent_id=agent_id):
+                return None
             continue
         vision_agent_id = str(vision.get("agent_id") or run.get("agent_id") or "").strip()
         if agent_id and vision_agent_id and vision_agent_id != agent_id:
@@ -292,7 +336,13 @@ def acceptance_gaps_from_agent_vision(
     if not isinstance(agent_vision, dict):
         return []
     patch = agent_vision.get("vision_patch") if isinstance(agent_vision.get("vision_patch"), dict) else {}
+    state = str(agent_vision.get("state") or "").strip().lower()
+    if state in AGENT_VISION_CLOSED_STATES:
+        return []
+    acceptance = _compact_projection_text(patch.get("acceptance_summary"), limit=420)
     trigger = _compact_projection_text(patch.get("replan_trigger_summary"), limit=240)
+    if not trigger and acceptance:
+        trigger = "active agent vision remains open without a runnable advancement frontier"
     if not trigger:
         return []
     gap: dict[str, Any] = {
@@ -302,7 +352,6 @@ def acceptance_gaps_from_agent_vision(
         "state": agent_vision.get("state"),
         "replan_trigger_summary": trigger,
     }
-    acceptance = _compact_projection_text(patch.get("acceptance_summary"), limit=420)
     if acceptance:
         gap["acceptance_summary"] = acceptance
     generated_at = _compact_projection_text(agent_vision.get("generated_at"), limit=80)


### PR DESCRIPTION
## Summary

- Treat an active agent vision with an acceptance summary as an open frontier gap even when it has no explicit replan trigger text.
- Keep watch-lane continuation ACKs from masking older open vision; only a structured retired/superseded vision checkpoint suppresses the older vision packet.
- Update heartbeat/quota smoke expectations so an empty monitor-only frontier replans first, then quiets only after a bounded continuation delta is written.

## Product / Architecture Judgment

- Motivation: LoopX should not equate monitor-only state with completion while a goal or agent vision remains unclosed.
- Solved: the goal-frontier read model now projects open vision into `acceptance_gaps`, so quota selects `autonomous_replan_required` before monitor quiet/wait classification.
- Operator impact: agents get a concrete replan obligation instead of silently waiting on monitor work when the intended frontier has not been closed.
- Main risk: quota/frontier hot path behavior. The rule is scoped to latest agent vision, no runnable advancement frontier, and explicit retired/superseded checkpoints, preserving pure monitor wait after valid continuation/no-follow-up writeback.
- Design judgment: this stays in `loopx.control_plane.goals.goal_frontier`, the existing bounded context, rather than adding lane-specific or product-capability-specific logic.

## Validation

- `python3 -m py_compile loopx/control_plane/goals/goal_frontier.py examples/control_plane/quota-replan-decision-plane-smoke.py examples/control_plane/heartbeat-quota-flow-smoke.py`
- `python3 examples/control_plane/quota-replan-decision-plane-smoke.py`
- `python3 examples/control_plane/control-plane-risk-characterization-smoke.py`
- `python3 examples/control_plane/heartbeat-quota-flow-smoke.py`
- `python3 examples/control_plane/monitor-scheduler-contract-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `loopx canary premerge --from-git-diff` passed: 17 selected checks, 0 failures, 0 manual holds; surfaces `control_plane, public_boundary, python`; risk profiles `core-control-plane, canary-runner`.

## Merge Decision

Self-merge candidate: small, single-purpose control-plane read-model fix with focused smokes and standard premerge canary passed. No Lark Kanban paths, benchmark runner/adapters, private state, raw benchmark evidence, credentials, public first-screen, or permission/destructive-git surfaces are touched.
