### PR TITLE
Classify SkillsBench network failure dependencies

### DIFF
--- a/examples/skillsbench-failure-attribution-smoke.py
+++ b/examples/skillsbench-failure-attribution-smoke.py
@@ -16,6 +16,7 @@ from loopx.benchmark_adapters.skillsbench import (
 )
 from loopx.benchmark_adapters.skillsbench_failure_signals import (
     reconcile_skillsbench_setup_attribution,
+    skillsbench_failure_dependency_classes,
 )
 
 
@@ -107,9 +108,25 @@ def test_supported_setup_attribution_is_unchanged() -> None:
     )
 
 
+def test_failure_dependency_classes_ignore_unrelated_dockerfile_lines() -> None:
+    error_text = (
+        "RUN apt-get update\n"
+        "RUN pip3 install numpy\n"
+        "ERROR: failed to solve: process /bin/sh -c micromamba install scipy "
+        "from https://repo.anaconda.com did not complete successfully: "
+        "connection timed out"
+    )
+    classes = skillsbench_failure_dependency_classes(error_text)
+    assert classes == ["conda_package"], classes
+    fingerprint = skillsbench_runner_error_fingerprint(error_text)
+    assert fingerprint["failure_line_dependency_classes"] == classes, fingerprint
+    assert "repo.anaconda.com" not in str(fingerprint), fingerprint
+
+
 if __name__ == "__main__":
     test_pip_bootstrap_failure_attribution()
     test_injected_pip_lines_do_not_mask_later_build_failure()
     test_setup_attribution_reconciles_to_public_fingerprint()
     test_supported_setup_attribution_is_unchanged()
