### PR TITLE
Keep no-handoff side-agent prompts in lane

### DIFF
--- a/docs/heartbeat-automation-prompt.md
+++ b/docs/heartbeat-automation-prompt.md
@@ -142,6 +142,10 @@ agent identity.
   goal registry declares `coordination.side_agent_handoff_agent`, LoopX routes
   the successor there instead. Same-agent broad handoff is rejected; use
   `--side-agent-self-merged --evidence` for same-agent delivery.
+- when `coordination.side_agent_handoff_agent` is the current side-agent id,
+  the scoped prompt treats that as a no-broad-handoff lane: blocked or unclear
+  work should stay claimed by the side agent with a concrete blocker, not be
+  routed to another review owner.
 Once a goal has `coordination.registered_agents`, prompt generation without
 `--agent-id` fails closed. That is the lightweight migration signal for stale
 Codex App automations: the next refresh attempt surfaces a concrete

--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -158,6 +158,11 @@ specific side-agent through
 `coordination.agent_profiles.<agent_id>.review_policy.handoff_agent`. First
 register the agent ids and primary agent in the goal registry:
 
+If `coordination.side_agent_handoff_agent` equals the current side-agent id,
+LoopX treats that as a no-broad-handoff lane for generated prompts. The side
+agent should keep blocked or unclear work claimed by itself with a concrete
+blocker instead of creating a successor review todo for another agent.
+
 `quota should-run --agent-id <side-agent-id>` enforces this as a preflight: when
 the side agent is running from the registered primary checkout, a non-git
 directory, or an unrelated git worktree, it returns `workspace_guard` and blocks

--- a/examples/control_plane/heartbeat-prompt-smoke.py
+++ b/examples/control_plane/heartbeat-prompt-smoke.py
@@ -1174,6 +1174,69 @@ def main() -> int:
             "task_body"
         ], cli_ignored_review_payload
 
