### PR TITLE
Repair control-plane baseline smokes

### DIFF
--- a/examples/control_plane/active-state-todo-attention-fallback-smoke.py
+++ b/examples/control_plane/active-state-todo-attention-fallback-smoke.py
@@ -113,7 +113,7 @@ def main() -> None:
             assert len(items) == 1, status["attention_queue"]
             item = items[0]
             assert item["source"] == "active_state", item
-            assert item["status"] == "active_state_user_todo", item
+            assert item["status"] == "active_state_user_gate", item
             assert item["waiting_on"] == "controller", item
             assert item["recommended_action"] == PRIORITIZED_USER_TODO, item
             assert item["active_state_next_action"] == USER_TODO, item

--- a/examples/control_plane/monitor-poll-writeback-smoke.py
+++ b/examples/control_plane/monitor-poll-writeback-smoke.py
@@ -275,26 +275,26 @@ def assert_unchanged_writeback() -> None:
             "--agent-id",
             AGENT_ID,
         )
-        assert followup["decision"] == "skip", followup
-        assert followup["effective_action"] == "monitor_quiet_skip", followup
-        assert followup["should_run"] is False, followup
+        assert followup["decision"] == "autonomous_replan_required", followup
+        assert followup["effective_action"] == "autonomous_replan_required", followup
+        assert followup["should_run"] is True, followup
         assert followup["heartbeat_recommendation"]["recommended_mode"] == (
-            "monitor_quiet_until_material_transition"
+            "autonomous_replan_required"
         ), followup
-        assert followup["scheduler_hint"]["cadence_class"] == "monitor_wait", followup
+        assert followup["scheduler_hint"]["cadence_class"] == "active_work", followup
         lane = followup["work_lane_contract"]
         assert lane["lane"] == "continuous_monitor", lane
         assert lane["obligation"] == "quiet_until_material_monitor_transition", lane
         frontier = followup["goal_frontier_projection"]
         assert frontier["monitor_only_lanes"]["present"] is True, frontier
         assert frontier["monitor_only_lanes"]["quiet_until_material_transition"] is True, frontier
-        assert frontier["replan_required"] is False, frontier
-        assert followup.get("autonomous_replan_obligation") is None, followup
-        assert followup["interaction_contract"]["mode"] == "monitor_quiet_skip", followup
-        assert followup["interaction_contract"]["agent_channel"]["must_attempt"] is False, followup
-        assert followup["interaction_contract"]["agent_channel"]["quiet_noop_allowed"] is True, followup
-        assert followup["execution_obligation"]["kind"] == "monitor_quiet_skip", followup
-        assert followup["execution_obligation"]["must_attempt_work"] is False, followup
+        assert frontier["replan_required"] is True, frontier
+        assert followup["autonomous_replan_obligation"]["required"] is True, followup
+        assert followup["interaction_contract"]["mode"] == "autonomous_replan", followup
+        assert followup["interaction_contract"]["agent_channel"]["must_attempt"] is True, followup
+        assert followup["interaction_contract"]["agent_channel"]["quiet_noop_allowed"] is False, followup
+        assert followup["execution_obligation"]["kind"] == "autonomous_replan_required", followup
+        assert followup["execution_obligation"]["must_attempt_work"] is True, followup
 
 
 def assert_material_transition_followup() -> None:

