### PR TITLE
Require benchmark egress proxy for formal SkillsBench Goal runs

### DIFF
--- a/docs/benchmark-developer-workflow.md
+++ b/docs/benchmark-developer-workflow.md
@@ -1381,12 +1381,24 @@ before launching `scripts/skillsbench_automation_loop.py`; the runner forwards
 standard proxy variables only to the private BenchFlow subprocess and agent
 environment, runs a bounded HTTP CONNECT preflight, and records only
 source/scheme/endpoint-kind/port plus `proxy_url_recorded=false` in public
-artifacts. Use `--benchmark-egress-proxy-mode require` when the run must fail
-fast without that private proxy. The default `auto` mode validates a configured
-proxy first, but if that proxy is unavailable and direct egress to the public
-test host is reachable, the runner records a direct fallback and does not inject
-the stale proxy into the benchmark runtime. Use `--benchmark-egress-proxy-mode
-off` only for explicit no-proxy debugging.
+artifacts. Formal host-local Goal benchmark routes resolve the default `auto`
+policy to `require`, so a missing benchmark egress proxy blocks before setup or
+verifier dependency installs begin. Outside those formal routes, `auto` still
+validates a configured proxy first, but if that proxy is unavailable and direct
+egress to the public test host is reachable, the runner records a direct
+fallback and does not inject the stale proxy into the benchmark runtime. Use
+`--benchmark-egress-proxy-mode off` only for explicit no-proxy debugging.
+
+For Docker-backed SkillsBench runs, the proxy endpoint must be reachable from
+both the remote host shell and Docker build/runtime containers. A loopback-only
+SSH reverse tunnel such as `127.0.0.1:<port>` is enough for host-side Codex API
+preflight, but Docker build steps interpret `127.0.0.1` as the build container
+itself, so apt/pip/bootstrap commands fail with connection refused. The public
+launcher starts a short-lived bridge listener on the remote Docker bridge
+address and passes that bridge URL as `LOOPX_SKILLSBENCH_EGRESS_PROXY`, while
+keeping the concrete proxy value out of public artifacts. Equivalent
+host-network or bridge-forwarder wiring is valid; do not treat a host-only
+loopback proxy as benchmark/verifier-ready.
 
 Keep upstream benchmark sources clean:
 

