### PR TITLE
feat(issue-fix): add reusable OpenViking context provider

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -512,18 +512,57 @@ until verified. The public
 pilot applies that evidence order without introducing a repository-specific
 control path.
 
-They also accept `--repository-memory-json
-<compact-search-read-result.json>`. This is a host-provider hook, not a memory
-client inside LoopX: the host explicitly searches a caller-approved public
-namespace, reads selected hits, distils public-safe summaries, and passes an
-`issue_fix_repository_memory_read_result_v0` packet. LoopX hashes provider
-references, keeps every memory source advisory, allows patch influence only
-for hits verified against the pinned checkout revision, and persists the
-compact hook projection in the existing repository context. Unverified or
-refuted hits contribute counts only; their summaries are not persisted. Provider
-unavailability, empty retrieval, or a missing revision is fail-open for the
-repository workflow; raw memory bodies, automatic transcript capture, memory
-writeback, private namespaces, and credentials are rejected.
+They also accept either `--repository-memory-json
+<compact-search-read-result.json>` or a configured context provider. The
+provider path is deliberately layered: the reusable LoopX context-provider
+module owns OpenViking CLI/version/service preflight, bounded explicit
+`search -> read`, time/result caps, fail-open errors, and authority-gated
+resource sync. Issue-fix owns the domain query, revision-scoped namespace,
+mapping retrieved resources back to repo-relative files, and exact current
+checkout verification. There is no repository-name special case.
+
+Set `LOOPX_ISSUE_FIX_REPOSITORY_MEMORY_PROVIDER_CONFIG` to a local-private
+`issue_fix_repository_memory_provider_config_v0` file, or pass
+`--repository-memory-provider-json`. When the configured provider, public
+scope, current revision, and caller-approved checkout are available,
+`workflow-plan` and `feasibility` run the provider by default. An explicit
+`--repository-memory-json` still overrides the environment default. LoopX
+hashes provider references, keeps every memory source advisory, allows patch
+influence only for canonical-text exact matches or parser chunks whose
+non-empty lines match the pinned checkout at least 98% (transport line
+endings and one terminal newline are normalised), and
+persists only the compact hook projection in the existing repository context.
+Unverified hits contribute counts only; their summaries are not persisted.
+Provider unavailability, empty retrieval, or a missing checkout is fail-open;
+raw memory bodies, automatic transcript capture, memory writeback, private
+namespaces, credentials, and provider config paths are never retained.
+
+Minimal local provider config (the revision must also appear in `scope_ref`):
+
+```json
+{
+  "schema_version": "issue_fix_repository_memory_provider_config_v0",
+  "enabled": true,
+  "provider": "openviking",
+  "namespace": "public-repository",
+  "visibility": "public",
+  "scope_ref": "viking://resources/public-repository/<git-revision>",
+  "repository_revision": "<full-git-revision>",
+  "max_results": 3,
+  "timeout_seconds": 15,
+  "sync_timeout_seconds": 180,
+  "resource_references": ["src/module.py", "tests/test_module.py"]
+}
+```
+
+Resource indexing is intentionally separate from retrieval. Use
+`loopx issue-fix repository-memory-sync` to preview a bounded set of
+repo-relative public files; add `--execute` only after the provider-resource
+write is authorized. Re-running the same immutable revision scope is
+idempotent when stored content still matches and stops on a conflict instead
+of replacing or auto-renaming it. Retrieval and resource sync use separate
+bounded timeouts because semantic indexing can legitimately take longer than
+read-only search.
 
 Default enablement is an evidence decision rather than an installation side
 effect. A project should first dogfood the hook across several independent
@@ -597,6 +636,17 @@ loopx issue-fix workflow-plan \
   --repo-path /path/to/approved/repo \
   --repository-context-json context.json \
   --repository-memory-json compact-search-read-result.json \
+  --validation-label "focused unit test" \
+  --format json
+
+# Or configure the reusable OpenViking provider once. The config stays local
+# and binds a public viking:// scope to the exact repository revision.
+export LOOPX_ISSUE_FIX_REPOSITORY_MEMORY_PROVIDER_CONFIG=/path/to/provider.json
+loopx issue-fix workflow-plan \
+  --url https://github.com/owner/repo/issues/123 \
+  --repo-path /path/to/approved/repo \
+  --repository-context-json context.json \
+  --repository-memory-query "affected module reproduction validation" \
   --validation-label "focused unit test" \
   --format json
 

--- a/docs/capabilities/issue-fix/README.zh-CN.md
+++ b/docs/capabilities/issue-fix/README.zh-CN.md
@@ -454,16 +454,49 @@ repo-relative source ref。当前 checkout 证据保持最高权威；memory/exp
 [OpenViking pilot handoff](openviking-pilot-handoff.md) 展示真实 pilot 如何应用该证据
 顺序，同时不引入仓库特判控制路径。
 
-两者也接受 `--repository-memory-json <compact-search-read-result.json>`。这是
-host-provider hook，不是 LoopX 内置的 memory client：host 只在调用方批准的公开
-namespace 中显式执行 `search`，再对选中的命中执行 `read`，把蒸馏后的 public-safe
-摘要封装成 `issue_fix_repository_memory_read_result_v0`。LoopX 会 hash provider ref，
-始终把 memory source 保持为 advisory；只有已经在 pinned checkout revision 上验证的
-命中才允许影响 patch。未验证或已被 refute 的命中只进入计数，其摘要不会持久化。
-紧凑 hook projection 仍写入现有 repository context，不建立
-第二套 ledger。Provider 不可用、空结果或缺少 revision 时，仓库工作流 fail-open；
-raw memory body、自动 transcript capture、memory writeback、私有 namespace 与凭据
-都会被拒绝。
+两者既接受 `--repository-memory-json <compact-search-read-result.json>`，也可以调用已配置的
+context provider。这里采用明确分层：LoopX 通用 context-provider module 负责 OpenViking
+CLI/版本/服务 preflight、有上限的显式 `search -> read`、超时与结果 cap、fail-open，
+以及需要独立授权的 resource sync；issue-fix 只负责领域 query、revision-scoped namespace、
+把命中映射回 repo-relative 文件，并对当前 checkout 做 exact-content 验证。通用层不会写
+`repo == OpenViking` 一类特判。
+
+可以把本地私有 `issue_fix_repository_memory_provider_config_v0` 路径写入
+`LOOPX_ISSUE_FIX_REPOSITORY_MEMORY_PROVIDER_CONFIG`，也可以显式传
+`--repository-memory-provider-json`。当 provider、公开 scope、当前 revision 和调用方批准的
+checkout 都可用时，`workflow-plan` 与 `feasibility` 默认调用 provider；显式
+`--repository-memory-json` 仍可覆盖环境默认。LoopX 会 hash provider ref，始终把 memory
+source 保持为 advisory；只有与 pinned checkout 文件做 canonical-text exact match，或
+非空行匹配率至少 98% 的 parser chunk，才允许影响 patch（仅归一化传输层换行符与一个
+末尾换行）。
+未验证命中只进入计数，其摘要不会持久化。紧凑 hook projection 仍写入现有 repository
+context，不建立第二套 ledger。Provider 不可用、空结果或 checkout 缺失时 fail-open；raw
+memory body、自动 transcript capture、memory writeback、私有 namespace、凭据和 provider
+配置路径都不会被保留。
+
+最小本地 provider 配置如下；`scope_ref` 也必须包含当前 revision：
+
+```json
+{
+  "schema_version": "issue_fix_repository_memory_provider_config_v0",
+  "enabled": true,
+  "provider": "openviking",
+  "namespace": "public-repository",
+  "visibility": "public",
+  "scope_ref": "viking://resources/public-repository/<git-revision>",
+  "repository_revision": "<full-git-revision>",
+  "max_results": 3,
+  "timeout_seconds": 15,
+  "sync_timeout_seconds": 180,
+  "resource_references": ["src/module.py", "tests/test_module.py"]
+}
+```
+
+Resource indexing 与 retrieval 刻意分离。先用
+`loopx issue-fix repository-memory-sync` 预览有限数量的 repo-relative 公开文件；只有
+provider resource write 已获授权时才加 `--execute`。同一个 immutable revision scope
+重复执行时，内容一致会幂等通过；出现冲突则停止，不会覆盖或自动改名。只读 retrieval
+与 resource sync 使用独立且有上限的 timeout，因为语义索引通常比 search/read 更慢。
 
 是否默认开启必须由真实证据决定，而不是安装即默认。项目应先在多个独立 issue/context
 run 和至少一次重启边界上 dogfood；只有当该 hook 能反复提供经 checkout 验证的新证据，
@@ -525,6 +558,17 @@ loopx issue-fix workflow-plan \
   --repo-path /path/to/approved/repo \
   --repository-context-json context.json \
   --repository-memory-json compact-search-read-result.json \
+  --validation-label "focused unit test" \
+  --format json
+
+# 也可以一次配置通用 OpenViking provider。配置只留在本机，并把公开
+# viking:// scope 绑定到精确 repository revision。
+export LOOPX_ISSUE_FIX_REPOSITORY_MEMORY_PROVIDER_CONFIG=/path/to/provider.json
+loopx issue-fix workflow-plan \
+  --url https://github.com/owner/repo/issues/123 \
+  --repo-path /path/to/approved/repo \
+  --repository-context-json context.json \
+  --repository-memory-query "affected module reproduction validation" \
   --validation-label "focused unit test" \
   --format json
 

