### PR TITLE
Document parallel release smoke sweeps

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -241,6 +241,16 @@ python3 examples/run-smokes.py --suite default-public --module canary
 loopx canary smoke-suite --suite default-public --module canary
 ```
 
+For larger source-checkout sweeps, use the runner's bounded parallelism instead
+of moving smoke semantics into a second test framework. `--jobs` keeps the
+LoopX runner payload as the source of truth while preserving serial execution
+for smokes that declare a scheduling-sensitive surface:
+
+```bash
+python3 -m loopx.cli canary smoke-suite --profile public-smoke-watch --jobs 4 --timeout-seconds 60
+python3 examples/run-smokes.py --suite full-public --jobs 4 --timeout-seconds 60
+```
+
 For repeatable canary/refactor batches, prefer named smoke-suite profiles over
 hand-curated script lists. Profiles expand to the same runner payload as
 `--module`, `--script`, catalog selectors, and the pytest facade:

--- a/examples/release/release-readiness-doc-smoke.py
+++ b/examples/release/release-readiness-doc-smoke.py
@@ -69,6 +69,8 @@ def main() -> None:
         "near-E2E",
         "do not add new IPs solely to describe a validation bundle",
         "examples/canary/canary-promotion-readiness-smoke.py --no-write-evidence",
+        "python3 -m loopx.cli canary smoke-suite --profile public-smoke-watch --jobs 4 --timeout-seconds 60",
+        "python3 examples/run-smokes.py --suite full-public --jobs 4 --timeout-seconds 60",
         "## What Is Safe To Depend On",
         "loopx doctor",
         "quota should-run",


### PR DESCRIPTION
## Summary
- document `--jobs` for larger source-checkout release smoke sweeps
- use `python3 -m loopx.cli` for the source-checkout CLI example so the command reflects the checked-out code, not a stale installed `loopx`
- extend `release-readiness-doc-smoke` to guard the new parallel smoke guidance

## Scope classification
- `docs/product/release-readiness.md`: release/canary documentation
- `examples/release/release-readiness-doc-smoke.py`: durable docs-smoke assertion

## Validation
- `python3 examples/release/release-readiness-doc-smoke.py`
- `python3 -m py_compile examples/release/release-readiness-doc-smoke.py`
- `python3 -m loopx.cli --format json canary smoke-suite --profile public-smoke-watch --jobs 4 --timeout-seconds 60 --no-execute` → ok, 175 selected, jobs=4
- `python3 examples/run-smokes.py --suite full-public --jobs 4 --timeout-seconds 60 --no-execute --json` → ok, 515 selected, jobs=4
- `git diff --check`
- diff private/raw-evidence scan: no hits for credentials, local private paths, raw benchmark logs, trajectories, or verifier output
- `loopx canary premerge --from-git-diff`: install_release/docs_project_content/public_boundary/python surfaces, 17 selected checks passed, 0 failures

## Merge note
Low-risk docs + docs-smoke consistency cleanup. No runtime behavior, benchmark execution, public evidence-policy, permission, or first-screen public surface change.
