### PR TITLE
Fail closed on missing agent vision baselines

### DIFF
--- a/docs/reference/protocols/goal-vision-replan-contract-v0.md
+++ b/docs/reference/protocols/goal-vision-replan-contract-v0.md
@@ -129,8 +129,10 @@ Valid checkpoint decisions are:
 
 - `patched`: the refresh wrote a bounded `agent_vision` packet for the same
   `agent_id`;
-- `unchanged_with_reason`: the current per-agent vision still applies, with a
-  compact public-safe reason;
+- `unchanged_with_reason`: an already persisted current per-agent vision still
+  applies, with a compact public-safe reason. A reason cannot create the first
+  vision baseline; without one, the checkpoint remains `missing_required` and
+  requires `write_vision_patch`;
 - `retired_or_superseded`: the frontier was explicitly closed, superseded, or
   given a no-follow-up rationale;
 - `missing_required`: the turn was material but did not make a per-agent vision

--- a/examples/project/goal-vision-refresh-state-budget-smoke.py
+++ b/examples/project/goal-vision-refresh-state-budget-smoke.py
@@ -30,7 +30,12 @@ def write_fixture(root: Path) -> tuple[Path, Path, Path]:
         "---\n\n"
         "# Goal Vision Budget Fixture\n\n"
         "## Next Action\n\n"
-        "- Refresh the compact goal vision packet.\n",
+        "- Refresh the compact goal vision packet.\n\n"
+        "## Agent Todo\n\n"
+        "- [ ] Monitor the bounded fixture without replacing advancement.\n"
+        "  <!-- loopx:todo todo_id=todo_123456789abc status=open "
+        "task_class=continuous_monitor action_kind=monitor claimed_by=research-curator "
+        "target_key=fixture-monitor cadence=1h next_due_at=2099-01-01T00:00:00Z -->\n",
         encoding="utf-8",
     )
     registry_path.parent.mkdir(parents=True)
@@ -142,6 +147,33 @@ def run_status(registry_path: Path, runtime: Path) -> dict:
     return payload(result)
 
 
+def run_quota(registry_path: Path, runtime: Path) -> dict:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "--registry",
+            str(registry_path),
+            "--runtime-root",
+            str(runtime),
+            "--format",
+            "json",
+            "quota",
+            "should-run",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+    return payload(result)
+
+
 def payload(result: subprocess.CompletedProcess[str]) -> dict:
     return json.loads(result.stdout)
 
@@ -175,6 +207,50 @@ def main() -> int:
                 "validation": {"write_correctness_checked": True},
             },
         )
+        missing_baseline = payload(
+            run_cli(
+                registry_path,
+                runtime,
+                inline_vision_args=[
+                    "--vision-unchanged-reason",
+                    "A reason cannot stand in for a first per-agent vision baseline.",
+                ],
+                check=True,
+                dry_run=False,
+            )
+        )
+        missing_baseline_checkpoint = missing_baseline["vision_checkpoint"]
+        assert missing_baseline_checkpoint["required"] is True, missing_baseline
+        assert missing_baseline_checkpoint["satisfied"] is False, missing_baseline
+        assert missing_baseline_checkpoint["decision"] == "missing_required", (
+            missing_baseline
+        )
+        assert missing_baseline_checkpoint["missing_baseline"] is True, (
+            missing_baseline
+        )
+        assert missing_baseline_checkpoint["required_resolution"] == [
+            "write_vision_patch",
+            "record_no_followup",
+            "link_successor_or_supersede",
+        ], missing_baseline
+        missing_baseline_quota = run_quota(registry_path, runtime)
+        assert missing_baseline_quota["effective_action"] == (
+            "autonomous_replan_required"
+        ), missing_baseline_quota
+        assert missing_baseline_quota["interaction_contract"]["agent_channel"][
+            "must_attempt"
+        ] is True, missing_baseline_quota
+        assert missing_baseline_quota["goal_frontier_projection"]["acceptance_gaps"][
+            0
+        ]["kind"] == "vision_checkpoint_missing", missing_baseline_quota
+        missing_baseline_gap = missing_baseline_quota["goal_frontier_projection"][
+            "acceptance_gaps"
+        ][0]
+        assert missing_baseline_gap["missing_baseline"] is True, missing_baseline_gap
+        assert "record an unchanged reason" not in missing_baseline_gap[
+            "acceptance_summary"
+        ], missing_baseline_gap
+
         valid = payload(
             run_cli(registry_path, runtime, vision_path=valid_path, check=True)
         )

