### PR TITLE
Make SkillsBench curl retry flag compatible

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -5893,13 +5893,14 @@ def test_skillsbench_docker_task_staging_rewrites_wget_gpg_key_download() -> Non
             encoding="utf-8"
         )
         assert "wget -qO -" not in staged_text, staged_text
+        curl_retry_all_errors_arg = skillsbench_loop._dockerfile_curl_retry_all_errors_arg()
         assert (
-            "curl -fsSL --retry 8 --retry-all-errors --retry-delay 3 "
+            f"curl -fsSL --retry 8 {curl_retry_all_errors_arg} --retry-delay 3 "
             "--connect-timeout 60 --max-time 300 "
             "https://example.invalid/public.key | gpg --dearmor"
         ) in staged_text, staged_text
         assert (
-            "curl -fsSL --retry 8 --retry-all-errors --retry-delay 3 "
+            f"curl -fsSL --retry 8 {curl_retry_all_errors_arg} --retry-delay 3 "
             "--connect-timeout 60 --max-time 300 "
             "https://aquasecurity.github.io/trivy-repo/deb/public.key | "
             "gpg --dearmor"
@@ -5987,7 +5988,7 @@ def test_skillsbench_docker_task_staging_hardens_build_downloads() -> None:
             "apache-druid-0.20.0-bin.tar.gz"
         ) in staged_text, staged_text
         assert (
-            "curl -fL --retry 5 --retry-all-errors --retry-delay 2 "
+            f"curl -fL --retry 5 {skillsbench_loop._dockerfile_curl_retry_all_errors_arg()} --retry-delay 2 "
             "--connect-timeout 60 --max-time 600 "
             "https://github.com/coursier/coursier/releases/download/"
             "v2.1.25-M23/cs-x86_64-pc-linux.gz"
@@ -6043,7 +6044,7 @@ def test_skillsbench_docker_task_staging_patches_dockerfile_uv_bootstrap() -> No
         ), staged_text
         assert "uv==${LOOPX_SKILLSBENCH_UV_VERSION}" in staged_text, staged_text
         assert "INSTALLER_DOWNLOAD_URL" in staged_text, staged_text
-        assert "--retry-all-errors" in staged_text, staged_text
+        assert skillsbench_loop._dockerfile_curl_retry_all_errors_arg() in staged_text, staged_text
         assert (
             "curl -LsSf https://astral.sh/uv/0.9.22/install.sh | sh &&"
             not in staged_text

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -6991,6 +6991,10 @@ def _dockerfile_instruction_block_end(lines: list[str], start: int) -> int:
     return end
 
 
+def _dockerfile_curl_retry_all_errors_arg() -> str:
+    return "$(curl --help all 2>/dev/null | grep -q -- '--retry-all-errors' && printf '%s' '--retry-all-errors' || true)"
+
+
 def patch_dockerfile_uv_bootstrap_mirror(dockerfile: Path) -> dict[str, Any]:
     """Make staged Dockerfile uv bootstraps tolerate installer egress failures."""
 
@@ -7034,7 +7038,7 @@ def patch_dockerfile_uv_bootstrap_mirror(dockerfile: Path) -> dict[str, Any]:
         "    fi; \\\n"
         "    if ! command -v uvx >/dev/null 2>&1; then \\\n"
         "      export INSTALLER_DOWNLOAD_URL=\"${LOOPX_SKILLSBENCH_UV_RELEASE_MIRROR}/${LOOPX_SKILLSBENCH_UV_VERSION}\"; \\\n"
-        "      curl -LsSf --retry 5 --retry-all-errors --retry-delay 2 --connect-timeout 30 \\\n"
+        f"      curl -LsSf --retry 5 {_dockerfile_curl_retry_all_errors_arg()} --retry-delay 2 --connect-timeout 30 \\\n"
         "        \"https://astral.sh/uv/${LOOPX_SKILLSBENCH_UV_VERSION}/install.sh\" | sh; \\\n"
         "    fi; \\\n"
         "    if [ -x \"${HOME}/.local/bin/uv\" ]; then install -m 0755 \"${HOME}/.local/bin/uv\" /usr/local/bin/uv; fi; \\\n"
@@ -7171,7 +7175,8 @@ def patch_dockerfile_wget_gpg_key_retry(dockerfile: Path) -> bool:
 
     def gpg_key_curl_command(url: str) -> str:
         return (
-            "curl -fsSL --retry 8 --retry-all-errors --retry-delay 3 "
+            "curl -fsSL --retry 8 "
+            f"{_dockerfile_curl_retry_all_errors_arg()} --retry-delay 3 "
             f"--connect-timeout 60 --max-time 300 {url} | gpg --dearmor"
         )
 
@@ -7338,7 +7343,7 @@ def patch_dockerfile_network_download_retry(dockerfile: Path) -> bool:
             return match.group(0)
         return (
             "curl"
-            f"{args} --retry 5 --retry-all-errors --retry-delay 2 "
+            f"{args} --retry 5 {_dockerfile_curl_retry_all_errors_arg()} --retry-delay 2 "
             f"--connect-timeout 60 --max-time 600 {match.group('url')}"
         )
 


### PR DESCRIPTION
## Summary

Fix SkillsBench staged Docker bootstrap commands so LoopX-injected curl retry hardening remains compatible with old base-image curl builds that do not support `--retry-all-errors`.

This keeps the stronger retry behavior when available, but downgrades cleanly to ordinary `--retry` on older curl. The change applies to the Dockerfile uv bootstrap mirror fallback, GPG key download rewrites, and generic build download rewrites.

## Why

`fix-build-google-auto` post-#1734 canary proved benchmark egress proxying was active, but the Docker build failed before entering the worker because the base image curl rejected `--retry-all-errors`. That is a runner/bootstrap failure, not a solver/verifier result.

## Validation

- `python3 -m py_compile scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-run-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `loopx check --scan-path scripts/skillsbench_automation_loop.py --scan-path examples/skillsbench-benchmark-run-smoke.py`
- `loopx canary premerge --from-git-diff`
  - direct checks passed
  - selected catalog canaries passed
  - public boundary passed
  - manual hold: `benchmark_sensitive`, covered by owner authorization for benchmark self-merge

## Boundary

No scoring/task semantics change. No benchmark jobs launched by this PR. No raw benchmark logs, trajectories, verifier output, credentials, local private paths, or generated artifacts are included.
