### PR TITLE
Compact quota todo summary payloads

### DIFF
--- a/examples/control_plane/quota-todo-summary-readmodel-smoke.py
+++ b/examples/control_plane/quota-todo-summary-readmodel-smoke.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 import sys
 
@@ -12,6 +13,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.control_plane.todos.quota_summary import (  # noqa: E402
+    compact_quota_todo_summary_for_payload,
     is_user_gate_todo_item,
     select_quota_todo_summary,
     summarize_project_asset_todos_for_quota,
@@ -221,11 +223,72 @@ def assert_user_gate_hint_detection_is_preserved() -> None:
     )
 
 
+def assert_quota_payload_summary_compacts_hot_path_lanes() -> None:
+    long_text = "[P2] " + "inspect projection consistency " * 30
+    source = {
+        "schema_version": "todo_summary_v0",
+        "source_section": "agent todo",
+        "open_count": 12,
+        "claimed_open_count": 12,
+        "claimed_monitor_open_count": 12,
+        "claimed_open_items": [
+            {
+                "index": index,
+                "todo_id": f"todo_payload_{index:03d}",
+                "text": long_text,
+                "title": long_text,
+                "status": "open",
+                "task_class": "continuous_monitor",
+                "claimed_by": "codex-main-control",
+                "handoff_note": {
+                    "schema_version": "handoff_note_v0",
+                    "body": "cold path detail " * 200,
+                },
+            }
+            for index in range(12)
+        ],
+        "claim_scope": {
+            "schema_version": "agent_claim_scope_v0",
+            "agent_id": "codex-product-capability",
+            "other_agent_claimed_open_count": 12,
+            "other_agent_claimed_items": [
+                {
+                    "index": index,
+                    "todo_id": f"todo_other_{index:03d}",
+                    "text": long_text,
+                    "task_class": "advancement_task",
+                    "claimed_by": "codex-main-control",
+                }
+                for index in range(12)
+            ],
+        },
+    }
+    compact = compact_quota_todo_summary_for_payload(source)
+    assert compact["open_count"] == 12, compact
+    assert compact["claimed_open_count"] == 12, compact
+    assert len(compact["claimed_open_items"]) == 2, compact
+    assert len(compact["claim_scope"]["other_agent_claimed_items"]) == 2, compact
+    first = compact["claimed_open_items"][0]
+    assert first["todo_id"] == "todo_payload_000", compact
+    assert first["text"].endswith("..."), first
+    assert len(first["text"]) <= 180, first
+    assert "title" not in first, first
+    assert "handoff_note" not in first, first
+    compaction = compact["payload_compaction"]
+    assert compaction["schema_version"] == "quota_todo_summary_payload_compaction_v0", compaction
+    assert compaction["compacted_lanes"]["claimed_open_items"] == {
+        "shown": 2,
+        "total": 12,
+    }, compaction
+    assert len(json.dumps(compact, ensure_ascii=False, sort_keys=True)) < 5000, compact
+
+
 def main() -> None:
     assert_agent_scoped_user_gate_and_monitor_state()
     assert_project_asset_fallback_and_canonical_precedence()
     assert_project_asset_summary_reuses_canonical_shape()
     assert_user_gate_hint_detection_is_preserved()
+    assert_quota_payload_summary_compacts_hot_path_lanes()
     print("quota todo summary read model smoke passed")
 
 

--- a/examples/control_plane/quota-work-lane-policy-smoke.py
+++ b/examples/control_plane/quota-work-lane-policy-smoke.py
@@ -117,6 +117,9 @@ def assert_work_lane_context_matches_quota_state_machine_cases() -> None:
             agent_todo_summary=guard["agent_todo_summary"],
         )
         assert direct == guard["work_lane_contract"], (name, direct, guard)
