### PR TITLE
Recover truthful Docker exec status in SkillsBench

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -6207,10 +6207,14 @@ def test_skillsbench_docker_task_staging_patches_verifier_uv_bootstrap_mirror() 
             metadata
         )
         assert metadata["verifier_uv_bootstrap_version"] == "0.9.7", metadata
+        assert metadata["verifier_script_executable_required"] is True, metadata
+        assert metadata["verifier_script_executable_ready"] is True, metadata
         assert metadata["verifier_uv_bootstrap_mirror_host"] == (
             DEFAULT_VERIFIER_UV_RELEASE_MIRROR_HOST
         ), metadata
         assert verifier.read_text(encoding="utf-8") == original_verifier
+        assert not os.access(verifier, os.X_OK), verifier
+        assert os.access(staged_path / "tests" / "test.sh", os.X_OK), staged_path
         staged_verifier = (staged_path / "tests" / "test.sh").read_text(
             encoding="utf-8"
         )
@@ -7284,6 +7288,8 @@ def test_skillsbench_task_staging_metadata_is_compacted() -> None:
             "verifier_uv_bootstrap_risk_detected": True,
             "verifier_uv_bootstrap_mirror_patch_required": True,
             "verifier_uv_bootstrap_mirror_patch_applied": True,
+            "verifier_script_executable_required": True,
+            "verifier_script_executable_ready": True,
             "verifier_uv_bootstrap_version": "0.9.7",
             "verifier_uv_bootstrap_mirror_host": (
                 DEFAULT_VERIFIER_UV_RELEASE_MIRROR_HOST
@@ -7325,6 +7331,8 @@ def test_skillsbench_task_staging_metadata_is_compacted() -> None:
             "verifier_uv_bootstrap_risk_detected": True,
             "verifier_uv_bootstrap_mirror_patch_required": True,
             "verifier_uv_bootstrap_mirror_patch_applied": True,
+            "verifier_script_executable_required": True,
+            "verifier_script_executable_ready": True,
             "verifier_uv_bootstrap_version": "0.9.7",
             "verifier_uv_bootstrap_mirror_host": (
                 DEFAULT_VERIFIER_UV_RELEASE_MIRROR_HOST

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -6011,6 +6011,8 @@ def _public_task_staging(value: Any) -> dict[str, Any]:
         "verifier_uv_bootstrap_mirror_patch_required",
         "verifier_uv_bootstrap_mirror_patch_applied",
         "verifier_uv_bootstrap_pip_fallback_patch_applied",
+        "verifier_script_executable_required",
+        "verifier_script_executable_ready",
         "benchmark_egress_proxy_verifier_env_patch_required",
         "benchmark_egress_proxy_verifier_env_patch_applied",
         "benchmark_egress_proxy_verifier_env_raw_proxy_recorded",
@@ -6085,7 +6087,7 @@ def _discover_prepared_task_staging(plan: dict[str, Any]) -> dict[str, Any]:
         )
     except OSError:
         dockerfile_text = ""
-    verifier = prepared_task / "verifier" / "test.sh"
+    verifier = proxy_runtime.skillsbench_verifier_script(prepared_task)
     try:
         verifier_text = (
             verifier.read_text(encoding="utf-8", errors="replace")
@@ -6169,6 +6171,10 @@ def _discover_prepared_task_staging(plan: dict[str, Any]) -> dict[str, Any]:
             and not (prepared_task / "environment" / "skills").exists()
         ),
         "original_task_mutated": False,
+        "verifier_script_executable_required": verifier.is_file(),
+        "verifier_script_executable_ready": (
+            verifier.is_file() and os.access(verifier, os.X_OK)
+        ),
     }
     dockerfile_uv_versions = _dockerfile_uv_bootstrap_versions(dockerfile_text)
     if DOCKER_UV_BOOTSTRAP_MIRROR_BEGIN in dockerfile_text:
@@ -8133,6 +8139,18 @@ def ensure_empty_skills_build_context(dockerfile: Path) -> bool:
     return True
 
 
