### PR TITLE
Keep issue-fix domain receipts truthful

### DIFF
--- a/examples/issue-fix-feasibility-smoke.py
+++ b/examples/issue-fix-feasibility-smoke.py
@@ -154,6 +154,10 @@ def main() -> int:
         assert ledger.exists(), ledger
         rows = ledger.read_text(encoding="utf-8").splitlines()
         assert len(rows) == 1, rows
+        first_row = json.loads(rows[0])
+        first_projection = first_row["domain_state_projection"]
+        assert first_projection["write_performed"] is True, first_row
+        assert "write_result" not in first_projection, first_row
 
         second_command = command.copy()
         second_command[second_command.index("confirmed")] = "missing"
@@ -174,7 +178,11 @@ def main() -> int:
         assert second_packet["decision"]["route"] == "comment_only", second_packet
         rows = ledger.read_text(encoding="utf-8").splitlines()
         assert len(rows) == 1, rows
-        assert json.loads(rows[0])["decision"]["route"] == "comment_only", rows
+        second_row = json.loads(rows[0])
+        assert second_row["decision"]["route"] == "comment_only", rows
+        second_projection = second_row["domain_state_projection"]
+        assert second_projection["write_performed"] is True, second_row
+        assert "write_result" not in second_projection, second_row
 
     print("issue-fix-feasibility-smoke: ok")
     return 0

--- a/examples/issue-fix-pr-lifecycle-smoke.py
+++ b/examples/issue-fix-pr-lifecycle-smoke.py
@@ -214,6 +214,13 @@ def main() -> int:
         assert cli_packet["domain_state_projection"]["write_performed"] is True
         write_result = cli_packet["domain_state_projection"]["write_result"]
         assert write_result["path_recorded"] is False, write_result
+        persisted_rows = [
+            json.loads(line) for line in ledger.read_text(encoding="utf-8").splitlines()
+        ]
+        assert len(persisted_rows) == 1, persisted_rows
+        persisted_projection = persisted_rows[0]["domain_state_projection"]
+        assert persisted_projection["write_performed"] is True, persisted_rows[0]
+        assert "write_result" not in persisted_projection, persisted_rows[0]
         assert_public_safe(cli_packet)
 
     print("issue-fix-pr-lifecycle-smoke: ok")

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -466,14 +466,10 @@ def handle_issue_fix_command(
                         goal_id=args.goal_id,
                     )
                 )
-                write_result = upsert_issue_fix_feasibility_ledger_jsonl(
+                upsert_issue_fix_feasibility_ledger_jsonl(
                     ledger_path,
                     payload,
                 )
-                domain_state = payload.get("domain_state_projection")
-                if isinstance(domain_state, dict):
-                    domain_state["write_performed"] = True
-                    domain_state["write_result"] = write_result
             else:
                 domain_state = payload.get("domain_state_projection")
                 if isinstance(domain_state, dict) and not args.no_write_domain_state:
@@ -507,14 +503,10 @@ def handle_issue_fix_command(
                         goal_id=args.goal_id,
                     )
                 )
-                write_result = upsert_issue_fix_pr_lifecycle_ledger_jsonl(
+                upsert_issue_fix_pr_lifecycle_ledger_jsonl(
                     ledger_path,
                     payload,
                 )
-                domain_state = payload.get("domain_state_projection")
-                if isinstance(domain_state, dict):
-                    domain_state["write_performed"] = True
-                    domain_state["write_result"] = write_result
             else:
                 domain_state = payload.get("domain_state_projection")
                 if isinstance(domain_state, dict) and not args.no_write_domain_state:

--- a/loopx/domain_packs/issue_fix.py
+++ b/loopx/domain_packs/issue_fix.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -8,6 +9,34 @@ from ..domain_state import default_domain_state_file_path, upsert_domain_state_j
 
 ISSUE_FIX_DOMAIN_STATE_LEDGER_FILENAME = "pr-lifecycle.jsonl"
 ISSUE_FIX_FEASIBILITY_LEDGER_FILENAME = "feasibility.jsonl"
+
+
+def _upsert_issue_fix_payload(
+    ledger_path: str | Path,
+    payload: dict[str, Any],
+    *,
+    key: dict[str, Any],
+    existing_key_fn: Callable[[dict[str, Any]], dict[str, Any] | None],
+) -> dict[str, Any]:
+    projection = payload.get("domain_state_projection")
+    if not isinstance(projection, dict):
+        raise ValueError("issue-fix payload must include domain_state_projection")
+
+    projection.pop("write_result", None)
+    projection.pop("write_skipped_reason", None)
+    projection["write_performed"] = True
+    try:
+        result = upsert_domain_state_jsonl(
+            ledger_path,
+            payload,
+            key=key,
+            existing_key_fn=existing_key_fn,
+        )
+    except Exception:
+        projection["write_performed"] = False
+        raise
+    projection["write_result"] = result
+    return result
 
 
 def issue_fix_feasibility_ledger_key(payload: dict[str, Any]) -> dict[str, Any]:
@@ -41,7 +70,7 @@ def upsert_issue_fix_feasibility_ledger_jsonl(
     ):
         if payload.get(key) is not False:
             raise ValueError(f"issue-fix domain-state payload must keep {key}=false")
-    return upsert_domain_state_jsonl(
+    return _upsert_issue_fix_payload(
         ledger_path,
         payload,
         key=issue_fix_feasibility_ledger_key(payload),
@@ -80,7 +109,7 @@ def upsert_issue_fix_pr_lifecycle_ledger_jsonl(
     ):
         if payload.get(key) is not False:
             raise ValueError(f"issue-fix domain-state payload must keep {key}=false")
-    return upsert_domain_state_jsonl(
+    return _upsert_issue_fix_payload(
         ledger_path,
         payload,
         key=issue_fix_pr_lifecycle_ledger_key(payload),


### PR DESCRIPTION
## Summary
- make issue-fix domain-state writers persist `write_performed=true` in the decision row when the atomic upsert succeeds
- keep the local `write_result` receipt in the CLI response only, not in the compact JSONL decision row
- centralize the rule for feasibility and PR-lifecycle writers and remove post-write CLI mutation

## Root cause
The CLI persisted the packet while `domain_state_projection.write_performed` was still `false`, then changed only the in-memory response to `true` after the upsert. The ledger and command response therefore contradicted each other.

## Validation
- `python3 examples/issue-fix-feasibility-smoke.py`
- `python3 examples/issue-fix-pr-lifecycle-smoke.py`
- `loopx canary premerge --from-git-diff`: 6/6 selected checks passed; merge gate and self-merge eligibility true
- changed-path public boundary scan: 0 errors, 0 warnings
- Python compile and diff checks passed

## Architecture
The domain-pack writer now owns receipt consistency for every caller. It prepares the truthful projection before the atomic write, restores the in-memory flag if the write raises, and attaches the operational receipt only after success. No schema version, raw path, or external-write behavior changes.