### PR TITLE
Preserve replan ACKs across bounded progress

### DIFF
--- a/examples/control_plane/quota-replan-decision-plane-smoke.py
+++ b/examples/control_plane/quota-replan-decision-plane-smoke.py
@@ -103,6 +103,17 @@ def side_agent_claimed_advancement(
     }
 
 
+def long_side_agent_todo_chain() -> list[dict]:
+    return [
+        side_agent_claimed_advancement(
+            index=index,
+            todo_id=f"todo_side_chain_{index:02d}",
+            text=f"[P1] Continue long-chain fixture slice {index}.",
+        )
+        for index in range(1, 16)
+    ]
+
+
 def completed_side_agent_advancement_without_successor() -> dict:
     return {
         "index": 3,
@@ -305,6 +316,19 @@ def watch_lane_continuation_ack_run(
             },
         },
     }
+
+
+def material_progress_runs_after_replan_ack(count: int) -> list[dict]:
+    return [
+        {
+            "classification": "benchmark_rotation_iteration",
+            "generated_at": f"2026-07-04T00:{minute:02d}:00+00:00",
+            "agent_id": SIDE_AGENT,
+            "progress_scope": "agent_lane",
+            "delivery_outcome": "outcome_progress",
+        }
+        for minute in range(count, 0, -1)
+    ]
 
 
 def missing_vision_checkpoint_run(*, agent_id: str = SIDE_AGENT) -> dict:
@@ -574,16 +598,8 @@ def assert_replan_preserves_current_agent_runnable_frontier() -> None:
 
 
 def assert_long_agent_todo_chain_derives_replan_before_linear_delivery() -> None:
-    long_chain = [
-        side_agent_claimed_advancement(
-            index=index,
-            todo_id=f"todo_side_chain_{index:02d}",
-            text=f"[P1] Continue long-chain fixture slice {index}.",
-        )
-        for index in range(1, 16)
-    ]
     guard = build_quota_should_run(
-        status_payload(long_chain, replan_obligation=None),
+        status_payload(long_side_agent_todo_chain(), replan_obligation=None),
         goal_id=GOAL_ID,
         agent_id=SIDE_AGENT,
     )
@@ -611,6 +627,48 @@ def assert_long_agent_todo_chain_derives_replan_before_linear_delivery() -> None
     assert "--todo-id" not in required_reads[0]["command"], required_reads
     markdown = render_quota_should_run_markdown(guard)
     assert "triggers=long_todo_chain" in markdown, markdown
+
+
+def assert_material_progress_does_not_immediately_invalidate_long_chain_replan_ack() -> None:
+    guard = build_quota_should_run(
+        status_payload(
+            long_side_agent_todo_chain(),
+            replan_obligation=None,
+            latest_runs=[
+                *material_progress_runs_after_replan_ack(1),
+                watch_lane_continuation_ack_run(
+                    delta_kinds=["runnable_todo_set", "monitor_target"]
+                ),
+            ],
+        ),
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+    )
+    assert guard["decision"] == "run", guard
+    assert guard["effective_action"] == "normal_run", guard
+    assert "autonomous_replan_obligation" not in guard, guard
+
+
+def assert_long_chain_replan_ack_expires_after_material_review_window() -> None:
+    guard = build_quota_should_run(
+        status_payload(
+            long_side_agent_todo_chain(),
+            replan_obligation=None,
+            latest_runs=[
+                *material_progress_runs_after_replan_ack(20),
+                watch_lane_continuation_ack_run(
+                    delta_kinds=["runnable_todo_set", "monitor_target"]
+                ),
+            ],
+        ),
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+    )
+    assert guard["decision"] == "autonomous_replan_required", guard
+    assert guard["effective_action"] == "autonomous_replan_required", guard
+    assert guard["autonomous_replan_obligation"]["triggers"][0]["kind"] == (
+        "long_todo_chain"
+    ), guard
 
 
 def assert_agent_vision_gap_derives_replan() -> None:
@@ -1180,6 +1238,8 @@ def main() -> None:
     assert_completed_advancement_without_successor_beats_monitor_quiet_skip()
     assert_replan_preserves_current_agent_runnable_frontier()
     assert_long_agent_todo_chain_derives_replan_before_linear_delivery()
