### PR TITLE
Fix quota spend after material monitor transitions

### DIFF
--- a/examples/control_plane/quota-material-monitor-spend-smoke.py
+++ b/examples/control_plane/quota-material-monitor-spend-smoke.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""Smoke-test quota accounting after a material monitor transition."""
+
+from __future__ import annotations
+
+import json
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from loopx.control_plane.quota.slot_accounting import (  # noqa: E402
+    build_quota_slot_preview_for_decision,
+)
+
+
+GOAL_ID = "material-monitor-spend"
+
+
+def write_run_index(runtime: Path, records: list[dict[str, Any]]) -> None:
+    index_path = runtime / "goals" / GOAL_ID / "runs" / "index.jsonl"
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    index_path.write_text(
+        "".join(json.dumps(record) + "\n" for record in records),
+        encoding="utf-8",
+    )
+
+
+def preview(runtime: Path) -> dict[str, Any]:
+    quota = {
+        "compute": 1.0,
+        "window_hours": 24,
+        "slot_minutes": 1,
+        "spent_slots": 0,
+        "allowed_slots": 1440,
+    }
+    before = {
+        "ok": True,
+        "goal_id": GOAL_ID,
+        "should_run": False,
+        "effective_action": "monitor_quiet_skip",
+        "state": "eligible",
+        "safe_bypass_allowed": False,
+        "quota": quota,
+    }
+    status = {
+        "runtime_root": str(runtime),
+        "attention_queue": {"items": [{"goal_id": GOAL_ID}]},
+        "run_history": {"goals": [{"id": GOAL_ID, "quota": quota}]},
+    }
+
+    return build_quota_slot_preview_for_decision(
+        status,
+        goal_id=GOAL_ID,
+        before=before,
+        after_decision=lambda _: {"state": "eligible", "should_run": False},
+        quota_status_builder=lambda goal, **_: goal["quota"],
+        self_repair_spend_actions=frozenset(),
+    )
+
+
+def main() -> int:
+    unchanged_poll = {
+        "generated_at": "2026-01-01T00:00:00+00:00",
+        "goal_id": GOAL_ID,
+        "classification": "quota_monitor_poll",
+        "delivery_outcome": "surface_only",
+        "material_change": False,
+    }
+    material_poll = {
+        "generated_at": "2026-01-01T00:01:00+00:00",
+        "goal_id": GOAL_ID,
+        "classification": "quota_monitor_poll",
+        "delivery_outcome": "outcome_progress",
+        "material_change": True,
+    }
+    spent = {
+        "generated_at": "2026-01-01T00:02:00+00:00",
+        "goal_id": GOAL_ID,
+        "classification": "quota_slot_spent",
+    }
+
+    with tempfile.TemporaryDirectory(prefix="loopx-material-monitor-spend-") as tmp:
+        runtime = Path(tmp) / "runtime"
+
+        write_run_index(runtime, [unchanged_poll])
+        unchanged_preview = preview(runtime)
+        assert unchanged_preview["ok"] is False, unchanged_preview
+
+        write_run_index(runtime, [unchanged_poll, material_poll])
+        material_preview = preview(runtime)
+        assert material_preview["ok"] is True, material_preview
+        assert material_preview["delivery_completion_spend"] is True, material_preview
+        assert material_preview["delivery_run_classification"] == "quota_monitor_poll", material_preview
+        assert material_preview["delivery_run_generated_at"] == material_poll["generated_at"], material_preview
+
+        write_run_index(runtime, [unchanged_poll, material_poll, spent])
+        duplicate_preview = preview(runtime)
+        assert duplicate_preview["ok"] is False, duplicate_preview
+
+    print("quota-material-monitor-spend-smoke ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/examples/control_plane/quota-material-monitor-spend-smoke.py
+++ b/examples/control_plane/quota-material-monitor-spend-smoke.py
@@ -16,6 +16,7 @@ if str(REPO_ROOT) not in sys.path:
 
 from loopx.control_plane.quota.slot_accounting import (  # noqa: E402
     build_quota_slot_preview_for_decision,
+    build_quota_slot_spend_event,
 )
 
 
@@ -31,7 +32,7 @@ def write_run_index(runtime: Path, records: list[dict[str, Any]]) -> None:
     )
 
 
-def preview(runtime: Path) -> dict[str, Any]:
+def preview(runtime: Path, *, agent_id: str | None = None) -> dict[str, Any]:
     quota = {
         "compute": 1.0,
         "window_hours": 24,
@@ -58,9 +59,13 @@ def preview(runtime: Path) -> dict[str, Any]:
         status,
         goal_id=GOAL_ID,
         before=before,
-        after_decision=lambda _: {"state": "eligible", "should_run": False},
+        after_decision=lambda _: {
+            **before,
+            "quota": {**quota, "spent_slots": 1},
+        },
         quota_status_builder=lambda goal, **_: goal["quota"],
         self_repair_spend_actions=frozenset(),
+        agent_id=agent_id,
     )
 
 
@@ -78,6 +83,7 @@ def main() -> int:
         "classification": "quota_monitor_poll",
         "delivery_outcome": "outcome_progress",
         "material_change": True,
+        "agent_id": "codex-monitor-a",
     }
     spent = {
         "generated_at": "2026-01-01T00:02:00+00:00",
@@ -93,14 +99,34 @@ def main() -> int:
         assert unchanged_preview["ok"] is False, unchanged_preview
 
         write_run_index(runtime, [unchanged_poll, material_poll])
-        material_preview = preview(runtime)
+        material_preview = preview(runtime, agent_id="codex-monitor-a")
         assert material_preview["ok"] is True, material_preview
         assert material_preview["delivery_completion_spend"] is True, material_preview
         assert material_preview["delivery_run_classification"] == "quota_monitor_poll", material_preview
         assert material_preview["delivery_run_generated_at"] == material_poll["generated_at"], material_preview
+        assert material_preview["delivery_run_agent_id"] == "codex-monitor-a", material_preview
+        spend_event = build_quota_slot_spend_event(
+            material_preview,
+            self_repair_spend_actions=frozenset(),
+        )
+        assert spend_event["agent_id"] == "codex-monitor-a", spend_event
+        assert spend_event["quota_event"]["delivery_run_agent_id"] == "codex-monitor-a", spend_event
+
+        cross_agent_preview = preview(runtime, agent_id="codex-monitor-b")
+        assert cross_agent_preview["ok"] is False, cross_agent_preview
+
+        unscoped_call_preview = preview(runtime)
+        assert unscoped_call_preview["ok"] is True, unscoped_call_preview
+        assert unscoped_call_preview["delivery_run_agent_id"] == "codex-monitor-a", unscoped_call_preview
+
+        unscoped_material_poll = {key: value for key, value in material_poll.items() if key != "agent_id"}
+        write_run_index(runtime, [unchanged_poll, unscoped_material_poll])
+        legacy_run_preview = preview(runtime, agent_id="codex-monitor-a")
+        assert legacy_run_preview["ok"] is True, legacy_run_preview
+        assert legacy_run_preview["delivery_run_agent_id"] is None, legacy_run_preview
 
         write_run_index(runtime, [unchanged_poll, material_poll, spent])
-        duplicate_preview = preview(runtime)
+        duplicate_preview = preview(runtime, agent_id="codex-monitor-a")
         assert duplicate_preview["ok"] is False, duplicate_preview
 
     print("quota-material-monitor-spend-smoke ok")

--- a/loopx/control_plane/quota/slot_accounting.py
+++ b/loopx/control_plane/quota/slot_accounting.py
@@ -114,7 +114,10 @@ def _latest_unspent_accountable_delivery_run(runtime_root: Path, goal_id: str) -
             continue
         if classification == QUOTA_SLOT_SPENT_CLASSIFICATION:
             return None
-        if classification == QUOTA_MONITOR_POLL_CLASSIFICATION:
+        if (
+            classification == QUOTA_MONITOR_POLL_CLASSIFICATION
+            and run.get("material_change") is not True
+        ):
             return None
         delivery_outcome = normalize_delivery_outcome(run.get("delivery_outcome"))
         if delivery_outcome in ACCOUNTABLE_DELIVERY_OUTCOMES:

--- a/loopx/control_plane/quota/slot_accounting.py
+++ b/loopx/control_plane/quota/slot_accounting.py
@@ -105,9 +105,15 @@ def _load_goal_run_index_records(runtime_root: Path, goal_id: str) -> list[dict[
     return records
 
 
-def _latest_unspent_accountable_delivery_run(runtime_root: Path, goal_id: str) -> dict[str, Any] | None:
+def _latest_unspent_accountable_delivery_run(
+    runtime_root: Path,
+    goal_id: str,
+    *,
+    agent_id: str | None = None,
+) -> dict[str, Any] | None:
     """Return the latest run only when it is a delivery that still needs accounting."""
 
+    safe_agent_id = normalize_todo_claimed_by(agent_id)
     for run in reversed(_load_goal_run_index_records(runtime_root, goal_id)):
         classification = str(run.get("classification") or "").strip()
         if classification == QUOTA_SLOT_VOIDED_CLASSIFICATION:
@@ -121,6 +127,9 @@ def _latest_unspent_accountable_delivery_run(runtime_root: Path, goal_id: str) -
             return None
         delivery_outcome = normalize_delivery_outcome(run.get("delivery_outcome"))
         if delivery_outcome in ACCOUNTABLE_DELIVERY_OUTCOMES:
+            run_agent_id = normalize_todo_claimed_by(run.get("agent_id"))
+            if safe_agent_id and run_agent_id and safe_agent_id != run_agent_id:
+                return None
             return run
         return None
     return None
@@ -176,7 +185,11 @@ def build_quota_slot_preview_for_decision(
         }
     raw_runtime_root = status_payload.get("runtime_root")
     delivery_completion_run = (
-        _latest_unspent_accountable_delivery_run(Path(str(raw_runtime_root)).expanduser(), safe_goal_id)
+        _latest_unspent_accountable_delivery_run(
+            Path(str(raw_runtime_root)).expanduser(),
+            safe_goal_id,
+            agent_id=safe_requested_agent_id,
+        )
         if raw_runtime_root
         else None
     )
@@ -280,6 +293,9 @@ def build_quota_slot_preview_for_decision(
         if delivery_completion_run
         else None,
         "delivery_run_classification": delivery_completion_run.get("classification")
+        if delivery_completion_run
+        else None,
+        "delivery_run_agent_id": normalize_todo_claimed_by(delivery_completion_run.get("agent_id"))
         if delivery_completion_run
         else None,
         "delivery_run_recommended_action": delivery_completion_run.get("recommended_action")
@@ -408,6 +424,7 @@ def build_quota_slot_spend_event(
             ),
             "delivery_run_generated_at": preview.get("delivery_run_generated_at"),
             "delivery_run_classification": preview.get("delivery_run_classification"),
+            "delivery_run_agent_id": preview.get("delivery_run_agent_id"),
             "delivery_run_recommended_action": delivery_run_action or None,
             "before": before_compact,
             "after": after_compact,


### PR DESCRIPTION
## Summary

- allow a material `quota_monitor_poll` with an accountable delivery outcome to be consumed by the next quota spend
- keep unchanged monitor polls non-accountable
- keep duplicate accounting blocked after a `quota_slot_spent` event

## Motivation

The heartbeat contract says a material monitor transition may spend once after validated writeback. The monitor command already records `material_change=true` and `delivery_outcome=outcome_progress`, but slot accounting rejected every monitor classification before reading those fields. This stranded the writeback-to-spend lifecycle.

## Validation

- `python3 examples/control_plane/quota-material-monitor-spend-smoke.py`
- `python3 examples/control_plane/quota-spend-agent-identity-smoke.py`
- `python3 examples/control_plane/monitor-poll-writeback-smoke.py`
- `python3 -m py_compile loopx/control_plane/quota/slot_accounting.py`
- `python3 -m loopx.cli --format json canary premerge --from-git-diff`
  - selected 14, failures 0, warnings 0, manual holds 0
- public/private boundary scan: clean, 2 files scanned

## Risk

The allowance is narrow: both `material_change=true` and an accountable `delivery_outcome` are required. Ordinary monitor no-change events remain non-spendable, and an existing spend event still prevents duplicate accounting.

## Merge decision

Hold for independent review because this changes quota hot-path runtime behavior, despite the narrow diff and passing premerge gate.
