### PR TITLE
Compact project asset todo display rows

### DIFF
--- a/examples/control_plane/todo-first-open-summary-smoke.py
+++ b/examples/control_plane/todo-first-open-summary-smoke.py
@@ -346,7 +346,11 @@ def assert_claimed_frontstage_lanes_visible() -> None:
     }
     decision = build_quota_should_run(status_payload, goal_id=GOAL_ID, agent_id="codex-side-bypass")
     summary = decision["agent_todo_summary"]
-    assert [item["index"] for item in summary["unclaimed_priority_open_items"]] == list(range(1, 9)), summary
+    assert [item["index"] for item in summary["unclaimed_priority_open_items"]] == [1, 2], summary
+    assert summary["payload_compaction"]["compacted_lanes"]["unclaimed_priority_open_items"] == {
+        "shown": 2,
+        "total": 8,
+    }, summary
     assert [item["index"] for item in summary["claimed_open_items"]] == [40, 41], summary
     assert [item["index"] for item in summary["current_agent_claimed_open_items"]] == [40, 41], summary
     assert [item["index"] for item in summary["current_agent_claimed_advancement_items"]] == [40], summary
@@ -676,6 +680,31 @@ def main() -> int:
     assert asset_summary["items"][0]["priority"] == "P0", asset_summary
     assert asset_summary["items"][0]["status"] == "open", asset_summary
     assert asset_summary["items"][0]["todo_id"] == agent_todos["first_open_items"][0]["todo_id"], asset_summary
