### PR TITLE
Add typed todo continuation policies

### DIFF
--- a/docs/project-agent-todo-contract.md
+++ b/docs/project-agent-todo-contract.md
@@ -346,25 +346,42 @@ shared default route, and may override that default for a specific side agent
 with `coordination.agent_profiles.<agent_id>.review_policy.handoff_agent`.
 `--next-claimed-by` is allowed only when it matches the resolved handoff owner.
 An explicitly declared primary review successor is the narrow exception: when a
-side agent completes a todo with `--next-action-kind primary_review*` and
+side agent completes a todo with `--next-continuation-policy primary_review` and
 `--next-claimed-by <primary_agent>`, that successor remains a primary-agent
 review handoff even if the goal has a broader `side_agent_handoff_agent`
 default. Use this only for real review/merge/publication decisions; ordinary
 side-agent continuation should follow the resolved handoff route.
+Legacy `action_kind=primary_review*` state remains readable, but new writers
+should use the typed continuation policy instead of encoding handoff authority
+in an action-name prefix.
 Existing registry fields named for review are not aliases for this route. This
 keeps broad side-agent handoff visible to the shared control plane without
 hard-coding a single follow-up surface for every side-agent lane.
 
-LoopX does not model "review" as a separate kernel object. Review, verification,
-or continuation are product-level names for a successor todo. The machine
-contract is generic: the generated successor records
+LoopX does not model "review" as a separate kernel object. `action_kind`
+remains an open domain token describing what work a todo performs. The closed
+`continuation_policy` field describes only who may continue after completion:
+
+- `independent_handoff` is the safe default;
+- `same_agent_non_delivery` permits an evidence-backed non-delivery gate to
+  link an existing same-agent successor;
+- `primary_review` preserves a primary-agent review handoff.
+
+`same_agent_non_delivery` is intentionally structural rather than
+review-specific. It covers readiness checks, audits, triage, verification, and
+other non-delivery gates only when the source has evidence, no required write
+scope, a distinct `blocks_agent`, and an explicitly linked open successor. It
+does not authorize repository delivery or bypass successor quota/capability
+checks. Legacy `*_review` and `*_verification` action kinds remain a read
+compatibility path and are materialized as the typed policy on the next write.
+
+The generated successor records
 `blocks_agent=<side-agent-id>` and
 `unblocks_todo_id=<completed-todo-id>`, while `claimed_by` names the agent that
 should handle the dependency. Quota and dashboards can prioritize this handoff
-without parsing prose or adding a review-specific action kind. Same-agent broad
-handoff is rejected; if the completing side agent is allowed to deliver without
-another agent, it must use the explicit `--side-agent-self-merged --evidence`
-path.
+without parsing prose. Same-agent broad delivery remains rejected; if the
+completing side agent is allowed to deliver without another agent, it must use
+the explicit `--side-agent-self-merged --evidence` path.
 
 For primary-agent completions and self-merged same-lane continuations, a
 successor created with `--next-agent-todo` inherits the completed todo's
@@ -488,7 +505,9 @@ carry `schema_version=todo_summary_v0`; individual items carry
 `schema_version=todo_item_v0`, `todo_id`, `role`, `status`, `priority`,
 `title`, `archive_state`, `source_section`, `index`, `text`, `task_class`, and
 optional `action_kind`, `claimed_by`, `required_capabilities`, and
-`target_capabilities`. Primary review handoffs may also carry
+`target_capabilities`. `action_kind` is extensible; optional
+`continuation_policy` is limited to `independent_handoff`,
+`same_agent_non_delivery`, or `primary_review`. Primary review handoffs may also carry
 `blocks_agent`, `unblocks_todo_id`, and `no_followup=true` to show which
 agent/todo they release and whether a completed handoff intentionally has no
 successor.

--- a/docs/reference/protocols/active-state-structured-projection-v0.md
+++ b/docs/reference/protocols/active-state-structured-projection-v0.md
@@ -58,7 +58,7 @@ current active-state Markdown and does not grant write permission.
 Todo items use the existing `todo_item_v0` fields where possible:
 
 - `todo_id`, `todo_id_source`, `role`, `status`, `done`;
-- `priority`, `title`, `task_class`, `action_kind`;
+- `priority`, `title`, `task_class`, `action_kind`, `continuation_policy`;
 - `claimed_by`, `blocks_agent`, `global_gate`, `unblocks_todo_id`;
 - `resume_when`, `no_followup`;
 - monitor metadata such as `target_key`, `cadence`, `next_due_at`, and

--- a/examples/control_plane/capability-gate-projection-smoke.py
+++ b/examples/control_plane/capability-gate-projection-smoke.py
@@ -31,6 +31,7 @@ def todo(
     claimed_by: str | None = None,
     blocks_agent: str | None = None,
     action_kind: str | None = None,
+    continuation_policy: str | None = None,
     required_capabilities: list[str] | None = None,
     target_capabilities: list[str] | None = None,
 ) -> dict:
@@ -52,6 +53,8 @@ def todo(
         item["blocks_agent"] = blocks_agent
     if action_kind:
         item["action_kind"] = action_kind
+    if continuation_policy:
+        item["continuation_policy"] = continuation_policy
     if required_capabilities:
         item["required_capabilities"] = required_capabilities
     if target_capabilities:
@@ -101,7 +104,14 @@ def assert_current_agent_candidate_order_contract() -> None:
             blocks_agent="codex-value-explorer",
         ),
         todo("todo_other_p0", 4, "P0", claimed_by=PRIMARY_AGENT),
-        todo("todo_primary_review", 5, "P2", claimed_by=AGENT_ID, action_kind="primary_review"),
+        todo(
+            "todo_primary_review",
+            5,
+            "P2",
+            claimed_by=AGENT_ID,
+            action_kind="merge_gate",
+            continuation_policy="primary_review",
+        ),
     ]
     ordered, policy = _sort_capability_runnable_candidates(
         runnable,

--- a/examples/control_plane/event-sourced-state-api-smoke.py
+++ b/examples/control_plane/event-sourced-state-api-smoke.py
@@ -59,6 +59,9 @@ def test_store_projection_and_markdown() -> None:
                 "planner_order": 1,
                 "task_class": "advancement_task",
                 "action_kind": "implement",
+                "continuation_policy": "independent_handoff",
+                "required_write_scopes": ["loopx/**"],
+                "blocks_agent": "codex-main-control",
             },
         )
         todo_b = todo_event(
@@ -142,6 +145,17 @@ def test_store_projection_and_markdown() -> None:
             "todo_event_b",
         ], projection
         assert projection["agent_todos"]["items"][0]["status"] == "done", projection
+        assert (
+            projection["agent_todos"]["items"][0]["continuation_policy"]
+            == "independent_handoff"
+        ), projection
+        assert projection["agent_todos"]["items"][0]["required_write_scopes"] == [
+            "loopx/**"
+        ], projection
+        assert (
+            projection["agent_todos"]["items"][0]["blocks_agent"]
+            == "codex-main-control"
+        ), projection
         assert projection["agent_todos"]["items"][1]["status"] == "blocked", projection
         assert projection["user_todos"]["first_open_items"][0]["todo_id"] == "todo_user_gate", projection
 
@@ -151,6 +165,9 @@ def test_store_projection_and_markdown() -> None:
         assert "todo_id=todo_event_a" in markdown, markdown
         assert "todo_id=todo_user_gate" in markdown, markdown
         assert "claimed_by=codex-product-capability" in markdown, markdown
+        assert "continuation_policy=independent_handoff" in markdown, markdown
+        assert "required_write_scopes=loopx%2F%2A%2A" in markdown, markdown
+        assert "blocks_agent=codex-main-control" in markdown, markdown
         assert "## Progress Ledger" in markdown, markdown
 
         parsed = parse_active_state_todos(markdown)

--- a/examples/control_plane/todo-cli-smoke.py
+++ b/examples/control_plane/todo-cli-smoke.py
@@ -302,6 +302,8 @@ def main() -> int:
             "advancement_task",
             "--action-kind",
             "run_eval",
+            "--continuation-policy",
+            "independent_handoff",
             "--required-capability",
             "shell",
             "--required-capability",
@@ -316,6 +318,9 @@ def main() -> int:
         assert metadata_payload["metadata_updated"] is True, metadata_payload
         assert metadata_payload["task_class"] == "advancement_task", metadata_payload
         assert metadata_payload["action_kind"] == "run_eval", metadata_payload
