### PR TITLE
Fix filtered todo resume projection

### DIFF
--- a/examples/control_plane/todo-list-event-projection-smoke.py
+++ b/examples/control_plane/todo-list-event-projection-smoke.py
@@ -23,6 +23,8 @@ from loopx.event_sourced_state import (  # noqa: E402
 
 
 GOAL_ID = "todo-list-event-projection-fixture"
+GATE_TODO_ID = "todo_markdown_gate_done"
+DEPENDENT_TODO_ID = "todo_event_dependent"
 
 
 def write_fixture(root: Path) -> tuple[Path, Path, Path]:
@@ -38,9 +40,15 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
         "updated_at: 2026-01-01T00:00:00+00:00\n"
         "---\n\n"
         "# Active Goal State\n\n"
+        "## User Todo\n\n"
+        "- [x] [P0] Completed Markdown gate\n"
+        f"  <!-- loopx:todo todo_id={GATE_TODO_ID} status=done task_class=user_gate -->\n\n"
         "## Agent Todo\n\n"
         "- [ ] [P1] Markdown fallback todo\n"
-        "  <!-- loopx:todo todo_id=todo_markdown status=open task_class=advancement_task -->\n",
+        "  <!-- loopx:todo todo_id=todo_markdown status=open task_class=advancement_task -->\n"
+        "- [-] [P1] Continue after the Markdown gate\n"
+        f"  <!-- loopx:todo todo_id={DEPENDENT_TODO_ID} status=deferred "
+        f"task_class=advancement_task resume_when=todo_done:{GATE_TODO_ID} -->\n",
         encoding="utf-8",
     )
     registry_path.parent.mkdir(parents=True)
@@ -154,20 +162,43 @@ def main() -> int:
         assert projected["ok"] is True, projected
         assert projected["read_only"] is True, projected
         assert projected["source"] == "event_projection_with_markdown_overlay", projected
-        assert projected["todo_count"] == 3, projected
+        assert projected["todo_count"] == 4, projected
         assert [item["todo_id"] for item in projected["todos"]] == [
             "todo_event_open",
             "todo_markdown",
+            DEPENDENT_TODO_ID,
             "todo_event_done",
         ], projected
+        dependent = next(
+            item for item in projected["todos"] if item["todo_id"] == DEPENDENT_TODO_ID
+        )
+        assert dependent["resume_ready"] is True, dependent
+        assert dependent["resume_condition"]["target_status"] == "done", dependent
         assert projected["projection_overlay"]["markdown_only_todo_ids"] == [
-            "todo_markdown"
+            GATE_TODO_ID,
+            DEPENDENT_TODO_ID,
+            "todo_markdown",
         ], projected
         assert projected["projection_overlay"]["event_only_todo_ids"] == [
             "todo_event_open",
             "todo_event_done",
         ], projected
         assert projected["state_event_projection"]["source_event_count"] == 3, projected
