### PR TITLE
Release LoopX v0.1.13

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -139,6 +139,20 @@ path, and canary route rather than as a user-facing release baseline.
   exposes premerge canary progress earlier, and promotes auto-research visible
   worker/successor routing plus selected public benchmark route/profile and
   SkillsBench helper hardening.
+- `v0.1.13` on 2026-07-08 18:15 +08:00: guided onboarding and multi-agent
+  control-plane release at the matching `v0.1.13` tag. This release makes new
+  project setup more repairable with guided start-goal previews (#1631, #1633),
+  non-destructive write-scope migration (#1636), delivery-scale aliases, and
+  clearer refresh-state diagnostics (#1641); routes primary controllers toward
+  subagent orchestration (#1622) behind an explicit default-off feature switch
+  (#1643); improves scheduler ACK/backoff recovery and heartbeat migration
+  (#1626, #1639); splits quota/status fixture hot paths, Lark projection row
+  helpers, and content-ops markdown renderers into narrower modules (#1640,
+  #1642, #1644, #1646); adds public-safe external ML task ledgers (#1627);
+  hardens SkillsBench source/countability/launcher evidence (#1612, #1620,
+  #1621, #1625); and relaxes local `next_action` / `recommended_action` text to
+  allow local project routing references while still rejecting inline
+  credentials (#1645).
 
 When a new public release is promoted, add it here only after the matching tag,
 release note, stable ref, update path, and focused release canary agree.

--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.12"
+__version__ = "0.1.13"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.1.12"
+version = "0.1.13"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary

Release LoopX v0.1.13 by bumping the named package version and adding the stable-channel timeline entry.

This release fairly packages the work merged since v0.1.12, including:

- guided project onboarding: start-goal preview and onboarding docs ([#1631](https://github.com/huangruiteng/loopx/pull/1631), [#1633](https://github.com/huangruiteng/loopx/pull/1633)), safer write-scope migration ([#1636](https://github.com/huangruiteng/loopx/pull/1636)), delivery-scale aliases, and clearer refresh-state diagnostics ([#1641](https://github.com/huangruiteng/loopx/pull/1641));
- scheduler and heartbeat reliability: stable/current scheduler ACK flows and heartbeat migration guidance ([#1626](https://github.com/huangruiteng/loopx/pull/1626), [#1639](https://github.com/huangruiteng/loopx/pull/1639)), monitor/backoff refinements, and closed-vision quota repair ([#1629](https://github.com/huangruiteng/loopx/pull/1629));
- multi-agent control plane: external-contributor primary-controller subagent orchestration ([#1622](https://github.com/huangruiteng/loopx/pull/1622)) plus the default-off feature switch ([#1643](https://github.com/huangruiteng/loopx/pull/1643));
- status/quota/content presentation quality: quota/status fixture splits and goal-boundary helper extraction ([#1640](https://github.com/huangruiteng/loopx/pull/1640), [#1642](https://github.com/huangruiteng/loopx/pull/1642)), Lark projection row helpers ([#1644](https://github.com/huangruiteng/loopx/pull/1644)), and content-ops markdown renderer extraction ([#1646](https://github.com/huangruiteng/loopx/pull/1646));
- external work/evidence support: public-safe ML task ledgers / ML experiment packet support ([#1627](https://github.com/huangruiteng/loopx/pull/1627)) and SkillsBench source/countability/launcher/aggregate hardening ([#1612](https://github.com/huangruiteng/loopx/pull/1612), [#1620](https://github.com/huangruiteng/loopx/pull/1620), [#1621](https://github.com/huangruiteng/loopx/pull/1621), [#1625](https://github.com/huangruiteng/loopx/pull/1625));
- local-control action policy: `next_action` / `recommended_action` now permit local routing refs while still rejecting inline credentials ([#1645](https://github.com/huangruiteng/loopx/pull/1645)).

## Validation

- `python3 -m py_compile loopx/*.py`
- `python3 examples/release/release-version-contract-smoke.py`
- `python3 examples/release/release-readiness-doc-smoke.py`
- `python3 examples/release/codex-cli-no-clone-release-verification-smoke.py`
- `python3 examples/fresh-clone-quickstart-smoke.py`
- `python3 examples/loopx-update-smoke.py`
- `python3 examples/install-local-smoke.py`
- `python3 examples/canary/canary-promotion-readiness-smoke.py --no-write-evidence`
- `loopx check --scan-path loopx/__init__.py --scan-path pyproject.toml --scan-path docs/product/release-readiness.md`
- `loopx canary premerge --from-git-diff --format json --timeout-seconds 120 --no-progress`

Premerge result: passed, `self_merge_allowed=true`, no failures, no manual holds. Dashboard browser smoke was skipped by the release canary because dashboard npm dependencies are not installed in this checkout; the skip is visible and non-blocking for this release boundary.

## Public/private boundary

Only `loopx/__init__.py`, `pyproject.toml`, and `docs/product/release-readiness.md` changed. Public boundary scan passed on the changed files and the release canary scan passed on the source checkout.
