### PR TITLE
Make slow integrated canary a deep profile check

### DIFF
--- a/examples/canary/catalog-planner-smoke.py
+++ b/examples/canary/catalog-planner-smoke.py
@@ -199,7 +199,7 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     assert "control-plane-state-machine" in state_machine_profiles, state_machine_payload
     state_machine_profile = state_machine_profiles["control-plane-state-machine"]
     state_machine_commands = [check["command"] for check in state_machine_profile["checks"]]
-    assert "python3 examples/control_plane/control-plane-integrated-canary-smoke.py" in state_machine_commands, (
+    assert "python3 examples/control_plane/control-plane-integrated-canary-smoke.py" not in state_machine_commands, (
         state_machine_profile
     )
     assert (
@@ -218,6 +218,28 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     assert all(check["tier"] == "default" for check in state_machine_profile["checks"]), (
         state_machine_profile
     )
+    assert state_machine_profile["deep_checks_available"] is True, state_machine_profile
+    assert state_machine_profile["deep_checks_included"] is False, state_machine_profile
+
+    state_machine_deep_payload = build_catalog_canary_plan(
+        changed_files=["examples/control_plane/control-plane-integrated-canary-smoke.py"],
+        surfaces=[
+            "complex control-plane state-machine interaction_contract "
+            "scheduler_hint work_lane_contract goal_frontier"
+        ],
+        include_deep_checks=True,
+        max_checks_per_profile=5,
+    )
+    state_machine_deep_profiles = {
+        profile["id"]: profile for profile in state_machine_deep_payload["domain_profiles"]
+    }
+    state_machine_deep_commands = [
+        check["command"]
+        for check in state_machine_deep_profiles["control-plane-state-machine"]["checks"]
+    ]
+    assert "python3 examples/control_plane/control-plane-integrated-canary-smoke.py" in (
+        state_machine_deep_commands
+    ), state_machine_deep_profiles["control-plane-state-machine"]
 
     interaction_contract_payload = build_catalog_canary_plan(
         changed_files=["loopx/control_plane/work_items/interaction_contract.py"],
@@ -272,7 +294,10 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
         check["command"]
         for check in bounded_context_profiles["control-plane-state-machine"]["checks"]
     ]
-    assert "python3 examples/control_plane/control-plane-integrated-canary-smoke.py" in (
+    assert "python3 examples/control_plane/control-plane-integrated-canary-smoke.py" not in (
+        bounded_context_state_machine_commands
+    ), bounded_context_profiles["control-plane-state-machine"]
+    assert "python3 examples/control_plane/interaction-contract-state-machine-smoke.py" in (
         bounded_context_state_machine_commands
     ), bounded_context_profiles["control-plane-state-machine"]
 
@@ -313,7 +338,10 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
         check["command"]
         for check in monitor_target_profiles["control-plane-state-machine"]["checks"]
     ]
-    assert "python3 examples/control_plane/control-plane-integrated-canary-smoke.py" in (
+    assert "python3 examples/control_plane/control-plane-integrated-canary-smoke.py" not in (
+        monitor_target_state_machine_commands
+    ), monitor_target_profiles["control-plane-state-machine"]
+    assert "python3 examples/control_plane/interaction-contract-state-machine-smoke.py" in (
         monitor_target_state_machine_commands
     ), monitor_target_profiles["control-plane-state-machine"]
 
@@ -331,7 +359,10 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
         check["command"]
         for check in monitor_writeback_profiles["control-plane-state-machine"]["checks"]
     ]
-    assert "python3 examples/control_plane/control-plane-integrated-canary-smoke.py" in (
+    assert "python3 examples/control_plane/control-plane-integrated-canary-smoke.py" not in (
+        monitor_writeback_state_machine_commands
+    ), monitor_writeback_profiles["control-plane-state-machine"]
+    assert "python3 examples/control_plane/interaction-contract-state-machine-smoke.py" in (
         monitor_writeback_state_machine_commands
     ), monitor_writeback_profiles["control-plane-state-machine"]
 

--- a/examples/canary/premerge-validation-gate-smoke.py
+++ b/examples/canary/premerge-validation-gate-smoke.py
@@ -55,7 +55,8 @@ def assert_control_plane_change_selects_state_machine_validation() -> None:
         summary["selected_commands"]
     ), payload
     assert any("interaction-contract-state-machine-smoke.py" in item for item in catalog_commands), payload
-    assert any("control-plane-integrated-canary-smoke.py" in item for item in catalog_commands), payload
+    assert not any("control-plane-integrated-canary-smoke.py" in item for item in catalog_commands), payload
+    assert any("heartbeat-quota-flow-smoke.py" in item for item in catalog_commands), payload
     assert any("bounded-context-namespace-smoke.py" in item for item in catalog_commands), payload
     assert risk_commands, payload
     assert payload["gate"]["status"] == "preview_only", payload

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -434,10 +434,11 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
         "checks": [
             {
                 "command": "python3 examples/control_plane/control-plane-integrated-canary-smoke.py",
-                "tier": "default",
+                "tier": "deep",
                 "reason": (
-                    "exercises event-sourced todo projection, status, quota interaction contract, "
-                    "work-lane contract, scheduler ack, refresh-state, spend-slot, and review-packet handoff together"
+                    "samples the full event-sourced todo projection, status, quota interaction contract, "
+                    "work-lane contract, scheduler ack, refresh-state, spend-slot, and review-packet handoff path; "
+                    "kept deep because it is a slow end-to-end fixture"
                 ),
             },
             {


### PR DESCRIPTION
## Summary

Move `control-plane-integrated-canary-smoke.py` out of the default `control-plane-state-machine` profile and keep it as a deep check. Routine control-plane read-model/planner PRs still get fast durable state-machine coverage from the focused quota/frontier/interaction smokes, while the full integrated fixture remains available for explicit deep validation.

## Why

`control-plane-integrated-canary-smoke.py` was measured at roughly 55s locally. Selecting it by default made routine control-plane planner/read-model changes pay for a slow end-to-end fixture even when the changed surface only needed fast parity/state-machine coverage.

## Changed surfaces

- `loopx/canary/planner.py`: marks the integrated control-plane smoke as `tier="deep"` and documents why.
- `examples/canary/catalog-planner-smoke.py`: updates planner coverage expectations so default state-machine plans exclude the integrated smoke, while `include_deep_checks=True` still selects it.
- `examples/canary/premerge-validation-gate-smoke.py`: asserts routine control-plane premerge selection keeps focused state-machine coverage without selecting the integrated smoke.

## Validation

- `python3 -m py_compile loopx/canary/planner.py`
- `python3 examples/canary/catalog-planner-smoke.py`
- `python3 examples/canary/premerge-validation-gate-smoke.py`
- `python3 examples/control_plane/interaction-contract-state-machine-smoke.py`
- `python3 examples/control_plane/heartbeat-quota-flow-smoke.py`
- `python3 examples/control_plane/quota-scheduler-state-ack-smoke.py`
- `python3 examples/control_plane/side-agent-self-iteration-state-machine-smoke.py`
- Dry-run premerge selection for `goal_frontier.py`, `interaction_contract.py` + `quota.py`, and `monitor_target.py`: `integrated_selected=False` for all three routine control-plane cases.
- `python3 -m loopx.cli check --scan-path loopx/canary/planner.py --scan-path examples/canary/catalog-planner-smoke.py --scan-path examples/canary/premerge-validation-gate-smoke.py`: errors=0, warnings=0.
- `loopx canary premerge --from-git-diff`: passed; selected=16, failures=0, manual_holds=0, self_merge_allowed=true.

## Residual risk / follow-up

This removes the ~55s integrated end-to-end fixture from the routine default selection path. The branch-level premerge still took about 50s because `canary-runner` and public-boundary checks remain relatively heavy; that is a separate residual latency target and should not be conflated with this PR.
