### PR TITLE
Canonicalize agent vision lifecycle states

### DIFF
--- a/docs/reference/protocols/goal-vision-replan-contract-v0.md
+++ b/docs/reference/protocols/goal-vision-replan-contract-v0.md
@@ -77,6 +77,14 @@ the same `agent_id` as the refresh run. This keeps `research-executor`,
 `evaluator-promoter`, and other roles from overwriting or satisfying each
 other's active vision.
 
+`state` is a lower `snake_case` lifecycle token. Domain-specific states remain
+extensible and are treated as open. The write path canonicalizes closure aliases
+such as `closed`, `satisfied`, and `vision_satisfied` to `vision_closed`, and
+`closed_no_followup` to `no_followup`. Quota/status use the same centralized
+closure predicate when reading older persisted packets, so a legacy alias cannot
+silently reopen a satisfied vision. Prose or malformed state values fail at the
+write boundary with an actionable error.
+
 When a valid packet includes `replan_trigger_summary`, status/quota projects it
 as `goal_frontier_projection.acceptance_gaps[]`. If no runnable advancement
 frontier remains, that gap is evaluated before monitor quiet skip and can
@@ -212,6 +220,11 @@ stateDiagram-v2
 | `VisionPatchProposed` | The patch is ready to apply. | Budget check and local-state write correctness. |
 | `Superseded` | Another route replaces this packet. | `superseded_by` or successor id. |
 | `Retired` | The route is complete or intentionally closed. | Acceptance evidence or no-follow-up evidence. |
+
+The canonical stored close states are `vision_closed`, `retired`,
+`retired_or_superseded`, `superseded`, and `no_followup`. A state such as
+`completed_current_slice` intentionally remains open because completing one
+slice is not evidence that the per-agent vision acceptance is satisfied.
 
 ## Replan Triggers
 

--- a/examples/control_plane/quota-replan-decision-plane-smoke.py
+++ b/examples/control_plane/quota-replan-decision-plane-smoke.py
@@ -267,11 +267,11 @@ def agent_vision_gap_run() -> dict:
     }
 
 
-def closed_agent_vision_run() -> dict:
+def closed_agent_vision_run(*, state: str = "vision_closed") -> dict:
     run = agent_vision_gap_run()
     run["generated_at"] = "2026-07-04T00:10:00+00:00"
     run["classification"] = "vision_gap_closed"
-    run["agent_vision"]["state"] = "vision_closed"
+    run["agent_vision"]["state"] = state
     return run
 
 
@@ -753,25 +753,46 @@ def assert_agent_vision_gap_derives_replan() -> None:
 
 
 def assert_closed_agent_vision_allows_bounded_monitor_wait() -> None:
+    for state in ("vision_closed", "vision_satisfied", "closed_no_followup"):
+        guard = build_quota_should_run(
+            status_payload(
+                [monitor_item()],
+                replan_obligation=None,
+                latest_runs=[
+                    watch_lane_continuation_ack_run(
+                        delta_kinds=["watch_lane_continuation", "no_followup"]
+                    ),
+                    closed_agent_vision_run(state=state),
+                ],
+            ),
+            goal_id=GOAL_ID,
+            agent_id=SIDE_AGENT,
+        )
+        assert guard["decision"] == "skip", (state, guard)
+        assert guard["effective_action"] == "monitor_quiet_skip", (state, guard)
+        assert guard["goal_frontier_projection"]["acceptance_gaps"] == [], (
+            state,
+            guard,
+        )
+        assert guard["goal_frontier_projection"]["replan_required"] is False, (
+            state,
+            guard,
+        )
+        assert guard.get("autonomous_replan_obligation") is None, (state, guard)
+
+
+def assert_custom_agent_vision_state_remains_open() -> None:
     guard = build_quota_should_run(
         status_payload(
             [monitor_item()],
             replan_obligation=None,
-            latest_runs=[
-                watch_lane_continuation_ack_run(
-                    delta_kinds=["watch_lane_continuation", "no_followup"]
-                ),
-                closed_agent_vision_run(),
-            ],
+            latest_runs=[closed_agent_vision_run(state="completed_current_slice")],
         ),
         goal_id=GOAL_ID,
         agent_id=SIDE_AGENT,
     )
