### PR TITLE
Refocus quota agent identity smoke

### DIFF
--- a/examples/control_plane/quota-plan-smoke.py
+++ b/examples/control_plane/quota-plan-smoke.py
@@ -18,7 +18,6 @@ if str(REPO_ROOT) not in sys.path:
 
 from loopx.quota import (  # noqa: E402
     build_quota_plan,
-    build_quota_monitor_poll_event,
     build_quota_should_run,
     build_quota_slot_spend_event,
     build_quota_slot_void_event,
@@ -32,7 +31,6 @@ from loopx.quota import (  # noqa: E402
     render_quota_should_run_markdown,
     void_quota_slot,
 )
-from loopx.control_plane.work_items.interaction_contract import interaction_next_cli_actions  # noqa: E402
 
 
 SCOPED_AGENT_ID = "codex-side-bypass"
@@ -2033,104 +2031,6 @@ def assert_quota_void_event_net_ledger() -> None:
         assert after["void_event_count"] == 1, after
 
 
-def assert_monitor_poll_event_carries_agent_id() -> None:
-    event = build_quota_monitor_poll_event(
-        {
-            "goal_id": "scoped-monitor-goal",
-            "should_run": True,
-            "effective_action": "monitor_quiet_skip",
-            "recommended_action": "stay quiet until material transition",
-            "reason": "unchanged monitor target",
-            "heartbeat_recommendation": {
-                "recommended_mode": "monitor_quiet_until_material_transition",
-                "reason": "unchanged monitor target",
-            },
-            "agent_identity": {
-                "agent_id": SCOPED_AGENT_ID,
-                "registered": True,
-                "role": "side-agent",
-                "primary_agent": "codex-main-control",
-                "registered_agents": ["codex-main-control", SCOPED_AGENT_ID],
-            },
-        },
-        source="heartbeat",
-    )
-
-    assert event["agent_id"] == SCOPED_AGENT_ID, event
-    assert event["monitor_event"]["agent_id"] == SCOPED_AGENT_ID, event
-    target = event["monitor_target"]
-    assert target["schema_version"] == "quota_monitor_target_v0", target
-    assert target["target_id"] == event["monitor_event"]["monitor_target"]["target_id"], event
-    assert target["agent_id"] == SCOPED_AGENT_ID, target
-    assert target["effective_action"] == "monitor_quiet_skip", target
-
-
-def assert_monitor_poll_next_cli_action_preserves_agent_id() -> None:
-    actions = interaction_next_cli_actions(
-        {
-            "goal_id": "scoped-monitor-goal",
-            "agent_identity": {
-                "agent_id": SCOPED_AGENT_ID,
-            },
-        },
-        mode="monitor_quiet_skip",
-    )
-
-    assert actions == [
-        (
-            "loopx quota monitor-poll --goal-id scoped-monitor-goal "
-            f"--agent-id {SCOPED_AGENT_ID} --execute"
-        ),
-        (
-            "loopx --format json quota should-run --goal-id scoped-monitor-goal "
-            f"--agent-id {SCOPED_AGENT_ID}"
-        ),
-    ], actions
-
-
-def assert_delivery_completion_spend_preserves_requested_agent_id() -> None:
-    before = {
-        "goal_id": "delivery-completion-goal",
-        "should_run": False,
-        "normal_delivery_allowed": False,
-        "recovery_delivery_allowed": False,
-        "effective_action": "monitor_quiet_skip",
-        "self_repair_allowed": False,
-        "capability_repair_allowed": False,
-        "workspace_repair_allowed": False,
-        "state": "eligible",
-        "safe_bypass_allowed": False,
-        "quota": {
-            "compute": 1.0,
-            "window_hours": 24,
-            "slot_minutes": 1,
-            "spent_slots": 0,
-            "allowed_slots": 1440,
-        },
-    }
-    after = deepcopy(before)
-    after["quota"] = {**before["quota"], "spent_slots": 1}
-    preview = {
-        "ok": True,
-        "mode": "spend-slot",
-        "dry_run": True,
-        "goal_id": "delivery-completion-goal",
-        "slots": 1,
-        "agent_id": SCOPED_AGENT_ID,
-        "before": before,
-        "after": after,
-        "delivery_completion_spend": True,
-        "delivery_run_generated_at": "2026-01-01T00:00:00+00:00",
-        "delivery_run_classification": "validated_delivery_fixture",
-    }
-    event = build_quota_slot_spend_event(preview, source="heartbeat")
-
-    assert event["agent_id"] == SCOPED_AGENT_ID, event
-    assert event["quota_event"]["agent_id"] == SCOPED_AGENT_ID, event
-    assert event["quota_event"]["delivery_run_classification"] == "validated_delivery_fixture", event
-    assert "validated delivery" in event["health_check"], event
-
-
 def main() -> int:
     assert_default_quota_is_duty_cycle()
     assert_rolling_window_ledger_expires_old_spends()
@@ -2157,9 +2057,6 @@ def main() -> int:
     assert_decision_freshness_warning_in_should_run()
     assert_safe_bypass_slot_preview(status_payload)
     assert_quota_void_event_net_ledger()
-    assert_monitor_poll_event_carries_agent_id()
-    assert_monitor_poll_next_cli_action_preserves_agent_id()
-    assert_delivery_completion_spend_preserves_requested_agent_id()
     assert_slot_preview(build_quota_slot_preview(status_payload, goal_id="near-limit-half", slots=1))
     with tempfile.TemporaryDirectory(prefix="loopx-quota-plan-smoke-") as tmp:
         cli_plan, cli_markdown = run_cli_quota_plan(Path(tmp))

--- a/examples/control_plane/quota-spend-agent-identity-smoke.py
+++ b/examples/control_plane/quota-spend-agent-identity-smoke.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Smoke-test spend-slot identity on registered multi-agent goals."""
+"""Smoke-test quota agent identity on registered multi-agent goals."""
 
 from __future__ import annotations
 
@@ -14,6 +14,12 @@ from types import ModuleType
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 FIXTURE_PATH = REPO_ROOT / "examples" / "control_plane" / "quota-plan-smoke.py"
+
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.work_items.interaction_contract import interaction_next_cli_actions  # noqa: E402
+from loopx.quota import build_quota_monitor_poll_event, build_quota_slot_spend_event  # noqa: E402
 
 
 def load_quota_plan_fixture() -> ModuleType:
@@ -48,8 +54,104 @@ def run_quota(root: Path, registry_path: Path, runtime: Path, *args: str) -> tup
     return json.loads(result.stdout), result.returncode
 
 
+def assert_monitor_poll_event_carries_agent_id(agent_id: str) -> None:
+    event = build_quota_monitor_poll_event(
+        {
+            "goal_id": "scoped-monitor-goal",
+            "should_run": True,
+            "effective_action": "monitor_quiet_skip",
+            "recommended_action": "stay quiet until material transition",
+            "reason": "unchanged monitor target",
+            "heartbeat_recommendation": {
+                "recommended_mode": "monitor_quiet_until_material_transition",
+                "reason": "unchanged monitor target",
+            },
+            "agent_identity": {
+                "agent_id": agent_id,
+                "registered": True,
+                "role": "side-agent",
+                "primary_agent": "codex-main-control",
+                "registered_agents": ["codex-main-control", agent_id],
+            },
+        },
+        source="heartbeat",
+    )
+
+    assert event["agent_id"] == agent_id, event
+    assert event["monitor_event"]["agent_id"] == agent_id, event
+    target = event["monitor_target"]
+    assert target["schema_version"] == "quota_monitor_target_v0", target
+    assert target["target_id"] == event["monitor_event"]["monitor_target"]["target_id"], event
+    assert target["agent_id"] == agent_id, target
+    assert target["effective_action"] == "monitor_quiet_skip", target
+
+
+def assert_monitor_poll_next_cli_action_preserves_agent_id(agent_id: str) -> None:
+    actions = interaction_next_cli_actions(
+        {
+            "goal_id": "scoped-monitor-goal",
+            "agent_identity": {
+                "agent_id": agent_id,
+            },
+        },
+        mode="monitor_quiet_skip",
+    )
+
+    assert actions == [
+        f"loopx quota monitor-poll --goal-id scoped-monitor-goal --agent-id {agent_id} --execute",
+        f"loopx --format json quota should-run --goal-id scoped-monitor-goal --agent-id {agent_id}",
+    ], actions
+
+
+def assert_delivery_completion_spend_preserves_requested_agent_id(agent_id: str) -> None:
+    before = {
+        "goal_id": "delivery-completion-goal",
+        "should_run": False,
+        "normal_delivery_allowed": False,
+        "recovery_delivery_allowed": False,
+        "effective_action": "monitor_quiet_skip",
+        "self_repair_allowed": False,
+        "capability_repair_allowed": False,
+        "workspace_repair_allowed": False,
+        "state": "eligible",
+        "safe_bypass_allowed": False,
+        "quota": {
+            "compute": 1.0,
+            "window_hours": 24,
+            "slot_minutes": 1,
+            "spent_slots": 0,
+            "allowed_slots": 1440,
+        },
+    }
+    after = {**before, "quota": {**before["quota"], "spent_slots": 1}}
+    preview = {
+        "ok": True,
+        "mode": "spend-slot",
+        "dry_run": True,
+        "goal_id": "delivery-completion-goal",
+        "slots": 1,
+        "agent_id": agent_id,
+        "before": before,
+        "after": after,
+        "delivery_completion_spend": True,
+        "delivery_run_generated_at": "2026-01-01T00:00:00+00:00",
+        "delivery_run_classification": "validated_delivery_fixture",
+    }
+    event = build_quota_slot_spend_event(preview, source="heartbeat")
+
+    assert event["agent_id"] == agent_id, event
+    assert event["quota_event"]["agent_id"] == agent_id, event
+    assert event["quota_event"]["delivery_run_classification"] == "validated_delivery_fixture", event
+    assert "validated delivery" in event["health_check"], event
+
+
 def main() -> int:
     fixture = load_quota_plan_fixture()
+    agent_id = fixture.SCOPED_AGENT_ID
+
+    assert_monitor_poll_event_carries_agent_id(agent_id)
+    assert_monitor_poll_next_cli_action_preserves_agent_id(agent_id)
+    assert_delivery_completion_spend_preserves_requested_agent_id(agent_id)
 
     with tempfile.TemporaryDirectory(prefix="loopx-quota-spend-agent-identity-") as tmp:
         root = Path(tmp)
@@ -98,14 +200,14 @@ def main() -> int:
             "heartbeat",
             "--execute",
             "--agent-id",
-            fixture.SCOPED_AGENT_ID,
+            agent_id,
             "--scan-path",
             str(project),
         )
         assert scoped_code == 0, scoped_payload
         assert scoped_payload["ok"] is True, scoped_payload
         assert scoped_payload["appended"] is True, scoped_payload
-        assert scoped_payload["agent_id"] == fixture.SCOPED_AGENT_ID, scoped_payload
+        assert scoped_payload["agent_id"] == agent_id, scoped_payload
 
     print("quota-spend-agent-identity-smoke ok")
     return 0

--- a/examples/control_plane/repo-python-line-budget-smoke.py
+++ b/examples/control_plane/repo-python-line-budget-smoke.py
@@ -49,7 +49,7 @@ LEGACY_OVERSIZED_RETIREMENT_PLANS = {
 
 LEGACY_OVERSIZED_LIMITS = {
     "examples/benchmark-run-ledger-smoke.py": 2106,
-    "examples/control_plane/quota-plan-smoke.py": 2176,
+    "examples/control_plane/quota-plan-smoke.py": 2079,
     "examples/skillsbench-app-server-goal-worker-smoke.py": 3119,
     "examples/skillsbench-benchmark-run-smoke.py": 14821,
     "examples/skillsbench-host-local-launch-plan-smoke.py": 2373,


### PR DESCRIPTION
## Summary
- Move quota agent identity propagation checks out of the broad quota plan smoke and into the existing focused quota agent identity smoke.
- Lower the legacy line-budget pin for quota-plan-smoke.py from 2176 to 2079 so the shrink is retained.
- Leave the remaining strict line-budget finding for scripts/harbor_host_codex_goal_agent.py untouched because it is benchmark-host helper scope, not this product-capability quality batch.

## Validation
- python3 examples/control_plane/quota-plan-smoke.py
- python3 examples/control_plane/quota-spend-agent-identity-smoke.py
- python3 examples/control_plane/repo-python-line-budget-smoke.py
- python3 -m compileall -q examples/control_plane/quota-plan-smoke.py examples/control_plane/quota-spend-agent-identity-smoke.py examples/control_plane/repo-python-line-budget-smoke.py
- loopx canary premerge --from-git-diff

## Notes
- Strict line-budget still reports only scripts/harbor_host_codex_goal_agent.py at 2142 lines over its 2140 pin; this is intentionally not folded into this non-benchmark control-plane smoke cleanup.