### PR TITLE
Keep benchmark standard seeds lane-local

### DIFF
--- a/examples/skillsbench-benchmark-egress-policy-smoke.py
+++ b/examples/skillsbench-benchmark-egress-policy-smoke.py
@@ -172,6 +172,7 @@ def test_public_launcher_batches_three_cases_with_closeout_sync() -> None:
             "SKILLSBENCH_EXPECTED_LOOPX_GIT_HEAD": "abc1234",
             "SKILLSBENCH_DOCKER_PROXY_HOST": "host.docker.internal",
             "SKILLSBENCH_RUN_STAMP": "20260710T000000CST",
+            "SKILLSBENCH_CANONICAL_CASE_IDS_FILE": "/opaque/canonical-ids.txt",
         }
     )
     proc = subprocess.run(
@@ -199,6 +200,9 @@ def test_public_launcher_batches_three_cases_with_closeout_sync() -> None:
     assert "--remote-public-artifact-root" in output, output
     assert "benchmark_run.compact.json" in output, output
     assert "--local-run-ledger-path" in output, output
+    assert "--local-target-lane-id codex-cli-goal-xhigh" in output, output
+    assert "--local-target-run-group-contains" not in output, output
+    assert "--local-target-backfill-run-group-contains" not in output, output
 
 
 def test_verifier_proxy_patch_is_required_only_for_existing_verifier() -> None:

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -35,8 +35,9 @@ Optional env:
   SKILLSBENCH_REGISTRY                 Optional registry path for history append
   SKILLSBENCH_LOCAL_RUN_LEDGER_PATH    Local private live ledger; default below
                                        the goal's skillsbench-ledgers directory
-  SKILLSBENCH_LOCAL_RUN_LEDGER_SEED    Optional ledger copied when the live
-                                       ledger does not exist yet
+  SKILLSBENCH_LOCAL_RUN_LEDGER_SEED    Optional accepted-lane ledger copied
+                                       when the live ledger does not exist yet;
+                                       keep unrelated benchmark lanes out
   SKILLSBENCH_CANONICAL_CASE_IDS_FILE  Optional canonical case-id file; enables
                                        standard aggregate refresh after closeout
   SKILLSBENCH_STANDARD_AGGREGATE_PATH  Aggregate output path; default beside
@@ -252,8 +253,6 @@ if [[ -n "${SKILLSBENCH_CANONICAL_CASE_IDS_FILE:-}" ]]; then
     --local-current-aggregate-path "$standard_aggregate"
     --local-canonical-case-ids-file "$SKILLSBENCH_CANONICAL_CASE_IDS_FILE"
     --local-target-lane-id codex-cli-goal-xhigh
-    --local-target-run-group-contains skillsbench-codex-cli-goal-xhigh-
-    --local-target-backfill-run-group-contains skillsbench-codex-cli-goal-xhigh-full87-
   )
 fi
 


### PR DESCRIPTION
## Summary

- treat the local run-ledger seed as an already accepted target-lane ledger
- remove redundant historical run-group filtering from standard aggregate refresh
- retain the target-lane label and add a dry-run regression assertion

## Why

A dedicated accepted-lane seed is the stable source of truth for a long-running benchmark. Reapplying broad historical run-group filters can exclude accepted rows whose legacy group labels differ, recreating count drift after a correct seed has already been selected. Future batches append only their compact closeouts to this lane-local ledger.

## Validation

- SkillsBench egress/launcher, reverse-tunnel closeout, and current-ledger aggregate smokes pass
- risk-based premerge canary: 7/7 checks pass, public boundary clean, 0 failures

This is a launcher cleanup only. It does not change scoring, task semantics, reducer behavior, permissions, submissions, or launch jobs.