### PR TITLE
fix(lark): run idempotent issue-fix field migrations before views

### DIFF
--- a/examples/lark-kanban-control-plane-smoke.py
+++ b/examples/lark-kanban-control-plane-smoke.py
@@ -173,7 +173,46 @@ def existing_setup_runner(args: list[str], cwd: Path | None, timeout: float | No
     if args[-1:] == ["--help"]:
         return {"returncode": 0, "stdout": "help\n", "stderr": "", "timed_out": False}
     if "+field-list" in args:
-        return {"returncode": 0, "stdout": json.dumps({"ok": True, "data": {"fields": [{"name": "Task"}, {"name": "Status"}, {"name": "Claim"}, {"name": "Priority"}]}}), "stderr": "", "timed_out": False}
+        return {
+            "returncode": 0,
+            "stdout": json.dumps(
+                {
+                    "ok": True,
+                    "data": {
+                        "fields": [
+                            {"name": "Task"},
+                            {"name": "Status"},
+                            {"name": "Claim"},
+                            {"name": "Priority"},
+                            {
+                                "id": "fld_issue_existing",
+                                "name": "Issue",
+                                "type": "text",
+                                "style": {"type": "plain"},
+                            },
+                            {
+                                "id": "fld_pr_existing",
+                                "name": "Pull Request",
+                                "type": "text",
+                                "style": {"type": "plain"},
+                            },
+                            {
+                                "id": "fld_stage_existing",
+                                "name": "Stage",
+                                "type": "select",
+                                "multiple": False,
+                                "options": [
+                                    {"name": "reproduction_planned"},
+                                    {"name": "reproduction_blocked"},
+                                ],
+                            },
+                        ]
+                    },
+                }
+            ),
+            "stderr": "",
+            "timed_out": False,
+        }
     if "+view-list" in args:
         existing_setup_view_list_count += 1
         views = [{"name": "Worker Queue", "view_id": "vew_worker_existing"}, {"name": "User Gates", "view_id": "vew_user_existing"}, {"name": "Kanban", "view_id": "vew_kanban_existing"}]
@@ -228,6 +267,9 @@ def main() -> int:
         "ci_failed",
         "review_wait",
     ], issue_fix_surface.ISSUE_FIX_STAGE_OPTIONS
