### PR TITLE
Align status agent-lane vision lookback

### DIFF
--- a/examples/control_plane/status-markdown-smoke.py
+++ b/examples/control_plane/status-markdown-smoke.py
@@ -33,6 +33,7 @@ from loopx.handoff_budget import PROJECT_AGENT_HANDOFF_BUDGET  # noqa: E402
 from status_markdown_agent_lane_fixtures import (  # noqa: E402
     assert_status_agent_lane_frontier_hint_projection,
     assert_status_agent_lane_next_action_projection,
+    assert_status_agent_lane_vision_lookback_survives_display_trim,
     assert_status_agent_member_handoff_uses_quota_identity,
     assert_status_agent_member_selected_lane_claim_survives_truncated_claim_list,
 )
@@ -1331,6 +1332,7 @@ def main() -> int:
     assert_status_agent_lane_next_action_projection()
     assert_status_agent_member_selected_lane_claim_survives_truncated_claim_list()
     assert_status_agent_member_handoff_uses_quota_identity()
+    assert_status_agent_lane_vision_lookback_survives_display_trim()
     assert_status_agent_lane_frontier_hint_projection()
     print("status-markdown-smoke ok")
     return 0

--- a/examples/control_plane/status_markdown_agent_lane_fixtures.py
+++ b/examples/control_plane/status_markdown_agent_lane_fixtures.py
@@ -2,7 +2,12 @@
 
 from __future__ import annotations
 
-from loopx.cli_commands.status import attach_agent_lane_next_actions, _review_handoff_agent
+from loopx.cli_commands.status import (
+    _review_handoff_agent,
+    _status_collection_limit_for_agent_lane,
+    _trim_run_history_for_status_display,
+    attach_agent_lane_next_actions,
+)
 from loopx.review_packet import build_review_packet
 from loopx.status import project_asset_todo_summary, render_status_markdown
 
@@ -335,6 +340,140 @@ def assert_status_agent_member_handoff_uses_quota_identity() -> None:
         )
         == "codex-product-capability"
     )
