### PR TITLE
Fix SkillsBench official score countability

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -1126,6 +1126,29 @@ def _assert_cli_goal_active_timeout_is_public_countability_stage() -> None:
     assert contract["goal_stage"] == "goal_active_timeout", contract
     assert contract["raw_material_recorded"] is False, contract
 
+    completed_attempt_trace = dict(trace)
+    completed_attempt_trace.update(
+        {
+            "codex_cli_goal_tui_stage": "timeout",
+            "remote_command_file_bridge_agent_operation_trace_status": (
+                "agent_operation_trace_recorded"
+            ),
+            "remote_command_file_bridge_agent_request_count": 4,
+            "remote_command_file_bridge_agent_task_facing_operation_count": 3,
+            "remote_command_file_bridge_agent_task_facing_success_count": 3,
+        }
+    )
+    compact = {
+        "route": CODEX_CLI_GOAL_BASELINE_ROUTE,
+        "official_score_status": "completed",
+        "official_score": 1.0,
+        "interaction_counters": completed_attempt_trace,
+        "runner_prerequisites": {},
+        "failure_attribution_labels": [],
+    }
+    assert _apply_codex_cli_goal_countability_guard_attribution(compact) is False
+    assert "codex_cli_goal_countability_contract" not in compact
+
     with tempfile.TemporaryDirectory() as temp:
         trace_dir = Path(temp) / "trace"
         relay = SkillsBenchLocalAcpRelay(

--- a/examples/skillsbench-current-ledger-aggregate-smoke.py
+++ b/examples/skillsbench-current-ledger-aggregate-smoke.py
@@ -439,7 +439,6 @@ def test_ledger_marks_uncountable_numeric_scores_noncountable() -> None:
             "kind": "skillsbench_verifier_reward",
             "passed": False,
         },
-        "score_failure_attribution": "verifier_infrastructure_failure",
     }
     entry = build_benchmark_run_ledger_entry(passed_false_missing_status)
     assert entry["official_score"] == 0.0, entry
@@ -450,9 +449,10 @@ def test_ledger_marks_uncountable_numeric_scores_noncountable() -> None:
         "countable_official_score"
     ), entry
 
-    passed_false_attempt_marked_noncountable = {
+    passed_false_verifier_infra = {
         **passed_false_missing_status,
-        "case_id": "passed-bool-false-attempt-marked-noncountable",
+        "case_id": "passed-bool-false-verifier-infra",
+        "score_failure_attribution": "verifier_infrastructure_failure",
         "attempt_accounting": {
             "official_score_attempt_countable": False,
             "case_attempt_countable": True,
@@ -460,15 +460,50 @@ def test_ledger_marks_uncountable_numeric_scores_noncountable() -> None:
             "verifier_attempt_countable": True,
         },
     }
-    entry = build_benchmark_run_ledger_entry(passed_false_attempt_marked_noncountable)
+    entry = build_benchmark_run_ledger_entry(passed_false_verifier_infra)
     assert entry["official_score"] == 0.0, entry
     assert entry["official_passed"] is False, entry
     assert entry["score_status"] == "failed", entry
     assert entry["official_score_attempt_countable"] is True, entry
+    assert entry["official_score_countable"] is False, entry
+    assert entry["official_score_countability_reason"] == (
+        "official_score_attempt_not_countable"
+    ), entry
+    assert "countable_score" not in entry, entry
+
+    completed_task_attempt_pass = {
+        "schema_version": "benchmark_run_v0",
+        "benchmark_id": BENCHMARK_ID,
+        "case_id": "completed-task-attempt-pass",
+        "job_name": "skillsbench_1_1_completed_task_attempt_pass_codex_cli_goal_baseline",
+        "route": "codex-cli-goal-baseline",
+        "official_score_status": "completed",
+        "official_score": 1.0,
+        "score_failure_attribution": (
+            "skillsbench_codex_cli_goal_uncountable_goal_failed"
+        ),
+        "failure_attribution_labels": [
+            "skillsbench_codex_cli_goal_uncountable_goal_failed",
+            "skillsbench_codex_cli_goal_uncountable_baseline",
+        ],
+        "attempt_accounting": {
+            "official_score_attempt_countable": False,
+            "case_attempt_countable": False,
+            "solver_attempt_countable": False,
+            "verifier_attempt_countable": False,
+        },
+        "solution_quality_signals": {
+            "worker_activity": {"task_facing_activity_observed": True},
+        },
+    }
+    entry = build_benchmark_run_ledger_entry(completed_task_attempt_pass)
+    assert entry["official_score"] == 1.0, entry
+    assert entry["official_passed"] is True, entry
     assert entry["official_score_countable"] is True, entry
     assert entry["official_score_countability_reason"] == (
-        "countable_official_score"
+        "countable_completed_task_attempt_pass"
     ), entry
+    assert entry["countable_score"] == 1.0, entry
 
 
 def test_current_aggregate_keeps_setup_bool_fallback_uncountable() -> None:
@@ -504,7 +539,11 @@ def test_current_aggregate_keeps_setup_bool_fallback_uncountable() -> None:
     )
     assert entry["official_score"] == 0.0, entry
     assert entry["official_score_bool_fallback_used"] is True, entry
-    assert entry["official_score_countable"] is True, entry
+    assert entry["official_score_countable"] is False, entry
+    assert entry["official_score_countability_reason"] == (
+        "official_score_attempt_not_countable"
+    ), entry
+    assert "countable_score" not in entry, entry
     assert entry["case_attempt_countable"] is False, entry
     assert entry["solver_attempt_countable"] is False, entry
     assert entry["verifier_attempt_countable"] is False, entry
