### PR TITLE
Preserve heartbeat capabilities across automation upgrades

### DIFF
--- a/examples/capability-gate-smoke.py
+++ b/examples/capability-gate-smoke.py
@@ -279,6 +279,9 @@ def main() -> int:
     assert owner_gate["requires_user_action"] is True, owner_gate
     assert owner_gate["capability_gate"]["action"] == "ask_owner", owner_gate
     assert owner_gate["interaction_contract"]["user_channel"]["action_required"] is True, owner_gate
+    assert owner_gate["interaction_contract"]["user_channel"]["actions"] == [
+        "provide or authorize the missing owner-held capability: network"
+    ], owner_gate
     assert owner_gate["heartbeat_recommendation"]["notify"] == "NOTIFY", owner_gate
 
     mixed_capability_todo = todo(

--- a/examples/control_plane/heartbeat-prompt-smoke.py
+++ b/examples/control_plane/heartbeat-prompt-smoke.py
@@ -238,6 +238,11 @@ def main() -> int:
         command = str(capability_scoped_payload[command_key])
         assert "--available-capability network" in command, command
         assert "--available-capability external_evidence_poll" in command, command
+    capability_task_body = str(capability_scoped_payload["task_body"])
+    assert "--available-capability network" in capability_task_body, capability_task_body
+    assert "--available-capability external_evidence_poll" in capability_task_body, (
+        capability_task_body
+    )
     assert "productization showcase docs lane" in normalized(str(profile_scoped_payload["task_body"])), (
         profile_scoped_payload
     )

--- a/examples/upgrade-plan-smoke.py
+++ b/examples/upgrade-plan-smoke.py
@@ -370,9 +370,8 @@ def assert_registered_agent_activation_is_checked(root: Path) -> None:
         cli_bin="loopx",
         agent_id=REGISTERED_AGENT_ID,
         registered_agents=[REGISTERED_AGENT_ID],
+        available_capabilities=["network", "external_evidence_poll"],
     )["task_body"]
-    expected_sha = goal["generated_prompts"]["thin:codex-current"]["sha256"]
-    assert prompt_digest(rendered) == expected_sha, payload
     write_registered_codex_app_automation(root / "registered-codex-home", prompt=rendered)
     old_codex_home = os.environ.get("CODEX_HOME")
     os.environ["CODEX_HOME"] = str(root / "registered-codex-home")
@@ -381,6 +380,16 @@ def assert_registered_agent_activation_is_checked(root: Path) -> None:
         pending_migration = pending_payload["managed_heartbeats"][0][
             "peer_runtime_automation_migration"
         ]
+        pending_goal = pending_payload["managed_heartbeats"][0]
+        pending_prompt = pending_goal["generated_prompts"]["thin:codex-current"]
+        assert "--available-capability network" in pending_prompt["command"], pending_prompt
+        assert "--available-capability external_evidence_poll" in pending_prompt["command"], (
+            pending_prompt
+        )
+        assert pending_goal["installed_prompts"]["thin:codex-current"][
+            "available_capabilities"
+        ] == ["network", "external_evidence_poll"], pending_goal
+        assert pending_migration["host_update_required_once"] is False, pending_migration
         pending_markdown = render_upgrade_plan_markdown(pending_payload)
         assert pending_migration["migration_id"] in pending_markdown, pending_markdown
         configure_goal(

--- a/loopx/control_plane/work_items/interaction_contract.py
+++ b/loopx/control_plane/work_items/interaction_contract.py
@@ -23,25 +23,6 @@ INTERACTION_CONTRACT_SCHEMA_VERSION = "loopx_interaction_contract_v0"
 PROTOCOL_ACTION_PACKET_SCHEMA_VERSION = "protocol_action_packet_v0"
 
 
-def _protocol_todo_actions(summary: Any, *, limit: int = 3) -> list[str]:
-    if not isinstance(summary, dict):
-        return []
-    first_open_items = summary.get("first_open_items")
-    if not isinstance(first_open_items, list):
-        return []
-    actions: list[str] = []
-    for item in first_open_items:
-        if not isinstance(item, dict):
-            continue
-        text = _protocol_action_label(item.get("text"))
-        if not text:
-            continue
-        actions.append(text)
-        if len(actions) >= limit:
-            break
-    return actions
-
-
 def _user_todo_item_is_explicitly_non_gating(item: dict[str, Any]) -> bool:
     if item.get("gating") is False or item.get("non_gating") is True:
         return True
@@ -83,6 +64,33 @@ def user_channel_action_required(payload: dict[str, Any]) -> bool:
     return bool(payload.get("requires_user_action")) or bool(
         user_channel_action_todo_actions(payload.get("user_todo_summary"))
     )
+
+
+def projected_user_channel_actions(
+    payload: dict[str, Any],
+    *,
+    limit: int = 3,
+) -> list[str]:
+    actions = user_channel_action_todo_actions(
+        payload.get("user_todo_summary"),
+        limit=limit,
+    )
+    if actions or not user_channel_action_required(payload):
+        return actions
+    capability_gate = (
+        payload.get("capability_gate")
+        if isinstance(payload.get("capability_gate"), dict)
+        else {}
+    )
+    if capability_gate.get("action") == "ask_owner":
+        owner_action = protocol_action_text(capability_gate.get("owner_action"))
+        if owner_action:
+            return [owner_action]
+    for key in ("gate_prompt", "operator_question", "open_todo_notify_reason"):
+        text = protocol_action_text(payload.get(key))
+        if text:
+            return [text]
+    return []
 
 
 def attach_user_action_compat_fields(payload: dict[str, Any]) -> None:
@@ -134,24 +142,7 @@ def build_protocol_action_packet(payload: dict[str, Any]) -> dict[str, Any]:
         and not scoped_user_gate_fallback
     )
 
