### PR TITLE
Centralize autonomous replan obligation payloads

### DIFF
--- a/examples/control_plane/autonomous-replan-obligation-readmodel-smoke.py
+++ b/examples/control_plane/autonomous-replan-obligation-readmodel-smoke.py
@@ -14,6 +14,7 @@ if str(REPO_ROOT) not in sys.path:
 from loopx.control_plane.work_items.autonomous_replan_obligation import (  # noqa: E402
     autonomous_replan_obligation_from_state as direct_autonomous_replan_obligation_from_state,
     build_autonomous_replan_obligation as direct_build_autonomous_replan_obligation,
+    build_autonomous_replan_obligation_payload,
 )
 from loopx.status import (  # noqa: E402
     AUTONOMOUS_REPLAN_SECTION_HEADINGS,
@@ -71,6 +72,57 @@ def assert_parity(evidence: list[dict[str, object]]) -> dict[str, object]:
     return wrapper
 
 
+def assert_payload_builder_contract() -> None:
+    payload = build_autonomous_replan_obligation_payload(
+        schema_version=AUTONOMOUS_REPLAN_SCHEMA_VERSION,
+        agent_id="codex-product-capability",
+        stall_threshold=1,
+        trigger_count=1,
+        triggers=[
+            {
+                "kind": "vision_acceptance_gap",
+                "section": "goal_frontier_projection.acceptance_gaps",
+                "text": "active agent vision remains open",
+            }
+        ],
+        guidance_actions=["create_successor", "record_no_followup"],
+        todo_actions=[
+            {
+                "action": "add",
+                "role": "agent",
+                "priority": "P1",
+                "text": "run a bounded vision-gap replan",
+            }
+        ],
+        stop_condition="stop at private material or owner-only decisions",
+        recommended_action="create a successor or record no-follow-up",
+        extra_fields={"source": "goal_frontier_projection"},
+    )
+
+    assert payload["schema_version"] == AUTONOMOUS_REPLAN_SCHEMA_VERSION, payload
+    assert payload["required"] is True, payload
+    assert payload["agent_id"] == "codex-product-capability", payload
+    assert payload["triggers"][0]["kind"] == "vision_acceptance_gap", payload
+    assert payload["guidance_actions"] == ["create_successor", "record_no_followup"], payload
+    assert payload["todo_actions"][0]["priority"] == "P1", payload
+    assert payload["source"] == "goal_frontier_projection", payload
+
+    unscoped_payload = build_autonomous_replan_obligation_payload(
+        schema_version=AUTONOMOUS_REPLAN_SCHEMA_VERSION,
+        agent_id=None,
+        include_agent_id=True,
+        stall_threshold=1,
+        trigger_count=1,
+        triggers=[],
+        guidance_actions=[],
+        todo_actions=[],
+        stop_condition="stop at owner-only decisions",
+        recommended_action="run a bounded replan",
+    )
+    assert "agent_id" in unscoped_payload, unscoped_payload
+    assert unscoped_payload["agent_id"] is None, unscoped_payload
+
+
 def direct_state_obligation() -> dict[str, object] | None:
     return direct_autonomous_replan_obligation_from_state(
         STATE_TEXT,
@@ -84,6 +136,8 @@ def direct_state_obligation() -> dict[str, object] | None:
 
 
 def main() -> int:
+    assert_payload_builder_contract()
+
     regular = assert_parity(
         [
             {

--- a/loopx/control_plane/goals/goal_frontier.py
+++ b/loopx/control_plane/goals/goal_frontier.py
@@ -12,6 +12,9 @@ from ..work_items.autonomous_replan_ack import (
     autonomous_replan_ack_matches_agent,
     latest_autonomous_replan_ack_for_projection,
 )
+from ..work_items.autonomous_replan_obligation import (
+    build_autonomous_replan_obligation_payload,
+)
 from ..work_items.repair_delta import repair_delta_kinds_have_frontier_delta
 
 
@@ -963,19 +966,19 @@ def derive_goal_frontier_replan_obligation_from_summaries(
             }
             for item in succession_gap_items[:3]
         ]
-        return {
-            "schema_version": AUTONOMOUS_REPLAN_OBLIGATION_SCHEMA_VERSION,
-            "required": True,
-            "agent_id": agent_id,
-            "stall_threshold": 1,
-            "trigger_count": len(succession_gap_items),
-            "triggers": triggers,
-            "guidance_actions": [
+        return build_autonomous_replan_obligation_payload(
+            schema_version=AUTONOMOUS_REPLAN_OBLIGATION_SCHEMA_VERSION,
+            agent_id=agent_id,
+            include_agent_id=True,
+            stall_threshold=1,
+            trigger_count=len(succession_gap_items),
+            triggers=triggers,
+            guidance_actions=[
                 "create_successor",
                 "link_successor",
                 "record_no_followup",
             ],
-            "todo_actions": [
+            todo_actions=[
                 {
                     "action": "add",
                     "role": "agent",
@@ -987,27 +990,27 @@ def derive_goal_frontier_replan_obligation_from_summaries(
                     ),
                 }
             ],
-            "stop_condition": (
+            stop_condition=(
                 "stop if the successor decision requires private material, "
                 "credentials, destructive git, production actions, or owner-only decisions"
             ),
-            "recommended_action": (
+            recommended_action=(
                 "run a bounded successor replan before another quiet poll: add/link "
                 "the next advancement todo, or record explicit no-follow-up"
             ),
-        }
+        )
     if (
         compact_acceptance_gaps
         and agent_counts.get("advancement", 0) == 0
         and total_frontier_advancement == 0
     ):
-        return {
-            "schema_version": AUTONOMOUS_REPLAN_OBLIGATION_SCHEMA_VERSION,
-            "required": True,
-            "agent_id": agent_id,
-            "stall_threshold": 1,
-            "trigger_count": len(compact_acceptance_gaps),
-            "triggers": [
+        return build_autonomous_replan_obligation_payload(
+            schema_version=AUTONOMOUS_REPLAN_OBLIGATION_SCHEMA_VERSION,
+            agent_id=agent_id,
+            include_agent_id=True,
+            stall_threshold=1,
+            trigger_count=len(compact_acceptance_gaps),
+            triggers=[
                 {
                     "kind": gap.get("kind") or VISION_ACCEPTANCE_GAP_TRIGGER,
                     "section": "goal_frontier_projection.acceptance_gaps",
@@ -1018,13 +1021,13 @@ def derive_goal_frontier_replan_obligation_from_summaries(
                 }
                 for gap in compact_acceptance_gaps[:3]
             ],
-            "guidance_actions": [
+            guidance_actions=[
                 "create_successor",
                 "update_agent_vision",
                 "record_evidence_gap",
                 "record_no_followup",
             ],
-            "todo_actions": [
+            todo_actions=[
                 {
                     "action": "add",
                     "role": "agent",
@@ -1035,16 +1038,16 @@ def derive_goal_frontier_replan_obligation_from_summaries(
                     ),
                 }
             ],
-            "stop_condition": (
+            stop_condition=(
                 "stop if the gap requires private material, credentials, destructive git, "
                 "production actions, or owner-only decisions"
             ),
-            "recommended_action": (
+            recommended_action=(
                 "run a bounded vision-gap replan before another quiet poll: create "
                 "successor work, update the agent vision, record evidence gap, or "
                 "record no-follow-up"
             ),
-        }
+        )
     long_chain_trigger = _long_todo_chain_trigger(
         agent_todo_summary=agent_todo_summary,
         agent_counts=agent_counts,
@@ -1054,13 +1057,13 @@ def derive_goal_frontier_replan_obligation_from_summaries(
     if long_chain_trigger and not autonomous_replan_ack_has_frontier_delta(
         latest_replan_ack
     ):
-        return {
-            "schema_version": AUTONOMOUS_REPLAN_OBLIGATION_SCHEMA_VERSION,
-            "required": True,
-            "agent_id": agent_id,
-            "stall_threshold": long_chain_trigger.get("threshold"),
-            "trigger_count": long_chain_trigger.get("trigger_count"),
-            "triggers": [
+        return build_autonomous_replan_obligation_payload(
+            schema_version=AUTONOMOUS_REPLAN_OBLIGATION_SCHEMA_VERSION,
+            agent_id=agent_id,
+            include_agent_id=True,
+            stall_threshold=long_chain_trigger.get("threshold"),
+            trigger_count=long_chain_trigger.get("trigger_count"),
+            triggers=[
                 {
                     "kind": LONG_TODO_CHAIN_TRIGGER,
                     "section": "agent_todo_summary",
@@ -1071,14 +1074,14 @@ def derive_goal_frontier_replan_obligation_from_summaries(
                     **long_chain_trigger,
                 }
             ],
-            "guidance_actions": [
+            guidance_actions=[
                 "read_evidence_log",
                 "run_bounded_public_research_if_local_evidence_is_missing",
                 "group_or_prune_todo_chain",
                 "update_agent_vision",
                 "create_successor",
             ],
-            "todo_actions": [
+            todo_actions=[
                 {
                     "action": "add",
                     "role": "agent",
@@ -1090,16 +1093,16 @@ def derive_goal_frontier_replan_obligation_from_summaries(
                     ),
                 }
             ],
-            "stop_condition": (
+            stop_condition=(
                 "stop if pruning or external research requires private material, "
                 "credentials, destructive git, production actions, or owner-only decisions"
             ),
-            "recommended_action": (
+            recommended_action=(
                 "run a bounded long-chain vision replan before continuing a 15+ "
                 "todo lane: read evidence, use public research if local evidence "
                 "is weak, group/prune work, and write a concrete todo or vision delta"
             ),
-        }
+        )
     if autonomous_replan_ack_has_frontier_delta(latest_replan_ack):
         return None
     if not _is_monitor_only_lane(work_lane_contract):
@@ -1110,12 +1113,11 @@ def derive_goal_frontier_replan_obligation_from_summaries(
         return None
     future_schedule_present = _monitor_only_lane_has_future_schedule(agent_todo_summary)
 
-    return {
-        "schema_version": AUTONOMOUS_REPLAN_OBLIGATION_SCHEMA_VERSION,
-        "required": True,
-        "stall_threshold": 1,
-        "trigger_count": 1,
-        "triggers": [
+    return build_autonomous_replan_obligation_payload(
+        schema_version=AUTONOMOUS_REPLAN_OBLIGATION_SCHEMA_VERSION,
+        stall_threshold=1,
+        trigger_count=1,
+        triggers=[
             {
                 "kind": FRONTIER_EXHAUSTED_MONITOR_TRIGGER,
                 "section": "goal_frontier_projection",
@@ -1129,13 +1131,13 @@ def derive_goal_frontier_replan_obligation_from_summaries(
                 "future_monitor_schedule_present": future_schedule_present,
             }
         ],
-        "guidance_actions": [
+        guidance_actions=[
             "create_successor",
             "supersede_monitor",
             "set_watch_expiry",
             "record_no_followup",
         ],
-        "todo_actions": [
+        todo_actions=[
             {
                 "action": "add",
                 "role": "agent",
@@ -1147,16 +1149,16 @@ def derive_goal_frontier_replan_obligation_from_summaries(
                 ),
             }
         ],
-        "stop_condition": (
+        stop_condition=(
             "stop if the replan requires private material, credentials, destructive git, "
             "production actions, or owner-only decisions"
         ),
-        "recommended_action": (
+        recommended_action=(
             "run a bounded goal-frontier replan before another monitor-only quiet "
             "poll: create successor work, supersede the monitor lane, set an expiry, "
             "record watch-lane continuation, or record no-follow-up"
         ),
-    }
+    )
 
 
 def build_goal_frontier_projection_from_summaries(

--- a/loopx/control_plane/work_items/autonomous_replan_obligation.py
+++ b/loopx/control_plane/work_items/autonomous_replan_obligation.py
@@ -310,28 +310,27 @@ def build_autonomous_replan_obligation(
             "monitor-only or repeated action consumes the eligible turn"
         )
 
-    result = {
-        "schema_version": autonomous_replan_schema_version,
-        "required": True,
-        "stall_threshold": (
+    result = build_autonomous_replan_obligation_payload(
+        schema_version=autonomous_replan_schema_version,
+        stall_threshold=(
             dead_monitor_repeat_threshold
             if dead_monitor_evidence
             else autonomous_replan_stall_threshold
         ),
-        "trigger_count": len(evidence),
-        "triggers": evidence,
-        "guidance_actions": (
+        trigger_count=len(evidence),
+        triggers=evidence,
+        guidance_actions=(
             ["set_watch_expiry", "write_blocker", "supersede_monitor", "create_successor"]
             if dead_monitor_evidence
             else ["keep", "split", "add", "retire", "ask_decision"]
         ),
-        "todo_actions": todo_actions[:3],
-        "stop_condition": (
+        todo_actions=todo_actions[:3],
+        stop_condition=(
             "stop if the replan requires private material, credentials, destructive git, "
             "production actions, or owner-only decisions"
         ),
-        "recommended_action": recommended_action,
-    }
+        recommended_action=recommended_action,
+    )
     if dead_monitor_evidence:
         result["dead_monitor_detector"] = {
             "schema_version": dead_monitor_repeat_schema_version,
@@ -346,6 +345,38 @@ def build_autonomous_replan_obligation(
             ],
         }
     return result
+
+
+def build_autonomous_replan_obligation_payload(
+    *,
+    schema_version: str,
+    stall_threshold: int,
+    trigger_count: int,
+    triggers: list[dict[str, Any]],
+    guidance_actions: list[str],
+    todo_actions: list[dict[str, Any]],
+    stop_condition: str,
+    recommended_action: str,
+    agent_id: str | None = None,
+    include_agent_id: bool = False,
+    extra_fields: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "schema_version": schema_version,
+        "required": True,
+        "stall_threshold": stall_threshold,
+        "trigger_count": trigger_count,
+        "triggers": triggers,
+        "guidance_actions": guidance_actions,
+        "todo_actions": todo_actions,
+        "stop_condition": stop_condition,
+        "recommended_action": recommended_action,
+    }
+    if include_agent_id or agent_id is not None:
+        payload["agent_id"] = agent_id
+    if extra_fields:
+        payload.update(extra_fields)
+    return payload
 
 
 def autonomous_replan_obligation_from_runs(


### PR DESCRIPTION
## Summary

- Add a shared `build_autonomous_replan_obligation_payload` helper in the existing autonomous replan obligation read-model module.
- Route goal-frontier succession, vision-gap, long-chain, and monitor-only replan obligations through that helper while preserving existing payload shapes.
- Extend the autonomous replan read-model smoke with a thin payload-builder contract check, including unscoped `agent_id: null` compatibility.

## Validation

- `python3 -m py_compile loopx/control_plane/goals/goal_frontier.py loopx/control_plane/work_items/autonomous_replan_obligation.py examples/control_plane/autonomous-replan-obligation-readmodel-smoke.py`
- `python3 examples/control_plane/autonomous-replan-obligation-readmodel-smoke.py`
- `python3 examples/control_plane/todo-projection-shared-helper-smoke.py`
- `python3 examples/control_plane/quota-replan-decision-plane-smoke.py`
- `python3 examples/control_plane/work-lane-contract-smoke.py`
- `python3 examples/control_plane/heartbeat-quota-flow-smoke.py`
- `python3 examples/control_plane/run-compaction-readmodel-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py --strict`
- `loopx check --scan-path loopx/control_plane/goals/goal_frontier.py --scan-path loopx/control_plane/work_items/autonomous_replan_obligation.py --scan-path examples/control_plane/autonomous-replan-obligation-readmodel-smoke.py`
- `git diff --check`
- `loopx canary premerge --from-git-diff` (passed, selected=17, failures=0, self_merge_allowed=true)
