### PR TITLE
Fail fast when the Codex sandbox cannot execute

### DIFF
--- a/loopx/benchmark_adapters/skillsbench_codex_runtime.py
+++ b/loopx/benchmark_adapters/skillsbench_codex_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shutil
 import subprocess
 import tempfile
 from collections.abc import Callable
@@ -18,11 +19,16 @@ _STRING_FIELDS = (
     "host_local_codex_cli_preflight_status",
     "host_local_codex_cli_preflight_first_blocker",
     "host_local_codex_cli_preflight_failure_category",
+    "host_local_codex_cli_preflight_sandbox_mode",
+    "host_local_codex_cli_preflight_sandbox_probe_status",
 )
 _BOOL_FIELDS = (
     "host_local_codex_cli_preflight_requested",
     "host_local_codex_cli_preflight_ready",
     "host_local_codex_cli_preflight_version_probe_invoked",
+    "host_local_codex_cli_preflight_sandbox_probe_required",
+    "host_local_codex_cli_preflight_sandbox_probe_invoked",
+    "host_local_codex_cli_preflight_sandbox_probe_ready",
     "host_local_codex_cli_preflight_raw_output_recorded",
     "host_local_codex_cli_preflight_path_recorded",
 )
@@ -165,6 +171,11 @@ def _fail(prerequisites: dict[str, Any], blocker: str, category: str) -> None:
 
 def run_preflight(args: Any, plan: dict[str, Any]) -> None:
     prerequisites = plan.setdefault("runner_prerequisites", {})
+    sandbox_mode = str(
+        getattr(args, "local_codex_sandbox", "workspace-write")
+        or "workspace-write"
+    )
+    sandbox_probe_required = sandbox_mode != "danger-full-access"
     prerequisites.update(
         {
             "host_local_codex_cli_preflight_requested": True,
@@ -173,6 +184,15 @@ def run_preflight(args: Any, plan: dict[str, Any]) -> None:
             "host_local_codex_cli_preflight_first_blocker": "",
             "host_local_codex_cli_preflight_failure_category": "",
             "host_local_codex_cli_preflight_version_probe_invoked": False,
+            "host_local_codex_cli_preflight_sandbox_mode": sandbox_mode,
+            "host_local_codex_cli_preflight_sandbox_probe_required": (
+                sandbox_probe_required
+            ),
+            "host_local_codex_cli_preflight_sandbox_probe_invoked": False,
+            "host_local_codex_cli_preflight_sandbox_probe_ready": False,
+            "host_local_codex_cli_preflight_sandbox_probe_status": (
+                "pending" if sandbox_probe_required else "not_required"
+            ),
             "host_local_codex_cli_preflight_raw_output_recorded": False,
             "host_local_codex_cli_preflight_path_recorded": False,
         }
@@ -203,6 +223,48 @@ def run_preflight(args: Any, plan: dict[str, Any]) -> None:
             "codex_cli_version_probe_failed",
         )
         raise RuntimeError("host-local Codex CLI version probe failed")
+    if sandbox_probe_required:
+        prerequisites[
+            "host_local_codex_cli_preflight_sandbox_probe_invoked"
+        ] = True
+        sandbox_probe_command = shutil.which("true") or "true"
+        try:
+            with tempfile.TemporaryDirectory(
+                prefix="gh-skillsbench-codex-sandbox-"
+            ) as tmp:
+                proc = subprocess.run(
+                    [
+                        resolved,
+                        "sandbox",
+                        "-c",
+                        f'sandbox_mode="{sandbox_mode}"',
+                        "--",
+                        sandbox_probe_command,
+                    ],
+                    cwd=tmp,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL,
+                    timeout=10,
+                    check=False,
+                )
+        except (OSError, subprocess.TimeoutExpired):
+            proc = None
+        if proc is None or proc.returncode != 0:
+            prerequisites[
+                "host_local_codex_cli_preflight_sandbox_probe_status"
+            ] = "failed"
+            _fail(
+                prerequisites,
+                "skillsbench_host_local_codex_cli_sandbox_probe_failed",
+                "codex_cli_sandbox_probe_failed",
+            )
+            raise RuntimeError("host-local Codex CLI sandbox probe failed")
+        prerequisites[
+            "host_local_codex_cli_preflight_sandbox_probe_ready"
+        ] = True
+        prerequisites[
+            "host_local_codex_cli_preflight_sandbox_probe_status"
+        ] = "ready"
     prerequisites["host_local_codex_cli_preflight_ready"] = True
     prerequisites["host_local_codex_cli_preflight_status"] = "ready"
 

--- a/tests/test_skillsbench_remote_codex_preflight.py
+++ b/tests/test_skillsbench_remote_codex_preflight.py
@@ -15,11 +15,17 @@ from loopx.codex_cli_goal_tui import resolve_codex_cli_binary
 from scripts import skillsbench_automation_loop as skillsbench_loop
 
 
-def _args(codex_bin: str, *, relay_command: str | None = None) -> SimpleNamespace:
+def _args(
+    codex_bin: str,
+    *,
+    relay_command: str | None = None,
+    sandbox: str = "workspace-write",
+) -> SimpleNamespace:
     return SimpleNamespace(
         host_local_acp_launch=True,
         local_acp_relay_command=relay_command,
         local_codex_bin=codex_bin,
+        local_codex_sandbox=sandbox,
     )
 
 