-    user_actions = _protocol_todo_actions(payload.get("user_todo_summary"))
-    if requires_user_action and not user_actions:
-        capability_gate = (
-            payload.get("capability_gate")
-            if isinstance(payload.get("capability_gate"), dict)
-            else {}
-        )
-        if capability_gate.get("action") == "ask_owner":
-            owner_action = protocol_action_text(capability_gate.get("owner_action"))
-            if owner_action:
-                user_actions = [owner_action]
-        for key in ("gate_prompt", "operator_question", "open_todo_notify_reason"):
-            if user_actions:
-                break
-            text = protocol_action_text(payload.get(key))
-            if text:
-                user_actions = [text]
-                break
+    user_actions = projected_user_channel_actions(payload)
 
     if requires_user_action and scoped_user_gate_fallback:
         primary_actor = "agent_with_user_gate"
@@ -651,6 +642,9 @@ def _build_interaction_user_channel(
     }
     if user_required:
         channel["max_items"] = 3
+        actions = projected_user_channel_actions(payload, limit=3)
+        if actions:
+            channel["actions"] = actions
     reason = _interaction_user_reason(payload)
     if reason:
         channel["reason"] = reason

--- a/loopx/heartbeat_prompt.py
+++ b/loopx/heartbeat_prompt.py
@@ -899,6 +899,11 @@ def render_thin_heartbeat_task_body(
         else material_queue_rule
     )
     scope_sentence = f"\n\n{agent_scope_instruction}" if agent_scope_instruction else ""
