### PR TITLE
Prepare issue-fix PR lifecycle monitoring

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -14,13 +14,14 @@ external comments, PRs, merges, or publishes.
 | CLI entry | `loopx issue-fix ...` |
 | Content-ops bridge | `loopx content-ops issue-fix-* ...` |
 | Protocol docs | `docs/capabilities/issue-fix/protocols/` |
-| Smoke | `examples/issue-fix-workflow-plan-smoke.py`, `examples/issue-fix-acceptance-loop-smoke.py` |
+| Smoke | `examples/issue-fix-workflow-plan-smoke.py`, `examples/issue-fix-pr-lifecycle-smoke.py`, `examples/issue-fix-acceptance-loop-smoke.py` |
 
 ## Protocols
 
 - [`issue_fix_workflow_contract_v0`](protocols/issue-fix-workflow-contract-v0.md)
 - [`issue_fix_acceptance_loop_v0`](protocols/issue-fix-acceptance-loop-v0.md)
 - `issue_fix_workflow_plan_packet_v0`
+- `issue_fix_pr_lifecycle_monitor_v0`
 - `github_issue_metadata_preview_v0`
 - `content_ops_issue_fix_metadata_preview_packet_v0`
 - `content_ops_issue_fix_intake_packet_v0`
@@ -71,10 +72,11 @@ loopx issue-fix workflow-plan \
 
 The workflow-plan output is still preview-only. Accepted candidates become
 ordered LoopX todos: public metadata/intake, repro or route selection,
-branch-local patch and validation, then PR review packet readiness. Concrete
-owner actions become explicit user gates, including private repro material,
-issue body/comment reads, external issue comments, PR creation, merge, publish,
-destructive git, production actions, and repository-policy approvals.
+branch-local patch and validation, PR review packet readiness, then a post-PR
+lifecycle monitor. Concrete owner actions become explicit user gates, including
+private repro material, issue body/comment reads, external issue comments, PR
+creation, merge, publish, destructive git, production actions, and
+repository-policy approvals.
 
 ## Workflow Plan
 
@@ -88,10 +90,34 @@ writeback previews, and PR review readiness blockers into one packet. It does
 not write LoopX todos, inspect the local repo in dry-run mode, create external
 comments or PRs, merge, or capture raw issue body/comment material.
 
+## PR Lifecycle Monitor
+
+```bash
+loopx issue-fix pr-lifecycle \
+  --url https://github.com/owner/repo/pull/123 \
+  --metadata-json public-pr-state.json \
+  --goal-id example-goal \
+  --format json
+```
+
+The PR lifecycle projection turns compact public PR state into one of four
+transitions: `runnable_successor`, `monitor_continuation`, `user_gate`, or
+`no_followup`. Terminal PR states such as `MERGED` or `CLOSED` take precedence
+over stale review metadata; failed checks and requested changes create runnable
+successors; quiet states continue the monitor.
+
+When `--goal-id` or `--ledger-path` is provided, the command writes the compact
+observation into `.loopx/domain-state/<goal-id>/issue_fix/pr-lifecycle.jsonl` by
+default. Use `--no-write-domain-state` for preview-only tests. Domain state is
+project-local and gitignored; it records compact row keys, observations,
+transition decisions, and fingerprints, never issue bodies, comments, raw
+provider payloads, raw check logs, local paths, or credentials.
+
 ## Validation
 
 ```bash
 python3 examples/issue-fix-workflow-plan-smoke.py
+python3 examples/issue-fix-pr-lifecycle-smoke.py
 python3 examples/issue-fix-workflow-contract-smoke.py
 python3 examples/content-ops-issue-fix-metadata-preview-smoke.py
 python3 examples/content-ops-issue-fix-intake-smoke.py

--- a/docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md
@@ -28,8 +28,9 @@ open PRs, merge, publish, or run destructive git without an explicit gate.
    todo, top gate when present, and next safe action.
 3. **Workflow plan:** build `issue_fix_workflow_plan_packet_v0` to compose the
    metadata preview, intake, branch dry-run, validation label, ordered LoopX
-   todo writeback preview, gate preview, and PR-review readiness blockers. This
-   stage is preview-only and does not write todos.
+   todo writeback preview, resolution route candidates, gate preview, post-PR
+   lifecycle monitor plan, and PR-review readiness blockers. This stage is
+   preview-only and does not write todos.
 4. **LoopX todo writeback:** convert accepted candidates into durable LoopX
    todos in priority and dependency order. Typical agent todos are repro smoke,
    code-context route, branch-local patch, validation, and review-packet
@@ -47,7 +48,16 @@ open PRs, merge, publish, or run destructive git without an explicit gate.
 7. **PR review packet:** emit `issue_fix_pr_review_packet_v0` only when branch,
    validation, and repo-relative changed-file evidence are sufficient for human
    review. The packet is review evidence, not external publication authority.
-8. **Gate handling:** surface concrete gates instead of silently blocking. Safe
+8. **PR lifecycle monitor:** after a PR exists, use
+   `issue_fix_pr_lifecycle_monitor_v0` to project compact public PR state into
+   exactly one of `runnable_successor`, `monitor_continuation`, `user_gate`, or
+   `no_followup`. Terminal PR states such as `MERGED` and `CLOSED` take
+   precedence over stale review metadata. Failed checks, requested changes, and
+   stale merge states create runnable successors instead of `monitor_quiet_skip`.
+   The command writes compact domain state by default when a `--goal-id` or
+   `--ledger-path` is provided, and `--no-write-domain-state` keeps it
+   preview-only.
+9. **Gate handling:** surface concrete gates instead of silently blocking. Safe
    metadata-only triage, public-code search, and focused smoke drafting may
    continue when those gates do not cover the selected action.
 
@@ -78,10 +88,33 @@ the minimum sufficient plan rather than management filler:
   validation.`
 - `[P1] Prepare the PR review packet with repo-relative changed files,
   validation labels, and remaining gates.`
+- `[P2] Monitor the PR lifecycle and project CI, review, merge, or stale-branch
+  changes into a successor, gate, continuation, or no-follow-up.`
 
 When several todos have the same priority, planner order plus LoopX write order
 is the tie-breaker. Do not infer a gate from prose alone: write it as a user
 todo or operator gate with the concrete action it blocks.
+
+Resolution routes must stay explicit. `fix_pr` is appropriate only when a
+focused repro or validation plan is available. `comment_only` should produce a
+public-safe maintainer comment packet but still needs an explicit external-write
+gate. `triage_only` is valid when the issue lacks enough public evidence for a
+useful patch or comment.
+
+## Domain State
+
+Issue-fix domain state is a project-local read model for long-running monitors:
+
+```text
+.loopx/domain-state/<goal-id>/issue_fix/pr-lifecycle.jsonl
+```
+
+Rows are keyed by compact `repo` and `pr_ref` and may store public-safe PR
+observations, transition decisions, and observation fingerprints. Domain state
+must not store issue bodies, comment bodies, raw provider payloads, raw check
+logs, local paths, credentials, or destructive-git output. The public packet and
+validation contract remain the source for behavior; domain state only keeps the
+watch lane from forgetting the latest compact observation.
 
 ## Ready Criteria
 
@@ -103,6 +136,9 @@ An issue-fix workflow is PR-review-ready only when all of these are true:
 - `content_ops_issue_fix_intake_packet_v0`
 - `issue_fix_intake_v0`
 - `issue_fix_workflow_plan_packet_v0`
+- `issue_fix_pr_lifecycle_monitor_v0`
+- `issue_fix_pr_lifecycle_transition_v0`
+- `issue_fix_pr_lifecycle_domain_state_projection_v0`
 - `loopx_todo_writeback_preview_v0`
 - `issue_fix_caller_repo_branch_packet_v0`
 - `issue_fix_validated_fix_artifact_v0`

--- a/examples/bootstrap-command-pack-smoke.py
+++ b/examples/bootstrap-command-pack-smoke.py
@@ -136,6 +136,7 @@ def test_goal_text_invocation_plans_ranked_todos_before_activation() -> None:
         assert "Preserve that exact order" in plan_prompt
         assert "GitHub issue/PR fix" in plan_prompt
         assert "loopx issue-fix workflow-plan" in plan_prompt
+        assert "loopx issue-fix pr-lifecycle" in plan_prompt
         assert "external comments, PR creation, merge, publish" in plan_prompt
         assert "issue_fix_workflow_plan_template" in commands
         issue_fix_template = str(commands["issue_fix_workflow_plan_template"])
@@ -143,13 +144,22 @@ def test_goal_text_invocation_plans_ranked_todos_before_activation() -> None:
         assert "--url <github-issue-or-pr-url>" in issue_fix_template
         assert "--repo-path <approved-repo>" in issue_fix_template
         assert "--validation-label '<validation command>'" in issue_fix_template
+        assert "issue_fix_pr_lifecycle_template" in commands
+        pr_lifecycle_template = str(commands["issue_fix_pr_lifecycle_template"])
+        assert "issue-fix pr-lifecycle" in pr_lifecycle_template
+        assert "--url <github-pr-url>" in pr_lifecycle_template
+        assert "--goal-id" in pr_lifecycle_template
+        assert str(payload["goal_id"]) in pr_lifecycle_template
         assert "--agent-id codex-test-agent" in str(commands["goal_start_quota_should_run"])
         assert "Same-priority items use that write order as the tie-breaker" in str(payload["message"])
         assert "preview the issue-fix route before todo writeback" in str(payload["message"])
