### PR TITLE
Add issue-first views to the Lark Kanban adapter

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -476,6 +476,14 @@ visible by default so the board shows outputs instead of only active work.
 Shared sinks continue to apply the existing local-path, private-link, and
 private-reference redaction boundary.
 
+The Lark adapter renders this as a first-class issue dimension rather than
+only flattening the packet into `Evidence`. Outcome rows set
+`Work Item Type=Issue Fix` and populate `Repository`, `Issue`, `Pull Request`,
+`Route`, `Stage`, `Validation`, and `Outcome`. `Issue Fix Outcomes` provides the
+table view; `Issue Fix Kanban` groups the same rows by `Stage`. Existing boards
+gain the missing fields and views through idempotent `lark-kanban setup
+--execute` schema reconciliation.
+
 ## Commands
 
 ```bash

--- a/docs/capabilities/issue-fix/README.zh-CN.md
+++ b/docs/capabilities/issue-fix/README.zh-CN.md
@@ -429,6 +429,12 @@ focused validation 已通过。
 终态卡默认保留可见，让看板能展示产出，而不只展示活跃工作。Shared sink 继续复用
 现有 local-path、private-link 与 private-reference redaction 边界。
 
+Lark adapter 会把它渲染成一等 issue 维度，而不只是把 packet 压平写进 `Evidence`。
+Outcome 行设置 `Work Item Type=Issue Fix`，并填写 `Repository`、`Issue`、
+`Pull Request`、`Route`、`Stage`、`Validation` 和 `Outcome`。`Issue Fix Outcomes`
+提供表格视图，`Issue Fix Kanban` 按 `Stage` 分组展示同一批行。已有看板通过幂等的
+`lark-kanban setup --execute` schema reconciliation 自动补齐缺失字段和视图。
+
 ## 命令
 
 ```bash

--- a/docs/lark-kanban-control-plane-adapter.md
+++ b/docs/lark-kanban-control-plane-adapter.md
@@ -29,9 +29,16 @@ intake, then projected back to Lark with `sync-loopx-todos`.
 | Scope | `Scope` text, advisory in v0. |
 | Quota | Omitted in v0; the prototype assumes no quota limit. |
 | Worker launch | `Worker Command` and `Workdir`, consumed by heartbeat. |
+| Issue-fix outcome | One stable `Work Item Type=Issue Fix` row with `Repository`, `Issue`, `Pull Request`, `Route`, `Stage`, `Validation`, and `Outcome`. |
 
 The Kanban view groups by `Status`, so the board is the operator-facing
 control surface. Agent workers use the filtered `Worker Queue` view.
+
+Issue-fix execution todos and issue outcomes deliberately remain different
+rows. Todos answer what should happen next. The outcome row answers what has
+happened to one issue and stays keyed by repository plus issue across PR
+lifecycle changes. It is a read model derived from existing LoopX issue-fix
+state, not a second workflow ledger.
 
 ## Operator View
 
@@ -48,6 +55,16 @@ fields visible on the card:
 All other fields remain in the record detail and `All Tasks` grid. This keeps
 the first page light enough to scan while preserving complete task context for
 agents, handoff, audit, and recovery.
+
+Issue work has two dedicated views so it does not disappear inside the todo
+queue:
+
+- `Issue Fix Outcomes`: grid view filtered to `Work Item Type=Issue Fix`;
+- `Issue Fix Kanban`: Kanban view with the same filter, grouped by `Stage`.
+
+Their visible fields are `Task`, `Repository`, `Issue`, `Pull Request`,
+`Route`, `Stage`, `Validation`, `Outcome`, and `Status`. This keeps the existing
+todo Kanban compact while making per-issue state and output directly scannable.
 
 `lark-cli` 1.0.56 exposes `base +view-set-visible-fields`, so
 `lark-kanban setup` writes this compact Kanban card field list directly. Verify
@@ -138,6 +155,12 @@ python3 -m loopx.cli lark-kanban sync-loopx-todos --goal-id <goal-id> --execute
 The local config stores the reusable Base token, table id, view ids, identity,
 and synced `goal_id:todo_id -> record_id` mappings. The file lives under
 `.loopx/`, which is gitignored.
+
+Running `setup --execute` against an existing board is also the schema
+reconciliation path. It lists current fields, creates only missing fields,
+creates missing issue-fix views, and then reapplies filters, grouping, and
+visible-field configuration. Existing todo rows and stable outcome record ids
+are reused.
 
 To use someone else's shared board, store its URL or IDs:
 

