### PR TITLE
Route quota execution through interaction contract

### DIFF
--- a/docs/heartbeat-automation-prompt.md
+++ b/docs/heartbeat-automation-prompt.md
@@ -55,6 +55,10 @@ prompt text.
 When the generated prompt and the installed skill disagree, the worker should
 trust the current CLI `interaction_contract` first, then use the skill as the
 operation manual and the prompt only as a bootstrap.
+Within that contract, the worker should execute
+`agent_channel.primary_action`. An optional `agent_channel.resolution_trace`
+is for debugging route selection and drift; it should not be treated as another
+action to run or as permission to rewrite active-state `Next Action`.
 
 You can generate the task body from the CLI. Prefer the registry-backed form
 for connected goals, so the installed automation does not hard-code a state-file

--- a/docs/state-interaction-model.md
+++ b/docs/state-interaction-model.md
@@ -158,6 +158,12 @@ The guard's `interaction_contract` is the first-class protocol. Older fields
 such as `execution_obligation`, `heartbeat_recommendation`,
 `work_lane_contract`, `external_evidence_observation`, `goal_boundary`, and
 `protocol_action_packet` remain compatibility and drill-down fields.
+Executors should treat `interaction_contract.agent_channel.primary_action` as
+the single action entrypoint for the current turn. If it carries a
+`resolution_trace`, that trace is only a compact explanation of which projected
+signal the primary action matched and whether `Next Action` / latest-run drift
+exists; it is not a second action source and does not authorize state sync by
+itself.
 Legacy Markdown parsing is even lower authority: it is a deterministic lint for
 unprojected prose in `Next Action`, not a source of gate truth. The hot path
 should not call an LLM to decide whether the user is gated, because that adds

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1290,7 +1290,15 @@ Its `user_channel` says whether to interrupt the user and why;
 `agent_channel` says whether Codex must attempt work, whether delivery is
 allowed, whether quiet no-op is allowed, and the primary action; `cli_channel`
 says which CLI transitions and spend policy apply. Executors should read
-`interaction_contract` first. `execution_obligation`,
+`interaction_contract` first, with
+`interaction_contract.agent_channel.primary_action` as the only executable
+action entrypoint for the current turn. Optional
+`agent_channel.resolution_trace.summary` is diagnostic: it compactly records
+the source signal matched by `primary_action` and whether drift was detected. Existing
+`state_action_projection_warning` / `next_action_projection_warning` fields
+carry any writeback review guidance. The trace is not an independent
+next-action authority and does not imply automatic active-state writeback.
+`execution_obligation`,
 `heartbeat_recommendation`, `work_lane_contract`,
 `external_evidence_observation`, `goal_boundary`, and
 `protocol_action_packet` remain compatibility and drill-down fields under that

--- a/examples/project/next-action-projection-contract-smoke.py
+++ b/examples/project/next-action-projection-contract-smoke.py
@@ -13,7 +13,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 
 import loopx.state_refresh as state_refresh
 from loopx.quota import build_quota_should_run, render_quota_should_run_markdown
-from loopx.state_projection import actions_are_projection_aligned, state_action_projection_warning
+from loopx.state_projection import (
+    actions_are_projection_aligned,
+    next_action_resolution_trace,
+    state_action_projection_warning,
+)
 from loopx.status import collect_status, render_status_markdown
 
 
@@ -150,6 +154,10 @@ def assert_state_action_projection_warning_read_model() -> None:
         "[P1] Agent: Validate the primary public PoC control-plane lane.",
         "Validate the primary public PoC control-plane lane.",
     )
+    assert actions_are_projection_aligned(
+        "todo_fe0c5551dd89: P2: Route quota execution through interaction_contract.agent_channel.primary_action",
+        "P2: Route quota execution through interaction_contract.agent_channel.primary_action",
+    )
     assert (
         state_action_projection_warning(
             {"active_state_next_action": ACTIVE_NEXT_ACTION},
@@ -171,6 +179,17 @@ def assert_state_action_projection_warning_read_model() -> None:
         )
         is None
     )
+
+    trace = next_action_resolution_trace(
+        primary_action=SIDE_AGENT_ACTION,
+        mode="bounded_delivery",
+        active_state_next_action=ACTIVE_NEXT_ACTION,
+        latest_run_recommended_action=RUN_RECOMMENDATION,
+        selected_recommended_action=SIDE_AGENT_ACTION,
+        agent_lane_next_action={"text": SIDE_AGENT_ACTION},
+    )
+    assert trace is not None, trace
+    assert trace["summary"] == "source=agent_lane drift=true", trace
 
 
 def main() -> None:
@@ -227,6 +246,10 @@ def main() -> None:
             assert first_item["next_action_projection_warning"]["requires_state_writeback"] is True, first_item
             assert first_decision["active_state_next_action"] == ACTIVE_NEXT_ACTION, first_decision
             assert first_decision["latest_run_recommended_action"] == RUN_RECOMMENDATION, first_decision