+def ensure_verifier_script_executable(verifier: Path) -> bool:
+    """Ensure a staged verifier remains executable after atomic text patches."""
+
+    if not verifier.is_file():
+        return False
+    try:
+        verifier.chmod(verifier.stat().st_mode | 0o111)
+        return bool(verifier.stat().st_mode & 0o111)
+    except OSError:
+        return False
+
+
 def stage_task_for_sandbox(
     *,
     task_path: Path,
@@ -8188,6 +8206,8 @@ def stage_task_for_sandbox(
         "verifier_uv_bootstrap_mirror_patch_required": False,
         "verifier_uv_bootstrap_mirror_patch_applied": False,
         "verifier_uv_bootstrap_pip_fallback_patch_applied": False,
+        "verifier_script_executable_required": False,
+        "verifier_script_executable_ready": False,
         "benchmark_egress_proxy_verifier_env_patch_required": False,
         "benchmark_egress_proxy_verifier_env_patch_applied": False,
         "benchmark_egress_proxy_verifier_env_key_count": 0,
@@ -8253,8 +8273,9 @@ def stage_task_for_sandbox(
         benchmark_egress_proxy_env
     )
     verifier_script = proxy_runtime.skillsbench_verifier_script(task_path)
+    verifier_script_present = verifier_script.is_file()
     needs_verifier_proxy_env_patch = bool(
-        verifier_proxy_exports and verifier_script.is_file()
+        verifier_proxy_exports and verifier_script_present
     )
     needs_dockerfile_proxy_env_patch = bool(
         verifier_proxy_exports and (task_path / "environment" / "Dockerfile").exists()
@@ -8314,6 +8335,7 @@ def stage_task_for_sandbox(
     metadata["verifier_uv_bootstrap_mirror_patch_required"] = (
         needs_verifier_uv_mirror_patch
     )
+    metadata["verifier_script_executable_required"] = verifier_script_present
     metadata["benchmark_egress_proxy_verifier_env_patch_required"] = (
         needs_verifier_proxy_env_patch
     )
@@ -8345,6 +8367,7 @@ def stage_task_for_sandbox(
         and not needs_maven_mirror_patch
         and not needs_runtime_tools_patch
         and not needs_verifier_uv_mirror_patch
+        and not verifier_script_present
         and not needs_verifier_proxy_env_patch
         and not needs_dockerfile_proxy_env_patch
     ):
@@ -8424,6 +8447,9 @@ def stage_task_for_sandbox(
         staged_verifier_script,
         proxy_env=benchmark_egress_proxy_env,
     )
+    verifier_script_executable_ready = ensure_verifier_script_executable(
+        staged_verifier_script
+    )
     resource_cap_patch = patch_task_cpu_cap_for_local_docker(
         staged_path / "task.toml",
         host_cpus=host_cpus,
@@ -8489,6 +8515,7 @@ def stage_task_for_sandbox(
             "codex_acp_runtime_tools_patch_applied": runtime_tools_patched,
             "empty_skills_build_context_required": empty_skills_context_required,
             "empty_skills_build_context_created": empty_skills_context_created,
+            "verifier_script_executable_ready": verifier_script_executable_ready,
             "app_skills_mount_target": "/app/skills",
             "original_task_mutated": False,
             "task_skills_removed": task_skills_removed,
@@ -8515,6 +8542,13 @@ def stage_task_for_sandbox(
         metadata[key] = value
     metadata.update(dockerfile_proxy_metadata)
     metadata.update(verifier_proxy_metadata)
+    if (
+        metadata.get("verifier_script_executable_required") is True
+        and metadata.get("verifier_script_executable_ready") is not True
+    ):
+        raise SkillsBenchSetupPreflightBlocked(
+            "skillsbench staged verifier script is not executable"
+        )
     if (
         metadata.get("benchmark_egress_proxy_verifier_env_patch_required") is True
         and metadata.get("benchmark_egress_proxy_verifier_env_patch_applied")

--- a/scripts/skillsbench_docker_command_file_bridge.py
+++ b/scripts/skillsbench_docker_command_file_bridge.py
@@ -303,20 +303,39 @@ class DockerCommandFileBridge:
         command = str(request.get("command") or "").strip()
         if not command:
             raise ValueError("command_missing")
+        return _json_response(
+            self._exec_response(
+                cwd=cwd,
+                command=command,
+                timeout_seconds=timeout_seconds,
+            )
+        )
+
+    def _exec_response(
+        self,
+        *,
+        cwd: str,
+        command: str,
+        timeout_seconds: int,
+    ) -> dict[str, Any]:
         capture_dir = f"{BRIDGE_TEMP_ROOT}/{uuid.uuid4().hex}.exec"
         stdout_path = capture_dir + "/stdout"
         stderr_path = capture_dir + "/stderr"
+        exit_code_path = capture_dir + "/exit_code"
         proc = self._compose_exec(
             "mkdir -p "
             + shlex.quote(capture_dir)
-            + " && timeout "
+            + " && { timeout "
             + shlex.quote(str(timeout_seconds))
             + " sh -lc "
             + shlex.quote(command)
             + " > "
             + shlex.quote(stdout_path)
             + " 2> "
-            + shlex.quote(stderr_path),
+            + shlex.quote(stderr_path)
+            + "; command_rc=$?; printf '%s\\n' \"$command_rc\" > "
+            + shlex.quote(exit_code_path)
+            + "; }",
             cwd=cwd,
             timeout_seconds=timeout_seconds,
         )
@@ -334,6 +353,13 @@ class DockerCommandFileBridge:
                 timeout_seconds=timeout_seconds,
             )
         )
+        exit_code_rc, exit_code_bytes, exit_code_copy_stderr = (
+            self._read_container_file_via_copy(
+                exit_code_path,
+                max_bytes=16,
+                timeout_seconds=timeout_seconds,
+            )
+        )
         self._remove_container_path(
             capture_dir,
             recursive=True,
@@ -343,28 +369,59 @@ class DockerCommandFileBridge:
             stdout_bytes, limit=MAX_CAPTURE_BYTES
         )
         stderr_source = stderr_bytes
-        if stdout_rc != 0 or stderr_rc != 0:
-            stderr_source += proc.stderr + stdout_copy_stderr + stderr_copy_stderr
+        try:
+            captured_exit_code = int(exit_code_bytes.decode("ascii").strip())
+            if not 0 <= captured_exit_code <= 255:
+                raise ValueError
+        except (UnicodeDecodeError, ValueError):
+            captured_exit_code = None
+        if (
+            proc.returncode != 0
+            or stdout_rc != 0
+            or stderr_rc != 0
+            or exit_code_rc != 0
+        ):
+            stderr_source += (
+                proc.stderr
+                + stdout_copy_stderr
+                + stderr_copy_stderr
+                + exit_code_copy_stderr
+            )
+        if exit_code_rc == 0 and captured_exit_code is None:
+            stderr_source += b"container exit status capture invalid\n"
         stderr, stderr_truncated = _bounded_text(
             stderr_source, limit=MAX_CAPTURE_BYTES
         )
-        capture_ok = stdout_rc == 0 and stderr_rc == 0
+        output_capture_ok = stdout_rc == 0 and stderr_rc == 0
+        status_capture_ok = exit_code_rc == 0 and captured_exit_code is not None
+        effective_exit_code = (
+            proc.returncode
+            if proc.returncode != 0
+            else captured_exit_code if captured_exit_code is not None else 1
+        )
         blocker = None
         if proc.returncode != 0:
             blocker = "exec_failed"
-        elif not capture_ok:
+        elif not status_capture_ok:
+            blocker = "exec_status_capture_failed"
+        elif not output_capture_ok:
             blocker = "exec_output_capture_failed"
-        return _json_response(
-            _operation_response(
-                ok=proc.returncode == 0 and capture_ok,
-                operation="exec",
-                first_blocker=blocker,
-                exit_code=proc.returncode,
-                stdout=stdout,
-                stderr=stderr,
-                stdout_truncated=stdout_truncated,
-                stderr_truncated=stderr_truncated,
-            )
+        elif effective_exit_code != 0:
+            blocker = "exec_failed"
+        return _operation_response(
+            ok=(
+                proc.returncode == 0
+                and output_capture_ok
+                and status_capture_ok
+                and effective_exit_code == 0
+            ),
+            operation="exec",
+            first_blocker=blocker,
+            exit_code=effective_exit_code,
+            stdout=stdout,
+            stderr=stderr,
+            stdout_truncated=stdout_truncated,
+            stderr_truncated=stderr_truncated,
         )
 
     def _run_read_file(self, request: dict[str, Any], timeout_seconds: int) -> int:
@@ -440,11 +497,9 @@ class DockerCommandFileBridge:
     def probe(self, timeout_seconds: int) -> tuple[list[dict[str, Any]], str | None]:
         probe_dir = BRIDGE_TEMP_ROOT
         marker = probe_dir + "/marker.txt"
-        exec_proc = self._compose_exec(
-            "mkdir -p "
-            + shlex.quote(probe_dir)
-            + " && test -d "
-            + shlex.quote(probe_dir),
+        exec_response = self._exec_response(
+            cwd="/tmp",
+            command="exit 7",
             timeout_seconds=timeout_seconds,
         )
         write_proc = self._compose_exec(
@@ -462,12 +517,17 @@ class DockerCommandFileBridge:
             timeout_seconds=timeout_seconds,
         )
         read_text, _ = _bounded_text(read_bytes, limit=MAX_CAPTURE_BYTES)
+        exit_status_roundtrip_ok = (
+            exec_response.get("ok") is False
+            and exec_response.get("first_blocker") == "exec_failed"
+            and exec_response.get("exit_code") == 7
+        )
         operations = [
             {
                 "kind": "exec",
-                "label": "bounded_noop_command",
-                "status": "ok" if exec_proc.returncode == 0 else "failed",
-                "exit_code_zero": exec_proc.returncode == 0,
+                "label": "nonzero_exit_status_roundtrip",
+                "status": "ok" if exit_status_roundtrip_ok else "failed",
+                "nonzero_exit_status_detected": exit_status_roundtrip_ok,
             },
             {
                 "kind": "write_file",

--- a/tests/test_skillsbench_docker_command_file_bridge.py
+++ b/tests/test_skillsbench_docker_command_file_bridge.py
@@ -79,6 +79,7 @@ def test_read_file_uses_bounded_docker_copy(monkeypatch, capsys) -> None:
 
 def test_exec_and_probe_do_not_depend_on_attached_stdout(monkeypatch, capsys) -> None:
     bridge = _bridge()
+    exit_codes = iter((b"0", b"7"))
 
     def fake_compose_exec(_shell_command, **_kwargs):
         return subprocess.CompletedProcess([], 0, b"", b"")
@@ -88,6 +89,8 @@ def test_exec_and_probe_do_not_depend_on_attached_stdout(monkeypatch, capsys) ->
             return 0, b"visible output\n", b""
         if path.endswith("/stderr"):
             return 0, b"", b""
+        if path.endswith("/exit_code"):
+            return 0, next(exit_codes), b""
         return 0, MARKER_CONTENT.encode(), b""
 
     monkeypatch.setattr(bridge, "_compose_exec", fake_compose_exec)
@@ -101,3 +104,34 @@ def test_exec_and_probe_do_not_depend_on_attached_stdout(monkeypatch, capsys) ->
     operations, blocker = bridge.probe(5)
     assert blocker is None
     assert all(operation["status"] == "ok" for operation in operations)
+
+
+def test_exec_recovers_container_exit_code_when_compose_reports_zero(
+    monkeypatch, capsys
+) -> None:
+    bridge = _bridge()
+    compose_commands: list[str] = []
+
+    def fake_compose_exec(shell_command, **_kwargs):
+        compose_commands.append(shell_command)
+        return subprocess.CompletedProcess([], 0, b"", b"")
+
+    def fake_read(path, **_kwargs):
+        if path.endswith("/stdout"):
+            return 0, b"", b""
+        if path.endswith("/stderr"):
+            return 0, b"command failed\n", b""
+        if path.endswith("/exit_code"):
+            return 0, b"7\n", b""
+        raise AssertionError(path)
+
+    monkeypatch.setattr(bridge, "_compose_exec", fake_compose_exec)
+    monkeypatch.setattr(bridge, "_read_container_file_via_copy", fake_read)
+
+    assert bridge._run_exec({"cwd": "/app", "command": "exit 7"}, 5) == 0
+    response = json.loads(capsys.readouterr().out)
+    assert response["ok"] is False
+    assert response["first_blocker"] == "exec_failed"
+    assert response["exit_code"] == 7
+    assert "command_rc=$?" in compose_commands[0]
+    assert "/exit_code" in compose_commands[0]


### PR DESCRIPTION
## Summary
- recover the command exit code from a container-side status file instead of trusting a broken Docker transport return code
- make the bridge preflight prove that a known nonzero exit is detected
- ensure staged verifier entrypoints remain executable after atomic text patches

## Validation
- `uv run --with pytest pytest -q tests/test_skillsbench_docker_command_file_bridge.py` (4 passed)
- `uv run python examples/skillsbench-benchmark-run-smoke.py`
- `uv run python examples/skillsbench-host-local-launch-plan-smoke.py`
- `uv run python examples/skillsbench-runner-core-contract-smoke.py`
- `uv run python examples/skillsbench-benchmark-egress-policy-smoke.py`
- real remote Docker probe: success returned 0/stdout; known failure returned 7/exec_failed despite transport reporting success
- `loopx canary premerge --from-git-diff`: all selected checks passed; expected benchmark-sensitive manual hold remains

## Boundaries
No scoring, task semantics, uploads, submissions, raw task material, trajectories, verifier output, credentials, or private paths are changed or included.