### PR TITLE
Compact quota execute responses

### DIFF
--- a/examples/control_plane/quota-scheduler-state-ack-smoke.py
+++ b/examples/control_plane/quota-scheduler-state-ack-smoke.py
@@ -767,6 +767,9 @@ def assert_cli_scheduler_ack_progression() -> None:
         assert ack["scheduler_state_mutated"] is True, ack
         assert ack["scheduler_ack_event"]["scheduler_state"]["last_applied_rrule"] == first_rrule, ack
         assert Path(ack["scheduler_state_path"]).exists(), ack
+        assert ack["before"] == ack["scheduler_ack_event"]["before"], ack
+        assert ack["before"]["spent_slots"] == 0, ack
+        assert "scheduler_hint" not in ack["before"], ack
         assert ack["after"] is None, ack
         assert ack["post_ack_contract"]["do_not_apply_successor_rrule_from_ack_response"] is True, ack
 

--- a/examples/control_plane/quota-spend-agent-identity-smoke.py
+++ b/examples/control_plane/quota-spend-agent-identity-smoke.py
@@ -13,7 +13,7 @@ from types import ModuleType
 
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-FIXTURE_PATH = REPO_ROOT / "examples" / "control_plane" / "quota-plan-smoke.py"
+FIXTURE_PATH = REPO_ROOT / "examples" / "control_plane" / "quota_plan_fixtures.py"
 
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
@@ -208,6 +208,10 @@ def main() -> int:
         assert scoped_payload["ok"] is True, scoped_payload
         assert scoped_payload["appended"] is True, scoped_payload
         assert scoped_payload["agent_id"] == agent_id, scoped_payload
+        assert scoped_payload["before"] == scoped_payload["quota_event"]["before"], scoped_payload
+        assert scoped_payload["after"] == scoped_payload["quota_event"]["after"], scoped_payload
+        assert scoped_payload["after"]["spent_slots"] == scoped_payload["before"]["spent_slots"] + 1, scoped_payload
+        assert "quota" not in scoped_payload["before"], scoped_payload
 
     print("quota-spend-agent-identity-smoke ok")
     return 0

--- a/loopx/control_plane/quota/scheduler_ack.py
+++ b/loopx/control_plane/quota/scheduler_ack.py
@@ -177,6 +177,7 @@ def record_quota_scheduler_ack_for_decision(
             use_current_hint=use_current_hint,
         )
     if ack_plan.get("already_applied"):
+        output_before = compact_quota_decision(before) if execute else before
         payload = {
             "ok": True,
             "mode": "scheduler-ack",
@@ -189,8 +190,8 @@ def record_quota_scheduler_ack_for_decision(
             "appended": False,
             "registry_mutated": False,
             "already_applied": True,
-            "before": before,
-            "after": before,
+            "before": output_before,
+            "after": output_before,
             "reason": "scheduler RRULE already applied; no ack write needed",
         }
         if use_current_hint:
@@ -266,7 +267,7 @@ def record_quota_scheduler_ack_for_decision(
         "health_check": record["health_check"],
         "delivery_outcome": record["delivery_outcome"],
         "scheduler_state_path": str(state_path),
-        "before": before,
+        "before": compact_quota_decision(before) if execute else before,
         "after": None,
         "post_ack_contract": {
             "next_action": "wait_for_next_scheduler_tick_or_material_state_transition",

--- a/loopx/control_plane/quota/slot_accounting.py
+++ b/loopx/control_plane/quota/slot_accounting.py
@@ -636,6 +636,9 @@ def record_quota_slot_void_from_preview(
         ),
     }
     if execute:
+        payload["before"] = record["quota_event"]["before"]
+        payload["after"] = record["quota_event"]["after"]
+    if execute:
         runs_dir.mkdir(parents=True, exist_ok=True)
         json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
         markdown_path.write_text(render_quota_slot_preview_markdown(payload) + "\n", encoding="utf-8")
@@ -704,6 +707,9 @@ def record_quota_slot_spend_from_preview(
         ),
     }
     if execute:
+        payload["before"] = record["quota_event"]["before"]
+        payload["after"] = record["quota_event"]["after"]
+    if execute:
         runs_dir.mkdir(parents=True, exist_ok=True)
         json_path.write_text(json.dumps(record, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
         markdown_path.write_text(render_quota_slot_preview_markdown(payload) + "\n", encoding="utf-8")
@@ -715,8 +721,8 @@ def record_quota_slot_spend_from_preview(
 def render_quota_slot_preview_markdown(payload: dict[str, Any]) -> str:
     before = payload.get("before") if isinstance(payload.get("before"), dict) else {}
     after = payload.get("after") if isinstance(payload.get("after"), dict) else {}
-    before_quota = before.get("quota") if isinstance(before.get("quota"), dict) else {}
-    after_quota = after.get("quota") if isinstance(after.get("quota"), dict) else {}
+    before_quota = before.get("quota") if isinstance(before.get("quota"), dict) else before
+    after_quota = after.get("quota") if isinstance(after.get("quota"), dict) else after
     lines = [
         "# LoopX Quota Slot Preview",
         "",


### PR DESCRIPTION
## Summary
- compact top-level `before` / `after` in successful `quota spend-slot --execute` and `quota void-slot --execute` responses to match the already-compact quota event
- compact top-level `before` in successful scheduler ACK execute responses while leaving dry-run diagnostic payloads full-fidelity
- restore `quota-spend-agent-identity-smoke.py` to import the shared quota fixture directly and assert the compact execute contract

## Validation
- `python3 -m py_compile loopx/control_plane/quota/slot_accounting.py loopx/control_plane/quota/scheduler_ack.py examples/control_plane/quota-spend-agent-identity-smoke.py examples/control_plane/quota-scheduler-state-ack-smoke.py`
- `python3 examples/control_plane/quota-spend-agent-identity-smoke.py`
- `python3 examples/control_plane/quota-scheduler-state-ack-smoke.py`
- `python3 examples/control_plane/quota-contract-smoke.py`
- `python3 examples/control_plane/heartbeat-quota-flow-smoke.py`
- `loopx canary premerge --from-git-diff`

## Risk / Scope
- Surfaces: quota accounting execute response, scheduler ACK execute response, control-plane smokes
- Dry-run previews keep full diagnostic payloads; persisted quota events already use compact decisions and are unchanged in shape
- No benchmark runner/scoring/task behavior, private state, credentials, local paths, or raw benchmark evidence included
