### PR TITLE
Link generated todo successors on completion

### DIFF
--- a/examples/control_plane/control-plane-integrated-canary-smoke.py
+++ b/examples/control_plane/control-plane-integrated-canary-smoke.py
@@ -246,7 +246,7 @@ def assert_event_projected_agent_todo(summary: dict[str, Any]) -> None:
         )
     assert [item.get("todo_id") for item in items] == [CANARY_TODO_ID], summary
     item = items[0]
-    assert item["title"] == CANARY_TODO_TITLE, summary
+    assert item.get("title") == CANARY_TODO_TITLE or CANARY_TODO_TITLE in str(item.get("text") or ""), summary
     assert item["claimed_by"] == AGENT_ID, summary
     assert item["task_class"] == "advancement_task", summary
     assert "todo_markdown_fallback" not in json.dumps(summary, sort_keys=True), summary
@@ -397,6 +397,7 @@ def assert_event_todo_completion_successor_state_machine(
     assert len(completed["next_todos"]) == 1, completed
     successor = completed["next_todos"][0]
     successor_id = successor["todo_id"]
+    assert completed["successor_todo_ids"] == [successor_id], completed
     assert successor["source"] == "event_log", completed
     assert successor["claimed_by"] == AGENT_ID, completed
     assert successor["task_class"] == "advancement_task", completed
@@ -421,6 +422,7 @@ def assert_event_todo_completion_successor_state_machine(
     by_id = {item["todo_id"]: item for item in listed["todos"]}
     assert by_id[CANARY_TODO_ID]["status"] == "done", listed
     assert by_id[CANARY_TODO_ID]["evidence"] == "fixture event-projected todo completion passed", listed
+    assert by_id[CANARY_TODO_ID]["successor_todo_ids"] == [successor_id], listed
     assert by_id[successor_id]["status"] == "open", listed
     assert by_id[successor_id]["claimed_by"] == AGENT_ID, listed
     assert by_id[successor_id]["unblocks_todo_id"] == CANARY_TODO_ID, listed

--- a/examples/control_plane/todo-lifecycle-cli-smoke.py
+++ b/examples/control_plane/todo-lifecycle-cli-smoke.py
@@ -105,12 +105,14 @@ def main() -> int:
         assert completed["changed"] is True, completed
         assert completed["next_todos"][0]["added"] is True, completed
         rebuild_todo_id = completed["next_todos"][0]["todo_id"]
+        assert completed["successor_todo_ids"] == [rebuild_todo_id], completed
         items = parsed_items(state_file)
         completed_item = next(item for item in items if item["todo_id"] == run_todo_id)
         rebuild_item = next(item for item in items if item["todo_id"] == rebuild_todo_id)
         assert completed_item["done"] is True and completed_item["status"] == "done", completed_item
         assert completed_item["evidence"] == "fresh-repeat-result-ready", completed_item
         assert completed_item["claimed_by"] == "codex-main-control", completed_item
+        assert completed_item["successor_todo_ids"] == [rebuild_todo_id], completed_item
         assert rebuild_item["done"] is False and rebuild_item["task_class"] == "advancement_task", rebuild_item
         assert rebuild_item["action_kind"] == "rebuild_score", rebuild_item
         assert rebuild_item["claimed_by"] == "codex-main-control", rebuild_item
@@ -231,6 +233,9 @@ def main() -> int:
             side_continuation_completed
         )
         side_successor_id = side_continuation_completed["next_todos"][0]["todo_id"]
+        assert side_continuation_completed["successor_todo_ids"] == [side_successor_id], (
+            side_continuation_completed
+        )
         side_successor_item = next(item for item in parsed_items(state_file) if item["todo_id"] == side_successor_id)
         assert side_successor_item["done"] is False, side_successor_item
         assert side_successor_item["claimed_by"] == "codex-side-bypass", side_successor_item
@@ -296,6 +301,7 @@ def main() -> int:
         assert side_completed["next_todos"][0]["claimed_by"] == "codex-main-control", side_completed
         assert side_completed["next_todos"][0]["blocks_agent"] == "codex-side-bypass", side_completed
         assert side_completed["next_todos"][0]["unblocks_todo_id"] == side_review_todo_id, side_completed
+        assert side_completed["successor_todo_ids"] == [review_todo_id], side_completed
         items = parsed_items(state_file)
         side_item = next(item for item in items if item["todo_id"] == side_todo_id)
         side_review_item = next(item for item in items if item["todo_id"] == side_review_todo_id)
@@ -304,6 +310,7 @@ def main() -> int:
         assert side_review_item["done"] is True and side_review_item["claimed_by"] == "codex-side-bypass", (
             side_review_item
         )
+        assert side_review_item["successor_todo_ids"] == [review_todo_id], side_review_item
         assert review_item["done"] is False and review_item["claimed_by"] == "codex-main-control", review_item
         assert not review_item.get("action_kind"), review_item
         assert review_item["blocks_agent"] == "codex-side-bypass", review_item
@@ -367,10 +374,12 @@ def main() -> int:
         )
         assert superseded["changed"] is True, superseded
         validate_todo_id = superseded["next_todos"][0]["todo_id"]
