### PR TITLE
Route benchmark proxy through rootless host interface

### DIFF
--- a/examples/skillsbench-benchmark-egress-policy-smoke.py
+++ b/examples/skillsbench-benchmark-egress-policy-smoke.py
@@ -229,10 +229,14 @@ def test_public_launcher_applies_ssh_options_to_remote_discovery() -> None:
         fake_ssh.write_text(
             "#!/usr/bin/env bash\n"
             "printf '%s\\n' \"$*\" >> \"$SKILLSBENCH_TEST_SSH_LOG\"\n"
-            "if [[ \"$*\" == *'ip -4 addr show docker0'* ]]; then\n"
-            "  printf 'docker-bridge.example.invalid\\n'\n"
-            "else\n"
+            "if [[ \"$*\" == *'/version'* ]]; then\n"
             "  printf '1.43\\n'\n"
+            "elif [[ \"$*\" == *'docker info'* ]]; then\n"
+            "  printf '[\"name=rootless\"]\\n'\n"
+            "elif [[ \"$*\" == *'hostname -I'* ]]; then\n"
+            "  printf 'runner-host.example.invalid\\n'\n"
+            "else\n"
+            "  exit 99\n"
             "fi\n",
             encoding="utf-8",
         )
@@ -269,9 +273,10 @@ def test_public_launcher_applies_ssh_options_to_remote_discovery() -> None:
         )
 
         discovery_calls = ssh_log.read_text(encoding="utf-8").splitlines()
-        assert len(discovery_calls) == 2, discovery_calls
+        assert len(discovery_calls) == 3, discovery_calls
         assert all("-o Port=2222" in call for call in discovery_calls), discovery_calls
-        assert "docker_proxy_host=docker-bridge.example.invalid" in proc.stdout, proc.stdout
+        assert "docker_proxy_host=runner-host.example.invalid" in proc.stdout, proc.stdout
+        assert "docker_proxy_endpoint_mode=rootless_host_interface" in proc.stdout
         assert "docker_api_version=1.43" in proc.stdout, proc.stdout
         assert "DOCKER_API_VERSION=1.43" in proc.stdout, proc.stdout
 

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -121,17 +121,6 @@ fi
 batch_case_start_gap="${SKILLSBENCH_BATCH_CASE_START_GAP_SEC:-3}"
 local_proxy_host="${SKILLSBENCH_LOCAL_CODEX_PROXY_HOST:-127.0.0.1}"
 local_proxy_port="${SKILLSBENCH_LOCAL_CODEX_PROXY_PORT:-18180}"
-docker_proxy_host="${SKILLSBENCH_DOCKER_PROXY_HOST:-auto}"
-if [[ -z "$docker_proxy_host" || "$docker_proxy_host" == "auto" ]]; then
-  docker_proxy_host="$(
-    ssh "${ssh_command_options[@]}" "$SKILLSBENCH_SSH_DESTINATION" \
-      "ip -4 addr show docker0 2>/dev/null | awk '/inet /{print \$2}' | cut -d/ -f1 | head -n1"
-  )"
-  if [[ -z "$docker_proxy_host" ]]; then
-    echo "missing remote Docker bridge host; set SKILLSBENCH_DOCKER_PROXY_HOST" >&2
-    exit 2
-  fi
-fi
 docker_api_version="${SKILLSBENCH_DOCKER_API_VERSION:-auto}"
 if [[ -z "$docker_api_version" || "$docker_api_version" == "auto" ]]; then
   docker_api_probe_py='import json, sys; print(json.load(sys.stdin)["ApiVersion"])'
@@ -147,11 +136,42 @@ if [[ ! "$docker_api_version" =~ ^[0-9]+\.[0-9]+$ ]]; then
   echo "invalid remote Docker API version; set SKILLSBENCH_DOCKER_API_VERSION" >&2
   exit 2
 fi
