### PR TITLE
Harden SkillsBench Codex goal recovery

### DIFF
--- a/examples/skillsbench-benchmark-egress-policy-smoke.py
+++ b/examples/skillsbench-benchmark-egress-policy-smoke.py
@@ -240,6 +240,45 @@ def test_verifier_proxy_patch_is_required_only_for_existing_verifier() -> None:
         assert patched["benchmark_egress_proxy_verifier_env_key_count"] > 0
 
 
+def test_verifier_proxy_patch_failure_blocks_task_staging() -> None:
+    proxy_url = "http://benchmark-proxy.example.invalid:18080"
+    with tempfile.TemporaryDirectory(prefix="skillsbench-verifier-proxy-block-") as tmp:
+        root = Path(tmp)
+        task = root / "tasks" / "citation-check"
+        dockerfile = task / "environment" / "Dockerfile"
+        verifier = task / "tests" / "test.sh"
+        dockerfile.parent.mkdir(parents=True)
+        verifier.parent.mkdir(parents=True)
+        dockerfile.write_text("FROM python:3.12-slim\n", encoding="utf-8")
+        verifier.write_text("#!/bin/sh\npytest -q\n", encoding="utf-8")
+        (task / "task.toml").write_text("version = \"1.1\"\n", encoding="utf-8")
+        failed_patch = {
+            "benchmark_egress_proxy_verifier_env_patch_required": True,
+            "benchmark_egress_proxy_verifier_env_patch_applied": False,
+            "benchmark_egress_proxy_verifier_env_key_count": 1,
+            "benchmark_egress_proxy_verifier_env_raw_proxy_recorded": False,
+        }
+        with mock.patch.object(
+            skillsbench_loop,
+            "patch_verifier_benchmark_egress_proxy_env",
+            return_value=failed_patch,
+        ):
+            try:
+                skillsbench_loop.stage_task_for_sandbox(
+                    task_path=task,
+                    jobs_dir=root / "jobs",
+                    job_name="citation-check-goal",
+                    sandbox="docker",
+                    benchmark_egress_proxy_env={
+                        "LOOPX_SKILLSBENCH_EGRESS_PROXY": proxy_url,
+                    },
+                )
+            except skillsbench_loop.SkillsBenchSetupPreflightBlocked as exc:
+                assert "verifier egress proxy patch required" in str(exc), exc
+            else:  # pragma: no cover - script-style assertion path
+                raise AssertionError("missing verifier proxy patch must block staging")
+
+
 def test_proxy_runtime_prewarms_external_base_images_without_public_refs() -> None:
     with tempfile.TemporaryDirectory(prefix="skillsbench-base-image-prewarm-") as tmp:
         dockerfile = Path(tmp) / "Dockerfile"
@@ -296,5 +335,6 @@ if __name__ == "__main__":
     test_public_launcher_uses_container_reachable_benchmark_proxy()
     test_public_launcher_batches_three_cases_with_closeout_sync()
     test_verifier_proxy_patch_is_required_only_for_existing_verifier()
+    test_verifier_proxy_patch_failure_blocks_task_staging()
     test_proxy_runtime_prewarms_external_base_images_without_public_refs()
     print("skillsbench-benchmark-egress-policy-smoke: ok")

--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -6167,7 +6167,7 @@ def test_skillsbench_docker_task_staging_patches_verifier_uv_bootstrap_mirror() 
         root = Path(tmp)
         task = root / "tasks" / "citation-check"
         dockerfile = task / "environment" / "Dockerfile"
-        verifier = task / "verifier" / "test.sh"
+        verifier = task / "tests" / "test.sh"
         dockerfile.parent.mkdir(parents=True)
         verifier.parent.mkdir(parents=True)
         dockerfile.write_text("FROM python:3.12-slim\n", encoding="utf-8")
@@ -6209,7 +6209,7 @@ def test_skillsbench_docker_task_staging_patches_verifier_uv_bootstrap_mirror() 
             DEFAULT_VERIFIER_UV_RELEASE_MIRROR_HOST
         ), metadata
         assert verifier.read_text(encoding="utf-8") == original_verifier
-        staged_verifier = (staged_path / "verifier" / "test.sh").read_text(
+        staged_verifier = (staged_path / "tests" / "test.sh").read_text(
             encoding="utf-8"
         )
         assert VERIFIER_UV_BOOTSTRAP_MIRROR_BEGIN in staged_verifier, staged_verifier

--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -1376,6 +1376,7 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     from loopx.benchmark_adapters.skillsbench_acp_relay import (
         CodexExecConfig,
         SkillsBenchLocalAcpRelay,
+        _codex_cli_goal_watchdog_expired,
         _prompt_requires_bridge_first_action,
         _prompt_requires_meaningful_bridge_progress,
     )
@@ -1406,6 +1407,30 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
             route="codex-cli-goal-baseline",
         )
         is True
