### PR TITLE
Quiet repeated external monitor observations

### DIFF
--- a/examples/control_plane/external-evidence-observation-smoke.py
+++ b/examples/control_plane/external-evidence-observation-smoke.py
@@ -94,12 +94,19 @@ def advancement_todo() -> dict[str, Any]:
     )
 
 
+def unavailable_advancement_todo() -> dict[str, Any]:
+    item = advancement_todo()
+    item["required_capabilities"] = ["private_read"]
+    return item
+
+
 def status_payload(
     summary: dict[str, Any],
     *,
     status: str = "launched_polling_result",
     waiting_on: str = "codex",
     next_action: str = "Observe compact result marker for remote job handle.",
+    latest_runs: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     return quota_status_payload(
         goal_id=GOAL_ID,
@@ -113,7 +120,7 @@ def status_payload(
             "primary_agent": "codex-main-control",
             "registered_agents": ["codex-main-control", AGENT_ID],
         },
-        latest_runs=[],
+        latest_runs=latest_runs or [],
         item_extra={"lifecycle_flags": ["launched polling result marker"]},
     )
 
@@ -150,6 +157,44 @@ def assert_monitor_only_launched_poll_requires_observation() -> None:
     assert guard["effective_action"] == "external_evidence_observe", guard
     assert guard["execution_obligation"]["kind"] == "external_evidence_observation_required", guard
     assert allows_no_spend_external_monitor_poll(guard) is True, guard
+
+
+def assert_recent_unchanged_observation_quiets_external_monitor() -> None:
+    summary = agent_todos(
+        [
+            monitor_todo(next_due_at=FUTURE_DUE_AT),
+            unavailable_advancement_todo(),
+        ]
+    )
+    guard = build_quota_should_run(
+        status_payload(
+            summary,
+            latest_runs=[
+                {
+                    "classification": "quota_slot_spent",
+                    "agent_id": AGENT_ID,
+                    "recommended_action": "wait quietly for material monitor evidence",
+                },
+                {
+                    "classification": "quota_monitor_poll",
+                    "agent_id": AGENT_ID,
+                    "delivery_outcome": "surface_only",
+                    "health_check": "external monitor observation unchanged; no quota spend; no material transition",
+                },
+            ],
+        ),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+    assert guard["decision"] == "skip", guard
+    assert guard["should_run"] is False, guard
+    assert guard["effective_action"] == "monitor_quiet_skip", guard
+    assert "external_evidence_observation" not in guard, guard
+    assert guard["external_evidence_observation_recent"]["classification"] == "quota_monitor_poll", guard
+    interaction = guard["interaction_contract"]
+    assert interaction["mode"] == "monitor_quiet_skip", interaction
+    assert interaction["agent_channel"]["must_attempt"] is False, interaction
+    assert interaction["agent_channel"]["quiet_noop_allowed"] is True, interaction
 
 
 def assert_advancement_lane_keeps_external_monitor_as_context() -> None:
@@ -224,6 +269,7 @@ def assert_explicit_external_wait_builds_registry_obligation() -> None:
 
 def main() -> int:
     assert_monitor_only_launched_poll_requires_observation()
+    assert_recent_unchanged_observation_quiets_external_monitor()
     assert_advancement_lane_keeps_external_monitor_as_context()
     assert_future_scoped_monitor_does_not_fake_external_poll()
     assert_explicit_external_wait_builds_registry_obligation()

--- a/examples/control_plane/heartbeat-quota-flow-smoke.py
+++ b/examples/control_plane/heartbeat-quota-flow-smoke.py
@@ -1057,7 +1057,9 @@ def main() -> int:
             "external_monitor_observed_without_material_transition"
         ), poll
         assert poll["monitor_event"]["before"]["effective_action"] == "external_evidence_observe", poll
-        assert poll["after"]["effective_action"] == "external_evidence_observe", poll
+        assert poll["after"]["effective_action"] == "blocked_wait", poll
+        assert poll["after"]["should_run"] is False, poll
+        assert poll["after"]["interaction_contract"]["agent_channel"]["quiet_noop_allowed"] is True, poll
         assert count_spend_events(runtime) == 0, poll
         assert count_events(runtime, "quota_monitor_poll") == 1, poll
 

--- a/loopx/control_plane/quota/recent_runs.py
+++ b/loopx/control_plane/quota/recent_runs.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ..todos.contract import normalize_todo_claimed_by
+from .monitor_poll import QUOTA_MONITOR_POLL_CLASSIFICATION
+
+
+def goal_latest_runs(status_payload: dict[str, Any], *, goal_id: str) -> list[dict[str, Any]]:
+    run_history = (
+        status_payload.get("run_history")
+        if isinstance(status_payload.get("run_history"), dict)
+        else {}
+    )
+    goals = run_history.get("goals") if isinstance(run_history.get("goals"), list) else []
+    goal = next(
+        (
+            candidate
+            for candidate in goals
+            if isinstance(candidate, dict) and str(candidate.get("id") or "") == goal_id
+        ),
+        None,
+    )
+    if not isinstance(goal, dict):
+        return []
+    runs = goal.get("latest_runs") if isinstance(goal.get("latest_runs"), list) else []
+    return [run for run in runs if isinstance(run, dict)]
+
+
+def recent_external_monitor_observation_unchanged(
+    status_payload: dict[str, Any],
+    *,
+    goal_id: str,
+    agent_id: str | None = None,
+    scan_limit: int = 8,
+) -> dict[str, Any] | None:
+    safe_agent_id = normalize_todo_claimed_by(agent_id)
+    for run in goal_latest_runs(status_payload, goal_id=goal_id)[: max(1, scan_limit)]:
+        run_agent_id = normalize_todo_claimed_by(run.get("agent_id"))
+        if safe_agent_id and run_agent_id and run_agent_id != safe_agent_id:
+            continue
+        if str(run.get("classification") or "") != QUOTA_MONITOR_POLL_CLASSIFICATION:
+            continue
+        monitor_event = run.get("monitor_event") if isinstance(run.get("monitor_event"), dict) else {}
+        monitor_mode = str(monitor_event.get("monitor_mode") or "").strip()
+        health_check = str(run.get("health_check") or "").strip().lower()
+        if monitor_event.get("material_change") is True:
+            return None
+        if (
+            monitor_mode == "external_monitor_observed_without_material_transition"
+            or "external monitor observation unchanged" in health_check
+        ):
+            return {
+                "classification": QUOTA_MONITOR_POLL_CLASSIFICATION,
+                "generated_at": run.get("generated_at"),
+                "agent_id": run_agent_id or None,
+                "monitor_mode": monitor_mode
+                or "external_monitor_observed_without_material_transition",
+                "reason": "recent external monitor observation was unchanged",
+            }
+    return None

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -72,6 +72,10 @@ from .control_plane.quota.monitor_poll import (
     record_quota_monitor_poll_for_decision,
     render_quota_monitor_poll_markdown,
 )
+from .control_plane.quota.recent_runs import (
+    goal_latest_runs as _goal_latest_runs,
+    recent_external_monitor_observation_unchanged as _recent_external_monitor_observation_unchanged,
+)
 from .control_plane.quota.markdown import (
     render_quota_markdown,
     render_quota_scheduler_ack_markdown,
@@ -1125,26 +1129,8 @@ def _quota_plan_items(plan: dict[str, Any]) -> list[dict[str, Any]]:
 
 
 def _recent_reward_lessons(status_payload: dict[str, Any], *, goal_id: str) -> list[dict[str, Any]]:
-    run_history = (
-        status_payload.get("run_history")
-        if isinstance(status_payload.get("run_history"), dict)
-        else {}
-    )
-    goals = run_history.get("goals") if isinstance(run_history.get("goals"), list) else []
-    goal = next(
-        (
-            candidate
-            for candidate in goals
-            if isinstance(candidate, dict) and str(candidate.get("id") or "") == goal_id
-        ),
-        None,
-    )
-    if not isinstance(goal, dict):
-        return []
     lessons: list[dict[str, Any]] = []
-    for run in goal.get("latest_runs") or []:
-        if not isinstance(run, dict):
-            continue
+    for run in _goal_latest_runs(status_payload, goal_id=goal_id):
         reward = run.get("human_reward") if isinstance(run.get("human_reward"), dict) else {}
         lesson = reward.get("lesson") if isinstance(reward.get("lesson"), dict) else {}
         if not lesson:
@@ -1608,6 +1594,17 @@ def build_quota_should_run(
             agent_todo_summary=agent_todo_summary,
             work_lane_contract=work_lane_contract,
         )
+        external_evidence_observation_recent = None
+        if external_evidence_observation:
+            external_evidence_observation_recent = _recent_external_monitor_observation_unchanged(
+                status_payload,
+                goal_id=safe_goal_id,
+                agent_id=normalize_todo_claimed_by(agent_identity.get("agent_id"))
+                if isinstance(agent_identity, dict)
+                else None,
+            )
+            if external_evidence_observation_recent:
+                external_evidence_observation = None
         ready_deferred_resume_candidates: list[dict[str, Any]] = []
         if (
             isinstance(agent_identity, dict)
@@ -1935,6 +1932,8 @@ def build_quota_should_run(
             payload["capability_monitor_fallback"] = capability_monitor_fallback
         if external_evidence_observation:
             payload["external_evidence_observation"] = external_evidence_observation
+        if external_evidence_observation_recent:
+            payload["external_evidence_observation_recent"] = external_evidence_observation_recent
         control_plane = compact_control_plane_policy(item.get("control_plane"))
         if control_plane:
             payload["control_plane"] = control_plane


### PR DESCRIPTION
## Summary
- Add a small quota recent-run helper for goal latest-run lookups and external monitor no-change detection.
- Suppress repeated `external_evidence_observation_required` after a recent unchanged external `quota_monitor_poll`, so the next guard can quiet-wait until due/material transition instead of looping every heartbeat.
- Cover the eligible/future-monitor cooldown path and the post-monitor-poll heartbeat flow.

## Validation
- python3 -m py_compile loopx/quota.py loopx/control_plane/quota/recent_runs.py examples/control_plane/external-evidence-observation-smoke.py examples/control_plane/heartbeat-quota-flow-smoke.py
- python3 examples/control_plane/external-evidence-observation-smoke.py
- python3 examples/control_plane/heartbeat-quota-flow-smoke.py
- python3 examples/control_plane/monitor-poll-policy-smoke.py
- python3 examples/control_plane/repo-python-line-budget-smoke.py
- loopx check --scan-path loopx/quota.py --scan-path loopx/control_plane/quota/recent_runs.py --scan-path examples/control_plane/external-evidence-observation-smoke.py --scan-path examples/control_plane/heartbeat-quota-flow-smoke.py
- loopx canary premerge --from-git-diff (passed; merge_gate_passed=true; self_merge_allowed=true)
