### PR TITLE
Split status markdown smoke fixtures

### DIFF
--- a/examples/control_plane/repo-python-line-budget-smoke.py
+++ b/examples/control_plane/repo-python-line-budget-smoke.py
@@ -53,7 +53,7 @@ LEGACY_OVERSIZED_LIMITS = {
     "examples/skillsbench-app-server-goal-worker-smoke.py": 3119,
     "examples/skillsbench-benchmark-run-smoke.py": 14821,
     "examples/skillsbench-host-local-launch-plan-smoke.py": 2373,
-    "examples/control_plane/status-markdown-smoke.py": 2607,
+    "examples/control_plane/status-markdown-smoke.py": 2304,
     "examples/terminal-bench-harbor-runner-ingest-smoke.py": 2759,
     "examples/terminal-bench-private-runner-env-guard-smoke.py": 2619,
     "loopx/benchmark.py": 2875,

--- a/examples/control_plane/status-markdown-smoke.py
+++ b/examples/control_plane/status-markdown-smoke.py
@@ -33,34 +33,40 @@ from loopx.quota import build_quota_should_run, render_quota_should_run_markdown
 from loopx.cli_commands.status import attach_agent_lane_next_actions, _review_handoff_agent  # noqa: E402
 from loopx.review_packet import build_review_packet  # noqa: E402
 from loopx.handoff_budget import PROJECT_AGENT_HANDOFF_BUDGET  # noqa: E402
-
-
-OLD_PLANNED_ACTION = "先审阅 LoopX operator gate；同意后再发送项目 agent 命令"
-NEW_PLANNED_ACTION = "先在 LoopX 完成 operator 判断；同意后项目 Agent 只执行 read-only map dry-run"
-APPROVED_ACTION = "把已批准的 agent_command 发给目标项目 agent；这不是写权限授权"
-APPROVED_COMMAND = "loopx read-only-map --goal-id planned-main-control --dry-run"
-POST_HANDOFF_ACTION = "post-handoff fixture run is visible; choose the next bounded delivery step"
-POST_HANDOFF_CLASSIFICATION = "read_only_project_map"
-REJECTED_ACTION = "保持 goal 在 gate 状态，修改 handoff 后再请求 operator 判断"
-DEFERRED_ACTION = "保持 goal 在 gate 状态，先补齐要求的证据后再请求判断"
-REGISTRY_OVERRIDE_STATUS = "owner_sop_review_pending"
-REGISTRY_OVERRIDE_ACTION = "请先完成 owner/SOP 判断；未决前不要让项目 agent 继续推进"
-REGISTRY_OVERRIDE_QUESTION = "是否同意 owner/SOP review 完成后继续推进？"
-REGISTRY_OVERRIDE_HANDOFF = "owner/SOP decision recorded"
-USER_TODO_TEXT = "Read source topic account-vs-group note before owner review."
-AGENT_TODO_TEXT = "Build the P0 two-layer config worksheet."
-DELIVERY_GOAL_ID = "delivery-side-bypass"
-DELIVERY_ACTION = "Continue the ranker path with the next clean readiness implementation/test batch."
-DELIVERY_AGENT_TODO = "Add the readiness smoke plus the matching implementation guard when both paths are clean."
-CONNECTED_READONLY_GOAL_ID = "connected-readonly-progress"
-CONNECTED_READONLY_CLASSIFICATION = "status_markdown_usage_summary_progress_signal"
-CONNECTED_READONLY_ACTION = "continue the next compact self-improvement slice after the progress run"
-EXPLICIT_REFRESH_CLASSIFICATION = "dashboard_home_browser_smoke_regression"
-DEPENDENCY_CURRENT_GOAL_ID = "meta-hardening-fixture"
-DEPENDENCY_BLOCKER_GOAL_ID = "dependency-owner-gate"
-DEPENDENCY_AGENT_TODO = "Continue the gate-independent P1/P2 product-hardening slice."
-DEPENDENCY_MONITOR_TODO = "Side-bypass dependency monitor: observe public-safe replay transitions only."
-DEPENDENCY_USER_TODO = "Confirm the sibling project evidence gate before its controller resumes delivery."
+from status_markdown_fixtures import (  # noqa: E402
+    AGENT_TODO_TEXT,
+    APPROVED_ACTION,
+    APPROVED_COMMAND,
+    CONNECTED_READONLY_ACTION,
+    CONNECTED_READONLY_CLASSIFICATION,
+    CONNECTED_READONLY_GOAL_ID,
+    DEFERRED_ACTION,
+    DELIVERY_ACTION,
+    DELIVERY_AGENT_TODO,
+    DELIVERY_GOAL_ID,
+    DEPENDENCY_AGENT_TODO,
+    DEPENDENCY_BLOCKER_GOAL_ID,
+    DEPENDENCY_CURRENT_GOAL_ID,
+    DEPENDENCY_MONITOR_TODO,
+    DEPENDENCY_USER_TODO,
+    EXPLICIT_REFRESH_CLASSIFICATION,
+    NEW_PLANNED_ACTION,
+    OLD_PLANNED_ACTION,
+    POST_HANDOFF_ACTION,
+    POST_HANDOFF_CLASSIFICATION,
+    REGISTRY_OVERRIDE_ACTION,
+    REGISTRY_OVERRIDE_HANDOFF,
+    REGISTRY_OVERRIDE_QUESTION,
+    REGISTRY_OVERRIDE_STATUS,
+    REJECTED_ACTION,
+    USER_TODO_TEXT,
+    mark_planned_todos_done,
+    write_connected_delivery_registry,
+    write_connected_readonly_registry,
+    write_dependency_blocker_registry,
+    write_global_source_registry_shadow,
+    write_planned_registry,
+)
 
 def assert_handoff_budget_contract(readiness: dict, label: str) -> None:
     budget = readiness.get("handoff_interface_budget")
@@ -68,315 +74,6 @@ def assert_handoff_budget_contract(readiness: dict, label: str) -> None:
     assert budget["mode"] == PROJECT_AGENT_HANDOFF_BUDGET["mode"], (label, budget)
     assert budget["max_lines"] == PROJECT_AGENT_HANDOFF_BUDGET["max_lines"], (label, budget)
     assert budget["max_chars"] == PROJECT_AGENT_HANDOFF_BUDGET["max_chars"], (label, budget)
-
-
-def write_planned_registry(root: Path) -> Path:
-    project = root / "project"
-    runtime = root / "runtime"
-    goal_id = "planned-main-control"
-    state_file = f".codex/goals/{goal_id}/ACTIVE_GOAL_STATE.md"
-    registry_path = project / ".loopx" / "registry.json"
-
-    (project / Path(state_file).parent).mkdir(parents=True, exist_ok=True)
-    (project / state_file).write_text(
-        "---\n"
-        "status: planned-high-complexity\n"
-        "updated_at: 2026-01-01T00:00:00+00:00\n"
-        "---\n\n"
-        "# Planned Main Control\n\n"
-        "## User Todo / Owner Review Reading Queue\n\n"
-        f"- [ ] {USER_TODO_TEXT}\n"
-        "  <!-- loopx:todo todo_id=todo_planned_user_gate task_class=user_gate global_gate=true -->\n"
-        "- [x] Open owner worksheet.\n\n"
-        "## Agent Todo\n\n"
-        f"- [ ] {AGENT_TODO_TEXT}\n",
-        encoding="utf-8",
-    )
-    registry_path.parent.mkdir(parents=True, exist_ok=True)
-    registry_path.write_text(
-        json.dumps(
-            {
-                "schema_version": 1,
-                "updated_at": "2026-01-01T00:00:00+00:00",
-                "common_runtime_root": str(runtime),
-                "goals": [
-                    {
-                        "id": goal_id,
-                        "domain": "complex-project",
-                        "status": "planned-high-complexity",
-                        "repo": str(project),
-                        "state_file": state_file,
-                        "adapter": {
-                            "kind": "complex_project_read_only_map_v0",
-                            "status": "planned",
-                        },
-                        "authority_sources": [],
-                    }
-                ],
-            },
-            indent=2,
-            sort_keys=True,
-        ),
-        encoding="utf-8",
-    )
-    return registry_path
-
-
-def mark_planned_todos_done(root: Path) -> None:
-    goal_id = "planned-main-control"
-    state_path = root / "project" / ".codex" / "goals" / goal_id / "ACTIVE_GOAL_STATE.md"
-    state_text = state_path.read_text(encoding="utf-8")
-    state_text = state_text.replace(f"- [ ] {USER_TODO_TEXT}", f"- [x] {USER_TODO_TEXT}")
-    state_text = state_text.replace(f"- [ ] {AGENT_TODO_TEXT}", f"- [x] {AGENT_TODO_TEXT}")
-    state_path.write_text(state_text, encoding="utf-8")
-
-def write_connected_delivery_registry(root: Path) -> Path:
-    project = root / "project"
-    runtime = root / "runtime"
-    state_file = f".codex/goals/{DELIVERY_GOAL_ID}/ACTIVE_GOAL_STATE.md"
-    registry_path = project / ".loopx" / "registry.json"
-
-    (project / Path(state_file).parent).mkdir(parents=True, exist_ok=True)
-    (project / state_file).write_text(
-        "---\n"
-        "status: active\n"
-        "updated_at: 2026-01-01T00:00:00+00:00\n"
-        "---\n\n"
-        "# Connected Delivery\n\n"
-        "## Agent Todo\n\n"
-        f"- [ ] {DELIVERY_AGENT_TODO}\n",
-        encoding="utf-8",
-    )
-    registry_path.parent.mkdir(parents=True, exist_ok=True)
-    registry_path.write_text(
-        json.dumps(
-            {
-                "schema_version": 1,
-                "updated_at": "2026-01-01T00:00:00+00:00",
-                "common_runtime_root": str(runtime),
-                "goals": [
-                    {
-                        "id": DELIVERY_GOAL_ID,
-                        "domain": "connected-delivery-fixture",
-                        "status": "active",
-                        "repo": str(project),
-                        "state_file": state_file,
-                        "adapter": {
-                            "kind": "fixture_connected_delivery_v0",
-                            "status": "connected-delivery",
-                        },
-                        "quota": {
-                            "compute": 0.33,
-                            "window_hours": 24,
-                        },
-                        "coordination": {
-                            "write_scope": ["src/**", "tests/**"],
-                            "requires_parent_approval": ["publish", "production-action"],
-                        },
-                        "spawn_policy": {
-                            "mode": "multi_subagent",
-                            "allowed": True,
-                            "max_children": 2,
-                            "allowed_domains": ["docs-map", "validation-map"],
-                        },
-                        "execution_profile": {
-                            "cadence": "bounded_progress_segment",
-                            "minimum_scale": "implementation",
-                            "must_include": [
-                                "implementation_artifact",
-                                "targeted_validation",
-                                "state_writeback",
-                            ],
-                            "spend_rule": "spend_only_after_artifact_validation_writeback",
-                            "outcome_floor": {
-                                "required_when": "after_surface_progress_streak",
-                                "surface_streak_threshold": 2,
-                                "outcome_markers": [
-                                    "ranker_readiness_batch",
-                                    "macro_evidence",
-                                    "evidence_segment",
-                                    "ranker_fit",
-                                    "eval_metric",
-                                ],
-                                "surface_only_hints": [
-                                    "forecast",
-                                    "runbook",
-                                    "queue",
-                                    "fields",
-                                ],
-                                "must_advance": [
-                                    "ranker_or_cross_domain_evidence",
-                                ],
-                                "avoid": [
-                                    "surface_only_progress_loop",
-                                ],
-                                "if_unavailable": "report_blocker_without_spend",
-                            },
-                            "degradation_policy": {
-                                "small_scale_streak_threshold": 3,
-                                "on_degradation": "require_blocker_or_expand_next_batch",
-                            },
-                        },
-                        "guards": [
-                            "low-conflict delivery within declared write_scope",
-                        ],
-                        "next_probe": f"loopx quota should-run --goal-id {DELIVERY_GOAL_ID}",
-                        "authority_sources": [],
-                    }
-                ],
-            },
-            indent=2,
-            sort_keys=True,
-        ),
-        encoding="utf-8",
-    )
-    return registry_path
-
-
-def write_global_source_registry_shadow(root: Path, registry_path: Path, *, goal_id: str) -> None:
-    runtime = root / "runtime"
-    local_registry = json.loads(registry_path.read_text(encoding="utf-8"))
-    goals = local_registry.get("goals") if isinstance(local_registry.get("goals"), list) else []
-    local_goal = next(goal for goal in goals if isinstance(goal, dict) and goal.get("id") == goal_id)
-    shadow_goal = dict(local_goal)
-    shadow_goal["source_registry"] = str(root / "missing-source" / "registry.json")
-    shadow_goal["synced_at"] = "2026-01-01T00:00:00+00:00"
-    runtime.mkdir(parents=True, exist_ok=True)
-    (runtime / "registry.global.json").write_text(
-        json.dumps(
-            {
-                "schema_version": 1,
-                "updated_at": "2026-01-01T00:00:00+00:00",
-                "common_runtime_root": str(runtime),
-                "goals": [shadow_goal],
-            },
-            ensure_ascii=False,
-            indent=2,
-            sort_keys=True,
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-
-
-def write_connected_readonly_registry(root: Path) -> Path:
-    project = root / "project"
-    runtime = root / "runtime"
-    state_file = f".codex/goals/{CONNECTED_READONLY_GOAL_ID}/ACTIVE_GOAL_STATE.md"
-    registry_path = project / ".loopx" / "registry.json"
-
-    (project / Path(state_file).parent).mkdir(parents=True, exist_ok=True)
-    (project / state_file).write_text(
-        "---\n"
-        "status: active-read-only\n"
-        "updated_at: 2026-01-01T00:00:00+00:00\n"
-        "---\n\n"
-        "# Connected Readonly Progress\n\n"
-        "## Next Action\n\n"
-        f"- {CONNECTED_READONLY_ACTION}\n",
-        encoding="utf-8",
-    )
-    registry_path.parent.mkdir(parents=True, exist_ok=True)
-    registry_path.write_text(
-        json.dumps(
-            {
-                "schema_version": 1,
-                "updated_at": "2026-01-01T00:00:00+00:00",
-                "common_runtime_root": str(runtime),
-                "goals": [
-                    {
-                        "id": CONNECTED_READONLY_GOAL_ID,
-                        "domain": "connected-readonly-fixture",
-                        "status": "active-read-only",
-                        "repo": str(project),
-                        "state_file": state_file,
-                        "adapter": {
-                            "kind": "fixture_connected_readonly_v0",
-                            "status": "connected-read-only",
-                        },
-                        "authority_sources": [],
-                    }
-                ],
-            },
-            indent=2,
-            sort_keys=True,
-        ),
-        encoding="utf-8",
-    )
-    return registry_path
-
-
-def write_dependency_blocker_registry(root: Path) -> Path:
-    project = root / "project"
-    runtime = root / "runtime"
-    registry_path = project / ".loopx" / "registry.json"
-    current_state_file = f".codex/goals/{DEPENDENCY_CURRENT_GOAL_ID}/ACTIVE_GOAL_STATE.md"
-    blocker_state_file = f".codex/goals/{DEPENDENCY_BLOCKER_GOAL_ID}/ACTIVE_GOAL_STATE.md"
-
-    (project / Path(current_state_file).parent).mkdir(parents=True, exist_ok=True)
-    (project / current_state_file).write_text(
-        "---\n"
-        "status: active\n"
-        "updated_at: 2026-01-01T00:00:00+00:00\n"
-        "---\n\n"
-        "# Meta Hardening Fixture\n\n"
-        "## Agent Todo\n\n"
-        f"- [ ] {DEPENDENCY_AGENT_TODO}\n"
-        f"- [ ] {DEPENDENCY_MONITOR_TODO}\n",
-        encoding="utf-8",
-    )
-    (project / Path(blocker_state_file).parent).mkdir(parents=True, exist_ok=True)
-    (project / blocker_state_file).write_text(
-        "---\n"
-        "status: planned-high-complexity\n"
-        "updated_at: 2026-01-01T00:00:00+00:00\n"
-        "---\n\n"
-        "# Dependency Owner Gate\n\n"
-        "## User Todo / Owner Review Reading Queue\n\n"
-        f"- [ ] {DEPENDENCY_USER_TODO}\n"
-        "  <!-- loopx:todo todo_id=todo_dependency_user_gate task_class=user_gate global_gate=true -->\n",
-        encoding="utf-8",
-    )
-    registry_path.parent.mkdir(parents=True, exist_ok=True)
-    registry_path.write_text(
-        json.dumps(
-            {
-                "schema_version": 1,
-                "updated_at": "2026-01-01T00:00:00+00:00",
-                "common_runtime_root": str(runtime),
-                "goals": [
-                    {
-                        "id": DEPENDENCY_CURRENT_GOAL_ID,
-                        "domain": "meta-hardening-fixture",
-                        "status": "active",
-                        "repo": str(project),
-                        "state_file": current_state_file,
-                        "adapter": {
-                            "kind": "fixture_connected_readonly_v0",
-                            "status": "connected-read-only",
-                        },
-                        "authority_sources": [],
-                    },
-                    {
-                        "id": DEPENDENCY_BLOCKER_GOAL_ID,
-                        "domain": "dependency-gate-fixture",
-                        "status": "planned-high-complexity",
-                        "repo": str(project),
-                        "state_file": blocker_state_file,
-                        "adapter": {
-                            "kind": "complex_project_read_only_map_v0",
-                            "status": "planned",
-                        },
-                        "authority_sources": [],
-                    },
-                ],
-            },
-            indent=2,
-            sort_keys=True,
-        ),
-        encoding="utf-8",
-    )
-    return registry_path
 
 
 def append_connected_delivery_fixture(

--- a/examples/control_plane/status_markdown_fixtures.py
+++ b/examples/control_plane/status_markdown_fixtures.py
@@ -1,0 +1,344 @@
+"""Reusable registry fixtures for the status markdown smoke."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+OLD_PLANNED_ACTION = "先审阅 LoopX operator gate；同意后再发送项目 agent 命令"
+NEW_PLANNED_ACTION = "先在 LoopX 完成 operator 判断；同意后项目 Agent 只执行 read-only map dry-run"
+APPROVED_ACTION = "把已批准的 agent_command 发给目标项目 agent；这不是写权限授权"
+APPROVED_COMMAND = "loopx read-only-map --goal-id planned-main-control --dry-run"
+POST_HANDOFF_ACTION = "post-handoff fixture run is visible; choose the next bounded delivery step"
+POST_HANDOFF_CLASSIFICATION = "read_only_project_map"
+REJECTED_ACTION = "保持 goal 在 gate 状态，修改 handoff 后再请求 operator 判断"
+DEFERRED_ACTION = "保持 goal 在 gate 状态，先补齐要求的证据后再请求判断"
+REGISTRY_OVERRIDE_STATUS = "owner_sop_review_pending"
+REGISTRY_OVERRIDE_ACTION = "请先完成 owner/SOP 判断；未决前不要让项目 agent 继续推进"
+REGISTRY_OVERRIDE_QUESTION = "是否同意 owner/SOP review 完成后继续推进？"
+REGISTRY_OVERRIDE_HANDOFF = "owner/SOP decision recorded"
+USER_TODO_TEXT = "Read source topic account-vs-group note before owner review."
+AGENT_TODO_TEXT = "Build the P0 two-layer config worksheet."
+DELIVERY_GOAL_ID = "delivery-side-bypass"
+DELIVERY_ACTION = "Continue the ranker path with the next clean readiness implementation/test batch."
+DELIVERY_AGENT_TODO = "Add the readiness smoke plus the matching implementation guard when both paths are clean."
+CONNECTED_READONLY_GOAL_ID = "connected-readonly-progress"
+CONNECTED_READONLY_CLASSIFICATION = "status_markdown_usage_summary_progress_signal"
+CONNECTED_READONLY_ACTION = "continue the next compact self-improvement slice after the progress run"
+EXPLICIT_REFRESH_CLASSIFICATION = "dashboard_home_browser_smoke_regression"
+DEPENDENCY_CURRENT_GOAL_ID = "meta-hardening-fixture"
+DEPENDENCY_BLOCKER_GOAL_ID = "dependency-owner-gate"
+DEPENDENCY_AGENT_TODO = "Continue the gate-independent P1/P2 product-hardening slice."
+DEPENDENCY_MONITOR_TODO = "Side-bypass dependency monitor: observe public-safe replay transitions only."
+DEPENDENCY_USER_TODO = "Confirm the sibling project evidence gate before its controller resumes delivery."
+
+
+def write_planned_registry(root: Path) -> Path:
+    project = root / "project"
+    runtime = root / "runtime"
+    goal_id = "planned-main-control"
+    state_file = f".codex/goals/{goal_id}/ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".loopx" / "registry.json"
+
+    (project / Path(state_file).parent).mkdir(parents=True, exist_ok=True)
+    (project / state_file).write_text(
+        "---\n"
+        "status: planned-high-complexity\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Planned Main Control\n\n"
+        "## User Todo / Owner Review Reading Queue\n\n"
+        f"- [ ] {USER_TODO_TEXT}\n"
+        "  <!-- loopx:todo todo_id=todo_planned_user_gate task_class=user_gate global_gate=true -->\n"
+        "- [x] Open owner worksheet.\n\n"
+        "## Agent Todo\n\n"
+        f"- [ ] {AGENT_TODO_TEXT}\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": goal_id,
+                        "domain": "complex-project",
+                        "status": "planned-high-complexity",
+                        "repo": str(project),
+                        "state_file": state_file,
+                        "adapter": {
+                            "kind": "complex_project_read_only_map_v0",
+                            "status": "planned",
+                        },
+                        "authority_sources": [],
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    return registry_path
+
+
+def mark_planned_todos_done(root: Path) -> None:
+    goal_id = "planned-main-control"
+    state_path = root / "project" / ".codex" / "goals" / goal_id / "ACTIVE_GOAL_STATE.md"
+    state_text = state_path.read_text(encoding="utf-8")
+    state_text = state_text.replace(f"- [ ] {USER_TODO_TEXT}", f"- [x] {USER_TODO_TEXT}")
+    state_text = state_text.replace(f"- [ ] {AGENT_TODO_TEXT}", f"- [x] {AGENT_TODO_TEXT}")
+    state_path.write_text(state_text, encoding="utf-8")
+
+
+def write_connected_delivery_registry(root: Path) -> Path:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{DELIVERY_GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".loopx" / "registry.json"
+
+    (project / Path(state_file).parent).mkdir(parents=True, exist_ok=True)
+    (project / state_file).write_text(
+        "---\n"
+        "status: active\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Connected Delivery\n\n"
+        "## Agent Todo\n\n"
+        f"- [ ] {DELIVERY_AGENT_TODO}\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": DELIVERY_GOAL_ID,
+                        "domain": "connected-delivery-fixture",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": state_file,
+                        "adapter": {
+                            "kind": "fixture_connected_delivery_v0",
+                            "status": "connected-delivery",
+                        },
+                        "quota": {
+                            "compute": 0.33,
+                            "window_hours": 24,
+                        },
+                        "coordination": {
+                            "write_scope": ["src/**", "tests/**"],
+                            "requires_parent_approval": ["publish", "production-action"],
+                        },
+                        "spawn_policy": {
+                            "mode": "multi_subagent",
+                            "allowed": True,
+                            "max_children": 2,
+                            "allowed_domains": ["docs-map", "validation-map"],
+                        },
+                        "execution_profile": {
+                            "cadence": "bounded_progress_segment",
+                            "minimum_scale": "implementation",
+                            "must_include": [
+                                "implementation_artifact",
+                                "targeted_validation",
+                                "state_writeback",
+                            ],
+                            "spend_rule": "spend_only_after_artifact_validation_writeback",
+                            "outcome_floor": {
+                                "required_when": "after_surface_progress_streak",
+                                "surface_streak_threshold": 2,
+                                "outcome_markers": [
+                                    "ranker_readiness_batch",
+                                    "macro_evidence",
+                                    "evidence_segment",
+                                    "ranker_fit",
+                                    "eval_metric",
+                                ],
+                                "surface_only_hints": [
+                                    "forecast",
+                                    "runbook",
+                                    "queue",
+                                    "fields",
+                                ],
+                                "must_advance": [
+                                    "ranker_or_cross_domain_evidence",
+                                ],
+                                "avoid": [
+                                    "surface_only_progress_loop",
+                                ],
+                                "if_unavailable": "report_blocker_without_spend",
+                            },
+                            "degradation_policy": {
+                                "small_scale_streak_threshold": 3,
+                                "on_degradation": "require_blocker_or_expand_next_batch",
+                            },
+                        },
+                        "guards": [
+                            "low-conflict delivery within declared write_scope",
+                        ],
+                        "next_probe": f"loopx quota should-run --goal-id {DELIVERY_GOAL_ID}",
+                        "authority_sources": [],
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    return registry_path
+
+
+def write_global_source_registry_shadow(root: Path, registry_path: Path, *, goal_id: str) -> None:
+    runtime = root / "runtime"
+    local_registry = json.loads(registry_path.read_text(encoding="utf-8"))
+    goals = local_registry.get("goals") if isinstance(local_registry.get("goals"), list) else []
+    local_goal = next(goal for goal in goals if isinstance(goal, dict) and goal.get("id") == goal_id)
+    shadow_goal = dict(local_goal)
+    shadow_goal["source_registry"] = str(root / "missing-source" / "registry.json")
+    shadow_goal["synced_at"] = "2026-01-01T00:00:00+00:00"
+    runtime.mkdir(parents=True, exist_ok=True)
+    (runtime / "registry.global.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [shadow_goal],
+            },
+            ensure_ascii=False,
+            indent=2,
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def write_connected_readonly_registry(root: Path) -> Path:
+    project = root / "project"
+    runtime = root / "runtime"
+    state_file = f".codex/goals/{CONNECTED_READONLY_GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    registry_path = project / ".loopx" / "registry.json"
+
+    (project / Path(state_file).parent).mkdir(parents=True, exist_ok=True)
+    (project / state_file).write_text(
+        "---\n"
+        "status: active-read-only\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Connected Readonly Progress\n\n"
+        "## Next Action\n\n"
+        f"- {CONNECTED_READONLY_ACTION}\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": CONNECTED_READONLY_GOAL_ID,
+                        "domain": "connected-readonly-fixture",
+                        "status": "active-read-only",
+                        "repo": str(project),
+                        "state_file": state_file,
+                        "adapter": {
+                            "kind": "fixture_connected_readonly_v0",
+                            "status": "connected-read-only",
+                        },
+                        "authority_sources": [],
+                    }
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    return registry_path
+
+
+def write_dependency_blocker_registry(root: Path) -> Path:
+    project = root / "project"
+    runtime = root / "runtime"
+    registry_path = project / ".loopx" / "registry.json"
+    current_state_file = f".codex/goals/{DEPENDENCY_CURRENT_GOAL_ID}/ACTIVE_GOAL_STATE.md"
+    blocker_state_file = f".codex/goals/{DEPENDENCY_BLOCKER_GOAL_ID}/ACTIVE_GOAL_STATE.md"
+
+    (project / Path(current_state_file).parent).mkdir(parents=True, exist_ok=True)
+    (project / current_state_file).write_text(
+        "---\n"
+        "status: active\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Meta Hardening Fixture\n\n"
+        "## Agent Todo\n\n"
+        f"- [ ] {DEPENDENCY_AGENT_TODO}\n"
+        f"- [ ] {DEPENDENCY_MONITOR_TODO}\n",
+        encoding="utf-8",
+    )
+    (project / Path(blocker_state_file).parent).mkdir(parents=True, exist_ok=True)
+    (project / blocker_state_file).write_text(
+        "---\n"
+        "status: planned-high-complexity\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Dependency Owner Gate\n\n"
+        "## User Todo / Owner Review Reading Queue\n\n"
+        f"- [ ] {DEPENDENCY_USER_TODO}\n"
+        "  <!-- loopx:todo todo_id=todo_dependency_user_gate task_class=user_gate global_gate=true -->\n",
+        encoding="utf-8",
+    )
+    registry_path.parent.mkdir(parents=True, exist_ok=True)
+    registry_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(runtime),
+                "goals": [
+                    {
+                        "id": DEPENDENCY_CURRENT_GOAL_ID,
+                        "domain": "meta-hardening-fixture",
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": current_state_file,
+                        "adapter": {
+                            "kind": "fixture_connected_readonly_v0",
+                            "status": "connected-read-only",
+                        },
+                        "authority_sources": [],
+                    },
+                    {
+                        "id": DEPENDENCY_BLOCKER_GOAL_ID,
+                        "domain": "dependency-gate-fixture",
+                        "status": "planned-high-complexity",
+                        "repo": str(project),
+                        "state_file": blocker_state_file,
+                        "adapter": {
+                            "kind": "complex_project_read_only_map_v0",
+                            "status": "planned",
+                        },
+                        "authority_sources": [],
+                    },
+                ],
+            },
+            indent=2,
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+    return registry_path


### PR DESCRIPTION
Summary
- Move non-benchmark status-markdown registry fixture builders into examples/control_plane/status_markdown_fixtures.py.
- Keep status-markdown-smoke.py focused on behavior assertions and run fixture composition from the helper module.
- Lower the status-markdown-smoke.py line-budget pin from 2607 to 2304 to lock in the split.

Validation
- python3 examples/control_plane/status-markdown-smoke.py
- python3 examples/control_plane/repo-python-line-budget-smoke.py --strict
- python3 -m py_compile examples/control_plane/status-markdown-smoke.py examples/control_plane/status_markdown_fixtures.py examples/control_plane/repo-python-line-budget-smoke.py
- git diff --check and git diff --cached --check
- loopx canary premerge --from-git-diff (passed; selected=5, failures=0, manual_holds=0, self_merge_allowed=true)

Risk
- Non-benchmark control-plane smoke fixture refactor.
- No runtime behavior change; public/private boundary check passed.