### PR TITLE
Add explicit Explore result-node linkage for todos

### DIFF
--- a/docs/capabilities/explore/README.md
+++ b/docs/capabilities/explore/README.md
@@ -143,6 +143,23 @@ packet with:
 - the safety boundary that makes the packet experimental rather than a
   replacement for `quota should-run`.
 
+An advancement todo may opt into typed result diagnostics by attaching one or
+more explicit Explore node ids:
+
+```bash
+loopx todo add --goal-id <id> --role agent --text "Evaluate the rejected route" \
+  --task-class advancement_task --explore-result-node-ref node_rejected_route
+```
+
+`todo-branch-plan` resolves only those explicit links. Its bounded
+`typed_evidence_audit` reports linked node lifecycle, finding statuses,
+relevant `supports`/`refutes` edges, unknown ids, and dead-end/refutation
+hazards. The audit is diagnostic-only (`score_delta=0`) and cannot claim,
+lease, launch, write state, or spend quota. Unlinked todos retain the prior
+planner behavior. Repair a stale link by replacing it with another repeated
+`--explore-result-node-ref`, or remove all links with
+`loopx todo update ... --clear-explore-result-node-refs`.
+
 Todos without declared write scopes are treated as speculative read or
 coordination work by default, because many exploration tasks are read-only.
 Use `--no-allow-unscoped-parallel` when the controller wants unknown scopes to

