### PR TITLE
Use todo lanes for project asset claimed counts

### DIFF
--- a/examples/control_plane/todo-first-open-summary-smoke.py
+++ b/examples/control_plane/todo-first-open-summary-smoke.py
@@ -357,6 +357,65 @@ def assert_claimed_frontstage_lanes_visible() -> None:
     assert decision["agent_identity"]["agent_id"] == "codex-side-bypass", decision
 
 
+def assert_project_asset_claimed_counts_use_lane_fallback() -> None:
+    todos = {
+        "schema_version": "todo_summary_v0",
+        "source_section": "Agent Todo",
+        "open_count": 5,
+        "done_count": 0,
+        "total_count": 5,
+        "first_open_items": [
+            {
+                "index": index,
+                "done": False,
+                "text": f"[P1] Unclaimed backlog item {index}.",
+                "task_class": "advancement_task",
+            }
+            for index in range(1, 4)
+        ],
+        "claimed_open_items": [
+            {
+                "index": 40,
+                "done": False,
+                "text": FRONTSTAGE_CLAIMED_TODO,
+                "task_class": "advancement_task",
+                "claimed_by": "codex-side-bypass",
+            },
+            {
+                "index": 41,
+                "done": False,
+                "text": FRONTSTAGE_MONITOR_TODO,
+                "task_class": "continuous_monitor",
+                "claimed_by": "codex-side-bypass",
+            },
+        ],
+        "claimed_advancement_open_items": [
+            {
+                "index": 40,
+                "done": False,
+                "text": FRONTSTAGE_CLAIMED_TODO,
+                "task_class": "advancement_task",
+                "claimed_by": "codex-side-bypass",
+            },
+        ],
+        "claimed_monitor_open_items": [
+            {
+                "index": 41,
+                "done": False,
+                "text": FRONTSTAGE_MONITOR_TODO,
+                "task_class": "continuous_monitor",
+                "claimed_by": "codex-side-bypass",
+            },
+        ],
+    }
+    asset_summary = project_asset_todo_summary(todos, role="agent")
+    assert asset_summary is not None, todos
+    assert asset_summary["claimed_open_count"] == 2, asset_summary
+    assert asset_summary["unclaimed_open_count"] == 3, asset_summary
+    assert asset_summary["claimed_advancement_open_count"] == 1, asset_summary
+    assert asset_summary["claimed_monitor_open_count"] == 1, asset_summary
+
+
 def assert_claimed_markdown_todos_survive_visibility_lanes() -> None:
     unclaimed_lines = "\n".join(
         f"- [ ] [P1] Unclaimed priority backlog item {index}."
@@ -691,6 +750,7 @@ def main() -> int:
     assert f"Agent 待办候选 2：{OPEN_TODO}" in packet["project_agent_handoff"], packet
     assert_blocked_priority_fallback_visible()
     assert_claimed_frontstage_lanes_visible()
+    assert_project_asset_claimed_counts_use_lane_fallback()
     assert_claimed_markdown_todos_survive_visibility_lanes()
     assert_claimed_advancement_lanes_preserve_claimants()
     print("todo-first-open-summary-smoke ok")

--- a/loopx/control_plane/work_items/project_asset.py
+++ b/loopx/control_plane/work_items/project_asset.py
@@ -470,6 +470,13 @@ def build_project_asset_todo_summary(
 ) -> dict[str, Any] | None:
     if not isinstance(todos, dict):
         return None
+
+    def lane_count(lane: str) -> int:
+        items = todos.get(lane)
+        if not isinstance(items, list):
+            return 0
+        return sum(1 for item in items if isinstance(item, dict))
+
     open_count = todos.get("open_count", 0)
     done_count = todos.get("done_count", 0)
     total_count = todos.get("total_count", 0)
@@ -488,9 +495,13 @@ def build_project_asset_todo_summary(
         **metadata,
     }
     open_items = open_todo_items(todos, limit=item_limit)
-    claimed_open_count = sum(1 for item in open_items if item.get("claimed_by"))
-    if claimed_open_count or todos.get("claimed_open_count"):
-        summary["claimed_open_count"] = todos.get("claimed_open_count", claimed_open_count)
+    claimed_open_count = todos.get("claimed_open_count")
+    if claimed_open_count is None:
+        claimed_open_count = lane_count("claimed_open_items") or sum(
+            1 for item in open_items if item.get("claimed_by")
+        )
+    if claimed_open_count:
+        summary["claimed_open_count"] = claimed_open_count
         summary["unclaimed_open_count"] = todos.get(
             "unclaimed_open_count",
             max(0, int(summary.get("open") or 0) - int(summary["claimed_open_count"] or 0)),
@@ -553,4 +564,9 @@ def build_project_asset_todo_summary(
     ):
         if todos.get(count_key) is not None:
             summary[count_key] = todos.get(count_key)
+            continue
+        lane = count_key.removesuffix("_count") + "_items"
+        count = lane_count(lane)
+        if count:
+            summary[count_key] = count
     return summary


### PR DESCRIPTION
## Summary

- Derive `project_asset.agent_todos` claimed counts from existing todo lanes when aggregate count fields are absent.
- Preserve existing aggregate counts when they are present, and keep the fallback bounded to the project-asset todo read model.
- Add a regression fixture for truncated first-open items with claimed advancement/monitor lanes.

## Validation

Focused local checks:

- `python3 examples/control_plane/todo-first-open-summary-smoke.py`
- `python3 examples/control_plane/quota-todo-summary-readmodel-smoke.py`
- `python3 examples/control_plane/todo-claim-visibility-lanes-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 examples/control_plane/todo-projection-shared-helper-smoke.py`
- `python3 -m py_compile loopx/control_plane/work_items/project_asset.py examples/control_plane/todo-first-open-summary-smoke.py`
- `git diff --check`
- added-line public/private scan for candidate paths
- source `python3 -m loopx.cli --format json status --goal-id loopx-meta`

Premerge gate:

- `loopx canary premerge --from-git-diff --git-diff-base origin/main --tier standard --timeout-seconds 120 --format json --no-progress`
- gate status: passed; self_merge_allowed: true; failures/manual holds: none
- selected commands: 13 risk/catalog/boundary checks plus 4 direct checks

## Boundary

Public-safe control-plane read-model change only. No credentials, raw benchmark logs, trajectories, verifier output, private paths, or production actions.