+    )
+    assert (
+        _codex_cli_goal_watchdog_expired(
+            deadline=100.0,
+            now=101.0,
+            turn_active=True,
+        )
+        is False
+    )
+    assert (
+        _codex_cli_goal_watchdog_expired(
+            deadline=100.0,
+            now=101.0,
+            turn_active=False,
+        )
+        is True
+    )
+    assert (
+        _codex_cli_goal_watchdog_expired(
+            deadline=0.0,
+            now=101.0,
+            turn_active=False,
+        )
+        is False
     )
     for relative in (
         "loopx/benchmark_adapters/skillsbench_acp_relay.py",
@@ -1444,6 +1469,7 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert "task_output_quiet_timeout_sec = max(" in source
     assert "_bridge_summary_has_successful_task_operation(" in source
     assert "turn_active = codex_cli_tui_turn_active(capture)" in source
+    assert source.count("_codex_cli_goal_watchdog_expired(") == 3
     assert "and not turn_active" in source
     assert "now - last_task_output_activity_at" in source
     assert "stage=\"task_output_quiet_timeout\"" in source

--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -651,13 +651,11 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
         SkillsBenchLocalAcpRelay,
     )
     from loopx.benchmark_adapters.skillsbench_codex_goal_recovery import (
-        CODEX_CLI_GOAL_POST_BRIDGE_CLOSEOUT_PROMPT,
-        POST_BRIDGE_CLOSEOUT_ATTEMPT_LIMIT,
+        CODEX_CLI_GOAL_POST_BRIDGE_CONTINUE_PROMPT,
         POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT,
         PRE_BRIDGE_RECOVERY_ATTEMPT_LIMIT,
         TUI_BLOCKER_RECENT_LINE_WINDOW,
         codex_cli_tui_post_bridge_blocker_stage,
-        codex_cli_tui_post_bridge_closeout_recovery_action,
         codex_cli_tui_post_bridge_recovery_action,
         codex_cli_tui_post_bridge_recovery_skip_reason,
         codex_cli_tui_pre_bridge_blocker_stage,
@@ -672,12 +670,13 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
     )
 
     assert POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT == 6
-    assert POST_BRIDGE_CLOSEOUT_ATTEMPT_LIMIT == 8
     assert PRE_BRIDGE_RECOVERY_ATTEMPT_LIMIT == 2
     assert TUI_BLOCKER_RECENT_LINE_WINDOW == 40
-    assert "Close out the active SkillsBench goal" in (
-        CODEX_CLI_GOAL_POST_BRIDGE_CLOSEOUT_PROMPT
+    assert "Continue the existing SkillsBench task from where you left off" in (
+        CODEX_CLI_GOAL_POST_BRIDGE_CONTINUE_PROMPT
     )
+    assert "one task-facing action" not in CODEX_CLI_GOAL_POST_BRIDGE_CONTINUE_PROMPT
+    assert "compact status" not in CODEX_CLI_GOAL_POST_BRIDGE_CONTINUE_PROMPT
     assert (
         codex_cli_tui_pre_bridge_blocker_stage(
             "request timed out while waiting for model\n› ",
@@ -880,31 +879,6 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
         == ""
     )
     assert (
-        codex_cli_tui_post_bridge_closeout_recovery_action(
-            recovery_action="typed_continue",
-            recovery_attempt_count=POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT,
-            closeout_attempted=False,
-        )
-        == "typed_closeout"
-    )
-    assert (
-        codex_cli_tui_post_bridge_closeout_recovery_action(
-            recovery_action="typed_continue",
-            recovery_attempt_count=POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT,
-            closeout_attempted=True,
-        )
-        == "typed_closeout"
-    )
-    assert (
-        codex_cli_tui_post_bridge_closeout_recovery_action(
-            recovery_action="typed_continue",
-            recovery_attempt_count=POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT,
-            closeout_attempted=True,
-            closeout_attempt_count=POST_BRIDGE_CLOSEOUT_ATTEMPT_LIMIT,
-        )
-        == ""
-    )
-    assert (
         codex_cli_tui_post_bridge_blocker_stage(
             "rate limit reached\n› ",
             prompt_visible=True,
@@ -1019,8 +993,8 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
             first_action_observed=True,
             bridge_summary_path=bridge_summary,
             post_bridge_recovery_attempt_count=POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT,
-            post_bridge_recovery_action="typed_closeout",
-            post_bridge_recovery_skip_reason="closeout_retry_limit_reached",
+            post_bridge_recovery_action="typed_continue",
+            post_bridge_recovery_skip_reason="retry_limit_reached",
         )
         plan = {
             "route": "codex-cli-goal-baseline",
@@ -1036,28 +1010,28 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
         trace["codex_cli_goal_tui_post_bridge_recovery_attempt_count"]
         == POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT
     )
-    assert trace["codex_cli_goal_tui_post_bridge_recovery_action"] == "typed_closeout"
+    assert trace["codex_cli_goal_tui_post_bridge_recovery_action"] == "typed_continue"
     assert (
         trace["codex_cli_goal_tui_post_bridge_recovery_skip_reason"]
-        == "closeout_retry_limit_reached"
+        == "retry_limit_reached"
     )
     assert trace["codex_cli_goal_tui_post_bridge_recovery_skip_reasons"] == [
-        "closeout_retry_limit_reached"
+        "retry_limit_reached"
     ]
     public_prerequisites = _public_runner_prerequisites(prerequisites)
     assert (
         public_prerequisites["codex_cli_goal_tui_post_bridge_recovery_action"]
-        == "typed_closeout"
+        == "typed_continue"
     )
     assert (
         public_prerequisites[
             "codex_cli_goal_tui_post_bridge_recovery_skip_reason"
         ]
-        == "closeout_retry_limit_reached"
+        == "retry_limit_reached"
     )
     assert public_prerequisites[
         "codex_cli_goal_tui_post_bridge_recovery_skip_reasons"
-    ] == ["closeout_retry_limit_reached"]
+    ] == ["retry_limit_reached"]
 
 
 def _assert_cli_goal_active_timeout_is_public_countability_stage() -> None:
@@ -1148,6 +1122,26 @@ def _assert_cli_goal_active_timeout_is_public_countability_stage() -> None:
     }
     assert _apply_codex_cli_goal_countability_guard_attribution(compact) is False
     assert "codex_cli_goal_countability_contract" not in compact
+
+    post_bridge_timeout_trace = dict(completed_attempt_trace)
+    post_bridge_timeout_trace.update(
+        {
+            "codex_cli_goal_tui_stage": "post_bridge_tui_model_timeout",
+            "codex_cli_goal_tui_ok_count": 0,
+        }
+    )
+    compact = {
+        "route": CODEX_CLI_GOAL_BASELINE_ROUTE,
+        "official_score_status": "completed",
+        "official_score": 0.0,
+        "interaction_counters": post_bridge_timeout_trace,
+        "runner_prerequisites": {},
+        "failure_attribution_labels": ["official_score_zero_case_failure"],
+    }
+    assert _apply_codex_cli_goal_countability_guard_attribution(compact) is True
+    assert compact["score_failure_attribution"] == (
+        "skillsbench_codex_cli_goal_uncountable_post_bridge_model_timeout"
+    )
 
     with tempfile.TemporaryDirectory() as temp:
         trace_dir = Path(temp) / "trace"
@@ -1338,6 +1332,8 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
         bridge_command_for_agent="/tmp/private-bridge",
     )
     assert "FIRST ACTION REQUIRED" in packet, packet
