### PR TITLE
Preserve scheduler ack current-hint failure metadata

### DIFF
--- a/examples/control_plane/quota-scheduler-state-ack-smoke.py
+++ b/examples/control_plane/quota-scheduler-state-ack-smoke.py
@@ -16,7 +16,10 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from loopx.control_plane.testing.canary_harness import run_json_cli  # noqa: E402
+from loopx.control_plane.testing.canary_harness import (  # noqa: E402
+    run_json_cli,
+    run_json_cli_result,
+)
 from loopx.control_plane.scheduler import scheduler_hint as scheduler_hint_module  # noqa: E402
 from loopx.control_plane.scheduler.scheduler_hint import (  # noqa: E402
     build_codex_app_scheduler_ack_event,
@@ -667,6 +670,19 @@ def run_cli(root: Path, *args: str, registry_path: Path, runtime: Path, project:
     )
 
 
+def run_cli_result(
+    root: Path, *args: str, registry_path: Path, runtime: Path, project: Path
+) -> tuple[int, dict]:
+    return run_json_cli_result(
+        *args,
+        "--scan-path",
+        str(project),
+        registry_path=registry_path,
+        runtime_root=runtime,
+        cwd=REPO_ROOT,
+    )
+
+
 def assert_cli_scheduler_ack_progression() -> None:
     fixture = _load_quota_plan_fixture_module()
     with tempfile.TemporaryDirectory(prefix="loopx-quota-scheduler-ack-") as tmp:
@@ -721,6 +737,30 @@ def assert_cli_scheduler_ack_progression() -> None:
         assert current_hint_preview["ok"] is True, current_hint_preview
         assert current_hint_preview["used_current_hint"] is True, current_hint_preview
         assert current_hint_preview["scheduler_state_mutated"] is False, current_hint_preview
+
+        failure_returncode, current_hint_failure = run_cli_result(
+            root,
+            "quota",
+            "scheduler-ack",
+            "--goal-id",
+            "needs-operator",
+            "--agent-id",
+            agent_id,
+            "--state-key",
+            "wrong.state.key",
+            "--use-current-hint",
+            registry_path=registry_path,
+            runtime=runtime,
+            project=project,
+        )
+        assert failure_returncode != 0, current_hint_failure
+        assert current_hint_failure["ok"] is False, current_hint_failure
+        assert current_hint_failure["used_current_hint"] is True, current_hint_failure
+        assert (
+            current_hint_failure["current_hint_source"]
+            == "quota.should-run.scheduler_hint"
+        ), current_hint_failure
+        assert "--state-key" in current_hint_failure["reason"], current_hint_failure
 
         ack = run_cli(
             root,

--- a/loopx/control_plane/quota/scheduler_ack.py
+++ b/loopx/control_plane/quota/scheduler_ack.py
@@ -53,6 +53,13 @@ def scheduler_ack_failure(
     }
 
 
+def _annotate_current_hint(payload: dict[str, Any], *, use_current_hint: bool) -> dict[str, Any]:
+    if use_current_hint:
+        payload["used_current_hint"] = True
+        payload["current_hint_source"] = "quota.should-run.scheduler_hint"
+    return payload
+
+
 def _resolve_scheduler_ack_current_hint(
     before: dict[str, Any],
     *,
@@ -156,20 +163,19 @@ def record_quota_scheduler_ack_for_decision(
         identity_signature=identity_signature,
     )
     if not ack_plan.get("ok"):
-        return scheduler_ack_failure(
-            goal_id=goal_id,
-            agent_id=safe_agent_id,
-            execute=execute,
-            surface=surface,
-            state_key=state_key,
-            applied_rrule=applied_rrule,
-            reason=str(ack_plan.get("reason") or "scheduler ack validation failed"),
-            before=before,
+        return _annotate_current_hint(
+            scheduler_ack_failure(
+                goal_id=goal_id,
+                agent_id=safe_agent_id,
+                execute=execute,
+                surface=surface,
+                state_key=state_key,
+                applied_rrule=applied_rrule,
+                reason=str(ack_plan.get("reason") or "scheduler ack validation failed"),
+                before=before,
+            ),
+            use_current_hint=use_current_hint,
         )
-        if use_current_hint:
-            failure["used_current_hint"] = True
-            failure["current_hint_source"] = "quota.should-run.scheduler_hint"
-        return failure
     if ack_plan.get("already_applied"):
         payload = {
             "ok": True,
@@ -205,20 +211,19 @@ def record_quota_scheduler_ack_for_decision(
             reason_summary=reason_summary,
         )
     except ValueError as exc:
-        return scheduler_ack_failure(
-            goal_id=goal_id,
-            agent_id=safe_agent_id,
-            execute=execute,
-            surface=surface,
-            state_key=state_key,
-            applied_rrule=applied_rrule,
-            reason=str(exc),
-            before=before,
+        return _annotate_current_hint(
+            scheduler_ack_failure(
+                goal_id=goal_id,
+                agent_id=safe_agent_id,
+                execute=execute,
+                surface=surface,
+                state_key=state_key,
+                applied_rrule=applied_rrule,
+                reason=str(exc),
+                before=before,
+            ),
+            use_current_hint=use_current_hint,
         )
-        if use_current_hint:
-            failure["used_current_hint"] = True
-            failure["current_hint_source"] = "quota.should-run.scheduler_hint"
-        return failure
 
     state_path = scheduler_state_path(
         runtime_root,


### PR DESCRIPTION
## Summary
- keep scheduler-ack failure payloads annotated with use-current-hint metadata when validation fails
- add a CLI smoke for --use-current-hint failure responses so current_hint_source remains projected

## Validation
- python3 -m py_compile loopx/control_plane/quota/scheduler_ack.py examples/control_plane/quota-scheduler-state-ack-smoke.py
- python3 examples/control_plane/quota-scheduler-state-ack-smoke.py
- python3 examples/control_plane/quota-scheduler-policy-smoke.py
- python3 examples/control_plane/quota-contract-smoke.py
- loopx check --scan-path loopx/control_plane/quota/scheduler_ack.py --scan-path examples/control_plane/quota-scheduler-state-ack-smoke.py
- loopx canary premerge --from-git-diff --git-diff-base origin/main --tier standard --timeout-seconds 120 --format json --no-progress

## Risk
- Narrow quota/scheduler projection fix; no benchmark execution, scoring, task text, verifier output, or private artifacts.