--- a/examples/explore-todo-result-node-linkage-smoke.py
+++ b/examples/explore-todo-result-node-linkage-smoke.py
@@ -1,0 +1,290 @@
+#!/usr/bin/env python3
+"""Smoke-test explicit todo-to-Explore-node linkage and diagnostics."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.capabilities.explore.todo_branch_plan import (  # noqa: E402
+    build_explore_todo_branch_plan,
+)
+from loopx.control_plane.todos.contract import format_todo_metadata_line  # noqa: E402
+
+
+GOAL_ID = "explore-todo-linkage-smoke"
+ORCHESTRATION = {
+    "spawn_allowed": False,
+    "max_children": 2,
+    "explore_harness": {"enabled": True},
+}
+
+
+def run_loopx(registry: Path, *args: str) -> dict[str, object]:
+    env = {**os.environ, "PYTHONPATH": str(REPO_ROOT)}
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry),
+            "--format",
+            "json",
+            *args,
+        ],
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+    assert completed.returncode == 0, (completed.stdout, completed.stderr)
+    return json.loads(completed.stdout)
+
+
+def write_fixture(root: Path) -> tuple[Path, Path]:
+    project = root / "project"
+    project.mkdir()
+    state_file = project / "ACTIVE_GOAL_STATE.md"
+    state_file.write_text(
+        "\n".join(
+            [
+                "# Explore Todo Linkage Smoke",
+                "",
+                "## User Todo / Owner Review Reading Queue",
+                "",
+                "## Agent Todo",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    registry = root / "registry.json"
+    registry.write_text(
+        json.dumps(
+            {
+                "common_runtime_root": str(root / "runtime"),
+                "goals": [
+                    {
+                        "id": GOAL_ID,
+                        "repo": str(project),
+                        "state_file": str(state_file),
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+    return registry, state_file
+
+
+def check_todo_lifecycle() -> None:
+    try:
+        format_todo_metadata_line(
+            todo_id="todo_invalid123",
+            explore_result_node_refs=["/private/result-node"],
+        )
+    except ValueError as exc:
+        assert "public-safe Explore node ids" in str(exc), exc
+    else:
+        raise AssertionError("private path-shaped Explore node refs must fail closed")
+
+    with tempfile.TemporaryDirectory(prefix="loopx-explore-todo-link-") as tmp:
+        registry, state_file = write_fixture(Path(tmp))
+        added = run_loopx(
+            registry,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--text",
+            "[P1] Follow explicit Explore evidence.",
+            "--task-class",
+            "advancement_task",
+            "--explore-result-node-ref",
+            "node_live",
+            "--explore-result-node-ref",
+            "node_dead",
+        )
+        todo_id = str(added["todo_id"])
+        assert added["explore_result_node_refs"] == ["node_live", "node_dead"], added
+
+        listed = run_loopx(
+            registry,
+            "todo",
+            "list",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            todo_id,
+        )
+        item = listed["todos"][0]
+        assert item["explore_result_node_refs"] == ["node_live", "node_dead"], item
+
+        completed = run_loopx(
+            registry,
+            "todo",
+            "complete",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            todo_id,
+            "--evidence",
+            "typed evidence inspected",
+            "--no-follow-up",
+        )
+        assert completed["status"] == "done", completed
+        state_text = state_file.read_text(encoding="utf-8")
+        assert "explore_result_node_refs=node_live%2Cnode_dead" in state_text, state_text
+
+        run_loopx(
+            registry,
+            "todo",
+            "archive-completed",
+            "--goal-id",
+            GOAL_ID,
+            "--max-active-done",
+            "0",
+            "--execute",
+        )
+        archived = state_file.read_text(encoding="utf-8")
+        assert "Completed Work Archive" in archived, archived
+        assert "explore_result_node_refs=node_live%2Cnode_dead" in archived, archived
+
+        second = run_loopx(
+            registry,
+            "todo",
+            "add",
+            "--goal-id",
+            GOAL_ID,
+            "--role",
+            "agent",
+            "--text",
+            "[P2] Temporary evidence link.",
+            "--explore-result-node-ref",
+            "node_unknown",
+        )
+        run_loopx(
+            registry,
+            "todo",
+            "update",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            str(second["todo_id"]),
+            "--clear-explore-result-node-refs",
+        )
+        cleared = run_loopx(
+            registry,
+            "todo",
+            "list",
+            "--goal-id",
+            GOAL_ID,
+            "--todo-id",
+            str(second["todo_id"]),
+        )["todos"][0]
+        assert "explore_result_node_refs" not in cleared, cleared
+
+
+def check_planner_diagnostics() -> None:
+    projection = {
+        "nodes": [
+            {
+                "node_id": "node_dead",
+                "status": "dead_end",
+                "node_kind": "hypothesis",
+                "title": "Rejected route",
+                "finding_count": 1,
+            }
+        ],
+        "findings": [
+            {
+                "finding_id": "finding_refuted",
+                "node_id": "node_dead",
+                "status": "refuted",
+                "confidence": 0.9,
+                "finding": "The route does not satisfy the invariant.",
+            }
+        ],
+        "edges": [
+            {
+                "edge_id": "edge_refutes",
+                "from_node": "node_dead",
+                "to_node": "node_baseline",
+                "edge_type": "refutes",
+                "confidence": 0.9,
+            }
+        ],
+        "frontier": [],
+        "stuck": [],
+    }
+    linked = {
+        "todo_id": "todo_linked123",
+        "index": 1,
+        "status": "open",
+        "text": "[P1] Evaluate a linked route.",
+        "task_class": "advancement_task",
+        "explore_result_node_refs": ["node_dead", "node_unknown"],
+    }
+    unlinked = {
+        "todo_id": "todo_unlinked123",
+        "index": 2,
+        "status": "open",
+        "text": "[P2] Keep ordinary behavior.",
+        "task_class": "advancement_task",
+    }
+    plan = build_explore_todo_branch_plan(
+        goal_id=GOAL_ID,
+        todos=[linked, unlinked],
+        projection=projection,
+        orchestration=ORCHESTRATION,
+        width=2,
+    )
+    candidates = {
+        item["todo_id"]: item
+        for item in [*plan["selected_branches"], *plan["rejected_candidates"]]
+    }
+    audit = candidates["todo_linked123"]["typed_evidence_audit"]
+    assert audit["mode"] == "diagnostic_only" and audit["score_delta"] == 0.0, audit
+    assert audit["unknown_node_refs"] == ["node_unknown"], audit
+    assert set(audit["hazards"]) == {
+        "unknown_result_node_ref",
+        "linked_node_dead_end",
+        "linked_finding_refuted",
+        "refute_edge_present",
+    }, audit
+    assert audit["boundary"] == {
+        "changes_score": False,
+        "writes_state": False,
+        "claims_todos": False,
+        "acquires_leases": False,
+        "starts_agents": False,
+        "changes_quota": False,
+    }, audit
+    assert "typed_evidence_audit" not in candidates["todo_unlinked123"], candidates
+    assert all(
+        not item.get("suggested_commands")
+        for item in [*plan["selected_branches"], *plan["rejected_candidates"]]
+    ), plan
+
+
+def main() -> int:
+    check_todo_lifecycle()
+    check_planner_diagnostics()
+    print("explore-todo-result-node-linkage-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/capabilities/explore/todo_branch_plan.py
+++ b/loopx/capabilities/explore/todo_branch_plan.py
@@ -31,6 +31,7 @@ from .speculative_scheduler import (
     partition_invalidated_successors,
     schedule_confidence_prefix,
 )
+from .todo_evidence import build_todo_typed_evidence_audit
 
 
 TODO_BRANCH_PLAN_SCHEMA_VERSION = "loopx_explore_todo_branch_plan_v0"
@@ -348,6 +349,9 @@ def build_explore_todo_branch_plan(
             "claim_bucket": _claim_bucket(item, agent_id=normalized_agent),
             "source_index": item.get("index"),
         }
+        typed_evidence_audit = build_todo_typed_evidence_audit(item, projection)
+        if typed_evidence_audit is not None:
+            candidate["typed_evidence_audit"] = typed_evidence_audit
         candidates.append(candidate)
 
     candidates.sort(
@@ -489,6 +493,10 @@ def build_explore_todo_branch_plan(
             "unscoped": (
                 "treated as speculative read-or-coordination work by default; disable with "
                 "--no-allow-unscoped-parallel"
+            ),
+            "typed_evidence": (
+                "explicit Explore result-node links add bounded diagnostic-only "
+                "dead-end/refutation warnings; they do not change score or authority"
             ),
         },
         "boundary": {

--- a/loopx/capabilities/explore/todo_evidence.py
+++ b/loopx/capabilities/explore/todo_evidence.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+from collections import Counter
+from typing import Any, Mapping
+
+from ...control_plane.todos.contract import normalize_explore_result_node_refs
+
+
+TODO_EVIDENCE_AUDIT_SCHEMA_VERSION = "loopx_explore_todo_evidence_audit_v0"
+MAX_AUDIT_FINDINGS = 24
+MAX_AUDIT_EDGES = 24
+RELEVANT_EDGE_TYPES = {"supports", "refutes"}
+
+
+def _compact_node(node: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "node_id": str(node.get("node_id") or ""),
+        "status": str(node.get("status") or "open"),
+        "node_kind": str(node.get("node_kind") or "area"),
+        "title": str(node.get("title") or ""),
+        "finding_count": int(node.get("finding_count") or 0),
+    }
+
+
+def _compact_finding(finding: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "finding_id": str(finding.get("finding_id") or ""),
+        "node_id": str(finding.get("node_id") or ""),
+        "status": str(finding.get("status") or "tentative"),
+        "confidence": finding.get("confidence"),
+        "finding": str(finding.get("finding") or ""),
+    }
+
+
+def _compact_edge(edge: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "edge_id": str(edge.get("edge_id") or ""),
+        "from_node": str(edge.get("from_node") or ""),
+        "to_node": str(edge.get("to_node") or ""),
+        "edge_type": str(edge.get("edge_type") or ""),
+        "confidence": edge.get("confidence"),
+    }
+
+
+def build_todo_typed_evidence_audit(
+    todo: Mapping[str, Any],
+    projection: Mapping[str, Any] | None,
+) -> dict[str, Any] | None:
+    """Resolve only explicit todo-to-node links into bounded diagnostics.
+
+    The audit is deliberately advisory. It never changes planner score or
+    authority, and unlinked todos preserve the pre-linkage planner shape.
+    """
+
+    requested_refs = normalize_explore_result_node_refs(
+        todo.get("explore_result_node_refs")
+    )
+    if not requested_refs:
+        return None
+
+    projection = projection if isinstance(projection, Mapping) else {}
+    nodes_by_id = {
+        str(node.get("node_id") or ""): node
+        for node in projection.get("nodes") or []
+        if isinstance(node, Mapping) and node.get("node_id")
+    }
+    linked_nodes = [nodes_by_id[ref] for ref in requested_refs if ref in nodes_by_id]
+    linked_ids = {str(node.get("node_id") or "") for node in linked_nodes}
+    unknown_refs = [ref for ref in requested_refs if ref not in nodes_by_id]
+
+    findings = [
+        finding
+        for finding in projection.get("findings") or []
+        if isinstance(finding, Mapping)
+        and str(finding.get("node_id") or "") in linked_ids
+    ][:MAX_AUDIT_FINDINGS]
+    edges = [
+        edge
+        for edge in projection.get("edges") or []
+        if isinstance(edge, Mapping)
+        and str(edge.get("edge_type") or "") in RELEVANT_EDGE_TYPES
+        and (
+            str(edge.get("from_node") or "") in linked_ids
+            or str(edge.get("to_node") or "") in linked_ids
+        )
+    ][:MAX_AUDIT_EDGES]
+
+    node_statuses = Counter(str(node.get("status") or "open") for node in linked_nodes)
+    finding_statuses = Counter(
+        str(finding.get("status") or "tentative") for finding in findings
+    )
+    edge_types = Counter(str(edge.get("edge_type") or "") for edge in edges)
+    reason_codes = ["explicit_result_node_link"]
+    hazards: list[str] = []
+    if linked_nodes:
+        reason_codes.append("linked_nodes_resolved")
+    if finding_statuses.get("confirmed"):
+        reason_codes.append("confirmed_finding_present")
+    if edge_types.get("supports"):
+        reason_codes.append("support_edge_present")
+    if unknown_refs:
+        hazards.append("unknown_result_node_ref")
+    if node_statuses.get("dead_end"):
+        hazards.append("linked_node_dead_end")
+    if finding_statuses.get("refuted"):
+        hazards.append("linked_finding_refuted")
+    if edge_types.get("refutes"):
+        hazards.append("refute_edge_present")
+
+    return {
+        "schema_version": TODO_EVIDENCE_AUDIT_SCHEMA_VERSION,
+        "mode": "diagnostic_only",
+        "score_delta": 0.0,
+        "requested_node_refs": requested_refs,
+        "resolved_node_refs": [str(node.get("node_id") or "") for node in linked_nodes],
+        "unknown_node_refs": unknown_refs,
+        "nodes": [_compact_node(node) for node in linked_nodes],
+        "findings": [_compact_finding(finding) for finding in findings],
+        "relevant_edges": [_compact_edge(edge) for edge in edges],
+        "status_counts": {
+            "nodes": dict(sorted(node_statuses.items())),
+            "findings": dict(sorted(finding_statuses.items())),
+            "edges": dict(sorted(edge_types.items())),
+        },
+        "reason_codes": reason_codes,
+        "hazards": hazards,
+        "repair_hint": (
+            "Replace unknown ids with existing Explore node ids, or run `loopx todo update "
+            "--clear-explore-result-node-refs` to unlink this todo."
+            if unknown_refs
+            else ""
+        ),
+        "boundary": {
+            "changes_score": False,
+            "writes_state": False,
+            "claims_todos": False,
+            "acquires_leases": False,
+            "starts_agents": False,
+            "changes_quota": False,
+        },
+    }

--- a/loopx/cli_commands/todo.py
+++ b/loopx/cli_commands/todo.py
@@ -129,6 +129,20 @@ def register_todo_command(subparsers: argparse._SubParsersAction) -> None:
         ),
     )
     todo_parser.add_argument(
+        "--explore-result-node-ref",
+        dest="explore_result_node_refs",
+        action="append",
+        help=(
+            "For todo add/update, link an explicit public-safe Explore result node id. "
+            "Repeat for multiple nodes; analysis resolves only these links."
+        ),
+    )
+    todo_parser.add_argument(
+        "--clear-explore-result-node-refs",
+        action="store_true",
+        help="For todo update, remove all explicit Explore result node links.",
+    )
+    todo_parser.add_argument(
         "--decision-scope",
         help=(
             "For user_gate add/update, declare the concrete decision as "
@@ -379,6 +393,10 @@ def handle_todo_command(
                 raise ValueError("todo add requires --text")
             if args.clear_claim:
                 raise ValueError("todo add accepts --claimed-by but not --clear-claim")
+            if args.clear_explore_result_node_refs:
+                raise ValueError(
+                    "todo add accepts --explore-result-node-ref but not --clear-explore-result-node-refs"
+                )
             if args.next_claimed_by:
                 raise ValueError("todo add does not support --next-claimed-by")
             if args.next_continuation_policy:
@@ -401,6 +419,7 @@ def handle_todo_command(
                 required_write_scopes=args.required_write_scopes,
                 required_capabilities=args.required_capabilities,
                 target_capabilities=args.target_capabilities,
+                explore_result_node_refs=args.explore_result_node_refs,
                 decision_scope=args.decision_scope,
                 required_decision_scopes=args.required_decision_scopes,
                 claimed_by=args.claimed_by,
@@ -440,6 +459,8 @@ def handle_todo_command(
                     ("--required-write-scope", args.required_write_scopes),
                     ("--required-capability", args.required_capabilities),
                     ("--target-capability", args.target_capabilities),
+                    ("--explore-result-node-ref", args.explore_result_node_refs),
+                    ("--clear-explore-result-node-refs", args.clear_explore_result_node_refs),
                     ("--decision-scope", args.decision_scope),
                     ("--required-decision-scope", args.required_decision_scopes),
                     ("--blocks-agent", args.blocks_agent),
@@ -485,6 +506,11 @@ def handle_todo_command(
                 raise ValueError("todo update requires --todo-id")
             if args.claimed_by and args.clear_claim:
                 raise ValueError("todo update accepts either --claimed-by or --clear-claim, not both")
+            if args.explore_result_node_refs and args.clear_explore_result_node_refs:
+                raise ValueError(
+                    "todo update accepts either --explore-result-node-ref or "
+                    "--clear-explore-result-node-refs, not both"
+                )
             if not any([
                 args.text,
                 args.followups,
@@ -498,6 +524,8 @@ def handle_todo_command(
                 args.required_write_scopes,
                 args.required_capabilities,
                 args.target_capabilities,
+                args.explore_result_node_refs,
+                args.clear_explore_result_node_refs,
                 args.decision_scope,
                 args.required_decision_scopes,
                 args.claimed_by,
@@ -513,7 +541,7 @@ def handle_todo_command(
                 args.expires_at,
                 args.clear_claim,
             ]):
-                raise ValueError("todo update requires at least one of --text, --status, --note, --evidence, --reason, --task-class, --action-kind, --continuation-policy, --required-write-scope, --required-capability, --target-capability, --decision-scope, --required-decision-scope, --claimed-by, --blocks-agent, --global-gate, --unblocks-todo-id, --successor-todo-id, --resume-when, --monitor-target-key, --cadence, --next-due-at, --expires-at, --no-follow-up, or --clear-claim")
+                raise ValueError("todo update requires at least one of --text, --status, --note, --evidence, --reason, --task-class, --action-kind, --continuation-policy, --required-write-scope, --required-capability, --target-capability, --explore-result-node-ref, --clear-explore-result-node-refs, --decision-scope, --required-decision-scope, --claimed-by, --blocks-agent, --global-gate, --unblocks-todo-id, --successor-todo-id, --resume-when, --monitor-target-key, --cadence, --next-due-at, --expires-at, --no-follow-up, or --clear-claim")
             if args.no_follow_up and not (args.note or args.reason or args.evidence):
                 raise ValueError("--no-follow-up requires --note, --reason, or --evidence")
             if args.followups:
@@ -540,6 +568,11 @@ def handle_todo_command(
                 required_write_scopes=args.required_write_scopes,
                 required_capabilities=args.required_capabilities,
                 target_capabilities=args.target_capabilities,
+                explore_result_node_refs=(
+                    []
+                    if args.clear_explore_result_node_refs
+                    else args.explore_result_node_refs
+                ),
                 decision_scope=args.decision_scope,
                 required_decision_scopes=args.required_decision_scopes,
                 claimed_by=args.claimed_by,
@@ -564,6 +597,10 @@ def handle_todo_command(
         elif args.todo_command == "complete":
             if not args.todo_id:
                 raise ValueError("todo complete requires --todo-id")
+            if args.explore_result_node_refs or args.clear_explore_result_node_refs:
+                raise ValueError(
+                    "todo complete does not update --explore-result-node-ref; use todo update first"
+                )
             if args.claimed_by and args.clear_claim:
                 raise ValueError("todo complete accepts either --claimed-by or --clear-claim, not both")
             if args.blocks_agent or args.global_gate or args.unblocks_todo_id or args.resume_when:
@@ -613,6 +650,10 @@ def handle_todo_command(
         elif args.todo_command == "supersede":
             if not args.todo_id:
                 raise ValueError("todo supersede requires --todo-id")
+            if args.explore_result_node_refs or args.clear_explore_result_node_refs:
+                raise ValueError(
+                    "todo supersede does not update --explore-result-node-ref; use todo update first"
+                )
             if args.claimed_by:
                 raise ValueError(
                     "todo supersede does not support --claimed-by; use --next-claimed-by "

--- a/loopx/cli_commands/todo_argument_validation.py
+++ b/loopx/cli_commands/todo_argument_validation.py
@@ -19,6 +19,8 @@ TODO_OPTION_FIELDS = (
     ("--required-write-scope", "required_write_scopes"),
     ("--required-capability", "required_capabilities"),
     ("--target-capability", "target_capabilities"),
+    ("--explore-result-node-ref", "explore_result_node_refs"),
+    ("--clear-explore-result-node-refs", "clear_explore_result_node_refs"),
     ("--decision-scope", "decision_scope"),
     ("--required-decision-scope", "required_decision_scopes"),
     ("--claimed-by", "claimed_by"),

--- a/loopx/control_plane/todos/contract.py
+++ b/loopx/control_plane/todos/contract.py
@@ -14,6 +14,8 @@ TODO_ACTION_KIND_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{0,63}$")
 TODO_ID_PATTERN = re.compile(r"^todo_[a-z0-9_-]{3,64}$")
 TODO_AGENT_CLAIM_PATTERN = re.compile(r"^[a-z][a-z0-9_.:@-]{0,79}$")
 TODO_CAPABILITY_PATTERN = re.compile(r"^[a-z][a-z0-9_:-]{0,63}$")
+TODO_EXPLORE_RESULT_NODE_REF_PATTERN = re.compile(r"^[A-Za-z][A-Za-z0-9_.:-]{0,95}$")
+TODO_EXPLORE_RESULT_NODE_REF_LIMIT = 8
 TODO_DECISION_SCOPE_KEY_PATTERN = re.compile(r"^(?:\*|[a-z0-9][a-z0-9_.:@*/-]{0,95})$")
 TODO_RESUME_KIND_TODO_DONE = "todo_done"
 TODO_RESUME_KIND_PR_MERGED = "pr_merged"
@@ -400,6 +402,27 @@ def normalize_target_capabilities(value: Any) -> list[str]:
     return normalize_required_capabilities(value)
 
 
+def normalize_explore_result_node_refs(value: Any) -> list[str]:
+    """Normalize explicit public-safe Explore node ids attached to a todo."""
+
+    if value is None:
+        return []
+    if isinstance(value, (list, tuple, set)):
+        raw_values = [str(item or "") for item in value]
+    else:
+        raw_values = re.split(r"[,;|]", str(value or ""))
+    refs: list[str] = []
+    for raw in raw_values:
+        ref = compact_todo_text(raw)
+        if not ref or not TODO_EXPLORE_RESULT_NODE_REF_PATTERN.match(ref):
+            continue
+        if ref not in refs:
+            refs.append(ref)
+        if len(refs) >= TODO_EXPLORE_RESULT_NODE_REF_LIMIT:
+            break
+    return refs
+
+
 def normalize_todo_decision_scope(value: Any) -> dict[str, str] | None:
     """Normalize the compact decision-scope metadata token.
 
