### PR TITLE
Add repository-memory read hook to issue-fix planning

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -519,7 +519,8 @@ namespace, reads selected hits, distils public-safe summaries, and passes an
 `issue_fix_repository_memory_read_result_v0` packet. LoopX hashes provider
 references, keeps every memory source advisory, allows patch influence only
 for hits verified against the pinned checkout revision, and persists the
-compact hook projection in the existing repository context. Provider
+compact hook projection in the existing repository context. Unverified or
+refuted hits contribute counts only; their summaries are not persisted. Provider
 unavailability, empty retrieval, or a missing revision is fail-open for the
 repository workflow; raw memory bodies, automatic transcript capture, memory
 writeback, private namespaces, and credentials are rejected.

--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -512,6 +512,25 @@ until verified. The public
 pilot applies that evidence order without introducing a repository-specific
 control path.
 
+They also accept `--repository-memory-json
+<compact-search-read-result.json>`. This is a host-provider hook, not a memory
+client inside LoopX: the host explicitly searches a caller-approved public
+namespace, reads selected hits, distils public-safe summaries, and passes an
+`issue_fix_repository_memory_read_result_v0` packet. LoopX hashes provider
+references, keeps every memory source advisory, allows patch influence only
+for hits verified against the pinned checkout revision, and persists the
+compact hook projection in the existing repository context. Provider
+unavailability, empty retrieval, or a missing revision is fail-open for the
+repository workflow; raw memory bodies, automatic transcript capture, memory
+writeback, private namespaces, and credentials are rejected.
+
+Default enablement is an evidence decision rather than an installation side
+effect. A project should first dogfood the hook across several independent
+issue/context runs and a restart boundary. Make it a packaged default only
+when it repeatedly contributes novel checkout-verified evidence without stale,
+misleading, or boundary-unsafe retrieval; otherwise keep it explicit opt-in
+with the same fail-open behavior.
+
 ## PR Lifecycle Monitor
 
 After publication, `loopx issue-fix pr-lifecycle` and a `continuous_monitor`
@@ -576,6 +595,7 @@ loopx issue-fix workflow-plan \
   --url https://github.com/owner/repo/issues/123 \
   --repo-path /path/to/approved/repo \
   --repository-context-json context.json \
+  --repository-memory-json compact-search-read-result.json \
   --validation-label "focused unit test" \
   --format json
 
@@ -587,6 +607,7 @@ loopx issue-fix feasibility \
   --scope-class bounded \
   --validation-label "focused unit test" \
   --repository-context-json context.json \
+  --repository-memory-json compact-search-read-result.json \
   --goal-id example-goal \
   --format json
 
@@ -640,6 +661,7 @@ python3 examples/issue-fix-reviewer-notification-sink-smoke.py
 python3 examples/issue-fix-workflow-plan-smoke.py
 python3 examples/issue-fix-workflow-contract-smoke.py
 python3 examples/issue-fix-repository-context-smoke.py
+python3 examples/issue-fix-repository-memory-smoke.py
 python3 examples/issue-fix-feasibility-smoke.py
 python3 examples/issue-fix-pr-lifecycle-smoke.py
 python3 examples/issue-fix-outcome-projection-smoke.py

--- a/docs/capabilities/issue-fix/README.zh-CN.md
+++ b/docs/capabilities/issue-fix/README.zh-CN.md
@@ -459,7 +459,8 @@ host-provider hook，不是 LoopX 内置的 memory client：host 只在调用方
 namespace 中显式执行 `search`，再对选中的命中执行 `read`，把蒸馏后的 public-safe
 摘要封装成 `issue_fix_repository_memory_read_result_v0`。LoopX 会 hash provider ref，
 始终把 memory source 保持为 advisory；只有已经在 pinned checkout revision 上验证的
-命中才允许影响 patch。紧凑 hook projection 仍写入现有 repository context，不建立
+命中才允许影响 patch。未验证或已被 refute 的命中只进入计数，其摘要不会持久化。
+紧凑 hook projection 仍写入现有 repository context，不建立
 第二套 ledger。Provider 不可用、空结果或缺少 revision 时，仓库工作流 fail-open；
 raw memory body、自动 transcript capture、memory writeback、私有 namespace 与凭据
 都会被拒绝。

--- a/docs/capabilities/issue-fix/README.zh-CN.md
+++ b/docs/capabilities/issue-fix/README.zh-CN.md
@@ -454,6 +454,21 @@ repo-relative source ref。当前 checkout 证据保持最高权威；memory/exp
 [OpenViking pilot handoff](openviking-pilot-handoff.md) 展示真实 pilot 如何应用该证据
 顺序，同时不引入仓库特判控制路径。
 