@@ -34,12 +40,29 @@ def test_host_local_codex_cli_preflight_is_public_and_fail_fast(tmp_path: Path) 
     prerequisites = plan["runner_prerequisites"]
     assert prerequisites["host_local_codex_cli_preflight_status"] == "ready"
     assert prerequisites["host_local_codex_cli_preflight_ready"] is True
+    assert (
+        prerequisites["host_local_codex_cli_preflight_sandbox_probe_required"]
+        is True
+    )
+    assert (
+        prerequisites["host_local_codex_cli_preflight_sandbox_probe_invoked"]
+        is True
+    )
+    assert (
+        prerequisites["host_local_codex_cli_preflight_sandbox_probe_ready"]
+        is True
+    )
+    assert (
+        prerequisites["host_local_codex_cli_preflight_sandbox_probe_status"]
+        == "ready"
+    )
     assert prerequisites["host_local_codex_cli_preflight_path_recorded"] is False
     assert str(codex) not in json.dumps(prerequisites, sort_keys=True)
 
     public = skillsbench_loop._public_runner_prerequisites(prerequisites)
     assert public["host_local_codex_cli_preflight_status"] == "ready"
     assert public["host_local_codex_cli_preflight_version_probe_invoked"] is True
+    assert public["host_local_codex_cli_preflight_sandbox_probe_ready"] is True
 
 
 def test_missing_codex_cli_has_precise_runner_attribution(tmp_path: Path) -> None:
@@ -61,6 +84,77 @@ def test_missing_codex_cli_has_precise_runner_attribution(tmp_path: Path) -> Non
     assert codex_runtime.preflight_required(_args("codex"))
     assert not codex_runtime.preflight_required(
         _args("unused", relay_command="custom-relay")
+    )
+
+
+def test_host_local_codex_cli_preflight_fails_when_selected_sandbox_cannot_run(
+    tmp_path: Path,
+) -> None:
+    codex = tmp_path / "codex"
+    codex.write_text(
+        "#!/bin/sh\n"
+        "if [ \"$1\" = \"--version\" ]; then exit 0; fi\n"
+        "if [ \"$1\" = \"sandbox\" ] && "
+        "[ \"$2\" = \"-c\" ] && "
+        "[ \"$3\" = 'sandbox_mode=\"workspace-write\"' ]; then exit 101; fi\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    codex.chmod(0o755)
+    plan = {"runner_prerequisites": {}}
+
+    with pytest.raises(RuntimeError, match="sandbox probe failed"):
+        codex_runtime.run_preflight(_args(str(codex)), plan)
+
+    prerequisites = plan["runner_prerequisites"]
+    assert prerequisites["host_local_codex_cli_preflight_status"] == "failed"
+    assert (
+        prerequisites["host_local_codex_cli_preflight_sandbox_probe_invoked"]
+        is True
+    )
+    assert (
+        prerequisites["host_local_codex_cli_preflight_sandbox_probe_ready"]
+        is False
+    )
+    assert prerequisites["host_local_codex_cli_preflight_first_blocker"] == (
+        "skillsbench_host_local_codex_cli_sandbox_probe_failed"
+    )
+    attribution = skillsbench_loop._runner_prerequisite_failure_attribution(
+        prerequisites
+    )
+    assert attribution is not None
+    assert attribution[0].endswith("_codex_cli_sandbox_probe_failed")
+
+
+def test_explicit_danger_full_access_does_not_require_a_codex_sandbox_probe(
+    tmp_path: Path,
+) -> None:
+    codex = tmp_path / "codex"
+    codex.write_text(
+        "#!/bin/sh\n"
+        "if [ \"$1\" = \"sandbox\" ]; then exit 101; fi\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    codex.chmod(0o755)
+    plan = {"runner_prerequisites": {}}
+
+    codex_runtime.run_preflight(
+        _args(str(codex), sandbox="danger-full-access"), plan
+    )
+
+    prerequisites = plan["runner_prerequisites"]
+    assert prerequisites["host_local_codex_cli_preflight_status"] == "ready"
+    assert (
+        prerequisites["host_local_codex_cli_preflight_sandbox_probe_required"]
+        is False
+    )
+    assert (
+        prerequisites["host_local_codex_cli_preflight_sandbox_probe_invoked"]
+        is False
+    )
+    assert prerequisites["host_local_codex_cli_preflight_sandbox_probe_status"] == (
+        "not_required"
     )
 
 


### PR DESCRIPTION
## Summary
- exercise the selected host-local Codex sandbox during runner preflight, not only `codex --version`
- emit public-safe readiness and precise setup attribution when the sandbox runtime cannot execute
- preserve an explicit no-probe path for `danger-full-access`, where Codex sandboxing is intentionally disabled

## Validation
- `uv run --extra test pytest -q tests/test_skillsbench_remote_codex_preflight.py` (5 passed)
- `python examples/skillsbench-host-local-launch-plan-smoke.py`
- `python examples/skillsbench-benchmark-run-smoke.py`
- `python examples/skillsbench-runner-core-contract-smoke.py`
- `loopx canary premerge --from-git-diff` (all 6 selected catalog canaries passed; expected benchmark-sensitive maintainer hold)

## Boundary
- no scoring, task-semantic, submission, permission, or benchmark launch behavior changes
- no raw task text, trajectories, verifier output, credentials, private paths, or generated run artifacts included