### PR TITLE
Add focused Explore graph exports

### DIFF
--- a/docs/capabilities/explore/README.md
+++ b/docs/capabilities/explore/README.md
@@ -65,6 +65,27 @@ parent/`subtopic_of` topology tree, and Mermaid flowchart source.
 `loopx explore graph --graph-format mermaid|json [--out <file>]` exports the
 topology for a Feishu doc, whiteboard, or any Mermaid renderer.
 
+For an executive view, keep the append-only result log as the single source
+and export a focused graph instead of maintaining a second hand-written
+Mermaid file:
+
+```bash
+loopx explore graph \
+  --goal-id <id> \
+  --status exploring \
+  --status blocked \
+  --tag executive \
+  --graph-format mermaid \
+  --out explore-executive.mmd
+```
+
+Repeated statuses match any requested status, repeated tags match any exact
+requested tag, and the status and tag groups are combined with AND. Matching
+nodes keep their ancestors by default so the focused graph retains explanatory
+context; pass `--no-include-ancestors` for a leaf-only view. Filtering changes
+only the graph export. It does not mutate the full result projection or the
+Lark node, edge, and finding tables.
+
 ## Experimental Todo Branch Plan
 
 `loopx explore todo-branch-plan` is a narrow experimental harness for

--- a/examples/explore-result-layer-smoke.py
+++ b/examples/explore-result-layer-smoke.py
@@ -67,6 +67,7 @@ def build_sample_events(goal_id: str) -> list[dict[str, object]]:
             node_id="node_root",
             node_kind="area",
             status="exploring",
