### PR TITLE
Expose current agent action in status projection

### DIFF
--- a/examples/control_plane/status_markdown_agent_lane_fixtures.py
+++ b/examples/control_plane/status_markdown_agent_lane_fixtures.py
@@ -197,6 +197,10 @@ def assert_status_agent_lane_next_action_projection() -> None:
     assert projection["projection_is_authoritative"] is False, projection
     lane_projection = payload["agent_lane_next_action_projection"]
     assert lane_projection["agent_interaction_attached_count"] == 1, lane_projection
+    assert lane_projection["current_agent_todo_id"] == "todo_side_tui", lane_projection
+    assert lane_projection["current_agent_action"] == side_action, lane_projection
+    assert lane_projection["selected_by"] == "current_agent_claimed_todo", lane_projection
+    assert lane_projection["confidence"] == "selected", lane_projection
     markdown = render_status_markdown(payload)
     assert "agent_member: agent=codex-side-bypass role=side-agent" in markdown, markdown
     assert "worktree_policy=independent_worktree_required" in markdown, markdown

--- a/loopx/cli_commands/status.py
+++ b/loopx/cli_commands/status.py
@@ -723,6 +723,7 @@ def attach_agent_lane_next_actions(payload: dict[str, object], *, agent_id: str)
     goal_frontier_attached = 0
     member_attached = 0
     interaction_attached = 0
+    current_agent_next_action: dict[str, Any] | None = None
     for item in items:
         if not isinstance(item, dict):
             continue
@@ -737,6 +738,8 @@ def attach_agent_lane_next_actions(payload: dict[str, object], *, agent_id: str)
         project_asset = item.get("project_asset")
         changed = False
         if isinstance(next_action, dict):
+            if current_agent_next_action is None:
+                current_agent_next_action = next_action
             item["agent_lane_next_action"] = next_action
             if isinstance(project_asset, dict):
                 project_asset["agent_lane_next_action"] = next_action
@@ -800,7 +803,7 @@ def attach_agent_lane_next_actions(payload: dict[str, object], *, agent_id: str)
         or member_attached
         or interaction_attached
     ):
-        payload["agent_lane_next_action_projection"] = {
+        projection: dict[str, object] = {
             "schema_version": "agent_lane_next_action_projection_v0",
             "agent_id": safe_agent_id,
             "attached_count": attached,
@@ -811,6 +814,23 @@ def attach_agent_lane_next_actions(payload: dict[str, object], *, agent_id: str)
             "agent_interaction_attached_count": interaction_attached,
             "preserves_goal_next_action": True,
         }
+        if isinstance(current_agent_next_action, dict):
+            current_action_text = _compact_member_text(
+                _agent_lane_text(current_agent_next_action),
+                limit=240,
+            )
+            current_todo_id = str(current_agent_next_action.get("todo_id") or "").strip()
+            if current_todo_id:
+                projection["current_agent_todo_id"] = current_todo_id
+            if current_action_text:
+                projection["current_agent_action"] = current_action_text
+            selected_by = str(current_agent_next_action.get("selected_by") or "").strip()
+            if selected_by:
+                projection["selected_by"] = selected_by
+            confidence = str(current_agent_next_action.get("confidence") or "").strip()
+            if confidence:
+                projection["confidence"] = confidence
+        payload["agent_lane_next_action_projection"] = projection
     if member_attached:
         payload["agent_member_projection"] = {
             "schema_version": "agent_member_projection_v0",


### PR DESCRIPTION
## Summary
- Add compact `current_agent_todo_id`, `current_agent_action`, `selected_by`, and `confidence` fields to the existing `agent_lane_next_action_projection` packet for `status --agent-id`.
- Preserve the goal-level `recommended_action` / Next Action behavior; this only makes the current agent lane directly visible to JSON consumers.
- Extend the status markdown agent-lane fixture to lock the selected current-agent todo/action projection.

## Validation
- `python3 examples/control_plane/status-markdown-smoke.py`
- `python3 examples/control_plane/status-collection-readmodel-smoke.py`
- `python3 examples/control_plane/status-quota-review-packet-parity-smoke.py`
- `python3 examples/control_plane/hot-path-interface-budget-smoke.py`
- `python3 -m py_compile loopx/cli_commands/status.py examples/control_plane/status_markdown_agent_lane_fixtures.py examples/control_plane/status-markdown-smoke.py`
- live source `status --agent-id` projection check: `current_agent_todo_id=todo_8bd5594a3464`, `selected_by=current_agent_claimed_todo`, `preserves_goal_next_action=true`
- `git diff --check` / public-private scan over changed files
- `loopx canary premerge --from-git-diff` (`selected=17`, `failures=0`, `manual_holds=0`, `self_merge_allowed=true`)