+        assert "PR lifecycle monitor" in str(payload["message"])
         domain_routes = goal_start["domain_route_hints"]
         assert domain_routes["issue_fix_workflow"]["when"].startswith("goal text contains")
         assert "workflow-plan" in domain_routes["issue_fix_workflow"]["preview_command"]
+        assert "pr-lifecycle" in domain_routes["issue_fix_workflow"]["post_pr_monitor_command"]
         assert "explicit gates" in domain_routes["issue_fix_workflow"]["writeback"]
+        assert "domain-state" in domain_routes["issue_fix_workflow"]["writeback"]
         assert not (project / ".loopx").exists()
         assert not (project / ".codex").exists()
 

--- a/examples/canary/catalog-planner-smoke.py
+++ b/examples/canary/catalog-planner-smoke.py
@@ -495,7 +495,7 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
             "scripts/update_notes_release_job.py",
         ],
         surfaces=["product-entry issue-fix content-ops update-note cross-runtime demo"],
-        max_checks_per_profile=4,
+        max_checks_per_profile=5,
     )
     product_entry_profiles = {
         profile["id"]: profile for profile in product_entry_payload["domain_profiles"]
@@ -505,6 +505,7 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     product_entry_profile = product_entry_profiles["product-entry-workflows"]
     product_entry_commands = [check["command"] for check in product_entry_profile["checks"]]
     assert "python3 examples/issue-fix-workflow-contract-smoke.py" in product_entry_commands, product_entry_profile
+    assert "python3 examples/issue-fix-pr-lifecycle-smoke.py" in product_entry_commands, product_entry_profile
     assert "python3 examples/content-ops-issue-fix-intake-smoke.py" in product_entry_commands, product_entry_profile
     assert "python3 examples/public_entry/readme-demo-surface-smoke.py" in product_entry_commands, product_entry_profile
     assert "python3 examples/update-notes-archive-smoke.py" in product_entry_commands, product_entry_profile

--- a/examples/issue-fix-pr-lifecycle-smoke.py
+++ b/examples/issue-fix-pr-lifecycle-smoke.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""Smoke-test issue-fix PR lifecycle projection and domain-state writeback."""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx.capabilities.issue_fix.pr_lifecycle import (  # noqa: E402
+    ISSUE_FIX_PR_LIFECYCLE_MONITOR_SCHEMA_VERSION,
+    build_issue_fix_pr_lifecycle_monitor_packet,
+)
+from loopx.domain_packs.issue_fix import (  # noqa: E402
+    default_issue_fix_domain_state_ledger_path,
+    issue_fix_pr_lifecycle_ledger_key,
+    upsert_issue_fix_pr_lifecycle_ledger_jsonl,
+)
+
+
+PRIVATE_PATTERNS = [
+    re.compile(r"/Users/[A-Za-z0-9._-]+/"),
+    re.compile(r"/home/[A-Za-z0-9._-]+/"),
+    re.compile(r"/private/"),
+    re.compile(r"[A-Za-z]:\\\\Users\\\\"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._-]+"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+]
+
+FORBIDDEN_VALUES = [
+    "raw issue body text that must stay gated",
+    "full issue comment text that must stay gated",
+    "raw provider response payload",
+    "private check log",
+    "secret-value",
+    "credential-value",
+]
+
+
+def assert_public_safe(payload: dict[str, Any] | str) -> None:
+    text = (
+        payload
+        if isinstance(payload, str)
+        else json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    )
+    for pattern in PRIVATE_PATTERNS:
+        if pattern.search(text):
+            raise AssertionError(f"payload matched private pattern {pattern.pattern!r}")
+    leaked = [value for value in FORBIDDEN_VALUES if value in text]
+    assert not leaked, leaked
+
+
+def run_cli(args: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", "--format", "json", *args],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+
+def assert_packet_shape(packet: dict[str, Any]) -> None:
+    assert packet["ok"] is True, packet
+    assert packet["schema_version"] == ISSUE_FIX_PR_LIFECYCLE_MONITOR_SCHEMA_VERSION
+    assert packet["external_writes_performed"] is False
+    assert packet["todo_write_performed"] is False
+    assert packet["issue_body_captured"] is False
+    assert packet["comment_bodies_captured"] is False
+    assert packet["response_payloads_captured"] is False
+    assert packet["raw_check_logs_captured"] is False
+    assert packet["local_paths_captured"] is False
+    assert packet["private_repo_state_read"] is False
+    assert packet["observation"]["body_captured"] is False
+    assert packet["observation"]["comment_bodies_captured"] is False
+    assert packet["observation"]["log_output_captured"] is False
+    assert packet["transition"]["would_write"] is False
+    assert packet["transition"]["requires_execute_flag"] is True
+    assert packet["domain_state_projection"]["domain_pack"] == "issue_fix"
+    assert packet["domain_state_projection"]["path_recorded"] is False
+    assert packet["validation"]["ok"] is True, packet
+    assert_public_safe(packet)
+
+
+def main() -> int:
+    merged = build_issue_fix_pr_lifecycle_monitor_packet(
+        url="https://github.com/huangruiteng/loopx/pull/1715",
+        provider_payload={
+            "state": "MERGED",
+            "reviewDecision": "REVIEW_REQUIRED",
+            "mergeStateStatus": "UNKNOWN",
+            "statusCheckRollup": [{"name": "Full Public Smokes", "conclusion": "SUCCESS"}],
+            "body": "raw issue body text that must stay gated",
+            "comments": ["full issue comment text that must stay gated"],
+            "raw": "raw provider response payload",
+        },
+    )
+    assert_packet_shape(merged)
+    assert merged["transition"]["decision"] == "no_followup", merged
+    assert merged["transition"]["action_kind"] == "issue_fix_pr_merged_no_followup"
+    assert merged["transition"]["terminal_state_precedence"] is True
+    assert merged["writeback_contract"]["monitor_quiet_skip_allowed"] is False
+
+    failing = build_issue_fix_pr_lifecycle_monitor_packet(
+        url="https://github.com/huangruiteng/loopx/pull/1715",
+        provider_payload={
+            "state": "OPEN",
+            "reviewDecision": "REVIEW_REQUIRED",
+            "mergeStateStatus": "CLEAN",
+            "statusCheckRollup": [{"name": "Full Public Smokes", "conclusion": "FAILURE"}],
+            "check_log": "private check log",
+        },
+    )
+    assert_packet_shape(failing)
+    assert failing["transition"]["decision"] == "runnable_successor", failing
+    assert failing["transition"]["action_kind"] == "issue_fix_ci_failure_replan"
+    assert failing["first_screen"]["agent_can_continue"] is True
+
+    requested = build_issue_fix_pr_lifecycle_monitor_packet(
+        url="https://github.com/huangruiteng/loopx/pull/1715",
+        provider_payload={
+            "state": "OPEN",
+            "reviewDecision": "CHANGES_REQUESTED",
+            "mergeStateStatus": "CLEAN",
+            "statusCheckRollup": [{"name": "lint", "conclusion": "SUCCESS"}],
+        },
+    )
+    assert_packet_shape(requested)
+    assert requested["transition"]["decision"] == "runnable_successor", requested
+    assert requested["transition"]["action_kind"] == "issue_fix_review_changes_replan"
+
+    quiet = build_issue_fix_pr_lifecycle_monitor_packet(
+        url="https://github.com/huangruiteng/loopx/pull/1715",
+        provider_payload={
+            "state": "OPEN",
+            "reviewDecision": "REVIEW_REQUIRED",
+            "mergeStateStatus": "CLEAN",
+            "statusCheckRollup": [{"name": "lint", "conclusion": "SUCCESS"}],
+        },
+    )
+    assert_packet_shape(quiet)
+    assert quiet["transition"]["decision"] == "monitor_continuation", quiet
+    assert quiet["transition"]["material_change"] is False
+    assert quiet["writeback_contract"]["monitor_quiet_skip_allowed"] is True
+    repo_ref = build_issue_fix_pr_lifecycle_monitor_packet(
+        repo="huangruiteng/loopx",
+        pr_ref="pull_1715",
+        provider_payload={
+            "state": "OPEN",
+            "reviewDecision": "REVIEW_REQUIRED",
+            "mergeStateStatus": "CLEAN",
+            "statusCheckRollup": [{"name": "lint", "conclusion": "SUCCESS"}],
+        },
+    )
+    assert_packet_shape(repo_ref)
+    assert repo_ref["observation"]["kind"] == "pull_request", repo_ref
+    assert repo_ref["observation"]["pr_ref"] == "pull_1715", repo_ref
+
+    with tempfile.TemporaryDirectory(prefix="loopx-issue-fix-pr-lifecycle-") as tmpdir:
+        project = Path(tmpdir)
+        ledger = default_issue_fix_domain_state_ledger_path(
+            project=project,
+            goal_id="example-goal",
+        )
+        key = issue_fix_pr_lifecycle_ledger_key(quiet)
+        assert key == {"repo": "huangruiteng/loopx", "pr_ref": "pull_1715"}
+        result = upsert_issue_fix_pr_lifecycle_ledger_jsonl(ledger, quiet)
+        assert result["status"] == "inserted", result
+        result = upsert_issue_fix_pr_lifecycle_ledger_jsonl(ledger, quiet)
+        assert result["status"] == "updated", result
+        rows = [json.loads(line) for line in ledger.read_text(encoding="utf-8").splitlines()]
+        assert len(rows) == 1, rows
+        assert rows[0]["domain_state_key"] == key, rows
+        assert_public_safe(rows[0])
+
+        metadata_path = project / "pr.json"
+        metadata_path.write_text(
+            json.dumps(
+                {
+                    "state": "OPEN",
+                    "reviewDecision": "REVIEW_REQUIRED",
+                    "mergeStateStatus": "CLEAN",
+                    "statusCheckRollup": [{"name": "lint", "conclusion": "SUCCESS"}],
+                }
+            ),
+            encoding="utf-8",
+        )
+        cli_result = run_cli(
+            [
+                "issue-fix",
+                "pr-lifecycle",
+                "--url",
+                "https://github.com/huangruiteng/loopx/pull/1715",
+                "--metadata-json",
+                str(metadata_path),
+                "--goal-id",
+                "example-goal",
+                "--project",
+                str(project),
+            ]
+        )
+        cli_packet = json.loads(cli_result.stdout)
+        assert_packet_shape(cli_packet)
+        assert cli_packet["domain_state_projection"]["write_performed"] is True
+        write_result = cli_packet["domain_state_projection"]["write_result"]
+        assert write_result["path_recorded"] is False, write_result
+        assert_public_safe(cli_packet)
+
+    print("issue-fix-pr-lifecycle-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/issue-fix-workflow-contract-smoke.py
+++ b/examples/issue-fix-workflow-contract-smoke.py
@@ -87,8 +87,12 @@ def main() -> int:
     assert "loopx bootstrap-command-pack --project ." in readme
     assert "--goal-text \"Fix https://github.com/owner/repo/issues/123\"" in readme
     assert "loopx issue-fix workflow-plan" in readme
+    assert "loopx issue-fix pr-lifecycle" in readme
     assert "ordered LoopX todos" in readme
     assert "PR review packet readiness" in readme
+    assert "## PR Lifecycle Monitor" in readme
+    assert "runnable_successor" in readme
+    assert "examples/issue-fix-pr-lifecycle-smoke.py" in readme
     assert "explicit user gates" in readme
     assert "## Issue-Fix Domain Route" in loopx_goal_command
     assert "loopx issue-fix workflow-plan" in loopx_goal_command
@@ -105,6 +109,7 @@ def main() -> int:
             "**Caller repo branch:**",
             "**Validation:**",
             "**PR review packet:**",
+            "**PR lifecycle monitor:**",
             "**Gate handling:**",
         ],
     )
@@ -118,6 +123,9 @@ def main() -> int:
         ISSUE_FIX_CALLER_REPO_BRANCH_PACKET_SCHEMA_VERSION,
         ISSUE_FIX_VALIDATED_FIX_ARTIFACT_SCHEMA_VERSION,
         "issue_fix_pr_review_packet_v0",
+        "issue_fix_pr_lifecycle_monitor_v0",
+        "issue_fix_pr_lifecycle_transition_v0",
+        "issue_fix_pr_lifecycle_domain_state_projection_v0",
     ):
         assert schema in doc, schema
     for boundary in (

--- a/examples/issue-fix-workflow-e2e-smoke.py
+++ b/examples/issue-fix-workflow-e2e-smoke.py
@@ -127,6 +127,7 @@ def test_metadata_to_ordered_todos_and_gates() -> None:
         4,
         5,
         6,
+        7,
     ], plan
     assert todo_by_action(plan, "issue_fix_public_metadata_classification")["role"] == "agent"
     assert todo_by_action(plan, "issue_fix_repro_and_route")["priority"] == "P0"
@@ -140,6 +141,22 @@ def test_metadata_to_ordered_todos_and_gates() -> None:
     publish_gate = todo_by_action(plan, "approve_external_issue_publish_or_merge")
     assert publish_gate["role"] == "user", publish_gate
     assert "external_pr_creation" in publish_gate["blocks"], publish_gate
+    lifecycle_monitor = todo_by_action(plan, "issue_fix_pr_lifecycle_monitor")
+    assert lifecycle_monitor["role"] == "agent", lifecycle_monitor
+    assert lifecycle_monitor["task_class"] == "continuous_monitor", lifecycle_monitor
+    assert lifecycle_monitor["depends_on"] == [
+        "issue_fix_pr_review_packet",
+        "approve_external_issue_publish_or_merge",
+    ], lifecycle_monitor
+    routes = {route["route"]: route for route in plan["resolution_route_candidates"]}
+    assert set(routes) == {"fix_pr", "comment_only", "triage_only"}, routes
+    assert routes["fix_pr"]["next_action_kind"] == "issue_fix_branch_validation"
+    assert routes["comment_only"]["external_issue_comment_performed"] is False
+    assert routes["comment_only"]["requires_user_gate_before_external_write"] is True
+    post_pr = plan["post_pr_lifecycle_monitor_plan"]
+    assert post_pr["creates_continuous_monitor_todo"] is True, post_pr
+    assert post_pr["monitor_action_kind"] == "issue_fix_pr_lifecycle_monitor", post_pr
+    assert "no_followup" in post_pr["decisions"], post_pr
 
     review_preview = plan["review_packet_preview"]
     assert review_preview["ready"] is False, review_preview

--- a/examples/issue-fix-workflow-plan-smoke.py
+++ b/examples/issue-fix-workflow-plan-smoke.py
@@ -92,9 +92,19 @@ def assert_workflow_shape(payload: dict[str, Any]) -> None:
         "issue_fix_branch_validation",
         "issue_fix_pr_review_packet",
     ]
+    assert any(todo["action_kind"] == "issue_fix_pr_lifecycle_monitor" for todo in todos)
     assert [todo["priority"] for todo in todos[:3]] == ["P0", "P0", "P0"]
     assert all(todo["would_write"] is False for todo in todos)
     assert all(todo["requires_execute_flag"] is True for todo in todos)
+
+    routes = {route["route"]: route for route in payload["resolution_route_candidates"]}
+    assert set(routes) == {"fix_pr", "comment_only", "triage_only"}, routes
+    assert routes["fix_pr"]["next_action_kind"] == "issue_fix_branch_validation"
+    assert routes["comment_only"]["requires_user_gate_before_external_write"] is True
+    post_pr = payload["post_pr_lifecycle_monitor_plan"]
+    assert post_pr["creates_continuous_monitor_todo"] is True, post_pr
+    assert post_pr["monitor_action_kind"] == "issue_fix_pr_lifecycle_monitor", post_pr
+    assert "runnable_successor" in post_pr["decisions"], post_pr
 
     review = payload["review_packet_preview"]
     assert review["schema_version"] == "issue_fix_pr_review_packet_v0", review
@@ -188,7 +198,10 @@ def main() -> int:
     ).stdout
     assert "# LoopX Issue Fix Workflow Plan" in markdown, markdown
     assert "Ordered Todo Writeback Preview" in markdown, markdown
+    assert "Resolution Routes" in markdown, markdown
+    assert "Post-PR Lifecycle Monitor" in markdown, markdown
     assert "issue_fix_pr_review_packet" in markdown, markdown
+    assert "issue_fix_pr_lifecycle_monitor" in markdown, markdown
     assert_public_safe(markdown)
 
     print("issue-fix-workflow-plan-smoke: ok")

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -306,10 +306,16 @@ def _goal_start_contract(*, goal_text: str | None, connected: bool, agent_type: 
                     "loopx issue-fix workflow-plan --url <github-issue-or-pr-url> "
                     "--repo-path <approved-repo> --validation-label '<validation command>' --format json"
                 ),
+                "post_pr_monitor_command": (
+                    "loopx issue-fix pr-lifecycle --url <github-pr-url> "
+                    "--goal-id <goal-id> --format json"
+                ),
                 "writeback": (
                     "turn accepted workflow-plan candidates into ordered LoopX agent/user todos; "
                     "private repro material, issue body/comment reads, external comments, PR creation, "
-                    "merge, publish, destructive git, and production actions stay explicit gates"
+                    "merge, publish, destructive git, and production actions stay explicit gates; "
+                    "after PR creation, keep a continuous_monitor todo that calls pr-lifecycle "
+                    "and lets domain-state remember compact public PR observations"
                 ),
             }
         },
@@ -343,7 +349,7 @@ Planning rules:
 4. If several todos share the same priority, their listed order is their relative priority. Preserve that exact order when writing them.
 5. Prefer executable Agent Todo items with `task_class=advancement_task`; use User Todo only for concrete owner decisions or private-material gates.
 6. After writing todos, run `loopx refresh-state --goal-id {goal_id}`, activate the host loop if it is missing, unknown, or stale (Codex App automation, Codex CLI `/goal <task_body>`, Claude Code `/loop`, or a custom host-loop gate), then run `loopx quota should-run --goal-id {goal_id}` and begin the first allowed bounded segment.
-7. If the goal is a GitHub issue/PR fix, first preview `loopx issue-fix workflow-plan --url <github-issue-or-pr-url> --repo-path <approved-repo> --validation-label '<validation command>' --format json`; convert accepted preview candidates into ordered todos and keep private repro material, body/comment reads, external comments, PR creation, merge, publish, destructive git, and production actions as explicit gates.
+7. If the goal is a GitHub issue/PR fix, first preview `loopx issue-fix workflow-plan --url <github-issue-or-pr-url> --repo-path <approved-repo> --validation-label '<validation command>' --format json`; convert accepted preview candidates into ordered todos, include the PR lifecycle continuous_monitor successor, and keep private repro material, body/comment reads, external comments, PR creation, merge, publish, destructive git, and production actions as explicit gates. After a PR exists, the monitor should call `loopx issue-fix pr-lifecycle --url <github-pr-url> --goal-id {goal_id} --format json` so CI, review, merge, stale branch, and no-follow-up states drive LoopX todos instead of chat memory.
 """
 
 
@@ -494,6 +500,12 @@ def build_loopx_bootstrap_command_pack(
                 "--url <github-issue-or-pr-url> "
                 "--repo-path <approved-repo> "
                 "--validation-label '<validation command>' "
+                "--format json"
+            ),
+            "issue_fix_pr_lifecycle_template": (
+                f"{shell_arg(cli_bin)} issue-fix pr-lifecycle "
+                "--url <github-pr-url> "
+                f"--goal-id {shell_arg(resolved_goal_id)} "
                 "--format json"
             ),
         },
