### PR TITLE
Make reviewer requests reliable and human-friendly

### DIFF
--- a/docs/capabilities/issue-fix/protocols/issue-fix-reviewer-notification-sinks-v0.md
+++ b/docs/capabilities/issue-fix/protocols/issue-fix-reviewer-notification-sinks-v0.md
@@ -84,10 +84,11 @@ write assertion; preview never calls the provider.
 
 Each logical `(repository, PR, sink instance, reviewer set)` produces a stable
 `sha256:` idempotency key. The Lark adapter derives a provider-bounded key from
-that digest and embeds a compact marker in the message. The full verified key
-is returned as a receipt. Callers store only that compact receipt in existing issue-fix state
-and pass it back on retry; a matching receipt returns `already_notified`
-without a provider call.
+that digest without exposing it in the human-visible message. The message uses
+public PR metadata to name the PR, linked issue when available, and a compact
+summary of the fix. The full verified key is returned as a receipt. Callers
+store only that compact receipt in existing issue-fix state and pass it back on
+retry; a matching receipt returns `already_notified` without a provider call.
 
 For connected goals, register only the repo-relative local-private pointer:
 
@@ -109,7 +110,7 @@ pointer value or profiles (`config_pointer_registered=true`).
 
 A zero exit status is insufficient. The adapter requires a message id from the
 send response, fetches that message with the same dedicated bot profile, and
-verifies both the id and marker. Results distinguish `preview_ready`,
+verifies both the id and PR URL. Results distinguish `preview_ready`,
 `sent_verified`, `already_notified`, `sent_unverified`, and `gate_required`.
 Permission or group-membership errors become the concrete
 `lark_bot_group_access_required` gate.

--- a/examples/issue-fix-reviewer-notification-sink-smoke.py
+++ b/examples/issue-fix-reviewer-notification-sink-smoke.py
@@ -36,7 +36,7 @@ class FakeSinkRunner:
         *,
         send_returncode: int = 0,
         verify_returncode: int = 0,
-        include_marker: bool = True,
+        include_message_content: bool = True,
         bot_name: str = "Project Review Bot",
         reader_verified: bool = True,
         include_member: bool = True,
@@ -44,7 +44,7 @@ class FakeSinkRunner:
     ) -> None:
         self.send_returncode = send_returncode
         self.verify_returncode = verify_returncode
-        self.include_marker = include_marker
+        self.include_message_content = include_message_content
         self.bot_name = bot_name
         self.reader_verified = reader_verified
         self.include_member = include_member
@@ -117,8 +117,7 @@ class FakeSinkRunner:
         if "+messages-mget" in command:
             send_call = next(call for call in self.calls if "+messages-send" in call)
             content = send_call[send_call.index("--content") + 1]
