### PR TITLE
Extract benchmark core projection from status

### DIFF
--- a/examples/benchmark-run-v0-status-projection-smoke.py
+++ b/examples/benchmark-run-v0-status-projection-smoke.py
@@ -17,6 +17,9 @@ if str(REPO_ROOT) not in sys.path:
 
 from loopx.review_packet import build_review_packet  # noqa: E402
 from loopx.status import collect_status, compact_benchmark_run, render_status_markdown  # noqa: E402
+from loopx.control_plane.runtime.benchmark_projection import (  # noqa: E402
+    compact_benchmark_run_core,
+)
 from loopx.worker_bridge import build_worker_bridge_outcome  # noqa: E402
 
 
@@ -256,6 +259,60 @@ def assert_no_private_surface(summary: dict[str, Any]) -> None:
     assert not leaked, leaked
 
 
+def assert_core_projection_parity() -> None:
+    source = {
+        "schema_version": "benchmark_run_v0",
+        "source_runner": "fixture-runner",
+        "benchmark_id": "fixture-bench",
+        "job_name": "fixture-job",
+        "mode": "fixture-mode",
+        "task_id": "fixture-case",
+        "case_ids": ["fixture-case", "fixture-case-2"],
+        "worker_mode": "fixture-worker",
+        "first_blocker": "fixture-blocker",
+        "loopx_cli_bridge_contract": "fixture-contract",
+        "real_run": True,
+        "submit_eligible": False,
+        "product_mode": True,
+        "runner_loopx_cli_call_total": 2,
+        "worker_loopx_cli_call_total": 3,
+        "controller_round_timeout_sec": 4.5,
+        "controller_last_decision": "continue",
+        "loopx_prompt_driven_event_counts": {"turn": 2, "ignored": "text"},
+        "private_payload": "must-not-project",
+    }
+    core = compact_benchmark_run_core(
+        source,
+        schema_version="benchmark_run_v0",
+        max_list_items=5,
+    )
+    assert core == {
+        "schema_version": "benchmark_run_v0",
+        "source_runner": "fixture-runner",
+        "benchmark_id": "fixture-bench",
+        "job_name": "fixture-job",
+        "mode": "fixture-mode",
+        "case_id": "fixture-case",
+        "case_ids": ["fixture-case", "fixture-case-2"],
+        "worker_mode": "fixture-worker",
+        "first_blocker": "fixture-blocker",
+        "loopx_cli_bridge_contract": "fixture-contract",
+        "real_run": True,
+        "submit_eligible": False,
+        "product_mode": True,
+        "runner_loopx_cli_call_total": 2,
+        "worker_loopx_cli_call_total": 3,
+        "controller_round_timeout_sec": 4.5,
+        "controller_last_decision": "continue",
+        "loopx_prompt_driven_event_counts": {"turn": 2},
+    }, core
+
+    assembled = compact_benchmark_run(source)
+    assert assembled is not None
+    assert all(assembled.get(key) == value for key, value in core.items()), assembled
+    assert "private_payload" not in assembled, assembled
+
+
 def assert_interrupted_worker_bridge_outcome_projection() -> None:
     compact = compact_benchmark_run(
         {
@@ -295,6 +352,7 @@ def assert_interrupted_worker_bridge_outcome_projection() -> None:
 
 
 def main() -> None:
+    assert_core_projection_parity()
     assert_interrupted_worker_bridge_outcome_projection()
     with tempfile.TemporaryDirectory(prefix="benchmark-run-v0-status-") as tmp:
         registry_path = write_fixture(Path(tmp))

--- a/examples/control_plane/repo-python-line-budget-smoke.py
+++ b/examples/control_plane/repo-python-line-budget-smoke.py
@@ -65,7 +65,7 @@ LEGACY_OVERSIZED_LIMITS = {
     "loopx/presentation/sinks/lark/kanban.py": 2614,
     "loopx/codex_cli_probe.py": 2221,
     "loopx/quota.py": 2455,
-    "loopx/status.py": 6926,
+    "loopx/status.py": 6736,
     "loopx/terminal_bench_agent.py": 2056,
     "scripts/harbor_host_codex_goal_agent.py": 2091,
     "scripts/skillsbench_automation_loop.py": 17631,

--- a/loopx/control_plane/runtime/benchmark_projection.py
+++ b/loopx/control_plane/runtime/benchmark_projection.py
@@ -1,0 +1,227 @@
+from __future__ import annotations
+
+from typing import Any
+
+from .public_safety import (
+    compact_numeric_map,
+    public_safe_compact_list,
+    public_safe_compact_text,
+)
+
+
+BENCHMARK_RUN_TEXT_FIELDS = (
+    "worker_mode",
+    "trace_publicness",
+    "first_blocker",
+    "score_failure_attribution",
+    "validation_scope",
+    "worker_submit_eligible_mismatch_reason",
+    "worker_bridge_writeback_loss_reason",
+    "worker_bridge_materialization_status",
+    "worker_bridge_materialization_blocker",
+    "worker_bridge_failure_attribution",
+    "repeat_blocked_by",
+    "pre_worker_startup_blocker",
+    "environment_setup_probe_status",
+    "runner_return_status",
+    "official_score_source",
+    "official_score_status",
+    "skillsbench_route_semantics",
+    "native_goal_mode_confirmation_status",
+    "loopx_treatment_evidence_tier",
+    "loopx_treatment_claim_blocker",
+    "loopx_cli_bridge_surface",
+    "loopx_cli_bridge_contract",
+    "loopx_cli_bridge_scope",
+    "loopx_counter_scope",
+)
+BENCHMARK_RUN_BOOL_FIELDS = (
+    "real_run",
+    "submit_eligible",
+    "case_semantics_changed_by_harness",
+    "loopx_inside_case",
+    "loopx_automation_loop",
+    "product_mode",
+    "official_score_comparable_to_native_codex",
+    "official_score_comparable_to_loopx_treatment",
+    "model_plus_harness_pair",
+    "control_plane_score_applicable",
+    "startup_surface_calibration",
+    "hardened_install_surface",
+    "hardened_install_baseline",
+    "environment_setup_probe_run",
+    "environment_setup_probe_cleared",
+    "leaderboard_evidence",
+    "loopx_cli_bridge_contract_available",
+    "loopx_cli_bridge_trace_observed",
+    "loopx_worker_cli_bridge_available",
+    "loopx_worker_cli_bridge_trace_observed",
+    "loopx_prompt_driven_trace_observed",
+    "loopx_prompt_driven_lifecycle_observed",
+    "loopx_controller_trace_present",
+    "loopx_controller_trace_public_safe",
+    "controller_turn_completed_observed",
+    "assisted_collaboration_claim_allowed",
+    "official_score_claim_allowed",
+    "bridge_connectivity_claim_allowed",
+    "case_success_claimed",
+    "official_verifier_validation_present",
+    "official_case_success",
+    "active_user_simulator_injection_channel_available",
+    "inner_codex_goal_mode",
+    "native_goal_mode_requested",
+    "native_goal_mode_invoked",
+    "codex_acp_protocol_used",
+    "blind_loop",
+    "agent_declared_done",
+    "official_feedback_blinded",
+    "reward_feedback_forwarded",
+    "native_goal_worker_route",
+    "native_goal_worker_connected",
+    "native_goal_worker_trace_dir_present",
+    "native_goal_worker_public_trace_read",
+    "native_goal_worker_raw_material_recorded",
+    "remote_command_file_bridge_consumed_by_solver",
+    "remote_command_file_bridge_solver_trace_dir_present",
+    "remote_command_file_bridge_solver_public_trace_read",
+    "remote_command_file_bridge_solver_raw_material_recorded",
+    "strict_loopx_treatment_claim_allowed",
+    "controller_trace_present",
+)
+BENCHMARK_RUN_INT_FIELDS = (
+    "runner_loopx_cli_call_total",
+    "worker_loopx_cli_call_total",
+    "loopx_prompt_driven_case_cli_call_count",
+    "loopx_prompt_driven_trace_file_count",
+    "loopx_prompt_driven_compact_file_count",
+    "worker_counter_trace_trial_count",
+    "worker_benchmark_run_file_count",
+    "worker_benchmark_run_schema_ok_count",
+    "worker_self_validation_official_score_mismatch_count",
+    "worker_validation_scope_ambiguous_official_score_failure_count",
+    "worker_bridge_connected_official_score_failure_count",
+    "worker_startup_blocker_count",
+    "worker_setup_diagnostic_file_count",
+    "worker_setup_diagnostic_schema_ok_count",
+    "worker_submit_eligible_mismatch_count",
+    "worker_bridge_writeback_loss_count",
+    "environment_setup_failure_before_worker_count",
+    "pre_worker_agent_setup_failure_count",
+    "worker_runtime_exception_before_checkpoint_count",
+    "verifier_failure_attribution_count",
+    "verifier_dependency_failure_count",
+    "official_zero_observation_count",
+    "planned_worker_loopx_cli_call_total",
+    "required_worker_loopx_cli_call_total_min",
+    "native_goal_worker_connect_count",
+    "native_goal_worker_trace_count",
+    "native_goal_worker_lifecycle_trace_count",
+    "native_goal_worker_prompt_received_count",
+    "native_goal_worker_ok_count",
+    "native_goal_worker_goal_get_count",
+    "native_goal_worker_turn_start_count",
+    "native_goal_worker_turn_completed_observed_count",
+    "native_goal_worker_assistant_message_present_count",
+    "native_goal_worker_assistant_context_only_count",
+    "native_goal_worker_context_only_recovery_attempted_count",
+    "native_goal_worker_context_only_recovery_succeeded_count",
+    "native_goal_worker_context_only_followup_start_attempted_count",
+    "native_goal_worker_context_only_followup_start_succeeded_count",
+    "native_goal_worker_normal_followup_attempted_count",
+    "native_goal_worker_normal_followup_succeeded_count",
+    "native_goal_worker_normal_followup_start_attempted_count",
+    "native_goal_worker_normal_followup_start_succeeded_count",
+    "native_goal_worker_finish_guard_followup_attempted_count",
+    "native_goal_worker_finish_guard_followup_succeeded_count",
+    "native_goal_worker_finish_guard_followup_start_attempted_count",
+    "native_goal_worker_finish_guard_followup_start_succeeded_count",
+    "native_goal_worker_incomplete_turn_status_count",
+    "native_goal_worker_incomplete_after_completion_event_count",
+    "native_goal_worker_transport_reconnect_attempted_count",
+    "native_goal_worker_transport_reconnect_succeeded_count",
+    "native_goal_worker_goal_reactivation_attempted_count",
+    "native_goal_worker_goal_reactivation_succeeded_count",
+    "native_goal_worker_post_context_assistant_chars_total",
+    "native_goal_worker_first_action_observed_count",
+    "native_goal_worker_effective_action_observed_count",
+    "remote_command_file_bridge_solver_trace_count",
+    "remote_command_file_bridge_solver_probe_ready_count",
+    "remote_command_file_bridge_solver_operation_count",
+    "controller_max_round_observed",
+    "controller_max_rounds_budget",
+    "controller_initial_prompt_count",
+    "controller_followup_prompt_count",
+    "controller_action_decisions",
+    "controller_no_active_todo_confirmed_count",
+    "max_rounds_budget",
+    "round_reward_count",
+)
+
+
+def benchmark_run_source(
+    run: dict[str, Any],
+    *,
+    schema_version: str,
+) -> dict[str, Any] | None:
+    nested = run.get("benchmark_run")
+    if isinstance(nested, dict) and nested.get("schema_version") == schema_version:
+        return nested
+    if run.get("schema_version") == schema_version:
+        return run
+    return None
+
+
+def compact_benchmark_run_core(
+    source: dict[str, Any],
+    *,
+    schema_version: str,
+    max_list_items: int,
+) -> dict[str, Any]:
+    compact: dict[str, Any] = {"schema_version": schema_version}
+    for field in ("source_runner", "benchmark_id", "job_name", "mode"):
+        value = public_safe_compact_text(source.get(field), limit=120)
+        if value:
+            compact[field] = value
+
+    trials = source.get("trials") if isinstance(source.get("trials"), list) else []
+    first_trial = trials[0] if trials and isinstance(trials[0], dict) else {}
+    case_ids_source = source.get("case_ids") if isinstance(source.get("case_ids"), list) else []
+    case_id = (
+        public_safe_compact_text(source.get("case_id"), limit=120)
+        or public_safe_compact_text(source.get("task_id"), limit=120)
+        or public_safe_compact_text(first_trial.get("task_id"), limit=120)
+        or (
+            public_safe_compact_text(case_ids_source[0], limit=120)
+            if case_ids_source
+            else None
+        )
+    )
+    if case_id:
+        compact["case_id"] = case_id
+        case_ids = public_safe_compact_list(case_ids_source, limit=max_list_items)
+        compact["case_ids"] = case_ids or [case_id]
+
+    for field in BENCHMARK_RUN_TEXT_FIELDS:
+        value = public_safe_compact_text(source.get(field), limit=140)
+        if value:
+            compact[field] = value
+    for field in BENCHMARK_RUN_BOOL_FIELDS:
+        if isinstance(source.get(field), bool):
+            compact[field] = source[field]
+    for field in BENCHMARK_RUN_INT_FIELDS:
+        if isinstance(source.get(field), int) and not isinstance(source.get(field), bool):
+            compact[field] = source[field]
+
+    round_timeout = source.get("controller_round_timeout_sec")
+    if isinstance(round_timeout, (int, float)) and not isinstance(round_timeout, bool):
+        compact["controller_round_timeout_sec"] = round_timeout
+    last_decision = public_safe_compact_text(
+        source.get("controller_last_decision"),
+        limit=120,
+    )
+    if last_decision:
+        compact["controller_last_decision"] = last_decision
+    event_counts = compact_numeric_map(source.get("loopx_prompt_driven_event_counts"))
+    if event_counts:
+        compact["loopx_prompt_driven_event_counts"] = event_counts
+    return compact

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -182,6 +182,10 @@ from .control_plane.runtime.run_compaction import (
     compact_operator_gate_resume_contract,
     compact_run_base as _compact_run_base_read_model,
 )
+from .control_plane.runtime.benchmark_projection import (
+    benchmark_run_source as _benchmark_run_source_read_model,
+    compact_benchmark_run_core as _compact_benchmark_run_core_read_model,
+)
 from .control_plane.runtime.public_safety import (
     compact_loopx_command_records as _compact_loopx_command_records,
     compact_numeric_map as _compact_numeric_map,
@@ -3816,216 +3820,22 @@ def _compact_benchmark_episode_policy(value: Any) -> dict[str, Any]:
     return compact
 
 
-def _benchmark_run_source(run: dict[str, Any]) -> dict[str, Any] | None:
-    nested = run.get("benchmark_run")
-    if isinstance(nested, dict) and nested.get("schema_version") == BENCHMARK_RUN_SCHEMA_VERSION:
-        return nested
-    if run.get("schema_version") == BENCHMARK_RUN_SCHEMA_VERSION:
-        return run
-    return None
-
-
 def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
-    source = _benchmark_run_source(run)
+    source = _benchmark_run_source_read_model(
+        run,
+        schema_version=BENCHMARK_RUN_SCHEMA_VERSION,
+    )
     if not source:
         return None
 
-    compact: dict[str, Any] = {"schema_version": BENCHMARK_RUN_SCHEMA_VERSION}
-    for field in ("source_runner", "benchmark_id", "job_name", "mode"):
-        value = public_safe_compact_text(source.get(field), limit=120)
-        if value:
-            compact[field] = value
-    trials_source = source.get("trials") if isinstance(source.get("trials"), list) else []
-    first_trial = trials_source[0] if trials_source and isinstance(trials_source[0], dict) else {}
-    case_ids_source = (
-        source.get("case_ids") if isinstance(source.get("case_ids"), list) else []
+    trials_source = (
+        source.get("trials") if isinstance(source.get("trials"), list) else []
     )
-    case_id = (
-        public_safe_compact_text(source.get("case_id"), limit=120)
-        or public_safe_compact_text(source.get("task_id"), limit=120)
-        or public_safe_compact_text(first_trial.get("task_id"), limit=120)
-        or (
-            public_safe_compact_text(case_ids_source[0], limit=120)
-            if case_ids_source
-            else None
-        )
+    compact = _compact_benchmark_run_core_read_model(
+        source,
+        schema_version=BENCHMARK_RUN_SCHEMA_VERSION,
+        max_list_items=MAX_BENCHMARK_RUN_LIST_ITEMS,
     )
-    if case_id:
-        compact["case_id"] = case_id
-        case_ids = public_safe_compact_list(case_ids_source, limit=MAX_BENCHMARK_RUN_LIST_ITEMS)
-        compact["case_ids"] = case_ids or [case_id]
-    for field in (
-        "worker_mode",
-        "trace_publicness",
-        "first_blocker",
-        "score_failure_attribution",
-        "validation_scope",
-        "worker_submit_eligible_mismatch_reason",
-        "worker_bridge_writeback_loss_reason",
-        "worker_bridge_materialization_status",
-        "worker_bridge_materialization_blocker",
-        "worker_bridge_failure_attribution",
-        "repeat_blocked_by",
-        "pre_worker_startup_blocker",
-        "environment_setup_probe_status",
-        "runner_return_status",
-        "official_score_source",
-        "official_score_status",
-        "skillsbench_route_semantics",
-        "native_goal_mode_confirmation_status",
-        "loopx_treatment_evidence_tier",
-        "loopx_treatment_claim_blocker",
-    ):
-        value = public_safe_compact_text(source.get(field), limit=140)
-        if value:
-            compact[field] = value
-    for field in (
-        "loopx_cli_bridge_surface",
-        "loopx_cli_bridge_contract",
-        "loopx_cli_bridge_scope",
-        "loopx_counter_scope",
-    ):
-        value = public_safe_compact_text(source.get(field), limit=140)
-        if value:
-            compact[field] = value
-    for field in (
-        "real_run",
-        "submit_eligible",
-        "case_semantics_changed_by_harness",
-        "loopx_inside_case",
-        "loopx_automation_loop",
-        "product_mode",
-        "official_score_comparable_to_native_codex",
-        "official_score_comparable_to_loopx_treatment",
-        "model_plus_harness_pair",
-        "control_plane_score_applicable",
-        "startup_surface_calibration",
-        "hardened_install_surface",
-        "hardened_install_baseline",
-        "environment_setup_probe_run",
-        "environment_setup_probe_cleared",
-        "leaderboard_evidence",
-        "loopx_cli_bridge_contract_available",
-        "loopx_cli_bridge_trace_observed",
-        "loopx_worker_cli_bridge_available",
-        "loopx_worker_cli_bridge_trace_observed",
-        "loopx_prompt_driven_trace_observed",
-        "loopx_prompt_driven_lifecycle_observed",
-        "loopx_controller_trace_present",
-        "loopx_controller_trace_public_safe",
-        "controller_turn_completed_observed",
-        "assisted_collaboration_claim_allowed",
-        "official_score_claim_allowed",
-        "bridge_connectivity_claim_allowed",
-        "case_success_claimed",
-        "official_verifier_validation_present",
-        "official_case_success",
-        "active_user_simulator_injection_channel_available",
-        "inner_codex_goal_mode",
-        "native_goal_mode_requested",
-        "native_goal_mode_invoked",
-        "codex_acp_protocol_used",
-        "blind_loop",
-        "agent_declared_done",
-        "official_feedback_blinded",
-        "reward_feedback_forwarded",
-        "native_goal_worker_route",
-        "native_goal_worker_connected",
-        "native_goal_worker_trace_dir_present",
-        "native_goal_worker_public_trace_read",
-        "native_goal_worker_raw_material_recorded",
-        "remote_command_file_bridge_consumed_by_solver",
-        "remote_command_file_bridge_solver_trace_dir_present",
-        "remote_command_file_bridge_solver_public_trace_read",
-        "remote_command_file_bridge_solver_raw_material_recorded",
-        "strict_loopx_treatment_claim_allowed",
-        "controller_trace_present",
-    ):
-        if isinstance(source.get(field), bool):
-            compact[field] = source.get(field)
-    for field in (
-        "runner_loopx_cli_call_total",
-        "worker_loopx_cli_call_total",
-        "loopx_prompt_driven_case_cli_call_count",
-        "loopx_prompt_driven_trace_file_count",
-        "loopx_prompt_driven_compact_file_count",
-        "worker_counter_trace_trial_count",
-        "worker_benchmark_run_file_count",
-        "worker_benchmark_run_schema_ok_count",
-        "worker_self_validation_official_score_mismatch_count",
-        "worker_validation_scope_ambiguous_official_score_failure_count",
-        "worker_bridge_connected_official_score_failure_count",
-        "worker_startup_blocker_count",
-        "worker_setup_diagnostic_file_count",
-        "worker_setup_diagnostic_schema_ok_count",
-        "worker_submit_eligible_mismatch_count",
-        "worker_bridge_writeback_loss_count",
-        "environment_setup_failure_before_worker_count",
-        "pre_worker_agent_setup_failure_count",
-        "worker_runtime_exception_before_checkpoint_count",
-        "verifier_failure_attribution_count",
-        "verifier_dependency_failure_count",
-        "official_zero_observation_count",
-        "planned_worker_loopx_cli_call_total",
-        "required_worker_loopx_cli_call_total_min",
-        "native_goal_worker_connect_count",
-        "native_goal_worker_trace_count",
-        "native_goal_worker_lifecycle_trace_count",
-        "native_goal_worker_prompt_received_count",
-        "native_goal_worker_ok_count",
-        "native_goal_worker_goal_get_count",
-        "native_goal_worker_turn_start_count",
-        "native_goal_worker_turn_completed_observed_count",
-        "native_goal_worker_assistant_message_present_count",
-        "native_goal_worker_assistant_context_only_count",
-        "native_goal_worker_context_only_recovery_attempted_count",
-        "native_goal_worker_context_only_recovery_succeeded_count",
-        "native_goal_worker_context_only_followup_start_attempted_count",
-        "native_goal_worker_context_only_followup_start_succeeded_count",
-        "native_goal_worker_normal_followup_attempted_count",
-        "native_goal_worker_normal_followup_succeeded_count",
-        "native_goal_worker_normal_followup_start_attempted_count",
-        "native_goal_worker_normal_followup_start_succeeded_count",
-        "native_goal_worker_finish_guard_followup_attempted_count",
-        "native_goal_worker_finish_guard_followup_succeeded_count",
-        "native_goal_worker_finish_guard_followup_start_attempted_count",
-        "native_goal_worker_finish_guard_followup_start_succeeded_count",
-        "native_goal_worker_incomplete_turn_status_count",
-        "native_goal_worker_incomplete_after_completion_event_count",
-        "native_goal_worker_transport_reconnect_attempted_count",
-        "native_goal_worker_transport_reconnect_succeeded_count",
-        "native_goal_worker_goal_reactivation_attempted_count",
-        "native_goal_worker_goal_reactivation_succeeded_count",
-        "native_goal_worker_post_context_assistant_chars_total",
-        "native_goal_worker_first_action_observed_count",
-        "native_goal_worker_effective_action_observed_count",
-        "remote_command_file_bridge_solver_trace_count",
-        "remote_command_file_bridge_solver_probe_ready_count",
-        "remote_command_file_bridge_solver_operation_count",
-        "controller_max_round_observed",
-        "controller_max_rounds_budget",
-        "controller_initial_prompt_count",
-        "controller_followup_prompt_count",
-        "controller_action_decisions",
-        "controller_no_active_todo_confirmed_count",
-        "max_rounds_budget",
-        "round_reward_count",
-    ):
-        if isinstance(source.get(field), int) and not isinstance(source.get(field), bool):
-            compact[field] = source.get(field)
-    for field in ("controller_round_timeout_sec",):
-        if isinstance(source.get(field), (int, float)) and not isinstance(
-            source.get(field), bool
-        ):
-            compact[field] = source.get(field)
-    for field in ("controller_last_decision",):
-        value = public_safe_compact_text(source.get(field), limit=120)
-        if value:
-            compact[field] = value
-    for field in ("loopx_prompt_driven_event_counts",):
-        calls = _compact_numeric_map(source.get(field))
-        if calls:
-            compact[field] = calls
     loop_contract = source.get("benchmark_loop_contract")
     if isinstance(loop_contract, dict):
         compact_loop_contract: dict[str, Any] = {}


### PR DESCRIPTION
## Summary
- move benchmark run source selection plus top-level identity/text/bool/int projection into `control_plane/runtime/benchmark_projection.py`
- keep `compact_benchmark_run` as the existing assembler and public entry point; attribution, validation, trial, permission, reducer, and closeout behavior stay in place
- add exact core-field parity coverage and tighten the `status.py` legacy line budget from 6926 to 6736

## Product / architecture judgment
`status.py` owned a nearly thousand-line benchmark assembler. This batch extracts one cohesive, pure read-model rule group with an active call site and no compatibility wrapper. It deliberately does not move benchmark scoring or runner behavior, and it avoids introducing a benchmark-specific builder hierarchy.

## Validation
- `loopx canary premerge --from-git-diff`: 17/17 checks passed, 0 failures, 0 warnings; public-boundary scan covered all 4 changed paths
- exact old/new synthetic parity across every extracted scalar field: 153 top-level fields matched
- representative parity smokes passed: status projection, benchmark ledger, official result reducer, runner invariant/permission, closeout status snapshot, SkillsBench missing-score attribution, event ledger, and Python line budget
- Python compile and diff hygiene passed

## Manual hold
The generic canary classifier reports `benchmark_sensitive` and requests explicit maintainer review. The diff is a behavior-preserving projection seam: it does not alter scoring, task semantics, leaderboard/submission behavior, permissions, runner execution, or launch benchmark jobs. Any self-merge decision must explicitly account for this hold under the repository's small benchmark seam/refactor rule.

## Excluded
No raw benchmark evidence, private state, credentials, local paths, generated logs, or temporary probes are included.
