### PR TITLE
Refactor Lark Kanban record map sync

### DIFF
--- a/examples/lark-kanban-control-plane-smoke.py
+++ b/examples/lark-kanban-control-plane-smoke.py
@@ -392,6 +392,68 @@ def main() -> int:
             "todo_agent_malformed",
         }, scoped_payload
 
+        todo_sync_calls: list[list[str]] = []
+
+        def todo_upsert_runner(args: list[str], cwd: Path | None, timeout: float | None) -> dict[str, object]:
+            todo_sync_calls.append(args)
+            if "+record-list" in args:
+                return {
+                    "returncode": 0,
+                    "stdout": json.dumps(
+                        {
+                            "ok": True,
+                            "data": {
+                                "fields": ["LoopX Goal ID", "LoopX Todo ID"],
+                                "data": [["goal_lark_sync_fixture", "todo_agent_sync"]],
+                                "record_id_list": ["recTodoSyncExisting"],
+                            },
+                        }
+                    ),
+                    "stderr": "",
+                    "timed_out": False,
+                }
+            if "+record-upsert" in args:
+                values = json.loads(args[args.index("--json") + 1])
+                record_id = (
+                    args[args.index("--record-id") + 1]
+                    if "--record-id" in args
+                    else "recTodo" + str(values["LoopX Todo ID"]).replace("_", "")[:24]
+                )
+                return {
+                    "returncode": 0,
+                    "stdout": json.dumps({"ok": True, "data": {"record_id": record_id}}),
+                    "stderr": "",
+                    "timed_out": False,
+                }
+            raise AssertionError(args)
+
+        todo_idempotent_config_path = Path(tmp) / ".loopx" / "todo-idempotent.json"
+        execute_todo_sync = sync_loopx_todos_to_lark_kanban(
+            LarkKanbanConfig(
+                **{"base_" + "token": "base_public_fixture"},
+                table_id="tbl_public_fixture",
+            ),
+            registry_path=registry,
+            goal_id="goal_lark_sync_fixture",
+            config_path=todo_idempotent_config_path,
+            execute=True,
+            runner=todo_upsert_runner,
+        )
+        assert execute_todo_sync["ok"] is True, execute_todo_sync
+        assert execute_todo_sync["todo_count"] == 4, execute_todo_sync
+        todo_upserts = [args for args in todo_sync_calls if "+record-upsert" in args]
+        assert len(todo_upserts) == 4, todo_sync_calls
+        reused_todo_upsert = [args for args in todo_upserts if "recTodoSyncExisting" in args]
+        assert len(reused_todo_upsert) == 1, todo_upserts
+        reused_values = json.loads(reused_todo_upsert[0][reused_todo_upsert[0].index("--json") + 1])
+        assert reused_values["LoopX Todo ID"] == "todo_agent_sync", reused_values
+        stored_todo_config = read_lark_kanban_local_config(todo_idempotent_config_path)
+        assert stored_todo_config["board"]["table_id"] == "tbl_public_fixture", stored_todo_config
+        assert (
+            stored_todo_config["todo_records"]["goal_lark_sync_fixture:todo_agent_sync"]
+            == "recTodoSyncExisting"
+        ), stored_todo_config
+
         projection_payload = {
             "schema_version": "goal_channel_projection_v0",
             "goal_id": "goal_lark_sync_fixture",

--- a/loopx/presentation/sinks/lark/kanban.py
+++ b/loopx/presentation/sinks/lark/kanban.py
@@ -2049,26 +2049,10 @@ def sync_loopx_projection_to_lark_kanban(
     )
     warnings = [*namespace_warnings, *warnings]
 
-    local = read_lark_kanban_local_config(config_path) if config_path else {}
-    record_map = dict(local.get("todo_records") or {}) if isinstance(local.get("todo_records"), dict) else {}
     commands: list[dict[str, Any]] = []
-    if execute:
-        list_config = LarkKanbanConfig(
-            **{"base_" + "token": config.base_token},
-            table_id=config.table_id,
-            view_id=None,
-            cli_bin=config.cli_bin,
-            identity=config.identity,
-        )
-        list_result = _run_command(build_record_list_command(list_config), execute=True, runner=runner)
-        commands.append(list_result)
-        if list_result.get("ok"):
-            for record in lark_record_rows(list_result.get("json") if isinstance(list_result.get("json"), dict) else {}):
-                todo_id = str(record.get("LoopX Todo ID") or "").strip()
-                row_goal_id = str(record.get("LoopX Goal ID") or "").strip()
-                record_id = str(record.get("_record_id") or "").strip()
-                if todo_id and row_goal_id and record_id:
-                    record_map[f"{row_goal_id}:{todo_id}"] = record_id
+    local, record_map = _load_lark_todo_record_map(
+        config, config_path=config_path, execute=execute, commands=commands, runner=runner
+    )
 
     results: list[dict[str, Any]] = []
     ok = True
@@ -2103,24 +2087,8 @@ def sync_loopx_projection_to_lark_kanban(
         if execute and not result.get("ok"):
             break
 
-    if execute and config_path and ok:
-        board = local.get("board") if isinstance(local.get("board"), dict) else {}
-        if not board:
-            board = {
-                "base_token": config.base_token,
-                "table_id": config.table_id,
-                "view_id": config.view_id,
-                "cli_bin": config.cli_bin,
-                "identity": config.identity,
-            }
-        write_lark_kanban_local_config(
-            config_path,
-            {
-                "schema_version": LARK_KANBAN_LOCAL_CONFIG_VERSION,
-                "board": board,
-                "todo_records": record_map,
-            },
-        )
+    if execute and ok:
+        _persist_lark_todo_record_map(config, config_path=config_path, local=local, record_map=record_map)
 
     return {
         "ok": ok,
@@ -2181,26 +2149,10 @@ def sync_loopx_todos_to_lark_kanban(
             todos.append(candidate)
     todos = todos[:limit]
 
-    local = read_lark_kanban_local_config(config_path) if config_path else {}
-    record_map = dict(local.get("todo_records") or {}) if isinstance(local.get("todo_records"), dict) else {}
     commands: list[dict[str, Any]] = []
-    if execute:
-        list_config = LarkKanbanConfig(
-            **{"base_" + "token": config.base_token},
-            table_id=config.table_id,
-            view_id=None,
-            cli_bin=config.cli_bin,
-            identity=config.identity,
-        )
-        list_result = _run_command(build_record_list_command(list_config), execute=True, runner=runner)
-        commands.append(list_result)
-        if list_result.get("ok"):
-            for record in lark_record_rows(list_result.get("json") if isinstance(list_result.get("json"), dict) else {}):
-                todo_id = str(record.get("LoopX Todo ID") or "").strip()
-                row_goal_id = str(record.get("LoopX Goal ID") or "").strip()
-                record_id = str(record.get("_record_id") or "").strip()
-                if todo_id and row_goal_id and record_id:
-                    record_map[f"{row_goal_id}:{todo_id}"] = record_id
+    local, record_map = _load_lark_todo_record_map(
+        config, config_path=config_path, execute=execute, commands=commands, runner=runner
+    )
 
     results: list[dict[str, Any]] = []
     ok = True
@@ -2234,24 +2186,8 @@ def sync_loopx_todos_to_lark_kanban(
         if execute and not result.get("ok"):
             break
 
-    if execute and config_path and ok:
-        board = local.get("board") if isinstance(local.get("board"), dict) else {}
-        if not board:
-            board = {
-                "base_token": config.base_token,
-                "table_id": config.table_id,
-                "view_id": config.view_id,
-                "cli_bin": config.cli_bin,
-                "identity": config.identity,
-            }
-        write_lark_kanban_local_config(
-            config_path,
-            {
-                "schema_version": LARK_KANBAN_LOCAL_CONFIG_VERSION,
-                "board": board,
-                "todo_records": record_map,
-            },
-        )
+    if execute and ok:
+        _persist_lark_todo_record_map(config, config_path=config_path, local=local, record_map=record_map)
 
     return {
         "ok": ok,
@@ -2266,6 +2202,66 @@ def sync_loopx_todos_to_lark_kanban(
         "commands": commands,
         "config_path": str(config_path) if config_path else None,
     }
+
+
+def _load_lark_todo_record_map(
+    config: LarkKanbanConfig, *, config_path: Path | None, execute: bool,
+    commands: list[dict[str, Any]], runner: CommandRunner,
+) -> tuple[dict[str, Any], dict[str, str]]:
+    local = read_lark_kanban_local_config(config_path) if config_path else {}
+    record_map = _todo_record_map_from_local_config(local)
+    if not execute:
+        return local, record_map
+
+    list_config = LarkKanbanConfig(
+        **{"base_" + "token": config.base_token},
+        table_id=config.table_id,
+        view_id=None,
+        cli_bin=config.cli_bin,
+        identity=config.identity,
+    )
+    list_result = _run_command(build_record_list_command(list_config), execute=True, runner=runner)
+    commands.append(list_result)
+    if list_result.get("ok"):
+        record_map.update(_todo_record_map_from_lark_records(list_result.get("json")))
+    return local, record_map
+
+
+def _todo_record_map_from_local_config(local: dict[str, Any]) -> dict[str, str]:
+    records = local.get("todo_records") if isinstance(local, dict) else None
+    if not isinstance(records, dict):
+        return {}
+    return {str(key): str(value) for key, value in records.items() if str(key).strip() and str(value).strip()}
+
+
+def _todo_record_map_from_lark_records(parsed: Any) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for record in lark_record_rows(parsed if isinstance(parsed, dict) else {}):
+        todo_id = str(record.get("LoopX Todo ID") or "").strip()
+        row_goal_id = str(record.get("LoopX Goal ID") or "").strip()
+        record_id = str(record.get("_record_id") or "").strip()
+        if todo_id and row_goal_id and record_id:
+            result[f"{row_goal_id}:{todo_id}"] = record_id
+    return result
+
+
+def _persist_lark_todo_record_map(
+    config: LarkKanbanConfig, *, config_path: Path | None,
+    local: dict[str, Any], record_map: dict[str, str],
+) -> None:
+    if not config_path:
+        return
+    board = local.get("board") if isinstance(local.get("board"), dict) else {}
+    if not board:
+        board = {
+            "base_token": config.base_token,
+            "table_id": config.table_id,
+            "view_id": config.view_id,
+            "cli_bin": config.cli_bin,
+            "identity": config.identity,
+        }
+    payload = {"schema_version": LARK_KANBAN_LOCAL_CONFIG_VERSION, "board": board, "todo_records": record_map}
+    write_lark_kanban_local_config(config_path, payload)
 
 
 def _lark_record_from_todo_block(


### PR DESCRIPTION
## Summary

Refactor the Lark Kanban sync idempotency path so projection sync and todo sync share the same record-map load/persist helpers.

This keeps the behavior narrow and existing-compatible:
- load local `todo_records` when present;
- when executing, refresh record ids from the current Lark table rows;
- reuse record ids for upserts;
- persist the merged record map after successful execute-mode sync.

## Product / Architecture Judgment

Motivation: the Lark Kanban presentation sink had duplicate record-id mapping logic in projection sync and todo sync, making idempotency behavior harder to audit as the file grows.

Solved: the duplicated rule is now one internal helper path, and both sync modes still return their existing payload shape. The smoke now covers execute-mode todo sync record reuse, complementing the existing projection idempotency check.

User/operator impact: repeated board syncs are easier to reason about and less likely to drift between projection and active-todo sources.

Main risk: low runtime risk, limited to Lark Kanban sync bookkeeping. No real Lark calls are introduced by validation; fake runner keeps it local/public.

Design judgment: this is a bounded internal seam, not a new protocol or sink framework.

## Validation

- `python3 examples/lark-kanban-control-plane-smoke.py`
- `python3 examples/lark-capability-layout-smoke.py`
- `python3 -m loopx.cli --format json lark-kanban schema`
- `python3 -m py_compile loopx/presentation/sinks/lark/kanban.py examples/lark-kanban-control-plane-smoke.py`
- `python3 -m compileall -q loopx/presentation/sinks/lark examples/lark-kanban-control-plane-smoke.py examples/lark-capability-layout-smoke.py`
- `git diff --check`

Boundary scan: changed paths contain only public fixture tokens plus existing intentional redaction-test strings; no credentials, private state, raw benchmark logs, trajectories, verifier output, or local runtime artifacts were added.

## Merge Gate

This touches Lark Kanban behavior and `examples/*lark-kanban*`, so per LoopX PR merge policy it should hold for `ZaynJarvis` review before merge. I am not self-merging without that review or explicit owner bypass.
