### PR TITLE
Fix closed agent vision quota gap

### DIFF
--- a/examples/control_plane/quota-replan-decision-plane-smoke.py
+++ b/examples/control_plane/quota-replan-decision-plane-smoke.py
@@ -256,6 +256,14 @@ def agent_vision_gap_run() -> dict:
     }
 
 
+def closed_agent_vision_run() -> dict:
+    run = agent_vision_gap_run()
+    run["generated_at"] = "2026-07-04T00:10:00+00:00"
+    run["classification"] = "vision_gap_closed"
+    run["agent_vision"]["state"] = "vision_closed"
+    return run
+
+
 def agent_vision_acceptance_only_run() -> dict:
     return {
         "classification": "state_refreshed",
@@ -679,6 +687,28 @@ def assert_agent_vision_gap_derives_replan() -> None:
     assert "deferred_ready=0 acceptance_gaps=1" in markdown, markdown
     assert "vision_continuation_audit: required=True" in markdown, markdown
     assert "vision_gap_judge: done=False decision=continue" in markdown, markdown
+
+
+def assert_closed_agent_vision_allows_bounded_monitor_wait() -> None:
+    guard = build_quota_should_run(
+        status_payload(
+            [monitor_item()],
+            replan_obligation=None,
+            latest_runs=[
+                watch_lane_continuation_ack_run(
+                    delta_kinds=["watch_lane_continuation", "no_followup"]
+                ),
+                closed_agent_vision_run(),
+            ],
+        ),
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+    )
+    assert guard["decision"] == "skip", guard
+    assert guard["effective_action"] == "monitor_quiet_skip", guard
+    assert guard["goal_frontier_projection"]["acceptance_gaps"] == [], guard
+    assert guard["goal_frontier_projection"]["replan_required"] is False, guard
+    assert guard.get("autonomous_replan_obligation") is None, guard
 
 
 def assert_goal_frontier_context_helper_matches_quota_payload() -> None:
@@ -1121,6 +1151,7 @@ def main() -> None:
     assert_replan_preserves_current_agent_runnable_frontier()
     assert_long_agent_todo_chain_derives_replan_before_linear_delivery()
     assert_agent_vision_gap_derives_replan()
+    assert_closed_agent_vision_allows_bounded_monitor_wait()
     assert_goal_frontier_context_helper_matches_quota_payload()
     assert_open_agent_vision_beats_watch_lane_continuation_ack()
     assert_retired_agent_vision_allows_bounded_monitor_wait()

--- a/loopx/control_plane/goals/goal_frontier.py
+++ b/loopx/control_plane/goals/goal_frontier.py
@@ -34,6 +34,7 @@ LONG_TODO_CHAIN_OPEN_THRESHOLD = 20
 AGENT_VISION_CLOSED_STATES = {
     "closed",
     "satisfied",
+    "vision_closed",
     "retired",
     "retired_or_superseded",
     "superseded",


### PR DESCRIPTION
## Summary
- Treat `agent_vision.state=vision_closed` as a closed vision state in quota/frontier projection.
- Add a regression smoke for the incident shape where a closed vision plus `no_followup` monitor continuation should quiet-skip instead of re-triggering autonomous replan.

## Validation
- `python3 -m py_compile loopx/control_plane/goals/goal_frontier.py`
- `python3 examples/control_plane/quota-replan-decision-plane-smoke.py`
- `loopx canary premerge --from-git-diff` (passed, selected 17, failures 0, manual_holds 0, self_merge_allowed true)
- `loopx check --scan-path examples/control_plane/quota-replan-decision-plane-smoke.py --scan-path loopx/control_plane/goals/goal_frontier.py`

## Scope
Changed surfaces: quota/frontier projection and focused control-plane smoke. No scheduler behavior, write-scope policy, public/private evidence policy, or benchmark semantics changed.