### PR TITLE
Keep setup failures out of benchmark countable scores

### DIFF
--- a/examples/benchmark-ledger-countability-smoke.py
+++ b/examples/benchmark-ledger-countability-smoke.py
@@ -1,0 +1,187 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.benchmark_ledger import (  # noqa: E402
+    BENCHMARK_RUN_LEDGER_SCHEMA_VERSION,
+    benchmark_run_official_score_countability,
+    build_benchmark_run_ledger_current_aggregate,
+    upsert_benchmark_run_ledger_entry,
+)
+
+
+def _setup_preflight_run() -> dict[str, object]:
+    return {
+        "schema_version": "benchmark_run_v0",
+        "benchmark_id": "skillsbench@1.1",
+        "case_id": "setup-preflight-case",
+        "case_ids": ["setup-preflight-case"],
+        "run_id": "setup-preflight-case-run",
+        "run_group_id": "skillsbench-codex-cli-goal-xhigh-setup-preflight-case",
+        "official_score_status": "missing",
+        "official_score": None,
+        "official_task_score": {
+            "kind": "skillsbench_verifier_reward_missing",
+            "value": None,
+            "passed": False,
+        },
+        "official_score_attempt_countable": True,
+        "attempt_accounting": {
+            "lifecycle_phase": "not_started",
+            "failure_class": "none",
+            "failure_label": "not_run_adapter_skeleton",
+            "launcher_attempt_countable": False,
+            "case_attempt_countable": False,
+            "solver_attempt_countable": False,
+            "verifier_attempt_countable": False,
+            "official_score_attempt_countable": False,
+        },
+        "failure_class": "skillsbench_runner_error",
+        "failure_scope": "runner_or_setup",
+        "score_status": "missing",
+    }
+
+
+def test_missing_verifier_reward_bool_does_not_override_uncountable_attempt() -> None:
+    run = _setup_preflight_run()
+
+    countability = benchmark_run_official_score_countability(run)
+    assert countability == {
+        "countable": False,
+        "reason": "official_score_attempt_not_countable",
+        "score": 0.0,
+    }, countability
+
+    persisted_run = dict(run)
+    persisted_run.pop("official_task_score")
+    persisted_run.pop("attempt_accounting")
+    persisted_run["official_score"] = 0.0
+    persisted_run["official_score_status"] = None
+    persisted_run["score_status"] = "failed"
+    persisted_run["attempt_lifecycle_phase"] = "not_started"
+
+    persisted_countability = benchmark_run_official_score_countability(persisted_run)
+    assert persisted_countability == {
+        "countable": False,
+        "reason": "official_score_attempt_not_countable",
+        "score": 0.0,
+    }, persisted_countability
+
+    ledger = upsert_benchmark_run_ledger_entry(
+        {
+            "schema_version": BENCHMARK_RUN_LEDGER_SCHEMA_VERSION,
+            "benchmarks": {},
+        },
+        persisted_run,
+    )
+    aggregate = build_benchmark_run_ledger_current_aggregate(
+        ledger,
+        benchmark_id="skillsbench@1.1",
+        canonical_case_ids=["setup-preflight-case"],
+    )
+    summary = aggregate["countable_score_summary"]
+    assert summary["countable_case_count"] == 0, aggregate
+    assert summary["uncountable_numeric_case_ids"] == ["setup-preflight-case"], aggregate
+    assert aggregate["case_best"]["setup-preflight-case"]["bucket"] == (
+        "uncountable_official_score"
+    ), aggregate
+
+
+def test_real_bool_official_result_remains_countable_zero() -> None:
+    run = _setup_preflight_run()
+    run["failure_class"] = "official_verifier_solution_failure"
+    run["failure_scope"] = "case_or_solution"
+    run["official_score_attempt_countable"] = False
+    run["official_task_score"] = {"kind": "skillsbench_reward", "passed": False}
+    run["score_status"] = "missing"
+
+    assert benchmark_run_official_score_countability(run) == {
+        "countable": True,
+        "reason": "countable_official_score",
+        "score": 0.0,
+    }
+
+
+def test_verifier_infrastructure_failure_zero_is_uncountable() -> None:
+    run = _setup_preflight_run()
+    run.pop("official_task_score")
+    run.pop("attempt_accounting")
+    run["case_id"] = "verifier-timeout-case"
+    run["case_ids"] = ["verifier-timeout-case"]
+    run["run_id"] = "verifier-timeout-case-run"
+    run["run_group_id"] = "skillsbench-codex-cli-goal-xhigh-verifier-timeout-case"
+    run["official_score"] = 0.0
+    run["official_score_status"] = None
+    run["official_score_attempt_countable"] = None
+    run["score_status"] = "failed"
+    run["failure_class"] = "verifier_infrastructure_failure"
+    run["failure_scope"] = "verifier_or_infra"
+    run["score_failure_attribution"] = "verifier_infrastructure_failure"
+
+    countability = benchmark_run_official_score_countability(run)
+    assert countability == {
+        "countable": False,
+        "reason": "official_score_attempt_not_countable",
+        "score": 0.0,
+    }, countability
+
+    ledger = upsert_benchmark_run_ledger_entry(
+        {
+            "schema_version": BENCHMARK_RUN_LEDGER_SCHEMA_VERSION,
+            "benchmarks": {},
+        },
+        run,
+    )
+    aggregate = build_benchmark_run_ledger_current_aggregate(
+        ledger,
+        benchmark_id="skillsbench@1.1",
+        canonical_case_ids=["verifier-timeout-case"],
+    )
+    summary = aggregate["countable_score_summary"]
+    assert summary["countable_case_count"] == 0, aggregate
+    assert summary["uncountable_numeric_case_ids"] == ["verifier-timeout-case"], aggregate
+    assert aggregate["case_best"]["verifier-timeout-case"]["bucket"] == (
+        "uncountable_official_score"
+    ), aggregate
+
+
+def test_verifier_dependency_failure_zero_is_uncountable() -> None:
+    run = _setup_preflight_run()
+    run.pop("official_task_score")
+    run.pop("attempt_accounting")
+    run["case_id"] = "verifier-dependency-case"
+    run["case_ids"] = ["verifier-dependency-case"]
+    run["run_id"] = "verifier-dependency-case-run"
+    run["run_group_id"] = "skillsbench-codex-cli-goal-xhigh-verifier-dependency-case"
+    run["official_score"] = 0.0
+    run["official_score_status"] = None
+    run["official_score_attempt_countable"] = None
+    run["score_status"] = "failed"
+    run["failure_class"] = "verifier_dependency_install_failure"
+    run["failure_scope"] = "verifier_or_infra"
+    run["score_failure_attribution"] = "verifier_dependency_install_failure"
+
+    countability = benchmark_run_official_score_countability(run)
+    assert countability == {
+        "countable": False,
+        "reason": "official_score_attempt_not_countable",
+        "score": 0.0,
+    }, countability
+
+
+def main() -> None:
+    test_missing_verifier_reward_bool_does_not_override_uncountable_attempt()
+    test_real_bool_official_result_remains_countable_zero()
+    test_verifier_infrastructure_failure_zero_is_uncountable()
+    test_verifier_dependency_failure_zero_is_uncountable()
+    print("benchmark-ledger-countability-smoke: ok")
+
+
+if __name__ == "__main__":
+    main()

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -15,6 +15,7 @@ from .benchmark_core import (
 from .benchmark_adapters.skillsbench_signals import (
     build_skillsbench_solution_quality_signals,
 )
+from .benchmark_ledger_countability import official_score_attempt_uncountable, official_score_bool_fallback_used
 
 
 BENCHMARK_RUN_LEDGER_SCHEMA_VERSION = "benchmark_run_ledger_v0"
@@ -461,18 +462,15 @@ def benchmark_run_official_score_countability(run: dict[str, Any]) -> dict[str, 
     )
     if explicit_attempt_countable is None:
         explicit_attempt_countable = accounting.get("official_score_attempt_countable")
-    has_official_bool_score = isinstance(_official_task_score_bool_passed(run), bool)
-    if explicit_attempt_countable is False and not has_official_bool_score:
+    has_official_bool_score = official_score_bool_fallback_used(run) or run.get("official_score_bool_fallback_used") is True
+    if official_score_attempt_uncountable(run, accounting, has_official_bool_score):
         return {
             "countable": False,
             "reason": "official_score_attempt_not_countable",
             "score": score,
         }
 
-    score_status = _compact_text(
-        run.get("official_score_status") or run.get("score_status"),
-        limit=80,
-    )
+    score_status = _compact_text(run.get("official_score_status") or run.get("score_status"), limit=80)
     if (
         score_status == "missing"
         and score is not None
@@ -1816,6 +1814,7 @@ def build_benchmark_run_ledger_entry(
     job_name = _compact_text(benchmark_run.get("job_name"), limit=160)
     mode = _compact_text(benchmark_run.get("mode"), limit=120)
     score, passed = _official_score(benchmark_run)
+    bool_fallback_used = official_score_bool_fallback_used(benchmark_run)
     score_status = _score_status(benchmark_run, score, passed)
     failure_class = _failure_class(benchmark_run, score)
     failure_scope = _failure_scope(failure_class, score, passed)
@@ -1996,6 +1995,7 @@ def build_benchmark_run_ledger_entry(
         "score_status": score_status,
         "official_score": score,
         "official_passed": passed,
+        "official_score_bool_fallback_used": bool_fallback_used,
         "first_success_round": first_success_round,
         "final_round": final_round,
         "final_round_reward": final_round_reward,
@@ -2219,7 +2219,7 @@ def build_benchmark_run_ledger_entry(
             if isinstance(marker.get("attempt_accounting"), dict)
             else {}
         )
-    has_official_bool_score = isinstance(_official_task_score_bool_passed(benchmark_run), bool)
+    has_official_bool_score = official_score_bool_fallback_used(benchmark_run)
     if attempt_accounting:
         for source_field, entry_field in (
             ("lifecycle_phase", "attempt_lifecycle_phase"),

--- a/loopx/benchmark_ledger_countability.py
+++ b/loopx/benchmark_ledger_countability.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def _compact_text(value: Any, *, limit: int = 160) -> str:
+    if value is None:
+        return ""
+    text = " ".join(str(value).split())
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 3)] + "..."
+
+
+def _numeric_score_value(value: Any) -> float | None:
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    return None
+
+
+def official_score_bool_fallback_used(run: dict[str, Any]) -> bool:
+    official = (
+        run.get("official_task_score")
+        if isinstance(run.get("official_task_score"), dict)
+        else {}
+    )
+    if not isinstance(official.get("passed"), bool):
+        return False
+    if _numeric_score_value(official.get("value")) is not None:
+        return False
+    if _numeric_score_value(run.get("official_score")) is not None:
+        return False
+    return True
+
+
+def official_score_attempt_uncountable(
+    run: dict[str, Any],
+    accounting: dict[str, Any],
+    has_official_bool_score: bool,
+) -> bool:
+    """Return true when a candidate official score came from a non-countable attempt."""
+
+    official = (
+        run.get("official_task_score")
+        if isinstance(run.get("official_task_score"), dict)
+        else {}
+    )
+    if (
+        _compact_text(official.get("kind"), limit=120)
+        == "skillsbench_verifier_reward_missing"
+        and _numeric_score_value(official.get("value")) is None
+    ):
+        return True
+
+    explicit_attempt_countable = run.get("official_score_attempt_countable")
+    if explicit_attempt_countable is None:
+        explicit_attempt_countable = accounting.get("official_score_attempt_countable")
+    if explicit_attempt_countable is False and not has_official_bool_score:
+        return True
+
+    lifecycle_phase = _compact_text(
+        run.get("attempt_lifecycle_phase") or accounting.get("lifecycle_phase"),
+        limit=120,
+    )
+    failure_scope = _compact_text(run.get("failure_scope"), limit=120)
+    failure_class = _compact_text(
+        run.get("score_failure_attribution")
+        or run.get("failure_class")
+        or accounting.get("failure_class")
+        or accounting.get("failure_label"),
+        limit=180,
+    ).lower()
+    if has_official_bool_score:
+        return False
+
+    if (
+        failure_scope == "runner_or_setup"
+        and lifecycle_phase in {"not_started", "runner_accepted_args"}
+        and any(
+            marker in failure_class
+            for marker in ("runner", "setup", "preflight", "docker", "compose")
+        )
+    ):
+        return True
+
+    if failure_scope == "verifier_or_infra":
+        return True
+
+    return False


### PR DESCRIPTION
## Summary

- Split benchmark official-score countability into a focused helper.
- Keep runner/setup early failures out of countable score aggregates even when persisted rows contain `official_score=0.0`.
- Preserve the intended boolean official-result fallback: real `official_task_score.passed=false` without a numeric reward remains countable as `0.0` when it is not a verifier-reward-missing/setup failure.

## Validation

- `python3 -m py_compile loopx/benchmark_ledger.py loopx/benchmark_ledger_countability.py examples/benchmark-ledger-countability-smoke.py`
- `python3 examples/benchmark-ledger-countability-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `python3 examples/benchmark-run-ledger-smoke.py`
- `python3 examples/skillsbench-current-ledger-aggregate-smoke.py`
- `loopx check --scan-path loopx/benchmark_ledger.py --scan-path loopx/benchmark_ledger_countability.py --scan-path examples/benchmark-ledger-countability-smoke.py`
- `loopx canary premerge --from-git-diff` passed direct checks, selected catalog canaries, and public-boundary checks; it reports the expected `benchmark_sensitive` manual review hold, so this PR is not self-merged.

## Notes

This only changes ledger countability classification. It does not change benchmark task semantics, runner launch behavior, raw evidence handling, or leaderboard/submission behavior.