-    assert guard["decision"] == "skip", guard
-    assert guard["effective_action"] == "monitor_quiet_skip", guard
-    assert guard["goal_frontier_projection"]["acceptance_gaps"] == [], guard
-    assert guard["goal_frontier_projection"]["replan_required"] is False, guard
-    assert guard.get("autonomous_replan_obligation") is None, guard
+    assert guard["effective_action"] == "autonomous_replan_required", guard
+    assert len(guard["goal_frontier_projection"]["acceptance_gaps"]) == 1, guard
 
 
 def assert_goal_frontier_context_helper_matches_quota_payload() -> None:
@@ -1242,6 +1263,7 @@ def main() -> None:
     assert_long_chain_replan_ack_expires_after_material_review_window()
     assert_agent_vision_gap_derives_replan()
     assert_closed_agent_vision_allows_bounded_monitor_wait()
+    assert_custom_agent_vision_state_remains_open()
     assert_goal_frontier_context_helper_matches_quota_payload()
     assert_open_agent_vision_beats_watch_lane_continuation_ack()
     assert_open_agent_vision_with_runnable_frontier_uses_neutral_gap_trigger()

--- a/examples/project/goal-vision-refresh-state-budget-smoke.py
+++ b/examples/project/goal-vision-refresh-state-budget-smoke.py
@@ -273,6 +273,40 @@ def main() -> int:
         assert inline["vision_checkpoint"]["agent_id"] == AGENT_ID, inline
         assert inline["vision_checkpoint"]["decision"] == "patched", inline
 
