### PR TITLE
Catch up omitted benchmark ledger rows during closeout

### DIFF
--- a/examples/benchmark-remote-closeout-catchup-smoke.py
+++ b/examples/benchmark-remote-closeout-catchup-smoke.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+"""Smoke-test generic remote benchmark ledger catch-up closeout."""
+
+from __future__ import annotations
+
+import base64
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.benchmark_core.remote_closeout import closeout_remote_benchmark_batch
+
+
+def _compact(case_id: str, score: float) -> dict[str, object]:
+    return {
+        "schema_version": "benchmark_run_v0",
+        "benchmark_id": "skillsbench@1.1",
+        "case_id": case_id,
+        "route": "codex-cli-goal-baseline",
+        "status": "completed",
+        "official_score": score,
+    }
+
+
+def _write_compact(path: Path, payload: dict[str, object]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+
+def _collection(payload: dict[str, object]) -> str:
+    content = (json.dumps(payload) + "\n").encode("utf-8")
+    return json.dumps(
+        {
+            "artifacts": [
+                {
+                    "relative_path": "current/benchmark_run.compact.json",
+                    "content_base64": base64.b64encode(content).decode("ascii"),
+                }
+            ],
+            "matched_count": 1,
+            "blocked_count": 0,
+        }
+    )
+
+
+def test_closeout_catches_up_public_target_rows_once() -> None:
+    with tempfile.TemporaryDirectory(prefix="benchmark-closeout-catchup-") as tmp:
+        root = Path(tmp)
+        catchup_root = root / "public-runs"
+        accepted = catchup_root / "target-old" / "benchmark_run.compact.json"
+        ignored = catchup_root / "other-lane" / "benchmark_run.compact.json"
+        private = catchup_root / "target-old" / "logs" / "benchmark_run.compact.json"
+        malformed = catchup_root / "target-malformed" / "benchmark_run.compact.json"
+        _write_compact(accepted, _compact("case-b", 1.0))
+        _write_compact(ignored, _compact("case-c", 1.0))
+        _write_compact(private, _compact("private-case", 1.0))
+        malformed.parent.mkdir(parents=True)
+        malformed.write_text("{not-json\n", encoding="utf-8")
+
+        canonical = root / "canonical.txt"
+        canonical.write_text("case-a\ncase-b\n", encoding="utf-8")
+        ledger = root / "ledger.json"
+        aggregate = root / "aggregate.json"
+        collection = _collection(_compact("case-a", 0.0))
+
+        def run_closeout() -> dict[str, object]:
+            return closeout_remote_benchmark_batch(
+                run_remote_command=lambda _command, _timeout: subprocess.CompletedProcess(
+                    [], 0, collection, ""
+                ),
+                remote_root="/redacted",
+                artifact_globs=["current/benchmark_run.compact.json"],
+                local_public_artifact_dir=root / "current",
+                adapter_kind="skillsbench",
+                max_bytes=1024 * 1024,
+                sync_timeout_sec=1,
+                ledger_path=str(ledger),
+                run_group_id="target-current",
+                aggregate_path=str(aggregate),
+                canonical_case_ids_file=str(canonical),
+                benchmark_id="skillsbench@1.1",
+                target_run_group_contains=["target-"],
+                ledger_catchup_root=str(catchup_root),
+                ledger_catchup_run_group_contains=["target-"],
+                repo_root=REPO_ROOT,
+            )
+
+        first = run_closeout()
+        update = first["local_ledger_update"]
+        assert first["ok"] is True, first
+        assert update["upserted_count"] == 2, update
+        assert update["catchup_compact_count"] == 2, update
+        assert update["catchup_upserted_count"] == 1, update
+        assert update["catchup_skipped_count"] == 1, update
+        assert update["catchup_blocked_count"] == 1, update
+        cases = json.loads(ledger.read_text(encoding="utf-8"))["benchmarks"][
+            "skillsbench@1.1"
+        ]["cases"]
+        assert set(cases) == {"case-a", "case-b"}, cases
+        assert json.loads(aggregate.read_text(encoding="utf-8"))["canonical_total"] == 2
+
+        second = run_closeout()
+        retry = second["local_ledger_update"]
+        assert retry["catchup_upserted_count"] == 0, retry
+        assert retry["catchup_already_present_count"] == 1, retry
+        cases = json.loads(ledger.read_text(encoding="utf-8"))["benchmarks"][
+            "skillsbench@1.1"
+        ]["cases"]
+        assert len(cases["case-b"]["runs"]) == 1, cases["case-b"]
+
+
+def test_closeout_rejects_missing_catchup_root() -> None:
+    with tempfile.TemporaryDirectory(prefix="benchmark-closeout-catchup-missing-") as tmp:
+        root = Path(tmp)
+        result = closeout_remote_benchmark_batch(
+            run_remote_command=lambda _command, _timeout: subprocess.CompletedProcess(
+                [], 0, _collection(_compact("case-a", 0.0)), ""
+            ),
+            remote_root="/redacted",
+            artifact_globs=["current/benchmark_run.compact.json"],
+            local_public_artifact_dir=root / "current",
+            adapter_kind="skillsbench",
+            max_bytes=1024 * 1024,
+            sync_timeout_sec=1,
+            ledger_path=str(root / "ledger.json"),
+            run_group_id="target-current",
+            ledger_catchup_root=str(root / "missing"),
+            ledger_catchup_run_group_contains=["target-"],
+            repo_root=REPO_ROOT,
+        )
+        assert result["ok"] is False, result
+        assert result["first_blocker"] == "public_artifact_local_closeout_failed", result
+        assert result["local_closeout_error_type"] == "ValueError", result
+        assert not (root / "ledger.json").exists(), result
+
+
+if __name__ == "__main__":
+    test_closeout_catches_up_public_target_rows_once()
+    test_closeout_rejects_missing_catchup_root()
+    print("benchmark-remote-closeout-catchup-smoke: ok")

--- a/examples/skillsbench-benchmark-egress-policy-smoke.py
+++ b/examples/skillsbench-benchmark-egress-policy-smoke.py
@@ -203,6 +203,11 @@ def test_public_launcher_batches_three_cases_with_closeout_sync() -> None:
     assert "--remote-public-artifact-root" in output, output
     assert "benchmark_run.compact.json" in output, output
     assert "--local-run-ledger-path" in output, output
+    assert "--local-ledger-catchup-root" in output, output
+    assert (
+        "--local-ledger-catchup-run-group-contains "
+        "skillsbench-codex-cli-goal-xhigh-" in output
+    ), output
     assert "--update-ledger" not in output, output
     assert "--local-target-lane-id codex-cli-goal-xhigh" in output, output
     assert "--local-target-run-group-contains" not in output, output

--- a/examples/skillsbench-reverse-tunnel-supervisor-smoke.py
+++ b/examples/skillsbench-reverse-tunnel-supervisor-smoke.py
@@ -162,10 +162,12 @@ def test_supervisor_syncs_only_compact_public_artifacts() -> None:
         public_output = root / "public.json"
         private_log = root / "private.log"
         synced_dir = root / "synced"
+        catchup_root = root / "public-runs"
         ledger_path = root / "live-ledger.json"
         aggregate_path = root / "standard-aggregate.json"
         canonical_ids = root / "canonical-case-ids.txt"
         canonical_ids.write_text("case-a\n", encoding="utf-8")
+        catchup_root.mkdir()
         _fake_ssh(fake_ssh, ssh_log)
 
         opaque_destination = "opaque-benchmark-host.example"
@@ -192,6 +194,10 @@ def test_supervisor_syncs_only_compact_public_artifacts() -> None:
                 str(ledger_path),
                 "--local-run-group-id",
                 "skillsbench-codex-cli-goal-xhigh-sync-smoke",
+                "--local-ledger-catchup-root",
+                str(catchup_root),
+                "--local-ledger-catchup-run-group-contains",
+                "skillsbench-codex-cli-goal-xhigh-",
                 "--local-current-aggregate-path",
                 str(aggregate_path),
                 "--local-canonical-case-ids-file",
@@ -229,7 +235,10 @@ def test_supervisor_syncs_only_compact_public_artifacts() -> None:
         assert compact_path.exists(), sync
         assert ledger_path.exists(), sync
         assert aggregate_path.exists(), sync
-        assert sync["local_ledger_update"]["upserted_count"] == 1, sync
+        ledger_update = sync["local_ledger_update"]
+        assert ledger_update["upserted_count"] == 1, ledger_update
+        assert ledger_update["catchup_requested"] is True, ledger_update
+        assert ledger_update["catchup_compact_count"] == 0, ledger_update
         assert sync["local_aggregate_update"]["canonical_total"] == 1, sync
         public_text = public_output.read_text(encoding="utf-8")
         assert opaque_destination not in public_text

--- a/loopx/benchmark_core/remote_closeout.py
+++ b/loopx/benchmark_core/remote_closeout.py
@@ -8,7 +8,10 @@ from pathlib import Path
 from typing import Any, Callable
 
 from ..file_lock import exclusive_file_lock
-from .artifacts import materialize_public_benchmark_artifacts
+from .artifacts import (
+    classify_benchmark_artifact_path,
+    materialize_public_benchmark_artifacts,
+)
 
 
 RemoteCommandRunner = Callable[[str, float], subprocess.CompletedProcess[str]]
@@ -78,6 +81,7 @@ def build_remote_benchmark_closeout_contract(
     requested: bool,
     ledger_requested: bool,
     aggregate_requested: bool,
+    ledger_catchup_requested: bool = False,
 ) -> dict[str, Any]:
     return {
         "schema_version": "benchmark_remote_public_artifact_sync_v0",
@@ -100,6 +104,7 @@ def build_remote_benchmark_closeout_contract(
             "requested": ledger_requested,
             "updated": False,
             "compact_count": 0,
+            "catchup_requested": ledger_catchup_requested,
             "raw_paths_recorded": False,
         },
         "local_aggregate_update": {
@@ -136,12 +141,22 @@ def _refresh_ledger_and_aggregate(
     target_lane_id: str,
     target_run_group_contains: list[str],
     target_backfill_run_group_contains: list[str],
+    ledger_catchup_root: str,
+    ledger_catchup_run_group_contains: list[str],
+    ledger_catchup_max_bytes: int,
     repo_root: Path,
 ) -> tuple[dict[str, Any], dict[str, Any]]:
     ledger_payload = {
         "requested": bool(ledger_path),
         "updated": False,
         "compact_count": 0,
+        "catchup_requested": bool(ledger_catchup_root),
+        "catchup_compact_count": 0,
+        "catchup_run_group_count": 0,
+        "catchup_upserted_count": 0,
+        "catchup_already_present_count": 0,
+        "catchup_skipped_count": 0,
+        "catchup_blocked_count": 0,
         "raw_paths_recorded": False,
     }
     aggregate_payload = {
@@ -151,38 +166,136 @@ def _refresh_ledger_and_aggregate(
     }
     if not ledger_path:
         return ledger_payload, aggregate_payload
+    catchup_root = Path(ledger_catchup_root).expanduser()
+    if ledger_catchup_root and not catchup_root.is_dir():
+        raise ValueError("ledger catch-up root must be an existing directory")
 
     from ..benchmark_ledger import (
+        build_benchmark_run_ledger_entry,
         build_benchmark_run_ledger_current_aggregate,
         load_benchmark_run_ledger,
-        update_benchmark_run_ledger,
+        update_benchmark_run_ledger_entries,
     )
 
     compact_paths = sorted(public_artifact_dir.rglob("benchmark_run.compact.json"))
-    updated = 0
+    current_entries: list[dict[str, Any]] = []
     skipped = 0
     for compact_path in compact_paths:
         compact = json.loads(compact_path.read_text(encoding="utf-8"))
         if not isinstance(compact, dict):
             skipped += 1
             continue
-        update = update_benchmark_run_ledger(
-            ledger_path=Path(ledger_path).expanduser(),
-            benchmark_run=compact,
-            run_group_id=run_group_id or None,
-            notes="remote batch compact/public closeout sync",
-            dry_run=False,
-            cwd=repo_root,
+        current_entries.append(
+            build_benchmark_run_ledger_entry(
+                compact,
+                run_group_id=run_group_id or None,
+                notes="remote batch compact/public closeout sync",
+                cwd=repo_root,
+            )
         )
-        if update.get("updated") is True:
-            updated += 1
-        else:
-            skipped += 1
+    current_update = update_benchmark_run_ledger_entries(
+        ledger_path=Path(ledger_path).expanduser(),
+        entries=current_entries,
+        dry_run=False,
+    )
+    updated = int(current_update.get("upserted_count") or 0)
+    skipped += int(current_update.get("skipped_entry_count") or 0)
+
+    catchup_paths: list[tuple[Path, str]] = []
+    catchup_blocked = 0
+    if compact_paths and ledger_catchup_root:
+        current_paths = {
+            str(path.resolve(strict=False))
+            for path in compact_paths
+        }
+        for compact_path in sorted(catchup_root.rglob("benchmark_run.compact.json")):
+            try:
+                relative = compact_path.relative_to(catchup_root)
+            except ValueError:
+                continue
+            if len(relative.parts) < 2:
+                continue
+            historical_run_group_id = relative.parts[0]
+            if ledger_catchup_run_group_contains and not any(
+                marker in historical_run_group_id
+                for marker in ledger_catchup_run_group_contains
+            ):
+                continue
+            classification = classify_benchmark_artifact_path(relative)
+            if (
+                classification.get("allowed_to_read") is not True
+                or compact_path.is_symlink()
+            ):
+                catchup_blocked += 1
+                continue
+            try:
+                if compact_path.stat().st_size > ledger_catchup_max_bytes:
+                    catchup_blocked += 1
+                    continue
+            except OSError:
+                catchup_blocked += 1
+                continue
+            if str(compact_path.resolve(strict=False)) in current_paths:
+                continue
+            catchup_paths.append((compact_path, historical_run_group_id))
+
+    catchup_updated = 0
+    catchup_already_present = 0
+    catchup_skipped = 0
+    catchup_run_groups: set[str] = set()
+    catchup_entries: list[dict[str, Any]] = []
+    if catchup_paths:
+        ledger = load_benchmark_run_ledger(Path(ledger_path).expanduser())
+        ledger_run_ids = {
+            str(run.get("run_id") or "")
+            for benchmark in (ledger.get("benchmarks") or {}).values()
+            if isinstance(benchmark, dict)
+            for case in (benchmark.get("cases") or {}).values()
+            if isinstance(case, dict)
+            for run in (case.get("runs") or [])
+            if isinstance(run, dict) and run.get("run_id")
+        }
+        for compact_path, historical_run_group_id in catchup_paths:
+            catchup_run_groups.add(historical_run_group_id)
+            try:
+                compact = json.loads(compact_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                catchup_skipped += 1
+                continue
+            if not isinstance(compact, dict):
+                catchup_skipped += 1
+                continue
+            entry = build_benchmark_run_ledger_entry(
+                compact,
+                run_group_id=historical_run_group_id,
+                notes="public compact catch-up during remote batch closeout",
+                cwd=repo_root,
+            )
+            run_id = str(entry.get("run_id") or "")
+            if run_id and run_id in ledger_run_ids:
+                catchup_already_present += 1
+                continue
+            catchup_entries.append(entry)
+            if run_id:
+                ledger_run_ids.add(run_id)
+    catchup_update = update_benchmark_run_ledger_entries(
+        ledger_path=Path(ledger_path).expanduser(),
+        entries=catchup_entries,
+        dry_run=False,
+    )
+    catchup_updated = int(catchup_update.get("upserted_count") or 0)
+    catchup_skipped += int(catchup_update.get("skipped_entry_count") or 0)
     ledger_payload.update(
         compact_count=len(compact_paths),
-        upserted_count=updated,
-        skipped_count=skipped,
-        updated=bool(updated),
+        upserted_count=updated + catchup_updated,
+        skipped_count=skipped + catchup_skipped,
+        updated=bool(updated or catchup_updated),
+        catchup_compact_count=len(catchup_paths),
+        catchup_run_group_count=len(catchup_run_groups),
+        catchup_upserted_count=catchup_updated,
+        catchup_already_present_count=catchup_already_present,
+        catchup_skipped_count=catchup_skipped,
+        catchup_blocked_count=catchup_blocked,
     )
 
     if not aggregate_path:
@@ -246,6 +359,8 @@ def closeout_remote_benchmark_batch(
     target_lane_id: str = "",
     target_run_group_contains: list[str] | None = None,
     target_backfill_run_group_contains: list[str] | None = None,
+    ledger_catchup_root: str = "",
+    ledger_catchup_run_group_contains: list[str] | None = None,
     repo_root: str | Path = ".",
 ) -> dict[str, Any]:
     requested = bool(remote_root or artifact_globs or local_public_artifact_dir)
@@ -253,6 +368,7 @@ def closeout_remote_benchmark_batch(
         requested=requested,
         ledger_requested=bool(ledger_path),
         aggregate_requested=bool(aggregate_path),
+        ledger_catchup_requested=bool(ledger_catchup_root),
     )
     if not requested:
         return payload
@@ -334,6 +450,11 @@ def closeout_remote_benchmark_batch(
                 target_backfill_run_group_contains=list(
                     target_backfill_run_group_contains or []
                 ),
+                ledger_catchup_root=ledger_catchup_root,
+                ledger_catchup_run_group_contains=list(
+                    ledger_catchup_run_group_contains or []
+                ),
+                ledger_catchup_max_bytes=max_bytes,
                 repo_root=Path(repo_root),
             )
     except (OSError, TimeoutError, ValueError, TypeError, json.JSONDecodeError) as exc:

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -3072,6 +3072,78 @@ def render_benchmark_run_ledger_markdown(ledger: dict[str, Any]) -> str:
     return "\n".join(lines) + "\n"
 
 
+def update_benchmark_run_ledger_entries(
+    *,
+    ledger_path: str | Path,
+    entries: list[dict[str, Any]],
+    dry_run: bool = False,
+) -> dict[str, Any]:
+    """Atomically upsert a compact batch of terminal public ledger entries."""
+
+    path = Path(ledger_path)
+    markdown_path = path.with_suffix(".md")
+    accepted = [
+        dict(entry)
+        for entry in entries
+        if isinstance(entry, dict) and _entry_is_public_ledger_closeout(entry)
+    ]
+
+    def apply_entries(ledger: dict[str, Any]) -> dict[str, Any]:
+        for entry in accepted:
+            ledger = upsert_benchmark_run_ledger_entry(ledger, entry)
+        return ledger
+
+    if dry_run:
+        updated = apply_entries(load_benchmark_run_ledger(path))
+    elif accepted:
+        with _LedgerWriteLock(path):
+            updated = apply_entries(load_benchmark_run_ledger(path))
+            path.parent.mkdir(parents=True, exist_ok=True)
+            tmp_path = path.with_suffix(path.suffix + ".tmp")
+            tmp_markdown_path = markdown_path.with_suffix(markdown_path.suffix + ".tmp")
+            tmp_path.write_text(
+                json.dumps(updated, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+                encoding="utf-8",
+            )
+            tmp_markdown_path.write_text(
+                render_benchmark_run_ledger_markdown(updated),
+                encoding="utf-8",
+            )
+            tmp_path.replace(path)
+            tmp_markdown_path.replace(markdown_path)
+    else:
+        updated = load_benchmark_run_ledger(path)
+
+    case_decisions = []
+    for entry in accepted:
+        case = (
+            updated.get("benchmarks", {})
+            .get(entry["benchmark_id"], {})
+            .get("cases", {})
+            .get(entry["case_id"], {})
+        )
+        case_decisions.append(
+            {
+                "benchmark_id": entry["benchmark_id"],
+                "case_id": entry["case_id"],
+                "decision": case.get("latest_decision", {}),
+            }
+        )
+    return {
+        "ok": True,
+        "dry_run": dry_run,
+        "updated": bool(accepted) and not dry_run,
+        "schema_version": BENCHMARK_RUN_LEDGER_SCHEMA_VERSION,
+        "ledger_path": str(path),
+        "markdown_path": str(markdown_path),
+        "input_entry_count": len(entries),
+        "accepted_entry_count": len(accepted),
+        "skipped_entry_count": len(entries) - len(accepted),
+        "upserted_count": len(accepted) if not dry_run else 0,
+        "case_decisions": case_decisions,
+    }
+
+
 def update_benchmark_run_ledger(
     *,
     ledger_path: str | Path,
@@ -3112,38 +3184,25 @@ def update_benchmark_run_ledger(
             "entry": entry,
             "case_decision": {},
         }
-    if dry_run:
-        updated = upsert_benchmark_run_ledger_entry(load_benchmark_run_ledger(path), entry)
-    else:
-        with _LedgerWriteLock(path):
-            updated = upsert_benchmark_run_ledger_entry(
-                load_benchmark_run_ledger(path),
-                entry,
-            )
-            path.parent.mkdir(parents=True, exist_ok=True)
-            tmp_path = path.with_suffix(path.suffix + ".tmp")
-            tmp_markdown_path = markdown_path.with_suffix(markdown_path.suffix + ".tmp")
-            tmp_path.write_text(
-                json.dumps(updated, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
-                encoding="utf-8",
-            )
-            tmp_markdown_path.write_text(
-                render_benchmark_run_ledger_markdown(updated),
-                encoding="utf-8",
-            )
-            tmp_path.replace(path)
-            tmp_markdown_path.replace(markdown_path)
+    batch = update_benchmark_run_ledger_entries(
+        ledger_path=path,
+        entries=[entry],
+        dry_run=dry_run,
+    )
+    case_decision = (
+        batch["case_decisions"][0]["decision"]
+        if batch.get("case_decisions")
+        else {}
+    )
     return {
         "ok": True,
         "dry_run": dry_run,
-        "updated": not dry_run,
+        "updated": batch["updated"],
         "schema_version": BENCHMARK_RUN_LEDGER_SCHEMA_VERSION,
         "ledger_path": str(path),
         "markdown_path": str(markdown_path),
         "entry": entry,
-        "case_decision": updated["benchmarks"][entry["benchmark_id"]]["cases"][
-            entry["case_id"]
-        ]["latest_decision"],
+        "case_decision": case_decision,
     }
 
 

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -175,7 +175,8 @@ fi
 run_group="skillsbench-codex-cli-goal-xhigh-${safe_task}-${tag}-${stamp}"
 job_name="${safe_task}__codex_cli_goal_xhigh_${tag}_${stamp}"
 
-public_dir=".local/goals/${goal_id}/skillsbench-runs/${run_group}"
+public_root=".local/goals/${goal_id}/skillsbench-runs"
+public_dir="${public_root}/${run_group}"
 private_dir=".local/goals/${goal_id}/private/skillsbench-runs/${run_group}"
 mkdir -p "$public_dir" "$private_dir"
 
@@ -237,6 +238,8 @@ supervisor_cmd=(
   --local-public-artifact-dir "$public_dir"
   --local-run-ledger-path "${SKILLSBENCH_LOCAL_RUN_LEDGER_PATH:-.local/goals/${goal_id}/skillsbench-ledgers/live-standard-run-ledger.json}"
   --local-run-group-id "$run_group"
+  --local-ledger-catchup-root "$public_root"
+  --local-ledger-catchup-run-group-contains "skillsbench-codex-cli-goal-xhigh-"
   --private-log-path "${private_dir}/remote-command.log"
   --public-output-path "${public_dir}/supervisor.public.json"
 )

--- a/scripts/skillsbench_reverse_tunnel_supervisor.py
+++ b/scripts/skillsbench_reverse_tunnel_supervisor.py
@@ -530,6 +530,7 @@ def _public_artifact_sync_contract(args: argparse.Namespace) -> dict[str, Any]:
         requested=_public_artifact_sync_requested(args),
         ledger_requested=bool(args.local_run_ledger_path),
         aggregate_requested=bool(args.local_current_aggregate_path),
+        ledger_catchup_requested=bool(args.local_ledger_catchup_root),
     )
 
 
@@ -555,6 +556,10 @@ def _sync_remote_public_artifacts(args: argparse.Namespace) -> dict[str, Any]:
         target_run_group_contains=list(args.local_target_run_group_contains or []),
         target_backfill_run_group_contains=list(
             args.local_target_backfill_run_group_contains or []
+        ),
+        ledger_catchup_root=args.local_ledger_catchup_root,
+        ledger_catchup_run_group_contains=list(
+            args.local_ledger_catchup_run_group_contains or []
         ),
         repo_root=REPO_ROOT,
     )
@@ -1128,6 +1133,24 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument("--local-run-group-id", default="")
+    parser.add_argument(
+        "--local-ledger-catchup-root",
+        default="",
+        help=(
+            "Optional local public artifact root laid out as "
+            "<run-group-id>/**/benchmark_run.compact.json. Missing terminal rows "
+            "are upserted before aggregation; raw artifacts are never read."
+        ),
+    )
+    parser.add_argument(
+        "--local-ledger-catchup-run-group-contains",
+        action="append",
+        default=[],
+        help=(
+            "Optional substring filter for catch-up run-group directories. "
+            "May be repeated."
+        ),
+    )
     parser.add_argument("--local-current-aggregate-path", default="")
     parser.add_argument("--local-canonical-case-ids-file", default="")
     parser.add_argument("--local-benchmark-id", default="skillsbench@1.1")
@@ -1185,6 +1208,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
                 parser.error("--remote-public-artifact-glob must be relative and bounded")
     if args.local_run_ledger_path and not _public_artifact_sync_requested(args):
         parser.error("--local-run-ledger-path requires artifact sync")
+    if args.local_ledger_catchup_root and not args.local_run_ledger_path:
+        parser.error("--local-ledger-catchup-root requires --local-run-ledger-path")
     if args.local_current_aggregate_path:
         if not args.local_run_ledger_path or not args.local_canonical_case_ids_file:
             parser.error(


### PR DESCRIPTION
## Summary
- add atomic batch upserts for terminal benchmark ledger entries
- reconcile missing compact rows from a bounded public run-group root before aggregate refresh
- wire the active SkillsBench goal-xhigh launcher to the generic catch-up contract
- keep target-lane filtering, public/private artifact checks, size bounds, and idempotent retries explicit

## Behavior boundaries
- no scoring or case-semantic changes
- no benchmark task launches
- no leaderboard/submission changes
- no raw task text, trajectories, logs, verifier output, credentials, or local paths in public artifacts

## Validation
- `python3 examples/benchmark-run-ledger-smoke.py`
- `python3 examples/cli-benchmark-run-ledger-command-modularization-smoke.py`
- `python3 examples/skillsbench-current-ledger-aggregate-smoke.py`
- `python3 examples/benchmark-remote-closeout-catchup-smoke.py`
- `python3 examples/skillsbench-reverse-tunnel-supervisor-smoke.py`
- `python3 examples/skillsbench-benchmark-egress-policy-smoke.py`
- `loopx canary premerge --from-git-diff --tier standard --timeout-seconds 180 --format json` (all 7 executed checks passed; benchmark-sensitive manual review hold remains by policy)
- `loopx check` on all changed public files (0 errors, 0 warnings)
