### PR TITLE
Explore: add resource-aware portfolio planning

### DIFF
--- a/docs/capabilities/explore/README.md
+++ b/docs/capabilities/explore/README.md
@@ -213,6 +213,44 @@ advancement todos or charges them against `worker_width`. A monitor transition
 may create or unblock a successor advancement todo through the normal todo
 lifecycle; that successor can participate in the next read-only planning call.
 
+### Resource-Aware Portfolio Planning
+
+Both branch planners can apply independent capacity ceilings to advancement
+todos that declare one `resource_lane:<key>` capability. Capacities and current
+occupancy are request inputs, not persisted control-plane state:
+
+```bash
+loopx explore worker-branch-plan --goal-id <id> --worker-width 5 \
+  --resource-capacity long_pool=2 --resource-usage long_pool=1 \
+  --resource-capacity short_pool=3 --resource-usage short_pool=1
+```
+
+The same repeatable flags work with `todo-branch-plan`; `--width` or
+`--worker-width` remains the overall plan ceiling. In this example the packet
+may assign one new `long_pool` slot and two new `short_pool` slots. Each selected
+branch carries `resource_lane` plus a `resource_assignment`, and the top-level
+`resource_portfolio` reports capacity, current usage, available, selected, and
+remaining slots per lane.
+
+When a higher-ranked candidate is rejected because its dependency is not in the
+selected wave, its write scope conflicts with an already selected branch, or it
+has another planner hazard, selection keeps scanning. A later safe candidate in
+the same resource lane can backfill the released predicted slot in the same
+call. `continuous_monitor` todos stay diagnostic-only and never consume a
+resource slot, even if they carry a resource-lane capability.
+
+Resource inputs are optional. With no `--resource-capacity`, unlaned and legacy
+todos retain the existing width/scheduler behavior. In resource-aware mode,
+untagged todos retain their previous unconstrained behavior, while a tagged lane
+must have a matching declared capacity. Usage without a matching capacity fails
+closed to catch misspelled lane keys.
+
+This remains analysis-only evidence: `resource_portfolio.score_delta=0`, typed
+evidence keeps `score_delta=0`, and the planner is read-only. Capacity and usage
+do not claim todos, acquire leases, launch workers, write state, or grant quota
+authority. They only constrain the predicted portfolio; execution still enters
+the normal LoopX lifecycle described below.
+
 This command is read-only and opt-in per goal. It is designed to sit on top of
 the existing LoopX harness, not beside it and not instead of it:
 

--- a/docs/capabilities/explore/README.md
+++ b/docs/capabilities/explore/README.md
@@ -232,6 +232,14 @@ branch carries `resource_lane` plus a `resource_assignment`, and the top-level
 `resource_portfolio` reports capacity, current usage, available, selected, and
 remaining slots per lane.
 
+Declaring resource capacities is an explicit portfolio-fill mode: the requested
+overall width becomes the selection ceiling instead of the legacy confidence
+prefix, while existing scores, hazards, and typed evidence remain unchanged.
+An available slot therefore makes a ranked candidate eligible for the analysis
+packet; it is not evidence that the candidate is valuable enough to execute.
+The agent must still apply the goal's evidence, serving-cost, quota, claim, and
+lease gates before launch.
+
 When a higher-ranked candidate is rejected because its dependency is not in the
 selected wave, its write scope conflicts with an already selected branch, or it
 has another planner hazard, selection keeps scanning. A later safe candidate in

--- a/examples/explore-result-layer-smoke.py
+++ b/examples/explore-result-layer-smoke.py
@@ -824,9 +824,9 @@ def check_cli_surface() -> None:
             "# Explore CLI Fixture\n\n"
             "## Agent Todo\n\n"
             "- [ ] [P0] Continue CLI topology experiment.\n"
-            "  <!-- loopx:todo todo_id=todo_cli_primary status=open task_class=advancement_task claimed_by=codex-main-control required_write_scopes=loopx/capabilities/explore/** -->\n"
+            "  <!-- loopx:todo todo_id=todo_cli_primary status=open task_class=advancement_task claimed_by=codex-main-control required_write_scopes=loopx/capabilities/explore/** required_capabilities=resource_lane:long_pool -->\n"
             "- [ ] [P1] Add CLI branch prediction smoke.\n"
-            "  <!-- loopx:todo todo_id=todo_cli_parallel status=open task_class=advancement_task required_write_scopes=examples/** -->\n",
+            "  <!-- loopx:todo todo_id=todo_cli_parallel status=open task_class=advancement_task required_write_scopes=examples/** required_capabilities=resource_lane:short_pool -->\n",
             encoding="utf-8",
         )
         registry.parent.mkdir(parents=True, exist_ok=True)
@@ -955,6 +955,26 @@ def check_cli_surface() -> None:
         assert branch_plan["selected_branches"][0]["todo_id"] == "todo_cli_primary", branch_plan
         assert set(branch_plan["scheduler"]["ab_comparison"]) == {"baseline_serial", "dspark_selected"}, branch_plan
         assert branch_plan["ab_result"]["estimated_speedup_vs_baseline"] > 0, branch_plan
