### PR TITLE
Make SkillsBench egress smoke hermetic

### DIFF
--- a/examples/skillsbench-benchmark-run-smoke.py
+++ b/examples/skillsbench-benchmark-run-smoke.py
@@ -773,6 +773,9 @@ def test_codex_app_server_goal_blocks_without_codex_api_egress() -> None:
         task_dir = skillsbench_root / "tasks" / "citation-check"
         task_dir.mkdir(parents=True)
         (task_dir / "task.toml").write_text("version = \"1.1\"\n", encoding="utf-8")
+        codex_bin = root / "codex"
+        codex_bin.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        codex_bin.chmod(0o755)
 
         original_create_connection = skillsbench_loop.socket.create_connection
 
@@ -792,6 +795,8 @@ def test_codex_app_server_goal_blocks_without_codex_api_egress() -> None:
                         "codex-app-server-goal-baseline",
                         "--allow-deprecated-app-server-goal-route",
                         "--host-local-acp-launch",
+                        "--local-codex-bin",
+                        str(codex_bin),
                         "--remote-command-file-bridge-ready",
                         "--skillsbench-root",
                         str(skillsbench_root),


### PR DESCRIPTION
## Summary
- give the egress-block smoke a case-local executable Codex preflight stub
- exercise both version and sandbox probe success without requiring a globally installed `codex`
- preserve the dedicated missing-CLI failure coverage

## Validation
- `env PATH=/usr/bin:/bin /usr/bin/python3 examples/skillsbench-benchmark-run-smoke.py`
- `env PATH=/usr/bin:/bin /usr/bin/python3 examples/run-smokes.py --suite full-public --offset 400 --limit 100 --timeout-seconds 120 --jobs 4 --json` (100/100)
- `uv run --with pytest pytest -q tests/test_skillsbench_remote_codex_preflight.py` (5 passed)
- `loopx canary premerge --from-git-diff` (all 6 selected canaries and public-boundary scan passed; benchmark-sensitive manual hold acknowledged under explicit owner self-merge authorization)

No runtime behavior, scoring, task semantics, uploads, or permission boundaries change.