### PR TITLE
ci: add full public smoke sweep workflow

### DIFF
--- a/.github/workflows/full-public-smokes.yml
+++ b/.github/workflows/full-public-smokes.yml
@@ -1,0 +1,94 @@
+name: Full Public Smokes
+
+on:
+  workflow_dispatch:
+    inputs:
+      timeout_seconds:
+        description: "Per-smoke timeout in seconds"
+        required: false
+        default: "120"
+        type: string
+  schedule:
+    # Daily off-hours sweep. The workflow is intentionally not a PR-required check.
+    - cron: "37 18 * * *"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/workflows/full-public-smokes.yml"
+      - "README.md"
+      - "README.zh-CN.md"
+      - "docs/**"
+      - "examples/**"
+      - "loopx/**"
+      - "pyproject.toml"
+      - "scripts/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: full-public-smokes-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  full-public-smokes:
+    if: github.repository == 'huangruiteng/loopx'
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - shard: 0
+            offset: 0
+          - shard: 1
+            offset: 100
+          - shard: 2
+            offset: 200
+          - shard: 3
+            offset: 300
+          - shard: 4
+            offset: 400
+          - shard: 5
+            offset: 500
+    env:
+      SHARD_LIMIT: "100"
+      SMOKE_TIMEOUT_SECONDS: ${{ github.event_name == 'workflow_dispatch' && inputs.timeout_seconds || '120' }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Preview full-public shard
+        run: |
+          python3 examples/run-smokes.py \
+            --suite full-public \
+            --offset "${{ matrix.offset }}" \
+            --limit "${SHARD_LIMIT}" \
+            --timeout-seconds "${SMOKE_TIMEOUT_SECONDS}" \
+            --no-execute
+
+      - name: Run full-public shard
+        run: |
+          set -euo pipefail
+          mkdir -p smoke-results
+          python3 examples/run-smokes.py \
+            --suite full-public \
+            --offset "${{ matrix.offset }}" \
+            --limit "${SHARD_LIMIT}" \
+            --timeout-seconds "${SMOKE_TIMEOUT_SECONDS}" \
+            --json \
+            | tee "smoke-results/full-public-shard-${{ matrix.shard }}.json"
+
+      - name: Upload smoke result
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: full-public-smokes-shard-${{ matrix.shard }}
+          path: smoke-results/full-public-shard-${{ matrix.shard }}.json
+          if-no-files-found: ignore

--- a/examples/full-public-smokes-workflow-smoke.py
+++ b/examples/full-public-smokes-workflow-smoke.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Validate the GitHub Actions full-public smoke workflow contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = REPO_ROOT / ".github" / "workflows" / "full-public-smokes.yml"
+
+
+def main() -> int:
+    text = WORKFLOW.read_text(encoding="utf-8")
+
+    for required in [
+        "name: Full Public Smokes",
+        "workflow_dispatch:",
+        "schedule:",
+        "push:",
+        "branches:",
+        "- main",
+        "permissions:",
+        "contents: read",
+        "fail-fast: false",
+        "timeout-minutes: 120",
+        "actions/setup-python@v5",
+        "python-version: \"3.11\"",
+        "python3 examples/run-smokes.py",
+        "--suite full-public",
+        "--offset \"${{ matrix.offset }}\"",
+        "--limit \"${SHARD_LIMIT}\"",
+        "--timeout-seconds \"${SMOKE_TIMEOUT_SECONDS}\"",
+        "--no-execute",
+        "--json",
+        "actions/upload-artifact@v4",
+        "smoke-results/full-public-shard-${{ matrix.shard }}.json",
+    ]:
+        assert required in text, required
+
+    assert "pull_request:" not in text
+    assert "contents: write" not in text
+    assert "pull-requests: write" not in text
+    assert "sec" + "rets." not in text
+
+    for shard, offset in enumerate(range(0, 600, 100)):
+        assert f"shard: {shard}" in text, shard
+        assert f"offset: {offset}" in text, offset
+
+    print("full-public-smokes-workflow-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add a `Full Public Smokes` GitHub Actions workflow for full-public smoke sweeps
- run the suite in six fixed shards with JSON artifacts per shard
- trigger it manually, nightly, and on scoped pushes to `main`; do not make it a default pull-request check
- add a focused workflow smoke so the trigger/sharding/runner contract stays stable

## Validation
- `python3 examples/full-public-smokes-workflow-smoke.py`
- `python3 -m py_compile examples/full-public-smokes-workflow-smoke.py examples/run-smokes.py`
- `python3 examples/run-smokes.py --script examples/full-public-smokes-workflow-smoke.py --timeout-seconds 120`
- full-public shard preview: offsets `0,100,200,300,400,500,600` => `100,100,100,100,100,15,0` selected checks from 515 matched
- `git diff --check` and `git diff --cached --check`
- `loopx check --scan-path .github/workflows/full-public-smokes.yml --scan-path examples/full-public-smokes-workflow-smoke.py`
- `loopx canary premerge --from-git-diff`

## Notes
- PRs stay fast: this workflow intentionally has no `pull_request` trigger.
- The workflow uses read-only repository permissions and uploads shard JSON artifacts for failure triage.