+    assert "relative output filenames from `/root`" in packet, packet
+    assert "an `/app/<name>` copy alone is not scored" in packet, packet
     assert _prompt_requires_bridge_first_action(packet) is True
     assert (
         _prompt_requires_meaningful_bridge_progress(
@@ -1374,10 +1370,10 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
         not in source
     )
     assert "post_bridge_recovery_attempt_count" in source
-    assert "post_bridge_closeout_attempt_count" in source
     assert "POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT" in source
-    assert "CODEX_CLI_GOAL_POST_BRIDGE_CLOSEOUT_PROMPT" in source
-    assert "typed_closeout" in source
+    assert "post_bridge_closeout_attempt_count" not in source
+    assert "CODEX_CLI_GOAL_POST_BRIDGE_CLOSEOUT_PROMPT" not in source
+    assert "typed_closeout" not in source
     assert "post_bridge_recovery_attempt_count < 2" not in source
     assert "last_bridge_activity_at >= 30.0" in source
     assert "task_output_quiet_timeout_sec = max(" in source

--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -420,6 +420,14 @@ def _assert_cli_goal_tui_ready_wait_rejects_startup_artifacts() -> None:
     assert goal_tui.codex_cli_tui_startup_blocker(historical_loading_then_ready) == ""
     assert goal_tui.codex_cli_tui_input_prompt_visible(historical_loading_then_ready)
     assert goal_tui.codex_cli_tui_input_prompt_visible("  > \n")
+    active_turn = (
+        "• Working (14m 00s • esc to interrupt)\n"
+        "› Explain this codebase\n"
+        "gpt-5.5 xhigh · workspace… Pursuing goal (13m)\n"
+    )
+    assert goal_tui.codex_cli_tui_input_prompt_visible(active_turn)
+    assert goal_tui.codex_cli_tui_turn_active(active_turn)
+    assert not goal_tui.codex_cli_tui_turn_active("› Explain this codebase\n")
 
 
 def _assert_cli_goal_tui_ready_wait_auto_accepts_trust_prompt() -> None:
@@ -1143,6 +1151,26 @@ def _assert_cli_goal_active_timeout_is_public_countability_stage() -> None:
         "skillsbench_codex_cli_goal_uncountable_post_bridge_model_timeout"
     )
 
