### PR TITLE
Align agent management current todo with executable lanes

### DIFF
--- a/examples/control_plane/agent-management-live-status-smoke.py
+++ b/examples/control_plane/agent-management-live-status-smoke.py
@@ -213,6 +213,120 @@ def assert_synthetic_projection() -> None:
     assert "reclaim_url" not in json.dumps(stale_hint, sort_keys=True), stale_hint
 
 
+def assert_advancement_current_todo_beats_standing_monitor() -> None:
+    payload = fixture_status_payload()
+    payload["run_history"]["goals"][0]["coordination"]["registered_agents"].append("agent-side")
+    payload["attention_queue"]["items"].append(
+        {
+            "goal_id": "fixture-goal",
+            "agent_lane_next_action": {
+                "index": 2,
+                "done": False,
+                "text": "Ship the next bounded improvement.",
+                "schema_version": "agent_lane_next_action_v0",
+                "todo_id": "todo_side_advancement",
+                "role": "agent",
+                "status": "open",
+                "priority": "P2",
+                "title": "Ship the next bounded improvement.",
+                "task_class": "advancement_task",
+                "action_kind": "refactor",
+                "claimed_by": "agent-side",
+                "agent_id": "agent-side",
+                "selected_by": "current_agent_claimed_todo",
+                "updated_at": "2026-07-05T00:01:00Z",
+            },
+            "project_asset": {
+                "agent_todos": {
+                    "items": [
+                        {
+                            "index": 1,
+                            "done": False,
+                            "text": "Watch standing external state.",
+                            "todo_id": "todo_standing_monitor",
+                            "role": "agent",
+                            "status": "open",
+                            "priority": "P0",
+                            "title": "Watch standing external state.",
+                            "task_class": "continuous_monitor",
+                            "action_kind": "external_state_monitor",
+                            "claimed_by": "agent-side",
+                            "updated_at": "2026-07-05T00:00:00Z",
+                        },
+                    ],
+                    "claimed_open_items": [
+                        {
+                            "index": 3,
+                            "done": False,
+                            "text": "Blocked cold-path API idea.",
+                            "todo_id": "todo_blocked_detail_api",
+                            "role": "agent",
+                            "status": "blocked",
+                            "priority": "P1",
+                            "title": "Blocked cold-path API idea.",
+                            "task_class": "advancement_task",
+                            "action_kind": "todo_detail_api",
+                            "claimed_by": "agent-side",
+                            "updated_at": "2026-07-04T00:00:00Z",
+                        },
+                    ],
+                    "claimed_advancement_open_items": [
+                        {
+                            "index": 2,
+                            "done": False,
+                            "text": "Ship the next bounded improvement.",
+                            "todo_id": "todo_side_advancement",
+                            "role": "agent",
+                            "status": "open",
+                            "priority": "P2",
+                            "title": "Ship the next bounded improvement.",
+                            "task_class": "advancement_task",
+                            "action_kind": "refactor",
+                            "claimed_by": "agent-side",
+                            "updated_at": "2026-07-05T00:01:00Z",
+                        },
+                    ],
+                }
+            },
+        }
+    )
+    projection = build_agent_management_projection(payload)
+    by_agent = {
+        row.get("agent_id"): row
+        for row in projection.get("agents", [])
+        if isinstance(row, dict)
+    }
+    side_row = by_agent["agent-side"]
+    assert side_row["state"] == "running", side_row
+    assert side_row["current_todo"]["todo_id"] == "todo_side_advancement", side_row
+    assert side_row["next_action"] == "Continue projected todo todo_side_advancement.", side_row
+
+    payload["attention_queue"]["items"][-1].pop("agent_lane_next_action")
+    lane_only = build_agent_management_projection(payload)
+    lane_only_row = next(
+        row
+        for row in lane_only.get("agents", [])
+        if isinstance(row, dict) and row.get("agent_id") == "agent-side"
+    )
+    assert lane_only_row["state"] == "running", lane_only_row
+    assert lane_only_row["current_todo"]["todo_id"] == "todo_side_advancement", lane_only_row
+
+    payload["attention_queue"]["items"][-1]["project_asset"]["agent_todos"][
+        "claimed_advancement_open_items"
+    ] = []
+    payload["attention_queue"]["items"][-1]["project_asset"]["agent_todos"][
+        "claimed_open_items"
+    ] = []
+    monitor_only = build_agent_management_projection(payload)
+    monitor_row = next(
+        row
+        for row in monitor_only.get("agents", [])
+        if isinstance(row, dict) and row.get("agent_id") == "agent-side"
+    )
+    assert monitor_row["state"] == "monitoring", monitor_row
+    assert monitor_row["current_todo"]["todo_id"] == "todo_standing_monitor", monitor_row
+
+
 def assert_bundled_public_example() -> dict[str, Any]:
     payload = json.loads((REPO_ROOT / "examples" / "status.example.json").read_text(encoding="utf-8"))
     projection = payload.get("agent_management_projection")
