### PR TITLE
Auto-compose issue-fix outcomes during Kanban sync

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -521,6 +521,10 @@ private material remain explicit gates. Each material transition must yield a
 `runnable_successor`, concrete blocker, or structured no-follow-up; unchanged
 polls remain quiet and do not spend delivery quota.
 
+Pass `--issue-ref` when persisting PR lifecycle state. This explicit public-safe
+link lets the outcome read model join the PR to its issue without guessing from
+branch names, titles, or text.
+
 ## Status And Output View
 
 Todo cards answer **what the agent should do next**. They do not, by
@@ -548,6 +552,13 @@ by repository and issue. A merged, closed, or triaged terminal card remains
 visible by default so the board shows outputs instead of only active work.
 Shared sinks continue to apply the existing local-path, private-link, and
 private-reference redaction boundary.
+
+The default `loopx lark-kanban sync-loopx-todos` path also derives all issue
+outcomes from the goal's existing feasibility and PR lifecycle domain state and
+upserts them beside todo rows. A feasibility row therefore appears as issue work
+even before a PR exists; a PR enriches that row only when its lifecycle
+observation carries the matching `repo` and explicit `issue_ref`. This automatic
+closeout projection adds no outcome ledger or second state machine.
 
 The Lark adapter renders this as a first-class issue dimension rather than
 only flattening the packet into `Evidence`. Outcome rows set
@@ -602,6 +613,7 @@ loopx issue-fix reviewer-request \
 # Project PR lifecycle into LoopX continuation state.
 loopx issue-fix pr-lifecycle \
   --url https://github.com/owner/repo/pull/456 \
+  --issue-ref issues_123 \
   --fetch-metadata \
   --goal-id example-goal \
   --format json

--- a/docs/capabilities/issue-fix/README.zh-CN.md
+++ b/docs/capabilities/issue-fix/README.zh-CN.md
@@ -462,6 +462,9 @@ review、maintainer correction、mergeability、stale branch 和 terminal status
 transition 必须生成 `runnable_successor`、具体 blocker 或结构化 no-follow-up；
 unchanged poll 保持安静且不消耗 delivery quota。
 
+持久化 PR lifecycle 时应传入 `--issue-ref`。这个显式、public-safe 的关联让 outcome
+read model 可以把 PR 精确连接到 issue，而不用从分支名、标题或正文中猜测。
+
 ## 状态与产出视图
 
 Todo 卡回答的是**agent 下一步要做什么**，但它本身不能完整回答**某个 issue 最后发生了
@@ -484,6 +487,12 @@ focused validation 已通过。
 卡片，稳定 outcome 卡则以 repository + issue 为 key。merged、closed 或 triaged 的
 终态卡默认保留可见，让看板能展示产出，而不只展示活跃工作。Shared sink 继续复用
 现有 local-path、private-link 与 private-reference redaction 边界。
+
+默认的 `loopx lark-kanban sync-loopx-todos` 还会从目标已有的 feasibility 与 PR
+lifecycle domain state 推导全部 issue outcome，并与 todo 行一起 upsert。因而 feasibility
+一经落盘，即使还没有 PR，也会作为 issue work 出现在看板；只有 lifecycle observation
+带有相同 `repo` 和显式 `issue_ref` 时，PR 才会补充到该行。这个自动 closeout projection
+不会新增 outcome ledger，也不会建立第二套状态机。
 
 Lark adapter 会把它渲染成一等 issue 维度，而不只是把 packet 压平写进 `Evidence`。
 Outcome 行设置 `Work Item Type=Issue Fix`，并填写 `Repository`、`Issue`、
@@ -536,6 +545,7 @@ loopx issue-fix reviewer-request \
 # 把 PR lifecycle 投影到 LoopX continuation state。
 loopx issue-fix pr-lifecycle \
   --url https://github.com/owner/repo/pull/456 \
+  --issue-ref issues_123 \
   --fetch-metadata \
   --goal-id example-goal \
   --format json

