### PR TITLE
Add guided start-goal preview

### DIFF
--- a/examples/bootstrap-command-pack-smoke.py
+++ b/examples/bootstrap-command-pack-smoke.py
@@ -154,6 +154,66 @@ def test_goal_text_invocation_plans_ranked_todos_before_activation() -> None:
         assert not (project / ".codex").exists()
 
 
+def test_start_goal_guided_previews_transaction_without_mutation() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        project = Path(tmp) / "guided-project"
+        project.mkdir()
+        payload = run_json(
+            "start-goal",
+            "--guided",
+            "--project",
+            str(project),
+            "--goal-id",
+            "guided-goal",
+            "--agent-id",
+            "codex-test-agent",
+            "--goal-text",
+            "Connect this repo and start an auto research lane",
+        )
+
+        assert payload["schema_version"] == "loopx_start_goal_guided_v0"
+        assert payload["read_only"] is True
+        assert payload["guided"] is True
+        assert payload["goal_text"] == "Connect this repo and start an auto research lane"
+        assert payload["goal_id"] == "guided-goal"
+
+        safety = payload["safety_contract"]
+        assert isinstance(safety, dict)
+        assert safety["writes_registry"] is False
+        assert safety["writes_state_file"] is False
+        assert safety["creates_heartbeat"] is False
+        assert safety["spends_quota"] is False
+        assert safety["force_bootstrap_allowed"] is False
+
+        transaction = payload["guided_transaction"]
+        assert isinstance(transaction, dict)
+        assert transaction["mode"] == "dry_run_preview"
+        step_ids = [step["id"] for step in transaction["ordered_steps"]]
+        assert step_ids == [
+            "inspect_connection",
+            "connect_if_needed",
+            "plan_ranked_todos",
+            "write_ordered_todos",
+            "refresh_state",
+            "activate_host_loop",
+            "quota_guard",
+            "scheduler_ack_when_needed",
+        ]
+        assert transaction["idempotency_policy"]["safe_to_rerun_preview"] is True
+        assert "do not duplicate" in transaction["idempotency_policy"]["do_not_duplicate_existing_todos"].lower()
+        preserve = transaction["preserve_todos_policy"]
+        assert preserve["force_bootstrap_default"] == "forbidden_in_guided_flow"
+        assert "backup-state" in preserve["before_destructive_reconnect"]
+        assert "configure-goal incremental" in preserve["preferred_scope_change"]
+
+        command_pack = payload["command_pack"]
+        assert isinstance(command_pack, dict)
+        assert command_pack["schema_version"] == "loopx_bootstrap_command_pack_v0"
+        assert command_pack["goal_start_contract"]["planner"]["required_before_todo_write"] is True
+        assert not (project / ".loopx").exists()
+        assert not (project / ".codex").exists()
+
+
 def test_connected_project_reuses_existing_state() -> None:
     with tempfile.TemporaryDirectory() as tmp:
         project = Path(tmp) / "connected-project"
@@ -375,6 +435,7 @@ def test_skill_slash_fallback_contract() -> None:
 def main() -> int:
     test_missing_project_stops_before_mutation()
     test_goal_text_invocation_plans_ranked_todos_before_activation()
+    test_start_goal_guided_previews_transaction_without_mutation()
     test_connected_project_reuses_existing_state()
     test_linked_git_worktree_reuses_canonical_source_registry()
     test_skill_slash_fallback_contract()

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -22,6 +22,7 @@ from .slash_commands import build_slash_command_catalog
 SCHEMA_VERSION = "loopx_bootstrap_command_pack_v0"
 CANONICAL_SLASH_COMMAND = "/loopx"
 GOAL_START_SCHEMA_VERSION = "loopx_goal_start_command_v0"
+GUIDED_START_SCHEMA_VERSION = "loopx_start_goal_guided_v0"
 
 
 def _resolve_project(project: Path) -> Path:
@@ -510,6 +511,172 @@ def build_loopx_bootstrap_command_pack(
     }
     payload["message"] = render_loopx_bootstrap_command_pack_message(payload)
     return payload
