### PR TITLE
Render status vision continuation audit

### DIFF
--- a/examples/control_plane/status_markdown_agent_lane_fixtures.py
+++ b/examples/control_plane/status_markdown_agent_lane_fixtures.py
@@ -474,6 +474,8 @@ def assert_status_agent_lane_vision_lookback_survives_display_trim() -> None:
     assert len(item["goal_frontier_projection"]["acceptance_gaps"]) == 1, item
     markdown = render_status_markdown(payload)
     assert "acceptance_gaps=1" in markdown, markdown
+    assert "vision_continuation_audit: required=True decision=acceptance_gap_open trigger_count=1" in markdown, markdown
+    assert "vision_gap_judge: done=False decision=continue" in markdown, markdown
 
 
 def assert_status_agent_lane_frontier_hint_projection() -> None:

--- a/loopx/presentation/renderers/status_markdown.py
+++ b/loopx/presentation/renderers/status_markdown.py
@@ -1166,6 +1166,21 @@ def _append_project_asset_agent_lane_markdown(
         f"deferred_ready={deferred_successors.get('ready_count')} "
         f"acceptance_gaps={len(acceptance_gaps)}"
     )
+    vision_audit = as_dict(goal_frontier.get("vision_continuation_audit"))
+    if vision_audit:
+        lines.append(
+            "    - vision_continuation_audit: "
+            f"required={vision_audit.get('required')} "
+            f"decision={markdown_scalar(vision_audit.get('decision') or '')} "
+            f"trigger_count={vision_audit.get('trigger_count')}"
+        )
+        vision_gap_judge = as_dict(vision_audit.get("vision_gap_judge"))
+        if vision_gap_judge:
+            lines.append(
+                "    - vision_gap_judge: "
+                f"done={vision_gap_judge.get('done')} "
+                f"decision={markdown_scalar(vision_gap_judge.get('decision') or '')}"
+            )
 
 
 def _append_project_asset_runtime_policy_markdown(


### PR DESCRIPTION
## Summary
- render `vision_continuation_audit` and `vision_gap_judge` in `status --agent-id` markdown when the agent-lane goal frontier carries an open vision acceptance gap
- extend the existing status markdown agent-lane fixture so display-trimmed frontier audits remain visible in human-readable status output

## Changed Surfaces
- `loopx/presentation/renderers/status_markdown.py`: presentation-only status markdown sink
- `examples/control_plane/status_markdown_agent_lane_fixtures.py`: focused status markdown regression fixture

## Validation
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 examples/project/goal-vision-replan-contract-smoke.py`
- `python3 -m compileall -q loopx/presentation/renderers/status_markdown.py examples/control_plane/status_markdown_agent_lane_fixtures.py`
- `PYTHONPATH="$PWD" python3 -m loopx.cli --registry "$HOME/.codex/loopx/registry.global.json" --runtime-root "$HOME/.codex/loopx" status --goal-id loopx-meta --agent-id codex-product-capability | rg -n "goal_frontier_projection|vision_continuation_audit|vision_gap_judge"`
- `python3 examples/control_plane/status-quota-perf-budget-smoke.py`
- `PYTHONPATH="$PWD" python3 -m loopx.cli check --scan-path loopx/presentation/renderers/status_markdown.py --scan-path examples/control_plane/status_markdown_agent_lane_fixtures.py`
- `PYTHONPATH="$PWD" python3 -m loopx.cli canary premerge --from-git-diff`

## Coverage Notes
This is a display/projection consistency fix. The decision payload already carries the audit in quota and interaction contracts; the PR only exposes that compact audit in status markdown so operators can see why a lane with `acceptance_gaps=1` still requires continuation work. The premerge canary selected Python, quota/work-lane, monitor scheduler, and public-boundary checks; all passed with no manual holds.
