### PR TITLE
Broaden replan evidence reads

### DIFF
--- a/docs/reference/protocols/goal-vision-replan-contract-v0.md
+++ b/docs/reference/protocols/goal-vision-replan-contract-v0.md
@@ -292,6 +292,13 @@ compact goal-route facts:
 These fields are projections. Writeback still goes through LoopX write APIs,
 not through dashboards, Lark mirrors, or chat text.
 
+When quota requires an autonomous replan, the required evidence read is scoped
+to the current agent's recent public-safe evidence ledger. A todo-specific
+evidence read may be useful as drill-down, but it is not sufficient as the
+decision basis for watch-lane continuation, no-follow-up, or successor choice.
+If local evidence is empty, stale, or contradictory, the agent may use bounded
+public-safe search as supporting evidence and write back source references.
+
 ## Write / Correction Mechanism
 
 Vision correction is a normal state-machine transition, not only a

--- a/examples/control_plane/quota-replan-decision-plane-smoke.py
+++ b/examples/control_plane/quota-replan-decision-plane-smoke.py
@@ -405,9 +405,12 @@ def assert_replan_beats_monitor_quiet_skip() -> None:
     required_reads = guard["required_reads"]
     assert required_reads[0]["kind"] == "agent_scoped_evidence_log", required_reads
     assert required_reads[0]["agent_id"] == SIDE_AGENT, required_reads
-    assert required_reads[0]["todo_id"] == "todo_monitor_wait", required_reads
+    assert required_reads[0]["todo_id"] is None, required_reads
     assert "evidence-log" in required_reads[0]["command"], required_reads
     assert " --agent-id codex-side-bypass " in f" {required_reads[0]['command']} ", required_reads
+    assert "--todo-id" not in required_reads[0]["command"], required_reads
+    assert "across this agent lane" in required_reads[0]["reason"], required_reads
+    assert "public-safe search" in required_reads[0]["reason"], required_reads
     assert guard["autonomous_replan_obligation"]["required_reads"] == required_reads, guard
     assert (
         guard["interaction_contract"]["agent_channel"]["required_reads"] == required_reads
@@ -604,6 +607,8 @@ def assert_long_agent_todo_chain_derives_replan_before_linear_delivery() -> None
     assert guard["autonomous_replan_decision"]["triggers"] == ["long_todo_chain"], guard
     required_reads = guard["required_reads"]
     assert required_reads[0]["kind"] == "agent_scoped_evidence_log", required_reads
+    assert required_reads[0]["todo_id"] is None, required_reads
+    assert "--todo-id" not in required_reads[0]["command"], required_reads
     markdown = render_quota_should_run_markdown(guard)
     assert "triggers=long_todo_chain" in markdown, markdown
 

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -88,7 +88,6 @@ from .control_plane.quota.scheduler_ack import (
     record_quota_scheduler_ack_for_decision,
 )
 from .control_plane.quota.selected_todo_projection import (
-    first_todo_id_from_items as _first_todo_id_from_items,
     selected_todo_projection as _selected_todo_projection,
 )
 from .control_plane.quota.subagent_orchestration import (
@@ -153,7 +152,6 @@ from .control_plane.todos.contract import (
     TODO_TASK_CLASS_ADVANCEMENT,
     TODO_TASK_CLASS_BLOCKER,
     normalize_todo_claimed_by,
-    normalize_todo_id,
     normalize_todo_status,
     normalize_todo_task_class,
 )
@@ -2215,40 +2213,6 @@ def build_quota_slot_preview(
     )
 
 
-def _required_read_todo_id(decision: dict[str, Any]) -> str | None:
-    lane_action = (
-        decision.get("agent_lane_next_action")
-        if isinstance(decision.get("agent_lane_next_action"), dict)
-        else {}
-    )
-    todo_id = normalize_todo_id(lane_action.get("todo_id") or lane_action.get("id"))
-    if todo_id:
-        return todo_id
-    agent_scope_frontier = (
-        decision.get("agent_scope_frontier")
-        if isinstance(decision.get("agent_scope_frontier"), dict)
-        else {}
-    )
-    for key in (
-        "deferred_resume_candidates",
-        "route_continuation_replan_candidates",
-        "monitor_blocked_resume_candidates",
-    ):
-        todo_id = _first_todo_id_from_items(agent_scope_frontier.get(key))
-        if todo_id:
-            return todo_id
-    agent_todos = (
-        decision.get("agent_todo_summary")
-        if isinstance(decision.get("agent_todo_summary"), dict)
-        else {}
-    )
-    for key in ("first_executable_items", "first_open_items"):
-        todo_id = _first_todo_id_from_items(agent_todos.get(key))
-        if todo_id:
-            return todo_id
-    return None
-
-
 def _quota_required_reads(decision: dict[str, Any]) -> list[dict[str, Any]]:
     effective_action = str(decision.get("effective_action") or "")
     replan_required = effective_action in {
@@ -2260,10 +2224,9 @@ def _quota_required_reads(decision: dict[str, Any]) -> list[dict[str, Any]]:
     read = build_agent_scoped_required_read(
         goal_id=str(decision.get("goal_id") or ""),
         agent_id=quota_decision_agent_id(decision),
-        todo_id=_required_read_todo_id(decision),
         reason=(
-            "read this agent's thin public-safe evidence ledger before autonomous "
-            "replan; other agents stay frontier-only"
+            "read recent public-safe evidence across this agent lane before "
+            "replan; if local evidence is thin, use bounded public-safe search"
         ),
     )
     return [read] if read else []


### PR DESCRIPTION
## Summary
- broaden autonomous replan required reads from a focused todo evidence-log to the current agent lane's recent evidence ledger
- keep todo-specific evidence as drill-down rather than the primary decision basis
- document that bounded public-safe search is an optional supplement when local evidence is empty, stale, or contradictory

## Root Cause
`quota should-run` built autonomous replan `required_reads` with a helper that selected a candidate todo id from the lane/frontier summary. That made a goal-frontier or agent-lane replan look like a single-todo evidence review, so monitor/watch-lane continuation could be decided from an empty focused todo log while recent agent evidence existed elsewhere.

## Validation
- `python3 examples/control_plane/quota-replan-decision-plane-smoke.py`
- `python3 examples/control_plane/interaction-contract-state-machine-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `loopx check --scan-path loopx/quota.py --scan-path examples/control_plane/quota-replan-decision-plane-smoke.py --scan-path docs/reference/protocols/goal-vision-replan-contract-v0.md`
- `loopx canary premerge --from-git-diff` passed, 17 selected checks, 0 failures, self_merge_allowed=true
