### PR TITLE
Guard validated memory revision ancestry

### DIFF
--- a/docs/capabilities/issue-fix/README.md
+++ b/docs/capabilities/issue-fix/README.md
@@ -596,8 +596,12 @@ Validated-outcome writeback is a separate, default-off hook. It runs only when
 the caller explicitly adds `--write-repository-memory`, the local provider
 config independently sets `writeback_enabled: true`, delivery evidence says
 `completed`, validation says `passed`, the delivery evidence has a stable
-`recorded_at`, and the outcome revision matches the configured public resource
-scope. LoopX writes one distilled fact containing
+`recorded_at`, the outcome revision matches the configured public resource
+scope, and `--repo-path` proves with git that delivery `commit_ref` is an
+ancestor of that pinned revision. Divergent, missing, or unresolved commits
+block before the provider is called. Squash flows should record the final
+merge/squash commit, not a superseded feature-branch commit. The checkout path
+and raw git output are never retained. LoopX writes one distilled fact containing
 revision, provenance, freshness, public outputs, risks, a stable supersession
 key, and explicit workspace/peer scopes. A content hash selects the immutable
 target, so an identical retry reads and accepts the existing fact without a
@@ -785,6 +789,7 @@ loopx issue-fix outcome \
   --write-delivery-evidence \
   --repository-memory-provider-json provider.json \
   --write-repository-memory \
+  --repo-path /path/to/approved/repo \
   --agent-id codex-issue-fix \
   --format json
 ```

--- a/docs/capabilities/issue-fix/README.zh-CN.md
+++ b/docs/capabilities/issue-fix/README.zh-CN.md
@@ -524,8 +524,11 @@ provider resource write 已获授权时才加 `--execute`。同一个 immutable 
 Validated-outcome writeback 是另一条默认关闭的 hook。只有调用方显式增加
 `--write-repository-memory`、本地 provider config 另行设置
 `writeback_enabled: true`、delivery evidence 为 `completed`、validation 为 `passed`，且
-delivery evidence 带有稳定 `recorded_at`、outcome revision 与公开 resource scope 一致时才会
-执行。LoopX 只写入一条 distilled fact：
+delivery evidence 带有稳定 `recorded_at`、outcome revision 与公开 resource scope 一致，
+并且 `--repo-path` 能通过 git 证明 delivery `commit_ref` 是该 pinned revision 的 ancestor
+时才会执行。Commit 缺失、无法解析或与 revision 分叉时，会在调用 provider 之前阻塞。
+Squash flow 应记录最终 merge/squash commit，而不是已经被替代的 feature-branch commit。
+Checkout path 与 raw git output 都不会保留。LoopX 只写入一条 distilled fact：
 revision、provenance、freshness、公开产出、风险、稳定 supersession key，以及显式的
 workspace/peer scope。内容 hash 决定 immutable target，因此相同重试会读取并接受已有 fact，
 不会二次写入；内容冲突则停止，不覆盖旧事实。Raw transcript、tool log/result、expert answer、
@@ -690,6 +693,7 @@ loopx issue-fix outcome \
   --write-delivery-evidence \
   --repository-memory-provider-json provider.json \
   --write-repository-memory \
+  --repo-path /path/to/approved/repo \
   --agent-id codex-issue-fix \
   --format json
 ```

--- a/examples/issue-fix-validated-memory-writeback-smoke.py
+++ b/examples/issue-fix-validated-memory-writeback-smoke.py
@@ -27,7 +27,13 @@ from loopx.capabilities.issue_fix.repository_memory_provider import (  # noqa: E
 )
 
 
-REVISION = "9cf42405a8bb0a8a17a66d4f953515f5a2c82620"
+REVISION = subprocess.run(
+    ["git", "rev-parse", "HEAD"],
+    cwd=ROOT,
+    text=True,
+    stdout=subprocess.PIPE,
+    check=True,
+).stdout.strip()
 OBSERVED_AT = "2026-07-11T08:40:00+08:00"
 
 
