### PR TITLE
Align work-lane projection with agent-scope waits

### DIFF
--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -190,10 +190,11 @@ the current agent's public-safe events, keeps other agents compressed to
 frontier context, and does not replace status, quota, review packets, or the
 append-only event sources.
 The same guard may include `work_lane_contract`. Schema
-`work_lane_contract_v1` is the single machine contract for monitor versus
-advancement routing. It distinguishes `lane=continuous_monitor` from
-`lane=advancement_task`, carries the next lane, and exposes one `obligation`
-string such as `advance_unless_material_monitor_transition`. Agent todo items
+`work_lane_contract_v1` is the compatibility drill-down for monitor versus
+advancement routing under the guard's first-class `interaction_contract`. It
+distinguishes `lane=continuous_monitor` from `lane=advancement_task`, carries
+the next lane, and exposes one `obligation` string such as
+`advance_unless_material_monitor_transition`. Agent todo items
 may include `task_class=advancement_task` or
 `task_class=continuous_monitor`, plus optional `action_kind` such as
 `run_eval`, `validate`, `rebuild`, `writeback`, `monitor`, or `poll`. Explicit
@@ -225,6 +226,12 @@ should not restate the lane semantics; unchanged monitor polls remain quiet
 no-spend checks with `should_run=false` and
 `effective_action=monitor_quiet_skip`, while a material dependency-state
 transition may be written back once when it changes the selected goal decision.
