### PR TITLE
Show status agent interaction summary

### DIFF
--- a/examples/control_plane/status_markdown_agent_lane_fixtures.py
+++ b/examples/control_plane/status_markdown_agent_lane_fixtures.py
@@ -181,14 +181,27 @@ def assert_status_agent_lane_next_action_projection() -> None:
     assert member["handoff_agent"] == "codex-main-control", member
     assert member["role_is_advisory"] is True, member
     assert item["project_asset"]["agent_member"] == member, item
+    interaction = item["agent_interaction_summary"]
+    assert interaction["schema_version"] == "agent_interaction_summary_v0", interaction
+    assert interaction["agent_id"] == "codex-side-bypass", interaction
+    assert interaction["user_action_required"] is False, interaction
+    assert interaction["agent_must_attempt"] is True, interaction
+    assert interaction["delivery_allowed"] is True, interaction
+    assert interaction["quiet_noop_allowed"] is False, interaction
+    assert item["project_asset"]["agent_interaction_summary"] == interaction, item
     projection = payload["agent_member_projection"]
     assert projection["schema_version"] == "agent_member_projection_v0", projection
     assert projection["attached_count"] == 1, projection
     assert projection["projection_is_authoritative"] is False, projection
+    lane_projection = payload["agent_lane_next_action_projection"]
+    assert lane_projection["agent_interaction_attached_count"] == 1, lane_projection
     markdown = render_status_markdown(payload)
     assert "agent_member: agent=codex-side-bypass role=side-agent" in markdown, markdown
     assert "worktree_policy=independent_worktree_required" in markdown, markdown
     assert "claims=todo_side_tui" in markdown, markdown
+    assert "current_agent_interaction: agent=codex-side-bypass mode=bounded_delivery" in markdown, markdown
+    assert "action_required=False" in markdown, markdown
+    assert "must_attempt=True delivery_allowed=True quiet_noop_allowed=False" in markdown, markdown
     assert "current_agent_todo: agent=codex-side-bypass todo_id=todo_side_tui" in markdown, markdown
     assert "source=agent_lane_next_action" in markdown, markdown
     assert "next_action_projection_warning: requires_state_writeback=False severity=info" in markdown, markdown

--- a/loopx/cli_commands/status.py
+++ b/loopx/cli_commands/status.py
@@ -596,6 +596,36 @@ def _guard_allows_agent_lane_next_action(guard: dict[str, object]) -> bool:
     return agent_must_attempt and not user_action_required
 
 