+        assert superseded["successor_todo_ids"] == [validate_todo_id], superseded
         items = parsed_items(state_file)
         rebuild_item = next(item for item in items if item["todo_id"] == rebuild_todo_id)
         validate_item = next(item for item in items if item["todo_id"] == validate_todo_id)
         assert rebuild_item["done"] is True and rebuild_item["superseded_by"] == validate_todo_id, rebuild_item
+        assert rebuild_item["successor_todo_ids"] == [validate_todo_id], rebuild_item
         assert validate_item["done"] is False and validate_item["task_class"] == "advancement_task", validate_item
         assert validate_item["claimed_by"] == "codex-main-control", validate_item
 
@@ -411,10 +420,12 @@ def main() -> int:
         assert handoff["changed"] is True, handoff
         assert handoff["next_todos"][0]["claimed_by"] == "codex-side-bypass", handoff
         handoff_successor_id = handoff["next_todos"][0]["todo_id"]
+        assert handoff["successor_todo_ids"] == [handoff_successor_id], handoff
         handoff_items = parsed_items(state_file)
         handoff_source_item = next(item for item in handoff_items if item["todo_id"] == handoff_source["todo_id"])
         handoff_successor_item = next(item for item in handoff_items if item["todo_id"] == handoff_successor_id)
         assert handoff_source_item["superseded_by"] == handoff_successor_id, handoff_source_item