+        for lane_item in guard["work_lane_contract"].get("monitor_due_items") or []:
+            assert "title" not in lane_item, (name, lane_item)
+            assert "handoff_note" not in lane_item, (name, lane_item)
 
 
 def assert_work_lane_context_progress_scope_sources() -> None:

--- a/loopx/control_plane/todos/quota_summary.py
+++ b/loopx/control_plane/todos/quota_summary.py
@@ -38,6 +38,69 @@ MONITOR_DUE_ITEM_LIMIT = 1
 TODO_BACKLOG_ITEM_LIMIT = 8
 TODO_DEFERRED_VISIBILITY_LIMIT = 8
 TODO_VISIBILITY_LANE_LIMIT = 16
+QUOTA_PAYLOAD_ITEM_TEXT_LIMIT = 180
+QUOTA_PAYLOAD_VISIBILITY_LANE_LIMIT = 2
+QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT = 2
+QUOTA_PAYLOAD_COMPACTION_SCHEMA_VERSION = "quota_todo_summary_payload_compaction_v0"
+QUOTA_PAYLOAD_ITEM_FIELDS = (
+    "index",
+    "text",
+    "todo_id",
+    "status",
+    "priority",
+    "task_class",
+    "action_kind",
+    "claimed_by",
+    "blocks_agent",
+    "global_gate",
+    "unblocks_todo_id",
+    "resume_when",
+    "resume_condition",
+    "resume_ready",
+    "blocking_monitor_todo_id",
+    "no_followup",
+    "successor_todo_ids",
+    "target_key",
+    "cadence",
+    "next_due_at",
+    "expires_at",
+    "last_checked_at",
+    "result_hash",
+    "consecutive_no_change",
+    "material_change",
+    "max_no_change_before_replan",
+    "route_continuation_replan_required",
+    "route_continuation_reason",
+    "route_id",
+    "route_key",
+    "completed_at",
+    "updated_at",
+)
+QUOTA_PAYLOAD_LANE_LIMITS = {
+    "monitor_due_items": MONITOR_DUE_ITEM_LIMIT,
+    "monitor_schedule_gap_items": MONITOR_DUE_ITEM_LIMIT,
+    "first_open_items": 3,
+    "first_executable_items": 3,
+    "active_next_action_items": 3,
+    "active_next_action_executable_items": 3,
+    "monitor_open_items": QUOTA_PAYLOAD_VISIBILITY_LANE_LIMIT,
+    "backlog_items": QUOTA_PAYLOAD_VISIBILITY_LANE_LIMIT,
+    "executable_backlog_items": QUOTA_PAYLOAD_VISIBILITY_LANE_LIMIT,
+    "unclaimed_priority_open_items": QUOTA_PAYLOAD_VISIBILITY_LANE_LIMIT,
+    "claimed_open_items": QUOTA_PAYLOAD_VISIBILITY_LANE_LIMIT,
+    "claimed_advancement_open_items": QUOTA_PAYLOAD_VISIBILITY_LANE_LIMIT,
+    "claimed_monitor_open_items": QUOTA_PAYLOAD_VISIBILITY_LANE_LIMIT,
+    "current_agent_claimed_open_items": QUOTA_PAYLOAD_VISIBILITY_LANE_LIMIT,
+    "current_agent_claimed_advancement_items": QUOTA_PAYLOAD_VISIBILITY_LANE_LIMIT,
+    "current_agent_claimed_monitor_items": QUOTA_PAYLOAD_VISIBILITY_LANE_LIMIT,
+    "claimed_by_others_items": QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,
+    "other_agent_scoped_items": QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,
+    "user_action_items": QUOTA_PAYLOAD_VISIBILITY_LANE_LIMIT,
+    "resume_blocked_items": QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,
+    "handoff_gates": QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,
+    "current_agent_handoff_gates": QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,
+    "current_agent_cleared_without_successor_handoff_gates": QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,
+}
 
 
 def summarize_user_todos_for_quota(
@@ -229,6 +292,107 @@ def summarize_user_todos_for_quota(
             for item in user_action_open_items[:TODO_VISIBILITY_LANE_LIMIT]
         ]
     return summary
+
+
+def _truncate_quota_payload_text(value: Any, *, limit: int) -> Any:
+    if not isinstance(value, str):
+        return value
+    text = value.strip()
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 3)].rstrip() + "..."
+
+
+def _compact_quota_payload_item(item: Any) -> Any:
+    if not isinstance(item, dict):
+        return item
+    compact: dict[str, Any] = {}
+    for key in QUOTA_PAYLOAD_ITEM_FIELDS:
+        value = item.get(key)
+        if value is None:
+            continue
+        if key == "text":
+            value = _truncate_quota_payload_text(
+                value,
+                limit=QUOTA_PAYLOAD_ITEM_TEXT_LIMIT,
+            )
+        compact[key] = value
+    if "text" not in compact and item.get("text") is not None:
+        compact["text"] = _truncate_quota_payload_text(
+            item.get("text"),
+            limit=QUOTA_PAYLOAD_ITEM_TEXT_LIMIT,
+        )
+    return compact
+
+
+def _compact_quota_payload_item_list(
+    items: Any,
+    *,
+    limit: int,
+) -> list[Any]:
+    if not isinstance(items, list):
+        return []
+    return [_compact_quota_payload_item(item) for item in items[:limit]]
+
+
+def _compact_quota_payload_claim_scope(value: Any) -> Any:
+    if not isinstance(value, dict):
+        return value
+    compact: dict[str, Any] = {}
+    for key, child in value.items():
+        if isinstance(child, list):
+            compact[key] = _compact_quota_payload_item_list(
+                child,
+                limit=QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,
+            )
+        else:
+            compact[key] = child
+    return compact
+
+
+def _compact_quota_payload_nested_warning(value: Any) -> Any:
+    if not isinstance(value, dict):
+        return value
+    compact: dict[str, Any] = {}
+    for key, child in value.items():
+        if isinstance(child, list) and key.endswith("items"):
+            compact[key] = _compact_quota_payload_item_list(
+                child,
+                limit=QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,
+            )
+        else:
+            compact[key] = child
+    return compact
+
+
+def compact_quota_todo_summary_for_payload(summary: dict[str, Any]) -> dict[str, Any]:
+    """Keep quota hot-path todo summaries bounded without changing decision input."""
+    compact: dict[str, Any] = {}
+    compacted_lanes: dict[str, dict[str, int]] = {}
+    for key, value in summary.items():
+        if isinstance(value, list):
+            limit = QUOTA_PAYLOAD_LANE_LIMITS.get(key, QUOTA_PAYLOAD_VISIBILITY_LANE_LIMIT)
+            compact[key] = _compact_quota_payload_item_list(value, limit=limit)
+            if len(value) > limit:
+                compacted_lanes[key] = {
+                    "shown": limit,
+                    "total": len(value),
+                }
+        elif key == "claim_scope":
+            compact[key] = _compact_quota_payload_claim_scope(value)
+        elif isinstance(value, dict):
+            compact[key] = _compact_quota_payload_nested_warning(value)
+        else:
+            compact[key] = value
+    compact["payload_compaction"] = {
+        "schema_version": QUOTA_PAYLOAD_COMPACTION_SCHEMA_VERSION,
+        "item_text_limit": QUOTA_PAYLOAD_ITEM_TEXT_LIMIT,
+        "visibility_lane_item_limit": QUOTA_PAYLOAD_VISIBILITY_LANE_LIMIT,
+        "diagnostic_lane_item_limit": QUOTA_PAYLOAD_DIAGNOSTIC_LANE_LIMIT,
+        "compacted_lanes": compacted_lanes,
+        "full_detail_cold_path": "status, todo list, or active state",
+    }
+    return compact
 
 
 def summarize_project_asset_todos_for_quota(

--- a/loopx/control_plane/work_items/work_lane.py
+++ b/loopx/control_plane/work_items/work_lane.py
@@ -12,6 +12,23 @@ WORK_LANE_CURRENT_AGENT_MONITOR_REPAIR_OBLIGATIONS = {
     "repair_resume_gate_or_close_standing_monitor",
 }
 WORK_LANE_TODO_MONITOR_DUE_KIND = "todo_monitor_due"
+WORK_LANE_TODO_ITEM_FIELDS = (
+    "index",
+    "text",
+    "todo_id",
+    "status",
+    "priority",
+    "task_class",
+    "action_kind",
+    "claimed_by",
+    "target_key",
+    "next_due_at",
+    "expires_at",
+    "resume_when",
+    "resume_ready",
+    "blocking_monitor_todo_id",
+    "result_hash",
+)
 PRIVATE_BOUNDARY_MONITOR_RESULT_HASHES = {
     "private_boundary_no_authorized_read",
 }
@@ -81,6 +98,26 @@ def work_lane_contract_is_due_monitor_attempt(
     )
 
 
+def _compact_work_lane_todo_item(item: dict[str, Any]) -> dict[str, Any]:
+    return {
+        key: item.get(key)
+        for key in WORK_LANE_TODO_ITEM_FIELDS
+        if item.get(key) is not None
+    }
+
+
+def _compact_work_lane_todo_items(
+    items: list[dict[str, Any]],
+    *,
+    limit: int,
+) -> list[dict[str, Any]]:
+    return [
+        _compact_work_lane_todo_item(item)
+        for item in items[:limit]
+        if isinstance(item, dict)
+    ]
+
+
 def build_work_lane_contract(
     *,
     progress_scope: str,
@@ -130,7 +167,10 @@ def build_work_lane_contract(
             "reason_codes": reason_codes,
             "monitor_policy": "attempt_due_monitor_once_then_writeback_or_no_spend_if_unchanged",
             "monitor_due_count": max(0, int(monitor_due_count)),
-            "monitor_due_items": due_monitor_items[:monitor_due_item_limit],
+            "monitor_due_items": _compact_work_lane_todo_items(
+                due_monitor_items,
+                limit=monitor_due_item_limit,
+            ),
             "selected_todo_id": selected.get("todo_id"),
             "selected_next_due_at": selected.get("next_due_at"),
             "action": (
@@ -209,7 +249,10 @@ def build_work_lane_contract(
                 "reason_codes": reason_codes,
                 "monitor_policy": "material_transition_only",
                 "resume_blocked_by_monitor_count": max(0, int(resume_blocked_by_monitor_count)),
-                "resume_blocked_by_monitor_items": blocked_by_monitor_items[:monitor_due_item_limit],
+                "resume_blocked_by_monitor_items": _compact_work_lane_todo_items(
+                    blocked_by_monitor_items,
+                    limit=monitor_due_item_limit,
+                ),
                 "selected_todo_id": selected.get("todo_id"),
                 "selected_resume_when": selected.get("resume_when"),
                 "action": (
@@ -250,7 +293,10 @@ def build_work_lane_contract(
                     ],
                     "monitor_policy": "repair_schedule_metadata_before_quiet_wait",
                     "monitor_schedule_gap_count": max(0, int(monitor_schedule_gap_count)),
-                    "monitor_schedule_gap_items": schedule_gap_items[:monitor_due_item_limit],
+                    "monitor_schedule_gap_items": _compact_work_lane_todo_items(
+                        schedule_gap_items,
+                        limit=monitor_due_item_limit,
+                    ),
                     "selected_todo_id": first_schedule_gap.get("todo_id"),
                     "action": (
                         "repair the selected continuous_monitor todo by adding cadence/"

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -171,6 +171,7 @@ from .control_plane.todos.projection import (
     todo_summary_claim_scope_agent_id as projection_todo_summary_claim_scope_agent_id,
 )
 from .control_plane.todos.quota_summary import (
+    compact_quota_todo_summary_for_payload,
     select_quota_todo_summary,
     summarize_user_todos_for_quota,
 )
@@ -1949,7 +1950,7 @@ def build_quota_should_run(
         if item.get("missing_gates"):
             payload["missing_gates"] = item.get("missing_gates")
         if user_todo_summary:
-            payload["user_todo_summary"] = user_todo_summary
+            payload["user_todo_summary"] = compact_quota_todo_summary_for_payload(user_todo_summary)
             repeat_open_todo_notification = (
                 heartbeat_recommendation.get("repeat_notification_required") is True
             )
@@ -2018,7 +2019,7 @@ def build_quota_should_run(
             or payload.get("notify_user_on_capability_gate") is True
         )
         if agent_todo_summary:
-            payload["agent_todo_summary"] = agent_todo_summary
+            payload["agent_todo_summary"] = compact_quota_todo_summary_for_payload(agent_todo_summary)
         if blocked_priority_fallback:
             payload["blocked_priority_fallback"] = blocked_priority_fallback
         attention_queue = status_payload.get("attention_queue") if isinstance(status_payload.get("attention_queue"), dict) else {}


### PR DESCRIPTION
## Summary

This PR keeps the `quota should-run` hot path smaller for long-lived goals with many active todos.

- Adds a quota-payload-only compaction layer for user/agent todo summaries.
- Preserves machine counts and representative lane items while trimming display-heavy todo fields.
- Compacts work-lane contract todo item projections so monitor/resume contracts do not leak display fields such as `title` or `handoff_note`.
- Adds focused smoke coverage for long todo-summary lanes and work-lane projection consistency.

## Observed Impact

On the active `loopx-meta` quota payload from this worktree:

- full payload: `144468` chars -> `60561` chars
- nested keys: `2417` -> `1166`
- `agent_todo_summary`: `100706` chars -> `21732` chars
- `user_todo_summary`: `9441` chars -> `4508` chars
- decision stayed `run`, `should_run=true`, `effective_action=normal_run`, selected todo stayed `todo_9ff8d317bb25`

Full detail remains available through the cold paths named in the payload compaction metadata: status, todo list, or active state.

## Changed Surfaces

- `loopx/control_plane/todos/quota_summary.py`
- `loopx/quota.py`
- `loopx/control_plane/work_items/work_lane.py`
- focused control-plane smoke tests

No benchmark adapter, runner, scoring, raw benchmark evidence, credentials, private state, or production action is included.

## Validation

Focused checks:

- `python3 examples/control_plane/quota-todo-summary-readmodel-smoke.py`
- `python3 examples/control_plane/quota-work-lane-policy-smoke.py`
- `python3 examples/control_plane/quota-action-scope-guard-smoke.py`
- `python3 examples/control_plane/quota-contract-smoke.py`
- `python3 examples/control_plane/hot-path-interface-budget-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 examples/control_plane/interaction-contract-state-machine-smoke.py`
- `python3 examples/control_plane/quota-heartbeat-recommendation-state-machine-smoke.py`
- `python3 examples/control_plane/control-plane-risk-characterization-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `python3 -m py_compile ...changed python files...`
- `./scripts/loopx check`

Premerge gate:

- `./scripts/loopx canary premerge --from-git-diff`
- Result: passed, selected `17`, failures `0`, advisory failures `0`, manual holds `0`
- Surfaces: `control_plane`, `public_boundary`, `python`
- Risk profiles: `core-control-plane`, `canary-runner`

## Coverage Rationale

The focused tests cover the new payload compaction rule, work-lane projection consistency, quota contract behavior, action-scope routing, interaction contract behavior, hot-path interface budget, and repository line budget. The premerge gate also selected catalog/risk-profile/public-boundary checks for the changed surfaces and passed cleanly.
