### PR TITLE
Relax local action safety checks

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -328,10 +328,16 @@ A project adapter should be thin and project-specific. It may read:
 It should output:
 
 - `classification`,
-- exactly one `recommended_action`,
+- exactly one `recommended_action` for the local control loop,
 - relevant warnings,
 - hard guards,
 - optional run log paths.
+
+`recommended_action` is local project state, not a public artifact by default:
+it may include private project refs such as todo ids, branch names, local
+aliases, or operator-private routing labels. It must not include AK/SK values,
+tokens, auth headers, passwords, or inline credentials. Public/export sinks
+must redact or omit private routing refs before rendering shareable surfaces.
 
 By default it should be read-only. Launching jobs, stopping jobs, syncing docs,
 or editing production state requires explicit user approval.

--- a/docs/reference/protocols/agent-management-projection-v0.md
+++ b/docs/reference/protocols/agent-management-projection-v0.md
@@ -90,7 +90,9 @@ Required fields:
 - `state`: one of `running`, `waiting`, `blocked`, `monitoring`,
   `scope_wait`, `stale`, or `unknown`;
 - `current_todo`: a `todo_row_v0` object or `null`;
-- `next_action`: compact public-safe next action text;
+- `next_action`: compact local-control next action text. Private project refs
+  are allowed; inline credentials are not. Shareable sinks must redact private
+  refs before export;
 - `last_activity_at`: best known status, quota, todo, or run timestamp;
 - `evidence_refs`: compact evidence ids, doc paths, run ids, or review packet
   refs.

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1099,7 +1099,9 @@ operator lane because the registry says `waiting_on=user_or_controller`, while
 the active state exposes a more concrete user checklist. This is the preferred
 shape for complex project review: keep `recommended_action` short enough to
 route the queue, and put ordered user work in checkbox sections the dashboard
-can summarize.
+can summarize. This routing text belongs to the user's local control plane: it
+may include private project refs, but it must not include AK/SK values, tokens,
+auth headers, passwords, or inline credentials.
 
 For registered planned high-complexity goals with a compatible
 `*_read_only_map_v0` adapter and no run yet, status keeps the queue item in

--- a/examples/project/goal-vision-refresh-state-budget-smoke.py
+++ b/examples/project/goal-vision-refresh-state-budget-smoke.py
@@ -332,17 +332,44 @@ def main() -> int:
         assert "limit is 80" in long_todo["error"], long_todo
         assert "suggested compact value" in long_todo["error"], long_todo
 
