### PR TITLE
Make deferred capacity resumes actionable

### DIFF
--- a/examples/control_plane/todo-deferred-capacity-cli-smoke.py
+++ b/examples/control_plane/todo-deferred-capacity-cli-smoke.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Smoke-test deferred todo writes and runtime capacity resume routing."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SMOKE_DIR = Path(__file__).resolve().parent
+if str(SMOKE_DIR) not in sys.path:
+    sys.path.insert(0, str(SMOKE_DIR))
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from todo_lifecycle_fixtures import (  # noqa: E402
+    GOAL_ID,
+    parsed_agent_summary,
+    parsed_items,
+    run_cli,
+    run_cli_error,
+    write_fixture,
+)
+
+
+CAPACITY_RESUME = "capacity_available:short_pool"
+
+
+def remove_legacy_placeholder(state_file: Path) -> None:
+    state_file.write_text(
+        state_file.read_text(encoding="utf-8").replace(
+            "- [ ] Legacy monitor-only placeholder.\n",
+            "",
+        ),
+        encoding="utf-8",
+    )
+
+
+def assert_deferred_add_and_capacity_resume() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-deferred-capacity-add-") as tmp:
+        registry_path, state_file = write_fixture(Path(tmp))
+        remove_legacy_placeholder(state_file)
+        before = state_file.read_text(encoding="utf-8")
+
+        unsupported = run_cli_error(
+            registry_path,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--text",
+            "Wait for an unregistered external predicate.",
+            "--status",
+            "deferred",
+            "--resume-when",
+            "external_signal:short_pool",
+        )
+        assert "supported condition" in unsupported["error"], unsupported
+        assert state_file.read_text(encoding="utf-8") == before
+
+        missing_condition = run_cli_error(
+            registry_path,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--text",
+            "Wait without a resume contract.",
+            "--status",
+            "deferred",
+        )
+        assert "requires --resume-when" in missing_condition["error"], missing_condition
+        assert state_file.read_text(encoding="utf-8") == before
+
+        added = run_cli(
+            registry_path,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--text",
+            "Run when a short worker is available.",
+            "--claimed-by",
+            "codex-side-bypass",
+            "--task-class",
+            "advancement_task",
+            "--status",
+            "deferred",
+            "--resume-when",
+            CAPACITY_RESUME,
+        )
+        assert added["status"] == "deferred", added
+        todo_id = added["todo_id"]
+        item = next(item for item in parsed_items(state_file) if item["todo_id"] == todo_id)
+        assert item["status"] == "deferred" and item["done"] is True, item
+        assert item["resume_when"] == CAPACITY_RESUME, item
+
+        projected = parsed_agent_summary(state_file)
+        condition = projected["deferred_items"][0]["resume_condition"]
+        assert condition["provider"] == "runtime_available_capabilities", condition
+        assert condition["provider_required"] is True, condition
+        assert projected["deferred_resume_candidates"] == [], projected
+
+        blocked = run_cli(
+            registry_path,
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            "codex-side-bypass",
+        )
+        assert blocked["agent_todo_summary"]["current_agent_deferred_resume_count"] == 0, blocked
+
+        state_before_polls = state_file.read_text(encoding="utf-8")
+        ready_packets = [
+            run_cli(
+                registry_path,
+                "quota",
+                "should-run",
+                "--goal-id",
+                GOAL_ID,
+                "--agent-id",
+                "codex-side-bypass",
+                "--available-capability",
+                "short_pool",
+            )
+            for _ in range(2)
+        ]
+        for ready in ready_packets:
+            assert ready["effective_action"] == "successor_replan_required", ready
+            assert ready["agent_todo_summary"]["current_agent_deferred_resume_count"] == 1, ready
+            assert ready["goal_frontier_projection"]["deferred_successors"]["ready_todo_ids"] == [
+                todo_id
+            ], ready
+            assert ready["execution_obligation"]["contract"] == "deferred_resume_projection", ready
+        assert state_file.read_text(encoding="utf-8") == state_before_polls
+
+
+def assert_open_to_deferred_update() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-deferred-capacity-update-") as tmp:
+        registry_path, state_file = write_fixture(Path(tmp))
+        added = run_cli(
+            registry_path,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--text",
+            "Queue work until capacity is declared.",
+            "--task-class",
+            "advancement_task",
+        )
+        todo_id = added["todo_id"]
+        before = state_file.read_text(encoding="utf-8")
+        unsupported = run_cli_error(
+            registry_path,
+            "todo",
+            "update",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            todo_id,
+            "--status",
+            "deferred",
+            "--resume-when",
+            "unknown_capacity:short_pool",
+        )
+        assert "supported condition" in unsupported["error"], unsupported
+        assert state_file.read_text(encoding="utf-8") == before
+
+        updated = run_cli(
+            registry_path,
+            "todo",
+            "update",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            todo_id,
+            "--status",
+            "deferred",
+            "--resume-when",
+            CAPACITY_RESUME,
+            "--reason",
+            "short worker capacity is not currently available",
+        )
+        assert updated["status"] == "deferred" and updated["status_changed"] is True, updated
+        item = next(item for item in parsed_items(state_file) if item["todo_id"] == todo_id)
+        assert item["status"] == "deferred" and item["resume_when"] == CAPACITY_RESUME, item
+
+
+def main() -> int:
+    assert_deferred_add_and_capacity_resume()
+    assert_open_to_deferred_update()
+    print("todo-deferred-capacity-cli-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -718,6 +718,11 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
                 "reason": "exercises claim, completion, successor, and handoff lifecycle transitions by todo_id",
             },
             {
+                "command": "python3 examples/control_plane/todo-deferred-capacity-cli-smoke.py",
+                "tier": "default",
+                "reason": "guards deferred writes, fail-closed resume kinds, and runtime capacity resume routing",
+            },
+            {
                 "command": "python3 examples/control_plane/todo-list-event-projection-smoke.py",
                 "tier": "default",
                 "reason": "guards event-sourced todo list projection with Markdown fallback",

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -70,7 +70,7 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
         help="For capture-followups, append one public-safe agent follow-up todo. Repeat up to the requested batch.",
     )
     todo_parser.add_argument("--todo-id", help="Structured todo id from status/quota, such as todo_ab12cd34ef56.")
