### PR TITLE
Add public-safe external ML task ledgers

### DIFF
--- a/docs/product/domain-capability-packs.md
+++ b/docs/product/domain-capability-packs.md
@@ -136,6 +136,94 @@ The preview writes no state and launches nothing. It returns compact public-safe
 Use artifact aliases instead of raw logs, private paths, internal links, or
 credential-bearing metric dumps.
 
+### Volc/MLP Task Packet
+
+For external training/eval systems, LoopX can also render a compact
+`volc_mlp_task_packet_v0` fact packet. This is an observation and handoff
+format, not a launcher. It captures task identity, task state, train/eval
+windows, code/model lineage, metric artifact aliases, and the allowed polling
+contract. It deliberately does not store raw command lines, environment dumps,
+credentials, production paths, workspace paths, or private logs. If a caller
+passes a raw path or URL as a workspace or metric reference, LoopX emits an
+irreversible `redacted:<digest>` handle instead.
+
+```bash
+loopx ml-experiment volc-task-packet --format json \
+  --task-id task-candidate-0 \
+  --task-name external_slice_cross_screen \
+  --state Running \
+  --priority 4 \
+  --retried-times 0 \
+  --train-window 20251002-20260501 \
+  --eval-window 20260501-20260508 \
+  --code-ref codex/example-feature-cross@abc1234 \
+  --model-name candidate_model_abc1234 \
+  --mechanism-family explicit_context_item_crosses \
+  --source-task-id task-baseline-0 \
+  --metric-ref metrics/eval-summary.json \
+  --primary-metric target_slice_auc \
+  --guardrail-metric overall_auc
+```
+
+The packet keeps `launch_actions_enabled=false` and
+`production_actions_enabled=false`. A project-specific adapter may use it as
+durable compact evidence, but actual create/stop/restart/sync actions still
+require explicit delivery authority, quota, preflight verification, and
+writeback.
+
+When the task reaches material evidence, the agent can render a
+`volc_mlp_result_ledger_v0` row. This is the benchmark-ledger layer on top of
+the task packet: it records same-window metric deltas, guardrail state,
+train-metric-as-guardrail policy, failure attribution labels, and the compact
+promotion/no-promotion route. It is useful for long-running model iteration
+because it prevents agents from repeatedly retrying weak near-neighbor
+experiments after a no-promote result, while still preserving enough public-safe
+evidence to replan.
+
+```bash
+loopx ml-experiment volc-result-ledger --format json \
+  --experiment-id external_slice_screen \
+  --task-id task-candidate-1 \
+  --task-name external_slice_cross_screen \
+  --state Completed \
+  --train-window 20251002-20260501 \
+  --eval-window 20260501-20260508 \
+  --code-ref codex/example-feature-cross@abc1234 \
+  --model-name candidate_model_abc1234 \
+  --mechanism-family explicit_context_item_crosses \
+  --primary-metric target_slice_auc \
+  --baseline-value 0.731 \
+  --candidate-value 0.742 \
+  --guardrail-status clean \
+  --guardrail-metric guardrail_slice_a_auc \
+  --guardrail-metric guardrail_slice_b_auc \
+  --positive-evidence same_window_target_slice_auc_up
+```
+
+For failed startup/eval attempts, omit metric values and pass compact failure
+labels instead:
+
+```bash
+loopx ml-experiment volc-result-ledger --format markdown \
+  --experiment-id external_slice_screen \
+  --task-id task-candidate-0 \
+  --task-name external_slice_cross_screen \
+  --state Failed \
+  --train-window 20251002-20260501 \
+  --eval-window 20260501-20260508 \
+  --code-ref codex/example-feature-cross@abc1234 \
+  --model-name candidate_model_abc1234 \
+  --mechanism-family explicit_context_item_crosses \
+  --primary-metric target_slice_auc \
+  --failure-label stale_model_py_root \
+  --failure-label missing_restore_checkpoint \
+  --negative-evidence failed_before_eval_metrics
+```
+
+The result ledger still keeps `launch_actions_enabled=false` and
+`production_actions_enabled=false`; it is a portable fact/decision row, not a
+Volc connector with create/stop/restart authority.
+
 ## Detection
 
 `domain_pack_detection_v0` is a suggest-only detector. It may inspect public-safe

--- a/loopx/cli_commands/ml_experiment.py
+++ b/loopx/cli_commands/ml_experiment.py
@@ -6,8 +6,13 @@ from collections.abc import Callable
 from ..ml_experiment import (
     GUARDRAIL_STATUSES,
     HYPOTHESIS_STATUSES,
+    VOLC_MLP_TASK_STATES,
     build_ml_experiment_advisory_packet,
+    build_volc_mlp_result_ledger,
+    build_volc_mlp_task_packet,
     render_ml_experiment_advisory_markdown,
+    render_volc_mlp_result_ledger_markdown,
+    render_volc_mlp_task_packet_markdown,
 )
 
 
@@ -87,6 +92,117 @@ def register_ml_experiment_commands(
         help="Compact public-safe follow-up candidate label. Repeatable.",
     )
 
