### PR TITLE
Gate multi-agent host activation on identity

### DIFF
--- a/docs/reference/protocols/loopx-goal-command-v0.md
+++ b/docs/reference/protocols/loopx-goal-command-v0.md
@@ -41,6 +41,13 @@ loopx agent-onboard --list-agent-types
 Ambiguous values such as `codex` must fail closed because Codex App and Codex
 CLI use different host-loop activation paths.
 
+Agent identity follows the same fail-closed rule. A goal with one registered
+agent may select that identity automatically. A goal with multiple registered
+agents and no `--agent-id` must project a concrete identity-selection gate with
+executable scoped choices; it must not advertise unscoped heartbeat or quota
+commands. Once selected, the identity must be preserved across `agent-onboard`,
+`bootstrap-command-pack`, `start-goal`, heartbeat prompt, and quota commands.
+
 The command pack preview is still read-only. It describes the commands and
 contracts; the slash invocation is what authorizes project-local state writes.
 New-user surfaces should also show the compact slash command catalog from the

--- a/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
+++ b/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
@@ -4,6 +4,8 @@
 from __future__ import annotations
 
 import json
+import os
+import shlex
 import subprocess
 import sys
 import tempfile
@@ -14,7 +16,11 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
-from loopx.bootstrap_command_pack import build_loopx_bootstrap_command_pack  # noqa: E402
+from loopx.agent_onboarding import build_agent_onboarding_packet  # noqa: E402
+from loopx.bootstrap_command_pack import (  # noqa: E402
+    build_loopx_bootstrap_command_pack,
+    build_start_goal_guided_packet,
+)
 from loopx.host_loop_activation import (  # noqa: E402
     agent_type_for_host_surface,
     build_agent_type_catalog,
@@ -48,6 +54,26 @@ def main() -> int:
     assert codex_app["activation_method"] == "create_or_update_codex_app_automation", codex_app
     assert codex_cli["host_mutation"]["host_command"] == "/goal <task_body>", codex_cli
     assert claude_code["host_mutation"]["host_command"] == "/loop", claude_code
+    gated_activation = build_host_loop_activation_packet(
+        agent_type="codex-app",
+        goal_id="multi-agent-demo",
+        registered_agents=["codex-main-control", "codex-product-capability"],
+        primary_agent="codex-main-control",
+    )
+    assert gated_activation["activation_state"] == "selection_required", gated_activation
+    assert gated_activation["activation_allowed"] is False, gated_activation
+    assert gated_activation["activation_input_command"] is None, gated_activation
+    assert len(gated_activation["identity_selection_gate"]["choices"]) == 2, gated_activation
+    single_agent_activation = build_host_loop_activation_packet(
+        agent_type="codex-app",
+        goal_id="single-agent-demo",
+        registered_agents=["codex-main-control"],
+        primary_agent="codex-main-control",
+    )
+    assert single_agent_activation["activation_state"] == "single_registered_agent_selected"
+    assert single_agent_activation["agent_id"] == "codex-main-control"
+    assert single_agent_activation["activation_allowed"] is True
+    assert "--agent-id codex-main-control" in single_agent_activation["activation_input_command"]
 
     list_result = run_cli("agent-onboard", "--list-agent-types")
     list_payload = json.loads(list_result.stdout)
@@ -86,6 +112,118 @@ def main() -> int:
     message = payload["message"]
     assert "/goal <task_body>" in message, message
     assert "agent-onboard" in message, message
+
+    with tempfile.TemporaryDirectory(prefix="loopx-agent-onboard-identity-") as tmp:
+        root = Path(tmp)
+        project = root / "project"
+        home = root / "home"
+        state_file = project / ".codex" / "goals" / "multi-agent-goal" / "ACTIVE_GOAL_STATE.md"
+        project_registry = project / ".loopx" / "registry.json"
+        global_registry = home / ".codex" / "loopx" / "registry.global.json"
+        state_file.parent.mkdir(parents=True)
+        project_registry.parent.mkdir(parents=True)
+        global_registry.parent.mkdir(parents=True)
+        state_file.write_text("# Active State\n", encoding="utf-8")
+        registry = {
+            "goals": [
+                {
+                    "id": "multi-agent-goal",
+                    "domain": "smoke",
+                    "status": "active",
+                    "repo": str(project),
+                    "state_file": ".codex/goals/multi-agent-goal/ACTIVE_GOAL_STATE.md",
+                    "adapter": {"kind": "generic_project_goal_v0", "status": "connected"},
+                    "coordination": {
+                        "registered_agents": [
+                            "codex-main-control",
+                            "codex-product-capability",
+                        ],
+                        "primary_agent": "codex-main-control",
+                    },
+                }
+            ]
+        }
+        serialized_registry = json.dumps(registry)
+        project_registry.write_text(serialized_registry, encoding="utf-8")
+        global_registry.write_text(serialized_registry, encoding="utf-8")
+        cli_bin = str(REPO_ROOT / "scripts" / "loopx")
+
+        onboarding_gate = build_agent_onboarding_packet(
+            project=project,
+            agent_type="codex-app",
+            goal_id="multi-agent-goal",
+            cli_bin=cli_bin,
+        )
+        gate = onboarding_gate["identity_selection_gate"]
+        assert onboarding_gate["host_loop_activation"]["activation_allowed"] is False
+        assert onboarding_gate["commands"]["quota_guard"] is None
+        assert onboarding_gate["host_loop_activation"]["activation_input_command"] is None
+        assert len(gate["choices"]) == 2, onboarding_gate
+        selected_choice = next(
+            choice
+            for choice in gate["choices"]
+            if choice["agent_id"] == "codex-product-capability"
+        )
+        assert "--agent-id codex-product-capability" in selected_choice["heartbeat_prompt_json"]
+        assert "--agent-scope" in selected_choice["heartbeat_prompt_json"]
+
+        choice_run = subprocess.run(
+            shlex.split(selected_choice["heartbeat_prompt_json"]),
+            cwd=REPO_ROOT,
+            env={**os.environ, "HOME": str(home)},
+            check=True,
+            text=True,
+            capture_output=True,
+        )
+        choice_payload = json.loads(choice_run.stdout)
+        assert choice_payload["ok"] is True, choice_payload
+        assert choice_payload["agent_id"] == "codex-product-capability", choice_payload
+        assert choice_payload["task_body"], choice_payload
+
+        command_pack_gate = build_loopx_bootstrap_command_pack(
+            project=project,
+            goal_id="multi-agent-goal",
+            agent_id=None,
+            cli_bin=cli_bin,
+            host_surface="codex-app",
+            goal_text="fix a public issue",
+        )
+        assert command_pack_gate["recommended_next_step"]["kind"] == "select_agent_identity"
+        assert command_pack_gate["commands"]["heartbeat_prompt_json"] is None
+        assert command_pack_gate["commands"]["goal_start_quota_should_run"] is None
+        assert "No unscoped heartbeat or quota command" in command_pack_gate["message"]
+
+        guided_gate = build_start_goal_guided_packet(
+            project=project,
+            goal_id="multi-agent-goal",
+            agent_id=None,
+            cli_bin=cli_bin,
+            host_surface="codex-app",
+            goal_text="fix a public issue",
+        )
+        transaction = guided_gate["guided_transaction"]
+        assert transaction["blocked_by"] == "agent_identity_selection", transaction
+        assert transaction["ordered_steps"][1]["id"] == "select_agent_identity", transaction
+
+        selected_pack = build_loopx_bootstrap_command_pack(
+            project=project,
+            goal_id="multi-agent-goal",
+            agent_id="codex-product-capability",
+            cli_bin=cli_bin,
+            host_surface="codex-app",
+            goal_text="fix a public issue",
+        )
+        assert selected_pack["host_loop_activation"]["activation_allowed"] is True
+        for key in (
+            "heartbeat_prompt_json",
+            "quota_guard",
+            "goal_start_agent_onboard_recheck",
+            "goal_start_quota_should_run",
+        ):
+            assert "--agent-id codex-product-capability" in selected_pack["commands"][key], (
+                key,
+                selected_pack["commands"],
+            )
 
     return 0
 

--- a/loopx/agent_onboarding.py
+++ b/loopx/agent_onboarding.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
+from .agent_registry import (
+    primary_agent_id_from_registry,
+    registered_agent_ids_from_registry,
+)
 from .bootstrap_command_pack import inspect_bootstrap_connection
 from .host_loop_activation import (
     AgentTypeError,
@@ -87,35 +91,53 @@ def build_agent_onboarding_packet(
     inspection = inspect_bootstrap_connection(project, goal_id=goal_id)
     resolved_project = str(inspection["project"])
     resolved_goal_id = str(inspection["goal_id"])
+    registry_path = Path(str(inspection["registry"]))
+    registered_agents = registered_agent_ids_from_registry(
+        registry_path,
+        resolved_goal_id,
+    )
+    primary_agent = primary_agent_id_from_registry(registry_path, resolved_goal_id)
     host_loop_activation = build_host_loop_activation_packet(
         agent_type=canonical_agent_type,
         goal_id=resolved_goal_id,
         cli_bin=cli_bin,
         agent_id=agent_id,
+        registered_agents=registered_agents,
+        primary_agent=primary_agent,
     )
+    selected_agent_id = host_loop_activation.get("agent_id")
+    activation_allowed = bool(host_loop_activation.get("activation_allowed"))
     install_command = _surface_install_command(canonical_agent_type, cli_bin)
     bootstrap_pack_command = _bootstrap_pack_command(
         project=resolved_project,
         goal_id=resolved_goal_id,
-        agent_id=agent_id,
+        agent_id=str(selected_agent_id) if selected_agent_id else None,
         agent_type=canonical_agent_type,
         cli_bin=cli_bin,
         task_text=task_text,
     )
-    commands: dict[str, str] = {
+    commands: dict[str, Any] = {
         "doctor_or_install": render_codex_cli_no_clone_preflight(cli_bin=cli_bin),
         "bootstrap_command_pack": bootstrap_pack_command,
-        "quota_guard": render_quota_guard_command(
-            resolved_goal_id,
-            cli_bin=cli_bin,
-            agent_id=agent_id,
+        "quota_guard": (
+            render_quota_guard_command(
+                resolved_goal_id,
+                cli_bin=cli_bin,
+                agent_id=str(selected_agent_id) if selected_agent_id else None,
+            )
+            if activation_allowed
+            else None
         ),
         "agent_onboard_recheck": (
             f"{shell_arg(cli_bin)} agent-onboard "
             f"--agent-type {shell_arg(canonical_agent_type)} "
             f"--project {shell_arg(resolved_project)} "
             f"--goal-id {shell_arg(resolved_goal_id)}"
-            + (f" --agent-id {shell_arg(agent_id)}" if agent_id else "")
+            + (
+                f" --agent-id {shell_arg(str(selected_agent_id))}"
+                if selected_agent_id
+                else ""
+            )
         ),
     }
     if install_command:
@@ -125,7 +147,11 @@ def build_agent_onboarding_packet(
             f"{shell_arg(cli_bin)} codex-cli-bootstrap-message "
             f"--project {shell_arg(resolved_project)} "
             f"--goal-id {shell_arg(resolved_goal_id)}"
-            + (f" --agent-id {shell_arg(agent_id)}" if agent_id else "")
+            + (
+                f" --agent-id {shell_arg(str(selected_agent_id))}"
+                if selected_agent_id
+                else ""
+            )
         )
     return {
         "ok": True,
@@ -133,11 +159,17 @@ def build_agent_onboarding_packet(
         "agent_type": canonical_agent_type,
         "project": resolved_project,
         "goal_id": resolved_goal_id,
-        "agent_id": agent_id,
+        "agent_id": selected_agent_id,
+        "requested_agent_id": agent_id,
+        "identity_selection_gate": host_loop_activation.get("identity_selection_gate"),
         "task_text": task_text,
         "project_connection": inspection,
         "host_loop_activation": host_loop_activation,
-        "recommended_start": _start_instruction(canonical_agent_type),
+        "recommended_start": (
+            "Select one registered agent lane from identity_selection_gate, then rerun onboarding."
+            if not activation_allowed
+            else _start_instruction(canonical_agent_type)
+        ),
         "commands": commands,
         "cost_model": {
             "onboarding": "run once during install/connect or when the active host loop is missing/stale",
@@ -177,6 +209,8 @@ def render_agent_onboarding_markdown(payload: dict[str, Any]) -> str:
         if isinstance(activation.get("success_criteria"), list)
         else []
     )
+    identity_gate = payload.get("identity_selection_gate")
+    identity_gate = identity_gate if isinstance(identity_gate, dict) else {}
     lines = [
         "# LoopX Agent Onboarding",
         "",
@@ -213,6 +247,15 @@ def render_agent_onboarding_markdown(payload: dict[str, Any]) -> str:
     lines.append("")
     lines.append("Success criteria:")
     lines.extend(f"- {item}" for item in criteria)
+    if identity_gate:
+        lines.extend(["", "## Agent Identity Gate", ""])
+        lines.append(f"- reason: {identity_gate.get('reason')}")
+        for choice in identity_gate.get("choices") or []:
+            if isinstance(choice, dict):
+                lines.append(
+                    f"- `{choice.get('agent_id')}` ({choice.get('role')}): "
+                    f"`{choice.get('heartbeat_prompt_json')}`"
+                )
     lines.extend(
         [
             "",

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -4,14 +4,16 @@ import json
 from pathlib import Path
 from typing import Any
 
+from .agent_registry import (
+    primary_agent_id_from_registry,
+    registered_agent_ids_from_registry,
+)
 from .bootstrap import default_goal_id
 from .host_loop_activation import agent_type_for_host_surface, build_host_loop_activation_packet
 from .project_alias import resolve_canonical_project_alias
 from .project_prompt import (
     DEFAULT_HANDOFF_ADAPTER_KIND,
     DEFAULT_HANDOFF_ADAPTER_STATUS,
-    render_heartbeat_prompt_command,
-    render_heartbeat_prompt_json_command,
     render_quota_guard_command,
     shell_arg,
 )
@@ -376,6 +378,12 @@ def build_loopx_bootstrap_command_pack(
     normalized_goal_text = " ".join(goal_text.split()) if goal_text else None
     explicit_goal_start = bool(normalized_goal_text)
     agent_type = agent_type_for_host_surface(host_surface)
+    registry_path = Path(str(inspection["registry"]))
+    registered_agents = registered_agent_ids_from_registry(
+        registry_path,
+        resolved_goal_id,
+    )
+    primary_agent = primary_agent_id_from_registry(registry_path, resolved_goal_id)
 
     bootstrap_preview_command = _bootstrap_command(
         project=resolved_project,
@@ -389,25 +397,29 @@ def build_loopx_bootstrap_command_pack(
         cli_bin=cli_bin,
         dry_run=False,
     )
-    heartbeat_prompt_command = render_heartbeat_prompt_command(
-        resolved_goal_id,
-        cli_bin=cli_bin,
-        agent_id=agent_id,
-        agent_scope=f"{host_surface} LoopX command pack",
-    )
-    heartbeat_prompt_json_command = render_heartbeat_prompt_json_command(
-        resolved_goal_id,
-        cli_bin=cli_bin,
-        agent_id=agent_id,
-        agent_scope=f"{host_surface} LoopX command pack",
-    )
     host_loop_activation = build_host_loop_activation_packet(
         agent_type=agent_type,
         goal_id=resolved_goal_id,
         cli_bin=cli_bin,
         agent_id=agent_id,
+        registered_agents=registered_agents,
+        primary_agent=primary_agent,
     )
-    quota_guard_command = render_quota_guard_command(resolved_goal_id, cli_bin=cli_bin, agent_id=agent_id)
+    selected_agent_id = host_loop_activation.get("agent_id")
+    activation_allowed = bool(host_loop_activation.get("activation_allowed"))
+    activation_commands = host_loop_activation.get("commands")
+    activation_commands = activation_commands if isinstance(activation_commands, dict) else {}
+    heartbeat_prompt_command = activation_commands.get("heartbeat_prompt")
+    heartbeat_prompt_json_command = activation_commands.get("heartbeat_prompt_json")
+    quota_guard_command = (
+        render_quota_guard_command(
+            resolved_goal_id,
+            cli_bin=cli_bin,
+            agent_id=str(selected_agent_id) if selected_agent_id else None,
+        )
+        if activation_allowed
+        else None
+    )
     status_command = _project_command(resolved_project, f"{shell_arg(cli_bin)} status")
     goal_start_bootstrap_command = _goal_start_bootstrap_command(
         project=resolved_project,
@@ -418,11 +430,20 @@ def build_loopx_bootstrap_command_pack(
     goal_start_plan_prompt = _goal_start_prompt(
         goal_text=normalized_goal_text,
         goal_id=resolved_goal_id,
-        agent_id=agent_id,
+        agent_id=str(selected_agent_id) if selected_agent_id else None,
     )
     slash_command_catalog = build_slash_command_catalog(cli_bin=cli_bin)
 
-    if explicit_goal_start:
+    identity_selection_gate = host_loop_activation.get("identity_selection_gate")
+    if isinstance(identity_selection_gate, dict):
+        recommended_next_step = {
+            "kind": "select_agent_identity",
+            "requires_user_confirmation": False,
+            "requires_agent_selection": True,
+            "summary": identity_selection_gate.get("reason"),
+            "identity_selection_gate": identity_selection_gate,
+        }
+    elif explicit_goal_start:
         recommended_next_step = {
             "kind": "goal_plan_write_and_activate",
             "requires_user_confirmation": False,
@@ -460,12 +481,18 @@ def build_loopx_bootstrap_command_pack(
         "canonical_cli_command": (
             f"{shell_arg(cli_bin)} bootstrap-command-pack --project {shell_arg(resolved_project)} "
             f"--goal-id {shell_arg(resolved_goal_id)}"
+            + (
+                f" --agent-id {shell_arg(str(selected_agent_id))}"
+                if selected_agent_id
+                else ""
+            )
         ),
         "read_only": True,
         "goal_text": normalized_goal_text,
         "project": resolved_project,
         "goal_id": resolved_goal_id,
-        "agent_id": agent_id,
+        "agent_id": selected_agent_id,
+        "requested_agent_id": agent_id,
         "agent_type": agent_type,
         "host_surface": host_surface,
         "project_connection": inspection,
@@ -495,11 +522,29 @@ def build_loopx_bootstrap_command_pack(
                 f"--agent-type {shell_arg(agent_type)} "
                 f"--project {shell_arg(resolved_project)} "
                 f"--goal-id {shell_arg(resolved_goal_id)}"
-                + (f" --agent-id {shell_arg(agent_id)}" if agent_id else "")
+                + (
+                    f" --agent-id {shell_arg(str(selected_agent_id))}"
+                    if selected_agent_id
+                    else ""
+                )
             ),
             "goal_start_quota_should_run": (
-                f"{shell_arg(cli_bin)} quota should-run --goal-id {shell_arg(resolved_goal_id)}"
-                + (f" --agent-id {shell_arg(agent_id)}" if agent_id else "")
+                (
+                    f"{shell_arg(cli_bin)} quota should-run --goal-id "
+                    f"{shell_arg(resolved_goal_id)}"
+                    + (
+                        f" --agent-id {shell_arg(str(selected_agent_id))}"
+                        if selected_agent_id
+                        else ""
+                    )
+                )
+                if activation_allowed
+                else None
+            ),
+            "identity_selection_choices": (
+                identity_selection_gate.get("choices")
+                if isinstance(identity_selection_gate, dict)
+                else []
             ),
             "issue_fix_workflow_plan_template": (
                 f"{shell_arg(cli_bin)} issue-fix workflow-plan "
@@ -533,6 +578,7 @@ def build_loopx_bootstrap_command_pack(
             "bare_command_mutation_requires_user_confirmation": mutation_confirmation_required,
             "explicit_goal_start_may_write_project_local_state": explicit_goal_start,
             "explicit_goal_start_must_activate_host_loop": explicit_goal_start,
+            "host_loop_activation_allowed": activation_allowed,
         },
     }
     payload["message"] = render_loopx_bootstrap_command_pack_message(payload)
@@ -558,6 +604,9 @@ def build_start_goal_guided_packet(
     )
     commands = command_pack.get("commands")
     commands = commands if isinstance(commands, dict) else {}
+    activation = command_pack.get("host_loop_activation")
+    activation = activation if isinstance(activation, dict) else {}
+    identity_selection_gate = activation.get("identity_selection_gate")
     guided_transaction = {
         "schema_version": GUIDED_START_SCHEMA_VERSION,
         "mode": "dry_run_preview",
@@ -601,7 +650,7 @@ def build_start_goal_guided_packet(
             },
             {
                 "id": "activate_host_loop",
-                "kind": "host_loop",
+                "kind": "identity_gate" if identity_selection_gate else "host_loop",
                 "command": commands.get("goal_start_host_loop_activation"),
                 "purpose": "install or refresh the host loop only when it is missing, unknown, stale, or agent type changed",
             },
@@ -635,6 +684,18 @@ def build_start_goal_guided_packet(
             "preferred_scope_change": "use configure-goal incremental updates instead of force bootstrap when state already exists",
         },
     }
+    if isinstance(identity_selection_gate, dict):
+        guided_transaction["blocked_by"] = "agent_identity_selection"
+        guided_transaction["identity_selection_gate"] = identity_selection_gate
+        guided_transaction["ordered_steps"].insert(
+            1,
+            {
+                "id": "select_agent_identity",
+                "kind": "identity_gate",
+                "choices": identity_selection_gate.get("choices") or [],
+                "purpose": "select one registered agent lane before generating heartbeat or quota commands",
+            },
+        )
     payload = {
         "ok": True,
         "schema_version": GUIDED_START_SCHEMA_VERSION,
@@ -682,6 +743,22 @@ def render_start_goal_guided_markdown(payload: dict[str, Any]) -> str:
             step_lines.append(f"   - command/source: `{str(command).splitlines()[0]}`")
     preserve = transaction.get("preserve_todos_policy")
     preserve = preserve if isinstance(preserve, dict) else {}
+    identity_gate = transaction.get("identity_selection_gate")
+    identity_gate = identity_gate if isinstance(identity_gate, dict) else {}
+    identity_gate_lines = ""
+    if identity_gate:
+        choices = [
+            f"- `{choice.get('agent_id')}` ({choice.get('role')}): "
+            f"`{choice.get('heartbeat_prompt_json')}`"
+            for choice in identity_gate.get("choices") or []
+            if isinstance(choice, dict)
+        ]
+        identity_gate_lines = (
+            "\n## Agent Identity Gate\n\n"
+            f"{identity_gate.get('reason')}\n\n"
+            + "\n".join(choices)
+            + "\n"
+        )
     return f"""# Guided Start Goal
 
 - schema: `{payload.get("schema_version")}`
@@ -696,6 +773,7 @@ behind explicit command execution by the host/agent.
 ## Ordered Transaction
 
 {chr(10).join(step_lines)}
+{identity_gate_lines}
 
 ## Todo Preservation
 
@@ -732,8 +810,27 @@ def render_loopx_bootstrap_command_pack_message(payload: dict[str, Any]) -> str:
     onboarding = onboarding if isinstance(onboarding, dict) else {}
     activation = payload.get("host_loop_activation")
     activation = activation if isinstance(activation, dict) else {}
+    identity_gate = activation.get("identity_selection_gate")
+    identity_gate = identity_gate if isinstance(identity_gate, dict) else {}
 
-    if goal_text:
+    if identity_gate:
+        choices = "\n".join(
+            f"- `{choice.get('agent_id')}` ({choice.get('role')}): "
+            f"`{choice.get('heartbeat_prompt_json')}`"
+            for choice in identity_gate.get("choices") or []
+            if isinstance(choice, dict)
+        )
+        action = f"""Select one registered agent lane before planning writes or host-loop activation.
+No unscoped heartbeat or quota command is advertised for this multi-agent goal.
+
+Reason: {identity_gate.get("reason")}
+
+Identity-aware choices:
+{choices}
+
+Rerun `{payload.get("canonical_cli_command")} --agent-id <registered-agent-id>`
+with the selected identity before continuing."""
+    elif goal_text:
         action = f"""This is an explicit goal-start invocation. Connect project-local LoopX state if needed:
 
 ```bash

--- a/loopx/host_loop_activation.py
+++ b/loopx/host_loop_activation.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from .agent_registry import normalize_registered_agents
+from .control_plane.todos.contract import normalize_todo_claimed_by
 from .project_prompt import (
     render_heartbeat_prompt_command,
     render_heartbeat_prompt_json_command,
@@ -10,6 +12,7 @@ from .project_prompt import (
 
 SCHEMA_VERSION = "loopx_host_loop_activation_v1"
 AGENT_TYPE_CATALOG_SCHEMA_VERSION = "loopx_agent_type_catalog_v0"
+IDENTITY_SELECTION_SCHEMA_VERSION = "loopx_host_loop_identity_selection_v0"
 
 SUPPORTED_AGENT_TYPES = ["codex-app", "codex-cli", "claude-code", "manual", "other-agent"]
 
@@ -235,6 +238,62 @@ def _heartbeat_commands(
     }
 
 
+def _identity_state(
+    *,
+    agent_id: str | None,
+    registered_agents: list[str] | None,
+    primary_agent: str | None,
+) -> dict[str, Any]:
+    registered = normalize_registered_agents(registered_agents)
+    selected = normalize_todo_claimed_by(agent_id)
+    primary = normalize_todo_claimed_by(primary_agent)
+    if not registered:
+        return {
+            "schema_version": IDENTITY_SELECTION_SCHEMA_VERSION,
+            "state": "legacy_unscoped",
+            "activation_allowed": True,
+            "selected_agent_id": selected,
+            "registered_agents": [],
+            "primary_agent": primary,
+            "action_required": False,
+        }
+    if not selected and len(registered) == 1:
+        selected = registered[0]
+        return {
+            "schema_version": IDENTITY_SELECTION_SCHEMA_VERSION,
+            "state": "single_registered_agent_selected",
+            "activation_allowed": True,
+            "selected_agent_id": selected,
+            "registered_agents": registered,
+            "primary_agent": primary,
+            "action_required": False,
+        }
+    if selected in registered:
+        return {
+            "schema_version": IDENTITY_SELECTION_SCHEMA_VERSION,
+            "state": "selected",
+            "activation_allowed": True,
+            "selected_agent_id": selected,
+            "registered_agents": registered,
+            "primary_agent": primary,
+            "action_required": False,
+        }
+    return {
+        "schema_version": IDENTITY_SELECTION_SCHEMA_VERSION,
+        "state": "invalid_selection" if selected else "selection_required",
+        "activation_allowed": False,
+        "selected_agent_id": None,
+        "requested_agent_id": selected,
+        "registered_agents": registered,
+        "primary_agent": primary,
+        "action_required": True,
+        "reason": (
+            f"agent_id={selected!r} is not registered for this goal"
+            if selected
+            else "multiple registered agent lanes exist; select one before host-loop activation"
+        ),
+        "required_cli_arg": "--agent-id <registered-agent-id>",
+    }
 def _codex_app_activation(commands: dict[str, str]) -> dict[str, Any]:
     return {
         "host_surface": "codex_app_heartbeat_automation",
@@ -351,13 +410,26 @@ def build_host_loop_activation_packet(
     goal_id: str,
     cli_bin: str = "loopx",
     agent_id: str | None = None,
+    registered_agents: list[str] | None = None,
+    primary_agent: str | None = None,
 ) -> dict[str, Any]:
     canonical = normalize_agent_type(agent_type)
-    commands = _heartbeat_commands(
-        goal_id=goal_id,
-        agent_type=canonical,
-        cli_bin=cli_bin,
+    identity = _identity_state(
         agent_id=agent_id,
+        registered_agents=registered_agents,
+        primary_agent=primary_agent,
+    )
+    selected_agent_id = identity.get("selected_agent_id")
+    activation_allowed = bool(identity.get("activation_allowed"))
+    commands: dict[str, Any] = (
+        _heartbeat_commands(
+            goal_id=goal_id,
+            agent_type=canonical,
+            cli_bin=cli_bin,
+            agent_id=str(selected_agent_id) if selected_agent_id else None,
+        )
+        if activation_allowed
+        else {"heartbeat_prompt_json": None, "heartbeat_prompt": None}
     )
     if canonical == "codex-app":
         surface = _codex_app_activation(commands)
@@ -370,11 +442,50 @@ def build_host_loop_activation_packet(
         if canonical == "other-agent":
             surface["entry_command_hint"] = "@loopx <task>, $loopx <task>, or another explicit host command facade"
             surface["host_surface"] = "custom_agent_loop_driver"
+    identity_selection_gate = None
+    if not activation_allowed:
+        choices = []
+        for candidate in identity["registered_agents"]:
+            candidate_commands = _heartbeat_commands(
+                goal_id=goal_id,
+                agent_type=canonical,
+                cli_bin=cli_bin,
+                agent_id=candidate,
+            )
+            choices.append(
+                {
+                    "agent_id": candidate,
+                    "role": "primary" if candidate == identity.get("primary_agent") else "side-agent",
+                    "heartbeat_prompt_json": candidate_commands["heartbeat_prompt_json"],
+                    "heartbeat_prompt": candidate_commands["heartbeat_prompt"],
+                }
+            )
+        identity_selection_gate = {
+            **identity,
+            "choices": choices,
+            "external_write_required": False,
+        }
+        surface["activation_method"] = "select_agent_identity_before_host_loop_activation"
+        surface["activation_input_command"] = None
+        surface["activation_steps"] = [
+            "Select one registered agent lane from identity_selection_gate.",
+            "Run that choice's identity-aware heartbeat-prompt JSON command.",
+            *surface["activation_steps"][1:],
+        ]
+        surface["success_criteria"] = [
+            "One registered agent identity is explicitly selected.",
+            *surface["success_criteria"],
+        ]
     return {
         "schema_version": SCHEMA_VERSION,
         "agent_type": canonical,
         "goal_id": goal_id,
-        "agent_id": agent_id,
+        "agent_id": selected_agent_id,
+        "requested_agent_id": normalize_todo_claimed_by(agent_id),
+        "activation_state": identity["state"],
+        "activation_allowed": activation_allowed,
+        "identity_contract": identity,
+        "identity_selection_gate": identity_selection_gate,
         "activation_required_after_todo_write": True,
         "status_probe_policy": {
             "check_once_during_onboarding": True,


### PR DESCRIPTION
## Summary
- gate multi-agent host-loop activation when no registered `agent_id` is selected
- auto-select the only registered agent for simple single-agent goals
- carry an explicit selected identity through onboarding, bootstrap-command-pack, guided start, heartbeat, and quota commands
- expose executable scoped heartbeat choices instead of advertising an unscoped command that the heartbeat CLI rejects

## Design
The existing heartbeat prompt remains fail-closed. This change fixes the producer side: host-loop activation now emits a compact identity selection contract. It does not add persistent state or silently default a multi-agent goal to the primary lane.

## Validation
- focused agent-onboard, bootstrap-command-pack, heartbeat prompt/error, multi-agent modularization, and issue-fix contract smokes: passed
- `loopx canary premerge --from-git-diff --format json --timeout-seconds 180`: passed, 10/10 selected checks
- selected identity command executed against the installed CLI and produced a scoped task body
- Python compile, diff hygiene, line budget, and public/private boundary scan: passed
- failures/skips/warnings/manual holds: none