+
+
+def assert_status_agent_lane_vision_lookback_survives_display_trim() -> None:
+    goal_id = "agent-lane-vision-lookback-fixture"
+    agent_id = "codex-product-capability"
+    side_action = "[P2] Continue the product capability audit."
+    side_todo = {
+        "schema_version": "todo_item_v0",
+        "todo_id": "todo_product_capability",
+        "index": 7,
+        "role": "agent",
+        "status": "open",
+        "priority": "P2",
+        "task_class": "advancement_task",
+        "action_kind": "engineering_quality_audit",
+        "claimed_by": agent_id,
+        "text": side_action,
+    }
+    agent_todos = {
+        "schema_version": "todo_summary_v0",
+        "open_count": 1,
+        "done_count": 0,
+        "total_count": 1,
+        "items": [side_todo],
+        "first_open_items": [side_todo],
+        "first_executable_items": [side_todo],
+    }
+    coordination = {
+        "primary_agent": "codex-main-control",
+        "registered_agents": ["codex-main-control", agent_id],
+    }
+    stale_runs = [
+        {
+            "goal_id": goal_id,
+            "generated_at": f"2026-07-09T06:{59 - offset:02d}:00+08:00",
+            "classification": f"recent_status_{offset}",
+            "agent_id": agent_id,
+        }
+        for offset in range(10)
+    ]
+    vision_run = {
+        "goal_id": goal_id,
+        "generated_at": "2026-07-09T05:45:45+08:00",
+        "classification": "product_capability_open_vision_patch",
+        "agent_id": agent_id,
+        "agent_vision": {
+            "schema_version": "agent_vision_v0",
+            "agent_id": agent_id,
+            "state": "open",
+            "vision_patch": {
+                "replan_trigger_summary": (
+                    "active agent vision remains open with acceptance evidence still required"
+                ),
+                "acceptance_summary": (
+                    "Continue bounded public-safe code/test improvements for status and quota."
+                ),
+            },
+        },
+    }
+    payload = {
+        "ok": True,
+        "registry": "./fixtures/registry.json",
+        "runtime_root": "./fixtures/runtime",
+        "goal_count": 1,
+        "run_count": 11,
+        "contract": {"ok": True, "summary": {"errors": 0, "warnings": 0, "checks": 0}},
+        "global_registry": {"available": False, "summary": {}},
+        "attention_queue": {
+            "available": True,
+            "item_count": 1,
+            "items": [
+                {
+                    "goal_id": goal_id,
+                    "status": "primary_route_active",
+                    "waiting_on": "codex",
+                    "severity": "action",
+                    "recommended_action": "[P0] Keep the durable primary route.",
+                    "source": "registry",
+                    "coordination": coordination,
+                    "quota": {
+                        "state": "eligible",
+                        "compute": 1.0,
+                        "window_hours": 24,
+                        "slot_minutes": 1,
+                        "allowed_slots": 10,
+                    },
+                    "agent_todos": agent_todos,
+                    "project_asset": {
+                        "owner": "codex-main-control",
+                        "gate": "none",
+                        "next_action": "[P0] Keep the durable primary route.",
+                        "agent_todos": project_asset_todo_summary(agent_todos, role="agent"),
+                    },
+                }
+            ],
+        },
+        "run_history": {
+            "recent_runs": [*stale_runs, vision_run],
+            "goals": [
+                {
+                    "id": goal_id,
+                    "registry_member": True,
+                    "status": "primary_route_active",
+                    "coordination": coordination,
+                    "quota": {
+                        "compute": 1.0,
+                        "window_hours": 24,
+                        "slot_minutes": 1,
+                        "allowed_slots": 10,
+                    },
+                    "latest_runs": [*stale_runs, vision_run],
+                }
+            ],
+        },
+    }
+
+    assert _status_collection_limit_for_agent_lane(
+        requested_limit=5,
+        agent_id=agent_id,
+    ) > 5
+    attach_agent_lane_next_actions(payload, agent_id=agent_id)
+    item = payload["attention_queue"]["items"][0]
+    goal_frontier = item["goal_frontier_projection"]
+    assert len(goal_frontier["acceptance_gaps"]) == 1, goal_frontier
+    assert goal_frontier["vision_continuation_audit"]["required"] is True, goal_frontier
+    assert item["project_asset"]["goal_frontier_projection"] == goal_frontier, item
+
+    _trim_run_history_for_status_display(payload, display_limit=5, collection_limit=30)
+    assert len(payload["run_history"]["recent_runs"]) == 5, payload
+    assert len(payload["run_history"]["goals"][0]["latest_runs"]) == 5, payload
+    assert payload["agent_lane_projection_lookback"]["display_limit"] == 5, payload
+    assert len(item["goal_frontier_projection"]["acceptance_gaps"]) == 1, item
+    markdown = render_status_markdown(payload)
+    assert "acceptance_gaps=1" in markdown, markdown
 
 
 def assert_status_agent_lane_frontier_hint_projection() -> None:

--- a/loopx/cli_commands/status.py
+++ b/loopx/cli_commands/status.py
@@ -10,7 +10,11 @@ from ..diagnose import collect_diagnosis, render_diagnosis_markdown
 from ..handoff_budget import build_handoff_interface_budget
 from ..quota import build_quota_should_run
 from ..review_packet import build_review_packet, render_review_packet_markdown
