### PR TITLE
Add repository context to issue-fix workflows

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -14,13 +14,14 @@ external comments, PRs, merges, or publishes.
 | CLI entry | `loopx issue-fix ...` |
 | Content-ops bridge | `loopx content-ops issue-fix-* ...` |
 | Protocol docs | `docs/capabilities/issue-fix/protocols/` |
-| Smoke | `examples/issue-fix-workflow-plan-smoke.py`, `examples/issue-fix-feasibility-smoke.py`, `examples/issue-fix-pr-lifecycle-smoke.py`, `examples/issue-fix-acceptance-loop-smoke.py` |
+| Smoke | `examples/issue-fix-workflow-plan-smoke.py`, `examples/issue-fix-repository-context-smoke.py`, `examples/issue-fix-feasibility-smoke.py`, `examples/issue-fix-pr-lifecycle-smoke.py`, `examples/issue-fix-acceptance-loop-smoke.py` |
 
 ## Protocols
 
 - [`issue_fix_workflow_contract_v0`](protocols/issue-fix-workflow-contract-v0.md)
 - [`issue_fix_acceptance_loop_v0`](protocols/issue-fix-acceptance-loop-v0.md)
 - `issue_fix_workflow_plan_packet_v0`
+- `issue_fix_repository_context_v0`
 - `issue_fix_feasibility_v0`
 - `issue_fix_pr_lifecycle_monitor_v0`
 - `github_issue_metadata_preview_v0`
@@ -67,6 +68,7 @@ workflow planner before todo writeback:
 loopx issue-fix workflow-plan \
   --url https://github.com/owner/repo/issues/123 \
   --repo-path <approved-repo> \
+  --repository-context-json repository-context.json \
   --validation-label "<validation command>" \
   --format json
 ```
@@ -91,6 +93,28 @@ writeback previews, and PR review readiness blockers into one packet. It does
 not write LoopX todos, inspect the local repo in dry-run mode, create external
 comments or PRs, merge, or capture raw issue body/comment material.
 
+## Repository Context
+
+`--repository-context-json` accepts an
+`issue_fix_repository_context_input_v0` object with a pinned repository
+revision and up to 16 compact source records. Each record names only a source
+id, kind, public-safe reference, trust, freshness, supported decision aspects,
+and an optional compact summary. Raw source content, expert responses, logs,
+credentials, and local paths are rejected.
+
+The projection distinguishes `authoritative`, `verified`, and `advisory`
+evidence across architecture, ownership, change scope, reproduction, and
+validation. Only current repository evidence can ground a decision. External
+experts always remain advisory and cannot authorize comments, PRs, merges, or
+other external writes. The workflow plan uses missing coverage to name the
+next repository reads without adding another lifecycle state or todo chain.
+
+Memory systems such as OpenViking may supply compact `memory_retrieval` source
+refs. They do not become the source of truth: retrieved claims must be checked
+against the pinned repository revision. Knowledge bundles remain
+format-agnostic so an Open Knowledge Format bundle can be referenced without
+making the issue-fix state machine depend on that draft interchange format.
+
 ## Feasibility Decision
 
 ```bash
@@ -100,6 +124,7 @@ loopx issue-fix feasibility \
   --reproduction-label "focused repro plan" \
   --scope-class bounded \
   --validation-label "focused unit test" \
+  --repository-context-json repository-context.json \
   --goal-id example-goal \
   --format json
 ```
@@ -113,7 +138,12 @@ a planned repro first projects `issue_fix_confirm_reproduction`, not patch work.
 
 With `--goal-id` or `--ledger-path`, the decision is upserted by repo and issue
 reference into `.loopx/domain-state/<goal-id>/issue_fix/feasibility.jsonl`.
-Use `--no-write-domain-state` for preview-only checks.
+The same row keeps the compact repository-context fingerprint, source refs,
+coverage, expert policy, and memory policy so the next agent turn does not lose
+its evidence basis. Use `--no-write-domain-state` for preview-only checks.
+
+For a concrete public pilot and staged adoption plan, see
+[`OpenViking issue-fix pilot handoff`](openviking-pilot-handoff.md).
 
 ## PR Lifecycle Monitor
 
@@ -142,6 +172,7 @@ provider payloads, raw check logs, local paths, or credentials.
 
 ```bash
 python3 examples/issue-fix-workflow-plan-smoke.py
+python3 examples/issue-fix-repository-context-smoke.py
 python3 examples/issue-fix-feasibility-smoke.py
 python3 examples/issue-fix-pr-lifecycle-smoke.py
 python3 examples/issue-fix-workflow-contract-smoke.py

