### PR TITLE
Expose quota user-action compatibility fields

### DIFF
--- a/docs/interface-budget-contract.md
+++ b/docs/interface-budget-contract.md
@@ -10,7 +10,7 @@ and size/count budgets.
 | --- | --- | --- | --- | --- | --- | --- |
 | `heartbeat_prompt_json` | heartbeat automation | wake and route one bounded turn | `quota should-run`, `status`, or `review-packet --handoff-only` | `json_chars <= 3500` plus `interface_budget.within_budget=true` | `nested_keys <= 40` | `top_level_keys <= 30` |
 | `review_packet_handoff_only_json` | project-agent handoff | forward the smallest sufficient task packet | full `review-packet` or run-history artifact | `json_chars <= 3000` plus `handoff_interface_budget.within_budget=true` | `nested_keys <= 40` | `top_level_keys <= 18` |
-| `quota_should_run_json` | quota guard | decide whether the selected goal may spend compute | `status`, `history`, or active state | `json_chars <= 12500` | `nested_keys <= 320` | `top_level_keys <= 50` |
+| `quota_should_run_json` | quota guard | decide whether the selected goal may spend compute | `status`, `history`, or active state | `json_chars <= 12550` | `nested_keys <= 322` | `top_level_keys <= 50` |
 | `dashboard_status_json` | operator dashboard | render first-screen operator state | `history`, run artifacts, or project-local adapter output | `json_chars <= 18200` | `nested_keys <= 260` | `top_level_keys <= 25` |
 
 These budgets are intentionally about the machine payloads, not the full
@@ -32,6 +32,11 @@ Restraint rules for new fields:
    status/quota/review-packet contract instead.
 5. If a short worker would need to read more than one hot-path payload before it
    can choose the next action, demote the extra detail to a cold-path command.
+
+The quota guard keeps top-level `action_required` and `open_count` as compact
+compatibility aliases for older heartbeat/host prompts; the authoritative
+structured fields remain `interaction_contract.user_channel` and
+`user_todo_summary`.
 
 Regression entrypoints:
 

--- a/examples/control_plane/hot-path-interface-budget-smoke.py
+++ b/examples/control_plane/hot-path-interface-budget-smoke.py
@@ -52,8 +52,8 @@ SURFACE_BUDGETS = {
         "owner": "quota guard",
         "consumer": "decide whether the selected goal may spend compute",
         "cold_path": "status, history, or active state",
-        "max_json_chars": 12_500,
-        "max_nested_keys": 320,
+        "max_json_chars": 12_550,
+        "max_nested_keys": 322,
         "max_top_level_keys": 50,
     },
     "dashboard_status_json": {

--- a/examples/control_plane/quota-agent-scoped-user-gate-smoke.py
+++ b/examples/control_plane/quota-agent-scoped-user-gate-smoke.py
@@ -226,9 +226,11 @@ def assert_other_agent_user_gate_does_not_block_current_agent() -> None:
     assert payload["requires_user_action"] is False, payload
     contract = payload["interaction_contract"]
     assert contract["user_channel"]["action_required"] is False, contract
+    assert payload["action_required"] is False, payload
     assert contract["agent_channel"]["delivery_allowed"] is True, contract
     summary = payload["user_todo_summary"]
     assert summary["open_count"] == 0, summary
+    assert payload["open_count"] == 0, payload
     assert summary["other_agent_scoped_open_count"] == 1, summary
     assert summary["other_agent_scoped_items"][0]["blocks_agent"] == "codex-product-capability"
     override = payload["agent_scoped_user_gate_override"]
@@ -247,6 +249,7 @@ def assert_other_agent_user_gate_does_not_notify_non_due_monitor_lane() -> None:
     assert payload["effective_action"] == "monitor_quiet_skip", payload
     assert payload["should_run"] is False, payload
     assert payload["requires_user_action"] is False, payload
+    assert payload["action_required"] is False, payload
     assert payload["heartbeat_recommendation"]["notify"] == "DONT_NOTIFY", payload
     assert payload["interaction_contract"]["user_channel"]["action_required"] is False, payload
     assert payload["interaction_contract"]["user_channel"]["notify"] == "DONT_NOTIFY", payload
@@ -274,9 +277,11 @@ def assert_target_agent_still_blocks_on_its_user_gate() -> None:
     contract = payload["interaction_contract"]
     assert contract["mode"] == "user_gate", contract
     assert contract["user_channel"]["action_required"] is True, contract
+    assert payload["action_required"] is True, payload
     assert contract["agent_channel"]["delivery_allowed"] is False, contract
     summary = payload["user_todo_summary"]
     assert summary["open_count"] == 1, summary
+    assert payload["open_count"] == 1, payload
     assert "agent_scoped_user_gate_override" not in payload, payload
 
 
@@ -288,8 +293,10 @@ def assert_unscoped_user_gate_remains_global() -> None:
     )
     assert payload["should_run"] is False, payload
     assert payload["requires_user_action"] is True, payload
