### PR TITLE
Preserve SkillsBench fingerprint evidence in compacts

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -4891,6 +4891,11 @@ def test_skillsbench_docker_apt_failure_attribution() -> None:
         assert "skillsbench_environment_setup_error" in compact[
             "failure_attribution_labels"
         ], compact
+        fingerprint = compact["runner_failure_fingerprint"]
+        assert "apt_failure" in fingerprint["matched_patterns"], fingerprint
+        assert fingerprint["failure_line_dependency_classes"] == [
+            "system_package"
+        ], fingerprint
         text = json.dumps(compact, sort_keys=True)
         assert "Hash Sum mismatch" not in text, compact
         assert "Docker compose command failed" not in text, compact

--- a/loopx/benchmark_adapters/skillsbench_failure_signals.py
+++ b/loopx/benchmark_adapters/skillsbench_failure_signals.py
@@ -28,6 +28,8 @@ _FAILURE_LINE_MARKERS = (
     "failed to download",
     "failed to fetch",
     "failed to solve",
+    "gpg error",
+    "hash sum mismatch",
     "manifest unknown",
     "max retries exceeded",
     "pull access denied",
@@ -35,6 +37,11 @@ _FAILURE_LINE_MARKERS = (
     "temporary failure in name resolution",
 )
 _FAILURE_DEPENDENCY_CLASS_PATTERNS = (
+    (
+        "system_package",
+        r"\bapt-get\b|\bapt\s+update\b|gpg error|hash sum mismatch|"
+        r"failed to fetch",
+    ),
     (
         "container_registry",
         r"registry-1\.docker\.io|docker\.io|gcr\.io|ghcr\.io|manifest unknown|"

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -4111,12 +4111,11 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
             bool,
         ):
             compact_fingerprint["line_count"] = fingerprint["line_count"]
-        matched_patterns = public_safe_compact_list(
-            fingerprint.get("matched_patterns"),
-            limit=MAX_BENCHMARK_RUN_LIST_ITEMS,
-        )
-        if matched_patterns:
-            compact_fingerprint["matched_patterns"] = matched_patterns
+        for field, limit in (("matched_patterns", MAX_BENCHMARK_RUN_LIST_ITEMS * 4),
+                             ("failure_line_dependency_classes", MAX_BENCHMARK_RUN_LIST_ITEMS * 2)):
+            values = public_safe_compact_list(fingerprint.get(field), limit=limit)
+            if values:
+                compact_fingerprint[field] = values
         for field in (
             "error_present",
             "has_host_paths",

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -4106,13 +4106,13 @@ def compact_benchmark_run(run: dict[str, Any]) -> dict[str, Any] | None:
             value = public_safe_compact_text(fingerprint.get(field), limit=100)
             if value:
                 compact_fingerprint[field] = value
-        if isinstance(fingerprint.get("line_count"), int) and not isinstance(
-            fingerprint.get("line_count"),
-            bool,
+        line_count = fingerprint.get("line_count")
+        if isinstance(line_count, int) and not isinstance(line_count, bool):
+            compact_fingerprint["line_count"] = line_count
+        for field, limit in (
+            ("matched_patterns", MAX_BENCHMARK_RUN_LIST_ITEMS * 4),
+            ("failure_line_dependency_classes", MAX_BENCHMARK_RUN_LIST_ITEMS * 2),
         ):
-            compact_fingerprint["line_count"] = fingerprint["line_count"]
-        for field, limit in (("matched_patterns", MAX_BENCHMARK_RUN_LIST_ITEMS * 4),
-                             ("failure_line_dependency_classes", MAX_BENCHMARK_RUN_LIST_ITEMS * 2)):
             values = public_safe_compact_list(fingerprint.get(field), limit=limit)
             if values:
                 compact_fingerprint[field] = values


### PR DESCRIPTION
## Summary
- preserve up to 20 bounded runner fingerprint patterns so late, specific setup evidence is not truncated behind generic patterns
- preserve fixed-enum failure-line dependency classes in public compact output
- classify APT/GPG/hash failures as `system_package`
- add end-to-end APT compact assertions

## Validation
- focused failure-attribution smoke
- full SkillsBench benchmark-run smoke
- repository Python line-budget smoke
- focused py_compile and diff check
- LoopX public-boundary check
- premerge canary: 8 catalog + 8 risk-profile + public-boundary checks passed; generic benchmark-sensitive maintainer hold remains

## Boundaries
No raw logs, task text, trajectories, verifier output, hosts, URLs, credentials, scoring changes, task-semantics changes, or benchmark launches.
