### PR TITLE
Shorten routine premerge canary latency

### DIFF
--- a/examples/canary/premerge-validation-gate-smoke.py
+++ b/examples/canary/premerge-validation-gate-smoke.py
@@ -16,6 +16,7 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.canary.premerge import (  # noqa: E402
     _gate_status,
+    _public_boundary_changed_files_run,
     build_premerge_validation_gate,
     downgrade_inherited_baseline_failures,
 )
@@ -72,9 +73,24 @@ def assert_public_docs_change_adds_boundary_scan() -> None:
     assert "docs_project_content" in classification["surfaces"], payload
     assert classification["public_boundary_scan_recommended"] is True, payload
     boundary_commands = commands_from(payload["boundary_run"])
-    assert boundary_commands == [
-        "python3 examples/control_plane/check-public-boundary-smoke.py"
-    ], payload
+    assert len(boundary_commands) == 1, payload
+    assert boundary_commands[0].startswith("loopx check --scan-path"), payload
+    assert "AGENTS.md" in boundary_commands[0], payload
+
+
+def assert_public_boundary_scan_executes_in_process() -> None:
+    run = _public_boundary_changed_files_run(
+        changed_files=["AGENTS.md"],
+        execute=True,
+        timeout_seconds=60,
+    )
+    assert run["ok"] is True, run
+    assert run["suite"] == "premerge-public-boundary", run
+    assert run["selected_check_count"] == 1, run
+    assert run["executed_check_count"] == 1, run
+    check = run["selected_checks"][0]
+    assert check["status"] == "passed", run
+    assert "AGENTS.md" in check["command"], run
 
 
 def assert_changed_python_gets_compile_check() -> None:
@@ -167,8 +183,10 @@ def assert_cli_premerge_reports_progress_by_default() -> None:
     payload = json.loads(completed.stdout)
     assert payload["schema_version"] == "loopx_premerge_validation_gate_v0", payload
     assert payload["gate"]["status"] == "no_changes", payload
+    assert payload["validation_summary"]["selected_check_count"] == 0, payload
     assert "[loopx canary] premerge start:" in completed.stderr, completed.stderr
     assert "[loopx canary] start direct_checks 1/3:" in completed.stderr, completed.stderr