+    assert payload["action_required"] is True, payload
     assert payload["interaction_contract"]["mode"] == "user_gate", payload
     assert payload["user_todo_summary"]["open_count"] == 1, payload
+    assert payload["open_count"] == 1, payload
     assert "agent_scoped_user_gate_override" not in payload, payload
 
 

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -10,6 +10,7 @@ from ..agents.agent_scope_frontier import (
 from ..goals.goal_frontier import AUTONOMOUS_REPLAN_REQUIRED_MODE
 from ..todos.contract import TODO_TASK_CLASS_ADVANCEMENT, TODO_TASK_CLASS_MONITOR
 from ..todos.projection import todo_item_is_actionable_open, todo_item_task_class
+from ..todos.user_gate import open_todo_count
 
 
 INTERACTION_CONTRACT_SCHEMA_VERSION = "loopx_interaction_contract_v0"
@@ -97,6 +98,11 @@ def user_channel_action_required(payload: dict[str, Any]) -> bool:
     return bool(payload.get("requires_user_action")) or bool(
         user_channel_action_todo_actions(payload.get("user_todo_summary"))
     )
+
+
+def attach_user_action_compat_fields(payload: dict[str, Any]) -> None:
+    payload["action_required"] = user_channel_action_required(payload)
+    payload["open_count"] = open_todo_count(payload.get("user_todo_summary"))
 
 
 def _protocol_first_candidate_action(payload: dict[str, Any]) -> str | None:

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -37,6 +37,7 @@ from .execution_profile import (
 )
 from .control_plane.work_items.execution_obligation import build_execution_obligation
 from .control_plane.work_items.interaction_contract import (
+    attach_user_action_compat_fields,
     build_interaction_contract,
     build_protocol_action_packet,
     protocol_action_text as _protocol_action_text,
@@ -2126,6 +2127,7 @@ def build_quota_should_run(
                 }
         payload["automation_liveness"] = build_automation_liveness(payload)
         payload["interaction_contract"] = build_interaction_contract(payload)
+        attach_user_action_compat_fields(payload)
         payload["scheduler_hint"] = _scheduler_hint(
             payload,
             include_detail=include_scheduler_detail,


### PR DESCRIPTION
## Summary

Expose `quota should-run` top-level `action_required` and `open_count` compatibility fields while keeping the authoritative user-action contract in `interaction_contract.user_channel` and `user_todo_summary`.

This repairs older heartbeat/host prompts that still branch on top-level `action_required/open_count` even though the structured contract already had the correct false/0 and true/1 values.

## Product / Architecture Judgment

- Motivation: avoid agent/host ambiguity when a quota payload has `interaction_contract.user_channel.action_required=false` and `user_todo_summary.open_count=0`, but legacy top-level fields are absent.
- Solved: `attach_user_action_compat_fields()` derives aliases from the same `user_channel_action_required()` and `open_todo_count()` helpers used by the structured contract, so scheduler/user-channel/top-level projection stay aligned.
- Operator impact: heartbeat agents can follow either the new structured contract or legacy top-level fields without misreporting user-action gates.
- Main risk: hot-path payload growth. The interface-budget smoke now pins the exact growth: quota payload remains within `json_chars <= 12550`, `nested_keys <= 322`, `top_level_keys <= 50`.
- Design judgment: scoped to the existing interaction-contract bounded context; `quota.py` only attaches the projection once after building the interaction contract.

## Validation

- `python3 -m py_compile loopx/quota.py loopx/control_plane/work_items/interaction_contract.py examples/control_plane/quota-agent-scoped-user-gate-smoke.py examples/control_plane/hot-path-interface-budget-smoke.py`
- `python3 examples/control_plane/quota-agent-scoped-user-gate-smoke.py`
- `python3 examples/control_plane/hot-path-interface-budget-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `python3 examples/control_plane/heartbeat-quota-flow-smoke.py`
- `loopx check --scan-path loopx/quota.py --scan-path loopx/control_plane/work_items/interaction_contract.py --scan-path examples/control_plane/quota-agent-scoped-user-gate-smoke.py --scan-path examples/control_plane/hot-path-interface-budget-smoke.py --scan-path docs/interface-budget-contract.md`
- `loopx canary premerge --from-git-diff --git-diff-base origin/main --tier standard --timeout-seconds 120 --format json --no-progress` passed: 4 direct checks, 17 selected checks, 0 failures, 0 warnings, 0 manual holds, `self_merge_allowed=true`.

## Boundary Notes

No credentials, private state, raw benchmark logs, trajectories, verifier output, local paths, benchmark scoring changes, or benchmark execution changes are included.
