### PR TITLE
Simplify remote benchmark ledger ownership

### DIFF
--- a/docs/research/long-horizon-agent-benchmarks/benchmark-core-adapter-contract-v0.md
+++ b/docs/research/long-horizon-agent-benchmarks/benchmark-core-adapter-contract-v0.md
@@ -87,6 +87,9 @@ Completed slices:
 10. `benchmark_core.attempts` for `benchmark_attempt_accounting_v0` and the
     shared failure taxonomy that keeps runner startup/materialization blockers
     out of case-attempt accounting.
+11. `benchmark_core.remote_closeout` for compact/public-only remote artifact
+    sync and local ledger/aggregate ownership. Remote benchmark runners produce
+    compacts; they do not also maintain a second ledger.
 
 ## Adapter Rollout Matrix
 

--- a/examples/skillsbench-benchmark-egress-policy-smoke.py
+++ b/examples/skillsbench-benchmark-egress-policy-smoke.py
@@ -200,6 +200,7 @@ def test_public_launcher_batches_three_cases_with_closeout_sync() -> None:
     assert "--remote-public-artifact-root" in output, output
     assert "benchmark_run.compact.json" in output, output
     assert "--local-run-ledger-path" in output, output
+    assert "--update-ledger" not in output, output
     assert "--local-target-lane-id codex-cli-goal-xhigh" in output, output
     assert "--local-target-run-group-contains" not in output, output
     assert "--local-target-backfill-run-group-contains" not in output, output

--- a/examples/skillsbench-reverse-tunnel-supervisor-smoke.py
+++ b/examples/skillsbench-reverse-tunnel-supervisor-smoke.py
@@ -223,6 +223,8 @@ def test_supervisor_syncs_only_compact_public_artifacts() -> None:
         assert sync["ok"] is True, sync
         assert sync["matched_count"] == 1, sync
         assert sync["written_count"] == 1, sync
+        assert sync["ledger_write_authority"] == "local_compact_closeout", sync
+        assert sync["remote_ledger_write_allowed"] is False, sync
         compact_path = synced_dir / "job" / "case" / "benchmark_run.compact.json"
         assert compact_path.exists(), sync
         assert ledger_path.exists(), sync

--- a/loopx/benchmark_core/remote_closeout.py
+++ b/loopx/benchmark_core/remote_closeout.py
@@ -92,6 +92,10 @@ def build_remote_benchmark_closeout_contract(
         "raw_task_text_read": False,
         "raw_logs_read": False,
         "raw_trajectory_read": False,
+        "ledger_write_authority": (
+            "local_compact_closeout" if ledger_requested else "none"
+        ),
+        "remote_ledger_write_allowed": False,
         "local_ledger_update": {
             "requested": ledger_requested,
             "updated": False,

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -204,8 +204,7 @@ remote_command=$(
     --host-local-acp-launch \
     --remote-command-file-bridge-probe \
     --run-group-id "$run_group" \
-    --job-name "$job_name" \
-    --update-ledger
+    --job-name "$job_name"
   if ((${#extra_runner_args[@]})); then
     printf '%q ' "${extra_runner_args[@]}"
   fi


### PR DESCRIPTION
## Summary
- make local compact closeout the sole ledger/aggregate write authority
- stop the SkillsBench remote runner from maintaining a duplicate ledger
- expose the adapter-neutral ownership rule in the shared closeout contract

## Validation
- `python3 examples/skillsbench-benchmark-egress-policy-smoke.py`
- `python3 examples/skillsbench-reverse-tunnel-supervisor-smoke.py`
- `python3 examples/benchmark-core-adapter-contract-smoke.py`
- `python3 examples/skillsbench-current-ledger-aggregate-smoke.py`
- `loopx canary premerge --from-git-diff` (all automated checks passed; expected benchmark-sensitive manual hold)

## Risk
No scoring, task semantics, upload, leaderboard, or benchmark launch behavior changes. Existing compact generation remains remote; authoritative ledger aggregation remains local.