### PR TITLE
Fix verifier completion polling on silent Docker exec

### DIFF
--- a/loopx/benchmark_core/__init__.py
+++ b/loopx/benchmark_core/__init__.py
@@ -31,6 +31,7 @@ from .artifacts import (
 )
 from .container_exec import (
     parse_container_exit_status,
+    read_container_file_via_compose_copy,
     run_container_command_with_exit_status,
     wrap_container_command_with_exit_status,
 )
@@ -191,6 +192,7 @@ __all__ = [
     "PreflightResult",
     "RoundReward",
     "RunHandle",
+    "read_container_file_via_compose_copy",
     "run_container_command_with_exit_status",
     "RUN_PERMISSION_POLICY_SCHEMA_VERSION",
     "RUN_PERMISSION_QUOTA_PROJECTION_SCHEMA_VERSION",

--- a/loopx/benchmark_core/container_exec.py
+++ b/loopx/benchmark_core/container_exec.py
@@ -6,10 +6,11 @@ import asyncio
 import contextlib
 import re
 import shlex
+import tempfile
 import time
 import uuid
 from collections.abc import Awaitable, Callable, Mapping
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 
@@ -47,6 +48,33 @@ def parse_container_exit_status(payload: bytes | str | None) -> int | None:
     return value if 0 <= value <= 255 else None
 
 
+async def read_container_file_via_compose_copy(
+    compose_fn: Callable[..., Awaitable[Any]],
+    container_path: str,
+    *,
+    service: str,
+    timeout_sec: float,
+) -> bytes | None:
+    """Copy a container file to the host when exec stdout is unreliable."""
+
+    with tempfile.TemporaryDirectory(prefix="loopx-container-file-") as tmp_dir:
+        destination = Path(tmp_dir) / "payload"
+        try:
+            result = await compose_fn(
+                ["cp", f"{service}:{container_path}", str(destination)],
+                check=False,
+                timeout_sec=max(1, min(10, int(timeout_sec))),
+            )
+        except (OSError, RuntimeError, TimeoutError):
+            return None
+        if getattr(result, "return_code", 1) != 0:
+            return None
+        try:
+            return destination.read_bytes()
+        except OSError:
+            return None
+
+
 async def run_container_command_with_exit_status(
     exec_fn: Callable[..., Awaitable[Any]],
     command: str,
@@ -55,13 +83,12 @@ async def run_container_command_with_exit_status(
     exec_args: tuple[Any, ...] = (),
     exec_kwargs: Mapping[str, Any] | None = None,
     poll_interval_sec: float = 0.5,
+    status_reader_fn: Callable[[str, str, float], Awaitable[bytes | str | None]]
+    | None = None,
 ) -> Any:
     """Run a container command and wait for its side-channel completion marker."""
 
-    status_path = (
-        "/tmp/loopx-benchmark-exec-status/"
-        f"{uuid.uuid4().hex}.status"
-    )
+    status_path = f"/tmp/loopx-benchmark-exec-status/{uuid.uuid4().hex}.status"
     kwargs = dict(exec_kwargs or {})
     kwargs["timeout_sec"] = timeout_sec
     service = kwargs.get("service", "main")
@@ -75,20 +102,20 @@ async def run_container_command_with_exit_status(
         captured_exit_code = None
         while captured_exit_code is None:
             remaining = deadline - time.monotonic()
-            probe = await exec_fn(
-                f"cat {shlex.quote(status_path)} 2>/dev/null",
-                timeout_sec=max(1.0, min(10.0, max(remaining, 1.0))),
-                user="root",
-                service=service,
-            )
-            captured_exit_code = parse_container_exit_status(
-                getattr(probe, "stdout", None)
-            )
+            if status_reader_fn is not None:
+                payload = await status_reader_fn(status_path, service, remaining)
+            else:
+                probe = await exec_fn(
+                    f"cat {shlex.quote(status_path)} 2>/dev/null",
+                    timeout_sec=max(1.0, min(10.0, max(remaining, 1.0))),
+                    user="root",
+                    service=service,
+                )
+                payload = getattr(probe, "stdout", None)
+            captured_exit_code = parse_container_exit_status(payload)
             if captured_exit_code is None:
                 if remaining <= 0:
-                    raise asyncio.TimeoutError(
-                        "container completion marker timed out"
-                    )
+                    raise asyncio.TimeoutError("container completion marker timed out")
                 await asyncio.sleep(min(poll_interval_sec, remaining))
         if hasattr(result, "model_copy"):
             return result.model_copy(update={"return_code": captured_exit_code})

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -142,6 +142,7 @@ from loopx.benchmark_core import (  # noqa: E402
     build_benchmark_launch_observable_handle,
     canonical_lifecycle,
     compact_benchmark_canonical_lifecycle,
+    read_container_file_via_compose_copy,
     run_container_command_with_exit_status,
     write_benchmark_run_observable_status,
 )
@@ -3654,8 +3655,33 @@ def install_benchflow_verifier_prep_timeout_override(
             call_args = args[1:] if positional_command else args
 
             prerequisites["benchflow_verifier_completion_poll_enabled"] = True
+            compose_fn = getattr(env, "_run_docker_compose_command", None)
+            status_reader_fn = None
+            if callable(compose_fn):
+                async def status_reader_fn(
+                    status_path: str,
+                    service: str,
+                    remaining: float,
+                ) -> bytes | None:
+                    return await read_container_file_via_compose_copy(
+                        compose_fn,
+                        status_path,
+                        service=service,
+                        timeout_sec=remaining,
+                    )
+
+                prerequisites["benchflow_verifier_completion_poll_reader"] = (
+                    "compose_copy"
+                )
+            else:
+                prerequisites["benchflow_verifier_completion_poll_reader"] = (
+                    "exec_stdout"
+                )
             if isinstance(trace, dict):
                 trace["benchflow_verifier_completion_poll_enabled"] = True
+                trace["benchflow_verifier_completion_poll_reader"] = prerequisites[
+                    "benchflow_verifier_completion_poll_reader"
+                ]
 
             try:
                 return await run_container_command_with_exit_status(
@@ -3664,6 +3690,7 @@ def install_benchflow_verifier_prep_timeout_override(
                     timeout_sec=completion_timeout,
                     exec_args=call_args,
                     exec_kwargs=call_kwargs,
+                    status_reader_fn=status_reader_fn,
                 )
             except asyncio.TimeoutError:
                 prerequisites[

--- a/tests/test_skillsbench_verifier_completion.py
+++ b/tests/test_skillsbench_verifier_completion.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import types
+from pathlib import Path
 from typing import Any
 
 import loopx.benchmark_core.container_exec as container_exec_module
@@ -13,15 +14,19 @@ from scripts.skillsbench_automation_loop import (
 
 def test_final_verifier_waits_for_container_completion_marker(monkeypatch) -> None:
     class FakeDockerEnv:
-        _run_docker_compose_command = object()
-
         def __init__(self) -> None:
             self.calls: list[tuple[str, dict[str, Any]]] = []
+            self.compose_calls: list[tuple[list[str], dict[str, Any]]] = []
+
+        async def _run_docker_compose_command(
+            self, command: list[str], **kwargs: Any
+        ) -> Any:
+            self.compose_calls.append((command, dict(kwargs)))
+            Path(command[-1]).write_text("7\n")
+            return types.SimpleNamespace(stdout=None, return_code=0)
 
         async def exec(self, command: str, **kwargs: Any) -> Any:
             self.calls.append((command, dict(kwargs)))
-            if command.startswith("cat "):
-                return types.SimpleNamespace(stdout="7\n", return_code=0)
             return types.SimpleNamespace(stdout=None, return_code=0)
 
     class FakeRollout:
@@ -35,7 +40,7 @@ def test_final_verifier_waits_for_container_completion_marker(monkeypatch) -> No
             return None
 
     rollout = FakeRollout()
-    completion_times = iter((0.0, 3.0))
+    completion_times = iter((0.0, 0.1))
     monkeypatch.setattr(
         container_exec_module,
         "time",
@@ -43,12 +48,14 @@ def test_final_verifier_waits_for_container_completion_marker(monkeypatch) -> No
     )
     plan = {"runner_prerequisites": {}}
     trace: dict[str, Any] = {}
-    original_verify, original_soft_verify = install_benchflow_verifier_prep_timeout_override(
-        FakeRollout,
-        timeout_sec=120,
-        final_verifier_timeout_sec=2,
-        plan=plan,
-        trace=trace,
+    original_verify, original_soft_verify = (
+        install_benchflow_verifier_prep_timeout_override(
+            FakeRollout,
+            timeout_sec=120,
+            final_verifier_timeout_sec=2,
+            plan=plan,
+            trace=trace,
+        )
     )
     try:
         result = asyncio.run(rollout.verify())
@@ -60,10 +67,40 @@ def test_final_verifier_waits_for_container_completion_marker(monkeypatch) -> No
     assert "/verifier/test.sh" in rollout._env.calls[0][0]
     assert "loopx_command_rc=$?" in rollout._env.calls[0][0]
     assert rollout._env.calls[0][1]["timeout_sec"] == 2
-    assert rollout._env.calls[1][0].startswith("cat ")
+    assert rollout._env.compose_calls[0][0][0] == "cp"
+    assert rollout._env.compose_calls[0][0][1].startswith(
+        "main:/tmp/loopx-benchmark-exec-status/"
+    )
     assert rollout._env.calls[-1][0].startswith("rm -f ")
     prereqs = plan["runner_prerequisites"]
     assert prereqs["benchflow_verifier_completion_poll_enabled"] is True
+    assert prereqs["benchflow_verifier_completion_poll_reader"] == "compose_copy"
     assert prereqs["benchflow_verifier_completion_poll_raw_command_recorded"] is False
     assert prereqs["benchflow_verifier_completion_poll_raw_output_recorded"] is False
     assert "test.sh" not in json.dumps(prereqs)
+
+
+def test_container_completion_falls_back_to_exec_stdout(monkeypatch) -> None:
+    calls: list[str] = []
+
+    async def exec_fn(command: str, **_: Any) -> Any:
+        calls.append(command)
+        stdout = "3\n" if command.startswith("cat ") else None
+        return types.SimpleNamespace(stdout=stdout, return_code=0)
+
+    completion_times = iter((0.0, 0.1))
+    monkeypatch.setattr(
+        container_exec_module,
+        "time",
+        types.SimpleNamespace(monotonic=lambda: next(completion_times)),
+    )
+    result = asyncio.run(
+        container_exec_module.run_container_command_with_exit_status(
+            exec_fn,
+            "true",
+            timeout_sec=2,
+        )
+    )
+
+    assert result.return_code == 3
+    assert calls[1].startswith("cat ")


### PR DESCRIPTION
## Summary
- read benchmark completion markers through `docker compose cp` when the sandbox exposes the Compose transport
- keep the existing exec-stdout reader as the generic fallback
- record the selected public-safe completion reader and cover both paths

## Why
Some remote Docker transports return from `compose exec` without preserving stdout. The verifier can finish and write an exit-status marker, while an stdout-based `cat` poll never observes it and waits until the outer timeout. Copying the marker to the runner host makes completion observation independent of exec output capture.

## Validation
- 8 focused pytest tests passed
- SkillsBench benchmark-run, runner-core, host-local launch, egress, UV-cache, benchmark-core, and Python line-budget smokes passed
- `loopx canary premerge --from-git-diff`: all 6 selected catalog canaries passed; benchmark-sensitive manual hold reviewed under owner authorization
- public/private boundary scan clean

## Scope
No scoring, task semantics, permission, submission, or benchmark launch behavior changes.