### PR TITLE
Fix monitor-wait vision replan loop

### DIFF
--- a/examples/control_plane/quota-replan-decision-plane-smoke.py
+++ b/examples/control_plane/quota-replan-decision-plane-smoke.py
@@ -829,7 +829,7 @@ def assert_goal_frontier_context_helper_matches_quota_payload() -> None:
     assert context["acceptance_gaps"] == guard["goal_frontier_projection"]["acceptance_gaps"], guard
 
 
-def assert_open_agent_vision_beats_watch_lane_continuation_ack() -> None:
+def assert_open_agent_vision_uses_watch_lane_continuation_ack() -> None:
     guard = build_quota_should_run(
         status_payload(
             [monitor_item()],
@@ -842,21 +842,66 @@ def assert_open_agent_vision_beats_watch_lane_continuation_ack() -> None:
         goal_id=GOAL_ID,
         agent_id=SIDE_AGENT,
     )
-    assert guard["decision"] == "autonomous_replan_required", guard
-    assert guard["effective_action"] == "autonomous_replan_required", guard
+    assert guard["decision"] == "skip", guard
+    assert guard["effective_action"] == "monitor_quiet_skip", guard
     gaps = guard["goal_frontier_projection"]["acceptance_gaps"]
     assert len(gaps) == 1, guard
     assert gaps[0]["kind"] == "vision_acceptance_gap", guard
     assert gaps[0]["acceptance_summary"].startswith("A visible successor"), guard
+    assert gaps[0]["replan_trigger_source"] == "implicit_open_acceptance", guard
     assert "acceptance evidence still required" in (
         gaps[0]["replan_trigger_summary"]
     ), guard
-    obligation = guard["autonomous_replan_obligation"]
-    assert obligation["triggers"][0]["kind"] == "vision_acceptance_gap", guard
+    assert guard["goal_frontier_projection"]["replan_required"] is False, guard
+    assert guard.get("autonomous_replan_obligation") is None, guard
     assert guard["vision_continuation_audit"]["required"] is True, guard
-    assert guard["interaction_contract"]["agent_channel"]["quiet_noop_allowed"] is False, (
+    assert guard["interaction_contract"]["agent_channel"]["quiet_noop_allowed"] is True, (
         guard
     )
+
+
+def assert_due_monitor_runs_under_watched_open_agent_vision() -> None:
+    guard = build_quota_should_run(
+        status_payload(
+            [monitor_item(next_due_at="2000-01-01T00:00:00+00:00")],
+            replan_obligation=None,
+            latest_runs=[
+                watch_lane_continuation_ack_run(),
+                agent_vision_acceptance_only_run(),
+            ],
+        ),
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+    )
+    assert guard["decision"] == "run", guard
+    assert guard["effective_action"] == "normal_run", guard
+    lane = guard["work_lane_contract"]
+    assert lane["obligation"] == "attempt_due_monitor", guard
+    assert lane["selected_todo_id"] == "todo_monitor_wait", guard
+    assert guard["goal_frontier_projection"]["replan_required"] is False, guard
+    assert guard.get("autonomous_replan_obligation") is None, guard
+    assert guard["vision_continuation_audit"]["required"] is True, guard
+
+
+def assert_non_watch_replan_ack_does_not_suppress_open_agent_vision() -> None:
+    guard = build_quota_should_run(
+        status_payload(
+            [monitor_item()],
+            replan_obligation=None,
+            latest_runs=[
+                watch_lane_continuation_ack_run(
+                    delta_kinds=["runnable_todo_set"]
+                ),
+                agent_vision_acceptance_only_run(),
+            ],
+        ),
+        goal_id=GOAL_ID,
+        agent_id=SIDE_AGENT,
+    )
+    assert guard["decision"] == "autonomous_replan_required", guard
+    assert guard["effective_action"] == "autonomous_replan_required", guard
+    obligation = guard["autonomous_replan_obligation"]
+    assert obligation["triggers"][0]["kind"] == "vision_acceptance_gap", guard
 
 
 def assert_open_agent_vision_with_runnable_frontier_uses_neutral_gap_trigger() -> None:
@@ -1265,7 +1310,9 @@ def main() -> None:
     assert_closed_agent_vision_allows_bounded_monitor_wait()
     assert_custom_agent_vision_state_remains_open()
     assert_goal_frontier_context_helper_matches_quota_payload()
-    assert_open_agent_vision_beats_watch_lane_continuation_ack()
+    assert_open_agent_vision_uses_watch_lane_continuation_ack()
+    assert_due_monitor_runs_under_watched_open_agent_vision()
+    assert_non_watch_replan_ack_does_not_suppress_open_agent_vision()
     assert_open_agent_vision_with_runnable_frontier_uses_neutral_gap_trigger()
     assert_retired_agent_vision_allows_bounded_monitor_wait()
     assert_missing_vision_checkpoint_derives_agent_scoped_replan()

--- a/loopx/control_plane/goals/goal_frontier.py
+++ b/loopx/control_plane/goals/goal_frontier.py
@@ -76,6 +76,25 @@ def autonomous_replan_ack_has_frontier_delta(ack: dict[str, Any] | None) -> bool
     return repair_delta_kinds_have_frontier_delta(delta_contract.get("delta_kinds"))
 
 
+def _autonomous_replan_ack_has_delta_kind(
+    ack: dict[str, Any] | None,
+    *,
+    delta_kind: str,
+) -> bool:
+    """Return whether a durable replan ACK records one exact delta kind."""
+
+    if not isinstance(ack, dict) or ack.get("recorded") is not True:
+        return False
+    delta_contract = ack.get("delta_contract")
+    if not isinstance(delta_contract, dict) or delta_contract.get("delta_present") is not True:
+        return False
+    return delta_kind in {
+        str(item or "").strip()
+        for item in (delta_contract.get("delta_kinds") or [])
+        if str(item or "").strip()
+    }
+
+
 def autonomous_replan_decision_allowed(
     *,
     replan_obligation: dict[str, Any] | None,
@@ -379,7 +398,11 @@ def acceptance_gaps_from_agent_vision(
     if goal_vision_state_is_closed(state):
         return []
     acceptance = _compact_projection_text(patch.get("acceptance_summary"), limit=420)
-    trigger = _compact_projection_text(patch.get("replan_trigger_summary"), limit=240)
+    explicit_trigger = _compact_projection_text(
+        patch.get("replan_trigger_summary"),
+        limit=240,
+    )
+    trigger = explicit_trigger
     if not trigger and acceptance:
         trigger = "active agent vision remains open with acceptance evidence still required"
     if not trigger:
@@ -390,6 +413,11 @@ def acceptance_gaps_from_agent_vision(
         "agent_id": agent_vision.get("agent_id"),
         "state": agent_vision.get("state"),
         "replan_trigger_summary": trigger,
+        "replan_trigger_source": (
+            "explicit_vision_trigger"
+            if explicit_trigger
+            else "implicit_open_acceptance"
+        ),
     }
     if acceptance:
         gap["acceptance_summary"] = acceptance
@@ -807,9 +835,17 @@ def _is_monitor_only_lane(
     work_lane_contract: dict[str, Any] | None,
 ) -> bool:
     return bool(
+        _is_continuous_monitor_lane(work_lane_contract)
+        and work_lane_contract.get("must_attempt_work") is False
+    )
+
+
+def _is_continuous_monitor_lane(
+    work_lane_contract: dict[str, Any] | None,
+) -> bool:
+    return bool(
         work_lane_contract
         and work_lane_contract.get("lane") == TODO_TASK_CLASS_MONITOR
-        and work_lane_contract.get("must_attempt_work") is False
     )
 
 
@@ -933,6 +969,21 @@ def derive_goal_frontier_replan_obligation_from_summaries(
     compact_acceptance_gaps = [
         item for item in (acceptance_gaps or []) if isinstance(item, dict)
     ]
+    explicit_acceptance_gaps = [
+        gap
+        for gap in compact_acceptance_gaps
+        if gap.get("replan_trigger_source") != "implicit_open_acceptance"
+    ]
+    implicit_acceptance_has_watch_lane_continuation = bool(
+        compact_acceptance_gaps
+        and not explicit_acceptance_gaps
+        and _is_continuous_monitor_lane(work_lane_contract)
+        and agent_counts.get("monitor", 0) > 0
+        and _autonomous_replan_ack_has_delta_kind(
+            latest_replan_ack,
+            delta_kind="watch_lane_continuation",
+        )
+    )
     if user_counts.get("open", 0) > 0:
         return None
     succession_gap_items = _succession_gap_items(
@@ -994,6 +1045,7 @@ def derive_goal_frontier_replan_obligation_from_summaries(
         compact_acceptance_gaps
         and agent_counts.get("advancement", 0) == 0
         and total_frontier_advancement == 0
+        and not implicit_acceptance_has_watch_lane_continuation
     ):
         return build_autonomous_replan_obligation_payload(
             schema_version=AUTONOMOUS_REPLAN_OBLIGATION_SCHEMA_VERSION,


### PR DESCRIPTION
## Motivation

An active agent vision may intentionally stay open while a bounded `continuous_monitor` watches an external transition. After the lane had already recorded `watch_lane_continuation`, quota still synthesized a replan trigger solely from the open acceptance summary. Every heartbeat then returned `autonomous_replan_required` instead of running a due monitor once or quiet-skipping a not-due monitor.

## Implementation

- Distinguish an explicit vision replan trigger from the implicit text used to keep open acceptance visible.
- Preserve the acceptance gap and continuation audit in the read model.
- When the lane is a continuous monitor and a durable `watch_lane_continuation` ACK exists, prevent only the implicit acceptance gap from creating another replan obligation.
- Keep explicit vision triggers, missing checkpoints, initial monitor-frontier replans, and non-watch ACKs unchanged.
- Cover due, not-due, and negative non-watch cases in the repository-native quota decision-plane smoke.

## Validation

- `python3 examples/control_plane/quota-replan-decision-plane-smoke.py`
- `python3 examples/control_plane/monitor-scheduler-contract-smoke.py`
- `python3 examples/control_plane/work-lane-contract-smoke.py`
- `python3 examples/control_plane/control-plane-integrated-canary-smoke.py`
- `python3 examples/project/goal-vision-replan-contract-smoke.py`
- `python3 examples/autonomous-replan-obligation-smoke.py`
- `uvx ruff check loopx/control_plane/goals/goal_frontier.py examples/control_plane/quota-replan-decision-plane-smoke.py`
- Python compile check and `git diff --check`
- `loopx canary premerge --from-git-diff --format json --no-progress`
- Real public issue-fix watch-lane replay selected the due PR monitor with `effective_action=normal_run` and `replan_required=false`; the unchanged observation rescheduled without quota spend.

## Risk and gaps

The exception is narrow: it requires an implicit open-acceptance gap, a continuous-monitor lane, and an exact durable `watch_lane_continuation` delta. The vision acceptance audit remains visible and still blocks unsupported closeout. Explicit replan triggers and other control-plane repair signals continue to take precedence.
