### PR TITLE
Add non-destructive write-scope migration

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -99,7 +99,19 @@ loopx bootstrap \
 
 `loopx connect` is an alias for the same operation. The command is
 safe to rerun: by default it keeps an existing state file and existing registry
-entry; pass `--force` only when you intentionally want to replace them.
+entry. If the goal only needs an additional write boundary after connection,
+prefer the incremental migration path:
+
+```bash
+loopx configure-goal \
+  --goal-id project-goal \
+  --write-scope "src/**" \
+  --execute
+```
+
+Pass `--force` only when you intentionally want to replace the registry entry or
+active state. If you need a force reconnect but want to keep the current todo
+projection, add `--preserve-todos`.
 
 The default files are:
 

--- a/docs/new-project-codex-prompt.md
+++ b/docs/new-project-codex-prompt.md
@@ -99,6 +99,17 @@ loopx new-project-prompt \
    --allowed-domain validation-map \
    --write-scope "<SAFE_WRITE_SCOPE>"
 
+   如果接入后才发现 write_scope / boundary 少了，不要为了补 scope 直接
+   `bootstrap --force`。先用增量配置：
+
+   loopx configure-goal \
+     --goal-id <STABLE_GOAL_ID> \
+     --write-scope "<SAFE_WRITE_SCOPE>" \
+     --execute
+
+   只有在用户明确要求重建连接时才用 `bootstrap --force`；如果要保留当前
+   active state/todo，必须同时加 `--preserve-todos`。
+
 3. 确认 `.loopx/registry.json` 和
    `.codex/goals/<STABLE_GOAL_ID>/ACTIVE_GOAL_STATE.md` 已创建或更新。
    阅读输出里的 `Onboarding Scan`、`Proposed Onboarding Candidates`、

--- a/examples/control_plane/control-plane-configure-api-smoke.py
+++ b/examples/control_plane/control-plane-configure-api-smoke.py
@@ -201,6 +201,9 @@ def configure_payload() -> dict[str, Any]:
         "primary_agent": "codex-main-control",
         "clear_registered_agents": False,
         "clear_primary_agent": False,
+        "write_scope": ["docs/**", "tests/**"],
+        "replace_write_scope": False,
+        "clear_write_scope": False,
     }
 
 
@@ -233,6 +236,7 @@ def main() -> None:
             assert dry["written"] is False, dry
             assert dry["after"]["registered_agents"] == ["codex-main-control", "codex-side-bypass"], dry
             assert dry["after"]["primary_agent"] == "codex-main-control", dry
