### PR TITLE
Make benchmark ledger catch-up logically idempotent

### DIFF
--- a/examples/benchmark-remote-closeout-catchup-smoke.py
+++ b/examples/benchmark-remote-closeout-catchup-smoke.py
@@ -16,6 +16,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from loopx.benchmark_core.remote_closeout import closeout_remote_benchmark_batch
+from loopx.benchmark_ledger import update_benchmark_run_ledger
 
 
 def _compact(case_id: str, score: float) -> dict[str, object]:
@@ -55,20 +56,28 @@ def test_closeout_catches_up_public_target_rows_once() -> None:
         root = Path(tmp)
         catchup_root = root / "public-runs"
         accepted = catchup_root / "target-old" / "benchmark_run.compact.json"
+        equivalent = catchup_root / "target-equivalent" / "benchmark_run.compact.json"
         ignored = catchup_root / "other-lane" / "benchmark_run.compact.json"
         private = catchup_root / "target-old" / "logs" / "benchmark_run.compact.json"
         malformed = catchup_root / "target-malformed" / "benchmark_run.compact.json"
         _write_compact(accepted, _compact("case-b", 1.0))
+        _write_compact(equivalent, _compact("case-d", 0.5))
         _write_compact(ignored, _compact("case-c", 1.0))
         _write_compact(private, _compact("private-case", 1.0))
         malformed.parent.mkdir(parents=True)
         malformed.write_text("{not-json\n", encoding="utf-8")
 
         canonical = root / "canonical.txt"
-        canonical.write_text("case-a\ncase-b\n", encoding="utf-8")
+        canonical.write_text("case-a\ncase-b\ncase-d\n", encoding="utf-8")
         ledger = root / "ledger.json"
         aggregate = root / "aggregate.json"
         collection = _collection(_compact("case-a", 0.0))
