### PR TITLE
Refine monitor scheduler window backoff

### DIFF
--- a/examples/control_plane/monitor-scheduler-contract-smoke.py
+++ b/examples/control_plane/monitor-scheduler-contract-smoke.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -22,6 +23,7 @@ AGENT_ID = "codex-product-capability"
 PAST_DUE_AT = "2000-01-01T00:00:00+00:00"
 FUTURE_DUE_AT = "2999-01-01T00:00:00+00:00"
 EXPIRED_AT = "2000-01-01T00:05:00+00:00"
+FROZEN_NOW = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
 FRONTIER_REPLAN_ACK_RUNS = [
     {
         "classification": "monitor_scheduler_replan_ack",
@@ -75,6 +77,7 @@ def monitor_item(
     cadence: str | None = "15m",
     claimed_by: str | None = AGENT_ID,
     expires_at: str | None = None,
+    last_checked_at: str | None = None,
 ) -> dict:
     item = {
         "index": index,
@@ -95,7 +98,17 @@ def monitor_item(
         item["next_due_at"] = next_due_at
     if expires_at:
         item["expires_at"] = expires_at
+    if last_checked_at:
+        item["last_checked_at"] = last_checked_at
     return item
+
+
+def frozen_timestamp_after(minutes: int) -> str:
+    return (FROZEN_NOW + timedelta(minutes=minutes)).isoformat()
+
+
+def frozen_timestamp_before(minutes: int) -> str:
+    return (FROZEN_NOW - timedelta(minutes=minutes)).isoformat()
 
 
 def blocking_handoff_item(*, index: int, todo_id: str = "todo_primary_handoff") -> dict:
@@ -133,16 +146,27 @@ def guard_for(
     agent_id: str = AGENT_ID,
     coordination: dict | None = None,
     latest_runs: list[dict] | None = None,
+    include_scheduler_detail: bool = False,
+    now: datetime = FROZEN_NOW,
 ) -> dict:
-    return build_quota_should_run(
-        status_payload(
-            agent_todo_items=items,
-            coordination=coordination,
-            latest_runs=latest_runs,
-        ),
-        goal_id=GOAL_ID,
-        agent_id=agent_id,
-    )
+    original_scheduler_now = scheduler_hint_module.now_utc
+    original_monitor_now = monitor_todo_module.now_utc
+    scheduler_hint_module.now_utc = lambda: now
+    monitor_todo_module.now_utc = lambda: now
+    try:
+        return build_quota_should_run(
+            status_payload(
+                agent_todo_items=items,
+                coordination=coordination,
+                latest_runs=latest_runs,
+            ),
+            goal_id=GOAL_ID,
+            agent_id=agent_id,
+            include_scheduler_detail=include_scheduler_detail,
+        )
+    finally:
+        scheduler_hint_module.now_utc = original_scheduler_now
+        monitor_todo_module.now_utc = original_monitor_now
 
 
 def assert_scheduler_timestamp_parser_is_shared_and_utc_normalized() -> None:
@@ -176,7 +200,7 @@ def assert_not_due_monitor_waits_quietly() -> None:
     assert guard["agent_todo_summary"]["monitor_due_count"] == 0, guard
 
 
-def assert_not_due_monitor_scheduler_honors_monitor_cadence() -> None:
+def assert_not_due_monitor_scheduler_applies_host_floor_before_cadence() -> None:
     guard = guard_for(
         [
             monitor_item(
@@ -195,9 +219,122 @@ def assert_not_due_monitor_scheduler_honors_monitor_cadence() -> None:
     assert guard["decision"] == "skip", guard
     assert guard["effective_action"] == "monitor_quiet_skip", guard
     assert scheduler["cadence_class"] == "monitor_wait", scheduler
-    assert codex_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=3", scheduler
-    assert codex_app["example_progression_minutes"] == [3, 3, 3, 3], scheduler
-    assert stateful["current_rrule"] == "FREQ=MINUTELY;INTERVAL=3", scheduler
+    assert codex_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=15", scheduler
+    assert codex_app["example_progression_minutes"] == [15, 30, 60, 120], scheduler
+    assert stateful["current_rrule"] == "FREQ=MINUTELY;INTERVAL=15", scheduler
+
+
+def assert_monitor_scheduler_far_window_uses_coarse_backoff() -> None:
+    guard = guard_for(
+        [
+            monitor_item(
+                index=1,
+                todo_id="todo_far_window",
+                priority="P1",
+                cadence="3m",
+                next_due_at=frozen_timestamp_after(90),
+                expires_at=frozen_timestamp_after(150),
+                target_key="far-window-watch",
+            )
+        ],
+        include_scheduler_detail=True,
+    )
+    scheduler = guard["scheduler_hint"]
+    codex_app = scheduler["codex_app"]
+    context = scheduler["cold_path_detail"]["cadence_context"]
+    assert guard["effective_action"] == "monitor_quiet_skip", guard
+    assert context["phase"] == "far_window", context
+    assert context["cap_minutes"] == 90, context
+    assert codex_app["example_progression_minutes"] == [15, 30, 60, 90], scheduler
+    assert codex_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=15", scheduler
+
+
+def assert_monitor_scheduler_near_window_caps_without_breaking_floor() -> None:
+    guard = guard_for(
+        [
+            monitor_item(
+                index=1,
+                todo_id="todo_near_window",
+                priority="P1",
+                cadence="3m",
+                next_due_at=frozen_timestamp_after(37),
+                expires_at=frozen_timestamp_after(100),
+                target_key="near-window-watch",
+            )
+        ],
+        include_scheduler_detail=True,
+    )
+    scheduler = guard["scheduler_hint"]
+    codex_app = scheduler["codex_app"]
+    context = scheduler["cold_path_detail"]["cadence_context"]
+    assert guard["effective_action"] == "monitor_quiet_skip", guard
+    assert context["phase"] == "near_window", context
+    assert context["host_floor_minutes"] == 15, context
+    assert context["cap_minutes"] == 37, context
+    assert codex_app["example_progression_minutes"] == [15, 30, 37, 37], scheduler
+
+
+def assert_monitor_scheduler_near_window_reset_identity_is_stable() -> None:
+    item = monitor_item(
+        index=1,
+        todo_id="todo_near_window_stable_identity",
+        priority="P1",
+        cadence="3m",
+        next_due_at=frozen_timestamp_after(37),
+        expires_at=frozen_timestamp_after(100),
+        target_key="near-window-stable-watch",
+    )
+    first = guard_for([item], include_scheduler_detail=True)
+    later = guard_for(
+        [item],
+        include_scheduler_detail=True,
+        now=FROZEN_NOW + timedelta(minutes=10),
+    )
+    first_scheduler = first["scheduler_hint"]
+    later_scheduler = later["scheduler_hint"]
+    first_context = first_scheduler["cold_path_detail"]["cadence_context"]
+    later_context = later_scheduler["cold_path_detail"]["cadence_context"]
+    assert first_context["phase"] == "near_window", first_context
+    assert later_context["phase"] == "near_window", later_context
+    assert first_context["cap_minutes"] == 37, first_context
+    assert later_context["cap_minutes"] == 27, later_context
+    assert first_scheduler["reset_policy"]["reset_token"] == later_scheduler["reset_policy"]["reset_token"], (
+        first_scheduler,
+        later_scheduler,
+    )
+    assert first_scheduler["cold_path_detail"]["reset_policy_detail"][
+        "reset_profile_signature"
+    ] == later_scheduler["cold_path_detail"]["reset_policy_detail"]["reset_profile_signature"], later_scheduler
+    assert first_scheduler["codex_app"]["example_progression_minutes"] != later_scheduler["codex_app"][
+        "example_progression_minutes"
+    ], later_scheduler
+
+
+def assert_monitor_scheduler_active_window_respects_host_floor() -> None:
+    guard = guard_for(
+        [
+            monitor_item(
+                index=1,
+                todo_id="todo_active_window",
+                priority="P0",
+                cadence="3m",
+                next_due_at=frozen_timestamp_after(3),
+                expires_at=frozen_timestamp_after(40),
+                last_checked_at=frozen_timestamp_before(5),
+                target_key="active-window-watch",
+            )
+        ],
+        include_scheduler_detail=True,
+    )
+    scheduler = guard["scheduler_hint"]
+    codex_app = scheduler["codex_app"]
+    context = scheduler["cold_path_detail"]["cadence_context"]
+    assert guard["effective_action"] == "monitor_quiet_skip", guard
+    assert context["phase"] == "active_window", context
+    assert context["cadence_minutes"] == 3, context
+    assert context["host_floor_minutes"] == 15, context
+    assert codex_app["example_progression_minutes"] == [15, 15, 15, 15], scheduler
+    assert codex_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=15", scheduler
 
 
 def assert_unscheduled_monitor_requires_metadata_repair() -> None:
@@ -294,7 +431,8 @@ def assert_expired_monitor_does_not_catch_up() -> None:
                 expires_at=EXPIRED_AT,
                 target_key="expired-publish-window",
             )
-        ]
+        ],
+        include_scheduler_detail=True,
     )
     lane = guard["work_lane_contract"]
     assert guard["decision"] == "skip", guard
@@ -307,7 +445,10 @@ def assert_expired_monitor_does_not_catch_up() -> None:
     assert monitor_items[0]["expires_at"] == EXPIRED_AT, monitor_items
     scheduler = guard["scheduler_hint"]
     codex_app = scheduler["codex_app"]
+    context = scheduler["cold_path_detail"]["cadence_context"]
     assert scheduler["cadence_class"] == "monitor_wait", scheduler
+    assert context["phase"] == "expired", context
+    assert context["expired_monitor_count"] == 1, context
     assert codex_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=15", scheduler
     assert codex_app["example_progression_minutes"] == [15, 30, 60, 120], scheduler
 
@@ -508,7 +649,11 @@ def assert_other_agent_claimed_work_stays_diagnostic_when_no_current_lane() -> N
 def main() -> int:
     assert_scheduler_timestamp_parser_is_shared_and_utc_normalized()
     assert_not_due_monitor_waits_quietly()
-    assert_not_due_monitor_scheduler_honors_monitor_cadence()
+    assert_not_due_monitor_scheduler_applies_host_floor_before_cadence()
+    assert_monitor_scheduler_far_window_uses_coarse_backoff()
+    assert_monitor_scheduler_near_window_caps_without_breaking_floor()
+    assert_monitor_scheduler_near_window_reset_identity_is_stable()
+    assert_monitor_scheduler_active_window_respects_host_floor()
     assert_unscheduled_monitor_requires_metadata_repair()
     assert_unscheduled_monitor_repair_survives_handoff_gates()
     assert_due_monitor_requires_explicit_attempt()

--- a/examples/control_plane/quota-agent-scoped-user-gate-smoke.py
+++ b/examples/control_plane/quota-agent-scoped-user-gate-smoke.py
@@ -684,12 +684,10 @@ def assert_agent_without_advancement_candidate_and_only_monitor_work_stays_quiet
     assert scheduler["action"] == "backoff_until_material_transition", scheduler
     assert scheduler["codex_app"]["recommended_interval_minutes"] == 15, scheduler
     assert scheduler["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=15", scheduler
-    # Monitor-only backoff is capped by the monitor cadence, so a 15m monitor
-    # should not be backed off beyond its next useful poll interval. Do not
-    # couple the smoke to the number of host-loop progression samples.
+    # A far-future monitor keeps the host floor at 15m, but may back off more
+    # coarsely until the scheduled window gets near.
     progression = scheduler["codex_app"]["example_progression_minutes"]
-    assert len(progression) >= 3, scheduler
-    assert all(item == 15 for item in progression), scheduler
+    assert progression == [15, 30, 60, 120], scheduler
     assert scheduler["unchanged_poll"]["limits"]["codex_cli_tui"] == 3, scheduler
     assert scheduler["unchanged_poll"]["final_quota_replan_check_enabled"] is True, scheduler
     assert scheduler["unchanged_poll"]["after_limits"]["claude_code_loop"] == "stop_loop", scheduler

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -27,6 +27,14 @@ CODEX_APP_SCHEDULER_ACK_HINT_SCHEMA_VERSION = "codex_app_scheduler_ack_hint_v0"
 MONITOR_CADENCE_PATTERN = re.compile(r"^\s*(\d+)\s*([mhd])\s*$", re.IGNORECASE)
 MONITOR_WAIT_PROGRESSION_MINUTES = [15, 30, 60, 120]
 DEFAULT_ACK_CAPABILITIES = {"shell", "filesystem_read", "filesystem_write"}
+MONITOR_WAIT_HOST_FLOOR_MINUTES = 15
+MONITOR_WAIT_NEAR_WINDOW_LEAD_MINUTES = 60
+MONITOR_WAIT_PHASE_RANK = {
+    "active_window": 0,
+    "near_window": 1,
+    "cadence_only": 2,
+    "far_window": 3,
+}
 
 
 def normalize_scheduler_rrule(value: Any) -> str:
@@ -248,29 +256,144 @@ def _monitor_wait_items(payload: dict[str, Any]) -> list[dict[str, Any]]:
     return items
 
 
-def _monitor_wait_cadence_progression(payload: dict[str, Any]) -> list[int] | None:
-    """Cap monitor quiet backoff so the host does not sleep past monitor due."""
+def _monitor_item_identity(item: dict[str, Any]) -> str:
+    for key in ("todo_id", "target_key", "action_kind", "title"):
+        value = str(item.get(key) or "").strip()
+        if value:
+            return value
+    return str(item.get("index") or "monitor")
+
+
+def _minutes_until(value: datetime, current_time: datetime) -> int:
+    return max(1, int(math.ceil((value - current_time).total_seconds() / 60)))
+
+
+def _cap_monitor_progression(*, cap_minutes: int, host_floor_minutes: int) -> list[int]:
+    safe_cap = max(1, int(cap_minutes))
+    safe_floor = max(1, int(host_floor_minutes))
+    return [
+        max(safe_floor, min(interval, safe_cap))
+        for interval in MONITOR_WAIT_PROGRESSION_MINUTES
+    ]
+
+
+def _monitor_wait_item_plan(
+    item: dict[str, Any],
+    *,
+    current_time: datetime,
+) -> dict[str, Any] | None:
+    expires_at = _parse_monitor_timestamp(item.get("expires_at"))
+    if expires_at is not None and expires_at <= current_time:
+        return {
+            "phase": "expired",
+            "selected_monitor_identity": _monitor_item_identity(item),
+        }
+
+    next_due_at = _parse_monitor_timestamp(item.get("next_due_at"))
+    last_checked_at = _parse_monitor_timestamp(item.get("last_checked_at"))
+    cadence_minutes = _monitor_cadence_minutes(item.get("cadence"))
+    host_floor = MONITOR_WAIT_HOST_FLOOR_MINUTES
+    phase: str | None = None
+    cap_candidates: list[int] = []
+    include_next_due_in_reset = False
+
+    if expires_at is not None and last_checked_at is not None and last_checked_at <= current_time:
+        phase = "active_window"
+        if cadence_minutes is not None:
+            cap_candidates.append(max(host_floor, cadence_minutes))
+        if next_due_at is not None and next_due_at > current_time:
+            cap_candidates.append(max(host_floor, _minutes_until(next_due_at, current_time)))
+    elif next_due_at is not None and next_due_at > current_time:
+        minutes_until_due = _minutes_until(next_due_at, current_time)
+        phase = (
+            "near_window"
+            if minutes_until_due <= MONITOR_WAIT_NEAR_WINDOW_LEAD_MINUTES
+            else "far_window"
+        )
+        cap_candidates.append(max(host_floor, minutes_until_due))
+        include_next_due_in_reset = True
+    elif cadence_minutes is not None:
+        phase = "cadence_only"
+        cap_candidates.append(max(host_floor, cadence_minutes))
+
+    if phase is None or not cap_candidates:
+        return None
+
+    cap_minutes = max(host_floor, min(cap_candidates))
+    selected_identity = _monitor_item_identity(item)
+    reset_profile = {
+        "monitor_wait_phase": phase,
+        "monitor_wait_host_floor_minutes": host_floor,
+        "monitor_wait_selected_identity": selected_identity,
+        "monitor_wait_cadence_minutes": cadence_minutes,
+        "monitor_wait_window_start_at": (
+            next_due_at.isoformat()
+            if include_next_due_in_reset and next_due_at is not None
+            else None
+        ),
+        "monitor_wait_window_end_at": expires_at.isoformat() if expires_at is not None else None,
+    }
+    progression = _cap_monitor_progression(
+        cap_minutes=cap_minutes,
+        host_floor_minutes=host_floor,
+    )
+    return {
+        "phase": phase,
+        "selected_monitor_identity": selected_identity,
+        "selected_todo_id": item.get("todo_id"),
+        "selected_target_key": item.get("target_key"),
+        "host_floor_minutes": host_floor,
+        "cap_minutes": cap_minutes,
+        "cadence_minutes": cadence_minutes,
+        "next_due_at": next_due_at.isoformat() if next_due_at is not None else None,
+        "expires_at": expires_at.isoformat() if expires_at is not None else None,
+        "last_checked_at": last_checked_at.isoformat() if last_checked_at is not None else None,
+        "progression_minutes": progression,
+        "reset_profile": reset_profile,
+    }
+
+
+def _monitor_wait_cadence_plan(payload: dict[str, Any]) -> dict[str, Any] | None:
+    """Build phase-aware monitor backoff without turning due horizon into identity."""
 
     current_time = now_utc()
-    caps: list[int] = []
+    plans: list[dict[str, Any]] = []
+    expired_count = 0
     for item in _monitor_wait_items(payload):
-        expires_at = _parse_monitor_timestamp(item.get("expires_at"))
-        if expires_at is not None and expires_at <= current_time:
+        plan = _monitor_wait_item_plan(item, current_time=current_time)
+        if not plan:
             continue
-        item_caps: list[int] = []
-        cadence_minutes = _monitor_cadence_minutes(item.get("cadence"))
-        if cadence_minutes is not None:
-            item_caps.append(cadence_minutes)
-        next_due_at = _parse_monitor_timestamp(item.get("next_due_at"))
-        if next_due_at is not None and next_due_at > current_time:
-            seconds_until_due = (next_due_at - current_time).total_seconds()
-            item_caps.append(max(1, int(math.ceil(seconds_until_due / 60))))
-        if item_caps:
-            caps.append(min(item_caps))
-    if not caps:
+        if plan.get("phase") == "expired":
+            expired_count += 1
+            continue
+        plans.append(plan)
+
+    if not plans:
+        if expired_count:
+            return {
+                "phase": "expired",
+                "expired_monitor_count": expired_count,
+                "host_floor_minutes": MONITOR_WAIT_HOST_FLOOR_MINUTES,
+                "base_progression_minutes": MONITOR_WAIT_PROGRESSION_MINUTES,
+                "progression_minutes": None,
+                "reset_profile": None,
+            }
         return None
-    cap = max(1, min(caps))
-    return [min(interval, cap) for interval in MONITOR_WAIT_PROGRESSION_MINUTES]
+
+    selected = min(
+        plans,
+        key=lambda plan: (
+            int(plan.get("cap_minutes") or 10**9),
+            MONITOR_WAIT_PHASE_RANK.get(str(plan.get("phase") or ""), 99),
+            str(plan.get("selected_monitor_identity") or ""),
+        ),
+    )
+    return {
+        **selected,
+        "base_progression_minutes": MONITOR_WAIT_PROGRESSION_MINUTES,
+        "candidate_count": len(plans),
+        "expired_monitor_count": expired_count,
+    }
 
 
 def build_codex_app_scheduler_ack_event(
@@ -441,6 +564,8 @@ def build_scheduler_hint(
         claude_limit: int | None,
         multiplier: int = 2,
         cadence_progression_override: list[int] | None = None,
+        reset_profile_snapshot_override: dict[str, Any] | None = None,
+        cadence_context_detail: dict[str, Any] | None = None,
         advance_same_identity: bool = True,
     ) -> dict[str, Any]:
         cadence_progression = cadence_progression_override or [
@@ -469,10 +594,11 @@ def build_scheduler_hint(
             "local_scheduler_unchanged_poll_limit": cli_limit,
             "claude_code_loop_unchanged_poll_limit": claude_limit,
         }
+        reset_profile_snapshot = reset_profile_snapshot_override or profile_snapshot
         reset_token_payload = {
             "action": action,
             "identity_snapshot": identity_snapshot,
-            "profile_snapshot": profile_snapshot,
+            "profile_snapshot": reset_profile_snapshot,
         }
         reset_token = hashlib.sha256(
             json.dumps(
@@ -498,6 +624,14 @@ def build_scheduler_hint(
                 default=str,
             ).encode("utf-8")
         ).hexdigest()[:12]
+        reset_profile_signature = hashlib.sha256(
+            json.dumps(
+                reset_profile_snapshot,
+                ensure_ascii=True,
+                sort_keys=True,
+                default=str,
+            ).encode("utf-8")
+        ).hexdigest()[:12]
         reset_policy_detail = {
             "schema_version": SCHEDULER_RESET_POLICY_SCHEMA_VERSION,
             "source": "quota.should-run",
@@ -512,6 +646,7 @@ def build_scheduler_hint(
             "identity_key_count": len(identity_keys),
             "identity_signature": identity_signature,
             "profile_signature": profile_signature,
+            "reset_profile_signature": reset_profile_signature,
             "reset_condition_summary": "token_changed|user_feedback|new_or_reassigned_todo|gate_or_material_transition|active_work_projected",
             "after_reset": "apply_initial_interval_before_backoff",
             "codex_app_tool": "automation_update",
@@ -693,6 +828,8 @@ def build_scheduler_hint(
                 "reset_policy_detail": reset_policy_detail,
                 "stateful_backoff_detail": stateful_backoff_detail,
             }
+            if cadence_context_detail:
+                scheduler_hint["cold_path_detail"]["cadence_context"] = cadence_context_detail
         return scheduler_hint
 
     if (
@@ -772,7 +909,27 @@ def build_scheduler_hint(
         effective_action == "monitor_quiet_skip"
         or recommended_mode == "monitor_quiet_until_material_transition"
     ):
-        monitor_progression = _monitor_wait_cadence_progression(payload)
+        monitor_plan = _monitor_wait_cadence_plan(payload)
+        monitor_progression = (
+            monitor_plan.get("progression_minutes")
+            if isinstance(monitor_plan, dict)
+            else None
+        )
+        monitor_reset_profile = (
+            {
+                "cadence_class": "monitor_wait",
+                "codex_app_initial_interval_minutes": MONITOR_WAIT_HOST_FLOOR_MINUTES,
+                "codex_app_initial_rrule": rrule_for_minutes(MONITOR_WAIT_HOST_FLOOR_MINUTES),
+                "codex_app_max_interval_minutes": 120,
+                "unchanged_poll_backoff_multiplier": 2,
+                "local_scheduler_unchanged_poll_limit": 3,
+                "claude_code_loop_unchanged_poll_limit": 3,
+                **monitor_plan["reset_profile"],
+            }
+            if isinstance(monitor_plan, dict)
+            and isinstance(monitor_plan.get("reset_profile"), dict)
+            else None
+        )
         return hint(
             action="backoff_until_material_transition",
             cadence_class="monitor_wait",
@@ -787,6 +944,8 @@ def build_scheduler_hint(
             cadence_progression_override=(
                 monitor_progression or MONITOR_WAIT_PROGRESSION_MINUTES
             ),
+            reset_profile_snapshot_override=monitor_reset_profile,
+            cadence_context_detail=monitor_plan,
         )
 
     if payload.get("should_run") is False:


### PR DESCRIPTION
## Summary

- Add phase-aware monitor wait scheduling for `far_window`, `near_window`, `active_window`, and `expired` monitor states.
- Apply a 15m host floor so monitor-only automation does not collapse into sub-floor heartbeat intervals.
- Keep reset identity stable by excluding moving due-horizon caps from the reset profile while still using them for the current progression.
- Extend monitor scheduler smoke coverage for the four phases plus near-window reset stability; update adjacent quota-agent smoke for far-window coarse backoff.

## Validation

Focused checks passing on latest `origin/main` after final rebase:

- `git diff --check origin/main...HEAD`
- `python3 -m py_compile loopx/control_plane/scheduler/scheduler_hint.py examples/control_plane/monitor-scheduler-contract-smoke.py examples/control_plane/quota-agent-scoped-user-gate-smoke.py`
- `python3 examples/control_plane/monitor-scheduler-contract-smoke.py`
- `python3 examples/control_plane/quota-agent-scoped-user-gate-smoke.py`
- `python3 examples/control_plane/quota-scheduler-state-ack-smoke.py`
- `python3 examples/control_plane/monitor-poll-policy-smoke.py`
- `python3 examples/control_plane/automation-liveness-state-machine-smoke.py`
- `python3 examples/control_plane/interaction-contract-state-machine-smoke.py`
- `python3 examples/control_plane/control-plane-risk-characterization-smoke.py`
- `python3 examples/control_plane/hot-path-interface-budget-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli check --scan-path loopx/control_plane/scheduler/scheduler_hint.py --scan-path examples/control_plane/monitor-scheduler-contract-smoke.py --scan-path examples/control_plane/quota-agent-scoped-user-gate-smoke.py`

Premerge canary evidence:

- `PYTHONPATH=. python3 -m loopx.cli canary premerge --from-git-diff --tier quick --max-checks-per-family 2 --max-checks-per-profile 4 --timeout-seconds 60 --format json --no-progress`
- Direct checks passed, catalog canaries passed, boundary run passed, side-effect guard clean.
- Gate failed because `risk_profile_run` selected 193 smoke-suite checks and 12 existing risk-profile checks failed; `self_merge_allowed=false`.
- Representative baseline failures were reproduced on detached `origin/main`, including `monitor-poll-writeback-smoke.py`, `decision-freshness-readmodel-smoke.py`, and `active-state-todo-attention-helper-smoke.py`.

## Merge decision

Not self-merging. The focused scheduler contract is validated, but the LoopX premerge gate currently rejects self-merge due existing broad risk-profile failures on main.
