### PR TITLE
Add read-only LoopX Ready score report

### DIFF
--- a/docs/product/beginner-loop-presets.md
+++ b/docs/product/beginner-loop-presets.md
@@ -34,6 +34,17 @@ These commands are read-only. They render `/loopx ...`, `start-goal`,
 `quota should-run`, and `heartbeat-prompt` command packets; they do not write
 registry state, install automations, edit docs, or create PRs.
 
+To check whether a project is ready for useful recurring loops, use the
+read-only score report:
+
+```bash
+loopx ready-score --goal-id <goal-id> --agent-id <agent-id>
+```
+
+The score aggregates existing `doctor`, `status`, `quota`, scheduler, todo, and
+evidence signals. It may render a badge preview, but it does not write README
+badges or change project state.
+
 ## Recommendation Matrix
 
 | Pattern | User value | LoopX default | Recommendation |

--- a/examples/cli-help-manpage-smoke.py
+++ b/examples/cli-help-manpage-smoke.py
@@ -27,6 +27,7 @@ def assert_concise_default_help(output: str) -> None:
     assert "Start here:" in output, output
     assert "/loopx <goal text>" in output, output
     assert "slash-commands --install" in output, output
+    assert "ready-score --goal-id ID" in output, output
     assert "start-goal --guided" in output, output
     assert "Run the loop:" in output, output
     assert "Codex App" in output, output
@@ -35,7 +36,7 @@ def assert_concise_default_help(output: str) -> None:
     assert "evidence-log --goal-id ID --agent-id AGENT --thin" in output, output
     assert "man loopx" in output, output
     assert LONG_TAIL_COMMAND not in output, output
-    assert len(output.splitlines()) <= 36, output
+    assert len(output.splitlines()) <= 38, output
 
 
 def assert_default_help_surface() -> None:
@@ -62,6 +63,7 @@ def assert_command_reference_surface() -> None:
     assert "Maintainer and adapter commands" in result.stdout, result.stdout
     assert "loopx <command> --help" in result.stdout, result.stdout
     assert "codex-cli-bootstrap-message" in result.stdout, result.stdout
+    assert "loopx ready-score --goal-id <goal-id>" in result.stdout, result.stdout
     assert result.stderr == "", result.stderr
 
 