+    assert_material_progress_does_not_immediately_invalidate_long_chain_replan_ack()
+    assert_long_chain_replan_ack_expires_after_material_review_window()
     assert_agent_vision_gap_derives_replan()
     assert_closed_agent_vision_allows_bounded_monitor_wait()
     assert_goal_frontier_context_helper_matches_quota_payload()

--- a/loopx/control_plane/work_items/autonomous_replan_ack.py
+++ b/loopx/control_plane/work_items/autonomous_replan_ack.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 from typing import Any
 
 
+AUTONOMOUS_REPLAN_ACK_MATERIAL_RUN_WINDOW = 20
+
+
 def autonomous_replan_ack_recorded(run: dict[str, Any]) -> bool:
     ack = run.get("autonomous_replan_ack")
     if not isinstance(ack, dict) or ack.get("recorded") is not True:
@@ -60,8 +63,9 @@ def latest_autonomous_replan_ack_for_projection(
     *,
     neutral_classifications: set[str],
 ) -> dict[str, Any] | None:
-    """Return the newest durable replan ACK, skipping neutral accounting runs."""
+    """Return a recent durable replan ACK within the material review window."""
 
+    material_run_count = 0
     for run in latest_runs or []:
         if not isinstance(run, dict):
             continue
@@ -75,5 +79,7 @@ def latest_autonomous_replan_ack_for_projection(
             continue
         if classification == "quota_monitor_poll":
             continue
-        return None
+        material_run_count += 1
+        if material_run_count >= AUTONOMOUS_REPLAN_ACK_MATERIAL_RUN_WINDOW:
+            return None
     return None

--- a/loopx/status.py
+++ b/loopx/status.py
@@ -132,6 +132,7 @@ from .control_plane.work_items.attention_fields import (
     readiness_attention_fields as _readiness_attention_fields_read_model,
 )
 from .control_plane.work_items.autonomous_replan_ack import (
+    AUTONOMOUS_REPLAN_ACK_MATERIAL_RUN_WINDOW,
     autonomous_replan_ack_recorded,
     compact_autonomous_replan_ack,
     latest_autonomous_replan_ack_for_projection as _latest_autonomous_replan_ack_for_projection_read_model,
@@ -595,7 +596,7 @@ MAX_BACKLOG_HYGIENE_EVIDENCE_ITEMS = _MAX_BACKLOG_HYGIENE_EVIDENCE_ITEMS_READ_MO
 MAX_AUTONOMOUS_REPLAN_TRIGGERS = _MAX_AUTONOMOUS_REPLAN_TRIGGERS_READ_MODEL
 AUTONOMOUS_REPLAN_STALL_THRESHOLD = 2
 DEAD_MONITOR_REPEAT_THRESHOLD = 6
-AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD = 20
+AUTONOMOUS_REPLAN_PERIODIC_RUN_THRESHOLD = AUTONOMOUS_REPLAN_ACK_MATERIAL_RUN_WINDOW
 AUTONOMOUS_REPLAN_PERIODIC_LOOKBACK = 30
 BACKLOG_HYGIENE_SECTION_HEADINGS = ("Next Action", "Operating Lessons")
 BACKLOG_HYGIENE_BULLET_PATTERN = re.compile(r"^\s*(?:[-*]|\d+[.)])\s+(.+?)\s*$")


### PR DESCRIPTION
## Summary
- keep a durable autonomous-replan ACK projected across subsequent material progress until the existing 20-run review window expires
- use the same constant for ACK validity and periodic replan cadence
- cover both immediate post-ACK progress and bounded expiry for long todo chains

## Validation
- `python3 examples/control_plane/quota-replan-decision-plane-smoke.py`
- `python3 examples/autonomous-replan-obligation-smoke.py --subprocess-cli`
- `python3 examples/control_plane/status-neutral-run-window-smoke.py`
- `python3 examples/control_plane/heartbeat-quota-flow-smoke.py`
- `python3 examples/project/goal-vision-refresh-state-budget-smoke.py`
- `python3 -m loopx.cli --format json check`
- `python3 -m loopx.cli --format json canary premerge --from-git-diff` (17/17 selected checks passed)