+        no_handoff_registry_path = project / ".loopx" / "no-handoff-registry.json"
+        no_handoff_registry_path.write_text(
+            json.dumps(
+                {
+                    "goals": [
+                        {
+                            "id": GOAL_ID,
+                            "domain": "smoke",
+                            "status": "active",
+                            "repo": str(project),
+                            "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
+                            "adapter": {"kind": "generic_project_goal_v0", "status": "connected"},
+                            "coordination": {
+                                "registered_agents": [
+                                    "codex-main-control",
+                                    "codex-side-bypass",
+                                ],
+                                "primary_agent": "codex-main-control",
+                                "side_agent_handoff_agent": "codex-side-bypass",
+                            },
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+        cli_no_handoff_json = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "loopx.cli",
+                "--format",
+                "json",
+                "--registry",
+                str(no_handoff_registry_path),
+                "heartbeat-prompt",
+                "--goal-id",
+                GOAL_ID,
+                "--thin",
+                "--agent-id",
+                "codex-side-bypass",
+                "--agent-scope",
+                "auto-research visible validation",
+            ],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        cli_no_handoff_payload = json.loads(cli_no_handoff_json)
+        assert cli_no_handoff_payload["side_agent_handoff_agent"] == "codex-side-bypass", (
+            cli_no_handoff_payload
+        )
+        no_handoff_task = normalized(cli_no_handoff_payload["task_body"])
+        assert "do not create broad handoff todos" in no_handoff_task, cli_no_handoff_payload
+        assert "keep the todo claimed_by you" in no_handoff_task, cli_no_handoff_payload
+        assert "handoff todo claimed_by `codex-side-bypass`" not in no_handoff_task, (
+            cli_no_handoff_payload
+        )
+        assert "handoff todo claimed_by primary_agent `codex-main-control`" not in no_handoff_task, (
+            cli_no_handoff_payload
+        )
+
         cli_unknown_scoped = subprocess.run(
             [
                 sys.executable,

--- a/loopx/heartbeat_prompt.py
+++ b/loopx/heartbeat_prompt.py
@@ -181,11 +181,21 @@ def render_agent_scope_instruction(
         if agent_id
         else f"{cli_bin} todo claim --goal-id {goal_id} --todo-id <todo_id> --claimed-by <agent_id>"
     )
+    handoff_stays_with_current_agent = bool(
+        agent_role == "side-agent"
+        and side_agent_handoff_agent
+        and agent_id
+        and side_agent_handoff_agent == agent_id
+    )
     handoff_agent = side_agent_handoff_agent or primary_agent
     handoff_owner_label = (
-        f"handoff todo claimed_by `{side_agent_handoff_agent}`"
-        if side_agent_handoff_agent
-        else f"handoff todo claimed_by primary_agent `{primary_agent or '<primary_agent>'}`"
+        "no broad handoff; keep blocked work claimed_by you"
+        if handoff_stays_with_current_agent
+        else (
+            f"handoff todo claimed_by `{side_agent_handoff_agent}`"
+            if side_agent_handoff_agent
+            else f"handoff todo claimed_by primary_agent `{primary_agent or '<primary_agent>'}`"
+        )
     )
     handoff_todo_text = (
         "Review, verify, and continue this side-agent handoff."
@@ -208,8 +218,13 @@ def render_agent_scope_instruction(
         else:
             role_rule = (
                 "Side-agent: independent git worktree/branch; self-merge small "
-                "validated changes with evidence; otherwise finish with a "
-                f"{handoff_owner_label}."
+                "validated changes with evidence; "
+                + (
+                    "if blocked or unclear, write a concrete blocker or keep the "
+                    "todo claimed_by you; do not create broad handoff todos."
+                    if handoff_stays_with_current_agent
+                    else f"otherwise finish with a {handoff_owner_label}."
+                )
             )
         return (
             f"Agent: `{identity}`; role: {agent_role}; primary: `{primary_agent}`; "
@@ -228,12 +243,21 @@ def render_agent_scope_instruction(
                 f"merge/publication, {primary_handoff_tail}"
             )
         else:
-            role_rule = (
-                "You are a side-agent. Use an independent git worktree/branch. "
-                "Self-merge only small AGENTS-eligible validated changes with "
-                "`--side-agent-self-merged --evidence`; otherwise create a handoff "
-                f"todo with `--next-agent-todo` and `--next-claimed-by {handoff_agent}`."
-            )
+            if handoff_stays_with_current_agent:
+                role_rule = (
+                    "You are a side-agent. Use an independent git worktree/branch. "
+                    "Self-merge only small AGENTS-eligible validated changes with "
+                    "`--side-agent-self-merged --evidence`; if blocked or unclear, "
+                    "write a concrete blocker or keep the todo claimed_by you. "
+                    "Do not create broad handoff todos."
+                )
+            else:
+                role_rule = (
+                    "You are a side-agent. Use an independent git worktree/branch. "
+                    "Self-merge only small AGENTS-eligible validated changes with "
+                    "`--side-agent-self-merged --evidence`; otherwise create a handoff "
+                    f"todo with `--next-agent-todo` and `--next-claimed-by {handoff_agent}`."
+                )
         return (
             f"Agent identity and scope: agent_id `{identity}`; role: {agent_role}; "
             f"primary_agent `{primary_agent}`; scope: {scope_text}. {role_rule} "
@@ -253,15 +277,27 @@ def render_agent_scope_instruction(
             f"{primary_handoff_tail}"
         )
     else:
-        role_rule = (
-            f"You are a side-agent for this goal; primary_agent is `{primary_agent}`. "
-            "Do development only in an independent git worktree/branch, never in the "
-            "main checkout. Self-merge only small AGENTS-eligible validated changes; "
-            "never self-merge runtime, benchmark, permission, production, destructive "
-            "git, or public evidence-policy changes that need review. For a "
-            f"self-merge, complete with `{self_merge_command}`. Otherwise complete "
-            f"with a handoff todo, for example `{completion_command}`."
-        )
+        if handoff_stays_with_current_agent:
+            role_rule = (
+                f"You are a side-agent for this goal; primary_agent is `{primary_agent}`. "
+                "Do development only in an independent git worktree/branch, never in the "
+                "main checkout. Self-merge only small AGENTS-eligible validated changes; "
+                "never self-merge runtime, benchmark, permission, production, destructive "
+                "git, or public evidence-policy changes that need review. For a "
+                f"self-merge, complete with `{self_merge_command}`. If blocked or unclear, "
+                "write a concrete blocker or keep the todo claimed_by you; do not create "
+                "a broad handoff todo."
+            )
+        else:
+            role_rule = (
+                f"You are a side-agent for this goal; primary_agent is `{primary_agent}`. "
+                "Do development only in an independent git worktree/branch, never in the "
+                "main checkout. Self-merge only small AGENTS-eligible validated changes; "
+                "never self-merge runtime, benchmark, permission, production, destructive "
+                "git, or public evidence-policy changes that need review. For a "
+                f"self-merge, complete with `{self_merge_command}`. Otherwise complete "
+                f"with a handoff todo, for example `{completion_command}`."
+            )
     return f"""Agent identity and scope:
 
 - agent_id: `{identity}`


### PR DESCRIPTION
## Summary
- Treat `coordination.side_agent_handoff_agent == current side-agent` as a no-broad-handoff lane in generated heartbeat prompts.
- Tell blocked side agents to keep work claimed by themselves with a concrete blocker instead of emitting ambiguous handoff todos.
- Add focused heartbeat-prompt smoke coverage and update the agent/todo docs.

## Validation
- `PYTHONPATH=/private/tmp/loopx-side-bypass-heartbeat-20260709T0442 python3 -m loopx.cli --format json --registry "$HOME/.codex/loopx/registry.global.json" heartbeat-prompt --thin --goal-id loopx-meta --agent-id codex-side-bypass --agent-scope 'side-bypass lane: independently advance auto-research visible validation and related status sufficiency checks'`
- `python3 -m py_compile loopx/heartbeat_prompt.py examples/control_plane/heartbeat-prompt-smoke.py`
- `python3 examples/control_plane/heartbeat-prompt-smoke.py`
- `git diff --check`
- `loopx check --scan-path loopx/heartbeat_prompt.py --scan-path examples/control_plane/heartbeat-prompt-smoke.py --scan-path docs/heartbeat-automation-prompt.md --scan-path docs/project-agent-todo-contract.md`
- `loopx canary premerge --from-git-diff` (passed, `self_merge_allowed: true`)

## Boundary
- Candidate paths classified as runtime prompt behavior, durable control-plane smoke, and public project docs.
- No untracked files included; public/private boundary scan clean.