+    task_output_quiet_trace = dict(completed_attempt_trace)
+    task_output_quiet_trace.update(
+        {
+            "codex_cli_goal_tui_stage": "task_output_quiet_timeout",
+            "codex_cli_goal_tui_ok_count": 0,
+        }
+    )
+    compact = {
+        "route": CODEX_CLI_GOAL_BASELINE_ROUTE,
+        "official_score_status": "completed",
+        "official_score": 0.0,
+        "interaction_counters": task_output_quiet_trace,
+        "runner_prerequisites": {},
+        "failure_attribution_labels": ["official_score_zero_case_failure"],
+    }
+    assert _apply_codex_cli_goal_countability_guard_attribution(compact) is True
+    assert compact["score_failure_attribution"] == (
+        "skillsbench_codex_cli_goal_uncountable_task_output_quiet_timeout"
+    )
+
     with tempfile.TemporaryDirectory() as temp:
         trace_dir = Path(temp) / "trace"
         relay = SkillsBenchLocalAcpRelay(
@@ -1378,6 +1406,9 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert "last_bridge_activity_at >= 30.0" in source
     assert "task_output_quiet_timeout_sec = max(" in source
     assert "_bridge_summary_has_successful_task_operation(" in source
+    assert "turn_active = codex_cli_tui_turn_active(capture)" in source
+    assert "and not turn_active" in source
+    assert "now - last_task_output_activity_at" in source
     assert "stage=\"task_output_quiet_timeout\"" in source
     assert "codex_exec_task_output_quiet_timeout" in source
     tui_loop_start = source.index(

--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -809,6 +809,35 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
         )
         == "post_bridge_tui_model_timeout"
     )
