### PR TITLE
Prewarm SkillsBench base images through benchmark proxy

### DIFF
--- a/examples/skillsbench-benchmark-egress-policy-smoke.py
+++ b/examples/skillsbench-benchmark-egress-policy-smoke.py
@@ -9,11 +9,14 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 sys.path.insert(0, str(REPO_ROOT))
 
 from scripts import skillsbench_automation_loop as skillsbench_loop
+from loopx.benchmark_adapters import skillsbench_proxy_runtime as proxy_runtime
 
 
 def _make_skillsbench_root(root: Path) -> Path:
@@ -232,10 +235,58 @@ def test_verifier_proxy_patch_is_required_only_for_existing_verifier() -> None:
         assert patched["benchmark_egress_proxy_verifier_env_key_count"] > 0
 
 
+def test_proxy_runtime_prewarms_external_base_images_without_public_refs() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-base-image-prewarm-") as tmp:
+        dockerfile = Path(tmp) / "Dockerfile"
+        image = "gcr.io/oss-fuzz-base/base-builder-python:latest"
+        dockerfile.write_text(
+            f"FROM {image} AS builder\n"
+            "FROM builder AS final\n",
+            encoding="utf-8",
+        )
+        calls: list[list[str]] = []
+
+        def fake_run(argv: list[str], **_kwargs: object) -> SimpleNamespace:
+            calls.append(argv)
+            cached = argv[1:3] == ["image", "inspect"]
+            return SimpleNamespace(returncode=1 if cached else 0)
+
+        with mock.patch.object(
+            proxy_runtime.shutil,
+            "which",
+            side_effect=lambda name: f"/usr/bin/{name}",
+        ), mock.patch.object(proxy_runtime.subprocess, "run", side_effect=fake_run):
+            metadata = proxy_runtime.prewarm_dockerfile_base_images(
+                dockerfile,
+                enabled=True,
+            )
+
+        assert metadata["benchmark_egress_proxy_base_image_prewarm_status"] == "completed"
+        assert metadata["benchmark_egress_proxy_base_image_prewarm_candidate_count"] == 1
+        assert metadata["benchmark_egress_proxy_base_image_prewarm_attempted_count"] == 1
+        assert metadata["benchmark_egress_proxy_base_image_prewarm_loaded_count"] == 1
+        assert metadata["benchmark_egress_proxy_base_image_prewarm_failed_count"] == 0
+        assert metadata["benchmark_egress_proxy_base_image_prewarm_raw_image_refs_recorded"] is False
+        assert metadata["benchmark_egress_proxy_base_image_prewarm_raw_output_recorded"] is False
+        assert image not in json.dumps(metadata, sort_keys=True), metadata
+        public_prerequisites = skillsbench_loop._public_runner_prerequisites(metadata)
+        public_config = skillsbench_loop._public_runner_config(
+            {"runner_prerequisites": metadata}
+        )
+        assert public_prerequisites == metadata, public_prerequisites
+        for key, value in metadata.items():
+            assert public_config[key] == value, public_config
+        assert image not in json.dumps(public_prerequisites, sort_keys=True)
+        skopeo_calls = [call for call in calls if call[0] == "/usr/bin/skopeo"]
+        assert len(skopeo_calls) == 1, calls
+        assert skopeo_calls[0][-2:] == [f"docker://{image}", f"docker-daemon:{image}"]
+
+
 if __name__ == "__main__":
     test_formal_cli_goal_auto_requires_benchmark_egress_proxy()
     test_formal_cli_goal_proxy_env_is_forwarded_without_public_url()
     test_public_launcher_uses_container_reachable_benchmark_proxy()
     test_public_launcher_batches_three_cases_with_closeout_sync()
     test_verifier_proxy_patch_is_required_only_for_existing_verifier()
+    test_proxy_runtime_prewarms_external_base_images_without_public_refs()
     print("skillsbench-benchmark-egress-policy-smoke: ok")

--- a/loopx/benchmark_adapters/skillsbench_proxy_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_proxy_runtime.py
@@ -2,8 +2,31 @@
 
 from __future__ import annotations
 
+import contextlib
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
 from collections.abc import Mapping, MutableMapping
