### PR TITLE
Make Explore Harness configurable and resumable

### DIFF
--- a/docs/capabilities/explore/README.md
+++ b/docs/capabilities/explore/README.md
@@ -153,6 +153,22 @@ spawn_policy:
     profile: generic      # optional pin; overrides the CLI-requested profile
 ```
 
+Use the incremental configuration path instead of editing the registry:
+
+```bash
+loopx configure-goal \
+  --goal-id <id> \
+  --explore-harness-enabled \
+  --explore-harness-profile adaptive-resilient \
+  --execute
+```
+
+This is analysis-only while spawn permission remains disabled. Use
+`--no-explore-harness-enabled` to close the gate again, or
+`--clear-explore-harness-profile` to let each planner request its own profile.
+Preview without `--execute` shows the exact orchestration delta and preserves
+unrelated `spawn_policy` keys.
+
 The planner folds this boundary into an `orchestration_gate` section of the
 packet and behaves as follows:
 
@@ -205,6 +221,11 @@ It deliberately does not control segment duration, does not force N=10, does
 not saturate every available branch, and does not enable the earlier
 coverage-floor calibration arm by default. Those remain runner or future-experiment decisions, not part of
 the generalized harness design.
+
+Retry/backoff and infrastructure cooldown are planner metadata for an external
+runner; the generic runtime does not enforce them. Runtime results expose this
+boundary explicitly instead of implying that selecting the profile activates a
+hidden retry loop.
 
 ```text
 loopx explore worker-branch-plan \
@@ -273,6 +294,25 @@ Without `--router-state` the profile still plans (router disabled, cold
 static scoring); passing state to a non-router profile is ignored, which
 keeps `adaptive-resilient` clean as the B-min ablation arm.
 
+### Runtime Restart And Item Failures
+
+`run_budget_arm` can write an atomic epoch-boundary checkpoint manifest.
+Restart is opt-in: start an arm with `resumable=True` (or an explicit
+`checkpoint_path`), then pass `resume=True` to restore completed epochs,
+novelty keys, router state, catalog consumption,
+cumulative metrics, coverage timestamps, and the next epoch. Missing, corrupt,
+or runtime-incompatible manifests fail closed with a concrete `ValueError`;
+loose rolling progress files are observability only and are never restart
+authority.
+
+Adapter exceptions default to the `record` item failure policy: the failed item
+becomes a zero-value structured observation and independent queue lanes keep
+running. Concurrency keys are released in every path. Pass
+`item_failure_policy="fatal"`, or set the adapter's `item_failure_policy`
+attribute to `"fatal"`, to retain exception propagation. These policies isolate
+work-item failures; they do not implement the planner profile's retry/backoff or
+cooldown guidance.
+
 ## Presentation Sink: Lark Mapping
 
 | LoopX concept | Lark surface |
