### PR TITLE
Align completed todo archive warning command

### DIFF
--- a/docs/status-data-contract.md
+++ b/docs/status-data-contract.md
@@ -1245,7 +1245,10 @@ When the payload includes `completed_todo_archive_warning`, the active
 dashboard/status surface to keep current open work visible. Executors should
 move older completed entries into a dedicated `Completed Work Archive` section
 and keep only current open work plus a small recent-done tail under active
-`Agent Todo`. Archive sections are intentionally ignored by active todo parsing.
+`Agent Todo`. The warning's `archive_command_template` includes the projected
+`default_archive_keep_count` as `--max-active-done`, so the copyable command and
+the warning's recent-done tail contract stay aligned. Archive sections are
+intentionally ignored by active todo parsing.
 This warning is a checklist hygiene signal only: it does not change quota
 eligibility, grant write or production permission, or supersede open user/agent
 todo blockers. It also does not mark an open todo complete; executors should

--- a/examples/backlog-hygiene-smoke.py
+++ b/examples/backlog-hygiene-smoke.py
@@ -167,6 +167,10 @@ def assert_completed_todo_archive_warning() -> None:
         assert warning["active_done_count"] == 13, warning
         assert warning["active_open_count"] == 1, warning
         assert warning["max_active_done_count"] == 12, warning
+        assert warning["default_archive_keep_count"] == 10, warning
+        assert warning["archive_command_template"].endswith(
+            "--max-active-done 10 --execute"
+        ), warning
         assert item["completed_todo_archive_warning"] == warning, item
 
         guard = run_cli("quota", "should-run", "--goal-id", GOAL_ID, registry_path=registry_path, runtime=runtime)

--- a/examples/control_plane/todo-archive-completed-smoke.py
+++ b/examples/control_plane/todo-archive-completed-smoke.py
@@ -117,7 +117,7 @@ def main() -> int:
         assert warning["max_active_done_count"] == 12, warning
         assert warning["default_archive_keep_count"] == 10, warning
         assert warning["archive_command_template"] == (
-            "loopx todo archive-completed --goal-id <goal-id> --execute"
+            "loopx todo archive-completed --goal-id <goal-id> --max-active-done 10 --execute"
         ), warning
 
         default_dry_run = run_cli(

--- a/loopx/control_plane/quota/markdown.py
+++ b/loopx/control_plane/quota/markdown.py
@@ -537,7 +537,8 @@ def render_quota_should_run_markdown(payload: dict[str, Any]) -> str:
             f"active_done={completed_todo_archive_warning.get('active_done_count')} "
             f"max_active_done={completed_todo_archive_warning.get('max_active_done_count')} "
             f"default_archive_keep={completed_todo_archive_warning.get('default_archive_keep_count')} "
-            f"archive_section={completed_todo_archive_warning.get('archive_section')}"
+            f"archive_section={completed_todo_archive_warning.get('archive_section')} "
+            f"archive_command={completed_todo_archive_warning.get('archive_command_template')}"
         )
         if completed_todo_archive_warning.get("recommended_action"):
             lines.append(

--- a/loopx/control_plane/todos/completed_archive.py
+++ b/loopx/control_plane/todos/completed_archive.py
@@ -14,8 +14,13 @@ from .active_state_editing import (
 DEFAULT_MAX_ACTIVE_DONE_TODOS_BEFORE_ARCHIVE = 12
 DEFAULT_COMPLETED_TODO_ARCHIVE_HEADROOM = 2
 COMPLETED_TODO_ARCHIVE_COMMAND_TEMPLATE = (
-    "loopx todo archive-completed --goal-id <goal-id> --execute"
+    "loopx todo archive-completed --goal-id <goal-id> "
+    "--max-active-done {max_active_done} --execute"
 )
+
+
+def completed_todo_archive_command_template(max_active_done: int) -> str:
+    return COMPLETED_TODO_ARCHIVE_COMMAND_TEMPLATE.format(max_active_done=max_active_done)
 
 
 def completed_todo_archive_warning(
@@ -47,7 +52,7 @@ def completed_todo_archive_warning(
         "active_open_count": open_count,
         "max_active_done_count": max_active_done_todos,
         "default_archive_keep_count": archive_keep_count,
-        "archive_command_template": COMPLETED_TODO_ARCHIVE_COMMAND_TEMPLATE,
+        "archive_command_template": completed_todo_archive_command_template(archive_keep_count),
         "recommended_action": (
             "move older completed Agent Todo entries into a dedicated Completed Work Archive "
             "until the active Agent Todo section keeps only current open work and a small recent-done tail"

--- a/loopx/presentation/renderers/status_markdown.py
+++ b/loopx/presentation/renderers/status_markdown.py
@@ -586,7 +586,9 @@ def append_project_asset_warning_markdown(
             f"requires_archive={archive_warning.get('requires_archive')} "
             f"active_done={archive_warning.get('active_done_count')} "
             f"max_active_done={archive_warning.get('max_active_done_count')} "
-            f"archive_section={markdown_scalar(archive_warning.get('archive_section') or '')}"
+            f"default_archive_keep={archive_warning.get('default_archive_keep_count')} "
+            f"archive_section={markdown_scalar(archive_warning.get('archive_section') or '')} "
+            f"archive_command={markdown_scalar(archive_warning.get('archive_command_template') or '')}"
         )
     replan_obligation = (
         project_asset.get("autonomous_replan_obligation")


### PR DESCRIPTION
## Summary
- make `completed_todo_archive_warning.archive_command_template` include the projected `--max-active-done <default_archive_keep_count>` value
- show the exact archive command in status/quota markdown renderers
- extend existing archive/backlog smokes and the status data contract docs

## Product / architecture judgment
- Motivation: the archive warning exposed both `max_active_done_count=12` and `default_archive_keep_count=10`, while the copyable command omitted the effective keep count; operators had to know CLI defaults to understand why a dry run moved the active done tail to 10.
- Solved: the warning now carries an exact, copyable command tied to the projected keep count, and human-readable status/quota output renders that same command.
- Impact: checklist hygiene can be executed without ambiguity, and future CLI-default drift is less likely to make the projection misleading.
- Risk: narrow status/quota/todo projection compatibility change; the CLI archive behavior is unchanged. Existing consumers that treat the command as display text should continue to work.
- Design: this keeps the rule in the completed-todo archive bounded context rather than adding a scheduler or todo lifecycle abstraction.

## Validation
- `python3 examples/control_plane/todo-archive-completed-smoke.py`
- `python3 examples/backlog-hygiene-smoke.py`
- `python3 examples/derived-state-boundary-smoke.py`
- `python3 examples/control_plane/quota-contract-smoke.py`
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 -m compileall -q loopx/control_plane/todos/completed_archive.py loopx/presentation/renderers/status_markdown.py loopx/control_plane/quota/markdown.py`
- `loopx check`
- `loopx canary premerge --from-git-diff` passed, 17 selected checks, 0 failures, 0 manual holds

## Boundary scan
- staged paths only; no credentials, private state, local paths, raw benchmark logs, trajectories, verifier output, or generated logs added

Self-merge candidate: small, single-purpose projection/display contract fix with focused smoke coverage and premerge canary approval.