### PR TITLE
Classify excluded SkillsBench task sources

### DIFF
--- a/examples/skillsbench-current-ledger-aggregate-smoke.py
+++ b/examples/skillsbench-current-ledger-aggregate-smoke.py
@@ -211,6 +211,26 @@ def make_ledger(path: Path) -> None:
                 "alternate_source_supported_by_runner": False,
             },
         ),
+        run_entry(
+            run_id="tasks-extra-excluded-preflight",
+            case_id="scheduling-email-assistant",
+            recorded_at="2026-07-02T01:52:00+08:00",
+            score=None,
+            score_status="missing",
+            failure_class="skillsbench_task_source_excluded",
+            failure_scope="score_missing",
+            task_setup_preflight={
+                "schema_version": "skillsbench_task_setup_preflight_v0",
+                "status": "task_excluded_from_formal_tasks",
+                "task_id": "scheduling-email-assistant",
+                "canonical_task_present": False,
+                "alternate_source_kind": "tasks_extra",
+                "registry_task_present": True,
+                "registry_task_path": "tasks-extra/scheduling-email-assistant",
+                "registry_excluded": True,
+                "alternate_source_supported_by_runner": False,
+            },
+        ),
     ):
         ledger = upsert_benchmark_run_ledger_entry(ledger, entry)
     write_json(path, ledger)
@@ -236,6 +256,7 @@ def test_current_aggregate_prefers_countable_results() -> None:
                 "reward-artifact-missing",
                 "fix-erlang-ssh-cve",
                 "hello-world",
+                "scheduling-email-assistant",
                 "never-run-case",
             ],
         )
@@ -293,6 +314,12 @@ def test_current_aggregate_prefers_countable_results() -> None:
         ] == "uncountable_attribution"
         assert "hello-world" not in aggregate["case_best"], aggregate["case_best"]
         assert "hello-world" not in aggregate["cases_by_bucket"]["setup_runner_infra"]
+        assert "scheduling-email-assistant" not in aggregate["case_best"], (
+            aggregate["case_best"]
+        )
+        assert "scheduling-email-assistant" not in aggregate["cases_by_bucket"][
+            "setup_runner_infra"
+        ]
 
 
 def test_ledger_marks_uncountable_numeric_scores_noncountable() -> None:
@@ -334,6 +361,23 @@ def test_ledger_marks_uncountable_numeric_scores_noncountable() -> None:
         "official_score_attempt_not_countable"
     ), entry
 
+    passed_false_only = {
+        "schema_version": "benchmark_run_v0",
+        "benchmark_id": BENCHMARK_ID,
+        "case_id": "passed-bool-false",
+        "job_name": "skillsbench_1_1_passed_bool_false_codex_cli_goal_baseline",
+        "route": "codex-cli-goal-baseline",
+        "official_score_status": "completed",
+        "official_task_score": {"passed": False},
+    }
+    entry = build_benchmark_run_ledger_entry(passed_false_only)
+    assert entry["official_score"] == 0.0, entry
+    assert entry["official_passed"] is False, entry
+    assert entry["official_score_countable"] is True, entry
+    assert entry["official_score_countability_reason"] == (
+        "countable_official_score"
+    ), entry
+
 
 def test_current_aggregate_default_inference_excludes_sanity_sources() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-current-aggregate-default-") as tmp:
@@ -353,6 +397,9 @@ def test_current_aggregate_default_inference_excludes_sanity_sources() -> None:
         assert aggregate["countable_score_summary"]["countable_score_mean"] == 0.166667, aggregate
         assert "hello-world" not in aggregate["case_best"], aggregate["case_best"]
         assert "hello-world" not in aggregate["cases_by_bucket"]["setup_runner_infra"]
+        assert "scheduling-email-assistant" not in aggregate["case_best"], (
+            aggregate["case_best"]
+        )
 
 
 def test_current_aggregate_cli_writes_public_safe_json() -> None:

--- a/examples/skillsbench-task-source-preflight-smoke.py
+++ b/examples/skillsbench-task-source-preflight-smoke.py
@@ -37,6 +37,12 @@ def _write_task(root: Path, relative: str, *, verifier_text: str = "") -> None:
         verifier.write_text(verifier_text, encoding="utf-8")
 
 
