### PR TITLE
Refactor auto-research demo frontier projection

### DIFF
--- a/examples/decentralized-auto-research-frontier-smoke.py
+++ b/examples/decentralized-auto-research-frontier-smoke.py
@@ -185,6 +185,51 @@ def main() -> None:
     assert live_payload["public_boundary"]["source"] == "live_quota_status_projection", live_payload
     assert_no_private_surface(live_payload)
 
+    live_from_todo_summary = build_live_auto_research_projection(
+        goal_id="loopx-auto-research-demo",
+        agent_id="research-curator",
+        quota_payload={
+            "ok": True,
+            "agent_todo_summary": {
+                "claimed_advancement_open_items": [
+                    {
+                        "todo_id": "todo_auto_summary_001",
+                        "title": "Write the public-safe research contract",
+                        "claimed_by": "research-curator",
+                        "status": "open",
+                        "task_class": "advancement_task",
+                        "action_kind": "write_research_contract",
+                    }
+                ],
+                "claimed_by_others_items": [
+                    {
+                        "todo_id": "todo_auto_summary_002",
+                        "title": "Wait for contract before proposing a hypothesis",
+                        "claimed_by": "hypothesis-proposer",
+                        "status": "open",
+                        "task_class": "advancement_task",
+                        "action_kind": "propose_hypothesis",
+                        "resume_when": "todo_done:todo_auto_summary_001",
+                        "resume_ready": False,
+                    }
+                ],
+            },
+        },
+    )
+    assert live_from_todo_summary["frontier"]["selected"]["todo_id"] == (
+        "todo_auto_summary_001"
+    ), live_from_todo_summary
+    assert live_from_todo_summary["frontier"]["selected"]["allowed_action"] == (
+        "write_research_contract"
+    ), live_from_todo_summary
+    assert [item["todo_id"] for item in live_from_todo_summary["frontier"]["runnable"]] == [
+        "todo_auto_summary_001"
+    ], live_from_todo_summary
+    assert live_from_todo_summary["frontier"]["blocked"][0]["blocked_by"] == (
+        "claimed_by:hypothesis-proposer"
+    ), live_from_todo_summary
+    assert_no_private_surface(live_from_todo_summary)
+
     print("decentralized-auto-research-frontier-smoke ok")
 
 

