### PR TITLE
Split registry authority CLI commands

### DIFF
--- a/examples/cli-registry-admin-command-modularization-smoke.py
+++ b/examples/cli-registry-admin-command-modularization-smoke.py
@@ -12,6 +12,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 CLI = ROOT / "loopx" / "cli.py"
 MODULE = ROOT / "loopx" / "cli_commands" / "registry_admin.py"
+AUTHORITY_MODULE = ROOT / "loopx" / "cli_commands" / "registry_authority.py"
 INIT = ROOT / "loopx" / "cli_commands" / "__init__.py"
 GOAL_ID = "registry-admin-smoke"
 
@@ -134,6 +135,8 @@ def write_fixture(project: Path) -> tuple[Path, Path, Path, Path]:
 def main() -> None:
     cli_source = CLI.read_text(encoding="utf-8")
     module_source = MODULE.read_text(encoding="utf-8")
+    authority_source = AUTHORITY_MODULE.read_text(encoding="utf-8")
+    registry_admin_family_source = module_source + "\n" + authority_source
     init_source = INIT.read_text(encoding="utf-8")
 
     forbidden_cli_markers = [
@@ -175,7 +178,19 @@ def main() -> None:
         "register-authority-source",
         "import-doc-registry-authority",
     ):
-        require(marker in module_source, f"registry admin module missing {marker}")
+        require(marker in registry_admin_family_source, f"registry admin command family missing {marker}")
+    for marker in (
+        "REGISTRY_AUTHORITY_COMMANDS",
+        "register_registry_authority_commands",
+        "handle_registry_authority_command",
+        'if args.command == "register-authority-source":',
+        'if args.command != "import-doc-registry-authority":',
+        "register_authority_source(",
+        "import_doc_registry_authority(",
+    ):
+        require(marker in authority_source, f"registry authority module missing {marker}")
+    for marker in ("register_registry_authority_commands", "handle_registry_authority_command"):
+        require(marker in module_source, f"registry admin module should delegate authority commands through {marker}")
     require("register_registry_admin_commands" in cli_source, "cli.py did not register registry admin commands")
     require("handle_registry_admin_command" in cli_source, "cli.py did not dispatch registry admin commands")
     require("register_registry_admin_commands" in init_source, "__init__ did not export registry admin registration")

--- a/loopx/cli_commands/registry_admin.py
+++ b/loopx/cli_commands/registry_admin.py
@@ -8,13 +8,6 @@ from ..agent_registry import (
     normalize_registered_agents,
     primary_agent_id_from_registry,
 )
-from ..authority import (
-    AUTHORITY_SOURCE_BOUNDARIES,
-    import_doc_registry_authority,
-    register_authority_source,
-    render_doc_registry_authority_import_markdown,
-    render_authority_source_markdown,
-)
 from ..configure_goal import configure_goal, render_configure_goal_markdown
 from ..global_registry import render_global_sync_markdown, sync_project_registry_to_global
 from ..history import load_registry
@@ -32,6 +25,11 @@ from ..state_migration import (
     render_state_migration_markdown,
 )
 from ..upgrade import build_upgrade_plan
+from .registry_authority import (
+    REGISTRY_AUTHORITY_COMMANDS,
+    handle_registry_authority_command,
+    register_registry_authority_commands,
+)
 
 
 PrintPayload = Callable[
@@ -46,9 +44,7 @@ REGISTRY_ADMIN_COMMANDS = {
     "uninstall-project",
     "sync-global",
     "migrate-state",
-    "register-authority-source",
-    "import-doc-registry-authority",
-}
+} | REGISTRY_AUTHORITY_COMMANDS
 
 
 def explicit_global_registry(runtime_root_arg: str | None) -> Path:
@@ -554,97 +550,7 @@ def register_registry_admin_commands(subparsers: argparse._SubParsersAction) -> 
         help="Write migrated state. Without this flag the command is a dry-run preview.",
     )
 
