### PR TITLE
Preserve captured follow-up todo timestamps

### DIFF
--- a/examples/control_plane/todo-capture-followups-smoke.py
+++ b/examples/control_plane/todo-capture-followups-smoke.py
@@ -122,6 +122,7 @@ def main() -> int:
         assert dry_run["recorded_count"] == 2, dry_run
         assert dry_run["skipped_count"] == 1, dry_run
         assert dry_run["items"][2]["skipped_reason"] == "max_items_exceeded", dry_run
+        assert dry_run["items"][0]["updated_at"] == dry_run["updated_at"], dry_run
         assert state_file.read_text(encoding="utf-8") == original
 
         payload = run_cli(
@@ -164,6 +165,8 @@ def main() -> int:
         assert first_followup["action_kind"] == "implement", first_followup
         assert first_followup["required_write_scopes"] == ["examples/**"], first_followup
         assert first_followup["evidence"] == "examples/control_plane/todo-capture-followups-smoke.py#main", first_followup
+        assert first_followup["updated_at"] == payload["updated_at"], first_followup
+        assert payload["items"][0]["updated_at"] == payload["updated_at"], payload
 
         duplicate_again = run_cli(
             registry_path,

--- a/loopx/todo_followups.py
+++ b/loopx/todo_followups.py
@@ -135,6 +135,7 @@ def capture_followup_todos(
                 target_capabilities=target_capabilities,
                 required_decision_scopes=required_decision_scopes,
                 evidence=evidence_text,
+                updated_at=updated_at,
             )
             changed = changed or bool(add_result.get("added")) or bool(add_result.get("metadata_updated"))
             recorded_count += 1


### PR DESCRIPTION
## Summary
- pass the capture-followups write timestamp into the shared todo metadata helper
- assert dry-run and persisted captured follow-up todos retain `updated_at`

## Validation
- `python3 -m py_compile loopx/todo_followups.py examples/control_plane/todo-capture-followups-smoke.py`
- `python3 examples/control_plane/todo-capture-followups-smoke.py`
- `python3 examples/control_plane/todo-cli-smoke.py`
- `python3 examples/control_plane/todo-lifecycle-cli-smoke.py`
- `python3 examples/control_plane/todo-durability-fixture-smoke.py`
- `python3 examples/control_plane/status-collection-readmodel-smoke.py`
- `loopx check --scan-path loopx/todo_followups.py --scan-path examples/control_plane/todo-capture-followups-smoke.py`
- `loopx canary premerge --from-git-diff --git-diff-base origin/main --tier standard --timeout-seconds 120 --format json --no-progress`

Premerge gate passed with 5 selected checks, 0 failures, 0 warnings, and 0 manual holds. Public/private boundary scan was clean for the 2 changed files.