+When final agent-scope projection selects a non-execution wait such as
+`effective_action=agent_scope_wait`, the exposed `work_lane_contract` must also
+be non-executing (`must_attempt_work=false`) even if a goal-level next action
+would otherwise derive an advancement obligation. The original goal-level lane
+may remain as compact deferred diagnostic context, but executors must not treat
+it as a competing obligation.
 `handoff_readiness.handoff_interface_budget` declares the machine-readable
 budget for the minimal project-agent handoff: `mode=project_agent_handoff`,
 `max_lines=16`, and `max_chars=1800`. `loopx review-packet

--- a/examples/control_plane/agent-scope-work-lane-consistency-smoke.py
+++ b/examples/control_plane/agent-scope-work-lane-consistency-smoke.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Smoke-test agent-scope wait consistency for legacy work-lane projection."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.quota import build_quota_should_run, render_quota_should_run_markdown
+from loopx.status import compact_todo_group
+
+
+GOAL_ID = "agent-scope-work-lane-consistency-fixture"
+PRIMARY_AGENT = "codex-main-control"
+SIDE_AGENT = "codex-product-capability"
+FUTURE_DUE_AT = "2999-01-01T00:00:00+00:00"
+
+
+def _status_payload() -> dict:
+    next_action = (
+        "Post-reporting lane should route to the planning/self-repair capability "
+        "lane as the next eligible advancement turn."
+    )
+    agent_todos = compact_todo_group(
+        [
+            {
+                "index": 1,
+                "text": "[P1-monitor] Watch the published PR until merge.",
+                "role": "agent",
+                "status": "open",
+                "priority": "P1-monitor",
+                "task_class": "continuous_monitor",
+                "action_kind": "monitor",
+                "claimed_by": SIDE_AGENT,
+                "todo_id": "todo_side_monitor",
+                "cadence": "60m",
+                "next_due_at": FUTURE_DUE_AT,
+            },
+            {
+                "index": 2,
+                "text": next_action,
+                "role": "agent",
+                "status": "open",
+                "priority": "P0",
+                "task_class": "advancement_task",
+                "claimed_by": PRIMARY_AGENT,
+                "todo_id": "todo_primary_frontier",
+            },
+        ],
+        source_section="Agent Todo",
+        role="agent",
+    )
+    assert agent_todos is not None
+    coordination = {
+        "primary_agent": PRIMARY_AGENT,
+        "registered_agents": [PRIMARY_AGENT, SIDE_AGENT],
+    }
+    return {
+        "ok": True,
+        "attention_queue": {
+            "items": [
+                {
+                    "goal_id": GOAL_ID,
+                    "status": "active",
+                    "waiting_on": "codex",
+                    "severity": "info",
+                    "source": "project_asset",
+                    "recommended_action": next_action,
+                    "quota": {
+                        "compute": 1.0,
+                        "window_hours": 24,
+                        "slot_minutes": 1,
+                        "allowed_slots": 10,
+                        "spent_slots": 0,
+                        "state": "eligible",
+                        "reason": "eligible fixture",
+                    },
+                    "coordination": coordination,
+                    "project_asset": {
+                        "next_action": next_action,
+                        "agent_todos": agent_todos,
+                    },
+                }
+            ]
+        },
+        "run_history": {
+            "goals": [
+                {
+                    "id": GOAL_ID,
+                    "registry_member": True,
+                    "status": "active",
+                    "adapter_kind": "harness_self_improvement",
+                    "adapter_status": "connected-read-only",
+                    "quota": {
+                        "compute": 1.0,
+                        "window_hours": 24,
+                        "slot_minutes": 1,
+                        "allowed_slots": 10,
+                    },
+                    "coordination": coordination,
+                }
+            ]
+        },
+    }
+
+
+def main() -> None:
+    guard = build_quota_should_run(
+        _status_payload(),
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+    )
+
+    assert guard["decision"] == "agent_scope_wait", guard
+    assert guard["should_run"] is False, guard
+    assert guard["effective_action"] == "agent_scope_wait", guard
+
+    lane = guard["work_lane_contract"]
+    assert lane["lane"] == "agent_scope_wait", lane
+    assert lane["obligation"] == "wait_for_current_agent_or_unclaimed_advancement", lane
+    assert lane["must_attempt_work"] is False, lane
+    assert lane["blocked_by_agent_scope"] is True, lane
+    assert lane["deferred_work_lane"]["obligation"] == (
+        "materialize_advancement_todo_or_blocker"
+    ), lane
+    assert "agent_scope_wait" in lane["reason_codes"], lane
+
+    obligation = guard["execution_obligation"]
+    assert obligation["kind"] == "agent_scope_wait", obligation
+    assert obligation["must_attempt_work"] is False, obligation
+
+    contract = guard["interaction_contract"]
+    assert contract["mode"] == "agent_scope_wait", contract
+    assert contract["agent_channel"]["must_attempt"] is False, contract
+    assert contract["agent_channel"]["delivery_allowed"] is False, contract
+    assert contract["agent_channel"]["quiet_noop_allowed"] is True, contract
+
+    markdown = render_quota_should_run_markdown(guard)
+    assert "obligation=materialize_advancement_todo_or_blocker" not in markdown, markdown
+    assert (
+        "work_lane_contract: lane=agent_scope_wait next=advancement_task" in markdown
+    ), markdown
+    print("agent-scope-work-lane-consistency-smoke ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -114,6 +114,7 @@ from .control_plane.work_items.work_lane_context import (
     build_work_lane_context_contract,
 )
 from .control_plane.work_items.work_lane import (
+    WORK_LANE_CONTRACT_SCHEMA_VERSION,
     work_lane_contract_is_due_monitor_attempt,
 )
 from .control_plane.scheduler.scheduler_hint import (
@@ -290,6 +291,86 @@ def _work_lane_contract(
         agent_todo_summary=agent_todo_summary,
         monitor_due_item_limit=MONITOR_DUE_ITEM_LIMIT,
     )
+
+
+AGENT_SCOPE_NON_EXECUTION_ACTIONS = {
+    AgentScopeFrontierAction.AGENT_SCOPE_EXHAUSTED.value,
+    AgentScopeFrontierAction.AGENT_SCOPE_WAIT.value,
+    AgentScopeFrontierAction.REASSIGNMENT_REQUIRED.value,
+}
+
+
+def _agent_scope_payload_work_lane_contract(
+    work_lane_contract: dict[str, Any],
+    *,
+    effective_action: str,
+    agent_scope_frontier: dict[str, Any],
+) -> dict[str, Any]:
+    reason_codes = [
+        str(value)
+        for value in (
+            work_lane_contract.get("reason_codes")
+            if isinstance(work_lane_contract.get("reason_codes"), list)
+            else []
+        )
+        if str(value).strip()
+    ]
+    for code in ("agent_scope_no_current_runnable_candidate", effective_action):
+        if code not in reason_codes:
+            reason_codes.append(code)
+
+    deferred_work_lane = {
+        key: work_lane_contract.get(key)
+        for key in ("lane", "next_lane", "obligation", "monitor_policy")
+        if work_lane_contract.get(key) is not None
+    }
+    if work_lane_contract.get("reason_codes") is not None:
+        deferred_work_lane["reason_codes"] = work_lane_contract.get("reason_codes")
+
+    return {
+        "schema_version": str(
+            work_lane_contract.get("schema_version")
+            or WORK_LANE_CONTRACT_SCHEMA_VERSION
+        ),
+        "lane": effective_action,
+        "next_lane": str(work_lane_contract.get("lane") or "advancement_task"),
+        "obligation": "wait_for_current_agent_or_unclaimed_advancement",
+        "must_attempt_work": False,
+        "reason_codes": reason_codes,
+        "monitor_policy": "no_delivery_until_current_agent_frontier_exists",
+        "blocked_by_agent_scope": True,
+        "agent_scope_action": effective_action,
+        "deferred_work_lane": deferred_work_lane,
+        "action": (
+            agent_scope_frontier.get("recommended_action")
+            or agent_scope_frontier.get("reason")
+            or "wait for a current-agent or unclaimed advancement todo before delivery"
+        ),
+    }
+
+
+def _payload_work_lane_contract(
+    work_lane_contract: dict[str, Any] | None,
+    *,
+    effective_action: str,
+    recovery_allowed: bool,
+    agent_scope_frontier: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if recovery_allowed and effective_action == "outcome_floor_recovery":
+        return None
+    if not isinstance(work_lane_contract, dict):
+        return work_lane_contract
+    if (
+        effective_action in AGENT_SCOPE_NON_EXECUTION_ACTIONS
+        and work_lane_contract.get("must_attempt_work") is True
+        and isinstance(agent_scope_frontier, dict)
+    ):
+        return _agent_scope_payload_work_lane_contract(
+            work_lane_contract,
+            effective_action=effective_action,
+            agent_scope_frontier=agent_scope_frontier,
+        )
+    return work_lane_contract
 
 
 def _focus_wait_quota(payload: dict[str, Any]) -> dict[str, Any]:
@@ -1968,10 +2049,11 @@ def build_quota_should_run(
             selected_recommended_action=selected_recommended_action,
         )
         agent_scope_action = _agent_scope_frontier_action(effective_action)
-        payload_work_lane_contract = (
-            None
-            if recovery_allowed and effective_action == "outcome_floor_recovery"
-            else work_lane_contract
+        payload_work_lane_contract = _payload_work_lane_contract(
+            work_lane_contract,
+            effective_action=effective_action,
+            recovery_allowed=recovery_allowed,
+            agent_scope_frontier=agent_scope_frontier,
         )
         payload = {
             "ok": bool(plan.get("ok")) or self_repair_allowed or capability_repair_allowed or workspace_repair_allowed,


### PR DESCRIPTION
## Summary
- Normalize legacy work_lane_contract in non-executing agent-scope wait/exhausted/reassignment modes so it cannot contradict interaction_contract.
- Preserve the original goal-level lane as compact deferred_work_lane diagnostic context instead of exposing it as a current execution obligation.
- Add a focused regression smoke for the monitor-only current-agent plus other-agent advancement frontier case, and update the status data contract wording.

## Validation
- python3 examples/control_plane/agent-scope-work-lane-consistency-smoke.py
- python3 examples/control_plane/work-lane-contract-smoke.py
- python3 examples/control_plane/quota-replan-decision-plane-smoke.py
- python3 examples/control_plane/repo-python-line-budget-smoke.py
- python3 -m py_compile loopx/quota.py examples/control_plane/agent-scope-work-lane-consistency-smoke.py
- loopx check --scan-path loopx/quota.py --scan-path examples/control_plane/agent-scope-work-lane-consistency-smoke.py --scan-path docs/status-data-contract.md
- loopx canary premerge --from-git-diff

## Notes
- Live narrow check for loopx-meta/codex-product-capability now reports effective_action=agent_scope_wait, work_lane_contract.must_attempt_work=false, and the old materialize_advancement_todo_or_blocker only under deferred_work_lane.