### PR TITLE
Reconcile SkillsBench setup attribution fingerprints

### DIFF
--- a/examples/skillsbench-failure-attribution-smoke.py
+++ b/examples/skillsbench-failure-attribution-smoke.py
@@ -14,6 +14,9 @@ from loopx.benchmark_adapters.skillsbench import (
     skillsbench_runner_error_attribution,
     skillsbench_runner_error_fingerprint,
 )
+from loopx.benchmark_adapters.skillsbench_failure_signals import (
+    reconcile_skillsbench_setup_attribution,
+)
 
 
 def test_pip_bootstrap_failure_attribution() -> None:
@@ -54,7 +57,59 @@ def test_injected_pip_lines_do_not_mask_later_build_failure() -> None:
     assert "pip_bootstrap_failure" not in fingerprint["matched_patterns"], fingerprint
 
 
+def test_setup_attribution_reconciles_to_public_fingerprint() -> None:
+    compact = {
+        "score_failure_attribution": "skillsbench_docker_compose_apt_repository_failure",
+        "failure_attribution_labels": [
+            "skillsbench_docker_compose_apt_repository_failure",
+            "skillsbench_docker_compose_setup_failure",
+            "skillsbench_environment_setup_error",
+        ],
+        "runner_failure": {
+            "exception_type": "skillsbench_docker_compose_apt_repository_failure",
+            "failure_class": "skillsbench_docker_compose_apt_repository_failure",
+        },
+        "runner_failure_fingerprint": {
+            "matched_patterns": [
+                "docker_compose_command_failed",
+                "network_failure",
+                "image_build",
+            ]
+        },
+        "attempt_accounting": {
+            "failure_label": "skillsbench_docker_compose_apt_repository_failure",
+            "failure_class": "job_materialization_failed",
+        },
+        "compose_setup_diagnostic": {
+            "failure_class": "skillsbench_docker_compose_apt_repository_failure"
+        },
+    }
+
+    assert reconcile_skillsbench_setup_attribution(compact) is True
+    expected = "skillsbench_docker_compose_image_build_failure"
+    assert compact["score_failure_attribution"] == expected, compact
+    assert compact["runner_failure"]["failure_class"] == expected, compact
+    assert compact["attempt_accounting"]["failure_label"] == expected, compact
+    assert compact["compose_setup_diagnostic"]["failure_class"] == expected, compact
+    assert "skillsbench_docker_compose_apt_repository_failure" not in compact[
+        "failure_attribution_labels"
+    ], compact
+
+
+def test_supported_setup_attribution_is_unchanged() -> None:
+    compact = {
+        "score_failure_attribution": "skillsbench_docker_compose_apt_repository_failure",
+        "runner_failure_fingerprint": {"matched_patterns": ["apt_failure"]},
+    }
+    assert reconcile_skillsbench_setup_attribution(compact) is False
+    assert compact["score_failure_attribution"] == (
+        "skillsbench_docker_compose_apt_repository_failure"
+    )
+
+
 if __name__ == "__main__":
     test_pip_bootstrap_failure_attribution()
     test_injected_pip_lines_do_not_mask_later_build_failure()
+    test_setup_attribution_reconciles_to_public_fingerprint()
+    test_supported_setup_attribution_is_unchanged()
     print("skillsbench-failure-attribution-smoke: ok")

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -19,7 +19,10 @@ from ..benchmark_core import (
     canonical_lifecycle,
 )
 from ..codex_goal_baseline import build_codex_app_server_goal_worker_plan
