### PR TITLE
Fix SkillsBench aggregate bool fallback countability

### DIFF
--- a/examples/skillsbench-current-ledger-aggregate-smoke.py
+++ b/examples/skillsbench-current-ledger-aggregate-smoke.py
@@ -421,6 +421,75 @@ def test_ledger_marks_uncountable_numeric_scores_noncountable() -> None:
     ), entry
 
 
+def test_current_aggregate_keeps_setup_bool_fallback_uncountable() -> None:
+    entry = build_benchmark_run_ledger_entry(
+        {
+            "schema_version": "benchmark_run_v0",
+            "benchmark_id": BENCHMARK_ID,
+            "case_id": "setup-bool-fallback",
+            "run_id": "setup-bool-fallback",
+            "job_name": "skillsbench_1_1_setup_bool_fallback_codex_cli_goal_baseline",
+            "route": "codex-cli-goal-baseline",
+            "official_score_status": "missing",
+            "official_task_score": {
+                "kind": "skillsbench_verifier_reward",
+                "passed": False,
+            },
+            "score_failure_attribution": (
+                "skillsbench_docker_compose_apt_repository_failure"
+            ),
+            "failure_attribution_labels": [
+                "skillsbench_docker_compose_apt_repository_failure",
+            ],
+            "attempt_accounting": {
+                "schema_version": "skillsbench_attempt_accounting_v0",
+                "lifecycle_phase": "runner_accepted_args",
+                "failure_class": "skillsbench_docker_compose_apt_repository_failure",
+                "case_attempt_countable": False,
+                "solver_attempt_countable": False,
+                "verifier_attempt_countable": False,
+                "official_score_attempt_countable": False,
+            },
+        }
+    )
+    assert entry["official_score"] == 0.0, entry
+    assert entry["official_score_bool_fallback_used"] is True, entry
+    assert entry["official_score_countable"] is True, entry
+    assert entry["case_attempt_countable"] is False, entry
+    assert entry["solver_attempt_countable"] is False, entry
+    assert entry["verifier_attempt_countable"] is False, entry
+
+    ledger: dict[str, Any] = {
+        "schema_version": BENCHMARK_RUN_LEDGER_SCHEMA_VERSION,
+        "benchmarks": {},
+    }
+    ledger = upsert_benchmark_run_ledger_entry(ledger, entry)
+    aggregate = build_benchmark_run_ledger_current_aggregate(
+        ledger,
+        benchmark_id=BENCHMARK_ID,
+        canonical_case_ids=["setup-bool-fallback"],
+    )
+    case_best = aggregate["case_best"]["setup-bool-fallback"]
+    assert case_best["official_score"] == 0.0, case_best
+    assert case_best["official_score_countable"] is True, case_best
+    assert case_best["bucket"] == "setup_runner_infra", case_best
+    assert "countable_score" not in case_best, case_best
+    assert aggregate["distribution"]["setup_runner_infra"] == 1, aggregate
+    assert aggregate["distribution"]["official_zero"] == 0, aggregate
+    assert aggregate["countable_score_summary"] == {
+        "schema_version": "benchmark_run_ledger_countable_score_summary_v0",
+        "countable_case_count": 0,
+        "countable_score_sum": 0,
+        "countable_score_mean": None,
+        "pass_count": 0,
+        "partial_count": 0,
+        "official_zero_count": 0,
+        "uncountable_numeric_case_count": 1,
+        "countable_case_ids": [],
+        "uncountable_numeric_case_ids": ["setup-bool-fallback"],
+    }, aggregate["countable_score_summary"]
+
+
 def test_current_aggregate_default_inference_excludes_sanity_sources() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-current-aggregate-default-") as tmp:
         ledger_path = Path(tmp) / "benchmark-run-ledger.json"
@@ -603,6 +672,7 @@ def test_current_aggregate_cli_writes_public_safe_json() -> None:
 if __name__ == "__main__":
     test_current_aggregate_prefers_countable_results()
     test_ledger_marks_uncountable_numeric_scores_noncountable()
