### PR TITLE
Fix issue-fix JSON input boundary

### DIFF
--- a/examples/canary/catalog-planner-smoke.py
+++ b/examples/canary/catalog-planner-smoke.py
@@ -533,6 +533,7 @@ def assert_pr_release_and_refactor_profiles_select() -> None:
     reviewer_profile = product_entry_profiles["issue-fix-reviewer-routing"]
     reviewer_commands = [check["command"] for check in reviewer_profile["checks"]]
     assert reviewer_commands == [
+        "python3 examples/issue-fix-json-input-boundary-smoke.py",
         "python3 examples/issue-fix-capability-guide-smoke.py",
         "python3 examples/issue-fix-reviewer-recommendation-smoke.py",
         "python3 examples/issue-fix-reviewer-request-smoke.py",

--- a/examples/issue-fix-json-input-boundary-smoke.py
+++ b/examples/issue-fix-json-input-boundary-smoke.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Smoke-test bounded, public-safe issue-fix JSON CLI inputs."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SENTINEL = "synthetic-payload-must-not-be-echoed"
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from loopx.capabilities.issue_fix.cli import (  # noqa: E402
+    _MAX_INLINE_JSON_CHARS,
+    _load_json_object,
+)
+
+
+def run_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, "-m", "loopx.cli", "--format", "json", *args],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def main() -> int:
+    inline = json.dumps(
+        {
+            "number": 123,
+            "state": "open",
+            "title": "Synthetic issue metadata",
+            "labels": [{"name": "bug"}],
+        }
+    )
+    accepted = run_cli(
+        "issue-fix",
+        "workflow-plan",
+        "--url",
+        "https://github.com/example/project/issues/123",
+        "--metadata-json",
+        inline,
+    )
+    assert accepted.returncode == 0, accepted.stdout
+    accepted_payload = json.loads(accepted.stdout)
+    assert accepted_payload["ok"] is True, accepted_payload
+    assert accepted_payload["external_writes_performed"] is False, accepted_payload
+
+    malformed = '{"title":"' + SENTINEL + "-" + ("x" * 5000)
+    rejected = run_cli(
+        "issue-fix",
+        "workflow-plan",
+        "--url",
+        "https://github.com/example/project/issues/123",
+        "--metadata-json",
+        malformed,
+    )
+    assert rejected.returncode != 0, rejected.stdout
+    rejected_payload = json.loads(rejected.stdout)
+    assert rejected_payload == {
+        "ok": False,
+        "mode": "issue-fix",
+        "error": "JSON input is invalid",
+    }, rejected_payload
+    combined_output = rejected.stdout + rejected.stderr
+    assert SENTINEL not in combined_output, combined_output
+    assert "File name too long" not in combined_output, combined_output
+
+    oversized = '{"value":"' + ("x" * _MAX_INLINE_JSON_CHARS) + '"}'
+    try:
+        _load_json_object(oversized)
+    except ValueError as exc:
+        assert str(exc) == "inline JSON input exceeds the 1 MiB limit", exc
+    else:
+        raise AssertionError("oversized inline JSON should be rejected")
+
+    missing = run_cli(
+        "issue-fix",
+        "workflow-plan",
+        "--url",
+        "https://github.com/example/project/issues/123",
+        "--metadata-json",
+        "missing-synthetic-metadata.json",
+    )
+    assert missing.returncode != 0, missing.stdout
+    missing_payload = json.loads(missing.stdout)
+    assert missing_payload["error"] == "could not read JSON input file", missing_payload
+    assert "missing-synthetic-metadata.json" not in missing.stdout, missing.stdout
+
+    help_result = subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "loopx.cli",
+            "issue-fix",
+            "reviewer-request",
+            "--help",
+        ],
+        cwd=ROOT,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+    normalized_help = " ".join(help_result.stdout.split())
+    assert "inline JSON object, file path" in normalized_help, help_result.stdout
+
+    print("issue-fix-json-input-boundary-smoke: ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/loopx/canary/planner.py
+++ b/loopx/canary/planner.py
@@ -911,12 +911,19 @@ CURRENT_REPO_PROFILES: tuple[dict[str, Any], ...] = (
             "examples/issue-fix-capability-guide-smoke.py",
             "examples/issue-fix-reviewer-recommendation-smoke.py",
             "examples/issue-fix-reviewer-request-smoke.py",
+            "examples/issue-fix-json-input-boundary-smoke.py",
             "examples/issue-fix-reviewer-notification-sink-smoke.py",
+            "loopx/capabilities/issue_fix/cli.py",
             "loopx/capabilities/issue_fix/reviewer_recommendation.py",
             "loopx/capabilities/issue_fix/reviewer_request.py",
             "loopx/capabilities/issue_fix/reviewer_notification.py",
         ),
         "checks": [
+            {
+                "command": "python3 examples/issue-fix-json-input-boundary-smoke.py",
+                "tier": "default",
+                "reason": "guards bounded inline issue-fix JSON inputs and compact errors that never echo raw payloads",
+            },
             {
                 "command": "python3 examples/issue-fix-capability-guide-smoke.py",
                 "tier": "default",

--- a/loopx/capabilities/catalog.py
+++ b/loopx/capabilities/catalog.py
@@ -173,6 +173,7 @@ CAPABILITIES: tuple[dict[str, Any], ...] = (
             "python3 examples/issue-fix-validated-memory-writeback-smoke.py",
             "python3 examples/issue-fix-reviewer-recommendation-smoke.py",
             "python3 examples/issue-fix-reviewer-request-smoke.py",
+            "python3 examples/issue-fix-json-input-boundary-smoke.py",
             "python3 examples/issue-fix-reviewer-notification-sink-smoke.py",
             "python3 examples/content-ops-issue-fix-metadata-preview-smoke.py",
             "python3 examples/content-ops-issue-fix-intake-smoke.py",

--- a/loopx/capabilities/issue_fix/cli.py
+++ b/loopx/capabilities/issue_fix/cli.py
@@ -74,13 +74,31 @@ FormatSelector = Callable[..., str]
 AddFormat = Callable[[argparse.ArgumentParser], None]
 
 
-def _load_json_object(path_text: str) -> dict[str, Any]:
-    if path_text == "-":
-        payload = json.loads(sys.stdin.read())
+_MAX_INLINE_JSON_CHARS = 1_048_576
+
+
+def _load_json_object(input_text: str) -> dict[str, Any]:
+    stripped = input_text.lstrip()
+    if input_text == "-":
+        source = "stdin"
+        raw = sys.stdin.read()
+    elif stripped.startswith(("{", "[")):
+        source = "inline"
+        raw = input_text
     else:
-        payload = json.loads(Path(path_text).expanduser().read_text(encoding="utf-8"))
+        source = "file"
+        try:
+            raw = Path(input_text).expanduser().read_text(encoding="utf-8")
+        except (OSError, RuntimeError):
+            raise ValueError("could not read JSON input file") from None
+    if source == "inline" and len(raw) > _MAX_INLINE_JSON_CHARS:
+        raise ValueError("inline JSON input exceeds the 1 MiB limit")
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        raise ValueError("JSON input is invalid") from None
     if not isinstance(payload, dict):
-        raise ValueError(f"{path_text} must contain a JSON object")
+        raise ValueError("JSON input must contain an object")
     return payload
 
 
@@ -849,8 +867,9 @@ def register_issue_fix_commands(
     reviewer_request_parser.add_argument(
         "--metadata-json",
         help=(
-            "Optional compact PR metadata JSON for a no-write preview. Live execute "
-            "mode fetches and verifies GitHub state instead."
+            "Optional compact PR metadata as an inline JSON object, file path, or "
+            "'-' for stdin in a no-write preview. Live execute mode fetches and "
+            "verifies GitHub state instead."
         ),
     )
     reviewer_request_parser.add_argument(


### PR DESCRIPTION
## Motivation

Issue-fix JSON options could be read as accepting compact JSON, but the shared loader always treated the argument as a file path. Long inline objects therefore raised a file-name error and echoed the input in the public error packet.

## Implementation

- Accept bounded inline JSON objects while preserving file-path and stdin inputs.
- Return compact parse/read/type errors without repeating the supplied payload or local path.
- Clarify reviewer-request help and register a provider-neutral CLI regression in the capability and canary catalogs.

## Validation

- issue-fix JSON input boundary smoke
- workflow-plan smoke
- reviewer-request smoke
- catalog planner smoke
- Python compile
- LoopX public-boundary check: 5 files, 0 warnings
- premerge canary: 17 selected checks, 0 failures, 0 warnings, 0 manual holds

## Risk and uncovered scope

The parser uses a 1 MiB cap only for inline JSON; existing file and stdin behavior remains compatible. This PR does not change external-write authority or provider behavior.