+docker_proxy_host="${SKILLSBENCH_DOCKER_PROXY_HOST:-auto}"
+docker_proxy_listen_host="$docker_proxy_host"
+docker_proxy_allowed_peer=""
+docker_proxy_endpoint_mode="explicit"
+if [[ -z "$docker_proxy_host" || "$docker_proxy_host" == "auto" ]]; then
+  docker_security_options="$(
+    ssh "${ssh_command_options[@]}" "$SKILLSBENCH_SSH_DESTINATION" \
+      "DOCKER_API_VERSION=${docker_api_version} docker info --format '{{json .SecurityOptions}}' 2>/dev/null"
+  )"
+  if [[ "$docker_security_options" == *'name=rootless'* ]]; then
+    docker_proxy_host="$(
+      ssh "${ssh_command_options[@]}" "$SKILLSBENCH_SSH_DESTINATION" \
+        'set -- $(hostname -I); printf "%s\n" "$1"'
+    )"
+    docker_proxy_listen_host="$docker_proxy_host"
+    docker_proxy_allowed_peer="$docker_proxy_host"
+    docker_proxy_endpoint_mode="rootless_host_interface"
+  else
+    docker_proxy_host="$(
+      ssh "${ssh_command_options[@]}" "$SKILLSBENCH_SSH_DESTINATION" \
+        "ip -4 addr show docker0 2>/dev/null | awk '/inet /{print \$2}' | cut -d/ -f1 | head -n1"
+    )"
+    docker_proxy_listen_host="$docker_proxy_host"
+    docker_proxy_endpoint_mode="docker_bridge"
+  fi
+  if [[ -z "$docker_proxy_host" ]]; then
+    echo "missing remote Docker proxy host; set SKILLSBENCH_DOCKER_PROXY_HOST" >&2
+    exit 2
+  fi
+fi
 bridge_proxy_url="http://${docker_proxy_host}:${remote_proxy_port}"
 loopback_proxy_url="http://127.0.0.1:${remote_proxy_port}"
 bridge_forwarder_py='import select, socket, sys, threading
 listen_host = sys.argv[1]
 listen_port = int(sys.argv[2])
+allowed_peer = sys.argv[3]
 target = ("127.0.0.1", listen_port)
 
 def pipe(a, b):
@@ -178,7 +198,10 @@ server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 server.bind((listen_host, listen_port))
 server.listen(64)
 while True:
-    client, _addr = server.accept()
+    client, addr = server.accept()
+    if allowed_peer and addr[0] != allowed_peer:
+        client.close()
+        continue
     upstream = socket.create_connection(target)
     threading.Thread(target=pipe, args=(client, upstream), daemon=True).start()
 '
@@ -211,8 +234,9 @@ mkdir -p "$public_dir" "$private_dir"
 remote_command=$(
   printf 'cd %q || exit 1; ' \
     "$SKILLSBENCH_REMOTE_ROOT"
-  printf 'python3 -c %q %q %q & ' \
-    "$bridge_forwarder_py" "$docker_proxy_host" "$remote_proxy_port"
+  printf 'python3 -c %q %q %q %q & ' \
+    "$bridge_forwarder_py" "$docker_proxy_listen_host" "$remote_proxy_port" \
+    "$docker_proxy_allowed_peer"
   printf 'loopx_benchmark_proxy_forwarder_pid=$!; '
   printf 'trap %q EXIT; ' 'kill "$loopx_benchmark_proxy_forwarder_pid" 2>/dev/null || true'
   printf 'sleep 0.5; '
@@ -290,6 +314,7 @@ if [[ "$dry_run" == "true" ]]; then
   printf 'private_dir=%s\n' "$private_dir"
   printf 'remote_proxy_port=%s\n' "$remote_proxy_port"
   printf 'docker_proxy_host=%s\n' "$docker_proxy_host"
+  printf 'docker_proxy_endpoint_mode=%s\n' "$docker_proxy_endpoint_mode"
   printf 'docker_api_version=%s\n' "$docker_api_version"
   printf 'remote_command=%s\n' "$remote_command"
   printf 'supervisor_command='
@@ -330,5 +355,6 @@ public_output=${public_dir}/supervisor.public.json
 private_dir=${private_dir}
 remote_proxy_port=${remote_proxy_port}
 docker_proxy_host=${docker_proxy_host}
+docker_proxy_endpoint_mode=${docker_proxy_endpoint_mode}
 docker_api_version=${docker_api_version}
 EOF


### PR DESCRIPTION
## Summary
- detect rootless Docker after daemon API negotiation
- keep docker0 for normal daemons, but use the host interface reachable through rootless NAT for benchmark build proxy egress
- restrict the rootless forwarder to the NAT source address observed from local containers, avoiding a LAN-wide open proxy
- preserve explicit proxy-host overrides

## Root cause
The benchmark proxy and Dockerfile env patch were both enabled, but the remote daemon is rootless. Build containers cannot reach host loopback, docker0, magic hostnames, or host-gateway; they can reach the host external interface and arrive NATed as that same local interface address. The previous host-only preflight therefore produced a false positive while both builds timed out in APT.

## Validation
- container-to-host probes for loopback/docker0/magic/rootless/explicit gateway all failed as expected
- host external interface probe succeeded and confirmed the NAT peer category is the local host interface
- launcher remote dry-run selected `rootless_host_interface` and daemon API `1.43`
- launcher focused smoke and `bash -n` passed
- six selected benchmark/core canaries and public-boundary scan passed

## Holds and boundaries
- generic `benchmark_sensitive` manual hold remains; owner explicitly authorized benchmark self-merge
- no task, scoring, verifier, submission, leaderboard, or permission semantics change
- no private addresses, credentials, task content, raw logs, or generated artifacts are committed