### PR TITLE
Retain issue-fix delivery evidence across default syncs

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -619,6 +619,15 @@ even before a PR exists; a PR enriches that row only when its lifecycle
 observation carries the matching `repo` and explicit `issue_ref`. This automatic
 closeout projection adds no outcome ledger or second state machine.
 
+Supplying `--delivery-evidence-json` alone is a read-only preview. Add
+`--write-delivery-evidence` after focused validation to store its validated,
+public-safe compact form inside the existing feasibility row. Later default
+outcome and Kanban syncs then retain the validation, changed files, commit, output
+links, and risks instead of falling back to the feasibility declaration. The
+write flag rejects an ad hoc `--feasibility-json` source so the destination is
+always the stable goal-scoped row.
+Repeating the same compact evidence is an unchanged, no-write operation.
+
 The Lark adapter renders this as a first-class issue dimension rather than
 only flattening the packet into `Evidence`. Outcome rows set
 `Work Item Type=Issue Fix` and populate `Repository`, `Issue`, `Pull Request`,
@@ -698,6 +707,7 @@ loopx issue-fix outcome \
   --issue-ref issues_123 \
   --pr-ref pull_456 \
   --delivery-evidence-json delivery-evidence.json \
+  --write-delivery-evidence \
   --agent-id codex-issue-fix \
   --format json
 ```

--- a/docs/capabilities/issue-fix/README.zh-CN.md
+++ b/docs/capabilities/issue-fix/README.zh-CN.md
@@ -543,6 +543,13 @@ lifecycle domain state 推导全部 issue outcome，并与 todo 行一起 upsert
 带有相同 `repo` 和显式 `issue_ref` 时，PR 才会补充到该行。这个自动 closeout projection
 不会新增 outcome ledger，也不会建立第二套状态机。
 
+只传 `--delivery-evidence-json` 仍是只读预览。focused validation 完成后，加上
+`--write-delivery-evidence`，LoopX 会把经过校验、public-safe 的紧凑证据写回现有
+feasibility row。之后默认 outcome 与看板同步会继续保留 validation、changed files、
+commit、output links 与 risks，而不会降回 feasibility 阶段的声明值。写入模式拒绝
+`--feasibility-json` 临时来源，确保目标始终是稳定的 goal-scoped row。
+相同的紧凑证据重复执行时会返回 unchanged，不重复写盘。
+
 Lark adapter 会把它渲染成一等 issue 维度，而不只是把 packet 压平写进 `Evidence`。
 Outcome 行设置 `Work Item Type=Issue Fix`，并填写 `Repository`、`Issue`、
 `Pull Request`、`Route`、`Stage`、`Validation` 和 `Outcome`。`Issue Fix Outcomes`
@@ -620,6 +627,7 @@ loopx issue-fix outcome \
   --issue-ref issues_123 \
   --pr-ref pull_456 \
   --delivery-evidence-json delivery-evidence.json \
+  --write-delivery-evidence \
   --agent-id codex-issue-fix \
   --format json
 ```

--- a/examples/issue-fix-outcome-projection-smoke.py
+++ b/examples/issue-fix-outcome-projection-smoke.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -228,7 +229,111 @@ def assert_default_goal_sync_composes_outcomes() -> None:
         }
         assert collection_by_issue["issues_42"]["pull_request"]["number"] == 77
         assert collection_by_issue["issues_43"]["pull_request"] is None
+        assert collection_by_issue["issues_42"]["validation"]["status"] == "declared"
         assert collection["source_contract"]["creates_parallel_state_machine"] is False
