### PR TITLE
Release LoopX v0.1.15

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -164,6 +164,22 @@ path, and canary route rather than as a user-facing release baseline.
   related scheduler fixes), plus quota/status/todo read-model hardening for
   user-gate counts, completed-todo successors, evidence-log counts, delivery
   lineage, and compact agent-lane status summaries (#1707-#1716).
+- `v0.1.15` on 2026-07-10: actionable routing and long-run reliability release
+  at the matching `v0.1.15` tag. This release makes the agent-facing current
+  action and quota-selected todo more explicit, centralizes primary-action
+  resolution, and preserves replan acknowledgements, filtered resumes, vision
+  lifecycle state, and due monitors across bounded progress (#1720, #1731,
+  #1751, #1757, #1764-#1766, #1769-#1770). It hardens external monitor and
+  multi-agent continuation through quiet-timeout handling, identity/capability
+  gates, no-handoff lane fidelity, and typed continuation policies (#1722-#1724,
+  #1745, #1747, #1754, #1773). Experimental issue-fix and SkillsBench routes
+  gain feasibility, lifecycle, evidence, failure-attribution, cache/proxy,
+  prewarm, and ledger-closeout improvements (#1726, #1734, #1738-#1744,
+  #1748-#1750, #1753, #1756, #1759-#1763, #1767-#1768, #1771-#1772). The
+  release also adds and repairs the parallel full-public smoke sweep, fixes
+  direct-install doctor behavior, clarifies Explore's measurable-metric fit,
+  and closes the todo CLI ownership-budget regression (#1721, #1725, #1727-#1730,
+  #1735, #1743, #1752, #1774).
 
 When a new public release is promoted, add it here only after the matching tag,
 release note, stable ref, update path, and focused release canary agree.

--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.14"
+__version__ = "0.1.15"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.1.14"
+version = "0.1.15"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Release scope

Promote LoopX `0.1.15` / `v0.1.15` after auditing every commit since `v0.1.14`. The pre-version-bump range contains 55 commits from one author, 182 changed files, 11,933 insertions, and 2,874 deletions.

The release note groups all 55 commits across: agent action/replan contracts; monitoring and multi-agent continuation; experimental issue-fix; experimental benchmark/SkillsBench reliability; and release/install/documentation. The release timeline remains neutral about experimental versus stable surfaces.

## Repository changes

- bump `loopx.__version__` and `pyproject.toml` together to `0.1.15`
- add the `v0.1.15` release timeline entry

## Validation

- main Full Public Smokes run 29067736346: 6/6 shards passed
- release version contract: passed
- release readiness doc contract: passed
- Python compileall: passed
- no-clone release verification: passed
- fresh-clone quickstart: passed
- update smoke: passed
- promotion readiness: passed without evidence writeback; optional dashboard check explicitly skipped because npm dependencies were absent and this release does not touch dashboard/frontstage
- public boundary check: 874 files, 0 errors, 0 warnings
- standard diff canary: 17 selected + 4 direct checks, 0 failures/warnings/holds, self-merge allowed
- `git diff --check`: passed

## Compatibility

No local-state migration is required. Existing extensible `action_kind` values and legacy review/verification continuation reads remain supported; new writes materialize typed `continuation_policy`. Issue-fix and benchmark runner/scoring/upload routes remain experimental.