@@ -61,10 +67,10 @@ class WritebackContractProvider:
         )
 
 
-def repository_context() -> dict[str, object]:
+def repository_context(revision: str = REVISION) -> dict[str, object]:
     return {
         "schema_version": "issue_fix_repository_context_input_v0",
-        "repository_revision": REVISION,
+        "repository_revision": revision,
         "sources": [
             {
                 "source_id": "current-source",
@@ -88,14 +94,18 @@ def repository_context() -> dict[str, object]:
     }
 
 
-def outcome_packet() -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+def outcome_packet(
+    *,
+    revision: str = REVISION,
+    commit_ref: str | None = None,
+) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
     feasibility = build_issue_fix_feasibility_packet(
         url="https://github.com/owner/repo/issues/7",
         reproduction_status="confirmed",
         reproduction_label="focused worker reproduction",
         scope_class="bounded",
         validation_label="focused worker regression",
-        repository_context_input=repository_context(),
+        repository_context_input=repository_context(revision),
     )
     delivery = {
         "schema_version": "issue_fix_delivery_evidence_input_v0",
@@ -103,7 +113,7 @@ def outcome_packet() -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
         "validation_status": "passed",
         "validation_label": "passed focused public contract test",
         "changed_files": ["src/worker.py", "tests/test_worker.py"],
-        "commit_ref": REVISION,
+        "commit_ref": commit_ref or revision,
         "outputs": [
             {"kind": "pull_request", "url": "https://github.com/owner/repo/pull/8"}
         ],
@@ -120,18 +130,22 @@ def outcome_packet() -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
     return feasibility, delivery, outcome
 
 
-def provider_config(provider: str = "contract_provider") -> dict[str, Any]:
+def provider_config(
+    provider: str = "contract_provider",
+    *,
+    revision: str = REVISION,
+) -> dict[str, Any]:
     return {
         "schema_version": "issue_fix_repository_memory_provider_config_v0",
         "enabled": True,
         "provider": provider,
         "namespace": "public-repository",
         "visibility": "public",
-        "scope_ref": f"viking://resources/public-repo/{REVISION}",
-        "repository_revision": REVISION,
+        "scope_ref": f"viking://resources/public-repo/{revision}",
+        "repository_revision": revision,
         "sync_timeout_seconds": 5,
         "writeback_enabled": True,
-        "writeback_scope_ref": f"viking://resources/public-repo/{REVISION}",
+        "writeback_scope_ref": f"viking://resources/public-repo/{revision}",
         "workspace_scope": "owner-repo",
         "peer_scope": "issue-fix-agent",
     }
@@ -150,6 +164,7 @@ def main() -> int:
         config=provider_config(),
         outcome_packet=outcome,
         repository_revision=REVISION,
+        repo_path=ROOT,
         observed_at=OBSERVED_AT,
         execute=True,
         provider=provider,
@@ -158,6 +173,7 @@ def main() -> int:
         config=provider_config(),
         outcome_packet=outcome,
         repository_revision=REVISION,
+        repo_path=ROOT,
         observed_at=OBSERVED_AT,
         execute=True,
         provider=provider,
@@ -166,6 +182,8 @@ def main() -> int:
     assert retry["status"] == "completed" and retry["write_count"] == 0, retry
     assert first["idempotency_key"] == retry["idempotency_key"]
     assert first["supersession_key_recorded"] is True
+    assert first["checkout_verification"]["commit_is_ancestor"] is True, first
+    assert first["checkout_verification"]["repo_path_recorded"] is False, first
     stored_fact = next(iter(provider.contents.values()))
     for expected in (
         "issue_fix_validated_outcome_memory_v0",
@@ -181,6 +199,7 @@ def main() -> int:
         config={**provider_config(), "writeback_enabled": False},
         outcome_packet=outcome,
         repository_revision=REVISION,
+        repo_path=ROOT,
         observed_at=OBSERVED_AT,
         execute=True,
         provider=provider,
@@ -191,6 +210,7 @@ def main() -> int:
             config=provider_config(),
             outcome_packet={**outcome, "raw_transcript": "must never be written"},
             repository_revision=REVISION,
+            repo_path=ROOT,
             observed_at=OBSERVED_AT,
             execute=True,
             provider=provider,
@@ -206,6 +226,7 @@ def main() -> int:
             config=provider_config(),
             outcome_packet=failed_outcome,
             repository_revision=REVISION,
+            repo_path=ROOT,
             observed_at=OBSERVED_AT,
             execute=True,
             provider=provider,
@@ -214,6 +235,85 @@ def main() -> int:
         assert "requires passed validation" in str(exc), exc
     else:
         raise AssertionError("failed validation must block memory writeback")
+
+    with tempfile.TemporaryDirectory(prefix="loopx-writeback-divergent-") as tmpdir:
+        checkout = Path(tmpdir)
+        subprocess.run(["git", "init", "-q"], cwd=checkout, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "public@example.com"],
+            cwd=checkout,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Public Fixture"],
+            cwd=checkout,
+            check=True,
+        )
+        (checkout / "main.txt").write_text("base\n", encoding="utf-8")
+        subprocess.run(["git", "add", "main.txt"], cwd=checkout, check=True)
+        subprocess.run(["git", "commit", "-qm", "base"], cwd=checkout, check=True)
+        main_branch = subprocess.run(
+            ["git", "branch", "--show-current"],
+            cwd=checkout,
+            text=True,
+            stdout=subprocess.PIPE,
+            check=True,
+        ).stdout.strip()
+        subprocess.run(
+            ["git", "checkout", "--orphan", "delivery"],
+            cwd=checkout,
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        subprocess.run(["git", "rm", "-rf", "."], cwd=checkout, check=True, stdout=subprocess.DEVNULL)
+        (checkout / "delivery.txt").write_text("delivered\n", encoding="utf-8")
+        subprocess.run(["git", "add", "delivery.txt"], cwd=checkout, check=True)
+        subprocess.run(["git", "commit", "-qm", "delivery"], cwd=checkout, check=True)
+        divergent_commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=checkout,
+            text=True,
+            stdout=subprocess.PIPE,
+            check=True,
+        ).stdout.strip()
+        subprocess.run(
+            ["git", "checkout", main_branch],
+            cwd=checkout,
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        (checkout / "main.txt").write_text("base\ncurrent\n", encoding="utf-8")
+        subprocess.run(["git", "add", "main.txt"], cwd=checkout, check=True)
+        subprocess.run(["git", "commit", "-qm", "current"], cwd=checkout, check=True)
+        current_revision = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=checkout,
+            text=True,
+            stdout=subprocess.PIPE,
+            check=True,
+        ).stdout.strip()
+        _, _, divergent_outcome = outcome_packet(
+            revision=current_revision,
+            commit_ref=divergent_commit,
+        )
+        blocked_provider = WritebackContractProvider()
+        blocked = write_issue_fix_validated_outcome_memory(
+            config=provider_config(revision=current_revision),
+            outcome_packet=divergent_outcome,
+            repository_revision=current_revision,
+            repo_path=checkout,
+            observed_at=OBSERVED_AT,
+            execute=True,
+            provider=blocked_provider,
+        )
+        assert blocked["ok"] is False and blocked["status"] == "blocked", blocked
+        assert blocked["reason_code"] == "delivery_commit_not_in_repository_revision", blocked
+        assert blocked["checkout_verification"]["commit_is_ancestor"] is False, blocked
+        assert blocked["external_writes_performed"] is False, blocked
+        assert blocked_provider.contents == {}, blocked_provider.contents
+        assert_public_boundary(blocked)
 
     with tempfile.TemporaryDirectory(prefix="loopx-writeback-smoke-") as tmpdir:
         tmp = Path(tmpdir)
@@ -266,6 +366,8 @@ def main() -> int:
             "--repository-memory-provider-json",
             str(config_path),
             "--write-repository-memory",
+            "--repo-path",
+            str(ROOT),
             "--generated-at",
             OBSERVED_AT,
         ]

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -630,6 +630,15 @@ def register_issue_fix_commands(
         ),
     )
     outcome_parser.add_argument(
+        "--repo-path",
+        default=None,
+        help=(
+            "Caller-approved git checkout used only to prove that delivery commit_ref "
+            "is contained in the pinned repository revision before memory writeback. "
+            "The path and raw git output are never recorded."
+        ),
+    )
+    outcome_parser.add_argument(
         "--agent-id",
         help="Optional registered agent id projected as the case owner.",
     )
@@ -1361,6 +1370,10 @@ def handle_issue_fix_command(
                 generated_at=generated_at,
             )
             if args.write_repository_memory:
+                if not args.repo_path:
+                    raise ValueError(
+                        "--write-repository-memory requires --repo-path for commit ancestry verification"
+                    )
                 outcome_case = (payload.get("issue_fix_outcomes") or [{}])[0]
                 repository_context = (
                     outcome_case.get("repository_context")
@@ -1380,6 +1393,7 @@ def handle_issue_fix_command(
                     config=_load_json_object(str(provider_path)),
                     outcome_packet=payload,
                     repository_revision=revision,
+                    repo_path=args.repo_path,
                     observed_at=generated_at,
                     execute=True,
                 )

--- a/loopx/capabilities/issue_fix/outcome_projection.py
+++ b/loopx/capabilities/issue_fix/outcome_projection.py
@@ -99,7 +99,7 @@ def _delivery_evidence(value: Mapping[str, Any] | None) -> dict[str, Any]:
             f"{sorted(DELIVERY_OUTCOME_STATUSES)}"
         )
     commit_ref = _safe_text(value.get("commit_ref"), field="commit_ref", limit=80)
-    if commit_ref and not re.fullmatch(r"[A-Za-z0-9._/-]{4,80}", commit_ref):
+    if commit_ref and not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._/-]{3,79}", commit_ref):
         raise ValueError("commit_ref must be a compact public-safe git reference")
     outputs: list[dict[str, str]] = []
     raw_outputs = value.get("outputs") or []

