### PR TITLE
Preserve todo titles in quota summary payloads

### DIFF
--- a/examples/control_plane/control-plane-integrated-canary-smoke.py
+++ b/examples/control_plane/control-plane-integrated-canary-smoke.py
@@ -246,7 +246,7 @@ def assert_event_projected_agent_todo(summary: dict[str, Any]) -> None:
         )
     assert [item.get("todo_id") for item in items] == [CANARY_TODO_ID], summary
     item = items[0]
-    assert item.get("title") == CANARY_TODO_TITLE or CANARY_TODO_TITLE in str(item.get("text") or ""), summary
+    assert item["title"] == CANARY_TODO_TITLE, summary
     assert item["claimed_by"] == AGENT_ID, summary
     assert item["task_class"] == "advancement_task", summary
     assert "todo_markdown_fallback" not in json.dumps(summary, sort_keys=True), summary

--- a/loopx/control_plane/todos/quota_summary.py
+++ b/loopx/control_plane/todos/quota_summary.py
@@ -45,6 +45,7 @@ QUOTA_PAYLOAD_COMPACTION_SCHEMA_VERSION = "quota_todo_summary_payload_compaction
 QUOTA_PAYLOAD_ITEM_FIELDS = (
     "index",
     "text",
+    "title",
     "todo_id",
     "status",
     "priority",


### PR DESCRIPTION
## Summary
- preserve `title` when compacting todo items into quota-facing summary payloads
- tighten the integrated control-plane canary so `agent_todo_summary` must carry the structured title instead of relying on text fallback

## Validation
- `python3 -m py_compile loopx/control_plane/todos/quota_summary.py examples/control_plane/control-plane-integrated-canary-smoke.py`
- `python3 examples/control_plane/quota-contract-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `loopx canary premerge --from-git-diff`

## Risk / Scope
- Surfaces: control-plane todo quota read model, integrated canary assertion
- No benchmark runner, scoring, task semantics, raw logs, private state, credentials, or local paths included
- Public/private boundary scan passed via premerge gate
