### PR TITLE
Add beginner preset picker

### DIFF
--- a/docs/product/beginner-loop-presets.md
+++ b/docs/product/beginner-loop-presets.md
@@ -16,6 +16,24 @@ of creating a second `STATE.md` runtime or a separate loop ledger. The first
 run should be safe and easy to explain. Advanced presets can be powerful, but
 they must be opt-in and visibly gated.
 
+The current thin entry point is:
+
+```bash
+loopx preset list
+```
+
+For one preset card:
+
+```bash
+loopx preset show daily-triage
+loopx preset show changelog-draft
+loopx preset show pr-watch
+```
+
+These commands are read-only. They render `/loopx ...`, `start-goal`,
+`quota should-run`, and `heartbeat-prompt` command packets; they do not write
+registry state, install automations, edit docs, or create PRs.
+
 ## Recommendation Matrix
 
 | Pattern | User value | LoopX default | Recommendation |

--- a/examples/beginner-preset-picker-smoke.py
+++ b/examples/beginner-preset-picker-smoke.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *args],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+    )
+
+
+def assert_markdown_list() -> None:
+    result = run_cli("preset", "list")
+    assert result.returncode == 0, (result.returncode, result.stdout, result.stderr)
+    assert result.stderr == "", result.stderr
+    assert "LoopX beginner preset picker" in result.stdout, result.stdout
+    assert "Daily Triage L1" in result.stdout, result.stdout
+    assert "Changelog Draft L1" in result.stdout, result.stdout
+    assert "PR Watch L1" in result.stdout, result.stdout
+    assert "/loopx Run Daily Triage L1" in result.stdout, result.stdout
+    assert "loopx start-goal --guided --project" in result.stdout, result.stdout
+    assert "quota should-run" in result.stdout, result.stdout
+    assert "loopx heartbeat-prompt --thin" in result.stdout, result.stdout
+    assert "Mutation policy: read_only" in result.stdout, result.stdout
+
+
+def assert_json_show_with_placeholders() -> None:
+    result = run_cli(
+        "preset",
+        "show",
+        "daily-triage",
+        "--format",
+        "json",
+        "--goal-id",
+        "demo-goal",
+        "--agent-id",
+        "codex-demo",
+        "--agent-scope",
+        "daily triage lane",
+    )
+    assert result.returncode == 0, (result.returncode, result.stdout, result.stderr)
+    assert result.stderr == "", result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["schema_version"] == "loopx_beginner_preset_picker_v0", payload
+    assert payload["mutation_policy"].startswith("read_only"), payload
+    assert payload["recommended_order"] == ["daily-triage", "changelog-draft", "pr-watch"], payload
+    presets = payload["presets"]
+    assert len(presets) == 1, payload
+    preset = presets[0]
+    assert preset["id"] == "daily-triage", preset
+    assert preset["maturity"] == "L1 report-only", preset
+    commands = preset["commands"]
+    assert "--goal-id demo-goal --agent-id codex-demo" in commands["quota_guard"], commands
+    assert "--agent-scope 'daily triage lane'" in commands["heartbeat_prompt"], commands
+    assert "start-goal --guided" in commands["cli_start"], commands
+
+
+def assert_pr_watch_is_watch_only() -> None:
+    result = run_cli("preset", "show", "pr-watch")
+    assert result.returncode == 0, (result.returncode, result.stdout, result.stderr)
+    assert result.stderr == "", result.stderr
+    assert "L1 watch-only" in result.stdout, result.stdout
+    assert "No auto-merge." in result.stdout, result.stdout
+    assert "No code edits unless the owner upgrades" in result.stdout, result.stdout
+    assert "Quiet unchanged polls should not spend quota." in result.stdout, result.stdout
+
+
+def assert_command_reference_mentions_presets() -> None:
+    result = run_cli("commands")
+    assert result.returncode == 0, (result.returncode, result.stdout, result.stderr)
+    assert result.stderr == "", result.stderr
+    assert "loopx preset list" in result.stdout, result.stdout
+    assert "Daily Triage, Changelog Draft, and PR Watch" in result.stdout, result.stdout
+
+
+def main() -> int:
+    assert_markdown_list()
+    assert_json_show_with_placeholders()
+    assert_pr_watch_is_watch_only()
+    assert_command_reference_mentions_presets()
+    print("beginner-preset-picker-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -37,6 +37,7 @@ from .cli_commands import (
     handle_lark_kanban_command,
     handle_ml_experiment_command,
     handle_multi_agent_command,
+    handle_preset_command,
     handle_project_lifecycle_command,
     handle_pr_review_command,
     handle_quota_command,
@@ -62,6 +63,7 @@ from .cli_commands import (
     register_lark_kanban_commands,
     register_ml_experiment_commands,
     register_multi_agent_commands,
+    register_preset_commands,
     register_project_lifecycle_commands,
     register_pr_review_command,
     register_quota_command,
@@ -166,6 +168,7 @@ def main(argv: list[str] | None = None) -> int:
     register_auto_research_commands(sub, add_subcommand_format)
 
     register_multi_agent_commands(sub, add_subcommand_format)
+    register_preset_commands(sub, add_subcommand_format)
 
     register_registry_admin_commands(sub)
 
@@ -311,6 +314,14 @@ def main(argv: list[str] | None = None) -> int:
     )
     if multi_agent_result is not None:
         return multi_agent_result
+
+    preset_result = handle_preset_command(
+        args,
+        output_format=output_format,
+        print_payload=print_payload,
+    )
+    if preset_result is not None:
+        return preset_result
 
     if args.command == "content-ops":
         return handle_content_ops_command(args, output_format=output_format, print_payload=print_payload)

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -89,6 +89,7 @@ from .project_lifecycle import (
     handle_project_lifecycle_command,
     register_project_lifecycle_commands,
 )
+from .preset import handle_preset_command, register_preset_commands
 from .pr_review import handle_pr_review_command, register_pr_review_command
 from .quota import handle_quota_command, register_quota_command
 from .registry_admin import (
@@ -212,6 +213,7 @@ __all__ = [
     "handle_ml_experiment_command",
     "handle_multi_agent_command",
     "handle_new_project_prompt_command",
+    "handle_preset_command",
     "handle_project_lifecycle_command",
     "handle_pr_review_command",
     "handle_quota_command",
@@ -261,6 +263,7 @@ __all__ = [
     "register_multi_agent_commands",
     "register_project_lifecycle_commands",
     "register_pr_review_command",
+    "register_preset_commands",
     "register_quota_command",
     "register_registry_admin_commands",
     "register_slash_commands_command",

--- a/loopx/cli_commands/preset.py
+++ b/loopx/cli_commands/preset.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+
+from ..presets import (
+    PRESET_IDS,
+    build_beginner_preset_packet,
+    render_beginner_preset_markdown,
+)
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+FormatSelector = Callable[..., str]
+AddFormat = Callable[[argparse.ArgumentParser], None]
+
+
+def _add_preset_runtime_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--cli-bin",
+        default="loopx",
+        help="LoopX CLI binary name to show in rendered commands.",
+    )
+    parser.add_argument(
+        "--project",
+        default=".",
+        help="Project path to show in the start-goal fallback command.",
+    )
+    parser.add_argument(
+        "--goal-id",
+        default="<goal-id>",
+        help="Goal id placeholder or concrete goal id to show in follow-up commands.",
+    )
+    parser.add_argument(
+        "--agent-id",
+        default="<agent-id>",
+        help="Agent id placeholder or concrete registered agent id to show in follow-up commands.",
+    )
+    parser.add_argument(
+        "--agent-scope",
+        default="<agent-scope>",
+        help="Agent scope placeholder or concrete scope text to show in heartbeat commands.",
+    )
+
+
+def register_preset_commands(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: AddFormat,
+) -> None:
+    preset_parser = subparsers.add_parser(
+        "preset",
+        help="List beginner LoopX presets and render safe start packets.",
+    )
+    preset_sub = preset_parser.add_subparsers(dest="preset_command", required=True)
+
+    list_parser = preset_sub.add_parser(
+        "list",
+        help="List beginner presets with copyable LoopX start and heartbeat commands.",
+    )
+    add_subcommand_format(list_parser)
+    _add_preset_runtime_args(list_parser)
+
+    show_parser = preset_sub.add_parser(
+        "show",
+        help="Show one beginner preset with its exact start packet.",
+    )
+    add_subcommand_format(show_parser)
+    show_parser.add_argument(
+        "preset_id",
+        choices=PRESET_IDS,
+        help="Beginner preset id to render.",
+    )
+    _add_preset_runtime_args(show_parser)
+
+
+def handle_preset_command(
+    args: argparse.Namespace,
+    *,
+    output_format: FormatSelector,
+    print_payload: PrintPayload,
+) -> int | None:
+    if args.command != "preset":
+        return None
+    payload = build_beginner_preset_packet(
+        preset_id=getattr(args, "preset_id", None),
+        cli_bin=args.cli_bin,
+        project=args.project,
+        goal_id=args.goal_id,
+        agent_id=args.agent_id,
+        agent_scope=args.agent_scope,
+    )
+    print_payload(payload, output_format(args), render_beginner_preset_markdown)
+    return 0

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -29,6 +29,10 @@ COMMAND_GROUPS: list[dict[str, object]] = [
                 "purpose": "Refresh host slash-command prompt and skill files.",
             },
             {
+                "command": "loopx preset list",
+                "purpose": "Show beginner-safe Daily Triage, Changelog Draft, and PR Watch start packets.",
+            },
+            {
                 "command": 'loopx start-goal --guided --project . --goal-text "<goal>"',
                 "purpose": "Preview the shell fallback for the same agent-safe `/loopx <goal>` path.",
             },
@@ -176,6 +180,7 @@ def render_concise_help(program: str = "loopx") -> str:
             "  /loopx <goal text>             Start or continue a concrete long-running goal.",
             "  loopx doctor                   Check install, PATH, release snapshot, and skills.",
             "  loopx slash-commands --install Refresh host slash-command skill files.",
+            "  loopx preset list              Show beginner-safe loop start packets.",
             "  loopx start-goal --guided --project . --goal-text \"<goal>\"",
             "                                  Preview the shell fallback for /loopx <goal>.",
             "",

--- a/loopx/presets.py
+++ b/loopx/presets.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass
+from typing import Any
+
+
+PRESET_PICKER_SCHEMA_VERSION = "loopx_beginner_preset_picker_v0"
+
+
+@dataclass(frozen=True)
+class BeginnerPreset:
+    preset_id: str
+    title: str
+    maturity: str
+    cadence: str
+    default_mode: str
+    summary: str
+    goal_text: str
+    capability_path: tuple[str, ...]
+    safety_defaults: tuple[str, ...]
+    useful_when: tuple[str, ...]
+
+
+BEGINNER_PRESETS: tuple[BeginnerPreset, ...] = (
+    BeginnerPreset(
+        preset_id="daily-triage",
+        title="Daily Triage L1",
+        maturity="L1 report-only",
+        cadence="daily or weekday morning",
+        default_mode="report_only",
+        summary=(
+            "Inspect LoopX status, active todos, open gates, stale signals, and the "
+            "single next action so the owner gets a useful project digest."
+        ),
+        goal_text=(
+            "Run Daily Triage L1 for this repository: inspect LoopX status, active "
+            "todos, open gates, stale signals, and next actions; write a compact "
+            "report and ask before code edits or external writes."
+        ),
+        capability_path=(
+            "status",
+            "todo projection",
+            "quota should-run",
+            "thin evidence log",
+        ),
+        safety_defaults=(
+            "No code edits by default.",
+            "No external writes by default.",
+            "Human review before changing project files, publishing, or closing gates.",
+        ),
+        useful_when=(
+            "You want LoopX to keep a long-running repo goal warm.",
+            "You need a low-risk first demo that still uses real LoopX state.",
+        ),
+    ),
+    BeginnerPreset(
+        preset_id="changelog-draft",
+        title="Changelog Draft L1",
+        maturity="L1 draft-only",
+        cadence="per release, or daily during release week",
+        default_mode="draft_only",
+        summary=(
+            "Turn recent merged work and LoopX run history into a release-note draft "
+            "with PR links when available."
+        ),
+        goal_text=(
+            "Run Changelog Draft L1 for this repository: summarize recent merged "
+            "work and LoopX run history into a human-reviewed release-note draft "
+            "with PR links when available; do not publish."
+        ),
+        capability_path=(
+            "history",
+            "release notes draft",
+            "PR link evidence",
+            "human review gate",
+        ),
+        safety_defaults=(
+            "Draft only; no release creation or publish action.",
+            "Prefer PR links and compact public evidence over raw logs.",
+            "Human review before tagging, announcing, or editing canonical docs.",
+        ),
+        useful_when=(
+            "You want visible maintainer value without granting write authority.",
+            "You need release copy that is grounded in recent work instead of memory.",
+        ),
+    ),
+    BeginnerPreset(
+        preset_id="pr-watch",
+        title="PR Watch L1",
+        maturity="L1 watch-only",
+        cadence="every 10-30 minutes while the PR is active",
+        default_mode="watch_only",
+        summary=(
+            "Watch review, CI, and merge blockers for a PR, then report what changed "
+            "and what needs a human decision."
+        ),
+        goal_text=(
+            "Run PR Watch L1 for this repository: watch review, CI, and merge "
+            "blockers for the target PR; report material changes, blockers, and "
+            "next human decisions; do not auto-merge."
+        ),
+        capability_path=(
+            "continuous monitor todo",
+            "quota monitor-poll",
+            "CI/review blocker summary",
+            "human merge gate",
+        ),
+        safety_defaults=(
+            "No auto-merge.",
+            "No code edits unless the owner upgrades the preset to an explicit L2 fix lane.",
+            "Quiet unchanged polls should not spend quota.",
+        ),
+        useful_when=(
+            "You want fewer manual PR refreshes while keeping merge authority human.",
+            "You need an automation-friendly monitor that still produces concrete blockers.",
+        ),
+    ),
+)
+
+PRESET_IDS = tuple(preset.preset_id for preset in BEGINNER_PRESETS)
+
+
+def _shell(value: str) -> str:
+    return shlex.quote(value)
+
+
+def _preset_commands(
+    preset: BeginnerPreset,
+    *,
+    cli_bin: str,
+    project: str,
+    goal_id: str,
+    agent_id: str,
+    agent_scope: str,
+) -> dict[str, str]:
+    return {
+        "slash_start": f"/loopx {preset.goal_text}",
+        "cli_start": (
+            f"{cli_bin} start-goal --guided --project {_shell(project)} "
+            f"--goal-text {_shell(preset.goal_text)}"
+        ),
+        "quota_guard": (
+            f"{cli_bin} --format json quota should-run "
+            f"--goal-id {_shell(goal_id)} --agent-id {_shell(agent_id)}"
+        ),
+        "heartbeat_prompt": (
+            f"{cli_bin} heartbeat-prompt --thin --goal-id {_shell(goal_id)} "
+            f"--agent-id {_shell(agent_id)} --agent-scope {_shell(agent_scope)}"
+        ),
+    }
+
+
+def _preset_to_dict(
+    preset: BeginnerPreset,
+    *,
+    cli_bin: str,
+    project: str,
+    goal_id: str,
+    agent_id: str,
+    agent_scope: str,
+) -> dict[str, Any]:
+    return {
+        "id": preset.preset_id,
+        "title": preset.title,
+        "maturity": preset.maturity,
+        "cadence": preset.cadence,
+        "default_mode": preset.default_mode,
+        "summary": preset.summary,
+        "goal_text": preset.goal_text,
+        "capability_path": list(preset.capability_path),
+        "safety_defaults": list(preset.safety_defaults),
+        "useful_when": list(preset.useful_when),
+        "commands": _preset_commands(
+            preset,
+            cli_bin=cli_bin,
+            project=project,
+            goal_id=goal_id,
+            agent_id=agent_id,
+            agent_scope=agent_scope,
+        ),
+    }
+
+
+def build_beginner_preset_packet(
+    *,
+    preset_id: str | None = None,
+    cli_bin: str = "loopx",
+    project: str = ".",
+    goal_id: str = "<goal-id>",
+    agent_id: str = "<agent-id>",
+    agent_scope: str = "<agent-scope>",
+) -> dict[str, Any]:
+    presets = BEGINNER_PRESETS
+    if preset_id:
+        presets = tuple(preset for preset in BEGINNER_PRESETS if preset.preset_id == preset_id)
+        if not presets:
+            raise ValueError(f"unknown beginner preset: {preset_id}")
+    return {
+        "ok": True,
+        "schema_version": PRESET_PICKER_SCHEMA_VERSION,
+        "summary": (
+            "Beginner LoopX presets compile common loop-engineering use cases into "
+            "existing LoopX start, quota, heartbeat, and evidence flows."
+        ),
+        "mutation_policy": "read_only; renders commands only; does not write registry, state, automation, PRs, or docs",
+        "recommended_order": list(PRESET_IDS),
+        "placeholders": {
+            "goal_id": goal_id,
+            "agent_id": agent_id,
+            "agent_scope": agent_scope,
+            "project": project,
+        },
+        "common_setup": [
+            f"{cli_bin} doctor",
+            f"{cli_bin} slash-commands --install",
+            f"{cli_bin} preset list",
+        ],
+        "presets": [
+            _preset_to_dict(
+                preset,
+                cli_bin=cli_bin,
+                project=project,
+                goal_id=goal_id,
+                agent_id=agent_id,
+                agent_scope=agent_scope,
+            )
+            for preset in presets
+        ],
+    }
+
+
+def render_beginner_preset_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# LoopX beginner preset picker",
+        "",
+        str(payload.get("summary") or ""),
+        "",
+        f"Mutation policy: {payload.get('mutation_policy')}",
+        "",
+        "Common setup:",
+    ]
+    for command in payload.get("common_setup", []):
+        lines.append(f"- `{command}`")
+    lines.append("")
+    presets = payload.get("presets") if isinstance(payload.get("presets"), list) else []
+    for preset in presets:
+        if not isinstance(preset, dict):
+            continue
+        lines.extend(
+            [
+                f"## {preset.get('title')}",
+                "",
+                f"- id: `{preset.get('id')}`",
+                f"- maturity: {preset.get('maturity')}",
+                f"- cadence: {preset.get('cadence')}",
+                f"- default mode: `{preset.get('default_mode')}`",
+                f"- summary: {preset.get('summary')}",
+                "",
+                "Useful when:",
+            ]
+        )
+        for item in preset.get("useful_when", []):
+            lines.append(f"- {item}")
+        lines.extend(["", "Safety defaults:"])
+        for item in preset.get("safety_defaults", []):
+            lines.append(f"- {item}")
+        lines.extend(["", "Commands:", ""])
+        commands = preset.get("commands") if isinstance(preset.get("commands"), dict) else {}
+        for label in ("slash_start", "cli_start", "quota_guard", "heartbeat_prompt"):
+            command = commands.get(label)
+            if command:
+                lines.extend([f"{label}:", "```bash", str(command), "```", ""])
+        lines.append(f"Show only this preset: `loopx preset show {preset.get('id')}`")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"


### PR DESCRIPTION
## Summary
- add `loopx preset list/show` as a read-only beginner preset picker for Daily Triage L1, Changelog Draft L1, and PR Watch L1
- render copyable `/loopx`, `start-goal`, `quota should-run`, and `heartbeat-prompt` packets with explicit L1 safety defaults
- document the thin entry point in the beginner preset mapping and cover it with a focused smoke

## Validation
- `python3 examples/beginner-preset-picker-smoke.py`
- `python3 examples/cli-help-manpage-smoke.py`
- `python3 -m py_compile loopx/presets.py loopx/cli_commands/preset.py`
- `git diff --check`
- `loopx check --scan-path docs/product/beginner-loop-presets.md --scan-path loopx/presets.py --scan-path loopx/cli_commands/preset.py --scan-path examples/beginner-preset-picker-smoke.py`
- `loopx canary premerge --from-git-diff` passed selected=12 failures=0

## Self-merge note
Small read-only CLI/docs/smoke PR; no runtime mutation, scheduler, quota accounting, merge, publish, benchmark scoring, or production authority changes.