--- a/loopx/control_plane/goals/goal_frontier.py
+++ b/loopx/control_plane/goals/goal_frontier.py
@@ -277,7 +277,22 @@ def latest_agent_vision_from_status_payload(
 ) -> dict[str, Any] | None:
     """Return the newest compact agent vision packet visible in run history."""
 
-    for run in _latest_runs_for_goal(status_payload, goal_id=goal_id):
+    return latest_agent_vision_from_runs(
+        _latest_runs_for_goal(status_payload, goal_id=goal_id),
+        goal_id=goal_id,
+        agent_id=agent_id,
+    )
+
+
+def latest_agent_vision_from_runs(
+    runs: list[dict[str, Any]],
+    *,
+    goal_id: str,
+    agent_id: str | None,
+) -> dict[str, Any] | None:
+    """Return the newest active vision from newest-first compact run records."""
+
+    for run in runs:
         vision = run.get("agent_vision")
         if not isinstance(vision, dict):
             if _run_retires_prior_agent_vision(run, agent_id=agent_id):
@@ -348,6 +363,7 @@ def latest_missing_vision_checkpoint_from_status_payload(
             "required_resolution": checkpoint.get("required_resolution")
             if isinstance(checkpoint.get("required_resolution"), list)
             else [],
+            "missing_baseline": checkpoint.get("missing_baseline") is True,
             "generated_at": run.get("generated_at"),
         }
     return None
@@ -453,20 +469,29 @@ def acceptance_gaps_from_vision_checkpoint(
         if isinstance(trigger, dict) and str(trigger.get("kind") or "").strip()
     ]
     trigger_text = ", ".join(trigger_kinds[:3]) or "required vision checkpoint"
+    missing_baseline = checkpoint.get("missing_baseline") is True
     gap: dict[str, Any] = {
         "kind": VISION_CHECKPOINT_MISSING_TRIGGER,
         "source": "latest_vision_checkpoint",
         "agent_id": checkpoint.get("agent_id"),
         "decision": checkpoint.get("decision"),
         "replan_trigger_summary": (
-            "refresh-state closed a material segment without a per-agent vision "
+            "refresh-state tried to keep vision unchanged without a persisted "
+            f"per-agent baseline; triggers={trigger_text}"
+            if missing_baseline
+            else "refresh-state closed a material segment without a per-agent vision "
             f"decision; triggers={trigger_text}"
         ),
         "acceptance_summary": (
-            "Write a bounded agent vision patch, record an unchanged reason, "
+            "Write a bounded agent vision patch, or retire/supersede the frontier "
+            "with an explicit rationale."
+            if missing_baseline
+            else "Write a bounded agent vision patch, record an unchanged reason, "
             "or retire/supersede the frontier with an explicit rationale."
         ),
     }
+    if missing_baseline:
+        gap["missing_baseline"] = True
     generated_at = _compact_projection_text(checkpoint.get("generated_at"), limit=80)
     if generated_at:
         gap["generated_at"] = generated_at

