### PR TITLE
Refactor quota frontier replan projection

### DIFF
--- a/examples/control_plane/quota-replan-decision-plane-smoke.py
+++ b/examples/control_plane/quota-replan-decision-plane-smoke.py
@@ -10,7 +10,17 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT))
 
-from loopx.quota import build_quota_should_run, render_quota_should_run_markdown  # noqa: E402
+from loopx.quota import (  # noqa: E402
+    AUTONOMOUS_REPLAN_ACK_NEUTRAL_CLASSIFICATIONS,
+    build_quota_should_run,
+    render_quota_should_run_markdown,
+)
+from loopx.control_plane.goals.goal_frontier import (  # noqa: E402
+    build_goal_frontier_projection_context_from_status,
+)
+from loopx.control_plane.todos.quota_summary import (  # noqa: E402
+    select_quota_todo_summary,
+)
 from loopx.status import compact_todo_group  # noqa: E402
 
 
@@ -671,6 +681,40 @@ def assert_agent_vision_gap_derives_replan() -> None:
     assert "vision_gap_judge: done=False decision=continue" in markdown, markdown
 
 
+def assert_goal_frontier_context_helper_matches_quota_payload() -> None:
+    payload = status_payload(
+        [monitor_item()],
+        replan_obligation=None,
+        latest_runs=[agent_vision_gap_run()],
+    )
+    guard = build_quota_should_run(payload, goal_id=GOAL_ID, agent_id=SIDE_AGENT)
+    item = payload["attention_queue"]["items"][0]
+    context = build_goal_frontier_projection_context_from_status(
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+        primary_agent_id=PRIMARY_AGENT,
+        status_payload=payload,
+        item=item,
+        project_asset=item["project_asset"],
+        user_todo_summary=select_quota_todo_summary(
+            item.get("user_todos"),
+            item.get("project_asset", {}).get("user_todos"),
+            agent_identity=guard["agent_identity"],
+            filter_user_gate_blocks_agent=True,
+        ),
+        agent_todo_summary=guard["agent_todo_summary"],
+        work_lane_contract=guard["work_lane_contract"],
+        neutral_replan_ack_classifications=AUTONOMOUS_REPLAN_ACK_NEUTRAL_CLASSIFICATIONS,
+    )
+    context_obligation = dict(context["replan_obligation"])
+    guard_obligation = dict(guard["autonomous_replan_obligation"])
+    guard_obligation.pop("required_reads", None)
+    assert context_obligation == guard_obligation, guard
+    assert context["replan_scope"] == guard["autonomous_replan_scope"], guard
+    assert context["goal_frontier_projection"] == guard["goal_frontier_projection"], guard
+    assert context["acceptance_gaps"] == guard["goal_frontier_projection"]["acceptance_gaps"], guard
+
+
 def assert_open_agent_vision_beats_watch_lane_continuation_ack() -> None:
     guard = build_quota_should_run(
         status_payload(
@@ -1077,6 +1121,7 @@ def main() -> None:
     assert_replan_preserves_current_agent_runnable_frontier()
     assert_long_agent_todo_chain_derives_replan_before_linear_delivery()
     assert_agent_vision_gap_derives_replan()
+    assert_goal_frontier_context_helper_matches_quota_payload()
     assert_open_agent_vision_beats_watch_lane_continuation_ack()
     assert_retired_agent_vision_allows_bounded_monitor_wait()
     assert_missing_vision_checkpoint_derives_agent_scoped_replan()

--- a/loopx/control_plane/goals/goal_frontier.py
+++ b/loopx/control_plane/goals/goal_frontier.py
@@ -8,6 +8,10 @@ from ..agents.agent_scope import (
     agent_scope_item_claimed_by,
     agent_scope_item_claimed_by_agent_or_unclaimed,
 )
+from ..work_items.autonomous_replan_ack import (
+    autonomous_replan_ack_matches_agent,
+    latest_autonomous_replan_ack_for_projection,
+)
 from ..work_items.repair_delta import repair_delta_kinds_have_frontier_delta
 
 
@@ -325,6 +329,46 @@ def latest_missing_vision_checkpoint_from_status_payload(
             else [],
             "generated_at": run.get("generated_at"),
         }
+    return None
+
+
+def latest_autonomous_replan_ack_from_status_payload(
+    status_payload: dict[str, Any],
+    *,
+    goal_id: str,
+    agent_id: str | None,
+    neutral_classifications: set[str],
+) -> dict[str, Any] | None:
+    """Return the newest agent-scoped durable replan ACK visible in run history."""
+
+    if not agent_id:
+        return None
+    latest_runs = [
+        run
+        for run in _latest_runs_for_goal(status_payload, goal_id=goal_id)
+        if _run_agent_id_matches(run, agent_id=agent_id)
+    ]
+    return latest_autonomous_replan_ack_for_projection(
+        latest_runs,
+        neutral_classifications=neutral_classifications,
+    )
+
+
+def projected_autonomous_replan_ack_for_agent(
+    item: dict[str, Any],
+    project_asset: dict[str, Any] | None,
+    *,
+    agent_id: str | None,
+) -> dict[str, Any] | None:
+    """Return the current projected replan ACK when it belongs to this agent."""
+
+    project_asset = project_asset if isinstance(project_asset, dict) else {}
+    for candidate in (
+        item.get("autonomous_replan_ack"),
+        project_asset.get("autonomous_replan_ack"),
+    ):
+        if autonomous_replan_ack_matches_agent(candidate, agent_id=agent_id):
+            return candidate
     return None
 
 
@@ -1151,6 +1195,97 @@ def build_goal_frontier_projection_from_summaries(
             agent_id=agent_id,
         ),
     )
+
+
+def build_goal_frontier_projection_context_from_status(
+    *,
+    goal_id: str,
+    agent_id: str | None,
+    primary_agent_id: str | None,
+    status_payload: dict[str, Any],
+    item: dict[str, Any],
+    project_asset: dict[str, Any] | None,
+    user_todo_summary: dict[str, Any] | None,
+    agent_todo_summary: dict[str, Any] | None,
+    work_lane_contract: dict[str, Any] | None,
+    neutral_replan_ack_classifications: set[str],
+) -> dict[str, Any]:
+    """Build the quota-facing goal-frontier read model.
+
+    Quota decides delivery permission, but this helper owns the goal-frontier
+    state reduction: existing obligation scope, latest replan ACK, open
+    per-agent vision gaps, derived replan obligation, and final projection.
+    """
+
+    replan_obligation = select_autonomous_replan_obligation(item, project_asset)
+    replan_scope = autonomous_replan_scope_decision(
+        replan_obligation,
+        agent_id=agent_id,
+        primary_agent_id=primary_agent_id,
+    )
+    if replan_scope.get("required") and not replan_scope.get("applies"):
+        replan_obligation = None
+
+    latest_agent_replan_ack = latest_autonomous_replan_ack_from_status_payload(
+        status_payload,
+        goal_id=goal_id,
+        agent_id=agent_id,
+        neutral_classifications=neutral_replan_ack_classifications,
+    )
+    latest_agent_vision = latest_agent_vision_from_status_payload(
+        status_payload,
+        goal_id=goal_id,
+        agent_id=agent_id,
+    )
+    latest_missing_vision_checkpoint = latest_missing_vision_checkpoint_from_status_payload(
+        status_payload,
+        goal_id=goal_id,
+        agent_id=agent_id,
+    )
+    acceptance_gaps = (
+        acceptance_gaps_from_agent_vision(latest_agent_vision)
+        + acceptance_gaps_from_vision_checkpoint(latest_missing_vision_checkpoint)
+    )
+    projected_replan_ack = projected_autonomous_replan_ack_for_agent(
+        item,
+        project_asset,
+        agent_id=agent_id,
+    )
+    frontier_replan_obligation = derive_goal_frontier_replan_obligation_from_summaries(
+        user_todo_summary=user_todo_summary,
+        agent_todo_summary=agent_todo_summary,
+        work_lane_contract=work_lane_contract,
+        agent_id=agent_id,
+        existing_replan_obligation=replan_obligation,
+        latest_replan_ack=latest_agent_replan_ack or projected_replan_ack,
+        acceptance_gaps=acceptance_gaps,
+    )
+    if frontier_replan_obligation:
+        replan_obligation = frontier_replan_obligation
+        replan_scope = autonomous_replan_scope_decision(
+            replan_obligation,
+            agent_id=agent_id,
+            primary_agent_id=primary_agent_id,
+        )
+
+    goal_frontier_projection = build_goal_frontier_projection_from_summaries(
+        goal_id=goal_id,
+        agent_id=agent_id,
+        user_todo_summary=user_todo_summary,
+        agent_todo_summary=agent_todo_summary,
+        work_lane_contract=work_lane_contract,
+        replan_obligation=replan_obligation,
+        acceptance_gaps=acceptance_gaps,
+    )
+    return {
+        "schema_version": "goal_frontier_projection_context_v0",
+        "replan_obligation": replan_obligation,
+        "replan_scope": replan_scope,
+        "goal_frontier_projection": goal_frontier_projection,
+        "acceptance_gaps": acceptance_gaps,
+        "latest_replan_ack": latest_agent_replan_ack,
+        "projected_replan_ack": projected_replan_ack,
+    }
 
 
 def compact_replan_obligation(replan_obligation: dict[str, Any]) -> dict[str, Any]:

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -48,20 +48,10 @@ from .control_plane.work_items.interaction_contract import (
     protocol_action_text as _protocol_action_text,
     user_channel_action_required as _user_channel_action_required,
 )
-from .control_plane.work_items.autonomous_replan_ack import (
-    autonomous_replan_ack_matches_agent,
-)
 from .control_plane.goals.goal_frontier import (
     AUTONOMOUS_REPLAN_REQUIRED_MODE,
-    acceptance_gaps_from_agent_vision,
-    acceptance_gaps_from_vision_checkpoint,
     autonomous_replan_decision_allowed,
-    autonomous_replan_scope_decision,
-    build_goal_frontier_projection_from_summaries,
-    derive_goal_frontier_replan_obligation_from_summaries,
-    latest_agent_vision_from_status_payload,
-    latest_missing_vision_checkpoint_from_status_payload,
-    select_autonomous_replan_obligation,
+    build_goal_frontier_projection_context_from_status,
 )
 from .control_plane.quota.heartbeat_recommendation import (
     HEARTBEAT_HANDOFF_READINESS_COMPACT_FIELDS as HANDOFF_READINESS_COMPACT_FIELDS,
@@ -1426,94 +1416,6 @@ def _registry_goal_by_id(status_payload: dict[str, Any]) -> dict[str, dict[str, 
     }
 
 
-def _compact_autonomous_replan_ack(run: dict[str, Any] | None) -> dict[str, Any] | None:
-    if not isinstance(run, dict):
-        return None
-    ack = run.get("autonomous_replan_ack")
-    if not isinstance(ack, dict) or ack.get("recorded") is not True:
-        return None
-    delta_contract = ack.get("delta_contract")
-    if not isinstance(delta_contract, dict) or delta_contract.get("delta_present") is not True:
-        return None
-    compact_delta = {
-        "schema_version": delta_contract.get("schema_version"),
-        "delta_present": True,
-        "delta_kinds": [
-            str(item)
-            for item in (delta_contract.get("delta_kinds") or [])
-            if str(item or "").strip()
-        ],
-    }
-    result = {
-        "schema_version": ack.get("schema_version"),
-        "recorded": True,
-        "source": ack.get("source"),
-        "delta_contract": compact_delta,
-    }
-    agent_id = str(run.get("agent_id") or "").strip()
-    if agent_id:
-        result["agent_id"] = agent_id
-    return result
-
-
-def _latest_autonomous_replan_ack_for_agent(
-    status_payload: dict[str, Any],
-    *,
-    goal_id: str,
-    agent_id: str | None,
-) -> dict[str, Any] | None:
-    if not agent_id:
-        return None
-    run_history = (
-        status_payload.get("run_history")
-        if isinstance(status_payload.get("run_history"), dict)
-        else {}
-    )
-    goals = run_history.get("goals") if isinstance(run_history.get("goals"), list) else []
-    goal = next(
-        (
-            item
-            for item in goals
-            if isinstance(item, dict) and str(item.get("id") or "") == goal_id
-        ),
-        None,
-    )
-    latest_runs = goal.get("latest_runs") if isinstance(goal, dict) else None
-    if not isinstance(latest_runs, list):
-        return None
-    for run in latest_runs:
-        if not isinstance(run, dict):
-            continue
-        run_agent_id = str(run.get("agent_id") or "").strip()
-        if run_agent_id and run_agent_id != agent_id:
-            continue
-        replan_ack = _compact_autonomous_replan_ack(run)
-        if replan_ack:
-            return replan_ack
-        classification = str(run.get("classification") or "").strip()
-        if not classification:
-            continue
-        if classification in AUTONOMOUS_REPLAN_ACK_NEUTRAL_CLASSIFICATIONS:
-            continue
-        if classification == QUOTA_MONITOR_POLL_CLASSIFICATION:
-            continue
-        return None
-    return None
-
-
-def _projected_autonomous_replan_ack_for_agent(
-    item: dict[str, Any],
-    project_asset: dict[str, Any],
-    *,
-    agent_id: str | None,
-) -> dict[str, Any] | None:
-    for candidate in (item.get("autonomous_replan_ack"), project_asset.get("autonomous_replan_ack")):
-        if not autonomous_replan_ack_matches_agent(candidate, agent_id=agent_id):
-            continue
-        return candidate
-    return None
-
-
 def _recovery_delivery_allowed(quota: dict[str, Any], *, plan_ok: bool) -> bool:
     return (
         bool(plan_ok)
@@ -1674,64 +1576,24 @@ def build_quota_should_run(
             if isinstance(agent_identity, dict)
             else None
         )
-        replan_obligation = select_autonomous_replan_obligation(item, project_asset)
-        replan_scope = autonomous_replan_scope_decision(
-            replan_obligation,
+        goal_frontier_context = build_goal_frontier_projection_context_from_status(
+            goal_id=safe_goal_id,
             agent_id=agent_frontier_id,
             primary_agent_id=primary_agent_id,
-        )
-        if replan_scope.get("required") and not replan_scope.get("applies"):
-            replan_obligation = None
-        latest_agent_replan_ack = _latest_autonomous_replan_ack_for_agent(
-            status_payload,
-            goal_id=safe_goal_id,
-            agent_id=agent_frontier_id,
-        )
-        latest_agent_vision = latest_agent_vision_from_status_payload(
-            status_payload,
-            goal_id=safe_goal_id,
-            agent_id=agent_frontier_id,
-        )
-        latest_missing_vision_checkpoint = latest_missing_vision_checkpoint_from_status_payload(
-            status_payload,
-            goal_id=safe_goal_id,
-            agent_id=agent_frontier_id,
-        )
-        goal_frontier_acceptance_gaps = (
-            acceptance_gaps_from_agent_vision(latest_agent_vision)
-            + acceptance_gaps_from_vision_checkpoint(latest_missing_vision_checkpoint)
-        )
-        frontier_replan_obligation = derive_goal_frontier_replan_obligation_from_summaries(
+            status_payload=status_payload,
+            item=item,
+            project_asset=project_asset,
             user_todo_summary=user_todo_summary,
             agent_todo_summary=agent_todo_summary,
             work_lane_contract=work_lane_contract,
-            agent_id=agent_frontier_id,
-            existing_replan_obligation=replan_obligation,
-            latest_replan_ack=(
-                latest_agent_replan_ack
-                or _projected_autonomous_replan_ack_for_agent(
-                    item,
-                    project_asset,
-                    agent_id=agent_frontier_id,
-                )
-            ),
-            acceptance_gaps=goal_frontier_acceptance_gaps,
+            neutral_replan_ack_classifications=AUTONOMOUS_REPLAN_ACK_NEUTRAL_CLASSIFICATIONS,
         )
-        if frontier_replan_obligation:
-            replan_obligation = frontier_replan_obligation
-            replan_scope = autonomous_replan_scope_decision(
-                replan_obligation,
-                agent_id=agent_frontier_id,
-                primary_agent_id=primary_agent_id,
-            )
-        goal_frontier_projection = build_goal_frontier_projection_from_summaries(
-            goal_id=safe_goal_id,
-            agent_id=agent_frontier_id,
-            user_todo_summary=user_todo_summary,
-            agent_todo_summary=agent_todo_summary,
-            work_lane_contract=work_lane_contract,
-            replan_obligation=replan_obligation,
-            acceptance_gaps=goal_frontier_acceptance_gaps,
+        replan_obligation = goal_frontier_context.get("replan_obligation")
+        replan_scope = goal_frontier_context.get("replan_scope") or {}
+        goal_frontier_projection = (
+            goal_frontier_context.get("goal_frontier_projection")
+            if isinstance(goal_frontier_context.get("goal_frontier_projection"), dict)
+            else {}
         )
         effective_available_capabilities = _effective_available_capabilities(
             available_capabilities,


### PR DESCRIPTION
## Summary
- Move quota/frontier replan projection assembly into `goal_frontier` read-model helper.
- Remove duplicated replan ACK / vision-gap / projection assembly from `loopx/quota.py`.
- Add focused parity coverage proving the helper matches quota payloads for monitor-only plus open-agent-vision frontier cases.

## Validation
- `python3 -m py_compile loopx/quota.py loopx/control_plane/goals/goal_frontier.py examples/control_plane/quota-replan-decision-plane-smoke.py`
- `python3 examples/control_plane/quota-replan-decision-plane-smoke.py`
- `python3 examples/control_plane/work-lane-contract-smoke.py`
- `python3 examples/control_plane/heartbeat-quota-flow-smoke.py`
- `python3 examples/control_plane/control-plane-risk-characterization-smoke.py`
- `python3 examples/control_plane/todo-projection-shared-helper-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `loopx canary premerge --from-git-diff` passed: 17 selected checks, 0 failures, 0 manual holds.

## Self-merge rationale
- Narrow control-plane read-model refactor with parity coverage.
- No benchmark task/log/trajectory/verifier material, no credentials, no private local state.
- Premerge gate passed and reports self_merge_allowed=true.