### PR TITLE
Restore Explore and peer review public smokes

### DIFF
--- a/examples/control_plane/review-packet-smoke.py
+++ b/examples/control_plane/review-packet-smoke.py
@@ -111,7 +111,7 @@ def build_sanitized_approved_command_packet() -> str:
             "",
             "【用户/Gate】",
             "待办：无",
-            "Gate：无；建议：直接转发给项目 Agent；不追加写权限、主控接管或生产动作授权。",
+            "Gate：无；建议：直接转发给已认领的项目 Agent；不追加写权限、全局接管或生产动作授权。",
             "边界：只执行已批准的只读/dry-run agent_command；如需写入或更高权限，项目 Agent 必须再次停下。",
             "",
             "【给项目 Agent】",
@@ -184,7 +184,7 @@ def main() -> int:
     assert "Status/history inspection only" in packet_builder
     assert "保持 focus_wait 并用中文回报仍在等待什么" in packet_builder
     assert "不执行交付路径、写入、reward append 或生产动作" in packet_builder
-    assert "直接转发给项目 Agent；不追加写权限、主控接管或生产动作授权。" in packet_builder
+    assert "直接转发给已认领的项目 Agent；不追加写权限、全局接管或生产动作授权。" in packet_builder
     assert "只执行已批准的只读/dry-run agent_command" in packet_builder
     assert "Approved agent command" in packet_builder
     assert_order(action_packet_source, ["【GH Packet】", "【用户/Gate】", "【给项目 Agent】"])
@@ -311,7 +311,7 @@ def main() -> int:
         approved_packet,
         [
             "【用户/Gate】",
-            "Gate：无；建议：直接转发给项目 Agent",
+            "Gate：无；建议：直接转发给已认领的项目 Agent",
             "只执行已批准的只读/dry-run agent_command",
             "【给项目 Agent】",
             "Approved agent command",
@@ -319,7 +319,7 @@ def main() -> int:
     )
     assert "同意让 Codex 沿 safe path 继续" not in approved_packet, approved_packet
     assert "如果下一步需要写入、reward append、approval" not in approved_packet, approved_packet
-    assert "不追加写权限、主控接管或生产动作授权" in approved_packet, approved_packet
+    assert "不追加写权限、全局接管或生产动作授权" in approved_packet, approved_packet
     assert len(approved_packet.splitlines()) <= 18, approved_packet
 
     focus_wait_packet = build_sanitized_focus_wait_packet()