+    active_after_timeout = "\n".join(
+        [
+            "request timed out while waiting for model",
+            "• Working (3m 15s • esc to interrupt)",
+            "› Run /review on my current changes",
+            "Pursuing goal (3m)",
+        ]
+    )
+    assert (
+        codex_cli_tui_pre_bridge_blocker_stage(
+            active_after_timeout,
+            prompt_visible=True,
+        )
+        == ""
+    )
+    assert (
+        codex_cli_tui_pre_bridge_terminal_stage(
+            active_after_timeout,
+            prompt_visible=True,
+        )
+        == ""
+    )
+    assert (
+        codex_cli_tui_post_bridge_blocker_stage(
+            active_after_timeout,
+            prompt_visible=True,
+        )
+        == ""
+    )
     stale_timeout_scrollback = "\n".join(
         [
             "request timed out while waiting for model",

--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -924,6 +924,14 @@ def _assert_cli_goal_post_bridge_blocker_is_public_safe_stage() -> None:
     )
     assert (
         codex_cli_tui_post_bridge_blocker_stage(
+            "Selected model is at capacity. Please try a different model.\n"
+            "Goal blocked\n› ",
+            prompt_visible=True,
+        )
+        == "post_bridge_tui_rate_limit"
+    )
+    assert (
+        codex_cli_tui_post_bridge_blocker_stage(
             "rate limit reached\n",
             prompt_visible=False,
         )

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -1069,6 +1069,7 @@ class SkillsBenchLocalAcpRelay:
             goal_active_observed = False
             goal_terminal_observed = False
             goal_failed_observed = False
+            post_bridge_terminal_stage = ""
             first_action_seen = False
             bridge_activity_seen = False
             last_bridge_summary_size = 0
@@ -1371,6 +1372,15 @@ class SkillsBenchLocalAcpRelay:
                             prompt_visible = codex_cli_tui_input_prompt_visible(capture)
                             pre_bridge_recovery_skip_reason = codex_cli_tui_pre_bridge_terminal_skip_reason(capture, prompt_visible=prompt_visible)
                             pre_bridge_terminal_stage = codex_cli_tui_pre_bridge_terminal_stage(capture, prompt_visible=prompt_visible)
+                        elif bridge_summary_path is not None:
+                            post_bridge_terminal_stage = (
+                                codex_cli_tui_post_bridge_blocker_stage(
+                                    capture,
+                                    prompt_visible=(
+                                        codex_cli_tui_input_prompt_visible(capture)
+                                    ),
+                                )
+                            )
                         goal_terminal_observed = True
                         goal_failed_observed = True
                         break
@@ -1647,7 +1657,17 @@ class SkillsBenchLocalAcpRelay:
                     )
                 self._publish_codex_cli_goal_trace(
                     ok=bool(goal_terminal_observed and not goal_failed_observed),
-                    stage=pre_bridge_terminal_stage or ("goal_achieved" if goal_terminal_observed and not goal_failed_observed else "goal_failed" if goal_failed_observed else "timeout"),
+                    stage=(
+                        pre_bridge_terminal_stage
+                        or post_bridge_terminal_stage
+                        or (
+                            "goal_achieved"
+                            if goal_terminal_observed and not goal_failed_observed
+                            else "goal_failed"
+                            if goal_failed_observed
+                            else "timeout"
+                        )
+                    ),
                     goal_active_observed=goal_active_observed,
                     goal_terminal_observed=goal_terminal_observed,
                     first_action_observed=first_action_seen,
@@ -1671,6 +1691,10 @@ class SkillsBenchLocalAcpRelay:
                     return "codex cli /goal completed"
                 if pre_bridge_terminal_stage:
                     return _recoverable_codex_turn_failure_message("codex_cli_goal_" + pre_bridge_terminal_stage)
+                if post_bridge_terminal_stage:
+                    return _recoverable_codex_turn_failure_message(
+                        "codex_cli_goal_" + post_bridge_terminal_stage
+                    )
                 if goal_failed_observed:
                     return _recoverable_codex_turn_failure_message(
                         "codex_exec_failed"

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -40,12 +40,10 @@ from loopx.benchmark_adapters.skillsbench_bridge_summary import (
     prompt_requires_meaningful_bridge_progress as _prompt_requires_meaningful_bridge_progress,
 )
 from loopx.benchmark_adapters.skillsbench_codex_goal_recovery import (
-    CODEX_CLI_GOAL_POST_BRIDGE_CLOSEOUT_PROMPT,
     CODEX_CLI_GOAL_POST_BRIDGE_CONTINUE_PROMPT,
     POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT,
     PRE_BRIDGE_RECOVERY_ATTEMPT_LIMIT,
     codex_cli_tui_post_bridge_blocker_stage,
-    codex_cli_tui_post_bridge_closeout_recovery_action,
     codex_cli_tui_post_bridge_recovery_action,
     codex_cli_tui_post_bridge_recovery_skip_reason,
     codex_cli_tui_pre_bridge_blocker_stage,
@@ -1081,7 +1079,6 @@ class SkillsBenchLocalAcpRelay:
             post_bridge_recovery_attempt_count = 0
             post_bridge_recovery_action = ""
             post_bridge_recovery_skip_reason = ""
-            post_bridge_closeout_attempt_count = 0
             pre_bridge_terminal_stage = ""
             try:
                 subprocess.run(
@@ -1499,27 +1496,6 @@ class SkillsBenchLocalAcpRelay:
                                 + max(1.0, self._config.stream_heartbeat_interval_sec)
                             )
                             continue
-                        closeout_action = (
-                            codex_cli_tui_post_bridge_closeout_recovery_action(
-                                recovery_action=recovery_action,
-                                recovery_attempt_count=post_bridge_recovery_attempt_count,
-                                closeout_attempted=post_bridge_closeout_attempt_count > 0,
-                                closeout_attempt_count=post_bridge_closeout_attempt_count,
-                            )
-                        )
-                        if closeout_action == "typed_closeout":
-                            post_bridge_closeout_attempt_count += 1
-                            post_bridge_recovery_action = closeout_action
-                            tmux_type_text_and_submit(
-                                tmux_name=tmux_name,
-                                text=CODEX_CLI_GOAL_POST_BRIDGE_CLOSEOUT_PROMPT,
-                            )
-                            last_bridge_activity_at = now
-                            next_heartbeat = (
-                                now
-                                + max(1.0, self._config.stream_heartbeat_interval_sec)
-                            )
-                            continue
                         post_bridge_recovery_skip_reason = (
                             codex_cli_tui_post_bridge_recovery_skip_reason(
                                 capture,
@@ -1531,7 +1507,7 @@ class SkillsBenchLocalAcpRelay:
                             not post_bridge_recovery_skip_reason
                             and recovery_action in {"press_enter", "typed_continue"}
                         ):
-                            post_bridge_recovery_skip_reason = "closeout_retry_limit_reached" if post_bridge_closeout_attempt_count else "retry_limit_reached"
+                            post_bridge_recovery_skip_reason = "retry_limit_reached"
                         tmux_kill_session(tmux_name)
                         self._publish_remote_bridge_agent_operations_trace(
                             bridge_summary_path=bridge_summary_path,
@@ -2211,6 +2187,9 @@ LoopX SkillsBench remote workspace bridge:
   - {{"operation":"cleanup","path":"/app/path/to/temp"}}
 - Allowed sandbox path roots are `/app`, `/tmp`, and `/root`; use `/root`
   when the task instruction names a scored input or output path there.
+- SkillsBench evaluates relative output filenames from `/root`. If the task
+  asks for `report.json`, `answer.json`, or another relative output file, write
+  and self-check `/root/<name>`; an `/app/<name>` copy alone is not scored.
 - Do not upload, submit, expose credentials, quote the bridge command in final output, or record raw stdout/stderr/task text in public artifacts.
 - The bridge readiness probe completed with ready=true and operation_count={operation_count}.
 - If a LoopX product-mode lifecycle contract is present later in this prompt,

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -61,6 +61,7 @@ from loopx.codex_cli_goal_tui import (
     codex_cli_tui_environment,
     codex_cli_tui_shell_command,
     codex_cli_tui_input_prompt_visible,
+    codex_cli_tui_turn_active,
     prewarm_codex_cli_goal_thread,
     tmux_capture,
     tmux_kill_session,
@@ -1198,9 +1199,13 @@ class SkillsBenchLocalAcpRelay:
                     + max(1.0, self._config.stream_heartbeat_interval_sec)
                 )
                 task_output_progress_seen = False
+                last_task_output_activity_at = last_bridge_activity_at
                 while time.monotonic() < deadline:
                     now = time.monotonic()
                     capture = self._last_codex_cli_goal_tui_capture = tmux_capture(tmux_name)
+                    turn_active = codex_cli_tui_turn_active(capture)
+                    if turn_active:
+                        last_task_output_activity_at = now
                     if "Goal active" in capture or "Pursuing goal" in capture:
                         goal_active_observed = True
                     goal_failed_now = "Goal failed" in capture or "Goal blocked" in capture
@@ -1212,6 +1217,7 @@ class SkillsBenchLocalAcpRelay:
                         if current_bridge_summary_size > last_bridge_summary_size:
                             last_bridge_summary_size = current_bridge_summary_size
                             last_bridge_activity_at = now
+                            last_task_output_activity_at = now
                             bridge_activity_seen = True
                             first_action_seen = True
                         elif (
@@ -1544,10 +1550,11 @@ class SkillsBenchLocalAcpRelay:
                         task_output_progress_seen
                         and bridge_summary_path is not None
                         and task_output_quiet_timeout_sec > 0
+                        and not turn_active
                         and not _bridge_summary_has_inflight_operation(
                             bridge_summary_path
                         )
-                        and now - last_bridge_activity_at
+                        and now - last_task_output_activity_at
                         >= task_output_quiet_timeout_sec
                     ):
                         tmux_kill_session(tmux_name)

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -147,6 +147,17 @@ def _prompt_requires_bridge_first_action(prompt: str) -> bool:
     return any(marker in lowered for marker in required_markers)
 
 
+def _codex_cli_goal_watchdog_expired(
+    *,
+    deadline: float,
+    now: float,
+    turn_active: bool,
+) -> bool:
+    """Keep bounded watchdogs from interrupting an active Codex turn."""
+
+    return bool(deadline and now >= deadline and not turn_active)
+
+
 def _is_bridge_action_preflight_prompt(prompt: str) -> bool:
     text = prompt or ""
     return (
@@ -1416,8 +1427,11 @@ class SkillsBenchLocalAcpRelay:
                         )
                     if (
                         not first_action_seen
-                        and first_action_deadline
-                        and now >= first_action_deadline
+                        and _codex_cli_goal_watchdog_expired(
+                            deadline=first_action_deadline,
+                            now=now,
+                            turn_active=turn_active,
+                        )
                     ):
                         tmux_kill_session(tmux_name)
                         if bridge_summary_path is not None:
@@ -1443,8 +1457,11 @@ class SkillsBenchLocalAcpRelay:
                     if (
                         meaningful_progress_required
                         and not meaningful_progress_seen
-                        and meaningful_progress_deadline
-                        and now >= meaningful_progress_deadline
+                        and _codex_cli_goal_watchdog_expired(
+                            deadline=meaningful_progress_deadline,
+                            now=now,
+                            turn_active=turn_active,
+                        )
                     ):
                         tmux_kill_session(tmux_name)
                         if bridge_summary_path is not None:

--- a/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
+++ b/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
@@ -74,6 +74,7 @@ def _capture_has_rate_limit(capture: str) -> bool:
             "too many requests",
             "status 429",
             "error 429",
+            "at capacity",
         )
     )
 

--- a/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
+++ b/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from pathlib import Path
 import uuid
 
-from loopx.codex_cli_goal_tui import codex_cli_tui_input_prompt_visible
+from loopx.codex_cli_goal_tui import (
+    codex_cli_tui_input_prompt_visible,
+    codex_cli_tui_turn_active,
+)
 
 
 PRE_BRIDGE_RECOVERY_ATTEMPT_LIMIT = 2
@@ -102,7 +105,7 @@ def codex_cli_tui_pre_bridge_blocker_stage(
 ) -> str:
     """Classify public-safe Codex CLI TUI blockers before bridge activity."""
 
-    if not prompt_visible:
+    if not prompt_visible or codex_cli_tui_turn_active(capture):
         return ""
     if _capture_has_rate_limit(capture):
         return "pre_bridge_tui_rate_limit"
@@ -163,7 +166,7 @@ def codex_cli_tui_pre_bridge_terminal_stage(
 ) -> str:
     """Classify a terminal goal that ended before any bridge activity."""
 
-    if not prompt_visible:
+    if not prompt_visible or codex_cli_tui_turn_active(capture):
         return ""
     if _capture_has_rate_limit(capture):
         return "pre_bridge_tui_rate_limit"
@@ -198,7 +201,7 @@ def codex_cli_tui_post_bridge_blocker_stage(
 ) -> str:
     """Classify public-safe Codex CLI TUI blockers after bridge activity."""
 
-    if not prompt_visible:
+    if not prompt_visible or codex_cli_tui_turn_active(capture):
         return ""
     if _capture_has_rate_limit(capture):
         return "post_bridge_tui_rate_limit"

--- a/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
+++ b/loopx/benchmark_adapters/skillsbench_codex_goal_recovery.py
@@ -10,19 +10,10 @@ PRE_BRIDGE_RECOVERY_ATTEMPT_LIMIT = 2
 CODEX_CLI_GOAL_PRIVATE_TUI_TAIL_MAX_LINES = 160
 CODEX_CLI_GOAL_PRIVATE_TUI_TAIL_MAX_CHARS = 60000
 CODEX_CLI_GOAL_POST_BRIDGE_CONTINUE_PROMPT = (
-    "Continue the active SkillsBench goal after the transient model timeout. "
-    "If ./skillsbench-task-prompt.md exists, read it before acting. Use the "
-    "private bridge command from the task instructions for one task-facing "
-    "action, then finish with compact status."
-)
-CODEX_CLI_GOAL_POST_BRIDGE_CLOSEOUT_PROMPT = (
-    "Close out the active SkillsBench goal after repeated post-bridge model "
-    "timeouts. Do not start a new investigation. If the task is complete, "
-    "finish the active goal now with compact status. If the task is not "
-    "complete, report the blocker compactly and end the active goal."
+    "Continue the existing SkillsBench task from where you left off after the "
+    "transient model timeout."
 )
 POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT = 6
-POST_BRIDGE_CLOSEOUT_ATTEMPT_LIMIT = 8
 TUI_BLOCKER_RECENT_LINE_WINDOW = 40
 
 
@@ -256,25 +247,3 @@ def codex_cli_tui_post_bridge_recovery_skip_reason(
     if not _capture_has_retry_affordance(capture):
         return "no_retry_affordance"
     return "unsupported_recovery_action"
-
-
-def codex_cli_tui_post_bridge_closeout_recovery_action(
-    *,
-    recovery_action: str,
-    recovery_attempt_count: int,
-    closeout_attempted: bool,
-    closeout_attempt_count: int = 0,
-) -> str:
-    """Return the final bounded closeout action after continue retries are spent."""
-
-    if recovery_action not in {"press_enter", "typed_continue"}:
-        return ""
-    if recovery_attempt_count < POST_BRIDGE_RECOVERY_ATTEMPT_LIMIT:
-        return ""
-    effective_closeout_count = max(
-        int(closeout_attempted),
-        max(0, int(closeout_attempt_count or 0)),
-    )
-    if effective_closeout_count >= POST_BRIDGE_CLOSEOUT_ATTEMPT_LIMIT:
-        return ""
-    return "typed_closeout"

--- a/loopx/benchmark_adapters/skillsbench_proxy_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_proxy_runtime.py
@@ -27,6 +27,20 @@ _DOCKERFILE_FROM_PATTERN = re.compile(
     flags=re.IGNORECASE,
 )
 _SAFE_IMAGE_REFERENCE_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/:@+-]{0,511}$")
+_VERIFIER_SCRIPT_CANDIDATES = (
+    Path("tests/test.sh"),
+    Path("verifier/test.sh"),
+)
+
+
+def skillsbench_verifier_script(task_path: Path) -> Path:
+    """Return the active verifier entrypoint for current or legacy task layouts."""
+
+    for relative_path in _VERIFIER_SCRIPT_CANDIDATES:
+        candidate = task_path / relative_path
+        if candidate.is_file():
+            return candidate
+    return task_path / _VERIFIER_SCRIPT_CANDIDATES[0]
 
 
 def apply_proxy_runtime_env(

--- a/loopx/codex_cli_goal_tui.py
+++ b/loopx/codex_cli_goal_tui.py
@@ -326,6 +326,19 @@ def codex_cli_tui_input_prompt_visible(capture: str) -> bool:
     return False
 
 
+def codex_cli_tui_turn_active(capture: str) -> bool:
+    """Return true while the visible TUI is still running the current turn."""
+
+    recent_lines = (capture or "").splitlines()[-20:]
+    for raw_line in recent_lines:
+        line = raw_line.lower()
+        if "working (" in line and "esc to interrupt" in line:
+            return True
+        if "queued follow-up inputs" in line:
+            return True
+    return False
+
+
 def wait_for_codex_cli_tui_ready(
     tmux_name: str,
     *,

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -7673,7 +7673,7 @@ def skillsbench_verifier_bootstrap_risk(task_path: Path) -> dict[str, Any]:
     commands.
     """
 
-    verifier = task_path / "verifier" / "test.sh"
+    verifier = proxy_runtime.skillsbench_verifier_script(task_path)
     result: dict[str, Any] = {
         "verifier_present": verifier.exists(),
         "verifier_bootstrap_risk_detected": False,
@@ -8369,8 +8369,9 @@ def stage_task_for_sandbox(
     verifier_proxy_exports = _verifier_benchmark_egress_proxy_exports(
         benchmark_egress_proxy_env
     )
+    verifier_script = proxy_runtime.skillsbench_verifier_script(task_path)
     needs_verifier_proxy_env_patch = bool(
-        verifier_proxy_exports and (task_path / "verifier" / "test.sh").exists()
+        verifier_proxy_exports and verifier_script.is_file()
     )
     needs_dockerfile_proxy_env_patch = bool(
         verifier_proxy_exports and (task_path / "environment" / "Dockerfile").exists()
@@ -8532,11 +8533,12 @@ def stage_task_for_sandbox(
     runtime_tools_patched = patch_dockerfile_codex_acp_runtime_tools(
         staged_path / "environment" / "Dockerfile"
     )
+    staged_verifier_script = proxy_runtime.skillsbench_verifier_script(staged_path)
     uv_mirror_metadata = patch_verifier_uv_bootstrap_mirror(
-        staged_path / "verifier" / "test.sh"
+        staged_verifier_script
     )
     verifier_proxy_metadata = patch_verifier_benchmark_egress_proxy_env(
-        staged_path / "verifier" / "test.sh",
+        staged_verifier_script,
         proxy_env=benchmark_egress_proxy_env,
     )
     resource_cap_patch = patch_task_cpu_cap_for_local_docker(
@@ -8630,6 +8632,14 @@ def stage_task_for_sandbox(
         metadata[key] = value
     metadata.update(dockerfile_proxy_metadata)
     metadata.update(verifier_proxy_metadata)
+    if (
+        metadata.get("benchmark_egress_proxy_verifier_env_patch_required") is True
+        and metadata.get("benchmark_egress_proxy_verifier_env_patch_applied")
+        is not True
+    ):
+        raise SkillsBenchSetupPreflightBlocked(
+            "skillsbench verifier egress proxy patch required but not applied"
+        )
     return staged_path, metadata
 
 

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -4909,8 +4909,18 @@ def _apply_codex_cli_goal_countability_guard_attribution(
         not missing_task_activity
         and str(compact.get("official_score_status") or "") == "completed"
     )
+    terminal_goal_failure_stages = {
+        "post_bridge_tui_model_timeout",
+        "post_bridge_tui_error_prompt",
+        "post_bridge_tui_rate_limit",
+    }
     goal_failed = (
-        trace_present and ok_count <= 0 and not completed_task_attempt_countable
+        trace_present
+        and ok_count <= 0
+        and (
+            not completed_task_attempt_countable
+            or goal_stage in terminal_goal_failure_stages
+        )
     )
     if not (missing_task_activity or goal_failed):
         return False
@@ -4924,8 +4934,24 @@ def _apply_codex_cli_goal_countability_guard_attribution(
         label = "skillsbench_codex_cli_goal_uncountable_pre_bridge_tui_error"
     elif goal_stage == "pre_bridge_tui_rate_limit":
         label = "skillsbench_codex_cli_goal_uncountable_pre_bridge_rate_limit"
+    elif goal_stage == "post_bridge_tui_model_timeout":
+        label = "skillsbench_codex_cli_goal_uncountable_post_bridge_model_timeout"
+    elif goal_stage == "post_bridge_tui_error_prompt":
+        label = "skillsbench_codex_cli_goal_uncountable_post_bridge_tui_error"
+    elif goal_stage == "post_bridge_tui_rate_limit":
+        label = "skillsbench_codex_cli_goal_uncountable_post_bridge_rate_limit"
     if goal_failed and not missing_task_activity:
-        label = "skillsbench_codex_cli_goal_uncountable_goal_failed"
+        label = {
+            "post_bridge_tui_model_timeout": (
+                "skillsbench_codex_cli_goal_uncountable_post_bridge_model_timeout"
+            ),
+            "post_bridge_tui_error_prompt": (
+                "skillsbench_codex_cli_goal_uncountable_post_bridge_tui_error"
+            ),
+            "post_bridge_tui_rate_limit": (
+                "skillsbench_codex_cli_goal_uncountable_post_bridge_rate_limit"
+            ),
+        }.get(goal_stage, "skillsbench_codex_cli_goal_uncountable_goal_failed")
     compact["score_failure_attribution"] = label
     compact["first_blocker"] = label
     compact["repeat_blocked_by"] = label

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -4913,6 +4913,7 @@ def _apply_codex_cli_goal_countability_guard_attribution(
         "post_bridge_tui_model_timeout",
         "post_bridge_tui_error_prompt",
         "post_bridge_tui_rate_limit",
+        "task_output_quiet_timeout",
     }
     goal_failed = (
         trace_present
@@ -4940,6 +4941,8 @@ def _apply_codex_cli_goal_countability_guard_attribution(
         label = "skillsbench_codex_cli_goal_uncountable_post_bridge_tui_error"
     elif goal_stage == "post_bridge_tui_rate_limit":
         label = "skillsbench_codex_cli_goal_uncountable_post_bridge_rate_limit"
+    elif goal_stage == "task_output_quiet_timeout":
+        label = "skillsbench_codex_cli_goal_uncountable_task_output_quiet_timeout"
     if goal_failed and not missing_task_activity:
         label = {
             "post_bridge_tui_model_timeout": (
@@ -4950,6 +4953,9 @@ def _apply_codex_cli_goal_countability_guard_attribution(
             ),
             "post_bridge_tui_rate_limit": (
                 "skillsbench_codex_cli_goal_uncountable_post_bridge_rate_limit"
+            ),
+            "task_output_quiet_timeout": (
+                "skillsbench_codex_cli_goal_uncountable_task_output_quiet_timeout"
             ),
         }.get(goal_stage, "skillsbench_codex_cli_goal_uncountable_goal_failed")
     compact["score_failure_attribution"] = label


### PR DESCRIPTION
## Summary

- make post-timeout Codex `/goal` continuation neutral and remove forced closeout injection
- document the scored `/root` output contract in the common remote bridge packet
- keep the task-output quiet watchdog from killing an active TUI turn
- ignore stale timeout text while a TUI turn is active and preserve post-bridge capacity failures as uncountable infrastructure outcomes

## Validation

- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 examples/skillsbench-current-ledger-aggregate-smoke.py`
- changed-file `py_compile` and `git diff --check`
- `loopx canary premerge --from-git-diff`: all direct checks, 6 selected canaries, and public/private boundary scan passed

## Review hold

The canary reports `manual_review_required` because this touches benchmark runner and countability behavior. No benchmark launch, leaderboard, submission, task semantics, or credentials are included in the change.