+    assert issue_fix_surface.field_definition_migrations(
+        {"data": {"fields": schema["fields"]}}, schema["fields"]
+    ) == []
     assert {issue_fix_surface.DEFAULT_ISSUE_FIX_GRID_VIEW, issue_fix_surface.DEFAULT_ISSUE_FIX_KANBAN_VIEW} <= {view["name"] for view in schema["views"]}
 
     plan = build_create_board_plan(
@@ -244,9 +286,7 @@ def main() -> int:
     assert any("+view-set-visible-fields" in command for command in joined), joined
     assert sum("+view-set-filter" in command and "Work Item Type" in command for command in joined) == 2, joined
     assert any("+view-set-group" in command and "Issue Fix Kanban" in command and "Stage" in command for command in joined), joined
-    assert sum("+field-update" in command and "--yes" in command for command in joined) == 3, joined
-    assert any("+field-update" in command and "--field-id Issue" in command and '\"type\": \"url\"' in command for command in joined), joined
-    assert any("+field-update" in command and "--field-id Stage" in command and "ci_pending" in command for command in joined), joined
+    assert not any("+field-update" in command for command in joined), joined
 
     heartbeat = lark_kanban_heartbeat(
         LarkKanbanConfig(
@@ -357,7 +397,20 @@ def main() -> int:
         use_lark_kanban_board(config_path=config_path, base_url="https://example.invalid/base/base_existing?table=tbl_existing", cli_bin="lark-cli", identity="user")
         migrated = setup_lark_kanban_board(config_path=config_path, base_name="LoopX Existing Board Fixture", cli_bin="lark-cli", identity="user", execute=True, runner=existing_setup_runner)
         assert migrated["ok"] is True, migrated
-        assert {"Work Item Type", "Repository", "Issue", "Pull Request", "Route", "Stage", "Validation", "Outcome"} <= set(migrated["created_fields"]), migrated
+        assert {"Work Item Type", "Repository", "Route", "Validation", "Outcome"} <= set(migrated["created_fields"]), migrated
+        assert set(migrated["updated_fields"]) == {"Issue", "Pull Request", "Stage"}, migrated
+        field_updates = [args for args in existing_setup_calls if "+field-update" in args]
+        assert len(field_updates) == 3, field_updates
+        assert [args[args.index("--field-id") + 1] for args in field_updates] == [
+            "fld_issue_existing",
+            "fld_pr_existing",
+            "fld_stage_existing",
+        ], field_updates
+        assert all("--yes" in args for args in field_updates), field_updates
+        assert "ci_pending" in field_updates[-1][field_updates[-1].index("--json") + 1], field_updates[-1]
+        first_view_write = next(index for index, args in enumerate(existing_setup_calls) if "+view-set-filter" in args)
+        last_field_update = max(index for index, args in enumerate(existing_setup_calls) if "+field-update" in args)
+        assert last_field_update < first_view_write, existing_setup_calls
         assert migrated["view_ids"][issue_fix_surface.DEFAULT_ISSUE_FIX_GRID_VIEW] == "vew_issue_grid", migrated
         assert migrated["view_ids"][issue_fix_surface.DEFAULT_ISSUE_FIX_KANBAN_VIEW] == "vew_issue_kanban", migrated
         created_views = next(args for args in existing_setup_calls if "+view-create" in args)

--- a/loopx/presentation/sinks/lark/issue_fix_surface.py
+++ b/loopx/presentation/sinks/lark/issue_fix_surface.py
@@ -165,11 +165,67 @@ def extract_field_names(parsed: Any) -> set[str]:
     return set()
 
 
+def extract_fields(parsed: Any) -> dict[str, Mapping[str, Any]]:
+    if isinstance(parsed, dict):
+        fields = parsed.get("fields")
+        if isinstance(fields, list):
+            return {
+                str(item.get("name") or "").strip(): item
+                for item in fields
+                if isinstance(item, Mapping) and str(item.get("name") or "").strip()
+            }
+        for value in parsed.values():
+            extracted = extract_fields(value)
+            if extracted:
+                return extracted
+    if isinstance(parsed, list):
+        for value in parsed:
+            extracted = extract_fields(value)
+            if extracted:
+                return extracted
+    return {}
+
+
 def missing_field_definitions(
     parsed: Any, definitions: list[dict[str, Any]]
 ) -> list[dict[str, Any]]:
     existing = extract_field_names(parsed)
     return [item for item in definitions if str(item.get("name") or "").strip() not in existing]
+
+
+def field_definition_migrations(
+    parsed: Any, definitions: list[dict[str, Any]]
+) -> list[dict[str, Any]]:
+    existing = extract_fields(parsed)
+    migrations: list[dict[str, Any]] = []
+    for definition in definitions:
+        name = str(definition.get("name") or "").strip()
+        if name not in {"Issue", "Pull Request", "Stage"} or name not in existing:
+            continue
+        current = existing[name]
+        matches = current.get("type") == definition.get("type")
+        if name in {"Issue", "Pull Request"}:
+            current_style = current.get("style") if isinstance(current.get("style"), Mapping) else {}
+            desired_style = definition.get("style") if isinstance(definition.get("style"), Mapping) else {}
+            matches = matches and current_style.get("type") == desired_style.get("type")
+        else:
+            current_options = current.get("options") if isinstance(current.get("options"), list) else []
+            desired_options = definition.get("options") if isinstance(definition.get("options"), list) else []
+            matches = (
+                matches
+                and current.get("multiple") is definition.get("multiple")
+                and [item.get("name") for item in current_options if isinstance(item, Mapping)]
+                == [item.get("name") for item in desired_options if isinstance(item, Mapping)]
+            )
+        if not matches:
+            migrations.append(
+                {
+                    "field_id": str(current.get("id") or name),
+                    "name": name,
+                    "definition": definition,
+                }
+            )
+    return migrations
 
 
 def issue_fix_view_configuration_commands(
@@ -199,25 +255,6 @@ def issue_fix_view_configuration_commands(
     commands = [
         [
             *common[:2],
-            "+field-update",
-            *common[2:],
-            "--field-id",
-            definition["name"],
-            "--json",
-            json.dumps(definition, ensure_ascii=False),
-            "--yes",
-        ]
-        for definition in issue_fix_field_definitions(
-            lambda options: [
-                {"name": option, "hue": "Blue", "lightness": "Light"}
-                for option in options
-            ]
-        )
-        if definition["name"] in {"Issue", "Pull Request", "Stage"}
-    ]
-    commands.extend(
-        [
-            *common[:2],
             "+view-set-filter",
             *common[2:],
             "--view-id",
@@ -232,7 +269,7 @@ def issue_fix_view_configuration_commands(
             ),
         ]
         for view_id in (issue_grid_view, issue_kanban_view)
-    )
+    ]
     commands.append(
         [
             *common[:2],

--- a/loopx/presentation/sinks/lark/kanban.py
+++ b/loopx/presentation/sinks/lark/kanban.py
@@ -1301,6 +1301,7 @@ def setup_lark_kanban_board(
     created_base = False
     created_table = False
     created_field_names: list[str] = []
+    updated_field_names: list[str] = []
     config_payload: dict[str, Any] | None = None
 
     def save_usable_config() -> None:
@@ -1470,6 +1471,33 @@ def setup_lark_kanban_board(
             if not field_create.get("ok"):
                 return partial_enrichment_payload(field_create)
             created_field_names.append(str(definition.get("name") or ""))
+        for migration in issue_fix_surface.field_definition_migrations(
+            field_list.get("json"), lark_kanban_field_definitions()
+        ):
+            field_update = _run_command(
+                [
+                    cli_bin,
+                    "base",
+                    "+field-update",
+                    "--as",
+                    identity,
+                    "--base-token",
+                    effective_base_token,
+                    "--table-id",
+                    effective_table_id,
+                    "--field-id",
+                    str(migration["field_id"]),
+                    "--json",
+                    json.dumps(migration["definition"], ensure_ascii=False),
+                    "--yes",
+                ],
+                execute=True,
+                runner=runner,
+            )
+            commands.append(field_update)
+            if not field_update.get("ok"):
+                return partial_enrichment_payload(field_update)
+            updated_field_names.append(str(migration["name"]))
 
     if execute:
         view_ids = _refresh_view_ids(
@@ -1548,6 +1576,7 @@ def setup_lark_kanban_board(
         "created_base": created_base,
         "created_table": created_table,
         "created_fields": created_field_names,
+        "updated_fields": updated_field_names,
         "base_token": effective_base_token,
         "table_id": effective_table_id,
         "view_ids": view_ids,


### PR DESCRIPTION
## Motivation

Live validation of the issue-fix Kanban link and stage migration exposed a product-path gap. Existing-board setup configured views before issue-fix fields. A platform rejection from an already-configured view caused partial return before field migration, while unconditional same-state field updates could themselves fail as no-op writes.

## Implementation

- compare the existing field-list read model with desired Issue, Pull Request, and Stage definitions;
- emit field updates only for real type/style/option-order drift;
- address fields by their resolved field ids;
- run migrations immediately after field discovery and before any view enrichment;
- report updated_fields separately from created_fields;
- cover drift, idempotent no-op, resolved ids, and migration-before-view ordering in the generic Lark smoke.

## Validation

- Python compile for the touched sink modules: passed
- issue-fix-outcome-projection-smoke: passed
- lark-kanban-control-plane-smoke: passed
- premerge canary: direct diff checks, Python compile, 5 selected catalog canaries, and public-boundary scan passed
- git diff check: passed

## Risk and gaps

This changes setup ordering for existing boards only. New boards already receive the desired field definitions at table creation. Field mutations remain same-type updates and are skipped when the live field list already matches. The view-enrichment platform limitation remains isolated as a partial setup warning and no longer prevents field migration.