### PR TITLE
Repair SkillsBench CLI goal pre-bridge recovery

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -753,6 +753,13 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
         == "typed_goal_resubmit"
     )
     assert (
+        codex_cli_tui_pre_bridge_recovery_action(
+            "Goal active\nerror seen\npress enter to retry\n› ",
+            stage="pre_bridge_tui_error_prompt",
+        )
+        == "typed_goal_resubmit"
+    )
+    assert (
         codex_cli_tui_pre_bridge_terminal_stage(
             first_turn_terminal_timeout_capture,
             prompt_visible=True,
@@ -1155,11 +1162,77 @@ def _assert_cli_goal_active_timeout_is_public_countability_stage() -> None:
         "skillsbench_codex_cli_goal_uncountable_pre_bridge_model_timeout"
     )
     assert (
-        trace["codex_cli_goal_tui_post_bridge_recovery_action"]
+        trace["codex_cli_goal_tui_pre_bridge_recovery_action"]
         == "typed_goal_resubmit"
     )
+    assert trace["codex_cli_goal_tui_pre_bridge_recovery_attempt_count"] == 2
+    assert trace["codex_cli_goal_tui_post_bridge_recovery_action"] == ""
+    assert trace["codex_cli_goal_tui_post_bridge_recovery_attempt_count"] == 0
+    public_prerequisites = _public_runner_prerequisites(plan["runner_prerequisites"])
+    assert (
+        public_prerequisites["codex_cli_goal_tui_pre_bridge_recovery_attempt_count"]
+        == 2
+    )
+    assert public_prerequisites[
+        "codex_cli_goal_tui_pre_bridge_recovery_actions"
+    ] == ["typed_goal_resubmit"]
     contract = compact["codex_cli_goal_countability_contract"]
     assert contract["goal_stage"] == "pre_bridge_tui_model_timeout", contract
+
+    with tempfile.TemporaryDirectory() as temp:
+        trace_dir = Path(temp) / "trace"
+        trace_dir.mkdir(parents=True)
+        (trace_dir / "legacy-pre-bridge.compact.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": (
+                        "skillsbench_host_local_acp_relay_public_trace_v0"
+                    ),
+                    "ok": False,
+                    "trace_kind": "codex_cli_goal_tui",
+                    "boundary": {
+                        "raw_command_recorded": False,
+                        "raw_stdout_recorded": False,
+                        "raw_stderr_recorded": False,
+                        "credential_values_recorded": False,
+                    },
+                    "codex_cli_goal": {
+                        "stage": "pre_bridge_tui_error_prompt",
+                        "goal_active_observed": True,
+                        "goal_terminal_observed": False,
+                        "first_action_observed": False,
+                        "bridge_request_count": 0,
+                        "task_facing_success_count": 0,
+                        "post_bridge_recovery_attempt_count": 2,
+                        "post_bridge_recovery_action": "press_enter",
+                        "post_bridge_recovery_skip_reason": "retry_limit_reached",
+                        "raw_tui_capture_recorded": False,
+                        "raw_task_text_recorded": False,
+                        "raw_stdout_recorded": False,
+                        "raw_stderr_recorded": False,
+                        "credential_values_recorded": False,
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        plan = {
+            "route": CODEX_CLI_GOAL_BASELINE_ROUTE,
+            "host_local_acp_relay_trace_dir": str(trace_dir),
+            "runner_prerequisites": {},
+        }
+        trace = {}
+        _merge_host_local_acp_relay_trace_summary(plan, trace)
+
+    assert trace["codex_cli_goal_tui_pre_bridge_recovery_attempt_count"] == 2
+    assert trace["codex_cli_goal_tui_pre_bridge_recovery_action"] == "press_enter"
+    assert (
+        trace["codex_cli_goal_tui_pre_bridge_recovery_skip_reason"]
+        == "retry_limit_reached"
+    )
+    assert trace["codex_cli_goal_tui_post_bridge_recovery_attempt_count"] == 0
+    assert trace["codex_cli_goal_tui_post_bridge_recovery_action"] == ""
 
     with tempfile.TemporaryDirectory() as temp:
         trace_dir = Path(temp) / "trace"

--- a/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
+++ b/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
@@ -130,6 +130,10 @@ def codex_cli_tui_pre_bridge_recovery_action(capture: str, *, stage: str) -> str
         "pre_bridge_tui_error_prompt",
     }:
         return ""
+    if stage == "pre_bridge_tui_error_prompt" and codex_cli_tui_input_prompt_visible(
+        capture
+    ):
+        return "typed_goal_resubmit"
     if _capture_has_retry_affordance(capture):
         return "press_enter"
     if codex_cli_tui_input_prompt_visible(capture):

--- a/loopx/benchmark_adapters/skillsbench_codex_goal_trace.py
+++ b/loopx/benchmark_adapters/skillsbench_codex_goal_trace.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def new_codex_cli_goal_recovery_summary() -> dict[str, Any]:
+    return {
+        "pre_bridge_attempt_count": 0,
+        "pre_bridge_actions": [],
+        "pre_bridge_skip_reasons": [],
+        "post_bridge_attempt_count": 0,
+        "post_bridge_actions": [],
+        "post_bridge_skip_reasons": [],
+    }
+
+
+def _append_unique(values: list[str], value: object, *, limit: int) -> None:
+    if not isinstance(value, str) or not value:
+        return
+    safe_value = value[:limit]
+    if safe_value not in values:
+        values.append(safe_value)
+
+
+def merge_codex_cli_goal_recovery_trace(
+    summary: dict[str, Any],
+    goal_trace: dict[str, Any],
+) -> None:
+    """Accumulate public-safe pre/post bridge TUI recovery counters.
+
+    Older traces wrote pre-bridge retry facts into the post-bridge fields. The
+    stage is the durable discriminator, so preserve compatibility by projecting
+    those legacy fields into the pre-bridge summary when stage starts with
+    ``pre_bridge_``.
+    """
+
+    stage = goal_trace.get("stage")
+    stage_is_pre_bridge = isinstance(stage, str) and stage.startswith("pre_bridge_")
+    phase = "pre_bridge" if stage_is_pre_bridge else "post_bridge"
+    attempts = goal_trace.get(f"{phase}_recovery_attempt_count")
+    if attempts is None and stage_is_pre_bridge:
+        attempts = goal_trace.get("post_bridge_recovery_attempt_count")
+    if isinstance(attempts, int) and not isinstance(attempts, bool):
+        summary[f"{phase}_attempt_count"] += max(0, attempts)
+
+    action = goal_trace.get(f"{phase}_recovery_action")
+    if not action and stage_is_pre_bridge:
+        action = goal_trace.get("post_bridge_recovery_action")
+    _append_unique(summary[f"{phase}_actions"], action, limit=40)
+
+    skip_reason = goal_trace.get(f"{phase}_recovery_skip_reason")
+    if not skip_reason and stage_is_pre_bridge:
+        skip_reason = goal_trace.get("post_bridge_recovery_skip_reason")
+    _append_unique(summary[f"{phase}_skip_reasons"], skip_reason, limit=80)
+
+
+def codex_cli_goal_recovery_public_fields(
+    summary: dict[str, Any],
+) -> dict[str, Any]:
+    fields: dict[str, Any] = {}
+    for phase in ("pre_bridge", "post_bridge"):
+        prefix = f"codex_cli_goal_tui_{phase}_recovery"
+        actions = [
+            item[:40]
+            for item in summary.get(f"{phase}_actions", [])
+            if isinstance(item, str) and item
+        ][:8]
+        skip_reasons = [
+            item[:80]
+            for item in summary.get(f"{phase}_skip_reasons", [])
+            if isinstance(item, str) and item
+        ][:8]
+        fields[f"{prefix}_attempt_count"] = max(
+            0,
+            int(summary.get(f"{phase}_attempt_count") or 0),
+        )
+        fields[f"{prefix}_actions"] = actions
+        fields[f"{prefix}_action"] = actions[0] if actions else ""
+        fields[f"{prefix}_skip_reasons"] = skip_reasons
+        fields[f"{prefix}_skip_reason"] = skip_reasons[0] if skip_reasons else ""
+    return fields

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -122,6 +122,11 @@ from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
     run_skillsbench_host_local_acp_transport_probe,
     run_skillsbench_local_acp_relay_probe,
 )
+from loopx.benchmark_adapters.skillsbench_codex_goal_trace import (  # noqa: E402
+    codex_cli_goal_recovery_public_fields,
+    merge_codex_cli_goal_recovery_trace,
+    new_codex_cli_goal_recovery_summary,
+)
 from loopx.benchmark_adapters.skillsbench_remote_bridge import (  # noqa: E402
     run_skillsbench_remote_command_file_bridge_probe,
     skillsbench_remote_command_file_bridge_command_is_fixture_probe,
@@ -2941,6 +2946,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "codex_cli_goal_tui_first_action_observed_count",
         "codex_cli_goal_tui_bridge_request_count",
         "codex_cli_goal_tui_task_facing_success_count",
+        "codex_cli_goal_tui_pre_bridge_recovery_attempt_count",
         "codex_cli_goal_tui_post_bridge_recovery_attempt_count",
         "host_local_acp_sandbox_bridge_compose_file_count",
         "host_local_acp_target_env_key_count",
@@ -3031,6 +3037,13 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
             for action in recovery_actions
             if isinstance(action, str) and action
         ][:8]
+    pre_recovery_actions = value.get("codex_cli_goal_tui_pre_bridge_recovery_actions")
+    if isinstance(pre_recovery_actions, list):
+        compact["codex_cli_goal_tui_pre_bridge_recovery_actions"] = [
+            action[:40]
+            for action in pre_recovery_actions
+            if isinstance(action, str) and action
+        ][:8]
     recovery_skip_reasons = value.get(
         "codex_cli_goal_tui_post_bridge_recovery_skip_reasons"
     )
@@ -3038,6 +3051,15 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         compact["codex_cli_goal_tui_post_bridge_recovery_skip_reasons"] = [
             reason[:80]
             for reason in recovery_skip_reasons
+            if isinstance(reason, str) and reason
+        ][:8]
+    pre_recovery_skip_reasons = value.get(
+        "codex_cli_goal_tui_pre_bridge_recovery_skip_reasons"
+    )
+    if isinstance(pre_recovery_skip_reasons, list):
+        compact["codex_cli_goal_tui_pre_bridge_recovery_skip_reasons"] = [
+            reason[:80]
+            for reason in pre_recovery_skip_reasons
             if isinstance(reason, str) and reason
         ][:8]
     reasoning_efforts = value.get("codex_cli_goal_tui_reasoning_efforts")
@@ -10838,9 +10860,7 @@ def _merge_host_local_acp_relay_trace_summary(
     codex_cli_goal_first_action_count = 0
     codex_cli_goal_bridge_request_count = 0
     codex_cli_goal_task_facing_success_count = 0
-    codex_cli_goal_post_bridge_recovery_attempt_count = 0
-    codex_cli_goal_post_bridge_recovery_actions: list[str] = []
-    codex_cli_goal_post_bridge_recovery_skip_reasons: list[str] = []
+    codex_cli_goal_recovery_summary = new_codex_cli_goal_recovery_summary()
     codex_cli_goal_stages: list[str] = []
     codex_cli_goal_reasoning_efforts: list[str] = []
     raw_material_recorded = False
@@ -11061,35 +11081,10 @@ def _merge_host_local_acp_relay_trace_summary(
                     0,
                     task_facing_successes,
                 )
-            recovery_attempts = goal_trace.get("post_bridge_recovery_attempt_count")
-            if isinstance(recovery_attempts, int) and not isinstance(
-                recovery_attempts,
-                bool,
-            ):
-                codex_cli_goal_post_bridge_recovery_attempt_count += max(
-                    0,
-                    recovery_attempts,
-                )
-            recovery_action = goal_trace.get("post_bridge_recovery_action")
-            if isinstance(recovery_action, str) and recovery_action:
-                safe_recovery_action = recovery_action[:40]
-                if (
-                    safe_recovery_action
-                    not in codex_cli_goal_post_bridge_recovery_actions
-                ):
-                    codex_cli_goal_post_bridge_recovery_actions.append(
-                        safe_recovery_action
-                    )
-            recovery_skip_reason = goal_trace.get("post_bridge_recovery_skip_reason")
-            if isinstance(recovery_skip_reason, str) and recovery_skip_reason:
-                safe_skip_reason = recovery_skip_reason[:80]
-                if (
-                    safe_skip_reason
-                    not in codex_cli_goal_post_bridge_recovery_skip_reasons
-                ):
-                    codex_cli_goal_post_bridge_recovery_skip_reasons.append(
-                        safe_skip_reason
-                    )
+            merge_codex_cli_goal_recovery_trace(
+                codex_cli_goal_recovery_summary,
+                goal_trace,
+            )
             stage = goal_trace.get("stage")
             if isinstance(stage, str) and stage:
                 safe_stage = stage[:80]
@@ -11364,25 +11359,7 @@ def _merge_host_local_acp_relay_trace_summary(
     trace["codex_cli_goal_tui_task_facing_success_count"] = (
         codex_cli_goal_task_facing_success_count
     )
-    trace["codex_cli_goal_tui_post_bridge_recovery_attempt_count"] = (
-        codex_cli_goal_post_bridge_recovery_attempt_count
-    )
-    trace["codex_cli_goal_tui_post_bridge_recovery_actions"] = (
-        codex_cli_goal_post_bridge_recovery_actions
-    )
-    trace["codex_cli_goal_tui_post_bridge_recovery_action"] = (
-        codex_cli_goal_post_bridge_recovery_actions[0]
-        if codex_cli_goal_post_bridge_recovery_actions
-        else ""
-    )
-    trace["codex_cli_goal_tui_post_bridge_recovery_skip_reasons"] = (
-        codex_cli_goal_post_bridge_recovery_skip_reasons
-    )
-    trace["codex_cli_goal_tui_post_bridge_recovery_skip_reason"] = (
-        codex_cli_goal_post_bridge_recovery_skip_reasons[0]
-        if codex_cli_goal_post_bridge_recovery_skip_reasons
-        else ""
-    )
+    trace.update(codex_cli_goal_recovery_public_fields(codex_cli_goal_recovery_summary))
     trace["codex_cli_goal_tui_stages"] = codex_cli_goal_stages
     trace["codex_cli_goal_tui_stage"] = (
         codex_cli_goal_stages[0] if codex_cli_goal_stages else ""
@@ -11569,24 +11546,8 @@ def _merge_host_local_acp_relay_trace_summary(
     prerequisites["codex_cli_goal_tui_task_facing_success_count"] = (
         codex_cli_goal_task_facing_success_count
     )
-    prerequisites["codex_cli_goal_tui_post_bridge_recovery_attempt_count"] = (
-        codex_cli_goal_post_bridge_recovery_attempt_count
-    )
-    prerequisites["codex_cli_goal_tui_post_bridge_recovery_actions"] = (
-        codex_cli_goal_post_bridge_recovery_actions
-    )
-    prerequisites["codex_cli_goal_tui_post_bridge_recovery_action"] = (
-        codex_cli_goal_post_bridge_recovery_actions[0]
-        if codex_cli_goal_post_bridge_recovery_actions
-        else ""
-    )
-    prerequisites["codex_cli_goal_tui_post_bridge_recovery_skip_reasons"] = (
-        codex_cli_goal_post_bridge_recovery_skip_reasons
-    )
-    prerequisites["codex_cli_goal_tui_post_bridge_recovery_skip_reason"] = (
-        codex_cli_goal_post_bridge_recovery_skip_reasons[0]
-        if codex_cli_goal_post_bridge_recovery_skip_reasons
-        else ""
+    prerequisites.update(
+        codex_cli_goal_recovery_public_fields(codex_cli_goal_recovery_summary)
     )
     prerequisites["codex_cli_goal_tui_stages"] = codex_cli_goal_stages
     prerequisites["codex_cli_goal_tui_stage"] = (


### PR DESCRIPTION
## Summary

Repair the SkillsBench `codex-cli-goal` pre-bridge recovery path observed on `python-scala-translation`.

- Prefer typed `/goal` resubmit when `pre_bridge_tui_error_prompt` shows the Codex input prompt, instead of repeating Enter retries that do not create a bridge request.
- Extract public-safe Codex goal recovery trace aggregation into `skillsbench_codex_goal_trace.py`.
- Preserve compatibility for older compact traces that wrote pre-bridge retry facts into post-bridge fields by projecting them into the new pre-bridge public fields when the stage starts with `pre_bridge_`.
- Extend the route smoke to cover the current error prompt and legacy trace projection.

## Boundary

This is benchmark helper/runtime recovery plumbing only. It does not change task text, official scoring semantics, leaderboard/submission behavior, credentials, or raw benchmark evidence policy. Private TUI tails remain private refs only.

## Validation

- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 -m py_compile loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py loopx/benchmark_adapters/skillsbench_codex_goal_trace.py scripts/skillsbench_automation_loop.py examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `loopx canary premerge --from-git-diff`
  - Direct checks passed.
  - Python compile passed.
  - Selected catalog canaries passed: repo line budget, terminal-bench adapter readiness, benchmark core adapter contract, benchmark artifact path filter, benchmark run ledger, benchmark case analysis.
  - Public boundary check passed.
  - Manual hold: `benchmark_sensitive`; owner has authorized self-merge for this batch.

