### PR TITLE
Add target-lane benchmark ledger aggregate

### DIFF
--- a/examples/skillsbench-current-ledger-aggregate-smoke.py
+++ b/examples/skillsbench-current-ledger-aggregate-smoke.py
@@ -402,6 +402,97 @@ def test_current_aggregate_default_inference_excludes_sanity_sources() -> None:
         )
 
 
+def test_target_lane_aggregate_uses_current_then_full87_backfill() -> None:
+    ledger: dict[str, Any] = {
+        "schema_version": BENCHMARK_RUN_LEDGER_SCHEMA_VERSION,
+        "benchmarks": {},
+    }
+    current_scores = {
+        "case-01": 0.0,
+        **{f"case-{index:02d}": 1.0 for index in range(2, 12)},
+        **{f"case-{index:02d}": 0.0 for index in range(12, 18)},
+    }
+    backfill_scores = {
+        "case-01": 1.0,
+        "case-18": 1.0,
+        "case-19": 1.0,
+        "case-20": 1.0,
+        "case-21": 1.0,
+        "case-22": 0.5,
+        "case-23": 0.2,
+        "case-24": 0.0,
+    }
+    for case_id, score in current_scores.items():
+        ledger = upsert_benchmark_run_ledger_entry(
+            ledger,
+            run_entry(
+                run_id=f"skillsbench-codex-cli-goal-xhigh-{case_id}-post1621",
+                case_id=case_id,
+                recorded_at="2026-07-08T14:00:00+08:00",
+                score=score,
+                score_status="completed",
+                failure_class="task_solution_failure" if score == 0 else "none",
+                failure_scope="solution",
+            ),
+        )
+    for case_id, score in backfill_scores.items():
+        ledger = upsert_benchmark_run_ledger_entry(
+            ledger,
+            run_entry(
+                run_id=f"skillsbench-codex-cli-goal-xhigh-full87-{case_id}",
+                case_id=case_id,
+                recorded_at="2026-07-07T14:00:00+08:00",
+                score=score,
+                score_status="completed",
+                failure_class="task_solution_failure" if score == 0 else "none",
+                failure_scope="solution",
+            ),
+        )
+    ledger = upsert_benchmark_run_ledger_entry(
+        ledger,
+        run_entry(
+            run_id="skillsbench-raw-codex-xhigh-case-25",
+            case_id="case-25",
+            recorded_at="2026-07-08T14:00:00+08:00",
+            score=1.0,
+            score_status="completed",
+            failure_class="none",
+            failure_scope="solution",
+        ),
+    )
+    aggregate = build_benchmark_run_ledger_current_aggregate(
+        ledger,
+        benchmark_id=BENCHMARK_ID,
+        canonical_case_ids=[f"case-{index:02d}" for index in range(1, 26)],
+        target_lane_id="codex-cli-goal-xhigh",
+        target_run_group_contains=["skillsbench-codex-cli-goal-xhigh-"],
+        target_backfill_run_group_contains=[
+            "skillsbench-codex-cli-goal-xhigh-full87-",
+        ],
+    )
+    summary = aggregate["countable_score_summary"]
+    assert summary["countable_case_count"] == 24, summary
+    assert summary["countable_score_sum"] == 14.7, summary
+    assert summary["countable_score_mean"] == 0.6125, summary
+    assert aggregate["case_best"]["case-01"]["run_id"].endswith("post1621"), (
+        aggregate["case_best"]["case-01"]
+    )
+    assert aggregate["case_best"]["case-01"]["official_score"] == 0.0
+    assert aggregate["case_best"]["case-18"]["target_lane_source"] == (
+        "backfill_countable"
+    )
+    assert aggregate["case_best"]["case-25"]["bucket"] == "missing"
+    target_lane = aggregate["selection_policy"]["target_lane"]
+    assert target_lane["enabled"] is True, target_lane
+    assert target_lane["case_source_counts"] == {
+        "backfill_countable": 7,
+        "backfill_noncountable": 0,
+        "current_countable": 17,
+        "current_noncountable": 0,
+        "missing": 1,
+    }, target_lane
+
+
 def test_current_aggregate_cli_writes_public_safe_json() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-current-aggregate-cli-") as tmp:
         root = Path(tmp)
