### PR TITLE
Refine SkillsBench setup failure attribution

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -4846,29 +4846,6 @@ def test_skillsbench_app_skills_permission_failure_not_overridden_by_worker_rout
         ), compact
 
 
-def test_skillsbench_docker_pip_bootstrap_failure_attribution() -> None:
-    error_text = (
-        "Docker compose command failed for environment adaptive-cruise-control. "
-        "Command: docker compose build. Return code: 1. "
-        "Dockerfile contains RUN mkdir -p /app /app/skills. "
-        "RUN pip3 install numpy==1.26.4 pandas==2.2.2. "
-        "ERROR: Read timed out from files.pythonhosted.org. "
-        "ERROR: No matching distribution found for numpy==1.26.4"
-    )
-
-    exception_type, attribution, labels = skillsbench_runner_error_attribution(
-        error_text
-    )
-    assert exception_type == "skillsbench_docker_compose_pip_bootstrap_failure"
-    assert attribution == "skillsbench_docker_compose_pip_bootstrap_failure"
-    assert "skillsbench_python_package_bootstrap_failure" in labels, labels
-    assert "skillsbench_environment_setup_error" in labels, labels
-    assert "skillsbench_environment_app_mount_missing" not in labels, labels
-    fingerprint = skillsbench_runner_error_fingerprint(error_text)
-    assert "pip_bootstrap_failure" in fingerprint["matched_patterns"], fingerprint
-    assert "volume_mount_failure" not in fingerprint["matched_patterns"], fingerprint
-
-
 def test_skillsbench_docker_port_conflict_attribution() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-docker-port-") as tmp:
         result_path = write_official_skillsbench_docker_port_conflict_failure(

--- a/examples/skillsbench-failure-attribution-smoke.py
+++ b/examples/skillsbench-failure-attribution-smoke.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Smoke public-safe SkillsBench setup-failure attribution."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.benchmark_adapters.skillsbench import (
+    skillsbench_runner_error_attribution,
+    skillsbench_runner_error_fingerprint,
+)
+
+
+def test_pip_bootstrap_failure_attribution() -> None:
+    error_text = (
+        "Docker compose command failed. RUN pip3 install numpy==1.26.4. "
+        "ERROR: Read timed out from files.pythonhosted.org. "
+        "ERROR: No matching distribution found for numpy==1.26.4"
+    )
+
+    exception_type, attribution, labels = skillsbench_runner_error_attribution(
+        error_text
+    )
+    assert exception_type == "skillsbench_docker_compose_pip_bootstrap_failure"
+    assert attribution == "skillsbench_docker_compose_pip_bootstrap_failure"
+    assert "skillsbench_python_package_bootstrap_failure" in labels, labels
+    fingerprint = skillsbench_runner_error_fingerprint(error_text)
+    assert "pip_bootstrap_failure" in fingerprint["matched_patterns"], fingerprint
+
+
+def test_injected_pip_lines_do_not_mask_later_build_failure() -> None:
+    error_text = (
+        "Docker compose command failed.\n"
+        "ARG LOOPX_SKILLSBENCH_PIP_INDEX_URL=https://pypi.tuna.tsinghua.edu.cn/simple\n"
+        "RUN pip3 install numpy scipy\n"
+        "ERROR: failed to solve: process /bin/sh -c curl artifact.example.invalid "
+        "did not complete successfully: read timed out from artifact.example.invalid"
+    )
+
+    exception_type, attribution, labels = skillsbench_runner_error_attribution(
+        error_text
+    )
+    assert exception_type == "skillsbench_docker_compose_image_build_failure"
+    assert attribution == "skillsbench_docker_compose_image_build_failure"
+    assert "skillsbench_python_package_bootstrap_failure" not in labels, labels
+    fingerprint = skillsbench_runner_error_fingerprint(error_text)
+    assert "image_build" in fingerprint["matched_patterns"], fingerprint
+    assert "network_failure" in fingerprint["matched_patterns"], fingerprint
+    assert "pip_bootstrap_failure" not in fingerprint["matched_patterns"], fingerprint
+
+
+if __name__ == "__main__":
+    test_pip_bootstrap_failure_attribution()
+    test_injected_pip_lines_do_not_mask_later_build_failure()
+    print("skillsbench-failure-attribution-smoke: ok")

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -19,6 +19,7 @@ from ..benchmark_core import (
     canonical_lifecycle,
 )
 from ..codex_goal_baseline import build_codex_app_server_goal_worker_plan
