### PR TITLE
Quiet due monitor observation repeats

### DIFF
--- a/examples/control_plane/external-evidence-observation-smoke.py
+++ b/examples/control_plane/external-evidence-observation-smoke.py
@@ -197,6 +197,56 @@ def assert_recent_unchanged_observation_quiets_external_monitor() -> None:
     assert interaction["agent_channel"]["quiet_noop_allowed"] is True, interaction
 
 
+def assert_recent_due_monitor_no_change_quiets_external_monitor() -> None:
+    summary = agent_todos(
+        [
+            monitor_todo(next_due_at=FUTURE_DUE_AT),
+            unavailable_advancement_todo(),
+        ]
+    )
+    guard = build_quota_should_run(
+        status_payload(
+            summary,
+            latest_runs=[
+                {
+                    "classification": "quota_slot_spent",
+                    "agent_id": AGENT_ID,
+                    "recommended_action": "wait quietly for material monitor evidence",
+                },
+                {
+                    "classification": "external_monitor_observation_cooldown_repaired",
+                    "agent_id": AGENT_ID,
+                    "delivery_outcome": "outcome_progress",
+                    "recommended_action": "wait quietly for material monitor evidence",
+                },
+                {
+                    "classification": "quota_monitor_poll",
+                    "agent_id": AGENT_ID,
+                    "delivery_outcome": "surface_only",
+                    "health_check": "due monitor observation unchanged; no quota spend; next due updated",
+                    "monitor_event": {
+                        "monitor_mode": "due_monitor_observed_without_material_transition",
+                        "material_change": False,
+                    },
+                },
+            ],
+        ),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+    assert guard["decision"] == "skip", guard
+    assert guard["should_run"] is False, guard
+    assert guard["effective_action"] == "monitor_quiet_skip", guard
+    assert "external_evidence_observation" not in guard, guard
+    recent = guard["external_evidence_observation_recent"]
+    assert recent["classification"] == "quota_monitor_poll", guard
+    assert recent["monitor_mode"] == "due_monitor_observed_without_material_transition", guard
+    assert recent["reason"] == "recent monitor observation was unchanged", guard
+    interaction = guard["interaction_contract"]
+    assert interaction["agent_channel"]["must_attempt"] is False, interaction
+    assert interaction["agent_channel"]["quiet_noop_allowed"] is True, interaction
+
+
 def assert_advancement_lane_keeps_external_monitor_as_context() -> None:
     summary = agent_todos(
         [
@@ -270,6 +320,7 @@ def assert_explicit_external_wait_builds_registry_obligation() -> None:
 def main() -> int:
     assert_monitor_only_launched_poll_requires_observation()
     assert_recent_unchanged_observation_quiets_external_monitor()
+    assert_recent_due_monitor_no_change_quiets_external_monitor()
     assert_advancement_lane_keeps_external_monitor_as_context()
     assert_future_scoped_monitor_does_not_fake_external_poll()
     assert_explicit_external_wait_builds_registry_obligation()

--- a/loopx/control_plane/quota/recent_runs.py
+++ b/loopx/control_plane/quota/recent_runs.py
@@ -46,16 +46,18 @@ def recent_external_monitor_observation_unchanged(
         health_check = str(run.get("health_check") or "").strip().lower()
         if monitor_event.get("material_change") is True:
             return None
-        if (
-            monitor_mode == "external_monitor_observed_without_material_transition"
+        monitor_unchanged = (
+            monitor_mode.endswith("_observed_without_material_transition")
+            or "monitor observation unchanged" in health_check
+            or "due monitor observation unchanged" in health_check
             or "external monitor observation unchanged" in health_check
-        ):
+        )
+        if monitor_unchanged:
             return {
                 "classification": QUOTA_MONITOR_POLL_CLASSIFICATION,
                 "generated_at": run.get("generated_at"),
                 "agent_id": run_agent_id or None,
-                "monitor_mode": monitor_mode
-                or "external_monitor_observed_without_material_transition",
-                "reason": "recent external monitor observation was unchanged",
+                "monitor_mode": monitor_mode or "monitor_observed_without_material_transition",
+                "reason": "recent monitor observation was unchanged",
             }
     return None


### PR DESCRIPTION
Summary
- Treat recent due-monitor no-change polls as monitor observations that can cool down external evidence observation.
- Keep material-change monitor polls from quieting follow-up observation.
- Add smoke coverage for the real refresh/spend-after-due-monitor path.

Validation
- python3 -m py_compile loopx/control_plane/quota/recent_runs.py loopx/quota.py examples/control_plane/external-evidence-observation-smoke.py
- python3 examples/control_plane/external-evidence-observation-smoke.py
- python3 examples/control_plane/heartbeat-quota-flow-smoke.py
- python3 examples/control_plane/monitor-poll-policy-smoke.py
- python3 examples/control_plane/repo-python-line-budget-smoke.py
- loopx check --scan-path loopx/control_plane/quota/recent_runs.py --scan-path examples/control_plane/external-evidence-observation-smoke.py
- loopx canary premerge --from-git-diff

Self-merge rationale
- Narrow control-plane monitor cooldown fix, public-safe, validated by focused smokes plus premerge gate; no benchmark launch, scoring change, private evidence, credentials, or raw logs.