### PR TITLE
Fix legacy reviewer notification receipt persistence

### DIFF
--- a/examples/issue-fix-reviewer-request-smoke.py
+++ b/examples/issue-fix-reviewer-request-smoke.py
@@ -743,6 +743,14 @@ def main() -> int:
             },
         )
         upsert_issue_fix_pr_lifecycle_ledger_jsonl(lifecycle_path, lifecycle)
+        legacy_lifecycle = json.loads(
+            lifecycle_path.read_text(encoding="utf-8").splitlines()[0]
+        )
+        legacy_lifecycle.pop("maintainer_correction_body_captured")
+        lifecycle_path.write_text(
+            json.dumps(legacy_lifecycle, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
         goal_execute_runner = FakeCombinedRunner(
             FakeGitHubRunner(
                 before=metadata(),
@@ -765,7 +773,7 @@ def main() -> int:
         receipt = goal_execute["secondary_notifications"]["receipts"][0]
         receipt_write = persist_issue_fix_reviewer_notification_receipts(
             lifecycle_path,
-            lifecycle,
+            legacy_lifecycle,
             [receipt],
         )
         assert receipt_write["write_performed"] is True, receipt_write
@@ -773,6 +781,19 @@ def main() -> int:
             lifecycle_path.read_text(encoding="utf-8").splitlines()[0]
         )
         assert stored_lifecycle["reviewer_notification_receipts"] == [receipt]
+        assert stored_lifecycle["maintainer_correction_body_captured"] is False
+        unsafe_lifecycle = json.loads(json.dumps(stored_lifecycle))
+        unsafe_lifecycle["maintainer_correction_body_captured"] = True
+        try:
+            persist_issue_fix_reviewer_notification_receipts(
+                lifecycle_path,
+                unsafe_lifecycle,
+                ["sha256:" + "f" * 64],
+            )
+        except ValueError as exc:
+            assert "maintainer_correction_body_captured=false" in str(exc)
+        else:
+            raise AssertionError("truthy legacy capture flag must remain blocked")
         later_monitor = build_issue_fix_pr_lifecycle_monitor_packet(
             url="https://github.com/owner/repo/pull/42",
             issue_ref="issues_40",

--- a/loopx/domain_packs/issue_fix.py
+++ b/loopx/domain_packs/issue_fix.py
@@ -171,6 +171,19 @@ def persist_issue_fix_reviewer_notification_receipts(
 ) -> dict[str, Any]:
     """Persist only verified hashed reviewer-notification receipts in PR state."""
 
+    # Rows written before a capture-boundary field was introduced may omit it.
+    # Receipt persistence is a metadata-only migration, so make that historical
+    # absence explicit without weakening the guard for any truthy value.
+    for key in (
+        "issue_body_captured",
+        "comment_bodies_captured",
+        "maintainer_correction_body_captured",
+        "response_payloads_captured",
+        "raw_check_logs_captured",
+        "local_paths_captured",
+    ):
+        payload.setdefault(key, False)
+
     existing = payload.get("reviewer_notification_receipts")
     merged = [
         str(value)


### PR DESCRIPTION
## Motivation

Verified secondary reviewer notifications for OpenViking PRs #3133 and #3139 could not persist their hashed receipts because their existing PR lifecycle rows predated the `maintainer_correction_body_captured` boundary flag. The send succeeded, but the receipt-only upsert failed current validation, leaving cross-process retries able to notify again.

## Implementation

- Normalize only missing capture-boundary flags to explicit `false` in the receipt-only migration path.
- Preserve the existing public-boundary guard: any truthy capture flag still fails.
- Extend the provider-neutral reviewer-request smoke with a historical lifecycle row, restart-safe receipt persistence, and the truthy-flag rejection case.

## Validation

- `python3 examples/issue-fix-reviewer-request-smoke.py`
- Real historical PR #3133 row reproduced the failure before the patch and persisted successfully in an isolated ledger after the patch.
- `loopx canary premerge --from-git-diff`: 4 direct checks and 9 selected checks passed; 0 failures, warnings, or holds; public-boundary scan clean.

## Risk and non-goals

The change is limited to receipt metadata migration for rows already accepted into issue-fix domain state. It does not weaken truthy capture guards, change notification selection, send content, authority, or external provider behavior.