### PR TITLE
Keep monitor lanes out of Explore branch budgets

### DIFF
--- a/docs/capabilities/explore/README.md
+++ b/docs/capabilities/explore/README.md
@@ -136,6 +136,8 @@ spend quota, or change the active state. Instead it emits a prediction
 packet with:
 
 - selected branches, confidence, hazards, and reason codes;
+- excluded `continuous_monitor` diagnostics, which remain visible but never
+  enter the exploration scheduler or consume branch width;
 - a dry-run A/B estimate comparing baseline serial execution with the
   DSpark-style selected prefix (`ab_result.estimated_speedup_vs_baseline`);
 - suggested `loopx todo claim` and `loopx task-lease acquire` commands for a
@@ -165,6 +167,15 @@ coordination work by default, because many exploration tasks are read-only.
 Use `--no-allow-unscoped-parallel` when the controller wants unknown scopes to
 collapse back to single-branch execution.
 
+Scope conflicts are based only on mutable `required_write_scopes`. Do not put a
+shared base checkout or an already-built immutable input in that field merely
+because multiple experiments read it. Represent reusable inputs with existing
+public-safe capability labels such as `shared_implementation:<name>` or
+`shared_artifact:<name>`, then give each experiment its own variant or launch
+output scope. Those lanes may run in parallel. If the shared build itself is
+still mutable, keep its path in `required_write_scopes`; the planner will
+correctly serialize lanes that could write the same artifact.
+
 ## Experimental Worker Branch Plan
 
 `loopx explore worker-branch-plan` is the worker-lane version of the same
@@ -172,6 +183,20 @@ experiment. It does not treat a branch as one todo. A worker branch is a
 predicted lane containing a small bundle of LoopX todos, an objective slice,
 required capabilities, write scopes, dependency hints, expected evidence,
 confidence, and suggested claim/lease commands.
+
+Sharing `shared_implementation:*` or `shared_artifact:*` capabilities does not
+make worker lanes mutually exclusive. This supports one shared implementation
+or artifact-build stage followed by independent long/short-style experiment
+lanes that write separate variant or launch directories. The shared inputs must
+be immutable for that execution wave; an in-progress shared build remains a
+write scope and therefore remains a real conflict.
+
+`continuous_monitor` todos are observation/control-plane lanes, not exploration
+work. The planner keeps them in `rejected_worker_branches` with
+`selection_status=excluded_non_exploration_lane`, but never bundles them with
+advancement todos or charges them against `worker_width`. A monitor transition
+may create or unblock a successor advancement todo through the normal todo
+lifecycle; that successor can participate in the next read-only planning call.
 
 This command is read-only and opt-in per goal. It is designed to sit on top of
 the existing LoopX harness, not beside it and not instead of it:

--- a/loopx/capabilities/explore/todo_branch_plan.py
+++ b/loopx/capabilities/explore/todo_branch_plan.py
@@ -38,6 +38,10 @@ TODO_BRANCH_PLAN_SCHEMA_VERSION = "loopx_explore_todo_branch_plan_v0"
 DEFAULT_BRANCH_WIDTH = 3
 MAX_BRANCH_WIDTH = 8
 TOKEN_PATTERN = re.compile(r"[A-Za-z0-9_:\-]{3,}")
+SHARED_DEPENDENCY_CAPABILITY_PREFIXES = (
+    "shared_artifact:",
+    "shared_implementation:",
+)
 
 
 def _tokenize(value: Any) -> set[str]:
@@ -73,6 +77,14 @@ def _required_write_scopes(item: Mapping[str, Any]) -> list[str]:
 
 def _required_capabilities(item: Mapping[str, Any]) -> list[str]:
     return normalize_required_capabilities(item.get("required_capabilities"))
+
+
+def _shared_dependency_capabilities(item: Mapping[str, Any]) -> list[str]:
+    return [
+        capability
+        for capability in _required_capabilities(item)
+        if capability.startswith(SHARED_DEPENDENCY_CAPABILITY_PREFIXES)
+    ]
 
 
 def _scopes_overlap(left: Sequence[str], right: Sequence[str]) -> bool:
@@ -196,6 +208,16 @@ def _claim_bucket(item: Mapping[str, Any], *, agent_id: str | None) -> int:
     return 2
 
 
