### PR TITLE
Fix scheduler ack capability context

### DIFF
--- a/examples/control_plane/quota-scheduler-state-ack-smoke.py
+++ b/examples/control_plane/quota-scheduler-state-ack-smoke.py
@@ -330,6 +330,28 @@ def assert_scheduler_ack_plan_validation() -> None:
         ack_args["identity_signature"],
         "--execute",
     ], ack_hint
+    with_capabilities = active_payload()
+    with_capabilities["capability_gate"] = {
+        "available": ["shell", "network", "benchmark_runner"],
+    }
+    capability_hint = build_scheduler_hint(
+        with_capabilities,
+        agent_scope_frontier_actions=AGENT_SCOPE_ACTIONS,
+    )
+    capability_ack_hint = capability_hint["codex_app"]["ack_hint"]
+    capability_ack_args = capability_ack_hint["args"]
+    capability_cli_args = capability_ack_hint["cli_args"]
+    assert capability_ack_args["available_capabilities"] == [
+        "network",
+        "benchmark_runner",
+    ], capability_ack_hint
+    assert capability_cli_args.count("--available-capability") == 2, capability_ack_hint
+    for capability in capability_ack_args["available_capabilities"]:
+        capability_index = capability_cli_args.index(capability)
+        assert capability_cli_args[capability_index - 1] == "--available-capability", (
+            capability,
+            capability_ack_hint,
+        )
     plan = build_scheduler_ack_plan(
         {"scheduler_hint": first},
         agent_id=ack_args["agent_id"],
@@ -655,7 +677,7 @@ def assert_cli_scheduler_ack_uses_should_run_lookback() -> None:
         quota_command="scheduler-ack",
         goal_id="scheduler-state-ack-smoke",
         agent_id="codex-side-agent",
-        available_capabilities=None,
+        available_capabilities=["shell", "network", "benchmark_runner"],
         include_scheduler_detail=False,
         slots=1,
         source="heartbeat",
@@ -702,6 +724,11 @@ def assert_cli_scheduler_ack_uses_should_run_lookback() -> None:
     assert seen["limit"] == AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK, seen
     assert seen["payload"] == {"ok": True, "mode": "scheduler-ack", "dry_run": True}, seen
     ack_kwargs = seen["ack_kwargs"]
+    assert ack_kwargs["available_capabilities"] == [
+        "shell",
+        "network",
+        "benchmark_runner",
+    ], seen
     assert ack_kwargs["reset_token"] == "fixture-reset-token", seen
     assert ack_kwargs["identity_signature"] == "fixture-identity-signature", seen
 

--- a/loopx/cli_commands/quota.py
+++ b/loopx/cli_commands/quota.py
@@ -236,6 +236,7 @@ def handle_quota_command(
                 goal_id=args.goal_id,
                 execute=bool(args.execute),
                 agent_id=args.agent_id,
+                available_capabilities=args.available_capabilities,
                 surface=args.surface,
                 state_key=args.state_key,
                 applied_rrule=args.applied_rrule,

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -26,6 +26,7 @@ CODEX_APP_STATEFUL_BACKOFF_SCHEMA_VERSION = "codex_app_stateful_backoff_v0"
 CODEX_APP_SCHEDULER_ACK_HINT_SCHEMA_VERSION = "codex_app_scheduler_ack_hint_v0"
 MONITOR_CADENCE_PATTERN = re.compile(r"^\s*(\d+)\s*([mhd])\s*$", re.IGNORECASE)
 MONITOR_WAIT_PROGRESSION_MINUTES = [15, 30, 60, 120]
+DEFAULT_ACK_CAPABILITIES = {"shell", "filesystem_read", "filesystem_write"}
 
 
 def normalize_scheduler_rrule(value: Any) -> str:
@@ -63,6 +64,7 @@ def build_codex_app_scheduler_ack_hint(
     applied_rrule: Any,
     reset_token: Any,
     identity_signature: Any,
+    available_capabilities: Any = None,
     surface: str = CODEX_APP_SURFACE,
     state_key: str = CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
 ) -> dict[str, Any]:
@@ -73,6 +75,16 @@ def build_codex_app_scheduler_ack_hint(
     safe_state_key = str(state_key or "").strip()
     safe_reset_token = str(reset_token or "").strip()
     safe_identity_signature = str(identity_signature or "").strip()
+    safe_available_capabilities: list[str] = []
+    if isinstance(available_capabilities, (list, tuple, set)):
+        for capability in available_capabilities:
+            safe_capability = str(capability or "").strip()
+            if (
+                safe_capability
+                and safe_capability not in DEFAULT_ACK_CAPABILITIES
+                and safe_capability not in safe_available_capabilities
+            ):
+                safe_available_capabilities.append(safe_capability)
     cli_args = [
         "quota",
         "scheduler-ack",
@@ -80,33 +92,42 @@ def build_codex_app_scheduler_ack_hint(
         safe_goal_id,
         "--agent-id",
         safe_agent_id,
-        "--surface",
-        safe_surface,
-        "--state-key",
-        safe_state_key,
-        "--applied-rrule",
-        safe_rrule,
-        "--reset-token",
-        safe_reset_token,
-        "--identity-signature",
-        safe_identity_signature,
-        "--execute",
     ]
+    for capability in safe_available_capabilities:
+        cli_args.extend(["--available-capability", capability])
+    cli_args.extend(
+        [
+            "--surface",
+            safe_surface,
+            "--state-key",
+            safe_state_key,
+            "--applied-rrule",
+            safe_rrule,
+            "--reset-token",
+            safe_reset_token,
+            "--identity-signature",
+            safe_identity_signature,
+            "--execute",
+        ]
+    )
+    args = {
+        "goal_id": safe_goal_id,
+        "agent_id": safe_agent_id,
+        "surface": safe_surface,
+        "state_key": safe_state_key,
+        "applied_rrule": safe_rrule,
+        "reset_token": safe_reset_token,
+        "identity_signature": safe_identity_signature,
+    }
+    if safe_available_capabilities:
+        args["available_capabilities"] = safe_available_capabilities
     return {
         "schema_version": CODEX_APP_SCHEDULER_ACK_HINT_SCHEMA_VERSION,
         "after": "automation_update_rrule_success",
         "command": "quota scheduler-ack",
         "execute": True,
         "cli_args": cli_args,
-        "args": {
-            "goal_id": safe_goal_id,
-            "agent_id": safe_agent_id,
-            "surface": safe_surface,
-            "state_key": safe_state_key,
-            "applied_rrule": safe_rrule,
-            "reset_token": safe_reset_token,
-            "identity_signature": safe_identity_signature,
-        },
+        "args": args,
         "no_spend": True,
     }
 
@@ -381,6 +402,16 @@ def build_scheduler_hint(
         or execution_obligation.get("spend_policy")
         or heartbeat_recommendation.get("spend_policy")
     )
+    capability_gate = (
+        payload.get("capability_gate")
+        if isinstance(payload.get("capability_gate"), dict)
+        else {}
+    )
+    scheduler_ack_capabilities = (
+        capability_gate.get("available")
+        if isinstance(capability_gate.get("available"), list)
+        else []
+    )
     identity_keys = [
         "goal_id",
         "agent_identity.agent_id",
@@ -602,6 +633,7 @@ def build_scheduler_hint(
                     applied_rrule=current_rrule,
                     reset_token=reset_token,
                     identity_signature=identity_signature,
+                    available_capabilities=scheduler_ack_capabilities,
                 )
         scheduler_hint = {
             "schema_version": SCHEDULER_HINT_SCHEMA_VERSION,

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -2437,6 +2437,7 @@ def record_quota_scheduler_ack(
     goal_id: str,
     execute: bool = False,
     agent_id: str | None = None,
+    available_capabilities: Any = None,
     surface: str = CODEX_APP_SURFACE,
     state_key: str = CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
     applied_rrule: str | None = None,
@@ -2448,7 +2449,12 @@ def record_quota_scheduler_ack(
     safe_agent_id = normalize_todo_claimed_by(agent_id)
     safe_surface = str(surface or CODEX_APP_SURFACE).strip() or CODEX_APP_SURFACE
     safe_state_key = str(state_key or CODEX_APP_STATEFUL_BACKOFF_STATE_KEY).strip()
-    before = build_quota_should_run(status_payload, goal_id=safe_goal_id, agent_id=safe_agent_id)
+    before = build_quota_should_run(
+        status_payload,
+        goal_id=safe_goal_id,
+        agent_id=safe_agent_id,
+        available_capabilities=available_capabilities,
+    )
     raw_runtime_root = status_payload.get("runtime_root")
     if not raw_runtime_root:
         raise ValueError("status payload does not include runtime_root")


### PR DESCRIPTION
Summary
- Include non-default available capabilities in Codex App scheduler ack hints so the emitted CLI args reproduce the same capability-aware should-run decision.
- Pass scheduler-ack available capabilities through the CLI handler into quota recomputation.
- Extend quota scheduler ack smoke coverage for capability-aware ack hints and handler propagation.

Changed surfaces
- loopx/control_plane/scheduler/scheduler_hint.py
- loopx/cli_commands/quota.py
- loopx/quota.py
- examples/control_plane/quota-scheduler-state-ack-smoke.py

Validation
- python3 examples/control_plane/quota-scheduler-state-ack-smoke.py
- python3 examples/control_plane/quota-scheduler-hint-compaction-smoke.py
- python3 examples/control_plane/quota-scheduler-policy-smoke.py
- PYTHONPATH=$PWD python3 -m loopx.cli check on changed files
- PYTHONPATH=$PWD python3 -m loopx.cli canary premerge --from-git-diff: passed, 17 checks, 0 failures, 0 manual holds
- Live source validation against loopx-meta: generated ack_hint included network/benchmark_runner capability args and scheduler-ack wrote the matching scheduler state; follow-up should-run reported apply_needed=false.

Risk
- Narrow scheduler/control-plane contract fix. No benchmark runner semantics, scoring behavior, credentials, raw logs, or private artifacts are included.