--- a/examples/issue-fix-outcome-projection-smoke.py
+++ b/examples/issue-fix-outcome-projection-smoke.py
@@ -161,6 +161,14 @@ def main() -> None:
         "public-fixture-widgets:issues_42"
     ), row
     assert row["values"]["Action Kind"] == "issue_fix_outcome", row
+    assert row["values"]["Work Item Type"] == "Issue Fix", row
+    assert row["values"]["Repository"] == "public-fixture/widgets", row
+    assert row["values"]["Issue"] == "#42", row
+    assert row["values"]["Pull Request"] == "#77", row
+    assert row["values"]["Route"] == "fix_pr", row
+    assert row["values"]["Stage"] == "ci_pending", row
+    assert row["values"]["Validation"].startswith("passed:"), row
+    assert row["values"]["Outcome"] == "fix_pr_open", row
     assert "stage=ci_pending" in row["values"]["Evidence"], row
     assert "commit=fix-parser-abc1234" in row["values"]["Evidence"], row
     assert "risks=full integration suite" in row["values"]["Evidence"], row

--- a/examples/lark-kanban-control-plane-smoke.py
+++ b/examples/lark-kanban-control-plane-smoke.py
@@ -14,6 +14,7 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+from loopx.presentation.sinks.lark import issue_fix_surface  # noqa: E402
 from loopx.presentation.sinks.lark.kanban import (  # noqa: E402
     CLAIM_UNCLAIMED,
     STATUS_CLAIMED,
@@ -37,6 +38,10 @@ from loopx.presentation.sinks.lark.kanban import (  # noqa: E402
     sync_loopx_todos_to_lark_kanban,
     use_lark_kanban_board,
 )
+
+
+existing_setup_calls: list[list[str]] = []
+existing_setup_view_list_count = 0
 
 
 def fixture_payload() -> dict[str, object]:
@@ -158,6 +163,26 @@ def partial_setup_runner(args: list[str], cwd: Path | None, timeout: float | Non
     return {"returncode": 0, "stdout": json.dumps({"ok": True}), "stderr": "", "timed_out": False}
 
 
+def existing_setup_runner(args: list[str], cwd: Path | None, timeout: float | None) -> dict[str, object]:
+    global existing_setup_view_list_count
+    existing_setup_calls.append(args)
+    if args == ["lark-cli", "--version"]:
+        return {"returncode": 0, "stdout": "lark-cli 1.0.56\n", "stderr": "", "timed_out": False}
+    if args == ["lark-cli", "auth", "status"]:
+        return {"returncode": 0, "stdout": json.dumps({"ok": True, "identities": {"user": {"available": True}}}), "stderr": "", "timed_out": False}
+    if args[-1:] == ["--help"]:
+        return {"returncode": 0, "stdout": "help\n", "stderr": "", "timed_out": False}
+    if "+field-list" in args:
+        return {"returncode": 0, "stdout": json.dumps({"ok": True, "data": {"fields": [{"name": "Task"}, {"name": "Status"}, {"name": "Claim"}, {"name": "Priority"}]}}), "stderr": "", "timed_out": False}
+    if "+view-list" in args:
+        existing_setup_view_list_count += 1
+        views = [{"name": "Worker Queue", "view_id": "vew_worker_existing"}, {"name": "User Gates", "view_id": "vew_user_existing"}, {"name": "Kanban", "view_id": "vew_kanban_existing"}]
+        if existing_setup_view_list_count > 1:
+            views += [{"name": issue_fix_surface.DEFAULT_ISSUE_FIX_GRID_VIEW, "view_id": "vew_issue_grid"}, {"name": issue_fix_surface.DEFAULT_ISSUE_FIX_KANBAN_VIEW, "view_id": "vew_issue_kanban"}]
+        return {"returncode": 0, "stdout": json.dumps({"ok": True, "data": views}), "stderr": "", "timed_out": False}
+    return {"returncode": 0, "stdout": json.dumps({"ok": True}), "stderr": "", "timed_out": False}
+
+
 def run_cli(*extra_args: str) -> dict[str, object]:
     result = subprocess.run(
         [sys.executable, "-m", "loopx.cli", "--format", "json", *extra_args],
@@ -170,6 +195,7 @@ def run_cli(*extra_args: str) -> dict[str, object]:
 
 
 def main() -> int:
+    global existing_setup_view_list_count
     schema = lark_kanban_schema_payload()
     assert schema["ok"] is True, schema
     assert schema["schema_version"] == "loopx_lark_kanban_control_plane_v0", schema
@@ -178,7 +204,7 @@ def main() -> int:
     assert schema["task_spawning_model"]["board_creates_tasks"] is False, schema
     assert "LoopX todo lifecycle" in schema["task_spawning_model"]["rule"], schema
     field_names = [field["name"] for field in schema["fields"]]
-    for expected in ["Task", "Status", "Claim", "Handoff", "Evidence", "Run History", "Worker Command"]:
+    for expected in ["Task", "Status", "Claim", "Handoff", "Evidence", "Run History", "Worker Command", "Work Item Type", "Repository", "Issue", "Pull Request", "Route", "Stage", "Validation", "Outcome"]:
         assert expected in field_names, field_names
     assert schema["heartbeat_model"]["fallback"].startswith("agent heartbeat"), schema
     assert schema["operator_view"]["kanban_card_fields"] == lark_kanban_operator_card_fields(), schema
@@ -190,6 +216,8 @@ def main() -> int:
         "Evidence",
         "Status",
     ]
+    assert schema["operator_view"]["issue_fix_card_fields"] == issue_fix_surface.ISSUE_FIX_CARD_FIELDS
+    assert {issue_fix_surface.DEFAULT_ISSUE_FIX_GRID_VIEW, issue_fix_surface.DEFAULT_ISSUE_FIX_KANBAN_VIEW} <= {view["name"] for view in schema["views"]}
 
     plan = build_create_board_plan(
         base_name="LoopX Lark Kanban Control Plane POC",
@@ -203,6 +231,8 @@ def main() -> int:
     assert any("+view-set-group" in command and "Kanban" in command for command in joined), joined
     assert any("group_config" in command for command in joined), joined
     assert any("+view-set-visible-fields" in command for command in joined), joined
+    assert sum("+view-set-filter" in command and "Work Item Type" in command for command in joined) == 2, joined
+    assert any("+view-set-group" in command and "Issue Fix Kanban" in command and "Stage" in command for command in joined), joined
 
     heartbeat = lark_kanban_heartbeat(
         LarkKanbanConfig(
@@ -305,6 +335,22 @@ def main() -> int:
         assert stored["board"]["table_id"] == "tbl_live_fixture", stored
         assert stored["board"]["view_ids"]["Kanban"] == "vew_kanban_fixture", stored
         assert setup_payload["config"]["board"]["table_id"] == "tbl_live_fixture", setup_payload
+
+    with tempfile.TemporaryDirectory(prefix="loopx-lark-kanban-existing-") as tmp:
+        existing_setup_calls.clear()
+        existing_setup_view_list_count = 0
+        config_path = Path(tmp) / ".loopx" / "lark-kanban.json"
+        use_lark_kanban_board(config_path=config_path, base_url="https://example.invalid/base/base_existing?table=tbl_existing", cli_bin="lark-cli", identity="user")
+        migrated = setup_lark_kanban_board(config_path=config_path, base_name="LoopX Existing Board Fixture", cli_bin="lark-cli", identity="user", execute=True, runner=existing_setup_runner)
+        assert migrated["ok"] is True, migrated
+        assert {"Work Item Type", "Repository", "Issue", "Pull Request", "Route", "Stage", "Validation", "Outcome"} <= set(migrated["created_fields"]), migrated
+        assert migrated["view_ids"][issue_fix_surface.DEFAULT_ISSUE_FIX_GRID_VIEW] == "vew_issue_grid", migrated
+        assert migrated["view_ids"][issue_fix_surface.DEFAULT_ISSUE_FIX_KANBAN_VIEW] == "vew_issue_kanban", migrated
+        created_views = next(args for args in existing_setup_calls if "+view-create" in args)
+        assert {item["name"] for item in json.loads(created_views[created_views.index("--json") + 1])} >= {issue_fix_surface.DEFAULT_ISSUE_FIX_GRID_VIEW, issue_fix_surface.DEFAULT_ISSUE_FIX_KANBAN_VIEW}
+        issue_group = next(args for args in existing_setup_calls if "+view-set-group" in args and "vew_issue_kanban" in args)
+        assert "Stage" in issue_group[issue_group.index("--json") + 1], issue_group
+        assert len([args for args in existing_setup_calls if "+view-set-visible-fields" in args and any(view in args for view in ("vew_issue_grid", "vew_issue_kanban"))]) == 2
 
     with tempfile.TemporaryDirectory(prefix="loopx-lark-kanban-sync-") as tmp:
         root = Path(tmp)

--- a/loopx/presentation/sinks/lark/issue_fix_surface.py
+++ b/loopx/presentation/sinks/lark/issue_fix_surface.py
@@ -1,0 +1,327 @@
+"""Issue-fix fields and views for the generic Lark Kanban sink."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable, Mapping
+from typing import Any
+
+
+DEFAULT_ISSUE_FIX_GRID_VIEW = "Issue Fix Outcomes"
+DEFAULT_ISSUE_FIX_KANBAN_VIEW = "Issue Fix Kanban"
+
+ISSUE_FIX_CARD_FIELDS = [
+    "Task",
+    "Repository",
+    "Issue",
+    "Pull Request",
+    "Route",
+    "Stage",
+    "Validation",
+    "Outcome",
+    "Status",
+]
+
+ISSUE_FIX_STAGE_OPTIONS = [
+    "reproduction_planned",
+    "reproduction_blocked",
+    "fix_in_progress",
+    "fix_blocked",
+    "delivery_blocked",
+    "fix_review_ready",
+    "draft_pr",
+    "ci_pending",
+    "ci_failed",
+    "review_wait",
+    "changes_requested",
+    "branch_stale_or_conflicted",
+    "pr_open",
+    "merge_ready",
+    "merged",
+    "closed_without_merge",
+    "comment_packet",
+    "comment_blocked",
+    "comment_published",
+    "triage_complete",
+]
+
+
+def issue_fix_field_definitions(
+    select_options: Callable[[list[str]], list[dict[str, str]]],
+) -> list[dict[str, Any]]:
+    return [
+        {
+            "name": "Work Item Type",
+            "type": "select",
+            "multiple": False,
+            "options": select_options(["Todo", "Issue Fix"]),
+        },
+        {"name": "Repository", "type": "text", "style": {"type": "plain"}},
+        {"name": "Issue", "type": "text", "style": {"type": "plain"}},
+        {"name": "Pull Request", "type": "text", "style": {"type": "plain"}},
+        {
+            "name": "Route",
+            "type": "select",
+            "multiple": False,
+            "options": select_options(["fix_pr", "comment_only", "triage_only"]),
+        },
+        {
+            "name": "Stage",
+            "type": "select",
+            "multiple": False,
+            "options": select_options(ISSUE_FIX_STAGE_OPTIONS),
+        },
+        {"name": "Validation", "type": "text", "style": {"type": "plain"}},
+        {"name": "Outcome", "type": "text", "style": {"type": "plain"}},
+    ]
+
+
+def issue_fix_views() -> list[dict[str, str]]:
+    return [
+        {"name": DEFAULT_ISSUE_FIX_GRID_VIEW, "type": "grid"},
+        {"name": DEFAULT_ISSUE_FIX_KANBAN_VIEW, "type": "kanban"},
+    ]
+
+
+def issue_fix_record_values(
+    block: Mapping[str, Any],
+    *,
+    compact_text: Callable[..., str],
+) -> dict[str, Any]:
+    if str(block.get("action_kind") or "") != "issue_fix_outcome":
+        return {}
+    issue = block.get("issue") if isinstance(block.get("issue"), Mapping) else {}
+    pull_request = (
+        block.get("pull_request")
+        if isinstance(block.get("pull_request"), Mapping)
+        else {}
+    )
+    validation = (
+        block.get("validation") if isinstance(block.get("validation"), Mapping) else {}
+    )
+    result = block.get("result") if isinstance(block.get("result"), Mapping) else {}
+    issue_number = issue.get("number")
+    pr_number = pull_request.get("number")
+    validation_status = compact_text(validation.get("status"), limit=80)
+    validation_label = compact_text(validation.get("label"), limit=220)
+    return {
+        "Work Item Type": "Issue Fix",
+        "Repository": compact_text(block.get("repo"), limit=160),
+        "Issue": f"#{issue_number}"
+        if issue_number is not None
+        else compact_text(block.get("issue_ref"), limit=80),
+        "Pull Request": f"#{pr_number}"
+        if pr_number is not None
+        else compact_text(pull_request.get("ref"), limit=80),
+        "Route": compact_text(block.get("route"), limit=80),
+        "Stage": compact_text(block.get("stage"), limit=80),
+        "Validation": compact_text(
+            ": ".join(part for part in (validation_status, validation_label) if part),
+            limit=300,
+        ),
+        "Outcome": compact_text(result.get("kind"), limit=120),
+    }
+
+
+def todo_record_values() -> dict[str, str]:
+    return {
+        "Work Item Type": "Todo",
+        "Repository": "",
+        "Issue": "",
+        "Pull Request": "",
+        "Route": "",
+        "Stage": "",
+        "Validation": "",
+        "Outcome": "",
+    }
+
+
+def extract_field_names(parsed: Any) -> set[str]:
+    if isinstance(parsed, dict):
+        fields = parsed.get("fields")
+        if isinstance(fields, list):
+            return {
+                str(item.get("name") or "").strip()
+                for item in fields
+                if isinstance(item, Mapping) and str(item.get("name") or "").strip()
+            }
+        for value in parsed.values():
+            names = extract_field_names(value)
+            if names:
+                return names
+    if isinstance(parsed, list):
+        for value in parsed:
+            names = extract_field_names(value)
+            if names:
+                return names
+    return set()
+
+
+def missing_field_definitions(
+    parsed: Any, definitions: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    existing = extract_field_names(parsed)
+    return [item for item in definitions if str(item.get("name") or "").strip() not in existing]
+
+
+def issue_fix_view_configuration_commands(
+    *,
+    cli_bin: str,
+    identity: str,
+    base_token: str,
+    table_id: str,
+    view_ids: dict[str, str],
+) -> list[list[str]]:
+    issue_grid_view = (
+        view_ids.get(DEFAULT_ISSUE_FIX_GRID_VIEW) or DEFAULT_ISSUE_FIX_GRID_VIEW
+    )
+    issue_kanban_view = (
+        view_ids.get(DEFAULT_ISSUE_FIX_KANBAN_VIEW) or DEFAULT_ISSUE_FIX_KANBAN_VIEW
+    )
+    common = [
+        cli_bin,
+        "base",
+        "--as",
+        identity,
+        "--base-token",
+        base_token,
+        "--table-id",
+        table_id,
+    ]
+    commands = [
+        [
+            *common[:2],
+            "+view-set-filter",
+            *common[2:],
+            "--view-id",
+            view_id,
+            "--json",
+            json.dumps(
+                {
+                    "logic": "and",
+                    "conditions": [["Work Item Type", "intersects", ["Issue Fix"]]],
+                },
+                ensure_ascii=False,
+            ),
+        ]
+        for view_id in (issue_grid_view, issue_kanban_view)
+    ]
+    commands.append(
+        [
+            *common[:2],
+            "+view-set-group",
+            *common[2:],
+            "--view-id",
+            issue_kanban_view,
+            "--json",
+            json.dumps(
+                {"group_config": [{"field": "Stage", "desc": False}]},
+                ensure_ascii=False,
+            ),
+        ]
+    )
+    commands.extend(
+        [
+            *common[:2],
+            "+view-set-visible-fields",
+            *common[2:],
+            "--view-id",
+            view_id,
+            "--json",
+            json.dumps({"visible_fields": ISSUE_FIX_CARD_FIELDS}, ensure_ascii=False),
+        ]
+        for view_id in (issue_grid_view, issue_kanban_view)
+    )
+    return commands
+
+
+def view_configuration_commands(
+    *,
+    cli_bin: str,
+    identity: str,
+    base_token: str,
+    table_id: str,
+    view_ids: dict[str, str],
+    worker_view_name: str,
+    todo_statuses: list[str],
+    user_gate_status: str,
+    operator_card_fields: list[str],
+) -> list[list[str]]:
+    worker_view = view_ids.get(worker_view_name) or worker_view_name
+    user_gate_view = view_ids.get("User Gates") or "User Gates"
+    kanban_view = view_ids.get("Kanban") or "Kanban"
+    common = [
+        "--as",
+        identity,
+        "--base-token",
+        base_token,
+        "--table-id",
+        table_id,
+    ]
+    commands = [
+        [
+            cli_bin,
+            "base",
+            "+view-set-filter",
+            *common,
+            "--view-id",
+            worker_view,
+            "--json",
+            json.dumps(
+                {
+                    "logic": "and",
+                    "conditions": [["Status", "intersects", todo_statuses]],
+                },
+                ensure_ascii=False,
+            ),
+        ],
+        [
+            cli_bin,
+            "base",
+            "+view-set-filter",
+            *common,
+            "--view-id",
+            user_gate_view,
+            "--json",
+            json.dumps(
+                {
+                    "logic": "and",
+                    "conditions": [["Status", "intersects", [user_gate_status]]],
+                },
+                ensure_ascii=False,
+            ),
+        ],
+        [
+            cli_bin,
+            "base",
+            "+view-set-group",
+            *common,
+            "--view-id",
+            kanban_view,
+            "--json",
+            json.dumps(
+                {"group_config": [{"field": "Status", "desc": False}]},
+                ensure_ascii=False,
+            ),
+        ],
+        [
+            cli_bin,
+            "base",
+            "+view-set-visible-fields",
+            *common,
+            "--view-id",
+            kanban_view,
+            "--json",
+            json.dumps({"visible_fields": operator_card_fields}, ensure_ascii=False),
+        ],
+    ]
+    commands.extend(
+        issue_fix_view_configuration_commands(
+            cli_bin=cli_bin,
+            identity=identity,
+            base_token=base_token,
+            table_id=table_id,
+            view_ids=view_ids,
+        )
+    )
+    return commands

--- a/loopx/presentation/sinks/lark/kanban.py
+++ b/loopx/presentation/sinks/lark/kanban.py
@@ -7,7 +7,7 @@ import subprocess
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Callable, Mapping, Optional
+from typing import Any, Callable, Optional
 from urllib.parse import parse_qs, urlparse
 
 from ....control_plane.todos.contract import (
@@ -21,6 +21,7 @@ from ....control_plane.todos.contract import (
     normalize_explicit_todo_task_class,
     normalize_todo_status,
 )
+from . import issue_fix_surface
 from .projection_rows import (
     projection_lifecycle_parts as _projection_lifecycle_parts,
     projection_lifecycle_state as _projection_lifecycle_state,
@@ -136,6 +137,7 @@ def lark_kanban_field_definitions() -> list[dict[str, Any]]:
         {"name": "Action Kind", "type": "text", "style": {"type": "plain"}},
         {"name": "LoopX Goal ID", "type": "text", "style": {"type": "plain"}},
         {"name": "LoopX Todo ID", "type": "text", "style": {"type": "plain"}},
+        *issue_fix_surface.issue_fix_field_definitions(_select_options),
         {"name": "Scope", "type": "text", "style": {"type": "plain"}},
         {"name": "User Gate", "type": "text", "style": {"type": "plain"}},
         {"name": "Handoff", "type": "text", "style": {"type": "plain"}},
@@ -178,6 +180,7 @@ def lark_kanban_views() -> list[dict[str, str]]:
         {"name": DEFAULT_STATUS_QUEUE_VIEW, "type": "grid"},
         {"name": "User Gates", "type": "grid"},
         {"name": "Kanban", "type": "kanban"},
+        *issue_fix_surface.issue_fix_views(),
     ]
 
 
@@ -197,11 +200,14 @@ def lark_kanban_schema_payload(*, table_name: str = DEFAULT_TABLE_NAME) -> dict[
             "run_history": "Run History append-style compact text field",
             "quota": "omitted in v0 prototype; assume no quota limit",
             "scope": "Scope text field; advisory in v0 prototype",
+            "issue_fix_outcome": "First-class issue row with repository, issue, PR, route, stage, validation, and outcome dimensions.",
         },
         "fields": lark_kanban_field_definitions(),
         "views": lark_kanban_views(),
         "operator_view": {
             "kanban_card_fields": OPERATOR_CARD_FIELDS,
+            "issue_fix_card_fields": issue_fix_surface.ISSUE_FIX_CARD_FIELDS,
+            "issue_fix_views": [issue_fix_surface.DEFAULT_ISSUE_FIX_GRID_VIEW, issue_fix_surface.DEFAULT_ISSUE_FIX_KANBAN_VIEW],
             "reason": (
                 "Keep the human-facing Kanban card small; retain the full task "
                 "context in the record detail and All Tasks grid."
@@ -981,84 +987,7 @@ def build_create_board_plan(
                 ),
             ]
         )
-    commands.extend(
-        [
-            [
-                cli_bin,
-                "base",
-                "+view-set-filter",
-                "--as",
-                identity,
-                "--base-token",
-                token,
-                "--table-id",
-                table_ref,
-                "--view-id",
-                DEFAULT_STATUS_QUEUE_VIEW,
-                "--json",
-                json.dumps(
-                    {
-                        "logic": "and",
-                        "conditions": [
-                            ["Status", "intersects", [STATUS_TODO, STATUS_CLAIMED]]
-                        ],
-                    },
-                    ensure_ascii=False,
-                ),
-            ],
-            [
-                cli_bin,
-                "base",
-                "+view-set-filter",
-                "--as",
-                identity,
-                "--base-token",
-                token,
-                "--table-id",
-                table_ref,
-                "--view-id",
-                "User Gates",
-                "--json",
-                json.dumps(
-                    {
-                        "logic": "and",
-                        "conditions": [["Status", "intersects", [STATUS_USER_GATE]]],
-                    },
-                    ensure_ascii=False,
-                ),
-            ],
-            [
-                cli_bin,
-                "base",
-                "+view-set-group",
-                "--as",
-                identity,
-                "--base-token",
-                token,
-                "--table-id",
-                table_ref,
-                "--view-id",
-                "Kanban",
-                "--json",
-                json.dumps({"group_config": [{"field": "Status", "desc": False}]}, ensure_ascii=False),
-            ],
-            [
-                cli_bin,
-                "base",
-                "+view-set-visible-fields",
-                "--as",
-                identity,
-                "--base-token",
-                token,
-                "--table-id",
-                table_ref,
-                "--view-id",
-                "Kanban",
-                "--json",
-                json.dumps({"visible_fields": OPERATOR_CARD_FIELDS}, ensure_ascii=False),
-            ],
-        ]
-    )
+    commands.extend(_view_configuration_commands(cli_bin=cli_bin, identity=identity, base_token=token, table_id=table_ref, view_ids={view["name"]: view["name"] for view in lark_kanban_views()}))
     return commands
 
 
@@ -1162,80 +1091,7 @@ def create_lark_kanban_board(
         commands.append(grant)
         if grant.get("executed") and not grant.get("ok"):
             return _board_payload(False, commands, effective_base_token, table_id)
-    for command in (
-        [
-            cli_bin,
-            "base",
-            "+view-set-filter",
-            "--as",
-            identity,
-            "--base-token",
-            token,
-            "--table-id",
-            table_ref,
-            "--view-id",
-            DEFAULT_STATUS_QUEUE_VIEW,
-            "--json",
-            json.dumps(
-                {
-                    "logic": "and",
-                    "conditions": [["Status", "intersects", [STATUS_TODO, STATUS_CLAIMED]]],
-                },
-                ensure_ascii=False,
-            ),
-        ],
-        [
-            cli_bin,
-            "base",
-            "+view-set-filter",
-            "--as",
-            identity,
-            "--base-token",
-            token,
-            "--table-id",
-            table_ref,
-            "--view-id",
-            "User Gates",
-            "--json",
-            json.dumps(
-                {
-                    "logic": "and",
-                    "conditions": [["Status", "intersects", [STATUS_USER_GATE]]],
-                },
-                ensure_ascii=False,
-            ),
-        ],
-        [
-            cli_bin,
-            "base",
-            "+view-set-group",
-            "--as",
-            identity,
-            "--base-token",
-            token,
-            "--table-id",
-            table_ref,
-            "--view-id",
-            "Kanban",
-            "--json",
-            json.dumps({"group_config": [{"field": "Status", "desc": False}]}, ensure_ascii=False),
-        ],
-        [
-            cli_bin,
-            "base",
-            "+view-set-visible-fields",
-            "--as",
-            identity,
-            "--base-token",
-            token,
-            "--table-id",
-            table_ref,
-            "--view-id",
-            "Kanban",
-            "--json",
-            json.dumps({"visible_fields": OPERATOR_CARD_FIELDS}, ensure_ascii=False),
-        ],
-    ):
+    for command in _view_configuration_commands(cli_bin=cli_bin, identity=identity, base_token=token, table_id=table_ref, view_ids={view["name"]: view["name"] for view in lark_kanban_views()}):
         result = _run_command(command, execute=execute, runner=runner)
         commands.append(result)
         if result.get("executed") and not result.get("ok"):
@@ -1444,6 +1300,7 @@ def setup_lark_kanban_board(
 
     created_base = False
     created_table = False
+    created_field_names: list[str] = []
     config_payload: dict[str, Any] | None = None
 
     def save_usable_config() -> None:
@@ -1594,6 +1451,26 @@ def setup_lark_kanban_board(
 
     save_usable_config()
 
+    if execute and not created_base and not created_table:
+        field_list = _run_command(
+            [cli_bin, "base", "+field-list", "--as", identity, "--base-token", effective_base_token, "--table-id", effective_table_id, "--format", "json", "--limit", "200"],
+            execute=True,
+            runner=runner,
+        )
+        commands.append(field_list)
+        if not field_list.get("ok"):
+            return partial_enrichment_payload(field_list)
+        for definition in issue_fix_surface.missing_field_definitions(field_list.get("json"), lark_kanban_field_definitions()):
+            field_create = _run_command(
+                [cli_bin, "base", "+field-create", "--as", identity, "--base-token", effective_base_token, "--table-id", effective_table_id, "--json", json.dumps(definition, ensure_ascii=False)],
+                execute=True,
+                runner=runner,
+            )
+            commands.append(field_create)
+            if not field_create.get("ok"):
+                return partial_enrichment_payload(field_create)
+            created_field_names.append(str(definition.get("name") or ""))
+
     if execute:
         view_ids = _refresh_view_ids(
             cli_bin=cli_bin,
@@ -1670,6 +1547,7 @@ def setup_lark_kanban_board(
         "config_path": str(config_path),
         "created_base": created_base,
         "created_table": created_table,
+        "created_fields": created_field_names,
         "base_token": effective_base_token,
         "table_id": effective_table_id,
         "view_ids": view_ids,
@@ -1758,83 +1636,7 @@ def _view_configuration_commands(
     table_id: str,
     view_ids: dict[str, str],
 ) -> list[list[str]]:
-    worker_view = view_ids.get(DEFAULT_STATUS_QUEUE_VIEW) or DEFAULT_STATUS_QUEUE_VIEW
-    user_gate_view = view_ids.get("User Gates") or "User Gates"
-    kanban_view = view_ids.get("Kanban") or "Kanban"
-    return [
-        [
-            cli_bin,
-            "base",
-            "+view-set-filter",
-            "--as",
-            identity,
-            "--base-token",
-            base_token,
-            "--table-id",
-            table_id,
-            "--view-id",
-            worker_view,
-            "--json",
-            json.dumps(
-                {
-                    "logic": "and",
-                    "conditions": [["Status", "intersects", [STATUS_TODO, STATUS_CLAIMED]]],
-                },
-                ensure_ascii=False,
-            ),
-        ],
-        [
-            cli_bin,
-            "base",
-            "+view-set-filter",
-            "--as",
-            identity,
-            "--base-token",
-            base_token,
-            "--table-id",
-            table_id,
-            "--view-id",
-            user_gate_view,
-            "--json",
-            json.dumps(
-                {
-                    "logic": "and",
-                    "conditions": [["Status", "intersects", [STATUS_USER_GATE]]],
-                },
-                ensure_ascii=False,
-            ),
-        ],
-        [
-            cli_bin,
-            "base",
-            "+view-set-group",
-            "--as",
-            identity,
-            "--base-token",
-            base_token,
-            "--table-id",
-            table_id,
-            "--view-id",
-            kanban_view,
-            "--json",
-            json.dumps({"group_config": [{"field": "Status", "desc": False}]}, ensure_ascii=False),
-        ],
-        [
-            cli_bin,
-            "base",
-            "+view-set-visible-fields",
-            "--as",
-            identity,
-            "--base-token",
-            base_token,
-            "--table-id",
-            table_id,
-            "--view-id",
-            kanban_view,
-            "--json",
-            json.dumps({"visible_fields": OPERATOR_CARD_FIELDS}, ensure_ascii=False),
-        ],
-    ]
+    return issue_fix_surface.view_configuration_commands(cli_bin=cli_bin, identity=identity, base_token=base_token, table_id=table_id, view_ids=view_ids, worker_view_name=DEFAULT_STATUS_QUEUE_VIEW, todo_statuses=[STATUS_TODO, STATUS_CLAIMED], user_gate_status=STATUS_USER_GATE, operator_card_fields=OPERATOR_CARD_FIELDS)
 
 
 def lark_kanban_doctor(
@@ -2017,6 +1819,7 @@ def _lark_record_from_projection_block(
             ),
         }
     )
+    values.update(issue_fix_surface.issue_fix_record_values(block, compact_text=_compact_text))
     return _public_safe_lark_values(values) if public_safe else values
 
 
@@ -2310,6 +2113,7 @@ def _lark_record_from_todo_block(
         "Action Kind": str(block.get("action_kind") or "sync_loopx_todo"),
         "LoopX Goal ID": goal_id,
         "LoopX Todo ID": str(block.get("todo_id") or ""),
+        **issue_fix_surface.todo_record_values(),
         "Scope": scope_text,
         "User Gate": text if lark_status == STATUS_USER_GATE else "",
         "Handoff": f"Synced from LoopX active state: {state_file.name}",


### PR DESCRIPTION
## Motivation

The issue-fix outcome projection already produced a stable row, but the shared Lark board exposed only todo-oriented fields and views. Operators could not answer what happened to one issue without opening flattened Evidence text.

## Implementation

- add first-class Repository, Issue, Pull Request, Route, Stage, Validation, and Outcome fields
- add `Issue Fix Outcomes` and Stage-grouped `Issue Fix Kanban` views while preserving the existing Todo Kanban
- reconcile missing fields and views idempotently when `lark-kanban setup --execute` targets an existing board
- keep issue outcomes derived from the existing read model rather than adding a second state machine
- isolate issue-specific rendering/configuration in a bounded Lark surface module and document the contract in English and Chinese

## Validation

- `python3 examples/lark-kanban-control-plane-smoke.py`
- `python3 examples/issue-fix-outcome-projection-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `python3 -m loopx.cli --format json lark-kanban schema`
- `loopx canary premerge --from-git-diff`: 4 direct checks and 17 selected checks passed; no failures, warnings, manual holds, or public-boundary findings

## Risk and coverage

The change performs additive schema/view migration and reuses stable record ids. Existing Todo cards remain intact. The main residual risk is live Lark API compatibility during migration; the existing-board smoke covers field/view creation and the real pilot board will be migrated and read back after merge. No local state, credentials, raw logs, or private material are included.