### PR TITLE
Split Harbor host bridge template

### DIFF
--- a/scripts/harbor_host_bridge.py
+++ b/scripts/harbor_host_bridge.py
@@ -1,0 +1,56 @@
+"""Host command bridge template for Harbor-based Codex agents."""
+
+from __future__ import annotations
+
+BRIDGE_SCRIPT_TEMPLATE = """#!/usr/bin/env python3
+import argparse
+import json
+import pathlib
+import sys
+import time
+import uuid
+
+REQUEST_DIR = pathlib.Path("__LOOPX_REQUEST_DIR__")
+
+parser = argparse.ArgumentParser(description="Forward a command into Harbor environment.exec")
+parser.add_argument("--cwd", default="")
+parser.add_argument("--timeout-sec", type=float, default=600)
+parser.add_argument("command", nargs=argparse.REMAINDER)
+args = parser.parse_args()
+
+if not args.command:
+    print("missing command", file=sys.stderr)
+    raise SystemExit(2)
+
+if args.command[0] == "--":
+    args.command = args.command[1:]
+
+command = " ".join(args.command) if len(args.command) > 1 else args.command[0]
+request_id = uuid.uuid4().hex
+request = REQUEST_DIR / f"{request_id}.request.json"
+response = REQUEST_DIR / f"{request_id}.response.json"
+tmp = REQUEST_DIR / f"{request_id}.tmp"
+tmp.write_text(json.dumps({
+    "command": command,
+    "cwd": args.cwd,
+    "timeout_sec": args.timeout_sec,
+}, ensure_ascii=False))
+tmp.rename(request)
+deadline = time.time() + args.timeout_sec + 30
+while time.time() < deadline:
+    if response.exists():
+        payload = json.loads(response.read_text())
+        stdout = payload.get("stdout") or ""
+        stderr = payload.get("stderr") or ""
+        if stdout:
+            sys.stdout.write(stdout)
+        if stderr:
+            sys.stderr.write(stderr)
+        raise SystemExit(int(payload.get("return_code") or 0))
+    time.sleep(0.5)
+
+print("harbor-env-exec timed out waiting for response", file=sys.stderr)
+raise SystemExit(124)
+"""
+
+__all__ = ["BRIDGE_SCRIPT_TEMPLATE"]

--- a/scripts/harbor_host_codex_goal_agent.py
+++ b/scripts/harbor_host_codex_goal_agent.py
@@ -34,6 +34,7 @@ from codex_app_server_goal_driver import (
     start_codex_app_server_goal_followup_turn,
     start_codex_app_server_goal_turn,
 )
+from harbor_host_bridge import BRIDGE_SCRIPT_TEMPLATE
 from loopx.benchmark_case_state import (
     BENCHMARK_CASE_ACTIVE_STATE_SCHEMA_VERSION,
     BENCHMARK_CASE_LOOPX_CLI_PATH,
@@ -88,58 +89,6 @@ except Exception:  # pragma: no cover - keeps local smoke import dependency-free
 
     class AgentContext:  # type: ignore[no-redef]
         metadata: dict[str, Any] | None = None
-
-
-BRIDGE_SCRIPT_TEMPLATE = """#!/usr/bin/env python3
-import argparse
-import json
-import pathlib
-import sys
-import time
-import uuid
-
-REQUEST_DIR = pathlib.Path("__LOOPX_REQUEST_DIR__")
-
-parser = argparse.ArgumentParser(description="Forward a command into Harbor environment.exec")
-parser.add_argument("--cwd", default="")
-parser.add_argument("--timeout-sec", type=float, default=600)
-parser.add_argument("command", nargs=argparse.REMAINDER)
-args = parser.parse_args()
-
-if not args.command:
-    print("missing command", file=sys.stderr)
-    raise SystemExit(2)
-
-if args.command[0] == "--":
-    args.command = args.command[1:]
-
-command = " ".join(args.command) if len(args.command) > 1 else args.command[0]
-request_id = uuid.uuid4().hex
-request = REQUEST_DIR / f"{request_id}.request.json"
-response = REQUEST_DIR / f"{request_id}.response.json"
-tmp = REQUEST_DIR / f"{request_id}.tmp"
-tmp.write_text(json.dumps({
-    "command": command,
-    "cwd": args.cwd,
-    "timeout_sec": args.timeout_sec,
-}, ensure_ascii=False))
-tmp.rename(request)
-deadline = time.time() + args.timeout_sec + 30
-while time.time() < deadline:
-    if response.exists():
-        payload = json.loads(response.read_text())
-        stdout = payload.get("stdout") or ""
-        stderr = payload.get("stderr") or ""
-        if stdout:
-            sys.stdout.write(stdout)
-        if stderr:
-            sys.stderr.write(stderr)
-        raise SystemExit(int(payload.get("return_code") or 0))
-    time.sleep(0.5)
-
-print("harbor-env-exec timed out waiting for response", file=sys.stderr)
-raise SystemExit(124)
-"""
 
 
 def build_codex_tui_command(


### PR DESCRIPTION
Summary
- Move the Harbor host command bridge template into scripts/harbor_host_bridge.py.
- Keep harbor_host_codex_goal_agent.py importing the same BRIDGE_SCRIPT_TEMPLATE while reducing that hot file from 2142 to 2091 lines.
- This makes repo-python-line-budget-smoke --strict pass with zero existing over-budget files.

Validation
- python3 examples/control_plane/repo-python-line-budget-smoke.py --strict
- python3 -m py_compile scripts/harbor_host_codex_goal_agent.py scripts/harbor_host_bridge.py
- PYTHONPATH=. import check for harbor_host_bridge and harbor_host_codex_goal_agent
- git diff --check and git diff --cached --check
- loopx canary premerge --from-git-diff (passed; selected=1, failures=0, manual_holds=0, self_merge_allowed=true)

Risk
- Refactor-only public benchmark host helper change.
- No benchmark execution, scoring, task semantics, credentials, raw logs, trajectories, or verifier output changes.