### PR TITLE
Fix auxiliary due monitor authorization after quota compaction

### DIFF
--- a/examples/control_plane/monitor-poll-writeback-smoke.py
+++ b/examples/control_plane/monitor-poll-writeback-smoke.py
@@ -64,6 +64,8 @@ def write_fixture(
     selected_target_key: str | None = TARGET_KEY,
     include_other_monitor: bool = False,
     include_user_gate: bool = False,
+    include_advancement: bool = False,
+    primary_monitor_priority: str = "P0",
 ) -> tuple[Path, Path]:
     project = root / "project"
     runtime = root / "runtime"
@@ -105,6 +107,17 @@ def write_fixture(
         if include_user_gate
         else ""
     )
+    advancement = (
+        "- [ ] [P0] Advance the independent delivery task.\n"
+        "  <!-- loopx:todo "
+        "todo_id=todo_monitorpolladvance "
+        "status=open "
+        "task_class=advancement_task "
+        f"claimed_by={AGENT_ID} "
+        "-->\n"
+        if include_advancement
+        else ""
+    )
     user_gate = (
         "\n## User Todo\n\n"
         "- [ ] [P0-user] Review the unrelated publication gate.\n"
@@ -128,7 +141,7 @@ def write_fixture(
         "## Objective\n\n"
         "Exercise due monitor poll writeback.\n\n"
         "## Agent Todo\n\n"
-        "- [ ] [P0] Poll the update-note draft PR for material changes.\n"
+        f"- [ ] [{primary_monitor_priority}] Poll the update-note draft PR for material changes.\n"
         "  <!-- loopx:todo "
         f"todo_id={TODO_ID} "
         "status=open "
@@ -144,6 +157,7 @@ def write_fixture(
         "-->\n"
         f"{other_monitor}"
         f"{gated_advancement}"
+        f"{advancement}"
         f"{user_gate}",
         encoding="utf-8",
     )
@@ -449,6 +463,52 @@ def assert_target_key_cannot_hijack_selected_due_monitor() -> None:
         assert monitor_poll_records(registry_path) == [], run_index_records(registry_path)
 
 
+def assert_compacted_auxiliary_due_monitor_can_write_back() -> None:
+    with tempfile.TemporaryDirectory(prefix="loopx-monitor-poll-compacted-due-") as tmp:
+        registry_path, state_file = write_fixture(
+            Path(tmp),
+            include_other_monitor=True,
+            include_advancement=True,
+            primary_monitor_priority="P1",
+        )
+        quota = run_cli(
+            registry_path,
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+        )
+        assert quota["work_lane_contract"]["obligation"] == "advance_one_bounded_segment", quota
+        assert quota["agent_todo_summary"]["monitor_due_count"] == 2, quota
+        assert len(quota["agent_todo_summary"]["monitor_due_items"]) == 1, quota
+        projected_due_id = quota["agent_todo_summary"]["monitor_due_items"][0]["todo_id"]
+        assert projected_due_id != "todo_monitorpoll111", quota
+
+        payload = run_cli(
+            registry_path,
+            "quota",
+            "monitor-poll",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--todo-id",
+            "todo_monitorpoll111",
+            "--target-key",
+            OTHER_TARGET_KEY,
+            "--result-hash",
+            "old",
+            "--execute",
+        )
+        assert payload["ok"] is True, payload
+        assert payload["todo_writeback"]["todo_id"] == "todo_monitorpoll111", payload
+        other = find_todo(state_file, "todo_monitorpoll111")
+        assert other["consecutive_no_change"] == "2", other
+        assert other["next_due_at"] != "2026-01-01T00:00:00+00:00", other
+
+
 def assert_writeback_helper_preview_contract() -> None:
     with tempfile.TemporaryDirectory(prefix="loopx-monitor-poll-helper-parity-") as tmp:
         registry_path, _state_file = write_fixture(Path(tmp))
@@ -555,6 +615,7 @@ def main() -> int:
     assert_material_transition_followup()
     assert_due_monitor_poll_allowed_with_open_user_gate()
     assert_target_key_cannot_hijack_selected_due_monitor()
+    assert_compacted_auxiliary_due_monitor_can_write_back()
     return 0
 
 

--- a/loopx/control_plane/quota/monitor_poll.py
+++ b/loopx/control_plane/quota/monitor_poll.py
@@ -13,8 +13,13 @@ from ..runtime.run_artifacts import run_file_stem, unique_run_artifact_paths
 from ..scheduler.monitor_poll_policy import (
     allows_due_monitor_poll,
     allows_no_spend_external_monitor_poll,
+    work_lane_reason_codes,
 )
-from ..scheduler.monitor_poll_writeback import write_monitor_poll_todo_state
+from ..scheduler.monitor_todo import monitor_todo_is_due
+from ..scheduler.monitor_poll_writeback import (
+    resolve_monitor_todo_item,
+    write_monitor_poll_todo_state,
+)
 from ..scheduler.monitor_target import build_quota_monitor_target
 from ..todos.contract import normalize_todo_claimed_by, normalize_todo_id
 from ..work_items.delivery_outcome import DeliveryOutcome
@@ -37,15 +42,20 @@ def build_quota_monitor_poll_event(
     target_key: str | None = None,
     result_hash: str | None = None,
     material_change: bool = False,
+    authorized_due_monitor_poll: bool | None = None,
 ) -> dict[str, Any]:
     safe_source = str(source or DEFAULT_SLOT_SPEND_SOURCE).strip()
     if safe_source not in VALID_SLOT_SPEND_SOURCES:
         raise ValueError(f"quota monitor-poll source must be one of: {', '.join(sorted(VALID_SLOT_SPEND_SOURCES))}")
     external_monitor_poll = allows_no_spend_external_monitor_poll(before)
-    due_monitor_poll = allows_due_monitor_poll(
-        before,
-        todo_id=todo_id,
-        target_key=target_key,
+    due_monitor_poll = (
+        allows_due_monitor_poll(
+            before,
+            todo_id=todo_id,
+            target_key=target_key,
+        )
+        if authorized_due_monitor_poll is None
+        else authorized_due_monitor_poll
     )
     if before.get("effective_action") != "monitor_quiet_skip" and not external_monitor_poll and not due_monitor_poll:
         raise ValueError(
@@ -128,6 +138,45 @@ def build_quota_monitor_poll_event(
         record["agent_id"] = safe_agent_id
         record["monitor_event"]["agent_id"] = safe_agent_id
     return record
+
+
+def _allows_registry_due_monitor_poll(
+    before: dict[str, Any],
+    *,
+    registry_path: Path | None,
+    goal_id: str,
+    todo_id: str | None,
+    target_key: str | None,
+) -> bool:
+    """Authorize an auxiliary due monitor omitted from the compact quota packet."""
+
+    if registry_path is None or not (todo_id or target_key):
+        return False
+    contract = (
+        before.get("work_lane_contract")
+        if isinstance(before.get("work_lane_contract"), dict)
+        else {}
+    )
+    if contract.get("must_attempt_work") is not True:
+        return False
+    if contract.get("obligation") == "attempt_due_monitor":
+        return False
+    if "due_monitor_context" not in work_lane_reason_codes(contract):
+        return False
+    try:
+        item = resolve_monitor_todo_item(
+            registry_path=registry_path,
+            goal_id=goal_id,
+            todo_id=todo_id,
+            target_key=target_key,
+        )
+    except ValueError:
+        return False
+    if not monitor_todo_is_due(item):
+        return False
+    decision_agent_id = quota_decision_agent_id(before)
+    claimed_by = normalize_todo_claimed_by(item.get("claimed_by"))
+    return bool(decision_agent_id and claimed_by == decision_agent_id)
 
 
 def _monitor_poll_failure(
@@ -213,6 +262,12 @@ def record_quota_monitor_poll_for_decision(
         before,
         todo_id=normalized_todo_id,
         target_key=safe_target_key,
+    ) or _allows_registry_due_monitor_poll(
+        before,
+        registry_path=registry_path,
+        goal_id=goal_id,
+        todo_id=normalized_todo_id,
+        target_key=safe_target_key,
     )
     if (
         before.get("effective_action") != "monitor_quiet_skip"
@@ -255,6 +310,7 @@ def record_quota_monitor_poll_for_decision(
         target_key=(todo_writeback or {}).get("target_key") or safe_target_key,
         result_hash=(todo_writeback or {}).get("result_hash") or result_hash,
         material_change=material_change,
+        authorized_due_monitor_poll=due_monitor_poll,
     )
     if todo_writeback:
         record["monitor_event"]["todo_writeback"] = {


### PR DESCRIPTION
## Motivation

A quota decision can report multiple claimed due monitors while intentionally projecting only one due-monitor item in its compact payload. The monitor-poll gate treated that display projection as the complete execution allowlist, so an omitted but genuinely due monitor was rejected and could remain permanently overdue.

## Implementation

- preserve the compact quota payload contract;
- when an advancement lane carries `due_monitor_context`, resolve an explicitly requested monitor from the registry and authorize it only when it is open, unexpired, actually due, and claimed by the quota decision's current agent;
- keep the selected-monitor obligation strict, so target keys cannot redirect a poll to a different due monitor;
- add an end-to-end regression with two due monitors, one compactly projected, and an independent higher-priority advancement todo.

## Validation

- `python3 examples/control_plane/monitor-poll-policy-smoke.py`
- `python3 examples/control_plane/monitor-poll-writeback-smoke.py`
- `python3 -m compileall -q loopx/control_plane/quota/monitor_poll.py examples/control_plane/monitor-poll-writeback-smoke.py`
- `loopx canary premerge --from-git-diff --format json`
  - standard tier, 2 changed files
  - 3/3 direct checks passed
  - Python compile passed
  - 7/7 catalog canaries passed
  - 8/8 risk-profile smokes passed
  - 1/1 public/private boundary check passed
  - no failures, skips, warnings, or manual holds

## Risk and non-goals

The fallback cannot authorize arbitrary or other-agent work: it requires the existing due-monitor context plus exact registry identity, due state, and claimant equality. It does not widen the selected-monitor lane and does not change quota payload size or projection ordering.