+
+
+def build_start_goal_guided_packet(
+    *,
+    project: Path,
+    goal_id: str | None,
+    agent_id: str | None,
+    cli_bin: str,
+    host_surface: str,
+    goal_text: str,
+) -> dict[str, Any]:
+    command_pack = build_loopx_bootstrap_command_pack(
+        project=project,
+        goal_id=goal_id,
+        agent_id=agent_id,
+        cli_bin=cli_bin,
+        host_surface=host_surface,
+        goal_text=goal_text,
+    )
+    commands = command_pack.get("commands")
+    commands = commands if isinstance(commands, dict) else {}
+    guided_transaction = {
+        "schema_version": GUIDED_START_SCHEMA_VERSION,
+        "mode": "dry_run_preview",
+        "writes_now": False,
+        "spends_quota_now": False,
+        "goal_text": command_pack.get("goal_text"),
+        "ordered_steps": [
+            {
+                "id": "inspect_connection",
+                "kind": "read_only",
+                "command": command_pack.get("canonical_cli_command"),
+                "purpose": "resolve canonical project, goal id, registry, and active state before any mutation",
+            },
+            {
+                "id": "connect_if_needed",
+                "kind": "conditional_mutation",
+                "command": commands.get("goal_start_connect_if_needed"),
+                "purpose": "create or reuse project-local LoopX state only when no matching goal exists",
+            },
+            {
+                "id": "plan_ranked_todos",
+                "kind": "model_checkpoint",
+                "prompt": commands.get("goal_start_plan_prompt"),
+                "purpose": "produce concise public-safe P0/P1/P2 todos before todo writeback",
+            },
+            {
+                "id": "write_ordered_todos",
+                "kind": "operator_or_agent_actions",
+                "command_template": (
+                    f"{shell_arg(cli_bin)} todo add --goal-id "
+                    f"{shell_arg(str(command_pack.get('goal_id') or ''))} --role agent "
+                    "--task-class advancement_task --action-kind <action_kind> --text '<[P0/P1/P2] ...>'"
+                ),
+                "purpose": "write todos in planner order so same-priority ordering stays deterministic",
+            },
+            {
+                "id": "refresh_state",
+                "kind": "state_sync",
+                "command": commands.get("goal_start_refresh_state"),
+                "purpose": "project the accepted plan and next action into active state/history",
+            },
+            {
+                "id": "activate_host_loop",
+                "kind": "host_loop",
+                "command": commands.get("goal_start_host_loop_activation"),
+                "purpose": "install or refresh the host loop only when it is missing, unknown, stale, or agent type changed",
+            },
+            {
+                "id": "quota_guard",
+                "kind": "guard",
+                "command": commands.get("goal_start_quota_should_run"),
+                "purpose": "let LoopX choose the first bounded segment and scheduler cadence",
+            },
+            {
+                "id": "scheduler_ack_when_needed",
+                "kind": "scheduler_state",
+                "command_source": "quota.should-run.scheduler_hint.codex_app.ack_hint.cli_args",
+                "purpose": "ack an applied Codex App RRULE without spending quota",
+            },
+        ],
+        "idempotency_policy": {
+            "safe_to_rerun_preview": True,
+            "reuse_connected_goal": True,
+            "do_not_duplicate_existing_todos": (
+                "Do not duplicate existing todos; before writing, compare active todos by text/action_kind "
+                "and update or skip matching items."
+            ),
+            "host_loop_recheck": (
+                "Only regenerate or update automation when the host loop is missing, unknown, stale, or agent type changed."
+            ),
+        },
+        "preserve_todos_policy": {
+            "force_bootstrap_default": "forbidden_in_guided_flow",
+            "before_destructive_reconnect": "run backup-state and stop for an explicit preserve-todos confirmation",
+            "preferred_scope_change": "use configure-goal incremental updates instead of force bootstrap when state already exists",
+        },
+    }
+    payload = {
+        "ok": True,
+        "schema_version": GUIDED_START_SCHEMA_VERSION,
+        "read_only": True,
+        "guided": True,
+        "project": command_pack.get("project"),
+        "goal_id": command_pack.get("goal_id"),
+        "agent_id": command_pack.get("agent_id"),
+        "host_surface": command_pack.get("host_surface"),
+        "goal_text": command_pack.get("goal_text"),
+        "project_connection": command_pack.get("project_connection"),
+        "recommended_next_step": command_pack.get("recommended_next_step"),
+        "guided_transaction": guided_transaction,
+        "command_pack": command_pack,
+        "safety_contract": {
+            "writes_registry": False,
+            "writes_state_file": False,
+            "creates_heartbeat": False,
+            "spends_quota": False,
+            "mutation_commands_are_previewed": True,
+            "force_bootstrap_allowed": False,
+        },
+    }
+    payload["message"] = render_start_goal_guided_markdown(payload)
+    return payload
+
+
+def render_start_goal_guided_markdown(payload: dict[str, Any]) -> str:
+    transaction = payload.get("guided_transaction")
+    transaction = transaction if isinstance(transaction, dict) else {}
+    steps = transaction.get("ordered_steps")
+    steps = steps if isinstance(steps, list) else []
+    step_lines: list[str] = []
+    for index, step in enumerate(steps, start=1):
+        if not isinstance(step, dict):
+            continue
+        command = step.get("command") or step.get("command_template") or step.get("command_source") or step.get("prompt")
+        step_lines.extend(
+            [
+                f"{index}. `{step.get('id')}` ({step.get('kind')})",
+                f"   - purpose: {step.get('purpose')}",
+            ]
+        )
+        if command:
+            step_lines.append(f"   - command/source: `{str(command).splitlines()[0]}`")
+    preserve = transaction.get("preserve_todos_policy")
+    preserve = preserve if isinstance(preserve, dict) else {}
+    return f"""# Guided Start Goal
+
+- schema: `{payload.get("schema_version")}`
+- read_only: `{payload.get("read_only")}`
+- project: `{payload.get("project")}`
+- goal_id: `{payload.get("goal_id")}`
+- goal_text: `{payload.get("goal_text")}`
+
+This is a guided dry-run packet. It previews the transaction and keeps mutation
+behind explicit command execution by the host/agent.
+
+## Ordered Transaction
+
+{chr(10).join(step_lines)}
+
+## Todo Preservation
+
+- force_bootstrap_default: `{preserve.get("force_bootstrap_default")}`
+- before_destructive_reconnect: {preserve.get("before_destructive_reconnect")}
+- preferred_scope_change: {preserve.get("preferred_scope_change")}
+"""
 
 
 def render_loopx_bootstrap_command_pack_message(payload: dict[str, Any]) -> str:

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -214,6 +214,7 @@ def main(argv: list[str] | None = None) -> int:
             "demo",
             "doctor",
             "new-project-prompt",
