### PR TITLE
Extract todo markdown renderer

### DIFF
--- a/examples/cli-control-plane-command-modularization-smoke.py
+++ b/examples/cli-control-plane-command-modularization-smoke.py
@@ -91,10 +91,30 @@ def assert_todo_error_payload() -> None:
     assert payload["error"] == "todo add requires --role", payload
 
 
+def assert_todo_markdown_error_payload() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-cli-todo-markdown-smoke-") as tmp:
+        result = run_cli(
+            "--registry",
+            str(Path(tmp) / "missing-registry.json"),
+            "todo",
+            "add",
+            "--goal-id",
+            "cli-modular-smoke",
+            "--text",
+            "Synthetic todo missing role.",
+            "--dry-run",
+        )
+    assert result.returncode == 1, result.stdout
+    assert_contains(result.stdout, "# LoopX Todo", "todo markdown error")
+    assert_contains(result.stdout, "- ok: `False`", "todo markdown error")
+    assert_contains(result.stdout, "- error: todo add requires --role", "todo markdown error")
+
+
 def main() -> int:
     assert_source_shape()
     assert_help_surfaces()
     assert_todo_error_payload()
+    assert_todo_markdown_error_payload()
     print("cli-control-plane-command-modularization-smoke: ok")
     return 0
 

--- a/loopx/control_plane/todos/markdown.py
+++ b/loopx/control_plane/todos/markdown.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .contract import TODO_STATUS_OPEN, todo_marker_for_status
+
+
+def render_todo_markdown(payload: dict[str, Any]) -> str:
+    if payload.get("command") == "list":
+        lines = [
+            "# LoopX Todo List",
+            "",
+            f"- ok: `{payload.get('ok')}`",
+            f"- read_only: `{payload.get('read_only')}`",
+            f"- goal_id: `{payload.get('goal_id')}`",
+            f"- role: `{payload.get('role')}`",
+            f"- status_filter: `{payload.get('status_filter')}`",
+            f"- source: `{payload.get('source')}`",
+            f"- todo_count: `{payload.get('todo_count')}`",
+            f"- state_file: `{payload.get('state_file')}`",
+        ]
+        if payload.get("agent_id_filter"):
+            lines.extend(
+                [
+                    f"- agent_id_filter: `{payload.get('agent_id_filter')}`",
+                    f"- unfiltered_todo_count: `{payload.get('unfiltered_todo_count')}`",
+                    f"- filter_semantics: `{payload.get('filter_semantics')}`",
+                ]
+            )
+        projection = payload.get("state_event_projection")
+        if isinstance(projection, dict):
+            lines.extend(
+                [
+                    f"- event_log: `{projection.get('event_log')}`",
+                    f"- source_event_count: `{projection.get('source_event_count')}`",
+                    f"- last_event_id: `{projection.get('last_event_id')}`",
+                ]
+            )
+        for key, heading in (
+            ("user_todos", "User Todo"),
+            ("agent_todos", "Agent Todo"),
+        ):
+            summary = payload.get(key)
+            if not isinstance(summary, dict):
+                continue
+            lines.extend(["", f"## {heading}", ""])
+            items = summary.get("items") or []
+            if not items:
+                lines.append("- none")
+                continue
+            for item in items:
+                if not isinstance(item, dict):
+                    continue
+                marker = todo_marker_for_status(item.get("status") or TODO_STATUS_OPEN)
+                text = item.get("text") or item.get("title") or ""
+                metadata = []
+                for metadata_key in (
+                    "todo_id",
+                    "status",
+                    "task_class",
+                    "action_kind",
+                    "claimed_by",
+                    "target_key",
+                    "cadence",
+                    "next_due_at",
+                    "expires_at",
+                ):
+                    if item.get(metadata_key):
+                        metadata.append(f"{metadata_key}={item.get(metadata_key)}")
+                suffix = f" <!-- {' '.join(metadata)} -->" if metadata else ""
+                lines.append(f"- [{marker}] {text}{suffix}")
+        if payload.get("error"):
+            lines.append(f"- error: {payload.get('error')}")
+        return "\n".join(lines)
+
+    lines = [
+        "# LoopX Todo",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- dry_run: `{payload.get('dry_run')}`",
+        f"- goal_id: `{payload.get('goal_id')}`",
+        f"- role: `{payload.get('role')}`",
+        f"- section: `{payload.get('section')}`",
+        f"- state_file: `{payload.get('state_file')}`",
+    ]
+    if "moved_count" in payload:
+        lines.extend(
+            [
+                f"- changed: `{payload.get('changed')}`",
+                f"- archive_section: `{payload.get('archive_section')}`",
+                f"- active_done_before: `{payload.get('active_done_before')}`",
+                f"- active_done_after: `{payload.get('active_done_after')}`",
+                f"- max_active_done: `{payload.get('max_active_done')}`",
+                f"- moved_count: `{payload.get('moved_count')}`",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                f"- changed: `{payload.get('changed')}`",
+                f"- added: `{payload.get('added')}`",
+                f"- already_exists: `{payload.get('already_exists')}`",
+                f"- todo_id: `{payload.get('todo_id')}`",
+                f"- status: `{payload.get('status')}`",
+                f"- required_capabilities: `{payload.get('required_capabilities')}`",
+                f"- target_capabilities: `{payload.get('target_capabilities')}`",
+                f"- claimed_by: `{payload.get('claimed_by')}`",
+                f"- blocks_agent: `{payload.get('blocks_agent')}`",
+                f"- global_gate: `{payload.get('global_gate')}`",
+                f"- resume_when: `{payload.get('resume_when')}`",
+                f"- target_key: `{payload.get('target_key')}`",
+                f"- cadence: `{payload.get('cadence')}`",
+                f"- next_due_at: `{payload.get('next_due_at')}`",
+                f"- expires_at: `{payload.get('expires_at')}`",
+            ]
+        )
+    if payload.get("error"):
+        lines.append(f"- error: {payload.get('error')}")
+    elif "todo" in payload:
+        marker = todo_marker_for_status(payload.get("status") or TODO_STATUS_OPEN)
+        lines.extend(["", "## Todo", "", f"- [{marker}] {payload.get('todo')}"])
+    correctness = payload.get("local_state_write_correctness")
+    if isinstance(correctness, dict):
+        intent = correctness.get("write_intent") if isinstance(correctness.get("write_intent"), dict) else {}
+        apply_result = (
+            correctness.get("apply_result")
+            if isinstance(correctness.get("apply_result"), dict)
+            else {}
+        )
+        lines.extend(
+            [
+                "",
+                "## Local State Write Correctness",
+                "",
+                f"- schema_version: `{correctness.get('schema_version')}`",
+                f"- write_id: `{intent.get('write_id')}`",
+                f"- write_class: `{intent.get('write_class')}`",
+                f"- idempotency_key: `{intent.get('idempotency_key')}`",
+                f"- status: `{apply_result.get('status')}`",
+            ]
+        )
+    return "\n".join(lines)

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -61,6 +61,7 @@ from .control_plane.todos.event_writeback import (
     complete_event_projected_goal_todo,
     event_projection_todo_context,
 )
