### PR TITLE
Fix SkillsBench Codex CLI goal TUI startup

### DIFF
--- a/examples/skillsbench-codex-cli-goal-route-smoke.py
+++ b/examples/skillsbench-codex-cli-goal-route-smoke.py
@@ -604,20 +604,20 @@ def _assert_cli_goal_rate_limit_is_public_safe_retryable_stage() -> None:
     from loopx.benchmark_adapters.skillsbench_acp_relay import (
         CodexExecConfig,
         SkillsBenchLocalAcpRelay,
-        _codex_cli_tui_retryable_startup_blocker_stage,
     )
+    from loopx.codex_cli_goal_tui import codex_cli_tui_retryable_startup_blocker_stage
     from scripts.skillsbench_automation_loop import (
         _merge_host_local_acp_relay_trace_summary,
         _public_runner_prerequisites,
     )
 
     assert (
-        _codex_cli_tui_retryable_startup_blocker_stage(
+        codex_cli_tui_retryable_startup_blocker_stage(
             "Codex CLI\nrate limit reached\n› "
         )
         == "rate_limit_before_goal_active"
     )
-    assert _codex_cli_tui_retryable_startup_blocker_stage("Goal active") == ""
+    assert codex_cli_tui_retryable_startup_blocker_stage("Goal active") == ""
 
     with tempfile.TemporaryDirectory() as temp:
         trace_dir = Path(temp) / "trace"
@@ -1376,12 +1376,13 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
         CODEX_CLI_GOAL_THREAD_PREWARM_MARKER,
         CODEX_CLI_GOAL_THREAD_PREWARM_PROMPT,
         build_codex_cli_goal_file_objective,
+        build_codex_cli_tui_command,
         build_codex_cli_goal_tui_input,
+        codex_cli_goal_watchdog_expired,
     )
     from loopx.benchmark_adapters.skillsbench_acp_relay import (
         CodexExecConfig,
         SkillsBenchLocalAcpRelay,
-        _codex_cli_goal_watchdog_expired,
         _prompt_requires_bridge_first_action,
         _prompt_requires_meaningful_bridge_progress,
     )
@@ -1395,6 +1396,17 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert CODEX_CLI_GOAL_TASK_PROMPT_FILENAME in objective, objective
     assert len(objective) < CODEX_CLI_GOAL_OBJECTIVE_MAX_CHARS
     assert build_codex_cli_goal_tui_input(objective).startswith("/goal "), objective