-        private_next_action_result = run_cli(
+        local_next_action = "/Users/example/private/raw-task-note"
+        private_next_action_result = payload(
+            run_cli(
+                registry_path,
+                runtime,
+                extra_args=[
+                    "--next-action",
+                    local_next_action,
+                    "--progress-scope",
+                    "goal",
+                ],
+                check=True,
+            )
+        )
+        assert private_next_action_result["ok"] is True, private_next_action_result
+        assert private_next_action_result["active_state_next_action_update"][
+            "next_action"
+        ] == local_next_action, private_next_action_result
+        assert private_next_action_result["active_state_next_action_update"][
+            "would_update"
+        ] is True, private_next_action_result
+
+        secret_next_action_result = run_cli(
             registry_path,
             runtime,
-            extra_args=["--next-action", "/Users/example/private/raw-task-note"],
+            extra_args=[
+                "--next-action",
+                "Continue with access_" + "key=" + "AKIA" + "1234567890ABCDEF",
+                "--progress-scope",
+                "goal",
+            ],
             check=False,
         )
-        assert private_next_action_result.returncode == 1, private_next_action_result
-        private_next_action = payload(private_next_action_result)
-        assert "active_state_next_action" in private_next_action["error"], private_next_action
-        assert "public-safe action alias" in private_next_action["error"], private_next_action
-        assert "evidence/private payloads" in private_next_action["error"], private_next_action
+        assert secret_next_action_result.returncode == 1, secret_next_action_result
+        secret_next_action = payload(secret_next_action_result)
+        assert "active_state_next_action" in secret_next_action["error"], secret_next_action
+        assert "secret-looking value" in secret_next_action["error"], secret_next_action
+        assert "AK/SK" in secret_next_action["error"], secret_next_action
 
         write_json(
             invalid_path,

--- a/examples/project/project-map-smoke.py
+++ b/examples/project/project-map-smoke.py
@@ -137,6 +137,44 @@ def main() -> int:
         assert before["opt_in_required"] is True, before
         assert "planned_adapter_requires_controller_opt_in" in before["residual_risks"], before
 
+        local_action = "/Users/example/private/project-next-action"
+        local_gate = json.loads(
+            run_cli(
+                root,
+                registry_path,
+                "operator-gate",
+                "--goal-id",
+                GOAL_ID,
+                "--decision",
+                "defer",
+                "--reason-summary",
+                "暂缓，只测试 local-control routing text.",
+                "--recommended-action",
+                local_action,
+                "--dry-run",
+            ).stdout
+        )
+        assert local_gate["recommended_action"] == local_action, local_gate
+
+        secret_action = "Continue with access_" + "key=" + "AKIA" + "1234567890ABCDEF"
+        secret_gate = run_cli(
+            root,
+            registry_path,
+            "operator-gate",
+            "--goal-id",
+            GOAL_ID,
+            "--decision",
+            "defer",
+            "--reason-summary",
+            "暂缓，只测试敏感值拦截.",
+            "--recommended-action",
+            secret_action,
+            "--dry-run",
+            check=False,
+        )
+        assert secret_gate.returncode != 0, secret_gate.stdout
+        assert "recommended_action contains a secret-looking value" in secret_gate.stdout, secret_gate.stdout
+
         run_cli(
             root,
             registry_path,
@@ -167,6 +205,33 @@ def main() -> int:
         assert project_map["project_material_owner_review_required_count"] == 1, project_map
         assert project_map["project_material_stale_count"] == 1, project_map
         assert project_map["project_material_current_authority_count"] == 1, project_map
+
+        local_map = json.loads(
+            run_cli(
+                root,
+                registry_path,
+                "read-only-map",
+                "--goal-id",
+                GOAL_ID,
+                "--recommended-action",
+                local_action,
+                "--dry-run",
+            ).stdout
+        )
+        assert local_map["recommended_action"] == local_action, local_map
+        secret_map = run_cli(
+            root,
+            registry_path,
+            "read-only-map",
+            "--goal-id",
+            GOAL_ID,
+            "--recommended-action",
+            secret_action,
+            "--dry-run",
+            check=False,
+        )
+        assert secret_map.returncode != 0, secret_map.stdout
+        assert "recommended_action contains a secret-looking value" in secret_map.stdout, secret_map.stdout
 
         real_map = run_cli(root, registry_path, "read-only-map", "--goal-id", GOAL_ID, check=False)
         assert real_map.returncode != 0, real_map.stdout

--- a/loopx/cli_commands/project_lifecycle.py
+++ b/loopx/cli_commands/project_lifecycle.py
@@ -108,7 +108,10 @@ def register_project_lifecycle_commands(
     )
     refresh_state_parser.add_argument(
         "--recommended-action",
-        help=f"Public-safe next action. Defaults to: {DEFAULT_REFRESH_ACTION}",
+        help=(
+            "Local-control next action. Private project refs are allowed; "
+            f"inline secrets are rejected. Defaults to: {DEFAULT_REFRESH_ACTION}"
+        ),
     )
     refresh_state_parser.add_argument(
         "--next-action",
@@ -249,7 +252,11 @@ def register_project_lifecycle_commands(
     )
     read_only_map_parser.add_argument(
         "--recommended-action",
-        help="Public-safe next action. Defaults to the first public-safe item from the active state's Next Action.",
+        help=(
+            "Local-control next action. Private project refs are allowed; "
+            "inline secrets are rejected. Defaults to the first item from the "
+            "active state's Next Action."
+        ),
     )
     read_only_map_parser.add_argument(
         "--dry-run",
@@ -346,7 +353,10 @@ def register_project_lifecycle_commands(
         "--agent-command",
         help="Target-agent command that becomes valid after approval. Defaults for read_only_map_opt_in approvals.",
     )
-    gate_parser.add_argument("--recommended-action", help="Public-safe next action for status/dashboard.")
+    gate_parser.add_argument(
+        "--recommended-action",
+        help="Local-control next action for status/dashboard; inline secrets are rejected.",
+    )
     gate_parser.add_argument("--dry-run", action="store_true", help="Print the decision run without appending it.")
     gate_parser.add_argument(
         "--no-global-sync",

--- a/loopx/dreaming.py
+++ b/loopx/dreaming.py
@@ -5,7 +5,7 @@ from collections import Counter
 from pathlib import Path
 from typing import Any
 
-from .feedback import validate_public_safe_text
+from .feedback import validate_local_control_text, validate_public_safe_text
 from .global_registry import sync_project_registry_to_global
 from .history import collect_history, load_registry, write_reserved_run_artifacts
 from .paths import resolve_runtime_root
@@ -489,7 +489,7 @@ def record_dreaming_proposal_decision(
     if claimed_by and decision == "approve":
         decision_payload["claimed_by"] = claimed_by
     recommended_action = _recommended_action_for_decision(decision, promoted_todo_id)
-    validate_public_safe_text("recommended_action", recommended_action)
+    validate_local_control_text("recommended_action", recommended_action)
     registry_goal = _registry_goal(registry, safe_goal_id)
     record = build_dreaming_decision_record(
         goal_id=safe_goal_id,

--- a/loopx/feedback.py
+++ b/loopx/feedback.py
@@ -35,6 +35,18 @@ LOCAL_CONTROL_TEXT_PATTERNS = (
     re.compile(r"\b" + "Bear" + r"er\s+[A-Za-z0-9._~+/=-]+\b", re.I),
     re.compile(r"\b" + "Author" + r"ization\s*:", re.I),
     re.compile(r"\b(?:tok" + r"en|pass" + r"word|sec" + r"ret)\s*[:=]", re.I),
+    re.compile(
+        r"\b(?:access[_-]?key(?:[_-]?id)?|accessKeyId|ak)\s*[:=]\s*"
+        r"[A-Za-z0-9._~+/=-]{8,}\b",
+        re.I,
+    ),
+    re.compile(
+        r"\b(?:secret[_-]?access[_-]?key|secretAccessKey|secret[_-]?key|sk)"
+        r"\s*[:=]\s*[A-Za-z0-9._~+/=-]{8,}\b",
+        re.I,
+    ),
+    re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b"),
+    re.compile(r"\bsk-[A-Za-z0-9_-]{20,}\b"),
 )
 HUMAN_REWARD_FIELDS = (
     "recorded_at",
@@ -63,8 +75,8 @@ def public_safe_text_guidance(label: str) -> str:
     normalized = label.lower().replace("-", "_")
     if "next_action" in normalized or "recommended_action" in normalized:
         return (
-            "use a public-safe action alias or short summary here; keep raw local "
-            "paths, private URLs, task bodies, and logs in evidence/private payloads"
+            "this field is usually local-control state; use validate_local_control_text "
+            "for private project routing, or a public-safe alias only on exported surfaces"
         )
     if "todo" in normalized:
         return (
@@ -114,7 +126,8 @@ def validate_local_control_text(label: str, value: str | None) -> None:
     for pattern in LOCAL_CONTROL_TEXT_PATTERNS:
         if pattern.search(value):
             raise ValueError(
-                f"{label} contains a secret-looking value; keep credentials out of control-plane text"
+                f"{label} contains a secret-looking value; keep AK/SK, tokens, auth headers, "
+                "passwords, and inline credentials out of local control-plane text"
             )
 
 

--- a/loopx/operator_gate.py
+++ b/loopx/operator_gate.py
@@ -4,7 +4,7 @@ import json
 from pathlib import Path
 from typing import Any
 
-from .feedback import validate_public_safe_text
+from .feedback import validate_local_control_text, validate_public_safe_text
 from .global_registry import sync_project_registry_to_global
 from .history import collect_history, load_registry
 from .paths import resolve_runtime_root
@@ -127,7 +127,7 @@ def build_operator_gate_resume_contract(
     validation = (
         "after resume, run the approved command in its declared mode and record validation before quota spend or follow-up side effects"
         if decision == "approve" and agent_command
-        else "after resume, keep the gate state current and record the next public-safe blocker or evidence condition"
+        else "after resume, keep the gate state current and record the next local-control blocker or evidence condition"
     )
     contract = {
         "version": OPERATOR_GATE_RESUME_CONTRACT_VERSION,
@@ -154,10 +154,10 @@ def build_operator_gate_resume_contract(
         ("freshness_check", contract["freshness_check"]),
         ("precondition_check", contract["precondition_check"]),
         ("migration_or_rebase_result", contract["migration_or_rebase_result"]),
-        ("resulting_action", contract["resulting_action"]),
         ("validation_after_resume", contract["validation_after_resume"]),
     ):
         validate_public_safe_text(label, str(value))
+    validate_local_control_text("resulting_action", str(contract["resulting_action"]))
     validate_public_safe_text("interrupt_payload.question", operator_question)
     return contract
 
@@ -327,7 +327,7 @@ def record_operator_gate(
     )
     classification = classification_for_decision(decision)
     action = recommended_action or default_recommended_action(decision=decision, agent_command=command)
-    validate_public_safe_text("recommended_action", action)
+    validate_local_control_text("recommended_action", action)
     generated_at = now_local()
     stem = f"{run_file_stem(generated_at)}-operator-gate"
     resume_contract = build_operator_gate_resume_contract(

--- a/loopx/project_map.py
+++ b/loopx/project_map.py
@@ -5,7 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from .authority import compact_authority_registry
-from .feedback import validate_public_safe_text
+from .feedback import validate_local_control_text, validate_public_safe_text
 from .global_registry import sync_project_registry_to_global
 from .history import load_registry
 from .paths import rel_or_abs, resolve_runtime_root
@@ -499,7 +499,7 @@ def read_only_project_map_run(
         )
     else:
         action = derive_recommended_action(state_text)
-    validate_public_safe_text("recommended_action", action)
+    validate_local_control_text("recommended_action", action)
     generated_at = now_local()
     record = build_project_map_record(
         goal_id=safe_goal_id,

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -121,7 +121,7 @@ def normalize_next_action_text(value: str) -> str:
     text = " ".join(str(value or "").strip().split())
     if not text:
         raise ValueError("next_action must not be empty")
-    validate_public_safe_text("active_state_next_action", text)
+    validate_local_control_text("active_state_next_action", text)
     return text
 
 


### PR DESCRIPTION
## Summary
- Treat `refresh-state --next-action` and `--recommended-action` as local-control routing text instead of public export text.
- Keep hard rejection for AK/SK, tokens, auth headers, passwords, and inline credentials.
- Update read-only-map/operator-gate/dreaming recommendation validation plus docs and smokes so private project refs remain allowed while secrets stay blocked.

## Validation
- `python3 examples/project/goal-vision-refresh-state-budget-smoke.py`
- `python3 examples/project/project-map-smoke.py`
- `python3 examples/project/next-action-projection-contract-smoke.py`
- `python3 examples/control_plane/refresh-state-agent-lane-scope-smoke.py`
- `python3 examples/control_plane/public-safety-readmodel-smoke.py`
- `python3 -m py_compile loopx/feedback.py loopx/state_refresh.py loopx/project_map.py loopx/operator_gate.py loopx/dreaming.py loopx/cli_commands/project_lifecycle.py examples/project/goal-vision-refresh-state-budget-smoke.py examples/project/project-map-smoke.py`
- `loopx check --scan-path ...` over all changed files
- `git diff --check origin/main...HEAD`
- `loopx canary premerge --from-git-diff --format json --timeout-seconds 120 --no-progress` passed; self_merge_allowed=true, no failures, warnings, or manual holds.
