### PR TITLE
Align status agent-lane next-action warning

### DIFF
--- a/examples/control_plane/status_markdown_agent_lane_fixtures.py
+++ b/examples/control_plane/status_markdown_agent_lane_fixtures.py
@@ -10,6 +10,7 @@ from loopx.status import project_asset_todo_summary, render_status_markdown
 def assert_status_agent_lane_next_action_projection() -> None:
     goal_id = "agent-lane-status-fixture"
     primary_action = "[P0] Continue the primary controller benchmark route."
+    stale_run_action = "[P0] Monitor the primary controller route before changing Next Action."
     side_action = (
         "[P0] Codex CLI TUI continuation: prove the visible steering turn "
         "without losing user takeover."
@@ -88,6 +89,16 @@ def assert_status_agent_lane_next_action_projection() -> None:
                     "waiting_on": "codex",
                     "severity": "action",
                     "recommended_action": primary_action,
+                    "active_state_next_action": primary_action,
+                    "latest_run_recommended_action": stale_run_action,
+                    "next_action_projection_warning": {
+                        "schema_version": "next_action_projection_warning_v0",
+                        "kind": "next_action_projection_mismatch",
+                        "severity": "warning",
+                        "requires_state_writeback": True,
+                        "active_state_next_action": primary_action,
+                        "latest_run_recommended_action": stale_run_action,
+                    },
                     "source": "registry",
                     "coordination": coordination,
                     "quota": {
@@ -103,6 +114,16 @@ def assert_status_agent_lane_next_action_projection() -> None:
                         "gate": "none",
                         "stop_condition": "stop on unsafe workspace or user gate",
                         "next_action": primary_action,
+                        "active_state_next_action": primary_action,
+                        "latest_run_recommended_action": stale_run_action,
+                        "next_action_projection_warning": {
+                            "schema_version": "next_action_projection_warning_v0",
+                            "kind": "next_action_projection_mismatch",
+                            "severity": "warning",
+                            "requires_state_writeback": True,
+                            "active_state_next_action": primary_action,
+                            "latest_run_recommended_action": stale_run_action,
+                        },
                         "agent_todos": project_asset_todo_summary(agent_todos, role="agent"),
                     },
                 }
@@ -132,6 +153,11 @@ def assert_status_agent_lane_next_action_projection() -> None:
     assert next_action["todo_id"] == "todo_side_tui", next_action
     assert next_action["agent_id"] == "codex-side-bypass", next_action
     assert next_action["preserves_goal_next_action"] is True, next_action
+    warning = item["next_action_projection_warning"]
+    assert warning["severity"] == "info", warning
+    assert warning["requires_state_writeback"] is False, warning
+    assert warning["agent_lane_next_action"] == side_action, warning
+    assert item["project_asset"]["next_action_projection_warning"] == warning, item
     goal_frontier = item["goal_frontier_projection"]
     assert goal_frontier["deferred_successors"]["ready_count"] == 0, goal_frontier
     assert goal_frontier["acceptance_gaps"] == [], goal_frontier
@@ -160,6 +186,7 @@ def assert_status_agent_lane_next_action_projection() -> None:
     assert "claims=todo_side_tui" in markdown, markdown
     assert "current_agent_todo: agent=codex-side-bypass todo_id=todo_side_tui" in markdown, markdown
     assert "source=agent_lane_next_action" in markdown, markdown
+    assert "next_action_projection_warning: requires_state_writeback=False severity=info" in markdown, markdown
     assert "goal_frontier_projection: replan_required=False" in markdown, markdown
     assert "deferred_ready=0 acceptance_gaps=0" in markdown, markdown
     assert side_action in markdown, markdown

--- a/loopx/cli_commands/status.py
+++ b/loopx/cli_commands/status.py
@@ -559,6 +559,20 @@ def _sync_status_item_next_action_from_agent_lane(
         goal_channel["next_action"] = text
 
 
+def _sync_next_action_projection_warning_from_guard(
+    item: dict[str, object],
+    *,
+    guard: dict[str, object],
+) -> None:
+    warning = guard.get("next_action_projection_warning")
+    if not isinstance(warning, dict):
+        return
+    item["next_action_projection_warning"] = warning
+    project_asset = item.get("project_asset")
+    if isinstance(project_asset, dict):
+        project_asset["next_action_projection_warning"] = warning
+
+
 def attach_agent_lane_next_actions(payload: dict[str, object], *, agent_id: str) -> dict[str, object]:
     safe_agent_id = str(agent_id or "").strip()
     if not safe_agent_id:
@@ -591,6 +605,7 @@ def attach_agent_lane_next_actions(payload: dict[str, object], *, agent_id: str)
             item["agent_lane_next_action"] = next_action
             if isinstance(project_asset, dict):
                 project_asset["agent_lane_next_action"] = next_action
+            _sync_next_action_projection_warning_from_guard(item, guard=guard)
             _sync_status_item_next_action_from_agent_lane(
                 item,
                 next_action=next_action,

--- a/loopx/presentation/renderers/status_markdown.py
+++ b/loopx/presentation/renderers/status_markdown.py
@@ -537,6 +537,7 @@ def append_project_asset_warning_markdown(
         lines.append(
             "    - next_action_projection_warning: "
             f"requires_state_writeback={next_action_warning.get('requires_state_writeback')} "
+            f"severity={markdown_scalar(next_action_warning.get('severity') or '')} "
             f"reason={markdown_scalar(next_action_warning.get('reason') or '')}"
         )
     backlog_warning = (


### PR DESCRIPTION
## Summary
- Reuse the quota guard's agent-lane next-action warning when `status --agent-id` attaches an agent-lane next action, so status no longer leaves a stale goal-level `requires_state_writeback=true` warning for side-agent work that explicitly preserves the durable goal Next Action.
- Render warning severity in status markdown, making the info vs warning distinction visible to operators.
- Extend the status markdown agent-lane fixture to cover the downgrade from goal-level warning to agent-lane info.

## Product / Architecture Judgment
This is a narrow projection-consistency fix. It does not change todo selection, quota decisions, scheduler cadence, benchmark behavior, or durable Next Action writeback semantics. It only keeps the status CLI/dashboard-facing projection aligned with the existing quota read model after agent-lane enrichment.

## Validation
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 examples/project/next-action-projection-contract-smoke.py`
- `python3 -m compileall -q loopx/cli_commands/status.py loopx/presentation/renderers/status_markdown.py examples/control_plane/status_markdown_agent_lane_fixtures.py`
- live projection check: `status --goal-id loopx-meta --agent-id codex-product-capability` now reports `requires_state_writeback=false`, `severity=info` for the agent-lane next-action warning
- `PYTHONPATH="$PWD" python3 -m loopx.cli check --scan-path loopx/cli_commands/status.py --scan-path loopx/presentation/renderers/status_markdown.py --scan-path examples/control_plane/status_markdown_agent_lane_fixtures.py`
- `loopx canary premerge --from-git-diff` passed: direct diff checks, py_compile, 8 catalog canaries, 8 risk-profile smokes, public-boundary scan

## Boundary Scan
Candidate paths were scanned for private/local material and no credentials, raw benchmark evidence, local paths, or internal/private context were found.

## Self-Merge Candidate
Yes. The diff is small, single-purpose, public-safe, and premerge canary reports `merge_gate_passed=true`, `self_merge_allowed=true`, with no manual holds.