+def _monitor_lane_exclusion(candidate: Mapping[str, Any]) -> dict[str, Any] | None:
+    if candidate.get("task_class") != TODO_TASK_CLASS_MONITOR:
+        return None
+    return {
+        **candidate,
+        "selection_status": "excluded_non_exploration_lane",
+        "exclusion_reason": "continuous_monitor_does_not_consume_exploration_budget",
+    }
+
+
 def _lane_id(todo_id: str, *, index: int) -> str:
     return f"branch_{index}_{todo_id.removeprefix('todo_')}"
 
@@ -263,6 +285,7 @@ def _disabled_todo_branch_plan(
         "required_contract": explore_harness_required_contract(default_profile="generic"),
         "issue_width": 0,
         "candidate_count": 0,
+        "exploration_candidate_count": 0,
         "selected_count": 0,
         "selected_branches": [],
         "rejected_candidates": [],
@@ -337,6 +360,7 @@ def build_explore_todo_branch_plan(
             "claimed_by": normalize_todo_claimed_by(item.get("claimed_by")) or "",
             "required_write_scopes": required_write_scopes,
             "required_capabilities": _required_capabilities(item),
+            "shared_dependency_capabilities": _shared_dependency_capabilities(item),
             "score": round(score, 2),
             "confidence": _branch_confidence(score, hazards=hazards),
             "expected_evidence_units": _branch_expected_evidence_units(
@@ -363,9 +387,19 @@ def build_explore_todo_branch_plan(
         )
     )
 
-    schedulable = [
+    monitor_lanes = [
+        exclusion
+        for candidate in candidates
+        if (exclusion := _monitor_lane_exclusion(candidate)) is not None
+    ]
+    exploration_candidates = [
         candidate
         for candidate in candidates
+        if candidate.get("task_class") != TODO_TASK_CLASS_MONITOR
+    ]
+    schedulable = [
+        candidate
+        for candidate in exploration_candidates
         if not (
             candidate.get("claimed_by")
             and candidate.get("claimed_by") != normalized_agent
@@ -380,9 +414,9 @@ def build_explore_todo_branch_plan(
     verification_budget = max(1, int(scheduler.get("selected_prefix_length") or 1))
 
     selected: list[dict[str, Any]] = []
-    rejected: list[dict[str, Any]] = []
+    rejected: list[dict[str, Any]] = list(monitor_lanes)
     selected_scopes: list[tuple[str, list[str]]] = []
-    for candidate in candidates:
+    for candidate in exploration_candidates:
         hazards = list(candidate.get("hazards") or [])
         scopes = _required_write_scopes(candidate)
         conflict_with = ""
@@ -484,12 +518,22 @@ def build_explore_todo_branch_plan(
         "allow_unscoped_parallel": bool(allow_unscoped_parallel),
         "source_todo_count": len(todos),
         "candidate_count": len(candidates),
+        "exploration_candidate_count": len(exploration_candidates),
         "selected_count": len(selected),
         "selected_branches": selected,
         "rejected_candidates": rejected[: max(0, normalized_width * 3)],
         "hazard_model": {
             "write_scope_conflicts": "skip speculative branch when declared write scopes overlap",
+            "shared_dependencies": (
+                "shared_artifact:* and shared_implementation:* capabilities are read-only "
+                "dependency labels, not write mutexes; mutable shared builds must remain in "
+                "required_write_scopes"
+            ),
             "claimed_by_other": "other-agent ownership is visible but not selected",
+            "monitor_lanes": (
+                "continuous_monitor todos stay visible as excluded diagnostics but never "
+                "enter the exploration scheduler or consume branch width"
+            ),
             "unscoped": (
                 "treated as speculative read-or-coordination work by default; disable with "
                 "--no-allow-unscoped-parallel"

--- a/loopx/capabilities/explore/worker_branch_plan.py
+++ b/loopx/capabilities/explore/worker_branch_plan.py
@@ -4,7 +4,11 @@ from copy import deepcopy
 import re
 from typing import Any, Mapping, Sequence
 
-from ...control_plane.todos.contract import normalize_todo_claimed_by, normalize_todo_id
+from ...control_plane.todos.contract import (
+    TODO_TASK_CLASS_MONITOR,
+    normalize_todo_claimed_by,
+    normalize_todo_id,
+)
 from .harness_gate import (
     GATE_STATE_ANALYSIS_ONLY,
     GATE_STATE_DISABLED,
@@ -30,8 +34,10 @@ from .todo_branch_plan import (
     _compact_text,
     _frontier_tokens,
     _lease_command,
+    _monitor_lane_exclusion,
     _required_capabilities,
     _required_write_scopes,
+    _shared_dependency_capabilities,
     _scopes_overlap,
 )
 from ...control_plane.todos.projection import todo_item_task_class, todo_projection_sort_key
@@ -390,6 +396,7 @@ def _todo_candidate(
         "claimed_by": normalize_todo_claimed_by(item.get("claimed_by")) or "",
         "required_write_scopes": _required_write_scopes(item),
         "required_capabilities": _required_capabilities(item),
+        "shared_dependency_capabilities": _shared_dependency_capabilities(item),
         "depends_on": item.get("depends_on") or item.get("dependency_todo_ids") or item.get("blocked_by_todo_ids") or [],
         "score": round(score, 2),
         "confidence": _branch_confidence(score, hazards=hazards),
@@ -450,6 +457,11 @@ def _branch_candidate(
     capabilities = _dedupe_preserve_order(
         capability for item in todo_bundle for capability in item.get("required_capabilities") or []
     )
+    shared_dependency_capabilities = _dedupe_preserve_order(
+        capability
+        for item in todo_bundle
+        for capability in item.get("shared_dependency_capabilities") or []
+    )
     dependencies = _dedupe_preserve_order(
         dep for item in todo_bundle for dep in item.get("depends_on") or []
     )
@@ -488,6 +500,7 @@ def _branch_candidate(
         "todo_bundle": todo_bundle,
         "required_write_scopes": write_scopes,
         "required_capabilities": capabilities,
+        "shared_dependency_capabilities": shared_dependency_capabilities,
         "depends_on": dependencies,
         "score": score,
         "confidence": aggregate_confidence,
@@ -613,14 +626,21 @@ def _build_worker_branch_candidates(
         )
     )
 
+    monitor_lanes = [
+        exclusion
+        for candidate in todo_candidates
+        if (exclusion := _monitor_lane_exclusion(candidate)) is not None
+    ]
     blocked = [
         {**candidate, "selection_status": "blocked_claimed_by_other"}
         for candidate in todo_candidates
+        if candidate.get("task_class") != TODO_TASK_CLASS_MONITOR
         if candidate.get("claimed_by") and candidate.get("claimed_by") != normalized_agent
     ]
     eligible = [
         candidate
         for candidate in todo_candidates
+        if candidate.get("task_class") != TODO_TASK_CLASS_MONITOR
         if not (candidate.get("claimed_by") and candidate.get("claimed_by") != normalized_agent)
     ]
 
@@ -708,7 +728,7 @@ def _build_worker_branch_candidates(
         )
 
     branch_candidates.sort(key=_branch_sort_key)
-    return branch_candidates, blocked
+    return branch_candidates, [*monitor_lanes, *blocked]
 
 
 def _baseline_worker_lanes(branch_candidates: Sequence[Mapping[str, Any]], *, width: int) -> dict[str, Any]:
@@ -764,6 +784,7 @@ def _disabled_worker_branch_plan(
         "worker_width": 0,
         "max_worker_lanes": MAX_WORKER_LANES,
         "branch_candidate_count": 0,
+        "excluded_monitor_todo_count": 0,
         "selected_worker_branch_count": 0,
         "selected_worker_branches": [],
         "rejected_worker_branches": [],
@@ -868,6 +889,10 @@ def build_explore_worker_branch_plan(
         bundle_confidence_threshold=float(profile.get("bundle_confidence_threshold") or 0.0),
         bundle_straggler_factor=float(profile.get("bundle_straggler_factor") or 0.0),
         router_state=router_state if router_used else None,
+    )
+    excluded_monitor_todo_count = sum(
+        item.get("selection_status") == "excluded_non_exploration_lane"
+        for item in blocked_todos
     )
     if gate["state"] == GATE_STATE_ANALYSIS_ONLY:
         # Analysis stays available (ranking, bundles, A/B estimate), but the
@@ -1088,6 +1113,7 @@ def build_explore_worker_branch_plan(
             ),
         },
         "branch_candidate_count": len(branch_candidates),
+        "excluded_monitor_todo_count": excluded_monitor_todo_count,
         "selected_worker_branch_count": len(selected),
         "selected_worker_branches": selected,
         "rejected_worker_branches": rejected[: max(0, normalized_width * 3)],
@@ -1096,6 +1122,15 @@ def build_explore_worker_branch_plan(
             "planner_layer": "experimental worker-branch planner",
             "execution_layer": "existing LoopX harness",
             "worker_branch_semantics": "one branch is a worker lane containing a bundle of LoopX todos",
+            "monitor_lane_semantics": (
+                "continuous_monitor todos remain visible as excluded diagnostics and do not "
+                "consume worker width or enter todo bundles"
+            ),
+            "scope_conflict_semantics": (
+                "only required_write_scopes create lane mutexes; shared_artifact:* and "
+                "shared_implementation:* capabilities describe immutable shared inputs, while "
+                "mutable shared builds remain required write scopes"
+            ),
             "branch_fill_semantics": (
                 "max_todos_per_branch is a safety ceiling; adaptive profiles decide "
                 "bundle size from marginal value and do not pad lanes to fill requested width"

--- a/tests/test_explore_monitor_lane_budget.py
+++ b/tests/test_explore_monitor_lane_budget.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+from loopx.capabilities.explore.todo_branch_plan import build_explore_todo_branch_plan
+from loopx.capabilities.explore.worker_branch_plan import build_explore_worker_branch_plan
+
+
+ANALYSIS_ONLY = {"explore_harness": {"enabled": True}}
+
+
+def _todo(
+    todo_id: str,
+    *,
+    index: int,
+    priority: str,
+    task_class: str,
+    capability: str,
+    write_scope: str | None = None,
+    shared_dependency: str | None = None,
+) -> dict[str, object]:
+    item: dict[str, object] = {
+        "todo_id": todo_id,
+        "index": index,
+        "status": "open",
+        "priority": priority,
+        "text": f"[{priority}] Inspect the synthetic {capability.replace('_', ' ')}",
+        "task_class": task_class,
+        "required_capabilities": [capability],
+    }
+    if write_scope:
+        item["required_write_scopes"] = [write_scope]
+    if shared_dependency:
+        item["required_capabilities"] = [shared_dependency, capability]
+    if task_class == "continuous_monitor":
+        item.update(
+            {
+                "monitor_cadence_seconds": 60,
+                "next_due_at": "2020-01-01T00:00:00Z",
+            }
+        )
+    return item
+
+
+TODOS = [
+    _todo(
+        "todo_observation_monitor",
+        index=1,
+        priority="P0",
+        task_class="continuous_monitor",
+        capability="observation_lane",
+    ),
+    _todo(
+        "todo_long_lane",
+        index=2,
+        priority="P4",
+        task_class="advancement_task",
+        capability="resource_lane:long",
+        write_scope="variants/long/**",
+        shared_dependency="shared_artifact:synthetic_build",
+    ),
+    _todo(
+        "todo_short_lane",
+        index=3,
+        priority="P4",
+        task_class="advancement_task",
+        capability="resource_lane:short",
+        write_scope="variants/short/**",
+        shared_dependency="shared_artifact:synthetic_build",
+    ),
+]
+
+
+def _assert_monitor_is_diagnostic_only(rejected: list[dict[str, object]]) -> None:
+    monitor = next(item for item in rejected if item.get("todo_id") == "todo_observation_monitor")
+    assert monitor["selection_status"] == "excluded_non_exploration_lane"
+    assert monitor["exclusion_reason"] == (
+        "continuous_monitor_does_not_consume_exploration_budget"
+    )
+
+
+def test_todo_branch_plan_does_not_spend_width_on_monitor_lane() -> None:
+    plan = build_explore_todo_branch_plan(
+        goal_id="synthetic-portfolio",
+        todos=TODOS,
+        orchestration=ANALYSIS_ONLY,
+        width=2,
+    )
+
+    assert plan["orchestration_gate"]["state"] == "analysis_only"
+    assert plan["verification_budget"] == 2
+    assert plan["exploration_candidate_count"] == 2
+    assert [item["todo_id"] for item in plan["selected_branches"]] == [
+        "todo_long_lane",
+        "todo_short_lane",
+    ]
+    assert all(
+        item["shared_dependency_capabilities"] == ["shared_artifact:synthetic_build"]
+        for item in plan["selected_branches"]
+    )
+    assert all(not item["suggested_commands"] for item in plan["selected_branches"])
+    _assert_monitor_is_diagnostic_only(plan["rejected_candidates"])
+
+
+def test_worker_branch_plan_keeps_monitor_out_of_worker_slots_and_bundles() -> None:
+    plan = build_explore_worker_branch_plan(
+        goal_id="synthetic-portfolio",
+        todos=TODOS,
+        orchestration=ANALYSIS_ONLY,
+        worker_width=2,
+        max_todos_per_branch=1,
+    )
+
+    assert plan["orchestration_gate"]["state"] == "analysis_only"
+    assert plan["verification_budget"] == 2
+    assert plan["excluded_monitor_todo_count"] == 1
+    assert {item["affinity_key"] for item in plan["selected_worker_branches"]} == {
+        "scope:variants/long",
+        "scope:variants/short",
+    }
+    assert all(
+        item["shared_dependency_capabilities"] == ["shared_artifact:synthetic_build"]
+        for item in plan["selected_worker_branches"]
+    )
+    selected_todo_ids = {
+        todo_id
+        for branch in plan["selected_worker_branches"]
+        for todo_id in branch["todo_ids"]
+    }
+    assert selected_todo_ids == {"todo_long_lane", "todo_short_lane"}
+    assert all(not item["suggested_commands"] for item in plan["selected_worker_branches"])
+    _assert_monitor_is_diagnostic_only(plan["rejected_worker_branches"])
+
+
+def test_mutable_shared_build_scope_still_serializes_worker_lanes() -> None:
+    todos = [
+        _todo(
+            "todo_long_build",
+            index=1,
+            priority="P1",
+            task_class="advancement_task",
+            capability="resource_lane:long",
+            write_scope="artifacts/shared_build/**",
+        ),
+        _todo(
+            "todo_short_build",
+            index=2,
+            priority="P1",
+            task_class="advancement_task",
+            capability="resource_lane:short",
+            write_scope="artifacts/shared_build/**",
+        ),
+    ]
+
+    plan = build_explore_worker_branch_plan(
+        goal_id="synthetic-shared-build",
+        todos=todos,
+        orchestration=ANALYSIS_ONLY,
+        worker_width=2,
+        max_todos_per_branch=1,
+    )
+
+    assert plan["selected_worker_branch_count"] == 1
+    conflict = next(
+        item
+        for item in plan["rejected_worker_branches"]
+        if item.get("selection_status") == "rejected_hazard"
+    )
+    assert any(
+        str(hazard).startswith("worker_branch_conflict:")
+        for hazard in conflict["hazards"]
+    )


### PR DESCRIPTION
## Summary

- exclude `continuous_monitor` todos from todo and worker exploration schedulers while preserving them as rejected diagnostics
- make the shared-input contract explicit: `shared_artifact:*` and `shared_implementation:*` capabilities may feed independent variant write scopes, while mutable shared builds remain write conflicts
- add synthetic long/short portfolio coverage for analysis-only planning and document the scope semantics

## Validation

- 6 focused fixture-free test functions passed
- `python3 examples/explore-worker-plan-gate-smoke.py`
- `python3 examples/explore-result-layer-smoke.py`
- `loopx canary premerge --from-git-diff --tier standard --timeout-seconds 180`
- Python compile and `git diff --check`

The full pytest suite was not run locally because pytest is not installed in the available environment.

## Boundary

The planners remain read-only and analysis-only behavior still suppresses all claim and lease commands. Fixtures and docs use only synthetic public-safe names.

## Remaining follow-ups

- worker capacity is still represented by one global width rather than per-resource lane capacities
- dependency invalidation happens after selection and does not backfill the newly empty slot; typed evidence remains diagnostic-only
