### PR TITLE
Fix runtime capability projection in thin heartbeats

### DIFF
--- a/docs/heartbeat-automation-prompt.md
+++ b/docs/heartbeat-automation-prompt.md
@@ -150,6 +150,13 @@ The generated quota guard and spend command preserve the same declarations.
 Do not declare credentials, production access, or another capability merely to
 bypass a gate; the launcher must actually provide it.
 
+When a thin prompt is generated without explicit declarations, it still tells
+the runtime worker to project non-basic capabilities that are actually present
+with `--available-capability`. This prevents an observed network or polling
+capability from becoming a false user gate without guessing capabilities the
+host does not have. Explicit generator arguments remain preferred for hosts
+whose capabilities are known when the automation is installed.
+
 - for small AGENTS-eligible validated changes, self-merge and complete the todo
   with `--self-merged --evidence "<commit and validation summary>"`;
 - for an independent continuation, create `--next-agent-todo` and optionally

--- a/examples/control_plane/heartbeat-prompt-smoke.py
+++ b/examples/control_plane/heartbeat-prompt-smoke.py
@@ -135,7 +135,7 @@ def main() -> int:
     assert_no_project_specific_prompt_leaks("brief", str(brief_payload["task_body"]))
     assert_no_project_specific_prompt_leaks("thin", str(thin_payload["task_body"]))
     thin_task = str(thin_payload["task_body"])
-    assert "Runtime capabilities -> `--available-capability`, never user gates." in thin_task, thin_task
+    assert "Observed runtime capabilities -> `--available-capability`, never user gates." in thin_task, thin_task
     assert payload["quota_guard_command"] == (
         'loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" '
         "quota should-run --goal-id public-heartbeat-goal"

--- a/examples/control_plane/heartbeat-prompt-smoke.py
+++ b/examples/control_plane/heartbeat-prompt-smoke.py
@@ -134,6 +134,8 @@ def main() -> int:
     assert_no_project_specific_prompt_leaks("compact", str(compact_payload["task_body"]))
     assert_no_project_specific_prompt_leaks("brief", str(brief_payload["task_body"]))
     assert_no_project_specific_prompt_leaks("thin", str(thin_payload["task_body"]))
+    thin_task = str(thin_payload["task_body"])
+    assert "Runtime capabilities -> `--available-capability`, never user gates." in thin_task, thin_task
     assert payload["quota_guard_command"] == (
         'loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" '
         "quota should-run --goal-id public-heartbeat-goal"
@@ -359,6 +361,8 @@ def main() -> int:
         'install_script="$HOME/loopx/scripts/install-local.sh"',
         "loopx doctor >/dev/null",
         'loopx --format json --registry "$HOME/.codex/loopx/registry.global.json" quota should-run --goal-id <GOAL_ID>',
+        "project non-basic capabilities that are actually present",
+        "without guessing capabilities the host does not have",
         "If that preflight still fails",
         "should_run=false",
         "state=operator_gate",

--- a/loopx/heartbeat_prompt.py
+++ b/loopx/heartbeat_prompt.py
@@ -45,7 +45,7 @@ SCHEDULER_HINT_THIN_RULE = (
     "RRULE then run `ack_hint.cli_args`; CLI/Claude final-check; no spend."
 )
 RUNTIME_CAPABILITY_PROJECTION_THIN_RULE = (
-    "Runtime capabilities -> `--available-capability`, never user gates."
+    "Observed runtime capabilities -> `--available-capability`, never user gates."
 )
 INTERFACE_BUDGET_CHARS = {
     "full": 12_000,

--- a/loopx/heartbeat_prompt.py
+++ b/loopx/heartbeat_prompt.py
@@ -44,11 +44,14 @@ SCHEDULER_HINT_THIN_RULE = (
     "Apply `scheduler_hint`: if App `stateful_backoff.apply_needed`, "
     "RRULE then run `ack_hint.cli_args`; CLI/Claude final-check; no spend."
 )
+RUNTIME_CAPABILITY_PROJECTION_THIN_RULE = (
+    "Runtime capabilities -> `--available-capability`, never user gates."
+)
 INTERFACE_BUDGET_CHARS = {
     "full": 12_000,
     "compact": 6_000,
     "brief": 3_500,
-    "thin": 1_500,
+    "thin": 1_570,
 }
 
 
@@ -914,6 +917,7 @@ Inspect registry/global quota, active state, status/history, repo; run
 {quota_guard_instruction}; follow `interaction_contract`. If action_required/open_count:
 Chinese concrete todos/questions; never only "owner gate"; missing ->
 "具体 user todo 未投影，需修复 LoopX 状态投影". If false/0: quiet/no-user-todo.
+{RUNTIME_CAPABILITY_PROJECTION_THIN_RULE}
 {SCHEDULER_HINT_THIN_RULE}
 Bounded batch/quiet no-op; spend after writeback.
 Plans/done -> LoopX todo/rationale; 2 no-progress -> self-repair.


### PR DESCRIPTION
## Motivation

A generated thin heartbeat without explicit host capability arguments tells the worker to run a bare quota guard. If the live runtime actually has network or polling capability, that observed capability can be omitted and an executable todo can be misclassified as a user gate.

## Implementation

- Teach the thin dispatcher to pass capabilities actually observed at runtime with `--available-capability` and never turn them into user gates.
- Keep explicit generator declarations as the deterministic path for hosts whose capabilities are known at install time.
- Extend the thin interface budget by 70 characters for this safety invariant.

## Validation

- `PYTHONPATH=. python3 examples/control_plane/heartbeat-prompt-smoke.py`
- OpenViking registry-backed thin prompt replay: runtime projection rule present, interface budget 1513/1570.
- `python3 -m py_compile loopx/heartbeat_prompt.py examples/control_plane/heartbeat-prompt-smoke.py`
- `loopx check` on all three changed public surfaces: 8 checks, 0 errors, 0 warnings.
- `loopx canary premerge --from-git-diff`: 14 selected checks passed, 0 failures, 0 manual holds.

## Risk

This changes prompt guidance only; it does not grant capabilities or assume network is universally available. The worker must project only capabilities the current host actually exposes.