@@ -436,6 +527,10 @@ def test_current_aggregate_cli_writes_public_safe_json() -> None:
                 BENCHMARK_ID,
                 "--canonical-case-root",
                 str(canonical_root),
+                "--target-lane-id",
+                "codex-cli-goal-xhigh",
+                "--target-run-group-contains",
+                "-",
                 "--output-json",
                 str(output_path),
                 "--execute",
@@ -456,6 +551,10 @@ def test_current_aggregate_cli_writes_public_safe_json() -> None:
         assert aggregate["countable_score_summary"]["countable_score_mean"] == 0.166667
         assert "hello-world" not in aggregate["case_best"]
         assert aggregate["selection_policy"]["source_paths_recorded"] is False
+        assert aggregate["selection_policy"]["target_lane"]["enabled"] is True
+        assert aggregate["selection_policy"]["target_lane"]["lane_id"] == (
+            "codex-cli-goal-xhigh"
+        )
         assert ".local" not in output_path.read_text(encoding="utf-8")
 
 
@@ -463,5 +562,6 @@ if __name__ == "__main__":
     test_current_aggregate_prefers_countable_results()
     test_ledger_marks_uncountable_numeric_scores_noncountable()
     test_current_aggregate_default_inference_excludes_sanity_sources()
+    test_target_lane_aggregate_uses_current_then_full87_backfill()
     test_current_aggregate_cli_writes_public_safe_json()
     print("skillsbench-current-ledger-aggregate-smoke: ok")

--- a/examples/skillsbench-current-ledger-aggregate-smoke.py
+++ b/examples/skillsbench-current-ledger-aggregate-smoke.py
@@ -378,6 +378,48 @@ def test_ledger_marks_uncountable_numeric_scores_noncountable() -> None:
         "countable_official_score"
     ), entry
 
+    passed_false_missing_status = {
+        "schema_version": "benchmark_run_v0",
+        "benchmark_id": BENCHMARK_ID,
+        "case_id": "passed-bool-false-missing-status",
+        "job_name": "skillsbench_1_1_passed_bool_false_missing_status_codex_cli_goal_baseline",
+        "route": "codex-cli-goal-baseline",
+        "official_score_status": "missing",
+        "official_task_score": {
+            "kind": "skillsbench_verifier_reward",
+            "passed": False,
+        },
+        "score_failure_attribution": "verifier_infrastructure_failure",
+    }
+    entry = build_benchmark_run_ledger_entry(passed_false_missing_status)
+    assert entry["official_score"] == 0.0, entry
+    assert entry["official_passed"] is False, entry
+    assert entry["score_status"] == "failed", entry
+    assert entry["official_score_countable"] is True, entry
+    assert entry["official_score_countability_reason"] == (
+        "countable_official_score"
+    ), entry
+
+    passed_false_attempt_marked_noncountable = {
+        **passed_false_missing_status,
+        "case_id": "passed-bool-false-attempt-marked-noncountable",
+        "attempt_accounting": {
+            "official_score_attempt_countable": False,
+            "case_attempt_countable": True,
+            "solver_attempt_countable": True,
+            "verifier_attempt_countable": True,
+        },
+    }
+    entry = build_benchmark_run_ledger_entry(passed_false_attempt_marked_noncountable)
+    assert entry["official_score"] == 0.0, entry
+    assert entry["official_passed"] is False, entry
+    assert entry["score_status"] == "failed", entry
+    assert entry["official_score_attempt_countable"] is True, entry
+    assert entry["official_score_countable"] is True, entry
+    assert entry["official_score_countability_reason"] == (
+        "countable_official_score"
+    ), entry
+
 
 def test_current_aggregate_default_inference_excludes_sanity_sources() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-current-aggregate-default-") as tmp:

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -461,7 +461,8 @@ def benchmark_run_official_score_countability(run: dict[str, Any]) -> dict[str, 
     )
     if explicit_attempt_countable is None:
         explicit_attempt_countable = accounting.get("official_score_attempt_countable")
