### PR TITLE
Fix review-only side-agent continuation closeout

### DIFF
--- a/examples/control_plane/side-agent-self-iteration-state-machine-smoke.py
+++ b/examples/control_plane/side-agent-self-iteration-state-machine-smoke.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import json
 import sys
 import tempfile
 from pathlib import Path
@@ -128,6 +129,11 @@ def write_existing_successor_fixture(
     *,
     successor_todo_id: str,
     successor_claimed_by: str,
+    source_action_kind: str = "state_machine_canary_refactor",
+    source_blocks_agent: str | None = None,
+    source_required_write_scope: str | None = None,
+    successor_action_kind: str = "primary_review",
+    handoff_agent: str | None = None,
 ) -> tuple[Path, Path, Path]:
     project = root / "project"
     runtime = root / "runtime"
@@ -135,6 +141,15 @@ def write_existing_successor_fixture(
     state_path = project / state_file
     registry_path = project / ".loopx" / "registry.json"
     state_path.parent.mkdir(parents=True)
+    source_metadata = (
+        f"todo_id={EXISTING_SUCCESSOR_START_TODO_ID} status=open "
+        f"task_class=advancement_task action_kind={source_action_kind} "
+        f"claimed_by={AGENT_ID}"
+    )
+    if source_blocks_agent:
+        source_metadata += f" blocks_agent={source_blocks_agent}"
+    if source_required_write_scope:
+        source_metadata += f" required_write_scopes={source_required_write_scope}"
     state_path.write_text(
         "---\n"
         "status: active\n"
@@ -149,12 +164,10 @@ def write_existing_successor_fixture(
         f"- {GOAL_NEXT_ACTION}\n\n"
         "## Agent Todo\n\n"
         f"- [ ] [P1] {EXISTING_SUCCESSOR_START_TEXT}\n"
-        f"  <!-- loopx:todo todo_id={EXISTING_SUCCESSOR_START_TODO_ID} status=open "
-        "task_class=advancement_task action_kind=state_machine_canary_refactor "
-        f"claimed_by={AGENT_ID} -->\n"
+        f"  <!-- loopx:todo {source_metadata} -->\n"
         f"- [ ] [P1] {EXISTING_SUCCESSOR_HANDOFF_TEXT}\n"
         f"  <!-- loopx:todo todo_id={successor_todo_id} status=open "
-        "task_class=advancement_task action_kind=primary_review "
+        f"task_class=advancement_task action_kind={successor_action_kind} "
         f"claimed_by={successor_claimed_by} -->\n",
         encoding="utf-8",
     )
@@ -164,6 +177,13 @@ def write_existing_successor_fixture(
         registry_path=registry_path,
         adapter_kind="side_agent_existing_successor_fixture_v0",
     )
+    if handoff_agent:
+        registry = json.loads(registry_path.read_text(encoding="utf-8"))
+        registry["goals"][0]["coordination"]["side_agent_handoff_agent"] = handoff_agent
+        registry_path.write_text(
+            json.dumps(registry, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
     return project, runtime, registry_path
 
 
@@ -463,6 +483,8 @@ def assert_same_agent_existing_successor_still_requires_self_merge_or_handoff() 
             Path(tmp),
             successor_todo_id=EXISTING_SUCCESSOR_SAME_AGENT_TODO_ID,
             successor_claimed_by=AGENT_ID,
+            successor_action_kind="state_machine_followup",
+            handoff_agent=AGENT_ID,
         )
 
         returncode, rejected = run_cli_result(
@@ -484,7 +506,95 @@ def assert_same_agent_existing_successor_still_requires_self_merge_or_handoff() 
             runtime=runtime,
         )
         assert returncode != 0, rejected
-        assert "handoff_agent='codex-main-control'" in rejected["error"], rejected
+        assert "handoff_agent='codex-product-capability'" in rejected["error"], rejected
+        assert "--side-agent-self-merged" in rejected["error"], rejected
+
+
+def assert_review_only_gate_can_continue_with_same_agent_successor() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-side-agent-review-continuation-") as tmp:
+        _project, runtime, registry_path = write_existing_successor_fixture(
+            Path(tmp),
+            successor_todo_id=EXISTING_SUCCESSOR_SAME_AGENT_TODO_ID,
+            successor_claimed_by=AGENT_ID,
+            source_action_kind="pilot_readiness_review",
+            source_blocks_agent=PRIMARY_AGENT_ID,
+            successor_action_kind="pilot_followup",
+            handoff_agent=AGENT_ID,
+        )
+
+        returncode, rejected = run_cli_result(
+            "todo",
+            "complete",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            EXISTING_SUCCESSOR_START_TODO_ID,
+            "--claimed-by",
+            AGENT_ID,
+            "--evidence",
+            "independent read-only readiness review passed",
+            "--next-agent-todo",
+            "Generate an unlinked same-agent continuation.",
+            registry_path=registry_path,
+            runtime=runtime,
+        )
+        assert returncode != 0, rejected
+        assert "--successor-todo-id" in rejected["error"], rejected
+
+        completed = run_cli(
+            "todo",
+            "complete",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--todo-id",
+            EXISTING_SUCCESSOR_START_TODO_ID,
+            "--claimed-by",
+            AGENT_ID,
+            "--evidence",
+            "independent read-only readiness review passed",
+            "--successor-todo-id",
+            EXISTING_SUCCESSOR_SAME_AGENT_TODO_ID,
+            registry_path=registry_path,
+            runtime=runtime,
+        )
+        assert completed["ok"] is True, completed
+        assert completed["side_agent_self_merged"] is False, completed
+        assert completed["linked_handoff_successor_id"] == EXISTING_SUCCESSOR_SAME_AGENT_TODO_ID, (
+            completed
+        )
+
+    with tempfile.TemporaryDirectory(prefix="loopx-side-agent-review-write-scope-") as tmp:
+        _project, runtime, registry_path = write_existing_successor_fixture(
+            Path(tmp),
+            successor_todo_id=EXISTING_SUCCESSOR_SAME_AGENT_TODO_ID,
+            successor_claimed_by=AGENT_ID,
+            source_action_kind="pilot_readiness_review",
+            source_blocks_agent=PRIMARY_AGENT_ID,
+            source_required_write_scope="loopx/**",
+            successor_action_kind="pilot_followup",
+            handoff_agent=AGENT_ID,
+        )
+        returncode, rejected = run_cli_result(
+            "todo",
+            "complete",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--todo-id",
+            EXISTING_SUCCESSOR_START_TODO_ID,
+            "--claimed-by",
+            AGENT_ID,
+            "--evidence",
+            "review included repository delivery",
+            "--successor-todo-id",
+            EXISTING_SUCCESSOR_SAME_AGENT_TODO_ID,
+            registry_path=registry_path,
+            runtime=runtime,
+        )
+        assert returncode != 0, rejected
         assert "--side-agent-self-merged" in rejected["error"], rejected
 
 
@@ -539,6 +649,7 @@ def main() -> int:
     assert_self_iteration_flow()
     assert_existing_handoff_successor_flow()
     assert_same_agent_existing_successor_still_requires_self_merge_or_handoff()
+    assert_review_only_gate_can_continue_with_same_agent_successor()
     assert_capability_fallback_preserves_frontier_and_scheduler()
     print("side-agent-self-iteration-state-machine-smoke ok")
     return 0

--- a/loopx/control_plane/todos/completion_policy.py
+++ b/loopx/control_plane/todos/completion_policy.py
@@ -11,7 +11,7 @@ from ...agent_registry import (
     require_registered_agent_id,
     side_agent_handoff_agent_id_from_registry,
 )
-from .contract import normalize_todo_claimed_by
+from .contract import normalize_todo_blocks_agent, normalize_todo_claimed_by
 
 
 @dataclass(frozen=True)
@@ -39,6 +39,15 @@ class CompletionPolicy:
 def is_primary_review_action_kind(value: Any) -> bool:
     action_kind = str(value or "").strip()
     return action_kind == "primary_review" or action_kind.startswith("primary_review_")
+
+
+def is_review_only_action_kind(value: Any) -> bool:
+    action_kind = str(value or "").strip()
+    if not action_kind or is_primary_review_action_kind(action_kind):
+        return False
+    return action_kind in {"review", "verification"} or action_kind.endswith(
+        ("_review", "_verification")
+    )
 
 
 def linked_successor_from_todo(todo: Mapping[str, Any]) -> LinkedSuccessor:
@@ -72,6 +81,43 @@ def _linked_handoff_successor_id(
         if successor.todo_id:
             return successor.todo_id
     return None
+
+
+def _linked_same_agent_review_successor_id(
+    *,
+    successors: Iterable[LinkedSuccessor],
+    completing_agent: str | None,
+) -> str | None:
+    if not completing_agent:
+        return None
+    for successor in successors:
+        if successor.role != "agent":
+            continue
+        if successor.status and successor.status != "open":
+            continue
+        if successor.claimed_by != completing_agent:
+            continue
+        if is_primary_review_action_kind(successor.action_kind):
+            continue
+        if successor.todo_id:
+            return successor.todo_id
+    return None
+
+
+def _allows_same_agent_review_continuation(
+    *,
+    completion_todo: Mapping[str, Any] | None,
+    completing_agent: str | None,
+    evidence: str | None,
+) -> bool:
+    if not completion_todo or not completing_agent or not str(evidence or "").strip():
+        return False
+    if not is_review_only_action_kind(completion_todo.get("action_kind")):
+        return False
+    if completion_todo.get("required_write_scopes"):
+        return False
+    blocked_agent = normalize_todo_blocks_agent(completion_todo.get("blocks_agent"))
+    return bool(blocked_agent and blocked_agent != completing_agent)
 
 
 def _goal_allows_role_workflow_successors(registry_path: Path, goal_id: str) -> bool:
@@ -125,7 +171,9 @@ def resolve_completion_policy(
     side_agent_self_merged: bool = False,
     evidence: str | None = None,
     linked_successors: Iterable[LinkedSuccessor] = (),
+    completion_todo: Mapping[str, Any] | None = None,
 ) -> CompletionPolicy:
+    linked_successor_items = list(linked_successors)
     effective_claimed_by = (
         require_registered_agent_id(
             registry_path=registry_path,
@@ -170,9 +218,27 @@ def resolve_completion_policy(
         effective_claimed_by and primary_agent and effective_claimed_by != primary_agent
     )
     linked_handoff_successor_id = _linked_handoff_successor_id(
-        successors=linked_successors,
+        successors=linked_successor_items,
         handoff_agent=handoff_agent,
         completing_agent=effective_claimed_by,
+    )
+    same_agent_review_candidate = bool(
+        side_agent_completion
+        and handoff_agent == effective_claimed_by
+        and not next_agent_todo
+        and _allows_same_agent_review_continuation(
+            completion_todo=completion_todo,
+            completing_agent=effective_claimed_by,
+            evidence=evidence,
+        )
+    )
+    if same_agent_review_candidate and not linked_handoff_successor_id:
+        linked_handoff_successor_id = _linked_same_agent_review_successor_id(
+            successors=linked_successor_items,
+            completing_agent=effective_claimed_by,
+        )
+    same_agent_review_continuation = bool(
+        same_agent_review_candidate and linked_handoff_successor_id
     )
     if (
         side_agent_completion
@@ -180,7 +246,7 @@ def resolve_completion_policy(
         and _goal_allows_role_workflow_successors(registry_path, goal_id)
     ):
         linked_handoff_successor_id = _linked_role_workflow_successor_id(
-            successors=linked_successors,
+            successors=linked_successor_items,
             registered_agents=registered_agents,
             completing_agent=effective_claimed_by,
         )
@@ -208,11 +274,17 @@ def resolve_completion_policy(
                 "or --side-agent-self-merged "
                 "with --evidence for a small validated self-merge"
             )
-        if not side_agent_self_merged and handoff_agent == effective_claimed_by:
+        if (
+            not side_agent_self_merged
+            and handoff_agent == effective_claimed_by
+            and not same_agent_review_continuation
+        ):
             raise ValueError(
                 "side-agent handoff todo cannot be claimed by the completing side agent; "
                 "use --side-agent-self-merged with --evidence for same-agent delivery, "
-                "or configure side_agent_handoff_agent to another registered agent"
+                "configure side_agent_handoff_agent to another registered agent, or close "
+                "an evidence-backed review-only gate with --successor-todo-id pointing "
+                "at an existing same-agent successor"
             )
         if (
             not side_agent_self_merged

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -1413,6 +1413,12 @@ def complete_goal_todo(
         original = resolved_state_file.read_text(encoding="utf-8")
         lines = original.splitlines()
         updated_at = now_local()
+        completion_match = find_todo_block(lines, todo_id=todo_id, role=role)
+        completion_todo = None
+        if completion_match:
+            completion_role, _section, _start, _end, completion_block = completion_match
+            completion_todo = dict(completion_block)
+            completion_todo["role"] = completion_role
         normalized_successor_todo_ids = normalize_todo_id_list(successor_todo_ids)
         if successor_todo_ids and not normalized_successor_todo_ids:
             raise ValueError("successor_todo_ids must contain public todo_<letters-digits-underscore-hyphen> tokens")
@@ -1434,6 +1440,7 @@ def complete_goal_todo(
             side_agent_self_merged=side_agent_self_merged,
             evidence=evidence,
             linked_successors=linked_successors,
+            completion_todo=completion_todo,
         )
         effective_claimed_by = completion_policy.effective_claimed_by
         primary_agent = completion_policy.primary_agent
@@ -1441,7 +1448,7 @@ def complete_goal_todo(
         effective_next_claimed_by = completion_policy.effective_next_claimed_by
         side_agent_completion = completion_policy.side_agent_completion
         effective_side_agent_self_merged = completion_policy.side_agent_self_merged
-        if not find_todo_block(lines, todo_id=todo_id, role=role):
+        if not completion_match:
             event_context = event_projection_todo_context(
                 registry_path=registry_path,
                 goal_id=goal_id,


### PR DESCRIPTION
## Summary
- let an evidence-backed review/verification gate link to an existing same-agent successor when the configured handoff agent is that completing side agent
- inspect the completing todo's action kind, write scope, and `blocks_agent` relation instead of treating every side-agent completion as repository delivery
- keep generated same-agent successors, write-scoped reviews, ordinary delivery, and primary-review successors behind the existing self-merge or independent-handoff gates

## Product / architecture judgment
The failure came from conflating review completion with delivery completion. This change adds a narrow completion-policy classification based on existing todo semantics rather than a new CLI flag or broad exception. It removes the need to misreport `--side-agent-self-merged` while retaining independent review and merge controls for repository writes.

## Validation
- `loopx canary premerge --from-git-diff` (17/17 selected checks passed; no warnings, skips, or manual holds)
- `python3 examples/control_plane/side-agent-self-iteration-state-machine-smoke.py`
- `python3 examples/control_plane/todo-lifecycle-cli-smoke.py`
- `python3 examples/control_plane/auto-research-role-successor-completion-smoke.py`
- public/private boundary scan clean for all 3 changed paths

## Excluded
No local goal state, raw evidence, credentials, generated logs, or private paths are included.
