### PR TITLE
Add issue-fix feasibility route projection

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -14,13 +14,14 @@ external comments, PRs, merges, or publishes.
 | CLI entry | `loopx issue-fix ...` |
 | Content-ops bridge | `loopx content-ops issue-fix-* ...` |
 | Protocol docs | `docs/capabilities/issue-fix/protocols/` |
-| Smoke | `examples/issue-fix-workflow-plan-smoke.py`, `examples/issue-fix-pr-lifecycle-smoke.py`, `examples/issue-fix-acceptance-loop-smoke.py` |
+| Smoke | `examples/issue-fix-workflow-plan-smoke.py`, `examples/issue-fix-feasibility-smoke.py`, `examples/issue-fix-pr-lifecycle-smoke.py`, `examples/issue-fix-acceptance-loop-smoke.py` |
 
 ## Protocols
 
 - [`issue_fix_workflow_contract_v0`](protocols/issue-fix-workflow-contract-v0.md)
 - [`issue_fix_acceptance_loop_v0`](protocols/issue-fix-acceptance-loop-v0.md)
 - `issue_fix_workflow_plan_packet_v0`
+- `issue_fix_feasibility_v0`
 - `issue_fix_pr_lifecycle_monitor_v0`
 - `github_issue_metadata_preview_v0`
 - `content_ops_issue_fix_metadata_preview_packet_v0`
@@ -70,13 +71,13 @@ loopx issue-fix workflow-plan \
   --format json
 ```
 
-The workflow-plan output is still preview-only. Accepted candidates become
-ordered LoopX todos: public metadata/intake, repro or route selection,
-branch-local patch and validation, PR review packet readiness, then a post-PR
-lifecycle monitor. Concrete owner actions become explicit user gates, including
-private repro material, issue body/comment reads, external issue comments, PR
-creation, merge, publish, destructive git, production actions, and
-repository-policy approvals.
+The workflow-plan output is still preview-only. Initial writeback is deliberately
+small: public metadata classification followed by one feasibility checkpoint.
+The checkpoint selects exactly one `fix_pr`, `comment_only`, or `triage_only`
+route and projects only that route's successor or no-follow-up. Concrete owner
+actions remain explicit gates, including private repro material, issue
+body/comment reads, external issue comments, PR creation, merge, publish,
+destructive git, production actions, and repository-policy approvals.
 
 ## Workflow Plan
 
@@ -89,6 +90,30 @@ issue intake, branch dry-run planning, validation labels, ordered LoopX todo
 writeback previews, and PR review readiness blockers into one packet. It does
 not write LoopX todos, inspect the local repo in dry-run mode, create external
 comments or PRs, merge, or capture raw issue body/comment material.
+
+## Feasibility Decision
+
+```bash
+loopx issue-fix feasibility \
+  --url https://github.com/owner/repo/issues/123 \
+  --reproduction-status planned \
+  --reproduction-label "focused repro plan" \
+  --scope-class bounded \
+  --validation-label "focused unit test" \
+  --goal-id example-goal \
+  --format json
+```
+
+Feasibility consumes only compact agent observations. It never stores raw issue
+bodies, comment bodies, provider responses, logs, local paths, or credentials.
+`fix_pr` requires bounded scope plus named reproduction and validation surfaces;
+a planned repro first projects `issue_fix_confirm_reproduction`, not patch work.
+`comment_only` projects a comment-draft todo with an external-write gate, while
+`triage_only` projects structured no-follow-up.
+
+With `--goal-id` or `--ledger-path`, the decision is upserted by repo and issue
+reference into `.loopx/domain-state/<goal-id>/issue_fix/feasibility.jsonl`.
+Use `--no-write-domain-state` for preview-only checks.
 
 ## PR Lifecycle Monitor
 
@@ -117,6 +142,7 @@ provider payloads, raw check logs, local paths, or credentials.
 
 ```bash
 python3 examples/issue-fix-workflow-plan-smoke.py
+python3 examples/issue-fix-feasibility-smoke.py
 python3 examples/issue-fix-pr-lifecycle-smoke.py
 python3 examples/issue-fix-workflow-contract-smoke.py
 python3 examples/content-ops-issue-fix-metadata-preview-smoke.py

--- a/docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md
@@ -31,24 +31,30 @@ open PRs, merge, publish, or run destructive git without an explicit gate.
    todo writeback preview, resolution route candidates, gate preview, post-PR
    lifecycle monitor plan, and PR-review readiness blockers. This stage is
    preview-only and does not write todos.
-4. **LoopX todo writeback:** convert accepted candidates into durable LoopX
-   todos in priority and dependency order. Typical agent todos are repro smoke,
-   code-context route, branch-local patch, validation, and review-packet
-   readiness. User todos represent gates such as private repro material,
-   external issue comment, PR creation, merge, publish, or repository policy.
-5. **Caller repo branch:** use `issue_fix_caller_repo_branch_packet_v0` only
+4. **Feasibility checkpoint:** build `issue_fix_feasibility_v0` from compact
+   public-safe agent observations. The decision must select exactly one
+   `fix_pr`, `comment_only`, or `triage_only` route. `fix_pr` requires bounded
+   scope plus named reproduction and validation surfaces; planned reproduction
+   projects confirmation work before patch work. With a goal id, the compact
+   decision writes issue-fix domain state by default.
+5. **LoopX todo writeback:** initially write only metadata classification and
+   the feasibility checkpoint. Then write the single route-specific successor
+   projected by feasibility, or record its structured no-follow-up. User todos
+   represent concrete external-write, private-material, merge, publish, or
+   repository-policy gates.
+6. **Caller repo branch:** use `issue_fix_caller_repo_branch_packet_v0` only
    after the caller provides an approved local git repo, base branch, issue
    branch policy, and validation command. Dry-run mode must not inspect the
    repo. Execute mode may inspect the approved repo and create or claim a
    `codex/` issue branch, but must refuse branch switches from dirty state.
-6. **Validation:** record focused validation as pass/fail, exit code, and
+7. **Validation:** record focused validation as pass/fail, exit code, and
    public-safe label. Validation stdout, stderr, local paths, and raw git output
    stay out of the packet. A validated fix should prove failing-before and
    passing-after evidence when that repro path is available.
-7. **PR review packet:** emit `issue_fix_pr_review_packet_v0` only when branch,
+8. **PR review packet:** emit `issue_fix_pr_review_packet_v0` only when branch,
    validation, and repo-relative changed-file evidence are sufficient for human
    review. The packet is review evidence, not external publication authority.
-8. **PR lifecycle monitor:** after a PR exists, use
+9. **PR lifecycle monitor:** after a PR exists, use
    `issue_fix_pr_lifecycle_monitor_v0` to project compact public PR state into
    exactly one of `runnable_successor`, `monitor_continuation`, `user_gate`, or
    `no_followup`. Terminal PR states such as `MERGED` and `CLOSED` take
@@ -57,7 +63,7 @@ open PRs, merge, publish, or run destructive git without an explicit gate.
    The command writes compact domain state by default when a `--goal-id` or
    `--ledger-path` is provided, and `--no-write-domain-state` keeps it
    preview-only.
-9. **Gate handling:** surface concrete gates instead of silently blocking. Safe
+10. **Gate handling:** surface concrete gates instead of silently blocking. Safe
    metadata-only triage, public-code search, and focused smoke drafting may
    continue when those gates do not cover the selected action.
 
@@ -103,18 +109,20 @@ useful patch or comment.
 
 ## Domain State
 
-Issue-fix domain state is a project-local read model for long-running monitors:
+Issue-fix domain state is a project-local read model for compact decisions and
+long-running monitors:
 
 ```text
+.loopx/domain-state/<goal-id>/issue_fix/feasibility.jsonl
 .loopx/domain-state/<goal-id>/issue_fix/pr-lifecycle.jsonl
 ```
 
-Rows are keyed by compact `repo` and `pr_ref` and may store public-safe PR
-observations, transition decisions, and observation fingerprints. Domain state
-must not store issue bodies, comment bodies, raw provider payloads, raw check
-logs, local paths, credentials, or destructive-git output. The public packet and
-validation contract remain the source for behavior; domain state only keeps the
-watch lane from forgetting the latest compact observation.
+Feasibility rows are keyed by `repo` and `issue_ref`; PR lifecycle rows are keyed
+by `repo` and `pr_ref`. They may store compact observations, decisions, and
+fingerprints. Domain state must not store issue bodies, comment bodies, raw
+provider payloads, raw logs, local paths, credentials, or destructive-git
+output. Public packet validation remains the behavior contract; domain state
+only keeps the agent from forgetting its latest compact decision.
 
 ## Ready Criteria
 
