### PR TITLE
Accept stale monitor scheduler ACK hints

### DIFF
--- a/examples/control_plane/quota-scheduler-state-ack-smoke.py
+++ b/examples/control_plane/quota-scheduler-state-ack-smoke.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from datetime import datetime, timedelta, timezone
 import importlib.util
 import json
 from pathlib import Path
@@ -16,7 +17,9 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.control_plane.testing.canary_harness import run_json_cli  # noqa: E402
+from loopx.control_plane.scheduler import scheduler_hint as scheduler_hint_module  # noqa: E402
 from loopx.control_plane.scheduler.scheduler_hint import (  # noqa: E402
+    build_codex_app_scheduler_ack_event,
     build_scheduler_ack_plan,
     build_scheduler_hint,
 )
@@ -30,6 +33,7 @@ from loopx.status import AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK  # noqa: E402
 
 
 AGENT_SCOPE_ACTIONS = [action.value for action in AgentScopeFrontierAction]
+FROZEN_NOW = datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
 
 
 def _load_quota_plan_fixture_module():
@@ -95,6 +99,27 @@ def monitor_payload(*, recommended_action: str = "Wait for material monitor evid
     }
 
 
+def monitor_window_payload(*, minutes_until_due: int = 119) -> dict:
+    due_at = FROZEN_NOW + timedelta(minutes=minutes_until_due)
+    expires_at = FROZEN_NOW + timedelta(minutes=minutes_until_due + 60)
+    payload = monitor_payload()
+    payload["agent_todo_summary"] = {
+        "current_agent_claimed_monitor_items": [
+            {
+                "todo_id": "todo_monitor_window_stale_ack",
+                "priority": "P1",
+                "task_class": "continuous_monitor",
+                "target_key": "monitor-window-stale-ack",
+                "cadence": "3m",
+                "next_due_at": due_at.isoformat(),
+                "expires_at": expires_at.isoformat(),
+            }
+        ],
+        "monitor_open_items": [],
+    }
+    return payload
+
+
 def active_payload() -> dict:
     return {
         "goal_id": "scheduler-state-ack-smoke",
@@ -144,6 +169,24 @@ def state_from_hint_with_applied_rrule(hint: dict, *, index: int, rrule: str) ->
     state["progression_index"] = index
     state["last_applied_rrule"] = rrule
     return state
+
+
+def build_hint_at(
+    payload: dict,
+    *,
+    now: datetime,
+    scheduler_state: dict | None = None,
+) -> dict:
+    original_now_utc = scheduler_hint_module.now_utc
+    try:
+        scheduler_hint_module.now_utc = lambda: now
+        return build_scheduler_hint(
+            deepcopy(payload),
+            agent_scope_frontier_actions=AGENT_SCOPE_ACTIONS,
+            codex_app_scheduler_state=scheduler_state,
+        )
+    finally:
+        scheduler_hint_module.now_utc = original_now_utc
 
 
 def assert_policy_state_progression() -> None:
@@ -438,6 +481,106 @@ def assert_scheduler_ack_plan_validation() -> None:
         "already_applied": True,
         "applied_rrule": "",
     }, already_applied
