### PR TITLE
Record SkillsBench proxy runtime injection

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -497,7 +497,7 @@ def test_benchmark_egress_proxy_env_is_public_safe_and_forwarded() -> None:
             assert "example-cache.invalid" in target_env["NO_PROXY"], target_env
 
             previous_docker_config = os.environ.get("DOCKER_CONFIG")
-            with skillsbench_loop._benchmark_egress_proxy_env_applied(args):
+            with skillsbench_loop._benchmark_egress_proxy_env_applied(args, plan=plan):
                 docker_config_dir = Path(os.environ["DOCKER_CONFIG"])
                 docker_config_path = docker_config_dir / "config.json"
                 docker_config = json.loads(docker_config_path.read_text(encoding="utf-8"))
@@ -513,7 +513,7 @@ def test_benchmark_egress_proxy_env_is_public_safe_and_forwarded() -> None:
                 assert os.environ["DOCKER_CONFIG"] == previous_docker_config
             assert not docker_config_dir.exists(), docker_config_dir
 
-            config = plan["runner_config"]
+            config = skillsbench_loop._public_runner_config(plan)
             assert config["benchmark_egress_proxy_required"] is True, config
             assert config["benchmark_egress_proxy_mode_requested"] == "require", config
             assert config["benchmark_egress_proxy_configured"] is True, config
@@ -523,7 +523,7 @@ def test_benchmark_egress_proxy_env_is_public_safe_and_forwarded() -> None:
             assert config["benchmark_egress_no_proxy_entry_count"] >= 5, config
             assert config["benchmark_egress_no_proxy_raw_value_recorded"] is False, config
             assert config["benchmark_egress_proxy_url_recorded"] is False, config
-            assert config["benchmark_egress_proxy_docker_config_injected"] is False, config
+            assert config["benchmark_egress_proxy_docker_config_injected"] is True, config
             assert config["benchmark_egress_proxy_docker_config_path_recorded"] is False, config
             assert config["benchmark_egress_proxy_docker_config_raw_proxy_recorded"] is False, config
             assert proxy_url not in json.dumps(config, sort_keys=True), config

--- a/loopx/benchmark_adapters/skillsbench_proxy_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_proxy_runtime.py
@@ -1,0 +1,27 @@
+"""Runtime proxy evidence helpers for SkillsBench launches."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping
+from typing import Any
+
+
+def apply_proxy_runtime_env(
+    environ: MutableMapping[str, str],
+    proxy_env: Mapping[str, str],
+    docker_config_env: Mapping[str, str],
+    *,
+    plan: dict[str, Any] | None,
+) -> None:
+    environ.update(proxy_env)
+    environ.update(docker_config_env)
+    if not isinstance(plan, dict):
+        return
+    prerequisites = plan.setdefault("runner_prerequisites", {})
+    if not isinstance(prerequisites, dict):
+        return
+    prerequisites["benchmark_egress_proxy_agent_env_injected"] = bool(proxy_env)
+    if docker_config_env.get("DOCKER_CONFIG"):
+        prerequisites["benchmark_egress_proxy_docker_config_injected"] = True
+        prerequisites["benchmark_egress_proxy_docker_config_path_recorded"] = False
+        prerequisites["benchmark_egress_proxy_docker_config_raw_proxy_recorded"] = False

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -116,7 +116,7 @@ from loopx.benchmark_adapters.skillsbench_verifier_bootstrap import (  # noqa: E
 from loopx.benchmark_adapters.skillsbench_task_source import (  # noqa: E402
     classify_missing_task_source,
 )
-from loopx.benchmark_adapters import skillsbench_runner_source as runner_source, skillsbench_uv_cache as uv_cache  # noqa: E402
+from loopx.benchmark_adapters import skillsbench_proxy_runtime as proxy_runtime, skillsbench_runner_source as runner_source, skillsbench_uv_cache as uv_cache  # noqa: E402
 from loopx.benchmark_adapters.skillsbench_acp_relay import (  # noqa: E402
     SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_MARKER,
     SKILLSBENCH_LOCAL_ACP_RELAY_BRIDGE_PREFLIGHT_PROMPT,
@@ -1965,7 +1965,7 @@ def _docker_config_payload_with_proxy(
 
 @contextlib.contextmanager
 def _benchmark_egress_proxy_env_applied(
-    args: argparse.Namespace,
+    args: argparse.Namespace, *, plan: dict[str, Any] | None = None,
 ) -> Any:
     proxy_env = _benchmark_egress_proxy_env(args)
     if not proxy_env:
@@ -1991,8 +1991,7 @@ def _benchmark_egress_proxy_env_applied(
     keys = set(proxy_env) | set(docker_config_env)
     previous = {key: os.environ.get(key) for key in keys}
     try:
-        os.environ.update(proxy_env)
-        os.environ.update(docker_config_env)
+        proxy_runtime.apply_proxy_runtime_env(os.environ, proxy_env, docker_config_env, plan=plan)
         yield
     finally:
         for key, value in previous.items():
@@ -9843,7 +9842,9 @@ async def run_benchflow_case_with_private_output(
         stream.flush()
         try:
             with redirect_stdout(stream), redirect_stderr(stream):
-                with _benchmark_egress_proxy_env_applied(args):
+                with _benchmark_egress_proxy_env_applied(args, plan=plan):
+                    _write_public_runner_config(plan)
+                    _write_public_runner_prerequisites(plan)
                     result = await run_benchflow_case(args, plan)
         finally:
             stream.write(
@@ -16767,8 +16768,6 @@ async def _async_main_with_observable_handle(
             run_benchflow_case_with_private_output(args, plan),
             timeout=args.outer_timeout_sec,
         )
-        _write_public_runner_config(plan)
-        _write_public_runner_prerequisites(plan)
     compact = reduce_result(args, result_path, plan)
     compact_path = Path(plan["compact_benchmark_run_json"])
     compact_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- record SkillsBench benchmark egress proxy runtime env and Docker config injection in public runner evidence
- write public runner config/prerequisites after entering the proxy runtime context so long setup runs expose the true proxy state
- keep runner/smoke line budgets stable by moving the tiny evidence helper into a bounded adapter module

## Validation
- python3 -m py_compile scripts/skillsbench_automation_loop.py loopx/benchmark_adapters/skillsbench_proxy_runtime.py
- python3 examples/skillsbench-benchmark-egress-policy-smoke.py
- python3 examples/skillsbench-benchmark-run-smoke.py
- python3 examples/control_plane/repo-python-line-budget-smoke.py
- loopx check
- loopx canary premerge --from-git-diff: all automated checks passed; manual hold is benchmark_sensitive, owner authorized benchmark self-merge

## Risk
- Does not change scoring, task semantics, solver prompts, or benchmark submission behavior.
- Public evidence remains URL/path redacted; no raw logs, trajectories, credentials, or local artifacts included.