### PR TITLE
Clarify autonomous replan spend accounting

### DIFF
--- a/docs/quota-allocation.md
+++ b/docs/quota-allocation.md
@@ -838,6 +838,10 @@ Post-turn accounting protocol:
   account the latest unspent `outcome_progress` delivery run once; a later
   duplicate spend is rejected because the latest run is then the spend event,
   not the delivery run.
+- autonomous replans follow the same accountable-outcome rule: spend after a
+  concrete successor, blocker, or `outcome_progress`/`primary_goal_outcome`
+  writeback, but do not spend for a `surface_only` watch-lane continuation or
+  no-follow-up rationale that closes into `monitor_quiet_skip`.
 - for unchanged `monitor_quiet_skip` heartbeat polls, append at most one
   no-spend `quota monitor-poll --execute` event and rerun `quota should-run`
   before choosing quiet no-op versus autonomous replan;

--- a/examples/control_plane/heartbeat-quota-flow-smoke.py
+++ b/examples/control_plane/heartbeat-quota-flow-smoke.py
@@ -803,6 +803,8 @@ def main() -> int:
         assert interaction["agent_channel"]["must_attempt"] is True, interaction
         assert interaction["agent_channel"]["quiet_noop_allowed"] is False, interaction
         assert interaction["cli_channel"]["spend_after_validation"] is True, interaction
+        assert "accountable replan delta" in interaction["cli_channel"]["spend_policy"], interaction
+        assert "surface_only" in " ".join(interaction["cli_channel"]["next_cli_actions"]), interaction
 
         refresh = run_cli(
             root,
@@ -982,6 +984,90 @@ def main() -> int:
             post_poll_guard["heartbeat_recommendation"]["recommended_mode"]
             == "monitor_quiet_until_material_transition"
         ), post_poll_guard
+
+    with tempfile.TemporaryDirectory(prefix="loopx-heartbeat-monitor-replan-surface-only-") as tmp:
+        root = Path(tmp)
+        project, runtime, registry_path = write_monitor_fixture(root)
+        first_guard = run_cli(
+            root,
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--scan-path",
+            str(project),
+            registry_path=registry_path,
+            runtime=runtime,
+        )
+        assert first_guard["effective_action"] == "autonomous_replan_required", first_guard
+        interaction = first_guard["interaction_contract"]
+        assert interaction["mode"] == "autonomous_replan", interaction
+        assert "accountable replan delta" in interaction["cli_channel"]["spend_policy"], interaction
+
+        refresh = run_cli(
+            root,
+            "refresh-state",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            "codex-side-bypass",
+            "--progress-scope",
+            "agent_lane",
+            "--classification",
+            "monitor_poll_autonomous_replan_recorded_v0",
+            "--autonomous-replan-recorded",
+            "--repair-delta-kind",
+            "watch_lane_continuation",
+            "--repair-delta-kind",
+            "no_followup",
+            "--vision-unchanged-reason",
+            "watch lane continuation recorded; no current acceptance gap is claimed complete",
+            "--delivery-batch-scale",
+            "single_surface",
+            "--delivery-outcome",
+            "surface_only",
+            "--no-global-sync",
+            registry_path=registry_path,
+            runtime=runtime,
+        )
+        assert refresh["ok"] is True, refresh
+        assert refresh["delivery_outcome"] == "surface_only", refresh
+
+        post_refresh_guard = run_cli(
+            root,
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--scan-path",
+            str(project),
+            registry_path=registry_path,
+            runtime=runtime,
+        )
+        assert post_refresh_guard["effective_action"] == "monitor_quiet_skip", post_refresh_guard
+        post_refresh_interaction = post_refresh_guard["interaction_contract"]
+        assert post_refresh_interaction["mode"] == "monitor_quiet_skip", post_refresh_interaction
+        assert post_refresh_interaction["cli_channel"]["spend_after_validation"] is False, post_refresh_interaction
+
+        spend_rc, spend = run_cli_result(
+            root,
+            "quota",
+            "spend-slot",
+            "--goal-id",
+            GOAL_ID,
+            "--slots",
+            "1",
+            "--source",
+            "heartbeat",
+            "--execute",
+            "--scan-path",
+            str(project),
+            registry_path=registry_path,
+            runtime=runtime,
+        )
+        assert spend_rc == 1, spend
+        assert spend["ok"] is False, spend
+        assert count_spend_events(runtime) == 0, spend
 
     with tempfile.TemporaryDirectory(prefix="loopx-external-evidence-observation-") as tmp:
         root = Path(tmp)

--- a/examples/control_plane/interaction-contract-state-machine-smoke.py
+++ b/examples/control_plane/interaction-contract-state-machine-smoke.py
@@ -452,6 +452,8 @@ def assert_autonomous_replan_preempts_monitor_quiet() -> None:
     assert contract["mode"] == "autonomous_replan", payload
     assert contract["agent_channel"]["must_attempt"] is True, contract
     assert contract["cli_channel"]["spend_after_validation"] is True, contract
+    assert "accountable replan delta" in contract["cli_channel"]["spend_policy"], contract
+    assert "surface_only" in " ".join(contract["cli_channel"]["next_cli_actions"]), contract
     assert payload["scheduler_hint"]["action"] == "run_now", payload
 
 

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -654,7 +654,12 @@ def interaction_next_cli_actions(payload: dict[str, Any], *, mode: str) -> list[
         return [
             first_action,
             f"loopx refresh-state --goal-id {goal_id} --classification autonomous_replan_recorded --autonomous-replan-recorded --repair-delta-kind <delta_kind> --delivery-batch-scale <scale> --delivery-outcome <outcome>",
-            f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute",
+            (
+                "if the replan writeback records an accountable delta such as "
+                "outcome_progress or primary_goal_outcome, run "
+                f"loopx quota spend-slot --goal-id {goal_id} --slots 1 --source heartbeat --execute; "
+                "otherwise do not spend for surface_only watch-lane continuation/no-followup"
+            ),
         ]
     if mode in {
         "bounded_delivery",
@@ -708,6 +713,11 @@ def _interaction_spend_policy(
         return "no spend for moving side-agent work into an independent worktree"
     if mode == "automation_prompt_upgrade":
         return "no spend until the automation reruns quota guard with --agent-id"
+    if mode == "autonomous_replan":
+        return (
+            "spend only after accountable replan delta; no spend for "
+            "surface_only watch-lane continuation"
+        )
     if spend_after_validation:
         return "spend once after validated writeback"
     raw_policy = execution_obligation.get("spend_policy") or heartbeat_recommendation.get(


### PR DESCRIPTION
## Summary
- Clarify `autonomous_replan` CLI guidance: quota spend only follows an accountable replan delta, not a `surface_only` watch-lane continuation/no-followup closeout.
- Add heartbeat quota coverage for the real surface-only monitor continuation path that closes into `monitor_quiet_skip` and rejects `spend-slot`.
- Document the accountable-outcome rule in quota allocation docs.

## Validation
- `python3 examples/control_plane/interaction-contract-state-machine-smoke.py`
- `python3 examples/control_plane/heartbeat-quota-flow-smoke.py`
- `git diff --check`
- `loopx check --scan-path loopx/control_plane/work_items/interaction_contract.py --scan-path examples/control_plane/interaction-contract-state-machine-smoke.py --scan-path examples/control_plane/heartbeat-quota-flow-smoke.py --scan-path docs/quota-allocation.md`
- `loopx canary premerge --from-git-diff` (passed 17 selected checks, 0 failures, 0 manual holds, self_merge_allowed=true)

## Boundary
- Public/private boundary scan clean for the four changed paths.
