### PR TITLE
Canonicalize issue-fix lifecycle references

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -625,8 +625,11 @@ The default `loopx lark-kanban sync-loopx-todos` path also derives all issue
 outcomes from the goal's existing feasibility and PR lifecycle domain state and
 upserts them beside todo rows. A feasibility row therefore appears as issue work
 even before a PR exists; a PR enriches that row only when its lifecycle
-observation carries the matching `repo` and explicit `issue_ref`. This automatic
-closeout projection adds no outcome ledger or second state machine.
+observation carries the matching `repo` and explicit `issue_ref`. Numeric issue
+aliases (`#123`, `issue_123`, `issues/123`) canonicalize to `issues_123` on
+write and when reading legacy rows, so equivalent explicit links cannot silently
+fall into the unlinked count. This automatic closeout projection adds no outcome
+ledger or second state machine.
 
 Supplying `--delivery-evidence-json` alone is a read-only preview. Add
 `--write-delivery-evidence` after focused validation to store its validated,

--- a/docs/capabilities/issue-fix/README.zh-CN.md
+++ b/docs/capabilities/issue-fix/README.zh-CN.md
@@ -548,8 +548,10 @@ focused validation 已通过。
 默认的 `loopx lark-kanban sync-loopx-todos` 还会从目标已有的 feasibility 与 PR
 lifecycle domain state 推导全部 issue outcome，并与 todo 行一起 upsert。因而 feasibility
 一经落盘，即使还没有 PR，也会作为 issue work 出现在看板；只有 lifecycle observation
-带有相同 `repo` 和显式 `issue_ref` 时，PR 才会补充到该行。这个自动 closeout projection
-不会新增 outcome ledger，也不会建立第二套状态机。
+带有相同 `repo` 和显式 `issue_ref` 时，PR 才会补充到该行。数字 issue 别名
+（`#123`、`issue_123`、`issues/123`）会在写入和读取旧行时统一为 `issues_123`，
+避免等价的显式关联静默落入 unlinked 计数。这个自动 closeout projection 不会新增
+outcome ledger，也不会建立第二套状态机。
 
 只传 `--delivery-evidence-json` 仍是只读预览。focused validation 完成后，加上
 `--write-delivery-evidence`，LoopX 会把经过校验、public-safe 的紧凑证据写回现有

--- a/docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md
@@ -69,8 +69,10 @@ open PRs, merge, publish, or run destructive git without an explicit gate.
    The command writes compact domain state by default when a `--goal-id` or
    `--ledger-path` is provided, and `--no-write-domain-state` keeps it
    preview-only. Persisted lifecycle state should carry an explicit public-safe
-   `issue_ref`; outcome projection must not infer the issue from a branch name,
-   PR title, or prose.
+   `issue_ref`; numeric aliases such as `#123`, `issue_123`, and `issues/123`
+   canonicalize to `issues_123` before writeback. Outcome projection applies
+   the same rule to legacy rows, but must not infer the issue from a branch
+   name, PR title, or prose.
 11. **Gate handling:** surface concrete gates instead of silently blocking. Safe
    metadata-only triage, public-code search, and focused smoke drafting may
    continue when those gates do not cover the selected action.

--- a/examples/issue-fix-outcome-projection-smoke.py
+++ b/examples/issue-fix-outcome-projection-smoke.py
@@ -188,7 +188,7 @@ def assert_default_goal_sync_composes_outcomes() -> None:
         )
         linked = build_issue_fix_pr_lifecycle_monitor_packet(
             url="https://github.com/public-fixture/widgets/pull/77",
-            issue_ref="issues_42",
+            issue_ref="#42",
             provider_payload={
                 "state": "OPEN",
                 "reviewDecision": "REVIEW_REQUIRED",
@@ -199,7 +199,30 @@ def assert_default_goal_sync_composes_outcomes() -> None:
             },
         )
         assert linked["observation"]["issue_ref"] == "issues_42", linked
+        receipt = "sha256:" + "a" * 64
+        linked["reviewer_notification_receipts"] = [receipt]
         upsert_issue_fix_pr_lifecycle_ledger_jsonl(lifecycle_ledger, linked)