+    verbose_group = dict(agent_todos)
+    verbose_first = dict(agent_todos["first_open_items"][0])
+    verbose_first.update(
+        {
+            "note": "implementation detail that belongs in the full todo read model",
+            "evidence": "validation evidence that should stay out of project_asset overview rows",
+            "reason": "selection rationale that should not bloat display sinks",
+            "handoff_note": {"summary": "handoff detail for cold-path inspection"},
+            "required_write_scopes": ["state"],
+            "successor_todo_ids": ["todo_successor"],
+        }
+    )
+    verbose_group["first_open_items"] = [
+        verbose_first,
+        *agent_todos["first_open_items"][1:],
+    ]
+    verbose_asset_summary = project_asset_todo_summary(verbose_group, role="agent")
+    assert verbose_asset_summary is not None, verbose_group
+    verbose_item = verbose_asset_summary["items"][0]
+    assert verbose_item["todo_id"] == verbose_first["todo_id"], verbose_asset_summary
+    assert verbose_item["priority"] == "P0", verbose_asset_summary
+    assert verbose_item["required_write_scopes"] == ["state"], verbose_asset_summary
+    assert verbose_item["successor_todo_ids"] == ["todo_successor"], verbose_asset_summary
+    for verbose_key in ("note", "evidence", "reason", "handoff_note"):
+        assert verbose_key not in verbose_item, verbose_asset_summary
 
     attention_item = {
         "goal_id": GOAL_ID,
@@ -733,13 +762,21 @@ def main() -> int:
     assert agent_summary["first_open_items"][0]["status"] == "open", decision
     assert agent_summary["first_open_items"][0]["todo_id"] == agent_todos["first_open_items"][0]["todo_id"], decision
     assert [item["index"] for item in agent_summary["first_open_items"]] == [17, 14, 15], decision
-    assert [item["index"] for item in agent_summary["backlog_items"]] == [17, 14, 15, 16], decision
-    assert [item["index"] for item in agent_summary["executable_backlog_items"]] == [17, 14, 15, 16], decision
+    assert [item["index"] for item in agent_summary["backlog_items"]] == [17, 14], decision
+    assert [item["index"] for item in agent_summary["executable_backlog_items"]] == [17, 14], decision
+    assert agent_summary["payload_compaction"]["compacted_lanes"]["backlog_items"] == {
+        "shown": 2,
+        "total": 4,
+    }, decision
+    assert agent_summary["payload_compaction"]["compacted_lanes"]["executable_backlog_items"] == {
+        "shown": 2,
+        "total": 4,
+    }, decision
     markdown = render_quota_should_run_markdown(decision)
     assert f"agent_todo_next[17]: {APPENDED_P0_TODO}" in markdown, markdown
     assert f"agent_todo_next[14]: {OPEN_TODO}" in markdown, markdown
     assert f"agent_todo_next[15]: {SECOND_OPEN_TODO}" in markdown, markdown
-    assert f"agent_todo_backlog[16]: {THIRD_OPEN_TODO}" in markdown, markdown
+    assert f"agent_todo_backlog[16]: {THIRD_OPEN_TODO}" not in markdown, markdown
     packet = build_review_packet(status_payload, goal_id=GOAL_ID, action_kind="codex")
     assert packet["agent_todo_items"] == [
         APPENDED_P0_TODO,

--- a/loopx/control_plane/work_items/project_asset.py
+++ b/loopx/control_plane/work_items/project_asset.py
@@ -455,6 +455,75 @@ def project_asset_todo_projection_gap(
     }
 
 
+PROJECT_ASSET_TODO_DISPLAY_FIELDS = (
+    "index",
+    "done",
+    "schema_version",
+    "todo_id",
+    "role",
+    "status",
+    "priority",
+    "archive_state",
+    "source_section",
+    "task_class",
+    "action_kind",
+    "required_write_scopes",
+    "required_capabilities",
+    "target_capabilities",
+    "decision_scope",
+    "required_decision_scopes",
+    "claimed_by",
+    "blocks_agent",
+    "global_gate",
+    "unblocks_todo_id",
+    "resume_when",
+    "resume_condition",
+    "resume_ready",
+    "blocking_monitor_todo_id",
+    "no_followup",
+    "successor_todo_ids",
+    "target_key",
+    "cadence",
+    "next_due_at",
+    "expires_at",
+    "last_checked_at",
+    "result_hash",
+    "consecutive_no_change",
+    "material_change",
+    "max_no_change_before_replan",
+    "route_continuation_replan_required",
+    "route_continuation_reason",
+    "route_id",
+    "route_key",
+    "completed_at",
+    "updated_at",
+    "superseded_by",
+)
+
+
+def _project_asset_display_todo_item(item: dict[str, Any]) -> dict[str, Any]:
+    display = {
+        key: item.get(key)
+        for key in PROJECT_ASSET_TODO_DISPLAY_FIELDS
+        if item.get(key) is not None
+    }
+    text = _compact_text(str(item.get("text") or ""), limit=220)
+    if text:
+        display["text"] = text
+    title = _compact_text(str(item.get("title") or ""), limit=220)
+    if title:
+        display["title"] = title
+    return display
+
+
+def _project_asset_display_todo_items(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [
+        _project_asset_display_todo_item(item)
+        for item in items
+        if isinstance(item, dict)
+    ]
+
+
 def build_project_asset_todo_summary(
     todos: dict[str, Any] | None,
     *,
@@ -506,6 +575,7 @@ def build_project_asset_todo_summary(
             "unclaimed_open_count",
             max(0, int(summary.get("open") or 0) - int(summary["claimed_open_count"] or 0)),
         )
+    open_items = _project_asset_display_todo_items(open_items)
     if open_items:
         summary["items"] = open_items
         summary["next"] = open_items[0]["text"]
@@ -517,12 +587,12 @@ def build_project_asset_todo_summary(
     if isinstance(monitor_writeback, dict):
         summary["monitor_writeback"] = dict(monitor_writeback)
     deferred_items = [
-        compact_todo_item(item)
+        _project_asset_display_todo_item(compact_todo_item(item))
         for item in todos.get("deferred_items", [])
         if isinstance(item, dict)
     ][:deferred_item_limit]
     deferred_resume_candidates = [
-        compact_todo_item(item)
+        _project_asset_display_todo_item(compact_todo_item(item))
         for item in todos.get("deferred_resume_candidates", [])
         if isinstance(item, dict)
     ][:deferred_item_limit]
@@ -544,7 +614,9 @@ def build_project_asset_todo_summary(
         if todo_item_task_class(item) == advancement_task_class
     ]
     if executable_items:
-        summary["first_executable_items"] = executable_items[:item_limit]
+        summary["first_executable_items"] = _project_asset_display_todo_items(
+            executable_items[:item_limit]
+        )
     for lane in (
         "gate_open_items",
         "current_agent_claimed_open_items",
@@ -557,7 +629,7 @@ def build_project_asset_todo_summary(
             limit=item_limit,
         )
         if lane_items:
-            summary[lane] = lane_items
+            summary[lane] = _project_asset_display_todo_items(lane_items)
     for count_key in (
         "claimed_advancement_open_count",
         "claimed_monitor_open_count",


### PR DESCRIPTION
## Summary
- Compact project_asset todo overview rows with a display-only whitelist so verbose note/evidence/reason/handoff fields stay in cold-path todo read models instead of first-screen status payloads.
- Keep routing/control fields such as todo_id, priority, status, claims, scopes, successor ids, monitor cadence, and route keys available for display sinks.
- Refresh the todo first-open smoke to assert quota hot-path compaction through payload_compaction totals and to guard project_asset display-row trimming.

## Validation
- python3 -m py_compile loopx/control_plane/work_items/project_asset.py examples/control_plane/todo-first-open-summary-smoke.py
- python3 examples/control_plane/todo-first-open-summary-smoke.py
- python3 examples/control_plane/quota-action-scope-guard-smoke.py
- python3 examples/control_plane/runtime-handoff-status-read-path-smoke.py
- python3 examples/control_plane/status-markdown-smoke.py
- python3 examples/control_plane/hot-path-interface-budget-smoke.py
- python3 examples/control_plane/status-quota-review-packet-parity-smoke.py
- python3 examples/control_plane/check-public-boundary-smoke.py
- ./scripts/loopx check
- ./scripts/loopx canary premerge --from-git-diff

## Size Check
Using loopx-meta status before/after from the product-capability worktree:
- attention_queue: 201955 -> 198596 (-3359)
- project_asset: 15835 -> 12482 (-3353)
- project_asset.agent_todos: 8431 -> 6501 (-1930)
- project_asset.user_todos: 3642 -> 2219 (-1423)
- run_history unchanged: 16645 -> 16645

## Self-Merge Gate
Small, focused control-plane projection cleanup plus smoke refresh. No benchmark runner/scoring/task semantics, raw benchmark evidence, credentials, private paths, or production actions. Premerge canary passed with manual_holds=0 and self_merge_allowed=true.