+            first_agent_channel = first_decision["interaction_contract"]["agent_channel"]
+            assert "independent worktree/branch" in first_agent_channel["primary_action"], first_decision
+            first_trace = first_agent_channel["resolution_trace"]
+            assert first_trace["summary"] == "source=selected drift=true", first_decision
             first_warning = first_decision["next_action_projection_warning"]
             assert first_warning["severity"] == "info", first_decision
             assert first_warning["requires_state_writeback"] is False, first_decision
@@ -265,6 +288,10 @@ def main() -> None:
             assert second_item["latest_run_recommended_action"] == UPDATED_RUN_RECOMMENDATION, second_item
             assert second_decision["active_state_next_action"] == UPDATED_NEXT_ACTION, second_decision
             assert second_decision["latest_run_recommended_action"] == UPDATED_RUN_RECOMMENDATION, second_decision
+            second_agent_channel = second_decision["interaction_contract"]["agent_channel"]
+            assert "independent worktree/branch" in second_agent_channel["primary_action"], second_decision
+            second_trace = second_agent_channel["resolution_trace"]
+            assert second_trace["summary"] == "source=selected drift=true", second_decision
             lane = second_decision["agent_lane_next_action"]
             assert lane["todo_id"] == "todo_side", second_decision
             assert lane["title"] == SIDE_AGENT_ACTION, second_decision
@@ -287,6 +314,8 @@ def main() -> None:
             assert "latest_run_recommended_action" in status_markdown, status_markdown
             assert "active_state_next_action" in quota_markdown, quota_markdown
             assert "latest_run_recommended_action" in quota_markdown, quota_markdown
