### PR TITLE
Add headroom to todo archive default

### DIFF
--- a/examples/control_plane/todo-archive-completed-smoke.py
+++ b/examples/control_plane/todo-archive-completed-smoke.py
@@ -115,6 +115,21 @@ def main() -> int:
         assert warning["active_done_count"] == 14, warning
         assert warning["active_open_count"] == 2, warning
 
+        default_dry_run = run_cli(
+            registry_path,
+            runtime,
+            "todo",
+            "archive-completed",
+            "--goal-id",
+            GOAL_ID,
+        )
+        assert default_dry_run["ok"] is True, default_dry_run
+        assert default_dry_run["dry_run"] is True, default_dry_run
+        assert default_dry_run["changed"] is True, default_dry_run
+        assert default_dry_run["active_done_after"] == 10, default_dry_run
+        assert default_dry_run["moved_count"] == 4, default_dry_run
+        assert state_path.read_text(encoding="utf-8") == original
+
         dry_run = run_cli(
             registry_path,
             runtime,

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -12,6 +12,7 @@ from ..todo_suggestion_prompt import (
 )
 from ..todo_followups import capture_followup_todos
 from ..todos import (
+    ARCHIVE_COMPLETED_DEFAULT_MAX_ACTIVE_DONE,
     archive_completed_todos,
     add_goal_todo,
     complete_goal_todo,
@@ -254,8 +255,11 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
     todo_parser.add_argument(
         "--max-active-done",
         type=int,
-        default=12,
-        help="For archive-completed, keep this many completed todos in the active section.",
+        default=ARCHIVE_COMPLETED_DEFAULT_MAX_ACTIVE_DONE,
+        help=(
+            "For archive-completed, keep this many completed todos in the active section. "
+            "The default leaves a small buffer below the status warning threshold."
+        ),
     )
     todo_parser.add_argument(
         "--agent-id",

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -104,6 +104,8 @@ TODO_METADATA_FIELDS = (
     "superseded_by",
 )
 
+ARCHIVE_COMPLETED_DEFAULT_MAX_ACTIVE_DONE = max(0, MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE - 2)
+
 
 def _attach_todo_write_correctness_dry_run_packet(
     payload: dict[str, Any],
@@ -1649,7 +1651,7 @@ def archive_completed_todos(
     registry_path: Path,
     goal_id: str,
     role: str = "agent",
-    max_active_done: int = MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE,
+    max_active_done: int = ARCHIVE_COMPLETED_DEFAULT_MAX_ACTIVE_DONE,
     project: Path | None = None,
     state_file: Path | None = None,
     dry_run: bool = True,


### PR DESCRIPTION
## Summary
- change `todo archive-completed` default retention from the warning threshold to a small headroom target
- keep explicit `--max-active-done` behavior unchanged
- cover the default headroom behavior in `todo-archive-completed-smoke`

## Why
After archiving to the exact warning threshold, completing the current todo immediately pushes active done count back over the warning limit. The default command should leave a small recent-done buffer so routine completion does not re-trigger housekeeping right away.

## Validation
- `python3 examples/control_plane/todo-archive-completed-smoke.py`
- `python3 -m py_compile loopx/todos.py loopx/cli_commands/todo.py examples/control_plane/todo-archive-completed-smoke.py`
- `python3 examples/backlog-hygiene-smoke.py`
- `python3 examples/derived-state-boundary-smoke.py`
- `python3 examples/cli-control-plane-command-modularization-smoke.py`
- `python3 -m loopx.cli --format json todo archive-completed --goal-id loopx-meta --role agent --dry-run`
- `loopx canary premerge --from-git-diff --git-diff-base origin/main --tier standard --timeout-seconds 120 --format json --no-progress`