+        assert handoff_source_item["successor_todo_ids"] == [handoff_successor_id], handoff_source_item
         assert handoff_successor_item["claimed_by"] == "codex-side-bypass", handoff_successor_item
 
         unclaimed_source = run_cli(

--- a/loopx/control_plane/todos/contract.py
+++ b/loopx/control_plane/todos/contract.py
@@ -247,6 +247,15 @@ def normalize_todo_id_list(value: Any) -> list[str]:
     return todo_ids
 
 
+def merge_todo_id_lists(*values: Any) -> list[str]:
+    todo_ids: list[str] = []
+    for value in values:
+        for todo_id in normalize_todo_id_list(value):
+            if todo_id not in todo_ids:
+                todo_ids.append(todo_id)
+    return todo_ids
+
+
 def normalize_required_write_scopes(value: Any) -> list[str]:
     if value is None:
         return []

--- a/loopx/control_plane/todos/event_writeback.py
+++ b/loopx/control_plane/todos/event_writeback.py
@@ -23,9 +23,9 @@ from .contract import (
     TODO_STATUS_DONE,
     TODO_STATUS_OPEN,
     build_todo_id,
+    merge_todo_id_lists,
     normalize_todo_claimed_by,
     normalize_todo_id,
-    normalize_todo_id_list,
     todo_done_for_status,
 )
 from .text import (
@@ -255,39 +255,8 @@ def complete_event_projected_goal_todo(
     if clear_claim and item.get("claimed_by"):
         item.pop("claimed_by", None)
     effective_claimed_by = claimed_by or normalize_todo_claimed_by(item.get("claimed_by"))
-    completion_payload: dict[str, Any] = {
-        "completed_at": updated_at,
-        "updated_at": updated_at,
-    }
-    if evidence:
-        completion_payload["evidence"] = evidence
-    if note:
-        completion_payload["note"] = note
-    if no_followup:
-        completion_payload["no_followup"] = "true"
-    normalized_successor_todo_ids = normalize_todo_id_list(successor_todo_ids)
-    if normalized_successor_todo_ids:
-        completion_payload["successor_todo_ids"] = normalized_successor_todo_ids
     store = AppendOnlyStateEventStore(Path(context["event_log_path"]))
     already_done = todo_done_for_status(str(item.get("status") or TODO_STATUS_OPEN))
-    completion_event = make_state_event(
-        event_id=_todo_write_event_id(
-            goal_id=goal_id,
-            todo_id=todo_id,
-            action="complete",
-            updated_at=updated_at,
-            text=evidence or note,
-        ),
-        goal_id=goal_id,
-        event_type=TODO_COMPLETED,
-        refs={"todo_id": todo_id},
-        payload=completion_payload,
-        recorded_at=updated_at,
-        producer="loopx.todo.complete",
-    )
-    if not already_done and not dry_run:
-        store.append(completion_event)
-
     if next_agent_todo and not next_claimed_by:
         next_claimed_by = normalize_todo_claimed_by(effective_claimed_by)
     next_unblocks_todo_id = todo_id if next_agent_todo else None
@@ -334,6 +303,40 @@ def complete_event_projected_goal_todo(
                 dry_run=dry_run,
             )
         )
+
+    normalized_successor_todo_ids = merge_todo_id_lists(
+        successor_todo_ids,
+        [item.get("todo_id") for item in next_results],
+    )
+    completion_payload: dict[str, Any] = {
+        "completed_at": updated_at,
+        "updated_at": updated_at,
+    }
+    if evidence:
+        completion_payload["evidence"] = evidence
+    if note:
+        completion_payload["note"] = note
+    if no_followup:
+        completion_payload["no_followup"] = "true"
+    if normalized_successor_todo_ids:
+        completion_payload["successor_todo_ids"] = normalized_successor_todo_ids
+    completion_event = make_state_event(
+        event_id=_todo_write_event_id(
+            goal_id=goal_id,
+            todo_id=todo_id,
+            action="complete",
+            updated_at=updated_at,
+            text=evidence or note,
+        ),
+        goal_id=goal_id,
+        event_type=TODO_COMPLETED,
+        refs={"todo_id": todo_id},
+        payload=completion_payload,
+        recorded_at=updated_at,
+        producer="loopx.todo.complete",
+    )
+    if not already_done and not dry_run:
+        store.append(completion_event)
 
     return {
         "ok": True,

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -27,6 +27,7 @@ from .control_plane.todos.contract import (
     TODO_TASK_CLASS_USER_GATE,
     build_todo_id,
     format_todo_metadata_line,
+    merge_todo_id_lists,
     normalize_required_capabilities,
     normalize_required_write_scopes,
     normalize_target_capabilities,
@@ -591,6 +592,38 @@ def upsert_todo_metadata(lines: list[str], block: dict[str, Any], metadata_line:
         insert_at -= 1
     lines.insert(insert_at, metadata_line)
     return True
+
+
+def link_generated_successor_todo_ids(
+    lines: list[str],
+    *,
+    update_result: dict[str, Any],
+    role: str | None,
+    successor_todo_ids: list[str],
+) -> bool:
+    merged_successor_ids = merge_todo_id_lists(
+        update_result.get("successor_todo_ids"),
+        successor_todo_ids,
+    )
+    if merged_successor_ids == normalize_todo_id_list(update_result.get("successor_todo_ids")):
+        return False
+    block_match = find_todo_block(
+        lines,
+        todo_id=str(update_result.get("todo_id") or ""),
+        role=role,
+    )
+    if not block_match:
+        return False
+    _resolved_role, _section, _start, _end, block = block_match
+    metadata_updated = upsert_todo_metadata(
+        lines,
+        block,
+        metadata_line_for_block(block, {"successor_todo_ids": merged_successor_ids}),
+    )
+    update_result["successor_todo_ids"] = merged_successor_ids
+    update_result["metadata_updated"] = bool(update_result.get("metadata_updated") or metadata_updated)
+    update_result["changed"] = bool(update_result.get("changed") or metadata_updated)
+    return metadata_updated
 
 
 def todo_metadata_would_change(lines: list[str], block: dict[str, Any], metadata_line: str | None) -> bool:
@@ -1503,8 +1536,18 @@ def complete_goal_todo(
                     updated_at=updated_at,
                 )
             )
+        generated_successor_todo_ids = [
+            todo_id
+            for todo_id in normalize_todo_id_list([item.get("todo_id") for item in next_results])
+        ]
+        successor_metadata_updated = link_generated_successor_todo_ids(
+            lines,
+            update_result=update_result,
+            role=role,
+            successor_todo_ids=generated_successor_todo_ids,
+        )
         next_changed = any(item.get("added") or item.get("metadata_updated") for item in next_results)
-        changed = bool(update_result["changed"] or next_changed)
+        changed = bool(update_result["changed"] or next_changed or successor_metadata_updated)
         new_text = "\n".join(lines) + ("\n" if original.endswith("\n") else "")
         if changed:
             new_text = replace_updated_at(new_text, updated_at)
@@ -1624,6 +1667,10 @@ def supersede_goal_todo(
                 )
             )
         superseded_by = next((item.get("todo_id") for item in next_results if item.get("todo_id")), None)
+        generated_successor_todo_ids = [
+            todo_id
+            for todo_id in normalize_todo_id_list([item.get("todo_id") for item in next_results])
+        ]
         if superseded_by:
             block_match = find_todo_block(lines, todo_id=str(update_result["todo_id"]), role=role)
             if block_match:
@@ -1631,9 +1678,22 @@ def supersede_goal_todo(
                 update_result["metadata_updated"] = upsert_todo_metadata(
                     lines,
                     block,
-                    metadata_line_for_block(block, {"superseded_by": superseded_by}),
+                    metadata_line_for_block(
+                        block,
+                        {
+                            "superseded_by": superseded_by,
+                            "successor_todo_ids": merge_todo_id_lists(
+                                update_result.get("successor_todo_ids"),
+                                generated_successor_todo_ids,
+                            ),
+                        },
+                    ),
                 ) or update_result["metadata_updated"]
                 update_result["superseded_by"] = superseded_by
+                update_result["successor_todo_ids"] = merge_todo_id_lists(
+                    update_result.get("successor_todo_ids"),
+                    generated_successor_todo_ids,
+                )
                 update_result["changed"] = True
         next_changed = any(item.get("added") or item.get("metadata_updated") for item in next_results)
         changed = bool(update_result["changed"] or next_changed)


### PR DESCRIPTION
## Summary
- Link generated `--next-agent-todo` / `--next-user-todo` continuation ids back onto the completed todo's `successor_todo_ids` in markdown active-state writeback.
- Keep `todo supersede --next-agent-todo` lineage explicit by recording both `superseded_by` and `successor_todo_ids`.
- Mirror the completion lineage in event-projected todo writeback, and tighten lifecycle/canary smokes so CLI payloads and read models agree.

## Product / architecture judgment
- Motivation: operators and quota/frontier reads should not infer that a completed advancement has no follow-up when the same CLI invocation already created a continuation todo.
- Solved: this makes continuation lineage explicit at the write boundary instead of relying only on reverse `unblocks_todo_id` inference.
- Impact: fewer false `completed advancement without successor`/replan signals and clearer todo history for side-agent self-iteration.
- Risk: narrow todo writeback/read-model surface. No benchmark scoring, runner, production, permission, or public evidence-policy behavior changes.
- Design: small shared `merge_todo_id_lists` helper; no new framework or speculative protocol fields.

## Validation
- `python3 -m py_compile loopx/todos.py loopx/control_plane/todos/contract.py loopx/control_plane/todos/event_writeback.py examples/control_plane/todo-lifecycle-cli-smoke.py examples/control_plane/control-plane-integrated-canary-smoke.py`
- `python3 examples/control_plane/todo-lifecycle-cli-smoke.py`
- `python3 examples/control_plane/todo-list-event-projection-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py` (`ok`, elapsed ~56s)
- `loopx canary premerge --from-git-diff` (`passed`, selected=17, failures=0, manual_holds=0)

Self-merge candidate after validation: single-purpose control-plane consistency fix, public/private scan clean, no manual holds.
