### PR TITLE
canary: remove lark kanban reviewer hold

### DIFF
--- a/examples/canary/premerge-validation-gate-smoke.py
+++ b/examples/canary/premerge-validation-gate-smoke.py
@@ -132,6 +132,17 @@ def assert_benchmark_sensitive_change_blocks_self_merge() -> None:
     assert payload["gate"]["self_merge_allowed"] is False, payload
 
 
+def assert_lark_kanban_change_keeps_surface_without_reviewer_hold() -> None:
+    payload = build_premerge_validation_gate(
+        changed_files=["loopx/cli_commands/lark_kanban.py"],
+        execute=False,
+    )
+    classification = payload["classification"]
+    assert "lark_kanban" in classification["surfaces"], payload
+    assert classification["manual_holds"] == [], payload
+    assert payload["gate"]["status"] == "preview_only", payload
+
+
 def assert_cli_json_preview() -> None:
     completed = subprocess.run(
         [
@@ -339,6 +350,7 @@ def main() -> None:
     assert_public_boundary_scan_executes_in_process()
     assert_changed_python_gets_compile_check()
     assert_benchmark_sensitive_change_blocks_self_merge()
+    assert_lark_kanban_change_keeps_surface_without_reviewer_hold()
     assert_cli_json_preview()
     assert_cli_premerge_reports_progress_by_default()
     assert_no_changes_does_not_mask_direct_failures()

--- a/loopx/canary/premerge.py
+++ b/loopx/canary/premerge.py
@@ -287,12 +287,6 @@ def classify_premerge_surfaces(changed_files: list[str]) -> dict[str, Any]:
         )
     if any(_path_matches(path, LARK_KANBAN_TOKENS) for path in files):
         mark("lark_kanban")
-        manual_holds.append(
-            {
-                "kind": "lark_kanban_reviewer",
-                "reason": "Lark Kanban paths require ZaynJarvis review or explicit owner bypass",
-            }
-        )
     if python_files:
         mark("python")
     if not surfaces and files:


### PR DESCRIPTION
## Summary
- remove the hard-coded ZaynJarvis manual hold from Lark Kanban premerge classification
- keep the lark_kanban surface marker so Lark Kanban changes remain visible in the canary output
- add a regression smoke proving Lark Kanban paths no longer require the dedicated reviewer hold

## Validation
- python3 examples/canary/premerge-validation-gate-smoke.py
- loopx check --scan-path loopx/canary/premerge.py --scan-path examples/canary/premerge-validation-gate-smoke.py
- rg -n "ZaynJarvis|lark_kanban_reviewer|Lark Kanban paths require" AGENTS.md loopx examples docs
- loopx canary premerge --from-git-diff