### PR TITLE
Drive observation for external dependency monitors

### DIFF
--- a/examples/control_plane/external-evidence-observation-smoke.py
+++ b/examples/control_plane/external-evidence-observation-smoke.py
@@ -84,6 +84,29 @@ def monitor_todo(
     )
 
 
+def pr_dependency_monitor_todo(
+    *,
+    result_hash: str | None = None,
+    last_checked_at: str | None = None,
+) -> dict[str, Any]:
+    metadata: dict[str, Any] = {
+        "target_key": "pr_merged:#532",
+        "next_due_at": FUTURE_DUE_AT,
+        "claimed_by": AGENT_ID,
+    }
+    if result_hash:
+        metadata["result_hash"] = result_hash
+    if last_checked_at:
+        metadata["last_checked_at"] = last_checked_at
+    return todo(
+        3,
+        "[P0] Monitor PR #532 review/merge state before resuming the rerun lane.",
+        task_class=TODO_TASK_CLASS_MONITOR,
+        todo_id="todo_pr_dependency_monitor",
+        **metadata,
+    )
+
+
 def advancement_todo() -> dict[str, Any]:
     return todo(
         2,
@@ -107,6 +130,7 @@ def status_payload(
     waiting_on: str = "codex",
     next_action: str = "Observe compact result marker for remote job handle.",
     latest_runs: list[dict[str, Any]] | None = None,
+    lifecycle_flags: list[str] | None = None,
 ) -> dict[str, Any]:
     return quota_status_payload(
         goal_id=GOAL_ID,
@@ -121,7 +145,11 @@ def status_payload(
             "registered_agents": ["codex-main-control", AGENT_ID],
         },
         latest_runs=latest_runs or [],
-        item_extra={"lifecycle_flags": ["launched polling result marker"]},
+        item_extra={
+            "lifecycle_flags": lifecycle_flags
+            if lifecycle_flags is not None
+            else ["launched polling result marker"]
+        },
     )
 
 
@@ -297,6 +325,82 @@ def assert_future_scoped_monitor_does_not_fake_external_poll() -> None:
     assert "external_evidence_observation" not in guard, guard
 
 
+def assert_pr_dependency_wait_requires_first_observation() -> None:
+    summary = agent_todos([pr_dependency_monitor_todo()])
+    next_action = (
+        "Keep PR #532 in review-required state; after maintainer review/merge, "
+        "resume dependent validation lane."
+    )
+    item = selected_item(
+        status_payload(
+            summary,
+            status="active",
+            next_action=next_action,
+            latest_runs=[],
+            lifecycle_flags=[],
+        )
+    )
+    signal = build_external_evidence_poll_signal(item, agent_todo_summary=summary)
+    assert signal and signal["matched_signal"] == "external_dependency_wait", signal
+    assert signal["monitor_handle"]["target_key"] == "pr_merged:#532", signal
+
+    guard = build_quota_should_run(
+        status_payload(
+            summary,
+            status="active",
+            next_action=next_action,
+            latest_runs=[],
+            lifecycle_flags=[],
+        ),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+    assert guard["should_run"] is True, guard
+    assert guard["effective_action"] == "external_evidence_observe", guard
+    observation = guard["external_evidence_observation"]
+    assert observation["kind"] == "launched_external_work_monitor", observation
+    assert observation["monitor_handle"]["target_key"] == "pr_merged:#532", observation
+    assert guard["interaction_contract"]["agent_channel"]["must_attempt"] is True, guard
+
+
+def assert_pr_dependency_wait_with_observation_does_not_reobserve_before_due() -> None:
+    summary = agent_todos(
+        [
+            pr_dependency_monitor_todo(
+                result_hash="pr_532_open_review_required",
+                last_checked_at="2026-07-08T18:00:00+08:00",
+            )
+        ]
+    )
+    next_action = (
+        "Keep PR #532 in review-required state; after maintainer review/merge, "
+        "resume dependent validation lane."
+    )
+    item = selected_item(
+        status_payload(
+            summary,
+            status="active",
+            next_action=next_action,
+            lifecycle_flags=[],
+        )
+    )
+    assert build_external_evidence_poll_signal(item, agent_todo_summary=summary) is None
+
+    guard = build_quota_should_run(
+        status_payload(
+            summary,
+            status="active",
+            next_action=next_action,
+            lifecycle_flags=[],
+        ),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+    assert guard["effective_action"] == "autonomous_replan_required", guard
+    assert "external_evidence_observation" not in guard, guard
+    assert guard["interaction_contract"]["agent_channel"]["must_attempt"] is True, guard
+
+
 def assert_explicit_external_wait_builds_registry_obligation() -> None:
     summary = agent_todos([])
     payload = status_payload(
@@ -323,6 +427,8 @@ def main() -> int:
     assert_recent_due_monitor_no_change_quiets_external_monitor()
     assert_advancement_lane_keeps_external_monitor_as_context()
     assert_future_scoped_monitor_does_not_fake_external_poll()
+    assert_pr_dependency_wait_requires_first_observation()
+    assert_pr_dependency_wait_with_observation_does_not_reobserve_before_due()
     assert_explicit_external_wait_builds_registry_obligation()
     print("external-evidence-observation-smoke ok")
     return 0

--- a/loopx/control_plane/scheduler/external_evidence_observation.py
+++ b/loopx/control_plane/scheduler/external_evidence_observation.py
@@ -44,6 +44,9 @@ EXTERNAL_EVIDENCE_HANDLE_ABSENT_PATTERNS = (
         r"(?:absent|missing|not\s+available|does\s+not\s+exist|exists\s+yet)\b"
     ),
 )
+EXTERNAL_DEPENDENCY_TARGET_KEY_PATTERN = re.compile(
+    r"(?i)^(?:pr_merged|pr_review(?:ed)?|github_pr|pull_request):"
+)
 
 
 def projected_monitor_handle(summary: dict[str, Any] | None) -> dict[str, Any] | None:
@@ -81,6 +84,56 @@ def scoped_monitor_watch_without_advancement(summary: dict[str, Any] | None) -> 
     return todo_summary_open_task_counts(summary).get("advancement", 0) <= 0
 
 
+def _monitor_item_has_observation_state(item: dict[str, Any]) -> bool:
+    if str(item.get("result_hash") or "").strip():
+        return True
+    if str(item.get("last_checked_at") or "").strip():
+        return True
+    return False
+
+
+def _external_dependency_monitor_needs_first_observation(
+    summary: dict[str, Any] | None,
+) -> bool:
+    for item in todo_summary_monitor_items(summary):
+        target_key = str(item.get("target_key") or "").strip()
+        if not target_key:
+            continue
+        if not EXTERNAL_DEPENDENCY_TARGET_KEY_PATTERN.search(target_key):
+            continue
+        if not _monitor_item_has_observation_state(item):
+            return True
+    return False
+
+
+def _matches_any(patterns: tuple[re.Pattern[str], ...], texts: list[str]) -> bool:
+    return any(pattern.search(text) for pattern in patterns for text in texts)
+
+
+def _monitor_window_allows_poll_signal(
+    summary: dict[str, Any] | None,
+    *,
+    scoped_monitor_watch: bool,
+    scoped_monitor_handle: dict[str, Any] | None,
+    dependency_monitor_pending: bool,
+) -> bool:
+    if (
+        todo_summary_has_only_future_scoped_monitor_work(summary)
+        and not dependency_monitor_pending
+    ):
+        return False
+    if scoped_monitor_watch and not scoped_monitor_handle:
+        return False
+    if (
+        scoped_monitor_watch
+        and todo_summary_monitor_due_count(summary) <= 0
+        and todo_summary_monitor_schedule_gap_count(summary) <= 0
+        and not dependency_monitor_pending
+    ):
+        return False
+    return True
+
+
 def build_external_evidence_poll_signal(
     item: dict[str, Any],
     *,
@@ -97,8 +150,9 @@ def build_external_evidence_poll_signal(
 
     scoped_monitor_handle = projected_monitor_handle(agent_todo_summary)
     scoped_monitor_watch = scoped_monitor_watch_without_advancement(agent_todo_summary)
-    if todo_summary_has_only_future_scoped_monitor_work(agent_todo_summary):
-        return None
+    dependency_monitor_pending = _external_dependency_monitor_needs_first_observation(
+        agent_todo_summary
+    )
     project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
     action_texts = [
         str(value or "").strip()
@@ -146,42 +200,39 @@ def build_external_evidence_poll_signal(
     if not all_texts:
         return None
 
-    direct_observe_action = any(
-        pattern.search(text)
-        for pattern in EXTERNAL_EVIDENCE_OBSERVE_PATTERNS
-        for text in action_texts
+    direct_observe_action = _matches_any(EXTERNAL_EVIDENCE_OBSERVE_PATTERNS, action_texts)
+    direct_observe_todo = _matches_any(EXTERNAL_EVIDENCE_OBSERVE_PATTERNS, todo_texts)
+    direct_observe_state = _matches_any(EXTERNAL_EVIDENCE_OBSERVE_PATTERNS, launched_texts)
+    launched_wait = bool(action_texts) and _matches_any(
+        EXTERNAL_EVIDENCE_LAUNCHED_PATTERNS,
+        launched_texts,
     )
-    direct_observe_todo = any(
-        pattern.search(text)
-        for pattern in EXTERNAL_EVIDENCE_OBSERVE_PATTERNS
-        for text in todo_texts
-    )
-    direct_observe_state = any(
-        pattern.search(text)
-        for pattern in EXTERNAL_EVIDENCE_OBSERVE_PATTERNS
-        for text in launched_texts
-    )
-    launched_wait = bool(action_texts) and any(
-        pattern.search(text)
-        for pattern in EXTERNAL_EVIDENCE_LAUNCHED_PATTERNS
-        for text in launched_texts
-    )
-    handle_absent = any(
-        pattern.search(text)
-        for pattern in EXTERNAL_EVIDENCE_HANDLE_ABSENT_PATTERNS
-        for text in action_texts
-    )
+    handle_absent = _matches_any(EXTERNAL_EVIDENCE_HANDLE_ABSENT_PATTERNS, action_texts)
     if handle_absent and not launched_wait and not direct_observe_action and not direct_observe_state:
         return None
     direct_observe = direct_observe_action or direct_observe_todo or direct_observe_state
-    if not direct_observe and not launched_wait:
+    if launched_wait:
+        matched_signal = "launched_wait"
+        matched_channel = "action"
+    elif dependency_monitor_pending:
+        matched_signal = "external_dependency_wait"
+        matched_channel = "state"
+    elif direct_observe:
+        matched_signal = "direct_observe"
+        matched_channel = (
+            "action"
+            if direct_observe_action
+            else "todo"
+            if direct_observe_todo
+            else "state"
+        )
+    else:
         return None
-    if scoped_monitor_watch and not scoped_monitor_handle:
-        return None
-    if (
-        scoped_monitor_watch
-        and todo_summary_monitor_due_count(agent_todo_summary) <= 0
-        and todo_summary_monitor_schedule_gap_count(agent_todo_summary) <= 0
+    if not _monitor_window_allows_poll_signal(
+        agent_todo_summary,
+        scoped_monitor_watch=scoped_monitor_watch,
+        scoped_monitor_handle=scoped_monitor_handle,
+        dependency_monitor_pending=dependency_monitor_pending,
     ):
         return None
 
@@ -198,14 +249,8 @@ def build_external_evidence_poll_signal(
         "source": "active_state_or_latest_run",
         "trigger": "implicit_launched_external_poll",
         "observation_target": observation_target,
-        "matched_signal": "launched_wait" if launched_wait else "direct_observe",
-        "matched_channel": (
-            "action"
-            if launched_wait or direct_observe_action
-            else "todo"
-            if direct_observe_todo
-            else "state"
-        ),
+        "matched_signal": matched_signal,
+        "matched_channel": matched_channel,
     }
     if scoped_monitor_handle:
         signal["monitor_handle"] = scoped_monitor_handle


### PR DESCRIPTION
## Summary
- treat structured external-dependency monitor targets such as `pr_merged:#N` as requiring one first observation before monitor-only quiet skip
- keep future monitor quiet behavior intact after a monitor has `result_hash` or `last_checked_at`
- avoid natural-language PR parsing; the gate uses structured todo projection state only

## Validation
- `python3 examples/control_plane/external-evidence-observation-smoke.py`
- `python3 examples/control_plane/work-lane-contract-smoke.py`
- `python3 examples/control_plane/monitor-poll-policy-smoke.py`
- `python3 examples/control_plane/heartbeat-quota-flow-smoke.py`
- `python3 -m py_compile loopx/control_plane/scheduler/external_evidence_observation.py examples/control_plane/external-evidence-observation-smoke.py`
- `PYTHONPATH=. python3 -m loopx.cli canary premerge --from-git-diff --no-progress`