+            assert "interaction_agent_action" in quota_markdown, quota_markdown
+            assert "interaction_agent_resolution" in quota_markdown, quota_markdown
 
             cli_ok = run_cli_json(
                 [

--- a/loopx/control_plane/quota/markdown.py
+++ b/loopx/control_plane/quota/markdown.py
@@ -897,6 +897,15 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
         )
         if agent_channel.get("primary_action"):
             lines.append(f"- interaction_agent_action: {agent_channel.get('primary_action')}")
+        resolution_trace = (
+            agent_channel.get("resolution_trace")
+            if isinstance(agent_channel.get("resolution_trace"), dict)
+            else {}
+        )
+        if resolution_trace:
+            lines.append(
+                f"- interaction_agent_resolution: {resolution_trace.get('summary')}"
+            )
     automation_liveness = (
         payload.get("automation_liveness")
         if isinstance(payload.get("automation_liveness"), dict)

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from ...state_projection import next_action_resolution_trace
 from ..agents.agent_scope import AgentScopeFrontierAction
 from ..goals.goal_frontier import AUTONOMOUS_REPLAN_REQUIRED_MODE
 from ..todos.contract import TODO_TASK_CLASS_ADVANCEMENT, TODO_TASK_CLASS_MONITOR
@@ -792,6 +793,23 @@ def build_interaction_contract(payload: dict[str, Any]) -> dict[str, Any]:
         "scoped_user_gate_fallback",
         "bounded_delivery_with_user_notice",
     }
+    primary_action = _interaction_primary_agent_action(payload, mode=mode)
+    agent_channel: dict[str, Any] = {
+        "must_attempt": must_attempt,
+        "delivery_allowed": delivery_allowed,
+        "quiet_noop_allowed": quiet_noop_allowed,
+        "primary_action": primary_action,
+    }
+    resolution_trace = next_action_resolution_trace(
+        primary_action=primary_action,
+        mode=mode,
+        active_state_next_action=payload.get("active_state_next_action"),
+        latest_run_recommended_action=payload.get("latest_run_recommended_action"),
+        selected_recommended_action=payload.get("recommended_action"),
+        agent_lane_next_action=payload.get("agent_lane_next_action"),
+    )
+    if resolution_trace:
+        agent_channel["resolution_trace"] = resolution_trace
     user_channel: dict[str, Any] = {
         "action_required": user_required,
         "notify": "NOTIFY" if user_required else heartbeat_recommendation.get("notify", "DONT_NOTIFY"),
@@ -833,12 +851,7 @@ def build_interaction_contract(payload: dict[str, Any]) -> dict[str, Any]:
         "schema_version": INTERACTION_CONTRACT_SCHEMA_VERSION,
         "mode": mode,
         "user_channel": user_channel,
-        "agent_channel": {
-            "must_attempt": must_attempt,
-            "delivery_allowed": delivery_allowed,
-            "quiet_noop_allowed": quiet_noop_allowed,
-            "primary_action": _interaction_primary_agent_action(payload, mode=mode),
-        },
+        "agent_channel": agent_channel,
         "cli_channel": {
             "next_cli_actions": interaction_next_cli_actions(payload, mode=mode),
             "spend_allowed_now": spend_allowed_now,

--- a/loopx/state_projection.py
+++ b/loopx/state_projection.py
@@ -121,6 +121,8 @@ def _action_projection_text(value: Any, *, limit: int = 320) -> str:
 
 def _action_projection_compare_text(value: Any) -> str:
     text = re.sub(r"\s+", " ", str(value or "").strip().lower())
+    text = re.sub(r"^todo_[0-9a-z]+:\s*", "", text)
+    text = re.sub(r"^p[0-9]+:\s*", "", text)
     text = re.sub(r"^\[(?:p[0-9]+|[^\]]+)\]\s*", "", text)
     return re.sub(r"^(?:agent|user|owner|codex)\s*:\s*", "", text)
 
@@ -217,6 +219,57 @@ def next_action_projection_warning(
     return warning
 
 
+def next_action_resolution_trace(
+    *,
+    primary_action: Any,
+    mode: Any = None,
+    active_state_next_action: Any,
+    latest_run_recommended_action: Any,
+    selected_recommended_action: Any,
+    agent_lane_next_action: Any = None,
+) -> dict[str, Any] | None:
+    primary_text = _action_projection_text(primary_action)
+    if not primary_text:
+        return None
+    selected_text = _action_projection_text(selected_recommended_action)
+    active_text = _action_projection_text(active_state_next_action)
+    latest_text = _action_projection_text(latest_run_recommended_action)
+    lane_value = (
+        agent_lane_next_action.get("text")
+        if isinstance(agent_lane_next_action, dict)
+        else agent_lane_next_action
+    )
+    lane_text = _action_projection_text(lane_value)
+
+    source = "interaction_contract"
+    source_candidates = (
+        ("agent_lane", lane_text),
+        ("selected", selected_text),
+        ("active_next", active_text),
+        ("latest_run", latest_text),
+    )
+    for candidate_source, candidate_text in source_candidates:
+        if candidate_text and actions_are_projection_aligned(primary_text, candidate_text):
+            source = candidate_source
+            break
+    if source == "interaction_contract" and mode:
+        source = f"mode:{mode}"
+
+    mismatches: list[str] = []
+    for label, left, right in (
+        ("active_vs_latest", active_text, latest_text),
+        ("active_vs_primary", active_text, primary_text),
+        ("latest_vs_primary", latest_text, primary_text),
+        ("selected_vs_primary", selected_text, primary_text),
+    ):
+        if left and right and not actions_are_projection_aligned(left, right):
+            mismatches.append(label)
+
+    return {
+        "summary": f"source={source} drift={'true' if mismatches else 'false'}",
+    }
+
+
 def state_action_projection_warning(
     item: dict[str, Any],
     *,
@@ -276,8 +329,7 @@ def state_action_projection_warning(
         "selected_recommended_action": _action_projection_text(selected_text, limit=320),
         "reason": "quota selected executable backlog while active Next Action differs",
         "recommended_action": (
-            "sync active-state Next Action, or treat protocol_action_packet / "
-            "interaction_contract as authoritative"
+            "run primary_action; sync active route only on route change"
         ),
     }
 


### PR DESCRIPTION
## Summary
- Keep `interaction_contract.agent_channel.primary_action` as the single executable action entrypoint for quota turns.
- Add a compact `resolution_trace.summary` beside `primary_action` to explain source/drift without introducing an authoritative next-action surface or auto-sync command.
- Document the contract in state interaction, status data, and heartbeat automation docs; extend next-action projection smoke coverage for todo-id/P-priority normalization.

## Validation
- `python3 -m py_compile loopx/state_projection.py loopx/control_plane/work_items/interaction_contract.py loopx/control_plane/quota/markdown.py examples/project/next-action-projection-contract-smoke.py`
- `python3 examples/project/next-action-projection-contract-smoke.py`
- `python3 examples/control_plane/hot-path-interface-budget-smoke.py`
- `python3 examples/control_plane/quota-contract-smoke.py`
- `python3 examples/control_plane/heartbeat-quota-flow-smoke.py`
- `python3 examples/control_plane/work-lane-contract-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `loopx check --scan-path loopx/state_projection.py --scan-path loopx/control_plane/work_items/interaction_contract.py --scan-path loopx/control_plane/quota/markdown.py --scan-path examples/project/next-action-projection-contract-smoke.py --scan-path docs/state-interaction-model.md --scan-path docs/status-data-contract.md --scan-path docs/heartbeat-automation-prompt.md`
- `loopx canary premerge --from-git-diff` passed: 17 selected checks, public boundary clean, manual_holds=0

## Notes
- Self-merge not performed because this changes control-plane runtime behavior; PR is ready for maintainer review.
