### PR TITLE
Make SkillsBench uv bootstrap cache-first

### DIFF
--- a/examples/skillsbench-uv-cache-smoke.py
+++ b/examples/skillsbench-uv-cache-smoke.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx.benchmark_adapters import skillsbench_uv_cache as uv_cache  # noqa: E402
+from scripts import skillsbench_automation_loop as runner  # noqa: E402
+
+
+def test_staged_dockerfile_prefers_host_uv_binary_cache() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-uv-cache-smoke-") as tmp:
+        root = Path(tmp)
+        fake_bin = root / "bin"
+        fake_bin.mkdir()
+        fake_uv = fake_bin / "uv"
+        fake_uvx = fake_bin / "uvx"
+        fake_uv.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        fake_uvx.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        fake_uv.chmod(0o755)
+        fake_uvx.chmod(0o755)
+
+        task = root / "tasks" / "pddl-tpp-planning"
+        dockerfile = task / "environment" / "Dockerfile"
+        dockerfile.parent.mkdir(parents=True)
+        dockerfile.write_text(
+            "FROM python:3.12-slim\n"
+            "RUN curl -LsSf https://astral.sh/uv/0.9.22/install.sh | sh && \\\n"
+            "    install -m 0755 ${HOME}/.local/bin/uv /usr/local/bin/uv && \\\n"
+            "    install -m 0755 ${HOME}/.local/bin/uvx /usr/local/bin/uvx\n",
+            encoding="utf-8",
+        )
+        (task / "task.toml").write_text("version = \"1.1\"\n", encoding="utf-8")
+
+        original_candidates = uv_cache.host_uv_binary_cache_candidates
+        try:
+            uv_cache.host_uv_binary_cache_candidates = lambda: {
+                "uv": fake_uv,
+                "uvx": fake_uvx,
+            }
+            staged_path, metadata = runner.stage_task_for_sandbox(
+                task_path=task,
+                jobs_dir=root / "jobs",
+                job_name="pddl-tpp-planning-goal",
+                sandbox="docker",
+                include_task_skills=False,
+            )
+        finally:
+            uv_cache.host_uv_binary_cache_candidates = original_candidates
+
+        assert metadata["dockerfile_uv_binary_cache_context_created"] is True
+        assert metadata["dockerfile_uv_binary_cache_available"] is True
+        assert metadata["dockerfile_uv_binary_cache_binary_count"] == 2
+        assert metadata["dockerfile_uv_binary_cache_has_uv"] is True
+        assert metadata["dockerfile_uv_binary_cache_has_uvx"] is True
+        assert metadata["dockerfile_uv_binary_cache_dockerfile_patch_applied"] is True
+        assert metadata["dockerfile_uv_binary_cache_raw_path_recorded"] is False
+
+        cache_dir = staged_path / "environment" / "loopx_uv_cache"
+        assert (cache_dir / "uv").exists()
+        assert (cache_dir / "uvx").exists()
+        staged_text = (staged_path / "environment" / "Dockerfile").read_text(
+            encoding="utf-8"
+        )
+        assert uv_cache.DOCKER_UV_BINARY_CACHE_BEGIN in staged_text
+        assert "COPY loopx_uv_cache/ /opt/loopx_uv_cache/" in staged_text
+        assert "uv --version >/dev/null 2>&1" in staged_text
+        assert "python3 -m pip install ${loopx_pip_break_system_packages}" in staged_text
+
+
+if __name__ == "__main__":
+    test_staged_dockerfile_prefers_host_uv_binary_cache()
+    print("skillsbench-uv-cache-smoke: ok")

