### PR TITLE
Expose quota selected todo projection

### DIFF
--- a/examples/control_plane/quota-agent-scoped-user-gate-smoke.py
+++ b/examples/control_plane/quota-agent-scoped-user-gate-smoke.py
@@ -237,6 +237,11 @@ def assert_other_agent_user_gate_does_not_block_current_agent() -> None:
     assert override["from_state"] == "operator_gate", override
     assert override["to_state"] == "eligible", override
     assert payload["agent_lane_next_action"]["todo_id"] == "todo_benchmark_driver", payload
+    assert payload["selected_todo"]["todo_id"] == "todo_benchmark_driver", payload
+    assert payload["selected_todo"]["source"] == (
+        "agent_todo_summary.first_executable_items"
+    ), payload
+    assert payload["selected_todo"]["selected_by"] == "current_agent_claimed_todo", payload
 
 
 def assert_other_agent_user_gate_does_not_notify_non_due_monitor_lane() -> None:

--- a/loopx/control_plane/quota/selected_todo_projection.py
+++ b/loopx/control_plane/quota/selected_todo_projection.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ..todos.contract import normalize_todo_id
+from ..work_items.interaction_contract import protocol_action_text
+
+
+SELECTED_TODO_COMPACT_FIELDS = (
+    "todo_id",
+    "index",
+    "role",
+    "priority",
+    "status",
+    "task_class",
+    "action_kind",
+    "claimed_by",
+    "blocks_agent",
+    "unblocks_todo_id",
+    "next_due_at",
+    "expires_at",
+)
+SELECTED_TODO_AGENT_FIELDS = (
+    "agent_id",
+    "selected_by",
+    "confidence",
+    "claim_required_before_work",
+)
+WORK_LANE_SELECTED_TODO_ITEM_FIELDS = (
+    "monitor_due_items",
+    "monitor_schedule_gap_items",
+    "resume_blocked_by_monitor_items",
+)
+
+
+def selected_todo_projection(
+    *,
+    agent_lane_next_action: dict[str, Any] | None,
+    work_lane_contract: dict[str, Any] | None,
+) -> dict[str, Any] | None:
+    if isinstance(agent_lane_next_action, dict):
+        source = str(agent_lane_next_action.get("source") or "agent_lane_next_action")
+        selected = _compact_selected_todo(agent_lane_next_action, source=source)
+        if selected:
+            return selected
+
+    if not isinstance(work_lane_contract, dict):
+        return None
+    selected_todo_id = normalize_todo_id(work_lane_contract.get("selected_todo_id"))
+    if not selected_todo_id:
+        return None
+    for key in WORK_LANE_SELECTED_TODO_ITEM_FIELDS:
+        items = work_lane_contract.get(key)
+        if not isinstance(items, list):
+            continue
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            item_todo_id = normalize_todo_id(item.get("todo_id") or item.get("id"))
+            if item_todo_id != selected_todo_id:
+                continue
+            selected = _compact_selected_todo(item, source=f"work_lane_contract.{key}")
+            if selected:
+                return selected
+    return {
+        "schema_version": "quota_selected_todo_v0",
+        "source": "work_lane_contract.selected_todo_id",
+        "todo_id": selected_todo_id,
+    }
+
+
+def first_todo_id_from_items(value: Any) -> str | None:
+    if not isinstance(value, list):
+        return None
+    for item in value:
+        if not isinstance(item, dict):
+            continue
+        todo_id = normalize_todo_id(item.get("todo_id") or item.get("id"))
+        if todo_id:
+            return todo_id
+    return None
+
+
+def _compact_selected_todo(
+    item: dict[str, Any],
+    *,
+    source: str,
+) -> dict[str, Any] | None:
+    todo_id = normalize_todo_id(item.get("todo_id") or item.get("id"))
+    text = protocol_action_text(item.get("text"), limit=320)
+    if not todo_id and not text:
+        return None
+    selected: dict[str, Any] = {
+        "schema_version": "quota_selected_todo_v0",
+        "source": source,
+    }
+    for key in SELECTED_TODO_COMPACT_FIELDS:
+        value = item.get(key)
+        if value is not None:
+            selected[key] = value
+    if todo_id:
+        selected["todo_id"] = todo_id
+    if text:
+        selected["text"] = text
+    for key in SELECTED_TODO_AGENT_FIELDS:
+        if item.get(key) is not None:
+            selected[key] = item.get(key)
+    return selected

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -87,6 +87,10 @@ from .control_plane.quota.scheduler_ack import (
     build_quota_scheduler_ack_event,
     record_quota_scheduler_ack_for_decision,
 )
+from .control_plane.quota.selected_todo_projection import (
+    first_todo_id_from_items as _first_todo_id_from_items,
+    selected_todo_projection as _selected_todo_projection,
+)
 from .control_plane.quota.subagent_orchestration import (
     apply_subagent_orchestration_contract,
     attach_subagent_payload_contract,
@@ -1912,6 +1916,12 @@ def build_quota_should_run(
             payload["agent_identity"] = agent_identity
         if agent_lane_next_action:
             payload["agent_lane_next_action"] = agent_lane_next_action
+        selected_todo_projection = _selected_todo_projection(
+            agent_lane_next_action=agent_lane_next_action,
+            work_lane_contract=payload_work_lane_contract,
+        )
+        if selected_todo_projection:
+            payload["selected_todo"] = selected_todo_projection
         if agent_lane_frontier_hint:
             payload["agent_lane_frontier_hint"] = agent_lane_frontier_hint
         if goal_route_hint:
@@ -2203,18 +2213,6 @@ def build_quota_slot_preview(
         quota_status_builder=quota_status,
         self_repair_spend_actions=SELF_REPAIR_SPEND_ACTIONS,
     )
-
-
-def _first_todo_id_from_items(value: Any) -> str | None:
-    if not isinstance(value, list):
-        return None
-    for item in value:
-        if not isinstance(item, dict):
-            continue
-        todo_id = normalize_todo_id(item.get("todo_id") or item.get("id"))
-        if todo_id:
-            return todo_id
-    return None
 
 
 def _required_read_todo_id(decision: dict[str, Any]) -> str | None:


### PR DESCRIPTION
## Summary
- add a top-level `selected_todo` read-model projection to `quota should-run`
- derive it from `agent_lane_next_action` first, with `work_lane_contract.selected_todo_id` as a fallback
- move the projection helper into `loopx/control_plane/quota/selected_todo_projection.py` so `loopx/quota.py` stays under the Python line-budget smoke

## Why
Agents currently receive the selected todo through `agent_lane_next_action` and prose-shaped `primary_action`, but there is no stable top-level field for the executable todo. This makes heartbeat agents re-scan todo state or parse action text. The change is additive and does not alter run/skip decisions or quota state transitions.

## Validation
- `python3 examples/control_plane/quota-agent-scoped-user-gate-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `python3 -m py_compile loopx/quota.py loopx/control_plane/quota/selected_todo_projection.py examples/control_plane/quota-agent-scoped-user-gate-smoke.py`
- source checkout `quota should-run` projection check for `loopx-meta` / `codex-product-capability`
- `PYTHONPATH=. python3 -m loopx.cli canary premerge --from-git-diff` passed, selected=17, failures=0, manual_holds=0, self_merge_allowed=true
