### PR TITLE
Compact run-history boundary authority projection

### DIFF
--- a/examples/control_plane/run-history-readmodel-smoke.py
+++ b/examples/control_plane/run-history-readmodel-smoke.py
@@ -12,6 +12,10 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx import status as status_module  # noqa: E402
+from loopx.boundary_authority import (  # noqa: E402
+    CHECKPOINTED_BOUNDARY_AUTHORITY_SCHEMA_VERSION,
+    checkpointed_boundary_authority_summary,
+)
 from loopx.control_plane.runtime import run_history as run_history_read_model  # noqa: E402
 
 
@@ -35,8 +39,16 @@ def direct_history(history: dict, *, display_limit: int | None = None) -> dict:
 
 
 def assert_parity(history: dict, *, display_limit: int | None = None) -> dict:
-    wrapper = status_module.build_run_history(history, display_limit=display_limit)
-    direct = direct_history(history, display_limit=display_limit)
+    effective_display_limit = 999 if display_limit is None else display_limit
+    wrapper = status_module.build_status_runtime_summaries(
+        history=history,
+        queue={},
+        runtime_root=REPO_ROOT,
+        goal_id_filter=None,
+        display_limit=effective_display_limit,
+        todo_index_limit=5,
+    )["run_history"]
+    direct = direct_history(history, display_limit=effective_display_limit)
     assert direct == wrapper, (direct, wrapper)
     return wrapper
 
@@ -73,7 +85,29 @@ def main() -> None:
                 "legacy_runtime_goal": False,
                 "adapter_kind": "harness_self_improvement",
                 "adapter_status": "connected-read-only",
-                "coordination": {"primary_agent": "codex-main-control"},
+                "coordination": {
+                    "primary_agent": "codex-main-control",
+                    "registered_agents": ["codex-main-control", "codex-product-capability"],
+                    "side_agent_handoff_agent": "codex-product-capability",
+                    "checkpointed_boundary_authority": [
+                        {
+                            "status": "active",
+                            "decision": "approve",
+                            "write_scope": ["loopx/**"],
+                            "source": "operator-approved product capability lane",
+                            "decision_id": "gate-approved",
+                            "recorded_at": "2026-07-04T00:04:00+00:00",
+                        },
+                        {
+                            "status": "inactive",
+                            "decision": "defer",
+                            "write_scope": ["docs/**"],
+                            "source": "deferred docs lane",
+                            "decision_id": "gate-deferred",
+                            "recorded_at": "2026-07-04T00:04:30+00:00",
+                        },
+                    ],
+                },
                 "guards": [{"kind": "private_boundary"}],
                 "next_probe": "continue",
                 "authority_registry": {"present": True},
@@ -171,7 +205,21 @@ def main() -> None:
 
     meta = full["goals"][0]
     assert meta["quota"] is not None, meta
