### PR TITLE
Clarify completed todo archive warning defaults

### DIFF
--- a/examples/control_plane/todo-archive-completed-smoke.py
+++ b/examples/control_plane/todo-archive-completed-smoke.py
@@ -114,6 +114,11 @@ def main() -> int:
         assert warning["kind"] == "completed_agent_todo_archive_required", warning
         assert warning["active_done_count"] == 14, warning
         assert warning["active_open_count"] == 2, warning
+        assert warning["max_active_done_count"] == 12, warning
+        assert warning["default_archive_keep_count"] == 10, warning
+        assert warning["archive_command_template"] == (
+            "loopx todo archive-completed --goal-id <goal-id> --execute"
+        ), warning
 
         default_dry_run = run_cli(
             registry_path,
@@ -126,7 +131,10 @@ def main() -> int:
         assert default_dry_run["ok"] is True, default_dry_run
         assert default_dry_run["dry_run"] is True, default_dry_run
         assert default_dry_run["changed"] is True, default_dry_run
-        assert default_dry_run["active_done_after"] == 10, default_dry_run
+        assert default_dry_run["active_done_after"] == warning["default_archive_keep_count"], (
+            warning,
+            default_dry_run,
+        )
         assert default_dry_run["moved_count"] == 4, default_dry_run
         assert state_path.read_text(encoding="utf-8") == original
 

--- a/loopx/control_plane/quota/markdown.py
+++ b/loopx/control_plane/quota/markdown.py
@@ -536,6 +536,7 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             f"requires_archive={completed_todo_archive_warning.get('requires_archive')} "
             f"active_done={completed_todo_archive_warning.get('active_done_count')} "
             f"max_active_done={completed_todo_archive_warning.get('max_active_done_count')} "
+            f"default_archive_keep={completed_todo_archive_warning.get('default_archive_keep_count')} "
             f"archive_section={completed_todo_archive_warning.get('archive_section')}"
         )
         if completed_todo_archive_warning.get("recommended_action"):

--- a/loopx/control_plane/todos/completed_archive.py
+++ b/loopx/control_plane/todos/completed_archive.py
@@ -12,6 +12,10 @@ from .active_state_editing import (
 
 
 DEFAULT_MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE = 12
+DEFAULT_COMPLETED_TODO_ARCHIVE_HEADROOM = 2
+COMPLETED_TODO_ARCHIVE_COMMAND_TEMPLATE = (
+    "loopx todo archive-completed --goal-id <goal-id> --execute"
+)
 
 
 def completed_todo_archive_warning(
@@ -31,6 +35,10 @@ def completed_todo_archive_warning(
         open_count = int(agent_todos.get("open_count") or 0)
     except (TypeError, ValueError):
         open_count = 0
+    archive_keep_count = max(
+        0,
+        max_active_done_todos - DEFAULT_COMPLETED_TODO_ARCHIVE_HEADROOM,
+    )
     return {
         "kind": "completed_agent_todo_archive_required",
         "requires_archive": True,
@@ -38,6 +46,8 @@ def completed_todo_archive_warning(
         "active_done_count": done_count,
         "active_open_count": open_count,
         "max_active_done_count": max_active_done_todos,
+        "default_archive_keep_count": archive_keep_count,
+        "archive_command_template": COMPLETED_TODO_ARCHIVE_COMMAND_TEMPLATE,
         "recommended_action": (
             "move older completed Agent Todo entries into a dedicated Completed Work Archive "
             "until the active Agent Todo section keeps only current open work and a small recent-done tail"


### PR DESCRIPTION
## Summary

Make `completed_todo_archive_warning` expose the same default keep-count used by `loopx todo archive-completed`, and render that keep-count in quota markdown.

This removes an operator/agent ambiguity where the warning threshold says active completed todos should stay under 12, while the CLI default intentionally archives down to 10 to leave headroom.

## Product / Architecture Judgment

- Motivation: quota/status can surface `completed_agent_todo_archive_required`; the payload should tell agents both the trigger threshold and the default archive target.
- Solved: warning payload now includes `default_archive_keep_count=10` and a public-safe `archive_command_template`; the smoke asserts the default dry-run result matches the warning field.
- Operator impact: an agent seeing the warning can run the default archive command without guessing why it keeps fewer completed todos than the threshold.
- Main risk: payload expansion in a warning-only object. The change is scoped to the warning surface and does not alter archive behavior.
- Design judgment: keep the behavior in the existing todo archive bounded context; no new module or scheduler behavior.

## Validation

- `python3 -m py_compile loopx/control_plane/todos/completed_archive.py loopx/control_plane/quota/markdown.py examples/control_plane/todo-archive-completed-smoke.py`
- `python3 examples/control_plane/todo-archive-completed-smoke.py`
- `python3 examples/control_plane/quota-contract-smoke.py`
- `loopx check --scan-path loopx/control_plane/todos/completed_archive.py --scan-path loopx/control_plane/quota/markdown.py --scan-path examples/control_plane/todo-archive-completed-smoke.py`
- Source checkout dry-run against current `loopx-meta`: `completed_todo_archive_warning.default_archive_keep_count == todo archive-completed.active_done_after == 10`.
- `loopx canary premerge --from-git-diff --git-diff-base origin/main --tier standard --timeout-seconds 120 --format json --no-progress` passed: 4 direct checks, 17 selected checks, 0 failures, 0 warnings, 0 manual holds, `self_merge_allowed=true`.

## Boundary Notes

No credentials, private state, raw benchmark logs, trajectories, verifier output, local paths, benchmark scoring changes, or benchmark execution changes are included.
