### PR TITLE
Release LoopX v0.1.16

### DIFF
--- a/docs/product/release-readiness.md
+++ b/docs/product/release-readiness.md
@@ -180,6 +180,13 @@ path, and canary route rather than as a user-facing release baseline.
   direct-install doctor behavior, clarifies Explore's measurable-metric fit,
   and closes the todo CLI ownership-budget regression (#1721, #1725, #1727-#1730,
   #1735, #1743, #1752, #1774).
+- `v0.1.16` on 2026-07-10: archive-install provenance hotfix at the matching
+  `v0.1.16` tag. This release isolates release-manifest generation from the
+  caller's working directory and inherited Python path, so running an update
+  from an older LoopX checkout cannot stamp that checkout's package version
+  into the new stable snapshot. The no-clone release gate now covers this
+  stale-checkout invocation directly (#1776). No product capability or state
+  migration changes in this hotfix.
 
 When a new public release is promoted, add it here only after the matching tag,
 release note, stable ref, update path, and focused release canary agree.

--- a/loopx/__init__.py
+++ b/loopx/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.1.15"
+__version__ = "0.1.16"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "loopx"
-version = "0.1.15"
+version = "0.1.16"
 description = "A lightweight Loop Engineering control plane for long-running agent goals."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Release scope

Promote a narrow archive-install provenance hotfix as `0.1.16` / `v0.1.16`. The feature/fix range after `v0.1.15` contains one code commit: #1776. No product capability or state migration changes.

## Repository changes

- bump `loopx.__version__` and `pyproject.toml` together to `0.1.16`
- add a factual hotfix timeline entry

## Validation

- #1776 main Full Public Smokes run 29068589002: 6/6 shards passed
- stale-checkout no-clone regression: passed
- release version/readiness contracts: passed
- Python compileall: passed
- no-clone release verification: passed
- fresh-clone quickstart: passed
- update smoke: passed
- promotion readiness: passed without evidence writeback; optional dashboard check explicitly skipped because dependencies were absent and this hotfix does not touch dashboard/frontstage
- public boundary check: 874 files, 0 errors, 0 warnings
- standard diff canary: 17 selected + 4 direct checks, 0 failures/warnings/holds, self-merge allowed
- `git diff --check`: passed

## Compatibility

No local-state or manifest-schema migration is required. Installer flags, update/rollback semantics, and release layout are unchanged.