--- a/examples/ready-score-smoke.py
+++ b/examples/ready-score-smoke.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.ready_score import build_ready_score_report, render_ready_score_markdown
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", *args],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+    )
+
+
+def fixture_payload() -> dict[str, object]:
+    doctor = {
+        "ok": True,
+        "skills": {
+            "loopx-project": {"exists": True, "required_phrases": True},
+            "loopx-self-repair": {"exists": True, "required_phrases": True},
+        },
+        "install_freshness": {
+            "status": "fresh",
+            "reason": "default release snapshot timestamp is within the freshness window",
+        },
+    }
+    status = {
+        "ok": True,
+        "goal_filter": "demo-goal",
+        "goal_count": 1,
+        "run_count": 12,
+        "contract": {"ok": True, "summary": {"errors": 0, "warnings": 0, "checks": 8}},
+        "contract_summary": {"errors": 0, "warnings": 0, "checks": 8},
+        "attention_queue": {
+            "items": [
+                {
+                    "goal_id": "demo-goal",
+                    "active_state_next_action": "continue the next bounded validated segment",
+                    "agent_todos": {
+                        "open_count": 2,
+                        "first_executable_items": [{"todo_id": "todo_demo", "claimed_by": "codex-demo"}],
+                    },
+                    "user_todos": {"open_count": 0},
+                }
+            ]
+        },
+        "usage_summary": {"totals": {"progress_signal_run_count_24h": 4}},
+        "event_ledger_summary": {"totals": {"events_24h": 5}},
+        "promotion_readiness_summary": {"is_fresh": True},
+        "global_registry": {"ok": True, "summary": {"high": 0, "action": 0}},
+    }
+    quota = {
+        "should_run": True,
+        "effective_action": "normal_run",
+        "normal_delivery_allowed": True,
+        "recommended_action": "continue demo todo",
+        "quota": {"state": "eligible"},
+        "scheduler_hint": {"codex_app": {"stateful_backoff": {"apply_needed": False}}},
+    }
+    return build_ready_score_report(
+        doctor_payload=doctor,
+        status_payload=status,
+        quota_payload=quota,
+        goal_id="demo-goal",
+        agent_id="codex-demo",
+    )
+
+
+def assert_fixture_score() -> None:
+    payload = fixture_payload()
+    assert payload["schema_version"] == "loopx_ready_score_report_v0", payload
+    assert payload["score"] == 100, payload
+    assert payload["grade"] == "ready", payload
+    assert payload["mutation_policy"].startswith("read_only"), payload
+    assert payload["badge"]["writeback_policy"].startswith("preview_only"), payload
+    markdown = render_ready_score_markdown(payload)
+    assert "LoopX Ready score" in markdown, markdown
+    assert "100/100" in markdown, markdown
+    assert "does not edit README" in markdown, markdown
+
+
+def assert_warn_score() -> None:
+    payload = fixture_payload()
+    checks = payload["checks"]
+    assert all(check["status"] == "pass" for check in checks), checks
+    doctor = {"ok": False, "skills": {}, "install_freshness": {"status": "missing"}}
+    status = {
+        "ok": True,
+        "attention_queue": {"items": [{"goal_id": "demo-goal", "user_todos": {"open_count": 1}}]},
+        "contract": {"ok": True, "summary": {"errors": 0}},
+        "global_registry": {"ok": True, "summary": {"high": 0, "action": 3}},
+    }
+    report = build_ready_score_report(
+        doctor_payload=doctor,
+        status_payload=status,
+        quota_payload={"should_run": False, "quota": {"state": "waiting"}},
+        goal_id="demo-goal",
+        agent_id="codex-demo",
+    )
+    assert report["score"] < 60, report
+    assert report["grade"] in {"needs_setup", "not_ready"}, report
+    assert report["recommendations"], report
+
+
+def assert_cli_surfaces() -> None:
+    help_result = run_cli("ready-score", "--help")
+    assert help_result.returncode == 0, (help_result.returncode, help_result.stdout, help_result.stderr)
+    assert "doctor/status/quota" in help_result.stdout, help_result.stdout
+
+    commands = run_cli("commands", "--format", "json")
+    assert commands.returncode == 0, (commands.returncode, commands.stdout, commands.stderr)
+    payload = json.loads(commands.stdout)
+    rendered = json.dumps(payload)
+    assert "ready-score" in rendered, rendered
+    assert "without writing badges" in rendered, rendered
+
+
+def main() -> int:
+    assert_fixture_score()
+    assert_warn_score()
+    assert_cli_surfaces()
+    print("ready-score-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -41,6 +41,7 @@ from .cli_commands import (
     handle_project_lifecycle_command,
     handle_pr_review_command,
     handle_quota_command,
+    handle_ready_score_command,
     handle_registry_admin_command,
     handle_review_packet_command,
     handle_slash_commands_command,
@@ -67,6 +68,7 @@ from .cli_commands import (
     register_project_lifecycle_commands,
     register_pr_review_command,
     register_quota_command,
+    register_ready_score_command,
     register_registry_admin_commands,
     register_slash_commands_command,
     register_starter_commands,
@@ -169,6 +171,7 @@ def main(argv: list[str] | None = None) -> int:
 
     register_multi_agent_commands(sub, add_subcommand_format)
     register_preset_commands(sub, add_subcommand_format)
+    register_ready_score_command(sub, add_subcommand_format)
 
     register_registry_admin_commands(sub)
 
@@ -322,6 +325,16 @@ def main(argv: list[str] | None = None) -> int:
     )
     if preset_result is not None:
         return preset_result
+
+    ready_score_result = handle_ready_score_command(
+        args,
+        registry_path=registry_path,
+        runtime_root_arg=args.runtime_root,
+        output_format=output_format,
+        print_payload=print_payload,
+    )
+    if ready_score_result is not None:
+        return ready_score_result
 
     if args.command == "content-ops":
         return handle_content_ops_command(args, output_format=output_format, print_payload=print_payload)

--- a/loopx/cli_commands/__init__.py
+++ b/loopx/cli_commands/__init__.py
@@ -92,6 +92,7 @@ from .project_lifecycle import (
 from .preset import handle_preset_command, register_preset_commands
 from .pr_review import handle_pr_review_command, register_pr_review_command
 from .quota import handle_quota_command, register_quota_command
+from .ready_score import handle_ready_score_command, register_ready_score_command
 from .registry_admin import (
     handle_registry_admin_command,
     register_registry_admin_commands,
@@ -217,6 +218,7 @@ __all__ = [
     "handle_project_lifecycle_command",
     "handle_pr_review_command",
     "handle_quota_command",
+    "handle_ready_score_command",
     "handle_registry_admin_command",
     "handle_review_packet_command",
     "handle_slash_commands_command",
@@ -265,6 +267,7 @@ __all__ = [
     "register_pr_review_command",
     "register_preset_commands",
     "register_quota_command",
+    "register_ready_score_command",
     "register_registry_admin_commands",
     "register_slash_commands_command",
     "register_starter_commands",

--- a/loopx/cli_commands/ready_score.py
+++ b/loopx/cli_commands/ready_score.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import argparse
+from collections.abc import Callable
+from pathlib import Path
+
+from ..doctor import collect_doctor
+from ..quota import build_quota_should_run
+from ..ready_score import (
+    build_ready_score_report,
+    render_ready_score_markdown,
+    select_ready_score_goal_id,
+)
+from ..status import collect_status
+
+
+PrintPayload = Callable[
+    [dict[str, object], str, Callable[[dict[str, object]], str]],
+    None,
+]
+FormatSelector = Callable[..., str]
+AddFormat = Callable[[argparse.ArgumentParser], None]
+
+
+def default_public_scan_root() -> str:
+    return str(Path(__file__).resolve().parents[2])
+
+
+def _scan_roots(args: argparse.Namespace) -> list[Path]:
+    scan_roots = [Path(item).expanduser() for item in args.scan_path]
+    return scan_roots or [Path(args.scan_root).expanduser()]
+
+
+def register_ready_score_command(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: AddFormat,
+) -> None:
+    parser = subparsers.add_parser(
+        "ready-score",
+        help="Render a read-only LoopX readiness score from doctor/status/quota signals.",
+        description=(
+            "Render a read-only LoopX readiness score from doctor/status/quota "
+            "signals without writing state, README files, or badges."
+        ),
+    )
+    add_subcommand_format(parser)
+    parser.add_argument("--goal-id", help="Goal id to score. Defaults to the first attention item.")
+    parser.add_argument(
+        "--agent-id",
+        help="Registered agent id for identity-scoped quota and scheduler readiness.",
+    )
+    parser.add_argument(
+        "--scan-root",
+        default=default_public_scan_root(),
+        help="Public files to scan through the status contract. Defaults to the LoopX install root.",
+    )
+    parser.add_argument(
+        "--scan-path",
+        action="append",
+        default=[],
+        help="Specific public file or directory to scan through the status contract. Repeatable.",
+    )
+    parser.add_argument("--limit", type=int, default=5)
+
+
+def handle_ready_score_command(
+    args: argparse.Namespace,
+    *,
+    registry_path: Path,
+    runtime_root_arg: str | None,
+    output_format: FormatSelector,
+    print_payload: PrintPayload,
+) -> int | None:
+    if args.command != "ready-score":
+        return None
+    doctor_payload = collect_doctor()
+    status_payload = collect_status(
+        registry_path=registry_path,
+        runtime_root_override=runtime_root_arg,
+        scan_roots=_scan_roots(args),
+        limit=max(0, args.limit),
+        goal_id=args.goal_id,
+    )
+    selected_goal_id = select_ready_score_goal_id(status_payload, args.goal_id)
+    quota_payload = None
+    if selected_goal_id:
+        quota_payload = build_quota_should_run(
+            status_payload,
+            goal_id=selected_goal_id,
+            agent_id=args.agent_id,
+        )
+    payload = build_ready_score_report(
+        doctor_payload=doctor_payload,
+        status_payload=status_payload,
+        quota_payload=quota_payload,
+        goal_id=selected_goal_id,
+        agent_id=args.agent_id,
+    )
+    print_payload(payload, output_format(args), render_ready_score_markdown)
+    return 0 if payload.get("ok") else 1

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -33,6 +33,10 @@ COMMAND_GROUPS: list[dict[str, object]] = [
                 "purpose": "Show beginner-safe Daily Triage, Changelog Draft, and PR Watch start packets.",
             },
             {
+                "command": "loopx ready-score --goal-id <goal-id>",
+                "purpose": "Score install, status, quota, scheduler, todo, and evidence readiness without writing badges.",
+            },
+            {
                 "command": 'loopx start-goal --guided --project . --goal-text "<goal>"',
                 "purpose": "Preview the shell fallback for the same agent-safe `/loopx <goal>` path.",
             },
@@ -181,6 +185,7 @@ def render_concise_help(program: str = "loopx") -> str:
             "  loopx doctor                   Check install, PATH, release snapshot, and skills.",
             "  loopx slash-commands --install Refresh host slash-command skill files.",
             "  loopx preset list              Show beginner-safe loop start packets.",
+            "  loopx ready-score --goal-id ID Score install/status/quota readiness.",
             "  loopx start-goal --guided --project . --goal-text \"<goal>\"",
             "                                  Preview the shell fallback for /loopx <goal>.",
             "",

--- a/loopx/ready_score.py
+++ b/loopx/ready_score.py
@@ -1,0 +1,393 @@
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import quote
+
+
+READY_SCORE_SCHEMA_VERSION = "loopx_ready_score_report_v0"
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _first_attention_item(status_payload: dict[str, Any], *, goal_id: str | None) -> dict[str, Any]:
+    queue = _as_dict(status_payload.get("attention_queue"))
+    for item in _as_list(queue.get("items")):
+        if not isinstance(item, dict):
+            continue
+        if goal_id is None or str(item.get("goal_id") or "") == goal_id:
+            return item
+    return {}
+
+
+def select_ready_score_goal_id(status_payload: dict[str, Any], requested_goal_id: str | None = None) -> str | None:
+    if requested_goal_id:
+        return requested_goal_id
+    item = _first_attention_item(status_payload, goal_id=None)
+    if item.get("goal_id"):
+        return str(item.get("goal_id"))
+    goal_filter = status_payload.get("goal_filter")
+    return str(goal_filter) if goal_filter else None
+
+
+def _todo_summary(item: dict[str, Any], key: str) -> dict[str, Any]:
+    direct = _as_dict(item.get(key))
+    project_asset = _as_dict(item.get("project_asset"))
+    asset = _as_dict(project_asset.get(key))
+    return direct or asset
+
+
+def _first_executable_count(summary: dict[str, Any]) -> int:
+    return len(_as_list(summary.get("first_executable_items")))
+
+
+def _quota_scheduler_apply_needed(quota_payload: dict[str, Any]) -> bool | None:
+    scheduler = _as_dict(quota_payload.get("scheduler_hint"))
+    codex_app = _as_dict(scheduler.get("codex_app"))
+    stateful = _as_dict(codex_app.get("stateful_backoff"))
+    value = stateful.get("apply_needed")
+    return value if isinstance(value, bool) else None
+
+
+def _check(
+    checks: list[dict[str, Any]],
+    *,
+    check_id: str,
+    label: str,
+    points: int,
+    max_points: int,
+    status: str,
+    detail: str,
+    action: str | None = None,
+) -> None:
+    checks.append(
+        {
+            "id": check_id,
+            "label": label,
+            "status": status,
+            "points": max(0, min(points, max_points)),
+            "max_points": max_points,
+            "detail": detail,
+            "action": action,
+        }
+    )
+
+
+def _grade(score: int) -> tuple[str, str, str]:
+    if score >= 90:
+        return "ready", "green", "Ready for autonomous LoopX use"
+    if score >= 75:
+        return "mostly_ready", "yellowgreen", "Mostly ready; review the warnings"
+    if score >= 60:
+        return "partially_ready", "yellow", "Partially ready; fix the main gaps first"
+    if score >= 40:
+        return "needs_setup", "orange", "Needs setup before recurring automation"
+    return "not_ready", "red", "Not ready for autonomous LoopX use"
+
+
+def _badge(score: int, grade: str, color: str) -> dict[str, Any]:
+    message = f"{grade}-{score}"
+    url = f"https://img.shields.io/badge/{quote('LoopX ready')}-{quote(message)}-{quote(color)}"
+    return {
+        "label": "LoopX ready",
+        "message": message,
+        "color": color,
+        "preview_url": url,
+        "markdown": f"![LoopX ready]({url})",
+        "writeback_policy": "preview_only; do not write README or badges from this command",
+    }
+
+
+def build_ready_score_report(
+    *,
+    doctor_payload: dict[str, Any],
+    status_payload: dict[str, Any],
+    quota_payload: dict[str, Any] | None = None,
+    goal_id: str | None = None,
+    agent_id: str | None = None,
+) -> dict[str, Any]:
+    selected_goal_id = select_ready_score_goal_id(status_payload, goal_id)
+    item = _first_attention_item(status_payload, goal_id=selected_goal_id)
+    quota = _as_dict(quota_payload)
+    agent_todos = _todo_summary(item, "agent_todos")
+    user_todos = _todo_summary(item, "user_todos")
+    checks: list[dict[str, Any]] = []
+
+    doctor_ok = bool(doctor_payload.get("ok"))
+    _check(
+        checks,
+        check_id="install_core",
+        label="CLI install and import health",
+        points=12 if doctor_ok else 0,
+        max_points=12,
+        status="pass" if doctor_ok else "fail",
+        detail="doctor required checks pass" if doctor_ok else "doctor required checks failed",
+        action=None if doctor_ok else "run loopx doctor and repair PATH/install/global registry write access",
+    )
+
+    skills = _as_dict(doctor_payload.get("skills"))
+    skill_values = [value for value in skills.values() if isinstance(value, dict)]
+    skill_exists = bool(skill_values) and all(bool(value.get("exists")) for value in skill_values)
+    skill_routes = bool(skill_values) and all(bool(value.get("required_phrases")) for value in skill_values)
+    if skill_exists and skill_routes:
+        skill_points, skill_status, skill_detail = 8, "pass", "installed LoopX skills and route phrases are current"
+    elif skill_exists:
+        skill_points, skill_status, skill_detail = 4, "warn", "skills exist but at least one route phrase is stale"
+    else:
+        skill_points, skill_status, skill_detail = 0, "fail", "one or more LoopX skills are missing"
+    _check(
+        checks,
+        check_id="install_skills",
+        label="Installed agent skills",
+        points=skill_points,
+        max_points=8,
+        status=skill_status,
+        detail=skill_detail,
+        action=None if skill_status == "pass" else "refresh installed LoopX skills with loopx slash-commands --install",
+    )
+
+    freshness = _as_dict(doctor_payload.get("install_freshness"))
+    freshness_status = str(freshness.get("status") or "unknown")
+    if freshness_status in {"fresh", "live_checkout"}:
+        freshness_points, freshness_state = 8, "pass"
+    elif freshness_status == "unknown":
+        freshness_points, freshness_state = 5, "warn"
+    elif freshness_status in {"stale", "repair_recommended"}:
+        freshness_points, freshness_state = 3, "warn"
+    else:
+        freshness_points, freshness_state = 0, "fail"
+    _check(
+        checks,
+        check_id="release_freshness",
+        label="Default release freshness",
+        points=freshness_points,
+        max_points=8,
+        status=freshness_state,
+        detail=str(freshness.get("reason") or freshness_status),
+        action=None if freshness_state == "pass" else "upgrade or reinstall LoopX before relying on unattended runs",
+    )
+
+    contract = _as_dict(status_payload.get("contract"))
+    contract_summary = _as_dict(status_payload.get("contract_summary") or contract.get("summary"))
+    contract_ok = bool(status_payload.get("ok")) and bool(contract.get("ok", True))
+    contract_errors = _int(contract_summary.get("errors"))
+    _check(
+        checks,
+        check_id="status_contract",
+        label="Status and contract projection",
+        points=12 if contract_ok and contract_errors == 0 else 4 if status_payload.get("ok") else 0,
+        max_points=12,
+        status="pass" if contract_ok and contract_errors == 0 else "warn" if status_payload.get("ok") else "fail",
+        detail=f"status ok={bool(status_payload.get('ok'))}, contract_errors={contract_errors}",
+        action=None if contract_ok and contract_errors == 0 else "run loopx check and repair status/contract projection errors",
+    )
+
+    has_goal = bool(selected_goal_id and item)
+    has_action = bool(item.get("active_state_next_action") or item.get("recommended_action"))
+    _check(
+        checks,
+        check_id="goal_connection",
+        label="Connected goal and next action",
+        points=12 if has_goal and has_action else 6 if has_goal else 0,
+        max_points=12,
+        status="pass" if has_goal and has_action else "warn" if has_goal else "fail",
+        detail=(
+            f"goal_id={selected_goal_id}, next_action_projected={has_action}"
+            if selected_goal_id
+            else "no goal selected"
+        ),
+        action=None if has_goal and has_action else "connect a goal or refresh state so status projects a concrete next action",
+    )
+
+    agent_open = _int(agent_todos.get("open_count"))
+    executable_open = _first_executable_count(agent_todos)
+    user_open = _int(user_todos.get("open_count"))
+    runway_points = 0
+    if executable_open > 0:
+        runway_points += 8
+    elif agent_open > 0:
+        runway_points += 4
+    if user_open == 0:
+        runway_points += 4
+    todo_status = "pass" if runway_points >= 12 else "warn" if runway_points > 0 else "fail"
+    _check(
+        checks,
+        check_id="todo_runway",
+        label="Agent todo runway and user gates",
+        points=runway_points,
+        max_points=12,
+        status=todo_status,
+        detail=f"agent_open={agent_open}, executable_open={executable_open}, user_open={user_open}",
+        action=None if todo_status == "pass" else "add/claim an executable agent todo or resolve open user gates",
+    )
+
+    quota_state = str(_as_dict(quota.get("quota")).get("state") or quota.get("state") or "unknown")
+    should_run = bool(quota.get("should_run"))
+    effective_action = str(quota.get("effective_action") or quota.get("decision") or "")
+    normal_allowed = bool(quota.get("normal_delivery_allowed"))
+    scheduler_apply_needed = _quota_scheduler_apply_needed(quota)
+    quota_points = 0
+    if should_run and quota_state == "eligible":
+        quota_points += 8
+    elif should_run:
+        quota_points += 5
+    if normal_allowed or effective_action == "normal_run":
+        quota_points += 5
+    if scheduler_apply_needed is False:
+        quota_points += 4
+    elif scheduler_apply_needed is None:
+        quota_points += 2
+    if quota.get("recommended_action") or _as_dict(quota.get("interaction_contract")).get("primary_action"):
+        quota_points += 3
+    quota_status = "pass" if quota_points >= 18 else "warn" if quota_points > 0 else "fail"
+    _check(
+        checks,
+        check_id="quota_scheduler",
+        label="Quota, identity, and scheduler readiness",
+        points=quota_points,
+        max_points=20,
+        status=quota_status,
+        detail=(
+            f"should_run={should_run}, quota_state={quota_state}, "
+            f"effective_action={effective_action or 'unknown'}, scheduler_apply_needed={scheduler_apply_needed}"
+        ),
+        action=None if quota_status == "pass" else "rerun quota should-run with the registered agent id and apply scheduler ack if requested",
+    )
+
+    run_count = _int(status_payload.get("run_count"))
+    usage = _as_dict(status_payload.get("usage_summary"))
+    usage_totals = _as_dict(usage.get("totals"))
+    event = _as_dict(status_payload.get("event_ledger_summary"))
+    event_totals = _as_dict(event.get("totals"))
+    promotion = _as_dict(status_payload.get("promotion_readiness_summary"))
+    evidence_points = 0
+    if run_count > 0:
+        evidence_points += 3
+    if _int(usage_totals.get("progress_signal_run_count_24h")) > 0:
+        evidence_points += 3
+    if _int(event_totals.get("events_24h")) > 0:
+        evidence_points += 2
+    if promotion.get("is_fresh") is True:
+        evidence_points += 2
+    _check(
+        checks,
+        check_id="evidence_history",
+        label="Evidence and progress history",
+        points=evidence_points,
+        max_points=10,
+        status="pass" if evidence_points >= 8 else "warn" if evidence_points > 0 else "fail",
+        detail=(
+            f"runs={run_count}, progress_24h={_int(usage_totals.get('progress_signal_run_count_24h'))}, "
+            f"events_24h={_int(event_totals.get('events_24h'))}, promotion_fresh={promotion.get('is_fresh')}"
+        ),
+        action=None if evidence_points >= 8 else "run one validated LoopX state refresh or smoke so readiness is grounded in fresh evidence",
+    )
+
+    global_registry = _as_dict(status_payload.get("global_registry"))
+    global_summary = _as_dict(global_registry.get("summary"))
+    high_findings = _int(global_summary.get("high"))
+    action_findings = _int(global_summary.get("action"))
+    global_points = 0
+    if global_registry.get("ok") and high_findings == 0:
+        global_points += 4
+    if action_findings == 0:
+        global_points += 2
+    elif action_findings <= 5:
+        global_points += 1
+    _check(
+        checks,
+        check_id="registry_hygiene",
+        label="Global registry hygiene",
+        points=global_points,
+        max_points=6,
+        status="pass" if global_points >= 6 else "warn" if global_points > 0 else "fail",
+        detail=f"global_ok={bool(global_registry.get('ok'))}, high={high_findings}, action={action_findings}",
+        action=None if global_points >= 6 else "archive or reconnect obsolete global registry entries when convenient",
+    )
+
+    score = int(round(sum(check["points"] for check in checks) * 100 / sum(check["max_points"] for check in checks)))
+    grade, badge_color, grade_summary = _grade(score)
+    recommendations = [
+        {
+            "id": check["id"],
+            "status": check["status"],
+            "action": check["action"],
+        }
+        for check in checks
+        if check.get("status") != "pass" and check.get("action")
+    ]
+    return {
+        "ok": True,
+        "schema_version": READY_SCORE_SCHEMA_VERSION,
+        "score": score,
+        "grade": grade,
+        "summary": grade_summary,
+        "mutation_policy": "read_only; computes a report only; does not write registry, state, automation, README, or badges",
+        "goal_id": selected_goal_id,
+        "agent_id": agent_id,
+        "checks": checks,
+        "recommendations": recommendations,
+        "badge": _badge(score, grade, badge_color),
+        "source_signals": {
+            "doctor": bool(doctor_payload),
+            "status": bool(status_payload),
+            "quota": bool(quota_payload),
+        },
+    }
+
+
+def render_ready_score_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# LoopX Ready score",
+        "",
+        f"- score: `{payload.get('score')}/100`",
+        f"- grade: `{payload.get('grade')}`",
+        f"- summary: {payload.get('summary')}",
+        f"- goal_id: `{payload.get('goal_id')}`",
+        f"- agent_id: `{payload.get('agent_id')}`",
+        f"- mutation_policy: {payload.get('mutation_policy')}",
+        "",
+        "## Badge Preview",
+        "",
+        str(_as_dict(payload.get("badge")).get("markdown") or ""),
+        "",
+        "This is a preview only. The command does not edit README files or publish a badge.",
+        "",
+        "## Checks",
+        "",
+        "| Check | Status | Points | Detail |",
+        "| --- | --- | ---: | --- |",
+    ]
+    for check in _as_list(payload.get("checks")):
+        if not isinstance(check, dict):
+            continue
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    str(check.get("label") or check.get("id") or ""),
+                    f"`{check.get('status')}`",
+                    f"{check.get('points')}/{check.get('max_points')}",
+                    str(check.get("detail") or "").replace("|", "\\|"),
+                ]
+            )
+            + " |"
+        )
+    recommendations = [item for item in _as_list(payload.get("recommendations")) if isinstance(item, dict)]
+    if recommendations:
+        lines.extend(["", "## Recommended Fixes", ""])
+        for item in recommendations:
+            lines.append(f"- `{item.get('id')}`: {item.get('action')}")
+    return "\n".join(lines).rstrip() + "\n"


### PR DESCRIPTION
## Summary
- add `loopx ready-score` as a read-only readiness report over existing doctor/status/quota/scheduler/todo/evidence signals
- render a preview-only badge payload without writing README files, badges, registry state, or automation state
- surface the command in beginner presets and concise CLI help

## Validation
- `python3 examples/ready-score-smoke.py`
- `python3 examples/cli-help-manpage-smoke.py`
- `python3 -m py_compile loopx/ready_score.py loopx/cli_commands/ready_score.py examples/ready-score-smoke.py`
- `python3 -m loopx.cli --format json ready-score --goal-id loopx-meta --agent-id codex-side-bypass --scan-path docs/product/beginner-loop-presets.md --limit 2` -> score 98/100, grade ready, preview-only badge policy
- `loopx check --scan-path docs/product/beginner-loop-presets.md --scan-path loopx/ready_score.py --scan-path loopx/cli_commands/ready_score.py --scan-path examples/ready-score-smoke.py --scan-path loopx/help_surface.py`
- `loopx canary premerge --from-git-diff`

## Self-merge note
Small single-purpose CLI/docs/smoke batch. The command is read-only and the canary reported `self_merge_allowed=true` with no manual holds.