+from .control_plane.todos.markdown import render_todo_markdown
 from .control_plane.todos.monitor_metadata import require_monitor_metadata_scope
 from .control_plane.todos.text import (
     inherit_todo_priority,
@@ -1514,7 +1515,6 @@ def complete_goal_todo(
         "updated_at": updated_at if changed else None,
     }
 
-
 def supersede_goal_todo(
     *,
     registry_path: Path,
@@ -1692,140 +1692,3 @@ def archive_completed_todos(
         "project": str(resolved_project) if resolved_project else None,
         "updated_at": updated_at if changed else None,
     }
-
-
-def render_todo_markdown(payload: dict[str, Any]) -> str:
-    if payload.get("command") == "list":
-        lines = [
-            "# LoopX Todo List",
-            "",
-            f"- ok: `{payload.get('ok')}`",
-            f"- read_only: `{payload.get('read_only')}`",
-            f"- goal_id: `{payload.get('goal_id')}`",
-            f"- role: `{payload.get('role')}`",
-            f"- status_filter: `{payload.get('status_filter')}`",
-            f"- source: `{payload.get('source')}`",
-            f"- todo_count: `{payload.get('todo_count')}`",
-            f"- state_file: `{payload.get('state_file')}`",
-        ]
-        if payload.get("agent_id_filter"):
-            lines.extend(
-                [
-                    f"- agent_id_filter: `{payload.get('agent_id_filter')}`",
-                    f"- unfiltered_todo_count: `{payload.get('unfiltered_todo_count')}`",
-                    f"- filter_semantics: `{payload.get('filter_semantics')}`",
-                ]
-            )
-        projection = payload.get("state_event_projection")
-        if isinstance(projection, dict):
-            lines.extend(
-                [
-                    f"- event_log: `{projection.get('event_log')}`",
-                    f"- source_event_count: `{projection.get('source_event_count')}`",
-                    f"- last_event_id: `{projection.get('last_event_id')}`",
-                ]
-            )
-        for key, heading in (
-            ("user_todos", "User Todo"),
-            ("agent_todos", "Agent Todo"),
-        ):
-            summary = payload.get(key)
-            if not isinstance(summary, dict):
-                continue
-            lines.extend(["", f"## {heading}", ""])
-            items = summary.get("items") or []
-            if not items:
-                lines.append("- none")
-                continue
-            for item in items:
-                if not isinstance(item, dict):
-                    continue
-                marker = todo_marker_for_status(item.get("status") or TODO_STATUS_OPEN)
-                text = item.get("text") or item.get("title") or ""
-                metadata = []
-                for metadata_key in (
-                    "todo_id",
-                    "status",
-                    "task_class",
-                    "action_kind",
-                    "claimed_by",
-                    "target_key",
-                    "cadence",
-                    "next_due_at",
-                    "expires_at",
-                ):
-                    if item.get(metadata_key):
-                        metadata.append(f"{metadata_key}={item.get(metadata_key)}")
-                suffix = f" <!-- {' '.join(metadata)} -->" if metadata else ""
-                lines.append(f"- [{marker}] {text}{suffix}")
-        if payload.get("error"):
-            lines.append(f"- error: {payload.get('error')}")
-        return "\n".join(lines)
-
-    lines = [
-        "# LoopX Todo",
-        "",
-        f"- ok: `{payload.get('ok')}`",
-        f"- dry_run: `{payload.get('dry_run')}`",
-        f"- goal_id: `{payload.get('goal_id')}`",
-        f"- role: `{payload.get('role')}`",
-        f"- section: `{payload.get('section')}`",
-        f"- state_file: `{payload.get('state_file')}`",
-    ]
-    if "moved_count" in payload:
-        lines.extend(
-            [
-                f"- changed: `{payload.get('changed')}`",
-                f"- archive_section: `{payload.get('archive_section')}`",
-                f"- active_done_before: `{payload.get('active_done_before')}`",
-                f"- active_done_after: `{payload.get('active_done_after')}`",
-                f"- max_active_done: `{payload.get('max_active_done')}`",
-                f"- moved_count: `{payload.get('moved_count')}`",
-            ]
-        )
-    else:
-        lines.extend(
-            [
-                f"- changed: `{payload.get('changed')}`",
-                f"- added: `{payload.get('added')}`",
-                f"- already_exists: `{payload.get('already_exists')}`",
-                f"- todo_id: `{payload.get('todo_id')}`",
-                f"- status: `{payload.get('status')}`",
-                f"- required_capabilities: `{payload.get('required_capabilities')}`",
-                f"- target_capabilities: `{payload.get('target_capabilities')}`",
-                f"- claimed_by: `{payload.get('claimed_by')}`",
-                f"- blocks_agent: `{payload.get('blocks_agent')}`",
-                f"- global_gate: `{payload.get('global_gate')}`",
-                f"- resume_when: `{payload.get('resume_when')}`",
-                f"- target_key: `{payload.get('target_key')}`",
-                f"- cadence: `{payload.get('cadence')}`",
-                f"- next_due_at: `{payload.get('next_due_at')}`",
-                f"- expires_at: `{payload.get('expires_at')}`",
-            ]
-        )
-    if payload.get("error"):
-        lines.append(f"- error: {payload.get('error')}")
-    elif "todo" in payload:
-        marker = todo_marker_for_status(payload.get("status") or TODO_STATUS_OPEN)
-        lines.extend(["", "## Todo", "", f"- [{marker}] {payload.get('todo')}"])
-    correctness = payload.get("local_state_write_correctness")
-    if isinstance(correctness, dict):
-        intent = correctness.get("write_intent") if isinstance(correctness.get("write_intent"), dict) else {}
-        apply_result = (
-            correctness.get("apply_result")
-            if isinstance(correctness.get("apply_result"), dict)
-            else {}
-        )
-        lines.extend(
-            [
-                "",
-                "## Local State Write Correctness",
-                "",
-                f"- schema_version: `{correctness.get('schema_version')}`",
-                f"- write_id: `{intent.get('write_id')}`",
-                f"- write_class: `{intent.get('write_class')}`",
-                f"- idempotency_key: `{intent.get('idempotency_key')}`",
-                f"- status: `{apply_result.get('status')}`",
-            ]
-        )
-    return "\n".join(lines)


### PR DESCRIPTION
## Summary
- Move todo CLI Markdown rendering into the todo control-plane bounded context.
- Keep loopx.todos.render_todo_markdown as the compatibility import for existing CLI callers.
- Extend the CLI command modularization smoke to cover Markdown error output.

## Validation
- python3 -m py_compile loopx/todos.py loopx/control_plane/todos/markdown.py loopx/cli_commands/todo.py
- python3 examples/cli-control-plane-command-modularization-smoke.py
- python3 examples/control_plane/todo-lifecycle-cli-smoke.py
- python3 examples/control_plane/todo-cli-smoke.py
- python3 examples/control_plane/todo-user-gate-scope-smoke.py
- python3 examples/control_plane/repo-python-line-budget-smoke.py
- loopx check --scan-path loopx/todos.py --scan-path loopx/control_plane/todos/markdown.py --scan-path examples/cli-control-plane-command-modularization-smoke.py
- loopx canary premerge --from-git-diff passed: selected=17, failures=0, manual_holds=0

## Boundary
- Public-safe repo code and smoke only.
- No benchmark runner/task/log/trajectory/verifier material.
- No credentials, private docs, or local runtime state.