+    cmd = build_codex_cli_tui_command(
+        codex_bin="codex",
+        sandbox="workspace-write",
+        approval_policy="never",
+        cwd="/tmp/loopx-skillsbench-cwd",
+        reasoning_effort="xhigh",
+        model="gpt-5.5",
+    )
+    assert cmd[:3] == ["codex", "--no-alt-screen", "--disable"], cmd
+    assert cmd[3] == "apps", cmd
+    assert cmd.count("--disable") == 1, cmd
     packet = SkillsBenchLocalAcpRelay(
         CodexExecConfig(remote_command_file_bridge_command="/tmp/private-bridge")
     )._prompt_with_remote_bridge_packet(
@@ -1417,7 +1429,7 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
         is True
     )
     assert (
-        _codex_cli_goal_watchdog_expired(
+        codex_cli_goal_watchdog_expired(
             deadline=100.0,
             now=101.0,
             turn_active=True,
@@ -1425,7 +1437,7 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
         is False
     )
     assert (
-        _codex_cli_goal_watchdog_expired(
+        codex_cli_goal_watchdog_expired(
             deadline=100.0,
             now=101.0,
             turn_active=False,
@@ -1433,7 +1445,7 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
         is True
     )
     assert (
-        _codex_cli_goal_watchdog_expired(
+        codex_cli_goal_watchdog_expired(
             deadline=0.0,
             now=101.0,
             turn_active=False,
@@ -1477,7 +1489,12 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     assert "task_output_quiet_timeout_sec = max(" in source
     assert "_bridge_summary_has_successful_task_operation(" in source
     assert "turn_active = codex_cli_tui_turn_active(capture)" in source
-    assert source.count("_codex_cli_goal_watchdog_expired(") == 3
+    assert "goal_kickoff_prompt_submitted = False" in source
+    assert "kickoff_submitted=goal_kickoff_prompt_submitted" in source
+    assert "text=CODEX_CLI_GOAL_KICKOFF_PROMPT" in source
+    assert "goal_failed_now = False" in source
+    assert "goal_kickoff_prompt_raw_text_recorded" in source
+    assert source.count("codex_cli_goal_watchdog_expired(") == 2
     assert "and not turn_active" in source
     assert "now - last_task_output_activity_at" in source
     assert "stage=\"task_output_quiet_timeout\"" in source
@@ -1513,6 +1530,12 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
     tui_source = (REPO_ROOT / "loopx/codex_cli_goal_tui.py").read_text(
         encoding="utf-8"
     )
+    assert '"--disable",\n        "apps",' in tui_source
+    assert "CODEX_CLI_GOAL_KICKOFF_PROMPT = (" in tui_source
+    assert "Start working on the active SkillsBench goal now" in tui_source
+    assert "def codex_cli_goal_watchdog_expired(" in tui_source
+    assert "not kickoff_submitted" in tui_source
+    assert "def codex_cli_goal_reset_pre_bridge_deadlines(" in tui_source
     assert "goal-thread-prewarm.txt" in tui_source
     assert CODEX_CLI_GOAL_TASK_PROMPT_FILENAME in tui_source
     assert "tmux_send_plain_enter" in tui_source
@@ -1540,6 +1563,8 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
         assert trace["goal_prompt_file_used"] is True, trace
         assert trace["goal_prompt_file_raw_path_recorded"] is False, trace
         assert trace["goal_command_submission_method"] == "typed", trace
+        assert trace["goal_kickoff_prompt_submitted"] is False, trace
+        assert trace["goal_kickoff_prompt_raw_text_recorded"] is False, trace
         assert trace["private_tui_tail_recorded"] is False, trace
 
     with tempfile.TemporaryDirectory() as temp:
@@ -1561,12 +1586,15 @@ def _assert_cli_goal_uses_short_file_backed_objective_for_bridge_packet() -> Non
             bridge_summary_path=None,
             goal_prompt_file_used=True,
             goal_command_submission_method="typed",
+            goal_kickoff_prompt_submitted=True,
         )
         traces = list(trace_dir.glob("*.compact.json"))
         assert len(traces) == 1, traces
         payload = json.loads(traces[0].read_text(encoding="utf-8"))
         trace = payload["codex_cli_goal"]
         assert trace["private_tui_tail_recorded"] is True, trace
+        assert trace["goal_kickoff_prompt_submitted"] is True, trace
+        assert trace["goal_kickoff_prompt_raw_text_recorded"] is False, trace
         assert trace["private_tui_tail_ref"].startswith("private/"), trace
         assert trace["private_tui_tail_line_count"] == 23, trace
         assert trace["raw_tui_capture_recorded"] is False, trace

--- a/loopx/benchmark_adapters/skillsbench_acp_relay.py
+++ b/loopx/benchmark_adapters/skillsbench_acp_relay.py
@@ -54,13 +54,19 @@ from loopx.benchmark_adapters.skillsbench_codex_goal_recovery import (
     write_private_codex_cli_goal_tui_tail,
 )
 from loopx.codex_cli_goal_tui import (
+    CODEX_CLI_GOAL_KICKOFF_PROMPT,
     CODEX_CLI_GOAL_TASK_PROMPT_FILENAME,
     build_codex_cli_goal_file_objective,
     build_codex_cli_goal_tui_input,
     build_codex_cli_tui_command,
+    codex_cli_goal_watchdog_expired,
+    codex_cli_goal_reset_pre_bridge_deadlines,
+    codex_cli_goal_should_ignore_stale_terminal,
+    codex_cli_goal_should_submit_kickoff,
     codex_cli_tui_environment,
     codex_cli_tui_shell_command,
     codex_cli_tui_input_prompt_visible,
+    codex_cli_tui_retryable_startup_blocker_stage,
     codex_cli_tui_turn_active,
     prewarm_codex_cli_goal_thread,
     resolve_codex_cli_binary,
@@ -154,17 +160,6 @@ def _prompt_requires_bridge_first_action(prompt: str) -> bool:
         "selected runnable p0",
     )
     return any(marker in lowered for marker in required_markers)
-
-
-def _codex_cli_goal_watchdog_expired(
-    *,
-    deadline: float,
-    now: float,
-    turn_active: bool,
-) -> bool:
-    """Keep bounded watchdogs from interrupting an active Codex turn."""
-
-    return bool(deadline and now >= deadline and not turn_active)
 
 
 def _is_bridge_action_preflight_prompt(prompt: str) -> bool:
@@ -394,24 +389,6 @@ def _recoverable_codex_turn_failure_message(category: str) -> str:
         f"{category}. Continue with the next scheduled product-mode round; "
         "raw task text, logs, and trajectory material were not recorded."
     )
-
-
-def _codex_cli_tui_retryable_startup_blocker_stage(capture: str) -> str:
-    """Classify public-safe Codex CLI TUI startup blockers from screen text."""
-
-    lowered = str(capture or "").lower()
-    if any(
-        marker in lowered
-        for marker in (
-            "rate limit",
-            "rate_limit",
-            "too many requests",
-            "status 429",
-            "error 429",
-        )
-    ):
-        return "rate_limit_before_goal_active"
-    return ""
 
 
 def _write_process_stdin_async(
@@ -1102,6 +1079,7 @@ class SkillsBenchLocalAcpRelay:
             goal_terminal_observed = False
             goal_failed_observed = False
             goal_slash_command_submitted = False
+            goal_kickoff_prompt_submitted = False
             post_bridge_terminal_stage = ""
             first_action_seen = False
             bridge_activity_seen = False
@@ -1278,14 +1256,51 @@ class SkillsBenchLocalAcpRelay:
                                     bridge_summary_path
                                 )
                             )
+                    if codex_cli_goal_should_submit_kickoff(
+                        bridge_enabled=bridge_summary_path is not None,
+                        goal_active_observed=goal_active_observed,
+                        kickoff_submitted=goal_kickoff_prompt_submitted,
+                        turn_active=turn_active,
+                        first_action_seen=first_action_seen,
+                        capture=capture,
+                    ):
+                        goal_kickoff_prompt_submitted = True
+                        tmux_type_text_and_submit(
+                            tmux_name=tmux_name,
+                            text=CODEX_CLI_GOAL_KICKOFF_PROMPT,
+                        )
+                        (
+                            goal_active_deadline,
+                            first_action_deadline,
+                            meaningful_progress_deadline,
+                        ) = codex_cli_goal_reset_pre_bridge_deadlines(
+                            now=now,
+                            first_action_timeout_sec=self._config.first_action_timeout_sec,
+                            goal_active_deadline=goal_active_deadline,
+                            goal_active_timeout_sec=self._config.goal_active_timeout_sec,
+                            first_action_deadline=first_action_deadline,
+                            meaningful_progress_deadline=meaningful_progress_deadline,
+                        )
+                        next_heartbeat = now + max(
+                            1.0,
+                            self._config.stream_heartbeat_interval_sec,
+                        )
+                        continue
+                    if codex_cli_goal_should_ignore_stale_terminal(
+                        goal_failed_now=goal_failed_now,
+                        kickoff_submitted=goal_kickoff_prompt_submitted,
+                        first_action_seen=first_action_seen,
+                        turn_active=turn_active,
+                        first_action_deadline=first_action_deadline,
+                        now=now,
+                    ):
+                        goal_failed_now = False
                     if "Goal achieved" in capture:
                         goal_terminal_observed = True
                         break
                     retryable_startup_blocker_stage = ""
                     if not goal_active_observed and not first_action_seen:
-                        retryable_startup_blocker_stage = (
-                            _codex_cli_tui_retryable_startup_blocker_stage(capture)
-                        )
+                        retryable_startup_blocker_stage = codex_cli_tui_retryable_startup_blocker_stage(capture)
                     if retryable_startup_blocker_stage:
                         tmux_kill_session(tmux_name)
                         if bridge_summary_path is not None:
@@ -1301,9 +1316,8 @@ class SkillsBenchLocalAcpRelay:
                             bridge_summary_path=bridge_summary_path,
                             thread_prewarm_observed=thread_prewarm_observed,
                             goal_prompt_file_used=goal_prompt_file_used,
-                            goal_command_submission_method=(
-                                goal_command_submission_method
-                            ),
+                            goal_command_submission_method=goal_command_submission_method,
+                            goal_kickoff_prompt_submitted=goal_kickoff_prompt_submitted,
                         )
                         return _recoverable_codex_turn_failure_message(
                             "codex_cli_goal_" + retryable_startup_blocker_stage
@@ -1452,7 +1466,7 @@ class SkillsBenchLocalAcpRelay:
                         )
                     if (
                         not first_action_seen
-                        and _codex_cli_goal_watchdog_expired(
+                        and codex_cli_goal_watchdog_expired(
                             deadline=first_action_deadline,
                             now=now,
                             turn_active=turn_active,
@@ -1475,6 +1489,9 @@ class SkillsBenchLocalAcpRelay:
                             goal_command_submission_method=(
                                 goal_command_submission_method
                             ),
+                            goal_kickoff_prompt_submitted=(
+                                goal_kickoff_prompt_submitted
+                            ),
                         )
                         return _recoverable_codex_turn_failure_message(
                             "codex_exec_first_action_timeout"
@@ -1482,7 +1499,7 @@ class SkillsBenchLocalAcpRelay:
                     if (
                         meaningful_progress_required
                         and not meaningful_progress_seen
-                        and _codex_cli_goal_watchdog_expired(
+                        and codex_cli_goal_watchdog_expired(
                             deadline=meaningful_progress_deadline,
                             now=now,
                             turn_active=turn_active,
@@ -1717,6 +1734,7 @@ class SkillsBenchLocalAcpRelay:
                     thread_prewarm_observed=thread_prewarm_observed,
                     goal_prompt_file_used=goal_prompt_file_used,
                     goal_command_submission_method=goal_command_submission_method,
+                    goal_kickoff_prompt_submitted=goal_kickoff_prompt_submitted,
                     post_bridge_recovery_attempt_count=(
                         pre_bridge_recovery_attempt_count
                         + post_bridge_recovery_attempt_count
@@ -1777,6 +1795,7 @@ class SkillsBenchLocalAcpRelay:
         goal_prompt_file_used: bool = False,
         goal_command_submission_method: str = "",
         goal_slash_command_submitted: bool = True,
+        goal_kickoff_prompt_submitted: bool = False,
         post_bridge_recovery_attempt_count: int = 0,
         post_bridge_recovery_action: str = "",
         post_bridge_recovery_skip_reason: str = "",
@@ -1832,6 +1851,10 @@ class SkillsBenchLocalAcpRelay:
                 )[:40],
                 "goal_active_observed": bool(goal_active_observed),
                 "goal_terminal_observed": bool(goal_terminal_observed),
+                "goal_kickoff_prompt_submitted": bool(
+                    goal_kickoff_prompt_submitted
+                ),
+                "goal_kickoff_prompt_raw_text_recorded": False,
                 "first_action_observed": bool(first_action_observed),
                 "bridge_request_count": bridge_request_count,
                 "task_facing_success_count": task_facing_success_count,

--- a/loopx/codex_cli_goal_tui.py
+++ b/loopx/codex_cli_goal_tui.py
@@ -20,6 +20,11 @@ CODEX_CLI_GOAL_THREAD_PREWARM_PROMPT = (
     "joining LOOPX, GOAL, THREAD, and READY with underscores. Do not use tools."
 )
 CODEX_CLI_GOAL_TASK_PROMPT_FILENAME = "skillsbench-task-prompt.md"
+CODEX_CLI_GOAL_KICKOFF_PROMPT = (
+    "Start working on the active SkillsBench goal now. Read the referenced "
+    "task prompt file first, follow it exactly, and perform at least one "
+    "task-facing bridge action before reporting status."
+)
 CODEX_CLI_TUI_READY_STARTUP_GRACE_SEC = 15.0
 CODEX_CLI_TUI_READY_STABLE_SEC = 2.0
 
@@ -71,6 +76,8 @@ def build_codex_cli_tui_command(
     cmd = [
         codex_bin,
         "--no-alt-screen",
+        "--disable",
+        "apps",
         "-s",
         sandbox,
         "-a",
@@ -351,6 +358,92 @@ def codex_cli_tui_turn_active(capture: str) -> bool:
         if "queued follow-up inputs" in line:
             return True
     return False
+
+
+def codex_cli_goal_watchdog_expired(
+    *,
+    deadline: float,
+    now: float,
+    turn_active: bool,
+) -> bool:
+    """Keep bounded watchdogs from interrupting an active Codex turn."""
+
+    return bool(deadline and now >= deadline and not turn_active)
+
+
+def codex_cli_tui_retryable_startup_blocker_stage(capture: str) -> str:
+    """Classify public-safe Codex CLI TUI startup blockers from screen text."""
+
+    lowered = str(capture or "").lower()
+    if any(
+        marker in lowered
+        for marker in (
+            "rate limit",
+            "rate_limit",
+            "too many requests",
+            "status 429",
+            "error 429",
+        )
+    ):
+        return "rate_limit_before_goal_active"
+    return ""
+
+
+def codex_cli_goal_should_submit_kickoff(
+    *,
+    bridge_enabled: bool,
+    goal_active_observed: bool,
+    kickoff_submitted: bool,
+    turn_active: bool,
+    first_action_seen: bool,
+    capture: str,
+) -> bool:
+    return (
+        bridge_enabled
+        and goal_active_observed
+        and not kickoff_submitted
+        and not turn_active
+        and not first_action_seen
+        and codex_cli_tui_input_prompt_visible(capture)
+    )
+
+
+def codex_cli_goal_should_ignore_stale_terminal(
+    *,
+    goal_failed_now: bool,
+    kickoff_submitted: bool,
+    first_action_seen: bool,
+    turn_active: bool,
+    first_action_deadline: float,
+    now: float,
+) -> bool:
+    return (
+        goal_failed_now
+        and kickoff_submitted
+        and not first_action_seen
+        and (turn_active or (first_action_deadline and now < first_action_deadline))
+    )
+
+
+def codex_cli_goal_reset_pre_bridge_deadlines(
+    *,
+    now: float,
+    first_action_timeout_sec: float,
+    goal_active_deadline: float,
+    goal_active_timeout_sec: float,
+    first_action_deadline: float,
+    meaningful_progress_deadline: float,
+) -> tuple[float, float, float]:
+    timeout = max(1.0, float(first_action_timeout_sec or 0.0))
+    return (
+        now + max(1.0, float(goal_active_timeout_sec or 0.0))
+        if goal_active_deadline
+        else goal_active_deadline,
+        now + timeout if first_action_deadline else first_action_deadline,
+        now + max(1.0, timeout)
+        if meaningful_progress_deadline
+        else meaningful_progress_deadline,
+    )
 
 
 def wait_for_codex_cli_tui_ready(


### PR DESCRIPTION
## Summary
- disable Codex App connectors in the SkillsBench Codex CLI `/goal` TUI worker with `--disable apps`
- add a single kickoff prompt after `Goal active` when the TUI is idle and no bridge request has happened yet
- record kickoff as public-safe trace booleans without storing the prompt text

## Validation
- `python3 examples/skillsbench-codex-cli-goal-route-smoke.py`
- `python3 -m py_compile loopx/benchmark_adapters/skillsbench_acp_relay.py loopx/codex_cli_goal_tui.py`
- exact-commit remote runner validation on quantum-numerical-simulation reached the kickoff-submitted layer, but is blocked before bridge countability because the remote Codex CLI login returns `refresh token revoked`; user gate `todo_1bbc585f6afa` tracks refreshing remote Codex CLI auth before replay.

## Boundary
- no scoring/task semantics changes
- no benchmark raw task text, raw trajectories, verifier tails, credentials, or local/private logs committed