+            assert dry["after"]["write_scope"] == ["docs/**", "tests/**"], dry
             assert goal_from_registry(registry)["quota"]["compute"] == 1
             status, blocked = request_json(
                 "POST",
@@ -298,6 +302,7 @@ def main() -> None:
             assert dry["preview_id"], dry
             assert dry["after"]["registered_agents"] == ["codex-main-control", "codex-side-bypass"], dry
             assert dry["after"]["primary_agent"] == "codex-main-control", dry
+            assert dry["after"]["write_scope"] == ["docs/**", "tests/**"], dry
             status, stale = request_json(
                 "POST",
                 f"{base_url}/control-plane/configure-goal/apply",
@@ -332,6 +337,7 @@ def main() -> None:
             assert goal["spawn_policy"]["allowed_domains"] == ["docs", "validation"], goal
             assert goal["coordination"]["registered_agents"] == ["codex-main-control", "codex-side-bypass"], goal
             assert goal["coordination"]["primary_agent"] == "codex-main-control", goal
+            assert goal["coordination"]["write_scope"] == ["docs/**", "tests/**"], goal
             status, refreshed = request_json("GET", f"{base_url}/status.json")
             assert status == 200, refreshed
             assert refreshed["local_dashboard_api"]["control_plane_write_enabled"] is True, refreshed

--- a/examples/project/bootstrap-force-preserve-todos-smoke.py
+++ b/examples/project/bootstrap-force-preserve-todos-smoke.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Smoke-test force bootstrap warnings and todo-preserving reconnects."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GOAL_ID = "bootstrap-preserve-fixture"
+
+
+def run_cli(*args: str, check: bool = True) -> dict:
+    result = subprocess.run(
+        [sys.executable, "-m", "loopx.cli", "--format", "json", *args],
+        cwd=REPO_ROOT,
+        check=check,
+        text=True,
+        capture_output=True,
+    )
+    return json.loads(result.stdout)
+
+
+def goal_from_registry(project: Path) -> dict:
+    registry = project / ".loopx" / "registry.json"
+    payload = json.loads(registry.read_text(encoding="utf-8"))
+    return payload["goals"][0]
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-bootstrap-preserve-") as tmp:
+        project = Path(tmp) / "project"
+        project.mkdir()
+        state_file = project / ".codex/goals/bootstrap-preserve-fixture/ACTIVE_GOAL_STATE.md"
+
+        initial = run_cli(
+            "bootstrap",
+            "--project",
+            str(project),
+            "--goal-id",
+            GOAL_ID,
+            "--objective",
+            "Exercise force reconnect preservation.",
+            "--no-onboarding-scan",
+            "--no-global-sync",
+        )
+        assert initial["ok"] is True, initial
+        assert initial["state_action"] == "created", initial
+
+        todo_state = "# Active Goal State\n\n## Agent Todo\n\n- [ ] Preserve this during reconnect.\n"
+        state_file.write_text(todo_state, encoding="utf-8")
+
+        preserved = run_cli(
+            "bootstrap",
+            "--project",
+            str(project),
+            "--goal-id",
+            GOAL_ID,
+            "--objective",
+            "Exercise force reconnect preservation.",
+            "--write-scope",
+            "src/**",
+            "--force",
+            "--preserve-todos",
+            "--no-onboarding-scan",
+            "--no-global-sync",
+        )
+        assert preserved["ok"] is True, preserved
+        assert preserved["state_action"] == "kept-existing-preserve-todos", preserved
+        warning = preserved["force_bootstrap_warning"]
+        assert warning["will_replace_active_state"] is False, warning
+        assert warning["preserve_todos_requested"] is True, warning
+        assert "configure-goal --write-scope" in warning["recommended_scope_migration"], warning
+        assert state_file.read_text(encoding="utf-8") == todo_state
+        assert goal_from_registry(project)["coordination"]["write_scope"] == ["src/**"]
+
+        replaced = run_cli(
+            "bootstrap",
+            "--project",
+            str(project),
+            "--goal-id",
+            GOAL_ID,
+            "--objective",
+            "Exercise force reconnect replacement warning.",
+            "--write-scope",
+            "docs/**",
+            "--force",
+            "--no-onboarding-scan",
+            "--no-global-sync",
+        )
+        assert replaced["ok"] is True, replaced
+        assert replaced["state_action"] == "replaced", replaced
+        warning = replaced["force_bootstrap_warning"]
+        assert warning["will_replace_active_state"] is True, warning
+        assert warning["preserve_todos_requested"] is False, warning
+        assert "Preserve this during reconnect." not in state_file.read_text(encoding="utf-8")
+        assert goal_from_registry(project)["coordination"]["write_scope"] == ["docs/**"]
+
+    print("bootstrap-force-preserve-todos-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/project/configure-goal-smoke.py
+++ b/examples/project/configure-goal-smoke.py
@@ -15,6 +15,12 @@ GOAL_ID = "configure-goal-fixture"
 
 
 def write_registry(root: Path) -> Path:
+    state_file = root / "project" / ".codex/goals/configure-goal-fixture/STATE.md"
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text(
+        "# Active Goal State\n\n## Agent Todo\n\n- [ ] Keep this todo during scope migration.\n",
+        encoding="utf-8",
+    )
     registry_path = root / "registry.json"
     registry_path.write_text(
         json.dumps(
@@ -110,6 +116,10 @@ def main() -> int:
             "codex-side-bypass,codex-main-control",
             "--primary-agent",
             "codex-main-control",
+            "--write-scope",
+            "docs/**",
+            "--write-scope",
+            "tests/**,docs/**",
             "--waiting-on",
             "user_or_controller",
             "--boundary-authority-scope",
@@ -126,7 +136,9 @@ def main() -> int:
         assert "checkpointed_boundary_authority" in dry["changed_fields"], dry
         assert "registered_agents" in dry["changed_fields"], dry
         assert "primary_agent" in dry["changed_fields"], dry
+        assert "write_scope" in dry["changed_fields"], dry
         assert dry["after"]["waiting_on"] == "user_or_controller", dry
+        assert dry["after"]["write_scope"] == ["docs/**", "tests/**"], dry
         assert dry["after"]["checkpointed_boundary_authority"]["active_write_scope"] == ["docs/**"], dry
         assert dry["after"]["registered_agents"] == ["codex-main-control", "codex-side-bypass"], dry
         assert dry["after"]["primary_agent"] == "codex-main-control", dry
@@ -154,6 +166,8 @@ def main() -> int:
             "codex-main-control,codex-side-bypass",
             "--primary-agent",
             "codex-main-control",
+            "--write-scope",
+            "docs/**,tests/**",
             "--waiting-on",
             "user_or_controller",
             "--boundary-authority-scope",
@@ -178,12 +192,37 @@ def main() -> int:
         assert goal["spawn_policy"]["allowed_domains"] == ["docs", "validation"], goal
         assert goal["coordination"]["registered_agents"] == ["codex-main-control", "codex-side-bypass"], goal
         assert goal["coordination"]["primary_agent"] == "codex-main-control", goal
+        assert goal["coordination"]["write_scope"] == ["docs/**", "tests/**"], goal
         assert goal["waiting_on"] == "user_or_controller", goal
         authority = goal["coordination"]["checkpointed_boundary_authority"][0]
         assert authority["schema_version"] == "checkpointed_boundary_authority_v0", authority
         assert authority["write_scope"] == ["docs/**"], authority
         assert authority["source"] == "operator_gate_resume_contract_v0:fixture", authority
         assert authority["decision_id"] == "gate-fixture-1", authority
+        state_file = root / "project" / ".codex/goals/configure-goal-fixture/STATE.md"
+        state_before_scope_migration = state_file.read_text(encoding="utf-8")
+
+        scope_migrated = payload(run_cli(
+            registry_path,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--write-scope",
+            "loopx/**,docs/**",
+            "--execute",
+        ))
+        assert scope_migrated["ok"] is True, scope_migrated
+        assert scope_migrated["changed"] is True, scope_migrated
+        assert scope_migrated["written"] is True, scope_migrated
+        assert "write_scope" in scope_migrated["changed_fields"], scope_migrated
+        assert scope_migrated["before"]["write_scope"] == ["docs/**", "tests/**"], scope_migrated
+        assert scope_migrated["after"]["write_scope"] == ["docs/**", "tests/**", "loopx/**"], scope_migrated
+        assert goal_from_registry(registry_path)["coordination"]["write_scope"] == [
+            "docs/**",
+            "tests/**",
+            "loopx/**",
+        ]
+        assert state_file.read_text(encoding="utf-8") == state_before_scope_migration
 
         no_change = payload(run_cli(
             registry_path,
@@ -237,6 +276,19 @@ def main() -> int:
         assert "registered_agents" not in goal_from_registry(registry_path)["coordination"], agents_cleared
         assert "primary_agent" not in goal_from_registry(registry_path)["coordination"], agents_cleared
 
+        scope_cleared = payload(run_cli(
+            registry_path,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--clear-write-scope",
+            "--execute",
+        ))
+        assert scope_cleared["ok"] is True, scope_cleared
+        assert scope_cleared["changed"] is True, scope_cleared
+        assert "write_scope" in scope_cleared["changed_fields"], scope_cleared
+        assert goal_from_registry(registry_path)["coordination"]["write_scope"] == [], scope_cleared
+
         invalid = payload(run_cli(
             registry_path,
             "configure-goal",
@@ -248,6 +300,17 @@ def main() -> int:
         ))
         assert invalid["ok"] is False, invalid
         assert "greater than 0" in invalid["error"], invalid
+
+        invalid_replace = payload(run_cli(
+            registry_path,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--replace-write-scope",
+            check=False,
+        ))
+        assert invalid_replace["ok"] is False, invalid_replace
+        assert "requires --write-scope" in invalid_replace["error"], invalid_replace
 
     print("configure-goal-smoke ok")
     return 0

--- a/loopx/bootstrap.py
+++ b/loopx/bootstrap.py
@@ -599,6 +599,7 @@ def bootstrap_project(
     onboarding_max_commits: int = 5,
     onboarding_max_status_paths: int = 12,
     onboarding_max_top_level_files: int = 24,
+    preserve_todos: bool = False,
     force: bool,
     dry_run: bool,
     sync_global: bool,
@@ -664,17 +665,35 @@ def bootstrap_project(
     )
     registry, registry_goal_action = merge_goal(registry, goal_entry, force=force)
 
+    state_exists = state_file.exists()
     state_action = "created"
-    if state_file.exists() and not force:
+    if state_exists and force and preserve_todos:
+        state_action = "kept-existing-preserve-todos"
+    elif state_exists and not force:
         state_action = "kept-existing"
-    elif state_file.exists() and force:
+    elif state_exists and force:
         state_action = "replaced"
 
     dry_state_actions = {
         "created": "would-create",
         "kept-existing": "would-keep-existing",
+        "kept-existing-preserve-todos": "would-keep-existing-preserve-todos",
         "replaced": "would-replace",
     }
+    force_bootstrap_warning = None
+    if state_exists and force:
+        force_bootstrap_warning = {
+            "kind": "force_reconnect_existing_active_state",
+            "state_file": str(state_file),
+            "state_action": state_action,
+            "will_replace_active_state": state_action == "replaced",
+            "preserve_todos_requested": bool(preserve_todos),
+            "recommended_scope_migration": (
+                "Use configure-goal --write-scope ... --execute to change write scope "
+                "without rebuilding the active state."
+            ),
+            "preserve_todos_option": "--preserve-todos",
+        }
     actions = [
         {"path": str(registry_path), "action": "would-write" if dry_run else "wrote", "goal": registry_goal_action},
         {"path": str(state_file), "action": dry_state_actions.get(state_action, "would-write") if dry_run else state_action},
@@ -741,6 +760,7 @@ def bootstrap_project(
                 "runtime_root": str(runtime_root),
                 "registry_goal_action": registry_goal_action,
                 "state_action": state_action,
+                "force_bootstrap_warning": force_bootstrap_warning,
                 "execution_profile": execution_profile,
                 "onboarding_scan": onboarding_scan,
                 "onboarding_agent_todo_candidates": candidates,
@@ -810,6 +830,7 @@ def bootstrap_project(
         "runtime_root": str(runtime_root),
         "registry_goal_action": registry_goal_action,
         "state_action": state_action,
+        "force_bootstrap_warning": force_bootstrap_warning,
         "execution_profile": execution_profile,
         "onboarding_scan": onboarding_scan,
         "onboarding_agent_todo_candidates": candidates,
@@ -887,6 +908,20 @@ def render_bootstrap_markdown(payload: dict[str, Any]) -> str:
     ]
     for action in payload.get("actions") or []:
         lines.append(f"- `{action.get('path')}`: {action.get('action')} ({action.get('goal', '')})")
+
+    force_warning = payload.get("force_bootstrap_warning")
+    if isinstance(force_warning, dict):
+        lines.extend(
+            [
+                "",
+                "## Force Bootstrap Warning",
+                f"- state_file: `{force_warning.get('state_file')}`",
+                f"- will_replace_active_state: `{force_warning.get('will_replace_active_state')}`",
+                f"- preserve_todos_requested: `{force_warning.get('preserve_todos_requested')}`",
+                f"- recommended_scope_migration: {force_warning.get('recommended_scope_migration')}",
+                f"- preserve_todos_option: `{force_warning.get('preserve_todos_option')}`",
+            ]
+        )
 
     onboarding_scan = payload.get("onboarding_scan")
     if isinstance(onboarding_scan, dict):

--- a/loopx/cli_commands/bootstrap_connect.py
+++ b/loopx/cli_commands/bootstrap_connect.py
@@ -144,6 +144,11 @@ def register_bootstrap_connect_command(subparsers: argparse._SubParsersAction) -
     )
     bootstrap_parser.add_argument("--force", action="store_true", help="Replace existing goal entry or state file.")
     bootstrap_parser.add_argument(
+        "--preserve-todos",
+        action="store_true",
+        help="With --force, preserve the existing active state file instead of replacing its todos.",
+    )
+    bootstrap_parser.add_argument(
         "--replace-state",
         action="store_true",
         help=(
@@ -207,6 +212,7 @@ def handle_bootstrap_connect_command(
             onboarding_max_commits=args.onboarding_max_commits,
             onboarding_max_status_paths=args.onboarding_max_status_paths,
             onboarding_max_top_level_files=args.onboarding_max_top_level_files,
+            preserve_todos=bool(args.preserve_todos),
             force=args.force,
             dry_run=args.dry_run,
             sync_global=not bool(args.no_global_sync),

--- a/loopx/cli_commands/registry_admin.py
+++ b/loopx/cli_commands/registry_admin.py
@@ -339,6 +339,25 @@ def register_registry_admin_commands(subparsers: argparse._SubParsersAction) -> 
         help="Clear coordination.primary_agent.",
     )
     configure_goal_parser.add_argument(
+        "--write-scope",
+        action="append",
+        default=None,
+        help=(
+            "Allowed repository/local-state write scope to add to coordination.write_scope. "
+            "Repeatable; comma-separated values are also accepted."
+        ),
+    )
+    configure_goal_parser.add_argument(
+        "--replace-write-scope",
+        action="store_true",
+        help="Replace coordination.write_scope with the supplied --write-scope values instead of merging.",
+    )
+    configure_goal_parser.add_argument(
+        "--clear-write-scope",
+        action="store_true",
+        help="Clear coordination.write_scope.",
+    )
+    configure_goal_parser.add_argument(
         "--waiting-on",
         choices=["codex", "user_or_controller", "controller", "external_evidence"],
         help="Override registry waiting owner for status/quota routing.",
@@ -648,6 +667,9 @@ def handle_registry_admin_command(
                 clear_registered_agents=bool(args.clear_registered_agents),
                 primary_agent=args.primary_agent,
                 clear_primary_agent=bool(args.clear_primary_agent),
+                write_scope=args.write_scope,
+                replace_write_scope=bool(args.replace_write_scope),
+                clear_write_scope=bool(args.clear_write_scope),
                 waiting_on=args.waiting_on,
                 clear_waiting_on=bool(args.clear_waiting_on),
                 boundary_authority_scopes=args.boundary_authority_scope,

--- a/loopx/configure_goal.py
+++ b/loopx/configure_goal.py
@@ -75,6 +75,18 @@ def _clean_registered_agents(values: list[str] | None) -> list[str] | None:
     return agents
 
 
+def _clean_write_scope(values: list[str] | None) -> list[str] | None:
+    if values is None:
+        return None
+    scopes: list[str] = []
+    for value in values:
+        for part in str(value).split(","):
+            scope = part.strip()
+            if scope and scope not in scopes:
+                scopes.append(scope)
+    return scopes
+
+
 def _settings_summary(goal: dict[str, Any]) -> dict[str, Any]:
     quota = goal_quota_config(goal)
     control_plane = compact_control_plane_policy(goal.get("control_plane"))
@@ -88,6 +100,7 @@ def _settings_summary(goal: dict[str, Any]) -> dict[str, Any]:
         "control_plane": control_plane,
         "orchestration": orchestration,
         "waiting_on": goal.get("waiting_on"),
+        "write_scope": _clean_write_scope(coordination.get("write_scope") or []) or [],
         "checkpointed_boundary_authority": checkpointed_boundary_authority_summary(coordination),
         "registered_agents": normalize_registered_agents(coordination.get("registered_agents")),
         "primary_agent": primary_agent_id_for_goal(goal),
@@ -121,6 +134,9 @@ def configure_goal(
     clear_registered_agents: bool = False,
     primary_agent: str | None = None,
     clear_primary_agent: bool = False,
+    write_scope: list[str] | None = None,
+    replace_write_scope: bool = False,
+    clear_write_scope: bool = False,
     waiting_on: str | None = None,
     clear_waiting_on: bool = False,
     boundary_authority_scopes: list[str] | None = None,
@@ -141,6 +157,12 @@ def configure_goal(
         raise ValueError("--clear-primary-agent cannot be combined with --primary-agent")
     if clear_registered_agents and primary_agent:
         raise ValueError("--clear-registered-agents cannot be combined with --primary-agent")
+    if clear_write_scope and write_scope:
+        raise ValueError("--clear-write-scope cannot be combined with --write-scope")
+    if replace_write_scope and not write_scope:
+        raise ValueError("--replace-write-scope requires --write-scope")
+    if clear_write_scope and replace_write_scope:
+        raise ValueError("--clear-write-scope cannot be combined with --replace-write-scope")
     if clear_waiting_on and waiting_on:
         raise ValueError("--clear-waiting-on cannot be combined with --waiting-on")
     adding_boundary_authority = any(
@@ -163,6 +185,7 @@ def configure_goal(
     max_children = _non_negative_int(max_children, field="max_children")
     allowed_domains = _clean_domains(allowed_domains)
     registered_agents = _clean_registered_agents(registered_agents)
+    write_scope = _clean_write_scope(write_scope)
     normalized_primary_agent = normalize_todo_claimed_by(primary_agent) if primary_agent else None
     if primary_agent and not normalized_primary_agent:
         raise ValueError("--primary-agent must be a public-safe registered agent id")
@@ -230,6 +253,8 @@ def configure_goal(
         or registered_agents is not None
         or normalized_primary_agent is not None
         or clear_primary_agent
+        or write_scope is not None
+        or clear_write_scope
         or clear_boundary_authority
         or adding_boundary_authority
     ):
@@ -250,6 +275,14 @@ def configure_goal(
             coordination.pop("primary_agent", None)
         elif normalized_primary_agent is not None:
             coordination["primary_agent"] = normalized_primary_agent
+        if clear_write_scope:
+            coordination["write_scope"] = []
+        elif write_scope is not None:
+            if replace_write_scope:
+                coordination["write_scope"] = write_scope
+            else:
+                existing_write_scope = _clean_write_scope(coordination.get("write_scope") or []) or []
+                coordination["write_scope"] = _clean_write_scope([*existing_write_scope, *write_scope]) or []
         if clear_boundary_authority:
             coordination.pop("checkpointed_boundary_authority", None)
         if adding_boundary_authority:

--- a/loopx/status_server.py
+++ b/loopx/status_server.py
@@ -57,6 +57,9 @@ CONFIGURE_GOAL_REQUEST_FIELDS = {
     "clear_registered_agents",
     "primary_agent",
     "clear_primary_agent",
+    "write_scope",
+    "replace_write_scope",
+    "clear_write_scope",
     "boundary_authority_scopes",
     "boundary_authority_source",
     "boundary_authority_decision_id",
@@ -324,6 +327,9 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
         boundary_authority_scopes = body.get("boundary_authority_scopes")
         if boundary_authority_scopes is not None and not isinstance(boundary_authority_scopes, list):
             raise ValueError("boundary_authority_scopes must be a list of strings")
+        write_scope = body.get("write_scope")
+        if write_scope is not None and not isinstance(write_scope, list):
+            raise ValueError("write_scope must be a list of strings")
         return {
             "goal_id": goal_id,
             "quota_compute": body.get("quota_compute"),
@@ -340,6 +346,9 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
             "clear_registered_agents": bool(body.get("clear_registered_agents", False)),
             "primary_agent": body.get("primary_agent"),
             "clear_primary_agent": bool(body.get("clear_primary_agent", False)),
+            "write_scope": [str(item) for item in write_scope] if write_scope is not None else None,
+            "replace_write_scope": bool(body.get("replace_write_scope", False)),
+            "clear_write_scope": bool(body.get("clear_write_scope", False)),
             "boundary_authority_scopes": (
                 [str(item) for item in boundary_authority_scopes]
                 if boundary_authority_scopes is not None
@@ -371,6 +380,9 @@ class StatusRequestHandler(BaseHTTPRequestHandler):
             clear_registered_agents=values["clear_registered_agents"],
             primary_agent=values["primary_agent"],
             clear_primary_agent=values["clear_primary_agent"],
+            write_scope=values["write_scope"],
+            replace_write_scope=values["replace_write_scope"],
+            clear_write_scope=values["clear_write_scope"],
             boundary_authority_scopes=values["boundary_authority_scopes"],
             boundary_authority_source=values["boundary_authority_source"],
             boundary_authority_decision_id=values["boundary_authority_decision_id"],

--- a/skills/loopx-project/SKILL.md
+++ b/skills/loopx-project/SKILL.md
@@ -61,6 +61,21 @@ silently downgrade `/loopx <goal text>` into a bare `/loopx` read-only command.
 Use `loopx bootstrap-command-pack --project . --goal-text "<GOAL_TEXT>"` only
 when implementing or debugging the lower-level host handoff packet.
 
+If the connected goal later needs a wider or corrected write boundary, do not
+rerun `loopx bootstrap --force` just to change scope. Use the incremental
+configuration path instead:
+
+```bash
+loopx configure-goal \
+  --goal-id <STABLE_GOAL_ID> \
+  --write-scope "<SAFE_WRITE_SCOPE>" \
+  --execute
+```
+
+If a destructive reconnect is explicitly required, pass `--preserve-todos` with
+`--force` unless the user intends to rebuild the active state file and discard
+existing todo projection.
+
 `/loopx <goal text>` is an explicit goal-start intent: first produce a concise
 ordered plan, then write todos in priority order, using planner order plus
 `todo add` write order as the same-priority tie-breaker. For broad or fuzzy


### PR DESCRIPTION
## Summary
- add incremental configure-goal write_scope merge/replace/clear support through CLI and local control-plane API
- add bootstrap --preserve-todos for force reconnects and expose an explicit force warning
- update integration/new-project/loopx-project skill docs and add focused smokes for no-todo-loss scope migration

## Validation
- python3 -m py_compile loopx/configure_goal.py loopx/cli_commands/registry_admin.py loopx/status_server.py loopx/bootstrap.py loopx/cli_commands/bootstrap_connect.py examples/project/bootstrap-force-preserve-todos-smoke.py examples/project/configure-goal-smoke.py examples/control_plane/control-plane-configure-api-smoke.py
- python3 examples/project/configure-goal-smoke.py
- python3 examples/project/bootstrap-force-preserve-todos-smoke.py
- python3 examples/control_plane/control-plane-configure-api-smoke.py
- python3 examples/control_plane/quota-action-scope-guard-smoke.py
- loopx check --scan-root /private/tmp/loopx-side-bypass-write-scope-boundary-20260708T1614CST
- loopx canary premerge --from-git-diff (passed, self_merge_allowed=true)