-from ..status import collect_status, render_status_markdown
+from ..status import (
+    AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK,
+    collect_status,
+    render_status_markdown,
+)
 from ..control_plane.runtime.status_projection_cache import (
     load_status_projection_cache,
     resolve_status_projection_cache_runtime_root,
@@ -33,6 +37,52 @@ def default_public_scan_root() -> str:
 def _scan_roots(args: argparse.Namespace) -> list[Path]:
     scan_roots = [Path(item).expanduser() for item in args.scan_path]
     return scan_roots or [Path(args.scan_root).expanduser()]
+
+
+def _status_collection_limit_for_agent_lane(*, requested_limit: int, agent_id: str | None) -> int:
+    safe_limit = max(0, int(requested_limit or 0))
+    if str(agent_id or "").strip():
+        return max(safe_limit, AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK)
+    return safe_limit
+
+
+def _trim_run_history_for_status_display(
+    payload: dict[str, object],
+    *,
+    display_limit: int,
+    collection_limit: int,
+) -> None:
+    if collection_limit <= display_limit:
+        return
+    run_history = payload.get("run_history")
+    if not isinstance(run_history, dict):
+        return
+    safe_display_limit = max(0, display_limit)
+    recent_runs = run_history.get("recent_runs")
+    trimmed = False
+    if isinstance(recent_runs, list) and len(recent_runs) > safe_display_limit:
+        run_history["recent_runs"] = recent_runs[:safe_display_limit]
+        trimmed = True
+    goals = run_history.get("goals")
+    if isinstance(goals, list):
+        for goal in goals:
+            if not isinstance(goal, dict):
+                continue
+            latest_runs = goal.get("latest_runs")
+            if isinstance(latest_runs, list) and len(latest_runs) > safe_display_limit:
+                goal["latest_runs"] = latest_runs[:safe_display_limit]
+                trimmed = True
+    if trimmed:
+        payload["agent_lane_projection_lookback"] = {
+            "schema_version": "agent_lane_projection_lookback_v0",
+            "collection_limit": collection_limit,
+            "display_limit": safe_display_limit,
+            "reason": (
+                "status --agent-id collected quota-equivalent run history for "
+                "agent-lane frontier projection, then restored the requested "
+                "status display limit"
+            ),
+        }
 
 
 def register_status_commands(
@@ -262,7 +312,11 @@ def handle_status_command(
 ) -> int:
     try:
         scan_roots = _scan_roots(args)
-        limit = max(0, args.limit)
+        display_limit = max(0, args.limit)
+        collection_limit = _status_collection_limit_for_agent_lane(
+            requested_limit=display_limit,
+            agent_id=args.agent_id,
+        )
         runtime_root = resolve_status_projection_cache_runtime_root(
             registry_path=registry_path,
             runtime_root_override=runtime_root_arg,
@@ -274,7 +328,7 @@ def handle_status_command(
                 registry_path=registry_path,
                 runtime_root=runtime_root,
                 scan_roots=scan_roots,
-                limit=limit,
+                limit=collection_limit,
                 include_task_graph=args.include_task_graph,
                 goal_id=args.goal_id,
                 max_age_seconds=args.projection_cache_ttl_seconds,
@@ -284,7 +338,7 @@ def handle_status_command(
                 registry_path=registry_path,
                 runtime_root_override=runtime_root_arg,
                 scan_roots=scan_roots,
-                limit=limit,
+                limit=collection_limit,
                 include_task_graph=args.include_task_graph,
                 goal_id=args.goal_id,
             )
@@ -293,7 +347,7 @@ def handle_status_command(
                     registry_path=registry_path,
                     runtime_root=runtime_root,
                     scan_roots=scan_roots,
-                    limit=limit,
+                    limit=collection_limit,
                     include_task_graph=args.include_task_graph,
                     goal_id=args.goal_id,
                     payload=payload,
@@ -304,6 +358,11 @@ def handle_status_command(
                 payload["projection_cache"] = cache_metadata
         if args.agent_id:
             attach_agent_lane_next_actions(payload, agent_id=args.agent_id)
+            _trim_run_history_for_status_display(
+                payload,
+                display_limit=display_limit,
+                collection_limit=collection_limit,
+            )
     except Exception as exc:
         payload = {
             "ok": False,


### PR DESCRIPTION
## Summary
- Make `status --agent-id` collect quota-equivalent run-history lookback for agent-lane projection so open per-agent vision gaps are visible in `goal_frontier_projection`.
- Restore the requested status display limit after projection so `run_history.recent_runs` and per-goal `latest_runs` stay compact.
- Add a status markdown regression fixture where the active agent vision sits beyond the visible `--limit` window.

## Product / Architecture Judgment
This is a projection consistency fix, not a new lifecycle policy. `quota should-run` already uses `AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK` so it can see active per-agent vision packets before deciding whether a lane still has an acceptance gap. `status --agent-id` reused the quota guard for agent-lane projection but fed it a shorter status history, which could make status show `acceptance_gaps=0` while quota showed an active vision continuation audit. The patch aligns the read context while preserving status display compactness.

## Validation
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 examples/project/goal-vision-replan-contract-smoke.py`
- `python3 -m compileall -q loopx/cli_commands/status.py examples/control_plane/status_markdown_agent_lane_fixtures.py examples/control_plane/status-markdown-smoke.py`
- live checkout assertion: `status --goal-id loopx-meta --agent-id codex-product-capability --limit 5` now projects `acceptance_gaps=1` while display history remains 5 runs
- `python3 examples/control_plane/status-quota-perf-budget-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `loopx check --scan-path loopx/cli_commands/status.py --scan-path examples/control_plane/status_markdown_agent_lane_fixtures.py --scan-path examples/control_plane/status-markdown-smoke.py`
- `loopx canary premerge --from-git-diff` passed: 8 catalog canaries, 8 risk-profile smokes, public boundary, `manual_holds=0`

## Boundary
Changed files are limited to status control-plane read code and durable public smokes. Added-line scan and LoopX public-boundary check found no private material, credentials, local paths, raw benchmark logs, task text, trajectories, or verifier output.