--- a/loopx/benchmark_adapters/skillsbench_uv_cache.py
+++ b/loopx/benchmark_adapters/skillsbench_uv_cache.py
@@ -1,0 +1,111 @@
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+from pathlib import Path
+from typing import Any
+
+DOCKER_UV_BINARY_CACHE_CONTEXT_DIR = "loopx_uv_cache"
+DOCKER_UV_BINARY_CACHE_BEGIN = "# BEGIN LOOPX_SKILLSBENCH_UV_BINARY_CACHE"
+DOCKER_UV_BINARY_CACHE_END = "# END LOOPX_SKILLSBENCH_UV_BINARY_CACHE"
+UV_BINARY_CACHE_KEYS = (
+    "dockerfile_uv_binary_cache_context_created",
+    "dockerfile_uv_binary_cache_available",
+    "dockerfile_uv_binary_cache_binary_count",
+    "dockerfile_uv_binary_cache_has_uv",
+    "dockerfile_uv_binary_cache_has_uvx",
+    "dockerfile_uv_binary_cache_dockerfile_patch_applied",
+    "dockerfile_uv_binary_cache_raw_path_recorded",
+)
+
+
+def empty_uv_binary_cache_metadata() -> dict[str, Any]:
+    return {
+        "dockerfile_uv_binary_cache_context_created": False,
+        "dockerfile_uv_binary_cache_available": False,
+        "dockerfile_uv_binary_cache_binary_count": 0,
+        "dockerfile_uv_binary_cache_has_uv": False,
+        "dockerfile_uv_binary_cache_has_uvx": False,
+        "dockerfile_uv_binary_cache_dockerfile_patch_applied": False,
+        "dockerfile_uv_binary_cache_raw_path_recorded": False,
+    }
+
+
+def dockerfile_uv_binary_cache_prelude() -> str:
+    return (
+        f"COPY {DOCKER_UV_BINARY_CACHE_CONTEXT_DIR}/ /opt/loopx_uv_cache/\n"
+        "RUN set -eux; \\\n"
+        f"    : \"{DOCKER_UV_BINARY_CACHE_BEGIN}\"; \\\n"
+        "    if [ -x /opt/loopx_uv_cache/uv ]; then install -m 0755 /opt/loopx_uv_cache/uv /usr/local/bin/uv; fi; \\\n"
+        "    if [ -x /opt/loopx_uv_cache/uvx ]; then install -m 0755 /opt/loopx_uv_cache/uvx /usr/local/bin/uvx; fi; \\\n"
+        "    if command -v uv >/dev/null 2>&1 && command -v uvx >/dev/null 2>&1 && uv --version >/dev/null 2>&1 && uvx --version >/dev/null 2>&1; then exit 0; fi; \\\n"
+        "    rm -f /usr/local/bin/uv /usr/local/bin/uvx; \\\n"
+        f"    : \"{DOCKER_UV_BINARY_CACHE_END}\"; \\\n"
+    )
+
+
+def host_uv_binary_cache_candidates() -> dict[str, Path]:
+    """Return host uv binaries that are safe to copy into Linux Docker images."""
+
+    if not sys.platform.startswith("linux"):
+        return {}
+    machine = os.uname().machine.lower()
+    if machine not in {"x86_64", "amd64"}:
+        return {}
+    candidates: dict[str, Path] = {}
+    for name in ("uv", "uvx"):
+        raw = shutil.which(name)
+        if not raw:
+            continue
+        path = Path(raw)
+        if path.is_file() and os.access(path, os.X_OK):
+            candidates[name] = path
+    return candidates
+
+
+def stage_uv_binary_cache_context(environment_dir: Path) -> dict[str, Any]:
+    """Stage optional host uv/uvx binaries into the Docker build context."""
+
+    cache_dir = environment_dir / DOCKER_UV_BINARY_CACHE_CONTEXT_DIR
+    if cache_dir.exists():
+        shutil.rmtree(cache_dir)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    (cache_dir / ".loopx_keep").write_text(
+        "Optional LoopX uv binary cache for SkillsBench Docker bootstrap.\n",
+        encoding="utf-8",
+    )
+    copied: list[str] = []
+    for name, source in host_uv_binary_cache_candidates().items():
+        target = cache_dir / name
+        shutil.copy2(source, target)
+        target.chmod(0o755)
+        copied.append(name)
+    return {
+        "dockerfile_uv_binary_cache_context_created": True,
+        "dockerfile_uv_binary_cache_available": bool(copied),
+        "dockerfile_uv_binary_cache_binary_count": len(copied),
+        "dockerfile_uv_binary_cache_has_uv": "uv" in copied,
+        "dockerfile_uv_binary_cache_has_uvx": "uvx" in copied,
+        "dockerfile_uv_binary_cache_raw_path_recorded": False,
+    }
+
+
+def discover_uv_binary_cache_metadata(
+    prepared_task: Path,
+    dockerfile_text: str,
+) -> dict[str, Any]:
+    cache_dir = prepared_task / "environment" / DOCKER_UV_BINARY_CACHE_CONTEXT_DIR
+    has_uv = (cache_dir / "uv").exists()
+    has_uvx = (cache_dir / "uvx").exists()
+    return {
+        "dockerfile_uv_binary_cache_context_created": cache_dir.exists(),
+        "dockerfile_uv_binary_cache_available": has_uv or has_uvx,
+        "dockerfile_uv_binary_cache_binary_count": int(has_uv) + int(has_uvx),
+        "dockerfile_uv_binary_cache_has_uv": has_uv,
+        "dockerfile_uv_binary_cache_has_uvx": has_uvx,
+        "dockerfile_uv_binary_cache_dockerfile_patch_applied": (
+            DOCKER_UV_BINARY_CACHE_BEGIN in dockerfile_text
+        ),
+        "dockerfile_uv_binary_cache_raw_path_recorded": False,
+    }

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -116,7 +116,7 @@ from loopx.benchmark_adapters.skillsbench_verifier_bootstrap import (  # noqa: E
 from loopx.benchmark_adapters.skillsbench_task_source import (  # noqa: E402
     classify_missing_task_source,
 )
-from loopx.benchmark_adapters import skillsbench_runner_source as runner_source  # noqa: E402
+from loopx.benchmark_adapters import skillsbench_runner_source as runner_source, skillsbench_uv_cache as uv_cache  # noqa: E402
 from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
     SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER,
     SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_PROMPT,
@@ -6277,6 +6277,7 @@ def _discover_prepared_task_staging(plan: dict[str, Any]) -> dict[str, Any]:
             and "python3 -m pip install" in dockerfile_text
             and "uv==${LOOPX_SKILLSBENCH_UV_VERSION}" in dockerfile_text
         ),
