### PR TITLE
Wait for real container command completion

### DIFF
--- a/loopx/benchmark_core/__init__.py
+++ b/loopx/benchmark_core/__init__.py
@@ -29,6 +29,11 @@ from .artifacts import (
     filter_public_benchmark_artifact_paths,
     materialize_public_benchmark_artifacts,
 )
+from .container_exec import (
+    parse_container_exit_status,
+    run_container_command_with_exit_status,
+    wrap_container_command_with_exit_status,
+)
 from .lifecycle import (
     BENCHMARK_CANONICAL_LIFECYCLE_SCHEMA_VERSION,
     BENCHMARK_LIFECYCLE_STATE_SCHEMA_VERSION,
@@ -181,10 +186,12 @@ __all__ = [
     "MAX5_BLIND_LOOP_NO_FEEDBACK_PROTOCOL_ID",
     "Observation",
     "PACKET_ONLY_OBSERVATION_PROTOCOL_ID",
+    "parse_container_exit_status",
     "PRODUCT_MODE_MAX5_NO_FEEDBACK_PROTOCOL_ID",
     "PreflightResult",
     "RoundReward",
     "RunHandle",
+    "run_container_command_with_exit_status",
     "RUN_PERMISSION_POLICY_SCHEMA_VERSION",
     "RUN_PERMISSION_QUOTA_PROJECTION_SCHEMA_VERSION",
     "RunPermissionAction",
@@ -202,4 +209,5 @@ __all__ = [
     "summarize_round_rewards",
     "validate_run_permission_policy",
     "validate_benchmark_route_profile",
+    "wrap_container_command_with_exit_status",
 ]

--- a/loopx/benchmark_core/container_exec.py
+++ b/loopx/benchmark_core/container_exec.py
@@ -1,0 +1,104 @@
+"""Container command completion markers shared by benchmark runners."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import re
+import shlex
+import time
+import uuid
+from collections.abc import Awaitable, Callable, Mapping
+from pathlib import PurePosixPath
+from typing import Any
+
+
+_EXIT_STATUS_PATTERN = re.compile(r"^[0-9]{1,3}$")
+
+
+def wrap_container_command_with_exit_status(command: str, status_path: str) -> str:
+    """Run *command* in a subshell and atomically leave its exit status behind."""
+
+    parent = str(PurePosixPath(status_path).parent)
+    return (
+        f"mkdir -p {shlex.quote(parent)} && {{ "
+        f"( {command} ); loopx_command_rc=$?; "
+        f"printf '%s\\n' \"$loopx_command_rc\" > {shlex.quote(status_path)}; "
+        'exit "$loopx_command_rc"; }'
+    )
+
+
+def parse_container_exit_status(payload: bytes | str | None) -> int | None:
+    """Return a valid POSIX shell exit status from a completion marker."""
+
+    if isinstance(payload, bytes):
+        try:
+            text = payload.decode("ascii")
+        except UnicodeDecodeError:
+            return None
+    elif isinstance(payload, str):
+        text = payload
+    else:
+        return None
+    text = text.strip()
+    if not _EXIT_STATUS_PATTERN.fullmatch(text):
+        return None
+    value = int(text)
+    return value if 0 <= value <= 255 else None
+
+
+async def run_container_command_with_exit_status(
+    exec_fn: Callable[..., Awaitable[Any]],
+    command: str,
+    *,
+    timeout_sec: float,
+    exec_args: tuple[Any, ...] = (),
+    exec_kwargs: Mapping[str, Any] | None = None,
+    poll_interval_sec: float = 0.5,
+) -> Any:
+    """Run a container command and wait for its side-channel completion marker."""
+
+    status_path = (
+        "/tmp/loopx-benchmark-exec-status/"
+        f"{uuid.uuid4().hex}.status"
+    )
+    kwargs = dict(exec_kwargs or {})
+    kwargs["timeout_sec"] = timeout_sec
+    service = kwargs.get("service", "main")
+    deadline = time.monotonic() + timeout_sec
+    try:
+        result = await exec_fn(
+            wrap_container_command_with_exit_status(command, status_path),
+            *exec_args,
+            **kwargs,
+        )
+        captured_exit_code = None
+        while captured_exit_code is None:
+            remaining = deadline - time.monotonic()
+            probe = await exec_fn(
+                f"cat {shlex.quote(status_path)} 2>/dev/null",
+                timeout_sec=max(1.0, min(10.0, max(remaining, 1.0))),
+                user="root",
+                service=service,
+            )
+            captured_exit_code = parse_container_exit_status(
+                getattr(probe, "stdout", None)
+            )
+            if captured_exit_code is None:
+                if remaining <= 0:
+                    raise asyncio.TimeoutError(
+                        "container completion marker timed out"
+                    )
+                await asyncio.sleep(min(poll_interval_sec, remaining))
+        if hasattr(result, "model_copy"):
+            return result.model_copy(update={"return_code": captured_exit_code})
+        setattr(result, "return_code", captured_exit_code)
+        return result
+    finally:
+        with contextlib.suppress(Exception):
+            await exec_fn(
+                f"rm -f {shlex.quote(status_path)}",
+                timeout_sec=10,
+                user="root",
+                service=service,
+            )

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -138,6 +138,7 @@ from loopx.benchmark_core import (  # noqa: E402
     build_benchmark_launch_observable_handle,
     canonical_lifecycle,
     compact_benchmark_canonical_lifecycle,
+    run_container_command_with_exit_status,
     write_benchmark_run_observable_status,
 )
 from loopx.benchmark_core.loop_protocol import (  # noqa: E402
@@ -2682,6 +2683,10 @@ def _public_runner_prerequisites(value: Any) -> dict[str, Any]:
         "benchflow_final_verifier_timeout_triggered",
         "benchflow_final_verifier_timeout_raw_command_recorded",
         "benchflow_final_verifier_timeout_raw_output_recorded",
+        "benchflow_verifier_completion_poll_enabled",
+        "benchflow_verifier_completion_poll_timeout_triggered",
+        "benchflow_verifier_completion_poll_raw_command_recorded",
+        "benchflow_verifier_completion_poll_raw_output_recorded",
         "benchflow_setup_stall_timeout_enabled",
         "benchflow_setup_stall_timeout_triggered",
         "benchflow_setup_stall_raw_logs_read",
@@ -3514,6 +3519,10 @@ def install_benchflow_verifier_prep_timeout_override(
     prerequisites["benchflow_verifier_prep_timeout_raw_command_recorded"] = False
     prerequisites["benchflow_final_verifier_timeout_enabled"] = final_timeout_enabled
     prerequisites["benchflow_final_verifier_timeout_raw_command_recorded"] = False
+    prerequisites["benchflow_verifier_completion_poll_enabled"] = False
+    prerequisites["benchflow_verifier_completion_poll_timeout_triggered"] = False
+    prerequisites["benchflow_verifier_completion_poll_raw_command_recorded"] = False
+    prerequisites["benchflow_verifier_completion_poll_raw_output_recorded"] = False
     prerequisites["benchflow_intermediate_soft_verify_timeout_enabled"] = (
         soft_timeout_enabled
     )
@@ -3535,6 +3544,10 @@ def install_benchflow_verifier_prep_timeout_override(
         trace["benchflow_verifier_prep_timeout_raw_command_recorded"] = False
         trace["benchflow_final_verifier_timeout_enabled"] = final_timeout_enabled
         trace["benchflow_final_verifier_timeout_raw_command_recorded"] = False
+        trace["benchflow_verifier_completion_poll_enabled"] = False
+        trace["benchflow_verifier_completion_poll_timeout_triggered"] = False
+        trace["benchflow_verifier_completion_poll_raw_command_recorded"] = False
+        trace["benchflow_verifier_completion_poll_raw_output_recorded"] = False
         trace["benchflow_intermediate_soft_verify_timeout_enabled"] = (
             soft_timeout_enabled
         )
@@ -3602,7 +3615,51 @@ def install_benchflow_verifier_prep_timeout_override(
                     kwargs = dict(kwargs)
                     kwargs["timeout_sec"] = soft_verifier_timeout_sec
                     soft_timeout_override_count += 1
-            return await original_exec(*args, **kwargs)
+            verifier_exec = _looks_like_final_verifier_exec(args, kwargs)
+            try:
+                completion_timeout = float(kwargs.get("timeout_sec") or 0)
+            except (TypeError, ValueError):
+                completion_timeout = 0
+            docker_completion_poll = (
+                verifier_exec
+                and hasattr(env, "_run_docker_compose_command")
+                and completion_timeout > 0
+            )
+            if not docker_completion_poll:
+                return await original_exec(*args, **kwargs)
+
+            command = kwargs.get("command")
+            positional_command = command is None and bool(args)
+            if command is None and positional_command:
+                command = args[0]
+            if not isinstance(command, str):
+                return await original_exec(*args, **kwargs)
+
+            call_kwargs = dict(kwargs)
+            call_kwargs.pop("command", None)
+            call_args = args[1:] if positional_command else args
+
+            prerequisites["benchflow_verifier_completion_poll_enabled"] = True
+            if isinstance(trace, dict):
+                trace["benchflow_verifier_completion_poll_enabled"] = True
+
+            try:
+                return await run_container_command_with_exit_status(
+                    original_exec,
+                    command,
+                    timeout_sec=completion_timeout,
+                    exec_args=call_args,
+                    exec_kwargs=call_kwargs,
+                )
+            except asyncio.TimeoutError:
+                prerequisites[
+                    "benchflow_verifier_completion_poll_timeout_triggered"
+                ] = True
+                if isinstance(trace, dict):
+                    trace[
+                        "benchflow_verifier_completion_poll_timeout_triggered"
+                    ] = True
+                raise
 
         phase_timeout_sec = 0
         if phase == "verify" and final_timeout_enabled:
@@ -4201,6 +4258,14 @@ def _runner_prerequisite_failure_attribution(
         return label, label, [
             label,
             "skillsbench_compact_closeout_recorded",
+            "skillsbench_runner_error",
+        ]
+
+    if value.get("benchflow_verifier_completion_poll_timeout_triggered") is True:
+        label = "skillsbench_verifier_completion_timeout"
+        return label, label, [
+            label,
+            "skillsbench_verifier_timeout",
             "skillsbench_runner_error",
         ]
 

--- a/scripts/skillsbench_docker_command_file_bridge.py
+++ b/scripts/skillsbench_docker_command_file_bridge.py
@@ -17,6 +17,7 @@ import shlex
 import subprocess
 import sys
 import tempfile
+import time
 import uuid
 from pathlib import Path
 from typing import Any
@@ -29,6 +30,10 @@ if str(REPO_ROOT) not in sys.path:
 from loopx.benchmark_adapters.skillsbench_remote_bridge import (  # noqa: E402
     SKILLSBENCH_REMOTE_COMMAND_FILE_BRIDGE_PROBE_REQUEST_SCHEMA_VERSION,
     build_skillsbench_remote_command_file_bridge_probe_response,
+)
+from loopx.benchmark_core.container_exec import (  # noqa: E402
+    parse_container_exit_status,
+    wrap_container_command_with_exit_status,
 )
 
 
@@ -322,10 +327,8 @@ class DockerCommandFileBridge:
         stdout_path = capture_dir + "/stdout"
         stderr_path = capture_dir + "/stderr"
         exit_code_path = capture_dir + "/exit_code"
-        proc = self._compose_exec(
-            "mkdir -p "
-            + shlex.quote(capture_dir)
-            + " && { timeout "
+        captured_command = (
+            "timeout "
             + shlex.quote(str(timeout_seconds))
             + " sh -lc "
             + shlex.quote(command)
@@ -333,12 +336,36 @@ class DockerCommandFileBridge:
             + shlex.quote(stdout_path)
             + " 2> "
             + shlex.quote(stderr_path)
-            + "; command_rc=$?; printf '%s\\n' \"$command_rc\" > "
-            + shlex.quote(exit_code_path)
-            + "; }",
+        )
+        started_at = time.monotonic()
+        proc = self._compose_exec(
+            wrap_container_command_with_exit_status(
+                captured_command,
+                exit_code_path,
+            ),
             cwd=cwd,
             timeout_seconds=timeout_seconds,
         )
+        deadline = started_at + timeout_seconds + 2
+        exit_code_rc = 1
+        exit_code_bytes = b""
+        exit_code_copy_stderr = b"container exit status capture unavailable"
+        captured_exit_code = None
+        while captured_exit_code is None:
+            remaining = deadline - time.monotonic()
+            exit_code_rc, exit_code_bytes, exit_code_copy_stderr = (
+                self._read_container_file_via_copy(
+                    exit_code_path,
+                    max_bytes=16,
+                    timeout_seconds=max(1, min(5, int(max(remaining, 1)))),
+                )
+            )
+            if exit_code_rc == 0:
+                captured_exit_code = parse_container_exit_status(exit_code_bytes)
+            if captured_exit_code is None:
+                if remaining <= 0:
+                    break
+                time.sleep(min(0.5, max(0.0, remaining)))
         stdout_rc, stdout_bytes, stdout_copy_stderr = (
             self._read_container_file_via_copy(
                 stdout_path,
@@ -353,13 +380,6 @@ class DockerCommandFileBridge:
                 timeout_seconds=timeout_seconds,
             )
         )
-        exit_code_rc, exit_code_bytes, exit_code_copy_stderr = (
-            self._read_container_file_via_copy(
-                exit_code_path,
-                max_bytes=16,
-                timeout_seconds=timeout_seconds,
-            )
-        )
         self._remove_container_path(
             capture_dir,
             recursive=True,
@@ -369,12 +389,6 @@ class DockerCommandFileBridge:
             stdout_bytes, limit=MAX_CAPTURE_BYTES
         )
         stderr_source = stderr_bytes
-        try:
-            captured_exit_code = int(exit_code_bytes.decode("ascii").strip())
-            if not 0 <= captured_exit_code <= 255:
-                raise ValueError
-        except (UnicodeDecodeError, ValueError):
-            captured_exit_code = None
         if (
             proc.returncode != 0
             or stdout_rc != 0
@@ -387,7 +401,7 @@ class DockerCommandFileBridge:
                 + stderr_copy_stderr
                 + exit_code_copy_stderr
             )
-        if exit_code_rc == 0 and captured_exit_code is None:
+        if captured_exit_code is None:
             stderr_source += b"container exit status capture invalid\n"
         stderr, stderr_truncated = _bounded_text(
             stderr_source, limit=MAX_CAPTURE_BYTES

--- a/tests/test_skillsbench_docker_command_file_bridge.py
+++ b/tests/test_skillsbench_docker_command_file_bridge.py
@@ -5,6 +5,7 @@ import subprocess
 from pathlib import Path
 
 import scripts.skillsbench_docker_command_file_bridge as bridge_module
+from loopx.benchmark_core.container_exec import parse_container_exit_status
 from scripts.skillsbench_docker_command_file_bridge import (
     MARKER_CONTENT,
     DockerCommandFileBridge,
@@ -18,6 +19,14 @@ def _bridge() -> DockerCommandFileBridge:
         compose_files=["/tmp/demo-project/compose.yaml"],
         service="main",
     )
+
+
+def test_container_exit_status_parser_fails_closed() -> None:
+    assert parse_container_exit_status(b"0\n") == 0
+    assert parse_container_exit_status("255") == 255
+    assert parse_container_exit_status(b"") is None
+    assert parse_container_exit_status(b"256") is None
+    assert parse_container_exit_status(b"not-a-status") is None
 
 
 def test_resolve_container_id_uses_compose_labels(monkeypatch) -> None:
@@ -127,11 +136,50 @@ def test_exec_recovers_container_exit_code_when_compose_reports_zero(
 
     monkeypatch.setattr(bridge, "_compose_exec", fake_compose_exec)
     monkeypatch.setattr(bridge, "_read_container_file_via_copy", fake_read)
+    completion_times = iter((0.0, 20.0))
+    monkeypatch.setattr(
+        bridge_module.time,
+        "monotonic",
+        lambda: next(completion_times),
+    )
 
     assert bridge._run_exec({"cwd": "/app", "command": "exit 7"}, 5) == 0
     response = json.loads(capsys.readouterr().out)
     assert response["ok"] is False
     assert response["first_blocker"] == "exec_failed"
     assert response["exit_code"] == 7
-    assert "command_rc=$?" in compose_commands[0]
+    assert "loopx_command_rc=$?" in compose_commands[0]
     assert "/exit_code" in compose_commands[0]
+
+
+def test_exec_waits_for_delayed_container_exit_status(monkeypatch, capsys) -> None:
+    bridge = _bridge()
+    status_reads = 0
+
+    def fake_compose_exec(_shell_command, **_kwargs):
+        return subprocess.CompletedProcess([], 0, b"", b"")
+
+    def fake_read(path, **_kwargs):
+        nonlocal status_reads
+        if path.endswith("/exit_code"):
+            status_reads += 1
+            if status_reads < 3:
+                return 1, b"", b"status pending"
+            return 0, b"7\n", b""
+        if path.endswith("/stdout"):
+            return 0, b"", b""
+        if path.endswith("/stderr"):
+            return 0, b"late failure\n", b""
+        raise AssertionError(path)
+
+    monkeypatch.setattr(bridge, "_compose_exec", fake_compose_exec)
+    monkeypatch.setattr(bridge, "_read_container_file_via_copy", fake_read)
+    monkeypatch.setattr(bridge_module.time, "sleep", lambda _seconds: None)
+
+    assert bridge._run_exec({"cwd": "/app", "command": "exit 7"}, 5) == 0
+    response = json.loads(capsys.readouterr().out)
+    assert status_reads == 3
+    assert response["ok"] is False
+    assert response["first_blocker"] == "exec_failed"
+    assert response["exit_code"] == 7
+    assert response["stderr"] == "late failure\n"

--- a/tests/test_skillsbench_verifier_completion.py
+++ b/tests/test_skillsbench_verifier_completion.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import types
+from typing import Any
+
+import loopx.benchmark_core.container_exec as container_exec_module
+from scripts.skillsbench_automation_loop import (
+    install_benchflow_verifier_prep_timeout_override,
+)
+
+
+def test_final_verifier_waits_for_container_completion_marker(monkeypatch) -> None:
+    class FakeDockerEnv:
+        _run_docker_compose_command = object()
+
+        def __init__(self) -> None:
+            self.calls: list[tuple[str, dict[str, Any]]] = []
+
+        async def exec(self, command: str, **kwargs: Any) -> Any:
+            self.calls.append((command, dict(kwargs)))
+            if command.startswith("cat "):
+                return types.SimpleNamespace(stdout="7\n", return_code=0)
+            return types.SimpleNamespace(stdout=None, return_code=0)
+
+    class FakeRollout:
+        def __init__(self) -> None:
+            self._env = FakeDockerEnv()
+
+        async def verify(self) -> Any:
+            return await self._env.exec("/verifier/test.sh", timeout_sec=9999)
+
+        async def soft_verify(self) -> None:
+            return None
+
+    rollout = FakeRollout()
+    completion_times = iter((0.0, 3.0))
+    monkeypatch.setattr(
+        container_exec_module,
+        "time",
+        types.SimpleNamespace(monotonic=lambda: next(completion_times)),
+    )
+    plan = {"runner_prerequisites": {}}
+    trace: dict[str, Any] = {}
+    original_verify, original_soft_verify = install_benchflow_verifier_prep_timeout_override(
+        FakeRollout,
+        timeout_sec=120,
+        final_verifier_timeout_sec=2,
+        plan=plan,
+        trace=trace,
+    )
+    try:
+        result = asyncio.run(rollout.verify())
+    finally:
+        FakeRollout.verify = original_verify
+        FakeRollout.soft_verify = original_soft_verify
+
+    assert result.return_code == 7
+    assert "/verifier/test.sh" in rollout._env.calls[0][0]
+    assert "loopx_command_rc=$?" in rollout._env.calls[0][0]
+    assert rollout._env.calls[0][1]["timeout_sec"] == 2
+    assert rollout._env.calls[1][0].startswith("cat ")
+    assert rollout._env.calls[-1][0].startswith("rm -f ")
+    prereqs = plan["runner_prerequisites"]
+    assert prereqs["benchflow_verifier_completion_poll_enabled"] is True
+    assert prereqs["benchflow_verifier_completion_poll_raw_command_recorded"] is False
+    assert prereqs["benchflow_verifier_completion_poll_raw_output_recorded"] is False
+    assert "test.sh" not in json.dumps(prereqs)


### PR DESCRIPTION
## Summary
- add a small benchmark-core container completion-marker contract
- make the Docker command/file bridge poll that marker before collecting output
- make BenchFlow final and soft verifier execution wait for the same marker before parsing reward artifacts
- fail closed with explicit completion-timeout evidence

## Root cause
The affected Docker transport can return success before a longer container command has finished. This truncated verifier execution before `reward.txt` existed and also made bridge output/status reads race the running command.

## Validation
- `uv run --with pytest pytest -q tests/test_skillsbench_docker_command_file_bridge.py tests/test_skillsbench_verifier_completion.py` (7 passed)
- full SkillsBench benchmark-run smoke
- host-local launch-plan, runner-core, benchmark-core adapter, and egress-policy smokes
- repo Python line-budget smoke
- real remote Docker: a two-second success waited and returned full stdout/0; a two-second failure waited and returned full stdout/7 even though the transport previously returned early
- `loopx canary premerge --from-git-diff`: all selected checks passed; expected benchmark-sensitive manual hold remains

## Boundaries
No scoring or task semantics change. No uploads, submissions, task material, trajectories, verifier output, credentials, private paths, or proxy values are included.