--- a/loopx/control_plane/runtime/run_compaction.py
+++ b/loopx/control_plane/runtime/run_compaction.py
@@ -58,6 +58,7 @@ VISION_CHECKPOINT_COMPACT_FIELDS = (
     "decision",
     "agent_vision_state",
     "unchanged_reason",
+    "missing_baseline",
 )
 VISION_CHECKPOINT_TRIGGER_FIELDS = (
     "kind",

--- a/loopx/state_refresh.py
+++ b/loopx/state_refresh.py
@@ -16,10 +16,16 @@ from .control_plane.work_items.repair_delta import (
 from .feedback import validate_local_control_text, validate_public_safe_text
 from .file_lock import exclusive_file_lock
 from .global_registry import sync_project_registry_to_global
-from .history import load_registry, reserve_unique_run_paths, unique_run_paths
+from .history import (
+    load_index,
+    load_registry,
+    reserve_unique_run_paths,
+    unique_run_paths,
+)
 from .control_plane.runtime.local_state_write_correctness import build_local_state_write_correctness_dry_run_packet
 from .paths import resolve_runtime_root
 from .control_plane.goals.goal_vision import normalize_goal_vision_packet
+from .control_plane.goals.goal_frontier import latest_agent_vision_from_runs
 from .registry import registry_goals, resolve_state_file
 from .runtime import validate_goal_id_path_segment
 from .state_projection import state_projection_gap_warning
@@ -221,6 +227,7 @@ def build_vision_checkpoint(
     *,
     agent_id: str | None,
     agent_vision: dict[str, Any] | None,
+    existing_agent_vision: dict[str, Any] | None,
     vision_unchanged_reason: str | None,
     delivery_outcome: str | None,
     autonomous_replan_recorded: bool,
@@ -245,13 +252,16 @@ def build_vision_checkpoint(
     delta_kinds = set(repair_delta_kinds or [])
     unchanged = normalize_vision_unchanged_reason(vision_unchanged_reason)
 
-    required = bool(triggers)
+    required = bool(triggers or unchanged)
     if agent_vision:
         decision = "patched"
         satisfied = True
-    elif unchanged:
+    elif unchanged and existing_agent_vision:
         decision = "unchanged_with_reason"
         satisfied = True
+    elif unchanged:
+        decision = "missing_required"
+        satisfied = False
     elif delta_kinds & {"no_followup", "successor_or_supersede"}:
         decision = "retired_or_superseded"
         satisfied = True
@@ -272,17 +282,21 @@ def build_vision_checkpoint(
     }
     if agent_vision:
         checkpoint["agent_vision_state"] = agent_vision.get("state")
-    if unchanged:
+    if unchanged and existing_agent_vision:
         checkpoint["unchanged_reason"] = unchanged
+        checkpoint["agent_vision_state"] = existing_agent_vision.get("state")
+    elif unchanged:
+        checkpoint["missing_baseline"] = True
+        checkpoint["rejected_unchanged_reason"] = unchanged
     if delta_kinds:
         checkpoint["repair_delta_kinds"] = sorted(delta_kinds)
     if not satisfied:
-        checkpoint["required_resolution"] = [
-            "write_vision_patch",
-            "record_unchanged_reason",
-            "record_no_followup",
-            "link_successor_or_supersede",
-        ]
+        checkpoint["required_resolution"] = ["write_vision_patch"]
+        if not checkpoint.get("missing_baseline"):
+            checkpoint["required_resolution"].append("record_unchanged_reason")
+        checkpoint["required_resolution"].extend(
+            ["record_no_followup", "link_successor_or_supersede"]
+        )
     return checkpoint
 
 
@@ -837,6 +851,24 @@ def refresh_state_run(
     normalized_vision_unchanged_reason = normalize_vision_unchanged_reason(
         vision_unchanged_reason
     )
+    existing_agent_vision: dict[str, Any] | None = None
+    if normalized_agent_id and normalized_vision_unchanged_reason:
+        existing_runs, _ = load_index(
+            runtime_root / "goals" / safe_goal_id / "runs" / "index.jsonl"
+        )
+        newest_first_runs = [
+            run
+            for _, run in sorted(
+                enumerate(existing_runs),
+                key=lambda item: (str(item[1].get("generated_at") or ""), item[0]),
+                reverse=True,
+            )
+        ]
+        existing_agent_vision = latest_agent_vision_from_runs(
+            newest_first_runs,
+            goal_id=safe_goal_id,
+            agent_id=normalized_agent_id,
+        )
     generated_at = now_local()
     active_state_next_action_update: dict[str, Any] | None = None
     if normalized_next_action:
@@ -885,6 +917,7 @@ def refresh_state_run(
     vision_checkpoint = build_vision_checkpoint(
         agent_id=normalized_agent_id or None,
         agent_vision=agent_vision,
+        existing_agent_vision=existing_agent_vision,
         vision_unchanged_reason=normalized_vision_unchanged_reason,
         delivery_outcome=normalized_delivery_outcome,
         autonomous_replan_recorded=bool(autonomous_replan_recorded),


### PR DESCRIPTION
## Motivation

A required vision checkpoint could accept an unchanged reason even when the agent had never persisted a vision. Long-running campaigns could therefore lose their advancement acceptance gap and fall into monitor-only quiet.

## Implementation

- Reuse the existing run-history vision reducer to resolve the current per-agent baseline during refresh-state.
- Reject unchanged-with-reason as a satisfying decision when no baseline exists; project missing_required plus missing_baseline instead.
- Preserve missing-baseline context through compact history and quota acceptance-gap guidance.
- Document the first-baseline rule and cover the real refresh-state to quota path with a future-monitor fixture.

## Validation

- goal-vision-refresh-state-budget-smoke
- goal-vision-replan-contract-smoke
- quota-replan-decision-plane-smoke
- run-history-agent-context-retention-smoke
- run-compaction-readmodel-smoke
- heartbeat-quota-flow-smoke
- LoopX premerge canary: 4 direct checks and 17 selected checks passed; 0 failures, warnings, skips, or manual holds
- Public/private boundary scan clean across all 5 changed files
- Real OpenViking compatibility preview accepts unchanged-with-reason after a persisted campaign vision exists

## Risk

The behavior change is limited to an invalid first-checkpoint case. Existing agents with a persisted active vision keep unchanged-with-reason behavior; explicit retire/supersede paths remain available for bounded goals.