### PR TITLE
Extract agent scope frontier contract

### DIFF
--- a/examples/control_plane/agent-scope-projection-characterization-smoke.py
+++ b/examples/control_plane/agent-scope-projection-characterization-smoke.py
@@ -19,6 +19,10 @@ from loopx.control_plane.agents.agent_scope import (  # noqa: E402
     _agent_scoped_user_gate_override,
     _scoped_user_gate_fallback,
 )
+from loopx.control_plane.agents.agent_scope_frontier import (  # noqa: E402
+    AgentScopeFrontierAction,
+    build_agent_scope_frontier_payload,
+)
 
 
 GOAL_ID = "agent-scope-projection-characterization"
@@ -229,6 +233,33 @@ def assert_agent_scoped_user_gate_override_contract() -> None:
     assert blocked is None, blocked
 
 
+def assert_agent_scope_frontier_builder_contract() -> None:
+    payload = build_agent_scope_frontier_payload(
+        agent_id=AGENT_ID,
+        primary_agent=PRIMARY_AGENT,
+        action=AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED,
+        quiet_noop_allowed=False,
+        spend_policy="spend once after validated successor replan/todo writeback",
+        reason="frontier has no runnable advancement but a successor is required",
+        recommended_action="record a successor todo or an explicit no-follow-up rationale",
+        requires_replan=True,
+        candidate_counts={
+            "current_agent_claimed_advancement_count": 0,
+            "unclaimed_advancement_count": 0,
+            "cleared_without_successor_handoff_count": 1,
+        },
+        extra_fields={"cleared_without_successor_handoff_gates": [{"todo_id": "todo_gate"}]},
+    )
+
+    assert payload["schema_version"] == "agent_scope_frontier_v0"
+    assert payload["action"] == "successor_replan_required"
+    assert payload["effective_action"] == payload["action"]
+    assert payload["blocks_delivery"] is True
+    assert payload["requires_replan"] is True
+    assert payload["quiet_noop_allowed"] is False
+    assert payload["cleared_without_successor_handoff_gates"][0]["todo_id"] == "todo_gate"
+
+
 def assert_agent_scope_frontier_and_hint_contract() -> None:
     blocked_resume = todo(
         "todo_waiting_advancement",
@@ -357,6 +388,7 @@ def main() -> None:
     assert_agent_scope_user_gate_filter_contract()
     assert_scoped_user_gate_fallback_contract()
     assert_agent_scoped_user_gate_override_contract()
+    assert_agent_scope_frontier_builder_contract()
     assert_agent_scope_frontier_and_hint_contract()
     assert_other_agent_frontier_wait_contract()
     print("agent-scope-projection-characterization-smoke ok")

--- a/loopx/control_plane/agents/agent_scope.py
+++ b/loopx/control_plane/agents/agent_scope.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
-from enum import Enum
 import re
 from typing import Any
 
+from .agent_scope_frontier import (
+    AGENT_LANE_FRONTIER_HINT_SCHEMA_VERSION,
+    AgentLaneFrontierHintDecision,
+    AgentScopeFrontierAction,
+    agent_scope_frontier_action as _agent_scope_frontier_action,
+    build_agent_scope_frontier_payload,
+)
 from ..todos.decision_scope import todo_gate_relation, todo_gate_relation_blocks_agent
 from ..work_items.work_lane import (
     work_lane_contract_is_due_monitor_attempt,
@@ -33,10 +39,6 @@ from ..todos.user_gate import (
     open_todo_count as _open_todo_count,
     open_user_gate_todo_items as _open_user_gate_todo_items,
 )
-
-
-AGENT_SCOPE_FRONTIER_SCHEMA_VERSION = "agent_scope_frontier_v0"
-AGENT_LANE_FRONTIER_HINT_SCHEMA_VERSION = "agent_lane_frontier_hint_v0"
 
 _ACTION_SCOPE_STOPWORDS = {
     "a",
@@ -78,20 +80,6 @@ _ACTION_SCOPE_STOPWORDS = {
     "whether",
     "with",
 }
-
-
-class AgentScopeFrontierAction(str, Enum):
-    AGENT_SCOPE_EXHAUSTED = "agent_scope_exhausted"
-    AGENT_SCOPE_WAIT = "agent_scope_wait"
-    REASSIGNMENT_REQUIRED = "reassignment_required"
-    SUCCESSOR_REPLAN_REQUIRED = "successor_replan_required"
-
-
-class AgentLaneFrontierHintDecision(str, Enum):
-    CLAIM_UNOWNED_IN_SCOPE = "claim_unowned_in_scope"
-    ADD_NEXT_ADVANCEMENT = "add_next_advancement"
-    RECORD_NO_FOLLOWUP = "record_no_followup"
-    QUIET_NOOP_BLOCKER = "quiet_noop_blocker"
 
 
 def _todo_task_class(item: dict[str, Any]) -> str:
@@ -481,13 +469,6 @@ def _agent_scoped_user_gate_override(
 
 def _count_advancement_items(items: Any, *, claimed_by: str | None = None) -> int:
     return agent_scope_count_advancement_items(items, claimed_by=claimed_by)
-
-
-def _agent_scope_frontier_action(value: Any) -> AgentScopeFrontierAction | None:
-    try:
-        return AgentScopeFrontierAction(str(value or ""))
-    except ValueError:
-        return None
 
 
 def _first_compact_todo_id(items: Any) -> str | None:
@@ -1005,25 +986,24 @@ def _agent_scope_no_candidate_frontier(
             f"{monitor_todo_id} after validated evidence, or rewrite {candidate_todo_id} "
             "to use a non-blocking monitor contract before delivery."
         )
-        return {
-            "schema_version": AGENT_SCOPE_FRONTIER_SCHEMA_VERSION,
-            "agent_id": agent_id,
-            "primary_agent": normalize_todo_claimed_by(agent_identity.get("primary_agent")),
-            "action": AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value,
-            "effective_action": AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value,
-            "blocks_delivery": True,
-            "requires_replan": True,
-            "quiet_noop_allowed": False,
-            "spend_policy": "spend once after validated standing-monitor gate repair/todo writeback",
-            "reason": reason,
-            "recommended_action": recommended_action,
-            "candidate_counts": {
+        return build_agent_scope_frontier_payload(
+            agent_id=agent_id,
+            primary_agent=normalize_todo_claimed_by(agent_identity.get("primary_agent")),
+            action=AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED,
+            quiet_noop_allowed=False,
+            spend_policy="spend once after validated standing-monitor gate repair/todo writeback",
+            reason=reason,
+            recommended_action=recommended_action,
+            requires_replan=True,
+            candidate_counts={
                 "current_agent_claimed_advancement_count": current_agent_count,
                 "unclaimed_advancement_count": unclaimed_count,
                 "monitor_blocked_resume_candidate_count": len(monitor_blocked_resume_candidates),
             },
-            "monitor_blocked_resume_candidates": monitor_blocked_resume_candidates[:3],
-        }
+            extra_fields={
+                "monitor_blocked_resume_candidates": monitor_blocked_resume_candidates[:3],
+            },
+        )
 
     deferred_resume_candidates = _agent_scope_deferred_resume_candidates(
         agent_todo_summary,
@@ -1040,25 +1020,22 @@ def _agent_scope_no_candidate_frontier(
             "Run a bounded successor replan before delivery: reopen, supersede, "
             f"or record a no-follow-up rationale for {candidate_todo_id}."
         )
-        return {
-            "schema_version": AGENT_SCOPE_FRONTIER_SCHEMA_VERSION,
-            "agent_id": agent_id,
-            "primary_agent": normalize_todo_claimed_by(agent_identity.get("primary_agent")),
-            "action": AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value,
-            "effective_action": AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value,
-            "blocks_delivery": True,
-            "requires_replan": True,
-            "quiet_noop_allowed": False,
-            "spend_policy": "spend once after validated successor replan/todo writeback",
-            "reason": reason,
-            "recommended_action": recommended_action,
-            "candidate_counts": {
+        return build_agent_scope_frontier_payload(
+            agent_id=agent_id,
+            primary_agent=normalize_todo_claimed_by(agent_identity.get("primary_agent")),
+            action=AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED,
+            quiet_noop_allowed=False,
+            spend_policy="spend once after validated successor replan/todo writeback",
+            reason=reason,
+            recommended_action=recommended_action,
+            requires_replan=True,
+            candidate_counts={
                 "current_agent_claimed_advancement_count": current_agent_count,
                 "unclaimed_advancement_count": unclaimed_count,
                 "deferred_resume_candidate_count": len(deferred_resume_candidates),
             },
-            "deferred_resume_candidates": deferred_resume_candidates[:3],
-        }
+            extra_fields={"deferred_resume_candidates": deferred_resume_candidates[:3]},
+        )
 
     route_continuation_replan_candidates = _agent_scope_route_continuation_replan_candidates(
         agent_todo_summary,
@@ -1085,27 +1062,26 @@ def _agent_scope_no_candidate_frontier(
             f"claim the next concrete {agent_id}/unclaimed advancement todo for "
             f"{route_label}, or record an explicit no-follow-up rationale."
         )
-        return {
-            "schema_version": AGENT_SCOPE_FRONTIER_SCHEMA_VERSION,
-            "agent_id": agent_id,
-            "primary_agent": normalize_todo_claimed_by(agent_identity.get("primary_agent")),
-            "action": AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value,
-            "effective_action": AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value,
-            "blocks_delivery": True,
-            "requires_replan": True,
-            "quiet_noop_allowed": False,
-            "spend_policy": "spend once after validated route continuation replan/todo writeback",
-            "reason": reason,
-            "recommended_action": recommended_action,
-            "candidate_counts": {
+        return build_agent_scope_frontier_payload(
+            agent_id=agent_id,
+            primary_agent=normalize_todo_claimed_by(agent_identity.get("primary_agent")),
+            action=AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED,
+            quiet_noop_allowed=False,
+            spend_policy="spend once after validated route continuation replan/todo writeback",
+            reason=reason,
+            recommended_action=recommended_action,
+            requires_replan=True,
+            candidate_counts={
                 "current_agent_claimed_advancement_count": current_agent_count,
                 "unclaimed_advancement_count": unclaimed_count,
                 "route_continuation_replan_candidate_count": len(
                     route_continuation_replan_candidates
                 ),
             },
-            "route_continuation_replan_candidates": route_continuation_replan_candidates[:3],
-        }
+            extra_fields={
+                "route_continuation_replan_candidates": route_continuation_replan_candidates[:3],
+            },
+        )
 
     blocking_handoff_gates = _agent_scope_blocking_handoff_gates(
         agent_todo_summary,
@@ -1130,26 +1106,25 @@ def _agent_scope_no_candidate_frontier(
             "blocking handoff, reassign it, or create a concrete current-agent/"
             "unclaimed advancement todo before delivery."
         )
-        return {
-            "schema_version": AGENT_SCOPE_FRONTIER_SCHEMA_VERSION,
-            "agent_id": agent_id,
-            "primary_agent": normalize_todo_claimed_by(agent_identity.get("primary_agent")),
-            "action": AgentScopeFrontierAction.AGENT_SCOPE_WAIT.value,
-            "effective_action": AgentScopeFrontierAction.AGENT_SCOPE_WAIT.value,
-            "blocks_delivery": True,
-            "quiet_noop_allowed": True,
-            "spend_policy": "no quota spend while the current agent has no in-scope runnable candidate",
-            "reason": reason,
-            "recommended_action": recommended_action,
-            "candidate_counts": {
+        return build_agent_scope_frontier_payload(
+            agent_id=agent_id,
+            primary_agent=normalize_todo_claimed_by(agent_identity.get("primary_agent")),
+            action=AgentScopeFrontierAction.AGENT_SCOPE_WAIT,
+            quiet_noop_allowed=True,
+            spend_policy="no quota spend while the current agent has no in-scope runnable candidate",
+            reason=reason,
+            recommended_action=recommended_action,
+            candidate_counts={
                 "current_agent_claimed_advancement_count": current_agent_count,
                 "unclaimed_advancement_count": unclaimed_count,
                 "blocking_handoff_gate_count": len(blocking_handoff_gates),
             },
-            "other_claimants": blocking_review_claimants,
-            "blocking_review_claimants": blocking_review_claimants,
-            "blocking_handoff_gates": blocking_handoff_gates[:3],
-        }
+            extra_fields={
+                "other_claimants": blocking_review_claimants,
+                "blocking_review_claimants": blocking_review_claimants,
+                "blocking_handoff_gates": blocking_handoff_gates[:3],
+            },
+        )
 
     cleared_handoff_gates = _agent_scope_cleared_without_successor_handoff_gates(
         agent_todo_summary,
@@ -1174,25 +1149,24 @@ def _agent_scope_no_candidate_frontier(
             f"{blocker_todo_id} into a concrete {agent_id}/unclaimed advancement todo, "
             "or record an explicit no-follow-up rationale."
         )
-        return {
-            "schema_version": AGENT_SCOPE_FRONTIER_SCHEMA_VERSION,
-            "agent_id": agent_id,
-            "primary_agent": normalize_todo_claimed_by(agent_identity.get("primary_agent")),
-            "action": AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value,
-            "effective_action": AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED.value,
-            "blocks_delivery": True,
-            "requires_replan": True,
-            "quiet_noop_allowed": False,
-            "spend_policy": "spend once after validated successor replan/todo writeback",
-            "reason": reason,
-            "recommended_action": recommended_action,
-            "candidate_counts": {
+        return build_agent_scope_frontier_payload(
+            agent_id=agent_id,
+            primary_agent=normalize_todo_claimed_by(agent_identity.get("primary_agent")),
+            action=AgentScopeFrontierAction.SUCCESSOR_REPLAN_REQUIRED,
+            quiet_noop_allowed=False,
+            spend_policy="spend once after validated successor replan/todo writeback",
+            reason=reason,
+            recommended_action=recommended_action,
+            requires_replan=True,
+            candidate_counts={
                 "current_agent_claimed_advancement_count": current_agent_count,
                 "unclaimed_advancement_count": unclaimed_count,
                 "cleared_without_successor_handoff_count": len(cleared_handoff_gates),
             },
-            "cleared_without_successor_handoff_gates": cleared_handoff_gates[:3],
-        }
+            extra_fields={
+                "cleared_without_successor_handoff_gates": cleared_handoff_gates[:3],
+            },
+        )
 
     claimed_advancement_items = (
         agent_todo_summary.get("claimed_advancement_open_items")
@@ -1276,18 +1250,15 @@ def _agent_scope_no_candidate_frontier(
             "current-agent or unclaimed advancement todo, or the primary reassigns work."
         )
 
-    return {
-        "schema_version": AGENT_SCOPE_FRONTIER_SCHEMA_VERSION,
-        "agent_id": agent_id,
-        "primary_agent": primary_agent,
-        "action": action.value,
-        "effective_action": action.value,
-        "blocks_delivery": True,
-        "quiet_noop_allowed": True,
-        "spend_policy": "no quota spend while the current agent has no in-scope runnable candidate",
-        "reason": reason,
-        "recommended_action": recommended_action,
-        "candidate_counts": {
+    return build_agent_scope_frontier_payload(
+        agent_id=agent_id,
+        primary_agent=primary_agent,
+        action=action,
+        quiet_noop_allowed=True,
+        spend_policy="no quota spend while the current agent has no in-scope runnable candidate",
+        reason=reason,
+        recommended_action=recommended_action,
+        candidate_counts={
             "current_agent_claimed_advancement_count": current_agent_count,
             "unclaimed_advancement_count": unclaimed_count,
             "other_agent_claimed_advancement_count": len(other_advancement_items),
@@ -1295,10 +1266,12 @@ def _agent_scope_no_candidate_frontier(
                 claim_scope.get("other_agent_claimed_open_count") or 0
             ),
         },
-        "other_claimants": other_claimants,
-        "blocking_review_claimants": blocking_review_claimants,
-        "other_agent_claimed_items": [
-            compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
-            for item in other_advancement_items[:3]
-        ],
-    }
+        extra_fields={
+            "other_claimants": other_claimants,
+            "blocking_review_claimants": blocking_review_claimants,
+            "other_agent_claimed_items": [
+                compact_todo_summary_item(item, text=str(item.get("text") or "").strip())
+                for item in other_advancement_items[:3]
+            ],
+        },
+    )

--- a/loopx/control_plane/agents/agent_scope_frontier.py
+++ b/loopx/control_plane/agents/agent_scope_frontier.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any
+
+
+AGENT_SCOPE_FRONTIER_SCHEMA_VERSION = "agent_scope_frontier_v0"
+AGENT_LANE_FRONTIER_HINT_SCHEMA_VERSION = "agent_lane_frontier_hint_v0"
+
+
+class AgentScopeFrontierAction(str, Enum):
+    AGENT_SCOPE_EXHAUSTED = "agent_scope_exhausted"
+    AGENT_SCOPE_WAIT = "agent_scope_wait"
+    REASSIGNMENT_REQUIRED = "reassignment_required"
+    SUCCESSOR_REPLAN_REQUIRED = "successor_replan_required"
+
+
+class AgentLaneFrontierHintDecision(str, Enum):
+    CLAIM_UNOWNED_IN_SCOPE = "claim_unowned_in_scope"
+    ADD_NEXT_ADVANCEMENT = "add_next_advancement"
+    RECORD_NO_FOLLOWUP = "record_no_followup"
+    QUIET_NOOP_BLOCKER = "quiet_noop_blocker"
+
+
+def agent_scope_frontier_action(value: Any) -> AgentScopeFrontierAction | None:
+    try:
+        return AgentScopeFrontierAction(str(value or ""))
+    except ValueError:
+        return None
+
+
+def build_agent_scope_frontier_payload(
+    *,
+    agent_id: str,
+    primary_agent: str | None,
+    action: AgentScopeFrontierAction,
+    quiet_noop_allowed: bool,
+    spend_policy: str,
+    reason: str,
+    recommended_action: str,
+    candidate_counts: dict[str, Any],
+    requires_replan: bool = False,
+    extra_fields: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema_version": AGENT_SCOPE_FRONTIER_SCHEMA_VERSION,
+        "agent_id": agent_id,
+        "primary_agent": primary_agent,
+        "action": action.value,
+        "effective_action": action.value,
+        "blocks_delivery": True,
+        "quiet_noop_allowed": quiet_noop_allowed,
+        "spend_policy": spend_policy,
+        "reason": reason,
+        "recommended_action": recommended_action,
+        "candidate_counts": candidate_counts,
+    }
+    if requires_replan:
+        payload["requires_replan"] = True
+    if extra_fields:
+        payload.update(extra_fields)
+    return payload

--- a/loopx/control_plane/quota/subagent_orchestration.py
+++ b/loopx/control_plane/quota/subagent_orchestration.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from ..agents.agent_scope import AgentScopeFrontierAction
+from ..agents.agent_scope_frontier import AgentScopeFrontierAction
 from ..todos.todo_summary import normalize_todo_claimed_by
 from ..work_items.work_lane import WORK_LANE_CONTRACT_SCHEMA_VERSION
 from ..work_items.work_lane_context import build_work_lane_context_contract

--- a/loopx/control_plane/scheduler/automation_liveness.py
+++ b/loopx/control_plane/scheduler/automation_liveness.py
@@ -2,7 +2,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from ..agents.agent_scope import AgentScopeFrontierAction, _agent_scope_frontier_action
+from ..agents.agent_scope_frontier import (
+    AgentScopeFrontierAction,
+    agent_scope_frontier_action as _agent_scope_frontier_action,
+)
 from ..goals.goal_frontier import AUTONOMOUS_REPLAN_REQUIRED_MODE
 
 

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from typing import Any
 
 from ...state_projection import next_action_resolution_trace
-from ..agents.agent_scope import AgentScopeFrontierAction
+from ..agents.agent_scope_frontier import (
+    AgentScopeFrontierAction,
+    agent_scope_frontier_action as _agent_scope_frontier_action,
+)
 from ..goals.goal_frontier import AUTONOMOUS_REPLAN_REQUIRED_MODE
 from ..todos.contract import TODO_TASK_CLASS_ADVANCEMENT, TODO_TASK_CLASS_MONITOR
 from ..todos.projection import todo_item_is_actionable_open, todo_item_task_class
@@ -94,13 +97,6 @@ def user_channel_action_required(payload: dict[str, Any]) -> bool:
     return bool(payload.get("requires_user_action")) or bool(
         user_channel_action_todo_actions(payload.get("user_todo_summary"))
     )
-
-
-def _agent_scope_frontier_action(value: Any) -> AgentScopeFrontierAction | None:
-    try:
-        return AgentScopeFrontierAction(str(value or ""))
-    except ValueError:
-        return None
 
 
 def _protocol_first_candidate_action(payload: dict[str, Any]) -> str | None:


### PR DESCRIPTION
## Summary

- Extract agent-scope frontier schema/actions/parser and payload builder into `loopx/control_plane/agents/agent_scope_frontier.py`.
- Route agent-scope no-candidate frontier payload construction through the shared builder while preserving the existing `agent_scope` import surface.
- Reuse the shared frontier parser from interaction-contract and automation-liveness consumers, and add a thin characterization smoke for the builder contract.

## Validation

- `python3 -m py_compile loopx/control_plane/agents/agent_scope.py loopx/control_plane/agents/agent_scope_frontier.py loopx/control_plane/work_items/interaction_contract.py loopx/control_plane/quota/subagent_orchestration.py loopx/control_plane/scheduler/automation_liveness.py examples/control_plane/agent-scope-projection-characterization-smoke.py`
- `python3 examples/control_plane/agent-scope-projection-characterization-smoke.py`
- `python3 examples/control_plane/work-lane-contract-smoke.py`
- `python3 examples/control_plane/quota-cleared-blocker-successor-gate-smoke.py`
- `python3 examples/control_plane/interaction-contract-state-machine-smoke.py`
- `python3 examples/control_plane/automation-liveness-state-machine-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py --strict`
- `loopx check --scan-path loopx/control_plane/agents/agent_scope.py --scan-path loopx/control_plane/agents/agent_scope_frontier.py --scan-path loopx/control_plane/work_items/interaction_contract.py --scan-path loopx/control_plane/scheduler/automation_liveness.py --scan-path loopx/control_plane/quota/subagent_orchestration.py --scan-path examples/control_plane/agent-scope-projection-characterization-smoke.py`
- `git diff --check`
- `loopx canary premerge --from-git-diff` (passed, self_merge_allowed=true)