+    test_current_aggregate_keeps_setup_bool_fallback_uncountable()
     test_current_aggregate_default_inference_excludes_sanity_sources()
     test_target_lane_aggregate_uses_current_then_full87_backfill()
     test_current_aggregate_cli_writes_public_safe_json()

--- a/loopx/benchmark_ledger_current.py
+++ b/loopx/benchmark_ledger_current.py
@@ -102,30 +102,48 @@ def _current_aggregate_effective_failure_class(run: dict[str, Any]) -> str:
     return ""
 
 
-def _current_aggregate_bucket(run: dict[str, Any] | None) -> str:
-    if not isinstance(run, dict):
-        return "missing"
-    score = _ledger_score_value(run)
-    if score is not None:
-        if not _official_score_countable(run):
-            return "uncountable_official_score"
-        if score >= 1.0:
-            return "pass"
-        if score > 0.0:
-            return "partial"
-        return "official_zero"
-    labels = _current_aggregate_failure_labels(run)
-    failure_class = _current_aggregate_effective_failure_class(run)
-    failure_scope = _compact_text(run.get("failure_scope"), limit=120)
-    score_status = _compact_text(run.get("score_status"), limit=120)
-    if (
-        "verifier_no_reward" in labels
-        or "verifier_reward_missing" in labels
-        or "reward_missing" in failure_class
-        or "verifier_no_reward" in failure_class
-    ):
-        return "verifier_no_reward"
-    if (
+def _current_aggregate_official_bool_fallback_used(run: dict[str, Any]) -> bool:
+    fallback_fn = getattr(_ledger_module(), "official_score_bool_fallback_used", None)
+    return run.get("official_score_bool_fallback_used") is True or (
+        callable(fallback_fn) and fallback_fn(run) is True
+    )
+
+
+def _current_aggregate_attempt_flag(
+    run: dict[str, Any], field_name: str
+) -> bool | None:
+    value = run.get(field_name)
+    if isinstance(value, bool):
+        return value
+    accounting = (
+        run.get("attempt_accounting")
+        if isinstance(run.get("attempt_accounting"), dict)
+        else {}
+    )
+    value = accounting.get(field_name)
+    if isinstance(value, bool):
+        return value
+    return None
+
+
+def _current_aggregate_core_attempt_marked_uncountable(run: dict[str, Any]) -> bool:
+    return any(
+        _current_aggregate_attempt_flag(run, field_name) is False
+        for field_name in (
+            "case_attempt_countable",
+            "solver_attempt_countable",
+            "verifier_attempt_countable",
+        )
+    )
+
+
+def _current_aggregate_has_setup_runner_infra_signal(
+    *,
+    labels: set[str],
+    failure_class: str,
+    failure_scope: str,
+) -> bool:
+    return (
         failure_scope == "runner_or_setup"
         or failure_scope == "score_missing"
         or "infrastructure" in failure_class
@@ -139,8 +157,64 @@ def _current_aggregate_bucket(run: dict[str, Any] | None) -> str:
             or "setup" in label
             or "compose" in label
             or "docker" in label
+            or "runner" in label
             for label in labels
         )
+    )
+
+
+def _current_aggregate_bool_fallback_setup_runner_infra(
+    run: dict[str, Any],
+    *,
+    labels: set[str],
+    failure_class: str,
+    failure_scope: str,
+) -> bool:
+    return (
+        _current_aggregate_official_bool_fallback_used(run)
+        and _current_aggregate_core_attempt_marked_uncountable(run)
+        and _current_aggregate_has_setup_runner_infra_signal(
+            labels=labels,
+            failure_class=failure_class,
+            failure_scope=failure_scope,
+        )
+    )
+
+
+def _current_aggregate_bucket(run: dict[str, Any] | None) -> str:
+    if not isinstance(run, dict):
+        return "missing"
+    labels = _current_aggregate_failure_labels(run)
+    failure_class = _current_aggregate_effective_failure_class(run)
+    failure_scope = _compact_text(run.get("failure_scope"), limit=120)
+    if _current_aggregate_bool_fallback_setup_runner_infra(
+        run,
+        labels=labels,
+        failure_class=failure_class,
+        failure_scope=failure_scope,
+    ):
+        return "setup_runner_infra"
+    score = _ledger_score_value(run)
+    if score is not None:
+        if not _official_score_countable(run):
+            return "uncountable_official_score"
+        if score >= 1.0:
+            return "pass"
+        if score > 0.0:
+            return "partial"
+        return "official_zero"
+    score_status = _compact_text(run.get("score_status"), limit=120)
+    if (
+        "verifier_no_reward" in labels
+        or "verifier_reward_missing" in labels
+        or "reward_missing" in failure_class
+        or "verifier_no_reward" in failure_class
+    ):
+        return "verifier_no_reward"
+    if _current_aggregate_has_setup_runner_infra_signal(
+        labels=labels,
+        failure_class=failure_class,
+        failure_scope=failure_scope,
     ):
         return "setup_runner_infra"
     if score_status == "missing":