--- a/loopx/cli_commands/explore.py
+++ b/loopx/cli_commands/explore.py
@@ -27,10 +27,8 @@ from ..capabilities.explore.todo_branch_plan import (
     resolve_todo_branch_plan_gate,
 )
 from ..capabilities.explore.worker_branch_plan import (
-    DEFAULT_WORKER_HARNESS_PROFILE,
     build_explore_worker_branch_plan,
     resolve_explore_harness_gate,
-    worker_harness_profile_names,
 )
 from ..presentation.sinks.lark.explore_results import (
     DEFAULT_EXPLORE_BASE_NAME,
@@ -49,6 +47,7 @@ from ..presentation.sinks.lark.kanban import DEFAULT_CLI_BIN
 from ..history import load_registry
 from ..paths import resolve_runtime_root
 from ..todos import list_goal_todos
+from .explore_planning_commands import register_explore_planning_commands
 
 
 PrintPayload = Callable[
@@ -154,118 +153,10 @@ def register_explore_commands(
     )
     graph.add_argument("--out", help="Also write the graph to this local file.")
 
-    branch_plan = sub.add_parser(
-        "todo-branch-plan",
-        help=(
-            "Experimentally rank multiple open agent todos as CPU-style predicted "
-            "exploration branches. Read-only; emits commands but does not execute them."
-        ),
-    )
-    add_subcommand_format(branch_plan)
-    branch_plan.add_argument("--goal-id", required=True)
-    _add_projection_limit_args(branch_plan)
-    branch_plan.add_argument("--agent-id", help="Prefer this agent's claimed todos, then unclaimed todos.")
-    branch_plan.add_argument("--width", type=int, default=3, help="Maximum predicted branch issue width.")
-    branch_plan.add_argument(
-        "--scheduler-strategy",
-        choices=["dspark"],
-        default="dspark",
-        help="Use DSpark-style confidence scheduled verification.",
-    )
-    branch_plan.add_argument(
-        "--scheduler-load",
-        type=float,
-        default=0.2,
-        help="0..1 load factor for DSpark-style verification-budget scheduling.",
-    )
-    branch_plan.add_argument(
-        "--allow-unscoped-parallel",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help=(
-            "Treat todos without declared write scopes as speculative read/coordination "
-            "branches. Disable to select only one unscoped branch."
-        ),
-    )
-
-    worker_branch_plan = sub.add_parser(
-        "worker-branch-plan",
-        help=(
-            "Experimentally group open LoopX todos into worker-lane branches. "
-            "Read-only; emits LoopX claim/lease suggestions but launches no workers."
-        ),
-    )
-    add_subcommand_format(worker_branch_plan)
-    worker_branch_plan.add_argument("--goal-id", required=True)
-    _add_projection_limit_args(worker_branch_plan)
-    worker_branch_plan.add_argument("--agent-id", help="Prefer this agent's claimed todos, then unclaimed todos.")
-    worker_branch_plan.add_argument(
-        "--harness-profile",
-        choices=worker_harness_profile_names(),
-        default=DEFAULT_WORKER_HARNESS_PROFILE,
-        help=(
-            "Harness design profile. adaptive-resilient captures the best observed "
-            "long-horizon traits without forcing N, duration, or full branch fill."
-        ),
-    )
-    worker_branch_plan.add_argument(
-        "--worker-width",
-        type=int,
-        default=3,
-        help="Maximum predicted worker lanes; the planner may select fewer.",
-    )
-    worker_branch_plan.add_argument(
-        "--max-todos-per-branch",
-        type=int,
-        default=None,
-        help=(
-            "Optional safety ceiling for LoopX todos bundled into one worker lane. "
-            "When omitted, adaptive profiles choose bundle size from marginal value."
-        ),
-    )
-    worker_branch_plan.add_argument(
-        "--branch-fill-policy",
-        choices=["bundle-by-affinity", "value-first"],
-        help=(
-            "bundle-by-affinity chunks related todos up to the ceiling; value-first "
-            "only adds lower-ranked todos when their marginal score clears the floor."
-        ),
-    )
-    worker_branch_plan.add_argument(
-        "--marginal-score-floor",
-        type=float,
-        help="For value-first fill, require added todos to meet this fraction of the seed score.",
-    )
-    worker_branch_plan.add_argument(
-        "--scheduler-load",
-        type=float,
-        default=0.2,
-        help=(
-            "0..1 fallback load factor for worker-lane scheduling; superseded by "
-            "--load-profile observations when provided."
-        ),
-    )
-    worker_branch_plan.add_argument(
-        "--allow-unscoped-parallel",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help="Allow multiple worker lanes whose todos do not declare write scopes.",
-    )
-    worker_branch_plan.add_argument(
-        "--router-state",
-        help=(
-            "Path to a loopx_explore_router_state_v0 JSON file with cross-epoch "
-            "per-family routing statistics (used by router-enabled profiles such "
-            "as moe-router; maintained by the runner between epochs)."
-        ),
-    )
-    worker_branch_plan.add_argument(
-        "--load-profile",
-        help=(
-            "Path to a JSON file with observed parallel timings "
-            "(parallel_wall_minutes, max_branch_minutes, branch_count) used to "
-            "calibrate the lane-admission load factor from measurements."
-        ),
+    register_explore_planning_commands(
+        sub,
+        add_subcommand_format,
+        _add_projection_limit_args,
     )
 
     setup = sub.add_parser(

--- a/loopx/cli_commands/explore_planning_commands.py
+++ b/loopx/cli_commands/explore_planning_commands.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import argparse
+from typing import Callable
+
+from ..capabilities.explore.worker_branch_plan import (
+    DEFAULT_WORKER_HARNESS_PROFILE,
+    worker_harness_profile_names,
+)
+
+
+def register_explore_planning_commands(
+    subparsers: argparse._SubParsersAction,
+    add_subcommand_format: Callable[[argparse.ArgumentParser], None],
+    add_projection_limit_args: Callable[[argparse.ArgumentParser], None],
+) -> None:
+    branch_plan = subparsers.add_parser(
+        "todo-branch-plan",
+        help=(
+            "Experimentally rank multiple open agent todos as CPU-style predicted "
+            "exploration branches. Read-only; emits commands but does not execute them."
+        ),
+    )
+    add_subcommand_format(branch_plan)
+    branch_plan.add_argument("--goal-id", required=True)
+    add_projection_limit_args(branch_plan)
+    branch_plan.add_argument("--agent-id", help="Prefer this agent's claimed todos, then unclaimed todos.")
+    branch_plan.add_argument("--width", type=int, default=3, help="Maximum predicted branch issue width.")
+    branch_plan.add_argument(
+        "--scheduler-strategy",
+        choices=["dspark"],
+        default="dspark",
+        help="Use DSpark-style confidence scheduled verification.",
+    )
+    branch_plan.add_argument(
+        "--scheduler-load",
+        type=float,
+        default=0.2,
+        help="0..1 load factor for DSpark-style verification-budget scheduling.",
+    )
+    branch_plan.add_argument(
+        "--allow-unscoped-parallel",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Treat todos without declared write scopes as speculative read/coordination "
+            "branches. Disable to select only one unscoped branch."
+        ),
+    )
+
+    worker_branch_plan = subparsers.add_parser(
+        "worker-branch-plan",
+        help=(
+            "Experimentally group open LoopX todos into worker-lane branches. "
+            "Read-only; emits LoopX claim/lease suggestions but launches no workers."
+        ),
+    )
+    add_subcommand_format(worker_branch_plan)
+    worker_branch_plan.add_argument("--goal-id", required=True)
+    add_projection_limit_args(worker_branch_plan)
+    worker_branch_plan.add_argument(
+        "--agent-id",
+        help="Prefer this agent's claimed todos, then unclaimed todos.",
+    )
+    worker_branch_plan.add_argument(
+        "--harness-profile",
+        choices=worker_harness_profile_names(),
+        default=DEFAULT_WORKER_HARNESS_PROFILE,
+        help=(
+            "Harness design profile. adaptive-resilient captures the best observed "
+            "long-horizon traits without forcing N, duration, or full branch fill."
+        ),
+    )
+    worker_branch_plan.add_argument(
+        "--worker-width",
+        type=int,
+        default=3,
+        help="Maximum predicted worker lanes; the planner may select fewer.",
+    )
+    worker_branch_plan.add_argument(
+        "--max-todos-per-branch",
+        type=int,
+        default=None,
+        help=(
+            "Optional safety ceiling for LoopX todos bundled into one worker lane. "
+            "When omitted, adaptive profiles choose bundle size from marginal value."
+        ),
+    )
+    worker_branch_plan.add_argument(
+        "--branch-fill-policy",
+        choices=["bundle-by-affinity", "value-first"],
+        help=(
+            "bundle-by-affinity chunks related todos up to the ceiling; value-first "
+            "only adds lower-ranked todos when their marginal score clears the floor."
+        ),
+    )
+    worker_branch_plan.add_argument(
+        "--marginal-score-floor",
+        type=float,
+        help="For value-first fill, require added todos to meet this fraction of the seed score.",
+    )
+    worker_branch_plan.add_argument(
+        "--scheduler-load",
+        type=float,
+        default=0.2,
+        help=(
+            "0..1 fallback load factor for worker-lane scheduling; superseded by "
+            "--load-profile observations when provided."
+        ),
+    )
+    worker_branch_plan.add_argument(
+        "--allow-unscoped-parallel",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Allow multiple worker lanes whose todos do not declare write scopes.",
+    )
+    worker_branch_plan.add_argument(
+        "--router-state",
+        help=(
+            "Path to a loopx_explore_router_state_v0 JSON file with cross-epoch "
+            "per-family routing statistics (used by router-enabled profiles such "
+            "as moe-router; maintained by the runner between epochs)."
+        ),
+    )
+    worker_branch_plan.add_argument(
+        "--load-profile",
+        help=(
+            "Path to a JSON file with observed parallel timings "
+            "(parallel_wall_minutes, max_branch_minutes, branch_count) used to "
+            "calibrate the lane-admission load factor from measurements."
+        ),
+    )


### PR DESCRIPTION
## Summary
- extract the two experimental Explore planning command registrations into a cohesive 132-line helper, reducing `explore.py` from 825 to 716 lines without widening its 800-line budget
- align the review-packet smoke with the shipped peer wording (`claimed agent`, `global takeover`) while retaining the no-write/no-production permission boundary
- preserve all parser defaults and execution paths by injecting the existing projection-limit argument registrar instead of duplicating it

## Main CI failures addressed
- `cli-command-module-size-ownership-command-modularization-smoke.py`: `explore.py has 825 lines, above budget 800`
- `review-packet-smoke.py`: stale assertion requiring `主控接管` after the peer runtime hard cut

Evidence: [Full Public Smokes run 29104055059](https://github.com/huangruiteng/loopx/actions/runs/29104055059).

## Validation
- both previously failing smokes
- `explore-configure-goal-smoke.py`
- `explore-harness-runtime-resume-smoke.py`
- `explore-worker-plan-gate-smoke.py`
- `explore-result-layer-smoke.py`
- repository Python line budget and public-boundary smokes
- `loopx canary premerge --from-git-diff --timeout-seconds 180` (9 selected checks passed, no skips/holds)

No CLI behavior, parser defaults, permission boundary, or size budget was relaxed.