### PR TITLE
Allow explicit external monitor poll observations

### DIFF
--- a/examples/control_plane/monitor-poll-policy-smoke.py
+++ b/examples/control_plane/monitor-poll-policy-smoke.py
@@ -13,6 +13,7 @@ if str(ROOT) not in sys.path:
 from loopx.control_plane.scheduler.monitor_poll_policy import (  # noqa: E402
     allows_due_monitor_poll,
     allows_no_spend_external_monitor_poll,
+    explicit_external_evidence_observation,
     quota_decision_due_monitor_item,
     work_lane_reason_codes,
 )
@@ -53,6 +54,30 @@ def assert_external_monitor_observation_policy() -> None:
         },
     }
     assert allows_no_spend_external_monitor_poll(explicit_observation) is True
+
+    explicit_observation_with_quiet_monitor_lane = {
+        "should_run": True,
+        "requires_user_action": False,
+        "effective_action": "external_evidence_observe",
+        "external_evidence_observation": {
+            "required": True,
+            "must_attempt_observation": True,
+            "delivery_allowed": False,
+            "if_handle_live_and_unchanged": "quiet_noop_no_spend",
+        },
+        "work_lane_contract": {
+            "lane": "continuous_monitor",
+            "obligation": "quiet_until_material_monitor_transition",
+            "must_attempt_work": False,
+            "monitor_policy": "write_once_per_material_transition_else_no_spend",
+            "reason_codes": [
+                "advancement_unavailable_by_capability",
+                "monitor_todo_present",
+            ],
+        },
+    }
+    assert explicit_external_evidence_observation(explicit_observation_with_quiet_monitor_lane) is True
+    assert allows_no_spend_external_monitor_poll(explicit_observation_with_quiet_monitor_lane) is True
 
     due_monitor_delivery = {
         "should_run": True,

--- a/loopx/control_plane/scheduler/monitor_poll_policy.py
+++ b/loopx/control_plane/scheduler/monitor_poll_policy.py
@@ -23,6 +23,15 @@ def work_lane_reason_codes(work_lane_contract: dict[str, Any]) -> set[str]:
     return {str(value) for value in reason_codes if str(value or "").strip()}
 
 
+def explicit_external_evidence_observation(decision: dict[str, Any]) -> bool:
+    observation = (
+        decision.get("external_evidence_observation")
+        if isinstance(decision.get("external_evidence_observation"), dict)
+        else {}
+    )
+    return observation.get("required") is True and observation.get("must_attempt_observation") is True
+
+
 def allows_no_spend_external_monitor_poll(decision: dict[str, Any]) -> bool:
     """Return true when should-run represents observation, not delivery completion."""
 
@@ -37,6 +46,8 @@ def allows_no_spend_external_monitor_poll(decision: dict[str, Any]) -> bool:
         return False
     if decision.get("should_run") is not True:
         return False
+    if explicit_external_evidence_observation(decision):
+        return True
     if work_lane_contract.get("must_attempt_work") is not True:
         return False
     if monitor_policy not in EXTERNAL_MONITOR_POLICIES:


### PR DESCRIPTION
## Summary
- Treat explicit external evidence observation obligations as a first-class no-spend monitor-poll contract.
- Preserve user-gate and should-run guards, and keep the existing work-lane policy path for compatibility.
- Add a regression case for quiet monitor lanes where work delivery is intentionally disabled but read-only observation is required.

## Validation
- python3 -m py_compile loopx/control_plane/scheduler/monitor_poll_policy.py loopx/control_plane/quota/monitor_poll.py examples/control_plane/monitor-poll-policy-smoke.py
- python3 examples/control_plane/monitor-poll-policy-smoke.py
- python3 examples/control_plane/external-evidence-observation-smoke.py
- python3 examples/control_plane/monitor-poll-writeback-smoke.py
- python3 examples/control_plane/heartbeat-quota-flow-smoke.py
- loopx check --scan-path loopx/control_plane/scheduler/monitor_poll_policy.py --scan-path examples/control_plane/monitor-poll-policy-smoke.py
- loopx canary premerge --from-git-diff (passed; merge_gate_passed=true; self_merge_allowed=true)
