### PR TITLE
feat(issue-fix): add bilingual guide and reviewer recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,7 +468,7 @@ new control plane every time:
 
 | App path | Start with | Expected output | User-visible lift |
 | --- | --- | --- | --- |
-| Issue / PR fix loop | LoopX slash entry: `Fix <github-issue-or-pr-url>`<br>`loopx issue-fix workflow-plan` | Branch-ready fix packet with repro, smoke result, remaining review owner, and PR-review-ready evidence. | Review comments and issues become a closed loop instead of reminders humans must shepherd by hand. |
+| [Issue / PR fix loop](docs/capabilities/issue-fix/README.md) | LoopX slash entry: `Fix <github-issue-or-pr-url>`<br>`loopx issue-fix workflow-plan` | Branch-ready fix packet with repro, smoke result, explainable reviewer recommendation, and PR-lifecycle evidence. | Review comments and issues become a monitored closed loop instead of reminders humans must shepherd by hand. |
 | PR-sized refactor loop | LoopX slash entry: `<refactor task>`<br>`loopx canary plan` | Reviewable slice list, validation notes, successor todo, and merge boundary. | More merged changes without turning the next morning into a giant diff audit. |
 | Research or experiment loop | `loopx auto-research start "<open question>" --execute`<br>`loopx ml-experiment preview --format json` | Hypothesis, source/evidence packet, replay or experiment boundary, and next validated question. | Research becomes a resumable long-horizon loop, not just a one-off report. |
 | Explore result / harness loop | `loopx explore node\|edge\|finding`<br>`loopx explore worker-branch-plan --goal-id <id>` | Public-safe exploration graph, blocked frontier, Mermaid/exportable projection, and default-off worker branch plan. | Long-running exploration becomes inspectable topology and opt-in worker planning instead of hidden notes. |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -394,7 +394,7 @@ review 信号不会自动变成执行权限。更完整的设计见
 
 | 应用路径 | 精简命令入口 | 预期产物 | 用户可感知增量 |
 | --- | --- | --- | --- |
-| Issue / PR fix loop | `/loopx Fix <github-issue-or-pr-url>`<br>`loopx issue-fix workflow-plan` | 可复核的修复包：repro、smoke 结果、剩余 review owner 和 PR-ready evidence。 | issue 和 review comment 不再只是提醒人，而是驱动 agent 闭环的入口。 |
+| [Issue / PR fix loop](docs/capabilities/issue-fix/README.zh-CN.md) | `/loopx Fix <github-issue-or-pr-url>`<br>`loopx issue-fix workflow-plan` | 可复核的修复包：repro、smoke 结果、可解释 reviewer 推荐和 PR-lifecycle evidence。 | issue 和 review comment 不再只是提醒人，而是驱动 agent 持续监控到终局的闭环入口。 |
 | PR-sized refactor loop | `/loopx <refactor goal>`<br>`loopx canary plan` | 可 review 的 slice 列表、验证记录、后续 todo、merge 边界。 | 增加可合并 change，而不是第二天早上面对一个巨型 diff。 |
 | Research / experiment loop | `loopx auto-research start "<open question>" --execute`<br>`loopx ml-experiment preview --format json` | hypothesis、source/evidence packet、replay 或实验边界，以及下一步可验证问题。 | research 不只是一次性报告，而是可继续、可沉淀的 long-horizon loop。 |
 | Explore result / harness loop | `loopx explore node\|edge\|finding`<br>`loopx explore worker-branch-plan --goal-id <id>` | public-safe 探索图、blocked frontier、Mermaid/exportable projection，以及默认关闭的 worker branch plan。 | 长程探索从隐藏笔记变成可检查拓扑和 opt-in worker planning。 |

--- a/docs/capabilities/README.md
+++ b/docs/capabilities/README.md
@@ -6,8 +6,9 @@ modules, CLI entrypoints, and smokes under the capability they serve.
 
 Current capability paths:
 
-- [issue-fix](issue-fix/README.md): turn public GitHub issue/PR signals into
-  caller-approved local issue branches and PR-review evidence.
+- [issue-fix](issue-fix/README.md) ([中文](issue-fix/README.zh-CN.md)): turn
+  public GitHub issue/PR signals into focused fixes, explainable reviewer
+  routes, authority-gated PRs, and monitored lifecycle outcomes.
 - [content-ops](content-ops/README.md): collect public/private content signals
   into reviewable source, angle, draft, feedback, and publish-gate packets.
 - [value-connectors](value-connectors/README.md): install and run public-safe

--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -1,182 +1,513 @@
 # Issue-Fix Capability
 
-The issue-fix capability is the product path for open-source issue/PR solver
-work. It is intentionally narrower than a generic workflow engine: it starts
-from public GitHub metadata, prepares or claims a caller-approved local branch,
-runs caller-declared validation, and emits review evidence without creating
-external comments, PRs, merges, or publishes.
+[中文](README.zh-CN.md) · [Capability index](../README.md) ·
+[Workflow contract](protocols/issue-fix-workflow-contract-v0.md) ·
+[Acceptance loop](protocols/issue-fix-acceptance-loop-v0.md) ·
+[Reviewer recommendation](protocols/issue-fix-reviewer-recommendation-v0.md)
 
-## Implemented Surface
+Issue-fix is LoopX's product path for turning a public repository issue into a
+small, validated, reviewable pull request and then keeping that PR moving until
+its lifecycle has a clear outcome. The capability is designed for a
+long-running issue-to-PR employee, not for a one-shot code generator: LoopX
+keeps goal state, todos, authority, repository evidence, validation, reviewer
+routing, monitors, human gates, and terminal closeout outside any single chat
+turn.
 
-| Layer | Current path |
+The core product outcome is a focused fix PR when the issue is suitable. A
+public comment or justified triage remains useful for rejecting unsuitable
+candidates or recording a concrete blocker, but it is not a substitute for the
+fix-PR path when that path is feasible.
+
+## What LoopX Provides Underneath
+
+You do not need to know LoopX before using this capability. The shortest mental
+model is: a coding agent can inspect and change a repository, while LoopX is the
+local-first control plane that remembers what the agent is trying to achieve,
+decides what may run next, exposes progress to people, and keeps the work alive
+across chat turns and external waits.
+
+GitHub remains the source of truth for issues, code, checks, reviews, and merge
+state. LoopX adds the missing employee-control layer between a host agent and
+GitHub:
+
+| LoopX foundation | What it contributes to issue/PR fixing |
 | --- | --- |
-| Capability module | `loopx/capabilities/issue_fix/` |
-| CLI entry | `loopx issue-fix ...` |
-| Content-ops bridge | `loopx content-ops issue-fix-* ...` |
-| Protocol docs | `docs/capabilities/issue-fix/protocols/` |
-| Smoke | `examples/issue-fix-workflow-plan-smoke.py`, `examples/issue-fix-repository-context-smoke.py`, `examples/issue-fix-feasibility-smoke.py`, `examples/issue-fix-pr-lifecycle-smoke.py`, `examples/issue-fix-acceptance-loop-smoke.py` |
+| Durable goal state | Keeps the objective, acceptance target, current status, next action, and compact outcome evidence after one model turn ends. |
+| Todo ownership and routing | Separates agent work from concrete human decisions; records priority, `claimed_by`, blockers, successors, handoffs, and monitor work so two agents do not silently do the same task. |
+| Kanban/status projection | Projects the same todo truth into a human-visible board or dashboard without making the board a second state machine. People can see who owns the issue, what was produced, and what is waiting. |
+| Quota and scheduler policy | Uses `quota should-run` to decide whether a bounded work segment should run now, wait, repair state, or stay quiet. Unchanged polling backs off and does not count as delivery progress. |
+| Authority and interaction gates | Separates technical capability from permission. Private material, public comments, push, PR creation, review requests, merge, and production actions can each require explicit recorded authority. |
+| Evidence and repository context | Pins conclusions to a repository revision, source trust, freshness, repo-relative references, reproduction, and validation. Compact evidence survives; raw logs, credentials, and private bodies do not leak into public state. |
+| Replan and handoff contracts | Converts CI failure, reviewer correction, missing information, or a stale branch into a runnable successor, a concrete blocker, or a scoped human question instead of losing the correction in chat. |
+| Continuous monitors | Watches CI, review, mergeability, maintainer comments, stale branches, merged, and closed states; writes back only material transitions and terminates with an explicit outcome. |
+| Public/private boundary checks | Scans public artifacts and keeps local paths, credentials, runtime state, raw transcripts, tool logs, and private evidence out of commits and PRs. |
 
-## Protocols
+The issue-fix capability composes these generic foundations into domain packets
+and CLI commands. The host agent still reads code, edits the worktree, runs
+tests, and performs separately authorized GitHub actions. This division is what
+turns “generate a patch once” into a visible, resumable issue-to-PR employee:
 
-- [`issue_fix_workflow_contract_v0`](protocols/issue-fix-workflow-contract-v0.md)
-- [`issue_fix_acceptance_loop_v0`](protocols/issue-fix-acceptance-loop-v0.md)
-- `issue_fix_workflow_plan_packet_v0`
-- `issue_fix_repository_context_v0`
-- `issue_fix_feasibility_v0`
-- `issue_fix_pr_lifecycle_monitor_v0`
-- `github_issue_metadata_preview_v0`
-- `content_ops_issue_fix_metadata_preview_packet_v0`
-- `content_ops_issue_fix_intake_packet_v0`
-- `issue_fix_intake_v0`
-- `issue_fix_validated_fix_artifact_v0`
-- `issue_fix_caller_repo_branch_packet_v0`
+```text
+public issue
+  -> durable goal and claimed todo
+  -> revision-pinned evidence and reproduction
+  -> focused patch and validation
+  -> explainable reviewer route and authority gate
+  -> PR monitor and material-transition replan
+  -> merged/closed outcome, successor, or explicit no-follow-up
+```
 
-Metadata and intake packet details are currently shared with the content-ops
-surface because issue discovery and content/source intake use the same public
-metadata boundary.
+## Product Position
 
-## Safe Defaults
+LoopX is the control plane, not the coding model or GitHub itself.
 