@@ -332,6 +372,7 @@ operator permits the write.
 
 ```bash
 python3 examples/explore-result-layer-smoke.py
+python3 examples/explore-harness-runtime-resume-smoke.py
 ```
 
 The smoke proves the projection contract (folding, blocked reasons, tree,

--- a/examples/canary/catalog-planner-smoke.py
+++ b/examples/canary/catalog-planner-smoke.py
@@ -610,6 +610,24 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     assert all(check["tier"] == "default" for check in auto_research_profile["checks"]), auto_research_profile
     assert auto_research_profile["deep_checks_available"] is True, auto_research_profile
 
+    explore_payload = build_catalog_canary_plan(
+        changed_files=[
+            "loopx/capabilities/explore/harness_runtime.py",
+            "loopx/configure_goal.py",
+        ],
+        surfaces=["explore harness resume configure-goal"],
+    )
+    explore_profiles = {
+        profile["id"]: profile for profile in explore_payload["domain_profiles"]
+    }
+    assert "explore-harness" in explore_profiles, explore_payload
+    explore_profile = explore_profiles["explore-harness"]
+    explore_commands = [check["command"] for check in explore_profile["checks"]]
+    assert "python3 examples/explore-configure-goal-smoke.py" in explore_commands
+    assert "python3 examples/explore-harness-runtime-resume-smoke.py" in explore_commands
+    assert "python3 examples/explore-worker-plan-gate-smoke.py" in explore_commands
+    assert explore_profile["deep_checks_available"] is True, explore_profile
+
 
 def assert_explicit_profile_can_include_deep_checks() -> None:
     payload = build_catalog_canary_plan(

--- a/examples/explore-configure-goal-smoke.py
+++ b/examples/explore-configure-goal-smoke.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""Smoke configure-goal as the Explore Harness opt-in authority."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+GOAL_ID = "explore-configure-fixture"
+
+
+def run_cli(registry: Path, runtime_root: Path, *args: str, check: bool = True) -> dict:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "--registry",
+            str(registry),
+            "--runtime-root",
+            str(runtime_root),
+            *args,
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    if check and result.returncode:
+        raise AssertionError(
+            f"loopx CLI failed ({result.returncode}): {' '.join(args)}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+    return json.loads(result.stdout)
+
+
+def write_fixture(root: Path) -> tuple[Path, Path]:
+    project = root / "project"
+    state_file = project / ".codex/goals/explore-configure-fixture/ACTIVE_GOAL_STATE.md"
+    state_file.parent.mkdir(parents=True)
+    state_file.write_text(
+        "---\n"
+        "status: active\n"
+        "updated_at: 2026-01-01T00:00:00+00:00\n"
+        "---\n\n"
+        "# Explore Configure Fixture\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] [P0] Probe the alpha route.\n"
+        "  <!-- loopx:todo todo_id=todo_probe_alpha status=open "
+        "task_class=advancement_task required_write_scopes=artifacts/alpha/** -->\n",
+        encoding="utf-8",
+    )
+    registry = root / "registry.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "updated_at": "2026-01-01T00:00:00+00:00",
+                "common_runtime_root": str(root / "runtime"),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "status": "active",
+                        "repo": str(project),
+                        "state_file": str(state_file.relative_to(project)),
+                        "adapter": {"kind": "explore_result_layer", "status": "connected"},
+                        "quota": {"compute": 1, "window_hours": 24},
+                        "spawn_policy": {
+                            "mode": "default",
+                            "allowed": False,
+                            "max_children": 0,
+                            "policy_note": "preserve-me",
+                        },
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    return registry, root / "runtime"
+
+
+def goal(registry: Path) -> dict:
+    return json.loads(registry.read_text(encoding="utf-8"))["goals"][0]
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-explore-configure-") as tmp:
+        registry, runtime_root = write_fixture(Path(tmp))
+        original = registry.read_text(encoding="utf-8")
+
+        disabled = run_cli(
+            registry,
+            runtime_root,
+            "explore",
+            "worker-branch-plan",
+            "--goal-id",
+            GOAL_ID,
+        )
+        assert disabled["orchestration_gate"]["state"] == "disabled", disabled
+
+        clear_absent = run_cli(
+            registry,
+            runtime_root,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--clear-explore-harness-profile",
+        )
+        assert clear_absent["changed"] is False, clear_absent
+
+        preview = run_cli(
+            registry,
+            runtime_root,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--explore-harness-enabled",
+            "--explore-harness-profile",
+            "moe-router",
+        )
+        assert preview["dry_run"] is True and preview["written"] is False, preview
+        assert preview["after"]["orchestration"]["spawn_allowed"] is False, preview
+        assert preview["feature_summary"]["explore_harness"] == {
+            "enabled": True,
+            "profile": "moe-router",
+        }, preview
+        assert registry.read_text(encoding="utf-8") == original
+
+        applied = run_cli(
+            registry,
+            runtime_root,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--explore-harness-enabled",
+            "--explore-harness-profile",
+            "moe-router",
+            "--execute",
+        )
+        assert applied["written"] is True, applied
+        configured = goal(registry)["spawn_policy"]
+        assert configured["policy_note"] == "preserve-me", configured
+        assert configured["allowed"] is False, configured
+        assert configured["explore_harness"] == {
+            "enabled": True,
+            "profile": "moe-router",
+        }, configured
+
+        quota = run_cli(
+            registry,
+            runtime_root,
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            check=False,
+        )
+        assert quota["ok"] is False and quota["status_health_ok"] is False, quota
+        boundary = quota["goal_boundary"]["orchestration"]
+        assert boundary["explore_harness"] == configured["explore_harness"], boundary
+
+        worker = run_cli(
+            registry,
+            runtime_root,
+            "explore",
+            "worker-branch-plan",
+            "--goal-id",
+            GOAL_ID,
+            "--harness-profile",
+            "generic",
+        )
+        assert worker["orchestration_gate"]["state"] == "analysis_only", worker
+        assert worker["orchestration_gate"]["effective_profile"] == "moe-router", worker
+        assert worker["orchestration_gate"]["profile_source"] == "goal_boundary", worker
+
+        todo = run_cli(
+            registry,
+            runtime_root,
+            "explore",
+            "todo-branch-plan",
+            "--goal-id",
+            GOAL_ID,
+        )
+        assert todo["orchestration_gate"]["state"] == "analysis_only", todo
+        assert todo["orchestration_gate"]["goal_pinned_profile"] == "moe-router", todo
+
+        cleared = run_cli(
+            registry,
+            runtime_root,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--clear-explore-harness-profile",
+            "--execute",
+        )
+        assert cleared["written"] is True, cleared
+        assert goal(registry)["spawn_policy"]["explore_harness"] == {"enabled": True}
+
+        closed = run_cli(
+            registry,
+            runtime_root,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--no-explore-harness-enabled",
+            "--execute",
+        )
+        assert closed["written"] is True, closed
+        assert goal(registry)["spawn_policy"]["explore_harness"] == {"enabled": False}
+
+        conflict = run_cli(
+            registry,
+            runtime_root,
+            "configure-goal",
+            "--goal-id",
+            GOAL_ID,
+            "--explore-harness-profile",
+            "generic",
+            "--clear-explore-harness-profile",
+            check=False,
+        )
+        assert conflict["ok"] is False, conflict
+        assert "cannot be combined" in conflict["error"], conflict
+
+    print("explore-configure-goal-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/explore-harness-runtime-resume-smoke.py
+++ b/examples/explore-harness-runtime-resume-smoke.py
@@ -1,0 +1,279 @@
+#!/usr/bin/env python3
+"""Smoke the Explore Harness restart and per-item failure contracts."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.capabilities.explore.harness_runtime import (  # noqa: E402
+    HARNESS_CHECKPOINT_SCHEMA_VERSION,
+    ITEM_FAILURE_POLICY_FATAL,
+    run_budget_arm,
+    run_queue_epoch,
+)
+
+
+class SyntheticRetryableError(RuntimeError):
+    retryable_infra_error = True
+
+
+class ResumeAdapter:
+    def __init__(self) -> None:
+        self.executed: list[str] = []
+
+    def list_seed_items(self) -> list[dict]:
+        return [
+            {
+                "item_id": "seed-alpha",
+                "text": "Probe alpha",
+                "family": "alpha",
+                "concurrency_key": "alpha",
+            }
+        ]
+
+    def compile_variant(self, spec: dict, seed_item: dict) -> dict:
+        spec_id = str(spec["spec_id"])
+        return {
+            "item_id": f"variant-{spec_id}",
+            "text": spec.get("intent"),
+            "family": seed_item["family"],
+            "concurrency_key": f"alpha:{spec_id}",
+        }
+
+    def execute(self, item: dict, **_: object) -> dict:
+        item_id = str(item["item_id"])
+        self.executed.append(item_id)
+        return {
+            "item_id": item_id,
+            "family": item["family"],
+            "observation_keys": ["shared-observation"],
+            "weighted_flags": {},
+            "accepted": True,
+            "duration_minutes": 0.1,
+            "retryable_infra_error": False,
+        }
+
+
+def write_catalog(path: Path, spec_ids: list[str]) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "schema_version": "loopx_explore_variant_catalog_v0",
+                "specs": [
+                    {
+                        "spec_id": spec_id,
+                        "seed_family": "alpha",
+                        "intent": f"Try {spec_id}",
+                        "priority": len(spec_ids) - index,
+                    }
+                    for index, spec_id in enumerate(spec_ids)
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def check_resume_contract(root: Path) -> None:
+    root.mkdir(parents=True)
+    adapter = ResumeAdapter()
+    default_run = run_budget_arm(
+        adapter,
+        arm_key="default-arm",
+        run_root=root,
+        budget_minutes=1.0,
+        worker_count=1,
+        max_epochs=1,
+    )
+    assert default_run["resume"]["enabled"] is False, default_run
+    assert default_run["resume"]["checkpoint_path"] is None, default_run
+    assert not (root / "arm_checkpoint_default-arm.json").exists(), default_run
+
+    try:
+        run_budget_arm(
+            adapter,
+            arm_key="missing-arm",
+            run_root=root,
+            budget_minutes=1.0,
+            worker_count=1,
+            max_epochs=1,
+            resume=True,
+        )
+    except ValueError as error:
+        assert "does not exist" in str(error), error
+    else:
+        raise AssertionError("missing resume checkpoint should fail closed")
+
+    catalog_path = root / "variant_catalog.json"
+    write_catalog(catalog_path, ["spec-alpha-1"])
+    common = {
+        "adapter": adapter,
+        "arm_key": "resume-arm",
+        "run_root": root,
+        "budget_minutes": 60.0,
+        "worker_count": 2,
+        "use_router": True,
+        "frontier_max_lanes": 1,
+        "variant_catalog_path": catalog_path,
+        "duration_guard_factor": 0.0,
+        "resumable": True,
+    }
+    first = run_budget_arm(max_epochs=1, **common)
+    checkpoint_path = root / "arm_checkpoint_resume-arm.json"
+    assert checkpoint_path.exists(), first
+    assert first["epoch_count"] == 1, first
+    assert first["novel_value_total"] == 1.0, first
+    assert first["variant_records_total"] == 1, first
+    assert first["resume"]["resumed"] is False, first
+    assert json.loads((root / "variant_consumption_resume-arm.json").read_text()) == [
+        "spec-alpha-1"
+    ]
+
+    write_catalog(catalog_path, ["spec-alpha-1", "spec-alpha-2"])
+    # The manifest, not a loose observability file, is restart authority.
+    (root / "variant_consumption_resume-arm.json").write_text("[]\n", encoding="utf-8")
+    resumed = run_budget_arm(max_epochs=2, resume=True, **common)
+    assert resumed["epoch_count"] == 2, resumed
+    assert resumed["resume"]["restored_epoch_count"] == 1, resumed
+    assert resumed["novel_value_total"] == 1.0, resumed
+    assert resumed["variant_records_total"] == 2, resumed
+    assert resumed["raw_value_total"] > first["raw_value_total"], resumed
+    assert [epoch["epoch"] for epoch in resumed["epochs"]] == [1, 2], resumed
+    assert adapter.executed.count("variant-spec-alpha-1") == 1, adapter.executed
+    assert adapter.executed.count("variant-spec-alpha-2") == 1, adapter.executed
+    assert json.loads((root / "variant_consumption_resume-arm.json").read_text()) == [
+        "spec-alpha-1",
+        "spec-alpha-2",
+    ]
+    guidance = resumed["runtime_policy"]["planner_guidance"]
+    assert guidance["retry_backoff"] == {
+        "enforced": False,
+        "owner": "external_runner",
+    }, resumed
+
+    manifest = json.loads(checkpoint_path.read_text(encoding="utf-8"))
+    assert manifest["schema_version"] == HARNESS_CHECKPOINT_SCHEMA_VERSION, manifest
+    assert manifest["completed_epochs"] == 2, manifest
+    assert manifest["state"]["novelty_seen"] == ["shared-observation"], manifest
+    assert manifest["state"]["router_state"]["totals"]["observed_epochs"] == 2, manifest
+
+    valid_manifest = checkpoint_path.read_text(encoding="utf-8")
+    checkpoint_path.write_text("{\n", encoding="utf-8")
+    try:
+        run_budget_arm(max_epochs=3, resume=True, **common)
+    except ValueError as error:
+        assert "invalid JSON" in str(error), error
+    else:
+        raise AssertionError("corrupt resume checkpoint should fail closed")
+    checkpoint_path.write_text(valid_manifest, encoding="utf-8")
+
+    incompatible = dict(common)
+    incompatible["worker_count"] = 3
+    try:
+        run_budget_arm(max_epochs=3, resume=True, **incompatible)
+    except ValueError as error:
+        assert "runtime is incompatible" in str(error), error
+        assert "worker_count" in str(error), error
+    else:
+        raise AssertionError("incompatible resume checkpoint should fail closed")
+
+
+def check_item_failure_isolation(root: Path) -> None:
+    root.mkdir(parents=True)
+    calls: list[str] = []
+
+    def execute(item: dict, **_: object) -> dict:
+        item_id = str(item["item_id"])
+        calls.append(item_id)
+        if item_id == "fails":
+            raise SyntheticRetryableError("transient provider failure")
+        return {
+            "item_id": item_id,
+            "family": item["family"],
+            "observation_keys": [item_id],
+            "weighted_flags": {},
+            "accepted": True,
+            "duration_minutes": 0.1,
+        }
+
+    lanes = run_queue_epoch(
+        [
+            {"item_id": "fails", "family": "alpha", "concurrency_key": "shared"},
+            {"item_id": "after", "family": "alpha", "concurrency_key": "shared"},
+            {"item_id": "other", "family": "beta", "concurrency_key": "other"},
+        ],
+        execute=execute,
+        worker_count=2,
+        run_root=root,
+        arm="failure-arm",
+        epoch=1,
+    )
+    records = [record for lane in lanes for record in lane["results"]]
+    assert {record["item_id"] for record in records} == {"fails", "after", "other"}, records
+    failed = next(record for record in records if record["item_id"] == "fails")
+    assert failed["execution_status"] == "adapter_error", failed
+    assert failed["accepted"] is False, failed
+    assert failed["retryable_infra_error"] is True, failed
+    assert failed["adapter_error"]["type"] == "SyntheticRetryableError", failed
+    assert calls.index("after") > calls.index("fails"), calls
+
+    try:
+        run_queue_epoch(
+            [{"item_id": "fails", "family": "alpha", "concurrency_key": "shared"}],
+            execute=execute,
+            worker_count=1,
+            run_root=root,
+            arm="fatal-arm",
+            epoch=1,
+            item_failure_policy=ITEM_FAILURE_POLICY_FATAL,
+        )
+    except SyntheticRetryableError:
+        pass
+    else:
+        raise AssertionError("fatal item failure policy should preserve fail-fast behavior")
+
+    class FatalAdapter:
+        item_failure_policy = "fatal"
+
+        def list_seed_items(self) -> list[dict]:
+            return [{"item_id": "fatal", "family": "fatal"}]
+
+        def execute(self, item: dict, **_: object) -> dict:
+            raise SyntheticRetryableError(str(item["item_id"]))
+
+    try:
+        run_budget_arm(
+            FatalAdapter(),
+            arm_key="adapter-fatal-arm",
+            run_root=root / "adapter-fatal",
+            budget_minutes=1.0,
+            worker_count=1,
+            max_epochs=1,
+        )
+    except SyntheticRetryableError:
+        pass
+    else:
+        raise AssertionError("adapter fatal policy should reach the budget-arm runner")
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="loopx-explore-runtime-resume-") as tmp:
+        root = Path(tmp)
+        check_resume_contract(root / "resume")
+        check_item_failure_isolation(root / "failures")
+    print("explore-harness-runtime-resume-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -1089,6 +1089,48 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
         ],
     },
     {
+        "id": "explore-harness",
+        "title": "Explore Harness configuration and runtime",
+        "purpose": (
+            "Check the deny-by-default goal boundary, planner agreement, resumable "
+            "runtime state, and per-item failure isolation."
+        ),
+        "catalog_families": ["Work Routing", "State And Boundary", "Evidence Lifecycle"],
+        "trigger_hints": (
+            "explore harness",
+            "explore-harness",
+            "harness_runtime",
+            "harness_checkpoint",
+            "explore_harness",
+            "loopx/capabilities/explore",
+            "docs/capabilities/explore",
+            "examples/explore-configure-goal-smoke.py",
+            "examples/explore-harness-runtime-resume-smoke.py",
+        ),
+        "checks": [
+            {
+                "command": "python3 examples/explore-configure-goal-smoke.py",
+                "tier": "default",
+                "reason": "guards configure-goal opt-in and quota/planner boundary agreement",
+            },
+            {
+                "command": "python3 examples/explore-harness-runtime-resume-smoke.py",
+                "tier": "default",
+                "reason": "guards validated resume state, novelty/variant restoration, and item failure isolation",
+            },
+            {
+                "command": "python3 examples/explore-worker-plan-gate-smoke.py",
+                "tier": "default",
+                "reason": "guards profile pinning, analysis-only planning, and lane-width authority",
+            },
+            {
+                "command": "python3 examples/explore-result-layer-smoke.py",
+                "tier": "deep",
+                "reason": "samples the wider Explore result and presentation contract",
+            },
+        ],
+    },
+    {
         "id": "catalog-canary-contract",
         "title": "Catalog canary contract",
         "purpose": "Check catalog-to-canary planning, JSON actionability, shell-free no-write execution, and full/module smoke-suite selection.",

--- a/loopx/capabilities/explore/harness_checkpoint.py
+++ b/loopx/capabilities/explore/harness_checkpoint.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+from .router_state import is_router_state
+
+
+HARNESS_CHECKPOINT_SCHEMA_VERSION = "loopx_explore_harness_checkpoint_v0"
+
+
+def write_arm_checkpoint(path: Path, payload: Mapping[str, Any]) -> None:
+    """Replace a restart contract only after the complete JSON is durable."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f".{path.name}.tmp")
+    try:
+        temporary.write_text(
+            json.dumps(payload, ensure_ascii=False, indent=2) + "\n",
+            encoding="utf-8",
+        )
+        temporary.replace(path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def load_arm_checkpoint(
+    path: Path,
+    *,
+    expected_signature: Mapping[str, Any],
+) -> dict[str, Any]:
+    if not path.exists():
+        raise ValueError(f"resume checkpoint does not exist: {path}")
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8-sig"))
+    except (OSError, UnicodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"resume checkpoint is unreadable or invalid JSON: {path}") from error
+    if not isinstance(payload, dict):
+        raise ValueError("resume checkpoint must be a JSON object")
+    if payload.get("schema_version") != HARNESS_CHECKPOINT_SCHEMA_VERSION:
+        raise ValueError(
+            "resume checkpoint schema is incompatible: expected "
+            f"{HARNESS_CHECKPOINT_SCHEMA_VERSION!r}, got {payload.get('schema_version')!r}"
+        )
+    expected_arm = str(expected_signature.get("arm_key") or "")
+    if str(payload.get("arm_key") or "") != expected_arm:
+        raise ValueError(
+            "resume checkpoint arm_key is incompatible: "
+            f"expected {expected_arm!r}, got {payload.get('arm_key')!r}"
+        )
+    signature = payload.get("runtime_signature")
+    if not isinstance(signature, dict):
+        raise ValueError("resume checkpoint is missing runtime_signature")
+    mismatches = [
+        key
+        for key, expected in expected_signature.items()
+        if signature.get(key) != expected
+    ]
+    if mismatches:
+        details = ", ".join(
+            f"{key}={signature.get(key)!r} (expected {expected_signature.get(key)!r})"
+            for key in mismatches
+        )
+        raise ValueError(f"resume checkpoint runtime is incompatible: {details}")
+    state = payload.get("state")
+    if not isinstance(state, dict):
+        raise ValueError("resume checkpoint is missing state")
+    for field in ("epochs", "checkpoints", "novelty_seen", "catalog_consumed"):
+        if not isinstance(state.get(field), list):
+            raise ValueError(f"resume checkpoint state.{field} must be a list")
+    if any(not isinstance(epoch, dict) for epoch in state["epochs"]):
+        raise ValueError("resume checkpoint state.epochs must contain objects")
+    if any(not isinstance(checkpoint, dict) for checkpoint in state["checkpoints"]):
+        raise ValueError("resume checkpoint state.checkpoints must contain objects")
+    if any(not isinstance(key, str) for key in state["novelty_seen"]):
+        raise ValueError("resume checkpoint state.novelty_seen must contain strings")
+    if any(not isinstance(spec_id, str) for spec_id in state["catalog_consumed"]):
+        raise ValueError("resume checkpoint state.catalog_consumed must contain strings")
+    if not isinstance(state.get("coverage_first_seen"), dict):
+        raise ValueError("resume checkpoint state.coverage_first_seen must be an object")
+    try:
+        for minutes in state["coverage_first_seen"].values():
+            float(minutes)
+    except (TypeError, ValueError) as error:
+        raise ValueError(
+            "resume checkpoint state.coverage_first_seen values must be numeric"
+        ) from error
+    if state.get("load_profile") is not None and not isinstance(state.get("load_profile"), dict):
+        raise ValueError("resume checkpoint state.load_profile must be an object or null")
+
+    try:
+        completed_epochs = int(payload.get("completed_epochs") or 0)
+    except (TypeError, ValueError) as error:
+        raise ValueError("resume checkpoint completed_epochs must be an integer") from error
+    if completed_epochs != len(state["epochs"]):
+        raise ValueError("resume checkpoint completed_epochs does not match epoch history")
+    if len(state["checkpoints"]) != completed_epochs:
+        raise ValueError("resume checkpoint anytime history does not match completed_epochs")
+    expected_epochs = list(range(1, completed_epochs + 1))
+    try:
+        epoch_numbers = [int(epoch.get("epoch") or 0) for epoch in state["epochs"]]
+        checkpoint_epochs = [
+            int(checkpoint.get("epoch") or 0) for checkpoint in state["checkpoints"]
+        ]
+    except (TypeError, ValueError) as error:
+        raise ValueError("resume checkpoint epoch history must use integer epoch ids") from error
+    if epoch_numbers != expected_epochs or checkpoint_epochs != expected_epochs:
+        raise ValueError("resume checkpoint epoch history is not contiguous from epoch 1")
+    try:
+        next_epoch = int(state.get("next_epoch") or 0)
+    except (TypeError, ValueError) as error:
+        raise ValueError("resume checkpoint state.next_epoch must be an integer") from error
+    expected_next_epoch = completed_epochs + 1
+    if next_epoch != expected_next_epoch:
+        raise ValueError(
+            "resume checkpoint next_epoch is inconsistent: "
+            f"expected {expected_next_epoch}, got {next_epoch}"
+        )
+    if expected_signature.get("use_router") and not is_router_state(state.get("router_state")):
+        raise ValueError("resume checkpoint has an invalid router_state for a router arm")
+    for field in (
+        "elapsed_minutes",
+        "raw_value_total",
+        "novel_value_total",
+        "variant_records_total",
+    ):
+        try:
+            float(state.get(field) or 0.0)
+        except (TypeError, ValueError) as error:
+            raise ValueError(f"resume checkpoint state.{field} must be numeric") from error
+    return state
+
+
+def build_arm_checkpoint(
+    *,
+    arm_key: str,
+    runtime_signature: Mapping[str, Any],
+    next_epoch: int,
+    elapsed_minutes: float,
+    epochs: Sequence[Mapping[str, Any]],
+    checkpoints: Sequence[Mapping[str, Any]],
+    novelty_seen: Sequence[str],
+    router_state: Mapping[str, Any] | None,
+    load_profile: Mapping[str, Any] | None,
+    catalog_consumed: Sequence[str],
+    coverage_first_seen: Mapping[str, float],
+    raw_value_total: float,
+    novel_value_total: float,
+    variant_records_total: int,
+) -> dict[str, Any]:
+    return {
+        "schema_version": HARNESS_CHECKPOINT_SCHEMA_VERSION,
+        "arm_key": arm_key,
+        "completed_epochs": len(epochs),
+        "runtime_signature": dict(runtime_signature),
+        "state": {
+            "next_epoch": int(next_epoch),
+            "elapsed_minutes": round(float(elapsed_minutes), 6),
+            "epochs": [dict(epoch) for epoch in epochs],
+            "checkpoints": [dict(checkpoint) for checkpoint in checkpoints],
+            "novelty_seen": sorted(novelty_seen),
+            "router_state": dict(router_state) if isinstance(router_state, Mapping) else None,
+            "load_profile": dict(load_profile) if isinstance(load_profile, Mapping) else None,
+            "catalog_consumed": sorted(catalog_consumed),
+            "coverage_first_seen": dict(coverage_first_seen),
+            "raw_value_total": round(float(raw_value_total), 6),
+            "novel_value_total": round(float(novel_value_total), 6),
+            "variant_records_total": int(variant_records_total),
+        },
+    }

--- a/loopx/capabilities/explore/harness_runtime.py
+++ b/loopx/capabilities/explore/harness_runtime.py
@@ -3,9 +3,16 @@ from __future__ import annotations
 import json
 import threading
 import time
+from enum import Enum
 from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence
 
+from .harness_checkpoint import (
+    HARNESS_CHECKPOINT_SCHEMA_VERSION,
+    build_arm_checkpoint,
+    load_arm_checkpoint,
+    write_arm_checkpoint,
+)
 from .router_state import (
     advance_epoch,
     family_routing_terms,
@@ -55,12 +62,25 @@ implementation):
   ``variant_spec`` attached, own ``concurrency_key``).
 - ``flag_weights`` is implicit: the adapter reports weights per record, so
   the harness never holds a domain weight table.
+- ``item_failure_policy`` may be set to ``"fatal"`` on the adapter to make
+  execution exceptions propagate; the default ``"record"`` policy emits a
+  zero-value structured observation and keeps independent lanes running.
 """
 
 
 HARNESS_ARM_SCHEMA_VERSION = "loopx_explore_harness_arm_v0"
 VARIANT_CATALOG_SCHEMA_VERSION = "loopx_explore_variant_catalog_v0"
 FRONTIER_REQUESTS_SCHEMA_VERSION = "loopx_explore_frontier_requests_v0"
+HARNESS_RUNTIME_POLICY_SCHEMA_VERSION = "loopx_explore_harness_runtime_policy_v0"
+
+class ItemFailurePolicy(str, Enum):
+    RECORD = "record"
+    FATAL = "fatal"
+
+
+ITEM_FAILURE_POLICY_RECORD = ItemFailurePolicy.RECORD.value
+ITEM_FAILURE_POLICY_FATAL = ItemFailurePolicy.FATAL.value
+ITEM_FAILURE_POLICIES = {policy.value for policy in ItemFailurePolicy}
 
 DEFAULT_OBSERVATION_WEIGHT = 1.0
 _MIN_DURATION_MINUTES = 0.05
@@ -82,6 +102,51 @@ def _read_json(path: Path) -> Any:
         return json.loads(path.read_text(encoding="utf-8-sig"))
     except json.JSONDecodeError:
         return None
+
+
+def _normalize_item_failure_policy(value: Any) -> str:
+    if isinstance(value, ItemFailurePolicy):
+        return value.value
+    policy = str(value or ITEM_FAILURE_POLICY_RECORD).strip().lower().replace("_", "-")
+    if policy not in ITEM_FAILURE_POLICIES:
+        raise ValueError(
+            "item_failure_policy must be one of: "
+            + ", ".join(sorted(ITEM_FAILURE_POLICIES))
+        )
+    return policy
+
+
+def _adapter_error_record(
+    item: Mapping[str, Any],
+    error: Exception,
+    *,
+    duration_minutes: float,
+) -> dict[str, Any]:
+    message = " ".join(str(error).split())
+    return {
+        "item_id": item.get("item_id"),
+        "family": item.get("family"),
+        "is_variant": bool(item.get("is_variant")),
+        "variant_spec_id": (
+            (item.get("variant_spec") or {}).get("spec_id")
+            if item.get("is_variant")
+            else None
+        ),
+        "execution_status": "adapter_error",
+        "item_failure_policy": ITEM_FAILURE_POLICY_RECORD,
+        "accepted": False,
+        "observation_keys": [],
+        "weighted_flags": {},
+        "duration_minutes": max(_MIN_DURATION_MINUTES, float(duration_minutes)),
+        "retryable_infra_error": bool(
+            getattr(error, "retryable_infra_error", False)
+        ),
+        "adapter_error": {
+            "schema_version": "loopx_explore_adapter_error_v0",
+            "type": type(error).__name__,
+            "message": message[:240],
+        },
+    }
 
 
 class NoveltyLedger:
@@ -129,6 +194,7 @@ def run_queue_epoch(
     arm: str,
     epoch: int,
     stagger_seconds: float = 0.0,
+    item_failure_policy: str = ITEM_FAILURE_POLICY_RECORD,
 ) -> list[dict[str, Any]]:
     """Drain one epoch's work items through a shared pull queue.
 
@@ -138,6 +204,7 @@ def run_queue_epoch(
     Returns per-worker lane records.
     """
 
+    failure_policy = _normalize_item_failure_policy(item_failure_policy)
     lock = threading.Lock()
     pending: list[dict[str, Any]] = [dict(item) for item in items]
     in_flight: set[str] = set()
@@ -169,20 +236,31 @@ def run_queue_epoch(
                 time.sleep(0.5)
                 continue
             key = str(item.get("concurrency_key") or item.get("family") or "")
+            item_started = time.perf_counter()
             try:
                 record = execute(
                     item, run_root=run_root, arm=arm, epoch=epoch, branch_id=branch_id
                 )
+                if not isinstance(record, dict):
+                    raise TypeError("adapter execute must return a dict observation record")
                 record.setdefault("item_id", item.get("item_id"))
                 record.setdefault("family", item.get("family"))
                 record.setdefault("is_variant", bool(item.get("is_variant")))
                 if item.get("is_variant"):
                     record.setdefault("variant_spec_id", (item.get("variant_spec") or {}).get("spec_id"))
-                results.append(record)
+            except Exception as error:
+                if failure_policy == ITEM_FAILURE_POLICY_FATAL:
+                    raise
+                record = _adapter_error_record(
+                    item,
+                    error,
+                    duration_minutes=_now_perf_minutes(item_started),
+                )
             finally:
                 if key:
                     with lock:
                         in_flight.discard(key)
+            results.append(record)
         return {
             "branch_id": branch_id,
             "launch_index": worker_index,
@@ -271,6 +349,10 @@ class VariantCatalog:
 
     def consume(self, spec_id: str) -> None:
         self.consumed.add(str(spec_id))
+        _write_json(self.consumption_path, sorted(self.consumed))
+
+    def restore_consumed(self, spec_ids: Sequence[Any]) -> None:
+        self.consumed = {str(spec_id) for spec_id in spec_ids if str(spec_id).strip()}
         _write_json(self.consumption_path, sorted(self.consumed))
 
 
@@ -476,6 +558,32 @@ def plan_router_no_prune(
     return ordered
 
 
+def _arm_runtime_signature(
+    adapter: Any,
+    *,
+    arm_key: str,
+    worker_count: int,
+    use_router: bool,
+    frontier_max_lanes: int,
+    variant_catalog_enabled: bool,
+    goal_id: str,
+    agent_id: str,
+    item_failure_policy: str,
+) -> dict[str, Any]:
+    adapter_type = f"{type(adapter).__module__}.{type(adapter).__qualname__}"
+    return {
+        "arm_key": str(arm_key),
+        "adapter_type": adapter_type,
+        "worker_count": max(1, int(worker_count)),
+        "use_router": bool(use_router),
+        "frontier_max_lanes": max(0, int(frontier_max_lanes)),
+        "variant_catalog_enabled": bool(variant_catalog_enabled),
+        "goal_id": str(goal_id),
+        "agent_id": str(agent_id),
+        "item_failure_policy": item_failure_policy,
+    }
+
+
 def run_budget_arm(
     adapter: Any,
     *,
@@ -492,16 +600,44 @@ def run_budget_arm(
     stagger_seconds: float = 0.0,
     duration_guard_factor: float = 1.15,
     duration_guard_recent: int = 3,
+    resumable: bool = False,
+    resume: bool = False,
+    checkpoint_path: Path | None = None,
+    item_failure_policy: str | None = None,
 ) -> dict[str, Any]:
     """Run ONE arm alone against its wall-clock budget; return arm payload.
 
     ``use_router=False`` is the blind baseline (round-robin sweep, no
     variants). ``use_router=True`` adds router-ordered no-prune planning,
     router-state feedback, and -- when a variant catalog path is given --
-    agent-authored frontier variants appended to each epoch's queue.
+    agent-authored frontier variants appended to each epoch's queue. Restart
+    is opt-in and only trusts the validated epoch-boundary checkpoint manifest;
+    rolling progress remains an observability surface.
     """
 
     run_root = Path(run_root)
+    failure_policy = _normalize_item_failure_policy(
+        item_failure_policy
+        if item_failure_policy is not None
+        else getattr(adapter, "item_failure_policy", None)
+    )
+    checkpoint_enabled = bool(resumable or resume or checkpoint_path is not None)
+    checkpoint_file = (
+        Path(checkpoint_path)
+        if checkpoint_path is not None
+        else run_root / f"arm_checkpoint_{arm_key}.json"
+    )
+    runtime_signature = _arm_runtime_signature(
+        adapter,
+        arm_key=arm_key,
+        worker_count=worker_count,
+        use_router=use_router,
+        frontier_max_lanes=frontier_max_lanes,
+        variant_catalog_enabled=variant_catalog_path is not None,
+        goal_id=goal_id,
+        agent_id=agent_id,
+        item_failure_policy=failure_policy,
+    )
     ledger = NoveltyLedger()
     router_state = initial_router_state() if use_router else None
     load_profile: Mapping[str, Any] | None = None
@@ -519,10 +655,47 @@ def run_budget_arm(
     raw_cum = 0.0
     novel_cum = 0.0
     variant_records_cum = 0
+    next_epoch = 1
+    elapsed_offset = 0.0
+    if resume:
+        state = load_arm_checkpoint(
+            checkpoint_file,
+            expected_signature=runtime_signature,
+        )
+        epochs = [dict(epoch) for epoch in state["epochs"]]
+        checkpoints = [dict(checkpoint) for checkpoint in state["checkpoints"]]
+        ledger.seen = {str(key) for key in state["novelty_seen"]}
+        router_state = (
+            dict(state["router_state"])
+            if isinstance(state.get("router_state"), Mapping)
+            else None
+        )
+        load_profile = (
+            dict(state["load_profile"])
+            if isinstance(state.get("load_profile"), Mapping)
+            else None
+        )
+        coverage_first_seen = {
+            str(family): float(minutes)
+            for family, minutes in state["coverage_first_seen"].items()
+        }
+        raw_cum = float(state.get("raw_value_total") or 0.0)
+        novel_cum = float(state.get("novel_value_total") or 0.0)
+        variant_records_cum = int(state.get("variant_records_total") or 0)
+        next_epoch = int(state["next_epoch"])
+        elapsed_offset = float(state.get("elapsed_minutes") or 0.0)
+        if catalog is not None:
+            catalog.restore_consumed(state["catalog_consumed"])
+    elif checkpoint_enabled and catalog is not None:
+        # Reusing a run_root is not an implicit restart contract. A fresh arm
+        # starts with fresh consumption; only resume restores prior attempts.
+        catalog.restore_consumed([])
+    if not resume:
+        checkpoint_file.unlink(missing_ok=True)
     stop_reason = "max_epochs"
     started = time.perf_counter()
-    for epoch in range(1, int(max_epochs) + 1):
-        elapsed = _now_perf_minutes(started)
+    for epoch in range(next_epoch, int(max_epochs) + 1):
+        elapsed = elapsed_offset + _now_perf_minutes(started)
         remaining = float(budget_minutes) - elapsed
         if epochs and remaining <= 0:
             stop_reason = "budget_exhausted"
@@ -579,6 +752,7 @@ def run_budget_arm(
             arm=arm_key,
             epoch=epoch,
             stagger_seconds=stagger_seconds,
+            item_failure_policy=failure_policy,
         )
         epoch_wall = _now_perf_minutes(epoch_start)
         epoch_raw = 0.0
@@ -596,7 +770,7 @@ def run_budget_arm(
                 records.append(record)
         raw_cum += epoch_raw
         novel_cum += epoch_novel
-        elapsed_after = _now_perf_minutes(started)
+        elapsed_after = elapsed_offset + _now_perf_minutes(started)
         for record in records:
             family = str(record.get("family") or "")
             if family:
@@ -652,6 +826,26 @@ def run_budget_arm(
                 "lanes": lanes,
             }
         )
+        if checkpoint_enabled:
+            write_arm_checkpoint(
+                checkpoint_file,
+                build_arm_checkpoint(
+                    arm_key=arm_key,
+                    runtime_signature=runtime_signature,
+                    next_epoch=epoch + 1,
+                    elapsed_minutes=elapsed_after,
+                    epochs=epochs,
+                    checkpoints=checkpoints,
+                    novelty_seen=sorted(ledger.seen),
+                    router_state=router_state,
+                    load_profile=load_profile,
+                    catalog_consumed=sorted(catalog.consumed) if catalog else [],
+                    coverage_first_seen=coverage_first_seen,
+                    raw_value_total=raw_cum,
+                    novel_value_total=novel_cum,
+                    variant_records_total=variant_records_cum,
+                ),
+            )
         _write_json(
             run_root / f"rolling_progress_{arm_key}.json",
             {"arm": arm_key, "completed_epochs": len(epochs), "last_checkpoint": checkpoints[-1]},
@@ -660,7 +854,7 @@ def run_budget_arm(
         "schema_version": HARNESS_ARM_SCHEMA_VERSION,
         "arm_key": arm_key,
         "budget_minutes": float(budget_minutes),
-        "elapsed_minutes": round(_now_perf_minutes(started), 3),
+        "elapsed_minutes": round(elapsed_offset + _now_perf_minutes(started), 3),
         "stop_reason": stop_reason,
         "epoch_count": len(epochs),
         "raw_value_total": round(raw_cum, 3),
@@ -670,6 +864,29 @@ def run_budget_arm(
         "coverage_first_seen_minutes": coverage_first_seen,
         "checkpoints": checkpoints,
         "epochs": epochs,
+        "resume": {
+            "schema_version": "loopx_explore_harness_resume_v0",
+            "enabled": checkpoint_enabled,
+            "resumed": bool(resume),
+            "checkpoint_schema_version": HARNESS_CHECKPOINT_SCHEMA_VERSION,
+            "checkpoint_path": str(checkpoint_file) if checkpoint_enabled else None,
+            "restored_epoch_count": next_epoch - 1 if resume else 0,
+        },
+        "runtime_policy": {
+            "schema_version": HARNESS_RUNTIME_POLICY_SCHEMA_VERSION,
+            "item_failure_policy": failure_policy,
+            "item_exception_isolation": failure_policy == ITEM_FAILURE_POLICY_RECORD,
+            "planner_guidance": {
+                "retry_backoff": {
+                    "enforced": False,
+                    "owner": "external_runner",
+                },
+                "infra_cooldown": {
+                    "enforced": False,
+                    "owner": "external_runner",
+                },
+            },
+        },
     }
 
 

--- a/loopx/cli_commands/registry_admin.py
+++ b/loopx/cli_commands/registry_admin.py
@@ -11,6 +11,7 @@ from ..agent_registry import (
 from ..configure_goal import configure_goal, render_configure_goal_markdown
 from ..global_registry import render_global_sync_markdown, sync_project_registry_to_global
 from ..history import load_registry
+from ..orchestration import EXPLORE_HARNESS_PROFILES
 from ..paths import DEFAULT_RUNTIME_ROOT, global_registry_path, resolve_runtime_root
 from ..project_uninstall import render_project_uninstall_markdown, uninstall_project
 from ..registry_writability import probe_registry_write_path
@@ -316,6 +317,25 @@ def register_registry_admin_commands(subparsers: argparse._SubParsersAction) -> 
         help="Clear allowed child-agent domains.",
     )
     configure_goal_parser.add_argument(
+        "--explore-harness-enabled",
+        action=argparse.BooleanOptionalAction,
+        default=None,
+        help=(
+            "Enable or disable analysis-only explore planning for this goal. "
+            "This does not grant child-agent spawn permission."
+        ),
+    )
+    configure_goal_parser.add_argument(
+        "--explore-harness-profile",
+        choices=EXPLORE_HARNESS_PROFILES,
+        help="Pin the explore planner profile on this goal's orchestration boundary.",
+    )
+    configure_goal_parser.add_argument(
+        "--clear-explore-harness-profile",
+        action="store_true",
+        help="Remove the goal-pinned explore profile while preserving the opt-in bit.",
+    )
+    configure_goal_parser.add_argument(
         "--registered-agent",
         dest="registered_agents",
         action="append",
@@ -578,6 +598,9 @@ def handle_registry_admin_command(
                 max_children=args.max_children,
                 allowed_domains=args.allowed_domain,
                 clear_allowed_domains=bool(args.clear_allowed_domains),
+                explore_harness_enabled=args.explore_harness_enabled,
+                explore_harness_profile=args.explore_harness_profile,
+                clear_explore_harness_profile=bool(args.clear_explore_harness_profile),
                 registered_agents=args.registered_agents,
                 clear_registered_agents=bool(args.clear_registered_agents),
                 primary_agent=args.primary_agent,

--- a/loopx/configure_goal.py
+++ b/loopx/configure_goal.py
@@ -15,6 +15,7 @@ from .agent_registry import normalize_registered_agents, primary_agent_id_for_go
 from .control_plane import compact_control_plane_policy, control_plane_policy_summary
 from .orchestration import (
     DEFAULT_ORCHESTRATION_MODE,
+    EXPLORE_HARNESS_PROFILES,
     MULTI_SUBAGENT_ORCHESTRATION_MODE,
     compact_orchestration_policy,
     orchestration_policy_summary,
@@ -204,6 +205,9 @@ def configure_goal(
     max_children: int | None = None,
     allowed_domains: list[str] | None = None,
     clear_allowed_domains: bool = False,
+    explore_harness_enabled: bool | None = None,
+    explore_harness_profile: str | None = None,
+    clear_explore_harness_profile: bool = False,
     registered_agents: list[str] | None = None,
     clear_registered_agents: bool = False,
     primary_agent: str | None = None,
@@ -225,6 +229,10 @@ def configure_goal(
         raise FileNotFoundError(f"registry file does not exist: {registry_path}")
     if clear_allowed_domains and allowed_domains:
         raise ValueError("--clear-allowed-domains cannot be combined with --allowed-domain")
+    if clear_explore_harness_profile and explore_harness_profile:
+        raise ValueError(
+            "--clear-explore-harness-profile cannot be combined with --explore-harness-profile"
+        )
     if clear_registered_agents and registered_agents:
         raise ValueError("--clear-registered-agents cannot be combined with --registered-agent")
     if clear_primary_agent and primary_agent:
@@ -260,6 +268,13 @@ def configure_goal(
             "--multi-subagent-feature cannot be combined with --orchestration-mode or --spawn-allowed; "
             "use --max-children/--allowed-domain for bounded feature settings"
         )
+    if explore_harness_profile is not None:
+        explore_harness_profile = str(explore_harness_profile).strip().lower().replace("_", "-")
+        if explore_harness_profile not in EXPLORE_HARNESS_PROFILES:
+            raise ValueError(
+                "--explore-harness-profile must be one of: "
+                + ", ".join(EXPLORE_HARNESS_PROFILES)
+            )
 
     quota_compute = _positive_number(quota_compute, field="quota_compute")
     quota_window_hours = _positive_number(quota_window_hours, field="quota_window_hours")
@@ -317,6 +332,9 @@ def configure_goal(
         or max_children is not None
         or allowed_domains is not None
         or clear_allowed_domains
+        or explore_harness_enabled is not None
+        or explore_harness_profile is not None
+        or clear_explore_harness_profile
     ):
         spawn_policy = goal.get("spawn_policy") if isinstance(goal.get("spawn_policy"), dict) else {}
         if multi_subagent_feature == "enabled":
@@ -344,6 +362,26 @@ def configure_goal(
             spawn_policy["allowed_domains"] = []
         elif allowed_domains is not None:
             spawn_policy["allowed_domains"] = allowed_domains
+        if (
+            explore_harness_enabled is not None
+            or explore_harness_profile is not None
+            or clear_explore_harness_profile
+        ):
+            explore_harness = (
+                spawn_policy.get("explore_harness")
+                if isinstance(spawn_policy.get("explore_harness"), dict)
+                else {}
+            )
+            if explore_harness_enabled is not None:
+                explore_harness["enabled"] = explore_harness_enabled
+            if clear_explore_harness_profile:
+                explore_harness.pop("profile", None)
+            elif explore_harness_profile is not None:
+                explore_harness["profile"] = explore_harness_profile
+            if explore_harness:
+                spawn_policy["explore_harness"] = explore_harness
+            else:
+                spawn_policy.pop("explore_harness", None)
         goal["spawn_policy"] = spawn_policy
 
     if waiting_on is not None:
@@ -430,6 +468,10 @@ def configure_goal(
         "orchestration_summary": orchestration_policy_summary(after.get("orchestration")),
         "feature_summary": {
             "multi_subagent": _multi_subagent_feature_status(after.get("orchestration") or {}),
+            "explore_harness": deepcopy(
+                (after.get("orchestration") or {}).get("explore_harness")
+                or {"enabled": False}
+            ),
             "default": "off",
             "configuration_entry": "multi_subagent_feature",
         },
@@ -464,6 +506,12 @@ def render_configure_goal_markdown(payload: dict[str, Any]) -> str:
     feature_summary = payload.get("feature_summary")
     if isinstance(feature_summary, dict):
         lines.append(f"- feature_multi_subagent: `{feature_summary.get('multi_subagent')}`")
+        harness = feature_summary.get("explore_harness")
+        if isinstance(harness, dict):
+            harness_state = "on" if harness.get("enabled") else "off"
+            if harness.get("profile"):
+                harness_state += f"({harness.get('profile')})"
+            lines.append(f"- feature_explore_harness: `{harness_state}`")
     migration = payload.get("heartbeat_prompt_migration")
     if isinstance(migration, dict):
         lines.append(f"- heartbeat_prompt_migration: {migration.get('action')}")

--- a/loopx/orchestration.py
+++ b/loopx/orchestration.py
@@ -9,6 +9,11 @@ VALID_ORCHESTRATION_MODES = {
     DEFAULT_ORCHESTRATION_MODE,
     MULTI_SUBAGENT_ORCHESTRATION_MODE,
 }
+EXPLORE_HARNESS_PROFILES = (
+    "generic",
+    "adaptive-resilient",
+    "moe-router",
+)
 
 
 def _int_number(value: Any, *, default: int = 0) -> int:


### PR DESCRIPTION
## Summary

- expose the existing Explore Harness opt-in and pinned profile through `configure-goal`, including preview/execute behavior and analysis-only activation
- add opt-in atomic runtime checkpoints that resume epoch, novelty, router, metrics, and variant-consumption state while failing closed on corrupt or incompatible manifests
- isolate adapter item failures by default, preserve explicit fatal behavior, and always release concurrency keys
- document the activation/restart contract and add a dedicated Explore Harness canary profile

## Design

This keeps one authority for activation: `orchestration.spawn_policy.explore_harness`. Configure-goal updates that existing contract without enabling spawn or adding a second config layer.

Checkpointing is opt-in so existing adapters with non-JSON private payloads remain compatible. Retry/backoff/cooldown remain explicit external-runner guidance rather than becoming an implicit runtime framework.

## Validation

- `python3 examples/explore-configure-goal-smoke.py`
- `python3 examples/explore-harness-runtime-resume-smoke.py`
- `python3 examples/explore-worker-plan-gate-smoke.py`
- `python3 examples/explore-result-layer-smoke.py`
- configure-goal/API/modularization/status/line-budget regression smokes
- `loopx canary run --profile explore-harness`: 3/3 passed
- premerge canary: 17 selected, 0 failures, 0 warnings, 0 holds
- public-boundary scan: 10 changed files clean
- `git diff --check` and changed-file compile checks

Closes #1782.
Closes #1783.
