### PR TITLE
Exclude blocked peer from review handoff routing

### DIFF
--- a/examples/control_plane/todo-claim-visibility-lanes-smoke.py
+++ b/examples/control_plane/todo-claim-visibility-lanes-smoke.py
@@ -16,6 +16,8 @@ from loopx.control_plane.todos.claim_visibility import (  # noqa: E402
     build_agent_claim_scoped_open_items,
     build_todo_claim_visibility_lanes,
 )
+from loopx.quota import build_quota_should_run  # noqa: E402
+from work_lane_contract_fixtures import GOAL_ID, status_payload  # noqa: E402
 
 
 CURRENT_AGENT = "codex-product-capability"
@@ -29,6 +31,8 @@ def todo(
     text: str,
     task_class: str,
     claimed_by: str | None = None,
+    continuation_policy: str | None = None,
+    blocks_agent: str | None = None,
 ) -> dict:
     item = {
         "index": index,
@@ -37,6 +41,8 @@ def todo(
         "status": "open",
         "task_class": task_class,
         "claimed_by": claimed_by,
+        "continuation_policy": continuation_policy,
+        "blocks_agent": blocks_agent,
         "required_write_scopes": [" loopx/** ", "loopx/**"],
         "decision_scope": "direction:action:claim",
     }
@@ -101,6 +107,112 @@ def assert_agent_claim_scope_prefers_current_then_unclaimed() -> None:
     assert claim_scope["blocked_claimed_items"][0]["todo_id"] == "todo_other_p0"
 
 
+def assert_review_handoff_excludes_only_the_blocked_peer() -> None:
+    review = todo(
+        "todo_review",
+        index=1,
+        text="[P0] Review the peer implementation.",
+        task_class="advancement_task",
+        continuation_policy="review_handoff",
+        blocks_agent=CURRENT_AGENT,
+    )
+    fallback = todo(
+        "todo_fallback",
+        index=2,
+        text="[P1] Continue the current peer lane.",
+        task_class="advancement_task",
+    )
+
+    blocked_selectable, blocked_scope = build_agent_claim_scoped_open_items(
+        [review, fallback],
+        agent_identity={"agent_id": CURRENT_AGENT, "agent_model": "peer_v1"},
+        diagnostic_item_limit=3,
+    )
+    assert [item["todo_id"] for item in blocked_selectable] == ["todo_fallback"]
+    assert blocked_scope is not None
+    assert blocked_scope["review_handoff_blocked_self_count"] == 1
+    assert blocked_scope["review_handoff_blocked_self_items"][0]["todo_id"] == (
+        "todo_review"
+    )
+    assert blocked_scope["review_handoff_eligibility_policy"] == (
+        "blocks_agent_cannot_review"
+    )
+
+    reviewer_selectable, reviewer_scope = build_agent_claim_scoped_open_items(
+        [review, fallback],
+        agent_identity={"agent_id": OTHER_AGENT, "agent_model": "peer_v1"},
+        diagnostic_item_limit=3,
+    )
+    assert [item["todo_id"] for item in reviewer_selectable] == [
+        "todo_review",
+        "todo_fallback",
+    ]
+    assert reviewer_scope is not None
+    assert reviewer_scope["review_handoff_blocked_self_count"] == 0
+
+    invalid_claim = dict(review, claimed_by=CURRENT_AGENT)
+    invalid_selectable, invalid_scope = build_agent_claim_scoped_open_items(
+        [invalid_claim],
+        agent_identity={"agent_id": CURRENT_AGENT, "agent_model": "peer_v1"},
+        diagnostic_item_limit=3,
+    )
+    assert invalid_selectable == []
+    assert invalid_scope is not None
+    assert invalid_scope["review_handoff_blocked_self_count"] == 1
+
+
+def assert_quota_routes_unclaimed_review_to_an_eligible_peer() -> None:
+    review = todo(
+        "todo_unclaimed_review",
+        index=1,
+        text="[P0] Review the peer implementation before delivery.",
+        task_class="advancement_task",
+        continuation_policy="review_handoff",
+        blocks_agent=CURRENT_AGENT,
+    )
+    fallback = todo(
+        "todo_side_fallback",
+        index=2,
+        text="[P1] Continue the blocked peer's independent fallback.",
+        task_class="advancement_task",
+        claimed_by=CURRENT_AGENT,
+    )
+    for item in (review, fallback):
+        item["role"] = "agent"
+        item["required_capabilities"] = ["shell"]
+    coordination = {
+        "agent_model": "peer_v1",
+        "registered_agents": [OTHER_AGENT, CURRENT_AGENT],
+    }
+
+    def guard(agent_id: str) -> dict:
+        return build_quota_should_run(
+            status_payload(
+                status="review_handoff_eligibility_frontier",
+                next_action=review["text"],
+                coordination=coordination,
+                agent_todo_items=[review, fallback],
+            ),
+            goal_id=GOAL_ID,
+            agent_id=agent_id,
+        )
+
+    blocked_guard = guard(CURRENT_AGENT)
+    assert blocked_guard["agent_lane_next_action"]["todo_id"] == (
+        "todo_side_fallback"
+    ), blocked_guard
+    assert [
+        item["todo_id"]
+        for item in blocked_guard["capability_gate"]["runnable_candidates"]
+    ] == ["todo_side_fallback"], blocked_guard
+
+    reviewer_guard = guard(OTHER_AGENT)
+    assert reviewer_guard["agent_lane_next_action"]["todo_id"] == (
+        "todo_unclaimed_review"
+    ), reviewer_guard
+    assert reviewer_guard["recommended_action"] == review["text"], reviewer_guard
+
+
 def assert_claim_visibility_lanes_split_current_other_and_task_class() -> None:
     open_items = [
         todo(
@@ -158,6 +270,8 @@ def assert_claim_visibility_lanes_split_current_other_and_task_class() -> None:
 
 def main() -> int:
     assert_agent_claim_scope_prefers_current_then_unclaimed()
+    assert_review_handoff_excludes_only_the_blocked_peer()
+    assert_quota_routes_unclaimed_review_to_an_eligible_peer()
     assert_claim_visibility_lanes_split_current_other_and_task_class()
     print("todo-claim-visibility-lanes-smoke ok")
     return 0

--- a/loopx/control_plane/agents/agent_scope.py
+++ b/loopx/control_plane/agents/agent_scope.py
@@ -29,8 +29,10 @@ from ..todos.contract import (
 from ..todos.handoff_gate import HandoffGateState
 from ..todos.projection import (
     todo_item_claimed_by_agent_or_unclaimed,
+    todo_item_is_review_handoff,
     todo_item_is_actionable_open,
     todo_item_is_deferred,
+    todo_item_review_handoff_blocks_agent,
     todo_item_task_class,
     todo_projection_sort_key,
 )
@@ -242,6 +244,10 @@ def _agent_scope_selectable_todo_item(
     agent_id = normalize_todo_claimed_by(agent_identity.get("agent_id"))
     if not agent_id:
         return True
+    if todo_item_is_review_handoff(item):
+        if todo_item_review_handoff_blocks_agent(item, agent_id=agent_id):
+            return False
+        return _todo_item_claimed_by_agent_or_unclaimed(item, agent_id=agent_id)
     blocks_agent = agent_scope_item_blocks_agent(item)
     if blocks_agent and blocks_agent != agent_id:
         return False

--- a/loopx/control_plane/todos/claim_visibility.py
+++ b/loopx/control_plane/todos/claim_visibility.py
@@ -10,6 +10,7 @@ from .contract import (
 from .projection import (
     todo_claimed_visibility_items,
     todo_item_is_actionable_open,
+    todo_item_review_handoff_blocks_agent,
     todo_item_task_class,
     todo_projection_sort_key,
 )
@@ -50,8 +51,22 @@ def build_agent_claim_scoped_open_items(
             return 1
         return 2
 
-    current_agent_items = [item for item in open_items if claim_bucket(item) == 0]
-    unclaimed_items = [item for item in open_items if claim_bucket(item) == 1]
+    blocked_review_handoff_items = [
+        item
+        for item in open_items
+        if todo_item_review_handoff_blocks_agent(item, agent_id=agent_id)
+    ]
+    selectable_source_items = [
+        item
+        for item in open_items
+        if not todo_item_review_handoff_blocks_agent(item, agent_id=agent_id)
+    ]
+    current_agent_items = [
+        item for item in selectable_source_items if claim_bucket(item) == 0
+    ]
+    unclaimed_items = [
+        item for item in selectable_source_items if claim_bucket(item) == 1
+    ]
     other_agent_claimed_items = [item for item in open_items if claim_bucket(item) == 2]
     selectable_items = sorted(
         [*current_agent_items, *unclaimed_items],
@@ -80,6 +95,12 @@ def build_agent_claim_scoped_open_items(
             other_agent_visibility,
             limit=diagnostic_item_limit,
         ),
+        "review_handoff_blocked_self_count": len(blocked_review_handoff_items),
+        "review_handoff_blocked_self_items": _compact_items(
+            blocked_review_handoff_items,
+            limit=diagnostic_item_limit,
+        ),
+        "review_handoff_eligibility_policy": "blocks_agent_cannot_review",
     }
     return selectable_items, claim_scope
 

--- a/loopx/control_plane/todos/projection.py
+++ b/loopx/control_plane/todos/projection.py
@@ -18,9 +18,11 @@ from .contract import (
     TODO_STATUS_DEFERRED,
     TODO_TASK_CLASS_ADVANCEMENT,
     TODO_TASK_CLASS_MONITOR,
+    normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
     normalize_todo_id,
     normalize_todo_status,
+    todo_continuation_requires_review,
 )
 
 
@@ -226,6 +228,27 @@ def todo_item_claimed_by_agent_or_unclaimed(
         return True
     claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
     return not claimed_by or claimed_by == normalized_agent_id
+
+
+def todo_item_is_review_handoff(item: dict[str, Any]) -> bool:
+    return todo_continuation_requires_review(
+        item.get("continuation_policy"),
+        action_kind=item.get("action_kind"),
+    )
+
+
+def todo_item_review_handoff_blocks_agent(
+    item: dict[str, Any],
+    *,
+    agent_id: str | None,
+) -> bool:
+    normalized_agent_id = normalize_todo_claimed_by(agent_id)
+    return bool(
+        normalized_agent_id
+        and todo_item_is_review_handoff(item)
+        and normalize_todo_blocks_agent(item.get("blocks_agent"))
+        == normalized_agent_id
+    )
 
 
 def todo_summary_claim_scope_agent_id(summary: dict[str, Any] | None) -> str | None:


### PR DESCRIPTION
## Summary
- exclude a `review_handoff` from the peer named by `blocks_agent` before quota candidate ranking
- keep claimed and unclaimed review handoffs selectable by eligible peers
- share the same eligibility rule across claim visibility and active-next filtering
- expose compact blocked-self diagnostics in claim scope

## Validation
- `python3 examples/control_plane/todo-claim-visibility-lanes-smoke.py`
- `python3 examples/control_plane/work-lane-contract-smoke.py`
- `python3 examples/control_plane/capability-gate-projection-smoke.py`
- `python3 examples/capability-gate-smoke.py`
- `python3 examples/control_plane/quota-resume-gated-open-todo-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `loopx check` on all four changed files
- `loopx canary premerge --from-git-diff` (17/17, merge gate passed, self-merge allowed)

No leader role, automatic reviewer assignment, permission widening, private state, or legacy hierarchy behavior is introduced.