### PR TITLE
Clarify Explore executive view projections

### DIFF
--- a/docs/capabilities/explore/README.md
+++ b/docs/capabilities/explore/README.md
@@ -65,9 +65,9 @@ parent/`subtopic_of` topology tree, and Mermaid flowchart source.
 `loopx explore graph --graph-format mermaid|json [--out <file>]` exports the
 topology for a Feishu doc, whiteboard, or any Mermaid renderer.
 
-For an executive view, keep the append-only result log as the single source
-and export a focused graph instead of maintaining a second hand-written
-Mermaid file:
+Focused exports are bounded evidence views, not executive decision views by
+default. They preserve machine-oriented node identity, edge semantics, and
+ancestor context while reducing the amount of canonical topology rendered:
 
 ```bash
 loopx explore graph \
@@ -76,7 +76,7 @@ loopx explore graph \
   --status blocked \
   --tag executive \
   --graph-format mermaid \
-  --out explore-executive.mmd
+  --out explore-focused-evidence.mmd
 ```
 
 Repeated statuses match any requested status, repeated tags match any exact
@@ -85,6 +85,28 @@ nodes keep their ancestors by default so the focused graph retains explanatory
 context; pass `--no-include-ancestors` for a leaf-only view. Filtering changes
 only the graph export. It does not mutate the full result projection or the
 Lark node, edge, and finding tables.
+
+An owner-facing executive graph is a separate display projection over that
+canonical evidence, not a second evidence source. Do not sync a full or focused
+canonical export directly into an executive whiteboard merely because it is
+smaller. The projection should compress the evidence into the decision roles
+the operator needs to see:
+
+- decision contract and primary metric;
+- baseline and current incumbent;
+- decisive negative or retired evidence;
+- active work or capacity slots;
+- material risk and guardrails;
+- terminal decision gate;
+- next decision or evidence gap.
+
+Give the projection explicit node and edge budgets, stable references back to
+canonical node ids, and a fail-fast guard that rejects accidental identity with
+the canonical export. Before syncing, render it with the target renderer, run
+geometry checks for overlap and text overflow, and visually inspect the actual
+preview. After syncing, verify the remote source or digest matches the validated
+projection. The canonical JSON and Nodes/Edges/Findings tables remain complete
+and authoritative throughout this presentation step.
 
 ## Experimental Todo Branch Plan
 

--- a/loopx/capabilities/explore/result_log.py
+++ b/loopx/capabilities/explore/result_log.py
@@ -683,8 +683,9 @@ def build_explore_graph_view(
 
     Status and tag filters are combined with AND semantics. Tag matching uses
     exact values and is OR within the requested tag set. Ancestors are included
-    by default so a focused executive graph keeps enough topology to explain
-    where each matched node belongs.
+    by default so a focused evidence graph keeps enough topology to explain
+    where each matched node belongs. Executive decision views require a
+    separate display projection with semantic compression and visual review.
     """
 
     requested_statuses = {

--- a/skills/loopx-project/SKILL.md
+++ b/skills/loopx-project/SKILL.md
@@ -147,6 +147,33 @@ memory. Stop and write a project-local todo or blocker when the target project
 is ambiguous, the source cannot be represented as public-safe metadata, or the
 next step would require reading a gated source body.
 
+## Owner-Facing Explore Views
+
+Treat the canonical Explore topology and an owner-facing decision graph as two
+different read models over one evidence source:
+
+- canonical JSON, Mermaid, and Nodes/Edges/Findings tables preserve complete
+  public-safe node identity, evidence, and lineage;
+- focused status/tag exports are bounded evidence subsets, not executive views
+  by default;
+- an executive graph applies semantic compression for operator decisions. It
+  should show the decision contract, baseline/incumbent, decisive negative
+  evidence, active work or capacity, material risk, terminal gate, and next
+  decision.
+
+Never overwrite an executive whiteboard directly from a full or focused
+canonical export unless a declared presentation contract proves that the
+export already carries those semantic roles. For a recurring sync, keep a
+project-local display contract with node/edge budgets, required roles, stable
+canonical ids, and a non-identity guard. Render with the target renderer, run
+overlap/text-overflow checks, inspect the preview, then sync and verify the
+remote source or digest. If any check fails, keep the previous owner view and
+repair the projection; do not publish a structurally valid but unreadable graph.
+
+This separation does not transfer quota, todo, launch, stop, or promotion
+authority into the presentation layer. Record material experiment transitions
+in canonical Explore state first, then refresh the executive projection.
+
 ## Preflight
 
 From the target project shell:


### PR DESCRIPTION
## Summary
- define focused Explore graph exports as bounded canonical evidence views, not executive views by default
- document the semantic roles and visual checks required for an owner-facing decision projection
- teach the LoopX project skill to preserve canonical evidence while validating executive whiteboard syncs

## Validation
- `python3 examples/explore-result-layer-smoke.py`
- `scripts/loopx canary premerge --from-git-diff` (17 selected checks passed)
- `git diff --check`
- public/private boundary scan passed

## Scope
Documentation, skill guidance, and a clarifying docstring only. No graph export, planner, quota, todo, or execution behavior changes.