### PR TITLE
Guide guarded self-repair issue escalation

### DIFF
--- a/examples/install-local-smoke.py
+++ b/examples/install-local-smoke.py
@@ -343,6 +343,19 @@ def main() -> int:
         assert "`boundary_projection_gap`" in self_repair_patterns_text, self_repair_patterns_text
         assert "`skill_cli_contract_drift`" in self_repair_patterns_text, self_repair_patterns_text
         assert "`tiny_turn_under_delivery`" in self_repair_patterns_text, self_repair_patterns_text
+        self_repair_issue_escalation = (
+            codex_home
+            / "skills"
+            / "loopx-self-repair"
+            / "references"
+            / "upstream-issue-escalation.md"
+        )
+        self_repair_issue_escalation_text = self_repair_issue_escalation.read_text(
+            encoding="utf-8"
+        )
+        assert "LOOPX_SELF_REPAIR_AUTO_ISSUE=1" in self_repair_issue_escalation_text
+        assert "gh issue list" in self_repair_issue_escalation_text
+        assert "gh issue create" in self_repair_issue_escalation_text
         assert (
             codex_home / "skills" / "loopx-self-repair" / "agents" / "openai.yaml"
         ).is_file()

--- a/examples/self-repair-upstream-issue-escalation-smoke.py
+++ b/examples/self-repair-upstream-issue-escalation-smoke.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Smoke-check guarded self-repair issue escalation stays safe and bounded."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL = ROOT / "skills" / "loopx-self-repair" / "SKILL.md"
+REFERENCE = (
+    ROOT
+    / "skills"
+    / "loopx-self-repair"
+    / "references"
+    / "upstream-issue-escalation.md"
+)
+
+
+def require(text: str, snippets: list[str], *, source: Path) -> None:
+    missing = [snippet for snippet in snippets if snippet not in text]
+    assert not missing, f"{source}: missing {missing}"
+
+
+def main() -> int:
+    skill = SKILL.read_text(encoding="utf-8")
+    reference = REFERENCE.read_text(encoding="utf-8")
+
+    require(
+        skill,
+        [
+            "## Upstream Issue Escalation",
+            "references/upstream-issue-escalation.md",
+            "Invoking this skill never grants publication permission",
+            "search open and closed issues",
+            "create at most one issue per repair turn",
+        ],
+        source=SKILL,
+    )
+    require(
+        reference,
+        [
+            "Self-repair invocation is diagnosis consent, not publication consent.",
+            "LOOPX_SELF_REPAIR_AUTO_ISSUE=1",
+            "credentials, suspected vulnerabilities",
+            "loopx check --scan-path",
+            "<!-- loopx-self-repair:fingerprint=<12-hex-sha256> -->",
+            "gh issue list",
+            "--state all",
+            "gh auth status",
+            "gh issue create",
+            "Create at most one issue per repair turn",
+            "upstream_issue_deduplicated",
+            "upstream_issue_opened",
+        ],
+        source=REFERENCE,
+    )
+
+    search_position = reference.index("gh issue list")
+    auth_position = reference.index("gh auth status")
+    create_position = reference.index("gh issue create")
+    assert search_position < auth_position < create_position, (
+        "duplicate search and auth must precede issue creation"
+    )
+
+    print("self-repair-upstream-issue-escalation-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/loopx-self-repair/SKILL.md
+++ b/skills/loopx-self-repair/SKILL.md
@@ -61,6 +61,30 @@ not only an apology or a one-off explanation.
 7. **Write back the lesson.** Update active goal state, docs, contributor
    tasks, or this skill so the same failure mode is visible next time.
 
+## Upstream Issue Escalation
+
+A public GitHub issue is an optional final escalation, not a default side
+effect of self-repair. Consider it only when the responsible layer is a
+reusable LoopX product, CLI, skill, installer, or control-plane gap and durable
+upstream tracking adds value beyond the local repair or PR.
+
+Read `references/upstream-issue-escalation.md` before publishing anything.
+Invoking this skill never grants publication permission. The guarded path must:
+
+1. reject private, project-specific, support-only, and security-sensitive
+   reports;
+2. reduce the evidence to a minimal public-safe reproduction and scan the
+   draft with `loopx check`;
+3. search open and closed issues by a stable fingerprint before creating one;
+4. auto-submit only under explicit current-turn approval or durable owner
+   opt-in; otherwise show the exact draft and ask once for confirmation;
+5. create at most one issue per repair turn, then record the existing or new
+   issue URL in the relevant LoopX todo/evidence writeback.
+
+If qualification, authority, authentication, boundary scanning, or duplicate
+search is uncertain, preserve the draft and stop before publication. Prefer a
+direct fix or PR when no separate issue is needed for coordination.
+
 ## Vision / Replan Writeback
 
 Use the bounded vision contract when self-repair discovers that LoopX did not
@@ -115,6 +139,8 @@ next quota check can enter replan.
 
 - For known symptom-to-repair mappings, read
   `references/repair-patterns.md`.
+- For guarded public GitHub issue escalation, read
+  `references/upstream-issue-escalation.md`.
 - For user/agent/state channel semantics, read
   `../../docs/state-interaction-model.md` and
   `../../docs/interaction-pattern-catalog.md`.

--- a/skills/loopx-self-repair/references/upstream-issue-escalation.md
+++ b/skills/loopx-self-repair/references/upstream-issue-escalation.md
@@ -1,0 +1,115 @@
+# Guarded Upstream Issue Escalation
+
+Use this route to turn a confirmed, reusable LoopX product gap into a compact
+upstream issue without leaking a user's project state or creating issue spam.
+Self-repair invocation is diagnosis consent, not publication consent.
+
+## 1. Qualify The Candidate
+
+An issue candidate should satisfy all of these conditions:
+
+- the responsible layer is the public LoopX product, CLI, skill, installer, or
+  control plane rather than the user's project;
+- the behavior reproduces on a supported clean install, a public/synthetic
+  fixture, or repeated independent public-safe evidence;
+- the impact is concrete for users or operators;
+- durable tracking or coordination adds value beyond a direct fix or PR.
+
+Do not publish an issue for:
+
+- a one-off agent judgment error, stale local state, or user-project defect;
+- a support question that docs or a direct answer can resolve;
+- a report that requires private names, task identifiers, repository details,
+  local paths, internal URLs, raw logs, trajectories, or verifier output;
+- credentials, suspected vulnerabilities, or other security-sensitive
+  material. Stop and use the repository's private security channel instead.
+
+Prefer a direct, reviewable PR when the repair is already understood and an
+issue would only duplicate that work.
+
+## 2. Establish Publication Authority
+
+Automatic submission is allowed only when one of these is true:
+
+- the user explicitly asked to open the issue in the current task; or
+- the owner has provided a durable opt-in through
+  `LOOPX_SELF_REPAIR_AUTO_ISSUE=1` in the current environment.
+
+The opt-in authorizes publication behavior, not the contents of a particular
+report. Qualification, public-safety, authentication, and deduplication gates
+still apply every time. Repository labels, self-repair invocation, a writable
+checkout, or an authenticated `gh` session are not publication authority.
+
+Without authority, render the exact public-safe title and body, then ask one
+yes/no confirmation. Do not create a user todo or interrupt the user until a
+candidate has passed qualification, scanning, and duplicate search.
+
+## 3. Build A Minimal Public Packet
+
+The issue body should contain only:
+
+1. observable symptom and user impact;
+2. expected and actual behavior;
+3. a minimal synthetic or public reproduction;
+4. LoopX version or public commit and relevant runtime version;
+5. the narrow suspected product surface, clearly marked as a hypothesis;
+6. public-safe validation already run.
+
+Add a stable marker derived from normalized affected surface, symptom, and
+cause class. Do not include private identifiers in the fingerprint input:
+
+```text
+<!-- loopx-self-repair:fingerprint=<12-hex-sha256> -->
+```
+
+Write the draft to a temporary file outside the repository and scan it before
+any GitHub write:
+
+```bash
+loopx check --scan-path "$draft_file"
+```
+
+A passing scanner is necessary but not sufficient. Read the final title and
+body and remove private project names, customer or team names, task IDs, local
+paths, internal links, credentials, raw logs, trajectories, verifier output,
+and private production details.
+
+## 4. Search Before Creating
+
+Search both open and closed issues in the canonical upstream repository using
+the fingerprint marker:
+
+```bash
+gh issue list \
+  --repo huangruiteng/loopx \
+  --state all \
+  --search "$fingerprint in:body" \
+  --limit 20 \
+  --json number,title,state,url
+```
+
+If a matching issue exists, record its URL and stop. Do not open a duplicate or
+comment on the existing issue unless comment publication is separately
+authorized. If search fails or its result is ambiguous, preserve the draft and
+stop before publication.
+
+## 5. Submit Once, Then Write Back
+
+Verify authentication and create only after every earlier gate passes:
+
+```bash
+gh auth status
+gh issue create \
+  --repo huangruiteng/loopx \
+  --title "$title" \
+  --body-file "$draft_file"
+```
+
+Create at most one issue per repair turn and make at most one submission
+attempt. On authentication or submission failure, keep the draft and provide a
+concrete recovery step; do not retry in a loop.
+
+After finding or creating an issue, write its URL and outcome
+(`upstream_issue_deduplicated` or `upstream_issue_opened`) into the related
+LoopX todo/evidence record. A draft alone is not durable delivery and should
+not consume a delivery spend.


### PR DESCRIPTION
## Summary
- add a guarded upstream GitHub issue escalation route to `loopx-self-repair`
- require qualification, explicit or standing publication authority, public-safe draft scanning, open/closed duplicate search, and one-attempt rate limiting
- preserve the protocol through focused and installed-skill smokes

## Product and architecture judgment
This gives users a low-friction way to turn reusable LoopX failures into upstream feedback without making public issue creation a default side effect. The implementation stays in the skill layer and reuses `gh` plus `loopx check`; it adds no issue service or control-plane schema. `LOOPX_SELF_REPAIR_AUTO_ISSUE=1` is only a standing publication opt-in and cannot bypass qualification, security, boundary, authentication, or deduplication gates.

## Validation
- `python3 examples/self-repair-upstream-issue-escalation-smoke.py`
- `python3 /Users/bytedance/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/loopx-self-repair`
- `python3 examples/install-local-smoke.py`
- `python3 examples/project/goal-vision-replan-contract-smoke.py`
- live read-only `gh issue list --state all --search ... in:body` syntax check
- `loopx check --scan-path` on all four changed files
- `loopx canary premerge --from-git-diff` (passed; 8 selected, 0 failures, 0 manual holds, self-merge allowed)

## Boundary and residual risk
No private state, raw logs, credentials, local project evidence, or generated artifacts are included. This PR does not open any issue. The remaining risk is agent interpretation of a prose protocol, bounded by the focused contract smoke and explicit fail-closed rules.