@@ -729,6 +741,12 @@ For GitHub issue/PR fix goals, preview the issue-fix route before todo writeback
 ```
 
 Accepted preview candidates become ordered Agent/User todos. Private repro material, issue body/comment reads, external comments, PR creation, merge, publish, destructive git, and production actions stay explicit gates.
+
+After a PR exists, the PR lifecycle monitor should observe compact public PR state and write issue-fix domain state by default:
+
+```bash
+{commands.get("issue_fix_pr_lifecycle_template", "")}
+```
 
 After todo writeback:
 

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -833,6 +833,11 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
                 "reason": "guards the public issue-fix workflow contract, gated metadata preview, and todo writeback preview",
             },
             {
+                "command": "python3 examples/issue-fix-pr-lifecycle-smoke.py",
+                "tier": "default",
+                "reason": "guards PR lifecycle transitions, terminal-state precedence, and issue_fix domain-state writeback",
+            },
+            {
                 "command": "python3 examples/content-ops-issue-fix-intake-smoke.py",
                 "tier": "default",
                 "reason": "checks content-ops issue-fix intake from public metadata without external reads or writes",

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -36,6 +36,11 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "write_boundary": "preview-only; no todo write, repo execution, external comment, PR creation, merge, or publish",
             },
             {
+                "command": "loopx issue-fix pr-lifecycle --url <github-pr-url> --goal-id <goal-id> --format json",
+                "purpose": "Project public PR lifecycle state into a successor, monitor continuation, user gate, or no-follow-up transition.",
+                "write_boundary": "writes compact project-local domain state when goal or ledger context is provided; no external comment, PR creation, merge, raw logs, or body/comment capture",
+            },
+            {
                 "command": "loopx issue-fix acceptance-fixture --format json",
                 "purpose": "Prove the failure-before/fix-after acceptance loop on a deterministic fixture.",
                 "write_boundary": "temporary local fixture only",
@@ -78,6 +83,11 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "doc": "docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md",
             },
             {
+                "schema_version": "issue_fix_pr_lifecycle_monitor_v0",
+                "module": "loopx.capabilities.issue_fix.pr_lifecycle",
+                "doc": "docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md",
+            },
+            {
                 "schema_version": "issue_fix_acceptance_loop_v0",
                 "module": "loopx.capabilities.issue_fix.acceptance_loop",
                 "doc": "docs/capabilities/issue-fix/protocols/issue-fix-acceptance-loop-v0.md",
@@ -95,6 +105,7 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
         ],
         "smokes": [
             "python3 examples/issue-fix-workflow-plan-smoke.py",
+            "python3 examples/issue-fix-pr-lifecycle-smoke.py",
             "python3 examples/content-ops-issue-fix-metadata-preview-smoke.py",
             "python3 examples/content-ops-issue-fix-intake-smoke.py",
             "python3 examples/issue-fix-acceptance-loop-smoke.py",

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -7,11 +7,19 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from ...domain_packs.issue_fix import (
+    default_issue_fix_domain_state_ledger_path,
+    upsert_issue_fix_pr_lifecycle_ledger_jsonl,
+)
 from .acceptance_loop import (
     build_issue_fix_acceptance_fixture_packet,
     build_issue_fix_caller_repo_branch_packet,
     build_issue_fix_repo_branch_fixture_packet,
     render_issue_fix_acceptance_loop_markdown,
+)
+from .pr_lifecycle import (
+    build_issue_fix_pr_lifecycle_monitor_packet,
+    render_issue_fix_pr_lifecycle_monitor_markdown,
 )
 from .workflow_plan import (
     build_issue_fix_workflow_plan_packet,
@@ -121,6 +129,79 @@ def register_issue_fix_commands(
         "--generated-at",
         default="2026-06-23T00:00:00Z",
         help="Public-safe generated_at timestamp for the workflow plan.",
+    )
+    pr_lifecycle_parser = issue_fix_sub.add_parser(
+        "pr-lifecycle",
+        help=(
+            "Project a public PR lifecycle observation into a successor, "
+            "monitor-continuation, user-gate, or no-follow-up transition."
+        ),
+    )
+    add_subcommand_format(pr_lifecycle_parser)
+    pr_lifecycle_parser.add_argument(
+        "--repo",
+        default="public_repo_fixture",
+        help="Public-safe repository label for the PR metadata.",
+    )
+    pr_lifecycle_parser.add_argument(
+        "--pr-ref",
+        default="pull_123_public_metadata_fixture",
+        help="Public-safe PR reference label.",
+    )
+    pr_lifecycle_parser.add_argument(
+        "--url",
+        default=None,
+        help="Optional https://github.com/owner/repo/pull/123 URL.",
+    )
+    pr_lifecycle_parser.add_argument(
+        "--metadata-json",
+        default=None,
+        help=(
+            "Path to mocked gh pr view JSON metadata, or '-' for stdin. "
+            "Bodies, comments, raw logs, and provider responses stay out."
+        ),
+    )
+    pr_lifecycle_parser.add_argument(
+        "--fetch-metadata",
+        action="store_true",
+        help=(
+            "Explicitly fetch public GitHub PR state with gh pr view. "
+            "Only compact lifecycle fields are captured."
+        ),
+    )
+    pr_lifecycle_parser.add_argument(
+        "--fetch-timeout-seconds",
+        type=int,
+        default=10,
+        help="Timeout for --fetch-metadata.",
+    )
+    pr_lifecycle_parser.add_argument(
+        "--generated-at",
+        default="2026-06-23T00:00:00Z",
+        help="Public-safe generated_at timestamp for the lifecycle projection.",
+    )
+    pr_lifecycle_parser.add_argument(
+        "--goal-id",
+        default=None,
+        help="Goal id used for the default issue_fix domain-state ledger path.",
+    )
+    pr_lifecycle_parser.add_argument(
+        "--project",
+        default=".",
+        help="Project root for the default issue_fix domain-state ledger path.",
+    )
+    pr_lifecycle_parser.add_argument(
+        "--ledger-path",
+        default=None,
+        help="Optional local JSONL ledger path. Overrides the default domain-state path.",
+    )
+    pr_lifecycle_parser.add_argument(
+        "--no-write-domain-state",
+        action="store_true",
+        help=(
+            "Keep the PR lifecycle command preview-only even when --goal-id or "
+            "--ledger-path is present."
+        ),
     )
     acceptance_parser = issue_fix_sub.add_parser(
         "acceptance-fixture",
@@ -276,6 +357,45 @@ def handle_issue_fix_command(
                 generated_at=args.generated_at,
             )
             renderer = render_issue_fix_workflow_plan_markdown
+        elif args.issue_fix_command == "pr-lifecycle":
+            if args.fetch_metadata and args.metadata_json:
+                raise ValueError("--fetch-metadata cannot be combined with --metadata-json")
+            payload = build_issue_fix_pr_lifecycle_monitor_packet(
+                repo=args.repo,
+                pr_ref=args.pr_ref,
+                url=args.url,
+                provider_payload=_load_json_object(args.metadata_json)
+                if args.metadata_json
+                else None,
+                fetch_metadata=args.fetch_metadata,
+                fetch_timeout_seconds=args.fetch_timeout_seconds,
+                generated_at=args.generated_at,
+            )
+            should_write_domain_state = bool(
+                not args.no_write_domain_state and (args.goal_id or args.ledger_path)
+            )
+            if should_write_domain_state:
+                ledger_path = (
+                    Path(args.ledger_path).expanduser()
+                    if args.ledger_path
+                    else default_issue_fix_domain_state_ledger_path(
+                        project=args.project,
+                        goal_id=args.goal_id,
+                    )
+                )
+                write_result = upsert_issue_fix_pr_lifecycle_ledger_jsonl(
+                    ledger_path,
+                    payload,
+                )
+                domain_state = payload.get("domain_state_projection")
+                if isinstance(domain_state, dict):
+                    domain_state["write_performed"] = True
+                    domain_state["write_result"] = write_result
+            else:
+                domain_state = payload.get("domain_state_projection")
+                if isinstance(domain_state, dict) and not args.no_write_domain_state:
+                    domain_state["write_skipped_reason"] = "goal_id_or_ledger_path_missing"
+            renderer = render_issue_fix_pr_lifecycle_monitor_markdown
         elif args.issue_fix_command == "acceptance-fixture":
             payload = build_issue_fix_acceptance_fixture_packet(
                 repo=args.repo,
@@ -310,7 +430,7 @@ def handle_issue_fix_command(
         else:
             raise ValueError(
                 "issue-fix requires `workflow-plan`, `acceptance-fixture`, "
-                "`repo-branch-fixture`, or `caller-repo-branch`"
+                "`pr-lifecycle`, `repo-branch-fixture`, or `caller-repo-branch`"
             )
     except Exception as exc:
         payload = {
@@ -321,6 +441,8 @@ def handle_issue_fix_command(
         renderer = (
             render_issue_fix_workflow_plan_markdown
             if getattr(args, "issue_fix_command", None) == "workflow-plan"
+            else render_issue_fix_pr_lifecycle_monitor_markdown
+            if getattr(args, "issue_fix_command", None) == "pr-lifecycle"
             else render_issue_fix_acceptance_loop_markdown
         )
     print_payload(payload, output_format(args), renderer)

--- a/loopx/capabilities/issue_fix/pr_lifecycle.py
+++ b/loopx/capabilities/issue_fix/pr_lifecycle.py
@@ -1,0 +1,611 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import subprocess
+from collections.abc import Mapping, Sequence
+from typing import Any
+from urllib.parse import quote
+
+from .metadata_preview import normalise_github_issue_reference
+
+
+ISSUE_FIX_PR_LIFECYCLE_MONITOR_SCHEMA_VERSION = (
+    "issue_fix_pr_lifecycle_monitor_v0"
+)
+
+TERMINAL_PR_STATES = {"MERGED", "CLOSED"}
+FAILING_CHECK_STATES = {
+    "ACTION_REQUIRED",
+    "CANCELLED",
+    "ERROR",
+    "FAILURE",
+    "FAILED",
+    "STARTUP_FAILURE",
+    "TIMED_OUT",
+}
+PENDING_CHECK_STATES = {
+    "EXPECTED",
+    "IN_PROGRESS",
+    "PENDING",
+    "QUEUED",
+    "REQUESTED",
+    "WAITING",
+}
+PASSING_CHECK_STATES = {"NEUTRAL", "SKIPPED", "SUCCESS"}
+BRANCH_BLOCKED_MERGE_STATES = {"BEHIND", "BLOCKED", "DIRTY", "UNKNOWN"}
+
+
+def _upper_label(value: Any, default: str = "UNKNOWN") -> str:
+    text = str(value or "").strip().upper()
+    return text or default
+
+
+def _compact_label(value: Any, default: str) -> str:
+    text = str(value or "").strip()
+    if not text:
+        return default
+    return "_".join(text.replace("/", "_").replace("-", "_").split()).lower()
+
+
+def _safe_bool(value: Any) -> bool:
+    return bool(value) if isinstance(value, bool) else False
+
+
+def _safe_count(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    try:
+        number = int(value)
+    except (TypeError, ValueError):
+        return None
+    return number if number >= 0 else None
+
+
+def _normalise_check_item(item: Mapping[str, Any]) -> str:
+    state = (
+        item.get("conclusion")
+        or item.get("state")
+        or item.get("status")
+        or item.get("workflowState")
+    )
+    status = _upper_label(state)
+    if status in {"COMPLETED", "COMPLETED_SUCCESSFULLY"}:
+        conclusion = _upper_label(item.get("conclusion"), "")
+        return conclusion or "SUCCESS"
+    return status
+
+
+def _check_rollup(payload: Mapping[str, Any]) -> dict[str, Any]:
+    raw_checks = payload.get("statusCheckRollup")
+    failing = 0
+    pending = 0
+    passing = 0
+    unknown = 0
+    names: list[str] = []
+    if isinstance(raw_checks, Sequence) and not isinstance(raw_checks, (str, bytes)):
+        for item in raw_checks:
+            if not isinstance(item, Mapping):
+                unknown += 1
+                continue
+            state = _normalise_check_item(item)
+            name = str(item.get("name") or item.get("context") or "").strip()
+            if name:
+                names.append(name[:80])
+            if state in FAILING_CHECK_STATES:
+                failing += 1
+            elif state in PENDING_CHECK_STATES:
+                pending += 1
+            elif state in PASSING_CHECK_STATES:
+                passing += 1
+            else:
+                unknown += 1
+    else:
+        failing = _safe_count(payload.get("failing_checks")) or 0
+        pending = _safe_count(payload.get("pending_checks")) or 0
+        passing = _safe_count(payload.get("passing_checks")) or 0
+        unknown = _safe_count(payload.get("unknown_checks")) or 0
+
+    total = failing + pending + passing + unknown
+    if failing:
+        aggregate = "FAILING"
+    elif pending:
+        aggregate = "PENDING"
+    elif unknown and not passing:
+        aggregate = "UNKNOWN"
+    elif total:
+        aggregate = "PASSING"
+    else:
+        aggregate = "NO_CHECKS"
+    return {
+        "schema_version": "issue_fix_pr_check_rollup_v0",
+        "aggregate": aggregate,
+        "failing_count": failing,
+        "pending_count": pending,
+        "passing_count": passing,
+        "unknown_count": unknown,
+        "check_name_sample": names[:5],
+        "raw_status_captured": False,
+        "log_output_captured": False,
+    }
+
+
+def _transition_preview(
+    *,
+    decision: str,
+    action_kind: str,
+    priority: str,
+    reason: str,
+    depends_on: Sequence[str],
+    role: str = "agent",
+    task_class: str = "continuous_monitor",
+    text: str | None = None,
+) -> dict[str, Any]:
+    if text is None:
+        text = f"[{priority}] {reason}"
+    return {
+        "schema_version": "issue_fix_pr_lifecycle_transition_v0",
+        "decision": decision,
+        "command_preview": "loopx todo transition",
+        "role": role,
+        "priority": priority,
+        "task_class": task_class,
+        "action_kind": action_kind,
+        "reason": reason,
+        "text": text,
+        "depends_on": list(depends_on),
+        "would_write": False,
+        "requires_execute_flag": True,
+    }
+
+
+def _build_observation(
+    *,
+    repo: str,
+    pr_ref: str,
+    reference: Mapping[str, Any],
+    provider_payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    state = _upper_label(provider_payload.get("state"), "OPEN")
+    if state == "OPEN":
+        merged_at = provider_payload.get("mergedAt") or provider_payload.get("merged_at")
+        merged = provider_payload.get("merged")
+        if merged_at or merged is True:
+            state = "MERGED"
+    review_decision = _upper_label(provider_payload.get("reviewDecision"))
+    merge_state = _upper_label(provider_payload.get("mergeStateStatus"))
+    return {
+        "schema_version": "issue_fix_pr_lifecycle_observation_v0",
+        "repo": repo,
+        "pr_ref": pr_ref,
+        "kind": "pull_request",
+        "number": reference.get("number"),
+        "state": state,
+        "review_decision": review_decision,
+        "merge_state_status": merge_state,
+        "is_draft": _safe_bool(provider_payload.get("isDraft")),
+        "updated_at": provider_payload.get("updatedAt")
+        or provider_payload.get("updated_at"),
+        "merged_at": provider_payload.get("mergedAt")
+        or provider_payload.get("merged_at"),
+        "closed_at": provider_payload.get("closedAt")
+        or provider_payload.get("closed_at"),
+        "permalink": reference.get("permalink") or provider_payload.get("url"),
+        "checks": _check_rollup(provider_payload),
+        "body_captured": False,
+        "comment_bodies_captured": False,
+        "timeline_captured": False,
+        "log_output_captured": False,
+        "response_payload_captured": False,
+    }
+
+
+def _observation_fingerprint(observation: Mapping[str, Any]) -> str:
+    text = json.dumps(observation, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+def _decide_transition(observation: Mapping[str, Any]) -> dict[str, Any]:
+    state = str(observation.get("state") or "UNKNOWN")
+    review_decision = str(observation.get("review_decision") or "UNKNOWN")
+    merge_state = str(observation.get("merge_state_status") or "UNKNOWN")
+    checks = observation.get("checks")
+    check_rollup = checks if isinstance(checks, Mapping) else {}
+    failing_checks = int(check_rollup.get("failing_count") or 0)
+    pending_checks = int(check_rollup.get("pending_count") or 0)
+    is_draft = bool(observation.get("is_draft"))
+
+    if state == "MERGED":
+        return _transition_preview(
+            decision="no_followup",
+            action_kind="issue_fix_pr_merged_no_followup",
+            priority="P1",
+            task_class="terminal_transition",
+            reason=(
+                "PR is merged; close the monitor with no follow-up even if stale "
+                "review metadata still says review is required."
+            ),
+            depends_on=["issue_fix_pr_lifecycle_monitor"],
+        ) | {
+            "terminal_state_precedence": True,
+            "material_change": True,
+        }
+    if state == "CLOSED":
+        return _transition_preview(
+            decision="no_followup",
+            action_kind="issue_fix_pr_closed_no_followup",
+            priority="P1",
+            task_class="terminal_transition",
+            reason="PR is closed without an open continuation; close the monitor.",
+            depends_on=["issue_fix_pr_lifecycle_monitor"],
+        ) | {
+            "terminal_state_precedence": True,
+            "material_change": True,
+        }
+    if failing_checks:
+        return _transition_preview(
+            decision="runnable_successor",
+            action_kind="issue_fix_ci_failure_replan",
+            priority="P0",
+            task_class="advancement_task",
+            reason="PR checks are failing; inspect public check summary and plan a fix.",
+            depends_on=["issue_fix_pr_lifecycle_monitor"],
+        ) | {
+            "terminal_state_precedence": False,
+            "material_change": True,
+        }
+    if review_decision == "CHANGES_REQUESTED":
+        return _transition_preview(
+            decision="runnable_successor",
+            action_kind="issue_fix_review_changes_replan",
+            priority="P0",
+            task_class="advancement_task",
+            reason="Maintainer review requested changes; derive a follow-up patch or blocker.",
+            depends_on=["issue_fix_pr_lifecycle_monitor"],
+        ) | {
+            "terminal_state_precedence": False,
+            "material_change": True,
+        }
+    if merge_state in BRANCH_BLOCKED_MERGE_STATES:
+        return _transition_preview(
+            decision="runnable_successor",
+            action_kind="issue_fix_branch_or_merge_blocker_replan",
+            priority="P1",
+            task_class="advancement_task",
+            reason="PR merge state is blocked or stale; decide rebase, blocker note, or no-follow-up.",
+            depends_on=["issue_fix_pr_lifecycle_monitor"],
+        ) | {
+            "terminal_state_precedence": False,
+            "material_change": True,
+        }
+    if is_draft:
+        return _transition_preview(
+            decision="user_gate",
+            action_kind="approve_pr_ready_for_review_or_keep_draft",
+            priority="P1",
+            role="user",
+            task_class="user_gate",
+            reason="PR is still draft; owner must approve marking ready or keep monitoring.",
+            depends_on=["issue_fix_pr_lifecycle_monitor"],
+        ) | {
+            "terminal_state_precedence": False,
+            "material_change": True,
+        }
+    if pending_checks:
+        return _transition_preview(
+            decision="monitor_continuation",
+            action_kind="issue_fix_pr_checks_pending_monitor",
+            priority="P2",
+            reason="PR checks are still pending; continue monitor without spawning work.",
+            depends_on=["issue_fix_pr_lifecycle_monitor"],
+        ) | {
+            "terminal_state_precedence": False,
+            "material_change": False,
+        }
+    return _transition_preview(
+        decision="monitor_continuation",
+        action_kind="issue_fix_pr_wait_for_review_or_merge_monitor",
+        priority="P2",
+        reason="No actionable PR state change; keep watching for CI, review, merge, or maintainer signal.",
+        depends_on=["issue_fix_pr_lifecycle_monitor"],
+    ) | {
+        "terminal_state_precedence": False,
+        "material_change": False,
+    }
+
+
+def fetch_github_pr_lifecycle_payload(
+    reference: Mapping[str, Any],
+    *,
+    timeout_seconds: int = 10,
+) -> dict[str, Any]:
+    repo = str(reference.get("repo") or "")
+    number = reference.get("number")
+    if "/" not in repo or not isinstance(number, int):
+        raise ValueError("--fetch-metadata requires a numeric GitHub pull request URL")
+    owner, repo_name = repo.split("/", 1)
+    repo_slug = f"{quote(owner, safe='')}/{quote(repo_name, safe='')}"
+    result = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "view",
+            str(number),
+            "--repo",
+            repo_slug,
+            "--json",
+            ",".join(
+                [
+                    "baseRefName",
+                    "closedAt",
+                    "headRefName",
+                    "isDraft",
+                    "mergeStateStatus",
+                    "mergedAt",
+                    "reviewDecision",
+                    "state",
+                    "statusCheckRollup",
+                    "updatedAt",
+                    "url",
+                ]
+            ),
+        ],
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=timeout_seconds,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            "GitHub PR lifecycle fetch failed; install/authenticate gh or use --metadata-json"
+        )
+    payload = json.loads(result.stdout)
+    if not isinstance(payload, dict):
+        raise ValueError("GitHub PR lifecycle fetch must return a JSON object")
+    return payload
+
+
+def build_issue_fix_pr_lifecycle_monitor_packet(
+    *,
+    repo: str = "public_repo_fixture",
+    pr_ref: str = "pull_123_public_metadata_fixture",
+    url: str | None = None,
+    provider_payload: Mapping[str, Any] | None = None,
+    fetch_metadata: bool = False,
+    fetch_timeout_seconds: int = 10,
+    generated_at: str | None = "2026-06-23T00:00:00Z",
+) -> dict[str, Any]:
+    reference = normalise_github_issue_reference(repo=repo, issue_ref=pr_ref, url=url)
+    if not url:
+        reference = {**reference, "kind": "pull_request"}
+    if reference.get("kind") != "pull_request":
+        raise ValueError("PR lifecycle projection requires a GitHub /pull/<number> URL")
+    payload = dict(provider_payload or {})
+    if fetch_metadata:
+        if provider_payload:
+            raise ValueError("--fetch-metadata cannot be combined with --metadata-json")
+        payload = fetch_github_pr_lifecycle_payload(
+            reference,
+            timeout_seconds=fetch_timeout_seconds,
+        )
+    observation = _build_observation(
+        repo=str(reference["repo"]),
+        pr_ref=str(reference["issue_ref"]),
+        reference=reference,
+        provider_payload=payload,
+    )
+    transition = _decide_transition(observation)
+    packet: dict[str, Any] = {
+        "ok": True,
+        "schema_version": ISSUE_FIX_PR_LIFECYCLE_MONITOR_SCHEMA_VERSION,
+        "mode": "issue-fix-pr-lifecycle",
+        "generated_at": generated_at,
+        "observation": observation,
+        "observation_fingerprint": _observation_fingerprint(observation),
+        "transition": transition,
+        "first_screen": {
+            "waiting_on": transition["role"],
+            "user_action_required": transition["role"] == "user",
+            "agent_can_continue": transition["decision"] == "runnable_successor",
+            "next_safe_action": transition["reason"],
+        },
+        "writeback_contract": {
+            "schema_version": "issue_fix_pr_lifecycle_writeback_contract_v0",
+            "allowed_decisions": [
+                "runnable_successor",
+                "monitor_continuation",
+                "user_gate",
+                "no_followup",
+            ],
+            "monitor_quiet_skip_allowed": transition["material_change"] is False,
+            "successor_or_terminal_required": transition["material_change"] is True,
+            "external_comment_performed": False,
+            "external_pr_created": False,
+            "merge_performed": False,
+            "todo_write_performed": False,
+        },
+        "domain_state_projection": {
+            "schema_version": "issue_fix_pr_lifecycle_domain_state_projection_v0",
+            "domain_pack": "issue_fix",
+            "default_filename": "pr-lifecycle.jsonl",
+            "row_key": {
+                "repo": observation["repo"],
+                "pr_ref": observation["pr_ref"],
+            },
+            "write_performed": False,
+            "path_recorded": False,
+        },
+        "external_reads_performed": bool(fetch_metadata),
+        "external_writes_performed": False,
+        "issue_body_captured": False,
+        "comment_bodies_captured": False,
+        "response_payloads_captured": False,
+        "raw_check_logs_captured": False,
+        "local_paths_captured": False,
+        "private_repo_state_read": False,
+        "todo_write_performed": False,
+        "destructive_git_used": False,
+    }
+    validation = validate_issue_fix_pr_lifecycle_monitor_packet(packet)
+    packet["ok"] = bool(validation["ok"])
+    packet["validation"] = validation
+    return packet
+
+
+def validate_issue_fix_pr_lifecycle_monitor_packet(
+    packet: Mapping[str, Any],
+) -> dict[str, Any]:
+    errors: list[str] = []
+    if packet.get("schema_version") != ISSUE_FIX_PR_LIFECYCLE_MONITOR_SCHEMA_VERSION:
+        errors.append("packet schema_version must be issue_fix_pr_lifecycle_monitor_v0")
+    for key in (
+        "external_writes_performed",
+        "issue_body_captured",
+        "comment_bodies_captured",
+        "response_payloads_captured",
+        "raw_check_logs_captured",
+        "local_paths_captured",
+        "private_repo_state_read",
+        "todo_write_performed",
+        "destructive_git_used",
+    ):
+        if packet.get(key) is not False:
+            errors.append(f"packet {key} must be false")
+    observation = packet.get("observation")
+    if not isinstance(observation, Mapping):
+        errors.append("observation is required")
+        observation = {}
+    if observation.get("kind") != "pull_request":
+        errors.append("observation kind must be pull_request")
+    for key in (
+        "body_captured",
+        "comment_bodies_captured",
+        "timeline_captured",
+        "log_output_captured",
+        "response_payload_captured",
+    ):
+        if observation.get(key) is not False:
+            errors.append(f"observation {key} must be false")
+    checks = observation.get("checks")
+    if isinstance(checks, Mapping):
+        if checks.get("raw_status_captured") is not False:
+            errors.append("checks raw_status_captured must be false")
+        if checks.get("log_output_captured") is not False:
+            errors.append("checks log_output_captured must be false")
+    else:
+        errors.append("observation checks are required")
+
+    transition = packet.get("transition")
+    if not isinstance(transition, Mapping):
+        errors.append("transition is required")
+        transition = {}
+    decision = transition.get("decision")
+    if decision not in {
+        "runnable_successor",
+        "monitor_continuation",
+        "user_gate",
+        "no_followup",
+    }:
+        errors.append("transition decision is invalid")
+    if transition.get("would_write") is not False:
+        errors.append("transition would_write must be false")
+    if transition.get("requires_execute_flag") is not True:
+        errors.append("transition must require execute flag")
+    state = observation.get("state")
+    if state in TERMINAL_PR_STATES and decision != "no_followup":
+        errors.append("terminal PR state must choose no_followup")
+    if state in TERMINAL_PR_STATES and transition.get("terminal_state_precedence") is not True:
+        errors.append("terminal PR state must record terminal_state_precedence")
+    if transition.get("material_change") is True and decision == "monitor_continuation":
+        errors.append("material PR change must not choose monitor_continuation")
+    contract = packet.get("writeback_contract")
+    if not isinstance(contract, Mapping):
+        errors.append("writeback_contract is required")
+    elif contract.get("todo_write_performed") is not False:
+        errors.append("writeback_contract todo_write_performed must be false")
+    domain_state = packet.get("domain_state_projection")
+    if not isinstance(domain_state, Mapping):
+        errors.append("domain_state_projection is required")
+    else:
+        if domain_state.get("domain_pack") != "issue_fix":
+            errors.append("domain_state_projection domain_pack must be issue_fix")
+        if domain_state.get("path_recorded") is not False:
+            errors.append("domain_state_projection path_recorded must be false")
+    return {
+        "ok": not errors,
+        "schema_version": "issue_fix_pr_lifecycle_monitor_validation_v0",
+        "errors": errors,
+        "decision": decision,
+        "terminal_state_precedence": transition.get("terminal_state_precedence"),
+    }
+
+
+def render_issue_fix_pr_lifecycle_monitor_markdown(payload: dict[str, Any]) -> str:
+    lines = [
+        "# LoopX Issue Fix PR Lifecycle",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- schema_version: `{payload.get('schema_version')}`",
+        f"- external_reads_performed: `{payload.get('external_reads_performed')}`",
+        f"- external_writes_performed: `{payload.get('external_writes_performed')}`",
+        f"- todo_write_performed: `{payload.get('todo_write_performed')}`",
+        f"- observation_fingerprint: `{payload.get('observation_fingerprint')}`",
+    ]
+    observation = payload.get("observation")
+    if isinstance(observation, Mapping):
+        checks = observation.get("checks") if isinstance(observation.get("checks"), Mapping) else {}
+        lines.extend(
+            [
+                "",
+                "## Observation",
+                "",
+                f"- repo: `{observation.get('repo')}`",
+                f"- pr_ref: `{observation.get('pr_ref')}`",
+                f"- state: `{observation.get('state')}`",
+                f"- review_decision: `{observation.get('review_decision')}`",
+                f"- merge_state_status: `{observation.get('merge_state_status')}`",
+                f"- checks: `{checks.get('aggregate')}`",
+            ]
+        )
+    transition = payload.get("transition")
+    if isinstance(transition, Mapping):
+        lines.extend(
+            [
+                "",
+                "## Transition",
+                "",
+                f"- decision: `{transition.get('decision')}`",
+                f"- action_kind: `{transition.get('action_kind')}`",
+                f"- material_change: `{transition.get('material_change')}`",
+                f"- terminal_state_precedence: `{transition.get('terminal_state_precedence')}`",
+                f"- reason: {transition.get('reason')}",
+            ]
+        )
+    domain_state = payload.get("domain_state_projection")
+    if isinstance(domain_state, Mapping):
+        lines.extend(
+            [
+                "",
+                "## Domain State Projection",
+                "",
+                f"- domain_pack: `{domain_state.get('domain_pack')}`",
+                f"- default_filename: `{domain_state.get('default_filename')}`",
+                f"- write_performed: `{domain_state.get('write_performed')}`",
+                f"- path_recorded: `{domain_state.get('path_recorded')}`",
+            ]
+        )
+    validation = payload.get("validation")
+    if isinstance(validation, Mapping):
+        errors = validation.get("errors") if isinstance(validation.get("errors"), list) else []
+        lines.extend(
+            [
+                "",
+                "## Validation",
+                "",
+                f"- validation_ok: `{validation.get('ok')}`",
+                f"- error_count: `{len(errors)}`",
+            ]
+        )
+    if payload.get("error"):
+        lines.extend(["", "## Error", "", str(payload.get("error"))])
+    return "\n".join(lines) + "\n"

--- a/loopx/capabilities/issue_fix/workflow_plan.py
+++ b/loopx/capabilities/issue_fix/workflow_plan.py
@@ -38,6 +38,92 @@ def _todo_preview(
     }
 
 
+def _resolution_route_candidates(
+    *,
+    repo_label: str,
+    issue_label: str,
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "schema_version": "issue_fix_resolution_route_candidate_v0",
+            "route": "fix_pr",
+            "priority": "P0",
+            "when": [
+                "public metadata suggests a bounded bug",
+                "caller-approved repo context is available",
+                "a focused repro or validation label can be named",
+            ],
+            "next_action_kind": "issue_fix_branch_validation",
+            "external_issue_comment_performed": False,
+            "external_pr_created": False,
+            "requires_user_gate_before_external_write": True,
+            "summary": (
+                f"Prepare a small fix branch for {repo_label} {issue_label}, "
+                "validate it, and emit a PR review packet."
+            ),
+        },
+        {
+            "schema_version": "issue_fix_resolution_route_candidate_v0",
+            "route": "comment_only",
+            "priority": "P1",
+            "when": [
+                "the issue needs missing repro detail",
+                "the safe answer is maintainer-facing clarification",
+                "patching would require private material or oversized design work",
+            ],
+            "next_action_kind": "issue_fix_external_comment_packet",
+            "external_issue_comment_performed": False,
+            "external_pr_created": False,
+            "requires_user_gate_before_external_write": True,
+            "summary": (
+                "Draft a public-safe maintainer comment packet, but require an "
+                "explicit gate before posting it."
+            ),
+        },
+        {
+            "schema_version": "issue_fix_resolution_route_candidate_v0",
+            "route": "triage_only",
+            "priority": "P2",
+            "when": [
+                "public metadata is too weak for repro or a useful comment",
+                "the issue is likely policy, product, or environment specific",
+            ],
+            "next_action_kind": "issue_fix_no_followup_or_owner_gate",
+            "external_issue_comment_performed": False,
+            "external_pr_created": False,
+            "requires_user_gate_before_external_write": True,
+            "summary": (
+                "Record a blocker or no-follow-up decision rather than opening "
+                "an ungrounded patch loop."
+            ),
+        },
+    ]
+
+
+def _post_pr_lifecycle_monitor_plan() -> dict[str, Any]:
+    return {
+        "schema_version": "issue_fix_post_pr_lifecycle_monitor_plan_v0",
+        "command_preview": (
+            "loopx issue-fix pr-lifecycle --url <github-pr-url> "
+            "--metadata-json <public-pr-state.json> --format json"
+        ),
+        "creates_continuous_monitor_todo": True,
+        "monitor_action_kind": "issue_fix_pr_lifecycle_monitor",
+        "decisions": [
+            "runnable_successor",
+            "monitor_continuation",
+            "user_gate",
+            "no_followup",
+        ],
+        "terminal_state_precedence": (
+            "PR terminal states such as MERGED or CLOSED win over stale review "
+            "metadata and must close the monitor with no-follow-up."
+        ),
+        "external_writes_performed": False,
+        "raw_check_logs_captured": False,
+    }
+
+
 def _branch_plan_from_dry_run(
     *,
     repo_path: str | None,
@@ -133,6 +219,11 @@ def build_issue_fix_workflow_plan_packet(
 
     repo_label = str(metadata["repo"])
     issue_label = str(metadata["issue_ref"])
+    resolution_routes = _resolution_route_candidates(
+        repo_label=repo_label,
+        issue_label=issue_label,
+    )
+    post_pr_monitor = _post_pr_lifecycle_monitor_plan()
     agent_todos = [
         _todo_preview(
             planner_order=1,
@@ -229,6 +320,34 @@ def build_issue_fix_workflow_plan_packet(
         for offset, gate in enumerate(user_gates, start=5):
             gate["planner_order"] = offset
 
+    monitor_order = max(
+        int(todo.get("planner_order", 0))
+        for todo in [*agent_todos, *user_gates]
+        if isinstance(todo.get("planner_order"), int)
+    ) + 1
+    agent_todos.append(
+        _todo_preview(
+            planner_order=monitor_order,
+            role="agent",
+            priority="P2",
+            task_class="continuous_monitor",
+            action_kind="issue_fix_pr_lifecycle_monitor",
+            text=(
+                "[P2] After a PR exists, observe public PR lifecycle state and "
+                "project it into runnable_successor, monitor_continuation, "
+                "user_gate, or no_followup."
+            ),
+            depends_on=[
+                "issue_fix_pr_review_packet",
+                "approve_external_issue_publish_or_merge",
+            ],
+        )
+    )
+    ordered_previews = sorted(
+        agent_todos + user_gates,
+        key=lambda preview: int(preview.get("planner_order", 0)),
+    )
+
     validation_plan = [
         {
             "schema_version": "issue_fix_validation_command_v0",
@@ -289,7 +408,9 @@ def build_issue_fix_workflow_plan_packet(
         },
         "first_screen": first_screen,
         "branch_plan": branch_plan,
-        "ordered_loopx_todo_writeback_preview": agent_todos + user_gates,
+        "resolution_route_candidates": resolution_routes,
+        "post_pr_lifecycle_monitor_plan": post_pr_monitor,
+        "ordered_loopx_todo_writeback_preview": ordered_previews,
         "validation_plan": validation_plan,
         "review_packet_preview": review_packet_preview,
         "external_reads_performed": bool(metadata_packet["external_reads_performed"]),
@@ -350,6 +471,40 @@ def validate_issue_fix_workflow_plan_packet(packet: Mapping[str, Any]) -> dict[s
         errors.append("branch_plan repo_path_captured must be false")
     if branch_plan.get("private_repo_state_read") is not False:
         errors.append("branch_plan private_repo_state_read must be false")
+
+    routes = packet.get("resolution_route_candidates")
+    if not isinstance(routes, Sequence) or isinstance(routes, (str, bytes)):
+        errors.append("resolution_route_candidates must be a list")
+        routes = []
+    route_names = {
+        route.get("route")
+        for route in routes
+        if isinstance(route, Mapping)
+    }
+    for route_name in ("fix_pr", "comment_only", "triage_only"):
+        if route_name not in route_names:
+            errors.append(f"resolution route {route_name} is required")
+    for route in routes:
+        if not isinstance(route, Mapping):
+            errors.append("resolution route entries must be objects")
+            continue
+        if route.get("external_issue_comment_performed") is not False:
+            errors.append("resolution routes must not perform external comments")
+        if route.get("external_pr_created") is not False:
+            errors.append("resolution routes must not create PRs")
+        if route.get("requires_user_gate_before_external_write") is not True:
+            errors.append("resolution routes must gate external writes")
+
+    post_pr = packet.get("post_pr_lifecycle_monitor_plan")
+    if not isinstance(post_pr, Mapping):
+        errors.append("post_pr_lifecycle_monitor_plan is required")
+        post_pr = {}
+    if post_pr.get("creates_continuous_monitor_todo") is not True:
+        errors.append("post PR lifecycle plan must create a monitor todo")
+    if post_pr.get("external_writes_performed") is not False:
+        errors.append("post PR lifecycle plan must not perform external writes")
+    if post_pr.get("raw_check_logs_captured") is not False:
+        errors.append("post PR lifecycle plan must not capture raw check logs")
 
     previews = packet.get("ordered_loopx_todo_writeback_preview")
     if not isinstance(previews, Sequence) or isinstance(previews, (str, bytes)):
@@ -475,6 +630,28 @@ def render_issue_fix_workflow_plan_markdown(payload: dict[str, Any]) -> str:
                     f"`{todo.get('priority')}` `{todo.get('action_kind')}`: "
                     f"would_write=`{todo.get('would_write')}`"
                 )
+    routes = payload.get("resolution_route_candidates")
+    if isinstance(routes, Sequence) and not isinstance(routes, (str, bytes)):
+        lines.extend(["", "## Resolution Routes", ""])
+        for route in routes:
+            if isinstance(route, Mapping):
+                lines.append(
+                    f"- `{route.get('route')}` `{route.get('priority')}`: "
+                    f"{route.get('summary')}"
+                )
+    post_pr = payload.get("post_pr_lifecycle_monitor_plan")
+    if isinstance(post_pr, Mapping):
+        lines.extend(
+            [
+                "",
+                "## Post-PR Lifecycle Monitor",
+                "",
+                f"- creates_continuous_monitor_todo: "
+                f"`{post_pr.get('creates_continuous_monitor_todo')}`",
+                f"- monitor_action_kind: `{post_pr.get('monitor_action_kind')}`",
+                f"- decisions: `{post_pr.get('decisions')}`",
+            ]
+        )
     review = payload.get("review_packet_preview")
     if isinstance(review, Mapping):
         lines.extend(

--- a/loopx/domain_packs/issue_fix.py
+++ b/loopx/domain_packs/issue_fix.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from ..domain_state import default_domain_state_file_path, upsert_domain_state_jsonl
+
+
+ISSUE_FIX_DOMAIN_STATE_LEDGER_FILENAME = "pr-lifecycle.jsonl"
+
+
+def issue_fix_pr_lifecycle_ledger_key(payload: dict[str, Any]) -> dict[str, Any]:
+    observation = payload.get("observation")
+    if not isinstance(observation, dict):
+        raise ValueError("issue-fix PR lifecycle payload must include observation")
+    repo = str(observation.get("repo") or "").strip()
+    pr_ref = str(observation.get("pr_ref") or "").strip()
+    if not repo or not pr_ref:
+        raise ValueError("issue-fix PR lifecycle payload must include repo and pr_ref")
+    return {
+        "repo": repo,
+        "pr_ref": pr_ref,
+    }
+
+
+def upsert_issue_fix_pr_lifecycle_ledger_jsonl(
+    ledger_path: str | Path,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Upsert a compact issue-fix PR lifecycle packet into domain state."""
+
+    if payload.get("ok") is not True:
+        raise ValueError("only successful issue-fix PR lifecycle payloads can be written")
+    for key in (
+        "issue_body_captured",
+        "comment_bodies_captured",
+        "response_payloads_captured",
+        "raw_check_logs_captured",
+        "local_paths_captured",
+    ):
+        if payload.get(key) is not False:
+            raise ValueError(f"issue-fix domain-state payload must keep {key}=false")
+    return upsert_domain_state_jsonl(
+        ledger_path,
+        payload,
+        key=issue_fix_pr_lifecycle_ledger_key(payload),
+        existing_key_fn=issue_fix_pr_lifecycle_ledger_key,
+    )
+
+
+def default_issue_fix_domain_state_ledger_path(
+    *,
+    project: str | Path = ".",
+    goal_id: str,
+) -> Path:
+    """Return the project-local domain-state ledger path for issue-fix PRs."""
+
+    return default_domain_state_file_path(
+        project=project,
+        goal_id=goal_id,
+        domain_pack="issue_fix",
+        filename=ISSUE_FIX_DOMAIN_STATE_LEDGER_FILENAME,
+    )


### PR DESCRIPTION
## Summary

Prepare the issue-fix capability for open-source PR/issue-fix autopilot loops by adding a compact PR lifecycle monitor path:

- add `loopx issue-fix pr-lifecycle` to project public PR state into `runnable_successor`, `monitor_continuation`, `user_gate`, or `no_followup`;
- make terminal PR states such as `MERGED`/`CLOSED` take precedence over stale review metadata;
- write compact issue-fix PR observations to `.loopx/domain-state/<goal-id>/issue_fix/pr-lifecycle.jsonl` by default when goal/ledger context is provided, with `--no-write-domain-state` for preview-only runs;
- extend workflow-plan/bootstrap surfaces so issue-fix goals include a post-PR continuous monitor instead of stopping at PR review packet readiness;
- document and smoke-test the route decisions, domain-state boundary, and canary selection.

## Validation

- `python3 examples/bootstrap-command-pack-smoke.py`
- `python3 examples/issue-fix-workflow-contract-smoke.py`
- `python3 examples/issue-fix-workflow-plan-smoke.py`
- `python3 examples/issue-fix-pr-lifecycle-smoke.py`
- `python3 examples/issue-fix-workflow-e2e-smoke.py`
- `python3 examples/canary/catalog-planner-smoke.py`
- `loopx canary premerge --from-git-diff --format json`

Premerge result: passed, 17 selected checks, 0 failures, public-boundary scan clean.

## Boundaries

- No issue bodies, comment bodies, raw provider payloads, raw check logs, local paths, credentials, external comments, PR creation, merge, publish, production action, or destructive git are captured or performed by the new lifecycle projection.
- Domain state is project-local and gitignored; it stores compact row keys, observations, fingerprints, and transition decisions only.