@@ -321,6 +435,7 @@ def assert_live_projection(args: argparse.Namespace) -> dict[str, Any]:
 def main() -> int:
     args = parse_args()
     assert_synthetic_projection()
+    assert_advancement_current_todo_beats_standing_monitor()
     result: dict[str, Any] = {
         "synthetic": "ok",
         "bundled_example": assert_bundled_public_example(),

--- a/loopx/control_plane/agents/management_projection.py
+++ b/loopx/control_plane/agents/management_projection.py
@@ -5,6 +5,7 @@ from typing import Any, Iterable
 from ..runtime.public_safety import public_safe_compact_text
 from ..runtime.time import now_utc, now_utc_iso, parse_timestamp
 from ..todos.contract import normalize_todo_claimed_by, normalize_todo_id
+from ..todos.summary_item import TODO_SUMMARY_SOURCE_KEYS
 
 
 AGENT_MANAGEMENT_PROJECTION_SCHEMA_VERSION = "agent_management_projection_v0"
@@ -15,6 +16,17 @@ MAX_AGENT_TODOS = 8
 MAX_REFS = 1
 MAX_WORKSPACE_SCOPES = 4
 STALE_CLAIM_THRESHOLD_HOURS = 36
+
+_TODO_GROUP_LIST_KEYS = tuple(
+    dict.fromkeys(
+        (
+            *TODO_SUMMARY_SOURCE_KEYS,
+            "executable_backlog_items",
+            "deferred_items",
+            "deferred_resume_candidates",
+        )
+    )
+)
 
 _PRIORITY_RANK = {
     "P0": 0,
@@ -79,6 +91,49 @@ def _todo_sort_key(todo: dict[str, Any]) -> tuple[int, int, int, str]:
     return (done_rank, _priority_rank(todo), _index_rank(todo), str(todo.get("todo_id") or ""))
 
 
+def _is_monitor_todo(todo: dict[str, Any]) -> bool:
+    return (
+        todo.get("task_class") == "continuous_monitor"
+        or "monitor" in str(todo.get("action_kind") or "").lower()
+    )
+
+
+def _is_agent_lane_next_action(todo: dict[str, Any]) -> bool:
+    return (
+        todo.get("schema_version") == "agent_lane_next_action_v0"
+        or str(todo.get("source") or "").endswith("agent_lane_next_action")
+        or bool(todo.get("selected_by"))
+    )
+
+
+def _current_todo_execution_rank(todo: dict[str, Any]) -> int:
+    if todo.get("task_class") == "blocker":
+        return 0
+    if _todo_status(todo) == "blocked":
+        return 2
+    if _is_monitor_todo(todo):
+        return 3
+    return 1
+
+
+def _current_todo_sort_key(todo: dict[str, Any]) -> tuple[int, int, int, int, str]:
+    selected_rank = 0 if _is_agent_lane_next_action(todo) else 1
+    return (
+        selected_rank,
+        _current_todo_execution_rank(todo),
+        _priority_rank(todo),
+        _index_rank(todo),
+        str(todo.get("todo_id") or ""),
+    )
+
+
+def _select_current_todo(todos: list[dict[str, Any]]) -> dict[str, Any] | None:
+    open_todos = [todo for todo in todos if not _is_done(todo)]
+    if not open_todos:
+        return None
+    return sorted(open_todos, key=_current_todo_sort_key)[0]
+
+
 def _registered_agents(status_payload: dict[str, Any]) -> dict[str, dict[str, Any]]:
     rows: dict[str, dict[str, Any]] = {}
     run_history = _as_dict(status_payload.get("run_history"))
@@ -106,28 +161,64 @@ def _registered_agents(status_payload: dict[str, Any]) -> dict[str, dict[str, An
     return rows
 
 
+def _iter_todo_group_items(
+    group: dict[str, Any],
+    *,
+    goal_id: str | None,
+    source: str,
+) -> Iterable[dict[str, Any]]:
+    for key in _TODO_GROUP_LIST_KEYS:
+        for todo in _as_list(group.get(key)):
+            if isinstance(todo, dict):
+                row = dict(todo)
+                row.setdefault("goal_id", goal_id)
+                row.setdefault("source", source if key == "items" else f"{source}.{key}")
+                yield row
+
+
+def _iter_next_action_todo(
+    owner: dict[str, Any],
+    *,
+    goal_id: str | None,
+    source: str,
+) -> Iterable[dict[str, Any]]:
+    todo = owner.get("agent_lane_next_action")
+    if isinstance(todo, dict):
+        row = dict(todo)
+        row.setdefault("goal_id", goal_id)
+        row.setdefault("source", source)
+        yield row
+
+
 def _iter_status_todos(status_payload: dict[str, Any]) -> Iterable[dict[str, Any]]:
     queue = _as_dict(status_payload.get("attention_queue"))
     for item in _as_list(queue.get("items")):
         if not isinstance(item, dict):
             continue
         goal_id = _compact(item.get("goal_id"), limit=180)
-        for source_name in ("agent_todos",):
-            group = _as_dict(item.get(source_name))
-            for todo in _as_list(group.get("items")):
-                if isinstance(todo, dict):
-                    row = dict(todo)
-                    row.setdefault("goal_id", goal_id)
-                    row.setdefault("source", f"attention_queue.{source_name}")
-                    yield row
+        yield from _iter_next_action_todo(
+            item,
+            goal_id=goal_id,
+            source="attention_queue.agent_lane_next_action",
+        )
+        group = _as_dict(item.get("agent_todos"))
+        yield from _iter_todo_group_items(
+            group,
+            goal_id=goal_id,
+            source="attention_queue.agent_todos",
+        )
         project_asset = _as_dict(item.get("project_asset"))
+        yield from _iter_next_action_todo(
+            project_asset,
+            goal_id=goal_id,
+            source="project_asset.agent_lane_next_action",
+        )
         group = _as_dict(project_asset.get("agent_todos"))
-        for todo in _as_list(group.get("items")):
-            if isinstance(todo, dict):
-                row = dict(todo)
-                row.setdefault("goal_id", goal_id)
-                row.setdefault("source", "project_asset.agent_todos")
-                yield row
+        yield from _iter_todo_group_items(
+            group,
+            goal_id=goal_id,
+            source="project_asset.agent_todos",
+        )
 
     todo_index = _as_dict(status_payload.get("todo_index"))
     for todo in _as_list(todo_index.get("items")):
@@ -293,17 +384,19 @@ def _refs_from_todo(todo: dict[str, Any]) -> tuple[list[str], list[str]]:
     return evidence_refs[:MAX_REFS], handoff_refs[:MAX_REFS]
 
 
-def _agent_state(todos: list[dict[str, Any]]) -> str:
+def _agent_state(todos: list[dict[str, Any]], *, current: dict[str, Any] | None = None) -> str:
     open_todos = [todo for todo in todos if not _is_done(todo)]
     if not open_todos:
         return "waiting" if todos else "unknown"
+    if current and not _is_done(current):
+        if _todo_status(current) == "blocked" or current.get("task_class") == "blocker":
+            return "blocked"
+        if _is_monitor_todo(current):
+            return "monitoring"
+        return "running"
     if any(_todo_status(todo) == "blocked" or todo.get("task_class") == "blocker" for todo in open_todos):
         return "blocked"
-    if any(
-        todo.get("task_class") == "continuous_monitor"
-        or "monitor" in str(todo.get("action_kind") or "").lower()
-        for todo in open_todos
-    ):
+    if all(_is_monitor_todo(todo) for todo in open_todos):
         return "monitoring"
     return "running"
 
@@ -359,8 +452,16 @@ def build_agent_management_projection(status_payload: dict[str, Any]) -> dict[st
 
     agents: list[dict[str, Any]] = []
     for agent_id, raw_row in sorted(rows_by_agent.items()):
-        todos = sorted(_as_list(raw_row.get("_todos")), key=_todo_sort_key)[:MAX_AGENT_TODOS]
-        current = next((todo for todo in todos if not _is_done(todo)), None)
+        all_todos = _as_list(raw_row.get("_todos"))
+        current = _select_current_todo(all_todos)
+        todos = sorted(all_todos, key=_todo_sort_key)
+        if current:
+            current_identity = _todo_identity(current)
+            todos = [
+                current,
+                *[todo for todo in todos if _todo_identity(todo) != current_identity],
+            ]
+        todos = todos[:MAX_AGENT_TODOS]
         evidence_refs: list[str] = []
         handoff_refs: list[str] = []
         for todo in todos:
@@ -374,7 +475,7 @@ def build_agent_management_projection(status_payload: dict[str, Any]) -> dict[st
         agent_row: dict[str, Any] = {
             "agent_id": agent_id,
             "role": raw_row.get("role") or "agent",
-            "state": _agent_state(todos),
+            "state": _agent_state(all_todos, current=current),
             "current_todo": _todo_row(current) if current else None,
             "next_action": _safe_next_action(current),
             "last_activity_at": _last_activity(todos),


### PR DESCRIPTION
## Summary
- expand `agent_management_projection_v0` to read the already-projected todo lane lists and `agent_lane_next_action` rows, not only the narrow `agent_todos.items` slice
- make `current_todo` prefer the selected agent-lane next action and open executable work over stale blocked advancement rows or standing monitors
- extend the live-status smoke with a regression fixture for selected next action, lane-only advancement, blocked stale work, and monitor-only fallback

## Validation
- `python3 -m py_compile loopx/control_plane/agents/management_projection.py examples/control_plane/agent-management-live-status-smoke.py`
- `python3 examples/control_plane/agent-management-live-status-smoke.py`
- `python3 examples/control_plane/agent-management-projection-contract-smoke.py`
- `python3 examples/control_plane/status-collection-readmodel-smoke.py`
- `python3 examples/control_plane/todo-readmodel-boundary-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 examples/control_plane/todo-claim-visibility-lanes-smoke.py`
- live source-status check: `codex-product-capability` projects `current_todo=todo_66f7d7e3c5ab`, `state=running`
- `loopx check --scan-path loopx/control_plane/agents/management_projection.py --scan-path examples/control_plane/agent-management-live-status-smoke.py`
- `loopx canary premerge --from-git-diff --git-diff-base origin/main --tier standard --timeout-seconds 120 --format json --no-progress` passed: 13/13 selected checks, no failures, no warnings, gate passed, self-merge allowed

## Boundary
- non-benchmark control-plane read-model fix only
- no runtime task model, dispatcher, benchmark scoring, production action, private evidence, or credential material
