### PR TITLE
Scope peer hierarchy boundary tokens

### DIFF
--- a/examples/control_plane/peer-agent-hard-cut-boundary-smoke.py
+++ b/examples/control_plane/peer-agent-hard-cut-boundary-smoke.py
@@ -37,7 +37,8 @@ ALLOWED_LEGACY_PATHS = {
     REPO_ROOT / "docs" / "product" / "agent-profile-contract.md",
 }
 LEGACY_PATTERN = re.compile(
-    r"primary_agent|primary_review|side_agent|handoff_agent|agent_profile_v0|primary_checkout|"
+    r"\bprimary_agent\b|\bprimary_review\b|\bside_agent\b|\bhandoff_agent\b|"
+    r"\bagent_profile_v0\b|\bprimary_checkout\b|"
     r"\bprimary agent\b|\bside agent\b|\bside-agent\b|\bmain controller\b|"
     r"controller/sub-agent|controller-subagent|controller owns|"
     r'"role"\s*:\s*"(?:controller|subagent)"',
@@ -59,6 +60,18 @@ def candidate_files() -> list[Path]:
 
 
 def main() -> int:
+    for token in (
+        "primary_agent",
+        "primary_review",
+        "side_agent",
+        "handoff_agent",
+        "agent_profile_v0",
+        "primary_checkout",
+    ):
+        assert LEGACY_PATTERN.search(token), token
+    for domain_term in ("primary_reviewers", "primary_review_score"):
+        assert not LEGACY_PATTERN.search(domain_term), domain_term
+
     violations: list[str] = []
     for path in candidate_files():
         if path in ALLOWED_LEGACY_PATHS:


### PR DESCRIPTION
## Summary
- constrain peer hard-cut identifier matching to whole hierarchy tokens
- allow unrelated domain fields such as `primary_reviewers`
- lock both rejected hierarchy tokens and accepted domain terms with direct assertions

## Validation
- `python3 examples/control_plane/peer-agent-hard-cut-boundary-smoke.py`
- `python3 examples/control_plane/peer-agent-runtime-v1-smoke.py`
- `loopx check`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `loopx canary premerge --from-git-diff --timeout-seconds 180` (6/6 selected checks; self-merge allowed)
- `git diff --check`

## Boundary
- one durable smoke file only
- no runtime behavior, private state, credentials, local paths, or generated evidence