+            tags=["portfolio"],
             recorded_at="2026-07-06T01:00:00Z",
         ),
         result_log.build_explore_node_event(
@@ -87,6 +88,7 @@ def build_sample_events(goal_id: str) -> list[dict[str, object]]:
             status="blocked",
             blocked_reason="vendor licence terms unclear",
             parent_id="node_root",
+            tags=["priority"],
             recorded_at="2026-07-06T02:00:00Z",
         ),
         result_log.build_explore_edge_event(
@@ -147,6 +149,39 @@ def check_result_log_contract() -> dict[str, object]:
         assert mermaid.startswith("flowchart TD"), mermaid
         assert "node_kcg" in mermaid and ":::blocked" in mermaid, mermaid
         assert "-->|subtopic_of|" in mermaid, mermaid
+
+        focused = result_log.build_explore_graph_view(
+            projection["nodes"],
+            projection["edges"],
+            statuses=["blocked"],
+            tags=["priority"],
+        )
+        assert focused["filter"] == {
+            "active": True,
+            "statuses": ["blocked"],
+            "tags": ["priority"],
+            "include_ancestors": True,
+            "semantics": "status_and_any_tag",
+        }, focused
+        assert [node["node_id"] for node in focused["nodes"]] == [
+            "node_root",
+            "node_kcg",
+        ], focused
+        assert focused["graph_counts"] == {
+            "node_count": 2,
+            "edge_count": 1,
+            "matched_node_count": 1,
+            "context_node_count": 1,
+        }, focused
+
+        leaf_only = result_log.build_explore_graph_view(
+            projection["nodes"],
+            projection["edges"],
+            tags=["priority"],
+            include_ancestors=False,
+        )
+        assert [node["node_id"] for node in leaf_only["nodes"]] == ["node_kcg"], leaf_only
+        assert leaf_only["edges"] == [], leaf_only
 
     # Public-safety gates at record time.
     try:
@@ -866,6 +901,8 @@ def check_cli_surface() -> None:
             "node_cli_root",
             "--status",
             "exploring",
+            "--tag",
+            "executive",
         )
         assert node["ok"] is True and node["result_id"] == "node_cli_root", node
         finding = run_cli(
@@ -886,6 +923,21 @@ def check_cli_surface() -> None:
         assert summary["counts"]["finding_count"] == 1, summary
         graph = run_cli("explore", "graph", "--goal-id", goal_id)
         assert str(graph["mermaid"]).startswith("flowchart TD"), graph
+        focused_graph = run_cli(
+            "explore",
+            "graph",
+            "--goal-id",
+            goal_id,
+            "--status",
+            "exploring",
+            "--tag",
+            "executive",
+        )
+        assert focused_graph["filter"]["active"] is True, focused_graph
+        assert focused_graph["graph_counts"]["matched_node_count"] == 1, focused_graph
+        assert [item["node_id"] for item in focused_graph["nodes"]] == [
+            "node_cli_root"
+        ], focused_graph
         branch_plan = run_cli(
             "explore",
             "todo-branch-plan",

--- a/loopx/capabilities/explore/result_log.py
+++ b/loopx/capabilities/explore/result_log.py
@@ -670,6 +670,94 @@ def build_explore_mermaid(
     return "\n".join(lines)
 
 
+def build_explore_graph_view(
+    nodes: Sequence[Mapping[str, Any]],
+    edges: Sequence[Mapping[str, Any]],
+    *,
+    statuses: Sequence[str] | None = None,
+    tags: Sequence[str] | None = None,
+    include_ancestors: bool = True,
+    node_limit: int = DEFAULT_MERMAID_NODE_LIMIT,
+) -> dict[str, Any]:
+    """Build a focused graph without mutating the full result projection.
+
+    Status and tag filters are combined with AND semantics. Tag matching uses
+    exact values and is OR within the requested tag set. Ancestors are included
+    by default so a focused executive graph keeps enough topology to explain
+    where each matched node belongs.
+    """
+
+    requested_statuses = {
+        _choice(status, choices=NODE_STATUSES, default="", field="status")
+        for status in statuses or []
+    }
+    requested_tags = {str(tag or "").strip() for tag in tags or []}
+    requested_tags.discard("")
+
+    node_list = [dict(node) for node in nodes]
+    edge_list = [dict(edge) for edge in edges]
+    node_by_id = {
+        str(node.get("node_id") or ""): node
+        for node in node_list
+        if str(node.get("node_id") or "")
+    }
+
+    def matches(node: Mapping[str, Any]) -> bool:
+        if requested_statuses and str(node.get("status") or "") not in requested_statuses:
+            return False
+        node_tags = {str(tag) for tag in node.get("tags") or []}
+        if requested_tags and requested_tags.isdisjoint(node_tags):
+            return False
+        return True
+
+    filtering = bool(requested_statuses or requested_tags)
+    matched_ids = {
+        node_id for node_id, node in node_by_id.items() if not filtering or matches(node)
+    }
+    selected_ids = set(matched_ids)
+    if filtering and include_ancestors:
+        parents = _parent_map(node_list, edge_list)
+        for node_id in tuple(matched_ids):
+            seen = {node_id}
+            parent = parents.get(node_id)
+            while parent and parent not in seen and parent in node_by_id:
+                selected_ids.add(parent)
+                seen.add(parent)
+                parent = parents.get(parent)
+
+    selected_nodes = [
+        node for node in node_list if str(node.get("node_id") or "") in selected_ids
+    ]
+    selected_edges = [
+        edge
+        for edge in edge_list
+        if str(edge.get("from_node") or "") in selected_ids
+        and str(edge.get("to_node") or "") in selected_ids
+    ]
+    return {
+        "nodes": selected_nodes,
+        "edges": selected_edges,
+        "mermaid": build_explore_mermaid(
+            selected_nodes,
+            selected_edges,
+            node_limit=max(1, int(node_limit)),
+        ),
+        "graph_counts": {
+            "node_count": len(selected_nodes),
+            "edge_count": len(selected_edges),
+            "matched_node_count": len(matched_ids),
+            "context_node_count": len(selected_ids - matched_ids),
+        },
+        "filter": {
+            "active": filtering,
+            "statuses": sorted(requested_statuses),
+            "tags": sorted(requested_tags),
+            "include_ancestors": bool(include_ancestors),
+            "semantics": "status_and_any_tag",
+        },
+    }
+
+
 def build_explore_result_projection(
     events: Sequence[Mapping[str, Any]],
     *,

--- a/loopx/cli_commands/explore.py
+++ b/loopx/cli_commands/explore.py
@@ -15,6 +15,7 @@ from ..capabilities.explore.result_log import (
     append_explore_result_event,
     build_explore_edge_event,
     build_explore_finding_event,
+    build_explore_graph_view,
     build_explore_node_event,
     build_explore_result_projection,
     explore_result_log_path,
@@ -129,6 +130,27 @@ def register_explore_commands(
         "--graph-format",
         choices=["mermaid", "json"],
         default="mermaid",
+    )
+    graph.add_argument(
+        "--status",
+        dest="graph_statuses",
+        action="append",
+        choices=sorted(NODE_STATUSES),
+        default=[],
+        help="Keep nodes with this status. Repeatable; combined with --tag using AND.",
+    )
+    graph.add_argument(
+        "--tag",
+        dest="graph_tags",
+        action="append",
+        default=[],
+        help="Keep nodes with any requested exact tag. Repeatable.",
+    )
+    graph.add_argument(
+        "--include-ancestors",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Keep ancestors of matching nodes so the focused topology retains context.",
     )
     graph.add_argument("--out", help="Also write the graph to this local file.")
 
@@ -599,26 +621,38 @@ def handle_explore_command(
             payload = _projection_for(args, runtime_root=runtime_root)
         elif args.explore_command == "graph":
             projection = _projection_for(args, runtime_root=runtime_root)
+            graph_view = build_explore_graph_view(
+                projection.get("nodes") or [],
+                projection.get("edges") or [],
+                statuses=args.graph_statuses,
+                tags=args.graph_tags,
+                include_ancestors=bool(args.include_ancestors),
+                node_limit=max(1, int(args.mermaid_node_limit)),
+            )
             payload = {
                 "ok": True,
                 "schema_version": "loopx_explore_graph_v0",
                 "goal_id": args.goal_id,
                 "graph_format": args.graph_format,
                 "counts": projection.get("counts"),
-                "nodes": projection.get("nodes"),
-                "edges": projection.get("edges"),
-                "mermaid": projection.get("mermaid"),
+                "graph_counts": graph_view.get("graph_counts"),
+                "filter": graph_view.get("filter"),
+                "nodes": graph_view.get("nodes"),
+                "edges": graph_view.get("edges"),
+                "mermaid": graph_view.get("mermaid"),
             }
             if args.out:
                 out_path = Path(args.out).expanduser()
                 out_path.parent.mkdir(parents=True, exist_ok=True)
                 if args.graph_format == "mermaid":
-                    out_path.write_text(str(projection.get("mermaid") or "") + "\n", encoding="utf-8")
+                    out_path.write_text(str(graph_view.get("mermaid") or "") + "\n", encoding="utf-8")
                 else:
                     graph_json = {
                         "goal_id": args.goal_id,
-                        "nodes": projection.get("nodes"),
-                        "edges": projection.get("edges"),
+                        "graph_counts": graph_view.get("graph_counts"),
+                        "filter": graph_view.get("filter"),
+                        "nodes": graph_view.get("nodes"),
+                        "edges": graph_view.get("edges"),
                     }
                     out_path.write_text(
                         json.dumps(graph_json, ensure_ascii=False, indent=2) + "\n",


### PR DESCRIPTION
## Summary

- add read-only Explore graph filtering by repeated node status and exact tag
- keep matching nodes' ancestors by default so focused graphs retain topology context
- expose filter metadata and graph-local counts for Mermaid and JSON exports
- document executive-view usage and extend the durable result-layer smoke

## Validation

- `python3 examples/explore-result-layer-smoke.py`
- source-checkout smoke against a live public-safe result projection
- `loopx canary premerge --from-git-diff` (17 selected checks passed)
- `git diff --check`
- public/private boundary scan on all four changed paths

## Boundary

This is a read-only projection change. It does not mutate Explore state, Lark tables, todo planning, quota, spawn policy, or execution authority.