### PR TITLE
Normalize untagged SkillsBench prewarm images

### DIFF
--- a/examples/skillsbench-benchmark-egress-policy-smoke.py
+++ b/examples/skillsbench-benchmark-egress-policy-smoke.py
@@ -238,7 +238,7 @@ def test_verifier_proxy_patch_is_required_only_for_existing_verifier() -> None:
 def test_proxy_runtime_prewarms_external_base_images_without_public_refs() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-base-image-prewarm-") as tmp:
         dockerfile = Path(tmp) / "Dockerfile"
-        image = "gcr.io/oss-fuzz-base/base-builder-python:latest"
+        image = "gcr.io/oss-fuzz-base/base-builder-python"
         dockerfile.write_text(
             f"FROM {image} AS builder\n"
             "FROM builder AS final\n",
@@ -279,7 +279,10 @@ def test_proxy_runtime_prewarms_external_base_images_without_public_refs() -> No
         assert image not in json.dumps(public_prerequisites, sort_keys=True)
         skopeo_calls = [call for call in calls if call[0] == "/usr/bin/skopeo"]
         assert len(skopeo_calls) == 1, calls
-        assert skopeo_calls[0][-2:] == [f"docker://{image}", f"docker-daemon:{image}"]
+        assert skopeo_calls[0][-2:] == [
+            f"docker://{image}",
+            f"docker-daemon:{image}:latest",
+        ]
 
 
 if __name__ == "__main__":

--- a/loopx/benchmark_adapters/skillsbench_proxy_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_proxy_runtime.py
@@ -172,6 +172,13 @@ def _image_cached(docker_bin: str, image: str) -> bool:
     return result.returncode == 0
 
 
+def _docker_daemon_destination_reference(image: str) -> str:
+    if "@" in image:
+        return image
+    final_segment = image.rsplit("/", 1)[-1]
+    return image if ":" in final_segment else f"{image}:latest"
+
+
 def prewarm_dockerfile_base_images(
     dockerfile: Path,
     *,
@@ -232,7 +239,7 @@ def prewarm_dockerfile_base_images(
                         "--retry-times",
                         "3",
                         f"docker://{image}",
-                        f"docker-daemon:{image}",
+                        f"docker-daemon:{_docker_daemon_destination_reference(image)}",
                     ],
                     stdin=subprocess.DEVNULL,
                     stdout=subprocess.DEVNULL,


### PR DESCRIPTION
## Summary
- normalize untagged Dockerfile base images to `:latest` only for the `docker-daemon:` destination
- keep the source reference unchanged and cover the behavior with the focused egress-policy smoke

## Motivation
The first real setup-blocker rerun after #1767 showed a GCR `FROM` reference without an explicit tag. `skopeo inspect` succeeded through the benchmark proxy, but `skopeo copy` rejected the untagged daemon destination immediately. A tagged Suricata base image prewarmed successfully and the case scored 1.0.

## Validation
- focused egress-policy smoke: passed
- full SkillsBench benchmark-run smoke: passed
- changed Python compile and diff hygiene: passed
- repository Python line budget: passed
- `loopx check` on changed files: clean
- premerge canary: 7/7 selected checks passed; benchmark-sensitive manual-review hold remains by policy

## Boundary and risk
No raw benchmark logs, task text, image references, command output, credentials, proxy values, or local paths are recorded. Digest-pinned references are deliberately left unchanged because they have distinct daemon-import semantics and are not part of this observed bad case.