+def _build_agent_interaction_summary(
+    guard: dict[str, object],
+    *,
+    agent_id: str,
+) -> dict[str, object] | None:
+    interaction = guard.get("interaction_contract")
+    if not isinstance(interaction, dict):
+        return None
+    user_channel = interaction.get("user_channel")
+    agent_channel = interaction.get("agent_channel")
+    cli_channel = interaction.get("cli_channel")
+    if not isinstance(user_channel, dict) or not isinstance(agent_channel, dict):
+        return None
+    summary: dict[str, object] = {
+        "schema_version": "agent_interaction_summary_v0",
+        "agent_id": agent_id,
+        "mode": interaction.get("mode"),
+        "user_action_required": bool(user_channel.get("action_required")),
+        "user_notify": user_channel.get("notify"),
+        "agent_must_attempt": bool(agent_channel.get("must_attempt")),
+        "delivery_allowed": agent_channel.get("delivery_allowed"),
+        "quiet_noop_allowed": agent_channel.get("quiet_noop_allowed"),
+        "primary_action": agent_channel.get("primary_action"),
+    }
+    if isinstance(cli_channel, dict):
+        summary["spend_after_validation"] = cli_channel.get("spend_after_validation")
+        summary["spend_policy"] = cli_channel.get("spend_policy")
+    return summary
+
+
 def _sync_status_item_next_action_from_agent_lane(
     item: dict[str, object],
     *,
@@ -647,6 +677,7 @@ def attach_agent_lane_next_actions(payload: dict[str, object], *, agent_id: str)
     hint_attached = 0
     goal_frontier_attached = 0
     member_attached = 0
+    interaction_attached = 0
     for item in items:
         if not isinstance(item, dict):
             continue
@@ -704,9 +735,26 @@ def attach_agent_lane_next_actions(payload: dict[str, object], *, agent_id: str)
                 project_asset["agent_member"] = agent_member
             member_attached += 1
             changed = True
+        interaction_summary = _build_agent_interaction_summary(
+            guard,
+            agent_id=safe_agent_id,
+        )
+        if isinstance(interaction_summary, dict):
+            item["agent_interaction_summary"] = interaction_summary
+            if isinstance(project_asset, dict):
+                project_asset["agent_interaction_summary"] = interaction_summary
+            interaction_attached += 1
+            changed = True
         if not changed:
             continue
-    if attached or frontier_attached or hint_attached or goal_frontier_attached or member_attached:
+    if (
+        attached
+        or frontier_attached
+        or hint_attached
+        or goal_frontier_attached
+        or member_attached
+        or interaction_attached
+    ):
         payload["agent_lane_next_action_projection"] = {
             "schema_version": "agent_lane_next_action_projection_v0",
             "agent_id": safe_agent_id,
@@ -715,6 +763,7 @@ def attach_agent_lane_next_actions(payload: dict[str, object], *, agent_id: str)
             "frontier_hint_attached_count": hint_attached,
             "goal_frontier_attached_count": goal_frontier_attached,
             "agent_member_attached_count": member_attached,
+            "agent_interaction_attached_count": interaction_attached,
             "preserves_goal_next_action": True,
         }
     if member_attached:

--- a/loopx/presentation/renderers/status_markdown.py
+++ b/loopx/presentation/renderers/status_markdown.py
@@ -1340,6 +1340,26 @@ def append_attention_queue_project_asset_markdown(
             "authority=advisory_projection"
         )
 
+    agent_interaction = (
+        project_asset.get("agent_interaction_summary")
+        if isinstance(project_asset.get("agent_interaction_summary"), dict)
+        else item.get("agent_interaction_summary")
+        if isinstance(item.get("agent_interaction_summary"), dict)
+        else {}
+    )
+    if agent_interaction:
+        lines.append(
+            "    - current_agent_interaction: "
+            f"agent={markdown_scalar(agent_interaction.get('agent_id') or '')} "
+            f"mode={markdown_scalar(agent_interaction.get('mode') or '')} "
+            f"action_required={agent_interaction.get('user_action_required')} "
+            f"notify={markdown_scalar(agent_interaction.get('user_notify') or '')} "
+            f"must_attempt={agent_interaction.get('agent_must_attempt')} "
+            f"delivery_allowed={agent_interaction.get('delivery_allowed')} "
+            f"quiet_noop_allowed={agent_interaction.get('quiet_noop_allowed')} "
+            f"spend_after_validation={agent_interaction.get('spend_after_validation')}"
+        )
+
     _append_project_asset_agent_lane_markdown(
         lines,
         item,


### PR DESCRIPTION
## Summary
- attach a compact `agent_interaction_summary_v0` to status agent-lane projections so `status --agent-id` carries the current agent's user/agent/CLI channel contract without duplicating the full quota payload
- render that compact summary in status markdown before todo details, making it clear when a goal-level user todo is not blocking the current side-agent lane
- extend the status markdown agent-lane fixture to cover the JSON attachment and markdown output

## Changed Surfaces
- `loopx/cli_commands/status.py`: status agent-lane read-model projection
- `loopx/presentation/renderers/status_markdown.py`: operator-facing status markdown sink
- `examples/control_plane/status_markdown_agent_lane_fixtures.py`: focused regression fixture

## Validation
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 examples/control_plane/agent-scope-projection-characterization-smoke.py`
- `python3 -m compileall -q loopx/cli_commands/status.py loopx/presentation/renderers/status_markdown.py examples/control_plane/status_markdown_agent_lane_fixtures.py`
- `PYTHONPATH="$PWD" python3 -m loopx.cli --registry "$HOME/.codex/loopx/registry.global.json" --runtime-root "$HOME/.codex/loopx" status --goal-id loopx-meta --agent-id codex-product-capability | rg -n "current_agent_interaction|asset_user_todo|current_agent_todo"`
- `python3 examples/control_plane/status-quota-perf-budget-smoke.py`
- `python3 examples/control_plane/work-lane-contract-smoke.py`
- `PYTHONPATH="$PWD" python3 -m loopx.cli check --scan-path loopx/cli_commands/status.py --scan-path loopx/presentation/renderers/status_markdown.py --scan-path examples/control_plane/status_markdown_agent_lane_fixtures.py`
- `PYTHONPATH="$PWD" python3 -m loopx.cli canary premerge --from-git-diff`

## Coverage Notes
This is a projection/read-model consistency fix. Quota already decides whether `user_channel.action_required` blocks the current agent; status markdown previously displayed the goal-level `asset_user_todo` without a nearby current-agent contract summary. The change adds a compact summary rather than embedding the full interaction contract, keeping the display bounded while making side-agent routing auditable. Premerge selected control-plane and canary-runner risk profiles; all 17 checks passed with no manual holds.
