### PR TITLE
Scope benchmark ledger catch-up by campaign

### DIFF
--- a/examples/skillsbench-benchmark-egress-policy-smoke.py
+++ b/examples/skillsbench-benchmark-egress-policy-smoke.py
@@ -171,6 +171,11 @@ def test_public_launcher_uses_container_reachable_benchmark_proxy() -> None:
     assert "--local-codex-sandbox danger-full-access" in output, output
     assert "local_codex_sandbox=danger-full-access" in output, output
     assert "remote_codex_bin_mode=explicit" in output, output
+    assert (
+        "--local-ledger-catchup-run-group-contains "
+        "skillsbench-codex-cli-goal-xhigh-citation-check-egress-smoke-"
+        "20260709T000000CST" in output
+    ), output
     assert "--append-history" not in output, output
 
 

--- a/scripts/skillsbench-launch-goal-xhigh.sh
+++ b/scripts/skillsbench-launch-goal-xhigh.sh
@@ -44,6 +44,10 @@ Optional env:
   SKILLSBENCH_LOCAL_RUN_LEDGER_SEED    Optional accepted-lane ledger copied
                                        when the live ledger does not exist yet;
                                        keep unrelated benchmark lanes out
+  SKILLSBENCH_LEDGER_CATCHUP_GROUP     Optional run-group substring used for
+                                       local ledger catch-up. Canonical runs
+                                       default to the Goal campaign prefix;
+                                       isolated ledgers default to this run.
   SKILLSBENCH_CANONICAL_CASE_IDS_FILE  Optional canonical case-id file; enables
                                        standard aggregate refresh after closeout
   SKILLSBENCH_STANDARD_AGGREGATE_PATH  Aggregate output path; default beside
@@ -259,6 +263,13 @@ fi
 
 run_group="skillsbench-codex-cli-goal-xhigh-${safe_task}-${tag}-${stamp}"
 job_name="${safe_task}__codex_cli_goal_xhigh_${tag}_${stamp}"
+if [[ -n "${SKILLSBENCH_LEDGER_CATCHUP_GROUP:-}" ]]; then
+  ledger_catchup_group="$SKILLSBENCH_LEDGER_CATCHUP_GROUP"
+elif [[ -n "${SKILLSBENCH_CANONICAL_CASE_IDS_FILE:-}" ]]; then
+  ledger_catchup_group="skillsbench-codex-cli-goal-xhigh-"
+else
+  ledger_catchup_group="$run_group"
+fi
 
 public_root=".local/goals/${goal_id}/skillsbench-runs"
 public_dir="${public_root}/${run_group}"
@@ -321,7 +332,7 @@ supervisor_cmd=(
   --local-run-ledger-path "$local_run_ledger"
   --local-run-group-id "$run_group"
   --local-ledger-catchup-root "$public_root"
-  --local-ledger-catchup-run-group-contains "skillsbench-codex-cli-goal-xhigh-"
+  --local-ledger-catchup-run-group-contains "$ledger_catchup_group"
   --private-log-path "${private_dir}/remote-command.log"
   --public-output-path "${public_dir}/supervisor.public.json"
 )


### PR DESCRIPTION
## Summary
- keep canonical Goal campaigns using the broad campaign catch-up prefix
- scope isolated comparison ledgers to the current run group by default
- allow an explicit catch-up substring override

## Validation
- `bash -n scripts/skillsbench-launch-goal-xhigh.sh`
- `python3 examples/skillsbench-benchmark-egress-policy-smoke.py`
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `loopx canary premerge --from-git-diff` (all selected checks and public boundary passed; expected benchmark-sensitive manual hold)

No scoring, task semantics, permission boundary, or benchmark job launch behavior changes.