### PR TITLE
Release LoopX v0.1.12

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -131,6 +131,14 @@ path, and canary route rather than as a user-facing release baseline.
   bounded-context cleanup, auto-research successor/evidence fixes, connector
   source-map packets, structured run-index classification, and Codex CLI/TUI
   recovery fixes.
+- `v0.1.12` on 2026-07-08 02:05 +08:00: presentation/read-model and frontier
+  recovery release at the matching `v0.1.12` tag. This release moves large
+  status, goal-channel, dashboard, and Lark rendering paths into bounded
+  presentation/read-model modules, fixes monitor-only plus open-vision frontier
+  replan gaps, makes installer reruns overwrite stale wrappers/files safely,
+  exposes premerge canary progress earlier, and promotes auto-research visible
+  worker/successor routing plus selected public benchmark route/profile and
+  SkillsBench helper hardening.
 
 When a new public release is promoted, add it here only after the matching tag,
 release note, stable ref, update path, and focused release canary agree.

--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.11"
+__version__ = "0.1.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.1.11"
+version = "0.1.12"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Release LoopX `v0.1.12`.

This PR only changes the release identity and public release-readiness timeline:

- bump `loopx.__version__` from `0.1.11` to `0.1.12`
- bump `pyproject.toml` from `0.1.11` to `0.1.12`
- add the `v0.1.12` public release timeline entry

## Diff since `v0.1.11`

Previous public release: `v0.1.11`, published 2026-07-06, target commit `51491ae4`.

Current release branch head: `db8a8f76`.

Diff size before promotion:

- `218 files changed`
- `12,309 insertions(+), 6,547 deletions(-)`

Main objectively visible areas:

- Presentation/read-model extraction: large status, goal-channel, dashboard, and Lark rendering paths moved into bounded `loopx/presentation/*`, `apps/presentation/*`, and control-plane read-model helpers. Notable old hot paths such as `loopx/status.py` and `loopx/capabilities/lark/kanban.py` were reduced while presentation sinks/renderers gained explicit homes.
- Frontier/replan behavior: monitor-only states, open goal-vision gaps, successor/no-follow-up semantics, and quota frontier projection now have more explicit decision-plane coverage and parity smokes.
- Install/update behavior: local and public installer paths now tolerate existing wrappers/files instead of failing on stale `~/.local/bin/loopx` state.
- Canary/operator feedback: premerge canary now streams phase progress earlier, reducing the old “silent >30s” iteration bottleneck.
- Auto-research and visible multi-agent flow: visible worker hook validation, role successor routing, auto-wake/backoff, and run-summary reuse were tightened.
- Public benchmark helper contracts: route/profile, SkillsBench batch pacing, build-stall timeout, first-action prompt, and countable ledger summary helpers were added or hardened as public contracts/helpers only. This release does not publish raw benchmark logs, task text, trajectories, verifier output, or leaderboard/submission behavior changes.
- Public docs/community surface: README community QR additions and release-readiness/docs refreshes are included from already-merged work.

## Validation

Release/version gates:

- `python3 -m py_compile loopx/*.py loopx/benchmark_core/*.py`
- `python3 examples/release/release-version-contract-smoke.py`
- `python3 examples/release/release-readiness-doc-smoke.py`
- `python3 examples/release/codex-cli-no-clone-release-verification-smoke.py`
- `python3 examples/fresh-clone-quickstart-smoke.py`
- `python3 examples/loopx-update-smoke.py`
- `python3 examples/install-local-smoke.py`
- `git diff --check`

Focused coverage for the main changed surfaces:

- `python3 -m loopx.cli check --scan-path README.md --scan-path README.zh-CN.md --scan-path docs/ --scan-path examples/`
- `python3 examples/control_plane/quota-replan-decision-plane-smoke.py`
- `python3 examples/control_plane/status-collection-readmodel-smoke.py`
- `python3 examples/control_plane/status-runtime-summaries-readmodel-smoke.py`
- `python3 examples/control_plane/presentation-markdown-primitives-smoke.py`
- `python3 examples/canary/premerge-validation-gate-smoke.py`
- `python3 examples/auto-research-visible-worker-hook-smoke.py`
- `python3 examples/control_plane/auto-research-role-successor-completion-smoke.py`
- `python3 examples/benchmark-route-profile-contract-smoke.py`
- `python3 examples/skillsbench-build-stall-timeout-smoke.py`
- `python3 examples/skillsbench-batch-case-start-gap-smoke.py`

Premerge gate:

- `python3 -m loopx.cli canary premerge --from-git-diff`
- result: passed, `selected=17`, `failures=0`, `manual_holds=0`, `self_merge_allowed=true`

Public/private boundary:

- `loopx check` reported `errors=0`, `warnings=0`, `public boundary scan clean: 843 files`.

## Release plan after merge

- tag the merged release commit as `v0.1.12`
- create GitHub Release `LoopX v0.1.12` with the release report
- fast-forward `stable` to the tagged release commit
- verify `loopx doctor` / version contract on the promoted code path