+from .skillsbench_failure_signals import skillsbench_pip_bootstrap_failure_evidence
 from .skillsbench_signals import build_skillsbench_solution_quality_signals
 from .skillsbench_result_discovery import (
     SKILLSBENCH_RESULT_DISCOVERY_SCHEMA_VERSION,
@@ -1674,16 +1675,7 @@ def skillsbench_runner_error_attribution(error_text: str) -> tuple[str, str, lis
                 "skillsbench_docker_compose_setup_failure",
                 "skillsbench_environment_setup_error",
             ]
-        if (
-            "pip install" in text
-            or "python -m pip" in text
-            or "python3 -m pip" in text
-            or "files.pythonhosted.org" in text
-            or "pypi.org" in text
-            or "pypi.tuna.tsinghua.edu.cn" in text
-            or "no matching distribution found" in text
-            or "read timed out" in text
-        ):
+        if skillsbench_pip_bootstrap_failure_evidence(text):
             label = "skillsbench_docker_compose_pip_bootstrap_failure"
             return label, label, [
                 label,
@@ -1771,7 +1763,10 @@ def skillsbench_runner_error_fingerprint(error_text: str) -> dict[str, Any]:
         "service_unhealthy": r"unhealthy|healthcheck|health check",
         "container_exited": r"exited with code|container .* exited|exit code",
         "dependency_failed": r"dependency failed|depends_on|dependency",
-        "network_failure": r"network|connection refused|could not connect",
+        "network_failure": (
+            r"network|connection refused|could not connect|read timed out|"
+            r"connection timed out|connection reset|max retries exceeded"
+        ),
         "volume_mount_failure": r"mount|volume|bind source path",
         "permission_denied": r"permission denied|operation not permitted",
         "missing_file": r"no such file|not found|does not exist",
@@ -1783,18 +1778,18 @@ def skillsbench_runner_error_fingerprint(error_text: str) -> dict[str, Any]:
         "image_build": r"failed to solve|failed to build|dockerfile|pull access denied|manifest unknown",
         "port_conflict": r"port is already allocated|address already in use|ports are not available|bind for",
         "apt_failure": r"apt-get|apt update|apt |gpg error|hash sum mismatch|failed to fetch",
-        "pip_bootstrap_failure": (
-            r"pip install|python3? -m pip|files\.pythonhosted\.org|pypi\.org|"
-            r"pypi\.tuna\.tsinghua\.edu\.cn|no matching distribution found"
-        ),
+        "pip_bootstrap_failure": r"$^",
         "subprocess_command_timeout": r"command timed out after \d+ seconds",
         "timeout": r"timeout|timed out|deadline",
     }
-    matched = [
-        label
-        for label, pattern in patterns.items()
-        if re.search(pattern, lowered)
-    ]
+    matched = []
+    for label, pattern in patterns.items():
+        if label == "pip_bootstrap_failure":
+            pattern_matched = skillsbench_pip_bootstrap_failure_evidence(lowered)
+        else:
+            pattern_matched = bool(re.search(pattern, lowered))
+        if pattern_matched:
+            matched.append(label)
     return {
         "schema_version": "skillsbench_runner_failure_fingerprint_v0",
         "error_present": bool(text),

--- a/loopx/benchmark_adapters/skillsbench_failure_signals.py
+++ b/loopx/benchmark_adapters/skillsbench_failure_signals.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import re
+
+
+def skillsbench_pip_bootstrap_failure_evidence(error_text: str) -> bool:
+    text = error_text.lower()
+    explicit_markers = (
+        "no matching distribution found",
+        "could not find a version that satisfies the requirement",
+        "failed building wheel",
+        "failed to build installable wheels",
+        "subprocess-exited-with-error",
+        "could not install packages due to an oserror",
+        "pip._vendor.",
+        "pip subprocess to install build dependencies did not run successfully",
+    )
+    if any(marker in text for marker in explicit_markers):
+        return True
+
+    package_hosts = (
+        "files.pythonhosted.org",
+        "pypi.org",
+        "pypi.tuna.tsinghua.edu.cn",
+    )
+    network_failures = (
+        "read timed out",
+        "connection timed out",
+        "connection reset",
+        "temporary failure in name resolution",
+        "max retries exceeded",
+    )
+    if any(
+        any(host in line for host in package_hosts)
+        and any(marker in line for marker in network_failures)
+        for line in text.splitlines()
+    ):
+        return True
+
+    pip_command = re.compile(
+        r"(?:python3?|python)\s+-m\s+pip\s+install\b|pip3?\s+install\b"
+    )
+    command_failures = (
+        "did not complete successfully",
+        "returned a non-zero code",
+        "exit code:",
+        " error:",
+        " failed",
+    )
+    return any(
+        pip_command.search(line)
+        and any(marker in line for marker in command_failures)
+        for line in text.splitlines()
+    )


### PR DESCRIPTION
## Summary
- require concrete pip/package failure evidence before assigning pip bootstrap attribution
- keep public failure fingerprints aligned with final attribution
- move the predicate and regression coverage out of existing line-budget hot files

## Validation
- `python3 examples/skillsbench-failure-attribution-smoke.py`
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- focused `py_compile`
- `loopx canary premerge --from-git-diff` (all automated checks passed; expected benchmark-sensitive manual hold)

## Risk
This changes setup-failure classification only. It does not change scoring, countability rules, task semantics, runner execution, uploads, or benchmark launches.