-    assert meta["coordination"] == {"primary_agent": "codex-main-control"}, meta
+    assert meta["coordination"]["primary_agent"] == "codex-main-control", meta
+    assert meta["coordination"]["registered_agents"] == [
+        "codex-main-control",
+        "codex-product-capability",
+    ], meta
+    boundary_authority = meta["coordination"]["checkpointed_boundary_authority"]
+    assert boundary_authority == {
+        "schema_version": CHECKPOINTED_BOUNDARY_AUTHORITY_SCHEMA_VERSION,
+        "active_count": 1,
+        "inactive_count": 1,
+        "active_write_scope": ["loopx/**"],
+    }, meta
+    assert checkpointed_boundary_authority_summary(meta["coordination"]) == boundary_authority, meta
+    assert "entries" not in boundary_authority, meta
+    assert "gate-approved" not in str(meta["coordination"]), meta
     assert meta["guards"] == [{"kind": "private_boundary"}], meta
     assert meta["latest_status_run"]["human_reward"]["lesson"] == {
         "schema_version": "lesson_v0",

--- a/loopx/boundary_authority.py
+++ b/loopx/boundary_authority.py
@@ -149,11 +149,38 @@ def normalize_checkpointed_boundary_authority_entries(
     return entries
 
 
+def _compact_checkpointed_boundary_authority_summary(value: Any) -> dict[str, Any] | None:
+    if not isinstance(value, dict):
+        return None
+
+    def _count(raw: Any) -> int:
+        try:
+            return max(0, int(raw or 0))
+        except (TypeError, ValueError):
+            return 0
+
+    active_scopes = normalize_required_write_scopes(value.get("active_write_scope"))
+    if not active_scopes and "active_count" not in value and "inactive_count" not in value:
+        return None
+    return {
+        "schema_version": CHECKPOINTED_BOUNDARY_AUTHORITY_SCHEMA_VERSION,
+        "active_count": _count(value.get("active_count")),
+        "inactive_count": _count(value.get("inactive_count")),
+        "active_write_scope": active_scopes,
+    }
+
+
 def checkpointed_boundary_authority_summary(coordination: dict[str, Any] | None) -> dict[str, Any] | None:
     if not isinstance(coordination, dict):
         return None
+    checkpointed_authority = coordination.get("checkpointed_boundary_authority")
+    if isinstance(checkpointed_authority, dict):
+        compact_summary = _compact_checkpointed_boundary_authority_summary(checkpointed_authority)
+        if compact_summary is not None and "entries" not in checkpointed_authority:
+            return compact_summary
+        checkpointed_authority = checkpointed_authority.get("entries")
     entries = normalize_checkpointed_boundary_authority_entries(
-        coordination.get("checkpointed_boundary_authority")
+        checkpointed_authority
     )
     if not entries:
         return None

--- a/loopx/control_plane/runtime/run_history.py
+++ b/loopx/control_plane/runtime/run_history.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any, Callable, Optional
 
+from ...boundary_authority import checkpointed_boundary_authority_summary
+
 
 LatestRun = Callable[[dict[str, Any]], Optional[dict[str, Any]]]
 GoalLifecycleFields = Callable[[dict[str, Any], Optional[dict[str, Any]]], dict[str, Any]]
@@ -30,6 +32,22 @@ def latest_run(
             continue
         return run
     return None
+
+
+def compact_goal_coordination(coordination: Any) -> dict[str, Any] | None:
+    if not isinstance(coordination, dict):
+        return None
+    compact = dict(coordination)
+    authority_summary = checkpointed_boundary_authority_summary(coordination)
+    if authority_summary is not None:
+        compact["checkpointed_boundary_authority"] = {
+            key: value
+            for key, value in authority_summary.items()
+            if key != "entries"
+        }
+    elif "checkpointed_boundary_authority" in compact:
+        compact.pop("checkpointed_boundary_authority", None)
+    return compact
 
 
 def build_run_history(
@@ -68,7 +86,7 @@ def build_run_history(
                 "legacy_runtime_goal": goal.get("legacy_runtime_goal"),
                 "adapter_kind": goal.get("adapter_kind"),
                 "adapter_status": goal.get("adapter_status"),
-                "coordination": goal.get("coordination") if isinstance(goal.get("coordination"), dict) else None,
+                "coordination": compact_goal_coordination(goal.get("coordination")),
                 "guards": goal.get("guards") if isinstance(goal.get("guards"), list) else [],
                 "next_probe": goal.get("next_probe"),
                 "authority_registry": goal.get("authority_registry"),


### PR DESCRIPTION
## Summary
- compact run-history goal coordination by replacing verbose checkpointed boundary authority entries with a count/scope summary
- let boundary authority summary consumers accept the compact projection form so quota/status can still recover active write scopes
- update the run-history read-model smoke to use the current status runtime summary facade and cover compact boundary authority projection

## Validation
- python3 -m py_compile loopx/boundary_authority.py loopx/control_plane/runtime/run_history.py examples/control_plane/run-history-readmodel-smoke.py
- python3 examples/control_plane/run-history-readmodel-smoke.py
- python3 examples/control_plane/status-runtime-summaries-readmodel-smoke.py
- python3 examples/control_plane/status-quota-review-packet-parity-smoke.py
- python3 examples/control_plane/agent-identity-readmodel-smoke.py
- python3 examples/control_plane/quota-contract-smoke.py
- python3 examples/control_plane/hot-path-interface-budget-smoke.py
- python3 examples/control_plane/repo-python-line-budget-smoke.py
- python3 examples/control_plane/check-public-boundary-smoke.py
- ./scripts/loopx check
- ./scripts/loopx canary premerge --from-git-diff

## Notes
- actual loopx-meta status projection keeps registered_agents/primary_agent and emits checkpointed_boundary_authority without entries; observed coordination payload dropped to 638 chars while preserving active_write_scope.