### PR TITLE
Fix refresh-state validation atomicity

### DIFF
--- a/examples/project/goal-vision-refresh-state-budget-smoke.py
+++ b/examples/project/goal-vision-refresh-state-budget-smoke.py
@@ -153,7 +153,7 @@ def write_json(path: Path, value: dict) -> None:
 def main() -> int:
     with tempfile.TemporaryDirectory(prefix="loopx-goal-vision-budget-") as tmp:
         root = Path(tmp)
-        registry_path, runtime, _project = write_fixture(root)
+        registry_path, runtime, project = write_fixture(root)
         valid_path = root / "valid-vision.json"
         invalid_path = root / "invalid-vision.json"
 
@@ -322,6 +322,33 @@ def main() -> int:
         assert unchanged["agent_vision"] is None, unchanged
         assert unchanged["vision_checkpoint"]["agent_id"] == AGENT_ID, unchanged
         assert unchanged["vision_checkpoint"]["decision"] == "unchanged_with_reason", unchanged
+
+        state_path = (
+            project / ".codex" / "goals" / GOAL_ID / "ACTIVE_GOAL_STATE.md"
+        )
+        state_before_rejected_refresh = state_path.read_text(encoding="utf-8")
+        oversized_unchanged_reason_result = run_cli(
+            registry_path,
+            runtime,
+            inline_vision_args=["--vision-unchanged-reason", "x" * 241],
+            extra_args=[
+                "--next-action",
+                "This rejected refresh must not replace the durable action.",
+                "--progress-scope",
+                "goal",
+            ],
+            dry_run=False,
+            check=False,
+        )
+        assert oversized_unchanged_reason_result.returncode == 1, (
+            oversized_unchanged_reason_result
+        )
+        oversized_unchanged_reason = payload(oversized_unchanged_reason_result)
+        assert (
+            "vision_unchanged_reason exceeds 240 chars"
+            in oversized_unchanged_reason["error"]
+        ), oversized_unchanged_reason
+        assert state_path.read_text(encoding="utf-8") == state_before_rejected_refresh
 
         missing_checkpoint = payload(
             run_cli(

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -252,14 +252,7 @@ def build_vision_checkpoint(
         triggers.append({"kind": "durable_next_action_update"})
 
     delta_kinds = set(repair_delta_kinds or [])
-    unchanged = " ".join(str(vision_unchanged_reason or "").strip().split())
-    if unchanged:
-        validate_public_safe_text("vision_unchanged_reason", unchanged)
-        if len(unchanged) > VISION_UNCHANGED_REASON_LIMIT:
-            raise ValueError(
-                "vision_unchanged_reason exceeds "
-                f"{VISION_UNCHANGED_REASON_LIMIT} chars"
-            )
+    unchanged = normalize_vision_unchanged_reason(vision_unchanged_reason)
 
     required = bool(triggers)
     if agent_vision:
@@ -300,6 +293,21 @@ def build_vision_checkpoint(
             "link_successor_or_supersede",
         ]
     return checkpoint
+
+
+def normalize_vision_unchanged_reason(value: str | None) -> str:
+    """Normalize and validate a vision closeout reason before state mutation."""
+
+    unchanged = " ".join(str(value or "").strip().split())
+    if not unchanged:
+        return ""
+    validate_public_safe_text("vision_unchanged_reason", unchanged)
+    if len(unchanged) > VISION_UNCHANGED_REASON_LIMIT:
+        raise ValueError(
+            "vision_unchanged_reason exceeds "
+            f"{VISION_UNCHANGED_REASON_LIMIT} chars"
+        )
+    return unchanged
 
 
 def next_action_section_bounds(lines: list[str]) -> tuple[int, int] | None:
@@ -843,6 +851,9 @@ def refresh_state_run(
             goal_id=safe_goal_id,
             agent_id=normalized_agent_id or None,
         )
+    normalized_vision_unchanged_reason = normalize_vision_unchanged_reason(
+        vision_unchanged_reason
+    )
     generated_at = now_local()
     active_state_next_action_update: dict[str, Any] | None = None
     if normalized_next_action:
@@ -891,7 +902,7 @@ def refresh_state_run(
     vision_checkpoint = build_vision_checkpoint(
         agent_id=normalized_agent_id or None,
         agent_vision=agent_vision,
-        vision_unchanged_reason=vision_unchanged_reason,
+        vision_unchanged_reason=normalized_vision_unchanged_reason,
         delivery_outcome=normalized_delivery_outcome,
         autonomous_replan_recorded=bool(autonomous_replan_recorded),
         active_state_next_action_update=active_state_next_action_update,


### PR DESCRIPTION
## Summary
- validate bounded vision unchanged reasons before any active-state mutation
- preserve the existing vision checkpoint normalization contract
- add a real non-dry-run regression proving rejected refreshes leave state unchanged

## Validation
- goal-vision-refresh-state-budget-smoke.py
- next-action-projection-contract-smoke.py
- refresh-state-agent-lane-scope-smoke.py
- python compileall
- loopx check
- loopx canary premerge --from-git-diff (17/17 passed, no manual holds)