### PR TITLE
Expose user gate counts in diagnose signals

### DIFF
--- a/examples/agent-diagnose-packet-smoke.py
+++ b/examples/agent-diagnose-packet-smoke.py
@@ -253,6 +253,8 @@ def main() -> int:
         assert "can_self_drive" not in selected, selected
         assert selected["todo_evidence"]["agent_open_count"] == 1, selected
         assert selected["quota_signals"]["should_run"] is True, selected
+        assert selected["quota_signals"]["action_required"] is False, selected
+        assert selected["quota_signals"]["open_count"] == 0, selected
         assert selected["quota_signals"]["goal_frontier_projection"]["replan_required"] is False, (
             selected
         )
@@ -275,6 +277,8 @@ def main() -> int:
         assert "Agent Reasoning Checklist" in markdown, markdown
         assert "These are for the agent to run" in markdown, markdown
         assert "goal_frontier_projection: replan_required=False" in markdown, markdown
+        assert "- action_required: `False`" in markdown, markdown
+        assert "- open_count: `0`" in markdown, markdown
         assert "current_agent_advancement=0" in markdown, markdown
         assert "unclaimed_advancement=1" in markdown, markdown
         assert "scheduler_hint: action=" in markdown, markdown
@@ -288,6 +292,8 @@ def main() -> int:
         gated_selected = gated_packet["selected"]
         assert gated_selected["machine_signal"] == "user_or_controller_attention", gated_selected
         assert gated_selected["todo_evidence"]["user_open_count"] == 1, gated_selected
+        assert gated_selected["quota_signals"]["action_required"] is True, gated_selected
+        assert gated_selected["quota_signals"]["open_count"] == 1, gated_selected
         assert "autonomous=yes/no" in str(gated_selected["user_question"]), gated_selected
         assert "can_self_drive" not in gated_selected, gated_selected
 

--- a/loopx/diagnose.py
+++ b/loopx/diagnose.py
@@ -135,6 +135,19 @@ def _interaction_user_required(quota: dict[str, Any]) -> bool:
     return bool(quota.get("requires_user_action") or quota.get("notify_user_on_gate"))
 
 
+def _quota_user_action_required(quota: dict[str, Any]) -> bool:
+    if quota.get("action_required") is not None:
+        return bool(quota.get("action_required"))
+    return _interaction_user_required(quota)
+
+
+def _quota_user_open_count(quota: dict[str, Any]) -> int:
+    value = quota.get("open_count")
+    if isinstance(value, int):
+        return value
+    return _open_count(_as_dict(quota.get("user_todo_summary")))
+
+
 def _machine_signal(*, status_payload: dict[str, Any], item: dict[str, Any] | None, quota: dict[str, Any]) -> str:
     if not status_payload.get("ok"):
         return "status_health_attention"
@@ -143,7 +156,7 @@ def _machine_signal(*, status_payload: dict[str, Any], item: dict[str, Any] | No
     if not quota.get("ok", True):
         return "quota_attention"
     user_summary = _todo_summary(quota, item, role="user")
-    if _interaction_user_required(quota) or _open_count(user_summary) > 0:
+    if _quota_user_action_required(quota) or _open_count(user_summary) > 0:
         return "user_or_controller_attention"
     if quota.get("self_repair_allowed"):
         return "self_repair_attention"
@@ -222,6 +235,8 @@ def _compact_quota_signals(quota: dict[str, Any]) -> dict[str, Any]:
         "autonomous_replan_decision",
     )
     signals = {key: quota.get(key) for key in keys if key in quota}
+    signals["action_required"] = _quota_user_action_required(quota)
+    signals["open_count"] = _quota_user_open_count(quota)
     scheduler_hint = _compact_scheduler_hint(_as_dict(quota.get("scheduler_hint")))
     if scheduler_hint:
         signals["scheduler_hint"] = scheduler_hint
@@ -509,6 +524,8 @@ def render_diagnosis_markdown(payload: dict[str, Any]) -> str:
                 f"- quota_state: `{quota.get('state')}`",
                 f"- quota_should_run: `{quota.get('should_run')}`",
                 f"- effective_action: `{quota.get('effective_action')}`",
+                f"- action_required: `{quota.get('action_required')}`",
+                f"- open_count: `{quota.get('open_count')}`",
                 f"- requires_user_action: `{quota.get('requires_user_action')}`",
                 f"- normal_delivery_allowed: `{quota.get('normal_delivery_allowed')}`",
                 f"- self_repair_allowed: `{quota.get('self_repair_allowed')}`",


### PR DESCRIPTION
## Summary
- expose action_required and open_count in diagnose quota_signals
- derive those values from the quota compatibility fields with interaction/user-todo fallback
- render both values in diagnose markdown and cover ready/gated paths in the diagnose smoke

## Product / Architecture Judgment
Motivation: heartbeat and quota routing use the paired user-channel contract action_required/open_count, but diagnose only exposed requires_user_action and separate todo_evidence counts. That made the agent-facing diagnosis packet slightly less aligned with the source-of-truth quota guard.

Solved or not: This keeps quota as source of truth and adds compact compatibility fields to diagnose quota_signals. It does not change quota decisions, scheduler behavior, todo selection, or runtime execution.

User/operator impact: an agent diagnosing a stuck or runnable goal can now read the same action_required/open_count contract directly in the diagnosis packet and markdown without drilling into quota JSON.

Main risk: low read-model/display risk. The implementation is additive, has interaction/user-todo fallback for older payload shapes, and is covered by existing diagnose smoke paths.

## Validation
- python3 examples/agent-diagnose-packet-smoke.py
- python3 -m compileall -q loopx/diagnose.py examples/agent-diagnose-packet-smoke.py
- PYTHONPATH="/private/tmp/loopx-product-capability-heartbeat-20260709T000017" python3 -m loopx.cli --format json --registry "/Users/bytedance/.codex/loopx/registry.global.json" --runtime-root "/Users/bytedance/.codex/loopx" diagnose --goal-id loopx-meta --agent-id codex-product-capability
- PYTHONPATH="/private/tmp/loopx-product-capability-heartbeat-20260709T000017" python3 -m loopx.cli --registry "/Users/bytedance/.codex/loopx/registry.global.json" --runtime-root "/Users/bytedance/.codex/loopx" diagnose --goal-id loopx-meta --agent-id codex-product-capability | rg -n "action_required|open_count|requires_user_action|quota_should_run"
- python3 examples/control_plane/status-quota-review-packet-parity-smoke.py
- python3 examples/control_plane/quota-contract-smoke.py
- python3 examples/control_plane/work-lane-contract-smoke.py
- PYTHONPATH="/private/tmp/loopx-product-capability-heartbeat-20260709T000017" python3 -m loopx.cli check --scan-path loopx/diagnose.py --scan-path examples/agent-diagnose-packet-smoke.py
- PYTHONPATH="/private/tmp/loopx-product-capability-heartbeat-20260709T000017" python3 -m loopx.cli canary premerge --from-git-diff
