### PR TITLE
Clarify recursive smoke runner help

### DIFF
--- a/examples/canary/smoke-suite-runner-smoke.py
+++ b/examples/canary/smoke-suite-runner-smoke.py
@@ -378,6 +378,21 @@ def assert_run_smokes_profile_preview_matches_runner_selection() -> None:
     assert all("status" not in script for script in scripts), payload
 
 
+def assert_run_smokes_help_describes_recursive_discovery() -> None:
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "examples/run-smokes.py",
+            "--help",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+    )
+    assert "examples/**/*-smoke.py" in completed.stdout, completed.stdout
+
+
 def assert_execution_reports_progress_indices() -> None:
     events: list[dict[str, object]] = []
     payload = build_canary_smoke_suite_run(
@@ -703,6 +718,7 @@ def main() -> int:
     assert_cli_named_smoke_profile_preview_works()
     assert_cli_named_smoke_profiles_list_works()
     assert_run_smokes_profile_preview_matches_runner_selection()
+    assert_run_smokes_help_describes_recursive_discovery()
     assert_execution_reports_progress_indices()
     assert_parallel_jobs_execute_and_preserve_report_order()
     assert_parallel_jobs_keep_marked_smokes_serial()

--- a/examples/run-smokes.py
+++ b/examples/run-smokes.py
@@ -26,7 +26,7 @@ def parse_args() -> argparse.Namespace:
         default="default-public",
         help=(
             "Smoke selection mode. default-public excludes explicit grouped checks; "
-            "full-public includes every tracked examples/*-smoke.py."
+            "full-public includes every tracked examples/**/*-smoke.py."
         ),
     )
     parser.add_argument(
@@ -45,7 +45,7 @@ def parse_args() -> argparse.Namespace:
         "--script",
         action="append",
         default=[],
-        help="Run a specific examples/*-smoke.py script.",
+        help="Run a specific examples/**/*-smoke.py script.",
     )
     parser.add_argument(
         "--profile",


### PR DESCRIPTION
## Summary
- clarify `examples/run-smokes.py --help` to say smoke discovery covers `examples/**/*-smoke.py`
- add a canary runner smoke assertion so the wrapper help stays aligned with recursive smoke discovery

## Scope classification
- `examples/run-smokes.py`: CLI wrapper help/documentation cleanup
- `examples/canary/smoke-suite-runner-smoke.py`: durable validation smoke

## Validation
- `python3 -m py_compile examples/run-smokes.py examples/canary/smoke-suite-runner-smoke.py`
- `python3 examples/canary/smoke-suite-runner-smoke.py`
- `git diff --check`
- `loopx canary premerge --from-git-diff` selected canary_runner/public_boundary/python checks: 13 selected, 13 passed, 0 failures
- diff private/raw-evidence scan: no hits for credentials, local private paths, raw benchmark logs, trajectories, or verifier output

## Merge note
Low-risk help/test consistency cleanup. No runtime behavior, benchmark execution, public evidence-policy, permission, or first-screen public surface change.