-            marker = re.search(r"loopx-reviewer-notification:[a-f0-9]{16}", content)
-            text = marker.group(0) if marker and self.include_marker else "missing"
+            text = content if self.include_message_content else "missing"
             return {
                 "returncode": self.verify_returncode,
                 "stdout": json.dumps(
@@ -252,6 +251,8 @@ def main() -> int:
         repo="owner/repo",
         pr_number=42,
         pr_url="https://github.com/owner/repo/pull/42",
+        pr_title="fix: reject file URI for consistency check",
+        linked_issue_refs=["#40"],
         author_handle="@current-author",
         reviewer_handles=["@service-owner"],
         sinks_input=fixture(),
@@ -270,10 +271,14 @@ def main() -> int:
     provider_key = send[send.index("--idempotency-key") + 1]
     assert provider_key.startswith("loopx-")
     assert len(provider_key) <= 50
-    assert "ou_private_member" in send[send.index("--content") + 1]
+    content = send[send.index("--content") + 1]
+    assert "ou_private_member" in content
     assert (
-        "https://github.com/owner/repo/pull/42" in (send[send.index("--content") + 1])
+        "https://github.com/owner/repo/pull/42" in content
     )
+    assert "请帮忙 review PR #42（修复 #40）" in content
+    assert "reject file URI for consistency check" in content
+    assert "loopx-reviewer-notification" not in content
     receipt = sent["receipts"][0]
     assert re.fullmatch(r"sha256:[a-f0-9]{64}", receipt)
     assert provider_key != receipt
@@ -457,7 +462,7 @@ def main() -> int:
         reviewer_handles=["@service-owner"],
         sinks_input=fixture(),
         execute=True,
-        runner=FakeSinkRunner(include_marker=False),
+        runner=FakeSinkRunner(include_message_content=False),
     )
     assert not_verified["ok"] is False
     assert not_verified["blocker"] == "lark_notification_not_verified"

--- a/examples/issue-fix-reviewer-request-smoke.py
+++ b/examples/issue-fix-reviewer-request-smoke.py
@@ -728,6 +728,55 @@ def main() -> int:
         assert goal_default_packet["secondary_notification_status"] == "preview_ready"
         assert_public_safe(goal_default_packet)
 
+        unrelated_cwd = path / "unrelated-control-plane"
+        write(
+            unrelated_cwd / ".loopx/registry.json",
+            json.dumps({"schema_version": 1, "goals": []}),
+        )
+        project_registry_cli = subprocess.run(
+            [
+                sys.executable,
+                "-m",
+                "loopx.cli",
+                "--format",
+                "json",
+                "issue-fix",
+                "reviewer-request",
+                "--url",
+                "https://github.com/owner/repo/pull/42",
+                "--repo-path",
+                str(path),
+                "--base-ref",
+                "main",
+                "--changed-file",
+                "src/map_only.py",
+                "--exclude-reviewer",
+                "@fallback-owner",
+                "--reviewer-sources-json",
+                str(reviewer_sources_path),
+                "--metadata-json",
+                str(metadata_path),
+                "--goal-id",
+                goal_id,
+                "--project",
+                str(path),
+            ],
+            cwd=unrelated_cwd,
+            env={**os.environ, "PYTHONPATH": str(ROOT)},
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        assert project_registry_cli.returncode == 0, project_registry_cli.stdout
+        project_registry_packet = json.loads(project_registry_cli.stdout)
+        assert (
+            project_registry_packet["secondary_notification_source"] == "goal_default"
+        )
+        assert (
+            project_registry_packet["secondary_notification_status"] == "preview_ready"
+        )
+        assert_public_safe(project_registry_packet)
+
         lifecycle_path = default_issue_fix_domain_state_ledger_path(
             project=path,
             goal_id=goal_id,

--- a/examples/issue-fix-reviewer-request-smoke.py
+++ b/examples/issue-fix-reviewer-request-smoke.py
@@ -106,6 +106,12 @@ def metadata(
 ) -> dict[str, Any]:
     return {
         "author": {"login": "current-author"},
+        "closingIssuesReferences": [
+            {
+                "number": 40,
+                "title": "Consistency check accepts unsupported file URIs",
+            }
+        ],
         "comments": comments or [],
         "isDraft": False,
         "reviewRequests": [{"login": login} for login in (requested or [])],
@@ -113,6 +119,7 @@ def metadata(
             {"author": {"login": login}} for login in (reviewed or [])
         ],
         "state": "OPEN",
+        "title": "fix: reject file URI for consistency check",
         "url": "https://github.com/owner/repo/pull/42",
     }
 
@@ -223,10 +230,9 @@ class FakeCombinedRunner:
                 call for call in self.lark_calls if "+messages-send" in call
             )
             content = send_call[send_call.index("--content") + 1]
-            marker = re.search(
-                r"loopx-reviewer-notification:[a-f0-9]{16}", content
-            )
-            assert marker, content
+            assert "请帮忙 review PR #42（修复 #40）" in content, content
+            assert "reject file URI for consistency check" in content, content
+            assert "loopx-reviewer-notification" not in content, content
             return {
                 "returncode": 0,
                 "stdout": json.dumps(
@@ -234,7 +240,7 @@ class FakeCombinedRunner:
                         "items": [
                             {
                                 "message_id": "om_fixture",
-                                "body": {"content": marker.group(0)},
+                                "body": {"content": content},
                             }
                         ]
                     }

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -235,6 +235,45 @@ def _goal_boundary_authority_projection(
     return [str(scope) for scope in scopes], True
 
 
+def _load_goal_for_project(
+    *,
+    registry_path: Path | None,
+    goal_id: str,
+    project: str | Path,
+) -> tuple[dict[str, Any], Path]:
+    """Resolve a connected goal from the active or explicit project registry."""
+
+    requested_project = Path(project).expanduser().resolve()
+    project_registry = requested_project / ".loopx" / "registry.json"
+    candidates = [
+        path for path in (registry_path, project_registry) if path is not None
+    ]
+    mismatched_goal = False
+    for candidate in dict.fromkeys(candidates):
+        goal = load_goal_from_registry(candidate, goal_id)
+        if not isinstance(goal, dict):
+            continue
+        goal_repo = str(goal.get("repo") or "").strip()
+        if not goal_repo:
+            raise ValueError(
+                "connected goal repository is required for goal-default "
+                "reviewer notification"
+            )
+        if Path(goal_repo).expanduser().resolve() == requested_project:
+            return goal, requested_project
+        mismatched_goal = True
+
+    if mismatched_goal:
+        raise ValueError(
+            "--project must match the connected goal repository for "
+            "goal-default reviewer notification"
+        )
+    raise ValueError(
+        "goal-default reviewer notification goal was not found in the active "
+        "or project-local registry"
+    )
+
+
 def register_issue_fix_commands(
     subparsers: argparse._SubParsersAction,
     add_subcommand_format: AddFormat,
@@ -1454,29 +1493,14 @@ def handle_issue_fix_command(
             notification_lifecycle_packet: dict[str, Any] | None = None
             notification_lifecycle_path: Path | None = None
             if notification_sinks_input is None and args.goal_id:
-                if registry_path is None:
-                    raise ValueError(
-                        "goal-default reviewer notification requires a registry"
-                    )
-                goal = load_goal_from_registry(registry_path, args.goal_id)
-                goal_repo = str(goal.get("repo") or "").strip()
-                if not goal_repo:
-                    raise ValueError(
-                        "connected goal repository is required for goal-default "
-                        "reviewer notification"
-                    )
-                goal_project = Path(goal_repo).expanduser().resolve()
-                requested_project = Path(args.project).expanduser().resolve()
-                if goal_project != requested_project:
-                    raise ValueError(
-                        "--project must match the connected goal repository for "
-                        "goal-default reviewer notification"
-                    )
-                notification_sinks_input = (
-                    load_goal_reviewer_notification_sinks_input(
-                        goal=goal,
-                        project=args.project,
-                    )
+                goal, requested_project = _load_goal_for_project(
+                    registry_path=registry_path,
+                    goal_id=args.goal_id,
+                    project=args.project,
+                )
+                notification_sinks_input = load_goal_reviewer_notification_sinks_input(
+                    goal=goal,
+                    project=requested_project,
                 )
                 if notification_sinks_input is not None:
                     notification_sinks_source = "goal_default"

--- a/loopx/capabilities/issue_fix/reviewer_notification.py
+++ b/loopx/capabilities/issue_fix/reviewer_notification.py
@@ -169,6 +169,27 @@ def _normalise_handle(value: Any) -> str | None:
     return f"@{text}" if text else None
 
 
+def _humanize_pr_title(value: Any) -> str:
+    title = public_safe_compact_text(value, limit=180) or ""
+    title = re.sub(
+        r"^(?:fix|bugfix)(?:\([^)]*\))?!?\s*:\s*",
+        "",
+        title,
+        flags=re.IGNORECASE,
+    )
+    return title.rstrip(".。")
+
+
+def _normalise_issue_refs(values: Sequence[Any]) -> list[str]:
+    return list(
+        dict.fromkeys(
+            str(value).strip()
+            for value in values
+            if re.fullmatch(r"#\d+", str(value).strip())
+        )
+    )[:3]
+
+
 def _idempotency_key(
     *,
     repo: str,
@@ -284,6 +305,8 @@ def _lark_result(
     repo: str,
     pr_number: int,
     pr_url: str,
+    pr_title: str,
+    linked_issue_refs: Sequence[str],
     reviewer_handles: Sequence[str],
     sink: Mapping[str, Any],
     receipts: set[str],
@@ -592,20 +615,17 @@ def _lark_result(
                 blocker="reviewer_notification_identity_unresolved",
             )
 
-    marker = f"loopx-reviewer-notification:{key.partition(':')[2][:16]}"
     provider_idempotency_key = f"loopx-{key.partition(':')[2][:32]}"
     mentions = " ".join(
         f'<at user_id="{member_id}">{html.escape(display_name)}</at>'
         for _, member_id, display_name in resolved
     )
+    issue_clause = (
+        f"（修复 {', '.join(linked_issue_refs)}）" if linked_issue_refs else ""
+    )
+    summary = f"：{pr_title}" if pr_title else ""
     content = json.dumps(
-        {
-            "text": (
-                f"{mentions} please review this focused issue-fix PR / "
-                f"请协助 review：{pr_url}\n\n"
-                f"[{marker}]"
-            )
-        },
+        {"text": f"{mentions} 请帮忙 review PR #{pr_number}{issue_clause}{summary}。{pr_url}"},
         ensure_ascii=False,
         separators=(",", ":"),
     )
@@ -705,7 +725,7 @@ def _lark_result(
     verified = bool(
         readback.get("returncode") == 0
         and message_id in readback_text
-        and marker in readback_text
+        and pr_url in readback_text
     )
     return _public_result(
         sink_kind=sink_kind,
@@ -798,6 +818,8 @@ def build_issue_fix_reviewer_notification_sinks_result(
     repo: str,
     pr_number: int,
     pr_url: str,
+    pr_title: str | None = None,
+    linked_issue_refs: Sequence[str] = (),
     author_handle: str | None,
     reviewer_handles: Sequence[str],
     sinks_input: Mapping[str, Any],
@@ -808,6 +830,8 @@ def build_issue_fix_reviewer_notification_sinks_result(
     """Preview or execute private-configured secondary reviewer notifications."""
 
     author = _normalise_handle(author_handle)
+    title = _humanize_pr_title(pr_title)
+    issue_refs = _normalise_issue_refs(linked_issue_refs)
     reviewers = list(
         dict.fromkeys(
             handle
@@ -822,6 +846,8 @@ def build_issue_fix_reviewer_notification_sinks_result(
         "repo": public_safe_compact_text(repo, limit=200),
         "pr_ref": f"#{int(pr_number)}",
         "permalink": public_safe_compact_text(pr_url, limit=300),
+        "pr_title": title,
+        "linked_issue_refs": issue_refs,
         "reviewer_handles": reviewers,
         "status": "gate_required",
         "results": [],
@@ -877,6 +903,8 @@ def build_issue_fix_reviewer_notification_sinks_result(
                 repo=repo,
                 pr_number=int(pr_number),
                 pr_url=pr_url,
+                pr_title=title,
+                linked_issue_refs=issue_refs,
                 reviewer_handles=reviewers,
                 sink=sink,
                 receipts=receipts,

--- a/loopx/capabilities/issue_fix/reviewer_request.py
+++ b/loopx/capabilities/issue_fix/reviewer_request.py
@@ -72,6 +72,17 @@ def _metadata_identities(
     author = payload.get("author")
     author = author if isinstance(author, Mapping) else {}
     author_handle = _normalise_login(author.get("login"))
+    pr_title = public_safe_compact_text(payload.get("title"), limit=180)
+    linked_issue_refs: list[str] = []
+    raw_issue_refs = payload.get("closingIssuesReferences") or payload.get(
+        "closing_issues_references"
+    )
+    for item in raw_issue_refs or []:
+        issue_number = item.get("number") if isinstance(item, Mapping) else None
+        if isinstance(issue_number, int):
+            issue_ref = f"#{issue_number}"
+            if issue_ref not in linked_issue_refs:
+                linked_issue_refs.append(issue_ref)
 
     requested: list[str] = []
     for item in payload.get("reviewRequests") or payload.get("review_requests") or []:
@@ -117,6 +128,8 @@ def _metadata_identities(
                 comment_urls[handle] = url
     return {
         "author_handle": author_handle,
+        "pr_title": pr_title,
+        "linked_issue_refs": linked_issue_refs[:3],
         "requested_reviewers": requested,
         "reviewed_by": reviewed,
         "comment_notified_reviewers": comment_notified,
@@ -142,7 +155,8 @@ def _fetch_pr_metadata(
                 "--repo",
                 repo,
                 "--json",
-                "author,comments,isDraft,reviewRequests,reviews,state,url",
+                "author,closingIssuesReferences,comments,isDraft,reviewRequests,"
+                "reviews,state,title,url",
             ]
         )
     except (OSError, subprocess.SubprocessError):
@@ -390,6 +404,8 @@ def build_issue_fix_reviewer_request_packet(
         "selection_policy": "request_top_requestable_when_authorized",
         "max_reviewers": max_reviewers,
         "author_handle": identities["author_handle"],
+        "pr_title": identities["pr_title"],
+        "linked_issue_refs": identities["linked_issue_refs"],
         "author_exclusion_verified": author_exclusion_verified,
         "pr_state_verified": pr_state_verified,
         "existing_requested_reviewers": identities["requested_reviewers"],
@@ -693,6 +709,8 @@ def build_issue_fix_reviewer_request_packet(
                 repo=repo,
                 pr_number=number,
                 pr_url=str(reference["permalink"]),
+                pr_title=identities["pr_title"],
+                linked_issue_refs=identities["linked_issue_refs"],
                 author_handle=identities["author_handle"],
                 reviewer_handles=notification_targets,
                 sinks_input=notification_sinks_input,


### PR DESCRIPTION
## Motivation

`issue-fix reviewer-request --goal-id ... --project ...` resolved the goal only from the CLI's active registry. When invoked from another connected checkout, that registry could be valid but not contain the target goal. The command then dereferenced the missing goal and returned the opaque error `'NoneType' object has no attribute 'get'`, preventing both the formal reviewer request and its permission-denied comment fallback.

## Implementation

- Resolve goal-default reviewer notification from either the active registry or the explicitly selected project's local registry.
- Require the resolved goal repository to match `--project` before loading local-private notification configuration.
- Return actionable missing-goal or project-mismatch errors instead of dereferencing an absent goal.
- Extend the existing reviewer-request smoke with an unrelated-current-registry fixture that proves project-local fallback.
- Build the Lark message from public PR title and linked-issue metadata so reviewers see one short explanation of the fix.
- Keep idempotency in the provider key and persisted receipt instead of exposing an internal marker in message text; readback verifies the message id and PR URL.

## Validation

- `python3 examples/issue-fix-reviewer-request-smoke.py`
- `python3 examples/issue-fix-reviewer-notification-sink-smoke.py`
- `python3 examples/issue-fix-capability-guide-smoke.py`
- `python3 examples/canary/catalog-planner-smoke.py`
- final-commit `loopx canary premerge --from-git-diff`
  - 3/3 direct checks passed
  - 8/8 catalog checks passed
  - 8/8 risk-profile checks passed
  - public/private boundary scan passed across all six changed files
  - no failures, warnings, skips, or manual holds

## Risk

The registry fallback is limited to an explicitly supplied project and still requires the connected goal's repository to match that project. Explicit `--registry` behavior remains authoritative when it contains the matching goal. Message content uses only public PR metadata; issue bodies and raw provider payloads remain excluded. No notification is sent by the new smoke or preview path.