+
+        delivery_path = project / "delivery-evidence.json"
+        delivery_path.write_text(
+            json.dumps(delivery_evidence(), ensure_ascii=False),
+            encoding="utf-8",
+        )
+        outcome_command = [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry),
+            "--format",
+            "json",
+            "issue-fix",
+            "outcome",
+            "--goal-id",
+            goal_id,
+            "--project",
+            str(project),
+            "--repo",
+            "public-fixture/widgets",
+            "--issue-ref",
+            "issues_42",
+            "--pr-ref",
+            "pull_77",
+            "--delivery-evidence-json",
+            str(delivery_path),
+        ]
+        ledger_before_preview = feasibility_ledger.read_text(encoding="utf-8")
+        preview = subprocess.run(
+            outcome_command,
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        preview_packet = json.loads(preview.stdout)
+        assert preview_packet["issue_fix_outcomes"][0]["validation"]["status"] == "passed"
+        assert preview_packet["source_contract"]["writes_source_state"] is False
+        assert feasibility_ledger.read_text(encoding="utf-8") == ledger_before_preview
+
+        persisted = subprocess.run(
+            [*outcome_command, "--write-delivery-evidence"],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        persisted_packet = json.loads(persisted.stdout)
+        assert persisted_packet["source_contract"]["writes_source_state"] is True
+        assert persisted_packet["domain_state_write"]["write_performed"] is True
+        feasibility_rows = [
+            json.loads(line)
+            for line in feasibility_ledger.read_text(encoding="utf-8").splitlines()
+        ]
+        assert len(feasibility_rows) == 2, feasibility_rows
+        stored = next(
+            row
+            for row in feasibility_rows
+            if row["observation"]["issue_ref"] == "issues_42"
+        )
+        assert stored["delivery_evidence"]["validation_status"] == "passed"
+        assert set(stored["delivery_evidence"]) == {
+            "schema_version",
+            "outcome_status",
+            "validation_status",
+            "validation_label",
+            "changed_files",
+            "commit_ref",
+            "outputs",
+            "risks",
+            "recorded_at",
+        }
+        assert not list(feasibility_ledger.parent.glob("*outcome*"))
+
+        ledger_after_write = feasibility_ledger.read_text(encoding="utf-8")
+        repeated = subprocess.run(
+            [*outcome_command, "--write-delivery-evidence"],
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        repeated_packet = json.loads(repeated.stdout)
+        assert repeated_packet["domain_state_write"]["status"] == "unchanged"
+        assert repeated_packet["domain_state_write"]["write_performed"] is False
+        assert feasibility_ledger.read_text(encoding="utf-8") == ledger_after_write
+
+        retained = build_issue_fix_outcome_collection_from_domain_state(
+            goal_id=goal_id,
+            project=project,
+            agent_id="codex-public-fixture",
+        )
+        retained_by_issue = {
+            item["issue_ref"]: item for item in retained["issue_fix_outcomes"]
+        }
+        assert retained_by_issue["issues_42"]["validation"]["status"] == "passed"
+        assert retained_by_issue["issues_42"]["delivery"]["evidence_provided"] is True
+        assert retained_by_issue["issues_43"]["validation"]["status"] == "declared"
 
         sync = sync_loopx_todos_to_lark_kanban(
             LarkKanbanConfig(
@@ -255,6 +360,7 @@ def assert_default_goal_sync_composes_outcomes() -> None:
             if item["values"]["Issue"].endswith("/issues/42")
         )
         assert linked_record["values"]["Pull Request"].endswith("/pull/77")
+        assert linked_record["values"]["Validation"].startswith("passed:")
         unlinked_record = next(
             item
             for item in outcome_records

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -28,6 +28,7 @@ from .feasibility import (
 )
 from .outcome_projection import (
     build_issue_fix_outcome_projection,
+    compact_issue_fix_delivery_evidence,
     render_issue_fix_outcome_projection_markdown,
 )
 from .pr_lifecycle import (
@@ -567,6 +568,14 @@ def register_issue_fix_commands(
         ),
     )
     outcome_parser.add_argument(
+        "--write-delivery-evidence",
+        action="store_true",
+        help=(
+            "Validate and write compact delivery evidence into the selected "
+            "existing feasibility row so default outcome and Kanban sync retain it."
+        ),
+    )
+    outcome_parser.add_argument(
         "--agent-id",
         help="Optional registered agent id projected as the case owner.",
     )
@@ -1058,6 +1067,15 @@ def handle_issue_fix_command(
                     domain_state["write_skipped_reason"] = "goal_id_or_ledger_path_missing"
             renderer = render_issue_fix_pr_lifecycle_monitor_markdown
         elif args.issue_fix_command == "outcome":
+            if args.write_delivery_evidence and not args.delivery_evidence_json:
+                raise ValueError(
+                    "--write-delivery-evidence requires --delivery-evidence-json"
+                )
+            if args.write_delivery_evidence and args.feasibility_json:
+                raise ValueError(
+                    "--write-delivery-evidence uses the default feasibility domain-state row; "
+                    "do not combine it with --feasibility-json"
+                )
             stdin_input_count = sum(
                 value == "-"
                 for value in (
@@ -1112,18 +1130,71 @@ def handle_issue_fix_command(
                     raise ValueError(
                         "--pr-ref must match the selected PR lifecycle packet"
                     )
+            explicit_delivery_evidence = (
+                _load_json_object(args.delivery_evidence_json)
+                if args.delivery_evidence_json
+                else None
+            )
+            delivery_evidence = (
+                compact_issue_fix_delivery_evidence(
+                    explicit_delivery_evidence,
+                )
+                if explicit_delivery_evidence is not None
+                else (
+                    feasibility_packet.get("delivery_evidence")
+                    if isinstance(feasibility_packet.get("delivery_evidence"), dict)
+                    else None
+                )
+            )
+            domain_state_write: dict[str, Any] | None = None
+            if args.write_delivery_evidence:
+                existing_delivery = feasibility_packet.get("delivery_evidence")
+                existing_compact = (
+                    compact_issue_fix_delivery_evidence(existing_delivery)
+                    if isinstance(existing_delivery, dict)
+                    else None
+                )
+                if existing_compact == delivery_evidence:
+                    delivery_evidence = existing_delivery
+                    write_result = {
+                        "write_performed": False,
+                        "status": "unchanged",
+                        "row_count": None,
+                    }
+                else:
+                    delivery_evidence = {
+                        **delivery_evidence,
+                        "recorded_at": generated_at,
+                    }
+                    feasibility_packet["delivery_evidence"] = delivery_evidence
+                    write_result = upsert_issue_fix_feasibility_ledger_jsonl(
+                        default_issue_fix_feasibility_ledger_path(
+                            project=project,
+                            goal_id=args.goal_id,
+                        ),
+                        feasibility_packet,
+                    )
+                domain_state_write = {
+                    "schema_version": "issue_fix_delivery_evidence_writeback_v0",
+                    "domain_pack": "issue_fix",
+                    "stream": "feasibility",
+                    "key": {"repo": args.repo, "issue_ref": args.issue_ref},
+                    "write_performed": write_result.get("write_performed") is True,
+                    "status": write_result.get("status"),
+                    "row_count": write_result.get("row_count"),
+                    "path_recorded": False,
+                }
             payload = build_issue_fix_outcome_projection(
                 goal_id=args.goal_id,
                 feasibility_packet=feasibility_packet,
                 pr_lifecycle_packet=pr_lifecycle_packet,
-                delivery_evidence_input=(
-                    _load_json_object(args.delivery_evidence_json)
-                    if args.delivery_evidence_json
-                    else None
-                ),
+                delivery_evidence_input=delivery_evidence,
                 agent_id=args.agent_id,
                 generated_at=generated_at,
             )
+            if domain_state_write is not None:
+                payload["domain_state_write"] = domain_state_write
+                payload["source_contract"]["writes_source_state"] = True
             renderer = render_issue_fix_outcome_projection_markdown
         elif args.issue_fix_command == "reviewer-plan":
             payload = build_issue_fix_reviewer_recommendation_packet(

--- a/loopx/capabilities/issue_fix/outcome_projection.py
+++ b/loopx/capabilities/issue_fix/outcome_projection.py
@@ -129,6 +129,33 @@ def _delivery_evidence(value: Mapping[str, Any] | None) -> dict[str, Any]:
     }
 
 
+def compact_issue_fix_delivery_evidence(
+    value: Mapping[str, Any],
+    *,
+    recorded_at: str | None = None,
+) -> dict[str, Any]:
+    """Validate and compact delivery evidence before domain-state writeback."""
+
+    delivery = _delivery_evidence(value)
+    compact: dict[str, Any] = {
+        "schema_version": ISSUE_FIX_DELIVERY_EVIDENCE_INPUT_SCHEMA_VERSION,
+        "outcome_status": delivery["outcome_status"],
+        "validation_status": delivery["validation_status"],
+        "validation_label": delivery.get("validation_label") or "",
+        "changed_files": list(delivery.get("changed_files") or []),
+        "commit_ref": delivery.get("commit_ref"),
+        "outputs": list(delivery.get("outputs") or []),
+        "risks": list(delivery.get("risks") or []),
+    }
+    if recorded_at:
+        compact["recorded_at"] = _safe_text(
+            recorded_at,
+            field="delivery evidence recorded_at",
+            limit=80,
+        )
+    return compact
+
+
 def _stage_and_card_status(
     *,
     route: str,
@@ -582,6 +609,13 @@ def build_issue_fix_outcome_collection_from_domain_state(
                 goal_id=goal_id,
                 feasibility_packet=feasibility_packet,
                 pr_lifecycle_packet=lifecycle_packet,
+                delivery_evidence_input=(
+                    feasibility_packet.get("delivery_evidence")
+                    if isinstance(
+                        feasibility_packet.get("delivery_evidence"), Mapping
+                    )
+                    else None
+                ),
                 agent_id=agent_id,
                 generated_at=generated_at,
             )
@@ -610,6 +644,7 @@ def build_issue_fix_outcome_collection_from_domain_state(
         "source_contract": {
             "feasibility": "issue_fix_feasibility_v0",
             "pr_lifecycle": "issue_fix_pr_lifecycle_monitor_v0",
+            "delivery_evidence": "embedded_in_feasibility_row",
             "association": "explicit_repo_and_issue_ref_only",
             "writes_source_state": False,
             "creates_parallel_state_machine": False,


### PR DESCRIPTION
## Motivation

The default issue-fix outcome/Kanban sync already composes feasibility and PR lifecycle rows, but explicit delivery evidence supplied to `issue-fix outcome` was process-local. The next default sync therefore downgraded validated work from `passed` to the feasibility declaration.

## Implementation

- add explicit `--write-delivery-evidence` writeback to the existing goal-scoped feasibility row
- validate and compact the evidence before persistence; retain only public-safe status, repo-relative files, commit ref, HTTPS outputs, risks, and recorded time
- make repeated identical evidence an unchanged/no-write operation
- have default outcome collection and Kanban sync consume the embedded evidence
- document preview versus writeback in the English and Chinese capability guides

This reuses the existing feasibility ledger and does not create an outcome ledger or second state machine.

## Validation

- `python3 examples/issue-fix-outcome-projection-smoke.py`
- `python3 examples/issue-fix-workflow-e2e-smoke.py`
- `python3 examples/issue-fix-acceptance-loop-smoke.py`
- `python3 examples/issue-fix-feasibility-smoke.py`
- `python3 examples/issue-fix-pr-lifecycle-smoke.py`
- `uvx ruff check ...`
- `loopx canary premerge --from-git-diff --format json`: 17/17 selected checks passed, public boundary clean, no warnings/manual holds, self-merge allowed

## Risk and exclusions

- Writeback is opt-in; supplying delivery JSON alone remains read-only.
- Write mode rejects ad hoc feasibility JSON so it cannot target an ambiguous row.
- No external system is written by this command, and no local paths, credentials, raw logs, or runtime state are included.
- Existing feasibility rows without delivery evidence keep the prior `declared` behavior.