+
+        dependent_only = run_cli(
+            registry_path,
+            "todo",
+            "list",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            DEPENDENT_TODO_ID,
+        )
+        assert dependent_only["todo_count"] == 1, dependent_only
+        assert dependent_only["relations"]["resume_ready"] is True, dependent_only
+        assert (
+            dependent_only["relations"]["resume_condition"]["target_status"] == "done"
+        ), dependent_only
 
         done_only = run_cli(
             registry_path,
@@ -187,8 +218,24 @@ def main() -> int:
         event_log.unlink()
         fallback = run_cli(registry_path, "todo", "list", "--goal-id", GOAL_ID, "--role", "agent")
         assert fallback["source"] == "markdown_active_state", fallback
-        assert fallback["todo_count"] == 1, fallback
-        assert fallback["todos"][0]["todo_id"] == "todo_markdown", fallback
+        assert fallback["todo_count"] == 2, fallback
+        assert [item["todo_id"] for item in fallback["todos"]] == [
+            "todo_markdown",
+            DEPENDENT_TODO_ID,
+        ], fallback
+        fallback_dependent = run_cli(
+            registry_path,
+            "todo",
+            "list",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            DEPENDENT_TODO_ID,
+        )
+        assert fallback_dependent["relations"]["resume_ready"] is True, fallback_dependent
+        assert (
+            fallback_dependent["relations"]["resume_condition"]["target_status"] == "done"
+        ), fallback_dependent
 
     print("todo-list-event-projection-smoke ok")
     return 0

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -185,6 +185,7 @@ def filtered_todo_summary(
     status: str | None = None,
     todo_id: str | None = None,
     agent_id: str | None = None,
+    resume_source_items: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     items = list((summary or {}).get("items") or [])
     normalized_status = normalize_todo_status(status)
@@ -220,6 +221,7 @@ def filtered_todo_summary(
             items,
             source_section=source_section,
             role=role,
+            resume_source_items=resume_source_items,
             item_limit=None,
         )
         or empty_todo_summary(role=role)
@@ -269,6 +271,8 @@ def _merge_todo_projection_fields(
     event_fields: dict[str, Any],
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     merged: dict[str, Any] = {}
+    merged_items: dict[str, list[dict[str, Any]]] = {"user": [], "agent": []}
+    source_sections: dict[str, str] = {}
     overlay: dict[str, Any] = {
         "schema_version": "todo_list_projection_overlay_v0",
         "base": "markdown_active_state",
@@ -316,10 +320,18 @@ def _merge_todo_projection_fields(
             or (event_fields.get(f"{role}_todos") or {}).get("source_section")
             or TODO_SECTION_HEADINGS[role]
         )
+        merged_items[role] = [by_id[todo_id] for todo_id in order]
+        source_sections[role] = source_section
+
+    resume_source_items = [*merged_items["user"], *merged_items["agent"]]
+    for role in ("user", "agent"):
+        if not merged_items[role]:
+            continue
         summary = compact_todo_group(
-            [by_id[todo_id] for todo_id in order],
-            source_section=source_section,
+            merged_items[role],
+            source_section=source_sections[role],
             role=role,
+            resume_source_items=resume_source_items,
             item_limit=None,
         )
         if summary:
@@ -388,6 +400,10 @@ def list_goal_todos(
         source = "markdown_active_state"
 
     roles = [role] if role else ["user", "agent"]
+    resume_source_items = [
+        *_summary_items(fields, "user"),
+        *_summary_items(fields, "agent"),
+    ]
     summaries: dict[str, dict[str, Any]] = {}
     todos: list[dict[str, Any]] = []
     unfiltered_count = 0
@@ -401,6 +417,7 @@ def list_goal_todos(
             status=status,
             todo_id=normalized_todo_id,
             agent_id=normalized_agent_id,
+            resume_source_items=resume_source_items,
         )
         summaries[key] = summary
         todos.extend(summary.get("items") or [])


### PR DESCRIPTION
## Summary\n- resolve todo  against the complete user + agent todo index before applying list filters\n- preserve the same relation semantics when Markdown and event projections are overlaid\n- extend the existing event-projection smoke with a cross-role completed gate and filtered lookup\n\n## Regression\nOn , the focused fixture projected the dependent todo as  and . This branch projects  and  for both full and  list queries.\n\n## Validation\n- todo-list-event-projection-smoke ok\n- todo-cli-smoke ok\n- todo-durability-fixture-smoke ok\n- quota-resume-gated-open-todo-smoke ok\n- # Pre-Merge Validation Gate

- status: `passed`
- ok: `true`
- merge_gate_passed: `true`
- self_merge_allowed: `true`
- tier: `standard`
- dry_run: `false`
- changed_files: `2`
- surfaces: `control_plane, public_boundary, python`
- risk_profiles: `core-control-plane, canary-runner`
- manual_holds: `0`

Pre-merge validation is a risk-based gate: it runs diff hygiene, changed Python compile checks, catalog-selected canaries, risk-profile smokes, and public/private boundary checks. It reports manual holds for benchmark-sensitive or reviewer-gated surfaces instead of treating local smoke success as self-merge permission.

## Direct Checks
- `diff_check_committed`: `passed` `git diff --check origin/main...HEAD`
- `diff_check_staged`: `passed` `git diff --cached --check`
- `diff_check_unstaged`: `passed` `git diff --check`
- `changed_python_py_compile`: `passed` `python3 -m py_compile examples/control_plane/todo-list-event-projection-smoke.py loopx/todos.py`

## Catalog Canaries
- ok: `true`
- selected_checks: `8`
- executed_checks: `8`
- failures: `0`
- advisory_failures: `0`
- warnings: `0`
- `passed` python3 examples/control_plane/repo-python-line-budget-smoke.py
- `passed` python3 examples/control_plane/todo-contract-smoke.py
- `passed` python3 examples/control_plane/todo-cli-smoke.py
- `passed` python3 examples/control_plane/todo-lifecycle-cli-smoke.py
- `passed` python3 examples/control_plane/todo-list-event-projection-smoke.py
- `passed` python3 examples/control_plane/todo-user-gate-scope-smoke.py
- `passed` python3 examples/project/operator-gate-resume-contract-smoke.py
- `passed` python3 examples/reward-gate-direct-write-contract-smoke.py

## Risk Profile Smokes
- ok: `true`
- selected_checks: `8`
- executed_checks: `8`
- failures: `0`
- advisory_failures: `0`
- warnings: `0`
- `passed` python3 examples/canary/catalog-planner-smoke.py
- `passed` python3 examples/canary/catalog-run-e2e-smoke.py
- `passed` python3 examples/canary/premerge-validation-gate-smoke.py
- `passed` python3 examples/canary/pytest-smoke-suite-facade-smoke.py
- `passed` python3 examples/canary/smoke-suite-runner-smoke.py
- `passed` python3 examples/canary/smoke-suite-subdir-discovery-smoke.py
- `passed` python3 examples/cli-control-plane-command-modularization-smoke.py
- `passed` python3 examples/cli-project-lifecycle-command-modularization-smoke.py

## Public Boundary
- ok: `true`
- selected_checks: `1`
- executed_checks: `1`
- failures: `0`
- advisory_failures: `0`
- warnings: `0`
- `passed` loopx check --scan-path examples/control_plane/todo-list-event-projection-smoke.py --scan-path loopx/todos.py: 17/17 selected checks passed, 0 warnings, 0 manual holds\n- public boundary scan clean for both changed files\n