+两者也接受 `--repository-memory-json <compact-search-read-result.json>`。这是
+host-provider hook，不是 LoopX 内置的 memory client：host 只在调用方批准的公开
+namespace 中显式执行 `search`，再对选中的命中执行 `read`，把蒸馏后的 public-safe
+摘要封装成 `issue_fix_repository_memory_read_result_v0`。LoopX 会 hash provider ref，
+始终把 memory source 保持为 advisory；只有已经在 pinned checkout revision 上验证的
+命中才允许影响 patch。紧凑 hook projection 仍写入现有 repository context，不建立
+第二套 ledger。Provider 不可用、空结果或缺少 revision 时，仓库工作流 fail-open；
+raw memory body、自动 transcript capture、memory writeback、私有 namespace 与凭据
+都会被拒绝。
+
+是否默认开启必须由真实证据决定，而不是安装即默认。项目应先在多个独立 issue/context
+run 和至少一次重启边界上 dogfood；只有当该 hook 能反复提供经 checkout 验证的新证据，
+且没有陈旧、误导或边界越界结果时，才作为打包默认能力。否则保留为显式可选能力，同时
+继续保持 fail-open。
+
 ## PR Lifecycle Monitor
 
 发布后，`loopx issue-fix pr-lifecycle` 与 `continuous_monitor` todo 持续跟踪 CI、
@@ -508,6 +523,7 @@ loopx issue-fix workflow-plan \
   --url https://github.com/owner/repo/issues/123 \
   --repo-path /path/to/approved/repo \
   --repository-context-json context.json \
+  --repository-memory-json compact-search-read-result.json \
   --validation-label "focused unit test" \
   --format json
 
@@ -519,6 +535,7 @@ loopx issue-fix feasibility \
   --scope-class bounded \
   --validation-label "focused unit test" \
   --repository-context-json context.json \
+  --repository-memory-json compact-search-read-result.json \
   --goal-id example-goal \
   --format json
 
@@ -572,6 +589,7 @@ python3 examples/issue-fix-reviewer-notification-sink-smoke.py
 python3 examples/issue-fix-workflow-plan-smoke.py
 python3 examples/issue-fix-workflow-contract-smoke.py
 python3 examples/issue-fix-repository-context-smoke.py
+python3 examples/issue-fix-repository-memory-smoke.py
 python3 examples/issue-fix-feasibility-smoke.py
 python3 examples/issue-fix-pr-lifecycle-smoke.py
 python3 examples/issue-fix-outcome-projection-smoke.py

--- a/examples/issue-fix-repository-memory-smoke.py
+++ b/examples/issue-fix-repository-memory-smoke.py
@@ -138,7 +138,7 @@ def main() -> int:
     memory_sources = [
         row for row in context["sources"] if row["source_kind"] == "memory_retrieval"
     ]
-    assert len(memory_sources) == 2, memory_sources
+    assert len(memory_sources) == 1, memory_sources
     assert all(row["trust"] == "advisory" for row in memory_sources), memory_sources
     assert all(row["reference"].startswith("memory:") for row in memory_sources)
     assert_boundary(context)

