### PR TITLE
Compact agent-lane status todo summaries

### DIFF
--- a/examples/control_plane/status-markdown-smoke.py
+++ b/examples/control_plane/status-markdown-smoke.py
@@ -33,6 +33,7 @@ from loopx.handoff_budget import PROJECT_AGENT_HANDOFF_BUDGET  # noqa: E402
 from status_markdown_agent_lane_fixtures import (  # noqa: E402
     assert_status_agent_lane_frontier_hint_projection,
     assert_status_agent_lane_next_action_projection,
+    assert_status_agent_lane_todo_summary_display_compaction,
     assert_status_agent_lane_vision_lookback_survives_display_trim,
     assert_status_agent_member_handoff_uses_quota_identity,
     assert_status_agent_member_selected_lane_claim_survives_truncated_claim_list,
@@ -1330,6 +1331,7 @@ def main() -> int:
     assert_promotion_readiness_full_scan_fallback()
     assert_promotion_readiness_warning_in_quota_guard()
     assert_status_agent_lane_next_action_projection()
+    assert_status_agent_lane_todo_summary_display_compaction()
     assert_status_agent_member_selected_lane_claim_survives_truncated_claim_list()
     assert_status_agent_member_handoff_uses_quota_identity()
     assert_status_agent_lane_vision_lookback_survives_display_trim()

--- a/examples/control_plane/status_markdown_agent_lane_fixtures.py
+++ b/examples/control_plane/status_markdown_agent_lane_fixtures.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from loopx.cli_commands.status import (
+    _compact_agent_lane_todos_for_status_display,
     _review_handoff_agent,
     _status_collection_limit_for_agent_lane,
     _trim_run_history_for_status_display,
@@ -215,6 +216,88 @@ def assert_status_agent_lane_next_action_projection() -> None:
     assert packet["agent_member"]["agent_id"] == "codex-side-bypass", packet
     assert "Agent 成员：agent=codex-side-bypass role=side-agent" in packet["project_agent_handoff"], packet
     assert "authority=advisory_projection" in packet["project_agent_handoff"], packet
+
+
+def assert_status_agent_lane_todo_summary_display_compaction() -> None:
+    long_todos = [
+        {
+            "schema_version": "todo_item_v0",
+            "todo_id": f"todo_compact_{index}",
+            "index": index,
+            "role": "agent",
+            "status": "open",
+            "task_class": "continuous_monitor" if index % 2 else "advancement_task",
+            "claimed_by": "codex-product-capability",
+            "text": f"[P2] Compact status todo summary item {index} " + ("detail " * 40),
+        }
+        for index in range(1, 8)
+    ]
+    agent_todos = {
+        "schema_version": "todo_summary_v0",
+        "source_section": "Agent Todo",
+        "open_count": 7,
+        "done_count": 3,
+        "total_count": 10,
+        "items": long_todos,
+        "first_open_items": long_todos,
+        "monitor_open_items": long_todos,
+        "claimed_open_items": long_todos,
+        "claimed_monitor_open_items": long_todos,
+        "claimed_open_count": 7,
+        "unclaimed_open_count": 0,
+    }
+    user_todos = {
+        "schema_version": "todo_summary_v0",
+        "source_section": "User Todo / Owner Review Reading Queue",
+        "open_count": 1,
+        "done_count": 1,
+        "total_count": 2,
+        "items": long_todos[:3],
+        "first_open_items": long_todos[:1],
+        "handoff_gates": long_todos,
+    }
+    project_asset_agent_summary = project_asset_todo_summary(agent_todos, role="agent")
+    payload = {
+        "attention_queue": {
+            "items": [
+                {
+                    "goal_id": "agent-lane-display-compaction",
+                    "status": "active_state_agent_todo",
+                    "waiting_on": "codex",
+                    "severity": "action",
+                    "recommended_action": long_todos[0]["text"],
+                    "agent_todos": agent_todos,
+                    "user_todos": user_todos,
+                    "project_asset": {
+                        "agent_todos": project_asset_agent_summary,
+                    },
+                }
+            ]
+        }
+    }
+
+    _compact_agent_lane_todos_for_status_display(payload)
+
+    item = payload["attention_queue"]["items"][0]
+    compact_agent = item["agent_todos"]
+    compact_user = item["user_todos"]
+    assert compact_agent["open_count"] == 7, compact_agent
+    assert compact_agent["done_count"] == 3, compact_agent
+    assert len(compact_agent["items"]) == 2, compact_agent
+    assert compact_agent["payload_compaction"]["compacted_lanes"]["items"] == {
+        "shown": 2,
+        "total": 7,
+    }, compact_agent
+    assert compact_user["open_count"] == 1, compact_user
+    assert len(compact_user["handoff_gates"]) == 2, compact_user
+    assert item["project_asset"]["agent_todos"] == project_asset_agent_summary, item
+    marker = payload["agent_lane_todo_summary_compaction"]
+    assert marker["schema_version"] == "agent_lane_status_todo_summary_compaction_v0", marker
+
+    markdown = render_status_markdown(payload)
+    assert "agent_todos: open=7" in markdown, markdown
+    assert "open=None" not in markdown, markdown
+    assert "next_agent_todo:" in markdown, markdown
 
 
 def assert_status_agent_member_selected_lane_claim_survives_truncated_claim_list() -> None:

--- a/loopx/cli_commands/status.py
+++ b/loopx/cli_commands/status.py
@@ -21,6 +21,7 @@ from ..control_plane.runtime.status_projection_cache import (
     write_status_projection_cache,
 )
 from ..control_plane.todos.contract import normalize_todo_claimed_by
+from ..control_plane.todos.quota_summary import compact_quota_todo_summary_for_payload
 
 
 PrintPayload = Callable[
@@ -81,6 +82,40 @@ def _trim_run_history_for_status_display(
                 "status --agent-id collected quota-equivalent run history for "
                 "agent-lane frontier projection, then restored the requested "
                 "status display limit"
+            ),
+        }
+
+
+def _compact_agent_lane_todos_for_status_display(payload: dict[str, object]) -> None:
+    queue = payload.get("attention_queue")
+    if not isinstance(queue, dict):
+        return
+    items = queue.get("items")
+    if not isinstance(items, list):
+        return
+    compacted = 0
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        for key in ("user_todos", "agent_todos"):
+            summary = item.get(key)
+            if not isinstance(summary, dict):
+                continue
+            compact = compact_quota_todo_summary_for_payload(summary)
+            compaction = compact.get("payload_compaction")
+            if isinstance(compaction, dict):
+                compaction["full_detail_cold_path"] = (
+                    "status without --agent-id, todo list, or active state"
+                )
+            item[key] = compact
+            compacted += 1
+    if compacted:
+        payload["agent_lane_todo_summary_compaction"] = {
+            "schema_version": "agent_lane_status_todo_summary_compaction_v0",
+            "compacted_summary_count": compacted,
+            "reason": (
+                "status --agent-id keeps agent-lane display payloads bounded; "
+                "full todo detail remains on cold paths"
             ),
         }
 
@@ -363,6 +398,7 @@ def handle_status_command(
                 display_limit=display_limit,
                 collection_limit=collection_limit,
             )
+            _compact_agent_lane_todos_for_status_display(payload)
     except Exception as exc:
         payload = {
             "ok": False,


### PR DESCRIPTION
## Summary
- Compact item-level `user_todos` / `agent_todos` only for `status --agent-id` display payloads.
- Keep `collect_status`, normal status output, and `project_asset.agent_todos` unchanged so full todo detail remains available through cold paths.
- Add an agent-lane status markdown fixture covering count preservation, truncation metadata, project-asset stability, and markdown rendering.

## Validation
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 examples/control_plane/status-collection-readmodel-smoke.py`
- `python3 -m py_compile loopx/cli_commands/status.py examples/control_plane/status_markdown_agent_lane_fixtures.py examples/control_plane/status-markdown-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 examples/control_plane/status-quota-perf-budget-smoke.py`
- `python3 examples/control_plane/quota-contract-smoke.py`
- `git diff --check`
- public/private scan over changed files
- live `status --agent-id` size check: about 222KB total, with item-level `agent_todos` and `user_todos` capped to 2 visible items plus compaction metadata
- `loopx canary premerge --from-git-diff` (`selected=17`, `failures=0`, `manual_holds=0`, `self_merge_allowed=true`)