--- a/docs/capabilities/issue-fix/openviking-pilot-handoff.md
+++ b/docs/capabilities/issue-fix/openviking-pilot-handoff.md
@@ -1,0 +1,162 @@
+# OpenViking Issue-Fix Pilot Handoff
+
+This plan starts one real OpenViking issue-fix agent without treating repository
+memory or an expert bot as an oracle. The target is a reviewable maintainer
+outcome: a focused fix PR, a useful public comment draft, or a justified triage
+decision, followed by CI and review monitoring.
+
+## What Makes VikingBot Repository-Aware
+
+VikingBot does not rely on a special OpenViking-trained model. Its repository
+awareness comes from composition:
+
+1. [ContextBuilder](https://github.com/volcengine/OpenViking/blob/main/bot/vikingbot/agent/context.py)
+   loads stable bootstrap files, skills, peer profiles, and relevant memory for
+   the current message.
+2. [MemoryStore](https://github.com/volcengine/OpenViking/blob/main/bot/vikingbot/agent/memory.py)
+   separates facts, cases, reusable experiences, and diagnostic trajectories,
+   then retrieves them with bounded quotas.
+3. [VikingBot's README](https://github.com/volcengine/OpenViking/blob/main/bot/README.md)
+   exposes OpenViking read, search, grep, glob, resource-add, and memory-commit
+   tools and describes experience recall around write operations.
+4. Repository-owned sources already encode important development knowledge:
+   [CONTRIBUTING.md](https://github.com/volcengine/OpenViking/blob/main/CONTRIBUTING.md)
+   maps components to maintainers, while
+   [.pr_agent.toml](https://github.com/volcengine/OpenViking/blob/main/.pr_agent.toml)
+   captures review invariants and project-specific risks.
+
+The practical lesson is to reproduce this composition, not to copy a large
+prompt. A LoopX issue-fix agent should retrieve only the sources relevant to the
+current issue, pin them to a repository revision, and preserve their provenance
+in feasibility domain state.
+
+## Use Order
+
+Use repository evidence first, memory second, and expert consultation third:
+
+1. Read repository policy, architecture, nearby code, tests, and recent related
+   fixes at the current revision.
+2. Retrieve compact prior lessons from OpenViking when they can narrow a route,
+   repro, or validation choice. Verify every retrieved claim against the current
+   checkout.
+3. Ask VikingBot a targeted question only when architecture, ownership, repro,
+   or validation remains uncertain. Store a compact conclusion and source ref,
+   not the raw response. Verify the conclusion locally before patching.
+
+An expert answer never supplies publication authority. External comments, PR
+creation, merge, and other writes retain their existing LoopX gates.
+
+## Immediate Launch
+
+Start with one issue that has a bounded suspected surface and a focused test or
+reproduction path. Prepare a compact context file from the current checkout:
+
+```json
+{
+  "schema_version": "issue_fix_repository_context_input_v0",
+  "repository_revision": "<current-commit>",
+  "sources": [
+    {
+      "source_id": "contributing",
+      "source_kind": "repository_policy",
+      "reference": "CONTRIBUTING.md",
+      "trust": "authoritative",
+      "freshness": "current",
+      "supports": ["change_scope", "ownership"]
+    },
+    {
+      "source_id": "focused-tests",
+      "source_kind": "test_surface",
+      "reference": "<repo-relative-test-path>",
+      "trust": "verified",
+      "freshness": "current",
+      "supports": ["reproduction", "validation"]
+    }
+  ]
+}
+```
+
+Then run the existing workflow and feasibility surfaces:
+
+```bash
+loopx issue-fix workflow-plan \
+  --url <public-github-issue-url> \
+  --repo-path <approved-openviking-checkout> \
+  --repository-context-json repository-context.json \
+  --validation-label "<focused-validation-label>" \
+  --format json
+
+loopx issue-fix feasibility \
+  --url <public-github-issue-url> \
+  --reproduction-status planned \
+  --reproduction-label "<focused-repro-plan>" \
+  --scope-class bounded \
+  --validation-label "<focused-validation-label>" \
+  --repository-context-json repository-context.json \
+  --goal-id <pilot-goal-id> \
+  --format json
+```
+
+The feasibility command writes the compact context projection into the normal
+issue-fix domain-state row by default. It does not create a second context
+ledger or another workflow state.
+
+## Short Term
+
+- Run one issue at a time through `fix_pr`, `comment_only`, or `triage_only`.
+- Pin every context packet to the checkout revision.
+- Require grounded change-scope, reproduction, and validation evidence before
+  treating repository context as strong confidence.
+- Use OpenViking retrieval read-only for prior issue and validation lessons.
+- Consult VikingBot only for a specific unresolved aspect, then verify locally.
+- After a PR exists, keep the existing lifecycle monitor responsible for CI,
+  review, stale branch, merge, and close transitions.
+
+## Medium Term
+
+- Implement the live OpenViking adapter behind explicit retrieval capability
+  and authority checks; retain compact refs in LoopX, not memory bodies.
+- Add controlled writeback after validated outcomes. Store distilled reusable
+  facts with repository revision, provenance, freshness, and supersession.
+- Add a read-only expert connector for VikingBot with targeted questions,
+  timeout/failure behavior, and a mandatory repository-verification result.
+- Convert CI failures, review corrections, rejected PRs, and merged outcomes
+  into successor todos and reusable issue-fix lessons.
+
+## Long Term
+
+- Build revision-aware repository knowledge that can supersede stale concepts
+  and distinguish stable architecture from issue-local observations.
+- Rank issue candidates using reproducibility, validation cost, maintainer
+  activity, expected scope, and permission risk.
+- Compare agents with and without accumulated repository knowledge on time to
+  first valid repro, first-review acceptance, rework rounds, and stranded PRs.
+- Add import/export for mature interchange formats without coupling runtime
+  decisions to a document layout.
+
+## Open Knowledge Format
+
+Google announced the
+[Open Knowledge Format](https://cloud.google.com/blog/products/data-analytics/how-the-open-knowledge-format-can-improve-data-sharing)
+as a portable Markdown and YAML-frontmatter knowledge bundle. The current
+[OKF v0.1 specification](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md)
+is explicitly a draft: concept identity is path-based, Markdown links form the
+graph, and `index.md` and `log.md` support progressive disclosure and history.
+
+This helps LoopX as an interchange and export shape for repository knowledge.
+It does not replace retrieval, trust, freshness, permissions, issue routing, or
+domain-state transitions. The near-term contract therefore accepts a generic
+`knowledge_bundle` source ref and remains format-agnostic. Add a concrete OKF
+importer only when a live producer and consumer need it and the draft has
+stabilized enough to justify compatibility work.
+
+## Pilot Success Signals
+
+- time from issue intake to a named reproduction path;
+- percentage of fix routes with grounded validation evidence;
+- expert answers verified or rejected against repository sources;
+- PR review rounds and CI recovery time;
+- duplicate repository reads avoided across issues;
+- stale memory detected before it influences a patch;
+- issue-fix loops that end in merge, useful comment, or explicit no-follow-up
+  instead of silent monitor-only drift.

--- a/docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md
@@ -26,35 +26,41 @@ open PRs, merge, publish, or run destructive git without an explicit gate.
    code-context route candidates, owner/user gate projections, and ordered
    agent todo candidates. The first screen must name `waiting_on`, top agent
    todo, top gate when present, and next safe action.
-3. **Workflow plan:** build `issue_fix_workflow_plan_packet_v0` to compose the
+3. **Repository context:** build `issue_fix_repository_context_v0` from a
+   pinned repository revision plus compact source refs. Current authoritative
+   or verified repository evidence may ground change scope, reproduction, and
+   validation. Stale memory and external experts remain advisory. The context
+   projects missing reads but does not introduce another lifecycle state,
+   authorize external writes, or override feasibility routing.
+4. **Workflow plan:** build `issue_fix_workflow_plan_packet_v0` to compose the
    metadata preview, intake, branch dry-run, validation label, ordered LoopX
    todo writeback preview, resolution route candidates, gate preview, post-PR
    lifecycle monitor plan, and PR-review readiness blockers. This stage is
    preview-only and does not write todos.
-4. **Feasibility checkpoint:** build `issue_fix_feasibility_v0` from compact
+5. **Feasibility checkpoint:** build `issue_fix_feasibility_v0` from compact
    public-safe agent observations. The decision must select exactly one
    `fix_pr`, `comment_only`, or `triage_only` route. `fix_pr` requires bounded
    scope plus named reproduction and validation surfaces; planned reproduction
    projects confirmation work before patch work. With a goal id, the compact
    decision writes issue-fix domain state by default.
-5. **LoopX todo writeback:** initially write only metadata classification and
+6. **LoopX todo writeback:** initially write only metadata classification and
    the feasibility checkpoint. Then write the single route-specific successor
    projected by feasibility, or record its structured no-follow-up. User todos
    represent concrete external-write, private-material, merge, publish, or
    repository-policy gates.
-6. **Caller repo branch:** use `issue_fix_caller_repo_branch_packet_v0` only
+7. **Caller repo branch:** use `issue_fix_caller_repo_branch_packet_v0` only
    after the caller provides an approved local git repo, base branch, issue
    branch policy, and validation command. Dry-run mode must not inspect the
    repo. Execute mode may inspect the approved repo and create or claim a
    `codex/` issue branch, but must refuse branch switches from dirty state.
-7. **Validation:** record focused validation as pass/fail, exit code, and
+8. **Validation:** record focused validation as pass/fail, exit code, and
    public-safe label. Validation stdout, stderr, local paths, and raw git output
    stay out of the packet. A validated fix should prove failing-before and
    passing-after evidence when that repro path is available.
-8. **PR review packet:** emit `issue_fix_pr_review_packet_v0` only when branch,
+9. **PR review packet:** emit `issue_fix_pr_review_packet_v0` only when branch,
    validation, and repo-relative changed-file evidence are sufficient for human
    review. The packet is review evidence, not external publication authority.
-9. **PR lifecycle monitor:** after a PR exists, use
+10. **PR lifecycle monitor:** after a PR exists, use
    `issue_fix_pr_lifecycle_monitor_v0` to project compact public PR state into
    exactly one of `runnable_successor`, `monitor_continuation`, `user_gate`, or
    `no_followup`. Terminal PR states such as `MERGED` and `CLOSED` take
@@ -63,7 +69,7 @@ open PRs, merge, publish, or run destructive git without an explicit gate.
    The command writes compact domain state by default when a `--goal-id` or
    `--ledger-path` is provided, and `--no-write-domain-state` keeps it
    preview-only.
-10. **Gate handling:** surface concrete gates instead of silently blocking. Safe
+11. **Gate handling:** surface concrete gates instead of silently blocking. Safe
    metadata-only triage, public-code search, and focused smoke drafting may
    continue when those gates do not cover the selected action.
 
@@ -119,7 +125,10 @@ long-running monitors:
 
 Feasibility rows are keyed by `repo` and `issue_ref`; PR lifecycle rows are keyed
 by `repo` and `pr_ref`. They may store compact observations, decisions, and
-fingerprints. Domain state must not store issue bodies, comment bodies, raw
+fingerprints. A feasibility observation may include one compact
+`issue_fix_repository_context_v0` projection so its repository revision,
+source refs, coverage, expert policy, and memory policy survive across turns.
+Domain state must not store issue bodies, comment bodies, raw
 provider payloads, raw logs, local paths, credentials, or destructive-git
 output. Public packet validation remains the behavior contract; domain state
 only keeps the agent from forgetting its latest compact decision.
@@ -144,6 +153,9 @@ An issue-fix workflow is PR-review-ready only when all of these are true:
 - `content_ops_issue_fix_intake_packet_v0`
 - `issue_fix_intake_v0`
 - `issue_fix_workflow_plan_packet_v0`
+- `issue_fix_repository_context_input_v0`
+- `issue_fix_repository_context_v0`
+- `issue_fix_repository_context_effect_v0`
 - `issue_fix_feasibility_v0`
 - `issue_fix_feasibility_observation_v0`
 - `issue_fix_feasibility_decision_v0`

--- a/docs/reference/protocols/loopx-goal-command-v0.md
+++ b/docs/reference/protocols/loopx-goal-command-v0.md
@@ -100,21 +100,26 @@ before writing todos:
 loopx issue-fix workflow-plan \
   --url <github-issue-or-pr-url> \
   --repo-path <approved-repo> \
+  --repository-context-json <compact-context.json> \
   --validation-label "<validation command>" \
   --format json
 ```
 
-The preview maps public metadata, intake classification, branch planning,
-validation labels, the feasibility checkpoint, and PR review readiness blockers
-into `/loopx <goal text>`. Initially write only metadata classification and the
-feasibility checkpoint in priority and planner order. Then record a compact
-observation and let LoopX select exactly one route:
+The preview maps public metadata, repository context, intake classification,
+branch planning, validation labels, the feasibility checkpoint, and PR review
+readiness blockers into `/loopx <goal text>`. Repository context pins compact
+policy, architecture, change-scope, reproduction, and validation refs to a
+revision; memory and external experts stay advisory until repository-verified.
+Initially write only metadata classification and the feasibility checkpoint in
+priority and planner order. Then record a compact observation and let LoopX
+select exactly one route:
 
 ```bash
 loopx issue-fix feasibility \
   --url <github-issue-url> \
   --reproduction-status <confirmed|planned|missing|blocked> \
   --scope-class <bounded|uncertain|oversized> \
+  --repository-context-json <compact-context.json> \
   --goal-id <goal-id> \
   --format json
 ```

--- a/examples/bootstrap-command-pack-smoke.py
+++ b/examples/bootstrap-command-pack-smoke.py
@@ -144,12 +144,14 @@ def test_goal_text_invocation_plans_ranked_todos_before_activation() -> None:
         assert "issue-fix workflow-plan" in issue_fix_template
         assert "--url <github-issue-or-pr-url>" in issue_fix_template
         assert "--repo-path <approved-repo>" in issue_fix_template
+        assert "--repository-context-json <compact-context.json>" in issue_fix_template
         assert "--validation-label '<validation command>'" in issue_fix_template
         assert "issue_fix_feasibility_template" in commands
         feasibility_template = str(commands["issue_fix_feasibility_template"])
         assert "issue-fix feasibility" in feasibility_template
         assert "--reproduction-status" in feasibility_template
         assert "--scope-class" in feasibility_template
+        assert "--repository-context-json <compact-context.json>" in feasibility_template
         assert "--goal-id" in feasibility_template
         assert "issue_fix_pr_lifecycle_template" in commands
         pr_lifecycle_template = str(commands["issue_fix_pr_lifecycle_template"])

--- a/examples/canary/catalog-planner-smoke.py
+++ b/examples/canary/catalog-planner-smoke.py
@@ -495,7 +495,7 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
             "scripts/update_notes_release_job.py",
         ],
         surfaces=["product-entry issue-fix content-ops update-note cross-runtime demo"],
-        max_checks_per_profile=6,
+        max_checks_per_profile=7,
     )
     product_entry_profiles = {
         profile["id"]: profile for profile in product_entry_payload["domain_profiles"]
@@ -505,6 +505,7 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     product_entry_profile = product_entry_profiles["product-entry-workflows"]
     product_entry_commands = [check["command"] for check in product_entry_profile["checks"]]
     assert "python3 examples/issue-fix-workflow-contract-smoke.py" in product_entry_commands, product_entry_profile
+    assert "python3 examples/issue-fix-repository-context-smoke.py" in product_entry_commands, product_entry_profile
     assert "python3 examples/issue-fix-feasibility-smoke.py" in product_entry_commands, product_entry_profile
     assert "python3 examples/issue-fix-pr-lifecycle-smoke.py" in product_entry_commands, product_entry_profile
     assert "python3 examples/content-ops-issue-fix-intake-smoke.py" in product_entry_commands, product_entry_profile

--- a/examples/fixtures/openviking-issue-fix-repository-context.public.json
+++ b/examples/fixtures/openviking-issue-fix-repository-context.public.json
@@ -1,0 +1,80 @@
+{
+  "schema_version": "issue_fix_repository_context_input_v0",
+  "repository_revision": "cbdab573539d64621b51da0090330e2552acd0a7",
+  "sources": [
+    {
+      "source_id": "openviking-contributing",
+      "source_kind": "repository_policy",
+      "reference": "CONTRIBUTING.md",
+      "trust": "authoritative",
+      "freshness": "current",
+      "supports": [
+        "change_scope",
+        "ownership"
+      ],
+      "summary": "Repository-owned contribution and maintainer routing rules."
+    },
+    {
+      "source_id": "openviking-pr-agent-rules",
+      "source_kind": "repository_policy",
+      "reference": ".pr_agent.toml",
+      "trust": "authoritative",
+      "freshness": "current",
+      "supports": [
+        "change_scope",
+        "validation"
+      ],
+      "summary": "Repository-owned review invariants and risk rules."
+    },
+    {
+      "source_id": "openviking-vikingbot-readme",
+      "source_kind": "architecture_doc",
+      "reference": "bot/README.md",
+      "trust": "verified",
+      "freshness": "current",
+      "supports": [
+        "architecture",
+        "reproduction",
+        "validation"
+      ],
+      "summary": "VikingBot setup, tools, memory behavior, and test entry points."
+    },
+    {
+      "source_id": "openviking-vikingbot-context",
+      "source_kind": "source_code",
+      "reference": "bot/vikingbot/agent/context.py",
+      "trust": "verified",
+      "freshness": "current",
+      "supports": [
+        "architecture",
+        "change_scope"
+      ],
+      "summary": "Current context assembly for bootstrap files, skills, and retrieved memory."
+    },
+    {
+      "source_id": "openviking-memory-preview",
+      "source_kind": "memory_retrieval",
+      "reference": "openviking:repository-memory-preview",
+      "trust": "advisory",
+      "freshness": "unknown",
+      "supports": [
+        "architecture",
+        "change_scope"
+      ],
+      "summary": "Prior repository lessons require verification against the pinned revision."
+    },
+    {
+      "source_id": "openviking-vikingbot-expert",
+      "source_kind": "external_expert",
+      "reference": "vikingbot:openviking-development",
+      "trust": "advisory",
+      "freshness": "current",
+      "supports": [
+        "architecture",
+        "ownership"
+      ],
+      "consultation_state": "available",
+      "summary": "Optional repository expert consultation; answers require local verification."
+    }
+  ]
+}

--- a/examples/issue-fix-repository-context-smoke.py
+++ b/examples/issue-fix-repository-context-smoke.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Smoke-test issue-fix repository context and domain-state integration."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx.capabilities.issue_fix.feasibility import (  # noqa: E402
+    build_issue_fix_feasibility_packet,
+    validate_issue_fix_feasibility_packet,
+)
+from loopx.capabilities.issue_fix.repository_context import (  # noqa: E402
+    ISSUE_FIX_REPOSITORY_CONTEXT_SCHEMA_VERSION,
+    build_issue_fix_repository_context_packet,
+)
+from loopx.capabilities.issue_fix.workflow_plan import (  # noqa: E402
+    build_issue_fix_workflow_plan_packet,
+    validate_issue_fix_workflow_plan_packet,
+)
+
+
+URL = "https://github.com/volcengine/OpenViking/issues/2792"
+FIXTURE = ROOT / "examples" / "fixtures" / "openviking-issue-fix-repository-context.public.json"
+
+
+def assert_public_safe(payload: dict[str, object]) -> None:
+    text = json.dumps(payload, ensure_ascii=True, sort_keys=True)
+    for forbidden in (
+        "/Users/",
+        "/private/tmp/",
+        "raw issue body",
+        "raw expert response",
+        "credential-value",
+    ):
+        assert forbidden not in text, (forbidden, text)
+
+
+def main() -> int:
+    context_input = json.loads(FIXTURE.read_text(encoding="utf-8"))
+    context = build_issue_fix_repository_context_packet(
+        repo="volcengine/OpenViking",
+        issue_ref="issue_2792",
+        context_input=context_input,
+    )
+    assert context["ok"] is True, context
+    assert context["schema_version"] == ISSUE_FIX_REPOSITORY_CONTEXT_SCHEMA_VERSION
+    assert context["context_status"] == "grounded", context
+    assert context["unresolved_required_aspects"] == [], context
+    assert context["coverage"]["reproduction"]["status"] == "grounded", context
+    assert context["coverage"]["validation"]["status"] == "grounded", context
+    assert context["expert_consultation"]["answer_is_authority"] is False, context
+    assert context["expert_consultation"]["external_write_authorized"] is False
+    assert context["memory_projection"]["writeback_performed"] is False
+    assert_public_safe(context)
+
+    advisory_only = {
+        "schema_version": "issue_fix_repository_context_input_v0",
+        "repository_revision": "public-revision-1",
+        "sources": [
+            {
+                "source_id": "expert-only",
+                "source_kind": "external_expert",
+                "reference": "expert:repository",
+                "trust": "advisory",
+                "freshness": "current",
+                "supports": ["change_scope", "reproduction", "validation"],
+                "consultation_state": "queried",
+                "summary": "Compact expert conclusion awaiting repository verification.",
+            }
+        ],
+    }
+    advisory = build_issue_fix_repository_context_packet(
+        repo="owner/repo",
+        issue_ref="issue_123",
+        context_input=advisory_only,
+    )
+    assert advisory["context_status"] == "ungrounded", advisory
+    assert advisory["advisory_required_aspects"] == [
+        "change_scope",
+        "reproduction",
+        "validation",
+    ], advisory
+    assert advisory["expert_consultation"]["next_action"] == (
+        "verify_queried_answer_against_repository"
+    ), advisory
+
+    stale_policy = {
+        "schema_version": "issue_fix_repository_context_input_v0",
+        "repository_revision": "public-revision-2",
+        "sources": [
+            {
+                "source_id": "stale-policy",
+                "source_kind": "repository_policy",
+                "reference": "CONTRIBUTING.md",
+                "trust": "authoritative",
+                "freshness": "stale",
+                "supports": ["change_scope"],
+            }
+        ],
+    }
+    stale = build_issue_fix_repository_context_packet(
+        repo="owner/repo",
+        issue_ref="issue_123",
+        context_input=stale_policy,
+    )
+    assert stale["coverage"]["change_scope"]["status"] == "advisory", stale
+    assert "change_scope" in stale["unresolved_required_aspects"], stale
+
+    workflow = build_issue_fix_workflow_plan_packet(
+        url=URL,
+        repository_context_input=context_input,
+        validation_label="focused OpenViking test",
+    )
+    assert workflow["ok"] is True, workflow
+    assert workflow["repository_context"]["context_status"] == "grounded", workflow
+    assert "use the grounded repository context" in workflow["first_screen"][
+        "next_safe_action"
+    ], workflow
+    actions = [
+        row["action_kind"] for row in workflow["ordered_loopx_todo_writeback_preview"]
+    ]
+    assert actions == [
+        "issue_fix_public_metadata_classification",
+        "issue_fix_feasibility_decision",
+    ], actions
+    legacy_workflow = json.loads(json.dumps(workflow))
+    legacy_workflow.pop("repository_context")
+    assert validate_issue_fix_workflow_plan_packet(legacy_workflow)["ok"] is True
+
+    feasibility = build_issue_fix_feasibility_packet(
+        url=URL,
+        reproduction_status="planned",
+        reproduction_label="focused OpenViking repro plan",
+        scope_class="bounded",
+        validation_label="focused OpenViking test",
+        repository_context_input=context_input,
+    )
+    assert feasibility["decision"]["route"] == "fix_pr", feasibility
+    assert "repository_context_grounded" in feasibility["decision"]["reason_codes"]
+    effect = feasibility["repository_context_effect"]
+    assert effect["route_confidence"] == "grounded", effect
+    assert effect["route_overridden"] is False, effect
+    assert "openviking-vikingbot-readme" in effect["reproduction_evidence_refs"]
+    assert "openviking-pr-agent-rules" in effect["validation_evidence_refs"]
+    assert_public_safe(feasibility)
+    legacy_feasibility = json.loads(json.dumps(feasibility))
+    legacy_feasibility["observation"].pop("repository_context")
+    legacy_feasibility.pop("repository_context_effect")
+    assert validate_issue_fix_feasibility_packet(legacy_feasibility)["ok"] is True
+
+    invalid = dict(context_input)
+    invalid["sources"] = [dict(context_input["sources"][0], content="raw content")]
+    try:
+        build_issue_fix_repository_context_packet(
+            repo="owner/repo",
+            issue_ref="issue_123",
+            context_input=invalid,
+        )
+    except ValueError as exc:
+        assert "unsupported fields" in str(exc), exc
+    else:
+        raise AssertionError("raw source content field must be rejected")
+
+    invalid_path = dict(context_input)
+    invalid_path["sources"] = [
+        dict(context_input["sources"][0], reference="/private/repository/context.md")
+    ]
+    try:
+        build_issue_fix_repository_context_packet(
+            repo="owner/repo",
+            issue_ref="issue_123",
+            context_input=invalid_path,
+        )
+    except ValueError as exc:
+        assert "absolute" in str(exc), exc
+    else:
+        raise AssertionError("absolute source reference must be rejected")
+
+    with tempfile.TemporaryDirectory(prefix="loopx-issue-fix-context-") as tmpdir:
+        project = Path(tmpdir)
+        command = [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "issue-fix",
+            "feasibility",
+            "--url",
+            URL,
+            "--reproduction-status",
+            "planned",
+            "--reproduction-label",
+            "focused OpenViking repro plan",
+            "--scope-class",
+            "bounded",
+            "--validation-label",
+            "focused OpenViking test",
+            "--repository-context-json",
+            str(FIXTURE),
+            "--goal-id",
+            "openviking-pilot",
+            "--project",
+            str(project),
+        ]
+        result = subprocess.run(
+            command,
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        cli_packet = json.loads(result.stdout)
+        assert cli_packet["domain_state_projection"]["write_performed"] is True
+        ledger = (
+            project
+            / ".loopx"
+            / "domain-state"
+            / "openviking-pilot"
+            / "issue_fix"
+            / "feasibility.jsonl"
+        )
+        row = json.loads(ledger.read_text(encoding="utf-8").strip())
+        persisted_context = row["observation"]["repository_context"]
+        assert persisted_context["context_status"] == "grounded", row
+        assert persisted_context["context_fingerprint"] == cli_packet["observation"][
+            "repository_context"
+        ]["context_fingerprint"]
+        assert_public_safe(row)
+
+    print("issue-fix-repository-context-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/issue-fix-workflow-contract-smoke.py
+++ b/examples/issue-fix-workflow-contract-smoke.py
@@ -91,12 +91,15 @@ def main() -> int:
     assert "loopx issue-fix pr-lifecycle" in readme
     assert "selects exactly one" in readme
     assert "## Feasibility Decision" in readme
+    assert "## Repository Context" in readme
+    assert "openviking-pilot-handoff.md" in readme
     assert "## PR Lifecycle Monitor" in readme
     assert "runnable_successor" in readme
     assert "examples/issue-fix-pr-lifecycle-smoke.py" in readme
     assert "explicit gates" in readme
     assert "## Issue-Fix Domain Route" in loopx_goal_command
     assert "loopx issue-fix workflow-plan" in loopx_goal_command
+    assert "--repository-context-json <compact-context.json>" in loopx_goal_command
     assert "before writing todos" in loopx_goal_command
     assert "priority and planner order" in loopx_goal_command
     assert "gates must cover private repro material" in loopx_goal_command
@@ -121,6 +124,9 @@ def main() -> int:
         CONTENT_OPS_ISSUE_FIX_INTAKE_PACKET_SCHEMA_VERSION,
         ISSUE_FIX_INTAKE_SCHEMA_VERSION,
         "issue_fix_workflow_plan_packet_v0",
+        "issue_fix_repository_context_input_v0",
+        "issue_fix_repository_context_v0",
+        "issue_fix_repository_context_effect_v0",
         "issue_fix_feasibility_v0",
         "issue_fix_feasibility_observation_v0",
         "issue_fix_feasibility_decision_v0",

--- a/examples/issue-fix-workflow-plan-smoke.py
+++ b/examples/issue-fix-workflow-plan-smoke.py
@@ -105,6 +105,8 @@ def assert_workflow_shape(payload: dict[str, Any]) -> None:
     assert feasibility["selects_exactly_one_route"] is True, feasibility
     assert feasibility["routes"] == ["fix_pr", "comment_only", "triage_only"]
     assert feasibility["writes_domain_state_by_default_with_goal_id"] is True
+    assert feasibility["persists_repository_context_with_feasibility"] is True
+    assert "--repository-context-json" in feasibility["command_preview"]
     assert feasibility["writes_loopx_todo"] is False
     post_pr = payload["post_pr_lifecycle_monitor_plan"]
     assert post_pr["creates_continuous_monitor_todo"] is True, post_pr

--- a/loopx/bootstrap_command_pack.py
+++ b/loopx/bootstrap_command_pack.py
@@ -307,11 +307,13 @@ def _goal_start_contract(*, goal_text: str | None, connected: bool, agent_type: 
                 "when": "goal text contains a public GitHub issue/PR URL or asks for an issue-fix workflow",
                 "preview_command": (
                     "loopx issue-fix workflow-plan --url <github-issue-or-pr-url> "
-                    "--repo-path <approved-repo> --validation-label '<validation command>' --format json"
+                    "--repo-path <approved-repo> --repository-context-json "
+                    "<compact-context.json> --validation-label '<validation command>' --format json"
                 ),
                 "decision_command": (
                     "loopx issue-fix feasibility --url <github-issue-url> "
                     "--reproduction-status <state> --scope-class <scope> "
+                    "--repository-context-json <compact-context.json> "
                     "--goal-id <goal-id> --format json"
                 ),
                 "post_pr_monitor_command": (
@@ -358,7 +360,7 @@ Planning rules:
 4. If several todos share the same priority, their listed order is their relative priority. Preserve that exact order when writing them.
 5. Prefer executable Agent Todo items with `task_class=advancement_task`; use User Todo only for concrete owner decisions or private-material gates.
 6. After writing todos, run `loopx refresh-state --goal-id {goal_id}`, activate the host loop if it is missing, unknown, or stale (Codex App automation, Codex CLI `/goal <task_body>`, Claude Code `/loop`, or a custom host-loop gate), then run `loopx quota should-run --goal-id {goal_id}` and begin the first allowed bounded segment.
-7. If the goal is a GitHub issue/PR fix, first preview `loopx issue-fix workflow-plan --url <github-issue-or-pr-url> --repo-path <approved-repo> --validation-label '<validation command>' --format json`; write only metadata classification plus the feasibility checkpoint. After a compact public-safe observation, run `loopx issue-fix feasibility --url <github-issue-url> --reproduction-status <state> --scope-class <scope> --goal-id {goal_id} --format json` and write only its selected route successor or no-follow-up. Keep private repro material, body/comment reads, external comments, PR creation, merge, publish, destructive git, and production actions as explicit gates. After a PR exists, the monitor should call `loopx issue-fix pr-lifecycle --url <github-pr-url> --goal-id {goal_id} --format json` so CI, review, merge, stale branch, and no-follow-up states drive LoopX todos instead of chat memory.
+7. If the goal is a GitHub issue/PR fix, first preview `loopx issue-fix workflow-plan --url <github-issue-or-pr-url> --repo-path <approved-repo> --repository-context-json <compact-context.json> --validation-label '<validation command>' --format json`; write only metadata classification plus the feasibility checkpoint. Repository context should pin current repo policy, architecture, change-scope, reproduction, and validation refs; memory and external experts remain advisory until verified against the pinned revision. After a compact public-safe observation, run `loopx issue-fix feasibility --url <github-issue-url> --reproduction-status <state> --scope-class <scope> --repository-context-json <compact-context.json> --goal-id {goal_id} --format json` and write only its selected route successor or no-follow-up. Keep private repro material, body/comment reads, external comments, PR creation, merge, publish, destructive git, and production actions as explicit gates. After a PR exists, the monitor should call `loopx issue-fix pr-lifecycle --url <github-pr-url> --goal-id {goal_id} --format json` so CI, review, merge, stale branch, and no-follow-up states drive LoopX todos instead of chat memory.
 """
 
 
@@ -556,6 +558,7 @@ def build_loopx_bootstrap_command_pack(
                 f"{shell_arg(cli_bin)} issue-fix workflow-plan "
                 "--url <github-issue-or-pr-url> "
                 "--repo-path <approved-repo> "
+                "--repository-context-json <compact-context.json> "
                 "--validation-label '<validation command>' "
                 "--format json"
             ),
@@ -564,6 +567,7 @@ def build_loopx_bootstrap_command_pack(
                 "--url <github-issue-url> "
                 "--reproduction-status <confirmed|planned|missing|blocked> "
                 "--scope-class <bounded|uncertain|oversized> "
+                "--repository-context-json <compact-context.json> "
                 f"--goal-id {shell_arg(resolved_goal_id)} "
                 "--format json"
             ),

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -833,6 +833,11 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
                 "reason": "guards the public issue-fix workflow contract, gated metadata preview, and todo writeback preview",
             },
             {
+                "command": "python3 examples/issue-fix-repository-context-smoke.py",
+                "tier": "default",
+                "reason": "guards provenance-aware repository context, advisory experts, and feasibility domain-state integration",
+            },
+            {
                 "command": "python3 examples/issue-fix-feasibility-smoke.py",
                 "tier": "default",
                 "reason": "guards single-route feasibility decisions and compact issue_fix domain-state writeback",

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -31,13 +31,13 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "write_boundary": "fixture-only; no external read or write",
             },
             {
-                "command": "loopx issue-fix workflow-plan --url <github-issue-url> --repo-path <repo> --format json",
-                "purpose": "Compose metadata, intake, the feasibility checkpoint, validation labels, and PR review readiness blockers.",
+                "command": "loopx issue-fix workflow-plan --url <github-issue-url> --repo-path <repo> --repository-context-json <context.json> --format json",
+                "purpose": "Compose metadata, repository context, intake, feasibility, validation labels, and PR review readiness blockers.",
                 "write_boundary": "preview-only; no todo write, repo execution, external comment, PR creation, merge, or publish",
             },
             {
-                "command": "loopx issue-fix feasibility --url <github-issue-url> --reproduction-status <state> --scope-class <scope> --goal-id <goal-id> --format json",
-                "purpose": "Select one fix_pr, comment_only, or triage_only route from compact agent observations.",
+                "command": "loopx issue-fix feasibility --url <github-issue-url> --reproduction-status <state> --scope-class <scope> --repository-context-json <context.json> --goal-id <goal-id> --format json",
+                "purpose": "Select one route and persist its compact repository evidence basis with feasibility domain state.",
                 "write_boundary": "writes compact project-local domain state with goal or ledger context; no raw issue/comment/log capture or external write",
             },
             {
@@ -88,6 +88,11 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "doc": "docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md",
             },
             {
+                "schema_version": "issue_fix_repository_context_v0",
+                "module": "loopx.capabilities.issue_fix.repository_context",
+                "doc": "docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md",
+            },
+            {
                 "schema_version": "issue_fix_feasibility_v0",
                 "module": "loopx.capabilities.issue_fix.feasibility",
                 "doc": "docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md",
@@ -115,6 +120,7 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
         ],
         "smokes": [
             "python3 examples/issue-fix-workflow-plan-smoke.py",
+            "python3 examples/issue-fix-repository-context-smoke.py",
             "python3 examples/issue-fix-feasibility-smoke.py",
             "python3 examples/issue-fix-pr-lifecycle-smoke.py",
             "python3 examples/content-ops-issue-fix-metadata-preview-smoke.py",
@@ -123,6 +129,7 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
         ],
         "docs": [
             "docs/capabilities/issue-fix/README.md",
+            "docs/capabilities/issue-fix/openviking-pilot-handoff.md",
             "docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md",
             "docs/capabilities/issue-fix/protocols/issue-fix-acceptance-loop-v0.md",
             "docs/reference/protocols/content-ops-surface-v0.md",

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -132,6 +132,14 @@ def register_issue_fix_commands(
         help="Public-safe validation label stored in the workflow plan.",
     )
     workflow_parser.add_argument(
+        "--repository-context-json",
+        default=None,
+        help=(
+            "Optional issue_fix_repository_context_input_v0 JSON path, or '-' for "
+            "stdin. Only compact source refs, trust, freshness, and coverage are kept."
+        ),
+    )
+    workflow_parser.add_argument(
         "--generated-at",
         default="2026-06-23T00:00:00Z",
         help="Public-safe generated_at timestamp for the workflow plan.",
@@ -186,6 +194,14 @@ def register_issue_fix_commands(
         default="none",
         choices=("none", "clarification", "diagnosis"),
         help="Whether a maintainer-facing comment would add public value.",
+    )
+    feasibility_parser.add_argument(
+        "--repository-context-json",
+        default=None,
+        help=(
+            "Optional issue_fix_repository_context_input_v0 JSON path, or '-' for "
+            "stdin. The compact projection is persisted with feasibility domain state."
+        ),
     )
     feasibility_parser.add_argument(
         "--generated-at",
@@ -426,6 +442,8 @@ def handle_issue_fix_command(
         if args.issue_fix_command == "workflow-plan":
             if args.fetch_metadata and args.metadata_json:
                 raise ValueError("--fetch-metadata cannot be combined with --metadata-json")
+            if args.metadata_json == "-" and args.repository_context_json == "-":
+                raise ValueError("only one JSON input may read from stdin")
             payload = build_issue_fix_workflow_plan_packet(
                 repo=args.repo,
                 issue_ref=args.issue_ref,
@@ -439,6 +457,11 @@ def handle_issue_fix_command(
                 base_branch=args.base_branch,
                 issue_branch=args.issue_branch,
                 validation_label=args.validation_label,
+                repository_context_input=(
+                    _load_json_object(args.repository_context_json)
+                    if args.repository_context_json
+                    else None
+                ),
                 generated_at=args.generated_at,
             )
             renderer = render_issue_fix_workflow_plan_markdown
@@ -452,6 +475,11 @@ def handle_issue_fix_command(
                 reproduction_label=args.reproduction_label,
                 validation_label=args.validation_label,
                 comment_value=args.comment_value,
+                repository_context_input=(
+                    _load_json_object(args.repository_context_json)
+                    if args.repository_context_json
+                    else None
+                ),
                 generated_at=args.generated_at,
             )
             should_write_domain_state = bool(

--- a/loopx/capabilities/issue_fix/feasibility.py
+++ b/loopx/capabilities/issue_fix/feasibility.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from ...control_plane.runtime.public_safety import public_safe_compact_text
 from .metadata_preview import normalise_github_issue_reference
+from .repository_context import build_issue_fix_repository_context_packet
 
 
 ISSUE_FIX_FEASIBILITY_PACKET_SCHEMA_VERSION = "issue_fix_feasibility_v0"
@@ -134,6 +135,32 @@ def _project_transition(
     }
 
 
+def _repository_context_effect(context: Mapping[str, Any]) -> dict[str, Any]:
+    coverage = context.get("coverage") if isinstance(context.get("coverage"), Mapping) else {}
+
+    def refs_for(aspect: str) -> list[str]:
+        row = coverage.get(aspect)
+        return list(row.get("source_refs") or []) if isinstance(row, Mapping) else []
+
+    return {
+        "schema_version": "issue_fix_repository_context_effect_v0",
+        "context_status": context.get("context_status"),
+        "context_fingerprint": context.get("context_fingerprint"),
+        "route_confidence": context.get("context_status"),
+        "change_scope_evidence_refs": refs_for("change_scope"),
+        "reproduction_evidence_refs": refs_for("reproduction"),
+        "validation_evidence_refs": refs_for("validation"),
+        "unresolved_required_aspects": list(
+            context.get("unresolved_required_aspects") or []
+        ),
+        "expert_next_action": (
+            context.get("expert_consultation") or {}
+        ).get("next_action"),
+        "route_overridden": False,
+        "external_write_authorized": False,
+    }
+
+
 def build_issue_fix_feasibility_packet(
     *,
     repo: str = "public_repo_fixture",
@@ -144,6 +171,7 @@ def build_issue_fix_feasibility_packet(
     reproduction_label: str | None = None,
     validation_label: str | None = None,
     comment_value: str = "none",
+    repository_context_input: Mapping[str, Any] | None = None,
     generated_at: str | None = "2026-06-23T00:00:00Z",
 ) -> dict[str, Any]:
     """Select one issue-fix route from compact, public-safe agent observations."""
@@ -159,6 +187,12 @@ def build_issue_fix_feasibility_packet(
         repo=repo,
         issue_ref=issue_ref,
         url=url,
+    )
+    repository_context = build_issue_fix_repository_context_packet(
+        repo=str(reference["repo"]),
+        issue_ref=str(reference["issue_ref"]),
+        context_input=repository_context_input,
+        generated_at=generated_at,
     )
     safe_reproduction_label = _safe_label(
         reproduction_label,
@@ -177,6 +211,9 @@ def build_issue_fix_feasibility_packet(
         validation_label=safe_validation_label,
         comment_value=comment_value,
     )
+    reason_codes.append(
+        f"repository_context_{repository_context['context_status']}"
+    )
     observation = {
         "schema_version": ISSUE_FIX_FEASIBILITY_OBSERVATION_SCHEMA_VERSION,
         "repo": reference["repo"],
@@ -189,6 +226,7 @@ def build_issue_fix_feasibility_packet(
         "scope_class": scope_class,
         "validation_label": safe_validation_label,
         "comment_value": comment_value,
+        "repository_context": repository_context,
         "issue_body_captured": False,
         "comment_bodies_captured": False,
         "raw_logs_captured": False,
@@ -220,6 +258,7 @@ def build_issue_fix_feasibility_packet(
             "reason_codes": reason_codes,
             "observation_fingerprint": fingerprint,
         },
+        "repository_context_effect": _repository_context_effect(repository_context),
         "transition": transition,
         "domain_state_projection": {
             "schema_version": "issue_fix_feasibility_domain_state_projection_v0",
@@ -282,6 +321,25 @@ def validate_issue_fix_feasibility_packet(packet: Mapping[str, Any]) -> dict[str
         transition = {}
     if transition.get("route") != route:
         errors.append("transition route must match the selected route")
+    repository_context = observation.get("repository_context")
+    context_effect = packet.get("repository_context_effect")
+    if repository_context is not None or context_effect is not None:
+        if not isinstance(repository_context, Mapping):
+            errors.append("observation repository_context must be an object when present")
+            repository_context = {}
+        if repository_context.get("ok") is not True:
+            errors.append("observation repository_context must be valid")
+        if not isinstance(context_effect, Mapping):
+            errors.append("repository_context_effect must be an object when present")
+            context_effect = {}
+        if context_effect.get("context_fingerprint") != repository_context.get(
+            "context_fingerprint"
+        ):
+            errors.append("repository context effect fingerprint must match observation")
+        if context_effect.get("route_overridden") is not False:
+            errors.append("repository context must not silently override feasibility route")
+        if context_effect.get("external_write_authorized") is not False:
+            errors.append("repository context must not authorize external writes")
     if route == "fix_pr":
         if observation.get("scope_class") != "bounded":
             errors.append("fix_pr requires bounded scope")
@@ -317,8 +375,11 @@ def render_issue_fix_feasibility_markdown(payload: dict[str, Any]) -> str:
             f"- reproduction_status: `{observation.get('reproduction_status')}`",
             f"- scope_class: `{observation.get('scope_class')}`",
             f"- route: `{decision.get('route')}`",
+            f"- repository_context_status: "
+            f"`{(payload.get('repository_context_effect') or {}).get('context_status')}`",
             f"- transition: `{transition.get('decision')}`",
             f"- external_writes_performed: `{payload.get('external_writes_performed')}`",
-            f"- domain_state_write_performed: `{(payload.get('domain_state_projection') or {}).get('write_performed')}`",
+            f"- domain_state_write_performed: "
+            f"`{(payload.get('domain_state_projection') or {}).get('write_performed')}`",
         ]
     )

--- a/loopx/capabilities/issue_fix/repository_context.py
+++ b/loopx/capabilities/issue_fix/repository_context.py
@@ -1,0 +1,410 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from collections.abc import Mapping, Sequence
+from pathlib import PurePosixPath
+from typing import Any
+from urllib.parse import urlsplit
+
+from ...control_plane.runtime.public_safety import public_safe_compact_text
+
+
+ISSUE_FIX_REPOSITORY_CONTEXT_INPUT_SCHEMA_VERSION = (
+    "issue_fix_repository_context_input_v0"
+)
+ISSUE_FIX_REPOSITORY_CONTEXT_SCHEMA_VERSION = "issue_fix_repository_context_v0"
+
+SOURCE_KINDS = {
+    "repository_policy",
+    "architecture_doc",
+    "maintainer_map",
+    "test_surface",
+    "source_code",
+    "prior_fix",
+    "memory_retrieval",
+    "external_expert",
+    "knowledge_bundle",
+}
+TRUST_LEVELS = {"authoritative", "verified", "advisory"}
+FRESHNESS_STATES = {"current", "stale", "unknown"}
+CONSULTATION_STATES = {"not_applicable", "available", "queried", "unavailable"}
+SUPPORT_ASPECTS = {
+    "architecture",
+    "ownership",
+    "change_scope",
+    "reproduction",
+    "validation",
+}
+REQUIRED_FIX_ASPECTS = ("change_scope", "reproduction", "validation")
+MAX_SOURCES = 16
+
+_SOURCE_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,119}$")
+_INPUT_FIELDS = {"schema_version", "repository_revision", "sources"}
+_SOURCE_FIELDS = {
+    "source_id",
+    "source_kind",
+    "reference",
+    "trust",
+    "freshness",
+    "supports",
+    "summary",
+    "consultation_state",
+}
+_EXPERT_QUESTIONS = {
+    "change_scope": "Which modules and invariants bound this issue?",
+    "reproduction": "What is the smallest repository-native reproduction path?",
+    "validation": "Which focused checks are authoritative for this change?",
+}
+
+
+def _safe_text(value: Any, *, field: str, limit: int = 220) -> str:
+    text = public_safe_compact_text(value, limit=limit)
+    if not text:
+        raise ValueError(f"{field} must be compact and public-safe")
+    return text
+
+
+def _safe_reference(value: Any, *, field: str) -> str:
+    reference = _safe_text(value, field=field, limit=260)
+    if "://" in reference:
+        parsed = urlsplit(reference)
+        if parsed.scheme != "https" or not parsed.netloc or parsed.username:
+            raise ValueError(f"{field} URL must be public https without user info")
+        if parsed.query:
+            raise ValueError(f"{field} URL must not contain query parameters")
+        return reference
+    if reference.startswith(("/", "~")) or re.match(r"^[A-Za-z]:[\\/]", reference):
+        raise ValueError(f"{field} must not be an absolute or home-relative path")
+    path = PurePosixPath(reference)
+    if ".." in path.parts:
+        raise ValueError(f"{field} must not traverse outside the repository")
+    return reference
+
+
+def _normalise_source(raw: Any, *, index: int, has_revision: bool) -> dict[str, Any]:
+    if not isinstance(raw, Mapping):
+        raise ValueError(f"sources[{index}] must be an object")
+    unknown = sorted(set(raw) - _SOURCE_FIELDS)
+    if unknown:
+        raise ValueError(f"sources[{index}] has unsupported fields: {unknown}")
+
+    source_id = _safe_text(raw.get("source_id"), field=f"sources[{index}].source_id")
+    if not _SOURCE_ID_PATTERN.fullmatch(source_id):
+        raise ValueError(f"sources[{index}].source_id has an invalid shape")
+    source_kind = str(raw.get("source_kind") or "").strip()
+    if source_kind not in SOURCE_KINDS:
+        raise ValueError(
+            f"sources[{index}].source_kind must be one of {sorted(SOURCE_KINDS)}"
+        )
+    trust = str(raw.get("trust") or "").strip()
+    if trust not in TRUST_LEVELS:
+        raise ValueError(f"sources[{index}].trust must be one of {sorted(TRUST_LEVELS)}")
+    if source_kind == "external_expert" and trust != "advisory":
+        raise ValueError("external_expert sources must remain advisory")
+    freshness = str(raw.get("freshness") or "unknown").strip()
+    if freshness not in FRESHNESS_STATES:
+        raise ValueError(
+            f"sources[{index}].freshness must be one of {sorted(FRESHNESS_STATES)}"
+        )
+    if freshness == "current" and not has_revision:
+        raise ValueError("current repository context sources require repository_revision")
+
+    raw_supports = raw.get("supports")
+    if not isinstance(raw_supports, Sequence) or isinstance(raw_supports, (str, bytes)):
+        raise ValueError(f"sources[{index}].supports must be a list")
+    supports = sorted({str(value).strip() for value in raw_supports if str(value).strip()})
+    if not supports or any(value not in SUPPORT_ASPECTS for value in supports):
+        raise ValueError(
+            f"sources[{index}].supports must use {sorted(SUPPORT_ASPECTS)}"
+        )
+
+    consultation_state = str(
+        raw.get("consultation_state")
+        or ("available" if source_kind == "external_expert" else "not_applicable")
+    ).strip()
+    if consultation_state not in CONSULTATION_STATES:
+        raise ValueError(
+            f"sources[{index}].consultation_state must be one of "
+            f"{sorted(CONSULTATION_STATES)}"
+        )
+    if source_kind != "external_expert" and consultation_state != "not_applicable":
+        raise ValueError("consultation_state only applies to external_expert sources")
+
+    source: dict[str, Any] = {
+        "schema_version": "issue_fix_repository_context_source_v0",
+        "source_id": source_id,
+        "source_kind": source_kind,
+        "reference": _safe_reference(
+            raw.get("reference"), field=f"sources[{index}].reference"
+        ),
+        "trust": trust,
+        "freshness": freshness,
+        "supports": supports,
+        "consultation_state": consultation_state,
+        "raw_content_captured": False,
+        "raw_response_captured": False,
+    }
+    if raw.get("summary") is not None:
+        source["summary"] = _safe_text(
+            raw.get("summary"), field=f"sources[{index}].summary"
+        )
+    return source
+
+
+def _coverage(sources: Sequence[Mapping[str, Any]]) -> dict[str, dict[str, Any]]:
+    result: dict[str, dict[str, Any]] = {}
+    for aspect in sorted(SUPPORT_ASPECTS):
+        matching = [source for source in sources if aspect in source.get("supports", [])]
+        grounded = [
+            source
+            for source in matching
+            if source.get("freshness") == "current"
+            and source.get("trust") in {"authoritative", "verified"}
+            and source.get("source_kind") != "external_expert"
+        ]
+        status = "grounded" if grounded else "advisory" if matching else "missing"
+        result[aspect] = {
+            "status": status,
+            "source_refs": [source["source_id"] for source in grounded or matching],
+        }
+    return result
+
+
+def _context_status(
+    *, provided: bool, coverage: Mapping[str, Mapping[str, Any]]
+) -> str:
+    if not provided:
+        return "not_provided"
+    statuses = [coverage[aspect]["status"] for aspect in REQUIRED_FIX_ASPECTS]
+    if all(status == "grounded" for status in statuses):
+        return "grounded"
+    if any(status == "grounded" for status in statuses):
+        return "partial"
+    return "ungrounded"
+
+
+def _expert_projection(
+    sources: Sequence[Mapping[str, Any]],
+    unresolved_aspects: Sequence[str],
+) -> dict[str, Any]:
+    experts = [source for source in sources if source.get("source_kind") == "external_expert"]
+    available = [
+        source
+        for source in experts
+        if source.get("consultation_state") in {"available", "queried"}
+    ]
+    queried = [
+        source["source_id"]
+        for source in experts
+        if source.get("consultation_state") == "queried"
+    ]
+    unqueried = [
+        source["source_id"]
+        for source in experts
+        if source.get("consultation_state") == "available"
+    ]
+    if unresolved_aspects and queried:
+        next_action = "verify_queried_answer_against_repository"
+    elif unresolved_aspects and unqueried:
+        next_action = "consult_then_verify_against_repository"
+    elif unresolved_aspects:
+        next_action = "read_repository_sources"
+    else:
+        next_action = "none"
+    return {
+        "schema_version": "issue_fix_repository_expert_consultation_v0",
+        "available": bool(available),
+        "recommended": bool(unresolved_aspects and unqueried),
+        "queried_source_refs": queried,
+        "unqueried_source_refs": unqueried,
+        "questions": [
+            {"aspect": aspect, "question": _EXPERT_QUESTIONS[aspect]}
+            for aspect in unresolved_aspects
+        ],
+        "next_action": next_action,
+        "answer_is_authority": False,
+        "external_write_authorized": False,
+        "raw_response_captured": False,
+    }
+
+
+def build_issue_fix_repository_context_packet(
+    *,
+    repo: str,
+    issue_ref: str,
+    context_input: Mapping[str, Any] | None = None,
+    generated_at: str | None = "2026-06-23T00:00:00Z",
+) -> dict[str, Any]:
+    """Build compact repository knowledge evidence without retrieving or writing it."""
+
+    provided = context_input is not None
+    raw_input: Mapping[str, Any] = context_input or {}
+    if provided:
+        if raw_input.get("schema_version") != ISSUE_FIX_REPOSITORY_CONTEXT_INPUT_SCHEMA_VERSION:
+            raise ValueError(
+                "repository context schema_version must be "
+                "issue_fix_repository_context_input_v0"
+            )
+        unknown = sorted(set(raw_input) - _INPUT_FIELDS)
+        if unknown:
+            raise ValueError(f"repository context has unsupported fields: {unknown}")
+
+    revision_value = raw_input.get("repository_revision")
+    repository_revision = (
+        _safe_text(revision_value, field="repository_revision", limit=120)
+        if revision_value is not None
+        else None
+    )
+    raw_sources = raw_input.get("sources") or []
+    if not isinstance(raw_sources, Sequence) or isinstance(raw_sources, (str, bytes)):
+        raise ValueError("repository context sources must be a list")
+    if len(raw_sources) > MAX_SOURCES:
+        raise ValueError(f"repository context supports at most {MAX_SOURCES} sources")
+    sources = [
+        _normalise_source(raw, index=index, has_revision=bool(repository_revision))
+        for index, raw in enumerate(raw_sources)
+    ]
+    source_ids = [source["source_id"] for source in sources]
+    if len(source_ids) != len(set(source_ids)):
+        raise ValueError("repository context source_id values must be unique")
+
+    coverage = _coverage(sources)
+    unresolved = [
+        aspect
+        for aspect in REQUIRED_FIX_ASPECTS
+        if coverage[aspect]["status"] != "grounded"
+    ]
+    advisory = [
+        aspect
+        for aspect in REQUIRED_FIX_ASPECTS
+        if coverage[aspect]["status"] == "advisory"
+    ]
+    fingerprint = hashlib.sha256(
+        json.dumps(
+            {
+                "repo": repo,
+                "issue_ref": issue_ref,
+                "repository_revision": repository_revision,
+                "sources": sources,
+            },
+            ensure_ascii=True,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+    ).hexdigest()[:16]
+    memory_refs = [
+        source["source_id"]
+        for source in sources
+        if source["source_kind"] == "memory_retrieval"
+    ]
+    bundle_refs = [
+        source["source_id"]
+        for source in sources
+        if source["source_kind"] == "knowledge_bundle"
+    ]
+    packet: dict[str, Any] = {
+        "ok": True,
+        "schema_version": ISSUE_FIX_REPOSITORY_CONTEXT_SCHEMA_VERSION,
+        "mode": "issue-fix-repository-context",
+        "generated_at": generated_at,
+        "repo": _safe_text(repo, field="repo", limit=160),
+        "issue_ref": _safe_text(issue_ref, field="issue_ref", limit=160),
+        "provided": provided,
+        "repository_revision": repository_revision,
+        "context_fingerprint": fingerprint,
+        "context_status": _context_status(provided=provided, coverage=coverage),
+        "sources": sources,
+        "coverage": coverage,
+        "required_fix_aspects": list(REQUIRED_FIX_ASPECTS),
+        "unresolved_required_aspects": unresolved,
+        "advisory_required_aspects": advisory,
+        "recommended_reads": [
+            {
+                "aspect": aspect,
+                "action": f"Ground {aspect} with current repository evidence.",
+            }
+            for aspect in unresolved
+        ],
+        "expert_consultation": _expert_projection(sources, unresolved),
+        "memory_projection": {
+            "schema_version": "issue_fix_repository_memory_projection_v0",
+            "source_refs": memory_refs,
+            "knowledge_bundle_refs": bundle_refs,
+            "live_retrieval_performed": False,
+            "writeback_performed": False,
+            "raw_memory_captured": False,
+            "writeback_policy": (
+                "After a validated outcome, write only distilled reusable facts with "
+                "repository revision, provenance, freshness, and supersession metadata."
+            ),
+        },
+        "truth_contract": {
+            "repository_at_revision_is_primary": True,
+            "memory_requires_repository_verification": True,
+            "external_expert_is_advisory": True,
+            "context_cannot_authorize_external_writes": True,
+        },
+        "external_reads_performed": False,
+        "external_writes_performed": False,
+        "raw_content_captured": False,
+        "raw_responses_captured": False,
+        "raw_logs_captured": False,
+        "local_paths_captured": False,
+        "credentials_captured": False,
+    }
+    validation = validate_issue_fix_repository_context_packet(packet)
+    packet["ok"] = validation["ok"]
+    packet["validation"] = validation
+    return packet
+
+
+def validate_issue_fix_repository_context_packet(
+    packet: Mapping[str, Any],
+) -> dict[str, Any]:
+    errors: list[str] = []
+    if packet.get("schema_version") != ISSUE_FIX_REPOSITORY_CONTEXT_SCHEMA_VERSION:
+        errors.append("packet schema_version must be issue_fix_repository_context_v0")
+    for key in (
+        "external_reads_performed",
+        "external_writes_performed",
+        "raw_content_captured",
+        "raw_responses_captured",
+        "raw_logs_captured",
+        "local_paths_captured",
+        "credentials_captured",
+    ):
+        if packet.get(key) is not False:
+            errors.append(f"packet {key} must be false")
+    if packet.get("context_status") not in {
+        "not_provided",
+        "grounded",
+        "partial",
+        "ungrounded",
+    }:
+        errors.append("packet context_status is invalid")
+    sources = packet.get("sources")
+    if not isinstance(sources, Sequence) or isinstance(sources, (str, bytes)):
+        errors.append("packet sources must be a list")
+        sources = []
+    for source in sources:
+        if not isinstance(source, Mapping):
+            errors.append("packet source entries must be objects")
+            continue
+        if source.get("raw_content_captured") is not False:
+            errors.append("packet sources must not capture raw content")
+        if source.get("raw_response_captured") is not False:
+            errors.append("packet sources must not capture raw responses")
+        if source.get("source_kind") == "external_expert" and source.get("trust") != "advisory":
+            errors.append("external expert sources must remain advisory")
+    truth = packet.get("truth_contract")
+    if not isinstance(truth, Mapping) or truth.get(
+        "context_cannot_authorize_external_writes"
+    ) is not True:
+        errors.append("truth contract must deny context-based external write authority")
+    return {
+        "ok": not errors,
+        "schema_version": "issue_fix_repository_context_validation_v0",
+        "errors": errors,
+    }

--- a/loopx/capabilities/issue_fix/workflow_plan.py
+++ b/loopx/capabilities/issue_fix/workflow_plan.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from .acceptance_loop import build_issue_fix_caller_repo_branch_packet
 from .intake_surface import build_content_ops_issue_fix_metadata_preview_packet
+from .repository_context import build_issue_fix_repository_context_packet
 
 
 ISSUE_FIX_WORKFLOW_PLAN_PACKET_SCHEMA_VERSION = "issue_fix_workflow_plan_packet_v0"
@@ -131,6 +132,7 @@ def _feasibility_checkpoint_plan() -> dict[str, Any]:
             "loopx issue-fix feasibility --url <github-issue-url> "
             "--reproduction-status <confirmed|planned|missing|blocked> "
             "--scope-class <bounded|uncertain|oversized> "
+            "--repository-context-json <compact-context.json> "
             "--goal-id <goal-id> --format json"
         ),
         "input_contract": "compact_public_safe_agent_observation",
@@ -142,6 +144,7 @@ def _feasibility_checkpoint_plan() -> dict[str, Any]:
             "named_validation_surface",
         ],
         "writes_domain_state_by_default_with_goal_id": True,
+        "persists_repository_context_with_feasibility": True,
         "writes_loopx_todo": False,
         "raw_issue_or_log_material_captured": False,
     }
@@ -212,6 +215,7 @@ def build_issue_fix_workflow_plan_packet(
     base_branch: str = "main",
     issue_branch: str | None = None,
     validation_label: str = "caller-declared validation",
+    repository_context_input: Mapping[str, Any] | None = None,
     generated_at: str | None = "2026-06-23T00:00:00Z",
 ) -> dict[str, Any]:
     """Build a public-safe issue-fix workflow plan without writing state."""
@@ -242,6 +246,15 @@ def build_issue_fix_workflow_plan_packet(
 
     repo_label = str(metadata["repo"])
     issue_label = str(metadata["issue_ref"])
+    repository_context = build_issue_fix_repository_context_packet(
+        repo=repo_label,
+        issue_ref=issue_label,
+        context_input=repository_context_input,
+        generated_at=generated_at,
+    )
+    unresolved_context = list(
+        repository_context.get("unresolved_required_aspects") or []
+    )
     resolution_routes = _resolution_route_candidates(
         repo_label=repo_label,
         issue_label=issue_label,
@@ -257,11 +270,14 @@ def build_issue_fix_workflow_plan_packet(
             action_kind="issue_fix_public_metadata_classification",
             text=(
                 f"[P0] Classify {repo_label} {issue_label} from body-free public "
-                "metadata and pick the first safe repro/code-context route."
+                "metadata and compact repository context; ground any missing "
+                "change-scope, reproduction, or validation evidence, or preserve it "
+                "as unresolved before routing."
             ),
             depends_on=[
                 "content_ops_issue_fix_metadata_preview_packet_v0",
                 "issue_fix_intake_v0",
+                "issue_fix_repository_context_v0",
             ],
         ),
         _todo_preview(
@@ -338,9 +354,17 @@ def build_issue_fix_workflow_plan_packet(
         "top_agent_todo": agent_todos[0],
         "top_gate": user_gates[0] if gated_fields else None,
         "next_safe_action": (
-            "write the metadata classification and feasibility checkpoint only; "
-            "then let the feasibility decision project one route-specific "
-            "successor or no-follow-up"
+            (
+                "inspect current repository evidence for "
+                f"{', '.join(unresolved_context)}; ground what is available and "
+                "preserve the rest as unresolved in feasibility instead of guessing"
+            )
+            if unresolved_context
+            else (
+                "use the grounded repository context in the metadata classification "
+                "and feasibility checkpoint; then let feasibility project one "
+                "route-specific successor or no-follow-up"
+            )
         ),
     }
     packet: dict[str, Any] = {
@@ -359,6 +383,7 @@ def build_issue_fix_workflow_plan_packet(
             "body_captured": False,
             "comment_bodies_captured": False,
         },
+        "repository_context": repository_context,
         "first_screen": first_screen,
         "branch_plan": branch_plan,
         "resolution_route_candidates": resolution_routes,
@@ -426,6 +451,21 @@ def validate_issue_fix_workflow_plan_packet(packet: Mapping[str, Any]) -> dict[s
     if branch_plan.get("private_repo_state_read") is not False:
         errors.append("branch_plan private_repo_state_read must be false")
 
+    repository_context = packet.get("repository_context")
+    if repository_context is not None:
+        if not isinstance(repository_context, Mapping):
+            errors.append("repository_context must be an object when present")
+            repository_context = {}
+        if repository_context.get("ok") is not True:
+            errors.append("repository_context must be valid")
+        if repository_context.get("external_writes_performed") is not False:
+            errors.append("repository_context must not perform external writes")
+        truth_contract = repository_context.get("truth_contract")
+        if not isinstance(truth_contract, Mapping) or truth_contract.get(
+            "context_cannot_authorize_external_writes"
+        ) is not True:
+            errors.append("repository_context must deny external-write authority")
+
     routes = packet.get("resolution_route_candidates")
     if not isinstance(routes, Sequence) or isinstance(routes, (str, bytes)):
         errors.append("resolution_route_candidates must be a list")
@@ -457,6 +497,11 @@ def validate_issue_fix_workflow_plan_packet(packet: Mapping[str, Any]) -> dict[s
         errors.append("feasibility checkpoint must select exactly one route")
     if feasibility.get("writes_domain_state_by_default_with_goal_id") is not True:
         errors.append("feasibility checkpoint must default-write domain state")
+    if (
+        packet.get("repository_context") is not None
+        and feasibility.get("persists_repository_context_with_feasibility") is not True
+    ):
+        errors.append("feasibility checkpoint must persist repository context")
     if feasibility.get("writes_loopx_todo") is not False:
         errors.append("feasibility checkpoint must not directly write LoopX todos")
     if feasibility.get("raw_issue_or_log_material_captured") is not False:
@@ -570,6 +615,22 @@ def render_issue_fix_workflow_plan_markdown(payload: dict[str, Any]) -> str:
                 f"- kind: `{issue_signal.get('kind')}`",
                 f"- state: `{issue_signal.get('state')}`",
                 f"- labels: `{issue_signal.get('labels')}`",
+            ]
+        )
+    repository_context = payload.get("repository_context")
+    if isinstance(repository_context, Mapping):
+        lines.extend(
+            [
+                "",
+                "## Repository Context",
+                "",
+                f"- status: `{repository_context.get('context_status')}`",
+                f"- repository_revision: `{repository_context.get('repository_revision')}`",
+                f"- context_fingerprint: `{repository_context.get('context_fingerprint')}`",
+                f"- unresolved_required_aspects: "
+                f"`{repository_context.get('unresolved_required_aspects')}`",
+                f"- expert_next_action: "
+                f"`{(repository_context.get('expert_consultation') or {}).get('next_action')}`",
             ]
         )
     branch = payload.get("branch_plan")


### PR DESCRIPTION
## Summary

- add `issue_fix_repository_context_v0`, a compact revision-pinned evidence model for repository policy, architecture, ownership, change scope, reproduction, validation, memory retrieval, and optional expert consultation
- integrate the optional context into `workflow-plan`, `feasibility`, bootstrap command templates, and the existing feasibility domain-state row without adding a lifecycle state or separate ledger
- add an OpenViking public fixture and pilot handoff covering repository learning, VikingBot consultation, OpenViking memory writeback stages, and an Open Knowledge Format adoption gate

## Design

- current authoritative or verified repository evidence can ground a decision
- stale memory and external experts remain advisory and cannot authorize external writes
- context changes confidence, evidence refs, and next reads, but never silently overrides the existing `fix_pr` / `comment_only` / `triage_only` route
- new fields are additive: legacy v0 workflow and feasibility packets without repository context still validate
- feasibility keeps the compact context in its existing default domain-state writeback

## Validation

- `loopx canary premerge --from-git-diff`: passed, 17 selected/executed checks, 0 failures, 0 warnings, 0 manual holds
- focused issue-fix workflow, feasibility, PR lifecycle, contract, E2E, acceptance, content-ops intake/metadata, OpenViking adapter, bootstrap command-pack, and catalog-planner smokes: passed
- changed Python `py_compile`: passed
- `git diff --check`: passed
- public/private boundary scan: clean across all 17 changed files
- `python3 -m pytest -q`: not run because pytest is not installed in the system Python; repository canonical smoke and premerge suites passed

## Boundaries

- no issue/comment bodies, expert response bodies, raw memory, raw logs, local paths, credentials, benchmark evidence, external comments, PR publication, merge, or production action are captured or performed by the new contract
- the OpenViking revision and all references in the fixture are public

## Merge decision

The premerge gate reports `self_merge_allowed=true`. This is a cohesive issue-fix control-plane contract with focused public smokes and no benchmark, scoring, permission, or production behavior changes.
