### PR TITLE
Close remote benchmark batches into standard ledgers

### DIFF
--- a/examples/skillsbench-benchmark-egress-policy-smoke.py
+++ b/examples/skillsbench-benchmark-egress-policy-smoke.py
@@ -162,6 +162,45 @@ def test_public_launcher_uses_container_reachable_benchmark_proxy() -> None:
     assert "--append-history" not in output, output
 
 
+def test_public_launcher_batches_three_cases_with_closeout_sync() -> None:
+    env = os.environ.copy()
+    env.update(
+        {
+            "SKILLSBENCH_SSH_DESTINATION": "example.invalid",
+            "SKILLSBENCH_REMOTE_ROOT": "/remote/loopx",
+            "SKILLSBENCH_ROOT": "/remote/skillsbench",
+            "SKILLSBENCH_EXPECTED_LOOPX_GIT_HEAD": "abc1234",
+            "SKILLSBENCH_DOCKER_PROXY_HOST": "host.docker.internal",
+            "SKILLSBENCH_RUN_STAMP": "20260710T000000CST",
+        }
+    )
+    proc = subprocess.run(
+        [
+            str(REPO_ROOT / "scripts" / "skillsbench-launch-goal-xhigh.sh"),
+            "--dry-run",
+            "case-a,case-b,case-c",
+            "batch-smoke",
+            "18186",
+        ],
+        cwd=REPO_ROOT,
+        env=env,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+        check=True,
+    )
+    output = proc.stdout
+    assert "task_ids=case-a,case-b,case-c" in output, output
+    assert "parallel_cases=3" in output, output
+    assert "--task-ids case-a\\,case-b\\,case-c" in output or (
+        "--task-ids case-a,case-b,case-c" in output
+    ), output
+    assert "--parallel-cases 3" in output, output
+    assert "--remote-public-artifact-root" in output, output
+    assert "benchmark_run.compact.json" in output, output
+    assert "--local-run-ledger-path" in output, output
+
+
 def test_verifier_proxy_patch_is_required_only_for_existing_verifier() -> None:
     proxy_env = {
         "LOOPX_SKILLSBENCH_EGRESS_PROXY": "http://benchmark-proxy.example.invalid:18080",
@@ -192,5 +231,6 @@ if __name__ == "__main__":
     test_formal_cli_goal_auto_requires_benchmark_egress_proxy()
     test_formal_cli_goal_proxy_env_is_forwarded_without_public_url()
     test_public_launcher_uses_container_reachable_benchmark_proxy()
+    test_public_launcher_batches_three_cases_with_closeout_sync()
     test_verifier_proxy_patch_is_required_only_for_existing_verifier()
     print("skillsbench-benchmark-egress-policy-smoke: ok")

--- a/examples/skillsbench-current-ledger-aggregate-smoke.py
+++ b/examples/skillsbench-current-ledger-aggregate-smoke.py
@@ -308,6 +308,23 @@ def test_current_aggregate_prefers_countable_results() -> None:
             ],
             "active_case_ids": [],
             "runnable_missing_case_ids": ["never-run-case"],
+            "runnable_blocked_uncountable_case_ids": [
+                "canonical-task-source-preflight",
+                "fix-druid-loophole-cve",
+                "fix-erlang-ssh-cve",
+                "flink-query",
+                "pddl-tpp-planning",
+                "reward-artifact-missing",
+            ],
+            "runnable_case_ids": [
+                "canonical-task-source-preflight",
+                "fix-druid-loophole-cve",
+                "fix-erlang-ssh-cve",
+                "flink-query",
+                "never-run-case",
+                "pddl-tpp-planning",
+                "reward-artifact-missing",
+            ],
             "raw_logs_recorded": False,
             "raw_task_text_recorded": False,
             "source_paths_recorded": False,
@@ -696,6 +713,14 @@ def test_current_aggregate_cli_writes_public_safe_json() -> None:
         assert aggregate["active_case_ids"] == ["never-run-case"], aggregate
         assert aggregate["missing_case_ids"] == ["never-run-case"], aggregate
         assert aggregate["runnable_missing_case_ids"] == [], aggregate
+        assert "fix-druid-loophole-cve" in aggregate[
+            "runnable_blocked_uncountable_case_ids"
+        ], aggregate
+        assert "fix-druid-loophole-cve" in aggregate["runnable_case_ids"], aggregate
+        assert "never-run-case" not in aggregate["runnable_case_ids"], aggregate
+        assert aggregate["standard_case_sets"]["runnable_case_ids"] == aggregate[
+            "runnable_case_ids"
+        ], aggregate
         assert aggregate["countable_score_summary"]["countable_case_count"] == 3
         assert aggregate["countable_score_summary"]["countable_score_mean"] == 0.166667
         assert "hello-world" not in aggregate["case_best"]

--- a/examples/skillsbench-reverse-tunnel-supervisor-smoke.py
+++ b/examples/skillsbench-reverse-tunnel-supervisor-smoke.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 import os
 import subprocess
@@ -12,6 +13,12 @@ from pathlib import Path
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.benchmark_core import materialize_public_benchmark_artifacts
+from loopx.benchmark_core.remote_closeout import closeout_remote_benchmark_batch
+
 SCRIPT = REPO_ROOT / "scripts" / "skillsbench_reverse_tunnel_supervisor.py"
 
 
