### PR TITLE
test: sync showcase catalog smoke with readme tagline

### DIFF
--- a/examples/showcase-catalog-smoke.py
+++ b/examples/showcase-catalog-smoke.py
@@ -236,9 +236,13 @@ def main() -> int:
     ):
         assert phrase in feedback_loop, phrase
     for phrase in (
-        "Loop engineering for long-running AI agents.",
+        "Loop engineering for long-running AI agents and agent teams.",
+        "A lightweight state kernel and agent-agnostic local control plane for",
         "https://huangruiteng.github.io/loopx/frontstage/",
         "docs/outreach/frontstage-demo-script.md",
+        "## Experimental Features",
+        "### Auto Research One-Click Start",
+        "### Review Agent Work",
         "## See It In Action",
         "docs/showcases/cases/0617-blocked-p0-safe-rotation.md",
         "docs/showcases/cases/0619-loopx-self-iteration.md",


### PR DESCRIPTION
## Summary
- Sync showcase catalog smoke with the merged README tagline and experimental feature anchors from PR #1717.
- Keeps the public Frontstage Pages build smoke aligned with the current public entry surface.

## Validation
- `python3 examples/showcase-catalog-smoke.py`
- `loopx canary premerge --from-git-diff`

## Notes
- Follow-up to PR #1717. The previous PR merged successfully, but GitHub Frontstage Pages failed on this stale smoke assertion.