+
+
+def assert_monitor_wait_stale_ack_hint_is_accepted() -> None:
+    base = monitor_window_payload(minutes_until_due=119)
+    first = build_hint_at(base, now=FROZEN_NOW)
+    second = build_hint_at(base, now=FROZEN_NOW, scheduler_state=state_from(first))
+    third = build_hint_at(base, now=FROZEN_NOW, scheduler_state=state_from(second))
+    previous_state = state_from(third)
+
+    stale_hint_source = build_hint_at(
+        base,
+        now=FROZEN_NOW,
+        scheduler_state=previous_state,
+    )
+    stale_app = stale_hint_source["codex_app"]
+    stale_ack_args = stale_app["ack_hint"]["args"]
+    assert stale_hint_source["cadence_class"] == "monitor_wait", stale_hint_source
+    assert stale_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=119", stale_hint_source
+
+    current_hint = build_hint_at(
+        base,
+        now=FROZEN_NOW + timedelta(minutes=1),
+        scheduler_state=previous_state,
+    )
+    current_app = current_hint["codex_app"]
+    assert current_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=118", current_hint
+    assert (
+        current_app["stateful_backoff"]["reset_token"]
+        == stale_ack_args["reset_token"]
+    ), current_hint
+    assert (
+        current_app["stateful_backoff"]["identity_signature"]
+        == stale_ack_args["identity_signature"]
+    ), current_hint
+
+    plan = build_scheduler_ack_plan(
+        {"scheduler_hint": current_hint},
+        agent_id=stale_ack_args["agent_id"],
+        state_key=stale_ack_args["state_key"],
+        applied_rrule=stale_ack_args["applied_rrule"],
+        reset_token=stale_ack_args["reset_token"],
+        identity_signature=stale_ack_args["identity_signature"],
+    )
+    assert plan == {
+        "ok": True,
+        "already_applied": False,
+        "applied_rrule": "FREQ=MINUTELY;INTERVAL=119",
+        "expected_rrule": "FREQ=MINUTELY;INTERVAL=118",
+        "stale_hint_accepted": True,
+        "stale_hint_tolerance_minutes": 2,
+    }, plan
+
+    event = build_codex_app_scheduler_ack_event(
+        {"goal_id": "scheduler-state-ack-smoke", "scheduler_hint": current_hint},
+        agent_id=stale_ack_args["agent_id"],
+        applied_rrule=stale_ack_args["applied_rrule"],
+        reset_token=stale_ack_args["reset_token"],
+        identity_signature=stale_ack_args["identity_signature"],
+    )
+    ack_event = event["scheduler_ack_event"]
+    assert ack_event["applied_rrule"] == "FREQ=MINUTELY;INTERVAL=119", event
+    assert ack_event["expected_rrule"] == "FREQ=MINUTELY;INTERVAL=118", event
+    assert ack_event["stale_hint_accepted"] is True, event
+    assert (
+        ack_event["scheduler_state"]["last_applied_rrule"]
+        == "FREQ=MINUTELY;INTERVAL=119"
+    ), event
+    quiet_after_stale_ack = build_hint_at(
+        base,
+        now=FROZEN_NOW + timedelta(minutes=1),
+        scheduler_state=ack_event["scheduler_state"],
+    )
+    quiet_app = quiet_after_stale_ack["codex_app"]
+    assert quiet_app["stateful_backoff"]["apply_needed"] is False, quiet_after_stale_ack
+    assert quiet_app["host_action"] == "none", quiet_after_stale_ack
+    assert "recommended_rrule" not in quiet_app, quiet_after_stale_ack
+
+    outside_state_tolerance = build_hint_at(
+        base,
+        now=FROZEN_NOW + timedelta(minutes=3),
+        scheduler_state=ack_event["scheduler_state"],
+    )
+    outside_app = outside_state_tolerance["codex_app"]
+    assert outside_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=116", (
+        outside_state_tolerance
+    )
+    assert outside_app["stateful_backoff"]["apply_needed"] is True, (
+        outside_state_tolerance
+    )
+
+    outside_tolerance = build_scheduler_ack_plan(
+        {"scheduler_hint": current_hint},
+        agent_id=stale_ack_args["agent_id"],
+        state_key=stale_ack_args["state_key"],
+        applied_rrule="FREQ=MINUTELY;INTERVAL=121",
+        reset_token=stale_ack_args["reset_token"],
+        identity_signature=stale_ack_args["identity_signature"],
+    )
+    assert outside_tolerance["ok"] is False, outside_tolerance
+    assert "does not match expected" in outside_tolerance["reason"], outside_tolerance
 
 
 def assert_scheduler_state_scope_validation() -> None:
@@ -738,6 +881,7 @@ def main() -> int:
     assert_monitor_wait_progression_reaches_120()
     assert_active_work_keeps_initial_cadence()
     assert_scheduler_ack_plan_validation()
+    assert_monitor_wait_stale_ack_hint_is_accepted()
     assert_scheduler_state_scope_validation()
     assert_cli_scheduler_ack_progression()
     assert_cli_ignores_corrupt_scheduler_state()

--- a/loopx/control_plane/quota/scheduler_ack.py
+++ b/loopx/control_plane/quota/scheduler_ack.py
@@ -59,6 +59,8 @@ def build_quota_scheduler_ack_event(
     applied_rrule: str,
     surface: str = CODEX_APP_SURFACE,
     state_key: str = CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
+    reset_token: str | None = None,
+    identity_signature: str | None = None,
     generated_at: str | None = None,
     reason_summary: str | None = None,
 ) -> dict[str, Any]:
@@ -69,6 +71,8 @@ def build_quota_scheduler_ack_event(
         classification=QUOTA_SCHEDULER_ACK_CLASSIFICATION,
         surface=surface,
         state_key=state_key,
+        reset_token=reset_token,
+        identity_signature=identity_signature,
         generated_at=generated_at or _now_local(),
         reason_summary=reason_summary,
         compact_before=compact_quota_decision(before),
@@ -135,6 +139,8 @@ def record_quota_scheduler_ack_for_decision(
             applied_rrule=str(applied_rrule),
             surface=surface,
             state_key=state_key,
+            reset_token=reset_token,
+            identity_signature=identity_signature,
             generated_at=safe_generated_at,
             reason_summary=reason_summary,
         )

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -29,6 +29,7 @@ MONITOR_WAIT_PROGRESSION_MINUTES = [15, 30, 60, 120]
 DEFAULT_ACK_CAPABILITIES = {"shell", "filesystem_read", "filesystem_write"}
 MONITOR_WAIT_HOST_FLOOR_MINUTES = 15
 MONITOR_WAIT_NEAR_WINDOW_LEAD_MINUTES = 60
+SCHEDULER_ACK_STALE_HINT_TOLERANCE_MINUTES = 2
 MONITOR_WAIT_PHASE_RANK = {
     "active_window": 0,
     "near_window": 1,
@@ -42,6 +43,122 @@ def normalize_scheduler_rrule(value: Any) -> str:
     if text.upper().startswith("RRULE:"):
         text = text[6:].strip()
     return text
+
+
+def _scheduler_rrule_interval_minutes(value: Any) -> int | None:
+    text = normalize_scheduler_rrule(value)
+    parts: dict[str, str] = {}
+    for part in text.split(";"):
+        key, separator, raw_value = part.partition("=")
+        if separator:
+            parts[key.strip().upper()] = raw_value.strip()
+    if parts.get("FREQ", "").upper() != "MINUTELY":
+        return None
+    try:
+        interval = int(parts.get("INTERVAL", ""))
+    except ValueError:
+        return None
+    return interval if interval > 0 else None
+
+
+def _accepts_stale_monitor_ack_rrule(
+    scheduler_hint: dict[str, Any],
+    stateful_backoff: dict[str, Any],
+    *,
+    applied_rrule: str,
+    expected_rrule: str,
+    reset_token: str | None,
+    identity_signature: str | None,
+) -> bool:
+    if str(scheduler_hint.get("cadence_class") or "") != "monitor_wait":
+        return False
+    safe_reset_token = str(reset_token or "").strip()
+    safe_identity_signature = str(identity_signature or "").strip()
+    if not safe_reset_token or not safe_identity_signature:
+        return False
+    if safe_reset_token != str(stateful_backoff.get("reset_token") or ""):
+        return False
+    if safe_identity_signature != str(stateful_backoff.get("identity_signature") or ""):
+        return False
+    applied_minutes = _scheduler_rrule_interval_minutes(applied_rrule)
+    expected_minutes = _scheduler_rrule_interval_minutes(expected_rrule)
+    if applied_minutes is None or expected_minutes is None:
+        return False
+    if applied_minutes < expected_minutes:
+        return False
+    return (
+        applied_minutes - expected_minutes
+        <= SCHEDULER_ACK_STALE_HINT_TOLERANCE_MINUTES
+    )
+
+
+def _monitor_rrule_applied_within_stale_tolerance(
+    *,
+    cadence_class: str,
+    last_applied_rrule: str,
+    current_rrule: str,
+) -> bool:
+    if cadence_class != "monitor_wait":
+        return False
+    applied_minutes = _scheduler_rrule_interval_minutes(last_applied_rrule)
+    current_minutes = _scheduler_rrule_interval_minutes(current_rrule)
+    if applied_minutes is None or current_minutes is None:
+        return False
+    if applied_minutes < current_minutes:
+        return False
+    return (
+        applied_minutes - current_minutes
+        <= SCHEDULER_ACK_STALE_HINT_TOLERANCE_MINUTES
+    )
+
+
+def _scheduler_ack_rrule_acceptance(
+    scheduler_hint: dict[str, Any],
+    codex_app: dict[str, Any],
+    stateful_backoff: dict[str, Any],
+    *,
+    applied_rrule: str,
+    reset_token: str | None,
+    identity_signature: str | None,
+) -> dict[str, Any]:
+    expected_rrule = normalize_scheduler_rrule(
+        codex_app.get("recommended_rrule") or stateful_backoff.get("current_rrule")
+    )
+    if not expected_rrule:
+        return {
+            "ok": False,
+            "reason": "quota scheduler-ack has no current recommended_rrule to acknowledge",
+            "expected_rrule": "",
+        }
+    if applied_rrule == expected_rrule:
+        return {
+            "ok": True,
+            "applied_rrule": applied_rrule,
+            "expected_rrule": expected_rrule,
+        }
+    if _accepts_stale_monitor_ack_rrule(
+        scheduler_hint,
+        stateful_backoff,
+        applied_rrule=applied_rrule,
+        expected_rrule=expected_rrule,
+        reset_token=reset_token,
+        identity_signature=identity_signature,
+    ):
+        return {
+            "ok": True,
+            "applied_rrule": applied_rrule,
+            "expected_rrule": expected_rrule,
+            "stale_hint_accepted": True,
+            "stale_hint_tolerance_minutes": SCHEDULER_ACK_STALE_HINT_TOLERANCE_MINUTES,
+        }
+    return {
+        "ok": False,
+        "reason": (
+            f"quota scheduler-ack applied_rrule {applied_rrule!r} "
+            f"does not match expected {expected_rrule!r}"
+        ),
+        "expected_rrule": expected_rrule,
+    }
 
 
 def scheduler_backoff_packet(
@@ -150,7 +267,7 @@ def build_scheduler_ack_plan(
     identity_signature: str | None = None,
 ) -> dict[str, Any]:
     safe_agent_id = str(agent_id or "").strip()
-    _, codex_app, stateful_backoff = scheduler_backoff_packet(before)
+    scheduler_hint, codex_app, stateful_backoff = scheduler_backoff_packet(before)
     if not safe_agent_id:
         return {
             "ok": False,
@@ -186,28 +303,36 @@ def build_scheduler_ack_plan(
             "already_applied": True,
             "applied_rrule": safe_applied_rrule,
         }
-    expected_rrule = normalize_scheduler_rrule(
-        codex_app.get("recommended_rrule") or stateful_backoff.get("current_rrule")
-    )
     if not safe_applied_rrule:
         return {
             "ok": False,
             "reason": "`loopx quota scheduler-ack` requires --applied-rrule when apply_needed=true",
         }
-    if expected_rrule and safe_applied_rrule != expected_rrule:
+    acceptance = _scheduler_ack_rrule_acceptance(
+        scheduler_hint,
+        codex_app,
+        stateful_backoff,
+        applied_rrule=safe_applied_rrule,
+        reset_token=reset_token,
+        identity_signature=identity_signature,
+    )
+    if not acceptance.get("ok"):
         return {
             "ok": False,
-            "reason": (
-                f"quota scheduler-ack applied_rrule {safe_applied_rrule!r} "
-                f"does not match expected {expected_rrule!r}"
-            ),
+            "reason": str(acceptance.get("reason") or "scheduler ack RRULE validation failed"),
         }
-    return {
+    result = {
         "ok": True,
         "already_applied": False,
-        "applied_rrule": safe_applied_rrule,
-        "expected_rrule": expected_rrule,
+        "applied_rrule": acceptance["applied_rrule"],
+        "expected_rrule": acceptance["expected_rrule"],
     }
+    if acceptance.get("stale_hint_accepted"):
+        result["stale_hint_accepted"] = True
+        result["stale_hint_tolerance_minutes"] = acceptance.get(
+            "stale_hint_tolerance_minutes"
+        )
+    return result
 
 
 def _int_number(value: Any, *, default: int) -> int:
@@ -404,6 +529,8 @@ def build_codex_app_scheduler_ack_event(
     classification: str = "quota_scheduler_ack",
     surface: str = CODEX_APP_SURFACE,
     state_key: str = CODEX_APP_STATEFUL_BACKOFF_STATE_KEY,
+    reset_token: str | None = None,
+    identity_signature: str | None = None,
     generated_at: str | None = None,
     reason_summary: str | None = None,
     compact_before: dict[str, Any] | None = None,
@@ -411,23 +538,26 @@ def build_codex_app_scheduler_ack_event(
     safe_agent_id = str(agent_id or "").strip()
     if not safe_agent_id:
         raise ValueError("quota scheduler-ack requires a scoped --agent-id")
-    _, codex_app, stateful_backoff = scheduler_backoff_packet(before)
+    scheduler_hint, codex_app, stateful_backoff = scheduler_backoff_packet(before)
     if not stateful_backoff:
         raise ValueError("quota scheduler-ack requires scheduler_hint.codex_app.stateful_backoff")
     if str(stateful_backoff.get("state_key") or "") != state_key:
         raise ValueError("quota scheduler-ack state_key does not match current quota scheduler hint")
     if stateful_backoff.get("apply_needed") is not True:
         raise ValueError("quota scheduler-ack is not needed because the current RRULE is already applied")
-    expected_rrule = normalize_scheduler_rrule(
-        codex_app.get("recommended_rrule") or stateful_backoff.get("current_rrule")
-    )
     safe_applied_rrule = normalize_scheduler_rrule(applied_rrule)
-    if not expected_rrule:
-        raise ValueError("quota scheduler-ack has no current recommended_rrule to acknowledge")
-    if safe_applied_rrule != expected_rrule:
-        raise ValueError(
-            f"quota scheduler-ack applied_rrule {safe_applied_rrule!r} does not match expected {expected_rrule!r}"
-        )
+    acceptance = _scheduler_ack_rrule_acceptance(
+        scheduler_hint,
+        codex_app,
+        stateful_backoff,
+        applied_rrule=safe_applied_rrule,
+        reset_token=reset_token,
+        identity_signature=identity_signature,
+    )
+    if not acceptance.get("ok"):
+        raise ValueError(str(acceptance.get("reason") or "scheduler ack RRULE validation failed"))
+    expected_rrule = acceptance["expected_rrule"]
+    acknowledged_rrule = acceptance["applied_rrule"]
     codex_progression = (
         codex_app.get("example_progression_minutes")
         if isinstance(codex_app.get("example_progression_minutes"), list)
@@ -449,13 +579,27 @@ def build_codex_app_scheduler_ack_event(
         identity_signature=stateful_backoff.get("identity_signature"),
         progression_index=progression_index,
         progression_minutes=progression_minutes,
-        last_applied_rrule=expected_rrule,
+        last_applied_rrule=acknowledged_rrule,
         updated_at=safe_generated_at,
         source=classification,
     )
     reason = str(reason_summary or "").strip() or (
-        f"acknowledged Codex App scheduler RRULE {expected_rrule}; no quota spend"
+        f"acknowledged Codex App scheduler RRULE {acknowledged_rrule}; no quota spend"
     )
+    scheduler_ack_event = {
+        "event_type": classification,
+        "surface": surface,
+        "state_key": state_key,
+        "applied_rrule": acknowledged_rrule,
+        "before": compact_before if isinstance(compact_before, dict) else before,
+        "scheduler_state": scheduler_state,
+    }
+    if acceptance.get("stale_hint_accepted"):
+        scheduler_ack_event["expected_rrule"] = expected_rrule
+        scheduler_ack_event["stale_hint_accepted"] = True
+        scheduler_ack_event["stale_hint_tolerance_minutes"] = acceptance.get(
+            "stale_hint_tolerance_minutes"
+        )
     return {
         "generated_at": safe_generated_at,
         "goal_id": before.get("goal_id"),
@@ -464,14 +608,7 @@ def build_codex_app_scheduler_ack_event(
         "recommended_action": reason,
         "health_check": "scheduler ack state updated; no quota spend",
         "delivery_outcome": DeliveryOutcome.SURFACE_ONLY.value,
-        "scheduler_ack_event": {
-            "event_type": classification,
-            "surface": surface,
-            "state_key": state_key,
-            "applied_rrule": expected_rrule,
-            "before": compact_before if isinstance(compact_before, dict) else before,
-            "scheduler_state": scheduler_state,
-        },
+        "scheduler_ack_event": scheduler_ack_event,
     }
 
 
@@ -707,7 +844,14 @@ def build_scheduler_hint(
         current_interval = cadence_progression[current_index]
         current_rrule = rrule_for_minutes(current_interval)
         last_applied_rrule = str(scheduler_state.get("last_applied_rrule") or "").strip()
-        apply_needed = state_status != "same_identity" or last_applied_rrule != current_rrule
+        current_rrule_already_applied = last_applied_rrule == current_rrule
+        if not current_rrule_already_applied and state_status == "same_identity":
+            current_rrule_already_applied = _monitor_rrule_applied_within_stale_tolerance(
+                cadence_class=cadence_class,
+                last_applied_rrule=last_applied_rrule,
+                current_rrule=current_rrule,
+            )
+        apply_needed = state_status != "same_identity" or not current_rrule_already_applied
         stateful_backoff_detail = {
             "progression_minutes": cadence_progression,
             "current_interval_minutes": current_interval,


### PR DESCRIPTION
Summary
- Accept bounded stale monitor_wait scheduler ACKs when the reset token and identity signature still match the current hint.
- Keep strict rejection for wrong state keys, wrong identities, non-monitor cadence, missing RRULEs, or RRULE drift outside the small tolerance window.
- Persist the actually applied RRULE in scheduler state so a stale-but-accepted ACK does not falsely mark a newer cadence as already applied.
- Add a focused smoke for the 119 -> 118 near-window countdown case.

Validation
- python3 examples/control_plane/quota-scheduler-state-ack-smoke.py
- python3 examples/control_plane/side-agent-self-iteration-state-machine-smoke.py
- python3 examples/control_plane/monitor-scheduler-contract-smoke.py
- python3 examples/control_plane/quota-scheduler-policy-smoke.py
- python3 -m compileall -q loopx/control_plane/scheduler/scheduler_hint.py loopx/control_plane/quota/scheduler_ack.py examples/control_plane/quota-scheduler-state-ack-smoke.py
- git diff --check
- loopx canary premerge --from-git-diff: passed, selected 17, failures 0, manual holds 0

Boundary
- No benchmark runner behavior, scoring behavior, private material, credentials, raw logs, trajectories, or local paths included.
- Public boundary check passed through the premerge gate.