+        assert (
+            metadata_payload["continuation_policy"] == "independent_handoff"
+        ), metadata_payload
         assert metadata_payload["required_capabilities"] == ["shell", "benchmark_runner"], metadata_payload
         assert metadata_payload["target_capabilities"] == ["benchmark_runner"], metadata_payload
         assert metadata_payload["required_decision_scopes"] == [
@@ -332,6 +337,7 @@ def main() -> int:
         agent_metadata_start = after_metadata.index("<!-- loopx:todo", agent_block_start)
         assert after_metadata.index("checklist is done.", agent_block_start) < agent_metadata_start, after_metadata
         assert "status=open task_class=advancement_task action_kind=run_eval" in after_metadata
+        assert "continuation_policy=independent_handoff" in after_metadata
         assert "required_capabilities=shell%2Cbenchmark_runner" in after_metadata
         assert "target_capabilities=benchmark_runner" in after_metadata
         assert (

--- a/examples/control_plane/todo-continuation-policy-smoke.py
+++ b/examples/control_plane/todo-continuation-policy-smoke.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Exercise typed todo continuation policy and legacy compatibility."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.todos.completion_policy import (  # noqa: E402
+    LinkedSuccessor,
+    resolve_completion_policy,
+)
+from loopx.control_plane.todos.contract import (  # noqa: E402
+    TodoContinuationPolicy,
+    format_todo_metadata_line,
+    parse_todo_metadata_line,
+    resolve_todo_continuation_policy,
+)
+
+
+GOAL_ID = "todo-continuation-policy-fixture"
+PRIMARY_AGENT = "codex-main-control"
+SIDE_AGENT = "codex-side-bypass"
+SUCCESSOR_ID = "todo_continuation_successor"
+
+
+def write_registry(root: Path) -> Path:
+    registry_path = root / "registry.json"
+    registry_path.write_text(
+        json.dumps(
+            {
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "coordination": {
+                            "registered_agents": [PRIMARY_AGENT, SIDE_AGENT],
+                            "primary_agent": PRIMARY_AGENT,
+                            "side_agent_handoff_agent": SIDE_AGENT,
+                        },
+                    }
+                ]
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry_path
+
+
+def source_todo(
+    *,
+    action_kind: str,
+    continuation_policy: str | None,
+    write_scoped: bool = False,
+) -> dict:
+    item = {
+        "role": "agent",
+        "task_class": "advancement_task",
+        "action_kind": action_kind,
+        "claimed_by": SIDE_AGENT,
+        "blocks_agent": PRIMARY_AGENT,
+    }
+    if continuation_policy:
+        item["continuation_policy"] = continuation_policy
+    if write_scoped:
+        item["required_write_scopes"] = ["loopx/**"]
+    return item
+
+
+def successor(policy: str = "independent_handoff") -> LinkedSuccessor:
+    return LinkedSuccessor(
+        todo_id=SUCCESSOR_ID,
+        role="agent",
+        status="open",
+        task_class="advancement_task",
+        action_kind="continue_lane",
+        continuation_policy=policy,
+        claimed_by=SIDE_AGENT,
+    )
+
+
+def resolve_existing(
+    registry_path: Path,
+    *,
+    source: dict,
+    linked_successor: LinkedSuccessor | None = None,
+):
+    return resolve_completion_policy(
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        claimed_by=SIDE_AGENT,
+        evidence="public-safe non-delivery evidence",
+        linked_successors=[linked_successor or successor()],
+        completion_todo=source,
+    )
+
+
+def expect_rejected(callable_) -> None:
+    try:
+        callable_()
+    except ValueError as exc:
+        assert "--side-agent-self-merged" in str(exc), exc
+    else:
+        raise AssertionError("expected side-agent completion policy rejection")
+
+
+def assert_action_agnostic_non_delivery_policy(registry_path: Path) -> None:
+    for action_kind in (
+        "readiness_check",
+        "evidence_audit",
+        "pilot_readiness_review",
+        "artifact_verification",
+    ):
+        policy = resolve_existing(
+            registry_path,
+            source=source_todo(
+                action_kind=action_kind,
+                continuation_policy="same_agent_non_delivery",
+            ),
+        )
+        assert policy.linked_handoff_successor_id == SUCCESSOR_ID, policy
+        assert policy.side_agent_self_merged is False, policy
+
+
+def assert_delivery_and_primary_review_stay_gated(registry_path: Path) -> None:
+    expect_rejected(
+        lambda: resolve_existing(
+            registry_path,
+            source=source_todo(
+                action_kind="readiness_check",
+                continuation_policy="independent_handoff",
+            ),
+        )
+    )
+    expect_rejected(
+        lambda: resolve_existing(
+            registry_path,
+            source=source_todo(
+                action_kind="readiness_check",
+                continuation_policy="same_agent_non_delivery",
+                write_scoped=True,
+            ),
+        )
+    )
+    expect_rejected(
+        lambda: resolve_existing(
+            registry_path,
+            source=source_todo(
+                action_kind="readiness_check",
+                continuation_policy="same_agent_non_delivery",
+            ),
+            linked_successor=successor("primary_review"),
+        )
+    )
+
+
+def assert_primary_review_override_is_typed(registry_path: Path) -> None:
+    policy = resolve_completion_policy(
+        registry_path=registry_path,
+        goal_id=GOAL_ID,
+        claimed_by=SIDE_AGENT,
+        next_claimed_by=PRIMARY_AGENT,
+        next_agent_todo="Review the validated delivery.",
+        next_action_kind="merge_gate",
+        next_continuation_policy="primary_review",
+        evidence="validated delivery evidence",
+    )
+    assert policy.effective_next_claimed_by == PRIMARY_AGENT, policy
+
+
+def assert_legacy_names_materialize_typed_policy() -> None:
+    metadata = format_todo_metadata_line(
+        todo_id="todo_legacy_review",
+        status="open",
+        task_class="advancement_task",
+        action_kind="pilot_readiness_review",
+    )
+    parsed = parse_todo_metadata_line(metadata or "") or {}
+    assert parsed["continuation_policy"] == "same_agent_non_delivery", parsed
+    assert resolve_todo_continuation_policy(
+        None,
+        action_kind="primary_review_merge",
+    ) == TodoContinuationPolicy.PRIMARY_REVIEW
+    assert resolve_todo_continuation_policy(
+        None,
+        action_kind="implementation_slice",
+    ) == TodoContinuationPolicy.INDEPENDENT_HANDOFF
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-continuation-policy-") as tmp:
+        registry_path = write_registry(Path(tmp))
+        assert_action_agnostic_non_delivery_policy(registry_path)
+        assert_delivery_and_primary_review_stay_gated(registry_path)
+        assert_primary_review_override_is_typed(registry_path)
+    assert_legacy_names_materialize_typed_policy()
+    print("todo-continuation-policy-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/control_plane/todo-list-event-projection-smoke.py
+++ b/examples/control_plane/todo-list-event-projection-smoke.py
@@ -23,8 +23,12 @@ from loopx.event_sourced_state import (  # noqa: E402
 
 
 GOAL_ID = "todo-list-event-projection-fixture"
+PRIMARY_AGENT = "codex-main-control"
+SIDE_AGENT = "codex-side-bypass"
 GATE_TODO_ID = "todo_markdown_gate_done"
 DEPENDENT_TODO_ID = "todo_event_dependent"
+EVENT_GATE_TODO_ID = "todo_event_non_delivery_gate"
+EVENT_SUCCESSOR_TODO_ID = "todo_event_same_agent_successor"
 
 
 def write_fixture(root: Path) -> tuple[Path, Path, Path]:
@@ -67,6 +71,11 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
                         "state_file": f".codex/goals/{GOAL_ID}/ACTIVE_GOAL_STATE.md",
                         "state_event_log": f".codex/goals/{GOAL_ID}/events.jsonl",
                         "adapter": {"kind": "generic_project_goal_v0", "status": "connected"},
+                        "coordination": {
+                            "registered_agents": [PRIMARY_AGENT, SIDE_AGENT],
+                            "primary_agent": PRIMARY_AGENT,
+                            "side_agent_handoff_agent": SIDE_AGENT,
+                        },
                         "authority_sources": [],
                     }
                 ],
@@ -126,6 +135,7 @@ def write_events(event_log: Path) -> None:
                 "planner_order": 1,
                 "task_class": "advancement_task",
                 "action_kind": "implement",
+                "continuation_policy": "independent_handoff",
             },
         )
     )
@@ -174,6 +184,10 @@ def main() -> int:
         )
         assert dependent["resume_ready"] is True, dependent
         assert dependent["resume_condition"]["target_status"] == "done", dependent