-- Issue bodies, comments, timeline events, and raw provider payloads are gated
-  and are not copied into packets.
-- Caller repo mode reads and writes only the explicitly approved local git repo.
-- Validation stdout/stderr and local paths are summarized, not recorded.
-- External issue comments, PR creation, merge, publish, and destructive git are
-  out of scope for this capability.
+| Layer | Responsibility |
+| --- | --- |
+| Host agent/runtime | Read code, reproduce the bug, edit files, run tests, and perform explicitly authorized git/GitHub actions. |
+| Issue-fix capability | Build public-safe workflow, feasibility, repository-context, reviewer, validation, and PR-lifecycle packets. |
+| LoopX kernel | Persist goal/todo ownership, quota, authority, evidence, monitor, replan, and human-interaction state. |
+| Repository/GitHub | Remain authoritative for code, policy, CI, review, mergeability, and terminal PR state. |
+| Human maintainer | Own design judgment, repository policy, sensitive/private context, and any action outside recorded authority. |
+
+The issue-fix packet builders do not silently publish. A host agent may create
+or update a PR only when the current LoopX boundary records that authority and
+repository policy allows it. Merge remains a separate decision unless it is
+explicitly authorized.
+
+## End-To-End Design
+
+```mermaid
+flowchart LR
+  I["Public issue candidates"] --> S["Selection and feasibility"]
+  S --> C["Revision-pinned repository context"]
+  C --> R["Reproduction"]
+  R --> F["Focused patch and regression test"]
+  F --> V["Layered validation"]
+  V --> O["Reviewer recommendation"]
+  O --> P["Authority-gated PR publication"]
+  P --> M["CI/review/mergeability monitor"]
+  M --> T["Merged/closed terminal closeout"]
+  T --> N["Next issue or no-follow-up"]
+  H["Human judgment"] --> S
+  H --> O
+  H --> P
+  H --> M
+  LX["LoopX goal/todo/quota/evidence"] --> S
+  LX --> C
+  LX --> V
+  LX --> M
+  T --> LX
+```
+
+### 1. Candidate selection
+
+The first round should select one issue. Prefer public open issues with a
+traceback, failing test, minimal reproduction, bounded change scope, and a
+repository-native focused validation surface. Avoid issues that require
+private data, credentials, production systems, large design debates, or broad
+semantic changes.
+
+Every candidate should receive one explicit route:
+
+- `fix_pr`: reproduction and validation are credible and scope is bounded;
+- `comment_only`: a public clarification or diagnosis adds value, but a safe
+  patch is not ready;
+- `triage_only`: evidence is insufficient, scope is oversized, or following up
+  would not add value.
+
+The long-running employee's primary acceptance target is `fix_pr`; the other
+routes protect quality and maintainer attention.
+
+### 2. Repository-grounded understanding
+
+The authority order is:
+
+1. current checkout evidence;
+2. repository-scoped historical memory;
+3. external expert or bot advice.
+
+Read repository policy, architecture, nearby source and tests, validation
+commands, and recent related fixes at the pinned revision. Compact this into
+`issue_fix_repository_context_input_v0`, including revision, repo-relative
+source references, evidence aspect, source trust, and freshness. Memory and
+expert conclusions are advisory until verified in the current checkout.
+
+### 3. Reproduction before modification
+
+Separate four outcomes instead of flattening every failure into a product bug:
+
+- product bug reproduced;
+- test or fixture bug;
+- environment/dependency failure;
+- report remains under-specified or cannot currently be reproduced.
+
+When possible, make the existing focused test fail for the reported contract
+before changing production code. Preserve compact pass/fail and command-label
+evidence, not raw logs or local paths.
+
+### 4. Focused patch and regression proof
+
+Use a clean worktree and branch from the latest approved base revision. Keep
+the patch small, explainable, and consistent with nearby repository patterns.
+Add or adjust a focused test that would fail without the fix. Expand validation
+only in proportion to risk.
+
+### 5. Reviewer recommendation
+
+Reviewer selection is part of the control plane because a correct patch can
+still stall when the wrong person is asked to review it. LoopX now provides:
+
+```bash
+loopx issue-fix reviewer-plan \
+  --repo-path /path/to/approved/repo \
+  --repo owner/repo \
+  --base-ref origin/main \
+  --exclude-reviewer @pull-request-author \
+  --exclude-author-name "PR Author Git Name" \
+  --execute \
+  --format json
+```
+
+The current evidence order is deliberately conservative:
+
+1. repository `CODEOWNERS` matches for each changed path;
+2. commit history for the exact changed path;
+3. nearest module-directory history when a new file has no usable path
+   history.
+
+The packet ranks candidates with source kinds, reason codes, changed-path
+coverage, history counts, recency, confidence, and whether a GitHub handle is
+actually requestable. It never captures commit email addresses, never records
+the local repo path, and never sends a review request. The caller should
+exclude the PR author and any known unavailable reviewer. History is read at
+the base revision so feature-branch commits do not recommend the author;
+`--exclude-author-name` covers unresolved git-name aliases.
+
+`CODEOWNERS` remains the strongest repository-native signal. Commit volume is
+only evidence of familiarity; it is not proof of maintainership, availability,
+or review authority. See the [reviewer recommendation
+contract](protocols/issue-fix-reviewer-recommendation-v0.md) for scoring,
+identity, and future-signal details.
+
+### 6. PR publication and public-write boundary
+
+Before an external write, prepare a public-safe package containing:
+
+- problem and root cause;
+- bounded diff summary;
+- focused and expanded validation;
+- risk and omissions;
+- reviewer evidence;
+- PR body or comment draft.
+
+PR creation, public comments, push, merge, and publish are external writes.
+The host agent may perform only the actions covered by current boundary
+authority. Recommendation packets themselves remain read-only.
+
+### 7. Continuous PR lifecycle
+
+After a PR exists, create a `continuous_monitor` todo with a stable target and
+cadence. `loopx issue-fix pr-lifecycle` projects compact public PR metadata
+into one of four decisions:
+
+- `runnable_successor`: CI failed, review requested changes, or the branch
+  needs an actionable replan;
+- `monitor_continuation`: checks/review are still pending or nothing material
+  changed;
+- `user_gate`: an explicit human decision is required;
+- `no_followup`: the PR is merged or closed and the monitor can terminate.
+
+Identical polls should not create work, consume delivery quota, or spam the
+maintainer. Material transitions must produce a successor, concrete blocker,
+or structured no-follow-up; the agent must not stop silently in monitor-only
+state.
+
+### 8. Terminal closeout and repeatability
+
+At merged/closed state, persist compact lifecycle evidence, close the monitor,
+sync the management surface, record residual risk, and choose one of:
+
+- next issue selection;
+- a concrete rollout/follow-up todo;
+- a blocker or superseding route;
+- structured no-follow-up.
+
+One merged PR proves a delivery slice. Repeating the loop on independent issues
+tests whether the system is a durable employee rather than a scripted demo.
+
+## Implemented Surfaces
+
+| Surface | Command or path | Current responsibility |
+| --- | --- | --- |
+| Workflow plan | `loopx issue-fix workflow-plan` | Compose body-free metadata, intake, branch plan, validation label, ordered todo previews, gates, and PR-readiness blockers. |
+| Repository context | `--repository-context-json` | Pin policy, architecture, change-scope, reproduction, and validation evidence with trust and freshness. |
+| Feasibility | `loopx issue-fix feasibility` | Select exactly one `fix_pr`, `comment_only`, or `triage_only` route and optionally persist compact domain state. |
+| Reviewer plan | `loopx issue-fix reviewer-plan` | Rank explainable reviewer candidates from CODEOWNERS and changed-path/module history without requesting review. |
+| PR lifecycle | `loopx issue-fix pr-lifecycle` | Project CI, review, merge state, draft, merged, and closed signals into monitor transitions. |
+| Acceptance fixture | `loopx issue-fix acceptance-fixture` | Prove failure-before, minimal patch, and pass-after in a deterministic fixture. |
+| Git branch fixture | `loopx issue-fix repo-branch-fixture` | Exercise the same repair contract through a temporary git branch. |
+| Caller repo branch | `loopx issue-fix caller-repo-branch` | Inspect an approved local repo, create/claim an issue branch, and run caller-declared validation. |
+| Content bridge | `loopx content-ops issue-fix-*` | Reuse body-free public metadata/intake boundaries. |
+| Long-running control | `loopx todo`, `quota`, `refresh-state`, `lark-kanban` | Persist ownership, gates, compute decisions, progress, evidence, and visible Kanban state. |
+
+The capability module lives at `loopx/capabilities/issue_fix/`; domain-state
+rows live in the existing issue-fix domain pack rather than a parallel context
+ledger.
+
+## Truth And Evidence Model
+
+### Revision-pinned repository context
+
+Repository context should answer:
+
+| Question | Required evidence |
+| --- | --- |
+| What revision is authoritative? | Full base revision and branch relationship. |
+| What can change? | Repo-relative source/test references and nearby patterns. |
+| How is the issue reproduced? | Focused command or compact observed contract. |
+| How is the fix validated? | Repository-native focused validation and risk-based expansion. |
+| Which source is trusted? | Repository policy/current code first; memory/expert sources marked advisory. |
+| Is the evidence fresh? | Revision or timestamp tied to the current checkout. |
+
+### Public-safe evidence
+
+Packets preserve compact classifications and references. They do not preserve:
+
+- raw issue/comment bodies by default;
+- raw validation, git, provider, or expert output;
+- local absolute paths;
+- credentials or private material;
+- transcript/tool capture or automatic memory writeback without an approved
+  isolation boundary.
+
+### Environment vs product attribution
+
+An unavailable dependency, killed process, or missing service is environment
+evidence. It may block a validation surface without refuting the product bug.
+Conversely, a failing legacy test does not prove the new patch caused the
+failure; compare the pinned base and changed hunks before attribution.
+
+## Reviewer Routing Contract
+
+The reviewer recommendation layer separates three concepts:
+
+1. **ownership evidence**: CODEOWNERS and path/module contribution history;
+2. **review recommendation**: explainable ranked candidates;
+3. **review request**: an external write governed by repository policy and
+   boundary authority.
+
+Current scoring gives CODEOWNERS matches dominant weight, then uses recency-
+weighted commit history. A new file falls back to its nearest module directory
+only when no non-excluded exact-path history is usable. The packet exposes the
+reason instead of presenting a score as authority.
+
+Important safeguards:
+
+- exclude the PR author and explicitly unavailable reviewers;
+- do not expose commit email addresses;
+- do not treat bots, anonymous identities, or unresolved names as requestable;
+- cap candidates and show path coverage;
+- keep team handles distinct from individual handles;
+- respect required-review and branch-protection policy outside the ranking;
+- never infer merge authority from reviewer familiarity.
+
+Planned signals, added only with real call sites and public-safe evidence:
+
+- package/module maintainer metadata beyond CODEOWNERS;
+- recent review participation and accepted-review history;
+- reviewer load, stale request detection, and fallback routing;
+- bus-factor/risk hints when one person dominates a critical module;
+- GitHub identity resolution for public git authors without noreply handles;
+- explicit repository allow/deny lists and team membership verification.
+
+## Human Interaction Model
+
+Humans should be interrupted for decisions, not routine progress. Typical
+concrete user gates are:
+
+- private reproduction material or credentials are required;
+- architecture or behavior scope is genuinely ambiguous;
+- repository policy requires a specific reviewer or owner approval;
+- public write authority is missing;
+- maintainer feedback changes the intended behavior;
+- merge or production authority is not recorded.
+
+CI pending, unchanged monitor polls, routine reviewer evidence collection, and
+repository-native focused validation remain agent work. A visible Kanban can
+project todo ownership, status, evidence, blockers, and outputs without becoming
+a second source of truth.
+
+## Public Pilot Evidence
+
+The first public end-to-end pilot selected
+[OpenViking issue #3102](https://github.com/volcengine/OpenViking/issues/3102),
+published a focused fix, passed required CI and review, and reached
+[merged PR #3115](https://github.com/volcengine/OpenViking/pull/3115). The case
+validated the host-agent loop around revision-pinned context, reproduction,
+focused validation, authority-gated publication, continuous monitoring,
+terminal closeout, Kanban visibility, and successor planning.
+
+The pilot also produced generic LoopX control-plane feedback in
+[PR #1784](https://github.com/huangruiteng/loopx/pull/1784). Pilot evidence is
+advisory for product design until the corresponding generic changes are merged;
+the current repository revision remains authoritative.
+
+## Roadmap
+
+### Current stage
+
+- public metadata and route selection;
+- repository-context provenance;
+- deterministic and caller-repo repair artifacts;
+- focused validation evidence;
+- reviewer recommendation from repository-native ownership evidence;
+- PR lifecycle projection;
+- LoopX todo/quota/monitor/Kanban integration through the host agent.
+
+### Next stage
+
+- integrate reviewer recommendation into PR-ready and lifecycle packets;
+- resolve public GitHub identities and repository teams without leaking email;
+- make publication authority visible per external action;
+- make unchanged lifecycle observations physically idempotent everywhere;
+- project maintainer corrections into explicit patch/blocker successors;
+- add a reusable terminal acceptance report across repeated issues.
+
+### Longer-term stage
+
+- multi-repository issue portfolios with bounded concurrency;
+- maintainer preference learning from public accepted/rejected outcomes;
+- reviewer load balancing and bus-factor awareness;
+- richer repository memory with explicit workspace/peer isolation;
+- Open Knowledge Format interoperability after the repository-context contract
+  stabilizes;
+- project-level metrics for accepted fixes, cycle time, human attention,
+  regressions, and boundary incidents.
+
+## Success Metrics
+
+Track outcomes, not agent activity:
+
+- selected issues that reach a focused PR;
+- focused PRs accepted or merged;
+- failure-before/pass-after proof rate;
+- unrelated regression rate;
+- time from issue selection to review-ready and terminal state;
+- number and type of human interventions;
+- reviewer recommendation acceptance/override rate;
+- unchanged monitor polls skipped;
+- public/private boundary incidents;
+- LoopX generic gaps fixed or converted into concrete claimed todos.
 
 ## Conversational `/loopx` Entry
 
-When the user starts from a chat box or command palette, use the project-local
-goal command first:
+On a host with the LoopX slash entry, start the long-running goal directly:
 
 ```text
 /loopx Fix https://github.com/owner/repo/issues/123
 ```
 
-The host or skill fallback should run the command pack preview with the exact
-goal text:
+For a manually integrated host, inspect the command pack and then start the
+same exact goal text through the guided CLI transaction:
 
 ```bash
-loopx bootstrap-command-pack --project . \
+loopx bootstrap-command-pack --project .
+loopx start-goal --guided --project . \
   --goal-text "Fix https://github.com/owner/repo/issues/123"
 ```
 
-For a GitHub issue/PR fix goal, the command pack points to the issue-fix
-workflow planner before todo writeback:
-
-```bash
-loopx issue-fix workflow-plan \
-  --url https://github.com/owner/repo/issues/123 \
-  --repo-path <approved-repo> \
-  --repository-context-json repository-context.json \
-  --validation-label "<validation command>" \
-  --format json
-```
-
-The workflow-plan output is still preview-only. Initial writeback is deliberately
-small: public metadata classification followed by one feasibility checkpoint.
-The checkpoint selects exactly one `fix_pr`, `comment_only`, or `triage_only`
-route and projects only that route's successor or no-follow-up. Concrete owner
-actions remain explicit gates, including private repro material, issue
-body/comment reads, external issue comments, PR creation, merge, publish,
-destructive git, production actions, and repository-policy approvals.
-
-## Workflow Plan
-
-```bash
-loopx issue-fix workflow-plan --url https://github.com/owner/repo/issues/123
-```
-
-The workflow planner is preview-only. It composes public metadata preview,
-issue intake, branch dry-run planning, validation labels, ordered LoopX todo
-writeback previews, and PR review readiness blockers into one packet. It does
-not write LoopX todos, inspect the local repo in dry-run mode, create external
-comments or PRs, merge, or capture raw issue body/comment material.
-
-## Repository Context
-
-`--repository-context-json` accepts an
-`issue_fix_repository_context_input_v0` object with a pinned repository
-revision and up to 16 compact source records. Each record names only a source
-id, kind, public-safe reference, trust, freshness, supported decision aspects,
-and an optional compact summary. Raw source content, expert responses, logs,
-credentials, and local paths are rejected.
-
-The projection distinguishes `authoritative`, `verified`, and `advisory`
-evidence across architecture, ownership, change scope, reproduction, and
-validation. Only current repository evidence can ground a decision. External
-experts always remain advisory and cannot authorize comments, PRs, merges, or
-other external writes. The workflow plan uses missing coverage to name the
-next repository reads without adding another lifecycle state or todo chain.
-
-Memory systems such as OpenViking may supply compact `memory_retrieval` source
-refs. They do not become the source of truth: retrieved claims must be checked
-against the pinned repository revision. Knowledge bundles remain
-format-agnostic so an Open Knowledge Format bundle can be referenced without
-making the issue-fix state machine depend on that draft interchange format.
+The conversational entry does not bypass issue selection, authority, or
+validation. It creates the durable goal/todo/host-loop route from which the
+issue-fix commands below can be executed.
 
 ## Feasibility Decision
 
-```bash
-loopx issue-fix feasibility \
-  --url https://github.com/owner/repo/issues/123 \
-  --reproduction-status planned \
-  --reproduction-label "focused repro plan" \
-  --scope-class bounded \
-  --validation-label "focused unit test" \
-  --repository-context-json repository-context.json \
-  --goal-id example-goal \
-  --format json
-```
+`loopx issue-fix feasibility` selects exactly one of `fix_pr`, `comment_only`,
+or `triage_only`. A `fix_pr` decision requires bounded change scope plus a
+named reproduction and validation surface. The compact decision belongs in the
+existing issue-fix domain state before writing todos for the chosen route; it
+does not create a parallel workflow ledger.
 
-Feasibility consumes only compact agent observations. It never stores raw issue
-bodies, comment bodies, provider responses, logs, local paths, or credentials.
-`fix_pr` requires bounded scope plus named reproduction and validation surfaces;
-a planned repro first projects `issue_fix_confirm_reproduction`, not patch work.
-`comment_only` projects a comment-draft todo with an external-write gate, while
-`triage_only` projects structured no-follow-up.
+## Repository Context
 
-With `--goal-id` or `--ledger-path`, the decision is upserted by repo and issue
-reference into `.loopx/domain-state/<goal-id>/issue_fix/feasibility.jsonl`.
-The same row keeps the compact repository-context fingerprint, source refs,
-coverage, expert policy, and memory policy so the next agent turn does not lose
-its evidence basis. Use `--no-write-domain-state` for preview-only checks.
-
-For a concrete public pilot and staged adoption plan, see
-[`OpenViking issue-fix pilot handoff`](openviking-pilot-handoff.md).
+Both workflow planning and feasibility accept
+`--repository-context-json <compact-context.json>`. The input must pin the
+current revision and keep source references repo-relative. Current checkout
+evidence remains authoritative; memory and expert conclusions stay advisory
+until verified. The public
+[OpenViking pilot handoff](openviking-pilot-handoff.md) shows how the real
+pilot applies that evidence order without introducing a repository-specific
+control path.
 
 ## PR Lifecycle Monitor
 
+After publication, `loopx issue-fix pr-lifecycle` and a `continuous_monitor`
+todo keep CI, review, maintainer correction, mergeability, stale branch, and
+terminal status visible. Publication, review requests, merge, and access to
+private material remain explicit gates. Each material transition must yield a
+`runnable_successor`, concrete blocker, or structured no-follow-up; unchanged
+polls remain quiet and do not spend delivery quota.
+
+## Commands
+
 ```bash
+# Preview the complete issue-fix workflow.
+loopx issue-fix workflow-plan \
+  --url https://github.com/owner/repo/issues/123 \
+  --repo-path /path/to/approved/repo \
+  --repository-context-json context.json \
+  --validation-label "focused unit test" \
+  --format json
+
+# Select one route and persist compact goal-scoped feasibility state.
+loopx issue-fix feasibility \
+  --url https://github.com/owner/repo/issues/123 \
+  --reproduction-status confirmed \
+  --reproduction-label "focused contract repro" \
+  --scope-class bounded \
+  --validation-label "focused unit test" \
+  --repository-context-json context.json \
+  --goal-id example-goal \
+  --format json
+
+# Recommend reviewers without requesting external review.
+loopx issue-fix reviewer-plan \
+  --repo-path /path/to/approved/repo \
+  --repo owner/repo \
+  --base-ref origin/main \
+  --exclude-reviewer @pull-request-author \
+  --exclude-author-name "PR Author Git Name" \
+  --execute \
+  --format json
+
+# Project PR lifecycle into LoopX continuation state.
 loopx issue-fix pr-lifecycle \
-  --url https://github.com/owner/repo/pull/123 \
-  --metadata-json public-pr-state.json \
+  --url https://github.com/owner/repo/pull/456 \
+  --fetch-metadata \
   --goal-id example-goal \
   --format json
 ```
-
-The PR lifecycle projection turns compact public PR state into one of four
-transitions: `runnable_successor`, `monitor_continuation`, `user_gate`, or
-`no_followup`. Terminal PR states such as `MERGED` or `CLOSED` take precedence
-over stale review metadata; failed checks and requested changes create runnable
-successors; quiet states continue the monitor.
-
-When `--goal-id` or `--ledger-path` is provided, the command writes the compact
-observation into `.loopx/domain-state/<goal-id>/issue_fix/pr-lifecycle.jsonl` by
-default. Use `--no-write-domain-state` for preview-only tests. Domain state is
-project-local and gitignored; it records compact row keys, observations,
-transition decisions, and fingerprints, never issue bodies, comments, raw
-provider payloads, raw check logs, local paths, or credentials.
 
 ## Validation
 
 ```bash
+python3 examples/issue-fix-capability-guide-smoke.py
+python3 examples/issue-fix-reviewer-recommendation-smoke.py
 python3 examples/issue-fix-workflow-plan-smoke.py
+python3 examples/issue-fix-workflow-contract-smoke.py
 python3 examples/issue-fix-repository-context-smoke.py
 python3 examples/issue-fix-feasibility-smoke.py
 python3 examples/issue-fix-pr-lifecycle-smoke.py
-python3 examples/issue-fix-workflow-contract-smoke.py
-python3 examples/content-ops-issue-fix-metadata-preview-smoke.py
-python3 examples/content-ops-issue-fix-intake-smoke.py
 python3 examples/issue-fix-acceptance-loop-smoke.py
+loopx canary premerge --from-git-diff
 ```
+
+## Non-Goals
+
+- LoopX does not bypass repository review or branch protection.
+- Reviewer recommendation is not reviewer assignment or availability proof.
+- The capability does not default to automatic merge or production actions.
+- It does not store raw transcripts, tool logs, expert answers, credentials, or
+  private issue material in public state.
+- It does not add repository-specific branches such as `if repo == ...` to the
+  generic control plane.

--- a/docs/capabilities/issue-fix/README.zh-CN.md
+++ b/docs/capabilities/issue-fix/README.zh-CN.md
@@ -1,0 +1,469 @@
+# Issue-Fix 能力
+
+[English](README.md) · [能力目录](../README.md) ·
+[工作流协议](protocols/issue-fix-workflow-contract-v0.md) ·
+[验收循环](protocols/issue-fix-acceptance-loop-v0.md) ·
+[Reviewer 推荐协议](protocols/issue-fix-reviewer-recommendation-v0.md)
+
+Issue-Fix 是 LoopX 把公开仓库 issue 持续推进成小而聚焦、验证充分、可审阅 PR，
+并继续跟进到明确 PR 生命周期终局的产品能力。它面向的是一个长程 issue→PR
+数字员工，而不是一次性的代码生成器：goal 状态、todo、authority、仓库证据、
+validation、reviewer 路由、monitor、人类 gate 和 terminal closeout 都保存在单次
+聊天之外。
+
+当 issue 适合修复时，核心产出是 focused fix PR。公开 comment 或有理有据的 triage
+仍可用于拒绝不合适候选、澄清信息或记录具体 blocker，但不能在 `fix_pr` 可行时
+替代 PR 主路径。
+
+## LoopX 底座提供什么
+
+使用这项能力不要求先了解 LoopX。最短的心智模型是：coding agent 负责理解仓库和修改
+代码；LoopX 是 local-first 控制面，负责记住 agent 要达成什么、决定下一步能否运行、
+把进度展示给人，并让任务跨聊天轮次和外部等待持续存在。
+
+GitHub 仍然是 issue、代码、checks、review 和 merge state 的事实源。LoopX 补上 host
+agent 与 GitHub 之间缺失的“数字员工控制层”：
+
+| LoopX 底座能力 | 在 issue/PR fix 场景中的作用 |
+| --- | --- |
+| 持久化 goal state | 在一次模型 turn 结束后继续保存 objective、acceptance target、current status、next action 和紧凑 outcome evidence。 |
+| Todo ownership 与 routing | 区分 agent 工作和具体人类决策；记录 priority、`claimed_by`、blocker、successor、handoff 和 monitor，避免多个 agent 无声重复做同一任务。 |
+| Kanban/status 投影 | 把同一份 todo 事实投影到人可见的看板或 dashboard，但不让看板变成第二套状态机。人可以看到谁负责、产出了什么、在等什么。 |
+| Quota 与 scheduler policy | 通过 `quota should-run` 决定现在应执行有界工作、等待、修状态还是安静跳过；unchanged poll 会退避，也不冒充 delivery progress。 |
+| Authority 与 interaction gate | 把“技术上能做”与“被允许做”分开。私有材料、公开 comment、push、建 PR、请求 review、merge 和 production action 都可分别要求明确 authority。 |
+| Evidence 与 repository context | 把结论固定到 repository revision、source trust、freshness、repo-relative reference、reproduction 和 validation；保留紧凑证据，不把 raw log、凭据或私有正文带进公开状态。 |
+| Replan 与 handoff contract | 把 CI failure、reviewer correction、信息缺失或 stale branch 转成 runnable successor、具体 blocker 或有范围的人类问题，而不是让修正消失在聊天里。 |
+| Continuous monitor | 跟踪 CI、review、mergeability、maintainer comment、stale branch、merged 和 closed；只写回 material transition，并以明确 outcome 终止。 |
+| Public/private boundary check | 扫描公开 artifact，阻止本地路径、credentials、runtime state、raw transcript、tool log 和私有 evidence 进入 commit/PR。 |
+
+Issue-Fix capability 把这些通用底座组合成领域 packet 和 CLI。Host agent 仍负责读代码、
+修改 worktree、跑测试，以及执行另行授权的 GitHub 动作。正是这种分工，把“一次性生成
+patch”变成可见、可恢复、可持续的 issue→PR 数字员工：
+
+```text
+公开 issue
+  -> 持久化 goal 与已认领 todo
+  -> revision-pinned evidence 与复现
+  -> focused patch 与 validation
+  -> 可解释 reviewer route 与 authority gate
+  -> PR monitor 与 material-transition replan
+  -> merged/closed outcome、successor 或明确 no-follow-up
+```
+
+## 产品定位
+
+LoopX 是控制面，不是 coding model，也不是 GitHub 本身。
+
+| 层次 | 职责 |
+| --- | --- |
+| Host agent/runtime | 读代码、复现、修改文件、运行测试，并执行已明确授权的 git/GitHub 动作。 |
+| Issue-Fix capability | 生成 public-safe 的 workflow、feasibility、repository-context、reviewer、validation 和 PR-lifecycle packet。 |
+| LoopX kernel | 持久化 goal/todo ownership、quota、authority、evidence、monitor、replan 和人机交互状态。 |
+| Repository/GitHub | 继续作为代码、仓库政策、CI、review、mergeability 和 PR 终局的事实源。 |
+| Human maintainer | 负责设计判断、仓库政策、敏感/私有上下文，以及超出已记录 authority 的动作。 |
+
+Issue-Fix packet builder 不会偷偷发布。只有当前 LoopX boundary 已记录相应 authority，
+且仓库政策允许时，host agent 才能创建或更新 PR。Merge 是独立决策，除非也被明确授权。
+
+## 端到端设计
+
+```mermaid
+flowchart LR
+  I["公开 issue 候选"] --> S["选题与可行性"]
+  S --> C["Revision-pinned 仓库上下文"]
+  C --> R["复现"]
+  R --> F["Focused patch 与回归测试"]
+  F --> V["分层验证"]
+  V --> O["Reviewer 推荐"]
+  O --> P["Authority-gated PR 发布"]
+  P --> M["CI/review/mergeability monitor"]
+  M --> T["Merged/closed 终局收口"]
+  T --> N["下一个 issue 或 no-follow-up"]
+  H["人类判断"] --> S
+  H --> O
+  H --> P
+  H --> M
+  LX["LoopX goal/todo/quota/evidence"] --> S
+  LX --> C
+  LX --> V
+  LX --> M
+  T --> LX
+```
+
+### 1. 候选筛选
+
+第一轮只选一个 issue。优先公开、open、带 traceback、failing test、最小复现、
+变更范围可控，并且存在 repository-native focused validation 的问题。避免依赖私有
+数据、凭据、生产系统、大型设计争议或宽泛语义变化的候选。
+
+每个候选必须明确选择一条路：
+
+- `fix_pr`：复现和验证可信，范围可控；
+- `comment_only`：公开澄清或诊断有价值，但尚不具备安全 patch 条件；
+- `triage_only`：证据不足、范围过大，或继续跟进没有实际价值。
+
+长程数字员工的主验收是 `fix_pr`；另外两条路用于保护质量和 maintainer 注意力。
+
+### 2. 以当前仓库为准的理解
+
+Authority 优先级严格为：
+
+1. 当前 checkout 的证据；
+2. 仓库范围内的历史 memory；
+3. 外部 expert/bot 建议。
+
+在 pinned revision 阅读仓库政策、架构、附近源码和测试、验证命令以及近期相关修复，
+再压缩成 `issue_fix_repository_context_input_v0`：包含 revision、repo-relative
+source ref、证据类别、source trust 与 freshness。Memory/expert 只作 advisory，
+影响 patch 的结论必须在当前 checkout 验证。
+
+### 3. 先复现，再修改
+
+不要把所有失败都解释成产品 bug，要区分：
+
+- 产品 bug 已复现；
+- 测试或 fixture bug；
+- 环境/依赖失败；
+- issue 信息仍不足或当前无法复现。
+
+如果条件允许，先让现有 focused test 因报告中的 contract 失败，再改生产代码。
+只记录紧凑的 pass/fail 和命令标签，不记录 raw log 或本地路径。
+
+### 4. Focused patch 与回归证明
+
+从最新获批 base revision 创建干净 worktree 和独立分支。补丁保持小、可解释，
+遵循附近代码模式；新增或调整一个“没有修复就会失败”的 focused test。验证范围随风险
+逐步扩大，而不是一开始就跑无边界的全仓测试。
+
+### 5. Reviewer 推荐
+
+Reviewer 路由属于控制面，因为 patch 正确但 reviewer 找错，同样会让 PR 长期停滞。
+LoopX 现在提供：
+
+```bash
+loopx issue-fix reviewer-plan \
+  --repo-path /path/to/approved/repo \
+  --repo owner/repo \
+  --base-ref origin/main \
+  --exclude-reviewer @pull-request-author \
+  --exclude-author-name "PR Author Git Name" \
+  --execute \
+  --format json
+```
+
+当前证据优先级刻意保持保守：
+
+1. 每个改动路径命中的仓库 `CODEOWNERS`；
+2. 改动文件本身的提交历史；
+3. 新文件没有可用 path history 时，回退到最近 module 目录的提交历史。
+
+Packet 输出候选的 source kind、reason code、改动路径覆盖、history 次数、recency、
+confidence，以及是否真的有可请求的 GitHub handle。它不保存 commit email，
+不记录本地 repo path，也不会自动发送 review request。调用方应排除 PR author 和已知
+不可用 reviewer。History 固定读取 base revision，避免 feature branch 自己的提交把
+作者推荐回来；`--exclude-author-name` 用于排除无法解析成 GitHub handle 的 git-name
+alias。
+
+`CODEOWNERS` 是最强的 repository-native 信号。提交量只说明“可能熟悉”，不代表
+maintainer 身份、可用性或 review authority。评分、身份解析与未来信号详见
+[Reviewer 推荐协议](protocols/issue-fix-reviewer-recommendation-v0.md)。
+
+### 6. PR 发布与公开写边界
+
+外部写入前应准备 public-safe package：
+
+- 问题与根因；
+- 有边界的 diff 摘要；
+- focused 与扩大验证；
+- 风险和未覆盖项；
+- reviewer 证据；
+- PR body/comment 草稿。
+
+PR 创建、公开 comment、push、merge 和 publish 都是外部写操作。Host agent 只能
+执行当前 boundary authority 覆盖的动作；recommendation packet 始终保持只读。
+
+### 7. 持续 PR 生命周期
+
+PR 存在后，创建带稳定 target 和 cadence 的 `continuous_monitor` todo。
+`loopx issue-fix pr-lifecycle` 把紧凑的公开 PR metadata 投影成四种决策：
+
+- `runnable_successor`：CI 失败、review 请求修改，或分支需要可执行 replan；
+- `monitor_continuation`：checks/review 仍在等待，或没有 material change；
+- `user_gate`：需要明确的人类决策；
+- `no_followup`：PR 已 merged/closed，monitor 可以终止。
+
+相同 poll 不应制造工作、消费 delivery quota 或打扰 maintainer。Material transition
+必须生成 successor、具体 blocker 或结构化 no-follow-up；agent 不能静默停在
+monitor-only。
+
+### 8. Terminal closeout 与可重复性
+
+到 merged/closed 状态后，持久化紧凑 lifecycle evidence、关闭 monitor、同步管理面、
+记录剩余风险，并选择：
+
+- 下一个 issue；
+- 明确 rollout/follow-up todo；
+- blocker 或 superseding route；
+- 结构化 no-follow-up。
+
+一个 merged PR 证明一次 delivery slice；在独立 issue 上重复，才能证明它是稳定数字
+员工，而不是 scripted demo。
+
+## 已实现能力面
+
+| 能力面 | 命令或路径 | 当前职责 |
+| --- | --- | --- |
+| Workflow plan | `loopx issue-fix workflow-plan` | 组合 body-free metadata、intake、branch plan、validation label、todo preview、gate 和 PR-readiness blocker。 |
+| Repository context | `--repository-context-json` | 用 trust/freshness 固定 policy、architecture、change-scope、reproduction 和 validation 证据。 |
+| Feasibility | `loopx issue-fix feasibility` | 在 `fix_pr`、`comment_only`、`triage_only` 中只选一条，并可写入紧凑 domain state。 |
+| Reviewer plan | `loopx issue-fix reviewer-plan` | 从 CODEOWNERS 与改动 path/module history 生成可解释候选，但不请求 review。 |
+| PR lifecycle | `loopx issue-fix pr-lifecycle` | 把 CI、review、merge state、draft、merged、closed 信号投影为 monitor transition。 |
+| Acceptance fixture | `loopx issue-fix acceptance-fixture` | 在 deterministic fixture 中证明 failure-before、minimal patch、pass-after。 |
+| Git branch fixture | `loopx issue-fix repo-branch-fixture` | 在临时 git branch 中运行同一修复 contract。 |
+| Caller repo branch | `loopx issue-fix caller-repo-branch` | 检查获批本地 repo、创建/认领 issue branch、运行 caller-declared validation。 |
+| Content bridge | `loopx content-ops issue-fix-*` | 复用 body-free public metadata/intake 边界。 |
+| 长程控制 | `loopx todo`、`quota`、`refresh-state`、`lark-kanban` | 保存 ownership、gate、compute 决策、进度、evidence 和可见 Kanban。 |
+
+Capability module 位于 `loopx/capabilities/issue_fix/`。Domain state 复用现有
+issue-fix domain pack，不额外创建平行 context ledger。
+
+## Truth 与 Evidence 模型
+
+### Revision-pinned repository context
+
+Repository context 应回答：
+
+| 问题 | 必需证据 |
+| --- | --- |
+| 哪个 revision 有权威性？ | 完整 base revision 与 branch 关系。 |
+| 哪些文件可变？ | Repo-relative source/test ref 与附近实现模式。 |
+| 如何复现？ | Focused command 或紧凑 observed contract。 |
+| 如何验证修复？ | Repository-native focused validation 与风险驱动的扩大验证。 |
+| 哪种 source 更可信？ | 仓库政策/当前代码优先，memory/expert 标为 advisory。 |
+| 证据是否新鲜？ | Revision 或 timestamp 与当前 checkout 绑定。 |
+
+### Public-safe evidence
+
+Packet 保存紧凑分类和 reference，不保存：
+
+- 默认不复制 raw issue/comment body；
+- raw validation、git、provider 或 expert 输出；
+- 本地绝对路径；
+- credentials 或私有材料；
+- 未获批准的 transcript/tool 自动捕获或 memory writeback。
+
+### 环境问题与产品问题分离
+
+依赖缺失、进程被 kill、服务不可用属于环境证据，可能阻塞某个 validation surface，
+但不能自动推翻产品 bug。反过来，legacy test 失败也不能证明新 patch 有问题；必须对比
+pinned base 与改动 hunk 后再归因。
+
+## Reviewer 路由 Contract
+
+Reviewer recommendation 明确拆开三个概念：
+
+1. **ownership evidence**：CODEOWNERS 与 path/module contribution history；
+2. **review recommendation**：可解释的排序候选；
+3. **review request**：受仓库政策和 boundary authority 管理的外部写操作。
+
+当前评分让 CODEOWNERS 占主导权重，再使用 recency-weighted commit history。新文件仅在
+没有可用 exact-path history 时回退到最近 module 目录。Packet 输出 reason，不把分数
+伪装成 authority。
+
+重要防护：
+
+- 排除 PR author 和明确不可用 reviewer；
+- 不暴露 commit email；
+- bot、匿名身份或未解析 name 不得视为 requestable；
+- 限制候选数量并展示 path coverage；
+- team handle 与个人 handle 分开；
+- 排序之外仍遵守 required-review 与 branch-protection policy；
+- 不从代码熟悉度推断 merge authority。
+
+只有出现真实 call site 和 public-safe evidence 后才加入的规划信号：
+
+- CODEOWNERS 之外的 package/module maintainer metadata；
+- 最近 review 参与和 accepted-review history；
+- reviewer load、stale request 与 fallback routing；
+- 关键 module 由单人主导时的 bus-factor 风险；
+- 无 noreply handle 的公开 git author 到 GitHub identity 的解析；
+- 仓库显式 allow/deny list 与 team membership 验证。
+
+## 人机交互模型
+
+人应当为判断被打扰，而不是为例行进度被打扰。典型 user gate：
+
+- 需要私有复现材料或凭据；
+- architecture/behavior scope 确实存在歧义；
+- 仓库政策要求特定 reviewer 或 owner approval；
+- 缺少公开写 authority；
+- maintainer feedback 改变预期行为；
+- merge/production authority 未记录。
+
+CI pending、相同 monitor poll、例行 reviewer 证据收集和 repository-native focused
+validation 都属于 agent 工作。可见 Kanban 可以投影 todo ownership、status、evidence、
+blocker 和 output，但不能成为第二个事实源。
+
+## 公开 Pilot 证据
+
+第一个公开端到端 pilot 选择了
+[OpenViking issue #3102](https://github.com/volcengine/OpenViking/issues/3102)，
+发布 focused fix，通过必需 CI 和 review，最终进入
+[merged PR #3115](https://github.com/volcengine/OpenViking/pull/3115)。该案例验证了
+host-agent 周边的 revision-pinned context、复现、focused validation、authority-gated
+发布、持续监控、terminal closeout、Kanban 可见性和 successor planning。
+
+Pilot 还在 [PR #1784](https://github.com/huangruiteng/loopx/pull/1784) 中形成了通用
+LoopX 控制面反馈。在对应通用改动合并前，pilot 证据只作为产品设计建议；当前仓库
+revision 仍是事实源。
+
+## Roadmap
+
+### 当前阶段
+
+- 公开 metadata 与 route selection；
+- repository-context provenance；
+- deterministic/caller-repo repair artifact；
+- focused validation evidence；
+- 基于 repository-native ownership evidence 的 reviewer recommendation；
+- PR lifecycle projection；
+- host agent 驱动的 LoopX todo/quota/monitor/Kanban 集成。
+
+### 下一阶段
+
+- 把 reviewer recommendation 接入 PR-ready 和 lifecycle packet；
+- 在不泄露 email 的前提下解析公开 GitHub identity 与 repository team；
+- 按外部动作显示 publication authority；
+- 让相同 lifecycle observation 在所有路径上物理幂等；
+- 把 maintainer correction 投影成明确 patch/blocker successor；
+- 跨重复 issue 生成统一 terminal acceptance report。
+
+### 更长期
+
+- 多仓库 issue portfolio 与有界并发；
+- 从公开 accepted/rejected outcome 学习 maintainer preference；
+- reviewer load balancing 与 bus-factor awareness；
+- 带显式 workspace/peer 隔离的 richer repository memory；
+- repository-context contract 稳定后的 Open Knowledge Format 互操作；
+- accepted fix、cycle time、human attention、regression、boundary incident 等项目级指标。
+
+## 成功指标
+
+衡量 outcome，而不是 agent 活跃度：
+
+- 选中 issue 到 focused PR 的比例；
+- focused PR accepted/merged 比例；
+- failure-before/pass-after 证明率；
+- 无关 regression 率；
+- issue selection 到 review-ready/terminal 的时间；
+- 人工介入次数和类型；
+- reviewer recommendation 接受/覆盖率；
+- 跳过的 unchanged monitor poll；
+- public/private boundary incident；
+- pilot 暴露的通用 LoopX gap 是否修复或转成具体 claimed todo。
+
+## 对话式 `/loopx` 入口
+
+Host 已提供 LoopX slash entry 时，直接启动长程目标：
+
+```text
+/loopx Fix https://github.com/owner/repo/issues/123
+```
+
+手工集成的 host 先查看 command pack，再用完全相同的目标文本启动 guided CLI
+transaction：
+
+```bash
+loopx bootstrap-command-pack --project .
+loopx start-goal --guided --project . \
+  --goal-text "Fix https://github.com/owner/repo/issues/123"
+```
+
+对话入口不会跳过 issue 筛选、authority 或 validation；它负责创建持久化的
+goal/todo/host-loop 路由，后续再执行下方 issue-fix 命令。
+
+## Feasibility 决策
+
+`loopx issue-fix feasibility` 必须在 `fix_pr`、`comment_only`、`triage_only`
+中唯一选择一条 route。`fix_pr` 需要 bounded change scope，以及明确命名的
+reproduction 和 validation surface。应先把紧凑决策写入现有 issue-fix domain state，
+再为选定 route 写 todos；不要另建并行 workflow ledger。
+
+## Repository Context
+
+Workflow plan 与 feasibility 都接受
+`--repository-context-json <compact-context.json>`。输入必须 pin 当前 revision，并使用
+repo-relative source ref。当前 checkout 证据保持最高权威；memory/expert 结论在当前
+仓库验证前只作 advisory。公开的
+[OpenViking pilot handoff](openviking-pilot-handoff.md) 展示真实 pilot 如何应用该证据
+顺序，同时不引入仓库特判控制路径。
+
+## PR Lifecycle Monitor
+
+发布后，`loopx issue-fix pr-lifecycle` 与 `continuous_monitor` todo 持续跟踪 CI、
+review、maintainer correction、mergeability、stale branch 和 terminal status。
+发布、review request、merge 与读取私有材料继续作为 explicit gate。每次 material
+transition 必须生成 `runnable_successor`、具体 blocker 或结构化 no-follow-up；
+unchanged poll 保持安静且不消耗 delivery quota。
+
+## 命令
+
+```bash
+# 预览完整 issue-fix workflow。
+loopx issue-fix workflow-plan \
+  --url https://github.com/owner/repo/issues/123 \
+  --repo-path /path/to/approved/repo \
+  --repository-context-json context.json \
+  --validation-label "focused unit test" \
+  --format json
+
+# 选择唯一 route，并持久化 goal-scoped feasibility state。
+loopx issue-fix feasibility \
+  --url https://github.com/owner/repo/issues/123 \
+  --reproduction-status confirmed \
+  --reproduction-label "focused contract repro" \
+  --scope-class bounded \
+  --validation-label "focused unit test" \
+  --repository-context-json context.json \
+  --goal-id example-goal \
+  --format json
+
+# 推荐 reviewer，但不发送外部 review request。
+loopx issue-fix reviewer-plan \
+  --repo-path /path/to/approved/repo \
+  --repo owner/repo \
+  --base-ref origin/main \
+  --exclude-reviewer @pull-request-author \
+  --exclude-author-name "PR Author Git Name" \
+  --execute \
+  --format json
+
+# 把 PR lifecycle 投影到 LoopX continuation state。
+loopx issue-fix pr-lifecycle \
+  --url https://github.com/owner/repo/pull/456 \
+  --fetch-metadata \
+  --goal-id example-goal \
+  --format json
+```
+
+## Validation
+
+```bash
+python3 examples/issue-fix-capability-guide-smoke.py
+python3 examples/issue-fix-reviewer-recommendation-smoke.py
+python3 examples/issue-fix-workflow-plan-smoke.py
+python3 examples/issue-fix-workflow-contract-smoke.py
+python3 examples/issue-fix-repository-context-smoke.py
+python3 examples/issue-fix-feasibility-smoke.py
+python3 examples/issue-fix-pr-lifecycle-smoke.py
+python3 examples/issue-fix-acceptance-loop-smoke.py
+loopx canary premerge --from-git-diff
+```
+
+## 非目标
+
+- LoopX 不绕过 repository review 或 branch protection。
+- Reviewer recommendation 不等于 reviewer assignment 或 availability proof。
+- 默认不自动 merge，也不执行 production action。
+- Public state 不保存 raw transcript、tool log、expert answer、credentials 或私有 issue material。
+- Generic control plane 不加入 `if repo == ...` 一类仓库特判。

--- a/docs/capabilities/issue-fix/protocols/issue-fix-reviewer-recommendation-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-reviewer-recommendation-v0.md
@@ -1,0 +1,183 @@
+# issue_fix_reviewer_recommendation_v0
+
+`issue_fix_reviewer_recommendation_v0` is the public-safe contract for ranking
+people or teams who may be appropriate reviewers for an issue-fix change. It
+turns repository-native ownership evidence into an explainable recommendation;
+it does not assign a reviewer, request review, or grant publication authority.
+
+## Product Intent
+
+A long-running issue-to-PR agent should not stop after producing a correct
+patch. It should also prepare a credible review route that helps the change
+reach a maintainer. Reviewer selection is therefore part of issue-fix planning,
+while the external GitHub review request remains a separately authorized write.
+
+The contract must answer four questions:
+
+1. Which changed paths support this candidate?
+2. Is the candidate backed by repository policy, contribution history, or both?
+3. Can the candidate be resolved to a requestable GitHub handle?
+4. What human or repository-policy check remains before requesting review?
+
+## Evidence Order
+
+The first implementation uses this conservative authority order:
+
+1. the last matching rule from the repository's first supported `CODEOWNERS`
+   file: `.github/CODEOWNERS`, `CODEOWNERS`, then `docs/CODEOWNERS`;
+2. author history for each exact changed path;
+3. author history for the nearest module directory when a new path has no
+   usable exact-path history.
+
+`CODEOWNERS` receives dominant scoring weight because it expresses repository
+policy. Git history is advisory familiarity evidence: commit count or recency
+does not by itself prove maintainer authority, current availability, or consent
+to review.
+
+The pattern matcher intentionally supports a common, deterministic subset of
+`CODEOWNERS` syntax. The packet reports
+`codeowners_pattern_support: common_subset`; repositories that depend on more
+specialized matching semantics must verify the recommendation against their
+native platform policy.
+
+## CLI
+
+Preview without reading the local repository:
+
+```bash
+loopx issue-fix reviewer-plan \
+  --repo-path /path/to/approved/repo \
+  --repo owner/repo \
+  --changed-file src/service.py \
+  --exclude-reviewer @pull-request-author \
+  --exclude-author-name "PR Author Git Name" \
+  --format json
+```
+
+Read only the caller-approved local checkout and derive changed paths from a
+base ref:
+
+```bash
+loopx issue-fix reviewer-plan \
+  --repo-path /path/to/approved/repo \
+  --repo owner/repo \
+  --base-ref origin/main \
+  --exclude-reviewer @pull-request-author \
+  --exclude-author-name "PR Author Git Name" \
+  --execute \
+  --format json
+```
+
+`--execute` authorizes local repository inspection only. It does not authorize
+network access, a GitHub review request, a comment, a push, or a merge.
+
+## Input Contract
+
+- `repo_path`: caller-approved local git checkout; never copied into output;
+- `repo`: compact public-safe repository label;
+- `changed_files`: optional explicit repo-relative paths;
+- `base_ref`: diff base used when changed files are not supplied;
+- `history_limit`: bounded history depth per path;
+- `max_candidates`: bounded result count;
+- `exclude_reviewers`: GitHub handles that must not be recommended, normally
+  including the PR author and known unavailable identities;
+- `exclude_author_names`: git display-name aliases for an excluded handle when
+  identity resolution is unavailable; only the count is retained in output;
+- `execute`: whether local repository state may be read.
+
+Changed paths must be non-empty and repo-relative. Preview mode does not
+inspect `repo_path` and returns `recommendation_status: preview_only`.
+
+## Output Contract
+
+The packet uses `schema_version: issue_fix_reviewer_recommendation_v0` and
+contains:
+
+- `recommendation_status`: `preview_only`, `candidates_ready`,
+  `identity_resolution_required`, or `no_candidates`;
+- `changed_files` and `changed_file_count` using repo-relative paths only;
+- ranked `candidates` with stable candidate id, optional GitHub handle,
+  requestability, score, source kinds, reason codes, matched paths,
+  `CODEOWNERS` patterns, history count, recency rank, path coverage, and
+  confidence;
+- `evidence_summary` describing the authority order and fallbacks;
+- `policy` stating that recommendation is not assignment and automatic review
+  request is forbidden;
+- public-safety and side-effect flags.
+
+Candidates without a verified GitHub handle remain visible as familiarity
+evidence but are marked `requestable: false` with
+`github_identity_resolution_required`. The packet never exposes the underlying
+commit email.
+
+## Ranking Rules
+
+- Each matching `CODEOWNERS` path adds a dominant ownership score.
+- Exact-path and module history at the selected base revision add bounded,
+  recency-weighted familiarity scores; feature-branch commits are not counted.
+- Bot-like identities found only in git history are excluded; an explicit
+  repository ownership rule remains authoritative.
+- Evidence from multiple changed paths raises path coverage.
+- A candidate supported by both ownership policy and history receives high
+  confidence; single-source evidence remains medium or low.
+- Excluded handles are removed before ranking.
+
+Scores only order evidence inside this packet. They must not be interpreted as
+a universal maintainer ranking or a performance metric.
+
+## Required Boundaries
+
+Every valid packet preserves:
+
+- `external_reads_performed: false`
+- `external_writes_performed: false`
+- `review_request_performed: false`
+- `local_paths_captured: false`
+- `raw_git_output_captured: false`
+- `commit_emails_captured: false`
+- `automatic_review_request_allowed: false`
+
+`private_repo_state_read` is `false` in preview and `true` only after an
+explicit `--execute` against the caller-approved checkout. No raw `CODEOWNERS`
+file, raw git log, credentials, private material, or runtime state belongs in
+the packet.
+
+## Human And Repository Policy Gate
+
+Before any external review request, the host agent or human must verify:
+
+- the PR author and unavailable reviewers are excluded;
+- the repository permits the request and any team handle is requestable;
+- the recommendation still matches the final diff;
+- ownership is not being inferred solely from a large historical commit count;
+- sensitive or architectural changes receive any additional mandatory review.
+
+A later authority-gated connector may consume this packet, but the connector
+must record a separate external-write decision. This schema must never be used
+as implicit review-request authority.
+
+## Planned Extensions
+
+Future versions may add repository-native signals with real call sites:
+
+- maintainer availability and explicit opt-out;
+- review-response and approval history;
+- semantic module mapping for generated or moved files;
+- risk-class or sensitive-path reviewer requirements;
+- load balancing and fallback escalation after a stale review request;
+- repository-host identity resolution for teams and non-noreply authors.
+
+These signals should extend the explainable evidence packet, not introduce an
+OpenViking-specific adapter or an independent reviewer state machine.
+
+## Validation
+
+Run:
+
+```bash
+python3 examples/issue-fix-reviewer-recommendation-smoke.py
+```
+
+The smoke uses a temporary non-project-specific repository to verify
+`CODEOWNERS`, exact-path history, module fallback, author exclusion, CLI
+execution, identity handling, and the no-external-write boundary.

--- a/examples/canary/catalog-planner-smoke.py
+++ b/examples/canary/catalog-planner-smoke.py
@@ -501,6 +501,7 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
         profile["id"]: profile for profile in product_entry_payload["domain_profiles"]
     }
     assert "product-entry-workflows" in product_entry_profiles, product_entry_payload
+    assert "issue-fix-reviewer-routing" in product_entry_profiles, product_entry_payload
     assert "install-update" not in product_entry_profiles, product_entry_payload
     product_entry_profile = product_entry_profiles["product-entry-workflows"]
     product_entry_commands = [check["command"] for check in product_entry_profile["checks"]]
@@ -514,6 +515,14 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     assert all(check["tier"] == "default" for check in product_entry_profile["checks"]), product_entry_profile
     assert product_entry_profile["deep_checks_available"] is True, product_entry_profile
     assert product_entry_profile["deep_checks_included"] is False, product_entry_profile
+    reviewer_profile = product_entry_profiles["issue-fix-reviewer-routing"]
+    reviewer_commands = [check["command"] for check in reviewer_profile["checks"]]
+    assert reviewer_commands == [
+        "python3 examples/issue-fix-capability-guide-smoke.py",
+        "python3 examples/issue-fix-reviewer-recommendation-smoke.py",
+    ], reviewer_profile
+    assert all(check["tier"] == "default" for check in reviewer_profile["checks"]), reviewer_profile
+    assert reviewer_profile["deep_checks_available"] is False, reviewer_profile
 
     cross_runtime_payload = build_catalog_canary_plan(
         changed_files=[

--- a/examples/issue-fix-capability-guide-smoke.py
+++ b/examples/issue-fix-capability-guide-smoke.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Smoke-test the bilingual public issue-fix capability entry surface."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ENGLISH_GUIDE = ROOT / "docs/capabilities/issue-fix/README.md"
+CHINESE_GUIDE = ROOT / "docs/capabilities/issue-fix/README.zh-CN.md"
+CAPABILITY_INDEX = ROOT / "docs/capabilities/README.md"
+ENGLISH_README = ROOT / "README.md"
+CHINESE_README = ROOT / "README.zh-CN.md"
+REVIEWER_PROTOCOL = (
+    ROOT
+    / "docs/capabilities/issue-fix/protocols/issue-fix-reviewer-recommendation-v0.md"
+)
+
+PRIVATE_PATTERNS = (
+    re.compile(r"/Users/[A-Za-z0-9._-]+/"),
+    re.compile(r"/home/[A-Za-z0-9._-]+/"),
+    re.compile(r"/private/"),
+    re.compile(r"[A-Za-z]:\\\\Users\\\\"),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._-]+"),
+    re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+)
+
+
+def assert_public_safe(text: str) -> None:
+    for pattern in PRIVATE_PATTERNS:
+        assert not pattern.search(text), pattern.pattern
+
+
+def assert_markers(text: str, markers: tuple[str, ...]) -> None:
+    for marker in markers:
+        assert marker in text, marker
+
+
+def main() -> int:
+    english = ENGLISH_GUIDE.read_text(encoding="utf-8")
+    chinese = CHINESE_GUIDE.read_text(encoding="utf-8")
+    capability_index = CAPABILITY_INDEX.read_text(encoding="utf-8")
+    english_readme = ENGLISH_README.read_text(encoding="utf-8")
+    chinese_readme = CHINESE_README.read_text(encoding="utf-8")
+    reviewer_protocol = REVIEWER_PROTOCOL.read_text(encoding="utf-8")
+
+    assert english.startswith("# Issue-Fix Capability")
+    assert chinese.startswith("# Issue-Fix 能力")
+    assert "[中文](README.zh-CN.md)" in english
+    assert "[English](README.md)" in chinese
+    assert "[issue-fix](issue-fix/README.md)" in capability_index
+    assert "[中文](issue-fix/README.zh-CN.md)" in capability_index
+    assert "docs/capabilities/issue-fix/README.md" in english_readme
+    assert "docs/capabilities/issue-fix/README.zh-CN.md" in chinese_readme
+
+    shared_markers = (
+        "issue_fix_repository_context_input_v0",
+        "fix_pr",
+        "comment_only",
+        "triage_only",
+        "loopx issue-fix reviewer-plan",
+        "CODEOWNERS",
+        "continuous_monitor",
+        "runnable_successor",
+        "https://github.com/volcengine/OpenViking/issues/3102",
+        "https://github.com/volcengine/OpenViking/pull/3115",
+        "https://github.com/huangruiteng/loopx/pull/1784",
+        "python3 examples/issue-fix-reviewer-recommendation-smoke.py",
+    )
+    assert_markers(english, shared_markers)
+    assert_markers(chinese, shared_markers)
+    assert_markers(
+        english,
+        (
+            "## Product Position",
+            "## What LoopX Provides Underneath",
+            "Durable goal state",
+            "Kanban/status projection",
+            "Quota and scheduler policy",
+            "Authority and interaction gates",
+            "## End-To-End Design",
+            "## Implemented Surfaces",
+            "## Reviewer Routing Contract",
+            "## Human Interaction Model",
+            "## Roadmap",
+            "## Success Metrics",
+            "## Conversational `/loopx` Entry",
+            "concrete blocker",
+            "structured no-follow-up",
+        ),
+    )
+    assert_markers(
+        chinese,
+        (
+            "## 产品定位",
+            "## LoopX 底座提供什么",
+            "持久化 goal state",
+            "Kanban/status 投影",
+            "Quota 与 scheduler policy",
+            "Authority 与 interaction gate",
+            "## 端到端设计",
+            "## 已实现能力面",
+            "## Reviewer 路由 Contract",
+            "## 人机交互模型",
+            "## Roadmap",
+            "## 成功指标",
+            "## 对话式 `/loopx` 入口",
+            "具体 blocker",
+            "结构化 no-follow-up",
+        ),
+    )
+    assert reviewer_protocol.startswith("# issue_fix_reviewer_recommendation_v0")
+    assert_markers(
+        reviewer_protocol,
+        (
+            "repository's first supported `CODEOWNERS`",
+            "changed path",
+            "nearest module directory",
+            "recommendation is not assignment",
+            "automatic_review_request_allowed: false",
+            "review_request_performed: false",
+            "python3 examples/issue-fix-reviewer-recommendation-smoke.py",
+        ),
+    )
+
+    for text in (
+        english,
+        chinese,
+        capability_index,
+        english_readme,
+        chinese_readme,
+        reviewer_protocol,
+    ):
+        assert_public_safe(text)
+
+    print("issue-fix-capability-guide-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/issue-fix-reviewer-recommendation-smoke.py
+++ b/examples/issue-fix-reviewer-recommendation-smoke.py
@@ -1,0 +1,245 @@
+#!/usr/bin/env python3
+"""Smoke-test explainable reviewer recommendations from local ownership evidence."""
+
+from __future__ import annotations
+
+import errno
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Iterator
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx.capabilities.issue_fix.reviewer_recommendation import (  # noqa: E402
+    ISSUE_FIX_REVIEWER_RECOMMENDATION_SCHEMA_VERSION,
+    build_issue_fix_reviewer_recommendation_packet,
+)
+
+
+PRIVATE_PATTERNS = [
+    re.compile(r"/Users/[A-Za-z0-9._-]+/"),
+    re.compile(r"/private/"),
+    re.compile(r"/tmp/"),
+    re.compile(r"[A-Za-z]:\\\\Users\\\\"),
+]
+
+
+@contextmanager
+def temporary_git_repo() -> Iterator[Path]:
+    path = Path(tempfile.mkdtemp(prefix="loopx-reviewer-recommendation-"))
+    try:
+        yield path
+    finally:
+        for attempt in range(10):
+            try:
+                shutil.rmtree(path)
+                break
+            except FileNotFoundError:
+                break
+            except OSError as exc:
+                if exc.errno != errno.ENOTEMPTY or attempt == 9:
+                    raise
+                time.sleep(0.05)
+
+
+def run_git(repo: Path, *args: str, author: str | None = None) -> None:
+    env = dict(os.environ)
+    if author:
+        login = author.lower().replace(" ", "-")
+        env.update(
+            {
+                "GIT_AUTHOR_NAME": author,
+                "GIT_AUTHOR_EMAIL": f"{login}@users.noreply.github.com",
+                "GIT_COMMITTER_NAME": author,
+                "GIT_COMMITTER_EMAIL": f"{login}@users.noreply.github.com",
+            }
+        )
+    subprocess.run(
+        ["git", "-c", "gc.auto=0", "-c", "maintenance.auto=false", *args],
+        cwd=repo,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def commit(repo: Path, message: str, author: str) -> None:
+    run_git(repo, "add", "-A")
+    run_git(repo, "commit", "-m", message, author=author)
+
+
+def assert_public_safe(payload: dict[str, Any]) -> None:
+    text = json.dumps(payload, ensure_ascii=False, sort_keys=True)
+    for pattern in PRIVATE_PATTERNS:
+        assert not pattern.search(text), pattern.pattern
+    assert "@users.noreply.github.com" not in text, text
+    assert "raw codeowners" not in text.lower(), text
+    assert payload["external_reads_performed"] is False
+    assert payload["external_writes_performed"] is False
+    assert payload["review_request_performed"] is False
+    assert payload["local_paths_captured"] is False
+    assert payload["raw_git_output_captured"] is False
+    assert payload["commit_emails_captured"] is False
+
+
+def run_cli(args: list[str]) -> dict[str, Any]:
+    result = subprocess.run(
+        [sys.executable, "-m", "loopx.cli", "--format", "json", *args],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def main() -> int:
+    dry = build_issue_fix_reviewer_recommendation_packet(
+        repo_path="path-not-read-in-preview",
+        repo="owner/repo",
+        changed_files=["src/service.py"],
+    )
+    assert dry["ok"] is True, dry
+    assert dry["schema_version"] == ISSUE_FIX_REVIEWER_RECOMMENDATION_SCHEMA_VERSION
+    assert dry["execute"] is False
+    assert dry["private_repo_state_read"] is False
+    assert dry["recommendation_status"] == "preview_only"
+    assert_public_safe(dry)
+    try:
+        build_issue_fix_reviewer_recommendation_packet(
+            repo_path="path-not-read-in-preview",
+            repo="owner/repo",
+            changed_files=[f"src/file-{index}.py" for index in range(101)],
+        )
+    except ValueError as exc:
+        assert "at most 100" in str(exc), exc
+    else:
+        raise AssertionError("changed-file truncation must fail closed")
+    try:
+        build_issue_fix_reviewer_recommendation_packet(
+            repo_path="path-not-read-in-preview",
+            repo="owner/repo",
+            changed_files=["src/service.py"],
+            base_ref="--output=unexpected",
+        )
+    except ValueError as exc:
+        assert "base_ref" in str(exc), exc
+    else:
+        raise AssertionError("option-like base refs must be rejected")
+
+    with temporary_git_repo() as repo:
+        run_git(repo, "init", "-b", "main")
+        write(
+            repo / ".github/CODEOWNERS",
+            "* @fallback-owner\n/src/ @core-team\n/src/service.py @service-owner\n/docs/ @docs-team\n",
+        )
+        write(repo / "src/service.py", "VALUE = 1\n")
+        write(repo / "src/existing.py", "EXISTING = True\n")
+        write(repo / "docs/guide.md", "# Guide\n")
+        commit(repo, "Add service and ownership policy", "Alice Maintainer")
+
+        write(repo / "src/service.py", "VALUE = 2\n")
+        commit(repo, "Refine service", "Bob Contributor")
+
+        write(repo / "src/service.py", "VALUE = 2\nAUTOMATED = True\n")
+        commit(repo, "Automated service refresh", "Release Bot")
+
+        write(repo / "docs/guide.md", "# Guide\n\nAuthored before the feature.\n")
+        commit(repo, "Refresh guide before feature", "Current Author")
+
+        run_git(repo, "checkout", "-b", "feature/reviewer-plan")
+        write(repo / "src/service.py", "VALUE = 3\n")
+        write(repo / "src/new_module.py", "NEW = True\n")
+        write(repo / "docs/guide.md", "# Guide\n\nUpdated.\n")
+        commit(repo, "Update service and docs", "Current Author")
+
+        packet = build_issue_fix_reviewer_recommendation_packet(
+            repo_path=repo,
+            repo="owner/repo",
+            base_ref="main",
+            history_limit=20,
+            max_candidates=10,
+            exclude_reviewers=["@current-author"],
+            exclude_author_names=["Current Author"],
+            execute=True,
+        )
+        assert packet["ok"] is True, packet
+        assert packet["private_repo_state_read"] is True
+        assert packet["recommendation_status"] == "candidates_ready", packet
+        assert packet["changed_files"] == [
+            "docs/guide.md",
+            "src/new_module.py",
+            "src/service.py",
+        ], packet
+        assert packet["evidence_summary"]["codeowners_source"] == ".github/CODEOWNERS"
+        assert packet["evidence_summary"]["history_revision"] == "main"
+        assert packet["excluded_author_name_count"] == 2
+        assert all(
+            item.get("display_name") != "Current Author"
+            for item in packet["candidates"]
+        ), packet
+        by_handle = {
+            item["reviewer_handle"]: item
+            for item in packet["candidates"]
+            if item.get("reviewer_handle")
+        }
+        assert "@current-author" not in by_handle, by_handle
+        assert "@release-bot" not in by_handle, by_handle
+        assert "@service-owner" in by_handle, by_handle
+        assert "@docs-team" in by_handle, by_handle
+        assert "@core-team" in by_handle, by_handle
+        assert "@alice-maintainer" in by_handle, by_handle
+        assert "@bob-contributor" in by_handle, by_handle
+        assert by_handle["@service-owner"]["confidence"] == "medium"
+        assert "repository_codeowners_match" in by_handle["@service-owner"]["reason_codes"]
+        assert "changed_module_commit_history" in by_handle["@alice-maintainer"]["reason_codes"]
+        assert packet["policy"]["automatic_review_request_allowed"] is False
+        assert_public_safe(packet)
+
+        cli_packet = run_cli(
+            [
+                "issue-fix",
+                "reviewer-plan",
+                "--repo-path",
+                str(repo),
+                "--repo",
+                "owner/repo",
+                "--base-ref",
+                "main",
+                "--exclude-reviewer",
+                "@current-author",
+                "--exclude-author-name",
+                "Current Author",
+                "--execute",
+            ]
+        )
+        assert cli_packet["ok"] is True, cli_packet
+        assert cli_packet["recommendation_status"] == "candidates_ready"
+        assert cli_packet["review_request_performed"] is False
+        assert_public_safe(cli_packet)
+
+    print("issue-fix-reviewer-recommendation-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -880,6 +880,37 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
         ],
     },
     {
+        "id": "issue-fix-reviewer-routing",
+        "title": "Issue-fix reviewer routing and bilingual guide",
+        "purpose": (
+            "Check the bilingual issue-fix product entry and explainable local "
+            "reviewer recommendation contract without external review requests."
+        ),
+        "catalog_families": ["Human Decision", "Evidence Lifecycle", "State And Boundary"],
+        "trigger_hints": (
+            "reviewer-plan",
+            "reviewer recommendation",
+            "issue_fix_reviewer_recommendation",
+            "docs/capabilities/issue-fix/README",
+            "docs/capabilities/issue-fix/protocols/issue-fix-reviewer-recommendation",
+            "examples/issue-fix-capability-guide-smoke.py",
+            "examples/issue-fix-reviewer-recommendation-smoke.py",
+            "loopx/capabilities/issue_fix/reviewer_recommendation.py",
+        ),
+        "checks": [
+            {
+                "command": "python3 examples/issue-fix-capability-guide-smoke.py",
+                "tier": "default",
+                "reason": "guards the bilingual issue-fix product entry, README links, reviewer protocol, and public-safe roadmap surface",
+            },
+            {
+                "command": "python3 examples/issue-fix-reviewer-recommendation-smoke.py",
+                "tier": "default",
+                "reason": "guards explainable CODEOWNERS and base-revision changed-path/module-history reviewer recommendations without external review requests",
+            },
+        ],
+    },
+    {
         "id": "cross-runtime-impl-review-demo",
         "title": "Cross-runtime implementation/review demo",
         "purpose": (

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -27,6 +27,10 @@ from .pr_lifecycle import (
     build_issue_fix_pr_lifecycle_monitor_packet,
     render_issue_fix_pr_lifecycle_monitor_markdown,
 )
+from .reviewer_recommendation import (
+    build_issue_fix_reviewer_recommendation_packet,
+    render_issue_fix_reviewer_recommendation_markdown,
+)
 from .workflow_plan import (
     build_issue_fix_workflow_plan_packet,
     render_issue_fix_workflow_plan_markdown,
@@ -304,6 +308,84 @@ def register_issue_fix_commands(
             "--ledger-path is present."
         ),
     )
+    reviewer_parser = issue_fix_sub.add_parser(
+        "reviewer-plan",
+        help=(
+            "Recommend reviewers from caller-approved repository ownership "
+            "evidence without requesting external review."
+        ),
+    )
+    add_subcommand_format(reviewer_parser)
+    reviewer_parser.add_argument(
+        "--repo-path",
+        required=True,
+        help=(
+            "Caller-approved local git repository. The public packet never "
+            "records this path."
+        ),
+    )
+    reviewer_parser.add_argument(
+        "--repo",
+        default="approved_local_repo",
+        help="Public-safe repository label stored in the recommendation packet.",
+    )
+    reviewer_parser.add_argument(
+        "--changed-file",
+        action="append",
+        default=[],
+        help=(
+            "Repo-relative changed file. Repeat for multiple files. When omitted "
+            "with --execute, derive files from --base-ref...HEAD."
+        ),
+    )
+    reviewer_parser.add_argument(
+        "--base-ref",
+        default="origin/main",
+        help="Base git ref used to derive changed files when none are explicit.",
+    )
+    reviewer_parser.add_argument(
+        "--history-limit",
+        type=int,
+        default=40,
+        help="Maximum changed-path git history rows to inspect per file.",
+    )
+    reviewer_parser.add_argument(
+        "--max-candidates",
+        type=int,
+        default=5,
+        help="Maximum ranked reviewer candidates to return.",
+    )
+    reviewer_parser.add_argument(
+        "--exclude-reviewer",
+        action="append",
+        default=[],
+        help=(
+            "GitHub handle to exclude, normally the PR author or unavailable "
+            "reviewer. Repeat for multiple handles."
+        ),
+    )
+    reviewer_parser.add_argument(
+        "--exclude-author-name",
+        action="append",
+        default=[],
+        help=(
+            "Git author display-name alias to exclude when it cannot be resolved "
+            "to the PR author handle. Repeat for multiple aliases."
+        ),
+    )
+    reviewer_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help=(
+            "Inspect only the caller-approved local repository. This still "
+            "does not request review or perform any external write."
+        ),
+    )
+    reviewer_parser.add_argument(
+        "--generated-at",
+        default="2026-07-10T00:00:00Z",
+        help="Public-safe generated_at timestamp for the recommendation packet.",
+    )
     acceptance_parser = issue_fix_sub.add_parser(
         "acceptance-fixture",
         help=(
@@ -540,6 +622,20 @@ def handle_issue_fix_command(
                 if isinstance(domain_state, dict) and not args.no_write_domain_state:
                     domain_state["write_skipped_reason"] = "goal_id_or_ledger_path_missing"
             renderer = render_issue_fix_pr_lifecycle_monitor_markdown
+        elif args.issue_fix_command == "reviewer-plan":
+            payload = build_issue_fix_reviewer_recommendation_packet(
+                repo_path=args.repo_path,
+                repo=args.repo,
+                changed_files=args.changed_file,
+                base_ref=args.base_ref,
+                history_limit=args.history_limit,
+                max_candidates=args.max_candidates,
+                exclude_reviewers=args.exclude_reviewer,
+                exclude_author_names=args.exclude_author_name,
+                execute=args.execute,
+                generated_at=args.generated_at,
+            )
+            renderer = render_issue_fix_reviewer_recommendation_markdown
         elif args.issue_fix_command == "acceptance-fixture":
             payload = build_issue_fix_acceptance_fixture_packet(
                 repo=args.repo,
@@ -574,8 +670,8 @@ def handle_issue_fix_command(
         else:
             raise ValueError(
                 "issue-fix requires `workflow-plan`, `feasibility`, "
-                "`acceptance-fixture`, `pr-lifecycle`, `repo-branch-fixture`, "
-                "or `caller-repo-branch`"
+                "`acceptance-fixture`, `pr-lifecycle`, `reviewer-plan`, "
+                "`repo-branch-fixture`, or `caller-repo-branch`"
             )
     except Exception as exc:
         payload = {
@@ -590,6 +686,8 @@ def handle_issue_fix_command(
             if getattr(args, "issue_fix_command", None) == "feasibility"
             else render_issue_fix_pr_lifecycle_monitor_markdown
             if getattr(args, "issue_fix_command", None) == "pr-lifecycle"
+            else render_issue_fix_reviewer_recommendation_markdown
+            if getattr(args, "issue_fix_command", None) == "reviewer-plan"
             else render_issue_fix_acceptance_loop_markdown
         )
     print_payload(payload, output_format(args), renderer)

--- a/loopx/capabilities/issue_fix/reviewer_recommendation.py
+++ b/loopx/capabilities/issue_fix/reviewer_recommendation.py
@@ -1,0 +1,547 @@
+from __future__ import annotations
+
+import fnmatch
+import hashlib
+import re
+import subprocess
+from collections.abc import Mapping, Sequence
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+from ...control_plane.runtime.public_safety import public_safe_compact_text
+
+
+ISSUE_FIX_REVIEWER_RECOMMENDATION_SCHEMA_VERSION = (
+    "issue_fix_reviewer_recommendation_v0"
+)
+CODEOWNERS_LOCATIONS = (
+    ".github/CODEOWNERS",
+    "CODEOWNERS",
+    "docs/CODEOWNERS",
+)
+GITHUB_NOREPLY_PATTERN = re.compile(
+    r"^(?:\d+\+)?(?P<login>[A-Za-z0-9](?:[A-Za-z0-9-]{0,38}))@users\.noreply\.github\.com$",
+    re.IGNORECASE,
+)
+REVIEWER_HANDLE_PATTERN = re.compile(
+    r"^@[A-Za-z0-9](?:[A-Za-z0-9-]{0,38})(?:/[A-Za-z0-9_.-]+)?$"
+)
+SAFE_GIT_REF_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/~^{}-]{0,119}$")
+AUTOMATED_HISTORY_IDENTITY_PATTERN = re.compile(
+    r"(?:^|[-_.\s])bot(?:$|[-_.\s])|\[bot\]$",
+    re.IGNORECASE,
+)
+
+
+def _run_git(repo_path: Path, args: Sequence[str]) -> str:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=repo_path,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        timeout=20,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"git {' '.join(args)} failed with exit code {result.returncode}")
+    return result.stdout
+
+
+def _normalise_changed_file(value: Any) -> str:
+    text = str(value or "").strip().replace("\\", "/")
+    while text.startswith("./"):
+        text = text[2:]
+    path = PurePosixPath(text)
+    if not text or path.as_posix() == "." or path.is_absolute() or ".." in path.parts:
+        raise ValueError("changed files must be non-empty repo-relative paths")
+    return path.as_posix()
+
+
+def _normalise_changed_files(values: Sequence[Any]) -> list[str]:
+    files: list[str] = []
+    for raw in values:
+        path = _normalise_changed_file(raw)
+        if path not in files:
+            files.append(path)
+    if len(files) > 100:
+        raise ValueError("reviewer recommendation accepts at most 100 changed files")
+    return files
+
+
+def _normalise_base_ref(value: Any) -> str:
+    text = str(value or "").strip()
+    if not SAFE_GIT_REF_PATTERN.fullmatch(text):
+        raise ValueError("base_ref must be a compact non-option git revision")
+    return text
+
+
+def _normalise_reviewer_handle(value: Any) -> str | None:
+    text = str(value or "").strip()
+    if text and not text.startswith("@"):
+        text = f"@{text}"
+    return text.lower() if REVIEWER_HANDLE_PATTERN.fullmatch(text) else None
+
+
+def _normalise_author_name(value: Any) -> str | None:
+    text = public_safe_compact_text(value, limit=80)
+    return " ".join(text.lower().split()) if text else None
+
+
+def _codeowners_tokens(line: str) -> tuple[str, list[str]] | None:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        return None
+    parts = stripped.split()
+    if len(parts) < 2:
+        return None
+    owners = [
+        handle
+        for handle in (_normalise_reviewer_handle(item) for item in parts[1:])
+        if handle
+    ]
+    return (parts[0], owners) if owners else None
+
+
+def _codeowners_pattern_matches(pattern: str, path: str) -> bool:
+    pattern = pattern.strip()
+    if not pattern or pattern.startswith("!"):
+        return False
+    anchored = pattern.startswith("/")
+    pattern = pattern.lstrip("/")
+    if pattern.endswith("/"):
+        prefix = pattern.rstrip("/")
+        return path == prefix or path.startswith(f"{prefix}/")
+    if "/" not in pattern:
+        return any(fnmatch.fnmatchcase(part, pattern) for part in path.split("/"))
+    if anchored:
+        return fnmatch.fnmatchcase(path, pattern)
+    return fnmatch.fnmatchcase(path, pattern) or PurePosixPath(path).match(pattern)
+
+
+def _load_codeowners(repo_path: Path) -> tuple[str | None, list[tuple[str, list[str]]]]:
+    for relative in CODEOWNERS_LOCATIONS:
+        candidate = repo_path / relative
+        if not candidate.is_file():
+            continue
+        rows: list[tuple[str, list[str]]] = []
+        for line in candidate.read_text(encoding="utf-8", errors="replace").splitlines():
+            parsed = _codeowners_tokens(line)
+            if parsed is not None:
+                rows.append(parsed)
+        return relative, rows
+    return None, []
+
+
+def _owners_for_path(
+    rules: Sequence[tuple[str, list[str]]],
+    path: str,
+) -> tuple[str | None, list[str]]:
+    matched_pattern: str | None = None
+    owners: list[str] = []
+    for pattern, rule_owners in rules:
+        if _codeowners_pattern_matches(pattern, path):
+            matched_pattern = pattern
+            owners = list(rule_owners)
+    return matched_pattern, owners
+
+
+def _github_handle_from_email(value: str) -> str | None:
+    match = GITHUB_NOREPLY_PATTERN.fullmatch(value.strip())
+    return f"@{match.group('login').lower()}" if match else None
+
+
+def _looks_like_automated_history_identity(
+    *,
+    display_name: str,
+    handle: str | None,
+) -> bool:
+    values = [display_name, (handle or "").lstrip("@")]
+    return any(AUTOMATED_HISTORY_IDENTITY_PATTERN.search(value) for value in values)
+
+
+def _candidate_key(*, handle: str | None, display_name: str) -> str:
+    if handle:
+        return f"handle:{handle}"
+    normalised_name = " ".join(display_name.lower().split())
+    digest = hashlib.sha256(normalised_name.encode("utf-8")).hexdigest()[:12]
+    return f"git-author:{digest}"
+
+
+def _candidate_id(key: str) -> str:
+    return "reviewer_" + hashlib.sha256(key.encode("utf-8")).hexdigest()[:12]
+
+
+def _new_candidate(
+    *,
+    key: str,
+    handle: str | None,
+    display_name: str,
+) -> dict[str, Any]:
+    return {
+        "candidate_id": _candidate_id(key),
+        "reviewer_handle": handle,
+        "display_name": display_name,
+        "requestable": bool(handle),
+        "score": 0,
+        "source_kinds": [],
+        "reason_codes": [],
+        "matched_files": [],
+        "codeowners_patterns": [],
+        "history_commit_count": 0,
+        "most_recent_history_rank": None,
+    }
+
+
+def _append_unique(row: dict[str, Any], field: str, value: str, *, limit: int = 20) -> None:
+    values = row[field]
+    if value not in values and len(values) < limit:
+        values.append(value)
+
+
+def _derive_changed_files(repo_path: Path, base_ref: str) -> list[str]:
+    output = _run_git(repo_path, ["diff", "--name-only", f"{base_ref}...HEAD"])
+    return _normalise_changed_files(output.splitlines())
+
+
+def _collect_history(
+    repo_path: Path,
+    path: str,
+    *,
+    revision: str,
+    history_limit: int,
+) -> list[tuple[str, str]]:
+    output = _run_git(
+        repo_path,
+        [
+            "log",
+            f"--max-count={history_limit}",
+            "--format=%aN%x1f%aE",
+            revision,
+            "--",
+            path,
+        ],
+    )
+    rows: list[tuple[str, str]] = []
+    for line in output.splitlines():
+        name, separator, email = line.partition("\x1f")
+        if not separator:
+            continue
+        safe_name = public_safe_compact_text(name, limit=80)
+        if safe_name:
+            rows.append((safe_name, email.strip()))
+    return rows
+
+
+def _confidence(candidate: Mapping[str, Any]) -> str:
+    sources = set(candidate.get("source_kinds") or [])
+    coverage = len(candidate.get("matched_files") or [])
+    if "codeowners" in sources and "git_history" in sources:
+        return "high"
+    if "codeowners" in sources or coverage >= 2:
+        return "medium"
+    return "low"
+
+
+def _recommendation_status(candidates: Sequence[Mapping[str, Any]]) -> str:
+    if any(candidate.get("requestable") for candidate in candidates):
+        return "candidates_ready"
+    if candidates:
+        return "identity_resolution_required"
+    return "no_candidates"
+
+
+def build_issue_fix_reviewer_recommendation_packet(
+    *,
+    repo_path: str | Path,
+    repo: str = "approved_local_repo",
+    changed_files: Sequence[str] = (),
+    base_ref: str = "origin/main",
+    history_limit: int = 40,
+    max_candidates: int = 5,
+    exclude_reviewers: Sequence[str] = (),
+    exclude_author_names: Sequence[str] = (),
+    execute: bool = False,
+    generated_at: str | None = "2026-07-10T00:00:00Z",
+) -> dict[str, Any]:
+    """Recommend reviewers from caller-approved repository ownership evidence."""
+
+    safe_repo = public_safe_compact_text(repo, limit=120)
+    if not safe_repo:
+        raise ValueError("repo must be a compact public-safe label")
+    safe_base_ref = _normalise_base_ref(
+        public_safe_compact_text(base_ref, limit=120)
+    )
+    history_limit = min(max(int(history_limit), 1), 200)
+    max_candidates = min(max(int(max_candidates), 1), 20)
+    explicit_files = _normalise_changed_files(changed_files)
+    excluded = {
+        handle
+        for handle in (_normalise_reviewer_handle(item) for item in exclude_reviewers)
+        if handle
+    }
+    excluded_author_names = {
+        name
+        for name in (_normalise_author_name(item) for item in exclude_author_names)
+        if name
+    }
+    excluded_author_names.update(handle.lstrip("@").lower() for handle in excluded)
+
+    packet: dict[str, Any] = {
+        "ok": True,
+        "schema_version": ISSUE_FIX_REVIEWER_RECOMMENDATION_SCHEMA_VERSION,
+        "mode": "issue-fix-reviewer-recommendation",
+        "generated_at": generated_at,
+        "repo": safe_repo,
+        "execute": execute,
+        "recommendation_status": "preview_only",
+        "changed_files": explicit_files,
+        "changed_file_count": len(explicit_files),
+        "candidates": [],
+        "excluded_reviewer_handles": sorted(excluded),
+        "excluded_author_name_count": len(excluded_author_names),
+        "evidence_summary": {
+            "schema_version": "issue_fix_reviewer_evidence_summary_v0",
+            "authority_order": [
+                "repository_codeowners",
+                "changed_path_git_history",
+                "changed_module_git_history_fallback",
+            ],
+            "codeowners_source": None,
+            "codeowners_pattern_support": "common_subset",
+            "history_limit_per_file": history_limit,
+            "history_revision": safe_base_ref,
+            "module_history_fallback": True,
+            "automated_history_identities_excluded": True,
+            "raw_codeowners_captured": False,
+            "raw_git_output_captured": False,
+            "commit_emails_captured": False,
+        },
+        "policy": {
+            "schema_version": "issue_fix_reviewer_policy_v0",
+            "recommendation_is_assignment": False,
+            "automatic_review_request_allowed": False,
+            "repository_policy_still_applies": True,
+            "current_author_should_be_excluded_by_caller": True,
+            "identity_resolution_required_for_non_handle_candidates": True,
+            "next_action": (
+                "Review the ranked evidence under repository policy; request review "
+                "only through a separately authorized external-write action."
+            ),
+        },
+        "external_reads_performed": False,
+        "external_writes_performed": False,
+        "review_request_performed": False,
+        "private_repo_state_read": False,
+        "local_paths_captured": False,
+        "raw_git_output_captured": False,
+        "commit_emails_captured": False,
+    }
+    if not execute:
+        packet["next_safe_action"] = (
+            "Rerun with --execute only for the caller-approved local repository."
+        )
+        packet["validation"] = validate_issue_fix_reviewer_recommendation_packet(packet)
+        return packet
+
+    path = Path(repo_path).expanduser()
+    if not path.is_dir():
+        raise ValueError("repo_path must be an existing caller-approved directory")
+    _run_git(path, ["rev-parse", "--is-inside-work-tree"])
+    files = explicit_files or _derive_changed_files(path, safe_base_ref)
+    if not files:
+        raise ValueError("reviewer recommendation requires at least one changed file")
+
+    codeowners_source, codeowners_rules = _load_codeowners(path)
+    candidates: dict[str, dict[str, Any]] = {}
+    for changed_file in files:
+        pattern, owners = _owners_for_path(codeowners_rules, changed_file)
+        for handle in owners:
+            if handle in excluded:
+                continue
+            key = _candidate_key(handle=handle, display_name=handle)
+            row = candidates.setdefault(
+                key,
+                _new_candidate(key=key, handle=handle, display_name=handle),
+            )
+            row["score"] += 1000
+            _append_unique(row, "source_kinds", "codeowners")
+            _append_unique(row, "reason_codes", "repository_codeowners_match")
+            _append_unique(row, "matched_files", changed_file)
+            if pattern:
+                _append_unique(row, "codeowners_patterns", pattern)
+
+        history_rows = _collect_history(
+            path,
+            changed_file,
+            revision=safe_base_ref,
+            history_limit=history_limit,
+        )
+        history_reason = "changed_path_commit_history"
+        usable_history_rows = [
+            row
+            for row in history_rows
+            if (_github_handle_from_email(row[1]) or "") not in excluded
+            and _normalise_author_name(row[0]) not in excluded_author_names
+            and not _looks_like_automated_history_identity(
+                display_name=row[0],
+                handle=_github_handle_from_email(row[1]),
+            )
+        ]
+        if not usable_history_rows:
+            parent = PurePosixPath(changed_file).parent.as_posix()
+            if parent not in {"", "."}:
+                history_rows = _collect_history(
+                    path,
+                    parent,
+                    revision=safe_base_ref,
+                    history_limit=history_limit,
+                )
+                history_reason = "changed_module_commit_history"
+        for rank, (name, email) in enumerate(history_rows, start=1):
+            handle = _github_handle_from_email(email)
+            if handle and handle in excluded:
+                continue
+            if _normalise_author_name(name) in excluded_author_names:
+                continue
+            if _looks_like_automated_history_identity(
+                display_name=name,
+                handle=handle,
+            ):
+                continue
+            key = _candidate_key(handle=handle, display_name=name)
+            row = candidates.setdefault(
+                key,
+                _new_candidate(key=key, handle=handle, display_name=name),
+            )
+            row["score"] += max(1, history_limit - rank + 1)
+            row["history_commit_count"] += 1
+            recent_rank = row["most_recent_history_rank"]
+            if recent_rank is None or rank < recent_rank:
+                row["most_recent_history_rank"] = rank
+            _append_unique(row, "source_kinds", "git_history")
+            _append_unique(row, "reason_codes", history_reason)
+            if rank <= 5:
+                _append_unique(row, "reason_codes", "recent_changed_path_contributor")
+            if handle is None:
+                _append_unique(row, "reason_codes", "github_identity_resolution_required")
+            _append_unique(row, "matched_files", changed_file)
+
+    ranked = sorted(
+        candidates.values(),
+        key=lambda row: (
+            -int(row["score"]),
+            -len(row["matched_files"]),
+            str(row.get("reviewer_handle") or row.get("display_name") or ""),
+        ),
+    )[:max_candidates]
+    for rank, row in enumerate(ranked, start=1):
+        row["rank"] = rank
+        row["confidence"] = _confidence(row)
+        row["path_coverage_count"] = len(row["matched_files"])
+
+    packet.update(
+        {
+            "recommendation_status": _recommendation_status(ranked),
+            "changed_files": files,
+            "changed_file_count": len(files),
+            "candidates": ranked,
+            "private_repo_state_read": True,
+            "next_safe_action": (
+                "Review candidate evidence and repository policy before any external "
+                "review request."
+            ),
+        }
+    )
+    packet["evidence_summary"]["codeowners_source"] = codeowners_source
+    validation = validate_issue_fix_reviewer_recommendation_packet(packet)
+    packet["ok"] = validation["ok"]
+    packet["validation"] = validation
+    return packet
+
+
+def validate_issue_fix_reviewer_recommendation_packet(
+    packet: Mapping[str, Any],
+) -> dict[str, Any]:
+    errors: list[str] = []
+    if packet.get("schema_version") != ISSUE_FIX_REVIEWER_RECOMMENDATION_SCHEMA_VERSION:
+        errors.append("schema_version must be issue_fix_reviewer_recommendation_v0")
+    for key in (
+        "external_reads_performed",
+        "external_writes_performed",
+        "review_request_performed",
+        "local_paths_captured",
+        "raw_git_output_captured",
+        "commit_emails_captured",
+    ):
+        if packet.get(key) is not False:
+            errors.append(f"{key} must be false")
+    execute = packet.get("execute") is True
+    if packet.get("private_repo_state_read") is not execute:
+        errors.append("private_repo_state_read must match execute")
+    changed_files = packet.get("changed_files")
+    if not isinstance(changed_files, list):
+        errors.append("changed_files must be a list")
+        changed_files = []
+    for path in changed_files:
+        try:
+            _normalise_changed_file(path)
+        except ValueError:
+            errors.append("changed_files must contain only repo-relative paths")
+            break
+    candidates = packet.get("candidates")
+    if not isinstance(candidates, list):
+        errors.append("candidates must be a list")
+        candidates = []
+    for candidate in candidates:
+        if not isinstance(candidate, Mapping):
+            errors.append("reviewer candidate must be an object")
+            continue
+        handle = candidate.get("reviewer_handle")
+        if handle is not None and _normalise_reviewer_handle(handle) != handle:
+            errors.append("reviewer_handle must be a normalized GitHub handle")
+        if candidate.get("requestable") is not bool(handle):
+            errors.append("requestable must reflect reviewer_handle availability")
+    policy = packet.get("policy")
+    if not isinstance(policy, Mapping):
+        errors.append("policy is required")
+    elif policy.get("automatic_review_request_allowed") is not False:
+        errors.append("reviewer recommendation must not authorize external requests")
+    return {
+        "ok": not errors,
+        "schema_version": "issue_fix_reviewer_recommendation_validation_v0",
+        "errors": errors,
+    }
+
+
+def render_issue_fix_reviewer_recommendation_markdown(
+    payload: Mapping[str, Any],
+) -> str:
+    lines = [
+        "# LoopX Issue-Fix Reviewer Recommendation",
+        "",
+        f"- ok: `{payload.get('ok')}`",
+        f"- repo: `{payload.get('repo')}`",
+        f"- execute: `{payload.get('execute')}`",
+        f"- recommendation_status: `{payload.get('recommendation_status')}`",
+        f"- changed_file_count: `{payload.get('changed_file_count')}`",
+        f"- external_writes_performed: `{payload.get('external_writes_performed')}`",
+        f"- review_request_performed: `{payload.get('review_request_performed')}`",
+        "",
+        "## Candidates",
+        "",
+    ]
+    candidates = payload.get("candidates")
+    if not isinstance(candidates, list) or not candidates:
+        lines.append("- none")
+    else:
+        for candidate in candidates:
+            if not isinstance(candidate, Mapping):
+                continue
+            identity = candidate.get("reviewer_handle") or candidate.get("display_name")
+            lines.append(
+                f"{candidate.get('rank')}. `{identity}` score=`{candidate.get('score')}` "
+                f"confidence=`{candidate.get('confidence')}` "
+                f"sources=`{','.join(candidate.get('source_kinds') or [])}`"
+            )
+    lines.extend(["", f"Next: {payload.get('next_safe_action')}"])
+    return "\n".join(lines)


### PR DESCRIPTION
## Motivation

The existing issue-fix capability entry was a short command index, had no full Chinese companion, and did not explain the long-running issue-to-PR employee design, current evidence/control surfaces, or roadmap. Issue-fix also lacked an executable, generic way to recommend an appropriate reviewer for the changed code.

## Implementation

- expand the canonical English issue-fix guide and add a paired Chinese guide covering product design, implemented capabilities, repository context, reproduction/validation, authority gates, Kanban-visible monitoring, terminal closeout, public pilot evidence, metrics, and roadmap
- add a newcomer-first explanation of the LoopX foundation: durable goals, todo ownership, Kanban projection, quota/scheduler policy, authority gates, evidence, replan/handoff, continuous monitors, and public/private boundaries
- link the matching language from the root READMEs and capability index
- add `loopx issue-fix reviewer-plan`, ranking repository `CODEOWNERS` first, then base-revision exact changed-path git history, with nearest-module history fallback for new files
- expose source kinds, reason codes, confidence, changed-path coverage, recency, handle/name exclusions, and requestable identity status without recording local paths, commit emails, raw git output, or performing a review request
- add a dedicated reviewer-routing/bilingual-guide canary profile so new checks run without displacing existing workflow, repository-context, feasibility, or PR-lifecycle coverage

## Validation

- `python3 -m loopx.cli --format json canary premerge --from-git-diff --timeout-seconds 180` — passed on head `9ab3bcdc`, 17 selected checks, 0 failures
- focused issue-fix guide, reviewer, workflow-plan, workflow-contract, repository-context, feasibility, PR-lifecycle, acceptance-loop, and workflow-e2e smokes — passed
- reviewer smoke passed 10 consecutive executions after hardening temporary git cleanup
- `python3 -m loopx.cli --format json check --scan-root .` — 0 errors, 0 warnings; public boundary clean
- `git diff --check origin/main...HEAD` — passed

## Risks and limitations

- `CODEOWNERS` matching deliberately supports a documented common subset; repositories with specialized patterns must verify against their native platform behavior
- git history is familiarity evidence, not proof of maintainer authority or availability
- history identities are requestable only when a public GitHub noreply identity can be resolved; bot-like history-only identities are excluded
- PR author handle and unresolved git display-name aliases must be supplied as exclusions when they differ
- this change recommends candidates only; external review requests, publication, merge, and production actions remain separately authorized

## Not covered

- automatic GitHub reviewer requests or availability lookup
- repository-host team and non-noreply identity resolution
- automatic integration of reviewer recommendations into PR-ready and lifecycle packets