@@ -19,6 +26,8 @@ def _fake_ssh(path: Path, log_path: Path) -> None:
     path.write_text(
         f"""#!/usr/bin/env python3
 import os
+import base64
+import json
 import signal
 import sys
 import time
@@ -46,6 +55,27 @@ if "LOOPX_REVERSE_TUNNEL_PROBE" in remote_command:
 
 if "LOOPX_REMOTE_FAILURE_CLEANUP" in remote_command:
     print('{{"alive_after_count": 0, "docker_matched_count": 1, "docker_removed_count": 1, "docker_status": "ok", "kill_sent_count": 0, "matched_count": 2, "term_sent_count": 2}}')
+    sys.exit(0)
+
+if "benchmark_remote_public_artifact_collection_v0" in remote_command:
+    compact = json.dumps({{
+        "schema_version": "benchmark_run_v0",
+        "benchmark_id": "skillsbench@1.1",
+        "task_id": "case-a",
+        "run_id": "case-a-sync-smoke",
+        "route": "codex-cli-goal-baseline",
+        "status": "completed",
+        "official_score": 0.0,
+    }}, sort_keys=True).encode("utf-8")
+    print(json.dumps({{
+        "schema_version": "benchmark_remote_public_artifact_collection_v0",
+        "matched_count": 1,
+        "blocked_count": 0,
+        "artifacts": [{{
+            "relative_path": "job/case/benchmark_run.compact.json",
+            "content_base64": base64.b64encode(compact).decode("ascii"),
+        }}],
+    }}, sort_keys=True))
     sys.exit(0)
 
 if "cat >" in remote_command:
@@ -122,6 +152,146 @@ def test_supervisor_holds_tunnel_and_redacts_private_command() -> None:
         assert opaque_command not in public_text
         assert opaque_command in ssh_log.read_text(encoding="utf-8")
         assert private_log.exists()
+
+
+def test_supervisor_syncs_only_compact_public_artifacts() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-tunnel-sync-") as tmp:
+        root = Path(tmp)
+        fake_ssh = root / "ssh"
+        ssh_log = root / "ssh.log"
+        public_output = root / "public.json"
+        private_log = root / "private.log"
+        synced_dir = root / "synced"
+        ledger_path = root / "live-ledger.json"
+        aggregate_path = root / "standard-aggregate.json"
+        canonical_ids = root / "canonical-case-ids.txt"
+        canonical_ids.write_text("case-a\n", encoding="utf-8")
+        _fake_ssh(fake_ssh, ssh_log)
+
+        opaque_destination = "opaque-benchmark-host.example"
+        opaque_remote_root = "/opaque/private/jobs"
+        proc = subprocess.run(
+            [
+                sys.executable,
+                str(SCRIPT),
+                "--ssh-bin",
+                str(fake_ssh),
+                "--ssh-destination",
+                opaque_destination,
+                "--remote-forward",
+                "127.0.0.1:18180:127.0.0.1:18180",
+                "--remote-command",
+                "run-skillsbench --case case-a",
+                "--remote-public-artifact-root",
+                opaque_remote_root,
+                "--remote-public-artifact-glob",
+                "job/*/benchmark_run.compact.json",
+                "--local-public-artifact-dir",
+                str(synced_dir),
+                "--local-run-ledger-path",
+                str(ledger_path),
+                "--local-run-group-id",
+                "skillsbench-codex-cli-goal-xhigh-sync-smoke",
+                "--local-current-aggregate-path",
+                str(aggregate_path),
+                "--local-canonical-case-ids-file",
+                str(canonical_ids),
+                "--local-target-lane-id",
+                "codex-cli-goal-xhigh",
+                "--local-target-run-group-contains",
+                "skillsbench-codex-cli-goal-xhigh-",
+                "--public-output-path",
+                str(public_output),
+                "--private-log-path",
+                str(private_log),
+                "--tunnel-ready-timeout-sec",
+                "5",
+                "--probe-interval-sec",
+                "0.1",
+                "--run-timeout-sec",
+                "5",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        assert proc.returncode == 0, proc.stderr or proc.stdout
+        payload = json.loads(proc.stdout)
+        sync = payload["public_artifact_sync"]
+        assert sync["ok"] is True, sync
+        assert sync["matched_count"] == 1, sync
+        assert sync["written_count"] == 1, sync
+        compact_path = synced_dir / "job" / "case" / "benchmark_run.compact.json"
+        assert compact_path.exists(), sync
+        assert ledger_path.exists(), sync
+        assert aggregate_path.exists(), sync
+        assert sync["local_ledger_update"]["upserted_count"] == 1, sync
+        assert sync["local_aggregate_update"]["canonical_total"] == 1, sync
+        public_text = public_output.read_text(encoding="utf-8")
+        assert opaque_destination not in public_text
+        assert opaque_remote_root not in public_text
+        assert str(synced_dir) not in public_text
+        assert sync["raw_paths_recorded"] is False
+        assert sync["raw_logs_read"] is False
+        assert sync["raw_trajectory_read"] is False
+
+
+def test_public_artifact_materializer_rejects_private_children() -> None:
+    with tempfile.TemporaryDirectory(prefix="benchmark-artifact-boundary-") as tmp:
+        content = base64.b64encode(b"{}\n").decode("ascii")
+        result = materialize_public_benchmark_artifacts(
+            [
+                {
+                    "relative_path": "private/leak.public.json",
+                    "content_base64": content,
+                },
+                {
+                    "relative_path": "case/benchmark_run.compact.json",
+                    "content_base64": content,
+                },
+            ],
+            output_dir=tmp,
+            adapter_kind="skillsbench",
+        )
+        assert result["written_count"] == 1, result
+        assert result["blocked_reasons"] == {"raw_private_surface": 1}, result
+        assert not (Path(tmp) / "private" / "leak.public.json").exists()
+
+
+def test_closeout_requires_compact_when_ledger_is_requested() -> None:
+    with tempfile.TemporaryDirectory(prefix="benchmark-closeout-compact-") as tmp:
+        content = base64.b64encode(b"{}\n").decode("ascii")
+        collection = json.dumps(
+            {
+                "artifacts": [
+                    {
+                        "relative_path": "job/runner_prerequisites.public.json",
+                        "content_base64": content,
+                    }
+                ],
+                "matched_count": 1,
+                "blocked_count": 0,
+            }
+        )
+        result = closeout_remote_benchmark_batch(
+            run_remote_command=lambda _command, _timeout: subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=collection, stderr=""
+            ),
+            remote_root="/opaque/private/jobs",
+            artifact_globs=["job/*.public.json"],
+            local_public_artifact_dir=tmp,
+            adapter_kind="skillsbench",
+            max_bytes=1024,
+            sync_timeout_sec=1,
+            ledger_path=str(Path(tmp) / "ledger.json"),
+        )
+        assert result["ok"] is False, result
+        assert (
+            result["first_blocker"]
+            == "benchmark_compact_missing_after_remote_closeout"
+        ), result
 
 
 def test_supervisor_cleans_remote_failure_without_public_pattern() -> None:
@@ -296,6 +466,9 @@ def test_supervisor_holds_json_bridge_and_materializes_remote_client() -> None:
 
 if __name__ == "__main__":
     test_supervisor_holds_tunnel_and_redacts_private_command()
+    test_supervisor_syncs_only_compact_public_artifacts()
+    test_public_artifact_materializer_rejects_private_children()
+    test_closeout_requires_compact_when_ledger_is_requested()
     test_supervisor_cleans_remote_failure_without_public_pattern()
     test_supervisor_holds_json_bridge_and_materializes_remote_client()
     print("skillsbench-reverse-tunnel-supervisor smoke ok")

--- a/loopx/benchmark_core/__init__.py
+++ b/loopx/benchmark_core/__init__.py
@@ -27,6 +27,7 @@ from .artifacts import (
     classify_benchmark_artifact_path,
     classify_benchmark_candidate_source_path,
     filter_public_benchmark_artifact_paths,
+    materialize_public_benchmark_artifacts,
 )
 from .lifecycle import (
     BENCHMARK_CANONICAL_LIFECYCLE_SCHEMA_VERSION,
@@ -174,6 +175,7 @@ __all__ = [
     "LOOPX_PROMPT_POLLING_TEST_ROUTE",
     "IngestResult",
     "filter_public_benchmark_artifact_paths",
+    "materialize_public_benchmark_artifacts",
     "LaunchResult",
     "LedgerUpdate",
     "MAX5_BLIND_LOOP_NO_FEEDBACK_PROTOCOL_ID",

--- a/loopx/benchmark_core/artifacts.py
+++ b/loopx/benchmark_core/artifacts.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import base64
+import hashlib
 from pathlib import Path
 from typing import Any, Iterable
 
@@ -30,6 +32,7 @@ BENCHMARK_PRIVATE_MANIFEST_SUFFIXES = (
     ".local.json",
     ".private.json",
 )
+BENCHMARK_PUBLIC_ARTIFACT_MAX_BYTES = 2 * 1024 * 1024
 BENCHMARK_ARTIFACT_POLICY_REGISTRY: dict[str, dict[str, tuple[str, ...]]] = {
     "default": {
         "public_suffixes": BENCHMARK_PUBLIC_ARTIFACT_SUFFIXES,
@@ -151,13 +154,14 @@ def classify_benchmark_artifact_path(
     normalized = str(path).replace("\\", "/").rstrip("/")
     basename = normalized.rsplit("/", 1)[-1] if normalized else ""
     lower_path = normalized.lower()
+    boundary_path = "/" + lower_path.lstrip("/")
     lower_basename = basename.lower()
     public_compact_candidate = (
         lower_basename.endswith(policy["public_suffixes"])
         or lower_basename in policy["public_filenames"]
     )
     raw_marker = next(
-        (marker for marker in policy["raw_private_markers"] if marker in lower_path),
+        (marker for marker in policy["raw_private_markers"] if marker in boundary_path),
         "",
     )
     private_manifest = lower_basename.endswith(policy["private_suffixes"])
@@ -243,6 +247,95 @@ def filter_public_benchmark_artifact_paths(
             "trajectory_or_origin_log_read": False,
             "intended_use": "preflight benchmark artifact reads before compact ingest",
         },
+    }
+
+
+def materialize_public_benchmark_artifacts(
+    artifacts: Iterable[dict[str, Any]],
+    *,
+    output_dir: str | Path,
+    adapter_kind: str | None = None,
+    max_bytes: int = BENCHMARK_PUBLIC_ARTIFACT_MAX_BYTES,
+) -> dict[str, Any]:
+    """Validate and atomically materialize transported compact/public files."""
+
+    root = Path(output_dir).expanduser().resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    written_basenames: list[str] = []
+    blocked_reasons: dict[str, int] = {}
+    seen_relative_paths: set[str] = set()
+
+    def block(reason: str) -> None:
+        blocked_reasons[reason] = blocked_reasons.get(reason, 0) + 1
+
+    for artifact in artifacts:
+        if not isinstance(artifact, dict):
+            block("invalid_artifact_record")
+            continue
+        relative_text = str(artifact.get("relative_path") or "").replace("\\", "/")
+        relative = Path(relative_text)
+        if (
+            not relative_text
+            or relative.is_absolute()
+            or any(part in {"", ".", ".."} for part in relative.parts)
+        ):
+            block("unsafe_relative_path")
+            continue
+        relative_key = relative.as_posix()
+        if any(
+            part.lower() in {"private", "raw", "logs", "screenshots", "sessions"}
+            for part in relative.parts[:-1]
+        ):
+            block("raw_private_surface")
+            continue
+        if relative_key in seen_relative_paths:
+            block("duplicate_relative_path")
+            continue
+        seen_relative_paths.add(relative_key)
+        classification = classify_benchmark_artifact_path(
+            relative_key,
+            adapter_kind=adapter_kind,
+        )
+        if classification.get("allowed_to_read") is not True:
+            block(str(classification.get("first_blocker") or "artifact_not_public"))
+            continue
+        encoded = artifact.get("content_base64")
+        if not isinstance(encoded, str):
+            block("artifact_content_missing")
+            continue
+        try:
+            content = base64.b64decode(encoded, validate=True)
+        except (ValueError, TypeError):
+            block("artifact_content_invalid_base64")
+            continue
+        if len(content) > max(1, int(max_bytes)):
+            block("artifact_too_large")
+            continue
+        expected_sha256 = str(artifact.get("sha256") or "").lower()
+        if expected_sha256 and hashlib.sha256(content).hexdigest() != expected_sha256:
+            block("artifact_sha256_mismatch")
+            continue
+        destination = (root / relative).resolve()
+        if root not in destination.parents:
+            block("artifact_destination_escape")
+            continue
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        temporary = destination.with_name(destination.name + ".tmp")
+        temporary.write_bytes(content)
+        temporary.replace(destination)
+        written_basenames.append(destination.name)
+
+    return {
+        "schema_version": "benchmark_public_artifact_materialization_v0",
+        "ok": not blocked_reasons and bool(written_basenames),
+        "written_count": len(written_basenames),
+        "written_artifact_basenames": sorted(written_basenames),
+        "blocked_count": sum(blocked_reasons.values()),
+        "blocked_reasons": blocked_reasons,
+        "raw_paths_recorded": False,
+        "raw_task_text_read": False,
+        "raw_logs_read": False,
+        "raw_trajectory_read": False,
     }
 
 

--- a/loopx/benchmark_core/remote_closeout.py
+++ b/loopx/benchmark_core/remote_closeout.py
@@ -1,0 +1,345 @@
+from __future__ import annotations
+
+import json
+import shlex
+import subprocess
+from contextlib import nullcontext
+from pathlib import Path
+from typing import Any, Callable
+
+from ..file_lock import exclusive_file_lock
+from .artifacts import materialize_public_benchmark_artifacts
+
+
+RemoteCommandRunner = Callable[[str, float], subprocess.CompletedProcess[str]]
+
+REMOTE_PUBLIC_ARTIFACT_COLLECTOR = r'''
+import base64
+import glob
+import hashlib
+import json
+import sys
+from pathlib import Path, PurePosixPath
+
+root = Path(sys.argv[1]).expanduser().resolve()
+max_bytes = int(sys.argv[2])
+records = []
+blocked = 0
+seen = set()
+for pattern in sys.argv[3:]:
+    pure = PurePosixPath(pattern)
+    if pure.is_absolute() or ".." in pure.parts:
+        blocked += 1
+        continue
+    for raw_path in sorted(glob.glob(str(root / pattern), recursive=True)):
+        path = Path(raw_path)
+        if not path.is_file():
+            continue
+        try:
+            resolved = path.resolve()
+            relative = resolved.relative_to(root).as_posix()
+        except (OSError, ValueError):
+            blocked += 1
+            continue
+        lower = "/" + relative.lower().lstrip("/")
+        public_name = resolved.name.lower().endswith((".compact.json", ".public.json"))
+        private = any(marker in lower for marker in (
+            "/private/", "/raw/", "/logs/", "/screenshots/", "/agent/",
+            "trajectory", "credential", "secret",
+        ))
+        if not public_name or private or relative in seen:
+            blocked += 1
+            continue
+        try:
+            content = resolved.read_bytes()
+        except OSError:
+            blocked += 1
+            continue
+        if len(content) > max_bytes:
+            blocked += 1
+            continue
+        seen.add(relative)
+        records.append({
+            "relative_path": relative,
+            "content_base64": base64.b64encode(content).decode("ascii"),
+            "sha256": hashlib.sha256(content).hexdigest(),
+        })
+print(json.dumps({
+    "schema_version": "benchmark_remote_public_artifact_collection_v0",
+    "artifacts": records,
+    "matched_count": len(records),
+    "blocked_count": blocked,
+}, sort_keys=True))
+'''
+
+
+def build_remote_benchmark_closeout_contract(
+    *,
+    requested: bool,
+    ledger_requested: bool,
+    aggregate_requested: bool,
+) -> dict[str, Any]:
+    return {
+        "schema_version": "benchmark_remote_public_artifact_sync_v0",
+        "requested": requested,
+        "attempted": False,
+        "ok": False,
+        "matched_count": 0,
+        "written_count": 0,
+        "blocked_count": 0,
+        "raw_paths_recorded": False,
+        "raw_remote_output_recorded": False,
+        "raw_task_text_read": False,
+        "raw_logs_read": False,
+        "raw_trajectory_read": False,
+        "local_ledger_update": {
+            "requested": ledger_requested,
+            "updated": False,
+            "compact_count": 0,
+            "raw_paths_recorded": False,
+        },
+        "local_aggregate_update": {
+            "requested": aggregate_requested,
+            "updated": False,
+            "raw_paths_recorded": False,
+        },
+    }
+
+
+def _collection_command(
+    *,
+    remote_root: str,
+    artifact_globs: list[str],
+    max_bytes: int,
+) -> str:
+    command = ["python3", "-", remote_root, str(max(1, max_bytes)), *artifact_globs]
+    return (
+        " ".join(shlex.quote(value) for value in command)
+        + " <<'PY'\n"
+        + REMOTE_PUBLIC_ARTIFACT_COLLECTOR.strip()
+        + "\nPY"
+    )
+
+
+def _refresh_ledger_and_aggregate(
+    *,
+    public_artifact_dir: Path,
+    ledger_path: str,
+    run_group_id: str,
+    aggregate_path: str,
+    canonical_case_ids_file: str,
+    benchmark_id: str,
+    target_lane_id: str,
+    target_run_group_contains: list[str],
+    target_backfill_run_group_contains: list[str],
+    repo_root: Path,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    ledger_payload = {
+        "requested": bool(ledger_path),
+        "updated": False,
+        "compact_count": 0,
+        "raw_paths_recorded": False,
+    }
+    aggregate_payload = {
+        "requested": bool(aggregate_path),
+        "updated": False,
+        "raw_paths_recorded": False,
+    }
+    if not ledger_path:
+        return ledger_payload, aggregate_payload
+
+    from ..benchmark_ledger import (
+        build_benchmark_run_ledger_current_aggregate,
+        load_benchmark_run_ledger,
+        update_benchmark_run_ledger,
+    )
+
+    compact_paths = sorted(public_artifact_dir.rglob("benchmark_run.compact.json"))
+    updated = 0
+    skipped = 0
+    for compact_path in compact_paths:
+        compact = json.loads(compact_path.read_text(encoding="utf-8"))
+        if not isinstance(compact, dict):
+            skipped += 1
+            continue
+        update = update_benchmark_run_ledger(
+            ledger_path=Path(ledger_path).expanduser(),
+            benchmark_run=compact,
+            run_group_id=run_group_id or None,
+            notes="remote batch compact/public closeout sync",
+            dry_run=False,
+            cwd=repo_root,
+        )
+        if update.get("updated") is True:
+            updated += 1
+        else:
+            skipped += 1
+    ledger_payload.update(
+        compact_count=len(compact_paths),
+        upserted_count=updated,
+        skipped_count=skipped,
+        updated=bool(updated),
+    )
+
+    if not aggregate_path:
+        return ledger_payload, aggregate_payload
+    canonical_ids = [
+        line.strip()
+        for line in Path(canonical_case_ids_file)
+        .expanduser()
+        .read_text(encoding="utf-8")
+        .splitlines()
+        if line.strip()
+    ]
+    ledger = load_benchmark_run_ledger(Path(ledger_path).expanduser())
+    aggregate = build_benchmark_run_ledger_current_aggregate(
+        ledger,
+        benchmark_id=benchmark_id,
+        canonical_case_ids=canonical_ids,
+        target_lane_id=target_lane_id or None,
+        target_run_group_contains=target_run_group_contains,
+        target_backfill_run_group_contains=target_backfill_run_group_contains,
+    )
+    output = Path(aggregate_path).expanduser()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = output.with_name(output.name + ".tmp")
+    temporary.write_text(
+        json.dumps(aggregate, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    temporary.replace(output)
+    summary = aggregate.get("countable_score_summary")
+    if not isinstance(summary, dict):
+        summary = {}
+    aggregate_payload.update(
+        updated=True,
+        canonical_total=aggregate.get("canonical_total"),
+        countable_case_count=summary.get("countable_case_count"),
+        countable_score_sum=summary.get("countable_score_sum"),
+        countable_score_mean=summary.get("countable_score_mean"),
+        blocked_uncountable_count=len(
+            aggregate.get("blocked_uncountable_case_ids") or []
+        ),
+        runnable_case_count=len(aggregate.get("runnable_case_ids") or []),
+    )
+    return ledger_payload, aggregate_payload
+
+
+def closeout_remote_benchmark_batch(
+    *,
+    run_remote_command: RemoteCommandRunner,
+    remote_root: str,
+    artifact_globs: list[str],
+    local_public_artifact_dir: str | Path,
+    adapter_kind: str,
+    max_bytes: int,
+    sync_timeout_sec: float,
+    ledger_path: str = "",
+    run_group_id: str = "",
+    aggregate_path: str = "",
+    canonical_case_ids_file: str = "",
+    benchmark_id: str = "",
+    target_lane_id: str = "",
+    target_run_group_contains: list[str] | None = None,
+    target_backfill_run_group_contains: list[str] | None = None,
+    repo_root: str | Path = ".",
+) -> dict[str, Any]:
+    requested = bool(remote_root or artifact_globs or local_public_artifact_dir)
+    payload = build_remote_benchmark_closeout_contract(
+        requested=requested,
+        ledger_requested=bool(ledger_path),
+        aggregate_requested=bool(aggregate_path),
+    )
+    if not requested:
+        return payload
+    payload["attempted"] = True
+    try:
+        proc = run_remote_command(
+            _collection_command(
+                remote_root=remote_root,
+                artifact_globs=artifact_globs,
+                max_bytes=max_bytes,
+            ),
+            sync_timeout_sec,
+        )
+    except subprocess.TimeoutExpired:
+        payload["first_blocker"] = "public_artifact_sync_timeout"
+        return payload
+    except OSError:
+        payload["first_blocker"] = "public_artifact_sync_launch_failed"
+        return payload
+    if proc.returncode != 0:
+        payload["first_blocker"] = "public_artifact_sync_remote_exit_nonzero"
+        payload["remote_exit_code"] = proc.returncode
+        return payload
+    try:
+        collected = json.loads((proc.stdout or "").strip().splitlines()[-1])
+    except (IndexError, json.JSONDecodeError):
+        payload["first_blocker"] = "public_artifact_sync_payload_missing"
+        return payload
+    artifacts = collected.get("artifacts") if isinstance(collected, dict) else None
+    if not isinstance(artifacts, list):
+        payload["first_blocker"] = "public_artifact_sync_payload_invalid"
+        return payload
+
+    local_dir = Path(local_public_artifact_dir).expanduser()
+    materialized = materialize_public_benchmark_artifacts(
+        artifacts,
+        output_dir=local_dir,
+        adapter_kind=adapter_kind,
+        max_bytes=max_bytes,
+    )
+    payload.update(
+        matched_count=int(collected.get("matched_count") or 0),
+        written_count=int(materialized.get("written_count") or 0),
+        blocked_count=(
+            int(collected.get("blocked_count") or 0)
+            + int(materialized.get("blocked_count") or 0)
+        ),
+        written_artifact_basenames=materialized.get(
+            "written_artifact_basenames", []
+        ),
+    )
+    if materialized.get("ok") is not True:
+        payload["first_blocker"] = "public_artifact_materialization_failed"
+        payload["blocked_reasons"] = materialized.get("blocked_reasons", {})
+        return payload
+    try:
+        closeout_path = (
+            Path(ledger_path).expanduser().with_suffix(
+                Path(ledger_path).expanduser().suffix + ".closeout"
+            )
+            if ledger_path
+            else None
+        )
+        lock = (
+            exclusive_file_lock(closeout_path)
+            if closeout_path is not None
+            else nullcontext()
+        )
+        with lock:
+            ledger_update, aggregate_update = _refresh_ledger_and_aggregate(
+                public_artifact_dir=local_dir,
+                ledger_path=ledger_path,
+                run_group_id=run_group_id,
+                aggregate_path=aggregate_path,
+                canonical_case_ids_file=canonical_case_ids_file,
+                benchmark_id=benchmark_id,
+                target_lane_id=target_lane_id,
+                target_run_group_contains=list(target_run_group_contains or []),
+                target_backfill_run_group_contains=list(
+                    target_backfill_run_group_contains or []
+                ),
+                repo_root=Path(repo_root),
+            )
+    except (OSError, TimeoutError, ValueError, TypeError, json.JSONDecodeError) as exc:
+        payload["first_blocker"] = "public_artifact_local_closeout_failed"
+        payload["local_closeout_error_type"] = type(exc).__name__[:80]
+        return payload
+    payload["local_ledger_update"] = ledger_update
+    payload["local_aggregate_update"] = aggregate_update
+    if ledger_path and int(ledger_update.get("compact_count") or 0) == 0:
+        payload["first_blocker"] = "benchmark_compact_missing_after_remote_closeout"
+        return payload
+    payload["ok"] = True
+    return payload

--- a/loopx/benchmark_ledger_current.py
+++ b/loopx/benchmark_ledger_current.py
@@ -609,6 +609,14 @@ def build_benchmark_run_ledger_current_aggregate(
     runnable_missing_case_ids = [
         case_id for case_id in missing_case_ids if case_id not in active_id_set
     ]
+    runnable_blocked_uncountable_case_ids = [
+        case_id
+        for case_id in blocked_uncountable_case_ids
+        if case_id not in active_id_set
+    ]
+    runnable_case_ids = sorted(
+        set(runnable_missing_case_ids) | set(runnable_blocked_uncountable_case_ids)
+    )
     standard_case_sets = {
         "schema_version": "benchmark_run_ledger_standard_case_sets_v0",
         "policy": "accepted_numeric_official_scores_blocked_uncountable_infra_missing_elsewhere",
@@ -617,6 +625,10 @@ def build_benchmark_run_ledger_current_aggregate(
         "blocked_uncountable_case_ids": blocked_uncountable_case_ids,
         "active_case_ids": active_ids,
         "runnable_missing_case_ids": runnable_missing_case_ids,
+        "runnable_blocked_uncountable_case_ids": (
+            runnable_blocked_uncountable_case_ids
+        ),
+        "runnable_case_ids": runnable_case_ids,
         "raw_logs_recorded": False,
         "raw_task_text_recorded": False,
         "source_paths_recorded": False,
@@ -654,6 +666,10 @@ def build_benchmark_run_ledger_current_aggregate(
         "blocked_uncountable_case_ids": blocked_uncountable_case_ids,
         "active_case_ids": active_ids,
         "runnable_missing_case_ids": runnable_missing_case_ids,
+        "runnable_blocked_uncountable_case_ids": (
+            runnable_blocked_uncountable_case_ids
+        ),
+        "runnable_case_ids": runnable_case_ids,
         "case_best": case_best,
         "deduped_run_count": len(deduped_run_ids),
         "source_ledger_files": source_ledger_count,

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -4,10 +4,10 @@ set -euo pipefail
 usage() {
   cat <<'EOF'
 Usage:
-  scripts/skillsbench-launch-goal-xhigh.sh [--dry-run] <task-id> [tag] [remote-proxy-port]
+  scripts/skillsbench-launch-goal-xhigh.sh [--dry-run] <task-id[,task-id...]> [tag] [remote-proxy-port]
 
-Launch one SkillsBench task through the host-local Codex CLI /goal route with
-the command/file bridge. Environment-specific values are supplied by env vars.
+Launch one or more SkillsBench tasks through one host-local Codex CLI /goal
+batch with a shared reverse tunnel. Environment-specific values use env vars.
 
 Required env:
   SKILLSBENCH_SSH_DESTINATION          SSH destination for the remote runner
@@ -26,11 +26,21 @@ Optional env:
   SKILLSBENCH_BUILD_STALL_TIMEOUT_SEC  Setup stall timeout, default 3600;
                                        0 disables cap
   SKILLSBENCH_RUN_TIMEOUT_SEC          Supervisor timeout, default 28800
+  SKILLSBENCH_PARALLEL_CASES           Batch concurrency, default 3
+  SKILLSBENCH_BATCH_CASE_START_GAP_SEC Delay between case starts, default 3
   SKILLSBENCH_GOAL_ID                  Local evidence goal id, default loopx-meta
   SKILLSBENCH_RUN_STAMP                Deterministic timestamp override
   SKILLSBENCH_SSH_OPTIONS              Extra ssh options, one shell word each
   SKILLSBENCH_APPEND_HISTORY           Set to 1 to append LoopX history
   SKILLSBENCH_REGISTRY                 Optional registry path for history append
+  SKILLSBENCH_LOCAL_RUN_LEDGER_PATH    Local private live ledger; default below
+                                       the goal's skillsbench-ledgers directory
+  SKILLSBENCH_LOCAL_RUN_LEDGER_SEED    Optional ledger copied when the live
+                                       ledger does not exist yet
+  SKILLSBENCH_CANONICAL_CASE_IDS_FILE  Optional canonical case-id file; enables
+                                       standard aggregate refresh after closeout
+  SKILLSBENCH_STANDARD_AGGREGATE_PATH  Aggregate output path; default beside
+                                       the local live ledger
 EOF
 }
 
@@ -44,11 +54,19 @@ if [[ "${1:-}" == "--dry-run" ]]; then
   shift
 fi
 
-task_id="${1:-}"
-if [[ -z "$task_id" ]]; then
+task_ids_raw="${1:-}"
+if [[ -z "$task_ids_raw" ]]; then
   usage >&2
   exit 2
 fi
+task_ids_normalized="${task_ids_raw//,/ }"
+read -r -a task_ids <<<"$task_ids_normalized"
+if ((${#task_ids[@]} == 0)); then
+  usage >&2
+  exit 2
+fi
+task_id="${task_ids[0]}"
+task_count="${#task_ids[@]}"
 tag="${2:-${SKILLSBENCH_RUN_TAG:-manual}}"
 remote_proxy_port="${3:-${SKILLSBENCH_REMOTE_CODEX_PROXY_PORT:-18180}}"
 
@@ -72,6 +90,9 @@ stamp="${SKILLSBENCH_RUN_STAMP:-$(date +%Y%m%dT%H%M%SCST)}"
 safe_task="${task_id//[^A-Za-z0-9_ -]/-}"
 safe_task="${safe_task// /-}"
 safe_task="${safe_task//_/-}"
+if ((task_count > 1)); then
+  safe_task="batch-${task_count}"
+fi
 
 goal_id="${SKILLSBENCH_GOAL_ID:-loopx-meta}"
 route="${SKILLSBENCH_ROUTE:-codex-cli-goal-baseline}"
@@ -79,6 +100,11 @@ model="${SKILLSBENCH_MODEL:-gpt-5.5}"
 reasoning_effort="${SKILLSBENCH_REASONING_EFFORT:-xhigh}"
 build_stall_timeout="${SKILLSBENCH_BUILD_STALL_TIMEOUT_SEC:-3600}"
 run_timeout="${SKILLSBENCH_RUN_TIMEOUT_SEC:-28800}"
+parallel_cases="${SKILLSBENCH_PARALLEL_CASES:-3}"
+if ((parallel_cases > task_count)); then
+  parallel_cases="$task_count"
+fi
+batch_case_start_gap="${SKILLSBENCH_BATCH_CASE_START_GAP_SEC:-3}"
 local_proxy_host="${SKILLSBENCH_LOCAL_CODEX_PROXY_HOST:-127.0.0.1}"
 local_proxy_port="${SKILLSBENCH_LOCAL_CODEX_PROXY_PORT:-18180}"
 docker_proxy_host="${SKILLSBENCH_DOCKER_PROXY_HOST:-auto}"
@@ -131,6 +157,16 @@ extra_runner_args=()
 if [[ -n "${SKILLSBENCH_REGISTRY:-}" ]]; then
   extra_runner_args+=(--registry "$SKILLSBENCH_REGISTRY")
 fi
+if ((task_count > 1)); then
+  task_ids_csv="$(IFS=,; printf '%s' "${task_ids[*]}")"
+  extra_runner_args+=(
+    --task-ids "$task_ids_csv"
+    --parallel-cases "$parallel_cases"
+    --batch-case-start-gap-sec "$batch_case_start_gap"
+  )
+else
+  extra_runner_args+=(--task-id "$task_id")
+fi
 if [[ "${SKILLSBENCH_APPEND_HISTORY:-0}" == "1" ]]; then
   extra_runner_args+=(--append-history)
 fi
@@ -157,7 +193,6 @@ remote_command=$(
   printf '%q ' \
     --skillsbench-root "$SKILLSBENCH_ROOT" \
     --expected-loopx-git-head "$SKILLSBENCH_EXPECTED_LOOPX_GIT_HEAD" \
-    --task-id "$task_id" \
     --route "$route" \
     --model "$model" \
     --reasoning-effort "$reasoning_effort" \
@@ -193,13 +228,39 @@ supervisor_cmd=(
   --remote-forward "127.0.0.1:${remote_proxy_port}:${local_proxy_host}:${local_proxy_port}"
   --run-timeout-sec "$run_timeout"
   --remote-command "$remote_command"
+  --remote-public-artifact-root "${SKILLSBENCH_REMOTE_ROOT}/.local/private-benchmark-jobs"
+  --remote-public-artifact-glob "${job_name}*/runner_prerequisites.public.json"
+  --remote-public-artifact-glob "${job_name}*/loopx_controller_trace.public.json"
+  --remote-public-artifact-glob "${job_name}*/runner_config.public.json"
+  --remote-public-artifact-glob "${job_name}*/*/benchmark_run.compact.json"
+  --remote-public-artifact-glob "${job_name}*/host_local_acp_relay_traces/*.compact.json"
+  --local-public-artifact-dir "$public_dir"
+  --local-run-ledger-path "${SKILLSBENCH_LOCAL_RUN_LEDGER_PATH:-.local/goals/${goal_id}/skillsbench-ledgers/live-standard-run-ledger.json}"
+  --local-run-group-id "$run_group"
   --private-log-path "${private_dir}/remote-command.log"
   --public-output-path "${public_dir}/supervisor.public.json"
 )
 
+local_run_ledger="${SKILLSBENCH_LOCAL_RUN_LEDGER_PATH:-.local/goals/${goal_id}/skillsbench-ledgers/live-standard-run-ledger.json}"
+if [[ "$dry_run" == "false" && ! -f "$local_run_ledger" && -n "${SKILLSBENCH_LOCAL_RUN_LEDGER_SEED:-}" ]]; then
+  mkdir -p "$(dirname "$local_run_ledger")"
+  cp "$SKILLSBENCH_LOCAL_RUN_LEDGER_SEED" "$local_run_ledger"
+fi
+if [[ -n "${SKILLSBENCH_CANONICAL_CASE_IDS_FILE:-}" ]]; then
+  standard_aggregate="${SKILLSBENCH_STANDARD_AGGREGATE_PATH:-$(dirname "$local_run_ledger")/standard-current-aggregate.json}"
+  supervisor_cmd+=(
+    --local-current-aggregate-path "$standard_aggregate"
+    --local-canonical-case-ids-file "$SKILLSBENCH_CANONICAL_CASE_IDS_FILE"
+    --local-target-lane-id codex-cli-goal-xhigh
+    --local-target-run-group-contains skillsbench-codex-cli-goal-xhigh-
+    --local-target-backfill-run-group-contains skillsbench-codex-cli-goal-xhigh-full87-
+  )
+fi
+
 if [[ "$dry_run" == "true" ]]; then
   printf 'dry_run=true\n'
-  printf 'task_id=%s\n' "$task_id"
+  printf 'task_ids=%s\n' "$(IFS=,; printf '%s' "${task_ids[*]}")"
+  printf 'parallel_cases=%s\n' "$parallel_cases"
   printf 'run_group=%s\n' "$run_group"
   printf 'job_name=%s\n' "$job_name"
   printf 'public_output=%s/supervisor.public.json\n' "$public_dir"
@@ -237,7 +298,8 @@ PY
 
 cat <<EOF
 pid=${pid}
-task_id=${task_id}
+task_ids=$(IFS=,; printf '%s' "${task_ids[*]}")
+parallel_cases=${parallel_cases}
 run_group=${run_group}
 job_name=${job_name}
 public_output=${public_dir}/supervisor.public.json

--- a/scripts/skillsbench_reverse_tunnel_supervisor.py
+++ b/scripts/skillsbench_reverse_tunnel_supervisor.py
@@ -24,6 +24,16 @@ from pathlib import Path
 from typing import Any
 
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.benchmark_core.remote_closeout import (
+    build_remote_benchmark_closeout_contract,
+    closeout_remote_benchmark_batch,
+)
+
+
 SCHEMA_VERSION = "skillsbench_reverse_tunnel_supervisor_v0"
 DEFAULT_REMOTE_FORWARD = "127.0.0.1:18180:127.0.0.1:18180"
 DEFAULT_TEST_HOST = "chatgpt.com"
@@ -507,6 +517,49 @@ def _write_private_log(
     return True
 
 
+def _public_artifact_sync_requested(args: argparse.Namespace) -> bool:
+    return bool(
+        args.remote_public_artifact_root
+        or args.remote_public_artifact_glob
+        or args.local_public_artifact_dir
+    )
+
+
+def _public_artifact_sync_contract(args: argparse.Namespace) -> dict[str, Any]:
+    return build_remote_benchmark_closeout_contract(
+        requested=_public_artifact_sync_requested(args),
+        ledger_requested=bool(args.local_run_ledger_path),
+        aggregate_requested=bool(args.local_current_aggregate_path),
+    )
+
+
+def _sync_remote_public_artifacts(args: argparse.Namespace) -> dict[str, Any]:
+    return closeout_remote_benchmark_batch(
+        run_remote_command=lambda command, timeout: _run_remote_shell_command(
+            args,
+            command,
+            timeout_sec=timeout,
+        ),
+        remote_root=args.remote_public_artifact_root,
+        artifact_globs=list(args.remote_public_artifact_glob or []),
+        local_public_artifact_dir=args.local_public_artifact_dir,
+        adapter_kind=args.public_artifact_adapter_kind,
+        max_bytes=args.public_artifact_max_bytes,
+        sync_timeout_sec=args.public_artifact_sync_timeout_sec,
+        ledger_path=args.local_run_ledger_path,
+        run_group_id=args.local_run_group_id,
+        aggregate_path=args.local_current_aggregate_path,
+        canonical_case_ids_file=args.local_canonical_case_ids_file,
+        benchmark_id=args.local_benchmark_id,
+        target_lane_id=args.local_target_lane_id,
+        target_run_group_contains=list(args.local_target_run_group_contains or []),
+        target_backfill_run_group_contains=list(
+            args.local_target_backfill_run_group_contains or []
+        ),
+        repo_root=REPO_ROOT,
+    )
+
+
 def _size_bucket(value: str) -> str:
     size = len(value.encode("utf-8", errors="replace"))
     if size <= 0:
@@ -734,6 +787,7 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
         "remote_forward": _forward_public_contract(args.remote_forward),
         "json_bridge": _json_bridge_public_contract(args),
         "remote_failure_cleanup": _remote_failure_cleanup_public_contract(args),
+        "public_artifact_sync": _public_artifact_sync_contract(args),
     }
 
     tunnel_proc: subprocess.Popen[Any] | None = None
@@ -878,14 +932,28 @@ def run_supervisor(args: argparse.Namespace) -> tuple[int, dict[str, Any]]:
             stdout_text=stdout_text,
             stderr_text=stderr_text,
         )
-        payload["ok"] = proc.returncode == 0
+        payload["public_artifact_sync"] = _sync_remote_public_artifacts(args)
+        sync_ok = (
+            not _public_artifact_sync_requested(args)
+            or payload["public_artifact_sync"].get("ok") is True
+        )
+        payload["ok"] = proc.returncode == 0 and sync_ok
         if proc.returncode != 0:
             payload["first_blocker"] = "remote_command_exit_nonzero"
             payload["remote_failure_cleanup"] = _run_remote_failure_cleanup(
                 args,
                 trigger="remote_command_exit_nonzero",
             )
-        return finish(0 if proc.returncode == 0 else proc.returncode or 1)
+        elif not sync_ok:
+            payload["first_blocker"] = str(
+                payload["public_artifact_sync"].get("first_blocker")
+                or "public_artifact_sync_failed"
+            )
+        return finish(
+            0
+            if proc.returncode == 0 and sync_ok
+            else proc.returncode or 3
+        )
     except subprocess.TimeoutExpired as exc:
         stdout_text = exc.stdout if isinstance(exc.stdout, str) else ""
         stderr_text = exc.stderr if isinstance(exc.stderr, str) else ""
@@ -1013,6 +1081,68 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--remote-command", default="")
     parser.add_argument("--preflight-only", action="store_true")
     parser.add_argument(
+        "--remote-public-artifact-root",
+        default="",
+        help=(
+            "Private remote root for post-run compact/public artifact collection. "
+            "The path is never written to public output."
+        ),
+    )
+    parser.add_argument(
+        "--remote-public-artifact-glob",
+        action="append",
+        default=[],
+        help=(
+            "Relative compact/public artifact glob below the private remote root. "
+            "May be repeated; raw artifacts are rejected before transport."
+        ),
+    )
+    parser.add_argument(
+        "--local-public-artifact-dir",
+        default="",
+        help=(
+            "Private local destination for synchronized compact/public artifacts. "
+            "The path is never written to public output."
+        ),
+    )
+    parser.add_argument(
+        "--public-artifact-adapter-kind",
+        default="skillsbench",
+    )
+    parser.add_argument(
+        "--public-artifact-max-bytes",
+        type=int,
+        default=2 * 1024 * 1024,
+    )
+    parser.add_argument(
+        "--public-artifact-sync-timeout-sec",
+        type=float,
+        default=60.0,
+    )
+    parser.add_argument(
+        "--local-run-ledger-path",
+        default="",
+        help=(
+            "Optional private local ledger updated from synchronized compact runs. "
+            "The path is never written to public output."
+        ),
+    )
+    parser.add_argument("--local-run-group-id", default="")
+    parser.add_argument("--local-current-aggregate-path", default="")
+    parser.add_argument("--local-canonical-case-ids-file", default="")
+    parser.add_argument("--local-benchmark-id", default="skillsbench@1.1")
+    parser.add_argument("--local-target-lane-id", default="")
+    parser.add_argument(
+        "--local-target-run-group-contains",
+        action="append",
+        default=[],
+    )
+    parser.add_argument(
+        "--local-target-backfill-run-group-contains",
+        action="append",
+        default=[],
+    )
+    parser.add_argument(
         "--private-log-path",
         default=None,
         help="Optional private stdout/stderr capture for the remote command.",
@@ -1038,6 +1168,28 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
             parser.error(
                 "--json-bridge requires "
                 + ", ".join("--" + item.replace("_", "-") for item in missing)
+            )
+    if _public_artifact_sync_requested(args):
+        missing = []
+        if not args.remote_public_artifact_root:
+            missing.append("--remote-public-artifact-root")
+        if not args.remote_public_artifact_glob:
+            missing.append("--remote-public-artifact-glob")
+        if not args.local_public_artifact_dir:
+            missing.append("--local-public-artifact-dir")
+        if missing:
+            parser.error("artifact sync requires " + ", ".join(missing))
+        for pattern in args.remote_public_artifact_glob:
+            parts = Path(pattern).parts
+            if Path(pattern).is_absolute() or ".." in parts:
+                parser.error("--remote-public-artifact-glob must be relative and bounded")
+    if args.local_run_ledger_path and not _public_artifact_sync_requested(args):
+        parser.error("--local-run-ledger-path requires artifact sync")
+    if args.local_current_aggregate_path:
+        if not args.local_run_ledger_path or not args.local_canonical_case_ids_file:
+            parser.error(
+                "--local-current-aggregate-path requires --local-run-ledger-path "
+                "and --local-canonical-case-ids-file"
             )
     return args
 


### PR DESCRIPTION
## Summary

- add an adapter-neutral benchmark closeout path that transports only compact/public artifacts, validates their boundary, and updates a local run ledger plus current aggregate
- make the SkillsBench goal launcher run comma-separated case batches through one reverse tunnel with bounded parallelism
- expose a runnable frontier that includes missing and blocked-uncountable cases while excluding active cases

## Why

Remote benchmark cases could finish without reaching the local standard ledger, leaving manual artifact copy, aggregation, and refill work. This change closes that lifecycle while keeping raw task text, trajectories, logs, credentials, and host paths out of public output. Shared behavior lives in `benchmark_core`; the SkillsBench scripts only wire the adapter-specific launch and artifact patterns.

## Validation

- changed Python modules compile
- focused supervisor, ledger aggregate, egress policy, and batch start-gap smokes pass
- benchmark-core adapter and runner invariant smokes pass
- full SkillsBench benchmark runner smoke passes
- risk-based premerge canary: 9/9 selected checks pass, public boundary scan clean, 0 failures

## Scope

This does not change benchmark scoring, task semantics, leaderboard behavior, submission behavior, permissions, or launch benchmark jobs. The existing remote ledger update remains temporarily compatible; the new local closeout is the migration path for later cleanup.