### PR TITLE
Fix SkillsBench countability and goal launcher

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -75,6 +75,7 @@ from examples.skillsbench_fixtures import (  # noqa: E402
     write_official_skillsbench_docker_daemon_unavailable_failure,
     write_official_skillsbench_docker_port_conflict_failure,
     write_official_skillsbench_oracle_reward_artifact_recovery_result,
+    write_official_skillsbench_passed_bool_result,
     write_official_skillsbench_result,
     write_official_skillsbench_reward_artifact_recovery_result,
     write_official_skillsbench_runner_error_zero_reward_result,
@@ -4552,6 +4553,42 @@ def test_skillsbench_official_result_builder() -> None:
         assert compact["trials"][0]["task_id"] == "sample-task"
         assert compact["read_boundary"]["compact_only"] is True
         assert compact["read_boundary"]["trajectory_read"] is False
+
+
+def test_skillsbench_passed_bool_result_is_countable_zero() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-passed-bool-") as tmp:
+        result_path = write_official_skillsbench_passed_bool_result(
+            Path(tmp),
+            passed=False,
+            task_id="travel-planning",
+        )
+        compact = compact_benchmark_run(
+            build_skillsbench_benchflow_result_benchmark_run(
+                result_path,
+                route="codex-cli-goal-baseline",
+            )
+        )
+        assert compact is not None
+        assert compact["official_score_status"] == "completed", compact
+        assert compact["official_score"] == 0.0, compact
+        assert compact["official_task_score"] == {
+            "kind": "skillsbench_verifier_reward_recovered_from_passed_bool",
+            "value": 0.0,
+            "passed": False,
+        }, compact
+        assert compact["official_score_source"] == (
+            "official_skillsbench_benchflow_result_rewards_passed_bool"
+        ), compact
+        assert compact["score_failure_attribution"] == (
+            "official_verifier_solution_failure"
+        ), compact
+        assert "verifier_infrastructure_failure" not in compact[
+            "failure_attribution_labels"
+        ], compact
+        attempt_accounting = compact["attempt_accounting"]
+        assert attempt_accounting["official_score_attempt_countable"] is True, compact
+        assert attempt_accounting["verifier_attempt_countable"] is True, compact
+        assert attempt_accounting["solver_attempt_countable"] is True, compact
 
 
 def test_skillsbench_verifier_uv_bootstrap_error_is_not_solution_failure() -> None:

--- a/examples/skillsbench-task-source-preflight-smoke.py
+++ b/examples/skillsbench-task-source-preflight-smoke.py
@@ -63,6 +63,7 @@ def _app_goal_args(
         "--update-ledger",
         "--host-local-acp-launch",
         "--remote-command-file-bridge-ready",
+        "--allow-deprecated-app-server-goal-route",
     ]
 
 
@@ -100,6 +101,9 @@ def test_sanity_task_source_fails_before_runner_spend() -> None:
         assert preflight["alternate_source_kind"] == "experiments_sanity_tasks", (
             preflight
         )
+        assert preflight["canonical_equivalent_status"] == (
+            "no_close_canonical_match"
+        ), preflight
         assert preflight["task_source_path_recorded"] is False, preflight
         assert preflight["task_source_content_recorded"] is False, preflight
         assert preflight["nearest_canonical_task_ids"] == [
@@ -129,6 +133,9 @@ def test_sanity_task_source_fails_before_runner_spend() -> None:
         assert compact["task_setup_preflight"]["alternate_source_kind"] == (
             "experiments_sanity_tasks"
         )
+        assert compact["task_setup_preflight"]["canonical_equivalent_status"] == (
+            "no_close_canonical_match"
+        )
         assert compact["validation"]["no_raw_task_text_read"] is True, compact
 
         update = load_benchmark_run_ledger(ledger)
@@ -139,6 +146,67 @@ def test_sanity_task_source_fails_before_runner_spend() -> None:
         assert case["runs"][0]["repair_class"] == (
             "skillsbench_task_source_preflight_selection"
         )
+
+
+def test_missing_task_source_records_no_close_canonical_equivalent() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-no-canonical-equivalent-") as tmp:
+        root = Path(tmp)
+        skillsbench_root = root / "skillsbench"
+        _write_task(skillsbench_root, "tasks/3d-scan-calc")
+        _write_task(skillsbench_root, "tasks/offer-letter-generator")
+        _write_task(skillsbench_root, "tasks/paratransit-routing")
+        _write_task(skillsbench_root, "tasks/travel-planning")
+
+        jobs = root / "jobs"
+        ledger = root / "ledger.json"
+        args = [
+            "--task-id",
+            "scheduling-email-assistant",
+            "--route",
+            "raw-codex-autonomous-max5",
+            "--skillsbench-root",
+            str(skillsbench_root),
+            "--jobs-dir",
+            str(jobs),
+            "--job-name",
+            "skillsbench-scheduling-email-task-source-preflight",
+            "--run-group-id",
+            "skillsbench-scheduling-email-task-source-preflight",
+            "--ledger-path",
+            str(ledger),
+            "--update-ledger",
+        ]
+        plan = build_plan(parse_args(args))
+        preflight = plan["task_setup_preflight"]
+        assert preflight["status"] == "task_missing_from_canonical_tasks", preflight
+        assert preflight["canonical_task_present"] is False, preflight
+        assert preflight["alternate_source_kind"] == "none", preflight
+        assert preflight["canonical_equivalent_status"] == (
+            "no_close_canonical_match"
+        ), preflight
+        assert preflight["raw_task_text_read"] is False, preflight
+        assert preflight["task_source_path_recorded"] is False, preflight
+        assert preflight["task_source_content_recorded"] is False, preflight
+
+        stderr = io.StringIO()
+        with contextlib.redirect_stderr(stderr):
+            rc = skillsbench_automation_loop_main(args)
+
+        assert rc == 0, stderr.getvalue()
+        compact_path = (
+            jobs
+            / "skillsbench-scheduling-email-task-source-preflight"
+            / "scheduling-email-assistant__raw_codex_autonomous_max5"
+            / "benchmark_run.compact.json"
+        )
+        compact = json.loads(compact_path.read_text(encoding="utf-8"))
+        assert compact["score_failure_attribution"] == (
+            "skillsbench_task_source_preflight_blocked"
+        )
+        assert compact["task_setup_preflight"]["canonical_equivalent_status"] == (
+            "no_close_canonical_match"
+        )
+        assert compact["validation"]["no_raw_task_text_read"] is True, compact
 
 
 def test_reverse_tunnel_app_goal_defaults_verifier_bootstrap_fail_fast() -> None:
@@ -174,6 +242,7 @@ def test_reverse_tunnel_app_goal_defaults_verifier_bootstrap_fail_fast() -> None
             "--update-ledger",
             "--host-local-acp-launch",
             "--remote-command-file-bridge-ready",
+            "--allow-deprecated-app-server-goal-route",
         ]
         parsed = parse_args(args)
         assert parsed.fail_fast_on_apt_risk is True
@@ -437,6 +506,7 @@ def test_reverse_tunnel_app_goal_allows_explicit_staged_bootstrap_repair() -> No
 
 if __name__ == "__main__":
     test_sanity_task_source_fails_before_runner_spend()
+    test_missing_task_source_records_no_close_canonical_equivalent()
     test_reverse_tunnel_app_goal_defaults_verifier_bootstrap_fail_fast()
     test_reverse_tunnel_app_goal_defaults_apt_bootstrap_fail_fast()
     test_reverse_tunnel_app_goal_blocks_pip_bootstrap_light_risk()

--- a/examples/skillsbench_fixtures.py
+++ b/examples/skillsbench_fixtures.py
@@ -54,6 +54,44 @@ def write_official_skillsbench_result(
     return result_path
 
 
+def write_official_skillsbench_passed_bool_result(
+    root: Path,
+    *,
+    passed: bool = False,
+    task_id: str = "sample-task",
+) -> Path:
+    run_dir = root / "official" / "2026-06-15__00-00-00" / f"{task_id}__abc123"
+    result_path = run_dir / "result.json"
+    write_json(
+        result_path,
+        {
+            "task_name": task_id,
+            "rollout_name": f"{task_id}__abc123",
+            "rewards": {"passed": passed},
+            "agent": "codex-acp",
+            "agent_name": "codex-acp",
+            "model": "gpt-5.5",
+            "n_tool_calls": 7,
+            "n_prompts": 1,
+            "error": None,
+            "verifier_error": "numeric reward missing from compact result",
+            "partial_trajectory": False,
+            "trajectory_source": "acp",
+        },
+    )
+    write_json(
+        run_dir / "timing.json",
+        {
+            "environment_setup": 2.0,
+            "agent_setup": 1.0,
+            "agent_execution": 3.0,
+            "verifier": 4.0,
+            "total": 10.0,
+        },
+    )
+    return result_path
+
+
 def write_official_skillsbench_reward_artifact_recovery_result(root: Path) -> Path:
     run_dir = root / "official" / "2026-06-15__00-00-00" / "sample-task__abc123"
     result_path = run_dir / "result.json"
@@ -503,5 +541,4 @@ def write_official_skillsbench_codex_acp_provider_zero_activity(root: Path) -> P
     )
     write_json(run_dir / "timing.json", {"agent_execution": 5.0, "total": 600.0})
     return result_path
-
 

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -460,6 +460,21 @@ def _skillsbench_number(value: Any) -> float | int | None:
     return None
 
 
+def _skillsbench_passed_bool_score_source(
+    *,
+    result: dict[str, Any],
+    rewards: dict[str, Any],
+) -> tuple[float | None, str | None]:
+    for source_name, container in (
+        ("official_skillsbench_benchflow_result_rewards_passed_bool", rewards),
+        ("official_skillsbench_benchflow_result_passed_bool", result),
+    ):
+        passed = container.get("passed") if isinstance(container, dict) else None
+        if isinstance(passed, bool):
+            return (1.0 if passed else 0.0), source_name
+    return None, None
+
+
 def _skillsbench_official_score_missing(benchmark_run: dict[str, Any]) -> bool:
     official = (
         benchmark_run.get("official_task_score")
@@ -3507,6 +3522,9 @@ def build_skillsbench_benchflow_result_benchmark_run(
         reward_value, reward_artifact_source = _skillsbench_rollout_reward_artifact(
             result_path
         )
+    passed_bool_score_source: str | None = None
+    if reward_value is None:
+        reward_value, passed_bool_score_source = _skillsbench_passed_bool_score_source(result=result, rewards=rewards)
 
     timing_path = result_path.with_name("timing.json")
     timing: dict[str, Any] = {}
@@ -3553,9 +3571,11 @@ def build_skillsbench_benchflow_result_benchmark_run(
             skillsbench_runner_error_attribution(error_text)
         )
         runner_score_failure_attribution = score_failure_attribution
-    if verifier_error_text and reward_artifact_source:
+    if verifier_error_text and (reward_artifact_source or passed_bool_score_source):
         warning_labels.append(
             "skillsbench_result_json_reward_missing_recovered_from_reward_txt"
+            if reward_artifact_source
+            else "skillsbench_result_json_reward_missing_recovered_from_passed_bool"
         )
     elif verifier_error_text:
         if score_failure_attribution in {"none", "skillsbench_runner_error"}:
@@ -4770,6 +4790,12 @@ def build_skillsbench_benchflow_result_benchmark_run(
         validation_scope = "official_benchflow_result_json_plus_rollout_reward_artifact"
         if not controller_trace_present:
             counter_trust_level = "official_benchflow_result_plus_rollout_reward_artifact"
+    if passed_bool_score_source:
+        official_score_kind = "skillsbench_verifier_reward_recovered_from_passed_bool"
+        official_score_source = passed_bool_score_source
+        validation_scope = "official_benchflow_result_json_plus_passed_bool_score"
+        if not controller_trace_present:
+            counter_trust_level = "official_benchflow_result_plus_passed_bool_score"
     if post_success_score:
         official_score_kind = (
             "skillsbench_verifier_reward_recovered_from_controller_trace"

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -251,6 +251,7 @@ def _compact_task_setup_preflight(value: Any) -> dict[str, Any]:
         "task_id",
         "first_blocker",
         "alternate_source_kind",
+        "canonical_equivalent_status",
         "selection_recommendation",
     ):
         text = _compact_text(value.get(field), limit=140)

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -2478,6 +2478,7 @@ def _compact_benchmark_task_setup_preflight(value: Any) -> dict[str, Any]:
         "task_id",
         "first_blocker",
         "alternate_source_kind",
+        "canonical_equivalent_status",
         "selection_recommendation",
     ):
         text = public_safe_compact_text(value.get(field), limit=180)

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  scripts/skillsbench-launch-goal-xhigh.sh [--dry-run] <task-id> [tag] [remote-proxy-port]
+
+Launch one SkillsBench task through the host-local Codex CLI /goal route with
+the command/file bridge. Environment-specific values are supplied by env vars.
+
+Required env:
+  SKILLSBENCH_SSH_DESTINATION          SSH destination for the remote runner
+  SKILLSBENCH_REMOTE_ROOT              Remote LoopX checkout to run from
+  SKILLSBENCH_ROOT                     Remote SkillsBench checkout/root
+  SKILLSBENCH_EXPECTED_LOOPX_GIT_HEAD  Expected LoopX git head in remote root
+
+Optional env:
+  SKILLSBENCH_LOCAL_CODEX_PROXY_HOST   Local proxy host, default 127.0.0.1
+  SKILLSBENCH_LOCAL_CODEX_PROXY_PORT   Local proxy port, default 18180
+  SKILLSBENCH_ROUTE                    Route, default codex-cli-goal-baseline
+  SKILLSBENCH_MODEL                    Model, default gpt-5.5
+  SKILLSBENCH_REASONING_EFFORT         Reasoning effort, default xhigh
+  SKILLSBENCH_BUILD_STALL_TIMEOUT_SEC  Setup stall timeout; 0 disables cap
+  SKILLSBENCH_RUN_TIMEOUT_SEC          Supervisor timeout, default 28800
+  SKILLSBENCH_GOAL_ID                  Local evidence goal id, default loopx-meta
+  SKILLSBENCH_RUN_STAMP                Deterministic timestamp override
+  SKILLSBENCH_SSH_OPTIONS              Extra ssh options, one shell word each
+EOF
+}
+
+dry_run=false
+if [[ "${1:-}" == "--help" || "${1:-}" == "-h" ]]; then
+  usage
+  exit 0
+fi
+if [[ "${1:-}" == "--dry-run" ]]; then
+  dry_run=true
+  shift
+fi
+
+task_id="${1:-}"
+if [[ -z "$task_id" ]]; then
+  usage >&2
+  exit 2
+fi
+tag="${2:-${SKILLSBENCH_RUN_TAG:-manual}}"
+remote_proxy_port="${3:-${SKILLSBENCH_REMOTE_CODEX_PROXY_PORT:-18180}}"
+
+required_env=(
+  SKILLSBENCH_SSH_DESTINATION
+  SKILLSBENCH_REMOTE_ROOT
+  SKILLSBENCH_ROOT
+  SKILLSBENCH_EXPECTED_LOOPX_GIT_HEAD
+)
+for key in "${required_env[@]}"; do
+  if [[ -z "${!key:-}" ]]; then
+    echo "missing required env: ${key}" >&2
+    exit 2
+  fi
+done
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+stamp="${SKILLSBENCH_RUN_STAMP:-$(date +%Y%m%dT%H%M%SCST)}"
+safe_task="${task_id//[^A-Za-z0-9_ -]/-}"
+safe_task="${safe_task// /-}"
+safe_task="${safe_task//_/-}"
+
+goal_id="${SKILLSBENCH_GOAL_ID:-loopx-meta}"
+route="${SKILLSBENCH_ROUTE:-codex-cli-goal-baseline}"
+model="${SKILLSBENCH_MODEL:-gpt-5.5}"
+reasoning_effort="${SKILLSBENCH_REASONING_EFFORT:-xhigh}"
+build_stall_timeout="${SKILLSBENCH_BUILD_STALL_TIMEOUT_SEC:-0}"
+run_timeout="${SKILLSBENCH_RUN_TIMEOUT_SEC:-28800}"
+local_proxy_host="${SKILLSBENCH_LOCAL_CODEX_PROXY_HOST:-127.0.0.1}"
+local_proxy_port="${SKILLSBENCH_LOCAL_CODEX_PROXY_PORT:-18180}"
+
+run_group="skillsbench-codex-cli-goal-xhigh-${safe_task}-${tag}-${stamp}"
+job_name="${safe_task}__codex_cli_goal_xhigh_${tag}_${stamp}"
+
+public_dir=".local/goals/${goal_id}/skillsbench-runs/${run_group}"
+private_dir=".local/goals/${goal_id}/private/skillsbench-runs/${run_group}"
+mkdir -p "$public_dir" "$private_dir"
+
+remote_command=$(
+  printf 'cd %q && python3 scripts/skillsbench_automation_loop.py ' \
+    "$SKILLSBENCH_REMOTE_ROOT"
+  printf '%q ' \
+    --skillsbench-root "$SKILLSBENCH_ROOT" \
+    --expected-loopx-git-head "$SKILLSBENCH_EXPECTED_LOOPX_GIT_HEAD" \
+    --task-id "$task_id" \
+    --route "$route" \
+    --model "$model" \
+    --reasoning-effort "$reasoning_effort" \
+    --build-stall-timeout-sec "$build_stall_timeout" \
+    --codex-api-egress-mode reverse-tunnel \
+    --codex-api-reverse-tunnel-proxy "http://127.0.0.1:${remote_proxy_port}" \
+    --host-local-acp-launch \
+    --remote-command-file-bridge-probe \
+    --run-group-id "$run_group" \
+    --job-name "$job_name" \
+    --update-ledger \
+    --append-history
+)
+
+ssh_options=(--ssh-option ConnectTimeout=10)
+if [[ -n "${SKILLSBENCH_SSH_OPTIONS:-}" ]]; then
+  # shellcheck disable=SC2206
+  extra_ssh_options=(${SKILLSBENCH_SSH_OPTIONS})
+  for option in "${extra_ssh_options[@]}"; do
+    ssh_options+=(--ssh-option "$option")
+  done
+fi
+
+supervisor_cmd=(
+  python3
+  scripts/skillsbench_reverse_tunnel_supervisor.py
+  --ssh-destination "$SKILLSBENCH_SSH_DESTINATION"
+  "${ssh_options[@]}"
+  --cleanup-stale-local-forward
+  --remote-forward "127.0.0.1:${remote_proxy_port}:${local_proxy_host}:${local_proxy_port}"
+  --run-timeout-sec "$run_timeout"
+  --remote-command "$remote_command"
+  --private-log-path "${private_dir}/remote-command.log"
+  --public-output-path "${public_dir}/supervisor.public.json"
+)
+
+if [[ "$dry_run" == "true" ]]; then
+  printf 'dry_run=true\n'
+  printf 'task_id=%s\n' "$task_id"
+  printf 'run_group=%s\n' "$run_group"
+  printf 'job_name=%s\n' "$job_name"
+  printf 'public_output=%s/supervisor.public.json\n' "$public_dir"
+  printf 'private_dir=%s\n' "$private_dir"
+  printf 'remote_proxy_port=%s\n' "$remote_proxy_port"
+  printf 'remote_command=%s\n' "$remote_command"
+  printf 'supervisor_command='
+  printf '%q ' "${supervisor_cmd[@]}"
+  printf '\n'
+  exit 0
+fi
+
+pid="$(
+  python3 - "$private_dir" "${supervisor_cmd[@]}" <<'PY'
+import subprocess
+import sys
+from pathlib import Path
+
+private_dir = Path(sys.argv[1])
+cmd = sys.argv[2:]
+stdout = open(private_dir / "supervisor.stdout", "ab", buffering=0)
+stderr = open(private_dir / "supervisor.stderr", "ab", buffering=0)
+proc = subprocess.Popen(
+    cmd,
+    stdin=subprocess.DEVNULL,
+    stdout=stdout,
+    stderr=stderr,
+    start_new_session=True,
+    close_fds=True,
+)
+print(proc.pid)
+PY
+)"
+
+cat <<EOF
+pid=${pid}
+task_id=${task_id}
+run_group=${run_group}
+job_name=${job_name}
+public_output=${public_dir}/supervisor.public.json
+private_dir=${private_dir}
+remote_proxy_port=${remote_proxy_port}
+EOF

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -52,6 +52,7 @@ import argparse
 import ast
 import asyncio
 import contextlib
+import difflib
 import importlib
 import inspect
 import json
@@ -6347,6 +6348,7 @@ def _public_task_setup_preflight(value: Any) -> dict[str, Any]:
         "task_id",
         "first_blocker",
         "alternate_source_kind",
+        "canonical_equivalent_status",
         "selection_recommendation",
     ):
         raw = value.get(field)
