### PR TITLE
fix(issue-fix): project authority and PR wait states

### DIFF
--- a/examples/issue-fix-feasibility-smoke.py
+++ b/examples/issue-fix-feasibility-smoke.py
@@ -18,6 +18,9 @@ from loopx.capabilities.issue_fix.feasibility import (  # noqa: E402
     ISSUE_FIX_FEASIBILITY_PACKET_SCHEMA_VERSION,
     build_issue_fix_feasibility_packet,
 )
+from loopx.boundary_authority import (  # noqa: E402
+    build_checkpointed_boundary_authority_entry,
+)
 
 
 URL = "https://github.com/owner/repo/issues/123"
@@ -58,6 +61,13 @@ def main() -> int:
     assert fix["transition"]["projected_todo"]["action_kind"] == (
         "issue_fix_branch_validation"
     ), fix
+    default_gate = fix["transition"]["external_write_gate"]
+    assert default_gate["authorized_before"] == [], default_gate
+    assert default_gate["blocked_before"] == [
+        "external_pr_creation",
+        "merge",
+        "publish",
+    ], default_gate
     assert_boundary(fix)
 
     planned = build_issue_fix_feasibility_packet(
@@ -110,10 +120,35 @@ def main() -> int:
 
     with tempfile.TemporaryDirectory(prefix="loopx-issue-fix-feasibility-") as tmpdir:
         project = Path(tmpdir)
+        registry = project / ".loopx" / "registry.json"
+        registry.parent.mkdir(parents=True, exist_ok=True)
+        authority = build_checkpointed_boundary_authority_entry(
+            write_scopes=["write", "publish"],
+            source="operator approval fixture",
+            decision_id="public-fix-pr-pilot",
+            recorded_at="2026-07-10T00:00:00+00:00",
+        )
+        registry.write_text(
+            json.dumps(
+                {
+                    "goals": [
+                        {
+                            "id": "pilot-goal",
+                            "coordination": {
+                                "checkpointed_boundary_authority": [authority]
+                            },
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
         command = [
             sys.executable,
             "-m",
             "loopx.cli",
+            "--registry",
+            str(registry),
             "--format",
             "json",
             "issue-fix",
@@ -143,6 +178,15 @@ def main() -> int:
         )
         first_packet = json.loads(first.stdout)
         assert first_packet["domain_state_projection"]["write_performed"] is True
+        gate = first_packet["transition"]["external_write_gate"]
+        assert gate["authority_projection_resolved"] is True, gate
+        assert gate["authority_source"] == "goal_checkpointed_boundary_authority", gate
+        assert gate["authorized_before"] == [
+            "external_pr_creation",
+            "publish",
+        ], gate
+        assert gate["blocked_before"] == ["merge"], gate
+        assert gate["satisfied"] is False, gate
         ledger = (
             project
             / ".loopx"

--- a/examples/issue-fix-pr-lifecycle-smoke.py
+++ b/examples/issue-fix-pr-lifecycle-smoke.py
@@ -139,6 +139,37 @@ def main() -> int:
     assert requested["transition"]["decision"] == "runnable_successor", requested
     assert requested["transition"]["action_kind"] == "issue_fix_review_changes_replan"
 
+    blocked_pending = build_issue_fix_pr_lifecycle_monitor_packet(
+        url="https://github.com/huangruiteng/loopx/pull/1715",
+        provider_payload={
+            "state": "OPEN",
+            "reviewDecision": "REVIEW_REQUIRED",
+            "mergeStateStatus": "BLOCKED",
+            "statusCheckRollup": [{"name": "lint", "status": "IN_PROGRESS"}],
+        },
+    )
+    assert_packet_shape(blocked_pending)
+    assert blocked_pending["transition"]["decision"] == "monitor_continuation"
+    assert blocked_pending["transition"]["action_kind"] == (
+        "issue_fix_pr_checks_pending_monitor"
+    )
+    assert blocked_pending["transition"]["material_change"] is False
+
+    stale = build_issue_fix_pr_lifecycle_monitor_packet(
+        url="https://github.com/huangruiteng/loopx/pull/1715",
+        provider_payload={
+            "state": "OPEN",
+            "reviewDecision": "REVIEW_REQUIRED",
+            "mergeStateStatus": "BEHIND",
+            "statusCheckRollup": [{"name": "lint", "conclusion": "SUCCESS"}],
+        },
+    )
+    assert_packet_shape(stale)
+    assert stale["transition"]["decision"] == "runnable_successor"
+    assert stale["transition"]["action_kind"] == (
+        "issue_fix_branch_or_merge_blocker_replan"
+    )
+
     quiet = build_issue_fix_pr_lifecycle_monitor_packet(
         url="https://github.com/huangruiteng/loopx/pull/1715",
         provider_payload={

--- a/examples/issue-fix-pr-lifecycle-smoke.py
+++ b/examples/issue-fix-pr-lifecycle-smoke.py
@@ -207,8 +207,15 @@ def main() -> int:
         assert key == {"repo": "huangruiteng/loopx", "pr_ref": "pull_1715"}
         result = upsert_issue_fix_pr_lifecycle_ledger_jsonl(ledger, quiet)
         assert result["status"] == "inserted", result
+        first_inode = ledger.stat().st_ino
         result = upsert_issue_fix_pr_lifecycle_ledger_jsonl(ledger, quiet)
-        assert result["status"] == "updated", result
+        assert result["status"] == "unchanged", result
+        assert result["write_performed"] is False, result
+        assert ledger.stat().st_ino == first_inode
+        assert quiet["domain_state_projection"]["write_performed"] is False, quiet
+        assert quiet["domain_state_projection"]["write_skipped_reason"] == (
+            "observation_fingerprint_unchanged"
+        ), quiet
         rows = [json.loads(line) for line in ledger.read_text(encoding="utf-8").splitlines()]
         assert len(rows) == 1, rows
         assert rows[0]["domain_state_key"] == key, rows
@@ -242,8 +249,11 @@ def main() -> int:
         )
         cli_packet = json.loads(cli_result.stdout)
         assert_packet_shape(cli_packet)
-        assert cli_packet["domain_state_projection"]["write_performed"] is True
+        assert cli_packet["domain_state_projection"]["write_performed"] is False
         write_result = cli_packet["domain_state_projection"]["write_result"]
+        assert write_result["status"] == "unchanged", write_result
+        assert write_result["write_performed"] is False, write_result
+        assert ledger.stat().st_ino == first_inode
         assert write_result["path_recorded"] is False, write_result
         persisted_rows = [
             json.loads(line) for line in ledger.read_text(encoding="utf-8").splitlines()
@@ -253,6 +263,12 @@ def main() -> int:
         assert persisted_projection["write_performed"] is True, persisted_rows[0]
         assert "write_result" not in persisted_projection, persisted_rows[0]
         assert_public_safe(cli_packet)
+
+        material_result = upsert_issue_fix_pr_lifecycle_ledger_jsonl(ledger, failing)
+        assert material_result["status"] == "updated", material_result
+        assert material_result["write_performed"] is True, material_result
+        assert failing["domain_state_projection"]["write_performed"] is True, failing
+        assert ledger.stat().st_ino != first_inode
 
     print("issue-fix-pr-lifecycle-smoke: ok")
     return 0

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -7,6 +7,8 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from ...agent_registry import load_goal_from_registry
+from ...boundary_authority import checkpointed_boundary_authority_summary
 from ...domain_packs.issue_fix import (
     default_issue_fix_domain_state_ledger_path,
     default_issue_fix_feasibility_ledger_path,
@@ -49,6 +51,30 @@ def _load_json_object(path_text: str) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise ValueError(f"{path_text} must contain a JSON object")
     return payload
+
+
+def _goal_boundary_authority_projection(
+    *,
+    registry_path: Path | None,
+    goal_id: str | None,
+) -> tuple[list[str], bool]:
+    if registry_path is None or not goal_id:
+        return [], False
+    goal = load_goal_from_registry(registry_path, goal_id)
+    if not isinstance(goal, dict):
+        return [], False
+    coordination = (
+        goal.get("coordination")
+        if isinstance(goal.get("coordination"), dict)
+        else {}
+    )
+    summary = checkpointed_boundary_authority_summary(coordination)
+    scopes = (
+        list(summary.get("active_write_scope") or [])
+        if isinstance(summary, dict)
+        else []
+    )
+    return [str(scope) for scope in scopes], True
 
 
 def register_issue_fix_commands(
@@ -435,6 +461,7 @@ def register_issue_fix_commands(
 def handle_issue_fix_command(
     args: argparse.Namespace,
     *,
+    registry_path: Path | None = None,
     output_format: FormatSelector,
     print_payload: PrintPayload,
 ) -> int:
@@ -466,6 +493,12 @@ def handle_issue_fix_command(
             )
             renderer = render_issue_fix_workflow_plan_markdown
         elif args.issue_fix_command == "feasibility":
+            boundary_authority_scopes, boundary_authority_resolved = (
+                _goal_boundary_authority_projection(
+                    registry_path=registry_path,
+                    goal_id=args.goal_id,
+                )
+            )
             payload = build_issue_fix_feasibility_packet(
                 repo=args.repo,
                 issue_ref=args.issue_ref,
@@ -480,6 +513,8 @@ def handle_issue_fix_command(
                     if args.repository_context_json
                     else None
                 ),
+                boundary_authority_scopes=boundary_authority_scopes,
+                boundary_authority_resolved=boundary_authority_resolved,
                 generated_at=args.generated_at,
             )
             should_write_domain_state = bool(

--- a/loopx/capabilities/issue_fix/feasibility.py
+++ b/loopx/capabilities/issue_fix/feasibility.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import Any
 
 from ...control_plane.runtime.public_safety import public_safe_compact_text
@@ -20,6 +20,12 @@ REPRODUCTION_STATES = {"confirmed", "planned", "missing", "blocked"}
 SCOPE_CLASSES = {"bounded", "uncertain", "oversized"}
 COMMENT_VALUES = {"none", "clarification", "diagnosis"}
 RESOLUTION_ROUTES = {"fix_pr", "comment_only", "triage_only"}
+EXTERNAL_ACTION_AUTHORITY_SCOPE_ALIASES = {
+    "external_pr_creation": {"external_pr_creation", "publish"},
+    "external_issue_comment": {"external_issue_comment", "publish"},
+    "merge": {"merge"},
+    "publish": {"publish"},
+}
 
 
 def _safe_label(value: str | None, *, field: str, required: bool = False) -> str | None:
@@ -70,6 +76,8 @@ def _project_transition(
     repo: str,
     issue_ref: str,
     reproduction_status: str,
+    boundary_authority_scopes: Sequence[str],
+    boundary_authority_resolved: bool,
 ) -> dict[str, Any]:
     base = {
         "schema_version": "issue_fix_feasibility_transition_v0",
@@ -99,10 +107,11 @@ def _project_transition(
                 "would_write": False,
                 "requires_execute_flag": True,
             },
-            "external_write_gate": {
-                "required_before": ["external_pr_creation", "merge", "publish"],
-                "satisfied": False,
-            },
+            "external_write_gate": _project_external_write_gate(
+                required_before=["external_pr_creation", "merge", "publish"],
+                boundary_authority_scopes=boundary_authority_scopes,
+                boundary_authority_resolved=boundary_authority_resolved,
+            ),
             "no_followup": False,
         }
     if route == "comment_only":
@@ -121,10 +130,11 @@ def _project_transition(
                 "would_write": False,
                 "requires_execute_flag": True,
             },
-            "external_write_gate": {
-                "required_before": ["external_issue_comment"],
-                "satisfied": False,
-            },
+            "external_write_gate": _project_external_write_gate(
+                required_before=["external_issue_comment"],
+                boundary_authority_scopes=boundary_authority_scopes,
+                boundary_authority_resolved=boundary_authority_resolved,
+            ),
             "no_followup": False,
         }
     return base | {
@@ -132,6 +142,40 @@ def _project_transition(
         "projected_todo": None,
         "external_write_gate": None,
         "no_followup": True,
+    }
+
+
+def _project_external_write_gate(
+    *,
+    required_before: Sequence[str],
+    boundary_authority_scopes: Sequence[str],
+    boundary_authority_resolved: bool,
+) -> dict[str, Any]:
+    active_scopes = {
+        str(scope).strip()
+        for scope in boundary_authority_scopes
+        if str(scope).strip()
+    }
+    required = [str(action) for action in required_before]
+    authorized = [
+        action
+        for action in required
+        if EXTERNAL_ACTION_AUTHORITY_SCOPE_ALIASES.get(action, {action})
+        & active_scopes
+    ]
+    blocked = [action for action in required if action not in authorized]
+    return {
+        "schema_version": "issue_fix_external_write_gate_v0",
+        "required_before": required,
+        "authorized_before": authorized,
+        "blocked_before": blocked,
+        "satisfied": not blocked,
+        "authority_projection_resolved": boundary_authority_resolved,
+        "authority_source": (
+            "goal_checkpointed_boundary_authority"
+            if boundary_authority_resolved
+            else "not_available"
+        ),
     }
 
 
@@ -172,6 +216,8 @@ def build_issue_fix_feasibility_packet(
     validation_label: str | None = None,
     comment_value: str = "none",
     repository_context_input: Mapping[str, Any] | None = None,
+    boundary_authority_scopes: Sequence[str] = (),
+    boundary_authority_resolved: bool = False,
     generated_at: str | None = "2026-06-23T00:00:00Z",
 ) -> dict[str, Any]:
     """Select one issue-fix route from compact, public-safe agent observations."""
@@ -237,6 +283,8 @@ def build_issue_fix_feasibility_packet(
         repo=str(reference["repo"]),
         issue_ref=str(reference["issue_ref"]),
         reproduction_status=reproduction_status,
+        boundary_authority_scopes=boundary_authority_scopes,
+        boundary_authority_resolved=boundary_authority_resolved,
     )
     fingerprint = hashlib.sha256(
         json.dumps(
@@ -353,6 +401,24 @@ def validate_issue_fix_feasibility_packet(packet: Mapping[str, Any]) -> dict[str
         errors.append("comment_only requires a useful comment value")
     if route == "triage_only" and transition.get("no_followup") is not True:
         errors.append("triage_only must project no_followup")
+    gate = transition.get("external_write_gate")
+    if route in {"fix_pr", "comment_only"}:
+        if not isinstance(gate, Mapping):
+            errors.append("runnable external-write route requires a gate projection")
+        else:
+            required = list(gate.get("required_before") or [])
+            authorized = list(gate.get("authorized_before") or [])
+            blocked = list(gate.get("blocked_before") or [])
+            if (
+                any(
+                    (action in authorized) == (action in blocked)
+                    for action in required
+                )
+                or any(action not in required for action in authorized + blocked)
+            ):
+                errors.append("external-write gate must partition required actions")
+            if gate.get("satisfied") is not (not blocked):
+                errors.append("external-write gate satisfied must match blocked actions")
 
     return {
         "ok": not errors,

--- a/loopx/capabilities/issue_fix/pr_lifecycle.py
+++ b/loopx/capabilities/issue_fix/pr_lifecycle.py
@@ -33,7 +33,7 @@ PENDING_CHECK_STATES = {
     "WAITING",
 }
 PASSING_CHECK_STATES = {"NEUTRAL", "SKIPPED", "SUCCESS"}
-BRANCH_BLOCKED_MERGE_STATES = {"BEHIND", "BLOCKED", "DIRTY", "UNKNOWN"}
+BRANCH_REPLAN_MERGE_STATES = {"BEHIND", "DIRTY"}
 
 
 def _upper_label(value: Any, default: str = "UNKNOWN") -> str:
@@ -266,13 +266,13 @@ def _decide_transition(observation: Mapping[str, Any]) -> dict[str, Any]:
             "terminal_state_precedence": False,
             "material_change": True,
         }
-    if merge_state in BRANCH_BLOCKED_MERGE_STATES:
+    if merge_state in BRANCH_REPLAN_MERGE_STATES:
         return _transition_preview(
             decision="runnable_successor",
             action_kind="issue_fix_branch_or_merge_blocker_replan",
             priority="P1",
             task_class="advancement_task",
-            reason="PR merge state is blocked or stale; decide rebase, blocker note, or no-follow-up.",
+            reason="PR branch is stale or conflicted; decide rebase, blocker note, or no-follow-up.",
             depends_on=["issue_fix_pr_lifecycle_monitor"],
         ) | {
             "terminal_state_precedence": False,

--- a/loopx/cli.py
+++ b/loopx/cli.py
@@ -343,7 +343,12 @@ def main(argv: list[str] | None = None) -> int:
         return handle_content_ops_command(args, output_format=output_format, print_payload=print_payload)
 
     if args.command == "issue-fix":
-        return handle_issue_fix_command(args, output_format=output_format, print_payload=print_payload)
+        return handle_issue_fix_command(
+            args,
+            registry_path=registry_path,
+            output_format=output_format,
+            print_payload=print_payload,
+        )
 
     if args.command == "value-connectors":
         return handle_value_connector_command(args, output_format=output_format, print_payload=print_payload)

--- a/loopx/domain_packs/issue_fix.py
+++ b/loopx/domain_packs/issue_fix.py
@@ -17,6 +17,7 @@ def _upsert_issue_fix_payload(
     *,
     key: dict[str, Any],
     existing_key_fn: Callable[[dict[str, Any]], dict[str, Any] | None],
+    unchanged_fn: Callable[[dict[str, Any], dict[str, Any]], bool] | None = None,
 ) -> dict[str, Any]:
     projection = payload.get("domain_state_projection")
     if not isinstance(projection, dict):
@@ -31,10 +32,14 @@ def _upsert_issue_fix_payload(
             payload,
             key=key,
             existing_key_fn=existing_key_fn,
+            unchanged_fn=unchanged_fn,
         )
     except Exception:
         projection["write_performed"] = False
         raise
+    if result.get("write_performed") is False:
+        projection["write_performed"] = False
+        projection["write_skipped_reason"] = "observation_fingerprint_unchanged"
     projection["write_result"] = result
     return result
 
@@ -109,11 +114,30 @@ def upsert_issue_fix_pr_lifecycle_ledger_jsonl(
     ):
         if payload.get(key) is not False:
             raise ValueError(f"issue-fix domain-state payload must keep {key}=false")
+    def unchanged_quiet_observation(
+        existing: dict[str, Any],
+        incoming: dict[str, Any],
+    ) -> bool:
+        existing_fingerprint = str(existing.get("observation_fingerprint") or "")
+        incoming_fingerprint = str(incoming.get("observation_fingerprint") or "")
+        transition = incoming.get("transition")
+        material_change = (
+            transition.get("material_change")
+            if isinstance(transition, dict)
+            else None
+        )
+        return bool(
+            existing_fingerprint
+            and existing_fingerprint == incoming_fingerprint
+            and material_change is False
+        )
+
     return _upsert_issue_fix_payload(
         ledger_path,
         payload,
         key=issue_fix_pr_lifecycle_ledger_key(payload),
         existing_key_fn=issue_fix_pr_lifecycle_ledger_key,
+        unchanged_fn=unchanged_quiet_observation,
     )
 
 

--- a/loopx/domain_state.py
+++ b/loopx/domain_state.py
@@ -55,6 +55,7 @@ def upsert_domain_state_jsonl(
     *,
     key: dict[str, Any],
     existing_key_fn: Callable[[dict[str, Any]], dict[str, Any] | None] | None = None,
+    unchanged_fn: Callable[[dict[str, Any], dict[str, Any]], bool] | None = None,
 ) -> dict[str, Any]:
     """Upsert a payload into a JSONL domain-state file by stable key."""
 
@@ -69,6 +70,8 @@ def upsert_domain_state_jsonl(
         try:
             rows: list[dict[str, Any]] = []
             updated = False
+            unchanged = False
+            candidate = {**payload, "domain_state_key": key}
             if path.exists():
                 for index, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
                     if not line.strip():
@@ -82,34 +85,40 @@ def upsert_domain_state_jsonl(
                         row_key = existing_key_fn(row)
                     if isinstance(row, dict) and row_key == key:
                         if not updated:
-                            rows.append({**payload, "domain_state_key": key})
+                            if unchanged_fn is not None and unchanged_fn(row, candidate):
+                                rows.append(row)
+                                unchanged = True
+                            else:
+                                rows.append(candidate)
                             updated = True
                         continue
                     rows.append(row)
             if not updated:
-                rows.append({**payload, "domain_state_key": key})
+                rows.append(candidate)
 
-            with tempfile.NamedTemporaryFile(
-                "w",
-                encoding="utf-8",
-                dir=path.parent,
-                prefix=f"{path.name}.",
-                suffix=".tmp",
-                delete=False,
-            ) as tmp_file:
-                tmp_name = tmp_file.name
-                tmp_file.write(
-                    "".join(
-                        json.dumps(row, sort_keys=True, ensure_ascii=False) + "\n"
-                        for row in rows
+            if not unchanged:
+                with tempfile.NamedTemporaryFile(
+                    "w",
+                    encoding="utf-8",
+                    dir=path.parent,
+                    prefix=f"{path.name}.",
+                    suffix=".tmp",
+                    delete=False,
+                ) as tmp_file:
+                    tmp_name = tmp_file.name
+                    tmp_file.write(
+                        "".join(
+                            json.dumps(row, sort_keys=True, ensure_ascii=False) + "\n"
+                            for row in rows
+                        )
                     )
-                )
-            os.replace(tmp_name, path)
+                os.replace(tmp_name, path)
         finally:
             if fcntl is not None:
                 fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)
     return {
-        "status": "updated" if updated else "inserted",
+        "status": "unchanged" if unchanged else "updated" if updated else "inserted",
+        "write_performed": not unchanged,
         "row_count": len(rows),
         "ledger_key": key,
         "path_recorded": False,


### PR DESCRIPTION
## Motivation

A real public issue-fix pilot exposed three control-plane ambiguities:

- feasibility reported a single unsatisfied external-write gate even when checkpointed goal authority already allowed PR publication but not merge;
- GitHub merge state `BLOCKED` was treated as a stale/conflicted branch even when the PR was mergeable and only waiting for required checks or review;
- identical quiet monitor polls rewrote domain state despite `material_change=false`.

## Implementation

- Resolve active checkpointed boundary authority for `issue-fix feasibility --goal-id` from the selected registry.
- Project external-write gates per action with `authorized_before` and `blocked_before`; `publish` can authorize PR creation/publication while `merge` remains independently gated.
- Reserve branch-replan transitions for `BEHIND` and `DIRTY`; keep policy-blocked or not-yet-computed PRs on the normal CI/review monitor path.
- Add an optional locked domain-state unchanged predicate and use it for lifecycle packets: an identical observation fingerprint with `material_change=false` returns `status=unchanged`, reports no write, and does not replace the ledger file.
- Add generic contract fixtures for all three behaviors. No repository-specific adapter or special case is introduced.

## Validation

- `python3 examples/issue-fix-feasibility-smoke.py`
- `python3 examples/issue-fix-pr-lifecycle-smoke.py`
- changed-file `py_compile`
- `loopx canary premerge --from-git-diff --format json --no-progress` (passed: 4 direct checks and 8 selected checks)
- public-boundary scan (clean)
- live public pilot replay: PR publication projected authorized, merge projected blocked; `OPEN + BLOCKED + pending checks` projected `monitor_continuation`; repeated fingerprints projected `unchanged` with `write_performed=false`

## Risk and gaps

The change enriches the existing feasibility gate, narrows an over-broad PR lifecycle classification, and adds opt-in idempotence to the existing locked domain-state upsert. Existing callers keep their current overwrite behavior unless they pass an unchanged predicate. Existing aggregate gate `satisfied` semantics remain intact. Merge is never inferred from `publish` authority. No external write is performed by these projections.