### PR TITLE
Keep Lark auth secrets out of Kanban commands

### DIFF
--- a/docs/lark-kanban-control-plane-adapter.md
+++ b/docs/lark-kanban-control-plane-adapter.md
@@ -15,6 +15,20 @@ and newly discovered tasks should be created with `loopx todo add`,
 `loopx todo complete --next-*`, `loopx todo supersede`, or a typed planning
 intake, then projected back to Lark with `sync-loopx-todos`.
 
+## Authentication Boundary
+
+The adapter passes Lark resource identifiers such as `base_token`, `table_id`,
+`view_id`, and `record_id` to `lark-cli`. These identifiers remain visible in
+command evidence because they are useful for operating and auditing the board;
+the adapter does not treat them as AK/SK secrets.
+
+Authentication stays inside the selected `lark-cli` identity and its local auth
+store. Adapter-generated commands must never contain application auth material
+such as AK/SK or app-secret arguments. The command runner rejects those inline
+secret-bearing options before a subprocess starts. Use `lark-cli auth
+login/status` to manage authentication instead of extending the Kanban config
+or command payload with auth material.
+
 ## Mapping
 
 | LoopX concept | Lark Base field |

--- a/examples/lark-kanban-control-plane-smoke.py
+++ b/examples/lark-kanban-control-plane-smoke.py
@@ -23,6 +23,7 @@ from loopx.presentation.sinks.lark.kanban import (  # noqa: E402
     STATUS_REVIEW,
     STATUS_TODO,
     LarkKanbanConfig,
+    _run_command,
     _lark_record_from_todo_block,
     build_create_board_plan,
     default_lark_kanban_config_path,
@@ -42,6 +43,45 @@ from loopx.presentation.sinks.lark.kanban import (  # noqa: E402
 
 existing_setup_calls: list[list[str]] = []
 existing_setup_view_list_count = 0
+
+
+def credential_boundary_smoke() -> None:
+    runner_called = False
+
+    def forbidden_runner(
+        args: list[str], cwd: Path | None, timeout: float | None
+    ) -> dict[str, object]:
+        nonlocal runner_called
+        runner_called = True
+        raise AssertionError("credential-bearing command reached the runner")
+
+    for argument in ("--ak", "--sk", "--app-secret", "--access-token"):
+        try:
+            _run_command(
+                ["lark-cli", "base", "+record-list", argument, "fixture-secret"],
+                execute=True,
+                runner=forbidden_runner,
+            )
+        except ValueError as error:
+            assert "must remain in lark-cli auth" in str(error), error
+        else:
+            raise AssertionError(f"credential argument was accepted: {argument}")
+    assert runner_called is False
+
+    dry_run = _run_command(
+        [
+            "lark-cli",
+            "base",
+            "+record-list",
+            "--base-token",
+            "base_public_fixture",
+            "--table-id",
+            "tbl_public_fixture",
+        ],
+        execute=False,
+    )
+    assert "base_public_fixture" in dry_run["command"], dry_run
+    assert "tbl_public_fixture" in dry_run["command"], dry_run
 
 
 def fixture_payload() -> dict[str, object]:
@@ -234,6 +274,7 @@ def run_cli(*extra_args: str) -> dict[str, object]:
 
 
 def main() -> int:
+    credential_boundary_smoke()
     global existing_setup_view_list_count
     schema = lark_kanban_schema_payload()
     assert schema["ok"] is True, schema

--- a/loopx/presentation/sinks/lark/kanban.py
+++ b/loopx/presentation/sinks/lark/kanban.py
@@ -41,6 +41,21 @@ DEFAULT_AGENT_ID = "codex-kanban-worker"
 DEFAULT_CLI_BIN = "lark-cli"
 DEFAULT_STATUS_QUEUE_VIEW = "Worker Queue"
 OPERATOR_CARD_FIELDS = ["Task", "Claim", "Priority", "User Gate", "Evidence", "Status"]
+_LARK_CREDENTIAL_ARGUMENTS = frozenset(
+    {
+        "--access-key",
+        "--access-token",
+        "--ak",
+        "--app-secret",
+        "--authorization",
+        "--bearer-token",
+        "--client-secret",
+        "--secret-key",
+        "--sk",
+        "--tenant-access-token",
+        "--user-access-token",
+    }
+)
 
 STATUS_TODO = "Todo"
 STATUS_CLAIMED = "Claimed"
@@ -449,6 +464,19 @@ def _run_command(
     cwd: Path | None = None,
     timeout_seconds: float | None = None,
 ) -> dict[str, Any]:
+    credential_argument = next(
+        (
+            argument.split("=", 1)[0].lower()
+            for argument in args
+            if argument.split("=", 1)[0].lower() in _LARK_CREDENTIAL_ARGUMENTS
+        ),
+        None,
+    )
+    if credential_argument:
+        raise ValueError(
+            f"{credential_argument} must remain in lark-cli auth; "
+            "the Kanban adapter never accepts inline credentials"
+        )
     command = shlex.join(args)
     if not execute:
         return {


### PR DESCRIPTION
## Motivation

The Kanban adapter should keep Base, table, view, and record identifiers visible for operations and audit. Real authentication material must remain owned by lark-cli auth and must never be added to adapter-generated command arguments.

## Implementation

- reject known AK/SK and secret-bearing auth options before the subprocess runner starts
- retain Base and table resource identifiers in command evidence
- document the authentication boundary and the lark-cli auth workflow
- add a generic smoke covering both rejection and allowed resource identifiers

## Validation

- python3 examples/lark-kanban-control-plane-smoke.py
- python3 -m py_compile loopx/presentation/sinks/lark/kanban.py examples/lark-kanban-control-plane-smoke.py
- loopx check on all three changed public files
- loopx canary premerge --from-git-diff: 14 selected checks passed, no manual holds

## Risk and uncovered areas

The guard only applies to adapter-generated argv. It intentionally does not redact normal Kanban resource identifiers or rewrite lark-cli output. Authentication storage and renewal remain lark-cli responsibilities.