+def _write_task_registry(root: Path, rows: list[dict[str, object]]) -> None:
+    registry = root / "website" / "src" / "data" / "tasks-registry.json"
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    registry.write_text(json.dumps(rows, indent=2) + "\n", encoding="utf-8")
+
+
 def _app_goal_args(
     *,
     task_id: str,
@@ -148,7 +154,7 @@ def test_sanity_task_source_fails_before_runner_spend() -> None:
         )
 
 
-def test_missing_task_source_records_no_close_canonical_equivalent() -> None:
+def test_tasks_extra_excluded_source_is_not_canonical_missing() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-no-canonical-equivalent-") as tmp:
         root = Path(tmp)
         skillsbench_root = root / "skillsbench"
@@ -156,6 +162,16 @@ def test_missing_task_source_records_no_close_canonical_equivalent() -> None:
         _write_task(skillsbench_root, "tasks/offer-letter-generator")
         _write_task(skillsbench_root, "tasks/paratransit-routing")
         _write_task(skillsbench_root, "tasks/travel-planning")
+        _write_task_registry(
+            skillsbench_root,
+            [
+                {
+                    "title": "scheduling-email-assistant",
+                    "path": "tasks-extra/scheduling-email-assistant",
+                    "excluded": True,
+                }
+            ],
+        )
 
         jobs = root / "jobs"
         ledger = root / "ledger.json"
@@ -178,11 +194,22 @@ def test_missing_task_source_records_no_close_canonical_equivalent() -> None:
         ]
         plan = build_plan(parse_args(args))
         preflight = plan["task_setup_preflight"]
-        assert preflight["status"] == "task_missing_from_canonical_tasks", preflight
+        assert preflight["status"] == "task_excluded_from_formal_tasks", preflight
+        assert preflight["first_blocker"] == "skillsbench_task_source_excluded", (
+            preflight
+        )
         assert preflight["canonical_task_present"] is False, preflight
-        assert preflight["alternate_source_kind"] == "none", preflight
+        assert preflight["alternate_source_kind"] == "tasks_extra", preflight
+        assert preflight["registry_task_present"] is True, preflight
+        assert preflight["registry_task_path"] == (
+            "tasks-extra/scheduling-email-assistant"
+        ), preflight
+        assert preflight["registry_excluded"] is True, preflight
         assert preflight["canonical_equivalent_status"] == (
             "no_close_canonical_match"
+        ), preflight
+        assert preflight["selection_recommendation"] == (
+            "excluded_tasks_extra_requires_explicit_sanity_source_mode"
         ), preflight
         assert preflight["raw_task_text_read"] is False, preflight
         assert preflight["task_source_path_recorded"] is False, preflight
@@ -200,13 +227,25 @@ def test_missing_task_source_records_no_close_canonical_equivalent() -> None:
             / "benchmark_run.compact.json"
         )
         compact = json.loads(compact_path.read_text(encoding="utf-8"))
+        assert compact["first_blocker"] == "skillsbench_task_source_excluded"
         assert compact["score_failure_attribution"] == (
-            "skillsbench_task_source_preflight_blocked"
+            "skillsbench_task_source_excluded"
         )