+        closed_alias = payload(
+            run_cli(
+                registry_path,
+                runtime,
+                inline_vision_args=[
+                    "--vision-state",
+                    "vision_satisfied",
+                    "--vision-summary",
+                    "Close the bounded research route after authoritative validation.",
+                ],
+                check=True,
+            )
+        )
+        assert closed_alias["agent_vision"]["state"] == "vision_closed", (
+            closed_alias
+        )
+
+        invalid_state_result = run_cli(
+            registry_path,
+            runtime,
+            inline_vision_args=[
+                "--vision-state",
+                "vision is done",
+                "--vision-summary",
+                "Invalid lifecycle prose should fail.",
+            ],
+            check=False,
+        )
+        assert invalid_state_result.returncode == 1, invalid_state_result
+        invalid_state = payload(invalid_state_result)
+        assert "lower snake_case lifecycle token" in invalid_state["error"], (
+            invalid_state
+        )
+
         unchanged = payload(
             run_cli(
                 registry_path,

--- a/loopx/cli_commands/project_lifecycle.py
+++ b/loopx/cli_commands/project_lifecycle.py
@@ -163,7 +163,12 @@ def register_project_lifecycle_commands(
     )
     refresh_state_parser.add_argument(
         "--vision-state",
-        help="Optional state for an inline goal_vision_replan_contract_v0 patch.",
+        help=(
+            "Optional lower snake_case lifecycle state for an inline "
+            "goal_vision_replan_contract_v0 patch. Closure aliases such as "
+            "satisfied and vision_satisfied normalize to vision_closed; "
+            "custom states remain open until explicitly closed."
+        ),
     )
     refresh_state_parser.add_argument(
         "--vision-summary",

--- a/loopx/control_plane/goals/goal_frontier.py
+++ b/loopx/control_plane/goals/goal_frontier.py
@@ -16,6 +16,7 @@ from ..work_items.autonomous_replan_obligation import (
     build_autonomous_replan_obligation_payload,
 )
 from ..work_items.repair_delta import repair_delta_kinds_have_frontier_delta
+from .goal_vision_state import goal_vision_state_is_closed
 
 
 GOAL_FRONTIER_PROJECTION_SCHEMA_VERSION = "goal_frontier_projection_v0"
@@ -34,16 +35,6 @@ TODO_TASK_CLASS_ADVANCEMENT = "advancement_task"
 TODO_TASK_CLASS_MONITOR = "continuous_monitor"
 LONG_TODO_CHAIN_ADVANCEMENT_THRESHOLD = 15
 LONG_TODO_CHAIN_OPEN_THRESHOLD = 20
-AGENT_VISION_CLOSED_STATES = {
-    "closed",
-    "satisfied",
-    "vision_closed",
-    "retired",
-    "retired_or_superseded",
-    "superseded",
-    "no_followup",
-    "no-followup",
-}
 VISION_CHECKPOINT_SATISFIED_DECISIONS = {
     "patched",
     "retired_or_superseded",
@@ -384,8 +375,8 @@ def acceptance_gaps_from_agent_vision(
     if not isinstance(agent_vision, dict):
         return []
     patch = agent_vision.get("vision_patch") if isinstance(agent_vision.get("vision_patch"), dict) else {}
-    state = str(agent_vision.get("state") or "").strip().lower()
-    if state in AGENT_VISION_CLOSED_STATES:
+    state = str(agent_vision.get("state") or "").strip()
+    if goal_vision_state_is_closed(state):
         return []
     acceptance = _compact_projection_text(patch.get("acceptance_summary"), limit=420)
     trigger = _compact_projection_text(patch.get("replan_trigger_summary"), limit=240)

--- a/loopx/control_plane/goals/goal_vision.py
+++ b/loopx/control_plane/goals/goal_vision.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 from typing import Any
 
 from ...feedback import validate_public_safe_text
+from .goal_vision_state import (
+    GOAL_VISION_DEFAULT_STATE,
+    normalize_goal_vision_state,
+)
 
 
 GOAL_VISION_REPLAN_SCHEMA_VERSION = "goal_vision_replan_contract_v0"
@@ -158,10 +162,12 @@ def normalize_goal_vision_packet(
         raise ValueError("agent_vision requires agent_id from packet or --agent-id")
     validate_public_safe_text("agent_vision.agent_id", resolved_agent_id)
 
-    state = _bounded_public_text(
-        field="state",
-        value=packet.get("state") or "vision_patch_proposed",
-        limit=80,
+    state = normalize_goal_vision_state(
+        _bounded_public_text(
+            field="state",
+            value=packet.get("state") or GOAL_VISION_DEFAULT_STATE,
+            limit=80,
+        )
     )
     vision_patch: dict[str, str] = {}
     field_usage: dict[str, int] = {}

--- a/loopx/control_plane/goals/goal_vision_state.py
+++ b/loopx/control_plane/goals/goal_vision_state.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+
+GOAL_VISION_DEFAULT_STATE = "vision_patch_proposed"
+GOAL_VISION_CLOSED_STATES = frozenset(
+    {
+        "vision_closed",
+        "retired",
+        "retired_or_superseded",
+        "superseded",
+        "no_followup",
+    }
+)
+GOAL_VISION_STATE_ALIASES = {
+    "closed": "vision_closed",
+    "satisfied": "vision_closed",
+    "vision_satisfied": "vision_closed",
+    "vision_retired": "retired",
+    "vision_superseded": "superseded",
+    "vision_no_followup": "no_followup",
+    "closed_no_followup": "no_followup",
+    "no_follow_up": "no_followup",
+}
+GOAL_VISION_STATE_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,79}$")
+
+
+def normalize_goal_vision_state(value: Any) -> str:
+    """Return a stable lifecycle token while preserving custom open states."""
+
+    state = (
+        str(value or GOAL_VISION_DEFAULT_STATE).strip().lower().replace("-", "_")
+    )
+    if not GOAL_VISION_STATE_PATTERN.fullmatch(state):
+        raise ValueError(
+            "agent_vision.state must be a lower snake_case lifecycle token "
+            "such as vision_patch_proposed or vision_closed"
+        )
+    return GOAL_VISION_STATE_ALIASES.get(state, state)
+
+
+def goal_vision_state_is_closed(value: Any) -> bool:
+    """Recognize canonical and legacy closure tokens without trusting bad state."""
+
+    try:
+        state = normalize_goal_vision_state(value)
+    except ValueError:
+        return False
+    return state in GOAL_VISION_CLOSED_STATES


### PR DESCRIPTION
## Summary
- centralize agent-vision lifecycle token normalization and closed-state detection in a cycle-free goals module
- canonicalize closure aliases such as `vision_satisfied` and `closed_no_followup` while preserving custom states as open
- reject malformed prose states at the refresh-state write boundary and document the lifecycle contract
- cover both new writes and legacy quota/status reads

## Motivation
A bounded closeout written as `vision_satisfied` passed refresh-state validation but quota treated it as an open acceptance gap, causing another autonomous replan. Closure semantics lived only as projection-side magic strings.

## Architecture
This does not add a protocol field or a strict enum. Existing domain-specific states remain extensible and open; only explicit closure aliases normalize to canonical states. Write and read paths share one lightweight predicate.

## Validation
- focused goal-vision refresh-state and quota decision-plane smokes
- goal-vision protocol, autonomous-replan, compaction, state-projection, side-agent state-machine, and integrated control-plane smokes
- `loopx canary premerge --from-git-diff`: 17/17 passed, zero failures, warnings, or manual holds
- public/private boundary scan: 7 changed files clean

## Risk
Low compatibility risk: legacy closure aliases become correctly terminal; unknown custom states intentionally remain open. No benchmark behavior, permissions, credentials, private state, or raw evidence is changed.