### PR TITLE
Repair SkillsBench Docker bridge output capture

### DIFF
--- a/scripts/skillsbench_docker_command_file_bridge.py
+++ b/scripts/skillsbench_docker_command_file_bridge.py
@@ -12,11 +12,15 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shlex
 import subprocess
 import sys
+import tempfile
+import uuid
 from pathlib import Path
 from typing import Any
+from urllib.parse import quote
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 if str(REPO_ROOT) not in sys.path:
@@ -34,6 +38,7 @@ OPERATION_RESPONSE_SCHEMA_VERSION = (
 )
 MAX_CAPTURE_BYTES = 200_000
 ALLOWED_SANDBOX_PATH_ROOTS = ("/app", "/tmp", "/root")
+BRIDGE_TEMP_ROOT = "/tmp/loopx-skillsbench-command-file-bridge"
 
 
 def _json_response(payload: dict[str, Any]) -> int:
@@ -131,6 +136,132 @@ class DockerCommandFileBridge:
             check=False,
         )
 
+    @staticmethod
+    def _docker_socket_path() -> str | None:
+        docker_host = os.environ.get("DOCKER_HOST", "").strip()
+        if docker_host.startswith("unix://"):
+            return docker_host.removeprefix("unix://")
+        if docker_host:
+            return None
+        return "/var/run/docker.sock"
+
+    def _resolve_container_id(self, *, timeout_seconds: int) -> str | None:
+        socket_path = self._docker_socket_path()
+        if not socket_path:
+            return None
+        filters = {
+            "label": [
+                f"com.docker.compose.project={self.project_name}",
+                f"com.docker.compose.service={self.service}",
+            ],
+            "status": ["running"],
+        }
+        url = (
+            "http://localhost/containers/json?all=1&filters="
+            + quote(json.dumps(filters, separators=(",", ":")), safe="")
+        )
+        try:
+            proc = subprocess.run(
+                [
+                    "curl",
+                    "--silent",
+                    "--show-error",
+                    "--fail",
+                    "--unix-socket",
+                    socket_path,
+                    url,
+                ],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=timeout_seconds + 10,
+                check=False,
+            )
+        except OSError:
+            return None
+        if proc.returncode != 0:
+            return None
+        try:
+            containers = json.loads(proc.stdout)
+            matches = [
+                str(container.get("Id") or "").strip()
+                for container in containers
+                if isinstance(container, dict) and container.get("Id")
+            ]
+        except (json.JSONDecodeError, TypeError, UnicodeDecodeError):
+            return None
+        return matches[0] if len(matches) == 1 else None
+
+    def _remove_container_path(
+        self, path: str, *, recursive: bool, timeout_seconds: int
+    ) -> None:
+        try:
+            self._compose_exec(
+                ("rm -rf -- " if recursive else "rm -f -- ") + shlex.quote(path),
+                timeout_seconds=timeout_seconds,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+
+    def _read_container_file_via_copy(
+        self,
+        path: str,
+        *,
+        max_bytes: int,
+        timeout_seconds: int,
+    ) -> tuple[int, bytes, bytes]:
+        staged_path = f"{BRIDGE_TEMP_ROOT}/{uuid.uuid4().hex}.bounded"
+        try:
+            stage_proc = self._compose_exec(
+                "mkdir -p "
+                + shlex.quote(BRIDGE_TEMP_ROOT)
+                + " && dd if="
+                + shlex.quote(path)
+                + " of="
+                + shlex.quote(staged_path)
+                + " bs="
+                + shlex.quote(str(max_bytes + 1))
+                + " count=1 status=none",
+                timeout_seconds=timeout_seconds,
+            )
+            if stage_proc.returncode != 0:
+                return stage_proc.returncode, b"", stage_proc.stderr
+            container_id = self._resolve_container_id(
+                timeout_seconds=timeout_seconds
+            )
+            if not container_id:
+                return 1, b"", b"docker container resolution failed"
+            with tempfile.TemporaryDirectory(
+                prefix="loopx-skillsbench-docker-copy-"
+            ) as tmp:
+                destination = Path(tmp) / "payload"
+                try:
+                    copy_proc = subprocess.run(
+                        [
+                            "docker",
+                            "cp",
+                            f"{container_id}:{staged_path}",
+                            str(destination),
+                        ],
+                        stdout=subprocess.PIPE,
+                        stderr=subprocess.PIPE,
+                        timeout=timeout_seconds + 10,
+                        check=False,
+                    )
+                except OSError:
+                    return 1, b"", b"docker copy unavailable"
+                if copy_proc.returncode != 0:
+                    return copy_proc.returncode, b"", copy_proc.stderr
+                try:
+                    return 0, destination.read_bytes(), b""
+                except OSError as exc:
+                    return 1, b"", str(exc).encode("utf-8", errors="replace")
+        finally:
+            self._remove_container_path(
+                staged_path,
+                recursive=False,
+                timeout_seconds=timeout_seconds,
+            )
+
     def run_operation(self, request: dict[str, Any]) -> int:
         operation = str(request.get("operation") or "").strip()
         if operation not in {"exec", "read_file", "write_file", "cleanup"}:
@@ -172,21 +303,62 @@ class DockerCommandFileBridge:
         command = str(request.get("command") or "").strip()
         if not command:
             raise ValueError("command_missing")
+        capture_dir = f"{BRIDGE_TEMP_ROOT}/{uuid.uuid4().hex}.exec"
+        stdout_path = capture_dir + "/stdout"
+        stderr_path = capture_dir + "/stderr"
         proc = self._compose_exec(
-            "timeout "
+            "mkdir -p "
+            + shlex.quote(capture_dir)
+            + " && timeout "
             + shlex.quote(str(timeout_seconds))
             + " sh -lc "
-            + shlex.quote(command),
+            + shlex.quote(command)
+            + " > "
+            + shlex.quote(stdout_path)
+            + " 2> "
+            + shlex.quote(stderr_path),
             cwd=cwd,
             timeout_seconds=timeout_seconds,
         )
-        stdout, stdout_truncated = _bounded_text(proc.stdout, limit=MAX_CAPTURE_BYTES)
-        stderr, stderr_truncated = _bounded_text(proc.stderr, limit=MAX_CAPTURE_BYTES)
+        stdout_rc, stdout_bytes, stdout_copy_stderr = (
+            self._read_container_file_via_copy(
+                stdout_path,
+                max_bytes=MAX_CAPTURE_BYTES,
+                timeout_seconds=timeout_seconds,
+            )
+        )
+        stderr_rc, stderr_bytes, stderr_copy_stderr = (
+            self._read_container_file_via_copy(
+                stderr_path,
+                max_bytes=MAX_CAPTURE_BYTES,
+                timeout_seconds=timeout_seconds,
+            )
+        )
+        self._remove_container_path(
+            capture_dir,
+            recursive=True,
+            timeout_seconds=timeout_seconds,
+        )
+        stdout, stdout_truncated = _bounded_text(
+            stdout_bytes, limit=MAX_CAPTURE_BYTES
+        )
+        stderr_source = stderr_bytes
+        if stdout_rc != 0 or stderr_rc != 0:
+            stderr_source += proc.stderr + stdout_copy_stderr + stderr_copy_stderr
+        stderr, stderr_truncated = _bounded_text(
+            stderr_source, limit=MAX_CAPTURE_BYTES
+        )
+        capture_ok = stdout_rc == 0 and stderr_rc == 0
+        blocker = None
+        if proc.returncode != 0:
+            blocker = "exec_failed"
+        elif not capture_ok:
+            blocker = "exec_output_capture_failed"
         return _json_response(
             _operation_response(
-                ok=proc.returncode == 0,
+                ok=proc.returncode == 0 and capture_ok,
                 operation="exec",
-                first_blocker=None if proc.returncode == 0 else "exec_failed",
+                first_blocker=blocker,
                 exit_code=proc.returncode,
                 stdout=stdout,
                 stderr=stderr,
@@ -201,18 +373,21 @@ class DockerCommandFileBridge:
             1,
             min(int(request.get("max_bytes") or MAX_CAPTURE_BYTES), MAX_CAPTURE_BYTES),
         )
-        proc = self._compose_exec(
-            "dd if=" + shlex.quote(path) + " bs=1 count=" + shlex.quote(str(max_bytes)),
+        returncode, content_bytes, copy_stderr = self._read_container_file_via_copy(
+            path,
+            max_bytes=max_bytes,
             timeout_seconds=timeout_seconds,
         )
-        content, truncated = _bounded_text(proc.stdout, limit=max_bytes)
-        stderr, stderr_truncated = _bounded_text(proc.stderr, limit=MAX_CAPTURE_BYTES)
+        content, truncated = _bounded_text(content_bytes, limit=max_bytes)
+        stderr, stderr_truncated = _bounded_text(
+            copy_stderr, limit=MAX_CAPTURE_BYTES
+        )
         return _json_response(
             _operation_response(
-                ok=proc.returncode == 0,
+                ok=returncode == 0,
                 operation="read_file",
-                first_blocker=None if proc.returncode == 0 else "read_file_failed",
-                exit_code=proc.returncode,
+                first_blocker=None if returncode == 0 else "read_file_failed",
+                exit_code=returncode,
                 content=content,
                 content_truncated=truncated,
                 stderr=stderr,
@@ -263,7 +438,7 @@ class DockerCommandFileBridge:
         )
 
     def probe(self, timeout_seconds: int) -> tuple[list[dict[str, Any]], str | None]:
-        probe_dir = "/tmp/loopx-skillsbench-command-file-bridge"
+        probe_dir = BRIDGE_TEMP_ROOT
         marker = probe_dir + "/marker.txt"
         exec_proc = self._compose_exec(
             "mkdir -p "
@@ -277,15 +452,16 @@ class DockerCommandFileBridge:
             stdin=MARKER_CONTENT.encode("utf-8"),
             timeout_seconds=timeout_seconds,
         )
-        read_proc = self._compose_exec(
-            "cat " + shlex.quote(marker),
+        read_returncode, read_bytes, _ = self._read_container_file_via_copy(
+            marker,
+            max_bytes=MAX_CAPTURE_BYTES,
             timeout_seconds=timeout_seconds,
         )
         cleanup_proc = self._compose_exec(
             "rm -f " + shlex.quote(marker),
             timeout_seconds=timeout_seconds,
         )
-        read_text, _ = _bounded_text(read_proc.stdout, limit=MAX_CAPTURE_BYTES)
+        read_text, _ = _bounded_text(read_bytes, limit=MAX_CAPTURE_BYTES)
         operations = [
             {
                 "kind": "exec",
@@ -303,11 +479,10 @@ class DockerCommandFileBridge:
                 "label": "probe_marker_read",
                 "status": (
                     "ok"
-                    if read_proc.returncode == 0 and read_text == MARKER_CONTENT
+                    if read_returncode == 0 and read_text == MARKER_CONTENT
                     else "failed"
                 ),
-                "content_match": read_proc.returncode == 0
-                and read_text == MARKER_CONTENT,
+                "content_match": read_returncode == 0 and read_text == MARKER_CONTENT,
             },
             {
                 "kind": "cleanup",

--- a/tests/test_skillsbench_docker_command_file_bridge.py
+++ b/tests/test_skillsbench_docker_command_file_bridge.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import scripts.skillsbench_docker_command_file_bridge as bridge_module
+from scripts.skillsbench_docker_command_file_bridge import (
+    MARKER_CONTENT,
+    DockerCommandFileBridge,
+)
+
+
+def _bridge() -> DockerCommandFileBridge:
+    return DockerCommandFileBridge(
+        project_name="demo-project",
+        project_dir="/tmp/demo-project",
+        compose_files=["/tmp/demo-project/compose.yaml"],
+        service="main",
+    )
+
+
+def test_resolve_container_id_uses_compose_labels(monkeypatch) -> None:
+    bridge = _bridge()
+    monkeypatch.setenv("DOCKER_HOST", "unix:///tmp/docker.sock")
+
+    def fake_run(command, **_kwargs):
+        assert command[:6] == [
+            "curl",
+            "--silent",
+            "--show-error",
+            "--fail",
+            "--unix-socket",
+            "/tmp/docker.sock",
+        ]
+        payload = [
+            {
+                "Id": "private-container-id",
+                "Labels": {
+                    "com.docker.compose.project": "demo-project",
+                    "com.docker.compose.service": "main",
+                },
+            }
+        ]
+        return subprocess.CompletedProcess(command, 0, json.dumps(payload).encode(), b"")
+
+    monkeypatch.setattr(bridge_module.subprocess, "run", fake_run)
+    assert bridge._resolve_container_id(timeout_seconds=5) == "private-container-id"
+
+
+def test_read_file_uses_bounded_docker_copy(monkeypatch, capsys) -> None:
+    bridge = _bridge()
+    compose_commands: list[str] = []
+
+    def fake_compose_exec(shell_command, **_kwargs):
+        compose_commands.append(shell_command)
+        return subprocess.CompletedProcess([], 0, b"", b"")
+
+    def fake_docker_cp(command, **_kwargs):
+        assert command[:2] == ["docker", "cp"]
+        assert command[2].startswith("private-container-id:")
+        Path(command[3]).write_bytes(b"abcde")
+        return subprocess.CompletedProcess(command, 0, b"", b"")
+
+    monkeypatch.setattr(bridge, "_compose_exec", fake_compose_exec)
+    monkeypatch.setattr(
+        bridge, "_resolve_container_id", lambda **_kwargs: "private-container-id"
+    )
+    monkeypatch.setattr(bridge_module.subprocess, "run", fake_docker_cp)
+
+    assert bridge._run_read_file({"path": "/app/result.txt", "max_bytes": 4}, 5) == 0
+    response = json.loads(capsys.readouterr().out)
+    assert response["ok"] is True
+    assert response["content"] == "abcd"
+    assert response["content_truncated"] is True
+    assert any("bs=5 count=1" in command for command in compose_commands)
+    assert any(command.startswith("rm -f -- ") for command in compose_commands)
+
+
+def test_exec_and_probe_do_not_depend_on_attached_stdout(monkeypatch, capsys) -> None:
+    bridge = _bridge()
+
+    def fake_compose_exec(_shell_command, **_kwargs):
+        return subprocess.CompletedProcess([], 0, b"", b"")
+
+    def fake_read(path, **_kwargs):
+        if path.endswith("/stdout"):
+            return 0, b"visible output\n", b""
+        if path.endswith("/stderr"):
+            return 0, b"", b""
+        return 0, MARKER_CONTENT.encode(), b""
+
+    monkeypatch.setattr(bridge, "_compose_exec", fake_compose_exec)
+    monkeypatch.setattr(bridge, "_read_container_file_via_copy", fake_read)
+
+    assert bridge._run_exec({"cwd": "/app", "command": "pwd"}, 5) == 0
+    response = json.loads(capsys.readouterr().out)
+    assert response["ok"] is True
+    assert response["stdout"] == "visible output\n"
+
+    operations, blocker = bridge.probe(5)
+    assert blocker is None
+    assert all(operation["status"] == "ok" for operation in operations)


### PR DESCRIPTION
## Summary
- resolve the active Compose service through Docker Engine labels
- read bounded container files through `docker cp` when attached stdout is unavailable
- route bridge `read_file` and exec stdout/stderr through the shared bounded transport
- add focused regression coverage for container resolution, truncation, exec output, and probe readiness

## Validation
- `uv run --with "pytest>=8,<9" pytest -q tests/test_skillsbench_docker_command_file_bridge.py`
- `python3 examples/skillsbench-host-local-launch-plan-smoke.py`
- `python3 examples/skillsbench-runner-core-contract-smoke.py`
- `python3 examples/skillsbench-runtime-layer-launch-plan-smoke.py`
- `python3 examples/benchmark-core-adapter-contract-smoke.py`
- `loopx check --scan-path ...` (8 checks, 0 warnings)
- `loopx canary premerge --from-git-diff` (all automated checks passed; generic benchmark-sensitive manual hold remains)
- synthetic remote Compose probe: all operations ready and exec output round-tripped

## Boundaries
No benchmark jobs, scoring changes, task semantics, raw task text, trajectories, verifier output, credentials, uploads, or submissions.