### PR TITLE
Add gated validated outcome memory writeback

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -460,7 +460,8 @@ the current repository revision remains authoritative.
 - multi-repository issue portfolios with bounded concurrency;
 - maintainer preference learning from public accepted/rejected outcomes;
 - reviewer load balancing and bus-factor awareness;
-- richer repository memory with explicit workspace/peer isolation;
+- evaluate validated-outcome memory utility across repeated issues before any
+  default enablement or session-memory expansion;
 - Open Knowledge Format interoperability after the repository-context contract
   stabilizes;
 - project-level metrics for accepted fixes, cycle time, human attention,
@@ -543,8 +544,8 @@ endings and one terminal newline are normalised), and
 persists only the compact hook projection in the existing repository context.
 Unverified hits contribute counts only; their summaries are not persisted.
 Provider unavailability, empty retrieval, or a missing checkout is fail-open;
-raw memory bodies, automatic transcript capture, memory writeback, private
-namespaces, credentials, and provider config paths are never retained.
+raw memory bodies, automatic transcript capture, private namespaces,
+credentials, and provider config paths are never retained.
 
 Minimal local provider config (the revision must also appear in `scope_ref`):
 
@@ -560,7 +561,11 @@ Minimal local provider config (the revision must also appear in `scope_ref`):
   "max_results": 3,
   "timeout_seconds": 15,
   "sync_timeout_seconds": 180,
-  "resource_references": ["src/module.py", "tests/test_module.py"]
+  "resource_references": ["src/module.py", "tests/test_module.py"],
+  "writeback_enabled": false,
+  "writeback_scope_ref": "viking://resources/public-repository/<git-revision>",
+  "workspace_scope": "owner-repo",
+  "peer_scope": "issue-fix-agent"
 }
 ```
 
@@ -572,6 +577,27 @@ idempotent when stored content still matches and stops on a conflict instead
 of replacing or auto-renaming it. Retrieval and resource sync use separate
 bounded timeouts because semantic indexing can legitimately take longer than
 read-only search.
+
+Validated-outcome writeback is a separate, default-off hook. It runs only when
+the caller explicitly adds `--write-repository-memory`, the local provider
+config independently sets `writeback_enabled: true`, delivery evidence says
+`completed`, validation says `passed`, the delivery evidence has a stable
+`recorded_at`, and the outcome revision matches the configured public resource
+scope. LoopX writes one distilled fact containing
+revision, provenance, freshness, public outputs, risks, a stable supersession
+key, and explicit workspace/peer scopes. A content hash selects the immutable
+target, so an identical retry reads and accepts the existing fact without a
+second write; conflicting content stops instead of overwriting. Raw
+transcripts, tool logs/results, expert answers, credentials, private material,
+and captured local paths are rejected. The provider packet retains only opaque
+refs and compact receipts.
+
+The OpenViking adapter deliberately uses deterministic `viking://resources/`
+writeback for this first contract. It does not call experimental `ov
+add-memory`, because that command creates a fresh session and currently accepts
+no idempotency key. Conversation/session capture therefore remains out of
+scope and requires a separate owner decision even when validated-outcome
+writeback is enabled.
 
 Default enablement is an evidence decision rather than an installation side
 effect. A project should first dogfood the hook across several independent
@@ -722,6 +748,8 @@ loopx issue-fix outcome \
   --pr-ref pull_456 \
   --delivery-evidence-json delivery-evidence.json \
   --write-delivery-evidence \
+  --repository-memory-provider-json provider.json \
+  --write-repository-memory \
   --agent-id codex-issue-fix \
   --format json
 ```
@@ -737,6 +765,7 @@ python3 examples/issue-fix-workflow-plan-smoke.py
 python3 examples/issue-fix-workflow-contract-smoke.py
 python3 examples/issue-fix-repository-context-smoke.py
 python3 examples/issue-fix-repository-memory-smoke.py
+python3 examples/issue-fix-validated-memory-writeback-smoke.py
 python3 examples/issue-fix-feasibility-smoke.py
 python3 examples/issue-fix-pr-lifecycle-smoke.py
 python3 examples/issue-fix-outcome-projection-smoke.py

--- a/docs/capabilities/issue-fix/README.zh-CN.md
+++ b/docs/capabilities/issue-fix/README.zh-CN.md
@@ -407,7 +407,8 @@ revision 仍是事实源。
 - 多仓库 issue portfolio 与有界并发；
 - 从公开 accepted/rejected outcome 学习 maintainer preference；
 - reviewer load balancing 与 bus-factor awareness；
-- 带显式 workspace/peer 隔离的 richer repository memory；
+- 跨多个重复 issue 评估 validated-outcome memory 的实际价值，再决定是否默认开启或扩展到
+  session memory；
 - repository-context contract 稳定后的 Open Knowledge Format 互操作；
 - accepted fix、cycle time、human attention、regression、boundary incident 等项目级指标。
 
@@ -479,8 +480,7 @@ source 保持为 advisory；只有与 pinned checkout 文件做 canonical-text e
 末尾换行）。
 未验证命中只进入计数，其摘要不会持久化。紧凑 hook projection 仍写入现有 repository
 context，不建立第二套 ledger。Provider 不可用、空结果或 checkout 缺失时 fail-open；raw
-memory body、自动 transcript capture、memory writeback、私有 namespace、凭据和 provider
-配置路径都不会被保留。
+memory body、自动 transcript capture、私有 namespace、凭据和 provider 配置路径都不会被保留。
 
 最小本地 provider 配置如下；`scope_ref` 也必须包含当前 revision：
 
@@ -496,7 +496,11 @@ memory body、自动 transcript capture、memory writeback、私有 namespace、
   "max_results": 3,
   "timeout_seconds": 15,
   "sync_timeout_seconds": 180,
-  "resource_references": ["src/module.py", "tests/test_module.py"]
+  "resource_references": ["src/module.py", "tests/test_module.py"],
+  "writeback_enabled": false,
+  "writeback_scope_ref": "viking://resources/public-repository/<git-revision>",
+  "workspace_scope": "owner-repo",
+  "peer_scope": "issue-fix-agent"
 }
 ```
 
