### PR TITLE
Fix semantic topic affinity in Explore worker planning

### DIFF
--- a/loopx/capabilities/explore/worker_branch_plan.py
+++ b/loopx/capabilities/explore/worker_branch_plan.py
@@ -219,24 +219,50 @@ WORKER_HARNESS_PROFILES: dict[str, dict[str, Any]] = {
 
 COMMON_TOPIC_TOKENS = {
     "add",
+    "after",
     "agent",
+    "against",
+    "and",
+    "audit",
+    "before",
+    "between",
     "branch",
     "build",
     "check",
     "codex",
     "continue",
+    "current",
+    "deliver",
+    "existing",
     "explore",
     "fix",
+    "from",
     "goal",
+    "inspect",
+    "into",
+    "latest",
     "loopx",
+    "new",
+    "next",
+    "one",
     "p0",
     "p1",
     "p2",
+    "recent",
+    "review",
     "run",
     "test",
+    "the",
+    "then",
+    "this",
+    "through",
     "todo",
     "update",
     "validate",
+    "when",
+    "while",
+    "with",
+    "without",
 }
 TOKEN_PATTERN = re.compile(r"[A-Za-z0-9_:\-]{3,}")
 
@@ -287,8 +313,18 @@ def _resolve_todo_bundle_ceiling(
     return max(1, min(MAX_TODOS_PER_WORKER_BRANCH, default_ceiling)), False, "profile_default"
 
 
-def _tokenize(value: Any) -> set[str]:
-    return {match.group(0).lower() for match in TOKEN_PATTERN.finditer(str(value or ""))}
+def _ordered_topic_tokens(value: Any) -> list[str]:
+    """Return meaningful topic tokens in their original textual order."""
+
+    tokens: list[str] = []
+    seen: set[str] = set()
+    for match in TOKEN_PATTERN.finditer(str(value or "")):
+        token = match.group(0).lower()
+        if token in COMMON_TOPIC_TOKENS or token in seen:
+            continue
+        seen.add(token)
+        tokens.append(token)
+    return tokens
 
 
 def _scope_family(scope: str) -> str:
@@ -315,7 +351,7 @@ def _affinity_key(candidate: Mapping[str, Any]) -> str:
     ]
     if capabilities:
         return f"capability:{str(capabilities[0]).strip()}"
-    tokens = sorted(_tokenize(candidate.get("text")) - COMMON_TOPIC_TOKENS)
+    tokens = _ordered_topic_tokens(candidate.get("text"))
     if tokens:
         return f"topic:{tokens[0]}"
     return "topic:general"

--- a/tests/test_explore_worker_topic_affinity.py
+++ b/tests/test_explore_worker_topic_affinity.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from loopx.capabilities.explore.worker_branch_plan import _affinity_key
+
+
+def test_topic_affinity_uses_first_meaningful_token() -> None:
+    assert (
+        _affinity_key({"text": "[P0] Audit current result graph and evidence closure"})
+        == "topic:result"
+    )
+    assert (
+        _affinity_key({"text": "[P1] Review recent candidates against matched comparators"})
+        == "topic:candidates"
+    )
+    assert (
+        _affinity_key({"text": "[P2] Inspect latest planner implementation and deliver reusable fix"})
+        == "topic:planner"
+    )
+
+
+def test_topic_affinity_does_not_emit_control_vocabulary() -> None:
+    assert _affinity_key({"text": "[P0] Continue and update this todo"}) == "topic:general"
+
+
+def test_explicit_affinity_signals_still_take_precedence() -> None:
+    assert (
+        _affinity_key(
+            {
+                "text": "[P0] Review candidate behavior",
+                "required_write_scopes": ["loopx/capabilities/explore/**"],
+                "required_capabilities": ["analysis"],
+            }
+        )
+        == "scope:loopx/capabilities"
+    )
+    assert (
+        _affinity_key(
+            {
+                "text": "[P0] Review candidate behavior",
+                "required_capabilities": ["analysis"],
+            }
+        )
+        == "capability:analysis"
+    )


### PR DESCRIPTION
## Summary
- preserve todo text order when deriving fallback topic affinity
- filter common task framing, connective, and control vocabulary
- keep explicit write-scope and capability affinity precedence unchanged
- add focused regression tests for semantic topic selection and safe fallback

## Validation
- focused pytest: 3 passed
- Explore worker-plan gate smoke: passed
- Explore result-layer smoke: passed
- standard pre-merge canary: 4/4 selected checks passed; self-merge allowed

## Risk
Narrow planner fallback behavior only. Explicit scope/capability grouping and worker execution boundaries are unchanged.