+        resource_branch_plan = run_cli(
+            "explore",
+            "todo-branch-plan",
+            "--goal-id",
+            goal_id,
+            "--agent-id",
+            "codex-main-control",
+            "--width",
+            "2",
+            "--resource-capacity",
+            "long_pool=2",
+            "--resource-usage",
+            "long_pool=1",
+            "--resource-capacity",
+            "short_pool=3",
+            "--resource-usage",
+            "short_pool=2",
+        )
+        assert resource_branch_plan["resource_portfolio"]["selected_slot_count"] == 2, resource_branch_plan
+        assert resource_branch_plan["resource_portfolio"]["remaining_slot_count"] == 0, resource_branch_plan
         worker_branch_plan = run_cli(
             "explore",
             "worker-branch-plan",

--- a/loopx/capabilities/explore/resource_portfolio.py
+++ b/loopx/capabilities/explore/resource_portfolio.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping, Sequence
+
+
+RESOURCE_PORTFOLIO_SCHEMA_VERSION = "loopx_explore_resource_portfolio_v0"
+RESOURCE_LANE_CAPABILITY_PREFIX = "resource_lane:"
+RESOURCE_LANE_KEY_PATTERN = re.compile(r"^[a-z][a-z0-9_]{0,63}$")
+
+
+def normalize_resource_lane_key(value: Any) -> str:
+    key = str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+    if not RESOURCE_LANE_KEY_PATTERN.match(key):
+        raise ValueError(
+            f"resource lane {value!r} must start with a letter and contain only "
+            "lowercase letters, digits, or underscores"
+        )
+    return key
+
+
+def parse_resource_counts(values: Sequence[str] | None, *, flag_name: str) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for value in values or []:
+        if "=" not in value:
+            raise ValueError(f"{flag_name} expects KEY=N, got: {value}")
+        raw_key, raw_count = value.split("=", 1)
+        key = normalize_resource_lane_key(raw_key)
+        if key in counts:
+            raise ValueError(f"{flag_name} repeats resource lane {key!r}")
+        try:
+            count = int(raw_count.strip())
+        except ValueError as exc:
+            raise ValueError(f"{flag_name} expects KEY=N with an integer N, got: {value}") from exc
+        if count < 0:
+            raise ValueError(f"{flag_name} expects a non-negative N, got: {value}")
+        counts[key] = count
+    return counts
+
+
+def normalize_resource_counts(
+    values: Mapping[str, Any] | None,
+    *,
+    field_name: str,
+) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for raw_key, raw_count in (values or {}).items():
+        key = normalize_resource_lane_key(raw_key)
+        try:
+            count = int(raw_count)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"{field_name}[{key!r}] must be a non-negative integer") from exc
+        if count < 0:
+            raise ValueError(f"{field_name}[{key!r}] must be a non-negative integer")
+        counts[key] = count
+    return dict(sorted(counts.items()))
+
+
+def resolve_resource_portfolio(
+    capacities: Mapping[str, Any] | None,
+    usage: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    normalized_capacities = normalize_resource_counts(
+        capacities,
+        field_name="resource_capacities",
+    )
+    normalized_usage = normalize_resource_counts(
+        usage,
+        field_name="resource_usage",
+    )
+    unknown_usage = sorted(set(normalized_usage) - set(normalized_capacities))
+    if unknown_usage:
+        raise ValueError(
+            "resource_usage requires matching resource_capacities for: "
+            + ", ".join(unknown_usage)
+        )
+    lane_keys = sorted(normalized_capacities)
+    lanes = {
+        key: {
+            "capacity": normalized_capacities[key],
+            "current_usage": normalized_usage.get(key, 0),
+            "available_slots": max(
+                0,
+                normalized_capacities[key] - normalized_usage.get(key, 0),
+            ),
+            "overcommitted_by": max(
+                0,
+                normalized_usage.get(key, 0) - normalized_capacities[key],
+            ),
+        }
+        for key in lane_keys
+    }
+    return {
+        "schema_version": RESOURCE_PORTFOLIO_SCHEMA_VERSION,
+        "enabled": bool(normalized_capacities),
+        "analysis_only": True,
+        "score_delta": 0.0,
+        "resource_capacities": normalized_capacities,
+        "resource_usage": {key: normalized_usage.get(key, 0) for key in lane_keys},
+        "available_slot_count": sum(lane["available_slots"] for lane in lanes.values()),
+        "lanes": lanes,
+        "continuous_monitor_consumes_capacity": False,
+        "authority": {
+            "writes_state": False,
+            "claims_todos": False,
+            "acquires_leases": False,
+            "starts_workers": False,
+            "changes_quota": False,
+        },
+    }
+
+
+def resource_lane_from_capabilities(capabilities: Sequence[Any]) -> str:
+    lanes = []
+    for capability in capabilities:
+        text = str(capability or "").strip().lower()
+        if not text.startswith(RESOURCE_LANE_CAPABILITY_PREFIX):
+            continue
+        key = text.removeprefix(RESOURCE_LANE_CAPABILITY_PREFIX)
+        if key and key not in lanes:
+            lanes.append(normalize_resource_lane_key(key))
+    if len(lanes) > 1:
+        raise ValueError(
+            "an advancement todo may declare only one resource_lane:<key> capability"
+        )
+    return lanes[0] if lanes else ""
+
+
+def resource_assignment(
+    portfolio: Mapping[str, Any],
+    *,
+    resource_lane: str,
+    selected_count: int,
+) -> dict[str, Any] | None:
+    if not portfolio.get("enabled") or not resource_lane:
+        return None
+    lane = (portfolio.get("lanes") or {}).get(resource_lane)
+    if not isinstance(lane, Mapping):
+        return None
+    return {
+        "resource_lane": resource_lane,
+        "slot_ordinal": int(lane.get("current_usage") or 0) + selected_count,
+        "capacity": int(lane.get("capacity") or 0),
+        "current_usage": int(lane.get("current_usage") or 0),
+    }
+
+
+def resource_portfolio_with_selection(
+    portfolio: Mapping[str, Any],
+    selected: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    result = {
+        **dict(portfolio),
+        "lanes": {
+            key: dict(value)
+            for key, value in (portfolio.get("lanes") or {}).items()
+            if isinstance(value, Mapping)
+        },
+    }
+    selected_by_lane = {
+        key: sum(item.get("resource_lane") == key for item in selected)
+        for key in result["lanes"]
+    }
+    for key, lane in result["lanes"].items():
+        selected_count = selected_by_lane[key]
+        lane["selected_slots"] = selected_count
+        lane["remaining_slots"] = max(0, int(lane.get("available_slots") or 0) - selected_count)
+    result["selected_slot_count"] = sum(selected_by_lane.values())
+    result["remaining_slot_count"] = sum(
+        int(lane.get("remaining_slots") or 0) for lane in result["lanes"].values()
+    )
+    result["unassigned_selected_count"] = sum(not item.get("resource_lane") for item in selected)
+    return result

--- a/loopx/capabilities/explore/todo_branch_plan.py
+++ b/loopx/capabilities/explore/todo_branch_plan.py
@@ -31,6 +31,12 @@ from .speculative_scheduler import (
     partition_invalidated_successors,
     schedule_confidence_prefix,
 )
+from .resource_portfolio import (
+    resource_assignment,
+    resource_lane_from_capabilities,
+    resource_portfolio_with_selection,
+    resolve_resource_portfolio,
+)
 from .todo_evidence import build_todo_typed_evidence_audit
 
 
@@ -318,6 +324,8 @@ def build_explore_todo_branch_plan(
     allow_unscoped_parallel: bool = True,
     scheduler_strategy: str = "dspark",
     scheduler_load: float = 0.2,
+    resource_capacities: Mapping[str, int] | None = None,
+    resource_usage: Mapping[str, int] | None = None,
 ) -> dict[str, Any]:
     """Rank open agent todos as CPU-like predicted execution branches.
 
@@ -333,6 +341,7 @@ def build_explore_todo_branch_plan(
     """
 
     normalized_agent = normalize_todo_claimed_by(agent_id)
+    resource_portfolio = resolve_resource_portfolio(resource_capacities, resource_usage)
     requested_width = max(1, int(width or DEFAULT_BRANCH_WIDTH))
     gate = resolve_todo_branch_plan_gate(orchestration, requested_width=requested_width)
     if gate["state"] == GATE_STATE_DISABLED:
@@ -352,6 +361,7 @@ def build_explore_todo_branch_plan(
         )
         required_write_scopes = _required_write_scopes(item)
         task_class = todo_item_task_class(dict(item))
+        required_capabilities = _required_capabilities(item)
         candidate = {
             "todo_id": todo_id,
             "text": _compact_text(item.get("text") or item.get("title")),
@@ -359,8 +369,15 @@ def build_explore_todo_branch_plan(
             "task_class": task_class,
             "claimed_by": normalize_todo_claimed_by(item.get("claimed_by")) or "",
             "required_write_scopes": required_write_scopes,
-            "required_capabilities": _required_capabilities(item),
+            "required_capabilities": required_capabilities,
             "shared_dependency_capabilities": _shared_dependency_capabilities(item),
+            "resource_lane": resource_lane_from_capabilities(required_capabilities),
+            "depends_on": (
+                item.get("depends_on")
+                or item.get("dependency_todo_ids")
+                or item.get("blocked_by_todo_ids")
+                or []
+            ),
             "score": round(score, 2),
             "confidence": _branch_confidence(score, hazards=hazards),
             "expected_evidence_units": _branch_expected_evidence_units(
@@ -413,78 +430,138 @@ def build_explore_todo_branch_plan(
     )
     verification_budget = max(1, int(scheduler.get("selected_prefix_length") or 1))
 
-    selected: list[dict[str, Any]] = []
-    rejected: list[dict[str, Any]] = list(monitor_lanes)
-    selected_scopes: list[tuple[str, list[str]]] = []
-    for candidate in exploration_candidates:
-        hazards = list(candidate.get("hazards") or [])
-        scopes = _required_write_scopes(candidate)
-        conflict_with = ""
-        if scopes:
-            for selected_todo_id, existing_scopes in selected_scopes:
-                if _scopes_overlap(scopes, existing_scopes):
-                    conflict_with = selected_todo_id
-                    hazards.append(f"write_scope_conflict:{selected_todo_id}")
-                    break
-        elif not allow_unscoped_parallel and selected:
-            conflict_with = selected[0]["todo_id"]
-            hazards.append("unscoped_parallel_disabled")
+    selection_budget = normalized_width if resource_portfolio["enabled"] else verification_budget
+    ordered_candidates = list(exploration_candidates)
+    if resource_portfolio["enabled"]:
+        ordered_candidates.sort(key=lambda item: 0 if item.get("resource_lane") else 1)
 
-        if candidate.get("claimed_by") and candidate.get("claimed_by") != normalized_agent:
-            candidate = {**candidate, "selection_status": "blocked_claimed_by_other"}
-            rejected.append(candidate)
-            continue
-        if conflict_with:
-            candidate = {
-                **candidate,
-                "selection_status": "rejected_hazard",
-                "conflict_with": conflict_with,
-                "hazards": hazards,
-            }
-            rejected.append(candidate)
-            continue
-        if len(selected) >= verification_budget:
-            rejected.append({**candidate, "selection_status": "outside_verification_budget"})
-            continue
+    invalidated_ids: set[str] = set()
+    dependency_rejections: list[dict[str, Any]] = []
+    dependency_events: list[dict[str, Any]] = []
+    while True:
+        selected = []
+        selection_rejections: list[dict[str, Any]] = []
+        selected_scopes: list[tuple[str, list[str]]] = []
+        selected_by_resource_lane: dict[str, int] = {}
+        for candidate in ordered_candidates:
+            todo_id = str(candidate.get("todo_id") or "")
+            if todo_id in invalidated_ids:
+                continue
+            hazards = list(candidate.get("hazards") or [])
+            scopes = _required_write_scopes(candidate)
+            resource_lane = str(candidate.get("resource_lane") or "")
+            conflict_with = ""
+            if scopes:
+                for selected_todo_id, existing_scopes in selected_scopes:
+                    if _scopes_overlap(scopes, existing_scopes):
+                        conflict_with = selected_todo_id
+                        hazards.append(f"write_scope_conflict:{selected_todo_id}")
+                        break
+            elif not allow_unscoped_parallel and selected:
+                conflict_with = selected[0]["todo_id"]
+                hazards.append("unscoped_parallel_disabled")
 
-        branch_index = len(selected)
-        todo_id = str(candidate["todo_id"])
-        role = "primary" if branch_index == 0 else "speculative"
-        selected_candidate = {
-            **candidate,
-            "selection_status": "selected",
-            "branch_role": role,
-            "branch_index": branch_index,
-            "lane_id": _lane_id(todo_id, index=branch_index),
-            "commit_policy": (
-                "verify and write back before keeping this branch; discard or convert "
-                "to successor todo if evidence does not advance the exploration"
-            ),
-            "suggested_commands": [
-                command
-                for command in (
-                    _claim_command(goal_id=goal_id, todo_id=todo_id, agent_id=normalized_agent),
-                    _lease_command(
-                        goal_id=goal_id,
-                        todo_id=todo_id,
-                        agent_id=normalized_agent,
-                        write_scopes=scopes,
-                    ),
+            if candidate.get("claimed_by") and candidate.get("claimed_by") != normalized_agent:
+                selection_rejections.append(
+                    {**candidate, "selection_status": "blocked_claimed_by_other"}
                 )
-                if command
-            ],
-        }
-        selected.append(selected_candidate)
-        selected_scopes.append((todo_id, scopes))
+                continue
+            if conflict_with:
+                selection_rejections.append(
+                    {
+                        **candidate,
+                        "selection_status": "rejected_hazard",
+                        "conflict_with": conflict_with,
+                        "hazards": hazards,
+                    }
+                )
+                continue
+            if resource_portfolio["enabled"] and resource_lane:
+                lane = resource_portfolio["lanes"].get(resource_lane)
+                if lane is None:
+                    selection_rejections.append(
+                        {
+                            **candidate,
+                            "selection_status": "rejected_resource_lane",
+                            "hazards": [*hazards, f"resource_capacity_undeclared:{resource_lane}"],
+                        }
+                    )
+                    continue
+                if selected_by_resource_lane.get(resource_lane, 0) >= int(
+                    lane.get("available_slots") or 0
+                ):
+                    selection_rejections.append(
+                        {
+                            **candidate,
+                            "selection_status": "resource_lane_capacity_exhausted",
+                            "hazards": [*hazards, f"resource_capacity_exhausted:{resource_lane}"],
+                        }
+                    )
+                    continue
+            if len(selected) >= selection_budget:
+                selection_rejections.append(
+                    {**candidate, "selection_status": "outside_verification_budget"}
+                )
+                continue
 
-    dependency_valid_selected, dependency_invalidated, dependency_events = partition_invalidated_successors(
-        selected,
-        selected_ids=[str(item.get("todo_id") or "") for item in selected],
-        lane="todo_branch_plan",
-    )
-    if dependency_invalidated:
-        rejected.extend(dependency_invalidated)
-        selected = dependency_valid_selected
+            branch_index = len(selected)
+            role = "primary" if branch_index == 0 else "speculative"
+            selected_in_lane = selected_by_resource_lane.get(resource_lane, 0) + 1
+            selected_candidate = {
+                **candidate,
+                "selection_status": "selected",
+                "branch_role": role,
+                "branch_index": branch_index,
+                "lane_id": _lane_id(todo_id, index=branch_index),
+                "commit_policy": (
+                    "verify and write back before keeping this branch; discard or convert "
+                    "to successor todo if evidence does not advance the exploration"
+                ),
+                "suggested_commands": [
+                    command
+                    for command in (
+                        _claim_command(goal_id=goal_id, todo_id=todo_id, agent_id=normalized_agent),
+                        _lease_command(
+                            goal_id=goal_id,
+                            todo_id=todo_id,
+                            agent_id=normalized_agent,
+                            write_scopes=scopes,
+                        ),
+                    )
+                    if command
+                ],
+            }
+            assignment = resource_assignment(
+                resource_portfolio,
+                resource_lane=resource_lane,
+                selected_count=selected_in_lane,
+            )
+            if assignment is not None:
+                selected_candidate["resource_assignment"] = assignment
+            selected.append(selected_candidate)
+            selected_scopes.append((todo_id, scopes))
+            if resource_lane:
+                selected_by_resource_lane[resource_lane] = selected_in_lane
+
+        valid_selected, invalidated, events = partition_invalidated_successors(
+            selected,
+            selected_ids=[str(item.get("todo_id") or "") for item in selected],
+            lane="todo_branch_plan",
+        )
+        if not invalidated:
+            rejected = [*monitor_lanes, *dependency_rejections, *selection_rejections]
+            selected = valid_selected
+            break
+        new_invalidated_ids = {
+            str(item.get("todo_id") or "") for item in invalidated
+        } - invalidated_ids
+        dependency_rejections.extend(invalidated)
+        dependency_events.extend(events)
+        invalidated_ids.update(new_invalidated_ids)
+        if not new_invalidated_ids:
+            rejected = [*monitor_lanes, *dependency_rejections, *selection_rejections]
+            selected = valid_selected
+            break
 
     if gate["state"] == GATE_STATE_ANALYSIS_ONLY:
         # Analysis stays available (ranking, hazards, A/B estimate), but the
@@ -508,6 +585,7 @@ def build_explore_todo_branch_plan(
         "issue_width": normalized_width,
         "requested_issue_width": requested_width,
         "verification_budget": verification_budget,
+        "selection_budget": selection_budget,
         "scheduler": scheduler,
         "accept_reject_trace": dependency_events,
         "ab_result": build_branch_plan_ab_result(
@@ -522,6 +600,7 @@ def build_explore_todo_branch_plan(
         "selected_count": len(selected),
         "selected_branches": selected,
         "rejected_candidates": rejected[: max(0, normalized_width * 3)],
+        "resource_portfolio": resource_portfolio_with_selection(resource_portfolio, selected),
         "hazard_model": {
             "write_scope_conflicts": "skip speculative branch when declared write scopes overlap",
             "shared_dependencies": (
@@ -541,6 +620,10 @@ def build_explore_todo_branch_plan(
             "typed_evidence": (
                 "explicit Explore result-node links add bounded diagnostic-only "
                 "dead-end/refutation warnings; they do not change score or authority"
+            ),
+            "resource_lanes": (
+                "resource_lane:<key> capabilities consume only explicitly declared empty slots; "
+                "rejected candidates release their predicted slot for same-call backfill"
             ),
         },
         "boundary": {

--- a/loopx/capabilities/explore/worker_branch_plan.py
+++ b/loopx/capabilities/explore/worker_branch_plan.py
@@ -16,6 +16,12 @@ from .harness_gate import (
     resolve_explore_harness_gate as _resolve_explore_harness_gate,
 )
 from .router_state import family_routing_terms, is_router_state
+from .resource_portfolio import (
+    resource_assignment,
+    resource_lane_from_capabilities,
+    resource_portfolio_with_selection,
+    resolve_resource_portfolio,
+)
 from .speculative_scheduler import (
     build_accept_reject_event,
     calibrate_load_factor,
@@ -388,6 +394,7 @@ def _todo_candidate(
         frontier=frontier,
     )
     task_class = todo_item_task_class(dict(item))
+    required_capabilities = _required_capabilities(item)
     candidate = {
         "todo_id": todo_id,
         "text": _compact_text(item.get("text") or item.get("title")),
@@ -395,8 +402,9 @@ def _todo_candidate(
         "task_class": task_class,
         "claimed_by": normalize_todo_claimed_by(item.get("claimed_by")) or "",
         "required_write_scopes": _required_write_scopes(item),
-        "required_capabilities": _required_capabilities(item),
+        "required_capabilities": required_capabilities,
         "shared_dependency_capabilities": _shared_dependency_capabilities(item),
+        "resource_lane": resource_lane_from_capabilities(required_capabilities),
         "depends_on": item.get("depends_on") or item.get("dependency_todo_ids") or item.get("blocked_by_todo_ids") or [],
         "score": round(score, 2),
         "confidence": _branch_confidence(score, hazards=hazards),
@@ -469,6 +477,11 @@ def _branch_candidate(
         hazard for item in todo_bundle for hazard in item.get("hazards") or []
     )
     branch_id = _branch_id(affinity_key, index=index)
+    resource_lanes = _dedupe_preserve_order(
+        item.get("resource_lane") for item in todo_bundle if item.get("resource_lane")
+    )
+    if len(resource_lanes) > 1:
+        raise ValueError("a worker branch cannot bundle todos from multiple resource lanes")
     expected_evidence = round(
         sum(float(item.get("expected_evidence_units") or 0.0) for item in todo_bundle),
         3,
@@ -501,6 +514,7 @@ def _branch_candidate(
         "required_write_scopes": write_scopes,
         "required_capabilities": capabilities,
         "shared_dependency_capabilities": shared_dependency_capabilities,
+        "resource_lane": resource_lanes[0] if resource_lanes else "",
         "depends_on": dependencies,
         "score": score,
         "confidence": aggregate_confidence,
@@ -644,15 +658,20 @@ def _build_worker_branch_candidates(
         if not (candidate.get("claimed_by") and candidate.get("claimed_by") != normalized_agent)
     ]
 
-    buckets: dict[str, list[dict[str, Any]]] = {}
+    buckets: dict[tuple[str, str], list[dict[str, Any]]] = {}
     for candidate in eligible:
-        buckets.setdefault(str(candidate.get("affinity_key") or "topic:general"), []).append(candidate)
+        bucket_key = (
+            str(candidate.get("resource_lane") or ""),
+            str(candidate.get("affinity_key") or "topic:general"),
+        )
+        buckets.setdefault(bucket_key, []).append(candidate)
 
     router_enabled = is_router_state(router_state)
-    terms_by_family: dict[str, dict[str, Any]] = {}
+    terms_by_family: dict[tuple[str, str], dict[str, Any]] = {}
     if router_enabled:
         terms_by_family = {
-            family: family_routing_terms(router_state, family) for family in buckets
+            bucket_key: family_routing_terms(router_state, bucket_key[1])
+            for bucket_key in buckets
         }
     known_durations = sorted(
         terms.get("duration_minutes")
@@ -663,22 +682,24 @@ def _build_worker_branch_candidates(
         float(known_durations[len(known_durations) // 2]) if known_durations else None
     )
 
-    def _bucket_sort_key(item: tuple[str, list[dict[str, Any]]]) -> tuple:
-        affinity_key, bucket = item
+    def _bucket_sort_key(item: tuple[tuple[str, str], list[dict[str, Any]]]) -> tuple:
+        bucket_key, bucket = item
+        resource_lane, affinity_key = bucket_key
         total_score = sum(float(todo.get("score") or 0.0) for todo in bucket)
         if router_enabled:
             routing_value = float(
-                (terms_by_family.get(affinity_key) or {}).get("routing_value") or 0.0
+                (terms_by_family.get(bucket_key) or {}).get("routing_value") or 0.0
             )
-            return (-routing_value, -total_score, affinity_key)
-        return (-total_score, affinity_key)
+            return (-routing_value, -total_score, resource_lane, affinity_key)
+        return (-total_score, resource_lane, affinity_key)
 
     branch_candidates: list[dict[str, Any]] = []
     branch_index = 0
     chunk_size = max(1, min(MAX_TODOS_PER_WORKER_BRANCH, int(max_todos_per_branch or 1)))
     score_floor = max(0.0, min(1.0, float(marginal_score_floor)))
-    for affinity_key, bucket in sorted(buckets.items(), key=_bucket_sort_key):
-        router_terms = terms_by_family.get(affinity_key)
+    for bucket_key, bucket in sorted(buckets.items(), key=_bucket_sort_key):
+        _, affinity_key = bucket_key
+        router_terms = terms_by_family.get(bucket_key)
         bundles: list[list[dict[str, Any]]] = []
         if branch_fill_policy == "confident-prefix":
             bundles = _confident_prefix_bundles(
@@ -822,6 +843,8 @@ def build_explore_worker_branch_plan(
     marginal_score_floor: float | None = None,
     router_state: Mapping[str, Any] | None = None,
     load_profile: Mapping[str, Any] | None = None,
+    resource_capacities: Mapping[str, int] | None = None,
+    resource_usage: Mapping[str, int] | None = None,
 ) -> dict[str, Any]:
     """Plan worker-lane branches on top of the existing LoopX harness.
 
@@ -843,6 +866,7 @@ def build_explore_worker_branch_plan(
     """
 
     normalized_agent = normalize_todo_claimed_by(agent_id)
+    resource_portfolio = resolve_resource_portfolio(resource_capacities, resource_usage)
     requested_width = max(1, int(worker_width or DEFAULT_BRANCH_WIDTH))
     gate = resolve_explore_harness_gate(orchestration, requested_width=requested_width)
     if gate["state"] == GATE_STATE_DISABLED:
@@ -954,63 +978,132 @@ def build_explore_worker_branch_plan(
     profile["scheduler_load"] = scheduler.get("load_factor")
     profile["scheduler_model"] = scheduler.get("strategy")
 
-    selected: list[dict[str, Any]] = []
-    rejected: list[dict[str, Any]] = list(blocked_todos)
-    selected_scopes: list[tuple[str, list[str]]] = []
-    for branch in branch_candidates:
-        branch_scopes = list(branch.get("required_write_scopes") or [])
-        conflict_with = ""
-        if branch_scopes:
-            for selected_branch_id, selected_branch_scopes in selected_scopes:
-                if _scopes_overlap(branch_scopes, selected_branch_scopes):
-                    conflict_with = selected_branch_id
-                    break
-        elif not allow_unscoped_parallel and selected:
-            conflict_with = str(selected[0].get("branch_id") or "")
+    selection_budget = normalized_width if resource_portfolio["enabled"] else verification_budget
+    ordered_branches = list(branch_candidates)
+    if resource_portfolio["enabled"]:
+        ordered_branches.sort(key=lambda item: 0 if item.get("resource_lane") else 1)
 
-        if conflict_with:
-            rejected.append(
-                {
-                    **branch,
-                    "selection_status": "rejected_hazard",
-                    "conflict_with": conflict_with,
-                    "hazards": [*list(branch.get("hazards") or []), f"worker_branch_conflict:{conflict_with}"],
-                }
+    invalidated_branch_ids: set[str] = set()
+    dependency_rejections: list[dict[str, Any]] = []
+    invalidation_events: list[dict[str, Any]] = []
+    while True:
+        selected = []
+        selection_rejections: list[dict[str, Any]] = []
+        selected_scopes: list[tuple[str, list[str]]] = []
+        selected_by_resource_lane: dict[str, int] = {}
+        for branch in ordered_branches:
+            branch_id = str(branch.get("branch_id") or "")
+            if branch_id in invalidated_branch_ids:
+                continue
+            branch_scopes = list(branch.get("required_write_scopes") or [])
+            resource_lane = str(branch.get("resource_lane") or "")
+            conflict_with = ""
+            if branch_scopes:
+                for selected_branch_id, selected_branch_scopes in selected_scopes:
+                    if _scopes_overlap(branch_scopes, selected_branch_scopes):
+                        conflict_with = selected_branch_id
+                        break
+            elif not allow_unscoped_parallel and selected:
+                conflict_with = str(selected[0].get("branch_id") or "")
+
+            if conflict_with:
+                selection_rejections.append(
+                    {
+                        **branch,
+                        "selection_status": "rejected_hazard",
+                        "conflict_with": conflict_with,
+                        "hazards": [
+                            *list(branch.get("hazards") or []),
+                            f"worker_branch_conflict:{conflict_with}",
+                        ],
+                    }
+                )
+                continue
+            if resource_portfolio["enabled"] and resource_lane:
+                lane = resource_portfolio["lanes"].get(resource_lane)
+                if lane is None:
+                    selection_rejections.append(
+                        {
+                            **branch,
+                            "selection_status": "rejected_resource_lane",
+                            "hazards": [
+                                *list(branch.get("hazards") or []),
+                                f"resource_capacity_undeclared:{resource_lane}",
+                            ],
+                        }
+                    )
+                    continue
+                if selected_by_resource_lane.get(resource_lane, 0) >= int(
+                    lane.get("available_slots") or 0
+                ):
+                    selection_rejections.append(
+                        {
+                            **branch,
+                            "selection_status": "resource_lane_capacity_exhausted",
+                            "hazards": [
+                                *list(branch.get("hazards") or []),
+                                f"resource_capacity_exhausted:{resource_lane}",
+                            ],
+                        }
+                    )
+                    continue
+            if len(selected) >= selection_budget:
+                selection_rejections.append(
+                    {**branch, "selection_status": "outside_verification_budget"}
+                )
+                continue
+
+            role = "primary" if not selected else "speculative_worker"
+            selected_in_lane = selected_by_resource_lane.get(resource_lane, 0) + 1
+            selected_branch = {
+                **branch,
+                "selection_status": "selected",
+                "branch_role": role,
+                "branch_index": len(selected),
+                "worker_hint": f"worker-{len(selected) + 1}",
+                "execution_contract": {
+                    "must_enter_loopx_harness": True,
+                    "requires_quota_should_run": True,
+                    "requires_todo_claim": True,
+                    "requires_task_lease_for_write_scopes": bool(branch_scopes),
+                    "writeback_surfaces": ["explore_result_log", "refresh_state", "quota_spend_slot"],
+                },
+            }
+            assignment = resource_assignment(
+                resource_portfolio,
+                resource_lane=resource_lane,
+                selected_count=selected_in_lane,
             )
-            continue
-        if len(selected) >= verification_budget:
-            rejected.append({**branch, "selection_status": "outside_verification_budget"})
-            continue
-        role = "primary" if not selected else "speculative_worker"
-        selected_branch = {
-            **branch,
-            "selection_status": "selected",
-            "branch_role": role,
-            "branch_index": len(selected),
-            "worker_hint": f"worker-{len(selected) + 1}",
-            "execution_contract": {
-                "must_enter_loopx_harness": True,
-                "requires_quota_should_run": True,
-                "requires_todo_claim": True,
-                "requires_task_lease_for_write_scopes": bool(branch_scopes),
-                "writeback_surfaces": ["explore_result_log", "refresh_state", "quota_spend_slot"],
-            },
-        }
-        selected.append(selected_branch)
-        selected_scopes.append((str(branch.get("branch_id")), branch_scopes))
+            if assignment is not None:
+                selected_branch["resource_assignment"] = assignment
+            selected.append(selected_branch)
+            selected_scopes.append((branch_id, branch_scopes))
+            if resource_lane:
+                selected_by_resource_lane[resource_lane] = selected_in_lane
 
-    valid_selected, invalidated, invalidation_events = partition_invalidated_successors(
-        selected,
-        selected_ids=[
-            todo_id
-            for branch in selected
-            for todo_id in branch.get("todo_ids") or []
-        ],
-        lane="worker_branch_plan",
-    )
-    if invalidated:
-        rejected.extend(invalidated)
-        selected = valid_selected
+        valid_selected, invalidated, events = partition_invalidated_successors(
+            selected,
+            selected_ids=[
+                todo_id
+                for selected_branch in selected
+                for todo_id in selected_branch.get("todo_ids") or []
+            ],
+            lane="worker_branch_plan",
+        )
+        if not invalidated:
+            rejected = [*blocked_todos, *dependency_rejections, *selection_rejections]
+            selected = valid_selected
+            break
+        new_invalidated_ids = {
+            str(item.get("branch_id") or "") for item in invalidated
+        } - invalidated_branch_ids
+        dependency_rejections.extend(invalidated)
+        invalidation_events.extend(events)
+        invalidated_branch_ids.update(new_invalidated_ids)
+        if not new_invalidated_ids:
+            rejected = [*blocked_todos, *dependency_rejections, *selection_rejections]
+            selected = valid_selected
+            break
 
     baseline = _baseline_worker_lanes(branch_candidates, width=normalized_width)
     treatment_expected = round(
@@ -1071,6 +1164,7 @@ def build_explore_worker_branch_plan(
         "max_todos_per_branch_source": max_todos_source,
         "branch_fill_policy": normalized_fill_policy,
         "verification_budget": verification_budget,
+        "selection_budget": selection_budget,
         "scheduler": scheduler,
         "harness_compatibility": {
             "uses_loopx_todo_projection": True,
@@ -1117,6 +1211,7 @@ def build_explore_worker_branch_plan(
         "selected_worker_branch_count": len(selected),
         "selected_worker_branches": selected,
         "rejected_worker_branches": rejected[: max(0, normalized_width * 3)],
+        "resource_portfolio": resource_portfolio_with_selection(resource_portfolio, selected),
         "accept_reject_trace": [*predicted_events, *invalidation_events],
         "execution_model": {
             "planner_layer": "experimental worker-branch planner",
@@ -1130,6 +1225,10 @@ def build_explore_worker_branch_plan(
                 "only required_write_scopes create lane mutexes; shared_artifact:* and "
                 "shared_implementation:* capabilities describe immutable shared inputs, while "
                 "mutable shared builds remain required write scopes"
+            ),
+            "resource_lane_semantics": (
+                "resource_lane:<key> capabilities consume only explicitly declared empty slots; "
+                "continuous monitors consume none, and rejected lanes are backfilled in the same call"
             ),
             "branch_fill_semantics": (
                 "max_todos_per_branch is a safety ceiling; adaptive profiles decide "

--- a/loopx/cli_commands/explore.py
+++ b/loopx/cli_commands/explore.py
@@ -22,6 +22,7 @@ from ..capabilities.explore.result_log import (
     load_explore_result_events,
 )
 from ..capabilities.explore.harness_gate import GATE_STATE_DISABLED
+from ..capabilities.explore.resource_portfolio import parse_resource_counts
 from ..capabilities.explore.todo_branch_plan import (
     build_explore_todo_branch_plan,
     resolve_todo_branch_plan_gate,
@@ -551,6 +552,14 @@ def handle_explore_command(
                     )
                 payload["out"] = str(out_path)
         elif args.explore_command == "todo-branch-plan":
+            resource_capacities = parse_resource_counts(
+                args.resource_capacity,
+                flag_name="--resource-capacity",
+            )
+            resource_usage = parse_resource_counts(
+                args.resource_usage,
+                flag_name="--resource-usage",
+            )
             orchestration = _goal_orchestration_boundary(registry, goal_id=args.goal_id)
             gate = resolve_todo_branch_plan_gate(orchestration, requested_width=args.width)
             if gate["state"] == GATE_STATE_DISABLED:
@@ -563,6 +572,8 @@ def handle_explore_command(
                     agent_id=args.agent_id,
                     orchestration=orchestration,
                     width=args.width,
+                    resource_capacities=resource_capacities,
+                    resource_usage=resource_usage,
                 )
             else:
                 projection = _projection_for(args, runtime_root=runtime_root)
@@ -587,6 +598,8 @@ def handle_explore_command(
                     allow_unscoped_parallel=bool(args.allow_unscoped_parallel),
                     scheduler_strategy=args.scheduler_strategy,
                     scheduler_load=args.scheduler_load,
+                    resource_capacities=resource_capacities,
+                    resource_usage=resource_usage,
                 )
                 payload["todo_source"] = {
                     "source": todo_payload.get("source"),
@@ -594,6 +607,14 @@ def handle_explore_command(
                     "todo_count": todo_payload.get("todo_count"),
                 }
         elif args.explore_command == "worker-branch-plan":
+            resource_capacities = parse_resource_counts(
+                args.resource_capacity,
+                flag_name="--resource-capacity",
+            )
+            resource_usage = parse_resource_counts(
+                args.resource_usage,
+                flag_name="--resource-usage",
+            )
             orchestration = _goal_orchestration_boundary(registry, goal_id=args.goal_id)
             gate = resolve_explore_harness_gate(
                 orchestration, requested_width=args.worker_width
@@ -608,6 +629,8 @@ def handle_explore_command(
                     agent_id=args.agent_id,
                     orchestration=orchestration,
                     worker_width=args.worker_width,
+                    resource_capacities=resource_capacities,
+                    resource_usage=resource_usage,
                 )
             else:
                 projection = _projection_for(args, runtime_root=runtime_root)
@@ -647,6 +670,8 @@ def handle_explore_command(
                     marginal_score_floor=args.marginal_score_floor,
                     router_state=router_state,
                     load_profile=load_profile,
+                    resource_capacities=resource_capacities,
+                    resource_usage=resource_usage,
                 )
                 payload["todo_source"] = {
                     "source": todo_payload.get("source"),

--- a/loopx/cli_commands/explore_planning_commands.py
+++ b/loopx/cli_commands/explore_planning_commands.py
@@ -9,6 +9,29 @@ from ..capabilities.explore.worker_branch_plan import (
 )
 
 
+def _add_resource_portfolio_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--resource-capacity",
+        action="append",
+        default=[],
+        metavar="KEY=N",
+        help=(
+            "Declare a resource-lane capacity for resource_lane:<key> todos. "
+            "Repeat for multiple lanes."
+        ),
+    )
+    parser.add_argument(
+        "--resource-usage",
+        action="append",
+        default=[],
+        metavar="KEY=N",
+        help=(
+            "Declare current occupancy for a resource lane. Requires a matching "
+            "--resource-capacity and may be repeated."
+        ),
+    )
+
+
 def register_explore_planning_commands(
     subparsers: argparse._SubParsersAction,
     add_subcommand_format: Callable[[argparse.ArgumentParser], None],
@@ -26,6 +49,7 @@ def register_explore_planning_commands(
     add_projection_limit_args(branch_plan)
     branch_plan.add_argument("--agent-id", help="Prefer this agent's claimed todos, then unclaimed todos.")
     branch_plan.add_argument("--width", type=int, default=3, help="Maximum predicted branch issue width.")
+    _add_resource_portfolio_args(branch_plan)
     branch_plan.add_argument(
         "--scheduler-strategy",
         choices=["dspark"],
@@ -77,6 +101,7 @@ def register_explore_planning_commands(
         default=3,
         help="Maximum predicted worker lanes; the planner may select fewer.",
     )
+    _add_resource_portfolio_args(worker_branch_plan)
     worker_branch_plan.add_argument(
         "--max-todos-per-branch",
         type=int,

--- a/tests/test_explore_resource_portfolio.py
+++ b/tests/test_explore_resource_portfolio.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+from loopx.capabilities.explore.resource_portfolio import parse_resource_counts
+from loopx.capabilities.explore.todo_branch_plan import build_explore_todo_branch_plan
+from loopx.capabilities.explore.worker_branch_plan import build_explore_worker_branch_plan
+
+
+ANALYSIS_ONLY = {"explore_harness": {"enabled": True}}
+CAPACITIES = {"long_pool": 2, "short_pool": 3}
+USAGE = {"long_pool": 1, "short_pool": 1}
+
+
+def _todo(
+    todo_id: str,
+    *,
+    index: int,
+    priority: str,
+    resource_lane: str,
+    write_scope: str,
+    depends_on: list[str] | None = None,
+    task_class: str = "advancement_task",
+) -> dict[str, object]:
+    todo: dict[str, object] = {
+        "todo_id": todo_id,
+        "index": index,
+        "status": "open",
+        "priority": priority,
+        "text": f"[{priority}] Evaluate synthetic {todo_id}",
+        "task_class": task_class,
+        "required_capabilities": [f"resource_lane:{resource_lane}"],
+        "required_write_scopes": [write_scope],
+    }
+    if depends_on:
+        todo["depends_on"] = depends_on
+    if task_class == "continuous_monitor":
+        todo["next_due_at"] = "2020-01-01T00:00:00Z"
+    return todo
+
+
+TODOS = [
+    _todo(
+        "todo_monitor",
+        index=1,
+        priority="P0",
+        resource_lane="long_pool",
+        write_scope="observations/**",
+        task_class="continuous_monitor",
+    ),
+    _todo(
+        "todo_long_blocked_dependency",
+        index=2,
+        priority="P0",
+        resource_lane="long_pool",
+        write_scope="variants/long-blocked/**",
+        depends_on=["todo_missing_prerequisite"],
+    ),
+    _todo(
+        "todo_short_primary",
+        index=3,
+        priority="P0",
+        resource_lane="short_pool",
+        write_scope="variants/short-shared/**",
+    ),
+    _todo(
+        "todo_short_conflict",
+        index=4,
+        priority="P1",
+        resource_lane="short_pool",
+        write_scope="variants/short-shared/**",
+    ),
+    {
+        **_todo(
+            "todo_long_backfill",
+            index=5,
+            priority="P2",
+            resource_lane="long_pool",
+            write_scope="variants/long-ready/**",
+        ),
+        "explore_result_node_refs": ["node_long_ready"],
+    },
+    _todo(
+        "todo_short_backfill",
+        index=6,
+        priority="P2",
+        resource_lane="short_pool",
+        write_scope="variants/short-ready/**",
+    ),
+]
+
+PROJECTION = {
+    "nodes": [
+        {
+            "node_id": "node_long_ready",
+            "status": "exploring",
+            "node_kind": "experiment",
+            "title": "Synthetic long lane",
+            "finding_count": 0,
+        }
+    ],
+    "findings": [],
+    "edges": [],
+}
+
+
+def _assert_resource_fill(plan: dict[str, object], *, selected_key: str) -> None:
+    selected = plan[selected_key]
+    selected_ids = {
+        todo_id
+        for branch in selected
+        for todo_id in branch.get("todo_ids", [branch.get("todo_id")])
+    }
+    assert selected_ids == {
+        "todo_long_backfill",
+        "todo_short_primary",
+        "todo_short_backfill",
+    }
+    portfolio = plan["resource_portfolio"]
+    assert portfolio["analysis_only"] is True
+    assert portfolio["score_delta"] == 0.0
+    assert portfolio["continuous_monitor_consumes_capacity"] is False
+    assert portfolio["selected_slot_count"] == 3
+    assert portfolio["remaining_slot_count"] == 0
+    assert portfolio["lanes"]["long_pool"]["selected_slots"] == 1
+    assert portfolio["lanes"]["short_pool"]["selected_slots"] == 2
+    assert all(not branch["suggested_commands"] for branch in selected)
+
+    rejected = plan[
+        "rejected_candidates" if selected_key == "selected_branches" else "rejected_worker_branches"
+    ]
+    statuses = {
+        todo_id: item.get("selection_status")
+        for item in rejected
+        for todo_id in item.get("todo_ids", [item.get("todo_id")])
+    }
+    assert statuses["todo_monitor"] == "excluded_non_exploration_lane"
+    assert statuses["todo_long_blocked_dependency"] == "invalidated_dependency"
+    assert statuses["todo_short_conflict"] == "rejected_hazard"
+
+
+def test_todo_plan_backfills_each_resource_lane_after_dependency_and_scope_rejections() -> None:
+    plan = build_explore_todo_branch_plan(
+        goal_id="synthetic-resource-portfolio",
+        todos=TODOS,
+        projection=PROJECTION,
+        orchestration=ANALYSIS_ONLY,
+        width=5,
+        resource_capacities=CAPACITIES,
+        resource_usage=USAGE,
+    )
+
+    assert plan["orchestration_gate"]["state"] == "analysis_only"
+    assert plan["selection_budget"] == 5
+    _assert_resource_fill(plan, selected_key="selected_branches")
+    long_branch = next(
+        branch for branch in plan["selected_branches"] if branch["todo_id"] == "todo_long_backfill"
+    )
+    assert long_branch["typed_evidence_audit"]["score_delta"] == 0.0
+
+
+def test_worker_plan_backfills_each_resource_lane_after_dependency_and_scope_rejections() -> None:
+    plan = build_explore_worker_branch_plan(
+        goal_id="synthetic-resource-portfolio",
+        todos=TODOS,
+        projection=PROJECTION,
+        orchestration=ANALYSIS_ONLY,
+        worker_width=5,
+        max_todos_per_branch=1,
+        resource_capacities=CAPACITIES,
+        resource_usage=USAGE,
+    )
+
+    assert plan["orchestration_gate"]["state"] == "analysis_only"
+    assert plan["selection_budget"] == 5
+    _assert_resource_fill(plan, selected_key="selected_worker_branches")
+
+
+def test_legacy_unlaned_planning_remains_unconstrained_without_resource_inputs() -> None:
+    todos = [
+        {
+            "todo_id": f"todo_legacy_{index}",
+            "index": index,
+            "status": "open",
+            "priority": "P1",
+            "text": f"[P1] Inspect legacy branch {index}",
+            "task_class": "advancement_task",
+            "required_write_scopes": [f"legacy/{index}/**"],
+        }
+        for index in range(1, 4)
+    ]
+    plan = build_explore_todo_branch_plan(
+        goal_id="synthetic-legacy-plan",
+        todos=todos,
+        orchestration=ANALYSIS_ONLY,
+        width=2,
+    )
+
+    assert plan["resource_portfolio"]["enabled"] is False
+    assert plan["selection_budget"] == plan["verification_budget"]
+    assert len(plan["selected_branches"]) == plan["verification_budget"]
+
+
+def test_resource_count_cli_values_are_normalized_and_duplicates_fail() -> None:
+    assert parse_resource_counts(
+        ["long-pool=2", "short_pool=3"],
+        flag_name="--resource-capacity",
+    ) == {"long_pool": 2, "short_pool": 3}
+
+    try:
+        parse_resource_counts(
+            ["long_pool=2", "long-pool=3"],
+            flag_name="--resource-capacity",
+        )
+    except ValueError as exc:
+        assert "repeats resource lane" in str(exc)
+    else:
+        raise AssertionError("duplicate resource lane should fail closed")


### PR DESCRIPTION
## Summary

- add repeatable `--resource-capacity KEY=N` and `--resource-usage KEY=N` inputs to Explore todo and worker branch plans
- assign `resource_lane:<key>` advancement candidates into per-lane empty slots while keeping `continuous_monitor` outside capacity
- release predicted slots and continue scanning after dependency invalidation, write-scope conflicts, or other planner rejection so safe same-lane candidates can backfill
- preserve legacy scheduling when no resource capacities are declared and keep all output read-only with `score_delta=0`

## Validation

- `pytest -q tests/test_explore_monitor_lane_budget.py tests/test_explore_worker_topic_affinity.py tests/test_explore_resource_portfolio.py` (10 passed)
- `python examples/explore-result-layer-smoke.py`
- `python examples/explore-worker-plan-gate-smoke.py`
- Ruff on changed Python surfaces
- `loopx canary premerge --from-git-diff` (17/17 selected checks passed; public-boundary scan clean across 8 files)
- staged diff private-boundary scan clean

## Boundary

The planner only emits analysis packets. Resource inputs do not claim todos, acquire leases, launch workers, write state, or change quota. Fixtures and examples use synthetic lane names such as `long_pool` and `short_pool`.

## Risk

Resource usage is caller-supplied point-in-time occupancy, so stale input can make the analysis packet over- or under-estimate available slots. Runtime authority remains outside this planner and must re-check normal quota, claim, and lease gates.

## Merge decision

Ready for review. Do not merge as part of this change request.