@@ -588,6 +611,10 @@ def parse_todo_metadata_line(line: str) -> dict[str, Any] | None:
             capabilities = normalize_target_capabilities(value)
             if capabilities:
                 metadata["target_capabilities"] = capabilities
+        elif key in {"explore_result_node_ref", "explore_result_node_refs"}:
+            refs = normalize_explore_result_node_refs(value)
+            if refs:
+                metadata["explore_result_node_refs"] = refs
         elif key == "decision_scope":
             decision_scope = normalize_todo_decision_scope(value)
             if decision_scope:
@@ -647,6 +674,7 @@ def format_todo_metadata_line(
     required_write_scopes: Any = None,
     required_capabilities: Any = None,
     target_capabilities: Any = None,
+    explore_result_node_refs: Any = None,
     decision_scope: Any = None,
     required_decision_scopes: Any = None,
     claimed_by: str | None = None,
@@ -733,6 +761,18 @@ def format_todo_metadata_line(
         fields.append(
             "target_capabilities="
             f"{encode_metadata_value(','.join(normalized_target_capabilities))}"
+        )
+    normalized_explore_result_node_refs = normalize_explore_result_node_refs(
+        explore_result_node_refs
+    )
+    if explore_result_node_refs and not normalized_explore_result_node_refs:
+        raise ValueError(
+            "explore_result_node_refs must contain public-safe Explore node ids"
+        )
+    if normalized_explore_result_node_refs:
+        fields.append(
+            "explore_result_node_refs="
+            f"{encode_metadata_value(','.join(normalized_explore_result_node_refs))}"
         )
     normalized_decision_scope = decision_scope_metadata_value(decision_scope)
     if decision_scope and not normalized_decision_scope:

--- a/loopx/control_plane/todos/todo_summary.py
+++ b/loopx/control_plane/todos/todo_summary.py
@@ -14,6 +14,7 @@ from .contract import (
     build_todo_id,
     normalize_required_capabilities,
     normalize_required_write_scopes,
+    normalize_explore_result_node_refs,
     normalize_target_capabilities,
     normalize_todo_action_kind,
     normalize_todo_blocks_agent,
@@ -311,6 +312,11 @@ def structured_todo_item(
     target_capabilities = normalize_target_capabilities(item.get("target_capabilities"))
     if target_capabilities:
         normalized["target_capabilities"] = target_capabilities
+    explore_result_node_refs = normalize_explore_result_node_refs(
+        item.get("explore_result_node_refs")
+    )
+    if explore_result_node_refs:
+        normalized["explore_result_node_refs"] = explore_result_node_refs
     decision_scope = normalize_todo_decision_scope(item.get("decision_scope"))
     if decision_scope:
         normalized["decision_scope"] = decision_scope
@@ -364,6 +370,7 @@ def compact_todo_item(item: dict[str, Any]) -> dict[str, Any]:
         "required_write_scopes",
         "required_capabilities",
         "target_capabilities",
+        "explore_result_node_refs",
         "decision_scope",
         "required_decision_scopes",
         "claimed_by",
@@ -821,6 +828,7 @@ def todo_item_is_succession_tracked_completion(item: dict[str, Any]) -> bool:
             "required_write_scopes",
             "required_capabilities",
             "target_capabilities",
+            "explore_result_node_refs",
             "decision_scope",
             "required_decision_scopes",
             "unblocks_todo_id",

--- a/loopx/todos.py
+++ b/loopx/todos.py
@@ -29,6 +29,7 @@ from .control_plane.todos.contract import (
     merge_todo_id_lists,
     normalize_required_capabilities,
     normalize_required_write_scopes,
+    normalize_explore_result_node_refs,
     normalize_target_capabilities,
     normalize_todo_blocks_agent,
     normalize_todo_claimed_by,
@@ -84,6 +85,7 @@ TODO_METADATA_FIELDS = (
     "required_write_scopes",
     "required_capabilities",
     "target_capabilities",
+    "explore_result_node_refs",
     "decision_scope",
     "required_decision_scopes",
     "claimed_by",
@@ -510,6 +512,11 @@ def block_metadata(block: dict[str, Any]) -> dict[str, Any]:
             if capabilities:
                 metadata[key] = capabilities
             continue
+        if key == "explore_result_node_refs":
+            refs = normalize_explore_result_node_refs(value)
+            if refs:
+                metadata[key] = refs
+            continue
         if key == "continuation_policy":
             continuation_policy = normalize_todo_continuation_policy(value)
             if continuation_policy:
@@ -563,6 +570,12 @@ def metadata_line_for_block(block: dict[str, Any], updates: dict[str, Any]) -> s
             capabilities = normalize_target_capabilities(value)
             if capabilities:
                 metadata[key] = capabilities
+            else:
+                metadata.pop(key, None)
+        elif key == "explore_result_node_refs":
+            refs = normalize_explore_result_node_refs(value)
+            if refs:
+                metadata[key] = refs
             else:
                 metadata.pop(key, None)
         elif key == "continuation_policy":
@@ -745,6 +758,7 @@ def add_todo_to_lines(
     required_write_scopes: list[str] | None = None,
     required_capabilities: list[str] | None = None,
     target_capabilities: list[str] | None = None,
+    explore_result_node_refs: list[str] | None = None,
     decision_scope: Any = None,
     required_decision_scopes: Any = None,
     claimed_by: str | None = None,
@@ -807,6 +821,7 @@ def add_todo_to_lines(
             required_write_scopes=required_write_scopes,
             required_capabilities=required_capabilities,
             target_capabilities=target_capabilities,
+            explore_result_node_refs=explore_result_node_refs,
             decision_scope=decision_scope,
             required_decision_scopes=required_decision_scopes,
             claimed_by=claimed_by,
@@ -844,6 +859,8 @@ def add_todo_to_lines(
             updates["required_capabilities"] = required_capabilities
         if target_capabilities is not None:
             updates["target_capabilities"] = target_capabilities
+        if explore_result_node_refs is not None:
+            updates["explore_result_node_refs"] = explore_result_node_refs
         if decision_scope is not None:
             updates["decision_scope"] = decision_scope
         if required_decision_scopes is not None:
@@ -893,6 +910,9 @@ def add_todo_to_lines(
         "target_capabilities": normalize_target_capabilities(
             effective_metadata.get("target_capabilities") or target_capabilities
         ),
+        "explore_result_node_refs": normalize_explore_result_node_refs(
+            effective_metadata.get("explore_result_node_refs") or explore_result_node_refs
+        ),
         "decision_scope": normalize_todo_decision_scope(
             effective_metadata.get("decision_scope") or decision_scope
         ),
@@ -926,6 +946,7 @@ def add_goal_todo(
     required_write_scopes: list[str] | None = None,
     required_capabilities: list[str] | None = None,
     target_capabilities: list[str] | None = None,
+    explore_result_node_refs: list[str] | None = None,
     decision_scope: Any = None,
     required_decision_scopes: Any = None,
     claimed_by: str | None = None,
@@ -1033,6 +1054,7 @@ def add_goal_todo(
             required_write_scopes=required_write_scopes,
             required_capabilities=required_capabilities,
             target_capabilities=target_capabilities,
+            explore_result_node_refs=explore_result_node_refs,
             decision_scope=decision_scope,
             required_decision_scopes=required_decision_scopes,
             claimed_by=effective_claimed_by,
@@ -1072,6 +1094,7 @@ def add_goal_todo(
         "required_write_scopes": add_result.get("required_write_scopes"),
         "required_capabilities": add_result.get("required_capabilities"),
         "target_capabilities": add_result.get("target_capabilities"),
+        "explore_result_node_refs": add_result.get("explore_result_node_refs"),
         "decision_scope": add_result.get("decision_scope"),
         "required_decision_scopes": add_result.get("required_decision_scopes"),
         "claimed_by": add_result.get("claimed_by"),
@@ -1129,6 +1152,7 @@ def apply_todo_update_to_lines(
     required_write_scopes: list[str] | None = None,
     required_capabilities: list[str] | None = None,
     target_capabilities: list[str] | None = None,
+    explore_result_node_refs: list[str] | None = None,
     decision_scope: Any = None,
     required_decision_scopes: Any = None,
     claimed_by: str | None = None,
@@ -1190,6 +1214,8 @@ def apply_todo_update_to_lines(
         updates["required_capabilities"] = required_capabilities
     if target_capabilities is not None:
         updates["target_capabilities"] = target_capabilities
+    if explore_result_node_refs is not None:
+        updates["explore_result_node_refs"] = explore_result_node_refs
     if decision_scope is not None:
         updates["decision_scope"] = decision_scope
     if required_decision_scopes is not None:
@@ -1248,6 +1274,9 @@ def apply_todo_update_to_lines(
         "target_capabilities": normalize_target_capabilities(
             effective_metadata.get("target_capabilities")
         ),
+        "explore_result_node_refs": normalize_explore_result_node_refs(
+            effective_metadata.get("explore_result_node_refs")
+        ),
         "decision_scope": normalize_todo_decision_scope(effective_metadata.get("decision_scope")),
         "required_decision_scopes": normalize_todo_required_decision_scopes(
             effective_metadata.get("required_decision_scopes")
@@ -1282,6 +1311,7 @@ def update_goal_todo(
     required_write_scopes: list[str] | None = None,
     required_capabilities: list[str] | None = None,
     target_capabilities: list[str] | None = None,
+    explore_result_node_refs: list[str] | None = None,
     decision_scope: Any = None,
     required_decision_scopes: Any = None,
     claimed_by: str | None = None,
@@ -1430,6 +1460,7 @@ def update_goal_todo(
             required_write_scopes=required_write_scopes,
             required_capabilities=required_capabilities,
             target_capabilities=target_capabilities,
+            explore_result_node_refs=explore_result_node_refs,
             decision_scope=decision_scope,
             required_decision_scopes=required_decision_scopes,
             claimed_by=effective_claimed_by,


### PR DESCRIPTION
## Summary
- add bounded `explore_result_node_refs` metadata to todo add/update/list and preserve it through completion/archive projections
- resolve only explicit links into a diagnostic-only typed-evidence audit for Explore todo branch planning
- surface dead-end, refuted, and unknown-reference hazards without changing score, claims, leases, workers, state, or quota
- document the opt-in CLI and add a focused lifecycle/planner smoke

Closes #1819.

## Validation
- `python3 examples/explore-todo-result-node-linkage-smoke.py`
- `python3 examples/explore-result-layer-smoke.py`
- focused todo contract/lifecycle/archive/projection and Explore gate smokes
- `python3 -m loopx.cli canary premerge --from-git-diff` (standard tier: 17 selected, 17 passed, 0 holds)
- `python3 -m compileall -q loopx`
- `git diff --check`

## Boundary
- typed evidence is diagnostics-only with `score_delta=0`
- unlinked todos retain prior behavior
- no private state, raw logs, credentials, local paths, benchmark launches, or authority changes are included

## Review note
This changes todo metadata and planner output contracts, so it is ready for independent review and is not proposed for self-merge.