### PR TITLE
Stabilize monitor scheduler identity

### DIFF
--- a/examples/control_plane/quota-scheduler-state-ack-smoke.py
+++ b/examples/control_plane/quota-scheduler-state-ack-smoke.py
@@ -284,6 +284,34 @@ def assert_monitor_wait_progression_reaches_120() -> None:
     assert "recommended_rrule" not in quiet["codex_app"], quiet
 
 
+def assert_monitor_wait_ignores_goal_recommended_action_identity_noise() -> None:
+    first_payload = monitor_window_payload(minutes_until_due=119)
+    first_payload["recommended_action"] = (
+        "Monitor another agent's post-merge run until material evidence appears."
+    )
+    first = build_hint_at(first_payload, now=FROZEN_NOW)
+    first_backoff = first["codex_app"]["stateful_backoff"]
+    assert first["cadence_class"] == "monitor_wait", first
+    assert first["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=15", first
+    assert "recommended_action" not in first["unchanged_identity_keys"], first
+
+    second_payload = monitor_window_payload(minutes_until_due=119)
+    second_payload["recommended_action"] = (
+        "Goal-level controller text changed, but the monitor target is unchanged."
+    )
+    second = build_hint_at(
+        second_payload,
+        now=FROZEN_NOW,
+        scheduler_state=state_from(first),
+    )
+    second_backoff = second["codex_app"]["stateful_backoff"]
+    assert second_backoff["state_status"] == "same_identity", second
+    assert second["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=30", second
+    assert second_backoff["identity_signature"] == first_backoff["identity_signature"], second
+    assert second_backoff["reset_token"] == first_backoff["reset_token"], second
+    assert "recommended_action" not in second["unchanged_identity_keys"], second
+
+
 def assert_active_work_keeps_initial_cadence() -> None:
     base = active_payload()
     first = build_scheduler_hint(
@@ -905,6 +933,7 @@ def assert_cli_scheduler_ack_uses_should_run_lookback() -> None:
 def main() -> int:
     assert_policy_state_progression()
     assert_monitor_wait_progression_reaches_120()
+    assert_monitor_wait_ignores_goal_recommended_action_identity_noise()
     assert_active_work_keeps_initial_cadence()
     assert_scheduler_ack_plan_validation()
     assert_monitor_wait_stale_ack_hint_is_accepted()

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -669,13 +669,20 @@ def build_scheduler_hint(
         if isinstance(capability_gate.get("available"), list)
         else []
     )
-    identity_keys = [
+    base_identity_keys = [
         "goal_id",
         "agent_identity.agent_id",
         "effective_action",
         "heartbeat_recommendation.recommended_mode",
         "interaction_contract.mode",
         "recommended_action",
+    ]
+    monitor_wait_identity_keys = [
+        "goal_id",
+        "agent_identity.agent_id",
+        "effective_action",
+        "heartbeat_recommendation.recommended_mode",
+        "interaction_contract.mode",
     ]
     agent_scope_action_set = {str(value) for value in agent_scope_frontier_actions}
 
@@ -716,6 +723,11 @@ def build_scheduler_hint(
             "if_unchanged": "apply_after_limit_without_spend",
             "spend_policy": "no quota spend for final replan check or loop stop",
         }
+        identity_keys = (
+            monitor_wait_identity_keys
+            if cadence_class == "monitor_wait"
+            else base_identity_keys
+        )
         identity_snapshot = {key: identity_value(key) for key in identity_keys}
         codex_rrule = rrule_for_minutes(codex_initial_interval)
         profile_snapshot = {


### PR DESCRIPTION
## Summary

- Keep goal-level `recommended_action` in scheduler identity for ordinary wait/noop lanes.
- Exclude goal-level `recommended_action` from `monitor_wait` identity so monitor quiet/wait cadence advances on unchanged monitor targets instead of resetting to the 15 minute bootstrap interval when controller text changes.
- Add scheduler state ack smoke coverage for unchanged monitor-window identity across changed goal-level recommended action text.

## Changed surfaces

- `loopx/control_plane/scheduler/scheduler_hint.py`: scheduler identity key selection for `monitor_wait`.
- `examples/control_plane/quota-scheduler-state-ack-smoke.py`: regression smoke for stable monitor identity.

## Validation

- `python3 -m py_compile loopx/control_plane/scheduler/scheduler_hint.py`
- `python3 examples/control_plane/quota-scheduler-state-ack-smoke.py`
- `python3 examples/control_plane/monitor-scheduler-contract-smoke.py`
- `python3 examples/control_plane/quota-scheduler-policy-smoke.py`
- `python3 examples/control_plane/quota-scheduler-hint-compaction-smoke.py`
- `python3 examples/control_plane/hot-path-interface-budget-smoke.py`
- `python3 examples/control_plane/quota-plan-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `loopx check --scan-path loopx/control_plane/scheduler --scan-path examples/control_plane/quota-scheduler-state-ack-smoke.py`
- `loopx canary premerge --from-git-diff` passed: selected=17, failures=0, manual_holds=0, self_merge_allowed=true.

## Coverage rationale

This is a narrow scheduler runtime change. The focused smoke proves the reported failure mode: an unchanged monitor window now progresses from 15m to 30m when only goal-level `recommended_action` changes, while existing policy-state smoke still proves non-monitor wait lanes reset on `recommended_action` changes. The adjacent scheduler, quota plan, compaction, interface-budget, integrated canary, public-boundary, and premerge risk checks passed with no skips or manual holds.
