### PR TITLE
Route host capabilities through heartbeat gates

### DIFF
--- a/docs/heartbeat-automation-prompt.md
+++ b/docs/heartbeat-automation-prompt.md
@@ -134,6 +134,23 @@ heartbeat commands pass the same `--agent-id` to both `quota should-run` and
 `quota spend-slot`, so workspace guards and quota accounting evaluate the same
 agent identity.
 
+Host capabilities are declarations, not permission grants. When the selected
+Codex App, CLI, or external launcher already has a capability required by its
+todos, declare it while generating the heartbeat:
+
+```bash
+loopx heartbeat-prompt \
+  --goal-id <GOAL_ID> \
+  --thin \
+  --agent-id <AGENT_ID> \
+  --available-capability network \
+  --available-capability external_evidence_poll
+```
+
+The generated quota guard and spend command preserve the same declarations.
+Do not declare credentials, production access, or another capability merely to
+bypass a gate; the launcher must actually provide it.
+
 - for small AGENTS-eligible validated changes, self-merge and complete the todo
   with `--side-agent-self-merged --evidence "<commit and validation summary>"`;
 - for runtime, benchmark, permission, production, destructive git, publication,

--- a/docs/interaction-pattern-catalog.md
+++ b/docs/interaction-pattern-catalog.md
@@ -674,6 +674,13 @@ If no visible executable todo can run, the gate chooses:
 - `skip` when the missing capability is unsupported and no safe repair or owner
   action is known.
 
+For a mixed missing set, the gate projects `owner_missing`, `repair_missing`,
+and `resolution_steps` separately. An unresolved owner-held capability takes
+precedence for the interaction decision, so a local bridge repair cannot hide
+the concrete user action. Once the launcher truthfully declares that owner-held
+capability available, the user gate disappears and any remaining bridge repair
+returns to the agent lane.
+
 Launchers that really have an extra capability should pass it to both
 `quota should-run` and `quota spend-slot` with `--available-capability`, so the
 preflight and accounting phases agree.

--- a/examples/capability-gate-smoke.py
+++ b/examples/capability-gate-smoke.py
@@ -281,6 +281,50 @@ def main() -> int:
     assert owner_gate["interaction_contract"]["user_channel"]["action_required"] is True, owner_gate
     assert owner_gate["heartbeat_recommendation"]["notify"] == "NOTIFY", owner_gate
 
+    mixed_capability_todo = todo(
+        8,
+        "P0",
+        "[P0] Observe a public external lifecycle and write back the next action.",
+        ["shell", "network", "external_evidence_poll"],
+    )
+    mixed_owner_gate = build_quota_should_run(
+        status_payload([mixed_capability_todo]),
+        goal_id=GOAL_ID,
+        available_capabilities=["shell", "filesystem_write"],
+    )
+    mixed_gate = mixed_owner_gate["capability_gate"]
+    assert mixed_gate["action"] == "ask_owner", mixed_owner_gate
+    assert mixed_gate["decision_owner"] == "user", mixed_owner_gate
+    assert mixed_gate["owner_missing"] == ["network"], mixed_owner_gate
+    assert mixed_gate["repair_missing"] == ["external_evidence_poll"], mixed_owner_gate
+    assert mixed_gate["resolution_steps"] == [
+        {
+            "owner": "user",
+            "action": "provide_or_authorize",
+            "capabilities": ["network"],
+        },
+        {
+            "owner": "agent",
+            "action": "repair_bridge",
+            "capabilities": ["external_evidence_poll"],
+        },
+    ], mixed_owner_gate
+    assert mixed_owner_gate["interaction_contract"]["user_channel"]["action_required"] is True
+    assert "network" in mixed_gate["owner_action"], mixed_owner_gate
+
+    mixed_ready = build_quota_should_run(
+        status_payload([mixed_capability_todo]),
+        goal_id=GOAL_ID,
+        available_capabilities=[
+            "shell",
+            "filesystem_write",
+            "network",
+            "external_evidence_poll",
+        ],
+    )
+    assert mixed_ready["capability_gate"]["action"] == "run", mixed_ready
+    assert mixed_ready["interaction_contract"]["user_channel"]["action_required"] is False
+
     print("capability-gate-smoke ok")
     return 0
 

--- a/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
+++ b/examples/control_plane/agent-onboard-host-loop-activation-smoke.py
@@ -212,6 +212,7 @@ def main() -> int:
             cli_bin=cli_bin,
             host_surface="codex-app",
             goal_text="fix a public issue",