+    volc_parser = ml_experiment_sub.add_parser(
+        "volc-task-packet",
+        help="Render a public-safe Volc/MLP external task packet.",
+    )
+    add_subcommand_format(volc_parser)
+    volc_parser.add_argument("--task-id", required=True, help="Volc task id, for example t-... .")
+    volc_parser.add_argument("--task-name", required=True, help="Compact public task label.")
+    volc_parser.add_argument("--state", choices=VOLC_MLP_TASK_STATES, default="Unknown")
+    volc_parser.add_argument("--priority", type=int)
+    volc_parser.add_argument("--retried-times", type=int)
+    volc_parser.add_argument("--train-window", required=True)
+    volc_parser.add_argument("--eval-window", required=True)
+    volc_parser.add_argument("--code-ref", required=True, help="Branch, commit, or other public code alias.")
+    volc_parser.add_argument("--model-name", required=True)
+    volc_parser.add_argument("--mechanism-family", default="unknown")
+    volc_parser.add_argument("--source-task-id")
+    volc_parser.add_argument(
+        "--workspace-ref",
+        help="Optional workspace handle. Raw paths or URLs are redacted in output.",
+    )
+    volc_parser.add_argument(
+        "--metric-ref",
+        action="append",
+        default=[],
+        help="Optional metric artifact handle. Raw paths or URLs are redacted in output. Repeatable.",
+    )
+    volc_parser.add_argument("--primary-metric", default="offline_auc")
+    volc_parser.add_argument(
+        "--guardrail-metric",
+        action="append",
+        default=[],
+        help="Compact guardrail metric label. Repeatable.",
+    )
+    volc_parser.add_argument("--next-action", default="monitor_task_until_terminal_metrics")
+
+    volc_result_parser = ml_experiment_sub.add_parser(
+        "volc-result-ledger",
+        help="Render a public-safe Volc/MLP benchmark result ledger row.",
+    )
+    add_subcommand_format(volc_result_parser)
+    volc_result_parser.add_argument("--experiment-id", required=True)
+    volc_result_parser.add_argument("--task-id", required=True, help="Volc task id, for example t-... .")
+    volc_result_parser.add_argument("--task-name", required=True, help="Compact public task label.")
+    volc_result_parser.add_argument("--state", choices=VOLC_MLP_TASK_STATES, default="Unknown")
+    volc_result_parser.add_argument("--priority", type=int)
+    volc_result_parser.add_argument("--retried-times", type=int)
+    volc_result_parser.add_argument("--train-window", required=True)
+    volc_result_parser.add_argument("--eval-window", required=True)
+    volc_result_parser.add_argument("--code-ref", required=True, help="Branch, commit, or other public code alias.")
+    volc_result_parser.add_argument("--model-name", required=True)
+    volc_result_parser.add_argument("--mechanism-family", default="unknown")
+    volc_result_parser.add_argument("--primary-metric", default="offline_auc")
+    volc_result_parser.add_argument("--baseline-value", type=float)
+    volc_result_parser.add_argument("--candidate-value", type=float)
+    result_metric_direction = volc_result_parser.add_mutually_exclusive_group()
+    result_metric_direction.add_argument(
+        "--higher-is-better",
+        dest="higher_is_better",
+        action="store_true",
+        default=True,
+        help="Classify positive metric deltas as improvements. This is the default.",
+    )
+    result_metric_direction.add_argument(
+        "--lower-is-better",
+        dest="higher_is_better",
+        action="store_false",
+        help="Classify negative metric deltas as improvements.",
+    )
+    volc_result_parser.add_argument(
+        "--guardrail-status",
+        choices=GUARDRAIL_STATUSES,
+        default="unknown",
+    )
+    volc_result_parser.add_argument("--baseline-task-id")
+    volc_result_parser.add_argument("--source-task-id")
+    volc_result_parser.add_argument(
+        "--workspace-ref",
+        help="Optional workspace handle. Raw paths or URLs are redacted in output.",
+    )
+    volc_result_parser.add_argument(
+        "--metric-ref",
+        action="append",
+        default=[],
+        help="Optional metric artifact handle. Raw paths or URLs are redacted in output. Repeatable.",
+    )
+    volc_result_parser.add_argument(
+        "--guardrail-metric",
+        action="append",
+        default=[],
+        help="Compact guardrail metric label. Repeatable.",
+    )
+    volc_result_parser.add_argument(
+        "--positive-evidence",
+        action="append",
+        default=[],
+        help="Compact public-safe evidence label. Repeatable.",
+    )
+    volc_result_parser.add_argument(
+        "--negative-evidence",
+        action="append",
+        default=[],
+        help="Compact public-safe evidence label. Repeatable.",
+    )
+    volc_result_parser.add_argument(
+        "--failure-label",
+        action="append",
+        default=[],
+        help="Compact public-safe failure attribution label. Repeatable.",
+    )
+    volc_result_parser.add_argument("--next-action")
+
 
 def handle_ml_experiment_command(
     args: argparse.Namespace,
@@ -95,31 +211,83 @@ def handle_ml_experiment_command(
     print_payload: PrintPayload,
 ) -> int:
     try:
-        if args.ml_experiment_command != "preview":
-            raise ValueError("ml-experiment requires the `preview` subcommand")
-        payload = build_ml_experiment_advisory_packet(
-            experiment_id=args.experiment_id,
-            primary_metric=args.primary_metric,
-            baseline_value=args.baseline_value,
-            candidate_value=args.candidate_value,
-            higher_is_better=bool(args.higher_is_better),
-            guardrail_status=args.guardrail_status,
-            train_window=args.train_window,
-            eval_window=args.eval_window,
-            granularity=args.granularity,
-            hypothesis_id=args.hypothesis_id,
-            mechanism_family=args.mechanism_family,
-            route=args.route,
-            hypothesis_status=args.hypothesis_status,
-            positive_evidence=args.positive_evidence,
-            negative_evidence=args.negative_evidence,
-            next_candidates=args.next_candidate,
-        )
+        if args.ml_experiment_command == "preview":
+            payload = build_ml_experiment_advisory_packet(
+                experiment_id=args.experiment_id,
+                primary_metric=args.primary_metric,
+                baseline_value=args.baseline_value,
+                candidate_value=args.candidate_value,
+                higher_is_better=bool(args.higher_is_better),
+                guardrail_status=args.guardrail_status,
+                train_window=args.train_window,
+                eval_window=args.eval_window,
+                granularity=args.granularity,
+                hypothesis_id=args.hypothesis_id,
+                mechanism_family=args.mechanism_family,
+                route=args.route,
+                hypothesis_status=args.hypothesis_status,
+                positive_evidence=args.positive_evidence,
+                negative_evidence=args.negative_evidence,
+                next_candidates=args.next_candidate,
+            )
+            renderer = render_ml_experiment_advisory_markdown
+        elif args.ml_experiment_command == "volc-task-packet":
+            payload = build_volc_mlp_task_packet(
+                task_id=args.task_id,
+                task_name=args.task_name,
+                state=args.state,
+                priority=args.priority,
+                retried_times=args.retried_times,
+                train_window=args.train_window,
+                eval_window=args.eval_window,
+                code_ref=args.code_ref,
+                model_name=args.model_name,
+                mechanism_family=args.mechanism_family,
+                source_task_id=args.source_task_id,
+                workspace_ref=args.workspace_ref,
+                metric_refs=args.metric_ref,
+                primary_metric=args.primary_metric,
+                guardrail_metrics=args.guardrail_metric,
+                next_action=args.next_action,
+            )
+            renderer = render_volc_mlp_task_packet_markdown
+        elif args.ml_experiment_command == "volc-result-ledger":
+            payload = build_volc_mlp_result_ledger(
+                experiment_id=args.experiment_id,
+                task_id=args.task_id,
+                task_name=args.task_name,
+                state=args.state,
+                priority=args.priority,
+                retried_times=args.retried_times,
+                train_window=args.train_window,
+                eval_window=args.eval_window,
+                code_ref=args.code_ref,
+                model_name=args.model_name,
+                mechanism_family=args.mechanism_family,
+                primary_metric=args.primary_metric,
+                baseline_value=args.baseline_value,
+                candidate_value=args.candidate_value,
+                higher_is_better=bool(args.higher_is_better),
+                guardrail_status=args.guardrail_status,
+                baseline_task_id=args.baseline_task_id,
+                source_task_id=args.source_task_id,
+                workspace_ref=args.workspace_ref,
+                metric_refs=args.metric_ref,
+                guardrail_metrics=args.guardrail_metric,
+                positive_evidence=args.positive_evidence,
+                negative_evidence=args.negative_evidence,
+                failure_labels=args.failure_label,
+                next_action=args.next_action,
+            )
+            renderer = render_volc_mlp_result_ledger_markdown
+        else:
+            raise ValueError("ml-experiment requires a supported subcommand")
     except Exception as exc:
         payload = {
             "ok": False,
             "mode": "ml-experiment",
             "error": str(exc),
         }
-    print_payload(payload, output_format(args), render_ml_experiment_advisory_markdown)
+        renderer = render_ml_experiment_advisory_markdown
+    print_payload(payload, output_format(args), renderer)
     return 0 if payload.get("ok") else 1

--- a/loopx/ml_experiment.py
+++ b/loopx/ml_experiment.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import math
 import re
 from typing import Any, Iterable
@@ -11,9 +12,23 @@ ML_EXPERIMENT_RESULT_SCHEMA_VERSION = "ml_experiment_result_v0"
 DATASET_WINDOW_CONTRACT_SCHEMA_VERSION = "dataset_window_contract_v0"
 HYPOTHESIS_LEDGER_SCHEMA_VERSION = "hypothesis_ledger_v0"
 EXPERIMENT_REPLAN_SCHEMA_VERSION = "experiment_replan_v0"
+VOLC_MLP_TASK_PACKET_SCHEMA_VERSION = "volc_mlp_task_packet_v0"
+VOLC_MLP_RESULT_LEDGER_SCHEMA_VERSION = "volc_mlp_result_ledger_v0"
 
 GUARDRAIL_STATUSES = ("clean", "warning", "failed", "unknown")
 HYPOTHESIS_STATUSES = ("active", "supported", "weakened", "retired", "unknown")
+VOLC_MLP_TASK_STATES = (
+    "Creating",
+    "Waiting",
+    "Queueing",
+    "Deploying",
+    "Running",
+    "Stopping",
+    "Completed",
+    "Failed",
+    "Stopped",
+    "Unknown",
+)
 
 _TOKEN_RE = re.compile(r"^[A-Za-z][A-Za-z0-9_.:-]{0,79}$")
 _ABSOLUTE_PATH_RE = re.compile(
@@ -73,6 +88,48 @@ def _finite_float(value: float | int | str, *, field: str) -> float:
     return number
 
 
+def _non_negative_int(value: int | str | None, *, field: str) -> int | None:
+    if value is None or value == "":
+        return None
+    number = int(value)
+    if number < 0:
+        raise ValueError(f"{field} must be non-negative")
+    return number
+
+
+def _redacted_ref(value: str, *, field: str) -> dict[str, Any]:
+    text = " ".join(str(value or "").strip().split())
+    if not text:
+        raise ValueError(f"{field} must be non-empty")
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+    return {
+        "kind": "redacted_ref",
+        "value": f"redacted:{digest}",
+        "raw_recorded": False,
+    }
+
+
+def _public_or_redacted_ref(value: str | None, *, field: str) -> dict[str, Any] | None:
+    if value is None or str(value).strip() == "":
+        return None
+    try:
+        return {
+            "kind": "alias",
+            "value": _compact_public_text(str(value), field=field),
+            "raw_recorded": False,
+        }
+    except ValueError:
+        return _redacted_ref(str(value), field=field)
+
+
+def _public_or_redacted_ref_list(values: Iterable[str] | None, *, field: str) -> list[dict[str, Any]]:
+    return [
+        ref
+        for ref in (_public_or_redacted_ref(value, field=f"{field}[]") for value in values or [])
+        if ref is not None
+    ]
+
+
 def build_ml_experiment_domain_pack_contract(*, enabled: bool = False) -> dict[str, Any]:
     """Return the default-off ML experiment domain-pack boundary."""
 
@@ -104,6 +161,281 @@ def build_ml_experiment_domain_pack_contract(*, enabled: bool = False) -> dict[s
             "launch_authority": "disabled_until_explicit_registry_delivery_mode",
             "production_authority": "disabled_until_explicit_registry_delivery_mode",
         },
+    }
+
+
+def build_volc_mlp_task_packet(
+    *,
+    task_id: str,
+    task_name: str,
+    state: str = "Unknown",
+    priority: int | str | None = None,
+    retried_times: int | str | None = None,
+    train_window: str,
+    eval_window: str,
+    code_ref: str,
+    model_name: str,
+    mechanism_family: str = "unknown",
+    source_task_id: str | None = None,
+    workspace_ref: str | None = None,
+    metric_refs: Iterable[str] | None = None,
+    primary_metric: str = "offline_auc",
+    guardrail_metrics: Iterable[str] | None = None,
+    next_action: str = "monitor_task_until_terminal_metrics",
+) -> dict[str, Any]:
+    """Build a public-safe Volc/MLP task fact packet.
+
+    The packet intentionally stores task identity, windows, lineage aliases, and
+    redacted artifact handles only. It must not become a raw launcher spec,
+    credential store, command log, environment dump, or private path ledger.
+    """
+
+    compact_state = _compact_public_text(state, field="state", max_len=40)
+    if compact_state not in VOLC_MLP_TASK_STATES:
+        raise ValueError(f"state must be one of {', '.join(VOLC_MLP_TASK_STATES)}")
+    dataset_window = build_dataset_window_contract(
+        train_window=train_window,
+        eval_window=eval_window,
+    )
+    source_handle = (
+        _compact_public_token(source_task_id, field="source_task_id")
+        if source_task_id
+        else None
+    )
+    workspace_handle = _public_or_redacted_ref(workspace_ref, field="workspace_ref")
+    metric_handles = _public_or_redacted_ref_list(metric_refs, field="metric_refs")
+    return {
+        "ok": True,
+        "schema_version": VOLC_MLP_TASK_PACKET_SCHEMA_VERSION,
+        "provider": "volc_mlp",
+        "pack": build_ml_experiment_domain_pack_contract(enabled=False),
+        "mode": "default_off_external_task_fact_packet",
+        "observable_handle": {
+            "task_id": _compact_public_token(task_id, field="task_id"),
+            "task_name": _compact_public_text(task_name, field="task_name"),
+            "state": compact_state,
+            "priority": _non_negative_int(priority, field="priority"),
+            "retried_times": _non_negative_int(retried_times, field="retried_times"),
+            "source_task_id": source_handle,
+        },
+        "dataset_window": dataset_window,
+        "lineage": {
+            "code_ref": _compact_public_text(code_ref, field="code_ref"),
+            "model_name": _compact_public_token(model_name, field="model_name"),
+            "mechanism_family": _compact_public_text(mechanism_family, field="mechanism_family"),
+            "workspace_ref": workspace_handle,
+        },
+        "metric_artifacts": metric_handles,
+        "decision_boundary": {
+            "primary_metric": _compact_public_text(primary_metric, field="primary_metric"),
+            "guardrail_metrics": _compact_public_text_list(guardrail_metrics, field="guardrail_metrics"),
+            "conclusion_eligibility": "aligned_eval_window_and_guardrails_required",
+            "train_metrics_are_guardrails_only": True,
+        },
+        "poll_contract": {
+            "allowed_observations": [
+                "task_state",
+                "workspace_created",
+                "fail_marker",
+                "done_marker",
+                "compact_train_metrics",
+                "compact_eval_metrics",
+            ],
+            "raw_logs_recorded": False,
+            "raw_command_recorded": False,
+            "raw_env_recorded": False,
+            "private_artifacts_recorded": False,
+        },
+        "launch_actions_enabled": False,
+        "production_actions_enabled": False,
+        "recommended_next_action": _compact_public_text(next_action, field="next_action"),
+    }
+
+
+def _optional_primary_metric_delta(
+    *,
+    baseline_value: float | int | str | None,
+    candidate_value: float | int | str | None,
+    higher_is_better: bool,
+) -> dict[str, Any]:
+    if baseline_value is None and candidate_value is None:
+        return {
+            "baseline_value": None,
+            "candidate_value": None,
+            "delta": None,
+            "relative_delta": None,
+            "higher_is_better": bool(higher_is_better),
+            "primary_metric_status": "pending",
+        }
+    if baseline_value is None or candidate_value is None:
+        raise ValueError("baseline_value and candidate_value must be provided together")
+    return classify_primary_metric_delta(
+        baseline_value=baseline_value,
+        candidate_value=candidate_value,
+        higher_is_better=higher_is_better,
+    )
+
+
+def _volc_result_outcome(
+    *,
+    state: str,
+    metric_status: str,
+    guardrail_status: str,
+    failure_labels: list[str],
+) -> str:
+    if failure_labels or state in {"Failed", "Stopped"}:
+        return "needs_repair_before_conclusion"
+    if metric_status == "pending":
+        return "monitor_until_aligned_eval"
+    if guardrail_status == "failed":
+        return "no_promote_guardrail_failed"
+    if metric_status == "regressed":
+        return "no_promote_metric_regressed"
+    if metric_status == "flat":
+        return "retire_or_replan"
+    if metric_status == "improved" and guardrail_status == "clean":
+        return "promote_to_larger_window_or_handoff"
+    return "inconclusive_guardrail_review"
+
+
+def _default_volc_result_next_action(outcome: str) -> str:
+    if outcome == "monitor_until_aligned_eval":
+        return "poll_until_terminal_aligned_eval"
+    if outcome == "promote_to_larger_window_or_handoff":
+        return "promote_after_owner_or_registry_gate"
+    if outcome == "needs_repair_before_conclusion":
+        return "repair_startup_or_eval_path_before_retry"
+    if outcome.startswith("no_promote"):
+        return "retire_candidate_and_avoid_near_neighbor_retry"
+    if outcome == "retire_or_replan":
+        return "retire_candidate_or_design_distinct_mechanism"
+    return "collect_guardrail_evidence_before_decision"
+
+
+def build_volc_mlp_result_ledger(
+    *,
+    experiment_id: str,
+    task_id: str,
+    task_name: str,
+    state: str = "Unknown",
+    priority: int | str | None = None,
+    retried_times: int | str | None = None,
+    train_window: str,
+    eval_window: str,
+    code_ref: str,
+    model_name: str,
+    mechanism_family: str = "unknown",
+    primary_metric: str = "offline_auc",
+    baseline_value: float | int | str | None = None,
+    candidate_value: float | int | str | None = None,
+    higher_is_better: bool = True,
+    guardrail_status: str = "unknown",
+    baseline_task_id: str | None = None,
+    source_task_id: str | None = None,
+    workspace_ref: str | None = None,
+    metric_refs: Iterable[str] | None = None,
+    guardrail_metrics: Iterable[str] | None = None,
+    positive_evidence: Iterable[str] | None = None,
+    negative_evidence: Iterable[str] | None = None,
+    failure_labels: Iterable[str] | None = None,
+    next_action: str | None = None,
+) -> dict[str, Any]:
+    """Build a public-safe result ledger row for a Volc/MLP task.
+
+    This is the bridge from an external task packet to LoopX's benchmark-ledger
+    reasoning: same-window comparison, train-metric guardrails, failure
+    attribution, and promotion/no-promotion routing. It remains observation-only
+    and deliberately avoids raw commands, env dumps, logs, private paths, and
+    credentials.
+    """
+
+    compact_state = _compact_public_text(state, field="state", max_len=40)
+    if compact_state not in VOLC_MLP_TASK_STATES:
+        raise ValueError(f"state must be one of {', '.join(VOLC_MLP_TASK_STATES)}")
+    compact_guardrail_status = _compact_public_token(guardrail_status, field="guardrail_status")
+    if compact_guardrail_status not in GUARDRAIL_STATUSES:
+        raise ValueError(f"guardrail_status must be one of {', '.join(GUARDRAIL_STATUSES)}")
+    compact_failures = _compact_public_text_list(failure_labels, field="failure_labels")
+    metric = _optional_primary_metric_delta(
+        baseline_value=baseline_value,
+        candidate_value=candidate_value,
+        higher_is_better=higher_is_better,
+    )
+    outcome = _volc_result_outcome(
+        state=compact_state,
+        metric_status=str(metric.get("primary_metric_status")),
+        guardrail_status=compact_guardrail_status,
+        failure_labels=compact_failures,
+    )
+    resolved_next_action = next_action or _default_volc_result_next_action(outcome)
+    task_packet = build_volc_mlp_task_packet(
+        task_id=task_id,
+        task_name=task_name,
+        state=compact_state,
+        priority=priority,
+        retried_times=retried_times,
+        train_window=train_window,
+        eval_window=eval_window,
+        code_ref=code_ref,
+        model_name=model_name,
+        mechanism_family=mechanism_family,
+        source_task_id=source_task_id or baseline_task_id,
+        workspace_ref=workspace_ref,
+        metric_refs=metric_refs,
+        primary_metric=primary_metric,
+        guardrail_metrics=guardrail_metrics,
+        next_action=resolved_next_action,
+    )
+    baseline_handle = (
+        _compact_public_token(baseline_task_id, field="baseline_task_id")
+        if baseline_task_id
+        else None
+    )
+    positive_labels = _compact_public_text_list(positive_evidence, field="positive_evidence")
+    negative_labels = _compact_public_text_list(negative_evidence, field="negative_evidence")
+    promotion_eligible = outcome == "promote_to_larger_window_or_handoff"
+    return {
+        "ok": True,
+        "schema_version": VOLC_MLP_RESULT_LEDGER_SCHEMA_VERSION,
+        "provider": "volc_mlp",
+        "pack": build_ml_experiment_domain_pack_contract(enabled=False),
+        "mode": "default_off_external_result_ledger",
+        "experiment_id": _compact_public_token(experiment_id, field="experiment_id"),
+        "task_packet": task_packet,
+        "comparison": {
+            "baseline_task_id": baseline_handle,
+            "primary_metric": _compact_public_text(primary_metric, field="primary_metric"),
+            "primary_metric_delta": metric,
+            "guardrail_status": compact_guardrail_status,
+            "guardrail_metrics": _compact_public_text_list(guardrail_metrics, field="guardrail_metrics"),
+            "same_window_required": True,
+            "aligned_eval_required_for_conclusion": True,
+            "train_metrics_are_guardrails_only": True,
+        },
+        "evidence": {
+            "positive": positive_labels,
+            "negative": negative_labels,
+            "raw_metrics_recorded": False,
+            "private_artifacts_recorded": False,
+        },
+        "failure_attribution": {
+            "labels": compact_failures,
+            "raw_logs_recorded": False,
+            "raw_command_recorded": False,
+            "raw_env_recorded": False,
+        },
+        "decision": {
+            "outcome": outcome,
+            "promotion_eligible": promotion_eligible,
+            "requires_owner_or_registry_gate": promotion_eligible,
+            "avoid_near_neighbor_retry": outcome.startswith("no_promote"),
+            "recommended_next_action": _compact_public_text(
+                resolved_next_action,
+                field="next_action",
+            ),
+        },
+        "launch_actions_enabled": False,
+        "production_actions_enabled": False,
     }
 
 
@@ -332,5 +664,93 @@ def render_ml_experiment_advisory_markdown(payload: dict[str, Any]) -> str:
         f"- allocation: `{replan.get('allocation')}`",
         "- next candidates: "
         + ", ".join(f"`{candidate}`" for candidate in replan.get("next_candidates", []) or []),
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def render_volc_mlp_task_packet_markdown(payload: dict[str, Any]) -> str:
+    if not payload.get("ok"):
+        return f"Volc MLP task packet failed: {payload.get('error')}\n"
+    handle = payload.get("observable_handle") if isinstance(payload.get("observable_handle"), dict) else {}
+    dataset_window = payload.get("dataset_window") if isinstance(payload.get("dataset_window"), dict) else {}
+    lineage = payload.get("lineage") if isinstance(payload.get("lineage"), dict) else {}
+    decision = payload.get("decision_boundary") if isinstance(payload.get("decision_boundary"), dict) else {}
+    metric_artifacts = [
+        ref.get("value")
+        for ref in payload.get("metric_artifacts", []) or []
+        if isinstance(ref, dict) and ref.get("value")
+    ]
+    workspace_ref = lineage.get("workspace_ref") if isinstance(lineage.get("workspace_ref"), dict) else {}
+    lines = [
+        "# Volc MLP Task Packet",
+        "",
+        f"- task: `{handle.get('task_id')}`",
+        f"- name: `{handle.get('task_name')}`",
+        f"- state: `{handle.get('state')}`",
+        f"- priority/retries: `{handle.get('priority')}` / `{handle.get('retried_times')}`",
+        f"- source task: `{handle.get('source_task_id')}`",
+        f"- train window: `{dataset_window.get('train_window')}`",
+        f"- eval window: `{dataset_window.get('eval_window')}`",
+        f"- code ref: `{lineage.get('code_ref')}`",
+        f"- model: `{lineage.get('model_name')}`",
+        f"- mechanism: `{lineage.get('mechanism_family')}`",
+        f"- workspace ref: `{workspace_ref.get('value')}`",
+        "- metric refs: " + ", ".join(f"`{ref}`" for ref in metric_artifacts),
+        f"- primary metric: `{decision.get('primary_metric')}`",
+        "- guardrails: "
+        + ", ".join(f"`{metric}`" for metric in decision.get("guardrail_metrics", []) or []),
+        f"- launch actions enabled: `{payload.get('launch_actions_enabled')}`",
+        f"- production actions enabled: `{payload.get('production_actions_enabled')}`",
+        f"- next action: `{payload.get('recommended_next_action')}`",
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def render_volc_mlp_result_ledger_markdown(payload: dict[str, Any]) -> str:
+    if not payload.get("ok"):
+        return f"Volc MLP result ledger failed: {payload.get('error')}\n"
+    task_packet = payload.get("task_packet") if isinstance(payload.get("task_packet"), dict) else {}
+    handle = (
+        task_packet.get("observable_handle")
+        if isinstance(task_packet.get("observable_handle"), dict)
+        else {}
+    )
+    comparison = payload.get("comparison") if isinstance(payload.get("comparison"), dict) else {}
+    metric = (
+        comparison.get("primary_metric_delta")
+        if isinstance(comparison.get("primary_metric_delta"), dict)
+        else {}
+    )
+    evidence = payload.get("evidence") if isinstance(payload.get("evidence"), dict) else {}
+    failure = (
+        payload.get("failure_attribution")
+        if isinstance(payload.get("failure_attribution"), dict)
+        else {}
+    )
+    decision = payload.get("decision") if isinstance(payload.get("decision"), dict) else {}
+    lines = [
+        "# Volc MLP Result Ledger",
+        "",
+        f"- experiment: `{payload.get('experiment_id')}`",
+        f"- task: `{handle.get('task_id')}`",
+        f"- name: `{handle.get('task_name')}`",
+        f"- state: `{handle.get('state')}`",
+        f"- baseline task: `{comparison.get('baseline_task_id')}`",
+        f"- primary metric: `{comparison.get('primary_metric')}`",
+        f"- metric status: `{metric.get('primary_metric_status')}`",
+        f"- delta: `{metric.get('delta')}`",
+        f"- guardrail: `{comparison.get('guardrail_status')}`",
+        "- positive evidence: "
+        + ", ".join(f"`{label}`" for label in evidence.get("positive", []) or []),
+        "- negative evidence: "
+        + ", ".join(f"`{label}`" for label in evidence.get("negative", []) or []),
+        "- failure labels: "
+        + ", ".join(f"`{label}`" for label in failure.get("labels", []) or []),
+        f"- outcome: `{decision.get('outcome')}`",
+        f"- promotion eligible: `{decision.get('promotion_eligible')}`",
+        f"- avoid near-neighbor retry: `{decision.get('avoid_near_neighbor_retry')}`",
+        f"- launch actions enabled: `{payload.get('launch_actions_enabled')}`",
+        f"- production actions enabled: `{payload.get('production_actions_enabled')}`",
+        f"- next action: `{decision.get('recommended_next_action')}`",
     ]
     return "\n".join(lines) + "\n"

--- a/tests/test_ml_experiment_volc_packet.py
+++ b/tests/test_ml_experiment_volc_packet.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from loopx.ml_experiment import (
+    VOLC_MLP_RESULT_LEDGER_SCHEMA_VERSION,
+    VOLC_MLP_TASK_PACKET_SCHEMA_VERSION,
+    build_volc_mlp_result_ledger,
+    build_volc_mlp_task_packet,
+    render_volc_mlp_result_ledger_markdown,
+    render_volc_mlp_task_packet_markdown,
+)
+
+
+def test_volc_mlp_task_packet_redacts_private_refs() -> None:
+    payload = build_volc_mlp_task_packet(
+        task_id="task-candidate-0",
+        task_name="external_slice_cross_screen",
+        state="Running",
+        priority=4,
+        retried_times=0,
+        train_window="20251002-20260501",
+        eval_window="20260501-20260508",
+        code_ref="codex/example-feature-cross@abc1234",
+        model_name="candidate_model_abc1234",
+        mechanism_family="explicit_context_item_crosses",
+        source_task_id="task-baseline-0",
+        workspace_ref="/private/raw/workspace",
+        metric_refs=["metrics/eval-summary.json", "https://private.example/raw-log"],
+        primary_metric="target_slice_auc",
+        guardrail_metrics=["overall_auc", "ctr_auc"],
+    )
+
+    assert payload["ok"] is True
+    assert payload["schema_version"] == VOLC_MLP_TASK_PACKET_SCHEMA_VERSION
+    assert payload["observable_handle"]["state"] == "Running"
+    assert payload["lineage"]["workspace_ref"]["kind"] == "redacted_ref"
+    assert payload["lineage"]["workspace_ref"]["value"].startswith("redacted:")
+    assert payload["metric_artifacts"][0]["kind"] == "alias"
+    assert payload["metric_artifacts"][1]["kind"] == "redacted_ref"
+    assert payload["poll_contract"]["raw_logs_recorded"] is False
+    assert payload["poll_contract"]["raw_command_recorded"] is False
+    assert payload["poll_contract"]["raw_env_recorded"] is False
+    assert payload["production_actions_enabled"] is False
+
+
+def test_volc_mlp_task_packet_markdown_is_public_safe() -> None:
+    payload = build_volc_mlp_task_packet(
+        task_id="task-candidate-0",
+        task_name="external_slice_cross_screen",
+        state="Queueing",
+        train_window="20251002-20260501",
+        eval_window="20260501-20260508",
+        code_ref="codex/example-feature-cross@abc1234",
+        model_name="candidate_model_abc1234",
+        workspace_ref="/private/raw/workspace",
+        metric_refs=["/private/raw/metrics"],
+    )
+
+    rendered = render_volc_mlp_task_packet_markdown(payload)
+
+    assert "Volc MLP Task Packet" in rendered
+    assert "task-candidate-0" in rendered
+    assert "/private/raw" not in rendered
+    assert "redacted:" in rendered
+
+
+def test_volc_mlp_result_ledger_classifies_public_safe_failure() -> None:
+    payload = build_volc_mlp_result_ledger(
+        experiment_id="external_slice_screen",
+        task_id="task-candidate-0",
+        task_name="external_slice_cross_screen",
+        state="Failed",
+        priority=4,
+        retried_times=0,
+        train_window="20251002-20260501",
+        eval_window="20260501-20260508",
+        code_ref="codex/example-feature-cross@abc1234",
+        model_name="candidate_model_abc1234",
+        mechanism_family="explicit_context_item_crosses",
+        primary_metric="target_slice_auc",
+        guardrail_status="unknown",
+        baseline_task_id="task-baseline-0",
+        workspace_ref="/private/raw/workspace",
+        metric_refs=["/private/raw/metrics"],
+        failure_labels=["stale_model_py_root", "missing_restore_checkpoint"],
+        negative_evidence=["failed_before_eval_metrics"],
+    )
+    rendered = render_volc_mlp_result_ledger_markdown(payload)
+
+    assert payload["ok"] is True
+    assert payload["schema_version"] == VOLC_MLP_RESULT_LEDGER_SCHEMA_VERSION
+    assert payload["comparison"]["primary_metric_delta"]["primary_metric_status"] == "pending"
+    assert payload["decision"]["outcome"] == "needs_repair_before_conclusion"
+    assert payload["decision"]["promotion_eligible"] is False
+    assert payload["failure_attribution"]["raw_logs_recorded"] is False
+    assert "/private/raw" not in rendered
+    assert "stale_model_py_root" in rendered
+
+
+def test_volc_mlp_result_ledger_marks_clean_improvement_as_promotion_candidate() -> None:
+    payload = build_volc_mlp_result_ledger(
+        experiment_id="external_slice_screen",
+        task_id="task-candidate-1",
+        task_name="external_slice_cross_screen",
+        state="Completed",
+        train_window="20251002-20260501",
+        eval_window="20260501-20260508",
+        code_ref="codex/example-feature-cross@abc1234",
+        model_name="candidate_model_abc1234",
+        mechanism_family="explicit_context_item_crosses",
+        primary_metric="target_slice_auc",
+        baseline_value=0.731,
+        candidate_value=0.742,
+        guardrail_status="clean",
+        guardrail_metrics=["guardrail_slice_a_auc", "guardrail_slice_b_auc"],
+        positive_evidence=["same_window_target_slice_auc_up"],
+    )
+
+    assert payload["comparison"]["primary_metric_delta"]["primary_metric_status"] == "improved"
+    assert payload["decision"]["outcome"] == "promote_to_larger_window_or_handoff"
+    assert payload["decision"]["promotion_eligible"] is True
+    assert payload["comparison"]["same_window_required"] is True
+    assert payload["comparison"]["train_metrics_are_guardrails_only"] is True


### PR DESCRIPTION
## Summary
- add a public-safe `volc_mlp_task_packet_v0` builder and renderer under the ML experiment pack
- expose `loopx ml-experiment volc-task-packet` for compact external task handoff facts
- add `volc_mlp_result_ledger_v0` plus `loopx ml-experiment volc-result-ledger` for same-window metric deltas, guardrail status, startup/eval failure attribution, and promote/no-promote routing
- document the Volc/MLP packet and result-ledger flow, with synthetic task ids in public examples

## Safety boundary
- default-off observation/ledger packet only; no launch/stop/restart/sync authority
- raw workspace paths and URLs are emitted as irreversible redacted refs
- raw commands, env dumps, logs, credentials, and private artifacts are not recorded
- result rows keep train metrics as guardrails only and require aligned eval windows for conclusions

## Validation
- `python3 -m py_compile loopx/ml_experiment.py loopx/cli_commands/ml_experiment.py tests/test_ml_experiment_volc_packet.py`
- `PYTHONPATH=. python3 - <<'PY' ...` manual pytest-function harness for `tests/test_ml_experiment_volc_packet.py` (4 functions passed)
- `PYTHONPATH=. python3 -m loopx.cli --format json ml-experiment volc-result-ledger ...` smoke generated a redacted failure ledger
- `git diff --check`
- `python3 -m pytest tests/test_ml_experiment_volc_packet.py -q` not run locally: pytest is not installed in this system Python