### PR TITLE
Show vision checkpoint resolution in refresh output

### DIFF
--- a/examples/project/goal-vision-refresh-state-budget-smoke.py
+++ b/examples/project/goal-vision-refresh-state-budget-smoke.py
@@ -69,6 +69,7 @@ def run_cli(
     registry_path: Path,
     runtime: Path,
     *,
+    output_format: str = "json",
     vision_path: Path | None = None,
     inline_vision_args: list[str] | None = None,
     check: bool,
@@ -85,7 +86,7 @@ def run_cli(
         "--runtime-root",
         str(runtime),
         "--format",
-        "json",
+        output_format,
         "refresh-state",
         "--goal-id",
         GOAL_ID,
@@ -287,6 +288,41 @@ def main() -> int:
         assert unchanged["agent_vision"] is None, unchanged
         assert unchanged["vision_checkpoint"]["agent_id"] == AGENT_ID, unchanged
         assert unchanged["vision_checkpoint"]["decision"] == "unchanged_with_reason", unchanged
+
+        missing_checkpoint = payload(
+            run_cli(
+                registry_path,
+                runtime,
+                check=True,
+            )
+        )
+        assert missing_checkpoint["vision_checkpoint"]["required"] is True, (
+            missing_checkpoint
+        )
+        assert missing_checkpoint["vision_checkpoint"]["satisfied"] is False, (
+            missing_checkpoint
+        )
+        assert missing_checkpoint["vision_checkpoint"]["decision"] == "missing_required", (
+            missing_checkpoint
+        )
+        assert missing_checkpoint["vision_checkpoint"]["required_resolution"] == [
+            "write_vision_patch",
+            "record_unchanged_reason",
+            "record_no_followup",
+            "link_successor_or_supersede",
+        ], missing_checkpoint
+        missing_markdown = run_cli(
+            registry_path,
+            runtime,
+            output_format="markdown",
+            check=True,
+        ).stdout
+        assert "vision_checkpoint_required_resolution:" in missing_markdown, (
+            missing_markdown
+        )
+        assert "write_vision_patch,record_unchanged_reason" in missing_markdown, (
+            missing_markdown
+        )
 
         no_agent_inline_result = run_cli(
             registry_path,

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -657,6 +657,12 @@ def render_state_refresh_markdown(payload: dict[str, Any]) -> str:
             lines.append(
                 f"- vision_unchanged_reason: {vision_checkpoint.get('unchanged_reason')}"
             )
+        required_resolution = vision_checkpoint.get("required_resolution")
+        if required_resolution:
+            lines.append(
+                "- vision_checkpoint_required_resolution: "
+                f"{','.join(str(item) for item in required_resolution)}"
+            )
 
     projection_gap = (
         payload.get("state_projection_gap")


### PR DESCRIPTION
## Summary
- render `vision_checkpoint.required_resolution` in `refresh-state` markdown output when a material closeout is missing a vision decision
- extend the existing goal vision refresh smoke to assert the JSON checkpoint remains `missing_required` and the markdown now names the required resolutions

## Product / architecture judgment
- Motivation: quota/status already detect missing per-agent vision checkpoints, but the immediate `refresh-state` markdown closeout only showed `decision=missing_required`; it did not name the concrete repair actions, so the operator/agent could miss the required follow-up until a later quota read.
- Solved: the existing checkpoint contract is now visible at the closeout boundary. Agents see `write_vision_patch`, `record_unchanged_reason`, `record_no_followup`, and `link_successor_or_supersede` directly in the command output.
- User/operator impact: fewer silent material closeouts with a hidden vision gap; the next action is discoverable without reading JSON or waiting for quota projection.
- Main risk: display-only compatibility risk for markdown consumers. JSON shape and checkpoint decision logic are unchanged.
- Design: this keeps the fix in the refresh-state presentation layer and uses the existing checkpoint field instead of adding a new lifecycle state.

## Validation
- `python3 examples/project/goal-vision-refresh-state-budget-smoke.py`
- `python3 examples/project/goal-vision-replan-contract-smoke.py`
- `python3 examples/control_plane/quota-replan-decision-plane-smoke.py`
- `python3 -m compileall -q loopx/state_refresh.py examples/project/goal-vision-refresh-state-budget-smoke.py`
- `loopx check`
- `loopx canary premerge --from-git-diff` passed, 17 selected checks, 0 failures, 0 manual holds

## Boundary scan
- staged pathspecs only; added lines contain no credentials, private state, local paths, raw benchmark logs/task text/trajectories/verifier output, or generated logs

Self-merge candidate: narrow display/diagnostic contract fix with focused smoke coverage and premerge canary approval.