+        update_benchmark_run_ledger(
+            ledger_path=ledger,
+            benchmark_run=_compact("case-d", 0.5),
+            run_group_id="target-equivalent-seed",
+            dry_run=False,
+        )
 
         def run_closeout() -> dict[str, object]:
             return closeout_remote_benchmark_batch(
@@ -96,20 +105,22 @@ def test_closeout_catches_up_public_target_rows_once() -> None:
         update = first["local_ledger_update"]
         assert first["ok"] is True, first
         assert update["upserted_count"] == 2, update
-        assert update["catchup_compact_count"] == 2, update
+        assert update["catchup_compact_count"] == 3, update
         assert update["catchup_upserted_count"] == 1, update
+        assert update["catchup_already_present_count"] == 1, update
         assert update["catchup_skipped_count"] == 1, update
         assert update["catchup_blocked_count"] == 1, update
         cases = json.loads(ledger.read_text(encoding="utf-8"))["benchmarks"][
             "skillsbench@1.1"
         ]["cases"]
-        assert set(cases) == {"case-a", "case-b"}, cases
-        assert json.loads(aggregate.read_text(encoding="utf-8"))["canonical_total"] == 2
+        assert set(cases) == {"case-a", "case-b", "case-d"}, cases
+        assert len(cases["case-d"]["runs"]) == 1, cases["case-d"]
+        assert json.loads(aggregate.read_text(encoding="utf-8"))["canonical_total"] == 3
 
         second = run_closeout()
         retry = second["local_ledger_update"]
         assert retry["catchup_upserted_count"] == 0, retry
-        assert retry["catchup_already_present_count"] == 1, retry
+        assert retry["catchup_already_present_count"] == 2, retry
         cases = json.loads(ledger.read_text(encoding="utf-8"))["benchmarks"][
             "skillsbench@1.1"
         ]["cases"]

--- a/loopx/benchmark_core/remote_closeout.py
+++ b/loopx/benchmark_core/remote_closeout.py
@@ -173,6 +173,7 @@ def _refresh_ledger_and_aggregate(
     from ..benchmark_ledger import (
         build_benchmark_run_ledger_entry,
         build_benchmark_run_ledger_current_aggregate,
+        benchmark_run_ledger_entry_signature,
         load_benchmark_run_ledger,
         update_benchmark_run_ledger_entries,
     )
@@ -255,6 +256,15 @@ def _refresh_ledger_and_aggregate(
             for run in (case.get("runs") or [])
             if isinstance(run, dict) and run.get("run_id")
         }
+        ledger_signatures = {
+            benchmark_run_ledger_entry_signature(run)
+            for benchmark in (ledger.get("benchmarks") or {}).values()
+            if isinstance(benchmark, dict)
+            for case in (benchmark.get("cases") or {}).values()
+            if isinstance(case, dict)
+            for run in (case.get("runs") or [])
+            if isinstance(run, dict)
+        }
         for compact_path, historical_run_group_id in catchup_paths:
             catchup_run_groups.add(historical_run_group_id)
             try:
@@ -272,12 +282,14 @@ def _refresh_ledger_and_aggregate(
                 cwd=repo_root,
             )
             run_id = str(entry.get("run_id") or "")
-            if run_id and run_id in ledger_run_ids:
+            signature = benchmark_run_ledger_entry_signature(entry)
+            if (run_id and run_id in ledger_run_ids) or signature in ledger_signatures:
                 catchup_already_present += 1
                 continue
             catchup_entries.append(entry)
             if run_id:
                 ledger_run_ids.add(run_id)
+            ledger_signatures.add(signature)
     catchup_update = update_benchmark_run_ledger_entries(
         ledger_path=Path(ledger_path).expanduser(),
         entries=catchup_entries,

--- a/loopx/benchmark_ledger.py
+++ b/loopx/benchmark_ledger.py
@@ -3398,7 +3398,11 @@ def archive_benchmark_run_ledger_runs(
     }
 
 
-def _ledger_entry_signature(entry: dict[str, Any]) -> tuple[str, ...]:
+def benchmark_run_ledger_entry_signature(
+    entry: dict[str, Any],
+) -> tuple[str, ...]:
+    """Return the stable logical identity used for ledger drift detection."""
+
     return (
         _compact_text(entry.get("benchmark_id"), limit=120),
         _compact_text(entry.get("case_id"), limit=160),
@@ -3499,7 +3503,10 @@ def merge_benchmark_run_ledgers(
             for run in _iter_ledger_runs(updated)
             if _compact_text(run.get("run_id"), limit=80)
         }
-        before_signatures = {_ledger_entry_signature(run) for run in _iter_ledger_runs(updated)}
+        before_signatures = {
+            benchmark_run_ledger_entry_signature(run)
+            for run in _iter_ledger_runs(updated)
+        }
         source_ledger_count = 0
         missing_source_count = 0
         source_run_count = 0
@@ -3547,7 +3554,9 @@ def merge_benchmark_run_ledgers(
             for run in after_runs
             if _compact_text(run.get("run_id"), limit=80)
         }
-        after_signatures = {_ledger_entry_signature(run) for run in after_runs}
+        after_signatures = {
+            benchmark_run_ledger_entry_signature(run) for run in after_runs
+        }
         summary = {
             "schema_version": "benchmark_run_ledger_merge_v0",
             "ok": True,
@@ -3625,7 +3634,9 @@ def check_benchmark_run_ledger_drift(
         for run in ledger_runs
         if _compact_text(run.get("run_id"), limit=80)
     }
-    ledger_signatures = {_ledger_entry_signature(run) for run in ledger_runs}
+    ledger_signatures = {
+        benchmark_run_ledger_entry_signature(run) for run in ledger_runs
+    }
 
     checked_history_run_count = 0
     terminal_history_run_count = 0
@@ -3654,7 +3665,7 @@ def check_benchmark_run_ledger_drift(
             continue
         terminal_history_run_count += 1
         run_id = _compact_text(entry.get("run_id"), limit=80)
-        signature = _ledger_entry_signature(entry)
+        signature = benchmark_run_ledger_entry_signature(entry)
         if run_id in ledger_run_ids or signature in ledger_signatures:
             matched_count += 1
             continue


### PR DESCRIPTION
## Summary
- expose the stable ledger signature already used by merge/drift checks
- treat either matching run id or matching logical signature as an existing catch-up row
- cover equivalent results from different run groups in the generic closeout smoke

## Root cause
A ledger logical-backfill merge can intentionally preserve the existing run id. Run-id-only catch-up therefore retried one equivalent compact on every closeout even though the ledger already represented it.

## Boundaries
- no scoring, case semantics, runner launch, or aggregate-selection changes
- no benchmark jobs launched
- compact/public evidence only

## Validation
- focused closeout, ledger, and supervisor smokes passed
- real public-root canary against a temporary copy of the live ledger: `40/40` historical candidates recognized as already present, `catchup_upserted_count=0`; aggregate preserved `87/87`, sum `28.525`, mean `0.327874`
- standard premerge canary: 7/7 executed checks passed, 0 failures
- public boundary scan: 0 errors, 0 warnings
