### PR TITLE
Show user open count in agent interaction status

### DIFF
--- a/examples/control_plane/status_markdown_agent_lane_fixtures.py
+++ b/examples/control_plane/status_markdown_agent_lane_fixtures.py
@@ -185,6 +185,7 @@ def assert_status_agent_lane_next_action_projection() -> None:
     assert interaction["schema_version"] == "agent_interaction_summary_v0", interaction
     assert interaction["agent_id"] == "codex-side-bypass", interaction
     assert interaction["user_action_required"] is False, interaction
+    assert interaction["user_open_count"] == 0, interaction
     assert interaction["agent_must_attempt"] is True, interaction
     assert interaction["delivery_allowed"] is True, interaction
     assert interaction["quiet_noop_allowed"] is False, interaction
@@ -200,7 +201,7 @@ def assert_status_agent_lane_next_action_projection() -> None:
     assert "worktree_policy=independent_worktree_required" in markdown, markdown
     assert "claims=todo_side_tui" in markdown, markdown
     assert "current_agent_interaction: agent=codex-side-bypass mode=bounded_delivery" in markdown, markdown
-    assert "action_required=False" in markdown, markdown
+    assert "action_required=False open_count=0" in markdown, markdown
     assert "must_attempt=True delivery_allowed=True quiet_noop_allowed=False" in markdown, markdown
     assert "current_agent_todo: agent=codex-side-bypass todo_id=todo_side_tui" in markdown, markdown
     assert "source=agent_lane_next_action" in markdown, markdown

--- a/loopx/cli_commands/status.py
+++ b/loopx/cli_commands/status.py
@@ -609,11 +609,20 @@ def _build_agent_interaction_summary(
     cli_channel = interaction.get("cli_channel")
     if not isinstance(user_channel, dict) or not isinstance(agent_channel, dict):
         return None
+    user_todo_summary = (
+        guard.get("user_todo_summary")
+        if isinstance(guard.get("user_todo_summary"), dict)
+        else {}
+    )
+    user_open_count = user_todo_summary.get("open_count")
+    if user_open_count is None:
+        user_open_count = guard.get("open_count")
     summary: dict[str, object] = {
         "schema_version": "agent_interaction_summary_v0",
         "agent_id": agent_id,
         "mode": interaction.get("mode"),
         "user_action_required": bool(user_channel.get("action_required")),
+        "user_open_count": user_open_count,
         "user_notify": user_channel.get("notify"),
         "agent_must_attempt": bool(agent_channel.get("must_attempt")),
         "delivery_allowed": agent_channel.get("delivery_allowed"),

--- a/loopx/presentation/renderers/status_markdown.py
+++ b/loopx/presentation/renderers/status_markdown.py
@@ -1348,11 +1348,18 @@ def append_attention_queue_project_asset_markdown(
         else {}
     )
     if agent_interaction:
+        user_open_count = agent_interaction.get("user_open_count")
+        open_count_part = (
+            f"open_count={user_open_count} "
+            if user_open_count is not None
+            else ""
+        )
         lines.append(
             "    - current_agent_interaction: "
             f"agent={markdown_scalar(agent_interaction.get('agent_id') or '')} "
             f"mode={markdown_scalar(agent_interaction.get('mode') or '')} "
             f"action_required={agent_interaction.get('user_action_required')} "
+            f"{open_count_part}"
             f"notify={markdown_scalar(agent_interaction.get('user_notify') or '')} "
             f"must_attempt={agent_interaction.get('agent_must_attempt')} "
             f"delivery_allowed={agent_interaction.get('delivery_allowed')} "


### PR DESCRIPTION
## Summary
- add user_open_count to the compact status agent interaction summary
- render open_count beside action_required in current_agent_interaction markdown
- extend the status markdown agent-lane fixture to lock the contract

## Product / Architecture Judgment
Motivation: Codex heartbeat routing uses the paired user-channel signals action_required and open_count. PR #1706 exposed action_required in status, but operators still had to fall back to quota JSON to confirm there were zero open user todos for the current agent lane.

Solved or not: This PR keeps quota as the source of truth and only mirrors the existing user_todo_summary/open_count into the status read-model and markdown. It does not add a new state machine or alter scheduling, quota, todo, or runtime decisions.

User/operator impact: The status first screen can now say action_required=False open_count=0 next to the current agent todo, making side-agent gate scope easier to verify when goal-level user todos are also visible.

Main risk: Low display-contract risk. The added field is compact and derived from existing quota payloads; validation includes focused status smokes, perf budget, public boundary scan, and premerge selected canaries.

## Validation
- python3 examples/control_plane/status-markdown-smoke.py
- python3 examples/control_plane/agent-scope-projection-characterization-smoke.py
- python3 -m compileall -q loopx/cli_commands/status.py loopx/presentation/renderers/status_markdown.py examples/control_plane/status_markdown_agent_lane_fixtures.py
- PYTHONPATH="/private/tmp/loopx-product-capability-heartbeat-20260708T233908" python3 -m loopx.cli --registry "/Users/bytedance/.codex/loopx/registry.global.json" --runtime-root "/Users/bytedance/.codex/loopx" status --goal-id loopx-meta --agent-id codex-product-capability | rg -n "current_agent_interaction|current_agent_todo|asset_user_todo"
- python3 examples/control_plane/status-quota-perf-budget-smoke.py
- python3 examples/control_plane/work-lane-contract-smoke.py
- PYTHONPATH="/private/tmp/loopx-product-capability-heartbeat-20260708T233908" python3 -m loopx.cli check --scan-path loopx/cli_commands/status.py --scan-path loopx/presentation/renderers/status_markdown.py --scan-path examples/control_plane/status_markdown_agent_lane_fixtures.py
- PYTHONPATH="/private/tmp/loopx-product-capability-heartbeat-20260708T233908" python3 -m loopx.cli canary premerge --from-git-diff