--- a/loopx/capabilities/auto_research/demo_e2e.py
+++ b/loopx/capabilities/auto_research/demo_e2e.py
@@ -358,6 +358,154 @@ def _command_text(
     return " ".join(parts)
 
 
+def _build_demo_frontier_route_contract(
+    *,
+    goal_id: str,
+    tracking_goal: str,
+    preset_context: dict[str, object] | None,
+    goal_surface_mode: str,
+    reuses_default_internal_goal: bool,
+) -> dict[str, object]:
+    return {
+        "schema_version": "auto_research_demo_frontier_route_v0",
+        "goal_surface_mode": goal_surface_mode,
+        "frontier_goal_id": goal_id,
+        "tracking_goal_id": tracking_goal or None,
+        "preset_id": preset_context.get("preset_id") if preset_context else None,
+        "preset_baseline_source": (
+            preset_context.get("baseline_source") if preset_context else None
+        ),
+        "tracking_goal_drives_frontier": False,
+        "visible_lanes_read_goal_id": goal_id,
+        "fresh_goal_default": goal_surface_mode == "fresh_demo_goal",
+        "inherits_default_goal": goal_surface_mode == "inherited_default_goal",
+        "reuses_default_internal_goal": reuses_default_internal_goal,
+        "default_internal_goal_id": AUTO_RESEARCH_DEFAULT_GOAL_ID,
+        "dedicated_positive_demo_frontier": not reuses_default_internal_goal,
+        "reason": (
+            "Omitting --goal-id creates an isolated demo goal surface. "
+            "Use --goal-id to target a specific research frontier, or --inherit-default-goal "
+            "to intentionally reuse the internal shared demo goal. --tracking-goal-id is metadata "
+            "for the parent productization goal and must not reroute panes."
+        ),
+    }
+
+
+def _build_demo_e2e_commands(
+    *,
+    cli_bin: str,
+    objective: str,
+    preset_id: str | None,
+    output_language: str,
+    goal_id: str,
+    agent_id: str,
+    tracking_goal: str,
+    session_name: str,
+) -> dict[str, str]:
+    tracking_goal_id = tracking_goal or None
+    return {
+        "one_question_contract": auto_research_contract_command_text(
+            cli_bin=cli_bin,
+            objective=objective,
+        ),
+        "one_question_start": auto_research_start_command_text(
+            cli_bin=cli_bin,
+            objective=objective,
+            preset_id=preset_id,
+            execute=True,
+            output_language=output_language,
+        ),
+        "one_question_start_preview": auto_research_start_command_text(
+            cli_bin=cli_bin,
+            objective=objective,
+            preset_id=preset_id,
+            output_language=output_language,
+        ),
+        "one_question_start_with_visible_wake": auto_research_start_command_text(
+            cli_bin=cli_bin,
+            objective=objective,
+            preset_id=preset_id,
+            execute=True,
+            output_language=output_language,
+        ),
+        "one_command_worker_loop": _command_text(
+            cli_bin=cli_bin,
+            goal_id=goal_id,
+            agent_id=agent_id,
+            execute=True,
+            run_worker_loop=True,
+            tracking_goal_id=tracking_goal_id,
+            output_language=output_language,
+        ),
+        "headless_worker_loop": _command_text(
+            cli_bin=cli_bin,
+            goal_id=goal_id,
+            agent_id=agent_id,
+            execute=True,
+            run_worker_loop=True,
+            headless=True,
+            tracking_goal_id=tracking_goal_id,
+            output_language=output_language,
+        ),
+        "start_visible_lanes_without_attach": _command_text(
+            cli_bin=cli_bin,
+            goal_id=goal_id,
+            agent_id=agent_id,
+            execute=True,
+            launch_visible=True,
+            no_attach=True,
+            tracking_goal_id=tracking_goal_id,
+            output_language=output_language,
+        ),
+        "one_command_visible_wake_demo": _command_text(
+            cli_bin=cli_bin,
+            goal_id=goal_id,
+            agent_id=agent_id,
+            execute=True,
+            launch_visible=True,
+            no_attach=True,
+            wake_visible_after_launch=True,
+            tracking_goal_id=tracking_goal_id,
+            output_language=output_language,
+        ),
+        "one_command_visible_worker_turn_validation": _command_text(
+            cli_bin=cli_bin,
+            goal_id=goal_id,
+            agent_id=agent_id,
+            execute=True,
+            launch_visible=True,
+            no_attach=True,
+            configure_visible_worker_turn=True,
+            tracking_goal_id=tracking_goal_id,
+            output_language=output_language,
+        ),
+        "one_command_worker_loop_with_visible_lanes": _command_text(
+            cli_bin=cli_bin,
+            goal_id=goal_id,
+            agent_id=agent_id,
+            execute=True,
+            run_worker_loop=True,
+            launch_visible=True,
+            attach=True,
+            tracking_goal_id=tracking_goal_id,
+            output_language=output_language,
+        ),
+        "load_live_worker_evidence": _command_text(
+            cli_bin=cli_bin,
+            goal_id=goal_id,
+            agent_id=agent_id,
+            execute=True,
+            live_evidence=True,
+            tracking_goal_id=tracking_goal_id,
+            output_language=output_language,
+        ),
+        "wake_visible_lanes": (
+            f"{shlex.quote(cli_bin)} --format json multi-agent wake --session-name "
+            f"{shlex.quote(session_name)} --execute"
+        ),
+    }
+
+
 def _supervisor_summary(supervisor: dict[str, object]) -> dict[str, object]:
     product_spec = (
         supervisor.get("product_spec")
@@ -1287,136 +1435,29 @@ def run_auto_research_demo_e2e(
         "result_source": result_source,
         "goal_id": goal_id,
         "tracking_goal_id": tracking_goal or None,
-        "route_contract": {
-            "schema_version": "auto_research_demo_frontier_route_v0",
-            "goal_surface_mode": goal_surface_mode,
-            "frontier_goal_id": goal_id,
-            "tracking_goal_id": tracking_goal or None,
-            "preset_id": preset_context.get("preset_id") if preset_context else None,
-            "preset_baseline_source": (
-                preset_context.get("baseline_source") if preset_context else None
-            ),
-            "tracking_goal_drives_frontier": False,
-            "visible_lanes_read_goal_id": goal_id,
-            "fresh_goal_default": goal_surface_mode == "fresh_demo_goal",
-            "inherits_default_goal": goal_surface_mode == "inherited_default_goal",
-            "reuses_default_internal_goal": reuses_default_internal_goal,
-            "default_internal_goal_id": AUTO_RESEARCH_DEFAULT_GOAL_ID,
-            "dedicated_positive_demo_frontier": not reuses_default_internal_goal,
-            "reason": (
-                "Omitting --goal-id creates an isolated demo goal surface. "
-                "Use --goal-id to target a specific research frontier, or --inherit-default-goal "
-                "to intentionally reuse the internal shared demo goal. --tracking-goal-id is metadata "
-                "for the parent productization goal and must not reroute panes."
-            ),
-        },
+        "route_contract": _build_demo_frontier_route_contract(
+            goal_id=goal_id,
+            tracking_goal=tracking_goal,
+            preset_context=preset_context,
+            goal_surface_mode=goal_surface_mode,
+            reuses_default_internal_goal=reuses_default_internal_goal,
+        ),
         "agent_id": agent_id,
         "reasoning_effort": reasoning_effort,
         "output_language": output_language,
         "user_contract": user_contract,
         "preset_context": preset_context,
         "contract_acceptance": contract_acceptance,
-        "commands": {
-            "one_question_contract": auto_research_contract_command_text(
-                cli_bin=cli_bin,
-                objective=objective,
-            ),
-            "one_question_start": auto_research_start_command_text(
-                cli_bin=cli_bin,
-                objective=objective,
-                preset_id=preset_id,
-                execute=True,
-                output_language=output_language,
-            ),
-            "one_question_start_preview": auto_research_start_command_text(
-                cli_bin=cli_bin,
-                objective=objective,
-                preset_id=preset_id,
-                output_language=output_language,
-            ),
-            "one_question_start_with_visible_wake": auto_research_start_command_text(
-                cli_bin=cli_bin,
-                objective=objective,
-                preset_id=preset_id,
-                execute=True,
-                output_language=output_language,
-            ),
-            "one_command_worker_loop": _command_text(
-                cli_bin=cli_bin,
-                goal_id=goal_id,
-                agent_id=agent_id,
-                execute=True,
-                run_worker_loop=True,
-                tracking_goal_id=tracking_goal or None,
-                output_language=output_language,
-            ),
-            "headless_worker_loop": _command_text(
-                cli_bin=cli_bin,
-                goal_id=goal_id,
-                agent_id=agent_id,
-                execute=True,
-                run_worker_loop=True,
-                headless=True,
-                tracking_goal_id=tracking_goal or None,
-                output_language=output_language,
-            ),
-            "start_visible_lanes_without_attach": _command_text(
-                cli_bin=cli_bin,
-                goal_id=goal_id,
-                agent_id=agent_id,
-                execute=True,
-                launch_visible=True,
-                no_attach=True,
-                tracking_goal_id=tracking_goal or None,
-                output_language=output_language,
-            ),
-            "one_command_visible_wake_demo": _command_text(
-                cli_bin=cli_bin,
-                goal_id=goal_id,
-                agent_id=agent_id,
-                execute=True,
-                launch_visible=True,
-                no_attach=True,
-                wake_visible_after_launch=True,
-                tracking_goal_id=tracking_goal or None,
-                output_language=output_language,
-            ),
-            "one_command_visible_worker_turn_validation": _command_text(
-                cli_bin=cli_bin,
-                goal_id=goal_id,
-                agent_id=agent_id,
-                execute=True,
-                launch_visible=True,
-                no_attach=True,
-                configure_visible_worker_turn=True,
-                tracking_goal_id=tracking_goal or None,
-                output_language=output_language,
-            ),
-            "one_command_worker_loop_with_visible_lanes": _command_text(
-                cli_bin=cli_bin,
-                goal_id=goal_id,
-                agent_id=agent_id,
-                execute=True,
-                run_worker_loop=True,
-                launch_visible=True,
-                attach=True,
-                tracking_goal_id=tracking_goal or None,
-                output_language=output_language,
-            ),
-            "load_live_worker_evidence": _command_text(
-                cli_bin=cli_bin,
-                goal_id=goal_id,
-                agent_id=agent_id,
-                execute=True,
-                live_evidence=True,
-                tracking_goal_id=tracking_goal or None,
-                output_language=output_language,
-            ),
-            "wake_visible_lanes": (
-                f"{shlex.quote(cli_bin)} --format json multi-agent wake --session-name "
-                f"{shlex.quote(session_name)} --execute"
-            ),
-        },
+        "commands": _build_demo_e2e_commands(
+            cli_bin=cli_bin,
+            objective=objective,
+            preset_id=preset_id,
+            output_language=output_language,
+            goal_id=goal_id,
+            agent_id=agent_id,
+            tracking_goal=tracking_goal,
+            session_name=session_name,
+        ),
         "supervisor": _supervisor_summary(supervisor),
         "public_boundary": {
             "raw_logs_recorded": False,

--- a/loopx/capabilities/auto_research/research_state.py
+++ b/loopx/capabilities/auto_research/research_state.py
@@ -118,6 +118,70 @@ def _claimed_by_current_or_unclaimed(item: dict[str, Any], *, agent_id: str) -> 
     return not claimed_by or claimed_by == agent_id
 
 
+def _public_todo_items(value: Any) -> list[dict[str, Any]]:
+    return [item for item in value or [] if isinstance(item, dict) and item.get("todo_id")]
+
+
+def _is_runnable_advancement_todo(item: dict[str, Any]) -> bool:
+    task_class = str(item.get("task_class") or "advancement_task").strip()
+    if task_class and task_class != "advancement_task":
+        return False
+    status = str(item.get("status") or "open").strip()
+    if status and status not in {"active", "open", "needs_retry"}:
+        return False
+    resume_when = str(item.get("resume_when") or "").strip()
+    if resume_when and item.get("resume_ready") is False:
+        return False
+    return True
+
+
+def _unique_todo_candidates(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    selected: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for item in items:
+        todo_id = str(item.get("todo_id") or "").strip()
+        if not todo_id or todo_id in seen:
+            continue
+        seen.add(todo_id)
+        selected.append(item)
+    return selected
+
+
+def _quota_payload_todo_candidates(
+    quota_payload: dict[str, Any],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    gate = quota_payload.get("capability_gate")
+    if not isinstance(gate, dict):
+        gate = {}
+    runnable = _public_todo_items(gate.get("runnable_candidates"))
+    blocked = _public_todo_items(gate.get("blocked_candidates"))
+
+    agent_summary = quota_payload.get("agent_todo_summary")
+    if not isinstance(agent_summary, dict):
+        return _unique_todo_candidates(runnable), _unique_todo_candidates(blocked)
+
+    for key in (
+        "active_next_action_executable_items",
+        "first_executable_items",
+        "claimed_advancement_open_items",
+        "unclaimed_advancement_open_items",
+    ):
+        runnable.extend(
+            item
+            for item in _public_todo_items(agent_summary.get(key))
+            if _is_runnable_advancement_todo(item)
+        )
+
+    claim_scope = agent_summary.get("claim_scope")
+    if not isinstance(claim_scope, dict):
+        claim_scope = {}
+    for key in ("claimed_by_others_items", "blocked_claimed_items", "blocked_items"):
+        blocked.extend(_public_todo_items(agent_summary.get(key)))
+        blocked.extend(_public_todo_items(claim_scope.get(key)))
+
+    return _unique_todo_candidates(runnable), _unique_todo_candidates(blocked)
+
+
 def normalize_auto_research_action(action: object) -> str:
     raw = str(action or "").strip()
     return AUTO_RESEARCH_ACTION_ALIASES.get(raw, raw)
@@ -691,15 +755,7 @@ def build_live_auto_research_projection(
     if not quota_payload.get("ok"):
         raise ValueError("quota payload must be ok for live auto-research projection")
 
-    gate = quota_payload.get("capability_gate")
-    if not isinstance(gate, dict):
-        gate = {}
-    runnable_candidates = [
-        item for item in gate.get("runnable_candidates") or [] if isinstance(item, dict)
-    ]
-    blocked_candidates = [
-        item for item in gate.get("blocked_candidates") or [] if isinstance(item, dict)
-    ]
+    runnable_candidates, blocked_candidates = _quota_payload_todo_candidates(quota_payload)
     selected_raw = quota_payload.get("agent_lane_next_action")
     selected = None
     if (


### PR DESCRIPTION
## Summary

This PR keeps the auto-research demo/read-model surface moving in a small non-benchmark engineering-quality batch.

- Extracts the demo E2E route-contract and command-map payload builders out of `run_auto_research_demo_e2e`, reducing the main function body while preserving the emitted payload schema.
- Fixes live auto-research frontier projection so it can fall back from `capability_gate` to `agent_todo_summary` when quota/status already contains runnable current-agent advancement todos but no capability-gate candidates.
- Extends `decentralized-auto-research-frontier-smoke.py` to cover the agent-todo-summary fallback that keeps demo-local worker-loop queues visible to worker turns.

## Validation

- `python3 -m py_compile loopx/capabilities/auto_research/demo_e2e.py loopx/capabilities/auto_research/research_state.py examples/decentralized-auto-research-frontier-smoke.py`
- `python3 examples/decentralized-auto-research-frontier-smoke.py`
- `python3 examples/auto-research-demo-e2e-worker-loop-smoke.py`
- `python3 examples/auto-research-rollout-readpath-smoke.py`
- `python3 examples/auto-research-demo-goal-isolation-smoke.py`
- `python3 examples/auto-research-demo-supervisor-smoke.py`
- `python3 examples/auto-research-start-markdown-commands-smoke.py`
- `python3 examples/auto-research-visible-launch-policy-smoke.py`
- `python3 examples/auto-research-worker-turn-smoke.py`
- `python3 examples/auto-research-live-evidence-capture-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py --strict`
- `loopx check --scan-path loopx/capabilities/auto_research/demo_e2e.py --scan-path loopx/capabilities/auto_research/research_state.py --scan-path examples/decentralized-auto-research-frontier-smoke.py`
- `git diff --check`
- `loopx canary premerge --from-git-diff`

## Risk / Holds

- Non-benchmark product-capability/read-model cleanup only.
- No benchmark runner/scoring behavior, raw benchmark evidence, credentials, private paths, or generated logs included.
- Premerge gate reported `self_merge_allowed=true` and `manual_holds=0`.