-    authority_parser = subparsers.add_parser(
-        "register-authority-source",
-        help="Register a redacted local authority/material source for a goal.",
-    )
-    authority_parser.add_argument("--goal-id", required=True, help="Goal id whose local registry should be updated.")
-    authority_parser.add_argument("--source-id", required=True, help="Stable local source id.")
-    authority_parser.add_argument(
-        "--source-ref",
-        help="Raw local source reference to hash and redact. The raw value is never stored.",
-    )
-    authority_parser.add_argument("--source-kind", required=True, help="Public-safe source kind, such as doc or repository.")
-    authority_parser.add_argument("--role", required=True, help="Public-safe material role.")
-    authority_parser.add_argument("--freshness", required=True, help="Public-safe freshness state.")
-    authority_parser.add_argument("--owner-status", help="Optional public-safe owner/review status.")
-    authority_parser.add_argument("--gate-status", help="Optional public-safe gate status.")
-    authority_parser.add_argument(
-        "--boundary",
-        choices=sorted(AUTHORITY_SOURCE_BOUNDARIES),
-        default="private_redacted",
-        help="Public/private boundary for this source. Defaults to private_redacted.",
-    )
-    authority_parser.add_argument("--revision", help="Optional public-safe revision label.")
-    authority_parser.add_argument("--conflict-rule", help="Optional public-safe conflict rule.")
-    authority_parser.add_argument("--topic", help="Optional topic_authority key to map to this source id.")
-    authority_parser.add_argument("--dry-run", action="store_true", help="Preview the registry update without writing.")
-    authority_parser.add_argument(
-        "--no-global-sync",
-        action="store_true",
-        help="Do not refresh the shared global registry after writing the local source registry.",
-    )
-
-    doc_registry_authority_parser = subparsers.add_parser(
-        "import-doc-registry-authority",
-        help="Import a redacted DOC_REGISTRY summary as a local authority/material source.",
-    )
-    doc_registry_authority_parser.add_argument(
-        "--goal-id", required=True, help="Goal id whose local registry should be updated."
-    )
-    doc_registry_authority_parser.add_argument("--source-id", required=True, help="Stable local source id.")
-    doc_registry_authority_parser.add_argument(
-        "--doc-registry-path",
-        required=True,
-        help="Local DOC_REGISTRY.yaml path to read. The raw path is hashed and not stored.",
-    )
-    doc_registry_authority_parser.add_argument(
-        "--source-kind",
-        default="doc_registry",
-        help="Public-safe source kind. Defaults to doc_registry.",
-    )
-    doc_registry_authority_parser.add_argument(
-        "--role",
-        default="external_doc_authority_registry",
-        help="Public-safe material role. Defaults to external_doc_authority_registry.",
-    )
-    doc_registry_authority_parser.add_argument(
-        "--freshness",
-        default="current",
-        help="Public-safe freshness state. Defaults to current.",
-    )
-    doc_registry_authority_parser.add_argument("--owner-status", help="Optional public-safe owner/review status.")
-    doc_registry_authority_parser.add_argument("--gate-status", help="Optional public-safe gate status.")
-    doc_registry_authority_parser.add_argument(
-        "--boundary",
-        choices=sorted(AUTHORITY_SOURCE_BOUNDARIES),
-        default="private_redacted",
-        help="Public/private boundary for this source. Defaults to private_redacted.",
-    )
-    doc_registry_authority_parser.add_argument("--revision", help="Optional public-safe revision label.")
-    doc_registry_authority_parser.add_argument("--conflict-rule", help="Optional public-safe conflict rule.")
-    doc_registry_authority_parser.add_argument(
-        "--topic",
-        action="append",
-        default=[],
-        help="Additional local topic_authority key to map to this source id. Repeatable.",
-    )
-    doc_registry_authority_parser.add_argument(
-        "--import-topic-prefix",
-        help="Prefix imported DOC_REGISTRY topic keys with this value before mapping them to the source id.",
-    )
-    doc_registry_authority_parser.add_argument(
-        "--max-imported-topics",
-        type=int,
-        default=50,
-        help="Maximum DOC_REGISTRY topics to map when --import-topic-prefix is set. Defaults to 50.",
-    )
-    doc_registry_authority_parser.add_argument("--dry-run", action="store_true", help="Preview without writing.")
-    doc_registry_authority_parser.add_argument(
-        "--no-global-sync",
-        action="store_true",
-        help="Do not refresh the shared global registry after writing the local source registry.",
-    )
+    register_registry_authority_commands(subparsers)
 
 
 def handle_registry_admin_command(
@@ -864,91 +770,8 @@ def handle_registry_admin_command(
         print_payload(payload, args.format, render_state_migration_markdown)
         return 0 if payload.get("ok") else 1
 
-    if args.command == "register-authority-source":
-        try:
-            payload = register_authority_source(
-                registry_path=registry_path,
-                goal_id=args.goal_id,
-                source_id=args.source_id,
-                source_ref=args.source_ref,
-                source_kind=args.source_kind,
-                role=args.role,
-                freshness=args.freshness,
-                owner_status=args.owner_status,
-                gate_status=args.gate_status,
-                boundary=args.boundary,
-                revision=args.revision,
-                conflict_rule=args.conflict_rule,
-                topic=args.topic,
-                dry_run=bool(args.dry_run),
-            )
-            if not bool(args.no_global_sync):
-                if args.dry_run:
-                    payload["global_sync"] = {"enabled": True, "dry_run": True, "wrote": False}
-                else:
-                    payload["global_sync"] = sync_project_registry_to_global(
-                        registry_path=registry_path,
-                        runtime_root_override=args.runtime_root,
-                        goal_id=args.goal_id,
-                        dry_run=False,
-                    )
-            else:
-                payload["global_sync"] = {"enabled": False}
-        except Exception as exc:
-            payload = {
-                "ok": False,
-                "registry": str(registry_path),
-                "runtime_root": args.runtime_root,
-                "goal_id": args.goal_id,
-                "source_id": getattr(args, "source_id", None),
-                "written": False,
-                "dry_run": bool(getattr(args, "dry_run", False)),
-                "error": str(exc),
-            }
-        print_payload(payload, args.format, render_authority_source_markdown)
-        return 0 if payload.get("ok") else 1
-
-    try:
-        payload = import_doc_registry_authority(
-            registry_path=registry_path,
-            goal_id=args.goal_id,
-            source_id=args.source_id,
-            doc_registry_path=Path(args.doc_registry_path),
-            source_kind=args.source_kind,
-            role=args.role,
-            freshness=args.freshness,
-            owner_status=args.owner_status,
-            gate_status=args.gate_status,
-            boundary=args.boundary,
-            revision=args.revision,
-            conflict_rule=args.conflict_rule,
-            topics=list(args.topic or []),
-            import_topic_prefix=args.import_topic_prefix,
-            max_imported_topics=int(args.max_imported_topics),
-            dry_run=bool(args.dry_run),
-        )
-        if not bool(args.no_global_sync):
-            if args.dry_run:
-                payload["global_sync"] = {"enabled": True, "dry_run": True, "wrote": False}
-            else:
-                payload["global_sync"] = sync_project_registry_to_global(
-                    registry_path=registry_path,
-                    runtime_root_override=args.runtime_root,
-                    goal_id=args.goal_id,
-                    dry_run=False,
-                )
-        else:
-            payload["global_sync"] = {"enabled": False}
-    except Exception as exc:
-        payload = {
-            "ok": False,
-            "registry": str(registry_path),
-            "runtime_root": args.runtime_root,
-            "goal_id": args.goal_id,
-            "source_id": getattr(args, "source_id", None),
-            "written": False,
-            "dry_run": bool(getattr(args, "dry_run", False)),
-            "error": str(exc),
-        }
-    print_payload(payload, args.format, render_doc_registry_authority_import_markdown)
-    return 0 if payload.get("ok") else 1
+    return handle_registry_authority_command(
+        args,
+        registry_path=registry_path,
+        print_payload=print_payload,
+    )

--- a/loopx/cli_commands/registry_authority.py
+++ b/loopx/cli_commands/registry_authority.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+from ..authority import (
+    AUTHORITY_SOURCE_BOUNDARIES,
+    import_doc_registry_authority,
+    register_authority_source,
+    render_doc_registry_authority_import_markdown,
+    render_authority_source_markdown,
+)
+from ..global_registry import sync_project_registry_to_global
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+
+REGISTRY_AUTHORITY_COMMANDS = {
+    "register-authority-source",
+    "import-doc-registry-authority",
+}
+
+
+def register_registry_authority_commands(subparsers: argparse._SubParsersAction) -> None:
+    authority_parser = subparsers.add_parser(
+        "register-authority-source",
+        help="Register a redacted local authority/material source for a goal.",
+    )
+    authority_parser.add_argument("--goal-id", required=True, help="Goal id whose local registry should be updated.")
+    authority_parser.add_argument("--source-id", required=True, help="Stable local source id.")
+    authority_parser.add_argument(
+        "--source-ref",
+        help="Raw local source reference to hash and redact. The raw value is never stored.",
+    )
+    authority_parser.add_argument("--source-kind", required=True, help="Public-safe source kind, such as doc or repository.")
+    authority_parser.add_argument("--role", required=True, help="Public-safe material role.")
+    authority_parser.add_argument("--freshness", required=True, help="Public-safe freshness state.")
+    authority_parser.add_argument("--owner-status", help="Optional public-safe owner/review status.")
+    authority_parser.add_argument("--gate-status", help="Optional public-safe gate status.")
+    authority_parser.add_argument(
+        "--boundary",
+        choices=sorted(AUTHORITY_SOURCE_BOUNDARIES),
+        default="private_redacted",
+        help="Public/private boundary for this source. Defaults to private_redacted.",
+    )
+    authority_parser.add_argument("--revision", help="Optional public-safe revision label.")
+    authority_parser.add_argument("--conflict-rule", help="Optional public-safe conflict rule.")
+    authority_parser.add_argument("--topic", help="Optional topic_authority key to map to this source id.")
+    authority_parser.add_argument("--dry-run", action="store_true", help="Preview the registry update without writing.")
+    authority_parser.add_argument(
+        "--no-global-sync",
+        action="store_true",
+        help="Do not refresh the shared global registry after writing the local source registry.",
+    )
+
+    doc_registry_authority_parser = subparsers.add_parser(
+        "import-doc-registry-authority",
+        help="Import a redacted DOC_REGISTRY summary as a local authority/material source.",
+    )
+    doc_registry_authority_parser.add_argument(
+        "--goal-id", required=True, help="Goal id whose local registry should be updated."
+    )
+    doc_registry_authority_parser.add_argument("--source-id", required=True, help="Stable local source id.")
+    doc_registry_authority_parser.add_argument(
+        "--doc-registry-path",
+        required=True,
+        help="Local DOC_REGISTRY.yaml path to read. The raw path is hashed and not stored.",
+    )
+    doc_registry_authority_parser.add_argument(
+        "--source-kind",
+        default="doc_registry",
+        help="Public-safe source kind. Defaults to doc_registry.",
+    )
+    doc_registry_authority_parser.add_argument(
+        "--role",
+        default="external_doc_authority_registry",
+        help="Public-safe material role. Defaults to external_doc_authority_registry.",
+    )
+    doc_registry_authority_parser.add_argument(
+        "--freshness",
+        default="current",
+        help="Public-safe freshness state. Defaults to current.",
+    )
+    doc_registry_authority_parser.add_argument("--owner-status", help="Optional public-safe owner/review status.")
+    doc_registry_authority_parser.add_argument("--gate-status", help="Optional public-safe gate status.")
+    doc_registry_authority_parser.add_argument(
+        "--boundary",
+        choices=sorted(AUTHORITY_SOURCE_BOUNDARIES),
+        default="private_redacted",
+        help="Public/private boundary for this source. Defaults to private_redacted.",
+    )
+    doc_registry_authority_parser.add_argument("--revision", help="Optional public-safe revision label.")
+    doc_registry_authority_parser.add_argument("--conflict-rule", help="Optional public-safe conflict rule.")
+    doc_registry_authority_parser.add_argument(
+        "--topic",
+        action="append",
+        default=[],
+        help="Additional local topic_authority key to map to this source id. Repeatable.",
+    )
+    doc_registry_authority_parser.add_argument(
+        "--import-topic-prefix",
+        help="Prefix imported DOC_REGISTRY topic keys with this value before mapping them to the source id.",
+    )
+    doc_registry_authority_parser.add_argument(
+        "--max-imported-topics",
+        type=int,
+        default=50,
+        help="Maximum DOC_REGISTRY topics to map when --import-topic-prefix is set. Defaults to 50.",
+    )
+    doc_registry_authority_parser.add_argument("--dry-run", action="store_true", help="Preview without writing.")
+    doc_registry_authority_parser.add_argument(
+        "--no-global-sync",
+        action="store_true",
+        help="Do not refresh the shared global registry after writing the local source registry.",
+    )
+
+
+def handle_registry_authority_command(
+    args: argparse.Namespace,
+    *,
+    registry_path: Path,
+    print_payload: PrintPayload,
+) -> int | None:
+    if args.command == "register-authority-source":
+        try:
+            payload = register_authority_source(
+                registry_path=registry_path,
+                goal_id=args.goal_id,
+                source_id=args.source_id,
+                source_ref=args.source_ref,
+                source_kind=args.source_kind,
+                role=args.role,
+                freshness=args.freshness,
+                owner_status=args.owner_status,
+                gate_status=args.gate_status,
+                boundary=args.boundary,
+                revision=args.revision,
+                conflict_rule=args.conflict_rule,
+                topic=args.topic,
+                dry_run=bool(args.dry_run),
+            )
+            if not bool(args.no_global_sync):
+                if args.dry_run:
+                    payload["global_sync"] = {"enabled": True, "dry_run": True, "wrote": False}
+                else:
+                    payload["global_sync"] = sync_project_registry_to_global(
+                        registry_path=registry_path,
+                        runtime_root_override=args.runtime_root,
+                        goal_id=args.goal_id,
+                        dry_run=False,
+                    )
+            else:
+                payload["global_sync"] = {"enabled": False}
+        except Exception as exc:
+            payload = {
+                "ok": False,
+                "registry": str(registry_path),
+                "runtime_root": args.runtime_root,
+                "goal_id": args.goal_id,
+                "source_id": getattr(args, "source_id", None),
+                "written": False,
+                "dry_run": bool(getattr(args, "dry_run", False)),
+                "error": str(exc),
+            }
+        print_payload(payload, args.format, render_authority_source_markdown)
+        return 0 if payload.get("ok") else 1
+
+    if args.command != "import-doc-registry-authority":
+        return None
+
+    try:
+        payload = import_doc_registry_authority(
+            registry_path=registry_path,
+            goal_id=args.goal_id,
+            source_id=args.source_id,
+            doc_registry_path=Path(args.doc_registry_path),
+            source_kind=args.source_kind,
+            role=args.role,
+            freshness=args.freshness,
+            owner_status=args.owner_status,
+            gate_status=args.gate_status,
+            boundary=args.boundary,
+            revision=args.revision,
+            conflict_rule=args.conflict_rule,
+            topics=list(args.topic or []),
+            import_topic_prefix=args.import_topic_prefix,
+            max_imported_topics=int(args.max_imported_topics),
+            dry_run=bool(args.dry_run),
+        )
+        if not bool(args.no_global_sync):
+            if args.dry_run:
+                payload["global_sync"] = {"enabled": True, "dry_run": True, "wrote": False}
+            else:
+                payload["global_sync"] = sync_project_registry_to_global(
+                    registry_path=registry_path,
+                    runtime_root_override=args.runtime_root,
+                    goal_id=args.goal_id,
+                    dry_run=False,
+                )
+        else:
+            payload["global_sync"] = {"enabled": False}
+    except Exception as exc:
+        payload = {
+            "ok": False,
+            "registry": str(registry_path),
+            "runtime_root": args.runtime_root,
+            "goal_id": args.goal_id,
+            "source_id": getattr(args, "source_id", None),
+            "written": False,
+            "dry_run": bool(getattr(args, "dry_run", False)),
+            "error": str(exc),
+        }
+    print_payload(payload, args.format, render_doc_registry_authority_import_markdown)
+    return 0 if payload.get("ok") else 1


### PR DESCRIPTION
## Summary
- move `register-authority-source` and `import-doc-registry-authority` parser/handler logic into `loopx/cli_commands/registry_authority.py`
- keep `registry_admin.py` as the aggregate registry-admin dispatcher, delegating authority commands through the new bounded module
- update the registry-admin modularization smoke to cover the split command family

## Diff Notes
- `registry_admin.py` drops from 954 lines to 777 lines, under its existing 780-line legacy budget
- new `registry_authority.py` is 218 lines and owns only redacted authority-source CLI registration/dispatch
- no benchmark/canary/runtime scoring paths changed

## Validation
- `python3 -m py_compile loopx/cli_commands/registry_admin.py loopx/cli_commands/registry_authority.py examples/cli-registry-admin-command-modularization-smoke.py`
- `python3 examples/cli-registry-admin-command-modularization-smoke.py`
- `python3 examples/register-authority-source-smoke.py`
- `python3 examples/import-doc-registry-authority-smoke.py`
- targeted registry authority budget/ownership subset check
- `git diff --check`
- `loopx check --scan-path loopx/cli_commands/registry_admin.py --scan-path loopx/cli_commands/registry_authority.py --scan-path examples/cli-registry-admin-command-modularization-smoke.py`
- `loopx canary premerge --from-git-diff` (passed, self_merge_allowed=true)

## Notes
- The broad `examples/cli-command-module-size-ownership-command-modularization-smoke.py` still has an unrelated pre-existing benchmark budget failure (`benchmark_run_ledger.py` 851 > 820). This PR deliberately does not touch benchmark surfaces.