@@ -521,7 +560,7 @@ def test_current_aggregate_keeps_setup_bool_fallback_uncountable() -> None:
     )
     case_best = aggregate["case_best"]["setup-bool-fallback"]
     assert case_best["official_score"] == 0.0, case_best
-    assert case_best["official_score_countable"] is True, case_best
+    assert case_best["official_score_countable"] is False, case_best
     assert case_best["bucket"] == "setup_runner_infra", case_best
     assert "countable_score" not in case_best, case_best
     assert aggregate["distribution"]["setup_runner_infra"] == 1, aggregate

--- a/loopx/benchmark_ledger_countability.py
+++ b/loopx/benchmark_ledger_countability.py
@@ -206,6 +206,31 @@ def _score_countability_label_values(run: dict[str, Any]) -> list[str]:
     return labels
 
 
+def _completed_task_attempt_pass(run: dict[str, Any], score: float) -> bool:
+    score_status = _compact_text(
+        run.get("official_score_status") or run.get("score_status"),
+        limit=80,
+    )
+    if score_status not in {"completed", "passed"} or score < 1:
+        return False
+    if (
+        run.get("official_passed") is not True
+        and _official_task_score_bool_passed(run) is not True
+    ):
+        return False
+    signals = (
+        run.get("solution_quality_signals")
+        if isinstance(run.get("solution_quality_signals"), dict)
+        else {}
+    )
+    activity = (
+        signals.get("worker_activity")
+        if isinstance(signals.get("worker_activity"), dict)
+        else {}
+    )
+    return activity.get("task_facing_activity_observed") is True
+
+
 def benchmark_run_official_score_countability(run: dict[str, Any]) -> dict[str, Any]:
     """Classify whether a compact/ledger run's official score is aggregate-countable."""
 
@@ -237,7 +262,10 @@ def benchmark_run_official_score_countability(run: dict[str, Any]) -> dict[str, 
         if isinstance(run.get("attempt_accounting"), dict)
         else {}
     )
-    if official_score_attempt_uncountable(run, accounting, bool_fallback_allowed):
+    completed_task_pass = _completed_task_attempt_pass(run, score)
+    if not completed_task_pass and official_score_attempt_uncountable(
+        run, accounting, bool_fallback_allowed
+    ):
         return {
             "countable": False,
             "reason": "official_score_attempt_not_countable",
@@ -256,8 +284,21 @@ def benchmark_run_official_score_countability(run: dict[str, Any]) -> dict[str, 
             "reason": "official_score_status_not_countable",
             "score": score,
         }
-    if any("uncountable" in label.lower() for label in _score_countability_label_values(run)):
-        return {"countable": False, "reason": "uncountable_attribution", "score": score}
+    if not completed_task_pass and any(
+        "uncountable" in label.lower()
+        for label in _score_countability_label_values(run)
+    ):
+        return {
+            "countable": False,
+            "reason": "uncountable_attribution",
+            "score": score,
+        }
+    if completed_task_pass:
+        return {
+            "countable": True,
+            "reason": "countable_completed_task_attempt_pass",
+            "score": score,
+        }
     return {"countable": True, "reason": "countable_official_score", "score": score}
 
 
@@ -298,9 +339,6 @@ def official_score_attempt_uncountable(
         or accounting.get("failure_label"),
         limit=180,
     ).lower()
-    if has_official_bool_score:
-        return False
-
     if (
         failure_scope == "runner_or_setup"
         and lifecycle_phase in {"not_started", "runner_accepted_args"}
@@ -313,5 +351,8 @@ def official_score_attempt_uncountable(
 
     if failure_scope == "verifier_or_infra":
         return True
+
+    if has_official_bool_score:
+        return False
 
     return False

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -4967,12 +4967,13 @@ def _apply_codex_cli_goal_countability_guard_attribution(
     )[:120]
 
     missing_task_activity = task_facing_count <= 0 or request_count <= 0
-    terminal_goal_failed_countable = (
-        goal_stage == "goal_failed"
-        and not missing_task_activity
+    completed_task_attempt_countable = (
+        not missing_task_activity
         and str(compact.get("official_score_status") or "") == "completed"
     )
-    goal_failed = trace_present and ok_count <= 0 and not terminal_goal_failed_countable
+    goal_failed = (
+        trace_present and ok_count <= 0 and not completed_task_attempt_countable
+    )
     if not (missing_task_activity or goal_failed):
         return False
 


### PR DESCRIPTION
## Summary
- keep bool-only score fallback countable for genuine verifier outcomes, but reject setup and verifier infrastructure failures
- preserve completed official passes when task-facing activity occurred even if the host Goal worker ended without a clean terminal acknowledgement
- align the live SkillsBench reducer guard with the ledger contract and add focused regressions

## Validation
- `python3 examples/skillsbench-current-ledger-aggregate-smoke.py`
- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 -m py_compile loopx/benchmark_ledger_countability.py scripts/skillsbench_automation_loop.py examples/skillsbench-current-ledger-aggregate-smoke.py examples/skillsbench-codex-cli-goal-route-smoke.py`
- compact-only replay of the completed three-case batch: setup failure uncountable, verifier infrastructure failure uncountable, completed task-attempt pass countable
- `loopx canary premerge --from-git-diff` (all direct checks, 8 catalog canaries, and public-boundary scan passed; benchmark-sensitive manual hold reviewed under owner-authorized benchmark self-merge)