### PR TITLE
Cap monitor wait heartbeat backoff at 60m

### DIFF
--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -738,7 +738,7 @@ After a successful host RRULE update, the agent records that fact with
 advances the per goal/agent scheduler state without spending quota. Human gates
 can move to `[30, 60, 120]` after the
 concrete user todo has been surfaced.
-Monitor-only quiet waits move through `[15, 30, 60, 120]` while preserving the
+Monitor-only quiet waits move through `[15, 30, 60]` while preserving the
 same no-spend monitor-poll contract, unless a monitor cadence or due time caps
 the progression earlier.
 Agent-scope waits use a more conservative adjustment curve such as

--- a/examples/control_plane/monitor-scheduler-contract-smoke.py
+++ b/examples/control_plane/monitor-scheduler-contract-smoke.py
@@ -229,7 +229,7 @@ def assert_not_due_monitor_scheduler_applies_host_floor_before_cadence() -> None
     assert guard["effective_action"] == "monitor_quiet_skip", guard
     assert scheduler["cadence_class"] == "monitor_wait", scheduler
     assert codex_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=15", scheduler
-    assert codex_app["example_progression_minutes"] == [15, 30, 60, 120], scheduler
+    assert codex_app["example_progression_minutes"] == [15, 30, 60], scheduler
     assert stateful["current_rrule"] == "FREQ=MINUTELY;INTERVAL=15", scheduler
 
 
@@ -254,7 +254,7 @@ def assert_monitor_scheduler_far_window_uses_coarse_backoff() -> None:
     assert guard["effective_action"] == "monitor_quiet_skip", guard
     assert context["phase"] == "far_window", context
     assert context["cap_minutes"] == 90, context
-    assert codex_app["example_progression_minutes"] == [15, 30, 60, 90], scheduler
+    assert codex_app["example_progression_minutes"] == [15, 30, 60], scheduler
     assert codex_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=15", scheduler
 
 
@@ -280,7 +280,7 @@ def assert_monitor_scheduler_near_window_caps_without_breaking_floor() -> None:
     assert context["phase"] == "near_window", context
     assert context["host_floor_minutes"] == 15, context
     assert context["cap_minutes"] == 37, context
-    assert codex_app["example_progression_minutes"] == [15, 30, 37, 37], scheduler
+    assert codex_app["example_progression_minutes"] == [15, 30, 37], scheduler
 
 
 def assert_monitor_scheduler_near_window_reset_identity_is_stable() -> None:
@@ -342,7 +342,7 @@ def assert_monitor_scheduler_active_window_respects_host_floor() -> None:
     assert context["phase"] == "active_window", context
     assert context["cadence_minutes"] == 3, context
     assert context["host_floor_minutes"] == 15, context
-    assert codex_app["example_progression_minutes"] == [15, 15, 15, 15], scheduler
+    assert codex_app["example_progression_minutes"] == [15, 15, 15], scheduler
     assert codex_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=15", scheduler
 
 
@@ -459,7 +459,7 @@ def assert_expired_monitor_does_not_catch_up() -> None:
     assert context["phase"] == "expired", context
     assert context["expired_monitor_count"] == 1, context
     assert codex_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=15", scheduler
-    assert codex_app["example_progression_minutes"] == [15, 30, 60, 120], scheduler
+    assert codex_app["example_progression_minutes"] == [15, 30, 60], scheduler
 
 
 def assert_due_monitor_priority_does_not_steal_advancement_lane() -> None:

--- a/examples/control_plane/quota-agent-scoped-user-gate-smoke.py
+++ b/examples/control_plane/quota-agent-scoped-user-gate-smoke.py
@@ -694,7 +694,7 @@ def assert_agent_without_advancement_candidate_and_only_monitor_work_stays_quiet
     # A far-future monitor keeps the host floor at 15m, but may back off more
     # coarsely until the scheduled window gets near.
     progression = scheduler["codex_app"]["example_progression_minutes"]