@@ -158,6 +232,8 @@ _CURRENT_AGGREGATE_BUCKET_RANK = {
     "pass": 6,
 }
 
+_CURRENT_AGGREGATE_COUNTABLE_BUCKETS = {"official_zero", "partial", "pass"}
+
 
 def _current_aggregate_run_sort_key(run: dict[str, Any]) -> tuple[Any, ...]:
     bucket = _current_aggregate_bucket(run)
@@ -173,6 +249,8 @@ def _current_aggregate_run_sort_key(run: dict[str, Any]) -> tuple[Any, ...]:
 
 
 def _current_aggregate_countable_run(run: dict[str, Any]) -> bool:
+    if _current_aggregate_bucket(run) not in _CURRENT_AGGREGATE_COUNTABLE_BUCKETS:
+        return False
     countability = _official_score_countability(run)
     return (
         countability.get("countable") is True
@@ -320,7 +398,12 @@ def _current_aggregate_run_summary(run: dict[str, Any] | None) -> dict[str, Any]
     countability = _official_score_countability(run)
     summary["official_score_countable"] = countability["countable"]
     summary["official_score_countability_reason"] = countability["reason"]
-    if countability["countable"] is True and countability.get("score") is not None:
+    summary.pop("countable_score", None)
+    if (
+        summary["bucket"] in _CURRENT_AGGREGATE_COUNTABLE_BUCKETS
+        and countability["countable"] is True
+        and countability.get("score") is not None
+    ):
         summary["countable_score"] = countability["score"]
     effective_failure_class = _current_aggregate_effective_failure_class(run)
     if effective_failure_class:
@@ -487,7 +570,11 @@ def build_benchmark_run_ledger_current_aggregate(
         cases_by_bucket.setdefault(bucket, []).append(case_id)
         case_best[case_id] = summary
         score = _ledger_score_value(summary)
-        if summary.get("official_score_countable") is True and score is not None:
+        if (
+            bucket in _CURRENT_AGGREGATE_COUNTABLE_BUCKETS
+            and summary.get("official_score_countable") is True
+            and score is not None
+        ):
             countable_case_ids.append(case_id)
             countable_scores.append(score)
         elif score is not None:


### PR DESCRIPTION
## Summary

- Keep setup/runner infra rows uncountable when their official 0.0 came from boolean `passed=false` fallback and core case/solver/verifier attempts are marked non-countable.
- Recompute aggregate `countable_score` from the selected bucket so infra rows cannot carry a copied ledger-level countable score into the current aggregate.
- Add a focused SkillsBench current-ledger smoke reproducing the setup bool-fallback case.

## Validation

- `python3 examples/skillsbench-current-ledger-aggregate-smoke.py`
- `python3 -m compileall loopx/benchmark_ledger_current.py examples/skillsbench-current-ledger-aggregate-smoke.py`
- Source-run local compact reproduction: paired debug goal aggregate moves the setup-failed bool-fallback case to `setup_runner_infra` and excludes it from the countable mean.
- `loopx check --scan-path loopx/benchmark_ledger_current.py --scan-path examples/skillsbench-current-ledger-aggregate-smoke.py`
- `loopx canary premerge --from-git-diff`

## Merge note

Premerge canary passed all automatic checks but returned `manual_review_required` because this touches benchmark-sensitive ledger/scoring behavior. This PR is intentionally not self-merged.