-    todo_parser.add_argument("--status", choices=["open", "done", "blocked", "deferred"], help="For todo update, set the lifecycle status by todo_id.")
+    todo_parser.add_argument("--status", choices=["open", "done", "blocked", "deferred"], help="For todo add/update, set the lifecycle status.")
     todo_parser.add_argument("--note", help="Public-safe note to attach to a lifecycle transition.")
     todo_parser.add_argument("--evidence", help="Public-safe evidence pointer or short result for complete/update.")
     todo_parser.add_argument("--reason", help="Public-safe reason for blocked/deferred/supersede transitions.")
@@ -187,7 +187,9 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
         "--resume-when",
         help=(
             "For deferred todo add/update, declare a machine-readable resume condition "
-            "such as todo_done:todo_ab12cd34ef56."
+            "such as todo_done:todo_ab12cd34ef56, pr_merged:#532, or "
+            "capacity_available:short_pool. Capacity keys are resolved from quota "
+            "--available-capability declarations."
         ),
     )
     todo_parser.add_argument(
@@ -394,6 +396,7 @@ def handle_todo_command(
                 goal_id=args.goal_id,
                 role=args.role,
                 text=args.text,
+                status=args.status,
                 task_class=args.task_class,
                 action_kind=args.action_kind,
                 continuation_policy=args.continuation_policy,

--- a/loopx/control_plane/todos/contract.py
+++ b/loopx/control_plane/todos/contract.py
@@ -17,6 +17,12 @@ TODO_CAPABILITY_PATTERN = re.compile(r"^[a-z][a-z0-9_:-]{0,63}$")
 TODO_DECISION_SCOPE_KEY_PATTERN = re.compile(r"^(?:\*|[a-z0-9][a-z0-9_.:@*/-]{0,95})$")
 TODO_RESUME_KIND_TODO_DONE = "todo_done"
 TODO_RESUME_KIND_PR_MERGED = "pr_merged"
+TODO_RESUME_KIND_CAPACITY_AVAILABLE = "capacity_available"
+TODO_RESUME_KIND_VALUES = {
+    TODO_RESUME_KIND_TODO_DONE,
+    TODO_RESUME_KIND_PR_MERGED,
+    TODO_RESUME_KIND_CAPACITY_AVAILABLE,
+}
 TODO_RESUME_WHEN_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,31}(?::[a-z0-9_.:@-]{1,96})?$")
 TODO_RESUME_PR_MERGED_PATTERN = re.compile(
     r"^pr_merged:(?:(?:[a-z0-9_.-]{1,80})/(?:[a-z0-9_.-]{1,100}))?#[1-9][0-9]{0,8}$"
@@ -246,6 +252,33 @@ def normalize_todo_resume_when(value: Any) -> str | None:
     if candidate and TODO_RESUME_WHEN_PATTERN.match(candidate):
         return candidate
     return None
+
+
+def normalize_supported_todo_resume_when(value: Any) -> str | None:
+    """Normalize resume conditions that LoopX can safely evaluate."""
+    candidate = normalize_todo_resume_when(value)
+    if not candidate:
+        return None
+    kind, separator, target = candidate.partition(":")
+    if kind == TODO_RESUME_KIND_TODO_DONE:
+        return candidate if separator and normalize_todo_id(target) else None
+    if kind == TODO_RESUME_KIND_PR_MERGED:
+        return candidate if TODO_RESUME_PR_MERGED_PATTERN.match(candidate) else None
+    if kind == TODO_RESUME_KIND_CAPACITY_AVAILABLE:
+        return candidate if separator and TODO_CAPABILITY_PATTERN.match(target) else None
+    return None
+
+
+def require_supported_todo_resume_when(value: Any) -> str | None:
+    if value is None or not str(value).strip():
+        return None
+    normalized = normalize_supported_todo_resume_when(value)
+    if normalized:
+        return normalized
+    raise ValueError(
+        "resume_when must use a supported condition: todo_done:<todo_id>, "
+        "pr_merged:[owner/repo]#<number>, or capacity_available:<capability>"
+    )
 
 
 def normalize_todo_no_followup(value: Any) -> bool | None:

--- a/loopx/control_plane/todos/deferred_resume.py
+++ b/loopx/control_plane/todos/deferred_resume.py
@@ -3,9 +3,11 @@ from __future__ import annotations
 from typing import Any
 
 from .contract import (
+    TODO_RESUME_KIND_CAPACITY_AVAILABLE,
     TODO_STATUS_OPEN,
     TODO_TASK_CLASS_ADVANCEMENT,
     TODO_TASK_CLASS_MONITOR,
+    normalize_required_capabilities,
     normalize_required_write_scopes,
     normalize_todo_claimed_by,
     normalize_todo_decision_scope,
@@ -27,6 +29,50 @@ TODO_MONITOR_BLOCKED_RESUME_SELECTION_POLICY = (
     "open advancement todos gated by todo_done:<continuous_monitor> must "
     "project as successor replan/state repair instead of quiet monitor wait"
 )
+
+
+def resolve_capacity_resume_summary(
+    value: Any,
+    *,
+    available_capabilities: Any,
+) -> Any:
+    """Resolve capacity-backed deferred todos from the quota host capability set."""
+    if not isinstance(value, dict):
+        return value
+    available = set(normalize_required_capabilities(available_capabilities))
+    resolved = dict(value)
+    deferred_items = todo_summary_deferred_items(value, "deferred_items")
+    for item in deferred_items:
+        resume_when = normalize_todo_resume_when(item.get("resume_when")) or ""
+        kind, separator, target = resume_when.partition(":")
+        if kind != TODO_RESUME_KIND_CAPACITY_AVAILABLE or not separator or not target:
+            continue
+        satisfied = target in available
+        condition = (
+            dict(item.get("resume_condition"))
+            if isinstance(item.get("resume_condition"), dict)
+            else {}
+        )
+        condition.update(
+            {
+                "schema_version": "todo_resume_condition_v0",
+                "resume_when": resume_when,
+                "kind": kind,
+                "target": target,
+                "capability": target,
+                "provider": "runtime_available_capabilities",
+                "provider_required": False,
+                "satisfied": satisfied,
+            }
+        )
+        condition.pop("unsupported", None)
+        item["resume_condition"] = condition
+        item["resume_ready"] = satisfied
+    resolved["deferred_items"] = deferred_items
+    resolved["deferred_resume_candidates"] = [
+        item for item in deferred_items if item.get("resume_ready") is True
+    ]
+    return resolved
 
 
 def _todo_task_class(item: dict[str, Any]) -> str:

--- a/loopx/control_plane/todos/quota_summary.py
+++ b/loopx/control_plane/todos/quota_summary.py
@@ -17,6 +17,7 @@ from .contract import (
 from .deferred_resume import (
     build_todo_deferred_visibility_lanes,
     build_todo_resume_blocked_visibility_lanes,
+    resolve_capacity_resume_summary,
 )
 from .handoff_gate import build_todo_handoff_gate_lanes
 from .projection import (
@@ -599,7 +600,16 @@ def select_quota_todo_summary(
     *,
     agent_identity: dict[str, Any] | None = None,
     filter_user_gate_blocks_agent: bool = False,
+    available_capabilities: Any = None,
 ) -> dict[str, Any] | None:
+    canonical_value = resolve_capacity_resume_summary(
+        canonical_value,
+        available_capabilities=available_capabilities,
+    )
+    project_asset_value = resolve_capacity_resume_summary(
+        project_asset_value,
+        available_capabilities=available_capabilities,
+    )
     canonical_summary = summarize_user_todos_for_quota(
         canonical_value,
         agent_identity=agent_identity,

--- a/loopx/control_plane/todos/todo_summary.py
+++ b/loopx/control_plane/todos/todo_summary.py
@@ -5,6 +5,7 @@ import re
 from typing import Any, Callable, Optional
 
 from .contract import (
+    TODO_RESUME_KIND_CAPACITY_AVAILABLE,
     TODO_RESUME_KIND_PR_MERGED,
     TODO_RESUME_KIND_TODO_DONE,
     TODO_TASK_CLASS_ADVANCEMENT,
@@ -737,6 +738,14 @@ def apply_resume_conditions(
             condition["satisfied"] = condition["target_status"] == "done"
         elif kind == TODO_RESUME_KIND_PR_MERGED and target:
             condition.update(pr_merged_condition(target, rollout_events or []))
+        elif kind == TODO_RESUME_KIND_CAPACITY_AVAILABLE and target:
+            condition.update(
+                {
+                    "provider": "runtime_available_capabilities",
+                    "provider_required": True,
+                    "capability": target,
+                }
+            )
         else:
             condition["unsupported"] = True
         item["resume_condition"] = condition

--- a/loopx/quota.py
+++ b/loopx/quota.py
@@ -1302,16 +1302,23 @@ def build_quota_should_run(
             reason = "status or contract health is not ok; skip automatic compute"
         project_asset = item.get("project_asset") if isinstance(item.get("project_asset"), dict) else {}
         agent_identity = build_quota_agent_identity(item, agent_id=agent_id)
+        effective_available_capabilities = _effective_available_capabilities(
+            available_capabilities,
+            item=item,
+            project_asset=project_asset,
+        )
         user_todo_summary = select_quota_todo_summary(
             item.get("user_todos"),
             project_asset.get("user_todos") if project_asset else None,
             agent_identity=agent_identity,
             filter_user_gate_blocks_agent=True,
+            available_capabilities=effective_available_capabilities,
         )
         agent_todo_summary = select_quota_todo_summary(
             item.get("agent_todos"),
             project_asset.get("agent_todos") if project_asset else None,
             agent_identity=agent_identity,
+            available_capabilities=effective_available_capabilities,
         )
         agent_scoped_user_gate_override = _agent_scoped_user_gate_override(
             state=state,
@@ -1384,7 +1391,7 @@ def build_quota_should_run(
             agent_identity=agent_identity,
             agent_todo_summary=agent_todo_summary,
         )
-        capability_gate, capability_monitor_contract, capability_monitor_fallback = build_capability_gate_with_monitor_fallback(agent_todo_summary, available_capabilities=_effective_available_capabilities(available_capabilities, item=item, project_asset=project_asset), agent_identity=agent_identity, monitor_item_limit=MONITOR_DUE_ITEM_LIMIT)
+        capability_gate, capability_monitor_contract, capability_monitor_fallback = build_capability_gate_with_monitor_fallback(agent_todo_summary, available_capabilities=effective_available_capabilities, agent_identity=agent_identity, monitor_item_limit=MONITOR_DUE_ITEM_LIMIT)
         if subagent_orchestration_contract:
             capability_monitor_contract = capability_monitor_fallback = None
         work_lane_contract = capability_monitor_contract or work_lane_contract

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -23,6 +23,7 @@ from .status import (
 from .control_plane.todos.contract import (
     TODO_MONITOR_METADATA_FIELDS,
     TODO_CONTINUATION_POLICY_VALUES,
+    TODO_STATUS_DEFERRED,
     TODO_STATUS_DONE,
     TODO_STATUS_OPEN,
     TODO_TASK_CLASS_USER_GATE,
@@ -42,8 +43,10 @@ from .control_plane.todos.contract import (
     normalize_todo_no_followup,
     normalize_todo_required_decision_scopes,
     normalize_todo_resume_when,
+    normalize_supported_todo_resume_when,
     normalize_todo_status,
     parse_todo_metadata_line,
+    require_supported_todo_resume_when,
     todo_done_for_status,
     todo_marker_for_status,
 )
@@ -736,6 +739,7 @@ def add_todo_to_lines(
     *,
     role: str,
     text: str,
+    status: str | None = None,
     task_class: str | None = None,
     action_kind: str | None = None,
     continuation_policy: str | None = None,
@@ -760,6 +764,10 @@ def add_todo_to_lines(
         global_gate=global_gate,
     )
     todo_text = normalize_new_todo(text)
+    normalized_status = normalize_todo_status(status) if status else TODO_STATUS_OPEN
+    if status and not normalized_status:
+        raise ValueError("todo status must be one of: open, done, blocked, deferred")
+    normalized_resume_when = require_supported_todo_resume_when(resume_when)
     normalized_monitor_metadata = require_monitor_metadata_scope(
         monitor_metadata=monitor_metadata,
         role=role,
@@ -782,6 +790,7 @@ def add_todo_to_lines(
     ) if bounds else None
     added = block is None
     metadata_updated = False
+    status_changed = False
 
     if block is None:
         todo_id = build_todo_id(
@@ -792,7 +801,7 @@ def add_todo_to_lines(
         )
         metadata_line = format_todo_metadata_line(
             todo_id=todo_id,
-            status=TODO_STATUS_OPEN,
+            status=normalized_status,
             task_class=task_class,
             action_kind=action_kind,
             continuation_policy=continuation_policy,
@@ -805,12 +814,13 @@ def add_todo_to_lines(
             blocks_agent=blocks_agent,
             global_gate=global_gate,
             unblocks_todo_id=unblocks_todo_id,
-            resume_when=resume_when,
+            resume_when=normalized_resume_when,
             **normalized_monitor_metadata,
             evidence=evidence,
             updated_at=updated_at,
         )
-        todo_line = "\n".join([f"- [ ] {todo_text}", metadata_line] if metadata_line else [f"- [ ] {todo_text}"])
+        marker = todo_marker_for_status(normalized_status)
+        todo_line = "\n".join([f"- [{marker}] {todo_text}", metadata_line] if metadata_line else [f"- [{marker}] {todo_text}"])
         if bounds:
             insert_into_existing_section(lines, bounds[0], bounds[1], todo_line)
         else:
@@ -819,8 +829,10 @@ def add_todo_to_lines(
     else:
         updates: dict[str, Any] = {
             "todo_id": block.get("todo_id"),
-            "status": block.get("status") or TODO_STATUS_OPEN,
+            "status": normalized_status if status else block.get("status") or TODO_STATUS_OPEN,
         }
+        if status:
+            status_changed = set_todo_marker(lines, block, normalized_status)
         if task_class:
             updates["task_class"] = task_class
         if action_kind:
@@ -845,8 +857,8 @@ def add_todo_to_lines(
             updates["global_gate"] = global_gate
         if unblocks_todo_id:
             updates["unblocks_todo_id"] = unblocks_todo_id
-        if resume_when:
-            updates["resume_when"] = resume_when
+        if normalized_resume_when:
+            updates["resume_when"] = normalized_resume_when
         updates.update(normalized_monitor_metadata)
         if evidence:
             updates["evidence"] = evidence
@@ -861,10 +873,13 @@ def add_todo_to_lines(
         "added": added,
         "already_exists": not added,
         "metadata_updated": metadata_updated,
+        "status_changed": status_changed,
+        "changed": added or metadata_updated or status_changed,
         "role": role,
         "section": section,
         "todo": todo_text,
         "todo_id": todo_id,
+        "status": normalize_todo_status(effective_metadata.get("status")) or normalized_status,
         "task_class": effective_metadata.get("task_class") or task_class,
         "action_kind": effective_metadata.get("action_kind") or action_kind,
         "continuation_policy": normalize_todo_continuation_policy(
@@ -905,6 +920,7 @@ def add_goal_todo(
     goal_id: str,
     role: str,
     text: str,
+    status: str | None = None,
     task_class: str | None = None,
     action_kind: str | None = None,
     continuation_policy: str | None = None,
@@ -934,6 +950,11 @@ def add_goal_todo(
     )
     if global_gate and not (role == "user" and task_class == TODO_TASK_CLASS_USER_GATE):
         raise ValueError("global_gate is only valid for `--role user --task-class user_gate`")
+    normalized_status = normalize_todo_status(status) if status else TODO_STATUS_OPEN
+    if status and not normalized_status:
+        raise ValueError("todo status must be one of: open, done, blocked, deferred")
+    if normalized_status == TODO_STATUS_DONE:
+        raise ValueError("todo add cannot create completed work; add it open and use `loopx todo complete`")
     todo_text = normalize_new_todo(text)
     resolved_project, resolved_state_file = resolve_todo_state_path(
         registry_path=registry_path,
@@ -994,9 +1015,9 @@ def add_goal_todo(
         normalized_unblocks_todo_id = normalize_todo_id(unblocks_todo_id) if unblocks_todo_id else None
         if unblocks_todo_id and not normalized_unblocks_todo_id:
             raise ValueError("unblocks_todo_id must use the public token shape todo_<letters-digits-underscore-hyphen>")
-        normalized_resume_when = normalize_todo_resume_when(resume_when) if resume_when else None
-        if resume_when and not normalized_resume_when:
-            raise ValueError("resume_when must be public-safe, e.g. todo_done:todo_ab12cd34ef56 or pr_merged:#532")
+        normalized_resume_when = require_supported_todo_resume_when(resume_when)
+        if normalized_status == TODO_STATUS_DEFERRED and not normalized_resume_when:
+            raise ValueError("deferred todo add requires --resume-when with a supported condition")
         normalized_monitor_metadata = require_monitor_metadata_scope(
             monitor_metadata=monitor_metadata,
             role=role,
@@ -1006,6 +1027,7 @@ def add_goal_todo(
             lines,
             role=role,
             text=todo_text,
+            status=normalized_status,
             task_class=task_class,
             action_kind=action_kind,
             continuation_policy=continuation_policy,
@@ -1024,11 +1046,12 @@ def add_goal_todo(
         )
         added = bool(add_result["added"])
         metadata_updated = bool(add_result["metadata_updated"])
+        changed = bool(add_result["changed"])
 
         new_text = "\n".join(lines) + ("\n" if original.endswith("\n") else "")
-        if added or metadata_updated:
+        if changed:
             new_text = replace_updated_at(new_text, updated_at)
-        if (added or metadata_updated) and not dry_run:
+        if changed and not dry_run:
             resolved_state_file.write_text(new_text, encoding="utf-8")
 
     payload = {
@@ -1037,11 +1060,13 @@ def add_goal_todo(
         "added": added,
         "already_exists": bool(add_result["already_exists"]),
         "metadata_updated": metadata_updated,
+        "status_changed": bool(add_result.get("status_changed")),
         "goal_id": goal_id,
         "role": role,
         "section": add_result.get("section"),
         "todo": todo_text,
         "todo_id": add_result.get("todo_id"),
+        "status": add_result.get("status"),
         "task_class": add_result.get("task_class"),
         "action_kind": add_result.get("action_kind"),
         "continuation_policy": add_result.get("continuation_policy"),
@@ -1062,7 +1087,7 @@ def add_goal_todo(
         "expires_at": add_result.get("expires_at"),
         "state_file": str(resolved_state_file),
         "project": str(resolved_project) if resolved_project else None,
-        "updated_at": updated_at if added or metadata_updated else None,
+        "updated_at": updated_at if changed else None,
     }
     return _attach_todo_write_correctness_dry_run_packet(
         payload,
@@ -1119,6 +1144,7 @@ def apply_todo_update_to_lines(
     claim_only: bool = False,
     updated_at: str,
 ) -> dict[str, Any]:
+    normalized_resume_when = require_supported_todo_resume_when(resume_when)
     normalized_todo_id = normalize_todo_id(todo_id)
     if not normalized_todo_id:
         raise ValueError("todo_id must use the public token shape todo_<letters-digits-underscore-hyphen>")
@@ -1145,7 +1171,7 @@ def apply_todo_update_to_lines(
     }
     if normalized_status == TODO_STATUS_DONE and not block.get("completed_at"):
         updates["completed_at"] = updated_at
-    elif normalized_status and not todo_done_for_status(normalized_status):
+    elif normalized_status and normalized_status != TODO_STATUS_DONE:
         updates["completed_at"] = None
     if note:
         updates["note"] = note
@@ -1187,8 +1213,8 @@ def apply_todo_update_to_lines(
         updates["unblocks_todo_id"] = unblocks_todo_id
     if successor_todo_ids is not None:
         updates["successor_todo_ids"] = successor_todo_ids
-    if resume_when:
-        updates["resume_when"] = resume_when
+    if normalized_resume_when:
+        updates["resume_when"] = normalized_resume_when
     if no_followup is not None:
         updates["no_followup"] = no_followup
     for key, value in (monitor_metadata or {}).items():
@@ -1338,7 +1364,7 @@ def update_goal_todo(
             if status
             else str(existing_block.get("status") or TODO_STATUS_OPEN)
         )
-        if status and target_role == "agent" and todo_done_for_status(target_status):
+        if status and target_role == "agent" and target_status == TODO_STATUS_DONE:
             raise ValueError(
                 "agent todo completion must use complete_goal_todo "
                 "(CLI: `loopx todo complete`) so completion policy, successor, "
@@ -1358,7 +1384,7 @@ def update_goal_todo(
             target_blocks_agent = effective_agent_id
             effective_blocks_agent = effective_agent_id
         target_global_gate = True if global_gate else existing_global_gate
-        if not todo_done_for_status(target_status):
+        if target_status != TODO_STATUS_DONE:
             require_user_todo_task_class(
                 role=target_role,
                 task_class=target_task_class,
@@ -1379,9 +1405,12 @@ def update_goal_todo(
         normalized_successor_todo_ids = normalize_todo_id_list(successor_todo_ids)
         if successor_todo_ids and not normalized_successor_todo_ids:
             raise ValueError("successor_todo_ids must contain public todo_<letters-digits-underscore-hyphen> tokens")
-        normalized_resume_when = normalize_todo_resume_when(resume_when) if resume_when else None
-        if resume_when and not normalized_resume_when:
-            raise ValueError("resume_when must be public-safe, e.g. todo_done:todo_ab12cd34ef56 or pr_merged:#532")
+        normalized_resume_when = require_supported_todo_resume_when(resume_when)
+        effective_resume_when = normalized_resume_when or normalize_supported_todo_resume_when(
+            existing_block.get("resume_when")
+        )
+        if status and target_status == TODO_STATUS_DEFERRED and not effective_resume_when:
+            raise ValueError("transition to deferred requires --resume-when with a supported condition")
         normalized_monitor_metadata = require_monitor_metadata_scope(
             monitor_metadata=monitor_metadata,
             role=target_role,


### PR DESCRIPTION
## Summary
- persist `todo add --status deferred` and allow `todo update --status deferred`
- reject unsupported resume condition kinds before state mutation
- resolve `capacity_available:<key>` from quota runtime capability declarations
- add a focused idempotent lifecycle and routing smoke

## Validation
- `python3 examples/control_plane/todo-deferred-capacity-cli-smoke.py`
- `python3 examples/control_plane/todo-contract-smoke.py`
- `python3 examples/control_plane/todo-cli-smoke.py`
- `python3 examples/control_plane/todo-lifecycle-cli-smoke.py`
- `python3 examples/control_plane/todo-deferred-resume-lanes-smoke.py`
- `python3 examples/control_plane/quota-replan-decision-plane-smoke.py`
- standard `canary premerge --from-git-diff` (all selected checks passed)

Closes #1792