+        **uv_cache.discover_uv_binary_cache_metadata(prepared_task, dockerfile_text),
         "dockerfile_uv_bootstrap_mirror_host": (
             DEFAULT_VERIFIER_UV_RELEASE_MIRROR_HOST
             if DOCKER_UV_BOOTSTRAP_MIRROR_BEGIN in dockerfile_text
@@ -7024,7 +7025,7 @@ def patch_dockerfile_uv_bootstrap_mirror(dockerfile: Path) -> dict[str, Any]:
         "# official uv installer as a bounded mirror-backed fallback.\n"
         f"ARG LOOPX_SKILLSBENCH_UV_RELEASE_MIRROR={DEFAULT_VERIFIER_UV_RELEASE_MIRROR_BASE}\n"
         f"ARG LOOPX_SKILLSBENCH_UV_VERSION={version}\n"
-        "RUN set -eux; \\\n"
+        f"{uv_cache.dockerfile_uv_binary_cache_prelude()}"
         "    if command -v python3 >/dev/null 2>&1; then \\\n"
         "      loopx_pip_break_system_packages=''; \\\n"
         "      if python3 -m pip install --help 2>/dev/null | grep -q -- '--break-system-packages'; then \\\n"
@@ -7077,6 +7078,7 @@ def patch_dockerfile_uv_bootstrap_mirror(dockerfile: Path) -> dict[str, Any]:
             "dockerfile_uv_bootstrap_mirror_patch_required": True,
             "dockerfile_uv_bootstrap_mirror_patch_applied": True,
             "dockerfile_uv_bootstrap_pip_fallback_patch_applied": True,
+            "dockerfile_uv_binary_cache_dockerfile_patch_applied": True,
             "dockerfile_uv_bootstrap_version": version,
             "dockerfile_uv_bootstrap_mirror_host": (
                 DEFAULT_VERIFIER_UV_RELEASE_MIRROR_HOST
@@ -8606,6 +8608,7 @@ def stage_task_for_sandbox(
                     )
                 )
             ),
+            **uv_cache.stage_uv_binary_cache_context(staged_path / "environment"),
             "dockerfile_uv_bootstrap_mirror_host": (
                 str(
                     dockerfile_uv_mirror_metadata.get(


### PR DESCRIPTION
## Summary
- stage compatible host `uv`/`uvx` binaries into each SkillsBench Docker build context when the runner is Linux x86_64
- make the uv bootstrap Dockerfile patch try the staged binaries before PyPI/mirror/network fallback
- add compact public-safe metadata and a focused smoke for the cache-first path

## Why
The post-1738 canary showed the egress proxy was configured, but Docker build still spent many minutes downloading the uv release tarball. This makes dependency bootstrap the benchmark throughput bottleneck rather than solver work. Cache-first bootstrap keeps the network fallback while avoiding repeated slow release downloads on prepared runners.

## Validation
- `python3 -m py_compile scripts/skillsbench_automation_loop.py loopx/benchmark_adapters/skillsbench_uv_cache.py examples/skillsbench-uv-cache-smoke.py examples/skillsbench-benchmark-run-smoke.py`
- `python3 examples/skillsbench-uv-cache-smoke.py`
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `loopx check --scan-path scripts/skillsbench_automation_loop.py --scan-path loopx/benchmark_adapters/skillsbench_uv_cache.py --scan-path examples/skillsbench-uv-cache-smoke.py`
- `loopx canary premerge --from-git-diff`: direct checks, 6 catalog canaries, and public boundary passed; manual hold is `benchmark_sensitive` and is covered by owner authorization for benchmark-related self-merge

## Boundary
No raw benchmark logs, trajectories, verifier output, credentials, local runtime paths, or private evidence are included.
