### PR TITLE
Clean up failed SkillsBench launches by run

### DIFF
--- a/examples/skillsbench-benchmark-egress-policy-smoke.py
+++ b/examples/skillsbench-benchmark-egress-policy-smoke.py
@@ -208,6 +208,8 @@ def test_public_launcher_batches_three_cases_with_closeout_sync() -> None:
         "--local-ledger-catchup-run-group-contains "
         "skillsbench-codex-cli-goal-xhigh-" in output
     ), output
+    assert "--remote-failure-cleanup-pattern" in output, output
+    assert "--remote-failure-cleanup-include-docker" in output, output
     assert "--update-ledger" not in output, output
     assert "--local-target-lane-id codex-cli-goal-xhigh" in output, output
     assert "--local-target-run-group-contains" not in output, output

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -228,6 +228,8 @@ supervisor_cmd=(
   --cleanup-stale-local-forward
   --remote-forward "127.0.0.1:${remote_proxy_port}:${local_proxy_host}:${local_proxy_port}"
   --run-timeout-sec "$run_timeout"
+  --remote-failure-cleanup-pattern "$job_name"
+  --remote-failure-cleanup-include-docker
   --remote-command "$remote_command"
   --remote-public-artifact-root "${SKILLSBENCH_REMOTE_ROOT}/.local/private-benchmark-jobs"
   --remote-public-artifact-glob "${job_name}*/runner_prerequisites.public.json"


### PR DESCRIPTION
## Summary
- pass each launcher-generated unique `job_name` into the supervisor failure-cleanup contract
- remove matching remote processes and Docker containers after nonzero or timed-out runs
- assert the exact-run cleanup wiring in the public launcher smoke

## Validation
- `python3 examples/skillsbench-benchmark-egress-policy-smoke.py`
- `python3 examples/skillsbench-reverse-tunnel-supervisor-smoke.py`
- `bash -n scripts/skillsbench-launch-goal-xhigh.sh`
- Python compile for touched smoke and supervisor
- `loopx check`
- `loopx canary premerge --from-git-diff` (all automated checks passed; expected benchmark-sensitive manual hold)

## Maintainer review
- changed surface: public SkillsBench launcher wiring plus focused smoke
- cleanup runs only after a remote failure/timeout, uses the unique per-run job name, and public output records counts rather than the private pattern
- no scoring, task semantics, permissions, proxy behavior, raw evidence, credentials, or local absolute paths changed
- owner has explicitly authorized benchmark-related self-merge