### PR TITLE
Fix value connector account setup access mode

### DIFF
--- a/examples/value-connectors-github-public-probe-smoke.py
+++ b/examples/value-connectors-github-public-probe-smoke.py
@@ -24,6 +24,8 @@ from loopx.capabilities.value_connectors.github_public import (  # noqa: E402
 )
 from loopx.capabilities.value_connectors.planner import (  # noqa: E402
     VALUE_CONNECTOR_PLAN_PACKET_SCHEMA_VERSION,
+    build_single_value_connector_plan,
+    validate_value_connector_plan,
 )
 from loopx.capabilities.value_connectors.source_map import (  # noqa: E402
     VALUE_CONNECTOR_SOURCE_MAP_PACKET_SCHEMA_VERSION,
@@ -347,6 +349,63 @@ def main() -> int:
     assert x_call["requires_user_approval"] is True, x_call
     assert x_gated["projection"]["first_screen"]["waiting_on"] == "user", x_gated
     assert_public_safe(x_gated)
+
+    x_account_setup = json.loads(
+        run_cli(
+            [
+                "--format",
+                "json",
+                "value-connectors",
+                "plan",
+                "--connector-id",
+                "social_browser_x",
+                "--connector-kind",
+                "browser_social_channel",
+                "--channel",
+                "X account profile via ego-browser",
+                "--stage",
+                "account_setup",
+                "--target-ref",
+                "LoopX-only public account identity",
+                "--target-url",
+                "https://x.com/loopxops",
+                "--money-metric",
+                "public product channel ready to receive qualified workflow-owner replies",
+                "--success-metric",
+                "profile identity is public-safe and ready for approved posts",
+                "--kill-condition",
+                "requires payment, captcha bypass, non-LoopX brand claims, or private context",
+            ]
+        ).stdout
+    )
+    assert x_account_setup["ok"] is True, x_account_setup
+    x_setup_call = x_account_setup["plan"]["connector_calls"][0]
+    assert x_setup_call["stage"] == "account_setup", x_setup_call
+    assert x_setup_call["access_mode"] == "agent_owned_identity", x_setup_call
+    assert x_setup_call["requires_user_approval"] is True, x_setup_call
+    assert x_account_setup["projection"]["first_screen"]["waiting_on"] == "user", x_account_setup
+    assert_public_safe(x_account_setup)
+
+    invalid_account_setup = build_single_value_connector_plan(
+        connector_id="social_browser_x",
+        connector_kind="browser_social_channel",
+        channel="X account profile via ego-browser",
+        stage="account_setup",
+        target_ref="LoopX-only public account identity",
+        target_url="https://x.com/loopxops",
+        value_axis="revenue",
+        money_metric="public product channel ready to receive qualified workflow-owner replies",
+        success_metric="profile identity is public-safe and ready for approved posts",
+        kill_condition="requires payment, captcha bypass, non-LoopX brand claims, or private context",
+        generated_at="2026-06-25T00:00:00Z",
+    )
+    invalid_account_setup["connector_calls"][0]["access_mode"] = "public_metadata_only"
+    invalid_validation = validate_value_connector_plan(invalid_account_setup)
+    assert invalid_validation["ok"] is False, invalid_validation
+    assert any(
+        "account_setup" in error and "public_metadata_only" in error
+        for error in invalid_validation["errors"]
+    ), invalid_validation
 
     gated = json.loads(
         run_cli(

--- a/loopx/capabilities/value_connectors/planner.py
+++ b/loopx/capabilities/value_connectors/planner.py
@@ -435,7 +435,12 @@ def build_single_value_connector_plan(
         "external_write_request",
     }
     gate_id = "gate_requested_connector_call" if requires_gate else None
-    access_mode = "external_write_gated" if external_write_requested else "public_metadata_only"
+    if external_write_requested:
+        access_mode = "external_write_gated"
+    elif stage == "account_setup":
+        access_mode = "agent_owned_identity"
+    else:
+        access_mode = "public_metadata_only"
     calls = [
         _connector_call(
             call_id=f"{connector_id}_{stage}",
@@ -552,6 +557,8 @@ def validate_value_connector_plan(plan: Mapping[str, Any]) -> dict[str, Any]:
             errors.append(f"connector call {call_id} has invalid stage")
         if call.get("access_mode") not in ALLOWED_ACCESS_MODES:
             errors.append(f"connector call {call_id} has invalid access_mode")
+        if call.get("stage") == "account_setup" and call.get("access_mode") == "public_metadata_only":
+            errors.append(f"connector call {call_id} account_setup must not use public_metadata_only access")
         if call.get("value_axis") not in ALLOWED_VALUE_AXES:
             errors.append(f"connector call {call_id} has invalid value_axis")
         if call.get("external_writes_allowed") is not False:


### PR DESCRIPTION
## Summary

Fix the single-call value connector planner so `stage=account_setup` no longer emits a contradictory `public_metadata_only` access mode.

Changes:
- generated single-call `account_setup` plans now use `agent_owned_identity` unless the caller explicitly requests an external write;
- validation rejects `account_setup` connector calls that claim `public_metadata_only` access;
- the existing value connector smoke now covers both the generated CLI packet and the validator rejection case.

## Product / Architecture Judgment

Motivation: account/profile setup is not merely a public metadata observation. It must remain behind the exact approval gate semantics that value connectors already project for account setup and external writes.

Solved: the generated plan now reports `access_mode=agent_owned_identity`, `requires_user_approval=true`, and `first_screen.waiting_on=user` for single-call account setup. The validator also prevents malformed hand-built plans from reintroducing the mismatch.

User/operator impact: operators see a safer and more accurate gate for account setup work before any external action, signup, or identity mutation can be attempted.

Main risk: low compatibility risk for generated plans, but this does touch external-action gating semantics. It is a tightening, not a permission expansion.

Design judgment: this keeps the existing planner contract and enum set; no new protocol field or connector framework is introduced.

## Validation

- `python3 examples/value-connectors-github-public-probe-smoke.py`
- `python3 -m py_compile loopx/capabilities/value_connectors/planner.py examples/value-connectors-github-public-probe-smoke.py`
- `python3 -m loopx.cli --format json value-connectors plan --connector-id social_browser_x --connector-kind browser_social_channel --channel 'X account profile via ego-browser' --stage account_setup --target-ref 'LoopX-only public account identity' --target-url https://x.com/loopxops --money-metric 'public product channel ready to receive qualified workflow-owner replies' --success-metric 'profile identity is public-safe and ready for approved posts' --kill-condition 'requires payment, captcha bypass, non-LoopX brand claims, or private context'`
- `python3 -m compileall -q loopx/capabilities/value_connectors examples/value-connectors-github-public-probe-smoke.py`
- `git diff --check`

Boundary scan: changed paths only include public fixture strings and existing negative-test sentinel values; no credentials, private state, raw benchmark logs, trajectories, verifier output, or local runtime artifacts were added.

## Merge Gate

Holding for reviewer/owner acceptance because the PR touches runtime external-action gating semantics, even though it is a narrow safety tightening.
