### PR TITLE
Fix doctor for direct installed invocation

### DIFF
--- a/examples/cli-help-manpage-smoke.py
+++ b/examples/cli-help-manpage-smoke.py
@@ -140,10 +140,10 @@ def assert_installer_manpage_surface() -> None:
             text=True,
             capture_output=True,
         )
-        assert man.returncode == 0, (man.returncode, man.stdout, man.stderr)
-        assert "LOOPX(1)" in man.stdout, man.stdout
-        assert "LoopX keeps long-running agent work moving" in man.stdout, man.stdout
-        assert "heartbeat automation" in man.stdout, man.stdout
+        rendered_man = "\n".join(part for part in (man.stdout, man.stderr) if part)
+        assert "LOOPX(1)" in rendered_man, (man.returncode, man.stdout, man.stderr)
+        assert "LoopX keeps long-running agent work moving" in rendered_man, rendered_man
+        assert "heartbeat automation" in rendered_man, rendered_man
 
 
 def main() -> int:

--- a/examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py
+++ b/examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py
@@ -38,6 +38,17 @@ def run(command: list[str], *, env: dict[str, str], cwd: Path) -> subprocess.Com
     )
 
 
+def path_without_loopx(path_text: str) -> str:
+    entries: list[str] = []
+    for entry in path_text.split(os.pathsep):
+        if not entry:
+            continue
+        if (Path(entry).expanduser() / "loopx").exists():
+            continue
+        entries.append(entry)
+    return os.pathsep.join(entries)
+
+
 def main() -> None:
     install_script = REPO_ROOT / "scripts" / "install-from-github.sh"
     subprocess.run(["bash", "-n", str(install_script)], check=True)
@@ -77,6 +88,7 @@ def main() -> None:
                 add_tree(tar, REPO_ROOT, name)
 
         env = os.environ.copy()
+        host_path_without_loopx = path_without_loopx(env.get("PATH", ""))
         env.update(
             {
                 "HOME": str(home),
@@ -87,7 +99,7 @@ def main() -> None:
                 "LOOPX_ARCHIVE_URL": f"file://{archive}",
                 "LOOPX_INSTALL_CANARY": "0",
                 "CODEX_CALLED_MARKER": str(codex_called_marker),
-                "PATH": f"{fake_bin}:{env.get('PATH', '')}",
+                "PATH": f"{fake_bin}:{host_path_without_loopx}",
             }
         )
         run(["bash", str(install_script)], env=env, cwd=tmp)

--- a/loopx/doctor.py
+++ b/loopx/doctor.py
@@ -79,6 +79,22 @@ def resolve_command_path(name: str) -> Path | None:
     return Path(path_text).expanduser() if path_text else None
 
 
+def current_script_invocation_path() -> Path | None:
+    """Return the active LoopX wrapper when doctor was invoked by absolute path."""
+    if not sys.argv or not sys.argv[0]:
+        return None
+    path = Path(sys.argv[0]).expanduser()
+    if not path.is_absolute():
+        path = Path.cwd() / path
+    try:
+        path = path.resolve()
+    except OSError:
+        path = path.absolute()
+    if path.exists() and path.name == "loopx" and path.parent.name == "scripts":
+        return path
+    return None
+
+
 def is_release_snapshot(root: Path | None) -> bool:
     return bool(root and "releases" in root.parts)
 
@@ -456,8 +472,9 @@ def latest_promotion_readiness_event(runtime_root: Path, goal_id: str | None = N
 
 def collect_doctor() -> dict[str, Any]:
     loopx_path = resolve_command_path("loopx")
+    invocation_path = current_script_invocation_path()
     loopx_canary_path = resolve_command_path("loopx-canary")
-    command_path_primary = loopx_path
+    command_path_primary = loopx_path or invocation_path
     canary_path = loopx_canary_path
     command_path = command_path_primary
     command_realpath = command_path.resolve() if command_path else None
@@ -512,10 +529,22 @@ def collect_doctor() -> dict[str, Any]:
     global_registry_writability = probe_registry_write_path(default_global_registry, create_parent=True)
     checks = [
         {
-            "id": "command_on_path",
+            "id": "command_available",
             "required": True,
             "ok": command_path is not None,
-            "detail": str(command_path) if command_path else "loopx was not found on PATH",
+            "detail": str(loopx_path)
+            if loopx_path
+            else (
+                f"loopx was not found on PATH; using current invocation {invocation_path}"
+                if invocation_path
+                else "loopx was not found on PATH"
+            ),
+        },
+        {
+            "id": "command_on_path",
+            "required": False,
+            "ok": loopx_path is not None,
+            "detail": str(loopx_path) if loopx_path else "loopx was not found on PATH",
         },
         {
             "id": "command_resolves",
@@ -607,8 +636,10 @@ def collect_doctor() -> dict[str, Any]:
             "version": sys.version.split()[0],
         },
         "path": {
-            "loopx": str(loopx_path) if loopx_path else None,
-            "loopx_realpath": str(loopx_realpath) if loopx_realpath else None,
+            "loopx": str(command_path) if command_path else None,
+            "loopx_realpath": str(command_realpath) if command_realpath else None,
+            "loopx_on_path": str(loopx_path) if loopx_path else None,
+            "current_invocation": str(invocation_path) if invocation_path else None,
             "loopx_canary": str(loopx_canary_path) if loopx_canary_path else None,
             "loopx_canary_realpath": str(loopx_canary_realpath) if loopx_canary_realpath else None,
             "user_local_bin": str(local_bin),


### PR DESCRIPTION
## Summary
- Let `loopx doctor` treat an absolute `scripts/loopx` invocation as a valid installed command when `loopx` is not yet on PATH.
- Keep `command_on_path` as an optional diagnostic and add required `command_available` semantics for the actual health gate.
- Harden the TUI bootstrap smoke so local developer PATH state cannot mask this fresh-install path, and make the manpage smoke assert rendered manual content instead of runner-specific `man` exit behavior.

## Validation
- `python3 examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py`
- `python3 examples/cli-help-manpage-smoke.py`
- direct installed invocation check with PATH excluding `loopx`: required doctor failures `[]`
- `python3 -m compileall -q loopx/doctor.py examples/codex-cli-tui-bootstrap-smoke-bundle-smoke.py examples/cli-help-manpage-smoke.py`
- `loopx canary premerge --from-git-diff --format json` passed: diff checks, py_compile, repo line budget smoke, public boundary scan

## Notes
Latest main Full Public still has benchmark-owned failures in SkillsBench/TerminalBench shards; this PR only addresses the non-benchmark install/doctor/help surface failures observed in the same run.

Not self-merged because the change touches runtime doctor behavior, even though the diff-based canary gate passed.