+    test_failure_dependency_classes_ignore_unrelated_dockerfile_lines()
     print("skillsbench-failure-attribution-smoke: ok")

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -22,6 +22,7 @@ from ..codex_goal_baseline import build_codex_app_server_goal_worker_plan
 from .skillsbench_failure_signals import (
     reconcile_skillsbench_setup_attribution,
     skillsbench_pip_bootstrap_failure_evidence,
+    skillsbench_runner_error_fingerprint,
 )
 from .skillsbench_signals import build_skillsbench_solution_quality_signals
 from .skillsbench_result_discovery import (
@@ -1735,80 +1736,6 @@ def skillsbench_runner_error_attribution(error_text: str) -> tuple[str, str, lis
         return label, label, [label, "skillsbench_host_local_acp_recoverable_timeout"]
     label = "skillsbench_runner_error"
     return label, label, [label]
-
-
-def skillsbench_error_len_bucket(text: str) -> str:
-    size = len(text)
-    if size <= 0:
-        return "empty"
-    if size < 200:
-        return "1_199"
-    if size < 500:
-        return "200_499"
-    if size < 1000:
-        return "500_999"
-    if size < 2000:
-        return "1000_1999"
-    return "2000_plus"
-
-
-def skillsbench_runner_error_fingerprint(error_text: str) -> dict[str, Any]:
-    """Return a public-safe shape summary without copying raw error text."""
-
-    text = error_text or ""
-    lowered = text.lower()
-    patterns = {
-        "docker_compose_command_failed": r"docker compose command failed",
-        "docker_daemon_unavailable": (
-            r"cannot connect to the docker daemon|is the docker daemon running|"
-            r"docker daemon is not running|colima is not running|error during connect"
-        ),
-        "service_unhealthy": r"unhealthy|healthcheck|health check",
-        "container_exited": r"exited with code|container .* exited|exit code",
-        "dependency_failed": r"dependency failed|depends_on|dependency",
-        "network_failure": (
-            r"network|connection refused|could not connect|read timed out|"
-            r"connection timed out|connection reset|max retries exceeded"
-        ),
-        "volume_mount_failure": r"mount|volume|bind source path",
-        "permission_denied": r"permission denied|operation not permitted",
-        "missing_file": r"no such file|not found|does not exist",
-        "codex_api_egress_failure": (
-            r"codex api egress preflight|reverse tunnel proxy|"
-            r"loopx_codex_api_reverse_tunnel_proxy"
-        ),
-        "task_output_quiet_timeout": r"codex_exec_task_output_quiet_timeout",
-        "image_build": r"failed to solve|failed to build|dockerfile|pull access denied|manifest unknown",
-        "port_conflict": r"port is already allocated|address already in use|ports are not available|bind for",
-        "apt_failure": r"apt-get|apt update|apt |gpg error|hash sum mismatch|failed to fetch",
-        "pip_bootstrap_failure": r"$^",
-        "subprocess_command_timeout": r"command timed out after \d+ seconds",
-        "timeout": r"timeout|timed out|deadline",
-    }
-    matched = []
-    for label, pattern in patterns.items():
-        if label == "pip_bootstrap_failure":
-            pattern_matched = skillsbench_pip_bootstrap_failure_evidence(lowered)
-        else:
-            pattern_matched = bool(re.search(pattern, lowered))
-        if pattern_matched:
-            matched.append(label)
-    return {
-        "schema_version": "skillsbench_runner_failure_fingerprint_v0",
-        "error_present": bool(text),
-        "error_len_bucket": skillsbench_error_len_bucket(text),
-        "line_count": len(text.splitlines()) if text else 0,
-        "matched_patterns": matched,
-        "has_host_paths": bool(
-            re.search(r"/Users/|/private/|/var/folders/", text)
-        ),
-        "has_urls": bool(re.search(r"https?://", text)),
-        "has_secret_like_tokens": bool(
-            re.search(r"(?i)(api[_-]?key|token|password|secret)", text)
-        ),
-        "raw_error_recorded": False,
-        "fingerprint_confidence": "coarse_public_safe_pattern_match",
-    }
 
 
 def build_skillsbench_benchmark_run(

--- a/loopx/benchmark_adapters/skillsbench_failure_signals.py
+++ b/loopx/benchmark_adapters/skillsbench_failure_signals.py
@@ -19,6 +19,65 @@ _FINGERPRINT_SETUP_ATTRIBUTIONS = (
     ("volume_mount_failure", "skillsbench_docker_compose_volume_mount_failure"),
     ("image_build", "skillsbench_docker_compose_image_build_failure"),
 )
+_FAILURE_LINE_MARKERS = (
+    "connection refused",
+    "connection reset",
+    "connection timed out",
+    "could not connect",
+    "did not complete successfully",
+    "failed to download",
+    "failed to fetch",
+    "failed to solve",
+    "manifest unknown",
+    "max retries exceeded",
+    "pull access denied",
+    "read timed out",
+    "temporary failure in name resolution",
+)
+_FAILURE_DEPENDENCY_CLASS_PATTERNS = (
+    (
+        "container_registry",
+        r"registry-1\.docker\.io|docker\.io|gcr\.io|ghcr\.io|manifest unknown|"
+        r"pull access denied|resolve source metadata",
+    ),
+    (
+        "python_package",
+        r"python\S*\s+-m\s+pip\s+install|pip3?\s+install|pypi\.|"
+        r"pythonhosted\.org",
+    ),
+    ("python_uv", r"\buvx?\b|astral\.sh"),
+    ("conda_package", r"\bconda\b|\bmamba\b|anaconda\.(?:com|org)"),
+    ("node_package", r"\bnpm\b|\byarn\b|\bpnpm\b|registry\.npmjs\.org"),
+    (
+        "java_package",
+        r"\bmvn\b|\bmaven\b|\bgradle\b|repo1\.maven\.org|"
+        r"repo\.maven\.apache\.org",
+    ),
+    ("rust_package", r"\bcargo\b|\brustup\b|crates\.io|static\.rust-lang\.org"),
+    ("go_module", r"\bgo\s+(?:mod|install|get)\b|proxy\.golang\.org"),
+    ("git_source", r"\bgit\s+clone\b|github\.com|gitlab\.com"),
+    ("http_download", r"\bcurl\b|\bwget\b"),
+    (
+        "cloud_object_storage",
+        r"s3[.-][^/ ]*amazonaws\.com|storage\.googleapis\.com",
+    ),
+    ("model_artifact", r"huggingface\.co|hf\.co"),
+)
+
+
+def skillsbench_failure_dependency_classes(error_text: str) -> list[str]:
+    """Classify dependencies named on public-safe failure lines."""
+
+    failure_lines = [
+        line.lower()
+        for line in error_text.splitlines()
+        if any(marker in line.lower() for marker in _FAILURE_LINE_MARKERS)
+    ]
+    return [
+        label
+        for label, pattern in _FAILURE_DEPENDENCY_CLASS_PATTERNS
+        if any(re.search(pattern, line) for line in failure_lines)
+    ]
 
 
 def reconcile_skillsbench_setup_attribution(
@@ -153,3 +212,86 @@ def skillsbench_pip_bootstrap_failure_evidence(error_text: str) -> bool:
         and any(marker in line for marker in command_failures)
         for line in text.splitlines()
     )
+
+
+def skillsbench_error_len_bucket(text: str) -> str:
+    size = len(text)
+    if size <= 0:
+        return "empty"
+    if size < 200:
+        return "1_199"
+    if size < 500:
+        return "200_499"
+    if size < 1000:
+        return "500_999"
+    if size < 2000:
+        return "1000_1999"
+    return "2000_plus"
+
+
+def skillsbench_runner_error_fingerprint(error_text: str) -> dict[str, object]:
+    """Return a public-safe shape summary without copying raw error text."""
+
+    text = error_text or ""
+    lowered = text.lower()
+    patterns = {
+        "docker_compose_command_failed": r"docker compose command failed",
+        "docker_daemon_unavailable": (
+            r"cannot connect to the docker daemon|is the docker daemon running|"
+            r"docker daemon is not running|colima is not running|error during connect"
+        ),
+        "service_unhealthy": r"unhealthy|healthcheck|health check",
+        "container_exited": r"exited with code|container .* exited|exit code",
+        "dependency_failed": r"dependency failed|depends_on|dependency",
+        "network_failure": (
+            r"network|connection refused|could not connect|read timed out|"
+            r"connection timed out|connection reset|max retries exceeded"
+        ),
+        "volume_mount_failure": r"mount|volume|bind source path",
+        "permission_denied": r"permission denied|operation not permitted",
+        "missing_file": r"no such file|not found|does not exist",
+        "codex_api_egress_failure": (
+            r"codex api egress preflight|reverse tunnel proxy|"
+            r"loopx_codex_api_reverse_tunnel_proxy"
+        ),
+        "task_output_quiet_timeout": r"codex_exec_task_output_quiet_timeout",
+        "image_build": (
+            r"failed to solve|failed to build|dockerfile|pull access denied|"
+            r"manifest unknown"
+        ),
+        "port_conflict": (
+            r"port is already allocated|address already in use|"
+            r"ports are not available|bind for"
+        ),
+        "apt_failure": (
+            r"apt-get|apt update|apt |gpg error|hash sum mismatch|failed to fetch"
+        ),
+        "pip_bootstrap_failure": r"$^",
+        "subprocess_command_timeout": r"command timed out after \d+ seconds",
+        "timeout": r"timeout|timed out|deadline",
+    }
+    matched = []
+    for label, pattern in patterns.items():
+        if label == "pip_bootstrap_failure":
+            pattern_matched = skillsbench_pip_bootstrap_failure_evidence(lowered)
+        else:
+            pattern_matched = bool(re.search(pattern, lowered))
+        if pattern_matched:
+            matched.append(label)
+    return {
+        "schema_version": "skillsbench_runner_failure_fingerprint_v0",
+        "error_present": bool(text),
+        "error_len_bucket": skillsbench_error_len_bucket(text),
+        "line_count": len(text.splitlines()) if text else 0,
+        "matched_patterns": matched,
+        "failure_line_dependency_classes": skillsbench_failure_dependency_classes(
+            text
+        ),
+        "has_host_paths": bool(re.search(r"/Users/|/private/|/var/folders/", text)),
+        "has_urls": bool(re.search(r"https?://", text)),
+        "has_secret_like_tokens": bool(
+            re.search(r"(?i)(api[_-]?key|token|password|secret)", text)
+        ),
+        "raw_error_recorded": False,
+        "fingerprint_confidence": "coarse_public_safe_pattern_match",
+    }


### PR DESCRIPTION
## Summary
- add compact failure-line dependency classes for image-build/network failures without recording raw hosts or URLs
- ignore unrelated Dockerfile lines so injected apt/pip setup does not mask the failing dependency class
- move the existing runner fingerprint builder out of the 6k-line SkillsBench adapter into the failure-signals bounded context

## Validation
- `python3 examples/skillsbench-failure-attribution-smoke.py`
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- focused `py_compile`, `git diff --check`, and `loopx check` public-boundary scan
- `loopx canary premerge --from-git-diff` (all checks passed; generic benchmark-sensitive maintainer hold remains)

## Boundaries
- public-safe enum classes only; no hostnames, URLs, raw logs, task text, trajectories, verifier output, credentials, scoring changes, or benchmark launches