--- a/loopx/capabilities/issue_fix/repository_memory_provider.py
+++ b/loopx/capabilities/issue_fix/repository_memory_provider.py
@@ -4,6 +4,7 @@ import hashlib
 import json
 import os
 import re
+import subprocess
 import tempfile
 from collections.abc import Mapping, Sequence
 from pathlib import Path, PurePosixPath
@@ -395,6 +396,7 @@ def write_issue_fix_validated_outcome_memory(
     config: Mapping[str, Any],
     outcome_packet: Mapping[str, Any],
     repository_revision: str,
+    repo_path: str | Path | None,
     observed_at: str,
     execute: bool,
     provider: ContextProvider | None = None,
@@ -429,6 +431,87 @@ def write_issue_fix_validated_outcome_memory(
             "reason_code": "writeback_not_owner_enabled",
             "external_writes_performed": False,
         }
+    outcomes = outcome_packet.get("issue_fix_outcomes")
+    cases = [item for item in outcomes or [] if isinstance(item, Mapping)]
+    case = cases[0] if len(cases) == 1 else {}
+    delivery = case.get("delivery") if isinstance(case, Mapping) else None
+    commit_ref = (
+        _compact(delivery.get("commit_ref"), field="commit ref", limit=80)
+        if isinstance(delivery, Mapping) and delivery.get("commit_ref")
+        else ""
+    )
+    verification = {
+        "schema_version": "issue_fix_validated_outcome_checkout_verification_v0",
+        "repository_revision": repository_revision,
+        "commit_ref": commit_ref or None,
+        "repository_revision_resolved": False,
+        "commit_ref_resolved": False,
+        "commit_is_ancestor": False,
+        "repo_path_recorded": False,
+        "raw_git_output_captured": False,
+    }
+    if repo_path is None:
+        return {
+            **base,
+            "ok": False,
+            "status": "blocked",
+            "reason_code": "repo_checkout_required",
+            "checkout_verification": verification,
+            "external_writes_performed": False,
+        }
+    if not commit_ref:
+        return {
+            **base,
+            "ok": False,
+            "status": "blocked",
+            "reason_code": "delivery_commit_ref_required",
+            "checkout_verification": verification,
+            "external_writes_performed": False,
+        }
+    checkout = Path(repo_path).expanduser().resolve()
+
+    def git_ok(*args: str) -> bool:
+        try:
+            result = subprocess.run(
+                ["git", *args],
+                cwd=checkout,
+                text=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=10,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            return False
+        return result.returncode == 0
+
+    verification["repository_revision_resolved"] = git_ok(
+        "cat-file", "-e", f"{repository_revision}^{{commit}}"
+    )
+    verification["commit_ref_resolved"] = git_ok(
+        "cat-file", "-e", f"{commit_ref}^{{commit}}"
+    )
+    if not verification["repository_revision_resolved"]:
+        reason_code = "repository_revision_not_in_checkout"
+    elif not verification["commit_ref_resolved"]:
+        reason_code = "delivery_commit_not_in_checkout"
+    else:
+        verification["commit_is_ancestor"] = git_ok(
+            "merge-base", "--is-ancestor", commit_ref, repository_revision
+        )
+        reason_code = (
+            None
+            if verification["commit_is_ancestor"]
+            else "delivery_commit_not_in_repository_revision"
+        )
+    if reason_code:
+        return {
+            **base,
+            "ok": False,
+            "status": "blocked",
+            "reason_code": reason_code,
+            "checkout_verification": verification,
+            "external_writes_performed": False,
+        }
     idempotency_key, body = _validated_outcome_fact(
         outcome_packet,
         repository_revision=repository_revision,
@@ -461,6 +544,7 @@ def write_issue_fix_validated_outcome_memory(
             "idempotency_key": idempotency_key,
             "supersession_key_recorded": True,
             "revision_scoped": True,
+            "checkout_verification": verification,
         }
     )
     return packet


### PR DESCRIPTION
## Motivation

Real OpenViking restart dogfood exposed a provenance bug in validated-outcome memory writeback. The persisted fact for public issue #3102 recorded repository revision `cbdab573...` and delivery commit `a071b948...`, but git proves that delivery commit is not an ancestor of the pinned revision. After restart the fact remained retrievable even though the pinned checkout still contained the pre-fix payload shape.

The previous gate checked that provider scope matched the outcome repository context, but did not prove that the recorded delivery commit was contained in that revision.

## Implementation

- require `--repo-path` for explicit validated-outcome memory writeback
- resolve the pinned revision and delivery `commit_ref` in the approved checkout
- require `git merge-base --is-ancestor <commit_ref> <repository_revision>` before any provider write
- return a compact public-safe blocker with zero external writes for missing, unresolved, or divergent commits
- keep checkout paths and raw git output out of packets
- tighten `commit_ref` so option-like refs cannot reach git
- document that squash flows must record the final merge/squash commit

## Validation

- focused writeback smoke covers ancestor success, identical retry idempotency, divergent history, zero provider writes on rejection, disabled/unsafe/failed-validation paths, and the CLI path
- real public pilot replay rejects the #3102 mismatch with `delivery_commit_not_in_repository_revision`, `commit_is_ancestor=false`, and `external_writes_performed=false`
- issue-fix outcome, workflow-contract, and bilingual capability-guide smokes passed
- `loopx canary premerge --from-git-diff`: 4 direct + 17 selected checks passed; 0 failures, warnings, or manual holds; public boundary clean

## Risk and omissions

- This intentionally tightens the writeback CLI: callers must provide an approved checkout.
- A squash workflow must record the final merge/squash commit rather than the superseded feature-branch commit.
- The previously written #3102 fact is not deleted automatically. Current retrieval classifies it as unverified with zero patch influence; cleanup or supersession needs a separately verified post-merge revision rather than destructive implicit repair.