--- a/docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md
@@ -68,7 +68,9 @@ open PRs, merge, publish, or run destructive git without an explicit gate.
    stale merge states create runnable successors instead of `monitor_quiet_skip`.
    The command writes compact domain state by default when a `--goal-id` or
    `--ledger-path` is provided, and `--no-write-domain-state` keeps it
-   preview-only.
+   preview-only. Persisted lifecycle state should carry an explicit public-safe
+   `issue_ref`; outcome projection must not infer the issue from a branch name,
+   PR title, or prose.
 11. **Gate handling:** surface concrete gates instead of silently blocking. Safe
    metadata-only triage, public-code search, and focused smoke drafting may
    continue when those gates do not cover the selected action.
@@ -78,6 +80,9 @@ open PRs, merge, publish, or run destructive git without an explicit gate.
    lifecycle row. This projection writes no source state and creates no parallel
    workflow state machine. It must keep unknown delivery evidence explicit,
    retain terminal outputs, and remain consumable by generic projection sinks.
+   Default goal-level Kanban sync derives an
+   `issue_fix_outcome_collection_projection_v0` from all feasibility rows and
+   explicitly linked lifecycle rows before upserting issue outcome cards.
 
 ## Public-Safe Boundary
 
@@ -172,6 +177,7 @@ An issue-fix workflow is PR-review-ready only when all of these are true:
 - `issue_fix_delivery_evidence_input_v0`
 - `issue_fix_outcome_case_v0`
 - `issue_fix_outcome_projection_v0`
+- `issue_fix_outcome_collection_projection_v0`
 - `loopx_todo_writeback_preview_v0`
 - `issue_fix_caller_repo_branch_packet_v0`
 - `issue_fix_validated_fix_artifact_v0`

--- a/docs/lark-kanban-control-plane-adapter.md
+++ b/docs/lark-kanban-control-plane-adapter.md
@@ -135,9 +135,11 @@ When a worker discovers follow-up work, it should classify the need first:
 - strategy-heavy fan-out: run `complex_request_intake_v0` to create a small
   typed todo batch.
 
-After that writeback, `sync-loopx-todos` updates the status tracker. This keeps
-task identity, `todo_id`, gates, claims, and successor metadata in LoopX while
-letting Kanban remain the operator-visible tracker for current work.
+After that writeback, `sync-loopx-todos` updates the status tracker and derives
+issue-fix outcome rows from existing goal domain state. This keeps task identity,
+`todo_id`, gates, claims, issue/PR lifecycle state, and successor metadata in
+LoopX while letting Kanban remain the operator-visible tracker for current work
+and delivered outputs.
 
 ## Setup And Reuse
 
