### PR TITLE
Split content-ops connector packet contracts

### DIFF
--- a/examples/control_plane/repo-python-line-budget-smoke.py
+++ b/examples/control_plane/repo-python-line-budget-smoke.py
@@ -62,7 +62,6 @@ LEGACY_OVERSIZED_LIMITS = {
     "loopx/benchmark_adapters/skillsbench_acp_relay.py": 4005,
     "loopx/benchmark_adapters/terminal_bench.py": 10083,
     "loopx/benchmark_ledger.py": 3745,
-    "loopx/capabilities/content_ops/surface.py": 2113,
     "loopx/presentation/sinks/lark/kanban.py": 2614,
     "loopx/codex_cli_probe.py": 2643,
     "loopx/quota.py": 2455,

--- a/loopx/capabilities/content_ops/connector_packets.py
+++ b/loopx/capabilities/content_ops/connector_packets.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .schemas import (
+    CONNECTOR_TRIAL_SCHEMA_VERSION,
+    CONTENT_OPS_PRIVATE_CONNECTOR_GATE_PACKET_SCHEMA_VERSION,
+    CONTENT_OPS_PUBLIC_HANDLE_OBSERVATION_PACKET_SCHEMA_VERSION,
+)
+
+
+def _require_packet_flag(payload: Mapping[str, Any], key: str, expected: Any) -> None:
+    if payload.get(key) != expected:
+        raise ValueError(f"packet {key} must be {expected!r}")
+
+
+def _connector_trial_from_public_packet(
+    packet: Mapping[str, Any],
+    source_item: Mapping[str, Any],
+    runtime_policy: Mapping[str, Any],
+    index: int,
+) -> dict[str, Any]:
+    observation = (
+        packet.get("observation")
+        if isinstance(packet.get("observation"), Mapping)
+        else {}
+    )
+    surface = str(packet.get("surface") or observation.get("surface") or "public_feed")
+    source_item_id = str(source_item.get("source_item_id") or "").strip()
+    if not source_item_id:
+        raise ValueError("public handle packet source_item_id is required")
+    return {
+        "schema_version": CONNECTOR_TRIAL_SCHEMA_VERSION,
+        "trial_id": f"trial_public_packet_{index + 1}",
+        "surface": surface,
+        "tool_hint": str(
+            runtime_policy.get("connector_name") or "public metadata connector"
+        ),
+        "access_mode": "public_metadata_only",
+        "source_status": str(source_item.get("source_status") or "public"),
+        "freshness": str(source_item.get("freshness") or "unknown"),
+        "allowed_use": str(source_item.get("allowed_use") or "metadata_only"),
+        "trial_state": "metadata_packet_collected",
+        "proposed_source_item_id": source_item_id,
+        "terms_note": str(
+            source_item.get("terms_note")
+            or "metadata-only public source packet already collected"
+        ),
+        "promotion_target": "source_item_v0",
+        "requires_user_gate": False,
+        "external_write_allowed": False,
+    }
+
+
+def _connector_trial_from_private_gate_packet(
+    packet: Mapping[str, Any],
+    source_item: Mapping[str, Any],
+    index: int,
+) -> dict[str, Any]:
+    connector = (
+        packet.get("connector")
+        if isinstance(packet.get("connector"), Mapping)
+        else {}
+    )
+    source_item_id = str(source_item.get("source_item_id") or "").strip()
+    if not source_item_id:
+        raise ValueError("private connector gate source_item_id is required")
+    return {
+        "schema_version": CONNECTOR_TRIAL_SCHEMA_VERSION,
+        "trial_id": f"trial_private_gate_packet_{index + 1}",
+        "surface": str(
+            packet.get("surface") or connector.get("surface") or "private_archive"
+        ),
+        "tool_hint": str(
+            connector.get("connector_name") or "private metadata connector"
+        ),
+        "access_mode": "private_metadata_only",
+        "source_status": "private_needs_review",
+        "freshness": str(source_item.get("freshness") or "unknown"),
+        "allowed_use": "metadata_only",
+        "trial_state": "needs_owner_gate",
+        "proposed_source_item_id": source_item_id,
+        "terms_note": str(
+            source_item.get("terms_note")
+            or "private connector metadata remains gated before source use"
+        ),
+        "promotion_target": "source_item_v0_after_owner_gate",
+        "requires_user_gate": True,
+        "external_write_allowed": False,
+    }
+
+
+def source_item_and_trial_from_public_packet(
+    packet: Mapping[str, Any],
+    index: int,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if (
+        packet.get("schema_version")
+        != CONTENT_OPS_PUBLIC_HANDLE_OBSERVATION_PACKET_SCHEMA_VERSION
+    ):
+        raise ValueError(
+            "public packet schema_version must be "
+            "content_ops_public_handle_observation_packet_v0"
+        )
+    _require_packet_flag(packet, "ok", True)
+    _require_packet_flag(packet, "external_writes_performed", False)
+    _require_packet_flag(packet, "private_source_content_read", False)
+    _require_packet_flag(packet, "autopublish_allowed", False)
+    runtime_policy = (
+        packet.get("runtime_policy")
+        if isinstance(packet.get("runtime_policy"), Mapping)
+        else {}
+    )
+    if runtime_policy.get("safe_default") != "head_only_metadata_probe":
+        raise ValueError("public packet runtime policy must be HEAD-only")
+    if runtime_policy.get("browser_open_allowed_before_gate") is not False:
+        raise ValueError("public packet must not allow browser open before gate")
+    source_item = packet.get("source_item")
+    if not isinstance(source_item, Mapping):
+        raise ValueError("public packet must include source_item")
+    return dict(source_item), _connector_trial_from_public_packet(
+        packet,
+        source_item,
+        runtime_policy,
+        index,
+    )
+
+
+def source_item_and_trial_from_private_gate_packet(
+    packet: Mapping[str, Any],
+    index: int,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    if (
+        packet.get("schema_version")
+        != CONTENT_OPS_PRIVATE_CONNECTOR_GATE_PACKET_SCHEMA_VERSION
+    ):
+        raise ValueError(
+            "private gate packet schema_version must be "
+            "content_ops_private_connector_gate_packet_v0"
+        )
+    _require_packet_flag(packet, "ok", True)
+    _require_packet_flag(packet, "owner_gate_required", True)
+    _require_packet_flag(packet, "external_reads_performed", False)
+    _require_packet_flag(packet, "external_writes_performed", False)
+    _require_packet_flag(packet, "private_source_content_read", False)
+    _require_packet_flag(packet, "autopublish_allowed", False)
+    runtime_policy = (
+        packet.get("runtime_policy")
+        if isinstance(packet.get("runtime_policy"), Mapping)
+        else {}
+    )
+    if runtime_policy.get("safe_default") != "gate_projection_only":
+        raise ValueError("private packet runtime policy must be gate-only")
+    if runtime_policy.get("browser_open_allowed_before_gate") is not False:
+        raise ValueError("private packet must not allow browser open before gate")
+    source_item = packet.get("source_item")
+    if not isinstance(source_item, Mapping):
+        raise ValueError("private gate packet must include source_item")
+    return dict(source_item), _connector_trial_from_private_gate_packet(
+        packet,
+        source_item,
+        index,
+    )

--- a/loopx/capabilities/content_ops/schemas.py
+++ b/loopx/capabilities/content_ops/schemas.py
@@ -1,0 +1,40 @@
+"""Schema identifiers for content-ops packets and state surfaces."""
+
+CONTENT_OPS_SURFACE_SCHEMA_VERSION = "content_ops_surface_v0"
+CONTENT_OPS_SURFACE_PROJECTION_SCHEMA_VERSION = "content_ops_surface_projection_v0"
+CONTENT_OPS_PREVIEW_PACKET_SCHEMA_VERSION = "content_ops_preview_packet_v0"
+CONTENT_OPS_PUBLIC_HANDLE_OBSERVATION_PACKET_SCHEMA_VERSION = (
+    "content_ops_public_handle_observation_packet_v0"
+)
+CONTENT_OPS_PUBLIC_HANDLE_OBSERVATION_SCHEMA_VERSION = (
+    "content_ops_public_handle_observation_v0"
+)
+CONTENT_OPS_PRIVATE_CONNECTOR_GATE_PACKET_SCHEMA_VERSION = (
+    "content_ops_private_connector_gate_packet_v0"
+)
+CONTENT_OPS_PRIVATE_CONNECTOR_OWNER_GATE_SCHEMA_VERSION = (
+    "content_ops_private_connector_owner_gate_v0"
+)
+CONTENT_OPS_CONNECTOR_RUNTIME_POLICY_SCHEMA_VERSION = (
+    "content_ops_connector_runtime_policy_v0"
+)
+CONTENT_OPS_PACKET_AGGREGATION_SCHEMA_VERSION = "content_ops_packet_aggregation_v0"
+CONTENT_OPS_CHATVIEW_CONNECTOR_REPORT_SCHEMA_VERSION = (
+    "content_ops_chatview_connector_report_v0"
+)
+CONTENT_OPS_WALKTHROUGH_ARTIFACT_SCHEMA_VERSION = (
+    "content_ops_walkthrough_artifact_v0"
+)
+CONTENT_OPS_EXPLORATION_PLAN_PACKET_SCHEMA_VERSION = (
+    "content_ops_exploration_plan_packet_v0"
+)
+EXPLORATION_PLAN_SCHEMA_VERSION = "exploration_plan_v0"
+
+SOURCE_ITEM_SCHEMA_VERSION = "source_item_v0"
+ANGLE_CANDIDATE_SCHEMA_VERSION = "angle_candidate_v0"
+DRAFT_ITEM_SCHEMA_VERSION = "draft_item_v0"
+FEEDBACK_SIGNAL_SCHEMA_VERSION = "feedback_signal_v0"
+PUBLISH_GATE_SCHEMA_VERSION = "publish_gate_v0"
+MATERIAL_MEMORY_SCHEMA_VERSION = "material_memory_v0"
+CONNECTOR_TRIAL_SCHEMA_VERSION = "connector_trial_v0"
+CONTENT_OPS_VALIDATION_SCHEMA_VERSION = "content_ops_surface_validation_v0"

--- a/loopx/capabilities/content_ops/surface.py
+++ b/loopx/capabilities/content_ops/surface.py
@@ -9,6 +9,10 @@ from urllib.parse import urljoin, urlsplit, urlunsplit
 from urllib.request import HTTPRedirectHandler, Request, build_opener
 
 
+from .connector_packets import (
+    source_item_and_trial_from_private_gate_packet,
+    source_item_and_trial_from_public_packet,
+)
 from .markdown import (
     render_content_ops_chatview_report_markdown,
     render_content_ops_exploration_plan_markdown,
@@ -18,45 +22,29 @@ from .markdown import (
     render_content_ops_public_handle_observation_markdown,
     render_content_ops_walkthrough_artifact_markdown,
 )
-
-CONTENT_OPS_SURFACE_SCHEMA_VERSION = "content_ops_surface_v0"
-CONTENT_OPS_SURFACE_PROJECTION_SCHEMA_VERSION = "content_ops_surface_projection_v0"
-CONTENT_OPS_PREVIEW_PACKET_SCHEMA_VERSION = "content_ops_preview_packet_v0"
-CONTENT_OPS_PUBLIC_HANDLE_OBSERVATION_PACKET_SCHEMA_VERSION = (
-    "content_ops_public_handle_observation_packet_v0"
+from .schemas import (
+    ANGLE_CANDIDATE_SCHEMA_VERSION,
+    CONNECTOR_TRIAL_SCHEMA_VERSION,
+    CONTENT_OPS_CHATVIEW_CONNECTOR_REPORT_SCHEMA_VERSION,
+    CONTENT_OPS_CONNECTOR_RUNTIME_POLICY_SCHEMA_VERSION,
+    CONTENT_OPS_EXPLORATION_PLAN_PACKET_SCHEMA_VERSION,
+    CONTENT_OPS_PACKET_AGGREGATION_SCHEMA_VERSION,
+    CONTENT_OPS_PREVIEW_PACKET_SCHEMA_VERSION,
+    CONTENT_OPS_PRIVATE_CONNECTOR_GATE_PACKET_SCHEMA_VERSION,
+    CONTENT_OPS_PRIVATE_CONNECTOR_OWNER_GATE_SCHEMA_VERSION,
+    CONTENT_OPS_PUBLIC_HANDLE_OBSERVATION_PACKET_SCHEMA_VERSION,
+    CONTENT_OPS_PUBLIC_HANDLE_OBSERVATION_SCHEMA_VERSION,
+    CONTENT_OPS_SURFACE_PROJECTION_SCHEMA_VERSION,
+    CONTENT_OPS_SURFACE_SCHEMA_VERSION,
+    CONTENT_OPS_VALIDATION_SCHEMA_VERSION,
+    CONTENT_OPS_WALKTHROUGH_ARTIFACT_SCHEMA_VERSION,
+    DRAFT_ITEM_SCHEMA_VERSION,
+    EXPLORATION_PLAN_SCHEMA_VERSION,
+    FEEDBACK_SIGNAL_SCHEMA_VERSION,
+    MATERIAL_MEMORY_SCHEMA_VERSION,
+    PUBLISH_GATE_SCHEMA_VERSION,
+    SOURCE_ITEM_SCHEMA_VERSION,
 )
-CONTENT_OPS_PUBLIC_HANDLE_OBSERVATION_SCHEMA_VERSION = (
-    "content_ops_public_handle_observation_v0"
-)
-CONTENT_OPS_PRIVATE_CONNECTOR_GATE_PACKET_SCHEMA_VERSION = (
-    "content_ops_private_connector_gate_packet_v0"
-)
-CONTENT_OPS_PRIVATE_CONNECTOR_OWNER_GATE_SCHEMA_VERSION = (
-    "content_ops_private_connector_owner_gate_v0"
-)
-CONTENT_OPS_CONNECTOR_RUNTIME_POLICY_SCHEMA_VERSION = (
-    "content_ops_connector_runtime_policy_v0"
-)
-CONTENT_OPS_PACKET_AGGREGATION_SCHEMA_VERSION = "content_ops_packet_aggregation_v0"
-CONTENT_OPS_CHATVIEW_CONNECTOR_REPORT_SCHEMA_VERSION = (
-    "content_ops_chatview_connector_report_v0"
-)
-CONTENT_OPS_WALKTHROUGH_ARTIFACT_SCHEMA_VERSION = (
-    "content_ops_walkthrough_artifact_v0"
-)
-CONTENT_OPS_EXPLORATION_PLAN_PACKET_SCHEMA_VERSION = (
-    "content_ops_exploration_plan_packet_v0"
-)
-EXPLORATION_PLAN_SCHEMA_VERSION = "exploration_plan_v0"
-
-SOURCE_ITEM_SCHEMA_VERSION = "source_item_v0"
-ANGLE_CANDIDATE_SCHEMA_VERSION = "angle_candidate_v0"
-DRAFT_ITEM_SCHEMA_VERSION = "draft_item_v0"
-FEEDBACK_SIGNAL_SCHEMA_VERSION = "feedback_signal_v0"
-PUBLISH_GATE_SCHEMA_VERSION = "publish_gate_v0"
-MATERIAL_MEMORY_SCHEMA_VERSION = "material_memory_v0"
-CONNECTOR_TRIAL_SCHEMA_VERSION = "connector_trial_v0"
-CONTENT_OPS_VALIDATION_SCHEMA_VERSION = "content_ops_surface_validation_v0"
 
 RAW_MATERIAL_KEY_HINTS = (
     "body",
@@ -1579,95 +1567,6 @@ def build_content_ops_chatview_report_packet(
     return packet
 
 
-def _require_packet_flag(payload: Mapping[str, Any], key: str, expected: Any) -> None:
-    if payload.get(key) != expected:
-        raise ValueError(f"packet {key} must be {expected!r}")
-
-
-def _connector_trial_from_public_packet(
-    packet: Mapping[str, Any],
-    index: int,
-) -> dict[str, Any]:
-    source_item = packet.get("source_item")
-    if not isinstance(source_item, Mapping):
-        raise ValueError("public handle packet must include source_item")
-    observation = (
-        packet.get("observation")
-        if isinstance(packet.get("observation"), Mapping)
-        else {}
-    )
-    runtime_policy = (
-        packet.get("runtime_policy")
-        if isinstance(packet.get("runtime_policy"), Mapping)
-        else {}
-    )
-    surface = str(packet.get("surface") or observation.get("surface") or "public_feed")
-    source_item_id = str(source_item.get("source_item_id") or "").strip()
-    if not source_item_id:
-        raise ValueError("public handle packet source_item_id is required")
-    return {
-        "schema_version": CONNECTOR_TRIAL_SCHEMA_VERSION,
-        "trial_id": f"trial_public_packet_{index + 1}",
-        "surface": surface,
-        "tool_hint": str(
-            runtime_policy.get("connector_name") or "public metadata connector"
-        ),
-        "access_mode": "public_metadata_only",
-        "source_status": str(source_item.get("source_status") or "public"),
-        "freshness": str(source_item.get("freshness") or "unknown"),
-        "allowed_use": str(source_item.get("allowed_use") or "metadata_only"),
-        "trial_state": "metadata_packet_collected",
-        "proposed_source_item_id": source_item_id,
-        "terms_note": str(
-            source_item.get("terms_note")
-            or "metadata-only public source packet already collected"
-        ),
-        "promotion_target": "source_item_v0",
-        "requires_user_gate": False,
-        "external_write_allowed": False,
-    }
-
-
-def _connector_trial_from_private_gate_packet(
-    packet: Mapping[str, Any],
-    index: int,
-) -> dict[str, Any]:
-    connector = (
-        packet.get("connector")
-        if isinstance(packet.get("connector"), Mapping)
-        else {}
-    )
-    source_item = packet.get("source_item")
-    if not isinstance(source_item, Mapping):
-        raise ValueError("private connector gate packet must include source_item")
-    source_item_id = str(source_item.get("source_item_id") or "").strip()
-    if not source_item_id:
-        raise ValueError("private connector gate source_item_id is required")
-    return {
-        "schema_version": CONNECTOR_TRIAL_SCHEMA_VERSION,
-        "trial_id": f"trial_private_gate_packet_{index + 1}",
-        "surface": str(
-            packet.get("surface") or connector.get("surface") or "private_archive"
-        ),
-        "tool_hint": str(
-            connector.get("connector_name") or "private metadata connector"
-        ),
-        "access_mode": "private_metadata_only",
-        "source_status": "private_needs_review",
-        "freshness": str(source_item.get("freshness") or "unknown"),
-        "allowed_use": "metadata_only",
-        "trial_state": "needs_owner_gate",
-        "proposed_source_item_id": source_item_id,
-        "terms_note": str(
-            source_item.get("terms_note")
-            or "private connector metadata remains gated before source use"
-        ),
-        "promotion_target": "source_item_v0_after_owner_gate",
-        "requires_user_gate": True,
-        "external_write_allowed": False,
-    }
-
-
 def build_content_ops_surface_from_connector_packets(
     *,
     public_handle_packets: Sequence[Mapping[str, Any]],
@@ -1688,62 +1587,20 @@ def build_content_ops_surface_from_connector_packets(
     connector_trials: list[dict[str, Any]] = []
 
     for index, packet in enumerate(public_packets):
-        if (
-            packet.get("schema_version")
-            != CONTENT_OPS_PUBLIC_HANDLE_OBSERVATION_PACKET_SCHEMA_VERSION
-        ):
-            raise ValueError(
-                "public packet schema_version must be "
-                "content_ops_public_handle_observation_packet_v0"
-            )
-        _require_packet_flag(packet, "ok", True)
-        _require_packet_flag(packet, "external_writes_performed", False)
-        _require_packet_flag(packet, "private_source_content_read", False)
-        _require_packet_flag(packet, "autopublish_allowed", False)
-        runtime_policy = (
-            packet.get("runtime_policy")
-            if isinstance(packet.get("runtime_policy"), Mapping)
-            else {}
+        source_item, connector_trial = source_item_and_trial_from_public_packet(
+            packet,
+            index,
         )
-        if runtime_policy.get("safe_default") != "head_only_metadata_probe":
-            raise ValueError("public packet runtime policy must be HEAD-only")
-        if runtime_policy.get("browser_open_allowed_before_gate") is not False:
-            raise ValueError("public packet must not allow browser open before gate")
-        source_item = packet.get("source_item")
-        if not isinstance(source_item, Mapping):
-            raise ValueError("public packet must include source_item")
-        source_items.append(dict(source_item))
-        connector_trials.append(_connector_trial_from_public_packet(packet, index))
+        source_items.append(source_item)
+        connector_trials.append(connector_trial)
 
     for index, packet in enumerate(private_packets):
-        if (
-            packet.get("schema_version")
-            != CONTENT_OPS_PRIVATE_CONNECTOR_GATE_PACKET_SCHEMA_VERSION
-        ):
-            raise ValueError(
-                "private gate packet schema_version must be "
-                "content_ops_private_connector_gate_packet_v0"
-            )
-        _require_packet_flag(packet, "ok", True)
-        _require_packet_flag(packet, "owner_gate_required", True)
-        _require_packet_flag(packet, "external_reads_performed", False)
-        _require_packet_flag(packet, "external_writes_performed", False)
-        _require_packet_flag(packet, "private_source_content_read", False)
-        _require_packet_flag(packet, "autopublish_allowed", False)
-        runtime_policy = (
-            packet.get("runtime_policy")
-            if isinstance(packet.get("runtime_policy"), Mapping)
-            else {}
+        source_item, connector_trial = source_item_and_trial_from_private_gate_packet(
+            packet,
+            index,
         )
-        if runtime_policy.get("safe_default") != "gate_projection_only":
-            raise ValueError("private packet runtime policy must be gate-only")
-        if runtime_policy.get("browser_open_allowed_before_gate") is not False:
-            raise ValueError("private packet must not allow browser open before gate")
-        source_item = packet.get("source_item")
-        if not isinstance(source_item, Mapping):
-            raise ValueError("private gate packet must include source_item")
-        source_items.append(dict(source_item))
-        connector_trials.append(_connector_trial_from_private_gate_packet(packet, index))
+        source_items.append(source_item)
+        connector_trials.append(connector_trial)
 
     public_source_ids = [
         str(item.get("source_item_id"))


### PR DESCRIPTION
## Summary
- Move content-ops schema identifiers into `content_ops/schemas.py` so packet helpers can share protocol constants without duplicating strings.
- Move connector packet validation and source/trial normalization into `content_ops/connector_packets.py`, leaving `surface.py` focused on building the aggregate surface.
- Retire the `content_ops/surface.py` line-budget whitelist entry after shrinking the file below the default 2000-line budget.

## Validation
- `python3 -m py_compile loopx/capabilities/content_ops/surface.py loopx/capabilities/content_ops/connector_packets.py loopx/capabilities/content_ops/schemas.py examples/control_plane/repo-python-line-budget-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- focused content-ops smokes: surface fixture, preview CLI, public handle observation, private connector gate, packet aggregation, exploration plan, chatview report, walkthrough artifact
- issue-fix bridge smokes: content-ops issue-fix intake and metadata preview
- `loopx check --scan-path ...` on all changed files
- `loopx canary premerge --from-git-diff` passed: surfaces `docs_project_content, public_boundary, python`; risk profile `docs-project-content-ops`; selected 17 checks; failures 0; manual holds 0; self_merge_allowed true

## Notes
- No benchmark adapter, benchmark runner, scoring, task text, raw logs, trajectories, or verifier output touched.
- No public first-screen README/showcase changes.