### PR TITLE
Add todo suggestion quality-watch trigger

### DIFF
--- a/docs/reference/protocols/todo-suggestion-prompt-v0.md
+++ b/docs/reference/protocols/todo-suggestion-prompt-v0.md
@@ -21,6 +21,9 @@ Useful triggers:
 - explicit user request such as "what looks worth doing next?";
 - no runnable agent todo after status/quota inspection;
 - material repo changes since the last candidate review.
+- `quality-watch` cadence turns, where the agent should compare fresh signals
+  against the last known state and return candidates only for new or
+  still-uncovered evidence.
 
 Avoid running this on every heartbeat. The default limit is 3 and the hard cap
 is 5.

--- a/examples/control_plane/todo-suggestion-prompt-smoke.py
+++ b/examples/control_plane/todo-suggestion-prompt-smoke.py
@@ -124,6 +124,35 @@ def main() -> int:
         assert "`requires_user_decision=true`" in task_body, task_body
         assert state_file.read_text(encoding="utf-8") == original_state
 
+        watch_result = run_cli(
+            registry_path,
+            "--format",
+            "json",
+            "todo",
+            "suggest",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            "codex-product-capability",
+            "--from",
+            "failing-checks",
+            "--from",
+            "complexity-hotspots",
+            "--trigger",
+            "quality-watch",
+        )
+        watch_payload = json.loads(watch_result.stdout)
+        assert watch_payload["ok"] is True, watch_payload
+        assert watch_payload["trigger"] == "quality-watch", watch_payload
+        assert watch_payload["sources"] == ["failing-checks", "complexity-hotspots"], watch_payload
+        assert watch_payload["formal_todos_written"] is False, watch_payload
+        watch_body = watch_payload["task_body"]
+        assert "Because this is a `quality-watch` turn" in watch_body, watch_body
+        assert "new or still-uncovered evidence" in watch_body, watch_body
+        assert "return an empty list with a short rationale" in watch_body, watch_body
+        assert "quality-watch" in watch_payload["frequency_policy"]["recommended_triggers"], watch_payload
+        assert state_file.read_text(encoding="utf-8") == original_state
+
         markdown = run_cli(
             registry_path,
             "todo",

--- a/loopx/todo_suggestion_prompt.py
+++ b/loopx/todo_suggestion_prompt.py
@@ -30,6 +30,7 @@ ALLOWED_TODO_SUGGESTION_TRIGGERS = (
     "post-connect",
     "no-runnable-todo",
     "repo-changed",
+    "quality-watch",
 )
 
 
@@ -86,6 +87,13 @@ def build_todo_suggestion_prompt_packet(
     project_hint = _project_hint(project)
     agent_label = agent_id or "current project agent"
     source_text = ", ".join(selected_sources)
+    quality_watch_note = (
+        "\n\nBecause this is a `quality-watch` turn, compare fresh signals against the "
+        "last known state first. Return candidates only for new or still-uncovered "
+        "evidence; otherwise return an empty list with a short rationale."
+        if selected_trigger == "quality-watch"
+        else ""
+    )
 
     task_body = f"""Generate a bounded candidate todo decision queue for LoopX goal `{goal_id}`.
 
@@ -104,6 +112,7 @@ decision candidates, not formal LoopX todos. Do not call `loopx todo add`,
 `loopx todo update`, `loopx todo complete`, or edit LoopX state in this turn.
 If the evidence is weak or already covered by existing runnable todos, return an
 empty list with a short rationale.
+{quality_watch_note}
 
 Each candidate must use schema `{SUGGESTED_TODO_CANDIDATE_SCHEMA_VERSION}` and
 include: `candidate_id`, `title`, `why_now`, `evidence`, `first_safe_action`,


### PR DESCRIPTION
## Summary
- add a `quality-watch` trigger to the agent-guided `loopx todo suggest` prompt contract
- tell watch turns to compare fresh signals against the last known state and return candidates only for new or still-uncovered evidence
- cover the trigger in the todo suggestion smoke and protocol doc

## Product / Architecture Judgment
- Motivation: recurring engineering-quality watches need a compact way to ask an agent for candidate work without creating formal todos every heartbeat.
- Solved: this PR adds the trigger as a thin prompt-contract preset; it deliberately does not add scheduler state, monitor plumbing, or automatic todo promotion.
- Operator impact: watch loops can stay quiet when evidence is stale or already covered, while still surfacing failing-check / complexity candidate work when fresh.
- Main risk: small CLI prompt-contract expansion; no benchmark semantics, permission boundary, or public/private evidence policy changes.
- Design judgment: this keeps the existing separation between monitor cadence, agent read-only analysis, and explicit todo promotion.

## Validation
- `python3 examples/control_plane/todo-suggestion-prompt-smoke.py`
- `python3 -m py_compile loopx/todo_suggestion_prompt.py loopx/cli_commands/todo.py`
- `python3 examples/control_plane/hot-path-interface-budget-smoke.py`
- `loopx canary premerge --from-git-diff` (passed, standard tier, 13 selected checks, 0 failures, self_merge_allowed=true)

## Boundary
- Public/private scan only matched protocol warning text about raw logs/credentials/local paths; no private material was added.