-    assert progression == [15, 30, 60, 120], scheduler
+    assert progression == [15, 30, 60], scheduler
     assert scheduler["unchanged_poll"]["limits"]["codex_cli_tui"] == 3, scheduler
     assert scheduler["unchanged_poll"]["final_quota_replan_check_enabled"] is True, scheduler
     assert scheduler["unchanged_poll"]["after_limits"]["claude_code_loop"] == "stop_loop", scheduler
@@ -708,7 +708,7 @@ def assert_agent_without_advancement_candidate_and_only_monitor_work_stays_quiet
     assert reset["host_state_key"] == "scheduler_hint.reset_policy.reset_token", reset
     assert reset["codex_app_initial_interval_minutes"] == 15, reset
     assert reset["codex_app_initial_rrule"] == "FREQ=MINUTELY;INTERVAL=15", reset
-    assert scheduler["codex_app"]["max_interval_minutes"] == 120, scheduler
+    assert scheduler["codex_app"]["max_interval_minutes"] == 60, scheduler
     assert len(reset["identity_signature"]) == 12, reset
     assert "identity_snapshot" not in reset, reset
     assert "profile_snapshot" not in reset, reset

--- a/examples/control_plane/quota-scheduler-policy-smoke.py
+++ b/examples/control_plane/quota-scheduler-policy-smoke.py
@@ -203,7 +203,7 @@ def main() -> int:
         ),
         expected_action="backoff_until_material_transition",
         expected_rrule="FREQ=MINUTELY;INTERVAL=15",