+            "start-goal",
             "slash-commands",
             "heartbeat-prompt",
             "sync-global",

--- a/loopx/cli_commands/starter_bootstrap.py
+++ b/loopx/cli_commands/starter_bootstrap.py
@@ -13,7 +13,9 @@ from ..agent_onboarding import (
     render_agent_type_catalog_markdown,
 )
 from ..bootstrap_command_pack import (
+    build_start_goal_guided_packet,
     build_loopx_bootstrap_command_pack,
+    render_start_goal_guided_markdown,
     render_loopx_bootstrap_command_pack_markdown,
 )
 from ..project_prompt import (
@@ -103,6 +105,38 @@ def register_starter_bootstrap_commands(subparsers: argparse._SubParsersAction) 
         dest="message_only",
         action="store_true",
         help="Print only the pasteable /loopx handling message.",
+    )
+
+    start_goal_parser = subparsers.add_parser(
+        "start-goal",
+        help="Preview a guided /loopx <goal text> start transaction without mutating state.",
+    )
+    start_goal_parser.add_argument(
+        "--guided",
+        action="store_true",
+        help="Required for now: render the guided dry-run transaction packet.",
+    )
+    start_goal_parser.add_argument("--project", default=".", help="Project directory to inspect.")
+    start_goal_parser.add_argument("--goal-id", help="Goal id. Defaults to <project-name>-goal.")
+    start_goal_parser.add_argument(
+        "--agent-id",
+        help="Registered LoopX agent id to include in quota/heartbeat commands.",
+    )
+    start_goal_parser.add_argument(
+        "--cli-bin",
+        default="loopx",
+        help="LoopX CLI binary name embedded in generated commands.",
+    )
+    start_goal_parser.add_argument(
+        "--host-surface",
+        default="codex-app",
+        choices=["chat-box", "codex-app", "codex-cli-tui", "claude-code", "shell", "http", "worker-bridge"],
+        help="Host surface that will own loop activation after todo writeback.",
+    )
+    start_goal_parser.add_argument(
+        "--goal-text",
+        required=True,
+        help="Exact goal text to plan before todo writeback.",
     )
 
     prompt_parser = subparsers.add_parser(
@@ -260,6 +294,31 @@ def handle_loopx_bootstrap_command_pack_command(
     return 0
 
 
+def handle_start_goal_command(
+    args: argparse.Namespace,
+    print_payload: PrintPayload,
+) -> int:
+    if not bool(getattr(args, "guided", False)):
+        payload = {
+            "ok": False,
+            "schema_version": "loopx_start_goal_guided_v0",
+            "error": "`loopx start-goal` currently requires --guided",
+            "suggested_command": "loopx start-goal --guided --goal-text '<goal text>'",
+        }
+        print_payload(payload, args.format, render_start_goal_guided_markdown)
+        return 2
+    payload = build_start_goal_guided_packet(
+        project=Path(args.project),
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        cli_bin=args.cli_bin,
+        host_surface=args.host_surface,
+        goal_text=args.goal_text,
+    )
+    print_payload(payload, args.format, render_start_goal_guided_markdown)
+    return 0
+
+
 def handle_codex_cli_bootstrap_message_command(
     args: argparse.Namespace,
     print_payload: PrintPayload,
@@ -313,6 +372,7 @@ def handle_starter_bootstrap_command(
     handlers: dict[str, Callable[[argparse.Namespace, PrintPayload], int]] = {
         "agent-onboard": handle_agent_onboard_command,
         "bootstrap-command-pack": handle_loopx_bootstrap_command_pack_command,
+        "start-goal": handle_start_goal_command,
         "new-project-prompt": handle_new_project_prompt_command,
         "codex-cli-bootstrap-message": handle_codex_cli_bootstrap_message_command,
         "codex-cli-tui-bootstrap-smoke-bundle": handle_codex_cli_tui_bootstrap_smoke_bundle_command,


### PR DESCRIPTION
## Summary
- Add `loopx start-goal --guided --goal-text ...` as a discoverable dry-run entry for `/loopx <goal text>` onboarding.
- Reuse the existing bootstrap command pack and expose an ordered guided transaction: inspect, connect-if-needed, plan ranked todos, write ordered todos, refresh state, activate host loop, quota guard, scheduler ack.
- Include idempotency and todo-preservation policy so guided onboarding avoids duplicate todos and forbids force bootstrap by default.

## Validation
- `python3 -m py_compile loopx/bootstrap_command_pack.py loopx/cli_commands/starter_bootstrap.py loopx/cli.py`
- `python3 examples/bootstrap-command-pack-smoke.py`
- `python3 -m loopx.cli --format json start-goal --guided --project . --goal-id loopx-meta --agent-id codex-side-bypass --goal-text "Improve onboarding"`
- `loopx canary premerge --from-git-diff` passed: selected 4, failures 0, manual_holds 0, self_merge_allowed true
- `loopx check --scan-path examples/bootstrap-command-pack-smoke.py --scan-path loopx/bootstrap_command_pack.py --scan-path loopx/cli.py --scan-path loopx/cli_commands/starter_bootstrap.py`

## Scope
This is the first bounded slice for guided onboarding. It is read-only/dry-run preview only: no registry writes, no state-file writes, no heartbeat mutation, and no quota spend.