### PR TITLE
Use delivery action for accounted quota spends

### DIFF
--- a/examples/control_plane/quota-plan-smoke.py
+++ b/examples/control_plane/quota-plan-smoke.py
@@ -1195,6 +1195,59 @@ def assert_safe_bypass_slot_preview(status_payload: dict) -> None:
     assert payload["after"]["state"] == "operator_gate", payload
     assert payload["after"]["quota"]["spent_slots"] == payload["before"]["quota"]["spent_slots"] + 1, payload
 
+
+def assert_delivery_completion_spend_uses_delivery_action() -> None:
+    preview = {
+        "ok": True,
+        "goal_id": "delivery-completion",
+        "slots": 1,
+        "delivery_completion_spend": True,
+        "delivery_run_generated_at": "2026-01-01T00:00:00+00:00",
+        "delivery_run_classification": "state_refreshed",
+        "delivery_run_recommended_action": "Validated delivery action to account.",
+        "before": {
+            "ok": True,
+            "decision": "observe",
+            "should_run": False,
+            "state": "waiting",
+            "effective_action": "external_evidence_observe",
+            "quota": {
+                "compute": 1.0,
+                "window_hours": 24,
+                "slot_minutes": 1,
+                "allowed_slots": 1440,
+                "spent_slots": 3,
+                "state": "waiting",
+            },
+        },
+        "after": {
+            "ok": True,
+            "decision": "run",
+            "should_run": True,
+            "state": "eligible",
+            "effective_action": "normal_run",
+            "recommended_action": "Next guard action should not label the spend event.",
+            "quota": {
+                "compute": 1.0,
+                "window_hours": 24,
+                "slot_minutes": 1,
+                "allowed_slots": 1440,
+                "spent_slots": 4,
+                "state": "eligible",
+            },
+        },
+    }
+
+    spend_event = build_quota_slot_spend_event(preview, source="heartbeat")
+
+    assert spend_event["recommended_action"] == "Validated delivery action to account.", spend_event
+    assert spend_event["quota_event"]["delivery_run_recommended_action"] == (
+        "Validated delivery action to account."
+    ), spend_event
+    assert spend_event["quota_event"]["delivery_run_classification"] == "state_refreshed", spend_event
+    assert "validated delivery completion" in spend_event["health_check"], spend_event
+
+
 def main() -> int:
     assert_default_quota_is_duty_cycle()
     assert_rolling_window_ledger_expires_old_spends()
@@ -1220,6 +1273,7 @@ def main() -> int:
     assert_goal_boundary_in_should_run()
     assert_decision_freshness_warning_in_should_run()
     assert_safe_bypass_slot_preview(status_payload)
+    assert_delivery_completion_spend_uses_delivery_action()
     assert_quota_void_event_net_ledger()
     assert_slot_preview(build_quota_slot_preview(status_payload, goal_id="near-limit-half", slots=1))
     with tempfile.TemporaryDirectory(prefix="loopx-quota-plan-smoke-") as tmp:

--- a/loopx/control_plane/quota/slot_accounting.py
+++ b/loopx/control_plane/quota/slot_accounting.py
@@ -279,6 +279,9 @@ def build_quota_slot_preview_for_decision(
         "delivery_run_classification": delivery_completion_run.get("classification")
         if delivery_completion_run
         else None,
+        "delivery_run_recommended_action": delivery_completion_run.get("recommended_action")
+        if delivery_completion_run
+        else None,
     }
 
 
@@ -343,11 +346,16 @@ def build_quota_slot_spend_event(
             "capability bridge repair, or latest validated delivery-completion quota should-run decision"
         )
 
+    delivery_run_action = str(preview.get("delivery_run_recommended_action") or "").strip()
     record = {
         "generated_at": generated_at or _now_local(),
         "goal_id": preview.get("goal_id"),
         "classification": QUOTA_SLOT_SPENT_CLASSIFICATION,
-        "recommended_action": after.get("recommended_action") or "inspect next quota should-run decision",
+        "recommended_action": (
+            delivery_run_action
+            if delivery_completion_spend and delivery_run_action
+            else after.get("recommended_action") or "inspect next quota should-run decision"
+        ),
         "health_check": (
             "quota should-run eligible; quota slot spend event public-safe"
             if eligible_spend
@@ -400,6 +408,9 @@ def build_quota_slot_spend_event(
             else None,
             "delivery_run_classification": preview.get("delivery_run_classification")
             if delivery_completion_spend
+            else None,
+            "delivery_run_recommended_action": delivery_run_action
+            if delivery_completion_spend and delivery_run_action
             else None,
             "before": before_compact,
             "after": after_compact,


### PR DESCRIPTION
## Summary
- Preserve the accounted delivery run's `recommended_action` on delivery-completion `quota_slot_spent` records.
- Keep ordinary eligible/safe-bypass quota spend records using the post-spend decision action.
- Add a focused quota-plan regression so accounting events do not inherit an unrelated next guard action.

## Validation
- `python3 -m py_compile loopx/control_plane/quota/slot_accounting.py examples/control_plane/quota-plan-smoke.py`
- `python3 examples/control_plane/quota-plan-smoke.py`
- `python3 examples/control_plane/quota-contract-smoke.py`
- `python3 examples/control_plane/heartbeat-quota-flow-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `python3 examples/control_plane/check-public-boundary-smoke.py`
- `./scripts/loopx check`
- `./scripts/loopx canary premerge --from-git-diff` passed: standard tier, 13 selected checks, 0 failures, 0 manual holds