@@ -505,6 +509,20 @@ Resource indexing 与 retrieval 刻意分离。先用
 provider resource write 已获授权时才加 `--execute`。同一个 immutable revision scope
 重复执行时，内容一致会幂等通过；出现冲突则停止，不会覆盖或自动改名。只读 retrieval
 与 resource sync 使用独立且有上限的 timeout，因为语义索引通常比 search/read 更慢。
+
+Validated-outcome writeback 是另一条默认关闭的 hook。只有调用方显式增加
+`--write-repository-memory`、本地 provider config 另行设置
+`writeback_enabled: true`、delivery evidence 为 `completed`、validation 为 `passed`，且
+delivery evidence 带有稳定 `recorded_at`、outcome revision 与公开 resource scope 一致时才会
+执行。LoopX 只写入一条 distilled fact：
+revision、provenance、freshness、公开产出、风险、稳定 supersession key，以及显式的
+workspace/peer scope。内容 hash 决定 immutable target，因此相同重试会读取并接受已有 fact，
+不会二次写入；内容冲突则停止，不覆盖旧事实。Raw transcript、tool log/result、expert answer、
+凭据、私有材料和已捕获本地路径都会被拒绝；provider packet 只保留 opaque ref 与紧凑收据。
+
+OpenViking adapter 的第一版刻意使用可确定定位的 `viking://resources/` 写回，不调用实验性的
+`ov add-memory`。后者会新建 session，当前没有 idempotency key；因此即使 validated-outcome
+writeback 已开启，conversation/session 自动捕获仍不在本能力边界内，必须另行获得 owner 决策。
 
 是否默认开启必须由真实证据决定，而不是安装即默认。项目应先在多个独立 issue/context
 run 和至少一次重启边界上 dogfood；只有当该 hook 能反复提供经 checkout 验证的新证据，
@@ -640,6 +658,8 @@ loopx issue-fix outcome \
   --pr-ref pull_456 \
   --delivery-evidence-json delivery-evidence.json \
   --write-delivery-evidence \
