### PR TITLE
Add opt-in CI and dependency sweeper presets

### DIFF
--- a/docs/product/beginner-loop-presets.md
+++ b/docs/product/beginner-loop-presets.md
@@ -28,6 +28,8 @@ For one preset card:
 loopx preset show daily-triage
 loopx preset show changelog-draft
 loopx preset show pr-watch
+loopx preset show ci-sweeper
+loopx preset show dependency-sweeper
 ```
 
 These commands are read-only. They render `/loopx ...`, `start-goal`,
@@ -90,6 +92,10 @@ guardrails are explicit." The required guardrails are:
 - token/cadence cap;
 - human review before push, merge, publish, or dependency rollout;
 - escalation after repeated failure or unchanged error signatures.
+
+The picker exposes both as `advanced_opt_in` cards. Their default output is a
+dry-run or policy report first; a patch lane starts only after explicit owner
+opt-in and stays inside an isolated `codex/` worktree.
 
 ### Tier 3: Later expansion
 

--- a/examples/beginner-preset-picker-smoke.py
+++ b/examples/beginner-preset-picker-smoke.py
@@ -27,6 +27,9 @@ def assert_markdown_list() -> None:
     assert "Daily Triage L1" in result.stdout, result.stdout
     assert "Changelog Draft L1" in result.stdout, result.stdout
     assert "PR Watch L1" in result.stdout, result.stdout
+    assert "CI Sweeper L2" in result.stdout, result.stdout
+    assert "Dependency Sweeper L2" in result.stdout, result.stdout
+    assert "advanced_opt_in" in result.stdout, result.stdout
     assert "/loopx Run Daily Triage L1" in result.stdout, result.stdout
     assert "loopx start-goal --guided --project" in result.stdout, result.stdout
     assert "quota should-run" in result.stdout, result.stdout
@@ -53,11 +56,20 @@ def assert_json_show_with_placeholders() -> None:
     payload = json.loads(result.stdout)
     assert payload["schema_version"] == "loopx_beginner_preset_picker_v0", payload
     assert payload["mutation_policy"].startswith("read_only"), payload
-    assert payload["recommended_order"] == ["daily-triage", "changelog-draft", "pr-watch"], payload
+    assert payload["recommended_order"] == [
+        "daily-triage",
+        "changelog-draft",
+        "pr-watch",
+        "ci-sweeper",
+        "dependency-sweeper",
+    ], payload
+    assert payload["default_preset_ids"] == ["daily-triage", "changelog-draft", "pr-watch"], payload
+    assert payload["advanced_preset_ids"] == ["ci-sweeper", "dependency-sweeper"], payload
     presets = payload["presets"]
     assert len(presets) == 1, payload
     preset = presets[0]
     assert preset["id"] == "daily-triage", preset
+    assert preset["tier"] == "beginner_default", preset
     assert preset["maturity"] == "L1 report-only", preset
     commands = preset["commands"]
     assert "--goal-id demo-goal --agent-id codex-demo" in commands["quota_guard"], commands
@@ -75,18 +87,45 @@ def assert_pr_watch_is_watch_only() -> None:
     assert "Quiet unchanged polls should not spend quota." in result.stdout, result.stdout
 
 
+def assert_ci_sweeper_is_opt_in() -> None:
+    result = run_cli("preset", "show", "ci-sweeper")
+    assert result.returncode == 0, (result.returncode, result.stdout, result.stderr)
+    assert result.stderr == "", result.stderr
+    assert "CI Sweeper L2" in result.stdout, result.stdout
+    assert "L2 opt-in patch lane" in result.stdout, result.stdout
+    assert "dry_run_report_first" in result.stdout, result.stdout
+    assert "Dry-run report first; no patch until owner opt-in." in result.stdout, result.stdout
+    assert "isolated codex/ worktree" in result.stdout, result.stdout
+    assert "Human review before push, merge" in result.stdout, result.stdout
+    assert "Escalate after repeated failures" in result.stdout, result.stdout
+
+
+def assert_dependency_sweeper_policy_gates() -> None:
+    result = run_cli("preset", "show", "dependency-sweeper")
+    assert result.returncode == 0, (result.returncode, result.stdout, result.stderr)
+    assert result.stderr == "", result.stderr
+    assert "Dependency Sweeper L2" in result.stdout, result.stdout
+    assert "policy_report_first" in result.stdout, result.stdout
+    assert "patch/minor policy and denylist" in result.stdout, result.stdout
+    assert "Policy report first; no dependency edit until owner opt-in." in result.stdout, result.stdout
+    assert "deny major, runtime, lockfile-wide" in result.stdout, result.stdout
+    assert "Human review before push, merge, publish, rollout" in result.stdout, result.stdout
+
+
 def assert_command_reference_mentions_presets() -> None:
     result = run_cli("commands")
     assert result.returncode == 0, (result.returncode, result.stdout, result.stderr)
     assert result.stderr == "", result.stderr
     assert "loopx preset list" in result.stdout, result.stdout
-    assert "Daily Triage, Changelog Draft, and PR Watch" in result.stdout, result.stdout
+    assert "beginner-safe and opt-in advanced" in result.stdout, result.stdout
 
 
 def main() -> int:
     assert_markdown_list()
     assert_json_show_with_placeholders()
     assert_pr_watch_is_watch_only()
+    assert_ci_sweeper_is_opt_in()
+    assert_dependency_sweeper_policy_gates()
     assert_command_reference_mentions_presets()
     print("beginner-preset-picker-smoke ok")
     return 0

--- a/loopx/help_surface.py
+++ b/loopx/help_surface.py
@@ -30,7 +30,7 @@ COMMAND_GROUPS: list[dict[str, object]] = [
             },
             {
                 "command": "loopx preset list",
-                "purpose": "Show beginner-safe Daily Triage, Changelog Draft, and PR Watch start packets.",
+                "purpose": "Show beginner-safe and opt-in advanced loop start packets.",
             },
             {
                 "command": "loopx ready-score --goal-id <goal-id>",
@@ -184,7 +184,7 @@ def render_concise_help(program: str = "loopx") -> str:
             "  /loopx <goal text>             Start or continue a concrete long-running goal.",
             "  loopx doctor                   Check install, PATH, release snapshot, and skills.",
             "  loopx slash-commands --install Refresh host slash-command skill files.",
-            "  loopx preset list              Show beginner-safe loop start packets.",
+            "  loopx preset list              Show safe preset start packets.",
             "  loopx ready-score --goal-id ID Score install/status/quota readiness.",
             "  loopx start-goal --guided --project . --goal-text \"<goal>\"",
             "                                  Preview the shell fallback for /loopx <goal>.",

--- a/loopx/presets.py
+++ b/loopx/presets.py
@@ -12,6 +12,7 @@ PRESET_PICKER_SCHEMA_VERSION = "loopx_beginner_preset_picker_v0"
 class BeginnerPreset:
     preset_id: str
     title: str
+    tier: str
     maturity: str
     cadence: str
     default_mode: str
@@ -26,6 +27,7 @@ BEGINNER_PRESETS: tuple[BeginnerPreset, ...] = (
     BeginnerPreset(
         preset_id="daily-triage",
         title="Daily Triage L1",
+        tier="beginner_default",
         maturity="L1 report-only",
         cadence="daily or weekday morning",
         default_mode="report_only",
@@ -57,6 +59,7 @@ BEGINNER_PRESETS: tuple[BeginnerPreset, ...] = (
     BeginnerPreset(
         preset_id="changelog-draft",
         title="Changelog Draft L1",
+        tier="beginner_default",
         maturity="L1 draft-only",
         cadence="per release, or daily during release week",
         default_mode="draft_only",
@@ -88,6 +91,7 @@ BEGINNER_PRESETS: tuple[BeginnerPreset, ...] = (
     BeginnerPreset(
         preset_id="pr-watch",
         title="PR Watch L1",
+        tier="beginner_default",
         maturity="L1 watch-only",
         cadence="every 10-30 minutes while the PR is active",
         default_mode="watch_only",
@@ -116,9 +120,89 @@ BEGINNER_PRESETS: tuple[BeginnerPreset, ...] = (
             "You need an automation-friendly monitor that still produces concrete blockers.",
         ),
     ),
+    BeginnerPreset(
+        preset_id="ci-sweeper",
+        title="CI Sweeper L2",
+        tier="advanced_opt_in",
+        maturity="L2 opt-in patch lane",
+        cadence="on failing checks, or every 30-60 minutes while a PR is active",
+        default_mode="dry_run_report_first",
+        summary=(
+            "Classify failing checks, propose the smallest bounded fix, and only draft "
+            "a worktree patch after explicit owner opt-in."
+        ),
+        goal_text=(
+            "Run CI Sweeper L2 for this repository: inspect failing checks and recent "
+            "CI context, classify the likely fix, then produce a dry-run report first. "
+            "Only after explicit owner opt-in, draft a bounded patch in an isolated "
+            "codex/ worktree, run focused verification, and stop for human review before "
+            "push, merge, rerun-cost expansion, or external writes."
+        ),
+        capability_path=(
+            "failing-check intake",
+            "bounded codex/ worktree patch",
+            "focused verifier or smoke",
+            "human review gate",
+        ),
+        safety_defaults=(
+            "Dry-run report first; no patch until owner opt-in.",
+            "Patch only in an isolated codex/ worktree with a narrow allowed scope.",
+            "Verifier or focused smoke must pass before marking a patch ready.",
+            "Human review before push, merge, rerun-cost expansion, or external writes.",
+            "Escalate after repeated failures or unchanged error signatures.",
+        ),
+        useful_when=(
+            "A PR or main branch has boring, well-scoped check failures.",
+            "You want LoopX to reduce maintainer toil without granting merge authority.",
+        ),
+    ),
+    BeginnerPreset(
+        preset_id="dependency-sweeper",
+        title="Dependency Sweeper L2",
+        tier="advanced_opt_in",
+        maturity="L2 opt-in dependency lane",
+        cadence="weekly, per security notice, or during release hardening",
+        default_mode="policy_report_first",
+        summary=(
+            "Review dependency update candidates against a patch/minor policy, denylist, "
+            "and verifier plan before drafting any update patch."
+        ),
+        goal_text=(
+            "Run Dependency Sweeper L2 for this repository: inspect dependency update "
+            "candidates, apply a patch/minor policy and denylist, then produce a policy "
+            "report first. Only after explicit owner opt-in, draft a bounded dependency "
+            "patch in an isolated codex/ worktree, run focused verification, and stop "
+            "for human review before push, merge, publish, or rollout."
+        ),
+        capability_path=(
+            "dependency candidate intake",
+            "patch/minor policy and denylist",
+            "bounded codex/ worktree patch",
+            "focused verifier or smoke",
+            "human review gate",
+        ),
+        safety_defaults=(
+            "Policy report first; no dependency edit until owner opt-in.",
+            "Default to patch and minor updates; deny major, runtime, lockfile-wide, "
+            "and toolchain jumps unless explicitly allowed.",
+            "Verifier or focused smoke must pass before marking an update ready.",
+            "Human review before push, merge, publish, rollout, or dependency source changes.",
+            "Escalate when updates fail twice, widen scope, or hit a denied package.",
+        ),
+        useful_when=(
+            "A repo has recurring safe dependency bumps or security patch noise.",
+            "You want update toil reduced while keeping rollout and publish authority human.",
+        ),
+    ),
 )
 
 PRESET_IDS = tuple(preset.preset_id for preset in BEGINNER_PRESETS)
+DEFAULT_PRESET_IDS = tuple(
+    preset.preset_id for preset in BEGINNER_PRESETS if preset.tier == "beginner_default"
+)
+ADVANCED_PRESET_IDS = tuple(
+    preset.preset_id for preset in BEGINNER_PRESETS if preset.tier == "advanced_opt_in"
+)
 
 
 def _shell(value: str) -> str:
@@ -163,6 +247,7 @@ def _preset_to_dict(
     return {
         "id": preset.preset_id,
         "title": preset.title,
+        "tier": preset.tier,
         "maturity": preset.maturity,
         "cadence": preset.cadence,
         "default_mode": preset.default_mode,
@@ -205,6 +290,8 @@ def build_beginner_preset_packet(
         ),
         "mutation_policy": "read_only; renders commands only; does not write registry, state, automation, PRs, or docs",
         "recommended_order": list(PRESET_IDS),
+        "default_preset_ids": list(DEFAULT_PRESET_IDS),
+        "advanced_preset_ids": list(ADVANCED_PRESET_IDS),
         "placeholders": {
             "goal_id": goal_id,
             "agent_id": agent_id,
@@ -252,6 +339,7 @@ def render_beginner_preset_markdown(payload: dict[str, Any]) -> str:
                 f"## {preset.get('title')}",
                 "",
                 f"- id: `{preset.get('id')}`",
+                f"- tier: `{preset.get('tier')}`",
                 f"- maturity: {preset.get('maturity')}",
                 f"- cadence: {preset.get('cadence')}",
                 f"- default mode: `{preset.get('default_mode')}`",


### PR DESCRIPTION
## Summary
- add `ci-sweeper` and `dependency-sweeper` as L2 `advanced_opt_in` cards in `loopx preset`
- keep both presets report/policy-first, with explicit owner opt-in before any bounded worktree patch
- encode verifier/cost/denylist/human-review/escalation safety defaults and update beginner preset docs/help

## Validation
- `python3 examples/beginner-preset-picker-smoke.py`
- `python3 examples/cli-help-manpage-smoke.py`
- `python3 -m py_compile loopx/presets.py loopx/cli_commands/preset.py examples/beginner-preset-picker-smoke.py`
- `python3 -m loopx.cli preset show ci-sweeper --format json`
- `loopx check --scan-path docs/product/beginner-loop-presets.md --scan-path loopx/presets.py --scan-path loopx/help_surface.py --scan-path examples/beginner-preset-picker-smoke.py`
- `loopx canary premerge --from-git-diff`

## Self-merge note
Small single-purpose public CLI/docs/smoke batch. It only renders start packets; it does not implement an auto-fix runtime, write registry state, push, merge, or touch README first-screen copy. Canary reported `self_merge_allowed=true` with no manual holds.