### PR TITLE
Fix remote Docker API compatibility for SkillsBench

### DIFF
--- a/examples/skillsbench-benchmark-egress-policy-smoke.py
+++ b/examples/skillsbench-benchmark-egress-policy-smoke.py
@@ -135,6 +135,7 @@ def test_public_launcher_uses_container_reachable_benchmark_proxy() -> None:
             "SKILLSBENCH_ROOT": "/remote/skillsbench",
             "SKILLSBENCH_EXPECTED_LOOPX_GIT_HEAD": "abc1234",
             "SKILLSBENCH_DOCKER_PROXY_HOST": "host.docker.internal",
+            "SKILLSBENCH_DOCKER_API_VERSION": "1.43",
             "SKILLSBENCH_RUN_STAMP": "20260709T000000CST",
         }
     )
@@ -160,6 +161,7 @@ def test_public_launcher_uses_container_reachable_benchmark_proxy() -> None:
         "LOOPX_SKILLSBENCH_EGRESS_PROXY=http://host.docker.internal:18186"
         in output
     ), output
+    assert "DOCKER_API_VERSION=1.43" in output, output
     assert "--codex-api-reverse-tunnel-proxy http://127.0.0.1:18186" in output, output
     assert "--benchmark-egress-proxy-mode require" in output, output
     assert "--append-history" not in output, output
@@ -174,6 +176,7 @@ def test_public_launcher_batches_three_cases_with_closeout_sync() -> None:
             "SKILLSBENCH_ROOT": "/remote/skillsbench",
             "SKILLSBENCH_EXPECTED_LOOPX_GIT_HEAD": "abc1234",
             "SKILLSBENCH_DOCKER_PROXY_HOST": "host.docker.internal",
+            "SKILLSBENCH_DOCKER_API_VERSION": "1.43",
             "SKILLSBENCH_RUN_STAMP": "20260710T000000CST",
             "SKILLSBENCH_CANONICAL_CASE_IDS_FILE": "/opaque/canonical-ids.txt",
         }
@@ -214,6 +217,63 @@ def test_public_launcher_batches_three_cases_with_closeout_sync() -> None:
     assert "--local-target-lane-id codex-cli-goal-xhigh" in output, output
     assert "--local-target-run-group-contains" not in output, output
     assert "--local-target-backfill-run-group-contains" not in output, output
+
+
+def test_public_launcher_applies_ssh_options_to_remote_discovery() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-launch-ssh-options-") as tmp:
+        root = Path(tmp)
+        fake_bin = root / "bin"
+        fake_bin.mkdir()
+        ssh_log = root / "ssh.log"
+        fake_ssh = fake_bin / "ssh"
+        fake_ssh.write_text(
+            "#!/usr/bin/env bash\n"
+            "printf '%s\\n' \"$*\" >> \"$SKILLSBENCH_TEST_SSH_LOG\"\n"
+            "if [[ \"$*\" == *'ip -4 addr show docker0'* ]]; then\n"
+            "  printf 'docker-bridge.example.invalid\\n'\n"
+            "else\n"
+            "  printf '1.43\\n'\n"
+            "fi\n",
+            encoding="utf-8",
+        )
+        fake_ssh.chmod(0o755)
+        env = os.environ.copy()
+        env.update(
+            {
+                "PATH": f"{fake_bin}:{env['PATH']}",
+                "SKILLSBENCH_TEST_SSH_LOG": str(ssh_log),
+                "SKILLSBENCH_SSH_DESTINATION": "example.invalid",
+                "SKILLSBENCH_SSH_OPTIONS": "Port=2222",
+                "SKILLSBENCH_REMOTE_ROOT": "/remote/loopx",
+                "SKILLSBENCH_ROOT": "/remote/skillsbench",
+                "SKILLSBENCH_EXPECTED_LOOPX_GIT_HEAD": "abc1234",
+                "SKILLSBENCH_RUN_STAMP": "20260710T010000CST",
+            }
+        )
+        env.pop("SKILLSBENCH_DOCKER_PROXY_HOST", None)
+        env.pop("SKILLSBENCH_DOCKER_API_VERSION", None)
+        proc = subprocess.run(
+            [
+                str(REPO_ROOT / "scripts" / "skillsbench-launch-goal-xhigh.sh"),
+                "--dry-run",
+                "citation-check",
+                "ssh-options-smoke",
+                "18186",
+            ],
+            cwd=REPO_ROOT,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=True,
+        )
+
+        discovery_calls = ssh_log.read_text(encoding="utf-8").splitlines()
+        assert len(discovery_calls) == 2, discovery_calls
+        assert all("-o Port=2222" in call for call in discovery_calls), discovery_calls
+        assert "docker_proxy_host=docker-bridge.example.invalid" in proc.stdout, proc.stdout
+        assert "docker_api_version=1.43" in proc.stdout, proc.stdout
+        assert "DOCKER_API_VERSION=1.43" in proc.stdout, proc.stdout
 
 
 def test_verifier_proxy_patch_is_required_only_for_existing_verifier() -> None:
@@ -336,6 +396,7 @@ if __name__ == "__main__":
     test_formal_cli_goal_proxy_env_is_forwarded_without_public_url()
     test_public_launcher_uses_container_reachable_benchmark_proxy()
     test_public_launcher_batches_three_cases_with_closeout_sync()
+    test_public_launcher_applies_ssh_options_to_remote_discovery()
     test_verifier_proxy_patch_is_required_only_for_existing_verifier()
     test_verifier_proxy_patch_failure_blocks_task_staging()
     test_proxy_runtime_prewarms_external_base_images_without_public_refs()

--- a/examples/skillsbench-failure-attribution-smoke.py
+++ b/examples/skillsbench-failure-attribution-smoke.py
@@ -37,6 +37,23 @@ def test_pip_bootstrap_failure_attribution() -> None:
     assert "pip_bootstrap_failure" in fingerprint["matched_patterns"], fingerprint
 
 
+def test_docker_api_version_mismatch_attribution() -> None:
+    error_text = (
+        "Docker compose command failed. Error response from daemon: "
+        "client version 1.52 is too new. Maximum supported API version is 1.43"
+    )
+
+    exception_type, attribution, labels = skillsbench_runner_error_attribution(
+        error_text
+    )
+    expected = "skillsbench_docker_api_version_mismatch"
+    assert exception_type == expected
+    assert attribution == expected
+    assert "skillsbench_docker_compose_setup_failure" in labels, labels
+    fingerprint = skillsbench_runner_error_fingerprint(error_text)
+    assert "docker_api_version_mismatch" in fingerprint["matched_patterns"], fingerprint
+
+
 def test_injected_pip_lines_do_not_mask_later_build_failure() -> None:
     error_text = (
         "Docker compose command failed.\n"
@@ -125,6 +142,7 @@ def test_failure_dependency_classes_ignore_unrelated_dockerfile_lines() -> None:
 
 if __name__ == "__main__":
     test_pip_bootstrap_failure_attribution()
+    test_docker_api_version_mismatch_attribution()
     test_injected_pip_lines_do_not_mask_later_build_failure()
     test_setup_attribution_reconciles_to_public_fingerprint()
     test_supported_setup_attribution_is_unchanged()

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -1655,6 +1655,17 @@ def skillsbench_runner_error_attribution(error_text: str) -> tuple[str, str, lis
         ]
     if "docker compose command failed" in text:
         if (
+            "client version" in text
+            and "is too new" in text
+            and "maximum supported api version" in text
+        ):
+            label = "skillsbench_docker_api_version_mismatch"
+            return label, label, [
+                label,
+                "skillsbench_docker_compose_setup_failure",
+                "skillsbench_environment_setup_error",
+            ]
+        if (
             "cannot connect to the docker daemon" in text
             or "is the docker daemon running" in text
             or "docker daemon is not running" in text

--- a/loopx/benchmark_adapters/skillsbench_failure_signals.py
+++ b/loopx/benchmark_adapters/skillsbench_failure_signals.py
@@ -4,6 +4,7 @@ import re
 
 
 _SETUP_ATTRIBUTION_FINGERPRINT_PATTERNS = {
+    "skillsbench_docker_api_version_mismatch": "docker_api_version_mismatch",
     "skillsbench_docker_daemon_unavailable": "docker_daemon_unavailable",
     "skillsbench_docker_compose_port_conflict": "port_conflict",
     "skillsbench_docker_compose_pip_bootstrap_failure": "pip_bootstrap_failure",
@@ -12,6 +13,7 @@ _SETUP_ATTRIBUTION_FINGERPRINT_PATTERNS = {
     "skillsbench_docker_compose_image_build_failure": "image_build",
 }
 _FINGERPRINT_SETUP_ATTRIBUTIONS = (
+    ("docker_api_version_mismatch", "skillsbench_docker_api_version_mismatch"),
     ("docker_daemon_unavailable", "skillsbench_docker_daemon_unavailable"),
     ("port_conflict", "skillsbench_docker_compose_port_conflict"),
     ("pip_bootstrap_failure", "skillsbench_docker_compose_pip_bootstrap_failure"),
@@ -243,6 +245,10 @@ def skillsbench_runner_error_fingerprint(error_text: str) -> dict[str, object]:
     lowered = text.lower()
     patterns = {
         "docker_compose_command_failed": r"docker compose command failed",
+        "docker_api_version_mismatch": (
+            r"client version \d+(?:\.\d+)+ is too new.*"
+            r"maximum supported api version is \d+(?:\.\d+)+"
+        ),
         "docker_daemon_unavailable": (
             r"cannot connect to the docker daemon|is the docker daemon running|"
             r"docker daemon is not running|colima is not running|error during connect"

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -20,6 +20,8 @@ Optional env:
   SKILLSBENCH_LOCAL_CODEX_PROXY_PORT   Local proxy port, default 18180
   SKILLSBENCH_DOCKER_PROXY_HOST        Remote Docker bridge host for benchmark
                                        setup/verifier egress; default auto
+  SKILLSBENCH_DOCKER_API_VERSION       Remote Docker daemon API version passed
+                                       to Docker CLI/Compose; default auto
   SKILLSBENCH_ROUTE                    Route, default codex-cli-goal-baseline
   SKILLSBENCH_MODEL                    Model, default gpt-5.5
   SKILLSBENCH_REASONING_EFFORT         Reasoning effort, default xhigh
@@ -87,6 +89,17 @@ done
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
+ssh_command_options=(-o BatchMode=yes -o ConnectTimeout=10)
+ssh_options=(--ssh-option ConnectTimeout=10)
+if [[ -n "${SKILLSBENCH_SSH_OPTIONS:-}" ]]; then
+  # shellcheck disable=SC2206
+  extra_ssh_options=(${SKILLSBENCH_SSH_OPTIONS})
+  for option in "${extra_ssh_options[@]}"; do
+    ssh_command_options+=(-o "$option")
+    ssh_options+=(--ssh-option "$option")
+  done
+fi
+
 stamp="${SKILLSBENCH_RUN_STAMP:-$(date +%Y%m%dT%H%M%SCST)}"
 safe_task="${task_id//[^A-Za-z0-9_ -]/-}"
 safe_task="${safe_task// /-}"
@@ -111,13 +124,28 @@ local_proxy_port="${SKILLSBENCH_LOCAL_CODEX_PROXY_PORT:-18180}"
 docker_proxy_host="${SKILLSBENCH_DOCKER_PROXY_HOST:-auto}"
 if [[ -z "$docker_proxy_host" || "$docker_proxy_host" == "auto" ]]; then
   docker_proxy_host="$(
-    ssh -o BatchMode=yes -o ConnectTimeout=10 "$SKILLSBENCH_SSH_DESTINATION" \
+    ssh "${ssh_command_options[@]}" "$SKILLSBENCH_SSH_DESTINATION" \
       "ip -4 addr show docker0 2>/dev/null | awk '/inet /{print \$2}' | cut -d/ -f1 | head -n1"
   )"
   if [[ -z "$docker_proxy_host" ]]; then
     echo "missing remote Docker bridge host; set SKILLSBENCH_DOCKER_PROXY_HOST" >&2
     exit 2
   fi
+fi
+docker_api_version="${SKILLSBENCH_DOCKER_API_VERSION:-auto}"
+if [[ -z "$docker_api_version" || "$docker_api_version" == "auto" ]]; then
+  docker_api_probe_py='import json, sys; print(json.load(sys.stdin)["ApiVersion"])'
+  printf -v docker_api_probe_command \
+    'curl --silent --show-error --fail --unix-socket /var/run/docker.sock http://localhost/version | python3 -c %q' \
+    "$docker_api_probe_py"
+  docker_api_version="$(
+    ssh "${ssh_command_options[@]}" "$SKILLSBENCH_SSH_DESTINATION" \
+      "$docker_api_probe_command"
+  )"
+fi
+if [[ ! "$docker_api_version" =~ ^[0-9]+\.[0-9]+$ ]]; then
+  echo "invalid remote Docker API version; set SKILLSBENCH_DOCKER_API_VERSION" >&2
+  exit 2
 fi
 bridge_proxy_url="http://${docker_proxy_host}:${remote_proxy_port}"
 loopback_proxy_url="http://127.0.0.1:${remote_proxy_port}"
@@ -190,6 +218,7 @@ remote_command=$(
   printf 'sleep 0.5; '
   printf '%q ' \
     "LOOPX_SKILLSBENCH_EGRESS_PROXY=${bridge_proxy_url}" \
+    "DOCKER_API_VERSION=${docker_api_version}" \
     python3 \
     scripts/skillsbench_automation_loop.py
   printf '%q ' \
@@ -210,15 +239,6 @@ remote_command=$(
     printf '%q ' "${extra_runner_args[@]}"
   fi
 )
-
-ssh_options=(--ssh-option ConnectTimeout=10)
-if [[ -n "${SKILLSBENCH_SSH_OPTIONS:-}" ]]; then
-  # shellcheck disable=SC2206
-  extra_ssh_options=(${SKILLSBENCH_SSH_OPTIONS})
-  for option in "${extra_ssh_options[@]}"; do
-    ssh_options+=(--ssh-option "$option")
-  done
-fi
 
 supervisor_cmd=(
   python3
@@ -270,6 +290,7 @@ if [[ "$dry_run" == "true" ]]; then
   printf 'private_dir=%s\n' "$private_dir"
   printf 'remote_proxy_port=%s\n' "$remote_proxy_port"
   printf 'docker_proxy_host=%s\n' "$docker_proxy_host"
+  printf 'docker_api_version=%s\n' "$docker_api_version"
   printf 'remote_command=%s\n' "$remote_command"
   printf 'supervisor_command='
   printf '%q ' "${supervisor_cmd[@]}"
@@ -309,4 +330,5 @@ public_output=${public_dir}/supervisor.public.json
 private_dir=${private_dir}
 remote_proxy_port=${remote_proxy_port}
 docker_proxy_host=${docker_proxy_host}
+docker_api_version=${docker_api_version}
 EOF


### PR DESCRIPTION
## Summary
- apply `SKILLSBENCH_SSH_OPTIONS` consistently to launcher discovery SSH calls and the detached supervisor
- auto-detect the remote Docker daemon API through its local socket and propagate `DOCKER_API_VERSION` to BenchFlow/Compose
- classify client/daemon API mismatches as `skillsbench_docker_api_version_mismatch` instead of an unclassified setup failure

## Validation
- `bash -n scripts/skillsbench-launch-goal-xhigh.sh`
- `python3 examples/skillsbench-benchmark-egress-policy-smoke.py`
- `python3 examples/skillsbench-failure-attribution-smoke.py`
- Python compile for all touched Python files
- real remote launcher dry-run: SSH discovery succeeded and daemon API auto-probed as `1.43`
- `loopx check` on all five changed files
- `loopx canary premerge --from-git-diff`: all direct checks, 6 selected catalog canaries, and public-boundary checks passed

## Holds and boundaries
- premerge reports the generic `benchmark_sensitive` manual hold; owner has explicitly authorized self-merge for benchmark changes
- no scoring, task semantics, leaderboard, submission, or permission behavior changes
- no benchmark jobs are launched by this PR
- private logs, credentials, local paths, and generated run artifacts are excluded
- `shellcheck` was skipped because it is not installed locally; `bash -n` and launcher dry-run cover shell syntax/assembly