### PR TITLE
Release LoopX v0.1.14

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -153,6 +153,17 @@ path, and canary route rather than as a user-facing release baseline.
   #1621, #1625); and relaxes local `next_action` / `recommended_action` text to
   allow local project routing references while still rejecting inline
   credentials (#1645).
+- `v0.1.14` on 2026-07-09 11:49 +08:00: developer-contributed exploration
+  topology and monitor/quota recovery release at the matching `v0.1.14` tag.
+  This release promotes the software exploration result layer (#1546): public
+  explore node/edge/finding records, Lark presentation mapping, graph exports,
+  router/load-profile planning primitives, and deny-by-default
+  `explore_harness` worker/todo branch planners gated by each goal's
+  `spawn_policy`. It also ships the monitor scheduler cadence repairs that
+  keep quiet monitor polls from collapsing back to short intervals (#1699 and
+  related scheduler fixes), plus quota/status/todo read-model hardening for
+  user-gate counts, completed-todo successors, evidence-log counts, delivery
+  lineage, and compact agent-lane status summaries (#1707-#1716).
 
 When a new public release is promoted, add it here only after the matching tag,
 release note, stable ref, update path, and focused release canary agree.

--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.13"
+__version__ = "0.1.14"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.1.13"
+version = "0.1.14"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
- bump LoopX package version from `0.1.13` to `0.1.14`
- add the `v0.1.14` release timeline entry for the developer-contributed exploration topology/result layer and monitor/quota/status recovery work
- keep the release contract scoped to GitHub tag/stable promotion; no runtime behavior changes beyond version metadata

## Validation
- `python3 examples/release/release-version-contract-smoke.py`
- `python3 examples/release/release-readiness-doc-smoke.py`
- `python3 -m py_compile loopx/*.py`
- `python3 examples/release/codex-cli-no-clone-release-verification-smoke.py`
- `python3 examples/fresh-clone-quickstart-smoke.py`
- `python3 examples/loopx-update-smoke.py`
- `python3 examples/explore-worker-plan-gate-smoke.py`
- `python3 examples/explore-result-layer-smoke.py`
- `python3 examples/control_plane/quota-plan-smoke.py`
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 -m loopx.cli check --scan-path README.md --scan-path docs/ --scan-path examples/`
- `python3 examples/canary/canary-promotion-readiness-smoke.py --no-write-evidence`
- `python3 -m loopx.cli canary premerge --from-git-diff --tier quick --timeout-seconds 60`
- `git diff --check`

Dashboard browser readiness was intentionally not included because local dashboard npm dependencies are unavailable; the promotion canary skipped that optional browser subcheck and reported the skip explicitly.

## Public/private boundary
Candidate paths scanned before staging: `pyproject.toml`, `loopx/__init__.py`, and `docs/product/release-readiness.md`. No private release evidence, credentials, raw logs, local goal state, or benchmark traces are included.

## Merge note
This is a small release metadata/docs PR. The diff-aware premerge gate reported `self_merge_allowed=true`.