@@ -136,6 +144,10 @@ An issue-fix workflow is PR-review-ready only when all of these are true:
 - `content_ops_issue_fix_intake_packet_v0`
 - `issue_fix_intake_v0`
 - `issue_fix_workflow_plan_packet_v0`
+- `issue_fix_feasibility_v0`
+- `issue_fix_feasibility_observation_v0`
+- `issue_fix_feasibility_decision_v0`
+- `issue_fix_feasibility_domain_state_projection_v0`
 - `issue_fix_pr_lifecycle_monitor_v0`
 - `issue_fix_pr_lifecycle_transition_v0`
 - `issue_fix_pr_lifecycle_domain_state_projection_v0`

--- a/docs/reference/protocols/loopx-goal-command-v0.md
+++ b/docs/reference/protocols/loopx-goal-command-v0.md
@@ -98,12 +98,24 @@ loopx issue-fix workflow-plan \
 ```
 
 The preview maps public metadata, intake classification, branch planning,
-validation labels, todo writeback previews, and PR review readiness blockers
-into the `/loopx <goal text>` planning checkpoint. Accepted candidates are then
-written with `loopx todo add` in priority and planner order. User todos or
-operator gates must cover private repro material, issue body/comment reads,
-external issue comments, PR creation, merge, publish, destructive git,
-production actions, and repository-policy approvals.
+validation labels, the feasibility checkpoint, and PR review readiness blockers
+into `/loopx <goal text>`. Initially write only metadata classification and the
+feasibility checkpoint in priority and planner order. Then record a compact
+observation and let LoopX select exactly one route:
+
+```bash
+loopx issue-fix feasibility \
+  --url <github-issue-url> \
+  --reproduction-status <confirmed|planned|missing|blocked> \
+  --scope-class <bounded|uncertain|oversized> \
+  --goal-id <goal-id> \
+  --format json
+```
+
+Write only the projected route successor or no-follow-up. User todos or operator
+gates must cover private repro material, issue body/comment reads, external
+issue comments, PR creation, merge, publish, destructive git, production
+actions, and repository-policy approvals.
 
 ## Stop Conditions
 

--- a/examples/bootstrap-command-pack-smoke.py
+++ b/examples/bootstrap-command-pack-smoke.py
@@ -136,6 +136,7 @@ def test_goal_text_invocation_plans_ranked_todos_before_activation() -> None:
         assert "Preserve that exact order" in plan_prompt
         assert "GitHub issue/PR fix" in plan_prompt
         assert "loopx issue-fix workflow-plan" in plan_prompt
+        assert "loopx issue-fix feasibility" in plan_prompt
         assert "loopx issue-fix pr-lifecycle" in plan_prompt
         assert "external comments, PR creation, merge, publish" in plan_prompt
         assert "issue_fix_workflow_plan_template" in commands
@@ -144,6 +145,12 @@ def test_goal_text_invocation_plans_ranked_todos_before_activation() -> None:
         assert "--url <github-issue-or-pr-url>" in issue_fix_template
         assert "--repo-path <approved-repo>" in issue_fix_template
         assert "--validation-label '<validation command>'" in issue_fix_template
+        assert "issue_fix_feasibility_template" in commands
+        feasibility_template = str(commands["issue_fix_feasibility_template"])
+        assert "issue-fix feasibility" in feasibility_template
+        assert "--reproduction-status" in feasibility_template
+        assert "--scope-class" in feasibility_template
+        assert "--goal-id" in feasibility_template
         assert "issue_fix_pr_lifecycle_template" in commands
         pr_lifecycle_template = str(commands["issue_fix_pr_lifecycle_template"])
         assert "issue-fix pr-lifecycle" in pr_lifecycle_template
@@ -157,6 +164,7 @@ def test_goal_text_invocation_plans_ranked_todos_before_activation() -> None:
         domain_routes = goal_start["domain_route_hints"]
         assert domain_routes["issue_fix_workflow"]["when"].startswith("goal text contains")
         assert "workflow-plan" in domain_routes["issue_fix_workflow"]["preview_command"]
+        assert "feasibility" in domain_routes["issue_fix_workflow"]["decision_command"]
         assert "pr-lifecycle" in domain_routes["issue_fix_workflow"]["post_pr_monitor_command"]
         assert "explicit gates" in domain_routes["issue_fix_workflow"]["writeback"]
         assert "domain-state" in domain_routes["issue_fix_workflow"]["writeback"]

--- a/examples/canary/catalog-planner-smoke.py
+++ b/examples/canary/catalog-planner-smoke.py
@@ -495,7 +495,7 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
             "scripts/update_notes_release_job.py",
         ],
         surfaces=["product-entry issue-fix content-ops update-note cross-runtime demo"],
-        max_checks_per_profile=5,
+        max_checks_per_profile=6,
     )
     product_entry_profiles = {
         profile["id"]: profile for profile in product_entry_payload["domain_profiles"]
@@ -505,6 +505,7 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     product_entry_profile = product_entry_profiles["product-entry-workflows"]
     product_entry_commands = [check["command"] for check in product_entry_profile["checks"]]
     assert "python3 examples/issue-fix-workflow-contract-smoke.py" in product_entry_commands, product_entry_profile
+    assert "python3 examples/issue-fix-feasibility-smoke.py" in product_entry_commands, product_entry_profile
     assert "python3 examples/issue-fix-pr-lifecycle-smoke.py" in product_entry_commands, product_entry_profile
     assert "python3 examples/content-ops-issue-fix-intake-smoke.py" in product_entry_commands, product_entry_profile
     assert "python3 examples/public_entry/readme-demo-surface-smoke.py" in product_entry_commands, product_entry_profile

--- a/examples/issue-fix-feasibility-smoke.py
+++ b/examples/issue-fix-feasibility-smoke.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Smoke-test compact issue-fix feasibility routing and domain-state writeback."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx.capabilities.issue_fix.feasibility import (  # noqa: E402
+    ISSUE_FIX_FEASIBILITY_PACKET_SCHEMA_VERSION,
+    build_issue_fix_feasibility_packet,
+)
+
+
+URL = "https://github.com/owner/repo/issues/123"
+
+
+def assert_boundary(packet: dict[str, object]) -> None:
+    for key in (
+        "external_reads_performed",
+        "external_writes_performed",
+        "todo_write_performed",
+        "issue_body_captured",
+        "comment_bodies_captured",
+        "response_payloads_captured",
+        "raw_logs_captured",
+        "local_paths_captured",
+        "destructive_git_used",
+    ):
+        assert packet[key] is False, (key, packet)
+    text = json.dumps(packet, sort_keys=True)
+    assert "/Users/" not in text, text
+    assert "/private/tmp/" not in text, text
+    assert "raw issue body" not in text, text
+    assert "raw check log" not in text, text
+
+
+def main() -> int:
+    fix = build_issue_fix_feasibility_packet(
+        url=URL,
+        reproduction_status="confirmed",
+        reproduction_label="focused unit repro",
+        scope_class="bounded",
+        validation_label="focused unit test",
+    )
+    assert fix["ok"] is True, fix
+    assert fix["schema_version"] == ISSUE_FIX_FEASIBILITY_PACKET_SCHEMA_VERSION
+    assert fix["decision"]["route"] == "fix_pr", fix
+    assert fix["transition"]["decision"] == "runnable_successor", fix
+    assert fix["transition"]["projected_todo"]["action_kind"] == (
+        "issue_fix_branch_validation"
+    ), fix
+    assert_boundary(fix)
+
+    planned = build_issue_fix_feasibility_packet(
+        url=URL,
+        reproduction_status="planned",
+        reproduction_label="focused repro plan",
+        scope_class="bounded",
+        validation_label="focused unit test",
+    )
+    assert planned["decision"]["route"] == "fix_pr", planned
+    assert planned["transition"]["projected_todo"]["action_kind"] == (
+        "issue_fix_confirm_reproduction"
+    ), planned
+
+    comment = build_issue_fix_feasibility_packet(
+        url=URL,
+        reproduction_status="missing",
+        scope_class="uncertain",
+        comment_value="clarification",
+    )
+    assert comment["decision"]["route"] == "comment_only", comment
+    assert comment["transition"]["projected_todo"]["action_kind"] == (
+        "issue_fix_external_comment_packet"
+    ), comment
+    assert comment["transition"]["external_write_gate"]["satisfied"] is False
+    assert_boundary(comment)
+
+    triage = build_issue_fix_feasibility_packet(
+        url=URL,
+        reproduction_status="missing",
+        scope_class="oversized",
+    )
+    assert triage["decision"]["route"] == "triage_only", triage
+    assert triage["transition"]["decision"] == "no_followup", triage
+    assert triage["transition"]["projected_todo"] is None, triage
+    assert_boundary(triage)
+
+    try:
+        build_issue_fix_feasibility_packet(
+            url=URL,
+            reproduction_status="confirmed",
+            reproduction_label="/Users/example/private/repro.log",
+            scope_class="bounded",
+            validation_label="focused unit test",
+        )
+    except ValueError as exc:
+        assert "reproduction_label" in str(exc), exc
+    else:
+        raise AssertionError("local path reproduction label must be rejected")
+
+    with tempfile.TemporaryDirectory(prefix="loopx-issue-fix-feasibility-") as tmpdir:
+        project = Path(tmpdir)
+        command = [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "issue-fix",
+            "feasibility",
+            "--url",
+            URL,
+            "--reproduction-status",
+            "confirmed",
+            "--reproduction-label",
+            "focused unit repro",
+            "--scope-class",
+            "bounded",
+            "--validation-label",
+            "focused unit test",
+            "--goal-id",
+            "pilot-goal",
+            "--project",
+            str(project),
+        ]
+        first = subprocess.run(
+            command,
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        first_packet = json.loads(first.stdout)
+        assert first_packet["domain_state_projection"]["write_performed"] is True
+        ledger = (
+            project
+            / ".loopx"
+            / "domain-state"
+            / "pilot-goal"
+            / "issue_fix"
+            / "feasibility.jsonl"
+        )
+        assert ledger.exists(), ledger
+        rows = ledger.read_text(encoding="utf-8").splitlines()
+        assert len(rows) == 1, rows
+
+        second_command = command.copy()
+        second_command[second_command.index("confirmed")] = "missing"
+        repro_index = second_command.index("--reproduction-label")
+        del second_command[repro_index : repro_index + 2]
+        validation_index = second_command.index("--validation-label")
+        del second_command[validation_index : validation_index + 2]
+        second_command.extend(["--comment-value", "diagnosis"])
+        second = subprocess.run(
+            second_command,
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        second_packet = json.loads(second.stdout)
+        assert second_packet["decision"]["route"] == "comment_only", second_packet
+        rows = ledger.read_text(encoding="utf-8").splitlines()
+        assert len(rows) == 1, rows
+        assert json.loads(rows[0])["decision"]["route"] == "comment_only", rows
+
+    print("issue-fix-feasibility-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/issue-fix-workflow-contract-smoke.py
+++ b/examples/issue-fix-workflow-contract-smoke.py
@@ -87,24 +87,26 @@ def main() -> int:
     assert "loopx bootstrap-command-pack --project ." in readme
     assert "--goal-text \"Fix https://github.com/owner/repo/issues/123\"" in readme
     assert "loopx issue-fix workflow-plan" in readme
+    assert "loopx issue-fix feasibility" in readme
     assert "loopx issue-fix pr-lifecycle" in readme
-    assert "ordered LoopX todos" in readme
-    assert "PR review packet readiness" in readme
+    assert "selects exactly one" in readme
+    assert "## Feasibility Decision" in readme
     assert "## PR Lifecycle Monitor" in readme
     assert "runnable_successor" in readme
     assert "examples/issue-fix-pr-lifecycle-smoke.py" in readme
-    assert "explicit user gates" in readme
+    assert "explicit gates" in readme
     assert "## Issue-Fix Domain Route" in loopx_goal_command
     assert "loopx issue-fix workflow-plan" in loopx_goal_command
     assert "before writing todos" in loopx_goal_command
     assert "priority and planner order" in loopx_goal_command
-    assert "operator gates must cover private repro material" in loopx_goal_command
+    assert "gates must cover private repro material" in loopx_goal_command
     assert_ordered(
         doc,
         [
             "**Metadata preview:**",
             "**Intake classification:**",
             "**Workflow plan:**",
+            "**Feasibility checkpoint:**",
             "**LoopX todo writeback:**",
             "**Caller repo branch:**",
             "**Validation:**",
@@ -119,6 +121,10 @@ def main() -> int:
         CONTENT_OPS_ISSUE_FIX_INTAKE_PACKET_SCHEMA_VERSION,
         ISSUE_FIX_INTAKE_SCHEMA_VERSION,
         "issue_fix_workflow_plan_packet_v0",
+        "issue_fix_feasibility_v0",
+        "issue_fix_feasibility_observation_v0",
+        "issue_fix_feasibility_decision_v0",
+        "issue_fix_feasibility_domain_state_projection_v0",
         "loopx_todo_writeback_preview_v0",
         ISSUE_FIX_CALLER_REPO_BRANCH_PACKET_SCHEMA_VERSION,
         ISSUE_FIX_VALIDATED_FIX_ARTIFACT_SCHEMA_VERSION,

--- a/examples/issue-fix-workflow-e2e-smoke.py
+++ b/examples/issue-fix-workflow-e2e-smoke.py
@@ -21,6 +21,9 @@ from loopx.capabilities.issue_fix.acceptance_loop import (  # noqa: E402
 from loopx.capabilities.issue_fix.intake_surface import (  # noqa: E402
     build_content_ops_issue_fix_metadata_preview_packet,
 )
+from loopx.capabilities.issue_fix.feasibility import (  # noqa: E402
+    build_issue_fix_feasibility_packet,
+)
 from loopx.capabilities.issue_fix.workflow_plan import (  # noqa: E402
     build_issue_fix_workflow_plan_packet,
 )
@@ -124,39 +127,43 @@ def test_metadata_to_ordered_todos_and_gates() -> None:
         1,
         2,
         3,
-        4,
-        5,
-        6,
-        7,
     ], plan
     assert todo_by_action(plan, "issue_fix_public_metadata_classification")["role"] == "agent"
-    assert todo_by_action(plan, "issue_fix_repro_and_route")["priority"] == "P0"
-    assert todo_by_action(plan, "issue_fix_branch_validation")["blocks"] == [
-        "pr_review_packet_ready"
-    ]
+    assert todo_by_action(plan, "issue_fix_feasibility_decision")["priority"] == "P0"
     gated_read = todo_by_action(plan, "approve_github_issue_body_or_comment_read")
     assert gated_read["role"] == "user", gated_read
     assert gated_read["priority"] == "P0", gated_read
     assert gated_read["would_write"] is False, gated_read
-    publish_gate = todo_by_action(plan, "approve_external_issue_publish_or_merge")
-    assert publish_gate["role"] == "user", publish_gate
-    assert "external_pr_creation" in publish_gate["blocks"], publish_gate
-    lifecycle_monitor = todo_by_action(plan, "issue_fix_pr_lifecycle_monitor")
-    assert lifecycle_monitor["role"] == "agent", lifecycle_monitor
-    assert lifecycle_monitor["task_class"] == "continuous_monitor", lifecycle_monitor
-    assert lifecycle_monitor["depends_on"] == [
-        "issue_fix_pr_review_packet",
-        "approve_external_issue_publish_or_merge",
-    ], lifecycle_monitor
+    action_kinds = {
+        todo["action_kind"] for todo in plan["ordered_loopx_todo_writeback_preview"]
+    }
+    assert "issue_fix_branch_validation" not in action_kinds, action_kinds
+    assert "issue_fix_pr_lifecycle_monitor" not in action_kinds, action_kinds
     routes = {route["route"]: route for route in plan["resolution_route_candidates"]}
     assert set(routes) == {"fix_pr", "comment_only", "triage_only"}, routes
     assert routes["fix_pr"]["next_action_kind"] == "issue_fix_branch_validation"
     assert routes["comment_only"]["external_issue_comment_performed"] is False
     assert routes["comment_only"]["requires_user_gate_before_external_write"] is True
+    checkpoint = plan["feasibility_checkpoint_plan"]
+    assert checkpoint["selects_exactly_one_route"] is True, checkpoint
+    assert checkpoint["writes_domain_state_by_default_with_goal_id"] is True
     post_pr = plan["post_pr_lifecycle_monitor_plan"]
     assert post_pr["creates_continuous_monitor_todo"] is True, post_pr
     assert post_pr["monitor_action_kind"] == "issue_fix_pr_lifecycle_monitor", post_pr
     assert "no_followup" in post_pr["decisions"], post_pr
+
+    decision = build_issue_fix_feasibility_packet(
+        url="https://github.com/huangruiteng/loopx/issues/123",
+        reproduction_status="planned",
+        reproduction_label="focused repro plan",
+        scope_class="bounded",
+        validation_label="python3 examples/focused-smoke.py",
+    )
+    assert decision["decision"]["route"] == "fix_pr", decision
+    assert decision["transition"]["projected_todo"]["action_kind"] == (
+        "issue_fix_confirm_reproduction"
+    ), decision
+    assert decision["external_writes_performed"] is False, decision
 
     review_preview = plan["review_packet_preview"]
     assert review_preview["ready"] is False, review_preview
@@ -165,6 +172,7 @@ def test_metadata_to_ordered_todos_and_gates() -> None:
     assert review_preview["merge_performed"] is False, review_preview
     assert_public_safe(metadata)
     assert_public_safe(plan)
+    assert_public_safe(decision)
 
 
 def test_validation_and_review_packet_readiness() -> None:

--- a/examples/issue-fix-workflow-plan-smoke.py
+++ b/examples/issue-fix-workflow-plan-smoke.py
@@ -82,18 +82,18 @@ def assert_workflow_shape(payload: dict[str, Any]) -> None:
     assert first_screen["agent_can_continue"] is True, first_screen
 
     todos = payload["ordered_loopx_todo_writeback_preview"]
-    assert len(todos) >= 5, todos
+    assert len(todos) >= 2, todos
     assert [todo["planner_order"] for todo in todos] == sorted(
         todo["planner_order"] for todo in todos
     )
-    assert [todo["action_kind"] for todo in todos[:4]] == [
+    assert [todo["action_kind"] for todo in todos[:2]] == [
         "issue_fix_public_metadata_classification",
-        "issue_fix_repro_and_route",
-        "issue_fix_branch_validation",
-        "issue_fix_pr_review_packet",
+        "issue_fix_feasibility_decision",
     ]
-    assert any(todo["action_kind"] == "issue_fix_pr_lifecycle_monitor" for todo in todos)
-    assert [todo["priority"] for todo in todos[:3]] == ["P0", "P0", "P0"]
+    assert not any(
+        todo["action_kind"] == "issue_fix_branch_validation" for todo in todos
+    ), todos
+    assert [todo["priority"] for todo in todos[:2]] == ["P0", "P0"]
     assert all(todo["would_write"] is False for todo in todos)
     assert all(todo["requires_execute_flag"] is True for todo in todos)
 
@@ -101,6 +101,11 @@ def assert_workflow_shape(payload: dict[str, Any]) -> None:
     assert set(routes) == {"fix_pr", "comment_only", "triage_only"}, routes
     assert routes["fix_pr"]["next_action_kind"] == "issue_fix_branch_validation"
     assert routes["comment_only"]["requires_user_gate_before_external_write"] is True
+    feasibility = payload["feasibility_checkpoint_plan"]
+    assert feasibility["selects_exactly_one_route"] is True, feasibility
+    assert feasibility["routes"] == ["fix_pr", "comment_only", "triage_only"]
+    assert feasibility["writes_domain_state_by_default_with_goal_id"] is True
+    assert feasibility["writes_loopx_todo"] is False
     post_pr = payload["post_pr_lifecycle_monitor_plan"]
     assert post_pr["creates_continuous_monitor_todo"] is True, post_pr
     assert post_pr["monitor_action_kind"] == "issue_fix_pr_lifecycle_monitor", post_pr
@@ -198,9 +203,10 @@ def main() -> int:
     ).stdout
     assert "# LoopX Issue Fix Workflow Plan" in markdown, markdown
     assert "Ordered Todo Writeback Preview" in markdown, markdown
+    assert "Feasibility Checkpoint" in markdown, markdown
     assert "Resolution Routes" in markdown, markdown
     assert "Post-PR Lifecycle Monitor" in markdown, markdown
-    assert "issue_fix_pr_review_packet" in markdown, markdown
+    assert "PR Review Packet Preview" in markdown, markdown
     assert "issue_fix_pr_lifecycle_monitor" in markdown, markdown
     assert_public_safe(markdown)
 

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -306,12 +306,18 @@ def _goal_start_contract(*, goal_text: str | None, connected: bool, agent_type: 
                     "loopx issue-fix workflow-plan --url <github-issue-or-pr-url> "
                     "--repo-path <approved-repo> --validation-label '<validation command>' --format json"
                 ),
+                "decision_command": (
+                    "loopx issue-fix feasibility --url <github-issue-url> "
+                    "--reproduction-status <state> --scope-class <scope> "
+                    "--goal-id <goal-id> --format json"
+                ),
                 "post_pr_monitor_command": (
                     "loopx issue-fix pr-lifecycle --url <github-pr-url> "
                     "--goal-id <goal-id> --format json"
                 ),
                 "writeback": (
-                    "turn accepted workflow-plan candidates into ordered LoopX agent/user todos; "
+                    "write metadata classification plus the feasibility checkpoint first, then "
+                    "write only its selected route successor or no-follow-up; "
                     "private repro material, issue body/comment reads, external comments, PR creation, "
                     "merge, publish, destructive git, and production actions stay explicit gates; "
                     "after PR creation, keep a continuous_monitor todo that calls pr-lifecycle "
@@ -349,7 +355,7 @@ Planning rules:
 4. If several todos share the same priority, their listed order is their relative priority. Preserve that exact order when writing them.
 5. Prefer executable Agent Todo items with `task_class=advancement_task`; use User Todo only for concrete owner decisions or private-material gates.
 6. After writing todos, run `loopx refresh-state --goal-id {goal_id}`, activate the host loop if it is missing, unknown, or stale (Codex App automation, Codex CLI `/goal <task_body>`, Claude Code `/loop`, or a custom host-loop gate), then run `loopx quota should-run --goal-id {goal_id}` and begin the first allowed bounded segment.
-7. If the goal is a GitHub issue/PR fix, first preview `loopx issue-fix workflow-plan --url <github-issue-or-pr-url> --repo-path <approved-repo> --validation-label '<validation command>' --format json`; convert accepted preview candidates into ordered todos, include the PR lifecycle continuous_monitor successor, and keep private repro material, body/comment reads, external comments, PR creation, merge, publish, destructive git, and production actions as explicit gates. After a PR exists, the monitor should call `loopx issue-fix pr-lifecycle --url <github-pr-url> --goal-id {goal_id} --format json` so CI, review, merge, stale branch, and no-follow-up states drive LoopX todos instead of chat memory.
+7. If the goal is a GitHub issue/PR fix, first preview `loopx issue-fix workflow-plan --url <github-issue-or-pr-url> --repo-path <approved-repo> --validation-label '<validation command>' --format json`; write only metadata classification plus the feasibility checkpoint. After a compact public-safe observation, run `loopx issue-fix feasibility --url <github-issue-url> --reproduction-status <state> --scope-class <scope> --goal-id {goal_id} --format json` and write only its selected route successor or no-follow-up. Keep private repro material, body/comment reads, external comments, PR creation, merge, publish, destructive git, and production actions as explicit gates. After a PR exists, the monitor should call `loopx issue-fix pr-lifecycle --url <github-pr-url> --goal-id {goal_id} --format json` so CI, review, merge, stale branch, and no-follow-up states drive LoopX todos instead of chat memory.
 """
 
 
@@ -500,6 +506,14 @@ def build_loopx_bootstrap_command_pack(
                 "--url <github-issue-or-pr-url> "
                 "--repo-path <approved-repo> "
                 "--validation-label '<validation command>' "
+                "--format json"
+            ),
+            "issue_fix_feasibility_template": (
+                f"{shell_arg(cli_bin)} issue-fix feasibility "
+                "--url <github-issue-url> "
+                "--reproduction-status <confirmed|planned|missing|blocked> "
+                "--scope-class <bounded|uncertain|oversized> "
+                f"--goal-id {shell_arg(resolved_goal_id)} "
                 "--format json"
             ),
             "issue_fix_pr_lifecycle_template": (
@@ -740,7 +754,13 @@ For GitHub issue/PR fix goals, preview the issue-fix route before todo writeback
 {commands.get("issue_fix_workflow_plan_template", "")}
 ```
 