--- a/examples/issue-fix-repository-memory-smoke.py
+++ b/examples/issue-fix-repository-memory-smoke.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Smoke-test provider-neutral repository-memory composition and fail-open use."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx.capabilities.issue_fix.feasibility import (  # noqa: E402
+    build_issue_fix_feasibility_packet,
+)
+from loopx.capabilities.issue_fix.repository_context import (  # noqa: E402
+    build_issue_fix_repository_context_packet,
+)
+
+REVISION = "9cf42405a8bb0a8a17a66d4f953515f5a2c82620"
+ISSUE_URL = "https://github.com/volcengine/OpenViking/issues/3124"
+
+
+def repository_context() -> dict[str, object]:
+    return {
+        "schema_version": "issue_fix_repository_context_input_v0",
+        "repository_revision": REVISION,
+        "sources": [
+            {
+                "source_id": "current-source",
+                "source_kind": "source_code",
+                "reference": "openviking/server/api/v1/vlm.py",
+                "trust": "authoritative",
+                "freshness": "current",
+                "supports": ["change_scope", "reproduction"],
+                "summary": "Current checkout bounds the affected VLM status path.",
+            },
+            {
+                "source_id": "focused-test",
+                "source_kind": "test_surface",
+                "reference": "tests/unit/server/test_vlm_status.py",
+                "trust": "verified",
+                "freshness": "current",
+                "supports": ["validation"],
+                "summary": "Focused status regression surface.",
+            },
+        ],
+    }
+
+
+def completed_memory() -> dict[str, object]:
+    return {
+        "schema_version": "issue_fix_repository_memory_read_result_v0",
+        "provider": "fake_memory",
+        "namespace": "public_repository_memory",
+        "visibility": "public",
+        "status": "completed",
+        "query_summary": "Prior public VLM status fixes and validation lessons.",
+        "observed_at": "2026-07-11T02:40:00+08:00",
+        "search_performed": True,
+        "read_performed": True,
+        "writeback_performed": False,
+        "automatic_capture_performed": False,
+        "results": [
+            {
+                "memory_ref": "provider-private-record-1",
+                "summary": "A prior fix kept provider failures distinct from status.",
+                "supports": ["change_scope", "reproduction"],
+                "verification_status": "confirmed",
+                "verification_reference": "openviking/server/api/v1/vlm.py",
+                "verification_revision": REVISION,
+            },
+            {
+                "memory_ref": "provider-private-record-2",
+                "summary": "A historical validation hint still needs checkout proof.",
+                "supports": ["validation"],
+                "verification_status": "unverified",
+            },
+        ],
+    }
+
+
+def unavailable_openviking() -> dict[str, object]:
+    return {
+        "schema_version": "issue_fix_repository_memory_read_result_v0",
+        "provider": "openviking_codex_memory",
+        "namespace": "openviking_public_repository",
+        "visibility": "public",
+        "status": "unavailable",
+        "query_summary": "Public OpenViking repository history for issue 3124.",
+        "observed_at": "2026-07-11T02:40:00+08:00",
+        "search_performed": False,
+        "read_performed": False,
+        "reason_code": "connector_unavailable",
+        "writeback_performed": False,
+        "automatic_capture_performed": False,
+        "results": [],
+    }
+
+
+def assert_boundary(payload: dict[str, object]) -> None:
+    text = json.dumps(payload, ensure_ascii=True, sort_keys=True)
+    for forbidden in (
+        "provider-private-record-1",
+        "provider-private-record-2",
+        "raw memory body",
+        "credential-value",
+        "/Users/",
+        "/private/tmp/",
+    ):
+        assert forbidden not in text, (forbidden, text)
+
+
+def main() -> int:
+    context_input = repository_context()
+    memory_input = completed_memory()
+    context = build_issue_fix_repository_context_packet(
+        repo="volcengine/OpenViking",
+        issue_ref="issue_3124",
+        context_input=context_input,
+        memory_retrieval_input=memory_input,
+    )
+    assert context["ok"] is True, context
+    assert context["context_status"] == "grounded", context
+    assert context["external_reads_performed"] is True, context
+    hook = context["memory_projection"]["retrieval_hook"]
+    assert hook["status"] == "used", hook
+    assert hook["result_count"] == 2, hook
+    assert hook["confirmed_count"] == 1, hook
+    assert hook["unverified_count"] == 1, hook
+    assert hook["patch_influence_allowed_count"] == 1, hook
+    assert hook["writeback_performed"] is False, hook
+    assert hook["automatic_capture_performed"] is False, hook
+    memory_sources = [
+        row for row in context["sources"] if row["source_kind"] == "memory_retrieval"
+    ]
+    assert len(memory_sources) == 2, memory_sources
+    assert all(row["trust"] == "advisory" for row in memory_sources), memory_sources
+    assert all(row["reference"].startswith("memory:") for row in memory_sources)
+    assert_boundary(context)
+
+    feasibility = build_issue_fix_feasibility_packet(
+        url=ISSUE_URL,
+        reproduction_status="planned",
+        reproduction_label="focused VLM status reproduction",
+        scope_class="bounded",
+        validation_label="focused VLM status regression",
+        repository_context_input=context_input,
+        repository_memory_input=memory_input,
+    )
+    assert feasibility["decision"]["route"] == "fix_pr", feasibility
+    assert feasibility["repository_context_effect"]["route_overridden"] is False
+    assert_boundary(feasibility)
+
+    unavailable = build_issue_fix_repository_context_packet(
+        repo="volcengine/OpenViking",
+        issue_ref="issue_3124",
+        context_input=context_input,
+        memory_retrieval_input=unavailable_openviking(),
+    )
+    unavailable_hook = unavailable["memory_projection"]["retrieval_hook"]
+    assert unavailable["ok"] is True, unavailable
+    assert unavailable["context_status"] == "grounded", unavailable
+    assert unavailable_hook["status"] == "unavailable", unavailable_hook
+    assert unavailable_hook["reason_code"] == "connector_unavailable"
+    assert unavailable_hook["fail_open"] is True
+    assert unavailable_hook["source_refs"] == []
+    assert_boundary(unavailable)
+
+    invalid_capture = dict(memory_input)
+    invalid_capture["automatic_capture_performed"] = True
+    try:
+        build_issue_fix_repository_context_packet(
+            repo="owner/repo",
+            issue_ref="issue_1",
+            context_input=context_input,
+            memory_retrieval_input=invalid_capture,
+        )
+    except ValueError as exc:
+        assert "automatic capture" in str(exc), exc
+    else:
+        raise AssertionError("automatic memory capture must be rejected")
+
+    with tempfile.TemporaryDirectory(prefix="loopx-memory-hook-") as tmpdir:
+        tmp = Path(tmpdir)
+        context_path = tmp / "context.json"
+        memory_path = tmp / "memory.json"
+        context_path.write_text(json.dumps(context_input), encoding="utf-8")
+        memory_path.write_text(json.dumps(memory_input), encoding="utf-8")
+        command = [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "issue-fix",
+            "workflow-plan",
+            "--url",
+            ISSUE_URL,
+            "--repository-context-json",
+            str(context_path),
+            "--repository-memory-json",
+            str(memory_path),
+            "--validation-label",
+            "focused VLM status regression",
+        ]
+        result = subprocess.run(
+            command,
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        cli_packet = json.loads(result.stdout)
+        cli_hook = cli_packet["repository_context"]["memory_projection"][
+            "retrieval_hook"
+        ]
+        assert cli_hook["status"] == "used", cli_hook
+        assert cli_hook["confirmed_count"] == 1, cli_hook
+        assert_boundary(cli_packet)
+
+    print("issue-fix-repository-memory-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -210,6 +210,15 @@ def register_issue_fix_commands(
         ),
     )
     workflow_parser.add_argument(
+        "--repository-memory-json",
+        default=None,
+        help=(
+            "Optional issue_fix_repository_memory_read_result_v0 JSON path, or '-' "
+            "for stdin. The host must perform explicit public-namespace search/read; "
+            "LoopX keeps only compact advisory refs and checkout verification."
+        ),
+    )
+    workflow_parser.add_argument(
         "--generated-at",
         default="2026-06-23T00:00:00Z",
         help="Public-safe generated_at timestamp for the workflow plan.",
@@ -271,6 +280,14 @@ def register_issue_fix_commands(
         help=(
             "Optional issue_fix_repository_context_input_v0 JSON path, or '-' for "
             "stdin. The compact projection is persisted with feasibility domain state."
+        ),
+    )
+    feasibility_parser.add_argument(
+        "--repository-memory-json",
+        default=None,
+        help=(
+            "Optional issue_fix_repository_memory_read_result_v0 JSON path, or '-' "
+            "for stdin. Provider failures stay fail-open and no writeback is allowed."
         ),
     )
     feasibility_parser.add_argument(
@@ -742,7 +759,16 @@ def handle_issue_fix_command(
         if args.issue_fix_command == "workflow-plan":
             if args.fetch_metadata and args.metadata_json:
                 raise ValueError("--fetch-metadata cannot be combined with --metadata-json")
-            if args.metadata_json == "-" and args.repository_context_json == "-":
+            stdin_inputs = [
+                value
+                for value in (
+                    args.metadata_json,
+                    args.repository_context_json,
+                    args.repository_memory_json,
+                )
+                if value == "-"
+            ]
+            if len(stdin_inputs) > 1:
                 raise ValueError("only one JSON input may read from stdin")
             payload = build_issue_fix_workflow_plan_packet(
                 repo=args.repo,
@@ -762,10 +788,20 @@ def handle_issue_fix_command(
                     if args.repository_context_json
                     else None
                 ),
+                repository_memory_input=(
+                    _load_json_object(args.repository_memory_json)
+                    if args.repository_memory_json
+                    else None
+                ),
                 generated_at=args.generated_at,
             )
             renderer = render_issue_fix_workflow_plan_markdown
         elif args.issue_fix_command == "feasibility":
+            if (
+                args.repository_context_json == "-"
+                and args.repository_memory_json == "-"
+            ):
+                raise ValueError("only one JSON input may read from stdin")
             boundary_authority_scopes, boundary_authority_resolved = (
                 _goal_boundary_authority_projection(
                     registry_path=registry_path,
@@ -784,6 +820,11 @@ def handle_issue_fix_command(
                 repository_context_input=(
                     _load_json_object(args.repository_context_json)
                     if args.repository_context_json
+                    else None
+                ),
+                repository_memory_input=(
+                    _load_json_object(args.repository_memory_json)
+                    if args.repository_memory_json
                     else None
                 ),
                 boundary_authority_scopes=boundary_authority_scopes,

--- a/loopx/capabilities/issue_fix/feasibility.py
+++ b/loopx/capabilities/issue_fix/feasibility.py
@@ -222,6 +222,7 @@ def build_issue_fix_feasibility_packet(
     validation_label: str | None = None,
     comment_value: str = "none",
     repository_context_input: Mapping[str, Any] | None = None,
+    repository_memory_input: Mapping[str, Any] | None = None,
     boundary_authority_scopes: Sequence[str] = (),
     boundary_authority_resolved: bool = False,
     generated_at: str | None = "2026-06-23T00:00:00Z",
@@ -244,6 +245,7 @@ def build_issue_fix_feasibility_packet(
         repo=str(reference["repo"]),
         issue_ref=str(reference["issue_ref"]),
         context_input=repository_context_input,
+        memory_retrieval_input=repository_memory_input,
         generated_at=generated_at,
     )
     safe_reproduction_label = _safe_label(

--- a/loopx/capabilities/issue_fix/repository_context.py
+++ b/loopx/capabilities/issue_fix/repository_context.py
@@ -9,6 +9,7 @@ from typing import Any
 from urllib.parse import urlsplit
 
 from ...control_plane.runtime.public_safety import public_safe_compact_text
+from .repository_memory import build_issue_fix_repository_memory_hook
 
 
 ISSUE_FIX_REPOSITORY_CONTEXT_INPUT_SCHEMA_VERSION = (
@@ -103,6 +104,8 @@ def _normalise_source(raw: Any, *, index: int, has_revision: bool) -> dict[str, 
         raise ValueError(f"sources[{index}].trust must be one of {sorted(TRUST_LEVELS)}")
     if source_kind == "external_expert" and trust != "advisory":
         raise ValueError("external_expert sources must remain advisory")
+    if source_kind == "memory_retrieval" and trust != "advisory":
+        raise ValueError("memory_retrieval sources must remain advisory")
     freshness = str(raw.get("freshness") or "unknown").strip()
     if freshness not in FRESHNESS_STATES:
         raise ValueError(
@@ -235,13 +238,14 @@ def build_issue_fix_repository_context_packet(
     repo: str,
     issue_ref: str,
     context_input: Mapping[str, Any] | None = None,
+    memory_retrieval_input: Mapping[str, Any] | None = None,
     generated_at: str | None = "2026-06-23T00:00:00Z",
 ) -> dict[str, Any]:
-    """Build compact repository knowledge evidence without retrieving or writing it."""
+    """Compose compact repository and host-retrieved memory evidence."""
 
-    provided = context_input is not None
+    provided = context_input is not None or memory_retrieval_input is not None
     raw_input: Mapping[str, Any] = context_input or {}
-    if provided:
+    if context_input is not None:
         if raw_input.get("schema_version") != ISSUE_FIX_REPOSITORY_CONTEXT_INPUT_SCHEMA_VERSION:
             raise ValueError(
                 "repository context schema_version must be "
@@ -260,11 +264,16 @@ def build_issue_fix_repository_context_packet(
     raw_sources = raw_input.get("sources") or []
     if not isinstance(raw_sources, Sequence) or isinstance(raw_sources, (str, bytes)):
         raise ValueError("repository context sources must be a list")
-    if len(raw_sources) > MAX_SOURCES:
+    memory_hook = build_issue_fix_repository_memory_hook(
+        memory_input=memory_retrieval_input,
+        repository_revision=repository_revision,
+    )
+    composed_sources = [*raw_sources, *memory_hook["sources"]]
+    if len(composed_sources) > MAX_SOURCES:
         raise ValueError(f"repository context supports at most {MAX_SOURCES} sources")
     sources = [
         _normalise_source(raw, index=index, has_revision=bool(repository_revision))
-        for index, raw in enumerate(raw_sources)
+        for index, raw in enumerate(composed_sources)
     ]
     source_ids = [source["source_id"] for source in sources]
     if len(source_ids) != len(set(source_ids)):
@@ -288,6 +297,7 @@ def build_issue_fix_repository_context_packet(
                 "issue_ref": issue_ref,
                 "repository_revision": repository_revision,
                 "sources": sources,
+                "memory_hook": memory_hook["projection"],
             },
             ensure_ascii=True,
             sort_keys=True,
@@ -332,9 +342,13 @@ def build_issue_fix_repository_context_packet(
             "schema_version": "issue_fix_repository_memory_projection_v0",
             "source_refs": memory_refs,
             "knowledge_bundle_refs": bundle_refs,
-            "live_retrieval_performed": False,
+            "live_retrieval_performed": bool(
+                memory_hook["projection"].get("search_performed")
+                or memory_hook["projection"].get("read_performed")
+            ),
             "writeback_performed": False,
             "raw_memory_captured": False,
+            "retrieval_hook": memory_hook["projection"],
             "writeback_policy": (
                 "After a validated outcome, write only distilled reusable facts with "
                 "repository revision, provenance, freshness, and supersession metadata."
@@ -346,7 +360,10 @@ def build_issue_fix_repository_context_packet(
             "external_expert_is_advisory": True,
             "context_cannot_authorize_external_writes": True,
         },
-        "external_reads_performed": False,
+        "external_reads_performed": bool(
+            memory_hook["projection"].get("search_performed")
+            or memory_hook["projection"].get("read_performed")
+        ),
         "external_writes_performed": False,
         "raw_content_captured": False,
         "raw_responses_captured": False,
@@ -366,8 +383,9 @@ def validate_issue_fix_repository_context_packet(
     errors: list[str] = []
     if packet.get("schema_version") != ISSUE_FIX_REPOSITORY_CONTEXT_SCHEMA_VERSION:
         errors.append("packet schema_version must be issue_fix_repository_context_v0")
+    if packet.get("external_reads_performed") not in {True, False}:
+        errors.append("packet external_reads_performed must be a boolean")
     for key in (
-        "external_reads_performed",
         "external_writes_performed",
         "raw_content_captured",
         "raw_responses_captured",
@@ -398,6 +416,8 @@ def validate_issue_fix_repository_context_packet(
             errors.append("packet sources must not capture raw responses")
         if source.get("source_kind") == "external_expert" and source.get("trust") != "advisory":
             errors.append("external expert sources must remain advisory")
+        if source.get("source_kind") == "memory_retrieval" and source.get("trust") != "advisory":
+            errors.append("memory retrieval sources must remain advisory")
     truth = packet.get("truth_contract")
     if not isinstance(truth, Mapping) or truth.get(
         "context_cannot_authorize_external_writes"

--- a/loopx/capabilities/issue_fix/repository_context.py
+++ b/loopx/capabilities/issue_fix/repository_context.py
@@ -383,7 +383,7 @@ def validate_issue_fix_repository_context_packet(
     errors: list[str] = []
     if packet.get("schema_version") != ISSUE_FIX_REPOSITORY_CONTEXT_SCHEMA_VERSION:
         errors.append("packet schema_version must be issue_fix_repository_context_v0")
-    if packet.get("external_reads_performed") not in {True, False}:
+    if not isinstance(packet.get("external_reads_performed"), bool):
         errors.append("packet external_reads_performed must be a boolean")
     for key in (
         "external_writes_performed",

--- a/loopx/capabilities/issue_fix/repository_memory.py
+++ b/loopx/capabilities/issue_fix/repository_memory.py
@@ -284,32 +284,38 @@ def build_issue_fix_repository_memory_hook(
                 "metadata while unverified"
             )
 
-        source_id = _memory_ref_id(
-            provider=provider,
-            namespace=namespace,
-            memory_ref=memory_ref,
-        )
-        source_summary = f"{summary} Checkout verification: {verification_status}."
-        if verification_reference:
-            source_summary += f" Evidence: {verification_reference}."
-        sources.append(
-            {
-                "source_id": source_id,
-                "source_kind": "memory_retrieval",
-                "reference": f"memory:{source_id.removeprefix('memory-')}",
-                "trust": "advisory",
-                "freshness": (
-                    "current"
-                    if verification_status in {"confirmed", "refuted"}
-                    else "unknown"
-                ),
-                "supports": supports,
-                "summary": source_summary,
-            }
-        )
+        if verification_status == "confirmed":
+            source_id = _memory_ref_id(
+                provider=provider,
+                namespace=namespace,
+                memory_ref=memory_ref,
+            )
+            source_summary = (
+                f"{summary} Checkout verification: confirmed. "
+                f"Evidence: {verification_reference}."
+            )
+            sources.append(
+                {
+                    "source_id": source_id,
+                    "source_kind": "memory_retrieval",
+                    "reference": f"memory:{source_id.removeprefix('memory-')}",
+                    "trust": "advisory",
+                    "freshness": "current",
+                    "supports": supports,
+                    "summary": source_summary,
+                }
+            )
 
     projection = _empty_projection(
-        status="used" if sources else "empty",
+        status=(
+            "used"
+            if sources
+            else "verification_required"
+            if counts["unverified"]
+            else "no_usable_results"
+            if counts["refuted"]
+            else "empty"
+        ),
         provider=provider,
         namespace=namespace,
         search_performed=search_performed,
@@ -319,7 +325,7 @@ def build_issue_fix_repository_memory_hook(
         {
             "query_summary": query_summary,
             "observed_at": observed_at,
-            "result_count": len(sources),
+            "result_count": len(raw_results),
             "confirmed_count": counts["confirmed"],
             "refuted_count": counts["refuted"],
             "unverified_count": counts["unverified"],

--- a/loopx/capabilities/issue_fix/repository_memory.py
+++ b/loopx/capabilities/issue_fix/repository_memory.py
@@ -1,0 +1,331 @@
+from __future__ import annotations
+
+import hashlib
+import re
+from collections.abc import Mapping, Sequence
+from pathlib import PurePosixPath
+from typing import Any
+
+from ...control_plane.runtime.public_safety import public_safe_compact_text
+
+
+ISSUE_FIX_REPOSITORY_MEMORY_READ_RESULT_SCHEMA_VERSION = (
+    "issue_fix_repository_memory_read_result_v0"
+)
+ISSUE_FIX_REPOSITORY_MEMORY_HOOK_SCHEMA_VERSION = "issue_fix_repository_memory_hook_v0"
+
+PROVIDER_STATUSES = {"completed", "unavailable", "disabled"}
+VERIFICATION_STATUSES = {"confirmed", "refuted", "unverified"}
+SUPPORT_ASPECTS = {
+    "architecture",
+    "ownership",
+    "change_scope",
+    "reproduction",
+    "validation",
+}
+MAX_MEMORY_RESULTS = 6
+
+_LABEL_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,119}$")
+_INPUT_FIELDS = {
+    "schema_version",
+    "provider",
+    "namespace",
+    "visibility",
+    "status",
+    "query_summary",
+    "observed_at",
+    "search_performed",
+    "read_performed",
+    "results",
+    "reason_code",
+    "writeback_performed",
+    "automatic_capture_performed",
+}
+_RESULT_FIELDS = {
+    "memory_ref",
+    "summary",
+    "supports",
+    "verification_status",
+    "verification_reference",
+    "verification_revision",
+}
+
+
+def _safe_text(value: Any, *, field: str, limit: int = 220) -> str:
+    text = public_safe_compact_text(value, limit=limit)
+    if not text:
+        raise ValueError(f"{field} must be compact and public-safe")
+    return text
+
+
+def _safe_label(value: Any, *, field: str) -> str:
+    label = _safe_text(value, field=field, limit=120)
+    if not _LABEL_PATTERN.fullmatch(label):
+        raise ValueError(f"{field} must be a compact public-safe label")
+    return label
+
+
+def _safe_repo_reference(value: Any, *, field: str) -> str:
+    reference = _safe_text(value, field=field, limit=260)
+    if reference.startswith(("/", "~")) or re.match(r"^[A-Za-z]:[\\/]", reference):
+        raise ValueError(f"{field} must be repository-relative")
+    if "://" in reference:
+        raise ValueError(f"{field} must be repository-relative")
+    path = PurePosixPath(reference)
+    if ".." in path.parts:
+        raise ValueError(f"{field} must not traverse outside the repository")
+    return reference
+
+
+def _memory_ref_id(*, provider: str, namespace: str, memory_ref: str) -> str:
+    digest = hashlib.sha256(
+        f"{provider}\n{namespace}\n{memory_ref}".encode("utf-8")
+    ).hexdigest()[:20]
+    return f"memory-{digest}"
+
+
+def _empty_projection(
+    *,
+    status: str,
+    provider: str | None = None,
+    namespace: str | None = None,
+    reason_code: str | None = None,
+    search_performed: bool = False,
+    read_performed: bool = False,
+) -> dict[str, Any]:
+    projection: dict[str, Any] = {
+        "schema_version": ISSUE_FIX_REPOSITORY_MEMORY_HOOK_SCHEMA_VERSION,
+        "status": status,
+        "provider": provider,
+        "namespace": namespace,
+        "visibility": "public" if namespace else None,
+        "explicit_search_read_only": True,
+        "search_performed": search_performed,
+        "read_performed": read_performed,
+        "result_count": 0,
+        "confirmed_count": 0,
+        "refuted_count": 0,
+        "unverified_count": 0,
+        "patch_influence_allowed_count": 0,
+        "source_refs": [],
+        "verification_refs": [],
+        "fail_open": True,
+        "writeback_performed": False,
+        "automatic_capture_performed": False,
+        "raw_memory_captured": False,
+        "raw_provider_payload_captured": False,
+        "credentials_captured": False,
+    }
+    if reason_code:
+        projection["reason_code"] = reason_code
+    return projection
+
+
+def build_issue_fix_repository_memory_hook(
+    *,
+    memory_input: Mapping[str, Any] | None,
+    repository_revision: str | None,
+) -> dict[str, Any]:
+    """Normalise a host-provided search/read result without retaining raw memory."""
+
+    if memory_input is None:
+        return {
+            "sources": [],
+            "projection": _empty_projection(status="not_requested"),
+        }
+    if not isinstance(memory_input, Mapping):
+        raise ValueError("repository memory result must be an object")
+    unknown = sorted(set(memory_input) - _INPUT_FIELDS)
+    if unknown:
+        raise ValueError(f"repository memory result has unsupported fields: {unknown}")
+    if (
+        memory_input.get("schema_version")
+        != ISSUE_FIX_REPOSITORY_MEMORY_READ_RESULT_SCHEMA_VERSION
+    ):
+        raise ValueError(
+            "repository memory result schema_version must be "
+            "issue_fix_repository_memory_read_result_v0"
+        )
+    if memory_input.get("writeback_performed") is not False:
+        raise ValueError("repository memory hook forbids memory writeback")
+    if memory_input.get("automatic_capture_performed") is not False:
+        raise ValueError("repository memory hook forbids automatic capture")
+
+    provider = _safe_label(memory_input.get("provider"), field="provider")
+    namespace = _safe_label(memory_input.get("namespace"), field="namespace")
+    if memory_input.get("visibility") != "public":
+        raise ValueError("repository memory namespace visibility must be public")
+    status = str(memory_input.get("status") or "").strip()
+    if status not in PROVIDER_STATUSES:
+        raise ValueError(
+            f"repository memory status must be one of {sorted(PROVIDER_STATUSES)}"
+        )
+    query_summary = _safe_text(
+        memory_input.get("query_summary"), field="query_summary", limit=220
+    )
+    observed_at = _safe_text(
+        memory_input.get("observed_at"), field="observed_at", limit=80
+    )
+    search_performed = memory_input.get("search_performed") is True
+    read_performed = memory_input.get("read_performed") is True
+    raw_results = memory_input.get("results") or []
+    if not isinstance(raw_results, Sequence) or isinstance(raw_results, (str, bytes)):
+        raise ValueError("repository memory results must be a list")
+    if len(raw_results) > MAX_MEMORY_RESULTS:
+        raise ValueError(
+            f"repository memory result supports at most {MAX_MEMORY_RESULTS} hits"
+        )
+
+    if status in {"unavailable", "disabled"}:
+        if raw_results:
+            raise ValueError(f"repository memory status {status} must not include hits")
+        reason_code = _safe_label(memory_input.get("reason_code"), field="reason_code")
+        return {
+            "sources": [],
+            "projection": _empty_projection(
+                status=status,
+                provider=provider,
+                namespace=namespace,
+                reason_code=reason_code,
+                search_performed=search_performed,
+                read_performed=read_performed,
+            )
+            | {
+                "query_summary": query_summary,
+                "observed_at": observed_at,
+            },
+        }
+
+    if not search_performed:
+        raise ValueError("completed repository memory result requires explicit search")
+    if raw_results and not read_performed:
+        raise ValueError("repository memory hits require explicit read")
+    if raw_results and not repository_revision:
+        return {
+            "sources": [],
+            "projection": _empty_projection(
+                status="skipped_missing_revision",
+                provider=provider,
+                namespace=namespace,
+                reason_code="repository_revision_required",
+                search_performed=search_performed,
+                read_performed=read_performed,
+            )
+            | {
+                "query_summary": query_summary,
+                "observed_at": observed_at,
+                "discarded_result_count": len(raw_results),
+            },
+        }
+
+    sources: list[dict[str, Any]] = []
+    verification_refs: list[str] = []
+    counts = {key: 0 for key in VERIFICATION_STATUSES}
+    for index, raw in enumerate(raw_results):
+        if not isinstance(raw, Mapping):
+            raise ValueError(f"repository memory results[{index}] must be an object")
+        unknown_result = sorted(set(raw) - _RESULT_FIELDS)
+        if unknown_result:
+            raise ValueError(
+                f"repository memory results[{index}] has unsupported fields: "
+                f"{unknown_result}"
+            )
+        memory_ref = _safe_text(
+            raw.get("memory_ref"), field=f"results[{index}].memory_ref", limit=500
+        )
+        summary = _safe_text(
+            raw.get("summary"), field=f"results[{index}].summary", limit=220
+        )
+        raw_supports = raw.get("supports")
+        if not isinstance(raw_supports, Sequence) or isinstance(
+            raw_supports, (str, bytes)
+        ):
+            raise ValueError(
+                f"repository memory results[{index}].supports must be a list"
+            )
+        supports = sorted(
+            {str(value).strip() for value in raw_supports if str(value).strip()}
+        )
+        if not supports or any(value not in SUPPORT_ASPECTS for value in supports):
+            raise ValueError(
+                f"repository memory results[{index}].supports must use "
+                f"{sorted(SUPPORT_ASPECTS)}"
+            )
+        verification_status = str(
+            raw.get("verification_status") or "unverified"
+        ).strip()
+        if verification_status not in VERIFICATION_STATUSES:
+            raise ValueError(
+                f"repository memory results[{index}].verification_status must be one "
+                f"of {sorted(VERIFICATION_STATUSES)}"
+            )
+        counts[verification_status] += 1
+
+        verification_reference: str | None = None
+        if verification_status in {"confirmed", "refuted"}:
+            verification_reference = _safe_repo_reference(
+                raw.get("verification_reference"),
+                field=f"results[{index}].verification_reference",
+            )
+            verification_revision = _safe_text(
+                raw.get("verification_revision"),
+                field=f"results[{index}].verification_revision",
+                limit=120,
+            )
+            if verification_revision != repository_revision:
+                raise ValueError(
+                    f"repository memory results[{index}] verification_revision must "
+                    "match repository_revision"
+                )
+            verification_refs.append(verification_reference)
+        elif raw.get("verification_reference") or raw.get("verification_revision"):
+            raise ValueError(
+                f"repository memory results[{index}] must not claim verification "
+                "metadata while unverified"
+            )
+
+        source_id = _memory_ref_id(
+            provider=provider,
+            namespace=namespace,
+            memory_ref=memory_ref,
+        )
+        source_summary = f"{summary} Checkout verification: {verification_status}."
+        if verification_reference:
+            source_summary += f" Evidence: {verification_reference}."
+        sources.append(
+            {
+                "source_id": source_id,
+                "source_kind": "memory_retrieval",
+                "reference": f"memory:{source_id.removeprefix('memory-')}",
+                "trust": "advisory",
+                "freshness": (
+                    "current"
+                    if verification_status in {"confirmed", "refuted"}
+                    else "unknown"
+                ),
+                "supports": supports,
+                "summary": source_summary,
+            }
+        )
+
+    projection = _empty_projection(
+        status="used" if sources else "empty",
+        provider=provider,
+        namespace=namespace,
+        search_performed=search_performed,
+        read_performed=read_performed,
+    )
+    projection.update(
+        {
+            "query_summary": query_summary,
+            "observed_at": observed_at,
+            "result_count": len(sources),
+            "confirmed_count": counts["confirmed"],
+            "refuted_count": counts["refuted"],
+            "unverified_count": counts["unverified"],
+            "patch_influence_allowed_count": counts["confirmed"],
+            "source_refs": [source["source_id"] for source in sources],
+            "verification_refs": sorted(set(verification_refs)),
+        }
+    )
+    return {"sources": sources, "projection": projection}

--- a/loopx/capabilities/issue_fix/workflow_plan.py
+++ b/loopx/capabilities/issue_fix/workflow_plan.py
@@ -216,6 +216,7 @@ def build_issue_fix_workflow_plan_packet(
     issue_branch: str | None = None,
     validation_label: str = "caller-declared validation",
     repository_context_input: Mapping[str, Any] | None = None,
+    repository_memory_input: Mapping[str, Any] | None = None,
     generated_at: str | None = "2026-06-23T00:00:00Z",
 ) -> dict[str, Any]:
     """Build a public-safe issue-fix workflow plan without writing state."""
@@ -250,6 +251,7 @@ def build_issue_fix_workflow_plan_packet(
         repo=repo_label,
         issue_ref=issue_label,
         context_input=repository_context_input,
+        memory_retrieval_input=repository_memory_input,
         generated_at=generated_at,
     )
     unresolved_context = list(


### PR DESCRIPTION
## Summary

- add a provider-neutral, host-supplied repository-memory `search`/`read` result hook to issue-fix workflow planning and feasibility
- accept only public namespaces, hash provider references, keep memory advisory, and persist summaries only after verification against the pinned checkout revision
- reject automatic capture and writeback; keep provider unavailability, empty results, and missing revisions fail-open
- document the contract in English and Chinese with one focused provider-neutral smoke

## Validation

- `python3 examples/issue-fix-repository-memory-smoke.py`
- `python3 examples/issue-fix-repository-context-smoke.py`
- `python3 examples/issue-fix-workflow-plan-smoke.py`
- `python3 examples/issue-fix-feasibility-smoke.py`
- `python3 examples/issue-fix-capability-guide-smoke.py`
- Python compile and Ruff checks on changed Python surfaces
- `loopx canary premerge --from-git-diff`: passed 17 selected checks, 0 failures, 0 warnings, 0 manual holds
- public/private boundary scan: 8 changed files, 0 findings

## Risk and follow-up

This PR deliberately does not install or enable an OpenViking Codex plugin, automatic recall/capture, credentials, or memory writeback. The current local OpenViking connector was unavailable, so live search/read dogfood and the evidence-based default-versus-opt-in packaging decision remain a separate tracked follow-up. The shipped path is fail-open and is not enabled by default.