@@ -171,12 +173,18 @@ python3 -m loopx.cli lark-kanban heartbeat --execute-lark
 ```
 
 `sync-loopx-todos` reads the goal active state from the LoopX registry and
-upserts open user/agent todos into the board. User todos become `User Gate`
+upserts open user/agent todos plus derived issue-fix outcome rows into the board.
+User todos become `User Gate`
 cards; claimed agent todos become `Claimed`; blocked/done todos map to
 `Blocked`/`Done` when included. Synced LoopX todos intentionally leave
 `Worker Command` and `Workdir` empty unless a task row was explicitly authored
 as a worker-launch row; the shared board must not receive raw local checkout or
 active-state paths.
+
+Issue outcomes are derived, not persisted separately. Every feasibility row is
+projected; a PR lifecycle row enriches it only through an explicit matching
+`repo` and `issue_ref`. This avoids title/branch guessing and makes the issue
+grid and stage Kanban part of the default sync path.
 
 ## CLI Surface
 

--- a/examples/issue-fix-outcome-projection-smoke.py
+++ b/examples/issue-fix-outcome-projection-smoke.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import json
 import sys
 import tempfile
 from pathlib import Path
@@ -11,12 +12,26 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from loopx.capabilities.issue_fix.outcome_projection import (  # noqa: E402
+    build_issue_fix_outcome_collection_from_domain_state,
     build_issue_fix_outcome_projection,
+)
+from loopx.capabilities.issue_fix.feasibility import (  # noqa: E402
+    build_issue_fix_feasibility_packet,
+)
+from loopx.capabilities.issue_fix.pr_lifecycle import (  # noqa: E402
+    build_issue_fix_pr_lifecycle_monitor_packet,
+)
+from loopx.domain_packs.issue_fix import (  # noqa: E402
+    default_issue_fix_domain_state_ledger_path,
+    default_issue_fix_feasibility_ledger_path,
+    upsert_issue_fix_feasibility_ledger_jsonl,
+    upsert_issue_fix_pr_lifecycle_ledger_jsonl,
 )
 from loopx.presentation.sinks.lark.kanban import (  # noqa: E402
     LarkKanbanConfig,
     STATUS_DONE,
     sync_loopx_projection_to_lark_kanban,
+    sync_loopx_todos_to_lark_kanban,
 )
 
 
@@ -116,6 +131,137 @@ def delivery_evidence() -> dict[str, object]:
         ],
         "risks": ["full integration suite remains outside focused validation"],
     }
+
+
+def assert_default_goal_sync_composes_outcomes() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-issue-fix-closeout-") as tmp:
+        project = Path(tmp)
+        goal_id = "public-issue-fix-closeout"
+        registry = project / "registry.json"
+        state = project / "active-state.md"
+        state.write_text(
+            "\n".join(
+                [
+                    "## User Todo / Owner Review Reading Queue",
+                    "",
+                    "## Agent Todo",
+                    "",
+                    "- [ ] [P2] Continue public fixture monitor",
+                    "  <!-- loopx: todo_id=todo_monitor status=open task_class=continuous_monitor action_kind=monitor claimed_by=codex-public-fixture -->",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        registry.write_text(
+            json.dumps(
+                {
+                    "goals": [
+                        {
+                            "id": goal_id,
+                            "repo": str(project),
+                            "state_file": state.name,
+                        }
+                    ]
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        feasibility_ledger = default_issue_fix_feasibility_ledger_path(
+            project=project,
+            goal_id=goal_id,
+        )
+        for number in (42, 43):
+            packet = build_issue_fix_feasibility_packet(
+                url=f"https://github.com/public-fixture/widgets/issues/{number}",
+                reproduction_status="confirmed",
+                scope_class="bounded",
+                reproduction_label=f"focused fixture repro {number}",
+                validation_label=f"focused fixture validation {number}",
+            )
+            upsert_issue_fix_feasibility_ledger_jsonl(feasibility_ledger, packet)
+
+        lifecycle_ledger = default_issue_fix_domain_state_ledger_path(
+            project=project,
+            goal_id=goal_id,
+        )
+        linked = build_issue_fix_pr_lifecycle_monitor_packet(
+            url="https://github.com/public-fixture/widgets/pull/77",
+            issue_ref="issues_42",
+            provider_payload={
+                "state": "OPEN",
+                "reviewDecision": "REVIEW_REQUIRED",
+                "mergeStateStatus": "CLEAN",
+                "statusCheckRollup": [
+                    {"name": "focused", "conclusion": "SUCCESS"}
+                ],
+            },
+        )
+        assert linked["observation"]["issue_ref"] == "issues_42", linked
+        upsert_issue_fix_pr_lifecycle_ledger_jsonl(lifecycle_ledger, linked)
+        unlinked = build_issue_fix_pr_lifecycle_monitor_packet(
+            url="https://github.com/public-fixture/widgets/pull/78",
+            provider_payload={
+                "state": "OPEN",
+                "reviewDecision": "REVIEW_REQUIRED",
+                "mergeStateStatus": "CLEAN",
+                "statusCheckRollup": [],
+            },
+        )
+        upsert_issue_fix_pr_lifecycle_ledger_jsonl(lifecycle_ledger, unlinked)
+
+        collection = build_issue_fix_outcome_collection_from_domain_state(
+            goal_id=goal_id,
+            project=project,
+            agent_id="codex-public-fixture",
+        )
+        assert collection["ok"] is True, collection
+        assert collection["validation"]["ok"] is True, collection
+        assert collection["source_counts"] == {
+            "feasibility": 2,
+            "pr_lifecycle": 2,
+            "outcomes": 2,
+            "unlinked_pr_lifecycle": 1,
+        }, collection
+        collection_by_issue = {
+            item["issue_ref"]: item for item in collection["issue_fix_outcomes"]
+        }
+        assert collection_by_issue["issues_42"]["pull_request"]["number"] == 77
+        assert collection_by_issue["issues_43"]["pull_request"] is None
+        assert collection["source_contract"]["creates_parallel_state_machine"] is False
+
+        sync = sync_loopx_todos_to_lark_kanban(
+            LarkKanbanConfig(
+                **{"base_" + "token": "base_public_fixture"},
+                table_id="tbl_public_fixture",
+            ),
+            registry_path=registry,
+            goal_id=goal_id,
+            agent_id="codex-public-fixture",
+            execute=False,
+        )
+        assert sync["ok"] is True, sync
+        assert sync["todo_count"] == 1, sync
+        assert sync["issue_fix_outcome_count"] == 2, sync
+        outcome_records = [
+            item
+            for item in sync["records"]
+            if item["values"].get("Work Item Type") == "Issue Fix"
+        ]
+        assert len(outcome_records) == 2, sync
+        linked_record = next(
+            item
+            for item in outcome_records
+            if item["values"]["Issue"].endswith("/issues/42")
+        )
+        assert linked_record["values"]["Pull Request"].endswith("/pull/77")
+        unlinked_record = next(
+            item
+            for item in outcome_records
+            if item["values"]["Issue"].endswith("/issues/43")
+        )
+        assert unlinked_record["values"]["Pull Request"] == ""
+        assert str(project) not in json.dumps(sync["records"], ensure_ascii=False)
 
 
 def main() -> None:
@@ -252,6 +398,8 @@ def main() -> None:
         assert "repo-relative" in str(exc) or "public-safe" in str(exc), exc
     else:
         raise AssertionError("absolute changed file should be rejected")
+
+    assert_default_goal_sync_composes_outcomes()
 
     print("issue-fix-outcome-projection-smoke: ok")
 

--- a/examples/issue-fix-pr-lifecycle-smoke.py
+++ b/examples/issue-fix-pr-lifecycle-smoke.py
@@ -172,6 +172,7 @@ def main() -> int:
 
     quiet = build_issue_fix_pr_lifecycle_monitor_packet(
         url="https://github.com/huangruiteng/loopx/pull/1715",
+        issue_ref="issues_1700",
         provider_payload={
             "state": "OPEN",
             "reviewDecision": "REVIEW_REQUIRED",
@@ -181,6 +182,7 @@ def main() -> int:
     )
     assert_packet_shape(quiet)
     assert quiet["transition"]["decision"] == "monitor_continuation", quiet
+    assert quiet["observation"]["issue_ref"] == "issues_1700", quiet
     assert quiet["transition"]["material_change"] is False
     assert quiet["writeback_contract"]["monitor_quiet_skip_allowed"] is True
     repo_ref = build_issue_fix_pr_lifecycle_monitor_packet(
@@ -241,6 +243,8 @@ def main() -> int:
                 "https://github.com/huangruiteng/loopx/pull/1715",
                 "--metadata-json",
                 str(metadata_path),
+                "--issue-ref",
+                "issues_1700",
                 "--goal-id",
                 "example-goal",
                 "--project",

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -320,6 +320,15 @@ def register_issue_fix_commands(
         help="Public-safe PR reference label.",
     )
     pr_lifecycle_parser.add_argument(
+        "--issue-ref",
+        default=None,
+        help=(
+            "Optional public-safe issue reference linked to this PR. Persisting "
+            "the explicit link lets default Kanban sync compose the issue outcome "
+            "without guessing from titles or branch names."
+        ),
+    )
+    pr_lifecycle_parser.add_argument(
         "--url",
         default=None,
         help="Optional https://github.com/owner/repo/pull/123 URL.",
@@ -810,6 +819,7 @@ def handle_issue_fix_command(
             payload = build_issue_fix_pr_lifecycle_monitor_packet(
                 repo=args.repo,
                 pr_ref=args.pr_ref,
+                issue_ref=args.issue_ref,
                 url=args.url,
                 provider_payload=_load_json_object(args.metadata_json)
                 if args.metadata_json

--- a/loopx/capabilities/issue_fix/outcome_projection.py
+++ b/loopx/capabilities/issue_fix/outcome_projection.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import json
 import re
 from collections.abc import Mapping, Sequence
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import Any
 
 from ...control_plane.runtime.public_safety import public_safe_compact_text
@@ -10,6 +11,9 @@ from ...control_plane.runtime.public_safety import public_safe_compact_text
 
 ISSUE_FIX_OUTCOME_PROJECTION_SCHEMA_VERSION = "issue_fix_outcome_projection_v0"
 ISSUE_FIX_OUTCOME_CASE_SCHEMA_VERSION = "issue_fix_outcome_case_v0"
+ISSUE_FIX_OUTCOME_COLLECTION_PROJECTION_SCHEMA_VERSION = (
+    "issue_fix_outcome_collection_projection_v0"
+)
 ISSUE_FIX_DELIVERY_EVIDENCE_INPUT_SCHEMA_VERSION = (
     "issue_fix_delivery_evidence_input_v0"
 )
@@ -481,6 +485,193 @@ def build_issue_fix_outcome_projection(
     packet["validation"] = validate_issue_fix_outcome_projection(packet)
     packet["ok"] = packet["validation"]["ok"]
     return packet
+
+
+def _load_domain_packets(path: Path) -> tuple[list[dict[str, Any]], list[str]]:
+    if not path.is_file():
+        return [], []
+    packets: list[dict[str, Any]] = []
+    warnings: list[str] = []
+    for line_number, line in enumerate(
+        path.read_text(encoding="utf-8").splitlines(), start=1
+    ):
+        if not line.strip():
+            continue
+        try:
+            packet = json.loads(line)
+        except json.JSONDecodeError:
+            warnings.append(f"{path.name}:{line_number} is not valid JSON")
+            continue
+        if not isinstance(packet, dict):
+            warnings.append(f"{path.name}:{line_number} is not an object")
+            continue
+        packets.append(packet)
+    return packets, warnings
+
+
+def _lifecycle_recency(packet: Mapping[str, Any]) -> tuple[str, str]:
+    observation = _mapping(packet.get("observation"))
+    return (
+        str(
+            observation.get("updated_at")
+            or observation.get("merged_at")
+            or observation.get("closed_at")
+            or packet.get("generated_at")
+            or ""
+        ),
+        str(observation.get("pr_ref") or ""),
+    )
+
+
+def build_issue_fix_outcome_collection_from_domain_state(
+    *,
+    goal_id: str,
+    project: str | Path = ".",
+    agent_id: str | None = None,
+    generated_at: str | None = None,
+) -> dict[str, Any]:
+    """Derive all goal issue outcomes from existing compact domain state.
+
+    Feasibility rows are the issue inventory. A PR lifecycle row enriches an
+    issue only when its observation carries the same explicit ``issue_ref``;
+    branch names, titles, and issue numbers are never guessed. No source state
+    or parallel outcome ledger is written.
+    """
+
+    from ...domain_packs.issue_fix import (
+        default_issue_fix_domain_state_ledger_path,
+        default_issue_fix_feasibility_ledger_path,
+    )
+
+    project_path = Path(project).expanduser()
+    feasibility_packets, feasibility_warnings = _load_domain_packets(
+        default_issue_fix_feasibility_ledger_path(
+            project=project_path,
+            goal_id=goal_id,
+        )
+    )
+    lifecycle_packets, lifecycle_warnings = _load_domain_packets(
+        default_issue_fix_domain_state_ledger_path(
+            project=project_path,
+            goal_id=goal_id,
+        )
+    )
+    warnings = [*feasibility_warnings, *lifecycle_warnings]
+
+    lifecycle_by_issue: dict[tuple[str, str], list[dict[str, Any]]] = {}
+    linked_lifecycle_ids: set[int] = set()
+    for packet in lifecycle_packets:
+        observation = _mapping(packet.get("observation"))
+        repo = str(observation.get("repo") or "").strip()
+        issue_ref = str(observation.get("issue_ref") or "").strip()
+        if repo and issue_ref:
+            lifecycle_by_issue.setdefault((repo, issue_ref), []).append(packet)
+
+    outcomes: list[dict[str, Any]] = []
+    for feasibility_packet in feasibility_packets:
+        observation = _mapping(feasibility_packet.get("observation"))
+        repo = str(observation.get("repo") or "").strip()
+        issue_ref = str(observation.get("issue_ref") or "").strip()
+        lifecycle_packet: dict[str, Any] | None = None
+        candidates = lifecycle_by_issue.get((repo, issue_ref), [])
+        if candidates:
+            lifecycle_packet = max(candidates, key=_lifecycle_recency)
+            linked_lifecycle_ids.update(id(item) for item in candidates)
+        try:
+            projection = build_issue_fix_outcome_projection(
+                goal_id=goal_id,
+                feasibility_packet=feasibility_packet,
+                pr_lifecycle_packet=lifecycle_packet,
+                agent_id=agent_id,
+                generated_at=generated_at,
+            )
+        except ValueError as exc:
+            safe_identity = public_safe_compact_text(
+                f"{repo}:{issue_ref}", limit=220
+            ) or "unknown issue"
+            safe_error = public_safe_compact_text(exc, limit=260) or "invalid row"
+            warnings.append(f"skipped {safe_identity}: {safe_error}")
+            continue
+        if projection.get("ok") is True:
+            outcomes.extend(list(projection.get("issue_fix_outcomes") or []))
+
+    unlinked_lifecycle_count = sum(
+        1 for packet in lifecycle_packets if id(packet) not in linked_lifecycle_ids
+    )
+    collection: dict[str, Any] = {
+        "ok": True,
+        "schema_version": ISSUE_FIX_OUTCOME_COLLECTION_PROJECTION_SCHEMA_VERSION,
+        "mode": "issue-fix-outcome-collection",
+        "source_id": "issue-fix-outcome",
+        "goal_id": goal_id,
+        "generated_at": generated_at,
+        "agent_identity": {"agent_id": agent_id} if agent_id else {},
+        "issue_fix_outcomes": outcomes,
+        "source_contract": {
+            "feasibility": "issue_fix_feasibility_v0",
+            "pr_lifecycle": "issue_fix_pr_lifecycle_monitor_v0",
+            "association": "explicit_repo_and_issue_ref_only",
+            "writes_source_state": False,
+            "creates_parallel_state_machine": False,
+        },
+        "source_counts": {
+            "feasibility": len(feasibility_packets),
+            "pr_lifecycle": len(lifecycle_packets),
+            "outcomes": len(outcomes),
+            "unlinked_pr_lifecycle": unlinked_lifecycle_count,
+        },
+        "warnings": warnings,
+        "external_reads_performed": False,
+        "external_writes_performed": False,
+        "raw_logs_captured": False,
+        "local_paths_captured": False,
+        "credentials_captured": False,
+    }
+    collection["validation"] = validate_issue_fix_outcome_collection_projection(
+        collection
+    )
+    collection["ok"] = bool(collection["validation"]["ok"])
+    return collection
+
+
+def validate_issue_fix_outcome_collection_projection(
+    packet: Mapping[str, Any],
+) -> dict[str, Any]:
+    errors: list[str] = []
+    if (
+        packet.get("schema_version")
+        != ISSUE_FIX_OUTCOME_COLLECTION_PROJECTION_SCHEMA_VERSION
+    ):
+        errors.append(
+            "schema_version must be issue_fix_outcome_collection_projection_v0"
+        )
+    outcomes = packet.get("issue_fix_outcomes")
+    if not isinstance(outcomes, list):
+        errors.append("issue_fix_outcomes must be a list")
+        outcomes = []
+    outcome_ids = [
+        str(item.get("outcome_id") or "")
+        for item in outcomes
+        if isinstance(item, Mapping)
+    ]
+    if any(not value for value in outcome_ids):
+        errors.append("every issue-fix outcome must have an outcome_id")
+    if len(set(outcome_ids)) != len(outcome_ids):
+        errors.append("issue-fix outcome ids must be unique")
+    for key in (
+        "external_reads_performed",
+        "external_writes_performed",
+        "raw_logs_captured",
+        "local_paths_captured",
+        "credentials_captured",
+    ):
+        if packet.get(key) is not False:
+            errors.append(f"{key} must be false")
+    return {
+        "schema_version": "issue_fix_outcome_collection_projection_validation_v0",
+        "ok": not errors,
+        "errors": errors,
+    }
 
 
 def validate_issue_fix_outcome_projection(packet: Mapping[str, Any]) -> dict[str, Any]:

--- a/loopx/capabilities/issue_fix/pr_lifecycle.py
+++ b/loopx/capabilities/issue_fix/pr_lifecycle.py
@@ -7,6 +7,7 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 from urllib.parse import quote
 
+from ...control_plane.runtime.public_safety import public_safe_compact_text
 from .metadata_preview import normalise_github_issue_reference
 
 
@@ -163,6 +164,7 @@ def _build_observation(
     *,
     repo: str,
     pr_ref: str,
+    issue_ref: str | None,
     reference: Mapping[str, Any],
     provider_payload: Mapping[str, Any],
 ) -> dict[str, Any]:
@@ -174,10 +176,14 @@ def _build_observation(
             state = "MERGED"
     review_decision = _upper_label(provider_payload.get("reviewDecision"))
     merge_state = _upper_label(provider_payload.get("mergeStateStatus"))
+    linked_issue_ref = public_safe_compact_text(issue_ref, limit=180)
+    if issue_ref and not linked_issue_ref:
+        raise ValueError("issue_ref must be a compact public-safe value")
     return {
         "schema_version": "issue_fix_pr_lifecycle_observation_v0",
         "repo": repo,
         "pr_ref": pr_ref,
+        "issue_ref": linked_issue_ref or None,
         "kind": "pull_request",
         "number": reference.get("number"),
         "state": state,
@@ -369,6 +375,7 @@ def build_issue_fix_pr_lifecycle_monitor_packet(
     *,
     repo: str = "public_repo_fixture",
     pr_ref: str = "pull_123_public_metadata_fixture",
+    issue_ref: str | None = None,
     url: str | None = None,
     provider_payload: Mapping[str, Any] | None = None,
     fetch_metadata: bool = False,
@@ -391,6 +398,7 @@ def build_issue_fix_pr_lifecycle_monitor_packet(
     observation = _build_observation(
         repo=str(reference["repo"]),
         pr_ref=str(reference["issue_ref"]),
+        issue_ref=issue_ref,
         reference=reference,
         provider_payload=payload,
     )

--- a/loopx/cli_commands/lark_kanban.py
+++ b/loopx/cli_commands/lark_kanban.py
@@ -120,7 +120,10 @@ def register_lark_kanban_commands(
 
     sync = sub.add_parser(
         "sync-loopx-todos",
-        help="Sync a goal's active LoopX todos into the configured board. Dry-run unless --execute.",
+        help=(
+            "Sync a goal's active LoopX todos and derived issue-fix outcomes into "
+            "the configured board. Dry-run unless --execute."
+        ),
     )
     add_subcommand_format(sync)
     _add_local_config_args(sync)

--- a/loopx/presentation/sinks/lark/kanban.py
+++ b/loopx/presentation/sinks/lark/kanban.py
@@ -1955,6 +1955,9 @@ def sync_loopx_todos_to_lark_kanban(
     execute: bool = False,
     runner: CommandRunner = default_subprocess_runner,
 ) -> dict[str, Any]:
+    from ....capabilities.issue_fix.outcome_projection import (
+        build_issue_fix_outcome_collection_from_domain_state,
+    )
     from ....control_plane.todos.text import todo_priority_prefix
     from ....todos import resolve_todo_state_path, section_bounds, todo_blocks
 
@@ -1981,6 +1984,28 @@ def sync_loopx_todos_to_lark_kanban(
                 continue
             todos.append(candidate)
     todos = todos[:limit]
+
+    outcome_projection = build_issue_fix_outcome_collection_from_domain_state(
+        goal_id=goal_id,
+        project=resolved_project or project or Path("."),
+    )
+    outcome_source_id, outcome_namespace_warnings = _projection_namespace(
+        outcome_projection,
+        None,
+    )
+    _, outcome_rows, outcome_row_warnings = _projection_rows_from_payload(
+        outcome_projection,
+        goal_id=goal_id,
+        agent_id=agent_id,
+        source_id=outcome_source_id,
+        include_done=True,
+        limit=limit,
+    )
+    outcome_warnings = [
+        *outcome_namespace_warnings,
+        *list(outcome_projection.get("warnings") or []),
+        *outcome_row_warnings,
+    ]
 
     commands: list[dict[str, Any]] = []
     local, record_map = _load_lark_todo_record_map(
@@ -2019,6 +2044,43 @@ def sync_loopx_todos_to_lark_kanban(
         if execute and not result.get("ok"):
             break
 
+    if ok:
+        for row in outcome_rows:
+            row_goal_id = str(row.get("goal_id") or goal_id)
+            todo_id = str(row.get("todo_id") or "").strip()
+            key = f"{row_goal_id}:{todo_id}"
+            values = _lark_record_from_projection_block(
+                row,
+                goal_id=row_goal_id,
+                source_id=outcome_source_id,
+            )
+            result = _run_command(
+                build_record_upsert_command(
+                    config,
+                    record_id=record_map.get(key),
+                    values=values,
+                ),
+                execute=execute,
+                runner=runner,
+            )
+            commands.append(result)
+            record_id = (
+                _extract_created_record_id(result.get("json")) or record_map.get(key)
+            )
+            if execute and result.get("ok") and record_id:
+                record_map[key] = record_id
+            results.append(
+                {
+                    "todo_id": todo_id,
+                    "record_id": record_id,
+                    "command": result,
+                    "values": values,
+                }
+            )
+            ok = ok and bool(result.get("ok"))
+            if execute and not result.get("ok"):
+                break
+
     if execute and ok:
         _persist_lark_todo_record_map(config, config_path=config_path, local=local, record_map=record_map)
 
@@ -2031,6 +2093,9 @@ def sync_loopx_todos_to_lark_kanban(
         "project": str(resolved_project) if resolved_project else None,
         "state_file": str(resolved_state_file),
         "todo_count": len(todos),
+        "issue_fix_outcome_count": len(outcome_rows),
+        "issue_fix_source_counts": outcome_projection.get("source_counts"),
+        "warnings": outcome_warnings,
         "records": results,
         "commands": commands,
         "config_path": str(config_path) if config_path else None,


### PR DESCRIPTION
Closes #1823

## Motivation

The issue-fix domain already persisted feasibility and PR lifecycle evidence, and the Lark sink already rendered outcome projections, but the default goal sync only wrote todo cards. Operators had to manually compose and sync the issue read model, so issue-oriented views could remain empty after a PR was published.

## Implementation

- add an optional public-safe `--issue-ref` link to PR lifecycle observations; no title or branch-name inference
- derive a goal-level outcome collection from existing feasibility and explicitly linked lifecycle ledgers without adding an outcome ledger
- make default `lark-kanban sync-loopx-todos` upsert stable issue outcome rows beside todo rows
- keep unlinked feasibility rows visible as work in progress and report unlinked lifecycle rows without guessing
- document the contract in the English and Chinese capability guides and the Lark adapter

## Validation

- `python3 examples/issue-fix-pr-lifecycle-smoke.py`
- `python3 examples/issue-fix-outcome-projection-smoke.py`
- `python3 examples/lark-kanban-control-plane-smoke.py`
- `python3 examples/issue-fix-capability-guide-smoke.py`
- `python3 examples/issue-fix-workflow-contract-smoke.py`
- `python3 -m loopx.cli --format json check`
- `loopx canary premerge --from-git-diff`: 17/17 selected checks passed, no failures, warnings, or manual holds; public/private boundary clean

## Risk and non-goals

The join is intentionally exact on repository plus explicit issue reference. Existing lifecycle rows without that link remain unassociated until replayed; they are not guessed. Automatic projection reuses existing domain state and does not persist delivery evidence or create a parallel state machine. No credentials, local runtime state, raw logs, private material, or local paths are included.