+        equivalent_retry = build_issue_fix_pr_lifecycle_monitor_packet(
+            url="https://github.com/public-fixture/widgets/pull/77",
+            issue_ref="issue_42",
+            provider_payload={
+                "state": "OPEN",
+                "reviewDecision": "REVIEW_REQUIRED",
+                "mergeStateStatus": "CLEAN",
+                "statusCheckRollup": [
+                    {"name": "focused", "conclusion": "SUCCESS"}
+                ],
+            },
+        )
+        retry_write = upsert_issue_fix_pr_lifecycle_ledger_jsonl(
+            lifecycle_ledger, equivalent_retry
+        )
+        assert retry_write["status"] == "unchanged", retry_write
+        stored_lifecycle = [
+            json.loads(line)
+            for line in lifecycle_ledger.read_text(encoding="utf-8").splitlines()
+        ]
+        assert stored_lifecycle[0]["reviewer_notification_receipts"] == [receipt]
         unlinked = build_issue_fix_pr_lifecycle_monitor_packet(
             url="https://github.com/public-fixture/widgets/pull/78",
             provider_payload={
@@ -230,6 +253,9 @@ def assert_default_goal_sync_composes_outcomes() -> None:
         assert collection_by_issue["issues_42"]["pull_request"]["number"] == 77
         assert collection_by_issue["issues_43"]["pull_request"] is None
         assert collection_by_issue["issues_42"]["validation"]["status"] == "declared"
+        assert collection["source_contract"]["association"] == (
+            "explicit_repo_and_issue_ref_only"
+        )
         assert collection["source_contract"]["creates_parallel_state_machine"] is False
 
         delivery_path = project / "delivery-evidence.json"

--- a/examples/issue-fix-pr-lifecycle-smoke.py
+++ b/examples/issue-fix-pr-lifecycle-smoke.py
@@ -186,6 +186,15 @@ def main() -> int:
     assert quiet["observation"]["issue_ref"] == "issues_1700", quiet
     assert quiet["transition"]["material_change"] is False
     assert quiet["writeback_contract"]["monitor_quiet_skip_allowed"] is True
+    for alias in ("#1700", "issue_1700", "issues/1700", "issue 1700"):
+        alias_packet = build_issue_fix_pr_lifecycle_monitor_packet(
+            url="https://github.com/huangruiteng/loopx/pull/1715",
+            issue_ref=alias,
+            provider_payload={"state": "OPEN"},
+        )
+        assert alias_packet["observation"]["issue_ref"] == "issues_1700", (
+            alias_packet
+        )
     repo_ref = build_issue_fix_pr_lifecycle_monitor_packet(
         repo="huangruiteng/loopx",
         pr_ref="pull_1715",

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -486,7 +486,8 @@ def register_issue_fix_commands(
         help=(
             "Optional public-safe issue reference linked to this PR. Persisting "
             "the explicit link lets default Kanban sync compose the issue outcome "
-            "without guessing from titles or branch names."
+            "without guessing from titles or branch names. Numeric aliases such "
+            "as #123 and issue_123 are stored as issues_123."
         ),
     )
     pr_lifecycle_parser.add_argument(

--- a/loopx/capabilities/issue_fix/metadata_preview.py
+++ b/loopx/capabilities/issue_fix/metadata_preview.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 from collections.abc import Mapping, Sequence
 from typing import Any
@@ -23,6 +24,20 @@ GITHUB_BODY_OR_COMMENT_KEYS = {
 }
 
 ALLOWED_ISSUE_FIX_INTAKE_STATES = {"open", "closed", "unknown"}
+GITHUB_ISSUE_LINK_REFERENCE_PATTERN = re.compile(
+    r"^(?:#|issues?\s*(?:#|[_:/-])?\s*)?([1-9][0-9]*)$",
+    re.IGNORECASE,
+)
+
+
+def normalise_github_issue_link_reference(issue_ref: Any) -> str:
+    """Canonicalise explicit numeric GitHub issue aliases without guessing."""
+
+    label = _normalise_exploration_label(issue_ref, "issue_ref")
+    match = GITHUB_ISSUE_LINK_REFERENCE_PATTERN.fullmatch(label.strip())
+    if match:
+        return f"issues_{int(match.group(1))}"
+    return label
 
 
 def normalise_github_issue_reference(
@@ -59,7 +74,7 @@ def normalise_github_issue_reference(
         }
 
     repo_label = _normalise_exploration_label(repo, "repo")
-    issue_label = _normalise_exploration_label(issue_ref, "issue_ref")
+    issue_label = normalise_github_issue_link_reference(issue_ref)
     number = None
     digits = "".join(ch for ch in issue_label if ch.isdigit())
     if digits:

--- a/loopx/capabilities/issue_fix/outcome_projection.py
+++ b/loopx/capabilities/issue_fix/outcome_projection.py
@@ -7,6 +7,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any
 
 from ...control_plane.runtime.public_safety import public_safe_compact_text
+from .metadata_preview import normalise_github_issue_link_reference
 
 
 ISSUE_FIX_OUTCOME_PROJECTION_SCHEMA_VERSION = "issue_fix_outcome_projection_v0"
@@ -590,7 +591,12 @@ def build_issue_fix_outcome_collection_from_domain_state(
     for packet in lifecycle_packets:
         observation = _mapping(packet.get("observation"))
         repo = str(observation.get("repo") or "").strip()
-        issue_ref = str(observation.get("issue_ref") or "").strip()
+        raw_issue_ref = str(observation.get("issue_ref") or "").strip()
+        issue_ref = (
+            normalise_github_issue_link_reference(raw_issue_ref)
+            if raw_issue_ref
+            else ""
+        )
         if repo and issue_ref:
             lifecycle_by_issue.setdefault((repo, issue_ref), []).append(packet)
 
@@ -598,7 +604,12 @@ def build_issue_fix_outcome_collection_from_domain_state(
     for feasibility_packet in feasibility_packets:
         observation = _mapping(feasibility_packet.get("observation"))
         repo = str(observation.get("repo") or "").strip()
-        issue_ref = str(observation.get("issue_ref") or "").strip()
+        raw_issue_ref = str(observation.get("issue_ref") or "").strip()
+        issue_ref = (
+            normalise_github_issue_link_reference(raw_issue_ref)
+            if raw_issue_ref
+            else ""
+        )
         lifecycle_packet: dict[str, Any] | None = None
         candidates = lifecycle_by_issue.get((repo, issue_ref), [])
         if candidates:

--- a/loopx/capabilities/issue_fix/pr_lifecycle.py
+++ b/loopx/capabilities/issue_fix/pr_lifecycle.py
@@ -7,8 +7,10 @@ from collections.abc import Mapping, Sequence
 from typing import Any
 from urllib.parse import quote
 
-from ...control_plane.runtime.public_safety import public_safe_compact_text
-from .metadata_preview import normalise_github_issue_reference
+from .metadata_preview import (
+    normalise_github_issue_link_reference,
+    normalise_github_issue_reference,
+)
 
 
 ISSUE_FIX_PR_LIFECYCLE_MONITOR_SCHEMA_VERSION = (
@@ -176,9 +178,9 @@ def _build_observation(
             state = "MERGED"
     review_decision = _upper_label(provider_payload.get("reviewDecision"))
     merge_state = _upper_label(provider_payload.get("mergeStateStatus"))
-    linked_issue_ref = public_safe_compact_text(issue_ref, limit=180)
-    if issue_ref and not linked_issue_ref:
-        raise ValueError("issue_ref must be a compact public-safe value")
+    linked_issue_ref = (
+        normalise_github_issue_link_reference(issue_ref) if issue_ref else ""
+    )
     return {
         "schema_version": "issue_fix_pr_lifecycle_observation_v0",
         "repo": repo,


### PR DESCRIPTION
## Motivation

PR lifecycle accepted explicit issue aliases such as `#42` and `issue_42`, while feasibility rows created from GitHub URLs used `issues_42`. Default outcome composition compared the raw labels, so an explicitly linked PR could silently appear as unlinked.

## Implementation

- Canonicalize explicit numeric GitHub issue aliases to `issues_<number>` at intake and PR lifecycle writeback.
- Apply the same normalization while composing outcomes so existing legacy rows become linkable without migration.
- Preserve the existing explicit-link-only contract: branch names, PR titles, and prose are never used to infer an issue.
- Document the accepted aliases in the bilingual issue-fix guide and workflow protocol.

## Validation

- `python3 examples/issue-fix-pr-lifecycle-smoke.py`
- `python3 examples/issue-fix-outcome-projection-smoke.py`
- `python3 examples/issue-fix-capability-guide-smoke.py`
- `uvx ruff check ...` on all changed Python files
- `loopx canary premerge --from-git-diff --format json`: 17/17 selected checks passed; zero failures, warnings, or manual holds; public-boundary scan clean.
- Real goal-state dry-run: five feasibility rows and five lifecycle rows still produce five outcomes, while legacy alias normalization reduces unlinked lifecycle rows from three to one.

## Risk

Low and bounded to explicit numeric issue references. Non-numeric public-safe custom labels retain their existing value, and no source state migration is performed.
