### PR TITLE
Preserve bootstrap onboarding todo timestamps

### DIFF
--- a/examples/onboarding-connect-candidates-smoke.py
+++ b/examples/onboarding-connect-candidates-smoke.py
@@ -73,6 +73,20 @@ def action_kinds(items: list[dict]) -> set[str]:
     return {str(item.get("action_kind") or "") for item in items}
 
 
+def state_updated_at(text: str) -> str:
+    for line in text.splitlines():
+        if line.startswith("updated_at: "):
+            return line.split(": ", 1)[1].strip()
+    raise AssertionError(text)
+
+
+def assert_todos_share_state_timestamp(text: str, items: list[dict]) -> None:
+    expected = state_updated_at(text)
+    assert items, items
+    for item in items:
+        assert item.get("updated_at") == expected, item
+
+
 def assert_default_onboarding(project: Path, runtime: Path) -> None:
     goal_id = "onboarding-smoke-default"
     payload = run_cli(
@@ -153,6 +167,7 @@ def assert_default_onboarding(project: Path, runtime: Path) -> None:
     assert len(agent_items) == 1, agent_items
     assert action_kinds(user_items) == {"onboarding_decision"}, user_items
     assert action_kinds(agent_items) == {"onboarding_todo_review"}, agent_items
+    assert_todos_share_state_timestamp(text, user_items + agent_items)
 
 
 def assert_preauthorized_onboarding(project: Path, runtime: Path) -> None:
@@ -197,6 +212,7 @@ def assert_preauthorized_onboarding(project: Path, runtime: Path) -> None:
     assert "repo_status_review" in kinds, agent_items
     assert "commit_summary" in kinds, agent_items
     assert "validation_plan" in kinds, agent_items
+    assert_todos_share_state_timestamp(text, agent_items)
 
 
 def assert_autonomy_preauth_still_requires_heartbeat_choice(project: Path, runtime: Path) -> None:
@@ -249,6 +265,7 @@ def assert_autonomy_preauth_still_requires_heartbeat_choice(project: Path, runti
     assert len(user_items) == 1, user_items
     assert action_kinds(user_items) == {"onboarding_decision"}, user_items
     assert "onboarding_todo_review" in action_kinds(agent_items), agent_items
+    assert_todos_share_state_timestamp(text, user_items + agent_items)
 
 
 def main() -> int:

--- a/loopx/bootstrap.py
+++ b/loopx/bootstrap.py
@@ -308,6 +308,7 @@ def onboarding_next_action(
 def apply_onboarding_todos_to_state(
     text: str,
     *,
+    updated_at: str,
     onboarding_scan: dict[str, Any] | None,
     accept_onboarding_agent_todos: bool,
     begin_autonomous_advance: bool,
@@ -327,6 +328,7 @@ def apply_onboarding_todos_to_state(
                 text=todo_text,
                 task_class=str(candidate.get("task_class") or "advancement_task"),
                 action_kind=str(candidate.get("action_kind") or "analyze"),
+                updated_at=updated_at,
             )
 
     acceptance_required = not accept_onboarding_agent_todos
@@ -344,6 +346,7 @@ def apply_onboarding_todos_to_state(
             text=user_todo,
             task_class="user_gate",
             action_kind="onboarding_decision",
+            updated_at=updated_at,
         )
     agent_todo = onboarding_agent_review_todo_text(
         acceptance_required=acceptance_required,
@@ -357,6 +360,7 @@ def apply_onboarding_todos_to_state(
             text=agent_todo,
             task_class="advancement_task",
             action_kind="onboarding_todo_review",
+            updated_at=updated_at,
         )
     return "\n".join(lines) + "\n"
 
@@ -442,6 +446,7 @@ adapter_id: {goal_id}
 """
     return apply_onboarding_todos_to_state(
         state_text,
+        updated_at=updated_at,
         onboarding_scan=onboarding_scan,
         accept_onboarding_agent_todos=accept_onboarding_agent_todos,
         begin_autonomous_advance=begin_autonomous_advance,


### PR DESCRIPTION
## Summary
- pass the bootstrap state `updated_at` timestamp into onboarding todos written during initial state render
- extend the onboarding connect smoke to assert default, preauthorized, and heartbeat-gated onboarding todos share the active-state timestamp

## Why
This closes a small projection consistency gap: first-connect onboarding todos were written without their own `updated_at`, while later todo entry points already stamp new todos. Status/quota/read-model consumers can now rely on onboarding todos carrying the same creation timestamp as the state snapshot that introduced them.

## Validation
- `python3 -m py_compile loopx/bootstrap.py examples/onboarding-connect-candidates-smoke.py`
- `python3 examples/onboarding-connect-candidates-smoke.py`
- `loopx check --scan-path loopx/bootstrap.py --scan-path examples/onboarding-connect-candidates-smoke.py`
- `loopx canary premerge --from-git-diff --git-diff-base origin/main --tier standard --timeout-seconds 120 --format json --no-progress`

## Risk
Low. The change only threads an existing timestamp into existing todo metadata creation. It does not change onboarding candidate selection, gates, quota decisions, benchmark behavior, or public/private evidence policy.