-        expected_progression=[15, 30, 60, 120],
+        expected_progression=[15, 30, 60],
     )
     assert_policy_case(
         "quiet-wait",

--- a/examples/control_plane/quota-scheduler-state-ack-smoke.py
+++ b/examples/control_plane/quota-scheduler-state-ack-smoke.py
@@ -246,14 +246,14 @@ def assert_policy_state_progression() -> None:
     assert reset["codex_app"]["stateful_backoff"]["state_status"] == "reset_required", reset
 
 
-def assert_monitor_wait_progression_reaches_120() -> None:
+def assert_monitor_wait_progression_caps_at_60() -> None:
     base = monitor_payload()
     first = build_scheduler_hint(
         deepcopy(base),
         agent_scope_frontier_actions=AGENT_SCOPE_ACTIONS,
     )
     assert first["action"] == "backoff_until_material_transition", first
-    assert first["codex_app"]["example_progression_minutes"] == [15, 30, 60, 120], first
+    assert first["codex_app"]["example_progression_minutes"] == [15, 30, 60], first
     assert first["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=15", first
 
     second = build_scheduler_hint(
@@ -270,21 +270,15 @@ def assert_monitor_wait_progression_reaches_120() -> None:
     )
     assert third["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=60", third
 
-    fourth = build_scheduler_hint(
+    steady = build_scheduler_hint(
         deepcopy(base),
         agent_scope_frontier_actions=AGENT_SCOPE_ACTIONS,
         codex_app_scheduler_state=state_from(third),
     )
-    assert fourth["codex_app"]["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=120", fourth
-
-    quiet = build_scheduler_hint(
-        deepcopy(base),
-        agent_scope_frontier_actions=AGENT_SCOPE_ACTIONS,
-        codex_app_scheduler_state=state_from(fourth),
-    )
-    assert quiet["codex_app"]["stateful_backoff"]["apply_needed"] is False, quiet
-    assert quiet["codex_app"]["host_action"] == "none", quiet
-    assert "recommended_rrule" not in quiet["codex_app"], quiet
+    assert steady["codex_app"]["stateful_backoff"]["apply_needed"] is False, steady
+    assert steady["codex_app"]["stateful_backoff"]["current_rrule"] == "FREQ=MINUTELY;INTERVAL=60", steady
+    assert steady["codex_app"]["host_action"] == "none", steady
+    assert "recommended_rrule" not in steady["codex_app"], steady
 
 
 def assert_monitor_wait_ignores_goal_recommended_action_identity_noise() -> None:
@@ -512,11 +506,10 @@ def assert_scheduler_ack_plan_validation() -> None:
 
 
 def assert_monitor_wait_stale_ack_hint_is_accepted() -> None:
-    base = monitor_window_payload(minutes_until_due=119)
+    base = monitor_window_payload(minutes_until_due=59)
     first = build_hint_at(base, now=FROZEN_NOW)
     second = build_hint_at(base, now=FROZEN_NOW, scheduler_state=state_from(first))
-    third = build_hint_at(base, now=FROZEN_NOW, scheduler_state=state_from(second))
-    previous_state = state_from(third)
+    previous_state = state_from(second)
 
     stale_hint_source = build_hint_at(
         base,
@@ -526,7 +519,7 @@ def assert_monitor_wait_stale_ack_hint_is_accepted() -> None:
     stale_app = stale_hint_source["codex_app"]
     stale_ack_args = stale_app["ack_hint"]["args"]
     assert stale_hint_source["cadence_class"] == "monitor_wait", stale_hint_source
-    assert stale_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=119", stale_hint_source
+    assert stale_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=59", stale_hint_source
 
     current_hint = build_hint_at(
         base,
@@ -534,7 +527,7 @@ def assert_monitor_wait_stale_ack_hint_is_accepted() -> None:
         scheduler_state=previous_state,
     )
     current_app = current_hint["codex_app"]
-    assert current_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=118", current_hint
+    assert current_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=58", current_hint
     assert (
         current_app["stateful_backoff"]["reset_token"]
         == stale_ack_args["reset_token"]
@@ -555,8 +548,8 @@ def assert_monitor_wait_stale_ack_hint_is_accepted() -> None:
     assert plan == {
         "ok": True,
         "already_applied": False,
-        "applied_rrule": "FREQ=MINUTELY;INTERVAL=119",
-        "expected_rrule": "FREQ=MINUTELY;INTERVAL=118",
+        "applied_rrule": "FREQ=MINUTELY;INTERVAL=59",
+        "expected_rrule": "FREQ=MINUTELY;INTERVAL=58",
         "stale_hint_accepted": True,
         "stale_hint_tolerance_minutes": 2,
     }, plan
@@ -569,12 +562,12 @@ def assert_monitor_wait_stale_ack_hint_is_accepted() -> None:
         identity_signature=stale_ack_args["identity_signature"],
     )
     ack_event = event["scheduler_ack_event"]
-    assert ack_event["applied_rrule"] == "FREQ=MINUTELY;INTERVAL=119", event
-    assert ack_event["expected_rrule"] == "FREQ=MINUTELY;INTERVAL=118", event
+    assert ack_event["applied_rrule"] == "FREQ=MINUTELY;INTERVAL=59", event
+    assert ack_event["expected_rrule"] == "FREQ=MINUTELY;INTERVAL=58", event
     assert ack_event["stale_hint_accepted"] is True, event
     assert (
         ack_event["scheduler_state"]["last_applied_rrule"]
-        == "FREQ=MINUTELY;INTERVAL=119"
+        == "FREQ=MINUTELY;INTERVAL=59"
     ), event
     quiet_after_stale_ack = build_hint_at(
         base,
@@ -592,7 +585,7 @@ def assert_monitor_wait_stale_ack_hint_is_accepted() -> None:
         scheduler_state=ack_event["scheduler_state"],
     )
     outside_app = outside_state_tolerance["codex_app"]
-    assert outside_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=116", (
+    assert outside_app["recommended_rrule"] == "FREQ=MINUTELY;INTERVAL=56", (
         outside_state_tolerance
     )
     assert outside_app["stateful_backoff"]["apply_needed"] is True, (
@@ -603,7 +596,7 @@ def assert_monitor_wait_stale_ack_hint_is_accepted() -> None:
         {"scheduler_hint": current_hint},
         agent_id=stale_ack_args["agent_id"],
         state_key=stale_ack_args["state_key"],
-        applied_rrule="FREQ=MINUTELY;INTERVAL=121",
+        applied_rrule="FREQ=MINUTELY;INTERVAL=61",
         reset_token=stale_ack_args["reset_token"],
         identity_signature=stale_ack_args["identity_signature"],
     )
@@ -972,7 +965,7 @@ def assert_cli_scheduler_ack_uses_should_run_lookback() -> None:
 
 def main() -> int:
     assert_policy_state_progression()
-    assert_monitor_wait_progression_reaches_120()
+    assert_monitor_wait_progression_caps_at_60()
     assert_monitor_wait_ignores_goal_recommended_action_identity_noise()
     assert_active_work_keeps_initial_cadence()
     assert_scheduler_ack_plan_validation()

--- a/loopx/control_plane/scheduler/scheduler_hint.py
+++ b/loopx/control_plane/scheduler/scheduler_hint.py
@@ -25,7 +25,7 @@ SCHEDULER_HINT_DETAIL_SCHEMA_VERSION = "scheduler_hint_detail_v0"
 CODEX_APP_STATEFUL_BACKOFF_SCHEMA_VERSION = "codex_app_stateful_backoff_v0"
 CODEX_APP_SCHEDULER_ACK_HINT_SCHEMA_VERSION = "codex_app_scheduler_ack_hint_v0"
 MONITOR_CADENCE_PATTERN = re.compile(r"^\s*(\d+)\s*([mhd])\s*$", re.IGNORECASE)
-MONITOR_WAIT_PROGRESSION_MINUTES = [15, 30, 60, 120]
+MONITOR_WAIT_PROGRESSION_MINUTES = [15, 30, 60]
 DEFAULT_ACK_CAPABILITIES = {"shell", "filesystem_read", "filesystem_write"}
 MONITOR_WAIT_HOST_FLOOR_MINUTES = 15
 MONITOR_WAIT_NEAR_WINDOW_LEAD_MINUTES = 60
@@ -1073,7 +1073,7 @@ def build_scheduler_hint(
                 "cadence_class": "monitor_wait",
                 "codex_app_initial_interval_minutes": MONITOR_WAIT_HOST_FLOOR_MINUTES,
                 "codex_app_initial_rrule": rrule_for_minutes(MONITOR_WAIT_HOST_FLOOR_MINUTES),
-                "codex_app_max_interval_minutes": 120,
+                "codex_app_max_interval_minutes": 60,
                 "unchanged_poll_backoff_multiplier": 2,
                 "local_scheduler_unchanged_poll_limit": 3,
                 "claude_code_loop_unchanged_poll_limit": 3,
@@ -1091,7 +1091,7 @@ def build_scheduler_hint(
                 "cadence until material evidence, a blocker, or replan obligation appears"
             ),
             codex_interval=15,
-            codex_max=120,
+            codex_max=60,
             cli_limit=3,
             claude_limit=3,
             cadence_progression_override=(


### PR DESCRIPTION
## Summary
- cap Codex App monitor-only scheduler backoff progression at `[15, 30, 60]` instead of reaching 120m
- keep monitor wait no-spend ack progression stable after 60m
- update scheduler smoke coverage and quota docs for the new monitor-only ceiling

## Changed Surfaces
- `loopx/control_plane/scheduler/scheduler_hint.py` monitor wait scheduler policy
- control-plane scheduler/monitor smoke fixtures
- `docs/quota-allocation.md` protocol note

## Validation
- `python3 examples/control_plane/quota-scheduler-state-ack-smoke.py`
- `python3 examples/control_plane/monitor-scheduler-contract-smoke.py`
- `python3 examples/control_plane/quota-agent-scoped-user-gate-smoke.py`
- `python3 examples/control_plane/quota-scheduler-policy-smoke.py`
- `python3 examples/control_plane/heartbeat-quota-flow-smoke.py`
- `python3 examples/control_plane/monitor-poll-writeback-smoke.py`
- `python3 examples/control_plane/quota-plan-smoke.py`
- `loopx canary premerge --from-git-diff` passed, `self_merge_allowed=true`, `manual_holds=0`
- public/private boundary scan passed via canary

## Self-Merge Rationale
This is a narrow scheduler policy correction for monitor-only quiet waits, with focused smoke updates and full risk-based canary coverage. It does not touch benchmark scoring, task semantics, permission boundaries, or private/raw evidence.