--- a/examples/issue-fix-repository-memory-smoke.py
+++ b/examples/issue-fix-repository-memory-smoke.py
@@ -4,10 +4,12 @@
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
+from typing import Any
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -20,9 +22,86 @@ from loopx.capabilities.issue_fix.feasibility import (  # noqa: E402
 from loopx.capabilities.issue_fix.repository_context import (  # noqa: E402
     build_issue_fix_repository_context_packet,
 )
+from loopx.capabilities.issue_fix.repository_memory_provider import (  # noqa: E402
+    retrieve_issue_fix_repository_memory,
+)
+from loopx.capabilities.context_providers.base import (  # noqa: E402
+    ContextProviderItem,
+    ContextProviderRetrieval,
+)
+from loopx.capabilities.context_providers.openviking import (  # noqa: E402
+    OpenVikingContextProvider,
+)
 
 REVISION = "9cf42405a8bb0a8a17a66d4f953515f5a2c82620"
 ISSUE_URL = "https://github.com/volcengine/OpenViking/issues/3124"
+
+
+class ContractProvider:
+    provider_id = "contract_provider"
+
+    def __init__(self, *, resource_ref: str, content: str) -> None:
+        self.resource_ref = resource_ref
+        self.content = content
+
+    def retrieve(self, **kwargs: Any) -> ContextProviderRetrieval:
+        return ContextProviderRetrieval(
+            provider="contract_provider",
+            namespace=str(kwargs["namespace"]),
+            status="completed",
+            query_summary=str(kwargs["query_summary"]),
+            observed_at=str(kwargs["observed_at"]),
+            search_performed=True,
+            read_performed=True,
+            requested_limit=int(kwargs["max_results"]),
+            items=(
+                ContextProviderItem(
+                    resource_ref=self.resource_ref,
+                    summary="Provider returned the bounded current source candidate.",
+                    content=self.content,
+                    score=0.91,
+                ),
+            ),
+        )
+
+    def sync(self, **kwargs: Any) -> Any:  # pragma: no cover - retrieval contract only.
+        raise AssertionError(kwargs)
+
+
+class OpenVikingContractRunner:
+    def __init__(self, *, scope_ref: str) -> None:
+        self.scope_ref = scope_ref
+        self.calls: list[list[str]] = []
+
+    def __call__(
+        self, command: list[str], **_kwargs: Any
+    ) -> subprocess.CompletedProcess[str]:
+        self.calls.append(command)
+        if command[1:] == ["--version"]:
+            stdout = "openviking 0.4.9.dev11\n"
+        elif command[1:3] == ["status", "-o"]:
+            stdout = json.dumps({"status": "healthy"})
+        elif command[1] == "search":
+            stdout = json.dumps(
+                {
+                    "result": {
+                        "resources": [
+                            {
+                                "uri": f"{self.scope_ref}/src/worker.py",
+                                "abstract": "Bounded public worker contract evidence.",
+                                "score": 0.93,
+                            }
+                        ]
+                    }
+                }
+            )
+        elif command[1] == "read":
+            stdout = json.dumps(
+                {"result": {"content": "private-to-call transient provider body"}}
+            )
+        else:
+            raise AssertionError(command)
+        return subprocess.CompletedProcess(command, 0, stdout=stdout)
 
 
 def repository_context() -> dict[str, object]:
@@ -171,6 +250,99 @@ def main() -> int:
     assert unavailable_hook["source_refs"] == []
     assert_boundary(unavailable)
 
+    ov_scope = f"viking://resources/public-repo/{REVISION}"
+    ov_runner = OpenVikingContractRunner(scope_ref=ov_scope)
+    ov_provider = OpenVikingContextProvider(
+        executable="ov-contract",
+        runner=ov_runner,
+    )
+    ov_retrieval = ov_provider.retrieve(
+        namespace="public-repository",
+        scope_ref=ov_scope,
+        query="worker contract",
+        query_summary="Current worker contract evidence.",
+        max_results=2,
+        timeout_seconds=5,
+        observed_at="2026-07-11T03:30:00+08:00",
+    )
+    assert ov_retrieval.status == "completed", ov_retrieval
+    assert ov_retrieval.search_performed is True
+    assert ov_retrieval.read_performed is True
+    assert len(ov_retrieval.items) == 1
+    assert any(call[1] == "search" for call in ov_runner.calls)
+    assert any(call[1] == "read" for call in ov_runner.calls)
+    ov_public = ov_retrieval.public_packet()
+    assert "private-to-call transient provider body" not in json.dumps(ov_public)
+    assert ov_scope not in json.dumps(ov_public)
+    assert_boundary(ov_public)
+
+    with tempfile.TemporaryDirectory(prefix="loopx-memory-provider-") as tmpdir:
+        checkout = Path(tmpdir)
+        source = checkout / "src" / "worker.py"
+        source.parent.mkdir(parents=True)
+        source.write_text(
+            "def current_contract():\n    return 'verified'\n", encoding="utf-8"
+        )
+        scope_ref = f"viking://resources/public-repo/{REVISION}"
+        sync_plan = ov_provider.sync(
+            namespace="public-repository",
+            resources=[
+                (
+                    str(source),
+                    f"viking://resources/public-repo/{REVISION}/src/worker.py",
+                )
+            ],
+            timeout_seconds=5,
+            observed_at="2026-07-11T03:30:00+08:00",
+            execute=False,
+        ).public_packet()
+        assert sync_plan["status"] == "planned", sync_plan
+        assert sync_plan["ok"] is True, sync_plan
+        assert sync_plan["external_writes_performed"] is False, sync_plan
+        assert_boundary(sync_plan)
+        provider_result = retrieve_issue_fix_repository_memory(
+            config={
+                "schema_version": "issue_fix_repository_memory_provider_config_v0",
+                "enabled": True,
+                "provider": "contract_provider",
+                "namespace": "public-repository",
+                "visibility": "public",
+                "scope_ref": scope_ref,
+                "repository_revision": REVISION,
+                "max_results": 3,
+                "timeout_seconds": 5,
+            },
+            repo_path=checkout,
+            repository_revision=REVISION,
+            query="current worker contract validation",
+            query_summary="Current worker contract evidence.",
+            supports=["change_scope", "validation"],
+            observed_at="2026-07-11T03:30:00+08:00",
+            provider=ContractProvider(
+                resource_ref=f"{scope_ref}/src/worker.py",
+                content=source.read_text(encoding="utf-8"),
+            ),
+        )
+        provider_memory = provider_result["memory_input"]
+        assert provider_memory["results"][0]["verification_status"] == "confirmed"
+        assert (
+            provider_memory["results"][0]["verification_reference"] == "src/worker.py"
+        )
+        assert provider_memory["latency_ms"] == 0
+        assert provider_memory["requested_limit"] == 3
+        assert provider_memory["configured_resource_count"] == 0
+        assert provider_memory["stale_or_unmapped_count"] == 0
+        assert provider_memory["verification_mode"] == "canonical_text_or_parser_chunk"
+        assert provider_result["provider_projection"]["checkout_verification"] == {
+            "revision": REVISION,
+            "confirmed_count": 1,
+            "stale_or_unmapped_count": 0,
+            "patch_influence_allowed_count": 1,
+            "configured_resource_count": 0,
+            "verification_mode": "canonical_text_or_parser_chunk",
+        }
+        assert_boundary(provider_result)
+
     invalid_capture = dict(memory_input)
     invalid_capture["automatic_capture_performed"] = True
     try:
@@ -223,6 +395,62 @@ def main() -> int:
         assert cli_hook["status"] == "used", cli_hook
         assert cli_hook["confirmed_count"] == 1, cli_hook
         assert_boundary(cli_packet)
+
+        provider_config_path = tmp / "provider-config.json"
+        provider_config_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "issue_fix_repository_memory_provider_config_v0",
+                    "enabled": False,
+                    "provider": "openviking",
+                    "namespace": "public-repository",
+                    "visibility": "public",
+                    "scope_ref": f"viking://resources/public-repo/{REVISION}",
+                    "repository_revision": REVISION,
+                    "max_results": 3,
+                    "timeout_seconds": 5,
+                }
+            ),
+            encoding="utf-8",
+        )
+        configured_command = [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "issue-fix",
+            "workflow-plan",
+            "--url",
+            ISSUE_URL,
+            "--repo-path",
+            str(tmp),
+            "--repository-context-json",
+            str(context_path),
+            "--validation-label",
+            "focused VLM status regression",
+        ]
+        configured_result = subprocess.run(
+            configured_command,
+            cwd=ROOT,
+            env={
+                **os.environ,
+                "LOOPX_ISSUE_FIX_REPOSITORY_MEMORY_PROVIDER_CONFIG": str(
+                    provider_config_path
+                ),
+            },
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        configured_packet = json.loads(configured_result.stdout)
+        configured_hook = configured_packet["repository_context"]["memory_projection"][
+            "retrieval_hook"
+        ]
+        assert configured_hook["status"] == "disabled", configured_hook
+        assert configured_hook["provider"] == "openviking", configured_hook
+        assert_boundary(configured_packet)
 
     print("issue-fix-repository-memory-smoke: ok")
     return 0

--- a/loopx/capabilities/context_providers/__init__.py
+++ b/loopx/capabilities/context_providers/__init__.py
@@ -1,0 +1,23 @@
+"""Reusable bounded context-provider integrations for LoopX capabilities."""
+
+from .base import (
+    canonical_context_text,
+    canonical_context_lines,
+    canonical_context_matches,
+    ContextProviderItem,
+    ContextProviderRetrieval,
+    ContextProviderSync,
+)
+from .openviking import OpenVikingContextProvider
+from .factory import build_context_provider
+
+__all__ = [
+    "ContextProviderItem",
+    "ContextProviderRetrieval",
+    "ContextProviderSync",
+    "OpenVikingContextProvider",
+    "build_context_provider",
+    "canonical_context_text",
+    "canonical_context_lines",
+    "canonical_context_matches",
+]

--- a/loopx/capabilities/context_providers/base.py
+++ b/loopx/capabilities/context_providers/base.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Protocol, Sequence
+
+
+CONTEXT_PROVIDER_RETRIEVAL_SCHEMA_VERSION = "context_provider_retrieval_v0"
+CONTEXT_PROVIDER_SYNC_SCHEMA_VERSION = "context_provider_sync_v0"
+
+
+def opaque_provider_ref(*, provider: str, namespace: str, resource_ref: str) -> str:
+    digest = hashlib.sha256(
+        f"{provider}\n{namespace}\n{resource_ref}".encode("utf-8")
+    ).hexdigest()[:20]
+    return f"provider-{digest}"
+
+
+def canonical_context_text(value: str) -> str:
+    """Normalise transport-only line endings and one terminal newline."""
+
+    return value.replace("\r\n", "\n").removesuffix("\n")
+
+
+def canonical_context_lines(value: str) -> tuple[str, ...]:
+    return tuple(
+        line.rstrip()
+        for line in canonical_context_text(value).splitlines()
+        if line.strip()
+    )
+
+
+def canonical_context_matches(candidate: str, source: str) -> bool:
+    """Verify exact text or a parser-split chunk against current source lines."""
+
+    if canonical_context_text(candidate) == canonical_context_text(source):
+        return True
+    candidate_lines = canonical_context_lines(candidate)
+    if len(candidate_lines) < 3 or len(candidate) < 80:
+        return False
+    source_lines = set(canonical_context_lines(source))
+    matched = sum(line in source_lines for line in candidate_lines)
+    return matched / len(candidate_lines) >= 0.98
+
+
+@dataclass(frozen=True)
+class ContextProviderItem:
+    """One transient provider hit.
+
+    ``content`` and ``resource_ref`` are intentionally available only to the
+    in-process caller. Public packets retain an opaque reference and compact
+    summary, never raw provider payloads or exact content.
+    """
+
+    resource_ref: str
+    summary: str
+    content: str
+    score: float | None = None
+
+
+@dataclass(frozen=True)
+class ContextProviderRetrieval:
+    provider: str
+    namespace: str
+    status: str
+    query_summary: str
+    observed_at: str
+    search_performed: bool
+    read_performed: bool
+    items: tuple[ContextProviderItem, ...] = ()
+    reason_code: str | None = None
+    provider_version: str | None = None
+    latency_ms: int = 0
+    requested_limit: int = 0
+
+    def public_packet(self) -> dict[str, object]:
+        return {
+            "schema_version": CONTEXT_PROVIDER_RETRIEVAL_SCHEMA_VERSION,
+            "ok": self.status == "completed",
+            "provider": self.provider,
+            "namespace": self.namespace,
+            "visibility": "public",
+            "status": self.status,
+            "reason_code": self.reason_code,
+            "provider_version": self.provider_version,
+            "query_summary": self.query_summary,
+            "observed_at": self.observed_at,
+            "search_performed": self.search_performed,
+            "read_performed": self.read_performed,
+            "requested_limit": self.requested_limit,
+            "result_count": len(self.items),
+            "results": [
+                {
+                    "provider_ref": opaque_provider_ref(
+                        provider=self.provider,
+                        namespace=self.namespace,
+                        resource_ref=item.resource_ref,
+                    ),
+                    "summary": item.summary,
+                    "score": item.score,
+                }
+                for item in self.items
+            ],
+            "telemetry": {
+                "latency_ms": max(0, self.latency_ms),
+                "result_cap_applied": len(self.items) >= self.requested_limit > 0,
+            },
+            "fail_open": True,
+            "external_writes_performed": False,
+            "raw_provider_payload_captured": False,
+            "raw_content_captured": False,
+            "credentials_captured": False,
+        }
+
+
+@dataclass(frozen=True)
+class ContextProviderSync:
+    provider: str
+    namespace: str
+    status: str
+    observed_at: str
+    requested_count: int
+    completed_count: int
+    write_count: int = 0
+    reason_code: str | None = None
+    provider_version: str | None = None
+    latency_ms: int = 0
+    result_refs: tuple[str, ...] = field(default_factory=tuple)
+
+    def public_packet(self) -> dict[str, object]:
+        return {
+            "schema_version": CONTEXT_PROVIDER_SYNC_SCHEMA_VERSION,
+            "ok": self.status in {"completed", "planned"},
+            "provider": self.provider,
+            "namespace": self.namespace,
+            "visibility": "public",
+            "status": self.status,
+            "reason_code": self.reason_code,
+            "provider_version": self.provider_version,
+            "observed_at": self.observed_at,
+            "requested_count": self.requested_count,
+            "completed_count": self.completed_count,
+            "write_count": self.write_count,
+            "result_refs": [
+                opaque_provider_ref(
+                    provider=self.provider,
+                    namespace=self.namespace,
+                    resource_ref=ref,
+                )
+                for ref in self.result_refs
+            ],
+            "telemetry": {"latency_ms": max(0, self.latency_ms)},
+            "external_writes_performed": self.write_count > 0,
+            "raw_provider_payload_captured": False,
+            "raw_content_captured": False,
+            "credentials_captured": False,
+        }
+
+
+class ContextProvider(Protocol):
+    provider_id: str
+
+    def retrieve(
+        self,
+        *,
+        namespace: str,
+        scope_ref: str,
+        query: str,
+        query_summary: str,
+        max_results: int,
+        timeout_seconds: float,
+        observed_at: str,
+    ) -> ContextProviderRetrieval: ...
+
+    def sync(
+        self,
+        *,
+        namespace: str,
+        resources: Sequence[tuple[str, str]],
+        timeout_seconds: float,
+        observed_at: str,
+        execute: bool,
+    ) -> ContextProviderSync: ...

--- a/loopx/capabilities/context_providers/factory.py
+++ b/loopx/capabilities/context_providers/factory.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from .base import ContextProvider
+from .openviking import OpenVikingContextProvider
+
+
+def build_context_provider(config: Mapping[str, Any]) -> ContextProvider:
+    """Resolve one configured provider without capability-specific branching."""
+
+    provider_id = str(config.get("provider") or "").strip()
+    if provider_id == "openviking":
+        return OpenVikingContextProvider(
+            executable=str(config.get("provider_binary") or "ov"),
+            minimum_version=str(config.get("minimum_provider_version") or "0.4.9"),
+        )
+    raise ValueError(f"unsupported context provider: {provider_id or '<missing>'}")

--- a/loopx/capabilities/context_providers/openviking.py
+++ b/loopx/capabilities/context_providers/openviking.py
@@ -1,0 +1,531 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import time
+from collections.abc import Callable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+from ...control_plane.runtime.public_safety import public_safe_compact_text
+from .base import (
+    ContextProviderItem,
+    ContextProviderRetrieval,
+    ContextProviderSync,
+    canonical_context_lines,
+    canonical_context_matches,
+)
+
+
+OPENVIKING_PROVIDER_ID = "openviking"
+MAX_OPENVIKING_RESULTS = 6
+MAX_OPENVIKING_SYNC_RESOURCES = 24
+DEFAULT_MINIMUM_VERSION = "0.4.9"
+
+CommandRunner = Callable[..., subprocess.CompletedProcess[str]]
+
+
+def _compact(value: Any, *, limit: int) -> str:
+    return public_safe_compact_text(value, limit=limit)
+
+
+def _extract_json(text: str) -> Any:
+    stripped = text.strip()
+    if not stripped:
+        raise ValueError("provider returned empty output")
+    try:
+        return json.loads(stripped)
+    except json.JSONDecodeError:
+        pass
+    decoder = json.JSONDecoder()
+    for index, char in enumerate(stripped):
+        if char not in "[{":
+            continue
+        try:
+            value, _end = decoder.raw_decode(stripped[index:])
+        except json.JSONDecodeError:
+            continue
+        return value
+    raise ValueError("provider output did not contain JSON")
+
+
+def _version_tuple(value: str) -> tuple[int, int, int]:
+    match = re.search(r"(\d+)\.(\d+)\.(\d+)", value)
+    if not match:
+        raise ValueError("provider version is not semantic")
+    return tuple(int(part) for part in match.groups())
+
+
+def _mapping_candidates(value: Any) -> list[Mapping[str, Any]]:
+    candidates: list[Mapping[str, Any]] = []
+    if isinstance(value, Mapping):
+        for key in ("resources", "memories", "skills", "results", "items"):
+            rows = value.get(key)
+            if isinstance(rows, Sequence) and not isinstance(rows, (str, bytes)):
+                candidates.extend(row for row in rows if isinstance(row, Mapping))
+        for key in ("result", "data"):
+            nested = value.get(key)
+            if nested is not value:
+                candidates.extend(_mapping_candidates(nested))
+    elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+        candidates.extend(row for row in value if isinstance(row, Mapping))
+    return candidates
+
+
+def _resource_ref(row: Mapping[str, Any]) -> str:
+    for key in ("uri", "resource_uri", "path", "url"):
+        value = str(row.get(key) or "").strip()
+        if value.startswith("viking://"):
+            return value
+    return ""
+
+
+def _resource_summary(row: Mapping[str, Any]) -> str:
+    for key in ("abstract", "summary", "overview", "description", "title"):
+        value = _compact(row.get(key), limit=220)
+        if value:
+            return value
+    return "Retrieved scoped public context from the configured provider."
+
+
+def _resource_score(row: Mapping[str, Any]) -> float | None:
+    for key in ("score", "similarity", "distance"):
+        value = row.get(key)
+        if isinstance(value, (int, float)) and not isinstance(value, bool):
+            return float(value)
+    return None
+
+
+def _read_content(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, Mapping):
+        for key in ("content", "text"):
+            content = value.get(key)
+            if isinstance(content, str):
+                return content
+        for key in ("result", "data"):
+            content = _read_content(value.get(key))
+            if content:
+                return content
+    return ""
+
+
+class OpenVikingContextProvider:
+    """Bounded OpenViking CLI integration with compact, fail-open outputs."""
+
+    provider_id = OPENVIKING_PROVIDER_ID
+
+    def __init__(
+        self,
+        *,
+        executable: str = "ov",
+        minimum_version: str = DEFAULT_MINIMUM_VERSION,
+        env: Mapping[str, str] | None = None,
+        runner: CommandRunner = subprocess.run,
+    ) -> None:
+        self.executable = executable
+        self.minimum_version = minimum_version
+        self.env = dict(env) if env is not None else dict(os.environ)
+        self.runner = runner
+
+    def _run(
+        self,
+        args: Sequence[str],
+        *,
+        timeout_seconds: float,
+    ) -> subprocess.CompletedProcess[str]:
+        return self.runner(
+            [self.executable, *args],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            timeout=max(1.0, timeout_seconds),
+            env=self.env,
+            check=False,
+        )
+
+    def _preflight(self, *, timeout_seconds: float) -> tuple[str | None, str | None]:
+        try:
+            version_result = self._run(["--version"], timeout_seconds=timeout_seconds)
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            return None, "provider_cli_unavailable"
+        if version_result.returncode != 0:
+            return None, "provider_version_preflight_failed"
+        version = _compact(version_result.stdout, limit=80)
+        try:
+            if _version_tuple(version) < _version_tuple(self.minimum_version):
+                return version, "provider_version_incompatible"
+        except ValueError:
+            return version, "provider_version_unparseable"
+        try:
+            status_result = self._run(
+                ["status", "-o", "json", "-c", "true"],
+                timeout_seconds=timeout_seconds,
+            )
+        except subprocess.TimeoutExpired:
+            return version, "provider_service_timeout"
+        if status_result.returncode != 0:
+            return version, "provider_service_unavailable"
+        return version, None
+
+    def retrieve(
+        self,
+        *,
+        namespace: str,
+        scope_ref: str,
+        query: str,
+        query_summary: str,
+        max_results: int,
+        timeout_seconds: float,
+        observed_at: str,
+    ) -> ContextProviderRetrieval:
+        started = time.monotonic()
+        namespace = _compact(namespace, limit=120)
+        query = _compact(query, limit=500)
+        query_summary = _compact(query_summary, limit=220)
+        requested_limit = min(max(1, int(max_results)), MAX_OPENVIKING_RESULTS)
+        if not namespace or not query or not query_summary:
+            raise ValueError("namespace, query, and query_summary are required")
+        if not scope_ref.startswith("viking://"):
+            raise ValueError("OpenViking scope_ref must use viking://")
+
+        version, blocker = self._preflight(timeout_seconds=timeout_seconds)
+        if blocker:
+            return ContextProviderRetrieval(
+                provider=self.provider_id,
+                namespace=namespace,
+                status="unavailable",
+                query_summary=query_summary,
+                observed_at=observed_at,
+                search_performed=False,
+                read_performed=False,
+                reason_code=blocker,
+                provider_version=version,
+                latency_ms=int((time.monotonic() - started) * 1000),
+                requested_limit=requested_limit,
+            )
+
+        try:
+            search_result = self._run(
+                [
+                    "search",
+                    query,
+                    "-u",
+                    scope_ref,
+                    "-n",
+                    str(requested_limit),
+                    "-o",
+                    "json",
+                    "-c",
+                    "true",
+                ],
+                timeout_seconds=timeout_seconds,
+            )
+        except subprocess.TimeoutExpired:
+            search_result = None
+        if search_result is None or search_result.returncode != 0:
+            return ContextProviderRetrieval(
+                provider=self.provider_id,
+                namespace=namespace,
+                status="unavailable",
+                query_summary=query_summary,
+                observed_at=observed_at,
+                search_performed=search_result is not None,
+                read_performed=False,
+                reason_code=(
+                    "provider_search_timeout"
+                    if search_result is None
+                    else "provider_search_failed"
+                ),
+                provider_version=version,
+                latency_ms=int((time.monotonic() - started) * 1000),
+                requested_limit=requested_limit,
+            )
+        try:
+            rows = _mapping_candidates(_extract_json(search_result.stdout))
+        except ValueError:
+            return ContextProviderRetrieval(
+                provider=self.provider_id,
+                namespace=namespace,
+                status="unavailable",
+                query_summary=query_summary,
+                observed_at=observed_at,
+                search_performed=True,
+                read_performed=False,
+                reason_code="provider_search_parse_failed",
+                provider_version=version,
+                latency_ms=int((time.monotonic() - started) * 1000),
+                requested_limit=requested_limit,
+            )
+
+        items: list[ContextProviderItem] = []
+        seen_refs: set[str] = set()
+        read_attempted = False
+        for row in rows:
+            resource_ref = _resource_ref(row)
+            if not resource_ref or not (
+                resource_ref == scope_ref
+                or resource_ref.startswith(scope_ref.rstrip("/") + "/")
+            ):
+                continue
+            if resource_ref in seen_refs:
+                continue
+            seen_refs.add(resource_ref)
+            read_attempted = True
+            remaining = max(1.0, timeout_seconds - (time.monotonic() - started))
+            try:
+                read_result = self._run(
+                    ["read", resource_ref, "-o", "json", "-c", "true"],
+                    timeout_seconds=remaining,
+                )
+            except subprocess.TimeoutExpired:
+                continue
+            if read_result.returncode != 0:
+                continue
+            try:
+                content = _read_content(_extract_json(read_result.stdout))
+            except ValueError:
+                continue
+            if not content:
+                continue
+            items.append(
+                ContextProviderItem(
+                    resource_ref=resource_ref,
+                    summary=_resource_summary(row),
+                    content=content,
+                    score=_resource_score(row),
+                )
+            )
+            if len(items) >= requested_limit:
+                break
+
+        return ContextProviderRetrieval(
+            provider=self.provider_id,
+            namespace=namespace,
+            status="completed",
+            query_summary=query_summary,
+            observed_at=observed_at,
+            search_performed=True,
+            read_performed=read_attempted,
+            items=tuple(items),
+            reason_code=(
+                "provider_reads_unusable" if read_attempted and not items else None
+            ),
+            provider_version=version,
+            latency_ms=int((time.monotonic() - started) * 1000),
+            requested_limit=requested_limit,
+        )
+
+    def sync(
+        self,
+        *,
+        namespace: str,
+        resources: Sequence[tuple[str, str]],
+        timeout_seconds: float,
+        observed_at: str,
+        execute: bool,
+    ) -> ContextProviderSync:
+        started = time.monotonic()
+        namespace = _compact(namespace, limit=120)
+        if len(resources) > MAX_OPENVIKING_SYNC_RESOURCES:
+            raise ValueError(
+                f"OpenViking sync supports at most {MAX_OPENVIKING_SYNC_RESOURCES} resources"
+            )
+        bounded = list(resources[:MAX_OPENVIKING_SYNC_RESOURCES])
+        if not namespace:
+            raise ValueError("namespace is required")
+        if not bounded:
+            raise ValueError("at least one resource is required")
+        for source, target in bounded:
+            source_path = Path(source).expanduser()
+            if not source_path.is_file():
+                raise ValueError("every sync source must be an existing file")
+            if not target.startswith("viking://resources/"):
+                raise ValueError("sync targets must stay under viking://resources/")
+            if source_path.name != target.rstrip("/").rsplit("/", 1)[-1]:
+                raise ValueError("sync target basename must match source basename")
+        if not execute:
+            return ContextProviderSync(
+                provider=self.provider_id,
+                namespace=namespace,
+                status="planned",
+                observed_at=observed_at,
+                requested_count=len(bounded),
+                completed_count=0,
+                write_count=0,
+                reason_code="execute_required_for_resource_write",
+                latency_ms=int((time.monotonic() - started) * 1000),
+            )
+
+        version, blocker = self._preflight(timeout_seconds=timeout_seconds)
+        if blocker:
+            return ContextProviderSync(
+                provider=self.provider_id,
+                namespace=namespace,
+                status="unavailable",
+                observed_at=observed_at,
+                requested_count=len(bounded),
+                completed_count=0,
+                write_count=0,
+                reason_code=blocker,
+                provider_version=version,
+                latency_ms=int((time.monotonic() - started) * 1000),
+            )
+
+        completed_refs: list[str] = []
+        write_count = 0
+        sync_reason: str | None = None
+        for source, target in bounded:
+            parent = target.rstrip("/").rsplit("/", 1)[0]
+            try:
+                source_content = Path(source).read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                sync_reason = "provider_sync_source_read_failed"
+                break
+            remaining = max(1.0, timeout_seconds - (time.monotonic() - started))
+            try:
+                existing = self._run(
+                    ["read", target, "-o", "json", "-c", "true"],
+                    timeout_seconds=remaining,
+                )
+            except subprocess.TimeoutExpired:
+                sync_reason = "provider_sync_timeout"
+                break
+            if existing.returncode == 0:
+                try:
+                    existing_content = _read_content(_extract_json(existing.stdout))
+                except (OSError, UnicodeDecodeError, ValueError):
+                    sync_reason = "provider_sync_existing_read_failed"
+                    break
+                if not canonical_context_matches(existing_content, source_content):
+                    sync_reason = "provider_sync_revision_conflict"
+                    break
+                completed_refs.append(target)
+                continue
+            try:
+                tree_result = self._run(
+                    ["tree", target, "-L", "3", "-o", "json", "-c", "true"],
+                    timeout_seconds=remaining,
+                )
+            except subprocess.TimeoutExpired:
+                sync_reason = "provider_sync_timeout"
+                break
+            tree_refs: list[str] = []
+            if tree_result.returncode == 0:
+                try:
+                    tree_refs = [
+                        ref
+                        for row in _mapping_candidates(
+                            _extract_json(tree_result.stdout)
+                        )
+                        if (ref := _resource_ref(row))
+                    ]
+                except ValueError:
+                    sync_reason = "provider_sync_tree_parse_failed"
+                    break
+            tree_contents: list[str] = []
+            for tree_ref in tree_refs:
+                try:
+                    tree_read = self._run(
+                        ["read", tree_ref, "-o", "json", "-c", "true"],
+                        timeout_seconds=remaining,
+                    )
+                except subprocess.TimeoutExpired:
+                    sync_reason = "provider_sync_timeout"
+                    break
+                if tree_read.returncode != 0:
+                    continue
+                try:
+                    tree_content = _read_content(_extract_json(tree_read.stdout))
+                except ValueError:
+                    continue
+                tree_contents.append(tree_content)
+            if sync_reason:
+                break
+            source_lines = set(canonical_context_lines(source_content))
+            matched_source_lines = {
+                line
+                for content in tree_contents
+                for line in canonical_context_lines(content)
+                if line in source_lines
+            }
+            coverage = len(matched_source_lines) / max(1, len(source_lines))
+            if (
+                tree_contents
+                and all(
+                    canonical_context_matches(content, source_content)
+                    for content in tree_contents
+                )
+                and coverage >= 0.8
+            ):
+                completed_refs.append(target)
+                continue
+            if tree_refs:
+                sync_reason = "provider_sync_revision_conflict"
+                break
+            try:
+                parent_probe = self._run(
+                    ["ls", parent, "-n", "1", "-o", "json", "-c", "true"],
+                    timeout_seconds=remaining,
+                )
+            except subprocess.TimeoutExpired:
+                sync_reason = "provider_sync_timeout"
+                break
+            if parent_probe.returncode != 0:
+                try:
+                    mkdir_result = self._run(
+                        ["mkdir", parent, "-o", "json", "-c", "true"],
+                        timeout_seconds=remaining,
+                    )
+                except subprocess.TimeoutExpired:
+                    sync_reason = "provider_sync_timeout"
+                    break
+                if mkdir_result.returncode != 0:
+                    sync_reason = "provider_sync_parent_create_failed"
+                    break
+            try:
+                result = self._run(
+                    [
+                        "add-resource",
+                        source,
+                        "--to",
+                        target,
+                        "--wait",
+                        "--timeout",
+                        str(max(1, int(remaining))),
+                        "-o",
+                        "json",
+                        "-c",
+                        "true",
+                    ],
+                    timeout_seconds=remaining,
+                )
+            except subprocess.TimeoutExpired:
+                break
+            if result.returncode != 0:
+                sync_reason = "provider_sync_write_failed"
+                break
+            completed_refs.append(target)
+            write_count += 1
+
+        status = "completed" if len(completed_refs) == len(bounded) else "partial"
+        return ContextProviderSync(
+            provider=self.provider_id,
+            namespace=namespace,
+            status=status,
+            observed_at=observed_at,
+            requested_count=len(bounded),
+            completed_count=len(completed_refs),
+            write_count=write_count,
+            reason_code=(
+                None
+                if status == "completed"
+                else sync_reason or "provider_sync_incomplete"
+            ),
+            provider_version=version,
+            latency_ms=int((time.monotonic() - started) * 1000),
+            result_refs=tuple(completed_refs),
+        )

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -41,6 +41,13 @@ from .reviewer_request import (
     build_issue_fix_reviewer_request_packet,
     render_issue_fix_reviewer_request_markdown,
 )
+from .repository_memory import SUPPORT_ASPECTS
+from .repository_memory_provider import (
+    default_repository_memory_provider_config_path,
+    render_issue_fix_repository_memory_sync_markdown,
+    retrieve_issue_fix_repository_memory,
+    sync_issue_fix_repository_memory,
+)
 from .workflow_plan import (
     build_issue_fix_workflow_plan_packet,
     render_issue_fix_workflow_plan_markdown,
@@ -63,6 +70,86 @@ def _load_json_object(path_text: str) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise ValueError(f"{path_text} must contain a JSON object")
     return payload
+
+
+def _configured_repository_memory_input(
+    *,
+    provider_path: str | None,
+    raw_memory_path: str | None,
+    repo_path: str | None,
+    repository_context_input: dict[str, Any] | None,
+    repo: str,
+    issue_ref: str,
+    query: str | None,
+    supports: list[str],
+    validation_label: str | None,
+    observed_at: str,
+) -> dict[str, Any] | None:
+    if raw_memory_path and provider_path:
+        raise ValueError(
+            "--repository-memory-json cannot be combined with a configured provider"
+        )
+    if raw_memory_path:
+        return _load_json_object(raw_memory_path)
+    if not provider_path:
+        return None
+    if not repo_path or not repository_context_input:
+        return None
+    revision = str(repository_context_input.get("repository_revision") or "").strip()
+    if not revision:
+        return None
+    retrieval_query = query or " ".join(
+        value
+        for value in (
+            repo,
+            issue_ref,
+            validation_label or "repository architecture reproduction validation",
+        )
+        if value
+    )
+    query_summary = (
+        query
+        or f"Public repository context for {repo} {issue_ref} before patch planning."
+    )
+    result = retrieve_issue_fix_repository_memory(
+        config=_load_json_object(provider_path),
+        repo_path=repo_path,
+        repository_revision=revision,
+        query=retrieval_query,
+        query_summary=query_summary,
+        supports=(
+            supports or ["architecture", "change_scope", "reproduction", "validation"]
+        ),
+        observed_at=observed_at,
+    )
+    return result["memory_input"]
+
+
+def _add_repository_memory_provider_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--repository-memory-provider-json",
+        default=None,
+        help=(
+            "Optional local-private issue_fix_repository_memory_provider_config_v0. "
+            "Defaults to LOOPX_ISSUE_FIX_REPOSITORY_MEMORY_PROVIDER_CONFIG. "
+            "The path, provider command, credentials, and raw payloads are never kept."
+        ),
+    )
+    parser.add_argument(
+        "--repository-memory-query",
+        default=None,
+        help=(
+            "Optional compact public query for configured provider search/read. "
+            "A bounded issue/ref/validation query is derived when omitted."
+        ),
+    )
+    parser.add_argument(
+        "--repository-memory-support",
+        action="append",
+        default=[],
+        choices=sorted(SUPPORT_ASPECTS),
+        help="Repository aspect supported by retrieved context. Repeat as needed.",
+    )
 
 
 def _load_jsonl_row(
@@ -132,6 +219,40 @@ def register_issue_fix_commands(
     issue_fix_sub = issue_fix_parser.add_subparsers(
         dest="issue_fix_command",
         required=True,
+    )
+    memory_sync_parser = issue_fix_sub.add_parser(
+        "repository-memory-sync",
+        help=(
+            "Plan or explicitly execute a bounded revision-scoped public resource "
+            "sync through the reusable context-provider module."
+        ),
+    )
+    add_subcommand_format(memory_sync_parser)
+    memory_sync_parser.add_argument("--repo-path", required=True)
+    memory_sync_parser.add_argument("--repository-context-json", required=True)
+    memory_sync_parser.add_argument(
+        "--repository-memory-provider-json",
+        default=None,
+        help=(
+            "Local-private provider config; defaults to "
+            "LOOPX_ISSUE_FIX_REPOSITORY_MEMORY_PROVIDER_CONFIG."
+        ),
+    )
+    memory_sync_parser.add_argument(
+        "--resource-reference",
+        action="append",
+        default=[],
+        required=True,
+        help="Repo-relative public file to index. Repeat up to the bounded cap.",
+    )
+    memory_sync_parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Perform the provider resource write. Without this flag, return a plan.",
+    )
+    memory_sync_parser.add_argument(
+        "--generated-at",
+        default="2026-07-11T00:00:00Z",
     )
     workflow_parser = issue_fix_sub.add_parser(
         "workflow-plan",
@@ -218,6 +339,7 @@ def register_issue_fix_commands(
             "LoopX keeps only compact advisory refs and checkout verification."
         ),
     )
+    _add_repository_memory_provider_args(workflow_parser)
     workflow_parser.add_argument(
         "--generated-at",
         default="2026-06-23T00:00:00Z",
@@ -290,6 +412,15 @@ def register_issue_fix_commands(
             "for stdin. Provider failures stay fail-open and no writeback is allowed."
         ),
     )
+    feasibility_parser.add_argument(
+        "--repo-path",
+        default=None,
+        help=(
+            "Optional caller-approved current checkout used only to verify provider "
+            "content. The path is never retained."
+        ),
+    )
+    _add_repository_memory_provider_args(feasibility_parser)
     feasibility_parser.add_argument(
         "--generated-at",
         default="2026-06-23T00:00:00Z",
@@ -756,20 +887,67 @@ def handle_issue_fix_command(
     print_payload: PrintPayload,
 ) -> int:
     try:
-        if args.issue_fix_command == "workflow-plan":
+        if args.issue_fix_command == "repository-memory-sync":
+            provider_path = (
+                args.repository_memory_provider_json
+                or default_repository_memory_provider_config_path()
+            )
+            if not provider_path:
+                raise ValueError("repository memory provider config is required")
+            if provider_path == "-" and args.repository_context_json == "-":
+                raise ValueError("only one JSON input may read from stdin")
+            repository_context_input = _load_json_object(args.repository_context_json)
+            revision = str(
+                repository_context_input.get("repository_revision") or ""
+            ).strip()
+            if not revision:
+                raise ValueError("repository context must pin repository_revision")
+            payload = sync_issue_fix_repository_memory(
+                config=_load_json_object(provider_path),
+                repo_path=args.repo_path,
+                repository_revision=revision,
+                references=args.resource_reference,
+                observed_at=args.generated_at,
+                execute=args.execute,
+            )
+            renderer = render_issue_fix_repository_memory_sync_markdown
+        elif args.issue_fix_command == "workflow-plan":
             if args.fetch_metadata and args.metadata_json:
                 raise ValueError("--fetch-metadata cannot be combined with --metadata-json")
+            provider_path = args.repository_memory_provider_json or (
+                None
+                if args.repository_memory_json
+                else default_repository_memory_provider_config_path()
+            )
             stdin_inputs = [
                 value
                 for value in (
                     args.metadata_json,
                     args.repository_context_json,
                     args.repository_memory_json,
+                    provider_path,
                 )
                 if value == "-"
             ]
             if len(stdin_inputs) > 1:
                 raise ValueError("only one JSON input may read from stdin")
+            repository_context_input = (
+                _load_json_object(args.repository_context_json)
+                if args.repository_context_json
+                else None
+            )
+            repository_memory_input = _configured_repository_memory_input(
+                provider_path=provider_path,
+                raw_memory_path=args.repository_memory_json,
+                repo_path=args.repo_path,
+                repository_context_input=repository_context_input,
+                repo=args.repo,
+                issue_ref=args.issue_ref,
+                query=args.repository_memory_query,
+                supports=args.repository_memory_support,
+                validation_label=args.validation_label,
+                observed_at=args.generated_at,
+            )
             payload = build_issue_fix_workflow_plan_packet(
                 repo=args.repo,
                 issue_ref=args.issue_ref,
@@ -783,25 +961,44 @@ def handle_issue_fix_command(
                 base_branch=args.base_branch,
                 issue_branch=args.issue_branch,
                 validation_label=args.validation_label,
-                repository_context_input=(
-                    _load_json_object(args.repository_context_json)
-                    if args.repository_context_json
-                    else None
-                ),
-                repository_memory_input=(
-                    _load_json_object(args.repository_memory_json)
-                    if args.repository_memory_json
-                    else None
-                ),
+                repository_context_input=repository_context_input,
+                repository_memory_input=repository_memory_input,
                 generated_at=args.generated_at,
             )
             renderer = render_issue_fix_workflow_plan_markdown
         elif args.issue_fix_command == "feasibility":
+            provider_path = args.repository_memory_provider_json or (
+                None
+                if args.repository_memory_json
+                else default_repository_memory_provider_config_path()
+            )
             if (
                 args.repository_context_json == "-"
                 and args.repository_memory_json == "-"
             ):
                 raise ValueError("only one JSON input may read from stdin")
+            if provider_path == "-" and (
+                args.repository_context_json == "-"
+                or args.repository_memory_json == "-"
+            ):
+                raise ValueError("only one JSON input may read from stdin")
+            repository_context_input = (
+                _load_json_object(args.repository_context_json)
+                if args.repository_context_json
+                else None
+            )
+            repository_memory_input = _configured_repository_memory_input(
+                provider_path=provider_path,
+                raw_memory_path=args.repository_memory_json,
+                repo_path=args.repo_path,
+                repository_context_input=repository_context_input,
+                repo=args.repo,
+                issue_ref=args.issue_ref,
+                query=args.repository_memory_query,
+                supports=args.repository_memory_support,
+                validation_label=args.validation_label,
+                observed_at=args.generated_at,
+            )
             boundary_authority_scopes, boundary_authority_resolved = (
                 _goal_boundary_authority_projection(
                     registry_path=registry_path,
@@ -817,16 +1014,8 @@ def handle_issue_fix_command(
                 reproduction_label=args.reproduction_label,
                 validation_label=args.validation_label,
                 comment_value=args.comment_value,
-                repository_context_input=(
-                    _load_json_object(args.repository_context_json)
-                    if args.repository_context_json
-                    else None
-                ),
-                repository_memory_input=(
-                    _load_json_object(args.repository_memory_json)
-                    if args.repository_memory_json
-                    else None
-                ),
+                repository_context_input=repository_context_input,
+                repository_memory_input=repository_memory_input,
                 boundary_authority_scopes=boundary_authority_scopes,
                 boundary_authority_resolved=boundary_authority_resolved,
                 generated_at=args.generated_at,
@@ -1050,7 +1239,7 @@ def handle_issue_fix_command(
             renderer = render_issue_fix_acceptance_loop_markdown
         else:
             raise ValueError(
-                "issue-fix requires `workflow-plan`, `feasibility`, "
+                "issue-fix requires `repository-memory-sync`, `workflow-plan`, `feasibility`, "
                 "`acceptance-fixture`, `pr-lifecycle`, `outcome`, `reviewer-plan`, "
                 "`reviewer-request`, "
                 "`repo-branch-fixture`, or `caller-repo-branch`"
@@ -1062,7 +1251,9 @@ def handle_issue_fix_command(
             "error": str(exc),
         }
         renderer = (
-            render_issue_fix_workflow_plan_markdown
+            render_issue_fix_repository_memory_sync_markdown
+            if getattr(args, "issue_fix_command", None) == "repository-memory-sync"
+            else render_issue_fix_workflow_plan_markdown
             if getattr(args, "issue_fix_command", None) == "workflow-plan"
             else render_issue_fix_feasibility_markdown
             if getattr(args, "issue_fix_command", None) == "feasibility"

--- a/loopx/capabilities/issue_fix/repository_memory.py
+++ b/loopx/capabilities/issue_fix/repository_memory.py
@@ -38,6 +38,12 @@ _INPUT_FIELDS = {
     "read_performed",
     "results",
     "reason_code",
+    "provider_version",
+    "latency_ms",
+    "requested_limit",
+    "configured_resource_count",
+    "stale_or_unmapped_count",
+    "verification_mode",
     "writeback_performed",
     "automatic_capture_performed",
 }
@@ -82,6 +88,23 @@ def _memory_ref_id(*, provider: str, namespace: str, memory_ref: str) -> str:
         f"{provider}\n{namespace}\n{memory_ref}".encode("utf-8")
     ).hexdigest()[:20]
     return f"memory-{digest}"
+
+
+def _optional_bounded_int(
+    value: Any,
+    *,
+    field: str,
+    minimum: int,
+    maximum: int,
+) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError(f"{field} must be an integer")
+    parsed = int(value)
+    if parsed < minimum or parsed > maximum:
+        raise ValueError(f"{field} must be between {minimum} and {maximum}")
+    return parsed
 
 
 def _empty_projection(
@@ -166,6 +189,54 @@ def build_issue_fix_repository_memory_hook(
     observed_at = _safe_text(
         memory_input.get("observed_at"), field="observed_at", limit=80
     )
+    provider_version = (
+        _safe_text(
+            memory_input.get("provider_version"), field="provider_version", limit=80
+        )
+        if memory_input.get("provider_version") is not None
+        else None
+    )
+    latency_ms = _optional_bounded_int(
+        memory_input.get("latency_ms"),
+        field="latency_ms",
+        minimum=0,
+        maximum=600_000,
+    )
+    requested_limit = _optional_bounded_int(
+        memory_input.get("requested_limit"),
+        field="requested_limit",
+        minimum=1,
+        maximum=MAX_MEMORY_RESULTS,
+    )
+    configured_resource_count = _optional_bounded_int(
+        memory_input.get("configured_resource_count"),
+        field="configured_resource_count",
+        minimum=0,
+        maximum=24,
+    )
+    stale_or_unmapped_count = _optional_bounded_int(
+        memory_input.get("stale_or_unmapped_count"),
+        field="stale_or_unmapped_count",
+        minimum=0,
+        maximum=MAX_MEMORY_RESULTS,
+    )
+    verification_mode = (
+        _safe_label(memory_input.get("verification_mode"), field="verification_mode")
+        if memory_input.get("verification_mode") is not None
+        else None
+    )
+    compact_telemetry = {
+        key: value
+        for key, value in {
+            "provider_version": provider_version,
+            "latency_ms": latency_ms,
+            "requested_limit": requested_limit,
+            "configured_resource_count": configured_resource_count,
+            "stale_or_unmapped_count": stale_or_unmapped_count,
+            "verification_mode": verification_mode,
+        }.items()
+        if value is not None
+    }
     search_performed = memory_input.get("search_performed") is True
     read_performed = memory_input.get("read_performed") is True
     raw_results = memory_input.get("results") or []
@@ -193,6 +264,7 @@ def build_issue_fix_repository_memory_hook(
             | {
                 "query_summary": query_summary,
                 "observed_at": observed_at,
+                **compact_telemetry,
             },
         }
 
@@ -215,6 +287,7 @@ def build_issue_fix_repository_memory_hook(
                 "query_summary": query_summary,
                 "observed_at": observed_at,
                 "discarded_result_count": len(raw_results),
+                **compact_telemetry,
             },
         }
 
@@ -332,6 +405,7 @@ def build_issue_fix_repository_memory_hook(
             "patch_influence_allowed_count": counts["confirmed"],
             "source_refs": [source["source_id"] for source in sources],
             "verification_refs": sorted(set(verification_refs)),
+            **compact_telemetry,
         }
     )
     return {"sources": sources, "projection": projection}

--- a/loopx/capabilities/issue_fix/repository_memory_provider.py
+++ b/loopx/capabilities/issue_fix/repository_memory_provider.py
@@ -1,0 +1,484 @@
+from __future__ import annotations
+
+import os
+import re
+from collections.abc import Mapping, Sequence
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import unquote
+
+from ..context_providers import build_context_provider, canonical_context_matches
+from ..context_providers.base import ContextProvider, opaque_provider_ref
+from ...control_plane.runtime.public_safety import public_safe_compact_text
+from .repository_memory import (
+    ISSUE_FIX_REPOSITORY_MEMORY_READ_RESULT_SCHEMA_VERSION,
+    MAX_MEMORY_RESULTS,
+    SUPPORT_ASPECTS,
+)
+
+
+ISSUE_FIX_REPOSITORY_MEMORY_PROVIDER_CONFIG_SCHEMA_VERSION = (
+    "issue_fix_repository_memory_provider_config_v0"
+)
+PROVIDER_CONFIG_ENV = "LOOPX_ISSUE_FIX_REPOSITORY_MEMORY_PROVIDER_CONFIG"
+MAX_PROVIDER_TIMEOUT_SECONDS = 60.0
+MAX_PROVIDER_SYNC_TIMEOUT_SECONDS = 600.0
+MAX_PROVIDER_SYNC_REFERENCES = 24
+
+_CONFIG_FIELDS = {
+    "schema_version",
+    "enabled",
+    "provider",
+    "provider_binary",
+    "minimum_provider_version",
+    "namespace",
+    "visibility",
+    "scope_ref",
+    "repository_revision",
+    "max_results",
+    "timeout_seconds",
+    "sync_timeout_seconds",
+    "resource_references",
+}
+_LABEL = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,119}$")
+
+
+def default_repository_memory_provider_config_path() -> str | None:
+    value = os.environ.get(PROVIDER_CONFIG_ENV, "").strip()
+    return value or None
+
+
+def _compact(value: Any, *, field: str, limit: int) -> str:
+    text = public_safe_compact_text(value, limit=limit)
+    if not text:
+        raise ValueError(f"{field} must be compact and public-safe")
+    return text
+
+
+def _label(value: Any, *, field: str) -> str:
+    value = _compact(value, field=field, limit=120)
+    if not _LABEL.fullmatch(value):
+        raise ValueError(f"{field} must be a compact public-safe label")
+    return value
+
+
+def _disabled_memory_input(
+    *,
+    provider: str,
+    namespace: str,
+    query_summary: str,
+    observed_at: str,
+) -> dict[str, Any]:
+    return {
+        "schema_version": ISSUE_FIX_REPOSITORY_MEMORY_READ_RESULT_SCHEMA_VERSION,
+        "provider": provider,
+        "namespace": namespace,
+        "visibility": "public",
+        "status": "disabled",
+        "query_summary": query_summary,
+        "observed_at": observed_at,
+        "search_performed": False,
+        "read_performed": False,
+        "reason_code": "provider_disabled",
+        "writeback_performed": False,
+        "automatic_capture_performed": False,
+        "results": [],
+    }
+
+
+def _unavailable_memory_input(
+    *,
+    provider: str,
+    namespace: str,
+    query_summary: str,
+    observed_at: str,
+    search_performed: bool,
+    read_performed: bool,
+    reason_code: str,
+) -> dict[str, Any]:
+    return {
+        "schema_version": ISSUE_FIX_REPOSITORY_MEMORY_READ_RESULT_SCHEMA_VERSION,
+        "provider": provider,
+        "namespace": namespace,
+        "visibility": "public",
+        "status": "unavailable",
+        "query_summary": query_summary,
+        "observed_at": observed_at,
+        "search_performed": search_performed,
+        "read_performed": read_performed,
+        "reason_code": _label(reason_code, field="reason_code"),
+        "writeback_performed": False,
+        "automatic_capture_performed": False,
+        "results": [],
+    }
+
+
+def _normalise_config(
+    config: Mapping[str, Any],
+    *,
+    repository_revision: str,
+) -> dict[str, Any]:
+    if (
+        config.get("schema_version")
+        != ISSUE_FIX_REPOSITORY_MEMORY_PROVIDER_CONFIG_SCHEMA_VERSION
+    ):
+        raise ValueError(
+            "repository memory provider config schema_version must be "
+            "issue_fix_repository_memory_provider_config_v0"
+        )
+    unknown = sorted(set(config) - _CONFIG_FIELDS)
+    if unknown:
+        raise ValueError(
+            f"repository memory provider config has unsupported fields: {unknown}"
+        )
+    provider = _label(config.get("provider"), field="provider")
+    namespace = _label(config.get("namespace"), field="namespace")
+    if config.get("visibility") != "public":
+        raise ValueError("repository memory provider visibility must be public")
+    configured_revision = _compact(
+        config.get("repository_revision"),
+        field="repository_revision",
+        limit=120,
+    )
+    if not re.fullmatch(r"[0-9a-fA-F]{12,64}", configured_revision):
+        raise ValueError("repository memory provider revision must be a git object id")
+    if configured_revision != repository_revision:
+        raise ValueError(
+            "repository memory provider revision must match current checkout"
+        )
+    scope_ref = _compact(config.get("scope_ref"), field="scope_ref", limit=500)
+    if not scope_ref.startswith("viking://"):
+        raise ValueError("repository memory provider scope_ref must use viking://")
+    if repository_revision[:12] not in scope_ref:
+        raise ValueError("repository memory provider scope_ref must be revision-scoped")
+    max_results = min(
+        max(1, int(config.get("max_results") or 3)),
+        MAX_MEMORY_RESULTS,
+    )
+    timeout_seconds = min(
+        max(1.0, float(config.get("timeout_seconds") or 15.0)),
+        MAX_PROVIDER_TIMEOUT_SECONDS,
+    )
+    sync_timeout_seconds = min(
+        max(1.0, float(config.get("sync_timeout_seconds") or 180.0)),
+        MAX_PROVIDER_SYNC_TIMEOUT_SECONDS,
+    )
+    raw_resource_references = config.get("resource_references") or []
+    if not isinstance(raw_resource_references, Sequence) or isinstance(
+        raw_resource_references, (str, bytes)
+    ):
+        raise ValueError("resource_references must be a list")
+    if len(raw_resource_references) > MAX_PROVIDER_SYNC_REFERENCES:
+        raise ValueError(
+            f"resource_references supports at most {MAX_PROVIDER_SYNC_REFERENCES} files"
+        )
+    resource_references: list[str] = []
+    for index, raw_reference in enumerate(raw_resource_references):
+        reference = PurePosixPath(
+            _compact(raw_reference, field=f"resource_references[{index}]", limit=260)
+        )
+        if reference.is_absolute() or ".." in reference.parts:
+            raise ValueError("resource_references must be repository-relative")
+        normalised_reference = reference.as_posix()
+        if normalised_reference not in resource_references:
+            resource_references.append(normalised_reference)
+    return {
+        **dict(config),
+        "provider": provider,
+        "namespace": namespace,
+        "scope_ref": scope_ref.rstrip("/"),
+        "repository_revision": configured_revision,
+        "max_results": max_results,
+        "timeout_seconds": timeout_seconds,
+        "sync_timeout_seconds": sync_timeout_seconds,
+        "resource_references": resource_references,
+        "enabled": config.get("enabled") is not False,
+    }
+
+
+def _repo_relative_ref(
+    *,
+    scope_ref: str,
+    resource_ref: str,
+    configured_references: Sequence[str],
+) -> str | None:
+    prefix = scope_ref.rstrip("/") + "/"
+    if not resource_ref.startswith(prefix):
+        return None
+    relative = unquote(resource_ref.removeprefix(prefix)).strip("/")
+    if not relative:
+        return None
+    path = PurePosixPath(relative)
+    if path.is_absolute() or ".." in path.parts:
+        return None
+    normalised = path.as_posix()
+    for reference in sorted(configured_references, key=len, reverse=True):
+        if normalised == reference or normalised.startswith(
+            reference.rstrip("/") + "/"
+        ):
+            return reference
+    return normalised if not configured_references else None
+
+
+def _checkout_content(repo_path: Path, reference: str) -> str | None:
+    root = repo_path.expanduser().resolve()
+    candidate = (root / reference).resolve()
+    try:
+        candidate.relative_to(root)
+    except ValueError:
+        return None
+    if not candidate.is_file():
+        return None
+    try:
+        return candidate.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def retrieve_issue_fix_repository_memory(
+    *,
+    config: Mapping[str, Any],
+    repo_path: str | Path,
+    repository_revision: str,
+    query: str,
+    query_summary: str,
+    supports: Sequence[str],
+    observed_at: str,
+    provider: ContextProvider | None = None,
+) -> dict[str, Any]:
+    """Run a configured provider and convert it into issue-fix advisory evidence."""
+
+    normalised = _normalise_config(config, repository_revision=repository_revision)
+    query = _compact(query, field="query", limit=500)
+    query_summary = _compact(query_summary, field="query_summary", limit=220)
+    support_values = sorted(
+        {str(value).strip() for value in supports if str(value).strip()}
+    )
+    if not support_values or any(
+        value not in SUPPORT_ASPECTS for value in support_values
+    ):
+        raise ValueError(f"supports must use {sorted(SUPPORT_ASPECTS)}")
+    provider_id = str(normalised["provider"])
+    namespace = str(normalised["namespace"])
+    if not normalised["enabled"]:
+        memory_input = _disabled_memory_input(
+            provider=provider_id,
+            namespace=namespace,
+            query_summary=query_summary,
+            observed_at=observed_at,
+        )
+        return {
+            "memory_input": memory_input,
+            "provider_projection": {
+                "status": "disabled",
+                "fail_open": True,
+                "result_count": 0,
+            },
+        }
+
+    provider = provider or build_context_provider(normalised)
+    retrieval = provider.retrieve(
+        namespace=namespace,
+        scope_ref=str(normalised["scope_ref"]),
+        query=query,
+        query_summary=query_summary,
+        max_results=int(normalised["max_results"]),
+        timeout_seconds=float(normalised["timeout_seconds"]),
+        observed_at=observed_at,
+    )
+    provider_projection = retrieval.public_packet()
+    if retrieval.status != "completed":
+        memory_input = _unavailable_memory_input(
+            provider=provider_id,
+            namespace=namespace,
+            query_summary=query_summary,
+            observed_at=observed_at,
+            search_performed=retrieval.search_performed,
+            read_performed=retrieval.read_performed,
+            reason_code=retrieval.reason_code or "provider_unavailable",
+        )
+        memory_input.update(
+            {
+                key: value
+                for key, value in {
+                    "provider_version": retrieval.provider_version,
+                    "latency_ms": retrieval.latency_ms,
+                    "requested_limit": retrieval.requested_limit,
+                    "configured_resource_count": len(normalised["resource_references"]),
+                    "stale_or_unmapped_count": 0,
+                    "verification_mode": "canonical_text_or_parser_chunk",
+                }.items()
+                if value is not None
+            }
+        )
+        return {
+            "memory_input": memory_input,
+            "provider_projection": provider_projection,
+        }
+
+    root = Path(repo_path)
+    results: list[dict[str, Any]] = []
+    confirmed_count = 0
+    stale_or_unmapped_count = 0
+    for item in retrieval.items:
+        reference = _repo_relative_ref(
+            scope_ref=str(normalised["scope_ref"]),
+            resource_ref=item.resource_ref,
+            configured_references=normalised["resource_references"],
+        )
+        checkout_content = _checkout_content(root, reference) if reference else None
+        confirmed = checkout_content is not None and canonical_context_matches(
+            item.content, checkout_content
+        )
+        row: dict[str, Any] = {
+            "memory_ref": opaque_provider_ref(
+                provider=provider_id,
+                namespace=namespace,
+                resource_ref=item.resource_ref,
+            ),
+            "summary": _compact(item.summary, field="result.summary", limit=220),
+            "supports": support_values,
+            "verification_status": "confirmed" if confirmed else "unverified",
+        }
+        if confirmed and reference:
+            row["verification_reference"] = reference
+            row["verification_revision"] = repository_revision
+            confirmed_count += 1
+        else:
+            stale_or_unmapped_count += 1
+        results.append(row)
+
+    memory_input = {
+        "schema_version": ISSUE_FIX_REPOSITORY_MEMORY_READ_RESULT_SCHEMA_VERSION,
+        "provider": provider_id,
+        "namespace": namespace,
+        "visibility": "public",
+        "status": "completed",
+        "query_summary": query_summary,
+        "observed_at": observed_at,
+        "search_performed": retrieval.search_performed,
+        "read_performed": retrieval.read_performed,
+        "writeback_performed": False,
+        "automatic_capture_performed": False,
+        "provider_version": retrieval.provider_version,
+        "latency_ms": retrieval.latency_ms,
+        "requested_limit": retrieval.requested_limit,
+        "configured_resource_count": len(normalised["resource_references"]),
+        "stale_or_unmapped_count": stale_or_unmapped_count,
+        "verification_mode": "canonical_text_or_parser_chunk",
+        "results": results,
+    }
+    if memory_input["provider_version"] is None:
+        del memory_input["provider_version"]
+    provider_projection["checkout_verification"] = {
+        "revision": repository_revision,
+        "confirmed_count": confirmed_count,
+        "stale_or_unmapped_count": stale_or_unmapped_count,
+        "patch_influence_allowed_count": confirmed_count,
+        "configured_resource_count": len(normalised["resource_references"]),
+        "verification_mode": "canonical_text_or_parser_chunk",
+    }
+    return {
+        "memory_input": memory_input,
+        "provider_projection": provider_projection,
+    }
+
+
+def sync_issue_fix_repository_memory(
+    *,
+    config: Mapping[str, Any],
+    repo_path: str | Path,
+    repository_revision: str,
+    references: Sequence[str],
+    observed_at: str,
+    execute: bool,
+    provider: ContextProvider | None = None,
+) -> dict[str, Any]:
+    """Bound an explicit provider resource refresh to one revision checkout."""
+
+    normalised = _normalise_config(config, repository_revision=repository_revision)
+    if not normalised["enabled"]:
+        return {
+            "schema_version": "issue_fix_repository_memory_sync_v0",
+            "ok": False,
+            "status": "disabled",
+            "provider": normalised["provider"],
+            "namespace": normalised["namespace"],
+            "repository_revision": repository_revision,
+            "requested_reference_count": 0,
+            "external_writes_performed": False,
+            "fail_open": True,
+        }
+    scope_ref = str(normalised["scope_ref"])
+    if not scope_ref.startswith("viking://resources/"):
+        raise ValueError("issue-fix repository sync requires a resources scope")
+    if len(references) > MAX_PROVIDER_SYNC_REFERENCES:
+        raise ValueError(
+            f"sync supports at most {MAX_PROVIDER_SYNC_REFERENCES} references"
+        )
+    bounded = list(dict.fromkeys(str(reference) for reference in references))
+    if not bounded:
+        raise ValueError("at least one repository reference is required")
+    root = Path(repo_path).expanduser().resolve()
+    configured_references = set(normalised["resource_references"])
+    if configured_references and any(
+        str(PurePosixPath(reference)) not in configured_references
+        for reference in bounded
+    ):
+        raise ValueError("sync references must be declared in resource_references")
+    resources: list[tuple[str, str]] = []
+    for index, raw_reference in enumerate(bounded):
+        reference = PurePosixPath(
+            _compact(raw_reference, field=f"references[{index}]", limit=260)
+        )
+        if reference.is_absolute() or ".." in reference.parts:
+            raise ValueError("sync references must be repository-relative")
+        source = (root / reference.as_posix()).resolve()
+        try:
+            source.relative_to(root)
+        except ValueError as exc:
+            raise ValueError("sync reference escapes the repository") from exc
+        if not source.is_file():
+            raise ValueError(f"sync reference is not a file: {reference.as_posix()}")
+        resources.append((str(source), f"{scope_ref}/{reference.as_posix()}"))
+
+    provider = provider or build_context_provider(normalised)
+    sync = provider.sync(
+        namespace=str(normalised["namespace"]),
+        resources=resources,
+        timeout_seconds=float(normalised["sync_timeout_seconds"]),
+        observed_at=observed_at,
+        execute=execute,
+    )
+    packet = sync.public_packet()
+    packet.update(
+        {
+            "schema_version": "issue_fix_repository_memory_sync_v0",
+            "repository_revision": repository_revision,
+            "requested_reference_count": len(resources),
+            "revision_scoped": True,
+            "automatic_capture_performed": False,
+            "memory_writeback_performed": False,
+        }
+    )
+    return packet
+
+
+def render_issue_fix_repository_memory_sync_markdown(
+    payload: Mapping[str, Any],
+) -> str:
+    return "\n".join(
+        [
+            "# Issue Fix Repository Memory Sync",
+            "",
+            f"- ok: `{bool(payload.get('ok'))}`",
+            f"- status: `{payload.get('status')}`",
+            f"- provider: `{payload.get('provider')}`",
+            f"- namespace: `{payload.get('namespace')}`",
+            f"- repository revision: `{payload.get('repository_revision')}`",
+            f"- requested references: `{payload.get('requested_reference_count', 0)}`",
+            f"- completed resources: `{payload.get('completed_count', 0)}`",
+            f"- provider writes: `{payload.get('write_count', 0)}`",
+            f"- external writes performed: `{bool(payload.get('external_writes_performed'))}`",
+        ]
+    )


### PR DESCRIPTION
## Motivation

The OpenViking issue-fix pilot proved that repository memory is useful only when search/read is revision-scoped, bounded, fail-open, and verified against the current checkout. LoopX previously accepted only a host-assembled memory JSON packet, so every capability had to own provider invocation and compatibility handling.

## Implementation

- add a reusable LoopX context-provider contract and OpenViking CLI implementation
- add version/service preflight, explicit search then read, result/latency caps, compact telemetry, and no raw payload retention
- add explicit bounded resource sync with revision scope, exact target URIs, retry idempotence, and conflict stop
- make issue-fix the first domain call site via a local provider config or environment default
- require current-checkout canonical text or parser-chunk verification before memory may influence a patch
- preserve the existing repository-context/domain-state projection; no second ledger or repository-name special case
- document the design and operator path in English and Chinese

## Validation

- LoopX canary premerge --from-git-diff: passed, 17/17 selected checks, public-boundary scan clean
- focused issue-fix repository-memory/context/workflow/feasibility/guide smokes: passed
- Ruff check and changed-file compile: passed
- real product smoke on OpenViking origin/main 9cf42405 with OpenViking 0.4.9.dev33:
  - revision-scoped two-resource sync completed and idempotent retry performed zero writes
  - default workflow-plan invoked search then read
  - 3 hits, 1 checkout-confirmed advisory source, patch influence count 1
  - provider version, 253 ms latency, cap, corpus coverage, and stale/unmapped counts projected
  - raw memory capture false and writeback false
  - offline service path remained workflow-ok with provider_service_unavailable fail-open

## Risk and limits

- provider configuration and credentials remain local and are never projected
- resource sync is never automatic and still requires explicit execute authority
- parser-generated parent summaries may remain unverified; only checkout-matched file/chunk content can influence a patch
- this PR does not enable transcript capture, memory writeback, private namespaces, or cross-revision retrieval