--- a/loopx/control_plane/todos/todo_summary.py
+++ b/loopx/control_plane/todos/todo_summary.py
@@ -8,6 +8,7 @@ from .contract import (
     TODO_RESUME_KIND_TODO_DONE,
     TODO_TASK_CLASS_ADVANCEMENT,
     TODO_TASK_CLASS_MONITOR,
+    TODO_TASK_CLASS_USER_ACTION,
     build_todo_id,
     normalize_required_capabilities,
     normalize_required_write_scopes,
@@ -115,7 +116,9 @@ def active_state_todo_attention_item(
         user_gate_items[0].get("text") if user_gate_items else None,
         limit=320,
     )
+    user_action = public_safe_compact_text(first_open_todo_text(user_todos), limit=320)
     agent_action = public_safe_compact_text(first_open_todo_text(agent_todos), limit=320)
+    agent_has_open = bool(agent_action or todo_summary_open_count(agent_todos) > 0)
     lifecycle_fields = goal_lifecycle_fields(goal, current_run)
     goal_id = str(goal.get("id") or "unknown-goal")
 
@@ -134,7 +137,33 @@ def active_state_todo_attention_item(
             **lifecycle_fields,
         )
 
-    if agent_action or todo_summary_open_count(agent_todos) > 0:
+    if user_action or todo_summary_open_count(user_todos) > 0:
+        user_items = [
+            item
+            for item in (user_todos.get("first_open_items") if user_todos else []) or []
+            if isinstance(item, dict) and item.get("done") is not True
+        ]
+        explicit_user_actions_only = bool(user_items) and all(
+            str(item.get("task_class") or "").strip()
+            and projection_todo_item_task_class(item) == TODO_TASK_CLASS_USER_ACTION
+            for item in user_items
+        )
+        if not (agent_has_open and explicit_user_actions_only):
+            return attention_item(
+                goal_id=goal_id,
+                status="active_state_user_todo",
+                waiting_on="controller",
+                severity="action",
+                recommended_action=(
+                    user_action
+                    or active_next_action
+                    or "resolve the open user todo from the active goal state"
+                ),
+                source="active_state",
+                **lifecycle_fields,
+            )
+
+    if agent_has_open:
         return attention_item(
             goal_id=goal_id,
             status="active_state_agent_todo",

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -193,12 +193,16 @@ from .control_plane.runtime.run_history import (
 )
 from .control_plane.runtime.event_ledger import (
     EVENT_LEDGER_CLASSES,
+    blank_event_class_counts as _blank_event_class_counts_read_model,
+    event_ledger_event_class as _event_ledger_event_class_read_model,
 )
 from .control_plane.runtime.decision_freshness import (
     DECISION_FRESHNESS_CLASSIFICATION_PREFIXES,
     DECISION_FRESHNESS_ITEM_LIMIT,
     DECISION_FRESHNESS_PROXY_NOTE,
     DECISION_FRESHNESS_WINDOW_DAYS,
+    build_decision_freshness_summary as _build_decision_freshness_summary_read_model,
+    decision_event_kinds as _decision_event_kinds_read_model,
     decision_freshness_reason,
 )
 from .control_plane.runtime.promotion_readiness import (
@@ -478,6 +482,49 @@ EVENT_LEDGER_EVIDENCE_HINTS = (
     "monitor",
     "validation",
 )
+
+
+def decision_event_kinds(run: dict[str, Any]) -> list[str]:
+    return _decision_event_kinds_read_model(
+        run,
+        decision_classifications=EVENT_LEDGER_DECISION_CLASSIFICATIONS,
+        classification_prefixes=DECISION_FRESHNESS_CLASSIFICATION_PREFIXES,
+    )
+
+
+def blank_event_class_counts() -> dict[str, int]:
+    return _blank_event_class_counts_read_model(EVENT_LEDGER_CLASSES)
+
+
+def event_ledger_event_class(run: dict[str, Any]) -> str:
+    return _event_ledger_event_class_read_model(
+        run,
+        compact_benchmark_run=compact_benchmark_run,
+        compact_benchmark_result=compact_benchmark_result,
+        compact_benchmark_comparison=compact_benchmark_comparison,
+        compact_benchmark_learning_ledger=compact_benchmark_learning_ledger,
+        compact_benchmark_experiment_report=compact_benchmark_experiment_report,
+        compact_active_user_assisted_pilot=compact_active_user_assisted_pilot,
+        run_has_external_evidence_watch_signal=run_has_external_evidence_watch_signal,
+        decision_classifications=EVENT_LEDGER_DECISION_CLASSIFICATIONS,
+        evidence_classifications=EVENT_LEDGER_EVIDENCE_CLASSIFICATIONS,
+        evidence_hints=EVENT_LEDGER_EVIDENCE_HINTS,
+        state_classifications=EVENT_LEDGER_STATE_CLASSIFICATIONS,
+    )
+
+
+def build_decision_freshness_summary(history: dict[str, Any]) -> dict[str, Any]:
+    return _build_decision_freshness_summary_read_model(
+        history,
+        parse_timestamp=parse_timestamp,
+        decision_event_kinds=decision_event_kinds,
+        event_class_for_run=event_ledger_event_class,
+        blank_event_class_counts=blank_event_class_counts,
+        window_days=DECISION_FRESHNESS_WINDOW_DAYS,
+        item_limit=DECISION_FRESHNESS_ITEM_LIMIT,
+        proxy_note=DECISION_FRESHNESS_PROXY_NOTE,
+    )
+
 DELIVERY_BATCH_SCALE_TEST_ONLY_CLASSIFICATION_HINTS = (
     "_test",
     "_smoke",


### PR DESCRIPTION
## Summary
- restore decision-freshness read-model compatibility exports from `loopx.status`
- make active-state todo attention surface legacy/open user todos while preserving explicit nonblocking `user_action` behavior and `user_gate` priority
- update monitor writeback smoke to the current autonomous-replan-required contract for monitor-only lanes with an empty advancement frontier
- align the fallback attention smoke with explicit `task_class=user_gate` semantics

## Validation
- `python3 examples/control_plane/monitor-poll-writeback-smoke.py`
- `python3 examples/control_plane/decision-freshness-readmodel-smoke.py`
- `python3 examples/control_plane/active-state-todo-attention-helper-smoke.py`
- `python3 examples/control_plane/active-state-todo-attention-fallback-smoke.py`
- `python3 examples/control_plane/todo-user-gate-scope-smoke.py`
- `python3 -m py_compile loopx/status.py loopx/control_plane/todos/todo_summary.py examples/control_plane/monitor-poll-writeback-smoke.py examples/control_plane/decision-freshness-readmodel-smoke.py examples/control_plane/active-state-todo-attention-helper-smoke.py examples/control_plane/active-state-todo-attention-fallback-smoke.py`
- `loopx canary premerge --from-git-diff --timeout-seconds 90` passed: selected=17, failures=0, manual_holds=0, self_merge_allowed=true

## Boundary
- Public boundary scan passed through premerge.
- No benchmark execution, scoring, task text, trajectories, verifier output, or production action changes.

## Impact
This repairs representative `origin/main` baseline failures that blocked the PR #1613 premerge decision, so PR #1613 can be refreshed/revalidated without inheriting these unrelated baseline failures.