### PR TITLE
Fix quick premerge risk-profile skip

### DIFF
--- a/examples/canary/premerge-validation-gate-smoke.py
+++ b/examples/canary/premerge-validation-gate-smoke.py
@@ -78,6 +78,19 @@ def assert_public_docs_change_adds_boundary_scan() -> None:
     assert "AGENTS.md" in boundary_commands[0], payload
 
 
+def assert_quick_public_docs_change_skips_risk_profile_smokes() -> None:
+    payload = build_premerge_validation_gate(
+        changed_files=["README.md"],
+        tier="quick",
+        execute=False,
+    )
+    assert payload["classification"]["risk_profiles"] == ["docs-project-content-ops"], payload
+    assert payload["risk_profile_run"] is None, payload
+    assert payload["boundary_run"]["selected_check_count"] == 1, payload
+    assert payload["catalog_run"]["selected_check_count"] <= 3, payload
+    assert payload["validation_summary"]["selected_check_count"] <= 4, payload
+
+
 def assert_public_boundary_scan_executes_in_process() -> None:
     run = _public_boundary_changed_files_run(
         changed_files=["AGENTS.md"],
@@ -322,6 +335,7 @@ def assert_inherited_line_budget_red_is_advisory_only() -> None:
 def main() -> None:
     assert_control_plane_change_selects_state_machine_validation()
     assert_public_docs_change_adds_boundary_scan()
+    assert_quick_public_docs_change_skips_risk_profile_smokes()
     assert_public_boundary_scan_executes_in_process()
     assert_changed_python_gets_compile_check()
     assert_benchmark_sensitive_change_blocks_self_merge()

--- a/loopx/canary/premerge.py
+++ b/loopx/canary/premerge.py
@@ -776,7 +776,11 @@ def build_premerge_validation_gate(
 
     risk_profiles = list(classification["risk_profiles"])
     risk_profile_run: dict[str, Any] | None = None
-    if risk_profiles:
+    profile_limit = int(limits["profile_limit"])
+    run_risk_profiles = bool(risk_profiles) and not (
+        tier == "quick" and profile_limit == 0
+    )
+    if run_risk_profiles:
         risk_progress = _section_progress_callback(
             progress_callback,
             section="risk_profile_smokes",
@@ -785,13 +789,13 @@ def build_premerge_validation_gate(
             risk_progress,
             event="section_started",
             profiles=risk_profiles,
-            selected_hint=int(limits["profile_limit"]),
+            selected_hint=profile_limit,
         )
         risk_profile_run = build_canary_smoke_suite_run(
             suite="default-public",
             profiles=risk_profiles,
             include_deep_checks=include_deep,
-            limit=int(limits["profile_limit"]),
+            limit=profile_limit,
             execute=execute,
             timeout_seconds=timeout_seconds,
             fail_fast=fail_fast,


### PR DESCRIPTION
## Summary
- keep quick-tier premerge from running risk-profile smokes when the tier limit is zero
- add a regression smoke for quick public-doc changes so the public-boundary fast path remains bounded

## Validation
- python3 -m py_compile loopx/canary/premerge.py examples/canary/premerge-validation-gate-smoke.py
- python3 examples/canary/premerge-validation-gate-smoke.py
- loopx --format json canary premerge --changed-file README.md --tier quick --no-progress --timeout-seconds 120
- loopx --format json check --scan-path loopx/canary/premerge.py --scan-path examples/canary/premerge-validation-gate-smoke.py
- loopx --format json canary premerge --from-git-diff --no-progress --timeout-seconds 120