### PR TITLE
Fix Codex goal active-turn detection

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -427,6 +427,11 @@ def _assert_cli_goal_tui_ready_wait_rejects_startup_artifacts() -> None:
     )
     assert goal_tui.codex_cli_tui_input_prompt_visible(active_turn)
     assert goal_tui.codex_cli_tui_turn_active(active_turn)
+    goal_status_only = (
+        "› Explain this codebase\n"
+        "gpt-5.5 xhigh · workspace… Pursuing goal (15m)\n"
+    )
+    assert goal_tui.codex_cli_tui_turn_active(goal_status_only)
     assert not goal_tui.codex_cli_tui_turn_active("› Explain this codebase\n")
 
 

--- a/loopx/codex_cli_goal_tui.py
+++ b/loopx/codex_cli_goal_tui.py
@@ -334,6 +334,8 @@ def codex_cli_tui_turn_active(capture: str) -> bool:
         line = raw_line.lower()
         if "working (" in line and "esc to interrupt" in line:
             return True
+        if "pursuing goal (" in line:
+            return True
         if "queued follow-up inputs" in line:
             return True
     return False


### PR DESCRIPTION
## Summary
- recognize the visible `Pursuing goal (...)` status as an active Codex TUI turn
- keep first-action and meaningful-progress watchdogs from interrupting a still-running `/goal` turn
- add a focused status-only regression fixture

## Validation
- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `python3 examples/skillsbench-benchmark-egress-policy-smoke.py`
- `python3 examples/skillsbench-cli-goal-first-action-timeout-smoke.py`
- `python3 examples/skillsbench-runner-core-contract-smoke.py`
- `python3 examples/skillsbench-agent-runtime-layer-smoke.py`
- `python3 examples/benchmark-runner-invariant-review-smoke.py`
- `python3 -m py_compile loopx/codex_cli_goal_tui.py loopx/benchmark_adapters/skillsbench_acp_relay.py examples/skillsbench-codex-cli-goal-route-smoke.py`
- `loopx check`
- `loopx canary premerge --from-git-diff` (all automated checks passed; expected benchmark-sensitive manual hold)

## Maintainer review
- changed surface: shared Codex TUI active-turn classifier plus focused public smoke
- no scoring, task semantics, permissions, proxy policy, raw evidence, credentials, private state, or local paths changed
- total agent timeout remains the final bound; the change only prevents the shorter watchdog from misclassifying a visible active Goal
- owner has explicitly authorized benchmark-related self-merge; live canary replay follows after merge/install