### PR TITLE
Preserve todo successor activity timestamps

### DIFF
--- a/examples/control_plane/todo-lifecycle-cli-smoke.py
+++ b/examples/control_plane/todo-lifecycle-cli-smoke.py
@@ -114,6 +114,8 @@ def main() -> int:
         assert rebuild_item["done"] is False and rebuild_item["task_class"] == "advancement_task", rebuild_item
         assert rebuild_item["action_kind"] == "rebuild_score", rebuild_item
         assert rebuild_item["claimed_by"] == "codex-main-control", rebuild_item
+        assert rebuild_item.get("updated_at"), rebuild_item
+        assert completed["next_todos"][0].get("updated_at") == rebuild_item["updated_at"], completed
 
         side_added = run_cli(
             registry_path,
@@ -134,6 +136,8 @@ def main() -> int:
         )
         assert side_added["added"] is True, side_added
         side_todo_id = side_added["todo_id"]
+        side_item = next(item for item in parsed_items(state_file) if item["todo_id"] == side_todo_id)
+        assert side_item.get("updated_at"), side_item
         missing_review = run_cli_error(
             registry_path,
             "todo",
@@ -304,6 +308,8 @@ def main() -> int:
         assert not review_item.get("action_kind"), review_item
         assert review_item["blocks_agent"] == "codex-side-bypass", review_item
         assert review_item["unblocks_todo_id"] == side_review_todo_id, review_item
+        assert review_item.get("updated_at"), review_item
+        assert side_completed["next_todos"][0].get("updated_at") == review_item["updated_at"], side_completed
 
         repeated = run_cli(
             registry_path,

--- a/loopx/control_plane/todos/event_writeback.py
+++ b/loopx/control_plane/todos/event_writeback.py
@@ -161,6 +161,7 @@ def _append_event_projected_successor(
         "priority": todo_priority_prefix(todo_text) or "P2",
         "title": title,
         "planner_order": index,
+        "updated_at": updated_at,
     }
     if task_class:
         payload["task_class"] = task_class
@@ -219,6 +220,7 @@ def _append_event_projected_successor(
         "claimed_by": claimed_by,
         "blocks_agent": blocks_agent,
         "unblocks_todo_id": unblocks_todo_id,
+        "updated_at": updated_at,
         "source": "event_log",
     }
 

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -680,6 +680,7 @@ def add_todo_to_lines(
     resume_when: str | None = None,
     monitor_metadata: dict[str, Any] | None = None,
     evidence: str | None = None,
+    updated_at: str | None = None,
 ) -> dict[str, Any]:
     require_user_todo_task_class(
         role=role,
@@ -735,6 +736,7 @@ def add_todo_to_lines(
             resume_when=resume_when,
             **normalized_monitor_metadata,
             evidence=evidence,
+            updated_at=updated_at,
         )
         todo_line = "\n".join([f"- [ ] {todo_text}", metadata_line] if metadata_line else [f"- [ ] {todo_text}"])
         if bounds:
@@ -774,6 +776,8 @@ def add_todo_to_lines(
         updates.update(normalized_monitor_metadata)
         if evidence:
             updates["evidence"] = evidence
+        if updated_at and not block.get("updated_at"):
+            updates["updated_at"] = updated_at
         metadata_line = metadata_line_for_block(block, updates)
         metadata_updated = upsert_todo_metadata(lines, block, metadata_line)
         todo_id = str(block.get("todo_id") or "")
@@ -814,6 +818,7 @@ def add_todo_to_lines(
         "next_due_at": effective_metadata.get("next_due_at"),
         "expires_at": effective_metadata.get("expires_at"),
         "evidence": effective_metadata.get("evidence") or evidence,
+        "updated_at": effective_metadata.get("updated_at") or updated_at,
     }
 
 
@@ -936,6 +941,7 @@ def add_goal_todo(
             unblocks_todo_id=normalized_unblocks_todo_id,
             resume_when=normalized_resume_when,
             monitor_metadata=normalized_monitor_metadata,
+            updated_at=updated_at,
         )
         added = bool(add_result["added"])
         metadata_updated = bool(add_result["metadata_updated"])
@@ -1480,6 +1486,7 @@ def complete_goal_todo(
                     claimed_by=effective_next_claimed_by,
                     blocks_agent=next_blocks_agent,
                     unblocks_todo_id=next_unblocks_todo_id,
+                    updated_at=updated_at,
                 )
             )
         if next_user_todo:
@@ -1493,6 +1500,7 @@ def complete_goal_todo(
                     ),
                     task_class="user_gate",
                     blocks_agent=next_user_blocks_agent,
+                    updated_at=updated_at,
                 )
             )
         next_changed = any(item.get("added") or item.get("metadata_updated") for item in next_results)
@@ -1598,6 +1606,7 @@ def supersede_goal_todo(
                     claimed_by=effective_next_claimed_by,
                     blocks_agent=next_blocks_agent,
                     unblocks_todo_id=next_unblocks_todo_id,
+                    updated_at=updated_at,
                 )
             )
         if next_user_todo:
@@ -1611,6 +1620,7 @@ def supersede_goal_todo(
                     ),
                     task_class="user_gate",
                     blocks_agent=next_user_blocks_agent,
+                    updated_at=updated_at,
                 )
             )
         superseded_by = next((item.get("todo_id") for item in next_results if item.get("todo_id")), None)


### PR DESCRIPTION
## Summary
- propagate `updated_at` through Markdown todo additions and successor writeback when the caller has a concrete write timestamp
- include `updated_at` in event-projected successor payloads and command return payloads
- extend lifecycle smoke coverage for direct claimed adds and `--next-agent-todo` successors

## Validation
- `python3 examples/control_plane/todo-lifecycle-cli-smoke.py`
- `python3 examples/control_plane/todo-cli-smoke.py`
- `python3 examples/control_plane/todo-durability-fixture-smoke.py`
- `python3 examples/control_plane/todo-list-event-projection-smoke.py`
- `python3 examples/control_plane/side-agent-self-iteration-state-machine-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `loopx check --scan-path loopx/todos.py --scan-path loopx/control_plane/todos/event_writeback.py --scan-path examples/control_plane/todo-lifecycle-cli-smoke.py`
- `loopx canary premerge --from-git-diff --git-diff-base origin/main --tier standard --timeout-seconds 120 --format json --no-progress`

Premerge gate passed with 17 selected checks, 0 failures, 0 warnings, and 0 manual holds. Public/private boundary scan was clean for the 3 changed files.