+            available_capabilities=["network", "external_evidence_poll"],
         )
         assert selected_pack["host_loop_activation"]["activation_allowed"] is True
         for key in (
@@ -221,6 +222,14 @@ def main() -> int:
             "goal_start_quota_should_run",
         ):
             assert "--agent-id codex-product-capability" in selected_pack["commands"][key], (
+                key,
+                selected_pack["commands"],
+            )
+            assert "--available-capability network" in selected_pack["commands"][key], (
+                key,
+                selected_pack["commands"],
+            )
+            assert "--available-capability external_evidence_poll" in selected_pack["commands"][key], (
                 key,
                 selected_pack["commands"],
             )

--- a/examples/control_plane/heartbeat-prompt-smoke.py
+++ b/examples/control_plane/heartbeat-prompt-smoke.py
@@ -79,6 +79,15 @@ def main() -> int:
         registered_agents=["codex-main-control", "codex-side-bypass"],
         primary_agent="codex-main-control",
     )
+    capability_scoped_payload = build_heartbeat_prompt(
+        goal_id=GOAL_ID,
+        active_state=ACTIVE_STATE,
+        thin=True,
+        agent_id="codex-side-bypass",
+        registered_agents=["codex-main-control", "codex-side-bypass"],
+        primary_agent="codex-main-control",
+        available_capabilities=["network", "external_evidence_poll", "network"],
+    )
     missing_agent_id = None
     try:
         build_heartbeat_prompt(
@@ -227,6 +236,18 @@ def main() -> int:
         "--active-state /tmp/public-heartbeat-goal/ACTIVE_GOAL_STATE.md --agent-id codex-side-bypass"
     ), profile_scoped_payload
     assert "--agent-scope" not in profile_scoped_payload["thin_prompt_command"], profile_scoped_payload
+    assert capability_scoped_payload["available_capabilities"] == [
+        "network",
+        "external_evidence_poll",
+    ], capability_scoped_payload
+    for command_key in (
+        "quota_guard_command",
+        "quota_spend_command",
+        "thin_prompt_command",
+    ):
+        command = str(capability_scoped_payload[command_key])
+        assert "--available-capability network" in command, command
+        assert "--available-capability external_evidence_poll" in command, command
     assert "productization showcase docs lane" in normalized(str(profile_scoped_payload["task_body"])), (
         profile_scoped_payload
     )

--- a/loopx/agent_onboarding.py
+++ b/loopx/agent_onboarding.py
@@ -113,6 +113,9 @@ def build_agent_onboarding_packet(
     )
     selected_agent_id = host_loop_activation.get("agent_id")
     activation_allowed = bool(host_loop_activation.get("activation_allowed"))
+    normalized_available_capabilities = list(
+        host_loop_activation.get("available_capabilities") or []
+    )
     install_command = _surface_install_command(canonical_agent_type, cli_bin)
     bootstrap_pack_command = _bootstrap_pack_command(
         project=resolved_project,
@@ -121,7 +124,7 @@ def build_agent_onboarding_packet(
         agent_type=canonical_agent_type,
         cli_bin=cli_bin,
         task_text=task_text,
-        available_capabilities=available_capabilities,
+        available_capabilities=normalized_available_capabilities,
     )
     commands: dict[str, Any] = {
         "doctor_or_install": render_codex_cli_no_clone_preflight(cli_bin=cli_bin),
@@ -131,7 +134,7 @@ def build_agent_onboarding_packet(
                 resolved_goal_id,
                 cli_bin=cli_bin,
                 agent_id=str(selected_agent_id) if selected_agent_id else None,
-                available_capabilities=available_capabilities,
+                available_capabilities=normalized_available_capabilities,
             )
             if activation_allowed
             else None
@@ -146,7 +149,7 @@ def build_agent_onboarding_packet(
                 if selected_agent_id
                 else ""
             )
-            + render_available_capability_args(available_capabilities)
+            + render_available_capability_args(normalized_available_capabilities)
         ),
     }
     if install_command:
@@ -170,7 +173,7 @@ def build_agent_onboarding_packet(
         "goal_id": resolved_goal_id,
         "agent_id": selected_agent_id,
         "requested_agent_id": agent_id,
-        "available_capabilities": host_loop_activation.get("available_capabilities") or [],
+        "available_capabilities": normalized_available_capabilities,
         "identity_selection_gate": host_loop_activation.get("identity_selection_gate"),
         "task_text": task_text,
         "project_connection": inspection,

--- a/loopx/agent_onboarding.py
+++ b/loopx/agent_onboarding.py
@@ -16,6 +16,7 @@ from .host_loop_activation import (
     render_agent_type_catalog_markdown,
 )
 from .project_prompt import (
+    render_available_capability_args,
     render_codex_cli_no_clone_preflight,
     render_quota_guard_command,
     shell_arg,
@@ -41,6 +42,7 @@ def _bootstrap_pack_command(
     agent_type: str,
     cli_bin: str,
     task_text: str | None,
+    available_capabilities: list[str] | None,
 ) -> str:
     surface_by_type = {
         "codex-app": "codex-app",
@@ -63,6 +65,8 @@ def _bootstrap_pack_command(
         parts.extend(["--agent-id", shell_arg(agent_id)])
     if task_text:
         parts.extend(["--goal-text", shell_arg(task_text)])
+    for capability in available_capabilities or []:
+        parts.extend(["--available-capability", shell_arg(capability)])
     return " ".join(parts)
 
 
@@ -86,6 +90,7 @@ def build_agent_onboarding_packet(
     agent_id: str | None = None,
     cli_bin: str = "loopx",
     task_text: str | None = None,
+    available_capabilities: list[str] | None = None,
 ) -> dict[str, Any]:
     canonical_agent_type = normalize_agent_type(agent_type)
     inspection = inspect_bootstrap_connection(project, goal_id=goal_id)
@@ -104,6 +109,7 @@ def build_agent_onboarding_packet(
         agent_id=agent_id,
         registered_agents=registered_agents,
         primary_agent=primary_agent,
+        available_capabilities=available_capabilities,
     )
     selected_agent_id = host_loop_activation.get("agent_id")
     activation_allowed = bool(host_loop_activation.get("activation_allowed"))
@@ -115,6 +121,7 @@ def build_agent_onboarding_packet(
         agent_type=canonical_agent_type,
         cli_bin=cli_bin,
         task_text=task_text,
+        available_capabilities=available_capabilities,
     )
     commands: dict[str, Any] = {
         "doctor_or_install": render_codex_cli_no_clone_preflight(cli_bin=cli_bin),
@@ -124,6 +131,7 @@ def build_agent_onboarding_packet(
                 resolved_goal_id,
                 cli_bin=cli_bin,
                 agent_id=str(selected_agent_id) if selected_agent_id else None,
+                available_capabilities=available_capabilities,
             )
             if activation_allowed
             else None
@@ -138,6 +146,7 @@ def build_agent_onboarding_packet(
                 if selected_agent_id
                 else ""
             )
+            + render_available_capability_args(available_capabilities)
         ),
     }
     if install_command:
@@ -161,6 +170,7 @@ def build_agent_onboarding_packet(
         "goal_id": resolved_goal_id,
         "agent_id": selected_agent_id,
         "requested_agent_id": agent_id,
+        "available_capabilities": host_loop_activation.get("available_capabilities") or [],
         "identity_selection_gate": host_loop_activation.get("identity_selection_gate"),
         "task_text": task_text,
         "project_connection": inspection,

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -14,6 +14,7 @@ from .project_alias import resolve_canonical_project_alias
 from .project_prompt import (
     DEFAULT_HANDOFF_ADAPTER_KIND,
     DEFAULT_HANDOFF_ADAPTER_STATUS,
+    render_available_capability_args,
     render_quota_guard_command,
     shell_arg,
 )
@@ -369,6 +370,7 @@ def build_loopx_bootstrap_command_pack(
     cli_bin: str,
     host_surface: str,
     goal_text: str | None = None,
+    available_capabilities: list[str] | None = None,
 ) -> dict[str, Any]:
     inspection = inspect_bootstrap_connection(project, goal_id=goal_id)
     resolved_project = str(inspection["project"])
@@ -404,6 +406,7 @@ def build_loopx_bootstrap_command_pack(
         agent_id=agent_id,
         registered_agents=registered_agents,
         primary_agent=primary_agent,
+        available_capabilities=available_capabilities,
     )
     selected_agent_id = host_loop_activation.get("agent_id")
     activation_allowed = bool(host_loop_activation.get("activation_allowed"))
@@ -416,6 +419,7 @@ def build_loopx_bootstrap_command_pack(
             resolved_goal_id,
             cli_bin=cli_bin,
             agent_id=str(selected_agent_id) if selected_agent_id else None,
+            available_capabilities=available_capabilities,
         )
         if activation_allowed
         else None
@@ -527,6 +531,7 @@ def build_loopx_bootstrap_command_pack(
                     if selected_agent_id
                     else ""
                 )
+                + render_available_capability_args(available_capabilities)
             ),
             "goal_start_quota_should_run": (
                 (
@@ -537,6 +542,7 @@ def build_loopx_bootstrap_command_pack(
                         if selected_agent_id
                         else ""
                     )
+                    + render_available_capability_args(available_capabilities)
                 )
                 if activation_allowed
                 else None
@@ -593,6 +599,7 @@ def build_start_goal_guided_packet(
     cli_bin: str,
     host_surface: str,
     goal_text: str,
+    available_capabilities: list[str] | None = None,
 ) -> dict[str, Any]:
     command_pack = build_loopx_bootstrap_command_pack(
         project=project,
@@ -601,6 +608,7 @@ def build_start_goal_guided_packet(
         cli_bin=cli_bin,
         host_surface=host_surface,
         goal_text=goal_text,
+        available_capabilities=available_capabilities,
     )
     commands = command_pack.get("commands")
     commands = commands if isinstance(commands, dict) else {}

--- a/loopx/cli_commands/starter_bootstrap.py
+++ b/loopx/cli_commands/starter_bootstrap.py
@@ -70,6 +70,12 @@ def register_starter_bootstrap_commands(subparsers: argparse._SubParsersAction) 
         "--task-text",
         help="Optional first task text to include in the bootstrap command pack.",
     )
+    agent_onboard_parser.add_argument(
+        "--available-capability",
+        dest="available_capabilities",
+        action="append",
+        help="Capability available in this host loop. Repeat for multiple capabilities.",
+    )
 
     bootstrap_command_pack_parser = subparsers.add_parser(
         "bootstrap-command-pack",
@@ -91,6 +97,12 @@ def register_starter_bootstrap_commands(subparsers: argparse._SubParsersAction) 
         default="chat-box",
         choices=["chat-box", "codex-app", "codex-cli-tui", "claude-code", "shell", "http", "worker-bridge"],
         help="Host surface where the slash command pack will be exposed.",
+    )
+    bootstrap_command_pack_parser.add_argument(
+        "--available-capability",
+        dest="available_capabilities",
+        action="append",
+        help="Capability available in this host loop. Repeat for multiple capabilities.",
     )
     bootstrap_command_pack_parser.add_argument(
         "--goal-text",
@@ -132,6 +144,12 @@ def register_starter_bootstrap_commands(subparsers: argparse._SubParsersAction) 
         default="codex-app",
         choices=["chat-box", "codex-app", "codex-cli-tui", "claude-code", "shell", "http", "worker-bridge"],
         help="Host surface that will own loop activation after todo writeback.",
+    )
+    start_goal_parser.add_argument(
+        "--available-capability",
+        dest="available_capabilities",
+        action="append",
+        help="Capability available in this host loop. Repeat for multiple capabilities.",
     )
     start_goal_parser.add_argument(
         "--goal-text",
@@ -267,6 +285,7 @@ def handle_agent_onboard_command(
             agent_id=args.agent_id,
             cli_bin=args.cli_bin,
             task_text=args.task_text,
+            available_capabilities=args.available_capabilities,
         )
     except AgentTypeError as exc:
         print_payload(exc.to_payload(), args.format, render_agent_onboarding_markdown)
@@ -286,6 +305,7 @@ def handle_loopx_bootstrap_command_pack_command(
         cli_bin=args.cli_bin,
         host_surface=args.host_surface,
         goal_text=args.goal_text,
+        available_capabilities=args.available_capabilities,
     )
     if bool(getattr(args, "message_only", False)):
         print(str(payload.get("message") or ""))
@@ -314,6 +334,7 @@ def handle_start_goal_command(
         cli_bin=args.cli_bin,
         host_surface=args.host_surface,
         goal_text=args.goal_text,
+        available_capabilities=args.available_capabilities,
     )
     print_payload(payload, args.format, render_start_goal_guided_markdown)
     return 0

--- a/loopx/cli_commands/support_control.py
+++ b/loopx/cli_commands/support_control.py
@@ -193,6 +193,16 @@ def register_support_control_commands(
         action="append",
         help="Optional natural-language scope for this automation agent. Repeat for multiple scope lines.",
     )
+    heartbeat_prompt_parser.add_argument(
+        "--available-capability",
+        dest="available_capabilities",
+        action="append",
+        help=(
+            "Declare a capability available in this host loop, such as network or "
+            "external_evidence_poll. Repeat for multiple capabilities; generated "
+            "quota guard and spend commands preserve the declaration."
+        ),
+    )
     heartbeat_style_group = heartbeat_prompt_parser.add_mutually_exclusive_group()
     heartbeat_style_group.add_argument(
         "--compact",
@@ -421,6 +431,7 @@ def handle_support_control_command(
                 registered_agents=registered_agents,
                 primary_agent=primary_agent,
                 side_agent_handoff_agent=side_agent_handoff_agent,
+                available_capabilities=args.available_capabilities,
             )
         except Exception as exc:
             fallback_active_state = active_state
@@ -449,6 +460,7 @@ def handle_support_control_command(
                 registered_agents=registered_agents,
                 primary_agent=primary_agent,
                 side_agent_handoff_agent=side_agent_handoff_agent,
+                available_capabilities=args.available_capabilities,
             )
         print_payload(payload, output_format(args), render_heartbeat_prompt_markdown)
         return 0 if payload.get("ok") else 1

--- a/loopx/control_plane/agents/capability_gate.py
+++ b/loopx/control_plane/agents/capability_gate.py
@@ -41,11 +41,67 @@ def _capability_missing_action(missing: list[str]) -> str:
     missing_set = set(missing)
     if not missing_set:
         return "run"
-    if missing_set & CAPABILITY_REPAIR_BRIDGE_HINTS:
-        return "repair_bridge"
     if missing_set & CAPABILITY_OWNER_GATE_HINTS:
         return "ask_owner"
+    if missing_set & CAPABILITY_REPAIR_BRIDGE_HINTS:
+        return "repair_bridge"
     return "skip"
+
+
+def _capability_resolution(missing: list[str]) -> dict[str, Any]:
+    owner_missing = [
+        capability for capability in missing if capability in CAPABILITY_OWNER_GATE_HINTS
+    ]
+    repair_missing = [
+        capability for capability in missing if capability in CAPABILITY_REPAIR_BRIDGE_HINTS
+    ]
+    unsupported_missing = [
+        capability
+        for capability in missing
+        if capability not in CAPABILITY_OWNER_GATE_HINTS
+        and capability not in CAPABILITY_REPAIR_BRIDGE_HINTS
+    ]
+    action = _capability_missing_action(missing)
+    decision_owner = (
+        "user"
+        if action == "ask_owner"
+        else "agent"
+        if action == "repair_bridge"
+        else "capability_gate"
+    )
+    resolution_steps: list[dict[str, Any]] = []
+    if owner_missing:
+        resolution_steps.append(
+            {
+                "owner": "user",
+                "action": "provide_or_authorize",
+                "capabilities": owner_missing,
+            }
+        )
+    if repair_missing:
+        resolution_steps.append(
+            {
+                "owner": "agent",
+                "action": "repair_bridge",
+                "capabilities": repair_missing,
+            }
+        )
+    if unsupported_missing:
+        resolution_steps.append(
+            {
+                "owner": "capability_gate",
+                "action": "unsupported",
+                "capabilities": unsupported_missing,
+            }
+        )
+    return {
+        "action": action,
+        "decision_owner": decision_owner,
+        "owner_missing": owner_missing,
+        "repair_missing": repair_missing,
+        "unsupported_missing": unsupported_missing,
+        "resolution_steps": resolution_steps,
+    }
 
 
 def available_capabilities_with_defaults(value: Any) -> list[str]:
@@ -300,7 +356,10 @@ def build_capability_gate(
         for capability in item.get("missing_capabilities") or []:
             if capability not in missing_all:
                 missing_all.append(str(capability))
-    action = _capability_missing_action(missing_all)
+    resolution = _capability_resolution(missing_all)
+    action = str(resolution["action"])
+    owner_missing = list(resolution["owner_missing"])
+    repair_missing = list(resolution["repair_missing"])
     return {
         "schema_version": CAPABILITY_GATE_SCHEMA_VERSION,
         "source": source,
@@ -308,7 +367,11 @@ def build_capability_gate(
         "available": available,
         "missing": missing_all,
         "action": action,
-        "decision_owner": "capability_gate",
+        "decision_owner": resolution["decision_owner"],
+        "owner_missing": owner_missing,
+        "repair_missing": repair_missing,
+        "unsupported_missing": resolution["unsupported_missing"],
+        "resolution_steps": resolution["resolution_steps"],
         "selection_policy": "no_runnable_candidate",
         "runnable_count": 0,
         "runnable_candidates": [],
@@ -316,8 +379,13 @@ def build_capability_gate(
         "blocks_delivery": True,
         "reason": "all visible executable todo candidates require unavailable capabilities",
         "owner_action": (
-            "provide an environment with the missing capability, mark the todo blocked, "
-            "or add a lower-risk fallback todo"
+            "provide or authorize the missing owner-held capability: "
+            + ", ".join(owner_missing)
+            + (
+                "; after that, the agent can repair: " + ", ".join(repair_missing)
+                if repair_missing
+                else ""
+            )
         )
         if action == "ask_owner"
         else None,

--- a/loopx/heartbeat_prompt.py
+++ b/loopx/heartbeat_prompt.py
@@ -6,12 +6,16 @@ from typing import Any
 
 from .agent_registry import normalize_registered_agents
 from .project_prompt import (
+    render_available_capability_args,
     render_cli_preflight,
     render_quota_guard_command,
     render_quota_spend_command,
     render_refresh_state_command,
 )
-from .control_plane.todos.contract import normalize_todo_claimed_by
+from .control_plane.todos.contract import (
+    normalize_required_capabilities,
+    normalize_todo_claimed_by,
+)
 
 
 DEFAULT_MATERIAL_QUEUE_RULE = "Do not consume the learning material queue unless the user explicitly asks."
@@ -362,6 +366,7 @@ def build_heartbeat_prompt(
     registered_agents: list[str] | tuple[str, ...] | None = None,
     primary_agent: str | None = None,
     side_agent_handoff_agent: str | None = None,
+    available_capabilities: list[str] | tuple[str, ...] | None = None,
 ) -> dict[str, Any]:
     effective_resolved_active_state = resolved_active_state or active_state
     active_state_text = str(active_state.expanduser()) if active_state else "the registry-declared active state"
@@ -445,6 +450,12 @@ def build_heartbeat_prompt(
         agent_id=normalized_agent_id,
         agent_scopes=command_agent_scopes,
     )
+    normalized_available_capabilities = normalize_required_capabilities(
+        available_capabilities
+    )
+    capability_args = render_available_capability_args(
+        normalized_available_capabilities
+    )
     agent_scope_instruction = render_agent_scope_instruction(
         goal_id=goal_id,
         agent_id=normalized_agent_id,
@@ -455,12 +466,18 @@ def build_heartbeat_prompt(
         compact=compact or brief,
         thin=thin,
     )
-    quota_guard_command = render_quota_guard_command(goal_id, cli_bin=cli_bin, agent_id=normalized_agent_id)
+    quota_guard_command = render_quota_guard_command(
+        goal_id,
+        cli_bin=cli_bin,
+        agent_id=normalized_agent_id,
+        available_capabilities=normalized_available_capabilities,
+    )
     quota_spend_command = render_quota_spend_command(
         goal_id,
         source="heartbeat",
         cli_bin=cli_bin,
         agent_id=normalized_agent_id,
+        available_capabilities=normalized_available_capabilities,
     )
     refresh_state_command = render_refresh_state_command(
         goal_id,
@@ -476,10 +493,10 @@ def build_heartbeat_prompt(
         delivery_outcome="outcome_progress",
     )
     cli_preflight = render_cli_preflight(cli_bin=cli_bin)
-    expanded_prompt_command = f"{cli_bin} heartbeat-prompt --goal-id {goal_id}{active_state_arg}{agent_args}"
-    compact_prompt_command = f"{cli_bin} heartbeat-prompt --compact --goal-id {goal_id}{active_state_arg}{agent_args}"
-    brief_prompt_command = f"{cli_bin} heartbeat-prompt --brief --goal-id {goal_id}{active_state_arg}{agent_args}"
-    thin_prompt_command = f"{cli_bin} heartbeat-prompt --thin --goal-id {goal_id}{active_state_arg}{agent_args}"
+    expanded_prompt_command = f"{cli_bin} heartbeat-prompt --goal-id {goal_id}{active_state_arg}{agent_args}{capability_args}"
+    compact_prompt_command = f"{cli_bin} heartbeat-prompt --compact --goal-id {goal_id}{active_state_arg}{agent_args}{capability_args}"
+    brief_prompt_command = f"{cli_bin} heartbeat-prompt --brief --goal-id {goal_id}{active_state_arg}{agent_args}{capability_args}"
+    thin_prompt_command = f"{cli_bin} heartbeat-prompt --thin --goal-id {goal_id}{active_state_arg}{agent_args}{capability_args}"
     if thin:
         task_body_renderer = render_thin_heartbeat_task_body
     elif brief:
@@ -525,6 +542,7 @@ def build_heartbeat_prompt(
         "registered_agents": normalized_registered_agents,
         "primary_agent": normalized_primary_agent,
         "side_agent_handoff_agent": normalized_side_agent_handoff_agent,
+        "available_capabilities": normalized_available_capabilities,
         "expanded_prompt_command": expanded_prompt_command,
         "compact_prompt_command": compact_prompt_command,
         "brief_prompt_command": brief_prompt_command,
@@ -564,6 +582,7 @@ def build_heartbeat_prompt_error_payload(
     registered_agents: list[str] | tuple[str, ...] | None = None,
     primary_agent: str | None = None,
     side_agent_handoff_agent: str | None = None,
+    available_capabilities: list[str] | tuple[str, ...] | None = None,
     material_queue_rule: str | None = None,
     permission_rule: str | None = None,
 ) -> dict[str, Any]:
@@ -579,10 +598,16 @@ def build_heartbeat_prompt_error_payload(
         agent_id=str(agent_id).strip() if agent_id else None,
         agent_scopes=projected_agent_scopes,
     )
-    expanded_prompt_command = f"{cli_bin} heartbeat-prompt --goal-id {goal_id}{active_state_arg}{agent_args}"
-    compact_prompt_command = f"{cli_bin} heartbeat-prompt --compact --goal-id {goal_id}{active_state_arg}{agent_args}"
-    brief_prompt_command = f"{cli_bin} heartbeat-prompt --brief --goal-id {goal_id}{active_state_arg}{agent_args}"
-    thin_prompt_command = f"{cli_bin} heartbeat-prompt --thin --goal-id {goal_id}{active_state_arg}{agent_args}"
+    projected_available_capabilities = normalize_required_capabilities(
+        available_capabilities
+    )
+    capability_args = render_available_capability_args(
+        projected_available_capabilities
+    )
+    expanded_prompt_command = f"{cli_bin} heartbeat-prompt --goal-id {goal_id}{active_state_arg}{agent_args}{capability_args}"
+    compact_prompt_command = f"{cli_bin} heartbeat-prompt --compact --goal-id {goal_id}{active_state_arg}{agent_args}{capability_args}"
+    brief_prompt_command = f"{cli_bin} heartbeat-prompt --brief --goal-id {goal_id}{active_state_arg}{agent_args}{capability_args}"
+    thin_prompt_command = f"{cli_bin} heartbeat-prompt --thin --goal-id {goal_id}{active_state_arg}{agent_args}{capability_args}"
     normalized_registered_agents = normalize_registered_agents(registered_agents)
     return {
         "ok": False,
@@ -603,6 +628,7 @@ def build_heartbeat_prompt_error_payload(
         "registered_agents": normalized_registered_agents,
         "primary_agent": str(primary_agent).strip() if primary_agent else None,
         "side_agent_handoff_agent": str(side_agent_handoff_agent).strip() if side_agent_handoff_agent else None,
+        "available_capabilities": projected_available_capabilities,
         "expanded_prompt_command": expanded_prompt_command,
         "compact_prompt_command": compact_prompt_command,
         "brief_prompt_command": brief_prompt_command,

--- a/loopx/host_loop_activation.py
+++ b/loopx/host_loop_activation.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from typing import Any
 
 from .agent_registry import normalize_registered_agents
-from .control_plane.todos.contract import normalize_todo_claimed_by
+from .control_plane.todos.contract import (
+    normalize_required_capabilities,
+    normalize_todo_claimed_by,
+)
 from .project_prompt import (
     render_heartbeat_prompt_command,
     render_heartbeat_prompt_json_command,
@@ -213,6 +216,7 @@ def _heartbeat_commands(
     agent_type: str,
     cli_bin: str,
     agent_id: str | None,
+    available_capabilities: list[str] | None = None,
 ) -> dict[str, str]:
     scope_by_type = {
         "codex-app": "Codex App heartbeat automation",
@@ -228,12 +232,14 @@ def _heartbeat_commands(
             cli_bin=cli_bin,
             agent_id=agent_id,
             agent_scope=agent_scope,
+            available_capabilities=available_capabilities,
         ),
         "heartbeat_prompt": render_heartbeat_prompt_command(
             goal_id,
             cli_bin=cli_bin,
             agent_id=agent_id,
             agent_scope=agent_scope,
+            available_capabilities=available_capabilities,
         ),
     }
 
@@ -412,6 +418,7 @@ def build_host_loop_activation_packet(
     agent_id: str | None = None,
     registered_agents: list[str] | None = None,
     primary_agent: str | None = None,
+    available_capabilities: list[str] | None = None,
 ) -> dict[str, Any]:
     canonical = normalize_agent_type(agent_type)
     identity = _identity_state(
@@ -421,12 +428,16 @@ def build_host_loop_activation_packet(
     )
     selected_agent_id = identity.get("selected_agent_id")
     activation_allowed = bool(identity.get("activation_allowed"))
+    normalized_available_capabilities = normalize_required_capabilities(
+        available_capabilities
+    )
     commands: dict[str, Any] = (
         _heartbeat_commands(
             goal_id=goal_id,
             agent_type=canonical,
             cli_bin=cli_bin,
             agent_id=str(selected_agent_id) if selected_agent_id else None,
+            available_capabilities=normalized_available_capabilities,
         )
         if activation_allowed
         else {"heartbeat_prompt_json": None, "heartbeat_prompt": None}
@@ -451,6 +462,7 @@ def build_host_loop_activation_packet(
                 agent_type=canonical,
                 cli_bin=cli_bin,
                 agent_id=candidate,
+                available_capabilities=normalized_available_capabilities,
             )
             choices.append(
                 {
@@ -482,6 +494,7 @@ def build_host_loop_activation_packet(
         "goal_id": goal_id,
         "agent_id": selected_agent_id,
         "requested_agent_id": normalize_todo_claimed_by(agent_id),
+        "available_capabilities": normalized_available_capabilities,
         "activation_state": identity["state"],
         "activation_allowed": activation_allowed,
         "identity_contract": identity,

--- a/loopx/project_prompt.py
+++ b/loopx/project_prompt.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from typing import Any
 
 from .bootstrap import default_goal_id
+from .control_plane.todos.contract import normalize_required_capabilities
 
 
 DEFAULT_HANDOFF_OBJECTIVE = "<OBJECTIVE_FROM_GOAL_DOC>"
@@ -25,6 +26,13 @@ def shell_arg_or_placeholder(value: str) -> str:
     if text.startswith("<") and text.endswith(">"):
         return text
     return shell_arg(text)
+
+
+def render_available_capability_args(values: Any) -> str:
+    return "".join(
+        f" --available-capability {shell_arg(capability)}"
+        for capability in normalize_required_capabilities(values)
+    )
 
 
 def render_cli_preflight(*, cli_bin: str = "loopx") -> str:
@@ -58,12 +66,19 @@ fi
 {cli_bin_arg} doctor >/dev/null"""
 
 
-def render_quota_guard_command(goal_id: str, *, cli_bin: str = "loopx", agent_id: str | None = None) -> str:
+def render_quota_guard_command(
+    goal_id: str,
+    *,
+    cli_bin: str = "loopx",
+    agent_id: str | None = None,
+    available_capabilities: Any = None,
+) -> str:
     agent_arg = f" --agent-id {shell_arg(agent_id)}" if agent_id else ""
+    capability_args = render_available_capability_args(available_capabilities)
     return (
         f"{shell_arg(cli_bin)} --format json "
         f"--registry {SHARED_GLOBAL_REGISTRY} "
-        f"quota should-run --goal-id {shell_arg(goal_id)}{agent_arg}"
+        f"quota should-run --goal-id {shell_arg(goal_id)}{agent_arg}{capability_args}"
     )
 
 
@@ -73,14 +88,16 @@ def render_quota_spend_command(
     source: str = "adapter",
     cli_bin: str = "loopx",
     agent_id: str | None = None,
+    available_capabilities: Any = None,
 ) -> str:
     agent_arg = f" --agent-id {shell_arg(agent_id)}" if agent_id else ""
+    capability_args = render_available_capability_args(available_capabilities)
     return (
         f"{shell_arg(cli_bin)} "
         f"--registry {SHARED_GLOBAL_REGISTRY} "
         "quota spend-slot "
         f"--goal-id {shell_arg(goal_id)} "
-        f"--slots 1 --source {shell_arg(source)} --execute{agent_arg}"
+        f"--slots 1 --source {shell_arg(source)} --execute{agent_arg}{capability_args}"
     )
 
 
@@ -124,12 +141,14 @@ def render_heartbeat_prompt_command(
     agent_id: str | None = None,
     agent_scope: str = "Codex CLI /goal visible TUI loop",
     body: str = "thin",
+    available_capabilities: Any = None,
 ) -> str:
     agent_arg = f" --agent-id {shell_arg(agent_id)}" if agent_id else ""
     scope_arg = f" --agent-scope {shell_arg(agent_scope)}" if agent_id else ""
+    capability_args = render_available_capability_args(available_capabilities)
     return (
         f"{shell_arg(cli_bin)} heartbeat-prompt --{shell_arg(body)} "
-        f"--goal-id {shell_arg(goal_id)}{agent_arg}{scope_arg}"
+        f"--goal-id {shell_arg(goal_id)}{agent_arg}{scope_arg}{capability_args}"
     )
 
 
@@ -140,12 +159,14 @@ def render_heartbeat_prompt_json_command(
     agent_id: str | None = None,
     agent_scope: str = "Codex CLI /goal visible TUI loop",
     body: str = "thin",
+    available_capabilities: Any = None,
 ) -> str:
     agent_arg = f" --agent-id {shell_arg(agent_id)}" if agent_id else ""
     scope_arg = f" --agent-scope {shell_arg(agent_scope)}" if agent_id else ""
+    capability_args = render_available_capability_args(available_capabilities)
     return (
         f"{shell_arg(cli_bin)} --format json heartbeat-prompt --{shell_arg(body)} "
-        f"--goal-id {shell_arg(goal_id)}{agent_arg}{scope_arg}"
+        f"--goal-id {shell_arg(goal_id)}{agent_arg}{scope_arg}{capability_args}"
     )
 
 


### PR DESCRIPTION
## Summary
- carry explicit host capability declarations through heartbeat prompt, onboarding, bootstrap guard, and quota spend commands
- separate owner-held, agent-repairable, and unsupported missing capabilities in capability-gate output
- make unresolved owner-held capabilities produce a concrete user action even when a repairable bridge is also missing

## Validation
- focused capability, heartbeat prompt, onboarding, and bootstrap smokes passed
- LoopX premerge gate passed 17/17 selected checks after rebase
- Python compile, line budget, diff hygiene, and public/private boundary scan passed

## Safety
Capability flags remain declarations supplied by the launcher. LoopX does not infer or grant network, credentials, production access, or other permissions.