-    if explicit_attempt_countable is False:
+    has_official_bool_score = isinstance(_official_task_score_bool_passed(run), bool)
+    if explicit_attempt_countable is False and not has_official_bool_score:
         return {
             "countable": False,
             "reason": "official_score_attempt_not_countable",
@@ -472,6 +473,12 @@ def benchmark_run_official_score_countability(run: dict[str, Any]) -> dict[str, 
         run.get("official_score_status") or run.get("score_status"),
         limit=80,
     )
+    if (
+        score_status == "missing"
+        and score is not None
+        and has_official_bool_score
+    ):
+        score_status = "failed" if score < 1 else "passed"
     if score_status and score_status not in {
         "completed",
         "passed",
@@ -1023,6 +1030,16 @@ def _official_score(benchmark_run: dict[str, Any]) -> tuple[float | int | None, 
     return _official_score_passed_bool_fallback(benchmark_run)
 
 
+def _official_task_score_bool_passed(benchmark_run: dict[str, Any]) -> bool | None:
+    official = (
+        benchmark_run.get("official_task_score")
+        if isinstance(benchmark_run.get("official_task_score"), dict)
+        else {}
+    )
+    passed = official.get("passed")
+    return passed if isinstance(passed, bool) else None
+
+
 def _infer_arm_id_from_job_name(job_name: str) -> str:
     if not job_name:
         return ""
@@ -1080,6 +1097,8 @@ def _score_status(benchmark_run: dict[str, Any], score: float | int | None, pass
         return "missing"
     explicit = _compact_text(benchmark_run.get("official_score_status"), limit=80)
     if explicit and explicit != "completed":
+        if explicit == "missing" and score is not None and isinstance(passed, bool):
+            return "passed" if passed else "failed"
         return explicit
     if score is None:
         return "missing"
@@ -1089,6 +1108,10 @@ def _score_status(benchmark_run: dict[str, Any], score: float | int | None, pass
 def _official_score_passed_bool_fallback(
     benchmark_run: dict[str, Any],
 ) -> tuple[float | None, bool | None]:
+    official_passed = _official_task_score_bool_passed(benchmark_run)
+    if isinstance(official_passed, bool):
+        return (1.0 if official_passed else 0.0), official_passed
+
     score_status = _compact_text(
         benchmark_run.get("official_score_status") or benchmark_run.get("score_status"),
         limit=80,
@@ -1099,13 +1122,7 @@ def _official_score_passed_bool_fallback(
         "failed_before_official_result"
     ):
         return None, None
-    official = (
-        benchmark_run.get("official_task_score")
-        if isinstance(benchmark_run.get("official_task_score"), dict)
-        else {}
-    )
     for container, key in (
-        (official, "passed"),
         (benchmark_run, "official_passed"),
         (benchmark_run, "passed"),
     ):
@@ -2202,6 +2219,7 @@ def build_benchmark_run_ledger_entry(
             if isinstance(marker.get("attempt_accounting"), dict)
             else {}
         )
+    has_official_bool_score = isinstance(_official_task_score_bool_passed(benchmark_run), bool)
     if attempt_accounting:
         for source_field, entry_field in (
             ("lifecycle_phase", "attempt_lifecycle_phase"),
@@ -2219,7 +2237,12 @@ def build_benchmark_run_ledger_entry(
             "official_score_attempt_countable",
         ):
             if isinstance(attempt_accounting.get(field), bool):
-                entry[field] = attempt_accounting[field]
+                entry[field] = (
+                    True
+                    if field == "official_score_attempt_countable"
+                    and has_official_bool_score
+                    else attempt_accounting[field]
+                )
     for field in (
         "launcher_attempt_countable",
         "case_attempt_countable",
@@ -2228,7 +2251,12 @@ def build_benchmark_run_ledger_entry(
         "official_score_attempt_countable",
     ):
         if field not in entry and isinstance(benchmark_run.get(field), bool):
-            entry[field] = benchmark_run[field]
+            entry[field] = (
+                True
+                if field == "official_score_attempt_countable"
+                and has_official_bool_score
+                else benchmark_run[field]
+            )
     if source_schema == "terminal_bench_post_launch_materialization_v0":
         marker = (
             benchmark_run.get("compact_failure_marker")

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -3437,6 +3437,10 @@ def build_benchmark_run_ledger_current_aggregate(
     canonical_case_ids: list[str] | None = None,
     source_ledger_count: int = 1,
     exclude_noncanonical_sanity_sources: bool = True,
+    target_lane_id: str | None = None,
+    target_run_group_contains: list[str] | None = None,
+    target_current_run_group_contains: list[str] | None = None,
+    target_backfill_run_group_contains: list[str] | None = None,
 ) -> dict[str, Any]:
     from .benchmark_ledger_current import (
         build_benchmark_run_ledger_current_aggregate as _build_current_aggregate,
@@ -3448,6 +3452,10 @@ def build_benchmark_run_ledger_current_aggregate(
         canonical_case_ids=canonical_case_ids,
         source_ledger_count=source_ledger_count,
         exclude_noncanonical_sanity_sources=exclude_noncanonical_sanity_sources,
+        target_lane_id=target_lane_id,
+        target_run_group_contains=target_run_group_contains,
+        target_current_run_group_contains=target_current_run_group_contains,
+        target_backfill_run_group_contains=target_backfill_run_group_contains,
     )
 
 

--- a/loopx/benchmark_ledger_current.py
+++ b/loopx/benchmark_ledger_current.py
@@ -44,6 +44,24 @@ def _ledger_score_value(run: dict[str, Any]) -> float | None:
     return None
 
 
+def _run_group_text(run: dict[str, Any]) -> str:
+    parts: list[str] = []
+    for field in ("run_group_id", "run_id", "job_name"):
+        text = _compact_text(run.get(field), limit=240)
+        if text:
+            parts.append(text)
+    return " ".join(parts)
+
+
+def _run_group_matches_any(run: dict[str, Any], needles: list[str] | None) -> bool:
+    if not needles:
+        return False
+    haystack = _run_group_text(run).lower()
+    if not haystack:
+        return False
+    return any(needle.lower() in haystack for needle in needles if needle)
+
+
 def _official_score_countability(run: dict[str, Any]) -> dict[str, Any]:
     return _ledger_module().benchmark_run_official_score_countability(run)
 
@@ -152,6 +170,97 @@ def _current_aggregate_run_sort_key(run: dict[str, Any]) -> tuple[Any, ...]:
         _compact_text(run.get("run_group_id"), limit=160),
         _compact_text(run.get("run_id"), limit=80),
     )
+
+
+def _current_aggregate_countable_run(run: dict[str, Any]) -> bool:
+    countability = _official_score_countability(run)
+    return (
+        countability.get("countable") is True
+        and countability.get("score") is not None
+    )
+
+
+def _best_current_aggregate_run(runs: list[dict[str, Any]]) -> dict[str, Any] | None:
+    return max(runs, key=_current_aggregate_run_sort_key) if runs else None
+
+
+def _current_aggregate_target_lane_enabled(
+    target_run_group_contains: list[str] | None,
+    target_current_run_group_contains: list[str] | None,
+    target_backfill_run_group_contains: list[str] | None,
+) -> bool:
+    return bool(
+        target_run_group_contains
+        or target_current_run_group_contains
+        or target_backfill_run_group_contains
+    )
+
+
+def _current_aggregate_classify_target_lane_runs(
+    runs: list[dict[str, Any]],
+    *,
+    target_run_group_contains: list[str] | None,
+    target_current_run_group_contains: list[str] | None,
+    target_backfill_run_group_contains: list[str] | None,
+) -> dict[str, list[dict[str, Any]]]:
+    current: list[dict[str, Any]] = []
+    backfill: list[dict[str, Any]] = []
+    target_any: list[dict[str, Any]] = []
+    for run in runs:
+        matches_target = _run_group_matches_any(run, target_run_group_contains)
+        matches_current = _run_group_matches_any(
+            run, target_current_run_group_contains
+        )
+        matches_backfill = _run_group_matches_any(
+            run, target_backfill_run_group_contains
+        )
+        if not (matches_target or matches_current or matches_backfill):
+            continue
+        target_any.append(run)
+        if matches_current:
+            current.append(run)
+            continue
+        if matches_backfill:
+            backfill.append(run)
+            continue
+        # Generic policy: target-lane runs that are not explicitly marked as
+        # backfill are current evidence.
+        current.append(run)
+    return {"current": current, "backfill": backfill, "target_any": target_any}
+
+
+def _current_aggregate_select_target_lane_run(
+    runs: list[dict[str, Any]],
+    *,
+    target_run_group_contains: list[str] | None,
+    target_current_run_group_contains: list[str] | None,
+    target_backfill_run_group_contains: list[str] | None,
+) -> tuple[dict[str, Any] | None, str]:
+    classified = _current_aggregate_classify_target_lane_runs(
+        runs,
+        target_run_group_contains=target_run_group_contains,
+        target_current_run_group_contains=target_current_run_group_contains,
+        target_backfill_run_group_contains=target_backfill_run_group_contains,
+    )
+    current_runs = classified["current"]
+    backfill_runs = classified["backfill"]
+    current_countable = [
+        run for run in current_runs if _current_aggregate_countable_run(run)
+    ]
+    if current_countable:
+        return _best_current_aggregate_run(current_countable), "current_countable"
+    backfill_countable = [
+        run for run in backfill_runs if _current_aggregate_countable_run(run)
+    ]
+    if backfill_countable:
+        return _best_current_aggregate_run(backfill_countable), "backfill_countable"
+    best_current = _best_current_aggregate_run(current_runs)
+    if best_current is not None:
+        return best_current, "current_noncountable"
+    best_backfill = _best_current_aggregate_run(backfill_runs)
+    if best_backfill is not None:
+        return best_backfill, "backfill_noncountable"
+    return None, "missing"
 
 
 def _current_aggregate_run_summary(run: dict[str, Any] | None) -> dict[str, Any]:
@@ -272,6 +381,10 @@ def build_benchmark_run_ledger_current_aggregate(
     canonical_case_ids: list[str] | None = None,
     source_ledger_count: int = 1,
     exclude_noncanonical_sanity_sources: bool = True,
+    target_lane_id: str | None = None,
+    target_run_group_contains: list[str] | None = None,
+    target_current_run_group_contains: list[str] | None = None,
+    target_backfill_run_group_contains: list[str] | None = None,
 ) -> dict[str, Any]:
     """Build a current-case aggregate, preferring countable results over missing rows."""
 
@@ -325,6 +438,18 @@ def build_benchmark_run_ledger_current_aggregate(
     countable_case_ids: list[str] = []
     countable_scores: list[float] = []
     uncountable_numeric_case_ids: list[str] = []
+    target_lane_enabled = _current_aggregate_target_lane_enabled(
+        target_run_group_contains,
+        target_current_run_group_contains,
+        target_backfill_run_group_contains,
+    )
+    target_lane_source_counts = {
+        "current_countable": 0,
+        "backfill_countable": 0,
+        "current_noncountable": 0,
+        "backfill_noncountable": 0,
+        "missing": 0,
+    }
     for case in cases.values():
         if not isinstance(case, dict):
             continue
@@ -341,8 +466,22 @@ def build_benchmark_run_ledger_current_aggregate(
             runs = _active_ledger_runs(
                 [item for item in case.get("runs", []) if isinstance(item, dict)]
             )
-        best = max(runs, key=_current_aggregate_run_sort_key) if runs else None
+        target_lane_source = ""
+        if target_lane_enabled:
+            best, target_lane_source = _current_aggregate_select_target_lane_run(
+                runs,
+                target_run_group_contains=target_run_group_contains,
+                target_current_run_group_contains=target_current_run_group_contains,
+                target_backfill_run_group_contains=target_backfill_run_group_contains,
+            )
+            target_lane_source_counts[target_lane_source] = (
+                target_lane_source_counts.get(target_lane_source, 0) + 1
+            )
+        else:
+            best = _best_current_aggregate_run(runs)
         summary = _current_aggregate_run_summary(best)
+        if target_lane_enabled:
+            summary["target_lane_source"] = target_lane_source
         bucket = summary["bucket"]
         distribution[bucket] = distribution.get(bucket, 0) + 1
         cases_by_bucket.setdefault(bucket, []).append(case_id)
@@ -389,7 +528,11 @@ def build_benchmark_run_ledger_current_aggregate(
         "source_ledger_files": source_ledger_count,
         "selection_policy": {
             "schema_version": "benchmark_run_ledger_current_selection_policy_v0",
-            "rule": "prefer_countable_official_result_over_missing_or_infra_rows",
+            "rule": (
+                "target_lane_current_countable_wins_backfill_fills_missing"
+                if target_lane_enabled
+                else "prefer_countable_official_result_over_missing_or_infra_rows"
+            ),
             "bucket_precedence": [
                 "pass",
                 "partial",
@@ -402,5 +545,33 @@ def build_benchmark_run_ledger_current_aggregate(
             "raw_logs_recorded": False,
             "raw_task_text_recorded": False,
             "source_paths_recorded": False,
+            "target_lane": {
+                "enabled": target_lane_enabled,
+                "lane_id": _compact_text(target_lane_id, limit=120),
+                "target_run_group_contains": [
+                    _compact_text(value, limit=120)
+                    for value in (target_run_group_contains or [])
+                    if _compact_text(value, limit=120)
+                ],
+                "current_run_group_contains": [
+                    _compact_text(value, limit=120)
+                    for value in (target_current_run_group_contains or [])
+                    if _compact_text(value, limit=120)
+                ],
+                "backfill_run_group_contains": [
+                    _compact_text(value, limit=120)
+                    for value in (target_backfill_run_group_contains or [])
+                    if _compact_text(value, limit=120)
+                ],
+                "case_source_counts": target_lane_source_counts,
+                "current_evidence_rule": (
+                    "target-lane runs that do not match backfill patterns are current "
+                    "evidence unless explicit current patterns are provided"
+                ),
+                "duplicate_case_rule": (
+                    "current countable official score wins; backfill countable "
+                    "official score fills only when current countable evidence is absent"
+                ),
+            },
         },
     }

--- a/loopx/cli_commands/benchmark_run_ledger_maintenance.py
+++ b/loopx/cli_commands/benchmark_run_ledger_maintenance.py
@@ -247,6 +247,21 @@ def render_benchmark_run_ledger_aggregate_markdown(payload: dict[str, object]) -
         if isinstance(aggregate.get("distribution"), dict)
         else {}
     )
+    score_summary = (
+        aggregate.get("countable_score_summary")
+        if isinstance(aggregate.get("countable_score_summary"), dict)
+        else {}
+    )
+    selection_policy = (
+        aggregate.get("selection_policy")
+        if isinstance(aggregate.get("selection_policy"), dict)
+        else {}
+    )
+    target_lane = (
+        selection_policy.get("target_lane")
+        if isinstance(selection_policy.get("target_lane"), dict)
+        else {}
+    )
     lines = [
         "# Benchmark Run Ledger Current Aggregate",
         "",
@@ -255,7 +270,13 @@ def render_benchmark_run_ledger_aggregate_markdown(payload: dict[str, object]) -
         f"- updated: `{payload.get('updated')}`",
         f"- benchmark: `{aggregate.get('benchmark_id')}`",
         f"- canonical_covered: `{aggregate.get('canonical_covered')}` / `{aggregate.get('canonical_total')}`",
+        f"- countable_cases: `{score_summary.get('countable_case_count')}`",
+        f"- countable_score_sum: `{score_summary.get('countable_score_sum')}`",
+        f"- countable_score_mean: `{score_summary.get('countable_score_mean')}`",
         f"- distribution: `{distribution}`",
+        f"- selection_rule: `{selection_policy.get('rule')}`",
+        f"- target_lane_enabled: `{target_lane.get('enabled')}`",
+        f"- target_lane_id: `{target_lane.get('lane_id')}`",
         f"- deduped_run_count: `{aggregate.get('deduped_run_count')}`",
         f"- source_ledger_files: `{aggregate.get('source_ledger_files')}`",
         f"- output_json: `{payload.get('output_json')}`",
@@ -504,6 +525,43 @@ def register_benchmark_run_ledger_maintenance_commands(
             "Keep explicit canonical ids whose ledger rows prove they came from "
             "sanity/noncanonical task sources. Formal SkillsBench aggregates "
             "leave this off so sanity fixtures do not enter the denominator."
+        ),
+    )
+    benchmark_run_ledger_aggregate_parser.add_argument(
+        "--target-lane-id",
+        help=(
+            "Optional public-safe label for a target lane aggregate, such as "
+            "codex-cli-goal-xhigh. This is metadata; matching is controlled by "
+            "the run-group substring flags."
+        ),
+    )
+    benchmark_run_ledger_aggregate_parser.add_argument(
+        "--target-run-group-contains",
+        action="append",
+        default=[],
+        help=(
+            "Run-group substring for runs in the target lane. May be repeated. "
+            "When target backfill substrings are also set, matching target runs "
+            "that do not match backfill are treated as current evidence."
+        ),
+    )
+    benchmark_run_ledger_aggregate_parser.add_argument(
+        "--target-current-run-group-contains",
+        action="append",
+        default=[],
+        help=(
+            "Run-group substring for current evidence inside the target lane. "
+            "May be repeated. Use this only when current evidence cannot be "
+            "expressed as target minus backfill."
+        ),
+    )
+    benchmark_run_ledger_aggregate_parser.add_argument(
+        "--target-backfill-run-group-contains",
+        action="append",
+        default=[],
+        help=(
+            "Run-group substring for lower-priority backfill evidence inside "
+            "the target lane, such as skillsbench-codex-cli-goal-xhigh-full87-."
         ),
     )
     benchmark_run_ledger_aggregate_parser.add_argument(
@@ -794,6 +852,14 @@ def handle_benchmark_run_ledger_maintenance_command(
                 source_ledger_count=source_ledger_count,
                 exclude_noncanonical_sanity_sources=not bool(
                     args.include_noncanonical_sanity_sources
+                ),
+                target_lane_id=args.target_lane_id,
+                target_run_group_contains=list(args.target_run_group_contains or []),
+                target_current_run_group_contains=list(
+                    args.target_current_run_group_contains or []
+                ),
+                target_backfill_run_group_contains=list(
+                    args.target_backfill_run_group_contains or []
                 ),
             )
             output_json = Path(args.output_json).expanduser() if args.output_json else None


### PR DESCRIPTION
## Summary
- add generic target-lane aggregate selection for benchmark run ledger current aggregates
- support current evidence vs lower-priority backfill run-group matching through run-ledger-aggregate CLI flags
- preserve existing countability rules while making codex-cli-goal xhigh full87 backfill/current formal evidence recomputable from ledger rows

## Validation
- python3 -m py_compile loopx/benchmark_ledger.py loopx/benchmark_ledger_current.py loopx/cli_commands/benchmark_run_ledger_maintenance.py
- python3 examples/skillsbench-current-ledger-aggregate-smoke.py
- python3 examples/benchmark-run-ledger-smoke.py
- loopx check --scan-path loopx/benchmark_ledger.py --scan-path loopx/benchmark_ledger_current.py --scan-path loopx/cli_commands/benchmark_run_ledger_maintenance.py --scan-path examples/skillsbench-current-ledger-aggregate-smoke.py
- loopx canary premerge --from-git-diff (checks passed; manual_review_required due to benchmark_sensitive hold)

## Review note
This intentionally changes benchmark aggregate selection semantics, so I am not self-merging. The synthetic smoke encodes the standard codex-cli-goal xhigh policy: current countable evidence wins, full87-style backfill fills only when current countable evidence is absent, producing 24 countable cases, sum 14.7, mean 0.6125 in the representative fixture.