-Accepted preview candidates become ordered Agent/User todos. Private repro material, issue body/comment reads, external comments, PR creation, merge, publish, destructive git, and production actions stay explicit gates.
+Write only metadata classification plus the feasibility checkpoint from this preview. Then run the compact decision and write only its selected successor or no-follow-up:
+
+```bash
+{commands.get("issue_fix_feasibility_template", "")}
+```
+
+Private repro material, issue body/comment reads, external comments, PR creation, merge, publish, destructive git, and production actions stay explicit gates.
 
 After a PR exists, the PR lifecycle monitor should observe compact public PR state and write issue-fix domain state by default:
 

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -833,6 +833,11 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
                 "reason": "guards the public issue-fix workflow contract, gated metadata preview, and todo writeback preview",
             },
             {
+                "command": "python3 examples/issue-fix-feasibility-smoke.py",
+                "tier": "default",
+                "reason": "guards single-route feasibility decisions and compact issue_fix domain-state writeback",
+            },
+            {
                 "command": "python3 examples/issue-fix-pr-lifecycle-smoke.py",
                 "tier": "default",
                 "reason": "guards PR lifecycle transitions, terminal-state precedence, and issue_fix domain-state writeback",

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -32,8 +32,13 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
             },
             {
                 "command": "loopx issue-fix workflow-plan --url <github-issue-url> --repo-path <repo> --format json",
-                "purpose": "Compose metadata, intake, ordered LoopX todo previews, validation labels, and PR review readiness blockers.",
+                "purpose": "Compose metadata, intake, the feasibility checkpoint, validation labels, and PR review readiness blockers.",
                 "write_boundary": "preview-only; no todo write, repo execution, external comment, PR creation, merge, or publish",
+            },
+            {
+                "command": "loopx issue-fix feasibility --url <github-issue-url> --reproduction-status <state> --scope-class <scope> --goal-id <goal-id> --format json",
+                "purpose": "Select one fix_pr, comment_only, or triage_only route from compact agent observations.",
+                "write_boundary": "writes compact project-local domain state with goal or ledger context; no raw issue/comment/log capture or external write",
             },
             {
                 "command": "loopx issue-fix pr-lifecycle --url <github-pr-url> --goal-id <goal-id> --format json",
@@ -83,6 +88,11 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "doc": "docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md",
             },
             {
+                "schema_version": "issue_fix_feasibility_v0",
+                "module": "loopx.capabilities.issue_fix.feasibility",
+                "doc": "docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md",
+            },
+            {
                 "schema_version": "issue_fix_pr_lifecycle_monitor_v0",
                 "module": "loopx.capabilities.issue_fix.pr_lifecycle",
                 "doc": "docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md",
@@ -105,6 +115,7 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
         ],
         "smokes": [
             "python3 examples/issue-fix-workflow-plan-smoke.py",
+            "python3 examples/issue-fix-feasibility-smoke.py",
             "python3 examples/issue-fix-pr-lifecycle-smoke.py",
             "python3 examples/content-ops-issue-fix-metadata-preview-smoke.py",
             "python3 examples/content-ops-issue-fix-intake-smoke.py",
@@ -123,8 +134,8 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
             "External comments, PR creation, merge, publish, and destructive git remain out of scope.",
         ],
         "next_real_step": (
-            "Put an agent patching step between branch preparation and PR-ready "
-            "packet generation, while keeping external PR/comment actions explicit."
+            "Exercise route selection and continuation on a public issue-fix pilot, "
+            "while keeping external PR/comment actions explicit."
         ),
     },
     {

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -9,6 +9,8 @@ from typing import Any
 
 from ...domain_packs.issue_fix import (
     default_issue_fix_domain_state_ledger_path,
+    default_issue_fix_feasibility_ledger_path,
+    upsert_issue_fix_feasibility_ledger_jsonl,
     upsert_issue_fix_pr_lifecycle_ledger_jsonl,
 )
 from .acceptance_loop import (
@@ -16,6 +18,10 @@ from .acceptance_loop import (
     build_issue_fix_caller_repo_branch_packet,
     build_issue_fix_repo_branch_fixture_packet,
     render_issue_fix_acceptance_loop_markdown,
+)
+from .feasibility import (
+    build_issue_fix_feasibility_packet,
+    render_issue_fix_feasibility_markdown,
 )
 from .pr_lifecycle import (
     build_issue_fix_pr_lifecycle_monitor_packet,
@@ -129,6 +135,85 @@ def register_issue_fix_commands(
         "--generated-at",
         default="2026-06-23T00:00:00Z",
         help="Public-safe generated_at timestamp for the workflow plan.",
+    )
+    feasibility_parser = issue_fix_sub.add_parser(
+        "feasibility",
+        help=(
+            "Select exactly one fix_pr, comment_only, or triage_only route "
+            "from compact public-safe agent observations."
+        ),
+    )
+    add_subcommand_format(feasibility_parser)
+    feasibility_parser.add_argument(
+        "--repo",
+        default="public_repo_fixture",
+        help="Public-safe repository label for the issue.",
+    )
+    feasibility_parser.add_argument(
+        "--issue-ref",
+        default="issue_123_public_metadata_fixture",
+        help="Public-safe issue reference label.",
+    )
+    feasibility_parser.add_argument(
+        "--url",
+        default=None,
+        help="Optional https://github.com/owner/repo/issues/123 URL.",
+    )
+    feasibility_parser.add_argument(
+        "--reproduction-status",
+        required=True,
+        choices=("confirmed", "planned", "missing", "blocked"),
+        help="Compact agent observation of reproduction readiness.",
+    )
+    feasibility_parser.add_argument(
+        "--scope-class",
+        required=True,
+        choices=("bounded", "uncertain", "oversized"),
+        help="Compact agent observation of expected change scope.",
+    )
+    feasibility_parser.add_argument(
+        "--reproduction-label",
+        default=None,
+        help="Compact public-safe repro or repro-plan label; never raw logs.",
+    )
+    feasibility_parser.add_argument(
+        "--validation-label",
+        default=None,
+        help="Compact public-safe validation surface label.",
+    )
+    feasibility_parser.add_argument(
+        "--comment-value",
+        default="none",
+        choices=("none", "clarification", "diagnosis"),
+        help="Whether a maintainer-facing comment would add public value.",
+    )
+    feasibility_parser.add_argument(
+        "--generated-at",
+        default="2026-06-23T00:00:00Z",
+        help="Public-safe generated_at timestamp for the feasibility decision.",
+    )
+    feasibility_parser.add_argument(
+        "--goal-id",
+        default=None,
+        help="Goal id used for the default issue_fix feasibility ledger path.",
+    )
+    feasibility_parser.add_argument(
+        "--project",
+        default=".",
+        help="Project root for the default issue_fix feasibility ledger path.",
+    )
+    feasibility_parser.add_argument(
+        "--ledger-path",
+        default=None,
+        help="Optional local JSONL ledger path. Overrides the default path.",
+    )
+    feasibility_parser.add_argument(
+        "--no-write-domain-state",
+        action="store_true",
+        help=(
+            "Keep feasibility preview-only even when --goal-id or --ledger-path "
+            "is present."
+        ),
     )
     pr_lifecycle_parser = issue_fix_sub.add_parser(
         "pr-lifecycle",
@@ -357,6 +442,45 @@ def handle_issue_fix_command(
                 generated_at=args.generated_at,
             )
             renderer = render_issue_fix_workflow_plan_markdown
+        elif args.issue_fix_command == "feasibility":
+            payload = build_issue_fix_feasibility_packet(
+                repo=args.repo,
+                issue_ref=args.issue_ref,
+                url=args.url,
+                reproduction_status=args.reproduction_status,
+                scope_class=args.scope_class,
+                reproduction_label=args.reproduction_label,
+                validation_label=args.validation_label,
+                comment_value=args.comment_value,
+                generated_at=args.generated_at,
+            )
+            should_write_domain_state = bool(
+                not args.no_write_domain_state and (args.goal_id or args.ledger_path)
+            )
+            if should_write_domain_state:
+                ledger_path = (
+                    Path(args.ledger_path).expanduser()
+                    if args.ledger_path
+                    else default_issue_fix_feasibility_ledger_path(
+                        project=args.project,
+                        goal_id=args.goal_id,
+                    )
+                )
+                write_result = upsert_issue_fix_feasibility_ledger_jsonl(
+                    ledger_path,
+                    payload,
+                )
+                domain_state = payload.get("domain_state_projection")
+                if isinstance(domain_state, dict):
+                    domain_state["write_performed"] = True
+                    domain_state["write_result"] = write_result
+            else:
+                domain_state = payload.get("domain_state_projection")
+                if isinstance(domain_state, dict) and not args.no_write_domain_state:
+                    domain_state["write_skipped_reason"] = (
+                        "goal_id_or_ledger_path_missing"
+                    )
+            renderer = render_issue_fix_feasibility_markdown
         elif args.issue_fix_command == "pr-lifecycle":
             if args.fetch_metadata and args.metadata_json:
                 raise ValueError("--fetch-metadata cannot be combined with --metadata-json")
@@ -429,8 +553,9 @@ def handle_issue_fix_command(
             renderer = render_issue_fix_acceptance_loop_markdown
         else:
             raise ValueError(
-                "issue-fix requires `workflow-plan`, `acceptance-fixture`, "
-                "`pr-lifecycle`, `repo-branch-fixture`, or `caller-repo-branch`"
+                "issue-fix requires `workflow-plan`, `feasibility`, "
+                "`acceptance-fixture`, `pr-lifecycle`, `repo-branch-fixture`, "
+                "or `caller-repo-branch`"
             )
     except Exception as exc:
         payload = {
@@ -441,6 +566,8 @@ def handle_issue_fix_command(
         renderer = (
             render_issue_fix_workflow_plan_markdown
             if getattr(args, "issue_fix_command", None) == "workflow-plan"
+            else render_issue_fix_feasibility_markdown
+            if getattr(args, "issue_fix_command", None) == "feasibility"
             else render_issue_fix_pr_lifecycle_monitor_markdown
             if getattr(args, "issue_fix_command", None) == "pr-lifecycle"
             else render_issue_fix_acceptance_loop_markdown

--- a/loopx/capabilities/issue_fix/feasibility.py
+++ b/loopx/capabilities/issue_fix/feasibility.py
@@ -1,0 +1,324 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+from typing import Any
+
+from ...control_plane.runtime.public_safety import public_safe_compact_text
+from .metadata_preview import normalise_github_issue_reference
+
+
+ISSUE_FIX_FEASIBILITY_PACKET_SCHEMA_VERSION = "issue_fix_feasibility_v0"
+ISSUE_FIX_FEASIBILITY_OBSERVATION_SCHEMA_VERSION = (
+    "issue_fix_feasibility_observation_v0"
+)
+ISSUE_FIX_FEASIBILITY_DECISION_SCHEMA_VERSION = "issue_fix_feasibility_decision_v0"
+
+REPRODUCTION_STATES = {"confirmed", "planned", "missing", "blocked"}
+SCOPE_CLASSES = {"bounded", "uncertain", "oversized"}
+COMMENT_VALUES = {"none", "clarification", "diagnosis"}
+RESOLUTION_ROUTES = {"fix_pr", "comment_only", "triage_only"}
+
+
+def _safe_label(value: str | None, *, field: str, required: bool = False) -> str | None:
+    label = public_safe_compact_text(value, limit=220)
+    if required and not label:
+        raise ValueError(f"{field} must be a compact public-safe label")
+    if value and not label:
+        raise ValueError(f"{field} must not contain a local path or secret-like value")
+    return label
+
+
+def _route_decision(
+    *,
+    reproduction_status: str,
+    scope_class: str,
+    reproduction_label: str | None,
+    validation_label: str | None,
+    comment_value: str,
+) -> tuple[str, list[str]]:
+    fix_ready = bool(
+        reproduction_status in {"confirmed", "planned"}
+        and scope_class == "bounded"
+        and reproduction_label
+        and validation_label
+    )
+    if fix_ready:
+        return "fix_pr", [
+            f"reproduction_{reproduction_status}",
+            "bounded_scope",
+            "validation_surface_named",
+        ]
+    if comment_value != "none":
+        return "comment_only", [
+            f"comment_value_{comment_value}",
+            f"reproduction_{reproduction_status}",
+            f"scope_{scope_class}",
+        ]
+    return "triage_only", [
+        f"reproduction_{reproduction_status}",
+        f"scope_{scope_class}",
+        "no_public_comment_value",
+    ]
+
+
+def _project_transition(
+    *,
+    route: str,
+    repo: str,
+    issue_ref: str,
+    reproduction_status: str,
+) -> dict[str, Any]:
+    base = {
+        "schema_version": "issue_fix_feasibility_transition_v0",
+        "route": route,
+        "would_write_todo": False,
+        "external_write_performed": False,
+    }
+    if route == "fix_pr":
+        action_kind = (
+            "issue_fix_confirm_reproduction"
+            if reproduction_status == "planned"
+            else "issue_fix_branch_validation"
+        )
+        return base | {
+            "decision": "runnable_successor",
+            "projected_todo": {
+                "schema_version": "loopx_todo_writeback_preview_v0",
+                "role": "agent",
+                "priority": "P0",
+                "task_class": "advancement_task",
+                "action_kind": action_kind,
+                "text": (
+                    f"[P0] Advance the selected fix_pr route for {repo} {issue_ref}; "
+                    "confirm the named repro before patching, then run the named "
+                    "validation surface."
+                ),
+                "would_write": False,
+                "requires_execute_flag": True,
+            },
+            "external_write_gate": {
+                "required_before": ["external_pr_creation", "merge", "publish"],
+                "satisfied": False,
+            },
+            "no_followup": False,
+        }
+    if route == "comment_only":
+        return base | {
+            "decision": "runnable_successor",
+            "projected_todo": {
+                "schema_version": "loopx_todo_writeback_preview_v0",
+                "role": "agent",
+                "priority": "P1",
+                "task_class": "advancement_task",
+                "action_kind": "issue_fix_external_comment_packet",
+                "text": (
+                    f"[P1] Draft a compact public-safe maintainer comment for "
+                    f"{repo} {issue_ref}; do not post it without an external-write gate."
+                ),
+                "would_write": False,
+                "requires_execute_flag": True,
+            },
+            "external_write_gate": {
+                "required_before": ["external_issue_comment"],
+                "satisfied": False,
+            },
+            "no_followup": False,
+        }
+    return base | {
+        "decision": "no_followup",
+        "projected_todo": None,
+        "external_write_gate": None,
+        "no_followup": True,
+    }
+
+
+def build_issue_fix_feasibility_packet(
+    *,
+    repo: str = "public_repo_fixture",
+    issue_ref: str = "issue_123_public_metadata_fixture",
+    url: str | None = None,
+    reproduction_status: str,
+    scope_class: str,
+    reproduction_label: str | None = None,
+    validation_label: str | None = None,
+    comment_value: str = "none",
+    generated_at: str | None = "2026-06-23T00:00:00Z",
+) -> dict[str, Any]:
+    """Select one issue-fix route from compact, public-safe agent observations."""
+
+    if reproduction_status not in REPRODUCTION_STATES:
+        raise ValueError(f"reproduction_status must be one of {sorted(REPRODUCTION_STATES)}")
+    if scope_class not in SCOPE_CLASSES:
+        raise ValueError(f"scope_class must be one of {sorted(SCOPE_CLASSES)}")
+    if comment_value not in COMMENT_VALUES:
+        raise ValueError(f"comment_value must be one of {sorted(COMMENT_VALUES)}")
+
+    reference = normalise_github_issue_reference(
+        repo=repo,
+        issue_ref=issue_ref,
+        url=url,
+    )
+    safe_reproduction_label = _safe_label(
+        reproduction_label,
+        field="reproduction_label",
+        required=reproduction_status in {"confirmed", "planned"},
+    )
+    safe_validation_label = _safe_label(
+        validation_label,
+        field="validation_label",
+        required=False,
+    )
+    route, reason_codes = _route_decision(
+        reproduction_status=reproduction_status,
+        scope_class=scope_class,
+        reproduction_label=safe_reproduction_label,
+        validation_label=safe_validation_label,
+        comment_value=comment_value,
+    )
+    observation = {
+        "schema_version": ISSUE_FIX_FEASIBILITY_OBSERVATION_SCHEMA_VERSION,
+        "repo": reference["repo"],
+        "issue_ref": reference["issue_ref"],
+        "kind": reference["kind"],
+        "number": reference["number"],
+        "permalink": reference["permalink"],
+        "reproduction_status": reproduction_status,
+        "reproduction_label": safe_reproduction_label,
+        "scope_class": scope_class,
+        "validation_label": safe_validation_label,
+        "comment_value": comment_value,
+        "issue_body_captured": False,
+        "comment_bodies_captured": False,
+        "raw_logs_captured": False,
+        "local_paths_captured": False,
+    }
+    transition = _project_transition(
+        route=route,
+        repo=str(reference["repo"]),
+        issue_ref=str(reference["issue_ref"]),
+        reproduction_status=reproduction_status,
+    )
+    fingerprint = hashlib.sha256(
+        json.dumps(
+            {"observation": observation, "route": route},
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()[:16]
+    packet: dict[str, Any] = {
+        "ok": True,
+        "schema_version": ISSUE_FIX_FEASIBILITY_PACKET_SCHEMA_VERSION,
+        "mode": "issue-fix-feasibility",
+        "generated_at": generated_at,
+        "observation": observation,
+        "decision": {
+            "schema_version": ISSUE_FIX_FEASIBILITY_DECISION_SCHEMA_VERSION,
+            "route": route,
+            "reason_codes": reason_codes,
+            "observation_fingerprint": fingerprint,
+        },
+        "transition": transition,
+        "domain_state_projection": {
+            "schema_version": "issue_fix_feasibility_domain_state_projection_v0",
+            "domain_pack": "issue_fix",
+            "stream": "feasibility",
+            "key": {
+                "repo": reference["repo"],
+                "issue_ref": reference["issue_ref"],
+            },
+            "write_performed": False,
+        },
+        "external_reads_performed": False,
+        "external_writes_performed": False,
+        "todo_write_performed": False,
+        "issue_body_captured": False,
+        "comment_bodies_captured": False,
+        "response_payloads_captured": False,
+        "raw_logs_captured": False,
+        "local_paths_captured": False,
+        "destructive_git_used": False,
+    }
+    validation = validate_issue_fix_feasibility_packet(packet)
+    packet["ok"] = validation["ok"]
+    packet["validation"] = validation
+    return packet
+
+
+def validate_issue_fix_feasibility_packet(packet: Mapping[str, Any]) -> dict[str, Any]:
+    errors: list[str] = []
+    if packet.get("schema_version") != ISSUE_FIX_FEASIBILITY_PACKET_SCHEMA_VERSION:
+        errors.append("packet schema_version must be issue_fix_feasibility_v0")
+    for key in (
+        "external_reads_performed",
+        "external_writes_performed",
+        "todo_write_performed",
+        "issue_body_captured",
+        "comment_bodies_captured",
+        "response_payloads_captured",
+        "raw_logs_captured",
+        "local_paths_captured",
+        "destructive_git_used",
+    ):
+        if packet.get(key) is not False:
+            errors.append(f"packet {key} must be false")
+
+    observation = packet.get("observation")
+    if not isinstance(observation, Mapping):
+        errors.append("observation is required")
+        observation = {}
+    decision = packet.get("decision")
+    if not isinstance(decision, Mapping):
+        errors.append("decision is required")
+        decision = {}
+    route = decision.get("route")
+    if route not in RESOLUTION_ROUTES:
+        errors.append("decision route must select exactly one supported route")
+    transition = packet.get("transition")
+    if not isinstance(transition, Mapping):
+        errors.append("transition is required")
+        transition = {}
+    if transition.get("route") != route:
+        errors.append("transition route must match the selected route")
+    if route == "fix_pr":
+        if observation.get("scope_class") != "bounded":
+            errors.append("fix_pr requires bounded scope")
+        if observation.get("reproduction_status") not in {"confirmed", "planned"}:
+            errors.append("fix_pr requires confirmed or planned reproduction")
+        if not observation.get("reproduction_label"):
+            errors.append("fix_pr requires a named reproduction label")
+        if not observation.get("validation_label"):
+            errors.append("fix_pr requires a named validation label")
+    if route == "comment_only" and observation.get("comment_value") == "none":
+        errors.append("comment_only requires a useful comment value")
+    if route == "triage_only" and transition.get("no_followup") is not True:
+        errors.append("triage_only must project no_followup")
+
+    return {
+        "ok": not errors,
+        "schema_version": "issue_fix_feasibility_validation_v0",
+        "errors": errors,
+    }
+
+
+def render_issue_fix_feasibility_markdown(payload: dict[str, Any]) -> str:
+    observation = payload.get("observation") or {}
+    decision = payload.get("decision") or {}
+    transition = payload.get("transition") or {}
+    return "\n".join(
+        [
+            "# LoopX Issue Fix Feasibility",
+            "",
+            f"- ok: `{payload.get('ok')}`",
+            f"- repo: `{observation.get('repo')}`",
+            f"- issue_ref: `{observation.get('issue_ref')}`",
+            f"- reproduction_status: `{observation.get('reproduction_status')}`",
+            f"- scope_class: `{observation.get('scope_class')}`",
+            f"- route: `{decision.get('route')}`",
+            f"- transition: `{transition.get('decision')}`",
+            f"- external_writes_performed: `{payload.get('external_writes_performed')}`",
+            f"- domain_state_write_performed: `{(payload.get('domain_state_projection') or {}).get('write_performed')}`",
+        ]
+    )

--- a/loopx/capabilities/issue_fix/workflow_plan.py
+++ b/loopx/capabilities/issue_fix/workflow_plan.py
@@ -124,6 +124,29 @@ def _post_pr_lifecycle_monitor_plan() -> dict[str, Any]:
     }
 
 
+def _feasibility_checkpoint_plan() -> dict[str, Any]:
+    return {
+        "schema_version": "issue_fix_feasibility_checkpoint_plan_v0",
+        "command_preview": (
+            "loopx issue-fix feasibility --url <github-issue-url> "
+            "--reproduction-status <confirmed|planned|missing|blocked> "
+            "--scope-class <bounded|uncertain|oversized> "
+            "--goal-id <goal-id> --format json"
+        ),
+        "input_contract": "compact_public_safe_agent_observation",
+        "selects_exactly_one_route": True,
+        "routes": ["fix_pr", "comment_only", "triage_only"],
+        "fix_pr_requires": [
+            "bounded_scope",
+            "named_reproduction_or_plan",
+            "named_validation_surface",
+        ],
+        "writes_domain_state_by_default_with_goal_id": True,
+        "writes_loopx_todo": False,
+        "raw_issue_or_log_material_captured": False,
+    }
+
+
 def _branch_plan_from_dry_run(
     *,
     repo_path: str | None,
@@ -223,6 +246,7 @@ def build_issue_fix_workflow_plan_packet(
         repo_label=repo_label,
         issue_label=issue_label,
     )
+    feasibility_checkpoint = _feasibility_checkpoint_plan()
     post_pr_monitor = _post_pr_lifecycle_monitor_plan()
     agent_todos = [
         _todo_preview(
@@ -245,65 +269,20 @@ def build_issue_fix_workflow_plan_packet(
             role="agent",
             priority="P0",
             task_class="advancement_task",
-            action_kind="issue_fix_repro_and_route",
+            action_kind="issue_fix_feasibility_decision",
             text=(
-                "[P0] Create or identify a focused repro smoke, inspect the "
-                "selected repo-relative code route, and stop before private "
-                "repro material or external comments."
+                "[P0] Record a compact feasibility observation and select exactly "
+                "one fix_pr, comment_only, or triage_only route; write only the "
+                "selected successor."
             ),
             depends_on=["issue_fix_public_metadata_classification"],
         ),
-        _todo_preview(
-            planner_order=3,
-            role="agent",
-            priority="P0",
-            task_class="advancement_task",
-            action_kind="issue_fix_branch_validation",
-            text=(
-                "[P0] Prepare or claim the approved issue branch and run the "
-                "caller-declared validation label before declaring review readiness."
-            ),
-            depends_on=["issue_fix_repro_and_route"],
-            blocks=["pr_review_packet_ready"],
-        ),
-        _todo_preview(
-            planner_order=4,
-            role="agent",
-            priority="P1",
-            task_class="advancement_task",
-            action_kind="issue_fix_pr_review_packet",
-            text=(
-                "[P1] Emit a PR review packet with repo-relative changed files, "
-                "validation labels, remaining gates, and no external publication."
-            ),
-            depends_on=["issue_fix_branch_validation"],
-        ),
     ]
-    user_gates = [
-        _todo_preview(
-            planner_order=5,
-            role="user",
-            priority="P1",
-            task_class="user_gate",
-            action_kind="approve_external_issue_publish_or_merge",
-            text=(
-                "[P1] Approve any external issue comment, PR creation, merge, "
-                "publish, or repository-policy exception before LoopX performs it."
-            ),
-            depends_on=["issue_fix_pr_review_packet"],
-            blocks=[
-                "external_issue_comment",
-                "external_pr_creation",
-                "merge",
-                "publish",
-            ],
-        )
-    ]
+    user_gates: list[dict[str, Any]] = []
     if gated_fields:
-        user_gates.insert(
-            0,
+        user_gates.append(
             _todo_preview(
-                planner_order=5,
+                planner_order=3,
                 role="user",
                 priority="P0",
                 task_class="user_gate",
@@ -317,32 +296,6 @@ def build_issue_fix_workflow_plan_packet(
             )
             | {"gated_fields": gated_fields},
         )
-        for offset, gate in enumerate(user_gates, start=5):
-            gate["planner_order"] = offset
-
-    monitor_order = max(
-        int(todo.get("planner_order", 0))
-        for todo in [*agent_todos, *user_gates]
-        if isinstance(todo.get("planner_order"), int)
-    ) + 1
-    agent_todos.append(
-        _todo_preview(
-            planner_order=monitor_order,
-            role="agent",
-            priority="P2",
-            task_class="continuous_monitor",
-            action_kind="issue_fix_pr_lifecycle_monitor",
-            text=(
-                "[P2] After a PR exists, observe public PR lifecycle state and "
-                "project it into runnable_successor, monitor_continuation, "
-                "user_gate, or no_followup."
-            ),
-            depends_on=[
-                "issue_fix_pr_review_packet",
-                "approve_external_issue_publish_or_merge",
-            ],
-        )
-    )
     ordered_previews = sorted(
         agent_todos + user_gates,
         key=lambda preview: int(preview.get("planner_order", 0)),
@@ -385,9 +338,9 @@ def build_issue_fix_workflow_plan_packet(
         "top_agent_todo": agent_todos[0],
         "top_gate": user_gates[0] if gated_fields else None,
         "next_safe_action": (
-            "write the ordered LoopX todo plan only after the metadata preview "
-            "stays body-free; then run branch/validation work inside the "
-            "caller-approved repo context"
+            "write the metadata classification and feasibility checkpoint only; "
+            "then let the feasibility decision project one route-specific "
+            "successor or no-follow-up"
         ),
     }
     packet: dict[str, Any] = {
@@ -409,6 +362,7 @@ def build_issue_fix_workflow_plan_packet(
         "first_screen": first_screen,
         "branch_plan": branch_plan,
         "resolution_route_candidates": resolution_routes,
+        "feasibility_checkpoint_plan": feasibility_checkpoint,
         "post_pr_lifecycle_monitor_plan": post_pr_monitor,
         "ordered_loopx_todo_writeback_preview": ordered_previews,
         "validation_plan": validation_plan,
@@ -494,6 +448,19 @@ def validate_issue_fix_workflow_plan_packet(packet: Mapping[str, Any]) -> dict[s
             errors.append("resolution routes must not create PRs")
         if route.get("requires_user_gate_before_external_write") is not True:
             errors.append("resolution routes must gate external writes")
+
+    feasibility = packet.get("feasibility_checkpoint_plan")
+    if not isinstance(feasibility, Mapping):
+        errors.append("feasibility_checkpoint_plan is required")
+        feasibility = {}
+    if feasibility.get("selects_exactly_one_route") is not True:
+        errors.append("feasibility checkpoint must select exactly one route")
+    if feasibility.get("writes_domain_state_by_default_with_goal_id") is not True:
+        errors.append("feasibility checkpoint must default-write domain state")
+    if feasibility.get("writes_loopx_todo") is not False:
+        errors.append("feasibility checkpoint must not directly write LoopX todos")
+    if feasibility.get("raw_issue_or_log_material_captured") is not False:
+        errors.append("feasibility checkpoint must not capture raw material")
 
     post_pr = packet.get("post_pr_lifecycle_monitor_plan")
     if not isinstance(post_pr, Mapping):
@@ -630,6 +597,21 @@ def render_issue_fix_workflow_plan_markdown(payload: dict[str, Any]) -> str:
                     f"`{todo.get('priority')}` `{todo.get('action_kind')}`: "
                     f"would_write=`{todo.get('would_write')}`"
                 )
+    feasibility = payload.get("feasibility_checkpoint_plan")
+    if isinstance(feasibility, Mapping):
+        lines.extend(
+            [
+                "",
+                "## Feasibility Checkpoint",
+                "",
+                f"- selects_exactly_one_route: "
+                f"`{feasibility.get('selects_exactly_one_route')}`",
+                f"- routes: `{feasibility.get('routes')}`",
+                f"- writes_domain_state_by_default_with_goal_id: "
+                f"`{feasibility.get('writes_domain_state_by_default_with_goal_id')}`",
+                f"- command_preview: `{feasibility.get('command_preview')}`",
+            ]
+        )
     routes = payload.get("resolution_route_candidates")
     if isinstance(routes, Sequence) and not isinstance(routes, (str, bytes)):
         lines.extend(["", "## Resolution Routes", ""])

--- a/loopx/domain_packs/issue_fix.py
+++ b/loopx/domain_packs/issue_fix.py
@@ -7,6 +7,46 @@ from ..domain_state import default_domain_state_file_path, upsert_domain_state_j
 
 
 ISSUE_FIX_DOMAIN_STATE_LEDGER_FILENAME = "pr-lifecycle.jsonl"
+ISSUE_FIX_FEASIBILITY_LEDGER_FILENAME = "feasibility.jsonl"
+
+
+def issue_fix_feasibility_ledger_key(payload: dict[str, Any]) -> dict[str, Any]:
+    observation = payload.get("observation")
+    if not isinstance(observation, dict):
+        raise ValueError("issue-fix feasibility payload must include observation")
+    repo = str(observation.get("repo") or "").strip()
+    issue_ref = str(observation.get("issue_ref") or "").strip()
+    if not repo or not issue_ref:
+        raise ValueError("issue-fix feasibility payload must include repo and issue_ref")
+    return {
+        "repo": repo,
+        "issue_ref": issue_ref,
+    }
+
+
+def upsert_issue_fix_feasibility_ledger_jsonl(
+    ledger_path: str | Path,
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Upsert one compact issue-fix feasibility decision into domain state."""
+
+    if payload.get("ok") is not True:
+        raise ValueError("only successful issue-fix feasibility payloads can be written")
+    for key in (
+        "issue_body_captured",
+        "comment_bodies_captured",
+        "response_payloads_captured",
+        "raw_logs_captured",
+        "local_paths_captured",
+    ):
+        if payload.get(key) is not False:
+            raise ValueError(f"issue-fix domain-state payload must keep {key}=false")
+    return upsert_domain_state_jsonl(
+        ledger_path,
+        payload,
+        key=issue_fix_feasibility_ledger_key(payload),
+        existing_key_fn=issue_fix_feasibility_ledger_key,
+    )
 
 
 def issue_fix_pr_lifecycle_ledger_key(payload: dict[str, Any]) -> dict[str, Any]:
@@ -60,4 +100,19 @@ def default_issue_fix_domain_state_ledger_path(
         goal_id=goal_id,
         domain_pack="issue_fix",
         filename=ISSUE_FIX_DOMAIN_STATE_LEDGER_FILENAME,
+    )
+
+
+def default_issue_fix_feasibility_ledger_path(
+    *,
+    project: str | Path = ".",
+    goal_id: str,
+) -> Path:
+    """Return the project-local issue-fix feasibility ledger path."""
+
+    return default_domain_state_file_path(
+        project=project,
+        goal_id=goal_id,
+        domain_pack="issue_fix",
+        filename=ISSUE_FIX_FEASIBILITY_LEDGER_FILENAME,
     )


### PR DESCRIPTION
## Summary
- add a compact issue-fix feasibility decision that selects exactly one `fix_pr`, `comment_only`, or `triage_only` route
- persist the latest public-safe decision in the existing `issue_fix` domain pack by default when goal context is present
- compress the initial workflow plan to metadata classification plus one feasibility checkpoint, then project only one successor or structured no-follow-up
- keep external comments, PR creation, merge, publish, private repro material, and destructive git behind existing gates

## Design
This does not add generic todo lifecycle states. The feasibility packet is an issue-fix domain read model. Existing LoopX todos continue to own execution and lifecycle; the decision only projects a route-specific preview.

A `fix_pr` route requires bounded scope, a named reproduction or reproduction plan, and a named validation surface. Planned reproduction projects confirmation before patch work. A useful maintainer clarification or diagnosis can select `comment_only`; otherwise the decision records `triage_only` with no follow-up.

## Validation
- `loopx canary premerge --from-git-diff --format json --timeout-seconds 180`: passed, 17/17 selected checks
- focused feasibility, workflow-plan, workflow-contract, workflow e2e, PR lifecycle, bootstrap, and catalog planner smokes: passed
- changed Python compile checks: passed
- public/private boundary scan: clean across all 16 changed files
- failures/skips/warnings/manual holds: none
