### PR TITLE
Preserve Docker plugins in benchmark proxy config

### DIFF
--- a/examples/skillsbench-benchmark-egress-policy-smoke.py
+++ b/examples/skillsbench-benchmark-egress-policy-smoke.py
@@ -276,6 +276,48 @@ def test_public_launcher_applies_ssh_options_to_remote_discovery() -> None:
         assert "DOCKER_API_VERSION=1.43" in proc.stdout, proc.stdout
 
 
+def test_proxy_runtime_preserves_docker_cli_plugins() -> None:
+    with tempfile.TemporaryDirectory(prefix="skillsbench-docker-config-") as tmp:
+        root = Path(tmp)
+        source_config = root / "source"
+        source_plugins = source_config / "cli-plugins"
+        source_plugins.mkdir(parents=True)
+        (source_plugins / "docker-compose").write_text("fixture\n", encoding="utf-8")
+        (source_config / "config.json").write_text("{}\n", encoding="utf-8")
+        previous = os.environ.get("DOCKER_CONFIG")
+        os.environ["DOCKER_CONFIG"] = str(source_config)
+        plan: dict[str, object] = {}
+        active_config: Path | None = None
+        try:
+            with proxy_runtime.proxy_runtime_env_applied(
+                {
+                    "LOOPX_SKILLSBENCH_EGRESS_PROXY": (
+                        "http://benchmark-proxy.example.invalid:18080"
+                    ),
+                    "NO_PROXY": "localhost",
+                },
+                plan=plan,
+            ):
+                active_config = Path(os.environ["DOCKER_CONFIG"])
+                linked_plugins = active_config / "cli-plugins"
+                assert linked_plugins.is_symlink(), linked_plugins
+                assert linked_plugins.resolve() == source_plugins.resolve()
+                prerequisites = plan["runner_prerequisites"]
+                assert isinstance(prerequisites, dict)
+                assert prerequisites[
+                    "benchmark_egress_proxy_docker_cli_plugins_preserved"
+                ] is True
+                assert prerequisites[
+                    "benchmark_egress_proxy_docker_cli_plugin_paths_recorded"
+                ] is False
+        finally:
+            if previous is None:
+                os.environ.pop("DOCKER_CONFIG", None)
+            else:
+                os.environ["DOCKER_CONFIG"] = previous
+        assert active_config is not None and not active_config.exists()
+
+
 def test_verifier_proxy_patch_is_required_only_for_existing_verifier() -> None:
     proxy_env = {
         "LOOPX_SKILLSBENCH_EGRESS_PROXY": "http://benchmark-proxy.example.invalid:18080",
@@ -397,6 +439,7 @@ if __name__ == "__main__":
     test_public_launcher_uses_container_reachable_benchmark_proxy()
     test_public_launcher_batches_three_cases_with_closeout_sync()
     test_public_launcher_applies_ssh_options_to_remote_discovery()
+    test_proxy_runtime_preserves_docker_cli_plugins()
     test_verifier_proxy_patch_is_required_only_for_existing_verifier()
     test_verifier_proxy_patch_failure_blocks_task_staging()
     test_proxy_runtime_prewarms_external_base_images_without_public_refs()

--- a/examples/skillsbench-failure-attribution-smoke.py
+++ b/examples/skillsbench-failure-attribution-smoke.py
@@ -54,6 +54,25 @@ def test_docker_api_version_mismatch_attribution() -> None:
     assert "docker_api_version_mismatch" in fingerprint["matched_patterns"], fingerprint
 
 
+def test_docker_compose_plugin_unavailable_attribution() -> None:
+    error_text = (
+        "Docker compose command failed. Stdout: unknown flag: --project-name\n"
+        "Usage:  docker [OPTIONS] COMMAND\nRun 'docker --help' for more information"
+    )
+
+    exception_type, attribution, labels = skillsbench_runner_error_attribution(
+        error_text
+    )
+    expected = "skillsbench_docker_compose_plugin_unavailable"
+    assert exception_type == expected
+    assert attribution == expected
+    assert "skillsbench_docker_compose_setup_failure" in labels, labels
+    fingerprint = skillsbench_runner_error_fingerprint(error_text)
+    assert "docker_compose_plugin_unavailable" in fingerprint["matched_patterns"], (
+        fingerprint
+    )
+
+
 def test_injected_pip_lines_do_not_mask_later_build_failure() -> None:
     error_text = (
         "Docker compose command failed.\n"
@@ -143,6 +162,7 @@ def test_failure_dependency_classes_ignore_unrelated_dockerfile_lines() -> None:
 if __name__ == "__main__":
     test_pip_bootstrap_failure_attribution()
     test_docker_api_version_mismatch_attribution()
+    test_docker_compose_plugin_unavailable_attribution()
     test_injected_pip_lines_do_not_mask_later_build_failure()
     test_setup_attribution_reconciles_to_public_fingerprint()
     test_supported_setup_attribution_is_unchanged()

--- a/loopx/benchmark_adapters/skillsbench.py
+++ b/loopx/benchmark_adapters/skillsbench.py
@@ -1654,6 +1654,13 @@ def skillsbench_runner_error_attribution(error_text: str) -> tuple[str, str, lis
             "skillsbench_environment_setup_error",
         ]
     if "docker compose command failed" in text:
+        if "unknown flag: --project-name" in text and "usage:  docker" in text:
+            label = "skillsbench_docker_compose_plugin_unavailable"
+            return label, label, [
+                label,
+                "skillsbench_docker_compose_setup_failure",
+                "skillsbench_environment_setup_error",
+            ]
         if (
             "client version" in text
             and "is too new" in text

--- a/loopx/benchmark_adapters/skillsbench_failure_signals.py
+++ b/loopx/benchmark_adapters/skillsbench_failure_signals.py
@@ -5,6 +5,7 @@ import re
 
 _SETUP_ATTRIBUTION_FINGERPRINT_PATTERNS = {
     "skillsbench_docker_api_version_mismatch": "docker_api_version_mismatch",
+    "skillsbench_docker_compose_plugin_unavailable": "docker_compose_plugin_unavailable",
     "skillsbench_docker_daemon_unavailable": "docker_daemon_unavailable",
     "skillsbench_docker_compose_port_conflict": "port_conflict",
     "skillsbench_docker_compose_pip_bootstrap_failure": "pip_bootstrap_failure",
@@ -14,6 +15,7 @@ _SETUP_ATTRIBUTION_FINGERPRINT_PATTERNS = {
 }
 _FINGERPRINT_SETUP_ATTRIBUTIONS = (
     ("docker_api_version_mismatch", "skillsbench_docker_api_version_mismatch"),
+    ("docker_compose_plugin_unavailable", "skillsbench_docker_compose_plugin_unavailable"),
     ("docker_daemon_unavailable", "skillsbench_docker_daemon_unavailable"),
     ("port_conflict", "skillsbench_docker_compose_port_conflict"),
     ("pip_bootstrap_failure", "skillsbench_docker_compose_pip_bootstrap_failure"),
@@ -248,6 +250,9 @@ def skillsbench_runner_error_fingerprint(error_text: str) -> dict[str, object]:
         "docker_api_version_mismatch": (
             r"client version \d+(?:\.\d+)+ is too new.*"
             r"maximum supported api version is \d+(?:\.\d+)+"
+        ),
+        "docker_compose_plugin_unavailable": (
+            r"unknown flag:\s*--project-name[\s\S]*usage:\s+docker"
         ),
         "docker_daemon_unavailable": (
             r"cannot connect to the docker daemon|is the docker daemon running|"

--- a/loopx/benchmark_adapters/skillsbench_proxy_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_proxy_runtime.py
@@ -64,13 +64,17 @@ def apply_proxy_runtime_env(
         prerequisites["benchmark_egress_proxy_docker_config_raw_proxy_recorded"] = False
 
 
-def _docker_config_payload_with_proxy(*, proxy_url: str, no_proxy: str) -> dict[str, Any]:
+def _docker_config_source_dir() -> Path:
     docker_config_dir = os.environ.get("DOCKER_CONFIG")
-    source_config = (
-        Path(docker_config_dir).expanduser() / "config.json"
+    return (
+        Path(docker_config_dir).expanduser()
         if docker_config_dir
-        else Path.home() / ".docker" / "config.json"
+        else Path.home() / ".docker"
     )
+
+
+def _docker_config_payload_with_proxy(*, proxy_url: str, no_proxy: str) -> dict[str, Any]:
+    source_config = _docker_config_source_dir() / "config.json"
     payload: dict[str, Any] = {}
     if source_config.exists():
         try:
@@ -105,6 +109,12 @@ def proxy_runtime_env_applied(
         docker_config_tmp = tempfile.TemporaryDirectory(
             prefix="loopx-skillsbench-docker-proxy-"
         )
+        source_plugins = _docker_config_source_dir() / "cli-plugins"
+        plugins_preserved = source_plugins.is_dir()
+        if plugins_preserved:
+            (Path(docker_config_tmp.name) / "cli-plugins").symlink_to(
+                source_plugins.resolve(), target_is_directory=True
+            )
         docker_config_path = Path(docker_config_tmp.name) / "config.json"
         docker_config_path.write_text(
             json.dumps(
@@ -119,6 +129,15 @@ def proxy_runtime_env_applied(
             encoding="utf-8",
         )
         docker_config_env["DOCKER_CONFIG"] = docker_config_tmp.name
+        if isinstance(plan, dict):
+            prerequisites = plan.setdefault("runner_prerequisites", {})
+            if isinstance(prerequisites, dict):
+                prerequisites[
+                    "benchmark_egress_proxy_docker_cli_plugins_preserved"
+                ] = plugins_preserved
+                prerequisites[
+                    "benchmark_egress_proxy_docker_cli_plugin_paths_recorded"
+                ] = False
     keys = set(proxy_env) | set(docker_config_env)
     previous = {key: os.environ.get(key) for key in keys}
     try:

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -2721,6 +2721,8 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchmark_egress_proxy_docker_config_injected",
         "benchmark_egress_proxy_docker_config_path_recorded",
         "benchmark_egress_proxy_docker_config_raw_proxy_recorded",
+        "benchmark_egress_proxy_docker_cli_plugins_preserved",
+        "benchmark_egress_proxy_docker_cli_plugin_paths_recorded",
         "host_local_acp_codex_exec_preflight_response_marker_observed",
         "host_local_acp_codex_exec_preflight_bridge_action_required",
         "host_local_acp_codex_exec_preflight_bridge_action_observed",


### PR DESCRIPTION
## Summary
- preserve the active Docker config `cli-plugins` directory when SkillsBench creates a temporary proxy-aware `DOCKER_CONFIG`
- publish boolean evidence that plugin discovery was preserved without recording paths
- classify the resulting `unknown flag: --project-name` failure as `skillsbench_docker_compose_plugin_unavailable`

## Root cause
The required benchmark egress proxy was enabled, but its temporary `DOCKER_CONFIG` hid the user-scoped Compose plugin. The Docker CLI then parsed BenchFlow compose flags as top-level Docker flags and both canaries failed before case materialization.

## Validation
- both focused SkillsBench smokes
- touched-file Python compile and `git diff --check`
- remote synthetic Compose build with temporary proxy config plus preserved plugin symlink
- six selected benchmark/core premerge canaries
- public-boundary scan across all six changed files

## Holds and boundaries
- generic `benchmark_sensitive` manual hold remains; owner has explicitly authorized benchmark self-merge
- no scoring, task semantics, submission, leaderboard, permission, or benchmark job launch behavior changes
- no private logs, credentials, task bodies, local paths, or generated artifacts are included