### PR TITLE
fix(issue-fix): make outcome Kanban links and active stages visible

### DIFF
--- a/examples/issue-fix-outcome-projection-smoke.py
+++ b/examples/issue-fix-outcome-projection-smoke.py
@@ -163,8 +163,8 @@ def main() -> None:
     assert row["values"]["Action Kind"] == "issue_fix_outcome", row
     assert row["values"]["Work Item Type"] == "Issue Fix", row
     assert row["values"]["Repository"] == "public-fixture/widgets", row
-    assert row["values"]["Issue"] == "#42", row
-    assert row["values"]["Pull Request"] == "#77", row
+    assert row["values"]["Issue"] == "https://github.com/public-fixture/widgets/issues/42", row
+    assert row["values"]["Pull Request"] == "https://github.com/public-fixture/widgets/pull/77", row
     assert row["values"]["Route"] == "fix_pr", row
     assert row["values"]["Stage"] == "ci_pending", row
     assert row["values"]["Validation"].startswith("passed:"), row

--- a/examples/lark-kanban-control-plane-smoke.py
+++ b/examples/lark-kanban-control-plane-smoke.py
@@ -217,6 +217,17 @@ def main() -> int:
         "Status",
     ]
     assert schema["operator_view"]["issue_fix_card_fields"] == issue_fix_surface.ISSUE_FIX_CARD_FIELDS