+    quota_guard_instruction = (
+        f"`{quota_guard_command}`"
+        if "--available-capability" in quota_guard_command
+        else "`quota should-run`"
+    )
     return f"""Advance `{goal_id}` from {active_state}.
 
 Use skills: `loopx-project`; if surprising/tiny/contradictory,
@@ -906,7 +911,7 @@ Use skills: `loopx-project`; if surprising/tiny/contradictory,
 {scope_sentence}
 
 Inspect registry/global quota, active state, status/history, repo; run
-`quota should-run`; follow `interaction_contract`. If action_required/open_count:
+{quota_guard_instruction}; follow `interaction_contract`. If action_required/open_count:
 Chinese concrete todos/questions; never only "owner gate"; missing ->
 "具体 user todo 未投影，需修复 LoopX 状态投影". If false/0: quiet/no-user-todo.
 {SCHEDULER_HINT_THIN_RULE}

--- a/loopx/upgrade.py
+++ b/loopx/upgrade.py
@@ -21,6 +21,7 @@ from .control_plane.agents.runtime_model import (
     peer_agent_runtime_migration_completed,
     peer_agent_runtime_migration_id,
 )
+from .control_plane.todos.contract import normalize_required_capabilities
 
 
 DEFAULT_UPGRADE_MODES = ("thin",)
@@ -43,6 +44,9 @@ PROJECT_POLICY_MARKERS = (
     "Current controller policy:",
     "Primary stability objective:",
     "Current controller policy",
+)
+AVAILABLE_CAPABILITY_PATTERN = re.compile(
+    r"--available-capability(?:=|\s+)([A-Za-z][A-Za-z0-9_:-]{0,63})"
 )
 STAGE_DEFERRED_ATTENTION_STATUSES = {
     "stage_deferred_not_installed",
@@ -231,6 +235,12 @@ def infer_prompt_mode(prompt: str) -> str:
     return DEFAULT_UPGRADE_MODES[0]
 
 
+def infer_available_capabilities_from_prompt(prompt: str) -> list[str]:
+    return normalize_required_capabilities(
+        AVAILABLE_CAPABILITY_PATTERN.findall(prompt)
+    )
+
+
 def load_codex_app_automation_manifest(root: Path | None = None) -> dict[str, Any]:
     home = root or codex_home()
     automations_root = home / "automations"
@@ -269,6 +279,9 @@ def load_codex_app_automation_manifest(root: Path | None = None) -> dict[str, An
                 "char_count": len(prompt),
                 "line_count": len(prompt.splitlines()),
                 "prompt_policy_audit": prompt_policy_audit(prompt),
+                "available_capabilities": infer_available_capabilities_from_prompt(
+                    prompt
+                ),
                 "status": status,
                 "installed": status.upper() != "DELETED",
                 "source": "codex_app_automation_toml",
@@ -294,6 +307,20 @@ def installed_entry_digest(entry: dict[str, Any]) -> str | None:
     if isinstance(task_body, str):
         return prompt_digest(task_body)
     return None
+
+
+def installed_entry_available_capabilities(
+    entry: dict[str, Any] | None,
+) -> list[str]:
+    if not entry:
+        return []
+    explicit = normalize_required_capabilities(entry.get("available_capabilities"))
+    if explicit:
+        return explicit
+    task_body = entry.get("task_body")
+    if isinstance(task_body, str):
+        return infer_available_capabilities_from_prompt(task_body)
+    return []
 
 
 def entry_declares_not_installed(entry: dict[str, Any] | None) -> bool:
@@ -619,6 +646,12 @@ def build_upgrade_plan(
         ]
         for mode, agent_id in prompt_targets:
             key = prompt_target_key(mode, agent_id)
+            entry = installed_by_key.get((goal_id, mode, agent_id or ""))
+            legacy_unscoped = False
+            if entry is None and agent_id:
+                entry = installed_by_key.get((goal_id, mode, ""))
+                legacy_unscoped = entry is not None
+            available_capabilities = installed_entry_available_capabilities(entry)
             agent_profile = agent_profile_for_goal(goal, agent_id)
             prompt = build_heartbeat_prompt(
                 goal_id=goal_id,
@@ -632,16 +665,12 @@ def build_upgrade_plan(
                 agent_id=agent_id,
                 agent_profile=agent_profile,
                 registered_agents=registered_agents or None,
+                available_capabilities=available_capabilities,
             )
             summary = prompt_summary(prompt, mode)
             summary["agent_id"] = agent_id
             summary["prompt_target"] = key
             prompt_summaries[key] = summary
-            entry = installed_by_key.get((goal_id, mode, agent_id or ""))
-            legacy_unscoped = False
-            if entry is None and agent_id:
-                entry = installed_by_key.get((goal_id, mode, ""))
-                legacy_unscoped = entry is not None
             expected_digest = str(summary.get("sha256") or "")
             not_installed = entry_declares_not_installed(entry)
             actual_digest = None if not_installed else installed_entry_digest(entry) if entry else None
@@ -695,6 +724,7 @@ def build_upgrade_plan(
                 "legacy_unscoped_match": legacy_unscoped,
                 "prompt_sha256": actual_digest,
                 "expected_sha256": expected_digest,
+                "available_capabilities": available_capabilities,
                 "prompt_policy_audit": policy_audit,
             }
         loop_activation = build_loop_activation_summary(installed=installed)


### PR DESCRIPTION
## Summary
- preserve installed host capability declarations when regenerating peer heartbeat prompts
- keep capability flags in thin automation prompts so future upgrades can recover them
- project a concrete owner action when a capability gate requires user input

## Validation
- focused upgrade, capability-gate, heartbeat-prompt, interaction-contract, and host-loop activation smokes
- `python3 -m compileall -q loopx`
- `loopx canary premerge --from-git-diff --tier standard --format json`: 17/17 passed
- public-boundary scan clean across all six changed files

## Merge policy
Runtime, quota/interaction, and automation-migration behavior changed, so this PR is ready for independent review and is not self-merged.