### PR TITLE
Clarify monitor-poll decision summary contract

### DIFF
--- a/examples/control_plane/monitor-poll-writeback-smoke.py
+++ b/examples/control_plane/monitor-poll-writeback-smoke.py
@@ -263,6 +263,14 @@ def assert_unchanged_writeback() -> None:
         assert payload["classification"] == "quota_monitor_poll", payload
         assert payload["delivery_outcome"] == "surface_only", payload
         assert "no quota spend" in payload["health_check"], payload
+        summary = payload["decision_summary"]
+        assert summary["before"] == payload["monitor_event"]["before"], payload
+        assert summary["before"]["effective_action"] == payload["before"]["effective_action"], payload
+        assert "work_lane_contract" not in summary["before"], payload
+        assert payload["before"]["work_lane_contract"]["obligation"] == "attempt_due_monitor", payload
+        assert summary["after"]["effective_action"] == payload["after"]["effective_action"], payload
+        assert "interaction_contract" not in summary["after"], payload
+        assert payload["after"]["interaction_contract"]["mode"] == "bounded_delivery", payload
         records = monitor_poll_records(registry_path)
         assert [record["classification"] for record in records] == ["quota_monitor_poll"], records
 

--- a/loopx/control_plane/quota/monitor_poll.py
+++ b/loopx/control_plane/quota/monitor_poll.py
@@ -157,6 +157,10 @@ def _monitor_poll_failure(
         "result_hash": result_hash,
         "material_change": material_change,
         "reason": reason,
+        "decision_summary": {
+            "before": compact_quota_decision(before),
+            "after": None,
+        },
         "before": before,
         "after": None,
     }
@@ -317,6 +321,10 @@ def record_quota_monitor_poll_for_decision(
         run_history["recent_runs"] = [index_record, *recent_runs]
 
     after = after_decision(after_status)
+    decision_summary = {
+        "before": record["monitor_event"]["before"],
+        "after": compact_quota_decision(after),
+    }
     return {
         "ok": True,
         "mode": "monitor-poll",
@@ -338,6 +346,9 @@ def record_quota_monitor_poll_for_decision(
         "json_path": str(json_path),
         "markdown_path": str(markdown_path),
         "index_path": str(index_path),
+        "decision_summary": decision_summary,
+        # Monitor-poll callers may need the full follow-up guard to decide whether
+        # to stay quiet, replan, or continue work after recording the observation.
         "before": before,
         "after": after,
         "reason": (


### PR DESCRIPTION
## Summary
- add a compact `decision_summary` to `quota monitor-poll` success and failure responses
- keep full top-level `before` / `after` guard payloads for follow-up routing decisions
- extend the monitor-poll writeback smoke to lock the compact-vs-full response contract

## Validation
- `python3 examples/control_plane/monitor-poll-writeback-smoke.py`
- `python3 examples/control_plane/heartbeat-quota-flow-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `python3 -m py_compile loopx/control_plane/quota/monitor_poll.py examples/control_plane/monitor-poll-writeback-smoke.py`
- `loopx canary premerge --from-git-diff`