### PR TITLE
Allow no-spend polling of auxiliary due monitors

### DIFF
--- a/examples/control_plane/monitor-poll-policy-smoke.py
+++ b/examples/control_plane/monitor-poll-policy-smoke.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from copy import deepcopy
 from pathlib import Path
 import sys
 
@@ -164,10 +165,51 @@ def assert_due_monitor_policy_from_contract_selection() -> None:
     assert allows_due_monitor_poll(not_attemptable, todo_id="todo_due_selected") is False
 
 
+def assert_auxiliary_due_monitor_context_policy() -> None:
+    decision = {
+        "work_lane_contract": {
+            "lane": "advancement_task",
+            "obligation": "advance_one_bounded_segment",
+            "must_attempt_work": True,
+            "reason_codes": ["open_agent_todo", "due_monitor_context"],
+        },
+        "agent_todo_summary": {
+            "monitor_due_items": [
+                {
+                    "todo_id": "todo_due_auxiliary",
+                    "task_class": "continuous_monitor",
+                    "target_key": "auxiliary-target",
+                }
+            ],
+        },
+        "agent_lane_next_action": {
+            "todo_id": "todo_advancement_selected",
+            "task_class": "advancement_task",
+        },
+    }
+    assert allows_due_monitor_poll(decision, todo_id="todo_due_auxiliary") is True
+    assert allows_due_monitor_poll(decision, target_key="auxiliary-target") is True
+    assert allows_due_monitor_poll(
+        decision,
+        todo_id="todo_due_auxiliary",
+        target_key="wrong-target",
+    ) is False
+    assert allows_due_monitor_poll(decision) is False
+    assert allows_due_monitor_poll(decision, todo_id="todo_not_due") is False
+
+    missing_context = deepcopy(decision)
+    missing_context["work_lane_contract"]["reason_codes"] = ["open_agent_todo"]
+    assert allows_due_monitor_poll(
+        missing_context,
+        todo_id="todo_due_auxiliary",
+    ) is False
+
+
 def main() -> int:
     assert_external_monitor_observation_policy()
     assert_due_monitor_policy_from_next_action()
     assert_due_monitor_policy_from_contract_selection()
+    assert_auxiliary_due_monitor_context_policy()
     print("monitor-poll-policy-smoke ok")
     return 0
 

--- a/loopx/control_plane/scheduler/monitor_poll_policy.py
+++ b/loopx/control_plane/scheduler/monitor_poll_policy.py
@@ -88,6 +88,35 @@ def quota_decision_due_monitor_item(decision: dict[str, Any]) -> dict[str, Any]:
     return item
 
 
+def _requested_auxiliary_due_monitor_item(
+    decision: dict[str, Any],
+    *,
+    todo_id: str | None,
+    target_key: str | None,
+) -> dict[str, Any]:
+    if not todo_id and not target_key:
+        return {}
+    summary = (
+        decision.get("agent_todo_summary")
+        if isinstance(decision.get("agent_todo_summary"), dict)
+        else {}
+    )
+    due_items = (
+        summary.get("monitor_due_items")
+        if isinstance(summary.get("monitor_due_items"), list)
+        else []
+    )
+    for item in due_items:
+        if not isinstance(item, dict) or todo_item_task_class(item) != TODO_TASK_CLASS_MONITOR:
+            continue
+        if todo_id and normalize_todo_id(item.get("todo_id")) != normalize_todo_id(todo_id):
+            continue
+        if target_key and str(item.get("target_key") or "").strip() != str(target_key).strip():
+            continue
+        return item
+    return {}
+
+
 def allows_due_monitor_poll(
     decision: dict[str, Any],
     *,
@@ -99,10 +128,17 @@ def allows_due_monitor_poll(
         if isinstance(decision.get("work_lane_contract"), dict)
         else {}
     )
-    if contract.get("obligation") != DUE_MONITOR_OBLIGATION:
-        return False
     if contract.get("must_attempt_work") is not True:
         return False
+    if contract.get("obligation") != DUE_MONITOR_OBLIGATION:
+        return bool(
+            "due_monitor_context" in work_lane_reason_codes(contract)
+            and _requested_auxiliary_due_monitor_item(
+                decision,
+                todo_id=todo_id,
+                target_key=target_key,
+            )
+        )
     item = quota_decision_due_monitor_item(decision)
     if not item:
         return False


### PR DESCRIPTION
## Summary
- allow an explicitly identified due monitor to be polled when advancement remains the primary work lane
- read the existing `agent_todo_summary.monitor_due_items` projection instead of widening the work-lane schema
- preserve selected-monitor anti-hijack behavior and require exact todo/target matching

## Validation
- `python3 examples/control_plane/monitor-poll-policy-smoke.py`
- `python3 examples/control_plane/monitor-poll-writeback-smoke.py`
- live canary dry-run against a due monitor projected beside an advancement todo
- `loopx canary premerge --from-git-diff`: 16/16 selected checks passed, no warnings or manual holds

## Boundary
No local state, raw benchmark evidence, credentials, generated logs, or private paths are included.