@@ -7333,6 +7335,63 @@ def _skillsbench_public_task_label(value: Any, *, limit: int = 120) -> str:
     return label[:limit]
 
 
+def _skillsbench_task_id_tokens(value: str) -> set[str]:
+    return {token for token in re.findall(r"[a-z0-9]+", value.lower()) if len(token) >= 2}
+
+
+def _skillsbench_task_id_similarity(
+    requested_task_id: str,
+    canonical_task_id: str,
+) -> tuple[float, bool]:
+    requested = _skillsbench_public_task_label(requested_task_id).lower()
+    canonical = _skillsbench_public_task_label(canonical_task_id).lower()
+    if not requested or not canonical:
+        return 0.0, False
+    sequence_score = difflib.SequenceMatcher(None, requested, canonical).ratio()
+    requested_tokens = _skillsbench_task_id_tokens(requested)
+    canonical_tokens = _skillsbench_task_id_tokens(canonical)
+    token_overlap = 0.0
+    has_token_overlap = False
+    if requested_tokens and canonical_tokens:
+        intersection = requested_tokens & canonical_tokens
+        union = requested_tokens | canonical_tokens
+        token_overlap = len(intersection) / len(union)
+        has_token_overlap = bool(intersection)
+    return (sequence_score * 0.4) + (token_overlap * 0.6), has_token_overlap
+
+
+def skillsbench_nearest_canonical_task_ids(
+    *,
+    requested_task_id: str,
+    canonical_root: Path,
+    limit: int = 5,
+) -> tuple[list[str], str]:
+    canonical_ids: list[str] = []
+    if canonical_root.is_dir():
+        for child in sorted(canonical_root.iterdir(), key=lambda item: item.name):
+            if not child.is_dir():
+                continue
+            label = _skillsbench_public_task_label(child.name)
+            if label:
+                canonical_ids.append(label)
+    if not canonical_ids:
+        return [], "canonical_task_index_empty"
+
+    ranked: list[tuple[float, bool, str]] = []
+    for canonical_id in canonical_ids:
+        score, has_token_overlap = _skillsbench_task_id_similarity(
+            requested_task_id,
+            canonical_id,
+        )
+        ranked.append((score, has_token_overlap, canonical_id))
+    ranked.sort(key=lambda item: (-item[0], item[2]))
+    best_score, best_has_token_overlap, _best_id = ranked[0]
+    close_match = best_has_token_overlap or best_score >= 0.34
+    if close_match:
+        return [item[2] for item in ranked[:limit]], "close_canonical_match_found"
+    return canonical_ids[:limit], "no_close_canonical_match"
+
+
 SKILLSBENCH_BOOTSTRAP_LIGHT_BLOCKING_PREFLIGHT_FIELDS = (
     "apt_setup_risk_detected",
     "apt_retry_patch_required",
@@ -7504,25 +7563,23 @@ def skillsbench_task_setup_preflight(
         alternate_source_kind = (
             "experiments_sanity_tasks" if sanity_task.is_dir() else "none"
         )
-        nearest: list[str] = []
-        canonical_root = skillsbench_root / "tasks"
-        if canonical_root.is_dir():
-            for child in sorted(canonical_root.iterdir(), key=lambda item: item.name):
-                if not child.is_dir():
-                    continue
-                label = _skillsbench_public_task_label(child.name)
-                if label:
-                    nearest.append(label)
-                if len(nearest) >= 5:
-                    break
+        nearest, canonical_equivalent_status = (
+            skillsbench_nearest_canonical_task_ids(
+                requested_task_id=public_task_id,
+                canonical_root=skillsbench_root / "tasks",
+            )
+        )
         preflight.update(
             {
                 "status": "task_missing_from_canonical_tasks",
                 "first_blocker": "skillsbench_task_source_preflight_blocked",
                 "alternate_source_kind": alternate_source_kind,
+                "canonical_equivalent_status": canonical_equivalent_status,
                 "nearest_canonical_task_ids": nearest,
                 "selection_recommendation": (
-                    "choose_normal_tasks_candidate_or_use_explicit_sanity_source_runner"
+                    "choose_nearest_canonical_task_candidate_or_use_explicit_sanity_source_runner"
+                    if canonical_equivalent_status == "close_canonical_match_found"
+                    else "no_close_canonical_task_match_choose_normal_tasks_candidate_or_explicit_sanity_source_runner"
                 ),
             }
         )


### PR DESCRIPTION
## Summary
- Treat BenchFlow `passed` booleans as official countable 0/1 scores when numeric reward is missing (`false -> 0.0`, `true -> 1.0`) instead of classifying the run as verifier infrastructure failure.
- Add canonical task-id preflight classification for missing SkillsBench task sources, including `canonical_equivalent_status=no_close_canonical_match` for cases such as `scheduling-email-assistant`.
- Add an env-configured host-local Codex CLI `/goal` xhigh launcher script that wires `--host-local-acp-launch` with the command/file bridge probe and disables setup stall capping by default (`SKILLSBENCH_BUILD_STALL_TIMEOUT_SEC=0`).

## Validation
- `python3 examples/skillsbench-task-source-preflight-smoke.py`
- Targeted reducer smoke: `test_skillsbench_passed_bool_result_is_countable_zero`
- `python3 -m py_compile scripts/skillsbench_automation_loop.py loopx/benchmark_adapters/skillsbench.py loopx/benchmark_ledger.py loopx/status.py examples/skillsbench_fixtures.py examples/skillsbench-task-source-preflight-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- Launcher dry-run confirmed route `codex-cli-goal-baseline`, `--reasoning-effort xhigh`, `--host-local-acp-launch`, `--remote-command-file-bridge-probe`, and `--build-stall-timeout-sec 0`.
- `python3 examples/control_plane/check-public-boundary-smoke.py`

## Canary / holds
- `loopx canary premerge --from-git-diff` direct checks and Python compile passed.
- First canary run: line-budget failed before compression; runtime-handoff timed out at 120s; public-boundary passed.
- After compression: line-budget passed; risk-profile smokes passed; runtime-handoff and public-boundary timed out inside the canary 120s window.
- Follow-up focused runs passed: `python3 examples/control_plane/runtime-handoff-status-read-path-smoke.py` and `python3 examples/control_plane/check-public-boundary-smoke.py`.
- Manual hold reported: `benchmark_sensitive`; this PR is limited to reducer/preflight/launcher plumbing and does not change task semantics or leaderboard submission behavior.
