### PR TITLE
Extract primary action resolution from interaction contract

### DIFF
--- a/examples/control_plane/primary-action-resolution-parity-smoke.py
+++ b/examples/control_plane/primary-action-resolution-parity-smoke.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Pin quota primary-action resolution across the four main decision paths."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx.control_plane.testing.quota_fixtures import (  # noqa: E402
+    quota_status_payload,
+    quota_todo_item,
+)
+from loopx.quota import build_quota_should_run  # noqa: E402
+
+
+GOAL_ID = "primary-action-resolution-parity"
+AGENT_ID = "codex-side-bypass"
+PRIMARY_AGENT_ID = "codex-main-control"
+
+
+def status_payload(
+    *,
+    agent_items: list[dict[str, Any]],
+    user_items: list[dict[str, Any]] | None = None,
+    quota_state: str = "eligible",
+) -> dict[str, Any]:
+    durable_action = "Keep the durable goal route unchanged."
+    return quota_status_payload(
+        goal_id=GOAL_ID,
+        status="operator_gate" if quota_state == "operator_gate" else "active",
+        recommended_action=durable_action,
+        next_action=durable_action,
+        active_state_next_action=durable_action,
+        agent_todo_items=agent_items,
+        user_todo_items=user_items or [],
+        quota_state=quota_state,
+        project_asset_source="project_asset",
+        coordination={
+            "primary_agent": PRIMARY_AGENT_ID,
+            "registered_agents": [PRIMARY_AGENT_ID, AGENT_ID],
+        },
+        latest_runs=[],
+        registry_status="active",
+    )
+
+
+def signature(payload: dict[str, Any]) -> dict[str, Any]:
+    contract = payload["interaction_contract"]
+    agent_channel = contract["agent_channel"]
+    trace = agent_channel.get("resolution_trace") or {}
+    assert "authoritative_next_action" not in payload, payload
+    return {
+        "decision": payload["decision"],
+        "effective_action": payload["effective_action"],
+        "mode": contract["mode"],
+        "primary_action": agent_channel["primary_action"],
+        "resolution_summary": trace.get("summary"),
+    }
+
+
+def main() -> int:
+    run = build_quota_should_run(
+        status_payload(
+            agent_items=[
+                quota_todo_item(
+                    todo_id="todo_run",
+                    title="Run the bounded implementation slice.",
+                    priority="P1",
+                    claimed_by=AGENT_ID,
+                )
+            ]
+        ),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+    gate = build_quota_should_run(
+        status_payload(
+            agent_items=[],
+            user_items=[
+                quota_todo_item(
+                    todo_id="todo_gate",
+                    title="Approve the external publication boundary.",
+                    role="user",
+                    task_class="user_gate",
+                    blocks_agent=AGENT_ID,
+                )
+            ],
+            quota_state="operator_gate",
+        ),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+    monitor = build_quota_should_run(
+        status_payload(
+            agent_items=[
+                quota_todo_item(
+                    todo_id="todo_monitor",
+                    title="Poll the due monitor.",
+                    priority="P0",
+                    task_class="continuous_monitor",
+                    claimed_by=AGENT_ID,
+                    cadence="15m",
+                    next_due_at="2026-01-01T00:00:00+00:00",
+                )
+            ]
+        ),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+    replan = build_quota_should_run(
+        status_payload(
+            agent_items=[
+                quota_todo_item(
+                    todo_id="todo_future_monitor",
+                    title="Watch the future monitor window.",
+                    priority="P1",
+                    task_class="continuous_monitor",
+                    claimed_by=AGENT_ID,
+                    cadence="15m",
+                    next_due_at="2099-01-01T00:00:00+00:00",
+                )
+            ]
+        ),
+        goal_id=GOAL_ID,
+        agent_id=AGENT_ID,
+    )
+
+    actual = {
+        "run": signature(run),
+        "gate": signature(gate),
+        "monitor": signature(monitor),
+        "replan": signature(replan),
+    }
+    expected = {
+        "run": {
+            "decision": "run",
+            "effective_action": "normal_run",
+            "mode": "bounded_delivery",
+            "primary_action": "todo_run: [P1] Run the bounded implementation slice.",
+            "resolution_summary": "source=agent_lane drift=true",
+        },
+        "gate": {
+            "decision": "skip",
+            "effective_action": "operator_gate_notify",
+            "mode": "user_gate",
+            "primary_action": "wait for user/owner action after surfacing the blocker or gate",
+            "resolution_summary": "source=mode:user_gate drift=true",
+        },
+        "monitor": {
+            "decision": "run",
+            "effective_action": "normal_run",
+            "mode": "bounded_delivery",
+            "primary_action": "todo_monitor: [P0] Poll the due monitor.",
+            "resolution_summary": "source=selected drift=true",
+        },
+        "replan": {
+            "decision": "autonomous_replan_required",
+            "effective_action": "autonomous_replan_required",
+            "mode": "autonomous_replan",
+            "primary_action": (
+                "run one bounded autonomous replan slice around wait quietly for "
+                "material monitor evidence"
+            ),
+            "resolution_summary": "source=mode:autonomous_replan drift=true",
+        },
+    }
+    assert actual == expected, actual
+    print("primary-action-resolution-parity-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/control_plane/agents/agent_lane_recommendation.py
+++ b/loopx/control_plane/agents/agent_lane_recommendation.py
@@ -9,7 +9,7 @@ from ..todos.contract import (
     normalize_todo_id,
 )
 from ..todos.summary_item import compact_todo_summary_item
-from ..work_items.interaction_contract import protocol_action_text
+from ..work_items.primary_action import protocol_action_text
 from ..work_items.work_lane import work_lane_contract_is_due_monitor_attempt
 from .agent_scope import (
     _todo_item_is_actionable_open,

--- a/loopx/control_plane/quota/projection_repair.py
+++ b/loopx/control_plane/quota/projection_repair.py
@@ -12,7 +12,7 @@ from ..todos.projection import (
     todo_item_is_actionable_open,
     todo_item_task_class,
 )
-from ..work_items.interaction_contract import protocol_action_text
+from ..work_items.primary_action import protocol_action_text
 
 
 def open_todo_count(summary: dict[str, Any] | None) -> int:

--- a/loopx/control_plane/quota/selected_todo_projection.py
+++ b/loopx/control_plane/quota/selected_todo_projection.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from ..todos.contract import normalize_todo_id
-from ..work_items.interaction_contract import protocol_action_text
+from ..work_items.primary_action import protocol_action_text
 
 
 SELECTED_TODO_COMPACT_FIELDS = (

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -2,40 +2,25 @@ from __future__ import annotations
 
 from typing import Any
 
-from ...state_projection import next_action_resolution_trace
 from ..agents.agent_scope_frontier import (
     AgentScopeFrontierAction,
     agent_scope_frontier_action as _agent_scope_frontier_action,
 )
 from ..goals.goal_frontier import AUTONOMOUS_REPLAN_REQUIRED_MODE
-from ..todos.contract import TODO_TASK_CLASS_ADVANCEMENT, TODO_TASK_CLASS_MONITOR
-from ..todos.projection import todo_item_is_actionable_open, todo_item_task_class
+from ..todos.contract import TODO_TASK_CLASS_MONITOR
+from ..todos.projection import todo_item_task_class
 from ..todos.user_gate import open_todo_count
+from .primary_action import (
+    build_primary_action_projection,
+    protocol_action_label as _protocol_action_label,
+    protocol_action_text,
+    protocol_first_candidate_action as _protocol_first_candidate_action,
+    protocol_monitor_action as _protocol_monitor_action,
+)
 
 
 INTERACTION_CONTRACT_SCHEMA_VERSION = "loopx_interaction_contract_v0"
 PROTOCOL_ACTION_PACKET_SCHEMA_VERSION = "protocol_action_packet_v0"
-
-
-def protocol_action_text(value: Any, *, limit: int = 220) -> str | None:
-    if value is None:
-        return None
-    text = " ".join(str(value).strip().split())
-    if not text:
-        return None
-    if len(text) <= limit:
-        return text
-    return text[: max(0, limit - 3)].rstrip() + "..."
-
-
-def _protocol_action_label(value: Any, *, limit: int = 80) -> str | None:
-    text = protocol_action_text(value)
-    if not text:
-        return None
-    head, separator, _tail = text.partition(":")
-    if separator and "[" in head and "]" in head and 8 <= len(head) <= limit:
-        return head.strip()
-    return protocol_action_text(text, limit=limit)
 
 
 def _protocol_todo_actions(summary: Any, *, limit: int = 3) -> list[str]:
@@ -103,141 +88,6 @@ def user_channel_action_required(payload: dict[str, Any]) -> bool:
 def attach_user_action_compat_fields(payload: dict[str, Any]) -> None:
     payload["action_required"] = user_channel_action_required(payload)
     payload["open_count"] = open_todo_count(payload.get("user_todo_summary"))
-
-
-def _protocol_first_candidate_action(payload: dict[str, Any]) -> str | None:
-    goal_id = str(payload.get("goal_id") or "")
-    agent_lane_next_action = (
-        payload.get("agent_lane_next_action")
-        if isinstance(payload.get("agent_lane_next_action"), dict)
-        else {}
-    )
-    lane_text = _protocol_action_label(agent_lane_next_action.get("text"))
-    if lane_text:
-        todo_id = str(agent_lane_next_action.get("todo_id") or "").strip()
-        return f"{todo_id}: {lane_text}" if todo_id else lane_text
-    capability_gate = (
-        payload.get("capability_gate")
-        if isinstance(payload.get("capability_gate"), dict)
-        else {}
-    )
-    if capability_gate.get("action") == "run":
-        runnable_candidates = (
-            capability_gate.get("runnable_candidates")
-            if isinstance(capability_gate.get("runnable_candidates"), list)
-            else []
-        )
-        if runnable_candidates:
-            return (
-                f"choose one of {len(runnable_candidates)} "
-                "capability-runnable todo(s) after steering audit"
-            )
-    scoped_fallback = (
-        payload.get("scoped_user_gate_fallback")
-        if isinstance(payload.get("scoped_user_gate_fallback"), dict)
-        else {}
-    )
-    selected = (
-        scoped_fallback.get("selected_executable")
-        if isinstance(scoped_fallback.get("selected_executable"), dict)
-        else {}
-    )
-    text = _protocol_action_label(selected.get("text"))
-    if text:
-        return text
-
-    work_lane = (
-        payload.get("work_lane_contract")
-        if isinstance(payload.get("work_lane_contract"), dict)
-        else {}
-    )
-    if work_lane.get("monitor_kind") == "todo_monitor_due":
-        due_items = (
-            work_lane.get("monitor_due_items")
-            if isinstance(work_lane.get("monitor_due_items"), list)
-            else []
-        )
-        for item in due_items:
-            if not isinstance(item, dict):
-                continue
-            text = _protocol_action_label(item.get("text"))
-            if text:
-                todo_id = str(item.get("todo_id") or "").strip()
-                return f"{todo_id}: {text}" if todo_id else text
-
-    agent_todos = (
-        payload.get("agent_todo_summary")
-        if isinstance(payload.get("agent_todo_summary"), dict)
-        else {}
-    )
-    for key in ("first_executable_items", "first_open_items"):
-        items = agent_todos.get(key) if isinstance(agent_todos.get(key), list) else []
-        for item in items:
-            if not isinstance(item, dict):
-                continue
-            if not todo_item_is_actionable_open(item):
-                continue
-            if todo_item_task_class(item) != TODO_TASK_CLASS_ADVANCEMENT:
-                continue
-            text = _protocol_action_label(item.get("text"))
-            if text:
-                return text
-
-    backlog = (
-        payload.get("autonomous_backlog_candidates")
-        if isinstance(payload.get("autonomous_backlog_candidates"), dict)
-        else {}
-    )
-    items = backlog.get("items") if isinstance(backlog.get("items"), list) else []
-    for item in items:
-        if not isinstance(item, dict):
-            continue
-        if goal_id and str(item.get("goal_id") or "") != goal_id:
-            continue
-        text = _protocol_action_label(item.get("text"))
-        if text:
-            return text
-
-    reason_codes = (
-        work_lane.get("reason_codes")
-        if isinstance(work_lane.get("reason_codes"), list)
-        else []
-    )
-    if "next_action_requires_advancement" in reason_codes:
-        text = protocol_action_text(payload.get("recommended_action"))
-        if text:
-            return text
-    for key in ("action", "obligation"):
-        text = protocol_action_text(work_lane.get(key))
-        if text:
-            return text
-    return protocol_action_text(payload.get("recommended_action"))
-
-
-def _protocol_monitor_action(payload: dict[str, Any]) -> str | None:
-    goal_id = str(payload.get("goal_id") or "")
-    work_lane = (
-        payload.get("work_lane_contract")
-        if isinstance(payload.get("work_lane_contract"), dict)
-        else {}
-    )
-    if work_lane.get("obligation") == "quiet_until_material_monitor_transition":
-        return "quiet until a material monitor transition, regression, or concrete blocker appears"
-    monitors = (
-        payload.get("autonomous_monitor_candidates")
-        if isinstance(payload.get("autonomous_monitor_candidates"), dict)
-        else {}
-    )
-    items = monitors.get("items") if isinstance(monitors.get("items"), list) else []
-    for item in items:
-        if not isinstance(item, dict):
-            continue
-        if goal_id and str(item.get("goal_id") or "") != goal_id:
-            continue
-        text = _protocol_action_label(item.get("text"), limit=160)
-        if text:
-            return text
-    return None
 
 
 def build_protocol_action_packet(payload: dict[str, Any]) -> dict[str, Any]:
@@ -454,87 +304,6 @@ def _interaction_mode(payload: dict[str, Any]) -> str:
     if state in {"waiting", "focus_wait"}:
         return "blocked_wait"
     return "skip"
-
-
-def _interaction_primary_agent_action(payload: dict[str, Any], *, mode: str) -> str:
-    execution_obligation = (
-        payload.get("execution_obligation")
-        if isinstance(payload.get("execution_obligation"), dict)
-        else {}
-    )
-    if mode == "external_evidence_observation":
-        external_observation = (
-            payload.get("external_evidence_observation")
-            if isinstance(payload.get("external_evidence_observation"), dict)
-            else {}
-        )
-        observation_target = protocol_action_text(
-            external_observation.get("observation_target"),
-            limit=220,
-        )
-        if observation_target:
-            return observation_target
-        return (
-            "verify an observable external handle or compact writeback channel; "
-            "write a compact blocker when it is absent"
-        )
-    if mode == "autonomous_replan":
-        lane_action = _protocol_first_candidate_action(payload)
-        if lane_action:
-            return f"run one bounded autonomous replan slice around {lane_action}"
-        return "run one bounded self-repair or replan segment before another quiet no-op"
-    if mode == "monitor_quiet_skip":
-        return "record at most one no-spend monitor-poll event, rerun the guard, then stay quiet if unchanged"
-    if _agent_scope_frontier_action(mode) is not None:
-        agent_scope_frontier = (
-            payload.get("agent_scope_frontier")
-            if isinstance(payload.get("agent_scope_frontier"), dict)
-            else {}
-        )
-        action = protocol_action_text(agent_scope_frontier.get("recommended_action"), limit=260)
-        return action or "stay quiet until this agent has a concrete in-scope runnable todo"
-    if mode == "scoped_user_gate_fallback":
-        return _protocol_first_candidate_action(payload) or (
-            "surface the scoped user gate, then advance one non-gated fallback"
-        )
-    if mode == "bounded_delivery_with_user_notice":
-        return _protocol_first_candidate_action(payload) or "advance one bounded validated segment"
-    if mode == "subagent_orchestration":
-        contract = (
-            payload.get("subagent_orchestration_contract")
-            if isinstance(payload.get("subagent_orchestration_contract"), dict)
-            else {}
-        )
-        lanes = (
-            contract.get("eligible_child_lanes")
-            if isinstance(contract.get("eligible_child_lanes"), list)
-            else []
-        )
-        return (
-            f"spawn/resume child lanes ({len(lanes)} eligible); "
-            "controller reviews returned evidence and writes back accepted state"
-        )
-    if mode in {"user_gate", "user_todo_blocker_push", "user_action_required"}:
-        return "wait for user/owner action after surfacing the blocker or gate"
-    if mode == "outcome_floor_recovery":
-        return "produce the required outcome-floor evidence artifact or write the concrete blocker"
-    if mode == "capability_bridge_repair":
-        return "repair or materialize the missing bridge capability, rewrite the todo, or write a compact blocker"
-    if mode == "side_agent_workspace_repair":
-        return "create or switch to an independent worktree/branch, then rerun quota guard before file edits"
-    if mode == "automation_prompt_upgrade":
-        return "regenerate the installed automation prompt with a registered agent id and scope, then rerun quota guard"
-    if mode == "control_plane_self_repair":
-        return "repair the bounded control-plane/status projection fault exposed by quota"
-    if mode == "boundary_projection_repair":
-        return "repair goal_boundary.write_scope projection before attempting the selected write"
-    if mode == "bounded_delivery":
-        return _protocol_first_candidate_action(payload) or "advance one bounded validated segment"
-    if mode == "mapped_noop_if_unchanged":
-        return "confirm no new instruction/evidence/todo/stale source/safe handoff, then quiet no-op"
-    if execution_obligation.get("contract_obligation"):
-        return str(execution_obligation.get("contract_obligation"))
-    return "do not run delivery work for this goal in this turn"
 
 
 def interaction_next_cli_actions(payload: dict[str, Any], *, mode: str) -> list[str]:
@@ -853,23 +622,12 @@ def _build_interaction_agent_channel(
     delivery_allowed: bool,
     quiet_noop_allowed: bool,
 ) -> dict[str, Any]:
-    primary_action = _interaction_primary_agent_action(payload, mode=mode)
     channel: dict[str, Any] = {
         "must_attempt": must_attempt,
         "delivery_allowed": delivery_allowed,
         "quiet_noop_allowed": quiet_noop_allowed,
-        "primary_action": primary_action,
     }
-    resolution_trace = next_action_resolution_trace(
-        primary_action=primary_action,
-        mode=mode,
-        active_state_next_action=payload.get("active_state_next_action"),
-        latest_run_recommended_action=payload.get("latest_run_recommended_action"),
-        selected_recommended_action=payload.get("recommended_action"),
-        agent_lane_next_action=payload.get("agent_lane_next_action"),
-    )
-    if resolution_trace:
-        channel["resolution_trace"] = resolution_trace
+    channel.update(build_primary_action_projection(payload, mode=mode))
     return channel
 
 

--- a/loopx/control_plane/work_items/primary_action.py
+++ b/loopx/control_plane/work_items/primary_action.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+from typing import Any
+
+from ...state_projection import next_action_resolution_trace
+from ..agents.agent_scope_frontier import (
+    agent_scope_frontier_action as _agent_scope_frontier_action,
+)
+from ..todos.contract import TODO_TASK_CLASS_ADVANCEMENT
+from ..todos.projection import todo_item_is_actionable_open, todo_item_task_class
+
+
+def protocol_action_text(value: Any, *, limit: int = 220) -> str | None:
+    if value is None:
+        return None
+    text = " ".join(str(value).strip().split())
+    if not text:
+        return None
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 3)].rstrip() + "..."
+
+
+def protocol_action_label(value: Any, *, limit: int = 80) -> str | None:
+    text = protocol_action_text(value)
+    if not text:
+        return None
+    head, separator, _tail = text.partition(":")
+    if separator and "[" in head and "]" in head and 8 <= len(head) <= limit:
+        return head.strip()
+    return protocol_action_text(text, limit=limit)
+
+
+def protocol_first_candidate_action(payload: dict[str, Any]) -> str | None:
+    goal_id = str(payload.get("goal_id") or "")
+    agent_lane_next_action = (
+        payload.get("agent_lane_next_action")
+        if isinstance(payload.get("agent_lane_next_action"), dict)
+        else {}
+    )
+    lane_text = protocol_action_label(agent_lane_next_action.get("text"))
+    if lane_text:
+        todo_id = str(agent_lane_next_action.get("todo_id") or "").strip()
+        return f"{todo_id}: {lane_text}" if todo_id else lane_text
+    capability_gate = (
+        payload.get("capability_gate")
+        if isinstance(payload.get("capability_gate"), dict)
+        else {}
+    )
+    if capability_gate.get("action") == "run":
+        runnable_candidates = (
+            capability_gate.get("runnable_candidates")
+            if isinstance(capability_gate.get("runnable_candidates"), list)
+            else []
+        )
+        if runnable_candidates:
+            return (
+                f"choose one of {len(runnable_candidates)} "
+                "capability-runnable todo(s) after steering audit"
+            )
+    scoped_fallback = (
+        payload.get("scoped_user_gate_fallback")
+        if isinstance(payload.get("scoped_user_gate_fallback"), dict)
+        else {}
+    )
+    selected = (
+        scoped_fallback.get("selected_executable")
+        if isinstance(scoped_fallback.get("selected_executable"), dict)
+        else {}
+    )
+    text = protocol_action_label(selected.get("text"))
+    if text:
+        return text
+
+    work_lane = (
+        payload.get("work_lane_contract")
+        if isinstance(payload.get("work_lane_contract"), dict)
+        else {}
+    )
+    if work_lane.get("monitor_kind") == "todo_monitor_due":
+        due_items = (
+            work_lane.get("monitor_due_items")
+            if isinstance(work_lane.get("monitor_due_items"), list)
+            else []
+        )
+        for item in due_items:
+            if not isinstance(item, dict):
+                continue
+            text = protocol_action_label(item.get("text"))
+            if text:
+                todo_id = str(item.get("todo_id") or "").strip()
+                return f"{todo_id}: {text}" if todo_id else text
+
+    agent_todos = (
+        payload.get("agent_todo_summary")
+        if isinstance(payload.get("agent_todo_summary"), dict)
+        else {}
+    )
+    for key in ("first_executable_items", "first_open_items"):
+        items = agent_todos.get(key) if isinstance(agent_todos.get(key), list) else []
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            if not todo_item_is_actionable_open(item):
+                continue
+            if todo_item_task_class(item) != TODO_TASK_CLASS_ADVANCEMENT:
+                continue
+            text = protocol_action_label(item.get("text"))
+            if text:
+                return text
+
+    backlog = (
+        payload.get("autonomous_backlog_candidates")
+        if isinstance(payload.get("autonomous_backlog_candidates"), dict)
+        else {}
+    )
+    items = backlog.get("items") if isinstance(backlog.get("items"), list) else []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if goal_id and str(item.get("goal_id") or "") != goal_id:
+            continue
+        text = protocol_action_label(item.get("text"))
+        if text:
+            return text
+
+    reason_codes = (
+        work_lane.get("reason_codes")
+        if isinstance(work_lane.get("reason_codes"), list)
+        else []
+    )
+    if "next_action_requires_advancement" in reason_codes:
+        text = protocol_action_text(payload.get("recommended_action"))
+        if text:
+            return text
+    for key in ("action", "obligation"):
+        text = protocol_action_text(work_lane.get(key))
+        if text:
+            return text
+    return protocol_action_text(payload.get("recommended_action"))
+
+
+def protocol_monitor_action(payload: dict[str, Any]) -> str | None:
+    goal_id = str(payload.get("goal_id") or "")
+    work_lane = (
+        payload.get("work_lane_contract")
+        if isinstance(payload.get("work_lane_contract"), dict)
+        else {}
+    )
+    if work_lane.get("obligation") == "quiet_until_material_monitor_transition":
+        return "quiet until a material monitor transition, regression, or concrete blocker appears"
+    monitors = (
+        payload.get("autonomous_monitor_candidates")
+        if isinstance(payload.get("autonomous_monitor_candidates"), dict)
+        else {}
+    )
+    items = monitors.get("items") if isinstance(monitors.get("items"), list) else []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if goal_id and str(item.get("goal_id") or "") != goal_id:
+            continue
+        text = protocol_action_label(item.get("text"), limit=160)
+        if text:
+            return text
+    return None
+
+
+def resolve_primary_agent_action(payload: dict[str, Any], *, mode: str) -> str:
+    execution_obligation = (
+        payload.get("execution_obligation")
+        if isinstance(payload.get("execution_obligation"), dict)
+        else {}
+    )
+    if mode == "external_evidence_observation":
+        external_observation = (
+            payload.get("external_evidence_observation")
+            if isinstance(payload.get("external_evidence_observation"), dict)
+            else {}
+        )
+        observation_target = protocol_action_text(
+            external_observation.get("observation_target"),
+            limit=220,
+        )
+        if observation_target:
+            return observation_target
+        return (
+            "verify an observable external handle or compact writeback channel; "
+            "write a compact blocker when it is absent"
+        )
+    if mode == "autonomous_replan":
+        lane_action = protocol_first_candidate_action(payload)
+        if lane_action:
+            return f"run one bounded autonomous replan slice around {lane_action}"
+        return "run one bounded self-repair or replan segment before another quiet no-op"
+    if mode == "monitor_quiet_skip":
+        return "record at most one no-spend monitor-poll event, rerun the guard, then stay quiet if unchanged"
+    if _agent_scope_frontier_action(mode) is not None:
+        agent_scope_frontier = (
+            payload.get("agent_scope_frontier")
+            if isinstance(payload.get("agent_scope_frontier"), dict)
+            else {}
+        )
+        action = protocol_action_text(agent_scope_frontier.get("recommended_action"), limit=260)
+        return action or "stay quiet until this agent has a concrete in-scope runnable todo"
+    if mode == "scoped_user_gate_fallback":
+        return protocol_first_candidate_action(payload) or (
+            "surface the scoped user gate, then advance one non-gated fallback"
+        )
+    if mode == "bounded_delivery_with_user_notice":
+        return protocol_first_candidate_action(payload) or "advance one bounded validated segment"
+    if mode == "subagent_orchestration":
+        contract = (
+            payload.get("subagent_orchestration_contract")
+            if isinstance(payload.get("subagent_orchestration_contract"), dict)
+            else {}
+        )
+        lanes = (
+            contract.get("eligible_child_lanes")
+            if isinstance(contract.get("eligible_child_lanes"), list)
+            else []
+        )
+        return (
+            f"spawn/resume child lanes ({len(lanes)} eligible); "
+            "controller reviews returned evidence and writes back accepted state"
+        )
+    if mode in {"user_gate", "user_todo_blocker_push", "user_action_required"}:
+        return "wait for user/owner action after surfacing the blocker or gate"
+    if mode == "outcome_floor_recovery":
+        return "produce the required outcome-floor evidence artifact or write the concrete blocker"
+    if mode == "capability_bridge_repair":
+        return "repair or materialize the missing bridge capability, rewrite the todo, or write a compact blocker"
+    if mode == "side_agent_workspace_repair":
+        return "create or switch to an independent worktree/branch, then rerun quota guard before file edits"
+    if mode == "automation_prompt_upgrade":
+        return "regenerate the installed automation prompt with a registered agent id and scope, then rerun quota guard"
+    if mode == "control_plane_self_repair":
+        return "repair the bounded control-plane/status projection fault exposed by quota"
+    if mode == "boundary_projection_repair":
+        return "repair goal_boundary.write_scope projection before attempting the selected write"
+    if mode == "bounded_delivery":
+        return protocol_first_candidate_action(payload) or "advance one bounded validated segment"
+    if mode == "mapped_noop_if_unchanged":
+        return "confirm no new instruction/evidence/todo/stale source/safe handoff, then quiet no-op"
+    if execution_obligation.get("contract_obligation"):
+        return str(execution_obligation.get("contract_obligation"))
+    return "do not run delivery work for this goal in this turn"
+
+
+def build_primary_action_projection(payload: dict[str, Any], *, mode: str) -> dict[str, Any]:
+    primary_action = resolve_primary_agent_action(payload, mode=mode)
+    projection: dict[str, Any] = {"primary_action": primary_action}
+    resolution_trace = next_action_resolution_trace(
+        primary_action=primary_action,
+        mode=mode,
+        active_state_next_action=payload.get("active_state_next_action"),
+        latest_run_recommended_action=payload.get("latest_run_recommended_action"),
+        selected_recommended_action=payload.get("recommended_action"),
+        agent_lane_next_action=payload.get("agent_lane_next_action"),
+    )
+    if resolution_trace:
+        projection["resolution_trace"] = resolution_trace
+    return projection

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -40,8 +40,10 @@ from .control_plane.work_items.interaction_contract import (
     attach_user_action_compat_fields,
     build_interaction_contract,
     build_protocol_action_packet,
-    protocol_action_text as _protocol_action_text,
     user_channel_action_required as _user_channel_action_required,
+)
+from .control_plane.work_items.primary_action import (
+    protocol_action_text as _protocol_action_text,
 )
 from .control_plane.goals.goal_frontier import (
     AUTONOMOUS_REPLAN_REQUIRED_MODE,


### PR DESCRIPTION
## Summary
- characterize the existing run, gate, due-monitor, and autonomous-replan action resolution paths with exact quota-output parity fixtures
- extract primary-action resolution from the oversized interaction-contract module into the work-items bounded context
- keep `interaction_contract.agent_channel.primary_action` as the sole executable agent entry, with only the existing compact `resolution_trace` beside it

## Architecture
This is a behavior-preserving extraction. It adds no protocol fields, aliases, compatibility wrappers, or speculative extension points. Existing callers now import the resolver from its bounded-context module, while the interaction-contract builder remains responsible for assembling the public packet.

## Validation
- `python3 -m py_compile` on all changed Python paths
- `python3 examples/control_plane/primary-action-resolution-parity-smoke.py`
- `python3 examples/control_plane/interaction-contract-state-machine-smoke.py`
- `python3 examples/control_plane/control-plane-risk-characterization-smoke.py`
- `python3 examples/protocol/protocol-action-packet-smoke.py`
- `python3 examples/project/next-action-projection-contract-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `loopx check` on all changed paths
- `git diff --check`

## Pre-merge gate
`loopx canary premerge --from-git-diff` passed 16/17 selected checks: all direct checks, 7/8 catalog canaries, 8/8 risk-profile smokes, and the public-boundary scan passed. The sole failure is the existing main-branch `heartbeat_prompt_json` interface budget (31 top-level keys vs budget 30), reproduced unchanged on clean `origin/main`. This PR does not widen that budget or mix in the separate repair.

Because this touches quota/control-plane runtime behavior and the repository gate remains red on that baseline issue, this PR is intentionally left for separate review rather than self-merged.