### PR TITLE
Improve refresh-state onboarding diagnostics

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -445,6 +445,10 @@ When `--recommended-action` is omitted, the command derives the compact action
 from the first public-safe item in the active state's `## Next Action`, joining
 wrapped continuation lines and falling back to a generic refresh action if that
 item contains private-looking content.
+If a `refresh-state` text field is rejected as private-looking, the CLI names
+the field and suggests using a compact public-safe alias/summary there while
+keeping raw local paths, private URLs, task bodies, and logs in evidence or
+private payloads.
 When the state refresh is also the compact record for a validated progress
 artifact, add explicit delivery hints so handoff readiness does not have to
 infer scale from a classification name:
@@ -458,8 +462,10 @@ loopx refresh-state \
 ```
 
 Use `--delivery-batch-scale` for `test_only`, `single_surface`,
-`multi_surface`, or `implementation`. `--delivery-outcome` is a structured enum,
-not a classification string:
+`multi_surface`, or `implementation`. For agent-facing `refresh-state` calls,
+`single_segment` and `bounded_segment` are accepted as input aliases for
+`single_surface`; the recorded run still stores the canonical `single_surface`
+value. `--delivery-outcome` is a structured enum, not a classification string:
 
 | Value | Meaning |
 | --- | --- |

--- a/docs/reference/protocols/goal-vision-replan-contract-v0.md
+++ b/docs/reference/protocols/goal-vision-replan-contract-v0.md
@@ -45,8 +45,9 @@ agent pane. Long reasoning belongs in evidence artifacts or design docs.
 
 Required write-path behavior:
 
-1. Reject over-budget writes with `vision_budget_exceeded`, or require an
-   explicit compacting command before writeback.
+1. Reject over-budget writes with `vision_budget_exceeded`, including the
+   current character count, field limit, and a compact suggested replacement
+   when the offending field is known.
 2. Do not silently truncate fields; truncation hides control-plane intent.
 3. Store verbose rationale as evidence and reference it by id.
 4. Keep the latest bounded packet visible in status/quota so agents can reason

--- a/examples/delivery-batch-scale-enum-smoke.py
+++ b/examples/delivery-batch-scale-enum-smoke.py
@@ -15,10 +15,13 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.control_plane.work_items.delivery_batch_scale import (  # noqa: E402
+    DELIVERY_BATCH_SCALE_ALIASES,
     DELIVERY_BATCH_SCALE_CHOICES,
+    DELIVERY_BATCH_SCALE_INPUT_CHOICES,
     SMALL_DELIVERY_BATCH_SCALES,
     UNKNOWN_DELIVERY_BATCH_SCALE,
     DeliveryBatchScale,
+    delivery_batch_scale_value,
     normalize_delivery_batch_scale,
     require_delivery_batch_scale,
 )
@@ -80,7 +83,19 @@ def assert_enum_sets() -> None:
         "multi_surface",
         "implementation",
     )
+    assert DELIVERY_BATCH_SCALE_ALIASES == {
+        "single_segment": DeliveryBatchScale.SINGLE_SURFACE,
+        "bounded_segment": DeliveryBatchScale.SINGLE_SURFACE,
+    }
+    assert set(DELIVERY_BATCH_SCALE_INPUT_CHOICES) == {
+        *DELIVERY_BATCH_SCALE_CHOICES,
+        "single_segment",
+        "bounded_segment",
+    }
     assert require_delivery_batch_scale("multi_surface") == DeliveryBatchScale.MULTI_SURFACE
+    assert require_delivery_batch_scale("single_segment") == DeliveryBatchScale.SINGLE_SURFACE
+    assert normalize_delivery_batch_scale("bounded_segment") == DeliveryBatchScale.SINGLE_SURFACE
+    assert delivery_batch_scale_value("single_segment") == DeliveryBatchScale.SINGLE_SURFACE.value
     assert normalize_delivery_batch_scale("unknown") is None
     assert SMALL_DELIVERY_BATCH_SCALES == {
         DeliveryBatchScale.TEST_ONLY,
@@ -108,6 +123,20 @@ def assert_refresh_state_enforces_enum(registry_path: Path) -> None:
         sync_global=False,
     )
     assert payload["delivery_batch_scale"] == DeliveryBatchScale.IMPLEMENTATION.value, payload
+
+    alias_payload = refresh_state_run(
+        registry_path=registry_path,
+        runtime_root_override=None,
+        goal_id=GOAL_ID,
+        project=None,
+        state_file=None,
+        classification="enum_fixture_alias",
+        recommended_action="Advance one bounded implementation batch.",
+        delivery_batch_scale="bounded_segment",
+        dry_run=True,
+        sync_global=False,
+    )
+    assert alias_payload["delivery_batch_scale"] == DeliveryBatchScale.SINGLE_SURFACE.value, alias_payload
 
     try:
         refresh_state_run(
@@ -150,6 +179,31 @@ def assert_refresh_state_enforces_enum(registry_path: Path) -> None:
     )
     assert cli_result.returncode != 0, cli_result.stdout
     assert "invalid choice" in cli_result.stderr, cli_result.stderr
+
+    alias_cli_result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry_path),
+            "--format",
+            "json",
+            "refresh-state",
+            "--goal-id",
+            GOAL_ID,
+            "--delivery-batch-scale",
+            "single_segment",
+            "--dry-run",
+            "--no-global-sync",
+        ],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    alias_payload = json.loads(alias_cli_result.stdout)
+    assert alias_payload["delivery_batch_scale"] == DeliveryBatchScale.SINGLE_SURFACE.value, alias_payload
 
 
 def assert_history_enforces_enum(registry_path: Path) -> None:

--- a/examples/project/goal-vision-refresh-state-budget-smoke.py
+++ b/examples/project/goal-vision-refresh-state-budget-smoke.py
@@ -72,6 +72,7 @@ def run_cli(
     vision_path: Path | None = None,
     inline_vision_args: list[str] | None = None,
     check: bool,
+    extra_args: list[str] | None = None,
     dry_run: bool = True,
     include_agent_id: bool = True,
 ) -> subprocess.CompletedProcess[str]:
@@ -103,6 +104,8 @@ def run_cli(
         command.extend(["--agent-vision-json", str(vision_path)])
     if inline_vision_args:
         command.extend(inline_vision_args)
+    if extra_args:
+        command.extend(extra_args)
     if dry_run:
         command.append("--dry-run")
     return subprocess.run(
@@ -307,6 +310,40 @@ def main() -> int:
         mixed = payload(mixed_result)
         assert "--agent-vision-json cannot be combined" in mixed["error"], mixed
 
+        long_todo_delta = (
+            "create a successor todo that references the public research frontier, "
+            "acceptance gap, validation check, owner handoff, and next compact action"
+        )
+        long_todo_result = run_cli(
+            registry_path,
+            runtime,
+            inline_vision_args=[
+                "--vision-summary",
+                "Keep the next research frontier bounded and public-safe.",
+                "--vision-todo-delta",
+                long_todo_delta,
+            ],
+            check=False,
+        )
+        assert long_todo_result.returncode == 1, long_todo_result
+        long_todo = payload(long_todo_result)
+        assert "vision_budget_exceeded" in long_todo["error"], long_todo
+        assert "todo_delta uses" in long_todo["error"], long_todo
+        assert "limit is 80" in long_todo["error"], long_todo
+        assert "suggested compact value" in long_todo["error"], long_todo
+
+        private_next_action_result = run_cli(
+            registry_path,
+            runtime,
+            extra_args=["--next-action", "/Users/example/private/raw-task-note"],
+            check=False,
+        )
+        assert private_next_action_result.returncode == 1, private_next_action_result
+        private_next_action = payload(private_next_action_result)
+        assert "active_state_next_action" in private_next_action["error"], private_next_action
+        assert "public-safe action alias" in private_next_action["error"], private_next_action
+        assert "evidence/private payloads" in private_next_action["error"], private_next_action
+
         write_json(
             invalid_path,
             {
@@ -326,6 +363,7 @@ def main() -> int:
         assert invalid["ok"] is False, invalid
         assert "vision_budget_exceeded" in invalid["error"], invalid
         assert "vision_summary" in invalid["error"], invalid
+        assert "suggested compact value" in invalid["error"], invalid
 
     print("goal-vision-refresh-state-budget-smoke ok")
     return 0

--- a/loopx/cli_commands/project_lifecycle.py
+++ b/loopx/cli_commands/project_lifecycle.py
@@ -5,7 +5,9 @@ import json
 from collections.abc import Callable
 from pathlib import Path
 
-from ..control_plane.work_items.delivery_batch_scale import DELIVERY_BATCH_SCALE_CHOICES
+from ..control_plane.work_items.delivery_batch_scale import (
+    DELIVERY_BATCH_SCALE_INPUT_CHOICES,
+)
 from ..control_plane.work_items.delivery_outcome import DELIVERY_OUTCOME_CHOICES
 from ..feedback import LESSON_KINDS, append_human_reward, compact_reward, render_reward_markdown
 from ..operator_gate import (
@@ -118,8 +120,12 @@ def register_project_lifecycle_commands(
     )
     refresh_state_parser.add_argument(
         "--delivery-batch-scale",
-        choices=DELIVERY_BATCH_SCALE_CHOICES,
-        help="Optional explicit delivery scale for this refresh run, overriding classification-name inference.",
+        choices=DELIVERY_BATCH_SCALE_INPUT_CHOICES,
+        help=(
+            "Optional explicit delivery scale for this refresh run, overriding "
+            "classification-name inference. Accepts canonical scales plus "
+            "single_segment/bounded_segment aliases for single_surface."
+        ),
     )
     refresh_state_parser.add_argument(
         "--delivery-outcome",

--- a/loopx/control_plane/goals/goal_vision.py
+++ b/loopx/control_plane/goals/goal_vision.py
@@ -27,20 +27,44 @@ GOAL_VISION_BUDGET_COMPACT_FIELDS = (
 
 
 class GoalVisionBudgetError(ValueError):
-    def __init__(self, *, field: str, used: int, limit: int) -> None:
+    def __init__(
+        self,
+        *,
+        field: str,
+        used: int,
+        limit: int,
+        suggestion: str | None = None,
+    ) -> None:
         self.field = field
         self.used = used
         self.limit = limit
-        super().__init__(
-            f"{GOAL_VISION_BUDGET_ERROR}: {field} uses {used} chars; limit is {limit}"
-        )
+        self.suggestion = suggestion
+        message = f"{GOAL_VISION_BUDGET_ERROR}: {field} uses {used} chars; limit is {limit}"
+        if suggestion:
+            message += f"; suggested compact value: {suggestion!r}"
+        else:
+            message += "; shorten one or more vision fields before retrying"
+        super().__init__(message)
+
+
+def _suggest_compact_text(text: str, *, limit: int) -> str:
+    if len(text) <= limit:
+        return text
+    if limit <= 3:
+        return text[:limit]
+    return text[: limit - 3].rstrip() + "..."
 
 
 def _bounded_public_text(*, field: str, value: Any, limit: int) -> str:
     text = " ".join(str(value or "").strip().split())
     validate_public_safe_text(f"agent_vision.{field}", text)
     if len(text) > limit:
-        raise GoalVisionBudgetError(field=field, used=len(text), limit=limit)
+        raise GoalVisionBudgetError(
+            field=field,
+            used=len(text),
+            limit=limit,
+            suggestion=_suggest_compact_text(text, limit=limit),
+        )
     return text
 
 

--- a/loopx/control_plane/work_items/delivery_batch_scale.py
+++ b/loopx/control_plane/work_items/delivery_batch_scale.py
@@ -14,6 +14,14 @@ class DeliveryBatchScale(str, Enum):
 
 
 DELIVERY_BATCH_SCALE_CHOICES = tuple(scale.value for scale in DeliveryBatchScale)
+DELIVERY_BATCH_SCALE_ALIASES: dict[str, DeliveryBatchScale] = {
+    "single_segment": DeliveryBatchScale.SINGLE_SURFACE,
+    "bounded_segment": DeliveryBatchScale.SINGLE_SURFACE,
+}
+DELIVERY_BATCH_SCALE_INPUT_CHOICES = (
+    *DELIVERY_BATCH_SCALE_CHOICES,
+    *DELIVERY_BATCH_SCALE_ALIASES.keys(),
+)
 SMALL_DELIVERY_BATCH_SCALES = frozenset(
     {
         DeliveryBatchScale.TEST_ONLY,
@@ -29,6 +37,9 @@ def normalize_delivery_batch_scale(value: Any) -> DeliveryBatchScale | None:
     text = str(value or "").strip()
     if not text:
         return None
+    alias = DELIVERY_BATCH_SCALE_ALIASES.get(text)
+    if alias:
+        return alias
     try:
         return DeliveryBatchScale(text)
     except ValueError:
@@ -38,7 +49,15 @@ def normalize_delivery_batch_scale(value: Any) -> DeliveryBatchScale | None:
 def require_delivery_batch_scale(value: Any) -> DeliveryBatchScale:
     scale = normalize_delivery_batch_scale(value)
     if scale is None:
-        raise ValueError("delivery_batch_scale must be one of: " + ", ".join(DELIVERY_BATCH_SCALE_CHOICES))
+        aliases = ", ".join(
+            f"{alias}={target.value}"
+            for alias, target in DELIVERY_BATCH_SCALE_ALIASES.items()
+        )
+        raise ValueError(
+            "delivery_batch_scale must be one of: "
+            + ", ".join(DELIVERY_BATCH_SCALE_CHOICES)
+            + f" (aliases: {aliases})"
+        )
     return scale
 
 

--- a/loopx/feedback.py
+++ b/loopx/feedback.py
@@ -59,6 +59,29 @@ RUN_OVERLAY_FIELDS = (
 )
 
 
+def public_safe_text_guidance(label: str) -> str:
+    normalized = label.lower().replace("-", "_")
+    if "next_action" in normalized or "recommended_action" in normalized:
+        return (
+            "use a public-safe action alias or short summary here; keep raw local "
+            "paths, private URLs, task bodies, and logs in evidence/private payloads"
+        )
+    if "todo" in normalized:
+        return (
+            "use a compact public-safe todo alias or summary here; keep raw local "
+            "paths, private URLs, task bodies, and logs in evidence/private payloads"
+        )
+    if "evidence" in normalized:
+        return (
+            "use a compact public-safe evidence pointer here; keep raw logs, local "
+            "paths, and private URLs in private payloads"
+        )
+    return (
+        "use a public-safe summary or alias here; keep raw local paths, private "
+        "URLs, and raw evidence in private payloads"
+    )
+
+
 def now_utc() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
 
@@ -72,7 +95,10 @@ def validate_public_safe_text(label: str, value: str | None) -> None:
         return
     for pattern in PRIVATE_TEXT_PATTERNS:
         if pattern.search(value):
-            raise ValueError(f"{label} contains a private-looking value; keep raw evidence in private payloads")
+            raise ValueError(
+                f"{label} contains a private-looking value; "
+                + public_safe_text_guidance(label)
+            )
 
 
 def validate_local_control_text(label: str, value: str | None) -> None:


### PR DESCRIPTION
## Summary
- Accept `single_segment` and `bounded_segment` as refresh-state input aliases for canonical `single_surface`.
- Add actionable goal-vision budget errors with field usage, limit, and a compact suggested replacement.
- Add field-specific public-safe validation guidance for next-action/todo/evidence text and update integration/protocol docs.

## Validation
- `python3 -m py_compile loopx/control_plane/work_items/delivery_batch_scale.py loopx/cli_commands/project_lifecycle.py loopx/control_plane/goals/goal_vision.py loopx/feedback.py examples/delivery-batch-scale-enum-smoke.py examples/project/goal-vision-refresh-state-budget-smoke.py`
- `python3 examples/delivery-batch-scale-enum-smoke.py`
- `python3 examples/project/goal-vision-refresh-state-budget-smoke.py`
- `python3 examples/control_plane/refresh-state-agent-lane-scope-smoke.py`
- `python3 examples/control_plane/check-public-boundary-smoke.py`
- `python3 examples/control_plane/public-safety-readmodel-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `git diff --check`
- `loopx check --scan-path ...` on all changed files: clean
- `loopx canary premerge --from-git-diff --format json --timeout-seconds 120 --no-progress`: passed, self_merge_allowed=true

## Self-merge basis
Small, single-purpose control-plane UX repair with focused smokes, public docs, clean boundary scan, and premerge canary coverage. No benchmark scoring, permission boundary, production action, or private evidence-policy change.
