### PR TITLE
Keep monitor fallback visible after capability skip

### DIFF
--- a/examples/control_plane/monitor-scheduler-contract-smoke.py
+++ b/examples/control_plane/monitor-scheduler-contract-smoke.py
@@ -127,8 +127,14 @@ def blocking_handoff_item(*, index: int, todo_id: str = "todo_primary_handoff") 
     }
 
 
-def advancement_item(*, index: int, priority: str = "P1", claimed_by: str = AGENT_ID) -> dict:
-    return {
+def advancement_item(
+    *,
+    index: int,
+    priority: str = "P1",
+    claimed_by: str = AGENT_ID,
+    required_capabilities: list[str] | None = None,
+) -> dict:
+    item = {
         "index": index,
         "text": f"[{priority}] Advance the runtime contract slice with validation.",
         "todo_id": f"todo_adv_{index}",
@@ -138,6 +144,9 @@ def advancement_item(*, index: int, priority: str = "P1", claimed_by: str = AGEN
         "task_class": "advancement_task",
         "claimed_by": claimed_by,
     }
+    if required_capabilities:
+        item["required_capabilities"] = required_capabilities
+    return item
 
 
 def guard_for(
@@ -472,6 +481,68 @@ def assert_due_monitor_priority_does_not_steal_advancement_lane() -> None:
     assert guard["agent_todo_summary"]["monitor_due_count"] == 1, guard
 
 
+def assert_capability_skip_yields_to_monitor_schedule_repair() -> None:
+    guard = guard_for(
+        [
+            advancement_item(
+                index=1,
+                priority="P1",
+                required_capabilities=["private_read"],
+            ),
+            monitor_item(
+                index=2,
+                todo_id="todo_capability_skip_monitor_gap",
+                priority="P0",
+                target_key="skillsbench-live-batch-watch",
+                cadence=None,
+                next_due_at=None,
+            ),
+        ]
+    )
+    lane = guard["work_lane_contract"]
+    fallback = guard["capability_monitor_fallback"]
+    assert guard["decision"] == "run", guard
+    assert guard["effective_action"] == "normal_run", guard
+    assert guard["capability_gate"]["action"] == "skip", guard
+    assert fallback["mode"] == "monitor_schedule_metadata_repair", fallback
+    assert lane["monitor_kind"] == "todo_monitor_schedule_gap", lane
+    assert lane["obligation"] == "repair_monitor_schedule_metadata", lane
+    assert lane["selected_todo_id"] == "todo_capability_skip_monitor_gap", lane
+    assert guard["heartbeat_recommendation"]["recommended_mode"] != "capability_skip", guard
+    assert guard["execution_obligation"]["contract_obligation"] == "repair_monitor_schedule_metadata", guard
+    assert "todo_adv_1" not in guard["interaction_contract"]["agent_channel"]["primary_action"], guard
+    assert guard["scheduler_hint"]["cadence_class"] == "active_work", guard
+
+
+def assert_capability_skip_yields_to_scheduled_monitor_wait() -> None:
+    guard = guard_for(
+        [
+            advancement_item(
+                index=1,
+                priority="P1",
+                required_capabilities=["private_read"],
+            ),
+            monitor_item(
+                index=2,
+                todo_id="todo_capability_skip_monitor_wait",
+                priority="P0",
+                target_key="skillsbench-live-batch-watch",
+                cadence="15m",
+                next_due_at=FUTURE_DUE_AT,
+            ),
+        ]
+    )
+    scheduler = guard["scheduler_hint"]
+    fallback = guard["capability_monitor_fallback"]
+    assert guard["decision"] == "skip", guard
+    assert guard["effective_action"] == "monitor_quiet_skip", guard
+    assert guard["capability_gate"]["action"] == "skip", guard
+    assert fallback["mode"] == "monitor_quiet_wait", fallback
+    assert guard["heartbeat_recommendation"]["recommended_mode"] == "monitor_quiet_until_material_transition", guard
+    assert scheduler["cadence_class"] == "monitor_wait", scheduler
+    assert scheduler["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=15", scheduler
+
+
 def assert_read_only_projected_due_monitor_does_not_force_writeback() -> None:
     status = status_payload(
         agent_todo_items=[
@@ -659,6 +730,8 @@ def main() -> int:
     assert_due_monitor_requires_explicit_attempt()
     assert_expired_monitor_does_not_catch_up()
     assert_due_monitor_priority_does_not_steal_advancement_lane()
+    assert_capability_skip_yields_to_monitor_schedule_repair()
+    assert_capability_skip_yields_to_scheduled_monitor_wait()
     assert_read_only_projected_due_monitor_does_not_force_writeback()
     assert_due_monitor_is_not_overridden_by_side_agent_scope_wait()
     assert_multiple_due_monitor_cap_and_order()

--- a/loopx/control_plane/work_items/capability_monitor_fallback.py
+++ b/loopx/control_plane/work_items/capability_monitor_fallback.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ..agents.capability_gate import build_capability_gate
+from ..todos.summary_item import compact_todo_summary_item
+
+
+CAPABILITY_MONITOR_FALLBACK_SCHEMA_VERSION = "capability_skip_monitor_fallback_v0"
+WORK_LANE_CONTRACT_SCHEMA_VERSION = "work_lane_contract_v1"
+DEFAULT_MONITOR_ITEM_LIMIT = 1
+
+
+def _compact_monitor_items(
+    items: list[dict[str, Any]],
+    *,
+    limit: int,
+) -> list[dict[str, Any]]:
+    return [
+        compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
+        for item in items[:limit]
+        if isinstance(item, dict)
+    ]
+
+
+def _safe_count(value: Any) -> int:
+    try:
+        return max(0, int(value or 0))
+    except (TypeError, ValueError):
+        return 0
+
+
+def build_capability_skip_monitor_fallback_contract(
+    capability_gate: dict[str, Any] | None,
+    agent_todo_summary: dict[str, Any] | None,
+    *,
+    monitor_item_limit: int = DEFAULT_MONITOR_ITEM_LIMIT,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Expose monitor work when unavailable advancement candidates would hide it.
+
+    Capability skip means every visible advancement candidate is unavailable to
+    the current agent. Current-agent monitor work still has a scheduler contract:
+    repair missing monitor schedule metadata, attempt due monitor work, or keep a
+    quiet monitor wait. Without this fallback, quota collapses to generic
+    quiet_wait and stateful host loops may drift to the slowest backoff.
+    """
+
+    if not isinstance(capability_gate, dict) or capability_gate.get("action") != "skip":
+        return None, None
+    if not isinstance(agent_todo_summary, dict):
+        return None, None
+    monitor_items = (
+        agent_todo_summary.get("monitor_open_items")
+        if isinstance(agent_todo_summary.get("monitor_open_items"), list)
+        else []
+    )
+
+    if not monitor_items:
+        return None, None
+
+    blocked_advancement_count = len(
+        capability_gate.get("blocked_candidates")
+        if isinstance(capability_gate.get("blocked_candidates"), list)
+        else []
+    )
+    base_fallback = {
+        "schema_version": CAPABILITY_MONITOR_FALLBACK_SCHEMA_VERSION,
+        "source": "quota.capability_gate",
+        "capability_gate_action": "skip",
+        "blocked_advancement_count": blocked_advancement_count,
+        "reason": (
+            "all advancement candidates require unavailable capabilities, "
+            "so current-agent monitor work must remain visible to the scheduler"
+        ),
+    }
+
+    due_items = (
+        agent_todo_summary.get("monitor_due_items")
+        if isinstance(agent_todo_summary.get("monitor_due_items"), list)
+        else []
+    )
+    monitor_due_count = _safe_count(agent_todo_summary.get("monitor_due_count"))
+    if monitor_due_count > 0 and due_items:
+        selected = due_items[0]
+        return (
+            {
+                "schema_version": WORK_LANE_CONTRACT_SCHEMA_VERSION,
+                "lane": "continuous_monitor",
+                "monitor_kind": "todo_monitor_due",
+                "next_lane": "continuous_monitor",
+                "obligation": "attempt_due_monitor",
+                "must_attempt_work": True,
+                "reason_codes": [
+                    "advancement_unavailable_by_capability",
+                    "monitor_due",
+                ],
+                "monitor_policy": "attempt_due_monitor_once_then_writeback_or_no_spend_if_unchanged",
+                "monitor_due_count": monitor_due_count,
+                "monitor_due_items": due_items[:monitor_item_limit],
+                "selected_todo_id": selected.get("todo_id"),
+                "selected_next_due_at": selected.get("next_due_at"),
+                "action": (
+                    "attempt the selected due continuous_monitor todo because all "
+                    "advancement candidates are unavailable to this agent"
+                ),
+            },
+            {**base_fallback, "mode": "due_monitor_attempt"},
+        )
+
+    schedule_gap_items = (
+        agent_todo_summary.get("monitor_schedule_gap_items")
+        if isinstance(agent_todo_summary.get("monitor_schedule_gap_items"), list)
+        else []
+    )
+    monitor_schedule_gap_count = _safe_count(
+        agent_todo_summary.get("monitor_schedule_gap_count")
+    )
+    if monitor_schedule_gap_count > 0 and schedule_gap_items:
+        selected = schedule_gap_items[0]
+        return (
+            {
+                "schema_version": WORK_LANE_CONTRACT_SCHEMA_VERSION,
+                "lane": "advancement_task",
+                "monitor_kind": "todo_monitor_schedule_gap",
+                "next_lane": "continuous_monitor",
+                "obligation": "repair_monitor_schedule_metadata",
+                "must_attempt_work": True,
+                "reason_codes": [
+                    "advancement_unavailable_by_capability",
+                    "monitor_schedule_metadata_gap",
+                ],
+                "monitor_policy": "repair_schedule_metadata_before_quiet_wait",
+                "monitor_schedule_gap_count": monitor_schedule_gap_count,
+                "monitor_schedule_gap_items": schedule_gap_items[:monitor_item_limit],
+                "selected_todo_id": selected.get("todo_id"),
+                "action": (
+                    "repair the selected continuous_monitor todo by adding cadence/"
+                    "next_due_at, superseding it, or recording an explicit no-schedule "
+                    "policy before quiet scheduler backoff"
+                ),
+            },
+            {**base_fallback, "mode": "monitor_schedule_metadata_repair"},
+        )
+
+    return (
+        {
+            "schema_version": WORK_LANE_CONTRACT_SCHEMA_VERSION,
+            "lane": "continuous_monitor",
+            "monitor_kind": "todo_monitor",
+            "next_lane": "continuous_monitor",
+            "obligation": "quiet_until_material_monitor_transition",
+            "must_attempt_work": False,
+            "reason_codes": [
+                "advancement_unavailable_by_capability",
+                "monitor_todo_present",
+            ],
+            "monitor_policy": "write_once_per_material_transition_else_no_spend",
+            "monitor_open_count": len(monitor_items),
+            "monitor_items": _compact_monitor_items(
+                monitor_items,
+                limit=monitor_item_limit,
+            ),
+            "material_transition": (
+                "a monitor todo may write back only material state transitions, regressions, or concrete blockers"
+            ),
+            "action": "wait quietly for material monitor evidence",
+        },
+        {**base_fallback, "mode": "monitor_quiet_wait"},
+    )
+
+
+def build_capability_gate_with_monitor_fallback(
+    agent_todo_summary: dict[str, Any] | None,
+    *,
+    available_capabilities: list[str],
+    agent_identity: dict[str, Any] | None = None,
+    monitor_item_limit: int = DEFAULT_MONITOR_ITEM_LIMIT,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None, dict[str, Any] | None]:
+    capability_gate = build_capability_gate(
+        agent_todo_summary,
+        available_capabilities=available_capabilities,
+        agent_identity=agent_identity,
+    )
+    contract, fallback = build_capability_skip_monitor_fallback_contract(
+        capability_gate,
+        agent_todo_summary,
+        monitor_item_limit=monitor_item_limit,
+    )
+    return capability_gate, contract, fallback

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -20,9 +20,6 @@ from .control_plane.agents.agent_lane_recommendation import (
     selected_action_with_agent_lane,
     selected_recommended_action_from_work_lane,
 )
-from .control_plane.agents.capability_gate import (
-    build_capability_gate,
-)
 from .control_plane.agents.workspace_guard import build_side_agent_workspace_guard
 from .control_plane.agents.identity import (
     build_identity_aware_prompt_upgrade,
@@ -121,6 +118,7 @@ from .control_plane.runtime.promotion_readiness import (
     promotion_readiness_warning as _promotion_readiness_warning,
 )
 from .control_plane.work_items.goal_route_hint import build_goal_route_hint
+from .control_plane.work_items.capability_monitor_fallback import build_capability_gate_with_monitor_fallback
 from .control_plane.work_items.work_lane import (
     work_lane_contract_is_due_monitor_attempt,
 )
@@ -1394,6 +1392,10 @@ def build_quota_should_run(
             agent_identity=agent_identity,
             agent_todo_summary=agent_todo_summary,
         )
+        capability_gate, capability_monitor_contract, capability_monitor_fallback = build_capability_gate_with_monitor_fallback(agent_todo_summary, available_capabilities=_effective_available_capabilities(available_capabilities, item=item, project_asset=project_asset), agent_identity=agent_identity, monitor_item_limit=MONITOR_DUE_ITEM_LIMIT)
+        if subagent_orchestration_contract:
+            capability_monitor_contract = capability_monitor_fallback = None
+        work_lane_contract = capability_monitor_contract or work_lane_contract
         agent_frontier_id = (
             normalize_todo_claimed_by(agent_identity.get("agent_id"))
             if isinstance(agent_identity, dict)
@@ -1422,16 +1424,6 @@ def build_quota_should_run(
             goal_frontier_context.get("goal_frontier_projection")
             if isinstance(goal_frontier_context.get("goal_frontier_projection"), dict)
             else {}
-        )
-        effective_available_capabilities = _effective_available_capabilities(
-            available_capabilities,
-            item=item,
-            project_asset=project_asset,
-        )
-        capability_gate = build_capability_gate(
-            agent_todo_summary,
-            available_capabilities=effective_available_capabilities,
-            agent_identity=agent_identity,
         )
         capability_repair_allowed = False
         workspace_repair_allowed = False
@@ -1465,7 +1457,7 @@ def build_quota_should_run(
             normal_delivery_allowed = False
             recovery_allowed = False
             reason = str(boundary_projection_repair.get("reason") or reason)
-        if capability_gate and capability_gate.get("action") != "run":
+        if capability_gate and capability_gate.get("action") != "run" and not capability_monitor_fallback:
             normal_delivery_allowed = False
             recovery_allowed = False
             if capability_gate.get("action") == "repair_bridge":
@@ -1548,7 +1540,7 @@ def build_quota_should_run(
             select_replan_obligation=False,
             monitor_due_item_limit=MONITOR_DUE_ITEM_LIMIT,
         )
-        if capability_gate and capability_gate.get("action") == "repair_bridge":
+        if capability_gate and not capability_monitor_fallback and capability_gate.get("action") == "repair_bridge":
             heartbeat_recommendation = {
                 **heartbeat_recommendation,
                 "recommended_mode": "repair_capability_bridge",
@@ -1559,7 +1551,7 @@ def build_quota_should_run(
                     "repair, todo rewrite, or compact blocker writeback"
                 ),
             }
-        elif capability_gate and capability_gate.get("action") == "ask_owner":
+        elif capability_gate and not capability_monitor_fallback and capability_gate.get("action") == "ask_owner":
             heartbeat_recommendation = {
                 **heartbeat_recommendation,
                 "recommended_mode": "ask_owner_for_capability",
@@ -1567,7 +1559,7 @@ def build_quota_should_run(
                 "reason": capability_gate.get("reason") or heartbeat_recommendation.get("reason"),
                 "spend_policy": "do not append quota spend while asking for missing capability",
             }
-        elif capability_gate and capability_gate.get("action") == "skip":
+        elif capability_gate and not capability_monitor_fallback and capability_gate.get("action") == "skip":
             heartbeat_recommendation = {
                 **heartbeat_recommendation,
                 "recommended_mode": "capability_skip",
@@ -1671,8 +1663,10 @@ def build_quota_should_run(
             subagent_orchestration_contract,
             selected_recommended_action,
         )
+        if capability_monitor_fallback and isinstance(work_lane_contract, dict) and work_lane_contract.get("action"):
+            selected_recommended_action = work_lane_contract["action"]
         due_monitor_attempt = work_lane_contract_is_due_monitor_attempt(work_lane_contract)
-        if capability_gate and not due_monitor_attempt:
+        if capability_gate and not due_monitor_attempt and not capability_monitor_fallback:
             if capability_gate.get("action") in {"repair_bridge", "ask_owner", "skip"}:
                 selected_recommended_action = (
                     capability_gate.get("owner_action")
@@ -1709,7 +1703,7 @@ def build_quota_should_run(
             allow_unrelated_gate=bool(quota.get("safe_bypass_allowed")),
         )
         agent_lane_next_action = None
-        if not due_monitor_attempt and not subagent_orchestration_contract:
+        if not due_monitor_attempt and not subagent_orchestration_contract and not capability_monitor_fallback:
             agent_lane_next_action = build_agent_lane_next_action(
                 agent_identity=agent_identity,
                 agent_todo_summary=agent_todo_summary,
@@ -1937,6 +1931,8 @@ def build_quota_should_run(
             payload["capability_gate"] = capability_gate
             if capability_gate.get("action") == "ask_owner":
                 payload["notify_user_on_capability_gate"] = True
+        if capability_monitor_fallback:
+            payload["capability_monitor_fallback"] = capability_monitor_fallback
         if external_evidence_observation:
             payload["external_evidence_observation"] = external_evidence_observation
         control_plane = compact_control_plane_policy(item.get("control_plane"))


### PR DESCRIPTION
## Summary
- Add a bounded work-lane helper that lets current-agent continuous monitor work remain visible when all advancement todos are blocked by unavailable capabilities.
- Route capability-skip + unscheduled monitor to monitor schedule metadata repair, and capability-skip + scheduled monitor to monitor_wait instead of generic quiet_wait.
- Extend monitor scheduler smoke coverage for both regression cases.

## Validation
- python3 examples/control_plane/monitor-scheduler-contract-smoke.py
- python3 examples/control_plane/capability-gate-projection-smoke.py
- python3 examples/control_plane/quota-scheduler-policy-smoke.py
- python3 examples/control_plane/quota-scheduler-state-ack-smoke.py
- python3 examples/control_plane/heartbeat-quota-flow-smoke.py
- python3 examples/control_plane/quota-replan-decision-plane-smoke.py
- python3 examples/control_plane/work-lane-contract-smoke.py
- python3 examples/control_plane/interaction-contract-state-machine-smoke.py
- python3 examples/control_plane/repo-python-line-budget-smoke.py
- loopx check --scan-path loopx/quota.py --scan-path loopx/control_plane/work_items/capability_monitor_fallback.py --scan-path examples/control_plane/monitor-scheduler-contract-smoke.py
- loopx canary premerge --from-git-diff

## Self-merge rationale
Premerge reported merge_gate_passed=true and self_merge_allowed=true. Changed surfaces are quota/work-lane routing plus durable regression smoke; no private state, raw benchmark logs, credentials, local paths, or generated evidence are included.