-from .skillsbench_failure_signals import skillsbench_pip_bootstrap_failure_evidence
+from .skillsbench_failure_signals import (
+    reconcile_skillsbench_setup_attribution,
+    skillsbench_pip_bootstrap_failure_evidence,
+)
 from .skillsbench_signals import build_skillsbench_solution_quality_signals
 from .skillsbench_result_discovery import (
     SKILLSBENCH_RESULT_DISCOVERY_SCHEMA_VERSION,
@@ -5975,6 +5978,7 @@ def build_skillsbench_benchflow_result_benchmark_run(
         benchmark_run["runner_failure"] = runner_failure
         if runner_failure_fingerprint is not None:
             benchmark_run["runner_failure_fingerprint"] = runner_failure_fingerprint
+    reconcile_skillsbench_setup_attribution(benchmark_run)
     if partial_trajectory and not host_local_acp_codex_exec_failure_present:
         benchmark_run["failure_attribution_labels"].append("partial_trajectory")
     benchmark_run["solution_quality_signals"] = (

--- a/loopx/benchmark_adapters/skillsbench_failure_signals.py
+++ b/loopx/benchmark_adapters/skillsbench_failure_signals.py
@@ -3,6 +3,107 @@ from __future__ import annotations
 import re
 
 
+_SETUP_ATTRIBUTION_FINGERPRINT_PATTERNS = {
+    "skillsbench_docker_daemon_unavailable": "docker_daemon_unavailable",
+    "skillsbench_docker_compose_port_conflict": "port_conflict",
+    "skillsbench_docker_compose_pip_bootstrap_failure": "pip_bootstrap_failure",
+    "skillsbench_docker_compose_apt_repository_failure": "apt_failure",
+    "skillsbench_docker_compose_volume_mount_failure": "volume_mount_failure",
+    "skillsbench_docker_compose_image_build_failure": "image_build",
+}
+_FINGERPRINT_SETUP_ATTRIBUTIONS = (
+    ("docker_daemon_unavailable", "skillsbench_docker_daemon_unavailable"),
+    ("port_conflict", "skillsbench_docker_compose_port_conflict"),
+    ("pip_bootstrap_failure", "skillsbench_docker_compose_pip_bootstrap_failure"),
+    ("apt_failure", "skillsbench_docker_compose_apt_repository_failure"),
+    ("volume_mount_failure", "skillsbench_docker_compose_volume_mount_failure"),
+    ("image_build", "skillsbench_docker_compose_image_build_failure"),
+)
+
+
+def reconcile_skillsbench_setup_attribution(
+    benchmark_run: dict[str, object],
+) -> bool:
+    """Keep setup attribution consistent with its public fingerprint."""
+
+    current = str(benchmark_run.get("score_failure_attribution") or "")
+    required_pattern = _SETUP_ATTRIBUTION_FINGERPRINT_PATTERNS.get(current)
+    fingerprint = benchmark_run.get("runner_failure_fingerprint")
+    if not required_pattern or not isinstance(fingerprint, dict):
+        return False
+    matched_patterns = fingerprint.get("matched_patterns")
+    if not isinstance(matched_patterns, list):
+        return False
+    matched = {
+        str(item)
+        for item in matched_patterns
+        if isinstance(item, str)
+    }
+    if required_pattern in matched:
+        return False
+
+    replacement = next(
+        (
+            attribution
+            for pattern, attribution in _FINGERPRINT_SETUP_ATTRIBUTIONS
+            if pattern in matched
+        ),
+        "skillsbench_docker_compose_setup_failure",
+    )
+    benchmark_run["score_failure_attribution"] = replacement
+    for field in ("first_blocker", "repeat_blocked_by"):
+        if benchmark_run.get(field) == current:
+            benchmark_run[field] = replacement
+
+    specific_labels = set(_SETUP_ATTRIBUTION_FINGERPRINT_PATTERNS)
+    raw_labels = benchmark_run.get("failure_attribution_labels")
+    if not isinstance(raw_labels, list):
+        raw_labels = []
+    labels = [replacement] + [
+        item
+        for item in raw_labels
+        if isinstance(item, str)
+        and item not in specific_labels
+        and item != "skillsbench_docker_compose_unclassified_setup_failure"
+    ]
+    for item in (
+        "skillsbench_docker_compose_setup_failure",
+        "skillsbench_environment_setup_error",
+        "skillsbench_setup_attribution_reconciled_from_fingerprint",
+    ):
+        if item not in labels:
+            labels.append(item)
+    if (
+        replacement == "skillsbench_docker_compose_setup_failure"
+        and "skillsbench_docker_compose_unclassified_setup_failure" not in labels
+    ):
+        labels.append("skillsbench_docker_compose_unclassified_setup_failure")
+    benchmark_run["failure_attribution_labels"] = labels
+
+    runner_failure = benchmark_run.get("runner_failure")
+    if isinstance(runner_failure, dict):
+        for field in ("exception_type", "failure_class"):
+            if runner_failure.get(field) == current:
+                runner_failure[field] = replacement
+    attempt_accounting = benchmark_run.get("attempt_accounting")
+    if (
+        isinstance(attempt_accounting, dict)
+        and attempt_accounting.get("failure_label") == current
+    ):
+        attempt_accounting["failure_label"] = replacement
+    diagnostic = benchmark_run.get("compose_setup_diagnostic")
+    if isinstance(diagnostic, dict):
+        if diagnostic.get("failure_class") == current:
+            diagnostic["failure_class"] = replacement
+        diagnostic["attribution_reconciled_from_fingerprint"] = True
+    trials = benchmark_run.get("trials")
+    if isinstance(trials, list):
+        for trial in trials:
+            if isinstance(trial, dict) and trial.get("exception_type") == current:
+                trial["exception_type"] = replacement
+    return True
+
+
 def skillsbench_pip_bootstrap_failure_evidence(error_text: str) -> bool:
     text = error_text.lower()
     explicit_markers = (


### PR DESCRIPTION
## Summary
- enforce that specialized SkillsBench setup attributions are supported by the public runner failure fingerprint
- fall back to the strongest fingerprint-supported setup category and update compact failure fields atomically
- cover the earthquake-style APT-vs-image-build contradiction and the supported no-op path

## Validation
- `python3 examples/skillsbench-failure-attribution-smoke.py`
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- focused `py_compile` and `git diff --check`
- `loopx canary premerge --from-git-diff` (all checks passed; benchmark-sensitive manual maintainer hold remains)

## Boundaries
- compact public-safe signals only
- no raw task text, trajectories, logs, verifier output, credentials, local paths, scoring semantics, or benchmark launches
