### PR TITLE
Render monitor-poll rejection details

### DIFF
--- a/examples/control_plane/monitor-poll-writeback-smoke.py
+++ b/examples/control_plane/monitor-poll-writeback-smoke.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import subprocess
 import sys
 import tempfile
 from datetime import datetime, timezone
@@ -197,6 +198,31 @@ def run_cli_expect_error(registry_path: Path, *args: str) -> dict:
     )
     assert returncode != 0, payload
     return payload
+
+
+def run_cli_markdown_expect_error(registry_path: Path, *args: str) -> str:
+    command = [
+        sys.executable,
+        "-m",
+        "loopx.cli",
+        "--registry",
+        str(registry_path),
+        "--runtime-root",
+        str(runtime_root_from_registry(registry_path)),
+        *args,
+        "--scan-path",
+        str(Path(__file__).resolve()),
+    ]
+    result = subprocess.run(
+        command,
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert result.returncode != 0, result.stdout
+    assert result.stdout.strip(), result.stderr
+    return result.stdout
 
 
 def agent_todos(state_file: Path) -> list[dict]:
@@ -456,6 +482,30 @@ def assert_target_key_cannot_hijack_selected_due_monitor() -> None:
         )
         assert payload["ok"] is False, payload
         assert "monitor-poll requires" in payload["reason"], payload
+        markdown = run_cli_markdown_expect_error(
+            registry_path,
+            "quota",
+            "monitor-poll",
+            "--goal-id",
+            GOAL_ID,
+            "--agent-id",
+            AGENT_ID,
+            "--target-key",
+            OTHER_TARGET_KEY,
+            "--result-hash",
+            "new",
+            "--material-change",
+            "--execute",
+        )
+        assert "- ok: `False`" in markdown, markdown
+        assert "- mode: `monitor-poll`" in markdown, markdown
+        assert f"- todo_id: ``" in markdown, markdown
+        assert f"- target_key: `{OTHER_TARGET_KEY}`" in markdown, markdown
+        assert "- material_change: `True`" in markdown, markdown
+        assert "- appended: `False`" in markdown, markdown
+        assert "- registry_mutated: `False`" in markdown, markdown
+        assert "- reason: monitor-poll requires" in markdown, markdown
+        assert "`None`" not in markdown, markdown
         selected = find_todo(state_file, TODO_ID)
         other = find_todo(state_file, "todo_monitorpoll111")
         assert selected["result_hash"] == "old", selected

--- a/loopx/control_plane/quota/monitor_poll.py
+++ b/loopx/control_plane/quota/monitor_poll.py
@@ -415,6 +415,24 @@ def record_quota_monitor_poll_for_decision(
 
 
 def render_quota_monitor_poll_markdown(payload: dict[str, Any]) -> str:
+    if payload.get("ok") is False:
+        return "\n".join(
+            [
+                "# LoopX Quota Monitor Poll",
+                "",
+                "- ok: `False`",
+                f"- mode: `{payload.get('mode') or 'monitor-poll'}`",
+                f"- goal_id: `{payload.get('goal_id') or ''}`",
+                f"- appended: `{bool(payload.get('appended'))}`",
+                f"- registry_mutated: `{bool(payload.get('registry_mutated'))}`",
+                f"- agent_id: `{payload.get('agent_id') or ''}`",
+                f"- source: `{payload.get('source') or ''}`",
+                f"- todo_id: `{payload.get('todo_id') or ''}`",
+                f"- target_key: `{payload.get('target_key') or ''}`",
+                f"- material_change: `{bool(payload.get('material_change'))}`",
+                f"- reason: {payload.get('reason') or 'monitor-poll rejected'}",
+            ]
+        )
     event = payload.get("monitor_event") if isinstance(payload.get("monitor_event"), dict) else {}
     before = event.get("before") if isinstance(event.get("before"), dict) else {}
     todo_writeback = event.get("todo_writeback") if isinstance(event.get("todo_writeback"), dict) else {}


### PR DESCRIPTION
## Motivation

A rejected quota monitor-poll returned an actionable JSON packet, but the Markdown renderer read only the success-only monitor_event object. Operators therefore saw None for the source, target, material-change intent, and reason, and could not distinguish a rejected write from a recorded poll.

## Implementation

- Render ok=false monitor-poll packets through a dedicated rejection view.
- Preserve mode, source, todo/target, material-change intent, and reason.
- Explicitly show appended=false and registry_mutated=false.
- Extend the provider-neutral CLI smoke with the rejected target-key path.

## Validation

- monitor-poll writeback smoke, including red-then-green CLI Markdown regression
- monitor-poll policy smoke
- quota material-monitor spend smoke
- status Markdown smoke
- catalog planner smoke
- changed Python compile
- public-boundary scan: 2 files, 0 warnings
- premerge canary: 16 selected checks, 0 failures, 0 warnings, 0 manual holds

## Risk and uncovered scope

This changes presentation only; monitor eligibility, todo writeback, scheduler policy, and quota accounting are unchanged. Success Markdown remains on the existing renderer path.