+    issue_fields = {field["name"]: field for field in schema["fields"]}
+    assert issue_fields["Issue"]["style"]["type"] == "url", issue_fields["Issue"]
+    assert issue_fields["Pull Request"]["style"]["type"] == "url", issue_fields["Pull Request"]
+    assert issue_fix_surface.ISSUE_FIX_STAGE_OPTIONS[:6] == [
+        "reproduction_planned",
+        "fix_in_progress",
+        "fix_review_ready",
+        "ci_pending",
+        "ci_failed",
+        "review_wait",
+    ], issue_fix_surface.ISSUE_FIX_STAGE_OPTIONS
     assert {issue_fix_surface.DEFAULT_ISSUE_FIX_GRID_VIEW, issue_fix_surface.DEFAULT_ISSUE_FIX_KANBAN_VIEW} <= {view["name"] for view in schema["views"]}
 
     plan = build_create_board_plan(
@@ -233,6 +244,9 @@ def main() -> int:
     assert any("+view-set-visible-fields" in command for command in joined), joined
     assert sum("+view-set-filter" in command and "Work Item Type" in command for command in joined) == 2, joined
     assert any("+view-set-group" in command and "Issue Fix Kanban" in command and "Stage" in command for command in joined), joined
+    assert sum("+field-update" in command and "--yes" in command for command in joined) == 3, joined
+    assert any("+field-update" in command and "--field-id Issue" in command and '\"type\": \"url\"' in command for command in joined), joined
+    assert any("+field-update" in command and "--field-id Stage" in command and "ci_pending" in command for command in joined), joined
 
     heartbeat = lark_kanban_heartbeat(
         LarkKanbanConfig(

--- a/loopx/presentation/sinks/lark/issue_fix_surface.py
+++ b/loopx/presentation/sinks/lark/issue_fix_surface.py
@@ -24,19 +24,19 @@ ISSUE_FIX_CARD_FIELDS = [
 
 ISSUE_FIX_STAGE_OPTIONS = [
     "reproduction_planned",
-    "reproduction_blocked",
     "fix_in_progress",
-    "fix_blocked",
-    "delivery_blocked",
     "fix_review_ready",
-    "draft_pr",
     "ci_pending",
     "ci_failed",
     "review_wait",
     "changes_requested",
+    "merge_ready",
+    "reproduction_blocked",
+    "fix_blocked",
+    "delivery_blocked",
+    "draft_pr",
     "branch_stale_or_conflicted",
     "pr_open",
-    "merge_ready",
     "merged",
     "closed_without_merge",
     "comment_packet",
@@ -57,8 +57,8 @@ def issue_fix_field_definitions(
             "options": select_options(["Todo", "Issue Fix"]),
         },
         {"name": "Repository", "type": "text", "style": {"type": "plain"}},
-        {"name": "Issue", "type": "text", "style": {"type": "plain"}},
-        {"name": "Pull Request", "type": "text", "style": {"type": "plain"}},
+        {"name": "Issue", "type": "text", "style": {"type": "url"}},
+        {"name": "Pull Request", "type": "text", "style": {"type": "url"}},
         {
             "name": "Route",
             "type": "select",
@@ -102,17 +102,25 @@ def issue_fix_record_values(
     result = block.get("result") if isinstance(block.get("result"), Mapping) else {}
     issue_number = issue.get("number")
     pr_number = pull_request.get("number")
+    issue_url = compact_text(issue.get("url"), limit=320)
+    pr_url = compact_text(pull_request.get("url"), limit=320)
     validation_status = compact_text(validation.get("status"), limit=80)
     validation_label = compact_text(validation.get("label"), limit=220)
     return {
         "Work Item Type": "Issue Fix",
         "Repository": compact_text(block.get("repo"), limit=160),
-        "Issue": f"#{issue_number}"
-        if issue_number is not None
-        else compact_text(block.get("issue_ref"), limit=80),
-        "Pull Request": f"#{pr_number}"
-        if pr_number is not None
-        else compact_text(pull_request.get("ref"), limit=80),
+        "Issue": issue_url
+        or (
+            f"#{issue_number}"
+            if issue_number is not None
+            else compact_text(block.get("issue_ref"), limit=80)
+        ),
+        "Pull Request": pr_url
+        or (
+            f"#{pr_number}"
+            if pr_number is not None
+            else compact_text(pull_request.get("ref"), limit=80)
+        ),
         "Route": compact_text(block.get("route"), limit=80),
         "Stage": compact_text(block.get("stage"), limit=80),
         "Validation": compact_text(
@@ -191,6 +199,25 @@ def issue_fix_view_configuration_commands(
     commands = [
         [
             *common[:2],
+            "+field-update",
+            *common[2:],
+            "--field-id",
+            definition["name"],
+            "--json",
+            json.dumps(definition, ensure_ascii=False),
+            "--yes",
+        ]
+        for definition in issue_fix_field_definitions(
+            lambda options: [
+                {"name": option, "hue": "Blue", "lightness": "Light"}
+                for option in options
+            ]
+        )
+        if definition["name"] in {"Issue", "Pull Request", "Stage"}
+    ]
+    commands.extend(
+        [
+            *common[:2],
             "+view-set-filter",
             *common[2:],
             "--view-id",
@@ -205,7 +232,7 @@ def issue_fix_view_configuration_commands(
             ),
         ]
         for view_id in (issue_grid_view, issue_kanban_view)
-    ]
+    )
     commands.append(
         [
             *common[:2],


### PR DESCRIPTION
## Motivation

The issue-fix outcome table wrote only number labels into the Issue and Pull Request columns even though canonical public URLs were already present in the outcome projection. The Stage option order also put current CI and review cards behind several empty columns, so a valid Kanban appeared empty on its first viewport.

## Implementation

- project canonical issue and pull-request URLs into URL-styled Base fields;
- migrate existing Issue, Pull Request, and Stage field definitions during board setup;
- order common active issue-fix stages before blocked and terminal lanes;
- update focused smoke contracts for link values, field migration, and first-viewport stage order.

## Validation

- python3 -m py_compile loopx/presentation/sinks/lark/issue_fix_surface.py
- python3 examples/issue-fix-outcome-projection-smoke.py
- python3 examples/lark-kanban-control-plane-smoke.py
- loopx canary premerge --from-git-diff: 3 direct checks, Python compile, 8 selected catalog canaries, and public-boundary scan passed
- git diff --check

## Risk and gaps

The migration performs same-type field updates for two text URL fields and one select field; existing stage option names are preserved, only their order changes. No private state, credentials, local paths, raw logs, or project-specific logic are included. Live Base readback will be performed after merge and local release refresh.