### PR TITLE
Flag zero-headroom interface budget checks

### DIFF
--- a/docs/interface-budget-contract.md
+++ b/docs/interface-budget-contract.md
@@ -66,12 +66,15 @@ Stable cadence fields:
   `headroom_remaining`: compact headroom evidence for the tightest observed
   surface.
 - `recommendation`: either `quiet_skip_until_next_check_due` or
-  `rerun_hot_path_interface_budget_smoke`.
+  `rerun_hot_path_interface_budget_smoke`. Fresh checks only quiet-skip when
+  every surface is within budget and the tightest metric still has positive
+  headroom; a zero-headroom surface is already at the compatibility edge and
+  should rerun the smoke before more hot-path growth is accepted.
 
 Do not add a heartbeat prompt branch for this cadence. Store exact measurements
 in run history, project only this compact decision summary, and rerun the smoke
-when `overdue=true` or when a prompt/status/quota/review-packet/dashboard
-contract changes.
+when `overdue=true`, when `headroom_remaining <= 0`, or when a
+prompt/status/quota/review-packet/dashboard contract changes.
 
 Scheduler reset policy budget:
 

--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -488,8 +488,9 @@ selected goal, `quota should-run` also mirrors the same object at top level as
 This field is a restraint signal for heartbeat workers, not a dashboard feature
 request. It records the latest clean hot-path budget check, the tightest
 headroom observed, and when the next check is due. Fresh clean checks can
-support a quiet skip for the ongoing interface-budget guard; overdue or
-out-of-budget checks should prompt `python3
+support a quiet skip for the ongoing interface-budget guard only while the
+tightest metric still has positive headroom; overdue, out-of-budget, or
+zero-headroom checks should prompt `python3
 examples/control_plane/hot-path-interface-budget-smoke.py` or an equivalent explicit
 drift-check run.
 

--- a/examples/control_plane/hot-path-interface-budget-smoke.py
+++ b/examples/control_plane/hot-path-interface-budget-smoke.py
@@ -260,7 +260,8 @@ def assert_cadence_projection(
     assert projected["overdue"] is False, projected
     assert projected["within_budget"] is True, projected
     assert projected["next_check_due_at"] == "2099-01-02T00:10:00+00:00", projected
-    assert projected["recommendation"] == "quiet_skip_until_next_check_due", projected
+    assert projected["headroom_remaining"] == 0, projected
+    assert projected["recommendation"] == "rerun_hot_path_interface_budget_smoke", projected
 
     quota_payload = build_quota_should_run(status_payload, goal_id=GOAL_ID)
     assert quota_payload["should_run"] is True, quota_payload
@@ -316,6 +317,26 @@ def main() -> int:
         assert cadence["surface_count"] == len(summaries), cadence
         assert cadence["next_check_due_at"] == "2099-01-02T00:10:00+00:00", cadence
         assert cadence["minimum_headroom_ratio"] is not None, cadence
+        assert cadence["headroom_remaining"] == 0, cadence
+        assert cadence["recommendation"] == "rerun_hot_path_interface_budget_smoke", cadence
+        relaxed_summaries = [dict(summary) for summary in summaries]
+        for summary in relaxed_summaries:
+            if summary["json_chars"] == summary["max_json_chars"]:
+                summary["max_json_chars"] = summary["json_chars"] + 1
+            if summary["nested_keys"] == summary["max_nested_keys"]:
+                summary["max_nested_keys"] = summary["nested_keys"] + 1
+            if summary["top_level_keys"] == summary["max_top_level_keys"]:
+                summary["max_top_level_keys"] = summary["top_level_keys"] + 1
+        relaxed_cadence = build_interface_budget_cadence(
+            relaxed_summaries,
+            checked_at="2099-01-01T00:10:00+00:00",
+            now="2099-01-01T01:00:00+00:00",
+            freshness_hours=24,
+        )
+        assert relaxed_cadence["within_budget"] is True, relaxed_cadence
+        assert relaxed_cadence["overdue"] is False, relaxed_cadence
+        assert relaxed_cadence["headroom_remaining"] > 0, relaxed_cadence
+        assert relaxed_cadence["recommendation"] == "quiet_skip_until_next_check_due", relaxed_cadence
         stale_cadence = build_interface_budget_cadence(
             summaries,
             checked_at="2099-01-01T00:10:00+00:00",

--- a/loopx/interface_budget.py
+++ b/loopx/interface_budget.py
@@ -93,9 +93,11 @@ def build_interface_budget_cadence(
     )
     overdue = bool(next_due_dt and now_dt and now_dt >= next_due_dt)
     within_budget = bool(headrooms) and all(item.get("within_budget") is True for item in headrooms)
+    headroom_remaining = _number(tightest.get("headroom_remaining")) if tightest else None
+    headroom_exhausted = headroom_remaining is not None and headroom_remaining <= 0
     recommendation = (
         "quiet_skip_until_next_check_due"
-        if within_budget and not overdue
+        if within_budget and not overdue and not headroom_exhausted
         else "rerun_hot_path_interface_budget_smoke"
     )
     return {
@@ -128,8 +130,10 @@ def compact_interface_budget_cadence(
     now_dt = parse_timestamp(now) if now is not None else datetime.now(timezone.utc)
     overdue = bool(next_due_dt and now_dt and now_dt >= next_due_dt)
     within_budget = value.get("within_budget") is True
+    headroom_remaining = _number(value.get("headroom_remaining"))
+    headroom_exhausted = headroom_remaining is not None and headroom_remaining <= 0
     recommendation = str(value.get("recommendation") or "").strip()
-    if within_budget and not overdue:
+    if within_budget and not overdue and not headroom_exhausted:
         recommendation = recommendation or "quiet_skip_until_next_check_due"
     else:
         recommendation = recommendation or "rerun_hot_path_interface_budget_smoke"


### PR DESCRIPTION
## Summary
- Treat interface-budget checks with zero remaining headroom as a rerun signal instead of a quiet-skip, even when every surface is technically within budget.
- Preserve the existing compact cadence shape; this changes only recommendation semantics and adds no new hot-path fields.
- Extend the hot-path smoke with both zero-headroom and positive-headroom assertions, then update public contract docs.

## Validation
- python3 -m py_compile loopx/interface_budget.py examples/control_plane/hot-path-interface-budget-smoke.py
- python3 examples/control_plane/hot-path-interface-budget-smoke.py
- python3 examples/control_plane/status-markdown-smoke.py
- python3 examples/control_plane/status-quota-review-packet-parity-smoke.py
- python3 examples/control_plane/check-public-boundary-smoke.py
- ./scripts/loopx check
- ./scripts/loopx canary premerge --from-git-diff

## Self-Merge Gate
Small, focused control-plane cadence/test/docs contract update. No benchmark runner/scoring/task semantics, no production actions, and no private state or raw benchmark evidence. Premerge canary passed with manual_holds=0 and self_merge_allowed=true.