+    assert "[loopx canary] start catalog_canaries" not in completed.stderr, completed.stderr
     assert "[loopx canary] premerge done:" in completed.stderr, completed.stderr
 
     quiet = subprocess.run(
@@ -304,6 +322,7 @@ def assert_inherited_line_budget_red_is_advisory_only() -> None:
 def main() -> None:
     assert_control_plane_change_selects_state_machine_validation()
     assert_public_docs_change_adds_boundary_scan()
+    assert_public_boundary_scan_executes_in_process()
     assert_changed_python_gets_compile_check()
     assert_benchmark_sensitive_change_blocks_self_merge()
     assert_cli_json_preview()

--- a/examples/control_plane/check-public-boundary-smoke.py
+++ b/examples/control_plane/check-public-boundary-smoke.py
@@ -45,7 +45,17 @@ def run_git(cwd: Path, *args: str) -> subprocess.CompletedProcess[str]:
 def main() -> int:
     with tempfile.TemporaryDirectory() as tmp:
         root = Path(tmp)
-        implicit = run_cli(root, "--format", "json", "check", "--scan-root", str(REPO_ROOT))
+        implicit_project = root / "implicit-project"
+        implicit_project.mkdir()
+        (implicit_project / "README.md").write_text("public docs stay clean\n", encoding="utf-8")
+        implicit = run_cli(
+            root,
+            "--format",
+            "json",
+            "check",
+            "--scan-root",
+            str(implicit_project),
+        )
         if implicit.returncode != 0:
             raise AssertionError(implicit.stderr or implicit.stdout)
         payload = json.loads(implicit.stdout)

--- a/loopx/canary/premerge.py
+++ b/loopx/canary/premerge.py
@@ -6,6 +6,7 @@ import time
 from pathlib import Path
 from typing import Any, Callable
 
+from ..contract import scan_public_boundary
 from .planner import REPO_ROOT
 from .runner import build_canary_smoke_suite_run
 
@@ -74,6 +75,149 @@ LARK_KANBAN_TOKENS = (
 INHERITED_BASELINE_COMMANDS = (
     "repo-python-line-budget-smoke.py",
 )
+
+
+def _synthetic_smoke_suite_run(
+    *,
+    suite: str,
+    execute: bool,
+    timeout_seconds: float,
+    selected_checks: list[dict[str, Any]],
+    note: str,
+) -> dict[str, Any]:
+    executed_checks = selected_checks if execute else []
+    failures = [item for item in selected_checks if item.get("ok") is False]
+    return {
+        "ok": not failures,
+        "schema_version": "canary_smoke_suite_run_v0",
+        "suite": suite,
+        "repo_root": str(REPO_ROOT),
+        "dry_run": not execute,
+        "executes_checks": execute,
+        "writes_evidence": False,
+        "creates_runtime_contract": False,
+        "timeout_seconds": max(1.0, timeout_seconds),
+        "fail_fast": False,
+        "side_effect_guard": {},
+        "offset": 0,
+        "limit": len(selected_checks),
+        "matched_check_count": len(selected_checks),
+        "selected_check_count": len(selected_checks),
+        "executed_check_count": len(executed_checks),
+        "failure_count": len(failures),
+        "git_required_skip_count": 0,
+        "timeout_count": 0,
+        "tracked_side_effect_failure_count": 0,
+        "unsafe_command_count": 0,
+        "warning_count": 0,
+        "warnings": [],
+        "selection_inputs": {"suite": suite, "changed_files": []},
+        "catalog_plan": None,
+        "selected_checks": selected_checks,
+        "failures": failures,
+        "git_required_skips": [],
+        "note": note,
+    }
+
+
+def _empty_smoke_suite_run(
+    *,
+    suite: str,
+    reason: str,
+    execute: bool,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    return _synthetic_smoke_suite_run(
+        suite=suite,
+        execute=execute,
+        timeout_seconds=timeout_seconds,
+        selected_checks=[],
+        note=reason,
+    )
+
+
+def _public_boundary_changed_files_run(
+    *,
+    changed_files: list[str],
+    execute: bool,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    existing_paths = [
+        (REPO_ROOT / path).resolve()
+        for path in _dedupe(changed_files)
+        if (REPO_ROOT / path).exists()
+    ]
+    display_paths: list[str] = []
+    for path in existing_paths:
+        try:
+            display_paths.append(str(path.relative_to(REPO_ROOT.resolve())))
+        except ValueError:
+            display_paths.append(str(path))
+    display_argv = ["loopx", "check"]
+    for path in display_paths:
+        display_argv.extend(["--scan-path", path])
+    check: dict[str, Any] = {
+        "source": "premerge_public_boundary",
+        "tier": "default",
+        "command": " ".join(display_argv),
+        "reason": "scans changed public-boundary files for private material",
+        "normalized": {
+            "ok": True,
+            "display_argv": display_argv,
+        },
+        "status": "ready",
+        "ok": True,
+    }
+    if execute:
+        started = time.monotonic()
+        if not existing_paths:
+            check.update(
+                {
+                    "status": "skipped_no_existing_files",
+                    "ok": True,
+                    "duration_seconds": 0.0,
+                    "stdout_tail": "no existing changed public-boundary files to scan",
+                }
+            )
+        else:
+            boundary = scan_public_boundary(existing_paths, registry={})
+            hits = [str(item) for item in boundary.get("hits") or []]
+            check.update(
+                {
+                    "status": "passed" if boundary.get("ok") else "failed",
+                    "ok": bool(boundary.get("ok")),
+                    "duration_seconds": round(time.monotonic() - started, 3),
+                    "stdout_tail": (
+                        f"public boundary scan clean: {boundary.get('scanned_files')} files"
+                        if boundary.get("ok")
+                        else ""
+                    ),
+                    "stderr_tail": "\n".join(hits)[-800:] if hits else "",
+                    "boundary": {
+                        "scanned_files": boundary.get("scanned_files"),
+                        "skipped_private_state_files": boundary.get("skipped_private_state_files"),
+                        "allowed_hits": boundary.get("allowed_hits"),
+                        "hit_count": len(hits),
+                    },
+                }
+            )
+    payload = _synthetic_smoke_suite_run(
+        suite="premerge-public-boundary",
+        execute=execute,
+        timeout_seconds=timeout_seconds,
+        selected_checks=[check],
+        note=(
+            "Premerge public-boundary validation scans the changed public files "
+            "directly. The full fresh-directory contract smoke remains available "
+            "through the canary catalog/profile suites."
+        ),
+    )
+    payload["selection_inputs"] = {
+        "suite": "premerge-public-boundary",
+        "changed_files": list(changed_files),
+        "scan_paths": display_paths,
+    }
+    return payload
 
 
 def _norm_path(path: str) -> str:
@@ -584,40 +728,51 @@ def build_premerge_validation_gate(
     if py_compile is not None:
         direct_checks.append(py_compile)
 
-    catalog_progress = _section_progress_callback(
-        progress_callback,
-        section="catalog_canaries",
-    )
-    _emit_section_progress(
-        catalog_progress,
-        event="section_started",
-        selected_hint=int(limits["catalog_limit"]),
-    )
-    catalog_run = build_canary_smoke_suite_run(
-        suite="catalog-plan",
-        changed_files=files,
-        include_deep_checks=include_deep,
-        max_checks_per_family=3,
-        max_checks_per_profile=4,
-        limit=int(limits["catalog_limit"]),
-        execute=execute,
-        timeout_seconds=timeout_seconds,
-        fail_fast=fail_fast,
-        progress_callback=catalog_progress if execute else None,
-    )
-    _emit_section_progress(
-        catalog_progress,
-        event="section_finished",
-        status="passed" if catalog_run.get("ok") else "failed",
-        ok=bool(catalog_run.get("ok")),
-        selected_check_count=catalog_run.get("selected_check_count"),
-        executed_check_count=catalog_run.get("executed_check_count"),
-        failure_count=catalog_run.get("failure_count"),
-    )
-    catalog_run = downgrade_inherited_baseline_failures(
-        catalog_run,
-        changed_files=files,
-    )
+    if files:
+        catalog_progress = _section_progress_callback(
+            progress_callback,
+            section="catalog_canaries",
+        )
+        _emit_section_progress(
+            catalog_progress,
+            event="section_started",
+            selected_hint=int(limits["catalog_limit"]),
+        )
+        catalog_run = build_canary_smoke_suite_run(
+            suite="catalog-plan",
+            changed_files=files,
+            include_deep_checks=include_deep,
+            max_checks_per_family=3,
+            max_checks_per_profile=4,
+            limit=int(limits["catalog_limit"]),
+            execute=execute,
+            timeout_seconds=timeout_seconds,
+            fail_fast=fail_fast,
+            progress_callback=catalog_progress if execute else None,
+        )
+        _emit_section_progress(
+            catalog_progress,
+            event="section_finished",
+            status="passed" if catalog_run.get("ok") else "failed",
+            ok=bool(catalog_run.get("ok")),
+            selected_check_count=catalog_run.get("selected_check_count"),
+            executed_check_count=catalog_run.get("executed_check_count"),
+            failure_count=catalog_run.get("failure_count"),
+        )
+        catalog_run = downgrade_inherited_baseline_failures(
+            catalog_run,
+            changed_files=files,
+        )
+    else:
+        catalog_run = _empty_smoke_suite_run(
+            suite="catalog-plan",
+            reason=(
+                "No changed files were provided, so premerge only runs direct "
+                "diff hygiene checks and skips catalog/risk/boundary smokes."
+            ),
+            execute=execute,
+            timeout_seconds=timeout_seconds,
+        )
 
     risk_profiles = list(classification["risk_profiles"])
     risk_profile_run: dict[str, Any] | None = None
@@ -663,13 +818,10 @@ def build_premerge_validation_gate(
             section="public_boundary",
         )
         _emit_section_progress(boundary_progress, event="section_started", selected_hint=1)
-        boundary_run = build_canary_smoke_suite_run(
-            suite="default-public",
-            scripts=["examples/control_plane/check-public-boundary-smoke.py"],
+        boundary_run = _public_boundary_changed_files_run(
+            changed_files=files,
             execute=execute,
             timeout_seconds=timeout_seconds,
-            fail_fast=fail_fast,
-            progress_callback=boundary_progress if execute else None,
         )
         _emit_section_progress(
             boundary_progress,


### PR DESCRIPTION
## Summary

This PR trims routine LoopX premerge latency without weakening the public/private boundary gate:

- no-change premerge runs only direct diff hygiene and reports `selected=0` instead of launching catalog/risk/boundary canaries;
- public-boundary premerge scans the changed files in-process through `scan_public_boundary` instead of running the full fresh-directory boundary smoke;
- the full public-boundary smoke remains available through catalog/profile validation, and its missing-registry case now scans a tiny fixture instead of the full repo.

## Observed Impact

Before this batch, the residual canary-runner/public-boundary path was dominated by routine no-change catalog selection and full boundary smoke startup:

- `examples/canary/premerge-validation-gate-smoke.py`: about 15.15s before, 2.22s after this change.
- no-change quick premerge: about 5.6s before, 0.53s after this change, with `selected_check_count=0`.
- `examples/control_plane/check-public-boundary-smoke.py`: about 14.5s before, 11.14s after the narrow fixture change; intentionally still a full smoke.
- `loopx canary premerge --from-git-diff` for this PR: 19.80s, with public-boundary validation reduced to one in-process changed-file scan.

## Validation

- `python3 -m py_compile loopx/canary/premerge.py examples/canary/premerge-validation-gate-smoke.py examples/control_plane/check-public-boundary-smoke.py`
- `python3 -m loopx.cli check --scan-path loopx/canary/premerge.py --scan-path examples/canary/premerge-validation-gate-smoke.py --scan-path examples/control_plane/check-public-boundary-smoke.py`
- `/usr/bin/time -p python3 examples/canary/premerge-validation-gate-smoke.py` -> passed, real 2.22s
- `/usr/bin/time -p python3 examples/control_plane/check-public-boundary-smoke.py` -> passed, real 11.14s
- `/usr/bin/time -p loopx canary premerge --tier quick --timeout-seconds 60` -> no_changes, selected=0, real 0.53s
- `/usr/bin/time -p loopx canary premerge --from-git-diff` -> passed, selected=17, failures=0, manual_holds=0, real 19.80s

## Residual Risk

The standard diff gate still spends around 20s on catalog/risk-profile smokes. This PR deliberately does not split or cache those remaining checks because they are the durable canary-runner coverage for a canary-runner diff. Further optimization should profile that residual path separately and only move checks out of the default gate when equivalent coverage remains.