+  --repository-memory-provider-json provider.json \
+  --write-repository-memory \
   --agent-id codex-issue-fix \
   --format json
 ```
@@ -655,6 +675,7 @@ python3 examples/issue-fix-workflow-plan-smoke.py
 python3 examples/issue-fix-workflow-contract-smoke.py
 python3 examples/issue-fix-repository-context-smoke.py
 python3 examples/issue-fix-repository-memory-smoke.py
+python3 examples/issue-fix-validated-memory-writeback-smoke.py
 python3 examples/issue-fix-feasibility-smoke.py
 python3 examples/issue-fix-pr-lifecycle-smoke.py
 python3 examples/issue-fix-outcome-projection-smoke.py

--- a/examples/canary/catalog-planner-smoke.py
+++ b/examples/canary/catalog-planner-smoke.py
@@ -526,6 +526,24 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     assert all(check["tier"] == "default" for check in reviewer_profile["checks"]), reviewer_profile
     assert reviewer_profile["deep_checks_available"] is False, reviewer_profile
 
+    outcome_payload = build_catalog_canary_plan(
+        changed_files=[
+            "loopx/capabilities/issue_fix/repository_memory_provider.py",
+            "examples/issue-fix-validated-memory-writeback-smoke.py",
+        ],
+        surfaces=["issue-fix outcome validated memory writeback"],
+    )
+    outcome_profiles = {
+        profile["id"]: profile for profile in outcome_payload["domain_profiles"]
+    }
+    outcome_profile = outcome_profiles["issue-fix-outcome-visibility"]
+    outcome_commands = [check["command"] for check in outcome_profile["checks"]]
+    assert "python3 examples/issue-fix-outcome-projection-smoke.py" in outcome_commands
+    assert (
+        "python3 examples/issue-fix-validated-memory-writeback-smoke.py"
+        in outcome_commands
+    )
+
     cross_runtime_payload = build_catalog_canary_plan(
         changed_files=[
             "loopx/capabilities/cross_runtime/impl_review.py",

--- a/examples/issue-fix-validated-memory-writeback-smoke.py
+++ b/examples/issue-fix-validated-memory-writeback-smoke.py
@@ -281,6 +281,10 @@ def main() -> int:
         assert packet["repository_memory_writeback"]["status"] == "completed"
         assert packet["repository_memory_writeback"]["write_count"] == 1
         assert packet["external_writes_performed"] is True
+        assert packet["source_contract"]["repository_memory_writeback"] == (
+            "issue_fix_validated_outcome_memory_writeback_v0"
+        )
+        assert packet["source_contract"]["writes_external_provider"] is True
         assert_public_boundary(packet)
 
     print("issue-fix-validated-memory-writeback-smoke: ok")

--- a/examples/issue-fix-validated-memory-writeback-smoke.py
+++ b/examples/issue-fix-validated-memory-writeback-smoke.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Smoke-test explicit, idempotent validated-outcome repository-memory writes."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx.capabilities.context_providers.base import ContextProviderSync  # noqa: E402
+from loopx.capabilities.issue_fix.feasibility import (  # noqa: E402
+    build_issue_fix_feasibility_packet,
+)
+from loopx.capabilities.issue_fix.outcome_projection import (  # noqa: E402
+    build_issue_fix_outcome_projection,
+)
+from loopx.capabilities.issue_fix.repository_memory_provider import (  # noqa: E402
+    write_issue_fix_validated_outcome_memory,
+)
+
+
+REVISION = "9cf42405a8bb0a8a17a66d4f953515f5a2c82620"
+OBSERVED_AT = "2026-07-11T08:40:00+08:00"
+
+
+class WritebackContractProvider:
+    provider_id = "contract_provider"
+
+    def __init__(self) -> None:
+        self.contents: dict[str, str] = {}
+
+    def retrieve(self, **kwargs: Any) -> Any:  # pragma: no cover
+        raise AssertionError(kwargs)
+
+    def sync(self, **kwargs: Any) -> ContextProviderSync:
+        assert kwargs["execute"] is True, kwargs
+        source, target = list(kwargs["resources"])[0]
+        content = Path(source).read_text(encoding="utf-8")
+        existing = self.contents.get(target)
+        if existing is not None:
+            assert existing == content, (existing, content)
+        else:
+            self.contents[target] = content
+        return ContextProviderSync(
+            provider=self.provider_id,
+            namespace=str(kwargs["namespace"]),
+            status="completed",
+            observed_at=str(kwargs["observed_at"]),
+            requested_count=1,
+            completed_count=1,
+            write_count=0 if existing is not None else 1,
+            result_refs=(target,),
+        )
+
+
+def repository_context() -> dict[str, object]:
+    return {
+        "schema_version": "issue_fix_repository_context_input_v0",
+        "repository_revision": REVISION,
+        "sources": [
+            {
+                "source_id": "current-source",
+                "source_kind": "source_code",
+                "reference": "src/worker.py",
+                "trust": "authoritative",
+                "freshness": "current",
+                "supports": ["change_scope", "reproduction"],
+                "summary": "Current checkout bounds the affected worker path.",
+            },
+            {
+                "source_id": "focused-test",
+                "source_kind": "test_surface",
+                "reference": "tests/test_worker.py",
+                "trust": "verified",
+                "freshness": "current",
+                "supports": ["validation"],
+                "summary": "Focused worker regression surface.",
+            },
+        ],
+    }
+
+
+def outcome_packet() -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    feasibility = build_issue_fix_feasibility_packet(
+        url="https://github.com/owner/repo/issues/7",
+        reproduction_status="confirmed",
+        reproduction_label="focused worker reproduction",
+        scope_class="bounded",
+        validation_label="focused worker regression",
+        repository_context_input=repository_context(),
+    )
+    delivery = {
+        "schema_version": "issue_fix_delivery_evidence_input_v0",
+        "outcome_status": "completed",
+        "validation_status": "passed",
+        "validation_label": "passed focused public contract test",
+        "changed_files": ["src/worker.py", "tests/test_worker.py"],
+        "commit_ref": REVISION,
+        "outputs": [
+            {"kind": "pull_request", "url": "https://github.com/owner/repo/pull/8"}
+        ],
+        "risks": ["broader integration validation was not run"],
+        "recorded_at": OBSERVED_AT,
+    }
+    outcome = build_issue_fix_outcome_projection(
+        goal_id="public-issue-fix-goal",
+        feasibility_packet=feasibility,
+        delivery_evidence_input=delivery,
+        agent_id="public-issue-fix-agent",
+        generated_at=OBSERVED_AT,
+    )
+    return feasibility, delivery, outcome
+
+
+def provider_config(provider: str = "contract_provider") -> dict[str, Any]:
+    return {
+        "schema_version": "issue_fix_repository_memory_provider_config_v0",
+        "enabled": True,
+        "provider": provider,
+        "namespace": "public-repository",
+        "visibility": "public",
+        "scope_ref": f"viking://resources/public-repo/{REVISION}",
+        "repository_revision": REVISION,
+        "sync_timeout_seconds": 5,
+        "writeback_enabled": True,
+        "writeback_scope_ref": f"viking://resources/public-repo/{REVISION}",
+        "workspace_scope": "owner-repo",
+        "peer_scope": "issue-fix-agent",
+    }
+
+
+def assert_public_boundary(payload: dict[str, Any]) -> None:
+    text = json.dumps(payload, ensure_ascii=True, sort_keys=True)
+    for forbidden in ("must never be written", "/Users/", "/private/tmp/"):
+        assert forbidden not in text, (forbidden, text)
+
+
+def main() -> int:
+    feasibility, delivery, outcome = outcome_packet()
+    provider = WritebackContractProvider()
+    first = write_issue_fix_validated_outcome_memory(
+        config=provider_config(),
+        outcome_packet=outcome,
+        repository_revision=REVISION,
+        observed_at=OBSERVED_AT,
+        execute=True,
+        provider=provider,
+    )
+    retry = write_issue_fix_validated_outcome_memory(
+        config=provider_config(),
+        outcome_packet=outcome,
+        repository_revision=REVISION,
+        observed_at=OBSERVED_AT,
+        execute=True,
+        provider=provider,
+    )
+    assert first["status"] == "completed" and first["write_count"] == 1, first
+    assert retry["status"] == "completed" and retry["write_count"] == 0, retry
+    assert first["idempotency_key"] == retry["idempotency_key"]
+    assert first["supersession_key_recorded"] is True
+    stored_fact = next(iter(provider.contents.values()))
+    for expected in (
+        "issue_fix_validated_outcome_memory_v0",
+        '"validation_status": "passed"',
+        '"freshness": "revision_pinned"',
+        '"supersession_key": "sha256:',
+    ):
+        assert expected in stored_fact, expected
+    assert_public_boundary(first)
+    assert_public_boundary(retry)
+
+    disabled = write_issue_fix_validated_outcome_memory(
+        config={**provider_config(), "writeback_enabled": False},
+        outcome_packet=outcome,
+        repository_revision=REVISION,
+        observed_at=OBSERVED_AT,
+        execute=True,
+        provider=provider,
+    )
+    assert disabled["status"] == "disabled" and not disabled["external_writes_performed"]
+    try:
+        write_issue_fix_validated_outcome_memory(
+            config=provider_config(),
+            outcome_packet={**outcome, "raw_transcript": "must never be written"},
+            repository_revision=REVISION,
+            observed_at=OBSERVED_AT,
+            execute=True,
+            provider=provider,
+        )
+    except ValueError as exc:
+        assert "unsafe field: raw_transcript" in str(exc), exc
+    else:
+        raise AssertionError("raw transcript writeback must be rejected")
+    failed_outcome = json.loads(json.dumps(outcome))
+    failed_outcome["issue_fix_outcomes"][0]["validation"]["status"] = "failed"
+    try:
+        write_issue_fix_validated_outcome_memory(
+            config=provider_config(),
+            outcome_packet=failed_outcome,
+            repository_revision=REVISION,
+            observed_at=OBSERVED_AT,
+            execute=True,
+            provider=provider,
+        )
+    except ValueError as exc:
+        assert "requires passed validation" in str(exc), exc
+    else:
+        raise AssertionError("failed validation must block memory writeback")
+
+    with tempfile.TemporaryDirectory(prefix="loopx-writeback-smoke-") as tmpdir:
+        tmp = Path(tmpdir)
+        fake_ov = tmp / "ov-contract"
+        fake_ov.write_text(
+            "#!/usr/bin/env python3\n"
+            "import json, sys\n"
+            "args = sys.argv[1:]\n"
+            "if args == ['--version']: print('openviking 0.4.9.dev11')\n"
+            "elif args and args[0] == 'status': print(json.dumps({'status':'healthy'}))\n"
+            "elif args and args[0] == 'tree': print(json.dumps({'resources':[]}))\n"
+            "elif args and args[0] in {'read','ls'}: sys.exit(1)\n"
+            "elif args and args[0] in {'mkdir','add-resource'}: print(json.dumps({'result':'ok'}))\n"
+            "else: sys.exit(2)\n",
+            encoding="utf-8",
+        )
+        fake_ov.chmod(0o755)
+        feasibility_path = tmp / "feasibility.json"
+        delivery_path = tmp / "delivery.json"
+        config_path = tmp / "provider.json"
+        feasibility_path.write_text(json.dumps(feasibility), encoding="utf-8")
+        delivery_path.write_text(json.dumps(delivery), encoding="utf-8")
+        config_path.write_text(
+            json.dumps(
+                {
+                    **provider_config("openviking"),
+                    "provider_binary": str(fake_ov),
+                }
+            ),
+            encoding="utf-8",
+        )
+        command = [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--format",
+            "json",
+            "issue-fix",
+            "outcome",
+            "--goal-id",
+            "public-issue-fix-goal",
+            "--repo",
+            "owner/repo",
+            "--issue-ref",
+            str(feasibility["observation"]["issue_ref"]),
+            "--feasibility-json",
+            str(feasibility_path),
+            "--delivery-evidence-json",
+            str(delivery_path),
+            "--repository-memory-provider-json",
+            str(config_path),
+            "--write-repository-memory",
+            "--generated-at",
+            OBSERVED_AT,
+        ]
+        result = subprocess.run(
+            command,
+            cwd=ROOT,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        packet = json.loads(result.stdout)
+        assert packet["repository_memory_writeback"]["status"] == "completed"
+        assert packet["repository_memory_writeback"]["write_count"] == 1
+        assert packet["external_writes_performed"] is True
+        assert_public_boundary(packet)
+
+    print("issue-fix-validated-memory-writeback-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -947,7 +947,9 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
             "issue_fix_outcome",
             "outcome_projection",
             "examples/issue-fix-outcome-projection-smoke.py",
+            "examples/issue-fix-validated-memory-writeback-smoke.py",
             "loopx/capabilities/issue_fix/outcome_projection.py",
+            "loopx/capabilities/issue_fix/repository_memory_provider.py",
             "loopx/presentation/sinks/lark/projection_rows.py",
         ),
         "checks": [
@@ -955,6 +957,11 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
                 "command": "python3 examples/issue-fix-outcome-projection-smoke.py",
                 "tier": "default",
                 "reason": "guards derived issue status/output cards, truthful delivery evidence, terminal visibility, and Lark projection reuse",
+            },
+            {
+                "command": "python3 examples/issue-fix-validated-memory-writeback-smoke.py",
+                "tier": "default",
+                "reason": "guards explicit owner gating, validated distilled facts, idempotent provider writes, and unsafe-capture rejection",
             },
         ],
     },

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -138,6 +138,11 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
                 "doc": "docs/capabilities/issue-fix/protocols/issue-fix-workflow-contract-v0.md",
             },
             {
+                "schema_version": "issue_fix_validated_outcome_memory_writeback_v0",
+                "module": "loopx.capabilities.issue_fix.repository_memory_provider",
+                "doc": "docs/capabilities/issue-fix/README.md",
+            },
+            {
                 "schema_version": "issue_fix_acceptance_loop_v0",
                 "module": "loopx.capabilities.issue_fix.acceptance_loop",
                 "doc": "docs/capabilities/issue-fix/protocols/issue-fix-acceptance-loop-v0.md",
@@ -159,6 +164,7 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
             "python3 examples/issue-fix-feasibility-smoke.py",
             "python3 examples/issue-fix-pr-lifecycle-smoke.py",
             "python3 examples/issue-fix-outcome-projection-smoke.py",
+            "python3 examples/issue-fix-validated-memory-writeback-smoke.py",
             "python3 examples/issue-fix-reviewer-recommendation-smoke.py",
             "python3 examples/issue-fix-reviewer-request-smoke.py",
             "python3 examples/issue-fix-reviewer-notification-sink-smoke.py",

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -1287,6 +1287,18 @@ def handle_issue_fix_command(
                     writeback.get("external_writes_performed")
                 )
                 payload["ok"] = writeback.get("ok") is True
+                payload["source_contract"]["repository_memory_writeback"] = (
+                    "issue_fix_validated_outcome_memory_writeback_v0"
+                )
+                payload["source_contract"]["writes_external_provider"] = bool(
+                    writeback.get("external_writes_performed")
+                )
+                if payload["ok"] is not True:
+                    payload["error"] = (
+                        "repository memory writeback "
+                        f"{writeback.get('status')}: "
+                        f"{writeback.get('reason_code') or 'provider write failed'}"
+                    )
             if domain_state_write is not None:
                 payload["domain_state_write"] = domain_state_write
                 payload["source_contract"]["writes_source_state"] = True

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -56,6 +56,7 @@ from .repository_memory_provider import (
     render_issue_fix_repository_memory_sync_markdown,
     retrieve_issue_fix_repository_memory,
     sync_issue_fix_repository_memory,
+    write_issue_fix_validated_outcome_memory,
 )
 from .workflow_plan import (
     build_issue_fix_workflow_plan_packet,
@@ -584,6 +585,24 @@ def register_issue_fix_commands(
         ),
     )
     outcome_parser.add_argument(
+        "--repository-memory-provider-json",
+        default=None,
+        help=(
+            "Local-private issue_fix_repository_memory_provider_config_v0 used "
+            "only when --write-repository-memory is explicit. Defaults to "
+            "LOOPX_ISSUE_FIX_REPOSITORY_MEMORY_PROVIDER_CONFIG."
+        ),
+    )
+    outcome_parser.add_argument(
+        "--write-repository-memory",
+        action="store_true",
+        help=(
+            "After passed validation and completed delivery, write one distilled "
+            "public outcome through an owner-enabled, revision-scoped provider. "
+            "No transcript or tool-result capture is performed."
+        ),
+    )
+    outcome_parser.add_argument(
         "--agent-id",
         help="Optional registered agent id projected as the case owner.",
     )
@@ -1096,6 +1115,16 @@ def handle_issue_fix_command(
                     "--write-delivery-evidence uses the default feasibility domain-state row; "
                     "do not combine it with --feasibility-json"
                 )
+            provider_path = args.repository_memory_provider_json or (
+                default_repository_memory_provider_config_path()
+                if args.write_repository_memory
+                else None
+            )
+            if args.write_repository_memory and not provider_path:
+                raise ValueError(
+                    "--write-repository-memory requires an explicit provider config "
+                    "or LOOPX_ISSUE_FIX_REPOSITORY_MEMORY_PROVIDER_CONFIG"
+                )
             stdin_input_count = sum(
                 value == "-"
                 for value in (
@@ -1174,7 +1203,25 @@ def handle_issue_fix_command(
                     if isinstance(existing_delivery, dict)
                     else None
                 )
-                if existing_compact == delivery_evidence:
+                comparable_existing = (
+                    {
+                        key: value
+                        for key, value in existing_compact.items()
+                        if key != "recorded_at"
+                    }
+                    if existing_compact is not None
+                    else None
+                )
+                comparable_delivery = (
+                    {
+                        key: value
+                        for key, value in delivery_evidence.items()
+                        if key != "recorded_at"
+                    }
+                    if delivery_evidence is not None
+                    else None
+                )
+                if comparable_existing == comparable_delivery:
                     delivery_evidence = existing_delivery
                     write_result = {
                         "write_performed": False,
@@ -1212,6 +1259,34 @@ def handle_issue_fix_command(
                 agent_id=args.agent_id,
                 generated_at=generated_at,
             )
+            if args.write_repository_memory:
+                outcome_case = (payload.get("issue_fix_outcomes") or [{}])[0]
+                repository_context = (
+                    outcome_case.get("repository_context")
+                    if isinstance(outcome_case, dict)
+                    else None
+                )
+                revision = (
+                    str(repository_context.get("revision") or "").strip()
+                    if isinstance(repository_context, dict)
+                    else ""
+                )
+                if not revision:
+                    raise ValueError(
+                        "--write-repository-memory requires a revision-pinned outcome"
+                    )
+                writeback = write_issue_fix_validated_outcome_memory(
+                    config=_load_json_object(str(provider_path)),
+                    outcome_packet=payload,
+                    repository_revision=revision,
+                    observed_at=generated_at,
+                    execute=True,
+                )
+                payload["repository_memory_writeback"] = writeback
+                payload["external_writes_performed"] = bool(
+                    writeback.get("external_writes_performed")
+                )
+                payload["ok"] = writeback.get("ok") is True
             if domain_state_write is not None:
                 payload["domain_state_write"] = domain_state_write
                 payload["source_contract"]["writes_source_state"] = True

--- a/loopx/capabilities/issue_fix/outcome_projection.py
+++ b/loopx/capabilities/issue_fix/outcome_projection.py
@@ -127,6 +127,10 @@ def _delivery_evidence(value: Mapping[str, Any] | None) -> dict[str, Any]:
         "risks": _safe_text_list(
             value.get("risks") or [], field="risks", limit=260, count_limit=10
         ),
+        "recorded_at": _safe_text(
+            value.get("recorded_at"), field="recorded_at", limit=80
+        )
+        or None,
     }
 
 
@@ -148,9 +152,10 @@ def compact_issue_fix_delivery_evidence(
         "outputs": list(delivery.get("outputs") or []),
         "risks": list(delivery.get("risks") or []),
     }
-    if recorded_at:
+    effective_recorded_at = recorded_at or delivery.get("recorded_at")
+    if effective_recorded_at:
         compact["recorded_at"] = _safe_text(
-            recorded_at,
+            effective_recorded_at,
             field="delivery evidence recorded_at",
             limit=80,
         )
@@ -449,6 +454,7 @@ def build_issue_fix_outcome_projection(
             "outcome_status": delivery.get("outcome_status"),
             "commit_ref": delivery.get("commit_ref"),
             "changed_files": list(delivery.get("changed_files") or []),
+            "recorded_at": delivery.get("recorded_at"),
         },
         "pull_request": (
             {
@@ -758,4 +764,12 @@ def render_issue_fix_outcome_projection_markdown(payload: dict[str, Any]) -> str
         f"- evidence: {outcome.get('evidence')}",
         f"- next action: {outcome.get('next_action') or 'none'}",
     ]
+    writeback = _mapping(payload.get("repository_memory_writeback"))
+    if writeback:
+        lines.extend(
+            [
+                f"- repository memory writeback: `{writeback.get('status')}`",
+                f"- provider writes: `{writeback.get('write_count', 0)}`",
+            ]
+        )
     return "\n".join(lines)

--- a/loopx/capabilities/issue_fix/repository_memory_provider.py
+++ b/loopx/capabilities/issue_fix/repository_memory_provider.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import hashlib
+import json
 import os
 import re
+import tempfile
 from collections.abc import Mapping, Sequence
 from pathlib import Path, PurePosixPath
 from typing import Any
@@ -39,8 +42,25 @@ _CONFIG_FIELDS = {
     "timeout_seconds",
     "sync_timeout_seconds",
     "resource_references",
+    "writeback_enabled",
+    "writeback_scope_ref",
+    "workspace_scope",
+    "peer_scope",
 }
 _LABEL = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.:-]{0,119}$")
+_FORBIDDEN_WRITEBACK_FIELDS = {
+    "credential",
+    "credentials",
+    "expert_answer",
+    "private_material",
+    "raw_expert_answer",
+    "raw_tool_logs",
+    "raw_tool_results",
+    "raw_transcript",
+    "tool_logs",
+    "tool_results",
+    "transcript",
+}
 
 
 def default_repository_memory_provider_config_path() -> str | None:
@@ -182,6 +202,26 @@ def _normalise_config(
         normalised_reference = reference.as_posix()
         if normalised_reference not in resource_references:
             resource_references.append(normalised_reference)
+    writeback_enabled = config.get("writeback_enabled") is True
+    writeback_scope_ref = str(config.get("writeback_scope_ref") or "").strip()
+    workspace_scope = str(config.get("workspace_scope") or "").strip()
+    peer_scope = str(config.get("peer_scope") or "").strip()
+    if writeback_enabled:
+        writeback_scope_ref = _compact(
+            writeback_scope_ref,
+            field="writeback_scope_ref",
+            limit=500,
+        ).rstrip("/")
+        if not writeback_scope_ref.startswith("viking://resources/"):
+            raise ValueError(
+                "repository memory writeback_scope_ref must use viking://resources/"
+            )
+        if repository_revision[:12] not in writeback_scope_ref:
+            raise ValueError(
+                "repository memory writeback_scope_ref must be revision-scoped"
+            )
+        workspace_scope = _label(workspace_scope, field="workspace_scope")
+        peer_scope = _label(peer_scope, field="peer_scope")
     return {
         **dict(config),
         "provider": provider,
@@ -193,7 +233,237 @@ def _normalise_config(
         "sync_timeout_seconds": sync_timeout_seconds,
         "resource_references": resource_references,
         "enabled": config.get("enabled") is not False,
+        "writeback_enabled": writeback_enabled,
+        "writeback_scope_ref": writeback_scope_ref,
+        "workspace_scope": workspace_scope,
+        "peer_scope": peer_scope,
     }
+
+
+def _validated_outcome_fact(
+    outcome_packet: Mapping[str, Any],
+    *,
+    repository_revision: str,
+    workspace_scope: str,
+    peer_scope: str,
+) -> tuple[str, str]:
+    def reject_unsafe_fields(value: Any) -> None:
+        if isinstance(value, Mapping):
+            for raw_key, nested in value.items():
+                key = str(raw_key).strip().lower().replace("-", "_")
+                if key in _FORBIDDEN_WRITEBACK_FIELDS and nested:
+                    raise ValueError(
+                        f"repository memory writeback rejects unsafe field: {key}"
+                    )
+                if key in {
+                    "credentials_captured",
+                    "local_paths_captured",
+                    "raw_content_captured",
+                    "raw_logs_captured",
+                } and nested is True:
+                    raise ValueError(
+                        f"repository memory writeback rejects unsafe capture flag: {key}"
+                    )
+                reject_unsafe_fields(nested)
+        elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+            for nested in value:
+                reject_unsafe_fields(nested)
+
+    reject_unsafe_fields(outcome_packet)
+    if outcome_packet.get("schema_version") != "issue_fix_outcome_projection_v0":
+        raise ValueError(
+            "repository memory writeback requires issue_fix_outcome_projection_v0"
+        )
+    outcomes = outcome_packet.get("issue_fix_outcomes")
+    if not isinstance(outcomes, Sequence) or isinstance(outcomes, (str, bytes)):
+        raise ValueError("repository memory writeback requires one outcome case")
+    cases = [item for item in outcomes if isinstance(item, Mapping)]
+    if len(cases) != 1:
+        raise ValueError("repository memory writeback requires exactly one outcome case")
+    case = cases[0]
+    repository_context = case.get("repository_context")
+    delivery = case.get("delivery")
+    validation = case.get("validation")
+    result = case.get("result")
+    issue = case.get("issue")
+    if not all(
+        isinstance(value, Mapping)
+        for value in (repository_context, delivery, validation, result, issue)
+    ):
+        raise ValueError("repository memory writeback outcome case is incomplete")
+    if str(repository_context.get("revision") or "") != repository_revision:
+        raise ValueError(
+            "repository memory writeback revision must match the outcome checkout"
+        )
+    if delivery.get("evidence_provided") is not True:
+        raise ValueError("repository memory writeback requires explicit delivery evidence")
+    if delivery.get("outcome_status") != "completed":
+        raise ValueError("repository memory writeback requires completed delivery")
+    if validation.get("status") != "passed":
+        raise ValueError("repository memory writeback requires passed validation")
+    recorded_at = _compact(
+        delivery.get("recorded_at"), field="delivery recorded_at", limit=80
+    )
+    if not recorded_at:
+        raise ValueError(
+            "repository memory writeback requires stable delivery recorded_at"
+        )
+
+    public_outputs: list[dict[str, str]] = []
+    for index, item in enumerate(result.get("public_outputs") or []):
+        if not isinstance(item, Mapping):
+            raise ValueError(f"public_outputs[{index}] must be an object")
+        kind = _compact(item.get("kind") or "artifact", field="output kind", limit=60)
+        url = _compact(item.get("url"), field="output url", limit=320)
+        if url and not url.startswith("https://"):
+            raise ValueError("repository memory output URLs must use https")
+        if url:
+            public_outputs.append({"kind": kind, "url": url})
+
+    changed_files: list[str] = []
+    for index, raw_path in enumerate(delivery.get("changed_files") or []):
+        path = PurePosixPath(
+            _compact(raw_path, field=f"changed_files[{index}]", limit=260)
+        )
+        if path.is_absolute() or ".." in path.parts:
+            raise ValueError("repository memory changed files must be repo-relative")
+        changed_files.append(path.as_posix())
+
+    repo = _compact(case.get("repo"), field="repo", limit=180)
+    issue_ref = _compact(case.get("issue_ref"), field="issue_ref", limit=180)
+    supersession_key = "sha256:" + hashlib.sha256(
+        f"{workspace_scope}\n{peer_scope}\n{repo}\n{issue_ref}".encode("utf-8")
+    ).hexdigest()
+    fact = {
+        "schema_version": "issue_fix_validated_outcome_memory_v0",
+        "fact_type": "validated_issue_fix_outcome",
+        "workspace_scope": workspace_scope,
+        "peer_scope": peer_scope,
+        "repository": repo,
+        "issue_ref": issue_ref,
+        "issue_url": _compact(issue.get("url"), field="issue URL", limit=320),
+        "route": _label(case.get("route"), field="route"),
+        "stage": _label(case.get("stage"), field="stage"),
+        "repository_revision": repository_revision,
+        "context_fingerprint": _compact(
+            repository_context.get("fingerprint"),
+            field="context fingerprint",
+            limit=80,
+        ),
+        "validation_status": "passed",
+        "validation_label": _compact(
+            validation.get("label"), field="validation label", limit=260
+        ),
+        "commit_ref": _compact(
+            delivery.get("commit_ref"), field="commit ref", limit=80
+        ),
+        "changed_files": changed_files,
+        "public_outputs": public_outputs,
+        "risks": [
+            _compact(item, field=f"risks[{index}]", limit=260)
+            for index, item in enumerate(case.get("risks") or [])
+        ],
+        "freshness": "revision_pinned",
+        "observed_at": recorded_at,
+        "provenance": "issue_fix_outcome_projection_v0",
+        "supersession_key": supersession_key,
+    }
+    canonical = json.dumps(
+        fact,
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    idempotency_key = "sha256:" + hashlib.sha256(
+        canonical.encode("utf-8")
+    ).hexdigest()
+    body = (
+        "# Validated issue-fix outcome\n\n```json\n"
+        + json.dumps(
+            {**fact, "idempotency_key": idempotency_key},
+            ensure_ascii=False,
+            sort_keys=True,
+            indent=2,
+        )
+        + "\n```\n"
+    )
+    return idempotency_key, body
+
+
+def write_issue_fix_validated_outcome_memory(
+    *,
+    config: Mapping[str, Any],
+    outcome_packet: Mapping[str, Any],
+    repository_revision: str,
+    observed_at: str,
+    execute: bool,
+    provider: ContextProvider | None = None,
+) -> dict[str, Any]:
+    """Write one distilled, revision-pinned outcome through an explicit provider gate."""
+
+    normalised = _normalise_config(config, repository_revision=repository_revision)
+    base = {
+        "schema_version": "issue_fix_validated_outcome_memory_writeback_v0",
+        "provider": normalised["provider"],
+        "namespace": normalised["namespace"],
+        "visibility": "public",
+        "repository_revision": repository_revision,
+        "writeback_enabled": normalised["writeback_enabled"],
+        "automatic_capture_performed": False,
+        "raw_content_captured": False,
+        "credentials_captured": False,
+    }
+    if not normalised["enabled"]:
+        return {
+            **base,
+            "ok": False,
+            "status": "disabled",
+            "reason_code": "provider_disabled",
+            "external_writes_performed": False,
+        }
+    if not normalised["writeback_enabled"]:
+        return {
+            **base,
+            "ok": False,
+            "status": "disabled",
+            "reason_code": "writeback_not_owner_enabled",
+            "external_writes_performed": False,
+        }
+    idempotency_key, body = _validated_outcome_fact(
+        outcome_packet,
+        repository_revision=repository_revision,
+        workspace_scope=str(normalised["workspace_scope"]),
+        peer_scope=str(normalised["peer_scope"]),
+    )
+    digest = idempotency_key.removeprefix("sha256:")
+    target = (
+        f"{normalised['writeback_scope_ref']}/validated-outcomes/"
+        f"{normalised['workspace_scope']}/{normalised['peer_scope']}/{digest}.md"
+    )
+    configured_provider = provider or build_context_provider(normalised)
+    with tempfile.TemporaryDirectory(prefix="loopx-validated-outcome-") as tmpdir:
+        source = Path(tmpdir) / f"{digest}.md"
+        source.write_text(body, encoding="utf-8")
+        sync = configured_provider.sync(
+            namespace=str(normalised["namespace"]),
+            resources=[(str(source), target)],
+            timeout_seconds=float(normalised["sync_timeout_seconds"]),
+            observed_at=observed_at,
+            execute=execute,
+        )
+    packet = sync.public_packet()
+    packet.update(
+        {
+            **base,
+            "ok": sync.status in {"completed", "planned"},
+            "status": sync.status,
+            "reason_code": sync.reason_code,
+            "idempotency_key": idempotency_key,
+            "supersession_key_recorded": True,
+            "revision_scoped": True,
+        }
+    )
+    return packet
 
 
 def _repo_relative_ref(


### PR DESCRIPTION
## Motivation

Issue-fix can already read checkout-verified public repository context, but it has no controlled way to retain a proven delivery outcome for later advisory retrieval. OpenViking's experimental one-shot session command does not expose an idempotency key, so using it directly would make automatic retries unsafe.

## Implementation

- add an explicit `loopx issue-fix outcome --write-repository-memory` call site
- require independent local provider opt-in, completed delivery, passed validation, stable `recorded_at`, and a matching revision-scoped public resource namespace
- write only a distilled public fact with revision, provenance, freshness, public outputs, risk notes, workspace/peer scopes, and stable supersession/idempotency hashes
- reuse deterministic provider resource sync so identical retries perform no second write and conflicts stop instead of overwriting
- reject transcript, tool-result/log, expert-answer, credential, private-material, raw-content, and local-path capture
- keep conversation/session capture out of scope; `ov add-memory` is not used
- register the contract and focused smoke in the capability catalog and canary planner
- document the default-off contract in English and Chinese

## Validation

- `python3 examples/issue-fix-repository-memory-smoke.py`
- `python3 examples/issue-fix-validated-memory-writeback-smoke.py`
- `python3 examples/issue-fix-outcome-projection-smoke.py`
- `python3 examples/issue-fix-capability-guide-smoke.py`
- `python3 examples/canary/catalog-planner-smoke.py`
- `loopx check --scan-path docs/capabilities/issue-fix/ --scan-path examples/issue-fix-validated-memory-writeback-smoke.py`
- `loopx canary premerge --from-git-diff`: 17/17 selected checks passed; 0 failures, 0 warnings, 0 manual holds

## Risk and limits

The hook is double-gated and remains disabled by default. It writes only deterministic public resources; it does not enable OpenViking session memory, automatic lifecycle capture, transcript capture, or private namespaces. A live OpenViking dogfood write still requires a separate project boundary decision and local configuration.