+        projected_open = next(
+            item for item in projected["todos"] if item["todo_id"] == "todo_event_open"
+        )
+        assert projected_open["continuation_policy"] == "independent_handoff", projected_open
         assert projected["projection_overlay"]["markdown_only_todo_ids"] == [
             GATE_TODO_ID,
             DEPENDENT_TODO_ID,
@@ -214,6 +228,60 @@ def main() -> int:
         assert done_only["source"] == "event_projection_with_markdown_overlay", done_only
         assert done_only["todo_count"] == 1, done_only
         assert done_only["todos"][0]["todo_id"] == "todo_event_done", done_only
+
+        store = AppendOnlyStateEventStore(event_log)
+        store.append(
+            event(
+                "evt-non-delivery-gate",
+                TODO_ADDED,
+                EVENT_GATE_TODO_ID,
+                {
+                    "role": "agent",
+                    "priority": "P1",
+                    "title": "Complete an event-projected readiness gate",
+                    "task_class": "advancement_task",
+                    "action_kind": "readiness_check",
+                    "continuation_policy": "same_agent_non_delivery",
+                    "claimed_by": SIDE_AGENT,
+                    "blocks_agent": PRIMARY_AGENT,
+                },
+            )
+        )
+        store.append(
+            event(
+                "evt-same-agent-successor",
+                TODO_ADDED,
+                EVENT_SUCCESSOR_TODO_ID,
+                {
+                    "role": "agent",
+                    "priority": "P1",
+                    "title": "Continue the event-projected lane",
+                    "task_class": "advancement_task",
+                    "action_kind": "continue_lane",
+                    "continuation_policy": "independent_handoff",
+                    "claimed_by": SIDE_AGENT,
+                },
+            )
+        )
+        completed = run_cli(
+            registry_path,
+            "todo",
+            "complete",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--todo-id",
+            EVENT_GATE_TODO_ID,
+            "--claimed-by",
+            SIDE_AGENT,
+            "--evidence",
+            "public-safe event-projected readiness evidence",
+            "--successor-todo-id",
+            EVENT_SUCCESSOR_TODO_ID,
+        )
+        assert completed["linked_handoff_successor_id"] == EVENT_SUCCESSOR_TODO_ID, completed
+        assert completed["side_agent_self_merged"] is False, completed
 
         event_log.unlink()
         fallback = run_cli(registry_path, "todo", "list", "--goal-id", GOAL_ID, "--role", "agent")

--- a/examples/control_plane/todo_lifecycle_fixtures.py
+++ b/examples/control_plane/todo_lifecycle_fixtures.py
@@ -210,6 +210,7 @@ def assert_configured_side_agent_handoff() -> None:
         review_successor = explicit_primary_review["next_todos"][0]
         assert review_successor["claimed_by"] == "codex-main-control", explicit_primary_review
         assert review_successor["action_kind"] == "primary_review_merge", explicit_primary_review
+        assert review_successor["continuation_policy"] == "primary_review", explicit_primary_review
         assert review_successor["blocks_agent"] == "codex-side-bypass", explicit_primary_review
         assert review_successor["unblocks_todo_id"] == review_source_added["todo_id"], explicit_primary_review
         review_successor_item = next(
@@ -217,6 +218,7 @@ def assert_configured_side_agent_handoff() -> None:
         )
         assert review_successor_item["claimed_by"] == "codex-main-control", review_successor_item
         assert review_successor_item["action_kind"] == "primary_review_merge", review_successor_item
+        assert review_successor_item["continuation_policy"] == "primary_review", review_successor_item
 
     with tempfile.TemporaryDirectory(prefix="loopx-side-agent-handoff-self-smoke-") as tmp:
         root = Path(tmp)

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -4,6 +4,7 @@ import argparse
 from collections.abc import Callable
 from pathlib import Path
 
+from ..control_plane.todos.contract import TODO_CONTINUATION_POLICY_VALUES
 from ..todo_suggestion_prompt import (
     ALLOWED_TODO_SUGGESTION_SOURCES,
     ALLOWED_TODO_SUGGESTION_TRIGGERS,
@@ -87,6 +88,14 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
         help=(
             "For todo add, optional public-safe action token such as run_eval, "
             "rebuild_score, compact_blocker_writeback, or monitor."
+        ),
+    )
+    todo_parser.add_argument(
+        "--continuation-policy",
+        choices=sorted(TODO_CONTINUATION_POLICY_VALUES),
+        help=(
+            "Closed completion/handoff policy for this todo. action_kind remains "
+            "an extensible domain token; defaults to independent_handoff."
         ),
     )
     todo_parser.add_argument(
@@ -253,6 +262,11 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
     )
     todo_parser.add_argument("--next-action-kind", help="Action kind for --next-agent-todo.")
     todo_parser.add_argument(
+        "--next-continuation-policy",
+        choices=sorted(TODO_CONTINUATION_POLICY_VALUES),
+        help="Continuation policy for --next-agent-todo.",
+    )
+    todo_parser.add_argument(
         "--max-active-done",
         type=int,
         default=ARCHIVE_COMPLETED_DEFAULT_MAX_ACTIVE_DONE,
@@ -345,6 +359,7 @@ def handle_todo_command(
                     ("--reason", args.reason),
                     ("--task-class", args.task_class),
                     ("--action-kind", args.action_kind),
+                    ("--continuation-policy", args.continuation_policy),
                     ("--required-write-scope", args.required_write_scopes),
                     ("--required-capability", args.required_capabilities),
                     ("--target-capability", args.target_capabilities),
@@ -367,6 +382,7 @@ def handle_todo_command(
                     ("--next-claimed-by", args.next_claimed_by),
                     ("--next-task-class", args.next_task_class),
                     ("--next-action-kind", args.next_action_kind),
+                    ("--next-continuation-policy", args.next_continuation_policy),
                     ("--side-agent-self-merged", args.side_agent_self_merged),
                     ("--from", args.suggestion_sources),
                     ("--limit", args.suggestion_limit),
@@ -402,6 +418,8 @@ def handle_todo_command(
                 raise ValueError("todo add accepts --claimed-by but not --clear-claim")
             if args.next_claimed_by:
                 raise ValueError("todo add does not support --next-claimed-by")
+            if args.next_continuation_policy:
+                raise ValueError("todo add does not support --next-continuation-policy")
             if args.side_agent_self_merged:
                 raise ValueError("todo add does not support --side-agent-self-merged")
             if args.no_follow_up:
@@ -415,6 +433,7 @@ def handle_todo_command(
                 text=args.text,
                 task_class=args.task_class,
                 action_kind=args.action_kind,
+                continuation_policy=args.continuation_policy,
                 required_write_scopes=args.required_write_scopes,
                 required_capabilities=args.required_capabilities,
                 target_capabilities=args.target_capabilities,
@@ -453,6 +472,7 @@ def handle_todo_command(
                     ("--reason", args.reason),
                     ("--task-class", args.task_class),
                     ("--action-kind", args.action_kind),
+                    ("--continuation-policy", args.continuation_policy),
                     ("--required-write-scope", args.required_write_scopes),
                     ("--required-capability", args.required_capabilities),
                     ("--target-capability", args.target_capabilities),
@@ -473,6 +493,7 @@ def handle_todo_command(
                     ("--next-claimed-by", args.next_claimed_by),
                     ("--next-task-class", args.next_task_class),
                     ("--next-action-kind", args.next_action_kind),
+                    ("--next-continuation-policy", args.next_continuation_policy),
                     ("--side-agent-self-merged", args.side_agent_self_merged),
                     ("--follow-up", args.followups),
                 )
@@ -509,6 +530,7 @@ def handle_todo_command(
                 args.reason,
                 args.task_class,
                 args.action_kind,
+                args.continuation_policy,
                 args.required_write_scopes,
                 args.required_capabilities,
                 args.target_capabilities,
@@ -527,13 +549,15 @@ def handle_todo_command(
                 args.expires_at,
                 args.clear_claim,
             ]):
-                raise ValueError("todo update requires at least one of --text, --status, --note, --evidence, --reason, --task-class, --action-kind, --required-write-scope, --required-capability, --target-capability, --decision-scope, --required-decision-scope, --claimed-by, --blocks-agent, --global-gate, --unblocks-todo-id, --successor-todo-id, --resume-when, --monitor-target-key, --cadence, --next-due-at, --expires-at, --no-follow-up, or --clear-claim")
+                raise ValueError("todo update requires at least one of --text, --status, --note, --evidence, --reason, --task-class, --action-kind, --continuation-policy, --required-write-scope, --required-capability, --target-capability, --decision-scope, --required-decision-scope, --claimed-by, --blocks-agent, --global-gate, --unblocks-todo-id, --successor-todo-id, --resume-when, --monitor-target-key, --cadence, --next-due-at, --expires-at, --no-follow-up, or --clear-claim")
             if args.no_follow_up and not (args.note or args.reason or args.evidence):
                 raise ValueError("--no-follow-up requires --note, --reason, or --evidence")
             if args.followups:
                 raise ValueError("todo update does not support --follow-up; use `todo capture-followups`")
             if args.next_claimed_by:
                 raise ValueError("todo update does not support --next-claimed-by")
+            if args.next_continuation_policy:
+                raise ValueError("todo update does not support --next-continuation-policy")
             if args.side_agent_self_merged:
                 raise ValueError("todo update does not support --side-agent-self-merged")
             payload = update_goal_todo(
@@ -548,6 +572,7 @@ def handle_todo_command(
                 reason=args.reason,
                 task_class=args.task_class,
                 action_kind=args.action_kind,
+                continuation_policy=args.continuation_policy,
                 required_write_scopes=args.required_write_scopes,
                 required_capabilities=args.required_capabilities,
                 target_capabilities=args.target_capabilities,
@@ -591,6 +616,14 @@ def handle_todo_command(
                 raise ValueError("--no-follow-up requires --note or --evidence")
             if args.followups:
                 raise ValueError("todo complete does not support --follow-up; use `todo capture-followups`")
+            if args.continuation_policy:
+                raise ValueError(
+                    "todo complete does not update --continuation-policy; use todo update first"
+                )
+            if args.next_continuation_policy and not args.next_agent_todo:
+                raise ValueError(
+                    "--next-continuation-policy requires --next-agent-todo"
+                )
             payload = complete_goal_todo(
                 registry_path=registry_path,
                 goal_id=args.goal_id,
@@ -607,6 +640,7 @@ def handle_todo_command(
                 next_claimed_by=args.next_claimed_by,
                 next_task_class=args.next_task_class,
                 next_action_kind=args.next_action_kind,
+                next_continuation_policy=args.next_continuation_policy,
                 side_agent_self_merged=bool(args.side_agent_self_merged),
                 project=Path(args.project).expanduser() if args.project else None,
                 state_file=Path(args.state_file).expanduser() if args.state_file else None,
@@ -629,6 +663,14 @@ def handle_todo_command(
                 raise ValueError("todo supersede does not support --no-follow-up")
             if args.followups:
                 raise ValueError("todo supersede does not support --follow-up; use `todo capture-followups`")
+            if args.continuation_policy:
+                raise ValueError(
+                    "todo supersede does not update --continuation-policy; use todo update first"
+                )
+            if args.next_continuation_policy and not args.next_agent_todo:
+                raise ValueError(
+                    "--next-continuation-policy requires --next-agent-todo"
+                )
             if args.blocks_agent or args.global_gate or args.unblocks_todo_id or args.resume_when:
                 raise ValueError("todo supersede does not support --blocks-agent, --global-gate, --unblocks-todo-id, or --resume-when; update the source todo first so the successor can inherit dependency metadata")
             if args.successor_todo_ids:
@@ -646,6 +688,7 @@ def handle_todo_command(
                 next_claimed_by=args.next_claimed_by,
                 next_task_class=args.next_task_class,
                 next_action_kind=args.next_action_kind,
+                next_continuation_policy=args.next_continuation_policy,
                 project=Path(args.project).expanduser() if args.project else None,
                 state_file=Path(args.state_file).expanduser() if args.state_file else None,
                 dry_run=bool(args.dry_run),
@@ -685,6 +728,7 @@ def handle_todo_command(
                     ("--reason", args.reason),
                     ("--task-class", args.task_class),
                     ("--action-kind", args.action_kind),
+                    ("--continuation-policy", args.continuation_policy),
                     ("--required-write-scope", args.required_write_scopes),
                     ("--required-capability", args.required_capabilities),
                     ("--target-capability", args.target_capabilities),
@@ -707,6 +751,7 @@ def handle_todo_command(
                     ("--next-claimed-by", args.next_claimed_by),
                     ("--next-task-class", args.next_task_class),
                     ("--next-action-kind", args.next_action_kind),
+                    ("--next-continuation-policy", args.next_continuation_policy),
                     ("--side-agent-self-merged", args.side_agent_self_merged),
                     ("--follow-up", args.followups),
                     ("--state-file", args.state_file),
@@ -758,6 +803,7 @@ def handle_todo_command(
                     ("--next-claimed-by", args.next_claimed_by),
                     ("--next-task-class", args.next_task_class),
                     ("--next-action-kind", args.next_action_kind),
+                    ("--next-continuation-policy", args.next_continuation_policy),
                     ("--side-agent-self-merged", args.side_agent_self_merged),
                     ("--agent-id", args.agent_id),
                     ("--from", args.suggestion_sources),

--- a/loopx/control_plane/agents/capability_gate.py
+++ b/loopx/control_plane/agents/capability_gate.py
@@ -4,9 +4,11 @@ from typing import Any
 
 from ..todos.contract import (
     TODO_TASK_CLASS_ADVANCEMENT,
+    TodoContinuationPolicy,
     normalize_required_capabilities,
     normalize_target_capabilities,
     normalize_todo_claimed_by,
+    resolve_todo_continuation_policy,
 )
 from ..todos.projection import (
     todo_index_rank,
@@ -155,12 +157,15 @@ def _unblock_handoff_rank(
 
 def _primary_review_rank(raw_item: dict[str, Any], *, agent_id: str | None) -> int:
     claimed_by = agent_scope_item_claimed_by(raw_item)
-    action_kind = str(raw_item.get("action_kind") or "").strip()
+    continuation_policy = resolve_todo_continuation_policy(
+        raw_item.get("continuation_policy"),
+        action_kind=raw_item.get("action_kind"),
+    )
     return (
         0
         if agent_id
         and claimed_by == agent_id
-        and (action_kind == "primary_review" or action_kind.startswith("primary_review_"))
+        and continuation_policy == TodoContinuationPolicy.PRIMARY_REVIEW
         else 1
     )
 

--- a/loopx/control_plane/todos/completion_policy.py
+++ b/loopx/control_plane/todos/completion_policy.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Iterable, Mapping
+from typing import Iterable, Mapping
 
 from ...agent_registry import (
     load_goal_from_registry,
@@ -13,8 +13,11 @@ from ...agent_registry import (
 )
 from .contract import (
     TODO_TASK_CLASS_MONITOR,
+    TodoContinuationPolicy,
     normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
+    normalize_todo_continuation_policy,
+    resolve_todo_continuation_policy,
 )
 
 
@@ -25,6 +28,7 @@ class LinkedSuccessor:
     status: str | None = None
     task_class: str | None = None
     action_kind: str | None = None
+    continuation_policy: str | None = None
     claimed_by: str | None = None
 
 
@@ -40,20 +44,6 @@ class CompletionPolicy:
     linked_handoff_successor_id: str | None = None
 
 
-def is_primary_review_action_kind(value: Any) -> bool:
-    action_kind = str(value or "").strip()
-    return action_kind == "primary_review" or action_kind.startswith("primary_review_")
-
-
-def is_review_only_action_kind(value: Any) -> bool:
-    action_kind = str(value or "").strip()
-    if not action_kind or is_primary_review_action_kind(action_kind):
-        return False
-    return action_kind in {"review", "verification"} or action_kind.endswith(
-        ("_review", "_verification")
-    )
-
-
 def linked_successor_from_todo(todo: Mapping[str, Any]) -> LinkedSuccessor:
     return LinkedSuccessor(
         todo_id=str(todo.get("todo_id") or ""),
@@ -61,6 +51,9 @@ def linked_successor_from_todo(todo: Mapping[str, Any]) -> LinkedSuccessor:
         status=str(todo.get("status") or "").strip() or None,
         task_class=str(todo.get("task_class") or "").strip() or None,
         action_kind=str(todo.get("action_kind") or "").strip() or None,
+        continuation_policy=normalize_todo_continuation_policy(
+            todo.get("continuation_policy")
+        ),
         claimed_by=normalize_todo_claimed_by(todo.get("claimed_by")),
     )
 
@@ -87,7 +80,7 @@ def _linked_handoff_successor_id(
     return None
 
 
-def _linked_same_agent_review_successor_id(
+def _linked_same_agent_non_delivery_successor_id(
     *,
     successors: Iterable[LinkedSuccessor],
     completing_agent: str | None,
@@ -101,14 +94,17 @@ def _linked_same_agent_review_successor_id(
             continue
         if successor.claimed_by != completing_agent:
             continue
-        if is_primary_review_action_kind(successor.action_kind):
+        if resolve_todo_continuation_policy(
+            successor.continuation_policy,
+            action_kind=successor.action_kind,
+        ) == TodoContinuationPolicy.PRIMARY_REVIEW:
             continue
         if successor.todo_id:
             return successor.todo_id
     return None
 
 
-def _allows_same_agent_review_continuation(
+def _allows_same_agent_non_delivery_continuation(
     *,
     completion_todo: Mapping[str, Any] | None,
     completing_agent: str | None,
@@ -116,7 +112,10 @@ def _allows_same_agent_review_continuation(
 ) -> bool:
     if not completion_todo or not completing_agent or not str(evidence or "").strip():
         return False
-    if not is_review_only_action_kind(completion_todo.get("action_kind")):
+    if resolve_todo_continuation_policy(
+        completion_todo.get("continuation_policy"),
+        action_kind=completion_todo.get("action_kind"),
+    ) != TodoContinuationPolicy.SAME_AGENT_NON_DELIVERY:
         return False
     if completion_todo.get("required_write_scopes"):
         return False
@@ -171,7 +170,10 @@ def _linked_role_workflow_successor_id(
             continue
         if successor.claimed_by not in registered_agent_set:
             continue
-        if is_primary_review_action_kind(successor.action_kind):
+        if resolve_todo_continuation_policy(
+            successor.continuation_policy,
+            action_kind=successor.action_kind,
+        ) == TodoContinuationPolicy.PRIMARY_REVIEW:
             continue
         return successor.todo_id
     return None
@@ -185,6 +187,7 @@ def resolve_completion_policy(
     next_claimed_by: str | None = None,
     next_agent_todo: str | None = None,
     next_action_kind: str | None = None,
+    next_continuation_policy: str | None = None,
     side_agent_self_merged: bool = False,
     evidence: str | None = None,
     no_followup: bool = False,
@@ -240,23 +243,23 @@ def resolve_completion_policy(
         handoff_agent=handoff_agent,
         completing_agent=effective_claimed_by,
     )
-    same_agent_review_candidate = bool(
+    same_agent_non_delivery_candidate = bool(
         side_agent_completion
         and handoff_agent == effective_claimed_by
         and not next_agent_todo
-        and _allows_same_agent_review_continuation(
+        and _allows_same_agent_non_delivery_continuation(
             completion_todo=completion_todo,
             completing_agent=effective_claimed_by,
             evidence=evidence,
         )
     )
-    if same_agent_review_candidate and not linked_handoff_successor_id:
-        linked_handoff_successor_id = _linked_same_agent_review_successor_id(
+    if same_agent_non_delivery_candidate and not linked_handoff_successor_id:
+        linked_handoff_successor_id = _linked_same_agent_non_delivery_successor_id(
             successors=linked_successor_items,
             completing_agent=effective_claimed_by,
         )
-    same_agent_review_continuation = bool(
-        same_agent_review_candidate and linked_handoff_successor_id
+    same_agent_non_delivery_continuation = bool(
+        same_agent_non_delivery_candidate and linked_handoff_successor_id
     )
     side_agent_monitor_no_followup = bool(
         side_agent_completion
@@ -283,7 +286,10 @@ def resolve_completion_policy(
         and not side_agent_self_merged
         and primary_agent
         and effective_next_claimed_by == primary_agent
-        and is_primary_review_action_kind(next_action_kind)
+        and resolve_todo_continuation_policy(
+            next_continuation_policy,
+            action_kind=next_action_kind,
+        ) == TodoContinuationPolicy.PRIMARY_REVIEW
     )
 
     if side_agent_completion:
@@ -309,14 +315,16 @@ def resolve_completion_policy(
         if (
             not side_agent_self_merged
             and handoff_agent == effective_claimed_by
-            and not same_agent_review_continuation
+            and not same_agent_non_delivery_continuation
             and not side_agent_monitor_no_followup
+            and not explicit_primary_review_handoff
         ):
             raise ValueError(
                 "side-agent handoff todo cannot be claimed by the completing side agent; "
                 "use --side-agent-self-merged with --evidence for same-agent delivery, "
                 "configure side_agent_handoff_agent to another registered agent, or close "
-                "an evidence-backed review-only gate with --successor-todo-id pointing "
+                "an evidence-backed same-agent non-delivery gate with "
+                "continuation_policy=same_agent_non_delivery and --successor-todo-id pointing "
                 "at an existing same-agent successor"
             )
         if (

--- a/loopx/control_plane/todos/contract.py
+++ b/loopx/control_plane/todos/contract.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import re
+from enum import Enum
 from typing import Any
 from urllib.parse import quote, unquote
 
@@ -103,6 +104,17 @@ TODO_ACTION_KIND_MONITOR_VALUES = {
     "watch",
 }
 
+
+class TodoContinuationPolicy(str, Enum):
+    INDEPENDENT_HANDOFF = "independent_handoff"
+    SAME_AGENT_NON_DELIVERY = "same_agent_non_delivery"
+    PRIMARY_REVIEW = "primary_review"
+
+
+TODO_CONTINUATION_POLICY_VALUES = {
+    policy.value for policy in TodoContinuationPolicy
+}
+
 TODO_HARD_MONITOR_PATTERNS = (
     re.compile(r"(?i)\bdo not\b.*\b(?:launch|run|execute|start)\b.*\buntil\b"),
     re.compile(r"(?i)\b(?:only|just)\b.*\b(?:after|when|once)\b.*\b(?:owner|user|credential|approval|prerequisite|evidence)\b"),
@@ -180,6 +192,40 @@ def normalize_todo_action_kind(value: Any) -> str | None:
     if TODO_ACTION_KIND_PATTERN.match(candidate):
         return candidate
     return None
+
+
+def normalize_todo_continuation_policy(value: Any) -> str | None:
+    candidate = str(value or "").strip().lower()
+    if candidate in TODO_CONTINUATION_POLICY_VALUES:
+        return candidate
+    return None
+
+
+def legacy_todo_continuation_policy_for_action_kind(value: Any) -> str | None:
+    action_kind = normalize_todo_action_kind(value)
+    if not action_kind:
+        return None
+    if action_kind == "primary_review" or action_kind.startswith("primary_review_"):
+        return TodoContinuationPolicy.PRIMARY_REVIEW.value
+    if action_kind in {"review", "verification"} or action_kind.endswith(
+        ("_review", "_verification")
+    ):
+        return TodoContinuationPolicy.SAME_AGENT_NON_DELIVERY.value
+    return None
+
+
+def resolve_todo_continuation_policy(
+    value: Any,
+    *,
+    action_kind: Any = None,
+) -> TodoContinuationPolicy:
+    explicit = normalize_todo_continuation_policy(value)
+    if explicit:
+        return TodoContinuationPolicy(explicit)
+    legacy = legacy_todo_continuation_policy_for_action_kind(action_kind)
+    if legacy:
+        return TodoContinuationPolicy(legacy)
+    return TodoContinuationPolicy.INDEPENDENT_HANDOFF
 
 
 def normalize_todo_claimed_by(value: Any) -> str | None:
@@ -480,6 +526,10 @@ def parse_todo_metadata_line(line: str) -> dict[str, Any] | None:
             action_kind = normalize_todo_action_kind(value)
             if action_kind:
                 metadata["action_kind"] = action_kind
+        elif key == "continuation_policy":
+            continuation_policy = normalize_todo_continuation_policy(value)
+            if continuation_policy:
+                metadata["continuation_policy"] = continuation_policy
         elif key in {"required_write_scope", "required_write_scopes"}:
             scopes = normalize_required_write_scopes(value)
             if scopes:
@@ -547,6 +597,7 @@ def format_todo_metadata_line(
     status: str | None = None,
     task_class: str | None = None,
     action_kind: str | None = None,
+    continuation_policy: str | None = None,
     required_write_scopes: Any = None,
     required_capabilities: Any = None,
     target_capabilities: Any = None,
@@ -596,6 +647,23 @@ def format_todo_metadata_line(
         raise ValueError("todo action_kind must be a public-safe token: lowercase letters, digits, '_' or '-'")
     if normalized_action_kind:
         fields.append(f"action_kind={encode_metadata_value(normalized_action_kind)}")
+    normalized_continuation_policy = normalize_todo_continuation_policy(
+        continuation_policy
+    )
+    if continuation_policy and not normalized_continuation_policy:
+        raise ValueError(
+            "todo continuation_policy must be one of: "
+            + ", ".join(sorted(TODO_CONTINUATION_POLICY_VALUES))
+        )
+    if not normalized_continuation_policy:
+        normalized_continuation_policy = legacy_todo_continuation_policy_for_action_kind(
+            normalized_action_kind
+        )
+    if normalized_continuation_policy:
+        fields.append(
+            "continuation_policy="
+            f"{encode_metadata_value(normalized_continuation_policy)}"
+        )
     normalized_write_scopes = normalize_required_write_scopes(required_write_scopes)
     if required_write_scopes and not normalized_write_scopes:
         raise ValueError("required_write_scopes must contain public-safe relative scope tokens")

--- a/loopx/control_plane/todos/deferred_resume.py
+++ b/loopx/control_plane/todos/deferred_resume.py
@@ -62,6 +62,7 @@ def _compact_deferred_resume_item(
         "source_section",
         "task_class",
         "action_kind",
+        "continuation_policy",
         "required_write_scopes",
         "required_capabilities",
         "target_capabilities",

--- a/loopx/control_plane/todos/event_writeback.py
+++ b/loopx/control_plane/todos/event_writeback.py
@@ -20,11 +20,14 @@ from ..goals.active_state_event_projection import (
 from ..goals.path_resolution import resolve_goal_local_path
 from .active_state_todo_parser import parse_active_state_todos
 from .contract import (
+    TODO_CONTINUATION_POLICY_VALUES,
     TODO_STATUS_DONE,
     TODO_STATUS_OPEN,
     build_todo_id,
+    legacy_todo_continuation_policy_for_action_kind,
     merge_todo_id_lists,
     normalize_todo_claimed_by,
+    normalize_todo_continuation_policy,
     normalize_todo_id,
     todo_done_for_status,
 )
@@ -139,6 +142,7 @@ def _append_event_projected_successor(
     fields: dict[str, Any],
     task_class: str | None,
     action_kind: str | None,
+    continuation_policy: str | None,
     claimed_by: str | None,
     dry_run: bool,
     blocks_agent: str | None = None,
@@ -167,6 +171,20 @@ def _append_event_projected_successor(
         payload["task_class"] = task_class
     if action_kind:
         payload["action_kind"] = action_kind
+    normalized_continuation_policy = normalize_todo_continuation_policy(
+        continuation_policy
+    )
+    if continuation_policy and not normalized_continuation_policy:
+        raise ValueError(
+            "todo continuation_policy must be one of: "
+            + ", ".join(sorted(TODO_CONTINUATION_POLICY_VALUES))
+        )
+    effective_continuation_policy = (
+        normalized_continuation_policy
+        or legacy_todo_continuation_policy_for_action_kind(action_kind)
+    )
+    if effective_continuation_policy:
+        payload["continuation_policy"] = effective_continuation_policy
     if blocks_agent:
         payload["blocks_agent"] = blocks_agent
     if unblocks_todo_id:
@@ -217,6 +235,7 @@ def _append_event_projected_successor(
         "todo_id": todo_id,
         "task_class": task_class,
         "action_kind": action_kind,
+        "continuation_policy": effective_continuation_policy,
         "claimed_by": claimed_by,
         "blocks_agent": blocks_agent,
         "unblocks_todo_id": unblocks_todo_id,
@@ -240,6 +259,7 @@ def complete_event_projected_goal_todo(
     next_claimed_by: str | None,
     next_task_class: str | None,
     next_action_kind: str | None,
+    next_continuation_policy: str | None,
     side_agent_completion: bool,
     side_agent_self_merged: bool,
     registered_agents: list[str],
@@ -280,6 +300,7 @@ def complete_event_projected_goal_todo(
                 fields=context["fields"],
                 task_class=next_task_class or "advancement_task",
                 action_kind=next_action_kind,
+                continuation_policy=next_continuation_policy,
                 claimed_by=next_claimed_by,
                 blocks_agent=None,
                 unblocks_todo_id=next_unblocks_todo_id,
@@ -297,6 +318,7 @@ def complete_event_projected_goal_todo(
                 fields=context["fields"],
                 task_class="user_gate",
                 action_kind="gate",
+                continuation_policy=None,
                 claimed_by=None,
                 blocks_agent=next_user_blocks_agent,
                 unblocks_todo_id=None,
@@ -355,6 +377,7 @@ def complete_event_projected_goal_todo(
         "claimed_by": normalize_todo_claimed_by(effective_claimed_by),
         "task_class": item.get("task_class"),
         "action_kind": item.get("action_kind"),
+        "continuation_policy": item.get("continuation_policy"),
         "successor_todo_ids": normalized_successor_todo_ids,
         "next_todos": next_results,
         "side_agent_self_merged": bool(side_agent_completion and side_agent_self_merged),

--- a/loopx/control_plane/todos/handoff_gate.py
+++ b/loopx/control_plane/todos/handoff_gate.py
@@ -144,6 +144,7 @@ def _compact_handoff_gate(
         "role",
         "task_class",
         "action_kind",
+        "continuation_policy",
         "claimed_by",
         "unblocks_todo_id",
         "resume_when",

--- a/loopx/control_plane/todos/markdown.py
+++ b/loopx/control_plane/todos/markdown.py
@@ -59,6 +59,7 @@ def render_todo_markdown(payload: dict[str, Any]) -> str:
                     "status",
                     "task_class",
                     "action_kind",
+                    "continuation_policy",
                     "claimed_by",
                     "target_key",
                     "cadence",

--- a/loopx/control_plane/todos/quota_summary.py
+++ b/loopx/control_plane/todos/quota_summary.py
@@ -52,6 +52,7 @@ QUOTA_PAYLOAD_ITEM_FIELDS = (
     "priority",
     "task_class",
     "action_kind",
+    "continuation_policy",
     "claimed_by",
     "blocks_agent",
     "global_gate",

--- a/loopx/control_plane/todos/route_continuation.py
+++ b/loopx/control_plane/todos/route_continuation.py
@@ -55,6 +55,7 @@ def _compact_route_continuation_item(
         "source_section",
         "task_class",
         "action_kind",
+        "continuation_policy",
         "required_write_scopes",
         "required_capabilities",
         "target_capabilities",

--- a/loopx/control_plane/todos/succession_warning.py
+++ b/loopx/control_plane/todos/succession_warning.py
@@ -29,6 +29,7 @@ def _compact_succession_warning_item(item: dict[str, Any]) -> dict[str, Any]:
         "source_section",
         "task_class",
         "action_kind",
+        "continuation_policy",
         "required_write_scopes",
         "required_capabilities",
         "target_capabilities",

--- a/loopx/control_plane/todos/summary_item.py
+++ b/loopx/control_plane/todos/summary_item.py
@@ -25,6 +25,7 @@ TODO_SUMMARY_COMPACT_FIELDS = (
     "source_section",
     "task_class",
     "action_kind",
+    "continuation_policy",
     "required_write_scopes",
     "required_capabilities",
     "target_capabilities",

--- a/loopx/control_plane/todos/todo_summary.py
+++ b/loopx/control_plane/todos/todo_summary.py
@@ -17,6 +17,7 @@ from .contract import (
     normalize_todo_action_kind,
     normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
+    normalize_todo_continuation_policy,
     normalize_todo_decision_scope,
     normalize_todo_global_gate,
     normalize_todo_id,
@@ -295,6 +296,11 @@ def structured_todo_item(
     action_kind = normalize_todo_action_kind(item.get("action_kind"))
     if action_kind:
         normalized["action_kind"] = action_kind
+    continuation_policy = normalize_todo_continuation_policy(
+        item.get("continuation_policy")
+    )
+    if continuation_policy:
+        normalized["continuation_policy"] = continuation_policy
     required_write_scopes = normalize_required_write_scopes(item.get("required_write_scopes"))
     if required_write_scopes:
         normalized["required_write_scopes"] = required_write_scopes
@@ -353,6 +359,7 @@ def compact_todo_item(item: dict[str, Any]) -> dict[str, Any]:
         "source_section",
         "task_class",
         "action_kind",
+        "continuation_policy",
         "required_write_scopes",
         "required_capabilities",
         "target_capabilities",
@@ -798,6 +805,7 @@ def todo_item_is_succession_tracked_completion(item: dict[str, Any]) -> bool:
         item.get(key) is not None
         for key in (
             "action_kind",
+            "continuation_policy",
             "claimed_by",
             "completed_at",
             "updated_at",

--- a/loopx/event_sourced_state.py
+++ b/loopx/event_sourced_state.py
@@ -19,8 +19,11 @@ from .control_plane.todos.contract import (
     build_todo_id,
     format_todo_metadata_line,
     normalize_explicit_todo_task_class,
+    normalize_required_write_scopes,
     normalize_todo_action_kind,
+    normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
+    normalize_todo_continuation_policy,
     normalize_todo_id,
     normalize_todo_id_list,
     normalize_todo_status,
@@ -258,10 +261,23 @@ def backfill_todo_events_from_markdown(
         }
         task_class = normalize_explicit_todo_task_class(record.get("task_class"))
         action_kind = normalize_todo_action_kind(record.get("action_kind"))
+        continuation_policy = normalize_todo_continuation_policy(
+            record.get("continuation_policy")
+        )
+        required_write_scopes = normalize_required_write_scopes(
+            record.get("required_write_scopes")
+        )
+        blocks_agent = normalize_todo_blocks_agent(record.get("blocks_agent"))
         if task_class:
             payload["task_class"] = task_class
         if action_kind:
             payload["action_kind"] = action_kind
+        if continuation_policy:
+            payload["continuation_policy"] = continuation_policy
+        if required_write_scopes:
+            payload["required_write_scopes"] = required_write_scopes
+        if blocks_agent:
+            payload["blocks_agent"] = blocks_agent
         events.append(
             make_state_event(
                 event_id=_backfill_event_id(goal_id=normalized_goal_id, todo_id=todo_id, suffix="add"),
@@ -538,6 +554,13 @@ def _todo_from_added_event(event: dict[str, Any]) -> dict[str, Any]:
     )
     task_class = normalize_explicit_todo_task_class(payload.get("task_class"))
     action_kind = normalize_todo_action_kind(payload.get("action_kind"))
+    continuation_policy = normalize_todo_continuation_policy(
+        payload.get("continuation_policy")
+    )
+    required_write_scopes = normalize_required_write_scopes(
+        payload.get("required_write_scopes")
+    )
+    blocks_agent = normalize_todo_blocks_agent(payload.get("blocks_agent"))
     claimed_by = normalize_todo_claimed_by(payload.get("claimed_by"))
     todo: dict[str, Any] = {
         "schema_version": "todo_item_v0",
@@ -557,6 +580,12 @@ def _todo_from_added_event(event: dict[str, Any]) -> dict[str, Any]:
         todo["task_class"] = task_class
     if action_kind:
         todo["action_kind"] = action_kind
+    if continuation_policy:
+        todo["continuation_policy"] = continuation_policy
+    if required_write_scopes:
+        todo["required_write_scopes"] = required_write_scopes
+    if blocks_agent:
+        todo["blocks_agent"] = blocks_agent
     unblocks_todo_id = normalize_todo_id(payload.get("unblocks_todo_id"))
     if unblocks_todo_id:
         todo["unblocks_todo_id"] = unblocks_todo_id
@@ -579,6 +608,19 @@ def _update_todo_from_event(todo: dict[str, Any], event: dict[str, Any]) -> None
         for key in ("priority", "role", "title", "task_class", "action_kind"):
             if payload.get(key):
                 todo[key] = compact_text(payload[key])
+        continuation_policy = normalize_todo_continuation_policy(
+            payload.get("continuation_policy")
+        )
+        if continuation_policy:
+            todo["continuation_policy"] = continuation_policy
+        required_write_scopes = normalize_required_write_scopes(
+            payload.get("required_write_scopes")
+        )
+        if required_write_scopes:
+            todo["required_write_scopes"] = required_write_scopes
+        blocks_agent = normalize_todo_blocks_agent(payload.get("blocks_agent"))
+        if blocks_agent:
+            todo["blocks_agent"] = blocks_agent
         for key in TODO_MONITOR_METADATA_FIELDS:
             if payload.get(key):
                 todo[key] = compact_text(payload[key])
@@ -713,7 +755,10 @@ def render_todo_markdown(item: dict[str, Any]) -> list[str]:
         status=status,
         task_class=item.get("task_class"),
         action_kind=item.get("action_kind"),
+        continuation_policy=item.get("continuation_policy"),
+        required_write_scopes=item.get("required_write_scopes"),
         claimed_by=item.get("claimed_by"),
+        blocks_agent=item.get("blocks_agent"),
         unblocks_todo_id=item.get("unblocks_todo_id"),
         successor_todo_ids=item.get("successor_todo_ids"),
         no_followup=True if item.get("no_followup") == "true" else None,

--- a/loopx/state_projection.py
+++ b/loopx/state_projection.py
@@ -14,6 +14,7 @@ from .control_plane.todos.contract import (
     normalize_todo_action_kind,
     normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
+    normalize_todo_continuation_policy,
     normalize_todo_global_gate,
     normalize_todo_id,
     normalize_todo_id_list,
@@ -79,6 +80,7 @@ NEXT_ACTION_USER_WAIT_PATTERN = re.compile(
 )
 TODO_METADATA_KEYS = (
     "action_kind",
+    "continuation_policy",
     "required_write_scopes",
     "required_capabilities",
     "target_capabilities",
@@ -502,6 +504,11 @@ def _normalize_structured_todo_item(
         normalized["title"] = title
     if action_kind:
         normalized["action_kind"] = action_kind
+    continuation_policy = normalize_todo_continuation_policy(
+        item.get("continuation_policy")
+    )
+    if continuation_policy:
+        normalized["continuation_policy"] = continuation_policy
 
     write_scopes = normalize_required_write_scopes(item.get("required_write_scopes"))
     if write_scopes:

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -22,6 +22,7 @@ from .status import (
 )
 from .control_plane.todos.contract import (
     TODO_MONITOR_METADATA_FIELDS,
+    TODO_CONTINUATION_POLICY_VALUES,
     TODO_STATUS_DONE,
     TODO_STATUS_OPEN,
     TODO_TASK_CLASS_USER_GATE,
@@ -33,6 +34,7 @@ from .control_plane.todos.contract import (
     normalize_target_capabilities,
     normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
+    normalize_todo_continuation_policy,
     normalize_todo_decision_scope,
     normalize_todo_global_gate,
     normalize_todo_id,
@@ -76,6 +78,7 @@ TODO_METADATA_FIELDS = (
     "status",
     "task_class",
     "action_kind",
+    "continuation_policy",
     "required_write_scopes",
     "required_capabilities",
     "target_capabilities",
@@ -247,6 +250,7 @@ def todo_item_relations(item: dict[str, Any]) -> dict[str, Any]:
         "target_capabilities",
         "task_class",
         "action_kind",
+        "continuation_policy",
         "target_key",
         "cadence",
         "next_due_at",
@@ -504,6 +508,11 @@ def block_metadata(block: dict[str, Any]) -> dict[str, Any]:
             if capabilities:
                 metadata[key] = capabilities
             continue
+        if key == "continuation_policy":
+            continuation_policy = normalize_todo_continuation_policy(value)
+            if continuation_policy:
+                metadata[key] = continuation_policy
+            continue
         if key == "decision_scope":
             decision_scope = normalize_todo_decision_scope(value)
             if decision_scope:
@@ -552,6 +561,17 @@ def metadata_line_for_block(block: dict[str, Any], updates: dict[str, Any]) -> s
             capabilities = normalize_target_capabilities(value)
             if capabilities:
                 metadata[key] = capabilities
+            else:
+                metadata.pop(key, None)
+        elif key == "continuation_policy":
+            continuation_policy = normalize_todo_continuation_policy(value)
+            if continuation_policy:
+                metadata[key] = continuation_policy
+            elif value:
+                raise ValueError(
+                    "todo continuation_policy must be one of: "
+                    + ", ".join(sorted(TODO_CONTINUATION_POLICY_VALUES))
+                )
             else:
                 metadata.pop(key, None)
         elif key == "decision_scope":
@@ -718,6 +738,7 @@ def add_todo_to_lines(
     text: str,
     task_class: str | None = None,
     action_kind: str | None = None,
+    continuation_policy: str | None = None,
     required_write_scopes: list[str] | None = None,
     required_capabilities: list[str] | None = None,
     target_capabilities: list[str] | None = None,
@@ -774,6 +795,7 @@ def add_todo_to_lines(
             status=TODO_STATUS_OPEN,
             task_class=task_class,
             action_kind=action_kind,
+            continuation_policy=continuation_policy,
             required_write_scopes=required_write_scopes,
             required_capabilities=required_capabilities,
             target_capabilities=target_capabilities,
@@ -803,6 +825,8 @@ def add_todo_to_lines(
             updates["task_class"] = task_class
         if action_kind:
             updates["action_kind"] = action_kind
+        if continuation_policy:
+            updates["continuation_policy"] = continuation_policy
         if required_write_scopes is not None:
             updates["required_write_scopes"] = required_write_scopes
         if required_capabilities is not None:
@@ -843,6 +867,9 @@ def add_todo_to_lines(
         "todo_id": todo_id,
         "task_class": effective_metadata.get("task_class") or task_class,
         "action_kind": effective_metadata.get("action_kind") or action_kind,
+        "continuation_policy": normalize_todo_continuation_policy(
+            effective_metadata.get("continuation_policy") or continuation_policy
+        ),
         "required_write_scopes": normalize_required_write_scopes(
             effective_metadata.get("required_write_scopes") or required_write_scopes
         ),
@@ -880,6 +907,7 @@ def add_goal_todo(
     text: str,
     task_class: str | None = None,
     action_kind: str | None = None,
+    continuation_policy: str | None = None,
     required_write_scopes: list[str] | None = None,
     required_capabilities: list[str] | None = None,
     target_capabilities: list[str] | None = None,
@@ -980,6 +1008,7 @@ def add_goal_todo(
             text=todo_text,
             task_class=task_class,
             action_kind=action_kind,
+            continuation_policy=continuation_policy,
             required_write_scopes=required_write_scopes,
             required_capabilities=required_capabilities,
             target_capabilities=target_capabilities,
@@ -1015,6 +1044,7 @@ def add_goal_todo(
         "todo_id": add_result.get("todo_id"),
         "task_class": add_result.get("task_class"),
         "action_kind": add_result.get("action_kind"),
+        "continuation_policy": add_result.get("continuation_policy"),
         "required_write_scopes": add_result.get("required_write_scopes"),
         "required_capabilities": add_result.get("required_capabilities"),
         "target_capabilities": add_result.get("target_capabilities"),
@@ -1071,6 +1101,7 @@ def apply_todo_update_to_lines(
     reason: str | None = None,
     task_class: str | None = None,
     action_kind: str | None = None,
+    continuation_policy: str | None = None,
     required_write_scopes: list[str] | None = None,
     required_capabilities: list[str] | None = None,
     target_capabilities: list[str] | None = None,
@@ -1126,6 +1157,8 @@ def apply_todo_update_to_lines(
         updates["task_class"] = task_class
     if action_kind:
         updates["action_kind"] = action_kind
+    if continuation_policy:
+        updates["continuation_policy"] = continuation_policy
     if required_write_scopes is not None:
         updates["required_write_scopes"] = required_write_scopes
     if required_capabilities is not None:
@@ -1181,6 +1214,9 @@ def apply_todo_update_to_lines(
         "claimed_by": normalize_todo_claimed_by(effective_metadata.get("claimed_by")),
         "task_class": effective_metadata.get("task_class"),
         "action_kind": effective_metadata.get("action_kind"),
+        "continuation_policy": normalize_todo_continuation_policy(
+            effective_metadata.get("continuation_policy")
+        ),
         "required_capabilities": normalize_required_capabilities(
             effective_metadata.get("required_capabilities")
         ),
@@ -1217,6 +1253,7 @@ def update_goal_todo(
     reason: str | None = None,
     task_class: str | None = None,
     action_kind: str | None = None,
+    continuation_policy: str | None = None,
     required_write_scopes: list[str] | None = None,
     required_capabilities: list[str] | None = None,
     target_capabilities: list[str] | None = None,
@@ -1361,6 +1398,7 @@ def update_goal_todo(
             reason=reason,
             task_class=task_class,
             action_kind=action_kind,
+            continuation_policy=continuation_policy,
             required_write_scopes=required_write_scopes,
             required_capabilities=required_capabilities,
             target_capabilities=target_capabilities,
@@ -1421,6 +1459,7 @@ def complete_goal_todo(
     next_claimed_by: str | None = None,
     next_task_class: str | None = None,
     next_action_kind: str | None = None,
+    next_continuation_policy: str | None = None,
     side_agent_self_merged: bool = False,
     project: Path | None = None,
     state_file: Path | None = None,
@@ -1438,10 +1477,24 @@ def complete_goal_todo(
         updated_at = now_local()
         completion_match = find_todo_block(lines, todo_id=todo_id, role=role)
         completion_todo = None
+        event_context = None
         if completion_match:
             completion_role, _section, _start, _end, completion_block = completion_match
             completion_todo = dict(completion_block)
             completion_todo["role"] = completion_role
+        else:
+            event_context = event_projection_todo_context(
+                registry_path=registry_path,
+                goal_id=goal_id,
+                state_path=resolved_state_file,
+                todo_id=todo_id,
+                role=role,
+            )
+            if event_context:
+                event_context["state_file"] = resolved_state_file
+                event_context["project"] = resolved_project
+                completion_todo = dict(event_context["item"])
+                completion_todo["role"] = event_context["role"]
         normalized_successor_todo_ids = normalize_todo_id_list(successor_todo_ids)
         if successor_todo_ids and not normalized_successor_todo_ids:
             raise ValueError("successor_todo_ids must contain public todo_<letters-digits-underscore-hyphen> tokens")
@@ -1453,6 +1506,27 @@ def complete_goal_todo(
                 successor_item = dict(successor_block)
                 successor_item["role"] = successor_role
                 linked_successors.append(linked_successor_from_todo(successor_item))
+                continue
+            if event_context:
+                for successor_role in ("user", "agent"):
+                    summary = event_context["fields"].get(f"{successor_role}_todos")
+                    items = summary.get("items") if isinstance(summary, dict) else []
+                    successor_item = next(
+                        (
+                            dict(item)
+                            for item in items or []
+                            if isinstance(item, dict)
+                            and normalize_todo_id(item.get("todo_id"))
+                            == successor_todo_id
+                        ),
+                        None,
+                    )
+                    if successor_item:
+                        successor_item["role"] = successor_role
+                        linked_successors.append(
+                            linked_successor_from_todo(successor_item)
+                        )
+                        break
         completion_policy = resolve_completion_policy(
             registry_path=registry_path,
             goal_id=goal_id,
@@ -1460,6 +1534,7 @@ def complete_goal_todo(
             next_claimed_by=next_claimed_by,
             next_agent_todo=next_agent_todo,
             next_action_kind=next_action_kind,
+            next_continuation_policy=next_continuation_policy,
             side_agent_self_merged=side_agent_self_merged,
             evidence=evidence,
             no_followup=no_followup,
@@ -1473,17 +1548,8 @@ def complete_goal_todo(
         side_agent_completion = completion_policy.side_agent_completion
         effective_side_agent_self_merged = completion_policy.side_agent_self_merged
         if not completion_match:
-            event_context = event_projection_todo_context(
-                registry_path=registry_path,
-                goal_id=goal_id,
-                state_path=resolved_state_file,
-                todo_id=todo_id,
-                role=role,
-            )
             if event_context:
-                event_context["state_file"] = resolved_state_file
-                event_context["project"] = resolved_project
-                return complete_event_projected_goal_todo(
+                event_result = complete_event_projected_goal_todo(
                     goal_id=goal_id,
                     context=event_context,
                     evidence=evidence,
@@ -1497,6 +1563,7 @@ def complete_goal_todo(
                     next_claimed_by=effective_next_claimed_by,
                     next_task_class=next_task_class,
                     next_action_kind=next_action_kind,
+                    next_continuation_policy=next_continuation_policy,
                     side_agent_completion=side_agent_completion,
                     side_agent_self_merged=effective_side_agent_self_merged,
                     registered_agents=registered_agents,
@@ -1504,6 +1571,10 @@ def complete_goal_todo(
                     updated_at=updated_at,
                     dry_run=dry_run,
                 )
+                event_result["linked_handoff_successor_id"] = (
+                    completion_policy.linked_handoff_successor_id
+                )
+                return event_result
         update_result = apply_todo_update_to_lines(
             lines,
             todo_id=todo_id,
@@ -1547,6 +1618,7 @@ def complete_goal_todo(
                     ),
                     task_class=next_task_class or "advancement_task",
                     action_kind=next_action_kind,
+                    continuation_policy=next_continuation_policy,
                     claimed_by=effective_next_claimed_by,
                     blocks_agent=next_blocks_agent,
                     unblocks_todo_id=next_unblocks_todo_id,
@@ -1611,6 +1683,7 @@ def supersede_goal_todo(
     next_claimed_by: str | None = None,
     next_task_class: str | None = None,
     next_action_kind: str | None = None,
+    next_continuation_policy: str | None = None,
     project: Path | None = None,
     state_file: Path | None = None,
     dry_run: bool = False,
@@ -1677,6 +1750,7 @@ def supersede_goal_todo(
                     ),
                     task_class=next_task_class or "advancement_task",
                     action_kind=next_action_kind,
+                    continuation_policy=next_continuation_policy,
                     claimed_by=effective_next_claimed_by,
                     blocks_agent=next_blocks_agent,
                     unblocks_todo_id=next_unblocks_todo_id,


### PR DESCRIPTION
## Summary
- keep `action_kind` extensible and add a closed `continuation_policy` enum for completion/handoff authorization
- support `independent_handoff`, `same_agent_non_delivery`, and `primary_review` across Markdown, event-log, CLI, quota/status read models, and capability ranking
- preserve legacy `primary_review*`, `*_review`, and `*_verification` reads while materializing typed policy on new writes
- keep same-agent continuation structural: evidence, no required write scope, distinct `blocks_agent`, and an explicit open same-agent successor

## Product / architecture judgment
PR #1754 solved the immediate review/verification case but authorized it through action-name prefixes and suffixes. This PR separates domain vocabulary from kernel authorization: products may keep defining action kinds, while LoopX owns a small closed policy contract. The policy is general to readiness, audit, triage, verification, and similar non-delivery gates; repository delivery still requires independent handoff or explicit validated self-merge.

## Validation
- `loopx canary premerge --from-git-diff --tier standard`: passed, 17 selected checks plus 4 direct checks, zero warnings/holds, self-merge allowed
- focused todo continuation, CLI, lifecycle, event projection/store, side-agent state-machine, role-successor, capability-gate, and quota/read-model smokes: passed
- changed Python compile checks: passed
- public/private boundary scan: clean across 24 changed files

## Excluded
- no local/private state, raw logs, credentials, benchmark jobs, permission changes, or generated evidence