+from pathlib import Path
 from typing import Any
+
+try:
+    import fcntl
+except ImportError:  # pragma: no cover - Windows import compatibility
+    fcntl = None  # type: ignore[assignment]
+
+
+BASE_IMAGE_PREWARM_TIMEOUT_SECONDS = 900.0
+_DOCKERFILE_FROM_PATTERN = re.compile(
+    r"^\s*FROM(?:\s+--platform=\S+)?\s+(?P<image>\S+)"
+    r"(?:\s+AS\s+(?P<alias>\S+))?\s*$",
+    flags=re.IGNORECASE,
+)
+_SAFE_IMAGE_REFERENCE_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/:@+-]{0,511}$")
 
 
 def apply_proxy_runtime_env(
@@ -25,3 +48,240 @@ def apply_proxy_runtime_env(
         prerequisites["benchmark_egress_proxy_docker_config_injected"] = True
         prerequisites["benchmark_egress_proxy_docker_config_path_recorded"] = False
         prerequisites["benchmark_egress_proxy_docker_config_raw_proxy_recorded"] = False
+
+
+def _docker_config_payload_with_proxy(*, proxy_url: str, no_proxy: str) -> dict[str, Any]:
+    docker_config_dir = os.environ.get("DOCKER_CONFIG")
+    source_config = (
+        Path(docker_config_dir).expanduser() / "config.json"
+        if docker_config_dir
+        else Path.home() / ".docker" / "config.json"
+    )
+    payload: dict[str, Any] = {}
+    if source_config.exists():
+        try:
+            loaded = json.loads(source_config.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            loaded = {}
+        if isinstance(loaded, dict):
+            payload = loaded
+    proxies = payload.setdefault("proxies", {})
+    if not isinstance(proxies, dict):
+        proxies = {}
+        payload["proxies"] = proxies
+    proxies["default"] = {
+        "httpProxy": proxy_url,
+        "httpsProxy": proxy_url,
+        "noProxy": no_proxy,
+    }
+    return payload
+
+
+@contextlib.contextmanager
+def proxy_runtime_env_applied(
+    proxy_env: Mapping[str, str], *, plan: dict[str, Any] | None = None
+) -> Any:
+    if not proxy_env:
+        yield
+        return
+    docker_config_tmp: tempfile.TemporaryDirectory[str] | None = None
+    docker_config_env: dict[str, str] = {}
+    proxy_url = proxy_env.get("LOOPX_SKILLSBENCH_EGRESS_PROXY", "")
+    if proxy_url:
+        docker_config_tmp = tempfile.TemporaryDirectory(
+            prefix="loopx-skillsbench-docker-proxy-"
+        )
+        docker_config_path = Path(docker_config_tmp.name) / "config.json"
+        docker_config_path.write_text(
+            json.dumps(
+                _docker_config_payload_with_proxy(
+                    proxy_url=proxy_url,
+                    no_proxy=proxy_env.get("NO_PROXY", "localhost,127.0.0.1,::1"),
+                ),
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        docker_config_env["DOCKER_CONFIG"] = docker_config_tmp.name
+    keys = set(proxy_env) | set(docker_config_env)
+    previous = {key: os.environ.get(key) for key in keys}
+    try:
+        apply_proxy_runtime_env(os.environ, proxy_env, docker_config_env, plan=plan)
+        yield
+    finally:
+        for key, value in previous.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
+        if docker_config_tmp is not None:
+            docker_config_tmp.cleanup()
+
+
+def dockerfile_external_base_images(dockerfile: Path) -> list[str]:
+    """Return external FROM references while excluding scratch and stage aliases."""
+
+    if not dockerfile.exists():
+        return []
+    try:
+        lines = dockerfile.read_text(encoding="utf-8", errors="replace").splitlines()
+    except OSError:
+        return []
+    aliases: set[str] = set()
+    images: list[str] = []
+    seen: set[str] = set()
+    for line in lines:
+        match = _DOCKERFILE_FROM_PATTERN.match(line)
+        if not match:
+            continue
+        image = match.group("image").strip()
+        image_key = image.lower()
+        if (
+            image_key == "scratch"
+            or image_key in aliases
+            or "$" in image
+            or not _SAFE_IMAGE_REFERENCE_PATTERN.fullmatch(image)
+        ):
+            alias = str(match.group("alias") or "").strip().lower()
+            if alias:
+                aliases.add(alias)
+            continue
+        if image not in seen:
+            images.append(image)
+            seen.add(image)
+        alias = str(match.group("alias") or "").strip().lower()
+        if alias:
+            aliases.add(alias)
+    return images
+
+
+def _image_cached(docker_bin: str, image: str) -> bool:
+    try:
+        result = subprocess.run(
+            [docker_bin, "image", "inspect", image],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return result.returncode == 0
+
+
+def prewarm_dockerfile_base_images(
+    dockerfile: Path,
+    *,
+    enabled: bool,
+    timeout_seconds: float = BASE_IMAGE_PREWARM_TIMEOUT_SECONDS,
+) -> dict[str, Any]:
+    """Load Dockerfile base images through proxy-aware skopeo into daemon cache."""
+
+    images = dockerfile_external_base_images(dockerfile) if enabled else []
+    docker_bin = shutil.which("docker") if images else None
+    skopeo_bin = shutil.which("skopeo") if images else None
+    metadata: dict[str, Any] = {
+        "benchmark_egress_proxy_base_image_prewarm_status": (
+            "pending" if images else "not_required"
+        ),
+        "benchmark_egress_proxy_base_image_prewarm_required": bool(images),
+        "benchmark_egress_proxy_base_image_prewarm_docker_available": bool(docker_bin),
+        "benchmark_egress_proxy_base_image_prewarm_skopeo_available": bool(skopeo_bin),
+        "benchmark_egress_proxy_base_image_prewarm_candidate_count": len(images),
+        "benchmark_egress_proxy_base_image_prewarm_attempted_count": 0,
+        "benchmark_egress_proxy_base_image_prewarm_cache_hit_count": 0,
+        "benchmark_egress_proxy_base_image_prewarm_loaded_count": 0,
+        "benchmark_egress_proxy_base_image_prewarm_failed_count": 0,
+        "benchmark_egress_proxy_base_image_prewarm_raw_image_refs_recorded": False,
+        "benchmark_egress_proxy_base_image_prewarm_raw_output_recorded": False,
+    }
+    if not images:
+        return metadata
+    if not docker_bin or not skopeo_bin:
+        metadata["benchmark_egress_proxy_base_image_prewarm_status"] = "tool_missing"
+        return metadata
+
+    timeout = max(30.0, float(timeout_seconds or 0.0))
+    for image in images:
+        if _image_cached(docker_bin, image):
+            metadata["benchmark_egress_proxy_base_image_prewarm_cache_hit_count"] += 1
+            continue
+        lock_digest = hashlib.sha256(image.encode("utf-8")).hexdigest()[:16]
+        lock_path = Path(tempfile.gettempdir()) / (
+            f"loopx-skillsbench-image-prewarm-{lock_digest}.lock"
+        )
+        try:
+            with lock_path.open("a", encoding="utf-8") as lock_file:
+                if fcntl is not None:
+                    fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+                if _image_cached(docker_bin, image):
+                    metadata[
+                        "benchmark_egress_proxy_base_image_prewarm_cache_hit_count"
+                    ] += 1
+                    continue
+                metadata[
+                    "benchmark_egress_proxy_base_image_prewarm_attempted_count"
+                ] += 1
+                result = subprocess.run(
+                    [
+                        skopeo_bin,
+                        "copy",
+                        "--retry-times",
+                        "3",
+                        f"docker://{image}",
+                        f"docker-daemon:{image}",
+                    ],
+                    stdin=subprocess.DEVNULL,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    check=False,
+                    timeout=timeout,
+                )
+        except (OSError, subprocess.TimeoutExpired):
+            metadata["benchmark_egress_proxy_base_image_prewarm_failed_count"] += 1
+            continue
+        if result.returncode == 0:
+            metadata["benchmark_egress_proxy_base_image_prewarm_loaded_count"] += 1
+        else:
+            metadata["benchmark_egress_proxy_base_image_prewarm_failed_count"] += 1
+
+    failed = metadata["benchmark_egress_proxy_base_image_prewarm_failed_count"]
+    if failed == 0:
+        status = "completed"
+    elif failed == len(images):
+        status = "failed"
+    else:
+        status = "partial"
+    metadata["benchmark_egress_proxy_base_image_prewarm_status"] = status
+    return metadata
+
+
+def compact_base_image_prewarm_fields(value: Mapping[str, Any] | None) -> dict[str, Any]:
+    if not isinstance(value, Mapping):
+        return {}
+    compact: dict[str, Any] = {}
+    status = value.get("benchmark_egress_proxy_base_image_prewarm_status")
+    if isinstance(status, str) and status:
+        compact["benchmark_egress_proxy_base_image_prewarm_status"] = status[:80]
+    for field in (
+        "benchmark_egress_proxy_base_image_prewarm_required",
+        "benchmark_egress_proxy_base_image_prewarm_docker_available",
+        "benchmark_egress_proxy_base_image_prewarm_skopeo_available",
+        "benchmark_egress_proxy_base_image_prewarm_raw_image_refs_recorded",
+        "benchmark_egress_proxy_base_image_prewarm_raw_output_recorded",
+    ):
+        if isinstance(value.get(field), bool):
+            compact[field] = value[field]
+    for field in (
+        "benchmark_egress_proxy_base_image_prewarm_candidate_count",
+        "benchmark_egress_proxy_base_image_prewarm_attempted_count",
+        "benchmark_egress_proxy_base_image_prewarm_cache_hit_count",
+        "benchmark_egress_proxy_base_image_prewarm_loaded_count",
+        "benchmark_egress_proxy_base_image_prewarm_failed_count",
+    ):
+        if isinstance(value.get(field), int) and not isinstance(value.get(field), bool):
+            compact[field] = value[field]
+    return compact

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -1930,77 +1930,14 @@ def _benchmark_egress_proxy_env(args: argparse.Namespace | None) -> dict[str, st
     return env
 
 
-def _docker_config_payload_with_proxy(
-    *,
-    proxy_url: str,
-    no_proxy: str,
-) -> dict[str, Any]:
-    """Return a Docker client config that forwards proxies without mutating home."""
-
-    docker_config_dir = os.environ.get("DOCKER_CONFIG")
-    source_config = (
-        Path(docker_config_dir).expanduser() / "config.json"
-        if docker_config_dir
-        else Path.home() / ".docker" / "config.json"
-    )
-    payload: dict[str, Any] = {}
-    if source_config.exists():
-        try:
-            loaded = json.loads(source_config.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            loaded = {}
-        if isinstance(loaded, dict):
-            payload = loaded
-    proxies = payload.setdefault("proxies", {})
-    if not isinstance(proxies, dict):
-        proxies = {}
-        payload["proxies"] = proxies
-    proxies["default"] = {
-        "httpProxy": proxy_url,
-        "httpsProxy": proxy_url,
-        "noProxy": no_proxy,
-    }
-    return payload
-
-
 @contextlib.contextmanager
 def _benchmark_egress_proxy_env_applied(
     args: argparse.Namespace, *, plan: dict[str, Any] | None = None,
 ) -> Any:
-    proxy_env = _benchmark_egress_proxy_env(args)
-    if not proxy_env:
+    with proxy_runtime.proxy_runtime_env_applied(
+        _benchmark_egress_proxy_env(args), plan=plan
+    ):
         yield
-        return
-    docker_config_tmp: tempfile.TemporaryDirectory[str] | None = None
-    docker_config_env: dict[str, str] = {}
-    proxy_url = proxy_env.get("LOOPX_SKILLSBENCH_EGRESS_PROXY", "")
-    if proxy_url:
-        docker_config_tmp = tempfile.TemporaryDirectory(
-            prefix="loopx-skillsbench-docker-proxy-"
-        )
-        docker_config_path = Path(docker_config_tmp.name) / "config.json"
-        docker_config_payload = _docker_config_payload_with_proxy(
-            proxy_url=proxy_url,
-            no_proxy=proxy_env.get("NO_PROXY", "localhost,127.0.0.1,::1"),
-        )
-        docker_config_path.write_text(
-            json.dumps(docker_config_payload, indent=2, sort_keys=True) + "\n",
-            encoding="utf-8",
-        )
-        docker_config_env["DOCKER_CONFIG"] = docker_config_tmp.name
-    keys = set(proxy_env) | set(docker_config_env)
-    previous = {key: os.environ.get(key) for key in keys}
-    try:
-        proxy_runtime.apply_proxy_runtime_env(os.environ, proxy_env, docker_config_env, plan=plan)
-        yield
-    finally:
-        for key, value in previous.items():
-            if value is None:
-                os.environ.pop(key, None)
-            else:
-                os.environ[key] = value
-        if docker_config_tmp is not None:
-            docker_config_tmp.cleanup()
 
 
 def _host_local_acp_target_env(
@@ -2999,6 +2936,7 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         if isinstance(value.get(field), int) and not isinstance(value.get(field), bool):
             compact[field] = value[field]
     compact.update(runner_source.compact_runner_source_public_fields(value))
+    compact.update(proxy_runtime.compact_base_image_prewarm_fields(value))
     target_keys = value.get("host_local_acp_target_env_keys")
     if isinstance(target_keys, list):
         compact["host_local_acp_target_env_keys"] = [
@@ -9553,6 +9491,7 @@ def _public_runner_config(plan: dict[str, Any]) -> dict[str, Any]:
         value = prerequisites.get("benchmark_egress_no_proxy_entry_count")
         if isinstance(value, int) and not isinstance(value, bool):
             config["benchmark_egress_no_proxy_entry_count"] = value
+        config.update(proxy_runtime.compact_base_image_prewarm_fields(prerequisites))
     app_server_observability = _app_server_goal_worker_observability(plan)
     if app_server_observability:
         config["app_server_goal_worker_observability"] = app_server_observability
@@ -13632,6 +13571,21 @@ async def run_benchflow_case(args: argparse.Namespace, plan: dict[str, Any]) -> 
     )
     plan["task_staging"] = staging_metadata
     plan["effective_task_path"] = str(effective_task_path)
+    prerequisites["benchflow_run_stage"] = "base_image_prewarm"
+    _write_public_runner_config(plan)
+    _write_public_runner_prerequisites(plan)
+    prerequisites.update(
+        proxy_runtime.prewarm_dockerfile_base_images(
+            effective_task_path / "environment" / "Dockerfile",
+            enabled=(
+                args.sandbox == "docker"
+                and bool(_benchmark_egress_proxy_env(args))
+            ),
+        )
+    )
+    prerequisites["benchflow_run_stage"] = "base_image_prewarm_complete"
+    _write_public_runner_config(plan)
+    _write_public_runner_prerequisites(plan)
 
     if str(REPO_ROOT) not in sys.path:
         sys.path.insert(0, str(REPO_ROOT))


### PR DESCRIPTION
## Summary
- move SkillsBench proxy runtime setup out of the oversized runner into its benchmark adapter
- discover external Dockerfile base images and prewarm them through the configured proxy with `skopeo` into the Docker daemon cache
- project only bounded counts/status while excluding image references, command output, proxy values, and local paths

## Motivation
Dockerfile `ENV` proxy injection only affects build steps after `FROM`; BuildKit base-image pulls can still bypass the benchmark egress proxy and strand otherwise valid runs. This closes that daemon-side gap without changing task or scoring semantics.

## Validation
- `python3 examples/skillsbench-benchmark-egress-policy-smoke.py`
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `python3 examples/skillsbench-host-local-launch-plan-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `python3 -m py_compile loopx/benchmark_adapters/skillsbench_proxy_runtime.py scripts/skillsbench_automation_loop.py examples/skillsbench-benchmark-egress-policy-smoke.py`
- `python3 -m loopx.cli --format json check`
- `python3 -m loopx.cli --format json canary premerge --from-git-diff` (all 7 selected checks passed; benchmark-sensitive manual review hold remains by policy)
- `git diff --check`

## Boundary and risk
No raw benchmark logs, task text, trajectories, verifier output, credentials, proxy values, image references, or local paths are included. Prewarm is best-effort and does not convert setup failures into scores. Main residual risk is registry-specific `skopeo` compatibility, which is surfaced as compact failure counts and will be checked by rerunning the blocked cases.
