### PR TITLE
Preserve verified scores after host transport failure

### DIFF
--- a/examples/skillsbench-failure-attribution-smoke.py
+++ b/examples/skillsbench-failure-attribution-smoke.py
@@ -203,7 +203,7 @@ def _codex_exec_failure_prerequisites() -> dict:
 
 
 def test_postscore_transport_failure_preserves_countable_score() -> None:
-    for score in (0.0, 0.6):
+    for score in (0.0, 0.6, 1.0):
         compact = _completed_score_compact(score, task_operations=2)
         assert (
             _apply_host_local_acp_prereq_failure_attribution(
@@ -216,12 +216,40 @@ def test_postscore_transport_failure_preserves_countable_score() -> None:
 
 
 def test_zero_activity_transport_failure_remains_uncountable() -> None:
-    compact = _completed_score_compact(0.0, task_operations=0)
-    assert _apply_host_local_acp_prereq_failure_attribution(
-        compact,
-        _codex_exec_failure_prerequisites(),
+    for score in (0.0, 1.0):
+        compact = _completed_score_compact(score, task_operations=0)
+        assert _apply_host_local_acp_prereq_failure_attribution(
+            compact,
+            _codex_exec_failure_prerequisites(),
+        )
+        assert (
+            compact["attempt_accounting"]["official_score_attempt_countable"]
+            is False
+        )
+
+
+def test_full_score_without_completed_verifier_evidence_is_uncountable() -> None:
+    invalid_evidence = (
+        {"validation": {}},
+        {
+            "validation": {
+                "official_verifier_status": "incomplete",
+                "official_verifier_validation_present": True,
+            }
+        },
+        {"official_score_status": "missing"},
     )
-    assert compact["attempt_accounting"]["official_score_attempt_countable"] is False
+    for updates in invalid_evidence:
+        compact = _completed_score_compact(1.0, task_operations=2)
+        compact.update(updates)
+        assert _apply_host_local_acp_prereq_failure_attribution(
+            compact,
+            _codex_exec_failure_prerequisites(),
+        ), compact
+        assert (
+            compact["attempt_accounting"]["official_score_attempt_countable"]
+            is False
+        ), compact
 
 
 if __name__ == "__main__":
@@ -235,4 +263,5 @@ if __name__ == "__main__":
     test_failure_dependency_classes_ignore_unrelated_dockerfile_lines()
     test_postscore_transport_failure_preserves_countable_score()
     test_zero_activity_transport_failure_remains_uncountable()
+    test_full_score_without_completed_verifier_evidence_is_uncountable()
     print("skillsbench-failure-attribution-smoke: ok")

--- a/examples/skillsbench-failure-attribution-smoke.py
+++ b/examples/skillsbench-failure-attribution-smoke.py
@@ -18,6 +18,9 @@ from loopx.benchmark_adapters.skillsbench_failure_signals import (
     reconcile_skillsbench_setup_attribution,
     skillsbench_failure_dependency_classes,
 )
+from scripts.skillsbench_automation_loop import (
+    _apply_host_local_acp_prereq_failure_attribution,
+)
 
 
 def test_pip_bootstrap_failure_attribution() -> None:
@@ -175,6 +178,52 @@ def test_failure_dependency_classes_ignore_unrelated_dockerfile_lines() -> None:
     assert "repo.anaconda.com" not in str(fingerprint), fingerprint
 
 
+def _completed_score_compact(score: float, *, task_operations: int) -> dict:
+    return {
+        "official_score": score,
+        "official_score_status": "completed",
+        "validation": {
+            "official_verifier_status": "completed",
+            "official_verifier_validation_present": True,
+        },
+        "interaction_counters": {
+            "remote_command_file_bridge_agent_task_facing_operation_count": (
+                task_operations
+            ),
+        },
+        "attempt_accounting": {"official_score_attempt_countable": True},
+    }
+
+
+def _codex_exec_failure_prerequisites() -> dict:
+    return {
+        "host_local_acp_codex_exec_failure_trace_present": True,
+        "host_local_acp_codex_exec_failure_category": "codex_exec_exit_1",
+    }
+
+
+def test_postscore_transport_failure_preserves_countable_score() -> None:
+    for score in (0.0, 0.6):
+        compact = _completed_score_compact(score, task_operations=2)
+        assert (
+            _apply_host_local_acp_prereq_failure_attribution(
+                compact,
+                _codex_exec_failure_prerequisites(),
+            )
+            is False
+        ), compact
+        assert compact["attempt_accounting"]["official_score_attempt_countable"]
+
+
+def test_zero_activity_transport_failure_remains_uncountable() -> None:
+    compact = _completed_score_compact(0.0, task_operations=0)
+    assert _apply_host_local_acp_prereq_failure_attribution(
+        compact,
+        _codex_exec_failure_prerequisites(),
+    )
+    assert compact["attempt_accounting"]["official_score_attempt_countable"] is False
+
+
 if __name__ == "__main__":
     test_pip_bootstrap_failure_attribution()
     test_task_skills_context_does_not_shadow_pip_failure()
@@ -184,4 +233,6 @@ if __name__ == "__main__":
     test_setup_attribution_reconciles_to_public_fingerprint()
     test_supported_setup_attribution_is_unchanged()
     test_failure_dependency_classes_ignore_unrelated_dockerfile_lines()
+    test_postscore_transport_failure_preserves_countable_score()
+    test_zero_activity_transport_failure_remains_uncountable()
     print("skillsbench-failure-attribution-smoke: ok")

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -4667,12 +4667,6 @@ def _apply_host_local_acp_prereq_failure_attribution(
     """Prefer host Codex failures unless a completed verifier score is usable."""
 
     official_score = compact.get("official_score")
-    if (
-        isinstance(official_score, (int, float))
-        and not isinstance(official_score, bool)
-        and official_score >= 1.0
-    ):
-        return False
     validation = compact.get("validation")
     counters = compact.get("interaction_counters")
     task_activity_count = 0

--- a/scripts/skillsbench_automation_loop.py
+++ b/scripts/skillsbench_automation_loop.py
@@ -4664,13 +4664,34 @@ def _apply_host_local_acp_prereq_failure_attribution(
     compact: dict[str, Any],
     runner_prerequisites: dict[str, Any],
 ) -> bool:
-    """Prefer structured host-local Codex exec failures over zero-score labels."""
+    """Prefer host Codex failures unless a completed verifier score is usable."""
 
     official_score = compact.get("official_score")
     if (
         isinstance(official_score, (int, float))
         and not isinstance(official_score, bool)
         and official_score >= 1.0
+    ):
+        return False
+    validation = compact.get("validation")
+    counters = compact.get("interaction_counters")
+    task_activity_count = 0
+    if isinstance(counters, dict):
+        for key in (
+            "remote_command_file_bridge_agent_task_facing_operation_count",
+            "remote_command_file_bridge_agent_task_facing_success_count",
+        ):
+            value = counters.get(key)
+            if isinstance(value, int) and not isinstance(value, bool):
+                task_activity_count = max(task_activity_count, value)
+    if (
+        isinstance(official_score, (int, float))
+        and not isinstance(official_score, bool)
+        and compact.get("official_score_status") == "completed"
+        and isinstance(validation, dict)
+        and validation.get("official_verifier_validation_present") is True
+        and validation.get("official_verifier_status") in {"completed", "passed"}
+        and task_activity_count > 0
     ):
         return False
 


### PR DESCRIPTION
## Summary
- preserve a completed numeric official verifier score when task-facing work is observed
- prevent a later host Codex transport failure from rewriting that attempt as setup-only
- keep zero-activity transport failures uncountable

## Bad case
A bare Codex comparison completed 29 task-facing bridge operations and produced an official partial verifier score, then a later continuation exited nonzero. The reducer retained the score but overwrote attempt accounting as `job_materialization_failed`.

## Validation
- `python3 examples/skillsbench-failure-attribution-smoke.py`
- `python3 examples/skillsbench-benchmark-run-smoke.py`
- `python3 examples/control_plane/repo-python-line-budget-smoke.py`
- `loopx canary premerge --from-git-diff` (all selected checks and public boundary passed; benchmark-sensitive manual hold remains)

This changes countability precedence, so the PR is intentionally left for independent maintainer review rather than self-merged.