-        assert compact["task_setup_preflight"]["canonical_equivalent_status"] == (
-            "no_close_canonical_match"
+        assert compact["task_setup_preflight"]["status"] == (
+            "task_excluded_from_formal_tasks"
         )
+        assert compact["task_setup_preflight"]["alternate_source_kind"] == "tasks_extra"
+        assert compact["task_setup_preflight"]["registry_excluded"] is True
         assert compact["validation"]["no_raw_task_text_read"] is True, compact
+
+        update = load_benchmark_run_ledger(ledger)
+        case = update["benchmarks"]["skillsbench@1.1"]["cases"][
+            "scheduling-email-assistant"
+        ]
+        assert case["latest_decision"]["decision"] == (
+            "baseline_task_source_excluded_from_formal_scoring"
+        ), case
+        assert case["runs"][0]["repair_class"] == "skillsbench_task_source_excluded"
 
 
 def test_reverse_tunnel_app_goal_defaults_verifier_bootstrap_fail_fast() -> None:
@@ -506,7 +545,7 @@ def test_reverse_tunnel_app_goal_allows_explicit_staged_bootstrap_repair() -> No
 
 if __name__ == "__main__":
     test_sanity_task_source_fails_before_runner_spend()
-    test_missing_task_source_records_no_close_canonical_equivalent()
+    test_tasks_extra_excluded_source_is_not_canonical_missing()
     test_reverse_tunnel_app_goal_defaults_verifier_bootstrap_fail_fast()
     test_reverse_tunnel_app_goal_defaults_apt_bootstrap_fail_fast()
     test_reverse_tunnel_app_goal_blocks_pip_bootstrap_light_risk()

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -1533,6 +1533,13 @@ def skillsbench_runner_error_attribution(error_text: str) -> tuple[str, str, lis
     if "benchflow result.json not found" in text:
         label = "skillsbench_result_json_missing_after_runner_exit"
         return label, label, [label, "skillsbench_runner_setup_error"]
+    if any(marker in text for marker in (
+        "skillsbench task source excluded",
+        "task is excluded from formal tasks source",
+        "task excluded from formal tasks source",
+    )):
+        label = "skillsbench_task_source_excluded"
+        return label, label, [label, "skillsbench_task_source_preflight", "skillsbench_noncanonical_task_source"]
     if (
         "skillsbench task source preflight blocked" in text
         or "task missing from canonical tasks source" in text

--- a/loopx/benchmark_adapters/skillsbench_task_source.py
+++ b/loopx/benchmark_adapters/skillsbench_task_source.py
@@ -1,0 +1,141 @@
+"""Public-safe SkillsBench task source classification helpers."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def _public_task_label(value: Any, *, limit: int = 120) -> str:
+    text = str(value or "").strip()
+    cleaned = [
+        char.lower() if char.isalnum() or char in {"-", "_", "."} else "-"
+        for char in text
+    ]
+    label = "".join(cleaned).strip("-_.")
+    while "--" in label:
+        label = label.replace("--", "-")
+    return label[:limit]
+
+
+def _public_registry_path(value: Any, *, limit: int = 200) -> str:
+    text = str(value or "").strip().replace("\\", "/")
+    parts = [
+        _public_task_label(part, limit=80)
+        for part in text.split("/")
+        if part.strip()
+    ]
+    return "/".join(part for part in parts if part)[:limit]
+
+
+def _registry_source_metadata(
+    *,
+    skillsbench_root: Path,
+    task_id: str,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "registry_task_present": False,
+        "registry_task_path_recorded": False,
+        "registry_task_path": "",
+        "registry_excluded": False,
+        "registry_source_kind": "none",
+        "registry_source_status": "missing",
+    }
+    registry_path = (
+        skillsbench_root.expanduser()
+        / "website"
+        / "src"
+        / "data"
+        / "tasks-registry.json"
+    )
+    if not registry_path.exists():
+        return metadata
+    try:
+        raw = json.loads(registry_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        metadata["registry_source_status"] = "unreadable"
+        return metadata
+    entries = raw if isinstance(raw, list) else None
+    if isinstance(raw, dict):
+        entries = raw.get("tasks") or raw.get("entries") or raw.get("data")
+    if not isinstance(entries, list):
+        metadata["registry_source_status"] = "unsupported_shape"
+        return metadata
+    requested = _public_task_label(task_id)
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        registry_path_text = _public_registry_path(entry.get("path"))
+        candidates = {
+            _public_task_label(entry.get(key))
+            for key in ("id", "task_id", "name", "title", "slug")
+        }
+        if registry_path_text:
+            candidates.add(Path(registry_path_text).name)
+        if requested not in candidates:
+            continue
+        source_kind = "other"
+        if registry_path_text.startswith("tasks/"):
+            source_kind = "tasks"
+        elif registry_path_text.startswith("tasks-extra/"):
+            source_kind = "tasks_extra"
+        elif registry_path_text.startswith("experiments/sanity-tasks/"):
+            source_kind = "experiments_sanity_tasks"
+        return {
+            **metadata,
+            "registry_task_present": True,
+            "registry_task_path_recorded": bool(registry_path_text),
+            "registry_task_path": registry_path_text,
+            "registry_excluded": entry.get("excluded") is True,
+            "registry_source_kind": source_kind,
+            "registry_source_status": "matched",
+        }
+    metadata["registry_source_status"] = "not_found"
+    return metadata
+
+
+def classify_missing_task_source(
+    *,
+    skillsbench_root: Path,
+    task_id: str,
+    sanity_task_exists: bool,
+    canonical_equivalent_status: str,
+) -> dict[str, Any]:
+    registry_source = _registry_source_metadata(
+        skillsbench_root=skillsbench_root,
+        task_id=task_id,
+    )
+    if sanity_task_exists:
+        alternate_source_kind = "experiments_sanity_tasks"
+    elif registry_source.get("registry_source_kind") == "tasks_extra":
+        alternate_source_kind = "tasks_extra"
+    else:
+        alternate_source_kind = "none"
+    source_is_excluded = (
+        registry_source.get("registry_source_kind") == "tasks_extra"
+        and registry_source.get("registry_excluded") is True
+    )
+    return {
+        **registry_source,
+        "status": (
+            "task_excluded_from_formal_tasks"
+            if source_is_excluded
+            else "task_missing_from_canonical_tasks"
+        ),
+        "first_blocker": (
+            "skillsbench_task_source_excluded"
+            if source_is_excluded
+            else "skillsbench_task_source_preflight_blocked"
+        ),
+        "alternate_source_kind": alternate_source_kind,
+        "selection_recommendation": (
+            "excluded_tasks_extra_requires_explicit_sanity_source_mode"
+            if source_is_excluded
+            else (
+                "choose_nearest_canonical_task_candidate_or_use_explicit_sanity_source_runner"
+                if canonical_equivalent_status == "close_canonical_match_found"
+                else "no_close_canonical_task_match_choose_normal_tasks_candidate_or_explicit_sanity_source_runner"
+            )
+        ),
+    }

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -252,6 +252,9 @@ def _compact_task_setup_preflight(value: Any) -> dict[str, Any]:
         "first_blocker",
         "alternate_source_kind",
         "canonical_equivalent_status",
+        "registry_source_kind",
+        "registry_source_status",
+        "registry_task_path",
         "selection_recommendation",
     ):
         text = _compact_text(value.get(field), limit=140)
@@ -273,6 +276,9 @@ def _compact_task_setup_preflight(value: Any) -> dict[str, Any]:
         "dockerfile_present",
         "canonical_task_present",
         "alternate_source_supported_by_runner",
+        "registry_task_present",
+        "registry_task_path_recorded",
+        "registry_excluded",
         "task_source_path_recorded",
         "task_source_content_recorded",
         "bootstrap_light_candidate_eligible",
@@ -438,6 +444,8 @@ def benchmark_run_official_score_countability(run: dict[str, Any]) -> dict[str, 
             else {}
         )
         score = _numeric_score_value(official.get("value"))
+    if score is None:
+        score, _passed = _official_score_passed_bool_fallback(run)
     if score is None:
         return {
             "countable": False,
@@ -1012,7 +1020,7 @@ def _official_score(benchmark_run: dict[str, Any]) -> tuple[float | int | None, 
     value = benchmark_run.get("official_score")
     if isinstance(value, (int, float)) and not isinstance(value, bool):
         return value, value >= 1
-    return None, None
+    return _official_score_passed_bool_fallback(benchmark_run)
 
 
 def _infer_arm_id_from_job_name(job_name: str) -> str:
@@ -1076,6 +1084,35 @@ def _score_status(benchmark_run: dict[str, Any], score: float | int | None, pass
     if score is None:
         return "missing"
     return "passed" if passed else "failed"
+
+
+def _official_score_passed_bool_fallback(
+    benchmark_run: dict[str, Any],
+) -> tuple[float | None, bool | None]:
+    score_status = _compact_text(
+        benchmark_run.get("official_score_status") or benchmark_run.get("score_status"),
+        limit=80,
+    )
+    if score_status not in {"completed", "passed", "failed"}:
+        return None, None
+    if _compact_text(benchmark_run.get("runner_return_status"), limit=120) == (
+        "failed_before_official_result"
+    ):
+        return None, None
+    official = (
+        benchmark_run.get("official_task_score")
+        if isinstance(benchmark_run.get("official_task_score"), dict)
+        else {}
+    )
+    for container, key in (
+        (official, "passed"),
+        (benchmark_run, "official_passed"),
+        (benchmark_run, "passed"),
+    ):
+        value = container.get(key) if isinstance(container, dict) else None
+        if isinstance(value, bool):
+            return (1.0 if value else 0.0), value
+    return None, None
 
 
 _SKILLSBENCH_PRE_AGENT_SETUP_STATUS_LABELS = {
@@ -1487,6 +1524,29 @@ def _repair_route(
                     "skillsbench_task_setup_preflight",
                     "canonical_task_present",
                     "nearest_canonical_task_ids",
+                ],
+                "raw_logs_required": False,
+                "raw_task_text_required": False,
+            },
+        }
+    if failure_class == "skillsbench_task_source_excluded":
+        return {
+            "repair_priority": "P1",
+            "repair_class": "skillsbench_task_source_excluded",
+            "next_action": (
+                "exclude this noncanonical SkillsBench source from formal "
+                "87-case scoring, or rerun it only through an explicit "
+                "sanity/source-extra runner"
+            ),
+            "repair_profile": {
+                "schema_version": "benchmark_repair_profile_v0",
+                "repair_class": "skillsbench_task_source_excluded",
+                "rerun_allowed_after_profile_applied": True,
+                "required_preflight": [
+                    "skillsbench_task_setup_preflight",
+                    "task_excluded_from_formal_tasks",
+                    "registry_source_kind=tasks_extra",
+                    "registry_excluded=true",
                 ],
                 "raw_logs_required": False,
                 "raw_task_text_required": False,
@@ -2562,6 +2622,8 @@ def _case_decision(case: dict[str, Any]) -> dict[str, Any]:
             decision = f"{prefix}_verifier_bootstrap_preflight_selection_required"
         elif repair_class == "skillsbench_task_source_preflight_selection":
             decision = f"{prefix}_task_source_preflight_selection_required"
+        elif repair_class == "skillsbench_task_source_excluded":
+            decision = f"{prefix}_task_source_excluded_from_formal_scoring"
         elif repair_class == "worker_verifier_alignment":
             decision = f"{prefix}_worker_verifier_alignment_required"
         elif repair_class == "verifier_or_infra_repair":

--- a/loopx/benchmark_ledger_current.py
+++ b/loopx/benchmark_ledger_current.py
@@ -219,37 +219,50 @@ def _current_aggregate_run_summary(run: dict[str, Any] | None) -> dict[str, Any]
     return summary
 
 
-def _current_aggregate_case_is_noncanonical_sanity_source(case: dict[str, Any]) -> bool:
+def _current_aggregate_case_is_noncanonical_source(case: dict[str, Any]) -> bool:
     runs = _active_ledger_runs(
         [item for item in case.get("runs", []) if isinstance(item, dict)]
     )
     if not runs:
         return False
-    saw_sanity_source_preflight = False
+    saw_noncanonical_source_preflight = False
     for run in runs:
         if _ledger_score_value(run) is not None:
             return False
-        if _current_aggregate_effective_failure_class(run) != (
-            "skillsbench_task_source_preflight_blocked"
-        ):
+        failure_class = _current_aggregate_effective_failure_class(run)
+        if failure_class not in {
+            "skillsbench_task_source_preflight_blocked",
+            "skillsbench_task_source_excluded",
+        }:
             return False
         preflight = run.get("task_setup_preflight")
         if not isinstance(preflight, dict):
             return False
         if preflight.get("canonical_task_present") is not False:
             return False
-        if _compact_text(preflight.get("status"), limit=120) != (
-            "task_missing_from_canonical_tasks"
-        ):
-            return False
-        if _compact_text(preflight.get("alternate_source_kind"), limit=120) != (
-            "experiments_sanity_tasks"
-        ):
+        status = _compact_text(preflight.get("status"), limit=120)
+        source_kind = _compact_text(preflight.get("alternate_source_kind"), limit=120)
+        if status == "task_missing_from_canonical_tasks":
+            source_is_noncanonical = source_kind == "experiments_sanity_tasks"
+        elif status == "task_excluded_from_formal_tasks":
+            source_is_noncanonical = (
+                source_kind == "tasks_extra"
+                and preflight.get("registry_excluded") is True
+            )
+        else:
+            source_is_noncanonical = False
+        if not source_is_noncanonical:
             return False
         if preflight.get("alternate_source_supported_by_runner") is not False:
             return False
-        saw_sanity_source_preflight = True
-    return saw_sanity_source_preflight
+        saw_noncanonical_source_preflight = True
+    return saw_noncanonical_source_preflight
+
+
+def _current_aggregate_case_is_noncanonical_sanity_source(case: dict[str, Any]) -> bool:
+    """Compatibility wrapper for the historical aggregate option name."""
+
+    return _current_aggregate_case_is_noncanonical_source(case)
 
 
 def build_benchmark_run_ledger_current_aggregate(
@@ -283,7 +296,7 @@ def build_benchmark_run_ledger_current_aggregate(
                 for case_id in canonical_ids
                 if not (
                     isinstance(cases.get(case_id), dict)
-                    and _current_aggregate_case_is_noncanonical_sanity_source(
+                    and _current_aggregate_case_is_noncanonical_source(
                         cases[case_id]
                     )
                 )
@@ -294,7 +307,7 @@ def build_benchmark_run_ledger_current_aggregate(
             for case_id, case in cases.items()
             if not (
                 isinstance(case, dict)
-                and _current_aggregate_case_is_noncanonical_sanity_source(case)
+                and _current_aggregate_case_is_noncanonical_source(case)
             )
         )
     distribution = {

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -2526,6 +2526,9 @@ def _compact_benchmark_task_setup_preflight(value: Any) -> dict[str, Any]:
         "first_blocker",
         "alternate_source_kind",
         "canonical_equivalent_status",
+        "registry_source_kind",
+        "registry_source_status",
+        "registry_task_path",
         "selection_recommendation",
     ):
         text = public_safe_compact_text(value.get(field), limit=180)
@@ -2547,6 +2550,9 @@ def _compact_benchmark_task_setup_preflight(value: Any) -> dict[str, Any]:
         "dockerfile_present",
         "canonical_task_present",
         "alternate_source_supported_by_runner",
+        "registry_task_present",
+        "registry_task_path_recorded",
+        "registry_excluded",
         "task_source_path_recorded",
         "task_source_content_recorded",
         "bootstrap_light_candidate_eligible",

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -113,6 +113,9 @@ from loopx.benchmark_adapters.skillsbench_batch import (  # noqa: E402
 from loopx.benchmark_adapters.skillsbench_verifier_bootstrap import (  # noqa: E402
     apply_skillsbench_verifier_bootstrap_missing_score_attribution,
 )
+from loopx.benchmark_adapters.skillsbench_task_source import (  # noqa: E402
+    classify_missing_task_source,
+)
 from loopx.benchmark_adapters import skillsbench_runner_source as runner_source  # noqa: E402
 from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
     SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER,
@@ -6371,6 +6374,9 @@ def _public_task_setup_preflight(value: Any) -> dict[str, Any]:
         "first_blocker",
         "alternate_source_kind",
         "canonical_equivalent_status",
+        "registry_source_kind",
+        "registry_source_status",
+        "registry_task_path",
         "selection_recommendation",
     ):
         raw = value.get(field)
@@ -6392,6 +6398,9 @@ def _public_task_setup_preflight(value: Any) -> dict[str, Any]:
         "dockerfile_present",
         "canonical_task_present",
         "alternate_source_supported_by_runner",
+        "registry_task_present",
+        "registry_task_path_recorded",
+        "registry_excluded",
         "task_source_path_recorded",
         "task_source_content_recorded",
         "bootstrap_light_candidate_eligible",
@@ -7582,9 +7591,6 @@ def skillsbench_task_setup_preflight(
             / "sanity-tasks"
             / expanded_task_path.name
         )
-        alternate_source_kind = (
-            "experiments_sanity_tasks" if sanity_task.is_dir() else "none"
-        )
         nearest, canonical_equivalent_status = (
             skillsbench_nearest_canonical_task_ids(
                 requested_task_id=public_task_id,
@@ -7593,16 +7599,14 @@ def skillsbench_task_setup_preflight(
         )
         preflight.update(
             {
-                "status": "task_missing_from_canonical_tasks",
-                "first_blocker": "skillsbench_task_source_preflight_blocked",
-                "alternate_source_kind": alternate_source_kind,
+                **classify_missing_task_source(
+                    skillsbench_root=skillsbench_root,
+                    task_id=expanded_task_path.name,
+                    sanity_task_exists=sanity_task.is_dir(),
+                    canonical_equivalent_status=canonical_equivalent_status,
+                ),
                 "canonical_equivalent_status": canonical_equivalent_status,
                 "nearest_canonical_task_ids": nearest,
-                "selection_recommendation": (
-                    "choose_nearest_canonical_task_candidate_or_use_explicit_sanity_source_runner"
-                    if canonical_equivalent_status == "close_canonical_match_found"
-                    else "no_close_canonical_task_match_choose_normal_tasks_candidate_or_explicit_sanity_source_runner"
-                ),
             }
         )
         preflight["bootstrap_light_blocking_fields"] = (
@@ -16665,7 +16669,11 @@ async def _async_main_with_observable_handle(
         )
     if (
         not args.reduce_only
-        and setup_preflight.get("status") == "task_missing_from_canonical_tasks"
+        and setup_preflight.get("status")
+        in {
+            "task_missing_from_canonical_tasks",
+            "task_excluded_from_formal_tasks",
+        }
     ):
         staging = plan.setdefault("task_staging", {})
         if isinstance(staging, dict):
@@ -16677,6 +16685,14 @@ async def _async_main_with_observable_handle(
                     args=args,
                 )
             staging["task_source_preflight_blocked"] = True
+            if setup_preflight.get("status") == "task_excluded_from_formal_tasks":
+                staging["task_source_excluded_preflight_blocked"] = True
+                staging["task_source_excluded"] = True
+        if setup_preflight.get("status") == "task_excluded_from_formal_tasks":
+            raise SkillsBenchSetupPreflightBlocked(
+                "skillsbench task source excluded: "
+                "task is excluded from formal tasks source before full case run"
+            )
         raise SkillsBenchSetupPreflightBlocked(
             "skillsbench task source preflight blocked: "
             "task missing from canonical tasks source before full case run"


### PR DESCRIPTION
## Summary
- classify SkillsBench `tasks-extra` rows marked `excluded: true` as `skillsbench_task_source_excluded` instead of canonical task missing
- exclude those noncanonical/excluded source rows from the formal current 87-case aggregate by default
- recover countable official scores from completed boolean-only `passed` payloads: `false -> 0.0`, `true -> 1.0`, while preserving setup failures as missing when no official result materialized
- move registry source parsing into a small benchmark adapter helper to keep large runner files under line-budget guard

## Validation
- `python3 examples/skillsbench-task-source-preflight-smoke.py`
- `python3 examples/skillsbench-current-ledger-aggregate-smoke.py`
- `python3 -m py_compile scripts/skillsbench_automation_loop.py loopx/benchmark_ledger.py loopx/benchmark_adapters/skillsbench.py loopx/benchmark_adapters/skillsbench_task_source.py loopx/benchmark_ledger_current.py loopx/status.py examples/skillsbench-task-source-preflight-smoke.py examples/skillsbench-current-ledger-aggregate-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `loopx check --scan-path scripts/skillsbench_automation_loop.py --scan-path loopx/benchmark_ledger.py --scan-path loopx/benchmark_adapters/skillsbench.py --scan-path loopx/benchmark_adapters/skillsbench_task_source.py --scan-path loopx/benchmark_ledger_current.py --scan-path loopx/status.py --scan-path examples/skillsbench-task-source-preflight-smoke.py --scan-path examples/skillsbench-current-ledger-aggregate-smoke.py`
- `loopx canary premerge --from-git-diff` returned no failures; status `manual_review_required` only because benchmark-sensitive surfaces have a manual hold

## Merge Note
Owner authorized self-merge for this benchmark ledger/runner repair. The diff is single-purpose, public-boundary clean, and does not read raw task text, raw logs, trajectories, credentials, or verifier tails.