--- a/examples/benchmark-core-adapter-contract-smoke.py
+++ b/examples/benchmark-core-adapter-contract-smoke.py
@@ -36,6 +36,7 @@ from loopx.benchmark_core import (  # noqa: E402
     RunHandle,
     build_round_artifact_restore_plan,
     compact_round_artifact_snapshots,
+    compact_benchmark_canonical_lifecycle,
     canonical_lifecycle,
     load_json_object,
     optional_float,
@@ -108,6 +109,15 @@ def test_process_started_is_not_case_entry() -> None:
     assert lifecycle["entered_benchmark_case"] is False, lifecycle
     assert lifecycle["case_attempt_countable"] is False, lifecycle
     assert lifecycle["next_required_phase"] == "runner_accepted_args", lifecycle
+    compact = compact_benchmark_canonical_lifecycle(lifecycle)
+    assert compact["current_phase"] == "process_started", compact
+    assert compact["phase_ready"]["process_started"] is True, compact
+    assert compact["phase_ready"]["runner_accepted_args"] is False, compact
+    noisy = dict(lifecycle)
+    noisy["phase_ready"] = {**lifecycle["phase_ready"], "fixture_private_phase": True}
+    assert "fixture_private_phase" not in compact_benchmark_canonical_lifecycle(
+        noisy
+    )["phase_ready"]
 
 
 def test_existing_lifecycle_builder_projects_canonical_state() -> None:

--- a/examples/skillsbench-benchmark-egress-policy-smoke.py
+++ b/examples/skillsbench-benchmark-egress-policy-smoke.py
@@ -1,0 +1,196 @@
+#!/usr/bin/env python3
+"""Smoke SkillsBench benchmark egress proxy policy for formal Goal routes."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT))
+
+from scripts import skillsbench_automation_loop as skillsbench_loop
+
+
+def _make_skillsbench_root(root: Path) -> Path:
+    skillsbench_root = root / "skillsbench"
+    task_dir = skillsbench_root / "tasks" / "citation-check"
+    task_dir.mkdir(parents=True)
+    (task_dir / "task.toml").write_text("version = \"1.1\"\n", encoding="utf-8")
+    return skillsbench_root
+
+
+def _formal_cli_goal_args(root: Path) -> object:
+    return skillsbench_loop.parse_args(
+        [
+            "--task-id",
+            "citation-check",
+            "--route",
+            "codex-cli-goal-baseline",
+            "--host-local-acp-launch",
+            "--remote-command-file-bridge-ready",
+            "--skillsbench-root",
+            str(_make_skillsbench_root(root)),
+            "--jobs-dir",
+            str(root / "jobs"),
+        ]
+    )
+
+
+def test_formal_cli_goal_auto_requires_benchmark_egress_proxy() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-egress-policy-missing-") as tmp:
+        root = Path(tmp)
+        previous = os.environ.get("LOOPX_SKILLSBENCH_EGRESS_PROXY")
+        previous_mode = os.environ.get("LOOPX_SKILLSBENCH_EGRESS_PROXY_MODE")
+        os.environ.pop("LOOPX_SKILLSBENCH_EGRESS_PROXY", None)
+        os.environ.pop("LOOPX_SKILLSBENCH_EGRESS_PROXY_MODE", None)
+        try:
+            args = _formal_cli_goal_args(root)
+            plan = skillsbench_loop.build_plan(args)
+            egress = plan["benchmark_egress_proxy"]
+            assert egress["requested_mode"] == "require", egress
+            assert egress["proxy_required"] is True, egress
+            assert egress["proxy_configured"] is False, egress
+            assert egress["proxy_url_recorded"] is False, egress
+            assert egress["raw_proxy_url_recorded"] is False, egress
+
+            try:
+                skillsbench_loop._run_benchmark_egress_proxy_preflight(args, plan)
+            except skillsbench_loop.SkillsBenchSetupPreflightBlocked:
+                pass
+            else:  # pragma: no cover - assertion path for script-style smoke
+                raise AssertionError("formal CLI Goal run should require benchmark egress proxy")
+
+            blocked = plan["benchmark_egress_proxy"]
+            assert blocked["status"] == "missing_required_proxy", blocked
+            assert blocked["ready"] is False, blocked
+            prereqs = plan["runner_prerequisites"]
+            assert prereqs["benchmark_egress_proxy_required"] is True, prereqs
+            assert prereqs["benchmark_egress_proxy_configured"] is False, prereqs
+            assert prereqs["benchmark_egress_proxy_mode_requested"] == "require", prereqs
+            assert prereqs["benchmark_egress_proxy_status"] == "missing_required_proxy", prereqs
+        finally:
+            if previous is None:
+                os.environ.pop("LOOPX_SKILLSBENCH_EGRESS_PROXY", None)
+            else:
+                os.environ["LOOPX_SKILLSBENCH_EGRESS_PROXY"] = previous
+            if previous_mode is None:
+                os.environ.pop("LOOPX_SKILLSBENCH_EGRESS_PROXY_MODE", None)
+            else:
+                os.environ["LOOPX_SKILLSBENCH_EGRESS_PROXY_MODE"] = previous_mode
+
+
+def test_formal_cli_goal_proxy_env_is_forwarded_without_public_url() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-egress-policy-forward-") as tmp:
+        root = Path(tmp)
+        proxy_url = "http://benchmark-proxy.example.invalid:18080"
+        previous = os.environ.get("LOOPX_SKILLSBENCH_EGRESS_PROXY")
+        previous_mode = os.environ.get("LOOPX_SKILLSBENCH_EGRESS_PROXY_MODE")
+        os.environ["LOOPX_SKILLSBENCH_EGRESS_PROXY"] = proxy_url
+        os.environ.pop("LOOPX_SKILLSBENCH_EGRESS_PROXY_MODE", None)
+        try:
+            args = _formal_cli_goal_args(root)
+            plan = skillsbench_loop.build_plan(args)
+            egress = plan["benchmark_egress_proxy"]
+            assert egress["requested_mode"] == "require", egress
+            assert egress["proxy_required"] is True, egress
+            assert egress["proxy_configured"] is True, egress
+            assert egress["proxy_env_key"] == "LOOPX_SKILLSBENCH_EGRESS_PROXY", egress
+            assert proxy_url not in json.dumps(plan, sort_keys=True), plan
+
+            private_env = skillsbench_loop._benchmark_egress_proxy_env(args)
+            assert private_env["LOOPX_SKILLSBENCH_EGRESS_PROXY"] == proxy_url, private_env
+            for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY"):
+                assert private_env[key] == proxy_url, private_env
+            assert "127.0.0.1" in private_env["NO_PROXY"], private_env
+
+            target_env = skillsbench_loop._host_local_acp_target_env({}, args=args)
+            assert target_env["LOOPX_SKILLSBENCH_EGRESS_PROXY"] == proxy_url, target_env
+            for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY"):
+                assert target_env[key] == proxy_url, target_env
+        finally:
+            if previous is None:
+                os.environ.pop("LOOPX_SKILLSBENCH_EGRESS_PROXY", None)
+            else:
+                os.environ["LOOPX_SKILLSBENCH_EGRESS_PROXY"] = previous
+            if previous_mode is None:
+                os.environ.pop("LOOPX_SKILLSBENCH_EGRESS_PROXY_MODE", None)
+            else:
+                os.environ["LOOPX_SKILLSBENCH_EGRESS_PROXY_MODE"] = previous_mode
+
+
+def test_public_launcher_uses_container_reachable_benchmark_proxy() -> None:
+    env = os.environ.copy()
+    env.update(
+        {
+            "SKILLSBENCH_SSH_DESTINATION": "example.invalid",
+            "SKILLSBENCH_REMOTE_ROOT": "/remote/loopx",
+            "SKILLSBENCH_ROOT": "/remote/skillsbench",
+            "SKILLSBENCH_EXPECTED_LOOPX_GIT_HEAD": "abc1234",
+            "SKILLSBENCH_DOCKER_PROXY_HOST": "host.docker.internal",
+            "SKILLSBENCH_RUN_STAMP": "20260709T000000CST",
+        }
+    )
+    env.pop("SKILLSBENCH_APPEND_HISTORY", None)
+    proc = subprocess.run(
+        [
+            str(REPO_ROOT / "scripts" / "skillsbench-launch-goal-xhigh.sh"),
+            "--dry-run",
+            "citation-check",
+            "egress-smoke",
+            "18186",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+    output = proc.stdout
+    assert "docker_proxy_host=host.docker.internal" in output, output
+    assert (
+        "LOOPX_SKILLSBENCH_EGRESS_PROXY=http://host.docker.internal:18186"
+        in output
+    ), output
+    assert "--codex-api-reverse-tunnel-proxy http://127.0.0.1:18186" in output, output
+    assert "--benchmark-egress-proxy-mode require" in output, output
+    assert "--append-history" not in output, output
+
+
+def test_verifier_proxy_patch_is_required_only_for_existing_verifier() -> None:
+    proxy_env = {
+        "LOOPX_SKILLSBENCH_EGRESS_PROXY": "http://benchmark-proxy.example.invalid:18080",
+        "NO_PROXY": "localhost,127.0.0.1,::1",
+    }
+    with tempfile.TemporaryDirectory(prefix="skillsbench-verifier-proxy-") as tmp:
+        root = Path(tmp)
+        missing = skillsbench_loop.patch_verifier_benchmark_egress_proxy_env(
+            root / "missing-test.sh",
+            proxy_env=proxy_env,
+        )
+        assert missing["benchmark_egress_proxy_verifier_env_patch_required"] is False
+        assert missing["benchmark_egress_proxy_verifier_env_patch_applied"] is False
+        assert missing["benchmark_egress_proxy_verifier_env_key_count"] == 0
+
+        verifier = root / "test.sh"
+        verifier.write_text("#!/usr/bin/env bash\npytest -q\n", encoding="utf-8")
+        patched = skillsbench_loop.patch_verifier_benchmark_egress_proxy_env(
+            verifier,
+            proxy_env=proxy_env,
+        )
+        assert patched["benchmark_egress_proxy_verifier_env_patch_required"] is True
+        assert patched["benchmark_egress_proxy_verifier_env_patch_applied"] is True
+        assert patched["benchmark_egress_proxy_verifier_env_key_count"] > 0
+
+
+if __name__ == "__main__":
+    test_formal_cli_goal_auto_requires_benchmark_egress_proxy()
+    test_formal_cli_goal_proxy_env_is_forwarded_without_public_url()
+    test_public_launcher_uses_container_reachable_benchmark_proxy()
+    test_verifier_proxy_patch_is_required_only_for_existing_verifier()
+    print("skillsbench-benchmark-egress-policy-smoke: ok")

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -464,6 +464,8 @@ def test_benchmark_egress_proxy_env_is_public_safe_and_forwarded() -> None:
             )
             plan = build_plan(args)
             egress = plan["benchmark_egress_proxy"]
+            assert egress["requested_mode"] == "require", egress
+            assert egress["proxy_required"] is True, egress
             assert egress["proxy_configured"] is True, egress
             assert egress["proxy_source"] == "env", egress
             assert egress["proxy_env_key"] == "LOOPX_SKILLSBENCH_EGRESS_PROXY", egress
@@ -511,6 +513,8 @@ def test_benchmark_egress_proxy_env_is_public_safe_and_forwarded() -> None:
             assert not docker_config_dir.exists(), docker_config_dir
 
             config = plan["runner_config"]
+            assert config["benchmark_egress_proxy_required"] is True, config
+            assert config["benchmark_egress_proxy_mode_requested"] == "require", config
             assert config["benchmark_egress_proxy_configured"] is True, config
             assert config["benchmark_egress_proxy_endpoint_kind"] == "public_or_unknown", config
             assert config["benchmark_egress_proxy_endpoint_port"] == 18080, config
@@ -12697,7 +12701,6 @@ def test_skillsbench_runner_failure_backfills_generic_timeout_stall_cleanup() ->
                 "benchflow_setup_stall_timeout_enabled": True,
                 "benchflow_setup_stall_timeout_requested_sec": 180,
                 "benchflow_setup_stall_timeout_sec": 180,
-                "benchflow_setup_stall_timeout_capped": False,
                 "benchflow_setup_stall_timeout_triggered": True,
                 "benchflow_setup_stall_before_agent_lifecycle": True,
                 "benchflow_setup_stall_raw_logs_read": False,

--- a/examples/skillsbench-build-stall-timeout-smoke.py
+++ b/examples/skillsbench-build-stall-timeout-smoke.py
@@ -46,9 +46,9 @@ def test_skillsbench_runner_failure_marks_build_stall_timeout() -> None:
         assert default_plan["runner_prerequisites"][
             "benchflow_setup_stall_timeout_enabled"
         ] is False
-        assert default_plan["runner_prerequisites"][
-            "benchflow_setup_stall_timeout_capped"
-        ] is False
+        assert "benchflow_setup_stall_timeout_capped" not in default_plan[
+            "runner_prerequisites"
+        ]
 
         args = parse_args(
             [
@@ -90,7 +90,6 @@ def test_skillsbench_runner_failure_marks_build_stall_timeout() -> None:
                 "benchflow_setup_stall_timeout_enabled": True,
                 "benchflow_setup_stall_timeout_requested_sec": 60,
                 "benchflow_setup_stall_timeout_sec": 60,
-                "benchflow_setup_stall_timeout_capped": False,
                 "benchflow_setup_stall_timeout_triggered": True,
                 "benchflow_setup_stall_before_agent_lifecycle": True,
                 "benchflow_setup_stall_raw_logs_read": False,
@@ -106,9 +105,9 @@ def test_skillsbench_runner_failure_marks_build_stall_timeout() -> None:
             "setup_stall_timeout_requested_sec"
         ] == 60, compact
         assert compact["compose_setup_diagnostic"]["setup_stall_timeout_sec"] == 60
-        assert compact["compose_setup_diagnostic"][
-            "setup_stall_timeout_capped"
-        ] is False, compact
+        assert "setup_stall_timeout_capped" not in compact[
+            "compose_setup_diagnostic"
+        ]
         compact_text = json.dumps(compact, sort_keys=True)
         assert "skillsbench docker compose build/setup stall timeout" not in compact_text
         assert "/private/" not in compact_text
@@ -133,9 +132,9 @@ def test_skillsbench_runner_failure_honors_long_build_stall_timeout() -> None:
         plan = build_plan(args)
         assert plan["build_stall_timeout_requested_sec"] == 7200
         assert plan["build_stall_timeout_sec"] == 7200
-        assert plan["runner_prerequisites"][
-            "benchflow_setup_stall_timeout_capped"
-        ] is False
+        assert "benchflow_setup_stall_timeout_capped" not in plan[
+            "runner_prerequisites"
+        ]
 
         compact = build_runner_failure_compact(
             args,
@@ -154,7 +153,6 @@ def test_skillsbench_runner_failure_honors_long_build_stall_timeout() -> None:
                 "benchflow_setup_stall_timeout_enabled": True,
                 "benchflow_setup_stall_timeout_requested_sec": 7200,
                 "benchflow_setup_stall_timeout_sec": 7200,
-                "benchflow_setup_stall_timeout_capped": False,
                 "benchflow_setup_stall_timeout_triggered": True,
                 "benchflow_setup_stall_before_agent_lifecycle": True,
             },
@@ -163,9 +161,9 @@ def test_skillsbench_runner_failure_honors_long_build_stall_timeout() -> None:
             "setup_stall_timeout_requested_sec"
         ] == 7200, compact
         assert compact["compose_setup_diagnostic"]["setup_stall_timeout_sec"] == 7200
-        assert compact["compose_setup_diagnostic"][
-            "setup_stall_timeout_capped"
-        ] is False, compact
+        assert "setup_stall_timeout_capped" not in compact[
+            "compose_setup_diagnostic"
+        ]
         compact_text = json.dumps(compact, sort_keys=True)
         assert "skillsbench docker compose build/setup stall timeout" not in compact_text
         assert "/private/" not in compact_text

--- a/examples/skillsbench-runner-core-contract-smoke.py
+++ b/examples/skillsbench-runner-core-contract-smoke.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Smoke-test SkillsBench runner use of shared benchmark_core lifecycle."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.status import compact_benchmark_run  # noqa: E402
+
+
+ROUTE = "codex-acp-blind-loop-baseline"
+TASK_ID = "software-dependency-audit"
+
+
+def _plan_only() -> dict[str, Any]:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-core-plan-") as tmp:
+        result = subprocess.run(
+            [
+                sys.executable,
+                str(REPO_ROOT / "scripts" / "skillsbench_automation_loop.py"),
+                "--task-id",
+                TASK_ID,
+                "--route",
+                ROUTE,
+                "--jobs-dir",
+                str(Path(tmp) / "jobs"),
+                "--plan-only",
+            ],
+            cwd=REPO_ROOT,
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+    payload = json.loads(result.stdout)
+    assert payload["ok"] is True, payload
+    return payload["launch_plan"]
+
+
+def _assert_launch_lifecycle(lifecycle: dict[str, Any]) -> None:
+    assert lifecycle["schema_version"] == "benchmark_canonical_lifecycle_v0", (
+        lifecycle
+    )
+    assert lifecycle["current_phase"] == "runner_accepted_args", lifecycle
+    assert lifecycle["entered_benchmark_case"] is False, lifecycle
+    assert lifecycle["case_attempt_countable"] is False, lifecycle
+    assert lifecycle["next_required_phase"] == "job_root_materialized", lifecycle
+    assert lifecycle["phase_ready"]["process_started"] is True, lifecycle
+    assert lifecycle["phase_ready"]["runner_accepted_args"] is True, lifecycle
+    assert lifecycle["phase_ready"]["job_root_materialized"] is False, lifecycle
+
+
+def test_launch_plan_exposes_core_lifecycle_without_wrapper() -> None:
+    plan = _plan_only()
+    lifecycle = plan["benchmark_canonical_lifecycle"]
+    _assert_launch_lifecycle(lifecycle)
+    assert plan["runner_prerequisites"]["benchmark_canonical_lifecycle"] == lifecycle
+    assert "benchmark_core_runner_contract" not in plan, plan
+
+
+def test_status_compact_keeps_lifecycle_and_drops_legacy_wrapper() -> None:
+    lifecycle = _plan_only()["benchmark_canonical_lifecycle"]
+    compact = compact_benchmark_run(
+        {
+            "schema_version": "benchmark_run_v0",
+            "source_runner": "skillsbench",
+            "benchmark_id": "skillsbench-1.1",
+            "task_id": TASK_ID,
+            "runner_prerequisites": {
+                "schema_version": "skillsbench_runner_prerequisites_v0",
+                "benchmark_core_runner_contract_available": True,
+                "benchmark_core_runner_contract_source": "legacy-wrapper",
+                "benchmark_canonical_lifecycle": lifecycle,
+            },
+        }
+    )
+    assert compact is not None
+    prerequisites = compact["runner_prerequisites"]
+    _assert_launch_lifecycle(prerequisites["benchmark_canonical_lifecycle"])
+    assert "benchmark_core_runner_contract_available" not in prerequisites
+    assert "benchmark_core_runner_contract_source" not in prerequisites
+
+
+def main() -> int:
+    test_launch_plan_exposes_core_lifecycle_without_wrapper()
+    test_status_compact_keeps_lifecycle_and_drops_legacy_wrapper()
+    print("skillsbench runner core contract smoke passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/benchmark_core/__init__.py
+++ b/loopx/benchmark_core/__init__.py
@@ -34,6 +34,7 @@ from .lifecycle import (
     CANONICAL_LIFECYCLE_PHASES,
     BenchmarkLifecyclePhase,
     canonical_lifecycle,
+    compact_benchmark_canonical_lifecycle,
 )
 from .loop_protocol import (
     BENCHMARK_LOOP_CONTROLLER_TRACE_SCHEMA_VERSION,
@@ -186,6 +187,7 @@ __all__ = [
     "RUN_PERMISSION_QUOTA_PROJECTION_SCHEMA_VERSION",
     "RunPermissionAction",
     "canonical_lifecycle",
+    "compact_benchmark_canonical_lifecycle",
     "compact_run_permission_policy_for_quota",
     "compact_round_rewards",
     "compact_round_artifact_snapshots",

--- a/loopx/benchmark_core/lifecycle.py
+++ b/loopx/benchmark_core/lifecycle.py
@@ -70,3 +70,29 @@ def canonical_lifecycle(**flags: Any) -> dict[str, Any]:
         "next_required_phase": next_required_phase,
         "phase_ready": ready,
     }
+
+
+def compact_benchmark_canonical_lifecycle(value: Any) -> dict[str, Any]:
+    """Return the public-safe subset of a canonical lifecycle projection."""
+
+    if not isinstance(value, dict):
+        return {}
+    compact: dict[str, Any] = {}
+    if value.get("schema_version") == BENCHMARK_CANONICAL_LIFECYCLE_SCHEMA_VERSION:
+        compact["schema_version"] = BENCHMARK_CANONICAL_LIFECYCLE_SCHEMA_VERSION
+    for field in ("current_phase", "next_required_phase"):
+        raw = value.get(field)
+        if isinstance(raw, str) and raw in CANONICAL_LIFECYCLE_PHASES:
+            compact[field] = raw
+    for field in ("entered_benchmark_case", "case_attempt_countable"):
+        if isinstance(value.get(field), bool):
+            compact[field] = value[field]
+    phase_ready = value.get("phase_ready")
+    if isinstance(phase_ready, dict):
+        compact_phase_ready: dict[str, bool] = {}
+        for key, ready in phase_ready.items():
+            if key in CANONICAL_LIFECYCLE_PHASES and isinstance(ready, bool):
+                compact_phase_ready[key] = ready
+        if compact_phase_ready:
+            compact["phase_ready"] = compact_phase_ready
+    return compact

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -337,7 +337,6 @@ def _compact_compose_setup_diagnostic(value: Any) -> dict[str, Any]:
         "official_score_missing",
         "official_result_json_materialized",
         "case_attempt_budget_should_count",
-        "setup_stall_timeout_capped",
         "runner_launch_preflight_passed",
         "apt_setup_risk_detected",
         "apt_retry_patch_required",

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -11,6 +11,7 @@ from .benchmark_adapters.skillsbench_signals import (
 from .benchmark_adapters.skillsbench_verifier_bootstrap import (
     apply_skillsbench_verifier_bootstrap_missing_score_attribution,
 )
+from .benchmark_core import compact_benchmark_canonical_lifecycle
 from .control_plane import compact_control_plane_policy
 from .control_plane.status_collection import (
     StatusCollectionContext,
@@ -2314,7 +2315,6 @@ def _compact_benchmark_runner_prerequisites(value: Any) -> dict[str, Any]:
         "loopx_source_mount_source_recorded",
         "benchflow_setup_stall_timeout_enabled",
         "benchflow_setup_stall_timeout_triggered",
-        "benchflow_setup_stall_timeout_capped",
         "benchflow_setup_stall_raw_logs_read",
         "benchflow_setup_stall_before_agent_lifecycle",
         "benchflow_agent_install_started",
@@ -2334,6 +2334,11 @@ def _compact_benchmark_runner_prerequisites(value: Any) -> dict[str, Any]:
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
+    lifecycle = compact_benchmark_canonical_lifecycle(
+        value.get("benchmark_canonical_lifecycle")
+    )
+    if lifecycle:
+        compact["benchmark_canonical_lifecycle"] = lifecycle
     for field in (
         "codex_acp_runtime_launch_preflight_rc",
         "benchflow_user_loop_recovery_round",
@@ -2420,7 +2425,6 @@ def _compact_benchmark_runner_prerequisites(value: Any) -> dict[str, Any]:
             "remote_command_file_bridge_agent_successful_loopx_command_records"
         ] = command_records
     return compact
-
 
 def _compact_benchmark_task_staging(value: Any) -> dict[str, Any]:
     if not isinstance(value, dict):
@@ -2612,7 +2616,6 @@ def _compact_benchmark_compose_setup_diagnostic(value: Any) -> dict[str, Any]:
         "official_score_missing",
         "official_result_json_materialized",
         "case_attempt_budget_should_count",
-        "setup_stall_timeout_capped",
         "runner_launch_preflight_passed",
         "apt_setup_risk_detected",
         "apt_retry_patch_required",

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -18,6 +18,8 @@ Required env:
 Optional env:
   SKILLSBENCH_LOCAL_CODEX_PROXY_HOST   Local proxy host, default 127.0.0.1
   SKILLSBENCH_LOCAL_CODEX_PROXY_PORT   Local proxy port, default 18180
+  SKILLSBENCH_DOCKER_PROXY_HOST        Remote Docker bridge host for benchmark
+                                       setup/verifier egress; default auto
   SKILLSBENCH_ROUTE                    Route, default codex-cli-goal-baseline
   SKILLSBENCH_MODEL                    Model, default gpt-5.5
   SKILLSBENCH_REASONING_EFFORT         Reasoning effort, default xhigh
@@ -26,6 +28,8 @@ Optional env:
   SKILLSBENCH_GOAL_ID                  Local evidence goal id, default loopx-meta
   SKILLSBENCH_RUN_STAMP                Deterministic timestamp override
   SKILLSBENCH_SSH_OPTIONS              Extra ssh options, one shell word each
+  SKILLSBENCH_APPEND_HISTORY           Set to 1 to append LoopX history
+  SKILLSBENCH_REGISTRY                 Optional registry path for history append
 EOF
 }
 
@@ -76,6 +80,59 @@ build_stall_timeout="${SKILLSBENCH_BUILD_STALL_TIMEOUT_SEC:-0}"
 run_timeout="${SKILLSBENCH_RUN_TIMEOUT_SEC:-28800}"
 local_proxy_host="${SKILLSBENCH_LOCAL_CODEX_PROXY_HOST:-127.0.0.1}"
 local_proxy_port="${SKILLSBENCH_LOCAL_CODEX_PROXY_PORT:-18180}"
+docker_proxy_host="${SKILLSBENCH_DOCKER_PROXY_HOST:-auto}"
+if [[ -z "$docker_proxy_host" || "$docker_proxy_host" == "auto" ]]; then
+  docker_proxy_host="$(
+    ssh -o BatchMode=yes -o ConnectTimeout=10 "$SKILLSBENCH_SSH_DESTINATION" \
+      "ip -4 addr show docker0 2>/dev/null | awk '/inet /{print \$2}' | cut -d/ -f1 | head -n1"
+  )"
+  if [[ -z "$docker_proxy_host" ]]; then
+    echo "missing remote Docker bridge host; set SKILLSBENCH_DOCKER_PROXY_HOST" >&2
+    exit 2
+  fi
+fi
+bridge_proxy_url="http://${docker_proxy_host}:${remote_proxy_port}"
+loopback_proxy_url="http://127.0.0.1:${remote_proxy_port}"
+bridge_forwarder_py='import select, socket, sys, threading
+listen_host = sys.argv[1]
+listen_port = int(sys.argv[2])
+target = ("127.0.0.1", listen_port)
+
+def pipe(a, b):
+    sockets = [a, b]
+    try:
+        while True:
+            readable, _, _ = select.select(sockets, [], [], 60)
+            if not readable:
+                return
+            for src in readable:
+                data = src.recv(65536)
+                if not data:
+                    return
+                (b if src is a else a).sendall(data)
+    finally:
+        for sock in sockets:
+            try:
+                sock.close()
+            except OSError:
+                pass
+
+server = socket.socket()
+server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+server.bind((listen_host, listen_port))
+server.listen(64)
+while True:
+    client, _addr = server.accept()
+    upstream = socket.create_connection(target)
+    threading.Thread(target=pipe, args=(client, upstream), daemon=True).start()
+'
+extra_runner_args=()
+if [[ -n "${SKILLSBENCH_REGISTRY:-}" ]]; then
+  extra_runner_args+=(--registry "$SKILLSBENCH_REGISTRY")
+fi
+if [[ "${SKILLSBENCH_APPEND_HISTORY:-0}" == "1" ]]; then
+  extra_runner_args+=(--append-history)
+fi
 
 run_group="skillsbench-codex-cli-goal-xhigh-${safe_task}-${tag}-${stamp}"
 job_name="${safe_task}__codex_cli_goal_xhigh_${tag}_${stamp}"
@@ -85,8 +142,17 @@ private_dir=".local/goals/${goal_id}/private/skillsbench-runs/${run_group}"
 mkdir -p "$public_dir" "$private_dir"
 
 remote_command=$(
-  printf 'cd %q && python3 scripts/skillsbench_automation_loop.py ' \
+  printf 'cd %q || exit 1; ' \
     "$SKILLSBENCH_REMOTE_ROOT"
+  printf 'python3 -c %q %q %q & ' \
+    "$bridge_forwarder_py" "$docker_proxy_host" "$remote_proxy_port"
+  printf 'loopx_benchmark_proxy_forwarder_pid=$!; '
+  printf 'trap %q EXIT; ' 'kill "$loopx_benchmark_proxy_forwarder_pid" 2>/dev/null || true'
+  printf 'sleep 0.5; '
+  printf '%q ' \
+    "LOOPX_SKILLSBENCH_EGRESS_PROXY=${bridge_proxy_url}" \
+    python3 \
+    scripts/skillsbench_automation_loop.py
   printf '%q ' \
     --skillsbench-root "$SKILLSBENCH_ROOT" \
     --expected-loopx-git-head "$SKILLSBENCH_EXPECTED_LOOPX_GIT_HEAD" \
@@ -96,13 +162,16 @@ remote_command=$(
     --reasoning-effort "$reasoning_effort" \
     --build-stall-timeout-sec "$build_stall_timeout" \
     --codex-api-egress-mode reverse-tunnel \
-    --codex-api-reverse-tunnel-proxy "http://127.0.0.1:${remote_proxy_port}" \
+    --codex-api-reverse-tunnel-proxy "$loopback_proxy_url" \
+    --benchmark-egress-proxy-mode require \
     --host-local-acp-launch \
     --remote-command-file-bridge-probe \
     --run-group-id "$run_group" \
     --job-name "$job_name" \
-    --update-ledger \
-    --append-history
+    --update-ledger
+  if ((${#extra_runner_args[@]})); then
+    printf '%q ' "${extra_runner_args[@]}"
+  fi
 )
 
 ssh_options=(--ssh-option ConnectTimeout=10)
@@ -135,6 +204,7 @@ if [[ "$dry_run" == "true" ]]; then
   printf 'public_output=%s/supervisor.public.json\n' "$public_dir"
   printf 'private_dir=%s\n' "$private_dir"
   printf 'remote_proxy_port=%s\n' "$remote_proxy_port"
+  printf 'docker_proxy_host=%s\n' "$docker_proxy_host"
   printf 'remote_command=%s\n' "$remote_command"
   printf 'supervisor_command='
   printf '%q ' "${supervisor_cmd[@]}"
@@ -172,4 +242,5 @@ job_name=${job_name}
 public_output=${public_dir}/supervisor.public.json
 private_dir=${private_dir}
 remote_proxy_port=${remote_proxy_port}
+docker_proxy_host=${docker_proxy_host}
 EOF

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -136,6 +136,8 @@ from loopx.benchmark_adapters.skillsbench_remote_bridge import (  # noqa: E402
 )
 from loopx.benchmark_core import (  # noqa: E402
     build_benchmark_launch_observable_handle,
+    canonical_lifecycle,
+    compact_benchmark_canonical_lifecycle,
     write_benchmark_run_observable_status,
 )
 from loopx.benchmark_core.loop_protocol import (  # noqa: E402
@@ -1386,8 +1388,27 @@ def _benchmark_egress_proxy_requested_mode(
     if args is not None:
         requested = str(getattr(args, "benchmark_egress_proxy_mode", "") or "")
     if requested in BENCHMARK_EGRESS_PROXY_MODE_CHOICES:
+        if requested == "auto" and _formal_goal_benchmark_egress_proxy_required(args):
+            return "require"
         return requested
     return "auto"
+
+
+def _formal_goal_benchmark_egress_proxy_required(
+    args: argparse.Namespace | None,
+) -> bool:
+    if args is None:
+        return False
+    if bool(getattr(args, "reduce_only", False)):
+        return False
+    if not bool(getattr(args, "host_local_acp_launch", False)):
+        return False
+    if getattr(args, "route", "") not in {
+        "codex-app-server-goal-baseline",
+        CODEX_CLI_GOAL_BASELINE_ROUTE,
+    }:
+        return False
+    return _codex_api_egress_resolved_mode(args) == "reverse-tunnel"
 
 
 def _proxy_host_kind(host: str) -> str:
@@ -2849,7 +2870,6 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_final_verifier_timeout_raw_output_recorded",
         "benchflow_setup_stall_timeout_enabled",
         "benchflow_setup_stall_timeout_triggered",
-        "benchflow_setup_stall_timeout_capped",
         "benchflow_setup_stall_raw_logs_read",
         "benchflow_setup_stall_before_agent_lifecycle",
         "benchflow_agent_install_started",
@@ -2865,6 +2885,11 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
     ):
         if isinstance(value.get(field), bool):
             compact[field] = value[field]
+    lifecycle = compact_benchmark_canonical_lifecycle(
+        value.get("benchmark_canonical_lifecycle")
+    )
+    if lifecycle:
+        compact["benchmark_canonical_lifecycle"] = lifecycle
     for field in (
         "codex_acp_runtime_launch_preflight_rc",
         "benchflow_agent_timeout_requested_sec",
@@ -4619,10 +4644,6 @@ def _ensure_setup_stall_timeout_prerequisites(
     )
     raw_prerequisites.setdefault(
         "benchflow_setup_stall_timeout_sec", build_stall_timeout_sec
-    )
-    raw_prerequisites.setdefault(
-        "benchflow_setup_stall_timeout_capped",
-        requested_build_stall_timeout_sec > build_stall_timeout_sec,
     )
     raw_prerequisites.setdefault("benchflow_setup_stall_timeout_triggered", True)
     raw_prerequisites.setdefault(
@@ -6580,10 +6601,6 @@ def build_compose_setup_diagnostic(
         "setup_stall_timeout_sec": _public_int(
             runner_prerequisites.get("benchflow_setup_stall_timeout_sec")
         ),
-        "setup_stall_timeout_capped": runner_prerequisites.get(
-            "benchflow_setup_stall_timeout_capped"
-        )
-        is True,
         "runner_prerequisite_status": str(
             runner_prerequisites.get(
                 "codex_acp_runtime_launch_preflight_status", ""
@@ -7899,13 +7916,16 @@ def patch_verifier_benchmark_egress_proxy_env(
     """Forward the private benchmark egress proxy into staged verifier scripts."""
 
     exports = _verifier_benchmark_egress_proxy_exports(proxy_env)
+    patch_required = bool(exports and verifier.exists())
     metadata: dict[str, Any] = {
-        "benchmark_egress_proxy_verifier_env_patch_required": bool(exports),
+        "benchmark_egress_proxy_verifier_env_patch_required": patch_required,
         "benchmark_egress_proxy_verifier_env_patch_applied": False,
-        "benchmark_egress_proxy_verifier_env_key_count": len(exports),
+        "benchmark_egress_proxy_verifier_env_key_count": (
+            len(exports) if patch_required else 0
+        ),
         "benchmark_egress_proxy_verifier_env_raw_proxy_recorded": False,
     }
-    if not verifier.exists() or not exports:
+    if not patch_required:
         return metadata
     try:
         original = verifier.read_text(encoding="utf-8", errors="replace")
@@ -8834,11 +8854,16 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         if is_app_server_goal_route
         else {}
     )
+    benchmark_canonical_lifecycle = canonical_lifecycle(
+        process_started=True,
+        runner_accepted_args=True,
+    )
     launch_plan = {
         "schema_version": "skillsbench_runner_launch_plan_v0",
         "benchmark_id": args.dataset,
         "task_id": task_id,
         "route": route,
+        "benchmark_canonical_lifecycle": benchmark_canonical_lifecycle,
         "agent": (
             "codex-app-server-goal"
             if is_app_server_goal_route
@@ -9002,6 +9027,7 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
         },
         "runner_prerequisites": {
             "schema_version": "skillsbench_runner_prerequisites_v0",
+            "benchmark_canonical_lifecycle": benchmark_canonical_lifecycle,
             "benchflow_setup_stall_timeout_enabled": (
                 _effective_build_stall_timeout_sec(args) > 0
             ),
@@ -9010,10 +9036,6 @@ def build_plan(args: argparse.Namespace) -> dict[str, Any]:
             ),
             "benchflow_setup_stall_timeout_sec": int(
                 _effective_build_stall_timeout_sec(args)
-            ),
-            "benchflow_setup_stall_timeout_capped": (
-                _requested_build_stall_timeout_sec(args)
-                > _effective_build_stall_timeout_sec(args)
             ),
             "benchflow_setup_stall_raw_logs_read": False,
             "codex_acp_runtime_container_bootstrap": (
@@ -14394,9 +14416,6 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
         requested_build_stall_timeout_sec
     )
     prerequisites["benchflow_setup_stall_timeout_sec"] = build_stall_timeout_sec
-    prerequisites["benchflow_setup_stall_timeout_capped"] = (
-        requested_build_stall_timeout_sec > build_stall_timeout_sec
-    )
     prerequisites["benchflow_setup_stall_raw_logs_read"] = False
     prerequisites["benchflow_run_stage"] = "before_benchflow_run"
 


### PR DESCRIPTION
## Summary

- Make formal host-local SkillsBench Goal routes resolve benchmark egress proxy `auto` to `require` when the Codex API path resolves to reverse-tunnel.
- Add a focused egress-policy smoke for `codex-cli-goal-baseline` so missing benchmark setup/verifier proxy blocks before dependency bootstrap.
- Update benchmark developer docs to distinguish formal Goal runs from explicit local no-proxy/debug runs.

## Why

Recent verifier dependency bootstrap timeouts showed `benchmark_egress_proxy_configured=false` and `benchmark_egress_proxy_verifier_env_patch_applied=false` while runs continued. That meant Codex API reverse-tunnel could be configured, but benchmark setup/verifier dependency installs still ran without the benchmark egress proxy. Formal Goal runs should fail fast instead.

## Validation

- `python3 examples/skillsbench-benchmark-egress-policy-smoke.py`
- targeted egress functions from `examples/skillsbench-benchmark-run-smoke.py`
- `python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py examples/skillsbench-benchmark-egress-policy-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `loopx canary premerge --from-git-diff`

`loopx canary premerge --from-git-diff` reported all automated checks passed, with the expected `benchmark_sensitive` manual hold, so this PR is not self-merged.

## Boundary

No private proxy URL, raw verifier output, benchmark trajectory, local path, or credential material is committed. Public artifacts continue to record only redacted proxy source/scheme/kind/port booleans.
